### PR TITLE
Change UART source clock to `UART_SCLK_DEFAULT` when IDF >=v5

### DIFF
--- a/esphome/components/uart/uart_component_esp_idf.cpp
+++ b/esphome/components/uart/uart_component_esp_idf.cpp
@@ -48,7 +48,11 @@ uart_config_t IDFUARTComponent::get_config_() {
   uart_config.parity = parity;
   uart_config.stop_bits = this->stop_bits_ == 1 ? UART_STOP_BITS_1 : UART_STOP_BITS_2;
   uart_config.flow_ctrl = UART_HW_FLOWCTRL_DISABLE;
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0)
+  uart_config.source_clk = UART_SCLK_DEFAULT;
+#else
   uart_config.source_clk = UART_SCLK_APB;
+#endif
   uart_config.rx_flow_ctrl_thresh = 122;
 
   return uart_config;


### PR DESCRIPTION
# What does this implement/fix?

This PR changes `uart_config.source_clk` to `UART_SCLK_DEFAULT` when ESP-IDF version is >= 5, because code for ESP32-C6 (possibly others) won't compile at all with this error:
```
src/esphome/components/uart/uart_component_esp_idf.cpp: In member function 'uart_config_t esphome::uart::IDFUARTComponent::get_config_()':
src/esphome/components/uart/uart_component_esp_idf.cpp:51:28: error: 'UART_SCLK_APB' was not declared in this scope; did you mean 'UART_SCLK_RTC'?
   51 |   uart_config.source_clk = UART_SCLK_APB;
      |                            ^~~~~~~~~~~~~
      |                            UART_SCLK_RTC
```

The [docs](https://docs.espressif.com/projects/esp-idf/en/v5.1.1/esp32/api-reference/peripherals/clk_tree.html#_CPPv4N32soc_periph_uart_clk_src_legacy_t17UART_SCLK_DEFAULTE) say `DEFAULT` is `APB`, so I guess this should be fine to just change that?

Also the `logger` component [already uses](https://github.com/esphome/esphome/blob/050fa0d4c17ac240abf2ebafdc27fdab1d53135d/esphome/components/logger/logger.cpp#L244) `DEFAULT`.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/4946

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
esp32:
  board: esp32-c6-devkitc-1
  variant: esp32c6
  framework:
    type: esp-idf
    platform_version: https://github.com/stintel/platform-espressif32#esp32-c6-test
    version: 5.1.1

uart:
  tx_pin: GPIO5
  rx_pin: GPIO4
  baud_rate: 9600
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
