### PR TITLE
Add deep sleep between updates for waveshare epaper 1.54in and 1.54inv2

### DIFF
--- a/esphome/components/waveshare_epaper/waveshare_epaper.h
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.h
@@ -92,13 +92,20 @@ class WaveshareEPaperTypeA : public WaveshareEPaper {
   void display() override;
 
   void deep_sleep() override {
-    if (this->model_ == WAVESHARE_EPAPER_2_9_IN_V2 || this->model_ == WAVESHARE_EPAPER_1_54_IN_V2) {
-      // COMMAND DEEP SLEEP MODE
-      this->command(0x10);
-      this->data(0x01);
-    } else {
-      // COMMAND DEEP SLEEP MODE
-      this->command(0x10);
+    switch (this->model_) {
+      // Models with specific deep sleep command and data
+      case WAVESHARE_EPAPER_1_54_IN:
+      case WAVESHARE_EPAPER_1_54_IN_V2:
+      case WAVESHARE_EPAPER_2_9_IN_V2:
+        // COMMAND DEEP SLEEP MODE
+        this->command(0x10);
+        this->data(0x01);
+        break;
+      // Other models default to simple deep sleep command
+      default:
+        // COMMAND DEEP SLEEP
+        this->command(0x10);
+        break;
     }
     this->wait_until_idle_();
   }
@@ -107,6 +114,8 @@ class WaveshareEPaperTypeA : public WaveshareEPaper {
 
  protected:
   void write_lut_(const uint8_t *lut, uint8_t size);
+
+  void init_display_();
 
   int get_width_internal() override;
 
@@ -118,6 +127,8 @@ class WaveshareEPaperTypeA : public WaveshareEPaper {
   uint32_t at_update_{0};
   WaveshareEPaperTypeAModel model_;
   uint32_t idle_timeout_() override;
+
+  bool deep_sleep_between_updates_{false};
 };
 
 enum WaveshareEPaperTypeBModel {


### PR DESCRIPTION
# What does this implement/fix?

Waveshare 1.54in and 1.54v2 displays are always powered on (not asleep) which causes damage to the display over time. Waveshare warns of display damage if the display is left on for an extended period of time:
- [Waveshare recommendation to set the screen to sleep mode or power off it](https://www.waveshare.com/wiki/1.54inch_e-Paper_Module_Manual#Precautions)
- [Waveshare datasheet "Normal Operation Flow" recommends to loop with deep-sleep > reconfigure > update display > deep-sleep...](https://www.waveshare.com/wiki/1.54inch_e-Paper_Module_Manual#Documentation)

I've updated the existing code of the WaveshareEPaperTypeA for 1.54in and 1.54inv2 display variants to fix this problem:
- When initializating the display: if a reset pin is provided and the display are of 1.54in or 1.54inv2, populate a boolean `deep_sleep_between_updates_` protected variable.
- On display update, following the "Normal Operation Flow" provided by Wavehsare:
  - Reset the display
  - Reconfigure it
  - Update the display (no changes done to that part)
  - Set the display back in deep sleep mode

I tried to make the code reusable to eventually include extra models to this the deep sleep feature.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes [#5235](https://github.com/esphome/issues/issues/5235)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [X] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
```yaml
display:
- platform: waveshare_epaper
  id: epaper
  spi_id: spi_bus
  cs_pin: D8
  dc_pin: D0
  busy_pin: D6
  reset_pin: D4 # Required to enable deep-sleep on 1.54in displays
  model: 1.54in
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
