### PR TITLE
Bump cryptography to 41.0.4 and pin optional dependencies

### DIFF
--- a/requirements_optional.txt
+++ b/requirements_optional.txt
@@ -1,3 +1,3 @@
-pillow>4.0.0,<10.0.0
-cairosvg>=2.2.0
-cryptography>=2.0.0,<4
+pillow==9.5.0
+cairosvg==2.7.1
+cryptography==41.0.4


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

The cryptography library as far as I can see is only used for wifi EAP certificate parsing and validation. I do not use EAP, but I can compile an example with a valid certificate and it is added to the firmware with no differences between the cryptography versions.

I also decided to hard pin the optional dependencies versions as well so we can test upgrades properly.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
