### PR TITLE
2023.11.2

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -68,7 +68,7 @@ ENV \
 # See: https://unix.stackexchange.com/questions/553743/correct-way-to-add-lib-ld-linux-so-3-in-debian
 RUN \
     if [ "$TARGETARCH$TARGETVARIANT" = "armv7" ]; then \
-        ln -s /lib/arm-linux-gnueabihf/ld-linux.so.3 /lib/ld-linux.so.3; \
+        ln -s /lib/arm-linux-gnueabihf/ld-linux-armhf.so.3 /lib/ld-linux.so.3; \
     fi
 
 RUN \

--- a/esphome/const.py
+++ b/esphome/const.py
@@ -1,6 +1,6 @@
 """Constants used by esphome."""
 
-__version__ = "2023.11.1"
+__version__ = "2023.11.2"
 
 ALLOWED_NAME_CHARS = "abcdefghijklmnopqrstuvwxyz0123456789-_"
 VALID_SUBSTITUTIONS_CHARACTERS = (

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ platformio==6.1.11  # When updating platformio, also update Dockerfile
 esptool==4.6.2
 click==8.1.7
 esphome-dashboard==20231107.0
-aioesphomeapi==18.4.1
+aioesphomeapi==18.5.2
 zeroconf==0.123.0
 
 # esp-idf requires this, but doesn't bundle it by default

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ platformio==6.1.11  # When updating platformio, also update Dockerfile
 esptool==4.6.2
 click==8.1.7
 esphome-dashboard==20231107.0
-aioesphomeapi==18.4.0
+aioesphomeapi==18.4.1
 zeroconf==0.123.0
 
 # esp-idf requires this, but doesn't bundle it by default


### PR DESCRIPTION
**Do not merge, release script will automatically merge**
- Bump aioesphomeapi from 18.4.0 to 18.4.1 [esphome#5767](https://github.com/esphome/esphome/pull/5767)
- Bump aioesphomeapi from 18.4.1 to 18.5.2 [esphome#5780](https://github.com/esphome/esphome/pull/5780)
- fix 32-bit arm [esphome#5781](https://github.com/esphome/esphome/pull/5781)
- Add 2MB option for partitions.csv generation and restore use of user-defined partitions [esphome#5779](https://github.com/esphome/esphome/pull/5779)
