### PR TITLE
dashboard: Fix file writes on Windows

### DIFF
--- a/esphome/dashboard/util/file.py
+++ b/esphome/dashboard/util/file.py
@@ -30,6 +30,7 @@ def write_file(
     """
 
     tmp_filename = ""
+    missing_fchmod = False
     try:
         # Modern versions of Python tempfile create this file with mode 0o600
         with tempfile.NamedTemporaryFile(
@@ -38,8 +39,15 @@ def write_file(
             fdesc.write(utf8_data)
             tmp_filename = fdesc.name
             if not private:
-                os.fchmod(fdesc.fileno(), 0o644)
+                try:
+                    os.fchmod(fdesc.fileno(), 0o644)
+                except AttributeError:
+                    # os.fchmod is not available on Windows
+                    missing_fchmod = True
+
         os.replace(tmp_filename, filename)
+        if missing_fchmod:
+            os.chmod(filename, 0o644)
     finally:
         if os.path.exists(tmp_filename):
             try:

--- a/tests/dashboard/util/test_file.py
+++ b/tests/dashboard/util/test_file.py
@@ -13,7 +13,7 @@ def test_write_utf8_file(tmp_path: Path) -> None:
     assert tmp_path.joinpath("foo.txt").read_text() == "foo"
 
     with pytest.raises(OSError):
-        write_utf8_file(Path("/not-writable"), "bar")
+        write_utf8_file(Path("/dev/not-writable"), "bar")
 
 
 def test_write_file(tmp_path: Path) -> None:


### PR DESCRIPTION
# What does this implement/fix?

Fix file writes on Windows

We have some failing tests that were missed that only fail on windows but since we don't have CI runner on windows they went unnoticed. https://github.com/esphome/esphome/pull/6010 will add a CI runner for windows and macos

```
FAILED tests/dashboard/util/test_file.py::test_write_utf8_file - AttributeError: module 'os' has no attribute 'fchmod'
FAILED tests/dashboard/util/test_file.py::test_write_file - AttributeError: module 'os' has no attribute 'fchmod'
FAILED tests/dashboard/util/test_file.py::test_write_utf8_file_fails_at_rename - AttributeError: module 'os' has no attribute 'fchmod'
FAILED tests/dashboard/util/test_file.py::test_write_utf8_file_fails_at_rename_and_remove - AttributeError: module 'os' has no attribute 'fchmod'
```


## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
