### PR TITLE
Copy display transform to touchscreen

### DIFF
--- a/esphome/components/display/display.h
+++ b/esphome/components/display/display.h
@@ -176,9 +176,13 @@ class Display : public PollingComponent {
   void clear();
 
   /// Get the width of the image in pixels with rotation applied.
-  virtual int get_width() = 0;
+  virtual int get_width() { return this->get_width_internal(); }
+
   /// Get the height of the image in pixels with rotation applied.
-  virtual int get_height() = 0;
+  virtual int get_height() { return this->get_height_internal(); }
+
+  virtual int get_height_internal() = 0;
+  virtual int get_width_internal() = 0;
 
   /// Set a single pixel at the specified coordinates to default color.
   inline void draw_pixel_at(int x, int y) { this->draw_pixel_at(x, y, COLOR_ON); }
@@ -230,7 +234,8 @@ class Display : public PollingComponent {
   /// Fill a rectangle with the top left point at [x1,y1] and the bottom right point at [x1+width,y1+height].
   void filled_rectangle(int x1, int y1, int width, int height, Color color = COLOR_ON);
 
-  /// Draw the outline of a circle centered around [center_x,center_y] with the radius radius with the given color.
+  /// Draw the outline of a circle centered around [center_x,center_y] with the radius radius with the given
+  /// color.
   void circle(int center_x, int center_xy, int radius, Color color = COLOR_ON);
 
   /// Fill a circle centered around [center_x,center_y] with the radius radius with the given color.
@@ -539,7 +544,7 @@ class Display : public PollingComponent {
   std::vector<DisplayOnPageChangeTrigger *> on_page_change_triggers_;
   bool auto_clear_enabled_{true};
   std::vector<Rect> clipping_rectangle_;
-};
+    };
 
 class DisplayPage {
  public:
@@ -613,5 +618,5 @@ class DisplayOnPageChangeTrigger : public Trigger<DisplayPage *, DisplayPage *> 
   DisplayPage *to_{nullptr};
 };
 
-}  // namespace display
+  }  // namespace display
 }  // namespace esphome

--- a/esphome/components/display/display.h
+++ b/esphome/components/display/display.h
@@ -544,7 +544,7 @@ class Display : public PollingComponent {
   std::vector<DisplayOnPageChangeTrigger *> on_page_change_triggers_;
   bool auto_clear_enabled_{true};
   std::vector<Rect> clipping_rectangle_;
-    };
+};
 
 class DisplayPage {
  public:
@@ -618,5 +618,5 @@ class DisplayOnPageChangeTrigger : public Trigger<DisplayPage *, DisplayPage *> 
   DisplayPage *to_{nullptr};
 };
 
-  }  // namespace display
+}  // namespace display
 }  // namespace esphome

