### PR TITLE
Allow set climate preset to NONE

### DIFF
--- a/esphome/components/climate/climate.cpp
+++ b/esphome/components/climate/climate.cpp
@@ -213,6 +213,8 @@ ClimateCall &ClimateCall::set_preset(const std::string &preset) {
     this->set_preset(CLIMATE_PRESET_SLEEP);
   } else if (str_equals_case_insensitive(preset, "ACTIVITY")) {
     this->set_preset(CLIMATE_PRESET_ACTIVITY);
+  } else if (str_equals_case_insensitive(preset, "NONE")) {
+    this->set_preset(CLIMATE_PRESET_NONE);
   } else {
     if (this->parent_->get_traits().supports_custom_preset(preset)) {
       this->custom_preset_ = preset;


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Added the ability to set the climate preset to `NONE` using a climate call or from MQTT.

Tested on ESP32 IDF, but should work on other platforms as well.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
