### PR TITLE
Let show_*_page actions depend on "Display"

### DIFF
--- a/esphome/components/display/__init__.py
+++ b/esphome/components/display/__init__.py
@@ -145,7 +145,7 @@ async def display_page_show_to_code(config, action_id, template_arg, args):
     DisplayPageShowNextAction,
     maybe_simple_id(
         {
-            cv.Required(CONF_ID): cv.templatable(cv.use_id(DisplayBuffer)),
+            cv.Required(CONF_ID): cv.templatable(cv.use_id(Display)),
         }
     ),
 )
@@ -159,7 +159,7 @@ async def display_page_show_next_to_code(config, action_id, template_arg, args):
     DisplayPageShowPrevAction,
     maybe_simple_id(
         {
-            cv.Required(CONF_ID): cv.templatable(cv.use_id(DisplayBuffer)),
+            cv.Required(CONF_ID): cv.templatable(cv.use_id(Display)),
         }
     ),
 )
@@ -173,7 +173,7 @@ async def display_page_show_previous_to_code(config, action_id, template_arg, ar
     DisplayIsDisplayingPageCondition,
     cv.maybe_simple_value(
         {
-            cv.GenerateID(CONF_ID): cv.use_id(DisplayBuffer),
+            cv.GenerateID(CONF_ID): cv.use_id(Display),
             cv.Required(CONF_PAGE_ID): cv.use_id(DisplayPage),
         },
         key=CONF_PAGE_ID,


### PR DESCRIPTION
Instead of forcing a DisplayBuffer, let the display page actions use Displays without buffer.

# What does this implement/fix?
With the latest split between pure display drivers and display drivers with displaybuffer, some displays could inherit from `Display` instead of `DisplayBuffer`. 
The `show_next`, `show_prev` actions and the `is_displaying_page` condition expect a `DisplayBuffer`, while the actual action is implemented on the `Display` base class.

This PR should fix the issue and let the page actions work with both buffered and unbuffered displays

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/R

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
button:
  platform: GPIO
  pin: 14
  id: page_button
  on_press:
     display.page.show_next: my_display
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
