### PR TITLE
Added alarm processing for Haier component (hOn protocol)

### DIFF
--- a/esphome/components/haier/haier_base.cpp
+++ b/esphome/components/haier/haier_base.cpp
@@ -25,13 +25,14 @@ const char *HaierClimateBase::phase_to_string_(ProtocolPhases phase) {
       "SENDING_INIT_1",
       "SENDING_INIT_2",
       "SENDING_FIRST_STATUS_REQUEST",
-      "SENDING_ALARM_STATUS_REQUEST",
+      "SENDING_FIRST_ALARM_STATUS_REQUEST",
       "IDLE",
       "SENDING_STATUS_REQUEST",
       "SENDING_UPDATE_SIGNAL_REQUEST",
       "SENDING_SIGNAL_LEVEL",
       "SENDING_CONTROL",
       "SENDING_ACTION_COMMAND",
+      "SENDING_ALARM_STATUS_REQUEST",
       "UNKNOWN"  // Should be the last!
   };
   static_assert(

--- a/esphome/components/haier/haier_base.h
+++ b/esphome/components/haier/haier_base.h
@@ -64,7 +64,7 @@ class HaierClimateBase : public esphome::Component,
     SENDING_INIT_1 = 0,
     SENDING_INIT_2,
     SENDING_FIRST_STATUS_REQUEST,
-    SENDING_ALARM_STATUS_REQUEST,
+    SENDING_FIRST_ALARM_STATUS_REQUEST,
     // FUNCTIONAL STATE
     IDLE,
     SENDING_STATUS_REQUEST,
@@ -72,6 +72,7 @@ class HaierClimateBase : public esphome::Component,
     SENDING_SIGNAL_LEVEL,
     SENDING_CONTROL,
     SENDING_ACTION_COMMAND,
+    SENDING_ALARM_STATUS_REQUEST,
     NUM_PROTOCOL_PHASES
   };
   const char *phase_to_string_(ProtocolPhases phase);

--- a/esphome/components/haier/hon_climate.h
+++ b/esphome/components/haier/hon_climate.h
@@ -2,6 +2,7 @@
 
 #include <chrono>
 #include "esphome/components/sensor/sensor.h"
