### PR TITLE
Add detail param to allow listing of select options in WebServer REST API

### DIFF
--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -805,7 +805,8 @@ void WebServer::handle_select_request(AsyncWebServerRequest *request, const UrlM
       continue;
 
     if (request->method() == HTTP_GET) {
-      std::string data = this->select_json(obj, obj->state, DETAIL_STATE);
+      auto detail = request->getParam("detail")->value() == "all" ? DETAIL_ALL : DETAIL_STATE;
+      std::string data = this->select_json(obj, obj->state, detail);
       request->send(200, "application/json", data.c_str());
       return;
     }

--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -806,7 +806,7 @@ void WebServer::handle_select_request(AsyncWebServerRequest *request, const UrlM
 
     if (request->method() == HTTP_GET) {
       auto detail = DETAIL_STATE;
-      auto param = request->getParam("detail");
+      auto *param = request->getParam("detail");
       if (param && param->value() == "all") {
         detail = DETAIL_ALL;
       }

--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -808,7 +808,7 @@ void WebServer::handle_select_request(AsyncWebServerRequest *request, const UrlM
       auto detail = DETAIL_STATE;
       auto param = request->getParam("detail");
       if (param && param->value() == "all") {
-          detail = DETAIL_ALL;
+        detail = DETAIL_ALL;
       }
       std::string data = this->select_json(obj, obj->state, detail);
       request->send(200, "application/json", data.c_str());

--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -805,7 +805,11 @@ void WebServer::handle_select_request(AsyncWebServerRequest *request, const UrlM
       continue;
 
     if (request->method() == HTTP_GET) {
-      auto detail = request->getParam("detail")->value() == "all" ? DETAIL_ALL : DETAIL_STATE;
+      auto detail = DETAIL_STATE;
+      auto param = request->getParam("detail");
+      if (param && param->value() == "all") {
+          detail = DETAIL_ALL;
+      }
       std::string data = this->select_json(obj, obj->state, detail);
       request->send(200, "application/json", data.c_str());
       return;


### PR DESCRIPTION
# What does this implement/fix?

Adds a query parameter "detail" that makes it possible to use DETAIL_ALL to list select options in the WebServer REST API.
Currently it is impossible to introspect which options are available to pass to a selects set method.

## Types of changes
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#3257

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
web_server:
  port: 80

select:
  - platform: template
     id: test
     optimistic: true
     options: 
       - One
       - Two
       - Three
```
```curl -iX GET http://esphome-web.local/select/test\?detail\=all```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
         *Doesn't look like there are any web_server tests.*
  

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
         *Will add upon positive feedback on PR*