### PR TITLE
Add Pro Check Universal sensor support.

### DIFF
--- a/esphome/components/mopeka_pro_check/mopeka_pro_check.cpp
+++ b/esphome/components/mopeka_pro_check/mopeka_pro_check.cpp
@@ -54,7 +54,7 @@ bool MopekaProCheck::parse_device(const esp32_ble_tracker::ESPBTDevice &device) 
 
   if (static_cast<SensorType>(manu_data.data[0]) != STANDARD_BOTTOM_UP &&
       static_cast<SensorType>(manu_data.data[0]) != LIPPERT_BOTTOM_UP &&
-      static_cast<SensorType>(manu_data.data[0]) != PLUS_BOTTOM_UP && 
+      static_cast<SensorType>(manu_data.data[0]) != PLUS_BOTTOM_UP &&
       static_cast<SensorType>(manu_data.data[0]) != PRO_UNIVERSAL) {
     ESP_LOGE(TAG, "Unsupported Sensor Type (0x%X)", manu_data.data[0]);
     return false;

--- a/esphome/components/mopeka_pro_check/mopeka_pro_check.cpp
+++ b/esphome/components/mopeka_pro_check/mopeka_pro_check.cpp
@@ -54,7 +54,8 @@ bool MopekaProCheck::parse_device(const esp32_ble_tracker::ESPBTDevice &device) 
 
   if (static_cast<SensorType>(manu_data.data[0]) != STANDARD_BOTTOM_UP &&
       static_cast<SensorType>(manu_data.data[0]) != LIPPERT_BOTTOM_UP &&
-      static_cast<SensorType>(manu_data.data[0]) != PLUS_BOTTOM_UP) {
+      static_cast<SensorType>(manu_data.data[0]) != PLUS_BOTTOM_UP && 
+      static_cast<SensorType>(manu_data.data[0]) != PRO_UNIVERSAL) {
     ESP_LOGE(TAG, "Unsupported Sensor Type (0x%X)", manu_data.data[0]);
     return false;
   }

--- a/esphome/components/mopeka_pro_check/mopeka_pro_check.h
+++ b/esphome/components/mopeka_pro_check/mopeka_pro_check.h
@@ -17,7 +17,9 @@ enum SensorType {
   TOP_DOWN_AIR_ABOVE = 0x04,
   BOTTOM_UP_WATER = 0x05,
   LIPPERT_BOTTOM_UP = 0x06,
-  PLUS_BOTTOM_UP = 0x08
+  PLUS_BOTTOM_UP = 0x08,
+  PRO_UNIVERSAL = 0xC  // Pro Check Universal
+
   // all other values are reserved
 };
 


### PR DESCRIPTION
# What does this implement/fix?

Add new Mopeka Pro Check Universal sensor support which is just a new sensor type identifier.  No other changes.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/5035

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#3418

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
