### PR TITLE
Drop LD2410 delays

### DIFF
--- a/esphome/components/ld2410/ld2410.cpp
+++ b/esphome/components/ld2410/ld2410.cpp
@@ -139,8 +139,6 @@ void LD2410Component::send_command_(uint8_t command, const uint8_t *command_valu
   }
   // frame end bytes
   this->write_array(CMD_FRAME_END, 4);
-  // FIXME to remove
-  delay(50);  // NOLINT
 }
 
 void LD2410Component::handle_periodic_data_(uint8_t *buffer, int len) {
@@ -598,7 +596,6 @@ void LD2410Component::set_max_distances_timeout() {
                        0x00};
   this->set_config_mode_(true);
   this->send_command_(CMD_MAXDIST_DURATION, value, 18);
-  delay(50);  // NOLINT
   this->query_parameters_();
   this->set_timeout(200, [this]() { this->restart_and_read_all_info(); });
   this->set_config_mode_(false);
@@ -628,7 +625,6 @@ void LD2410Component::set_gate_threshold(uint8_t gate) {
                        0x01, 0x00, lowbyte(motion), highbyte(motion), 0x00, 0x00,
                        0x02, 0x00, lowbyte(still),  highbyte(still),  0x00, 0x00};
   this->send_command_(CMD_GATE_SENS, value, 18);
-  delay(50);  // NOLINT
   this->query_parameters_();
   this->set_config_mode_(false);
 }
