### PR TITLE
Update htu21d.cpp, fix publishing of heater level

### DIFF
--- a/esphome/components/htu21d/htu21d.cpp
+++ b/esphome/components/htu21d/htu21d.cpp
@@ -76,7 +76,7 @@ void HTU21DComponent::update() {
   if (this->humidity_ != nullptr)
     this->humidity_->publish_state(humidity);
   if (this->heater_ != nullptr)
-    this->heater_->publish_state(humidity);
+    this->heater_->publish_state(heater_level);
   this->status_clear_warning();
 }
 


### PR DESCRIPTION
publish_state published humidity instead of heater_level

# What does this implement/fix?

Testing an Si7021, with the htu21d component, I noticed, that my sensors dashboard prints humidity instead of heater level.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:


```yaml
# Example config.yaml
i2c:
   - id: bus_garage
     sda: 16
     scl: 17
     scan: true
     frequency: 10kHz
sensor:
  - platform: htu21d
    i2c_id: bus_garage
    id: garage_sensor
    temperature:
      name: "Garage Temperature"
      id: garage_temp
    humidity:
      name: "Garage Rel Humidity"
      id: garage_rel_hum
    heater:
      name: "Garage Sensor Heater"   
      id: garage_heater
    update_interval: 60s
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
