### PR TITLE
Fixed using lambda expressions as source values for Haier IR protocol

### DIFF
--- a/esphome/components/remote_base/__init__.py
+++ b/esphome/components/remote_base/__init__.py
@@ -1652,5 +1652,5 @@ def haier_dumper(var, config):
 @register_action("haier", HaierAction, HAIER_SCHEMA)
 async def haier_action(var, config, args):
     vec_ = cg.std_vector.template(cg.uint8)
-    template_ = await cg.templatable(config[CONF_CODE], args, vec_, vec_)
+    template_ = await cg.templatable(config[CONF_CODE], args, vec_)
     cg.add(var.set_code(template_))

--- a/esphome/components/remote_base/haier_protocol.h
+++ b/esphome/components/remote_base/haier_protocol.h
@@ -26,12 +26,12 @@ DECLARE_REMOTE_PROTOCOL(Haier)
 
 template<typename... Ts> class HaierAction : public RemoteTransmitterActionBase<Ts...> {
  public:
-  TEMPLATABLE_VALUE(std::vector<uint8_t>, data)
+  TEMPLATABLE_VALUE(std::vector<uint8_t>, code)
 
-  void set_code(const std::vector<uint8_t> &code) { data_ = code; }
+  void set_code(const std::vector<uint8_t> &code) { this->code_ = code; }
   void encode(RemoteTransmitData *dst, Ts... x) override {
     HaierData data{};
-    data.data = this->data_.value(x...);
+    data.data = this->code_.value(x...);
     HaierProtocol().encode(dst, data);
   }
 };


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->
Fix for lambdas with Haier IR protocol

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/5159

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
  - platform: template
    id: set_away
    name: Set Away
    on_press:
      - remote_transmitter.transmit_haier:
          code: !lambda |-
            return {1,2,3};
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
