### PR TITLE
Ensure esphome directory exists on addon startup

### DIFF
--- a/docker/ha-addon-rootfs/etc/s6-overlay/s6-rc.d/esphome/run
+++ b/docker/ha-addon-rootfs/etc/s6-overlay/s6-rc.d/esphome/run
@@ -41,6 +41,8 @@ fi
 
 mkdir -p "${pio_cache_base}"
 
+mkdir -p /config/esphome
+
 if bashio::fs.directory_exists '/config/esphome/.esphome'; then
     bashio::log.info "Migrating old .esphome directory..."
     if bashio::fs.file_exists '/config/esphome/.esphome/esphome.json'; then


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

I am assuming after the `.esphome` folder was (re)moved in #5374, the main folder was no longer being created. This ensures it will be there.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/4926

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
