### PR TITLE
Don't allow entity category "CONFIG" for sensors

### DIFF
--- a/esphome/components/sensor/__init__.py
+++ b/esphome/components/sensor/__init__.py
@@ -190,9 +190,7 @@ def validate_datapoint(value):
 
 
 _SENSOR_ENTITY_CATEGORIES = {
-    k: v
-    for k, v in cv.ENTITY_CATEGORIES.items()
-    if k != ENTITY_CATEGORY_CONFIG
+    k: v for k, v in cv.ENTITY_CATEGORIES.items() if k != ENTITY_CATEGORY_CONFIG
 }
 
 

--- a/esphome/components/sensor/__init__.py
+++ b/esphome/components/sensor/__init__.py
@@ -85,6 +85,7 @@ from esphome.const import (
     DEVICE_CLASS_WATER,
     DEVICE_CLASS_WEIGHT,
     DEVICE_CLASS_WIND_SPEED,
+    ENTITY_CATEGORY_CONFIG,
 )
 from esphome.core import CORE, coroutine_with_priority
 from esphome.cpp_generator import MockObjClass
@@ -188,6 +189,15 @@ def validate_datapoint(value):
     return validate_datapoint({CONF_FROM: cv.float_(a), CONF_TO: cv.float_(b)})
 
 
+_SENSOR_ENTITY_CATEGORIES = {
+    k: v for k, v in cv._ENTITY_CATEGORIES.items() if k != ENTITY_CATEGORY_CONFIG
+}
+
+
+def sensor_entity_category(value):
+    return cv.enum(_SENSOR_ENTITY_CATEGORIES, lower=True)(value)
+
+
 # Base
 Sensor = sensor_ns.class_("Sensor", cg.EntityBase)
 SensorPtr = Sensor.operator("ptr")
@@ -246,6 +256,7 @@ SENSOR_SCHEMA = cv.ENTITY_BASE_SCHEMA.extend(cv.MQTT_COMPONENT_SCHEMA).extend(
         cv.Optional(CONF_ACCURACY_DECIMALS): validate_accuracy_decimals,
         cv.Optional(CONF_DEVICE_CLASS): validate_device_class,
         cv.Optional(CONF_STATE_CLASS): validate_state_class,
+        cv.Optional(CONF_ENTITY_CATEGORY): sensor_entity_category,
         cv.Optional("last_reset_type"): cv.invalid(
             "last_reset_type has been removed since 2021.9.0. state_class: total_increasing should be used for total values."
         ),
@@ -301,7 +312,7 @@ def sensor_schema(
         (CONF_ACCURACY_DECIMALS, accuracy_decimals, validate_accuracy_decimals),
         (CONF_DEVICE_CLASS, device_class, validate_device_class),
         (CONF_STATE_CLASS, state_class, validate_state_class),
-        (CONF_ENTITY_CATEGORY, entity_category, cv.entity_category),
+        (CONF_ENTITY_CATEGORY, entity_category, sensor_entity_category),
     ]:
         if default is not _UNDEF:
             schema[cv.Optional(key, default=default)] = validator

--- a/esphome/components/sensor/__init__.py
+++ b/esphome/components/sensor/__init__.py
@@ -191,7 +191,7 @@ def validate_datapoint(value):
 
 _SENSOR_ENTITY_CATEGORIES = {
     k: v
-    for k, v in cv._ENTITY_CATEGORIES.items()  # pylint: disable=protected-access
+    for k, v in cv.ENTITY_CATEGORIES.items()  # pylint: disable=protected-access
     if k != ENTITY_CATEGORY_CONFIG
 }
 

--- a/esphome/components/sensor/__init__.py
+++ b/esphome/components/sensor/__init__.py
@@ -191,7 +191,7 @@ def validate_datapoint(value):
 
 _SENSOR_ENTITY_CATEGORIES = {
     k: v
-    for k, v in cv.ENTITY_CATEGORIES.items()  # pylint: disable=protected-access
+    for k, v in cv.ENTITY_CATEGORIES.items()
     if k != ENTITY_CATEGORY_CONFIG
 }
 

--- a/esphome/components/sensor/__init__.py
+++ b/esphome/components/sensor/__init__.py
@@ -190,7 +190,9 @@ def validate_datapoint(value):
 
 
 _SENSOR_ENTITY_CATEGORIES = {
-    k: v for k, v in cv._ENTITY_CATEGORIES.items() if k != ENTITY_CATEGORY_CONFIG
+    k: v
+    for k, v in cv._ENTITY_CATEGORIES.items()  # pylint: disable=protected-access
+    if k != ENTITY_CATEGORY_CONFIG
 }
 
 

--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -1669,7 +1669,7 @@ def maybe_simple_value(*validators, **kwargs):
     return validate
 
 
-_ENTITY_CATEGORIES = {
+ENTITY_CATEGORIES = {
     ENTITY_CATEGORY_NONE: cg.EntityCategory.ENTITY_CATEGORY_NONE,
     ENTITY_CATEGORY_CONFIG: cg.EntityCategory.ENTITY_CATEGORY_CONFIG,
     ENTITY_CATEGORY_DIAGNOSTIC: cg.EntityCategory.ENTITY_CATEGORY_DIAGNOSTIC,
@@ -1677,7 +1677,7 @@ _ENTITY_CATEGORIES = {
 
 
 def entity_category(value):
-    return enum(_ENTITY_CATEGORIES, lower=True)(value)
+    return enum(ENTITY_CATEGORIES, lower=True)(value)
 
 
 MQTT_COMPONENT_AVAILABILITY_SCHEMA = Schema(


### PR DESCRIPTION
# What does this implement/fix?

The configuration category "config" is for read/write entities that control things. A sensor can never control things (and thus the change triggering because of this change are incorrect to begin with).
See https://github.com/home-assistant/core/pull/101471

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
