### PR TITLE
analog_threshold: Publish state only when available

### DIFF
--- a/esphome/components/analog_threshold/analog_threshold_binary_sensor.cpp
+++ b/esphome/components/analog_threshold/analog_threshold_binary_sensor.cpp
@@ -7,29 +7,30 @@ namespace analog_threshold {
 static const char *const TAG = "analog_threshold.binary_sensor";
 
 void AnalogThresholdBinarySensor::setup() {
-  float sensor_value = this->sensor_->get_state();
-
-  // TRUE state is defined to be when sensor is >= threshold
-  // so when undefined sensor value initialize to FALSE
-  if (std::isnan(sensor_value)) {
-    this->publish_initial_state(false);
-  } else {
-    this->publish_initial_state(sensor_value >=
-                                (this->lower_threshold_.value() + this->upper_threshold_.value()) / 2.0f);
-  }
-}
-
-void AnalogThresholdBinarySensor::set_sensor(sensor::Sensor *analog_sensor) {
-  this->sensor_ = analog_sensor;
-
   this->sensor_->add_on_state_callback([this](float sensor_value) {
-    // if there is an invalid sensor reading, ignore the change and keep the current state
-    if (!std::isnan(sensor_value)) {
-      this->publish_state(sensor_value >=
-                          (this->state ? this->lower_threshold_.value() : this->upper_threshold_.value()));
+    if (std::isnan(sensor_value)) {
+      // If there is an invalid sensor reading, ignore the change and keep the current state.
+      // As an alternative, we could call this->invalidate_state() here, but that would be
+      // a breaking change without a config option to enable it.
+      return;
     }
+
+    float threshold;
+    if (!this->has_state()) {
+      // No prior state, use the midpoint of the thresholds.
+      threshold = (this->lower_threshold_.value() + this->upper_threshold_.value()) / 2.0f;
+    } else if (this->state) {
+      // Currently TRUE, use lower_threshold for comparison.
+      threshold = this->lower_threshold_.value();
+    } else {
+      // Currently FALSE, use upper_threshold for comparison.
+      threshold = this->upper_threshold_.value();
+    }
+    this->publish_state(sensor_value >= threshold);
   });
 }
+
+void AnalogThresholdBinarySensor::set_sensor(sensor::Sensor *analog_sensor) { this->sensor_ = analog_sensor; }
 
 void AnalogThresholdBinarySensor::dump_config() {
   LOG_BINARY_SENSOR("", "Analog Threshold Binary Sensor", this);


### PR DESCRIPTION
This avoids spurious triggers since most sensors won't have state during setup().

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/5325

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
esphome:
  name: water-meter
  friendly_name: Water meter

esp32:
  board: adafruit_qtpy_esp32s2
  framework:
    type: esp-idf
    platform_version: 6.4.0
    version: 5.1.2
    sdkconfig_options:
      CONFIG_ESP_CONSOLE_USB_CDC: n

time:
  - platform: homeassistant
    id: homeassistant_time
    on_time:
      - seconds: 0
        minutes: 0
        hours: 0
        then:
          - globals.set:
              id: pulse_count
              value: '0'

globals:
  - id: pulse_count
    type: int

i2c:
  sda: 41
  scl: 40
  scan: true
  frequency: 400kHz

sensor:
  - platform: mmc5983
    field_strength_z:
      id: magnet_z
    update_interval: 50ms

  - platform: copy
    source_id: magnet_z
    name: "Magnetic field strength"
    filters:
      - throttle: 1s
    entity_category: DIAGNOSTIC

  - platform: template
    id: total_daily_water
    name: "Total daily water consumption"
    unit_of_measurement: gal
    device_class: water
    state_class: total_increasing
    accuracy_decimals: 3
    update_interval: 1s
    lambda: "return id(pulse_count) / 64.0;"

binary_sensor:
  - platform: analog_threshold
    id: magnet_threshold
    sensor_id: magnet_z
    threshold:
      lower: -0.0137
      upper: 0.0063
    on_state:
      then:
        - lambda: "id(pulse_count)++;"

# Enable logging
logger:

# Enable Home Assistant API
api:

wifi:
  ssid: !secret wifi_ssid
  password: !secret wifi_password

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
