### PR TITLE
Use platform consts

### DIFF
--- a/esphome/components/async_tcp/__init__.py
+++ b/esphome/components/async_tcp/__init__.py
@@ -2,13 +2,19 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.core import CORE, coroutine_with_priority
+from esphome.const import (
+    PLATFORM_ESP32,
+    PLATFORM_ESP8266,
+    PLATFORM_BK72XX,
+    PLATFORM_RTL87XX,
+)
 
 CODEOWNERS = ["@OttoWinter"]
 
 CONFIG_SCHEMA = cv.All(
     cv.Schema({}),
     cv.only_with_arduino,
-    cv.only_on(["esp32", "esp8266", "bk72xx", "rtl87xx"]),
+    cv.only_on([PLATFORM_ESP32, PLATFORM_ESP8266, PLATFORM_BK72XX, PLATFORM_RTL87XX]),
 )
 
 

--- a/esphome/components/captive_portal/__init__.py
+++ b/esphome/components/captive_portal/__init__.py
@@ -2,7 +2,13 @@ import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import web_server_base
 from esphome.components.web_server_base import CONF_WEB_SERVER_BASE_ID
-from esphome.const import CONF_ID
+from esphome.const import (
+    CONF_ID,
+    PLATFORM_ESP32,
+    PLATFORM_ESP8266,
+    PLATFORM_BK72XX,
+    PLATFORM_RTL87XX,
+)
 from esphome.core import coroutine_with_priority, CORE
 
 AUTO_LOAD = ["web_server_base"]
@@ -21,7 +27,7 @@ CONFIG_SCHEMA = cv.All(
             ),
         }
     ).extend(cv.COMPONENT_SCHEMA),
-    cv.only_on(["esp32", "esp8266", "bk72xx", "rtl87xx"]),
+    cv.only_on([PLATFORM_ESP32, PLATFORM_ESP8266, PLATFORM_BK72XX, PLATFORM_RTL87XX]),
 )
 
 

--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -25,6 +25,7 @@ from esphome.const import (
     KEY_NAME,
     KEY_TARGET_FRAMEWORK,
     KEY_TARGET_PLATFORM,
+    PLATFORM_ESP32,
     TYPE_GIT,
     TYPE_LOCAL,
     __version__,
@@ -62,7 +63,7 @@ AUTO_LOAD = ["preferences"]
 
 def set_core_data(config):
     CORE.data[KEY_ESP32] = {}
-    CORE.data[KEY_CORE][KEY_TARGET_PLATFORM] = "esp32"
+    CORE.data[KEY_CORE][KEY_TARGET_PLATFORM] = PLATFORM_ESP32
     conf = config[CONF_FRAMEWORK]
     if conf[CONF_TYPE] == FRAMEWORK_ESP_IDF:
         CORE.data[KEY_CORE][KEY_TARGET_FRAMEWORK] = "esp-idf"

--- a/esphome/components/esp8266/__init__.py
+++ b/esphome/components/esp8266/__init__.py
@@ -11,6 +11,7 @@ from esphome.const import (
     KEY_FRAMEWORK_VERSION,
     KEY_TARGET_FRAMEWORK,
     KEY_TARGET_PLATFORM,
+    PLATFORM_ESP8266,
 )
 from esphome.core import CORE, coroutine_with_priority
 import esphome.config_validation as cv
@@ -38,7 +39,7 @@ AUTO_LOAD = ["preferences"]
 
 def set_core_data(config):
     CORE.data[KEY_ESP8266] = {}
-    CORE.data[KEY_CORE][KEY_TARGET_PLATFORM] = "esp8266"
+    CORE.data[KEY_CORE][KEY_TARGET_PLATFORM] = PLATFORM_ESP8266
     CORE.data[KEY_CORE][KEY_TARGET_FRAMEWORK] = "arduino"
     CORE.data[KEY_CORE][KEY_FRAMEWORK_VERSION] = cv.Version.parse(
         config[CONF_FRAMEWORK][CONF_VERSION]

--- a/esphome/components/host/__init__.py
+++ b/esphome/components/host/__init__.py
@@ -3,6 +3,7 @@ from esphome.const import (
     KEY_FRAMEWORK_VERSION,
     KEY_TARGET_FRAMEWORK,
     KEY_TARGET_PLATFORM,
+    PLATFORM_HOST,
 )
 from esphome.core import CORE
 import esphome.config_validation as cv
@@ -20,7 +21,7 @@ AUTO_LOAD = ["network"]
 
 def set_core_data(config):
     CORE.data[KEY_HOST] = {}
-    CORE.data[KEY_CORE][KEY_TARGET_PLATFORM] = "host"
+    CORE.data[KEY_CORE][KEY_TARGET_PLATFORM] = PLATFORM_HOST
     CORE.data[KEY_CORE][KEY_TARGET_FRAMEWORK] = "host"
     CORE.data[KEY_CORE][KEY_FRAMEWORK_VERSION] = cv.Version(1, 0, 0)
     return config

--- a/esphome/components/i2c/__init__.py
+++ b/esphome/components/i2c/__init__.py
@@ -12,6 +12,9 @@ from esphome.const import (
     CONF_SDA,
     CONF_ADDRESS,
     CONF_I2C_ID,
+    PLATFORM_ESP32,
+    PLATFORM_ESP8266,
+    PLATFORM_RP2040,
 )
 from esphome.core import coroutine_with_priority, CORE
 
@@ -60,7 +63,7 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_SCAN, default=True): cv.boolean,
         }
     ).extend(cv.COMPONENT_SCHEMA),
