### PR TITLE
dashboard: use fastest available yaml loader in the dashboard

### DIFF
--- a/esphome/dashboard/status/ping.py
+++ b/esphome/dashboard/status/ping.py
@@ -4,9 +4,8 @@ import asyncio
 import os
 from typing import cast
 
-from ..core import DASHBOARD
+from ..core import DASHBOARD, list_dashboard_entries
 from ..entries import DashboardEntry
-from ..core import list_dashboard_entries
 from ..util import chunked
 
 

--- a/esphome/dashboard/status/ping.py
+++ b/esphome/dashboard/status/ping.py
@@ -4,8 +4,9 @@ import asyncio
 import os
 from typing import cast
 
-from ..core import DASHBOARD, list_dashboard_entries
+from ..core import DASHBOARD
 from ..entries import DashboardEntry
+from ..core import list_dashboard_entries
 from ..util import chunked
 
 

--- a/esphome/dashboard/web_server.py
+++ b/esphome/dashboard/web_server.py
@@ -34,6 +34,7 @@ from esphome import const, platformio_api, yaml_util
 from esphome.helpers import get_bool_env, mkdir_p, run_system_command
 from esphome.storage_json import StorageJSON, ext_storage_path, trash_storage_path
 from esphome.util import get_serial_ports, shlex_quote
+from esphome.yaml_util import FastestAvailableSafeLoader
 
 from .core import DASHBOARD, list_dashboard_entries
 from .entries import DashboardEntry
@@ -885,7 +886,7 @@ class SecretKeysRequestHandler(BaseHandler):
         self.write(json.dumps(secret_keys))
 
 
-class SafeLoaderIgnoreUnknown(yaml.SafeLoader):
+class SafeLoaderIgnoreUnknown(FastestAvailableSafeLoader):
     def ignore_unknown(self, node):
         return f"{node.tag} {node.value}"
 


### PR DESCRIPTION
# What does this implement/fix?

Use fastest available yaml loader in the dashboard

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
