### PR TITLE
Update Improv BLE component

### DIFF
--- a/esphome/components/esp32_ble_server/ble_service.cpp
+++ b/esphome/components/esp32_ble_server/ble_service.cpp
@@ -91,6 +91,7 @@ void BLEService::stop() {
     return;
   }
   esp32_ble::global_ble->get_advertising()->remove_service_uuid(this->uuid_);
+  esp32_ble::global_ble->get_advertising()->start();
   this->running_state_ = STOPPING;
 }
 

--- a/esphome/components/esp32_ble_server/ble_service.cpp
+++ b/esphome/components/esp32_ble_server/ble_service.cpp
@@ -90,6 +90,7 @@ void BLEService::stop() {
     ESP_LOGE(TAG, "esp_ble_gatts_stop_service failed: %d", err);
     return;
   }
+  esp32_ble::global_ble->get_advertising()->remove_service_uuid(this->uuid_);
   this->running_state_ = STOPPING;
 }
 

--- a/esphome/components/esp32_ble_server/ble_service.h
+++ b/esphome/components/esp32_ble_server/ble_service.h
@@ -7,11 +7,11 @@
 
 #ifdef USE_ESP32
 
+#include <esp_bt_defs.h>
 #include <esp_gap_ble_api.h>
 #include <esp_gatt_defs.h>
 #include <esp_gattc_api.h>
 #include <esp_gatts_api.h>
