### PR TITLE
Improve mitsubishi HVAC component to implement more functions

### DIFF
--- a/esphome/components/mitsubishi/mitsubishi.cpp
+++ b/esphome/components/mitsubishi/mitsubishi.cpp
@@ -12,7 +12,27 @@ const uint8_t MITSUBISHI_COOL = 0x18;
 const uint8_t MITSUBISHI_DRY = 0x10;
 const uint8_t MITSUBISHI_AUTO = 0x20;
 const uint8_t MITSUBISHI_HEAT = 0x08;
+const uint8_t MITSUBISHI_FAN = 0x38;
 const uint8_t MITSUBISHI_FAN_AUTO = 0x00;
+
+// Mitsubishi vertical swing codes
+const uint8_t MITSUBISHI_VERT_SWING = 0x78;
+const uint8_t MITSUBISHI_VS_AUTO = 0x40;
+const uint8_t MITSUBISHI_ECONOCOOL = 0x20;  // KJ byte 14 + 0x03
+const uint8_t MITSUBISHI_ISAVE = 0x20;      // KJ byte 15 w temperature=0
+const uint8_t MITSUBISHI_1FLOW = 0x02;      // KJ byte 16
+const uint8_t MITSUBISHI_VERT_UP = 0x48;
+const uint8_t MITSUBISHI_VERT_MUP = 0x50;
+const uint8_t MITSUBISHI_VERT_MIDDLE = 0x58;
+const uint8_t MITSUBISHI_VERT_MDOWN = 0x60;
+const uint8_t MITSUBISHI_VERT_DOWN = 0x68;
+
+const uint8_t MITSUBISHI_HORZ_SWING = 0xC0;
+const uint8_t MITSUBISHI_HORZ_MIDDLE = 0x30;
+const uint8_t MITSUBISHI_HORZ_LEFT = 0x10;
+const uint8_t MITSUBISHI_HORZ_MLEFT = 0x20;
+const uint8_t MITSUBISHI_HORZ_MRIGHT = 0x40;
+const uint8_t MITSUBISHI_HORZ_RIGHT = 0x50;
 
 // Pulse parameters in usec
 const uint16_t MITSUBISHI_BIT_MARK = 430;
@@ -36,17 +56,83 @@ void MitsubishiClimate::transmit_state() {
     case climate::CLIMATE_MODE_HEAT_COOL:
       remote_state[6] = MITSUBISHI_AUTO;
       break;
+    case climate::CLIMATE_MODE_DRY:
+      remote_state[6] = MITSUBISHI_DRY;
+      break;
+    case climate::CLIMATE_MODE_FAN_ONLY:
+      remote_state[6] = MITSUBISHI_FAN;
+      break;
     case climate::CLIMATE_MODE_OFF:
     default:
       remote_state[5] = MITSUBISHI_OFF;
       break;
   }
 
