### PR TITLE
Bump platformio to 6.4.0

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -71,7 +71,7 @@ RUN \
 RUN \
     # Ubuntu python3-pip is missing wheel
     pip3 install --break-system-packages --no-cache-dir \
-        platformio==6.1.11 \
+        platformio==6.4.0 \
     # Change some platformio settings
     && platformio settings set enable_telemetry No \
     && platformio settings set check_platformio_interval 1000000 \

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ tornado==6.3.3
 tzlocal==5.1    # from time
 tzdata>=2021.1  # from time
 pyserial==3.5
-platformio==6.1.11  # When updating platformio, also update Dockerfile
+platformio==6.4.0  # When updating platformio, also update Dockerfile
 esptool==4.6.2
 click==8.1.7
 esphome-dashboard==20230904.0


### PR DESCRIPTION
# What does this implement/fix?

Upgrades Platformio which brings support for the esp-idf 5.1.1 framework. This is required to
reload the partition table without rebooting which is used by https://github.com/esphome/esphome/pull/5535

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** unblocks https://github.com/esphome/esphome/pull/5535

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** NA

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
# Example for esp32-c3 (Shelly Plus 1PM Mini)
esphome:
  name: test
  platformio_options:
    board_build.flash_mode: dio
esp32:
  board: esp32-c3-devkitm-1
  framework:
    type: esp-idf
    platform_version: 6.4.0
    version: 5.1.1
  variant: esp32c3
wifi:
  manual_ip:
    static_ip: 192.168.0.33
    gateway: 192.168.2.1
    subnet: 255.255.192.0
    dns1: 192.168.2.1
  networks:
  - ssid: my_wifi
    password: my_wifi_password
ota:
  password: my_ota_password
  unprotected_writes: True
logger:
  hardware_uart: USB_SERIAL_JTAG
web_server:
button:
- platform: restart
  name: Restart
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
