### PR TITLE
add pin config for denky_d4

### DIFF
--- a/esphome/components/esp32/boards.py
+++ b/esphome/components/esp32/boards.py
@@ -235,6 +235,10 @@ ESP32_BOARD_PINS = {
         "SDA": 5,
         "SS": 15,
     },
+    "denky_d4": {
+        "RX": 8,
+        "LED": 14
+    },
     "esp-wrover-kit": {},
     "esp32-devkitlipo": {},
     "esp32-evb": {

--- a/esphome/components/esp32/boards.py
+++ b/esphome/components/esp32/boards.py
@@ -235,10 +235,7 @@ ESP32_BOARD_PINS = {
         "SDA": 5,
         "SS": 15,
     },
-    "denky_d4": {
-        "RX": 8,
-        "LED": 14
-    },
+    "denky_d4": {"RX": 8, "LED": 14},
     "esp-wrover-kit": {},
     "esp32-devkitlipo": {},
     "esp32-evb": {


### PR DESCRIPTION
# What does this implement/fix?

Adds a pin config for the Denky D4 to get rid of the `This pin cannot be used on ESP32s and is already used by the flash interface (function: Flash Data 1).` error.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/4151

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
esphome:
  name: linky
  friendly_name: Linky

esp32:
  board: denky_d4
  framework:
    type: esp-idf

uart:
  rx_pin: GPIO8
  baud_rate: 9600
  parity: EVEN
  data_bits: 7
  stop_bits: 1

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
