### PR TITLE
rename set_raw_touch_position_ to add_raw_touch_position_

### DIFF
--- a/esphome/components/ektf2232/touchscreen/ektf2232.cpp
+++ b/esphome/components/ektf2232/touchscreen/ektf2232.cpp
@@ -74,7 +74,7 @@ void EKTF2232Touchscreen::update_touches() {
     uint8_t *d = raw + 1 + (i * 3);
     x_raw = (d[0] & 0xF0) << 4 | d[1];
     y_raw = (d[0] & 0x0F) << 8 | d[2];
-    this->set_raw_touch_position_(i, x_raw, y_raw);
+    this->add_raw_touch_position_(i, x_raw, y_raw);
   }
 }
 

--- a/esphome/components/ft5x06/touchscreen/ft5x06_touchscreen.h
+++ b/esphome/components/ft5x06/touchscreen/ft5x06_touchscreen.h
@@ -94,7 +94,7 @@ class FT5x06Touchscreen : public touchscreen::Touchscreen, public i2c::I2CDevice
 
       esph_log_d(TAG, "Read %X status, id: %d, pos %d/%d", status, id, x, y);
       if (status == 0 || status == 2) {
-        this->set_raw_touch_position_(id, x, y);
+        this->add_raw_touch_position_(id, x, y);
       }
     }
   }

--- a/esphome/components/ft63x6/ft63x6.cpp
+++ b/esphome/components/ft63x6/ft63x6.cpp
@@ -53,13 +53,13 @@ void FT63X6Touchscreen::update_touches() {
   uint8_t touch_id = this->read_touch_id_(FT63X6_ADDR_TOUCH1_ID);  // id1 = 0 or 1
   int16_t x = this->read_touch_coordinate_(FT63X6_ADDR_TOUCH1_X);
   int16_t y = this->read_touch_coordinate_(FT63X6_ADDR_TOUCH1_Y);
-  this->set_raw_touch_position_(touch_id, x, y);
+  this->add_raw_touch_position_(touch_id, x, y);
 
   if (touch_count >= 2) {
     touch_id = this->read_touch_id_(FT63X6_ADDR_TOUCH2_ID);  // id2 = 0 or 1(~id1 & 0x01)
     x = this->read_touch_coordinate_(FT63X6_ADDR_TOUCH2_X);
     y = this->read_touch_coordinate_(FT63X6_ADDR_TOUCH2_Y);
-    this->set_raw_touch_position_(touch_id, x, y);
+    this->add_raw_touch_position_(touch_id, x, y);
   }
 }
 

--- a/esphome/components/gt911/touchscreen/gt911_touchscreen.cpp
+++ b/esphome/components/gt911/touchscreen/gt911_touchscreen.cpp
@@ -92,7 +92,7 @@ void GT911Touchscreen::update_touches() {
     uint16_t id = data[i][0];
     uint16_t x = encode_uint16(data[i][2], data[i][1]);
     uint16_t y = encode_uint16(data[i][4], data[i][3]);
-    this->set_raw_touch_position_(id, x, y);
+    this->add_raw_touch_position_(id, x, y);
   }
   auto keys = data[num_of_touches][0];
   for (size_t i = 0; i != 4; i++) {

--- a/esphome/components/lilygo_t5_47/touchscreen/lilygo_t5_47_touchscreen.cpp
+++ b/esphome/components/lilygo_t5_47/touchscreen/lilygo_t5_47_touchscreen.cpp
@@ -84,7 +84,7 @@ void LilygoT547Touchscreen::update_touches() {
     id = (buffer[i * 5] >> 4) & 0x0F;
     y_raw = (uint16_t) ((buffer[i * 5 + 1] << 4) | ((buffer[i * 5 + 3] >> 4) & 0x0F));
     x_raw = (uint16_t) ((buffer[i * 5 + 2] << 4) | (buffer[i * 5 + 3] & 0x0F));
-    this->set_raw_touch_position_(id, x_raw, y_raw);
+    this->add_raw_touch_position_(id, x_raw, y_raw);
   }
 
   this->status_clear_warning();

--- a/esphome/components/touchscreen/touchscreen.cpp
+++ b/esphome/components/touchscreen/touchscreen.cpp
@@ -51,7 +51,7 @@ void Touchscreen::loop() {
   }
 }
 
-void Touchscreen::set_raw_touch_position_(uint8_t id, int16_t x_raw, int16_t y_raw, int16_t z_raw) {
+void Touchscreen::add_raw_touch_position_(uint8_t id, int16_t x_raw, int16_t y_raw, int16_t z_raw) {
   TouchPoint tp;
   uint16_t x, y;
   if (this->touches_.count(id) == 0) {

--- a/esphome/components/touchscreen/touchscreen.h
+++ b/esphome/components/touchscreen/touchscreen.h
@@ -87,7 +87,7 @@ class Touchscreen : public PollingComponent {
 
   void attach_interrupt_(InternalGPIOPin *irq_pin, esphome::gpio::InterruptType type);
 
-  void set_raw_touch_position_(uint8_t id, int16_t x_raw, int16_t y_raw, int16_t z_raw = 0);
+  void add_raw_touch_position_(uint8_t id, int16_t x_raw, int16_t y_raw, int16_t z_raw = 0);
 
   void send_touches_();
 

--- a/esphome/components/tt21100/touchscreen/tt21100.cpp
+++ b/esphome/components/tt21100/touchscreen/tt21100.cpp
@@ -109,7 +109,7 @@ void TT21100Touchscreen::update_touches() {
                  i, touch->touch_type, touch->tip, touch->event_id, touch->touch_id, touch->x, touch->y,
                  touch->pressure, touch->major_axis_length, touch->orientation);
 
-        this->set_raw_touch_position_(touch->tip, touch->x, touch->y, touch->pressure);
+        this->add_raw_touch_position_(touch->tip, touch->x, touch->y, touch->pressure);
       }
     }
   }

--- a/esphome/components/xpt2046/touchscreen/xpt2046.cpp
+++ b/esphome/components/xpt2046/touchscreen/xpt2046.cpp
@@ -55,7 +55,7 @@ void XPT2046Component::update_touches() {
 
     ESP_LOGV(TAG, "Touchscreen Update [%d, %d], z = %d", x_raw, y_raw, z_raw);
 
-    this->set_raw_touch_position_(0, x_raw, y_raw, z_raw);
+    this->add_raw_touch_position_(0, x_raw, y_raw, z_raw);
   }
 }
 


### PR DESCRIPTION
# What does this implement/fix?
I was not happy with my chosen method name for adding touches to the touch list.

So this PR will rename:

**`set_raw_touch_position_();`** to **`add_raw_touch_position_();`**

This is only important for touchscreen driver developers.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other


## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Checklist:
  - [x] The code change is tested and works locally.
  