### PR TITLE
Add ability to lock to set mode

### DIFF
--- a/esphome/components/hlw8012/hlw8012.cpp
+++ b/esphome/components/hlw8012/hlw8012.cpp
@@ -96,7 +96,7 @@ void HLW8012Component::update() {
     this->energy_sensor_->publish_state(energy);
   }
 
-  if (this->change_mode_at_++ == this->change_mode_every_) {
+  if (this->change_mode_every_ != 0 && this->change_mode_at_++ == this->change_mode_every_) {
     this->current_mode_ = !this->current_mode_;
     ESP_LOGV(TAG, "Changing mode to %s mode", this->current_mode_ ? "CURRENT" : "VOLTAGE");
     this->change_mode_at_ = 0;

--- a/esphome/components/hlw8012/sensor.py
+++ b/esphome/components/hlw8012/sensor.py
@@ -79,8 +79,9 @@ CONFIG_SCHEMA = cv.Schema(
         cv.Optional(CONF_CURRENT_RESISTOR, default=0.001): cv.resistance,
         cv.Optional(CONF_VOLTAGE_DIVIDER, default=2351): cv.positive_float,
         cv.Optional(CONF_MODEL, default="HLW8012"): cv.enum(MODELS, upper=True),
-        cv.Optional(CONF_CHANGE_MODE_EVERY, default=8): cv.All(
-            cv.uint32_t, cv.Range(min=1)
+        cv.Optional(CONF_CHANGE_MODE_EVERY, default=8): cv.Any(
+            "never",
+            cv.All(cv.uint32_t, cv.Range(min=1)),
         ),
         cv.Optional(CONF_INITIAL_MODE, default=CONF_VOLTAGE): cv.one_of(
             *INITIAL_MODES, lower=True
@@ -114,6 +115,10 @@ async def to_code(config):
         cg.add(var.set_energy_sensor(sens))
     cg.add(var.set_current_resistor(config[CONF_CURRENT_RESISTOR]))
     cg.add(var.set_voltage_divider(config[CONF_VOLTAGE_DIVIDER]))
-    cg.add(var.set_change_mode_every(config[CONF_CHANGE_MODE_EVERY]))
     cg.add(var.set_initial_mode(INITIAL_MODES[config[CONF_INITIAL_MODE]]))
     cg.add(var.set_sensor_model(config[CONF_MODEL]))
+
+    interval = config[CONF_CHANGE_MODE_EVERY]
+    if interval == "never":
+        interval = 0
+    cg.add(var.set_change_mode_every(interval))

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -794,7 +794,7 @@ sensor:
     update_interval: 15s
     current_resistor: 0.001 ohm
     voltage_divider: 2351
-    change_mode_every: 16
+    change_mode_every: "never"
     initial_mode: VOLTAGE
     model: hlw8012
   - platform: total_daily_energy


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->
It allows locking the read out of the HLW8012 component to a single mode (e.g current or voltage). This is useful when you're not interested in one of the two values and want to continuously read back the other.

This allows the `change_mode_every` parameter to be set to `"never"` which locks the mode to the set `initial_mode`.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** https://github.com/esphome/esphome-docs/pull/3473

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [x] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

With the below config the `mode` will be locked to `VOLTAGE`.

```yaml
# Example config.yaml
  - platform: hlw8012
    change_mode_every: "never"
    initial_mode: VOLTAGE
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
