### PR TITLE
Improved sensor readings in htu21d component.

### DIFF
--- a/esphome/components/htu21d/htu21d.cpp
+++ b/esphome/components/htu21d/htu21d.cpp
@@ -39,45 +39,53 @@ void HTU21DComponent::dump_config() {
   LOG_SENSOR("  ", "Humidity", this->humidity_);
 }
 void HTU21DComponent::update() {
-  uint16_t raw_temperature;
   if (this->write(&HTU21D_REGISTER_TEMPERATURE, 1) != i2c::ERROR_OK) {
     this->status_set_warning();
     return;
   }
-  delay(50);  // NOLINT
-  if (this->read(reinterpret_cast<uint8_t *>(&raw_temperature), 2) != i2c::ERROR_OK) {
-    this->status_set_warning();
-    return;
-  }
-  raw_temperature = i2c::i2ctohs(raw_temperature);
 
-  float temperature = (float(raw_temperature & 0xFFFC)) * 175.72f / 65536.0f - 46.85f;
+  this->set_timeout(50, [this]() {
+    uint16_t raw_temperature;
+    if (this->read(reinterpret_cast<uint8_t *>(&raw_temperature), 2) != i2c::ERROR_OK) {
+      this->status_set_warning();
+      return;
+    }
+    raw_temperature = i2c::i2ctohs(raw_temperature);
 
-  uint16_t raw_humidity;
-  if (this->write(&HTU21D_REGISTER_HUMIDITY, 1) != i2c::ERROR_OK) {
-    this->status_set_warning();
-    return;
-  }
-  delay(50);  // NOLINT
-  if (this->read(reinterpret_cast<uint8_t *>(&raw_humidity), 2) != i2c::ERROR_OK) {
-    this->status_set_warning();
-    return;
-  }
-  raw_humidity = i2c::i2ctohs(raw_humidity);
+    float temperature = (float(raw_temperature & 0xFFFC)) * 175.72f / 65536.0f - 46.85f;
 
-  float humidity = (float(raw_humidity & 0xFFFC)) * 125.0f / 65536.0f - 6.0f;
+    ESP_LOGD(TAG, "Got Temperature=%.1f°C", temperature);
 
-  int8_t heater_level = this->get_heater_level();
+    if (this->temperature_ != nullptr)
+      this->temperature_->publish_state(temperature);
+    this->status_clear_warning(); // See bmp085.cpp
 
-  ESP_LOGD(TAG, "Got Temperature=%.1f°C Humidity=%.1f%% Heater Level=%d", temperature, humidity, heater_level);
+    if (this->write(&HTU21D_REGISTER_HUMIDITY, 1) != i2c::ERROR_OK) {
+      this->status_set_warning();
+      return;
+    }
 
-  if (this->temperature_ != nullptr)
-    this->temperature_->publish_state(temperature);
-  if (this->humidity_ != nullptr)
-    this->humidity_->publish_state(humidity);
-  if (this->heater_ != nullptr)
-    this->heater_->publish_state(heater_level);
-  this->status_clear_warning();
+    this->set_timeout(50, [this]() {
+      uint16_t raw_humidity;
+      if (this->read(reinterpret_cast<uint8_t *>(&raw_humidity), 2) != i2c::ERROR_OK) {
+        this->status_set_warning();
+        return;
+      }
+      raw_humidity = i2c::i2ctohs(raw_humidity);
+
+      float humidity = (float(raw_humidity & 0xFFFC)) * 125.0f / 65536.0f - 6.0f;
+
+      int8_t heater_level = this->get_heater_level();
+
+      ESP_LOGD(TAG, "Got Humidity=%.1f%% Heater Level=%d", humidity, heater_level);
+
+      if (this->humidity_ != nullptr)
+        this->humidity_->publish_state(humidity);
+      if (this->heater_ != nullptr)
+        this->heater_->publish_state(heater_level);
+      this->status_clear_warning();
+    });
+  });
 }
 
 bool HTU21DComponent::is_heater_enabled() {

--- a/esphome/components/htu21d/htu21d.cpp
+++ b/esphome/components/htu21d/htu21d.cpp
@@ -44,7 +44,8 @@ void HTU21DComponent::update() {
     return;
   }
 
-  this->set_timeout(50, [this]() {
+  // According to the datasheet sht21 temperature readings can take up to 85ms
+  this->set_timeout(85, [this]() {
     uint16_t raw_temperature;
     if (this->read(reinterpret_cast<uint8_t *>(&raw_temperature), 2) != i2c::ERROR_OK) {
       this->status_set_warning();

--- a/esphome/components/htu21d/htu21d.cpp
+++ b/esphome/components/htu21d/htu21d.cpp
@@ -59,7 +59,7 @@ void HTU21DComponent::update() {
 
     if (this->temperature_ != nullptr)
       this->temperature_->publish_state(temperature);
-    this->status_clear_warning(); // See bmp085.cpp
+    this->status_clear_warning();
 
     if (this->write(&HTU21D_REGISTER_HUMIDITY, 1) != i2c::ERROR_OK) {
       this->status_set_warning();


### PR DESCRIPTION
# What does this implement/fix?

Made sensor readings asyncronous using set_timeout() and deleted any delay() call. This removes the warning that "Component htu21d took a long time for an operation".

Furthermore I increased the delay when reading the temperature from the sensor because the original delay was 50ms but according to datasheet the sht21 sensor can take up to 85 ms when reading the temperature.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** 
- https://github.com/esphome/esphome/pull/4641
- https://github.com/esphome/issues/issues/3549

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
