### PR TITLE
Minimum 1 for full_update_every to prevent IntegerDivideByZero.

### DIFF
--- a/esphome/components/waveshare_epaper/display.py
+++ b/esphome/components/waveshare_epaper/display.py
@@ -135,7 +135,7 @@ CONFIG_SCHEMA = cv.All(
             cv.Required(CONF_MODEL): cv.one_of(*MODELS, lower=True),
             cv.Optional(CONF_RESET_PIN): pins.gpio_output_pin_schema,
             cv.Optional(CONF_BUSY_PIN): pins.gpio_input_pin_schema,
-            cv.Optional(CONF_FULL_UPDATE_EVERY): cv.uint32_t,
+            cv.Optional(CONF_FULL_UPDATE_EVERY): cv.int_range(min=1, max=4294967295),
             cv.Optional(CONF_RESET_DURATION): cv.All(
                 cv.positive_time_period_milliseconds,
                 cv.Range(max=core.TimePeriod(milliseconds=500)),


### PR DESCRIPTION
# What does this implement/fix?

I naively assumed that setting the `full_update_every` to `0` should disable the full updates. It did not. It caused my ESP to go in a boot loop with this error:
```
Guru Meditation Error: Core  1 panic'ed (IntegerDivideByZero). Exception was unhandled.

Core  1 register dump:
PC      : 0x400df034  PS      : 0x00060b30  A0      : 0x800df1a6  A1      : 0x3ffb2240  
A2      : 0x3ffb3a68  A3      : 0x3ffb47e4  A4      : 0x3f403888  A5      : 0x3ffb8aac  
A6      : 0x00000000  A7      : 0x00000000  A8      : 0x00000001  A9      : 0x00000000  
A10     : 0x3ffb3a68  A11     : 0x00000020  A12     : 0x00001280  A13     : 0x400d9ad8  
A14     : 0x3ffd30d6  A15     : 0x3ffb2204  SAR     : 0x00000012  EXCCAUSE: 0x00000006  
EXCVADDR: 0x00000000  LBEG    : 0x40084699  LEND    : 0x400846a1  LCOUNT  : 0x00000027  
```
So here's a tiny bit of validation to prevent this from happening :)

In the future, the component might need some rewriting to support disabling full refreshes, but for now setting the value to the highest possible value(4294967295) should do that job too.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

This should give an error now:
```yaml
display:
  - platform: waveshare_epaper
    cs_pin: D2
    dc_pin: D3
    busy_pin: D4
    reset_pin: D5
    model: 2.90in
    full_update_every: 0
    lambda: |-
      it.print(0, 0, id(font1), "Hello World!");
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
