### PR TITLE
dashboard: remove usage of codecs module

### DIFF
--- a/esphome/dashboard/dashboard.py
+++ b/esphome/dashboard/dashboard.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import base64
 import binascii
-import codecs
 import collections
 import datetime
 import functools
@@ -339,8 +338,8 @@ class EsphomeCommandWebSocket(tornado.websocket.WebSocketHandler):
     def handle_stdin(self, json_message):
         if not self.is_process_active:
             return
-        data = json_message["data"]
-        data = codecs.encode(data, "utf8", "replace")
+        text: str = json_message["data"]
+        data = text.encode("utf-8", "replace")
         _LOGGER.debug("< stdin: %s", data)
         self._proc.stdin.write(data)
 
@@ -351,18 +350,18 @@ class EsphomeCommandWebSocket(tornado.websocket.WebSocketHandler):
         while True:
             try:
                 if self._use_popen:
-                    data = yield self._queue.get()
+                    data: bytes = yield self._queue.get()
                     if data is None:
                         self._proc_on_exit(self._proc.poll())
                         break
                 else:
-                    data = yield self._proc.stdout.read_until_regex(reg)
+                    data: bytes = yield self._proc.stdout.read_until_regex(reg)
             except tornado.iostream.StreamClosedError:
                 break
-            data = codecs.decode(data, "utf8", "replace")
 
-            _LOGGER.debug("> stdout: %s", data)
-            self.write_message({"event": "line", "data": data})
+            text = data.decode("utf-8", "replace")
+            _LOGGER.debug("> stdout: %s", text)
+            self.write_message({"event": "line", "data": text})
 
     def _stdout_thread(self):
         if not self._use_popen:


### PR DESCRIPTION

# What does this implement/fix?

codecs is legacy, encode and decode are now built-in to str and bytes objects


## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
