### PR TITLE
Nextion - Remove soft reset at start

### DIFF
--- a/esphome/components/nextion/base_component.py
+++ b/esphome/components/nextion/base_component.py
@@ -30,6 +30,7 @@ CONF_FOREGROUND_COLOR = "foreground_color"
 CONF_FOREGROUND_PRESSED_COLOR = "foreground_pressed_color"
 CONF_FONT_ID = "font_id"
 CONF_EXIT_REPARSE_ON_START = "exit_reparse_on_start"
+CONF_SOFT_RESET_ON_START = "soft_reset_on_start"
 
 
 def NextionName(value):

--- a/esphome/components/nextion/display.py
+++ b/esphome/components/nextion/display.py
@@ -23,6 +23,7 @@ from .base_component import (
     CONF_START_UP_PAGE,
     CONF_AUTO_WAKE_ON_TOUCH,
     CONF_EXIT_REPARSE_ON_START,
+    CONF_SOFT_RESET_ON_START,
 )
 
 CODEOWNERS = ["@senexcrenshaw"]
@@ -72,6 +73,7 @@ CONFIG_SCHEMA = (
             cv.Optional(CONF_START_UP_PAGE): cv.positive_int,
             cv.Optional(CONF_AUTO_WAKE_ON_TOUCH, default=True): cv.boolean,
             cv.Optional(CONF_EXIT_REPARSE_ON_START, default=False): cv.boolean,
+            cv.Optional(CONF_SOFT_RESET_ON_START, default=True): cv.boolean,
         }
     )
     .extend(cv.polling_component_schema("5s"))

--- a/esphome/components/nextion/display.py
+++ b/esphome/components/nextion/display.py
@@ -120,6 +120,8 @@ async def to_code(config):
 
     cg.add(var.set_exit_reparse_on_start_internal(config[CONF_EXIT_REPARSE_ON_START]))
 
+    cg.add(var.set_soft_reset_on_start_internal(config[CONF_SOFT_RESET_ON_START]))
+
     await display.register_display(var, config)
 
     for conf in config.get(CONF_ON_SETUP, []):

--- a/esphome/components/nextion/nextion.cpp
+++ b/esphome/components/nextion/nextion.cpp
@@ -24,7 +24,7 @@ void Nextion::setup() {
   if (this->soft_reset_on_start_) {
     this->send_command_("rest");
   }
-  
+
   this->ignore_is_setup_ = false;
 }
 

--- a/esphome/components/nextion/nextion.cpp
+++ b/esphome/components/nextion/nextion.cpp
@@ -21,8 +21,10 @@ void Nextion::setup() {
   this->send_command_("sleep=0");
 
   // Reboot it
-  // this->send_command_("rest");
-
+  if (this->soft_reset_on_start_) {
+    this->send_command_("rest");
+  }
+  
   this->ignore_is_setup_ = false;
 }
 
