### PR TITLE
Deep sleep is only available on esp32 and esp8266

### DIFF
--- a/esphome/components/deep_sleep/__init__.py
+++ b/esphome/components/deep_sleep/__init__.py
@@ -198,7 +198,7 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_TOUCH_WAKEUP): cv.All(cv.only_on_esp32, cv.boolean),
         }
     ).extend(cv.COMPONENT_SCHEMA),
-    cv.only_on(PLATFORM_ESP32, PLATFORM_ESP8266),
+    cv.only_on([PLATFORM_ESP32, PLATFORM_ESP8266]),
 )
 
 

--- a/esphome/components/deep_sleep/__init__.py
+++ b/esphome/components/deep_sleep/__init__.py
@@ -14,6 +14,8 @@ from esphome.const import (
     CONF_SLEEP_DURATION,
     CONF_TIME_ID,
     CONF_WAKEUP_PIN,
+    PLATFORM_ESP32,
+    PLATFORM_ESP8266,
 )
 
 from esphome.components.esp32 import get_esp32_variant
@@ -165,34 +167,39 @@ WAKEUP_CAUSES_SCHEMA = cv.Schema(
     }
 )
 
-CONFIG_SCHEMA = cv.Schema(
-    {
-        cv.GenerateID(): cv.declare_id(DeepSleepComponent),
-        cv.Optional(CONF_RUN_DURATION): cv.Any(
-            cv.All(cv.only_on_esp32, WAKEUP_CAUSES_SCHEMA),
-            cv.positive_time_period_milliseconds,
-        ),
-        cv.Optional(CONF_SLEEP_DURATION): cv.positive_time_period_milliseconds,
-        cv.Optional(CONF_WAKEUP_PIN): cv.All(
-            cv.only_on_esp32, pins.internal_gpio_input_pin_schema, validate_pin_number
-        ),
-        cv.Optional(CONF_WAKEUP_PIN_MODE): cv.All(
-            cv.only_on_esp32, cv.enum(WAKEUP_PIN_MODES), upper=True
-        ),
-        cv.Optional(CONF_ESP32_EXT1_WAKEUP): cv.All(
-            cv.only_on_esp32,
-            cv.Schema(
-                {
-                    cv.Required(CONF_PINS): cv.ensure_list(
-                        pins.internal_gpio_input_pin_schema, validate_pin_number
-                    ),
-                    cv.Required(CONF_MODE): cv.enum(EXT1_WAKEUP_MODES, upper=True),
-                }
+CONFIG_SCHEMA = cv.All(
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.declare_id(DeepSleepComponent),
+            cv.Optional(CONF_RUN_DURATION): cv.Any(
+                cv.All(cv.only_on_esp32, WAKEUP_CAUSES_SCHEMA),
+                cv.positive_time_period_milliseconds,
             ),
-        ),
-        cv.Optional(CONF_TOUCH_WAKEUP): cv.All(cv.only_on_esp32, cv.boolean),
-    }
-).extend(cv.COMPONENT_SCHEMA)
+            cv.Optional(CONF_SLEEP_DURATION): cv.positive_time_period_milliseconds,
+            cv.Optional(CONF_WAKEUP_PIN): cv.All(
+                cv.only_on_esp32,
+                pins.internal_gpio_input_pin_schema,
+                validate_pin_number,
+            ),
+            cv.Optional(CONF_WAKEUP_PIN_MODE): cv.All(
+                cv.only_on_esp32, cv.enum(WAKEUP_PIN_MODES), upper=True
+            ),
+            cv.Optional(CONF_ESP32_EXT1_WAKEUP): cv.All(
+                cv.only_on_esp32,
+                cv.Schema(
+                    {
+                        cv.Required(CONF_PINS): cv.ensure_list(
+                            pins.internal_gpio_input_pin_schema, validate_pin_number
+                        ),
+                        cv.Required(CONF_MODE): cv.enum(EXT1_WAKEUP_MODES, upper=True),
+                    }
+                ),
+            ),
+            cv.Optional(CONF_TOUCH_WAKEUP): cv.All(cv.only_on_esp32, cv.boolean),
+        }
+    ).extend(cv.COMPONENT_SCHEMA),
+    cv.only_on(PLATFORM_ESP32, PLATFORM_ESP8266),
+)
 
 
 async def to_code(config):


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->
Deep sleep is only available on esp32 and esp8266 so we can validate this and disallow it to be in YAML. Right now it successfuly compile, but when it comes time to sleep, it does nothing as its not implemented.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
