### PR TITLE
Update current_based_cover bugfix

### DIFF
--- a/esphome/components/current_based/current_based_cover.cpp
+++ b/esphome/components/current_based/current_based_cover.cpp
@@ -104,7 +104,8 @@ void CurrentBasedCover::loop() {
       ESP_LOGD(TAG, "'%s' - Close position reached. Took %.1fs.", this->name_.c_str(), dur);
       this->direction_idle_(COVER_CLOSED);
     }
-  } if (now - this->start_dir_time_ > this->max_duration_) {
+  }
+  if (now - this->start_dir_time_ > this->max_duration_) {
     ESP_LOGD(TAG, "'%s' - Max duration reached. Stopping cover.", this->name_.c_str());
     this->direction_idle_();
   }

--- a/esphome/components/current_based/current_based_cover.cpp
+++ b/esphome/components/current_based/current_based_cover.cpp
@@ -104,7 +104,7 @@ void CurrentBasedCover::loop() {
       ESP_LOGD(TAG, "'%s' - Close position reached. Took %.1fs.", this->name_.c_str(), dur);
       this->direction_idle_(COVER_CLOSED);
     }
-  } else if (now - this->start_dir_time_ > this->max_duration_) {
+  } if (now - this->start_dir_time_ > this->max_duration_) {
     ESP_LOGD(TAG, "'%s' - Max duration reached. Stopping cover.", this->name_.c_str());
     this->direction_idle_();
   }


### PR DESCRIPTION
changed "else if" to "if" to make sure this section of the code is reached for max duration validation.

# What does this implement/fix?

bugfix of current based cover, detection of max duration

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
