### PR TITLE
Add round sensor filter

### DIFF
--- a/esphome/components/sensor/__init__.py
+++ b/esphome/components/sensor/__init__.py
@@ -242,6 +242,7 @@ CalibrateLinearFilter = sensor_ns.class_("CalibrateLinearFilter", Filter)
 CalibratePolynomialFilter = sensor_ns.class_("CalibratePolynomialFilter", Filter)
 SensorInRangeCondition = sensor_ns.class_("SensorInRangeCondition", Filter)
 ClampFilter = sensor_ns.class_("ClampFilter", Filter)
+RoundFilter = sensor_ns.class_("RoundFilter", Filter)
 
 validate_unit_of_measurement = cv.string_strict
 validate_accuracy_decimals = cv.int_
@@ -699,6 +700,23 @@ async def clamp_filter_to_code(config, filter_id):
         filter_id,
         config[CONF_MIN_VALUE],
         config[CONF_MAX_VALUE],
+    )
+
+
+@FILTER_REGISTRY.register(
+    "round",
+    RoundFilter,
+    cv.maybe_simple_value(
+        {
+            cv.Required(CONF_ACCURACY_DECIMALS): cv.uint8_t,
+        },
+        key=CONF_ACCURACY_DECIMALS,
+    ),
+)
+async def round_filter_to_code(config, filter_id):
+    return cg.new_Pvariable(
+        filter_id,
+        config[CONF_ACCURACY_DECIMALS],
     )
 
 

--- a/esphome/components/sensor/filter.cpp
+++ b/esphome/components/sensor/filter.cpp
@@ -445,5 +445,14 @@ optional<float> ClampFilter::new_value(float value) {
   return value;
 }
 
+RoundFilter::RoundFilter(uint8_t precision) : precision_(precision) {}
+optional<float> RoundFilter::new_value(float value) {
+  if (std::isfinite(value)) {
+    float accuracy_mult = powf(10.0f, this->precision_);
+    return roundf(accuracy_mult * value) / accuracy_mult;
+  }
+  return value;
+}
+
 }  // namespace sensor
 }  // namespace esphome

--- a/esphome/components/sensor/filter.h
+++ b/esphome/components/sensor/filter.h
@@ -419,5 +419,14 @@ class ClampFilter : public Filter {
   float max_{NAN};
 };
 
+class RoundFilter : public Filter {
+ public:
+  explicit RoundFilter(uint8_t precision);
+  optional<float> new_value(float value) override;
+
+ protected:
+  uint8_t precision_;
+};
+
 }  // namespace sensor
 }  // namespace esphome


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->
```yaml
sensor: 
  - platform: ...
    filters:
      - round: 1 # will round to 1 decimal place
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#3266

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
