### PR TITLE
Make IPAddress's operator!= compare values, not memory addresses.

### DIFF
--- a/esphome/components/network/ip_address.h
+++ b/esphome/components/network/ip_address.h
@@ -87,7 +87,7 @@ struct IPAddress {
   bool is_ip6() { return IP_IS_V6(&ip_addr_); }
   std::string str() const { return ipaddr_ntoa(&ip_addr_); }
   bool operator==(const IPAddress &other) const { return ip_addr_cmp(&ip_addr_, &other.ip_addr_); }
-  bool operator!=(const IPAddress &other) const { return !(&ip_addr_ == &other.ip_addr_); }
+  bool operator!=(const IPAddress &other) const { return !ip_addr_cmp(&ip_addr_, &other.ip_addr_); }
   IPAddress &operator+=(uint8_t increase) {
     if (IP_IS_V4(&ip_addr_)) {
 #if LWIP_IPV6


### PR DESCRIPTION
# What does this implement/fix?

The implementation of `operator!=` in [pr#5252](https://github.com/esphome/esphome/pull/5252) compares memory addresses instead of IP addresses.  This causes checks like `current_ip != state->ip`, as done in the ip_address sensors, to always be true.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):**
[pr#5252 Refactor ip address representation](https://github.com/esphome/esphome/pull/5252)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** n/a

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
text_sensor:
  - platform: wifi_info
    ip_address:
      name: ESP IP Address
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
