### PR TITLE
ST7789v - Allow predefined backlight pin to be disabled.

### DIFF
--- a/esphome/components/st7789v/display.py
+++ b/esphome/components/st7789v/display.py
@@ -138,7 +138,7 @@ CONFIG_SCHEMA = cv.All(
             cv.Required(CONF_MODEL): cv.one_of(*MODELS.keys(), upper=True, space="_"),
             cv.Optional(CONF_RESET_PIN): pins.gpio_output_pin_schema,
             cv.Optional(CONF_DC_PIN): pins.gpio_output_pin_schema,
-            cv.Optional(CONF_BACKLIGHT_PIN, default=False): cv.Any(
+            cv.Optional(CONF_BACKLIGHT_PIN): cv.Any(
                 cv.boolean,
                 pins.gpio_output_pin_schema,
             ),

--- a/esphome/components/st7789v/display.py
+++ b/esphome/components/st7789v/display.py
@@ -138,7 +138,10 @@ CONFIG_SCHEMA = cv.All(
             cv.Required(CONF_MODEL): cv.one_of(*MODELS.keys(), upper=True, space="_"),
             cv.Optional(CONF_RESET_PIN): pins.gpio_output_pin_schema,
             cv.Optional(CONF_DC_PIN): pins.gpio_output_pin_schema,
-            cv.Optional(CONF_BACKLIGHT_PIN): pins.gpio_output_pin_schema,
+            cv.Optional(CONF_BACKLIGHT_PIN, default=False): cv.Any(
+                cv.boolean,
+                pins.gpio_output_pin_schema,
+            ),
             cv.Optional(CONF_POWER_SUPPLY): cv.use_id(power_supply.PowerSupply),
             cv.Optional(CONF_EIGHTBITCOLOR, default=False): cv.boolean,
             cv.Optional(CONF_HEIGHT): cv.int_,
@@ -174,7 +177,7 @@ async def to_code(config):
     reset = await cg.gpio_pin_expression(config[CONF_RESET_PIN])
     cg.add(var.set_reset_pin(reset))
 
-    if CONF_BACKLIGHT_PIN in config:
+    if CONF_BACKLIGHT_PIN in config and config[CONF_BACKLIGHT_PIN]:
         bl = await cg.gpio_pin_expression(config[CONF_BACKLIGHT_PIN])
         cg.add(var.set_backlight_pin(bl))
 

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -2948,7 +2948,7 @@ display:
     cs_pin: GPIO5
     dc_pin: GPIO16
     reset_pin: GPIO23
-    backlight_pin: GPIO4
+    backlight_pin: no
     lambda: |-
       it.rectangle(0, 0, it.get_width(), it.get_height());
   - platform: st7920


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

The predefined backlight in an st7789v config needs to be overridden if the user wants to manually control the backlight. This PR allows it to be turned off. 
## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/4933

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#3235

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
display:
  - platform: st7789v
    model: LILYGO_T-EMBED_170X320
    height: 320
    backlight_pin: no
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
