### PR TITLE
esp32_improv advertise capabilities and state in ble service data

### DIFF
--- a/esphome/components/esp32_ble/ble_advertising.cpp
+++ b/esphome/components/esp32_ble/ble_advertising.cpp
@@ -2,9 +2,9 @@
 
 #ifdef USE_ESP32
 
-#include "ble_uuid.h"
-#include <cstring>
 #include <cstdio>
+#include <cstring>
+#include "ble_uuid.h"
 #include "esphome/core/log.h"
 
 namespace esphome {
@@ -40,6 +40,17 @@ void BLEAdvertising::add_service_uuid(ESPBTUUID uuid) { this->advertising_uuids_
 void BLEAdvertising::remove_service_uuid(ESPBTUUID uuid) {
   this->advertising_uuids_.erase(std::remove(this->advertising_uuids_.begin(), this->advertising_uuids_.end(), uuid),
                                  this->advertising_uuids_.end());
+}
+
+void BLEAdvertising::set_service_data(const std::vector<uint8_t> &data) {
+  delete[] this->advertising_data_.p_service_data;
+  this->advertising_data_.p_service_data = nullptr;
+  this->advertising_data_.service_data_len = data.size();
+  if (!data.empty()) {
+    // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
+    this->advertising_data_.p_service_data = new uint8_t[data.size()];
+    memcpy(this->advertising_data_.p_service_data, data.data(), data.size());
+  }
 }
 
 void BLEAdvertising::set_manufacturer_data(const std::vector<uint8_t> &data) {

--- a/esphome/components/esp32_ble/ble_advertising.cpp
+++ b/esphome/components/esp32_ble/ble_advertising.cpp
@@ -16,8 +16,8 @@ BLEAdvertising::BLEAdvertising() {
   this->advertising_data_.set_scan_rsp = false;
   this->advertising_data_.include_name = true;
   this->advertising_data_.include_txpower = true;
-  this->advertising_data_.min_interval = 0x20;
-  this->advertising_data_.max_interval = 0x40;
+  this->advertising_data_.min_interval = 0;
+  this->advertising_data_.max_interval = 0;
   this->advertising_data_.appearance = 0x00;
   this->advertising_data_.manufacturer_len = 0;
   this->advertising_data_.p_manufacturer_data = nullptr;
@@ -96,8 +96,6 @@ void BLEAdvertising::start() {
     this->scan_response_data_.set_scan_rsp = true;
     this->scan_response_data_.include_name = true;
     this->scan_response_data_.include_txpower = true;
-    this->scan_response_data_.min_interval = 0;
-    this->scan_response_data_.max_interval = 0;
     this->scan_response_data_.manufacturer_len = 0;
     this->scan_response_data_.appearance = 0;
     this->scan_response_data_.flag = 0;

--- a/esphome/components/esp32_ble/ble_advertising.h
+++ b/esphome/components/esp32_ble/ble_advertising.h
@@ -21,6 +21,7 @@ class BLEAdvertising {
   void set_scan_response(bool scan_response) { this->scan_response_ = scan_response; }
   void set_min_preferred_interval(uint16_t interval) { this->advertising_data_.min_interval = interval; }
   void set_manufacturer_data(const std::vector<uint8_t> &data);
+  void set_service_data(const std::vector<uint8_t> &data);
 
   void start();
   void stop();

--- a/esphome/components/esp32_improv/esp32_improv_component.cpp
+++ b/esphome/components/esp32_improv/esp32_improv_component.cpp
@@ -189,9 +189,10 @@ void ESP32ImprovComponent::set_state_(improv::State state) {
     if (state != improv::STATE_STOPPED)
       this->status_->notify();
   }
-  std::vector<uint8_t> service_data(6, 0);
+  std::vector<uint8_t> service_data(8, 0);
   service_data[0] = 0x77;  // PR
   service_data[1] = 0x46;  // IM
+  service_data[2] = static_cast<uint8_t>(state);
 
   uint8_t capabilities = 0x00;
 #ifdef USE_OUTPUT
@@ -199,10 +200,11 @@ void ESP32ImprovComponent::set_state_(improv::State state) {
     capabilities |= improv::CAPABILITY_IDENTIFY;
 #endif
 
-  service_data[2] = capabilities;
-  service_data[3] = static_cast<uint8_t>(state);
+  service_data[3] = capabilities;
   service_data[4] = 0x00;  // Reserved
   service_data[5] = 0x00;  // Reserved
+  service_data[6] = 0x00;  // Reserved
+  service_data[7] = 0x00;  // Reserved
 
   esp32_ble::global_ble->get_advertising()->set_service_data(service_data);
   esp32_ble::global_ble->get_advertising()->start();

--- a/esphome/components/esp32_improv/esp32_improv_component.cpp
+++ b/esphome/components/esp32_improv/esp32_improv_component.cpp
@@ -189,6 +189,23 @@ void ESP32ImprovComponent::set_state_(improv::State state) {
     if (state != improv::STATE_STOPPED)
       this->status_->notify();
   }
+  std::vector<uint8_t> service_data(6, 0);
+  service_data[0] = 0x77;  // PR
+  service_data[1] = 0x46;  // IM
+
+  uint8_t capabilities = 0x00;
+#ifdef USE_OUTPUT
+  if (this->status_indicator_ != nullptr)
+    capabilities |= improv::CAPABILITY_IDENTIFY;
+#endif
+
+  service_data[2] = capabilities;
+  service_data[3] = static_cast<uint8_t>(state);
+  service_data[4] = 0x00;  // Reserved
+  service_data[5] = 0x00;  // Reserved
+
+  esp32_ble::global_ble->get_advertising()->set_service_data(service_data);
+  esp32_ble::global_ble->get_advertising()->start();
 }
 
 void ESP32ImprovComponent::set_error_(improv::Error error) {


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

This will advertise the capabilites and state in the service data under UUID `0x4677` (IMPR)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
