### PR TITLE
Read signed values for temperature from PMSX003 sensors

### DIFF
--- a/esphome/components/pmsx003/pmsx003.cpp
+++ b/esphome/components/pmsx003/pmsx003.cpp
@@ -195,7 +195,7 @@ void PMSX003Component::send_command_(uint8_t cmd, uint16_t data) {
 void PMSX003Component::parse_data_() {
   switch (this->type_) {
     case PMSX003_TYPE_5003ST: {
-      float temperature = (int16_t) this->get_16_bit_uint_(30) / 10.0f;
+      float temperature = (int16_t) this->get_16_bit_int_(30) / 10.0f;
       float humidity = this->get_16_bit_uint_(32) / 10.0f;
 
       ESP_LOGD(TAG, "Got Temperature: %.1f°C, Humidity: %.1f%%", temperature, humidity);
@@ -279,7 +279,7 @@ void PMSX003Component::parse_data_() {
       // Note the pm particles 50um & 100um are not returned,
       // as PMS5003T uses those data values for temperature and humidity.
 
-      float temperature = this->get_16_bit_uint_(24) / 10.0f;
+      float temperature = this->get_16_bit_int_(24) / 10.0f;
       float humidity = this->get_16_bit_uint_(26) / 10.0f;
 
       ESP_LOGD(TAG,
@@ -326,6 +326,9 @@ void PMSX003Component::parse_data_() {
   }
 
   this->status_clear_warning();
+}
+int16_t PMSX003Component::get_16_bit_int_(uint8_t start_index) {
+  return (int16_t(this->get_16_bit_uint_(start_index)));
 }
 uint16_t PMSX003Component::get_16_bit_uint_(uint8_t start_index) {
   return (uint16_t(this->data_[start_index]) << 8) | uint16_t(this->data_[start_index + 1]);

--- a/esphome/components/pmsx003/pmsx003.h
+++ b/esphome/components/pmsx003/pmsx003.h
@@ -61,6 +61,7 @@ class PMSX003Component : public uart::UARTDevice, public Component {
   optional<bool> check_byte_();
   void parse_data_();
   void send_command_(uint8_t cmd, uint16_t data);
+  int16_t get_16_bit_int_(uint8_t start_index);
   uint16_t get_16_bit_uint_(uint8_t start_index);
 
   uint8_t data_[64];


### PR DESCRIPTION
# What does this implement/fix?

The PMS5003T and PMS5003ST sensors send a 16-bit signed value for temperature, which was being incorrectly read as unsigned, resulting in wildly incorrect values for temperature when the  measured value was below 0°C. We now read the negative values correctly.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** No separate issue created since it's a simple fix, but I can if appropriate.

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** Should not require documentation update.

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
sensor:
  - platform: pmsx003
    type: PMS5003T
    uart_id: uart_pm
    temperature:
      id: pm_temperature
      name: "Temperature"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
