### PR TITLE
core: Don't delay loop if already late

### DIFF
--- a/esphome/core/application.cpp
+++ b/esphome/core/application.cpp
@@ -82,9 +82,7 @@ void Application::loop() {
   const uint32_t now = millis();
   const uint32_t elapsed = now - this->last_loop_;
 
-  if (HighFrequencyLoopRequester::is_high_frequency() || elapsed >= this->loop_interval_) {
-    yield();
-  } else {
+  if (!HighFrequencyLoopRequester::is_high_frequency() && elapsed < this->loop_interval_) {
     uint32_t delay_time = this->loop_interval_ - elapsed;
     uint32_t next_schedule = this->scheduler.next_schedule_in().value_or(delay_time);
     // next_schedule is max 0.5*delay_time
@@ -93,6 +91,7 @@ void Application::loop() {
     delay_time = std::min(next_schedule, delay_time);
     delay(delay_time);
   }
+
   this->last_loop_ = now;
 
   if (this->dump_config_at_ < this->components_.size()) {

--- a/esphome/core/application.cpp
+++ b/esphome/core/application.cpp
@@ -81,16 +81,17 @@ void Application::loop() {
 
   const uint32_t now = millis();
   const uint32_t elapsed = now - this->last_loop_;
+  uint32_t delay_time = 1;  // minimum delay due to tasks at prio 0
 
   if (!HighFrequencyLoopRequester::is_high_frequency() && elapsed < this->loop_interval_) {
-    uint32_t delay_time = this->loop_interval_ - elapsed;
+    delay_time = this->loop_interval_ - elapsed;
     uint32_t next_schedule = this->scheduler.next_schedule_in().value_or(delay_time);
     // next_schedule is max 0.5*delay_time
     // otherwise interval=0 schedules result in constant looping with almost no sleep
     next_schedule = std::max(next_schedule, delay_time / 2);
     delay_time = std::min(next_schedule, delay_time);
-    delay(delay_time);
   }
+  delay(delay_time);
 
   this->last_loop_ = now;
 

--- a/esphome/core/application.cpp
+++ b/esphome/core/application.cpp
@@ -79,8 +79,19 @@ void Application::loop() {
   }
   this->app_state_ = new_app_state;
 
-  const uint32_t now = millis();
-  const uint32_t elapsed = now - this->last_loop_;
+  if (this->dump_config_at_ < this->components_.size()) {
+    if (this->dump_config_at_ == 0) {
+      ESP_LOGI(TAG, "ESPHome version " ESPHOME_VERSION " compiled on %s", this->compilation_time_);
+#ifdef ESPHOME_PROJECT_NAME
+      ESP_LOGI(TAG, "Project " ESPHOME_PROJECT_NAME " version " ESPHOME_PROJECT_VERSION);
+#endif
+    }
+
+    this->components_[this->dump_config_at_]->call_dump_config();
+    this->dump_config_at_++;
+  }
+
+  const uint32_t elapsed = millis() - this->last_loop_;
   uint32_t delay_time = 1;  // minimum delay due to tasks at prio 0
 
   if (!HighFrequencyLoopRequester::is_high_frequency() && elapsed < this->loop_interval_) {
@@ -93,19 +104,7 @@ void Application::loop() {
   }
   delay(delay_time);
 
-  this->last_loop_ = now;
-
-  if (this->dump_config_at_ < this->components_.size()) {
-    if (this->dump_config_at_ == 0) {
-      ESP_LOGI(TAG, "ESPHome version " ESPHOME_VERSION " compiled on %s", this->compilation_time_);
-#ifdef ESPHOME_PROJECT_NAME
-      ESP_LOGI(TAG, "Project " ESPHOME_PROJECT_NAME " version " ESPHOME_PROJECT_VERSION);
-#endif
-    }
-
-    this->components_[this->dump_config_at_]->call_dump_config();
-    this->dump_config_at_++;
-  }
+  this->last_loop_ = millis();
 }
 
 void IRAM_ATTR HOT Application::feed_wdt() {

--- a/esphome/core/application.cpp
+++ b/esphome/core/application.cpp
@@ -80,14 +80,12 @@ void Application::loop() {
   this->app_state_ = new_app_state;
 
   const uint32_t now = millis();
+  const uint32_t elapsed = now - this->last_loop_;
 
-  if (HighFrequencyLoopRequester::is_high_frequency()) {
+  if (HighFrequencyLoopRequester::is_high_frequency() || elapsed >= this->loop_interval_) {
     yield();
   } else {
-    uint32_t delay_time = this->loop_interval_;
-    if (now - this->last_loop_ < this->loop_interval_)
-      delay_time = this->loop_interval_ - (now - this->last_loop_);
-
+    uint32_t delay_time = this->loop_interval_ - elapsed;
     uint32_t next_schedule = this->scheduler.next_schedule_in().value_or(delay_time);
     // next_schedule is max 0.5*delay_time
     // otherwise interval=0 schedules result in constant looping with almost no sleep


### PR DESCRIPTION
# What does this implement/fix?

The application loop would delay a full loop_interval_ when the last loop run already took more than loop_interval_ time.

Instead, don't delay if we're already late and run the next loop as soon as possible.

This makes the code do what the docs for `set_loop_interval()` says:
> If the loop() method takes longer than the target interval, ESPHome won't sleep in loop()

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
