### PR TITLE
Nextion draw QR code at runtime

### DIFF
--- a/esphome/components/nextion/nextion.h
+++ b/esphome/components/nextion/nextion.h
@@ -750,6 +750,47 @@ class Nextion : public NextionBase, public PollingComponent, public uart::UARTDe
    */
   void filled_circle(int center_x, int center_y, int radius, Color color);
 
+  /**
+   * Draws a QR code in the screen
+   * @param x1 The top left x coordinate to start the QR code.
+   * @param y1 The top left y coordinate to start the QR code.
+   * @param content The content of the QR code (as a plain text - Nextion will generate the QR code).
+   * @param size The size (in pixels) for the QR code. Defaults to 200px.
+   * @param background_color The background color to draw with (as rgb565 integer). Defaults to 65535 (white).
+   * @param foreground_color The foreground color to draw with (as rgb565 integer). Defaults to 0 (black).
+   * @param logo_pic The picture id for the logo in the center of the QR code. Defaults to -1 (no logo).
+   * @param border_width The border width (in pixels) for the QR code. Defaults to 8px.
+   *
+   * Example:
+   * ```cpp
+   * it.qrcode(25, 25, "WIFI:S:MySSID;T:WPA;P:MyPassW0rd;;");
+   * ```
+   *
+   * Draws a QR code with a Wi-Fi network credentials starting at the given coordinates (25,25).
+   */
+  void qrcode(int x1, int y1, const char *content, int size = 200, uint16_t background_color = 65535, uint16_t foreground_color = 0, int logo_pic = -1, uint8_t border_width = 8);
+  /**
+   * Draws a QR code in the screen
+   * @param x1 The top left x coordinate to start the QR code.
+   * @param y1 The top left y coordinate to start the QR code.
+   * @param content The content of the QR code (as a plain text - Nextion will generate the QR code).
+   * @param size The size (in pixels) for the QR code. Defaults to 200px.
+   * @param background_color The background color to draw with (as Color). Defaults to 65535 (white).
+   * @param foreground_color The foreground color to draw with (as Color). Defaults to 0 (black).
+   * @param logo_pic The picture id for the logo in the center of the QR code. Defaults to -1 (no logo).
+   * @param border_width The border width (in pixels) for the QR code. Defaults to 8px.
+   *
+   * Example:
+   * ```cpp
+   * auto blue = Color(0, 0, 255);
+   * auto red = Color(255, 0, 0);
+   * it.qrcode(25, 25, "WIFI:S:MySSID;T:WPA;P:MyPassW0rd;;", 150, blue, red);
+   * ```
+   *
+   * Draws a QR code with a Wi-Fi network credentials starting at the given coordinates (25,25) with size of 150px in red on a blue background.
+   */
+  void qrcode(int x1, int y1, const char *content, int size = 200, Color background_color = Color(255, 255, 255), Color foreground_color = Color(0, 0, 0), int logo_pic = -1, uint8_t border_width = 8);
+
   /** Set the brightness of the backlight.
    *
    * @param brightness The brightness percentage from 0 to 1.0.

--- a/esphome/components/nextion/nextion.h
+++ b/esphome/components/nextion/nextion.h
@@ -768,7 +768,8 @@ class Nextion : public NextionBase, public PollingComponent, public uart::UARTDe
    *
    * Draws a QR code with a Wi-Fi network credentials starting at the given coordinates (25,25).
    */
-  void qrcode(int x1, int y1, const char *content, int size = 200, uint16_t background_color = 65535, uint16_t foreground_color = 0, int logo_pic = -1, uint8_t border_width = 8);
+  void qrcode(int x1, int y1, const char *content, int size = 200, uint16_t background_color = 65535,
+              uint16_t foreground_color = 0, int logo_pic = -1, uint8_t border_width = 8);
   /**
    * Draws a QR code in the screen
    * @param x1 The top left x coordinate to start the QR code.
@@ -787,9 +788,11 @@ class Nextion : public NextionBase, public PollingComponent, public uart::UARTDe
    * it.qrcode(25, 25, "WIFI:S:MySSID;T:WPA;P:MyPassW0rd;;", 150, blue, red);
    * ```
    *
-   * Draws a QR code with a Wi-Fi network credentials starting at the given coordinates (25,25) with size of 150px in red on a blue background.
+   * Draws a QR code with a Wi-Fi network credentials starting at the given coordinates (25,25) with size of 150px in
+   * red on a blue background.
    */
