### PR TITLE
clang-format and clang-tidy scripts: More robust algorithm to find correct executable

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,5 +23,3 @@ pyparsing >= 3.0
 
 # For autocompletion
 argcomplete>=2.0.0
-clang-tidy==14.0.6
-clang-format==13.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,3 +23,5 @@ pyparsing >= 3.0
 
 # For autocompletion
 argcomplete>=2.0.0
+clang-tidy==14.0.6
+clang-format=13.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,4 +24,4 @@ pyparsing >= 3.0
 # For autocompletion
 argcomplete>=2.0.0
 clang-tidy==14.0.6
-clang-format=13.0.1
+clang-format==13.0.1

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,0 +1,3 @@
+# Useful stuff when working in a development environment
+clang-format==13.0.1
+clang-tidy==14.0.6

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -13,3 +13,4 @@ asyncmock==0.4.2
 hypothesis==5.49.0
 
 clang-format==13.0.1 ; platform_machine != 'armv7l'
+clang-tidy==14.0.6 ; platform_machine != 'armv7l'

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -11,6 +11,3 @@ pytest-mock==3.12.0
 pytest-asyncio==0.23.2
 asyncmock==0.4.2
 hypothesis==5.49.0
-
-clang-format==13.0.1 ; platform_machine != 'armv7l'
-clang-tidy==14.0.6 ; platform_machine != 'armv7l'

--- a/script/clang-format
+++ b/script/clang-format
@@ -102,14 +102,14 @@ def main():
         task_queue.join()
 
     except FileNotFoundError as ex:
-        pass
+        return 1
     except KeyboardInterrupt:
         print()
         print("Ctrl-C detected, goodbye.")
-        os.kill(0, 9)
+        return 2
 
-    sys.exit(len(failed_files))
+    return len(failed_files)
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/script/clang-format
+++ b/script/clang-format
@@ -34,7 +34,7 @@ def get_binary(name, version):
         f"""
         Oops. It looks like {name} is not installed.
 
-        Please check you can run "{name} -version" or "{name}-{version} -version"
+        Please confirm you can run "{name} -version" or "{name}-{version} -version"
         in your terminal and install
         {name} (v{version}) if necessary.
 

--- a/script/clang-format
+++ b/script/clang-format
@@ -106,7 +106,10 @@ def main():
     except KeyboardInterrupt:
         print()
         print("Ctrl-C detected, goodbye.")
-        return 2
+        # Kill subprocesses (and ourselves!)
+        # No simple, clean alternative appears to be available.
+        os.kill(0, 9)
+        return 2    # Will not execute.
 
     return len(failed_files)
 

--- a/script/clang-format
+++ b/script/clang-format
@@ -13,11 +13,43 @@ import sys
 import threading
 
 
+
+def get_binary(name, version):
+    clang_binary = f"{name}-{version}"
+    try:
+        result = subprocess.check_output([clang_binary, '-version'])
+        if result.returncode == 0:
+            return clang_binary
+    except Exception:
+        pass
+    clang_binary = name
+    try:
+        result = subprocess.run([clang_binary, '-version'], text=True, capture_output=True)
+        if result.returncode == 0 and (f"version {version}") in result.stdout:
+            return clang_binary
+    except Exception as ex:
+        pass
+
+    print(
+        f"""
+        Oops. It looks like {name} is not installed.
+
+        Please check you can run "{name} -version" or "{name}-{version} -version"
+        in your terminal and install
+        {name} (v{version}) if necessary.
+
+        Note you can also upload your code as a pull request on GitHub and see the CI check
+        output to apply {name}
+        """
+    )
+    sys.exit()
+ 
+
 def run_format(args, queue, lock, failed_files):
     """Takes filenames out of queue and runs clang-format on them."""
     while True:
         path = queue.get()
-        invocation = ["clang-format-13"]
+        invocation = [get_binary("clang-format", 13)]
         if args.inplace:
             invocation.append("-i")
         else:
@@ -57,22 +89,6 @@ def main():
         "-c", "--changed", action="store_true", help="only run on changed files"
     )
     args = parser.parse_args()
-
-    try:
-        get_output("clang-format-13", "-version")
-    except:
-        print(
-            """
-        Oops. It looks like clang-format is not installed. 
-        
-        Please check you can run "clang-format-13 -version" in your terminal and install
-        clang-format (v13) if necessary.
-        
-        Note you can also upload your code as a pull request on GitHub and see the CI check
-        output to apply clang-format.
-        """
-        )
-        return 1
 
     files = []
     for path in git_ls_files(["*.cpp", "*.h", "*.tcc"]):

--- a/script/clang-format
+++ b/script/clang-format
@@ -1,6 +1,12 @@
 #!/usr/bin/env python3
 
-from helpers import print_error_for_file, get_output, git_ls_files, filter_changed
+from helpers import (
+    print_error_for_file,
+    get_output,
+    git_ls_files,
+    filter_changed,
+    get_binary,
+)
 import argparse
 import click
 import colorama
@@ -14,45 +20,11 @@ import threading
 
 
 
-def get_binary(name, version):
-    clang_binary = f"{name}-{version}"
-    try:
-        result = subprocess.check_output([clang_binary, '-version'])
-        if result.returncode == 0:
-            return clang_binary
-    except Exception:
-        pass
-    clang_binary = name
-    try:
-        result = subprocess.run([clang_binary, '-version'], text=True, capture_output=True)
-        if result.returncode == 0 and (f"version {version}") in result.stdout:
-            return clang_binary
-    except Exception as ex:
-        pass
-
-    print(
-        f"""
-        Oops. It looks like {name} is not installed. It will be available under venv/bin
-        and in PATH after running in turn:
-          script/setup
-          source venv/bin/activate.
-
-        Please confirm you can run "{name} -version" or "{name}-{version} -version"
-        in your terminal and install
-        {name} (v{version}) if necessary.
-
-        Note you can also upload your code as a pull request on GitHub and see the CI check
-        output to apply {name}
-        """
-    )
-    sys.exit()
- 
-
-def run_format(args, queue, lock, failed_files):
+def run_format(executable, args, queue, lock, failed_files):
     """Takes filenames out of queue and runs clang-format on them."""
     while True:
         path = queue.get()
-        invocation = [get_binary("clang-format", 13)]
+        invocation = [executable]
         if args.inplace:
             invocation.append("-i")
         else:
@@ -109,11 +81,12 @@ def main():
 
     failed_files = []
     try:
+        executable = get_binary("clang-format", 13)
         task_queue = queue.Queue(args.jobs)
         lock = threading.Lock()
         for _ in range(args.jobs):
             t = threading.Thread(
-                target=run_format, args=(args, task_queue, lock, failed_files)
+                target=run_format, args=(executable, args, task_queue, lock, failed_files)
             )
             t.daemon = True
             t.start()
@@ -128,6 +101,8 @@ def main():
         # Wait for all threads to be done.
         task_queue.join()
 
+    except FileNotFoundError as ex:
+        pass
     except KeyboardInterrupt:
         print()
         print("Ctrl-C detected, goodbye.")

--- a/script/clang-format
+++ b/script/clang-format
@@ -32,7 +32,10 @@ def get_binary(name, version):
 
     print(
         f"""
