### PR TITLE
Voice Assistant: add on_idle trigger and fix nevermind

### DIFF
--- a/esphome/components/voice_assistant/__init__.py
+++ b/esphome/components/voice_assistant/__init__.py
@@ -32,6 +32,7 @@ CONF_ON_TTS_START = "on_tts_start"
 CONF_ON_TTS_STREAM_START = "on_tts_stream_start"
 CONF_ON_TTS_STREAM_END = "on_tts_stream_end"
 CONF_ON_WAKE_WORD_DETECTED = "on_wake_word_detected"
+CONF_ON_IDLE = "on_idle"
 
 CONF_SILENCE_DETECTION = "silence_detection"
 CONF_USE_WAKE_WORD = "use_wake_word"
@@ -125,6 +126,9 @@ CONFIG_SCHEMA = cv.All(
                 single=True
             ),
             cv.Optional(CONF_ON_TTS_STREAM_END): automation.validate_automation(
+                single=True
+            ),
+            cv.Optional(CONF_ON_IDLE): automation.validate_automation(
                 single=True
             ),
         }
@@ -257,6 +261,13 @@ async def to_code(config):
             var.get_tts_stream_end_trigger(),
             [],
             config[CONF_ON_TTS_STREAM_END],
+        )
+
+    if CONF_ON_IDLE in config:
+        await automation.build_automation(
+            var.get_idle_trigger(),
+            [],
+            config[CONF_ON_IDLE],
         )
 
     cg.add_define("USE_VOICE_ASSISTANT")

--- a/esphome/components/voice_assistant/__init__.py
+++ b/esphome/components/voice_assistant/__init__.py
@@ -128,9 +128,7 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_ON_TTS_STREAM_END): automation.validate_automation(
                 single=True
             ),
-            cv.Optional(CONF_ON_IDLE): automation.validate_automation(
-                single=True
-            ),
+            cv.Optional(CONF_ON_IDLE): automation.validate_automation(single=True),
         }
     ).extend(cv.COMPONENT_SCHEMA),
     tts_stream_validate,

--- a/esphome/components/voice_assistant/voice_assistant.cpp
+++ b/esphome/components/voice_assistant/voice_assistant.cpp
@@ -135,6 +135,8 @@ void VoiceAssistant::loop() {
   switch (this->state_) {
     case State::IDLE: {
       if (this->continuous_ && this->desired_state_ == State::IDLE) {
+        this->idle_trigger_->trigger();
+
         this->ring_buffer_->reset();
 #ifdef USE_ESP_ADF
         if (this->use_wake_word_) {
@@ -618,6 +620,9 @@ void VoiceAssistant::on_event(const api::VoiceAssistantEventResponse &msg) {
         {
           this->set_state_(State::IDLE, State::IDLE);
         }
+      } else if (this->state_ == State::AWAITING_RESPONSE) {
+        // No TTS start event ("nevermind")
+        this->set_state_(State::IDLE, State::IDLE);
       }
       this->defer([this]() { this->end_trigger_->trigger(); });
       break;

--- a/esphome/components/voice_assistant/voice_assistant.h
+++ b/esphome/components/voice_assistant/voice_assistant.h
@@ -116,6 +116,7 @@ class VoiceAssistant : public Component {
   Trigger<std::string> *get_tts_end_trigger() const { return this->tts_end_trigger_; }
   Trigger<std::string> *get_tts_start_trigger() const { return this->tts_start_trigger_; }
   Trigger<std::string, std::string> *get_error_trigger() const { return this->error_trigger_; }
+  Trigger<> *get_idle_trigger() const { return this->idle_trigger_; }
 
   Trigger<> *get_client_connected_trigger() const { return this->client_connected_trigger_; }
   Trigger<> *get_client_disconnected_trigger() const { return this->client_disconnected_trigger_; }
@@ -148,6 +149,7 @@ class VoiceAssistant : public Component {
   Trigger<std::string> *tts_end_trigger_ = new Trigger<std::string>();
   Trigger<std::string> *tts_start_trigger_ = new Trigger<std::string>();
   Trigger<std::string, std::string> *error_trigger_ = new Trigger<std::string, std::string>();
+  Trigger<> *idle_trigger_ = new Trigger<>();
 
   Trigger<> *client_connected_trigger_ = new Trigger<>();
   Trigger<> *client_disconnected_trigger_ = new Trigger<>();


### PR DESCRIPTION
# What does this implement/fix?

The `Nevermind` intent in HA does not produce TTS start/end events. This causes the current voice assistant to freeze, since it gets stuck in the `AWAITING_RESPONSE` state. This PR returns the assistant to the `IDLE` state instead.

Additionally, this PR adds an `idle` trigger to `voice_assistant`. There are currently 4 ways (I believe) to exit from a pipeline run:

1. A wake word timeout (technically an error, but handled differently) - no trigger, `WAITING_FOR_VAD` state is set
2. An error - `on_error` trigger is called and the `IDLE` state is set
3. A run with TTS - `on_tts_stream_end` is ultimately called and the `IDLE` state is set
4. (New) A run without TTS - `on_idle` is called and the `IDLE` state is set

Without the `idle` trigger, condition 4 will not be handled and the display will not be updated. The default YAML will need this addition:

```yaml
voice_assistant:
  # ...
  on_idle:
    - lambda: id(voice_assistant_phase) = ${voice_assist_idle_phase_id};
    - script.execute: draw_display

```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#3572

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
