### PR TITLE
Add support for lan867x Microchip 10BASE-T1S Single Pair Ethernet PHY

### DIFF
--- a/esphome/components/ethernet/__init__.py
+++ b/esphome/components/ethernet/__init__.py
@@ -2,7 +2,11 @@ import logging
 
 from esphome import pins
 import esphome.codegen as cg
-from esphome.components.esp32 import add_idf_sdkconfig_option, get_esp32_variant
+from esphome.components.esp32 import (
+    add_idf_component,
+    add_idf_sdkconfig_option,
+    get_esp32_variant,
+)
 from esphome.components.esp32.const import (
     VARIANT_ESP32C3,
     VARIANT_ESP32S2,
@@ -66,6 +70,7 @@ ETHERNET_TYPES = {
     "KSZ8081RNA": EthernetType.ETHERNET_TYPE_KSZ8081RNA,
     "W5500": EthernetType.ETHERNET_TYPE_W5500,
     "OPENETH": EthernetType.ETHERNET_TYPE_OPENETH,
+    "LAN867X": EthernetType.ETHERNET_TYPE_LAN867X,
 }
 
 SPI_ETHERNET_TYPES = ["W5500"]
@@ -132,6 +137,9 @@ def _validate(config):
         else:
             use_address = CORE.name + config[CONF_DOMAIN]
         config[CONF_USE_ADDRESS] = use_address
+    if config.get(CONF_TYPE) == "LAN867X":
+        validator = cv.require_framework_version(esp_idf=cv.Version(5, 3, 0))
+        validator(config)
     if config[CONF_TYPE] in SPI_ETHERNET_TYPES:
         if _is_framework_spi_polling_mode_supported():
             if CONF_POLLING_INTERVAL in config and CONF_INTERRUPT_PIN in config:
@@ -176,6 +184,7 @@ PHY_REGISTER_SCHEMA = cv.Schema(
         cv.Optional(CONF_PAGE_ID): cv.hex_int,
     }
 )