-        Oops. It looks like {name} is not installed.
+        Oops. It looks like {name} is not installed. It will be available under venv/bin
+        and in PATH after running in turn:
+          script/setup
+          source venv/bin/activate.
 
         Please confirm you can run "{name} -version" or "{name}-{version} -version"
         in your terminal and install

--- a/script/clang-tidy
+++ b/script/clang-tidy
@@ -47,7 +47,7 @@ def get_binary(name, version):
         f"""
         Oops. It looks like {name} is not installed.
 
-        Please check you can run "{name} -version" or "{name}-{version} -version"
+        Please confirm you can run "{name} -version" or "{name}-{version} -version"
         in your terminal and install
         {name} (v{version}) if necessary.
 

--- a/script/clang-tidy
+++ b/script/clang-tidy
@@ -112,6 +112,8 @@ def clang_options(idedata):
     return cmd
 
 
+pids = set()
+
 def run_tidy(executable, args, options, tmpdir, queue, lock, failed_files):
     while True:
         path = queue.get()
@@ -256,7 +258,10 @@ def main():
         print("Ctrl-C detected, goodbye.")
         if tmpdir:
             shutil.rmtree(tmpdir)
-        return 2
+        # Kill subprocesses (and ourselves!)
+        # No simple, clean alternative appears to be available.
+        os.kill(0, 9)
+        return 2    # Will not execute.
 
     if args.fix and failed_files:
         print("Applying fixes ...")

--- a/script/clang-tidy
+++ b/script/clang-tidy
@@ -45,7 +45,10 @@ def get_binary(name, version):
 
     print(
         f"""
-        Oops. It looks like {name} is not installed.
+        Oops. It looks like {name} is not installed. It will be available under venv/bin
+        and in PATH after running in turn:
+          script/setup
+          source venv/bin/activate.
 
         Please confirm you can run "{name} -version" or "{name}-{version} -version"
         in your terminal and install

--- a/script/clang-tidy
+++ b/script/clang-tidy
@@ -11,6 +11,7 @@ from helpers import (
     load_idedata,
     root_path,
     basepath,
+    get_binary,
 )
 import argparse
 import click
