### PR TITLE
Fix build error when building with IDF and S2 or S3 variants

### DIFF
--- a/esphome/components/wifi/__init__.py
+++ b/esphome/components/wifi/__init__.py
@@ -296,12 +296,12 @@ CONFIG_SCHEMA = cv.All(
             cv.SplitDefault(CONF_OUTPUT_POWER, esp8266=20.0): cv.All(
                 cv.decibel, cv.float_range(min=8.5, max=20.5)
             ),
-            cv.SplitDefault(CONF_ENABLE_BTM, esp32_idf=False): cv.All(
-                cv.boolean, cv.only_with_esp_idf
-            ),
-            cv.SplitDefault(CONF_ENABLE_RRM, esp32_idf=False): cv.All(
-                cv.boolean, cv.only_with_esp_idf
-            ),
+            cv.SplitDefault(
+                CONF_ENABLE_BTM, esp32_idf=False, esp32_s2_idf=False, esp32_s3_idf=False
+            ): cv.All(cv.boolean, cv.only_with_esp_idf),
+            cv.SplitDefault(
+                CONF_ENABLE_RRM, esp32_idf=False, esp32_s2_idf=False, esp32_s3_idf=False
+            ): cv.All(cv.boolean, cv.only_with_esp_idf),
             cv.Optional(CONF_PASSIVE_SCAN, default=False): cv.boolean,
             cv.Optional("enable_mdns"): cv.invalid(
                 "This option has been removed. Please use the [disabled] option under the "


### PR DESCRIPTION
# What does this implement/fix?

I just stumbled across this error when building with IDF and S2 and S3 variants:

```
INFO Generating C++ source...
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/Users/kburzinski/Development/Embedded/Espressif/esphome/esphome/esphome/__main__.py", line 1050, in <module>
    sys.exit(main())
             ^^^^^^
  File "/Users/kburzinski/Development/Embedded/Espressif/esphome/esphome/esphome/__main__.py", line 1041, in main
    return run_esphome(sys.argv)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/kburzinski/Development/Embedded/Espressif/esphome/esphome/esphome/__main__.py", line 1028, in run_esphome
    rc = POST_CONFIG_ACTIONS[args.command](args, config)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/kburzinski/Development/Embedded/Espressif/esphome/esphome/esphome/__main__.py", line 458, in command_run
    exit_code = write_cpp(config)
                ^^^^^^^^^^^^^^^^^
  File "/Users/kburzinski/Development/Embedded/Espressif/esphome/esphome/esphome/__main__.py", line 192, in write_cpp
    generate_cpp_contents(config)
  File "/Users/kburzinski/Development/Embedded/Espressif/esphome/esphome/esphome/__main__.py", line 204, in generate_cpp_contents
    CORE.flush_tasks()
  File "/Users/kburzinski/Development/Embedded/Espressif/esphome/esphome/esphome/core/__init__.py", line 679, in flush_tasks
    self.event_loop.flush_tasks()
  File "/Users/kburzinski/Development/Embedded/Espressif/esphome/esphome/esphome/coroutine.py", line 246, in flush_tasks
    next(task.iterator)
  File "/Users/kburzinski/Development/Embedded/Espressif/esphome/esphome/esphome/__main__.py", line 184, in wrapped
    await coro(conf)
  File "/Users/kburzinski/Development/Embedded/Espressif/esphome/esphome/esphome/components/wifi/__init__.py", line 428, in to_code
    if config[CONF_ENABLE_BTM] or config[CONF_ENABLE_RRM]:
       ~~~~~~^^^^^^^^^^^^^^^^^
KeyError: 'enable_btm'
```

...this PR fixes the error.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
