### PR TITLE
Reduce memory usage with StringRef in MQTT Components

### DIFF
--- a/esphome/components/mqtt/mqtt_binary_sensor.cpp
+++ b/esphome/components/mqtt/mqtt_binary_sensor.cpp
@@ -25,7 +25,7 @@ void MQTTBinarySensorComponent::dump_config() {
 MQTTBinarySensorComponent::MQTTBinarySensorComponent(binary_sensor::BinarySensor *binary_sensor)
     : binary_sensor_(binary_sensor) {
   if (this->binary_sensor_->is_status_binary_sensor()) {
-    this->set_custom_state_topic(mqtt::global_mqtt_client->get_availability().topic);
+    this->set_custom_state_topic(mqtt::global_mqtt_client->get_availability().topic.c_str());
   }
 }
 

--- a/esphome/components/mqtt/mqtt_component.cpp
+++ b/esphome/components/mqtt/mqtt_component.cpp
@@ -34,13 +34,13 @@ std::string MQTTComponent::get_default_topic_for_(const std::string &suffix) con
 
 std::string MQTTComponent::get_state_topic_() const {
   if (this->has_custom_state_topic_)
-    return this->custom_state_topic_;
+    return this->custom_state_topic_.str();
   return this->get_default_topic_for_("state");
 }
 
 std::string MQTTComponent::get_command_topic_() const {
   if (this->has_custom_command_topic_)
-    return this->custom_command_topic_;
+    return this->custom_command_topic_.str();
   return this->get_default_topic_for_("command");
 }
 
@@ -176,12 +176,12 @@ MQTTComponent::MQTTComponent() = default;
 
 float MQTTComponent::get_setup_priority() const { return setup_priority::AFTER_CONNECTION; }
 void MQTTComponent::disable_discovery() { this->discovery_enabled_ = false; }
-void MQTTComponent::set_custom_state_topic(const std::string &custom_state_topic) {
-  this->custom_state_topic_ = custom_state_topic;
+void MQTTComponent::set_custom_state_topic(const char *custom_state_topic) {
+  this->custom_state_topic_ = StringRef(custom_state_topic);
   this->has_custom_state_topic_ = true;
 }
-void MQTTComponent::set_custom_command_topic(const std::string &custom_command_topic) {
-  this->custom_command_topic_ = custom_command_topic;
+void MQTTComponent::set_custom_command_topic(const char *custom_command_topic) {
+  this->custom_command_topic_ = StringRef(custom_command_topic);
   this->has_custom_command_topic_ = true;
 }
 void MQTTComponent::set_command_retain(bool command_retain) { this->command_retain_ = command_retain; }

--- a/esphome/components/mqtt/mqtt_component.h
+++ b/esphome/components/mqtt/mqtt_component.h
@@ -8,6 +8,7 @@
 
 #include "esphome/core/component.h"
 #include "esphome/core/entity_base.h"
+#include "esphome/core/string_ref.h"
 #include "mqtt_client.h"
 
 namespace esphome {
@@ -88,9 +89,9 @@ class MQTTComponent : public Component {
   virtual std::string component_type() const = 0;
 
   /// Set a custom state topic. Set to "" for default behavior.
-  void set_custom_state_topic(const std::string &custom_state_topic);
+  void set_custom_state_topic(const char *custom_state_topic);
   /// Set a custom command topic. Set to "" for default behavior.
-  void set_custom_command_topic(const std::string &custom_command_topic);
+  void set_custom_command_topic(const char *custom_command_topic);
   /// Set whether command message should be retained.
   void set_command_retain(bool command_retain);
 
@@ -188,15 +189,17 @@ class MQTTComponent : public Component {
   /// Generate the Home Assistant MQTT discovery object id by automatically transforming the friendly name.
   std::string get_default_object_id_() const;
 
-  std::string custom_state_topic_{};
-  std::string custom_command_topic_{};
+  StringRef custom_state_topic_{};
+  StringRef custom_command_topic_{};
+
+  std::unique_ptr<Availability> availability_;
+
   bool has_custom_state_topic_{false};
   bool has_custom_command_topic_{false};
 
   bool command_retain_{false};
   bool retain_{true};
   bool discovery_enabled_{true};
-  std::unique_ptr<Availability> availability_;
   bool resend_state_{false};
 };
 


### PR DESCRIPTION
# What does this implement/fix?

This small PR uses a ``StringRef`` instead of an ``std::string`` for custom MQTT state and command topics. It is very similar to PR esphome/esphome#4594. It saved around 1 kilobyte of memory on a relatively simple device with no custom topics set. It saved over 20 kilobytes on a very complicated configuration with over 150 custom state topics. I have tested this using ESP32s with both Arduino and esp-idf frameworks. I have also tested it on an ESP8266 device with no issues.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** not applicable

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** not applicable

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
