### PR TITLE
Allow split uart pin inversion for ESP-IDF

### DIFF
--- a/esphome/components/uart/__init__.py
+++ b/esphome/components/uart/__init__.py
@@ -75,12 +75,13 @@ def validate_rx_pin(value):
 def validate_invert_esp32(config):
     if (
         CORE.is_esp32
+        and CORE.using_arduino
         and CONF_TX_PIN in config
         and CONF_RX_PIN in config
         and config[CONF_TX_PIN][CONF_INVERTED] != config[CONF_RX_PIN][CONF_INVERTED]
     ):
         raise cv.Invalid(
-            "Different invert values for TX and RX pin are not (yet) supported for ESP32."
+            "Different invert values for TX and RX pin are not supported for ESP32 when using Arduino."
         )
     return config
 

--- a/tests/test5.yaml
+++ b/tests/test5.yaml
@@ -41,7 +41,7 @@ uart:
     rx_pin: 3
     baud_rate: 9600
   - id: uart_2
-    tx_pin: 
+    tx_pin:
       number: 17
       inverted: true
     rx_pin: 16

--- a/tests/test5.yaml
+++ b/tests/test5.yaml
@@ -41,7 +41,9 @@ uart:
     rx_pin: 3
     baud_rate: 9600
   - id: uart_2
-    tx_pin: 17
+    tx_pin: 
+      number: 17
+      inverted: true
     rx_pin: 16
     baud_rate: 19200
 


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

The uart component disallows different `inverted` values for the tx and rx pins on ESP32. This is an Arduino library limitation and need not be imposed when using ESP-IDF.


## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/4699


## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
uart:
  - id: door_uart
    baud_rate: 1200
    parity: even
    stop_bits: 1
    tx_pin:
      number: 23
      inverted: true
    rx_pin:
      number: 22
      mode:
        input: true
        pullup: true
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