@@ -25,41 +26,6 @@ import sys
 import tempfile
 import threading
 
-def get_binary(name, version):
-    clang_binary = f"{name}-{version}"
-    try:
-        result = subprocess.check_output([clang_binary, '-version'])
-        if result.returncode == 0:
-            return clang_binary
-    except Exception:
-        pass
-    clang_binary = name
-    try:
-        result = subprocess.run([clang_binary, '-version'], text=True, capture_output=True)
-        if result.returncode == 0 and (f"version {version}") in result.stdout:
-            return clang_binary
-        print(f"did not find version {version} in output: {result.stdout}")
-    except Exception as ex:
-        print(ex)
-        pass
-
-    print(
-        f"""
-        Oops. It looks like {name} is not installed. It will be available under venv/bin
-        and in PATH after running in turn:
-          script/setup
-          source venv/bin/activate.
-
-        Please confirm you can run "{name} -version" or "{name}-{version} -version"
-        in your terminal and install
-        {name} (v{version}) if necessary.
-
-        Note you can also upload your code as a pull request on GitHub and see the CI check
-        output to apply {name}
-        """
-    )
-    sys.exit()
- 
 
 
 def clang_options(idedata):
@@ -146,10 +112,10 @@ def clang_options(idedata):
     return cmd
 
 
-def run_tidy(args, options, tmpdir, queue, lock, failed_files):
+def run_tidy(executable, args, options, tmpdir, queue, lock, failed_files):
     while True:
         path = queue.get()
-        invocation = [get_binary("clang-tidy", 14)]
+        invocation = [executable]
 
         if tmpdir is not None:
             invocation.append("--export-fixes")
@@ -262,12 +228,13 @@ def main():
 
     failed_files = []
     try:
+        executable = get_binary("clang-tidy", 14)
         task_queue = queue.Queue(args.jobs)
         lock = threading.Lock()
         for _ in range(args.jobs):
             t = threading.Thread(
                 target=run_tidy,
-                args=(args, options, tmpdir, task_queue, lock, failed_files),
+                args=(executable, args, options, tmpdir, task_queue, lock, failed_files),
             )
             t.daemon = True
             t.start()
@@ -282,6 +249,8 @@ def main():
         # Wait for all threads to be done.
         task_queue.join()
 
+    except FileNotFoundError as ex:
+        pass
     except KeyboardInterrupt:
         print()
         print("Ctrl-C detected, goodbye.")

--- a/script/clang-tidy
+++ b/script/clang-tidy
@@ -250,13 +250,13 @@ def main():
         task_queue.join()
 
     except FileNotFoundError as ex:
-        pass
+        return 1
     except KeyboardInterrupt:
         print()
         print("Ctrl-C detected, goodbye.")
         if tmpdir:
             shutil.rmtree(tmpdir)
-        os.kill(0, 9)
+        return 2
 
     if args.fix and failed_files:
         print("Applying fixes ...")
@@ -266,8 +266,8 @@ def main():
             print("Error applying fixes.\n", file=sys.stderr)
             raise
 
-    sys.exit(len(failed_files))
+    return len(failed_files)
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/script/clang-tidy
+++ b/script/clang-tidy
@@ -25,6 +25,39 @@ import sys
 import tempfile
 import threading
 
+def get_binary(name, version):
+    clang_binary = f"{name}-{version}"
+    try:
+        result = subprocess.check_output([clang_binary, '-version'])
+        if result.returncode == 0:
+            return clang_binary
+    except Exception:
+        pass
+    clang_binary = name
+    try:
+        result = subprocess.run([clang_binary, '-version'], text=True, capture_output=True)
+        if result.returncode == 0 and (f"version {version}") in result.stdout:
+            return clang_binary
+        print(f"did not find version {version} in output: {result.stdout}")
+    except Exception as ex:
+        print(ex)
+        pass
+
+    print(
+        f"""
+        Oops. It looks like {name} is not installed.
+
+        Please check you can run "{name} -version" or "{name}-{version} -version"
+        in your terminal and install
+        {name} (v{version}) if necessary.
+
+        Note you can also upload your code as a pull request on GitHub and see the CI check
+        output to apply {name}
+        """
+    )
+    sys.exit()
+ 
+
 
 def clang_options(idedata):
     cmd = []
@@ -113,7 +146,7 @@ def clang_options(idedata):
 def run_tidy(args, options, tmpdir, queue, lock, failed_files):
     while True:
         path = queue.get()
-        invocation = ["clang-tidy-14"]
+        invocation = [get_binary("clang-tidy", 14)]
 
         if tmpdir is not None:
             invocation.append("--export-fixes")
