### PR TITLE
Fix e131 and voice_assistant sockets

### DIFF
--- a/esphome/components/e131/e131.cpp
+++ b/esphome/components/e131/e131.cpp
@@ -40,7 +40,6 @@ void E131Component::setup() {
     this->mark_failed();
     return;
   }
-  server.ss_family = AF_INET;
 
   err = this->socket_->bind((struct sockaddr *) &server, sizeof(server));
   if (err != 0) {

--- a/esphome/components/voice_assistant/voice_assistant.cpp
+++ b/esphome/components/voice_assistant/voice_assistant.cpp
@@ -47,7 +47,6 @@ void VoiceAssistant::setup() {
       this->mark_failed();
       return;
     }
-    server.ss_family = AF_INET;
 
     err = socket_->bind((struct sockaddr *) &server, sizeof(server));
     if (err != 0) {


### PR DESCRIPTION
# What does this implement/fix?

As outlined in https://github.com/esphome/issues/issues/4645 E1.31 broke after https://github.com/esphome/esphome/pull/4832#issue-1710788306. This fixes the issue with E131. I also noticed that the voice assistant does the same thing when using a speaker and fixed that as well.

The problem is that the socket family is getting overwritten to be an AF_INET (ipv4), even though the socket address itself may be an AF_INET6 (ipv6). `set_sockaddr_any` sets the sockaddr family appropriately (AF_INET or AF_INET6 depending upon the LWIP_IPV6 define), resetting it is extraneous and will cause the bind to fail if it's initialized as an IPv6 socket address.

Relevant logs:

Before:
```
...
[C][api:025]: Setting up Home Assistant API server...
[W][e131:055]: Socket unable to bind: errno 22
[E][component:113]: Component e131 was marked as failed.
[I][app:062]: setup() finished successfully!
```

After:
```
[C][api:025]: Setting up Home Assistant API server...
[I][app:062]: setup() finished successfully!
```

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/4645

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:

```yaml
e131:
  method: unicast

light:
  - platform: neopixelbus
    type: GRBW
    variant: SK6812
    pin: GPIO21
    num_leds: 60
    name: Lights
    effects:
      - e131:
          universe: 1
          channels: RGBW
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [-] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
