### PR TITLE
Improvements to RF receiver for Drayton Digistat heating controller 

### DIFF
--- a/esphome/components/remote_base/drayton_protocol.cpp
+++ b/esphome/components/remote_base/drayton_protocol.cpp
@@ -152,7 +152,7 @@ optional<DraytonData> DraytonProtocol::decode(RemoteReceiveData src) {
     // Look for sync pulse, after. If sucessful index points to space of sync symbol
     while (src.size() - src.get_index() >= NDATABITS) {
       ESP_LOGVV(TAG, "Decode Drayton: sync search %d, %" PRId32 " %" PRId32, src.size() - src.get_index(), src.peek(),
-        src.peek(1));
+                src.peek(1));
       if (src.peek_mark(2 * BIT_TIME_US) &&
           (src.peek_space(2 * BIT_TIME_US, 1) || src.peek_space(3 * BIT_TIME_US, 1))) {
         src.advance(1);

--- a/esphome/components/remote_base/drayton_protocol.cpp
+++ b/esphome/components/remote_base/drayton_protocol.cpp
@@ -138,8 +138,8 @@ optional<DraytonData> DraytonProtocol::decode(RemoteReceiveData src) {
   while (src.size() - src.get_index() > MIN_RX_SRC) {
     ESP_LOGVV(TAG,
               "Decode Drayton: %" PRId32 ", %" PRId32 " %" PRId32 " %" PRId32 " %" PRId32 " %" PRId32 " %" PRId32
-              " %" PRId32 " %" PRId32 " %" PRId32 " %" PRId32 " %" PRId32 " %" PRId32 " %" PRId32 " %" PRId32 " %" PRId32
-              " %" PRId32 " %" PRId32 " %" PRId32 " %" PRId32 " %" PRId32 "",
+              " %" PRId32 " %" PRId32 " %" PRId32 " %" PRId32 " %" PRId32 " %" PRId32 " %" PRId32 " %" PRId32
+              " %" PRId32 " %" PRId32 " %" PRId32 " %" PRId32 " %" PRId32 " %" PRId32 "",
               src.size() - src.get_index(), src.peek(0), src.peek(1), src.peek(2), src.peek(3), src.peek(4),
               src.peek(5), src.peek(6), src.peek(7), src.peek(8), src.peek(9), src.peek(10), src.peek(11), src.peek(12),
               src.peek(13), src.peek(14), src.peek(15), src.peek(16), src.peek(17), src.peek(18), src.peek(19));
@@ -151,7 +151,8 @@ optional<DraytonData> DraytonProtocol::decode(RemoteReceiveData src) {
 
     // Look for sync pulse, after. If sucessful index points to space of sync symbol
     while (src.size() - src.get_index() >= NDATABITS) {
-      ESP_LOGVV(TAG, "Decode Drayton: sync search %d, %" PRId32 " %" PRId32, src.size() - src.get_index(), src.peek(), src.peek(1));
+      ESP_LOGVV(TAG, "Decode Drayton: sync search %d, %" PRId32 " %" PRId32, src.size() - src.get_index(), src.peek(),
+	      src.peek(1));
       if (src.peek_mark(2 * BIT_TIME_US) &&
           (src.peek_space(2 * BIT_TIME_US, 1) || src.peek_space(3 * BIT_TIME_US, 1))) {
         src.advance(1);

--- a/esphome/components/remote_base/drayton_protocol.cpp
+++ b/esphome/components/remote_base/drayton_protocol.cpp
@@ -152,7 +152,7 @@ optional<DraytonData> DraytonProtocol::decode(RemoteReceiveData src) {
     // Look for sync pulse, after. If sucessful index points to space of sync symbol
     while (src.size() - src.get_index() >= NDATABITS) {
       ESP_LOGVV(TAG, "Decode Drayton: sync search %d, %" PRId32 " %" PRId32, src.size() - src.get_index(), src.peek(),
-	      src.peek(1));
+        src.peek(1));
       if (src.peek_mark(2 * BIT_TIME_US) &&
           (src.peek_space(2 * BIT_TIME_US, 1) || src.peek_space(3 * BIT_TIME_US, 1))) {
         src.advance(1);

--- a/esphome/components/remote_base/drayton_protocol.cpp
+++ b/esphome/components/remote_base/drayton_protocol.cpp
@@ -151,7 +151,7 @@ optional<DraytonData> DraytonProtocol::decode(RemoteReceiveData src) {
 
     // Look for sync pulse, after. If sucessful index points to space of sync symbol
     while (src.size() - src.get_index() >= NDATABITS) {
-      ESP_LOGVV(TAG, "Decode Drayton: sync search %d, %" PRId32 " %" PRId32", src.size() - src.get_index(), src.peek(), src.peek(1));
+      ESP_LOGVV(TAG, "Decode Drayton: sync search %d, %" PRId32 " %" PRId32, src.size() - src.get_index(), src.peek(), src.peek(1));
       if (src.peek_mark(2 * BIT_TIME_US) &&
           (src.peek_space(2 * BIT_TIME_US, 1) || src.peek_space(3 * BIT_TIME_US, 1))) {
         src.advance(1);
@@ -173,7 +173,7 @@ optional<DraytonData> DraytonProtocol::decode(RemoteReceiveData src) {
     // Checks next bit to leave index pointing correctly
     uint32_t out_data = 0;
     uint8_t bit = NDATABITS - 1;
-    ESP_LOGVV(TAG, "Decode Drayton: first bit %d  %" PRId32 ", %" PRDd32, src.peek(0), src.peek(1), src.peek(2));
+    ESP_LOGVV(TAG, "Decode Drayton: first bit %d  %" PRId32 ", %" PRId32, src.peek(0), src.peek(1), src.peek(2));
     if (src.expect_space(3 * BIT_TIME_US) && (src.expect_mark(BIT_TIME_US) || src.peek_mark(2 * BIT_TIME_US))) {
       out_data |= 0 << bit;
     } else if (src.expect_space(2 * BIT_TIME_US) && src.expect_mark(BIT_TIME_US) &&

--- a/esphome/components/remote_base/drayton_protocol.cpp
+++ b/esphome/components/remote_base/drayton_protocol.cpp
@@ -13,7 +13,8 @@ static const uint8_t NBITS_SYNC = 4;
 static const uint8_t NBITS_ADDRESS = 16;
 static const uint8_t NBITS_CHANNEL = 5;
 static const uint8_t NBITS_COMMAND = 7;
-static const uint8_t NBITS = NBITS_ADDRESS + NBITS_CHANNEL + NBITS_COMMAND;
+static const uint8_t NDATABITS = NBITS_ADDRESS + NBITS_CHANNEL + NBITS_COMMAND;
+static const uint8_t MIN_RX_SRC = (NDATABITS * 2 + NBITS_SYNC / 2);
 
 static const uint8_t CMD_ON = 0x41;
 static const uint8_t CMD_OFF = 0x02;
@@ -116,7 +117,7 @@ void DraytonProtocol::encode(RemoteTransmitData *dst, const DraytonData &data) {
 
   ESP_LOGV(TAG, "Send Drayton: out_data %08" PRIx32, out_data);
 
-  for (uint32_t mask = 1UL << (NBITS - 1); mask != 0; mask >>= 1) {
+  for (uint32_t mask = 1UL << (NDATABITS - 1); mask != 0; mask >>= 1) {
     if (out_data & mask) {
       dst->mark(BIT_TIME_US);
       dst->space(BIT_TIME_US);
@@ -134,79 +135,95 @@ optional<DraytonData> DraytonProtocol::decode(RemoteReceiveData src) {
       .command = 0,
   };
 
-  if (src.size() < 45) {
-    return {};
-  }
+  while (src.size() - src.get_index() > MIN_RX_SRC) {
+    ESP_LOGVV(TAG,
+              "Decode Drayton: %" PRId32 ", %" PRId32 " %" PRId32 " %" PRId32 " %" PRId32 " %" PRId32 " %" PRId32
+              " %" PRId32 " %" PRId32 " %" PRId32 " %" PRId32 " %" PRId32 " %" PRId32 " %" PRId32 " %" PRId32 " %" PRId32
+              " %" PRId32 " %" PRId32 " %" PRId32 " %" PRId32 " %" PRId32 "",
+              src.size() - src.get_index(), src.peek(0), src.peek(1), src.peek(2), src.peek(3), src.peek(4),
+              src.peek(5), src.peek(6), src.peek(7), src.peek(8), src.peek(9), src.peek(10), src.peek(11), src.peek(12),
+              src.peek(13), src.peek(14), src.peek(15), src.peek(16), src.peek(17), src.peek(18), src.peek(19));
 
-  ESP_LOGVV(TAG,
-            "Decode Drayton: %" PRId32 ", %" PRId32 " %" PRId32 " %" PRId32 " %" PRId32 " %" PRId32 " %" PRId32
-            " %" PRId32 " %" PRId32 " %" PRId32 " %" PRId32 " %" PRId32 " %" PRId32 " %" PRId32 " %" PRId32 " %" PRId32
-            " %" PRId32 " %" PRId32 " %" PRId32 " %" PRId32 " %" PRId32 "",
-            src.size(), src.peek(0), src.peek(1), src.peek(2), src.peek(3), src.peek(4), src.peek(5), src.peek(6),
-            src.peek(7), src.peek(8), src.peek(9), src.peek(10), src.peek(11), src.peek(12), src.peek(13), src.peek(14),
-            src.peek(15), src.peek(16), src.peek(17), src.peek(18), src.peek(19));
+    // If first preamble item is a space, skip it
+    if (src.peek_space_at_least(1)) {
+      src.advance(1);
+    }
 
-  // If first preamble item is a space, skip it
-  if (src.peek_space_at_least(1)) {
-    src.advance(1);
-  }
+    // Look for sync pulse, after. If sucessful index points to space of sync symbol
+    while (src.size() - src.get_index() >= NDATABITS) {
+      ESP_LOGVV(TAG, "Decode Drayton: sync search %d, %" PRId32 " %" PRId32", src.size() - src.get_index(), src.peek(), src.peek(1));
+      if (src.peek_mark(2 * BIT_TIME_US) &&
+          (src.peek_space(2 * BIT_TIME_US, 1) || src.peek_space(3 * BIT_TIME_US, 1))) {
+        src.advance(1);
+        ESP_LOGVV(TAG, "Decode Drayton: Found SYNC, - %d", src.get_index());
+        break;
+      } else {
+        src.advance(2);
+      }
+    }
 
-  // Look for sync pulse, after. If sucessful index points to space of sync symbol
-  for (uint16_t preamble = 0; preamble <= NBITS_PREAMBLE * 2; preamble += 2) {
-    ESP_LOGVV(TAG, "Decode Drayton: preamble %d  %" PRId32 " %" PRId32, preamble, src.peek(preamble),
-              src.peek(preamble + 1));
-    if (src.peek_mark(2 * BIT_TIME_US, preamble) &&
-        (src.peek_space(2 * BIT_TIME_US, preamble + 1) || src.peek_space(3 * BIT_TIME_US, preamble + 1))) {
-      src.advance(preamble + 1);
+    // No point continuing if not enough samples remaining to complete a packet
+    if (src.size() - src.get_index() < NDATABITS) {
+      ESP_LOGV(TAG, "Decode Drayton: Fail 1, - %" PRIu32, src.get_index());
       break;
     }
-  }
 
-  // Read data. Index points to space of sync symbol
-  // Extract first bit
-  // Checks next bit to leave index pointing correctly
-  uint32_t out_data = 0;
-  uint8_t bit = NBITS_ADDRESS + NBITS_COMMAND + NBITS_CHANNEL - 1;
-  if (src.expect_space(3 * BIT_TIME_US) && (src.expect_mark(BIT_TIME_US) || src.peek_mark(2 * BIT_TIME_US))) {
-    out_data |= 0 << bit;
-  } else if (src.expect_space(2 * BIT_TIME_US) && src.expect_mark(BIT_TIME_US) &&
-             (src.expect_space(BIT_TIME_US) || src.peek_space(2 * BIT_TIME_US))) {
-    out_data |= 1 << bit;
-  } else {
-    ESP_LOGV(TAG, "Decode Drayton: Fail 1, - %" PRIu32, src.get_index());
-    return {};
-  }
-
-  // Before/after each bit is read the index points to the transition at the start of the bit period or,
-  // if there is no transition at the start of the bit period, then the transition in the middle of
-  // the previous bit period.
-  while (--bit >= 1) {
-    ESP_LOGVV(TAG, "Decode Drayton: Data, %2d %08" PRIx32, bit, out_data);
-    if ((src.expect_space(BIT_TIME_US) || src.expect_space(2 * BIT_TIME_US)) &&
-        (src.expect_mark(BIT_TIME_US) || src.peek_mark(2 * BIT_TIME_US))) {
+    // Read data. Index points to space of sync symbol
+    // Extract first bit
+    // Checks next bit to leave index pointing correctly
+    uint32_t out_data = 0;
+    uint8_t bit = NDATABITS - 1;
+    ESP_LOGVV(TAG, "Decode Drayton: first bit %d  %" PRId32 ", %" PRDd32, src.peek(0), src.peek(1), src.peek(2));
+    if (src.expect_space(3 * BIT_TIME_US) && (src.expect_mark(BIT_TIME_US) || src.peek_mark(2 * BIT_TIME_US))) {
       out_data |= 0 << bit;
-    } else if ((src.expect_mark(BIT_TIME_US) || src.expect_mark(2 * BIT_TIME_US)) &&
+    } else if (src.expect_space(2 * BIT_TIME_US) && src.expect_mark(BIT_TIME_US) &&
                (src.expect_space(BIT_TIME_US) || src.peek_space(2 * BIT_TIME_US))) {
       out_data |= 1 << bit;
     } else {
-      ESP_LOGVV(TAG, "Decode Drayton: Fail 2, %2d %08" PRIx32, bit, out_data);
-      return {};
+      ESP_LOGV(TAG, "Decode Drayton: Fail 2, - %d %d %d", src.peek(-1), src.peek(0), src.peek(1));
+      continue;
     }
-  }
-  if (src.expect_space(BIT_TIME_US) || src.expect_space(2 * BIT_TIME_US)) {
-    out_data |= 0;
-  } else if (src.expect_mark(BIT_TIME_US) || src.expect_mark(2 * BIT_TIME_US)) {
-    out_data |= 1;
-  }
-  ESP_LOGV(TAG, "Decode Drayton: Data, %2d %08" PRIx32, bit, out_data);
 
-  out.channel = (uint8_t) (out_data & 0x1F);
-  out_data >>= NBITS_CHANNEL;
-  out.command = (uint8_t) (out_data & 0x7F);
-  out_data >>= NBITS_COMMAND;
-  out.address = (uint16_t) (out_data & 0xFFFF);
+    // Before/after each bit is read the index points to the transition at the start of the bit period or,
+    // if there is no transition at the start of the bit period, then the transition in the middle of
+    // the previous bit period.
+    while (--bit >= 1) {
+      ESP_LOGVV(TAG, "Decode Drayton: Data, %2d %08" PRIx32, bit, out_data);
+      if ((src.expect_space(BIT_TIME_US) || src.expect_space(2 * BIT_TIME_US)) &&
+          (src.expect_mark(BIT_TIME_US) || src.peek_mark(2 * BIT_TIME_US))) {
+        out_data |= 0 << bit;
+      } else if ((src.expect_mark(BIT_TIME_US) || src.expect_mark(2 * BIT_TIME_US)) &&
+                 (src.expect_space(BIT_TIME_US) || src.peek_space(2 * BIT_TIME_US))) {
+        out_data |= 1 << bit;
+      } else {
+        break;
+      }
+    }
 
-  return out;
+    if (bit > 0) {
+      ESP_LOGVV(TAG, "Decode Drayton: Fail 3, %d %" PRId32 " %" PRId32, src.peek(-1), src.peek(0), src.peek(1));
+      continue;
+    }
+
+    if (src.expect_space(BIT_TIME_US) || src.expect_space(2 * BIT_TIME_US)) {
+      out_data |= 0;
+    } else if (src.expect_mark(BIT_TIME_US) || src.expect_mark(2 * BIT_TIME_US)) {
+      out_data |= 1;
+    } else {
+      continue;
+    }
+
+    ESP_LOGV(TAG, "Decode Drayton: Data, %2d %08x", bit, out_data);
+
+    out.channel = (uint8_t) (out_data & 0x1F);
+    out_data >>= NBITS_CHANNEL;
+    out.command = (uint8_t) (out_data & 0x7F);
+    out_data >>= NBITS_COMMAND;
+    out.address = (uint16_t) (out_data & 0xFFFF);
+
+    return out;
+  }
+  return {};
 }
 void DraytonProtocol::dump(const DraytonData &data) {
   ESP_LOGI(TAG, "Received Drayton: address=0x%04X (0x%04x), channel=0x%03x command=0x%03X", data.address,


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->
Drayton RF packets are sometimes not received in noisy RF environments. Scanning of the buffer stops if a protocol error is detected, ignoring the remainder of the buffer and potentially missing a valid packet. This change improves the packet detection by scanning through all of the data in the buffer until either a valid packet is found or the end of the buffer is reached.

No changes to user exposed functionality.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**  N/A

## Test Environment

- [ ] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
binary_sensor:
  - platform: remote_receiver
    name: Drayton On
    drayton:
      address: 0x6180
      channel: 0x12
      command: 0x41
    on_press:
      then:
        - switch.turn_on: switch_relay_1
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
