### PR TITLE
Allow validation of pins based on hub config

### DIFF
--- a/esphome/components/pca6416a/__init__.py
+++ b/esphome/components/pca6416a/__init__.py
@@ -64,7 +64,7 @@ PCA6416A_PIN_SCHEMA = cv.All(
 )
 
 
-@pins.PIN_SCHEMA_REGISTRY.register("pca6416a", PCA6416A_PIN_SCHEMA)
+@pins.PIN_SCHEMA_REGISTRY.register(CONF_PCA6416A, PCA6416A_PIN_SCHEMA)
 async def pca6416a_pin_to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     parent = await cg.get_variable(config[CONF_PCA6416A])

--- a/esphome/components/pca9554/__init__.py
+++ b/esphome/components/pca9554/__init__.py
@@ -62,7 +62,7 @@ PCA9554_PIN_SCHEMA = cv.All(
 )
 
 
-@pins.PIN_SCHEMA_REGISTRY.register("pca9554", PCA9554_PIN_SCHEMA)
+@pins.PIN_SCHEMA_REGISTRY.register(CONF_PCA9554, PCA9554_PIN_SCHEMA)
 async def pca9554_pin_to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     parent = await cg.get_variable(config[CONF_PCA9554])

--- a/esphome/components/pcf8574/__init__.py
+++ b/esphome/components/pcf8574/__init__.py
@@ -65,7 +65,7 @@ PCF8574_PIN_SCHEMA = cv.All(
 )
 
 
-@pins.PIN_SCHEMA_REGISTRY.register("pcf8574", PCF8574_PIN_SCHEMA)
+@pins.PIN_SCHEMA_REGISTRY.register(CONF_PCF8574, PCF8574_PIN_SCHEMA)
 async def pcf8574_pin_to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     parent = await cg.get_variable(config[CONF_PCF8574])

--- a/esphome/components/sn74hc165/__init__.py
+++ b/esphome/components/sn74hc165/__init__.py
@@ -1,6 +1,5 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
-import esphome.final_validate as fv
 from esphome import pins
 from esphome.const import (
     CONF_ID,
@@ -78,20 +77,14 @@ SN74HC165_PIN_SCHEMA = cv.All(
 )
 
 
-def sn74hc165_pin_final_validate_schema(pin_config):
-    fconf = fv.full_config.get()
-    parent_path = fconf.get_path_for_id(pin_config[CONF_SN74HC165])[:-1]
-    parent_config = fconf.get_config_for_path(parent_path)
-
-    pin_path = fconf.get_path_for_id(pin_config[CONF_ID])[:-1]
-    with cv.prepend_path([cv.ROOT_CONFIG_PATH] + pin_path):
-        max_pins = parent_config[CONF_SR_COUNT] * 8
-        if pin_config[CONF_NUMBER] >= max_pins:
-            raise cv.Invalid(f"Pin number must be less than {max_pins}")
+def sn74hc165_pin_final_validate(pin_config, parent_config):
+    max_pins = parent_config[CONF_SR_COUNT] * 8
+    if pin_config[CONF_NUMBER] >= max_pins:
+        raise cv.Invalid(f"Pin number must be less than {max_pins}")
 
 
 @pins.PIN_SCHEMA_REGISTRY.register(
-    CONF_SN74HC165, SN74HC165_PIN_SCHEMA, sn74hc165_pin_final_validate_schema
+    CONF_SN74HC165, SN74HC165_PIN_SCHEMA, sn74hc165_pin_final_validate
 )
 async def sn74hc165_pin_to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])

--- a/esphome/config.py
+++ b/esphome/config.py
@@ -659,7 +659,7 @@ class FinalValidateValidationStep(ConfigValidationStep):
                 for key, entry in pins.PIN_SCHEMA_REGISTRY.items():
                     if key != CORE.target_platform and key in value:
                         if pin_final_validate := entry[2]:
-                            pin_final_validate(value)
+                            pin_final_validate(fv.full_config.get(), value)
 
         fv.full_config.reset(token)
 

--- a/esphome/config.py
+++ b/esphome/config.py
@@ -652,6 +652,24 @@ class FinalValidateValidationStep(ConfigValidationStep):
             if self.comp.final_validate_schema is not None:
                 self.comp.final_validate_schema(conf)
 
