### PR TITLE
Socket: Add recvfrom method to receive UDP with source address.

### DIFF
--- a/esphome/components/socket/bsd_sockets_impl.cpp
+++ b/esphome/components/socket/bsd_sockets_impl.cpp
@@ -87,7 +87,11 @@ class BSDSocketImpl : public Socket {
   int listen(int backlog) override { return ::listen(fd_, backlog); }
   ssize_t read(void *buf, size_t len) override { return ::read(fd_, buf, len); }
   ssize_t recvfrom(void *buf, size_t len, sockaddr *addr, socklen_t *addr_len) override {
+#if defined(USE_ESP32)
     return ::recvfrom(this->fd_, buf, len, 0, addr, addr_len);
+#else
+    return ::lwip_recvfrom(this->fd_, buf, len, 0, addr, addr_len);
+#endif
   }
   ssize_t readv(const struct iovec *iov, int iovcnt) override {
 #if defined(USE_ESP32)

--- a/esphome/components/socket/bsd_sockets_impl.cpp
+++ b/esphome/components/socket/bsd_sockets_impl.cpp
@@ -86,6 +86,9 @@ class BSDSocketImpl : public Socket {
   }
   int listen(int backlog) override { return ::listen(fd_, backlog); }
   ssize_t read(void *buf, size_t len) override { return ::read(fd_, buf, len); }
+  ssize_t recvfrom(void *buf, size_t len, sockaddr *addr, socklen_t *addr_len) override {
+    return ::recvfrom(this->fd_, buf, len, 0, addr, addr_len);
+  }
   ssize_t readv(const struct iovec *iov, int iovcnt) override {
 #if defined(USE_ESP32)
     return ::lwip_readv(fd_, iov, iovcnt);

--- a/esphome/components/socket/socket.h
+++ b/esphome/components/socket/socket.h
@@ -31,7 +31,9 @@ class Socket {
   virtual int setsockopt(int level, int optname, const void *optval, socklen_t optlen) = 0;
   virtual int listen(int backlog) = 0;
   virtual ssize_t read(void *buf, size_t len) = 0;
+#ifdef USE_SOCKET_IMPL_BSD_SOCKETS
   virtual ssize_t recvfrom(void *buf, size_t len, sockaddr *addr, socklen_t *addr_len) = 0;
+#endif
   virtual ssize_t readv(const struct iovec *iov, int iovcnt) = 0;
   virtual ssize_t write(const void *buf, size_t len) = 0;
   virtual ssize_t writev(const struct iovec *iov, int iovcnt) = 0;

--- a/esphome/components/socket/socket.h
+++ b/esphome/components/socket/socket.h
@@ -31,6 +31,7 @@ class Socket {
   virtual int setsockopt(int level, int optname, const void *optval, socklen_t optlen) = 0;
   virtual int listen(int backlog) = 0;
   virtual ssize_t read(void *buf, size_t len) = 0;
+  virtual ssize_t recvfrom(void *buf, size_t len, sockaddr *addr, socklen_t *addr_len) = 0;
   virtual ssize_t readv(const struct iovec *iov, int iovcnt) = 0;
   virtual ssize_t write(const void *buf, size_t len) = 0;
   virtual ssize_t writev(const struct iovec *iov, int iovcnt) = 0;


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Add method to the `socket::Socket` class to allow UDP receive with source address information.


## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
