### PR TITLE
Allow pulse light effect to have separate on and off transition lengths

### DIFF
--- a/esphome/components/light/base_light_effects.h
+++ b/esphome/components/light/base_light_effects.h
@@ -3,8 +3,8 @@
 #include <utility>
 #include <vector>
 
-#include "light_effect.h"
 #include "esphome/core/automation.h"
+#include "light_effect.h"
 
 namespace esphome {
 namespace light {
@@ -27,8 +27,8 @@ class PulseLightEffect : public LightEffect {
     auto call = this->state_->turn_on();
     float out = this->on_ ? this->max_brightness : this->min_brightness;
     call.set_brightness_if_supported(out);
+    call.set_transition_length_if_supported(this->on_ ? this->transition_on_length_ : this->transition_off_length_);
     this->on_ = !this->on_;
-    call.set_transition_length_if_supported(this->transition_length_);
     // don't tell HA every change
     call.set_publish(false);
     call.set_save(false);
@@ -37,7 +37,8 @@ class PulseLightEffect : public LightEffect {
     this->last_color_change_ = now;
   }
 
-  void set_transition_length(uint32_t transition_length) { this->transition_length_ = transition_length; }
+  void set_transition_on_length(uint32_t transition_length) { this->transition_on_length_ = transition_length; }
+  void set_transition_off_length(uint32_t transition_length) { this->transition_off_length_ = transition_length; }
 
   void set_update_interval(uint32_t update_interval) { this->update_interval_ = update_interval; }
 
@@ -49,7 +50,8 @@ class PulseLightEffect : public LightEffect {
  protected:
   bool on_ = false;
   uint32_t last_color_change_{0};
-  uint32_t transition_length_{};
+  uint32_t transition_on_length_{};
+  uint32_t transition_off_length_{};
   uint32_t update_interval_{};
   float min_brightness{0.0};
   float max_brightness{1.0};

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -2148,6 +2148,20 @@ light:
             state += 1;
             if (state == 4)
               state = 0;
+      - pulse:
+          transition_length: 10s
+          update_interval: 20s
+          min_brightness: 10%
+          max_brightness: 90%
+      - pulse:
+          name: pulse2
+          transition_length:
+            on_length: 10s
+            off_length: 5s
+          update_interval: 15s
+          min_brightness: 10%
+          max_brightness: 90%
+
   - platform: rgb
     name: Living Room Lights
     id: ${roomname}_lights


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

```yaml
light:
  - platform: ...
    effects:
      - pulse:
      	  name: pulse1s1s
          transition_length: 1s
      - pulse:
          name: pulse1s2s
          transition_length:
            on_length: 1s
            off_length: 2s
```
        

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#3321

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
