### PR TITLE
Fixed precision for Nextion sensor with float values

### DIFF
--- a/esphome/components/nextion/sensor/nextion_sensor.cpp
+++ b/esphome/components/nextion/sensor/nextion_sensor.cpp
@@ -76,9 +76,15 @@ void NextionSensor::set_state(float state, bool publish, bool send_to_nextion) {
     }
   }
 
+  float published_state = state;
   if (this->wave_chan_id_ == UINT8_MAX) {
     if (publish) {
-      this->publish_state(state);
+      if (this->precision_ > 0) {
+        double to_multiply = pow(10, -this->precision_);
+        published_state = (float)(state * to_multiply);
+      }
+
+      this->publish_state(published_state);
     } else {
       this->raw_state = state;
       this->state = state;
@@ -87,7 +93,7 @@ void NextionSensor::set_state(float state, bool publish, bool send_to_nextion) {
   }
   this->update_component_settings();
 
-  ESP_LOGN(TAG, "Wrote state for sensor \"%s\" state %lf", this->variable_name_.c_str(), state);
+  ESP_LOGN(TAG, "Wrote state for sensor \"%s\" state %lf", this->variable_name_.c_str(), published_state);
 }
 
 void NextionSensor::wave_update_() {

--- a/esphome/components/nextion/sensor/nextion_sensor.cpp
+++ b/esphome/components/nextion/sensor/nextion_sensor.cpp
@@ -81,7 +81,7 @@ void NextionSensor::set_state(float state, bool publish, bool send_to_nextion) {
     if (publish) {
       if (this->precision_ > 0) {
         double to_multiply = pow(10, -this->precision_);
-        published_state = (float)(state * to_multiply);
+        published_state = (float) (state * to_multiply);
       }
 
       this->publish_state(published_state);


### PR DESCRIPTION
# What does this implement/fix?

Nextion Sensor component doesn't work correctly if `precision` is set for `float` components. Nextion doesn't support floats natively, it just emulates them by multiplying or dividing integers by powers of 10. Nextion sensor in ESPHome already has `precision` property, but it only multiplies values when sending them to Nextion. When values are received from Nextion, they should be divided by the appropriate amount, but in fact they are not. This pull request fixes that.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
esphome:
  name: test

esp32:
  board: mhetesp32minikit
  framework:
    type: arduino

uart:
  id: uart_2
  rx_pin: GPIO16
  tx_pin: GPIO17
  baud_rate: 115200

sensor:
  - platform: nextion
    id: test_sensor
    name: "Test sensor"
    component_name: page0.x0
    precision: 1
    update_interval: 1s
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).