### PR TITLE
Bump aioesphomeapi to 20.1.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ platformio==6.1.11  # When updating platformio, also update Dockerfile
 esptool==4.6.2
 click==8.1.7
 esphome-dashboard==20231107.0
-aioesphomeapi==20.0.0
+aioesphomeapi==20.1.0
 zeroconf==0.128.4
 python-magic==0.4.27
 


### PR DESCRIPTION
I'd usually let dependabot pick this up but I wanted to make sure the logging fix went in before beta

changelog: https://github.com/esphome/aioesphomeapi/compare/v20.0.0...v20.1.0

- Happy Eyeballs delay is now 0.1 (since ESPHome devices are less likely to be connected over the public internet)
- Improve logging with multiple addresses (it was confusing about which one we were actually connected over)
- Passing in multiple addresses is now supported by the lib, but its not currently used in ESPHome itself. At some point the Dashboard should be updated and `--device` should accept multiple addresses