### PR TITLE
Improve temperature precision in BME280 and BMP280

### DIFF
--- a/esphome/components/bme280_base/bme280_base.cpp
+++ b/esphome/components/bme280_base/bme280_base.cpp
@@ -265,8 +265,8 @@ float BME280Component::read_temperature_(const uint8_t *data, int32_t *t_fine) {
   int32_t const var2 = (((((adc >> 4) - t1) * ((adc >> 4) - t1)) >> 12) * t3) >> 14;
   *t_fine = var1 + var2;
 
-  float const temperature = (*t_fine * 5 + 128) >> 8;
-  return temperature / 100.0f;
+  float const temperature = (*t_fine * 5 + 128);
+  return temperature / 25600.0f;
 }
 
 float BME280Component::read_pressure_(const uint8_t *data, int32_t t_fine) {

--- a/esphome/components/bmp280/bmp280.cpp
+++ b/esphome/components/bmp280/bmp280.cpp
@@ -200,8 +200,8 @@ float BMP280Component::read_temperature_(int32_t *t_fine) {
   int32_t var2 = (((((adc >> 4) - t1) * ((adc >> 4) - t1)) >> 12) * t3) >> 14;
   *t_fine = var1 + var2;
 
-  float temperature = (*t_fine * 5 + 128) >> 8;
-  return temperature / 100.0f;
+  float temperature = (*t_fine * 5 + 128) ;
+  return temperature / 25600.0f;
 }
 
 float BMP280Component::read_pressure_(int32_t t_fine) {

--- a/esphome/components/bmp280/bmp280.cpp
+++ b/esphome/components/bmp280/bmp280.cpp
@@ -200,7 +200,7 @@ float BMP280Component::read_temperature_(int32_t *t_fine) {
   int32_t var2 = (((((adc >> 4) - t1) * ((adc >> 4) - t1)) >> 12) * t3) >> 14;
   *t_fine = var1 + var2;
 
-  float temperature = (*t_fine * 5 + 128) ;
+  float temperature = (*t_fine * 5 + 128);
   return temperature / 25600.0f;
 }
 


### PR DESCRIPTION
# What does this implement/fix?

The RMS precision in the BME280 and BMP280 sensors is 0.002°C . But the existing routines truncated the precision to 0.01°C.
This is a very minor change that brings back the full precision to BME280 and BMP280.


## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```
# Example config.yaml
sensor:
  - platform: bme280_i2c
    temperature:
      name: "BME280 Temperature"
      oversampling: 16x
      accuracy_decimals: 3
    pressure:
      name: "BME280 Pressure"
      accuracy_decimals: 2
    humidity:
      name: "BME280 Humidity"
      accuracy_decimals: 2
    address: 0x76
    update_interval: 5s
```

## Checklist:
  - [X] The code change is tested and works locally. (tested for BME280 and BMP280)
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
