### PR TITLE
Security improvement: Support wifi ap_timeout=0s (disable)

### DIFF
--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -164,7 +164,7 @@ void WiFiComponent::loop() {
 
 #ifdef USE_WIFI_AP
     if (this->has_ap() && !this->ap_setup_) {
-      if (now - this->last_connected_ > this->ap_timeout_) {
+      if (this->ap_timeout_ != 0 && (now - this->last_connected_ > this->ap_timeout_)) {
         ESP_LOGI(TAG, "Starting fallback AP!");
         this->setup_ap_config_();
 #ifdef USE_CAPTIVE_PORTAL


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

In the scenario wher one does:

```
wifi:
  ap: {}
captive_portal:
ota:
```

There's a security risk:

- First boot Captive portals starts up.
- User connects to Captive Portal and sets credentials.
- Reboot, ESPHome connects to Wifi, all secure.
- ESPHome can't connect to Wifi (poor signal quality, credentials changed etc) at any "random" time in the future.
- Captive portal starts up.
- Any attacker can get 100% control of the device, including uploading a rogue firmware to attack the next network the device connects to.

This is possible, because there's no password set for either `ap` or `ota`, and setting these passwords would be a good mitigation.

There's an alternative to setting passwords however: require physical access to the device to enable the captive portal. There are multiple possibilities here:

- Pressing a button.
- Power off / on X number of times (eg: similar to [what Athom does](https://github.com/athom-tech/athom-configs/blob/main/athom-rgbct-light.yaml)).
- Pressing the reset button (and `on_boot` checks reset cause).

In order for any of these to be possible, it is required to disable `ap_timeout`, but it is not possible ATM. Trying to set it to 2^32 = 4294966296s yields:

```
src/main.cpp: In function 'void setup()':
src/main.cpp:226:34: warning: conversion from 'long long unsigned int' to 'uint32_t' {aka 'long unsigned int'} changes value from '4294966296000' to '4293967296' [-Woverflow]
   wifi_component->set_ap_timeout(4294966296000ULL);
```

This PR pushes a tiny change, to make the semantics of  `ap_timeout: 0s` to mean "never automatically start the AP".

After this PR, this config:

```
wifi:
  ap:
    ap_timeout: 0s
captive_portal:
ota:
```

will be possible, enabling no password to be set, and physical access to the device in order to gain access to it.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

https://github.com/esphome/esphome-docs/pull/3431

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
esphome:
  name: "esphome_ld2410"
  on_boot:
    priority: 600.0
    then:
      - script.execute: fast_boot_factory_reset_script
esp32:
  board: esp32-c3-devkitm-1

globals:
  - id: fast_boot
    type: int
    restore_value: yes
    initial_value: '0'

  - id: factory_reset_boot_count_trigger
    type: int
    initial_value: '3'

logger:

script:
  - id: fast_boot_factory_reset_script
    then:
      - if:
          condition:
            lambda: return ( id(fast_boot) >= id(factory_reset_boot_count_trigger) );
          then:
            - lambda: |-
                ESP_LOGD("Fast Boot Factory Reset", "Performing factotry reset");
                id(fast_boot) = 0;
                fast_boot->loop();
                global_preferences->sync();
            - switch.turn_on: factory_reset_switch
      - lambda: |-
          if(id(fast_boot) > 0)
            ESP_LOGD("Fast Boot Factory Reset", "Quick reboot %d/%d, do it %d more times to factory reset", id(fast_boot), id(factory_reset_boot_count_trigger), id(factory_reset_boot_count_trigger) - id(fast_boot));
          id(fast_boot) += 1;
          fast_boot->loop();
          global_preferences->sync();
      - delay: 10s
      - lambda: |-
          id(fast_boot) = 0;
          fast_boot->loop();
          global_preferences->sync();

wifi:
  id: wifi_component
  ap:
    ap_timeout: 0s
  reboot_timeout: 0s

captive_portal:

switch:
  - platform: factory_reset
    id: factory_reset_switch
    name: "ESPHome: Factory reset"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
