### PR TITLE
update ESP32-audioI2S library

### DIFF
--- a/esphome/components/i2s_audio/media_player/__init__.py
+++ b/esphome/components/i2s_audio/media_player/__init__.py
@@ -104,5 +104,9 @@ async def to_code(config):
 
     cg.add_library("WiFiClientSecure", None)
     cg.add_library("HTTPClient", None)
-    cg.add_library("esphome/ESP32-audioI2S", "2.0.7")
+    cg.add_library(
+        name="ESP32-audioI2S",
+        repository="https://github.com/schreibfaul1/ESP32-audioI2S.git",
+        version="f2f1f5bcce74523dfc59e5844ba5878ed69c040a",
+    )
     cg.add_build_flag("-DAUDIO_NO_SD_FS")

--- a/platformio.ini
+++ b/platformio.ini
@@ -121,14 +121,13 @@ lib_deps =
     HTTPClient                           ; http_request,nextion (Arduino built-in)
     ESPmDNS                              ; mdns (Arduino built-in)
     DNSServer                            ; captive_portal (Arduino built-in)
-    esphome/ESP32-audioI2S@2.0.7         ; i2s_audio
+    https://github.com/schreibfaul1/ESP32-audioI2S.git#f2f1f5bcce74523dfc59e5844ba5878ed69c040a  ; i2s_audio
     crankyoldgit/IRremoteESP8266@2.7.12  ; heatpumpir
     droscy/esp_wireguard@0.3.2           ; wireguard
 build_flags =
     ${common:arduino.build_flags}
     -DUSE_ESP32
     -DUSE_ESP32_FRAMEWORK_ARDUINO
-    -DAUDIO_NO_SD_FS                ; i2s_audio
 extra_scripts = post:esphome/components/esp32/post_build.py.script
 
 ; This are common settings for the ESP32 (all variants) using IDF.


### PR DESCRIPTION
# What does this implement/fix?

Currently we use [a fork](https://github.com/esphome/ESP32-audioI2S) of the ESP32-audioI2S library for the I2S media_player component. That fork is out of date and seems not to be maintained.
I've sent the custom patches from that repo to upstream and they got accepted. I propose we switch to [schreibfaul1's original version of the library](https://github.com/schreibfaul1/ESP32-audioI2S) instead of maintaining an own fork. This would save us the extra effort and also pull in all the latest bugfixes and improvements.

This will update the library from the version of November 2022 to whatever upstream has improved and fixed since.

Caveat: The version of the Arduino framework has to be at least 2.0.8 or it will trigger this error and not play internet streams:
```
        m_timeout_ms_ssl = UINT16_MAX;  // bug in v2.0.3 if hostwoext is a IPaddr not a name
        m_timeout_ms = UINT16_MAX;  // [WiFiClient.cpp:253] connect(): select returned due to timeout 250 ms for fd 48
```
I'm not sure which version of the Arduino framework esphome uses.

Currently I added the sha hash of the latest commit. Once a new version of the library gets released we can change that to the proper tag.

Not applicable to the ESP-IDF, it's an Arduino library and there is no media_player support for the IDF in esphome. Also not available to other microcontrollers except the ESP32.

However, I think this is required if we ever want to start the potential IDF rewrite of the library. I think nobody wants to work on a fork of a fork that is more than a year out of date. (But maybe that rewrite is a pipedream anyways.) Related to that:
* https://github.com/esphome/feature-requests/issues/2429
* https://github.com/esphome/feature-requests/issues/1864
* https://github.com/esphome/issues/issues/3481
* https://github.com/esphome/issues/issues/4446
* https://github.com/esphome/firmware/issues/77

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):**

fixes https://github.com/esphome/ESP32-audioI2S/issues/14
fixes https://github.com/esphome/ESP32-audioI2S/pull/6
fixes https://github.com/esphome/ESP32-audioI2S/pull/9
fixes https://github.com/esphome/issues/issues/4589
related https://github.com/esphome/issues/issues/5069
related https://github.com/esphome/issues/issues/4085
related https://github.com/esphome/issues/issues/3970
related https://github.com/esphome/issues/issues/3934
related https://github.com/esphome/issues/issues/3840
conflicts with https://github.com/esphome/ESP32-audioI2S/pull/12 (which is superseeded by https://github.com/home-assistant/core/issues/92969)
probably fixes some more issues as it pulls in all the the updates of that library since November 2022

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** not applicable

## Test Environment

- [x] ESP32
- [ ] ~~ESP32 IDF~~
- [ ] ~~ESP8266~~
- [ ] ~~RP2040~~
- [ ] ~~BK72xx~~
- [ ] ~~RTL87xx~~

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
esphome:
  name: audioi2s

esp32:
  board: lolin_d32_pro
  framework:
    type: arduino
    version: latest

psram:
  mode: octal
  speed: 80MHz

i2s_audio:
  i2s_lrclk_pin: GPIO33
  i2s_bclk_pin: GPIO19

media_player:
  - platform: i2s_audio
    name: "ESPHome I2S Media Player"
    dac_type: external
    i2s_dout_pin: GPIO22
    mode: stereo

external_components:
  - source:
      type: git
      url: https://github.com/h3ndrik/esphome
      ref: update_audioi2s
    refresh: 0s
    components: [ i2s_audio, media_player ]
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] ~~Tests have been added to verify that the new code works (under `tests/` folder).~~

If user exposed functionality or configuration variables are added/changed:
  - [ ] ~~Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).~~
