### PR TITLE
2023.12.0b3

### DIFF
--- a/esphome/components/esp32_camera/esp32_camera.cpp
+++ b/esphome/components/esp32_camera/esp32_camera.cpp
@@ -37,7 +37,7 @@ void ESP32Camera::setup() {
                           "framebuffer_task",  // name
                           1024,                // stack size
                           nullptr,             // task pv params
-                          0,                   // priority
+                          1,                   // priority
                           nullptr,             // handle
                           1                    // core
   );

--- a/esphome/components/i2s_audio/speaker/i2s_audio_speaker.cpp
+++ b/esphome/components/i2s_audio/speaker/i2s_audio_speaker.cpp
@@ -29,7 +29,7 @@ void I2SAudioSpeaker::start_() {
   }
   this->state_ = speaker::STATE_RUNNING;
 
-  xTaskCreate(I2SAudioSpeaker::player_task, "speaker_task", 8192, (void *) this, 0, &this->player_task_handle_);
+  xTaskCreate(I2SAudioSpeaker::player_task, "speaker_task", 8192, (void *) this, 1, &this->player_task_handle_);
 }
 
 void I2SAudioSpeaker::player_task(void *params) {

--- a/esphome/components/logger/logger.cpp
+++ b/esphome/components/logger/logger.cpp
@@ -237,8 +237,8 @@ void Logger::pre_setup() {
         Serial1.begin(this->baud_rate_);
 #else
 #if ARDUINO_USB_CDC_ON_BOOT
-        this->hw_serial_ = &Serial;
-        Serial.begin(this->baud_rate_);
+        this->hw_serial_ = &Serial0;
+        Serial0.begin(this->baud_rate_);
 #else
         this->hw_serial_ = &Serial;
         Serial.begin(this->baud_rate_);

--- a/esphome/components/tuya/fan/tuya_fan.cpp
+++ b/esphome/components/tuya/fan/tuya_fan.cpp
@@ -9,13 +9,20 @@ static const char *const TAG = "tuya.fan";
 void TuyaFan::setup() {
   if (this->speed_id_.has_value()) {
     this->parent_->register_listener(*this->speed_id_, [this](const TuyaDatapoint &datapoint) {
-      ESP_LOGV(TAG, "MCU reported speed of: %d", datapoint.value_enum);
-      if (datapoint.value_enum >= this->speed_count_) {
-        ESP_LOGE(TAG, "Speed has invalid value %d", datapoint.value_enum);
-      } else {
-        this->speed = datapoint.value_enum + 1;
+      if (datapoint.type == TuyaDatapointType::ENUM) {
+        ESP_LOGV(TAG, "MCU reported speed of: %d", datapoint.value_enum);
+        if (datapoint.value_enum >= this->speed_count_) {
+          ESP_LOGE(TAG, "Speed has invalid value %d", datapoint.value_enum);
+        } else {
+          this->speed = datapoint.value_enum + 1;
+          this->publish_state();
+        }
+      } else if (datapoint.type == TuyaDatapointType::INTEGER) {
+        ESP_LOGV(TAG, "MCU reported speed of: %d", datapoint.value_int);
+        this->speed = datapoint.value_int;
         this->publish_state();
       }
+      this->speed_type_ = datapoint.type;
     });
   }
   if (this->switch_id_.has_value()) {
@@ -80,7 +87,11 @@ void TuyaFan::control(const fan::FanCall &call) {
     this->parent_->set_enum_datapoint_value(*this->direction_id_, enable);
   }
   if (this->speed_id_.has_value() && call.get_speed().has_value()) {
-    this->parent_->set_enum_datapoint_value(*this->speed_id_, *call.get_speed() - 1);
+    if (this->speed_type_ == TuyaDatapointType::ENUM) {
+      this->parent_->set_enum_datapoint_value(*this->speed_id_, *call.get_speed() - 1);
+    } else if (this->speed_type_ == TuyaDatapointType::INTEGER) {
+      this->parent_->set_integer_datapoint_value(*this->speed_id_, *call.get_speed());
+    }
   }
 }
 

--- a/esphome/components/tuya/fan/tuya_fan.h
+++ b/esphome/components/tuya/fan/tuya_fan.h
@@ -28,6 +28,7 @@ class TuyaFan : public Component, public fan::Fan {
   optional<uint8_t> oscillation_id_{};
   optional<uint8_t> direction_id_{};
   int speed_count_{};
+  TuyaDatapointType speed_type_{};
 };
 
 }  // namespace tuya

--- a/esphome/components/uart/uart_component.h
+++ b/esphome/components/uart/uart_component.h
@@ -134,7 +134,7 @@ class UARTComponent {
    *
    * This will load the current UART interface with the latest settings (baud_rate, parity, etc).
    */
-  virtual void load_settings(bool dump_config) = 0;
+  virtual void load_settings(bool dump_config){};
 
   /**
    * Load the UART settings.
@@ -146,7 +146,7 @@ class UARTComponent {
    *
    * This will load the current UART interface with the latest settings (baud_rate, parity, etc).
    */
-  virtual void load_settings() = 0;
+  virtual void load_settings(){};
 #endif  // USE_ESP32
 
 #ifdef USE_UART_DEBUGGER

--- a/esphome/components/uart/uart_component.h
+++ b/esphome/components/uart/uart_component.h
@@ -31,40 +31,122 @@ const LogString *parity_to_str(UARTParityOptions parity);
 
 class UARTComponent {
  public:
+  // Writes an array of bytes to the UART bus.
+  // @param data A vector of bytes to be written.
   void write_array(const std::vector<uint8_t> &data) { this->write_array(&data[0], data.size()); }
+
+  // Writes a single byte to the UART bus.
+  // @param data The byte to be written.
   void write_byte(uint8_t data) { this->write_array(&data, 1); };
+
+  // Writes a null-terminated string to the UART bus.
+  // @param str Pointer to the null-terminated string.
   void write_str(const char *str) {
     const auto *data = reinterpret_cast<const uint8_t *>(str);
     this->write_array(data, strlen(str));
   };
 
+  // Pure virtual method to write an array of bytes to the UART bus.
+  // @param data Pointer to the array of bytes.
+  // @param len Length of the array.
   virtual void write_array(const uint8_t *data, size_t len) = 0;
 
+  // Reads a single byte from the UART bus.
+  // @param data Pointer to the byte where the read data will be stored.
+  // @return True if a byte was successfully read, false otherwise.
   bool read_byte(uint8_t *data) { return this->read_array(data, 1); };
+
+  // Pure virtual method to peek the next byte in the UART buffer without removing it.
+  // @param data Pointer to the byte where the peeked data will be stored.
+  // @return True if a byte is available to peek, false otherwise.
   virtual bool peek_byte(uint8_t *data) = 0;
+
+  // Pure virtual method to read an array of bytes from the UART bus.
+  // @param data Pointer to the array where the read data will be stored.
+  // @param len Number of bytes to read.
+  // @return True if the specified number of bytes were successfully read, false otherwise.
   virtual bool read_array(uint8_t *data, size_t len) = 0;
 
-  /// Return available number of bytes.
+  // Pure virtual method to return the number of bytes available for reading.
+  // @return Number of available bytes.
   virtual int available() = 0;
-  /// Block until all bytes have been written to the UART bus.
+
+  // Pure virtual method to block until all bytes have been written to the UART bus.
   virtual void flush() = 0;
 
+  // Sets the TX (transmit) pin for the UART bus.
+  // @param tx_pin Pointer to the internal GPIO pin used for transmission.
   void set_tx_pin(InternalGPIOPin *tx_pin) { this->tx_pin_ = tx_pin; }
+
+  // Sets the RX (receive) pin for the UART bus.
+  // @param rx_pin Pointer to the internal GPIO pin used for reception.
   void set_rx_pin(InternalGPIOPin *rx_pin) { this->rx_pin_ = rx_pin; }
+
+  // Sets the size of the RX buffer.
+  // @param rx_buffer_size Size of the RX buffer in bytes.
   void set_rx_buffer_size(size_t rx_buffer_size) { this->rx_buffer_size_ = rx_buffer_size; }
+
+  // Gets the size of the RX buffer.
+  // @return Size of the RX buffer in bytes.
   size_t get_rx_buffer_size() { return this->rx_buffer_size_; }
 
+  // Sets the number of stop bits used in UART communication.
+  // @param stop_bits Number of stop bits.
   void set_stop_bits(uint8_t stop_bits) { this->stop_bits_ = stop_bits; }
+
+  // Gets the number of stop bits used in UART communication.
+  // @return Number of stop bits.
   uint8_t get_stop_bits() const { return this->stop_bits_; }
+
+  // Set the number of data bits used in UART communication.
+  // @param data_bits Number of data bits.
   void set_data_bits(uint8_t data_bits) { this->data_bits_ = data_bits; }
+
+  // Get the number of data bits used in UART communication.
+  // @return Number of data bits.
   uint8_t get_data_bits() const { return this->data_bits_; }
+
+  // Set the parity used in UART communication.
+  // @param parity Parity option.
   void set_parity(UARTParityOptions parity) { this->parity_ = parity; }
+
+  // Get the parity used in UART communication.
+  // @return Parity option.
   UARTParityOptions get_parity() const { return this->parity_; }
+
+  // Set the baud rate for UART communication.
+  // @param baud_rate Baud rate in bits per second.
   void set_baud_rate(uint32_t baud_rate) { baud_rate_ = baud_rate; }
+
+  // Get the baud rate for UART communication.
+  // @return Baud rate in bits per second.
   uint32_t get_baud_rate() const { return baud_rate_; }
+
 #ifdef USE_ESP32
-  virtual void load_settings() = 0;
+  /**
+   * Load the UART settings.
+   * @param dump_config If true (default), output the new settings to logs; otherwise, change settings quietly.
+   *
+   * Example:
+   * ```cpp
+   * id(uart1).load_settings(false);
+   * ```
+   *
+   * This will load the current UART interface with the latest settings (baud_rate, parity, etc).
+   */
   virtual void load_settings(bool dump_config) = 0;
+
+  /**
+   * Load the UART settings.
+   *
+   * Example:
+   * ```cpp
+   * id(uart1).load_settings();
+   * ```
+   *
+   * This will load the current UART interface with the latest settings (baud_rate, parity, etc).
+   */
+  virtual void load_settings() = 0;
 #endif  // USE_ESP32
 
 #ifdef USE_UART_DEBUGGER

--- a/esphome/components/web_server_idf/web_server_idf.h
+++ b/esphome/components/web_server_idf/web_server_idf.h
@@ -117,7 +117,7 @@ class AsyncWebServerRequest {
   // NOLINTNEXTLINE(readability-identifier-naming)
   AsyncWebServerResponse *beginResponse(int code, const char *content_type) {
     auto *res = new AsyncWebServerResponseEmpty(this);  // NOLINT(cppcoreguidelines-owning-memory)
-    this->init_response_(res, 200, content_type);
+    this->init_response_(res, code, content_type);
     return res;
   }
   // NOLINTNEXTLINE(readability-identifier-naming)

--- a/esphome/const.py
+++ b/esphome/const.py
@@ -1,6 +1,6 @@
 """Constants used by esphome."""
 
-__version__ = "2023.12.0b2"
+__version__ = "2023.12.0b3"
 
 ALLOWED_NAME_CHARS = "abcdefghijklmnopqrstuvwxyz0123456789-_"
 VALID_SUBSTITUTIONS_CHARACTERS = (

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ esptool==4.6.2
 click==8.1.7
 esphome-dashboard==20231107.0
 aioesphomeapi==21.0.0
-zeroconf==0.128.4
+zeroconf==0.130.0
 python-magic==0.4.27
 
 # esp-idf requires this, but doesn't bundle it by default


### PR DESCRIPTION
**Do not merge, release script will automatically merge**
- Bump zeroconf from 0.128.4 to 0.130.0 [esphome#5950](https://github.com/esphome/esphome/pull/5950)
- UARTComponent inline doc [esphome#5930](https://github.com/esphome/esphome/pull/5930)
- Fix - Tuya Fan - Allow integer speed datapoint [esphome#5948](https://github.com/esphome/esphome/pull/5948)
- i2s_audio: Set player_task's prio to 1 [esphome#5945](https://github.com/esphome/esphome/pull/5945)
- esp32_camera: Set framebuffer task prio to 1 [esphome#5943](https://github.com/esphome/esphome/pull/5943)
- web_server_idf: fix call with hardcoded http code [esphome#5942](https://github.com/esphome/esphome/pull/5942)
- Revert pure virtual functions in UART component from #5920 [esphome#5932](https://github.com/esphome/esphome/pull/5932)
- Use the correct UART/`Serial` when CDC is enabled [esphome#5957](https://github.com/esphome/esphome/pull/5957)
