### PR TITLE
SML: fix incomplete sign extension for abbreviated transmissions

### DIFF
--- a/esphome/components/sml/sml_parser.cpp
+++ b/esphome/components/sml/sml_parser.cpp
@@ -88,11 +88,6 @@ uint64_t bytes_to_uint(const bytes &buffer) {
   for (auto const value : buffer) {
     val = (val << 8) + value;
   }
-  // Some smart meters send 24 bit signed integers. Sign extend to 64 bit if the
-  // 24 bit value is negative.
-  if (buffer.size() == 3 && buffer[0] & 0x80) {
-    val |= 0xFFFFFFFFFF000000;
-  }
   return val;
 }
 
@@ -100,19 +95,15 @@ int64_t bytes_to_int(const bytes &buffer) {
   uint64_t tmp = bytes_to_uint(buffer);
   int64_t val;
 
-  switch (buffer.size()) {
-    case 1:  // int8
-      val = (int8_t) tmp;
-      break;
-    case 2:  // int16
-      val = (int16_t) tmp;
-      break;
-    case 4:  // int32
-      val = (int32_t) tmp;
-      break;
-    default:  // int64
-      val = (int64_t) tmp;
+  // sign extension for abbreviations of leading ones (e.g. 3 byte transmissions, see 6.2.2 of SML protocol definition)
+  // see https://stackoverflow.com/questions/42534749/signed-extension-from-24-bit-to-32-bit-in-c
+  if (buffer.size() < 8) {
+    const int bits = buffer.size() * 8;
+    const uint64_t m = 1u << (bits - 1);
+    tmp = (tmp ^ m) - m;
   }
+
+  val = (int64_t) tmp;
   return val;
 }
 


### PR DESCRIPTION
# What does this implement/fix?

The SML protocol allows the sender to omit whole bytes with only leading ones or zeroes, as long as the transmitted value is still unambigous for the receiver. Therefore, integers might be anywhere from 1 to 8 bytes in size, and have to be sign-extended appropriately.

Previously, only 1, 2, and 4 byte sized integers were handled correctly. This issue has already been reported once, but the resulting fix only considers 3 byte sized integers and breaks 3 byte unsigned integers above 0x7fffff.

Replace both the incomplete sign extension and the previous bug fix attempt with a proper sign extension for arbitrary integer sizes.



## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** 
Fixes: 6089526975ee74b73d5b4975b7b481f37d50ac58
Fixes: https://github.com/esphome/issues/issues/4858

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
