### PR TITLE
Handle case where using enetity level name: None with MQTT

### DIFF
--- a/esphome/components/mqtt/mqtt_component.cpp
+++ b/esphome/components/mqtt/mqtt_component.cpp
@@ -76,7 +76,10 @@ bool MQTTComponent::send_discovery_() {
         this->send_discovery(root, config);
 
         // Fields from EntityBase
-        root[MQTT_NAME] = this->friendly_name();
+        if (this->get_entity()->has_own_name())
+          root[MQTT_NAME] = this->friendly_name();
+        else
+          root[MQTT_NAME] = "";
         if (this->is_disabled_by_default())
           root[MQTT_ENABLED_BY_DEFAULT] = false;
         if (!this->get_icon().empty())

--- a/esphome/components/mqtt/mqtt_component.cpp
+++ b/esphome/components/mqtt/mqtt_component.cpp
@@ -76,10 +76,11 @@ bool MQTTComponent::send_discovery_() {
         this->send_discovery(root, config);
 
         // Fields from EntityBase
-        if (this->get_entity()->has_own_name())
+        if (this->get_entity()->has_own_name()) {
           root[MQTT_NAME] = this->friendly_name();
-        else
+        } else {
           root[MQTT_NAME] = "";
+        }
         if (this->is_disabled_by_default())
           root[MQTT_ENABLED_BY_DEFAULT] = false;
         if (!this->get_icon().empty())


### PR DESCRIPTION
# What does this implement/fix?

Sending a discovery message with the entity level `name = ""` and the device level name set with a friendly name works as intended:

{"name":"","ic":"mdi:power-socket-us","stat_t":"sb04/switch/sb04_relay/state","cmd_t":"sb04/switch/sb04_relay/command","avty_t":"sb04/status","uniq_id":"dc4f22ded8f3-switch-dd7e66f1","dev":{"ids":"dc4f22ded8f3","name":"SB04 Relay","sw":"esphome v2023.11.6 Dec  5 2023, 16:20:18","mdl":"esp01_1m","mf":"espressif","sa":""}}

Implementing this at the MQTT component level seems to make sense since this behavior should be consistent for all types of components whenever MQTT is used.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/5200

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [X] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
switch:
  - platform: gpio
    name: "None"
    icon: "mdi:power-socket-us"
    pin: GPIO12
    id: relay
    restore_mode: RESTORE_DEFAULT_ON

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
