### PR TITLE
Incorrect ESP32 Strapping PIN Defined

### DIFF
--- a/esphome/components/esp32/gpio_esp32.py
+++ b/esphome/components/esp32/gpio_esp32.py
@@ -18,7 +18,7 @@ _ESP_SDIO_PINS = {
     11: "Flash Command",
 }
 
-_ESP32_STRAPPING_PINS = {0, 2, 4, 12, 15}
+_ESP32_STRAPPING_PINS = {0, 2, 5, 12, 15}
 _LOGGER = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
# What does this implement/fix?


WARNING GPIO4 is a Strapping PIN and should be avoided.
GPIO4 should be GPIO5

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

