### PR TITLE
Fix some Voice Assistant bugs

### DIFF
--- a/esphome/components/voice_assistant/voice_assistant.cpp
+++ b/esphome/components/voice_assistant/voice_assistant.cpp
@@ -231,10 +231,12 @@ void VoiceAssistant::loop() {
     }
     case State::STREAMING_MICROPHONE: {
       this->read_microphone_();
-      if (this->ring_buffer_->available() >= SEND_BUFFER_SIZE) {
-        this->ring_buffer_->read((void *) this->send_buffer_, SEND_BUFFER_SIZE, 0);
-        this->socket_->sendto(this->send_buffer_, SEND_BUFFER_SIZE, 0, (struct sockaddr *) &this->dest_addr_,
+      size_t available = this->ring_buffer_->available();
+      while (available >= SEND_BUFFER_SIZE) {
+        size_t read_bytes = this->ring_buffer_->read((void *) this->send_buffer_, SEND_BUFFER_SIZE, 0);
+        this->socket_->sendto(this->send_buffer_, read_bytes, 0, (struct sockaddr *) &this->dest_addr_,
                               sizeof(this->dest_addr_));
+        available = this->ring_buffer_->available();
       }
 
       break;

--- a/esphome/components/voice_assistant/voice_assistant.cpp
+++ b/esphome/components/voice_assistant/voice_assistant.cpp
@@ -17,7 +17,7 @@ static const char *const TAG = "voice_assistant";
 
 static const size_t SAMPLE_RATE_HZ = 16000;
 static const size_t INPUT_BUFFER_SIZE = 32 * SAMPLE_RATE_HZ / 1000;  // 32ms * 16kHz / 1000ms
-static const size_t BUFFER_SIZE = 1000 * SAMPLE_RATE_HZ / 1000;      // 1s
+static const size_t BUFFER_SIZE = 1024 * SAMPLE_RATE_HZ / 1000;
 static const size_t SEND_BUFFER_SIZE = INPUT_BUFFER_SIZE * sizeof(int16_t);
 static const size_t RECEIVE_SIZE = 1024;
 static const size_t SPEAKER_BUFFER_SIZE = 16 * RECEIVE_SIZE;

--- a/esphome/core/ring_buffer.cpp
+++ b/esphome/core/ring_buffer.cpp
@@ -15,17 +15,18 @@ std::unique_ptr<RingBuffer> RingBuffer::create(size_t len) {
   std::unique_ptr<RingBuffer> rb = make_unique<RingBuffer>();
 
   ExternalRAMAllocator<uint8_t> allocator(ExternalRAMAllocator<uint8_t>::ALLOW_FAILURE);
-  rb->storage_ = allocator.allocate(len);
+  rb->storage_ = allocator.allocate(len + 1);
   if (rb->storage_ == nullptr) {
     return nullptr;
   }
 
-  rb->handle_ = xStreamBufferCreateStatic(len, 0, rb->storage_, &rb->structure_);
+  rb->handle_ = xStreamBufferCreateStatic(len + 1, 0, rb->storage_, &rb->structure_);
+  ESP_LOGD(TAG, "Created ring buffer with size %u", len);
   return rb;
 }
 
-size_t RingBuffer::read(void *data, size_t size, TickType_t ticks_to_wait) {
-  return xStreamBufferReceive(this->handle_, data, size, ticks_to_wait);
+size_t RingBuffer::read(void *data, size_t len, TickType_t ticks_to_wait) {
+  return xStreamBufferReceive(this->handle_, data, len, ticks_to_wait);
 }
 
 size_t RingBuffer::write(void *data, size_t len) {

--- a/esphome/core/ring_buffer.h
+++ b/esphome/core/ring_buffer.h
@@ -12,7 +12,7 @@ namespace esphome {
 
 class RingBuffer {
  public:
-  size_t read(void *data, size_t size, TickType_t ticks_to_wait = 0);
+  size_t read(void *data, size_t len, TickType_t ticks_to_wait = 0);
 
   size_t write(void *data, size_t len);
 


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->
Some changes in #6102 had some unexpected side effects when the ring buffer got filled up entirely due to VAD before streaming to HA.

Fix that by allocating 1 more byte in the RingBuffer so the expected number of bytes can be written and read correctly as StreamBuffer will only have space for `size - 1`

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/5392

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
