### PR TITLE
[BP1658CJ] Missing clock line delays and ack bit

### DIFF
--- a/esphome/components/bp1658cj/bp1658cj.cpp
+++ b/esphome/components/bp1658cj/bp1658cj.cpp
@@ -12,6 +12,8 @@ static const uint8_t BP1658CJ_ADDR_START_3CH = 0x10;
 static const uint8_t BP1658CJ_ADDR_START_2CH = 0x20;
 static const uint8_t BP1658CJ_ADDR_START_5CH = 0x30;
 
+static const uint8_t BP1658CJ_DELAY = 2;
+
 void BP1658CJ::setup() {
   ESP_LOGCONFIG(TAG, "Setting up BP1658CJ Output Component...");
   this->data_pin_->setup();
@@ -81,27 +83,41 @@ void BP1658CJ::set_channel_value_(uint8_t channel, uint16_t value) {
   }
   this->pwm_amounts_[channel] = value;
 }
+
 void BP1658CJ::write_bit_(bool value) {
-  this->clock_pin_->digital_write(false);
   this->data_pin_->digital_write(value);
   this->clock_pin_->digital_write(true);
+
+  esphome::delayMicroseconds(BP1658CJ_DELAY);
+
+  this->clock_pin_->digital_write(false);
 }
 
 void BP1658CJ::write_byte_(uint8_t data) {
   for (uint8_t mask = 0x80; mask; mask >>= 1) {
     this->write_bit_(data & mask);
+    esphome::delayMicroseconds(BP1658CJ_DELAY);
   }
-  this->clock_pin_->digital_write(false);
-  this->data_pin_->digital_write(true);
+
+  // ack bit
+  this->data_pin_->pin_mode(gpio::FLAG_INPUT);
   this->clock_pin_->digital_write(true);
+
+  esphome::delayMicroseconds(BP1658CJ_DELAY);
+
+  this->clock_pin_->digital_write(false);
+  this->data_pin_->pin_mode(gpio::FLAG_OUTPUT);
 }
 
 void BP1658CJ::write_buffer_(uint8_t *buffer, uint8_t size) {
   this->data_pin_->digital_write(false);
+  this->clock_pin_->digital_write(false);
+
   for (uint32_t i = 0; i < size; i++) {
     this->write_byte_(buffer[i]);
+    esphome::delayMicroseconds(BP1658CJ_DELAY);
   }
-  this->clock_pin_->digital_write(false);
+  
   this->clock_pin_->digital_write(true);
   this->data_pin_->digital_write(true);
 }

--- a/esphome/components/bp1658cj/bp1658cj.cpp
+++ b/esphome/components/bp1658cj/bp1658cj.cpp
@@ -88,7 +88,7 @@ void BP1658CJ::write_bit_(bool value) {
   this->data_pin_->digital_write(value);
   this->clock_pin_->digital_write(true);
 
-  esphome::delayMicroseconds(BP1658CJ_DELAY);
+  delayMicroseconds(BP1658CJ_DELAY);
 
   this->clock_pin_->digital_write(false);
 }
@@ -96,14 +96,14 @@ void BP1658CJ::write_bit_(bool value) {
 void BP1658CJ::write_byte_(uint8_t data) {
   for (uint8_t mask = 0x80; mask; mask >>= 1) {
     this->write_bit_(data & mask);
-    esphome::delayMicroseconds(BP1658CJ_DELAY);
+    delayMicroseconds(BP1658CJ_DELAY);
   }
 
   // ack bit
   this->data_pin_->pin_mode(gpio::FLAG_INPUT);
   this->clock_pin_->digital_write(true);
 
-  esphome::delayMicroseconds(BP1658CJ_DELAY);
+  delayMicroseconds(BP1658CJ_DELAY);
 
   this->clock_pin_->digital_write(false);
   this->data_pin_->pin_mode(gpio::FLAG_OUTPUT);
@@ -115,7 +115,7 @@ void BP1658CJ::write_buffer_(uint8_t *buffer, uint8_t size) {
 
   for (uint32_t i = 0; i < size; i++) {
     this->write_byte_(buffer[i]);
-    esphome::delayMicroseconds(BP1658CJ_DELAY);
+    delayMicroseconds(BP1658CJ_DELAY);
   }
   
   this->clock_pin_->digital_write(true);

--- a/esphome/components/bp1658cj/bp1658cj.cpp
+++ b/esphome/components/bp1658cj/bp1658cj.cpp
@@ -117,7 +117,7 @@ void BP1658CJ::write_buffer_(uint8_t *buffer, uint8_t size) {
     this->write_byte_(buffer[i]);
     delayMicroseconds(BP1658CJ_DELAY);
   }
-  
+
   this->clock_pin_->digital_write(true);
   this->data_pin_->digital_write(true);
 }


### PR DESCRIPTION
# What does this implement/fix?

This PR adds clock line delays and waiting for ack bit in the BP1658CJ driver (as seen in Tasmota and OBK implementation).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes [#4919](https://github.com/esphome/issues/issues/4919)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [x] BK72XX

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
