### PR TITLE
ble_client rssi sensor fix when not connected

### DIFF
--- a/esphome/components/ble_client/sensor/ble_rssi_sensor.h
+++ b/esphome/components/ble_client/sensor/ble_rssi_sensor.h
@@ -1,9 +1,9 @@
 #pragma once
 
-#include "esphome/core/component.h"
 #include "esphome/components/ble_client/ble_client.h"
 #include "esphome/components/esp32_ble_tracker/esp32_ble_tracker.h"
 #include "esphome/components/sensor/sensor.h"
+#include "esphome/core/component.h"
 
 #ifdef USE_ESP32
 #include <esp_gattc_api.h>
@@ -24,6 +24,10 @@ class BLEClientRSSISensor : public sensor::Sensor, public PollingComponent, publ
 
   void gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if,
                            esp_ble_gattc_cb_param_t *param) override;
+
+ protected:
+  void get_rssi_();
+  bool should_update_{false};
 };
 
 }  // namespace ble_client


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

As reported in discord, if the client is not connected, the rssi sensor cannot update. This adds an extra boolean to fetch the rssi on next connection.

```
[12:26:01][I][ble_rssi_sensor:027]: [Button RSSI] Connected successfully!
[12:26:04][W][ble_rssi_sensor:063]: [Button RSSI] Cannot poll, not connected
[12:26:07][I][esp32_ble_client:196]: [0] [FF:FF:10:7E:9D:29] Connected
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
