### PR TITLE
Don't crash with invalid adc pin

### DIFF
--- a/esphome/components/adc/__init__.py
+++ b/esphome/components/adc/__init__.py
@@ -139,6 +139,12 @@ ESP32_VARIANT_ADC2_PIN_TO_CHANNEL = {
     VARIANT_ESP32C3: {
         5: adc2_channel_t.ADC2_CHANNEL_0,
     },
+    VARIANT_ESP32C2: {
+    },
+    VARIANT_ESP32C6: {
+    },
+    VARIANT_ESP32H2: {
+    },
 }
 
 

--- a/esphome/components/adc/__init__.py
+++ b/esphome/components/adc/__init__.py
@@ -139,12 +139,9 @@ ESP32_VARIANT_ADC2_PIN_TO_CHANNEL = {
     VARIANT_ESP32C3: {
         5: adc2_channel_t.ADC2_CHANNEL_0,
     },
-    VARIANT_ESP32C2: {
-    },
-    VARIANT_ESP32C6: {
-    },
-    VARIANT_ESP32H2: {
-    },
+    VARIANT_ESP32C2: {},
+    VARIANT_ESP32C6: {},
+    VARIANT_ESP32H2: {},
 }
 
 


### PR DESCRIPTION
# What does this implement/fix?

For C2, C6, or H2, if an invalid pin is used, the parser will crash instead of giving a nice message.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
