### PR TITLE
Ld2410 light unit missing

### DIFF
--- a/esphome/components/ld2410/sensor.py
+++ b/esphome/components/ld2410/sensor.py
@@ -4,6 +4,7 @@ import esphome.config_validation as cv
 from esphome.const import (
     DEVICE_CLASS_DISTANCE,
     UNIT_CENTIMETER,
+    UNIT_LUX,
     UNIT_PERCENT,
     CONF_LIGHT,
     DEVICE_CLASS_ILLUMINANCE,
@@ -48,6 +49,7 @@ CONFIG_SCHEMA = cv.Schema(
             device_class=DEVICE_CLASS_ILLUMINANCE,
             entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
             icon=ICON_LIGHTBULB,
+            unit_of_measurement=UNIT_LUX,
         ),
         cv.Optional(CONF_DETECTION_DISTANCE): sensor.sensor_schema(
             device_class=DEVICE_CLASS_DISTANCE,


### PR DESCRIPTION
# What does this implement/fix?

- Light sensor of component LD2410 has no unit

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other


## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
