### PR TITLE
Extends UART change at runtime to ESP8266

### DIFF
--- a/esphome/components/uart/uart_component.h
+++ b/esphome/components/uart/uart_component.h
@@ -122,7 +122,7 @@ class UARTComponent {
   // @return Baud rate in bits per second.
   uint32_t get_baud_rate() const { return baud_rate_; }
 
-#ifdef USE_ESP32
+#if defined(USE_ESP8266) || defined(USE_ESP32)
   /**
    * Load the UART settings.
    * @param dump_config If true (default), output the new settings to logs; otherwise, change settings quietly.
@@ -147,7 +147,7 @@ class UARTComponent {
    * This will load the current UART interface with the latest settings (baud_rate, parity, etc).
    */
   virtual void load_settings(){};
-#endif  // USE_ESP32
+#endif  // USE_ESP8266 || USE_ESP32
 
 #ifdef USE_UART_DEBUGGER
   void add_debug_callback(std::function<void(UARTDirection, uint8_t)> &&callback) {

--- a/esphome/components/uart/uart_component_esp8266.cpp
+++ b/esphome/components/uart/uart_component_esp8266.cpp
@@ -98,10 +98,26 @@ void ESP8266UartComponent::setup() {
   }
 }
 
+void ESP8266UartComponent::load_settings(bool dump_config) {
+  ESP_LOGCONFIG(TAG, "Loading UART bus settings...");
+  if (this->hw_serial_ != nullptr) {
+    SerialConfig config = static_cast<SerialConfig>(get_config());
+    this->hw_serial_->begin(this->baud_rate_, config);
+    this->hw_serial_->setRxBufferSize(this->rx_buffer_size_);
+  } else {
+    this->sw_serial_->setup(this->tx_pin_, this->rx_pin_, this->baud_rate_, this->stop_bits_, this->data_bits_, this->parity_,
+                            this->rx_buffer_size_);
+  }
+  if (dump_config) {
+    ESP_LOGCONFIG(TAG, "UART bus was reloaded.");
+    this->dump_config();
+  }
+}
+
 void ESP8266UartComponent::dump_config() {
   ESP_LOGCONFIG(TAG, "UART Bus:");
-  LOG_PIN("  TX Pin: ", tx_pin_);
-  LOG_PIN("  RX Pin: ", rx_pin_);
+  LOG_PIN("  TX Pin: ", this->tx_pin_);
+  LOG_PIN("  RX Pin: ", this->rx_pin_);
   if (this->rx_pin_ != nullptr) {
     ESP_LOGCONFIG(TAG, "  RX Buffer Size: %u", this->rx_buffer_size_);  // NOLINT
   }

--- a/esphome/components/uart/uart_component_esp8266.cpp
+++ b/esphome/components/uart/uart_component_esp8266.cpp
@@ -105,8 +105,8 @@ void ESP8266UartComponent::load_settings(bool dump_config) {
     this->hw_serial_->begin(this->baud_rate_, config);
     this->hw_serial_->setRxBufferSize(this->rx_buffer_size_);
   } else {
-    this->sw_serial_->setup(this->tx_pin_, this->rx_pin_, this->baud_rate_, this->stop_bits_, this->data_bits_, this->parity_,
-                            this->rx_buffer_size_);
+    this->sw_serial_->setup(this->tx_pin_, this->rx_pin_, this->baud_rate_, this->stop_bits_, this->data_bits_,
+                            this->parity_, this->rx_buffer_size_);
   }
   if (dump_config) {
     ESP_LOGCONFIG(TAG, "UART bus was reloaded.");

--- a/esphome/components/uart/uart_component_esp8266.h
+++ b/esphome/components/uart/uart_component_esp8266.h
@@ -63,6 +63,21 @@ class ESP8266UartComponent : public UARTComponent, public Component {
 
   uint32_t get_config();
 
+  /**
+   * Load the UART with the current settings.
+   * @param dump_config (Optional, default `true`): True for displaying new settings or
+   * false to change it quitely
+   *
+   * Example:
+   * ```cpp
+   * id(uart1).load_settings();
+   * ```
+   *
+   * This will load the current UART interface with the latest settings (baud_rate, parity, etc).
+   */
+  void load_settings(bool dump_config) override;
+  void load_settings() override { this->load_settings(true); }
+
  protected:
   void check_logger_conflict() override;
 


### PR DESCRIPTION
This extends the changes made on #5909 to esp8266 devices.

This adds the method `load_settings()` to the UART component allowing the interface to reload with the new settings used by methods `set_baud_rate`, `set_parity`, `set_data_bits`, etc. without the assignment of a new software UART.

This can be useful for connecting to devices which supports multiple baud rates or for devices which changes it's serial communication at runtime, but also allows some logic for a user's configurable baud rate to be set at `on_boot` after the UART component is loaded.

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** N/A
There is a Discord thread about this: https://discord.com/channels/429907082951524364/1180653963461275648

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#3496

## Test Environment

- [X] ESP32
- [X] ESP32 IDF
- [X] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
```yaml
# Example config.yaml
select:
  - id: change_baud_rate
    name: Baud rate
    platform: template
    options:
      - "2400"
      - "9600"
      - "38400"
      - "57600"
      - "115200"
      - "256000"
      - "512000"
      - "921600"
    initial_option: "115200"
    optimistic: true
    restore_value: True
    internal: false
    entity_category: config
    icon: mdi:swap-horizontal
    set_action:
      - lambda: |-
          tf_uart->flush();
          ESP_LOGD("change_baud_rate", "Set new baud rate to %i", stoi(x));
          tf_uart->set_baud_rate(stoi(x));
          tf_uart->load_settings();
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
