### PR TITLE
feat: Add ESP32 BLE enable/disable automations

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -87,9 +87,9 @@ esphome/components/ee895/* @Stock-M
 esphome/components/ektf2232/* @jesserockz
 esphome/components/ens210/* @itn3rd77
 esphome/components/esp32/* @esphome/core
-esphome/components/esp32_ble/* @jesserockz
+esphome/components/esp32_ble/* @Rapsssito @jesserockz
 esphome/components/esp32_ble_client/* @jesserockz
-esphome/components/esp32_ble_server/* @clydebarrow @jesserockz
+esphome/components/esp32_ble_server/* @Rapsssito @clydebarrow @jesserockz
 esphome/components/esp32_camera_web_server/* @ayufan
 esphome/components/esp32_can/* @Sympatron
 esphome/components/esp32_improv/* @jesserockz

--- a/esphome/components/esp32_ble/__init__.py
+++ b/esphome/components/esp32_ble/__init__.py
@@ -1,15 +1,17 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
+from esphome import automation
 from esphome.const import CONF_ID
 from esphome.core import CORE
 from esphome.components.esp32 import add_idf_sdkconfig_option, get_esp32_variant, const
 
 DEPENDENCIES = ["esp32"]
-CODEOWNERS = ["@jesserockz"]
+CODEOWNERS = ["@jesserockz", "@Rapsssito"]
 CONFLICTS_WITH = ["esp32_ble_beacon"]
 
 CONF_BLE_ID = "ble_id"
 CONF_IO_CAPABILITY = "io_capability"
+CONF_ENABLE_ON_BOOT = "enable_on_boot"
 
 NO_BLUETOOTH_VARIANTS = [const.VARIANT_ESP32S2]
 
@@ -19,6 +21,10 @@ ESP32BLE = esp32_ble_ns.class_("ESP32BLE", cg.Component)
 GAPEventHandler = esp32_ble_ns.class_("GAPEventHandler")
 GATTcEventHandler = esp32_ble_ns.class_("GATTcEventHandler")
 GATTsEventHandler = esp32_ble_ns.class_("GATTsEventHandler")
+
+BLEEnabledCondition = esp32_ble_ns.class_("BLEEnabledCondition", automation.Condition)
+BLEEnableAction = esp32_ble_ns.class_("BLEEnableAction", automation.Action)
+BLEDisableAction = esp32_ble_ns.class_("BLEDisableAction", automation.Action)
 
 IoCapability = esp32_ble_ns.enum("IoCapability")
 IO_CAPABILITY = {
@@ -35,6 +41,7 @@ CONFIG_SCHEMA = cv.Schema(
         cv.Optional(CONF_IO_CAPABILITY, default="none"): cv.enum(
             IO_CAPABILITY, lower=True
         ),
+        cv.Optional(CONF_ENABLE_ON_BOOT, default=True): cv.boolean,
     }
 ).extend(cv.COMPONENT_SCHEMA)
 
@@ -50,9 +57,25 @@ FINAL_VALIDATE_SCHEMA = validate_variant
 
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
-    await cg.register_component(var, config)
+    cg.add(var.set_enable_on_boot(config[CONF_ENABLE_ON_BOOT]))
     cg.add(var.set_io_capability(config[CONF_IO_CAPABILITY]))
+    await cg.register_component(var, config)
 
     if CORE.using_esp_idf:
         add_idf_sdkconfig_option("CONFIG_BT_ENABLED", True)
         add_idf_sdkconfig_option("CONFIG_BT_BLE_42_FEATURES_SUPPORTED", True)
+
+
+@automation.register_condition("ble.enabled", BLEEnabledCondition, cv.Schema({}))
+async def ble_enabled_to_code(config, condition_id, template_arg, args):
+    return cg.new_Pvariable(condition_id, template_arg)
+
+
+@automation.register_action("ble.enable", BLEEnableAction, cv.Schema({}))
+async def ble_enable_to_code(config, action_id, template_arg, args):
+    return cg.new_Pvariable(action_id, template_arg)
+
+
+@automation.register_action("ble.disable", BLEDisableAction, cv.Schema({}))
+async def ble_disable_to_code(config, action_id, template_arg, args):
+    return cg.new_Pvariable(action_id, template_arg)

--- a/esphome/components/esp32_ble/ble.cpp
+++ b/esphome/components/esp32_ble/ble.cpp
@@ -68,10 +68,12 @@ void ESP32BLE::disable() {
   }
 }
 
-bool ESP32BLE::is_disabled() { return this->state_ == BLE_COMPONENT_STATE_DISABLED; }
+bool ESP32BLE::is_active() { return this->state_ == BLE_COMPONENT_STATE_ACTIVE; }
 
 void ESP32BLE::advertising_start() {
   this->advertising_init_();
+  if (!this->is_active())
+    return;
   // TODO: Test if it works disabled
   this->advertising_->start();
 }

--- a/esphome/components/esp32_ble/ble.cpp
+++ b/esphome/components/esp32_ble/ble.cpp
@@ -44,7 +44,7 @@ void ESP32BLE::enable() {
 
   ESP_LOGD(TAG, "Enabling BLE...");
   this->state_ = BLE_COMPONENT_STATE_OFF;
-  
+
   if (!ble_setup_()) {
     ESP_LOGE(TAG, "BLE could not be set up");
     this->mark_failed();
@@ -233,24 +233,24 @@ bool ESP32BLE::ble_dismantle_() {
     return false;
   }
 
-  #ifdef USE_ARDUINO
+#ifdef USE_ARDUINO
   if (!btStop()) {
     ESP_LOGE(TAG, "btStop failed: %d", esp_bt_controller_get_status());
     return false;
   }
 #else
-  if(esp_bt_controller_get_status() != ESP_BT_CONTROLLER_STATUS_IDLE) {
+  if (esp_bt_controller_get_status() != ESP_BT_CONTROLLER_STATUS_IDLE) {
     // stop bt controller
-    if(esp_bt_controller_get_status() == ESP_BT_CONTROLLER_STATUS_ENABLED) {
+    if (esp_bt_controller_get_status() == ESP_BT_CONTROLLER_STATUS_ENABLED) {
       err = esp_bt_controller_disable();
       if (err != ESP_OK) {
         ESP_LOGE(TAG, "esp_bt_controller_disable failed: %s", esp_err_to_name(err));
         return false;
       }
-      while(esp_bt_controller_get_status() == ESP_BT_CONTROLLER_STATUS_ENABLED)
+      while (esp_bt_controller_get_status() == ESP_BT_CONTROLLER_STATUS_ENABLED)
         ;
     }
-    if(esp_bt_controller_get_status() == ESP_BT_CONTROLLER_STATUS_INITED) {
+    if (esp_bt_controller_get_status() == ESP_BT_CONTROLLER_STATUS_INITED) {
       err = esp_bt_controller_deinit();
       if (err != ESP_OK) {
         ESP_LOGE(TAG, "esp_bt_controller_deinit failed: %s", esp_err_to_name(err));

--- a/esphome/components/esp32_ble/ble.cpp
+++ b/esphome/components/esp32_ble/ble.cpp
@@ -52,6 +52,10 @@ void ESP32BLE::enable() {
   }
 
   this->state_ = BLE_COMPONENT_STATE_ACTIVE;
+
+  for (auto *ble_event_handler : this->ble_status_event_handlers_) {
+    ble_event_handler->on_ble_enabled();
+  }
 }
 
 void ESP32BLE::disable() {
@@ -60,6 +64,10 @@ void ESP32BLE::disable() {
 
   ESP_LOGD(TAG, "Disabling BLE...");
   this->state_ = BLE_COMPONENT_STATE_DISABLED;
+
+  for (auto *ble_event_handler : this->ble_status_event_handlers_) {
+    ble_event_handler->on_ble_disabled();
+  }
 
   if (!ble_dismantle_()) {
     ESP_LOGE(TAG, "BLE could not be dismantled");

--- a/esphome/components/esp32_ble/ble.cpp
+++ b/esphome/components/esp32_ble/ble.cpp
@@ -78,7 +78,6 @@ void ESP32BLE::advertising_start() {
   this->advertising_init_();
   if (!this->is_active())
     return;
-  // TODO: Test if it works disabled
   this->advertising_->start();
 }
 

--- a/esphome/components/esp32_ble/ble.cpp
+++ b/esphome/components/esp32_ble/ble.cpp
@@ -267,33 +267,28 @@ bool ESP32BLE::ble_dismantle_() {
 }
 
 void ESP32BLE::loop() {
-  switch (this->state_) {
-    case BLE_COMPONENT_STATE_ACTIVE: {
-      BLEEvent *ble_event = this->ble_events_.pop();
-      while (ble_event != nullptr) {
-        switch (ble_event->type_) {
-          case BLEEvent::GATTS:
-            this->real_gatts_event_handler_(ble_event->event_.gatts.gatts_event, ble_event->event_.gatts.gatts_if,
-                                            &ble_event->event_.gatts.gatts_param);
-            break;
-          case BLEEvent::GATTC:
-            this->real_gattc_event_handler_(ble_event->event_.gattc.gattc_event, ble_event->event_.gattc.gattc_if,
-                                            &ble_event->event_.gattc.gattc_param);
-            break;
-          case BLEEvent::GAP:
-            this->real_gap_event_handler_(ble_event->event_.gap.gap_event, &ble_event->event_.gap.gap_param);
-            break;
-          default:
-            break;
-        }
-        delete ble_event;  // NOLINT(cppcoreguidelines-owning-memory)
-        ble_event = this->ble_events_.pop();
-      }
-      break;
+  if (!this->is_active()) {
+    return;
+  }
+  BLEEvent *ble_event = this->ble_events_.pop();
+  while (ble_event != nullptr) {
+    switch (ble_event->type_) {
+      case BLEEvent::GATTS:
+        this->real_gatts_event_handler_(ble_event->event_.gatts.gatts_event, ble_event->event_.gatts.gatts_if,
+                                        &ble_event->event_.gatts.gatts_param);
+        break;
+      case BLEEvent::GATTC:
+        this->real_gattc_event_handler_(ble_event->event_.gattc.gattc_event, ble_event->event_.gattc.gattc_if,
+                                        &ble_event->event_.gattc.gattc_param);
+        break;
+      case BLEEvent::GAP:
+        this->real_gap_event_handler_(ble_event->event_.gap.gap_event, &ble_event->event_.gap.gap_param);
+        break;
+      default:
+        break;
     }
-    case BLE_COMPONENT_STATE_DISABLED:
-    case BLE_COMPONENT_STATE_OFF:
-      return;
+    delete ble_event;  // NOLINT(cppcoreguidelines-owning-memory)
+    ble_event = this->ble_events_.pop();
   }
 }
 

--- a/esphome/components/esp32_ble/ble.cpp
+++ b/esphome/components/esp32_ble/ble.cpp
@@ -52,10 +52,6 @@ void ESP32BLE::enable() {
   }
 
   this->state_ = BLE_COMPONENT_STATE_ACTIVE;
-
-  for (auto *ble_event_handler : this->ble_status_event_handlers_) {
-    ble_event_handler->on_ble_enabled();
-  }
 }
 
 void ESP32BLE::disable() {
@@ -66,7 +62,7 @@ void ESP32BLE::disable() {
   this->state_ = BLE_COMPONENT_STATE_DISABLED;
 
   for (auto *ble_event_handler : this->ble_status_event_handlers_) {
-    ble_event_handler->on_ble_disabled();
+    ble_event_handler->on_ble_before_disabled();
   }
 
   if (!ble_dismantle_()) {

--- a/esphome/components/esp32_ble/ble.cpp
+++ b/esphome/components/esp32_ble/ble.cpp
@@ -62,7 +62,7 @@ void ESP32BLE::disable() {
   this->state_ = BLE_COMPONENT_STATE_DISABLED;
 
   for (auto *ble_event_handler : this->ble_status_event_handlers_) {
-    ble_event_handler->on_ble_before_disabled();
+    ble_event_handler->ble_before_disabled_event_handler();
   }
 
   if (!ble_dismantle_()) {

--- a/esphome/components/esp32_ble/ble.h
+++ b/esphome/components/esp32_ble/ble.h
@@ -69,7 +69,7 @@ class ESP32BLE : public Component {
 
   void enable();
   void disable();
-  bool is_disabled();
+  bool is_active();
   void setup() override;
   void loop() override;
   void dump_config() override;
@@ -116,7 +116,7 @@ extern ESP32BLE *global_ble;
 
 template<typename... Ts> class BLEEnabledCondition : public Condition<Ts...> {
  public:
-  bool check(Ts... x) override { return !global_ble->is_disabled(); }
+  bool check(Ts... x) override { return global_ble->is_active(); }
 };
 
 template<typename... Ts> class BLEEnableAction : public Action<Ts...> {

--- a/esphome/components/esp32_ble/ble.h
+++ b/esphome/components/esp32_ble/ble.h
@@ -3,19 +3,19 @@
 #include "ble_advertising.h"
 #include "ble_uuid.h"
 
+#include "esphome/core/automation.h"
 #include "esphome/core/component.h"
 #include "esphome/core/defines.h"
-#include "esphome/core/automation.h"
 #include "esphome/core/helpers.h"
 
-#include "queue.h"
 #include "ble_event.h"
+#include "queue.h"
 
 #ifdef USE_ESP32
 
 #include <esp_gap_ble_api.h>
-#include <esp_gatts_api.h>
 #include <esp_gattc_api.h>
+#include <esp_gatts_api.h>
 
 namespace esphome {
 namespace esp32_ble {
@@ -40,8 +40,12 @@ enum IoCapability {
 enum BLEComponentState {
   /** Nothing has been initialized yet. */
   BLE_COMPONENT_STATE_OFF = 0,