@@ -665,7 +661,6 @@ void LD2410Component::set_light_out_control() {
   uint8_t out_pin_level = OUT_PIN_LEVEL_ENUM_TO_INT.at(this->out_pin_level_);
   uint8_t value[4] = {light_function, light_threshold, out_pin_level, 0x00};
   this->send_command_(CMD_SET_LIGHT_CONTROL, value, 4);
-  delay(50);  // NOLINT
   this->get_light_control_();
   this->set_timeout(200, [this]() { this->restart_and_read_all_info(); });
   this->set_config_mode_(false);


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

It looks like some debugging code was left behind from #4434 which adds extra delays, which seem not to be necessary, and contributes to warnings such as this:

```
[22:48:05][W][component:214]: Component ld2410 took a long time for an operation (0.24 s).
[22:48:05][W][component:215]: Components should block for at most 20-30ms.
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
esphome:
  name: "esphome_ld2410"
  friendly_name: "ESPHome > Hi-Link HLK-LD2410"
  name_add_mac_suffix: true
  on_boot:
    then:
      - switch.turn_on: ld2410_engineering_mode

esp32:
  board: esp32-c3-devkitm-1

logger:

wifi:
  id: wifi_component
  reboot_timeout: 0s
  fast_connect: true

web_server:

api:
  password: ""
  reboot_timeout: 0s

ota:

prometheus:

uart:
  baud_rate: 256000
  tx_pin: 1
  rx_pin: 0
  parity: NONE
  stop_bits: 1

ld2410:

binary_sensor:
  - platform: ld2410
    has_target:
      name: 'Hi-Link HLK-LD2410: Sensor: Binary: Presence'
      icon: 'mdi:motion-sensor'
    has_moving_target:
      name: 'Hi-Link HLK-LD2410: Sensor: Binary: Moving Target'
      icon: 'mdi:motion-sensor'
    has_still_target:
      name: 'Hi-Link HLK-LD2410: Sensor: Binary: Still Target'
      icon: 'mdi:motion-sensor'
    out_pin_presence_status:
      name: 'Hi-Link HLK-LD2410: Sensor: Binary: OUT pin indicates presence'
      icon: 'mdi:motion-sensor'

  - platform: gpio
    pin: 3
    name: 'Hi-Link HLK-LD2410: Sensor: Binary: GPIO out pin presence'
    device_class: presence
    icon: 'mdi:motion-sensor'

sensor:
  - platform: uptime
    name: 'Uptime'
    icon: 'mdi:timer-outline'
    update_interval: 1s

  - platform: wifi_signal
    name: "WiFi: Signal dB"
    id: wifi_signal_db
    update_interval: 15s
    entity_category: "diagnostic"
    icon: 'mdi:signal'

  - platform: copy
    source_id: wifi_signal_db
    name: "WiFi: Signal Percent"
    filters:
      - lambda: return min(max(2 * (x + 100.0), 0.0), 100.0);
    unit_of_measurement: "Signal %"
    entity_category: "diagnostic"
    device_class: ""
    icon: 'mdi:signal'

  - platform: ld2410
    light:
      name: 'Hi-Link HLK-LD2410: Sensor: Light'
      icon: 'mdi:brightness-5'
      filters:
        - lambda: |-
            return 100 * (x - 80.0) / (255.0 - 80.0);
      unit_of_measurement: "%"
    moving_distance:
      name: 'Hi-Link HLK-LD2410: Sensor: Moving Distance'
      icon: 'mdi:motion-sensor'
    still_distance:
      name: 'Hi-Link HLK-LD2410: Sensor: Still Distance'
      icon: 'mdi:motion-sensor'
    moving_energy:
      name: 'Hi-Link HLK-LD2410: Sensor: Move Energy'
      icon: 'mdi:motion-sensor'
    still_energy:
      name: 'Hi-Link HLK-LD2410: Sensor: Still Energy'
      icon: 'mdi:motion-sensor'
    detection_distance:
      name: 'Hi-Link HLK-LD2410: Sensor: Detection Distance'
      icon: 'mdi:ruler'
    g0:
      move_energy:
        name: 'Hi-Link HLK-LD2410: Sensor: Move Energy: g0'
        icon: 'mdi:percent'
      still_energy:
        name: 'Hi-Link HLK-LD2410: Sensor: Still Energy: g0'
        icon: 'mdi:percent'
    g1:
      move_energy:
        name: 'Hi-Link HLK-LD2410: Sensor: Move Energy: g1'
        icon: 'mdi:percent'
      still_energy:
        name: 'Hi-Link HLK-LD2410: Sensor: Still Energy: g1'
        icon: 'mdi:percent'
    g2:
      move_energy:
        name: 'Hi-Link HLK-LD2410: Sensor: Move Energy: g2'
        icon: 'mdi:percent'
      still_energy:
        name: 'Hi-Link HLK-LD2410: Sensor: Still Energy: g2'
        icon: 'mdi:percent'
    g3:
      move_energy:
        name: 'Hi-Link HLK-LD2410: Sensor: Move Energy: g3'
        icon: 'mdi:percent'
      still_energy:
        name: 'Hi-Link HLK-LD2410: Sensor: Still Energy: g3'
        icon: 'mdi:percent'
    g4:
      move_energy:
        name: 'Hi-Link HLK-LD2410: Sensor: Move Energy: g4'
        icon: 'mdi:percent'
      still_energy:
        name: 'Hi-Link HLK-LD2410: Sensor: Still Energy: g4'
        icon: 'mdi:percent'
    g5:
      move_energy:
        name: 'Hi-Link HLK-LD2410: Sensor: Move Energy: g5'
        icon: 'mdi:percent'
      still_energy:
        name: 'Hi-Link HLK-LD2410: Sensor: Still Energy: g5'
        icon: 'mdi:percent'
    g6:
      move_energy:
        name: 'Hi-Link HLK-LD2410: Sensor: Move Energy: g6'
        icon: 'mdi:percent'
      still_energy:
        name: 'Hi-Link HLK-LD2410: Sensor: Still Energy: g6'
        icon: 'mdi:percent'
    g7:
      move_energy:
        name: 'Hi-Link HLK-LD2410: Sensor: Move Energy: g7'
        icon: 'mdi:percent'
      still_energy:
        name: 'Hi-Link HLK-LD2410: Sensor: Still Energy: g7'
        icon: 'mdi:percent'
    g8:
      move_energy:
        name: 'Hi-Link HLK-LD2410: Sensor: Move Energy: g8'
        icon: 'mdi:percent'
      still_energy:
        name: 'Hi-Link HLK-LD2410: Sensor: Still Energy: g8'
        icon: 'mdi:percent'

switch:
  - platform: ld2410
    engineering_mode:
      name: "Hi-Link HLK-LD2410: Switch: engineering mode"
      id: ld2410_engineering_mode
      icon: 'mdi:chip'
    bluetooth:
      id: ld2410_bluetooth
      name: "Hi-Link HLK-LD2410: Switch: control bluetooth"
      icon: 'mdi:bluetooth'

number:
  - platform: ld2410
    timeout:
      name: 'Hi-Link HLK-LD2410: Number: Timeout'
      icon: 'mdi:timer-outline'
    light_threshold:
      name: 'Hi-Link HLK-LD2410: Number: Light threshold'
      icon: 'mdi:brightness-5'
    max_move_distance_gate:
      name: 'Hi-Link HLK-LD2410: Number: Move: Max distance gate'
      icon: 'mdi:ruler'
    max_still_distance_gate:
      name: 'Hi-Link HLK-LD2410: Number: Still: Max distance gate'
      icon: 'mdi:ruler'
    g0:
      move_threshold:
        name: 'Hi-Link HLK-LD2410: Number: Move: Threshold: g0'
        icon: 'mdi:percent'
      still_threshold:
        name: 'Hi-Link HLK-LD2410: Number: Still: Threshold: g0'
        icon: 'mdi:percent'
    g1:
      move_threshold:
        name: 'Hi-Link HLK-LD2410: Number: Move: Threshold: g1'
        icon: 'mdi:percent'
      still_threshold:
        name: 'Hi-Link HLK-LD2410: Number: Still: Threshold: g1'
        icon: 'mdi:percent'
    g2:
      move_threshold:
        name: 'Hi-Link HLK-LD2410: Number: Move: Threshold: g2'
        icon: 'mdi:percent'
      still_threshold:
        name: 'Hi-Link HLK-LD2410: Number: Still: Threshold: g2'
        icon: 'mdi:percent'
    g3:
      move_threshold:
        name: 'Hi-Link HLK-LD2410: Number: Move: Threshold: g3'
        icon: 'mdi:percent'
      still_threshold:
        name: 'Hi-Link HLK-LD2410: Number: Still: Threshold: g3'
        icon: 'mdi:percent'
    g4:
      move_threshold:
        name: 'Hi-Link HLK-LD2410: Number: Move: Threshold: g4'
        icon: 'mdi:percent'
      still_threshold:
        name: 'Hi-Link HLK-LD2410: Number: Still: Threshold: g4'
        icon: 'mdi:percent'
    g5:
      move_threshold:
        name: 'Hi-Link HLK-LD2410: Number: Move: Threshold: g5'
        icon: 'mdi:percent'
      still_threshold:
        name: 'Hi-Link HLK-LD2410: Number: Still: Threshold: g5'
        icon: 'mdi:percent'
    g6:
      move_threshold:
        name: 'Hi-Link HLK-LD2410: Number: Move: Threshold: g6'
        icon: 'mdi:percent'
      still_threshold:
        name: 'Hi-Link HLK-LD2410: Number: Still: Threshold: g6'
        icon: 'mdi:percent'
    g7:
      move_threshold:
        name: 'Hi-Link HLK-LD2410: Number: Move: Threshold: g7'
        icon: 'mdi:percent'
      still_threshold:
        name: 'Hi-Link HLK-LD2410: Number: Still: Threshold: g7'
        icon: 'mdi:percent'
    g8:
      move_threshold:
        name: 'Hi-Link HLK-LD2410: Number: Move: Threshold: g8'
        icon: 'mdi:percent'
      still_threshold:
        name: 'Hi-Link HLK-LD2410: Number: Still: Threshold: g8'
        icon: 'mdi:percent'

button:
  - platform: ld2410
    factory_reset:
      name: "Hi-Link HLK-LD2410: Button: factory reset"
      icon: 'mdi:restart'
    restart:
      name: "Hi-Link HLK-LD2410: Button: restart"
      icon: 'mdi:restart'
    query_params:
      name: 'Hi-Link HLK-LD2410: Button: query params'
      icon: ''

text_sensor:
  - platform: ld2410
    version:
      name: "Hi-Link HLK-LD2410: Sensor: Text: Firmware version"
      icon: 'mdi:chip'
    mac_address:
      name: "Hi-Link HLK-LD2410: Sensor: Text: Mac address"
      icon: 'mdi:bluetooth'

select:
  - platform: ld2410
    distance_resolution:
      name: "Hi-Link HLK-LD2410: Select: Distance resolution"
      icon: 'mdi:ruler'
    baud_rate:
      name: "Hi-Link HLK-LD2410: Select: Baud rate"
      icon: ''
    light_function:
      name: 'Hi-Link HLK-LD2410: Select: Light function'
      icon: 'mdi:brightness-5'
    out_pin_level:
      name: 'Hi-Link HLK-LD2410: Select: Out pin level'
      icon: 'mdi:motion-sensor'
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
