### PR TITLE
wifi: Don't build SoftAP/DHCPS support unless 'ap' is in config.

### DIFF
--- a/esphome/components/wifi/__init__.py
+++ b/esphome/components/wifi/__init__.py
@@ -403,6 +403,10 @@ async def to_code(config):
             lambda ap: cg.add(var.set_ap(wifi_network(conf, ap, ip_config))),
         )
         cg.add(var.set_ap_timeout(conf[CONF_AP_TIMEOUT]))
+        cg.add_define("ENABLE_WIFI_AP")
+    elif CORE.is_esp32 and CORE.using_esp_idf:
+        add_idf_sdkconfig_option("CONFIG_ESP_WIFI_SOFTAP_SUPPORT", False)
+        add_idf_sdkconfig_option("CONFIG_LWIP_DHCPS", False)
 
     cg.add(var.set_reboot_timeout(config[CONF_REBOOT_TIMEOUT]))
     cg.add(var.set_power_save_mode(config[CONF_POWER_SAVE_MODE]))

--- a/esphome/components/wifi/__init__.py
+++ b/esphome/components/wifi/__init__.py
@@ -403,7 +403,7 @@ async def to_code(config):
             lambda ap: cg.add(var.set_ap(wifi_network(conf, ap, ip_config))),
         )
         cg.add(var.set_ap_timeout(conf[CONF_AP_TIMEOUT]))
-        cg.add_define("ENABLE_WIFI_AP")
+        cg.add_define("USE_WIFI_AP")
     elif CORE.is_esp32 and CORE.using_esp_idf:
         add_idf_sdkconfig_option("CONFIG_ESP_WIFI_SOFTAP_SUPPORT", False)
         add_idf_sdkconfig_option("CONFIG_LWIP_DHCPS", False)

--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -162,7 +162,7 @@ void WiFiComponent::loop() {
         return;
     }
 
