### PR TITLE
GT911 touchscreen: Fix bug causing touch button release to fail

### DIFF
--- a/esphome/components/gt911/touchscreen/gt911_touchscreen.cpp
+++ b/esphome/components/gt911/touchscreen/gt911_touchscreen.cpp
@@ -14,6 +14,7 @@ static const uint8_t GET_TOUCHES[2] = {0x81, 0x4F};
 static const uint8_t GET_SWITCHES[2] = {0x80, 0x4D};
 static const uint8_t GET_MAX_VALUES[2] = {0x80, 0x48};
 static const size_t MAX_TOUCHES = 5;  // max number of possible touches reported
+static const size_t MAX_BUTTONS = 4;  // max number of buttons scanned
 
 #define ERROR_CHECK(err) \
   if ((err) != i2c::ERROR_OK) { \
@@ -91,10 +92,13 @@ void GT911Touchscreen::update_touches() {
     uint16_t y = encode_uint16(data[i][4], data[i][3]);
     this->add_raw_touch_position_(id, x, y);
   }
-  auto keys = data[num_of_touches][0];
-  for (size_t i = 0; i != 4; i++) {
-    for (auto *listener : this->button_listeners_)
-      listener->update_button(i, (keys & (1 << i)) != 0);
+  auto keys = data[num_of_touches][0] & ((1 << MAX_BUTTONS) - 1);
+  if (keys != this->button_state_) {
+    this->button_state_ = keys;
+    for (size_t i = 0; i != MAX_BUTTONS; i++) {
+      for (auto *listener : this->button_listeners_)
+        listener->update_button(i, (keys & (1 << i)) != 0);
+    }
   }
 }
 

--- a/esphome/components/gt911/touchscreen/gt911_touchscreen.cpp
+++ b/esphome/components/gt911/touchscreen/gt911_touchscreen.cpp
@@ -79,9 +79,6 @@ void GT911Touchscreen::update_touches() {
     return;
   }
 
-  if (num_of_touches == 0)
-    return;
-
   err = this->write(GET_TOUCHES, sizeof(GET_TOUCHES), false);
   ERROR_CHECK(err);
   // num_of_touches is guaranteed to be 0..5. Also read the key data

--- a/esphome/components/gt911/touchscreen/gt911_touchscreen.h
+++ b/esphome/components/gt911/touchscreen/gt911_touchscreen.h
@@ -26,6 +26,7 @@ class GT911Touchscreen : public touchscreen::Touchscreen, public i2c::I2CDevice 
 
   InternalGPIOPin *interrupt_pin_{};
   std::vector<GT911ButtonListener *> button_listeners_;
+  uint8_t button_state_{0xFF};  // last button state. Initial FF guarantees first update.
 };
 
 }  // namespace gt911


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Recent changes to the touchscreen components introduced a bug in the GT911 that resulted in a release of a touch button (e.g. the red button on an S3BOX-3) to not be notified.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
