### PR TITLE
dashboard: refactor ping implementation to be more efficient

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -34,7 +34,7 @@ RUN \
         python3-wheel=0.38.4-2 \
         iputils-ping=3:20221126-1 \
         git=1:2.39.2-1.1 \
-        curl=7.88.1-10+deb12u4 \
+        curl=7.88.1-10+deb12u5 \
         openssh-client=1:9.2p1-2+deb12u1 \
         python3-cffi=1.15.1-5 \
         libcairo2=1.16.0-7 \

--- a/esphome/dashboard/const.py
+++ b/esphome/dashboard/const.py
@@ -4,5 +4,7 @@ EVENT_ENTRY_ADDED = "entry_added"
 EVENT_ENTRY_REMOVED = "entry_removed"
 EVENT_ENTRY_UPDATED = "entry_updated"
 EVENT_ENTRY_STATE_CHANGED = "entry_state_changed"
+MAX_EXECUTOR_WORKERS = 48
+
 
 SENTINEL = object()

--- a/esphome/dashboard/core.py
+++ b/esphome/dashboard/core.py
@@ -70,6 +70,7 @@ class ESPHomeDashboard:
         "mqtt_ping_request",
         "mdns_status",
         "settings",
+        "dns_cache",
     )
 
     def __init__(self) -> None:

--- a/esphome/dashboard/core.py
+++ b/esphome/dashboard/core.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Any, Callable
 from ..zeroconf import DiscoveredImport
 from .entries import DashboardEntries
 from .settings import DashboardSettings
+from .dns import DNSCache
 
 if TYPE_CHECKING:
     from .status.mdns import MDNSStatus
@@ -81,7 +82,8 @@ class ESPHomeDashboard:
         self.ping_request: asyncio.Event | None = None
         self.mqtt_ping_request = threading.Event()
         self.mdns_status: MDNSStatus | None = None
-        self.settings: DashboardSettings = DashboardSettings()
+        self.settings = DashboardSettings()
+        self.dns_cache = DNSCache()
 
     async def async_setup(self) -> None:
         """Setup the dashboard."""

--- a/esphome/dashboard/core.py
+++ b/esphome/dashboard/core.py
@@ -8,9 +8,9 @@ from functools import partial
 from typing import TYPE_CHECKING, Any, Callable
 
 from ..zeroconf import DiscoveredImport
+from .dns import DNSCache
 from .entries import DashboardEntries
 from .settings import DashboardSettings
-from .dns import DNSCache
 
 if TYPE_CHECKING:
     from .status.mdns import MDNSStatus

--- a/esphome/dashboard/dashboard.py
+++ b/esphome/dashboard/dashboard.py
@@ -13,8 +13,8 @@ from typing import Any
 
 from esphome.storage_json import EsphomeStorageJSON, esphome_storage_path
 
-from .core import DASHBOARD
 from .const import MAX_EXECUTOR_WORKERS
+from .core import DASHBOARD
 from .web_server import make_app, start_web_server
 
 ENV_DEV = "ESPHOME_DASHBOARD_DEV"

--- a/esphome/dashboard/dashboard.py
+++ b/esphome/dashboard/dashboard.py
@@ -14,13 +14,12 @@ from typing import Any
 from esphome.storage_json import EsphomeStorageJSON, esphome_storage_path
 
 from .core import DASHBOARD
+from .const import MAX_EXECUTOR_WORKERS
 from .web_server import make_app, start_web_server
 
 ENV_DEV = "ESPHOME_DASHBOARD_DEV"
 
 settings = DASHBOARD.settings
-
-MAX_EXECUTOR_WORKERS = 48
 
 
 def can_use_pidfd() -> bool:

--- a/esphome/dashboard/dashboard.py
+++ b/esphome/dashboard/dashboard.py
@@ -94,7 +94,7 @@ def start_dashboard(args) -> None:
             storage.save(path)
         settings.cookie_secret = storage.cookie_secret
 
-    asyncio.set_event_loop_policy(DashboardEventLoopPolicy(settings.debug))
+    asyncio.set_event_loop_policy(DashboardEventLoopPolicy(settings.verbose))
 
     try:
         asyncio.run(async_start(args))

--- a/esphome/dashboard/dns.py
+++ b/esphome/dashboard/dns.py
@@ -6,15 +6,15 @@ import sys
 from icmplib import NameLookupError, async_resolve
 
 if sys.version_info >= (3, 11):
-    import asyncio as async_timeout
+    from asyncio import timeout as async_timeout
 else:
-    import async_timeout
+    from async_timeout import timeout as async_timeout
 
 
 async def _async_resolve_wrapper(hostname: str) -> list[str] | Exception:
     """Wrap the icmplib async_resolve function."""
     try:
