### PR TITLE
Splits FastLed test scripts out of test1.yaml

### DIFF
--- a/tests/test1.1.yaml
+++ b/tests/test1.1.yaml
@@ -1,0 +1,205 @@
+---
+substitutions:
+  devicename: test1_1
+  sensorname: my
+  textname: template
+  roomname: fastled_room
+
+esphome:
+  name: test1-1
+  name_add_mac_suffix: true
+  platform: ESP32
+  board: nodemcu-32s
+  platformio_options:
+    board_build.partitions: huge_app.csv
+  on_loop:
+    then:
+      - light.addressable_set:
+          id: addr1
+          range_from: 0
+          range_to: 100
+          red: 100%
+          green: !lambda "return 255;"
+          blue: 0%
+          white: 100%
+
+wled:
+
+wifi:
+  networks:
+    - ssid: "MySSID"
+      password: "password1"
+
+uart:
+  - id: adalight_uart
+    tx_pin: GPIO25
+    rx_pin: GPIO26
+    baud_rate: 115200
+    rx_buffer_size: 1024
+
+adalight:
+
+network:
+
+e131:
+
+power_supply:
+  id: atx_power_supply
+  enable_time: 20ms
+  keep_on_time: 10s
+  pin:
+    number: 13
+    inverted: true
+
+i2c:
+  sda: 21
+  scl: 22
+  scan: true
+  frequency: 100kHz
+  setup_priority: -100
+  id: i2c_bus
+
+pca9685:
+  frequency: 500
+  address: 0x0
+  i2c_id: i2c_bus
+
+output:
+  - platform: pca9685
+    id: pca_0
+    channel: 0
+  - platform: pca9685
+    id: pca_1
+    channel: 1
+  - platform: pca9685
+    id: pca_2
+    channel: 2
+
+light:
+  - platform: rgb
+    name: Living Room Lights
+    id: ${roomname}_lights
+    red: pca_0
+    green: pca_1
+    blue: pca_2
+  - platform: fastled_clockless
+    id: addr1
+    chipset: WS2811
+    pin: GPIO23
+    num_leds: 60
+    rgb_order: BRG
+    max_refresh_rate: 20ms
+    power_supply: atx_power_supply
+    color_correct: [75%, 100%, 50%]
+    name: FastLED WS2811 Light
+    effects:
+      - addressable_color_wipe:
+      - addressable_color_wipe:
+          name: Color Wipe Effect With Custom Values
+          colors:
+            - red: 100%
+              green: 100%
+              blue: 100%
+              num_leds: 1
+            - red: 0%
+              green: 0%
+              blue: 0%
+              num_leds: 1
+          add_led_interval: 100ms
+          reverse: false
+      - addressable_scan:
+      - addressable_scan:
+          name: Scan Effect With Custom Values
+          move_interval: 100ms
+      - addressable_twinkle:
+      - addressable_twinkle:
+          name: Twinkle Effect With Custom Values
+          twinkle_probability: 5%
+          progress_interval: 4ms
+      - addressable_random_twinkle:
+      - addressable_random_twinkle:
+          name: Random Twinkle Effect With Custom Values
+          twinkle_probability: 5%
+          progress_interval: 32ms
+      - addressable_fireworks:
+      - addressable_fireworks:
+          name: Fireworks Effect With Custom Values
+          update_interval: 32ms
+          spark_probability: 10%
+          use_random_color: false
+          fade_out_rate: 120
+      - addressable_flicker:
+      - addressable_flicker:
+          name: Flicker Effect With Custom Values
+          update_interval: 16ms
+          intensity: 5%
+      - addressable_lambda:
+          name: Test For Custom Lambda Effect
+          lambda: |-
+            if (initial_run) {
+              it[0] = current_color;
+            }
+
+      - wled:
+          port: 11111
+
+      - adalight:
+          uart_id: adalight_uart
+
+      - e131:
+          universe: 1
+
+      - automation:
+          name: Custom Effect
+          sequence:
+            - light.addressable_set:
+                id: addr1
+                red: 100%
+                green: 100%
+                blue: 0%
+            - delay: 100ms
+            - light.addressable_set:
+                id: addr1
+                red: 0%
+                green: 100%
+                blue: 0%
+
+  - platform: fastled_spi
+    id: addr2
+    chipset: WS2801
+    data_pin: GPIO23
+    clock_pin: GPIO22
+    data_rate: 2MHz
+    num_leds: 60
+    rgb_order: BRG
+    name: FastLED SPI Light
+  - platform: neopixelbus
+    id: addr3
+    name: Neopixelbus Light
+    gamma_correct: 2.8
+    color_correct: [0.0, 0.0, 0.0, 0.0]
+    default_transition_length: 10s
+    power_supply: atx_power_supply
+    effects:
+      - addressable_flicker:
+          name: Flicker Effect With Custom Values
+          update_interval: 16ms
+          intensity: 5%
+    type: GRBW
+    variant: SK6812
+    method: ESP32_I2S_0
+    num_leds: 60
+    pin: GPIO23
+  - platform: partition
+    name: Partition Light
+    segments:
+      - id: addr1
+        from: 0
+        to: 0
+      - id: addr2
+        from: 1
+        to: 10
+      - id: addr2
+        from: 20
+        to: 25
+      - single_light_id: ${roomname}_lights

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -25,14 +25,6 @@ esphome:
     then:
       - lambda: >-
           ESP_LOGV("main", "ON LOOP!");
