### PR TITLE
pylontech: fix voltage_low and voltage_high wrong unit

### DIFF
--- a/esphome/components/pylontech/sensor/__init__.py
+++ b/esphome/components/pylontech/sensor/__init__.py
@@ -59,14 +59,14 @@ TYPES: dict[str, cv.Schema] = {
         device_class=DEVICE_CLASS_TEMPERATURE,
     ),
     CONF_VOLTAGE_LOW: sensor.sensor_schema(
-        unit_of_measurement=UNIT_CELSIUS,
-        accuracy_decimals=1,
-        device_class=DEVICE_CLASS_TEMPERATURE,
+        unit_of_measurement=UNIT_VOLT,
+        accuracy_decimals=3,
+        device_class=DEVICE_CLASS_VOLTAGE,
     ),
     CONF_VOLTAGE_HIGH: sensor.sensor_schema(
-        unit_of_measurement=UNIT_CELSIUS,
-        accuracy_decimals=1,
-        device_class=DEVICE_CLASS_TEMPERATURE,
+        unit_of_measurement=UNIT_VOLT,
+        accuracy_decimals=3,
+        device_class=DEVICE_CLASS_VOLTAGE,
     ),
     CONF_COULOMB: sensor.sensor_schema(
         unit_of_measurement=UNIT_PERCENT,


### PR DESCRIPTION
`voltage_low` and `voltage_high` were described as temperature sensors.
This PR fixes that.
Additionally, the documentation is fixed to actually describe the sensors.

Thanks to @Dackara for finding this bug.

## Renaming sensors

@Dackara's [patch set](https://github.com/Dackara/esphome-pylontech/commit/df7b96f0095b308870f2d5008d5430d6c7dcc34e) also suggests renaming some sensors:
| current name | @Dakara's suggestion |
|--------------|----------------------|
| voltage_low  | cell_low             |
| voltage_high | cell_high            |
| coulomb      | capacity             |

While those names would be more clear, they would no longer match the names from the output of the batteries.
This could introduce more confusion when debugging and comparing with other pylontech logging software.
I don't think the sensors should be renamed, which is why this PR does not include any name changes.
Instead, the documentation is updated to tell the user what the values mean.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** partially addresses https://github.com/esphome/feature-requests/issues/2544

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#3519

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
pylontech:

sensor:
  - platform: pylontech
    battery: 1

    voltage_low:
      name: "Battery1 min cell voltage"
    voltage_high:
      name: "Battery1 max cell voltage"
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
