### PR TITLE
sm2135: add separate_modes option to support different chip variants

### DIFF
--- a/esphome/components/sm2135/__init__.py
+++ b/esphome/components/sm2135/__init__.py
@@ -15,6 +15,7 @@ SM2135 = sm2135_ns.class_("SM2135", cg.Component)
 
 CONF_RGB_CURRENT = "rgb_current"
 CONF_CW_CURRENT = "cw_current"
+CONF_SEPARATE_MODES = "separate_modes"
 
 SM2135Current = sm2135_ns.enum("SM2135Current")
 
@@ -51,6 +52,7 @@ CONFIG_SCHEMA = cv.Schema(
         cv.Required(CONF_CLOCK_PIN): pins.gpio_output_pin_schema,
         cv.Optional(CONF_RGB_CURRENT, "20mA"): cv.enum(DRIVE_STRENGTHS_RGB),
         cv.Optional(CONF_CW_CURRENT, "10mA"): cv.enum(DRIVE_STRENGTHS_CW),
+        cv.Optional(CONF_SEPARATE_MODES, default=True): cv.boolean,
     }
 ).extend(cv.COMPONENT_SCHEMA)
 
@@ -66,3 +68,4 @@ async def to_code(config):
 
     cg.add(var.set_rgb_current(config[CONF_RGB_CURRENT]))
     cg.add(var.set_cw_current(config[CONF_CW_CURRENT]))
+    cg.add(var.set_separate_modes(config[CONF_SEPARATE_MODES]))

--- a/esphome/components/sm2135/sm2135.cpp
+++ b/esphome/components/sm2135/sm2135.cpp
@@ -97,23 +97,32 @@ void SM2135::loop() {
   this->write_byte_(SM2135_ADDR_MC);
   this->write_byte_(current_mask_);
 
-  if (this->update_channel_ == 3 || this->update_channel_ == 4) {
-    // No color so must be Cold/Warm
+  if (this->separate_modes_) {
+    if (this->update_channel_ == 3 || this->update_channel_ == 4) {
+      // No color so must be Cold/Warm
 
-    this->write_byte_(SM2135_CW);
-    this->sm2135_stop_();
-    delay(1);
-    this->sm2135_start_();
-    this->write_byte_(SM2135_ADDR_C);
-    this->write_byte_(this->pwm_amounts_[4]);  // Warm
-    this->write_byte_(this->pwm_amounts_[3]);  // Cold
+      this->write_byte_(SM2135_CW);
+      this->sm2135_stop_();
+      delay(1);
+      this->sm2135_start_();
+      this->write_byte_(SM2135_ADDR_C);
+      this->write_byte_(this->pwm_amounts_[4]);  // Warm
+      this->write_byte_(this->pwm_amounts_[3]);  // Cold
+    } else {
+      // Color
+
+      this->write_byte_(SM2135_RGB);
+      this->write_byte_(this->pwm_amounts_[1]);  // Green
+      this->write_byte_(this->pwm_amounts_[0]);  // Red
+      this->write_byte_(this->pwm_amounts_[2]);  // Blue
+    }
   } else {
-    // Color
-
     this->write_byte_(SM2135_RGB);
     this->write_byte_(this->pwm_amounts_[1]);  // Green
     this->write_byte_(this->pwm_amounts_[0]);  // Red
     this->write_byte_(this->pwm_amounts_[2]);  // Blue
+    this->write_byte_(this->pwm_amounts_[4]);  // Warm
+    this->write_byte_(this->pwm_amounts_[3]);  // Cold
   }
 
   this->sm2135_stop_();

--- a/esphome/components/sm2135/sm2135.h
+++ b/esphome/components/sm2135/sm2135.h
@@ -39,6 +39,8 @@ class SM2135 : public Component {
     this->current_mask_ = (this->rgb_current_ << 4) | this->cw_current_;
   }
 
+  void set_separate_modes(bool separate_modes) { this->separate_modes_ = separate_modes; }
+
   void setup() override;
 
   void dump_config() override;
@@ -78,6 +80,7 @@ class SM2135 : public Component {
   uint8_t current_mask_;
   SM2135Current rgb_current_;
   SM2135Current cw_current_;
+  bool separate_modes_;
   uint8_t update_channel_;
   std::vector<uint8_t> pwm_amounts_;
   bool update_{true};


### PR DESCRIPTION
# What does this implement/fix?
<!-- Quick description and explanation of changes -->
The current code only has support for chips that only support separate RGB and CT light like SM2135E. This adds support for chips like the SM2135EJ or SM2135EG that can have RGB and CT on at the same time. This PR moves this support behind a flag separate_modes, and is a non-breaking change for existing SM2135E users of the component.

This is the opposite of default values in https://github.com/openshwprojects/OpenBK7231T_App, with flag 9 or OBK_FLAG_SM2135_SEPARATE_MODES. I referenced these lines of code: https://github.com/openshwprojects/OpenBK7231T_App/blob/9d3e20d7719cf33afbf3fff23c92336dad04c181/src/driver/drv_sm2135.c#L24C1-L63C3

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/2504 (probably related)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#3579

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [x] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
```yaml
# Example config.yaml
# This is the config I use with Action LSC connect GU10 RGBWW with the beken chip.
sm2135:
  data_pin: P24
  clock_pin: P26
  cw_current: 20mA
  separate_modes: false

output:
  - platform: sm2135
    id: output_red
    channel: 2
    max_power: 0.90
    zero_means_zero: true
  - platform: sm2135
    id: output_green
    channel: 1
    max_power: 0.90
    zero_means_zero: true
  - platform: sm2135
    id: output_blue
    channel: 0
    max_power: 0.40
    zero_means_zero: true
  - platform: sm2135
    id: output_cold
    channel: 3
    min_power: 0.02
    max_power: 0.90
    zero_means_zero: true
  - platform: sm2135
    id: output_warm
    channel: 4
    min_power: 0.02
    max_power: 0.90
    zero_means_zero: true

light:
  - platform: rgbww
    id: light_rgbww
    icon: mdi:spotlight-beam
    name: Light
    color_interlock: true
    cold_white_color_temperature: 6536 K
    warm_white_color_temperature: 2000 K
    red: output_red
    green: output_green
    blue: output_blue
    cold_white: output_cold
    warm_white: output_warm
    constant_brightness: false
    default_transition_length: 0s
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

