### PR TITLE
Add callback for raw sml messages

### DIFF
--- a/esphome/components/sml/__init__.py
+++ b/esphome/components/sml/__init__.py
@@ -1,9 +1,10 @@
 import re
 
+from esphome import automation
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import uart
-from esphome.const import CONF_ID
+from esphome.const import CONF_ID, CONF_TRIGGER_ID
 
 CODEOWNERS = ["@alengwenus"]
 
@@ -16,10 +17,26 @@ MULTI_CONF = True
 CONF_SML_ID = "sml_id"
 CONF_OBIS_CODE = "obis_code"
 CONF_SERVER_ID = "server_id"
+CONF_ON_DATA = "on_data"
+
+sml_ns = cg.esphome_ns.namespace("sml")
+
+DataTrigger = sml_ns.class_(
+    "DataTrigger",
+    automation.Trigger.template(
+        cg.std_vector.template(cg.uint8).operator("ref"), cg.bool_
+    ),
+)
+
 
 CONFIG_SCHEMA = cv.Schema(
     {
         cv.GenerateID(): cv.declare_id(Sml),
+        cv.Optional(CONF_ON_DATA): automation.validate_automation(
+            {
+                cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(DataTrigger),
+            }
+        ),
     }
 ).extend(uart.UART_DEVICE_SCHEMA)
 
@@ -28,6 +45,19 @@ async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
     await uart.register_uart_device(var, config)
+    for conf in config.get(CONF_ON_DATA, []):
+        trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
+        await automation.build_automation(
+            trigger,
+            [
+                (
+                    cg.std_vector.template(cg.uint8).operator("ref").operator("const"),
+                    "bytes",
+                ),
+                (cg.bool_, "valid"),
+            ],
+            conf,
+        )
 
 
 def obis_code(value):

--- a/esphome/components/sml/automation.h
+++ b/esphome/components/sml/automation.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "esphome/core/automation.h"
+#include "sml.h"
+
+#include <vector>
+
+namespace esphome {
+namespace sml {
+
+class DataTrigger : public Trigger<const std::vector<uint8_t> &, bool> {
+ public:
+  explicit DataTrigger(Sml *sml) {
+    sml->add_on_data_callback([this](const std::vector<uint8_t> &data, bool valid) { this->trigger(data, valid); });
+  }
+};
+
+}  // namespace sml
+}  // namespace esphome

--- a/esphome/components/sml/constants.h
+++ b/esphome/components/sml/constants.h
@@ -18,8 +18,10 @@ enum SmlType : uint8_t {
 enum SmlMessageType : uint16_t { SML_PUBLIC_OPEN_RES = 0x0101, SML_GET_LIST_RES = 0x701 };
 
 // masks with two-bit mapping 0x1b -> 0b01; 0x01 -> 0b10; 0x1a -> 0b11
-const uint16_t START_MASK = 0x55aa;  // 0x1b 1b 1b 1b 1b 01 01 01 01
+const uint16_t START_MASK = 0x55aa;  // 0x1b 1b 1b 1b 01 01 01 01
 const uint16_t END_MASK = 0x0157;    // 0x1b 1b 1b 1b 1a
+
+const std::vector<uint8_t> START_SEQ = {0x1b, 0x1b, 0x1b, 0x1b, 0x01, 0x01, 0x01, 0x01};
 
 }  // namespace sml
 }  // namespace esphome

--- a/esphome/components/sml/sml.cpp
+++ b/esphome/components/sml/sml.cpp
@@ -35,16 +35,24 @@ void Sml::loop() {
       case START_BYTES_DETECTED: {
         this->record_ = true;
         this->sml_data_.clear();
+        // add start sequence (for callbacks)
+        this->sml_data_.insert(this->sml_data_.begin(), START_SEQ.begin(), START_SEQ.end());
         break;
       };
       case END_BYTES_DETECTED: {
         if (this->record_) {
           this->record_ = false;
 
-          if (!check_sml_data(this->sml_data_))
+          bool valid = check_sml_data(this->sml_data_);
+
+          // call callbacks
+          this->data_callbacks_.call(this->sml_data_, valid);
+
+          if (!valid)
             break;
 
-          // remove footer bytes
+          // remove start/end sequence
+          this->sml_data_.erase(this->sml_data_.begin(), this->sml_data_.begin() + START_SEQ.size());
           this->sml_data_.resize(this->sml_data_.size() - 8);
           this->process_sml_file_(this->sml_data_);
         }
@@ -52,6 +60,10 @@ void Sml::loop() {
       };
     };
   }
+}
+
+void Sml::add_on_data_callback(std::function<void(std::vector<uint8_t>, bool)> &&callback) {
+  this->data_callbacks_.add(std::move(callback));
 }
 
 void Sml::process_sml_file_(const bytes &sml_data) {
@@ -100,14 +112,14 @@ bool check_sml_data(const bytes &buffer) {
   }
 
   uint16_t crc_received = (buffer.at(buffer.size() - 2) << 8) | buffer.at(buffer.size() - 1);
-  uint16_t crc_calculated = crc16(buffer.data(), buffer.size() - 2, 0x6e23, 0x8408, true, true);
+  uint16_t crc_calculated = crc16(buffer.data() + 8, buffer.size() - 10, 0x6e23, 0x8408, true, true);
   crc_calculated = (crc_calculated >> 8) | (crc_calculated << 8);
   if (crc_received == crc_calculated) {
     ESP_LOGV(TAG, "Checksum verification successful with CRC16/X25.");
     return true;
   }
 
-  crc_calculated = crc16(buffer.data(), buffer.size() - 2, 0xed50, 0x8408);
+  crc_calculated = crc16(buffer.data() + 8, buffer.size() - 10, 0xed50, 0x8408);
   if (crc_received == crc_calculated) {
     ESP_LOGV(TAG, "Checksum verification successful with CRC16/KERMIT.");
     return true;

--- a/esphome/components/sml/sml.h
+++ b/esphome/components/sml/sml.h
@@ -3,6 +3,7 @@
 #include <string>
 #include <vector>
 #include "esphome/core/component.h"
+#include "esphome/core/helpers.h"
 #include "esphome/components/uart/uart.h"
 #include "sml_parser.h"
 
@@ -23,6 +24,7 @@ class Sml : public Component, public uart::UARTDevice {
   void loop() override;
   void dump_config() override;
   std::vector<SmlListener *> sml_listeners_{};
+  void add_on_data_callback(std::function<void(std::vector<uint8_t>, bool)> &&callback);
 
  protected:
   void process_sml_file_(const bytes &sml_data);
@@ -35,6 +37,8 @@ class Sml : public Component, public uart::UARTDevice {
   bool record_ = false;
   uint16_t incoming_mask_ = 0;
   bytes sml_data_;
+
+  CallbackManager<void(const std::vector<uint8_t> &, bool)> data_callbacks_{};
 };
 
 bool check_sml_data(const bytes &buffer);


### PR DESCRIPTION
# What does this implement/fix?

Adds an `on_data` callback to SML component which allows to access the raw SML message

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/feature-requests/issues/2424

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** https://github.com/esphome/esphome-docs/pull/3326

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
sml:
  - id: sml0
    uart_id: meter_in
    on_data:
      - lambda: id(mqttclient).publish("gridmeter/sensor/sml/state", format_hex(bytes));

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