+  /** BLE should be disabled on next loop. */
+  BLE_COMPONENT_STATE_DISABLE,
   /** BLE is disabled. */
   BLE_COMPONENT_STATE_DISABLED,
+  /** BLE should be enabled on next loop. */
+  BLE_COMPONENT_STATE_ENABLE,
   /** BLE is active. */
   BLE_COMPONENT_STATE_ACTIVE,
 };

--- a/esphome/components/esp32_ble/ble.h
+++ b/esphome/components/esp32_ble/ble.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "ble_advertising.h"
+#include "ble_uuid.h"
 
 #include "esphome/core/component.h"
 #include "esphome/core/defines.h"
@@ -74,7 +75,11 @@ class ESP32BLE : public Component {
   void dump_config() override;
   float get_setup_priority() const override;
 
-  BLEAdvertising *get_advertising() { return this->advertising_; }
+  void advertising_start();
+  void advertising_set_service_data(const std::vector<uint8_t> &data);
+  void advertising_set_manufacturer_data(const std::vector<uint8_t> &data);
+  void advertising_add_service_uuid(ESPBTUUID uuid);
+  void advertising_remove_service_uuid(ESPBTUUID uuid);
 
   void register_gap_event_handler(GAPEventHandler *handler) { this->gap_event_handlers_.push_back(handler); }
   void register_gattc_event_handler(GATTcEventHandler *handler) { this->gattc_event_handlers_.push_back(handler); }
@@ -93,6 +98,7 @@ class ESP32BLE : public Component {
   bool ble_setup_();
   bool ble_dismantle_();
   bool ble_pre_setup_();
+  void advertising_init_();
 
   std::vector<GAPEventHandler *> gap_event_handlers_;
   std::vector<GATTcEventHandler *> gattc_event_handlers_;

--- a/esphome/components/esp32_ble/ble.h
+++ b/esphome/components/esp32_ble/ble.h
@@ -64,8 +64,8 @@ class GATTsEventHandler {
 };
 
 class BLEStatusEventHandler {
-  public:
-    virtual void on_ble_before_disabled() = 0;
+ public:
+  virtual void on_ble_before_disabled() = 0;
 };
 
 class ESP32BLE : public Component {
@@ -89,7 +89,9 @@ class ESP32BLE : public Component {
   void register_gap_event_handler(GAPEventHandler *handler) { this->gap_event_handlers_.push_back(handler); }
   void register_gattc_event_handler(GATTcEventHandler *handler) { this->gattc_event_handlers_.push_back(handler); }
   void register_gatts_event_handler(GATTsEventHandler *handler) { this->gatts_event_handlers_.push_back(handler); }
-  void register_ble_status_event_handler(BLEStatusEventHandler *handler) { this->ble_status_event_handlers_.push_back(handler); }
+  void register_ble_status_event_handler(BLEStatusEventHandler *handler) {
+    this->ble_status_event_handlers_.push_back(handler);
+  }
   void set_enable_on_boot(bool enable_on_boot) { this->enable_on_boot_ = enable_on_boot; }
 
  protected:

--- a/esphome/components/esp32_ble/ble.h
+++ b/esphome/components/esp32_ble/ble.h
@@ -65,8 +65,7 @@ class GATTsEventHandler {
 
 class BLEStatusEventHandler {
   public:
-    virtual void on_ble_enabled() = 0;
-    virtual void on_ble_disabled() = 0;
+    virtual void on_ble_before_disabled() = 0;
 };
 
 class ESP32BLE : public Component {

--- a/esphome/components/esp32_ble/ble.h
+++ b/esphome/components/esp32_ble/ble.h
@@ -63,6 +63,12 @@ class GATTsEventHandler {
                                    esp_ble_gatts_cb_param_t *param) = 0;
 };
 
+class BLEStatusEventHandler {
+  public:
+    virtual void on_ble_enabled() = 0;
+    virtual void on_ble_disabled() = 0;
+};
+
 class ESP32BLE : public Component {
  public:
   void set_io_capability(IoCapability io_capability) { this->io_cap_ = (esp_ble_io_cap_t) io_capability; }
@@ -84,6 +90,7 @@ class ESP32BLE : public Component {
   void register_gap_event_handler(GAPEventHandler *handler) { this->gap_event_handlers_.push_back(handler); }
   void register_gattc_event_handler(GATTcEventHandler *handler) { this->gattc_event_handlers_.push_back(handler); }
   void register_gatts_event_handler(GATTsEventHandler *handler) { this->gatts_event_handlers_.push_back(handler); }
+  void register_ble_status_event_handler(BLEStatusEventHandler *handler) { this->ble_status_event_handlers_.push_back(handler); }
   void set_enable_on_boot(bool enable_on_boot) { this->enable_on_boot_ = enable_on_boot; }
 
  protected:
@@ -103,6 +110,7 @@ class ESP32BLE : public Component {
   std::vector<GAPEventHandler *> gap_event_handlers_;
   std::vector<GATTcEventHandler *> gattc_event_handlers_;
   std::vector<GATTsEventHandler *> gatts_event_handlers_;
+  std::vector<BLEStatusEventHandler *> ble_status_event_handlers_;
   BLEComponentState state_{BLE_COMPONENT_STATE_OFF};
 
   Queue<BLEEvent> ble_events_;

--- a/esphome/components/esp32_ble/ble.h
+++ b/esphome/components/esp32_ble/ble.h
@@ -4,6 +4,7 @@
 
 #include "esphome/core/component.h"
 #include "esphome/core/defines.h"
+#include "esphome/core/automation.h"
 #include "esphome/core/helpers.h"
 
 #include "queue.h"
@@ -35,6 +36,15 @@ enum IoCapability {
   IO_CAP_KBDISP = ESP_IO_CAP_KBDISP,
 };
 
+enum BLEComponentState {
+  /** Nothing has been initialized yet. */
+  BLE_COMPONENT_STATE_OFF = 0,
+  /** BLE is disabled. */
+  BLE_COMPONENT_STATE_DISABLED,
+  /** BLE is active. */
+  BLE_COMPONENT_STATE_ACTIVE,
+};
+
 class GAPEventHandler {
  public:
   virtual void gap_event_handler(esp_gap_ble_cb_event_t event, esp_ble_gap_cb_param_t *param) = 0;
@@ -56,6 +66,9 @@ class ESP32BLE : public Component {
  public:
   void set_io_capability(IoCapability io_capability) { this->io_cap_ = (esp_ble_io_cap_t) io_capability; }
 
+  void enable();
+  void disable();
+  bool is_disabled();
   void setup() override;
   void loop() override;
   void dump_config() override;
@@ -66,6 +79,7 @@ class ESP32BLE : public Component {
   void register_gap_event_handler(GAPEventHandler *handler) { this->gap_event_handlers_.push_back(handler); }
   void register_gattc_event_handler(GATTcEventHandler *handler) { this->gattc_event_handlers_.push_back(handler); }
   void register_gatts_event_handler(GATTsEventHandler *handler) { this->gatts_event_handlers_.push_back(handler); }
+  void set_enable_on_boot(bool enable_on_boot) { this->enable_on_boot_ = enable_on_boot; }
 
  protected:
   static void gatts_event_handler(esp_gatts_cb_event_t event, esp_gatt_if_t gatts_if, esp_ble_gatts_cb_param_t *param);
@@ -77,18 +91,37 @@ class ESP32BLE : public Component {
   void real_gap_event_handler_(esp_gap_ble_cb_event_t event, esp_ble_gap_cb_param_t *param);
 
   bool ble_setup_();
+  bool ble_dismantle_();
+  bool ble_pre_setup_();
 
   std::vector<GAPEventHandler *> gap_event_handlers_;
   std::vector<GATTcEventHandler *> gattc_event_handlers_;
   std::vector<GATTsEventHandler *> gatts_event_handlers_;
+  BLEComponentState state_{BLE_COMPONENT_STATE_OFF};
 
   Queue<BLEEvent> ble_events_;
   BLEAdvertising *advertising_;
   esp_ble_io_cap_t io_cap_{ESP_IO_CAP_NONE};
+  bool enable_on_boot_;
 };
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 extern ESP32BLE *global_ble;
+
+template<typename... Ts> class BLEEnabledCondition : public Condition<Ts...> {
+ public:
+  bool check(Ts... x) override { return !global_ble->is_disabled(); }
+};
+
+template<typename... Ts> class BLEEnableAction : public Action<Ts...> {
+ public:
+  void play(Ts... x) override { global_ble->enable(); }
+};
+
+template<typename... Ts> class BLEDisableAction : public Action<Ts...> {
+ public:
+  void play(Ts... x) override { global_ble->disable(); }
+};
 
 }  // namespace esp32_ble
 }  // namespace esphome

--- a/esphome/components/esp32_ble/ble.h
+++ b/esphome/components/esp32_ble/ble.h
@@ -65,7 +65,7 @@ class GATTsEventHandler {
 
 class BLEStatusEventHandler {
  public:
-  virtual void on_ble_before_disabled() = 0;
+  virtual void ble_before_disabled_event_handler() = 0;
 };
 
 class ESP32BLE : public Component {

--- a/esphome/components/esp32_ble_server/__init__.py
+++ b/esphome/components/esp32_ble_server/__init__.py
@@ -6,7 +6,7 @@ from esphome.core import CORE
 from esphome.components.esp32 import add_idf_sdkconfig_option
 
 AUTO_LOAD = ["esp32_ble"]
-CODEOWNERS = ["@jesserockz", "@clydebarrow"]
+CODEOWNERS = ["@jesserockz", "@clydebarrow", "@Rapsssito"]
 CONFLICTS_WITH = ["esp32_ble_beacon"]
 DEPENDENCIES = ["esp32"]
 

--- a/esphome/components/esp32_ble_server/__init__.py
+++ b/esphome/components/esp32_ble_server/__init__.py
@@ -41,6 +41,7 @@ async def to_code(config):
 
     parent = await cg.get_variable(config[esp32_ble.CONF_BLE_ID])
     cg.add(parent.register_gatts_event_handler(var))
+    cg.add(parent.register_ble_status_event_handler(var))
     cg.add(var.set_parent(parent))
 
     cg.add(var.set_manufacturer(config[CONF_MANUFACTURER]))

--- a/esphome/components/esp32_ble_server/ble_characteristic.cpp
+++ b/esphome/components/esp32_ble_server/ble_characteristic.cpp
@@ -13,7 +13,7 @@ static const char *const TAG = "esp32_ble_server.characteristic";
 
 BLECharacteristic::~BLECharacteristic() {
   for (auto *descriptor : this->descriptors_) {
-    delete descriptor;
+    delete descriptor;  // NOLINT(cppcoreguidelines-owning-memory)
   }
   vSemaphoreDelete(this->set_value_lock_);
 }

--- a/esphome/components/esp32_ble_server/ble_characteristic.cpp
+++ b/esphome/components/esp32_ble_server/ble_characteristic.cpp
@@ -11,6 +11,13 @@ namespace esp32_ble_server {
 
 static const char *const TAG = "esp32_ble_server.characteristic";
 
+BLECharacteristic::~BLECharacteristic() {
+  for (auto *descriptor : this->descriptors_) {
+    delete descriptor;
+  }
+  vSemaphoreDelete(this->set_value_lock_);
+}
+
 BLECharacteristic::BLECharacteristic(const ESPBTUUID uuid, uint32_t properties) : uuid_(uuid) {
   this->set_value_lock_ = xSemaphoreCreateBinary();
   xSemaphoreGive(this->set_value_lock_);
@@ -97,6 +104,11 @@ void BLECharacteristic::notify(bool notification) {
 }
 
 void BLECharacteristic::add_descriptor(BLEDescriptor *descriptor) { this->descriptors_.push_back(descriptor); }
+
+void BLECharacteristic::remove_descriptor(BLEDescriptor *descriptor) {
+  this->descriptors_.erase(std::remove(this->descriptors_.begin(), this->descriptors_.end(), descriptor),
+                           this->descriptors_.end());
+}
 
 void BLECharacteristic::do_create(BLEService *service) {
   this->service_ = service;

--- a/esphome/components/esp32_ble_server/ble_characteristic.h
+++ b/esphome/components/esp32_ble_server/ble_characteristic.h
@@ -25,6 +25,7 @@ class BLEService;
 class BLECharacteristic {
  public:
   BLECharacteristic(ESPBTUUID uuid, uint32_t properties);
+  ~BLECharacteristic();
 
   void set_value(const uint8_t *data, size_t length);
   void set_value(std::vector<uint8_t> value);
@@ -52,6 +53,7 @@ class BLECharacteristic {
   void on_write(const std::function<void(const std::vector<uint8_t> &)> &&func) { this->on_write_ = func; }
 
   void add_descriptor(BLEDescriptor *descriptor);
+  void remove_descriptor(BLEDescriptor *descriptor);
 
   BLEService *get_service() { return this->service_; }
   ESPBTUUID get_uuid() { return this->uuid_; }

--- a/esphome/components/esp32_ble_server/ble_server.cpp
+++ b/esphome/components/esp32_ble_server/ble_server.cpp
@@ -59,7 +59,8 @@ void BLEServer::loop() {
         }
         if (this->device_information_service_ == nullptr) {
           this->create_service(ESPBTUUID::from_uint16(DEVICE_INFORMATION_SERVICE_UUID));
-          this->device_information_service_ = this->get_service(ESPBTUUID::from_uint16(DEVICE_INFORMATION_SERVICE_UUID));
+          this->device_information_service_ =
+              this->get_service(ESPBTUUID::from_uint16(DEVICE_INFORMATION_SERVICE_UUID));
           this->create_device_characteristics_();
         }
         this->state_ = STARTING_SERVICE;
@@ -82,13 +83,9 @@ void BLEServer::loop() {
   }
 }
 
-bool BLEServer::is_running() {
-  return this->parent_->is_active() && this->state_ == RUNNING;
-}
+bool BLEServer::is_running() { return this->parent_->is_active() && this->state_ == RUNNING; }
 
-bool BLEServer::can_proceed() {
-  return this->is_running() || !this->parent_->is_active();
-}
+bool BLEServer::can_proceed() { return this->is_running() || !this->parent_->is_active(); }
 
 void BLEServer::restart_advertising_() {
   if (this->is_running()) {
@@ -118,8 +115,7 @@ bool BLEServer::create_device_characteristics_() {
   return true;
 }
 
-void BLEServer::create_service(ESPBTUUID uuid, bool advertise, uint16_t num_handles,
-                                                      uint8_t inst_id) {
+void BLEServer::create_service(ESPBTUUID uuid, bool advertise, uint16_t num_handles, uint8_t inst_id) {
   ESP_LOGV(TAG, "Creating BLE service - %s", uuid.to_string().c_str());
   // If the service already exists, do nothing
   BLEService *service = this->get_service(uuid);

--- a/esphome/components/esp32_ble_server/ble_server.cpp
+++ b/esphome/components/esp32_ble_server/ble_server.cpp
@@ -123,7 +123,7 @@ void BLEServer::create_service(ESPBTUUID uuid, bool advertise, uint16_t num_hand
     ESP_LOGW(TAG, "BLE service %s already exists", uuid.to_string().c_str());
     return;
   }
-  service = new BLEService(uuid, num_handles, inst_id, advertise);
+  service = new BLEService(uuid, num_handles, inst_id, advertise);  // NOLINT(cppcoreguidelines-owning-memory)
   this->services_.emplace(uuid.to_string(), service);
   service->do_create(this);
 }
@@ -136,7 +136,7 @@ void BLEServer::remove_service(ESPBTUUID uuid) {
     return;
   }
   service->do_delete();
-  delete service;
+  delete service;  // NOLINT(cppcoreguidelines-owning-memory)
   this->services_.erase(uuid.to_string());
 }
 

--- a/esphome/components/esp32_ble_server/ble_server.cpp
+++ b/esphome/components/esp32_ble_server/ble_server.cpp
@@ -188,10 +188,7 @@ void BLEServer::gatts_event_handler(esp_gatts_cb_event_t event, esp_gatt_if_t ga
   }
 }
 
-void BLEServer::on_ble_enabled() {
-}
-
-void BLEServer::on_ble_disabled() {
+void BLEServer::on_ble_before_disabled() {
   // Delete all clients
   this->clients_.clear();
   // Delete all services

--- a/esphome/components/esp32_ble_server/ble_server.cpp
+++ b/esphome/components/esp32_ble_server/ble_server.cpp
@@ -94,8 +94,7 @@ bool BLEServer::can_proceed() {
 
 void BLEServer::restart_advertising_() {
   if (this->is_running()) {
-    esp32_ble::global_ble->get_advertising()->set_manufacturer_data(this->manufacturer_data_);
-    esp32_ble::global_ble->get_advertising()->start();
+    esp32_ble::global_ble->advertising_set_manufacturer_data(this->manufacturer_data_);
   }
 }
 
@@ -133,11 +132,8 @@ std::shared_ptr<BLEService> BLEServer::create_service(const std::string &uuid, b
 std::shared_ptr<BLEService> BLEServer::create_service(ESPBTUUID uuid, bool advertise, uint16_t num_handles,
                                                       uint8_t inst_id) {
   ESP_LOGV(TAG, "Creating service - %s", uuid.to_string().c_str());
-  std::shared_ptr<BLEService> service = std::make_shared<BLEService>(uuid, num_handles, inst_id);
+  std::shared_ptr<BLEService> service = std::make_shared<BLEService>(uuid, num_handles, inst_id, advertise);
   this->services_.emplace_back(service);
-  if (advertise) {
-    esp32_ble::global_ble->get_advertising()->add_service_uuid(uuid);
-  }
   service->do_create(this);
   return service;
 }
@@ -158,7 +154,7 @@ void BLEServer::gatts_event_handler(esp_gatts_cb_event_t event, esp_gatt_if_t ga
       ESP_LOGD(TAG, "BLE Client disconnected");
       if (this->remove_client_(param->disconnect.conn_id))
         this->connected_clients_--;
-      esp32_ble::global_ble->get_advertising()->start();
+      esp32_ble::global_ble->advertising_start();
       for (auto *component : this->service_components_) {
         component->on_client_disconnect();
       }

--- a/esphome/components/esp32_ble_server/ble_server.cpp
+++ b/esphome/components/esp32_ble_server/ble_server.cpp
@@ -89,7 +89,7 @@ bool BLEServer::can_proceed() { return this->is_running() || !this->parent_->is_
 
 void BLEServer::restart_advertising_() {
   if (this->is_running()) {
-    esp32_ble::global_ble->advertising_set_manufacturer_data(this->manufacturer_data_);
+    this->parent_->advertising_set_manufacturer_data(this->manufacturer_data_);
   }
 }
 
@@ -164,7 +164,7 @@ void BLEServer::gatts_event_handler(esp_gatts_cb_event_t event, esp_gatt_if_t ga
       ESP_LOGD(TAG, "BLE Client disconnected");
       if (this->remove_client_(param->disconnect.conn_id))
         this->connected_clients_--;
-      esp32_ble::global_ble->advertising_start();
+      this->parent_->advertising_start();
       for (auto *component : this->service_components_) {
         component->on_client_disconnect();
       }
@@ -184,7 +184,7 @@ void BLEServer::gatts_event_handler(esp_gatts_cb_event_t event, esp_gatt_if_t ga
   }
 }
 
-void BLEServer::on_ble_before_disabled() {
+void BLEServer::ble_before_disabled_event_handler() {
   // Delete all clients
   this->clients_.clear();
   // Delete all services

--- a/esphome/components/esp32_ble_server/ble_server.h
+++ b/esphome/components/esp32_ble_server/ble_server.h
@@ -62,8 +62,7 @@ class BLEServer : public Component, public GATTsEventHandler, public BLEStatusEv
   void gatts_event_handler(esp_gatts_cb_event_t event, esp_gatt_if_t gatts_if,
                            esp_ble_gatts_cb_param_t *param) override;
 
-  void on_ble_enabled() override;
-  void on_ble_disabled() override;
+  void on_ble_before_disabled() override;
 
   void register_service_component(BLEServiceComponent *component) { this->service_components_.push_back(component); }
 

--- a/esphome/components/esp32_ble_server/ble_server.h
+++ b/esphome/components/esp32_ble_server/ble_server.h
@@ -11,9 +11,9 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/preferences.h"
 
-#include <map>
 #include <memory>
 #include <vector>
+#include <unordered_map>
 
 #ifdef USE_ESP32
 
@@ -33,7 +33,7 @@ class BLEServiceComponent {
   virtual void stop();
 };
 
-class BLEServer : public Component, public GATTsEventHandler, public Parented<ESP32BLE> {
+class BLEServer : public Component, public GATTsEventHandler, public BLEStatusEventHandler, public Parented<ESP32BLE> {
  public:
   void setup() override;
   void loop() override;
@@ -51,29 +51,28 @@ class BLEServer : public Component, public GATTsEventHandler, public Parented<ES
     this->restart_advertising_();
   }
 
-  std::shared_ptr<BLEService> create_service(const uint8_t *uuid, bool advertise = false);
-  std::shared_ptr<BLEService> create_service(uint16_t uuid, bool advertise = false);
-  std::shared_ptr<BLEService> create_service(const std::string &uuid, bool advertise = false);
-  std::shared_ptr<BLEService> create_service(ESPBTUUID uuid, bool advertise = false, uint16_t num_handles = 15,
-                                             uint8_t inst_id = 0);
-  void delete_service(std::shared_ptr<BLEService> service);
+  void create_service(ESPBTUUID uuid, bool advertise = false, uint16_t num_handles = 15, uint8_t inst_id = 0);
+  void remove_service(ESPBTUUID uuid);
+  BLEService *get_service(ESPBTUUID uuid);
 
   esp_gatt_if_t get_gatts_if() { return this->gatts_if_; }
   uint32_t get_connected_client_count() { return this->connected_clients_; }
-  const std::map<uint16_t, void *> &get_clients() { return this->clients_; }
+  const std::unordered_map<uint16_t, void *> &get_clients() { return this->clients_; }
 
   void gatts_event_handler(esp_gatts_cb_event_t event, esp_gatt_if_t gatts_if,
                            esp_ble_gatts_cb_param_t *param) override;
+
+  void on_ble_enabled() override;
+  void on_ble_disabled() override;
 
   void register_service_component(BLEServiceComponent *component) { this->service_components_.push_back(component); }
 
  protected:
   bool create_device_characteristics_();
   void restart_advertising_();
-  void reset_();
 
   void add_client_(uint16_t conn_id, void *client) {
-    this->clients_.insert(std::pair<uint16_t, void *>(conn_id, client));
+    this->clients_.emplace(conn_id, client);
   }
   bool remove_client_(uint16_t conn_id) { return this->clients_.erase(conn_id) > 0; }
 
@@ -84,10 +83,9 @@ class BLEServer : public Component, public GATTsEventHandler, public Parented<ES
   bool registered_{false};
 
   uint32_t connected_clients_{0};
-  std::map<uint16_t, void *> clients_;
-
-  std::vector<std::shared_ptr<BLEService>> services_;
-  std::shared_ptr<BLEService> device_information_service_;
+  std::unordered_map<uint16_t, void *> clients_;
+  std::unordered_map<std::string, BLEService*> services_;
+  BLEService *device_information_service_;
 
   std::vector<BLEServiceComponent *> service_components_;
 

--- a/esphome/components/esp32_ble_server/ble_server.h
+++ b/esphome/components/esp32_ble_server/ble_server.h
@@ -62,7 +62,7 @@ class BLEServer : public Component, public GATTsEventHandler, public BLEStatusEv
   void gatts_event_handler(esp_gatts_cb_event_t event, esp_gatt_if_t gatts_if,
                            esp_ble_gatts_cb_param_t *param) override;
 
-  void on_ble_before_disabled() override;
+  void ble_before_disabled_event_handler() override;
 
   void register_service_component(BLEServiceComponent *component) { this->service_components_.push_back(component); }
 

--- a/esphome/components/esp32_ble_server/ble_server.h
+++ b/esphome/components/esp32_ble_server/ble_server.h
@@ -70,9 +70,7 @@ class BLEServer : public Component, public GATTsEventHandler, public BLEStatusEv
   bool create_device_characteristics_();
   void restart_advertising_();
 
-  void add_client_(uint16_t conn_id, void *client) {
-    this->clients_.emplace(conn_id, client);
-  }
+  void add_client_(uint16_t conn_id, void *client) { this->clients_.emplace(conn_id, client); }
   bool remove_client_(uint16_t conn_id) { return this->clients_.erase(conn_id) > 0; }
 
   std::string manufacturer_;
@@ -83,7 +81,7 @@ class BLEServer : public Component, public GATTsEventHandler, public BLEStatusEv
 
   uint32_t connected_clients_{0};
   std::unordered_map<uint16_t, void *> clients_;
-  std::unordered_map<std::string, BLEService*> services_;
+  std::unordered_map<std::string, BLEService *> services_;
   BLEService *device_information_service_;
 
   std::vector<BLEServiceComponent *> service_components_;

--- a/esphome/components/esp32_ble_server/ble_server.h
+++ b/esphome/components/esp32_ble_server/ble_server.h
@@ -56,6 +56,7 @@ class BLEServer : public Component, public GATTsEventHandler, public Parented<ES
   std::shared_ptr<BLEService> create_service(const std::string &uuid, bool advertise = false);
   std::shared_ptr<BLEService> create_service(ESPBTUUID uuid, bool advertise = false, uint16_t num_handles = 15,
                                              uint8_t inst_id = 0);
+  void delete_service(std::shared_ptr<BLEService> service);
 
   esp_gatt_if_t get_gatts_if() { return this->gatts_if_; }
   uint32_t get_connected_client_count() { return this->connected_clients_; }
@@ -69,6 +70,7 @@ class BLEServer : public Component, public GATTsEventHandler, public Parented<ES
  protected:
   bool create_device_characteristics_();
   void restart_advertising_();
+  void reset_();
 
   void add_client_(uint16_t conn_id, void *client) {
     this->clients_.insert(std::pair<uint16_t, void *>(conn_id, client));

--- a/esphome/components/esp32_ble_server/ble_server.h
+++ b/esphome/components/esp32_ble_server/ble_server.h
@@ -39,9 +39,10 @@ class BLEServer : public Component, public GATTsEventHandler, public Parented<ES
   void loop() override;
   void dump_config() override;
   float get_setup_priority() const override;
-  bool can_proceed() override { return this->can_proceed_; }
+  bool can_proceed() override;
 
   void teardown();
+  bool is_running();
 
   void set_manufacturer(const std::string &manufacturer) { this->manufacturer_ = manufacturer; }
   void set_model(const std::string &model) { this->model_ = model; }
@@ -73,8 +74,6 @@ class BLEServer : public Component, public GATTsEventHandler, public Parented<ES
     this->clients_.insert(std::pair<uint16_t, void *>(conn_id, client));
   }
   bool remove_client_(uint16_t conn_id) { return this->clients_.erase(conn_id) > 0; }
-
-  bool can_proceed_{false};
 
   std::string manufacturer_;
   optional<std::string> model_;

--- a/esphome/components/esp32_ble_server/ble_service.cpp
+++ b/esphome/components/esp32_ble_server/ble_service.cpp
@@ -87,10 +87,12 @@ void BLEService::start() {
 }
 
 void BLEService::stop() {
-  esp_err_t err = esp_ble_gatts_stop_service(this->handle_);
-  if (err != ESP_OK) {
-    ESP_LOGE(TAG, "esp_ble_gatts_stop_service failed: %d", err);
-    return;
+  if (esp32_ble::global_ble->is_active()) {
+    esp_err_t err = esp_ble_gatts_stop_service(this->handle_);
+    if (err != ESP_OK) {
+      ESP_LOGE(TAG, "esp_ble_gatts_stop_service failed: %d", err);
+      return;
+    }
   }
   if (this->advertise_)
     esp32_ble::global_ble->advertising_remove_service_uuid(this->uuid_);

--- a/esphome/components/esp32_ble_server/ble_service.cpp
+++ b/esphome/components/esp32_ble_server/ble_service.cpp
@@ -9,8 +9,8 @@ namespace esp32_ble_server {
 
 static const char *const TAG = "esp32_ble_server.service";
 
-BLEService::BLEService(ESPBTUUID uuid, uint16_t num_handles, uint8_t inst_id)
-    : uuid_(uuid), num_handles_(num_handles), inst_id_(inst_id) {}
+BLEService::BLEService(ESPBTUUID uuid, uint16_t num_handles, uint8_t inst_id, bool advertise)
+    : uuid_(uuid), num_handles_(num_handles), inst_id_(inst_id), advertise_(advertise) {}
 
 BLEService::~BLEService() {
   for (auto &chr : this->characteristics_)
@@ -81,6 +81,8 @@ void BLEService::start() {
     ESP_LOGE(TAG, "esp_ble_gatts_start_service failed: %d", err);
     return;
   }
+  if (this->advertise_)
+    esp32_ble::global_ble->advertising_add_service_uuid(this->uuid_);
   this->running_state_ = STARTING;
 }
 
@@ -90,8 +92,8 @@ void BLEService::stop() {
     ESP_LOGE(TAG, "esp_ble_gatts_stop_service failed: %d", err);
     return;
   }
-  esp32_ble::global_ble->get_advertising()->remove_service_uuid(this->uuid_);
-  esp32_ble::global_ble->get_advertising()->start();
+  if (this->advertise_)
+    esp32_ble::global_ble->advertising_remove_service_uuid(this->uuid_);
   this->running_state_ = STOPPING;
 }
 

--- a/esphome/components/esp32_ble_server/ble_service.h
+++ b/esphome/components/esp32_ble_server/ble_service.h
@@ -38,6 +38,7 @@ class BLEService {
   BLEServer *get_server() { return this->server_; }
 
   void do_create(BLEServer *server);
+  void do_delete();
   void gatts_event_handler(esp_gatts_cb_event_t event, esp_gatt_if_t gatts_if, esp_ble_gatts_cb_param_t *param);
 
   void start();
@@ -59,6 +60,7 @@ class BLEService {
   uint16_t handle_{0xFFFF};
   uint8_t inst_id_;
   bool advertise_{false};
+  bool should_start_{false};
 
   bool do_create_characteristics_();
 
@@ -68,6 +70,7 @@ class BLEService {
     CREATING,
     CREATING_DEPENDENTS,
     CREATED,
+    DELETED,
   } init_state_{INIT};
 
   enum RunningState : uint8_t {

--- a/esphome/components/esp32_ble_server/ble_service.h
+++ b/esphome/components/esp32_ble_server/ble_service.h
@@ -22,7 +22,7 @@ using namespace esp32_ble;
 
 class BLEService {
  public:
-  BLEService(ESPBTUUID uuid, uint16_t num_handles, uint8_t inst_id);
+  BLEService(ESPBTUUID uuid, uint16_t num_handles, uint8_t inst_id, bool advertise);
   ~BLEService();
   BLECharacteristic *get_characteristic(ESPBTUUID uuid);
   BLECharacteristic *get_characteristic(uint16_t uuid);
@@ -58,6 +58,7 @@ class BLEService {
   uint16_t num_handles_;
   uint16_t handle_{0xFFFF};
   uint8_t inst_id_;
+  bool advertise_{false};
 
   bool do_create_characteristics_();
 

--- a/esphome/components/esp32_ble_server/ble_service.h
+++ b/esphome/components/esp32_ble_server/ble_service.h
@@ -49,6 +49,7 @@ class BLEService {
 
   bool is_running() { return this->running_state_ == RUNNING; }
   bool is_starting() { return this->running_state_ == STARTING; }
+  bool is_deleted() { return this->init_state_ == DELETED; }
 
  protected:
   std::vector<BLECharacteristic *> characteristics_;
@@ -63,6 +64,7 @@ class BLEService {
   bool should_start_{false};
 
   bool do_create_characteristics_();
+  void stop_();
 
   enum InitState : uint8_t {
     FAILED = 0x00,
@@ -70,6 +72,7 @@ class BLEService {
     CREATING,
     CREATING_DEPENDENTS,
     CREATED,
+    DELETING,
     DELETED,
   } init_state_{INIT};
 

--- a/esphome/components/esp32_ble_tracker/__init__.py
+++ b/esphome/components/esp32_ble_tracker/__init__.py
@@ -212,6 +212,7 @@ async def to_code(config):
     parent = await cg.get_variable(config[esp32_ble.CONF_BLE_ID])
     cg.add(parent.register_gap_event_handler(var))
     cg.add(parent.register_gattc_event_handler(var))
+    cg.add(parent.register_ble_status_event_handler(var))
     cg.add(var.set_parent(parent))
 
     params = config[CONF_SCAN_PARAMETERS]

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
@@ -64,17 +64,19 @@ void ESP32BLETracker::setup() {
     }
   });
 #endif
-
-  if (this->scan_continuous_) {
-    if (xSemaphoreTake(this->scan_end_lock_, 0L)) {
-      this->start_scan_(true);
-    } else {
-      ESP_LOGW(TAG, "Cannot start scan!");
-    }
-  }
 }
 
 void ESP32BLETracker::loop() {
+  if (!this->parent_->is_active()) {
+    this->ble_was_disabled_ = true;
+    return;
+  } else if (this->ble_was_disabled_) {
+    this->ble_was_disabled_ = false;
+    // If the BLE stack was disabled, we need to start the scan again.
+    if (this->scan_continuous_) {
+      this->start_scan();
+    }
+  }
   int connecting = 0;
   int discovered = 0;
   int searching = 0;
@@ -233,8 +235,16 @@ void ESP32BLETracker::stop_scan() {
   this->stop_scan_();
 }
 
+void ESP32BLETracker::ble_before_disabled_event_handler() {
+  this->stop_scan_();
+  xSemaphoreGive(this->scan_end_lock_);
+}
+
 void ESP32BLETracker::stop_scan_() {
   this->cancel_timeout("scan");
+  if (this->scanner_idle_) {
+    return;
+  }
   esp_err_t err = esp_ble_gap_stop_scanning();
   if (err != ESP_OK) {
     ESP_LOGE(TAG, "esp_ble_gap_stop_scanning failed: %d", err);
@@ -243,6 +253,10 @@ void ESP32BLETracker::stop_scan_() {
 }
 
 void ESP32BLETracker::start_scan_(bool first) {
+  if (!this->parent_->is_active()) {
+    ESP_LOGW(TAG, "Cannot start scan while ESP32BLE is disabled.");
+    return;
+  }
   // The lock must be held when calling this function.
   if (xSemaphoreTake(this->scan_end_lock_, 0L)) {
     ESP_LOGE(TAG, "start_scan called without holding scan_end_lock_");
@@ -255,7 +269,6 @@ void ESP32BLETracker::start_scan_(bool first) {
       listener->on_scan_end();
   }
   this->already_discovered_.clear();
-  this->scanner_idle_ = false;
   this->scan_params_.scan_type = this->scan_active_ ? BLE_SCAN_TYPE_ACTIVE : BLE_SCAN_TYPE_PASSIVE;
   this->scan_params_.own_addr_type = BLE_ADDR_TYPE_PUBLIC;
   this->scan_params_.scan_filter_policy = BLE_SCAN_FILTER_ALLOW_ALL;
@@ -272,6 +285,7 @@ void ESP32BLETracker::start_scan_(bool first) {
     ESP_LOGE(TAG, "esp_ble_gap_start_scanning failed: %d", err);
     return;
   }
+  this->scanner_idle_ = false;
 
   this->set_timeout("scan", this->scan_duration_ * 2000, []() {
     ESP_LOGE(TAG, "ESP-IDF BLE scan never terminated, rebooting to restore BLE stack...");

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
@@ -206,6 +206,7 @@ class ESP32BLETracker : public Component, public GAPEventHandler, public GATTcEv
   void gap_event_handler(esp_gap_ble_cb_event_t event, esp_ble_gap_cb_param_t *param) override;
 
  protected:
+  void stop_scan_();
   /// Start a single scan by setting up the parameters and doing some esp-idf calls.
   void start_scan_(bool first);
   /// Called when a scan ends

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
@@ -177,7 +177,11 @@ class ESPBTClient : public ESPBTDeviceListener {
   ClientState state_;
 };
 
-class ESP32BLETracker : public Component, public GAPEventHandler, public GATTcEventHandler, public BLEStatusEventHandler, public Parented<ESP32BLE> {
+class ESP32BLETracker : public Component,
+                        public GAPEventHandler,
+                        public GATTcEventHandler,
+                        public BLEStatusEventHandler,
+                        public Parented<ESP32BLE> {
  public:
   void set_scan_duration(uint32_t scan_duration) { scan_duration_ = scan_duration; }
   void set_scan_interval(uint32_t scan_interval) { scan_interval_ = scan_interval; }

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
@@ -177,7 +177,7 @@ class ESPBTClient : public ESPBTDeviceListener {
   ClientState state_;
 };
 
-class ESP32BLETracker : public Component, public GAPEventHandler, public GATTcEventHandler, public Parented<ESP32BLE> {
+class ESP32BLETracker : public Component, public GAPEventHandler, public GATTcEventHandler, public BLEStatusEventHandler, public Parented<ESP32BLE> {
  public:
   void set_scan_duration(uint32_t scan_duration) { scan_duration_ = scan_duration; }
   void set_scan_interval(uint32_t scan_interval) { scan_interval_ = scan_interval; }
@@ -204,6 +204,7 @@ class ESP32BLETracker : public Component, public GAPEventHandler, public GATTcEv
   void gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if,
                            esp_ble_gattc_cb_param_t *param) override;
   void gap_event_handler(esp_gap_ble_cb_event_t event, esp_ble_gap_cb_param_t *param) override;
+  void ble_before_disabled_event_handler() override;
 
  protected:
   void stop_scan_();
@@ -237,6 +238,7 @@ class ESP32BLETracker : public Component, public GAPEventHandler, public GATTcEv
   bool scan_continuous_;
   bool scan_active_;
   bool scanner_idle_;
+  bool ble_was_disabled_{true};
   bool raw_advertisements_{false};
   bool parse_advertisements_{false};
   SemaphoreHandle_t scan_result_lock_;

--- a/esphome/components/esp32_improv/__init__.py
+++ b/esphome/components/esp32_improv/__init__.py
@@ -5,7 +5,7 @@ from esphome.const import CONF_ID
 
 
 AUTO_LOAD = ["esp32_ble_server"]
-CODEOWNERS = ["@jesserockz"]
+CODEOWNERS = ["@jesserockz", "@Rapsssito"]
 CONFLICTS_WITH = ["esp32_ble_beacon"]
 DEPENDENCIES = ["wifi", "esp32"]
 

--- a/esphome/components/esp32_improv/__init__.py
+++ b/esphome/components/esp32_improv/__init__.py
@@ -5,7 +5,7 @@ from esphome.const import CONF_ID
 
 
 AUTO_LOAD = ["esp32_ble_server"]
-CODEOWNERS = ["@jesserockz", "@Rapsssito"]
+CODEOWNERS = ["@jesserockz"]
 CONFLICTS_WITH = ["esp32_ble_beacon"]
 DEPENDENCIES = ["wifi", "esp32"]
 

--- a/esphome/components/esp32_improv/esp32_improv_component.cpp
+++ b/esphome/components/esp32_improv/esp32_improv_component.cpp
@@ -63,12 +63,8 @@ void ESP32ImprovComponent::setup_characteristics() {
 }
 
 void ESP32ImprovComponent::loop() {
-  if (!global_ble_server->is_running()) {
-    this->state_ = improv::STATE_STOPPED;
-    this->setup_complete_ = false;
-    this->service_ = nullptr;
+  if (!global_ble_server->is_running())
     return;
-  }
   if (this->service_ == nullptr) {
     // Setup the service
     ESP_LOGD(TAG, "Creating Improv service");

--- a/esphome/components/esp32_improv/esp32_improv_component.cpp
+++ b/esphome/components/esp32_improv/esp32_improv_component.cpp
@@ -40,7 +40,11 @@ void ESP32ImprovComponent::setup_characteristics() {
   this->error_->add_descriptor(error_descriptor);
 
   this->rpc_ = this->service_->create_characteristic(improv::RPC_COMMAND_UUID, BLECharacteristic::PROPERTY_WRITE);
-  this->rpc_->on_write(ESP32ImprovComponent::rpc_on_write_);
+  this->rpc_->on_write([this](const std::vector<uint8_t> &data) {
+    if (!data.empty()) {
+      this->incoming_data_.insert(this->incoming_data_.end(), data.begin(), data.end());
+    }
+  });
   BLEDescriptor *rpc_descriptor = new BLE2902();
   this->rpc_->add_descriptor(rpc_descriptor);
 
@@ -180,16 +184,6 @@ bool ESP32ImprovComponent::check_identify_() {
     this->set_status_indicator_state_(time < 600 && time % 200 < 100);
   }
   return identify;
-}
-
-void ESP32ImprovComponent::rpc_on_write_(const std::vector<uint8_t> &data) {
-  global_improv_component->real_rpc_on_write_(data);
-}
-
-void ESP32ImprovComponent::real_rpc_on_write_(const std::vector<uint8_t> &data) {
-  if (data.empty())
-    return;
-  this->incoming_data_.insert(this->incoming_data_.end(), data.begin(), data.end());
 }
 
 void ESP32ImprovComponent::set_state_(improv::State state) {

--- a/esphome/components/esp32_improv/esp32_improv_component.cpp
+++ b/esphome/components/esp32_improv/esp32_improv_component.cpp
@@ -69,16 +69,17 @@ void ESP32ImprovComponent::setup_characteristics() {
 void ESP32ImprovComponent::loop() {
   if (!global_ble_server->is_running()) {
     this->state_ = improv::STATE_STOPPED;
-    // TODO: Do something with this->status_
+// TODO: Do something with this->status_
     this->setup_complete_ = false;
     if (this->service_ != nullptr) {
-      // TODO: Probably del this->service_
+// TODO: Probably del this->service_
       this->service_ = nullptr;
     }
     return;
   }
   if(this->service_ == nullptr) {
     // Setup the service
+    ESP_LOGD(TAG, "Creating Improv service");
     this->service_ = global_ble_server->create_service(improv::SERVICE_UUID, true);
     this->setup_characteristics();
   }

--- a/esphome/components/esp32_improv/esp32_improv_component.cpp
+++ b/esphome/components/esp32_improv/esp32_improv_component.cpp
@@ -93,7 +93,7 @@ void ESP32ImprovComponent::loop() {
 
       if (this->service_->is_created() && this->should_start_ && this->setup_complete_) {
         if (this->service_->is_running()) {
-          esp32_ble::global_ble->get_advertising()->start();
+          esp32_ble::global_ble->advertising_start();
 
           this->set_state_(improv::STATE_AWAITING_AUTHORIZATION);
           this->set_error_(improv::ERROR_NONE);
@@ -219,8 +219,7 @@ void ESP32ImprovComponent::set_state_(improv::State state) {
   service_data[6] = 0x00;  // Reserved
   service_data[7] = 0x00;  // Reserved
 
-  esp32_ble::global_ble->get_advertising()->set_service_data(service_data);
-  esp32_ble::global_ble->get_advertising()->start();
+  esp32_ble::global_ble->advertising_set_service_data(service_data);
 }
 
 void ESP32ImprovComponent::set_error_(improv::Error error) {

--- a/esphome/components/esp32_improv/esp32_improv_component.h
+++ b/esphome/components/esp32_improv/esp32_improv_component.h
@@ -71,7 +71,7 @@ class ESP32ImprovComponent : public Component, public BLEServiceComponent {
   std::vector<uint8_t> incoming_data_;
   wifi::WiFiAP connecting_sta_;
 
-  BLEService *service_;
+  BLEService *service_ = nullptr;
   BLECharacteristic *status_;
   BLECharacteristic *error_;
   BLECharacteristic *rpc_;

--- a/esphome/components/esp32_improv/esp32_improv_component.h
+++ b/esphome/components/esp32_improv/esp32_improv_component.h
@@ -55,6 +55,9 @@ class ESP32ImprovComponent : public Component, public BLEServiceComponent {
   uint32_t get_wifi_timeout() const { return this->wifi_timeout_; }
 
  protected:
+  static void rpc_on_write_(const std::vector<uint8_t> &data);
+  void real_rpc_on_write_(const std::vector<uint8_t> &data);
+
   bool should_start_{false};
   bool setup_complete_{false};
 
@@ -68,7 +71,7 @@ class ESP32ImprovComponent : public Component, public BLEServiceComponent {
   std::vector<uint8_t> incoming_data_;
   wifi::WiFiAP connecting_sta_;
 
-  std::shared_ptr<BLEService> service_;
+  BLEService *service_;
   BLECharacteristic *status_;
   BLECharacteristic *error_;
   BLECharacteristic *rpc_;

--- a/esphome/components/esp32_improv/esp32_improv_component.h
+++ b/esphome/components/esp32_improv/esp32_improv_component.h
@@ -55,9 +55,6 @@ class ESP32ImprovComponent : public Component, public BLEServiceComponent {
   uint32_t get_wifi_timeout() const { return this->wifi_timeout_; }
 
  protected:
-  static void rpc_on_write_(const std::vector<uint8_t> &data);
-  void real_rpc_on_write_(const std::vector<uint8_t> &data);
-
   bool should_start_{false};
   bool setup_complete_{false};
 

--- a/tests/test11.5.yaml
+++ b/tests/test11.5.yaml
@@ -104,6 +104,12 @@ binary_sensor:
     on_release:
       then:
         - switch.turn_off: Led0
+        - if:
+            condition: ble.enabled
+            then:
+              - ble.disable:
+            else:
+              - ble.enable:
 
   - platform: tm1638
     id: Button1
@@ -273,6 +279,7 @@ output:
 demo:
 
 esp32_ble:
+  enable_on_boot: false
 
 esp32_ble_server:
   manufacturer: ESPHome


### PR DESCRIPTION
# What does this implement/fix?

Adds `ble.enable` and `ble.disable` actions like the existing `wifi.enable` and `wifi.disable` (with the corresponding `ble.enabled` condition). Along with this, it adds the parameter `enable_on_boot` to the `esp32_ble` component to select if the service should start at boot or not.

Currently, the BLE controller, once it is setup, keeps running forever. This is far from desirable in projects with very high energy limitations. For example, `esp32_improv` turns on the BLE controller for a service that becomes useless once the device has connected to a WiFi network. The `ble.enable` and `ble.disable` actions will empower users to shutdown the whole BLE controller after it is not needed.

Updated components dependent on `esp32_ble`:
- [x] `esp32_improv` stack (i.e. including `esp32_ble_server`)
- [x] `esp32_ble_tracker`

_Note: I have noticed that "esp32_ble_beacon" shares a lot of code with "esp32_ble". It would be ideal if both components shared the same codebase so "esp32_ble_beacon" would also get these new features. An ideal solution will be creating a single BLE controller that abstracts all the BLE functionality from the rest of the components. That will also simplify the implementation of NimBLE (https://github.com/esphome/feature-requests/issues/810)_

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/feature-requests/issues/2418

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#3303

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

Tested in a ESP32-C3-WROOM-02 chip.

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
esphome:
  name: test-esp-enable
  friendly_name: test-esp-enable
  platformio_options:
    board_build.flash_mode: dio # Required for ESP-IDF framework
  on_boot:
    - priority: 260
      then:
        # Wait 5s before enabling BLE
        - delay: 5s
        - ble.enable:
        # Disable BLE to enable it again, just to test everything can ramp up again correctly
        - delay: 5s
        - ble.disable:
        - delay: 5s
        - ble.enable:

wifi:
  ssid: no_ssid
  password: no_password

esp32_ble:
  enable_on_boot: False

esp32_improv:
  authorizer: none
  wifi_timeout: 1s
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).
  - [x] The code does not generate memory leaks.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
