### PR TITLE
Fix compile with latest esp-idf on esp32c6

### DIFF
--- a/esphome/components/aht10/aht10.cpp
+++ b/esphome/components/aht10/aht10.cpp
@@ -15,6 +15,7 @@
 #include "aht10.h"
 #include "esphome/core/log.h"
 #include "esphome/core/hal.h"
+#include <cinttypes>
 
 namespace esphome {
 namespace aht10 {
@@ -72,7 +73,7 @@ void AHT10Component::update() {
     delay_ms = AHT10_HUMIDITY_DELAY;
   bool success = false;
   for (int i = 0; i < AHT10_ATTEMPTS; ++i) {
-    ESP_LOGVV(TAG, "Attempt %d at %6u", i, millis());
+    ESP_LOGVV(TAG, "Attempt %d at %6" PRIu32, i, millis());
     delay(delay_ms);
     if (this->read(data, 6) != i2c::ERROR_OK) {
       ESP_LOGD(TAG, "Communication with AHT10 failed, waiting...");
@@ -96,7 +97,7 @@ void AHT10Component::update() {
       }
     } else {
       // data is valid, we can break the loop
-      ESP_LOGVV(TAG, "Answer at %6u", millis());
+      ESP_LOGVV(TAG, "Answer at %6" PRIu32, millis());
       success = true;
       break;
     }

--- a/esphome/components/atm90e32/atm90e32.cpp
+++ b/esphome/components/atm90e32/atm90e32.cpp
@@ -1,6 +1,7 @@
 #include "atm90e32.h"
 #include "atm90e32_reg.h"
 #include "esphome/core/log.h"
+#include <cinttypes>
 
 namespace esphome {
 namespace atm90e32 {
@@ -173,7 +174,7 @@ uint16_t ATM90E32Component::read16_(uint16_t a_register) {
   this->disable();
 
   output = (uint16_t(data[0] & 0xFF) << 8) | (data[1] & 0xFF);
-  ESP_LOGVV(TAG, "read16_ 0x%04X output 0x%04X", a_register, output);
+  ESP_LOGVV(TAG, "read16_ 0x%04" PRIX16 " output 0x%04" PRIX16, a_register, output);
   return output;
 }
 
@@ -182,8 +183,10 @@ int ATM90E32Component::read32_(uint16_t addr_h, uint16_t addr_l) {
   uint16_t val_l = this->read16_(addr_l);
   int32_t val = (val_h << 16) | val_l;
 
-  ESP_LOGVV(TAG, "read32_ addr_h 0x%04X val_h 0x%04X addr_l 0x%04X val_l 0x%04X = %d", addr_h, val_h, addr_l, val_l,
-            val);
+  ESP_LOGVV(TAG,
+            "read32_ addr_h 0x%04" PRIX16 " val_h 0x%04" PRIX16 " addr_l 0x%04" PRIX16 " val_l 0x%04" PRIX16
+            " = %" PRId32,
+            addr_h, val_h, addr_l, val_l, val);
 
   return val;
 }
@@ -192,7 +195,7 @@ void ATM90E32Component::write16_(uint16_t a_register, uint16_t val) {
   uint8_t addrh = (a_register >> 8) & 0x03;
   uint8_t addrl = (a_register & 0xFF);
 
-  ESP_LOGVV(TAG, "write16_ 0x%04X val 0x%04X", a_register, val);
+  ESP_LOGVV(TAG, "write16_ 0x%04" PRIX16 " val 0x%04" PRIX16, a_register, val);
   this->enable();
   delayMicroseconds(10);
   this->write_byte(addrh);

--- a/esphome/components/bl0939/bl0939.cpp
+++ b/esphome/components/bl0939/bl0939.cpp
@@ -81,7 +81,7 @@ void BL0939::setup() {
 void BL0939::received_package_(const DataPacket *data) const {
   // Bad header
   if (data->frame_header != BL0939_PACKET_HEADER) {
-    ESP_LOGI("bl0939", "Invalid data. Header mismatch: %d", data->frame_header);
+    ESP_LOGI(TAG, "Invalid data. Header mismatch: %d", data->frame_header);
     return;
   }
 
@@ -121,7 +121,7 @@ void BL0939::received_package_(const DataPacket *data) const {
     energy_sensor_sum_->publish_state(total_energy_consumption);
   }
 
-  ESP_LOGV("bl0939",
+  ESP_LOGV(TAG,
            "BL0939: U %fV, I1 %fA, I2 %fA, P1 %fW, P2 %fW, CntA %" PRId32 ", CntB %" PRId32 ", ∫P1 %fkWh, ∫P2 %fkWh",
            v_rms, ia_rms, ib_rms, a_watt, b_watt, cfa_cnt, cfb_cnt, a_energy_consumption, b_energy_consumption);
 }

--- a/esphome/components/bl0939/bl0939.cpp
+++ b/esphome/components/bl0939/bl0939.cpp
@@ -1,5 +1,6 @@
 #include "bl0939.h"
 #include "esphome/core/log.h"
+#include <cinttypes>
 
 namespace esphome {
 namespace bl0939 {
@@ -120,8 +121,9 @@ void BL0939::received_package_(const DataPacket *data) const {
     energy_sensor_sum_->publish_state(total_energy_consumption);
   }
 
-  ESP_LOGV("bl0939", "BL0939: U %fV, I1 %fA, I2 %fA, P1 %fW, P2 %fW, CntA %d, CntB %d, ∫P1 %fkWh, ∫P2 %fkWh", v_rms,
-           ia_rms, ib_rms, a_watt, b_watt, cfa_cnt, cfb_cnt, a_energy_consumption, b_energy_consumption);
+  ESP_LOGV("bl0939",
+           "BL0939: U %fV, I1 %fA, I2 %fA, P1 %fW, P2 %fW, CntA %" PRId32 ", CntB %" PRId32 ", ∫P1 %fkWh, ∫P2 %fkWh",
+           v_rms, ia_rms, ib_rms, a_watt, b_watt, cfa_cnt, cfb_cnt, a_energy_consumption, b_energy_consumption);
 }
 
 void BL0939::dump_config() {  // NOLINT(readability-function-cognitive-complexity)

--- a/esphome/components/bl0940/bl0940.cpp
+++ b/esphome/components/bl0940/bl0940.cpp
@@ -78,7 +78,7 @@ float BL0940::update_temp_(sensor::Sensor *sensor, ube16_t temperature) const {
   float converted_temp = ((float) 170 / 448) * (tb / 2 - 32) - 45;
   if (sensor != nullptr) {
     if (sensor->has_state() && std::abs(converted_temp - sensor->get_state()) > max_temperature_diff_) {
-      ESP_LOGD("bl0940", "Invalid temperature change. Sensor: '%s', Old temperature: %f, New temperature: %f",
+      ESP_LOGD(TAG, "Invalid temperature change. Sensor: '%s', Old temperature: %f, New temperature: %f",
                sensor->get_name().c_str(), sensor->get_state(), converted_temp);
       return 0.0f;
     }
@@ -90,7 +90,7 @@ float BL0940::update_temp_(sensor::Sensor *sensor, ube16_t temperature) const {
 void BL0940::received_package_(const DataPacket *data) const {
   // Bad header
   if (data->frame_header != BL0940_PACKET_HEADER) {
-    ESP_LOGI("bl0940", "Invalid data. Header mismatch: %d", data->frame_header);
+    ESP_LOGI(TAG, "Invalid data. Header mismatch: %d", data->frame_header);
     return;
   }
 
@@ -116,8 +116,8 @@ void BL0940::received_package_(const DataPacket *data) const {
     energy_sensor_->publish_state(total_energy_consumption);
   }
 
-  ESP_LOGV("bl0940", "BL0940: U %fV, I %fA, P %fW, Cnt %" PRId32 ", ∫P %fkWh, T1 %f°C, T2 %f°C", v_rms, i_rms, watt,
-           cf_cnt, total_energy_consumption, tps1, tps2);
+  ESP_LOGV(TAG, "BL0940: U %fV, I %fA, P %fW, Cnt %" PRId32 ", ∫P %fkWh, T1 %f°C, T2 %f°C", v_rms, i_rms, watt, cf_cnt,
+           total_energy_consumption, tps1, tps2);
 }
 
 void BL0940::dump_config() {  // NOLINT(readability-function-cognitive-complexity)

--- a/esphome/components/bl0940/bl0940.cpp
+++ b/esphome/components/bl0940/bl0940.cpp
@@ -1,5 +1,6 @@
 #include "bl0940.h"
 #include "esphome/core/log.h"
+#include <cinttypes>
 
 namespace esphome {
 namespace bl0940 {
@@ -115,8 +116,8 @@ void BL0940::received_package_(const DataPacket *data) const {
     energy_sensor_->publish_state(total_energy_consumption);
   }
 
-  ESP_LOGV("bl0940", "BL0940: U %fV, I %fA, P %fW, Cnt %d, ∫P %fkWh, T1 %f°C, T2 %f°C", v_rms, i_rms, watt, cf_cnt,
-           total_energy_consumption, tps1, tps2);
+  ESP_LOGV("bl0940", "BL0940: U %fV, I %fA, P %fW, Cnt %" PRId32 ", ∫P %fkWh, T1 %f°C, T2 %f°C", v_rms, i_rms, watt,
+           cf_cnt, total_energy_consumption, tps1, tps2);
 }
 
 void BL0940::dump_config() {  // NOLINT(readability-function-cognitive-complexity)

--- a/esphome/components/bl0942/bl0942.cpp
+++ b/esphome/components/bl0942/bl0942.cpp
@@ -1,5 +1,6 @@
 #include "bl0942.h"
 #include "esphome/core/log.h"
+#include <cinttypes>
 
 namespace esphome {
 namespace bl0942 {
@@ -104,8 +105,8 @@ void BL0942::received_package_(DataPacket *data) {
     frequency_sensor_->publish_state(frequency);
   }
 
-  ESP_LOGV(TAG, "BL0942: U %fV, I %fA, P %fW, Cnt %d, ∫P %fkWh, frequency %f°Hz, status 0x%08X", v_rms, i_rms, watt,
-           cf_cnt, total_energy_consumption, frequency, data->status);
+  ESP_LOGV(TAG, "BL0942: U %fV, I %fA, P %fW, Cnt %" PRId32 ", ∫P %fkWh, frequency %fHz, status 0x%08X", v_rms, i_rms,
+           watt, cf_cnt, total_energy_consumption, frequency, data->status);
 }
 
 void BL0942::dump_config() {  // NOLINT(readability-function-cognitive-complexity)

--- a/esphome/components/bmp3xx/bmp3xx.cpp
+++ b/esphome/components/bmp3xx/bmp3xx.cpp
@@ -8,6 +8,7 @@
 #include "bmp3xx.h"
 #include "esphome/core/log.h"
 #include "esphome/core/hal.h"
+#include <cinttypes>
 
 namespace esphome {
 namespace bmp3xx {
@@ -198,8 +199,9 @@ void BMP3XXComponent::update() {
     return;
   }
 
-  ESP_LOGVV(TAG, "measurement time %d", uint32_t(ceilf(meas_time)));
-  this->set_timeout("data", uint32_t(ceilf(meas_time)), [this]() {
+  const uint32_t meas_timeout = uint32_t(ceilf(meas_time));
+  ESP_LOGVV(TAG, "measurement time %" PRIu32, meas_timeout);
+  this->set_timeout("data", meas_timeout, [this]() {
     float temperature = 0.0f;
     float pressure = 0.0f;
     if (this->pressure_sensor_ != nullptr) {

--- a/esphome/components/canbus/canbus.cpp
+++ b/esphome/components/canbus/canbus.cpp
@@ -51,9 +51,9 @@ void Canbus::send_data(uint32_t can_id, bool use_extended_id, bool remote_transm
 
 void Canbus::add_trigger(CanbusTrigger *trigger) {
   if (trigger->use_extended_id_) {
-    ESP_LOGVV(TAG, "add trigger for extended canid=0x%08x", trigger->can_id_);
+    ESP_LOGVV(TAG, "add trigger for extended canid=0x%08" PRIx32, trigger->can_id_);
   } else {
-    ESP_LOGVV(TAG, "add trigger for std canid=0x%03x", trigger->can_id_);
+    ESP_LOGVV(TAG, "add trigger for std canid=0x%03" PRIx32, trigger->can_id_);
   }
   this->triggers_.push_back(trigger);
 };

--- a/esphome/components/cd74hc4067/cd74hc4067.cpp
+++ b/esphome/components/cd74hc4067/cd74hc4067.cpp
@@ -1,5 +1,6 @@
 #include "cd74hc4067.h"
 #include "esphome/core/log.h"
+#include <cinttypes>
 
 namespace esphome {
 namespace cd74hc4067 {
@@ -27,7 +28,7 @@ void CD74HC4067Component::dump_config() {
   LOG_PIN("  S1 Pin: ", this->pin_s1_);
   LOG_PIN("  S2 Pin: ", this->pin_s2_);
   LOG_PIN("  S3 Pin: ", this->pin_s3_);
-  ESP_LOGCONFIG(TAG, "switch delay: %d", this->switch_delay_);
+  ESP_LOGCONFIG(TAG, "switch delay: %" PRIu32, this->switch_delay_);
 }
 
 void CD74HC4067Component::activate_pin(uint8_t pin) {

--- a/esphome/components/cse7761/cse7761.cpp
+++ b/esphome/components/cse7761/cse7761.cpp
@@ -217,7 +217,7 @@ void CSE7761Component::get_data_() {
     this->voltage_sensor_->publish_state(voltage);
   }
 
-  for (int channel = 0; channel < 2; channel++) {
+  for (uint8_t channel = 0; channel < 2; channel++) {
     // Active power = PowerPA * PowerPAC * 1000 / 0x80000000
     float active_power = (float) this->data_.active_power[channel] / this->coefficient_by_unit_(POWER_PAC);  // W
     float amps = (float) this->data_.current_rms[channel] / this->coefficient_by_unit_(RMS_IAC);             // A

--- a/esphome/components/cse7761/cse7761.cpp
+++ b/esphome/components/cse7761/cse7761.cpp
@@ -217,7 +217,7 @@ void CSE7761Component::get_data_() {
     this->voltage_sensor_->publish_state(voltage);
   }
 
-  for (uint32_t channel = 0; channel < 2; channel++) {
+  for (int channel = 0; channel < 2; channel++) {
     // Active power = PowerPA * PowerPAC * 1000 / 0x80000000
     float active_power = (float) this->data_.active_power[channel] / this->coefficient_by_unit_(POWER_PAC);  // W
     float amps = (float) this->data_.current_rms[channel] / this->coefficient_by_unit_(RMS_IAC);             // A

--- a/esphome/components/cse7766/cse7766.cpp
+++ b/esphome/components/cse7766/cse7766.cpp
@@ -1,5 +1,6 @@
 #include "cse7766.h"
 #include "esphome/core/log.h"
+#include <cinttypes>
 
 namespace esphome {
 namespace cse7766 {
@@ -162,7 +163,7 @@ void CSE7766Component::update() {
     if (counts != 0) {
       const auto avg = acc / counts;
 
-      ESP_LOGV(TAG, "Got %s_acc=%.2f %s_counts=%d %s=%.1f", name, acc, name, counts, name, avg);
+      ESP_LOGV(TAG, "Got %s_acc=%.2f %s_counts=%" PRIu32 " %s=%.1f", name, acc, name, counts, name, avg);
 
       if (sensor != nullptr) {
         sensor->publish_state(avg);
@@ -178,7 +179,8 @@ void CSE7766Component::update() {
   publish_state("power", this->power_sensor_, this->power_acc_, this->power_counts_);
 
   if (this->energy_total_counts_ != 0) {
-    ESP_LOGV(TAG, "Got energy_total=%.2f energy_total_counts=%d", this->energy_total_, this->energy_total_counts_);
+    ESP_LOGV(TAG, "Got energy_total=%.2f energy_total_counts=%" PRIu32, this->energy_total_,
+             this->energy_total_counts_);
 
     if (this->energy_sensor_ != nullptr) {
       this->energy_sensor_->publish_state(this->energy_total_);

--- a/esphome/components/ethernet/ethernet_component.cpp
+++ b/esphome/components/ethernet/ethernet_component.cpp
@@ -5,6 +5,7 @@
 
 #ifdef USE_ESP32
 
+#include <cinttypes>
 #include <lwip/dns.h>
 #include "esp_event.h"
 
@@ -275,7 +276,7 @@ void EthernetComponent::got_ip_event_handler(void *arg, esp_event_base_t event_b
 #if ENABLE_IPV6
 void EthernetComponent::got_ip6_event_handler(void *arg, esp_event_base_t event_base, int32_t event_id,
                                               void *event_data) {
-  ESP_LOGV(TAG, "[Ethernet event] ETH Got IP6 (num=%d)", event_id);
+  ESP_LOGV(TAG, "[Ethernet event] ETH Got IP6 (num=%" PRId32 ")", event_id);
   global_eth_component->got_ipv6_ = true;
   global_eth_component->ipv6_count_ += 1;
 }

--- a/esphome/components/fingerprint_grow/fingerprint_grow.cpp
+++ b/esphome/components/fingerprint_grow/fingerprint_grow.cpp
@@ -1,5 +1,6 @@
 #include "fingerprint_grow.h"
 #include "esphome/core/log.h"
+#include <cinttypes>
 
 namespace esphome {
 namespace fingerprint_grow {
@@ -204,7 +205,7 @@ bool FingerprintGrowComponent::check_password_() {
 }
 
 bool FingerprintGrowComponent::set_password_() {
-  ESP_LOGI(TAG, "Setting new password: %d", this->new_password_);
+  ESP_LOGI(TAG, "Setting new password: %" PRIu32, this->new_password_);
   this->data_ = {SET_PASSWORD, (uint8_t) (this->new_password_ >> 24), (uint8_t) (this->new_password_ >> 16),
                  (uint8_t) (this->new_password_ >> 8), (uint8_t) (this->new_password_ & 0xFF)};
   if (this->send_command_() == OK) {

--- a/esphome/components/nfc/ndef_message.cpp
+++ b/esphome/components/nfc/ndef_message.cpp
@@ -1,4 +1,5 @@
 #include "ndef_message.h"
+#include <cinttypes>
 
 namespace esphome {
 namespace nfc {
@@ -32,7 +33,7 @@ NdefMessage::NdefMessage(std::vector<uint8_t> &data) {
       id_length = data[index++];
     }
 
-    ESP_LOGVV(TAG, "Lengths: type=%d, payload=%d, id=%d", type_length, payload_length, id_length);
+    ESP_LOGVV(TAG, "Lengths: type=%d, payload=%" PRIu32 ", id=%d", type_length, payload_length, id_length);
 
     std::string type_str(data.begin() + index, data.begin() + index + type_length);
 

--- a/esphome/components/pid/pid_autotuner.cpp
+++ b/esphome/components/pid/pid_autotuner.cpp
@@ -1,5 +1,6 @@
 #include "pid_autotuner.h"
 #include "esphome/core/log.h"
+#include <cinttypes>
 
 #ifndef M_PI
 #define M_PI 3.1415926535897932384626433
@@ -108,7 +109,7 @@ PIDAutotuner::PIDAutotuneResult PIDAutotuner::update(float setpoint, float proce
     }
     uint32_t phase = this->relay_function_.phase_count;
     ESP_LOGVV(TAG, "%s: >", this->id_.c_str());
-    ESP_LOGVV(TAG, "  Phase %u, enough=%u", phase, enough_data_phase_);
+    ESP_LOGVV(TAG, "  Phase %" PRIu32 ", enough=%" PRIu32, phase, enough_data_phase_);
 
     if (this->enough_data_phase_ == 0) {
       this->enough_data_phase_ = phase;
@@ -186,8 +187,8 @@ void PIDAutotuner::dump_config() {
     ESP_LOGD(TAG, "  Autotune is still running!");
     ESP_LOGD(TAG, "  Status: Trying to reach %.2f °C", setpoint_ - relay_function_.current_target_error());
     ESP_LOGD(TAG, "  Stats so far:");
-    ESP_LOGD(TAG, "    Phases: %u", relay_function_.phase_count);
-    ESP_LOGD(TAG, "    Detected %u zero-crossings", frequency_detector_.zerocrossing_intervals.size());  // NOLINT
+    ESP_LOGD(TAG, "    Phases: %" PRIu32, relay_function_.phase_count);
+    ESP_LOGD(TAG, "    Detected %zu zero-crossings", frequency_detector_.zerocrossing_intervals.size());
     ESP_LOGD(TAG, "    Current Phase Min: %.2f, Max: %.2f", amplitude_detector_.phase_min,
              amplitude_detector_.phase_max);
   }

--- a/esphome/components/pzem004t/pzem004t.cpp
+++ b/esphome/components/pzem004t/pzem004t.cpp
@@ -1,5 +1,6 @@
 #include "pzem004t.h"
 #include "esphome/core/log.h"
+#include <cinttypes>
 
 namespace esphome {
 namespace pzem004t {
@@ -75,7 +76,7 @@ void PZEM004T::loop() {
         uint32_t energy = (uint32_t(resp[1]) << 16) | (uint32_t(resp[2]) << 8) | (uint32_t(resp[3]));
         if (this->energy_sensor_ != nullptr)
           this->energy_sensor_->publish_state(energy);
-        ESP_LOGD(TAG, "Got Energy %u Wh", energy);
+        ESP_LOGD(TAG, "Got Energy %" PRIu32 " Wh", energy);
         this->write_state_(DONE);
         break;
       }

--- a/esphome/components/remote_base/drayton_protocol.cpp
+++ b/esphome/components/remote_base/drayton_protocol.cpp
@@ -138,9 +138,12 @@ optional<DraytonData> DraytonProtocol::decode(RemoteReceiveData src) {
     return {};
   }
 
-  ESP_LOGVV(TAG, "Decode Drayton: %d, %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d", src.size(),
-            src.peek(0), src.peek(1), src.peek(2), src.peek(3), src.peek(4), src.peek(5), src.peek(6), src.peek(7),
-            src.peek(8), src.peek(9), src.peek(10), src.peek(11), src.peek(12), src.peek(13), src.peek(14),
+  ESP_LOGVV(TAG,
+            "Decode Drayton: %" PRId32 ", %" PRId32 " %" PRId32 " %" PRId32 " %" PRId32 " %" PRId32 " %" PRId32
+            " %" PRId32 " %" PRId32 " %" PRId32 " %" PRId32 " %" PRId32 " %" PRId32 " %" PRId32 " %" PRId32 " %" PRId32
+            " %" PRId32 " %" PRId32 " %" PRId32 " %" PRId32 " %" PRId32 "",
+            src.size(), src.peek(0), src.peek(1), src.peek(2), src.peek(3), src.peek(4), src.peek(5), src.peek(6),
+            src.peek(7), src.peek(8), src.peek(9), src.peek(10), src.peek(11), src.peek(12), src.peek(13), src.peek(14),
             src.peek(15), src.peek(16), src.peek(17), src.peek(18), src.peek(19));
 
   // If first preamble item is a space, skip it
@@ -150,7 +153,8 @@ optional<DraytonData> DraytonProtocol::decode(RemoteReceiveData src) {
 
   // Look for sync pulse, after. If sucessful index points to space of sync symbol
   for (uint16_t preamble = 0; preamble <= NBITS_PREAMBLE * 2; preamble += 2) {
-    ESP_LOGVV(TAG, "Decode Drayton: preamble %d  %d %d", preamble, src.peek(preamble), src.peek(preamble + 1));
+    ESP_LOGVV(TAG, "Decode Drayton: preamble %d  %" PRId32 " %" PRId32, preamble, src.peek(preamble),
+              src.peek(preamble + 1));
     if (src.peek_mark(2 * BIT_TIME_US, preamble) &&
         (src.peek_space(2 * BIT_TIME_US, preamble + 1) || src.peek_space(3 * BIT_TIME_US, preamble + 1))) {
       src.advance(preamble + 1);
@@ -177,7 +181,7 @@ optional<DraytonData> DraytonProtocol::decode(RemoteReceiveData src) {
   // if there is no transition at the start of the bit period, then the transition in the middle of
   // the previous bit period.
   while (--bit >= 1) {
-    ESP_LOGVV(TAG, "Decode Drayton: Data, %2d %08x", bit, out_data);
+    ESP_LOGVV(TAG, "Decode Drayton: Data, %2d %08" PRIx32, bit, out_data);
     if ((src.expect_space(BIT_TIME_US) || src.expect_space(2 * BIT_TIME_US)) &&
         (src.expect_mark(BIT_TIME_US) || src.peek_mark(2 * BIT_TIME_US))) {
       out_data |= 0 << bit;
@@ -185,7 +189,7 @@ optional<DraytonData> DraytonProtocol::decode(RemoteReceiveData src) {
                (src.expect_space(BIT_TIME_US) || src.peek_space(2 * BIT_TIME_US))) {
       out_data |= 1 << bit;
     } else {
-      ESP_LOGVV(TAG, "Decode Drayton: Fail 2, %2d %08x", bit, out_data);
+      ESP_LOGVV(TAG, "Decode Drayton: Fail 2, %2d %08" PRIx32, bit, out_data);
       return {};
     }
   }

--- a/esphome/components/remote_base/remote_base.cpp
+++ b/esphome/components/remote_base/remote_base.cpp
@@ -125,7 +125,7 @@ void RemoteTransmitterBase::send_(uint32_t send_times, uint32_t send_wait) {
   const auto &vec = this->temp_.get_data();
   char buffer[256];
   uint32_t buffer_offset = 0;
-  buffer_offset += sprintf(buffer, "Sending times=%u wait=%ums: ", send_times, send_wait);
+  buffer_offset += sprintf(buffer, "Sending times=%" PRIu32 " wait=%" PRIu32 "ms: ", send_times, send_wait);
 
   for (size_t i = 0; i < vec.size(); i++) {
     const int32_t value = vec[i];
@@ -133,9 +133,9 @@ void RemoteTransmitterBase::send_(uint32_t send_times, uint32_t send_wait) {
     int written;
 
     if (i + 1 < vec.size()) {
-      written = snprintf(buffer + buffer_offset, remaining_length, "%d, ", value);
+      written = snprintf(buffer + buffer_offset, remaining_length, "%" PRId32 ", ", value);
     } else {
-      written = snprintf(buffer + buffer_offset, remaining_length, "%d", value);
+      written = snprintf(buffer + buffer_offset, remaining_length, "%" PRId32, value);
     }
 
     if (written < 0 || written >= int(remaining_length)) {
@@ -145,9 +145,9 @@ void RemoteTransmitterBase::send_(uint32_t send_times, uint32_t send_wait) {
       buffer_offset = 0;
       written = sprintf(buffer, "  ");
       if (i + 1 < vec.size()) {
-        written += sprintf(buffer + written, "%d, ", value);
+        written += sprintf(buffer + written, "%" PRId32 ", ", value);
       } else {
-        written += sprintf(buffer + written, "%d", value);
+        written += sprintf(buffer + written, "%" PRId32, value);
       }
     }
 

--- a/esphome/components/remote_receiver/remote_receiver_esp32.cpp
+++ b/esphome/components/remote_receiver/remote_receiver_esp32.cpp
@@ -92,14 +92,18 @@ void RemoteReceiverComponent::decode_rmt_(rmt_item32_t *item, size_t len) {
   ESP_LOGVV(TAG, "START:");
   for (size_t i = 0; i < item_count; i++) {
     if (item[i].level0) {
-      ESP_LOGVV(TAG, "%u A: ON %uus (%u ticks)", i, this->to_microseconds_(item[i].duration0), item[i].duration0);
+      ESP_LOGVV(TAG, "%zu A: ON %" PRIu32 "us (%u ticks)", i, this->to_microseconds_(item[i].duration0),
+                item[i].duration0);
     } else {
-      ESP_LOGVV(TAG, "%u A: OFF %uus (%u ticks)", i, this->to_microseconds_(item[i].duration0), item[i].duration0);
+      ESP_LOGVV(TAG, "%zu A: OFF %" PRIu32 "us (%u ticks)", i, this->to_microseconds_(item[i].duration0),
+                item[i].duration0);
     }
     if (item[i].level1) {
-      ESP_LOGVV(TAG, "%u B: ON %uus (%u ticks)", i, this->to_microseconds_(item[i].duration1), item[i].duration1);
+      ESP_LOGVV(TAG, "%zu B: ON %" PRIu32 "us (%u ticks)", i, this->to_microseconds_(item[i].duration1),
+                item[i].duration1);
     } else {
-      ESP_LOGVV(TAG, "%u B: OFF %uus (%u ticks)", i, this->to_microseconds_(item[i].duration1), item[i].duration1);
+      ESP_LOGVV(TAG, "%zu B: OFF %" PRIu32 "us (%u ticks)", i, this->to_microseconds_(item[i].duration1),
+                item[i].duration1);
     }
   }
   ESP_LOGVV(TAG, "\n");

--- a/esphome/components/rf_bridge/rf_bridge.cpp
+++ b/esphome/components/rf_bridge/rf_bridge.cpp
@@ -1,5 +1,6 @@
 #include "rf_bridge.h"
 #include "esphome/core/log.h"
+#include <cinttypes>
 #include <cstring>
 
 namespace esphome {
@@ -53,8 +54,10 @@ bool RFBridgeComponent::parse_bridge_byte_(uint8_t byte) {
         ESP_LOGD(TAG, "Learning success");
       }
 
-      ESP_LOGI(TAG, "Received RFBridge Code: sync=0x%04X low=0x%04X high=0x%04X code=0x%06X", data.sync, data.low,
-               data.high, data.code);
+      ESP_LOGI(TAG,
+               "Received RFBridge Code: sync=0x%04" PRIX16 " low=0x%04" PRIX16 " high=0x%04" PRIX16
+               " code=0x%06" PRIX32,
+               data.sync, data.low, data.high, data.code);
       this->data_callback_.call(data);
       break;
     }
@@ -144,8 +147,8 @@ void RFBridgeComponent::loop() {
 }
 
 void RFBridgeComponent::send_code(RFBridgeData data) {
-  ESP_LOGD(TAG, "Sending code: sync=0x%04X low=0x%04X high=0x%04X code=0x%06X", data.sync, data.low, data.high,
-           data.code);
+  ESP_LOGD(TAG, "Sending code: sync=0x%04" PRIX16 " low=0x%04" PRIX16 " high=0x%04" PRIX16 " code=0x%06" PRIX32,
+           data.sync, data.low, data.high, data.code);
   this->write(RF_CODE_START);
   this->write(RF_CODE_RFOUT);
   this->write((data.sync >> 8) & 0xFF);

--- a/esphome/components/servo/servo.cpp
+++ b/esphome/components/servo/servo.cpp
@@ -1,6 +1,7 @@
 #include "servo.h"
 #include "esphome/core/log.h"
 #include "esphome/core/hal.h"
+#include <cinttypes>
 
 namespace esphome {
 namespace servo {
@@ -14,8 +15,8 @@ void Servo::dump_config() {
   ESP_LOGCONFIG(TAG, "  Idle Level: %.1f%%", this->idle_level_ * 100.0f);
   ESP_LOGCONFIG(TAG, "  Min Level: %.1f%%", this->min_level_ * 100.0f);
   ESP_LOGCONFIG(TAG, "  Max Level: %.1f%%", this->max_level_ * 100.0f);
-  ESP_LOGCONFIG(TAG, "  auto detach time: %d ms", this->auto_detach_time_);
-  ESP_LOGCONFIG(TAG, "  run duration: %d ms", this->transition_length_);
+  ESP_LOGCONFIG(TAG, "  auto detach time: %" PRIu32 " ms", this->auto_detach_time_);
+  ESP_LOGCONFIG(TAG, "  run duration: %" PRIu32 " ms", this->transition_length_);
 }
 
 void Servo::loop() {

--- a/esphome/components/sgp4x/sgp4x.cpp
+++ b/esphome/components/sgp4x/sgp4x.cpp
@@ -166,7 +166,7 @@ bool SGP4xComponent::measure_gas_indices_(int32_t &voc, int32_t &nox) {
   if (nox_sensor_) {
     nox = nox_algorithm_.process(nox_sraw);
   }
-  ESP_LOGV(TAG, "VOC = %d, NOx = %d", voc, nox);
+  ESP_LOGV(TAG, "VOC = %" PRId32 ", NOx = %" PRId32, voc, nox);
   // Store baselines after defined interval or if the difference between current and stored baseline becomes too
   // much
   if (this->store_baseline_ && this->seconds_since_last_store_ > SHORTEST_BASELINE_STORE_INTERVAL) {

--- a/esphome/components/spi/spi_arduino.cpp
+++ b/esphome/components/spi/spi_arduino.cpp
@@ -18,7 +18,7 @@ class SPIDelegateHw : public SPIDelegate {
 #elif defined(ESP8266)
     // Arduino ESP8266 library has mangled values for SPI modes :-(
     auto mode = (this->mode_ & 0x01) + ((this->mode_ & 0x02) << 3);
-    ESP_LOGV(TAG, "8266 mangled SPI mode 0x%X", mode);
+    ESP_LOGVV(TAG, "8266 mangled SPI mode 0x%X", mode);
     SPISettings const settings(this->data_rate_, this->bit_order_, mode);
 #else
     SPISettings const settings(this->data_rate_, this->bit_order_, this->mode_);

--- a/esphome/components/sprinkler/sprinkler.cpp
+++ b/esphome/components/sprinkler/sprinkler.cpp
@@ -4,6 +4,7 @@
 #include "esphome/core/application.h"
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
+#include <cinttypes>
 #include <utility>
 
 namespace esphome {
@@ -875,7 +876,7 @@ void Sprinkler::queue_valve(optional<size_t> valve_number, optional<uint32_t> ru
     if (this->is_a_valid_valve(valve_number.value()) && (this->queued_valves_.size() < this->max_queue_size_)) {
       SprinklerQueueItem item{valve_number.value(), run_duration.value()};
       this->queued_valves_.insert(this->queued_valves_.begin(), item);
-      ESP_LOGD(TAG, "Valve %u placed into queue with run duration of %u seconds", valve_number.value_or(0),
+      ESP_LOGD(TAG, "Valve %zu placed into queue with run duration of %" PRIu32 " seconds", valve_number.value_or(0),
                run_duration.value_or(0));
     }
   }
@@ -954,7 +955,7 @@ void Sprinkler::pause() {
   this->paused_valve_ = this->active_valve();
   this->resume_duration_ = this->time_remaining_active_valve();
   this->shutdown(false);
-  ESP_LOGD(TAG, "Paused valve %u with %u seconds remaining", this->paused_valve_.value_or(0),
+  ESP_LOGD(TAG, "Paused valve %zu with %" PRIu32 " seconds remaining", this->paused_valve_.value_or(0),
            this->resume_duration_.value_or(0));
 }
 
@@ -967,7 +968,7 @@ void Sprinkler::resume() {
   if (this->paused_valve_.has_value() && (this->resume_duration_.has_value())) {
     // Resume only if valve has not been completed yet
     if (!this->valve_cycle_complete_(this->paused_valve_.value())) {
-      ESP_LOGD(TAG, "Resuming valve %u with %u seconds remaining", this->paused_valve_.value_or(0),
+      ESP_LOGD(TAG, "Resuming valve %zu with %" PRIu32 " seconds remaining", this->paused_valve_.value_or(0),
                this->resume_duration_.value_or(0));
       this->fsm_request_(this->paused_valve_.value(), this->resume_duration_.value());
     }
@@ -1389,7 +1390,8 @@ void Sprinkler::load_next_valve_run_request_(const optional<size_t> first_valve)
       this->next_req_.set_run_duration(
           this->valve_run_duration_adjusted(this->next_valve_number_in_cycle_(first_valve).value_or(0)));
     } else if ((this->repeat_count_++ < this->repeat().value_or(0))) {
-      ESP_LOGD(TAG, "Repeating - starting cycle %u of %u", this->repeat_count_ + 1, this->repeat().value_or(0) + 1);
+      ESP_LOGD(TAG, "Repeating - starting cycle %" PRIu32 " of %" PRIu32, this->repeat_count_ + 1,
+               this->repeat().value_or(0) + 1);
       // if there are repeats remaining and no more valves were left in the cycle, start a new cycle
       this->prep_full_cycle_();
       if (this->next_valve_number_in_cycle_().has_value()) {  // this should always succeed here, but just in case...
@@ -1420,7 +1422,7 @@ void Sprinkler::start_valve_(SprinklerValveRunRequest *req) {
   for (auto &vo : this->valve_op_) {  // find the first available SprinklerValveOperator, load it and start it up
     if (vo.state() == IDLE) {
       auto run_duration = req->run_duration() ? req->run_duration() : this->valve_run_duration_adjusted(req->valve());
-      ESP_LOGD(TAG, "%s is starting valve %u for %u seconds, cycle %u of %u",
+      ESP_LOGD(TAG, "%s is starting valve %zu for %" PRIu32 " seconds, cycle %" PRIu32 " of %" PRIu32,
                this->req_as_str_(req->request_is_from()).c_str(), req->valve(), run_duration, this->repeat_count_ + 1,
                this->repeat().value_or(0) + 1);
       req->set_valve_operator(&vo);
@@ -1645,7 +1647,7 @@ void Sprinkler::start_timer_(const SprinklerTimerIndex timer_index) {
     this->timer_[timer_index].start_time = millis();
     this->timer_[timer_index].active = true;
   }
-  ESP_LOGVV(TAG, "Timer %u started for %u sec", static_cast<size_t>(timer_index),
+  ESP_LOGVV(TAG, "Timer %zu started for %" PRIu32 " sec", static_cast<size_t>(timer_index),
             this->timer_duration_(timer_index) / 1000);
 }
 
@@ -1684,48 +1686,48 @@ void Sprinkler::sm_timer_callback_() {
 void Sprinkler::dump_config() {
   ESP_LOGCONFIG(TAG, "Sprinkler Controller -- %s", this->name_.c_str());
   if (this->manual_selection_delay_.has_value()) {
-    ESP_LOGCONFIG(TAG, "  Manual Selection Delay: %u seconds", this->manual_selection_delay_.value_or(0));
+    ESP_LOGCONFIG(TAG, "  Manual Selection Delay: %" PRIu32 " seconds", this->manual_selection_delay_.value_or(0));
   }
   if (this->repeat().has_value()) {
-    ESP_LOGCONFIG(TAG, "  Repeat Cycles: %u times", this->repeat().value_or(0));
+    ESP_LOGCONFIG(TAG, "  Repeat Cycles: %" PRIu32 " times", this->repeat().value_or(0));
   }
   if (this->start_delay_) {
     if (this->start_delay_is_valve_delay_) {
-      ESP_LOGCONFIG(TAG, "  Pump Start Valve Delay: %u seconds", this->start_delay_);
+      ESP_LOGCONFIG(TAG, "  Pump Start Valve Delay: %" PRIu32 " seconds", this->start_delay_);
     } else {
-      ESP_LOGCONFIG(TAG, "  Pump Start Pump Delay: %u seconds", this->start_delay_);
+      ESP_LOGCONFIG(TAG, "  Pump Start Pump Delay: %" PRIu32 " seconds", this->start_delay_);
     }
   }
   if (this->stop_delay_) {
     if (this->stop_delay_is_valve_delay_) {
-      ESP_LOGCONFIG(TAG, "  Pump Stop Valve Delay: %u seconds", this->stop_delay_);
+      ESP_LOGCONFIG(TAG, "  Pump Stop Valve Delay: %" PRIu32 " seconds", this->stop_delay_);
     } else {
-      ESP_LOGCONFIG(TAG, "  Pump Stop Pump Delay: %u seconds", this->stop_delay_);
+      ESP_LOGCONFIG(TAG, "  Pump Stop Pump Delay: %" PRIu32 " seconds", this->stop_delay_);
     }
   }
   if (this->switching_delay_.has_value()) {
     if (this->valve_overlap_) {
-      ESP_LOGCONFIG(TAG, "  Valve Overlap: %u seconds", this->switching_delay_.value_or(0));
+      ESP_LOGCONFIG(TAG, "  Valve Overlap: %" PRIu32 " seconds", this->switching_delay_.value_or(0));
     } else {
-      ESP_LOGCONFIG(TAG, "  Valve Open Delay: %u seconds", this->switching_delay_.value_or(0));
+      ESP_LOGCONFIG(TAG, "  Valve Open Delay: %" PRIu32 " seconds", this->switching_delay_.value_or(0));
       ESP_LOGCONFIG(TAG, "  Pump Switch Off During Valve Open Delay: %s",
                     YESNO(this->pump_switch_off_during_valve_open_delay_));
     }
   }
   for (size_t valve_number = 0; valve_number < this->number_of_valves(); valve_number++) {
-    ESP_LOGCONFIG(TAG, "  Valve %u:", valve_number);
+    ESP_LOGCONFIG(TAG, "  Valve %zu:", valve_number);
     ESP_LOGCONFIG(TAG, "    Name: %s", this->valve_name(valve_number));
-    ESP_LOGCONFIG(TAG, "    Run Duration: %u seconds", this->valve_run_duration(valve_number));
+    ESP_LOGCONFIG(TAG, "    Run Duration: %" PRIu32 " seconds", this->valve_run_duration(valve_number));
     if (this->valve_[valve_number].valve_switch.pulse_duration()) {
-      ESP_LOGCONFIG(TAG, "    Pulse Duration: %u milliseconds",
+      ESP_LOGCONFIG(TAG, "    Pulse Duration: %" PRIu32 " milliseconds",
                     this->valve_[valve_number].valve_switch.pulse_duration());
     }
   }
   if (!this->pump_.empty()) {
-    ESP_LOGCONFIG(TAG, "  Total number of pumps: %u", this->pump_.size());
+    ESP_LOGCONFIG(TAG, "  Total number of pumps: %zu", this->pump_.size());
   }
   if (!this->valve_.empty()) {
-    ESP_LOGCONFIG(TAG, "  Total number of valves: %u", this->valve_.size());
+    ESP_LOGCONFIG(TAG, "  Total number of valves: %zu", this->valve_.size());
   }
 }
 

--- a/esphome/components/status_led/light/status_led_light.cpp
+++ b/esphome/components/status_led/light/status_led_light.cpp
@@ -1,6 +1,7 @@
 #include "status_led_light.h"
 #include "esphome/core/log.h"
 #include "esphome/core/application.h"
+#include <cinttypes>
 
 namespace esphome {
 namespace status_led {
@@ -11,7 +12,7 @@ void StatusLEDLightOutput::loop() {
   uint32_t new_state = App.get_app_state() & STATUS_LED_MASK;
 
   if (new_state != this->last_app_state_) {
-    ESP_LOGV(TAG, "New app state 0x%08X", new_state);
+    ESP_LOGV(TAG, "New app state 0x%08" PRIX32, new_state);
   }
 
   if ((new_state & STATUS_LED_ERROR) != 0u) {

--- a/esphome/components/thermostat/thermostat_climate.cpp
+++ b/esphome/components/thermostat/thermostat_climate.cpp
@@ -1,5 +1,6 @@
 #include "thermostat_climate.h"
 #include "esphome/core/log.h"
+#include <cinttypes>
 
 namespace esphome {
 namespace thermostat {
@@ -1283,11 +1284,13 @@ void ThermostatClimate::dump_config() {
     ESP_LOGCONFIG(TAG, "    Overrun: %.1f°C", this->cooling_overrun_);
     if ((this->supplemental_cool_delta_ > 0) || (this->timer_duration_(thermostat::TIMER_COOLING_MAX_RUN_TIME) > 0)) {
       ESP_LOGCONFIG(TAG, "    Supplemental Delta: %.1f°C", this->supplemental_cool_delta_);
-      ESP_LOGCONFIG(TAG, "    Maximum Run Time: %us",
+      ESP_LOGCONFIG(TAG, "    Maximum Run Time: %" PRIu32 "s",
                     this->timer_duration_(thermostat::TIMER_COOLING_MAX_RUN_TIME) / 1000);
     }
-    ESP_LOGCONFIG(TAG, "    Minimum Off Time: %us", this->timer_duration_(thermostat::TIMER_COOLING_OFF) / 1000);
-    ESP_LOGCONFIG(TAG, "    Minimum Run Time: %us", this->timer_duration_(thermostat::TIMER_COOLING_ON) / 1000);
+    ESP_LOGCONFIG(TAG, "    Minimum Off Time: %" PRIu32 "s",
+                  this->timer_duration_(thermostat::TIMER_COOLING_OFF) / 1000);
+    ESP_LOGCONFIG(TAG, "    Minimum Run Time: %" PRIu32 "s",
+                  this->timer_duration_(thermostat::TIMER_COOLING_ON) / 1000);
   }
   if (this->supports_heat_) {
     ESP_LOGCONFIG(TAG, "  Heating Parameters:");
@@ -1295,24 +1298,28 @@ void ThermostatClimate::dump_config() {
     ESP_LOGCONFIG(TAG, "    Overrun: %.1f°C", this->heating_overrun_);
     if ((this->supplemental_heat_delta_ > 0) || (this->timer_duration_(thermostat::TIMER_HEATING_MAX_RUN_TIME) > 0)) {
       ESP_LOGCONFIG(TAG, "    Supplemental Delta: %.1f°C", this->supplemental_heat_delta_);
-      ESP_LOGCONFIG(TAG, "    Maximum Run Time: %us",
+      ESP_LOGCONFIG(TAG, "    Maximum Run Time: %" PRIu32 "s",
                     this->timer_duration_(thermostat::TIMER_HEATING_MAX_RUN_TIME) / 1000);
     }
-    ESP_LOGCONFIG(TAG, "    Minimum Off Time: %us", this->timer_duration_(thermostat::TIMER_HEATING_OFF) / 1000);
-    ESP_LOGCONFIG(TAG, "    Minimum Run Time: %us", this->timer_duration_(thermostat::TIMER_HEATING_ON) / 1000);
+    ESP_LOGCONFIG(TAG, "    Minimum Off Time: %" PRIu32 "s",
+                  this->timer_duration_(thermostat::TIMER_HEATING_OFF) / 1000);
+    ESP_LOGCONFIG(TAG, "    Minimum Run Time: %" PRIu32 "s",
+                  this->timer_duration_(thermostat::TIMER_HEATING_ON) / 1000);
   }
   if (this->supports_fan_only_) {
-    ESP_LOGCONFIG(TAG, "  Fanning Minimum Off Time: %us", this->timer_duration_(thermostat::TIMER_FANNING_OFF) / 1000);
-    ESP_LOGCONFIG(TAG, "  Fanning Minimum Run Time: %us", this->timer_duration_(thermostat::TIMER_FANNING_ON) / 1000);
+    ESP_LOGCONFIG(TAG, "  Fanning Minimum Off Time: %" PRIu32 "s",
+                  this->timer_duration_(thermostat::TIMER_FANNING_OFF) / 1000);
+    ESP_LOGCONFIG(TAG, "  Fanning Minimum Run Time: %" PRIu32 "s",
+                  this->timer_duration_(thermostat::TIMER_FANNING_ON) / 1000);
   }
   if (this->supports_fan_mode_on_ || this->supports_fan_mode_off_ || this->supports_fan_mode_auto_ ||
       this->supports_fan_mode_low_ || this->supports_fan_mode_medium_ || this->supports_fan_mode_high_ ||
       this->supports_fan_mode_middle_ || this->supports_fan_mode_focus_ || this->supports_fan_mode_diffuse_ ||
       this->supports_fan_mode_quiet_) {
-    ESP_LOGCONFIG(TAG, "  Minimum Fan Mode Switching Time: %us",
+    ESP_LOGCONFIG(TAG, "  Minimum Fan Mode Switching Time: %" PRIu32 "s",
                   this->timer_duration_(thermostat::TIMER_FAN_MODE) / 1000);
   }
-  ESP_LOGCONFIG(TAG, "  Minimum Idle Time: %us", this->timer_[thermostat::TIMER_IDLE_ON].time / 1000);
+  ESP_LOGCONFIG(TAG, "  Minimum Idle Time: %" PRIu32 "s", this->timer_[thermostat::TIMER_IDLE_ON].time / 1000);
   ESP_LOGCONFIG(TAG, "  Supports AUTO: %s", YESNO(this->supports_auto_));
   ESP_LOGCONFIG(TAG, "  Supports HEAT/COOL: %s", YESNO(this->supports_heat_cool_));
   ESP_LOGCONFIG(TAG, "  Supports COOL: %s", YESNO(this->supports_cool_));

--- a/esphome/components/tof10120/tof10120_sensor.cpp
+++ b/esphome/components/tof10120/tof10120_sensor.cpp
@@ -1,6 +1,7 @@
 #include "tof10120_sensor.h"
 #include "esphome/core/log.h"
 #include "esphome/core/hal.h"
+#include <cinttypes>
 
 // Very basic support for TOF10120 distance sensor
 
@@ -44,7 +45,7 @@ void TOF10120Sensor::update() {
   }
 
   uint32_t distance_mm = (data[0] << 8) | data[1];
-  ESP_LOGI(TAG, "Data read: %dmm", distance_mm);
+  ESP_LOGI(TAG, "Data read: %" PRIu32 "mm", distance_mm);
 
   if (distance_mm == TOF10120_OUT_OF_RANGE_VALUE) {
     ESP_LOGW(TAG, "Distance measurement out of range");

--- a/esphome/components/tuya/sensor/tuya_sensor.cpp
+++ b/esphome/components/tuya/sensor/tuya_sensor.cpp
@@ -1,5 +1,6 @@
 #include "esphome/core/log.h"
 #include "tuya_sensor.h"
+#include <cinttypes>
 
 namespace esphome {
 namespace tuya {
@@ -18,7 +19,7 @@ void TuyaSensor::setup() {
       ESP_LOGV(TAG, "MCU reported sensor %u is: %u", datapoint.id, datapoint.value_enum);
       this->publish_state(datapoint.value_enum);
     } else if (datapoint.type == TuyaDatapointType::BITMASK) {
-      ESP_LOGV(TAG, "MCU reported sensor %u is: %x", datapoint.id, datapoint.value_bitmask);
+      ESP_LOGV(TAG, "MCU reported sensor %u is: %" PRIx32, datapoint.id, datapoint.value_bitmask);
       this->publish_state(datapoint.value_bitmask);
     }
   });

--- a/esphome/components/vbus/vbus.cpp
+++ b/esphome/components/vbus/vbus.cpp
@@ -1,6 +1,7 @@
 #include "vbus.h"
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
+#include <cinttypes>
 
 namespace esphome {
 namespace vbus {
@@ -64,8 +65,8 @@ void VBus::loop() {
         uint16_t id = (this->buffer_[8] << 8) + this->buffer_[7];
         uint32_t value =
             (this->buffer_[12] << 24) + (this->buffer_[11] << 16) + (this->buffer_[10] << 8) + this->buffer_[9];
-        ESP_LOGV(TAG, "P1 C%04x %04x->%04x: %04x %04x (%d)", this->command_, this->source_, this->dest_, id, value,
-                 value);
+        ESP_LOGV(TAG, "P1 C%04x %04x->%04x: %04x %04" PRIx32 " (%" PRIu32 ")", this->command_, this->source_,
+                 this->dest_, id, value, value);
       } else if ((this->protocol_ == 0x10) && (this->buffer_.size() == 9)) {
         if (!checksum(this->buffer_.data(), 0, 9)) {
           ESP_LOGE(TAG, "P1 checksum failed");

--- a/esphome/components/wireguard/wireguard.cpp
+++ b/esphome/components/wireguard/wireguard.cpp
@@ -2,6 +2,7 @@
 
 #ifdef USE_ESP32
 
+#include <cinttypes>
 #include <ctime>
 #include <functional>
 
@@ -144,7 +145,7 @@ void Wireguard::dump_config() {
   }
   ESP_LOGCONFIG(TAG, "  Peer Persistent Keepalive: %d%s", this->keepalive_,
                 (this->keepalive_ > 0 ? "s" : " (DISABLED)"));
-  ESP_LOGCONFIG(TAG, "  Reboot Timeout: %d%s", (this->reboot_timeout_ / 1000),
+  ESP_LOGCONFIG(TAG, "  Reboot Timeout: %" PRIu32 "%s", (this->reboot_timeout_ / 1000),
                 (this->reboot_timeout_ != 0 ? "s" : " (DISABLED)"));
   // be careful: if proceed_allowed_ is true, require connection is false
   ESP_LOGCONFIG(TAG, "  Require Connection to Proceed: %s", (this->proceed_allowed_ ? "NO" : "YES"));
@@ -287,7 +288,7 @@ void resume_wdt() {
 #if ESP_IDF_VERSION_MAJOR >= 5
   wdtc.timeout_ms = CONFIG_ESP_TASK_WDT_TIMEOUT_S * 1000;
   esp_task_wdt_reconfigure(&wdtc);
-  ESP_LOGV(TAG, "wdt resumed with %d ms timeout", wdtc.timeout_ms);
+  ESP_LOGV(TAG, "wdt resumed with %" PRIu32 " ms timeout", wdtc.timeout_ms);
 #else
   esp_task_wdt_init(CONFIG_ESP_TASK_WDT_TIMEOUT_S, false);
   ESP_LOGV(TAG, "wdt resumed with %d seconds timeout", CONFIG_ESP_TASK_WDT_TIMEOUT_S);


### PR DESCRIPTION
# What does this implement/fix?

Trying to compile with the latest esp-idf for an esp32c6 (specifically the OLIMEX ESP32-C6-EVB) with logging set to VERBOSE or VERY_VERBOSE resulted in a number of components failing to compile.

This is mostly due to incorrect printf modifiers for \*int32_t types.
#4671 addressed some of the format strings but only for default logging.
This PR addresses as many as I could get to compile on an esp32c6, which is hopefully most of them now.

Tested on ESP32-C6 (esp-idf), ESP32 (arduino), and an ESP8266 (arduino).

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Test Environment

- [X] ESP32
- [X] ESP32 IDF
- [X] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
esphome:
  name: esp32c6
  friendly_name: esp32c6
  # OLIMEX ESP32-C6-EVB
  # platformio esp32-c6-devkitm-1 claims 320K RAM which appears wrong per the datasheet
  # platformio esp32-c6-devkitc-1 has RAM right, but has 8MB flash, we actually have 4MB, so fix it:
  platformio_options:
    board_build.flash_size: 4MB
    board_upload.flash_size: 4MB
    board_upload.maximum_size: 4194304

esp32:
  board: esp32-c6-devkitc-1
  variant: esp32c6
  framework:
    type: esp-idf
    version: latest
    platform_version: "https://github.com/stintel/platform-espressif32#esp32-c6-test"

logger:
  level: VERY_VERBOSE
api:
ota:
wifi:
  ssid: !secret wifi_ssid
  password: !secret wifi_password
captive_portal:

# These won't compile with VERBOSE logging prior to this PR
binary_sensor:
  # Button
  - platform: gpio
    name: BUT1
    pin:
      number: 9
      mode:
        input: true
        pullup: true
      inverted: true
light:
  - platform: status_led
    name: "Status LED"
    pin:
      inverted: true
      number: 8
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
