### PR TITLE
Update Dockerfile to use piwheels for armv7

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,9 +12,19 @@ FROM debian:12.2-slim AS base-docker
 
 FROM base-${BASEIMGTYPE} AS base
 
+FROM base AS branch-armv7
+ENV PIP_EXTRA_INDEX_URL="https://www.piwheels.org/simple"
+
+FROM base AS branch-aarch64
+ENV PIP_EXTRA_INDEX_URL=""
+
+FROM base AS branch-amd64
+ENV PIP_EXTRA_INDEX_URL=""
+
+FROM branch-${TARGETARCH}${TARGETVARIANT} AS final
+
 ARG TARGETARCH
 ARG TARGETVARIANT
-ARG PIP_EXTRA_INDEX_URL
 
 # Note that --break-system-packages is used below because
 # https://peps.python.org/pep-0668/ added a safety check that prevents
@@ -59,8 +69,7 @@ ENV \
   # Fix click python3 lang warning https://click.palletsprojects.com/en/7.x/python3/
   LANG=C.UTF-8 LC_ALL=C.UTF-8 \
   # Store globally installed pio libs in /piolibs
-  PLATFORMIO_GLOBALLIB_DIR=/piolibs \
-  PIP_EXTRA_INDEX_URL=${PIP_EXTRA_INDEX_URL}
+  PLATFORMIO_GLOBALLIB_DIR=/piolibs
 
 # Support legacy binaries on Debian multiarch system. There is no "correct" way
 # to do this, other than using properly built toolchains...

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -75,9 +75,9 @@ RUN \
 RUN \
     # Ubuntu python3-pip is missing wheel
     pip3 install \
-        $([ "$TARGETARCH$TARGETVARIANT" == "armv7" ] && echo "--extra-index-url=https://www.piwheels.org/simple" || echo "") \
-        --break-system-packages --no-cache-dir \
-        platformio==6.1.11 \
+    $([ "$TARGETARCH$TARGETVARIANT" == "armv7" ] && echo "--extra-index-url=https://www.piwheels.org/simple" || echo "") \
+    --break-system-packages --no-cache-dir \
+    platformio==6.1.11 \
     # Change some platformio settings
     && platformio settings set enable_telemetry No \
     && platformio settings set check_platformio_interval 1000000 \
