### PR TITLE
2023.12.0b4

### DIFF
--- a/esphome/components/api/proto.h
+++ b/esphome/components/api/proto.h
@@ -160,8 +160,7 @@ class ProtoWriteBuffer {
     this->encode_field_raw(field_id, 2);
     this->encode_varint_raw(len);
     auto *data = reinterpret_cast<const uint8_t *>(string);
-    for (size_t i = 0; i < len; i++)
-      this->write(data[i]);
+    this->buffer_->insert(this->buffer_->end(), data, data + len);
   }
   void encode_string(uint32_t field_id, const std::string &value, bool force = false) {
     this->encode_string(field_id, value.data(), value.size());

--- a/esphome/components/i2c/i2c.h
+++ b/esphome/components/i2c/i2c.h
@@ -11,43 +11,116 @@ namespace i2c {
 
 #define LOG_I2C_DEVICE(this) ESP_LOGCONFIG(TAG, "  Address: 0x%02X", this->address_);
 
-class I2CDevice;
+class I2CDevice;  // forward declaration
+
+/// @brief This class is used to create I2CRegister objects that act as proxies to read/write internal registers on an
+/// I2C device.
+/// @details
+/// @n typical usage:
+/// @code
+/// constexpr uint8_t ADDR_REGISTER_1 = 0x12;
+/// i2c::I2CRegister reg_1 = this->reg(ADDR_REGISTER_1); // declare
+/// reg_1 |= 0x01; // set bit
+/// reg_1 &= ~0x01; // reset bit
+/// reg_1 = 10; // Set value
+/// uint val = reg_1.get(); // get value
+/// @endcode
+/// @details The I²C protocol specifies how to read/write in sets of 8-bits followed by an Acknowledgement (ACK/NACK)
+/// from the device receiving the data. How the device interprets the bits read/written can vary greatly from
+/// device to device. However most of the devices follow the same protocol for reading/writing 8 bit registers using as
+/// implemented in the I2CRegister: after sending the device address, the controller sends one byte with the internal
+/// register address and then read or write the specified register content.
 class I2CRegister {
  public:
+  /// @brief overloads the = operator. This allows to set the value of an i2c register
+  /// @param value value to be set in the register
+  /// @return pointer to current object
   I2CRegister &operator=(uint8_t value);
+
+  /// @brief overloads the compound &= operator. This allows to reset specific bits of an I²C register
+  /// @param value used for the & operation
+  /// @return pointer to current object
   I2CRegister &operator&=(uint8_t value);
+
+  /// @brief overloads the compound |= operator. This allows to set specific bits of an I²C register
+  /// @param value used for the & operation
+  /// @return pointer to current object
   I2CRegister &operator|=(uint8_t value);
 
+  /// @brief overloads the uint8_t() cast operator to return the I²C register value
+  /// @return pointer to current object
   explicit operator uint8_t() const { return get(); }
 
+  /// @brief returns the register value
+  /// @return the register value
   uint8_t get() const;
 
  protected:
   friend class I2CDevice;
 
+  /// @brief protected constructor that stores the owning object and the register address. Note as only friends can
+  /// create an I2CRegister @see I2CDevice::reg()
+  /// @param parent our parent
+  /// @param a_register address of the i2c register
   I2CRegister(I2CDevice *parent, uint8_t a_register) : parent_(parent), register_(a_register) {}
 
-  I2CDevice *parent_;
-  uint8_t register_;
+  I2CDevice *parent_;  ///< I2CDevice object pointer
+  uint8_t register_;   ///< the internal address of the register
 };
 
+/// @brief This class is used to create I2CRegister16 objects that act as proxies to read/write internal registers
+/// (specified with a 16 bit address) on an I2C device.
+/// @details
+/// @n typical usage:
+/// @code
+/// constexpr uint16_t X16_BIT_ADDR_REGISTER_1 = 0x1234;
+/// i2c::I2CRegister16 reg_1 = this->reg16(X16_BIT_ADDR_REGISTER_1); // declare
+/// reg_1 |= 0x01; // set bit
+/// reg_1 &= ~0x01; // reset bit
+/// reg_1 = 10; // Set value
+/// uint val = reg_1.get(); // get value
+/// @endcode
+/// @details The I²C protocol specification, reads/writes in sets of 8-bits followed by an Acknowledgement (ACK/NACK)
+/// from the device receiving the data. How the device interprets the bits read/written to it can vary greatly from
+/// device to device. This class can be used to access in the device 8 bits registers that uses a 16 bits internal
+/// address. After sending the device address, the controller sends the internal register address (using two consecutive
+/// bytes following the big indian convention) and then read or write the register content.
 class I2CRegister16 {
  public:
+  /// @brief overloads the = operator. This allows to set the value of an I²C register
+  /// @param value value to be set in the register
+  /// @return pointer to current object
   I2CRegister16 &operator=(uint8_t value);
+
+  /// @brief overloads the compound &= operator. This allows to reset specific bits of an I²C register
+  /// @param value used for the & operation
+  /// @return pointer to current object
   I2CRegister16 &operator&=(uint8_t value);
+
+  /// @brief overloads the compound |= operator. This allows to set bits of an I²C register
+  /// @param value used for the & operation
+  /// @return pointer to current object
   I2CRegister16 &operator|=(uint8_t value);
 
+  /// @brief overloads the uint8_t() cast operator to return the I²C register value
+  /// @return the register value
   explicit operator uint8_t() const { return get(); }
 
+  /// @brief returns the register value
+  /// @return the register value
   uint8_t get() const;
 
  protected:
   friend class I2CDevice;
 
+  /// @brief protected constructor that store the owning object and the register address. Only friends can create an
+  /// I2CRegister16 @see I2CDevice::reg16()
+  /// @param parent our parent
+  /// @param a_register 16 bits address of the i2c register
   I2CRegister16(I2CDevice *parent, uint16_t a_register) : parent_(parent), register_(a_register) {}
 
-  I2CDevice *parent_;
-  uint16_t register_;
+  I2CDevice *parent_;  ///< I2CDevice object pointer
+  uint16_t register_;  ///< the internal 16 bits address of the register
 };
 
 // like ntohs/htons but without including networking headers.
@@ -55,29 +128,91 @@ class I2CRegister16 {
 inline uint16_t i2ctohs(uint16_t i2cshort) { return convert_big_endian(i2cshort); }
 inline uint16_t htoi2cs(uint16_t hostshort) { return convert_big_endian(hostshort); }
 
+/// @brief This Class provides the methods to read/write bytes from/to an i2c device.
+/// Objects keep a list of devices found on bus as well as a pointer to the I2CBus in use.
 class I2CDevice {
  public:
+  /// @brief we use the C++ default constructor
   I2CDevice() = default;
 
+  /// @brief We store the address of the device on the bus
+  /// @param address of the device
   void set_i2c_address(uint8_t address) { address_ = address; }
+
+  /// @brief we store the pointer to the I2CBus to use
+  /// @param bus pointer to the I2CBus object
   void set_i2c_bus(I2CBus *bus) { bus_ = bus; }
 
+  /// @brief calls the I2CRegister constructor
+  /// @param a_register address of the I²C register
+  /// @return an I2CRegister proxy object
   I2CRegister reg(uint8_t a_register) { return {this, a_register}; }
+
+  /// @brief calls the I2CRegister16 constructor
+  /// @param a_register 16 bits address of the I²C register
+  /// @return an I2CRegister16 proxy object
   I2CRegister16 reg16(uint16_t a_register) { return {this, a_register}; }
 
+  /// @brief reads an array of bytes from the device using an I2CBus
+  /// @param data pointer to an array to store the bytes
+  /// @param len length of the buffer = number of bytes to read
+  /// @return an i2c::ErrorCode
   ErrorCode read(uint8_t *data, size_t len) { return bus_->read(address_, data, len); }
+
+  /// @brief reads an array of bytes from a specific register in the I²C device
+  /// @param a_register an 8 bits internal address of the I²C register to read from
+  /// @param data pointer to an array to store the bytes
+  /// @param len length of the buffer = number of bytes to read
+  /// @param stop (true/false): True will send a stop message, releasing the bus after
+  /// transmission. False will send a restart, keeping the connection active.
+  /// @return an i2c::ErrorCode
   ErrorCode read_register(uint8_t a_register, uint8_t *data, size_t len, bool stop = true);
+
+  /// @brief reads an array of bytes from a specific register in the I²C device
+  /// @param a_register the 16 bits internal address of the I²C register to read from
+  /// @param data pointer to an array of bytes to store the information
+  /// @param len length of the buffer = number of bytes to read
+  /// @param stop (true/false): True will send a stop message, releasing the bus after
+  /// transmission. False will send a restart, keeping the connection active.
+  /// @return an i2c::ErrorCode
   ErrorCode read_register16(uint16_t a_register, uint8_t *data, size_t len, bool stop = true);
 
-  ErrorCode write(const uint8_t *data, uint8_t len, bool stop = true) { return bus_->write(address_, data, len, stop); }
+  /// @brief writes an array of bytes to a device using an I2CBus
+  /// @param data pointer to an array that contains the bytes to send
+  /// @param len length of the buffer = number of bytes to write
+  /// @param stop (true/false): True will send a stop message, releasing the bus after
+  /// transmission. False will send a restart, keeping the connection active.
+  /// @return an i2c::ErrorCode
+  ErrorCode write(const uint8_t *data, size_t len, bool stop = true) { return bus_->write(address_, data, len, stop); }
+
+  /// @brief writes an array of bytes to a specific register in the I²C device
+  /// @param a_register the internal address of the register to read from
+  /// @param data pointer to an array to store the bytes
+  /// @param len length of the buffer = number of bytes to read
+  /// @param stop (true/false): True will send a stop message, releasing the bus after
+  /// transmission. False will send a restart, keeping the connection active.
+  /// @return an i2c::ErrorCode
   ErrorCode write_register(uint8_t a_register, const uint8_t *data, size_t len, bool stop = true);
+
+  /// @brief write an array of bytes to a specific register in the I²C device
+  /// @param a_register the 16 bits internal address of the register to read from
+  /// @param data pointer to an array to store the bytes
+  /// @param len length of the buffer = number of bytes to read
+  /// @param stop (true/false): True will send a stop message, releasing the bus after
+  /// transmission. False will send a restart, keeping the connection active.
+  /// @return an i2c::ErrorCode
   ErrorCode write_register16(uint16_t a_register, const uint8_t *data, size_t len, bool stop = true);
 
-  // Compat APIs
+  ///
+  /// Compat APIs
+  /// All methods below have been added for compatibility reasons. They do not bring any functionality and therefore on
+  /// new code it is not recommend to use them.
+  ///
 
   bool read_bytes(uint8_t a_register, uint8_t *data, uint8_t len) {
     return read_register(a_register, data, len) == ERROR_OK;
   }
+
   bool read_bytes_raw(uint8_t *data, uint8_t len) { return read(data, len) == ERROR_OK; }
 
   template<size_t N> optional<std::array<uint8_t, N>> read_bytes(uint8_t a_register) {
@@ -131,8 +266,8 @@ class I2CDevice {
   bool write_byte_16(uint8_t a_register, uint16_t data) { return write_bytes_16(a_register, &data, 1); }
 
  protected:
-  uint8_t address_{0x00};
-  I2CBus *bus_{nullptr};
+  uint8_t address_{0x00};  ///< store the address of the device on the bus
+  I2CBus *bus_{nullptr};   ///< pointer to I2CBus instance
 };
 
 }  // namespace i2c

--- a/esphome/components/i2c/i2c_bus.h
+++ b/esphome/components/i2c/i2c_bus.h
@@ -7,50 +7,93 @@
 namespace esphome {
 namespace i2c {
 
+/// @brief Error codes returned by I2CBus and I2CDevice methods
 enum ErrorCode {
-  ERROR_OK = 0,
-  ERROR_INVALID_ARGUMENT = 1,
-  ERROR_NOT_ACKNOWLEDGED = 2,
-  ERROR_TIMEOUT = 3,
-  ERROR_NOT_INITIALIZED = 4,
-  ERROR_TOO_LARGE = 5,
-  ERROR_UNKNOWN = 6,
-  ERROR_CRC = 7,
+  NO_ERROR = 0,                ///< No error found during execution of method
+  ERROR_OK = 0,                ///< No error found during execution of method
+  ERROR_INVALID_ARGUMENT = 1,  ///< method called invalid argument(s)
+  ERROR_NOT_ACKNOWLEDGED = 2,  ///< I2C bus acknowledgment not received
+  ERROR_TIMEOUT = 3,           ///< timeout while waiting to receive bytes
+  ERROR_NOT_INITIALIZED = 4,   ///< call method to a not initialized bus
+  ERROR_TOO_LARGE = 5,         ///< requested a transfer larger than buffers can hold
+  ERROR_UNKNOWN = 6,           ///< miscellaneous I2C error during execution
+  ERROR_CRC = 7,               ///< bytes received with a CRC error
 };
 
+/// @brief the ReadBuffer structure stores a pointer to a read buffer and its length
 struct ReadBuffer {
-  uint8_t *data;
-  size_t len;
-};
-struct WriteBuffer {
-  const uint8_t *data;
-  size_t len;
+  uint8_t *data;  ///< pointer to the read buffer
+  size_t len;     ///< length of the buffer
 };
 
+/// @brief the WriteBuffer structure stores a pointer to a write buffer and its length
+struct WriteBuffer {
+  const uint8_t *data;  ///< pointer to the write buffer
+  size_t len;           ///< length of the buffer
+};
+
+/// @brief This Class provides the methods to read and write bytes from an I2CBus.
+/// @note The I2CBus virtual class follows a *Factory design pattern* that provides all the interfaces methods required
+/// by clients while deferring the actual implementation of these methods to a subclasses. I2C-bus specification and
+/// user manual can be found here https://www.nxp.com/docs/en/user-guide/UM10204.pdf and an interesting I²C Application
+/// note https://www.nxp.com/docs/en/application-note/AN10216.pdf
 class I2CBus {
  public:
+  /// @brief Creates a ReadBuffer and calls the virtual readv() method to read bytes into this buffer
+  /// @param address address of the I²C component on the i2c bus
+  /// @param buffer pointer to an array of bytes that will be used to store the data received
+  /// @param len length of the buffer = number of bytes to read
+  /// @return an i2c::ErrorCode
   virtual ErrorCode read(uint8_t address, uint8_t *buffer, size_t len) {
     ReadBuffer buf;
     buf.data = buffer;
     buf.len = len;
     return readv(address, &buf, 1);
   }
-  virtual ErrorCode readv(uint8_t address, ReadBuffer *buffers, size_t cnt) = 0;
+
+  /// @brief This virtual method reads bytes from an I2CBus into an array of ReadBuffer.
+  /// @param address address of the I²C component on the i2c bus
+  /// @param buffers pointer to an array of ReadBuffer
+  /// @param count number of ReadBuffer to read
+  /// @return an i2c::ErrorCode
+  /// @details This is a pure virtual method that must be implemented in a subclass.
+  virtual ErrorCode readv(uint8_t address, ReadBuffer *buffers, size_t count) = 0;
+
   virtual ErrorCode write(uint8_t address, const uint8_t *buffer, size_t len) {
     return write(address, buffer, len, true);
   }
+
+  /// @brief Creates a WriteBuffer and calls the writev() method to send the bytes from this buffer
+  /// @param address address of the I²C component on the i2c bus
+  /// @param buffer pointer to an array of bytes that contains the data to be sent
+  /// @param len length of the buffer = number of bytes to write
+  /// @param stop true or false: True will send a stop message, releasing the bus after
+  /// transmission. False will send a restart, keeping the connection active.
+  /// @return an i2c::ErrorCode
   virtual ErrorCode write(uint8_t address, const uint8_t *buffer, size_t len, bool stop) {
     WriteBuffer buf;
     buf.data = buffer;
     buf.len = len;
     return writev(address, &buf, 1, stop);
   }
+
   virtual ErrorCode writev(uint8_t address, WriteBuffer *buffers, size_t cnt) {
     return writev(address, buffers, cnt, true);
   }
-  virtual ErrorCode writev(uint8_t address, WriteBuffer *buffers, size_t cnt, bool stop) = 0;
+
+  /// @brief This virtual method writes bytes to an I2CBus from an array of WriteBuffer.
+  /// @param address address of the I²C component on the i2c bus
+  /// @param buffers pointer to an array of WriteBuffer
+  /// @param count number of WriteBuffer to write
+  /// @param stop true or false: True will send a stop message, releasing the bus after
+  /// transmission. False will send a restart, keeping the connection active.
+  /// @return an i2c::ErrorCode
+  /// @details This is a pure virtual method that must be implemented in the subclass.
+  virtual ErrorCode writev(uint8_t address, WriteBuffer *buffers, size_t count, bool stop) = 0;
 
  protected:
+  /// @brief Scans the I2C bus for devices. Devices presence is kept in an array of std::pair
+  /// that contains the address and the corresponding bool presence flag.
   void i2c_scan_() {
     for (uint8_t address = 8; address < 120; address++) {
       auto err = writev(address, nullptr, 0);
@@ -61,8 +104,8 @@ class I2CBus {
       }
     }
   }
-  std::vector<std::pair<uint8_t, bool>> scan_results_;
-  bool scan_{false};
+  std::vector<std::pair<uint8_t, bool>> scan_results_;  ///< array containing scan results
+  bool scan_{false};                                    ///< Should we scan ? Can be set in the yaml
 };
 
 }  // namespace i2c

--- a/esphome/components/uart/uart_component_esp32_arduino.cpp
+++ b/esphome/components/uart/uart_component_esp32_arduino.cpp
@@ -88,7 +88,11 @@ void ESP32ArduinoUARTComponent::setup() {
 #endif
   static uint8_t next_uart_num = 0;
   if (is_default_tx && is_default_rx && next_uart_num == 0) {
+#if ARDUINO_USB_CDC_ON_BOOT
+    this->hw_serial_ = &Serial0;
+#else
     this->hw_serial_ = &Serial;
+#endif
     next_uart_num++;
   } else {
 #ifdef USE_LOGGER

--- a/esphome/components/waveshare_epaper/waveshare_epaper.h
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.h
@@ -92,13 +92,20 @@ class WaveshareEPaperTypeA : public WaveshareEPaper {
   void display() override;
 
   void deep_sleep() override {
-    if (this->model_ == WAVESHARE_EPAPER_2_9_IN_V2 || this->model_ == WAVESHARE_EPAPER_1_54_IN_V2) {
-      // COMMAND DEEP SLEEP MODE
-      this->command(0x10);
-      this->data(0x01);
-    } else {
-      // COMMAND DEEP SLEEP MODE
-      this->command(0x10);
+    switch (this->model_) {
+      // Models with specific deep sleep command and data
+      case WAVESHARE_EPAPER_1_54_IN:
+      case WAVESHARE_EPAPER_1_54_IN_V2:
+      case WAVESHARE_EPAPER_2_9_IN_V2:
+        // COMMAND DEEP SLEEP MODE
+        this->command(0x10);
+        this->data(0x01);
+        break;
+      // Other models default to simple deep sleep command
+      default:
+        // COMMAND DEEP SLEEP
+        this->command(0x10);
+        break;
     }
     this->wait_until_idle_();
   }
@@ -107,6 +114,8 @@ class WaveshareEPaperTypeA : public WaveshareEPaper {
 
  protected:
   void write_lut_(const uint8_t *lut, uint8_t size);
+
+  void init_display_();
 
   int get_width_internal() override;
 
@@ -118,6 +127,8 @@ class WaveshareEPaperTypeA : public WaveshareEPaper {
   uint32_t at_update_{0};
   WaveshareEPaperTypeAModel model_;
   uint32_t idle_timeout_() override;
+
+  bool deep_sleep_between_updates_{false};
 };
 
 enum WaveshareEPaperTypeBModel {

--- a/esphome/const.py
+++ b/esphome/const.py
@@ -1,6 +1,6 @@
 """Constants used by esphome."""
 
-__version__ = "2023.12.0b3"
+__version__ = "2023.12.0b4"
 
 ALLOWED_NAME_CHARS = "abcdefghijklmnopqrstuvwxyz0123456789-_"
 VALID_SUBSTITUTIONS_CHARACTERS = (

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ platformio==6.1.11  # When updating platformio, also update Dockerfile
 esptool==4.6.2
 click==8.1.7
 esphome-dashboard==20231107.0
-aioesphomeapi==21.0.0
+aioesphomeapi==21.0.1
 zeroconf==0.130.0
 python-magic==0.4.27
 


### PR DESCRIPTION
**Do not merge, release script will automatically merge**
- Fix build issue with UART component when building with Arduino and CDC [esphome#5964](https://github.com/esphome/esphome/pull/5964)
- Fix I2CBus::write() bug and add i2c documentation [esphome#5947](https://github.com/esphome/esphome/pull/5947)
- Add deep sleep between updates for waveshare epaper 1.54in and 1.54inv2 [esphome#5961](https://github.com/esphome/esphome/pull/5961)
- Speed up writing protobuf strings/bytes [esphome#5828](https://github.com/esphome/esphome/pull/5828)
- Bump aioesphomeapi to 21.0.1 [esphome#5969](https://github.com/esphome/esphome/pull/5969)