+
 RMII_SCHEMA = BASE_SCHEMA.extend(
     cv.Schema(
         {
@@ -222,6 +231,7 @@ CONFIG_SCHEMA = cv.All(
             "JL1101": RMII_SCHEMA,
             "KSZ8081": RMII_SCHEMA,
             "KSZ8081RNA": RMII_SCHEMA,
+            "LAN867X": RMII_SCHEMA,
             "W5500": SPI_SCHEMA,
             "OPENETH": BASE_SCHEMA,
         },
@@ -277,6 +287,17 @@ def phy_register(address: int, value: int, page: int):
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
+
+    if config[CONF_TYPE] == "LAN867X":
+        add_idf_component(
+            name="esp-eth-drivers",
+            repo="https://github.com/espressif/esp-eth-drivers.git",
+            ref="master",
+            path="lan867x",
+        )
+        add_idf_sdkconfig_option("CONFIG_GPIO_CTRL_FUNC_IN_IRAM", True)
+        add_idf_sdkconfig_option("CONFIG_ETHERNET_INTERNAL_SUPPORT", True)
+        add_idf_sdkconfig_option("CONFIG_ETHERNET_PHY_LAN867X", True)
 
     if config[CONF_TYPE] == "W5500":
         cg.add(var.set_clk_pin(config[CONF_CLK_PIN]))

--- a/esphome/components/ethernet/ethernet_component.cpp
+++ b/esphome/components/ethernet/ethernet_component.cpp
@@ -192,6 +192,12 @@ void EthernetComponent::setup() {
       break;
     }
 #endif
+#if ESP_IDF_VERSION_MAJOR >= 5 && ESP_IDF_VERSION_MINOR >= 3
+    case ETHERNET_TYPE_LAN867X: {
+      this->phy_ = esp_eth_phy_new_lan867x(&phy_config);
+      break;
+    }
+#endif
     default: {
       this->mark_failed();
       return;
@@ -316,6 +322,10 @@ void EthernetComponent::dump_config() {
 
     case ETHERNET_TYPE_OPENETH:
       eth_type = "OPENETH";
+      break;
+
+    case ETHERNET_TYPE_LAN867X:
+      eth_type = "LAN867X";
       break;
 
     default:

--- a/esphome/components/ethernet/ethernet_component.cpp
+++ b/esphome/components/ethernet/ethernet_component.cpp
@@ -130,14 +130,34 @@ void EthernetComponent::setup() {
   phy_config.reset_gpio_num = this->power_pin_;
 
 #if ESP_IDF_VERSION_MAJOR >= 5
+#if ESP_IDF_VERSION_MINOR >= 3 && ESP_IDF_VERSION_PATCH < 2
+  // fix https://github.com/espressif/esp-idf/commit/e9df36a2dfe9ee074f421aedaff8952a348b339d
+  // for v5.3.0 and v5.3.1
+  eth_esp32_emac_config_t esp32_emac_config = {
+      .smi_gpio = {.mdc_num = this->mdc_pin_, .mdio_num = this->mdio_pin_},
+      .interface = EMAC_DATA_INTERFACE_RMII,
+      .clock_config = {.rmii =
+                           {
+                               .clock_mode = this->clk_mode_,
+                               .clock_gpio = this->clk_gpio_,
+                           }},
+      .dma_burst_len = ETH_DMA_BURST_LEN_32,
+      .intr_priority = 0,
+  };
+#else  // ESP_IDF_VERSION_MINOR >= 3 && ESP_IDF_VERSION_PATCH > 2
   eth_esp32_emac_config_t esp32_emac_config = ETH_ESP32_EMAC_DEFAULT_CONFIG();
+#if ESP_IDF_VERSION_MINOR >= 3
+  esp32_emac_config.smi_gpio = {.mdc_num = this->mdc_pin_, .mdio_num = this->mdio_pin_};
+#else  // ESP_IDF_VERSION_MINOR < 3
   esp32_emac_config.smi_mdc_gpio_num = this->mdc_pin_;
   esp32_emac_config.smi_mdio_gpio_num = this->mdio_pin_;
+#endif
   esp32_emac_config.clock_config.rmii.clock_mode = this->clk_mode_;
   esp32_emac_config.clock_config.rmii.clock_gpio = this->clk_gpio_;
+#endif
 
   esp_eth_mac_t *mac = esp_eth_mac_new_esp32(&esp32_emac_config, &mac_config);
-#else
+#else  // ESP_IDF_VERSION_MAJOR < 5
   mac_config.smi_mdc_gpio_num = this->mdc_pin_;
   mac_config.smi_mdio_gpio_num = this->mdio_pin_;
   mac_config.clock_config.rmii.clock_mode = this->clk_mode_;

--- a/esphome/components/ethernet/ethernet_component.h
+++ b/esphome/components/ethernet/ethernet_component.h
@@ -12,6 +12,10 @@
 #include "esp_netif.h"
 #include "esp_mac.h"
 
+#if ESP_IDF_VERSION_MAJOR >= 5 && ESP_IDF_VERSION_MINOR >= 3
+#include "esp_eth_phy_lan867x.h"
+#endif
+
 namespace esphome {
 namespace ethernet {
 
@@ -26,6 +30,7 @@ enum EthernetType {
   ETHERNET_TYPE_KSZ8081RNA,
   ETHERNET_TYPE_W5500,
   ETHERNET_TYPE_OPENETH,
+  ETHERNET_TYPE_LAN867X,
 };
 
 struct ManualIP {


### PR DESCRIPTION
# What does this implement/fix?

Add driver for lan867x Microchip 10BASE-T1S Single Pair Ethernet PHY via espressif esp-eth-drivers component for IDF>=5.3

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/feature-requests/issues/2126

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#3449

## Test Environment

- [ ] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
esphome:
  name: jxd-e1-t1s
  name_add_mac_suffix: true

esp32:
  board: nodemcu-32s
  framework:
    type: esp-idf
    version: 5.3.0
    platform_version: 6.8.1
    # Custom sdkconfig options
    sdkconfig_options:
      CONFIG_GPIO_CTRL_FUNC_IN_IRAM: y
      CONFIG_ETHERNET_INTERNAL_SUPPORT: y
      CONFIG_ETHERNET_PHY_LAN867X: y


ethernet:
  type: LAN867x
  mdc_pin: GPIO23
  mdio_pin: GPIO18
  power_pin: GPIO17
  clk_mode: GPIO0_IN
  phy_addr: 0

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
