### PR TITLE
Add some additional VA triggers, part 2

### DIFF
--- a/esphome/components/voice_assistant/__init__.py
+++ b/esphome/components/voice_assistant/__init__.py
@@ -1,5 +1,6 @@
 import esphome.config_validation as cv
 import esphome.codegen as cg
+import esphome.final_validate as fv
 
 from esphome.const import (
     CONF_ID,
@@ -29,6 +30,8 @@ CONF_ON_STT_VAD_END = "on_stt_vad_end"
 CONF_ON_STT_VAD_START = "on_stt_vad_start"
 CONF_ON_TTS_END = "on_tts_end"
 CONF_ON_TTS_START = "on_tts_start"
+CONF_ON_TTS_STREAM_START = "on_tts_stream_start"
+CONF_ON_TTS_STREAM_END = "on_tts_stream_end"
 CONF_ON_WAKE_WORD_DETECTED = "on_wake_word_detected"
 
 CONF_SILENCE_DETECTION = "silence_detection"
@@ -55,6 +58,17 @@ StopAction = voice_assistant_ns.class_(
 IsRunningCondition = voice_assistant_ns.class_(
     "IsRunningCondition", automation.Condition, cg.Parented.template(VoiceAssistant)
 )
+
+
+def final_validate(config):
+    if CONF_SPEAKER not in fv.full_config.get() and (
+        CONF_ON_TTS_STREAM_START in config or CONF_ON_TTS_STREAM_END in config
+    ):
+        raise cv.Invalid(
+            f"{CONF_SPEAKER} is required when using {CONF_ON_TTS_STREAM_START} and/or {CONF_ON_TTS_STREAM_END}"
+        )
+    return config
+
 
 CONFIG_SCHEMA = cv.All(
     cv.Schema(
@@ -105,9 +119,17 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_ON_STT_VAD_END): automation.validate_automation(
                 single=True
             ),
+            cv.Optional(CONF_ON_TTS_STREAM_START): automation.validate_automation(
+                single=True
+            ),
+            cv.Optional(CONF_ON_TTS_STREAM_END): automation.validate_automation(
+                single=True
+            ),
         }
     ).extend(cv.COMPONENT_SCHEMA),
 )
+
+FINAL_VALIDATE_SCHEMA = cv.Schema(final_validate)
 
 
 async def to_code(config):
@@ -220,6 +242,20 @@ async def to_code(config):
             var.get_stt_vad_end_trigger(),
             [],
             config[CONF_ON_STT_VAD_END],
+        )
+
+    if CONF_ON_TTS_STREAM_START in config:
+        await automation.build_automation(
+            var.get_tts_stream_start_trigger(),
+            [],
+            config[CONF_ON_TTS_STREAM_START],
+        )
+
+    if CONF_ON_TTS_STREAM_END in config:
+        await automation.build_automation(
+            var.get_tts_stream_end_trigger(),
+            [],
+            config[CONF_ON_TTS_STREAM_END],
         )
 
     cg.add_define("USE_VOICE_ASSISTANT")

--- a/esphome/components/voice_assistant/__init__.py
+++ b/esphome/components/voice_assistant/__init__.py
@@ -1,6 +1,5 @@
 import esphome.config_validation as cv
 import esphome.codegen as cg
-import esphome.final_validate as fv
 
 from esphome.const import (
     CONF_ID,
@@ -60,8 +59,8 @@ IsRunningCondition = voice_assistant_ns.class_(
 )
 
 
-def final_validate(config):
-    if CONF_SPEAKER not in fv.full_config.get() and (
+def tts_stream_validate(config):
+    if CONF_SPEAKER not in config and (
         CONF_ON_TTS_STREAM_START in config or CONF_ON_TTS_STREAM_END in config
     ):
         raise cv.Invalid(
@@ -127,9 +126,8 @@ CONFIG_SCHEMA = cv.All(
             ),
         }
     ).extend(cv.COMPONENT_SCHEMA),
+    tts_stream_validate,
 )
-
-FINAL_VALIDATE_SCHEMA = cv.Schema(final_validate)
 
 
 async def to_code(config):

--- a/esphome/components/voice_assistant/voice_assistant.cpp
+++ b/esphome/components/voice_assistant/voice_assistant.cpp
@@ -632,11 +632,17 @@ void VoiceAssistant::on_event(const api::VoiceAssistantEventResponse &msg) {
     case api::enums::VOICE_ASSISTANT_TTS_STREAM_START: {
 #ifdef USE_SPEAKER
       this->wait_for_stream_end_ = true;
+      ESP_LOGD(TAG, "TTS stream start");
+      this->tts_stream_start_trigger_->trigger();
 #endif
       break;
     }
     case api::enums::VOICE_ASSISTANT_TTS_STREAM_END: {
       this->set_state_(State::RESPONSE_FINISHED, State::IDLE);
+#ifdef USE_SPEAKER
+      ESP_LOGD(TAG, "TTS stream end");
+      this->tts_stream_end_trigger_->trigger();
+#endif
       break;
     }
     case api::enums::VOICE_ASSISTANT_STT_VAD_START:

--- a/esphome/components/voice_assistant/voice_assistant.h
+++ b/esphome/components/voice_assistant/voice_assistant.h
@@ -107,6 +107,10 @@ class VoiceAssistant : public Component {
   Trigger<> *get_start_trigger() const { return this->start_trigger_; }
   Trigger<> *get_stt_vad_end_trigger() const { return this->stt_vad_end_trigger_; }
   Trigger<> *get_stt_vad_start_trigger() const { return this->stt_vad_start_trigger_; }
+#ifdef USE_SPEAKER
+  Trigger<> *get_tts_stream_start_trigger() const { return this->tts_stream_start_trigger_; }
+  Trigger<> *get_tts_stream_end_trigger() const { return this->tts_stream_end_trigger_; }
+#endif
   Trigger<> *get_wake_word_detected_trigger() const { return this->wake_word_detected_trigger_; }
   Trigger<std::string> *get_stt_end_trigger() const { return this->stt_end_trigger_; }
   Trigger<std::string> *get_tts_end_trigger() const { return this->tts_end_trigger_; }
@@ -135,6 +139,10 @@ class VoiceAssistant : public Component {
   Trigger<> *start_trigger_ = new Trigger<>();
   Trigger<> *stt_vad_start_trigger_ = new Trigger<>();
   Trigger<> *stt_vad_end_trigger_ = new Trigger<>();
+#ifdef USE_SPEAKER
+  Trigger<> *tts_stream_start_trigger_ = new Trigger<>();
+  Trigger<> *tts_stream_end_trigger_ = new Trigger<>();
+#endif
   Trigger<> *wake_word_detected_trigger_ = new Trigger<>();
   Trigger<std::string> *stt_end_trigger_ = new Trigger<std::string>();
   Trigger<std::string> *tts_end_trigger_ = new Trigger<std::string>();


### PR DESCRIPTION
# What does this implement/fix?

Adds TTS start and end triggers for VA.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#3399

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
