### PR TITLE
Revert pure virtual functions in UART component from #5920

### DIFF
--- a/esphome/components/uart/uart_component.h
+++ b/esphome/components/uart/uart_component.h
@@ -63,8 +63,8 @@ class UARTComponent {
   void set_baud_rate(uint32_t baud_rate) { baud_rate_ = baud_rate; }
   uint32_t get_baud_rate() const { return baud_rate_; }
 #ifdef USE_ESP32
-  virtual void load_settings() = 0;
-  virtual void load_settings(bool dump_config) = 0;
+  virtual void load_settings(){};
+  virtual void load_settings(bool dump_config){};
 #endif  // USE_ESP32
 
 #ifdef USE_UART_DEBUGGER

--- a/esphome/components/uart/uart_component.h
+++ b/esphome/components/uart/uart_component.h
@@ -134,7 +134,7 @@ class UARTComponent {
    *
    * This will load the current UART interface with the latest settings (baud_rate, parity, etc).
    */
-  virtual void load_settings(bool dump_config) {};
+  virtual void load_settings(bool dump_config){};
 
   /**
    * Load the UART settings.
@@ -146,7 +146,7 @@ class UARTComponent {
    *
    * This will load the current UART interface with the latest settings (baud_rate, parity, etc).
    */
-  virtual void load_settings() {};
+  virtual void load_settings(){};
 #endif  // USE_ESP32
 
 #ifdef USE_UART_DEBUGGER


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->
PR5920 has introduced a braking change by adding two PURE virtual functions. Therefore **ANY** class derived from UARTComponent will **not compile anymore** !!! Big badaboom

This fix keeps the two new virtual functions introduced in PR5920 but not as PURE VIRTUAL functions.
What's amazing is that there was absolutely no reason to make them pure virtual ???

For more info see my comment on https://github.com/esphome/esphome/pull/5920

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>
https://github.com/esphome/esphome/pull/5920

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
NA


## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
