### PR TITLE
Adding support for RDS-RGBW-02 data-over-power lights

### DIFF
--- a/esphome/components/esp32_rmt_led_strip/led_strip.cpp
+++ b/esphome/components/esp32_rmt_led_strip/led_strip.cpp
@@ -1,5 +1,6 @@
 #include <cinttypes>
 #include "led_strip.h"
+#include "rds_rgbw_02.h"
 
 #ifdef USE_ESP32
 
@@ -13,7 +14,12 @@ namespace esp32_rmt_led_strip {
 
 static const char *const TAG = "esp32_rmt_led_strip";
 
-static const uint8_t RMT_CLK_DIV = 2;
+static constexpr uint8_t RMT_CLK_DIV = 2;
+static constexpr float CLK_RATIO = (float) APB_CLK_FREQ / RMT_CLK_DIV / 1e09f;
+
+// 15 bits of duration per each high/low per item
+static constexpr uint32_t MAX_CYCLES_PER_DURATION = std::numeric_limits<uint16_t>::max() >> 1;
+static constexpr uint32_t MAX_CYCLES_PER_ITEM = MAX_CYCLES_PER_DURATION * 2;
 
 void ESP32RMTLEDStripLightOutput::setup() {
   ESP_LOGCONFIG(TAG, "Setting up ESP32 LED Strip...");
@@ -21,8 +27,12 @@ void ESP32RMTLEDStripLightOutput::setup() {
   size_t buffer_size = this->get_buffer_size_();
 
   ExternalRAMAllocator<uint8_t> allocator(ExternalRAMAllocator<uint8_t>::ALLOW_FAILURE);
-  this->buf_ = allocator.allocate(buffer_size);
-  if (this->buf_ == nullptr) {
+  this->buf_[0] = allocator.allocate(buffer_size);
+  if (this->allow_partial_updates_) {
+    // allocate a second buffer for swap->delta comparison
+    this->buf_[1] = allocator.allocate(buffer_size);
+  }
+  if (this->buf_[0] == nullptr || (this->allow_partial_updates_ && this->buf_[1] == nullptr)) {
     ESP_LOGE(TAG, "Cannot allocate LED buffer!");
     this->mark_failed();
     return;
@@ -36,7 +46,7 @@ void ESP32RMTLEDStripLightOutput::setup() {
   }
 
   ExternalRAMAllocator<rmt_item32_t> rmt_allocator(ExternalRAMAllocator<rmt_item32_t>::ALLOW_FAILURE);
-  this->rmt_buf_ = rmt_allocator.allocate(buffer_size * 8);  // 8 bits per byte, 1 rmt_item32_t per bit
+  this->rmt_buf_ = rmt_allocator.allocate(this->get_rmt_buffer_size_());
 
   rmt_config_t config;
   memset(&config, 0, sizeof(config));
@@ -50,6 +60,9 @@ void ESP32RMTLEDStripLightOutput::setup() {
   config.tx_config.carrier_en = false;
   config.tx_config.idle_level = RMT_IDLE_LEVEL_LOW;
   config.tx_config.idle_output_en = true;
+  if (this->is_inverted_) {
+    config.flags |= RMT_CHANNEL_FLAGS_INVERT_SIG;
+  }
 
   if (rmt_config(&config) != ESP_OK) {
     ESP_LOGE(TAG, "Cannot initialize RMT!");
@@ -65,18 +78,20 @@ void ESP32RMTLEDStripLightOutput::setup() {
 
 void ESP32RMTLEDStripLightOutput::set_led_params(uint32_t bit0_high, uint32_t bit0_low, uint32_t bit1_high,
                                                  uint32_t bit1_low) {
-  float ratio = (float) APB_CLK_FREQ / RMT_CLK_DIV / 1e09f;
-
   // 0-bit
-  this->bit0_.duration0 = (uint32_t) (ratio * bit0_high);
+  this->bit0_.duration0 = (uint32_t) (CLK_RATIO * bit0_high);
   this->bit0_.level0 = 1;
-  this->bit0_.duration1 = (uint32_t) (ratio * bit0_low);
+  this->bit0_.duration1 = (uint32_t) (CLK_RATIO * bit0_low);
   this->bit0_.level1 = 0;
   // 1-bit
-  this->bit1_.duration0 = (uint32_t) (ratio * bit1_high);
-  this->bit1_.level0 = 1;
-  this->bit1_.duration1 = (uint32_t) (ratio * bit1_low);
-  this->bit1_.level1 = 0;
+  this->bit1_.duration0 = (uint32_t) (CLK_RATIO * bit1_high);
+  this->bit1_.level0 = this->encoding_ != ENCODING_BI_PHASE ? 1 : 0;
+  this->bit1_.duration1 = (uint32_t) (CLK_RATIO * bit1_low);
+  this->bit1_.level1 = this->encoding_ != ENCODING_BI_PHASE ? 0 : 1;
+}
+
+void ESP32RMTLEDStripLightOutput::set_sync_start(uint32_t sync_start) {
+  this->sync_start_ = (uint32_t) (CLK_RATIO * sync_start);
 }
 
 void ESP32RMTLEDStripLightOutput::write_state(light::LightState *state) {
@@ -99,29 +114,43 @@ void ESP32RMTLEDStripLightOutput::write_state(light::LightState *state) {
   }
   delayMicroseconds(50);
 
-  size_t buffer_size = this->get_buffer_size_();
+  const int command_len = this->get_bits_per_command_();
 
-  size_t size = 0;
-  size_t len = 0;
-  uint8_t *psrc = this->buf_;
-  rmt_item32_t *pdest = this->rmt_buf_;
-  while (size < buffer_size) {
-    uint8_t b = *psrc;
-    for (int i = 0; i < 8; i++) {
-      pdest->val = b & (1 << (7 - i)) ? this->bit1_.val : this->bit0_.val;
-      pdest++;
+  int len = 0;
+  uint8_t *src = this->get_current_buf_();
+  rmt_item32_t *dest = this->rmt_buf_;
+  for (size_t i = 0; i < this->num_leds_; i++) {
+    if (this->allow_partial_updates_ && this->bufs_same_at_index_(i)) {
+      src += this->get_bytes_per_led_();
+      continue;
+    }
+
+    this->rmt_generator_(*this, i, src, dest, state);
+    src += this->get_bytes_per_led_();
+    dest += command_len;
+    len += command_len;
+
+    // Pulse distance requires a final pulse to bookend the last distance.
+    if (this->encoding_ == ENCODING_PULSE_DISTANCE) {
+      dest->val = this->bit0_.val;
+      dest++;
       len++;
     }
-    size++;
-    psrc++;
+
+    if (this->intermission_ > 0) {
+      generate_rmt_items_for_micros_delay(dest, this->intermission_);
+      const uint32_t delay_count = get_rmt_item_count_for_micros_delay(this->intermission_);
+      dest += delay_count;
+      len += delay_count;
+    }
   }
 
-  if (rmt_write_items(this->channel_, this->rmt_buf_, len, false) != ESP_OK) {
-    ESP_LOGE(TAG, "RMT TX error");
-    this->status_set_warning();
-    return;
+  if (len > this->get_rmt_buffer_size_()) {
+    ESP_LOGE(TAG, "Attempting to write %d items to RMT buffer size %d", len, this->get_rmt_buffer_size_());
+  } else if (len > 0 && this->rmt_write_items_(len)) {
+    this->status_clear_warning();
+    this->swap_buf_();
   }
-  this->status_clear_warning();
 }
 
 light::ESPColorView ESP32RMTLEDStripLightOutput::get_view_internal(int32_t index) const {
@@ -159,10 +188,10 @@ light::ESPColorView ESP32RMTLEDStripLightOutput::get_view_internal(int32_t index
       break;
   }
   uint8_t multiplier = this->is_rgbw_ ? 4 : 3;
-  return {this->buf_ + (index * multiplier) + r,
-          this->buf_ + (index * multiplier) + g,
-          this->buf_ + (index * multiplier) + b,
-          this->is_rgbw_ ? this->buf_ + (index * multiplier) + 3 : nullptr,
+  return {this->get_current_buf_() + (index * multiplier) + r,
+          this->get_current_buf_() + (index * multiplier) + g,
+          this->get_current_buf_() + (index * multiplier) + b,
+          this->is_rgbw_ ? this->get_current_buf_() + (index * multiplier) + 3 : nullptr,
           &this->effect_data_[index],
           &this->correction_};
 }
@@ -196,11 +225,157 @@ void ESP32RMTLEDStripLightOutput::dump_config() {
       break;
   }
   ESP_LOGCONFIG(TAG, "  RGB Order: %s", rgb_order);
+  ESP_LOGCONFIG(TAG, "  ColorModes:");
+  for (const light::ColorMode mode : this->supported_color_modes_) {
+    const char *mode_string = "UNKNOWN";
+    switch (mode) {
+      case light::ColorMode::ON_OFF:
+        mode_string = "ON_OFF";
+        break;
+      case light::ColorMode::BRIGHTNESS:
+        mode_string = "BRIGHTNESS";
+        break;
+      case light::ColorMode::WHITE:
+        mode_string = "WHITE";
+        break;
+      case light::ColorMode::COLOR_TEMPERATURE:
+        mode_string = "COLOR_TEMPERATURE";
+        break;
+      case light::ColorMode::COLD_WARM_WHITE:
+        mode_string = "COLD_WARM_WHITE";
+        break;
+      case light::ColorMode::RGB:
+        mode_string = "RGB";
+        break;
+      case light::ColorMode::RGB_WHITE:
+        mode_string = "RGB_WHITE";
+        break;
+      case light::ColorMode::RGB_COLOR_TEMPERATURE:
+        mode_string = "RGB_COLOR_TEMPERATURE";
+        break;
+      case light::ColorMode::RGB_COLD_WARM_WHITE:
+        mode_string = "RGB_COLD_WARM_WHITE";
+        break;
+      default:
+        mode_string = "UNKNOWN";
+        break;
+    }
+    ESP_LOGCONFIG(TAG, "    %s", mode_string);
+  }
   ESP_LOGCONFIG(TAG, "  Max refresh rate: %" PRIu32, *this->max_refresh_rate_);
   ESP_LOGCONFIG(TAG, "  Number of LEDs: %u", this->num_leds_);
+  const char *encoding = "UNKNOWN";
+  switch (this->encoding_) {
+    case ENCODING_PULSE_LENGTH:
+      encoding = "PULSE_LENGTH";
+      break;
+    case ENCODING_PULSE_DISTANCE:
+      encoding = "PULSE_DISTANCE";
+      break;
+    case ENCODING_BI_PHASE:
+      encoding = "BI_PHASE";
+      break;
+  }
+  ESP_LOGCONFIG(TAG, "  Encoding: %s", encoding);
+
+  ESP_LOGD(TAG, "RMT item buffer size: %d", this->get_rmt_buffer_size_());
 }
 
 float ESP32RMTLEDStripLightOutput::get_setup_priority() const { return setup_priority::HARDWARE; }
+
+light::LightTraits ESP32RMTLEDStripLightOutput::get_traits() {
+  auto traits = light::LightTraits();
+  traits.set_supported_color_modes(this->supported_color_modes_);
+  return traits;
+}
+
+size_t ESP32RMTLEDStripLightOutput::get_bits_per_command_() const {
+  return this->bits_per_command_ > 0 ? this->bits_per_command_ : this->get_bytes_per_led_() * 8;
+}
+
+size_t ESP32RMTLEDStripLightOutput::get_items_per_command_() const {
+  int count = this->get_bits_per_command_();
+  count += (this->encoding_ == ENCODING_PULSE_DISTANCE);
+  if (this->intermission_ > 0) {
+    count += get_rmt_item_count_for_micros_delay(this->intermission_);
+  }
+  return count;
+}
+
+size_t ESP32RMTLEDStripLightOutput::get_rmt_buffer_size_() const {
+  return this->num_leds_ * this->get_items_per_command_();
+}
+
+uint32_t ESP32RMTLEDStripLightOutput::get_cycle_count_for_micros_delay(const uint32_t delay) {
+  return (uint32_t) (CLK_RATIO * (float) delay * 1000.f);  // CLK_RATIO is to nanos
+}
+
+uint32_t ESP32RMTLEDStripLightOutput::get_rmt_item_count_for_micros_delay(const uint32_t delay) {
+  return (uint32_t) std::ceil((float) get_cycle_count_for_micros_delay(delay) / (float) MAX_CYCLES_PER_ITEM);
+}
+
+static constexpr int32_t constexpr_ceil(float num) {
+  return (static_cast<float>(static_cast<int32_t>(num)) == num) ? static_cast<int32_t>(num)
+                                                                : static_cast<int32_t>(num) + ((num > 0) ? 1 : 0);
+}
+
+void ESP32RMTLEDStripLightOutput::generate_rmt_items_for_micros_delay(rmt_item32_t *dest, const uint32_t delay) {
+  // the RMT driver will glitch with duration values below this
+  static constexpr int32_t RMT_MIN_DURATION = (int32_t) constexpr_ceil(2.f / CLK_RATIO);
+
+  assert(get_cycle_count_for_micros_delay(delay) <= (std::numeric_limits<uint32_t>::max() >> 1));
+  int32_t cycles_remaining = (int32_t) get_cycle_count_for_micros_delay(delay);
+  while (cycles_remaining > 0) {
+    dest->duration0 = (uint32_t) std::min(cycles_remaining, (int32_t) MAX_CYCLES_PER_DURATION);
+    cycles_remaining -= (int32_t) dest->duration0;
+    dest->level0 = 0;
+    dest->duration1 =
+        (uint32_t) std::min(std::max(cycles_remaining, (int32_t) RMT_MIN_DURATION), (int32_t) MAX_CYCLES_PER_DURATION);
+    cycles_remaining -= (int32_t) dest->duration1;
+    dest->level1 = 0;
+    dest++;
+  }
+}
+
+void ESP32RMTLEDStripLightOutput::set_supported_color_modes(const std::set<esphome::light::ColorMode> &color_modes) {
+  this->supported_color_modes_ = color_modes;
+  if (color_modes.find(light::ColorMode::RGB_WHITE) != color_modes.cend()) {
+    this->is_rgbw_ = true;
+  }
+}
+
+bool ESP32RMTLEDStripLightOutput::bufs_same_at_index_(const int i) const {
+  assert(this->allow_partial_updates_);
+  assert(this->buf_[1]);
+
+  const int bpc = this->get_bytes_per_led_();
+  const uint8_t *buf0 = this->buf_[0];
+  const uint8_t *buf1 = this->buf_[1];
+  return buf0[i * bpc] == buf1[i * bpc] && buf0[i * bpc + 1] == buf1[i * bpc + 1] &&
+         buf0[i * bpc + 2] == buf1[i * bpc + 2] && (!this->is_rgbw_ || buf0[i * bpc + 3] == buf1[i * bpc + 3]);
+}
+
+bool ESP32RMTLEDStripLightOutput::rmt_write_items_(const size_t len, const bool wait_tx_done) {
+  if (rmt_write_items(this->channel_, this->rmt_buf_, len, wait_tx_done) != ESP_OK) {
+    ESP_LOGE(TAG, "RMT TX error");
+    this->status_set_warning();
+    return false;
+  }
+  return true;
+}
+
+void ESP32RMTLEDStripLightOutput::default_rmt_generate(const ESP32RMTLEDStripLightOutput &light, const int index,
+                                                       const uint8_t *src, rmt_item32_t *dest,
+                                                       light::LightState *state) {
+  const int color_count = 3 + light.get_is_rgbw();
+  for (int i = 0; i < color_count; i++) {
+    const uint8_t color = src[i];
+    for (int j = 7; j >= 0; j--) {
+      dest->val = (color >> j) & 1 ? light.get_bit1().val : light.get_bit0().val;
+      dest++;
+    }
+  }
+}
 
 }  // namespace esp32_rmt_led_strip
 }  // namespace esphome

--- a/esphome/components/esp32_rmt_led_strip/led_strip.h
+++ b/esphome/components/esp32_rmt_led_strip/led_strip.h
@@ -15,6 +15,8 @@
 namespace esphome {
 namespace esp32_rmt_led_strip {
 
+class ESP32RMTLEDStripLightOutput;
+
 enum RGBOrder : uint8_t {
   ORDER_RGB,
   ORDER_RBG,
@@ -24,6 +26,17 @@ enum RGBOrder : uint8_t {
   ORDER_BRG,
 };
 
+// encoding types sourced from Vishay reference
+// https://www.vishay.com/docs/80071/dataform.pdf
+enum Encoding : uint8_t {
+  ENCODING_PULSE_LENGTH,
+  ENCODING_PULSE_DISTANCE,
+  ENCODING_BI_PHASE,
+};
+
+using Generator = void(const ESP32RMTLEDStripLightOutput &light, int led_num, const uint8_t *src_buf,
+                       rmt_item32_t *dest_buf, light::LightState *state);
+
 class ESP32RMTLEDStripLightOutput : public light::AddressableLight {
  public:
   void setup() override;
@@ -31,27 +44,42 @@ class ESP32RMTLEDStripLightOutput : public light::AddressableLight {
   float get_setup_priority() const override;
 
   int32_t size() const override { return this->num_leds_; }
-  light::LightTraits get_traits() override {
-    auto traits = light::LightTraits();
-    if (this->is_rgbw_) {
-      traits.set_supported_color_modes({light::ColorMode::RGB_WHITE, light::ColorMode::WHITE});
-    } else {
-      traits.set_supported_color_modes({light::ColorMode::RGB});
-    }
-    return traits;
-  }
+  light::LightTraits get_traits() override;
 
   void set_pin(uint8_t pin) { this->pin_ = pin; }
   void set_num_leds(uint16_t num_leds) { this->num_leds_ = num_leds; }
-  void set_is_rgbw(bool is_rgbw) { this->is_rgbw_ = is_rgbw; }
+  bool get_is_rgbw() const { return this->is_rgbw_; }
+  void set_is_rgbw(bool is_rgbw) {
+    if (is_rgbw) {
+      this->set_supported_color_modes({light::ColorMode::RGB_WHITE, light::ColorMode::WHITE});
+    } else {
+      this->set_supported_color_modes({light::ColorMode::RGB});
+    }
+  }
+  // used to set rgbw backing buffer without exposing the "RGB_WHITE" mode trait to HA
+  void set_internal_is_rgbw(bool is_rgbw) { this->is_rgbw_ = is_rgbw; }
+  void set_supported_color_modes(const std::set<esphome::light::ColorMode> &color_modes);
+  void set_is_inverted(bool is_inverted) { this->is_inverted_ = is_inverted; }
+  Encoding get_encoding() const { return this->encoding_; }
+  void set_encoding(Encoding encoding) { this->encoding_ = encoding; }
+  void set_allow_partial_updates(bool allow) { this->allow_partial_updates_ = allow; }
 
   /// Set a maximum refresh rate in µs as some lights do not like being updated too often.
   void set_max_refresh_rate(uint32_t interval_us) { this->max_refresh_rate_ = interval_us; }
 
+  const rmt_item32_t &get_bit0() const { return this->bit0_; }
+  const rmt_item32_t &get_bit1() const { return this->bit1_; }
   void set_led_params(uint32_t bit0_high, uint32_t bit0_low, uint32_t bit1_high, uint32_t bit1_low);
+  uint32_t get_sync_start() const { return this->sync_start_; }
+  void set_sync_start(uint32_t sync_start);
+  void set_intermission(uint32_t intermission) { this->intermission_ = intermission; }
 
+  RGBOrder get_rgb_order() const { return this->rgb_order_; }
   void set_rgb_order(RGBOrder rgb_order) { this->rgb_order_ = rgb_order; }
   void set_rmt_channel(rmt_channel_t channel) { this->channel_ = channel; }
+  void set_rmt_generator(std::function<Generator> gen) { this->rmt_generator_ = std::move(gen); }
+
+  void set_bits_per_command(uint32_t bits) { this->bits_per_command_ = bits; }
 
   void clear_effect_data() override {
     for (int i = 0; i < this->size(); i++)
@@ -63,19 +91,48 @@ class ESP32RMTLEDStripLightOutput : public light::AddressableLight {
  protected:
   light::ESPColorView get_view_internal(int32_t index) const override;
 
-  size_t get_buffer_size_() const { return this->num_leds_ * (3 + this->is_rgbw_); }
+  size_t get_bytes_per_led_() const { return 3 + this->is_rgbw_; }
+  size_t get_bits_per_command_() const;
+  size_t get_items_per_command_() const;
+  size_t get_buffer_size_() const { return this->num_leds_ * this->get_bytes_per_led_(); }
+  size_t get_rmt_buffer_size_() const;
 
-  uint8_t *buf_{nullptr};
+  static uint32_t get_cycle_count_for_micros_delay(uint32_t delay);
+  static uint32_t get_rmt_item_count_for_micros_delay(uint32_t delay);
+  static void generate_rmt_items_for_micros_delay(rmt_item32_t *dest, uint32_t delay);
+
+  uint8_t *get_current_buf_() const { return buf_[this->current_buf_]; }
+  uint8_t *get_old_buf_() const { return buf_[!this->current_buf_]; }
+  void swap_buf_() {
+    if (this->allow_partial_updates_)
+      this->current_buf_ = !this->current_buf_;
+  }
+  bool bufs_same_at_index_(int i) const;
+  bool rmt_write_items_(size_t len, bool wait_tx_done = false);
+
+  static Generator default_rmt_generate;
+
+  uint8_t *buf_[2];
+  int current_buf_ = 0;
   uint8_t *effect_data_{nullptr};
   rmt_item32_t *rmt_buf_{nullptr};
 
   uint8_t pin_;
   uint16_t num_leds_;
   bool is_rgbw_;
+  std::set<light::ColorMode> supported_color_modes_;
+  bool is_inverted_;
+  bool allow_partial_updates_;
 
+  uint32_t sync_start_ = 0;
+  uint32_t intermission_ = 0;
   rmt_item32_t bit0_, bit1_;
   RGBOrder rgb_order_;
+  Encoding encoding_ = ENCODING_PULSE_LENGTH;
+  std::function<Generator> rmt_generator_ = default_rmt_generate;
   rmt_channel_t channel_;
+
+  uint32_t bits_per_command_ = 0;
 
   uint32_t last_refresh_{0};
   optional<uint32_t> max_refresh_rate_{};

--- a/esphome/components/esp32_rmt_led_strip/light.py
+++ b/esphome/components/esp32_rmt_led_strip/light.py
@@ -1,11 +1,17 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from typing import Optional
 
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome import pins
 from esphome.components import esp32, light
+from esphome.components.light.types import (
+    ColorMode,
+    COLOR_MODES,
+)
 from esphome.const import (
     CONF_CHIPSET,
+    CONF_INVERTED,
     CONF_MAX_REFRESH_RATE,
     CONF_NUM_LEDS,
     CONF_OUTPUT_ID,
@@ -22,6 +28,7 @@ ESP32RMTLEDStripLightOutput = esp32_rmt_led_strip_ns.class_(
 )
 
 rmt_channel_t = cg.global_ns.enum("rmt_channel_t")
+rmt_item32_t = cg.global_ns.struct("rmt_item32_t")
 
 RGBOrder = esp32_rmt_led_strip_ns.enum("RGBOrder")
 
@@ -34,29 +41,65 @@ RGB_ORDERS = {
     "BRG": RGBOrder.ORDER_BRG,
 }
 
+Encoding = esp32_rmt_led_strip_ns.enum("Encoding")
+
+ENCODINGS = {
+    "PULSE_LENGTH": Encoding.ENCODING_PULSE_LENGTH,
+    "PULSE_DISTANCE": Encoding.ENCODING_PULSE_DISTANCE,
+    "BI_PHASE": Encoding.ENCODING_BI_PHASE,
+}
+
 
 @dataclass
-class LEDStripTimings:
+class LEDStripChipConfigs:
     bit0_high: int
     bit0_low: int
     bit1_high: int
     bit1_low: int
+    encoding: Encoding = Encoding.ENCODING_PULSE_LENGTH
+    rmt_generator: Optional[str] = None
+    sync_start: int = 0
+    intermission: int = 0
+    bits_per_command: int = 0
+    color_modes: list[ColorMode] = field(default_factory=lambda: [ColorMode.RGB])
+    allow_partial_updates: bool = False
+    internal_is_rgbw: bool = False
 
 
 CHIPSETS = {
-    "WS2812": LEDStripTimings(400, 1000, 1000, 400),
-    "SK6812": LEDStripTimings(300, 900, 600, 600),
-    "APA106": LEDStripTimings(350, 1360, 1360, 350),
-    "SM16703": LEDStripTimings(300, 900, 1360, 350),
+    "WS2812": LEDStripChipConfigs(400, 1000, 1000, 400),
+    "SK6812": LEDStripChipConfigs(300, 900, 600, 600),
+    "APA106": LEDStripChipConfigs(350, 1360, 1360, 350),
+    "SM16703": LEDStripChipConfigs(300, 900, 1360, 350),
+    "RDS-RGBW-02": LEDStripChipConfigs(
+        22_000,
+        22_000,
+        22_000,
+        61_000,
+        encoding=Encoding.ENCODING_PULSE_DISTANCE,
+        rmt_generator="esp32_rmt_led_strip::rds_rgbw_02_rmt_generator",
+        sync_start=77_000,
+        intermission=5_000,
+        bits_per_command=32,
+        color_modes=[ColorMode.RGB, ColorMode.WHITE],
+        allow_partial_updates=True,
+        internal_is_rgbw=True,
+    ),
 }
 
 
 CONF_IS_RGBW = "is_rgbw"
+CONF_SUPPORTED_COLOR_MODES = "supported_color_modes"
+CONF_SYNC_START = "sync_start"
+CONF_ENCODING = "encoding"
+CONF_INTERMISSION = "intermission"
 CONF_BIT0_HIGH = "bit0_high"
 CONF_BIT0_LOW = "bit0_low"
 CONF_BIT1_HIGH = "bit1_high"
 CONF_BIT1_LOW = "bit1_low"
 CONF_RMT_CHANNEL = "rmt_channel"
+CONF_RMT_GENERATOR = "rmt_generator"
+CONF_ALLOW_PARTIAL_UPDATES = "allow_partial_updates"
 
 RMT_CHANNELS = {
     esp32.const.VARIANT_ESP32: [0, 1, 2, 3, 4, 5, 6, 7],
@@ -87,9 +130,16 @@ CONFIG_SCHEMA = cv.All(
             cv.Required(CONF_NUM_LEDS): cv.positive_not_null_int,
             cv.Required(CONF_RGB_ORDER): cv.enum(RGB_ORDERS, upper=True),
             cv.Required(CONF_RMT_CHANNEL): _validate_rmt_channel,
+            cv.Optional(CONF_RMT_GENERATOR): cv.lambda_,
             cv.Optional(CONF_MAX_REFRESH_RATE): cv.positive_time_period_microseconds,
             cv.Optional(CONF_CHIPSET): cv.one_of(*CHIPSETS, upper=True),
-            cv.Optional(CONF_IS_RGBW, default=False): cv.boolean,
+            cv.Optional(CONF_IS_RGBW): cv.boolean,
+            cv.Optional(CONF_ALLOW_PARTIAL_UPDATES): cv.boolean,
+            cv.Optional(CONF_SUPPORTED_COLOR_MODES): cv.ensure_list(
+                cv.enum(COLOR_MODES, upper=True)
+            ),
+            cv.Optional(CONF_SYNC_START): cv.positive_time_period_nanoseconds,
+            cv.Optional(CONF_INTERMISSION): cv.positive_time_period_microseconds,
             cv.Inclusive(
                 CONF_BIT0_HIGH,
                 "custom",
@@ -106,9 +156,16 @@ CONFIG_SCHEMA = cv.All(
                 CONF_BIT1_LOW,
                 "custom",
             ): cv.positive_time_period_nanoseconds,
+            cv.Optional(CONF_INVERTED, default=False): cv.boolean,
+            cv.Optional(CONF_ENCODING, default="PULSE_LENGTH"): cv.enum(
+                ENCODINGS, upper=True
+            ),
         }
     ),
     cv.has_exactly_one_key(CONF_CHIPSET, CONF_BIT0_HIGH),
+    cv.has_at_most_one_key(CONF_CHIPSET, CONF_SYNC_START),
+    cv.has_at_most_one_key(CONF_CHIPSET, CONF_INTERMISSION),
+    cv.has_at_most_one_key(CONF_SUPPORTED_COLOR_MODES, CONF_IS_RGBW),
 )
 
 
@@ -133,6 +190,27 @@ async def to_code(config):
                 chipset.bit1_low,
             )
         )
+        cg.add(var.set_encoding(chipset.encoding))
+        cg.add(var.set_allow_partial_updates(chipset.allow_partial_updates))
+
+        if chipset.sync_start > 0:
+            cg.add(var.set_sync_start(chipset.sync_start))
+
+        if chipset.intermission > 0:
+            cg.add(var.set_intermission(chipset.intermission))
+
+        if chipset.bits_per_command > 0:
+            cg.add(var.set_bits_per_command(chipset.bits_per_command))
+
+        # allow users to override and shoot themselves in the foot
+        if CONF_SUPPORTED_COLOR_MODES not in config and CONF_IS_RGBW not in config:
+            cg.add(var.set_supported_color_modes(chipset.color_modes))
+
+        if chipset.internal_is_rgbw:
+            cg.add(var.set_internal_is_rgbw(True))
+
+        if CONF_RMT_GENERATOR not in config and chipset.rmt_generator is not None:
+            cg.add(var.set_rmt_generator(cg.RawExpression(chipset.rmt_generator)))
     else:
         cg.add(
             var.set_led_params(
@@ -143,11 +221,50 @@ async def to_code(config):
             )
         )
 
+        if CONF_ALLOW_PARTIAL_UPDATES in config:
+            cg.add(var.set_allow_partial_updates(config[CONF_ALLOW_PARTIAL_UPDATES]))
+
+        if CONF_ENCODING in config:
+            cg.add(var.set_encoding(config[CONF_ENCODING]))
+
+        if CONF_SYNC_START in config:
+            cg.add(var.set_sync_start(config[CONF_SYNC_START]))
+
+        if CONF_INTERMISSION in config:
+            cg.add(var.set_intermission(config[CONF_INTERMISSION]))
+
     cg.add(var.set_rgb_order(config[CONF_RGB_ORDER]))
-    cg.add(var.set_is_rgbw(config[CONF_IS_RGBW]))
+
+    if CONF_SUPPORTED_COLOR_MODES in config:
+        cg.add(var.set_supported_color_modes(config[CONF_SUPPORTED_COLOR_MODES]))
+    elif CONF_IS_RGBW in config:
+        cg.add(var.set_is_rgbw(config[CONF_IS_RGBW]))
+
+    cg.add(var.set_is_inverted(config[CONF_INVERTED]))
 
     cg.add(
         var.set_rmt_channel(
             getattr(rmt_channel_t, f"RMT_CHANNEL_{config[CONF_RMT_CHANNEL]}")
         )
     )
+
+    if CONF_RMT_GENERATOR in config:
+        cg.add(
+            var.set_rmt_generator(
+                await cg.process_lambda(
+                    config[CONF_RMT_GENERATOR],
+                    [
+                        (
+                            ESP32RMTLEDStripLightOutput.operator("const").operator(
+                                "ref"
+                            ),
+                            "light",
+                        ),
+                        (cg.int_, "index"),
+                        (cg.uint8.operator("const").operator("ptr"), "src_buf"),
+                        (rmt_item32_t.operator("ptr"), "dest_buf"),
+                        (light.LightState.operator("ptr"), "state"),
+                    ],
+                )
+            )
+        )

--- a/esphome/components/esp32_rmt_led_strip/rds_rgbw_02.cpp
+++ b/esphome/components/esp32_rmt_led_strip/rds_rgbw_02.cpp
@@ -1,0 +1,78 @@
+#include <cassert>
+#include <cinttypes>
+#include "rds_rgbw_02.h"
+
+#ifdef USE_ESP32
+
+#include "esphome/components/light/light_color_values.h"
+#include "esphome/core/log.h"
+
+namespace esphome {
+namespace esp32_rmt_led_strip {
+
+constexpr char TAG[] = "esp32_rmt_led_strip";
+
+RDSRGBW02Color get_rds_rgbw_02_color(const uint8_t *color_buf) {
+  // we're assuming these chipsets are all RGB until otherwise indicated.
+  const uint8_t red = color_buf[0];
+  const uint8_t green = color_buf[1];
+  const uint8_t blue = color_buf[2];
+  if (red >= green && blue >= green)
+    return RDS_RGBW_02_PURPLE;
+  if (red >= blue && green >= blue)
+    return RDS_RGBW_02_YELLOW;
+  if (green >= red && blue >= red)
+    return RDS_RGBW_02_CYAN;
+  ESP_LOGE(TAG, "this should be unreachable");
+  return RDS_RGBW_02_RED;
+}
+
+void rds_rgbw_02_rmt_generator(const ESP32RMTLEDStripLightOutput &light, int index, const uint8_t *src,
+                               rmt_item32_t *dest, light::LightState *state) {
+  const light::LightColorValues &values{state->current_values};
+  const bool is_white = (values.get_color_mode() == light::ColorMode::WHITE && !light.is_effect_active()) ||
+                        src[3] > std::max(std::max(src[0], src[1]), src[2]);
+  const rmt_item32_t &bit0{light.get_bit0()};
+  const rmt_item32_t &bit1{light.get_bit1()};
+  bool first_item = true;
+
+  // address (4 bits)
+  uint8_t address = (uint8_t) index + 1;
+  for (int i = 3; i >= 0; i--) {
+    dest->val = (address >> i) & 1 ? bit1.val : bit0.val;
+    if (first_item && light.get_sync_start() > 0) {
+      first_item = false;
+      dest->duration0 = light.get_sync_start();
+    }
+    dest++;
+  }
+
+  // color enum (4 bits)
+  RDSRGBW02Color color = values.get_state() > 0.f ? RDS_RGBW_02_WHITE : RDS_RGBW_02_OFF;
+  if (!is_white) {
+    color = get_rds_rgbw_02_color(src);
+  }
+  for (int i = 3; i >= 0; i--) {
+    dest->val = (color >> i) & 1 ? bit1.val : bit0.val;
+    dest++;
+  }
+
+  // rgb brightness (24 bits)
+  for (int i = 0; i < 3; i++) {
+    uint8_t color = src[i];
+    if (is_white && i == 2) {
+      // white brightness uses the same index as blue, at least in ORDER_RGB
+      // we'll make the assumption that this is true regardless of RGB order until proven otherwise.
+      color = (uint8_t) (values.get_brightness() * std::numeric_limits<uint8_t>::max());
+    }
+    for (int j = 7; j >= 0; j--) {
+      dest->val = (color >> j) & 1 ? bit1.val : bit0.val;
+      dest++;
+    }
+  }
+}
+
+};  // namespace esp32_rmt_led_strip
+};  // namespace esphome
+
+#endif

--- a/esphome/components/esp32_rmt_led_strip/rds_rgbw_02.h
+++ b/esphome/components/esp32_rmt_led_strip/rds_rgbw_02.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#ifdef USE_ESP32
+
+#include "led_strip.h"
+
+#include "esphome/components/light/light_state.h"
+
+namespace esphome {
+namespace esp32_rmt_led_strip {
+
+enum RDSRGBW02Color : uint8_t {
+  RDS_RGBW_02_OFF = 0,
+  RDS_RGBW_02_RED,
+  RDS_RGBW_02_GREEN,
+  RDS_RGBW_02_BLUE,
+  RDS_RGBW_02_WHITE,
+  RDS_RGBW_02_PURPLE,
+  RDS_RGBW_02_YELLOW,
+  RDS_RGBW_02_CYAN,
+};
+
+Generator rds_rgbw_02_rmt_generator;
+
+};  // namespace esp32_rmt_led_strip
+};  // namespace esphome
+
+#endif

--- a/esphome/components/light/addressable_light_effect.h
+++ b/esphome/components/light/addressable_light_effect.h
@@ -39,8 +39,15 @@ class AddressableLightEffect : public LightEffect {
   void stop() override { this->get_addressable_()->set_effect_active(false); }
   virtual void apply(AddressableLight &it, const Color &current_color) = 0;
   void apply() override {
-    // not using any color correction etc. that will be handled by the addressable layer through ESPColorCorrection
-    Color current_color = color_from_light_color_values(this->state_->remote_values);
+    // not using any color correction etc. that will be handled by the addressable layer through
+    // ESPColorCorrection
+    Color current_color{};
+    if (this->state_->remote_values.get_color_mode() & ColorCapability::WHITE) {
+      // this is to support lights that support only RGB or White separately
+      current_color = Color{0, 0, 0, to_uint8_scale(this->state_->remote_values.get_brightness())};
+    } else {
+      current_color = color_from_light_color_values(this->state_->remote_values);
+    }
     this->apply(*this->get_addressable_(), current_color);
   }
 

--- a/esphome/components/light/base_light_effects.h
+++ b/esphome/components/light/base_light_effects.h
@@ -118,7 +118,7 @@ class LambdaLightEffect : public LightEffect {
   void start() override { this->initial_run_ = true; }
   void apply() override {
     const uint32_t now = millis();
-    if (now - this->last_run_ >= this->update_interval_ || this->initial_run_) {
+    if (now - this->last_run_ >= this->update_interval_) {
       this->last_run_ = now;
       this->f_(this->initial_run_);
       this->initial_run_ = false;

--- a/esphome/components/light/esp_color_view.h
+++ b/esphome/components/light/esp_color_view.h
@@ -22,12 +22,13 @@ class ESPColorSettable {
   void set(const ESPHSVColor &color) { this->set_hsv(color); }
   void set_hsv(const ESPHSVColor &color) {
     Color rgb = color.to_rgb();
-    this->set_rgb(rgb.r, rgb.g, rgb.b);
+    this->set_rgbw(rgb.r, rgb.g, rgb.b, 0);
   }
   void set_rgb(uint8_t red, uint8_t green, uint8_t blue) {
     this->set_red(red);
     this->set_green(green);
     this->set_blue(blue);
+    this->set_white(0);
   }
   void set_rgbw(uint8_t red, uint8_t green, uint8_t blue, uint8_t white) {
     this->set_rgb(red, green, blue);


### PR DESCRIPTION
# What does this implement/fix?

This adds support for the RDS-RGBW-02 data-over-power lights and potentially further DOP implementations down the road.

This required significant re-architecting as the existing architecture was built under the assumption one would be using 1- or 2-wire strings that use simple RGB(W) arrays and shift subsequent data down the line. The RDS-RDBW-02 and other data-over-power schemes require in-band addressing and potentially other, more complex structuring, possibly application-specific.

To enable this, the transformation of the color buffer to `rmt_item32_t`s is facilitated by the `Generator` functor (e.g. lambda). This lets the component host swappable transformation code and can potentially allow a user to implement their own schema in a config-included header file if they so desire.

**MAINTAINER NOTE** I do not currently have any of the previously-supported addressable lights (e.g. WS2811/2), therefore I cannot properly test that I maintained backwards-compatibility. If I could have a volunteer test this code, that would be very helpful!

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here> **TODO**

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
platform: esp32_rmt_led_strip
chipset: RDS-RGBW-02
num_leds: 15
rgb_order: RGB
default_transition_length: 0s
restore_mode: RESTORE_DEFAULT_ON
effects:
  - addressable_rainbow:
      speed: 10
      width: 15
  - addressable_lambda:
      name: Candy Cane
      update_interval: 1h
      lambda: static_colors(it, {RED, WHITE});
  - addressable_lambda:
      name: Red Green
      update_interval: 1h
      lambda: static_colors(it, {RED, GREEN});
  - addressable_lambda:
      name: Five Color
      update_interval: 1h
      lambda: static_colors(it, {RED, GREEN, BLUE, YELLOW, PURPLE});
  - addressable_lambda:
      name: Seahawks
      update_interval: 1h
      lambda: static_colors(it, {GREEN, BLUE});
  - addressable_rainbow:
      name: ARE GEE BEE
      speed: 10
      width: 150
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
