### PR TITLE
Add connection triggers to api

### DIFF
--- a/esphome/components/api/api_connection.h
+++ b/esphome/components/api/api_connection.h
@@ -207,6 +207,8 @@ class APIConnection : public APIServerConnection {
   std::unique_ptr<APIFrameHelper> helper_;
 
   std::string client_info_;
+  std::string client_peername_;
+  std::string client_combined_info_;
   uint32_t client_api_version_major_{0};
   uint32_t client_api_version_minor_{0};
 #ifdef USE_ESP32_CAMERA

--- a/esphome/components/api/api_server.cpp
+++ b/esphome/components/api/api_server.cpp
@@ -111,6 +111,7 @@ void APIServer::loop() {
                                 [](const std::unique_ptr<APIConnection> &conn) { return !conn->remove_; });
   // print disconnection messages
   for (auto it = new_end; it != this->clients_.end(); ++it) {
+    this->client_disconnected_trigger_->trigger((*it)->client_info_, (*it)->client_peername_);
     ESP_LOGV(TAG, "Removing connection to %s", (*it)->client_info_.c_str());
   }
   // resize vector

--- a/esphome/components/api/api_server.h
+++ b/esphome/components/api/api_server.h
@@ -4,6 +4,7 @@
 #include "api_pb2.h"
 #include "api_pb2_service.h"
 #include "esphome/components/socket/socket.h"
+#include "esphome/core/automation.h"
 #include "esphome/core/component.h"
 #include "esphome/core/controller.h"
 #include "esphome/core/defines.h"
@@ -106,6 +107,11 @@ class APIServer : public Component, public Controller {
   const std::vector<HomeAssistantStateSubscription> &get_state_subs() const;
   const std::vector<UserServiceDescriptor *> &get_user_services() const { return this->user_services_; }
 
+  Trigger<std::string, std::string> *get_client_connected_trigger() const { return this->client_connected_trigger_; }
+  Trigger<std::string, std::string> *get_client_disconnected_trigger() const {
+    return this->client_disconnected_trigger_;
+  }
+
  protected:
   std::unique_ptr<socket::Socket> socket_ = nullptr;
   uint16_t port_{6053};
@@ -115,6 +121,8 @@ class APIServer : public Component, public Controller {
   std::string password_;
   std::vector<HomeAssistantStateSubscription> state_subs_;
   std::vector<UserServiceDescriptor *> user_services_;
+  Trigger<std::string, std::string> *client_connected_trigger_ = new Trigger<std::string, std::string>();
+  Trigger<std::string, std::string> *client_disconnected_trigger_ = new Trigger<std::string, std::string>();
 
 #ifdef USE_API_NOISE
   std::shared_ptr<APINoiseContext> noise_ctx_ = std::make_shared<APINoiseContext>();


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

This adds `on_client_connected` and `on_client_disconnected` triggers to the `api` server.

The `client_info` and `client_address` are provided to actions as `std::string` variables.

```yaml
api:
  on_client_connected:
    - logger.log:
        format: "Client %s connected to API with IP %s"
        args: ["client_info.c_str()", "client_address.c_str()"]

  on_client_disconnected:
    - logger.log:
        format: "Client %s disconnected from API with IP %s"
        args: ["client_info.c_str()", "client_address.c_str()"]
```


```
[13:34:38][D][api:102]: Accepted 10.1.1.162
[13:34:38][D][api.connection:1077]: Home Assistant 2023.11.0b1 (10.1.1.162): Connected successfully
[13:34:38][D][main:149]: Client Home Assistant 2023.11.0b1 connected to API with IP 10.1.1.162
[13:35:03][D][api.connection:176]: Home Assistant 2023.11.0b1 (10.1.1.162) requested disconnected
[13:35:03][D][main:154]: Client Home Assistant 2023.11.0b1 disconnected from API with IP 10.1.1.162
[13:35:03][D][api:102]: Accepted 10.1.1.162
[13:35:03][D][api.connection:1077]: Home Assistant 2023.11.0b1 (10.1.1.162): Connected successfully
[13:35:03][D][main:149]: Client Home Assistant 2023.11.0b1 connected to API with IP 10.1.1.162
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#3308

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
