### PR TITLE
pylontech: Fix parsing error with US2000

### DIFF
--- a/esphome/components/pylontech/__init__.py
+++ b/esphome/components/pylontech/__init__.py
@@ -19,7 +19,7 @@ PylontechComponent = pylontech_ns.class_(
 )
 PylontechBattery = pylontech_ns.class_("PylontechBattery")
 
-CV_NUM_BATTERIES = cv.int_range(1, 6)
+CV_NUM_BATTERIES = cv.int_range(1, 16)
 
 PYLONTECH_COMPONENT_SCHEMA = cv.Schema(
     {

--- a/esphome/components/pylontech/pylontech.cpp
+++ b/esphome/components/pylontech/pylontech.cpp
@@ -72,10 +72,10 @@ void PylontechComponent::process_line_(std::string &buffer) {
 
   PylontechListener::LineContents l{};
   char mostempr_s[6];
-  const int parsed = sscanf(                                                                                  // NOLINT
-      buffer.c_str(), "%d %d %d %d %d %d %d %d %7s %7s %7s %7s %d%% %*d-%*d-%*d %*d:%*d:%*d %*s %*s %5s %*s", // NOLINT
-      &l.bat_num, &l.volt, &l.curr, &l.tempr, &l.tlow, &l.thigh, &l.vlow, &l.vhigh, l.base_st, l.volt_st,     // NOLINT
-      l.curr_st, l.temp_st, &l.coulomb, mostempr_s);                                                          // NOLINT
+  const int parsed = sscanf(                                                                                   // NOLINT
+      buffer.c_str(), "%d %d %d %d %d %d %d %d %7s %7s %7s %7s %d%% %*d-%*d-%*d %*d:%*d:%*d %*s %*s %5s %*s",  // NOLINT
+      &l.bat_num, &l.volt, &l.curr, &l.tempr, &l.tlow, &l.thigh, &l.vlow, &l.vhigh, l.base_st, l.volt_st,      // NOLINT
+      l.curr_st, l.temp_st, &l.coulomb, mostempr_s);                                                           // NOLINT
 
   if (l.bat_num <= 0) {
     ESP_LOGD(TAG, "invalid bat_num in line %s", buffer.substr(0, buffer.size() - 2).c_str());

--- a/esphome/components/pylontech/pylontech.cpp
+++ b/esphome/components/pylontech/pylontech.cpp
@@ -66,10 +66,11 @@ void PylontechComponent::process_line_(std::string &buffer) {
   // clang-format on
 
   PylontechListener::LineContents l{};
+  char mostempr_s[6];
   const int parsed = sscanf(                                                                                  // NOLINT
-      buffer.c_str(), "%d %d %d %d %d %d %d %d %7s %7s %7s %7s %d%% %*d-%*d-%*d %*d:%*d:%*d %*s %*s %d %*s",  // NOLINT
+      buffer.c_str(), "%d %d %d %d %d %d %d %d %7s %7s %7s %7s %d%% %*d-%*d-%*d %*d:%*d:%*d %*s %*s %5s %*s", // NOLINT
       &l.bat_num, &l.volt, &l.curr, &l.tempr, &l.tlow, &l.thigh, &l.vlow, &l.vhigh, l.base_st, l.volt_st,     // NOLINT
-      l.curr_st, l.temp_st, &l.coulomb, &l.mostempr);                                                         // NOLINT
+      l.curr_st, l.temp_st, &l.coulomb, mostempr_s);                                                          // NOLINT
 
   if (l.bat_num <= 0) {
     ESP_LOGD(TAG, "invalid bat_num in line %s", buffer.substr(0, buffer.size() - 2).c_str());
@@ -79,6 +80,14 @@ void PylontechComponent::process_line_(std::string &buffer) {
     ESP_LOGW(TAG, "invalid line: found only %d items in %s", parsed, buffer.substr(0, buffer.size() - 2).c_str());
     return;
   }
+  auto mostempr_parsed = parse_number<int>(mostempr_s);
+  if(mostempr_parsed.has_value()) {
+    l.mostempr = mostempr_parsed.value();
+  } else {
+    l.mostempr = -300;
+    ESP_LOGW(TAG, "bat_num %d: received no mostempr", l.bat_num);
+  }
+
 
   for (PylontechListener *listener : this->listeners_) {
     listener->on_line_read(&l);

--- a/esphome/components/pylontech/pylontech.cpp
+++ b/esphome/components/pylontech/pylontech.cpp
@@ -35,7 +35,7 @@ void PylontechComponent::setup() {
 void PylontechComponent::update() { this->write_str("pwr\n"); }
 
 void PylontechComponent::loop() {
-  if(this->available() > 0) {
+  if (this->available() > 0) {
     // pylontech sends a lot of data very suddenly
     // we need to quickly put it all into our own buffer, otherwise the uart's buffer will overflow
     uint8_t data;
@@ -72,10 +72,10 @@ void PylontechComponent::process_line_(std::string &buffer) {
 
   PylontechListener::LineContents l{};
   char mostempr_s[6];
-  const int parsed = sscanf(                                                                                  // NOLINT
-      buffer.c_str(), "%d %d %d %d %d %d %d %d %7s %7s %7s %7s %d%% %*d-%*d-%*d %*d:%*d:%*d %*s %*s %5s %*s", // NOLINT
-      &l.bat_num, &l.volt, &l.curr, &l.tempr, &l.tlow, &l.thigh, &l.vlow, &l.vhigh, l.base_st, l.volt_st,     // NOLINT
-      l.curr_st, l.temp_st, &l.coulomb, mostempr_s);                                                          // NOLINT
+  const int parsed = sscanf(                                                                                 // NOLINT
+      buffer.c_str(), "%d %d %d %d %d %d %d %d %7s %7s %7s %7s %d%% %*d-%*d-%*d %*d:%*d:%*d %*s %*s %5s %*s",// NOLINT
+      &l.bat_num, &l.volt, &l.curr, &l.tempr, &l.tlow, &l.thigh, &l.vlow, &l.vhigh, l.base_st, l.volt_st,    // NOLINT
+      l.curr_st, l.temp_st, &l.coulomb, mostempr_s);                                                         // NOLINT
 
   if (l.bat_num <= 0) {
     ESP_LOGD(TAG, "invalid bat_num in line %s", buffer.substr(0, buffer.size() - 2).c_str());
@@ -86,14 +86,13 @@ void PylontechComponent::process_line_(std::string &buffer) {
     return;
   }
   auto mostempr_parsed = parse_number<int>(mostempr_s);
-  if(mostempr_parsed.has_value()) {
+  if (mostempr_parsed.has_value()) {
     l.mostempr = mostempr_parsed.value();
   } else {
     l.mostempr = -300;
     ESP_LOGW(TAG, "bat_num %d: received no mostempr", l.bat_num);
   }
-
-
+  
   for (PylontechListener *listener : this->listeners_) {
     listener->on_line_read(&l);
   }

--- a/esphome/components/pylontech/pylontech.cpp
+++ b/esphome/components/pylontech/pylontech.cpp
@@ -72,10 +72,10 @@ void PylontechComponent::process_line_(std::string &buffer) {
 
   PylontechListener::LineContents l{};
   char mostempr_s[6];
-  const int parsed = sscanf(                                                                                 // NOLINT
-      buffer.c_str(), "%d %d %d %d %d %d %d %d %7s %7s %7s %7s %d%% %*d-%*d-%*d %*d:%*d:%*d %*s %*s %5s %*s",// NOLINT
-      &l.bat_num, &l.volt, &l.curr, &l.tempr, &l.tlow, &l.thigh, &l.vlow, &l.vhigh, l.base_st, l.volt_st,    // NOLINT
-      l.curr_st, l.temp_st, &l.coulomb, mostempr_s);                                                         // NOLINT
+  const int parsed = sscanf(                                                                                  // NOLINT
+      buffer.c_str(), "%d %d %d %d %d %d %d %d %7s %7s %7s %7s %d%% %*d-%*d-%*d %*d:%*d:%*d %*s %*s %5s %*s", // NOLINT
+      &l.bat_num, &l.volt, &l.curr, &l.tempr, &l.tlow, &l.thigh, &l.vlow, &l.vhigh, l.base_st, l.volt_st,     // NOLINT
+      l.curr_st, l.temp_st, &l.coulomb, mostempr_s);                                                          // NOLINT
 
   if (l.bat_num <= 0) {
     ESP_LOGD(TAG, "invalid bat_num in line %s", buffer.substr(0, buffer.size() - 2).c_str());
@@ -92,7 +92,7 @@ void PylontechComponent::process_line_(std::string &buffer) {
     l.mostempr = -300;
     ESP_LOGW(TAG, "bat_num %d: received no mostempr", l.bat_num);
   }
-  
+
   for (PylontechListener *listener : this->listeners_) {
     listener->on_line_read(&l);
   }


### PR DESCRIPTION
# What does this implement/fix?

Fixes bug preventing US2000 batteries from being read.

These batteries don't report MosTempr, which was confusing the parsing algorithm.
This PR modifies the parsing to accept missing MosTempr.

Additionally, buffer overflows on ESP8266 are fixed by not processing any lines while data is still being received.

Finally, the maximum number of batteries is increased to 16.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** no issue

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#3520

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [X] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
pylontech:

sensor:
  - platform: pylontech
    pylontech_id: pylontech0
    battery: 7
    coulomb:
      id: bat7_soc
      name: "Battery7 State of Charge"
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
