### PR TITLE
Prometheus fix for esp-idf and fix newlines

### DIFF
--- a/esphome/components/prometheus/prometheus_handler.cpp
+++ b/esphome/components/prometheus/prometheus_handler.cpp
@@ -87,7 +87,7 @@ void PrometheusHandler::sensor_row_(AsyncResponseStream *stream, sensor::Sensor 
     stream->print(obj->get_unit_of_measurement().c_str());
     stream->print(F("\"} "));
     stream->print(value_accuracy_to_string(obj->state, obj->get_accuracy_decimals()).c_str());
-    stream->print('\n');
+    stream->print(F("\n"));
   } else {
     // Invalid state
     stream->print(F("esphome_sensor_failed{id=\""));
@@ -122,7 +122,7 @@ void PrometheusHandler::binary_sensor_row_(AsyncResponseStream *stream, binary_s
     stream->print(relabel_name_(obj).c_str());
     stream->print(F("\"} "));
     stream->print(obj->state);
-    stream->print('\n');
+    stream->print(F("\n"));
   } else {
     // Invalid state
     stream->print(F("esphome_binary_sensor_failed{id=\""));
@@ -156,7 +156,7 @@ void PrometheusHandler::fan_row_(AsyncResponseStream *stream, fan::Fan *obj) {
   stream->print(relabel_name_(obj).c_str());
   stream->print(F("\"} "));
   stream->print(obj->state);
-  stream->print('\n');
+  stream->print(F("\n"));
   // Speed if available
   if (obj->get_traits().supports_speed()) {
     stream->print(F("esphome_fan_speed{id=\""));
@@ -165,7 +165,7 @@ void PrometheusHandler::fan_row_(AsyncResponseStream *stream, fan::Fan *obj) {
     stream->print(relabel_name_(obj).c_str());
     stream->print(F("\"} "));
     stream->print(obj->speed);
-    stream->print('\n');
+    stream->print(F("\n"));
   }
   // Oscillation if available
   if (obj->get_traits().supports_oscillation()) {
@@ -175,7 +175,7 @@ void PrometheusHandler::fan_row_(AsyncResponseStream *stream, fan::Fan *obj) {
     stream->print(relabel_name_(obj).c_str());
     stream->print(F("\"} "));
     stream->print(obj->oscillating);
-    stream->print('\n');
+    stream->print(F("\n"));
   }
 }
 #endif
@@ -279,7 +279,7 @@ void PrometheusHandler::cover_row_(AsyncResponseStream *stream, cover::Cover *ob
     stream->print(relabel_name_(obj).c_str());
     stream->print(F("\"} "));
     stream->print(obj->position);
-    stream->print('\n');
+    stream->print(F("\n"));
     if (obj->get_traits().get_supports_tilt()) {
       stream->print(F("esphome_cover_tilt{id=\""));
       stream->print(relabel_id_(obj).c_str());
@@ -287,7 +287,7 @@ void PrometheusHandler::cover_row_(AsyncResponseStream *stream, cover::Cover *ob
       stream->print(relabel_name_(obj).c_str());
       stream->print(F("\"} "));
       stream->print(obj->tilt);
-      stream->print('\n');
+      stream->print(F("\n"));
     }
   } else {
     // Invalid state
@@ -320,7 +320,7 @@ void PrometheusHandler::switch_row_(AsyncResponseStream *stream, switch_::Switch
   stream->print(relabel_name_(obj).c_str());
   stream->print(F("\"} "));
   stream->print(obj->state);
-  stream->print('\n');
+  stream->print(F("\n"));
 }
 #endif
 
@@ -344,7 +344,7 @@ void PrometheusHandler::lock_row_(AsyncResponseStream *stream, lock::Lock *obj) 
   stream->print(relabel_name_(obj).c_str());
   stream->print(F("\"} "));
   stream->print(obj->state);
-  stream->print('\n');
+  stream->print(F("\n"));
 }
 #endif
 

--- a/esphome/components/prometheus/prometheus_handler.cpp
+++ b/esphome/components/prometheus/prometheus_handler.cpp
@@ -1,5 +1,3 @@
-#ifdef USE_ARDUINO
-
 #include "prometheus_handler.h"
 #include "esphome/core/application.h"
 
@@ -352,5 +350,3 @@ void PrometheusHandler::lock_row_(AsyncResponseStream *stream, lock::Lock *obj) 
 
 }  // namespace prometheus
 }  // namespace esphome
-
-#endif  // USE_ARDUINO

--- a/esphome/components/prometheus/prometheus_handler.h
+++ b/esphome/components/prometheus/prometheus_handler.h
@@ -1,14 +1,12 @@
 #pragma once
 
-#ifdef USE_ARDUINO
-
 #include <map>
 #include <utility>
 
-#include "esphome/core/entity_base.h"
 #include "esphome/components/web_server_base/web_server_base.h"
-#include "esphome/core/controller.h"
 #include "esphome/core/component.h"
+#include "esphome/core/controller.h"
+#include "esphome/core/entity_base.h"
 
 namespace esphome {
 namespace prometheus {
@@ -119,5 +117,3 @@ class PrometheusHandler : public AsyncWebHandler, public Component {
 
 }  // namespace prometheus
 }  // namespace esphome
-
-#endif  // USE_ARDUINO


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Since the base webserver code is now esp-idf compatible, the prometheus component can now be used as well.

`stream->print('\n');` was printing as `0.000000` instead of printing an actual newline https://github.com/esphome/issues/issues/4982#issuecomment-1763501031.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/4982

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
