### PR TITLE
Exposes `load_settings` to `UARTComponent` class

### DIFF
--- a/esphome/components/uart/uart_component.h
+++ b/esphome/components/uart/uart_component.h
@@ -62,6 +62,10 @@ class UARTComponent {
   UARTParityOptions get_parity() const { return this->parity_; }
   void set_baud_rate(uint32_t baud_rate) { baud_rate_ = baud_rate; }
   uint32_t get_baud_rate() const { return baud_rate_; }
+#ifdef USE_ESP32
+  virtual void load_settings() = 0;
+  virtual void load_settings(bool dump_config) = 0;
+#endif  // USE_ESP32
 
 #ifdef USE_UART_DEBUGGER
   void add_debug_callback(std::function<void(UARTDirection, uint8_t)> &&callback) {

--- a/esphome/components/uart/uart_component_esp32_arduino.h
+++ b/esphome/components/uart/uart_component_esp32_arduino.h
@@ -45,7 +45,7 @@ class ESP32ArduinoUARTComponent : public UARTComponent, public Component {
    * This will load the current UART interface with the latest settings (baud_rate, parity, etc).
    */
   void load_settings(bool dump_config) override;
-  void load_settings() override { this->load_settings(false); }
+  void load_settings() override { this->load_settings(true); }
 
  protected:
   void check_logger_conflict() override;

--- a/esphome/components/uart/uart_component_esp32_arduino.h
+++ b/esphome/components/uart/uart_component_esp32_arduino.h
@@ -44,7 +44,8 @@ class ESP32ArduinoUARTComponent : public UARTComponent, public Component {
    *
    * This will load the current UART interface with the latest settings (baud_rate, parity, etc).
    */
-  void load_settings(bool dump_config = true);
+  void load_settings(bool dump_config) override;
+  void load_settings() override { this->load_settings(false); }
 
  protected:
   void check_logger_conflict() override;

--- a/esphome/components/uart/uart_component_esp_idf.h
+++ b/esphome/components/uart/uart_component_esp_idf.h
@@ -38,7 +38,8 @@ class IDFUARTComponent : public UARTComponent, public Component {
    *
    * This will load the current UART interface with the latest settings (baud_rate, parity, etc).
    */
-  void load_settings(bool dump_config = true);
+  void load_settings(bool dump_config) override;
+  void load_settings() override { this->load_settings(false); }
 
  protected:
   void check_logger_conflict() override;

--- a/esphome/components/uart/uart_component_esp_idf.h
+++ b/esphome/components/uart/uart_component_esp_idf.h
@@ -39,7 +39,7 @@ class IDFUARTComponent : public UARTComponent, public Component {
    * This will load the current UART interface with the latest settings (baud_rate, parity, etc).
    */
   void load_settings(bool dump_config) override;
-  void load_settings() override { this->load_settings(false); }
+  void load_settings() override { this->load_settings(true); }
 
  protected:
   void check_logger_conflict() override;


### PR DESCRIPTION
# What does this implement/fix?

This will expose `load_settings` (introduced on #5909) to `UARTComponent` class and any component using that class. I'm changing this as I wanna Nextion component to be able to change it's baud rate on the communication with the display without the need to create temporary UART components to handle it.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [X] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
N/A

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