-      - light.addressable_set:
-          id: addr1
-          range_from: 0
-          range_to: 100
-          red: 100%
-          green: !lambda "return 255;"
-          blue: 0%
-          white: 100%
       - http_request.get:
           url: https://esphome.io
           headers:
@@ -222,12 +214,6 @@ uart:
         - lambda: UARTDebug::log_string(direction, bytes);
         - lambda: UARTDebug::log_int(direction, bytes, ',');
         - lambda: UARTDebug::log_binary(direction, bytes, ';');
-
-  - id: adalight_uart
-    tx_pin: GPIO25
-    rx_pin: GPIO26
-    baud_rate: 115200
-    rx_buffer_size: 1024
   - id: ld2410_uart
     tx_pin: 18
     rx_pin: 23
@@ -299,10 +285,6 @@ dallas:
 as3935_spi:
   cs_pin: GPIO12
   irq_pin: GPIO13
-
-wled:
-
-adalight:
 
 esp32_ble:
   io_capability: keyboard_only
@@ -2073,8 +2055,6 @@ output:
     ud_pin: GPIO27
     initial_value: 0.5
 
-e131:
-
 light:
   - platform: binary
     name: Desk Lamp
@@ -2163,125 +2143,6 @@ light:
     brightness: pca_6
     cold_white_color_temperature: 153 mireds
     warm_white_color_temperature: 500 mireds
-  - platform: fastled_clockless
-    id: addr1
-    chipset: WS2811
-    pin: GPIO23
-    num_leds: 60
-    rgb_order: BRG
-    max_refresh_rate: 20ms
-    power_supply: atx_power_supply
-    color_correct: [75%, 100%, 50%]
-    name: FastLED WS2811 Light
-    effects:
-      - addressable_color_wipe:
-      - addressable_color_wipe:
-          name: Color Wipe Effect With Custom Values
-          colors:
-            - red: 100%
-              green: 100%
-              blue: 100%
-              num_leds: 1
-            - red: 0%
-              green: 0%
-              blue: 0%
-              num_leds: 1
-          add_led_interval: 100ms
-          reverse: false
-      - addressable_scan:
-      - addressable_scan:
-          name: Scan Effect With Custom Values
-          move_interval: 100ms
-      - addressable_twinkle:
-      - addressable_twinkle:
-          name: Twinkle Effect With Custom Values
-          twinkle_probability: 5%
-          progress_interval: 4ms
-      - addressable_random_twinkle:
-      - addressable_random_twinkle:
-          name: Random Twinkle Effect With Custom Values
-          twinkle_probability: 5%
-          progress_interval: 32ms
-      - addressable_fireworks:
-      - addressable_fireworks:
-          name: Fireworks Effect With Custom Values
-          update_interval: 32ms
-          spark_probability: 10%
-          use_random_color: false
-          fade_out_rate: 120
-      - addressable_flicker:
-      - addressable_flicker:
-          name: Flicker Effect With Custom Values
-          update_interval: 16ms
-          intensity: 5%
-      - addressable_lambda:
-          name: Test For Custom Lambda Effect
-          lambda: |-
-            if (initial_run) {
-              it[0] = current_color;
-            }
-
-      - wled:
-          port: 11111
-
-      - adalight:
-          uart_id: adalight_uart
-
-      - automation:
-          name: Custom Effect
-          sequence:
-            - light.addressable_set:
-                id: addr1
-                red: 100%
-                green: 100%
-                blue: 0%
-            - delay: 100ms
-            - light.addressable_set:
-                id: addr1
-                red: 0%
-                green: 100%
-                blue: 0%
-      - e131:
-          universe: 1
-  - platform: fastled_spi
-    id: addr2
-    chipset: WS2801
-    data_pin: GPIO23
-    clock_pin: GPIO22
-    data_rate: 2MHz
-    num_leds: 60
-    rgb_order: BRG
-    name: FastLED SPI Light
-  - platform: neopixelbus
-    id: addr3
-    name: Neopixelbus Light
-    gamma_correct: 2.8
-    color_correct: [0.0, 0.0, 0.0, 0.0]
-    default_transition_length: 10s
-    power_supply: atx_power_supply
-    effects:
-      - addressable_flicker:
-          name: Flicker Effect With Custom Values
-          update_interval: 16ms
-          intensity: 5%
-    type: GRBW
-    variant: SK6812
-    method: ESP32_I2S_0
-    num_leds: 60
-    pin: GPIO23
-  - platform: partition
-    name: Partition Light
-    segments:
-      - id: addr1
-        from: 0
-        to: 0
-      - id: addr2
-        from: 1
-        to: 10
-      - id: addr2
-        from: 20
-        to: 25
-      - single_light_id: ${roomname}_lights
 
 remote_transmitter:
   - pin: 32


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->
Splitsing the FastLed test script out of test1,yaml


## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).
