### PR TITLE
Ensure names containing characters other than `a-z` `A-Z` `0-9` or `_` are unique

### DIFF
--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -279,9 +279,12 @@ std::string str_snake_case(const std::string &str) {
 }
 std::string str_sanitize(const std::string &str) {
   std::string out;
-  std::replace_if(str.begin(), str.end(), [](const char &c) {
-    return c == '-' || c == '_' || (c >= '0' && c <= '9') || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z');
-  }, '_');
+  std::replace_if(
+      str.begin(), str.end(),
+      [](const char &c) {
+        return c == '-' || c == '_' || (c >= '0' && c <= '9') || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z');
+      },
+      '_');
   return out;
 }
 std::string str_snprintf(const char *fmt, size_t len, ...) {

--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -282,7 +282,7 @@ std::string str_sanitize(const std::string &str) {
   std::replace_if(
       str.begin(), str.end(),
       [](const char &c) {
-        return c == '-' || c == '_' || (c >= '0' && c <= '9') || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z');
+        return !(c == '-' || c == '_' || (c >= '0' && c <= '9') || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z'));
       },
       '_');
   return out;

--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -278,9 +278,9 @@ std::string str_snake_case(const std::string &str) {
   return result;
 }
 std::string str_sanitize(const std::string &str) {
-  std::string out;
+  std::string out = str;
   std::replace_if(
-      str.begin(), str.end(),
+      out.begin(), out.end(),
       [](const char &c) {
         return !(c == '-' || c == '_' || (c >= '0' && c <= '9') || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z'));
       },

--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -279,9 +279,9 @@ std::string str_snake_case(const std::string &str) {
 }
 std::string str_sanitize(const std::string &str) {
   std::string out;
-  std::copy_if(str.begin(), str.end(), std::back_inserter(out), [](const char &c) {
+  std::replace_if(str.begin(), str.end(), [](const char &c) {
     return c == '-' || c == '_' || (c >= '0' && c <= '9') || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z');
-  });
+  }, '_');
   return out;
 }
 std::string str_snprintf(const char *fmt, size_t len, ...) {

--- a/esphome/helpers.py
+++ b/esphome/helpers.py
@@ -357,6 +357,9 @@ def snake_case(value):
     return value.replace(" ", "_").lower()
 
 
+_DISALLOWED_CHARS = re.compile(r"[^a-zA-Z0-9_]")
+
+
 def sanitize(value):
     """Same behaviour as `helpers.cpp` method `str_sanitize`."""
-    return re.sub("[^-_0-9a-zA-Z]", r"", value)
+    return _DISALLOWED_CHARS.sub("_", value)

--- a/tests/unit_tests/test_helpers.py
+++ b/tests/unit_tests/test_helpers.py
@@ -258,9 +258,9 @@ def test_snake_case(text, expected):
     "text, expected",
     (
         ("foo_bar", "foo_bar"),
-        ('!"§$%&/()=?foo_bar', "foo_bar"),
-        ('foo_!"§$%&/()=?bar', "foo_bar"),
-        ('foo_bar!"§$%&/()=?', "foo_bar"),
+        ('!"§$%&/()=?foo_bar', "___________foo_bar"),
+        ('foo_!"§$%&/()=?bar', "foo____________bar"),
+        ('foo_bar!"§$%&/()=?', "foo_bar___________"),
     ),
 )
 def test_sanitize(text, expected):


### PR DESCRIPTION
## Breaking change

Home Assistant users may need to remove the config entry, and set it back up again if the name contained non-ascii characters.  Alternatively the entity can be manually renamed.

# What does this implement/fix?

Instead of dropping chars in `str_sanitize` we now replace them with `_` to reduce the chance of collisions.  

This will cause the unique ids to change for any entity that previously had characters disallowed by sanitize

fixes esphome/issues#5135

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
