### PR TITLE
Implement a memory cache for dashboard entries to avoid frequent disk reads

### DIFF
--- a/esphome/dashboard/dashboard.py
+++ b/esphome/dashboard/dashboard.py
@@ -154,6 +154,16 @@ class DashboardSettings:
             )
 
         entry_cache = self._entry_cache
+
+        # Remove entries that no longer exist
+        removed: list[str] = []
+        for file in entry_cache:
+            if file not in path_to_cache_key:
+                removed.append(file)
+
+        for file in removed:
+            entry_cache.pop(file)
+
         dashboard_entries: list[DashboardEntry] = []
         for file, cache_key in path_to_cache_key.items():
             if cached_entry := entry_cache.get(file):
@@ -165,15 +175,6 @@ class DashboardSettings:
             dashboard_entry = DashboardEntry(file)
             dashboard_entries.append(dashboard_entry)
             entry_cache[file] = (cache_key, dashboard_entry)
-
-        # Remove entries that no longer exist
-        removed: list[str] = []
-        for file in entry_cache:
-            if file not in path_to_cache_key:
-                removed.append(file)
-
-        for file in removed:
-            entry_cache.pop(file)
 
         return dashboard_entries
 

--- a/esphome/dashboard/dashboard.py
+++ b/esphome/dashboard/dashboard.py
@@ -145,7 +145,7 @@ class DashboardSettings:
         # does not have a lock contention issue.
         #
         for file in self.list_yaml_files():
-            stat = Path(file).stat()
+            stat = os.stat(ext_storage_path(os.path.basename(file)))
             path_to_cache_key[file] = (
                 stat.st_ino,
                 stat.st_dev,

--- a/esphome/dashboard/dashboard.py
+++ b/esphome/dashboard/dashboard.py
@@ -127,7 +127,7 @@ class DashboardSettings:
     def list_yaml_files(self) -> list[str]:
         return util.list_yaml_files([self.config_dir])
 
-    def entries(self):
+    def entries(self) -> list[DashboardEntry]:
         """Fetch all dashboard entries, thread-safe."""
         path_to_cache_key: dict[str, tuple[int, int, float, int]] = {}
         #

--- a/esphome/dashboard/dashboard.py
+++ b/esphome/dashboard/dashboard.py
@@ -145,7 +145,17 @@ class DashboardSettings:
         # does not have a lock contention issue.
         #
         for file in self.list_yaml_files():
-            stat = os.stat(ext_storage_path(os.path.basename(file)))
+            try:
+                # Prefer the json storage path if it exists
+                stat = os.stat(ext_storage_path(os.path.basename(file)))
+            except OSError:
+                try:
+                    # Fallback to the yaml file if the storage
+                    # file does not exist or could not be generated
+                    stat = os.stat(file)
+                except OSError:
+                    # File was deleted, ignore
+                    continue
             path_to_cache_key[file] = (
                 stat.st_ino,
                 stat.st_dev,


### PR DESCRIPTION
# What does this implement/fix?


We now `stat()` the files to be loaded and if we already have the entry with the same properties in the cache, we avoid re-creating the `DashboardEntry` object and in turn reading the json file from disk

The api would call `/devices` over and over which would hit the disk over and over.

<img width="1248" alt="Screenshot 2023-11-06 at 8 05 00 PM" src="https://github.com/esphome/esphome/assets/663432/c8b6d820-55bb-47dc-a2be-0adc5684ce88">
<img width="1283" alt="Screenshot 2023-11-06 at 8 03 59 PM" src="https://github.com/esphome/esphome/assets/663432/a5fd690a-578f-4ad5-a441-c4d3b4a26364">




## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
