### PR TITLE
Fix: Incorporate unique serial number in preference's hash for multiple Sensirion sensors

### DIFF
--- a/esphome/components/sen5x/sen5x.cpp
+++ b/esphome/components/sen5x/sen5x.cpp
@@ -1,5 +1,6 @@
 #include "sen5x.h"
 #include "esphome/core/hal.h"
+#include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 #include <cinttypes>
 
@@ -135,8 +136,8 @@ void SEN5XComponent::setup() {
       ESP_LOGD(TAG, "Firmware version %d", this->firmware_version_);
 
       if (this->voc_sensor_ && this->store_baseline_) {
-        uint32_t combined_serial = (uint32_t(this->serial_number_[0]) << 24) |
-                                   (uint32_t(this->serial_number_[1]) << 16) | (uint32_t(this->serial_number_[2]));
+        uint32_t combined_serial =
+            encode_uint24(this->serial_number_[0], this->serial_number_[1], this->serial_number_[2]);
         // Hash with compilation time and serial number
         // This ensures the baseline storage is cleared after OTA
         // Serial numbers are unique to each sensor, so mulitple sensors can be used without conflict

--- a/esphome/components/sen5x/sen5x.cpp
+++ b/esphome/components/sen5x/sen5x.cpp
@@ -135,9 +135,12 @@ void SEN5XComponent::setup() {
       ESP_LOGD(TAG, "Firmware version %d", this->firmware_version_);
 
       if (this->voc_sensor_ && this->store_baseline_) {
-        // Hash with compilation time
+        uint32_t combined_serial = (uint32_t(this->serial_number_[0]) << 24) |
+                                   (uint32_t(this->serial_number_[1]) << 16) | (uint32_t(this->serial_number_[2]));
+        // Hash with compilation time and serial number
         // This ensures the baseline storage is cleared after OTA
-        uint32_t hash = fnv1_hash(App.get_compilation_time());
+        // Serial numbers are unique to each sensor, so mulitple sensors can be used without conflict
+        uint32_t hash = fnv1_hash(App.get_compilation_time() + std::to_string(combined_serial));
         this->pref_ = global_preferences->make_preference<Sen5xBaselines>(hash, true);
 
         if (this->pref_.load(&this->voc_baselines_storage_)) {

--- a/esphome/components/sgp30/sgp30.cpp
+++ b/esphome/components/sgp30/sgp30.cpp
@@ -73,9 +73,10 @@ void SGP30Component::setup() {
     return;
   }
 
-  // Hash with compilation time
+  // Hash with compilation time and serial number
   // This ensures the baseline storage is cleared after OTA
-  uint32_t hash = fnv1_hash(App.get_compilation_time());
+  // Serial numbers are unique to each sensor, so mulitple sensors can be used without conflict
+  uint32_t hash = fnv1_hash(App.get_compilation_time() + std::to_string(this->serial_number_));
   this->pref_ = global_preferences->make_preference<SGP30Baselines>(hash, true);
 
   if (this->pref_.load(&this->baselines_storage_)) {

--- a/esphome/components/sgp4x/sgp4x.cpp
+++ b/esphome/components/sgp4x/sgp4x.cpp
@@ -61,9 +61,10 @@ void SGP4xComponent::setup() {
   ESP_LOGD(TAG, "Product version: 0x%0X", uint16_t(this->featureset_ & 0x1FF));
 
   if (this->store_baseline_) {
-    // Hash with compilation time
+    // Hash with compilation time and serial number
     // This ensures the baseline storage is cleared after OTA
-    uint32_t hash = fnv1_hash(App.get_compilation_time());
+    // Serial numbers are unique to each sensor, so mulitple sensors can be used without conflict
+    uint32_t hash = fnv1_hash(App.get_compilation_time() + std::to_string(this->serial_number_));
     this->pref_ = global_preferences->make_preference<SGP4xBaselines>(hash, true);
 
     if (this->pref_.load(&this->voc_baselines_storage_)) {


### PR DESCRIPTION
# What does this implement/fix?

Currently, the ``sgp4x``, ``spg30``, and ``sen5x`` components store the baseline values in the preferences using a hash derived from the compilation time. If you have multiple sensors on different I2C buses, then the same baseline preference will be used for each sensor. This PR changes it so that the hash computation uses the compilation time (so the baseline still resets with any new firmware) and each sensor's unique serial number.

This PR isn't a breaking change, as the current behavior will already recompute the baseline after flashing a new firmware.

I have tested it locally with two SGP40 sensors. The ``sgp30`` and ``sen5x`` components should also work, as the changes follow the same logic. The existing test cases already have the baseline stored (by default), so the modifications are tested at least through compilation.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** not applicable

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** not applicable

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

  - platform: sgp4x
    i2c_id: multplex0channel0
    store_baseline: true
    voc:
      name: "VOC Index 0"
    compensation:
      temperature_source: temp_sensor
      humidity_source: humidity_sensor
  - platform: sgp4x
    i2c_id: multplex0channel1
    store_baseline: true
    voc:
      name: "VOC Index 1"
    compensation:
      temperature_source: temp_sensor
      humidity_source: humidity_sensor    
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
