### PR TITLE
Fix exception handling when loading packages

### DIFF
--- a/esphome/components/packages/__init__.py
+++ b/esphome/components/packages/__init__.py
@@ -139,17 +139,22 @@ def _process_base_package(config: dict) -> dict:
                 ) from e
         return packages
 
-    packages = {}
+    packages = None
+    error = ""
 
     try:
         packages = get_packages(files)
-    except cv.Invalid:
-        if revert is not None:
-            revert()
-            packages = get_packages(files)
-    finally:
-        if packages is None:
-            raise cv.Invalid("Failed to load packages")
+    except cv.Invalid as e:
+        error = e
+        try:
+            if revert is not None:
+                revert()
+                packages = get_packages(files)
+        except cv.Invalid as er:
+            error = er
+
+    if packages is None:
+        raise cv.Invalid(f"Failed to load packages. {error}")
 
     return {"packages": packages}
 


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->
Replaces `AttributeError: 'dict' object has no attribute 'move_to_end'` error message with correct one when error loading packages.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes [4485](https://github.com/esphome/issues/issues/4485)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
packages:
  failed: github://dentra/esphome-tion/packages/non-existing-package.yaml@master
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