-#include <esp_bt_defs.h>
 
 namespace esphome {
 namespace esp32_ble_server {

--- a/esphome/components/esp32_improv/__init__.py
+++ b/esphome/components/esp32_improv/__init__.py
@@ -4,7 +4,7 @@ from esphome.components import binary_sensor, output, esp32_ble_server
 from esphome.const import CONF_ID
 
 
-AUTO_LOAD = ["binary_sensor", "output", "esp32_ble_server"]
+AUTO_LOAD = ["esp32_ble_server"]
 CODEOWNERS = ["@jesserockz"]
 CONFLICTS_WITH = ["esp32_ble_beacon"]
 DEPENDENCIES = ["wifi", "esp32"]

--- a/esphome/components/esp32_improv/esp32_improv_component.cpp
+++ b/esphome/components/esp32_improv/esp32_improv_component.cpp
@@ -92,7 +92,8 @@ void ESP32ImprovComponent::loop() {
       break;
     case improv::STATE_AWAITING_AUTHORIZATION: {
 #ifdef USE_BINARY_SENSOR
-      if (this->authorizer_ == nullptr || (now - this->authorized_start_) < this->authorized_duration_) {
+      if (this->authorizer_ == nullptr ||
+          (this->authorized_start_ != 0 && ((now - this->authorized_start_) < this->authorized_duration_))) {
         this->set_state_(improv::STATE_AUTHORIZED);
       } else
 #else

--- a/esphome/components/esp32_improv/esp32_improv_component.cpp
+++ b/esphome/components/esp32_improv/esp32_improv_component.cpp
@@ -18,6 +18,16 @@ ESP32ImprovComponent::ESP32ImprovComponent() { global_improv_component = this; }
 void ESP32ImprovComponent::setup() {
   this->service_ = global_ble_server->create_service(improv::SERVICE_UUID, true);
   this->setup_characteristics();
+
+#ifdef USE_BINARY_SENSOR
+  if (this->authorizer_ != nullptr) {
+    this->authorizer_->add_on_state_callback([this](bool state) {
+      if (state) {
+        this->authorized_start_ = millis();
+      }
+    });
+  }
+#endif
 }
 
 void ESP32ImprovComponent::setup_characteristics() {
@@ -50,8 +60,10 @@ void ESP32ImprovComponent::setup_characteristics() {
   BLEDescriptor *capabilities_descriptor = new BLE2902();
   this->capabilities_->add_descriptor(capabilities_descriptor);
   uint8_t capabilities = 0x00;
+#ifdef USE_OUTPUT
   if (this->status_indicator_ != nullptr)
     capabilities |= improv::CAPABILITY_IDENTIFY;
+#endif
   this->capabilities_->set_value(capabilities);
   this->setup_complete_ = true;
 }
@@ -63,8 +75,7 @@ void ESP32ImprovComponent::loop() {
 
   switch (this->state_) {
     case improv::STATE_STOPPED:
-      if (this->status_indicator_ != nullptr)
-        this->status_indicator_->turn_off();
+      this->set_status_indicator_state_(false);
 
       if (this->service_->is_created() && this->should_start_ && this->setup_complete_) {
         if (this->service_->is_running()) {
@@ -80,14 +91,16 @@ void ESP32ImprovComponent::loop() {
       }
       break;
     case improv::STATE_AWAITING_AUTHORIZATION: {
-      if (this->authorizer_ == nullptr || this->authorizer_->state) {
+#ifdef USE_BINARY_SENSOR
+      if (this->authorizer_ == nullptr || (now - this->authorized_start_) < this->authorized_duration_) {
         this->set_state_(improv::STATE_AUTHORIZED);
-        this->authorized_start_ = now;
-      } else {
-        if (this->status_indicator_ != nullptr) {
-          if (!this->check_identify_())
-            this->status_indicator_->turn_on();
-        }
+      } else
+#else
+      this->set_state_(improv::STATE_AUTHORIZED);
+#endif
+      {
+        if (!this->check_identify_())
+          this->set_status_indicator_state_(true);
       }
       break;
     }
@@ -99,25 +112,13 @@ void ESP32ImprovComponent::loop() {
           return;
         }
       }
-      if (this->status_indicator_ != nullptr) {
-        if (!this->check_identify_()) {
-          if ((now % 1000) < 500) {
-            this->status_indicator_->turn_on();
-          } else {
-            this->status_indicator_->turn_off();
-          }
-        }
+      if (!this->check_identify_()) {
+        this->set_status_indicator_state_((now % 1000) < 500);
       }
       break;
     }
     case improv::STATE_PROVISIONING: {
-      if (this->status_indicator_ != nullptr) {
-        if ((now % 200) < 100) {
-          this->status_indicator_->turn_on();
-        } else {
-          this->status_indicator_->turn_off();
-        }
-      }
+      this->set_status_indicator_state_((now % 200) < 100);
       if (wifi::global_wifi_component->is_connected()) {
         wifi::global_wifi_component->save_wifi_sta(this->connecting_sta_.get_ssid(),
                                                    this->connecting_sta_.get_password());
@@ -142,11 +143,25 @@ void ESP32ImprovComponent::loop() {
     }
     case improv::STATE_PROVISIONED: {
       this->incoming_data_.clear();
-      if (this->status_indicator_ != nullptr)
-        this->status_indicator_->turn_off();
+      this->set_status_indicator_state_(false);
       break;
     }
   }
+}
+
+void ESP32ImprovComponent::set_status_indicator_state_(bool state) {
+#ifdef USE_OUTPUT
+  if (this->status_indicator_ == nullptr)
+    return;
+  if (this->status_indicator_state_ == state)
+    return;
+  this->status_indicator_state_ = state;
+  if (state) {
+    this->status_indicator_->turn_on();
+  } else {
+    this->status_indicator_->turn_off();
+  }
+#endif
 }
 
 bool ESP32ImprovComponent::check_identify_() {
@@ -156,11 +171,7 @@ bool ESP32ImprovComponent::check_identify_() {
 
   if (identify) {
     uint32_t time = now % 1000;
-    if (time < 600 && time % 200 < 100) {
-      this->status_indicator_->turn_on();
-    } else {
-      this->status_indicator_->turn_off();
-    }
+    this->set_status_indicator_state_(time < 600 && time % 200 < 100);
   }
   return identify;
 }
@@ -213,8 +224,12 @@ float ESP32ImprovComponent::get_setup_priority() const { return setup_priority::
 
 void ESP32ImprovComponent::dump_config() {
   ESP_LOGCONFIG(TAG, "ESP32 Improv:");
+#ifdef USE_BINARY_SENSOR
   LOG_BINARY_SENSOR("  ", "Authorizer", this->authorizer_);
+#endif
+#ifdef USE_OUTPUT
   ESP_LOGCONFIG(TAG, "  Status Indicator: '%s'", YESNO(this->status_indicator_ != nullptr));
+#endif
 }
 
 void ESP32ImprovComponent::process_incoming_data_() {

--- a/esphome/components/esp32_improv/esp32_improv_component.cpp
+++ b/esphome/components/esp32_improv/esp32_improv_component.cpp
@@ -24,6 +24,7 @@ void ESP32ImprovComponent::setup() {
     this->authorizer_->add_on_state_callback([this](bool state) {
       if (state) {
         this->authorized_start_ = millis();
+        this->identify_start_ = 0;
       }
     });
   }

--- a/esphome/components/esp32_improv/esp32_improv_component.h
+++ b/esphome/components/esp32_improv/esp32_improv_component.h
@@ -1,13 +1,21 @@
 #pragma once
 
-#include "esphome/components/binary_sensor/binary_sensor.h"
-#include "esphome/components/esp32_ble_server/ble_characteristic.h"
-#include "esphome/components/esp32_ble_server/ble_server.h"
-#include "esphome/components/output/binary_output.h"
-#include "esphome/components/wifi/wifi_component.h"
 #include "esphome/core/component.h"
+#include "esphome/core/defines.h"
 #include "esphome/core/helpers.h"
 #include "esphome/core/preferences.h"
+
+#include "esphome/components/esp32_ble_server/ble_characteristic.h"
+#include "esphome/components/esp32_ble_server/ble_server.h"
+#include "esphome/components/wifi/wifi_component.h"
+
+#ifdef USE_BINARY_SENSOR
+#include "esphome/components/binary_sensor/binary_sensor.h"
+#endif
+
+#ifdef USE_OUTPUT
+#include "esphome/components/output/binary_output.h"
+#endif
 
 #include <vector>
 
@@ -34,8 +42,12 @@ class ESP32ImprovComponent : public Component, public BLEServiceComponent {
   void stop() override;
   bool is_active() const { return this->state_ != improv::STATE_STOPPED; }
 
+#ifdef USE_BINARY_SENSOR
   void set_authorizer(binary_sensor::BinarySensor *authorizer) { this->authorizer_ = authorizer; }
+#endif
+#ifdef USE_OUTPUT
   void set_status_indicator(output::BinaryOutput *status_indicator) { this->status_indicator_ = status_indicator; }
+#endif
   void set_identify_duration(uint32_t identify_duration) { this->identify_duration_ = identify_duration; }
   void set_authorized_duration(uint32_t authorized_duration) { this->authorized_duration_ = authorized_duration; }
 
@@ -58,11 +70,18 @@ class ESP32ImprovComponent : public Component, public BLEServiceComponent {
   BLECharacteristic *rpc_response_;
   BLECharacteristic *capabilities_;
 
+#ifdef USE_BINARY_SENSOR
   binary_sensor::BinarySensor *authorizer_{nullptr};
+#endif
+#ifdef USE_OUTPUT
   output::BinaryOutput *status_indicator_{nullptr};
+#endif
 
   improv::State state_{improv::STATE_STOPPED};
   improv::Error error_state_{improv::ERROR_NONE};
+
+  bool status_indicator_state_{false};
+  void set_status_indicator_state_(bool state);
 
   void set_state_(improv::State state);
   void set_error_(improv::Error error);

--- a/esphome/components/output/__init__.py
+++ b/esphome/components/output/__init__.py
@@ -106,4 +106,5 @@ async def output_set_level_to_code(config, action_id, template_arg, args):
 
 
 async def to_code(config):
+    cg.add_define("USE_OUTPUT")
     cg.add_global(output_ns.using)

--- a/esphome/core/defines.h
+++ b/esphome/core/defines.h
@@ -37,6 +37,7 @@
 #define USE_OTA
 #define USE_OTA_PASSWORD
 #define USE_OTA_STATE_CALLBACK
+#define USE_OUTPUT
 #define USE_POWER_SUPPLY
 #define USE_QR_CODE
 #define USE_SELECT
@@ -117,6 +118,6 @@
 #endif
 
 // Disabled feature flags
-//#define USE_BSEC  // Requires a library with proprietary license.
+// #define USE_BSEC  // Requires a library with proprietary license.
 
 #define USE_DASHBOARD_IMPORT


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

When a BLE service is stopped that was set to advertise in the BLE advertisements, it currently is not removed from the advertisements. This fixes that to remove it from the list.

This also removes AUTO_LOADing of the output and binary sensors.

This PR also includes a small change to the `output` component to add a new define

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
