### PR TITLE
Tuya Fan component fix to handle enum datapoint type

### DIFF
--- a/esphome/components/tuya/fan/tuya_fan.cpp
+++ b/esphome/components/tuya/fan/tuya_fan.cpp
@@ -34,7 +34,8 @@ void TuyaFan::setup() {
   }
   if (this->oscillation_id_.has_value()) {
     this->parent_->register_listener(*this->oscillation_id_, [this](const TuyaDatapoint &datapoint) {
-      //Whether data type is BOOL or ENUM, it will still be a 1 or a 0, so the functions below are valid in both scenarios
+      // Whether data type is BOOL or ENUM, it will still be a 1 or a 0, so the functions below are valid in both
+      // scenarios
       ESP_LOGV(TAG, "MCU reported oscillation is: %s", ONOFF(datapoint.value_bool));
       this->oscillating = datapoint.value_bool;
       this->publish_state();

--- a/esphome/components/tuya/fan/tuya_fan.cpp
+++ b/esphome/components/tuya/fan/tuya_fan.cpp
@@ -85,8 +85,8 @@ void TuyaFan::control(const fan::FanCall &call) {
   if (this->oscillation_id_.has_value() && call.get_oscillating().has_value()) {
     if (this->oscillation_type_ == TuyaDatapointType::ENUM) {
       this->parent_->set_enum_datapoint_value(*this->oscillation_id_, *call.get_oscillating());
-    } else if (this->speed_type_ == TuyaDatapointType::INTEGER) {
-      this->parent_->set_integer_datapoint_value(*this->oscillation_id_, *call.get_oscillating());
+    } else if (this->speed_type_ == TuyaDatapointType::BOOLEAN) {
+      this->parent_->set_boolean_datapoint_value(*this->oscillation_id_, *call.get_oscillating());
     }
   }
   if (this->direction_id_.has_value() && call.get_direction().has_value()) {

--- a/esphome/components/tuya/fan/tuya_fan.cpp
+++ b/esphome/components/tuya/fan/tuya_fan.cpp
@@ -34,9 +34,12 @@ void TuyaFan::setup() {
   }
   if (this->oscillation_id_.has_value()) {
     this->parent_->register_listener(*this->oscillation_id_, [this](const TuyaDatapoint &datapoint) {
+      //Whether data type is BOOL or ENUM, it will still be a 1 or a 0, so the functions below are valid in both scenarios
       ESP_LOGV(TAG, "MCU reported oscillation is: %s", ONOFF(datapoint.value_bool));
       this->oscillating = datapoint.value_bool;
       this->publish_state();
+
+      this->oscillation_type_ = datapoint.type;
     });
   }
   if (this->direction_id_.has_value()) {
@@ -80,7 +83,11 @@ void TuyaFan::control(const fan::FanCall &call) {
     this->parent_->set_boolean_datapoint_value(*this->switch_id_, *call.get_state());
   }
   if (this->oscillation_id_.has_value() && call.get_oscillating().has_value()) {
-    this->parent_->set_boolean_datapoint_value(*this->oscillation_id_, *call.get_oscillating());
+    if (this->oscillation_type_ == TuyaDatapointType::ENUM) {
+      this->parent_->set_enum_datapoint_value(*this->oscillation_id_, *call.get_oscillating());
+    } else if (this->speed_type_ == TuyaDatapointType::INTEGER) {
+      this->parent_->set_integer_datapoint_value(*this->oscillation_id_, *call.get_oscillating());
+    }
   }
   if (this->direction_id_.has_value() && call.get_direction().has_value()) {
     bool enable = *call.get_direction() == fan::FanDirection::REVERSE;

--- a/esphome/components/tuya/fan/tuya_fan.h
+++ b/esphome/components/tuya/fan/tuya_fan.h
@@ -29,6 +29,7 @@ class TuyaFan : public Component, public fan::Fan {
   optional<uint8_t> direction_id_{};
   int speed_count_{};
   TuyaDatapointType speed_type_{};
+  TuyaDatapointType oscillation_type_{};
 };
 
 }  // namespace tuya


### PR DESCRIPTION
# What does this implement/fix?

Fixes the existing Tuya Fan Oscillation feature to work with ENUM data points (in addition to BOOL/INTEGER). The current implementation gives an error whenever attempting to set the datapoint when an ENUM type.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** N/A - didn't raise issue.

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**  N/A - no changes to documentation

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [X] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
fan:
  - platform: tuya
    name: "Fan"
    switch_datapoint: 1
    speed_datapoint: 3
    direction_datapoint: 8
    oscillation_datapoint: 2
    speed_count: 6
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
