### PR TITLE
Add continuous option to the graph

### DIFF
--- a/esphome/components/graph/__init__.py
+++ b/esphome/components/graph/__init__.py
@@ -61,6 +61,7 @@ VALUE_POSITION_TYPE = {
     "BELOW": ValuePositionType.VALUE_POSITION_TYPE_BELOW,
 }
 
+CONF_CONNECT_THE_DOTS = "connect_the_dots"
 
 GRAPH_TRACE_SCHEMA = cv.Schema(
     {
@@ -70,6 +71,7 @@ GRAPH_TRACE_SCHEMA = cv.Schema(
         cv.Optional(CONF_LINE_THICKNESS): cv.positive_int,
         cv.Optional(CONF_LINE_TYPE): cv.enum(LINE_TYPE, upper=True),
         cv.Optional(CONF_COLOR): cv.use_id(color.ColorStruct),
+        cv.Optional(CONF_CONNECT_THE_DOTS): cv.boolean,
     }
 )
 
@@ -186,6 +188,8 @@ async def to_code(config):
         if CONF_COLOR in trace:
             c = await cg.get_variable(trace[CONF_COLOR])
             cg.add(tr.set_line_color(c))
+        if CONF_CONNECT_THE_DOTS in trace:
+            cg.add(tr.set_connected(trace[CONF_CONNECT_THE_DOTS]))
         cg.add(var.add_trace(tr))
     # Add legend
     if CONF_LEGEND in config:

--- a/esphome/components/graph/__init__.py
+++ b/esphome/components/graph/__init__.py
@@ -61,7 +61,7 @@ VALUE_POSITION_TYPE = {
     "BELOW": ValuePositionType.VALUE_POSITION_TYPE_BELOW,
 }
 
-CONF_CONNECT_THE_DOTS = "connect_the_dots"
+CONF_CONTINUOUS = "continuous"
 
 GRAPH_TRACE_SCHEMA = cv.Schema(
     {
@@ -71,7 +71,7 @@ GRAPH_TRACE_SCHEMA = cv.Schema(
         cv.Optional(CONF_LINE_THICKNESS): cv.positive_int,
         cv.Optional(CONF_LINE_TYPE): cv.enum(LINE_TYPE, upper=True),
         cv.Optional(CONF_COLOR): cv.use_id(color.ColorStruct),
-        cv.Optional(CONF_CONNECT_THE_DOTS): cv.boolean,
+        cv.Optional(CONF_CONTINUOUS): cv.boolean,
     }
 )
 
@@ -188,8 +188,8 @@ async def to_code(config):
         if CONF_COLOR in trace:
             c = await cg.get_variable(trace[CONF_COLOR])
             cg.add(tr.set_line_color(c))
-        if CONF_CONNECT_THE_DOTS in trace:
-            cg.add(tr.set_connected(trace[CONF_CONNECT_THE_DOTS]))
+        if CONF_CONTINUOUS in trace:
+            cg.add(tr.set_continuous(trace[CONF_CONTINUOUS]))
         cg.add(var.add_trace(tr))
     # Add legend
     if CONF_LEGEND in config:

--- a/esphome/components/graph/graph.cpp
+++ b/esphome/components/graph/graph.cpp
@@ -183,10 +183,17 @@ void Graph::draw(Display *buff, uint16_t x_offset, uint16_t y_offset, Color colo
             }
           } else {
             int16_t mid_y = (y + prev_y + thick) / 2;
-            for (uint16_t t = prev_y + thick; t <= mid_y; t++)
-              buff->draw_pixel_at(x - 1, t, c);
-            for (uint16_t t = mid_y + 1; t < y + thick; t++)
-              buff->draw_pixel_at(x, t, c);
+            if (y > prev_y) {
+              for (uint16_t t = prev_y + thick; t <= mid_y; t++)
+                buff->draw_pixel_at(x + 1, t, c);
+              for (uint16_t t = mid_y + 1; t < y + thick; t++)
+                buff->draw_pixel_at(x, t, c);
+            } else {
+              for (uint16_t t = prev_y - 1; t >= mid_y; t--)
+                buff->draw_pixel_at(x + 1, t, c);
+              for (uint16_t t = mid_y - 1; t >= y; t--)
+                buff->draw_pixel_at(x, t, c);
+            }
           }
           prev_y = y;
         }

