### PR TITLE
Fix regex for 'byte' custom CI check

### DIFF
--- a/script/ci-custom.py
+++ b/script/ci-custom.py
@@ -458,7 +458,7 @@ def lint_no_removed_in_idf_conversions(fname, match):
 
 
 @lint_re_check(
-    r"[^\w\d]byte\s+[\w\d]+\s*=",
+    r"[^\w\d]byte +[\w\d]+\s*=",
     include=cpp_include,
     exclude={
         "esphome/components/tuya/tuya.h",


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Fixes an issue with the word `byte` in comments followed by an assignment on a following line
https://github.com/esphome/esphome/actions/runs/7012860345/job/19078105485?pr=4596


## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
