### PR TITLE
Fixes Waveshare 7.5in B V2 and V3

### DIFF
--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -1443,6 +1443,12 @@ void WaveshareEPaper7P5InBV2::initialize() {
   // COMMAND TCON SETTING
   this->command(0x60);
   this->data(0x22);
+
+  this->command(0x82);
+  this->data(0x08);
+  this->command(0x30);
+  this->data(0x06);
+
   // COMMAND RESOLUTION SETTING
   this->command(0x65);
   this->data(0x00);

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -1472,6 +1472,7 @@ void HOT WaveshareEPaper7P5InBV2::display() {
   this->command(0x12);
   delay(100);  // NOLINT
   this->wait_until_idle_();
+  this->deep_sleep();
 }
 int WaveshareEPaper7P5InBV2::get_width_internal() { return 800; }
 int WaveshareEPaper7P5InBV2::get_height_internal() { return 480; }

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -1617,7 +1617,7 @@ void HOT WaveshareEPaper7P5InBV3::display() {
   this->command(0x13);  // Start Transmission
   delay(2);
   for (uint32_t i = 0; i < buf_len; i++) {
-    this->data(this->buffer_[i]);
+    this->data(~this->buffer_[i]);
   }
 
   this->command(0x12);  // Display Refresh


### PR DESCRIPTION
# What does this implement/fix?

- First commit fixes https://github.com/esphome/issues/issues/5306 for Waveshare 7.5in B V3.
- Second commit add missing deep sleep  Waveshare 7.5in B V2 (as stated in the [doc](https://www.waveshare.com/w/upload/4/44/7.5inch_e-Paper_B_V2_Specification.pdf) page.
- Third commit is to comply with the constructor example here: https://github.com/waveshareteam/e-Paper/blob/master/STM32/STM32-F103ZET6/User/e-Paper/EPD_7in5b_V2.c#L140-L143 (even if I found nothing about that in the doc).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes [<link to issue>](https://github.com/esphome/issues/issues/5306)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** Not Applicable

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
button:
  - platform: template
    name: "Clear Screen"
    on_press:
      - lambda: id(epaper).clear_screen();

font:
  - file:
      type: gfonts
      family: Inter
      weight: 900
    id: font_main_title
    size: 24

spi:
  clk_pin: 13
  mosi_pin: 14
  id: epaper_display

display:
  - platform: waveshare_epaper
    id: epaper
    cs_pin: GPIO15
    dc_pin: GPIO27
    busy_pin:
      number: GPIO25
      inverted: False
    reset_pin: GPIO26
    model: 7.50in-bV2
    update_interval: 600s
    reset_duration: 2ms
    rotation: 90°
    lambda: |-
      it.filled_circle(240, 200, 50);
      it.print(240, 400, id(font_main_title), TextAlign::CENTER, "Hello World!");
      it.filled_circle(240, 600, 50);
```

Same config by replacing `7.50in-bV3` into `7.50in-bV2` for the second and third commits.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
