### PR TITLE
Add resistance_sampler interface for config validation

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -246,6 +246,7 @@ esphome/components/radon_eye_rd200/* @jeffeb3
 esphome/components/rc522/* @glmnet
 esphome/components/rc522_i2c/* @glmnet
 esphome/components/rc522_spi/* @glmnet
+esphome/components/resistance_sampler/* @jesserockz
 esphome/components/restart/* @esphome/core
 esphome/components/rf_bridge/* @jesserockz
 esphome/components/rgbct/* @jesserockz

--- a/esphome/components/ntc/sensor.py
+++ b/esphome/components/ntc/sensor.py
@@ -2,7 +2,7 @@ from math import log
 
 import esphome.config_validation as cv
 import esphome.codegen as cg
-from esphome.components import sensor
+from esphome.components import sensor, resistance_sampler
 from esphome.const import (
     CONF_CALIBRATION,
     CONF_REFERENCE_RESISTANCE,
@@ -14,6 +14,8 @@ from esphome.const import (
     STATE_CLASS_MEASUREMENT,
     UNIT_CELSIUS,
 )
+
+AUTO_LOAD = ["resistance_sampler"]
 
 ntc_ns = cg.esphome_ns.namespace("ntc")
 NTC = ntc_ns.class_("NTC", cg.Component, sensor.Sensor)
@@ -124,7 +126,7 @@ CONFIG_SCHEMA = (
     )
     .extend(
         {
-            cv.Required(CONF_SENSOR): cv.use_id(sensor.Sensor),
+            cv.Required(CONF_SENSOR): cv.use_id(resistance_sampler.ResistanceSampler),
             cv.Required(CONF_CALIBRATION): process_calibration,
         }
     )

--- a/esphome/components/resistance/resistance_sensor.h
+++ b/esphome/components/resistance/resistance_sensor.h
@@ -1,7 +1,8 @@
 #pragma once
 
-#include "esphome/core/component.h"
+#include "esphome/components/resistance_sampler/resistance_sampler.h"
 #include "esphome/components/sensor/sensor.h"
+#include "esphome/core/component.h"
 
 namespace esphome {
 namespace resistance {
@@ -11,7 +12,7 @@ enum ResistanceConfiguration {
   DOWNSTREAM,
 };
 
-class ResistanceSensor : public Component, public sensor::Sensor {
+class ResistanceSensor : public Component, public sensor::Sensor, resistance_sampler::ResistanceSampler {
  public:
   void set_sensor(Sensor *sensor) { sensor_ = sensor; }
   void set_configuration(ResistanceConfiguration configuration) { configuration_ = configuration; }

--- a/esphome/components/resistance/sensor.py
+++ b/esphome/components/resistance/sensor.py
@@ -1,6 +1,6 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
-from esphome.components import sensor
+from esphome.components import sensor, resistance_sampler
 from esphome.const import (
     CONF_SENSOR,
     STATE_CLASS_MEASUREMENT,
@@ -8,8 +8,15 @@ from esphome.const import (
     ICON_FLASH,
 )
 
+AUTO_LOAD = ["resistance_sampler"]
+
 resistance_ns = cg.esphome_ns.namespace("resistance")
-ResistanceSensor = resistance_ns.class_("ResistanceSensor", cg.Component, sensor.Sensor)
+ResistanceSensor = resistance_ns.class_(
+    "ResistanceSensor",
+    cg.Component,
+    sensor.Sensor,
+    resistance_sampler.ResistanceSampler,
+)
 
 CONF_REFERENCE_VOLTAGE = "reference_voltage"
 CONF_CONFIGURATION = "configuration"

--- a/esphome/components/resistance_sampler/__init__.py
+++ b/esphome/components/resistance_sampler/__init__.py
@@ -2,3 +2,5 @@ import esphome.codegen as cg
 
 resistance_sampler_ns = cg.esphome_ns.namespace("resistance_sampler")
 ResistanceSampler = resistance_sampler_ns.class_("ResistanceSampler")
+
+CODEOWNERS = ["@jesserockz"]

--- a/esphome/components/resistance_sampler/__init__.py
+++ b/esphome/components/resistance_sampler/__init__.py
@@ -1,0 +1,4 @@
+import esphome.codegen as cg
+
+resistance_sampler_ns = cg.esphome_ns.namespace("resistance_sampler")
+ResistanceSampler = resistance_sampler_ns.class_("ResistanceSampler")

--- a/esphome/components/resistance_sampler/resistance_sampler.h
+++ b/esphome/components/resistance_sampler/resistance_sampler.h
@@ -1,0 +1,10 @@
+#pragma once
+
+namespace esphome {
+namespace resistance_sampler {
+
+/// Abstract interface to mark components that provide resistance values.
+class ResistanceSampler {};
+
+}  // namespace resistance_sampler
+}  // namespace esphome


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->
An issue noticed via discord was that someone can set the wrong sensor id for the `ntc` sensor platform


Tested by altering test3.1.yaml
```diff
diff --git a/tests/test3.1.yaml b/tests/test3.1.yaml
index 151e53fd6..548684973 100644
--- a/tests/test3.1.yaml
+++ b/tests/test3.1.yaml
@@ -133,7 +133,7 @@ sensor:
       reference_resistance: 10k
       reference_temperature: 25°C
   - platform: ntc
-    sensor: resist
+    sensor: my_sensor
     name: NTC Sensor2
     calibration:
       - 10.0kOhm -> 25°C

```

```
esphome config tests/test3.1.yaml
INFO ESPHome 2023.12.0-dev
INFO Reading configuration tests/test3.1.yaml...
Failed config

sensor.ntc: [source tests/test3.1.yaml:135]
  platform: ntc
  
  ID 'my_sensor' of type adc::ADCSensor doesn't inherit from resistance_sampler::ResistanceSampler. Please double check your ID is pointing to the correct value.
  sensor: my_sensor
  name: NTC Sensor2
  calibration: 
    a: 0.0008407919494250122
    b: 0.0002584565344993939
    c: 1.6990786404369544e-07
  disabled_by_default: False
  force_update: False
  unit_of_measurement: °C
  accuracy_decimals: 1
  device_class: temperature
  state_class: measurement
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
