### PR TITLE
Speed up OTAs

### DIFF
--- a/esphome/espota2.py
+++ b/esphome/espota2.py
@@ -40,6 +40,10 @@ MAGIC_BYTES = [0x6C, 0x26, 0xF7, 0x5C, 0x45]
 
 FEATURE_SUPPORTS_COMPRESSION = 0x01
 
+
+UPLOAD_BLOCK_SIZE = 8192
+UPLOAD_BUFFER_SIZE = UPLOAD_BLOCK_SIZE * 8
+
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -254,14 +258,16 @@ def perform_ota(sock, password, file_handle, filename):
     sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 0)
     # Limit send buffer (usually around 100kB) in order to have progress bar
     # show the actual progress
-    sock.setsockopt(socket.SOL_SOCKET, socket.SO_SNDBUF, 8192)
+
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_SNDBUF, UPLOAD_BUFFER_SIZE)
     # Set higher timeout during upload
-    sock.settimeout(20.0)
+    sock.settimeout(30.0)
+    start_time = time.perf_counter()
 
     offset = 0
     progress = ProgressBar()
     while True:
-        chunk = upload_contents[offset : offset + 1024]
+        chunk = upload_contents[offset : offset + UPLOAD_BLOCK_SIZE]
         if not chunk:
             break
         offset += len(chunk)
@@ -277,7 +283,9 @@ def perform_ota(sock, password, file_handle, filename):
 
     # Enable nodelay for last checks
     sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+    duration = time.perf_counter() - start_time
 
+    _LOGGER.info("Upload took %.2f seconds", duration)
     _LOGGER.info("Waiting for result...")
 
     receive_exactly(sock, 1, "receive OK", RESPONSE_RECEIVE_OK)

--- a/esphome/espota2.py
+++ b/esphome/espota2.py
@@ -1,10 +1,13 @@
+from __future__ import annotations
+
+import gzip
 import hashlib
+import io
 import logging
 import random
 import socket
 import sys
 import time
-import gzip
 
 from esphome.core import EsphomeError
 from esphome.helpers import is_ip_address, resolve_ip_address
@@ -188,7 +191,9 @@ def send_check(sock, data, msg):
         raise OTAError(f"Error sending {msg}: {err}") from err
 
 
-def perform_ota(sock, password, file_handle, filename):
+def perform_ota(
+    sock: socket.socket, password: str, file_handle: io.IOBase, filename: str
+) -> None:
     file_contents = file_handle.read()
     file_size = len(file_contents)
     _LOGGER.info("Uploading %s (%s bytes)", filename, file_size)
@@ -285,8 +290,7 @@ def perform_ota(sock, password, file_handle, filename):
     sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
     duration = time.perf_counter() - start_time
 
-    _LOGGER.info("Upload took %.2f seconds", duration)
-    _LOGGER.info("Waiting for result...")
+    _LOGGER.info("Upload took %.2f seconds, waiting for result...", duration)
 
     receive_exactly(sock, 1, "receive OK", RESPONSE_RECEIVE_OK)
     receive_exactly(sock, 1, "Update end", RESPONSE_UPDATE_END_OK)


### PR DESCRIPTION
# What does this implement/fix?

The upload buffer was limited to 1024 which limited the speed of the OTA. By increasing the buffer size to 8192, the OTA can happen around 20-30% faster for most cases (YMMV with network performance and how busy the ESP is)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
