### PR TITLE
Add support for Sharp GP2Y1010AU0F PM2.5 sensor

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -152,6 +152,7 @@ esphome/components/ft63x6/* @gpambrozio
 esphome/components/gcja5/* @gcormier
 esphome/components/gdk101/* @Szewcson
 esphome/components/globals/* @esphome/core
+esphome/components/gp2y1010au0f/* @zry98
 esphome/components/gp8403/* @jesserockz
 esphome/components/gpio/* @esphome/core
 esphome/components/gpio/one_wire/* @ssieb

--- a/esphome/components/gp2y1010au0f/gp2y1010au0f.cpp
+++ b/esphome/components/gp2y1010au0f/gp2y1010au0f.cpp
@@ -1,6 +1,8 @@
 #include "gp2y1010au0f.h"
-#include "esphome/core/log.h"
 #include "esphome/core/hal.h"
+#include "esphome/core/log.h"
+
+#include <cinttypes>
 
 namespace esphome {
 namespace gp2y1010au0f {
@@ -11,7 +13,7 @@ static const float MAX_VOLTAGE = 4.0f;
 
 void GP2Y1010AU0FSensor::dump_config() {
   LOG_SENSOR("", "Sharp GP2Y1010AU0F PM2.5 Sensor", this);
-  ESP_LOGCONFIG(TAG, "  Sampling duration: %d ms", this->sample_duration_);
+  ESP_LOGCONFIG(TAG, "  Sampling duration: %" PRId32 " ms", this->sample_duration_);
   ESP_LOGCONFIG(TAG, "  ADC voltage multiplier: %.3f", this->voltage_multiplier_);
   LOG_UPDATE_INTERVAL(this);
 }
@@ -25,7 +27,7 @@ void GP2Y1010AU0FSensor::update() {
       return;
 
     float mean = this->sample_sum_ / float(this->num_samples_);
-    ESP_LOGD(TAG, "ADC read voltage: %.3f V (mean from %d samples)", mean, this->num_samples_);
+    ESP_LOGD(TAG, "ADC read voltage: %.3f V (mean from %" PRId32 " samples)", mean, this->num_samples_);
 
     // PM2.5 calculation
     // ref: https://www.howmuchsnow.com/arduino/airquality/

--- a/esphome/components/gp2y1010au0f/gp2y1010au0f.cpp
+++ b/esphome/components/gp2y1010au0f/gp2y1010au0f.cpp
@@ -1,0 +1,65 @@
+#include "gp2y1010au0f.h"
+#include "esphome/core/log.h"
+#include "esphome/core/hal.h"
+
+namespace esphome {
+namespace gp2y1010au0f {
+
+static const char *const TAG = "gp2y1010au0f";
+static const float MIN_VOLTAGE = 0.0f;
+static const float MAX_VOLTAGE = 4.0f;
+
+void GP2Y1010AU0FSensor::dump_config() {
+  LOG_SENSOR("", "Sharp GP2Y1010AU0F PM2.5 Sensor", this);
+  ESP_LOGCONFIG(TAG, "  Sampling duration: %d ms", this->sample_duration_);
+  ESP_LOGCONFIG(TAG, "  ADC voltage multiplier: %.3f", this->voltage_multiplier_);
+  LOG_UPDATE_INTERVAL(this);
+}
+
+void GP2Y1010AU0FSensor::update() {
+  is_sampling_ = true;
+
+  this->set_timeout("read", this->sample_duration_, [this]() {
+    this->is_sampling_ = false;
+    if (this->num_samples_ == 0)
+      return;
+
+    float mean = this->sample_sum_ / float(this->num_samples_);
+    ESP_LOGD(TAG, "ADC read voltage: %.3f V (mean from %d samples)", mean, this->num_samples_);
+
+    // PM2.5 calculation
+    // ref: https://www.howmuchsnow.com/arduino/airquality/
+    int16_t pm_2_5_value = 170 * mean;
+    this->publish_state(pm_2_5_value);
+  });
+
+  // reset readings
+  this->num_samples_ = 0;
+  this->sample_sum_ = 0.0f;
+}
+
+void GP2Y1010AU0FSensor::loop() {
+  if (!this->is_sampling_)
+    return;
+
+  // enable the internal IR LED
+  this->led_output_->turn_on();
+  // wait for the sensor to stabilize
+  delayMicroseconds(this->sample_wait_before_);
+  // perform a single sample
+  float read_voltage = this->source_->sample();
+  // disable the internal IR LED
+  this->led_output_->turn_off();
+
+  if (std::isnan(read_voltage))
+    return;
+  read_voltage = read_voltage * this->voltage_multiplier_ - this->voltage_offset_;
+  if (read_voltage < MIN_VOLTAGE || read_voltage > MAX_VOLTAGE)
+    return;
+
+  this->num_samples_++;
+  this->sample_sum_ += read_voltage;
+}
+
+}  // namespace gp2y1010au0f
+}  // namespace esphome

--- a/esphome/components/gp2y1010au0f/gp2y1010au0f.h
+++ b/esphome/components/gp2y1010au0f/gp2y1010au0f.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/components/sensor/sensor.h"
+#include "esphome/components/voltage_sampler/voltage_sampler.h"
+#include "esphome/components/output/binary_output.h"
+
+namespace esphome {
+namespace gp2y1010au0f {
+
+class GP2Y1010AU0FSensor : public sensor::Sensor, public PollingComponent {
+ public:
+  void update() override;
+  void loop() override;
+  void dump_config() override;
+  float get_setup_priority() const override {
+    // after the base sensor has been initialized
+    return setup_priority::DATA - 1.0f;
+  }
+
+  void set_adc_source(voltage_sampler::VoltageSampler *source) { source_ = source; }
+  void set_voltage_refs(float offset, float multiplier) {
+    this->voltage_offset_ = offset;
+    this->voltage_multiplier_ = multiplier;
+  }
+  void set_led_output(output::BinaryOutput *output) { led_output_ = output; }
+
+ protected:
+  // duration in ms of the sampling phase
+  uint32_t sample_duration_ = 100;
+  // duration in us of the wait before sampling
+  // ref: https://global.sharp/products/device/lineup/data/pdf/datasheet/gp2y1010au_appl_e.pdf
+  uint32_t sample_wait_before_ = 280;
+  // duration in us of the wait after sampling
+  // it seems no need to delay on purpose since one ADC sampling takes longer than that (300-400 us on ESP8266)
+  // uint32_t sample_wait_after_ = 40;
+  // the sampling source to read voltage from
+  voltage_sampler::VoltageSampler *source_;
+  // ADC voltage reading offset
+  float voltage_offset_ = 0.0f;
+  // ADC voltage reading multiplier
+  float voltage_multiplier_ = 1.0f;
+  // the binary output to control the sampling LED
+  output::BinaryOutput *led_output_;
+
+  float sample_sum_ = 0.0f;
+  uint32_t num_samples_ = 0;
+  bool is_sampling_ = false;
+};
+
+}  // namespace gp2y1010au0f
+}  // namespace esphome

--- a/esphome/components/gp2y1010au0f/sensor.py
+++ b/esphome/components/gp2y1010au0f/sensor.py
@@ -30,12 +30,16 @@ CONFIG_SCHEMA = (
         device_class=DEVICE_CLASS_PM25,
         state_class=STATE_CLASS_MEASUREMENT,
         icon=ICON_CHEMICAL_WEAPON,
-    ).extend({
-        cv.Required(CONF_SENSOR): cv.use_id(voltage_sampler.VoltageSampler),
-        cv.Optional(CONF_ADC_VOLTAGE_OFFSET, default=0.0): cv.float_,
-        cv.Optional(CONF_ADC_VOLTAGE_MULTIPLIER, default=3.3): cv.float_,
-        cv.Required(CONF_OUTPUT): cv.use_id(output.BinaryOutput),
-    }).extend(cv.polling_component_schema("60s"))
+    )
+    .extend(
+        {
+            cv.Required(CONF_SENSOR): cv.use_id(voltage_sampler.VoltageSampler),
+            cv.Optional(CONF_ADC_VOLTAGE_OFFSET, default=0.0): cv.float_,
+            cv.Optional(CONF_ADC_VOLTAGE_MULTIPLIER, default=3.3): cv.float_,
+            cv.Required(CONF_OUTPUT): cv.use_id(output.BinaryOutput),
+        }
+    )
+    .extend(cv.polling_component_schema("60s"))
 )
 
 
@@ -46,7 +50,11 @@ async def to_code(config):
     # the ADC sensor to read voltage from
     adc_sensor = await cg.get_variable(config[CONF_SENSOR])
     cg.add(var.set_adc_source(adc_sensor))
-    cg.add(var.set_voltage_refs(config[CONF_ADC_VOLTAGE_OFFSET], config[CONF_ADC_VOLTAGE_MULTIPLIER]))
+    cg.add(
+        var.set_voltage_refs(
+            config[CONF_ADC_VOLTAGE_OFFSET], config[CONF_ADC_VOLTAGE_MULTIPLIER]
+        )
+    )
 
     # the binary output to control the module's internal IR LED
     led_output = await cg.get_variable(config[CONF_OUTPUT])

--- a/esphome/components/gp2y1010au0f/sensor.py
+++ b/esphome/components/gp2y1010au0f/sensor.py
@@ -1,0 +1,53 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import sensor, voltage_sampler, output
+from esphome.const import (
+    CONF_SENSOR,
+    CONF_OUTPUT,
+    DEVICE_CLASS_PM25,
+    STATE_CLASS_MEASUREMENT,
+    UNIT_MICROGRAMS_PER_CUBIC_METER,
+    ICON_CHEMICAL_WEAPON,
+)
+
+DEPENDENCIES = ["output"]
+AUTO_LOAD = ["voltage_sampler"]
+CODEOWNERS = ["@zry98"]
+
+CONF_ADC_VOLTAGE_OFFSET = "adc_voltage_offset"
+CONF_ADC_VOLTAGE_MULTIPLIER = "adc_voltage_multiplier"
+
+gp2y1010au0f_ns = cg.esphome_ns.namespace("gp2y1010au0f")
+GP2Y1010AU0FSensor = gp2y1010au0f_ns.class_(
+    "GP2Y1010AU0FSensor", sensor.Sensor, cg.PollingComponent
+)
+
+CONFIG_SCHEMA = (
+    sensor.sensor_schema(
+        GP2Y1010AU0FSensor,
+        unit_of_measurement=UNIT_MICROGRAMS_PER_CUBIC_METER,
+        accuracy_decimals=0,
+        device_class=DEVICE_CLASS_PM25,
+        state_class=STATE_CLASS_MEASUREMENT,
+        icon=ICON_CHEMICAL_WEAPON,
+    ).extend({
+        cv.Required(CONF_SENSOR): cv.use_id(voltage_sampler.VoltageSampler),
+        cv.Optional(CONF_ADC_VOLTAGE_OFFSET, default=0.0): cv.float_,
+        cv.Optional(CONF_ADC_VOLTAGE_MULTIPLIER, default=3.3): cv.float_,
+        cv.Required(CONF_OUTPUT): cv.use_id(output.BinaryOutput),
+    }).extend(cv.polling_component_schema("60s"))
+)
+
+
+async def to_code(config):
+    var = await sensor.new_sensor(config)
+    await cg.register_component(var, config)
+
+    # the ADC sensor to read voltage from
+    adc_sensor = await cg.get_variable(config[CONF_SENSOR])
+    cg.add(var.set_adc_source(adc_sensor))
+    cg.add(var.set_voltage_refs(config[CONF_ADC_VOLTAGE_OFFSET], config[CONF_ADC_VOLTAGE_MULTIPLIER]))
+
+    # the binary output to control the module's internal IR LED
+    led_output = await cg.get_variable(config[CONF_OUTPUT])
+    cg.add(var.set_led_output(led_output))

--- a/esphome/components/gp2y1010au0f/sensor.py
+++ b/esphome/components/gp2y1010au0f/sensor.py
@@ -35,7 +35,7 @@ CONFIG_SCHEMA = (
         {
             cv.Required(CONF_SENSOR): cv.use_id(voltage_sampler.VoltageSampler),
             cv.Optional(CONF_ADC_VOLTAGE_OFFSET, default=0.0): cv.float_,
-            cv.Optional(CONF_ADC_VOLTAGE_MULTIPLIER, default=3.3): cv.float_,
+            cv.Optional(CONF_ADC_VOLTAGE_MULTIPLIER, default=1.0): cv.float_,
             cv.Required(CONF_OUTPUT): cv.use_id(output.BinaryOutput),
         }
     )

--- a/tests/component_tests/gp2y1010au0f/test.esp32-idf.yaml
+++ b/tests/component_tests/gp2y1010au0f/test.esp32-idf.yaml
@@ -1,0 +1,15 @@
+sensor:
+  - platform: adc
+    pin: GPIO36
+    id: adc_sensor
+
+  - platform: gp2y1010au0f
+    sensor: adc_sensor
+    adc_voltage_offset: 0.2
+    adc_voltage_multiplier: 3.3
+    output: dust_sensor_led
+
+output:
+  - platform: gpio
+    id: dust_sensor_led
+    pin: GPIO6

--- a/tests/components/gp2y1010au0f/test.esp32-idf.yaml
+++ b/tests/components/gp2y1010au0f/test.esp32-idf.yaml
@@ -5,6 +5,7 @@ sensor:
 
   - platform: gp2y1010au0f
     sensor: adc_sensor
+    name: Dust Sensor
     adc_voltage_offset: 0.2
     adc_voltage_multiplier: 3.3
     output: dust_sensor_led
@@ -12,4 +13,4 @@ sensor:
 output:
   - platform: gpio
     id: dust_sensor_led
-    pin: GPIO6
+    pin: GPIO32


### PR DESCRIPTION
# What does this implement/fix?

Add support for Sharp GP2Y1010AU0F dust sensor, which is a very cheap (read: inaccurate) optical (infrared LED and phototransistor) sensor suitable for detecting fine particulate matter like dust and smoke.

While the official [datasheet](https://global.sharp/products/device/lineup/data/pdf/datasheet/gp2y1010au_e.pdf) doesn't mention its sensing resolution (whether it can detect PM2.5 particle or not), some vendors (e.g., [Waveshare](https://www.waveshare.com/wiki/Dust_Sensor)) say it can detect particle larger than 0.8 μm in diameter. To make things easier, we'll assume it's capable of that and let the sensor use the PM2.5 device class, reporting in "µg/m³" with 0 accuracy decimals as default.

See also:
- [Datasheet](https://global.sharp/products/device/lineup/data/pdf/datasheet/gp2y1010au_e.pdf>)
- [Application note](https://global.sharp/products/device/lineup/data/pdf/datasheet/gp2y1010au_appl_e.pdf)
- [Research notes by Chris Nafis](https://www.howmuchsnow.com/arduino/airquality/)
- [Interfacing with Arduino](https://electropeak.com/learn/interfacing-gp2y1010au0f-optical-dust-sensor-module-with-arduino/)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#3492

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
output:
  - platform: gpio
    id: dust_sensor_led
    pin: 5
    inverted: true

sensor:
  - platform: adc
    id: adc_sensor
    pin: A0
    internal: true
    update_interval: never

  - platform: gp2y1010au0f
    name: 'Indoor PM2.5'
    sensor: adc_sensor
    adc_voltage_offset: 0.2
    adc_voltage_multiplier: 3.3
    output: dust_sensor_led
    update_interval: 10s
    filters:
      - sliding_window_moving_average:
          window_size: 3
          send_every: 3
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
