### PR TITLE
Add Healthcheck to Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -101,6 +101,10 @@ ENV USERNAME="" PASSWORD=""
 # Expose the dashboard to Docker
 EXPOSE 6052
 
+# Run healthcheck (heartbeat)
+HEALTHCHECK --interval=30s --timeout=30s \
+  CMD curl --fail http://localhost:6052/version -A "HealthCheck" || exit 1
+
 COPY docker/docker_entrypoint.sh /entrypoint.sh
 
 # The directory the user should mount their configuration files to


### PR DESCRIPTION
# What does this implement/fix?
Add [Healthcheck](https://docs.docker.com/engine/reference/builder/#healthcheck) status to the docker container

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** 
This functionality was initially added on https://github.com/esphome/esphome/pull/1492 and updated on https://github.com/esphome/esphome/pull/1517, but looks like "by error" It was removed on this [refactor PR ](https://github.com/esphome/esphome/pull/2338/files#diff-f34da55ca08f1a30591d8b0b3e885bcc678537b2a9a4aadea4f190806b374ddcL20-L22) (cc/ @OttoWinter) 

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
