### PR TITLE
Devcontainer: allow pip install and dont warn about root user

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,17 +1,13 @@
 {
   "name": "ESPHome Dev",
   "image": "ghcr.io/esphome/esphome-lint:dev",
-  "postCreateCommand": [
-    "script/devcontainer-post-create"
-  ],
+  "postCreateCommand": ["script/devcontainer-post-create"],
   "containerEnv": {
-    "DEVCONTAINER": "1"
+    "DEVCONTAINER": "1",
+    "PIP_BREAK_SYSTEM_PACKAGES": "1",
+    "PIP_ROOT_USER_ACTION": "ignore"
   },
-  "runArgs": [
-    "--privileged",
-    "-e",
-    "ESPHOME_DASHBOARD_USE_PING=1"
-  ],
+  "runArgs": ["--privileged", "-e", "ESPHOME_DASHBOARD_USE_PING=1"],
   "appPort": 6052,
   "customizations": {
     "vscode": {
@@ -24,7 +20,7 @@
         // cpp
         "ms-vscode.cpptools",
         // editorconfig
-        "editorconfig.editorconfig",
+        "editorconfig.editorconfig"
       ],
       "settings": {
         "python.languageServer": "Pylance",


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

With the recent changes to the base docker images, pip now blocks system pip installs. But as we are in an isolated devcontainer, we can set the env var to ignore this.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
