### PR TITLE
Nextion enable upload from https when using esp-idf

### DIFF
--- a/esphome/components/nextion/display.py
+++ b/esphome/components/nextion/display.py
@@ -99,8 +99,12 @@ async def to_code(config):
             cg.add_library("HTTPClient", None)
         elif CORE.is_esp32 and CORE.using_esp_idf:
             esp32.add_idf_sdkconfig_option("CONFIG_ESP_TLS_INSECURE", True)
-            esp32.add_idf_sdkconfig_option("CONFIG_ESP_TLS_SKIP_SERVER_CERT_VERIFY", True)
-            esp32.add_idf_sdkconfig_option("CONFIG_ESP_HTTP_CLIENT_ENABLE_HTTP_REDIRECT", True)
+            esp32.add_idf_sdkconfig_option(
+                "CONFIG_ESP_TLS_SKIP_SERVER_CERT_VERIFY", True
+            )
+            esp32.add_idf_sdkconfig_option(
+                "CONFIG_ESP_HTTP_CLIENT_ENABLE_HTTP_REDIRECT", True
+            )
         elif CORE.is_esp8266 and CORE.using_arduino:
             cg.add_library("ESP8266HTTPClient", None)
 

--- a/esphome/components/nextion/display.py
+++ b/esphome/components/nextion/display.py
@@ -102,9 +102,6 @@ async def to_code(config):
             esp32.add_idf_sdkconfig_option(
                 "CONFIG_ESP_TLS_SKIP_SERVER_CERT_VERIFY", True
             )
-            esp32.add_idf_sdkconfig_option(
-                "CONFIG_ESP_HTTP_CLIENT_ENABLE_HTTP_REDIRECT", True
-            )
         elif CORE.is_esp8266 and CORE.using_arduino:
             cg.add_library("ESP8266HTTPClient", None)
 

--- a/esphome/components/nextion/display.py
+++ b/esphome/components/nextion/display.py
@@ -2,6 +2,7 @@ import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome import automation
 from esphome.components import display, uart