@@ -132,6 +134,7 @@ void Nextion::dump_config() {
   ESP_LOGCONFIG(TAG, "  Flash Size:       %s", this->flash_size_.c_str());
   ESP_LOGCONFIG(TAG, "  Wake On Touch:    %s", YESNO(this->auto_wake_on_touch_));
   ESP_LOGCONFIG(TAG, "  Exit reparse:     %s", YESNO(this->exit_reparse_on_start_));
+  ESP_LOGCONFIG(TAG, "  Soft reset:       %s", YESNO(this->soft_reset_on_start_));
 
   if (this->touch_sleep_timeout_ != 0) {
     ESP_LOGCONFIG(TAG, "  Touch Timeout:    %" PRIu32, this->touch_sleep_timeout_);
@@ -253,6 +256,7 @@ void Nextion::loop() {
 
     this->set_auto_wake_on_touch(this->auto_wake_on_touch_);
     this->set_exit_reparse_on_start(this->exit_reparse_on_start_);
+    this->set_soft_reset_on_start(this->soft_reset_on_start_);
 
     if (this->touch_sleep_timeout_ != 0) {
       this->set_touch_sleep_timeout(this->touch_sleep_timeout_);

--- a/esphome/components/nextion/nextion.cpp
+++ b/esphome/components/nextion/nextion.cpp
@@ -23,6 +23,8 @@ void Nextion::setup() {
   // Reboot it
   if (this->soft_reset_on_start_) {
     this->send_command_("rest");
+    ESP_LOGD(TAG, "Manually set Nextion report ready");
+    this->nextion_reports_is_setup_ = true;
   }
 
   this->ignore_is_setup_ = false;

--- a/esphome/components/nextion/nextion.cpp
+++ b/esphome/components/nextion/nextion.cpp
@@ -23,6 +23,7 @@ void Nextion::setup() {
   // Reboot it
   if (this->soft_reset_on_start_) {
     this->send_command_("rest");
+  } else {
     ESP_LOGD(TAG, "Manually set Nextion report ready");
     this->nextion_reports_is_setup_ = true;
   }

--- a/esphome/components/nextion/nextion.cpp
+++ b/esphome/components/nextion/nextion.cpp
@@ -21,7 +21,7 @@ void Nextion::setup() {
   this->send_command_("sleep=0");
 
   // Reboot it
-  this->send_command_("rest");
+  // this->send_command_("rest");
 
   this->ignore_is_setup_ = false;
 }

--- a/esphome/components/nextion/nextion.h
+++ b/esphome/components/nextion/nextion.h
@@ -873,6 +873,19 @@ class Nextion : public NextionBase, public PollingComponent, public uart::UARTDe
    */
   void set_exit_reparse_on_start(bool exit_reparse);
   /**
+   * Sets if Nextion should execute a soft restart when this component is starting
+   * @param soft_reset True or false. When soft_reset is true (default), the Nextion
+   * will restart when this component is starting.
+   *
+   * Example:
+   * ```cpp
+   * it.set_soft_reset_on_start(false);
+   * ```
+   *
+   * The display will be skip the soft reset when starting.
+   */
+  void set_soft_reset_on_start(bool soft_reset);
+  /**
    * Sets Nextion mode between sleep and awake
    * @param True or false. Sleep=true to enter sleep mode or sleep=false to exit sleep mode.
    */
@@ -1003,6 +1016,7 @@ class Nextion : public NextionBase, public PollingComponent, public uart::UARTDe
   void set_exit_reparse_on_start_internal(bool exit_reparse_on_start) {
     this->exit_reparse_on_start_ = exit_reparse_on_start;
   }
+  void set_soft_reset_on_start_internal(bool soft_reset_on_start) { this->soft_reset_on_start_ = soft_reset_on_start; }
 
   /**
    * @brief Retrieves the number of commands pending in the Nextion command queue.
@@ -1042,6 +1056,7 @@ class Nextion : public NextionBase, public PollingComponent, public uart::UARTDe
   int start_up_page_ = -1;
   bool auto_wake_on_touch_ = true;
   bool exit_reparse_on_start_ = false;
+  bool soft_reset_on_start_ = true;
 
   /**
    * Manually send a raw command to the display and don't wait for an acknowledgement packet.

--- a/esphome/components/nextion/nextion_commands.cpp
+++ b/esphome/components/nextion/nextion_commands.cpp
@@ -54,6 +54,7 @@ void Nextion::set_protocol_reparse_mode(bool active_mode) {
   this->write_array(to_send, sizeof(to_send));
 }
 void Nextion::set_exit_reparse_on_start(bool exit_reparse) { this->exit_reparse_on_start_ = exit_reparse; }
+void Nextion::set_soft_reset_on_start(bool soft_reset) { this->soft_reset_on_start_ = soft_reset; }
 
 // Set Colors - Background
 void Nextion::set_component_background_color(const char *component, uint16_t color) {


### PR DESCRIPTION
# What does this implement/fix?

This introduces a user configurable attribute to Nextion display which allows skipping the soft reset on displays during the component startup.
I don't know really why this reset was introduced from the beginning, so I've left as a configurable attribute to avoid a breaking change, but on my tests it always work without this command and it makes the startup process a bit faster (my main goal).

This is not a breaking change, as the previous behavior is the default.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** solves esphome/feature-requests#2074

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#3566

## Test Environment

- [X] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
display:
  - id: disp1
    platform: nextion
    soft_reset_on_start: false
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
