### PR TITLE
update script/setup so it works fine on windows 

### DIFF
--- a/script/setup
+++ b/script/setup
@@ -4,14 +4,13 @@
 set -e
 
 cd "$(dirname "$0")/.."
-
+location = "venv/bin/activate"
 if [ ! -n "$DEVCONTAINER" ] && [ ! -n "$VIRTUAL_ENV" ] && [ ! "$ESPHOME_NO_VENV" ]; then
   python3 -m venv venv
   if [ -f venv/Scripts/activate ]; then
-    source venv/Scripts/activate;
-  else
-    source venv/bin/activate;
+    location = "venv/Scripts/activate"
   fi
+  source %location;
 fi
 
 # Avoid unsafe git error when running inside devcontainer
@@ -29,5 +28,4 @@ script/platformio_install_deps.py platformio.ini --libraries --tools --platforms
 
 echo
 echo
-echo "Virtual environment created. Depending on your Phyton version and OS run;"
-echo "'source venv/Scripts/activate' or 'source venv/bin/activate' to use it."
+echo "Virtual environment created. Run 'source $location' to use it."

--- a/script/setup
+++ b/script/setup
@@ -7,7 +7,11 @@ cd "$(dirname "$0")/.."
 
 if [ ! -n "$DEVCONTAINER" ] && [ ! -n "$VIRTUAL_ENV" ] && [ ! "$ESPHOME_NO_VENV" ]; then
   python3 -m venv venv
-  source venv/bin/activate
+  if [ -f venv/Scripts/activate ]; then
+    source venv/Scripts/activate;
+  else
+    source venv/bin/activate;
+  fi
 fi
 
 # Avoid unsafe git error when running inside devcontainer
@@ -25,4 +29,5 @@ script/platformio_install_deps.py platformio.ini --libraries --tools --platforms
 
 echo
 echo
-echo "Virtual environment created; source venv/bin/activate to use it"
+echo "Virtual environment created. Depending on your Phyton version and OS run;"
+echo "'source venv/Scripts/activate' or 'source venv/bin/activate' to use it."

--- a/script/setup
+++ b/script/setup
@@ -4,13 +4,13 @@
 set -e
 
 cd "$(dirname "$0")/.."
-location = "venv/bin/activate"
+location="venv/bin/activate"
 if [ ! -n "$DEVCONTAINER" ] && [ ! -n "$VIRTUAL_ENV" ] && [ ! "$ESPHOME_NO_VENV" ]; then
   python3 -m venv venv
   if [ -f venv/Scripts/activate ]; then
-    location = "venv/Scripts/activate"
+    location="venv/Scripts/activate"
   fi
-  source %location;
+  source $location;
 fi
 
 # Avoid unsafe git error when running inside devcontainer


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->
It looks like that Python 3.12 changed the location where the *venv* files are stored on windows systems,
instead if `venv\bin` it is now in `venv\Script`.
This PR checks if `activate` file exist in `venv\Script` or `venv\bin`  and call it from that location.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
