### PR TITLE
dashboard: Use mdns cache when available if device connection is OTA

### DIFF
--- a/esphome/dashboard/async_adapter.py
+++ b/esphome/dashboard/async_adapter.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import asyncio
+import threading
+
+
+class ThreadedAsyncEvent:
+    """This is a shim to allow the asyncio event to be used in a threaded context.
+
+    When more of the code is moved to asyncio, this can be removed.
+    """
+
+    def __init__(self) -> None:
+        """Initialize the ThreadedAsyncEvent."""
+        self.event = threading.Event()
+        self.async_event: asyncio.Event | None = None
+        self.loop: asyncio.AbstractEventLoop | None = None
+
+    def async_setup(
+        self, loop: asyncio.AbstractEventLoop, async_event: asyncio.Event
+    ) -> None:
+        """Set the asyncio.Event instance."""
+        self.loop = loop
+        self.async_event = async_event
+
+    def async_set(self) -> None:
+        """Set the asyncio.Event instance."""
+        self.async_event.set()
+        self.event.set()
+
+    def set(self) -> None:
+        """Set the event."""
+        self.loop.call_soon_threadsafe(self.async_event.set)
+        self.event.set()
+
+    def wait(self) -> None:
+        """Wait for the event."""
+        self.event.wait()
+
+    async def async_wait(self) -> None:
+        """Wait the event async."""
+        await self.async_event.wait()
+
+    def clear(self) -> None:
+        """Clear the event."""
+        self.loop.call_soon_threadsafe(self.async_event.clear)
+        self.event.clear()
+
+    def async_clear(self) -> None:
+        """Clear the event async."""
+        self.async_event.clear()
+        self.event.clear()
+
+    def is_set(self) -> bool:
+        """Return if the event is set."""
+        return self.event.is_set()

--- a/esphome/dashboard/dashboard.py
+++ b/esphome/dashboard/dashboard.py
@@ -1001,8 +1001,6 @@ class MDNSStatus:
     async def async_resolve_host(self, host_name: str) -> str | None:
         """Resolve a host name to an address in a thread-safe manner."""
         if aiozc := self.aiozc:
-            # Currently we do not do any I/O and only
-            # return the cached result (timeout=0)
             return await aiozc.async_resolve_host(host_name)
         return None
 

--- a/esphome/dashboard/dashboard.py
+++ b/esphome/dashboard/dashboard.py
@@ -1261,6 +1261,11 @@ class MDNSContainer:
 
 
 class ThreadedAsyncEvent:
+    """This is a shim to allow the asyncio event to be used in a threaded context.
+
+    When more of the code is moved to asyncio, this can be removed.
+    """
+
     def __init__(self) -> None:
         """Initialize the ThreadedAsyncEvent."""
         self.event = threading.Event()

--- a/esphome/dashboard/dashboard.py
+++ b/esphome/dashboard/dashboard.py
@@ -409,7 +409,7 @@ DASHBOARD_COMMAND = ["esphome", "--dashboard"]
 class EsphomePortCommandWebSocket(EsphomeCommandWebSocket):
     """Base class for commands that require a port."""
 
