### PR TITLE
Add xor automation condition

### DIFF
--- a/esphome/automation.py
+++ b/esphome/automation.py
@@ -138,6 +138,7 @@ AUTOMATION_SCHEMA = cv.Schema(
 AndCondition = cg.esphome_ns.class_("AndCondition", Condition)
 OrCondition = cg.esphome_ns.class_("OrCondition", Condition)
 NotCondition = cg.esphome_ns.class_("NotCondition", Condition)
+XorCondition = cg.esphome_ns.class_("XorCondition", Condition)
 
 
 @register_condition("and", AndCondition, validate_condition_list)
@@ -156,6 +157,12 @@ async def or_condition_to_code(config, condition_id, template_arg, args):
 async def not_condition_to_code(config, condition_id, template_arg, args):
     condition = await build_condition(config, template_arg, args)
     return cg.new_Pvariable(condition_id, template_arg, condition)
+
+
+@register_condition("xor", XorCondition, validate_condition_list)
+async def xor_condition_to_code(config, condition_id, template_arg, args):
+    conditions = await build_condition_list(config, template_arg, args)
+    return cg.new_Pvariable(condition_id, template_arg, conditions)
 
 
 @register_condition("lambda", LambdaCondition, cv.returning_lambda)

--- a/esphome/core/base_automation.h
+++ b/esphome/core/base_automation.h
@@ -48,6 +48,22 @@ template<typename... Ts> class NotCondition : public Condition<Ts...> {
   Condition<Ts...> *condition_;
 };
 
+template<typename... Ts> class XorCondition : public Condition<Ts...> {
+ public:
+  explicit XorCondition(const std::vector<Condition<Ts...> *> &conditions) : conditions_(conditions) {}
+  bool check(Ts... x) override {
+    bool xor_state = false;
+    for (auto *condition : this->conditions_) {
+      xor_state = xor_state ^ condition->check(x...);
+    }
+
+    return xor_state;
+  }
+
+ protected:
+  std::vector<Condition<Ts...> *> conditions_;
+};
+
 template<typename... Ts> class LambdaCondition : public Condition<Ts...> {
  public:
   explicit LambdaCondition(std::function<bool(Ts...)> &&f) : f_(std::move(f)) {}

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -3104,11 +3104,39 @@ time:
   - platform: ds1307
     id: ds1307_time
     update_interval: never
-    on_time:
-      seconds: 0
-      then: ds1307.read_time
     i2c_id: i2c_bus
-
+    on_time:
+      - seconds: 0
+        then: ds1307.read_time
+      - at: "16:00:00"
+        then:
+          - if:
+              condition:
+                or:
+                  - binary_sensor.is_on: close_sensor
+                  - binary_sensor.is_on: open_sensor
+              then:
+                logger.log: "close_sensor or open_sensor is on"
+          - if:
+              condition:
+                and:
+                  - binary_sensor.is_on: close_sensor
+                  - binary_sensor.is_on: open_sensor
+              then:
+                logger.log: "close_sensor and open_sensor are both on"
+          - if:
+              condition:
+                xor:
+                  - binary_sensor.is_on: close_sensor
+                  - binary_sensor.is_on: open_sensor
+              then:
+                logger.log: "close_sensor or open_sensor is exclusively on"
+          - if:
+              condition:
+                not:
+                  - binary_sensor.is_on: close_sensor
+              then:
+                logger.log: "close_sensor is not on"
 cover:
   - platform: template
     name: Template Cover


### PR DESCRIPTION
# What does this implement/fix?

This PR adds a xor condition for automations. I have added test cases for all 4 basic logic conditions to ``test1.yaml``. If there is a better location to add tests for these base automations, please let me know!

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** closes esphome/feature-requests#2390

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#3222

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
      on_*:
        then:
          - if:
              condition:
                xor:
                  - binary_sensor.is_on: binary_sensor_1
                  - binary_sensor.is_on: binary_sensor_2
              then:
                logger.log: "binary_sensor_1 or binary_sensor_2 is exclusively on"

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
