### PR TITLE
Add ability to retrieve pulse counts

### DIFF
--- a/esphome/components/pulse_counter/pulse_counter_sensor.cpp
+++ b/esphome/components/pulse_counter/pulse_counter_sensor.cpp
@@ -151,6 +151,14 @@ void PulseCounterSensor::setup() {
   }
 }
 
+int PulseCounterSensor::get_total_pulses() {
+  if (this->total_sensor_ != nullptr) {
+    return current_total_;
+  } else {
+    return 0;
+  }
+}
+
 void PulseCounterSensor::set_total_pulses(uint32_t pulses) {
   this->current_total_ = pulses;
   this->total_sensor_->publish_state(pulses);

--- a/esphome/components/pulse_counter/pulse_counter_sensor.h
+++ b/esphome/components/pulse_counter/pulse_counter_sensor.h
@@ -71,6 +71,7 @@ class PulseCounterSensor : public sensor::Sensor, public PollingComponent {
   void set_total_sensor(sensor::Sensor *total_sensor) { total_sensor_ = total_sensor; }
 
   void set_total_pulses(uint32_t pulses);
+  int get_total_pulses();
 
   /// Unit of measurement is "pulses/min".
   void setup() override;

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -1007,12 +1007,18 @@ sensor:
     i2c_id: i2c_bus
   - platform: pulse_counter
     name: Pulse Counter
+    id: pulse_counter_test
     pin: GPIO12
     count_mode:
       rising_edge: INCREMENT
       falling_edge: DECREMENT
     internal_filter: 13us
     update_interval: 15s
+  - platform: template
+    name: Pulse Counts
+    state_class: measurement
+    lambda: !lambda 'return id(pulse_counter_test).get_total_pulses();'
+    update_interval: 10s
   - platform: pulse_meter
     name: Pulse Meter
     id: pulse_meter_sensor


### PR DESCRIPTION
# What does this implement/fix?

This commit implements a method in pulse_counter library to retrieve the latest pulse count.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#3344

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
```yaml
# Example config.yaml
  - platform: template
    name: Pulse Counts
    state_class: measurement
    lambda: !lambda 'return id(pulse_counter_test).get_total_pulses();'
    update_interval: 10s
```

## Checklist:
  - [x] The code change is tested and works locally.
    - test docker build available here: https://github.com/iganeshk/esphome/pkgs/container/esphome/145452769?tag=2023.12.0-dev20231108-pulseCounter-patch-ci
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
