### PR TITLE
Fix MY9231 flicker

### DIFF
--- a/esphome/components/my9231/my9231.h
+++ b/esphome/components/my9231/my9231.h
@@ -49,6 +49,7 @@ class MY9231OutputComponent : public Component {
   void init_chips_(uint8_t command);
   void write_word_(uint16_t value, uint8_t bits);
   void send_di_pulses_(uint8_t count);
+  void send_dcki_pulses_(uint8_t count);
 
   GPIOPin *pin_di_;
   GPIOPin *pin_dcki_;


### PR DESCRIPTION
# What does this implement/fix?

Changes:
 - Add interrupt lock for more accurate timings
 - Reset the MY9231 on reboot, this allows changing the `bit_depth` without power cycling

Fixes:
 - Flickering during long transitions (with `bit_depth` 12, 14 and 16)
 - Color changing to blue or purple after reboot while showing "off" in Home Assistant (with `bit_depth` 8, 12 and 14)
 - Heavy flickering and wrong colors after changing `bit_depth`, power cycle required

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
my9231:
  data_pin: GPIO12
  clock_pin: GPIO14
  num_channels: 6
  num_chips: 2

output:
  - platform: my9231
    id: output_blue
    channel: 0
  - platform: my9231
    id: output_red
    channel: 1
  - platform: my9231
    id: output_green
    channel: 2
  - platform: my9231
    id: output_warm_white
    channel: 4
  - platform: my9231
    id: output_cold_white
    channel: 5

light:
  - platform: rgbww
    name: Light
    red: output_red
    green: output_green
    blue: output_blue
    cold_white: output_cold_white
    warm_white: output_warm_white
    cold_white_color_temperature: 6500 K
    warm_white_color_temperature: 2800 K
    gamma_correct: 1.5
    color_interlock: True
    restore_mode: RESTORE_DEFAULT_OFF
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
