### PR TITLE
dfrobot_sen0395: Use setLatency instead of outputLatency

### DIFF
--- a/esphome/components/dfrobot_sen0395/__init__.py
+++ b/esphome/components/dfrobot_sen0395/__init__.py
@@ -128,14 +128,14 @@ MMWAVE_SETTINGS_SCHEMA = cv.Schema(
         cv.Optional(CONF_OUTPUT_LATENCY): {
             cv.Required(CONF_DELAY_AFTER_DETECT): cv.templatable(
                 cv.All(
-                    cv.positive_time_period,
-                    cv.Range(max=core.TimePeriod(seconds=1638.375)),
+                    cv.positive_time_period_seconds,
+                    cv.Range(max=core.TimePeriod(seconds=60)),
                 )
             ),
             cv.Required(CONF_DELAY_AFTER_DISAPPEAR): cv.templatable(
                 cv.All(
-                    cv.positive_time_period,
-                    cv.Range(max=core.TimePeriod(seconds=1638.375)),
+                    cv.positive_time_period_seconds,
+                    cv.Range(max=core.TimePeriod(seconds=60)),
                 )
             ),
         },
@@ -189,17 +189,17 @@ async def dfrobot_sen0395_settings_to_code(config, action_id, template_arg, args
             cg.add(var.set_det_max4(template_))
     if CONF_OUTPUT_LATENCY in config:
         template_ = await cg.templatable(
-            config[CONF_OUTPUT_LATENCY][CONF_DELAY_AFTER_DETECT], args, float
+            config[CONF_OUTPUT_LATENCY][CONF_DELAY_AFTER_DETECT], args, int
         )
         if isinstance(template_, cv.TimePeriod):
-            template_ = template_.total_milliseconds / 1000
+            template_ = template_.total_seconds
         cg.add(var.set_delay_after_detect(template_))
 
         template_ = await cg.templatable(
-            config[CONF_OUTPUT_LATENCY][CONF_DELAY_AFTER_DISAPPEAR], args, float
+            config[CONF_OUTPUT_LATENCY][CONF_DELAY_AFTER_DISAPPEAR], args, int
         )
         if isinstance(template_, cv.TimePeriod):
-            template_ = template_.total_milliseconds / 1000
+            template_ = template_.total_seconds
         cg.add(var.set_delay_after_disappear(template_))
     if CONF_SENSITIVITY in config:
         template_ = await cg.templatable(config[CONF_SENSITIVITY], args, int)

--- a/esphome/components/dfrobot_sen0395/automation.h
+++ b/esphome/components/dfrobot_sen0395/automation.h
@@ -22,8 +22,8 @@ class DfrobotSen0395SettingsAction : public Action<Ts...>, public Parented<Dfrob
   TEMPLATABLE_VALUE(int8_t, turn_on_led)
   TEMPLATABLE_VALUE(int8_t, presence_via_uart)
   TEMPLATABLE_VALUE(int8_t, sensitivity)
-  TEMPLATABLE_VALUE(float, delay_after_detect)
-  TEMPLATABLE_VALUE(float, delay_after_disappear)
+  TEMPLATABLE_VALUE(int8_t, delay_after_detect)
+  TEMPLATABLE_VALUE(int8_t, delay_after_disappear)
   TEMPLATABLE_VALUE(float, det_min1)
   TEMPLATABLE_VALUE(float, det_max1)
   TEMPLATABLE_VALUE(float, det_min2)
@@ -47,10 +47,10 @@ class DfrobotSen0395SettingsAction : public Action<Ts...>, public Parented<Dfrob
       }
     }
     if (this->delay_after_detect_.has_value() && this->delay_after_disappear_.has_value()) {
-      float detect = this->delay_after_detect_.value(x...);
-      float disappear = this->delay_after_disappear_.value(x...);
+      int8_t detect = this->delay_after_detect_.value(x...);
+      int8_t disappear = this->delay_after_disappear_.value(x...);
       if (detect >= 0 && disappear >= 0) {
-        this->parent_->enqueue(make_unique<OutputLatencyCommand>(detect, disappear));
+        this->parent_->enqueue(make_unique<SetLatencyCommand>(detect, disappear));
       }
     }
     if (this->start_after_power_on_.has_value()) {

--- a/esphome/components/dfrobot_sen0395/commands.cpp
+++ b/esphome/components/dfrobot_sen0395/commands.cpp
@@ -194,32 +194,20 @@ uint8_t DetRangeCfgCommand::on_message(std::string &message) {
   return 0;  // Command not done yet.
 }
 
-OutputLatencyCommand::OutputLatencyCommand(float delay_after_detection, float delay_after_disappear) {
-  delay_after_detection = round(delay_after_detection / 0.025) * 0.025;
-  delay_after_disappear = round(delay_after_disappear / 0.025) * 0.025;
-  if (delay_after_detection < 0)
-    delay_after_detection = 0;
-  if (delay_after_detection > 1638.375)
-    delay_after_detection = 1638.375;
-  if (delay_after_disappear < 0)
-    delay_after_disappear = 0;
-  if (delay_after_disappear > 1638.375)
-    delay_after_disappear = 1638.375;
-
-  this->delay_after_detection_ = delay_after_detection;
-  this->delay_after_disappear_ = delay_after_disappear;
-
-  this->cmd_ = str_sprintf("outputLatency -1 %.0f %.0f", delay_after_detection / 0.025, delay_after_disappear / 0.025);
+SetLatencyCommand::SetLatencyCommand(int8_t delay_after_detection, int8_t delay_after_disappear) {
+  this->delay_after_detection_ = std::min(std::max(delay_after_detection, int8_t(0)), int8_t(60));
+  this->delay_after_disappear_ = std::min(std::max(delay_after_disappear, int8_t(0)), int8_t(60));
+  this->cmd_ = str_sprintf("setLatency %d %d", this->delay_after_detection_, this->delay_after_disappear_);
 };
 
-uint8_t OutputLatencyCommand::on_message(std::string &message) {
+uint8_t SetLatencyCommand::on_message(std::string &message) {
   if (message == "sensor is not stopped") {
     ESP_LOGE(TAG, "Cannot configure output latency. Sensor is not stopped!");
     return 1;  // Command done
   } else if (message == "Done") {
     ESP_LOGI(TAG, "Updated output latency config:");
-    ESP_LOGI(TAG, "Signal that someone was detected is delayed by %.02fs.", this->delay_after_detection_);
-    ESP_LOGI(TAG, "Signal that nobody is detected anymore is delayed by %.02fs.", this->delay_after_disappear_);
+    ESP_LOGI(TAG, "Signal that someone was detected is delayed by %ds.", this->delay_after_detection_);
+    ESP_LOGI(TAG, "Signal that nobody is detected anymore is delayed by %ds.", this->delay_after_disappear_);
     ESP_LOGD(TAG, "Used command: %s", this->cmd_.c_str());
     return 1;  // Command done
   }

--- a/esphome/components/dfrobot_sen0395/commands.h
+++ b/esphome/components/dfrobot_sen0395/commands.h
@@ -62,14 +62,14 @@ class DetRangeCfgCommand : public Command {
   // TODO: Set min max values in component, so they can be published as sensor.
 };
 
-class OutputLatencyCommand : public Command {
+class SetLatencyCommand : public Command {
  public:
-  OutputLatencyCommand(float delay_after_detection, float delay_after_disappear);
+  SetLatencyCommand(int8_t delay_after_detection, int8_t delay_after_disappear);
   uint8_t on_message(std::string &message) override;
 
  protected:
-  float delay_after_detection_;
-  float delay_after_disappear_;
+  int8_t delay_after_detection_;
+  int8_t delay_after_disappear_;
 };
 
 class SensorCfgStartCommand : public Command {


### PR DESCRIPTION
# What does this implement/fix?

The `outputLatency` command does not properly set the detect (on) latency. See https://github.com/esphome/esphome/pull/4203#issuecomment-1370804752.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** #4203

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [ ] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
external_components:
  - source: github://pr#5663
    components: [ dfrobot_mmwave_radar ]

uart:
  - id: uart_mmwave
    tx_pin: 14
    rx_pin: 27
    baud_rate: 115200

dfrobot_mmwave_radar:
    - id: mmwave
      uart_id: uart_mmwave

binary_sensor:
  - platform: dfrobot_mmwave_radar
    name: Mmwave Detected UART

  - platform: gpio
    name: Mmwave Detected GPIO
    device_class: motion
    pin:
      number: 13
      mode: INPUT_PULLDOWN

button:
  - platform: template
    name: "Update Settings"
    on_press:
      - dfrobot_mmwave_radar.settings:
          # id: mmwave
          factory_reset: true
          detection_segments:
            - [0cm, 3m]
          output_latency:
            delay_after_detect: 0s
            delay_after_disappear: 0s
          start_after_power_on: true
          turn_on_led: false
          presence_via_uart: true
          sensitivity: 7
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
