### PR TITLE
Add an optional binary_sensor to digital signals components

### DIFF
--- a/esphome/components/pulse_counter/pulse_counter_sensor.cpp
+++ b/esphome/components/pulse_counter/pulse_counter_sensor.cpp
@@ -180,6 +180,13 @@ void PulseCounterSensor::update() {
     ESP_LOGD(TAG, "'%s': Total : %" PRIu32 " pulses", this->get_name().c_str(), current_total_);
     this->total_sensor_->publish_state(current_total_);
   }
+
+  if (this->binary_sensor_ != nullptr) {
+    bool level = this->storage_.pin->digital_read();
+    ESP_LOGD(TAG, "'%s': Sending state %s", this->get_name().c_str(), ONOFF(level));
+    this->binary_sensor_->publish_state(level);
+  }
+
   this->last_time_ = now;
 }
 

--- a/esphome/components/pulse_counter/pulse_counter_sensor.h
+++ b/esphome/components/pulse_counter/pulse_counter_sensor.h
@@ -69,6 +69,7 @@ class PulseCounterSensor : public sensor::Sensor, public PollingComponent {
   void set_falling_edge_mode(PulseCounterCountMode mode) { storage_.falling_edge_mode = mode; }
   void set_filter_us(uint32_t filter) { storage_.filter_us = filter; }
   void set_total_sensor(sensor::Sensor *total_sensor) { total_sensor_ = total_sensor; }
+  void set_binary_sensor(sensor::Sensor *binary_sensor) { binary_sensor_ = binary_sensor; }
 
   void set_total_pulses(uint32_t pulses);
 
@@ -84,6 +85,7 @@ class PulseCounterSensor : public sensor::Sensor, public PollingComponent {
   uint32_t last_time_{0};
   uint32_t current_total_{0};
   sensor::Sensor *total_sensor_{nullptr};
+  sensor::Sensor *binary_sensor_{nullptr};
 };
 
 }  // namespace pulse_counter

--- a/esphome/components/pulse_counter/sensor.py
+++ b/esphome/components/pulse_counter/sensor.py
@@ -3,6 +3,7 @@ import esphome.config_validation as cv
 from esphome import automation, pins
 from esphome.components import sensor
 from esphome.const import (
+    CONF_BINARY_SENSOR,
     CONF_COUNT_MODE,
     CONF_FALLING_EDGE,
     CONF_ID,
@@ -115,6 +116,7 @@ CONFIG_SCHEMA = cv.All(
                 accuracy_decimals=0,
                 state_class=STATE_CLASS_TOTAL_INCREASING,
             ),
+            cv.Optional(CONF_BINARY_SENSOR): sensor.sensor_schema(),
         },
     )
     .extend(cv.polling_component_schema("60s")),
@@ -136,6 +138,10 @@ async def to_code(config):
     if CONF_TOTAL in config:
         sens = await sensor.new_sensor(config[CONF_TOTAL])
         cg.add(var.set_total_sensor(sens))
+
+    if CONF_BINARY_SENSOR in config:
+        bsens = await sensor.new_sensor(config[CONF_BINARY_SENSOR])
+        cg.add(var.set_binary_sensor(bsens))
 
 
 @automation.register_action(


### PR DESCRIPTION
# What does this implement/fix?

This PR add the option to use a "Digital Signal" component also as binary sensor.

The need arises from the automation of a BFT gate where the SCA (Gate Open Indicator) signal is open (HIGH) if the gate is open, closed (LOW) if the gate is full close and blink (intermittent LOW/HIGH) if the gate is closing.

Ref: [BFT PHEBE TECNICAL MANUAL](https://www.atecnica.it/file/manuale-istruzioni-bft-vega-centrale-scheda-elettronica-di-comando-bft-phebe-basculante-i700062-10001.pdf)



## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#3514

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040
- [x] BK72xx
- [x] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
- platform: pulse_counter
    pin:
      number: D7
      mode: INPUT_PULLUP
      inverted: True
    id: sca_pulse
    name: "Pulse Counter"
    update_interval: 1s
    binary_sensor:
        id: cover_open
        internal: True    
    filters:
      - filter_out: nan
      - throttle_average: 2s
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
