### PR TITLE
Allow ESP8266 to use multiple i2c busses

### DIFF
--- a/esphome/components/i2c/i2c_bus_arduino.cpp
+++ b/esphome/components/i2c/i2c_bus_arduino.cpp
@@ -89,7 +89,7 @@ void ArduinoI2CBus::dump_config() {
 
 ErrorCode ArduinoI2CBus::readv(uint8_t address, ReadBuffer *buffers, size_t cnt) {
 #if defined(USE_ESP8266)
-  set_pins_and_clock_();  // reconfigure Wire global state in case there are multiple instances
+  this->set_pins_and_clock_();  // reconfigure Wire global state in case there are multiple instances
 #endif
 
   // logging is only enabled with vv level, if warnings are shown the caller

--- a/esphome/components/i2c/i2c_bus_arduino.cpp
+++ b/esphome/components/i2c/i2c_bus_arduino.cpp
@@ -131,7 +131,7 @@ ErrorCode ArduinoI2CBus::readv(uint8_t address, ReadBuffer *buffers, size_t cnt)
 }
 ErrorCode ArduinoI2CBus::writev(uint8_t address, WriteBuffer *buffers, size_t cnt, bool stop) {
 #if defined(USE_ESP8266)
-  set_pins_and_clock_();  // reconfigure Wire global state in case there are multiple instances
+  this->set_pins_and_clock_();  // reconfigure Wire global state in case there are multiple instances
 #endif
 
   // logging is only enabled with vv level, if warnings are shown the caller

--- a/esphome/components/i2c/i2c_bus_arduino.cpp
+++ b/esphome/components/i2c/i2c_bus_arduino.cpp
@@ -37,7 +37,7 @@ void ArduinoI2CBus::setup() {
 
   this->set_pins_and_clock_();
 
-  initialized_ = true;
+  this->initialized_ = true;
   if (this->scan_) {
     ESP_LOGV(TAG, "Scanning i2c bus for active devices...");
     this->i2c_scan_();

--- a/esphome/components/i2c/i2c_bus_arduino.cpp
+++ b/esphome/components/i2c/i2c_bus_arduino.cpp
@@ -24,7 +24,7 @@ void ArduinoI2CBus::setup() {
   }
   next_bus_num++;
 #elif defined(USE_ESP8266)
-  wire_ = &Wire;  // NOLINT(cppcoreguidelines-prefer-member-initializer)
+  wire_ = new TwoWire();  // NOLINT(cppcoreguidelines-owning-memory)
 #elif defined(USE_RP2040)
   static bool first = true;
   if (first) {
@@ -35,6 +35,16 @@ void ArduinoI2CBus::setup() {
   }
 #endif
 
+  set_pins_and_clock_();
+
+  initialized_ = true;
+  if (this->scan_) {
+    ESP_LOGV(TAG, "Scanning i2c bus for active devices...");
+    this->i2c_scan_();
+  }
+}
+
+void ArduinoI2CBus::set_pins_and_clock_() {
 #ifdef USE_RP2040
   wire_->setSDA(this->sda_pin_);
   wire_->setSCL(this->scl_pin_);
@@ -43,12 +53,8 @@ void ArduinoI2CBus::setup() {
   wire_->begin(static_cast<int>(sda_pin_), static_cast<int>(scl_pin_));
 #endif
   wire_->setClock(frequency_);
-  initialized_ = true;
-  if (this->scan_) {
-    ESP_LOGV(TAG, "Scanning i2c bus for active devices...");
-    this->i2c_scan_();
-  }
 }
+
 void ArduinoI2CBus::dump_config() {
   ESP_LOGCONFIG(TAG, "I2C Bus:");
   ESP_LOGCONFIG(TAG, "  SDA Pin: GPIO%u", this->sda_pin_);
@@ -82,6 +88,10 @@ void ArduinoI2CBus::dump_config() {
 }
 
 ErrorCode ArduinoI2CBus::readv(uint8_t address, ReadBuffer *buffers, size_t cnt) {
+#if defined(USE_ESP8266)
+  set_pins_and_clock_();  // reconfigure Wire global state in case there are multiple instances
+#endif
+
   // logging is only enabled with vv level, if warnings are shown the caller
   // should log them
   if (!initialized_) {
@@ -120,6 +130,10 @@ ErrorCode ArduinoI2CBus::readv(uint8_t address, ReadBuffer *buffers, size_t cnt)
   return ERROR_OK;
 }
 ErrorCode ArduinoI2CBus::writev(uint8_t address, WriteBuffer *buffers, size_t cnt, bool stop) {
+#if defined(USE_ESP8266)
+  set_pins_and_clock_();  // reconfigure Wire global state in case there are multiple instances
+#endif
+
   // logging is only enabled with vv level, if warnings are shown the caller
   // should log them
   if (!initialized_) {
@@ -164,7 +178,7 @@ ErrorCode ArduinoI2CBus::writev(uint8_t address, WriteBuffer *buffers, size_t cn
       return ERROR_UNKNOWN;
     case 2:
     case 3:
-      ESP_LOGVV(TAG, "TX failed: not acknowledged");
+      ESP_LOGVV(TAG, "TX failed: not acknowledged: %d", status);
       return ERROR_NOT_ACKNOWLEDGED;
     case 5:
       ESP_LOGVV(TAG, "TX failed: timeout");

--- a/esphome/components/i2c/i2c_bus_arduino.cpp
+++ b/esphome/components/i2c/i2c_bus_arduino.cpp
@@ -35,7 +35,7 @@ void ArduinoI2CBus::setup() {
   }
 #endif
 
-  set_pins_and_clock_();
+  this->set_pins_and_clock_();
 
   initialized_ = true;
   if (this->scan_) {

--- a/esphome/components/i2c/i2c_bus_arduino.h
+++ b/esphome/components/i2c/i2c_bus_arduino.h
@@ -30,6 +30,7 @@ class ArduinoI2CBus : public I2CBus, public Component {
 
  private:
   void recover_();
+  void set_pins_and_clock_();
   RecoveryCode recovery_result_;
 
  protected:


### PR DESCRIPTION
# What does this implement/fix?

I have some esp8266 D1 devices which I made which have both an AHT10 and BMP025 sensor attached, but I wired these to separate i2c busses. With my own custom firmware these worked just fine, but when installing esphome and setting up the i2c busses I found that only one sensor at a time would be working.

I traced this down to the Wire.h library, which stores SDA and SCL pin assignments in global variables :roll_eyes: 

This PR works around this by resetting the SDA/SCL assignments and clock frequency between every i2c read and write.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):**
EDIT: found an issue relating to this: https://github.com/esphome/issues/issues/2558

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
esphome:
  name: env-sensors

esp8266:
  board: nodemcuv2

# Enable logging
logger:

# Enable Home Assistant API
api:
  password: ""

ota:
  password: ""

wifi:
  ssid: !secret wifi_ssid
  password: !secret wifi_pass

  # Enable fallback hotspot (captive portal) in case wifi connection fails
  ap:
    ssid: "Fallback Hotspot"
    password: "nnnnnnnnnn"

captive_portal:
  #

external_components:
  - source:
      type: git
      url: https://github.com/LouDou/esphome
      ref: i2c-esp8266-multi-bus
    components: [i2c]

i2c:
  - id: bus_a
    sda: D2
    scl: D3
    frequency: 100kHz
    scan: false
  - id: bus_b
    sda: D5
    scl: D6
    frequency: 100kHz
    scan: false

# probably any two sensors on different busses would be able to reproduce the issue on ESP8266
sensor:
  # SDA D2, SCL D3
  # AHT10_ADDRESS_0X38
  - platform: aht10
    variant: AHT10
    i2c_id: bus_a
    address: 0x38
    temperature:
      name: "Temperature (1)"
    humidity:
      name: "Humidity"
    update_interval: 300s

  # SDA D5, SCL D6
  - platform: bmp085
    i2c_id: bus_b
    address: 0x77
    temperature:
      name: "Temperature (2)"
    pressure:
      name: "Atm. Pressure"
    update_interval: 300s

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder). - no tests exist for i2c component

If user exposed functionality or configuration variables are added/changed: N/A
