### PR TITLE
SCD30 support pressure compensation updates

### DIFF
--- a/esphome/components/scd30/scd30.h
+++ b/esphome/components/scd30/scd30.h
@@ -30,6 +30,7 @@ class SCD30Component : public Component, public sensirion_common::SensirionI2CDe
 
  protected:
   bool is_data_ready_();
+  void restart_continuous_measurements_();
 
   enum ErrorCode {
     COMMUNICATION_FAILED,
@@ -41,6 +42,7 @@ class SCD30Component : public Component, public sensirion_common::SensirionI2CDe
   bool enable_asc_{true};
   uint16_t altitude_compensation_{0xFFFF};
   uint16_t ambient_pressure_compensation_{0x0000};
+  uint16_t current_ambient_pressure_compensation_{0x0000};
   float temperature_offset_{0.0};
   uint16_t update_interval_{0xFFFF};
 


### PR DESCRIPTION
# What does this implement/fix?

Continuously process changed pressure compensation values for SCD30 CO2 sensor.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
esp8266:
  board: d1_mini

esphome:
  name: "test"
  friendly_name: "test"

globals:
  - id: last_calibrate_pressure
    type: float
    restore_value: no
    initial_value: '0'

i2c:
  scan: false
  id: bus_a

sensor:
  - platform: scd30
    id: sensor_scd30
    co2:
      name: "scd30_co2"
      accuracy_decimals: 0
      icon: "mdi:molecule-co2"
    automatic_self_calibration: false
    address: 0x61
    update_interval: 3s
  - platform: bme280
    pressure:
      name: "bme280_pressure"
      id: "bme280_pressure"
      on_value:
        then:
          - lambda: |-
              if (abs(id(bme280_pressure).state - id(last_calibrate_pressure)) > 1) {
                ESP_LOGD("calibrate_pressure", "SCD30 set_ambient_pressure_compensation(%f)", id(bme280_pressure).state/1000);
                sensor_scd30->set_ambient_pressure_compensation(id(bme280_pressure).state/1000);
                id(last_calibrate_pressure) = id(bme280_pressure).state;
              }
      accuracy_decimals: 1
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
