### PR TITLE
Fix an Issue with IR Remote Climate and Whirlpool protocol toggle

### DIFF
--- a/esphome/components/whirlpool/whirlpool.cpp
+++ b/esphome/components/whirlpool/whirlpool.cpp
@@ -4,7 +4,7 @@
 namespace esphome {
 namespace whirlpool {
 
-long int t1 = millis() + 500;
+int32_t t1 = millis() + 500;
 
 static const char *const TAG = "whirlpool.climate";
 

--- a/esphome/components/whirlpool/whirlpool.cpp
+++ b/esphome/components/whirlpool/whirlpool.cpp
@@ -4,7 +4,7 @@
 namespace esphome {
 namespace whirlpool {
 
-long int t1 = millis() + 500; 
+long int t1 = millis() + 500;
 
 static const char *const TAG = "whirlpool.climate";
 
@@ -35,7 +35,7 @@ const uint8_t WHIRLPOOL_SWING_MASK = 128;
 const uint8_t WHIRLPOOL_POWER = 0x04;
 
 void WhirlpoolClimate::transmit_state() {
-  t1 = millis(); // setting the time of the last transmission.
+  t1 = millis();  // setting the time of the last transmission.
   uint8_t remote_state[WHIRLPOOL_STATE_LENGTH] = {0};
   remote_state[0] = 0x83;
   remote_state[1] = 0x06;
@@ -153,7 +153,7 @@ void WhirlpoolClimate::transmit_state() {
 
 bool WhirlpoolClimate::on_receive(remote_base::RemoteReceiveData data) {
   // Check if the esp isn't currently transmitting.
-  if(millis() - t1 < 500 ){
+  if (millis() - t1 < 500) {
     ESP_LOGV(TAG, "Blocked receive because of current trasmittion");
     return false;
   }

--- a/esphome/components/whirlpool/whirlpool.cpp
+++ b/esphome/components/whirlpool/whirlpool.cpp
@@ -4,8 +4,6 @@
 namespace esphome {
 namespace whirlpool {
 
-int32_t t1 = millis() + 500;
-
 static const char *const TAG = "whirlpool.climate";
 
 const uint16_t WHIRLPOOL_HEADER_MARK = 9000;
@@ -35,7 +33,7 @@ const uint8_t WHIRLPOOL_SWING_MASK = 128;
 const uint8_t WHIRLPOOL_POWER = 0x04;
 
 void WhirlpoolClimate::transmit_state() {
-  t1 = millis();  // setting the time of the last transmission.
+  this->last_transmit_time_ = millis();  // setting the time of the last transmission.
   uint8_t remote_state[WHIRLPOOL_STATE_LENGTH] = {0};
   remote_state[0] = 0x83;
   remote_state[1] = 0x06;
@@ -153,7 +151,7 @@ void WhirlpoolClimate::transmit_state() {
 
 bool WhirlpoolClimate::on_receive(remote_base::RemoteReceiveData data) {
   // Check if the esp isn't currently transmitting.
-  if (millis() - t1 < 500) {
+  if (millis() - this->last_transmit_time_ < 500) {
     ESP_LOGV(TAG, "Blocked receive because of current trasmittion");
     return false;
   }

--- a/esphome/components/whirlpool/whirlpool.cpp
+++ b/esphome/components/whirlpool/whirlpool.cpp
@@ -4,6 +4,8 @@
 namespace esphome {
 namespace whirlpool {
 
+long int t1 = millis() + 500; 
+
 static const char *const TAG = "whirlpool.climate";
 
 const uint16_t WHIRLPOOL_HEADER_MARK = 9000;
@@ -33,6 +35,7 @@ const uint8_t WHIRLPOOL_SWING_MASK = 128;
 const uint8_t WHIRLPOOL_POWER = 0x04;
 
 void WhirlpoolClimate::transmit_state() {
+  t1 = millis(); // setting the time of the last transmission.
   uint8_t remote_state[WHIRLPOOL_STATE_LENGTH] = {0};
   remote_state[0] = 0x83;
   remote_state[1] = 0x06;
@@ -149,6 +152,12 @@ void WhirlpoolClimate::transmit_state() {
 }
 
 bool WhirlpoolClimate::on_receive(remote_base::RemoteReceiveData data) {
+  // Check if the esp isn't currently transmitting.
+  if(millis() - t1 < 500 ){
+    ESP_LOGV(TAG, "Blocked receive because of current trasmittion");
+    return false;
+  }
+
   // Validate header
   if (!data.expect_item(WHIRLPOOL_HEADER_MARK, WHIRLPOOL_HEADER_SPACE)) {
     ESP_LOGV(TAG, "Header fail");

--- a/esphome/components/whirlpool/whirlpool.h
+++ b/esphome/components/whirlpool/whirlpool.h
@@ -48,7 +48,7 @@ class WhirlpoolClimate : public climate_ir::ClimateIR {
   /// Handle received IR Buffer
   bool on_receive(remote_base::RemoteReceiveData data) override;
   /// Set the time of the last transmission.
-  int32_t last_transmit_time_;
+  int32_t last_transmit_time_{};
 
   bool send_swing_cmd_{false};
   Model model_;

--- a/esphome/components/whirlpool/whirlpool.h
+++ b/esphome/components/whirlpool/whirlpool.h
@@ -48,7 +48,7 @@ class WhirlpoolClimate : public climate_ir::ClimateIR {
   /// Handle received IR Buffer
   bool on_receive(remote_base::RemoteReceiveData data) override;
   /// Set the time of the last transmission.
-  int32_t last_transmit_time_ = millis() + 500;
+  int32_t last_transmit_time_;
 
   bool send_swing_cmd_{false};
   Model model_;

--- a/esphome/components/whirlpool/whirlpool.h
+++ b/esphome/components/whirlpool/whirlpool.h
@@ -47,6 +47,8 @@ class WhirlpoolClimate : public climate_ir::ClimateIR {
   void transmit_state() override;
   /// Handle received IR Buffer
   bool on_receive(remote_base::RemoteReceiveData data) override;
+  /// Set the time of the last transmission.
+  int32_t last_transmit_time_ = millis() + 500;
 
   bool send_swing_cmd_{false};
   Model model_;


### PR DESCRIPTION
# What does this fix?
In short because the whirlpool protocol is based on toggle we need to block the receiver while transmitting to prevent the system from getting confused. 

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

Related issues:
https://github.com/esphome/issues/issues/4650
https://github.com/esphome/issues/issues/4468

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
```
 remote_transmitter:
  id: remote_transmitter_id
  pin: GPIO14
  carrier_duty_percent: 50%

remote_receiver:
  id: "remote_receiver_id"
  pin:
    number: GPIO5
    inverted: True
  tolerance: 55%
  dump: all

climate:
  - platform: whirlpool
    name: "Study AC"
    model: "DG11J1-91"
    sensor: room_temperature
    transmitter_id: remote_transmitter_id
    receiver_id: remote_receiver_id
```

## Checklist:
  - [x] The code change is tested and works locally.