### PR TITLE
Fix unexpected disconnects when outgoing buffer is full during keepalive

### DIFF
--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -138,6 +138,9 @@ void APIConnection::loop() {
         on_fatal_error();
         ESP_LOGE(TAG, "%s: Sending keepalive failed %d time(s). Disconnecting...", this->client_combined_info_.c_str(),
                  this->ping_retries_);
+      } else if (this->ping_retries_ >= 10) {
+        ESP_LOGW(TAG, "%s: Sending keepalive failed %d time(s), will retry in %d ms",
+                 this->client_combined_info_.c_str(), this->ping_retries_, ping_retry_interval);
       } else {
         ESP_LOGD(TAG, "%s: Sending keepalive failed %d time(s), will retry in %d ms",
                  this->client_combined_info_.c_str(), this->ping_retries_, ping_retry_interval);

--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -136,9 +136,11 @@ void APIConnection::loop() {
       this->ping_retries_++;
       if (this->ping_retries_ >= max_ping_retries) {
         on_fatal_error();
-        ESP_LOGE(TAG, "%s: Sending keepalive failed %d times. Disconnecting...", this->client_combined_info_.c_str(), this->ping_retries_);
+        ESP_LOGE(TAG, "%s: Sending keepalive failed %d times. Disconnecting...", this->client_combined_info_.c_str(),
+                 this->ping_retries_);
       } else {
-        ESP_LOGW(TAG, "%s: Sending keepalive failed %d times, will retry in %d ms", this->client_combined_info_.c_str(), this->ping_retries_, ping_retry_interval);
+        ESP_LOGW(TAG, "%s: Sending keepalive failed %d times, will retry in %d ms", this->client_combined_info_.c_str(),
+                 this->ping_retries_, ping_retry_interval);
       }
     }
   }

--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -118,7 +118,9 @@ void APIConnection::loop() {
   this->list_entities_iterator_.advance();
   this->initial_state_iterator_.advance();
 
-  const uint32_t keepalive = 60000;
+  static uint32_t keepalive = 60000;
+  static uint8_t max_ping_retries = 60;
+  static uint16_t ping_retry_interval = 1000;
   const uint32_t now = millis();
   if (this->sent_ping_) {
     // Disconnect if not responded within 2.5*keepalive
@@ -126,10 +128,19 @@ void APIConnection::loop() {
       on_fatal_error();
       ESP_LOGW(TAG, "%s didn't respond to ping request in time. Disconnecting...", this->client_combined_info_.c_str());
     }
-  } else if (now - this->last_traffic_ > keepalive) {
+  } else if (now - this->last_traffic_ > keepalive && now > this->next_ping_retry_) {
     ESP_LOGVV(TAG, "Sending keepalive PING...");
-    this->sent_ping_ = true;
-    this->send_ping_request(PingRequest());
+    this->sent_ping_ = this->send_ping_request(PingRequest());
+    if (!this->sent_ping_) {
+      this->next_ping_retry_ = now + ping_retry_interval;
+      this->ping_retries_++;
+      if (this->ping_retries_ >= max_ping_retries) {
+        on_fatal_error();
+        ESP_LOGE(TAG, "%s: Sending keepalive failed %d times. Disconnecting...", this->client_combined_info_.c_str(), this->ping_retries_);
+      } else {
+        ESP_LOGW(TAG, "%s: Sending keepalive failed %d times, will retry in %d ms", this->client_combined_info_.c_str(), this->ping_retries_, ping_retry_interval);
+      }
+    }
   }
 
 #ifdef USE_ESP32_CAMERA

--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -136,11 +136,11 @@ void APIConnection::loop() {
       this->ping_retries_++;
       if (this->ping_retries_ >= max_ping_retries) {
         on_fatal_error();
-        ESP_LOGE(TAG, "%s: Sending keepalive failed %d times. Disconnecting...", this->client_combined_info_.c_str(),
+        ESP_LOGE(TAG, "%s: Sending keepalive failed %d time(s). Disconnecting...", this->client_combined_info_.c_str(),
                  this->ping_retries_);
       } else {
-        ESP_LOGW(TAG, "%s: Sending keepalive failed %d times, will retry in %d ms", this->client_combined_info_.c_str(),
-                 this->ping_retries_, ping_retry_interval);
+        ESP_LOGD(TAG, "%s: Sending keepalive failed %d time(s), will retry in %d ms",
+                 this->client_combined_info_.c_str(), this->ping_retries_, ping_retry_interval);
       }
     }
   }

--- a/esphome/components/api/api_connection.h
+++ b/esphome/components/api/api_connection.h
@@ -140,6 +140,7 @@ class APIConnection : public APIServerConnection {
   void on_disconnect_response(const DisconnectResponse &value) override;
   void on_ping_response(const PingResponse &value) override {
     // we initiated ping
+    this->ping_retries_ = 0;
     this->sent_ping_ = false;
   }
   void on_home_assistant_state_response(const HomeAssistantStateResponse &msg) override;
@@ -217,6 +218,8 @@ class APIConnection : public APIServerConnection {
   bool state_subscription_{false};
   int log_subscription_{ESPHOME_LOG_LEVEL_NONE};
   uint32_t last_traffic_;
+  uint32_t next_ping_retry_{0};
+  uint8_t ping_retries_{0};
   bool sent_ping_{false};
   bool service_call_subscription_{false};
   bool next_close_ = false;


### PR DESCRIPTION
# What does this implement/fix?

<img width="864" alt="Screenshot 2023-12-21 at 4 26 10 PM" src="https://github.com/esphome/esphome/assets/663432/d1dec16c-f4d6-44a0-9b36-163af8d04c3c">


```
64 bytes from 192.168.107.104: icmp_seq=5026 ttl=64 time=4.007 ms
Request timeout for icmp_seq 5027
Request timeout for icmp_seq 5028
Request timeout for icmp_seq 5029
64 bytes from 192.168.107.104: icmp_seq=5030 ttl=64 time=4.111 ms
64 bytes from 192.168.107.104: icmp_seq=5031 ttl=64 time=4.491 ms
```

The retries correspond with the drop outs

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
