### PR TITLE
dump config after logging CDC port is opened by host

### DIFF
--- a/esphome/components/logger/logger.cpp
+++ b/esphome/components/logger/logger.cpp
@@ -3,6 +3,7 @@
 
 #include "esphome/core/hal.h"
 #include "esphome/core/log.h"
+#include "esphome/core/application.h"
 
 namespace esphome {
 namespace logger {
@@ -127,6 +128,24 @@ Logger::Logger(uint32_t baud_rate, size_t tx_buffer_size) : baud_rate_(baud_rate
   // add 1 to buffer size for null terminator
   this->tx_buffer_ = new char[this->tx_buffer_size_ + 1];  // NOLINT
 }
+
+#ifdef USE_LOGGER_USB_CDC
+void Logger::loop() {
+#ifdef USE_ARDUINO
+  if (this->uart_ != UART_SELECTION_USB_CDC) {
+    return;
+  }
+  static bool opened = false;
+  if (opened == Serial) {
+    return;
+  }
+  if (false == opened) {
+    App.schedule_dump_config();
+  }
+  opened = !opened;
+#endif
+}
+#endif
 
 void Logger::set_baud_rate(uint32_t baud_rate) { this->baud_rate_ = baud_rate; }
 void Logger::set_log_level(const std::string &tag, int log_level) {

--- a/esphome/components/logger/logger.h
+++ b/esphome/components/logger/logger.h
@@ -56,7 +56,9 @@ enum UARTSelection {
 class Logger : public Component {
  public:
   explicit Logger(uint32_t baud_rate, size_t tx_buffer_size);
-
+#ifdef USE_LOGGER_USB_CDC
+  void loop() override;
+#endif
   /// Manually set the baud rate for serial, set to 0 to disable.
   void set_baud_rate(uint32_t baud_rate);
   uint32_t get_baud_rate() const { return baud_rate_; }


### PR DESCRIPTION
# What does this implement/fix?

USB CDC allows to check if port is opened on host side. It allows to see device configuration using CDC logger.
```
$ python -m esphome logs esps2.yaml 
INFO ESPHome 2024.1.0-dev
INFO Reading configuration esps2.yaml...
INFO Starting log output from /dev/ttyACM0 with baud rate 115200
[09:23:57][I][app:102]: ESPHome version 2024.1.0-dev compiled on Feb  3 2024, 09:23:33
[09:23:57][C][logger:188]: Logger:
[09:23:57][C][logger:189]:   Level: DEBUG
[09:23:57][C][logger:190]:   Log Baud Rate: 115200
[09:23:57][C][logger:191]:   Hardware UART: USB_CDC
```
## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [x] ESP32-S2

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
