### PR TITLE
Fix replaced - in allowed characters during object_id sanitizing

### DIFF
--- a/esphome/helpers.py
+++ b/esphome/helpers.py
@@ -357,7 +357,7 @@ def snake_case(value):
     return value.replace(" ", "_").lower()
 
 
-_DISALLOWED_CHARS = re.compile(r"[^a-zA-Z0-9_]")
+_DISALLOWED_CHARS = re.compile(r"[^a-zA-Z0-9-_]")
 
 
 def sanitize(value):

--- a/tests/unit_tests/test_helpers.py
+++ b/tests/unit_tests/test_helpers.py
@@ -261,6 +261,7 @@ def test_snake_case(text, expected):
         ('!"§$%&/()=?foo_bar', "___________foo_bar"),
         ('foo_!"§$%&/()=?bar', "foo____________bar"),
         ('foo_bar!"§$%&/()=?', "foo_bar___________"),
+        ('foo-bar!"§$%&/()=?', "foo-bar___________"),
     ),
 )
 def test_sanitize(text, expected):


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

https://github.com/esphome/esphome/pull/5810 dropped the `-` from the regex of *not* DISALLOWED CHARACTERS when it should have been kept as allowed.

```diff
+_DISALLOWED_CHARS = re.compile(r"[^a-zA-Z0-9_]")
-    return re.sub("[^-_0-9a-zA-Z]", r"", value)
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
