### PR TITLE
Ensure filename is shown when YAML raises an error

### DIFF
--- a/esphome/yaml_util.py
+++ b/esphome/yaml_util.py
@@ -19,7 +19,7 @@ except ImportError:
     FastestAvailableSafeLoader = PurePythonLoader
 
 from esphome import core
-from esphome.config_helpers import Extend, Remove, read_config_file
+from esphome.config_helpers import Extend, Remove
 from esphome.core import (
     CORE,
     DocumentRange,
@@ -418,13 +418,20 @@ def load_yaml(fname: str, clear_secrets: bool = True) -> Any:
 
 def _load_yaml_internal(fname: str) -> Any:
     """Load a YAML file."""
-    content = read_config_file(fname)
     try:
-        return _load_yaml_internal_with_type(ESPHomeLoader, fname, content)
-    except EsphomeError:
-        # Loading failed, so we now load with the Python loader which has more
-        # readable exceptions
-        return _load_yaml_internal_with_type(ESPHomePurePythonLoader, fname, content)
+        with open(fname, encoding="utf-8") as f_handle:
+            try:
+                return _load_yaml_internal_with_type(ESPHomeLoader, fname, f_handle)
+            except EsphomeError:
+                # Loading failed, so we now load with the Python loader which has more
+                # readable exceptions
+                # Rewind the stream so we can try again
+                f_handle.seek(0, 0)
+                return _load_yaml_internal_with_type(
+                    ESPHomePurePythonLoader, fname, f_handle
+                )
+    except (UnicodeDecodeError, OSError) as err:
+        raise EsphomeError(f"Error reading file {fname}: {err}") from err
 
 
 def _load_yaml_internal_with_type(

--- a/esphome/yaml_util.py
+++ b/esphome/yaml_util.py
@@ -8,7 +8,7 @@ import math
 import os
 import uuid
 from typing import Any
-
+from io import TextIOWrapper
 import yaml
 import yaml.constructor
 from yaml import SafeLoader as PurePythonLoader
@@ -437,7 +437,7 @@ def _load_yaml_internal(fname: str) -> Any:
 def _load_yaml_internal_with_type(
     loader_type: type[ESPHomeLoader] | type[ESPHomePurePythonLoader],
     fname: str,
-    content: str,
+    content: str | TextIOWrapper,
 ) -> Any:
     """Load a YAML file."""
     loader = loader_type(content)

--- a/esphome/yaml_util.py
+++ b/esphome/yaml_util.py
@@ -437,7 +437,7 @@ def _load_yaml_internal(fname: str) -> Any:
 def _load_yaml_internal_with_type(
     loader_type: type[ESPHomeLoader] | type[ESPHomePurePythonLoader],
     fname: str,
-    content: str | TextIOWrapper,
+    content: TextIOWrapper,
 ) -> Any:
     """Load a YAML file."""
     loader = loader_type(content)

--- a/esphome/yaml_util.py
+++ b/esphome/yaml_util.py
@@ -7,8 +7,9 @@ import logging
 import math
 import os
 import uuid
-from typing import Any
 from io import TextIOWrapper
+from typing import Any
+
 import yaml
 import yaml.constructor
 from yaml import SafeLoader as PurePythonLoader

--- a/tests/unit_tests/fixtures/yaml_util/missing_comp.yaml
+++ b/tests/unit_tests/fixtures/yaml_util/missing_comp.yaml
@@ -1,0 +1,12 @@
+esphome:
+  name: test
+
+esp32:
+  board: esp32dev
+
+wifi:
+  ap: ~
+
+image:
+  - id: its_a_bug
+    file: "mdi:bug"

--- a/tests/unit_tests/test_yaml_util.py
+++ b/tests/unit_tests/test_yaml_util.py
@@ -22,3 +22,23 @@ def test_loading_a_broken_yaml_file(fixture_path):
         yaml_util.load_yaml(yaml_file)
     except EsphomeError as err:
         assert "broken_included.yaml" in str(err)
+
+
+def test_loading_a_yaml_file_with_a_missing_component(fixture_path):
+    """Ensure we show the filename for a yaml file with a missing component."""
+    yaml_file = fixture_path / "yaml_util" / "missing_comp.yaml"
+
+    try:
+        yaml_util.load_yaml(yaml_file)
+    except EsphomeError as err:
+        assert "missing_comp.yaml" in str(err)
+
+
+def test_loading_a_missing_file(fixture_path):
+    """We throw EsphomeError when loading a missing file."""
+    yaml_file = fixture_path / "yaml_util" / "missing.yaml"
+
+    try:
+        yaml_util.load_yaml(yaml_file)
+    except EsphomeError as err:
+        assert "missing.yaml" in str(err)


### PR DESCRIPTION
# What does this implement/fix?

We were doing the file I/O ourselves. Since PyYAML gives a much better error if we let it do the I/O on the file handle (for all loaders), we pass the handle in instead.  This mirrors how we load yaml in HA.

fixes esphome/issues#5423
fixes esphome/issues#5377

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
