### PR TITLE
Prevent network config on rpipico board

### DIFF
--- a/esphome/wizard.py
+++ b/esphome/wizard.py
@@ -140,7 +140,7 @@ def wizard_file(**kwargs):
 
     config += LOGGER_CONFIG
 
-    if kwargs['board'] != 'rpipico':
+    if kwargs["board"] != "rpipico":
         config += API_CONFIG
 
         # Configure API

--- a/esphome/wizard.py
+++ b/esphome/wizard.py
@@ -140,59 +140,61 @@ def wizard_file(**kwargs):
 
     config += LOGGER_CONFIG
 
-    if kwargs["board"] != "rpipico":
-        config += API_CONFIG
+    if kwargs["board"] == "rpipico":
+        return config
 
-        # Configure API
-        if "password" in kwargs:
-            config += f"  password: \"{kwargs['password']}\"\n"
-        if "api_encryption_key" in kwargs:
-            config += f"  encryption:\n    key: \"{kwargs['api_encryption_key']}\"\n"
+    config += API_CONFIG
 
-        # Configure OTA
-        config += "\nota:\n"
-        if "ota_password" in kwargs:
-            config += f"  password: \"{kwargs['ota_password']}\""
-        elif "password" in kwargs:
-            config += f"  password: \"{kwargs['password']}\""
+    # Configure API
+    if "password" in kwargs:
+        config += f"  password: \"{kwargs['password']}\"\n"
+    if "api_encryption_key" in kwargs:
+        config += f"  encryption:\n    key: \"{kwargs['api_encryption_key']}\"\n"
 
-        # Configuring wifi
-        config += "\n\nwifi:\n"
+    # Configure OTA
+    config += "\nota:\n"
+    if "ota_password" in kwargs:
+        config += f"  password: \"{kwargs['ota_password']}\""
+    elif "password" in kwargs:
+        config += f"  password: \"{kwargs['password']}\""
 
-        if "ssid" in kwargs:
-            if kwargs["ssid"].startswith("!secret"):
-                template = "  ssid: {ssid}\n  password: {psk}\n"
-            else:
-                template = """  ssid: "{ssid}"\n  password: "{psk}"\n"""
-            config += template.format(**kwargs)
+    # Configuring wifi
+    config += "\n\nwifi:\n"
+
+    if "ssid" in kwargs:
+        if kwargs["ssid"].startswith("!secret"):
+            template = "  ssid: {ssid}\n  password: {psk}\n"
         else:
-            config += """  # ssid: "My SSID"
-  # password: "mypassword"
+            template = """  ssid: "{ssid}"\n  password: "{psk}"\n"""
+        config += template.format(**kwargs)
+    else:
+        config += """  # ssid: "My SSID"
+# password: "mypassword"
 
-  networks:
+networks:
 """
 
-        # pylint: disable=consider-using-f-string
-        if kwargs["platform"] in ["ESP8266", "ESP32", "BK72XX", "RTL87XX"]:
-            config += """
-  # Enable fallback hotspot (captive portal) in case wifi connection fails
-  ap:
-    ssid: "{fallback_name}"
-    password: "{fallback_psk}"
+    # pylint: disable=consider-using-f-string
+    if kwargs["platform"] in ["ESP8266", "ESP32", "BK72XX", "RTL87XX"]:
+        config += """
+# Enable fallback hotspot (captive portal) in case wifi connection fails
+ap:
+ssid: "{fallback_name}"
+password: "{fallback_psk}"
 
 captive_portal:
-        """.format(
-                **kwargs
-            )
-        else:
-            config += """
-  # Enable fallback hotspot in case wifi connection fails
-  ap:
-    ssid: "{fallback_name}"
-    password: "{fallback_psk}"
-        """.format(
-                **kwargs
-            )
+    """.format(
+            **kwargs
+        )
+    else:
+        config += """
+# Enable fallback hotspot in case wifi connection fails
+ap:
+ssid: "{fallback_name}"
+password: "{fallback_psk}"
+    """.format(
+            **kwargs
+        )
 
     return config
 

--- a/esphome/wizard.py
+++ b/esphome/wizard.py
@@ -182,7 +182,7 @@ def wizard_file(**kwargs):
     ssid: "{fallback_name}"
     password: "{fallback_psk}"
 
-  captive_portal:
+captive_portal:
     """.format(
             **kwargs
         )

--- a/esphome/wizard.py
+++ b/esphome/wizard.py
@@ -169,29 +169,29 @@ def wizard_file(**kwargs):
         config += template.format(**kwargs)
     else:
         config += """  # ssid: "My SSID"
-# password: "mypassword"
+  # password: "mypassword"
 
-networks:
+  networks:
 """
 
     # pylint: disable=consider-using-f-string
     if kwargs["platform"] in ["ESP8266", "ESP32", "BK72XX", "RTL87XX"]:
         config += """
-# Enable fallback hotspot (captive portal) in case wifi connection fails
-ap:
-ssid: "{fallback_name}"
-password: "{fallback_psk}"
+  # Enable fallback hotspot (captive portal) in case wifi connection fails
+  ap:
+    ssid: "{fallback_name}"
+    password: "{fallback_psk}"
 
-captive_portal:
+  captive_portal:
     """.format(
             **kwargs
         )
     else:
         config += """
-# Enable fallback hotspot in case wifi connection fails
-ap:
-ssid: "{fallback_name}"
-password: "{fallback_psk}"
+  # Enable fallback hotspot in case wifi connection fails
+  ap:
+    ssid: "{fallback_name}"
+    password: "{fallback_psk}"
     """.format(
             **kwargs
         )

