### PR TITLE
Fix static assets cache logic

### DIFF
--- a/esphome/dashboard/dashboard.py
+++ b/esphome/dashboard/dashboard.py
@@ -1417,7 +1417,7 @@ def make_app(debug=get_bool_env(ENV_DEV)):
             # filenames hashed so we can cache them for a long time
             if (
                 "hash" in self.request.arguments
-                or "application/javascript" in mime_type
+                or "/javascript" in mime_type
             ):
                 return self.CACHE_MAX_AGE
             return super().get_cache_time(path, modified, mime_type)

--- a/esphome/dashboard/dashboard.py
+++ b/esphome/dashboard/dashboard.py
@@ -1415,10 +1415,7 @@ def make_app(debug=get_bool_env(ENV_DEV)):
                 return 0
             # Assets that are hashed have ?hash= in the URL, all javascript
             # filenames hashed so we can cache them for a long time
-            if (
-                "hash" in self.request.arguments
-                or "/javascript" in mime_type
-            ):
+            if "hash" in self.request.arguments or "/javascript" in mime_type:
                 return self.CACHE_MAX_AGE
             return super().get_cache_time(path, modified, mime_type)
 


### PR DESCRIPTION
# What does this implement/fix?

The default tornado logic only know about `v=` which is tornado specific. Since we use `hash=` and hash the JS filenames ourselves the logic didn't work as excepted.

Only cache assets if
- They have `?hash=` (`favicon.ico` already has this ... `logo-text..svg` does not but that has to be fixed in the other repo)
- They are javascript (we hash the filenames themselves)
- Debug is not enabled


## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
