### PR TITLE
refix Bug Created with PR 4758

### DIFF
--- a/esphome/components/dfplayer/dfplayer.cpp
+++ b/esphome/components/dfplayer/dfplayer.cpp
@@ -7,10 +7,10 @@ namespace dfplayer {
 static const char *const TAG = "dfplayer";
 
 void DFPlayer::play_folder(uint16_t folder, uint16_t file) {
-  if (folder <= 10 && file <= 1000) {
+  if (folder < 100 && file < 256) {
     this->ack_set_is_playing_ = true;
-    this->send_cmd_(0x0F, (uint8_t) folder, (uint8_t) file);
-  } else if (folder < 100 && file < 256) {
+    this->send_cmd_(0x0F, (uint8_t) folder, (uint8_t) file);  
+  else if (folder <= 15 && file <= 3000) {
     this->ack_set_is_playing_ = true;
     this->send_cmd_(0x14, (((uint16_t) folder) << 12) | file);
   } else {


### PR DESCRIPTION
# What does this implement/fix?

The Bugfix from PR 4758 implemented a Bug because of the changed order of the if function.
I reordered de conditions and made some changes according to the [Documentation](http://www.robotsforfun.com/datasheets/DFPlayer.pdf) Point 3.6.5 and 3.6.9

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable): PR 4758 fixes <https://github.com/esphome/esphome/pull/4758>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
on_...:
  then:
    - dfplayer.play_folder:
        folder: 12
        file: 5

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
