### PR TITLE
Nextion queue size

### DIFF
--- a/esphome/components/nextion/nextion.h
+++ b/esphome/components/nextion/nextion.h
@@ -959,6 +959,20 @@ class Nextion : public NextionBase, public PollingComponent, public uart::UARTDe
   void set_exit_reparse_on_start_internal(bool exit_reparse_on_start) {
     this->exit_reparse_on_start_ = exit_reparse_on_start;
   }
+
+  /**
+   * @brief Retrieves the number of commands pending in the Nextion command queue.
+   *
+   * This function returns the current count of commands that have been queued but not yet processed 
+   * for the Nextion display. The Nextion command queue is used to store commands that are sent to 
+   * the Nextion display for various operations like updating the display, changing interface elements,
+   * or other interactive features. A larger queue size might indicate a higher processing time or potential 
+   * delays in command execution. This function is useful for monitoring the command flow and managing 
+   * the execution efficiency of the Nextion display interface.
+   *
+   * @return size_t The number of commands currently in the Nextion queue. This count includes all commands 
+   *                that have been added to the queue and are awaiting processing.
+   */
   size_t queue_size() { return this->nextion_queue_.size(); }
 
  protected:

--- a/esphome/components/nextion/nextion.h
+++ b/esphome/components/nextion/nextion.h
@@ -963,14 +963,14 @@ class Nextion : public NextionBase, public PollingComponent, public uart::UARTDe
   /**
    * @brief Retrieves the number of commands pending in the Nextion command queue.
    *
-   * This function returns the current count of commands that have been queued but not yet processed 
-   * for the Nextion display. The Nextion command queue is used to store commands that are sent to 
+   * This function returns the current count of commands that have been queued but not yet processed
+   * for the Nextion display. The Nextion command queue is used to store commands that are sent to
    * the Nextion display for various operations like updating the display, changing interface elements,
-   * or other interactive features. A larger queue size might indicate a higher processing time or potential 
-   * delays in command execution. This function is useful for monitoring the command flow and managing 
+   * or other interactive features. A larger queue size might indicate a higher processing time or potential
+   * delays in command execution. This function is useful for monitoring the command flow and managing
    * the execution efficiency of the Nextion display interface.
    *
-   * @return size_t The number of commands currently in the Nextion queue. This count includes all commands 
+   * @return size_t The number of commands currently in the Nextion queue. This count includes all commands
    *                that have been added to the queue and are awaiting processing.
    */
   size_t queue_size() { return this->nextion_queue_.size(); }

--- a/esphome/components/nextion/nextion.h
+++ b/esphome/components/nextion/nextion.h
@@ -959,6 +959,7 @@ class Nextion : public NextionBase, public PollingComponent, public uart::UARTDe
   void set_exit_reparse_on_start_internal(bool exit_reparse_on_start) {
     this->exit_reparse_on_start_ = exit_reparse_on_start;
   }
+  size_t queue_size() { return this->nextion_queue_.size(); }
 
  protected:
   std::deque<NextionQueue *> nextion_queue_;

--- a/esphome/components/nextion/nextion_base.h
+++ b/esphome/components/nextion/nextion_base.h
@@ -51,7 +51,6 @@ class NextionBase {
   bool is_sleeping() { return this->is_sleeping_; }
   bool is_setup() { return this->is_setup_; }
   bool is_detected() { return this->is_detected_; }
-  size_t queue_size() { return this->nextion_queue_.size(); }
 
  protected:
   bool is_setup_ = false;

--- a/esphome/components/nextion/nextion_base.h
+++ b/esphome/components/nextion/nextion_base.h
@@ -51,6 +51,7 @@ class NextionBase {
   bool is_sleeping() { return this->is_sleeping_; }
   bool is_setup() { return this->is_setup_; }
   bool is_detected() { return this->is_detected_; }
+  size_t queue_size() { return this->nextion_queue_.size(); }
 
  protected:
   bool is_setup_ = false;


### PR DESCRIPTION
# What does this implement/fix?

This adds the method `queue_size()` to Nextion component.
This function returns the current count of commands that have been queued but not yet processed for the Nextion display. The Nextion command queue is used to store commands that are sent to the Nextion display for various operations like updating the display, changing interface elements, or other interactive features. A larger queue size might indicate a higher processing time or potential delays in command execution. This function is useful for monitoring the command flow and managing the execution efficiency of the Nextion display interface.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [X] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
interval:
  - interval: 5m
    then:
      - lambda: |-
          ESP_LOGD("DEBUG", "Nextion queue size: %d", disp1->queue_size());
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
