### PR TITLE
Add gradient option to addressable color wipe effect

### DIFF
--- a/esphome/components/light/addressable_light_effect.h
+++ b/esphome/components/light/addressable_light_effect.h
@@ -152,7 +152,6 @@ class AddressableColorWipeEffect : public AddressableLightEffect {
   uint32_t add_led_interval_{};
   size_t leds_added_{0};
   bool reverse_{};
-  bool gradient_{};
 };
 
 class AddressableScanEffect : public AddressableLightEffect {

--- a/esphome/components/light/addressable_light_effect.h
+++ b/esphome/components/light/addressable_light_effect.h
@@ -108,6 +108,7 @@ class AddressableColorWipeEffect : public AddressableLightEffect {
   void set_colors(const std::vector<AddressableColorWipeEffectColor> &colors) { this->colors_ = colors; }
   void set_add_led_interval(uint32_t add_led_interval) { this->add_led_interval_ = add_led_interval; }
   void set_reverse(bool reverse) { this->reverse_ = reverse; }
+  void set_gradient(bool gradient) { this->gradient_ = gradient; }
   void apply(AddressableLight &it, const Color &current_color) override {
     const uint32_t now = millis();
     if (now - this->last_add_ < this->add_led_interval_)
@@ -118,7 +119,14 @@ class AddressableColorWipeEffect : public AddressableLightEffect {
     else
       it.shift_right(1);
     const AddressableColorWipeEffectColor color = this->colors_[this->at_color_];
-    const Color esp_color = Color(color.r, color.g, color.b, color.w);
+    Color esp_color = Color(color.r, color.g, color.b, color.w);
+    if(this->gradient_) {
+      size_t next_color_index = (this->at_color_ + 1) % this->colors_.size();
+      const AddressableColorWipeEffectColor next_color = this->colors_[next_color_index];
+      const Color next_esp_color = Color(next_color.r, next_color.g, next_color.b, next_color.w);
+      uint8_t gradient = 255 * ((float)this->leds_added_ / color.num_leds);
+      esp_color = esp_color.gradient(next_esp_color, gradient);
+    }
     if (this->reverse_)
       it[-1] = esp_color;
     else
@@ -144,6 +152,7 @@ class AddressableColorWipeEffect : public AddressableLightEffect {
   uint32_t add_led_interval_{};
   size_t leds_added_{0};
   bool reverse_{};
+  bool gradient_{};
 };
 
 class AddressableScanEffect : public AddressableLightEffect {

--- a/esphome/components/light/addressable_light_effect.h
+++ b/esphome/components/light/addressable_light_effect.h
@@ -100,6 +100,7 @@ struct AddressableColorWipeEffectColor {
   uint8_t r, g, b, w;
   bool random;
   size_t num_leds;
+  bool gradient;
 };
 
 class AddressableColorWipeEffect : public AddressableLightEffect {
@@ -108,7 +109,6 @@ class AddressableColorWipeEffect : public AddressableLightEffect {
   void set_colors(const std::vector<AddressableColorWipeEffectColor> &colors) { this->colors_ = colors; }
   void set_add_led_interval(uint32_t add_led_interval) { this->add_led_interval_ = add_led_interval; }
   void set_reverse(bool reverse) { this->reverse_ = reverse; }
-  void set_gradient(bool gradient) { this->gradient_ = gradient; }
   void apply(AddressableLight &it, const Color &current_color) override {
     const uint32_t now = millis();
     if (now - this->last_add_ < this->add_led_interval_)
@@ -118,11 +118,11 @@ class AddressableColorWipeEffect : public AddressableLightEffect {
       it.shift_left(1);
     else
       it.shift_right(1);
-    const AddressableColorWipeEffectColor color = this->colors_[this->at_color_];
+    const AddressableColorWipeEffectColor &color = this->colors_[this->at_color_];
     Color esp_color = Color(color.r, color.g, color.b, color.w);
-    if (this->gradient_) {
+    if (color.gradient) {
       size_t next_color_index = (this->at_color_ + 1) % this->colors_.size();
-      const AddressableColorWipeEffectColor next_color = this->colors_[next_color_index];
+      const AddressableColorWipeEffectColor &next_color = this->colors_[next_color_index];
       const Color next_esp_color = Color(next_color.r, next_color.g, next_color.b, next_color.w);
       uint8_t gradient = 255 * ((float) this->leds_added_ / color.num_leds);
       esp_color = esp_color.gradient(next_esp_color, gradient);

--- a/esphome/components/light/addressable_light_effect.h
+++ b/esphome/components/light/addressable_light_effect.h
@@ -120,11 +120,11 @@ class AddressableColorWipeEffect : public AddressableLightEffect {
       it.shift_right(1);
     const AddressableColorWipeEffectColor color = this->colors_[this->at_color_];
     Color esp_color = Color(color.r, color.g, color.b, color.w);
-    if(this->gradient_) {
+    if (this->gradient_) {
       size_t next_color_index = (this->at_color_ + 1) % this->colors_.size();
       const AddressableColorWipeEffectColor next_color = this->colors_[next_color_index];
       const Color next_esp_color = Color(next_color.r, next_color.g, next_color.b, next_color.w);
-      uint8_t gradient = 255 * ((float)this->leds_added_ / color.num_leds);
+      uint8_t gradient = 255 * ((float) this->leds_added_ / color.num_leds);
       esp_color = esp_color.gradient(next_esp_color, gradient);
     }
     if (this->reverse_)

--- a/esphome/components/light/effects.py
+++ b/esphome/components/light/effects.py
@@ -386,8 +386,8 @@ async def addressable_rainbow_effect_to_code(config, effect_id):
                 cv.Optional(CONF_BLUE, default=1.0): cv.percentage,
                 cv.Optional(CONF_WHITE, default=1.0): cv.percentage,
                 cv.Optional(CONF_RANDOM, default=False): cv.boolean,
-                cv.Optional(CONF_NUM_LEDS): cv.All(cv.uint32_t, cv.Range(min=1)),
-                cv.Optional(CONF_GRADIENT): cv.boolean,
+                cv.Required(CONF_NUM_LEDS): cv.All(cv.uint32_t, cv.Range(min=1)),
+                cv.Optional(CONF_GRADIENT, default=False): cv.boolean,
             }
         ),
         cv.Optional(
@@ -401,11 +401,7 @@ async def addressable_color_wipe_effect_to_code(config, effect_id):
     cg.add(var.set_add_led_interval(config[CONF_ADD_LED_INTERVAL]))
     cg.add(var.set_reverse(config[CONF_REVERSE]))
     colors = []
-    num_leds = 1
-    gradient = False
     for color in config.get(CONF_COLORS, []):
-        num_leds = color.get(CONF_NUM_LEDS, num_leds)
-        gradient = color.get(CONF_GRADIENT, gradient)
         colors.append(
             cg.StructInitializer(
                 AddressableColorWipeEffectColor,
@@ -414,8 +410,8 @@ async def addressable_color_wipe_effect_to_code(config, effect_id):
                 ("b", int(round(color[CONF_BLUE] * 255))),
                 ("w", int(round(color[CONF_WHITE] * 255))),
                 ("random", color[CONF_RANDOM]),
-                ("num_leds", num_leds),
-                ("gradient", gradient),
+                ("num_leds", color[CONF_NUM_LEDS]),
+                ("gradient", color[CONF_GRADIENT]),
             )
         )
     cg.add(var.set_colors(colors))

--- a/esphome/components/light/effects.py
+++ b/esphome/components/light/effects.py
@@ -387,24 +387,25 @@ async def addressable_rainbow_effect_to_code(config, effect_id):
                 cv.Optional(CONF_WHITE, default=1.0): cv.percentage,
                 cv.Optional(CONF_RANDOM, default=False): cv.boolean,
                 cv.Optional(CONF_NUM_LEDS): cv.All(cv.uint32_t, cv.Range(min=1)),
+                cv.Optional(CONF_GRADIENT): cv.boolean,
             }
         ),
         cv.Optional(
             CONF_ADD_LED_INTERVAL, default="0.1s"
         ): cv.positive_time_period_milliseconds,
         cv.Optional(CONF_REVERSE, default=False): cv.boolean,
-        cv.Optional(CONF_GRADIENT, default=False): cv.boolean,
     },
 )
 async def addressable_color_wipe_effect_to_code(config, effect_id):
     var = cg.new_Pvariable(effect_id, config[CONF_NAME])
     cg.add(var.set_add_led_interval(config[CONF_ADD_LED_INTERVAL]))
     cg.add(var.set_reverse(config[CONF_REVERSE]))
-    cg.add(var.set_gradient(config[CONF_GRADIENT]))
     colors = []
     num_leds = 1
+    gradient = False
     for color in config.get(CONF_COLORS, []):
         num_leds = color.get(CONF_NUM_LEDS, num_leds)
+        gradient = color.get(CONF_GRADIENT, gradient)
         colors.append(
             cg.StructInitializer(
                 AddressableColorWipeEffectColor,
@@ -414,6 +415,7 @@ async def addressable_color_wipe_effect_to_code(config, effect_id):
                 ("w", int(round(color[CONF_WHITE] * 255))),
                 ("random", color[CONF_RANDOM]),
                 ("num_leds", num_leds),
+                ("gradient", gradient)
             )
         )
     cg.add(var.set_colors(colors))

--- a/esphome/components/light/effects.py
+++ b/esphome/components/light/effects.py
@@ -415,7 +415,7 @@ async def addressable_color_wipe_effect_to_code(config, effect_id):
                 ("w", int(round(color[CONF_WHITE] * 255))),
                 ("random", color[CONF_RANDOM]),
                 ("num_leds", num_leds),
-                ("gradient", gradient)
+                ("gradient", gradient),
             )
         )
     cg.add(var.set_colors(colors))

--- a/esphome/components/light/effects.py
+++ b/esphome/components/light/effects.py
@@ -58,6 +58,7 @@ from .types import (
 
 CONF_ADD_LED_INTERVAL = "add_led_interval"
 CONF_REVERSE = "reverse"
+CONF_GRADIENT = "gradient"
 CONF_MOVE_INTERVAL = "move_interval"
 CONF_SCAN_WIDTH = "scan_width"
 CONF_TWINKLE_PROBABILITY = "twinkle_probability"
@@ -385,21 +386,25 @@ async def addressable_rainbow_effect_to_code(config, effect_id):
                 cv.Optional(CONF_BLUE, default=1.0): cv.percentage,
                 cv.Optional(CONF_WHITE, default=1.0): cv.percentage,
                 cv.Optional(CONF_RANDOM, default=False): cv.boolean,
-                cv.Required(CONF_NUM_LEDS): cv.All(cv.uint32_t, cv.Range(min=1)),
+                cv.Optional(CONF_NUM_LEDS): cv.All(cv.uint32_t, cv.Range(min=1)),
             }
         ),
         cv.Optional(
             CONF_ADD_LED_INTERVAL, default="0.1s"
         ): cv.positive_time_period_milliseconds,
         cv.Optional(CONF_REVERSE, default=False): cv.boolean,
+        cv.Optional(CONF_GRADIENT, default=False): cv.boolean,
     },
 )
 async def addressable_color_wipe_effect_to_code(config, effect_id):
     var = cg.new_Pvariable(effect_id, config[CONF_NAME])
     cg.add(var.set_add_led_interval(config[CONF_ADD_LED_INTERVAL]))
     cg.add(var.set_reverse(config[CONF_REVERSE]))
+    cg.add(var.set_gradient(config[CONF_GRADIENT]))
     colors = []
+    num_leds = 1
     for color in config.get(CONF_COLORS, []):
+        num_leds = color.get(CONF_NUM_LEDS, num_leds)
         colors.append(
             cg.StructInitializer(
                 AddressableColorWipeEffectColor,
@@ -408,7 +413,7 @@ async def addressable_color_wipe_effect_to_code(config, effect_id):
                 ("b", int(round(color[CONF_BLUE] * 255))),
                 ("w", int(round(color[CONF_WHITE] * 255))),
                 ("random", color[CONF_RANDOM]),
-                ("num_leds", color[CONF_NUM_LEDS]),
+                ("num_leds", num_leds),
             )
         )
     cg.add(var.set_colors(colors))


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->
This PR adds a new option to the addressable color wipe effect to enable gradient transitions between colors.

This also addresses the code/doc discrepancy of `num_leds` being required/options respectively. The approach taken is to honor the docs and allow it to be optional (see docs PR for details). The only catch here is that I couldn't figure out how to get voluptuous to statefully reference previous entries in a list as a default value, so my approach was to tackle this during code generation which I know isn't the preferred method.

For the new `gradient` option, I used the same approach above. Maybe a better approach for both is explicit rather than implicit, and make `num_leds` required, and have `gradient` optional, but default to `false`. I'm looking for opinions and input on this.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#3339

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
light:
  - platform: neopixelbus
    type: RGB
    pin: D2
    num_leds: 50
    method: BIT_BANG
    variant: ws2811
    id: lights
    name: "Holiday Lights"
    effects:
      - addressable_color_wipe:
          name: thanksgiving
          add_led_interval: 30ms
          reverse: false
          colors:
            - # yellow
              red: 100%
              green: 91%
              blue: 0%
              num_leds: 10
              gradient: true
            - # red
              red: 100%
              green: 6%
              blue: 18%
            - # orange solid
              red: 100%
              green: 63%
              blue: 0%
              gradient: false
              num_leds: 100
            - # orange
              red: 100%
              green: 63%
              blue: 0%
              gradient: true
              num_leds: 10
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
