### PR TITLE
timeout filter: return value

### DIFF
--- a/esphome/components/sensor/filter.cpp
+++ b/esphome/components/sensor/filter.cpp
@@ -1,8 +1,8 @@
 #include "filter.h"
+#include <cmath>
 #include "esphome/core/hal.h"
 #include "esphome/core/log.h"
 #include "sensor.h"
-#include <cmath>
 
 namespace esphome {
 namespace sensor {
@@ -376,9 +376,7 @@ void OrFilter::initialize(Sensor *parent, Filter *next) {
 // TimeoutFilter
 optional<float> TimeoutFilter::new_value(float value) {
   this->set_timeout("timeout", this->time_period_, [this]() { this->output(this->value_); });
-  this->output(value);
-
-  return {};
+  return value;
 }
 
 TimeoutFilter::TimeoutFilter(uint32_t time_period, float new_value) : time_period_(time_period), value_(new_value) {}


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Instead of calling `this->output(value);` it should be returning the value as the caller of `new_value` will output the new value. 

No change in functionality, just a cleanup of the code.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