+from esphome.components import esp32
 from esphome.const import (
     CONF_ID,
     CONF_LAMBDA,
@@ -96,6 +97,10 @@ async def to_code(config):
         if CORE.is_esp32 and CORE.using_arduino:
             cg.add_library("WiFiClientSecure", None)
             cg.add_library("HTTPClient", None)
+        elif CORE.is_esp32 and CORE.using_esp_idf:
+            esp32.add_idf_sdkconfig_option("CONFIG_ESP_TLS_INSECURE", True)
+            esp32.add_idf_sdkconfig_option("CONFIG_ESP_TLS_SKIP_SERVER_CERT_VERIFY", True)
+            esp32.add_idf_sdkconfig_option("CONFIG_ESP_HTTP_CLIENT_ENABLE_HTTP_REDIRECT", True)
         elif CORE.is_esp8266 and CORE.using_arduino:
             cg.add_library("ESP8266HTTPClient", None)
 

--- a/esphome/components/nextion/nextion_upload_idf.cpp
+++ b/esphome/components/nextion/nextion_upload_idf.cpp
@@ -37,6 +37,9 @@ int Nextion::upload_range(const std::string &url, int range_start) {
   esp_http_client_config_t config = {
       .url = url.c_str(),
       .cert_pem = nullptr,
+      .timeout_ms = 15000,
+      .disable_auto_redirect = false,
+      .max_redirection_count = 10,
   };
   esp_http_client_handle_t client = esp_http_client_init(&config);
 
@@ -151,6 +154,8 @@ bool Nextion::upload_tft() {
       .cert_pem = nullptr,
       .method = HTTP_METHOD_HEAD,
       .timeout_ms = 15000,
+      .disable_auto_redirect = false,
+      .max_redirection_count = 10,
   };
 
   // Initialize the HTTP client with the configuration

--- a/esphome/components/nextion/nextion_upload_idf.cpp
+++ b/esphome/components/nextion/nextion_upload_idf.cpp
@@ -37,7 +37,6 @@ int Nextion::upload_range(const std::string &url, int range_start) {
   esp_http_client_config_t config = {
       .url = url.c_str(),
       .cert_pem = nullptr,
-      .timeout_ms = 15000,
       .disable_auto_redirect = false,
       .max_redirection_count = 10,
   };

--- a/esphome/components/nextion/nextion_upload_idf.cpp
+++ b/esphome/components/nextion/nextion_upload_idf.cpp
@@ -24,7 +24,7 @@ int Nextion::upload_range(const std::string &url, int range_start) {
   ESP_LOGVV(TAG, "url: %s", url.c_str());
   uint range_size = this->tft_size_ - range_start;
   ESP_LOGVV(TAG, "tft_size_: %i", this->tft_size_);
-  ESP_LOGV(TAG, "Available heap: %lu", esp_get_free_heap_size());
+  ESP_LOGV(TAG, "Available heap: %" PRIu32, esp_get_free_heap_size());
   int range_end = (range_start == 0) ? std::min(this->tft_size_, 16383) : this->tft_size_;
   if (range_size <= 0 or range_end <= range_start) {
     ESP_LOGE(TAG, "Invalid range");
@@ -44,7 +44,7 @@ int Nextion::upload_range(const std::string &url, int range_start) {
   sprintf(range_header, "bytes=%d-%d", range_start, range_end);
   ESP_LOGV(TAG, "Requesting range: %s", range_header);
   esp_http_client_set_header(client, "Range", range_header);
-  ESP_LOGVV(TAG, "Available heap: %lu", esp_get_free_heap_size());
+  ESP_LOGVV(TAG, "Available heap: %" PRIu32, esp_get_free_heap_size());
 
   ESP_LOGV(TAG, "Opening http connetion");
   esp_err_t err;
@@ -70,13 +70,13 @@ int Nextion::upload_range(const std::string &url, int range_start) {
   std::string recv_string;
   if (buffer == nullptr) {
     ESP_LOGE(TAG, "Failed to allocate memory for buffer");
-    ESP_LOGV(TAG, "Available heap: %lu", esp_get_free_heap_size());
+    ESP_LOGV(TAG, "Available heap: %" PRIu32, esp_get_free_heap_size());
   } else {
     ESP_LOGV(TAG, "Memory for buffer allocated successfully");
 
     while (true) {
       App.feed_wdt();
-      ESP_LOGVV(TAG, "Available heap: %lu", esp_get_free_heap_size());
+      ESP_LOGVV(TAG, "Available heap: %" PRIu32, esp_get_free_heap_size());
       int read_len = esp_http_client_read(client, reinterpret_cast<char *>(buffer), 4096);
       ESP_LOGVV(TAG, "Read %d bytes from HTTP client, writing to UART", read_len);
       if (read_len > 0) {
@@ -145,7 +145,7 @@ bool Nextion::upload_tft() {
 
   // Define the configuration for the HTTP client
   ESP_LOGV(TAG, "Establishing connection to HTTP server");
-  ESP_LOGVV(TAG, "Available heap: %lu", esp_get_free_heap_size());
+  ESP_LOGVV(TAG, "Available heap: %" PRIu32, esp_get_free_heap_size());
   esp_http_client_config_t config = {
       .url = this->tft_url_.c_str(),
       .cert_pem = nullptr,
@@ -155,7 +155,7 @@ bool Nextion::upload_tft() {
 
   // Initialize the HTTP client with the configuration
   ESP_LOGV(TAG, "Initializing HTTP client");
-  ESP_LOGV(TAG, "Available heap: %lu", esp_get_free_heap_size());
+  ESP_LOGV(TAG, "Available heap: %" PRIu32, esp_get_free_heap_size());
   esp_http_client_handle_t http = esp_http_client_init(&config);
   if (!http) {
     ESP_LOGE(TAG, "Failed to initialize HTTP client.");
@@ -164,7 +164,7 @@ bool Nextion::upload_tft() {
 
   // Perform the HTTP request
   ESP_LOGV(TAG, "Check if the client could connect");
-  ESP_LOGV(TAG, "Available heap: %lu", esp_get_free_heap_size());
+  ESP_LOGV(TAG, "Available heap: %" PRIu32, esp_get_free_heap_size());
   esp_err_t err = esp_http_client_perform(http);
   if (err != ESP_OK) {
     ESP_LOGE(TAG, "HTTP request failed: %s", esp_err_to_name(err));

--- a/esphome/components/nextion/nextion_upload_idf.cpp
+++ b/esphome/components/nextion/nextion_upload_idf.cpp
@@ -24,7 +24,7 @@ int Nextion::upload_range(const std::string &url, int range_start) {
   ESP_LOGVV(TAG, "url: %s", url.c_str());
   uint range_size = this->tft_size_ - range_start;
   ESP_LOGVV(TAG, "tft_size_: %i", this->tft_size_);
-  ESP_LOGV(TAG, "Available heap: %u", esp_get_free_heap_size());
+  ESP_LOGV(TAG, "Available heap: %lu", esp_get_free_heap_size());
   int range_end = (range_start == 0) ? std::min(this->tft_size_, 16383) : this->tft_size_;
   if (range_size <= 0 or range_end <= range_start) {
     ESP_LOGE(TAG, "Invalid range");
@@ -155,7 +155,7 @@ bool Nextion::upload_tft() {
 
   // Initialize the HTTP client with the configuration
   ESP_LOGV(TAG, "Initializing HTTP client");
-  ESP_LOGV(TAG, "Available heap: %u", esp_get_free_heap_size());
+  ESP_LOGV(TAG, "Available heap: %lu", esp_get_free_heap_size());
   esp_http_client_handle_t http = esp_http_client_init(&config);
   if (!http) {
     ESP_LOGE(TAG, "Failed to initialize HTTP client.");
@@ -164,7 +164,7 @@ bool Nextion::upload_tft() {
 
   // Perform the HTTP request
   ESP_LOGV(TAG, "Check if the client could connect");
-  ESP_LOGV(TAG, "Available heap: %u", esp_get_free_heap_size());
+  ESP_LOGV(TAG, "Available heap: %lu", esp_get_free_heap_size());
   esp_err_t err = esp_http_client_perform(http);
   if (err != ESP_OK) {
     ESP_LOGE(TAG, "HTTP request failed: %s", esp_err_to_name(err));

--- a/esphome/components/nextion/nextion_upload_idf.cpp
+++ b/esphome/components/nextion/nextion_upload_idf.cpp
@@ -260,7 +260,7 @@ bool Nextion::upload_end(bool successful) {
   this->soft_reset();
   vTaskDelay(pdMS_TO_TICKS(1500));  // NOLINT
   if (successful) {
-    ESP_LOGD(TAG, "Restarting esphome");
+    ESP_LOGD(TAG, "Restarting ESPHome");
     esp_restart();  // NOLINT(readability-static-accessed-through-instance)
   }
   return successful;

--- a/esphome/components/nextion/nextion_upload_idf.cpp
+++ b/esphome/components/nextion/nextion_upload_idf.cpp
@@ -44,7 +44,7 @@ int Nextion::upload_range(const std::string &url, int range_start) {
   sprintf(range_header, "bytes=%d-%d", range_start, range_end);
   ESP_LOGV(TAG, "Requesting range: %s", range_header);
   esp_http_client_set_header(client, "Range", range_header);
-  ESP_LOGVV(TAG, "Available heap: %u", esp_get_free_heap_size());
+  ESP_LOGVV(TAG, "Available heap: %lu", esp_get_free_heap_size());
 
   ESP_LOGV(TAG, "Opening http connetion");
   esp_err_t err;
@@ -70,13 +70,13 @@ int Nextion::upload_range(const std::string &url, int range_start) {
   std::string recv_string;
   if (buffer == nullptr) {
     ESP_LOGE(TAG, "Failed to allocate memory for buffer");
-    ESP_LOGV(TAG, "Available heap: %u", esp_get_free_heap_size());
+    ESP_LOGV(TAG, "Available heap: %lu", esp_get_free_heap_size());
   } else {
     ESP_LOGV(TAG, "Memory for buffer allocated successfully");
 
     while (true) {
       App.feed_wdt();
-      ESP_LOGVV(TAG, "Available heap: %u", esp_get_free_heap_size());
+      ESP_LOGVV(TAG, "Available heap: %lu", esp_get_free_heap_size());
       int read_len = esp_http_client_read(client, reinterpret_cast<char *>(buffer), 4096);
       ESP_LOGVV(TAG, "Read %d bytes from HTTP client, writing to UART", read_len);
       if (read_len > 0) {
@@ -145,7 +145,7 @@ bool Nextion::upload_tft() {
 
   // Define the configuration for the HTTP client
   ESP_LOGV(TAG, "Establishing connection to HTTP server");
-  ESP_LOGVV(TAG, "Available heap: %u", esp_get_free_heap_size());
+  ESP_LOGVV(TAG, "Available heap: %lu", esp_get_free_heap_size());
   esp_http_client_config_t config = {
       .url = this->tft_url_.c_str(),
       .cert_pem = nullptr,


### PR DESCRIPTION
# What does this implement/fix?

The implementation of ESP-IDF support wasn't preventing httpS requests. This adds this capability by handling in the same way as it was done for `arduino`.
If fact, the https request worked pretty well on my tests.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [X] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
N/A

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
