### PR TITLE
fix a01nyub data reading

### DIFF
--- a/esphome/components/a01nyub/a01nyub.cpp
+++ b/esphome/components/a01nyub/a01nyub.cpp
@@ -38,9 +38,7 @@ void A01nyubComponent::check_buffer_() {
   this->buffer_.clear();
 }
 
-void A01nyubComponent::dump_config() {
-  LOG_SENSOR("", "A01nyub Sensor", this);
-}
+void A01nyubComponent::dump_config() { LOG_SENSOR("", "A01nyub Sensor", this); }
 
 }  // namespace a01nyub
 }  // namespace esphome

--- a/esphome/components/a01nyub/a01nyub.cpp
+++ b/esphome/components/a01nyub/a01nyub.cpp
@@ -8,49 +8,38 @@ namespace esphome {
 namespace a01nyub {
 
 static const char *const TAG = "a01nyub.sensor";
-static const uint8_t MAX_DATA_LENGTH_BYTES = 4;
 
 void A01nyubComponent::loop() {
   uint8_t data;
   while (this->available() > 0) {
-    if (this->read_byte(&data)) {
-      buffer_.push_back(data);
+    this->read_byte(&data);
+    if (this->buffer_.empty() && (data != 0xff))
+      continue;
+    buffer_.push_back(data);
+    if (this->buffer_.size() == 4)
       this->check_buffer_();
-    }
   }
 }
 
 void A01nyubComponent::check_buffer_() {
-  if (this->buffer_.size() >= MAX_DATA_LENGTH_BYTES) {
-    size_t i;
-    for (i = 0; i < this->buffer_.size(); i++) {
-      // Look for the first packet
-      if (this->buffer_[i] == 0xFF) {
-        if (i + 1 + 3 < this->buffer_.size()) {  // Packet is not complete
-          return;                                // Wait for completion
-        }
-
-        uint8_t checksum = (this->buffer_[i] + this->buffer_[i + 1] + this->buffer_[i + 2]) & 0xFF;
-        if (this->buffer_[i + 3] == checksum) {
-          float distance = (this->buffer_[i + 1] << 8) + this->buffer_[i + 2];
-          if (distance > 280) {
-            float meters = distance / 1000.0;
-            ESP_LOGV(TAG, "Distance from sensor: %f mm, %f m", distance, meters);
-            this->publish_state(meters);
-          } else {
-            ESP_LOGW(TAG, "Invalid data read from sensor: %s", format_hex_pretty(this->buffer_).c_str());
-          }
-        }
-        break;
-      }
+  uint8_t checksum = this->buffer_[0] + this->buffer_[1] + this->buffer_[2];
+  if (this->buffer_[3] == checksum) {
+    float distance = (this->buffer_[1] << 8) + this->buffer_[2];
+    if (distance > 280) {
+      float meters = distance / 1000.0;
+      ESP_LOGV(TAG, "Distance from sensor: %f mm, %f m", distance, meters);
+      this->publish_state(meters);
+    } else {
+      ESP_LOGW(TAG, "Invalid data read from sensor: %s", format_hex_pretty(this->buffer_).c_str());
     }
-    this->buffer_.clear();
+  } else {
+    ESP_LOGW(TAG, "checksum failed: %02x != %02x", checksum, this->buffer_[3]);
   }
+  this->buffer_.clear();
 }
 
 void A01nyubComponent::dump_config() {
-  ESP_LOGCONFIG(TAG, "A01nyub Sensor:");
-  LOG_SENSOR("  ", "Distance", this);
+  LOG_SENSOR("", "A01nyub Sensor", this);
 }
 
 }  // namespace a01nyub


### PR DESCRIPTION
# What does this implement/fix?

The data reading can get stuck in some cases of bad data.  This cleans it up.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/5182

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
