### PR TITLE
Fix the initial run of lambda light effects

### DIFF
--- a/esphome/components/light/addressable_light_effect.h
+++ b/esphome/components/light/addressable_light_effect.h
@@ -57,7 +57,7 @@ class AddressableLambdaLightEffect : public AddressableLightEffect {
   void start() override { this->initial_run_ = true; }
   void apply(AddressableLight &it, const Color &current_color) override {
     const uint32_t now = millis();
-    if (now - this->last_run_ >= this->update_interval_) {
+    if (now - this->last_run_ >= this->update_interval_ || this->initial_run_) {
       this->last_run_ = now;
       this->f_(it, current_color, this->initial_run_);
       this->initial_run_ = false;

--- a/esphome/components/light/base_light_effects.h
+++ b/esphome/components/light/base_light_effects.h
@@ -118,7 +118,7 @@ class LambdaLightEffect : public LightEffect {
   void start() override { this->initial_run_ = true; }
   void apply() override {
     const uint32_t now = millis();
-    if (now - this->last_run_ >= this->update_interval_) {
+    if (now - this->last_run_ >= this->update_interval_ || this->initial_run_) {
       this->last_run_ = now;
       this->f_(this->initial_run_);
       this->initial_run_ = false;


### PR DESCRIPTION
The timer used for `millis()` is a monotonic timer based on the last start time of the device. If, for some reason, you pick a long `update_interval` and try to apply it as soon as you start the device, nothing happens because the device hasn't been on for longer than the `update_interval`

Why would you want a long `update_interval`? Data-over-power lights tend to flicker with updates, so maybe you have a slower or static effect you want to apply immediately but run slowly.

# What does this implement/fix?

Lambda light effects now apply immediately, regardless of `update_interval` or `millis()` uptime.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable): N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
```yaml
light:
  - ...
    effects:
      - addressable_lambda:
          name: Candy Cane
          update_interval: 1h
          lambda: |-
            for (int i = 0; i < it.size(); i++) {
              if (i & 1) {
                it[i] = Color(255, 0, 0);
              } else {
                it[i] = Color(255, 255, 255);
              }
            }
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
