### PR TITLE
Remove optional<> for pointer types

### DIFF
--- a/esphome/components/bedjet/bedjet_hub.cpp
+++ b/esphome/components/bedjet/bedjet_hub.cpp
@@ -242,7 +242,7 @@ void BedJetHub::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t ga
         this->set_notify_(true);
 
 #ifdef USE_TIME
-        if (this->time_id_.has_value()) {
+        if (this->time_id_ != nullptr) {
           this->send_local_time();
         }
 #endif
@@ -441,9 +441,8 @@ uint8_t BedJetHub::write_notify_config_descriptor_(bool enable) {
 
 #ifdef USE_TIME
 void BedJetHub::send_local_time() {
-  if (this->time_id_.has_value()) {
-    auto *time_id = *this->time_id_;
-    ESPTime now = time_id->now();
+  if (this->time_id_ != nullptr) {
+    ESPTime now = this->time_id_->now();
     if (now.is_valid()) {
       this->set_clock(now.hour, now.minute);
       ESP_LOGD(TAG, "Using time component to set BedJet clock: %d:%02d", now.hour, now.minute);
@@ -454,10 +453,9 @@ void BedJetHub::send_local_time() {
 }
 
 void BedJetHub::setup_time_() {
-  if (this->time_id_.has_value()) {
+  if (this->time_id_ != nullptr) {
     this->send_local_time();
-    auto *time_id = *this->time_id_;
-    time_id->add_on_time_sync_callback([this] { this->send_local_time(); });
+    this->time_id_->add_on_time_sync_callback([this] { this->send_local_time(); });
   } else {
     ESP_LOGI(TAG, "`time_id` is not configured: will not sync BedJet clock.");
   }

--- a/esphome/components/bedjet/bedjet_hub.h
+++ b/esphome/components/bedjet/bedjet_hub.h
@@ -141,7 +141,7 @@ class BedJetHub : public esphome::ble_client::BLEClientNode, public PollingCompo
 #ifdef USE_TIME
   /** Initializes time sync callbacks to support syncing current time to the BedJet. */
   void setup_time_();
-  optional<time::RealTimeClock *> time_id_{};
+  time::RealTimeClock *time_id_{nullptr};
 #endif
 
   uint32_t timeout_{DEFAULT_STATUS_TIMEOUT};

--- a/esphome/components/tuya/tuya.cpp
+++ b/esphome/components/tuya/tuya.cpp
@@ -23,8 +23,8 @@ static const int MAX_RETRIES = 5;
 
 void Tuya::setup() {
   this->set_interval("heartbeat", 15000, [this] { this->send_empty_command_(TuyaCommandType::HEARTBEAT); });
-  if (this->status_pin_.has_value()) {
-    this->status_pin_.value()->digital_write(false);
+  if (this->status_pin_ != nullptr) {
+    this->status_pin_->digital_write(false);
   }
 }
 
@@ -70,9 +70,7 @@ void Tuya::dump_config() {
     ESP_LOGCONFIG(TAG, "  GPIO Configuration: status: pin %d, reset: pin %d", this->status_pin_reported_,
                   this->reset_pin_reported_);
   }
-  if (this->status_pin_.has_value()) {
-    LOG_PIN("  Status Pin: ", this->status_pin_.value());
-  }
+  LOG_PIN("  Status Pin: ", this->status_pin_);
   ESP_LOGCONFIG(TAG, "  Product: '%s'", this->product_.c_str());
 }
 
@@ -194,7 +192,7 @@ void Tuya::handle_command_(uint8_t command, uint8_t version, const uint8_t *buff
           this->init_state_ = TuyaInitState::INIT_DATAPOINT;
           this->send_empty_command_(TuyaCommandType::DATAPOINT_QUERY);
           bool is_pin_equals =
-              this->status_pin_.has_value() && this->status_pin_.value()->get_pin() == this->status_pin_reported_;
+              this->status_pin_ != nullptr && this->status_pin_->get_pin() == this->status_pin_reported_;
           // Configure status pin toggling (if reported and configured) or WIFI_STATE periodic send
           if (is_pin_equals) {
             ESP_LOGV(TAG, "Configured status pin %i", this->status_pin_reported_);
@@ -244,13 +242,12 @@ void Tuya::handle_command_(uint8_t command, uint8_t version, const uint8_t *buff
       break;
     case TuyaCommandType::LOCAL_TIME_QUERY:
 #ifdef USE_TIME
-      if (this->time_id_.has_value()) {
+      if (this->time_id_ != nullptr) {
         this->send_local_time_();
 
         if (!this->time_sync_callback_registered_) {
           // tuya mcu supports time, so we let them know when our time changed
-          auto *time_id = *this->time_id_;
-          time_id->add_on_time_sync_callback([this] { this->send_local_time_(); });
+          this->time_id_->add_on_time_sync_callback([this] { this->send_local_time_(); });
           this->time_sync_callback_registered_ = true;
         }
       } else
@@ -463,7 +460,7 @@ void Tuya::send_empty_command_(TuyaCommandType command) {
 
 void Tuya::set_status_pin_() {
   bool is_network_ready = network::is_connected() && remote_is_connected();
-  this->status_pin_.value()->digital_write(is_network_ready);
+  this->status_pin_->digital_write(is_network_ready);
 }
 
 uint8_t Tuya::get_wifi_status_code_() {
@@ -511,8 +508,7 @@ void Tuya::send_wifi_status_() {
 #ifdef USE_TIME
 void Tuya::send_local_time_() {
   std::vector<uint8_t> payload;
-  auto *time_id = *this->time_id_;
-  ESPTime now = time_id->now();
+  ESPTime now = this->time_id_->now();
   if (now.is_valid()) {
     uint8_t year = now.year - 2000;
     uint8_t month = now.month;

--- a/esphome/components/tuya/tuya.h
+++ b/esphome/components/tuya/tuya.h
@@ -130,7 +130,7 @@ class Tuya : public Component, public uart::UARTDevice {
 
 #ifdef USE_TIME
   void send_local_time_();
-  time::RealTimeClock *time_id_{};
+  time::RealTimeClock *time_id_{nullptr};
   bool time_sync_callback_registered_{false};
 #endif
   TuyaInitState init_state_ = TuyaInitState::INIT_HEARTBEAT;

--- a/esphome/components/tuya/tuya.h
+++ b/esphome/components/tuya/tuya.h
@@ -130,14 +130,14 @@ class Tuya : public Component, public uart::UARTDevice {
 
 #ifdef USE_TIME
   void send_local_time_();
-  optional<time::RealTimeClock *> time_id_{};
+  time::RealTimeClock *time_id_{};
   bool time_sync_callback_registered_{false};
 #endif
   TuyaInitState init_state_ = TuyaInitState::INIT_HEARTBEAT;
   bool init_failed_{false};
   int init_retries_{0};
   uint8_t protocol_version_ = -1;
-  optional<InternalGPIOPin *> status_pin_{};
+  InternalGPIOPin *status_pin_{nullptr};
   int status_pin_reported_ = -1;
   int reset_pin_reported_ = -1;
   uint32_t last_command_timestamp_ = 0;


### PR DESCRIPTION
# What does this implement/fix?

Refactor/cleanup/style:
Don't use `optional` for pointer types as identified during code review [here](https://github.com/esphome/esphome/pull/5769#discussion_r1458261143).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Other

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