+  switch (this->fan_mode.value()) {
+    case climate::CLIMATE_FAN_QUIET:
+      remote_state[9] = 5;
+      break;
+    case climate::CLIMATE_FAN_LOW:
+      remote_state[9] = 1;
+      break;
+    case climate::CLIMATE_FAN_MIDDLE:
+      remote_state[9] = 2;
+      break;
+    case climate::CLIMATE_FAN_MEDIUM:
+      remote_state[9] = 3;
+      break;
+    case climate::CLIMATE_FAN_HIGH:
+      remote_state[9] = 4;
+      break;
+
+    case climate::CLIMATE_FAN_AUTO:
+    default:
+      remote_state[9] = 0;
+      break;
+  }
+
+  switch (this->swing_mode) {
+    case climate::CLIMATE_SWING_VERTICAL:
+      remote_state[9] |= MITSUBISHI_VERT_SWING;
+      remote_state[8] = MITSUBISHI_HORZ_MIDDLE;
+      break;
+    case climate::CLIMATE_SWING_HORIZONTAL:
+      remote_state[8] = MITSUBISHI_HORZ_SWING;
+      remote_state[9] |= MITSUBISHI_VERT_MIDDLE;
+      break;
+    case climate::CLIMATE_SWING_BOTH:
+      remote_state[8] = MITSUBISHI_HORZ_SWING;
+      remote_state[9] |= MITSUBISHI_VERT_SWING;
+      break;
+    case climate::CLIMATE_SWING_OFF:
+    default:
+      remote_state[8] = MITSUBISHI_HORZ_MIDDLE;
+      remote_state[9] |= MITSUBISHI_VERT_MIDDLE;
+      break;
+  }
+
+  switch (this->preset.value()) {
+    case climate::CLIMATE_PRESET_ECO:
+      /* My unit doesn't support this, so I can't test it */
+      remote_state[9] = 0x7 | MITSUBISHI_ECONOCOOL;
+      break;
+    case climate::CLIMATE_PRESET_BOOST:
+      /* My unit doesn't support this, so I can't test it */
+      remote_state[9] = (remote_state[9] & ~0x07) | 4;
+      break;
+    case climate::CLIMATE_PRESET_NONE:
+    default:
+      break;
+  }
+
   remote_state[7] = (uint8_t) roundf(clamp<float>(this->target_temperature, MITSUBISHI_TEMP_MIN, MITSUBISHI_TEMP_MAX) -
                                      MITSUBISHI_TEMP_MIN);
 
-  ESP_LOGV(TAG, "Sending Mitsubishi target temp: %.1f state: %02" PRIX32 " mode: %02" PRIX32 " temp: %02" PRIX32,
-           this->target_temperature, remote_state[5], remote_state[6], remote_state[7]);
+  ESP_LOGV(TAG,
+           "Sending Mitsubishi target temp: %.1f state: %02" PRIX32 " mode: %02" PRIX32 " temp: %02" PRIX32
+           " fan/vswing: %02" PRIX32 " hswing: %02" PRIX32,
+           this->target_temperature, remote_state[5], remote_state[6], remote_state[7], remote_state[9],
+           remote_state[8]);
 
   // Checksum
   for (int i = 0; i < 17; i++) {

--- a/esphome/components/mitsubishi/mitsubishi.h
+++ b/esphome/components/mitsubishi/mitsubishi.h
@@ -13,7 +13,14 @@ const uint8_t MITSUBISHI_TEMP_MAX = 31;  // Celsius
 
 class MitsubishiClimate : public climate_ir::ClimateIR {
  public:
-  MitsubishiClimate() : climate_ir::ClimateIR(MITSUBISHI_TEMP_MIN, MITSUBISHI_TEMP_MAX) {}
+  MitsubishiClimate()
+      : climate_ir::ClimateIR(
+            MITSUBISHI_TEMP_MIN, MITSUBISHI_TEMP_MAX, 1.0f, true, true,
+            {climate::CLIMATE_FAN_AUTO, climate::CLIMATE_FAN_LOW, climate::CLIMATE_FAN_MIDDLE,
+             climate::CLIMATE_FAN_MEDIUM, climate::CLIMATE_FAN_HIGH, climate::CLIMATE_FAN_QUIET},
+            {climate::CLIMATE_SWING_OFF, climate::CLIMATE_SWING_VERTICAL, climate::CLIMATE_SWING_HORIZONTAL,
+             climate::CLIMATE_SWING_BOTH},
+            {climate::CLIMATE_PRESET_NONE, climate::CLIMATE_PRESET_ECO, climate::CLIMATE_PRESET_BOOST}) {}
 
  protected:
   /// Transmit via IR the state of this climate controller.


### PR DESCRIPTION
# What does this implement/fix?

This implements more function for Mitsubishi HVAC system, such as enabling fan mode, swing mode, and some preset.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** 
None

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** 
None, all added features are documented in `Climate` component already, the implementation was just missing before this.

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [X] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

I've manually checked the code is generating the same output as before the PR when all new *optional* parameters are left by default. I've compared the output with HeatPumpIR library for the optional features. I can't test the generated IR packet will work on all units, but if it doesn't, one can disable the optional features by omitting them and it'll behave like it previously behaved.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
