### PR TITLE
CSE7766: fix power and current measurements at low loads

### DIFF
--- a/esphome/components/cse7766/cse7766.cpp
+++ b/esphome/components/cse7766/cse7766.cpp
@@ -1,6 +1,8 @@
 #include "cse7766.h"
 #include "esphome/core/log.h"
 #include <cinttypes>
+#include <iomanip>
+#include <sstream>
 
 namespace esphome {
 namespace cse7766 {
@@ -68,11 +70,16 @@ bool CSE7766Component::check_byte_() {
   return true;
 }
 void CSE7766Component::parse_data_() {
-  ESP_LOGVV(TAG, "CSE7766 Data: ");
-  for (uint8_t i = 0; i < 23; i++) {
-    ESP_LOGVV(TAG, "  %u: 0b" BYTE_TO_BINARY_PATTERN " (0x%02X)", i + 1, BYTE_TO_BINARY(this->raw_data_[i]),
-              this->raw_data_[i]);
+#if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERY_VERBOSE
+  {
+    std::stringstream ss;
+    ss << "Raw data:" << std::hex << std::uppercase << std::setfill('0');
+    for (uint8_t i = 0; i < 23; i++) {
+      ss << ' ' << std::setw(2) << static_cast<unsigned>(this->raw_data_[i]);
+    }
+    ESP_LOGVV(TAG, "%s", ss.str().c_str());
   }
+#endif
 
   uint8_t header1 = this->raw_data_[0];
   if (header1 == 0xAA) {

--- a/esphome/components/cse7766/cse7766.cpp
+++ b/esphome/components/cse7766/cse7766.cpp
@@ -168,9 +168,14 @@ void CSE7766Component::parse_data_() {
   }
 
   float current = 0.0f;
+  float calculated_current = 0.0f;
   if (have_current) {
     // Assumption: if we don't have power measurement, then current is likely below 50mA
-    if (have_power) {
+    if (have_power && voltage > 1.0f) {
+      calculated_current = power / voltage;
+    }
+    // Datasheet: minimum measured current is 50mA
+    if (calculated_current > 0.05f) {
       current = current_coeff / float(current_cycle);
     }
     if (this->current_sensor_ != nullptr) {
@@ -186,7 +191,7 @@ void CSE7766Component::parse_data_() {
       ss << " V=" << voltage << "V";
     }
     if (have_current) {
-      ss << " I=" << current * 1000.0f << "mA";
+      ss << " I=" << current * 1000.0f << "mA (~" << calculated_current * 1000.0f << "mA)";
     }
     if (have_power) {
       ss << " P=" << power << "W";

--- a/esphome/components/cse7766/cse7766.cpp
+++ b/esphome/components/cse7766/cse7766.cpp
@@ -81,14 +81,15 @@ void CSE7766Component::parse_data_() {
   }
 #endif
 
+  // Parse header
   uint8_t header1 = this->raw_data_[0];
+
   if (header1 == 0xAA) {
     ESP_LOGE(TAG, "CSE7766 not calibrated!");
     return;
   }
 
   bool power_cycle_exceeds_range = false;
-
   if ((header1 & 0xF0) == 0xF0) {
     if (header1 & 0xD) {
       ESP_LOGE(TAG, "CSE7766 reports abnormal external circuit or chip damage: (0x%02X)", header1);
@@ -101,74 +102,104 @@ void CSE7766Component::parse_data_() {
       if (header1 & (1 << 0)) {
         ESP_LOGE(TAG, "  Coefficient storage area is abnormal.");
       }
+
+      // Datasheet: voltage or current cycle exceeding range means invalid values
       return;
     }
 
     power_cycle_exceeds_range = header1 & (1 << 1);
   }
 
-  uint32_t voltage_calib = this->get_24_bit_uint_(2);
+  // Parse data frame
+  uint32_t voltage_coeff = this->get_24_bit_uint_(2);
   uint32_t voltage_cycle = this->get_24_bit_uint_(5);
-  uint32_t current_calib = this->get_24_bit_uint_(8);
+  uint32_t current_coeff = this->get_24_bit_uint_(8);
   uint32_t current_cycle = this->get_24_bit_uint_(11);
-  uint32_t power_calib = this->get_24_bit_uint_(14);
+  uint32_t power_coeff = this->get_24_bit_uint_(14);
   uint32_t power_cycle = this->get_24_bit_uint_(17);
-
   uint8_t adj = this->raw_data_[20];
   uint32_t cf_pulses = (this->raw_data_[21] << 8) + this->raw_data_[22];
 
+  bool have_power = adj & 0x10;
+  bool have_current = adj & 0x20;
   bool have_voltage = adj & 0x40;
+
+  float voltage = 0.0f;
   if (have_voltage) {
-    // voltage cycle of serial port outputted is a complete cycle;
-    float voltage = voltage_calib / float(voltage_cycle);
-    if (this->voltage_sensor_ != nullptr)
+    voltage = voltage_coeff / float(voltage_cycle);
+    if (this->voltage_sensor_ != nullptr) {
       this->voltage_sensor_->publish_state(voltage);
+    }
   }
 
-  bool have_power = adj & 0x10;
   float power = 0.0f;
-
+  float energy = 0.0f;
   if (have_power) {
-    // power cycle of serial port outputted is a complete cycle;
-    // According to the user manual, power cycle exceeding range means the measured power is 0
+    // Datasheet: power cycle exceeding range means active power is 0
     if (!power_cycle_exceeds_range) {
-      power = power_calib / float(power_cycle);
+      power = power_coeff / float(power_cycle);
     }
-    if (this->power_sensor_ != nullptr)
+    if (this->power_sensor_ != nullptr) {
       this->power_sensor_->publish_state(power);
+    }
 
-    uint32_t difference;
+    // Add CF pulses to the total energy only if we have Power coefficient to multiply by
+
     if (this->cf_pulses_last_ == 0) {
       this->cf_pulses_last_ = cf_pulses;
     }
 
+    uint32_t cf_diff;
     if (cf_pulses < this->cf_pulses_last_) {
-      difference = cf_pulses + (0x10000 - this->cf_pulses_last_);
+      cf_diff = cf_pulses + (0x10000 - this->cf_pulses_last_);
     } else {
-      difference = cf_pulses - this->cf_pulses_last_;
+      cf_diff = cf_pulses - this->cf_pulses_last_;
     }
     this->cf_pulses_last_ = cf_pulses;
-    this->energy_total_ += difference * float(power_calib) / 1000000.0f / 3600.0f;
+
+    energy = cf_diff * float(power_coeff) / 1000000.0f / 3600.0f;
+    this->energy_total_ += energy;
     if (this->energy_sensor_ != nullptr)
       this->energy_sensor_->publish_state(this->energy_total_);
   } else if ((this->energy_sensor_ != nullptr) && !this->energy_sensor_->has_state()) {
     this->energy_sensor_->publish_state(0);
   }
 
-  if (adj & 0x20) {
-    // indicates current cycle of serial port outputted is a complete cycle;
-    float current = 0.0f;
+  float current = 0.0f;
+  if (have_current) {
     if (have_voltage && !have_power) {
       // Testing has shown that when we have voltage and current but not power, that means the power is 0.
       // We report a power of 0, which in turn means we should report a current of 0.
-      if (this->power_sensor_ != nullptr)
+      if (this->power_sensor_ != nullptr) {
         this->power_sensor_->publish_state(0);
+      }
     } else if (power != 0.0f) {
-      current = current_calib / float(current_cycle);
+      current = current_coeff / float(current_cycle);
     }
-    if (this->current_sensor_ != nullptr)
+    if (this->current_sensor_ != nullptr) {
       this->current_sensor_->publish_state(current);
+    }
   }
+
+#if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERY_VERBOSE
+  {
+    std::stringstream ss;
+    ss << "Parsed:";
+    if (have_voltage) {
+      ss << " V=" << voltage << "V";
+    }
+    if (have_current) {
+      ss << " I=" << current * 1000.0f << "mA";
+    }
+    if (have_power) {
+      ss << " P=" << power << "W";
+    }
+    if (energy != 0.0f) {
+      ss << " E=" << energy << "kWh (" << cf_pulses << ")";
+    }
+    ESP_LOGVV(TAG, "%s", ss.str().c_str());
+  }
+#endif
 }
 
 uint32_t CSE7766Component::get_24_bit_uint_(uint8_t start_index) {


### PR DESCRIPTION
# What does this implement/fix?

CSE7766 (Sonoff S31) with the current implementation reports bad values at low loads. This PR fixes this along with some cleanup.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Other

**Related issue or feature (if applicable):** fixes a bug that hasn't been officially reported outside of this PR

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [X] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
esphome:
  name: s31
  friendly_name: S31

esp8266:
  board: esp01_1m

# Enable logging
logger:
  baud_rate: 0 # (UART logging interferes with cse7766)
  level: VERY_VERBOSE
  logs:
    sensor: VERBOSE
    api: INFO
    api.connection: INFO
    api.service: INFO
    scheduler: INFO
    mdns: INFO
    wifi: INFO

api:

ota:

wifi:
  ssid: !secret wifi_ssid
  password: !secret wifi_password

captive_portal:

uart:
  rx_pin: RX
  baud_rate: 4800

binary_sensor:
  - platform: gpio
    pin:
      number: GPIO0
      mode: INPUT_PULLUP
      inverted: True
    name: "Sonoff S31 Button"
    on_press:
      - switch.toggle: relay
  - platform: status
    name: "Sonoff S31 Status"

sensor:
  - platform: wifi_signal
    name: "Sonoff S31 WiFi Signal"
    update_interval: 60s
  - platform: cse7766
    #update_interval: 1s # XXX: this works with release branch, but not dev!
    current:
      name: "Sonoff S31 Current"
      accuracy_decimals: 4
    voltage:
      name: "Sonoff S31 Voltage"
      accuracy_decimals: 1
    power:
      name: "Sonoff S31 Power"
      accuracy_decimals: 2

switch:
  - platform: gpio
    name: "Sonoff S31 Relay"
    pin: GPIO12
    id: relay
    restore_mode: ALWAYS_ON

status_led:
  pin:
    number: GPIO13
    inverted: True
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
