### PR TITLE
Fix esp32_rmt_led_strip custom timing units

### DIFF
--- a/esphome/components/esp32_rmt_led_strip/light.py
+++ b/esphome/components/esp32_rmt_led_strip/light.py
@@ -93,19 +93,19 @@ CONFIG_SCHEMA = cv.All(
             cv.Inclusive(
                 CONF_BIT0_HIGH,
                 "custom",
-            ): cv.positive_time_period_microseconds,
+            ): cv.positive_time_period_nanoseconds,
             cv.Inclusive(
                 CONF_BIT0_LOW,
                 "custom",
-            ): cv.positive_time_period_microseconds,
+            ): cv.positive_time_period_nanoseconds,
             cv.Inclusive(
                 CONF_BIT1_HIGH,
                 "custom",
-            ): cv.positive_time_period_microseconds,
+            ): cv.positive_time_period_nanoseconds,
             cv.Inclusive(
                 CONF_BIT1_LOW,
                 "custom",
-            ): cv.positive_time_period_microseconds,
+            ): cv.positive_time_period_nanoseconds,
         }
     ),
     cv.has_exactly_one_key(CONF_CHIPSET, CONF_BIT0_HIGH),


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Based on top of #5695, this changes the units that are output from the custom timings to correctly be nanoseconds.

This will break any configs using the custom timings currently as it will multiply the value by 1000.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