-    cv.only_on(["esp32", "esp8266", "rp2040"]),
+    cv.only_on([PLATFORM_ESP32, PLATFORM_ESP8266, PLATFORM_RP2040]),
 )
 
 

--- a/esphome/components/internal_temperature/sensor.py
+++ b/esphome/components/internal_temperature/sensor.py
@@ -12,6 +12,8 @@ from esphome.const import (
     ENTITY_CATEGORY_DIAGNOSTIC,
     KEY_CORE,
     KEY_FRAMEWORK_VERSION,
+    PLATFORM_ESP32,
+    PLATFORM_RP2040,
 )
 from esphome.core import CORE
 
@@ -49,7 +51,7 @@ CONFIG_SCHEMA = cv.All(
         state_class=STATE_CLASS_MEASUREMENT,
         entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
     ).extend(cv.polling_component_schema("60s")),
-    cv.only_on(["esp32", "rp2040"]),
+    cv.only_on([PLATFORM_ESP32, PLATFORM_RP2040]),
     validate_config,
 )
 

--- a/esphome/components/mqtt/__init__.py
+++ b/esphome/components/mqtt/__init__.py
@@ -43,6 +43,9 @@ from esphome.const import (
     CONF_USE_ABBREVIATIONS,
     CONF_USERNAME,
     CONF_WILL_MESSAGE,
+    PLATFORM_ESP32,
+    PLATFORM_ESP8266,
+    PLATFORM_BK72XX,
 )
 from esphome.core import coroutine_with_priority, CORE
 from esphome.components.esp32 import add_idf_sdkconfig_option
@@ -250,7 +253,7 @@ CONFIG_SCHEMA = cv.All(
         }
     ),
     validate_config,
-    cv.only_on(["esp32", "esp8266", "bk72xx"]),
+    cv.only_on([PLATFORM_ESP32, PLATFORM_ESP8266, PLATFORM_BK72XX]),
 )
 
 

--- a/esphome/components/rp2040/__init__.py
+++ b/esphome/components/rp2040/__init__.py
@@ -14,6 +14,7 @@ from esphome.const import (
     KEY_FRAMEWORK_VERSION,
     KEY_TARGET_FRAMEWORK,
     KEY_TARGET_PLATFORM,
+    PLATFORM_RP2040,
 )
 from esphome.core import CORE, coroutine_with_priority, EsphomeError
 from esphome.helpers import mkdir_p, write_file, copy_file_if_changed
@@ -30,7 +31,7 @@ AUTO_LOAD = []
 
 def set_core_data(config):
     CORE.data[KEY_RP2040] = {}
