### PR TITLE
Fix 18 bit displays.

### DIFF
--- a/esphome/components/ili9xxx/ili9xxx_display.h
+++ b/esphome/components/ili9xxx/ili9xxx_display.h
@@ -30,13 +30,24 @@ class ILI9XXXDisplay : public display::DisplayBuffer,
     const uint8_t *addr = init_sequence;
     while ((cmd = *addr++) != 0) {
       num_args = *addr++ & 0x7F;
-      if (cmd == ILI9XXX_MADCTL) {
-        bits = *addr;
-        this->swap_xy_ = (bits & MADCTL_MV) != 0;
-        this->mirror_x_ = (bits & MADCTL_MX) != 0;
-        this->mirror_y_ = (bits & MADCTL_MY) != 0;
-        this->color_order_ = (bits & MADCTL_BGR) ? display::COLOR_ORDER_BGR : display::COLOR_ORDER_RGB;
-        break;
+      bits = *addr;
+      switch (cmd) {
+        case ILI9XXX_MADCTL: {
+          this->swap_xy_ = (bits & MADCTL_MV) != 0;
+          this->mirror_x_ = (bits & MADCTL_MX) != 0;
+          this->mirror_y_ = (bits & MADCTL_MY) != 0;
+          this->color_order_ = (bits & MADCTL_BGR) ? display::COLOR_ORDER_BGR : display::COLOR_ORDER_RGB;
+          break;
+        }
+
+        case ILI9XXX_PIXFMT: {
+          if ((bits & 0xF) == 6)
+            this->is_18bitdisplay_ = true;
+          break;
+        }
+
+        default:
+          break;
       }
       addr += num_args;
     }


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Changes recently to the `ili9xxx` component broke 18 bit displays (were being driven as 16 bit.)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
  - platform: ili9xxx
    data_rate: 20MHz
    model: ili9481-18
    invert_colors: true
    auto_clear_enabled: true
    dc_pin: GPIO27
    #reset_pin: GPIO21
    cs_pin:
      number: GPIO5
      ignore_strapping_warning: true
```


## Checklist:
  - [x] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
