### PR TITLE
Increased debug message precision

### DIFF
--- a/esphome/components/ultrasonic/ultrasonic_sensor.cpp
+++ b/esphome/components/ultrasonic/ultrasonic_sensor.cpp
@@ -37,7 +37,7 @@ void UltrasonicSensorComponent::update() {
     this->publish_state(NAN);
   } else {
     float result = UltrasonicSensorComponent::us_to_m(pulse_end - pulse_start);
-    ESP_LOGD(TAG, "'%s' - Got distance: %.2f m", this->name_.c_str(), result);
+    ESP_LOGD(TAG, "'%s' - Got distance: %.3f m", this->name_.c_str(), result);
     this->publish_state(result);
   }
 }


### PR DESCRIPTION
# What does this implement/fix?
Changed the debug message for distance reported from 2 decimal places to 3. Most ultrasonic sensors have 1mm of accuracy so it is fair and useful to show the precision to 3 places. I have marked as a bugfix/new feature as I think it was a mistake to only report 2 decimal places but also could be considered a new feature.
<!-- Quick description and explanation of changes -->

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
esphome:
  name: "ultrasonic"
  friendly_name: "ultrasonic"

esp8266:
  board: esp01_1m

# Enable logging
logger:

# Enable Home Assistant API
api:

wifi:
  - ssid: !secret wifi_ssid
    password: !secret wifi_password

captive_portal:

sensor:
  - platform: ultrasonic
    name: "distance"
    trigger_pin: 16
    echo_pin: 5
    
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
