### PR TITLE
RP2040: Add support in `async_tcp`, `web_server` and `mqtt` components.

### DIFF
--- a/esphome/components/async_tcp/__init__.py
+++ b/esphome/components/async_tcp/__init__.py
@@ -7,6 +7,7 @@ from esphome.const import (
     PLATFORM_ESP8266,
     PLATFORM_BK72XX,
     PLATFORM_RTL87XX,
+    PLATFORM_RP2040,
 )
 
 CODEOWNERS = ["@OttoWinter"]
@@ -14,7 +15,15 @@ CODEOWNERS = ["@OttoWinter"]
 CONFIG_SCHEMA = cv.All(
     cv.Schema({}),
     cv.only_with_arduino,
-    cv.only_on([PLATFORM_ESP32, PLATFORM_ESP8266, PLATFORM_BK72XX, PLATFORM_RTL87XX]),
+    cv.only_on(
+        [
+            PLATFORM_ESP32,
+            PLATFORM_ESP8266,
+            PLATFORM_BK72XX,
+            PLATFORM_RTL87XX,
+            PLATFORM_RP2040,
+        ]
+    ),
 )
 
 
@@ -26,3 +35,10 @@ async def to_code(config):
     elif CORE.is_esp8266:
         # https://github.com/esphome/ESPAsyncTCP
         cg.add_library("esphome/ESPAsyncTCP-esphome", "2.0.0")
+    elif CORE.is_rp2040:
+        # https://github.com/khoih-prog/AsyncTCP_RP2040W.git
+        cg.add_library(
+            None,
+            None,
+            "https://github.com/khoih-prog/AsyncTCP_RP2040W.git",
+        )

--- a/esphome/components/mqtt/__init__.py
+++ b/esphome/components/mqtt/__init__.py
@@ -46,6 +46,7 @@ from esphome.const import (
     PLATFORM_ESP32,
     PLATFORM_ESP8266,
     PLATFORM_BK72XX,
+    PLATFORM_RP2040,
 )
 from esphome.core import coroutine_with_priority, CORE
 from esphome.components.esp32 import add_idf_sdkconfig_option
@@ -268,7 +269,14 @@ CONFIG_SCHEMA = cv.All(
         }
     ),
     validate_config,
-    cv.only_on([PLATFORM_ESP32, PLATFORM_ESP8266, PLATFORM_BK72XX]),
+    cv.only_on(
+        [
+            PLATFORM_ESP32,
+            PLATFORM_ESP8266,
+            PLATFORM_BK72XX,
+            PLATFORM_RP2040,
+        ]
+    ),
 )
 
 
@@ -290,7 +298,7 @@ async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
     # Add required libraries for ESP8266 and LibreTiny
-    if CORE.is_esp8266 or CORE.is_libretiny:
+    if CORE.is_esp8266 or CORE.is_libretiny or CORE.is_rp2040:
         # https://github.com/heman/async-mqtt-client/blob/master/library.json
         cg.add_library("heman/AsyncMqttClient-esphome", "2.0.0")
 

