### PR TITLE
Fix SPI support for second bus on 2023.9.1

### DIFF
--- a/esphome/components/spi/__init__.py
+++ b/esphome/components/spi/__init__.py
@@ -187,7 +187,7 @@ def get_spi_interface(index):
     # Following code can't apply to C2, H2 or 8266 since they have only one SPI
     if get_target_variant() in (VARIANT_ESP32S3, VARIANT_ESP32S2):
         return "new SPIClass(FSPI)"
-    return "return new SPIClass(HSPI)"
+    return "new SPIClass(HSPI)"
 
 
 SPI_SCHEMA = cv.All(


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->
When compiling devices with 2 or more SPI buses on 2023.9.1 with the default Arduino framework, the compilation breaks. This fixes the build error.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes [<link to issue>](https://github.com/esphome/issues/issues/4927)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** NA

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
esphome:
  name: test
  platform: ESP32
  board: esp32dev

spi:
  - id: spi_bus_1
    clk_pin: GPIO32
    mosi_pin: GPIO33
    miso_pin: GPIO39
  - id: spi_bus_2
    clk_pin: GPIO15
    mosi_pin: GPIO13
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
