### PR TITLE
Fix RMT timing clock base

### DIFF
--- a/esphome/components/esp32_rmt_led_strip/led_strip.cpp
+++ b/esphome/components/esp32_rmt_led_strip/led_strip.cpp
@@ -13,7 +13,7 @@ namespace esp32_rmt_led_strip {
 
 static const char *const TAG = "esp32_rmt_led_strip";
 
-static const uint32_t RMT_CLK_FREQ = 80'000'000;
+static const uint32_t RMT_CLK_FREQ = 80000000;
 
 static const uint8_t RMT_CLK_DIV = 2;
 

--- a/esphome/components/esp32_rmt_led_strip/led_strip.cpp
+++ b/esphome/components/esp32_rmt_led_strip/led_strip.cpp
@@ -13,6 +13,8 @@ namespace esp32_rmt_led_strip {
 
 static const char *const TAG = "esp32_rmt_led_strip";
 
+static const uint32_t RMT_CLK_FREQ = 80'000'000;
+
 static const uint8_t RMT_CLK_DIV = 2;
 
 void ESP32RMTLEDStripLightOutput::setup() {
@@ -65,7 +67,7 @@ void ESP32RMTLEDStripLightOutput::setup() {
 
 void ESP32RMTLEDStripLightOutput::set_led_params(uint32_t bit0_high, uint32_t bit0_low, uint32_t bit1_high,
                                                  uint32_t bit1_low) {
-  float ratio = (float) APB_CLK_FREQ / RMT_CLK_DIV / 1e09f;
+  float ratio = (float) RMT_CLK_FREQ / RMT_CLK_DIV / 1e09f;
 
   // 0-bit
   this->bit0_.duration0 = (uint32_t) (ratio * bit0_high);


### PR DESCRIPTION
# What does this implement/fix?

RMT on ESP32 is no longer clocked with the ABP clock, which value were used in the `esp32_rmt_led_strip` component. In recent C6 (and probably couple previous) `PLL_F80M_CLK` 80 MHz clocks used, while earlier `ABP_CLK` was used, which is stated to be always 80 MHz for that case also, as stated in Tehnical Reference Manuals. 

This cause wrong timings in `esp32_rmt_led_strip` for chips like ESP32 C6 and most likely P4, H2, C5 and sometimes C2.

To fix it, I suggest adding a constant missing from `esp-idf` framework, and using it istead.


## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).


## References
  - https://github.com/espressif/esp-idf/pull/12972