--- a/esphome/wizard.py
+++ b/esphome/wizard.py
@@ -51,10 +51,12 @@ BASE_CONFIG_FRIENDLY = """esphome:
   friendly_name: {friendly_name}
 """
 
-LOGGER_API_CONFIG = """
+LOGGER_CONFIG = """
 # Enable logging
 logger:
+"""
 
+API_CONFIG = """
 # Enable Home Assistant API
 api:
 """
@@ -136,58 +138,61 @@ def wizard_file(**kwargs):
 
     config += HARDWARE_BASE_CONFIGS[kwargs["platform"]].format(**kwargs)
 
-    config += LOGGER_API_CONFIG
+    config += LOGGER_CONFIG
 
-    # Configure API
-    if "password" in kwargs:
-        config += f"  password: \"{kwargs['password']}\"\n"
-    if "api_encryption_key" in kwargs:
-        config += f"  encryption:\n    key: \"{kwargs['api_encryption_key']}\"\n"
+    if kwargs['board'] != 'rpipico':
+        config += API_CONFIG
 
-    # Configure OTA
-    config += "\nota:\n"
-    if "ota_password" in kwargs:
-        config += f"  password: \"{kwargs['ota_password']}\""
-    elif "password" in kwargs:
-        config += f"  password: \"{kwargs['password']}\""
+        # Configure API
+        if "password" in kwargs:
+            config += f"  password: \"{kwargs['password']}\"\n"
+        if "api_encryption_key" in kwargs:
+            config += f"  encryption:\n    key: \"{kwargs['api_encryption_key']}\"\n"
 
-    # Configuring wifi
-    config += "\n\nwifi:\n"
+        # Configure OTA
+        config += "\nota:\n"
+        if "ota_password" in kwargs:
+            config += f"  password: \"{kwargs['ota_password']}\""
+        elif "password" in kwargs:
+            config += f"  password: \"{kwargs['password']}\""
 
-    if "ssid" in kwargs:
-        if kwargs["ssid"].startswith("!secret"):
-            template = "  ssid: {ssid}\n  password: {psk}\n"
+        # Configuring wifi
+        config += "\n\nwifi:\n"
+
+        if "ssid" in kwargs:
+            if kwargs["ssid"].startswith("!secret"):
+                template = "  ssid: {ssid}\n  password: {psk}\n"
+            else:
+                template = """  ssid: "{ssid}"\n  password: "{psk}"\n"""
+            config += template.format(**kwargs)
         else:
-            template = """  ssid: "{ssid}"\n  password: "{psk}"\n"""
-        config += template.format(**kwargs)
-    else:
-        config += """  # ssid: "My SSID"
+            config += """  # ssid: "My SSID"
   # password: "mypassword"
 
   networks:
 """
 
-    # pylint: disable=consider-using-f-string
-    if kwargs["platform"] in ["ESP8266", "ESP32", "BK72XX", "RTL87XX"]:
-        config += """
+        # pylint: disable=consider-using-f-string
+        if kwargs["platform"] in ["ESP8266", "ESP32", "BK72XX", "RTL87XX"]:
+            config += """
   # Enable fallback hotspot (captive portal) in case wifi connection fails
   ap:
     ssid: "{fallback_name}"
     password: "{fallback_psk}"
 
 captive_portal:
-    """.format(
-            **kwargs
-        )
-    else:
-        config += """
+        """.format(
+                **kwargs
+            )
+        else:
+            config += """
   # Enable fallback hotspot in case wifi connection fails
   ap:
     ssid: "{fallback_name}"
     password: "{fallback_psk}"
-    """.format(
-            **kwargs
-        )
+        """.format(
+                **kwargs
+            )
 
     return config
 


### PR DESCRIPTION
# What does this implement/fix?

It prevents adding networking capabilities to a board that doesn't support them.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/5134

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** n/a

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [x] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

This bugfix actually fixes the wizard that generates the yaml files. Nevertheless, here is an example generated for the `rpipicow` board:
```yaml
esphome:
  name: picowboard
  friendly_name: picowboard

rp2040:
  board: rpipicow
  framework:
    # Required until https://github.com/platformio/platform-raspberrypi/pull/36 is merged
    platform_version: https://github.com/maxgerhardt/platform-raspberrypi.git

# Enable logging
logger:

# Enable Home Assistant API
api:
  encryption:
    key: "SzsbyFrPhZEzvdJ27nxNdMoLFSDi28t2uFMT7IGy9pI="

ota:
  password: "eb0c1a91c47001b923f61e28bf9b4b0d"

wifi:
  ssid: !secret wifi_ssid
  password: !secret wifi_password

  # Enable fallback hotspot in case wifi connection fails
  ap:
    ssid: "Picow Fallback Hotspot"
    password: "EL2kvLpeXTmm"
```

And another example generated for the `rpipico` board:
```yaml
esphome:
  name: picoboard
  friendly_name: picoboard

rp2040:
  board: rpipico
  framework:
    # Required until https://github.com/platformio/platform-raspberrypi/pull/36 is merged
    platform_version: https://github.com/maxgerhardt/platform-raspberrypi.git

# Enable logging
logger:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

Couldn't find any test for the wizard. If they exist, please, could you point me to them so I can update them accordingly? Many thanks!