### PR TITLE
Fixes sml parser to process extended length lists with a number of items that is dividable by 16

### DIFF
--- a/esphome/components/sml/sml_parser.cpp
+++ b/esphome/components/sml/sml_parser.cpp
@@ -27,7 +27,7 @@ bool SmlFile::setup_node(SmlNode *node) {
   uint8_t parse_length = length;
   if (has_extended_length) {
     length = (length << 4) + (this->buffer_[this->pos_ + 1] & 0x0f);
-    parse_length = length - 1;
+    parse_length = length;
     this->pos_ += 1;
   }
 
@@ -37,7 +37,9 @@ bool SmlFile::setup_node(SmlNode *node) {
   node->type = type & 0x07;
   node->nodes.clear();
   node->value_bytes.clear();
-  if (this->buffer_[this->pos_] == 0x00) {  // end of message
+
+  // if the list is a has_extended_length list with e.g. 16 elements this is a 0x00 byte but not the end of message
+  if (!has_extended_length && this->buffer_[this->pos_] == 0x00) {  // end of message
     this->pos_ += 1;
   } else if (is_list) {  // list
     this->pos_ += 1;


### PR DESCRIPTION
# What does this implement/fix?

My smartmeter type ZPA crashes the esp when receiving each sml message. 
By chance this meter sends a list of 16 items and the sml parser had a bug when the number of items is dividable by 16. 

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** 

Maybe some of the problems of https://github.com/esphome/issues/issues/4642 are fixed.

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** 

no docs needed

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

See default yaml from docs: https://esphome.io/components/sml.html?highlight=sml

The original error is only observed with certain smart meters like ZPA. If needed I could provide a binary dump of the message that crashes esphime.


## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

Currently there are no tests for the sml parser

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).


## Details of fix

The code change is very small. If the extended length field is used and the low part of the 2nd byte is 0x0 then the end-of-message-if was triggered. That was wrong. A list with e.g. 16 items is valid AND has a 2nd byte with 0x00. This is followed by the Data and is not the end of message.

Furthermore. The calculation `parse_length = length - 1;` was wrong since. 0x10 is 16 items not 15. for 15 0x0F is used and no extended-length is needed.



