### PR TITLE
ld2420: Firmware v1.5.4+ bug workaround

### DIFF
--- a/esphome/components/ld2420/ld2420.cpp
+++ b/esphome/components/ld2420/ld2420.cpp
@@ -211,10 +211,11 @@ void LD2420Component::factory_reset_action() {
 void LD2420Component::restart_module_action() {
   ESP_LOGCONFIG(TAG, "Restarting LD2420 module...");
   this->send_module_restart();
-  delay_microseconds_safe(45000);
-  this->set_config_mode(true);
-  this->set_system_mode(system_mode_);
-  this->set_config_mode(false);
+  this->set_timeout(250, [this]() {
+    this->set_config_mode(true);
+    this->set_system_mode(system_mode_);
+    this->set_config_mode(false);
+  });
   ESP_LOGCONFIG(TAG, "LD2420 Restarted.");
 }
 
@@ -424,10 +425,6 @@ void LD2420Component::handle_simple_mode_(const uint8_t *inbuf, int len) {
 }
 
 void LD2420Component::handle_ack_data_(uint8_t *buffer, int len) {
-  // This is a workaround to a firmware bug that started in v1.5.4 if we send write registers updates
-  // faster than 22 per second the modules will not respond correctly and will ignore further commands
-  // The symptoms are constant detection at the 35cm range.
-  delay_microseconds_safe(70000);  // Throttle down to no more than 22 LD2420 register writes per second
   this->cmd_reply_.command = buffer[CMD_FRAME_COMMAND];
   this->cmd_reply_.length = buffer[CMD_FRAME_DATA_LENGTH];
   uint8_t reg_element = 0;
@@ -531,18 +528,16 @@ int LD2420Component::send_cmd_from_array(CmdFrameT frame) {
       this->write_byte(cmd_buffer[index]);
     }
 
-    delay_microseconds_safe(500);  // give the module a moment to process it
     error = 0;
     if (frame.command == CMD_RESTART) {
-      delay_microseconds_safe(25000);  // Wait for the restart
-      return 0;                        // restart does not reply exit now
+      return 0;  // restart does not reply exit now
     }
 
     while (!this->cmd_reply_.ack) {
       while (available()) {
         this->readline_(read(), ack_buffer, sizeof(ack_buffer));
       }
-      delay_microseconds_safe(250);
+      delay_microseconds_safe(1450);
       if (loop_count <= 0) {
         error = LD2420_ERROR_TIMEOUT;
         retry--;

--- a/esphome/components/ld2420/ld2420.cpp
+++ b/esphome/components/ld2420/ld2420.cpp
@@ -424,6 +424,10 @@ void LD2420Component::handle_simple_mode_(const uint8_t *inbuf, int len) {
 }
 
 void LD2420Component::handle_ack_data_(uint8_t *buffer, int len) {
+  // This is a workaround to a firmware bug that started in v1.5.4 if we send write registers updates
+  // faster than 22 per second the modules will not respond correctly and will ignore further commands
+  // The symptoms are constant detection at the 35cm range.
+  delay_microseconds_safe(70000);  // Throttle down to no more than 22 LD2420 register writes per second
   this->cmd_reply_.command = buffer[CMD_FRAME_COMMAND];
   this->cmd_reply_.length = buffer[CMD_FRAME_DATA_LENGTH];
   uint8_t reg_element = 0;


### PR DESCRIPTION
# What does this implement/fix?

This is a workaround to a firmware bug that started in v1.5.4 where if we send write registers updates
faster than 22 per second the module will not respond correctly and will ignore further commands.
The symptoms are constant detection at the 35cm range and no communication with it until a power cycle is done..

<!-- Quick description and explanation of changes -->

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/5115



## Test Environment

- [x] ESP32

## Example entry for `config.yaml`:
N/A

## Checklist:
  - [x] The code change is tested and works locally.
