### PR TITLE
Sleep mode fix for BP5758D driver

### DIFF
--- a/esphome/components/bp5758d/bp5758d.cpp
+++ b/esphome/components/bp5758d/bp5758d.cpp
@@ -39,11 +39,17 @@ void BP5758D::loop() {
   uint8_t data[17];
   if (this->pwm_amounts_[0] == 0 && this->pwm_amounts_[1] == 0 && this->pwm_amounts_[2] == 0 &&
       this->pwm_amounts_[3] == 0 && this->pwm_amounts_[4] == 0) {
-    // Off / Sleep
+    // First turn all channels off
+    data[0] = BP5758D_MODEL_ID + BP5758D_ADDR_START_3CH;
+    for (int i = 1; i < 16; i++)
+      data[i] = 0;
+    this->write_buffer_(data, 17);
+    // Then sleep
     data[0] = BP5758D_MODEL_ID + BP5758D_ADDR_STANDBY;
     for (int i = 1; i < 16; i++)
       data[i] = 0;
     this->write_buffer_(data, 17);
+    this->sleep_=true;
   } else if (this->pwm_amounts_[0] == 0 && this->pwm_amounts_[1] == 0 && this->pwm_amounts_[2] == 0 &&
              (this->pwm_amounts_[3] > 0 || this->pwm_amounts_[4] > 0)) {
     // Only data on white channels

--- a/esphome/components/bp5758d/bp5758d.cpp
+++ b/esphome/components/bp5758d/bp5758d.cpp
@@ -39,15 +39,14 @@ void BP5758D::loop() {
   uint8_t data[17];
   if (this->pwm_amounts_[0] == 0 && this->pwm_amounts_[1] == 0 && this->pwm_amounts_[2] == 0 &&
       this->pwm_amounts_[3] == 0 && this->pwm_amounts_[4] == 0) {
-    // First turn all channels off
-    data[0] = BP5758D_MODEL_ID + BP5758D_ADDR_START_3CH;
     for (int i = 1; i < 16; i++)
       data[i] = 0;
+
+    // First turn all channels off
+    data[0] = BP5758D_MODEL_ID + BP5758D_ADDR_START_3CH;
     this->write_buffer_(data, 17);
     // Then sleep
     data[0] = BP5758D_MODEL_ID + BP5758D_ADDR_STANDBY;
-    for (int i = 1; i < 16; i++)
-      data[i] = 0;
     this->write_buffer_(data, 17);
   } else if (this->pwm_amounts_[0] == 0 && this->pwm_amounts_[1] == 0 && this->pwm_amounts_[2] == 0 &&
              (this->pwm_amounts_[3] > 0 || this->pwm_amounts_[4] > 0)) {

--- a/esphome/components/bp5758d/bp5758d.cpp
+++ b/esphome/components/bp5758d/bp5758d.cpp
@@ -49,7 +49,6 @@ void BP5758D::loop() {
     for (int i = 1; i < 16; i++)
       data[i] = 0;
     this->write_buffer_(data, 17);
-    this->sleep_=true;
   } else if (this->pwm_amounts_[0] == 0 && this->pwm_amounts_[1] == 0 && this->pwm_amounts_[2] == 0 &&
              (this->pwm_amounts_[3] > 0 || this->pwm_amounts_[4] > 0)) {
     // Only data on white channels

--- a/esphome/components/bp5758d/bp5758d.h
+++ b/esphome/components/bp5758d/bp5758d.h
@@ -58,6 +58,7 @@ class BP5758D : public Component {
   std::vector<uint8_t> channel_current_;
   std::vector<uint16_t> pwm_amounts_;
   bool update_{true};
+  bool sleeping_{false};
 };
 
 }  // namespace bp5758d

--- a/esphome/components/bp5758d/bp5758d.h
+++ b/esphome/components/bp5758d/bp5758d.h
@@ -58,7 +58,6 @@ class BP5758D : public Component {
   std::vector<uint8_t> channel_current_;
   std::vector<uint16_t> pwm_amounts_;
   bool update_{true};
-  bool sleeping_{false};
 };
 
 }  // namespace bp5758d


### PR DESCRIPTION
# What does this implement/fix?

This is an implementation of a detail in the BP5758D specification which requires that all channels be set to zero before entering sleep mode. Failure to do so can cause the lights to slowly creep back up to being dim rather than off after the lights have been turned off. This same issue was explored in detail in openshwprojects/OpenBK7231T_App#221 and fixed in openshwprojects/OpenBK7231T_App#242. This code is based closely on that PR.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes esphome/issues#4920

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [X] BK7231N

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
