### PR TITLE
More voice assistant fixes

### DIFF
--- a/esphome/components/i2s_audio/microphone/i2s_audio_microphone.cpp
+++ b/esphome/components/i2s_audio/microphone/i2s_audio_microphone.cpp
@@ -37,6 +37,8 @@ void I2SAudioMicrophone::setup() {
 void I2SAudioMicrophone::start() {
   if (this->is_failed())
     return;
+  if (this->state_ == microphone::STATE_RUNNING)
+    return;  // Already running
   this->state_ = microphone::STATE_STARTING;
 }
 void I2SAudioMicrophone::start_() {

--- a/esphome/components/voice_assistant/voice_assistant.cpp
+++ b/esphome/components/voice_assistant/voice_assistant.cpp
@@ -287,6 +287,7 @@ void VoiceAssistant::loop() {
           }
         }
         if (this->wait_for_stream_end_) {
+          this->cancel_timeout("playing");
           break;  // We dont want to timeout here as the STREAM_END event will take care of that.
         }
         playing = this->speaker_->is_running();


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

- Don't set microphone to starting if already running - Causes the microphone to start the i2s driver and lock the parent, but then the `state` was stuck in `starting` and could never get another lock from the parent.

- Cancel the playing timeout in case it was already triggered before the TTS_STREAM_START event was received by UDP data coming faster.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
