### PR TITLE
[ssd1351] fix: wait for the component to be at least in setup phase b…

### DIFF
--- a/esphome/components/ssd1351_base/ssd1351_base.cpp
+++ b/esphome/components/ssd1351_base/ssd1351_base.cpp
@@ -112,6 +112,9 @@ void SSD1351::set_brightness(float brightness) {
   } else {
     this->brightness_ = brightness;
   }
+  if (!this->is_ready()) {
+    return;  // Component is not yet setup skip the command
+  }
   // now write the new brightness level to the display
   this->command(SSD1351_CONTRASTMASTER);
   this->data(int(SSD1351_MAX_CONTRAST * (this->brightness_)));


### PR DESCRIPTION
ait for the component to be at least in setup phase before setting contrast

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/4924

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** 

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
