### PR TITLE
Fix - Tuya Fan - Allow integer speed datapoint

### DIFF
--- a/esphome/components/tuya/fan/tuya_fan.cpp
+++ b/esphome/components/tuya/fan/tuya_fan.cpp
@@ -9,13 +9,20 @@ static const char *const TAG = "tuya.fan";
 void TuyaFan::setup() {
   if (this->speed_id_.has_value()) {
     this->parent_->register_listener(*this->speed_id_, [this](const TuyaDatapoint &datapoint) {
-      ESP_LOGV(TAG, "MCU reported speed of: %d", datapoint.value_enum);
-      if (datapoint.value_enum >= this->speed_count_) {
-        ESP_LOGE(TAG, "Speed has invalid value %d", datapoint.value_enum);
-      } else {
-        this->speed = datapoint.value_enum + 1;
+      if (datapoint.type == TuyaDatapointType::ENUM) {
+        ESP_LOGV(TAG, "MCU reported speed of: %d", datapoint.value_enum);
+        if (datapoint.value_enum >= this->speed_count_) {
+          ESP_LOGE(TAG, "Speed has invalid value %d", datapoint.value_enum);
+        } else {
+          this->speed = datapoint.value_enum + 1;
+          this->publish_state();
+        }
+      } else if (datapoint.type == TuyaDatapointType::INTEGER) {
+        ESP_LOGV(TAG, "MCU reported speed of: %d", datapoint.value_int);
+        this->speed = datapoint.value_int;
         this->publish_state();
       }
+      this->speed_type_ = datapoint.type;
     });
   }
   if (this->switch_id_.has_value()) {
@@ -80,7 +87,11 @@ void TuyaFan::control(const fan::FanCall &call) {
     this->parent_->set_enum_datapoint_value(*this->direction_id_, enable);
   }
   if (this->speed_id_.has_value() && call.get_speed().has_value()) {
-    this->parent_->set_enum_datapoint_value(*this->speed_id_, *call.get_speed() - 1);
+    if (this->speed_type_ == TuyaDatapointType::ENUM) {
+      this->parent_->set_enum_datapoint_value(*this->speed_id_, *call.get_speed() - 1);
+    } else if (this->speed_type_ == TuyaDatapointType::INTEGER) {
+      this->parent_->set_integer_datapoint_value(*this->speed_id_, *call.get_speed());
+    }
   }
 }
 

--- a/esphome/components/tuya/fan/tuya_fan.h
+++ b/esphome/components/tuya/fan/tuya_fan.h
@@ -28,6 +28,7 @@ class TuyaFan : public Component, public fan::Fan {
   optional<uint8_t> oscillation_id_{};
   optional<uint8_t> direction_id_{};
   int speed_count_{};
+  TuyaDatapointType speed_type_{};
 };
 
 }  // namespace tuya


### PR DESCRIPTION
# What does this implement/fix?

Currently, only ENUM datapoints for fan speed are handled in the Tuya Fan integration, though some devices use INTEGER datapoints for this. Just added functionality in Tuya Fan to use integers as per the Tuya Number component.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/2902

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [X] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
fan:
  - platform: tuya
    name: APDC160WHA
    switch_datapoint: 1
    speed_datapoint: 3  # <-- This is an INTEGER datapoint
    speed_count: 15
    oscillation_datapoint: 5
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
