### PR TITLE
add support for samples per second via data_rate option to ADS1115

### DIFF
--- a/esphome/components/ads1115/ads1115.h
+++ b/esphome/components/ads1115/ads1115.h
@@ -35,6 +35,17 @@ enum ADS1115Resolution {
   ADS1015_12_BITS = 12,
 };
 
+enum ADS1115DataRate {
+  ADS1115_8_SPS = 0b000,
+  ADS1115_16_SPS = 0b001,
+  ADS1115_32_SPS = 0b010,
+  ADS1115_64_SPS = 0b011,
+  ADS1115_128_SPS = 0b100,
+  ADS1115_250_SPS = 0b101,
+  ADS1115_475_SPS = 0b110,
+  ADS1115_860_SPS = 0b111,
+};
+
 class ADS1115Sensor;
 
 class ADS1115Component : public Component, public i2c::I2CDevice {
@@ -64,16 +75,19 @@ class ADS1115Sensor : public sensor::Sensor, public PollingComponent, public vol
   void set_multiplexer(ADS1115Multiplexer multiplexer) { multiplexer_ = multiplexer; }
   void set_gain(ADS1115Gain gain) { gain_ = gain; }
   void set_resolution(ADS1115Resolution resolution) { resolution_ = resolution; }
+  void set_data_rate(ADS1115DataRate data_rate) { data_rate_ = data_rate; }
   float sample() override;
   uint8_t get_multiplexer() const { return multiplexer_; }
   uint8_t get_gain() const { return gain_; }
   uint8_t get_resolution() const { return resolution_; }
+  uint8_t get_data_rate() const { return data_rate_; }
 
  protected:
   ADS1115Component *parent_;
   ADS1115Multiplexer multiplexer_;
   ADS1115Gain gain_;
   ADS1115Resolution resolution_;
+  ADS1115DataRate data_rate_;
 };
 
 }  // namespace ads1115

--- a/esphome/components/ads1115/sensor.py
+++ b/esphome/components/ads1115/sensor.py
@@ -55,6 +55,7 @@ DATA_RATE = {
     "ADS1115_860_SPS": ADS1115DataRate.ADS1115_860_SPS,
 }
 
+
 def validate_gain(value):
     if isinstance(value, float):
         value = f"{value:0.03f}"

--- a/esphome/components/ads1115/sensor.py
+++ b/esphome/components/ads1115/sensor.py
@@ -5,6 +5,7 @@ from esphome.const import (
     CONF_GAIN,
     CONF_MULTIPLEXER,
     CONF_RESOLUTION,
+    CONF_DATA_RATE,
     DEVICE_CLASS_VOLTAGE,
     STATE_CLASS_MEASUREMENT,
     UNIT_VOLT,
@@ -42,6 +43,17 @@ RESOLUTION = {
     "12_BITS": ADS1115Resolution.ADS1015_12_BITS,
 }
 
+ADS1115DataRate = ads1115_ns.enum("ADS1115DataRate")
+DATA_RATE = {
+    "ADS1115_8_SPS": ADS1115DataRate.ADS1115_8_SPS,
+    "ADS1115_16_SPS": ADS1115DataRate.ADS1115_16_SPS,
+    "ADS1115_32_SPS": ADS1115DataRate.ADS1115_32_SPS,
+    "ADS1115_64_SPS": ADS1115DataRate.ADS1115_64_SPS,
+    "ADS1115_128_SPS": ADS1115DataRate.ADS1115_128_SPS,
+    "ADS1115_250_SPS": ADS1115DataRate.ADS1115_250_SPS,
+    "ADS1115_475_SPS": ADS1115DataRate.ADS1115_475_SPS,
+    "ADS1115_860_SPS": ADS1115DataRate.ADS1115_860_SPS,
+}
 
 def validate_gain(value):
     if isinstance(value, float):
@@ -73,6 +85,9 @@ CONFIG_SCHEMA = (
             cv.Optional(CONF_RESOLUTION, default="16_BITS"): cv.enum(
                 RESOLUTION, upper=True, space="_"
             ),
+            cv.Optional(CONF_DATA_RATE, default="ADS1115_860_SPS"): cv.enum(
+                DATA_RATE, upper=True, space="_"
+            ),
         }
     )
     .extend(cv.polling_component_schema("60s"))
@@ -88,5 +103,6 @@ async def to_code(config):
     cg.add(var.set_multiplexer(config[CONF_MULTIPLEXER]))
     cg.add(var.set_gain(config[CONF_GAIN]))
     cg.add(var.set_resolution(config[CONF_RESOLUTION]))
+    cg.add(var.set_data_rate(config[CONF_DATA_RATE]))
 
     cg.add(paren.register_sensor(var))


### PR DESCRIPTION
# What does this implement/fix?

Add samples per second feature to ADS 1115. Before this change, there was no way to change the data rate (samples per second) and ADS 1115 was always configured to use 860 samples per second (SPS). With this change, user can configure the SPS to all the available options in ADS 1115 by setting `data_rate` in yaml. I set the default value to 860 SPS so older projects will not be affected.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
ads1115:
  - address: 0x48
sensor:
  - platform: my_ads1115
    multiplexer: 'A0_GND'
    gain: 6.144
    data_rate: 'ADS1115_8_SPS'
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