--- a/esphome/components/mqtt/mqtt_backend_rp2040.h
+++ b/esphome/components/mqtt/mqtt_backend_rp2040.h
@@ -1,0 +1,72 @@
+#pragma once
+
+#ifdef USE_RP2040
+
+#include "mqtt_backend.h"
+#include <AsyncMqttClient.h>
+
+namespace esphome {
+namespace mqtt {
+
+class MQTTBackendRP2040 final : public MQTTBackend {
+ public:
+  void set_keep_alive(uint16_t keep_alive) final { mqtt_client_.setKeepAlive(keep_alive); }
+  void set_client_id(const char *client_id) final { mqtt_client_.setClientId(client_id); }
+  void set_clean_session(bool clean_session) final { mqtt_client_.setCleanSession(clean_session); }
+  void set_credentials(const char *username, const char *password) final {
+    mqtt_client_.setCredentials(username, password);
+  }
+  void set_will(const char *topic, uint8_t qos, bool retain, const char *payload) final {
+    mqtt_client_.setWill(topic, qos, retain, payload);
+  }
+  void set_server(network::IPAddress ip, uint16_t port) final { mqtt_client_.setServer(IPAddress(ip), port); }
+  void set_server(const char *host, uint16_t port) final { mqtt_client_.setServer(host, port); }
+#if ASYNC_TCP_SSL_ENABLED
+  void set_secure(bool secure) { mqtt_client.setSecure(secure); }
+  void add_server_fingerprint(const uint8_t *fingerprint) { mqtt_client.addServerFingerprint(fingerprint); }
+#endif
+
+  void set_on_connect(std::function<on_connect_callback_t> &&callback) final {
+    this->mqtt_client_.onConnect(std::move(callback));
+  }
+  void set_on_disconnect(std::function<on_disconnect_callback_t> &&callback) final {
+    auto async_callback = [callback](AsyncMqttClientDisconnectReason reason) {
+      // int based enum so casting isn't a problem
+      callback(static_cast<MQTTClientDisconnectReason>(reason));
+    };
+    this->mqtt_client_.onDisconnect(std::move(async_callback));
+  }
+  void set_on_subscribe(std::function<on_subscribe_callback_t> &&callback) final {
+    this->mqtt_client_.onSubscribe(std::move(callback));
+  }
+  void set_on_unsubscribe(std::function<on_unsubscribe_callback_t> &&callback) final {
+    this->mqtt_client_.onUnsubscribe(std::move(callback));
+  }
+  void set_on_message(std::function<on_message_callback_t> &&callback) final {
+    auto async_callback = [callback](const char *topic, const char *payload,
+                                     AsyncMqttClientMessageProperties async_properties, size_t len, size_t index,
+                                     size_t total) { callback(topic, payload, len, index, total); };
+    mqtt_client_.onMessage(std::move(async_callback));
+  }
+  void set_on_publish(std::function<on_publish_user_callback_t> &&callback) final {
+    this->mqtt_client_.onPublish(std::move(callback));
+  }
+
+  bool connected() const final { return mqtt_client_.connected(); }
+  void connect() final { mqtt_client_.connect(); }
+  void disconnect() final { mqtt_client_.disconnect(true); }
+  bool subscribe(const char *topic, uint8_t qos) final { return mqtt_client_.subscribe(topic, qos) != 0; }
+  bool unsubscribe(const char *topic) final { return mqtt_client_.unsubscribe(topic) != 0; }
+  bool publish(const char *topic, const char *payload, size_t length, uint8_t qos, bool retain) final {
+    return mqtt_client_.publish(topic, qos, retain, payload, length, false, 0) != 0;
+  }
+  using MQTTBackend::publish;
+
+ protected:
+  AsyncMqttClient mqtt_client_;
+};
+
+}  // namespace mqtt
+}  // namespace esphome
+
+#endif  // defined(USE_RP2040)

--- a/esphome/components/mqtt/mqtt_client.cpp
+++ b/esphome/components/mqtt/mqtt_client.cpp
@@ -109,6 +109,9 @@ void MQTTClientComponent::send_device_info_() {
 #ifdef USE_LIBRETINY
         root["platform"] = lt_cpu_get_model_name();
 #endif
+#ifdef USE_RP2040
+        root["platform"] = "RP2040";
+#endif
 
         root["board"] = ESPHOME_BOARD;
 #if defined(USE_WIFI)
@@ -164,6 +167,10 @@ void MQTTClientComponent::start_dnslookup_() {
                                          MQTTClientComponent::dns_found_callback, this, LWIP_DNS_ADDRTYPE_IPV4);
 #endif
 #ifdef USE_ESP8266
+  err_t err = dns_gethostbyname(this->credentials_.address.c_str(), &addr,
+                                esphome::mqtt::MQTTClientComponent::dns_found_callback, this);
+#endif
+#ifdef USE_RP2040
   err_t err = dns_gethostbyname(this->credentials_.address.c_str(), &addr,
                                 esphome::mqtt::MQTTClientComponent::dns_found_callback, this);
 #endif

--- a/esphome/components/mqtt/mqtt_client.h
+++ b/esphome/components/mqtt/mqtt_client.h
@@ -15,6 +15,8 @@
 #include "mqtt_backend_esp8266.h"
 #elif defined(USE_LIBRETINY)
 #include "mqtt_backend_libretiny.h"
+#elif defined(USE_RP2040)
+#include "mqtt_backend_rp2040.h"
 #endif
 #include "lwip/ip_addr.h"
 
@@ -304,6 +306,8 @@ class MQTTClientComponent : public Component {
   MQTTBackendESP8266 mqtt_backend_;
 #elif defined(USE_LIBRETINY)
   MQTTBackendLibreTiny mqtt_backend_;
+#elif defined(USE_RP2040)
+  MQTTBackendRP2040 mqtt_backend_;
 #endif
 
   MQTTClientState state_{MQTT_CLIENT_DISCONNECTED};

--- a/esphome/components/web_server/__init__.py
+++ b/esphome/components/web_server/__init__.py
@@ -23,6 +23,7 @@ from esphome.const import (
     PLATFORM_ESP8266,
     PLATFORM_BK72XX,
     PLATFORM_RTL87XX,
+    PLATFORM_RP2040,
 )
 from esphome.core import CORE, coroutine_with_priority
 
@@ -91,12 +92,21 @@ CONFIG_SCHEMA = cv.All(
                 esp32_idf=False,
                 bk72xx=True,
                 rtl87xx=True,
+                rp2040=True,
             ): cv.boolean,
             cv.Optional(CONF_LOG, default=True): cv.boolean,
             cv.Optional(CONF_LOCAL): cv.boolean,
         }
     ).extend(cv.COMPONENT_SCHEMA),
