### PR TITLE
Fix bug when requesting italic gfonts

### DIFF
--- a/esphome/components/font/__init__.py
+++ b/esphome/components/font/__init__.py
@@ -137,7 +137,9 @@ def validate_weight_name(value):
 
 
 def download_gfonts(value):
-    name = f"{value[CONF_FAMILY]}:ital,wght@{int(value[CONF_ITALIC])},{value[CONF_WEIGHT]}"
+    name = (
+        f"{value[CONF_FAMILY]}:ital,wght@{int(value[CONF_ITALIC])},{value[CONF_WEIGHT]}"
+    )
     url = f"https://fonts.googleapis.com/css2?family={name}"
 
     path = _compute_gfonts_local_path(value)

--- a/esphome/components/font/__init__.py
+++ b/esphome/components/font/__init__.py
@@ -137,13 +137,7 @@ def validate_weight_name(value):
 
 
 def download_gfonts(value):
-    if value[CONF_ITALIC] and value[CONF_WEIGHT]:
-        spec = f":ital,wght@1,{value[CONF_WEIGHT]}"
-    elif value[CONF_WEIGHT]:
-        spec = f":wght@{value[CONF_WEIGHT]}"
-    else:
-        spec = ""
-    name = f"{value[CONF_FAMILY]}{spec}"
+    name = f"{value[CONF_FAMILY]}:ital,wght@{int(value[CONF_ITALIC])},{value[CONF_WEIGHT]}"
     url = f"https://fonts.googleapis.com/css2?family={name}"
 
     path = _compute_gfonts_local_path(value)

--- a/esphome/components/font/__init__.py
+++ b/esphome/components/font/__init__.py
@@ -137,11 +137,14 @@ def validate_weight_name(value):
 
 
 def download_gfonts(value):
-    wght = value[CONF_WEIGHT]
-    if value[CONF_ITALIC]:
-        wght = f"1,{wght}"
-    name = f"{value[CONF_FAMILY]}@{value[CONF_WEIGHT]}"
-    url = f"https://fonts.googleapis.com/css2?family={value[CONF_FAMILY]}:wght@{wght}"
+    if value[CONF_ITALIC] and value[CONF_WEIGHT]:
+        spec = f":ital,wght@1,{value[CONF_WEIGHT]}"
+    elif value[CONF_WEIGHT]:
+        spec = f":wght@{value[CONF_WEIGHT]}"
+    else:
+        spec = ""
+    name = f"{value[CONF_FAMILY]}{spec}"
+    url = f"https://fonts.googleapis.com/css2?family={name}"
 
     path = _compute_gfonts_local_path(value)
     if path.is_file():


### PR DESCRIPTION
# What does this implement/fix?

This fixes the missing left-hand side of the font spec. Currently an italic font will be requested as `<family>:wght@1,700` which fails with HTTP 400 "Invalid selector: Too many values in tuple" referring to the right-hand side. The correct selector would be `<family>:ital,wght@1,700`.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** n/a

## Test Environment

n/a, not hardware-specific.

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
```yaml
 font:
   - file:
       type: "gfonts"
       family: "Archivo+Narrow"
       weight: 500
     id: font_weight
     size: 30
   - file:
       type: "gfonts"
       family: "Archivo+Narrow"
       weight: 700
       italic: true
     id: font_weight_italic
     size: 30
   - file:
       type: "gfonts"
       family: "Archivo+Narrow"
       italic: true
     id: font_italic
     size: 30
   - file:
       type: "gfonts"
       family: "Archivo+Narrow"
     id: font_default
     size: 30
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
