### PR TITLE
include payload_open when a lock supports OPEN

### DIFF
--- a/esphome/components/mqtt/mqtt_lock.cpp
+++ b/esphome/components/mqtt/mqtt_lock.cpp
@@ -40,6 +40,8 @@ const EntityBase *MQTTLockComponent::get_entity() const { return this->lock_; }
 void MQTTLockComponent::send_discovery(JsonObject root, mqtt::SendDiscoveryConfig &config) {
   if (this->lock_->traits.get_assumed_state())
     root[MQTT_OPTIMISTIC] = true;
+  if (this->lock_->traits.get_supports_open())
+    root[MQTT_PAYLOAD_OPEN] = "OPEN";
 }
 bool MQTTLockComponent::send_initial_state() { return this->publish_state(); }
 


### PR DESCRIPTION
# What does this implement/fix?

Home Assistant doesn't show a lock supports open unless the payload is present.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
external_components:
  - source: github://ccutrer/esphome@mqtt-lock-open-payload
    components: [mqtt]

lock:
  - id: lock_with_open
    platform: template
    name: "Lock With Open"
    optimistic: true
    open_action:
      - delay: 1s

  - id: lock_without_open
    platform: template
    name: "Lock Without Open"
    optimistic: true
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
