### PR TITLE
Allow setup to continue past mqtt if network/wifi is disabled

### DIFF
--- a/esphome/components/mqtt/mqtt_client.cpp
+++ b/esphome/components/mqtt/mqtt_client.cpp
@@ -147,7 +147,7 @@ void MQTTClientComponent::dump_config() {
     ESP_LOGCONFIG(TAG, "  Availability: '%s'", this->availability_.topic.c_str());
   }
 }
-bool MQTTClientComponent::can_proceed() { return this->is_connected(); }
+bool MQTTClientComponent::can_proceed() { return network::is_disabled() || this->is_connected(); }
 
 void MQTTClientComponent::start_dnslookup_() {
   for (auto &subscription : this->subscriptions_) {

--- a/esphome/components/network/util.cpp
+++ b/esphome/components/network/util.cpp
@@ -29,6 +29,14 @@ bool is_connected() {
   return false;
 }
 
+bool is_disabled() {
+#ifdef USE_WIFI
+  if (wifi::global_wifi_component != nullptr)
+    return wifi::global_wifi_component->is_disabled();
+#endif
+  return false;
+}
+
 network::IPAddress get_ip_address() {
 #ifdef USE_ETHERNET
   if (ethernet::global_eth_component != nullptr)

--- a/esphome/components/network/util.h
+++ b/esphome/components/network/util.h
@@ -8,6 +8,8 @@ namespace network {
 
 /// Return whether the node is connected to the network (through wifi, eth, ...)
 bool is_connected();
+/// Return whether the network is disabled (only wifi for now)
+bool is_disabled();
 /// Get the active network hostname
 std::string get_use_address();
 IPAddress get_ip_address();


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Currently `mqtt` "blocks" setup of any further components until it is connected

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
