### PR TITLE
Improve error message when client uses encryption when not enabled

### DIFF
--- a/esphome/components/api/api_frame_helper.cpp
+++ b/esphome/components/api/api_frame_helper.cpp
@@ -211,7 +211,11 @@ APIError APINoiseFrameHelper::try_read_frame_(ParsedFrame *frame) {
   uint8_t indicator = rx_header_buf_[0];
   if (indicator != 0x01) {
     state_ = State::FAILED;
-    HELPER_LOG("Bad indicator byte %u", indicator);
+    if (indicator == 0x00) {
+      HELPER_LOG("Client requested plaintext, but only noise encryption is required");
+    } else {
+      HELPER_LOG("Bad indicator byte %u", indicator);
+    }
     return APIError::BAD_INDICATOR;
   }
 
@@ -818,7 +822,11 @@ APIError APIPlaintextFrameHelper::try_read_frame_(ParsedFrame *frame) {
     // try parse header
     if (rx_header_buf_[0] != 0x00) {
       state_ = State::FAILED;
-      HELPER_LOG("Bad indicator byte %u", rx_header_buf_[0]);
+      if (rx_header_buf_[0] == 0x01) {
+        HELPER_LOG("Client requested noise encryption, but only plaintext is available");
+      } else {
+        HELPER_LOG("Bad indicator byte %u", rx_header_buf_[0]);
+      }
       return APIError::BAD_INDICATOR;
     }
 


### PR DESCRIPTION

# What does this implement/fix?

Improve error message when client uses encryption when not enabled
Also improves the error message when the client uses plaintext when noise is required

`Bad indicator byte` is cryptic to most users and it generates questions that can be avoided with a better error message

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
