### PR TITLE
Revert "Bump actions/download-artifact from 3.0.2 to 4.0.0"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -158,7 +158,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4.1.1
       - name: Download digests
-        uses: actions/download-artifact@v4.0.0
+        uses: actions/download-artifact@v3.0.2
         with:
           name: digests-${{ matrix.image.target }}-${{ matrix.registry }}
           path: /tmp/digests


### PR DESCRIPTION
Reverts esphome/esphome#5936

After reverting upload-artifact back to v3 in #5955, since v3 and v4 are not compatible, this needs to be reverted.

- https://github.com/orgs/aio-libs/discussions/31
- https://github.com/actions/upload-artifact/issues/472