### PR TITLE
Add address text sensor to WireGuard

### DIFF
--- a/esphome/components/wireguard/text_sensor.py
+++ b/esphome/components/wireguard/text_sensor.py
@@ -1,0 +1,28 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import text_sensor
+from esphome.const import (
+    CONF_ADDRESS,
+    ENTITY_CATEGORY_DIAGNOSTIC,
+)
+
+from . import Wireguard
+
+CONF_WIREGUARD_ID = "wireguard_id"
+
+DEPENDENCIES = ["wireguard"]
+
+CONFIG_SCHEMA = {
+    cv.GenerateID(CONF_WIREGUARD_ID): cv.use_id(Wireguard),
+    cv.Optional(CONF_ADDRESS): text_sensor.text_sensor_schema(
+        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+    ),
+}
+
+
+async def to_code(config):
+    parent = await cg.get_variable(config[CONF_WIREGUARD_ID])
+
+    if address_config := config.get(CONF_ADDRESS):
+        sens = await text_sensor.new_text_sensor(address_config)
+        cg.add(parent.set_address_sensor(sens))

--- a/esphome/components/wireguard/wireguard.cpp
+++ b/esphome/components/wireguard/wireguard.cpp
@@ -54,6 +54,12 @@ void Wireguard::setup() {
     this->wg_peer_offline_time_ = millis();
     this->srctime_->add_on_time_sync_callback(std::bind(&Wireguard::start_connection_, this));
     this->defer(std::bind(&Wireguard::start_connection_, this));  // defer to avoid blocking setup
+
+#ifdef USE_TEXT_SENSOR
+    if (this->address_sensor_ != nullptr) {
+      this->address_sensor_->publish_state(this->address_);
+    }
+#endif
   } else {
     ESP_LOGE(TAG, "cannot initialize WireGuard, error code %d", this->wg_initialized_);
     this->mark_failed();
@@ -184,6 +190,10 @@ void Wireguard::set_status_sensor(binary_sensor::BinarySensor *sensor) { this->s
 
 #ifdef USE_SENSOR
 void Wireguard::set_handshake_sensor(sensor::Sensor *sensor) { this->handshake_sensor_ = sensor; }
+#endif
+
+#ifdef USE_TEXT_SENSOR
+void Wireguard::set_address_sensor(text_sensor::TextSensor *sensor) { this->address_sensor_ = sensor; }
 #endif
 
 void Wireguard::disable_auto_proceed() { this->proceed_allowed_ = false; }

--- a/esphome/components/wireguard/wireguard.h
+++ b/esphome/components/wireguard/wireguard.h
@@ -17,6 +17,10 @@
 #include "esphome/components/sensor/sensor.h"
 #endif
 
+#ifdef USE_TEXT_SENSOR
+#include "esphome/components/text_sensor/text_sensor.h"
+#endif
+
 #include <esp_wireguard.h>
 
 namespace esphome {
@@ -55,6 +59,10 @@ class Wireguard : public PollingComponent {
   void set_handshake_sensor(sensor::Sensor *sensor);
 #endif
 
+#ifdef USE_TEXT_SENSOR
+  void set_address_sensor(text_sensor::TextSensor *sensor);
+#endif
+
   /// Block the setup step until peer is connected.
   void disable_auto_proceed();
 
@@ -83,6 +91,10 @@ class Wireguard : public PollingComponent {
 
 #ifdef USE_SENSOR
   sensor::Sensor *handshake_sensor_ = nullptr;
+#endif
+
+#ifdef USE_TEXT_SENSOR
+  text_sensor::TextSensor *address_sensor_ = nullptr;
 #endif
 
   /// Set to false to block the setup step until peer is connected.

--- a/tests/test10.yaml
+++ b/tests/test10.yaml
@@ -49,3 +49,8 @@ sensor:
   - platform: wireguard
     latest_handshake:
       name: 'WireGuard Latest Handshake'
+
+text_sensor:
+  - platform: wireguard
+    address:
+      name: 'WireGuard Address'


### PR DESCRIPTION
# What does this implement/fix?

Add address text sensor to WireGuard component.

Sometimes it is useful to have that address directly available in the frontend without having to look in the config file.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** none

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#3288

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
```yaml
# configure wireguard as usual
wireguard:
  [...]

text_sensor:
  - platform: wireguard
    address:
      name: 'WireGuard Address'

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
