### PR TITLE
Implement variable length single word SPI writes.

### DIFF
--- a/esphome/components/spi/spi.h
+++ b/esphome/components/spi/spi.h
@@ -203,7 +203,6 @@ class SPIDelegate {
    * write a variable length data item, up to 16 bits.
    * @param data The data to send. Should be LSB-aligned (i.e. top bits will be discarded.)
    * @param num_bits The number of bits to send
-   * @return The data clocked in, or -1 on error
    */
   virtual void write(uint16_t data, size_t num_bits) {
     esph_log_e("spi_device", "variable length write not implemented");

--- a/esphome/components/spi/spi.h
+++ b/esphome/components/spi/spi.h
@@ -199,6 +199,16 @@ class SPIDelegate {
       rxbuf[i] = this->transfer(txbuf[i]);
   }
 
+  /**
+   * write a variable length data item, up to 16 bits.
+   * @param data The data to send. Should be LSB-aligned (i.e. top bits will be discarded.)
+   * @param num_bits The number of bits to send
+   * @return The data clocked in, or -1 on error
+   */
+  virtual void write(uint16_t data, size_t num_bits) {
+    esph_log_e("spi_device", "variable length write not implemented");
+  }
+
   // write 16 bits
   virtual void write16(uint16_t data) {
     if (this->bit_order_ == BIT_ORDER_MSB_FIRST) {
@@ -270,6 +280,10 @@ class SPIDelegateBitBash : public SPIDelegate {
 
   uint8_t transfer(uint8_t data) override;
 
+  void write(uint16_t data, size_t num_bits) override;
+
+  void write16(uint16_t data) override { this->write(data, 16); };
+
  protected:
   GPIOPin *clk_pin_;
   GPIOPin *sdo_pin_;
@@ -284,6 +298,7 @@ class SPIDelegateBitBash : public SPIDelegate {
       continue;
     this->last_transition_ += this->wait_cycle_;
   }
+  uint16_t transfer_(uint16_t data, size_t num_bits);
 };
 
 class SPIBus {
@@ -407,6 +422,8 @@ class SPIDevice : public SPIClient {
   uint8_t read_byte() { return this->delegate_->transfer(0); }
 
   void read_array(uint8_t *data, size_t length) { return this->delegate_->read_array(data, length); }
+
+  void write(uint16_t data, size_t num_bits) { this->delegate_->write(data, num_bits); };
 
   void write_byte(uint8_t data) { this->delegate_->write_array(&data, 1); }
 

--- a/esphome/components/spi/spi_esp_idf.cpp
+++ b/esphome/components/spi/spi_esp_idf.cpp
@@ -72,7 +72,11 @@ class SPIDelegateHw : public SPIDelegate {
       desc.rxlength = this->write_only_ ? 0 : partial * 8;
       desc.tx_buffer = txbuf;
       desc.rx_buffer = rxbuf;
-      esp_err_t const err = spi_device_transmit(this->handle_, &desc);
+      // polling is used as it has about 10% less overhead than queuing an interrupt transfer
+      esp_err_t err = spi_device_polling_start(this->handle_, &desc, portMAX_DELAY);
+      if (err == ESP_OK) {
+        err = spi_device_polling_end(this->handle_, portMAX_DELAY);
+      }
       if (err != ESP_OK) {
         ESP_LOGE(TAG, "Transmit failed - err %X", err);
         break;
@@ -90,7 +94,11 @@ class SPIDelegateHw : public SPIDelegate {
     desc.command_bits = num_bits;
     desc.base.flags = SPI_TRANS_VARIABLE_CMD;
     desc.base.cmd = data;
-    esp_err_t const err = spi_device_transmit(this->handle_, (spi_transaction_t *) &desc);
+    esp_err_t err = spi_device_polling_start(this->handle_, (spi_transaction_t *) &desc, portMAX_DELAY);
+    if (err == ESP_OK) {
+      err = spi_device_polling_end(this->handle_, portMAX_DELAY);
+    }
+
     if (err != ESP_OK) {
       ESP_LOGE(TAG, "Transmit failed - err %X", err);
     }

--- a/esphome/components/spi/spi_esp_idf.cpp
+++ b/esphome/components/spi/spi_esp_idf.cpp
@@ -85,6 +85,17 @@ class SPIDelegateHw : public SPIDelegate {
     }
   }
 
+  void write(uint16_t data, size_t num_bits) override {
+    spi_transaction_ext_t desc = {};
+    desc.command_bits = num_bits;
+    desc.base.flags = SPI_TRANS_VARIABLE_CMD;
+    desc.base.cmd = data;
+    esp_err_t const err = spi_device_transmit(this->handle_, (spi_transaction_t *) &desc);
+    if (err != ESP_OK) {
+      ESP_LOGE(TAG, "Transmit failed - err %X", err);
+    }
+  }
+
   void transfer(uint8_t *ptr, size_t length) override { this->transfer(ptr, ptr, length); }
 
   uint8_t transfer(uint8_t data) override {
@@ -93,14 +104,7 @@ class SPIDelegateHw : public SPIDelegate {
     return rxbuf;
   }
 
-  void write16(uint16_t data) override {
-    if (this->bit_order_ == BIT_ORDER_MSB_FIRST) {
-      uint16_t txbuf = SPI_SWAP_DATA_TX(data, 16);
-      this->transfer((uint8_t *) &txbuf, nullptr, 2);
-    } else {
-      this->transfer((uint8_t *) &data, nullptr, 2);
-    }
-  }
+  void write16(uint16_t data) override { this->write(data, 16); }
 
   void write_array(const uint8_t *ptr, size_t length) override { this->transfer(ptr, nullptr, length); }
 


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

1. Implement variable-width writes. This is mainly to support 3-wire SPI mode on certain displays, where a 9 bit transfer is required. Also improves 16 bit writes. This is for ESP-IDF only, will not work on Arduino.
2. Small reduction in SPI setup overhead by switching from queued interrupt to polling transactions for ESP-IDF only.
## Types of changes

- [x] Other

## Test Environment

- [x] ESP32 IDF


## Checklist:
  - [x] The code change is tested and works locally.