@@ -186,7 +186,9 @@ RUN \
         /var/lib/apt/lists/*
 
 COPY requirements_test.txt /
-RUN pip3 install --break-system-packages --no-cache-dir -r /requirements_test.txt
+RUN pip3 install \
+  $([ "$TARGETARCH$TARGETVARIANT" == "armv7" ] && echo "--extra-index-url=https://www.piwheels.org/simple" || echo "") \
+  --break-system-packages --no-cache-dir -r /requirements_test.txt
 
 VOLUME ["/esphome"]
 WORKDIR /esphome

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,8 +17,6 @@ FROM base-${BASEIMGTYPE} AS base
 ARG TARGETARCH
 ARG TARGETVARIANT
 
-ENV TARGETARCH=${TARGETARCH}
-ENV TARGETVARIANT=${TARGETVARIANT}
 
 # Note that --break-system-packages is used below because
 # https://peps.python.org/pep-0668/ added a safety check that prevents

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,18 +12,11 @@ FROM debian:12.2-slim AS base-docker
 
 FROM base-${BASEIMGTYPE} AS base
 
+ARG TARGETARCH
+ARG TARGETVARIANT
 
-FROM base AS branch_armv7
-ENV PIP_EXTRA_INDEX_URL="https://www.piwheels.org/simple"
-
-FROM base AS branch_aarch64
-ENV PIP_EXTRA_INDEX_URL=""
-
-FROM base AS branch_amd64
-ENV PIP_EXTRA_INDEX_URL=""
-
-FROM branch_${TARGETARCH}${TARGETVARIANT} AS final
-RUN echo "PIP_EXTRA_INDEX_URL is equal to ${PIP_EXTRA_INDEX_URL}"
+ENV TARGETARCH=${TARGETARCH}
+ENV TARGETVARIANT=${TARGETVARIANT}
 
 
 # Note that --break-system-packages is used below because
@@ -81,7 +74,9 @@ RUN \
 
 RUN \
     # Ubuntu python3-pip is missing wheel
-    pip3 install --break-system-packages --no-cache-dir \
+    pip3 install \
+        $([ "$TARGETARCH$TARGETVARIANT" == "armv7" ] && echo "--extra-index-url=https://www.piwheels.org/simple" || echo "") \
+        --break-system-packages --no-cache-dir \
         platformio==6.1.11 \
     # Change some platformio settings
     && platformio settings set enable_telemetry No \
@@ -94,7 +89,9 @@ RUN \
 
 COPY requirements.txt requirements_optional.txt script/platformio_install_deps.py platformio.ini /
 RUN --mount=type=tmpfs,target=/root/.cargo CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse CARGO_HOME=/root/.cargo \
-    pip3 install --break-system-packages --no-cache-dir -r /requirements.txt -r /requirements_optional.txt \
+    pip3 install \
+    $([ "$TARGETARCH$TARGETVARIANT" == "armv7" ] && echo "--extra-index-url=https://www.piwheels.org/simple" || echo "") \
+    --break-system-packages --no-cache-dir -r /requirements.txt -r /requirements_optional.txt \
     && /platformio_install_deps.py /platformio.ini --libraries
 
 
@@ -103,7 +100,9 @@ FROM base AS docker
 
 # Copy esphome and install
 COPY . /esphome
-RUN pip3 install --break-system-packages --no-cache-dir --no-use-pep517 -e /esphome
+RUN pip3 install \
+  $([ "$TARGETARCH$TARGETVARIANT" == "armv7" ] && echo "--extra-index-url=https://www.piwheels.org/simple" || echo "") \ 
+  --break-system-packages --no-cache-dir --no-use-pep517 -e /esphome
 
 # Settings for dashboard
 ENV USERNAME="" PASSWORD=""
@@ -149,7 +148,9 @@ COPY docker/ha-addon-rootfs/ /
 
 # Copy esphome and install
 COPY . /esphome
-RUN pip3 install --break-system-packages --no-cache-dir --no-use-pep517 -e /esphome
+RUN pip3 install \
+  $([ "$TARGETARCH$TARGETVARIANT" == "armv7" ] && echo "--extra-index-url=https://www.piwheels.org/simple" || echo "") \
+  --break-system-packages --no-cache-dir --no-use-pep517 -e /esphome
 
 # Labels
 LABEL \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,12 +5,11 @@
 # One of "docker", "hassio"
 ARG BASEIMGTYPE=docker
 
+
 # https://github.com/hassio-addons/addon-debian-base/releases
 FROM ghcr.io/hassio-addons/debian-base:7.2.0 AS base-hassio
 # https://hub.docker.com/_/debian?tab=tags&page=1&name=bookworm
 FROM debian:12.2-slim AS base-docker
-
-FROM base-${BASEIMGTYPE} AS base
 
 ARG TARGETARCH
 ARG TARGETVARIANT
@@ -18,6 +17,7 @@ ARG TARGETVARIANT
 ENV TARGETARCH=${TARGETARCH}
 ENV TARGETVARIANT=${TARGETVARIANT}
 
+FROM base-${BASEIMGTYPE} AS base
 
 # Note that --break-system-packages is used below because
 # https://peps.python.org/pep-0668/ added a safety check that prevents

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,16 +16,16 @@ FROM base-${BASEIMGTYPE} AS base
 ARG TARGETARCH
 ARG TARGETVARIANT
 
-FROM base AS branch-armv7
+FROM base AS branch_armv7
 ENV PIP_EXTRA_INDEX_URL="https://www.piwheels.org/simple"
 
-FROM base AS branch-aarch64
+FROM base AS branch_aarch64
 ENV PIP_EXTRA_INDEX_URL=""
 
-FROM base AS branch-amd64
+FROM base AS branch_amd64
 ENV PIP_EXTRA_INDEX_URL=""
 
-FROM branch-${TARGETARCH}${TARGETVARIANT} AS final
+FROM branch_${TARGETARCH}${TARGETVARIANT} AS final
 RUN echo "PIP_EXTRA_INDEX_URL is equal to ${PIP_EXTRA_INDEX_URL}"
 
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,6 +12,10 @@ FROM debian:12.2-slim AS base-docker
 
 FROM base-${BASEIMGTYPE} AS base
 
+
+ARG TARGETARCH
+ARG TARGETVARIANT
+
 FROM base AS branch-armv7
 ENV PIP_EXTRA_INDEX_URL="https://www.piwheels.org/simple"
 
@@ -22,9 +26,8 @@ FROM base AS branch-amd64
 ENV PIP_EXTRA_INDEX_URL=""
 
 FROM branch-${TARGETARCH}${TARGETVARIANT} AS final
+RUN echo "PIP_EXTRA_INDEX_URL is equal to ${PIP_EXTRA_INDEX_URL}"
 
-ARG TARGETARCH
-ARG TARGETVARIANT
 
 # Note that --break-system-packages is used below because
 # https://peps.python.org/pep-0668/ added a safety check that prevents

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -74,8 +74,10 @@ RUN \
 
 RUN \
     # Ubuntu python3-pip is missing wheel
+    if [ "$TARGETARCH$TARGETVARIANT" = "armv7" ]; then \
+        export PIP_EXTRA_INDEX_URL="https://www.piwheels.org/simple"; \
+    fi; \
     pip3 install \
-    $([ "$TARGETARCH$TARGETVARIANT" == "armv7" ] && echo "--extra-index-url=https://www.piwheels.org/simple" || echo "") \
     --break-system-packages --no-cache-dir \
     platformio==6.1.11 \
     # Change some platformio settings
@@ -88,9 +90,11 @@ RUN \
 # tmpfs is for https://github.com/rust-lang/cargo/issues/8719
 
 COPY requirements.txt requirements_optional.txt script/platformio_install_deps.py platformio.ini /
-RUN --mount=type=tmpfs,target=/root/.cargo CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse CARGO_HOME=/root/.cargo \
+RUN --mount=type=tmpfs,target=/root/.cargo if [ "$TARGETARCH$TARGETVARIANT" = "armv7" ]; then \
+        export PIP_EXTRA_INDEX_URL="https://www.piwheels.org/simple"; \
+    fi; \
+    CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse CARGO_HOME=/root/.cargo \
     pip3 install \
-    $([ "$TARGETARCH$TARGETVARIANT" == "armv7" ] && echo "--extra-index-url=https://www.piwheels.org/simple" || echo "") \
     --break-system-packages --no-cache-dir -r /requirements.txt -r /requirements_optional.txt \
     && /platformio_install_deps.py /platformio.ini --libraries
 
@@ -100,8 +104,10 @@ FROM base AS docker
 
 # Copy esphome and install
 COPY . /esphome
-RUN pip3 install \
-  $([ "$TARGETARCH$TARGETVARIANT" == "armv7" ] && echo "--extra-index-url=https://www.piwheels.org/simple" || echo "") \ 
+RUN if [ "$TARGETARCH$TARGETVARIANT" = "armv7" ]; then \
+        export PIP_EXTRA_INDEX_URL="https://www.piwheels.org/simple"; \
+  fi; \
+  pip3 install \
   --break-system-packages --no-cache-dir --no-use-pep517 -e /esphome
 
 # Settings for dashboard
@@ -148,8 +154,10 @@ COPY docker/ha-addon-rootfs/ /
 
 # Copy esphome and install
 COPY . /esphome
-RUN pip3 install \
-  $([ "$TARGETARCH$TARGETVARIANT" == "armv7" ] && echo "--extra-index-url=https://www.piwheels.org/simple" || echo "") \
+RUN if [ "$TARGETARCH$TARGETVARIANT" = "armv7" ]; then \
+        export PIP_EXTRA_INDEX_URL="https://www.piwheels.org/simple"; \
+  fi; \
+  pip3 install \
   --break-system-packages --no-cache-dir --no-use-pep517 -e /esphome
 
 # Labels
@@ -186,8 +194,10 @@ RUN \
         /var/lib/apt/lists/*
 
 COPY requirements_test.txt /
-RUN pip3 install \
-  $([ "$TARGETARCH$TARGETVARIANT" == "armv7" ] && echo "--extra-index-url=https://www.piwheels.org/simple" || echo "") \
+RUN if [ "$TARGETARCH$TARGETVARIANT" = "armv7" ]; then \
+        export PIP_EXTRA_INDEX_URL="https://www.piwheels.org/simple"; \
+  fi; \
+  pip3 install \
   --break-system-packages --no-cache-dir -r /requirements_test.txt
 
 VOLUME ["/esphome"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,9 +13,6 @@ FROM debian:12.2-slim AS base-docker
 FROM base-${BASEIMGTYPE} AS base
 
 
-ARG TARGETARCH
-ARG TARGETVARIANT
-
 FROM base AS branch_armv7
 ENV PIP_EXTRA_INDEX_URL="https://www.piwheels.org/simple"
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,13 +11,14 @@ FROM ghcr.io/hassio-addons/debian-base:7.2.0 AS base-hassio
 # https://hub.docker.com/_/debian?tab=tags&page=1&name=bookworm
 FROM debian:12.2-slim AS base-docker
 
+FROM base-${BASEIMGTYPE} AS base
+
+
 ARG TARGETARCH
 ARG TARGETVARIANT
 
 ENV TARGETARCH=${TARGETARCH}
 ENV TARGETVARIANT=${TARGETVARIANT}
-
-FROM base-${BASEIMGTYPE} AS base
 
 # Note that --break-system-packages is used below because
 # https://peps.python.org/pep-0668/ added a safety check that prevents

--- a/docker/build.py
+++ b/docker/build.py
@@ -143,25 +143,15 @@ def main():
         imgs = [f"{params.build_to}:{tag}" for tag in tags_to_push]
         imgs += [f"ghcr.io/{params.build_to}:{tag}" for tag in tags_to_push]
 
-        build_args = [
-            "--build-arg",
-            f"BASEIMGTYPE={params.baseimgtype}",
-            "--build-arg",
-            f"BUILD_VERSION={args.tag}",
-        ]
-
-        if args.arch == ARCH_ARMV7:
-            build_args += [
-                "--build-arg",
-                "PIP_EXTRA_INDEX_URL=https://www.piwheels.org/simple",
-            ]
-
         # 3. build
         cmd = [
             "docker",
             "buildx",
             "build",
-            *build_args,
+            "--build-arg",
+            f"BASEIMGTYPE={params.baseimgtype}",
+            "--build-arg",
+            f"BUILD_VERSION={args.tag}",
             "--cache-from",
             f"type=registry,ref={cache_img}",
             "--file",


### PR DESCRIPTION
# What does this implement/fix?

Releases should now use piwheels for armv7 since everything is contained in the Dockerfile

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
