### PR TITLE
make capability for mlx90615 derived from mlx90614

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -195,6 +195,7 @@ esphome/components/midea_ir/* @dudanov
 esphome/components/mitsubishi/* @RubyBailey
 esphome/components/mlx90393/* @functionpointer
 esphome/components/mlx90614/* @jesserockz
+esphome/components/mlx90615/* @goatchurchprime
 esphome/components/mmc5603/* @benhoff
 esphome/components/mmc5983/* @agoode
 esphome/components/modbus_controller/* @martgras

--- a/esphome/components/mlx90615/mlx90615.cpp
+++ b/esphome/components/mlx90615/mlx90615.cpp
@@ -1,0 +1,108 @@
+#include "mlx90615.h"
+
+#include "esphome/core/hal.h"
+#include "esphome/core/log.h"
+
+namespace esphome {
+namespace mlx90615 {
+
+static const uint8_t MLX90615_EMISSIVITY = 0x13;
+static const uint8_t MLX90615_TEMPERATURE_AMBIENT = 0x26;
+static const uint8_t MLX90615_TEMPERATURE_OBJECT = 0x27;
+
+static const char *const TAG = "mlx90615";
+
+void MLX90615Component::setup() {
+  ESP_LOGCONFIG(TAG, "Setting up MLX90615...");
+  if (!this->write_emissivity_()) {
+    ESP_LOGE(TAG, "Communication with MLX90615 failed!");
+    this->mark_failed();
+    return;
+  }
+}
+
+bool MLX90615Component::write_emissivity_() {
+  if (std::isnan(this->emissivity_))
+    return true;
+  uint16_t value = (uint16_t) (this->emissivity_ * 65535);
+  if (!this->write_bytes_(MLX90615_EMISSIVITY, 0)) {
+    return false;
+  }
+  delay(10);
+  if (!this->write_bytes_(MLX90615_EMISSIVITY, value)) {
+    return false;
+  }
+  delay(10);
+  return true;
+}
+
+uint8_t MLX90615Component::crc8_pec_(const uint8_t *data, uint8_t len) {
+  uint8_t crc = 0;
+  for (uint8_t i = 0; i < len; i++) {
+    uint8_t in = data[i];
+    for (uint8_t j = 0; j < 8; j++) {
+      bool carry = (crc ^ in) & 0x80;
+      crc <<= 1;
+      if (carry)
+        crc ^= 0x07;
+      in <<= 1;
+    }
+  }
+  return crc;
+}
+
+bool MLX90615Component::write_bytes_(uint8_t reg, uint16_t data) {
+  uint8_t buf[5];
+  buf[0] = this->address_ << 1;
+  buf[1] = reg;
+  buf[2] = data & 0xFF;
+  buf[3] = data >> 8;
+  buf[4] = this->crc8_pec_(buf, 4);
+  return this->write_bytes(reg, buf + 2, 3);
+}
+
+void MLX90615Component::dump_config() {
+  ESP_LOGCONFIG(TAG, "MLX90615:");
+  LOG_I2C_DEVICE(this);
+  if (this->is_failed()) {
+    ESP_LOGE(TAG, "Communication with MLX90615 failed!");
+  }
+  LOG_UPDATE_INTERVAL(this);
+  LOG_SENSOR("  ", "Ambient", this->ambient_sensor_);
+  LOG_SENSOR("  ", "Object", this->object_sensor_);
+}
+
+float MLX90615Component::get_setup_priority() const { return setup_priority::DATA; }
+
+void MLX90615Component::update() {
+  uint8_t emissivity[3];
+  if (this->read_register(MLX90615_EMISSIVITY, emissivity, 3, false) != i2c::ERROR_OK) {
+    this->status_set_warning();
+    return;
+  }
+  uint8_t raw_object[3];
+  if (this->read_register(MLX90615_TEMPERATURE_OBJECT, raw_object, 3, false) != i2c::ERROR_OK) {
+    this->status_set_warning();
+    return;
+  }
+
+  uint8_t raw_ambient[3];
+  if (this->read_register(MLX90615_TEMPERATURE_AMBIENT, raw_ambient, 3, false) != i2c::ERROR_OK) {
+    this->status_set_warning();
+    return;
+  }
+
+  float ambient = raw_ambient[1] & 0x80 ? NAN : encode_uint16(raw_ambient[1], raw_ambient[0]) * 0.02f - 273.15f;
+  float object = raw_object[1] & 0x80 ? NAN : encode_uint16(raw_object[1], raw_object[0]) * 0.02f - 273.15f;
+
+  ESP_LOGD(TAG, "Got Temperature=%.1f°C Ambient=%.1f°C", object, ambient);
+
+  if (this->ambient_sensor_ != nullptr && !std::isnan(ambient))
+    this->ambient_sensor_->publish_state(ambient);
+  if (this->object_sensor_ != nullptr && !std::isnan(object))
+    this->object_sensor_->publish_state(object);
+  this->status_clear_warning();
+}
+
+}  // namespace mlx90615
+}  // namespace esphome

--- a/esphome/components/mlx90615/mlx90615.h
+++ b/esphome/components/mlx90615/mlx90615.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "esphome/components/i2c/i2c.h"
+#include "esphome/components/sensor/sensor.h"
+#include "esphome/core/component.h"
+
+namespace esphome {
+namespace mlx90615 {
+
+class MLX90615Component : public PollingComponent, public i2c::I2CDevice {
+ public:
+  void setup() override;
+  void dump_config() override;
+  void update() override;
+  float get_setup_priority() const override;
+
+  void set_ambient_sensor(sensor::Sensor *ambient_sensor) { ambient_sensor_ = ambient_sensor; }
+  void set_object_sensor(sensor::Sensor *object_sensor) { object_sensor_ = object_sensor; }
+
+  void set_emissivity(float emissivity) { emissivity_ = emissivity; }
+
+ protected:
+  bool write_emissivity_();
+
+  uint8_t crc8_pec_(const uint8_t *data, uint8_t len);
+  bool write_bytes_(uint8_t reg, uint16_t data);
+
+  sensor::Sensor *ambient_sensor_{nullptr};
+  sensor::Sensor *object_sensor_{nullptr};
+
+  float emissivity_{NAN};
+};
+}  // namespace mlx90615
+}  // namespace esphome

--- a/esphome/components/mlx90615/sensor.py
+++ b/esphome/components/mlx90615/sensor.py
@@ -1,0 +1,63 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import i2c, sensor
+from esphome.const import (
+    CONF_ID,
+    DEVICE_CLASS_TEMPERATURE,
+    STATE_CLASS_MEASUREMENT,
+    UNIT_CELSIUS,
+)
+
+CODEOWNERS = ["@goatchurchprime"]
+DEPENDENCIES = ["i2c"]
+
+CONF_AMBIENT = "ambient"
+CONF_EMISSIVITY = "emissivity"
+CONF_OBJECT = "object"
+
+mlx90615_ns = cg.esphome_ns.namespace("mlx90615")
+MLX90615Component = mlx90615_ns.class_(
+    "MLX90615Component", cg.PollingComponent, i2c.I2CDevice
+)
+
+CONFIG_SCHEMA = (
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.declare_id(MLX90615Component),
+            cv.Optional(CONF_AMBIENT): sensor.sensor_schema(
+                unit_of_measurement=UNIT_CELSIUS,
+                accuracy_decimals=1,
+                device_class=DEVICE_CLASS_TEMPERATURE,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ),
+            cv.Optional(CONF_OBJECT): sensor.sensor_schema(
+                unit_of_measurement=UNIT_CELSIUS,
+                accuracy_decimals=1,
+                device_class=DEVICE_CLASS_TEMPERATURE,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ).extend(
+                {
+                    cv.Optional(CONF_EMISSIVITY, default=1.0): cv.percentage,
+                }
+            ),
+        }
+    )
+    .extend(cv.polling_component_schema("60s"))
+    .extend(i2c.i2c_device_schema(0x5B))
+)
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+    await i2c.register_i2c_device(var, config)
+
+    if CONF_AMBIENT in config:
+        sens = await sensor.new_sensor(config[CONF_AMBIENT])
+        cg.add(var.set_ambient_sensor(sens))
+
+    if CONF_OBJECT in config:
+        sens = await sensor.new_sensor(config[CONF_OBJECT])
+        cg.add(var.set_object_sensor(sens))
+
+        cg.add(var.set_emissivity(config[CONF_OBJECT][CONF_EMISSIVITY]))

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -1388,6 +1388,13 @@ sensor:
     object:
       name: Object
       emissivity: 1.0
+  - platform: mlx90615
+    i2c_id: i2c_bus
+    ambient:
+      name: Ambient
+    object:
+      name: Object
+      emissivity: 1.0
   - platform: mpl3115a2
     i2c_id: i2c_bus
     temperature:


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
sensor:
  - platform: mlx90615
    ambient:
      name: Ambient
    object:
      name: Object
    update_interval: 5s
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
