### PR TITLE
Tuya Number: split "multiply" to a separate option

### DIFF
--- a/esphome/components/tuya/number/__init__.py
+++ b/esphome/components/tuya/number/__init__.py
@@ -6,6 +6,7 @@ from esphome.const import (
     CONF_NUMBER_DATAPOINT,
     CONF_MAX_VALUE,
     CONF_MIN_VALUE,
+    CONF_MULTIPLY,
     CONF_STEP,
 )
 from .. import tuya_ns, CONF_TUYA_ID, Tuya
@@ -31,6 +32,7 @@ CONFIG_SCHEMA = cv.All(
             cv.Required(CONF_MAX_VALUE): cv.float_,
             cv.Required(CONF_MIN_VALUE): cv.float_,
             cv.Required(CONF_STEP): cv.positive_float,
+            cv.Optional(CONF_MULTIPLY, default=1.0): cv.float_,
         }
     )
     .extend(cv.COMPONENT_SCHEMA),
@@ -49,7 +51,8 @@ async def to_code(config):
         step=config[CONF_STEP],
     )
 
-    paren = await cg.get_variable(config[CONF_TUYA_ID])
-    cg.add(var.set_tuya_parent(paren))
+    cg.add(var.set_write_multiply(config[CONF_MULTIPLY]))
+    parent = await cg.get_variable(config[CONF_TUYA_ID])
+    cg.add(var.set_tuya_parent(parent))
 
     cg.add(var.set_number_id(config[CONF_NUMBER_DATAPOINT]))

--- a/esphome/components/tuya/number/tuya_number.cpp
+++ b/esphome/components/tuya/number/tuya_number.cpp
@@ -10,7 +10,7 @@ void TuyaNumber::setup() {
   this->parent_->register_listener(this->number_id_, [this](const TuyaDatapoint &datapoint) {
     if (datapoint.type == TuyaDatapointType::INTEGER) {
       ESP_LOGV(TAG, "MCU reported number %u is: %d", datapoint.id, datapoint.value_int);
-      this->publish_state(datapoint.value_int * this->traits.get_step());
+      this->publish_state(datapoint.value_int / multiply_by_);
     } else if (datapoint.type == TuyaDatapointType::ENUM) {
       ESP_LOGV(TAG, "MCU reported number %u is: %u", datapoint.id, datapoint.value_enum);
       this->publish_state(datapoint.value_enum);
@@ -22,7 +22,7 @@ void TuyaNumber::setup() {
 void TuyaNumber::control(float value) {
   ESP_LOGV(TAG, "Setting number %u: %f", this->number_id_, value);
   if (this->type_ == TuyaDatapointType::INTEGER) {
-    int integer_value = lround(value / this->traits.get_step());
+    int integer_value = lround(value * multiply_by_);
     this->parent_->set_integer_datapoint_value(this->number_id_, integer_value);
   } else if (this->type_ == TuyaDatapointType::ENUM) {
     this->parent_->set_enum_datapoint_value(this->number_id_, value);

--- a/esphome/components/tuya/number/tuya_number.h
+++ b/esphome/components/tuya/number/tuya_number.h
@@ -12,6 +12,7 @@ class TuyaNumber : public number::Number, public Component {
   void setup() override;
   void dump_config() override;
   void set_number_id(uint8_t number_id) { this->number_id_ = number_id; }
+  void set_write_multiply(float factor) { multiply_by_ = factor; }
 
   void set_tuya_parent(Tuya *parent) { this->parent_ = parent; }
 
@@ -20,6 +21,7 @@ class TuyaNumber : public number::Number, public Component {
 
   Tuya *parent_;
   uint8_t number_id_{0};
+  float multiply_by_{1.0};
   TuyaDatapointType type_{};
 };
 


### PR DESCRIPTION
# What does this implement/fix?

Commit 9d4f471 (PR #5108), part of ESPHome 2023.9.1, introduced a multiplication factor for Tuya Number, to be used when converting from a float (say, pH 5.2) to an integer-only data-point (say, 5200).

However, that commit overloaded the "step" attribute, incorrectly assuming that all stepped values are supposed to be multiplied. There are devices in the wild that expect integers to be moved in steps, but do not require any multiplication; for example, a dehumidifier that accepts an integer for target humidity, but only in steps of 5%.

With the aforementioned commit, it's impossible to correctly configure such a device. Moreover, despite documented, it is counter-intuitive, as "step" (CONF_STEP) now does something different compared to other ESPHome components.

To resolve this, revert "step" to its previous function, and add a separate "multiply" attribute, using the standard CONF_MULTIPLY key. This follows what other components do, such as for example the Modbus Controller Number component, thereby providing an additional knob in a standard way.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected) : _sort of: this breaks 2023.9.1 configs, but restores <= 2023.9.0 configs_
- [ ] Other

**Related issue or feature (if applicable):** fixes esphome/issues#4928

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#3224

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:

```yaml
tuya:

number:
  - platform: tuya
    name: "Target humidity"
    number_datapoint: 4
    min_value: 30`
    max_value: 80
    step: 5
```

```yaml
tuya:

number:
  - platform: tuya
    name: "pH Low Limit"
    number_datapoint: 108
    min_value: 0
    max_value: 15
    multiply: 100
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