--- a/esphome/components/graph/graph.cpp
+++ b/esphome/components/graph/graph.cpp
@@ -165,7 +165,7 @@ void Graph::draw(Display *buff, uint16_t x_offset, uint16_t y_offset, Color colo
   for (auto *trace : traces_) {
     Color c = trace->get_line_color();
     uint16_t thick = trace->get_line_thickness();
-    bool connected = trace->get_connected();
+    bool continuous = trace->get_continuous();
     bool has_prev = false;
     bool prev_b = false;
     int16_t prev_y = 0;
@@ -177,7 +177,7 @@ void Graph::draw(Display *buff, uint16_t x_offset, uint16_t y_offset, Color colo
         bool b = (trace->get_line_type() & bit) == bit;
         if (b) {
           int16_t y = (int16_t) roundf((this->height_ - 1) * (1.0 - v)) - thick / 2 + y_offset;
-          if (!connected || !has_prev || !prev_b || (abs(y - prev_y) <= thick)) {
+          if (!continuous || !has_prev || !prev_b || (abs(y - prev_y) <= thick)) {
             for (uint16_t t = 0; t < thick; t++) {
               buff->draw_pixel_at(x, y + t, c);
             }

--- a/esphome/components/graph/graph.cpp
+++ b/esphome/components/graph/graph.cpp
@@ -174,7 +174,7 @@ void Graph::draw(Display *buff, uint16_t x_offset, uint16_t y_offset, Color colo
       if (!std::isnan(v) && (thick > 0)) {
         int16_t x = this->width_ - 1 - i + x_offset;
         uint8_t bit = 1 << ((i % (thick * LineType::PATTERN_LENGTH)) / thick);
-        bool b = (trace->get_line_type() & b) == b;
+        bool b = (trace->get_line_type() & bit) == bit;
         if (b) {
           int16_t y = (int16_t) roundf((this->height_ - 1) * (1.0 - v)) - thick / 2 + y_offset;
           if (!connected || !has_prev || !prev_b || (abs(y - prev_y) <= thick)) {

--- a/esphome/components/graph/graph.cpp
+++ b/esphome/components/graph/graph.cpp
@@ -165,17 +165,35 @@ void Graph::draw(Display *buff, uint16_t x_offset, uint16_t y_offset, Color colo
   for (auto *trace : traces_) {
     Color c = trace->get_line_color();
     uint16_t thick = trace->get_line_thickness();
+    bool connected = trace->get_connected();
+    bool has_prev = false;
+    bool prev_b = false;
+    int16_t prev_y = 0;
     for (uint32_t i = 0; i < this->width_; i++) {
       float v = (trace->get_tracedata()->get_value(i) - ymin) / yrange;
       if (!std::isnan(v) && (thick > 0)) {
-        int16_t x = this->width_ - 1 - i;
-        uint8_t b = (i % (thick * LineType::PATTERN_LENGTH)) / thick;
-        if (((uint8_t) trace->get_line_type() & (1 << b)) == (1 << b)) {
-          int16_t y = (int16_t) roundf((this->height_ - 1) * (1.0 - v)) - thick / 2;
-          for (uint16_t t = 0; t < thick; t++) {
-            buff->draw_pixel_at(x_offset + x, y_offset + y + t, c);
+        int16_t x = this->width_ - 1 - i + x_offset;
+        uint8_t bit = 1 << ((i % (thick * LineType::PATTERN_LENGTH)) / thick);
+        bool b = (trace->get_line_type() & b) == b;
+        if (b) {
+          int16_t y = (int16_t) roundf((this->height_ - 1) * (1.0 - v)) - thick / 2 + y_offset;
+          if (!connected || !has_prev || !prev_b || (abs(y - prev_y) <= thick)) {
+            for (uint16_t t = 0; t < thick; t++) {
+              buff->draw_pixel_at(x, y + t, c);
+            }
+          } else {
+            int16_t mid_y = (y + prev_y + thick) / 2;
+            for (uint16_t t = prev_y + thick; t <= mid_y; t++)
+              buff->draw_pixel_at(x - 1, t, c);
+            for (uint16_t t = mid_y + 1; t < y + thick; t++)
+              buff->draw_pixel_at(x, t, c);
           }
+          prev_y = y;
         }
+        prev_b = b;
+        has_prev = true;
+      } else {
+        has_prev = false;
       }
     }
   }

--- a/esphome/components/graph/graph.h
+++ b/esphome/components/graph/graph.h
@@ -116,8 +116,8 @@ class GraphTrace {
   void set_line_type(enum LineType val) { this->line_type_ = val; }
   Color get_line_color() { return this->line_color_; }
   void set_line_color(Color val) { this->line_color_ = val; }
-  bool get_connected() { return this->connected_; }
-  void set_connected(bool connected) { this->connected_ = connected; }
+  bool get_continuous() { return this->continuous_; }
+  void set_continuous(bool continuous) { this->continuous_ = continuous; }
   std::string get_name() { return name_; }
   const HistoryData *get_tracedata() { return &data_; }
 
@@ -127,7 +127,7 @@ class GraphTrace {
   uint8_t line_thickness_{3};
   enum LineType line_type_ { LINE_TYPE_SOLID };
   Color line_color_{COLOR_ON};
-  bool connected_{false};
+  bool continuous_{false};
   HistoryData data_;
 
   friend Graph;

--- a/esphome/components/graph/graph.h
+++ b/esphome/components/graph/graph.h
@@ -116,6 +116,8 @@ class GraphTrace {
   void set_line_type(enum LineType val) { this->line_type_ = val; }
   Color get_line_color() { return this->line_color_; }
   void set_line_color(Color val) { this->line_color_ = val; }
+  bool get_connected() { return this->connected_; }
+  void set_connected(bool connected) { this->connected_ = connected; }
   std::string get_name() { return name_; }
   const HistoryData *get_tracedata() { return &data_; }
 
@@ -125,6 +127,7 @@ class GraphTrace {
   uint8_t line_thickness_{3};
   enum LineType line_type_ { LINE_TYPE_SOLID };
   Color line_color_{COLOR_ON};
+  bool connected_{false};
   HistoryData data_;
 
   friend Graph;


### PR DESCRIPTION
# What does this implement/fix?

The graph currently doesn't connect the data points if they aren't beside each other.  This adds an option to make a continuous graph line.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#3537

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
