### PR TITLE
LTR390 - Multiple bugfixes

### DIFF
--- a/esphome/components/ltr390/ltr390.cpp
+++ b/esphome/components/ltr390/ltr390.cpp
@@ -8,6 +8,17 @@ namespace ltr390 {
 
 static const char *const TAG = "ltr390";
 
+static const float GAINVALUES[5] = {1.0, 3.0, 6.0, 9.0, 18.0};
+static const float RESOLUTIONVALUE[6] = {4.0, 2.0, 1.0, 0.5, 0.25, 0.125};
+
+// Request fastest measurement rate - will be slowed by device if conversion rate is slower.
+static const float RESOLUTION_SETTING[6] = {0x00, 0x10, 0x20, 0x30, 0x40, 0x50};
+static const uint32_t MODEADDRESSES[2] = {0x0D, 0x10};
+
+static const float SENSITIVITY_MAX = 2300;
+static const float INTG_MAX = RESOLUTIONVALUE[0] * 100;
+static const int GAIN_MAX = GAINVALUES[4];
+
 uint32_t little_endian_bytes_to_int(const uint8_t *buffer, uint8_t num_bytes) {
   uint32_t value = 0;
 

--- a/esphome/components/ltr390/ltr390.cpp
+++ b/esphome/components/ltr390/ltr390.cpp
@@ -8,10 +8,6 @@ namespace ltr390 {
 
 static const char *const TAG = "ltr390";
 
-static const float GAINVALUES[5] = {1.0, 3.0, 6.0, 9.0, 18.0};
-static const float RESOLUTIONVALUE[6] = {4.0, 2.0, 1.0, 0.5, 0.25, 0.125};
-static const uint32_t MODEADDRESSES[2] = {0x0D, 0x10};
-
 uint32_t little_endian_bytes_to_int(const uint8_t *buffer, uint8_t num_bytes) {
   uint32_t value = 0;
 
@@ -58,7 +54,7 @@ void LTR390Component::read_als_() {
   uint32_t als = *val;
 
   if (this->light_sensor_ != nullptr) {
-    float lux = (0.6 * als) / (GAINVALUES[this->gain_] * RESOLUTIONVALUE[this->res_]) * this->wfac_;
+    float lux = ((0.6 * als) / (GAINVALUES[this->gain_] * RESOLUTIONVALUE[this->res_])) * this->wfac_;
     this->light_sensor_->publish_state(lux);
   }
 
@@ -74,7 +70,7 @@ void LTR390Component::read_uvs_() {
   uint32_t uv = *val;
 
   if (this->uvi_sensor_ != nullptr) {
-    this->uvi_sensor_->publish_state(uv / LTR390_SENSITIVITY * this->wfac_);
+    this->uvi_sensor_->publish_state( (uv / this->sensitivity_) * this->wfac_);
   }
 
   if (this->uv_sensor_ != nullptr) {
@@ -132,12 +128,13 @@ void LTR390Component::setup() {
   // Set gain
   this->reg(LTR390_GAIN) = gain_;
 
-  // Set resolution
-  uint8_t res = this->reg(LTR390_MEAS_RATE).get();
-  // resolution is in bits 5-7
-  res &= ~0b01110000;
-  res |= res << 4;
-  this->reg(LTR390_MEAS_RATE) = res;
+  // Set resolution and measurement rate
+  this->reg(LTR390_MEAS_RATE) = RESOLUTION_SETTING[this->res_] ;
+
+  // Set sensitivity by linearly scaling against known value in the datasheet
+  float gain_scale = GAINVALUES[this->gain_]/GAIN_MAX;
+  float intg_scale = (RESOLUTIONVALUE[this->res_]*100)/INTG_MAX;
+  this->sensitivity_ = SENSITIVITY_MAX * gain_scale * intg_scale;
 
   // Set sensor read state
   this->reading_ = false;

--- a/esphome/components/ltr390/ltr390.cpp
+++ b/esphome/components/ltr390/ltr390.cpp
@@ -70,7 +70,7 @@ void LTR390Component::read_uvs_() {
   uint32_t uv = *val;
 
   if (this->uvi_sensor_ != nullptr) {
-    this->uvi_sensor_->publish_state( (uv / this->sensitivity_) * this->wfac_);
+    this->uvi_sensor_->publish_state((uv / this->sensitivity_) * this->wfac_);
   }
 
   if (this->uv_sensor_ != nullptr) {
@@ -129,11 +129,11 @@ void LTR390Component::setup() {
   this->reg(LTR390_GAIN) = gain_;
 
   // Set resolution and measurement rate
-  this->reg(LTR390_MEAS_RATE) = RESOLUTION_SETTING[this->res_] ;
+  this->reg(LTR390_MEAS_RATE) = RESOLUTION_SETTING[this->res_];
 
   // Set sensitivity by linearly scaling against known value in the datasheet
-  float gain_scale = GAINVALUES[this->gain_]/GAIN_MAX;
-  float intg_scale = (RESOLUTIONVALUE[this->res_]*100)/INTG_MAX;
+  float gain_scale = GAINVALUES[this->gain_] / GAIN_MAX;
+  float intg_scale = (RESOLUTIONVALUE[this->res_] * 100) / INTG_MAX;
   this->sensitivity_ = SENSITIVITY_MAX * gain_scale * intg_scale;
 
   // Set sensor read state

--- a/esphome/components/ltr390/ltr390.cpp
+++ b/esphome/components/ltr390/ltr390.cpp
@@ -8,6 +8,12 @@ namespace ltr390 {
 
 static const char *const TAG = "ltr390";
 
+static const uint8_t LTR390_MAIN_CTRL = 0x00;
+static const uint8_t LTR390_MEAS_RATE = 0x04;
+static const uint8_t LTR390_GAIN = 0x05;
+static const uint8_t LTR390_PART_ID = 0x06;
+static const uint8_t LTR390_MAIN_STATUS = 0x07;
+
 static const float GAINVALUES[5] = {1.0, 3.0, 6.0, 9.0, 18.0};
 static const float RESOLUTIONVALUE[6] = {4.0, 2.0, 1.0, 0.5, 0.25, 0.125};
 

--- a/esphome/components/ltr390/ltr390.h
+++ b/esphome/components/ltr390/ltr390.h
@@ -17,12 +17,6 @@ enum LTR390CTRL {
 };
 
 // enums from https://github.com/adafruit/Adafruit_LTR390/
-static const uint8_t LTR390_MAIN_CTRL = 0x00;
-static const uint8_t LTR390_MEAS_RATE = 0x04;
-static const uint8_t LTR390_GAIN = 0x05;
-static const uint8_t LTR390_PART_ID = 0x06;
-static const uint8_t LTR390_MAIN_STATUS = 0x07;
-
 // Sensing modes
 enum LTR390MODE {
   LTR390_MODE_ALS,

--- a/esphome/components/ltr390/ltr390.h
+++ b/esphome/components/ltr390/ltr390.h
@@ -17,13 +17,11 @@ enum LTR390CTRL {
 };
 
 // enums from https://github.com/adafruit/Adafruit_LTR390/
-
 static const uint8_t LTR390_MAIN_CTRL = 0x00;
 static const uint8_t LTR390_MEAS_RATE = 0x04;
 static const uint8_t LTR390_GAIN = 0x05;
 static const uint8_t LTR390_PART_ID = 0x06;
 static const uint8_t LTR390_MAIN_STATUS = 0x07;
-static const float LTR390_SENSITIVITY = 2300.0;
 
 // Sensing modes
 enum LTR390MODE {
@@ -49,6 +47,17 @@ enum LTR390RESOLUTION {
   LTR390_RESOLUTION_16BIT,
   LTR390_RESOLUTION_13BIT,
 };
+
+static const float GAINVALUES[5] = {1.0, 3.0, 6.0, 9.0, 18.0};
+static const float RESOLUTIONVALUE[6] = {4.0, 2.0, 1.0, 0.5, 0.25, 0.125};
+
+// Request fastest measurement rate - will be slowed by device if conversion rate is slower.
+static const float RESOLUTION_SETTING[6] = {0x00, 0x10, 0x20, 0x30, 0x40, 0x50};
+static const uint32_t MODEADDRESSES[2] = {0x0D, 0x10};
+
+static const float SENSITIVITY_MAX = 2300;
+static const float INTG_MAX = RESOLUTIONVALUE[0]*100;
+static const int GAIN_MAX = GAINVALUES[4];
 
 class LTR390Component : public PollingComponent, public i2c::I2CDevice {
  public:
@@ -81,6 +90,7 @@ class LTR390Component : public PollingComponent, public i2c::I2CDevice {
 
   LTR390GAIN gain_;
   LTR390RESOLUTION res_;
+  float sensitivity_;
   float wfac_;
 
   sensor::Sensor *light_sensor_{nullptr};

--- a/esphome/components/ltr390/ltr390.h
+++ b/esphome/components/ltr390/ltr390.h
@@ -56,7 +56,7 @@ static const float RESOLUTION_SETTING[6] = {0x00, 0x10, 0x20, 0x30, 0x40, 0x50};
 static const uint32_t MODEADDRESSES[2] = {0x0D, 0x10};
 
 static const float SENSITIVITY_MAX = 2300;
-static const float INTG_MAX = RESOLUTIONVALUE[0]*100;
+static const float INTG_MAX = RESOLUTIONVALUE[0] * 100;
 static const int GAIN_MAX = GAINVALUES[4];
 
 class LTR390Component : public PollingComponent, public i2c::I2CDevice {

--- a/esphome/components/ltr390/ltr390.h
+++ b/esphome/components/ltr390/ltr390.h
@@ -48,17 +48,6 @@ enum LTR390RESOLUTION {
   LTR390_RESOLUTION_13BIT,
 };
 
-static const float GAINVALUES[5] = {1.0, 3.0, 6.0, 9.0, 18.0};
-static const float RESOLUTIONVALUE[6] = {4.0, 2.0, 1.0, 0.5, 0.25, 0.125};
-
-// Request fastest measurement rate - will be slowed by device if conversion rate is slower.
-static const float RESOLUTION_SETTING[6] = {0x00, 0x10, 0x20, 0x30, 0x40, 0x50};
-static const uint32_t MODEADDRESSES[2] = {0x0D, 0x10};
-
-static const float SENSITIVITY_MAX = 2300;
-static const float INTG_MAX = RESOLUTIONVALUE[0] * 100;
-static const int GAIN_MAX = GAINVALUES[4];
-
 class LTR390Component : public PollingComponent, public i2c::I2CDevice {
  public:
   float get_setup_priority() const override { return setup_priority::DATA; }

--- a/esphome/components/ltr390/sensor.py
+++ b/esphome/components/ltr390/sensor.py
@@ -8,6 +8,7 @@ from esphome.const import (
     CONF_RESOLUTION,
     UNIT_LUX,
     ICON_BRIGHTNESS_5,
+    DEVICE_CLASS_EMPTY,
     DEVICE_CLASS_ILLUMINANCE,
 )
 
@@ -61,19 +62,19 @@ CONFIG_SCHEMA = cv.All(
                 unit_of_measurement=UNIT_COUNTS,
                 icon=ICON_BRIGHTNESS_5,
                 accuracy_decimals=1,
-                device_class=DEVICE_CLASS_ILLUMINANCE,
+                device_class=DEVICE_CLASS_EMPTY,
             ),
             cv.Optional(CONF_UV_INDEX): sensor.sensor_schema(
                 unit_of_measurement=UNIT_UVI,
                 icon=ICON_BRIGHTNESS_5,
                 accuracy_decimals=5,
-                device_class=DEVICE_CLASS_ILLUMINANCE,
+                device_class=DEVICE_CLASS_EMPTY,
             ),
             cv.Optional(CONF_UV): sensor.sensor_schema(
                 unit_of_measurement=UNIT_COUNTS,
                 icon=ICON_BRIGHTNESS_5,
                 accuracy_decimals=1,
-                device_class=DEVICE_CLASS_ILLUMINANCE,
+                device_class=DEVICE_CLASS_EMPTY,
             ),
             cv.Optional(CONF_GAIN, default="X3"): cv.enum(GAIN_OPTIONS),
             cv.Optional(CONF_RESOLUTION, default=18): cv.enum(RES_OPTIONS),

--- a/esphome/components/ltr390/sensor.py
+++ b/esphome/components/ltr390/sensor.py
@@ -76,8 +76,8 @@ CONFIG_SCHEMA = cv.All(
                 accuracy_decimals=1,
                 device_class=DEVICE_CLASS_EMPTY,
             ),
-            cv.Optional(CONF_GAIN, default="X3"): cv.enum(GAIN_OPTIONS),
-            cv.Optional(CONF_RESOLUTION, default=18): cv.enum(RES_OPTIONS),
+            cv.Optional(CONF_GAIN, default="X18"): cv.enum(GAIN_OPTIONS),
+            cv.Optional(CONF_RESOLUTION, default=20): cv.enum(RES_OPTIONS),
             cv.Optional(CONF_WINDOW_CORRECTION_FACTOR, default=1.0): cv.float_range(
                 min=1.0
             ),


### PR DESCRIPTION
 # What does this implement/fix?

- fix https://github.com/esphome/issues/issues/4380
  - Set resolution parameter on the device, which was not set previously.
  - Added correction to UV index calculation to account for different gain and integration time combinations. 
  - Set default gain and resolution/integration time to the value which is used as a reference point in the data sheet and provides the most accurate values. All other UVI calculations are computed from this reference point.

- https://github.com/home-assistant/core/issues/88278
  - Fix incorrect device class

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** See above

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** https://github.com/esphome/esphome-docs/pull/3585

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
sensor:
  - platform: ltr390
    update_interval: 5s
    gain: "X3"
    resolution: 18
    uv_index:
      name: "UV Index"
    uv:
      name: "UV Counts"
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
