### PR TITLE
Migrate to using aioesphomeapi for the log runner to fix multiple issues

### DIFF
--- a/esphome/components/api/client.py
+++ b/esphome/components/api/client.py
@@ -1,19 +1,22 @@
 import asyncio
 import logging
 from datetime import datetime
-from typing import Optional
+from typing import Any, Optional
 
-from aioesphomeapi import APIClient, ReconnectLogic, APIConnectionError, LogLevel
-import zeroconf
+from aioesphomeapi import APIClient
+from aioesphomeapi.api_pb2 import SubscribeLogsResponse
+from aioesphomeapi.log_runner import async_run
 
-from esphome.const import CONF_KEY, CONF_PORT, CONF_PASSWORD, __version__
-from esphome.util import safe_print
+from esphome.const import CONF_KEY, CONF_PASSWORD, CONF_PORT, __version__
+from esphome.core import CORE
+
 from . import CONF_ENCRYPTION
 
 _LOGGER = logging.getLogger(__name__)
 
 
 async def async_run_logs(config, address):
+    """Run the logs command in the event loop."""
     conf = config["api"]
     port: int = int(conf[CONF_PORT])
     password: str = conf[CONF_PASSWORD]
@@ -28,44 +31,28 @@ async def async_run_logs(config, address):
         client_info=f"ESPHome Logs {__version__}",
         noise_psk=noise_psk,
     )
-    first_connect = True
+    dashboard = CORE.dashboard
 
-    def on_log(msg):
-        time_ = datetime.now().time().strftime("[%H:%M:%S]")
-        text = msg.message.decode("utf8", "backslashreplace")
-        safe_print(time_ + text)
+    def on_log(msg: SubscribeLogsResponse) -> None:
+        """Handle a new log message."""
+        time_ = datetime.now()
+        message: bytes = msg.message
+        text = message.decode("utf8", "backslashreplace")
+        if dashboard:
+            text = text.replace("\033", "\\033")
+        print(f"[{time_.hour:02}:{time_.minute:02}:{time_.second:02}]{text}")
 
-    async def on_connect():
-        nonlocal first_connect
-        try:
-            await cli.subscribe_logs(
-                on_log,
-                log_level=LogLevel.LOG_LEVEL_VERY_VERBOSE,
-                dump_config=first_connect,
-            )
-            first_connect = False
-        except APIConnectionError:
-            cli.disconnect()
-
-    async def on_disconnect(expected_disconnect: bool) -> None:
-        _LOGGER.warning("Disconnected from API")
-
-    zc = zeroconf.Zeroconf()
-    reconnect = ReconnectLogic(
-        client=cli,
-        on_connect=on_connect,
-        on_disconnect=on_disconnect,
-        zeroconf_instance=zc,
-    )
-    await reconnect.start()
-
+    stop = await async_run(cli, on_log)
     try:
         while True:
             await asyncio.sleep(60)
+    finally:
+        await stop()
+
+
+def run_logs(config: dict[str, Any], address: str) -> None:
+    """Run the logs command."""
+    try:
+        asyncio.run(async_run_logs(config, address))
     except KeyboardInterrupt:
-        await reconnect.stop()
-        zc.close()
-
-
-def run_logs(config, address):
-    asyncio.run(async_run_logs(config, address))
+        pass

--- a/esphome/components/api/client.py
+++ b/esphome/components/api/client.py
@@ -35,7 +35,7 @@ async def async_run_logs(config, address):
         password,
         client_info=f"ESPHome Logs {__version__}",
         noise_psk=noise_psk,
-        zeroconf_instance=aiozc,
+        zeroconf_instance=aiozc.zeroconf,
     )
     dashboard = CORE.dashboard
 

--- a/esphome/components/api/client.py
+++ b/esphome/components/api/client.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 import asyncio
 import logging
 from datetime import datetime
-from typing import Any, Optional
+from typing import Any
 
 from aioesphomeapi import APIClient
 from aioesphomeapi.api_pb2 import SubscribeLogsResponse
@@ -20,7 +22,7 @@ async def async_run_logs(config, address):
     conf = config["api"]
     port: int = int(conf[CONF_PORT])
     password: str = conf[CONF_PASSWORD]
-    noise_psk: Optional[str] = None
+    noise_psk: str | None = None
     if CONF_ENCRYPTION in conf:
         noise_psk = conf[CONF_ENCRYPTION][CONF_KEY]
     _LOGGER.info("Starting log output from %s using esphome API", address)

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ platformio==6.1.11  # When updating platformio, also update Dockerfile
 esptool==4.6.2
 click==8.1.7
 esphome-dashboard==20231107.0
-aioesphomeapi==18.2.7
+aioesphomeapi==18.4.0
 zeroconf==0.122.3
 
 # esp-idf requires this, but doesn't bundle it by default


### PR DESCRIPTION
If we want to backport this fix, it also needs https://github.com/esphome/esphome/pull/5735

# What does this implement/fix?

- Use the log runner code from aioesphomeapi since it handles zeroconf correctly which fixes log runner using zeroconf sync close running in the event loop

- The connection to the ESP is now shutdown cleanly on keyboard interrupt.

- Avoid calling `safe_print` since it has a slow late import and does multiple bytes/string conversions (which were probably unreachable for this case since we already did a decode with how to handle error specified)

- Ensure the zeroconf object is passed to the client (resolution didn't always work because it relied on the host system and not zeroconf since it created two zeroconf instances and the second one didn't always work)

- Refactor to avoid running two copies of zeroconf

- The log runner code in `aioesphomeapi` has test coverage

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/3517 (assuming there isn't something else broken there) fixes https://github.com/esphome/issues/issues/2379 (again, assumes its not a local problem there)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
