### PR TITLE
dashboard: Run get_serial_ports in the executor

### DIFF
--- a/esphome/dashboard/dashboard.py
+++ b/esphome/dashboard/dashboard.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import base64
 import binascii
 import codecs
@@ -510,7 +511,7 @@ class EsphomeUpdateAllHandler(EsphomeCommandWebSocket):
 class SerialPortRequestHandler(BaseHandler):
     @authenticated
     async def get(self):
-        ports = await tornado.ioloop.IOLoop.run_in_executor(None, get_serial_ports)
+        ports = await asyncio.get_running_loop().run_in_executor(None, get_serial_ports)
         data = []
         for port in ports:
             desc = port.description

--- a/esphome/dashboard/dashboard.py
+++ b/esphome/dashboard/dashboard.py
@@ -509,8 +509,8 @@ class EsphomeUpdateAllHandler(EsphomeCommandWebSocket):
 
 class SerialPortRequestHandler(BaseHandler):
     @authenticated
-    def get(self):
-        ports = get_serial_ports()
+    async def get(self):
+        ports = await tornado.ioloop.IOLoop.run_in_executor(None, get_serial_ports)
         data = []
         for port in ports:
             desc = port.description


### PR DESCRIPTION
# What does this implement/fix?

get_serial_ports does blocking I/O and should not be running in tornado event loop
<img width="1750" alt="Screenshot 2023-11-12 at 6 10 19 PM" src="https://github.com/esphome/esphome/assets/663432/a72173f5-9977-447c-a45a-7784b45e1f63">

`_list_dashboard_entries` is also a problem and fixed in https://github.com/esphome/esphome/pull/5724

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
