### PR TITLE
fix canbus send config

### DIFF
--- a/esphome/components/canbus/__init__.py
+++ b/esphome/components/canbus/__init__.py
@@ -17,11 +17,12 @@ CONF_ON_FRAME = "on_frame"
 
 
 def validate_id(config):
-    can_id = config[CONF_CAN_ID]
-    id_ext = config[CONF_USE_EXTENDED_ID]
-    if not id_ext:
-        if can_id > 0x7FF:
-            raise cv.Invalid("Standard IDs must be 11 Bit (0x000-0x7ff / 0-2047)")
+    if CONF_CAN_ID in config:
+        can_id = config[CONF_CAN_ID]
+        id_ext = config[CONF_USE_EXTENDED_ID]
+        if not id_ext:
+            if can_id > 0x7FF:
+                raise cv.Invalid("Standard IDs must be 11 Bit (0x000-0x7ff / 0-2047)")
     return config
 
 
@@ -151,22 +152,18 @@ async def canbus_action_to_code(config, action_id, template_arg, args):
     if can_id := config.get(CONF_CAN_ID):
         can_id = await cg.templatable(can_id, args, cg.uint32)
         cg.add(var.set_can_id(can_id))
-    use_extended_id = await cg.templatable(
-        config[CONF_USE_EXTENDED_ID], args, cg.uint32
-    )
-    cg.add(var.set_use_extended_id(use_extended_id))
+        cg.add(var.set_use_extended_id(config[CONF_USE_EXTENDED_ID]))
 
-    remote_transmission_request = await cg.templatable(
-        config[CONF_REMOTE_TRANSMISSION_REQUEST], args, bool
+    cg.add(
+        var.set_remote_transmission_request(config[CONF_REMOTE_TRANSMISSION_REQUEST])
     )
-    cg.add(var.set_remote_transmission_request(remote_transmission_request))
 
     data = config[CONF_DATA]
-    if isinstance(data, bytes):
-        data = [int(x) for x in data]
     if cg.is_template(data):
         templ = await cg.templatable(data, args, cg.std_vector.template(cg.uint8))
         cg.add(var.set_data_template(templ))
     else:
+        if isinstance(data, bytes):
+            data = [int(x) for x in data]
         cg.add(var.set_data_static(data))
     return var

--- a/tests/test1.1.yaml
+++ b/tests/test1.1.yaml
@@ -203,3 +203,19 @@ light:
         from: 20
         to: 25
       - single_light_id: ${roomname}_lights
+
+canbus:
+  - platform: esp32_can
+    id: esp32_internal_can
+    rx_pin: GPIO04
+    tx_pin: GPIO05
+    can_id: 4
+    bit_rate: 50kbps
+
+button:
+  - platform: template
+    name: Canbus Actions
+    on_press:
+      - canbus.send: "abc"
+      - canbus.send: [0, 1, 2]
+      - canbus.send: !lambda return {0, 1, 2};

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -3215,6 +3215,10 @@ text_sensor:
           can_id: 23
           data: [0x10, 0x20, 0x30]
       - canbus.send:
+          canbus_id: mcp2515_can
+          can_id: 23
+          data: !lambda return {0x10, 0x20, 0x30};
+      - canbus.send:
           canbus_id: esp32_internal_can
           can_id: 23
           data: [0x10, 0x20, 0x30]


### PR DESCRIPTION
# What does this implement/fix?

The `canbus.send` short form doesn't compile.  Also, the config parsing had errors.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/5016

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [X] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
