### PR TITLE
Implement has_buffered_data for ESPADFSpeaker

### DIFF
--- a/esphome/components/esp_adf/speaker/esp_adf_speaker.cpp
+++ b/esphome/components/esp_adf/speaker/esp_adf_speaker.cpp
@@ -266,6 +266,8 @@ size_t ESPADFSpeaker::play(const uint8_t *data, size_t length) {
   return index;
 }
 
+bool ESPADFSpeaker::has_buffered_data() const { return uxQueueMessagesWaiting(this->buffer_queue_) > 0; }
+
 }  // namespace esp_adf
 }  // namespace esphome
 

--- a/esphome/components/esp_adf/speaker/esp_adf_speaker.h
+++ b/esphome/components/esp_adf/speaker/esp_adf_speaker.h
@@ -29,6 +29,8 @@ class ESPADFSpeaker : public ESPADFPipeline, public speaker::Speaker, public Com
 
   size_t play(const uint8_t *data, size_t length) override;
 
+  bool has_buffered_data() const override;
+
  protected:
   void start_();
   void watch_();


### PR DESCRIPTION
In https://github.com/esphome/esphome/pull/5827 the `has_buffered_data` virtual method was introduced which is not implemented in `ESPADFSpeaker`, causing build for ESP32-S3-Box to fail.

With current `esp_adf` component from PR #5230, build fails with the following message:
```
src/main.cpp: In function 'void setup()':
src/main.cpp:563:44: error: invalid new-expression of abstract class type 'esphome::esp_adf::ESPADFSpeaker'
   box_speaker = new esp_adf::ESPADFSpeaker();
                                            ^
In file included from src/esphome.h:28,
                 from src/main.cpp:3:
src/esphome/components/esp_adf/speaker/esp_adf_speaker.h:20:7: note:   because the following virtual functions are pure within 'esphome::esp_adf::ESPADFSpeaker':
 class ESPADFSpeaker : public ESPADFPipeline, public speaker::Speaker, public Component {
       ^~~~~~~~~~~~~
In file included from src/esphome/components/esp_adf/speaker/esp_adf_speaker.h:10,
                 from src/esphome.h:28,
                 from src/main.cpp:3:
src/esphome/components/speaker/speaker.h:21:16: note: 	'virtual bool esphome::speaker::Speaker::has_buffered_data() const'
   virtual bool has_buffered_data() const = 0;
                ^~~~~~~~~~~~~~~~~
```

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
