### PR TITLE
Allow E1.31 component to work with individual bulbs

### DIFF
--- a/esphome/components/e131/__init__.py
+++ b/esphome/components/e131/__init__.py
@@ -1,13 +1,16 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components.light.types import AddressableLightEffect
+from esphome.components.light.types import LightEffect
 from esphome.components.light.effects import register_addressable_effect
+from esphome.components.light.effects import register_monochromatic_effect
 from esphome.const import CONF_ID, CONF_NAME, CONF_METHOD, CONF_CHANNELS
 
 AUTO_LOAD = ["socket"]
 DEPENDENCIES = ["network"]
 
 e131_ns = cg.esphome_ns.namespace("e131")
+E131BasicLightEffect = e131_ns.class_("E131BasicLightEffect", LightEffect)
 E131AddressableLightEffect = e131_ns.class_(
     "E131AddressableLightEffect", AddressableLightEffect
 )
@@ -38,6 +41,16 @@ async def to_code(config):
     cg.add(var.set_method(METHODS[config[CONF_METHOD]]))
 
 
+@register_monochromatic_effect(
+    "e131",
+    E131BasicLightEffect,
+    "E1.31",
+    {
+        cv.GenerateID(CONF_E131_ID): cv.use_id(E131Component),
+        cv.Required(CONF_UNIVERSE): cv.int_range(min=1, max=512),
+        cv.Optional(CONF_CHANNELS, default="RGB"): cv.one_of(*CHANNELS, upper=True),
+    },
+)
 @register_addressable_effect(
     "e131",
     E131AddressableLightEffect,

--- a/esphome/components/e131/e131.h
+++ b/esphome/components/e131/e131.h
@@ -12,6 +12,7 @@
 namespace esphome {
 namespace e131 {
 
+class E131BasicLightEffect;
 class E131AddressableLightEffect;
 
 enum E131ListenMethod { E131_MULTICAST, E131_UNICAST };

--- a/esphome/components/e131/e131_addressable_light_effect.cpp
+++ b/esphome/components/e131/e131_addressable_light_effect.cpp
@@ -10,7 +10,9 @@ static const int MAX_DATA_SIZE = (sizeof(E131Packet::values) - 1);
 
 E131AddressableLightEffect::E131AddressableLightEffect(const std::string &name) : AddressableLightEffect(name) {}
 
-bool E131AddressableLightEffect::is_universe_valid(int universe) const { return !(universe < first_universe_ || universe > get_last_universe()); }
+bool E131AddressableLightEffect::is_universe_valid(int universe) const {
+  return !(universe < first_universe_ || universe > get_last_universe());
+}
 
 int E131AddressableLightEffect::get_data_per_universe() const { return get_lights_per_universe() * channels_; }
 

--- a/esphome/components/e131/e131_addressable_light_effect.cpp
+++ b/esphome/components/e131/e131_addressable_light_effect.cpp
@@ -10,6 +10,8 @@ static const int MAX_DATA_SIZE = (sizeof(E131Packet::values) - 1);
 
 E131AddressableLightEffect::E131AddressableLightEffect(const std::string &name) : AddressableLightEffect(name) {}
 
+bool E131AddressableLightEffect::is_universe_valid(int universe) const { return !(universe < first_universe_ || universe > get_last_universe()); }
+
 int E131AddressableLightEffect::get_data_per_universe() const { return get_lights_per_universe() * channels_; }
 
 int E131AddressableLightEffect::get_lights_per_universe() const { return MAX_DATA_SIZE / channels_; }
@@ -48,7 +50,7 @@ bool E131AddressableLightEffect::process_(int universe, const E131Packet &packet
   auto *it = get_addressable_();
 
   // check if this is our universe and data are valid
-  if (universe < first_universe_ || universe > get_last_universe())
+  if (!is_universe_valid(universe))
     return false;
 
   int32_t output_offset = (universe - first_universe_) * get_lights_per_universe();

--- a/esphome/components/e131/e131_addressable_light_effect.h
+++ b/esphome/components/e131/e131_addressable_light_effect.h
@@ -20,17 +20,19 @@ class E131AddressableLightEffect : public light::AddressableLightEffect {
   void apply(light::AddressableLight &it, const Color &current_color) override;
 
   int get_data_per_universe() const;
-  int get_lights_per_universe() const;
+  virtual int get_lights_per_universe() const;
   int get_first_universe() const;
   int get_last_universe() const;
   int get_universe_count() const;
+
+  bool is_universe_valid(int universe) const;
 
   void set_first_universe(int universe) { this->first_universe_ = universe; }
   void set_channels(E131LightChannels channels) { this->channels_ = channels; }
   void set_e131(E131Component *e131) { this->e131_ = e131; }
 
  protected:
-  bool process_(int universe, const E131Packet &packet);
+  virtual bool process_(int universe, const E131Packet &packet);
 
   int first_universe_{0};
   int last_universe_{0};

--- a/esphome/components/e131/e131_basic_light_effect.cpp
+++ b/esphome/components/e131/e131_basic_light_effect.cpp
@@ -1,0 +1,57 @@
+#include "e131_basic_light_effect.h"
+#include "e131.h"
+#include "esphome/core/log.h"
+
+namespace esphome {
+namespace e131 {
+
+static const char *const TAG = "e131_basic_light_effect";
+static const int MAX_DATA_SIZE = (sizeof(E131Packet::values) - 1);
+
+E131BasicLightEffect::E131BasicLightEffect(const std::string &name) : E131AddressableLightEffect(name) {}
+
+int E131BasicLightEffect::get_lights_per_universe() const { return 1; }
+
+bool E131BasicLightEffect::process_(int universe, const E131Packet &packet) {
+  // check if this is our universe and data are valid
+  if (!is_universe_valid(universe))
+    return false;
+
+  auto *input_data = packet.values + 1;
+
+  ESP_LOGV(TAG, "Applying data for '%s' on %d universe, for %" PRId32 "-%d.", get_name().c_str(), universe);
+
+  auto call = this->state_->turn_on();
+
+  switch (channels_) {
+    case E131_MONO:
+      call.set_red(input_data[0]);
+      call.set_green(input_data[0]);
+      call.set_blue(input_data[0]);
+      break;
+
+    case E131_RGB:
+      ESP_LOGV(TAG, "Applying RGB values %d, %d, %d", input_data[0], input_data[1], input_data[2]);
+
+      call.set_red(input_data[0]);
+      call.set_green(input_data[1]);
+      call.set_blue(input_data[2]);
+      break;
+
+    case E131_RGBW:
+      call.set_red(input_data[0]);
+      call.set_green(input_data[1]);
+      call.set_blue(input_data[2]);
+      call.set_white(input_data[3]);
+      break;
+  }
+
+  call.set_publish(true);
+  call.set_save(false);
+  call.perform();
+
+  return true;
+}
+
+}  // namespace e131
+}  // namespace esphome

--- a/esphome/components/e131/e131_basic_light_effect.h
+++ b/esphome/components/e131/e131_basic_light_effect.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "esphome/core/component.h"
+
+#include "e131_addressable_light_effect.h"
+
+namespace esphome {
+namespace e131 {
+
+class E131Component;
+struct E131Packet;
+
+class E131BasicLightEffect : public E131AddressableLightEffect {
+ public:
+  E131BasicLightEffect(const std::string &name);
+
+  int get_lights_per_universe() const override;
+
+ protected:
+  bool process_(int universe, const E131Packet &packet) override;
+};
+
+}  // namespace e131
+}  // namespace esphome


### PR DESCRIPTION
# What does this implement/fix?

This allows the E1.31 effect to be applied to regular bulbs, rather than just addressable strips etc.
I still need to test this.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/ayufan/esphome-components/issues/14

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [X] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
light:
  - platform: rgb
    name: "bulb"
    effects:
      - e131:
          universe: 1
          channels: RGB
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
