### PR TITLE
add Pico-ResTouch-LCD-3.5

### DIFF
--- a/esphome/components/ili9xxx/display.py
+++ b/esphome/components/ili9xxx/display.py
@@ -79,6 +79,7 @@ COLOR_PALETTE = cv.one_of("NONE", "GRAYSCALE", "IMAGE_ADAPTIVE")
 CONF_LED_PIN = "led_pin"
 CONF_COLOR_PALETTE_IMAGES = "color_palette_images"
 CONF_INVERT_DISPLAY = "invert_display"
+CONF_18BIT_MODE = "18bit_mode"
 
 
 def _validate(config):
@@ -140,6 +141,7 @@ CONFIG_SCHEMA = cv.All(
                 "'invert_display' has been replaced by 'invert_colors'"
             ),
             cv.Optional(CONF_INVERT_COLORS): cv.boolean,
+            cv.Optional(CONF_18BIT_MODE): cv.boolean,
             cv.Optional(CONF_COLOR_ORDER): cv.one_of(*COLOR_ORDERS.keys(), upper=True),
             cv.Exclusive(CONF_ROTATION, CONF_ROTATION): validate_rotation,
             cv.Exclusive(CONF_TRANSFORM, CONF_ROTATION): cv.Schema(
@@ -242,3 +244,6 @@ async def to_code(config):
 
     if CONF_INVERT_COLORS in config:
         cg.add(var.invert_colors(config[CONF_INVERT_COLORS]))
+
+    if CONF_18BIT_MODE in config:
+        cg.add(var.set_18bit_mode(config[CONF_18BIT_MODE]))

--- a/esphome/components/ili9xxx/display.py
+++ b/esphome/components/ili9xxx/display.py
@@ -66,6 +66,7 @@ MODELS = {
     "ST7789V": ili9xxx_ns.class_("ILI9XXXST7789V", ILI9XXXDisplay),
     "S3BOX": ili9xxx_ns.class_("ILI9XXXS3Box", ILI9XXXDisplay),
     "S3BOX_LITE": ili9xxx_ns.class_("ILI9XXXS3BoxLite", ILI9XXXDisplay),
+    "WSPICOLCD": ili9xxx_ns.class_("ILI9XXXWSPICOLCD", ILI9XXXDisplay),
 }
 
 COLOR_ORDERS = {

--- a/esphome/components/ili9xxx/ili9xxx_display.cpp
+++ b/esphome/components/ili9xxx/ili9xxx_display.cpp
@@ -34,6 +34,9 @@ void ILI9XXXDisplay::setup() {
     mad |= MADCTL_MY;
   this->send_command(ILI9XXX_MADCTL, &mad, 1);
 
+  mad = this->is_18bitdisplay_ ? 0x66 : 0x55;
+  this->send_command(ILI9XXX_PIXFMT, &mad, 1);
+
   this->x_low_ = this->width_;
   this->y_low_ = this->height_;
   this->x_high_ = 0;

--- a/esphome/components/ili9xxx/ili9xxx_display.h
+++ b/esphome/components/ili9xxx/ili9xxx_display.h
@@ -53,9 +53,9 @@ class ILI9XXXDisplay : public display::DisplayBuffer,
       addr += num_args;
     }
   }
+  float get_setup_priority() const override;
 
   void set_dc_pin(GPIOPin *dc_pin) { dc_pin_ = dc_pin; }
-  float get_setup_priority() const override;
   void set_reset_pin(GPIOPin *reset) { this->reset_pin_ = reset; }
   void set_palette(const uint8_t *palette) { this->palette_ = palette; }
   void set_buffer_color_mode(ILI9XXXColorMode color_mode) { this->buffer_color_mode_ = color_mode; }
@@ -67,7 +67,10 @@ class ILI9XXXDisplay : public display::DisplayBuffer,
     this->offset_x_ = offset_x;
     this->offset_y_ = offset_y;
   }
+  void set_18bit_mode(bool mode) { this->is_18bitdisplay_ = mode; };
+
   void invert_colors(bool invert);
+
   void command(uint8_t value);
   void data(uint8_t value);
   void send_command(uint8_t command_byte, const uint8_t *data_bytes, uint8_t num_data_bytes);

--- a/esphome/components/ili9xxx/ili9xxx_display.h
+++ b/esphome/components/ili9xxx/ili9xxx_display.h
@@ -209,5 +209,10 @@ class ILI9XXXS3BoxLite : public ILI9XXXDisplay {
   ILI9XXXS3BoxLite() : ILI9XXXDisplay(INITCMD_S3BOXLITE, 320, 240, true) {}
 };
 
+class ILI9XXXWSPICOLCD : public ILI9XXXDisplay {
+ public:
+  ILI9XXXWSPICOLCD() : ILI9XXXDisplay(INITCMD_WSPICOLCD, 320, 480, true) {}
+};
+
 }  // namespace ili9xxx
 }  // namespace esphome

--- a/esphome/components/ili9xxx/ili9xxx_init.h
+++ b/esphome/components/ili9xxx/ili9xxx_init.h
@@ -316,6 +316,28 @@ static const uint8_t PROGMEM INITCMD_ST7789V[] = {
   0x00                                   // End of list
 };
 
+static const uint8_t PROGMEM INITCMD_WSPICOLCD[] = {
+ILI9XXX_SLPOUT, 0x80,
+ILI9XXX_PIXFMT, 1, 0x66,
+ILI9XXX_PWCTR1, 2, 0x17, 0x15, // VRH1 VRH2 -ok
+ILI9XXX_PWCTR2, 1, 0x41, // VGH, VGL - ok
+ILI9XXX_PWCTR3, 1, 0x44,
+//ILI9XXX_VMCTR1, 4, 0x00, 0x00, 0x00, 0x00,
+ILI9XXX_VMCTR1, 3, 0x00, 0x12, 0x80, // nVM VCM_REG VCM_REG_EN - not ok?
+ILI9XXX_IFMODE, 1, 0x00, // -ok
+ILI9XXX_FRMCTR1, 1, 0xA0, // Frame rate = 60Hz -- seems to help the background! -ok
+ILI9XXX_INVCTR, 1, 0x02, // Display Inversion Control = 2dot - ok
+ILI9XXX_DFUNCTR, 2, 0x02, 0x02, // Nomal scan -ok
+ILI9XXX_ADJCTL3, 4, 0xA9, 0x51, 0x2C, 0x82, // Adjust Control 3
+ILI9XXX_GMCTRP1,15, 0x00, 0x03, 0x09, 0x08, 0x16, 0x0A, 0x3F, 0x78, 0x4C, 0x09, 0x0A, 0x08, 0x16, 0x1A, 0x0F,
+ILI9XXX_GMCTRN1,15, 0x00, 0x16, 0x19, 0x03, 0x0F, 0x05, 0x32, 0x45, 0x46, 0x04, 0x0E, 0x0D, 0x35, 0x37, 0x0F,
+
+ILI9XXX_INVON, 0x80,
+ILI9XXX_MADCTL, 1, 0x48,
+ILI9XXX_DISPON, 0x80,
+0x00 // End of list
+};
+
 // clang-format on
 }  // namespace ili9xxx
 }  // namespace esphome


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/5324

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#3542


## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
display:
#Waveshare PICO 3.5 DISPLAY with ESP32-S3-PICO board.
  - platform: ili9xxx
    model: WSPICOLCD
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
