### PR TITLE
BP1658CJ - Fix timing for all platforms, now consistent with other drivers

### DIFF
--- a/esphome/components/bp1658cj/bp1658cj.cpp
+++ b/esphome/components/bp1658cj/bp1658cj.cpp
@@ -90,40 +90,41 @@ void BP1658CJ::set_channel_value_(uint8_t channel, uint16_t value) {
 
 void BP1658CJ::write_bit_(bool value) {
   this->data_pin_->digital_write(value);
-  this->clock_pin_->digital_write(true);
-
   delayMicroseconds(BP1658CJ_DELAY);
-
+  this->clock_pin_->digital_write(true);
+  delayMicroseconds(BP1658CJ_DELAY);
   this->clock_pin_->digital_write(false);
+  delayMicroseconds(BP1658CJ_DELAY);
 }
 
 void BP1658CJ::write_byte_(uint8_t data) {
   for (uint8_t mask = 0x80; mask; mask >>= 1) {
     this->write_bit_(data & mask);
-    delayMicroseconds(BP1658CJ_DELAY);
   }
 
   // ack bit
   this->data_pin_->pin_mode(gpio::FLAG_INPUT);
   this->clock_pin_->digital_write(true);
-
   delayMicroseconds(BP1658CJ_DELAY);
-
   this->clock_pin_->digital_write(false);
+  delayMicroseconds(BP1658CJ_DELAY);
   this->data_pin_->pin_mode(gpio::FLAG_OUTPUT);
 }
 
 void BP1658CJ::write_buffer_(uint8_t *buffer, uint8_t size) {
   this->data_pin_->digital_write(false);
+  delayMicroseconds(BP1658CJ_DELAY);
   this->clock_pin_->digital_write(false);
+  delayMicroseconds(BP1658CJ_DELAY);
 
   for (uint32_t i = 0; i < size; i++) {
     this->write_byte_(buffer[i]);
-    delayMicroseconds(BP1658CJ_DELAY);
   }
 
   this->clock_pin_->digital_write(true);
+  delayMicroseconds(BP1658CJ_DELAY);
   this->data_pin_->digital_write(true);
+  delayMicroseconds(BP1658CJ_DELAY);
 }
 
 }  // namespace bp1658cj


### PR DESCRIPTION
# What does this implement/fix?

Fix timing for bp1658cj led driver to be consistent with other drivers.  Verified on esp32-c3 & bk72xx with the current changes.  In 2023.10.x, a user posted some timing fixes for bk72xx, which prompted me to update sm10bit_base and bp5758d, but I skpped bp1658cj because I thought their changes fixed it, but it only fixed bk72xx and broke esp32-c3.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Test Environment

- [ ] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [X] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
bp1658cj:
  data_pin: GPIO6
  clock_pin: GPIO7
  max_power_color_channels: 7 # Valid values 0-15
  max_power_white_channels: 10 # Valid values 0-15

# Individual outputs
output:
  - platform: bp1658cj
    id: output_red
    channel: 1
  - platform: bp1658cj
    id: output_green
    channel: 2
  - platform: bp1658cj
    id: output_blue
    channel: 0
  - platform: bp1658cj
    id: output_cold_white
    channel: 3
  - platform: bp1658cj
    id: output_warm_white
    channel: 4
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
