### PR TITLE
Fix ESP-IDF uart initialisation sequence to match Espressif docs.

### DIFF
--- a/esphome/components/uart/uart_component_esp_idf.cpp
+++ b/esphome/components/uart/uart_component_esp_idf.cpp
@@ -84,27 +84,8 @@ void IDFUARTComponent::setup() {
     return;
   }
 
-  err = uart_driver_install(this->uart_num_, /* UART RX ring buffer size. */ this->rx_buffer_size_,
-                            /* UART TX ring buffer size. If set to zero, driver will not use TX buffer, TX function will
-                               block task until all data have been sent out.*/
-                            0,
-                            /* UART event queue size/depth. */ 20, &(this->uart_event_queue_),
-                            /* Flags used to allocate the interrupt. */ 0);
-  if (err != ESP_OK) {
-    ESP_LOGW(TAG, "uart_driver_install failed: %s", esp_err_to_name(err));
-    this->mark_failed();
-    return;
-  }
-
   int8_t tx = this->tx_pin_ != nullptr ? this->tx_pin_->get_pin() : -1;
   int8_t rx = this->rx_pin_ != nullptr ? this->rx_pin_->get_pin() : -1;
-
-  err = uart_set_pin(this->uart_num_, tx, rx, UART_PIN_NO_CHANGE, UART_PIN_NO_CHANGE);
-  if (err != ESP_OK) {
-    ESP_LOGW(TAG, "uart_set_pin failed: %s", esp_err_to_name(err));
-    this->mark_failed();
-    return;
-  }
 
   uint32_t invert = 0;
   if (this->tx_pin_ != nullptr && this->tx_pin_->is_inverted())
@@ -115,6 +96,25 @@ void IDFUARTComponent::setup() {
   err = uart_set_line_inverse(this->uart_num_, invert);
   if (err != ESP_OK) {
     ESP_LOGW(TAG, "uart_set_line_inverse failed: %s", esp_err_to_name(err));
+    this->mark_failed();
+    return;
+  }
+
+  err = uart_set_pin(this->uart_num_, tx, rx, UART_PIN_NO_CHANGE, UART_PIN_NO_CHANGE);
+  if (err != ESP_OK) {
+    ESP_LOGW(TAG, "uart_set_pin failed: %s", esp_err_to_name(err));
+    this->mark_failed();
+    return;
+  }
+
+  err = uart_driver_install(this->uart_num_, /* UART RX ring buffer size. */ this->rx_buffer_size_,
+                            /* UART TX ring buffer size. If set to zero, driver will not use TX buffer, TX function will
+                               block task until all data have been sent out.*/
+                            0,
+                            /* UART event queue size/depth. */ 20, &(this->uart_event_queue_),
+                            /* Flags used to allocate the interrupt. */ 0);
+  if (err != ESP_OK) {
+    ESP_LOGW(TAG, "uart_driver_install failed: %s", esp_err_to_name(err));
     this->mark_failed();
     return;
   }


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

The uart initialisation in the ESP-IDF code makes api calls in the wrong order. Under certain circumstances (specifically inverted TX) this causes a glitch on the TX line. The correct sequence is:

* Set up pin inversion
* Select pins
* install driver


## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

**Related issue or feature (if applicable):** fixes <link to issue>


## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
