### PR TITLE
Speed up YAML by using YAML C loader when available

### DIFF
--- a/esphome/yaml_util.py
+++ b/esphome/yaml_util.py
@@ -25,13 +25,9 @@ from esphome.util import OrderedDict, filter_yaml_files
 
 try:
     from yaml import CSafeLoader as FastestAvailableSafeLoader
-    from yaml import CSafeDumper as FastestAvailableSafeDumper
 except ImportError:
     from yaml import (  # type: ignore[assignment]
         SafeLoader as FastestAvailableSafeLoader,
-    )
-    from yaml import (  # type: ignore[assignment]
-        SafeDumper as FastestAvailableSafeDumper,
     )
 
 
@@ -451,7 +447,7 @@ def is_secret(value):
         return None
 
 
-class ESPHomeDumper(FastestAvailableSafeDumper):
+class ESPHomeDumper(yaml.SafeDumper):
     def represent_mapping(self, tag, mapping, flow_style=None):
         value = []
         node = yaml.MappingNode(tag, value, flow_style=flow_style)

--- a/esphome/yaml_util.py
+++ b/esphome/yaml_util.py
@@ -23,6 +23,18 @@ from esphome.core import (
 from esphome.helpers import add_class_to_obj
 from esphome.util import OrderedDict, filter_yaml_files
 
+try:
+    from yaml import CSafeLoader as FastestAvailableSafeLoader
+    from yaml import CSafeDumper as FastestAvailableSafeDumper
+except ImportError:
+    from yaml import (  # type: ignore[assignment]
+        SafeLoader as FastestAvailableSafeLoader,
+    )
+    from yaml import (  # type: ignore[assignment]
+        SafeDumper as FastestAvailableSafeDumper,
+    )
+
+
 _LOGGER = logging.getLogger(__name__)
 
 # Mostly copied from Home Assistant because that code works fine and
@@ -89,7 +101,7 @@ def _add_data_ref(fn):
     return wrapped
 
 
-class ESPHomeLoader(yaml.SafeLoader):
+class ESPHomeLoader(FastestAvailableSafeLoader):
     """Loader class that keeps track of line numbers."""
 
     @_add_data_ref
@@ -439,7 +451,7 @@ def is_secret(value):
         return None
 
 
-class ESPHomeDumper(yaml.SafeDumper):
+class ESPHomeDumper(FastestAvailableSafeDumper):
     def represent_mapping(self, tag, mapping, flow_style=None):
         value = []
         node = yaml.MappingNode(tag, value, flow_style=flow_style)


### PR DESCRIPTION
# What does this implement/fix?

This is borrowed from HA core
https://github.com/home-assistant/core/blob/527a3dba9cd3eebd59257f6dd8be0e2ee95c630d/homeassistant/util/yaml/loader.py#L14 


## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
