### PR TITLE
Pass through additional arguments to create number

### DIFF
--- a/esphome/components/number/__init__.py
+++ b/esphome/components/number/__init__.py
@@ -257,8 +257,8 @@ async def register_number(
     )
 
 
-async def new_number(config, *, min_value: float, max_value: float, step: float):
-    var = cg.new_Pvariable(config[CONF_ID])
+async def new_number(config, *args, min_value: float, max_value: float, step: float):
+    var = cg.new_Pvariable(config[CONF_ID], *args)
     await register_number(
         var, config, min_value=min_value, max_value=max_value, step=step
     )


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

The helper functions `switch.new_switch()` and `sensor.new_sensor()` already allow additional arguments to be passed to the object constructor. This should also be allowed with `number.new_number()`.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx


## Checklist:
  - [x] The code change is tested and works locally.