-        async with async_timeout.timeout(2):
+        async with async_timeout(2):
             return await async_resolve(hostname)
     except (asyncio.TimeoutError, NameLookupError, UnicodeError) as ex:
         return ex

--- a/esphome/dashboard/dns.py
+++ b/esphome/dashboard/dns.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import asyncio
 import sys
-import time
 
 from icmplib import NameLookupError, async_resolve
 
@@ -29,14 +28,16 @@ class DNSCache:
         self._cache: dict[str, tuple[float, list[str] | Exception]] = {}
         self._ttl = ttl
 
-    async def async_resolve(self, hostname: str) -> list[str] | Exception:
+    async def async_resolve(
+        self, hostname: str, now_monotonic: float
+    ) -> list[str] | Exception:
         """Resolve a hostname to a list of IP address."""
         if expire_time_addresses := self._cache.get(hostname):
             expire_time, addresses = expire_time_addresses
-            if expire_time > time.monotonic():
+            if expire_time > now_monotonic:
                 return addresses
 
-        expires = time.monotonic() + self._ttl
+        expires = now_monotonic + self._ttl
         addresses = await _async_resolve_wrapper(hostname)
         self._cache[hostname] = (expires, addresses)
         return addresses

--- a/esphome/dashboard/dns.py
+++ b/esphome/dashboard/dns.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import time
+
+from icmplib import NameLookupError, async_resolve
+
+
+class DNSCache:
+    """DNS cache for the dashboard."""
+
+    def __init__(self, ttl: int | None = 120) -> None:
+        """Initialize the DNSCache."""
+        self._cache: dict[str, tuple[float, list[str] | None]] = {}
+        self._ttl = ttl
+
+    async def async_resolve(self, hostname: str) -> list[str] | None:
+        """Resolve a hostname to a list of IP address."""
+        if expire_time_addresses := self._cache.get(hostname):
+            expire_time, addresses = expire_time_addresses
+            if expire_time > time.monotonic():
+                return addresses
+
+        expires = time.monotonic() + self._ttl
+        try:
+            addresses = await async_resolve(hostname)
+        except NameLookupError:
+            self._cache[hostname] = (expires, None)
+            return None
+
+        self._cache[hostname] = (expires, addresses)
+        return addresses

--- a/esphome/dashboard/settings.py
+++ b/esphome/dashboard/settings.py
@@ -14,6 +14,17 @@ from .util.password import password_hash
 class DashboardSettings:
     """Settings for the dashboard."""
 
+    __slots__ = (
+        "config_dir",
+        "password_hash",
+        "username",
+        "using_password",
+        "on_ha_addon",
+        "cookie_secret",
+        "absolute_config_dir",
+        "verbose",
+    )
+
     def __init__(self) -> None:
         """Initialize the dashboard settings."""
         self.config_dir: str = ""
@@ -23,6 +34,7 @@ class DashboardSettings:
         self.on_ha_addon: bool = False
         self.cookie_secret: str | None = None
         self.absolute_config_dir: Path | None = None
+        self.verbose: bool = False
 
     def parse_args(self, args: Any) -> None:
         """Parse the arguments."""

--- a/esphome/dashboard/settings.py
+++ b/esphome/dashboard/settings.py
@@ -35,7 +35,7 @@ class DashboardSettings:
             self.password_hash = password_hash(password)
         self.config_dir = args.configuration
         self.absolute_config_dir = Path(self.config_dir).resolve()
-        self.debug = args.debug
+        self.verbose = args.verbose
         CORE.config_path = os.path.join(self.config_dir, ".")
 
     @property

--- a/esphome/dashboard/settings.py
+++ b/esphome/dashboard/settings.py
@@ -15,6 +15,7 @@ class DashboardSettings:
     """Settings for the dashboard."""
 
     def __init__(self) -> None:
+        """Initialize the dashboard settings."""
         self.config_dir: str = ""
         self.password_hash: str = ""
         self.username: str = ""
@@ -24,6 +25,7 @@ class DashboardSettings:
         self.absolute_config_dir: Path | None = None
 
     def parse_args(self, args: Any) -> None:
+        """Parse the arguments."""
         self.on_ha_addon: bool = args.ha_addon
         password = args.password or os.getenv("PASSWORD") or ""
         if not self.on_ha_addon:
@@ -33,6 +35,7 @@ class DashboardSettings:
             self.password_hash = password_hash(password)
         self.config_dir = args.configuration
         self.absolute_config_dir = Path(self.config_dir).resolve()
+        self.debug = args.debug
         CORE.config_path = os.path.join(self.config_dir, ".")
 
     @property

--- a/esphome/dashboard/status/ping.py
+++ b/esphome/dashboard/status/ping.py
@@ -6,10 +6,10 @@ from typing import cast
 
 from icmplib import Host, SocketPermissionError, async_ping
 
