### PR TITLE
Handle nanoseconds in config

### DIFF
--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -742,7 +742,10 @@ def time_period_str_unit(value):
         raise Invalid(f"Expected time period with unit, got {value}")
     kwarg = unit_to_kwarg[one_of(*unit_to_kwarg)(match.group(2))]
 
-    return TimePeriod(**{kwarg: float(match.group(1))})
+    try:
+        return TimePeriod(**{kwarg: float(match.group(1))})
+    except ValueError as e:
+        raise Invalid(e) from e
 
 
 def time_period_in_milliseconds_(value):

--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -66,6 +66,7 @@ from esphome.core import (
     TimePeriod,
     TimePeriodMicroseconds,
     TimePeriodMilliseconds,
+    TimePeriodNanoseconds,
     TimePeriodSeconds,
     TimePeriodMinutes,
 )
@@ -718,6 +719,8 @@ def time_period_str_unit(value):
         raise Invalid("Expected string for time period with unit.")
 
     unit_to_kwarg = {
+        "ns": "nanoseconds",
+        "nanoseconds": "nanoseconds",
         "us": "microseconds",
         "microseconds": "microseconds",
         "ms": "milliseconds",
@@ -749,10 +752,18 @@ def time_period_in_milliseconds_(value):
 
 
 def time_period_in_microseconds_(value):
+    if value.nanoseconds is not None and value.nanoseconds != 0:
+        raise Invalid("Maximum precision is microseconds")
     return TimePeriodMicroseconds(**value.as_dict())
 
 
+def time_period_in_nanoseconds_(value):
+    return TimePeriodNanoseconds(**value.as_dict())
+
+
 def time_period_in_seconds_(value):
+    if value.nanoseconds is not None and value.nanoseconds != 0:
+        raise Invalid("Maximum precision is seconds")
     if value.microseconds is not None and value.microseconds != 0:
         raise Invalid("Maximum precision is seconds")
     if value.milliseconds is not None and value.milliseconds != 0:
@@ -761,6 +772,8 @@ def time_period_in_seconds_(value):
 
 
 def time_period_in_minutes_(value):
+    if value.nanoseconds is not None and value.nanoseconds != 0:
+        raise Invalid("Maximum precision is minutes")
     if value.microseconds is not None and value.microseconds != 0:
         raise Invalid("Maximum precision is minutes")
     if value.milliseconds is not None and value.milliseconds != 0:
@@ -786,6 +799,9 @@ positive_time_period_minutes = All(positive_time_period, time_period_in_minutes_
 time_period_microseconds = All(time_period, time_period_in_microseconds_)
 positive_time_period_microseconds = All(
     positive_time_period, time_period_in_microseconds_
+)
+positive_time_period_nanoseconds = All(
+    positive_time_period, time_period_in_nanoseconds_
 )
 positive_not_null_time_period = All(
     time_period, Range(min=TimePeriod(), min_included=False)

--- a/esphome/core/__init__.py
+++ b/esphome/core/__init__.py
@@ -87,6 +87,7 @@ def is_approximately_integer(value):
 class TimePeriod:
     def __init__(
         self,
+        nanoseconds=None,
         microseconds=None,
         milliseconds=None,
         seconds=None,
@@ -136,13 +137,23 @@ class TimePeriod:
 
         if microseconds is not None:
             if not is_approximately_integer(microseconds):
-                raise ValueError("Maximum precision is microseconds")
+                frac_microseconds, microseconds = math.modf(microseconds)
+                nanoseconds = (nanoseconds or 0) + frac_microseconds * 1000
             self.microseconds = int(round(microseconds))
         else:
             self.microseconds = None
 
+        if nanoseconds is not None:
+            if not is_approximately_integer(nanoseconds):
+                raise ValueError("Maximum precision is nanoseconds")
+            self.nanoseconds = int(round(nanoseconds))
+        else:
+            self.nanoseconds = None
+
     def as_dict(self):
         out = OrderedDict()
+        if self.nanoseconds is not None:
+            out["nanoseconds"] = self.nanoseconds
         if self.microseconds is not None:
             out["microseconds"] = self.microseconds
         if self.milliseconds is not None:
@@ -158,6 +169,8 @@ class TimePeriod:
         return out
 
     def __str__(self):
+        if self.nanoseconds is not None:
+            return f"{self.total_nanoseconds}ns"
         if self.microseconds is not None:
             return f"{self.total_microseconds}us"
         if self.milliseconds is not None:
@@ -173,7 +186,11 @@ class TimePeriod:
         return "0s"
 
     def __repr__(self):
-        return f"TimePeriod<{self.total_microseconds}>"
+        return f"TimePeriod<{self.total_nanoseconds}ns>"
+
+    @property
+    def total_nanoseconds(self):
+        return self.total_microseconds * 1000 + (self.nanoseconds or 0)
 
     @property
     def total_microseconds(self):
@@ -201,33 +218,37 @@ class TimePeriod:
 
     def __eq__(self, other):
         if isinstance(other, TimePeriod):
-            return self.total_microseconds == other.total_microseconds
+            return self.total_nanoseconds == other.total_nanoseconds
         return NotImplemented
 
     def __ne__(self, other):
         if isinstance(other, TimePeriod):
-            return self.total_microseconds != other.total_microseconds
+            return self.total_nanoseconds != other.total_nanoseconds
         return NotImplemented
 
     def __lt__(self, other):
         if isinstance(other, TimePeriod):
-            return self.total_microseconds < other.total_microseconds
+            return self.total_nanoseconds < other.total_nanoseconds
         return NotImplemented
 
     def __gt__(self, other):
         if isinstance(other, TimePeriod):
-            return self.total_microseconds > other.total_microseconds
+            return self.total_nanoseconds > other.total_nanoseconds
         return NotImplemented
 
     def __le__(self, other):
         if isinstance(other, TimePeriod):
-            return self.total_microseconds <= other.total_microseconds
+            return self.total_nanoseconds <= other.total_nanoseconds
         return NotImplemented
 
     def __ge__(self, other):
         if isinstance(other, TimePeriod):
-            return self.total_microseconds >= other.total_microseconds
+            return self.total_nanoseconds >= other.total_nanoseconds
         return NotImplemented
+
+
+class TimePeriodNanoseconds(TimePeriod):
+    pass
 
 
 class TimePeriodMicroseconds(TimePeriod):

--- a/esphome/cpp_generator.py
+++ b/esphome/cpp_generator.py
@@ -17,6 +17,7 @@ from esphome.core import (
     TimePeriodMicroseconds,
     TimePeriodMilliseconds,
     TimePeriodMinutes,
+    TimePeriodNanoseconds,
     TimePeriodSeconds,
 )
 from esphome.helpers import cpp_string_escape, indent_all_but_first_and_last
@@ -351,6 +352,8 @@ def safe_exp(obj: SafeExpType) -> Expression:
         return IntLiteral(obj)
     if isinstance(obj, float):
         return FloatLiteral(obj)
+    if isinstance(obj, TimePeriodNanoseconds):
+        return IntLiteral(int(obj.total_nanoseconds))
     if isinstance(obj, TimePeriodMicroseconds):
         return IntLiteral(int(obj.total_microseconds))
     if isinstance(obj, TimePeriodMilliseconds):

--- a/tests/unit_tests/test_core.py
+++ b/tests/unit_tests/test_core.py
@@ -116,14 +116,16 @@ class TestTimePeriod:
 
         assert actual == expected
 
-    def test_init__microseconds_with_fraction(self):
-        with pytest.raises(ValueError, match="Maximum precision is microseconds"):
-            core.TimePeriod(microseconds=1.1)
+    def test_init__nanoseconds_with_fraction(self):
+        with pytest.raises(ValueError, match="Maximum precision is nanoseconds"):
+            core.TimePeriod(nanoseconds=1.1)
 
     @pytest.mark.parametrize(
         "kwargs, expected",
         (
             ({}, "0s"),
+            ({"nanoseconds": 1}, "1ns"),
+            ({"nanoseconds": 1.0001}, "1ns"),
             ({"microseconds": 1}, "1us"),
             ({"microseconds": 1.0001}, "1us"),
             ({"milliseconds": 2}, "2ms"),


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

A bug found in the `esp32_rmt_led_strip` code led to finding that the values set in config should be nanoseconds not microseconds which ESPHome did not yet support.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
