### PR TITLE
Added support for lc709203f component

### DIFF
--- a/esphome/components/lc709203f/__init__.py
+++ b/esphome/components/lc709203f/__init__.py
@@ -1,0 +1,1 @@
+CODEOWNERS = ["@JGAguado"]

--- a/esphome/components/lc709203f/__init__.py
+++ b/esphome/components/lc709203f/__init__.py
@@ -1,1 +1,0 @@
-CODEOWNERS = ["@JGAguado"]

--- a/esphome/components/lc709203f/lc709203f.cpp
+++ b/esphome/components/lc709203f/lc709203f.cpp
@@ -256,7 +256,7 @@ static uint8_t crc8(uint8_t *data, int len) {
 
 // writes a 16-bit word (d) to register pointer regAddress
 // when selecting a register pointer to read from, data = 0
-void LC709203FComponent::write16_(uint8_t reg_address, uint16_t data) {
+void LC709203FComponent::write16(uint8_t reg_address, uint16_t data) {
   // Setup array to hold bytes to send including CRC-8
   uint8_t crc_array[5];
   crc_array[0] = 0x16;
@@ -278,7 +278,7 @@ void LC709203FComponent::write16_(uint8_t reg_address, uint16_t data) {
   Wire.endTransmission();
 }
 
-int16_t LC709203FComponent::read16_(uint8_t reg_address) {
+int16_t LC709203FComponent::read16(uint8_t reg_address) {
   int16_t data = 0;
   Wire.beginTransmission(i2c_address);
   Wire.write(reg_address);

--- a/esphome/components/lc709203f/lc709203f.cpp
+++ b/esphome/components/lc709203f/lc709203f.cpp
@@ -38,7 +38,7 @@ bool LC709203FComponent::begin() {
   set_temperature_mode(LC709203F_TEMPERATURE_THERMISTOR);
 
   set_cell_capacity(LC709203F_APA_2000MAH);     // jbo to suit the battery I am testing with
-  set_cell_profile(L_C709203_NO_M3P7_CHARGE4P2);  // jbo to suit the battery I am testing with
+  set_cell_profile(LC709203_NOM3p7_Charge4p2);  // jbo to suit the battery I am testing with
 
   return true;
 }
@@ -55,7 +55,7 @@ void LC709203FComponent::setup() {
   set_power_mode(LC709203F_POWER_OPERATE);
   set_temperature_mode(LC709203F_TEMPERATURE_THERMISTOR);
   set_cell_capacity(LC709203F_APA_2000MAH);     // jbo to suit the batery I am testing with
-  set_cell_profile(L_C709203_NO_M3P7_CHARGE4P2);  // jbo to suit the batery I am testing with
+  set_cell_profile(LC709203_NOM3p7_Charge4p2);  // jbo to suit the batery I am testing with
 }
 
 /*!
@@ -256,7 +256,7 @@ static uint8_t crc8(uint8_t *data, int len) {
 
 // writes a 16-bit word (d) to register pointer regAddress
 // when selecting a register pointer to read from, data = 0
-void LC709203FComponent::write16_(uint8_t reg_address, uint16_t data) {
+void LC709203FComponent::write16(uint8_t reg_address, uint16_t data) {
   // Setup array to hold bytes to send including CRC-8
   uint8_t crc_array[5];
   crc_array[0] = 0x16;
@@ -278,7 +278,7 @@ void LC709203FComponent::write16_(uint8_t reg_address, uint16_t data) {
   Wire.endTransmission();
 }
 
-int16_t LC709203FComponent::read16_(uint8_t reg_address) {
+int16_t LC709203FComponent::read16(uint8_t reg_address) {
   int16_t data = 0;
   Wire.beginTransmission(i2c_address);
   Wire.write(reg_address);

--- a/esphome/components/lc709203f/lc709203f.cpp
+++ b/esphome/components/lc709203f/lc709203f.cpp
@@ -1,0 +1,351 @@
+/*
+ * File:          lc709203f.cpp
+ * Addapted by:   J.G. Aguado
+ * Date:          30/11/2023
+ * 
+ * Description:
+ * This component adapts (into ESPHome) the I2C Driver for the LC709203F Battery Monitor IC,
+ * based on the library from Daniel deBeer (EzSBC) available at:
+ * https://github.com/EzSBC/ESP32_Bat_Pro from Daniel deBeer (EzSBC)
+ */
+
+#include "esphome/core/log.h"
+
+#include "lc709203f.h"
+#include <Wire.h>
+#include "Arduino.h"
+
+namespace esphome {
+namespace lc709203f {
+
+static const char *TAG = "lc709203f.sensor";
+
+/*!
+ *    @brief  Instantiates a new LC709203F class
+ */
+
+uint8_t i2c_address = LC709203F_I2C_ADDR ;
+
+/*!
+ *    @brief  Sets up the hardware and initializes I2C
+ *    @param  
+ *    @return True if initialization was successful, otherwise false.
+ */
+bool LC709203FComponent::begin( void ) 
+{
+
+  ESP_LOGCONFIG( TAG, "Starting up LC709203F sensor");
+  Wire.begin();
+  setPowerMode(LC709203F_POWER_OPERATE) ;
+  setTemperatureMode(LC709203F_TEMPERATURE_THERMISTOR) ;
+
+  setCellCapacity(LC709203F_APA_2000MAH) ;     // jbo to suit the battery I am testing with
+  setCellProfile( LC709203_NOM3p7_Charge4p2 ); // jbo to suit the battery I am testing with
+  
+  return true;
+}
+
+/*   added update and setup and dump_config for esphome
+ */
+
+/*!
+ *    @brief  Sets up the hardware and battery parameters 
+ */
+void LC709203FComponent::setup() {
+
+  ESP_LOGCONFIG( TAG, "Setting Up  LC709203F sensor");
+  Wire.begin();
+  setPowerMode(LC709203F_POWER_OPERATE) ;
+  setTemperatureMode(LC709203F_TEMPERATURE_THERMISTOR) ;
+  setCellCapacity(LC709203F_APA_2000MAH) ;    // jbo to suit the batery I am testing with
+  setCellProfile( LC709203_NOM3p7_Charge4p2 ); // jbo to suit the batery I am testing with
+
+}
+
+
+/*!
+ *    @brief  for esphome - Collects values when polled
+ */
+void LC709203FComponent::update() {
+
+    uint16_t cuv_mV = cellVoltage_mV();
+    uint16_t rempct = cellRemainingPercent10();
+    uint16_t ic_ver = getICversion();
+    uint16_t celchg = cellStateOfCharge();
+
+    ESP_LOGD(TAG, "Got Battery values: cellVoltage_mV=%d cellRemainingPercent10=%d cellStateOfCharge=%d ic=0x%x", 
+              cuv_mV, 
+              rempct, 
+              celchg, 
+              ic_ver );
+
+    if (this->cellVoltage_ != nullptr) {
+        uint16_t cellVoltage    = cuv_mV;
+        this->cellVoltage_->publish_state(cellVoltage / 1000.0);
+    }
+
+    if (this->cellRemPercent_ != nullptr) {
+        uint16_t cellRemPercent = rempct;
+        this->cellRemPercent_->publish_state(cellRemPercent / 10.0);
+    }
+
+    if (this->icversion_ != nullptr) {
+        uint16_t icversion      = ic_ver;
+        this->icversion_->publish_state(icversion);
+    }
+
+    if (this->cellCharge_ != nullptr) {
+        uint16_t cellStateOfCharge      = celchg;
+        this->cellCharge_->publish_state(cellStateOfCharge );
+    }
+
+}
+
+
+/*!
+ *    @brief  for esphome - occurs at boot
+ */
+void LC709203FComponent::dump_config() {
+  ESP_LOGCONFIG(TAG, "LC709203F:");
+  LOG_I2C_DEVICE(this);
+
+  if (this->is_failed()) {
+    ESP_LOGE(TAG, "Communication with LC709203F failed!");
+    return;
+  }
+  LOG_UPDATE_INTERVAL(this);
+
+  LOG_SENSOR("  ", "Cell Voltage", this->cellVoltage_ );
+  LOG_SENSOR("  ", "Cell Rem Pct", this->cellRemPercent_);
+  LOG_SENSOR("  ", "Cell StateCharge", this->cellCharge_);
+  LOG_SENSOR("  ", "IC version", this->icversion_);
+}
+
+
+
+/*!
+ *    @brief  Get IC version
+ *    @return 16-bit value read from LC709203F_RO_ICVERSION registers
+ */
+uint16_t LC709203FComponent::getICversion(void) 
+{
+  uint16_t vers = 0;
+  vers = read16(LC709203F_RO_ICVERSION);
+  return vers;
+}
+
+
+/*!
+ *    @brief  Initialize the RSOC algorithm
+ *    @return
+ */
+void LC709203FComponent::initRSOC(void) 
+{
+  write16(LC709203F_WO_INITRSOC, 0xAA55);
+}
+
+
+/*!
+ *    @brief  Get battery voltage
+ *    @return Cell voltage in milliVolt
+ */
+uint16_t LC709203FComponent::cellVoltage_mV(void) 
+{
+  uint16_t mV = 0;
+  mV = read16(LC709203F_RO_CELLVOLTAGE);
+  return 1000 * ( mV / 1000.0 ) ;
+}
+
+
+/*!
+ *    @brief  Get cell remaining charge in percent (0-100%)
+ *    @return point value from 0 to 1000
+ */
+uint16_t LC709203FComponent::cellRemainingPercent10(void) 
+{
+  uint16_t percent = 0;
+  percent = read16(LC709203F_RO_ITE );
+  return percent ;
+}
+
+/*!
+ *    @brief  Get battery state of charge in percent (0-100%)
+ *    @return point value from 0 to 100
+ */
+uint16_t LC709203FComponent::cellStateOfCharge(void)
+{
+  uint16_t percent = 0;
+  percent = read16(LC709203F_RW_RSOC );
+  return percent ;
+}
+
+
+/*!
+ *    @brief  Get battery thermistor temperature
+ *    @return value from -20 to 60 *C  // CdB Needs testing, no thermistor on ESP32_Bat_R2 board
+ */
+uint16_t LC709203FComponent::getCellTemperature(void) 
+{
+  uint16_t temp = 0;
+  temp = read16(LC709203F_RW_CELLTEMPERATURE );
+  return temp ;
+}
+
+
+/*!
+ *    @brief  Set the temperature mode (external or internal)
+ *    @param t The desired mode: LC709203F_TEMPERATURE_I2C or
+ * LC709203F_TEMPERATURE_THERMISTOR
+ */
+void LC709203FComponent::setTemperatureMode(lc709203_tempmode_t t) 
+{
+  return write16(LC709203F_RW_STATUSBIT, (uint16_t)t);
+}
+
+
+/*!
+ *    @brief  Set the cell capacity, 
+ *    @param apa The lc709203_adjustment_t enumerated approximate cell capacity
+ */
+void LC709203FComponent::setCellCapacity(lc709203_adjustment_t apa) 
+{
+  write16(LC709203F_RW_APA, (uint16_t)apa);
+}
+
+
+/*!
+ *    @brief  Set the alarm pin to respond to an RSOC percentage level
+ *    @param percent The threshold value, set to 0 to disable alarm
+ */
+void LC709203FComponent::setAlarmRSOC(uint8_t percent) 
+{
+  write16(LC709203F_RW_ALARMRSOC, percent);
+}
+
+
+/*!
+ *    @brief  Set the alarm pin to respond to a battery voltage level
+ *    @param voltage The threshold value, set to 0 to disable alarm
+ */
+void LC709203FComponent::setAlarmVoltage(float voltage) 
+{
+  write16(LC709203F_RW_ALARMVOLT, voltage * 1000);
+}
+
+
+/*!
+ *    @brief  Set the power mode, LC709203F_POWER_OPERATE or
+ *            LC709203F_POWER_SLEEP
+ *    @param t The power mode desired
+ *    @return 
+ */
+void LC709203FComponent::setPowerMode(lc709203_powermode_t t) 
+{
+  write16(LC709203F_RW_POWERMODE, (uint16_t)t);
+}
+
+/*!
+ *    @brief  Set cell type 
+ *    @param t The profile, Table 8.  Normally 1 for 3.7 nominal 4.2V Full carge cells
+ *    @return
+ */
+void LC709203FComponent::setCellProfile(lc709203_cell_profile_t t) 
+{
+  write16(LC709203F_RW_PROFILE, (uint16_t)t);
+}
+
+/*!
+ *    @brief  Get the thermistor Beta value //For completeness since we have to write it.
+ *    @return The uint16_t Beta value
+ */
+uint16_t LC709203FComponent::getThermistorBeta(void) 
+{
+  uint16_t val = 0;
+  val = read16(LC709203F_RW_THERMISTORB);
+  return val;
+}
+
+
+/*!
+ *    @brief  Set the thermistor Beta value
+ *    @param b The value to set it to
+ *    @return 
+ */
+void LC709203FComponent::setThermistorB(uint16_t beta) 
+{
+  write16(LC709203F_RW_THERMISTORB, beta);
+}
+
+
+//
+// -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+//
+/*
+    INTERNAL I2C FUNCTIONS and CRC CALCULATION
+*/
+
+
+/**
+ * Performs a CRC8 calculation on the supplied values.
+ *
+ * @param data  Pointer to the data to use when calculating the CRC8.
+ * @param len   The number of bytes in 'data'.
+ *
+ * @return The computed CRC8 value.
+ */
+static uint8_t crc8(uint8_t *data, int len) 
+{
+  const uint8_t POLYNOMIAL(0x07);
+  uint8_t crc(0x00);
+
+  for (int j = len; j; --j) {
+    crc ^= *data++;
+
+    for (int i = 8; i; --i) {
+      crc = (crc & 0x80) ? (crc << 1) ^ POLYNOMIAL : (crc << 1);
+    }
+  }
+  return crc;
+}
+
+
+// writes a 16-bit word (d) to register pointer regAddress
+// when selecting a register pointer to read from, data = 0
+void LC709203FComponent::write16(uint8_t regAddress, uint16_t data)
+{
+  // Setup array to hold bytes to send including CRC-8
+  uint8_t crcArray[5];
+  crcArray[0] = 0x16;
+  crcArray[1] = regAddress;
+  crcArray[2] = lowByte(data);
+  crcArray[3] = highByte(data);
+  // Calculate crc of preceding four bytes and place in crcArray[4]
+  crcArray[4] = crc8( crcArray, 4 );
+  // Device address
+  Wire.beginTransmission(i2c_address);
+  // Register address
+  Wire.write(regAddress);
+  // low byte
+  Wire.write(crcArray[2]);
+  // high byte
+  Wire.write(crcArray[3]);
+  // Send crc8 
+  Wire.write(crcArray[4]);
+  Wire.endTransmission();
+}
+
+int16_t LC709203FComponent::read16( uint8_t regAddress)
+{
+  int16_t data = 0;
+  Wire.beginTransmission(i2c_address);
+  Wire.write(regAddress);
+  Wire.endTransmission(false);
+  Wire.requestFrom(i2c_address, (uint8_t)  2);   // jbo added per WEMOS_SHT3x_Arduino_Library issue 7
+  uint8_t lowByteData = Wire.read();
+  uint8_t highByteData = Wire.read();
+  data = word(highByteData, lowByteData);
+  return( data );
+}
+
+}
+}

--- a/esphome/components/lc709203f/lc709203f.cpp
+++ b/esphome/components/lc709203f/lc709203f.cpp
@@ -261,8 +261,8 @@ void LC709203FComponent::write16(uint8_t regAddress, uint16_t data) {
   uint8_t crcArray[5];
   crcArray[0] = 0x16;
   crcArray[1] = regAddress;
-  crcArray[2] = lowByte(data);
-  crcArray[3] = highByte(data);
+  crcArray[2] = static_cast<uint8_t>(data & 0xFF);       // Extract low byte
+  crcArray[3] = static_cast<uint8_t>((data >> 8) & 0xFF); // Extract high byte
   // Calculate crc of preceding four bytes and place in crcArray[4]
   crcArray[4] = crc8(crcArray, 4);
   // Device address

--- a/esphome/components/lc709203f/lc709203f.cpp
+++ b/esphome/components/lc709203f/lc709203f.cpp
@@ -38,7 +38,7 @@ bool LC709203FComponent::begin() {
   set_temperature_mode(LC709203F_TEMPERATURE_THERMISTOR);
 
   set_cell_capacity(LC709203F_APA_2000MAH);     // jbo to suit the battery I am testing with
-  set_cell_profile(LC709203_NOM3p7_Charge4p2);  // jbo to suit the battery I am testing with
+  set_cell_profile(L_C709203_NO_M3P7_CHARGE4P2);  // jbo to suit the battery I am testing with
 
   return true;
 }
@@ -55,7 +55,7 @@ void LC709203FComponent::setup() {
   set_power_mode(LC709203F_POWER_OPERATE);
   set_temperature_mode(LC709203F_TEMPERATURE_THERMISTOR);
   set_cell_capacity(LC709203F_APA_2000MAH);     // jbo to suit the batery I am testing with
-  set_cell_profile(LC709203_NOM3p7_Charge4p2);  // jbo to suit the batery I am testing with
+  set_cell_profile(L_C709203_NO_M3P7_CHARGE4P2);  // jbo to suit the batery I am testing with
 }
 
 /*!
@@ -256,7 +256,7 @@ static uint8_t crc8(uint8_t *data, int len) {
 
 // writes a 16-bit word (d) to register pointer regAddress
 // when selecting a register pointer to read from, data = 0
-void LC709203FComponent::write16(uint8_t reg_address, uint16_t data) {
+void LC709203FComponent::write16_(uint8_t reg_address, uint16_t data) {
   // Setup array to hold bytes to send including CRC-8
   uint8_t crc_array[5];
   crc_array[0] = 0x16;
@@ -278,7 +278,7 @@ void LC709203FComponent::write16(uint8_t reg_address, uint16_t data) {
   Wire.endTransmission();
 }
 
-int16_t LC709203FComponent::read16(uint8_t reg_address) {
+int16_t LC709203FComponent::read16_(uint8_t reg_address) {
   int16_t data = 0;
   Wire.beginTransmission(i2c_address);
   Wire.write(reg_address);

--- a/esphome/components/lc709203f/lc709203f.cpp
+++ b/esphome/components/lc709203f/lc709203f.cpp
@@ -261,8 +261,8 @@ void LC709203FComponent::write16(uint8_t regAddress, uint16_t data) {
   uint8_t crcArray[5];
   crcArray[0] = 0x16;
   crcArray[1] = regAddress;
-  crcArray[2] = static_cast<uint8_t>(data & 0xFF);       // Extract low byte
-  crcArray[3] = static_cast<uint8_t>((data >> 8) & 0xFF); // Extract high byte
+  crcArray[2] = static_cast<uint8_t>(data & 0xFF);         // Extract low byte
+  crcArray[3] = static_cast<uint8_t>((data >> 8) & 0xFF);  // Extract high byte
   // Calculate crc of preceding four bytes and place in crcArray[4]
   crcArray[4] = crc8(crcArray, 4);
   // Device address

--- a/esphome/components/lc709203f/lc709203f.cpp
+++ b/esphome/components/lc709203f/lc709203f.cpp
@@ -31,14 +31,14 @@ uint8_t i2c_address = LC709203F_I2C_ADDR;
  *    @param
  *    @return True if initialization was successful, otherwise false.
  */
-bool LC709203FComponent::begin(void) {
+bool LC709203FComponent::begin() {
   ESP_LOGCONFIG(TAG, "Starting up LC709203F sensor");
   Wire.begin();
-  setPowerMode(LC709203F_POWER_OPERATE);
-  setTemperatureMode(LC709203F_TEMPERATURE_THERMISTOR);
+  set_power_mode(LC709203F_POWER_OPERATE);
+  set_temperature_mode(LC709203F_TEMPERATURE_THERMISTOR);
 
-  setCellCapacity(LC709203F_APA_2000MAH);     // jbo to suit the battery I am testing with
-  setCellProfile(LC709203_NOM3p7_Charge4p2);  // jbo to suit the battery I am testing with
+  set_cell_capacity(LC709203F_APA_2000MAH);     // jbo to suit the battery I am testing with
+  set_cell_profile(LC709203_NOM3p7_Charge4p2);  // jbo to suit the battery I am testing with
 
   return true;
 }
@@ -52,32 +52,32 @@ bool LC709203FComponent::begin(void) {
 void LC709203FComponent::setup() {
   ESP_LOGCONFIG(TAG, "Setting Up  LC709203F sensor");
   Wire.begin();
-  setPowerMode(LC709203F_POWER_OPERATE);
-  setTemperatureMode(LC709203F_TEMPERATURE_THERMISTOR);
-  setCellCapacity(LC709203F_APA_2000MAH);     // jbo to suit the batery I am testing with
-  setCellProfile(LC709203_NOM3p7_Charge4p2);  // jbo to suit the batery I am testing with
+  set_power_mode(LC709203F_POWER_OPERATE);
+  set_temperature_mode(LC709203F_TEMPERATURE_THERMISTOR);
+  set_cell_capacity(LC709203F_APA_2000MAH);     // jbo to suit the batery I am testing with
+  set_cell_profile(LC709203_NOM3p7_Charge4p2);  // jbo to suit the batery I am testing with
 }
 
 /*!
  *    @brief  for esphome - Collects values when polled
  */
 void LC709203FComponent::update() {
-  uint16_t cuv_mV = cellVoltage_mV();
-  uint16_t rempct = cellRemainingPercent10();
-  uint16_t ic_ver = getICversion();
-  uint16_t celchg = cellStateOfCharge();
+  uint16_t cuv_m_v = cell_voltage_m_v();
+  uint16_t rempct = cell_remaining_percent10();
+  uint16_t ic_ver = get_i_cversion();
+  uint16_t celchg = cell_state_of_charge();
 
-  ESP_LOGD(TAG, "Got Battery values: cellVoltage_mV=%d cellRemainingPercent10=%d cellStateOfCharge=%d ic=0x%x", cuv_mV,
+  ESP_LOGD(TAG, "Got Battery values: cellVoltage_mV=%d cellRemainingPercent10=%d cellStateOfCharge=%d ic=0x%x", cuv_m_v,
            rempct, celchg, ic_ver);
 
-  if (this->cellVoltage_ != nullptr) {
-    uint16_t cellVoltage = cuv_mV;
-    this->cellVoltage_->publish_state(cellVoltage / 1000.0);
+  if (this->cell_voltage_ != nullptr) {
+    uint16_t cell_voltage = cuv_m_v;
+    this->cell_voltage_->publish_state(cell_voltage / 1000.0);
   }
 
-  if (this->cellRemPercent_ != nullptr) {
-    uint16_t cellRemPercent = rempct;
-    this->cellRemPercent_->publish_state(cellRemPercent / 10.0);
+  if (this->cell_rem_percent_ != nullptr) {
+    uint16_t cell_rem_percent = rempct;
+    this->cell_rem_percent_->publish_state(cell_rem_percent / 10.0);
   }
 
   if (this->icversion_ != nullptr) {
@@ -85,9 +85,9 @@ void LC709203FComponent::update() {
     this->icversion_->publish_state(icversion);
   }
 
-  if (this->cellCharge_ != nullptr) {
-    uint16_t cellStateOfCharge = celchg;
-    this->cellCharge_->publish_state(cellStateOfCharge);
+  if (this->cell_charge_ != nullptr) {
+    uint16_t cell_state_of_charge = celchg;
+    this->cell_charge_->publish_state(cell_state_of_charge);
   }
 }
 
@@ -104,9 +104,9 @@ void LC709203FComponent::dump_config() {
   }
   LOG_UPDATE_INTERVAL(this);
 
-  LOG_SENSOR("  ", "Cell Voltage", this->cellVoltage_);
-  LOG_SENSOR("  ", "Cell Rem Pct", this->cellRemPercent_);
-  LOG_SENSOR("  ", "Cell StateCharge", this->cellCharge_);
+  LOG_SENSOR("  ", "Cell Voltage", this->cell_voltage_);
+  LOG_SENSOR("  ", "Cell Rem Pct", this->cell_rem_percent_);
+  LOG_SENSOR("  ", "Cell StateCharge", this->cell_charge_);
   LOG_SENSOR("  ", "IC version", this->icversion_);
 }
 
@@ -114,9 +114,9 @@ void LC709203FComponent::dump_config() {
  *    @brief  Get IC version
  *    @return 16-bit value read from LC709203F_RO_ICVERSION registers
  */
-uint16_t LC709203FComponent::getICversion(void) {
+uint16_t LC709203FComponent::get_i_cversion() {
   uint16_t vers = 0;
-  vers = read16(LC709203F_RO_ICVERSION);
+  vers = read16_(LC709203F_RO_ICVERSION);
   return vers;
 }
 
@@ -124,25 +124,25 @@ uint16_t LC709203FComponent::getICversion(void) {
  *    @brief  Initialize the RSOC algorithm
  *    @return
  */
-void LC709203FComponent::initRSOC(void) { write16(LC709203F_WO_INITRSOC, 0xAA55); }
+void LC709203FComponent::init_rsoc() { write16_(LC709203F_WO_INITRSOC, 0xAA55); }
 
 /*!
  *    @brief  Get battery voltage
  *    @return Cell voltage in milliVolt
  */
-uint16_t LC709203FComponent::cellVoltage_mV(void) {
-  uint16_t mV = 0;
-  mV = read16(LC709203F_RO_CELLVOLTAGE);
-  return 1000 * (mV / 1000.0);
+uint16_t LC709203FComponent::cell_voltage_m_v() {
+  uint16_t m_v = 0;
+  m_v = read16_(LC709203F_RO_CELLVOLTAGE);
+  return 1000 * (m_v / 1000.0);
 }
 
 /*!
  *    @brief  Get cell remaining charge in percent (0-100%)
  *    @return point value from 0 to 1000
  */
-uint16_t LC709203FComponent::cellRemainingPercent10(void) {
+uint16_t LC709203FComponent::cell_remaining_percent10() {
   uint16_t percent = 0;
-  percent = read16(LC709203F_RO_ITE);
+  percent = read16_(LC709203F_RO_ITE);
   return percent;
 }
 
@@ -150,9 +150,9 @@ uint16_t LC709203FComponent::cellRemainingPercent10(void) {
  *    @brief  Get battery state of charge in percent (0-100%)
  *    @return point value from 0 to 100
  */
-uint16_t LC709203FComponent::cellStateOfCharge(void) {
+uint16_t LC709203FComponent::cell_state_of_charge() {
   uint16_t percent = 0;
-  percent = read16(LC709203F_RW_RSOC);
+  percent = read16_(LC709203F_RW_RSOC);
   return percent;
 }
 
@@ -160,9 +160,9 @@ uint16_t LC709203FComponent::cellStateOfCharge(void) {
  *    @brief  Get battery thermistor temperature
  *    @return value from -20 to 60 *C  // CdB Needs testing, no thermistor on ESP32_Bat_R2 board
  */
-uint16_t LC709203FComponent::getCellTemperature(void) {
+uint16_t LC709203FComponent::get_cell_temperature() {
   uint16_t temp = 0;
-  temp = read16(LC709203F_RW_CELLTEMPERATURE);
+  temp = read16_(LC709203F_RW_CELLTEMPERATURE);
   return temp;
 }
 
@@ -171,27 +171,27 @@ uint16_t LC709203FComponent::getCellTemperature(void) {
  *    @param t The desired mode: LC709203F_TEMPERATURE_I2C or
  * LC709203F_TEMPERATURE_THERMISTOR
  */
-void LC709203FComponent::setTemperatureMode(lc709203_tempmode_t t) {
-  return write16(LC709203F_RW_STATUSBIT, (uint16_t) t);
+void LC709203FComponent::set_temperature_mode(lc709203_tempmode_t t) {
+  return write16_(LC709203F_RW_STATUSBIT, (uint16_t) t);
 }
 
 /*!
  *    @brief  Set the cell capacity,
  *    @param apa The lc709203_adjustment_t enumerated approximate cell capacity
  */
-void LC709203FComponent::setCellCapacity(lc709203_adjustment_t apa) { write16(LC709203F_RW_APA, (uint16_t) apa); }
+void LC709203FComponent::set_cell_capacity(lc709203_adjustment_t apa) { write16_(LC709203F_RW_APA, (uint16_t) apa); }
 
 /*!
  *    @brief  Set the alarm pin to respond to an RSOC percentage level
  *    @param percent The threshold value, set to 0 to disable alarm
  */
-void LC709203FComponent::setAlarmRSOC(uint8_t percent) { write16(LC709203F_RW_ALARMRSOC, percent); }
+void LC709203FComponent::set_alarm_rsoc(uint8_t percent) { write16_(LC709203F_RW_ALARMRSOC, percent); }
 
 /*!
  *    @brief  Set the alarm pin to respond to a battery voltage level
  *    @param voltage The threshold value, set to 0 to disable alarm
  */
-void LC709203FComponent::setAlarmVoltage(float voltage) { write16(LC709203F_RW_ALARMVOLT, voltage * 1000); }
+void LC709203FComponent::set_alarm_voltage(float voltage) { write16_(LC709203F_RW_ALARMVOLT, voltage * 1000); }
 
 /*!
  *    @brief  Set the power mode, LC709203F_POWER_OPERATE or
@@ -199,22 +199,22 @@ void LC709203FComponent::setAlarmVoltage(float voltage) { write16(LC709203F_RW_A
  *    @param t The power mode desired
  *    @return
  */
-void LC709203FComponent::setPowerMode(lc709203_powermode_t t) { write16(LC709203F_RW_POWERMODE, (uint16_t) t); }
+void LC709203FComponent::set_power_mode(lc709203_powermode_t t) { write16_(LC709203F_RW_POWERMODE, (uint16_t) t); }
 
 /*!
  *    @brief  Set cell type
  *    @param t The profile, Table 8.  Normally 1 for 3.7 nominal 4.2V Full carge cells
  *    @return
  */
-void LC709203FComponent::setCellProfile(lc709203_cell_profile_t t) { write16(LC709203F_RW_PROFILE, (uint16_t) t); }
+void LC709203FComponent::set_cell_profile(lc709203_cell_profile_t t) { write16_(LC709203F_RW_PROFILE, (uint16_t) t); }
 
 /*!
  *    @brief  Get the thermistor Beta value //For completeness since we have to write it.
  *    @return The uint16_t Beta value
  */
-uint16_t LC709203FComponent::getThermistorBeta(void) {
+uint16_t LC709203FComponent::get_thermistor_beta() {
   uint16_t val = 0;
-  val = read16(LC709203F_RW_THERMISTORB);
+  val = read16_(LC709203F_RW_THERMISTORB);
   return val;
 }
 
@@ -223,7 +223,7 @@ uint16_t LC709203FComponent::getThermistorBeta(void) {
  *    @param b The value to set it to
  *    @return
  */
-void LC709203FComponent::setThermistorB(uint16_t beta) { write16(LC709203F_RW_THERMISTORB, beta); }
+void LC709203FComponent::set_thermistor_b(uint16_t beta) { write16_(LC709203F_RW_THERMISTORB, beta); }
 
 //
 // -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
@@ -241,14 +241,14 @@ void LC709203FComponent::setThermistorB(uint16_t beta) { write16(LC709203F_RW_TH
  * @return The computed CRC8 value.
  */
 static uint8_t crc8(uint8_t *data, int len) {
-  const uint8_t POLYNOMIAL(0x07);
+  const uint8_t polynomial(0x07);
   uint8_t crc(0x00);
 
   for (int j = len; j; --j) {
     crc ^= *data++;
 
     for (int i = 8; i; --i) {
-      crc = (crc & 0x80) ? (crc << 1) ^ POLYNOMIAL : (crc << 1);
+      crc = (crc & 0x80) ? (crc << 1) ^ polynomial : (crc << 1);
     }
   }
   return crc;
@@ -256,37 +256,37 @@ static uint8_t crc8(uint8_t *data, int len) {
 
 // writes a 16-bit word (d) to register pointer regAddress
 // when selecting a register pointer to read from, data = 0
-void LC709203FComponent::write16(uint8_t regAddress, uint16_t data) {
+void LC709203FComponent::write16_(uint8_t reg_address, uint16_t data) {
   // Setup array to hold bytes to send including CRC-8
-  uint8_t crcArray[5];
-  crcArray[0] = 0x16;
-  crcArray[1] = regAddress;
-  crcArray[2] = static_cast<uint8_t>(data & 0xFF);         // Extract low byte
-  crcArray[3] = static_cast<uint8_t>((data >> 8) & 0xFF);  // Extract high byte
+  uint8_t crc_array[5];
+  crc_array[0] = 0x16;
+  crc_array[1] = reg_address;
+  crc_array[2] = static_cast<uint8_t>(data & 0xFF);         // Extract low byte
+  crc_array[3] = static_cast<uint8_t>((data >> 8) & 0xFF);  // Extract high byte
   // Calculate crc of preceding four bytes and place in crcArray[4]
-  crcArray[4] = crc8(crcArray, 4);
+  crc_array[4] = crc8(crc_array, 4);
   // Device address
   Wire.beginTransmission(i2c_address);
   // Register address
-  Wire.write(regAddress);
+  Wire.write(reg_address);
   // low byte
-  Wire.write(crcArray[2]);
+  Wire.write(crc_array[2]);
   // high byte
-  Wire.write(crcArray[3]);
+  Wire.write(crc_array[3]);
   // Send crc8
-  Wire.write(crcArray[4]);
+  Wire.write(crc_array[4]);
   Wire.endTransmission();
 }
 
-int16_t LC709203FComponent::read16(uint8_t regAddress) {
+int16_t LC709203FComponent::read16_(uint8_t reg_address) {
   int16_t data = 0;
   Wire.beginTransmission(i2c_address);
-  Wire.write(regAddress);
+  Wire.write(reg_address);
   Wire.endTransmission(false);
   Wire.requestFrom(i2c_address, (uint8_t) 2);  // jbo added per WEMOS_SHT3x_Arduino_Library issue 7
-  uint8_t lowByteData = Wire.read();
-  uint8_t highByteData = Wire.read();
-  data = word(highByteData, lowByteData);
+  uint8_t low_byte_data = Wire.read();
+  uint8_t high_byte_data = Wire.read();
+  data = word(high_byte_data, low_byte_data);
   return (data);
 }
 

--- a/esphome/components/lc709203f/lc709203f.cpp
+++ b/esphome/components/lc709203f/lc709203f.cpp
@@ -2,7 +2,7 @@
  * File:          lc709203f.cpp
  * Addapted by:   J.G. Aguado
  * Date:          30/11/2023
- * 
+ *
  * Description:
  * This component adapts (into ESPHome) the I2C Driver for the LC709203F Battery Monitor IC,
  * based on the library from Daniel deBeer (EzSBC) available at:
@@ -24,24 +24,22 @@ static const char *TAG = "lc709203f.sensor";
  *    @brief  Instantiates a new LC709203F class
  */
 
-uint8_t i2c_address = LC709203F_I2C_ADDR ;
+uint8_t i2c_address = LC709203F_I2C_ADDR;
 
 /*!
  *    @brief  Sets up the hardware and initializes I2C
- *    @param  
+ *    @param
  *    @return True if initialization was successful, otherwise false.
  */
-bool LC709203FComponent::begin( void ) 
-{
-
-  ESP_LOGCONFIG( TAG, "Starting up LC709203F sensor");
+bool LC709203FComponent::begin(void) {
+  ESP_LOGCONFIG(TAG, "Starting up LC709203F sensor");
   Wire.begin();
-  setPowerMode(LC709203F_POWER_OPERATE) ;
-  setTemperatureMode(LC709203F_TEMPERATURE_THERMISTOR) ;
+  setPowerMode(LC709203F_POWER_OPERATE);
+  setTemperatureMode(LC709203F_TEMPERATURE_THERMISTOR);
 
-  setCellCapacity(LC709203F_APA_2000MAH) ;     // jbo to suit the battery I am testing with
-  setCellProfile( LC709203_NOM3p7_Charge4p2 ); // jbo to suit the battery I am testing with
-  
+  setCellCapacity(LC709203F_APA_2000MAH);     // jbo to suit the battery I am testing with
+  setCellProfile(LC709203_NOM3p7_Charge4p2);  // jbo to suit the battery I am testing with
+
   return true;
 }
 
@@ -49,58 +47,49 @@ bool LC709203FComponent::begin( void )
  */
 
 /*!
- *    @brief  Sets up the hardware and battery parameters 
+ *    @brief  Sets up the hardware and battery parameters
  */
 void LC709203FComponent::setup() {
-
-  ESP_LOGCONFIG( TAG, "Setting Up  LC709203F sensor");
+  ESP_LOGCONFIG(TAG, "Setting Up  LC709203F sensor");
   Wire.begin();
-  setPowerMode(LC709203F_POWER_OPERATE) ;
-  setTemperatureMode(LC709203F_TEMPERATURE_THERMISTOR) ;
-  setCellCapacity(LC709203F_APA_2000MAH) ;    // jbo to suit the batery I am testing with
-  setCellProfile( LC709203_NOM3p7_Charge4p2 ); // jbo to suit the batery I am testing with
-
+  setPowerMode(LC709203F_POWER_OPERATE);
+  setTemperatureMode(LC709203F_TEMPERATURE_THERMISTOR);
+  setCellCapacity(LC709203F_APA_2000MAH);     // jbo to suit the batery I am testing with
+  setCellProfile(LC709203_NOM3p7_Charge4p2);  // jbo to suit the batery I am testing with
 }
-
 
 /*!
  *    @brief  for esphome - Collects values when polled
  */
 void LC709203FComponent::update() {
+  uint16_t cuv_mV = cellVoltage_mV();
+  uint16_t rempct = cellRemainingPercent10();
+  uint16_t ic_ver = getICversion();
+  uint16_t celchg = cellStateOfCharge();
 
-    uint16_t cuv_mV = cellVoltage_mV();
-    uint16_t rempct = cellRemainingPercent10();
-    uint16_t ic_ver = getICversion();
-    uint16_t celchg = cellStateOfCharge();
+  ESP_LOGD(TAG, "Got Battery values: cellVoltage_mV=%d cellRemainingPercent10=%d cellStateOfCharge=%d ic=0x%x", cuv_mV,
+           rempct, celchg, ic_ver);
 
-    ESP_LOGD(TAG, "Got Battery values: cellVoltage_mV=%d cellRemainingPercent10=%d cellStateOfCharge=%d ic=0x%x", 
-              cuv_mV, 
-              rempct, 
-              celchg, 
-              ic_ver );
+  if (this->cellVoltage_ != nullptr) {
+    uint16_t cellVoltage = cuv_mV;
+    this->cellVoltage_->publish_state(cellVoltage / 1000.0);
+  }
 
-    if (this->cellVoltage_ != nullptr) {
-        uint16_t cellVoltage    = cuv_mV;
-        this->cellVoltage_->publish_state(cellVoltage / 1000.0);
-    }
+  if (this->cellRemPercent_ != nullptr) {
+    uint16_t cellRemPercent = rempct;
+    this->cellRemPercent_->publish_state(cellRemPercent / 10.0);
+  }
 
-    if (this->cellRemPercent_ != nullptr) {
-        uint16_t cellRemPercent = rempct;
-        this->cellRemPercent_->publish_state(cellRemPercent / 10.0);
-    }
+  if (this->icversion_ != nullptr) {
+    uint16_t icversion = ic_ver;
+    this->icversion_->publish_state(icversion);
+  }
 
-    if (this->icversion_ != nullptr) {
-        uint16_t icversion      = ic_ver;
-        this->icversion_->publish_state(icversion);
-    }
-
-    if (this->cellCharge_ != nullptr) {
-        uint16_t cellStateOfCharge      = celchg;
-        this->cellCharge_->publish_state(cellStateOfCharge );
-    }
-
+  if (this->cellCharge_ != nullptr) {
+    uint16_t cellStateOfCharge = celchg;
+    this->cellCharge_->publish_state(cellStateOfCharge);
+  }
 }
-
 
 /*!
  *    @brief  for esphome - occurs at boot
@@ -115,167 +104,126 @@ void LC709203FComponent::dump_config() {
   }
   LOG_UPDATE_INTERVAL(this);
 
-  LOG_SENSOR("  ", "Cell Voltage", this->cellVoltage_ );
+  LOG_SENSOR("  ", "Cell Voltage", this->cellVoltage_);
   LOG_SENSOR("  ", "Cell Rem Pct", this->cellRemPercent_);
   LOG_SENSOR("  ", "Cell StateCharge", this->cellCharge_);
   LOG_SENSOR("  ", "IC version", this->icversion_);
 }
 
-
-
 /*!
  *    @brief  Get IC version
  *    @return 16-bit value read from LC709203F_RO_ICVERSION registers
  */
-uint16_t LC709203FComponent::getICversion(void) 
-{
+uint16_t LC709203FComponent::getICversion(void) {
   uint16_t vers = 0;
   vers = read16(LC709203F_RO_ICVERSION);
   return vers;
 }
 
-
 /*!
  *    @brief  Initialize the RSOC algorithm
  *    @return
  */
-void LC709203FComponent::initRSOC(void) 
-{
-  write16(LC709203F_WO_INITRSOC, 0xAA55);
-}
-
+void LC709203FComponent::initRSOC(void) { write16(LC709203F_WO_INITRSOC, 0xAA55); }
 
 /*!
  *    @brief  Get battery voltage
  *    @return Cell voltage in milliVolt
  */
-uint16_t LC709203FComponent::cellVoltage_mV(void) 
-{
+uint16_t LC709203FComponent::cellVoltage_mV(void) {
   uint16_t mV = 0;
   mV = read16(LC709203F_RO_CELLVOLTAGE);
-  return 1000 * ( mV / 1000.0 ) ;
+  return 1000 * (mV / 1000.0);
 }
-
 
 /*!
  *    @brief  Get cell remaining charge in percent (0-100%)
  *    @return point value from 0 to 1000
  */
-uint16_t LC709203FComponent::cellRemainingPercent10(void) 
-{
+uint16_t LC709203FComponent::cellRemainingPercent10(void) {
   uint16_t percent = 0;
-  percent = read16(LC709203F_RO_ITE );
-  return percent ;
+  percent = read16(LC709203F_RO_ITE);
+  return percent;
 }
 
 /*!
  *    @brief  Get battery state of charge in percent (0-100%)
  *    @return point value from 0 to 100
  */
-uint16_t LC709203FComponent::cellStateOfCharge(void)
-{
+uint16_t LC709203FComponent::cellStateOfCharge(void) {
   uint16_t percent = 0;
-  percent = read16(LC709203F_RW_RSOC );
-  return percent ;
+  percent = read16(LC709203F_RW_RSOC);
+  return percent;
 }
-
 
 /*!
  *    @brief  Get battery thermistor temperature
  *    @return value from -20 to 60 *C  // CdB Needs testing, no thermistor on ESP32_Bat_R2 board
  */
-uint16_t LC709203FComponent::getCellTemperature(void) 
-{
+uint16_t LC709203FComponent::getCellTemperature(void) {
   uint16_t temp = 0;
-  temp = read16(LC709203F_RW_CELLTEMPERATURE );
-  return temp ;
+  temp = read16(LC709203F_RW_CELLTEMPERATURE);
+  return temp;
 }
-
 
 /*!
  *    @brief  Set the temperature mode (external or internal)
  *    @param t The desired mode: LC709203F_TEMPERATURE_I2C or
  * LC709203F_TEMPERATURE_THERMISTOR
  */
-void LC709203FComponent::setTemperatureMode(lc709203_tempmode_t t) 
-{
-  return write16(LC709203F_RW_STATUSBIT, (uint16_t)t);
+void LC709203FComponent::setTemperatureMode(lc709203_tempmode_t t) {
+  return write16(LC709203F_RW_STATUSBIT, (uint16_t) t);
 }
-
 
 /*!
- *    @brief  Set the cell capacity, 
+ *    @brief  Set the cell capacity,
  *    @param apa The lc709203_adjustment_t enumerated approximate cell capacity
  */
-void LC709203FComponent::setCellCapacity(lc709203_adjustment_t apa) 
-{
-  write16(LC709203F_RW_APA, (uint16_t)apa);
-}
-
+void LC709203FComponent::setCellCapacity(lc709203_adjustment_t apa) { write16(LC709203F_RW_APA, (uint16_t) apa); }
 
 /*!
  *    @brief  Set the alarm pin to respond to an RSOC percentage level
  *    @param percent The threshold value, set to 0 to disable alarm
  */
-void LC709203FComponent::setAlarmRSOC(uint8_t percent) 
-{
-  write16(LC709203F_RW_ALARMRSOC, percent);
-}
-
+void LC709203FComponent::setAlarmRSOC(uint8_t percent) { write16(LC709203F_RW_ALARMRSOC, percent); }
 
 /*!
  *    @brief  Set the alarm pin to respond to a battery voltage level
  *    @param voltage The threshold value, set to 0 to disable alarm
  */
-void LC709203FComponent::setAlarmVoltage(float voltage) 
-{
-  write16(LC709203F_RW_ALARMVOLT, voltage * 1000);
-}
-
+void LC709203FComponent::setAlarmVoltage(float voltage) { write16(LC709203F_RW_ALARMVOLT, voltage * 1000); }
 
 /*!
  *    @brief  Set the power mode, LC709203F_POWER_OPERATE or
  *            LC709203F_POWER_SLEEP
  *    @param t The power mode desired
- *    @return 
+ *    @return
  */
-void LC709203FComponent::setPowerMode(lc709203_powermode_t t) 
-{
-  write16(LC709203F_RW_POWERMODE, (uint16_t)t);
-}
+void LC709203FComponent::setPowerMode(lc709203_powermode_t t) { write16(LC709203F_RW_POWERMODE, (uint16_t) t); }
 
 /*!
- *    @brief  Set cell type 
+ *    @brief  Set cell type
  *    @param t The profile, Table 8.  Normally 1 for 3.7 nominal 4.2V Full carge cells
  *    @return
  */
-void LC709203FComponent::setCellProfile(lc709203_cell_profile_t t) 
-{
-  write16(LC709203F_RW_PROFILE, (uint16_t)t);
-}
+void LC709203FComponent::setCellProfile(lc709203_cell_profile_t t) { write16(LC709203F_RW_PROFILE, (uint16_t) t); }
 
 /*!
  *    @brief  Get the thermistor Beta value //For completeness since we have to write it.
  *    @return The uint16_t Beta value
  */
-uint16_t LC709203FComponent::getThermistorBeta(void) 
-{
+uint16_t LC709203FComponent::getThermistorBeta(void) {
   uint16_t val = 0;
   val = read16(LC709203F_RW_THERMISTORB);
   return val;
 }
 
-
 /*!
  *    @brief  Set the thermistor Beta value
  *    @param b The value to set it to
- *    @return 
+ *    @return
  */
-void LC709203FComponent::setThermistorB(uint16_t beta) 
-{
-  write16(LC709203F_RW_THERMISTORB, beta);
-}
-
+void LC709203FComponent::setThermistorB(uint16_t beta) { write16(LC709203F_RW_THERMISTORB, beta); }
 
 //
 // -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
@@ -283,7 +231,6 @@ void LC709203FComponent::setThermistorB(uint16_t beta)
 /*
     INTERNAL I2C FUNCTIONS and CRC CALCULATION
 */
-
 
 /**
  * Performs a CRC8 calculation on the supplied values.
@@ -293,8 +240,7 @@ void LC709203FComponent::setThermistorB(uint16_t beta)
  *
  * @return The computed CRC8 value.
  */
-static uint8_t crc8(uint8_t *data, int len) 
-{
+static uint8_t crc8(uint8_t *data, int len) {
   const uint8_t POLYNOMIAL(0x07);
   uint8_t crc(0x00);
 
@@ -308,11 +254,9 @@ static uint8_t crc8(uint8_t *data, int len)
   return crc;
 }
 
-
 // writes a 16-bit word (d) to register pointer regAddress
 // when selecting a register pointer to read from, data = 0
-void LC709203FComponent::write16(uint8_t regAddress, uint16_t data)
-{
+void LC709203FComponent::write16(uint8_t regAddress, uint16_t data) {
   // Setup array to hold bytes to send including CRC-8
   uint8_t crcArray[5];
   crcArray[0] = 0x16;
@@ -320,7 +264,7 @@ void LC709203FComponent::write16(uint8_t regAddress, uint16_t data)
   crcArray[2] = lowByte(data);
   crcArray[3] = highByte(data);
   // Calculate crc of preceding four bytes and place in crcArray[4]
-  crcArray[4] = crc8( crcArray, 4 );
+  crcArray[4] = crc8(crcArray, 4);
   // Device address
   Wire.beginTransmission(i2c_address);
   // Register address
@@ -329,23 +273,22 @@ void LC709203FComponent::write16(uint8_t regAddress, uint16_t data)
   Wire.write(crcArray[2]);
   // high byte
   Wire.write(crcArray[3]);
-  // Send crc8 
+  // Send crc8
   Wire.write(crcArray[4]);
   Wire.endTransmission();
 }
 
-int16_t LC709203FComponent::read16( uint8_t regAddress)
-{
+int16_t LC709203FComponent::read16(uint8_t regAddress) {
   int16_t data = 0;
   Wire.beginTransmission(i2c_address);
   Wire.write(regAddress);
   Wire.endTransmission(false);
-  Wire.requestFrom(i2c_address, (uint8_t)  2);   // jbo added per WEMOS_SHT3x_Arduino_Library issue 7
+  Wire.requestFrom(i2c_address, (uint8_t) 2);  // jbo added per WEMOS_SHT3x_Arduino_Library issue 7
   uint8_t lowByteData = Wire.read();
   uint8_t highByteData = Wire.read();
   data = word(highByteData, lowByteData);
-  return( data );
+  return (data);
 }
 
-}
-}
+}  // namespace lc709203f
+}  // namespace esphome

--- a/esphome/components/lc709203f/lc709203f.h
+++ b/esphome/components/lc709203f/lc709203f.h
@@ -22,37 +22,44 @@ namespace lc709203f {
 
 static const uint8_t LC709203F_I2C_ADDR = 0x0B  // LC709203F default i2c address
 
-// Registers per datasheet Table 6
+    // Registers per datasheet Table 6
 
-static const uint8_t LC709203F_WO_BEFORE_RSOC = 0x04  // Executes RSOC initialization with sampled maximum voltage when 0xAA55 is set
-static const uint8_t LC709203F_RW_THERMISTORB = 0x06  // Sets B−constant of the thermistor to be measured.
-static const uint8_t LC709203F_WO_INITRSOC = 0x07     // Executes RSOC initialization when = 0xAA55 is set.
-static const uint8_t LC709203F_RW_CELLTEMPERATURE = 0x08  // Read or Write Cell Temperature  For ESP32-Bar-Rev2 must write temperature, no thermistor on board
-static const uint8_t LC709203F_RO_CELLVOLTAGE = 0x09  // Read cell voltage
-static const uint8_t LC709203F_RW_CURRENTDIRECTION = 0x0A  // Selects Auto/Charge/Discharge mode = 0x0000: Auto mode, = 0x0001: Charge mode, = 0xFFFF: Discharge mode
-static const uint8_t LC709203F_RW_APA = 0x0B  // APA Register, Table 7
-static const uint8_t LC709203F_RW_APTHERMISTOR = 0x0C                               // Sets a value to adjust temperature measurement delay timing. Defaults to0x001E
-static const uint8_t LC709203F_RW_RSOC = 0x0D       // Read cell indicator to empty in 1% steps
-static const uint8_t LC709203F_RO_ITE = 0x0F        // Read cell indicator to empty in 0.1% steps
-static const uint8_t LC709203F_RO_ICVERSION = 0x11  // Contains the ID number of the IC
-static const uint8_t LC709203F_RW_PROFILE = 0x12    // Adjusts the battery profile for nominal and fully charged voltages, see Table 8
-static const uint8_t LC709203F_RW_ALARMRSOC = 0x13  // Alarm on percent threshold
-static const uint8_t LC709203F_RW_ALARMVOLT = 0x14  // Alarm on voltage threshold
-static const uint8_t LC709203F_RW_POWERMODE = 0x15  // Sets sleep/power mode = 0x0001: Operational mode = 0x0002: Sleep mode
-static const uint8_t LC709203F_RW_STATUSBIT = 0x16  // Temperature method, = 0x0000: I2C mode, = 0x0001: Thermistor mode
-static const uint8_t LC709203F_RO_CELLPROFILE = 0x1A  // Displays battery profile code
+    static const uint8_t LC709203F_WO_BEFORE_RSOC =
+        0x04  // Executes RSOC initialization with sampled maximum voltage when 0xAA55 is set
+    static const uint8_t LC709203F_RW_THERMISTORB = 0x06  // Sets B−constant of the thermistor to be measured.
+    static const uint8_t LC709203F_WO_INITRSOC = 0x07     // Executes RSOC initialization when = 0xAA55 is set.
+    static const uint8_t LC709203F_RW_CELLTEMPERATURE =
+        0x08  // Read or Write Cell Temperature  For ESP32-Bar-Rev2 must write temperature, no thermistor on board
+    static const uint8_t LC709203F_RO_CELLVOLTAGE = 0x09  // Read cell voltage
+    static const uint8_t LC709203F_RW_CURRENTDIRECTION =
+        0x0A  // Selects Auto/Charge/Discharge mode = 0x0000: Auto mode, = 0x0001: Charge mode, = 0xFFFF: Discharge mode
+    static const uint8_t LC709203F_RW_APA = 0x0B  // APA Register, Table 7
+    static const uint8_t LC709203F_RW_APTHERMISTOR =
+        0x0C  // Sets a value to adjust temperature measurement delay timing. Defaults to0x001E
+    static const uint8_t LC709203F_RW_RSOC = 0x0D       // Read cell indicator to empty in 1% steps
+    static const uint8_t LC709203F_RO_ITE = 0x0F        // Read cell indicator to empty in 0.1% steps
+    static const uint8_t LC709203F_RO_ICVERSION = 0x11  // Contains the ID number of the IC
+    static const uint8_t LC709203F_RW_PROFILE =
+        0x12  // Adjusts the battery profile for nominal and fully charged voltages, see Table 8
+    static const uint8_t LC709203F_RW_ALARMRSOC = 0x13  // Alarm on percent threshold
+    static const uint8_t LC709203F_RW_ALARMVOLT = 0x14  // Alarm on voltage threshold
+    static const uint8_t LC709203F_RW_POWERMODE =
+        0x15  // Sets sleep/power mode = 0x0001: Operational mode = 0x0002: Sleep mode
+    static const uint8_t LC709203F_RW_STATUSBIT =
+        0x16  // Temperature method, = 0x0000: I2C mode, = 0x0001: Thermistor mode
+    static const uint8_t LC709203F_RO_CELLPROFILE = 0x1A  // Displays battery profile code
 
-// to remove warning static uint8_t crc8(uint8_t *data, int len);
+    // to remove warning static uint8_t crc8(uint8_t *data, int len);
 
-/*!  Approx cell capacity Table 7 */
-typedef enum {
-  LC709203F_APA_100MAH = 0x08,
-  LC709203F_APA_200MAH = 0x0B,
-  LC709203F_APA_500MAH = 0x10,
-  LC709203F_APA_1000MAH = 0x19,
-  LC709203F_APA_2000MAH = 0x2D,
-  LC709203F_APA_3000MAH = 0x36,
-} lc709203_adjustment_t;
+    /*!  Approx cell capacity Table 7 */
+    typedef enum {
+      LC709203F_APA_100MAH = 0x08,
+      LC709203F_APA_200MAH = 0x0B,
+      LC709203F_APA_500MAH = 0x10,
+      LC709203F_APA_1000MAH = 0x19,
+      LC709203F_APA_2000MAH = 0x2D,
+      LC709203F_APA_3000MAH = 0x36,
+    } lc709203_adjustment_t;
 
 /*!  Cell profile */
 typedef enum {

--- a/esphome/components/lc709203f/lc709203f.h
+++ b/esphome/components/lc709203f/lc709203f.h
@@ -11,7 +11,7 @@
  */
 
 #ifndef _LC709203F_H
-#define _LC709203F_H
+#define LC709203F_H
 
 #include "esphome/core/component.h"
 #include "esphome/components/sensor/sensor.h"
@@ -52,35 +52,35 @@ static const uint8_t LC709203F_RO_CELLPROFILE = 0x1A;  // Displays battery profi
 // to remove warning static uint8_t crc8(uint8_t *data, int len);
 
 /*!  Approx cell capacity Table 7 */
-typedef enum {
+using lc709203_adjustment_t = enum {
   LC709203F_APA_100MAH = 0x08,
   LC709203F_APA_200MAH = 0x0B,
   LC709203F_APA_500MAH = 0x10,
   LC709203F_APA_1000MAH = 0x19,
   LC709203F_APA_2000MAH = 0x2D,
   LC709203F_APA_3000MAH = 0x36,
-} lc709203_adjustment_t;
+};
 
 /*!  Cell profile */
-typedef enum {
+using lc709203_cell_profile_t = enum {
   LC709203_NOM3p7_Charge4p2 = 1,
   LC709203_NOM3p8_Charge4p35 = 3,
   LC709203_NOM3p8_Charge4p35_Less500mAh = 6,
   LC709203_ICR18650_SAMSUNG = 5,
   LC709203_ICR18650_PANASONIC = 4
-} lc709203_cell_profile_t;
+};
 
 /*!  Cell temperature source */
-typedef enum {
+using lc709203_tempmode_t = enum {
   LC709203F_TEMPERATURE_I2C = 0x0000,
   LC709203F_TEMPERATURE_THERMISTOR = 0x0001,
-} lc709203_tempmode_t;
+};
 
 /*!  Chip power state */
-typedef enum {
+using lc709203_powermode_t = enum {
   LC709203F_POWER_OPERATE = 0x0001,
   LC709203F_POWER_SLEEP = 0x0002,
-} lc709203_powermode_t;
+};
 
 /*!
  *    @brief  Class that stores state and functions for interacting with
@@ -89,44 +89,44 @@ typedef enum {
 // class LC709203F {
 class LC709203FComponent : public PollingComponent, public i2c::I2CDevice {
  public:
-  bool begin(void);
-  void initRSOC(void);
+  bool begin();
+  void init_rsoc();
 
-  void setPowerMode(lc709203_powermode_t t);
-  void setCellCapacity(lc709203_adjustment_t apa);
-  void setCellProfile(lc709203_cell_profile_t t);
+  void set_power_mode(lc709203_powermode_t t);
+  void set_cell_capacity(lc709203_adjustment_t apa);
+  void set_cell_profile(lc709203_cell_profile_t t);
 
-  uint16_t getICversion(void);
-  uint16_t cellVoltage_mV(void);
-  uint16_t cellRemainingPercent10(void);  // Remaining capacity in increments of 0.1% as integer
-  uint16_t cellStateOfCharge(void);       // In increments of 1% as integer
+  uint16_t get_i_cversion();
+  uint16_t cell_voltage_m_v();
+  uint16_t cell_remaining_percent10();  // Remaining capacity in increments of 0.1% as integer
+  uint16_t cell_state_of_charge();       // In increments of 1% as integer
 
-  uint16_t getThermistorBeta(void);
-  void setThermistorB(uint16_t beta);
+  uint16_t get_thermistor_beta();
+  void set_thermistor_b(uint16_t beta);
 
-  void setTemperatureMode(lc709203_tempmode_t t);
-  uint16_t getCellTemperature(void);
-  void setAlarmRSOC(uint8_t percent);
-  void setAlarmVoltage(float voltage);
+  void set_temperature_mode(lc709203_tempmode_t t);
+  uint16_t get_cell_temperature();
+  void set_alarm_rsoc(uint8_t percent);
+  void set_alarm_voltage(float voltage);
 
   //  added to align with esphome
-  void set_cellVoltage_sensor(sensor::Sensor *cellVoltage) { cellVoltage_ = cellVoltage; }
-  void set_cellRemPercent_sensor(sensor::Sensor *cellRemPercent) { cellRemPercent_ = cellRemPercent; }
+  void set_cell_voltage_sensor(sensor::Sensor *cell_voltage) { cell_voltage_ = cell_voltage; }
+  void set_cell_rem_percent_sensor(sensor::Sensor *cell_rem_percent) { cell_rem_percent_ = cell_rem_percent; }
   void set_icversion_sensor(sensor::Sensor *icversion) { icversion_ = icversion; }
-  void set_cellCharge_sensor(sensor::Sensor *cellCharge) { cellCharge_ = cellCharge; }
+  void set_cell_charge_sensor(sensor::Sensor *cell_charge) { cell_charge_ = cell_charge; }
   void setup() override;
   void update() override;
   void dump_config() override;
 
  protected:
-  void write16(uint8_t regAddress, uint16_t data);
-  int16_t read16(uint8_t regAddress);
+  void write16_(uint8_t reg_address, uint16_t data);
+  int16_t read16_(uint8_t reg_address);
 
   // added for esphome
-  sensor::Sensor *cellVoltage_;
-  sensor::Sensor *cellRemPercent_;
+  sensor::Sensor *cell_voltage_;
+  sensor::Sensor *cell_rem_percent_;
   sensor::Sensor *icversion_;
-  sensor::Sensor *cellCharge_;
+  sensor::Sensor *cell_charge_;
 };
 
 }  // namespace lc709203f

--- a/esphome/components/lc709203f/lc709203f.h
+++ b/esphome/components/lc709203f/lc709203f.h
@@ -22,44 +22,44 @@ namespace lc709203f {
 
 static const uint8_t LC709203F_I2C_ADDR = 0x0B;  // LC709203F default i2c address
 
-    // Registers per datasheet Table 6
+// Registers per datasheet Table 6
 
-    static const uint8_t LC709203F_WO_BEFORE_RSOC =
-        0x04;  // Executes RSOC initialization with sampled maximum voltage when 0xAA55 is set
-    static const uint8_t LC709203F_RW_THERMISTORB = 0x06;  // Sets B−constant of the thermistor to be measured.
-    static const uint8_t LC709203F_WO_INITRSOC = 0x07;     // Executes RSOC initialization when = 0xAA55 is set.
-    static const uint8_t LC709203F_RW_CELLTEMPERATURE =
-        0x08;  // Read or Write Cell Temperature  For ESP32-Bar-Rev2 must write temperature, no thermistor on board
-    static const uint8_t LC709203F_RO_CELLVOLTAGE = 0x09;  // Read cell voltage
-    static const uint8_t LC709203F_RW_CURRENTDIRECTION =
-        0x0A;  // Selects Auto/Charge/Discharge mode = 0x0000: Auto mode, = 0x0001: Charge mode, = 0xFFFF: Discharge mode
-    static const uint8_t LC709203F_RW_APA = 0x0B;  // APA Register, Table 7
-    static const uint8_t LC709203F_RW_APTHERMISTOR =
-        0x0C;  // Sets a value to adjust temperature measurement delay timing. Defaults to0x001E
-    static const uint8_t LC709203F_RW_RSOC = 0x0D;       // Read cell indicator to empty in 1% steps
-    static const uint8_t LC709203F_RO_ITE = 0x0F;        // Read cell indicator to empty in 0.1% steps
-    static const uint8_t LC709203F_RO_ICVERSION = 0x11;  // Contains the ID number of the IC
-    static const uint8_t LC709203F_RW_PROFILE =
-        0x12;  // Adjusts the battery profile for nominal and fully charged voltages, see Table 8
-    static const uint8_t LC709203F_RW_ALARMRSOC = 0x13;  // Alarm on percent threshold
-    static const uint8_t LC709203F_RW_ALARMVOLT = 0x14;  // Alarm on voltage threshold
-    static const uint8_t LC709203F_RW_POWERMODE =
-        0x15;  // Sets sleep/power mode = 0x0001: Operational mode = 0x0002: Sleep mode
-    static const uint8_t LC709203F_RW_STATUSBIT =
-        0x16;  // Temperature method, = 0x0000: I2C mode, = 0x0001: Thermistor mode
-    static const uint8_t LC709203F_RO_CELLPROFILE = 0x1A;  // Displays battery profile code
+static const uint8_t LC709203F_WO_BEFORE_RSOC =
+    0x04;  // Executes RSOC initialization with sampled maximum voltage when 0xAA55 is set
+static const uint8_t LC709203F_RW_THERMISTORB = 0x06;  // Sets B−constant of the thermistor to be measured.
+static const uint8_t LC709203F_WO_INITRSOC = 0x07;     // Executes RSOC initialization when = 0xAA55 is set.
+static const uint8_t LC709203F_RW_CELLTEMPERATURE =
+    0x08;  // Read or Write Cell Temperature  For ESP32-Bar-Rev2 must write temperature, no thermistor on board
+static const uint8_t LC709203F_RO_CELLVOLTAGE = 0x09;  // Read cell voltage
+static const uint8_t LC709203F_RW_CURRENTDIRECTION =
+    0x0A;  // Selects Auto/Charge/Discharge mode = 0x0000: Auto mode, = 0x0001: Charge mode, = 0xFFFF: Discharge mode
+static const uint8_t LC709203F_RW_APA = 0x0B;  // APA Register, Table 7
+static const uint8_t LC709203F_RW_APTHERMISTOR =
+    0x0C;  // Sets a value to adjust temperature measurement delay timing. Defaults to0x001E
+static const uint8_t LC709203F_RW_RSOC = 0x0D;       // Read cell indicator to empty in 1% steps
+static const uint8_t LC709203F_RO_ITE = 0x0F;        // Read cell indicator to empty in 0.1% steps
+static const uint8_t LC709203F_RO_ICVERSION = 0x11;  // Contains the ID number of the IC
+static const uint8_t LC709203F_RW_PROFILE =
+    0x12;  // Adjusts the battery profile for nominal and fully charged voltages, see Table 8
+static const uint8_t LC709203F_RW_ALARMRSOC = 0x13;  // Alarm on percent threshold
+static const uint8_t LC709203F_RW_ALARMVOLT = 0x14;  // Alarm on voltage threshold
+static const uint8_t LC709203F_RW_POWERMODE =
+    0x15;  // Sets sleep/power mode = 0x0001: Operational mode = 0x0002: Sleep mode
+static const uint8_t LC709203F_RW_STATUSBIT =
+    0x16;  // Temperature method, = 0x0000: I2C mode, = 0x0001: Thermistor mode
+static const uint8_t LC709203F_RO_CELLPROFILE = 0x1A;  // Displays battery profile code
 
-    // to remove warning static uint8_t crc8(uint8_t *data, int len);
+// to remove warning static uint8_t crc8(uint8_t *data, int len);
 
-    /*!  Approx cell capacity Table 7 */
-    typedef enum {
-      LC709203F_APA_100MAH = 0x08,
-      LC709203F_APA_200MAH = 0x0B,
-      LC709203F_APA_500MAH = 0x10,
-      LC709203F_APA_1000MAH = 0x19,
-      LC709203F_APA_2000MAH = 0x2D,
-      LC709203F_APA_3000MAH = 0x36,
-    } lc709203_adjustment_t;
+/*!  Approx cell capacity Table 7 */
+typedef enum {
+  LC709203F_APA_100MAH = 0x08,
+  LC709203F_APA_200MAH = 0x0B,
+  LC709203F_APA_500MAH = 0x10,
+  LC709203F_APA_1000MAH = 0x19,
+  LC709203F_APA_2000MAH = 0x2D,
+  LC709203F_APA_3000MAH = 0x36,
+} lc709203_adjustment_t;
 
 /*!  Cell profile */
 typedef enum {

--- a/esphome/components/lc709203f/lc709203f.h
+++ b/esphome/components/lc709203f/lc709203f.h
@@ -2,7 +2,7 @@
  * File:          lc709203f.h
  * Addapted by:   J.G. Aguado
  * Date:          30/11/2023
- * 
+ *
  * Description:
  * This component adapts (into ESPHome) the I2C Driver for the LC709203F Battery Monitor IC,
  * based on the library from Daniel deBeer (EzSBC) available at:
@@ -12,7 +12,6 @@
 #ifndef _LC709203F_H
 #define _LC709203F_H
 
-
 #include "esphome/core/component.h"
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/i2c/i2c.h"
@@ -20,59 +19,62 @@
 namespace esphome {
 namespace lc709203f {
 
-#define LC709203F_I2C_ADDR              0x0B    // LC709203F default i2c address
+#define LC709203F_I2C_ADDR 0x0B  // LC709203F default i2c address
 
 // Registers per datasheet Table 6
 
-#define LC709203F_WO_BEFORE_RSOC      0x04    // Executes RSOC initialization with sampled maximum voltage when 0xAA55 is set
-#define LC709203F_RW_THERMISTORB      0x06    // Sets B−constant of the thermistor to be measured.
-#define LC709203F_WO_INITRSOC 	      0x07    // Executes RSOC initialization when 0xAA55 is set.
-#define LC709203F_RW_CELLTEMPERATURE  0x08    // Read or Write Cell Temperature  For ESP32-Bar-Rev2 must write temperature, no thermistor on board
-#define LC709203F_RO_CELLVOLTAGE      0x09    // Read cell voltage
-#define LC709203F_RW_CURRENTDIRECTION 0x0A    // Selects Auto/Charge/Discharge mode 0x0000: Auto mode, 0x0001: Charge mode, 0xFFFF: Discharge mode
-#define LC709203F_RW_APA 	      0x0B    // APA Register, Table 7
-#define LC709203F_RW_APTHERMISTOR     0x0C    // Sets a value to adjust temperature measurement delay timing. Defaults to0x001E
-#define LC709203F_RW_RSOC             0x0D    // Read cell indicator to empty in 1% steps
-#define LC709203F_RO_ITE     	      0x0F    // Read cell indicator to empty in 0.1% steps
-#define LC709203F_RO_ICVERSION 	      0x11    // Contains the ID number of the IC
-#define LC709203F_RW_PROFILE	      0x12    // Adjusts the battery profile for nominal and fully charged voltages, see Table 8
-#define LC709203F_RW_ALARMRSOC 	      0x13    // Alarm on percent threshold
-#define LC709203F_RW_ALARMVOLT 	      0x14    // Alarm on voltage threshold
-#define LC709203F_RW_POWERMODE 	      0x15    // Sets sleep/power mode 0x0001: Operational mode 0x0002: Sleep mode
-#define LC709203F_RW_STATUSBIT 	      0x16    // Temperature method, 0x0000: I2C mode, 0x0001: Thermistor mode 
-#define LC709203F_RO_CELLPROFILE      0x1A    // Displays battery profile code
+#define LC709203F_WO_BEFORE_RSOC 0x04  // Executes RSOC initialization with sampled maximum voltage when 0xAA55 is set
+#define LC709203F_RW_THERMISTORB 0x06  // Sets B−constant of the thermistor to be measured.
+#define LC709203F_WO_INITRSOC 0x07     // Executes RSOC initialization when 0xAA55 is set.
+#define LC709203F_RW_CELLTEMPERATURE \
+  0x08  // Read or Write Cell Temperature  For ESP32-Bar-Rev2 must write temperature, no thermistor on board
+#define LC709203F_RO_CELLVOLTAGE 0x09  // Read cell voltage
+#define LC709203F_RW_CURRENTDIRECTION \
+  0x0A  // Selects Auto/Charge/Discharge mode 0x0000: Auto mode, 0x0001: Charge mode, 0xFFFF: Discharge mode
+#define LC709203F_RW_APA 0x0B  // APA Register, Table 7
+#define LC709203F_RW_APTHERMISTOR \
+  0x0C                               // Sets a value to adjust temperature measurement delay timing. Defaults to0x001E
+#define LC709203F_RW_RSOC 0x0D       // Read cell indicator to empty in 1% steps
+#define LC709203F_RO_ITE 0x0F        // Read cell indicator to empty in 0.1% steps
+#define LC709203F_RO_ICVERSION 0x11  // Contains the ID number of the IC
+#define LC709203F_RW_PROFILE 0x12    // Adjusts the battery profile for nominal and fully charged voltages, see Table 8
+#define LC709203F_RW_ALARMRSOC 0x13  // Alarm on percent threshold
+#define LC709203F_RW_ALARMVOLT 0x14  // Alarm on voltage threshold
+#define LC709203F_RW_POWERMODE 0x15  // Sets sleep/power mode 0x0001: Operational mode 0x0002: Sleep mode
+#define LC709203F_RW_STATUSBIT 0x16  // Temperature method, 0x0000: I2C mode, 0x0001: Thermistor mode
+#define LC709203F_RO_CELLPROFILE 0x1A  // Displays battery profile code
 
 // to remove warning static uint8_t crc8(uint8_t *data, int len);
 
 /*!  Approx cell capacity Table 7 */
 typedef enum {
-  LC709203F_APA_100MAH              = 0x08,
-  LC709203F_APA_200MAH              = 0x0B,
-  LC709203F_APA_500MAH              = 0x10,
-  LC709203F_APA_1000MAH             = 0x19,
-  LC709203F_APA_2000MAH             = 0x2D,
-  LC709203F_APA_3000MAH             = 0x36,
+  LC709203F_APA_100MAH = 0x08,
+  LC709203F_APA_200MAH = 0x0B,
+  LC709203F_APA_500MAH = 0x10,
+  LC709203F_APA_1000MAH = 0x19,
+  LC709203F_APA_2000MAH = 0x2D,
+  LC709203F_APA_3000MAH = 0x36,
 } lc709203_adjustment_t;
 
 /*!  Cell profile */
 typedef enum {
-  LC709203_NOM3p7_Charge4p2         = 1,
-  LC709203_NOM3p8_Charge4p35        = 3,
+  LC709203_NOM3p7_Charge4p2 = 1,
+  LC709203_NOM3p8_Charge4p35 = 3,
   LC709203_NOM3p8_Charge4p35_Less500mAh = 6,
-  LC709203_ICR18650_SAMSUNG         = 5,
-  LC709203_ICR18650_PANASONIC       = 4
-}lc709203_cell_profile_t ;
+  LC709203_ICR18650_SAMSUNG = 5,
+  LC709203_ICR18650_PANASONIC = 4
+} lc709203_cell_profile_t;
 
 /*!  Cell temperature source */
 typedef enum {
-  LC709203F_TEMPERATURE_I2C         = 0x0000,
-  LC709203F_TEMPERATURE_THERMISTOR  = 0x0001,
+  LC709203F_TEMPERATURE_I2C = 0x0000,
+  LC709203F_TEMPERATURE_THERMISTOR = 0x0001,
 } lc709203_tempmode_t;
 
 /*!  Chip power state */
 typedef enum {
-  LC709203F_POWER_OPERATE           = 0x0001,
-  LC709203F_POWER_SLEEP             = 0x0002,
+  LC709203F_POWER_OPERATE = 0x0001,
+  LC709203F_POWER_SLEEP = 0x0002,
 } lc709203_powermode_t;
 
 /*!
@@ -81,20 +83,18 @@ typedef enum {
  */
 // class LC709203F {
 class LC709203FComponent : public PollingComponent, public i2c::I2CDevice {
-public:
-
-  bool begin( void );
+ public:
+  bool begin(void);
   void initRSOC(void);
 
   void setPowerMode(lc709203_powermode_t t);
   void setCellCapacity(lc709203_adjustment_t apa);
   void setCellProfile(lc709203_cell_profile_t t);
-  
+
   uint16_t getICversion(void);
   uint16_t cellVoltage_mV(void);
-  uint16_t cellRemainingPercent10(void);	// Remaining capacity in increments of 0.1% as integer
-  uint16_t cellStateOfCharge(void);		// In increments of 1% as integer
-	
+  uint16_t cellRemainingPercent10(void);  // Remaining capacity in increments of 0.1% as integer
+  uint16_t cellStateOfCharge(void);       // In increments of 1% as integer
 
   uint16_t getThermistorBeta(void);
   void setThermistorB(uint16_t beta);
@@ -104,18 +104,17 @@ public:
   void setAlarmRSOC(uint8_t percent);
   void setAlarmVoltage(float voltage);
 
-
   //  added to align with esphome
-  void set_cellVoltage_sensor( sensor::Sensor *cellVoltage)       { cellVoltage_    = cellVoltage; }
-  void set_cellRemPercent_sensor( sensor::Sensor *cellRemPercent) { cellRemPercent_ = cellRemPercent; }
-  void set_icversion_sensor( sensor::Sensor *icversion)           { icversion_      = icversion; }
-  void set_cellCharge_sensor( sensor::Sensor *cellCharge)         { cellCharge_     = cellCharge; }
+  void set_cellVoltage_sensor(sensor::Sensor *cellVoltage) { cellVoltage_ = cellVoltage; }
+  void set_cellRemPercent_sensor(sensor::Sensor *cellRemPercent) { cellRemPercent_ = cellRemPercent; }
+  void set_icversion_sensor(sensor::Sensor *icversion) { icversion_ = icversion; }
+  void set_cellCharge_sensor(sensor::Sensor *cellCharge) { cellCharge_ = cellCharge; }
   void setup() override;
   void update() override;
   void dump_config() override;
 
-protected:
-  void write16( uint8_t regAddress, uint16_t data);
+ protected:
+  void write16(uint8_t regAddress, uint16_t data);
   int16_t read16(uint8_t regAddress);
 
   // added for esphome
@@ -123,10 +122,9 @@ protected:
   sensor::Sensor *cellRemPercent_;
   sensor::Sensor *icversion_;
   sensor::Sensor *cellCharge_;
-
 };
 
-}   // namespace lc709203f
-}   // namespace esphome
+}  // namespace lc709203f
+}  // namespace esphome
 
 #endif

--- a/esphome/components/lc709203f/lc709203f.h
+++ b/esphome/components/lc709203f/lc709203f.h
@@ -1,3 +1,4 @@
+#pragma once
 /*
  * File:          lc709203f.h
  * Addapted by:   J.G. Aguado
@@ -19,30 +20,27 @@
 namespace esphome {
 namespace lc709203f {
 
-#define LC709203F_I2C_ADDR 0x0B  // LC709203F default i2c address
+static const uint8_t LC709203F_I2C_ADDR = 0x0B  // LC709203F default i2c address
 
 // Registers per datasheet Table 6
 
-#define LC709203F_WO_BEFORE_RSOC 0x04  // Executes RSOC initialization with sampled maximum voltage when 0xAA55 is set
-#define LC709203F_RW_THERMISTORB 0x06  // Sets B−constant of the thermistor to be measured.
-#define LC709203F_WO_INITRSOC 0x07     // Executes RSOC initialization when 0xAA55 is set.
-#define LC709203F_RW_CELLTEMPERATURE \
-  0x08  // Read or Write Cell Temperature  For ESP32-Bar-Rev2 must write temperature, no thermistor on board
-#define LC709203F_RO_CELLVOLTAGE 0x09  // Read cell voltage
-#define LC709203F_RW_CURRENTDIRECTION \
-  0x0A  // Selects Auto/Charge/Discharge mode 0x0000: Auto mode, 0x0001: Charge mode, 0xFFFF: Discharge mode
-#define LC709203F_RW_APA 0x0B  // APA Register, Table 7
-#define LC709203F_RW_APTHERMISTOR \
-  0x0C                               // Sets a value to adjust temperature measurement delay timing. Defaults to0x001E
-#define LC709203F_RW_RSOC 0x0D       // Read cell indicator to empty in 1% steps
-#define LC709203F_RO_ITE 0x0F        // Read cell indicator to empty in 0.1% steps
-#define LC709203F_RO_ICVERSION 0x11  // Contains the ID number of the IC
-#define LC709203F_RW_PROFILE 0x12    // Adjusts the battery profile for nominal and fully charged voltages, see Table 8
-#define LC709203F_RW_ALARMRSOC 0x13  // Alarm on percent threshold
-#define LC709203F_RW_ALARMVOLT 0x14  // Alarm on voltage threshold
-#define LC709203F_RW_POWERMODE 0x15  // Sets sleep/power mode 0x0001: Operational mode 0x0002: Sleep mode
-#define LC709203F_RW_STATUSBIT 0x16  // Temperature method, 0x0000: I2C mode, 0x0001: Thermistor mode
-#define LC709203F_RO_CELLPROFILE 0x1A  // Displays battery profile code
+static const uint8_t LC709203F_WO_BEFORE_RSOC = 0x04  // Executes RSOC initialization with sampled maximum voltage when 0xAA55 is set
+static const uint8_t LC709203F_RW_THERMISTORB = 0x06  // Sets B−constant of the thermistor to be measured.
+static const uint8_t LC709203F_WO_INITRSOC = 0x07     // Executes RSOC initialization when = 0xAA55 is set.
+static const uint8_t LC709203F_RW_CELLTEMPERATURE = 0x08  // Read or Write Cell Temperature  For ESP32-Bar-Rev2 must write temperature, no thermistor on board
+static const uint8_t LC709203F_RO_CELLVOLTAGE = 0x09  // Read cell voltage
+static const uint8_t LC709203F_RW_CURRENTDIRECTION = 0x0A  // Selects Auto/Charge/Discharge mode = 0x0000: Auto mode, = 0x0001: Charge mode, = 0xFFFF: Discharge mode
+static const uint8_t LC709203F_RW_APA = 0x0B  // APA Register, Table 7
+static const uint8_t LC709203F_RW_APTHERMISTOR = 0x0C                               // Sets a value to adjust temperature measurement delay timing. Defaults to0x001E
+static const uint8_t LC709203F_RW_RSOC = 0x0D       // Read cell indicator to empty in 1% steps
+static const uint8_t LC709203F_RO_ITE = 0x0F        // Read cell indicator to empty in 0.1% steps
+static const uint8_t LC709203F_RO_ICVERSION = 0x11  // Contains the ID number of the IC
+static const uint8_t LC709203F_RW_PROFILE = 0x12    // Adjusts the battery profile for nominal and fully charged voltages, see Table 8
+static const uint8_t LC709203F_RW_ALARMRSOC = 0x13  // Alarm on percent threshold
+static const uint8_t LC709203F_RW_ALARMVOLT = 0x14  // Alarm on voltage threshold
+static const uint8_t LC709203F_RW_POWERMODE = 0x15  // Sets sleep/power mode = 0x0001: Operational mode = 0x0002: Sleep mode
+static const uint8_t LC709203F_RW_STATUSBIT = 0x16  // Temperature method, = 0x0000: I2C mode, = 0x0001: Thermistor mode
+static const uint8_t LC709203F_RO_CELLPROFILE = 0x1A  // Displays battery profile code
 
 // to remove warning static uint8_t crc8(uint8_t *data, int len);
 

--- a/esphome/components/lc709203f/lc709203f.h
+++ b/esphome/components/lc709203f/lc709203f.h
@@ -63,9 +63,9 @@ using lc709203_adjustment_t = enum {
 
 /*!  Cell profile */
 using lc709203_cell_profile_t = enum {
-  LC709203_NOM3p7_Charge4p2 = 1,
-  LC709203_NOM3p8_Charge4p35 = 3,
-  LC709203_NOM3p8_Charge4p35_Less500mAh = 6,
+  L_C709203_NO_M3P7_CHARGE4P2 = 1,
+  L_C709203_NO_M3P8_CHARGE4P35 = 3,
+  L_C709203_NO_M3P8_CHARGE4P35_LESS500M_AH = 6,
   LC709203_ICR18650_SAMSUNG = 5,
   LC709203_ICR18650_PANASONIC = 4
 };

--- a/esphome/components/lc709203f/lc709203f.h
+++ b/esphome/components/lc709203f/lc709203f.h
@@ -20,34 +20,34 @@
 namespace esphome {
 namespace lc709203f {
 
-static const uint8_t LC709203F_I2C_ADDR = 0x0B  // LC709203F default i2c address
+static const uint8_t LC709203F_I2C_ADDR = 0x0B;  // LC709203F default i2c address
 
     // Registers per datasheet Table 6
 
     static const uint8_t LC709203F_WO_BEFORE_RSOC =
-        0x04  // Executes RSOC initialization with sampled maximum voltage when 0xAA55 is set
-    static const uint8_t LC709203F_RW_THERMISTORB = 0x06  // Sets B−constant of the thermistor to be measured.
-    static const uint8_t LC709203F_WO_INITRSOC = 0x07     // Executes RSOC initialization when = 0xAA55 is set.
+        0x04;  // Executes RSOC initialization with sampled maximum voltage when 0xAA55 is set
+    static const uint8_t LC709203F_RW_THERMISTORB = 0x06;  // Sets B−constant of the thermistor to be measured.
+    static const uint8_t LC709203F_WO_INITRSOC = 0x07;     // Executes RSOC initialization when = 0xAA55 is set.
     static const uint8_t LC709203F_RW_CELLTEMPERATURE =
-        0x08  // Read or Write Cell Temperature  For ESP32-Bar-Rev2 must write temperature, no thermistor on board
-    static const uint8_t LC709203F_RO_CELLVOLTAGE = 0x09  // Read cell voltage
+        0x08;  // Read or Write Cell Temperature  For ESP32-Bar-Rev2 must write temperature, no thermistor on board
+    static const uint8_t LC709203F_RO_CELLVOLTAGE = 0x09;  // Read cell voltage
     static const uint8_t LC709203F_RW_CURRENTDIRECTION =
-        0x0A  // Selects Auto/Charge/Discharge mode = 0x0000: Auto mode, = 0x0001: Charge mode, = 0xFFFF: Discharge mode
-    static const uint8_t LC709203F_RW_APA = 0x0B  // APA Register, Table 7
+        0x0A;  // Selects Auto/Charge/Discharge mode = 0x0000: Auto mode, = 0x0001: Charge mode, = 0xFFFF: Discharge mode
+    static const uint8_t LC709203F_RW_APA = 0x0B;  // APA Register, Table 7
     static const uint8_t LC709203F_RW_APTHERMISTOR =
-        0x0C  // Sets a value to adjust temperature measurement delay timing. Defaults to0x001E
-    static const uint8_t LC709203F_RW_RSOC = 0x0D       // Read cell indicator to empty in 1% steps
-    static const uint8_t LC709203F_RO_ITE = 0x0F        // Read cell indicator to empty in 0.1% steps
-    static const uint8_t LC709203F_RO_ICVERSION = 0x11  // Contains the ID number of the IC
+        0x0C;  // Sets a value to adjust temperature measurement delay timing. Defaults to0x001E
+    static const uint8_t LC709203F_RW_RSOC = 0x0D;       // Read cell indicator to empty in 1% steps
+    static const uint8_t LC709203F_RO_ITE = 0x0F;        // Read cell indicator to empty in 0.1% steps
+    static const uint8_t LC709203F_RO_ICVERSION = 0x11;  // Contains the ID number of the IC
     static const uint8_t LC709203F_RW_PROFILE =
-        0x12  // Adjusts the battery profile for nominal and fully charged voltages, see Table 8
-    static const uint8_t LC709203F_RW_ALARMRSOC = 0x13  // Alarm on percent threshold
-    static const uint8_t LC709203F_RW_ALARMVOLT = 0x14  // Alarm on voltage threshold
+        0x12;  // Adjusts the battery profile for nominal and fully charged voltages, see Table 8
+    static const uint8_t LC709203F_RW_ALARMRSOC = 0x13;  // Alarm on percent threshold
+    static const uint8_t LC709203F_RW_ALARMVOLT = 0x14;  // Alarm on voltage threshold
     static const uint8_t LC709203F_RW_POWERMODE =
-        0x15  // Sets sleep/power mode = 0x0001: Operational mode = 0x0002: Sleep mode
+        0x15;  // Sets sleep/power mode = 0x0001: Operational mode = 0x0002: Sleep mode
     static const uint8_t LC709203F_RW_STATUSBIT =
-        0x16  // Temperature method, = 0x0000: I2C mode, = 0x0001: Thermistor mode
-    static const uint8_t LC709203F_RO_CELLPROFILE = 0x1A  // Displays battery profile code
+        0x16;  // Temperature method, = 0x0000: I2C mode, = 0x0001: Thermistor mode
+    static const uint8_t LC709203F_RO_CELLPROFILE = 0x1A;  // Displays battery profile code
 
     // to remove warning static uint8_t crc8(uint8_t *data, int len);
 

--- a/esphome/components/lc709203f/lc709203f.h
+++ b/esphome/components/lc709203f/lc709203f.h
@@ -1,0 +1,132 @@
+/*
+ * File:          lc709203f.h
+ * Addapted by:   J.G. Aguado
+ * Date:          30/11/2023
+ * 
+ * Description:
+ * This component adapts (into ESPHome) the I2C Driver for the LC709203F Battery Monitor IC,
+ * based on the library from Daniel deBeer (EzSBC) available at:
+ * https://github.com/EzSBC/ESP32_Bat_Pro from Daniel deBeer (EzSBC)
+ */
+
+#ifndef _LC709203F_H
+#define _LC709203F_H
+
+
+#include "esphome/core/component.h"
+#include "esphome/components/sensor/sensor.h"
+#include "esphome/components/i2c/i2c.h"
+
+namespace esphome {
+namespace lc709203f {
+
+#define LC709203F_I2C_ADDR              0x0B    // LC709203F default i2c address
+
+// Registers per datasheet Table 6
+
+#define LC709203F_WO_BEFORE_RSOC      0x04    // Executes RSOC initialization with sampled maximum voltage when 0xAA55 is set
+#define LC709203F_RW_THERMISTORB      0x06    // Sets B−constant of the thermistor to be measured.
+#define LC709203F_WO_INITRSOC 	      0x07    // Executes RSOC initialization when 0xAA55 is set.
+#define LC709203F_RW_CELLTEMPERATURE  0x08    // Read or Write Cell Temperature  For ESP32-Bar-Rev2 must write temperature, no thermistor on board
+#define LC709203F_RO_CELLVOLTAGE      0x09    // Read cell voltage
+#define LC709203F_RW_CURRENTDIRECTION 0x0A    // Selects Auto/Charge/Discharge mode 0x0000: Auto mode, 0x0001: Charge mode, 0xFFFF: Discharge mode
+#define LC709203F_RW_APA 	      0x0B    // APA Register, Table 7
+#define LC709203F_RW_APTHERMISTOR     0x0C    // Sets a value to adjust temperature measurement delay timing. Defaults to0x001E
+#define LC709203F_RW_RSOC             0x0D    // Read cell indicator to empty in 1% steps
+#define LC709203F_RO_ITE     	      0x0F    // Read cell indicator to empty in 0.1% steps
+#define LC709203F_RO_ICVERSION 	      0x11    // Contains the ID number of the IC
+#define LC709203F_RW_PROFILE	      0x12    // Adjusts the battery profile for nominal and fully charged voltages, see Table 8
+#define LC709203F_RW_ALARMRSOC 	      0x13    // Alarm on percent threshold
+#define LC709203F_RW_ALARMVOLT 	      0x14    // Alarm on voltage threshold
+#define LC709203F_RW_POWERMODE 	      0x15    // Sets sleep/power mode 0x0001: Operational mode 0x0002: Sleep mode
+#define LC709203F_RW_STATUSBIT 	      0x16    // Temperature method, 0x0000: I2C mode, 0x0001: Thermistor mode 
+#define LC709203F_RO_CELLPROFILE      0x1A    // Displays battery profile code
+
+// to remove warning static uint8_t crc8(uint8_t *data, int len);
+
+/*!  Approx cell capacity Table 7 */
+typedef enum {
+  LC709203F_APA_100MAH              = 0x08,
+  LC709203F_APA_200MAH              = 0x0B,
+  LC709203F_APA_500MAH              = 0x10,
+  LC709203F_APA_1000MAH             = 0x19,
+  LC709203F_APA_2000MAH             = 0x2D,
+  LC709203F_APA_3000MAH             = 0x36,
+} lc709203_adjustment_t;
+
+/*!  Cell profile */
+typedef enum {
+  LC709203_NOM3p7_Charge4p2         = 1,
+  LC709203_NOM3p8_Charge4p35        = 3,
+  LC709203_NOM3p8_Charge4p35_Less500mAh = 6,
+  LC709203_ICR18650_SAMSUNG         = 5,
+  LC709203_ICR18650_PANASONIC       = 4
+}lc709203_cell_profile_t ;
+
+/*!  Cell temperature source */
+typedef enum {
+  LC709203F_TEMPERATURE_I2C         = 0x0000,
+  LC709203F_TEMPERATURE_THERMISTOR  = 0x0001,
+} lc709203_tempmode_t;
+
+/*!  Chip power state */
+typedef enum {
+  LC709203F_POWER_OPERATE           = 0x0001,
+  LC709203F_POWER_SLEEP             = 0x0002,
+} lc709203_powermode_t;
+
+/*!
+ *    @brief  Class that stores state and functions for interacting with
+ *            the LC709203F I2C LiPo monitor
+ */
+// class LC709203F {
+class LC709203FComponent : public PollingComponent, public i2c::I2CDevice {
+public:
+
+  bool begin( void );
+  void initRSOC(void);
+
+  void setPowerMode(lc709203_powermode_t t);
+  void setCellCapacity(lc709203_adjustment_t apa);
+  void setCellProfile(lc709203_cell_profile_t t);
+  
+  uint16_t getICversion(void);
+  uint16_t cellVoltage_mV(void);
+  uint16_t cellRemainingPercent10(void);	// Remaining capacity in increments of 0.1% as integer
+  uint16_t cellStateOfCharge(void);		// In increments of 1% as integer
+	
+
+  uint16_t getThermistorBeta(void);
+  void setThermistorB(uint16_t beta);
+
+  void setTemperatureMode(lc709203_tempmode_t t);
+  uint16_t getCellTemperature(void);
+  void setAlarmRSOC(uint8_t percent);
+  void setAlarmVoltage(float voltage);
+
+
+  //  added to align with esphome
+  void set_cellVoltage_sensor( sensor::Sensor *cellVoltage)       { cellVoltage_    = cellVoltage; }
+  void set_cellRemPercent_sensor( sensor::Sensor *cellRemPercent) { cellRemPercent_ = cellRemPercent; }
+  void set_icversion_sensor( sensor::Sensor *icversion)           { icversion_      = icversion; }
+  void set_cellCharge_sensor( sensor::Sensor *cellCharge)         { cellCharge_     = cellCharge; }
+  void setup() override;
+  void update() override;
+  void dump_config() override;
+
+protected:
+  void write16( uint8_t regAddress, uint16_t data);
+  int16_t read16(uint8_t regAddress);
+
+  // added for esphome
+  sensor::Sensor *cellVoltage_;
+  sensor::Sensor *cellRemPercent_;
+  sensor::Sensor *icversion_;
+  sensor::Sensor *cellCharge_;
+
+};
+
+}   // namespace lc709203f
+}   // namespace esphome
+
+#endif

--- a/esphome/components/lc709203f/lc709203f.h
+++ b/esphome/components/lc709203f/lc709203f.h
@@ -11,7 +11,7 @@
  */
 
 #ifndef _LC709203F_H
-#define LC709203F_H
+#define _LC709203F_H
 
 #include "esphome/core/component.h"
 #include "esphome/components/sensor/sensor.h"
@@ -52,35 +52,35 @@ static const uint8_t LC709203F_RO_CELLPROFILE = 0x1A;  // Displays battery profi
 // to remove warning static uint8_t crc8(uint8_t *data, int len);
 
 /*!  Approx cell capacity Table 7 */
-using lc709203_adjustment_t = enum {
+typedef enum {
   LC709203F_APA_100MAH = 0x08,
   LC709203F_APA_200MAH = 0x0B,
   LC709203F_APA_500MAH = 0x10,
   LC709203F_APA_1000MAH = 0x19,
   LC709203F_APA_2000MAH = 0x2D,
   LC709203F_APA_3000MAH = 0x36,
-};
+} lc709203_adjustment_t;
 
 /*!  Cell profile */
-using lc709203_cell_profile_t = enum {
+typedef enum {
   LC709203_NOM3p7_Charge4p2 = 1,
   LC709203_NOM3p8_Charge4p35 = 3,
   LC709203_NOM3p8_Charge4p35_Less500mAh = 6,
   LC709203_ICR18650_SAMSUNG = 5,
   LC709203_ICR18650_PANASONIC = 4
-};
+} lc709203_cell_profile_t;
 
 /*!  Cell temperature source */
-using lc709203_tempmode_t = enum {
+typedef enum {
   LC709203F_TEMPERATURE_I2C = 0x0000,
   LC709203F_TEMPERATURE_THERMISTOR = 0x0001,
-};
+} lc709203_tempmode_t;
 
 /*!  Chip power state */
-using lc709203_powermode_t = enum {
+typedef enum {
   LC709203F_POWER_OPERATE = 0x0001,
   LC709203F_POWER_SLEEP = 0x0002,
-};
+} lc709203_powermode_t;
 
 /*!
  *    @brief  Class that stores state and functions for interacting with
@@ -89,44 +89,44 @@ using lc709203_powermode_t = enum {
 // class LC709203F {
 class LC709203FComponent : public PollingComponent, public i2c::I2CDevice {
  public:
-  bool begin();
-  void init_rsoc();
+  bool begin(void);
+  void initRSOC(void);
 
-  void set_power_mode(lc709203_powermode_t t);
-  void set_cell_capacity(lc709203_adjustment_t apa);
-  void set_cell_profile(lc709203_cell_profile_t t);
+  void setPowerMode(lc709203_powermode_t t);
+  void setCellCapacity(lc709203_adjustment_t apa);
+  void setCellProfile(lc709203_cell_profile_t t);
 
-  uint16_t get_i_cversion();
-  uint16_t cell_voltage_m_v();
-  uint16_t cell_remaining_percent10();  // Remaining capacity in increments of 0.1% as integer
-  uint16_t cell_state_of_charge();       // In increments of 1% as integer
+  uint16_t getICversion(void);
+  uint16_t cellVoltage_mV(void);
+  uint16_t cellRemainingPercent10(void);  // Remaining capacity in increments of 0.1% as integer
+  uint16_t cellStateOfCharge(void);       // In increments of 1% as integer
 
-  uint16_t get_thermistor_beta();
-  void set_thermistor_b(uint16_t beta);
+  uint16_t getThermistorBeta(void);
+  void setThermistorB(uint16_t beta);
 
-  void set_temperature_mode(lc709203_tempmode_t t);
-  uint16_t get_cell_temperature();
-  void set_alarm_rsoc(uint8_t percent);
-  void set_alarm_voltage(float voltage);
+  void setTemperatureMode(lc709203_tempmode_t t);
+  uint16_t getCellTemperature(void);
+  void setAlarmRSOC(uint8_t percent);
+  void setAlarmVoltage(float voltage);
 
   //  added to align with esphome
-  void set_cell_voltage_sensor(sensor::Sensor *cell_voltage) { cell_voltage_ = cell_voltage; }
-  void set_cell_rem_percent_sensor(sensor::Sensor *cell_rem_percent) { cell_rem_percent_ = cell_rem_percent; }
+  void set_cellVoltage_sensor(sensor::Sensor *cellVoltage) { cellVoltage_ = cellVoltage; }
+  void set_cellRemPercent_sensor(sensor::Sensor *cellRemPercent) { cellRemPercent_ = cellRemPercent; }
   void set_icversion_sensor(sensor::Sensor *icversion) { icversion_ = icversion; }
-  void set_cell_charge_sensor(sensor::Sensor *cell_charge) { cell_charge_ = cell_charge; }
+  void set_cellCharge_sensor(sensor::Sensor *cellCharge) { cellCharge_ = cellCharge; }
   void setup() override;
   void update() override;
   void dump_config() override;
 
  protected:
-  void write16_(uint8_t reg_address, uint16_t data);
-  int16_t read16_(uint8_t reg_address);
+  void write16(uint8_t regAddress, uint16_t data);
+  int16_t read16(uint8_t regAddress);
 
   // added for esphome
-  sensor::Sensor *cell_voltage_;
-  sensor::Sensor *cell_rem_percent_;
+  sensor::Sensor *cellVoltage_;
+  sensor::Sensor *cellRemPercent_;
   sensor::Sensor *icversion_;
-  sensor::Sensor *cell_charge_;
+  sensor::Sensor *cellCharge_;
 };
 
 }  // namespace lc709203f

--- a/esphome/components/lc709203f/lc709203f.h
+++ b/esphome/components/lc709203f/lc709203f.h
@@ -99,7 +99,7 @@ class LC709203FComponent : public PollingComponent, public i2c::I2CDevice {
   uint16_t get_i_cversion();
   uint16_t cell_voltage_m_v();
   uint16_t cell_remaining_percent10();  // Remaining capacity in increments of 0.1% as integer
-  uint16_t cell_state_of_charge();       // In increments of 1% as integer
+  uint16_t cell_state_of_charge();      // In increments of 1% as integer
 
   uint16_t get_thermistor_beta();
   void set_thermistor_b(uint16_t beta);

--- a/esphome/components/lc709203f/sensor.py
+++ b/esphome/components/lc709203f/sensor.py
@@ -1,34 +1,48 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import i2c, sensor
-from esphome.const import CONF_ID,\
-    CONF_BATTERY_LEVEL, CONF_BATTERY_VOLTAGE, UNIT_VOLT, ICON_EMPTY, UNIT_PERCENT, UNIT_EMPTY
+from esphome.const import (
+    CONF_ID,
+    CONF_BATTERY_LEVEL,
+    CONF_BATTERY_VOLTAGE,
+    UNIT_VOLT,
+    ICON_EMPTY,
+    UNIT_PERCENT,
+    UNIT_EMPTY,
+)
 
-DEPENDENCIES = ['i2c']
+DEPENDENCIES = ["i2c"]
 
 # locally defined constant
 
-lc709203f_ns = cg.esphome_ns.namespace('lc709203f')
+lc709203f_ns = cg.esphome_ns.namespace("lc709203f")
 
-LC709203FComponent = lc709203f_ns.class_('LC709203FComponent', cg.PollingComponent, i2c.I2CDevice)
+LC709203FComponent = lc709203f_ns.class_(
+    "LC709203FComponent", cg.PollingComponent, i2c.I2CDevice
+)
 
-CONFIG_SCHEMA = cv.Schema({
-    cv.GenerateID(): cv.declare_id(LC709203FComponent),
-    cv.Optional(CONF_BATTERY_VOLTAGE):
-        sensor.sensor_schema(unit_of_measurement=UNIT_VOLT, icon=ICON_EMPTY, accuracy_decimals=2).extend({
-        }),
-    cv.Optional(CONF_BATTERY_LEVEL):
-        sensor.sensor_schema(unit_of_measurement=UNIT_PERCENT, icon=ICON_EMPTY, accuracy_decimals=1).extend({
-        }),
-    cv.Optional('cell_charge'):
-        sensor.sensor_schema(unit_of_measurement=UNIT_PERCENT, icon=ICON_EMPTY, accuracy_decimals=0).extend({
-        }),
-    #cv.Optional('icversion'): cv.uint16_t,
-    cv.Optional('icversion'):
-        sensor.sensor_schema(unit_of_measurement=UNIT_EMPTY, icon=ICON_EMPTY, accuracy_decimals=0).extend({
-        }),
-
-}).extend(cv.polling_component_schema('60s')).extend(i2c.i2c_device_schema(0x77))
+CONFIG_SCHEMA = (
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.declare_id(LC709203FComponent),
+            cv.Optional(CONF_BATTERY_VOLTAGE): sensor.sensor_schema(
+                unit_of_measurement=UNIT_VOLT, icon=ICON_EMPTY, accuracy_decimals=2
+            ).extend({}),
+            cv.Optional(CONF_BATTERY_LEVEL): sensor.sensor_schema(
+                unit_of_measurement=UNIT_PERCENT, icon=ICON_EMPTY, accuracy_decimals=1
+            ).extend({}),
+            cv.Optional("cell_charge"): sensor.sensor_schema(
+                unit_of_measurement=UNIT_PERCENT, icon=ICON_EMPTY, accuracy_decimals=0
+            ).extend({}),
+            # cv.Optional('icversion'): cv.uint16_t,
+            cv.Optional("icversion"): sensor.sensor_schema(
+                unit_of_measurement=UNIT_EMPTY, icon=ICON_EMPTY, accuracy_decimals=0
+            ).extend({}),
+        }
+    )
+    .extend(cv.polling_component_schema("60s"))
+    .extend(i2c.i2c_device_schema(0x77))
+)
 
 
 def to_code(config):
@@ -44,20 +58,20 @@ def to_code(config):
         sens = yield sensor.new_sensor(config[CONF_BATTERY_VOLTAGE])
         cg.add(var.set_cellVoltage_sensor(sens))
 
-    if 'cell_charge' in config:
-        sens = yield sensor.new_sensor(config['cell_charge'])
+    if "cell_charge" in config:
+        sens = yield sensor.new_sensor(config["cell_charge"])
         cg.add(var.set_cellCharge_sensor(sens))
 
-    if 'icversion'  in config:
-        sens = yield sensor.new_sensor(config['icversion'])
+    if "icversion" in config:
+        sens = yield sensor.new_sensor(config["icversion"])
         cg.add(var.set_icversion_sensor(sens))
 
 
-#/ read-only values
-#/ implement sensors for cellVoltage_mV, cellRemainingPercent10, cellStateOfCharge, getICversion
+# / read-only values
+# / implement sensors for cellVoltage_mV, cellRemainingPercent10, cellStateOfCharge, getICversion
 
-#/ write-only values
-#/ implement config for setPowerMode, setCellCapacity, setCellProfile, setAlarmRSOC, setAlarmVoltage
+# / write-only values
+# / implement config for setPowerMode, setCellCapacity, setCellProfile, setAlarmRSOC, setAlarmVoltage
 
-#/ uninstalled ( exsbc source )
-#/ getThermistorBeta, setThermistorB, setTemperatureMode, getCellTemperature, initRSOC
+# / uninstalled ( exsbc source )
+# / getThermistorBeta, setThermistorB, setTemperatureMode, getCellTemperature, initRSOC

--- a/esphome/components/lc709203f/sensor.py
+++ b/esphome/components/lc709203f/sensor.py
@@ -1,0 +1,63 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import i2c, sensor
+from esphome.const import CONF_ID,\
+    CONF_BATTERY_LEVEL, CONF_BATTERY_VOLTAGE, UNIT_VOLT, ICON_EMPTY, UNIT_PERCENT, UNIT_EMPTY
+
+DEPENDENCIES = ['i2c']
+
+# locally defined constant
+
+lc709203f_ns = cg.esphome_ns.namespace('lc709203f')
+
+LC709203FComponent = lc709203f_ns.class_('LC709203FComponent', cg.PollingComponent, i2c.I2CDevice)
+
+CONFIG_SCHEMA = cv.Schema({
+    cv.GenerateID(): cv.declare_id(LC709203FComponent),
+    cv.Optional(CONF_BATTERY_VOLTAGE):
+        sensor.sensor_schema(unit_of_measurement=UNIT_VOLT, icon=ICON_EMPTY, accuracy_decimals=2).extend({
+        }),
+    cv.Optional(CONF_BATTERY_LEVEL):
+        sensor.sensor_schema(unit_of_measurement=UNIT_PERCENT, icon=ICON_EMPTY, accuracy_decimals=1).extend({
+        }),
+    cv.Optional('cell_charge'):
+        sensor.sensor_schema(unit_of_measurement=UNIT_PERCENT, icon=ICON_EMPTY, accuracy_decimals=0).extend({
+        }),
+    #cv.Optional('icversion'): cv.uint16_t,
+    cv.Optional('icversion'):
+        sensor.sensor_schema(unit_of_measurement=UNIT_EMPTY, icon=ICON_EMPTY, accuracy_decimals=0).extend({
+        }),
+
+}).extend(cv.polling_component_schema('60s')).extend(i2c.i2c_device_schema(0x77))
+
+
+def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    yield cg.register_component(var, config)
+    yield i2c.register_i2c_device(var, config)
+
+    if CONF_BATTERY_LEVEL in config:
+        sens = yield sensor.new_sensor(config[CONF_BATTERY_LEVEL])
+        cg.add(var.set_cellRemPercent_sensor(sens))
+
+    if CONF_BATTERY_VOLTAGE in config:
+        sens = yield sensor.new_sensor(config[CONF_BATTERY_VOLTAGE])
+        cg.add(var.set_cellVoltage_sensor(sens))
+
+    if 'cell_charge' in config:
+        sens = yield sensor.new_sensor(config['cell_charge'])
+        cg.add(var.set_cellCharge_sensor(sens))
+
+    if 'icversion'  in config:
+        sens = yield sensor.new_sensor(config['icversion'])
+        cg.add(var.set_icversion_sensor(sens))
+
+
+#/ read-only values
+#/ implement sensors for cellVoltage_mV, cellRemainingPercent10, cellStateOfCharge, getICversion
+
+#/ write-only values
+#/ implement config for setPowerMode, setCellCapacity, setCellProfile, setAlarmRSOC, setAlarmVoltage
+
+#/ uninstalled ( exsbc source )
+#/ getThermistorBeta, setThermistorB, setTemperatureMode, getCellTemperature, initRSOC


### PR DESCRIPTION
# What does this implement/fix?

Adds support for the LC709203F component for monitoring battery status as a "fuel gauge". 


## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other


## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```
sensor:
  - platform: lc709203f
    address: "0x0B"
    i2c_id: bus_a
    battery_voltage:
      name: "Battery V"
    battery_level:
      id: battery
      name: "Battery lvl"
    icversion:
      name: "Version ic"
    cell_charge:
      name: "Cell charge"
    update_interval: 5s
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
