### PR TITLE
fix: negative temperatures on PMS5003T sensors

### DIFF
--- a/esphome/components/pmsx003/pmsx003.cpp
+++ b/esphome/components/pmsx003/pmsx003.cpp
@@ -279,7 +279,7 @@ void PMSX003Component::parse_data_() {
       // Note the pm particles 50um & 100um are not returned,
       // as PMS5003T uses those data values for temperature and humidity.
 
-      float temperature = this->get_16_bit_uint_(24) / 10.0f;
+      float temperature = (int16_t) this->get_16_bit_uint_(24) / 10.0f;
       float humidity = this->get_16_bit_uint_(26) / 10.0f;
 
       ESP_LOGD(TAG,


### PR DESCRIPTION
# What does this implement/fix?

Fixes negative temperatures on PMS5003T sensors, which had previously been interpreted as unsigned integers.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** Fixes https://github.com/esphome/issues/issues/3814 for the PMS5003T (#6083 fixed it for the PMS5003**S**T, but missed the 5003T)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** No documentation update should be needed.

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
sensor:
  - platform: pmsx003
    type: PMS5003T
    uart_id: uart_pm
    temperature:
      id: pm_temperature
      name: "Temperature"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
