### PR TITLE
add on/off options for uart switch

### DIFF
--- a/esphome/components/uart/switch/__init__.py
+++ b/esphome/components/uart/switch/__init__.py
@@ -9,34 +9,27 @@ DEPENDENCIES = ["uart"]
 
 UARTSwitch = uart_ns.class_("UARTSwitch", switch.Switch, uart.UARTDevice, cg.Component)
 
-CONF_DATA_ON = "data_on"
-CONF_DATA_OFF = "data_off"
+CONF_TURN_OFF = "turn_off"
+CONF_TURN_ON = "turn_on"
 
-
-def validate_data(config):
-    if (CONF_DATA_ON in config or CONF_DATA_OFF in config) and (
-        CONF_DATA in config or CONF_SEND_EVERY in config
-    ):
-        raise cv.Invalid(
-            '"data" or "send_every" can\'t be used with "data_on" or "data_off"'
-        )
-    return config
-
-
-CONFIG_SCHEMA = cv.All(
+CONFIG_SCHEMA = (
     switch.switch_schema(UARTSwitch, block_inverted=True)
     .extend(
         {
-            cv.Optional(CONF_DATA): validate_raw_data,
-            cv.Optional(CONF_DATA_OFF): validate_raw_data,
-            cv.Optional(CONF_DATA_ON): validate_raw_data,
+            cv.Required(CONF_DATA): cv.Any(
+                validate_raw_data,
+                cv.Schema(
+                    {
+                        cv.Optional(CONF_TURN_OFF): validate_raw_data,
+                        cv.Optional(CONF_TURN_ON): validate_raw_data,
+                    }
+                ),
+            ),
             cv.Optional(CONF_SEND_EVERY): cv.positive_time_period_milliseconds,
         },
     )
     .extend(uart.UART_DEVICE_SCHEMA)
-    .extend(cv.COMPONENT_SCHEMA),
-    cv.has_at_least_one_key(CONF_DATA, CONF_DATA_ON, CONF_DATA_OFF),
-    validate_data,
+    .extend(cv.COMPONENT_SCHEMA)
 )
 
 
@@ -45,20 +38,21 @@ async def to_code(config):
     await cg.register_component(var, config)
     await uart.register_uart_device(var, config)
 
-    if data := config.get(CONF_DATA):
-        if isinstance(data, bytes):
-            data = [HexInt(x) for x in data]
-        cg.add(var.set_data(data))
-
-    if data := config.get(CONF_DATA_ON):
+    data = config[CONF_DATA]
+    if isinstance(data, dict):
+        if data_on := data.get(CONF_TURN_ON):
+            if isinstance(data_on, bytes):
+                data_on = [HexInt(x) for x in data_on]
+            cg.add(var.set_data_on(data_on))
+        if data_off := data.get(CONF_TURN_OFF):
+            if isinstance(data_off, bytes):
+                data_off = [HexInt(x) for x in data_off]
+            cg.add(var.set_data_off(data_off))
+    else:
+        data = config[CONF_DATA]
         if isinstance(data, bytes):
             data = [HexInt(x) for x in data]
         cg.add(var.set_data_on(data))
-
-    if data := config.get(CONF_DATA_OFF):
-        if isinstance(data, bytes):
-            data = [HexInt(x) for x in data]
-        cg.add(var.set_data_off(data))
-
+        cg.add(var.set_single_state(True))
     if CONF_SEND_EVERY in config:
         cg.add(var.set_send_every(config[CONF_SEND_EVERY]))

--- a/esphome/components/uart/switch/__init__.py
+++ b/esphome/components/uart/switch/__init__.py
@@ -9,17 +9,34 @@ DEPENDENCIES = ["uart"]
 
 UARTSwitch = uart_ns.class_("UARTSwitch", switch.Switch, uart.UARTDevice, cg.Component)
 
+CONF_DATA_ON = "data_on"
+CONF_DATA_OFF = "data_off"
 
-CONFIG_SCHEMA = (
+
+def validate_data(config):
+    if (CONF_DATA_ON in config or CONF_DATA_OFF in config) and (
+        CONF_DATA in config or CONF_SEND_EVERY in config
+    ):
+        raise cv.Invalid(
+            '"data" or "send_every" can\'t be used with "data_on" or "data_off"'
+        )
+    return config
+
+
+CONFIG_SCHEMA = cv.All(
     switch.switch_schema(UARTSwitch, block_inverted=True)
     .extend(
         {
-            cv.Required(CONF_DATA): validate_raw_data,
+            cv.Optional(CONF_DATA): validate_raw_data,
+            cv.Optional(CONF_DATA_OFF): validate_raw_data,
+            cv.Optional(CONF_DATA_ON): validate_raw_data,
             cv.Optional(CONF_SEND_EVERY): cv.positive_time_period_milliseconds,
-        }
+        },
     )
     .extend(uart.UART_DEVICE_SCHEMA)
-    .extend(cv.COMPONENT_SCHEMA)
+    .extend(cv.COMPONENT_SCHEMA),
+    cv.has_at_least_one_key(CONF_DATA, CONF_DATA_ON, CONF_DATA_OFF),
+    validate_data,
 )
 
 
@@ -28,10 +45,20 @@ async def to_code(config):
     await cg.register_component(var, config)
     await uart.register_uart_device(var, config)
 
-    data = config[CONF_DATA]
-    if isinstance(data, bytes):
-        data = [HexInt(x) for x in data]
-    cg.add(var.set_data(data))
+    if data := config.get(CONF_DATA):
+        if isinstance(data, bytes):
+            data = [HexInt(x) for x in data]
+        cg.add(var.set_data(data))
+
+    if data := config.get(CONF_DATA_ON):
+        if isinstance(data, bytes):
+            data = [HexInt(x) for x in data]
+        cg.add(var.set_data_on(data))
+
+    if data := config.get(CONF_DATA_OFF):
+        if isinstance(data, bytes):
+            data = [HexInt(x) for x in data]
+        cg.add(var.set_data_off(data))
 
     if CONF_SEND_EVERY in config:
         cg.add(var.set_send_every(config[CONF_SEND_EVERY]))

--- a/esphome/components/uart/switch/uart_switch.cpp
+++ b/esphome/components/uart/switch/uart_switch.cpp
@@ -21,7 +21,24 @@ void UARTSwitch::write_command_() {
   this->write_array(this->data_.data(), this->data_.size());
 }
 
+void UARTSwitch::write_command_(bool state) {
+  if (state && this->data_on_.size()) {
+    ESP_LOGD(TAG, "'%s': Sending on data...", this->get_name().c_str());
+    this->write_array(this->data_on_.data(), this->data_on_.size());
+  }
+  if (!state && this->data_off_.size()) {
+    ESP_LOGD(TAG, "'%s': Sending off data...", this->get_name().c_str());
+    this->write_array(this->data_off_.data(), this->data_off_.size());
+  }
+}
+
 void UARTSwitch::write_state(bool state) {
+  if (!this->single_state_) {
+    this->publish_state(state);
+    this->write_command_(state);
+    return;
+  }
+
   if (!state) {
     this->publish_state(false);
     return;
@@ -36,6 +53,7 @@ void UARTSwitch::write_state(bool state) {
     this->last_transmission_ = millis();
   }
 }
+
 void UARTSwitch::dump_config() {
   LOG_SWITCH("", "UART Switch", this);
   if (this->send_every_) {

--- a/esphome/components/uart/switch/uart_switch.cpp
+++ b/esphome/components/uart/switch/uart_switch.cpp
@@ -7,18 +7,13 @@ namespace uart {
 static const char *const TAG = "uart.switch";
 
 void UARTSwitch::loop() {
-  if (this->state && this->send_every_) {
+  if (this->send_every_) {
     const uint32_t now = millis();
     if (now - this->last_transmission_ > this->send_every_) {
-      this->write_command_();
+      this->write_command_(this->state);
       this->last_transmission_ = now;
     }
   }
-}
-
-void UARTSwitch::write_command_() {
-  ESP_LOGD(TAG, "'%s': Sending data...", this->get_name().c_str());
-  this->write_array(this->data_.data(), this->data_.size());
 }
 
 void UARTSwitch::write_command_(bool state) {
@@ -36,6 +31,7 @@ void UARTSwitch::write_state(bool state) {
   if (!this->single_state_) {
     this->publish_state(state);
     this->write_command_(state);
+    this->last_transmission_ = millis();
     return;
   }
 
@@ -45,7 +41,7 @@ void UARTSwitch::write_state(bool state) {
   }
 
   this->publish_state(true);
-  this->write_command_();
+  this->write_command_(true);
 
   if (this->send_every_ == 0) {
     this->publish_state(false);

--- a/esphome/components/uart/switch/uart_switch.cpp
+++ b/esphome/components/uart/switch/uart_switch.cpp
@@ -17,11 +17,11 @@ void UARTSwitch::loop() {
 }
 
 void UARTSwitch::write_command_(bool state) {
-  if (state && this->data_on_.size()) {
+  if (state && !this->data_on_.empty()) {
     ESP_LOGD(TAG, "'%s': Sending on data...", this->get_name().c_str());
     this->write_array(this->data_on_.data(), this->data_on_.size());
   }
-  if (!state && this->data_off_.size()) {
+  if (!state && !this->data_off_.empty()) {
     ESP_LOGD(TAG, "'%s': Sending off data...", this->get_name().c_str());
     this->write_array(this->data_off_.data(), this->data_off_.size());
   }

--- a/esphome/components/uart/switch/uart_switch.h
+++ b/esphome/components/uart/switch/uart_switch.h
@@ -13,15 +13,24 @@ class UARTSwitch : public switch_::Switch, public UARTDevice, public Component {
  public:
   void loop() override;
 
-  void set_data(const std::vector<uint8_t> &data) { data_ = data; }
+  void set_data(const std::vector<uint8_t> &data) {
+    this->data_ = data;
+    this->single_state_ = true;
+  }
+  void set_data_on(const std::vector<uint8_t> &data) { this->data_on_ = data; }
+  void set_data_off(const std::vector<uint8_t> &data) { this->data_off_ = data; }
   void set_send_every(uint32_t send_every) { this->send_every_ = send_every; }
 
   void dump_config() override;
 
  protected:
   void write_command_();
+  void write_command_(bool state);
   void write_state(bool state) override;
   std::vector<uint8_t> data_;
+  std::vector<uint8_t> data_on_;
+  std::vector<uint8_t> data_off_;
+  bool single_state_{false};
   uint32_t send_every_;
   uint32_t last_transmission_;
 };

--- a/esphome/components/uart/switch/uart_switch.h
+++ b/esphome/components/uart/switch/uart_switch.h
@@ -13,21 +13,16 @@ class UARTSwitch : public switch_::Switch, public UARTDevice, public Component {
  public:
   void loop() override;
 
-  void set_data(const std::vector<uint8_t> &data) {
-    this->data_ = data;
-    this->single_state_ = true;
-  }
   void set_data_on(const std::vector<uint8_t> &data) { this->data_on_ = data; }
   void set_data_off(const std::vector<uint8_t> &data) { this->data_off_ = data; }
   void set_send_every(uint32_t send_every) { this->send_every_ = send_every; }
+  void set_single_state(bool single) { this->single_state_ = single; }
 
   void dump_config() override;
 
  protected:
-  void write_command_();
   void write_command_(bool state);
   void write_state(bool state) override;
-  std::vector<uint8_t> data_;
   std::vector<uint8_t> data_on_;
   std::vector<uint8_t> data_off_;
   bool single_state_{false};

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -2588,6 +2588,10 @@ switch:
     name: UART Recurring Output
     data: [0xDE, 0xAD, 0xBE, 0xEF]
     send_every: 1s
+  - platform: uart
+    name: "UART On/Off"
+    data_on: "TurnOn\r\n"
+    data_off: "TurnOff\r\n"
   - platform: template
     assumed_state: true
     name: Stepper Switch

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -2589,9 +2589,11 @@ switch:
     data: [0xDE, 0xAD, 0xBE, 0xEF]
     send_every: 1s
   - platform: uart
+    uart_id: uart_0
     name: "UART On/Off"
-    data_on: "TurnOn\r\n"
-    data_off: "TurnOff\r\n"
+    data:
+      turn_on: "TurnOn\r\n"
+      turn_off: "TurnOff\r\n"
   - platform: template
     assumed_state: true
     name: Stepper Switch


### PR DESCRIPTION
# What does this implement/fix?

Allows a uart switch to send data on both on and off.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#3269

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [X] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