-#if USE_WIFI_AP
+#ifdef USE_WIFI_AP
     if (this->has_ap() && !this->ap_setup_) {
       if (now - this->last_connected_ > this->ap_timeout_) {
         ESP_LOGI(TAG, "Starting fallback AP!");
@@ -208,7 +208,7 @@ network::IPAddress WiFiComponent::get_ip_address() {
   if (this->has_sta())
     return this->wifi_sta_ip();
 
-#if USE_WIFI_AP
+#ifdef USE_WIFI_AP
   if (this->has_ap())
     return this->wifi_soft_ap_ip();
 #endif  // USE_WIFI_AP

--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -82,8 +82,8 @@ void WiFiComponent::start() {
     } else {
       this->start_scanning();
     }
+#ifdef USE_WIFI_AP
   } else if (this->has_ap()) {
-#ifdef ENABLE_WIFI_AP
     this->setup_ap_config_();
     if (this->output_power_.has_value() && !this->wifi_apply_output_power_(*this->output_power_)) {
       ESP_LOGV(TAG, "Setting Output Power Option failed!");
@@ -95,7 +95,7 @@ void WiFiComponent::start() {
       captive_portal::global_captive_portal->start();
     }
 #endif
-#endif  // ENABLE_WIFI_AP
+#endif  // USE_WIFI_AP
   }
 #ifdef USE_IMPROV
   if (!this->has_sta() && esp32_improv::global_improv_component != nullptr) {
@@ -162,8 +162,8 @@ void WiFiComponent::loop() {
         return;
     }
 
+#if USE_WIFI_AP
     if (this->has_ap() && !this->ap_setup_) {
-#if ENABLE_WIFI_AP
       if (now - this->last_connected_ > this->ap_timeout_) {
         ESP_LOGI(TAG, "Starting fallback AP!");
         this->setup_ap_config_();
@@ -172,8 +172,8 @@ void WiFiComponent::loop() {
           captive_portal::global_captive_portal->start();
 #endif
       }
-#endif  // ENABLE_WIFI_AP
     }
+#endif  // USE_WIFI_AP
 
 #ifdef USE_IMPROV
     if (esp32_improv::global_improv_component != nullptr && !esp32_improv::global_improv_component->is_active()) {
@@ -208,10 +208,10 @@ network::IPAddress WiFiComponent::get_ip_address() {
   if (this->has_sta())
     return this->wifi_sta_ip();
 
-#if ENABLE_WIFI_AP
+#if USE_WIFI_AP
   if (this->has_ap())
     return this->wifi_soft_ap_ip();
-#endif  // ENABLE_WIFI_AP
+#endif  // USE_WIFI_AP
 
   return {};
 }
@@ -228,7 +228,7 @@ std::string WiFiComponent::get_use_address() const {
 }
 void WiFiComponent::set_use_address(const std::string &use_address) { this->use_address_ = use_address; }
 
-#ifdef ENABLE_WIFI_AP
+#ifdef USE_WIFI_AP
 void WiFiComponent::setup_ap_config_() {
   this->wifi_mode_({}, true);
 
@@ -265,18 +265,16 @@ void WiFiComponent::setup_ap_config_() {
     this->state_ = WIFI_COMPONENT_STATE_AP;
   }
 }
-#endif  // ENABLE_WIFI_AP
 
-float WiFiComponent::get_loop_priority() const {
-  return 10.0f;  // before other loop components
-}
-
-#ifdef ENABLE_WIFI_AP
 void WiFiComponent::set_ap(const WiFiAP &ap) {
   this->ap_ = ap;
   this->has_ap_ = true;
 }
-#endif  // ENABLE_WIFI_AP
+#endif  // USE_WIFI_AP
+
+float WiFiComponent::get_loop_priority() const {
+  return 10.0f;  // before other loop components
+}
 
 void WiFiComponent::add_sta(const WiFiAP &ap) { this->sta_.push_back(ap); }
 void WiFiComponent::set_sta(const WiFiAP &ap) {

--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -83,6 +83,7 @@ void WiFiComponent::start() {
       this->start_scanning();
     }
   } else if (this->has_ap()) {
+#ifdef ENABLE_WIFI_AP
     this->setup_ap_config_();
     if (this->output_power_.has_value() && !this->wifi_apply_output_power_(*this->output_power_)) {
       ESP_LOGV(TAG, "Setting Output Power Option failed!");
@@ -94,6 +95,7 @@ void WiFiComponent::start() {
       captive_portal::global_captive_portal->start();
     }
 #endif
+#endif  // ENABLE_WIFI_AP
   }
 #ifdef USE_IMPROV
   if (!this->has_sta() && esp32_improv::global_improv_component != nullptr) {
@@ -161,6 +163,7 @@ void WiFiComponent::loop() {
     }
 
     if (this->has_ap() && !this->ap_setup_) {
+#if ENABLE_WIFI_AP
       if (now - this->last_connected_ > this->ap_timeout_) {
         ESP_LOGI(TAG, "Starting fallback AP!");
         this->setup_ap_config_();
@@ -169,6 +172,7 @@ void WiFiComponent::loop() {
           captive_portal::global_captive_portal->start();
 #endif
       }
+#endif  // ENABLE_WIFI_AP
     }
 
 #ifdef USE_IMPROV
@@ -199,11 +203,16 @@ void WiFiComponent::set_fast_connect(bool fast_connect) { this->fast_connect_ = 
 void WiFiComponent::set_btm(bool btm) { this->btm_ = btm; }
 void WiFiComponent::set_rrm(bool rrm) { this->rrm_ = rrm; }
 #endif
+
 network::IPAddress WiFiComponent::get_ip_address() {
   if (this->has_sta())
     return this->wifi_sta_ip();
+
+#if ENABLE_WIFI_AP
   if (this->has_ap())
     return this->wifi_soft_ap_ip();
+#endif  // ENABLE_WIFI_AP
+
   return {};
 }
 network::IPAddress WiFiComponent::get_dns_address(int num) {
@@ -218,6 +227,8 @@ std::string WiFiComponent::get_use_address() const {
   return this->use_address_;
 }
 void WiFiComponent::set_use_address(const std::string &use_address) { this->use_address_ = use_address; }
+
+#ifdef ENABLE_WIFI_AP
 void WiFiComponent::setup_ap_config_() {
   this->wifi_mode_({}, true);
 
@@ -254,14 +265,19 @@ void WiFiComponent::setup_ap_config_() {
     this->state_ = WIFI_COMPONENT_STATE_AP;
   }
 }
+#endif  // ENABLE_WIFI_AP
 
 float WiFiComponent::get_loop_priority() const {
   return 10.0f;  // before other loop components
 }
+
+#ifdef ENABLE_WIFI_AP
 void WiFiComponent::set_ap(const WiFiAP &ap) {
   this->ap_ = ap;
   this->has_ap_ = true;
 }
+#endif  // ENABLE_WIFI_AP
+
 void WiFiComponent::add_sta(const WiFiAP &ap) { this->sta_.push_back(ap); }
 void WiFiComponent::set_sta(const WiFiAP &ap) {
   this->clear_sta();

--- a/esphome/components/wifi/wifi_component.h
+++ b/esphome/components/wifi/wifi_component.h
@@ -194,7 +194,7 @@ class WiFiComponent : public Component {
   void add_sta(const WiFiAP &ap);
   void clear_sta();
 
-#ifdef ENABLE_WIFI_AP
+#ifdef USE_WIFI_AP
   /** Setup an Access Point that should be created if no connection to a station can be made.
    *
    * This can also be used without set_sta(). Then the AP will always be active.
@@ -204,7 +204,7 @@ class WiFiComponent : public Component {
    */
   void set_ap(const WiFiAP &ap);
   WiFiAP get_ap() { return this->ap_; }
-#endif  // ENABLE_WIFI_AP
+#endif  // USE_WIFI_AP
 
   void enable();
   void disable();
@@ -302,9 +302,9 @@ class WiFiComponent : public Component {
  protected:
   static std::string format_mac_addr(const uint8_t mac[6]);
 
-#ifdef ENABLE_WIFI_AP
+#ifdef USE_WIFI_AP
   void setup_ap_config_();
-#endif  // ENABLE_WIFI_AP
+#endif  // USE_WIFI_AP
 
   void print_connect_params_();
 
@@ -320,10 +320,10 @@ class WiFiComponent : public Component {
   WiFiSTAConnectStatus wifi_sta_connect_status_();
   bool wifi_scan_start_(bool passive);
 
-#ifdef ENABLE_WIFI_AP
+#ifdef USE_WIFI_AP
   bool wifi_ap_ip_config_(optional<ManualIP> manual_ip);
   bool wifi_start_ap_(const WiFiAP &ap);
-#endif  // ENABLE_WIFI_AP
+#endif  // USE_WIFI_AP
 
   bool wifi_disconnect_();
   int32_t wifi_channel_();

--- a/esphome/components/wifi/wifi_component.h
+++ b/esphome/components/wifi/wifi_component.h
@@ -194,6 +194,7 @@ class WiFiComponent : public Component {
   void add_sta(const WiFiAP &ap);
   void clear_sta();
 
+#ifdef ENABLE_WIFI_AP
   /** Setup an Access Point that should be created if no connection to a station can be made.
    *
    * This can also be used without set_sta(). Then the AP will always be active.
@@ -203,6 +204,7 @@ class WiFiComponent : public Component {
    */
   void set_ap(const WiFiAP &ap);
   WiFiAP get_ap() { return this->ap_; }
+#endif  // ENABLE_WIFI_AP
 
   void enable();
   void disable();
@@ -299,7 +301,11 @@ class WiFiComponent : public Component {
 
  protected:
   static std::string format_mac_addr(const uint8_t mac[6]);
+
+#ifdef ENABLE_WIFI_AP
   void setup_ap_config_();
+#endif  // ENABLE_WIFI_AP
+
   void print_connect_params_();
 
   void wifi_loop_();
@@ -313,8 +319,12 @@ class WiFiComponent : public Component {
   void wifi_pre_setup_();
   WiFiSTAConnectStatus wifi_sta_connect_status_();
   bool wifi_scan_start_(bool passive);
+
+#ifdef ENABLE_WIFI_AP
   bool wifi_ap_ip_config_(optional<ManualIP> manual_ip);
   bool wifi_start_ap_(const WiFiAP &ap);
+#endif  // ENABLE_WIFI_AP
+
   bool wifi_disconnect_();
   int32_t wifi_channel_();
   network::IPAddress wifi_subnet_mask_();

--- a/esphome/components/wifi/wifi_component_esp32_arduino.cpp
+++ b/esphome/components/wifi/wifi_component_esp32_arduino.cpp
@@ -597,6 +597,8 @@ void WiFiComponent::wifi_scan_done_callback_() {
   WiFi.scanDelete();
   this->scan_done_ = true;
 }
+
+#ifdef ENABLE_WIFI_AP
 bool WiFiComponent::wifi_ap_ip_config_(optional<ManualIP> manual_ip) {
   esp_err_t err;
 
@@ -654,6 +656,7 @@ bool WiFiComponent::wifi_ap_ip_config_(optional<ManualIP> manual_ip) {
 
   return true;
 }
+
 bool WiFiComponent::wifi_start_ap_(const WiFiAP &ap) {
   // enable AP
   if (!this->wifi_mode_({}, true))
@@ -692,11 +695,14 @@ bool WiFiComponent::wifi_start_ap_(const WiFiAP &ap) {
 
   return true;
 }
+
 network::IPAddress WiFiComponent::wifi_soft_ap_ip() {
   tcpip_adapter_ip_info_t ip;
   tcpip_adapter_get_ip_info(TCPIP_ADAPTER_IF_AP, &ip);
   return network::IPAddress(&ip.ip);
 }
+#endif  // ENABLE_WIFI_AP
+
 bool WiFiComponent::wifi_disconnect_() { return esp_wifi_disconnect(); }
 
 bssid_t WiFiComponent::wifi_bssid() {

--- a/esphome/components/wifi/wifi_component_esp32_arduino.cpp
+++ b/esphome/components/wifi/wifi_component_esp32_arduino.cpp
@@ -598,7 +598,7 @@ void WiFiComponent::wifi_scan_done_callback_() {
   this->scan_done_ = true;
 }
 
-#ifdef ENABLE_WIFI_AP
+#ifdef USE_WIFI_AP
 bool WiFiComponent::wifi_ap_ip_config_(optional<ManualIP> manual_ip) {
   esp_err_t err;
 
@@ -701,7 +701,7 @@ network::IPAddress WiFiComponent::wifi_soft_ap_ip() {
   tcpip_adapter_get_ip_info(TCPIP_ADAPTER_IF_AP, &ip);
   return network::IPAddress(&ip.ip);
 }
-#endif  // ENABLE_WIFI_AP
+#endif  // USE_WIFI_AP
 
 bool WiFiComponent::wifi_disconnect_() { return esp_wifi_disconnect(); }
 

--- a/esphome/components/wifi/wifi_component_esp8266.cpp
+++ b/esphome/components/wifi/wifi_component_esp8266.cpp
@@ -689,7 +689,7 @@ void WiFiComponent::wifi_scan_done_callback_(void *arg, STATUS status) {
   this->scan_done_ = true;
 }
 
-#ifdef ENABLE_WIFI_AP
+#ifdef USE_WIFI_AP
 bool WiFiComponent::wifi_ap_ip_config_(optional<ManualIP> manual_ip) {
   // enable AP
   if (!this->wifi_mode_({}, true))
@@ -799,7 +799,7 @@ network::IPAddress WiFiComponent::wifi_soft_ap_ip() {
   wifi_get_ip_info(SOFTAP_IF, &ip);
   return network::IPAddress(&ip.ip);
 }
-#endif  // ENABLE_WIFI_AP
+#endif  // USE_WIFI_AP
 
 bssid_t WiFiComponent::wifi_bssid() {
   bssid_t bssid{};

--- a/esphome/components/wifi/wifi_component_esp8266.cpp
+++ b/esphome/components/wifi/wifi_component_esp8266.cpp
@@ -688,6 +688,8 @@ void WiFiComponent::wifi_scan_done_callback_(void *arg, STATUS status) {
   }
   this->scan_done_ = true;
 }
+
+#ifdef ENABLE_WIFI_AP
 bool WiFiComponent::wifi_ap_ip_config_(optional<ManualIP> manual_ip) {
   // enable AP
   if (!this->wifi_mode_({}, true))
@@ -753,6 +755,7 @@ bool WiFiComponent::wifi_ap_ip_config_(optional<ManualIP> manual_ip) {
 
   return true;
 }
+
 bool WiFiComponent::wifi_start_ap_(const WiFiAP &ap) {
   // enable AP
   if (!this->wifi_mode_({}, true))
@@ -790,11 +793,14 @@ bool WiFiComponent::wifi_start_ap_(const WiFiAP &ap) {
 
   return true;
 }
+
 network::IPAddress WiFiComponent::wifi_soft_ap_ip() {
   struct ip_info ip {};
   wifi_get_ip_info(SOFTAP_IF, &ip);
   return network::IPAddress(&ip.ip);
 }
+#endif  // ENABLE_WIFI_AP
+
 bssid_t WiFiComponent::wifi_bssid() {
   bssid_t bssid{};
   uint8_t *raw_bssid = WiFi.BSSID();

--- a/esphome/components/wifi/wifi_component_esp_idf.cpp
+++ b/esphome/components/wifi/wifi_component_esp_idf.cpp
@@ -18,9 +18,9 @@
 #include <esp_wpa2.h>
 #endif
 
-#ifdef ENABLE_WIFI_AP
+#ifdef USE_WIFI_AP
 #include "dhcpserver/dhcpserver.h"
-#endif  // ENABLE_WIFI_AP
+#endif  // USE_WIFI_AP
 
 #include "lwip/err.h"
 #include "lwip/dns.h"
@@ -40,9 +40,9 @@ static EventGroupHandle_t s_wifi_event_group;  // NOLINT(cppcoreguidelines-avoid
 static QueueHandle_t s_event_queue;            // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 static esp_netif_t *s_sta_netif = nullptr;     // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
-#ifdef ENABLE_WIFI_AP
+#ifdef USE_WIFI_AP
 static esp_netif_t *s_ap_netif = nullptr;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
-#endif                                     // ENABLE_WIFI_AP
+#endif                                     // USE_WIFI_AP
 
 static bool s_sta_started = false;            // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 static bool s_sta_connected = false;          // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
@@ -168,9 +168,9 @@ void WiFiComponent::wifi_pre_setup_() {
 
   s_sta_netif = esp_netif_create_default_wifi_sta();
 
-#ifdef ENABLE_WIFI_AP
+#ifdef USE_WIFI_AP
   s_ap_netif = esp_netif_create_default_wifi_ap();
-#endif  // ENABLE_WIFI_AP
+#endif  // USE_WIFI_AP
 
   wifi_init_config_t cfg = WIFI_INIT_CONFIG_DEFAULT();
   // cfg.nvs_enable = false;
@@ -774,7 +774,7 @@ bool WiFiComponent::wifi_scan_start_(bool passive) {
   return true;
 }
 
-#ifdef ENABLE_WIFI_AP
+#ifdef USE_WIFI_AP
 bool WiFiComponent::wifi_ap_ip_config_(optional<ManualIP> manual_ip) {
   esp_err_t err;
 
@@ -868,7 +868,7 @@ bool WiFiComponent::wifi_start_ap_(const WiFiAP &ap) {
 
   return true;
 }
-#endif  // ENABLE_WIFI_AP
+#endif  // USE_WIFI_AP
 
 network::IPAddress WiFiComponent::wifi_soft_ap_ip() {
   esp_netif_ip_info_t ip;

--- a/esphome/components/wifi/wifi_component_libretiny.cpp
+++ b/esphome/components/wifi/wifi_component_libretiny.cpp
@@ -412,6 +412,8 @@ void WiFiComponent::wifi_scan_done_callback_() {
   WiFi.scanDelete();
   this->scan_done_ = true;
 }
+
+#ifdef ENABLE_WIFI_AP
 bool WiFiComponent::wifi_ap_ip_config_(optional<ManualIP> manual_ip) {
   // enable AP
   if (!this->wifi_mode_({}, true))
@@ -423,6 +425,7 @@ bool WiFiComponent::wifi_ap_ip_config_(optional<ManualIP> manual_ip) {
     return WiFi.softAPConfig(IPAddress(192, 168, 4, 1), IPAddress(192, 168, 4, 1), IPAddress(255, 255, 255, 0));
   }
 }
+
 bool WiFiComponent::wifi_start_ap_(const WiFiAP &ap) {
   // enable AP
   if (!this->wifi_mode_({}, true))
@@ -438,7 +441,10 @@ bool WiFiComponent::wifi_start_ap_(const WiFiAP &ap) {
   return WiFi.softAP(ap.get_ssid().c_str(), ap.get_password().empty() ? NULL : ap.get_password().c_str(),
                      ap.get_channel().value_or(1), ap.get_hidden());
 }
+
 network::IPAddress WiFiComponent::wifi_soft_ap_ip() { return {WiFi.softAPIP()}; }
+#endif  // ENABLE_WIFI_AP
+
 bool WiFiComponent::wifi_disconnect_() { return WiFi.disconnect(); }
 
 bssid_t WiFiComponent::wifi_bssid() {

--- a/esphome/components/wifi/wifi_component_libretiny.cpp
+++ b/esphome/components/wifi/wifi_component_libretiny.cpp
@@ -413,7 +413,7 @@ void WiFiComponent::wifi_scan_done_callback_() {
   this->scan_done_ = true;
 }
 
-#ifdef ENABLE_WIFI_AP
+#ifdef USE_WIFI_AP
 bool WiFiComponent::wifi_ap_ip_config_(optional<ManualIP> manual_ip) {
   // enable AP
   if (!this->wifi_mode_({}, true))
@@ -443,7 +443,7 @@ bool WiFiComponent::wifi_start_ap_(const WiFiAP &ap) {
 }
 
 network::IPAddress WiFiComponent::wifi_soft_ap_ip() { return {WiFi.softAPIP()}; }
-#endif  // ENABLE_WIFI_AP
+#endif  // USE_WIFI_AP
 
 bool WiFiComponent::wifi_disconnect_() { return WiFi.disconnect(); }
 

--- a/esphome/components/wifi/wifi_component_pico_w.cpp
+++ b/esphome/components/wifi/wifi_component_pico_w.cpp
@@ -138,7 +138,7 @@ bool WiFiComponent::wifi_scan_start_(bool passive) {
   return true;
 }
 
-#ifdef ENABLE_WIFI_AP
+#ifdef USE_WIFI_AP
 bool WiFiComponent::wifi_ap_ip_config_(optional<ManualIP> manual_ip) {
   // TODO:
   return false;
@@ -154,7 +154,7 @@ bool WiFiComponent::wifi_start_ap_(const WiFiAP &ap) {
 }
 
 network::IPAddress WiFiComponent::wifi_soft_ap_ip() { return {(const ip_addr_t *) WiFi.localIP()}; }
-#endif  // ENABLE_WIFI_AP
+#endif  // USE_WIFI_AP
 
 bool WiFiComponent::wifi_disconnect_() {
   int err = cyw43_wifi_leave(&cyw43_state, CYW43_ITF_STA);

--- a/esphome/components/wifi/wifi_component_pico_w.cpp
+++ b/esphome/components/wifi/wifi_component_pico_w.cpp
@@ -138,6 +138,7 @@ bool WiFiComponent::wifi_scan_start_(bool passive) {
   return true;
 }
 
+#ifdef ENABLE_WIFI_AP
 bool WiFiComponent::wifi_ap_ip_config_(optional<ManualIP> manual_ip) {
   // TODO:
   return false;
@@ -151,7 +152,9 @@ bool WiFiComponent::wifi_start_ap_(const WiFiAP &ap) {
 
   return true;
 }
+
 network::IPAddress WiFiComponent::wifi_soft_ap_ip() { return {(const ip_addr_t *) WiFi.localIP()}; }
+#endif  // ENABLE_WIFI_AP
 
 bool WiFiComponent::wifi_disconnect_() {
   int err = cyw43_wifi_leave(&cyw43_state, CYW43_ITF_STA);

--- a/esphome/core/defines.h
+++ b/esphome/core/defines.h
@@ -50,6 +50,7 @@
 #define USE_TOUCHSCREEN
 #define USE_UART_DEBUGGER
 #define USE_WIFI
+#define USE_WIFI_AP
 
 // Arduino-specific feature flags
 #ifdef USE_ARDUINO


### PR DESCRIPTION
# What does this implement/fix?

Optimization: don't build the SoftAP and DHCP server code (in the ESP-IDF framework) unless the ESPHome config includes `ap`; don't build AP setup code in the `wifi` component either in that case.

Also updates version of `flake8` in pre-commit config to avoid a false negative when checking `__init__.py` in the wifi component.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Other

## Test Environment

- [ ] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).