### PR TITLE
Fix un-initialized version string

### DIFF
--- a/esphome/components/ld2420/ld2420.h
+++ b/esphome/components/ld2420/ld2420.h
@@ -255,12 +255,11 @@ class LD2420Component : public Component, public uart::UARTDevice {
 
   uint16_t gate_energy_[LD2420_TOTAL_GATES];
   CmdReplyT cmd_reply_;
-  uint32_t timeout_;
   uint32_t max_distance_gate_;
   uint32_t min_distance_gate_;
   uint16_t system_mode_{CMD_SYSTEM_MODE_ENERGY};
   bool cmd_active_{false};
-  char ld2420_firmware_ver_[8];
+  char ld2420_firmware_ver_[8]{"v0.0.0"};
   bool presence_{false};
   bool calibration_{false};
   uint16_t distance_{0};


### PR DESCRIPTION
## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

[PR#5115](https://github.com/esphome/issues/issues/5115)

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Checklist:
  - [x] The code change is tested and works locally.

 If the LD2420 module is not connected correctly, missing or defective we are comparing an un-initialized version string and that exceptions.