### PR TITLE
dashboard: Only ping when polling is active

### DIFF
--- a/esphome/dashboard/status/ping.py
+++ b/esphome/dashboard/status/ping.py
@@ -31,6 +31,7 @@ class PingStatus:
         while not dashboard.stop_event.is_set():
             # Only ping if the dashboard is open
             await dashboard.ping_request.wait()
+            dashboard.ping_request.clear()
             current_entries = dashboard.entries.async_all()
             to_ping: list[DashboardEntry] = [
                 entry for entry in current_entries if entry.address is not None


### PR DESCRIPTION
# What does this implement/fix?

The event was never cleared in the ping path, only the mdns path, so when the dashboard was left, pings would keep happening in the background.

Side note: our ping implementation spawns a subprocess for compatibility. Its incredibly inefficient (see cpu drain in https://github.com/esphome/issues/issues/5257). We could use https://pypi.org/project/icmplib/ like we do in HA core but that would add another dep. If we think its important, we can move https://github.com/esphome/esphome/pull/6002 forward

fixes https://github.com/esphome/issues/issues/5257


## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
