### PR TITLE
Add getter for image data_start

### DIFF
--- a/esphome/components/image/image.h
+++ b/esphome/components/image/image.h
@@ -37,6 +37,7 @@ class Image : public display::BaseImage {
   Color get_pixel(int x, int y, Color color_on = display::COLOR_ON, Color color_off = display::COLOR_OFF) const;
   int get_width() const override;
   int get_height() const override;
+  const uint8_t *get_data_start() { return this->data_start_; }
   ImageType get_type() const;
 
   void draw(int x, int y, display::Display *display, Color color_on, Color color_off) override;


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

The `image::Image` class has 4 invariant properties but only had getters for 3 of those. This PR adds the missing one.

Needed for use by image renderers e.g. LVGL.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