-    async def run_command(
+    async def build_device_command(
         self, args: list[str], json_message: dict[str, Any]
     ) -> list[str]:
         """Build the command to run."""
@@ -436,7 +436,7 @@ class EsphomePortCommandWebSocket(EsphomeCommandWebSocket):
 class EsphomeLogsHandler(EsphomePortCommandWebSocket):
     async def build_command(self, json_message: dict[str, Any]) -> list[str]:
         """Build the command to run."""
-        return await self.run_command(["logs"], json_message)
+        return await self.build_device_command(["logs"], json_message)
 
 
 class EsphomeRenameHandler(EsphomeCommandWebSocket):
@@ -465,13 +465,13 @@ class EsphomeRenameHandler(EsphomeCommandWebSocket):
 class EsphomeUploadHandler(EsphomePortCommandWebSocket):
     async def build_command(self, json_message: dict[str, Any]) -> list[str]:
         """Build the command to run."""
-        return await self.run_command(["upload"], json_message)
+        return await self.build_device_command(["upload"], json_message)
 
 
 class EsphomeRunHandler(EsphomePortCommandWebSocket):
     async def build_command(self, json_message: dict[str, Any]) -> list[str]:
         """Build the command to run."""
-        return await self.run_command(["run"], json_message)
+        return await self.build_device_command(["run"], json_message)
 
 
 class EsphomeCompileHandler(EsphomeCommandWebSocket):

--- a/esphome/dashboard/dashboard.py
+++ b/esphome/dashboard/dashboard.py
@@ -1314,9 +1314,9 @@ class ThreadedAsyncEvent:
 
 PING_RESULT: dict = {}
 IMPORT_RESULT = {}
-STOP_EVENT = ThreadedAsyncEvent()
+STOP_EVENT = threading.Event()
 PING_REQUEST = ThreadedAsyncEvent()
-MQTT_PING_REQUEST = ThreadedAsyncEvent()
+MQTT_PING_REQUEST = threading.Event()
 MDNS_CONTAINER = MDNSContainer()
 
 
@@ -1589,8 +1589,6 @@ def start_web_server(args):
 async def async_start_web_server(args):
     loop = asyncio.get_event_loop()
     PING_REQUEST.async_setup(loop, asyncio.Event())
-    MQTT_PING_REQUEST.async_setup(loop, asyncio.Event())
-    STOP_EVENT.async_setup(loop, asyncio.Event())
 
     app = make_app(args.verbose)
     if args.socket is not None:

--- a/esphome/dashboard/dashboard.py
+++ b/esphome/dashboard/dashboard.py
@@ -53,6 +53,7 @@ from esphome.zeroconf import (
     DashboardImportDiscovery,
     DashboardStatus,
 )
+from .async_adapter import ThreadedAsyncEvent
 
 from .util import friendly_name_slugify, password_hash
 
@@ -1258,58 +1259,6 @@ class MDNSContainer:
     def get_mdns(self) -> MDNSStatus | None:
         """Return the MDNSStatus instance."""
         return self._mdns
-
-
-class ThreadedAsyncEvent:
-    """This is a shim to allow the asyncio event to be used in a threaded context.
-
-    When more of the code is moved to asyncio, this can be removed.
-    """
-
-    def __init__(self) -> None:
-        """Initialize the ThreadedAsyncEvent."""
-        self.event = threading.Event()
-        self.async_event: asyncio.Event | None = None
-        self.loop: asyncio.AbstractEventLoop | None = None
-
-    def async_setup(
-        self, loop: asyncio.AbstractEventLoop, async_event: asyncio.Event
-    ) -> None:
-        """Set the asyncio.Event instance."""
-        self.loop = loop
-        self.async_event = async_event
-
-    def async_set(self) -> None:
-        """Set the asyncio.Event instance."""
-        self.async_event.set()
-        self.event.set()
-
-    def set(self) -> None:
-        """Set the event."""
-        self.loop.call_soon_threadsafe(self.async_event.set)
-        self.event.set()
-
-    def wait(self) -> None:
-        """Wait for the event."""
-        self.event.wait()
-
-    async def async_wait(self) -> None:
-        """Wait the event async."""
-        await self.async_event.wait()
-
-    def clear(self) -> None:
-        """Clear the event."""
-        self.loop.call_soon_threadsafe(self.async_event.clear)
-        self.event.clear()
-
-    def async_clear(self) -> None:
-        """Clear the event async."""
-        self.async_event.clear()
-        self.event.clear()
-
-    def is_set(self) -> bool:
-        """Return if the event is set."""
-        return self.event.is_set()
 
 
 PING_RESULT: dict = {}

--- a/esphome/dashboard/dashboard.py
+++ b/esphome/dashboard/dashboard.py
@@ -852,8 +852,9 @@ class DashboardEntry:
 
 class ListDevicesHandler(BaseHandler):
     @authenticated
-    def get(self):
-        entries = _list_dashboard_entries()
+    async def get(self):
+        loop = asyncio.get_running_loop()
+        entries = await loop.run_in_executor(None, _list_dashboard_entries)
         self.set_header("content-type", "application/json")
         configured = {entry.name for entry in entries}
         self.write(

--- a/esphome/dashboard/dashboard.py
+++ b/esphome/dashboard/dashboard.py
@@ -307,7 +307,7 @@ class EsphomeCommandWebSocket(tornado.websocket.WebSocketHandler):
         await handlers[type_](self, json_message)
 
     @websocket_method("spawn")
-    async def handle_spawn(self, json_message):
+    async def handle_spawn(self, json_message: dict[str, Any]) -> None:
         if self._proc is not None:
             # spawn can only be called once
             return

--- a/esphome/dashboard/dashboard.py
+++ b/esphome/dashboard/dashboard.py
@@ -18,6 +18,7 @@ import shutil
 import subprocess
 import threading
 from pathlib import Path
+from typing import Any
 
 import tornado
 import tornado.concurrent
@@ -32,7 +33,7 @@ import tornado.web
 import tornado.websocket
 import yaml
 from tornado.log import access_log
-from typing import Any
+
 from esphome import const, platformio_api, util, yaml_util
 from esphome.core import CORE
 from esphome.helpers import get_bool_env, mkdir_p, run_system_command

--- a/esphome/dashboard/dashboard.py
+++ b/esphome/dashboard/dashboard.py
@@ -993,7 +993,9 @@ class MDNSStatusThread(threading.Thread):
     def resolve_host_thread_safe(self, host_name: str) -> str | None:
         """Resolve a host name to an address in a thread-safe manner."""
         if zc := self.zeroconf:
-            return zc.resolve_host(host_name)
+            # Currently we do not do any I/O and only
+            # return the cached result (timeout=0)
+            return zc.resolve_host(host_name, 0)
         return None
 
     def _refresh_hosts(self):

--- a/esphome/dashboard/dashboard.py
+++ b/esphome/dashboard/dashboard.py
@@ -1588,7 +1588,8 @@ async def async_start_web_server(args):
         if ping_status_thread:
             ping_status_thread.join()
         MDNS_CONTAINER.set_mdns(None)
-        mdns_task.cancel()
+        if mdns_task:
+            mdns_task.cancel()
         if settings.status_use_mqtt:
             status_thread_mqtt.join()
             MQTT_PING_REQUEST.set()

--- a/esphome/dashboard/dashboard.py
+++ b/esphome/dashboard/dashboard.py
@@ -1580,8 +1580,6 @@ async def async_start_web_server(args):
     shutdown_event = asyncio.Event()
     try:
         await shutdown_event.wait()
-    except KeyboardInterrupt:
-        raise
     finally:
         _LOGGER.info("Shutting down...")
         STOP_EVENT.set()

--- a/esphome/dashboard/dashboard.py
+++ b/esphome/dashboard/dashboard.py
@@ -342,7 +342,7 @@ class EsphomeCommandWebSocket(tornado.websocket.WebSocketHandler):
         return self._proc is not None and self._proc.returncode is None
 
     @websocket_method("stdin")
-    async def handle_stdin(self, json_message):
+    async def handle_stdin(self, json_message: dict[str, Any]) -> None:
         if not self.is_process_active:
             return
         data = json_message["data"]
@@ -351,7 +351,7 @@ class EsphomeCommandWebSocket(tornado.websocket.WebSocketHandler):
         self._proc.stdin.write(data)
 
     @tornado.gen.coroutine
-    def _redirect_stdout(self):
+    def _redirect_stdout(self) -> None:
         reg = b"[\n\r]"
 
         while True:
@@ -370,7 +370,7 @@ class EsphomeCommandWebSocket(tornado.websocket.WebSocketHandler):
             _LOGGER.debug("> stdout: %s", data)
             self.write_message({"event": "line", "data": data})
 
-    def _stdout_thread(self):
+    def _stdout_thread(self) -> None:
         if not self._use_popen:
             return
         while True:
@@ -383,13 +383,13 @@ class EsphomeCommandWebSocket(tornado.websocket.WebSocketHandler):
         self._proc.wait(1.0)
         self._queue.put_nowait(None)
 
-    def _proc_on_exit(self, returncode):
+    def _proc_on_exit(self, returncode: int) -> None:
         if not self._is_closed:
             # Check if the proc was not forcibly closed
             _LOGGER.info("Process exited with return code %s", returncode)
             self.write_message({"event": "exit", "code": returncode})
 
-    def on_close(self):
+    def on_close(self) -> None:
         # Check if proc exists (if 'start' has been run)
         if self.is_process_active:
             _LOGGER.debug("Terminating process")
@@ -466,13 +466,13 @@ class EsphomeRenameHandler(EsphomeCommandWebSocket):
 class EsphomeUploadHandler(EsphomePortCommandWebSocket):
     async def build_command(self, json_message: dict[str, Any]) -> list[str]:
         """Build the command to run."""
-        return self.run_command(["upload"], json_message)
+        return await self.run_command(["upload"], json_message)
 
 
 class EsphomeRunHandler(EsphomePortCommandWebSocket):
     async def build_command(self, json_message: dict[str, Any]) -> list[str]:
         """Build the command to run."""
-        return self.run_command(["run"], json_message)
+        return await self.run_command(["run"], json_message)
 
 
 class EsphomeCompileHandler(EsphomeCommandWebSocket):

--- a/esphome/dashboard/dashboard.py
+++ b/esphome/dashboard/dashboard.py
@@ -289,7 +289,10 @@ class EsphomeCommandWebSocket(tornado.websocket.WebSocketHandler):
         self._use_popen = os.name == "nt"
 
     @authenticated
-    async def on_message(self, message):
+    async def on_message(  # pylint: disable=invalid-overridden-method
+        self, message: str
+    ) -> None:
+        # Since tornado 4.5, on_message is allowed to be a coroutine
         # Messages are always JSON, 500 when not
         json_message = json.loads(message)
         type_ = json_message["type"]

--- a/esphome/zeroconf.py
+++ b/esphome/zeroconf.py
@@ -147,12 +147,13 @@ class DashboardImportDiscovery:
 
 
 class EsphomeZeroconf(Zeroconf):
-    def resolve_host(self, host: str, timeout=3.0):
+    def resolve_host(self, host: str, timeout: float = 3.0) -> str | None:
         """Resolve a host name to an IP address."""
         name = host.partition(".")[0]
-        info = HostResolver(f"{name}.{ESPHOME_SERVICE_TYPE}", ESPHOME_SERVICE_TYPE)
-        if (info.load_from_cache(self) or info.request(self, timeout * 1000)) and (
-            addresses := info.ip_addresses_by_version(IPVersion.V4Only)
-        ):
+        info = HostResolver(ESPHOME_SERVICE_TYPE, f"{name}.{ESPHOME_SERVICE_TYPE}")
+        if (
+            info.load_from_cache(self)
+            or (timeout and info.request(self, timeout * 1000))
+        ) and (addresses := info.ip_addresses_by_version(IPVersion.V4Only)):
             return str(addresses[0])
         return None

--- a/esphome/zeroconf.py
+++ b/esphome/zeroconf.py
@@ -1,20 +1,19 @@
 from __future__ import annotations
 
+import asyncio
 import logging
 from dataclasses import dataclass
 from typing import Callable
 
-from zeroconf import (
-    IPVersion,
-    ServiceBrowser,
-    ServiceInfo,
-    ServiceStateChange,
-    Zeroconf,
-)
+from zeroconf import IPVersion, ServiceInfo, ServiceStateChange, Zeroconf
+from zeroconf.asyncio import AsyncServiceBrowser, AsyncServiceInfo, AsyncZeroconf
 
 from esphome.storage_json import StorageJSON, ext_storage_path
 
 _LOGGER = logging.getLogger(__name__)
+
+
+_BACKGROUND_TASKS: set[asyncio.Task] = set()
 
 
 class HostResolver(ServiceInfo):
@@ -65,7 +64,7 @@ class DiscoveredImport:
     network: str
 
 
-class DashboardBrowser(ServiceBrowser):
+class DashboardBrowser(AsyncServiceBrowser):
     """A class to browse for ESPHome nodes."""
 
 
@@ -94,7 +93,28 @@ class DashboardImportDiscovery:
             # Ignore updates for devices that are not in the import state
             return
 
-        info = zeroconf.get_service_info(service_type, name)
+        info = AsyncServiceInfo(
+            service_type,
+            name,
+        )
+        if info.load_from_cache(zeroconf):
+            self._process_service_info(name, info)
+            return
+        task = asyncio.create_task(
+            self._async_process_service_info(zeroconf, info, service_type, name)
+        )
+        _BACKGROUND_TASKS.add(task)
+        task.add_done_callback(_BACKGROUND_TASKS.discard)
+
+    async def _async_process_service_info(
+        self, zeroconf: Zeroconf, info: AsyncServiceInfo, service_type: str, name: str
+    ) -> None:
+        """Process a service info."""
+        if await info.async_request(zeroconf):
+            self._process_service_info(name, info)
+
+    def _process_service_info(self, name: str, info: ServiceInfo) -> None:
+        """Process a service info."""
         _LOGGER.debug("-> resolved info: %s", info)
         if info is None:
             return
@@ -146,16 +166,17 @@ class DashboardImportDiscovery:
                 )
 
 
-class EsphomeZeroconf(Zeroconf):
-    def _make_host_resolver(self, host: str) -> HostResolver:
-        """Create a new HostResolver for the given host name."""
-        name = host.partition(".")[0]
-        info = HostResolver(ESPHOME_SERVICE_TYPE, f"{name}.{ESPHOME_SERVICE_TYPE}")
-        return info
+def _make_host_resolver(host: str) -> HostResolver:
+    """Create a new HostResolver for the given host name."""
+    name = host.partition(".")[0]
+    info = HostResolver(ESPHOME_SERVICE_TYPE, f"{name}.{ESPHOME_SERVICE_TYPE}")
+    return info
 
+
+class EsphomeZeroconf(Zeroconf):
     def resolve_host(self, host: str, timeout: float = 3.0) -> str | None:
         """Resolve a host name to an IP address."""
-        info = self._make_host_resolver(host)
+        info = _make_host_resolver(host)
         if (
             info.load_from_cache(self)
             or (timeout and info.request(self, timeout * 1000))
@@ -163,12 +184,14 @@ class EsphomeZeroconf(Zeroconf):
             return str(addresses[0])
         return None
 
+
+class AsyncEsphomeZeroconf(AsyncZeroconf):
     async def async_resolve_host(self, host: str, timeout: float = 3.0) -> str | None:
         """Resolve a host name to an IP address."""
-        info = self._make_host_resolver(host)
+        info = _make_host_resolver(host)
         if (
-            info.load_from_cache(self)
-            or (timeout and await info.async_request(self, timeout * 1000))
+            info.load_from_cache(self.zeroconf)
+            or (timeout and await info.async_request(self.zeroconf, timeout * 1000))
         ) and (addresses := info.ip_addresses_by_version(IPVersion.V4Only)):
             return str(addresses[0])
         return None


### PR DESCRIPTION
# What does this implement/fix?

Since we already have a service browser running, we likely already know the IP of the device we want to connect to so we can replace `--device OTA` with the address if its in the cache (ie seen in the last 120 seconds aka host ttl) to avoid the esphome app having to look it up again (and multicast another query to the network)

To accomplish this, we need to migrate the tornado websocket handler to use coroutines since tornado already supports them natively. The way we are currently starting the webserver is deprecated and going away so we will also migrate partially to `asyncio` with some wrappers for the un-migrated parts https://www.tornadoweb.org/en/stable/guide/structure.html#the-main-coroutine

Before this change zeroconf is starting its own event loop in a thread, after the change, a single event loop is used.
<img width="651" alt="Screenshot 2023-11-12 at 6 08 06 PM" src="https://github.com/esphome/esphome/assets/663432/093106b5-e7e7-42a6-ac22-cc43594dffbf">
<img width="648" alt="Screenshot 2023-11-12 at 6 07 58 PM" src="https://github.com/esphome/esphome/assets/663432/81e83902-86e1-4f15-a46f-12487ad6adda">

In a future pr we can avoid spawning another process to run the logs which will further reduce the number of zeroconf instances running at the same time

This should help reduce cases where the system runs out of buffer space aka https://github.com/esphome/issues/issues/2669 https://github.com/esphome/issues/issues/2534

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
