### PR TITLE
Fixed int variables for user defined service in case of ESP32-C3

### DIFF
--- a/esphome/components/api/user_services.cpp
+++ b/esphome/components/api/user_services.cpp
@@ -26,11 +26,13 @@ template<> std::vector<std::string> get_execute_arg_value<std::vector<std::strin
 }
 
 template<> enums::ServiceArgType to_service_arg_type<bool>() { return enums::SERVICE_ARG_TYPE_BOOL; }
-template<> enums::ServiceArgType to_service_arg_type<int>() { return enums::SERVICE_ARG_TYPE_INT; }
+template<> enums::ServiceArgType to_service_arg_type<int32_t>() { return enums::SERVICE_ARG_TYPE_INT; }
 template<> enums::ServiceArgType to_service_arg_type<float>() { return enums::SERVICE_ARG_TYPE_FLOAT; }
 template<> enums::ServiceArgType to_service_arg_type<std::string>() { return enums::SERVICE_ARG_TYPE_STRING; }
 template<> enums::ServiceArgType to_service_arg_type<std::vector<bool>>() { return enums::SERVICE_ARG_TYPE_BOOL_ARRAY; }
-template<> enums::ServiceArgType to_service_arg_type<std::vector<int>>() { return enums::SERVICE_ARG_TYPE_INT_ARRAY; }
+template<> enums::ServiceArgType to_service_arg_type<std::vector<int32_t>>() {
+  return enums::SERVICE_ARG_TYPE_INT_ARRAY;
+}
 template<> enums::ServiceArgType to_service_arg_type<std::vector<float>>() {
   return enums::SERVICE_ARG_TYPE_FLOAT_ARRAY;
 }

--- a/esphome/components/api/user_services.cpp
+++ b/esphome/components/api/user_services.cpp
@@ -5,7 +5,7 @@ namespace esphome {
 namespace api {
 
 template<> bool get_execute_arg_value<bool>(const ExecuteServiceArgument &arg) { return arg.bool_; }
-template<> int get_execute_arg_value<int>(const ExecuteServiceArgument &arg) {
+template<> int32_t get_execute_arg_value<int32_t>(const ExecuteServiceArgument &arg) {
   if (arg.legacy_int != 0)
     return arg.legacy_int;
   return arg.int_;


### PR DESCRIPTION
# What does this implement/fix?

If using int or int[] variables for user defined service with ESP32-C3 board, it got a linker error:
```
Compiling .pioenvs\test\src\main.cpp.o
Linking .pioenvs\test\firmware.elf
c:/users/user/.platformio/packages/toolchain-riscv32-esp@8.4.0+2021r2-patch5/bin/../lib/gcc/riscv32-esp-elf/8.4.0/../../../../riscv32-esp-elf/bin/ld.exe: .pioenvs/test/src/main.cpp.o: in function `esphome::api::ExecuteServiceArgument* 
std::__uninitialized_copy<false>::__uninit_copy<__gnu_cxx::__normal_iterator<esphome::api::ExecuteServiceArgument const*, std::vector<esphome::api::ExecuteServiceArgument, std::allocator<esphome::api::ExecuteServiceArgument> > >, 
esphome::api::ExecuteServiceArgument*>(__gnu_cxx::__normal_iterator<esphome::api::ExecuteServiceArgument const*, std::vector<esphome::api::ExecuteServiceArgument, std::allocator<esphome::api::ExecuteServiceArgument> > >, 
__gnu_cxx::__normal_iterator<esphome::api::ExecuteServiceArgument const*, std::vector<esphome::api::ExecuteServiceArgument, std::allocator<esphome::api::ExecuteServiceArgument> > >, esphome::api::ExecuteServiceArgument*)':

c:\users\user\.platformio\packages\toolchain-riscv32-esp@8.4.0+2021r2-patch5\riscv32-esp-elf\include\c++\8.4.0\bits/stl_uninitialized.h:82: undefined reference to `long esphome::api::get_execute_arg_value<long>(esphome::api::ExecuteServiceArgument const&)'

c:/users/user/.platformio/packages/toolchain-riscv32-esp@8.4.0+2021r2-patch5/bin/../lib/gcc/riscv32-esp-elf/8.4.0/../../../../riscv32-esp-elf/bin/ld.exe: .pioenvs/test/src/main.cpp.o: in function `esphome::api::ListEntitiesServicesArgument::ListEntitiesServicesArgument()':

D:\Work\git\haier-esphome\.esphome\build\test/src/esphome\components\api/api_pb2.h:852: undefined reference to `esphome::api::enums::ServiceArgType esphome::api::to_service_arg_type<long>()'

c:/users/user/.platformio/packages/toolchain-riscv32-esp@8.4.0+2021r2-patch5/bin/../lib/gcc/riscv32-esp-elf/8.4.0/../../../../riscv32-esp-elf/bin/ld.exe: .pioenvs/test/src/main.cpp.o: in function `esphome::api::UserServiceBase<long, std::vector<long, std::allocator<long> > 
>::encode_list_service_response()':

D:\Work\git\haier-esphome\.esphome\build\test/src/esphome\components\api/user_services.h:35: undefined reference to `esphome::api::enums::ServiceArgType esphome::api::to_service_arg_type<std::vector<long, std::allocator<long> > >()'

collect2.exe: error: ld returned 1 exit status

*** [.pioenvs\test\firmware.elf] Error 1
```

This error was caused by using a long variable instead of int in the generated C++ code.

<!-- Quick description and explanation of changes -->

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

esphome:
  name: test

esp32:
  board: esp32-c3-devkitm-1
  variant: esp32c3

wifi:
  ssid: !secret wifi_ssid
  password: !secret wifi_password

api:
  services:
    - service: test_service
      variables:
        arg_1: int
        arg_2: int[]
      then:
        - logger.log: "Test message"

logger:
  level: DEBUG


```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
