### PR TITLE
dfrobot_sen0395: Use setLatency instead of outputLatency

### DIFF
--- a/esphome/components/dfrobot_sen0395/__init__.py
+++ b/esphome/components/dfrobot_sen0395/__init__.py
@@ -128,13 +128,13 @@ MMWAVE_SETTINGS_SCHEMA = cv.Schema(
         cv.Optional(CONF_OUTPUT_LATENCY): {
             cv.Required(CONF_DELAY_AFTER_DETECT): cv.templatable(
                 cv.All(
-                    cv.positive_time_period,
+                    cv.positive_time_period_milliseconds,
                     cv.Range(max=core.TimePeriod(seconds=1638.375)),
                 )
             ),
             cv.Required(CONF_DELAY_AFTER_DISAPPEAR): cv.templatable(
                 cv.All(
-                    cv.positive_time_period,
+                    cv.positive_time_period_milliseconds,
                     cv.Range(max=core.TimePeriod(seconds=1638.375)),
                 )
             ),

--- a/esphome/components/dfrobot_sen0395/__init__.py
+++ b/esphome/components/dfrobot_sen0395/__init__.py
@@ -1,7 +1,6 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome import automation
-from esphome import core
 from esphome.automation import maybe_simple_id
 from esphome.const import CONF_ID
 from esphome.components import uart
@@ -101,7 +100,7 @@ def range_segment_list(input):
 
     largest_distance = -1
     for distance in input:
-        if isinstance(distance, core.Lambda):
+        if isinstance(distance, cv.Lambda):
             continue
         m = cv.distance(distance)
         if m > 9:
@@ -129,13 +128,13 @@ MMWAVE_SETTINGS_SCHEMA = cv.Schema(
             cv.Required(CONF_DELAY_AFTER_DETECT): cv.templatable(
                 cv.All(
                     cv.positive_time_period_milliseconds,
-                    cv.Range(max=core.TimePeriod(seconds=1638.375)),
+                    cv.Range(max=cv.TimePeriod(seconds=1638.375)),
                 )
             ),
             cv.Required(CONF_DELAY_AFTER_DISAPPEAR): cv.templatable(
                 cv.All(
                     cv.positive_time_period_milliseconds,
-                    cv.Range(max=core.TimePeriod(seconds=1638.375)),
+                    cv.Range(max=cv.TimePeriod(seconds=1638.375)),
                 )
             ),
         },

--- a/esphome/components/dfrobot_sen0395/automation.h
+++ b/esphome/components/dfrobot_sen0395/automation.h
@@ -50,7 +50,7 @@ class DfrobotSen0395SettingsAction : public Action<Ts...>, public Parented<Dfrob
       float detect = this->delay_after_detect_.value(x...);
       float disappear = this->delay_after_disappear_.value(x...);
       if (detect >= 0 && disappear >= 0) {
-        this->parent_->enqueue(make_unique<OutputLatencyCommand>(detect, disappear));
+        this->parent_->enqueue(make_unique<SetLatencyCommand>(detect, disappear));
       }
     }
     if (this->start_after_power_on_.has_value()) {

--- a/esphome/components/dfrobot_sen0395/commands.h
+++ b/esphome/components/dfrobot_sen0395/commands.h
@@ -62,9 +62,9 @@ class DetRangeCfgCommand : public Command {
   // TODO: Set min max values in component, so they can be published as sensor.
 };
 
-class OutputLatencyCommand : public Command {
+class SetLatencyCommand : public Command {
  public:
-  OutputLatencyCommand(float delay_after_detection, float delay_after_disappear);
+  SetLatencyCommand(float delay_after_detection, float delay_after_disappear);
   uint8_t on_message(std::string &message) override;
 
  protected:


### PR DESCRIPTION
# What does this implement/fix?

The `outputLatency` command does not properly set the detect (on) latency. See https://github.com/esphome/esphome/pull/4203#issuecomment-1370804752.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** #4203

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** TODO

## Test Environment

- [ ] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
external_components:
  - source: github://pr#5663
    components: [ dfrobot_mmwave_radar ]

uart:
  - id: uart_mmwave
    tx_pin: 14
    rx_pin: 27
    baud_rate: 115200

dfrobot_mmwave_radar:
    - id: mmwave
      uart_id: uart_mmwave

binary_sensor:
  - platform: dfrobot_mmwave_radar
    name: Mmwave Detected UART

  - platform: gpio
    name: Mmwave Detected GPIO
    device_class: motion
    pin:
      number: 13
      mode: INPUT_PULLDOWN

button:
  - platform: template
    name: "Update Settings"
    on_press:
      - dfrobot_mmwave_radar.settings:
          # id: mmwave
          factory_reset: true
          detection_segments:
            - [0cm, 3m]
          output_latency:
            delay_after_detect: 0s
            delay_after_disappear: 0s
          start_after_power_on: true
          turn_on_led: false
          presence_via_uart: true
          sensitivity: 7
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
