### PR TITLE
Displays with resolutions of 320x480 or more failing on ESP32

### DIFF
--- a/esphome/components/ili9xxx/ili9xxx_display.cpp
+++ b/esphome/components/ili9xxx/ili9xxx_display.cpp
@@ -42,7 +42,7 @@ void ILI9XXXDisplay::setup() {
   }
 }
 
-void ILI9XXXDisplay::downsize_resolution(uint16_t bytes_per_pixel) {
+void ILI9XXXDisplay::downsize_resolution_(uint16_t bytes_per_pixel) {
   uint32_t max_mem = heap_caps_get_largest_free_block(MALLOC_CAP_8BIT);
   while (this->get_buffer_length_() * bytes_per_pixel > max_mem) {
     this->width_ = this->width_ - 2;

--- a/esphome/components/ili9xxx/ili9xxx_display.cpp
+++ b/esphome/components/ili9xxx/ili9xxx_display.cpp
@@ -24,7 +24,7 @@ void ILI9XXXDisplay::setup() {
   if (this->buffer_color_mode_ == BITS_16) {
     if (this->get_buffer_length_() * 2 > max_mem) {
       downsize_resolution(2);  // Reduce size.
-      this->fill_spi(this->x_high_, this->y_high_, this->x_low_, this->y_low_, 0x0000);  // fill display without using the buffer to clear border around buffered screen
+      this->fill_spi(this->x_high_, this->y_high_, this->x_low_, this->y_low_, 0x0000);
     }
     this->init_internal_(this->get_buffer_length_() * 2);
     if (this->buffer_ != nullptr) {
@@ -34,8 +34,8 @@ void ILI9XXXDisplay::setup() {
   }
   if (this->get_buffer_length_() > max_mem) {
     downsize_resolution(1);  // Reduce size
-    this->fill_spi(this->x_high_, this->y_high_, this->x_low_, this->y_low_, 0x0000);  // fill display without using the buffer to clear border around buffered screen
-  }
+    this->fill_spi(this->x_high_, this->y_high_, this->x_low_, this->y_low_, 0x0000);
+    }
   this->init_internal_(this->get_buffer_length_());
   if (this->buffer_ == nullptr) {
     this->mark_failed();

--- a/esphome/components/ili9xxx/ili9xxx_display.cpp
+++ b/esphome/components/ili9xxx/ili9xxx_display.cpp
@@ -23,7 +23,7 @@ void ILI9XXXDisplay::setup() {
   uint32_t max_mem = heap_caps_get_largest_free_block(MALLOC_CAP_8BIT);
   if (this->buffer_color_mode_ == BITS_16) {
     if (this->get_buffer_length_() * 2 > max_mem) {
-      downsize_resolution(2);  // Reduce size.
+      downsize_resolution_(2);  // Reduce size.
       this->fill_spi(this->x_high_, this->y_high_, this->x_low_, this->y_low_, 0x0000);
     }
     this->init_internal_(this->get_buffer_length_() * 2);
@@ -33,7 +33,7 @@ void ILI9XXXDisplay::setup() {
     this->buffer_color_mode_ = BITS_8;
   }
   if (this->get_buffer_length_() > max_mem) {
-    downsize_resolution(1);  // Reduce size
+    downsize_resolution_(1);  // Reduce size
     this->fill_spi(this->x_high_, this->y_high_, this->x_low_, this->y_low_, 0x0000);
   }
   this->init_internal_(this->get_buffer_length_());

--- a/esphome/components/ili9xxx/ili9xxx_display.cpp
+++ b/esphome/components/ili9xxx/ili9xxx_display.cpp
@@ -145,7 +145,6 @@ void ILI9XXXDisplay::fill(Color color) {
 // color: color
 void ILI9XXXDisplay::fill_spi(uint16_t x1, uint16_t y1, uint16_t x2, uint16_t y2, uint16_t color) {
   static uint8_t byte[1024];
-  int index = 0;
   uint16_t w = x2 - x1 + 1;  // NOLINT
   uint16_t h = y2 - y1 + 1;  // NOLINT
 
@@ -155,7 +154,7 @@ void ILI9XXXDisplay::fill_spi(uint16_t x1, uint16_t y1, uint16_t x2, uint16_t y2
   this->start_data_();
   for (int i = x1; i <= x2; i++) {
     uint16_t size = y2 - y1 + 1;
-    index = 0;
+    int index = 0;
     for (int b = 0; b < size; b++) {
       byte[index++] = (color >> 8) & 0xFF;
       byte[index++] = color & 0xFF;

--- a/esphome/components/ili9xxx/ili9xxx_display.cpp
+++ b/esphome/components/ili9xxx/ili9xxx_display.cpp
@@ -150,7 +150,6 @@ void ILI9XXXDisplay::fill_spi(uint16_t x1, uint16_t y1, uint16_t x2, uint16_t y2
 
   set_addr_window_(x1, y1, w, h);
 
-  //this->dc_pin_->digital_write(true);
   this->start_data_();
   for (int i = x1; i <= x2; i++) {
     uint16_t size = y2 - y1 + 1;

--- a/esphome/components/ili9xxx/ili9xxx_display.cpp
+++ b/esphome/components/ili9xxx/ili9xxx_display.cpp
@@ -52,7 +52,7 @@ void ILI9XXXDisplay::downsize_resolution_(uint16_t bytes_per_pixel) {
   this->x_low_ = this->width_;
   this->y_low_ = this->height_;
   ESP_LOGD(TAG, "Largest free heap block: %u bytes", max_mem);
-  ESP_LOGD(TAG, "Reduced display size to %ux%u", this->width_, this->height_);
+  ESP_LOGD(TAG, "Reduced display size to %ux%u", this->get_width_internal(), this->get_height_internal());
 }
 
 void ILI9XXXDisplay::setup_pins_() {

--- a/esphome/components/ili9xxx/ili9xxx_display.cpp
+++ b/esphome/components/ili9xxx/ili9xxx_display.cpp
@@ -19,7 +19,7 @@ void ILI9XXXDisplay::setup() {
   this->y_high_ = 0;
   this->offset_height_ = 0;
   this->offset_width_ = 0;
-  
+
   uint32_t max_mem = heap_caps_get_largest_free_block(MALLOC_CAP_8BIT);
   if (this->buffer_color_mode_ == BITS_16) {
     if (this->get_buffer_length_() * 2 > max_mem) {
@@ -27,7 +27,7 @@ void ILI9XXXDisplay::setup() {
       downsize_resolution(2);
       //fill display without using the buffer to clear border around buffered screen
       this->fill_spi(this->x_high_, this->y_high_, this->x_low_, this->y_low_, 0x0000);
-    }	
+    }
     this->init_internal_(this->get_buffer_length_() * 2);
     if (this->buffer_ != nullptr) {
       return;
@@ -39,7 +39,7 @@ void ILI9XXXDisplay::setup() {
     downsize_resolution(1);
     //fill display without using the buffer to clear border around buffered screen
     this->fill_spi(this->x_high_, this->y_high_, this->x_low_, this->y_low_, 0x0000);
-  }	
+  }
   this->init_internal_(this->get_buffer_length_());
   if (this->buffer_ == nullptr) {
     this->mark_failed();
@@ -148,9 +148,9 @@ void ILI9XXXDisplay::fill_spi(uint16_t x1, uint16_t y1, uint16_t x2, uint16_t y2
   int index = 0;
   uint16_t w = x2 - x1 + 1;  // NOLINT
   uint16_t h = y2 - y1 + 1;  // NOLINT
-  
+
   set_addr_window_(x1, y1, w, h);
-  
+
   //this->dc_pin_->digital_write(true);
   this->start_data_();
   for (int i = x1; i <= x2; i++) {
@@ -160,7 +160,7 @@ void ILI9XXXDisplay::fill_spi(uint16_t x1, uint16_t y1, uint16_t x2, uint16_t y2
       byte[index++] = (color >> 8) & 0xFF;
       byte[index++] = color & 0xFF;
     }
-    write_array(byte, size * 2);
+    this->write_array(byte, size * 2);
   }
   this->end_data_();
 }

--- a/esphome/components/ili9xxx/ili9xxx_display.cpp
+++ b/esphome/components/ili9xxx/ili9xxx_display.cpp
@@ -49,7 +49,7 @@ void ILI9XXXDisplay::setup() {
 void ILI9XXXDisplay::downsize_resolution(uint16_t bytes_per_pixel) {
   uint32_t max_mem = heap_caps_get_largest_free_block(MALLOC_CAP_8BIT);
   while (this->get_buffer_length_() * bytes_per_pixel > max_mem) {
-   	this->width_ = this->width_ - 2;
+    this->width_ = this->width_ - 2;
    	this->height_ = this->height_ - 2;
     this->offset_height_ = this->offset_height_ + 1;
     this->offset_width_ = this->offset_width_ + 1;

--- a/esphome/components/ili9xxx/ili9xxx_display.cpp
+++ b/esphome/components/ili9xxx/ili9xxx_display.cpp
@@ -23,10 +23,8 @@ void ILI9XXXDisplay::setup() {
   uint32_t max_mem = heap_caps_get_largest_free_block(MALLOC_CAP_8BIT);
   if (this->buffer_color_mode_ == BITS_16) {
     if (this->get_buffer_length_() * 2 > max_mem) {
-      //Reduce size
-      downsize_resolution(2);
-      //fill display without using the buffer to clear border around buffered screen
-      this->fill_spi(this->x_high_, this->y_high_, this->x_low_, this->y_low_, 0x0000);
+      downsize_resolution(2);//Reduce size.
+      this->fill_spi(this->x_high_, this->y_high_, this->x_low_, this->y_low_, 0x0000);//fill display without using the buffer to clear border around buffered screen
     }
     this->init_internal_(this->get_buffer_length_() * 2);
     if (this->buffer_ != nullptr) {
@@ -35,10 +33,8 @@ void ILI9XXXDisplay::setup() {
     this->buffer_color_mode_ = BITS_8;
   }
   if (this->get_buffer_length_() > max_mem) {
-    //Reduce size
-    downsize_resolution(1);
-    //fill display without using the buffer to clear border around buffered screen
-    this->fill_spi(this->x_high_, this->y_high_, this->x_low_, this->y_low_, 0x0000);
+    downsize_resolution(1);//Reduce size
+    this->fill_spi(this->x_high_, this->y_high_, this->x_low_, this->y_low_, 0x0000);//fill display without using the buffer to clear border around buffered screen
   }
   this->init_internal_(this->get_buffer_length_());
   if (this->buffer_ == nullptr) {

--- a/esphome/components/ili9xxx/ili9xxx_display.cpp
+++ b/esphome/components/ili9xxx/ili9xxx_display.cpp
@@ -23,8 +23,8 @@ void ILI9XXXDisplay::setup() {
   uint32_t max_mem = heap_caps_get_largest_free_block(MALLOC_CAP_8BIT);
   if (this->buffer_color_mode_ == BITS_16) {
     if (this->get_buffer_length_() * 2 > max_mem) {
-      downsize_resolution(2);//Reduce size.
-      this->fill_spi(this->x_high_, this->y_high_, this->x_low_, this->y_low_, 0x0000);//fill display without using the buffer to clear border around buffered screen
+      downsize_resolution(2);  // Reduce size.
+      this->fill_spi(this->x_high_, this->y_high_, this->x_low_, this->y_low_, 0x0000);  // fill display without using the buffer to clear border around buffered screen
     }
     this->init_internal_(this->get_buffer_length_() * 2);
     if (this->buffer_ != nullptr) {
@@ -33,8 +33,8 @@ void ILI9XXXDisplay::setup() {
     this->buffer_color_mode_ = BITS_8;
   }
   if (this->get_buffer_length_() > max_mem) {
-    downsize_resolution(1);//Reduce size
-    this->fill_spi(this->x_high_, this->y_high_, this->x_low_, this->y_low_, 0x0000);//fill display without using the buffer to clear border around buffered screen
+    downsize_resolution(1);  // Reduce size
+    this->fill_spi(this->x_high_, this->y_high_, this->x_low_, this->y_low_, 0x0000);  // fill display without using the buffer to clear border around buffered screen
   }
   this->init_internal_(this->get_buffer_length_());
   if (this->buffer_ == nullptr) {

--- a/esphome/components/ili9xxx/ili9xxx_display.cpp
+++ b/esphome/components/ili9xxx/ili9xxx_display.cpp
@@ -24,7 +24,6 @@ void ILI9XXXDisplay::setup() {
   if (this->buffer_color_mode_ == BITS_16) {
     if (this->get_buffer_length_() * 2 > max_mem) {
       downsize_resolution_(2);  // Reduce size.
-      this->fill_spi(this->x_high_, this->y_high_, this->x_low_, this->y_low_, 0x0000);
     }
     this->init_internal_(this->get_buffer_length_() * 2);
     if (this->buffer_ != nullptr) {
@@ -34,7 +33,6 @@ void ILI9XXXDisplay::setup() {
   }
   if (this->get_buffer_length_() > max_mem) {
     downsize_resolution_(1);  // Reduce size
-    this->fill_spi(this->x_high_, this->y_high_, this->x_low_, this->y_low_, 0x0000);
   }
   this->init_internal_(this->get_buffer_length_());
   if (this->buffer_ == nullptr) {
@@ -44,6 +42,7 @@ void ILI9XXXDisplay::setup() {
 
 void ILI9XXXDisplay::downsize_resolution_(uint16_t bytes_per_pixel) {
   uint32_t max_mem = heap_caps_get_largest_free_block(MALLOC_CAP_8BIT);
+  this->fill_spi(this->x_high_, this->y_high_, this->x_low_, this->y_low_, 0x0000);
   while (this->get_buffer_length_() * bytes_per_pixel > max_mem) {
     this->width_ = this->width_ - 2;
     this->height_ = this->height_ - 2;

--- a/esphome/components/ili9xxx/ili9xxx_display.cpp
+++ b/esphome/components/ili9xxx/ili9xxx_display.cpp
@@ -35,7 +35,7 @@ void ILI9XXXDisplay::setup() {
   if (this->get_buffer_length_() > max_mem) {
     downsize_resolution(1);  // Reduce size
     this->fill_spi(this->x_high_, this->y_high_, this->x_low_, this->y_low_, 0x0000);
-    }
+  }
   this->init_internal_(this->get_buffer_length_());
   if (this->buffer_ == nullptr) {
     this->mark_failed();

--- a/esphome/components/ili9xxx/ili9xxx_display.cpp
+++ b/esphome/components/ili9xxx/ili9xxx_display.cpp
@@ -50,7 +50,7 @@ void ILI9XXXDisplay::downsize_resolution(uint16_t bytes_per_pixel) {
   uint32_t max_mem = heap_caps_get_largest_free_block(MALLOC_CAP_8BIT);
   while (this->get_buffer_length_() * bytes_per_pixel > max_mem) {
     this->width_ = this->width_ - 2;
-   	this->height_ = this->height_ - 2;
+    this->height_ = this->height_ - 2;
     this->offset_height_ = this->offset_height_ + 1;
     this->offset_width_ = this->offset_width_ + 1;
   }

--- a/esphome/components/ili9xxx/ili9xxx_display.h
+++ b/esphome/components/ili9xxx/ili9xxx_display.h
@@ -41,6 +41,7 @@ class ILI9XXXDisplay : public PollingComponent,
   void update() override;
 
   void fill(Color color) override;
+  void fill_spi(uint16_t x1, uint16_t y1, uint16_t x2, uint16_t y2, uint16_t color);
 
   void dump_config() override;
   void setup() override;
@@ -49,6 +50,7 @@ class ILI9XXXDisplay : public PollingComponent,
 
  protected:
   void draw_absolute_pixel_internal(int x, int y, Color color) override;
+  void downsize_resolution(uint16_t bytes_per_pixel);
   void setup_pins_();
   virtual void initialize() = 0;
 
@@ -64,6 +66,8 @@ class ILI9XXXDisplay : public PollingComponent,
   uint16_t y_low_{0};
   uint16_t x_high_{0};
   uint16_t y_high_{0};
+  uint16_t offset_height_{0};
+  uint16_t offset_width_{0};
   const uint8_t *palette_;
 
   ILI9XXXColorMode buffer_color_mode_{BITS_16};

--- a/esphome/components/ili9xxx/ili9xxx_display.h
+++ b/esphome/components/ili9xxx/ili9xxx_display.h
@@ -50,7 +50,7 @@ class ILI9XXXDisplay : public PollingComponent,
 
  protected:
   void draw_absolute_pixel_internal(int x, int y, Color color) override;
-  void downsize_resolution(uint16_t bytes_per_pixel);
+  void downsize_resolution_(uint16_t bytes_per_pixel);
   void setup_pins_();
   virtual void initialize() = 0;
 


### PR DESCRIPTION
with 520kB RAM or less on allocating memory for the frame buffer.

By reducing the display size and clearing the border via SPI the setup of the display will no longer fail but only getting a small border.

# What does this implement/fix?

Display setup will no longer fail on displays with higher resolutions. The buffered display size will be reduced to the resolution the largest free memory block will make possible. The unaccessable border will be cleared via a SPI fill function during setup.
Did this to make [ESP32-3248S035](https://de.aliexpress.com/item/1005005542773413.html) board including a 3.5" ST7796 display work. 

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
display:
  - platform: ili9xxx
    model: ST7796
    spi_id: lcd
    cs_pin: GPIO15
    dc_pin: GPIO2
    reset_pin: GPIO23
    dimensions: 320x480
    rotation: 270
    update_interval: 1s
    lambda: |-
      it.filled_rectangle(0, 0, it.get_width(), it.get_height(), id(my_blue));
-->

```yaml
esphome:
  name: Test1
  friendly_name: Test1

esp32:
  board: az-delivery-devkit-v4
  framework: 

    type: esp-idf
    version: recommended

# Enable logging
logger:
  level: VERY_VERBOSE

# Enable Home Assistant API
api:
  encryption:
    key: "..."

ota:
  password: "..."

wifi:
  ssid: !secret wifi_ssid
  password: !secret wifi_password

  # Enable fallback hotspot (captive portal) in case wifi connection fails
  ap:
    ssid: "Test1 Fallback Hotspot"
    password: "..."

captive_portal:

color:

  - id: my_blue
    red: 0%
    green: 0%
    blue: 100%

spi:
  - id: lcd
    clk_pin: GPIO14
    mosi_pin: GPIO13
    miso_pin: GPIO12

display:
  - platform: ili9xxx
    model: ST7796
    spi_id: lcd
    cs_pin: GPIO15
    dc_pin: GPIO2
    reset_pin: GPIO23
    dimensions: 320x480
    rotation: 270
    update_interval: 1s
    lambda: |-
      it.filled_rectangle(0, 0, it.get_width(), it.get_height(), id(my_blue));

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
