### PR TITLE
Fix Prometheus Output to Match Spec

### DIFF
--- a/esphome/components/prometheus/prometheus_handler.cpp
+++ b/esphome/components/prometheus/prometheus_handler.cpp
@@ -65,8 +65,8 @@ std::string PrometheusHandler::relabel_name_(EntityBase *obj) {
 // Type-specific implementation
 #ifdef USE_SENSOR
 void PrometheusHandler::sensor_type_(AsyncResponseStream *stream) {
-  stream->print(F("#TYPE esphome_sensor_value GAUGE\n"));
-  stream->print(F("#TYPE esphome_sensor_failed GAUGE\n"));
+  stream->print(F("#TYPE esphome_sensor_value gauge\n"));
+  stream->print(F("#TYPE esphome_sensor_failed gauge\n"));
 }
 void PrometheusHandler::sensor_row_(AsyncResponseStream *stream, sensor::Sensor *obj) {
   if (obj->is_internal() && !this->include_internal_)
@@ -102,8 +102,8 @@ void PrometheusHandler::sensor_row_(AsyncResponseStream *stream, sensor::Sensor 
 // Type-specific implementation
 #ifdef USE_BINARY_SENSOR
 void PrometheusHandler::binary_sensor_type_(AsyncResponseStream *stream) {
-  stream->print(F("#TYPE esphome_binary_sensor_value GAUGE\n"));
-  stream->print(F("#TYPE esphome_binary_sensor_failed GAUGE\n"));
+  stream->print(F("#TYPE esphome_binary_sensor_value gauge\n"));
+  stream->print(F("#TYPE esphome_binary_sensor_failed gauge\n"));
 }
 void PrometheusHandler::binary_sensor_row_(AsyncResponseStream *stream, binary_sensor::BinarySensor *obj) {
   if (obj->is_internal() && !this->include_internal_)
@@ -136,10 +136,10 @@ void PrometheusHandler::binary_sensor_row_(AsyncResponseStream *stream, binary_s
 
 #ifdef USE_FAN
 void PrometheusHandler::fan_type_(AsyncResponseStream *stream) {
-  stream->print(F("#TYPE esphome_fan_value GAUGE\n"));
-  stream->print(F("#TYPE esphome_fan_failed GAUGE\n"));
-  stream->print(F("#TYPE esphome_fan_speed GAUGE\n"));
-  stream->print(F("#TYPE esphome_fan_oscillation GAUGE\n"));
+  stream->print(F("#TYPE esphome_fan_value gauge\n"));
+  stream->print(F("#TYPE esphome_fan_failed gauge\n"));
+  stream->print(F("#TYPE esphome_fan_speed gauge\n"));
+  stream->print(F("#TYPE esphome_fan_oscillation gauge\n"));
 }
 void PrometheusHandler::fan_row_(AsyncResponseStream *stream, fan::Fan *obj) {
   if (obj->is_internal() && !this->include_internal_)
@@ -182,9 +182,9 @@ void PrometheusHandler::fan_row_(AsyncResponseStream *stream, fan::Fan *obj) {
 
 #ifdef USE_LIGHT
 void PrometheusHandler::light_type_(AsyncResponseStream *stream) {
-  stream->print(F("#TYPE esphome_light_state GAUGE\n"));
-  stream->print(F("#TYPE esphome_light_color GAUGE\n"));
-  stream->print(F("#TYPE esphome_light_effect_active GAUGE\n"));
+  stream->print(F("#TYPE esphome_light_state gauge\n"));
+  stream->print(F("#TYPE esphome_light_color gauge\n"));
+  stream->print(F("#TYPE esphome_light_effect_active gauge\n"));
 }
 void PrometheusHandler::light_row_(AsyncResponseStream *stream, light::LightState *obj) {
   if (obj->is_internal() && !this->include_internal_)
@@ -259,8 +259,8 @@ void PrometheusHandler::light_row_(AsyncResponseStream *stream, light::LightStat
 
 #ifdef USE_COVER
 void PrometheusHandler::cover_type_(AsyncResponseStream *stream) {
-  stream->print(F("#TYPE esphome_cover_value GAUGE\n"));
-  stream->print(F("#TYPE esphome_cover_failed GAUGE\n"));
+  stream->print(F("#TYPE esphome_cover_value gauge\n"));
+  stream->print(F("#TYPE esphome_cover_failed gauge\n"));
 }
 void PrometheusHandler::cover_row_(AsyncResponseStream *stream, cover::Cover *obj) {
   if (obj->is_internal() && !this->include_internal_)
@@ -302,8 +302,8 @@ void PrometheusHandler::cover_row_(AsyncResponseStream *stream, cover::Cover *ob
 
 #ifdef USE_SWITCH
 void PrometheusHandler::switch_type_(AsyncResponseStream *stream) {
-  stream->print(F("#TYPE esphome_switch_value GAUGE\n"));
-  stream->print(F("#TYPE esphome_switch_failed GAUGE\n"));
+  stream->print(F("#TYPE esphome_switch_value gauge\n"));
+  stream->print(F("#TYPE esphome_switch_failed gauge\n"));
 }
 void PrometheusHandler::switch_row_(AsyncResponseStream *stream, switch_::Switch *obj) {
   if (obj->is_internal() && !this->include_internal_)
@@ -326,8 +326,8 @@ void PrometheusHandler::switch_row_(AsyncResponseStream *stream, switch_::Switch
 
 #ifdef USE_LOCK
 void PrometheusHandler::lock_type_(AsyncResponseStream *stream) {
-  stream->print(F("#TYPE esphome_lock_value GAUGE\n"));
-  stream->print(F("#TYPE esphome_lock_failed GAUGE\n"));
+  stream->print(F("#TYPE esphome_lock_value gauge\n"));
+  stream->print(F("#TYPE esphome_lock_failed gauge\n"));
 }
 void PrometheusHandler::lock_row_(AsyncResponseStream *stream, lock::Lock *obj) {
   if (obj->is_internal() && !this->include_internal_)


### PR DESCRIPTION
# What does this implement/fix?

This change updates the output to use `gauge` over `GAUGE`.

The [exposition format spec](https://prometheus.io/docs/instrumenting/exposition_formats/) states:

> If the token is `TYPE`, exactly two more tokens are expected. The first is the metric name, and the second is either
> `counter`, `gauge`, `histogram`, `summary`, or `untyped`, defining the type for the metric of that name.

While prometheus itself may successfully parse the current format, some third-party parsers more closely follow the specification, and fail to properly parse this.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** n/a

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
prometheus:
sensor:
  - platform: uptime
    name: uptime
web_server:
  port: 80
```
Load the `/metrics` URL on the esp device after install, and you should see something like this:
```
#TYPE esphome_sensor_value gauge
#TYPE esphome_sensor_failed gauge
esphome_sensor_failed{id="uptime",name="uptime"} 0
esphome_sensor_value{id="uptime",name="uptime",unit="s"} 55
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