-    CORE.data[KEY_CORE][KEY_TARGET_PLATFORM] = "rp2040"
+    CORE.data[KEY_CORE][KEY_TARGET_PLATFORM] = PLATFORM_RP2040
     CORE.data[KEY_CORE][KEY_TARGET_FRAMEWORK] = "arduino"
     CORE.data[KEY_CORE][KEY_FRAMEWORK_VERSION] = cv.Version.parse(
         config[CONF_FRAMEWORK][CONF_VERSION]

--- a/esphome/components/spi/__init__.py
+++ b/esphome/components/spi/__init__.py
@@ -26,6 +26,9 @@ from esphome.const import (
     KEY_TARGET_PLATFORM,
     KEY_VARIANT,
     CONF_DATA_RATE,
+    PLATFORM_ESP32,
+    PLATFORM_ESP8266,
+    PLATFORM_RP2040,
 )
 from esphome.core import coroutine_with_priority, CORE
 
@@ -102,9 +105,9 @@ def get_target_variant():
 # The returned value is a list of lists of names
 def get_hw_interface_list():
     target_platform = get_target_platform()
-    if target_platform == "esp8266":
+    if target_platform == PLATFORM_ESP8266:
         return [["spi", "hspi"]]
-    if target_platform == "esp32":
+    if target_platform == PLATFORM_ESP32:
         if get_target_variant() in [
             VARIANT_ESP32C2,
             VARIANT_ESP32C3,
@@ -113,7 +116,7 @@ def get_hw_interface_list():
         ]:
             return [["spi", "spi2"]]
         return [["spi", "spi2"], ["spi3"]]
-    if target_platform == "rp2040":
+    if target_platform == PLATFORM_RP2040:
         return [["spi"], ["spi1"]]
     return []
 
@@ -150,17 +153,17 @@ def validate_hw_pins(spi, index=-1):
         sdi_pin_no = sdi_pin[CONF_NUMBER]
 
     target_platform = get_target_platform()
-    if target_platform == "esp8266":
+    if target_platform == PLATFORM_ESP8266:
         if clk_pin_no == 6:
             return sdo_pin_no in (-1, 8) and sdi_pin_no in (-1, 7)
         if clk_pin_no == 14:
             return sdo_pin_no in (-1, 13) and sdi_pin_no in (-1, 12)
         return False
 
-    if target_platform == "esp32":
+    if target_platform == PLATFORM_ESP32:
         return clk_pin_no >= 0
 
-    if target_platform == "rp2040":
+    if target_platform == PLATFORM_RP2040:
         pin_set = (
             list(filter(lambda s: clk_pin_no in s[CONF_CLK_PIN], RP_SPI_PINSETS))[0]
             if index == -1
@@ -236,7 +239,7 @@ def get_spi_interface(index):
         return ["SPI2_HOST", "SPI3_HOST"][index]
     # Arduino code follows
     platform = get_target_platform()
-    if platform == "rp2040":
+    if platform == PLATFORM_RP2040:
         return ["&SPI", "&SPI1"][index]
     if index == 0:
         return "&SPI"
@@ -261,7 +264,7 @@ SPI_SCHEMA = cv.All(
         }
     ),
     cv.has_at_least_one_key(CONF_MISO_PIN, CONF_MOSI_PIN),
-    cv.only_on(["esp32", "esp8266", "rp2040"]),
+    cv.only_on([PLATFORM_ESP32, PLATFORM_ESP8266, PLATFORM_RP2040]),
 )
 
 CONFIG_SCHEMA = cv.All(

--- a/esphome/components/web_server/__init__.py
+++ b/esphome/components/web_server/__init__.py
@@ -18,6 +18,10 @@ from esphome.const import (
     CONF_LOG,
     CONF_VERSION,
     CONF_LOCAL,
+    PLATFORM_ESP32,
+    PLATFORM_ESP8266,
+    PLATFORM_BK72XX,
+    PLATFORM_RTL87XX,
 )
 from esphome.core import CORE, coroutine_with_priority
 
@@ -90,7 +94,7 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_LOCAL): cv.boolean,
         }
     ).extend(cv.COMPONENT_SCHEMA),
-    cv.only_on(["esp32", "esp8266", "bk72xx", "rtl87xx"]),
+    cv.only_on([PLATFORM_ESP32, PLATFORM_ESP8266, PLATFORM_BK72XX, PLATFORM_RTL87XX]),
     default_url,
     validate_local,
     validate_ota,

