### PR TITLE
dashboard: Add support for firing events

### DIFF
--- a/esphome/dashboard/const.py
+++ b/esphome/dashboard/const.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+EVENT_ENTRY_ADDED = "entry_added"
+EVENT_ENTRY_REMOVED = "entry_removed"
+EVENT_ENTRY_UPDATED = "entry_updated"
+EVENT_ENTRY_STATE_CHANGED = "entry_state_changed"
+
+SENTINEL = object()

--- a/esphome/dashboard/core.py
+++ b/esphome/dashboard/core.py
@@ -60,6 +60,7 @@ class ESPHomeDashboard:
     """Class that represents the dashboard."""
 
     __slots__ = (
+        "bus",
         "entries",
         "loop",
         "import_result",

--- a/esphome/dashboard/core.py
+++ b/esphome/dashboard/core.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 import asyncio
 import logging
 import threading
-from typing import TYPE_CHECKING
+from dataclasses import dataclass
+from functools import partial
+from typing import TYPE_CHECKING, Any, Callable
 
 from ..zeroconf import DiscoveredImport
 from .entries import DashboardEntries
@@ -12,7 +14,46 @@ from .settings import DashboardSettings
 if TYPE_CHECKING:
     from .status.mdns import MDNSStatus
 
+
 _LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class Event:
+    """Dashboard Event."""
+
+    event_type: str
+    data: dict[str, Any]
+
+
+class EventBus:
+    """Dashboard event bus."""
+
+    def __init__(self) -> None:
+        """Initialize the Dashboard event bus."""
+        self._listeners: dict[str, set[Callable[[Event], None]]] = {}
+
+    def async_add_listener(
+        self, event_type: str, listener: Callable[[Event], None]
+    ) -> Callable[[], None]:
+        """Add a listener to the event bus."""
+        self._listeners.setdefault(event_type, set()).add(listener)
+        return partial(self._async_remove_listener, event_type, listener)
+
+    def _async_remove_listener(
+        self, event_type: str, listener: Callable[[Event], None]
+    ) -> None:
+        """Remove a listener from the event bus."""
+        self._listeners[event_type].discard(listener)
+
+    def async_fire(self, event_type: str, event_data: dict[str, Any]) -> None:
+        """Fire an event."""
+        event = Event(event_type, event_data)
+
+        _LOGGER.debug("Firing event: %s", event)
+
+        for listener in self._listeners.get(event_type, set()):
+            listener(event)
 
 
 class ESPHomeDashboard:
@@ -21,7 +62,6 @@ class ESPHomeDashboard:
     __slots__ = (
         "entries",
         "loop",
-        "ping_result",
         "import_result",
         "stop_event",
         "ping_request",
@@ -32,9 +72,9 @@ class ESPHomeDashboard:
 
     def __init__(self) -> None:
         """Initialize the ESPHomeDashboard."""
+        self.bus = EventBus()
         self.entries: DashboardEntries | None = None
         self.loop: asyncio.AbstractEventLoop | None = None
-        self.ping_result: dict[str, bool | None] = {}
         self.import_result: dict[str, DiscoveredImport] = {}
         self.stop_event = threading.Event()
         self.ping_request: asyncio.Event | None = None
@@ -46,7 +86,7 @@ class ESPHomeDashboard:
         """Setup the dashboard."""
         self.loop = asyncio.get_running_loop()
         self.ping_request = asyncio.Event()
-        self.entries = DashboardEntries(self.settings.config_dir)
+        self.entries = DashboardEntries(self)
 
     async def async_run(self) -> None:
         """Run the dashboard."""

--- a/esphome/dashboard/entries.py
+++ b/esphome/dashboard/entries.py
@@ -155,14 +155,15 @@ class DashboardEntries:
         path_to_cache_key = await self._loop.run_in_executor(
             None, self._get_path_to_cache_key
         )
+        entries = self._entries
         added: dict[DashboardEntry, DashboardCacheKeyType] = {}
         updated: dict[DashboardEntry, DashboardCacheKeyType] = {}
         removed: set[DashboardEntry] = {
             entry
-            for filename, entry in self._entries.items()
+            for filename, entry in entries.items()
             if filename not in path_to_cache_key
         }
-        entries = self._entries
+
         for path, cache_key in path_to_cache_key.items():
             if entry := self._entries.get(path):
                 if entry.cache_key != cache_key:
@@ -181,8 +182,8 @@ class DashboardEntries:
             entries[entry.path] = entry
             bus.async_fire(EVENT_ENTRY_ADDED, {"entry": entry})
 
-        if entry in removed:
-            entries.pop(entry.path)
+        for entry in removed:
+            del entries[entry.path]
             bus.async_fire(EVENT_ENTRY_REMOVED, {"entry": entry})
 
         for entry in updated:
@@ -240,11 +241,13 @@ class DashboardEntry:
     def __repr__(self):
         """Return the representation of this entry."""
         return (
-            f"DashboardEntry({self.path} "
+            f"DashboardEntry(path={self.path} "
             f"address={self.address} "
             f"web_port={self.web_port} "
             f"name={self.name} "
-            f"no_mdns={self.no_mdns})"
+            f"no_mdns={self.no_mdns} "
+            f"state={self.state} "
+            ")"
         )
 
     def load_from_disk(self, cache_key: DashboardCacheKeyType | None = None) -> None:

--- a/esphome/dashboard/entries.py
+++ b/esphome/dashboard/entries.py
@@ -36,11 +36,26 @@ class EntryState(StrEnum):
     UNKNOWN = "unknown"
 
 
+_BOOL_TO_ENTRY_STATE = {
+    True: EntryState.ONLINE,
+    False: EntryState.OFFLINE,
+    None: EntryState.UNKNOWN,
+}
+_ENTRY_STATE_TO_BOOL = {
+    EntryState.ONLINE: True,
+    EntryState.OFFLINE: False,
+    EntryState.UNKNOWN: None,
+}
+
+
 def bool_to_entry_state(value: bool) -> EntryState:
     """Convert a bool to an entry state."""
-    if value is None:
-        return EntryState.UNKNOWN
-    return EntryState.ONLINE if value else EntryState.OFFLINE
+    return _BOOL_TO_ENTRY_STATE[value]
+
+
+def entry_state_to_bool(value: EntryState) -> bool | None:
+    """Convert an entry state to a bool."""
+    return _ENTRY_STATE_TO_BOOL[value]
 
 
 class DashboardEntries:
@@ -211,12 +226,12 @@ class DashboardEntry:
     This class is thread-safe and read-only.
     """
 
-    __slots__ = ("path", "filename", "_storage_path", "cache_key", "storage", "online")
+    __slots__ = ("path", "filename", "_storage_path", "cache_key", "storage", "state")
 
     def __init__(self, path: str, cache_key: DashboardCacheKeyType) -> None:
         """Initialize the DashboardEntry."""
         self.path = path
-        self.filename = os.path.basename(path)
+        self.filename: str = os.path.basename(path)
         self._storage_path = ext_storage_path(self.filename)
         self.cache_key = cache_key
         self.storage: StorageJSON | None = None

--- a/esphome/dashboard/entries.py
+++ b/esphome/dashboard/entries.py
@@ -5,11 +5,6 @@ import logging
 import os
 from typing import TYPE_CHECKING
 
-from .enum import StrEnum
-
-if TYPE_CHECKING:
-    from .core import ESPHomeDashboard
-
 from esphome import const, util
 from esphome.storage_json import StorageJSON, ext_storage_path
 
@@ -19,6 +14,10 @@ from .const import (
     EVENT_ENTRY_STATE_CHANGED,
     EVENT_ENTRY_UPDATED,
 )
+from .enum import StrEnum
+
+if TYPE_CHECKING:
+    from .core import ESPHomeDashboard
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/esphome/dashboard/entries.py
+++ b/esphome/dashboard/entries.py
@@ -165,7 +165,7 @@ class DashboardEntries:
         }
 
         for path, cache_key in path_to_cache_key.items():
-            if entry := self._entries.get(path):
+            if entry := entries.get(path):
                 if entry.cache_key != cache_key:
                     updated[entry] = cache_key
             else:

--- a/esphome/dashboard/entries.py
+++ b/esphome/dashboard/entries.py
@@ -258,7 +258,7 @@ class DashboardEntry:
             ")"
         )
 
-    def to_dict(self) -> dict[str, str | bool | None]:
+    def to_dict(self) -> dict[str, Any]:
         """Return a dict representation of this entry.
 
         The dict includes the loaded configuration but not

--- a/esphome/dashboard/entries.py
+++ b/esphome/dashboard/entries.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
-from enum import Enum
 from typing import TYPE_CHECKING
+
+from .enum import StrEnum
 
 if TYPE_CHECKING:
     from .core import ESPHomeDashboard
@@ -29,7 +30,7 @@ DashboardCacheKeyType = tuple[int, int, float, int]
 # it may be expanded to include more states
 
 
-class EntryState(Enum):
+class EntryState(StrEnum):
     ONLINE = "online"
     OFFLINE = "offline"
     UNKNOWN = "unknown"

--- a/esphome/dashboard/enum.py
+++ b/esphome/dashboard/enum.py
@@ -1,0 +1,21 @@
+"""Enum backports from standard lib."""
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any
+
+from typing_extensions import Self
+
+
+class StrEnum(str, Enum):
+    """Partial backport of Python 3.11's StrEnum for our basic use cases."""
+
+    def __new__(cls, value: str, *args: Any, **kwargs: Any) -> Self:
+        """Create a new StrEnum instance."""
+        if not isinstance(value, str):
+            raise TypeError(f"{value!r} is not a string")
+        return super().__new__(cls, value, *args, **kwargs)
+
+    def __str__(self) -> str:
+        """Return self.value."""
+        return str(self.value)

--- a/esphome/dashboard/enum.py
+++ b/esphome/dashboard/enum.py
@@ -4,13 +4,11 @@ from __future__ import annotations
 from enum import Enum
 from typing import Any
 
-from typing_extensions import Self
-
 
 class StrEnum(str, Enum):
     """Partial backport of Python 3.11's StrEnum for our basic use cases."""
 
-    def __new__(cls, value: str, *args: Any, **kwargs: Any) -> Self:
+    def __new__(cls, value: str, *args: Any, **kwargs: Any) -> StrEnum:
         """Create a new StrEnum instance."""
         if not isinstance(value, str):
             raise TypeError(f"{value!r} is not a string")

--- a/esphome/dashboard/status/mdns.py
+++ b/esphome/dashboard/status/mdns.py
@@ -89,8 +89,7 @@ class MDNSStatus:
                 host_mdns_state[name] = result
                 if name not in host_name_with_mdns_enabled:
                     continue
-                path = host_name_to_path[name]
-                if entry := entries.get(path):
+                if entry := entries.get(host_name_to_path[name]):
                     entries.async_set_state(entry, bool_to_entry_state(result))
 
         stat = DashboardStatus(on_update)

--- a/esphome/dashboard/status/mdns.py
+++ b/esphome/dashboard/status/mdns.py
@@ -31,7 +31,7 @@ class MDNSStatus:
         self.host_name_with_mdns_enabled: set[set] = set()
         self._loop = asyncio.get_running_loop()
 
-    def path_to_host_name_thread_safe(self, path: str) -> str | None:
+    def get_path_to_host_name(self, path: str) -> str | None:
         """Resolve a path to an address in a thread-safe manner."""
         return self.path_to_host_name.get(path)
 

--- a/esphome/dashboard/status/mdns.py
+++ b/esphome/dashboard/status/mdns.py
@@ -87,10 +87,11 @@ class MDNSStatus:
             """Update the entry state."""
             for name, result in dat.items():
                 host_mdns_state[name] = result
-                if name in host_name_with_mdns_enabled:
-                    path = host_name_to_path[name]
-                    if entry := entries.get(path):
-                        entries.async_set_state(entry, bool_to_entry_state(result))
+                if name not in host_name_with_mdns_enabled:
+                    continue
+                path = host_name_to_path[name]
+                if entry := entries.get(path):
+                    entries.async_set_state(entry, bool_to_entry_state(result))
 
         stat = DashboardStatus(on_update)
         imports = DashboardImportDiscovery()

--- a/esphome/dashboard/web_server.py
+++ b/esphome/dashboard/web_server.py
@@ -37,7 +37,7 @@ from esphome.util import get_serial_ports, shlex_quote
 from esphome.yaml_util import FastestAvailableSafeLoader
 
 from .core import DASHBOARD
-from .entries import EntryState
+from .entries import EntryState, entry_state_to_bool
 from .util.subprocess import async_run_system_command
 from .util.text import friendly_name_slugify
 
@@ -276,7 +276,7 @@ class EsphomePortCommandWebSocket(EsphomeCommandWebSocket):
         if (
             port == "OTA"
             and (mdns := dashboard.mdns_status)
-            and (host_name := mdns.filename_to_host_name_thread_safe(configuration))
+            and (host_name := mdns.path_to_host_name_thread_safe(config_file))
             and (address := await mdns.async_resolve_host(host_name))
         ):
             port = address
@@ -735,7 +735,7 @@ class PingRequestHandler(BaseHandler):
         self.write(
             json.dumps(
                 {
-                    entry.filename: entry.state == EntryState.ONLINE
+                    entry.filename: entry_state_to_bool(entry.state)
                     for entry in dashboard.entries.async_all()
                 }
             )

--- a/esphome/dashboard/web_server.py
+++ b/esphome/dashboard/web_server.py
@@ -612,22 +612,7 @@ class ListDevicesHandler(BaseHandler):
         self.write(
             json.dumps(
                 {
-                    "configured": [
-                        {
-                            "name": entry.name,
-                            "friendly_name": entry.friendly_name,
-                            "configuration": entry.filename,
-                            "loaded_integrations": entry.loaded_integrations,
-                            "deployed_version": entry.update_old,
-                            "current_version": entry.update_new,
-                            "path": entry.path,
-                            "comment": entry.comment,
-                            "address": entry.address,
-                            "web_port": entry.web_port,
-                            "target_platform": entry.target_platform,
-                        }
-                        for entry in entries
-                    ],
+                    "configured": [entry.to_dict() for entry in entries],
                     "importable": [
                         {
                             "name": res.device_name,

--- a/esphome/dashboard/web_server.py
+++ b/esphome/dashboard/web_server.py
@@ -276,7 +276,7 @@ class EsphomePortCommandWebSocket(EsphomeCommandWebSocket):
         if (
             port == "OTA"
             and (mdns := dashboard.mdns_status)
-            and (host_name := mdns.path_to_host_name_thread_safe(config_file))
+            and (host_name := mdns.get_path_to_host_name(config_file))
             and (address := await mdns.async_resolve_host(host_name))
         ):
             port = address


### PR DESCRIPTION
# What does this implement/fix?

Add support for firing events

We now fire the following events:

Intended to be consumed by a `websocket` version of the `devices` endpoint.  These events are for the longer term, stored state of the dashboard entry.
- EVENT_ENTRY_ADDED - A new dashboard entry has been added
- EVENT_ENTRY_REMOVED - A dashboard entry has been removed
- EVENT_ENTRY_UPDATED - A dashboard entry has been updated

Intended to be consumed by a `websocket` version of the `ping` endpoint. These events are for the short term transient state of the dashboard entry. This event may change in the future to include more than the online/offline state if we need to know more about what the device is doing but currently this is no need to extend it.
- EVENT_ENTRY_STATE_CHANGED - The state of a dashboard entry has changed (previously ping result)

Current nothing listens for these events yet, there are no events for discovery yet (aka importable)


## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
