### PR TITLE
Add 'enable_on_boot' feature to power_supply

### DIFF
--- a/esphome/components/power_supply/__init__.py
+++ b/esphome/components/power_supply/__init__.py
@@ -8,7 +8,7 @@ power_supply_ns = cg.esphome_ns.namespace("power_supply")
 PowerSupply = power_supply_ns.class_("PowerSupply", cg.Component)
 MULTI_CONF = True
 
-CONF_ENABLE_AT_STARTUP = "enable_at_startup"
+CONF_ENABLE_ON_BOOT = "enable_on_boot"
 
 CONFIG_SCHEMA = cv.Schema(
     {
@@ -20,7 +20,7 @@ CONFIG_SCHEMA = cv.Schema(
         cv.Optional(
             CONF_KEEP_ON_TIME, default="10s"
         ): cv.positive_time_period_milliseconds,
-        cv.Optional(CONF_ENABLE_AT_STARTUP, default=False): cv.boolean,
+        cv.Optional(CONF_ENABLE_ON_BOOT, default=False): cv.boolean,
     }
 ).extend(cv.COMPONENT_SCHEMA)
 
@@ -33,6 +33,6 @@ async def to_code(config):
     cg.add(var.set_pin(pin))
     cg.add(var.set_enable_time(config[CONF_ENABLE_TIME]))
     cg.add(var.set_keep_on_time(config[CONF_KEEP_ON_TIME]))
-    cg.add(var.set_enable_at_startup(config[CONF_ENABLE_AT_STARTUP]))
+    cg.add(var.set_enable_on_boot(config[CONF_ENABLE_ON_BOOT]))
 
     cg.add_define("USE_POWER_SUPPLY")

--- a/esphome/components/power_supply/__init__.py
+++ b/esphome/components/power_supply/__init__.py
@@ -8,6 +8,8 @@ power_supply_ns = cg.esphome_ns.namespace("power_supply")
 PowerSupply = power_supply_ns.class_("PowerSupply", cg.Component)
 MULTI_CONF = True
 
+CONF_ENABLE_AT_STARTUP = "enable_at_startup"
+
 CONFIG_SCHEMA = cv.Schema(
     {
         cv.Required(CONF_ID): cv.declare_id(PowerSupply),
@@ -18,6 +20,7 @@ CONFIG_SCHEMA = cv.Schema(
         cv.Optional(
             CONF_KEEP_ON_TIME, default="10s"
         ): cv.positive_time_period_milliseconds,
+        cv.Optional(CONF_ENABLE_AT_STARTUP, default=False): cv.boolean,
     }
 ).extend(cv.COMPONENT_SCHEMA)
 
@@ -30,5 +33,6 @@ async def to_code(config):
     cg.add(var.set_pin(pin))
     cg.add(var.set_enable_time(config[CONF_ENABLE_TIME]))
     cg.add(var.set_keep_on_time(config[CONF_KEEP_ON_TIME]))
+    cg.add(var.set_enable_at_startup(config[CONF_ENABLE_AT_STARTUP]))
 
     cg.add_define("USE_POWER_SUPPLY")

--- a/esphome/components/power_supply/power_supply.cpp
+++ b/esphome/components/power_supply/power_supply.cpp
@@ -11,7 +11,7 @@ void PowerSupply::setup() {
 
   this->pin_->setup();
   this->pin_->digital_write(false);
-  if (this->enable_at_startup_)
+  if (this->enable_on_boot_)
     this->request_high_power();
 }
 void PowerSupply::dump_config() {
@@ -19,7 +19,7 @@ void PowerSupply::dump_config() {
   LOG_PIN("  Pin: ", this->pin_);
   ESP_LOGCONFIG(TAG, "  Time to enable: %" PRIu32 " ms", this->enable_time_);
   ESP_LOGCONFIG(TAG, "  Keep on time: %.1f s", this->keep_on_time_ / 1000.0f);
-  if (this->enable_at_startup_)
+  if (this->enable_on_boot_)
     ESP_LOGCONFIG(TAG, "  Enabled at startup: True");
 }
 

--- a/esphome/components/power_supply/power_supply.cpp
+++ b/esphome/components/power_supply/power_supply.cpp
@@ -11,47 +11,42 @@ void PowerSupply::setup() {
 
   this->pin_->setup();
   this->pin_->digital_write(false);
-  this->enabled_ = false;
+  if (this->enable_at_startup_)
+    this->request_high_power();
 }
 void PowerSupply::dump_config() {
   ESP_LOGCONFIG(TAG, "Power Supply:");
   LOG_PIN("  Pin: ", this->pin_);
   ESP_LOGCONFIG(TAG, "  Time to enable: %" PRIu32 " ms", this->enable_time_);
   ESP_LOGCONFIG(TAG, "  Keep on time: %.1f s", this->keep_on_time_ / 1000.0f);
+  if (this->enable_at_startup_)
+    ESP_LOGCONFIG(TAG, "  Enabled at startup: True");
 }
 
 float PowerSupply::get_setup_priority() const { return setup_priority::IO; }
 
-bool PowerSupply::is_enabled() const { return this->enabled_; }
+bool PowerSupply::is_enabled() const { return this->active_requests_ != 0; }
 
 void PowerSupply::request_high_power() {
-  this->cancel_timeout("power-supply-off");
-  this->pin_->digital_write(true);
-
   if (this->active_requests_ == 0) {
-    // we need to enable the power supply.
-    // cancel old timeout if it exists because we now definitely have a high power mode.
+    this->cancel_timeout("power-supply-off");
     ESP_LOGD(TAG, "Enabling power supply.");
+    this->pin_->digital_write(true);
     delay(this->enable_time_);
   }
-  this->enabled_ = true;
-  // increase active requests
   this->active_requests_++;
 }
 
 void PowerSupply::unrequest_high_power() {
-  this->active_requests_--;
-  if (this->active_requests_ < 0) {
-    // we're just going to use 0 as our new counter.
-    this->active_requests_ = 0;
-  }
-
   if (this->active_requests_ == 0) {
-    // set timeout for power supply off
+    ESP_LOGW(TAG, "Invalid call to unrequest_high_power");
+    return;
+  }
+  this->active_requests_--;
+  if (this->active_requests_ == 0) {
     this->set_timeout("power-supply-off", this->keep_on_time_, [this]() {
       ESP_LOGD(TAG, "Disabling power supply.");
       this->pin_->digital_write(false);
-      this->enabled_ = false;
     });
   }
 }

--- a/esphome/components/power_supply/power_supply.h
+++ b/esphome/components/power_supply/power_supply.h
@@ -13,6 +13,7 @@ class PowerSupply : public Component {
   void set_pin(GPIOPin *pin) { pin_ = pin; }
   void set_enable_time(uint32_t enable_time) { enable_time_ = enable_time; }
   void set_keep_on_time(uint32_t keep_on_time) { keep_on_time_ = keep_on_time; }
+  void set_enable_at_startup(uint32_t enable_at_startup) { enable_at_startup_ = enable_at_startup; }
 
   /// Is this power supply currently on?
   bool is_enabled() const;
@@ -35,7 +36,7 @@ class PowerSupply : public Component {
 
  protected:
   GPIOPin *pin_;
-  bool enabled_{false};
+  bool enable_at_startup_{false};
   uint32_t enable_time_;
   uint32_t keep_on_time_;
   int16_t active_requests_{0};  // use signed integer to make catching negative requests easier.

--- a/esphome/components/power_supply/power_supply.h
+++ b/esphome/components/power_supply/power_supply.h
@@ -13,7 +13,7 @@ class PowerSupply : public Component {
   void set_pin(GPIOPin *pin) { pin_ = pin; }
   void set_enable_time(uint32_t enable_time) { enable_time_ = enable_time; }
   void set_keep_on_time(uint32_t keep_on_time) { keep_on_time_ = keep_on_time; }
-  void set_enable_at_startup(uint32_t enable_at_startup) { enable_at_startup_ = enable_at_startup; }
+  void set_enable_on_boot(bool enable_on_boot) { enable_on_boot_ = enable_on_boot; }
 
   /// Is this power supply currently on?
   bool is_enabled() const;
@@ -36,7 +36,7 @@ class PowerSupply : public Component {
 
  protected:
   GPIOPin *pin_;
-  bool enable_at_startup_{false};
+  bool enable_on_boot_{false};
   uint32_t enable_time_;
   uint32_t keep_on_time_;
   int16_t active_requests_{0};  // use signed integer to make catching negative requests easier.

--- a/tests/test1.1.yaml
+++ b/tests/test1.1.yaml
@@ -47,7 +47,7 @@ power_supply:
   - id: atx_power_supply
     enable_time: 20ms
     keep_on_time: 10s
-    enable_at_startup: true
+    enable_on_boot: true
     pin:
       number: 13
       inverted: true

--- a/tests/test1.1.yaml
+++ b/tests/test1.1.yaml
@@ -44,12 +44,13 @@ network:
 e131:
 
 power_supply:
-  id: atx_power_supply
-  enable_time: 20ms
-  keep_on_time: 10s
-  pin:
-    number: 13
-    inverted: true
+  - id: atx_power_supply
+    enable_time: 20ms
+    keep_on_time: 10s
+    enable_at_startup: true
+    pin:
+      number: 13
+      inverted: true
 
 i2c:
   sda: 21


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Add `enable_at_startup` option to the `power_supply` component. This is useful for boards that need a pin in a specific mode and state early in the boot process.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other


**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#3411

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
power_supply:
  - id: atx_power_supply
    enable_time: 20ms
    keep_on_time: 10s
    enable_at_startup: true
    pin:
      number: 13
      inverted: true
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