+            fconf = fv.full_config.get()
+
+            def _check_pins(c):
+                for value in c.values():
+                    if not isinstance(value, dict):
+                        continue
+                    for key, (
+                        _,
+                        _,
+                        pin_final_validate,
+                    ) in pins.PIN_SCHEMA_REGISTRY.items():
+                        if (
+                            key != CORE.target_platform
+                            and key in value
+                            and pin_final_validate is not None
+                        ):
+                            pin_final_validate(fconf, value)
+
             # Check for pin configs and a final_validate schema in the pin registry
             confs = conf
             if not isinstance(
@@ -660,17 +678,7 @@ class FinalValidateValidationStep(ConfigValidationStep):
                 confs = [conf]
             for c in confs:
                 if c:  # Some component have None or empty schemas
-                    for value in c.values():
-                        if not isinstance(value, dict):
-                            continue
-                        for key, (
-                            _,
-                            _,
-                            pin_final_validate,
-                        ) in pins.PIN_SCHEMA_REGISTRY.items():
-                            if key != CORE.target_platform and key in value:
-                                if pin_final_validate is not None:
-                                    pin_final_validate(fv.full_config.get(), value)
+                    _check_pins(c)
 
         fv.full_config.reset(token)
 

--- a/esphome/config.py
+++ b/esphome/config.py
@@ -653,13 +653,24 @@ class FinalValidateValidationStep(ConfigValidationStep):
                 self.comp.final_validate_schema(conf)
 
             # Check for pin configs and a final_validate schema in the pin registry
-            for value in conf.values():
-                if not isinstance(value, dict):
-                    continue
-                for key, (_, _, pin_final_validate) in pins.PIN_SCHEMA_REGISTRY.items():
-                    if key != CORE.target_platform and key in value:
-                        if pin_final_validate is not None:
-                            pin_final_validate(fv.full_config.get(), value)
+            confs = conf
+            if not isinstance(
+                confs, list
+            ):  # Handle components like SPI that have a list instead of MULTI_CONF
+                confs = [conf]
+            for c in confs:
+                if c:  # Some component have None or empty schemas
+                    for value in c.values():
+                        if not isinstance(value, dict):
+                            continue
+                        for key, (
+                            _,
+                            _,
+                            pin_final_validate,
+                        ) in pins.PIN_SCHEMA_REGISTRY.items():
+                            if key != CORE.target_platform and key in value:
+                                if pin_final_validate is not None:
+                                    pin_final_validate(fv.full_config.get(), value)
 
         fv.full_config.reset(token)
 

--- a/esphome/config.py
+++ b/esphome/config.py
@@ -656,9 +656,9 @@ class FinalValidateValidationStep(ConfigValidationStep):
             for value in conf.values():
                 if not isinstance(value, dict):
                     continue
-                for key, entry in pins.PIN_SCHEMA_REGISTRY.items():
+                for key, (_, _, pin_final_validate) in pins.PIN_SCHEMA_REGISTRY.items():
                     if key != CORE.target_platform and key in value:
-                        if pin_final_validate := entry[2]:
+                        if pin_final_validate is not None:
                             pin_final_validate(fv.full_config.get(), value)
 
         fv.full_config.reset(token)

--- a/esphome/cpp_helpers.py
+++ b/esphome/cpp_helpers.py
@@ -35,7 +35,7 @@ async def gpio_pin_expression(conf):
         return None
     from esphome import pins
 
-    for key, (func, _) in pins.PIN_SCHEMA_REGISTRY.items():
+    for key, (func, _, _) in pins.PIN_SCHEMA_REGISTRY.items():
         if key in conf:
             return await coroutine(func)(conf)
     return await coroutine(pins.PIN_SCHEMA_REGISTRY[CORE.target_platform][0])(conf)

--- a/esphome/pins.py
+++ b/esphome/pins.py
@@ -11,10 +11,10 @@ from esphome.const import (
     CONF_PULLUP,
     CONF_IGNORE_STRAPPING_WARNING,
 )
-from esphome.util import SimpleRegistry
+from esphome.util import PinRegistry
 from esphome.core import CORE
 
-PIN_SCHEMA_REGISTRY = SimpleRegistry()
+PIN_SCHEMA_REGISTRY = PinRegistry()
 
 
 def _set_mode(value, default_mode):

--- a/esphome/util.py
+++ b/esphome/util.py
@@ -57,6 +57,15 @@ class SimpleRegistry(dict):
         return decorator
 
 
+class PinRegistry(dict):
+    def register(self, name, schema, final_validate_schema=None):
+        def decorator(fun):
+            self[name] = (fun, schema, final_validate_schema)
+            return fun
+
+        return decorator
+
+
 def safe_print(message="", end="\n"):
     from esphome.core import CORE
 

--- a/esphome/util.py
+++ b/esphome/util.py
@@ -57,10 +57,26 @@ class SimpleRegistry(dict):
         return decorator
 
 
+def _final_validate(parent_id_key, fun):
+    def validator(fconf, pin_config):
+        import esphome.config_validation as cv
+
+        parent_path = fconf.get_path_for_id(pin_config[parent_id_key])[:-1]
+        parent_config = fconf.get_config_for_path(parent_path)
+
+        pin_path = fconf.get_path_for_id(pin_config[const.CONF_ID])[:-1]
+        with cv.prepend_path([cv.ROOT_CONFIG_PATH] + pin_path):
+            fun(pin_config, parent_config)
+
+    return validator
+
+
 class PinRegistry(dict):
-    def register(self, name, schema, final_validate_schema=None):
+    def register(self, name, schema, final_validate=None):
         def decorator(fun):
-            self[name] = (fun, schema, final_validate_schema)
+            if final_validate is not None:
+                fun = _final_validate(name, final_validate)
+            self[name] = (fun, schema, fun)
             return fun
 
         return decorator

--- a/esphome/util.py
+++ b/esphome/util.py
@@ -73,10 +73,11 @@ def _final_validate(parent_id_key, fun):
 
 class PinRegistry(dict):
     def register(self, name, schema, final_validate=None):
+        if final_validate is not None:
+            final_validate = _final_validate(name, final_validate)
+
         def decorator(fun):
-            if final_validate is not None:
-                fun = _final_validate(name, final_validate)
-            self[name] = (fun, schema, fun)
+            self[name] = (fun, schema, final_validate)
             return fun
 
         return decorator


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Until this, the following config would be valid even though pin 300 is never going to be valid.

```yaml
binary_sensor:
  - platform: gpio
    id: my_test_pin_id
    pin:
      number: 300
      sn74hc165: my_165

sn74hc165:
  id: my_165
  clock_pin: GPIO19
  load_pin: GPIO18
  data_pin: GPIO17
  sr_count: 20
```

With these changes, the pin schema gets an optional final validation function to test against the parent configuration.

```
Failed config

binary_sensor.gpio: [source config/test.yaml:63]
  platform: gpio
  id: my_test_pin_id
  
  Pin number must be less than 160.
  pin: 
    number: 300
    sn74hc165: my_165
    mode: 
      input: True
    inverted: False
  disabled_by_default: False
  name: my_test_pin_id
  internal: True
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

Closes #5646

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
