### PR TITLE
bugfix: Change setup priority for PMSA003I

### DIFF
--- a/esphome/components/pmsa003i/pmsa003i.h
+++ b/esphome/components/pmsa003i/pmsa003i.h
@@ -32,7 +32,7 @@ class PMSA003IComponent : public PollingComponent, public i2c::I2CDevice {
   void setup() override;
   void dump_config() override;
   void update() override;
-  float get_setup_priority() const override { return setup_priority::DATA; }
+  float get_setup_priority() const override { return setup_priority::LATE; }
 
   void set_standard_units(bool standard_units) { standard_units_ = standard_units; }
 


### PR DESCRIPTION
# What does this implement/fix?
This change updates the setup priority for the PMSA003I to LATE to avoid a common failure mode of reading from the device before it's ready. I personally was experiencing issues setting up the sensor, and when I logged the error from `this->read` I was receiving `ERROR_TIMEOUT`. Setting this to LATE resolved my issues, which I tried after reading [this thread](https://community.home-assistant.io/t/is-there-some-way-to-delay-setting-up-a-sensor-is-that-setup-priority/481700). I am making this change at the component level so others do not experience this point of friction.

<!-- Quick description and explanation of changes -->

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/2344

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
sensor:
  - platform: pmsa003i
    pm_1_0:
      name: "PM1.0"
    pm_2_5:
      name: "PM2.5"
    pm_10_0:
      name: "PM10.0"
    pmc_0_3:
      name: "PMC >0.3µm"
    pmc_0_5:
      name: "PMC >0.5µm"
    pmc_1_0:
      name: "PMC >1µm"
    pmc_2_5:
      name: "PMC >2.5µm"
    pmc_5_0:
      name: "PMC >5µm"
    pmc_10_0:
      name: "PMC >10µm"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