@@ -192,22 +225,6 @@ def main():
         help="create a dummy file that checks all headers",
     )
     args = parser.parse_args()
-
-    try:
-        get_output("clang-tidy-14", "-version")
-    except:
-        print(
-            """
-        Oops. It looks like clang-tidy-14 is not installed.
-
-        Please check you can run "clang-tidy-14 -version" in your terminal and install
-        clang-tidy (v14) if necessary.
-
-        Note you can also upload your code as a pull request on GitHub and see the CI check
-        output to apply clang-tidy.
-        """
-        )
-        return 1
 
     idedata = load_idedata(args.environment)
     options = clang_options(idedata)

--- a/script/helpers.py
+++ b/script/helpers.py
@@ -170,23 +170,22 @@ def get_binary(name: str, version: str) -> str:
         )
         if result.returncode == 0 and (f"version {version}") in result.stdout:
             return binary_file
-        print(f"did not find version {version} in output: {result.stdout}")
+        raise FileNotFoundError(f"{name} not found")
+
     except FileNotFoundError as ex:
-        pass
+        print(
+            f"""
+            Oops. It looks like {name} is not installed. It should be available under venv/bin
+            and in PATH after running in turn:
+              script/setup
+              source venv/bin/activate.
 
-    print(
-        f"""
-        Oops. It looks like {name} is not installed. It should be available under venv/bin
-        and in PATH after running in turn:
-          script/setup
-          source venv/bin/activate.
+            Please confirm you can run "{name} -version" or "{name}-{version} -version"
+            in your terminal and install
+            {name} (v{version}) if necessary.
 
-        Please confirm you can run "{name} -version" or "{name}-{version} -version"
-        in your terminal and install
-        {name} (v{version}) if necessary.
-
-        Note you can also upload your code as a pull request on GitHub and see the CI check
-        output to apply {name}
-        """
-    )
-    raise FileNotFoundError(f"{name} not found")
+            Note you can also upload your code as a pull request on GitHub and see the CI check
+            output to apply {name}
+            """
+        )
+        raise

--- a/script/helpers.py
+++ b/script/helpers.py
@@ -153,3 +153,40 @@ def load_idedata(environment):
 
     temp_idedata.write_text(json.dumps(data, indent=2) + "\n")
     return data
+
+
+def get_binary(name, version):
+    binary_file = f"{name}-{version}"
+    try:
+        result = subprocess.check_output([binary_file, "-version"])
+        if result.returncode == 0:
+            return binary_file
+    except Exception:
+        pass
+    binary_file = name
+    try:
+        result = subprocess.run(
+            [binary_file, "-version"], text=True, capture_output=True
+        )
+        if result.returncode == 0 and (f"version {version}") in result.stdout:
+            return binary_file
+        print(f"did not find version {version} in output: {result.stdout}")
+    except FileNotFoundError as ex:
+        pass
+
+    print(
+        f"""
+        Oops. It looks like {name} is not installed. It should be available under venv/bin
+        and in PATH after running in turn:
+          script/setup
+          source venv/bin/activate.
+
+        Please confirm you can run "{name} -version" or "{name}-{version} -version"
+        in your terminal and install
+        {name} (v{version}) if necessary.
+
+        Note you can also upload your code as a pull request on GitHub and see the CI check
+        output to apply {name}
+        """
+    )
+    raise FileNotFoundError(f"{name} not found")

--- a/script/helpers.py
+++ b/script/helpers.py
@@ -155,7 +155,7 @@ def load_idedata(environment):
     return data
 
 
-def get_binary(name, version):
+def get_binary(name: str, version: str) -> str:
     binary_file = f"{name}-{version}"
     try:
         result = subprocess.check_output([binary_file, "-version"])

--- a/script/setup
+++ b/script/setup
@@ -15,7 +15,7 @@ if [ -n "$DEVCONTAINER" ];then
   git config --global --add safe.directory "$PWD"
 fi
 
-pip3 install -r requirements.txt -r requirements_optional.txt -r requirements_test.txt
+pip3 install -r requirements.txt -r requirements_optional.txt -r requirements_test.txt -r requirements_dev.txt
 pip3 install setuptools wheel
 pip3 install --no-use-pep517 -e .
 

--- a/script/setup
+++ b/script/setup
@@ -22,3 +22,7 @@ pip3 install --no-use-pep517 -e .
 pre-commit install
 
 script/platformio_install_deps.py platformio.ini --libraries --tools --platforms
+
+echo
+echo
+echo "Virtual environment created; source venv/bin/activate to use it"


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

The scripts `script/clang-format` and `script/clang-tidy` don't work well on a Mac with executables installed by
homebrew. This PR checks for either the plain executable name that reports the correct version or a versioned name, 

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
