### PR TITLE
Remove explicit cast for IPAddress

### DIFF
--- a/esphome/components/mqtt/mqtt_backend_libretiny.h
+++ b/esphome/components/mqtt/mqtt_backend_libretiny.h
@@ -20,7 +20,7 @@ class MQTTBackendLibreTiny final : public MQTTBackend {
     mqtt_client_.setWill(topic, qos, retain, payload);
   }
   void set_server(network::IPAddress ip, uint16_t port) final {
-    mqtt_client_.setServer(IPAddress(static_cast<uint32_t>(ip)), port);
+    mqtt_client_.setServer(IPAddress(ip), port);
   }
   void set_server(const char *host, uint16_t port) final { mqtt_client_.setServer(host, port); }
 #if ASYNC_TCP_SSL_ENABLED

--- a/esphome/components/mqtt/mqtt_backend_libretiny.h
+++ b/esphome/components/mqtt/mqtt_backend_libretiny.h
@@ -19,9 +19,7 @@ class MQTTBackendLibreTiny final : public MQTTBackend {
   void set_will(const char *topic, uint8_t qos, bool retain, const char *payload) final {
     mqtt_client_.setWill(topic, qos, retain, payload);
   }
-  void set_server(network::IPAddress ip, uint16_t port) final {
-    mqtt_client_.setServer(IPAddress(ip), port);
-  }
+  void set_server(network::IPAddress ip, uint16_t port) final { mqtt_client_.setServer(IPAddress(ip), port); }
   void set_server(const char *host, uint16_t port) final { mqtt_client_.setServer(host, port); }
 #if ASYNC_TCP_SSL_ENABLED
   void set_secure(bool secure) { mqtt_client.setSecure(secure); }

--- a/tests/test9.yaml
+++ b/tests/test9.yaml
@@ -26,3 +26,9 @@ sensor:
     name: ADC
     pin: GPIO23
     update_interval: 1s
+
+mqtt:
+  broker: test.mosquitto.org
+  port: 1883
+  discovery: true
+  discovery_prefix: homeassistant


### PR DESCRIPTION
# What does this implement/fix?

Remove explicit cast for IPAddress. The IPAddress class has implicit cast for regular datatypes which should be used instead of explicit casts.
## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/5011

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [x] libretiny

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Tests for bk7xx boards using LibreTiny
---
wifi:
  ssid: "ssid"

bk72xx:
  board: cb2s

esphome:
  name: bk72xx-test

mqtt:
  broker: test.mosquitto.org
  port: 1883
  discovery: true
  discovery_prefix: homeassistant
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
