### PR TITLE
st7789 using mode3 when no cs pin

### DIFF
--- a/esphome/components/st7789v/st7789v.cpp
+++ b/esphome/components/st7789v/st7789v.cpp
@@ -15,7 +15,7 @@ void ST7789V::setup() {
 #endif
   // If no CS pin st7789 needs to operate in SPI mode 3 instead of mode 0
   if (this->cs_ == nullptr) {
-    ESP_LOGD(TAG,"No CS pin : Using SPI mode 3");
+    ESP_LOGD(TAG, "No CS pin : Using SPI mode 3");
     this->set_mode(spi::MODE3);
   }
   this->spi_setup();

--- a/esphome/components/st7789v/st7789v.cpp
+++ b/esphome/components/st7789v/st7789v.cpp
@@ -13,6 +13,11 @@ void ST7789V::setup() {
   this->power_.request();
   // the PowerSupply component takes care of post turn-on delay
 #endif
+  // If no CS pin st7789 needs to operate in SPI mode 3 instead of mode 0
+  if (this->cs_ == nullptr) {
+    ESP_LOGD(TAG,"No CS pin : Using SPI mode 3");
+    this->set_mode(spi::MODE3);
+  }
   this->spi_setup();
   this->dc_pin_->setup();  // OUTPUT
 


### PR DESCRIPTION
# What does this implement/fix?

The ST7789 display component uses CS pin with SPI mode 0. But when the hwd implementation physically tight CS pin to GND, the idle state of SCK line should be high and leading the SPI mode being used move to mode 3 instead of 0.


## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

Issue seems having being discussed multiple times for users experimenting issues with ST7789 with no real outcomes
Recently while trying to use  ESP Home with such litle gadget [Geekmagic with ESPHome](https://community.home-assistant.io/t/installing-esphome-on-geekmagic-smart-weather-clock-smalltv-pro/618029) I figure out the issue.
This PR is only addressing the SPI mode concern with no CS pin, the ESP8266 memory limitation might be addressed later on in a different PR since this is more a workaround for frame buffer size limitation on this platform.

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [X] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:

The fix is fully transparent and detects if no CS pin being declared in the display st7789 component.
If no CS, the SPI mode is forced to 3.

```yaml

font:
  - file: 'OpenSans-Regular.ttf'
    id: font1
    size: 30

color:
    - id: color_green
      red: 0%
      green: 100%
      blue: 0%

spi:
  clk_pin: GPIO18
  mosi_pin: GPIO23
  interface: hardware
  id: spihwd

display:
  - platform: st7789v
    model: "Custom"
    spi_id: spihwd
    height: 240
    width: 240
    offset_height: 0
    offset_width: 0
    dc_pin: GPIO02
    reset_pin: GPIO04
    id: disp

        
    lambda: |-
      it.rectangle(0,  0, it.get_width()-1, it.get_height()-1, id(color_green));

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
