### PR TITLE
Set tone with ESP32_audioI2S library's built-in EQ

### DIFF
--- a/esphome/components/i2s_audio/media_player/__init__.py
+++ b/esphome/components/i2s_audio/media_player/__init__.py
@@ -41,6 +41,21 @@ NO_INTERNAL_DAC_VARIANTS = [esp32.const.VARIANT_ESP32S2]
 
 I2C_COMM_FMT_OPTIONS = ["lsb", "msb"]
 
+CONF_TONE = "tone"
+CONF_LO = "lo"
+CONF_MID = "mid"
+CONF_HI = "hi"
+
+AUDIO_EQ_SCHEMA = cv.All(
+    cv.Schema(
+        {
+            cv.Optional(CONF_LO, default=0): cv.float_range(-40, 6),
+            cv.Optional(CONF_MID, default=0): cv.float_range(-40, 6),
+            cv.Optional(CONF_HI, default=0): cv.float_range(-40, 6),
+        }
+    )
+)
+
 
 def validate_esp32_variant(config):
     if config[CONF_DAC_TYPE] != "internal":
@@ -75,6 +90,7 @@ CONFIG_SCHEMA = cv.All(
                     cv.Optional(CONF_I2S_COMM_FMT, default="msb"): cv.one_of(
                         *I2C_COMM_FMT_OPTIONS, lower=True
                     ),
+                    cv.Optional(CONF_TONE): AUDIO_EQ_SCHEMA,
                 }
             ).extend(cv.COMPONENT_SCHEMA),
         },
@@ -101,6 +117,11 @@ async def to_code(config):
             cg.add(var.set_mute_pin(pin))
         cg.add(var.set_external_dac_channels(2 if config[CONF_MODE] == "stereo" else 1))
         cg.add(var.set_i2s_comm_fmt_lsb(config[CONF_I2S_COMM_FMT] == "lsb"))
+
+    if config[CONF_TONE] is not None:
+        cg.add(var.set_eq_lo(config[CONF_TONE][CONF_LO]))
+        cg.add(var.set_eq_mid(config[CONF_TONE][CONF_MID]))
+        cg.add(var.set_eq_hi(config[CONF_TONE][CONF_HI]))
 
     cg.add_library("WiFiClientSecure", None)
     cg.add_library("HTTPClient", None)

--- a/esphome/components/i2s_audio/media_player/i2s_audio_media_player.cpp
+++ b/esphome/components/i2s_audio/media_player/i2s_audio_media_player.cpp
@@ -161,6 +161,7 @@ void I2SAudioMediaPlayer::start_() {
   this->i2s_state_ = I2S_STATE_RUNNING;
   this->high_freq_.start();
   this->audio_->setVolume(remap<uint8_t, float>(this->volume, 0.0f, 1.0f, 0, 21));
+  this->audio_->setTone(this->eq_lo_, this->eq_mid_, this->eq_hi_);
   if (this->current_url_.has_value()) {
     this->audio_->connecttohost(this->current_url_.value().c_str());
     this->state = media_player::MEDIA_PLAYER_STATE_PLAYING;

--- a/esphome/components/i2s_audio/media_player/i2s_audio_media_player.h
+++ b/esphome/components/i2s_audio/media_player/i2s_audio_media_player.h
@@ -41,6 +41,10 @@ class I2SAudioMediaPlayer : public Component, public media_player::MediaPlayer, 
 
   void set_i2s_comm_fmt_lsb(bool lsb) { this->i2s_comm_fmt_lsb_ = lsb; }
 
+  void set_eq_lo(float bias) { this->eq_lo_ = bias; }
+  void set_eq_mid(float bias) { this->eq_mid_ = bias; }
+  void set_eq_hi(float bias) { this->eq_hi_ = bias; }
+
   media_player::MediaPlayerTraits get_traits() override;
 
   bool is_muted() const override { return this->muted_; }
@@ -74,6 +78,10 @@ class I2SAudioMediaPlayer : public Component, public media_player::MediaPlayer, 
   uint8_t external_dac_channels_;
 
   bool i2s_comm_fmt_lsb_;
+
+  float eq_lo_;
+  float eq_mid_;
+  float eq_hi_;
 
   HighFrequencyLoopRequester high_freq_;
 

--- a/tests/test4.yaml
+++ b/tests/test4.yaml
@@ -988,6 +988,10 @@ media_player:
       number: GPIO25
     mute_pin:
       number: GPIO14
+    tone:
+      lo: 6
+      mid: 2
+      hi: -2
     on_state:
       - media_player.play:
       - media_player.play_media: http://localhost/media.mp3


### PR DESCRIPTION
# What does this implement/fix?

ESP32_audioI2S includes functionality to do 3-band equalization, so this adds the configuration and call to set the tone as per the configuration. Helpful for the tinny Raspiaudio Muse Luxe or other small speakers.

Documentation update to come...

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
media_player:
  - platform: i2s_audio
    name: None
    dac_type: external
    i2s_dout_pin: GPIO25
    mute_pin: GPIO14
    tone:
      lo: 6
      mid: 2
      hi: -2
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
