### PR TITLE
ajsr04m: Add support for AJ-SR04M ultrasonic sensor

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -24,6 +24,7 @@ esphome/components/airthings_ble/* @jeromelaban
 esphome/components/airthings_wave_base/* @jeromelaban @kpfleming @ncareau
 esphome/components/airthings_wave_mini/* @ncareau
 esphome/components/airthings_wave_plus/* @jeromelaban
+esphome/components/ajsr04m/* @tathamoddie
 esphome/components/alarm_control_panel/* @grahambrown11
 esphome/components/alpha3/* @jan-hofmeier
 esphome/components/am43/* @buxtronix

--- a/esphome/components/ajsr04m/__init__.py
+++ b/esphome/components/ajsr04m/__init__.py
@@ -1,0 +1,1 @@
+CODEOWNERS = ["@tathamoddie"]

--- a/esphome/components/ajsr04m/ajsr04m.cpp
+++ b/esphome/components/ajsr04m/ajsr04m.cpp
@@ -1,0 +1,48 @@
+#include "ajsr04m.h"
+#include "esphome/core/log.h"
+
+namespace esphome {
+namespace ajsr04m {
+
+static const char *const TAG = "ajsr04m";
+
+static const uint8_t AJSR04M_START_BYTE = 0xFF;
+
+void AJSR04MComponent::loop() {
+  // Expected frame is:
+  //   0xFF - start byte
+  //   0xnn - distance, upper byte
+  //   0xnn - distance, lower byte
+  //   0xnn - checksum: upper + lower == 1
+  uint8_t data[3];
+  while (available() >= 4) {
+    if (read() != AJSR04M_START_BYTE) {
+      continue;
+    }
+
+    read_array(data, 3);
+    ESP_LOGD(TAG, "Read bytes %02X %02X %02X", data[0], data[1], data[2]);
+
+    uint8_t expected_checksum = data[0] + data[1];
+    if (expected_checksum - data[2] != 1) {
+      ESP_LOGE(TAG, "Checksum mismatch. Expected %02X. Got %02X.", expected_checksum, data[2]);
+      continue;
+    }
+
+    float distance = ((data[0] << 8) + data[1]) / 10.0f;
+    ESP_LOGD(TAG, "Calculated distance %.1fcm", distance);
+
+    this->distance_sensor_->publish_state(distance);
+  }
+}
+
+float AJSR04MComponent::get_setup_priority() const { return setup_priority::DATA; }
+
+void AJSR04MComponent::dump_config() {
+  ESP_LOGCONFIG(TAG, "AJSR04M:");
+  LOG_SENSOR("  ", "Distance", this->distance_sensor_);
+  this->check_uart_settings(9600);
+}
+
+}  // namespace ajsr04m
+}  // namespace esphome

--- a/esphome/components/ajsr04m/ajsr04m.h
+++ b/esphome/components/ajsr04m/ajsr04m.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/components/sensor/sensor.h"
+#include "esphome/components/uart/uart.h"
+
+namespace esphome {
+namespace ajsr04m {
+
+class AJSR04MComponent : public Component, public uart::UARTDevice {
+ public:
+  float get_setup_priority() const override;
+
+  void loop() override;
+  void dump_config() override;
+
+  void set_distance_sensor(sensor::Sensor *distance_sensor) { this->distance_sensor_ = distance_sensor; }
+
+ protected:
+  sensor::Sensor *distance_sensor_{nullptr};
+};
+
+}  // namespace ajsr04m
+}  // namespace esphome

--- a/esphome/components/ajsr04m/sensor.py
+++ b/esphome/components/ajsr04m/sensor.py
@@ -1,0 +1,42 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import sensor, uart
+from esphome.const import (
+    CONF_DISTANCE,
+    CONF_ID,
+    DEVICE_CLASS_DISTANCE,
+    STATE_CLASS_MEASUREMENT,
+    UNIT_CENTIMETER,
+)
+
+CODEOWNERS = ["@tathamoddie"]
+DEPENDENCIES = ["uart"]
+
+ajsr04m_ns = cg.esphome_ns.namespace("ajsr04m")
+AJSR04MComponent = ajsr04m_ns.class_("AJSR04MComponent", cg.Component, uart.UARTDevice)
+
+CONFIG_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(): cv.declare_id(AJSR04MComponent),
+        cv.Required(CONF_DISTANCE): sensor.sensor_schema(
+            unit_of_measurement=UNIT_CENTIMETER,
+            accuracy_decimals=1,
+            device_class=DEVICE_CLASS_DISTANCE,
+            state_class=STATE_CLASS_MEASUREMENT,
+        ),
+    }
+).extend(uart.UART_DEVICE_SCHEMA)
+
+FINAL_VALIDATE_SCHEMA = uart.final_validate_device_schema(
+    "ajsr04m", baud_rate=9600, require_rx=True, require_tx=True
+)
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+    await uart.register_uart_device(var, config)
+
+    if CONF_DISTANCE in config:
+        sens = await sensor.new_sensor(config[CONF_DISTANCE])
+        cg.add(var.set_distance_sensor(sens))


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Adds support for the AJ-SR04M waterproof ultrasonic sensor.

Specifically, the [automatic serial mode](https://tutorials.probots.co.in/communicating-with-a-waterproof-ultrasonic-sensor-aj-sr04m-jsn-sr04t/) communication via UART.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#3424

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
uart:
  tx_pin: 19
  rx_pin: 33
  baud_rate: 9600

sensor:
  - platform: ajsr04m
    distance:
      name: "Distance to Surface"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
