### PR TITLE
fix RGBW Mode on RP2040

### DIFF
--- a/esphome/components/rp2040_pio_led_strip/led_strip.cpp
+++ b/esphome/components/rp2040_pio_led_strip/led_strip.cpp
@@ -70,9 +70,10 @@ void RP2040PIOLEDStripLightOutput::write_state(light::LightState *state) {
 
   // assemble bits in buffer to 32 bit words with ex for GBR: 0bGGGGGGGGRRRRRRRRBBBBBBBB00000000
   for (int i = 0; i < this->num_leds_; i++) {
-    uint8_t c1 = this->buf_[(i * 3) + 0];
-    uint8_t c2 = this->buf_[(i * 3) + 1];
-    uint8_t c3 = this->buf_[(i * 3) + 2];
+    uint8_t multiplier = this->is_rgbw_ ? 4 : 3;
+    uint8_t c1 = this->buf_[(i * multiplier) + 0];
+    uint8_t c2 = this->buf_[(i * multiplier) + 1];
+    uint8_t c3 = this->buf_[(i * multiplier) + 2];
     uint8_t w = this->is_rgbw_ ? this->buf_[(i * 4) + 3] : 0;
     uint32_t color = encode_uint32(c1, c2, c3, w);
     pio_sm_put_blocking(this->pio_, this->sm_, color);


### PR DESCRIPTION
# What does this implement/fix?

this PR fixes an Issue in the rp2040_pio_led_strip component where the Colorbits are overwriting the Whitebit which leds to all Colors being wrong on RGBW Strips.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/5105

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** None

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [X] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
```yaml
light:
  - platform: rp2040_pio_led_strip
    name: led_strip
    id: led_strip
    pin: GPIO15
    num_leds: 144
    pio: 1
    rgb_order: GRB
    is_rgbw: true
    chipset: SK6812

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