+from ..const import MAX_EXECUTOR_WORKERS
 from ..core import DASHBOARD
 from ..entries import DashboardEntry, EntryState, bool_to_entry_state
 from ..util.itertools import chunked
-from ..const import MAX_EXECUTOR_WORKERS
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -59,6 +59,9 @@ class PingStatus:
                         raise result
                     entries_with_addresses[entry] = result
 
+            _LOGGER.warning(
+                "Pinging entries with addresses: %s", entries_with_addresses
+            )
             # Ping all entries with valid addresses
             for ping_group in chunked(entries_with_addresses.items(), GROUP_SIZE):
                 entry_addresses = cast(tuple[DashboardEntry, list[str]], ping_group)

--- a/esphome/dashboard/status/ping.py
+++ b/esphome/dashboard/status/ping.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import time
 from typing import cast
 
 from icmplib import Host, SocketPermissionError, async_ping
@@ -44,9 +45,10 @@ class PingStatus:
             entries_with_addresses: dict[DashboardEntry, list[str]] = {}
             for ping_group in chunked(to_ping, GROUP_SIZE):
                 ping_group = cast(list[DashboardEntry], ping_group)
+                now_monotonic = time.monotonic()
                 dns_results = await asyncio.gather(
                     *(
-                        dashboard.dns_cache.async_resolve(entry.address)
+                        dashboard.dns_cache.async_resolve(entry.address, now_monotonic)
                         for entry in ping_group
                     ),
                     return_exceptions=True,

--- a/esphome/dashboard/status/ping.py
+++ b/esphome/dashboard/status/ping.py
@@ -60,9 +60,6 @@ class PingStatus:
                         raise result
                     entries_with_addresses[entry] = result
 
-            _LOGGER.warning(
-                "Pinging entries with addresses: %s", entries_with_addresses
-            )
             # Ping all entries with valid addresses
             for ping_group in chunked(entries_with_addresses.items(), GROUP_SIZE):
                 entry_addresses = cast(tuple[DashboardEntry, list[str]], ping_group)

--- a/esphome/dashboard/status/ping.py
+++ b/esphome/dashboard/status/ping.py
@@ -48,7 +48,7 @@ class PingStatus:
                 entries_with_addresses: dict[DashboardEntry, list[str]] = {}
                 for entry, result in zip(ping_group, dns_results):
                     if result is None:
-                        entries.async_set_state(entry, None)
+                        entries.async_set_state(entry, False)
                         continue
                     entries_with_addresses[entry] = result
 

--- a/esphome/dashboard/web_server.py
+++ b/esphome/dashboard/web_server.py
@@ -9,6 +9,7 @@ import hashlib
 import json
 import logging
 import os
+import time
 import secrets
 import shutil
 import subprocess
@@ -315,7 +316,11 @@ class EsphomePortCommandWebSocket(EsphomeCommandWebSocket):
                 port = address
             elif (
                 entry.address
-                and (address_list := dashboard.dns_cache.async_resolve(entry.address))
+                and (
+                    address_list := dashboard.dns_cache.async_resolve(
+                        entry.address, time.monotonic()
+                    )
+                )
                 and not isinstance(address_list, Exception)
             ):
                 # If mdns is not available, try to use the DNS cache

--- a/esphome/dashboard/web_server.py
+++ b/esphome/dashboard/web_server.py
@@ -317,7 +317,7 @@ class EsphomePortCommandWebSocket(EsphomeCommandWebSocket):
             elif (
                 entry.address
                 and (
-                    address_list := dashboard.dns_cache.async_resolve(
+                    address_list := await dashboard.dns_cache.async_resolve(
                         entry.address, time.monotonic()
                     )
                 )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+async_timeout==4.0.3; python_version <= "3.10"
 voluptuous==0.14.1
 PyYAML==6.0.1
 paho-mqtt==1.6.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ voluptuous==0.14.1
 PyYAML==6.0.1
 paho-mqtt==1.6.1
 colorama==0.4.6
+icmplib==3.0.4
 tornado==6.4
 tzlocal==5.2    # from time
 tzdata>=2021.1  # from time


### PR DESCRIPTION
# What does this implement/fix?

- Use icmplib to send the pings
- Cache the dns record for 120s (there were complaints about the number of dns requests that ping generates)
- Set reasonable event loop policies to avoid running out of executor threads (borrowed from HA)
- Use PidfdChildWatcher child watcher from python 3.12 when available (borrowed from HA)
- Log loop exceptions (borrowed from HA)

The subprocesses use a lot of cpu time since they have the overhead of the fork/exec/spawn
related https://github.com/esphome/issues/issues/5257

A future PR should be able to need to manually specify ping as its efficient enough that we can auto fallback

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
