### PR TITLE
Fix armv7 docker builds

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -47,7 +47,7 @@ RUN \
           libffi-dev=3.4.4-1 \
           cargo=0.66.0+ds1-1 \
           pkg-config=1.8.1-1; \
-          'gcc-arm*'; \
+          'gcc-arm-linux-gnueabihf'; \
     fi; \
     rm -rf \
         /tmp/* \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -43,7 +43,7 @@ RUN \
           zlib1g-dev=1:1.2.13.dfsg-1 \
           libjpeg-dev=1:2.1.5-2 \
           libfreetype-dev=2.12.1+dfsg-5 \
-          libssl-dev=3.0.11-1~deb12u1 \
+          libssl-dev=3.0.11-1~deb12u2 \
           libffi-dev=3.4.4-1 \
           cargo=0.66.0+ds1-1 \
           pkg-config=1.8.1-1; \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -47,7 +47,7 @@ RUN \
           libffi-dev=3.4.4-1 \
           cargo=0.66.0+ds1-1 \
           pkg-config=1.8.1-1; \
-          'gcc-arm-linux-gnueabihf'; \
+          gcc-arm-linux-gnueabihf=4:12.2.0-3; \
     fi; \
     rm -rf \
         /tmp/* \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -47,6 +47,7 @@ RUN \
           libffi-dev=3.4.4-1 \
           cargo=0.66.0+ds1-1 \
           pkg-config=1.8.1-1; \
+          'gcc-arm*'; \
     fi; \
     rm -rf \
         /tmp/* \


### PR DESCRIPTION
https://github.com/esphome/esphome/pull/5606 started failing 4 days ago due to the openssl security update

- fix the openssl version
- pin the compiler version so we get better errors in the future