### PR TITLE
dashboard: set nodelay on the websocket to avoid a delay seeing log messages

### DIFF
--- a/esphome/dashboard/web_server.py
+++ b/esphome/dashboard/web_server.py
@@ -154,7 +154,7 @@ class EsphomeCommandWebSocket(tornado.websocket.WebSocketHandler):
         # use Popen() with a reading thread instead
         self._use_popen = os.name == "nt"
 
-    def open(self) -> None:
+    def open(self, *args: str, **kwargs: str) -> None:
         """Handle new WebSocket connection."""
         # Ensure messages from the subprocess are sent immediately
         # to avoid a 200-500ms delay when nodelay is not set.


### PR DESCRIPTION

# What does this implement/fix?

Log messages would sometimes come in with a 200-500ms delay

https://www.tornadoweb.org/en/stable/websocket.html#tornado.websocket.WebSocketHandler.set_nodelay


## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
