### PR TITLE
Fix XOR condition

### DIFF
--- a/esphome/core/base_automation.h
+++ b/esphome/core/base_automation.h
@@ -52,12 +52,12 @@ template<typename... Ts> class XorCondition : public Condition<Ts...> {
  public:
   explicit XorCondition(const std::vector<Condition<Ts...> *> &conditions) : conditions_(conditions) {}
   bool check(Ts... x) override {
-    bool xor_state = false;
+    size_t result = 0;
     for (auto *condition : this->conditions_) {
-      xor_state = xor_state ^ condition->check(x...);
+      result += condition->check(x...);
     }
 
-    return xor_state;
+    return result == 1;
   }
 
  protected:


### PR DESCRIPTION
…dd number

# What does this implement/fix?

The new xor condition currently will be true for any odd number of true conditions.
Instead it should be true if and only if 1 single condition is true.

<!-- Quick description and explanation of changes -->

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
