### PR TITLE
Create IPv4 sockets if ipv6 is not enabled

### DIFF
--- a/esphome/components/socket/socket.cpp
+++ b/esphome/components/socket/socket.cpp
@@ -10,7 +10,7 @@ namespace socket {
 Socket::~Socket() {}
 
 std::unique_ptr<Socket> socket_ip(int type, int protocol) {
-#if LWIP_IPV6
+#if ENABLE_IPV6
   return socket(AF_INET6, type, protocol);
 #else
   return socket(AF_INET, type, protocol);
@@ -18,7 +18,7 @@ std::unique_ptr<Socket> socket_ip(int type, int protocol) {
 }
 
 socklen_t set_sockaddr(struct sockaddr *addr, socklen_t addrlen, const std::string &ip_address, uint16_t port) {
-#if LWIP_IPV6
+#if ENABLE_IPV6
   if (addrlen < sizeof(sockaddr_in6)) {
     errno = EINVAL;
     return 0;
@@ -51,7 +51,7 @@ socklen_t set_sockaddr(struct sockaddr *addr, socklen_t addrlen, const std::stri
 }
 
 socklen_t set_sockaddr_any(struct sockaddr *addr, socklen_t addrlen, uint16_t port) {
-#if LWIP_IPV6
+#if ENABLE_IPV6
   if (addrlen < sizeof(sockaddr_in6)) {
     errno = EINVAL;
     return 0;


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->
When using Arduino on esp32, LWIP is always set to 1 even if we disable ipv6 explicitly in ESPHome. 

This change makes it so that we use our preference for creating a socket.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
