### PR TITLE
Fix SplitDefault with variants

### DIFF
--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -1518,6 +1518,13 @@ class GenerateID(Optional):
         super().__init__(key, default=lambda: None)
 
 
+def _get_priority_default(*args):
+    for arg in args:
+        if arg is not vol.UNDEFINED:
+            return arg
+    return vol.UNDEFINED
+
+
 class SplitDefault(Optional):
     """Mark this key to have a split default for ESP8266/ESP32."""
 
@@ -1542,30 +1549,22 @@ class SplitDefault(Optional):
         super().__init__(key)
         self._esp8266_default = vol.default_factory(esp8266)
         self._esp32_arduino_default = vol.default_factory(
-            esp32_arduino if esp32 is vol.UNDEFINED else esp32
+            _get_priority_default(esp32, esp32_arduino)
         )
         self._esp32_idf_default = vol.default_factory(
-            esp32_idf if esp32 is vol.UNDEFINED else esp32
+            _get_priority_default(esp32, esp32_idf)
         )
         self._esp32_s2_arduino_default = vol.default_factory(
-            (esp32_s2_arduino if esp32 is vol.UNDEFINED else esp32)
-            if esp32_s2 is vol.UNDEFINED
-            else esp32_s2
+            _get_priority_default(esp32_s2, esp32, esp32_s2_arduino, esp32_arduino)
         )
         self._esp32_s2_idf_default = vol.default_factory(
-            (esp32_s2_idf if esp32 is vol.UNDEFINED else esp32)
-            if esp32_s2 is vol.UNDEFINED
-            else esp32_s2
+            _get_priority_default(esp32_s2, esp32, esp32_s2_idf, esp32_idf)
         )
         self._esp32_s3_arduino_default = vol.default_factory(
-            (esp32_s3_arduino if esp32 is vol.UNDEFINED else esp32)
-            if esp32_s3 is vol.UNDEFINED
-            else esp32_s3
+            _get_priority_default(esp32_s3, esp32, esp32_s3_arduino, esp32_arduino)
         )
         self._esp32_s3_idf_default = vol.default_factory(
-            (esp32_s3_idf if esp32 is vol.UNDEFINED else esp32)
-            if esp32_s3 is vol.UNDEFINED
-            else esp32_s3
+            _get_priority_default(esp32_s3, esp32, esp32_s3_idf, esp32_idf)
         )
         self._rp2040_default = vol.default_factory(rp2040)
         self._bk72xx_default = vol.default_factory(bk72xx)


### PR DESCRIPTION
# What does this implement/fix?

See [discussion on Discord](https://discord.com/channels/429907082951524364/1184758253092085820)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
