### PR TITLE
Speed up writing protobuf strings/bytes

### DIFF
--- a/esphome/components/api/proto.h
+++ b/esphome/components/api/proto.h
@@ -160,8 +160,7 @@ class ProtoWriteBuffer {
     this->encode_field_raw(field_id, 2);
     this->encode_varint_raw(len);
     auto *data = reinterpret_cast<const uint8_t *>(string);
-    for (size_t i = 0; i < len; i++)
-      this->write(data[i]);
+    this->buffer_->insert(this->buffer_->end(), data, data + len);
   }
   void encode_string(uint32_t field_id, const std::string &value, bool force = false) {
     this->encode_string(field_id, value.data(), value.size());


### PR DESCRIPTION
# What does this implement/fix?

Speed up writing protobuf strings/bytes

I recently got an esp32 cam and noticed the performance was not so great over the api (https://community.home-assistant.io/t/getting-better-performance-from-an-espcam32/561615)

I tried a few different ways ... and this might be faster but not sure if its safe
```cpp
    this->buffer_->resize(old_size + len);
    std::memcpy(&(*this->buffer_)[old_size], data, len);
```

so I settled on
```cpp
this->buffer_->insert(this->buffer_->end(), data, data + len);
```

after reading https://stackoverflow.com/questions/2208293/what-is-the-most-efficient-way-to-append-one-stdvector-to-the-end-of-another , in theory it should be 2x the speed of the `push_back` but I currently have no way to validate that its actually faster on the ESP and not just locally.




## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
