### PR TITLE
hydreon_rgxx - fix missing cg.add(var.set_model(...))

### DIFF
--- a/esphome/components/hydreon_rgxx/hydreon_rgxx.cpp
+++ b/esphome/components/hydreon_rgxx/hydreon_rgxx.cpp
@@ -17,6 +17,12 @@ void HydreonRGxxComponent::dump_config() {
   if (this->is_failed()) {
     ESP_LOGE(TAG, "Connection with hydreon_rgxx failed!");
   }
+  if (model_ == RG9) {
+    ESP_LOGCONFIG(TAG, "  Model: RG9");
+    ESP_LOGCONFIG(TAG, "  Disable Led: %s", TRUEFALSE(this->disable_led_));
+  } else {
+    ESP_LOGCONFIG(TAG, "  Model: RG15");
+  }
   LOG_UPDATE_INTERVAL(this);
 
   int i = 0;
@@ -25,10 +31,6 @@ void HydreonRGxxComponent::dump_config() {
     LOG_SENSOR("  ", #s, this->sensors_[i - 1]); \
   }
   HYDREON_RGXX_PROTOCOL_LIST(HYDREON_RGXX_LOG_SENSOR, );
-
-  if (this->model_ == RG9) {
-    ESP_LOGCONFIG(TAG, "disable_led: %s", TRUEFALSE(this->disable_led_));
-  }
 }
 
 void HydreonRGxxComponent::setup() {

--- a/esphome/components/hydreon_rgxx/sensor.py
+++ b/esphome/components/hydreon_rgxx/sensor.py
@@ -138,6 +138,7 @@ async def to_code(config):
             sens = await sensor.new_sensor(config[conf])
             cg.add(var.set_sensor(sens, i))
 
+    cg.add(var.set_model(config[CONF_MODEL]))
     cg.add(var.set_request_temperature(CONF_TEMPERATURE in config))
 
     if CONF_DISABLE_LED in config:


### PR DESCRIPTION
# What does this implement/fix?
cg.add(var.set_model(config[CONF_MODEL])) is omitted from sensor.py, so the configured model (required) is not passed through.
The default model is defined in .h file as RG_9, so RG_9 models are not affected. When RG_15 is configured, the bug is not easily evident because the configuration command for polling mode is the same for RG_9 and RG15. However, the configuration of units as mm and resolution as high is never set for RG_15 as was intended - so the units and resolution are actually currently defined by the DIP switch settings of the RG_15.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
