### PR TITLE
ILI9XXX: Restore offset usage in set_addr_window

### DIFF
--- a/esphome/components/ili9xxx/ili9xxx_display.cpp
+++ b/esphome/components/ili9xxx/ili9xxx_display.cpp
@@ -366,6 +366,10 @@ void ILI9XXXDisplay::init_lcd_() {
 
 // Tell the display controller where we want to draw pixels.
 void ILI9XXXDisplay::set_addr_window_(uint16_t x1, uint16_t y1, uint16_t x2, uint16_t y2) {
+  x1 += this->offset_x_;
+  x2 += this->offset_x_;
+  y1 += this->offset_y_;
+  y2 += this->offset_y_;
   this->command(ILI9XXX_CASET);
   this->data(x1 >> 8);
   this->data(x1 & 0xFF);


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->
this fixes a bug introduced in the recent changes for the Pico Res Touch 3.5 support. The x and y offsets to the screen
position were lost. Affects the T-Embed.
## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
