### PR TITLE
Revert "Bump build-image action versions"

### DIFF
--- a/.github/actions/build-image/action.yaml
+++ b/.github/actions/build-image/action.yaml
@@ -36,7 +36,7 @@ runs:
 
     - name: Build and push to ghcr by digest
       id: build-ghcr
-      uses: docker/build-push-action@v5.1.0
+      uses: docker/build-push-action@v5.0.0
       with:
         context: .
         file: ./docker/Dockerfile
@@ -58,7 +58,7 @@ runs:
         touch "/tmp/digests/${{ inputs.target }}/ghcr/${digest#sha256:}"
 
     - name: Upload ghcr digest
-      uses: actions/upload-artifact@v4.0.0
+      uses: actions/upload-artifact@v3.1.3
       with:
         name: digests-${{ inputs.target }}-ghcr
         path: /tmp/digests/${{ inputs.target }}/ghcr/*
@@ -67,7 +67,7 @@ runs:
 
     - name: Build and push to dockerhub by digest
       id: build-dockerhub
-      uses: docker/build-push-action@v5.1.0
+      uses: docker/build-push-action@v5.0.0
       with:
         context: .
         file: ./docker/Dockerfile
@@ -89,7 +89,7 @@ runs:
         touch "/tmp/digests/${{ inputs.target }}/dockerhub/${digest#sha256:}"
 
     - name: Upload dockerhub digest
-      uses: actions/upload-artifact@v4.0.0
+      uses: actions/upload-artifact@v3.1.3
       with:
         name: digests-${{ inputs.target }}-dockerhub
         path: /tmp/digests/${{ inputs.target }}/dockerhub/*


### PR DESCRIPTION
Reverts esphome/esphome#5954

upload-artifact@v4 has a breaking change that means you cannot upload from multiple jobs into the same named artifact as our release flow is currently using.