--- a/esphome/components/display/display_buffer.h
+++ b/esphome/components/display/display_buffer.h
@@ -22,7 +22,6 @@ class DisplayBuffer : public Display {
   /// Set a single pixel at the specified coordinates to the given color.
   void draw_pixel_at(int x, int y, Color color) override;
 
-
  protected:
   virtual void draw_absolute_pixel_internal(int x, int y, Color color) = 0;
 

--- a/esphome/components/display/display_buffer.h
+++ b/esphome/components/display/display_buffer.h
@@ -22,8 +22,6 @@ class DisplayBuffer : public Display {
   /// Set a single pixel at the specified coordinates to the given color.
   void draw_pixel_at(int x, int y, Color color) override;
 
-  virtual int get_height_internal() = 0;
-  virtual int get_width_internal() = 0;
 
  protected:
   virtual void draw_absolute_pixel_internal(int x, int y, Color color) = 0;

--- a/esphome/components/ektf2232/touchscreen/ektf2232.cpp
+++ b/esphome/components/ektf2232/touchscreen/ektf2232.cpp
@@ -55,9 +55,8 @@ void EKTF2232Touchscreen::setup() {
     }
     this->y_raw_max_ = ((received[2])) | ((received[3] & 0xf0) << 4);
   }
-  
   this->set_power_state(true);
-  }
+}
 
 void EKTF2232Touchscreen::update_touches() {
   uint8_t touch_count = 0;

--- a/esphome/components/ektf2232/touchscreen/ektf2232.cpp
+++ b/esphome/components/ektf2232/touchscreen/ektf2232.cpp
@@ -34,26 +34,30 @@ void EKTF2232Touchscreen::setup() {
 
   // Get touch resolution
   uint8_t received[4];
-  this->write(GET_X_RES, 4);
-  if (this->read(received, 4)) {
-    ESP_LOGE(TAG, "Failed to read X resolution!");
-    this->interrupt_pin_->detach_interrupt();
-    this->mark_failed();
-    return;
+  if (this->x_raw_max_ == this->x_raw_min_) {
+    this->write(GET_X_RES, 4);
+    if (this->read(received, 4)) {
+      ESP_LOGE(TAG, "Failed to read X resolution!");
+      this->interrupt_pin_->detach_interrupt();
+      this->mark_failed();
+      return;
+    }
+    this->x_raw_max_ = ((received[2])) | ((received[3] & 0xf0) << 4);
   }
-  this->x_raw_max_ = ((received[2])) | ((received[3] & 0xf0) << 4);
 
-  this->write(GET_Y_RES, 4);
-  if (this->read(received, 4)) {
-    ESP_LOGE(TAG, "Failed to read Y resolution!");
-    this->interrupt_pin_->detach_interrupt();
-    this->mark_failed();
-    return;
+  if (this->y_raw_max_ == this->y_raw_min_) {
+    this->write(GET_Y_RES, 4);
+    if (this->read(received, 4)) {
+      ESP_LOGE(TAG, "Failed to read Y resolution!");
+      this->interrupt_pin_->detach_interrupt();
+      this->mark_failed();
+      return;
+    }
+    this->y_raw_max_ = ((received[2])) | ((received[3] & 0xf0) << 4);
   }
-  this->y_raw_max_ = ((received[2])) | ((received[3] & 0xf0) << 4);
-
+  
   this->set_power_state(true);
-}
+  }
 
 void EKTF2232Touchscreen::update_touches() {
   uint8_t touch_count = 0;

--- a/esphome/components/ft5x06/touchscreen/ft5x06_touchscreen.h
+++ b/esphome/components/ft5x06/touchscreen/ft5x06_touchscreen.h
@@ -66,8 +66,14 @@ class FT5x06Touchscreen : public touchscreen::Touchscreen, public i2c::I2CDevice
         return;
     }
     // reading the chip registers to get max x/y does not seem to work.
-    this->x_raw_max_ = this->display_->get_width();
-    this->y_raw_max_ = this->display_->get_height();
+    if (this->display_ != nullptr) {
+      if (this->x_raw_max_ == this->x_raw_min_) {
+        this->x_raw_max_ = this->display_->get_width_internal();
+      }
+      if (this->y_raw_max_ == this->y_raw_min_) {
+        this->y_raw_max_ = this->display_->get_height_internal();
+      }
+    }
     esph_log_config(TAG, "FT5x06 Touchscreen setup complete");
   }
 

--- a/esphome/components/ft63x6/ft63x6.cpp
+++ b/esphome/components/ft63x6/ft63x6.cpp
@@ -40,8 +40,12 @@ void FT63X6Touchscreen::setup() {
   this->hard_reset_();
 
   // Get touch resolution
-  this->x_raw_max_ = 320;
-  this->y_raw_max_ = 480;
+  if (this->x_raw_max_ == this->x_raw_min_) {
+    this->x_raw_max_ = 320;
+  }
+  if (this->y_raw_max_ == this->y_raw_min_) {
+    this->y_raw_max_ = 480;
+  }
 }
 
 void FT63X6Touchscreen::update_touches() {

--- a/esphome/components/gt911/touchscreen/gt911_touchscreen.cpp
+++ b/esphome/components/gt911/touchscreen/gt911_touchscreen.cpp
@@ -48,9 +48,13 @@ void GT911Touchscreen::setup() {
     if (err == i2c::ERROR_OK) {
       err = this->read(data, sizeof(data));
       if (err == i2c::ERROR_OK) {
-        this->x_raw_max_ = encode_uint16(data[1], data[0]);
-        this->y_raw_max_ = encode_uint16(data[3], data[2]);
-        esph_log_d(TAG, "Read max_x/max_y %d/%d", this->x_raw_max_, this->y_raw_max_);
+        if (this->x_raw_max_ == this->x_raw_min_) {
+          this->x_raw_max_ = encode_uint16(data[1], data[0]);
+        }
+        if (this->y_raw_max_ == this->y_raw_min_) {
+          this->y_raw_max_ = encode_uint16(data[3], data[2]);
+        }
+        esph_log_d(TAG, "calibration max_x/max_y %d/%d", this->x_raw_max_, this->y_raw_max_);
       }
     }
   }

--- a/esphome/components/lilygo_t5_47/touchscreen/lilygo_t5_47_touchscreen.cpp
+++ b/esphome/components/lilygo_t5_47/touchscreen/lilygo_t5_47_touchscreen.cpp
@@ -38,9 +38,14 @@ void LilygoT547Touchscreen::setup() {
   }
 
   this->write_register(POWER_REGISTER, WAKEUP_CMD, 1);
-
-  this->x_raw_max_ = this->get_width_();
-  this->y_raw_max_ = this->get_height_();
+  if (this->display_ != nullptr) {
+    if (this->x_raw_max_ == this->x_raw_min_) {
+      this->x_raw_max_ = this->display_->get_width_internal();
+    }
+    if (this->y_raw_max_ == this->y_raw_min_) {
+      this->y_raw_max_ = this->display_->get_height_internal();
+    }
+  }
 }
 
 void LilygoT547Touchscreen::update_touches() {

--- a/esphome/components/media_player/media_player.h
+++ b/esphome/components/media_player/media_player.h
@@ -3,6 +3,10 @@
 #include "esphome/core/entity_base.h"
 #include "esphome/core/helpers.h"
 
+#ifdef USE_SPEAKER
+#include "esphome/components/speaker/speaker.h"
+#endif
+
 namespace esphome {
 namespace media_player {
 
@@ -70,6 +74,9 @@ class MediaPlayer : public EntityBase {
  public:
   MediaPlayerState state{MEDIA_PLAYER_STATE_NONE};
   float volume{1.0f};
+#ifdef USE_SPEAKER
+  void set_speaker(speaker::Speaker *speaker) { this->speaker_ = speaker; }
+#endif
 
   MediaPlayerCall make_call() { return MediaPlayerCall(this); }
 
@@ -87,6 +94,9 @@ class MediaPlayer : public EntityBase {
   virtual void control(const MediaPlayerCall &call) = 0;
 
   CallbackManager<void()> state_callback_{};
+#ifdef USE_SPEAKER
+  speaker::Speaker *speaker_;
+#endif
 };
 
 }  // namespace media_player

--- a/esphome/components/touchscreen/__init__.py
+++ b/esphome/components/touchscreen/__init__.py
@@ -4,6 +4,7 @@ import esphome.codegen as cg
 from esphome.components import display
 from esphome import automation
 from esphome.const import (
+    CONF_CALIBRATION,
     CONF_ON_TOUCH,
     CONF_ON_RELEASE,
     CONF_MIRROR_X,
@@ -33,7 +34,6 @@ CONF_REPORT_INTERVAL = "report_interval"  # not used yet:
 CONF_ON_UPDATE = "on_update"
 CONF_TOUCH_TIMEOUT = "touch_timeout"
 
-CONF_CALIBRATION = "calibration"
 CONF_X_MIN = "x_min"
 CONF_X_MAX = "x_max"
 CONF_Y_MIN = "y_min"

--- a/esphome/components/touchscreen/touchscreen.cpp
+++ b/esphome/components/touchscreen/touchscreen.cpp
@@ -69,17 +69,18 @@ void Touchscreen::add_raw_touch_position_(uint8_t id, int16_t x_raw, int16_t y_r
   tp.x_raw = x_raw;
   tp.y_raw = y_raw;
   tp.z_raw = z_raw;
+  if (this->x_raw_max_ != this->x_raw_min_ and
+      this->y_raw_max_ != this->y_raw_min_) {
+    x = this->normalize_(x_raw, this->x_raw_min_, this->x_raw_max_, this->invert_x_);
+    y = this->normalize_(y_raw, this->y_raw_min_, this->y_raw_max_, this->invert_y_);
 
-  x = this->normalize_(x_raw, this->x_raw_min_, this->x_raw_max_, this->invert_x_);
-  y = this->normalize_(y_raw, this->y_raw_min_, this->y_raw_max_, this->invert_y_);
+    if (this->swap_x_y_) {
+      std::swap(x, y);
+    }
 
-  if (this->swap_x_y_) {
-    std::swap(x, y);
+    tp.x = (uint16_t) ((int) x * this->get_width_() / 0x1000);
+    tp.y = (uint16_t) ((int) y * this->get_height_() / 0x1000);
   }
-
-  tp.x = (uint16_t) ((int) x * this->get_width_() / 0x1000);
-  tp.y = (uint16_t) ((int) y * this->get_height_() / 0x1000);
-
   if (tp.state == STATE_PRESSED) {
     tp.x_org = tp.x;
     tp.y_org = tp.y;

--- a/esphome/components/touchscreen/touchscreen.cpp
+++ b/esphome/components/touchscreen/touchscreen.cpp
@@ -69,8 +69,7 @@ void Touchscreen::add_raw_touch_position_(uint8_t id, int16_t x_raw, int16_t y_r
   tp.x_raw = x_raw;
   tp.y_raw = y_raw;
   tp.z_raw = z_raw;
-  if (this->x_raw_max_ != this->x_raw_min_ and
-      this->y_raw_max_ != this->y_raw_min_) {
+  if (this->x_raw_max_ != this->x_raw_min_ and this->y_raw_max_ != this->y_raw_min_) {
     x = this->normalize_(x_raw, this->x_raw_min_, this->x_raw_max_, this->invert_x_);
     y = this->normalize_(y_raw, this->y_raw_min_, this->y_raw_max_, this->invert_y_);
 

--- a/esphome/components/tt21100/touchscreen/tt21100.cpp
+++ b/esphome/components/tt21100/touchscreen/tt21100.cpp
@@ -62,11 +62,14 @@ void TT21100Touchscreen::setup() {
   }
 
   // Update display dimensions if they were updated during display setup
-  this->x_raw_max_ = this->get_width_();
-  this->y_raw_max_ = this->get_height_();
-
-  // Trigger initial read to activate the interrupt
-  this->store_.touched = true;
+  if (this->display_ != nullptr) {
+    if (this->x_raw_max_ == this->x_raw_min_) {
+      this->x_raw_max_ = this->display_->get_width_internal();
+    }
+    if (this->y_raw_max_ == this->y_raw_min_) {
+      this->y_raw_max_ = this->display_->get_height_internal();
+    }
+  }
 }
 
 void TT21100Touchscreen::update_touches() {

--- a/esphome/components/xpt2046/touchscreen/__init__.py
+++ b/esphome/components/xpt2046/touchscreen/__init__.py
@@ -21,29 +21,6 @@ CONF_CALIBRATION_X_MAX = "calibration_x_max"
 CONF_CALIBRATION_Y_MIN = "calibration_y_min"
 CONF_CALIBRATION_Y_MAX = "calibration_y_max"
 
-
-def validate_calibration(config):
-    if (
-        abs(
-            cv.int_(config[CONF_CALIBRATION_X_MAX])
-            - cv.int_(config[CONF_CALIBRATION_X_MIN])
-        )
-        < 1000
-    ):
-        raise cv.Invalid("Calibration X values difference < 1000")
-
-    if (
-        abs(
-            cv.int_(config[CONF_CALIBRATION_Y_MAX])
-            - cv.int_(config[CONF_CALIBRATION_Y_MIN])
-        )
-        < 1000
-    ):
-        raise cv.Invalid("Calibration Y values difference < 1000")
-
-    return config
-
-
 CONFIG_SCHEMA = cv.All(
     touchscreen.TOUCHSCREEN_SCHEMA.extend(
         cv.Schema(
@@ -77,7 +54,6 @@ CONFIG_SCHEMA = cv.All(
             },
         )
     ).extend(spi.spi_device_schema()),
-    validate_calibration,
 )
 
 

--- a/esphome/components/xpt2046/touchscreen/__init__.py
+++ b/esphome/components/xpt2046/touchscreen/__init__.py
@@ -22,7 +22,7 @@ CONF_CALIBRATION_Y_MIN = "calibration_y_min"
 CONF_CALIBRATION_Y_MAX = "calibration_y_max"
 
 
-def validate_xpt2046(config):
+def validate_calibration(config):
     if (
         abs(
             cv.int_(config[CONF_CALIBRATION_X_MAX])
@@ -52,23 +52,32 @@ CONFIG_SCHEMA = cv.All(
                 cv.Optional(CONF_INTERRUPT_PIN): cv.All(
                     pins.internal_gpio_input_pin_schema
                 ),
-                cv.Optional(CONF_CALIBRATION_X_MIN, default=0): cv.int_range(
-                    min=0, max=4095
-                ),
-                cv.Optional(CONF_CALIBRATION_X_MAX, default=4095): cv.int_range(
-                    min=0, max=4095
-                ),
-                cv.Optional(CONF_CALIBRATION_Y_MIN, default=0): cv.int_range(
-                    min=0, max=4095
-                ),
-                cv.Optional(CONF_CALIBRATION_Y_MAX, default=4095): cv.int_range(
-                    min=0, max=4095
-                ),
                 cv.Optional(CONF_THRESHOLD, default=400): cv.int_range(min=0, max=4095),
+                cv.Optional(
+                    touchscreen.CONF_CALIBRATION
+                ): touchscreen.calibration_schema(4095),
+                cv.Optional(CONF_CALIBRATION_X_MIN): cv.invalid(
+                    "Deprecated: use the new Calibration variable"
+                ),
+                cv.Optional(CONF_CALIBRATION_X_MAX): cv.invalid(
+                    "Deprecated: use the new Calibration variable"
+                ),
+                cv.Optional(CONF_CALIBRATION_Y_MIN): cv.invalid(
+                    "Deprecated: use the new Calibration variable"
+                ),
+                cv.Optional(CONF_CALIBRATION_Y_MAX): cv.invalid(
+                    "Deprecated: use the new Calibration variable"
+                ),
+                cv.Optional(CONF_CALIBRATION_Y_MAX): cv.invalid(
+                    "Deprecated: use the new Calibration variable"
+                ),
+                cv.Optional("report_interval"): cv.invalid(
+                    "Deprecated: use the update_interval variable"
+                ),
             },
         )
     ).extend(spi.spi_device_schema()),
-    validate_xpt2046,
+    validate_calibration,
 )
 
 
@@ -78,15 +87,6 @@ async def to_code(config):
     await spi.register_spi_device(var, config)
 
     cg.add(var.set_threshold(config[CONF_THRESHOLD]))
-
-    cg.add(
-        var.set_calibration(
-            config[CONF_CALIBRATION_X_MIN],
-            config[CONF_CALIBRATION_X_MAX],
-            config[CONF_CALIBRATION_Y_MIN],
-            config[CONF_CALIBRATION_Y_MAX],
-        )
-    )
 
     if CONF_INTERRUPT_PIN in config:
         pin = await cg.gpio_pin_expression(config[CONF_INTERRUPT_PIN])

--- a/esphome/components/xpt2046/touchscreen/xpt2046.cpp
+++ b/esphome/components/xpt2046/touchscreen/xpt2046.cpp
@@ -77,8 +77,6 @@ void XPT2046Component::dump_config() {
   LOG_UPDATE_INTERVAL(this);
 }
 
-float XPT2046Component::get_setup_priority() const { return setup_priority::DATA; }
-
 int16_t XPT2046Component::best_two_avg(int16_t value1, int16_t value2, int16_t value3) {
   int16_t delta_a, delta_b, delta_c;
   int16_t reta = 0;

--- a/esphome/components/xpt2046/touchscreen/xpt2046.h
+++ b/esphome/components/xpt2046/touchscreen/xpt2046.h
@@ -23,7 +23,6 @@ class XPT2046Component : public Touchscreen,
 
   void setup() override;
   void dump_config() override;
-  float get_setup_priority() const override;
 
  protected:
   static int16_t best_two_avg(int16_t value1, int16_t value2, int16_t value3);

--- a/tests/test4.yaml
+++ b/tests/test4.yaml
@@ -929,10 +929,11 @@ touchscreen:
     display: inkplate_display
     update_interval: 50ms
     threshold: 400
-    calibration_x_min: 3860
-    calibration_x_max: 280
-    calibration_y_min: 340
-    calibration_y_max: 3860
+    calibration:
+      x_min: 3860
+      x_max: 280
+      y_min: 340
+      y_max: 3860
     on_touch:
       - logger.log:
           format: Touch at (%d, %d)


### PR DESCRIPTION
# What does this implement/fix?
    If the display has 'rotation' or 'transform' options, and the touchscreen
    does not, create a 'transform' configuration for the touchscreen matching
    the display's one.

    This avoids duplicating the transformations when the display and the
    touchscreen have the same (rotated) orientation, but can be easily overridden
    for cases where the orientations differ.



## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** Might fix https://github.com/esphome/issues/issues/5265

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#TBD

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
display:
  - id: disp
    platform: ili9xxx
    transform:
       swap_xy: true

touchscreen:
  - id: my_touch
    display: disp
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
