### PR TITLE
Copy esp32 custom partition files to build folder

### DIFF
--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -497,10 +497,11 @@ async def to_code(config):
         add_idf_sdkconfig_option("CONFIG_ESP_TASK_WDT_CHECK_IDLE_TASK_CPU0", False)
         add_idf_sdkconfig_option("CONFIG_ESP_TASK_WDT_CHECK_IDLE_TASK_CPU1", False)
 
+        cg.add_platformio_option("board_build.partitions", "partitions.csv")
         if CONF_PARTITIONS in config:
-            cg.add_platformio_option("board_build.partitions", config[CONF_PARTITIONS])
-        else:
-            cg.add_platformio_option("board_build.partitions", "partitions.csv")
+            add_extra_build_file(
+                "partitions.csv", CORE.relative_config_path(config[CONF_PARTITIONS])
+            )
 
         for name, value in conf[CONF_SDKCONFIG_OPTIONS].items():
             add_idf_sdkconfig_option(name, RawSdkconfigValue(value))
@@ -639,20 +640,22 @@ def _write_sdkconfig():
 # Called by writer.py
 def copy_files():
     if CORE.using_arduino:
-        write_file_if_changed(
-            CORE.relative_build_path("partitions.csv"),
-            get_arduino_partition_csv(
-                CORE.platformio_options.get("board_upload.flash_size")
-            ),
-        )
+        if "partitions.csv" not in CORE.data[KEY_ESP32][KEY_EXTRA_BUILD_FILES]:
+            write_file_if_changed(
+                CORE.relative_build_path("partitions.csv"),
+                get_arduino_partition_csv(
+                    CORE.platformio_options.get("board_upload.flash_size")
+                ),
+            )
     if CORE.using_esp_idf:
         _write_sdkconfig()
-        write_file_if_changed(
-            CORE.relative_build_path("partitions.csv"),
-            get_idf_partition_csv(
-                CORE.platformio_options.get("board_upload.flash_size")
-            ),
-        )
+        if "partitions.csv" not in CORE.data[KEY_ESP32][KEY_EXTRA_BUILD_FILES]:
+            write_file_if_changed(
+                CORE.relative_build_path("partitions.csv"),
+                get_idf_partition_csv(
+                    CORE.platformio_options.get("board_upload.flash_size")
+                ),
+            )
         # IDF build scripts look for version string to put in the build.
         # However, if the build path does not have an initialized git repo,
         # and no version.txt file exists, the CMake script fails for some setups.


### PR DESCRIPTION
# What does this implement/fix?

Currently it is required to use an absolute path to the partitions file due to the config value being copied directly to `platformio.ini`. This change will copy any custom file into the build folder as `partitions.csv` and set that as the filename to use. This allows files to be relative to the config YAML file.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
