### PR TITLE
dashboard: Fix online status when api is disabled

### DIFF
--- a/esphome/dashboard/dashboard.py
+++ b/esphome/dashboard/dashboard.py
@@ -973,6 +973,7 @@ class MDNSStatusThread(threading.Thread):
         self.host_name_to_filename: dict[str, str] = {}
         # This is a set of host names to track (i.e no_mdns = false)
         self.host_name_with_mdns_enabled: set[set] = set()
+        self.zc: EsphomeZeroconf | None = None
         self._refresh_hosts(poll_non_api_hosts=False)
 
     def _refresh_hosts(self, poll_non_api_hosts: bool = True):

--- a/esphome/dashboard/dashboard.py
+++ b/esphome/dashboard/dashboard.py
@@ -973,7 +973,6 @@ class MDNSStatusThread(threading.Thread):
         self.host_name_to_filename: dict[str, str] = {}
         # This is a set of host names to track (i.e no_mdns = false)
         self.host_name_with_mdns_enabled: set[set] = set()
-        self.zc = EsphomeZeroconf()
         self._refresh_hosts(poll_non_api_hosts=False)
 
     def _refresh_hosts(self, poll_non_api_hosts: bool = True):
@@ -1015,6 +1014,7 @@ class MDNSStatusThread(threading.Thread):
     def run(self):
         global IMPORT_RESULT
 
+        self.zc = EsphomeZeroconf()
         zc = self.zc
         host_mdns_state = self.host_mdns_state
         host_name_to_filename = self.host_name_to_filename

--- a/esphome/dashboard/dashboard.py
+++ b/esphome/dashboard/dashboard.py
@@ -974,9 +974,9 @@ class MDNSStatusThread(threading.Thread):
         # This is a set of host names to track (i.e no_mdns = false)
         self.host_name_with_mdns_enabled: set[set] = set()
         self.zc: EsphomeZeroconf | None = None
-        self._refresh_hosts(poll_non_api_hosts=False)
+        self._refresh_hosts()
 
-    def _refresh_hosts(self, poll_non_api_hosts: bool = True):
+    def _refresh_hosts(self):
         """Refresh the hosts to track."""
         entries = _list_dashboard_entries()
         host_name_with_mdns_enabled = self.host_name_with_mdns_enabled
@@ -997,7 +997,7 @@ class MDNSStatusThread(threading.Thread):
             # If we just adopted/imported this host, we likely
             # already have a state for it, so we should make sure
             # to set it so the dashboard shows it as online
-            if poll_non_api_hosts and (
+            if self.zc and (
                 entry.loaded_integrations and "api" not in entry.loaded_integrations
             ):
                 # No api available so we have to poll since

--- a/esphome/zeroconf.py
+++ b/esphome/zeroconf.py
@@ -150,7 +150,11 @@ class EsphomeZeroconf(Zeroconf):
     def resolve_host(self, host: str, timeout: float = 3.0) -> str | None:
         """Resolve a host name to an IP address."""
         name = host.partition(".")[0]
-        info = HostResolver(ESPHOME_SERVICE_TYPE, f"{name}.{ESPHOME_SERVICE_TYPE}")
+        info = HostResolver(
+            ESPHOME_SERVICE_TYPE,
+            f"{name}.{ESPHOME_SERVICE_TYPE}",
+            server=f"{name}.local.",
+        )
         if (
             info.load_from_cache(self)
             or (timeout and info.request(self, timeout * 1000))


### PR DESCRIPTION
# What does this implement/fix?

Fix dashboard online status when api is disabled.  We can't avoid a lookup for these devices since the device does not respond to requests for `._esphomelib._tcp.local.`

Note: merging directly to release because this code no longer exists in `dev`.  The `dev` fix is https://github.com/esphome/esphome/pull/5792 

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes # esphome/issues#5112

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
