### PR TITLE
[Touchscreen] Add expire of touch record.

### DIFF
--- a/esphome/components/lilygo_t5_47/touchscreen/__init__.py
+++ b/esphome/components/lilygo_t5_47/touchscreen/__init__.py
@@ -18,7 +18,7 @@ LilygoT547Touchscreen = lilygo_t5_47_ns.class_(
 
 CONF_LILYGO_T5_47_TOUCHSCREEN_ID = "lilygo_t5_47_touchscreen_id"
 
-CONFIG_SCHEMA = touchscreen.TOUCHSCREEN_SCHEMA.extend(
+CONFIG_SCHEMA = touchscreen.touchscreen_schema("250ms").extend(
     cv.Schema(
         {
             cv.GenerateID(): cv.declare_id(LilygoT547Touchscreen),

--- a/esphome/components/touchscreen/__init__.py
+++ b/esphome/components/touchscreen/__init__.py
@@ -24,6 +24,7 @@ CONF_DISPLAY = "display"
 CONF_TOUCHSCREEN_ID = "touchscreen_id"
 CONF_REPORT_INTERVAL = "report_interval"  # not used yet:
 CONF_ON_UPDATE = "on_update"
+CONF_TOUCH_TIMEOUT = "touch_timeout"
 
 CONF_MIRROR_X = "mirror_x"
 CONF_MIRROR_Y = "mirror_y"
@@ -31,21 +32,29 @@ CONF_SWAP_XY = "swap_xy"
 CONF_TRANSFORM = "transform"
 
 
-TOUCHSCREEN_SCHEMA = cv.Schema(
-    {
-        cv.GenerateID(CONF_DISPLAY): cv.use_id(display.Display),
-        cv.Optional(CONF_TRANSFORM): cv.Schema(
-            {
-                cv.Optional(CONF_SWAP_XY, default=False): cv.boolean,
-                cv.Optional(CONF_MIRROR_X, default=False): cv.boolean,
-                cv.Optional(CONF_MIRROR_Y, default=False): cv.boolean,
-            }
-        ),
-        cv.Optional(CONF_ON_TOUCH): automation.validate_automation(single=True),
-        cv.Optional(CONF_ON_UPDATE): automation.validate_automation(single=True),
-        cv.Optional(CONF_ON_RELEASE): automation.validate_automation(single=True),
-    }
-).extend(cv.polling_component_schema("50ms"))
+def touchscreen_schema(default_touch_timeout):
+    return cv.Schema(
+        {
+            cv.GenerateID(CONF_DISPLAY): cv.use_id(display.Display),
+            cv.Optional(CONF_TRANSFORM): cv.Schema(
+                {
+                    cv.Optional(CONF_SWAP_XY, default=False): cv.boolean,
+                    cv.Optional(CONF_MIRROR_X, default=False): cv.boolean,
+                    cv.Optional(CONF_MIRROR_Y, default=False): cv.boolean,
+                }
+            ),
+            cv.Optional(CONF_TOUCH_TIMEOUT, default=default_touch_timeout): cv.All(
+                cv.positive_time_period_milliseconds,
+                cv.Range(max=cv.TimePeriod(milliseconds=65535)),
+            ),
+            cv.Optional(CONF_ON_TOUCH): automation.validate_automation(single=True),
+            cv.Optional(CONF_ON_UPDATE): automation.validate_automation(single=True),
+            cv.Optional(CONF_ON_RELEASE): automation.validate_automation(single=True),
+        }
+    ).extend(cv.polling_component_schema("50ms"))
+
+
+TOUCHSCREEN_SCHEMA = touchscreen_schema(cv.UNDEFINED)
 
 
 async def register_touchscreen(var, config):
@@ -53,6 +62,9 @@ async def register_touchscreen(var, config):
 
     disp = await cg.get_variable(config[CONF_DISPLAY])
     cg.add(var.set_display(disp))
+
+    if CONF_TOUCH_TIMEOUT in config:
+        cg.add(var.set_touch_timeout(config[CONF_TOUCH_TIMEOUT]))
 
     if CONF_TRANSFORM in config:
         transform = config[CONF_TRANSFORM]

--- a/esphome/components/touchscreen/touchscreen.cpp
+++ b/esphome/components/touchscreen/touchscreen.cpp
@@ -48,7 +48,7 @@ void Touchscreen::loop() {
       this->store_.touched = false;
       this->defer([this]() { this->send_touches_(); });
     }
-  } else if (this->touches_.size() > 0) {
+  } else if (!this->touches_.empty()) {
     // Found active touches without `touched` interrupt/event. Start expire/timeout process.
     bool call_send_touches = false;
     bool all_touches_state_released = true;

--- a/esphome/components/touchscreen/touchscreen.cpp
+++ b/esphome/components/touchscreen/touchscreen.cpp
@@ -48,6 +48,29 @@ void Touchscreen::loop() {
       this->store_.touched = false;
       this->defer([this]() { this->send_touches_(); });
     }
+  } else if (this->touches_.size() > 0) {
+    // Found active touches without `touched` interrupt/event. Start expire/timeout process.
+    bool call_send_touches = false;
+    bool all_touches_state_released = true;
+    for (auto &tp : this->touches_) {
+      if (tp.second.state == STATE_PRESSED || tp.second.state == STATE_UPDATED) {
+        all_touches_state_released = false;
+        tp.second.release_counter++;
+      } else {
+        tp.second.state = STATE_RELEASED;
+        call_send_touches = true;
+      }
+      if (tp.second.release_counter == 5) {
+        // I made 5 loop (5*~50ms = >250ms) without `touched` active. Assume touch is expired.
+        tp.second.state = tp.second.state | STATE_RELEASING;
+        call_send_touches = true;
+      }
+    }
+    if (call_send_touches) {
+      this->need_update_ = false;
+      this->is_touched_ = !all_touches_state_released;
+      this->defer([this]() { this->send_touches_(); });
+    }
   }
 }
 
@@ -79,6 +102,7 @@ void Touchscreen::add_raw_touch_position_(uint8_t id, int16_t x_raw, int16_t y_r
     tp.x_org = tp.x;
     tp.y_org = tp.y;
   }
+  tp.release_counter = 0;
 
   this->touches_[id] = tp;
 

--- a/esphome/components/touchscreen/touchscreen.cpp
+++ b/esphome/components/touchscreen/touchscreen.cpp
@@ -93,6 +93,7 @@ void Touchscreen::add_raw_touch_position_(uint8_t id, int16_t x_raw, int16_t y_r
 
 void Touchscreen::send_touches_() {
   if (!this->is_touched_) {
+    this->cancel_timeout(TAG);
     this->release_trigger_.trigger();
     for (auto *listener : this->touch_listeners_)
       listener->release();

--- a/esphome/components/touchscreen/touchscreen.h
+++ b/esphome/components/touchscreen/touchscreen.h
@@ -46,6 +46,7 @@ class Touchscreen : public PollingComponent {
   void set_display(display::Display *display) { this->display_ = display; }
   display::Display *get_display() const { return this->display_; }
 
+  void set_touch_timeout(uint16_t val) { this->touch_timeout_ = val; }
   void set_mirror_x(bool invert_x) { this->invert_x_ = invert_x; }
   void set_mirror_y(bool invert_y) { this->invert_y_ = invert_y; }
   void set_swap_xy(bool swap) { this->swap_x_y_ = swap; }
@@ -100,6 +101,7 @@ class Touchscreen : public PollingComponent {
   display::Display *display_{nullptr};
 
   int16_t x_raw_min_{0}, x_raw_max_{0}, y_raw_min_{0}, y_raw_max_{0};
+  uint16_t touch_timeout_{0};
   bool invert_x_{false}, invert_y_{false}, swap_x_y_{false};
 
   Trigger<TouchPoint, const TouchPoints_t &> touch_trigger_;

--- a/esphome/components/touchscreen/touchscreen.h
+++ b/esphome/components/touchscreen/touchscreen.h
@@ -24,7 +24,6 @@ struct TouchPoint {
   uint16_t x_org{0}, y_org{0};
   uint16_t x{0}, y{0};
   int8_t state{0};
-  uint8_t release_counter;
 };
 
 using TouchPoints_t = std::vector<TouchPoint>;

--- a/esphome/components/touchscreen/touchscreen.h
+++ b/esphome/components/touchscreen/touchscreen.h
@@ -24,6 +24,7 @@ struct TouchPoint {
   uint16_t x_org{0}, y_org{0};
   uint16_t x{0}, y{0};
   int8_t state{0};
+  uint8_t release_counter;
 };
 
 using TouchPoints_t = std::vector<TouchPoint>;


### PR DESCRIPTION
# What does this implement/fix?

I observed an issue while using touchscreen `lilygo_t5_47`. A touch event was fired once on the first touch, but no release or new touch events were fired.

The issue is when interrupt is used for touchscreen i2c handling. On touch release the `this->store_.touched` is no longer set inside the `loop()` function. Therefore `send_touches_` is never called to release the touch.

Added logic into the `loop()` that a touch event expires when not found by touchscreen for ~250ms.

Calling `update_touches` more frequently is not an option. As when requesting data via i2c without an event (indicated by interrupt) will result in no detected touches.

This is a regression of PR https://github.com/esphome/esphome/pull/4596.

<!-- Quick description and explanation of changes -->

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
touchscreen:
- platform: lilygo_t5_47
  interrupt_pin: GPIO47
  address: 0x5A
  on_touch:
    then:
      - logger.log:
          format: "Touch x:%i y:%i"
          args: [ 'touch.x', 'touch.y' ]
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
