### PR TITLE
dashboard: Fix online status when api is disabled

### DIFF
--- a/esphome/zeroconf.py
+++ b/esphome/zeroconf.py
@@ -169,7 +169,9 @@ class DashboardImportDiscovery:
 def _make_host_resolver(host: str) -> HostResolver:
     """Create a new HostResolver for the given host name."""
     name = host.partition(".")[0]
-    info = HostResolver(ESPHOME_SERVICE_TYPE, f"{name}.{ESPHOME_SERVICE_TYPE}")
+    info = HostResolver(
+        ESPHOME_SERVICE_TYPE, f"{name}.{ESPHOME_SERVICE_TYPE}", server=f"{name}.local."
+    )
     return info
 
 


### PR DESCRIPTION
~~needs https://github.com/esphome/esphome/pull/5790~~

This is a forward port of the fix in https://github.com/esphome/esphome/pull/5791

# What does this implement/fix?

Fix dashboard online status when api is disabled.  We can't avoid a lookup for these devices since the device does not respond to requests for `._esphomelib._tcp.local.`

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes # esphome/issues#5112 (dev)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