-    cv.only_on([PLATFORM_ESP32, PLATFORM_ESP8266, PLATFORM_BK72XX, PLATFORM_RTL87XX]),
+    cv.only_on(
+        [
+            PLATFORM_ESP32,
+            PLATFORM_ESP8266,
+            PLATFORM_BK72XX,
+            PLATFORM_RTL87XX,
+            PLATFORM_RP2040,
+        ]
+    ),
     default_url,
     validate_local,
     validate_ota,

--- a/esphome/components/web_server_base/__init__.py
+++ b/esphome/components/web_server_base/__init__.py
@@ -36,5 +36,6 @@ async def to_code(config):
             cg.add_library("WiFi", None)
             cg.add_library("FS", None)
             cg.add_library("Update", None)
-        # https://github.com/esphome/ESPAsyncWebServer/blob/master/library.json
-        cg.add_library("esphome/ESPAsyncWebServer-esphome", "3.1.0")
+        # Fork of https://github.com/esphome/ESPAsyncWebServer/blob/master/library.json
+        # that includes https://github.com/esphome/ESPAsyncWebServer/pull/22
+        cg.add_library(None, None, "https://github.com/skilau/ESPAsyncWebServer.git")

--- a/platformio.ini
+++ b/platformio.ini
@@ -57,7 +57,7 @@ lib_deps =
     ${common.lib_deps}
     SPI                                                   ; spi (Arduino built-in)
     Wire                                                  ; i2c (Arduino built-int)
-    heman/AsyncMqttClient-esphome@1.0.0                   ; mqtt
+    heman/AsyncMqttClient-esphome@1.1.0                   ; mqtt
     https://github.com/skilau/ESPAsyncWebServer.git       ; web_server_base
     fastled/FastLED@3.3.2                                 ; fastled_base
     mikalhart/TinyGPSPlus@1.0.2                           ; gps

--- a/platformio.ini
+++ b/platformio.ini
@@ -164,6 +164,7 @@ platform_packages =
 framework = arduino
 lib_deps =
     ${common:arduino.lib_deps}
+    https://github.com/khoih-prog/AsyncTCP_RP2040W.git ; async_tcp
 build_flags =
     ${common:arduino.build_flags}
     -DUSE_RP2040

--- a/platformio.ini
+++ b/platformio.ini
@@ -58,7 +58,7 @@ lib_deps =
     SPI                                                   ; spi (Arduino built-in)
     Wire                                                  ; i2c (Arduino built-int)
     heman/AsyncMqttClient-esphome@1.0.0                   ; mqtt
-    esphome/ESPAsyncWebServer-esphome@2.1.0               ; web_server_base
+    https://github.com/skilau/ESPAsyncWebServer.git       ; web_server_base
     fastled/FastLED@3.3.2                                 ; fastled_base
     mikalhart/TinyGPSPlus@1.0.2                           ; gps
     freekode/TM1651@1.0.1                                 ; tm1651


### PR DESCRIPTION
# What does this implement/fix?

This is a rebased and slightly modified version of https://github.com/esphome/esphome/pull/5305 by @skilau

It adds support for RP2040 in the `async_tcp`, `web_server` and `mqtt` components.

Ideally, https://github.com/esphome/ESPAsyncWebServer/pull/22 is merged first.


## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):**
- fixes https://github.com/esphome/issues/issues/4055
- closes https://github.com/esphome/feature-requests/issues/1966

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [x] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
