### PR TITLE
Fix missing include in remote_base

### DIFF
--- a/esphome/components/remote_base/remote_base.cpp
+++ b/esphome/components/remote_base/remote_base.cpp
@@ -1,6 +1,8 @@
 #include "remote_base.h"
 #include "esphome/core/log.h"
 
+#include <cinttypes>
+
 namespace esphome {
 namespace remote_base {
 


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

```
INFO ESPHome 2023.11.4
INFO Reading configuration /config/esphome/ir-blaster.yaml...
INFO Generating C++ source...
INFO Compiling app...
Processing ir-blaster (board: esp01_1m; framework: arduino; platform: platformio/espressif8266@3.2.0)
--------------------------------------------------------------------------------
HARDWARE: ESP8266 80MHz, 80KB RAM, 1MB Flash
Dependency Graph
|-- ESPAsyncTCP-esphome @ 2.0.0
|-- ESPAsyncWebServer-esphome @ 3.1.0
|-- DNSServer @ 1.1.1
|-- ESP8266WiFi @ 1.0
|-- ESP8266mDNS @ 1.2
|-- noise-c @ 0.1.4
Compiling .pioenvs/ir-blaster/src/esphome/components/remote_base/remote_base.cpp.o
Compiling .pioenvs/ir-blaster/src/esphome/core/time.cpp.o
Compiling .pioenvs/ir-blaster/src/esphome/core/util.cpp.o
Compiling .pioenvs/ir-blaster/src/main.cpp.o
Generating LD script .pioenvs/ir-blaster/ld/local.eagle.app.v6.common.ld
Compiling .pioenvs/ir-blaster/libf0d/ESPAsyncTCP-esphome/AsyncPrinter.cpp.o
Compiling .pioenvs/ir-blaster/libf0d/ESPAsyncTCP-esphome/ESPAsyncTCP.cpp.o
Compiling .pioenvs/ir-blaster/libf0d/ESPAsyncTCP-esphome/ESPAsyncTCPbuffer.cpp.o
src/esphome/components/remote_base/remote_base.cpp: In member function 'void esphome::remote_base::RemoteTransmitterBase::send_(uint32_t, uint32_t)':
src/esphome/components/remote_base/remote_base.cpp:128:53: error: expected ')' before 'PRIu32'
  128 |   buffer_offset += sprintf(buffer, "Sending times=%" PRIu32 " wait=%" PRIu32 "ms: ", send_times, send_wait);
      |                           ~                         ^~~~~~~
      |                                                     )
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
