### PR TITLE
Pulse meter sensor timeout fix

### DIFF
--- a/esphome/components/pulse_meter/pulse_meter_sensor.cpp
+++ b/esphome/components/pulse_meter/pulse_meter_sensor.cpp
@@ -71,7 +71,10 @@ void PulseMeterSensor::loop() {
       // Running and initial states can timeout
       case MeterState::INITIAL:
       case MeterState::RUNNING: {
-        if (time_since_valid_edge_us > this->timeout_us_) {
+        // time_since_valid_edge_us is the time not since the last edge, but since the one before
+        // This is because the data structs are swapped
+        // So we have to compare against the double timeout value
+        if (time_since_valid_edge_us > this->timeout_us_ * 2) {
           this->meter_state_ = MeterState::TIMED_OUT;
           ESP_LOGD(TAG, "No pulse detected for %" PRIu32 "s, assuming 0 pulses/min",
                    time_since_valid_edge_us / 1000000);

--- a/esphome/components/pulse_meter/sensor.py
+++ b/esphome/components/pulse_meter/sensor.py
@@ -43,8 +43,8 @@ def validate_internal_filter(value):
 
 def validate_timeout(value):
     value = cv.positive_time_period_microseconds(value)
-    if value.total_minutes > 70:
-        raise cv.Invalid("Maximum timeout is 70 minutes")
+    if value.total_minutes > 35:
+        raise cv.Invalid("Maximum timeout is 35 minutes")
     return value
 
 


### PR DESCRIPTION
# What does this implement/fix?

The timeout check is actually not against the timestamp of the last valid edge, but against the one before. So if i.e. the timeout is set to 4 minutes, the reset to 0 pulses/min occurs already if the pulse length is longer than 2 minutes.

This bugfix checks against the double value of 'timeout', and changes the max allowed timeout from 70 minutes to 35 minutes.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
