### PR TITLE
esp32_ble_beacon: Delete setup task after setup

### DIFF
--- a/esphome/components/esp32_ble_beacon/esp32_ble_beacon.cpp
+++ b/esphome/components/esp32_ble_beacon/esp32_ble_beacon.cpp
@@ -74,9 +74,7 @@ float ESP32BLEBeacon::get_setup_priority() const { return setup_priority::BLUETO
 void ESP32BLEBeacon::ble_core_task(void *params) {
   ble_setup();
 
-  while (true) {
-    delay(1000);  // NOLINT
-  }
+  vTaskDelete(nullptr);
 }
 
 void ESP32BLEBeacon::ble_setup() {


### PR DESCRIPTION
# What does this implement/fix?

The task does nothing after setup except consuming CPU cycles. Delete the task instead.

<!-- Quick description and explanation of changes -->

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
