### PR TITLE
Suppress full config output of "esphome config" when -q option is used.

### DIFF
--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -389,7 +389,8 @@ def command_config(args, config):
         output = re.sub(
             r"(password|key|psk|ssid)\: (.+)", r"\1: \\033[5m\2\\033[6m", output
         )
-    safe_print(output)
+    if not CORE.quiet:
+        safe_print(output)
     _LOGGER.info("Configuration is valid!")
     return 0
 

--- a/esphome/core/__init__.py
+++ b/esphome/core/__init__.py
@@ -522,6 +522,8 @@ class EsphomeCore:
         self.component_ids = set()
         # Whether ESPHome was started in verbose mode
         self.verbose = False
+        # Whether ESPHome was started in quiet mode
+        self.quiet = False
 
     def reset(self):
         self.dashboard = False

--- a/esphome/log.py
+++ b/esphome/log.py
@@ -78,6 +78,7 @@ def setup_log(
         CORE.verbose = True
     elif quiet:
         log_level = logging.CRITICAL
+        CORE.quiet = True
     else:
         log_level = logging.INFO
     logging.basicConfig(level=log_level)


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Suppress full config output of "esphome config" when -q option is used. Handy for this:

```
#!/bin/csh
rm -f outfile
foreach i (tests/*yaml)
echo $i >> outfile
esphome -q config $i >>& outfile || echo $i failed
end
```


## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** related to  #5666 


## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx


## Checklist:
  - [x] The code change is tested and works locally.