-  void qrcode(int x1, int y1, const char *content, int size = 200, Color background_color = Color(255, 255, 255), Color foreground_color = Color(0, 0, 0), int logo_pic = -1, uint8_t border_width = 8);
+  void qrcode(int x1, int y1, const char *content, int size, Color background_color = Color(255, 255, 255),
+              Color foreground_color = Color(0, 0, 0), int logo_pic = -1, uint8_t border_width = 8);
 
   /** Set the brightness of the backlight.
    *

--- a/esphome/components/nextion/nextion_commands.cpp
+++ b/esphome/components/nextion/nextion_commands.cpp
@@ -294,16 +294,17 @@ void Nextion::filled_circle(int center_x, int center_y, int radius, Color color)
                                             display::ColorUtil::color_to_565(color));
 }
 
-void Nextion::qrcode(int x1, int y1, const char *content, int size, uint16_t background_color, uint16_t foreground_color,
-            int logo_pic, uint8_t border_width) {
-  this->add_no_result_to_queue_with_printf_("qrcode", "qrcode %d,%d,%d,%d,%d,%d,%d,\"%s\"", x1, y1, size, background_color,
-                                            foreground_color, logo_pic, border_width, content);
+void Nextion::qrcode(int x1, int y1, const char *content, int size, uint16_t background_color,
+                     uint16_t foreground_color, int logo_pic, uint8_t border_width) {
+  this->add_no_result_to_queue_with_printf_("qrcode", "qrcode %d,%d,%d,%d,%d,%d,%d,\"%s\"", x1, y1, size,
+                                            background_color, foreground_color, logo_pic, border_width, content);
 }
 
-void Nextion::qrcode(int x1, int y1, const char *content, int size, Color background_color,
-            Color foreground_color, int logo_pic, uint8_t border_width) {
-  this->add_no_result_to_queue_with_printf_("qrcode", "qrcode %d,%d,%d,%d,%d,%d,%d,\"%s\"", x1, y1, size, display::ColorUtil::color_to_565(background_color),
-                                            display::ColorUtil::color_to_565(foreground_color), logo_pic, border_width, content);
+void Nextion::qrcode(int x1, int y1, const char *content, int size, Color background_color, Color foreground_color,
+                     int logo_pic, uint8_t border_width) {
+  this->add_no_result_to_queue_with_printf_(
+      "qrcode", "qrcode %d,%d,%d,%d,%d,%d,%d,\"%s\"", x1, y1, size, display::ColorUtil::color_to_565(background_color),
+      display::ColorUtil::color_to_565(foreground_color), logo_pic, border_width, content);
 }
 
 void Nextion::set_nextion_rtc_time(ESPTime time) {

--- a/esphome/components/nextion/nextion_commands.cpp
+++ b/esphome/components/nextion/nextion_commands.cpp
@@ -294,6 +294,18 @@ void Nextion::filled_circle(int center_x, int center_y, int radius, Color color)
                                             display::ColorUtil::color_to_565(color));
 }
 
+void qrcode(int x1, int y1, const char *content, int size = 200, uint16_t background_color = 65535, uint16_t foreground_color = 0,
+            int logo_pic = -1, uint8_t border_width = 8) {
+  this->add_no_result_to_queue_with_printf_("qrcode", "qrcode %d,%d,%d,%d,%d,%d,%d,\"%s\"", x1, y1, size, background_color,
+                                            foreground_color, logo_pic, border_width, content);
+}
+
+void qrcode(int x1, int y1, const char *content, int size = 200, Color background_color = Color(255, 255, 255),
+            Color foreground_color = Color(0, 0, 0), int logo_pic = -1, uint8_t border_width = 8) {
+  this->add_no_result_to_queue_with_printf_("qrcode", "qrcode %d,%d,%d,%d,%d,%d,%d,\"%s\"", x1, y1, size, display::ColorUtil::color_to_565(background_color),
+                                            display::ColorUtil::color_to_565(foreground_color), logo_pic, border_width, content);
+}
+
 void Nextion::set_nextion_rtc_time(ESPTime time) {
   this->add_no_result_to_queue_with_printf_("rtc0", "rtc0=%u", time.year);
   this->add_no_result_to_queue_with_printf_("rtc1", "rtc1=%u", time.month);

--- a/esphome/components/nextion/nextion_commands.cpp
+++ b/esphome/components/nextion/nextion_commands.cpp
@@ -294,14 +294,14 @@ void Nextion::filled_circle(int center_x, int center_y, int radius, Color color)
                                             display::ColorUtil::color_to_565(color));
 }
 
-void Nextion::qrcode(int x1, int y1, const char *content, int size = 200, uint16_t background_color = 65535, uint16_t foreground_color = 0,
-            int logo_pic = -1, uint8_t border_width = 8) {
+void Nextion::qrcode(int x1, int y1, const char *content, int size, uint16_t background_color, uint16_t foreground_color,
+            int logo_pic, uint8_t border_width) {
   this->add_no_result_to_queue_with_printf_("qrcode", "qrcode %d,%d,%d,%d,%d,%d,%d,\"%s\"", x1, y1, size, background_color,
                                             foreground_color, logo_pic, border_width, content);
 }
 
-void Nextion::qrcode(int x1, int y1, const char *content, int size = 200, Color background_color = Color(255, 255, 255),
-            Color foreground_color = Color(0, 0, 0), int logo_pic = -1, uint8_t border_width = 8) {
+void Nextion::qrcode(int x1, int y1, const char *content, int size, Color background_color,
+            Color foreground_color, int logo_pic, uint8_t border_width) {
   this->add_no_result_to_queue_with_printf_("qrcode", "qrcode %d,%d,%d,%d,%d,%d,%d,\"%s\"", x1, y1, size, display::ColorUtil::color_to_565(background_color),
                                             display::ColorUtil::color_to_565(foreground_color), logo_pic, border_width, content);
 }

--- a/esphome/components/nextion/nextion_commands.cpp
+++ b/esphome/components/nextion/nextion_commands.cpp
@@ -294,13 +294,13 @@ void Nextion::filled_circle(int center_x, int center_y, int radius, Color color)
                                             display::ColorUtil::color_to_565(color));
 }
 
-void qrcode(int x1, int y1, const char *content, int size = 200, uint16_t background_color = 65535, uint16_t foreground_color = 0,
+void Nextion::qrcode(int x1, int y1, const char *content, int size = 200, uint16_t background_color = 65535, uint16_t foreground_color = 0,
             int logo_pic = -1, uint8_t border_width = 8) {
   this->add_no_result_to_queue_with_printf_("qrcode", "qrcode %d,%d,%d,%d,%d,%d,%d,\"%s\"", x1, y1, size, background_color,
                                             foreground_color, logo_pic, border_width, content);
 }
 
-void qrcode(int x1, int y1, const char *content, int size = 200, Color background_color = Color(255, 255, 255),
+void Nextion::qrcode(int x1, int y1, const char *content, int size = 200, Color background_color = Color(255, 255, 255),
             Color foreground_color = Color(0, 0, 0), int logo_pic = -1, uint8_t border_width = 8) {
   this->add_no_result_to_queue_with_printf_("qrcode", "qrcode %d,%d,%d,%d,%d,%d,%d,\"%s\"", x1, y1, size, display::ColorUtil::color_to_565(background_color),
                                             display::ColorUtil::color_to_565(foreground_color), logo_pic, border_width, content);


### PR DESCRIPTION
# What does this implement/fix?

This adds the `qrcode` method to Nextion library, allowing to plot QR codes on any Nextion page without the need of a QR code component previously added to the TFT.
This isn't the exactly same `qr_code` from `display` component as Nextion already have it's own QR code generator and it didn't requires a QR code component at build time.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A - Nextion docs don't includes this kind of method documentation, so I've added inline doc only, keeping consistency with existing methods.

## Test Environment

- [X] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
display:
  - id: disp1
    platform: nextion

text:
  - id: nextion_qrcode
    name: QR code
    platform: template
    icon: mdi:qrcode-scan
    restore_value: false
    initial_value: ""
    mode: text
    set_action:
      then:
        - lambda: |-
            static const char *const TAG = "text.nextion_qrcode.set_action";
            ESP_LOGD(TAG, "Plotting new QR code: %s", x.c_str());
            disp1->qrcode(113, 62, x.c_str(), 222, 65535, 0, -1, 7);
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
