### PR TITLE
Allow haier remote protocol to use lambdas

### DIFF
--- a/esphome/components/remote_base/haier_protocol.h
+++ b/esphome/components/remote_base/haier_protocol.h
@@ -26,12 +26,11 @@ DECLARE_REMOTE_PROTOCOL(Haier)
 
 template<typename... Ts> class HaierAction : public RemoteTransmitterActionBase<Ts...> {
  public:
-  TEMPLATABLE_VALUE(std::vector<uint8_t>, data)
+  TEMPLATABLE_VALUE(std::vector<uint8_t>, code)
 
-  void set_code(const std::vector<uint8_t> &code) { data_ = code; }
   void encode(RemoteTransmitData *dst, Ts... x) override {
     HaierData data{};
-    data.data = this->data_.value(x...);
+    data.data = this->code_.value(x...);
     HaierProtocol().encode(dst, data);
   }
 };


### PR DESCRIPTION
# What does this implement/fix?

Allows lambdas to be used for the `code` attribute in `remote_transmitter.transmit_haier`. Previous to this trying to use a lambda expression would cause a compilation error.

I changed `code` to be a `TEMPLATABLE_VALUE`, which allows us to remove the custom `set_code` function, which is used by the codegen in `__init__.py`.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/5159

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
```yaml
# Example config.yaml
button:
  - platform: template
    id: set_heat_22
    name: Set to 22C
    icon: "mdi:heat-wave"
    on_press:
      - remote_transmitter.transmit_haier:
          code: !lambda |-
            return { 0xA6, 0x6C, 0xF0, 0x00, 0x5B, 0x40, 0x1E, 0x80, 0x1E, 0x00, 0x00, 0x00, 0x00 };
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
