### PR TITLE
ssd1306: handle V_COM differently for SH1106

### DIFF
--- a/esphome/components/ssd1306_base/ssd1306_base.cpp
+++ b/esphome/components/ssd1306_base/ssd1306_base.cpp
@@ -154,6 +154,7 @@ void SSD1306::setup() {
   // Set V_COM (0xDB)
   this->command(SSD1306_COMMAND_SET_VCOM_DETECT);
   switch (this->model_) {
+    case SH1106_MODEL_128_64:
     case SH1107_MODEL_128_64:
     case SH1107_MODEL_128_128:
       this->command(0x35);


### PR DESCRIPTION
# What does this implement/fix?
On a noname SH1106 display text is "washed out" below the text. I compared the code to U8g2, where this problem does not exist and found the following:
https://github.com/olikraus/u8g2/blob/master/csrc/u8x8_d_ssd1306_128x64_noname.c#L65
Setting V_COM to 0x35 fixes the washed out text.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx



## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