+#include "esphome/core/automation.h"
 #include "haier_base.h"
 
 namespace esphome {
@@ -52,6 +53,9 @@ class HonClimate : public HaierClimateBase {
   void start_steri_cleaning();
   void set_extra_control_packet_bytes_size(size_t size) { this->extra_control_packet_bytes_ = size; };
   void set_control_method(HonControlMethod method) { this->control_method_ = method; };
+  void add_alarm_start_callback(std::function<void(uint8_t, const char *)> &&callback);
+  void add_alarm_end_callback(std::function<void(uint8_t, const char *)> &&callback);
+  float get_active_alarm_count() const { return this->active_alarm_count_; }
 
  protected:
   void set_handlers() override;
@@ -77,8 +81,11 @@ class HonClimate : public HaierClimateBase {
   haier_protocol::HandlerError get_alarm_status_answer_handler_(haier_protocol::FrameType request_type,
                                                                 haier_protocol::FrameType message_type,
                                                                 const uint8_t *data, size_t data_size);
+  haier_protocol::HandlerError alarm_status_message_handler_(haier_protocol::FrameType type, const uint8_t *buffer,
+                                                             size_t size);
   // Helper functions
   haier_protocol::HandlerError process_status_message_(const uint8_t *packet, uint8_t size);
+  void process_alarm_message_(const uint8_t *packet, uint8_t size, bool check_new);
   void fill_control_messages_queue_();
   void clear_control_messages_queue_();
 
@@ -101,6 +108,26 @@ class HonClimate : public HaierClimateBase {
   HonControlMethod control_method_;
   esphome::sensor::Sensor *outdoor_sensor_;
   std::queue<haier_protocol::HaierMessage> control_messages_queue_;
+  CallbackManager<void(uint8_t, const char *)> alarm_start_callback_{};
+  CallbackManager<void(uint8_t, const char *)> alarm_end_callback_{};
+  float active_alarm_count_{NAN};
+  std::chrono::steady_clock::time_point last_alarm_request_;
+};
+
+class HaierAlarmStartTrigger : public Trigger<uint8_t, const char *> {
+ public:
+  explicit HaierAlarmStartTrigger(HonClimate *parent) {
+    parent->add_alarm_start_callback(
+        [this](uint8_t alarm_code, const char *alarm_message) { this->trigger(alarm_code, alarm_message); });
+  }
+};
+
+class HaierAlarmEndTrigger : public Trigger<uint8_t, const char *> {
+ public:
+  explicit HaierAlarmEndTrigger(HonClimate *parent) {
+    parent->add_alarm_end_callback(
+        [this](uint8_t alarm_code, const char *alarm_message) { this->trigger(alarm_code, alarm_message); });
+  }
 };
 
 }  // namespace haier

--- a/esphome/components/haier/hon_packet.h
+++ b/esphome/components/haier/hon_packet.h
@@ -163,6 +163,62 @@ enum class SubcommandsControl : uint16_t {
                                   // content: all values like in status packet)
 };
 
+const std::string HON_ALARM_MESSAGES[] = {
+    "Outdoor module failure",
+    "Outdoor defrost sensor failure",
+    "Outdoor compressor exhaust sensor failure",
+    "Outdoor EEPROM abnormality",
+    "Indoor coil sensor failure",
+    "Indoor-outdoor communication failure",
+    "Power supply overvoltage protection",
+    "Communication failure between panel and indoor unit",
+    "Outdoor compressor overheat protection",
+    "Outdoor environmental sensor abnormality",
+    "Full water protection",
+    "Indoor EEPROM failure",
+    "Outdoor out air sensor failure",
+    "CBD and module communication failure",
+    "Indoor DC fan failure",
+    "Outdoor DC fan failure",
+    "Door switch failure",
+    "Dust filter needs cleaning reminder",
+    "Water shortage protection",
+    "Humidity sensor failure",
+    "Indoor temperature sensor failure",
+    "Manipulator limit failure",
+    "Indoor PM2.5 sensor failure",
+    "Outdoor PM2.5 sensor failure",
+    "Indoor heating overload/high load alarm",
+    "Outdoor AC current protection",
+    "Outdoor compressor operation abnormality",
+    "Outdoor DC current protection",
+    "Outdoor no-load failure",
+    "CT current abnormality",
+    "Indoor cooling freeze protection",
+    "High and low pressure protection",
+    "Compressor out air temperature is too high",
+    "Outdoor evaporator sensor failure",
+    "Outdoor cooling overload",
+    "Water pump drainage failure",
+    "Three-phase power supply failure",
+    "Four-way valve failure",
+    "External alarm/scraper flow switch failure",
+    "Temperature cutoff protection alarm",
+    "Different mode operation failure",
+    "Electronic expansion valve failure",
+    "Dual heat source sensor Tw failure",
+    "Communication failure with the wired controller",
+    "Indoor unit address duplication failure",
+    "50Hz zero crossing failure",
+    "Outdoor unit failure",
+    "Formaldehyde sensor failure",
+    "VOC sensor failure",
+    "CO2 sensor failure",
+    "Firewall failure",
+};
+
+constexpr size_t HON_ALARM_COUNT = sizeof(HON_ALARM_MESSAGES) / sizeof(HON_ALARM_MESSAGES[0]);
+
 }  // namespace hon_protocol
 }  // namespace haier
 }  // namespace esphome

--- a/esphome/components/haier/smartair2_climate.cpp
+++ b/esphome/components/haier/smartair2_climate.cpp
@@ -95,7 +95,7 @@ haier_protocol::HandlerError Smartair2Climate::messages_timeout_handler_with_cyc
   ESP_LOGI(TAG, "Answer timeout for command %02X, phase %s", (uint8_t) message_type,
            phase_to_string_(this->protocol_phase_));
   ProtocolPhases new_phase = (ProtocolPhases) ((int) this->protocol_phase_ + 1);
-  if (new_phase >= ProtocolPhases::SENDING_ALARM_STATUS_REQUEST)
+  if (new_phase >= ProtocolPhases::SENDING_FIRST_ALARM_STATUS_REQUEST)
     new_phase = ProtocolPhases::SENDING_INIT_1;
   this->set_phase(new_phase);
   return haier_protocol::HandlerError::HANDLER_OK;
@@ -170,8 +170,11 @@ void Smartair2Climate::process_phase(std::chrono::steady_clock::time_point now) 
     case ProtocolPhases::SENDING_UPDATE_SIGNAL_REQUEST:
       this->set_phase(ProtocolPhases::SENDING_SIGNAL_LEVEL);
       break;
-    case ProtocolPhases::SENDING_ALARM_STATUS_REQUEST:
+    case ProtocolPhases::SENDING_FIRST_ALARM_STATUS_REQUEST:
       this->set_phase(ProtocolPhases::SENDING_INIT_1);
