### PR TITLE
Support full (>460 char) dumps of Pronto IR commands

### DIFF
--- a/esphome/components/remote_base/pronto_protocol.cpp
+++ b/esphome/components/remote_base/pronto_protocol.cpp
@@ -227,16 +227,17 @@ optional<ProntoData> ProntoProtocol::decode(RemoteReceiveData src) {
 }
 
 void ProntoProtocol::dump(const ProntoData &data) {
-  std::string first, rest;
-  if (data.data.size() < 230) {
-    first = data.data;
-  } else {
-    first = data.data.substr(0, 229);
-    rest = data.data.substr(230);
-  }
-  ESP_LOGI(TAG, "Received Pronto: data=%s", first.c_str());
-  if (!rest.empty()) {
-    ESP_LOGI(TAG, "%s", rest.c_str());
+  std::string rest;
+
+  rest = data.data;
+  ESP_LOGI(TAG, "Received Pronto: data=");
+  while (true) {
+    ESP_LOGI(TAG, "%s", rest.substr(0, 230).c_str());
+    if (rest.size() > 230) {
+      rest = rest.substr(230);
+    } else {
+      break;
+    }
   }
 }
 


### PR DESCRIPTION
# What does this implement/fix?

Currently Pronto IR messages get truncated, this allows them to be fully logged

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):**  https://github.com/esphome/issues/issues/3557#issuecomment-1409604480

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [x] BK72xx
- [ ] RTL87xx

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
