### PR TITLE
Fix issue when setting cw/ww brightness via temperature

### DIFF
--- a/esphome/components/light/light_call.cpp
+++ b/esphome/components/light/light_call.cpp
@@ -337,9 +337,12 @@ LightColorValues LightCall::validate_() {
 void LightCall::transform_parameters_() {
   auto traits = this->parent_->get_traits();
 
-  // Allow CWWW modes to be set with a white value and/or color temperature. This is used by HA,
-  // which doesn't support CWWW modes (yet?), and for compatibility with the pre-colormode model,
-  // as CWWW and RGBWW lights used to represent their values as white + color temperature.
+  // Allow CWWW modes to be set with a white value and/or color temperature.
+  // This is used in three cases in HA:
+  // - CW/WW lights, which set the "brightness" and "color_temperature"
+  // - RGBWW lights with color_interlock=true, which also sets "brightness" and
+  //   "color_temperature" (without color_interlock, CW/WW are set directly)
+  // - Legacy Home Assistant (pre-colormode), which sets "white" and "color_temperature"
   if (((this->white_.has_value() && *this->white_ > 0.0f) || this->color_temperature_.has_value()) &&  //
       (*this->color_mode_ & ColorCapability::COLD_WARM_WHITE) &&                                       //
       !(*this->color_mode_ & ColorCapability::WHITE) &&                                                //
@@ -347,21 +350,17 @@ void LightCall::transform_parameters_() {
       traits.get_min_mireds() > 0.0f && traits.get_max_mireds() > 0.0f) {
     ESP_LOGD(TAG, "'%s' - Setting cold/warm white channels using white/color temperature values.",
              this->parent_->get_name().c_str());
-    auto current_values = this->parent_->remote_values;
     if (this->color_temperature_.has_value()) {
-      const float white =
-          this->white_.value_or(fmaxf(current_values.get_cold_white(), current_values.get_warm_white()));
       const float color_temp = clamp(*this->color_temperature_, traits.get_min_mireds(), traits.get_max_mireds());
       const float ww_fraction =
           (color_temp - traits.get_min_mireds()) / (traits.get_max_mireds() - traits.get_min_mireds());
       const float cw_fraction = 1.0f - ww_fraction;
       const float max_cw_ww = std::max(ww_fraction, cw_fraction);
-      this->cold_white_ = white * gamma_uncorrect(cw_fraction / max_cw_ww, this->parent_->get_gamma_correct());
-      this->warm_white_ = white * gamma_uncorrect(ww_fraction / max_cw_ww, this->parent_->get_gamma_correct());
-    } else {
-      const float max_cw_ww = std::max(current_values.get_warm_white(), current_values.get_cold_white());
-      this->cold_white_ = *this->white_ * current_values.get_cold_white() / max_cw_ww;
-      this->warm_white_ = *this->white_ * current_values.get_warm_white() / max_cw_ww;
+      this->cold_white_ = gamma_uncorrect(cw_fraction / max_cw_ww, this->parent_->get_gamma_correct());
+      this->warm_white_ = gamma_uncorrect(ww_fraction / max_cw_ww, this->parent_->get_gamma_correct());
+    }
+    if (this->white_.has_value()) {
+      this->brightness_ = *this->white_;
     }
   }
 }


### PR DESCRIPTION
# What does this implement/fix?

This fixes an issue when CW/WW lights are used via Home Assistant, after both CW and WW values have been set below 1 (which can happen with the `random` effect as that does `call.set_publish(true);` for some reason.

More details in the linked issue.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/5241

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** -

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [x] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
output:
  - platform: template
    id: output_cw
    type: float
    write_action:
      - logger.log:
              format: "CW: %.1f"
              args: [ 'state' ]
  - platform: template
    id: output_ww
    type: float
    write_action:
      - logger.log:
              format: "WW: %.1f"
              args: [ 'state' ]

light:
  - platform: cwww
    name: "Test"
    cold_white: output_cw
    warm_white: output_ww
    cold_white_color_temperature: 6536 K
    warm_white_color_temperature: 2000 K
    default_transition_length: 0s
    gamma_correct: 1
    effects:
      - random:
          transition_length: 0s
```
After enabling and disabling the `random` effect once, it can be seen that there is no way (via Home Assistant) to go back to full brightness (before this PR).

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] ~Tests have been added to verify that the new code works (under `tests/` folder).~ (there are currently no tests for the light component as far as I can tell)

If user exposed functionality or configuration variables are added/changed:
  - [ ] ~Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).~