+      break;
+    case ProtocolPhases::SENDING_ALARM_STATUS_REQUEST:
+      this->set_phase(ProtocolPhases::IDLE);
       break;
     case ProtocolPhases::SENDING_CONTROL:
       if (this->can_send_message() && this->is_control_message_interval_exceeded_(now)) {
@@ -343,19 +346,29 @@ haier_protocol::HaierMessage Smartair2Climate::get_control_message() {
     } else if (climate_control.preset.has_value()) {
       switch (climate_control.preset.value()) {
         case CLIMATE_PRESET_NONE:
+          out_data->ten_degree = 0;
           out_data->turbo_mode = 0;
           out_data->quiet_mode = 0;
           break;
         case CLIMATE_PRESET_BOOST:
+          out_data->ten_degree = 0;
           out_data->turbo_mode = 1;
           out_data->quiet_mode = 0;
           break;
         case CLIMATE_PRESET_COMFORT:
+          out_data->ten_degree = 0;
           out_data->turbo_mode = 0;
           out_data->quiet_mode = 1;
           break;
+        case CLIMATE_PRESET_AWAY:
+          // Only allowed in heat mode
+          out_data->ten_degree = (this->mode == CLIMATE_MODE_HEAT) ? 1 : 0;
+          out_data->turbo_mode = 0;
+          out_data->quiet_mode = 0;
+          break;
         default:
           ESP_LOGE("Control", "Unsupported preset");
+          out_data->ten_degree = 0;
           out_data->turbo_mode = 0;
           out_data->quiet_mode = 0;
           break;
@@ -381,6 +394,8 @@ haier_protocol::HandlerError Smartair2Climate::process_status_message_(const uin
       this->preset = CLIMATE_PRESET_BOOST;
     } else if (packet.control.quiet_mode != 0) {
       this->preset = CLIMATE_PRESET_COMFORT;
+    } else if (packet.control.ten_degree != 0) {
+      this->preset = CLIMATE_PRESET_AWAY;
     } else {
       this->preset = CLIMATE_PRESET_NONE;
     }

--- a/tests/test3.yaml
+++ b/tests/test3.yaml
@@ -1026,11 +1026,13 @@ climate:
     wifi_signal: true
     beeper: true
     outdoor_temperature:
-      name:  Haier AC outdoor temperature
+      name: Haier AC outdoor temperature
     visual:
       min_temperature: 16 °C
       max_temperature: 30 °C
-      temperature_step: 1 °C
+      temperature_step:
+        target_temperature: 1
+        current_temperature: 0.5
     supported_modes:
     - 'OFF'
     - HEAT_COOL
@@ -1043,6 +1045,23 @@ climate:
     - VERTICAL
     - HORIZONTAL
     - BOTH
+    supported_presets:
+    - AWAY
+    - BOOST
+    - ECO
+    - SLEEP
+    on_alarm_start:
+      then:
+        - logger.log:
+            level: DEBUG
+            format: "Alarm activated. Code: %d. Message: \"%s\""
+            args: [ code, message]
+    on_alarm_end:
+      then:
+        - logger.log:
+            level: DEBUG
+            format: "Alarm deactivated. Code: %d. Message: \"%s\""
+            args: [ code, message]
 
 sprinkler:
   - id: yard_sprinkler_ctrlr


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->
Added AC alarm processing for hOn protocol. Added AWAY preset for both hOn and SmartAir2 protocol. Two new triggers were added for alarm processing:

- on_alarm_start
- on_alarm_end

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#3474

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

uart:
  baud_rate: 9600
  tx_pin: 17
  rx_pin: 16
  id: ac_port  

climate:
  - platform: haier
    id: haier_ac
    protocol: hOn
    name: Haier AC 
    uart_id: ac_port
    wifi_signal: true           # Optional, default true, enables WiFI signal transmission from ESP to AC
    beeper: true                # Optional, default true, disables beep on commands from ESP
    display: true               # Optional, default true, can be used to turn off LED display
    answer_timeout:: 200ms      # Optional, request answer timeout, can be used to increase the timeout
                                # for some ACs that have longer answer delays
    outdoor_temperature:        # Optional, outdoor temperature sensor
      name: Haier AC outdoor temperature
    visual:                     # Optional, you can use it to limit min and max temperatures in UI (not working for remote!)
      min_temperature: 16 °C
      max_temperature: 30 °C
      temperature_step: 1 °C
    supported_modes:            # Optional, can be used to disable some modes if you don't need them
      - 'OFF'
      - AUTO
      - COOL
      - HEAT
      - DRY
      - FAN_ONLY
    supported_presets:          # Optional, can be used to disable some presets if your AC does not support it
      - AWAY
      - ECO
      - BOOST
      - SLEEP
    supported_swing_modes:      # Optional, can be used to disable some (or all) swing modes if your AC does not support it
      - 'OFF'
      - VERTICAL
      - HORIZONTAL
      - BOTH
    on_alarm_start:
      then:
        - logger.log:
            level: WARN
            format: "Alarm activated. Code: %d. Message: \"%s\""
            args: [ code, message]
    on_alarm_end:
      then:
        - logger.log:
            level: INFO
            format: "Alarm deactivated. Code: %d. Message: \"%s\""
            args: [ code, message]

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
