### PR TITLE
Fix uninitialized climate target temperature

### DIFF
--- a/esphome/components/climate/climate.h
+++ b/esphome/components/climate/climate.h
@@ -160,7 +160,7 @@ struct ClimateDeviceRestoreState {
  */
 class Climate : public EntityBase {
  public:
-  Climate() { }
+  Climate() {}
 
   /// The active mode of the climate device.
   ClimateMode mode{CLIMATE_MODE_OFF};

--- a/esphome/components/climate/climate.h
+++ b/esphome/components/climate/climate.h
@@ -161,7 +161,7 @@ struct ClimateDeviceRestoreState {
 class Climate : public EntityBase {
  public:
   Climate() { }
-  
+
   /// The active mode of the climate device.
   ClimateMode mode{CLIMATE_MODE_OFF};
   /// The active state of the climate device.

--- a/esphome/components/climate/climate.h
+++ b/esphome/components/climate/climate.h
@@ -160,6 +160,8 @@ struct ClimateDeviceRestoreState {
  */
 class Climate : public EntityBase {
  public:
+  Climate() { }
+  
   /// The active mode of the climate device.
   ClimateMode mode{CLIMATE_MODE_OFF};
   /// The active state of the climate device.

--- a/esphome/components/climate/climate.h
+++ b/esphome/components/climate/climate.h
@@ -172,9 +172,9 @@ class Climate : public EntityBase {
     float target_temperature;
     struct {
       /// The minimum target temperature of the climate device, for climate devices with split target temperature.
-      float target_temperature_low;
+      float target_temperature_low{NAN};
       /// The maximum target temperature of the climate device, for climate devices with split target temperature.
-      float target_temperature_high;
+      float target_temperature_high{NAN};
     };
   };
 


### PR DESCRIPTION
# What does this fix?

Fixes the bugs caused by uninitialized target temperature variables in `Climate` class.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature:** See dmitry-cherkas/esphome-danfoss-eco#20 for an example issue caused by this bug.

## Test Environment

- [ ] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
