### PR TITLE
Add feature to reverse TM1637 display char order

### DIFF
--- a/esphome/components/tm1637/display.py
+++ b/esphome/components/tm1637/display.py
@@ -9,6 +9,7 @@ from esphome.const import (
     CONF_LAMBDA,
     CONF_INTENSITY,
     CONF_INVERTED,
+    CONF_REVERSED,
     CONF_LENGTH,
 )
 
@@ -25,6 +26,7 @@ CONFIG_SCHEMA = display.BASIC_DISPLAY_SCHEMA.extend(
             cv.uint8_t, cv.Range(min=0, max=7)
         ),
         cv.Optional(CONF_INVERTED, default=False): cv.boolean,
+        cv.Optional(CONF_REVERSED, default=False): cv.boolean,
         cv.Optional(CONF_LENGTH, default=6): cv.All(cv.uint8_t, cv.Range(min=1, max=6)),
         cv.Required(CONF_CLK_PIN): pins.gpio_output_pin_schema,
         cv.Required(CONF_DIO_PIN): pins.gpio_output_pin_schema,
@@ -43,6 +45,7 @@ async def to_code(config):
 
     cg.add(var.set_intensity(config[CONF_INTENSITY]))
     cg.add(var.set_inverted(config[CONF_INVERTED]))
+    cg.add(var.set_reversed(config[CONF_REVERSED]))
     cg.add(var.set_length(config[CONF_LENGTH]))
 
     if CONF_LAMBDA in config:

--- a/esphome/components/tm1637/tm1637.cpp
+++ b/esphome/components/tm1637/tm1637.cpp
@@ -212,20 +212,20 @@ void TM1637Display::display() {
   this->send_byte_(TM1637_CMD_ADDR);
 
   if (this->reversed_) {
-    uint8_t revbuf_[6] = {0};
+    uint8_t revbuf[6] = {0};
 
     // Reverse character order first half
     for (int8_t i = 2; i >= 0; i--) {
-      revbuf_[2 - i] = this->buffer_[i];
+      revbuf[2 - i] = this->buffer_[i];
     }
 
     // Reverse character order second half
     for (int8_t i = 2; i >= 0; i--) {
-      revbuf_[5 - i] = this->buffer_[3 + i];
+      revbuf[5 - i] = this->buffer_[3 + i];
     }
 
     // Writeback
-    memcpy(this->buffer_, revbuf_, 6);
+    memcpy(this->buffer_, revbuf, 6);
   }
 
   // Write the data bytes

--- a/esphome/components/tm1637/tm1637.cpp
+++ b/esphome/components/tm1637/tm1637.cpp
@@ -215,13 +215,13 @@ void TM1637Display::display() {
     uint8_t revbuf_[6] = {0};
 
     // Reverse character order first half
-    for (int8_t i = 2; i >= 0;  i--) {
-    revbuf_[2-i] = this->buffer_[i];
+    for (int8_t i = 2; i >= 0; i--) {
+      revbuf_[2 - i] = this->buffer_[i];
     }
 
     // Reverse character order second half
-    for (int8_t i = 2; i >= 0;  i--) {
-      revbuf_[5-i] = this->buffer_[3+i];
+    for (int8_t i = 2; i >= 0; i--) {
+      revbuf_[5 - i] = this->buffer_[3 + i];
     }
 
     // Writeback

--- a/esphome/components/tm1637/tm1637.cpp
+++ b/esphome/components/tm1637/tm1637.cpp
@@ -138,6 +138,7 @@ void TM1637Display::dump_config() {
   ESP_LOGCONFIG(TAG, "TM1637:");
   ESP_LOGCONFIG(TAG, "  Intensity: %d", this->intensity_);
   ESP_LOGCONFIG(TAG, "  Inverted: %d", this->inverted_);
+  ESP_LOGCONFIG(TAG, "  Reversed: %d", this->reversed_);
   ESP_LOGCONFIG(TAG, "  Length: %d", this->length_);
   LOG_PIN("  CLK Pin: ", this->clk_pin_);
   LOG_PIN("  DIO Pin: ", this->dio_pin_);
@@ -209,6 +210,23 @@ void TM1637Display::display() {
   // Write ADDR CMD + first digit address
   this->start_();
   this->send_byte_(TM1637_CMD_ADDR);
+
+  if (this->reversed_) {
+    uint8_t revbuf_[6] = {0};
+
+    // Reverse character order first half
+    for (int8_t i = 2; i >= 0;  i--) {
+    revbuf_[2-i] = this->buffer_[i];
+    }
+
+    // Reverse character order second half
+    for (int8_t i = 2; i >= 0;  i--) {
+      revbuf_[5-i] = this->buffer_[3+i];
+    }
+
+    // Writeback
+    memcpy(this->buffer_, revbuf_, 6);
+  }
 
   // Write the data bytes
   if (this->inverted_) {

--- a/esphome/components/tm1637/tm1637.h
+++ b/esphome/components/tm1637/tm1637.h
@@ -48,6 +48,7 @@ class TM1637Display : public PollingComponent {
 
   void set_intensity(uint8_t intensity) { this->intensity_ = intensity; }
   void set_inverted(bool inverted) { this->inverted_ = inverted; }
+  void set_reversed(bool reversed) { this->reversed_ = reversed; }
   void set_length(uint8_t length) { this->length_ = length; }
 
   void display();
@@ -76,6 +77,7 @@ class TM1637Display : public PollingComponent {
   uint8_t intensity_;
   uint8_t length_;
   bool inverted_;
+  bool reversed_;
   optional<tm1637_writer_t> writer_{};
   uint8_t buffer_[6] = {0};
 #ifdef USE_BINARY_SENSOR


### PR DESCRIPTION
# What does this implement/fix?

This PR adds a feature to optionally reverse the character order.
This is helpful when driving TM1637 modules that have the segment-blocks reversed and display "210543" when "012345" is defined.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/4375

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
display:
    platform: tm1637
    id: tm1637_display
    clk_pin: 16
    dio_pin: 15
    reversed: True
    lambda: |-
      it.print("012345");

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
