### PR TITLE
web_server.py: return empty content when file doesn't exist

### DIFF
--- a/esphome/dashboard/web_server.py
+++ b/esphome/dashboard/web_server.py
@@ -797,8 +797,11 @@ class EditRequestHandler(BaseHandler):
 
     def _read_file(self, filename: str) -> bytes:
         """Read a file and return the content as bytes."""
-        with open(file=filename, encoding="utf-8") as f:
-            return f.read()
+        try:
+            with open(file=filename, encoding="utf-8") as f:
+                return f.read()
+        except FileNotFoundError:
+            return ''
 
     def _write_file(self, filename: str, content: bytes) -> None:
         """Write a file with the given content."""

--- a/esphome/dashboard/web_server.py
+++ b/esphome/dashboard/web_server.py
@@ -792,20 +792,21 @@ class EditRequestHandler(BaseHandler):
         """Get the content of a file."""
         loop = asyncio.get_running_loop()
         filename = settings.rel_path(configuration)
-        content = await loop.run_in_executor(None, self._read_file, filename)
-        if content:
+        content = await loop.run_in_executor(
+            None, self._read_file, filename, configuration
+        )
+        if content is not None:
             self.write(content)
 
-    def _read_file(self, filename: str) -> bytes | None:
+    def _read_file(self, filename: str, configuration: str) -> bytes | None:
         """Read a file and return the content as bytes."""
         try:
             with open(file=filename, encoding="utf-8") as f:
                 return f.read()
         except FileNotFoundError:
-            if filename in const.SECRETS_FILES:
+            if configuration in const.SECRETS_FILES:
                 return ""
             self.set_status(404)
-            return None
 
     def _write_file(self, filename: str, content: bytes) -> None:
         """Write a file with the given content."""

--- a/esphome/dashboard/web_server.py
+++ b/esphome/dashboard/web_server.py
@@ -807,6 +807,7 @@ class EditRequestHandler(BaseHandler):
             if configuration in const.SECRETS_FILES:
                 return ""
             self.set_status(404)
+            return None
 
     def _write_file(self, filename: str, content: bytes) -> None:
         """Write a file with the given content."""

--- a/esphome/dashboard/web_server.py
+++ b/esphome/dashboard/web_server.py
@@ -801,7 +801,7 @@ class EditRequestHandler(BaseHandler):
             with open(file=filename, encoding="utf-8") as f:
                 return f.read()
         except FileNotFoundError:
-            return ''
+            return ""
 
     def _write_file(self, filename: str, content: bytes) -> None:
         """Write a file with the given content."""

--- a/esphome/dashboard/web_server.py
+++ b/esphome/dashboard/web_server.py
@@ -793,15 +793,19 @@ class EditRequestHandler(BaseHandler):
         loop = asyncio.get_running_loop()
         filename = settings.rel_path(configuration)
         content = await loop.run_in_executor(None, self._read_file, filename)
-        self.write(content)
+        if content:
+            self.write(content)
 
-    def _read_file(self, filename: str) -> bytes:
+    def _read_file(self, filename: str) -> bytes | None:
         """Read a file and return the content as bytes."""
         try:
             with open(file=filename, encoding="utf-8") as f:
                 return f.read()
         except FileNotFoundError:
-            return ""
+            if filename in const.SECRETS_FILES:
+                return ""
+            self.set_status(404)
+            return None
 
     def _write_file(self, filename: str, content: bytes) -> None:
         """Write a file with the given content."""


### PR DESCRIPTION
Fixes an error, "Failed to store Wi-Fi credentials", when adopting a device and there is no `secrets.yaml` in `config/esphome`.

Experienced with Home Assistant installation with supervisor on bare Debian Bookworm install, and an HAOS install in VirtualBox with the official VDI.

# What does this implement/fix?

Should resolve issue with config file not existing when trying to edit.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
