### PR TITLE
Small fixes for voice assistant

### DIFF
--- a/esphome/components/i2s_audio/speaker/i2s_audio_speaker.cpp
+++ b/esphome/components/i2s_audio/speaker/i2s_audio_speaker.cpp
@@ -11,7 +11,7 @@
 namespace esphome {
 namespace i2s_audio {
 
-static const size_t BUFFER_COUNT = 10;
+static const size_t BUFFER_COUNT = 20;
 
 static const char *const TAG = "i2s_audio.speaker";
 
@@ -19,7 +19,7 @@ void I2SAudioSpeaker::setup() {
   ESP_LOGCONFIG(TAG, "Setting up I2S Audio Speaker...");
 
   this->buffer_queue_ = xQueueCreate(BUFFER_COUNT, sizeof(DataEvent));
-  this->event_queue_ = xQueueCreate(20, sizeof(TaskEvent));
+  this->event_queue_ = xQueueCreate(BUFFER_COUNT, sizeof(TaskEvent));
 }
 
 void I2SAudioSpeaker::start() { this->state_ = speaker::STATE_STARTING; }
@@ -47,7 +47,7 @@ void I2SAudioSpeaker::player_task(void *params) {
       .communication_format = I2S_COMM_FORMAT_STAND_I2S,
       .intr_alloc_flags = ESP_INTR_FLAG_LEVEL1,
       .dma_buf_count = 8,
-      .dma_buf_len = 1024,
+      .dma_buf_len = 128,
       .use_apll = false,
       .tx_desc_auto_clear = true,
       .fixed_mclk = I2S_PIN_NO_CHANGE,
@@ -60,7 +60,17 @@ void I2SAudioSpeaker::player_task(void *params) {
   }
 #endif
 
-  i2s_driver_install(this_speaker->parent_->get_port(), &config, 0, nullptr);
+  esp_err_t err = i2s_driver_install(this_speaker->parent_->get_port(), &config, 0, nullptr);
+  if (err != ESP_OK) {
+    event.type = TaskEventType::WARNING;
+    event.err = err;
+    xQueueSend(this_speaker->event_queue_, &event, 0);
+    event.type = TaskEventType::STOPPED;
+    xQueueSend(this_speaker->event_queue_, &event, 0);
+    while (true) {
+      delay(10);
+    }
+  }
 
 #if SOC_I2S_SUPPORTS_DAC
   if (this_speaker->internal_dac_mode_ == I2S_DAC_CHANNEL_DISABLE) {
@@ -88,9 +98,7 @@ void I2SAudioSpeaker::player_task(void *params) {
     }
     if (data_event.stop) {
       // Stop signal from main thread
-      while (xQueueReceive(this_speaker->buffer_queue_, &data_event, 0) == pdTRUE) {
-        // Flush queue
-      }
+      xQueueReset(this_speaker->buffer_queue_);  // Flush queue
       break;
     }
     size_t bytes_written;
@@ -103,7 +111,7 @@ void I2SAudioSpeaker::player_task(void *params) {
       uint32_t sample = (buffer[current] << 16) | (buffer[current] & 0xFFFF);
 
       esp_err_t err = i2s_write(this_speaker->parent_->get_port(), &sample, sizeof(sample), &bytes_written,
-                                (100 / portTICK_PERIOD_MS));
+                                (10 / portTICK_PERIOD_MS));
       if (err != ESP_OK) {
         event = {.type = TaskEventType::WARNING, .err = err};
         xQueueSend(this_speaker->event_queue_, &event, portMAX_DELAY);
@@ -122,7 +130,6 @@ void I2SAudioSpeaker::player_task(void *params) {
   event.type = TaskEventType::STOPPING;
   xQueueSend(this_speaker->event_queue_, &event, portMAX_DELAY);
 
-  i2s_stop(this_speaker->parent_->get_port());
   i2s_driver_uninstall(this_speaker->parent_->get_port());
 
   event.type = TaskEventType::STOPPED;
@@ -162,6 +169,7 @@ void I2SAudioSpeaker::watch_() {
         vTaskDelete(this->player_task_handle_);
         this->player_task_handle_ = nullptr;
         this->parent_->unlock();
+        xQueueReset(this->buffer_queue_);
         break;
       case TaskEventType::WARNING:
         ESP_LOGW(TAG, "Error writing to I2S: %s", esp_err_to_name(event.err));

--- a/esphome/components/voice_assistant/voice_assistant.cpp
+++ b/esphome/components/voice_assistant/voice_assistant.cpp
@@ -281,7 +281,6 @@ void VoiceAssistant::loop() {
             memmove(this->speaker_buffer_, this->speaker_buffer_ + written, this->speaker_buffer_size_ - written);
             this->speaker_buffer_size_ -= written;
             this->speaker_buffer_index_ -= written;
-            this->last_data_played_at_ = millis();
             this->set_timeout("speaker-timeout", 1000, [this]() { this->speaker_->stop(); });
           } else {
             ESP_LOGW(TAG, "Speaker buffer full.");

--- a/esphome/components/voice_assistant/voice_assistant.cpp
+++ b/esphome/components/voice_assistant/voice_assistant.cpp
@@ -491,8 +491,17 @@ void VoiceAssistant::on_event(const api::VoiceAssistantEventResponse &msg) {
     case api::enums::VOICE_ASSISTANT_RUN_END: {
       ESP_LOGD(TAG, "Assist Pipeline ended");
       if (this->state_ == State::STREAMING_MICROPHONE) {
-        // No need to stop the microphone since we didn't use the speaker
-        this->set_state_(State::WAITING_FOR_VAD, State::WAITING_FOR_VAD);
+#ifdef USE_ESP_ADF
+        if (this->use_wake_word_) {
+          rb_reset(this->ring_buffer_);
+          // No need to stop the microphone since we didn't use the speaker
+          this->set_state_(State::WAIT_FOR_VAD, State::WAITING_FOR_VAD);
+        } else
+#else
+        {
+          this->set_state_(State::IDLE, State::IDLE);
+        }
+#endif
       }
       this->end_trigger_->trigger();
       break;

--- a/esphome/components/voice_assistant/voice_assistant.cpp
+++ b/esphome/components/voice_assistant/voice_assistant.cpp
@@ -497,11 +497,10 @@ void VoiceAssistant::on_event(const api::VoiceAssistantEventResponse &msg) {
           // No need to stop the microphone since we didn't use the speaker
           this->set_state_(State::WAIT_FOR_VAD, State::WAITING_FOR_VAD);
         } else
-#else
+#endif
         {
           this->set_state_(State::IDLE, State::IDLE);
         }
-#endif
       }
       this->end_trigger_->trigger();
       break;


### PR DESCRIPTION
# What does this implement/fix?

- VAD counter is reset to 0 when threshold is crossed
- Playback is aborted when speaker buffer is full (to avoid infinite loop)
- Wake word timeout does not change state (already changed via other events)
- Pipeline end goes back to waiting for VAD instead of stopping/starting microphone (avoid failed starts)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
