### PR TITLE
Add Waveshare 1.47in 172x320 to ST7789v component 

### DIFF
--- a/esphome/components/st7789v/display.py
+++ b/esphome/components/st7789v/display.py
@@ -97,6 +97,19 @@ MODELS = {
             CONF_BACKLIGHT_PIN: "GPIO15",
         }
     ),
+    "WAVESHARE_1.47IN_172X320": model_spec(
+        presets={
+            CONF_HEIGHT: 320,
+            CONF_WIDTH: 172,
+            CONF_OFFSET_HEIGHT: 34,
+            CONF_OFFSET_WIDTH: 0,
+            CONF_ROTATION: 90,
+            CONF_CS_PIN: "GPIO21",
+            CONF_DC_PIN: "GPIO22",
+            CONF_RESET_PIN: "GPIO23",
+            CONF_BACKLIGHT_PIN: "GPIO4",
+        }
+    ),
     "CUSTOM": model_spec(),
 }
 


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#3440

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
display:
  - platform: st7789v
    model: Waveshare 1.47in 172X320
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