--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -51,6 +51,9 @@ from esphome.const import (
     KEY_FRAMEWORK_VERSION,
     KEY_TARGET_FRAMEWORK,
     KEY_TARGET_PLATFORM,
+    PLATFORM_ESP32,
+    PLATFORM_ESP8266,
+    PLATFORM_RP2040,
     TYPE_GIT,
     TYPE_LOCAL,
     VALID_SUBSTITUTIONS_CHARACTERS,
@@ -583,9 +586,9 @@ def only_with_framework(frameworks):
     return validator_
 
 
-only_on_esp32 = only_on("esp32")
-only_on_esp8266 = only_on("esp8266")
-only_on_rp2040 = only_on("rp2040")
+only_on_esp32 = only_on(PLATFORM_ESP32)
+only_on_esp8266 = only_on(PLATFORM_ESP8266)
+only_on_rp2040 = only_on(PLATFORM_RP2040)
 only_with_arduino = only_with_framework("arduino")
 only_with_esp_idf = only_with_framework("esp-idf")
 

--- a/esphome/core/__init__.py
+++ b/esphome/core/__init__.py
@@ -15,6 +15,12 @@ from esphome.const import (
     KEY_CORE,
     KEY_TARGET_FRAMEWORK,
     KEY_TARGET_PLATFORM,
+    PLATFORM_ESP32,
+    PLATFORM_ESP8266,
+    PLATFORM_BK72XX,
+    PLATFORM_RTL87XX,
+    PLATFORM_RP2040,
+    PLATFORM_HOST,
 )
 from esphome.coroutine import FakeAwaitable as _FakeAwaitable
 from esphome.coroutine import FakeEventLoop as _FakeEventLoop
@@ -598,23 +604,23 @@ class EsphomeCore:
 
     @property
     def is_esp8266(self):
-        return self.target_platform == "esp8266"
+        return self.target_platform == PLATFORM_ESP8266
 
     @property
     def is_esp32(self):
-        return self.target_platform == "esp32"
+        return self.target_platform == PLATFORM_ESP32
 
     @property
     def is_rp2040(self):
-        return self.target_platform == "rp2040"
+        return self.target_platform == PLATFORM_RP2040
 
     @property
     def is_bk72xx(self):
-        return self.target_platform == "bk72xx"
+        return self.target_platform == PLATFORM_BK72XX
 
     @property
     def is_rtl87xx(self):
-        return self.target_platform == "rtl87xx"
+        return self.target_platform == PLATFORM_RTL87XX
 
     @property
     def is_libretiny(self):
@@ -622,7 +628,7 @@ class EsphomeCore:
 
     @property
     def is_host(self):
-        return self.target_platform == "host"
+        return self.target_platform == PLATFORM_HOST
 
     @property
     def target_framework(self):

--- a/esphome/dashboard/dashboard.py
+++ b/esphome/dashboard/dashboard.py
@@ -838,17 +838,17 @@ class BoardsRequestHandler(BaseHandler):
         from esphome.components.rtl87xx.boards import BOARDS as RTL87XX_BOARDS
 
         platform_to_boards = {
-            "esp32": ESP32_BOARDS,
-            "esp8266": ESP8266_BOARDS,
-            "rp2040": RP2040_BOARDS,
-            "bk72xx": BK72XX_BOARDS,
-            "rtl87xx": RTL87XX_BOARDS,
+            const.PLATFORM_ESP32: ESP32_BOARDS,
+            const.PLATFORM_ESP8266: ESP8266_BOARDS,
+            const.PLATFORM_RP2040: RP2040_BOARDS,
+            const.PLATFORM_BK72XX: BK72XX_BOARDS,
+            const.PLATFORM_RTL87XX: RTL87XX_BOARDS,
         }
         # filter all ESP32 variants by requested platform
         if platform.startswith("esp32"):
             boards = {
                 k: v
-                for k, v in platform_to_boards["esp32"].items()
+                for k, v in platform_to_boards[const.PLATFORM_ESP32].items()
                 if v[const.KEY_VARIANT] == platform.upper()
             }
         else:


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Just a minor PR to tidy up the use of the platform names as consts instead of strings everywhere.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
