### PR TITLE
Add `is_detected()` for Nextion displays

### DIFF
--- a/esphome/components/nextion/nextion.cpp
+++ b/esphome/components/nextion/nextion.cpp
@@ -93,7 +93,8 @@ bool Nextion::check_connect_() {
     connect_info.push_back(response.substr(start, end - start));
   }
 
-  if (connect_info.size() == 7) {
+  this->is_detected_ = (connect_info.size() == 7);
+  if (this->is_detected_) {
     ESP_LOGN(TAG, "Received connect_info %zu", connect_info.size());
 
     this->device_model_ = connect_info[2];

--- a/esphome/components/nextion/nextion_base.h
+++ b/esphome/components/nextion/nextion_base.h
@@ -48,10 +48,12 @@ class NextionBase {
 
   bool is_sleeping() { return this->is_sleeping_; }
   bool is_setup() { return this->is_setup_; }
+  bool is_detected() { return this->is_detected_; }
 
  protected:
   bool is_setup_ = false;
   bool is_sleeping_ = false;
+  bool is_detected_ = false;
 };
 
 }  // namespace nextion

--- a/esphome/components/nextion/nextion_base.h
+++ b/esphome/components/nextion/nextion_base.h
@@ -48,7 +48,6 @@ class NextionBase {
 
   bool is_sleeping() { return this->is_sleeping_; }
   bool is_setup() { return this->is_setup_; }
-  bool is_connected() { return get_is_connected_();}
   bool is_detected() { return this->is_detected_; }
 
  protected:

--- a/esphome/components/nextion/nextion_base.h
+++ b/esphome/components/nextion/nextion_base.h
@@ -48,7 +48,6 @@ class NextionBase {
 
   bool is_sleeping() { return this->is_sleeping_; }
   bool is_setup() { return this->is_setup_; }
-  bool is_connected() { return this->is_connected_; }
   bool is_detected() { return this->is_detected_; }
 
  protected:

--- a/esphome/components/nextion/nextion_base.h
+++ b/esphome/components/nextion/nextion_base.h
@@ -48,6 +48,7 @@ class NextionBase {
 
   bool is_sleeping() { return this->is_sleeping_; }
   bool is_setup() { return this->is_setup_; }
+  bool is_connected() { return get_is_connected_();}
   bool is_detected() { return this->is_detected_; }
 
  protected:

--- a/esphome/components/nextion/nextion_base.h
+++ b/esphome/components/nextion/nextion_base.h
@@ -48,6 +48,7 @@ class NextionBase {
 
   bool is_sleeping() { return this->is_sleeping_; }
   bool is_setup() { return this->is_setup_; }
+  bool is_connected() { return this->is_connected_; }
   bool is_detected() { return this->is_detected_; }
 
  protected:


### PR DESCRIPTION
# What does this implement/fix?

This will return "True" when the display is detected, which could happen even before the setup or in case of a setup error, so we know it's a Nextion display there even if setup fails.
If Nextion is on Active Protocol Reparse mode, it's expected that setup routine fails, as it is not designed to that mode, however the display still connected and some actions are possible, as send an exit reparse or using the reparse mode, but for this is useful to know if a Nextion display is connected.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [X] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
N/A

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
