### PR TITLE
Add support for the DA217 family of MEMS accelerometers

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -79,6 +79,7 @@ esphome/components/cs5460a/* @balrog-kun
 esphome/components/cse7761/* @berfenger
 esphome/components/ct_clamp/* @jesserockz
 esphome/components/current_based/* @djwmarcx
+esphome/components/da217/* @ecco
 esphome/components/dac7678/* @NickB1
 esphome/components/daikin_brc/* @hagak
 esphome/components/daly_bms/* @s1lvi0

--- a/esphome/components/da217/__init__.py
+++ b/esphome/components/da217/__init__.py
@@ -1,1 +1,2 @@
 CODEOWNERS = ["@ecco"]
+

--- a/esphome/components/da217/__init__.py
+++ b/esphome/components/da217/__init__.py
@@ -1,0 +1,1 @@
+CODEOWNERS = ["@ecco"]

--- a/esphome/components/da217/__init__.py
+++ b/esphome/components/da217/__init__.py
@@ -1,2 +1,1 @@
 CODEOWNERS = ["@ecco"]
-

--- a/esphome/components/da217/da217.cpp
+++ b/esphome/components/da217/da217.cpp
@@ -28,11 +28,11 @@ const uint8_t DA217_RESOLUTION_RANGE_WATCHDOG_50MS = 1 << 5;
 const uint8_t DA217_RESOLUTION_RANGE_RESOLUTION_14BITS = 0b00 << 2;
 const uint8_t DA217_RESOLUTION_RANGE_RESOLUTION_12BITS = 0b01 << 2;
 const uint8_t DA217_RESOLUTION_RANGE_RESOLUTION_10BITS = 0b10 << 2;
-const uint8_t DA217_RESOLUTION_RANGE_RESOLUTION_8BITS =  0b11 << 2;
-const uint8_t DA217_RESOLUTION_RANGE_SCALE_2G =  0b00;
-const uint8_t DA217_RESOLUTION_RANGE_SCALE_4G =  0b01;
-const uint8_t DA217_RESOLUTION_RANGE_SCALE_8G =  0b10;
-const uint8_t DA217_RESOLUTION_RANGE_SCALE_16G =  0b11;
+const uint8_t DA217_RESOLUTION_RANGE_RESOLUTION_8BITS = 0b11 << 2;
+const uint8_t DA217_RESOLUTION_RANGE_SCALE_2G = 0b00;
+const uint8_t DA217_RESOLUTION_RANGE_SCALE_4G = 0b01;
+const uint8_t DA217_RESOLUTION_RANGE_SCALE_8G = 0b10;
+const uint8_t DA217_RESOLUTION_RANGE_SCALE_16G = 0b11;
 
 const uint8_t DA217_REGISTER_ODR_AXIS = 0x10;
 const uint8_t DA217_ODR_AXIS_DISABLE_X = 1 << 7;
@@ -70,7 +70,6 @@ const uint8_t DA217_INT_MAP1_ACTIVE = 1 << 2;
 const uint8_t DA217_INT_MAP1_STEP = 1 << 1;
 const uint8_t DA217_INT_MAP1_FREEFALL = 1;
 
-
 const uint8_t DA217_REGISTER_INT_LATCH = 0x21;
 const uint8_t DA217_INT_LATCH_INT1_LATCH_100MS = 0b1110;
 const uint8_t DA217_INT_LATCH_INT2_LATCH_100MS = 0b1110 << 4;
@@ -97,8 +96,7 @@ const float GRAVITY_EARTH = 9.80665f;
 void DA217Component::setup() {
   ESP_LOGCONFIG(TAG, "Setting up DA217...");
   uint8_t chip_id;
-  if (!this->read_byte(DA217_REGISTER_CHIP_ID, &chip_id) ||
-      (chip_id != 0x13)) {
+  if (!this->read_byte(DA217_REGISTER_CHIP_ID, &chip_id) || (chip_id != 0x13)) {
     this->mark_failed();
     return;
   }
@@ -116,7 +114,8 @@ void DA217Component::setup() {
   set_register_(DA217_REGISTER_ODR_AXIS, odr_axis_);
 
   ESP_LOGV(TAG, "  Setting up interrupt latching...");
-  if (!this->write_byte(DA217_REGISTER_INT_LATCH, DA217_INT_LATCH_INT1_LATCH_100MS | DA217_INT_LATCH_INT2_LATCH_100MS)) {
+  if (!this->write_byte(DA217_REGISTER_INT_LATCH,
+                        DA217_INT_LATCH_INT1_LATCH_100MS | DA217_INT_LATCH_INT2_LATCH_100MS)) {
     this->mark_failed();
     return;
   }
@@ -162,7 +161,6 @@ void DA217Component::dump_config() {
 void DA217Component::update() {
   ESP_LOGV(TAG, "    Updating DA217...");
 
-
   uint8_t status = 0;
   this->read_byte(0x11, &status);
   ESP_LOGD(TAG, "Register 0x11 is %d", status);
@@ -171,12 +169,12 @@ void DA217Component::update() {
   int16_t raw_accel_y;
   int16_t raw_accel_z;
 
-  uint8_t * raw_accel_x_lsb_ptr = reinterpret_cast<uint8_t *>(&raw_accel_x);
-  uint8_t * raw_accel_x_msb_ptr = raw_accel_x_lsb_ptr + 1;
-  uint8_t * raw_accel_y_lsb_ptr = reinterpret_cast<uint8_t *>(&raw_accel_y);
-  uint8_t * raw_accel_y_msb_ptr = raw_accel_y_lsb_ptr + 1;
-  uint8_t * raw_accel_z_lsb_ptr = reinterpret_cast<uint8_t *>(&raw_accel_z);
-  uint8_t * raw_accel_z_msb_ptr = raw_accel_z_lsb_ptr + 1;
+  uint8_t *raw_accel_x_lsb_ptr = reinterpret_cast<uint8_t *>(&raw_accel_x);
+  uint8_t *raw_accel_x_msb_ptr = raw_accel_x_lsb_ptr + 1;
+  uint8_t *raw_accel_y_lsb_ptr = reinterpret_cast<uint8_t *>(&raw_accel_y);
+  uint8_t *raw_accel_y_msb_ptr = raw_accel_y_lsb_ptr + 1;
+  uint8_t *raw_accel_z_lsb_ptr = reinterpret_cast<uint8_t *>(&raw_accel_z);
+  uint8_t *raw_accel_z_msb_ptr = raw_accel_z_lsb_ptr + 1;
 
   if (!this->read_byte(DA217_REGISTER_ACC_X_LSB, raw_accel_x_lsb_ptr) ||
       !this->read_byte(DA217_REGISTER_ACC_X_MSB, raw_accel_x_msb_ptr) ||
@@ -191,14 +189,12 @@ void DA217Component::update() {
   // The sensor has been configured to use a scale of ±4g, so a span of 8g.
   // It also "left-justifies" the data it outputs, so no matter its actual
   // resolution, the reported values will use the full 16 bit span.
-  float g_per_bit = 8.0f/(1<<16);
+  float g_per_bit = 8.0f / (1 << 16);
   float accel_x = raw_accel_x * g_per_bit * GRAVITY_EARTH;
   float accel_y = raw_accel_y * g_per_bit * GRAVITY_EARTH;
   float accel_z = raw_accel_z * g_per_bit * GRAVITY_EARTH;
 
-  ESP_LOGD(TAG,
-           "Got accel={x=%.3f m/s², y=%.3f m/s², z=%.3f m/s²}, ",
-           accel_x, accel_y, accel_z);
+  ESP_LOGD(TAG, "Got accel={x=%.3f m/s², y=%.3f m/s², z=%.3f m/s²}, ", accel_x, accel_y, accel_z);
 
   if (this->accel_x_sensor_ != nullptr)
     this->accel_x_sensor_->publish_state(accel_x);
@@ -212,51 +208,29 @@ void DA217Component::update() {
 
 float DA217Component::get_setup_priority() const { return setup_priority::DATA; }
 
-void DA217Component::set_resolution_range(bool hp_en, bool wdt_en, WatchdogTime wdt_time, Resolution resolution, FullScale fs) {
-  resolution_range_ =
-    hp_en << 7 |
-    wdt_en << 6 |
-    wdt_time << 5 |
-    resolution << 2 |
-    fs;
+void DA217Component::set_resolution_range(bool hp_en, bool wdt_en, WatchdogTime wdt_time, Resolution resolution,
+                                          FullScale fs) {
+  resolution_range_ = hp_en << 7 | wdt_en << 6 | wdt_time << 5 | resolution << 2 | fs;
 }
 
 void DA217Component::set_odr_axis(bool x_axis_disable, bool y_axis_disable, bool z_axis_disable, OutputDataRate odr) {
-  odr_axis_ =
-    x_axis_disable << 7 |
-    y_axis_disable << 6 |
-    z_axis_disable << 5 |
-    odr;
+  odr_axis_ = x_axis_disable << 7 | y_axis_disable << 6 | z_axis_disable << 5 | odr;
 }
 
-void DA217Component::set_int_set1(InterruptSource int_source, bool s_tap_int_en, bool d_tap_int_en, bool orient_int_en, bool active_int_en_z, bool active_int_en_y, bool active_int_en_x) {
-  int_set1_ =
-    int_source << 6 |
-    s_tap_int_en << 5 |
-    d_tap_int_en << 4 |
-    orient_int_en << 3 |
-    active_int_en_z << 2 |
-    active_int_en_y << 1 |
-    active_int_en_x;
+void DA217Component::set_int_set1(InterruptSource int_source, bool s_tap_int_en, bool d_tap_int_en, bool orient_int_en,
+                                  bool active_int_en_z, bool active_int_en_y, bool active_int_en_x) {
+  int_set1_ = int_source << 6 | s_tap_int_en << 5 | d_tap_int_en << 4 | orient_int_en << 3 | active_int_en_z << 2 |
+              active_int_en_y << 1 | active_int_en_x;
 }
 
-void DA217Component::set_int_map1(bool int1_sm, bool int1_orient, bool int1_s_tap, bool int1_d_tap, bool int1_tilt, bool int1_active, bool int1_step, bool int1_freefall) {
-  int_map1_ =
-    int1_sm << 7 |
-    int1_orient << 6 |
-    int1_s_tap << 5 |
-    int1_d_tap << 4 |
-    int1_tilt << 3 |
-    int1_active << 2 |
-    int1_step << 1 |
-    int1_freefall;
+void DA217Component::set_int_map1(bool int1_sm, bool int1_orient, bool int1_s_tap, bool int1_d_tap, bool int1_tilt,
+                                  bool int1_active, bool int1_step, bool int1_freefall) {
+  int_map1_ = int1_sm << 7 | int1_orient << 6 | int1_s_tap << 5 | int1_d_tap << 4 | int1_tilt << 3 | int1_active << 2 |
+              int1_step << 1 | int1_freefall;
 }
 
 void DA217Component::set_tap_dur(TapQuietDuration tap_quiet, TapShockDuration tap_shock, DoubleTapDuration tap_dur) {
-  tap_dur_ =
-    tap_quiet << 7 |
-    tap_shock << 6 |
-    tap_dur;
+  tap_dur_ = tap_quiet << 7 | tap_shock << 6 | tap_dur;
 }
 
 void DA217Component::set_tap_ths(StableTiltTime tilt_time, uint8_t tap_th) {
@@ -264,9 +238,7 @@ void DA217Component::set_tap_ths(StableTiltTime tilt_time, uint8_t tap_th) {
   // tap_th uses 5 bits to describe the sensor's whole acceleration range. For
   // instance, in the ±4g range, a value of 0x1F for tap_th will mean a tap
   // threshold of 4g, and a value of 0 would mean 0g.
-  tap_ths_ =
-    tilt_time << 5 |
-    (tap_th & DA217_TAP_THS_TAP_TH_MASK);
+  tap_ths_ = tilt_time << 5 | (tap_th & DA217_TAP_THS_TAP_TH_MASK);
 }
 
 void DA217Component::set_register_(uint8_t a_register, uint8_t data) {

--- a/esphome/components/da217/da217.cpp
+++ b/esphome/components/da217/da217.cpp
@@ -1,0 +1,282 @@
+#include "da217.h"
+#include "esphome/core/log.h"
+
+namespace esphome {
+namespace da217 {
+
+static const char *const TAG = "da217";
+
+const uint8_t DA217_REGISTER_SPI_CONFIG = 0x00;
+const uint8_t DA217_SPI_CONFIG_SDO_ACTIVE = 0b10000001;
+const uint8_t DA217_SPI_CONFIG_LSB_FIRST = 0b01000010;
+const uint8_t DA217_SPI_CONFIG_SOFT_RESET = 0b00100100;
+
+const uint8_t DA217_REGISTER_CHIP_ID = 0x01;
+
+const uint8_t DA217_REGISTER_ACC_X_LSB = 0x02;
+const uint8_t DA217_REGISTER_ACC_X_MSB = 0x03;
+const uint8_t DA217_REGISTER_ACC_Y_LSB = 0x04;
+const uint8_t DA217_REGISTER_ACC_Y_MSB = 0x05;
+const uint8_t DA217_REGISTER_ACC_Z_LSB = 0x06;
+const uint8_t DA217_REGISTER_ACC_Z_MSB = 0x07;
+
+const uint8_t DA217_REGISTER_RESOLUTION_RANGE = 0x0F;
+const uint8_t DA217_RESOLUTION_RANGE_HIGH_PASS_FILTER = 1 << 7;
+const uint8_t DA217_RESOLUTION_RANGE_WATCHDOG = 1 << 6;
+const uint8_t DA217_RESOLUTION_RANGE_WATCHDOG_1MS = 0 << 5;
+const uint8_t DA217_RESOLUTION_RANGE_WATCHDOG_50MS = 1 << 5;
+const uint8_t DA217_RESOLUTION_RANGE_RESOLUTION_14BITS = 0b00 << 2;
+const uint8_t DA217_RESOLUTION_RANGE_RESOLUTION_12BITS = 0b01 << 2;
+const uint8_t DA217_RESOLUTION_RANGE_RESOLUTION_10BITS = 0b10 << 2;
+const uint8_t DA217_RESOLUTION_RANGE_RESOLUTION_8BITS =  0b11 << 2;
+const uint8_t DA217_RESOLUTION_RANGE_SCALE_2G =  0b00;
+const uint8_t DA217_RESOLUTION_RANGE_SCALE_4G =  0b01;
+const uint8_t DA217_RESOLUTION_RANGE_SCALE_8G =  0b10;
+const uint8_t DA217_RESOLUTION_RANGE_SCALE_16G =  0b11;
+
+const uint8_t DA217_REGISTER_ODR_AXIS = 0x10;
+const uint8_t DA217_ODR_AXIS_DISABLE_X = 1 << 7;
+const uint8_t DA217_ODR_AXIS_DISABLE_Y = 1 << 6;
+const uint8_t DA217_ODR_AXIS_DISABLE_Z = 1 << 5;
+const uint8_t DA217_ODR_AXIS_1HZ = 0b0000;
+const uint8_t DA217_ODR_AXIS_1_95HZ = 0b0001;
+const uint8_t DA217_ODR_AXIS_3_9HZ = 0b0010;
+const uint8_t DA217_ODR_AXIS_7_81HZ = 0b0011;
+const uint8_t DA217_ODR_AXIS_15_63HZ = 0b0100;
+const uint8_t DA217_ODR_AXIS_31_25HZ = 0b0101;
+const uint8_t DA217_ODR_AXIS_62_5HZ = 0b0110;
+const uint8_t DA217_ODR_AXIS_125HZ = 0b0111;
+const uint8_t DA217_ODR_AXIS_250HZ = 0b1000;
+const uint8_t DA217_ODR_AXIS_500HZ = 0b1001;
+
+const uint8_t DA217_REGISTER_MODE_BW = 0x11;
+const uint8_t DA217_MODE_BW_SUSPEND_MODE = 1 << 7;
+const uint8_t DA217_MODE_BW_NORMAL_MODE = 0 << 7;
+
+const uint8_t DA217_REGISTER_INT_SET1 = 0x16;
+const uint8_t DA217_INT_SET1_INT_SOURCE_OVERSAMPLING = 0b00 << 6;
+const uint8_t DA217_INT_SET1_INT_SOURCE_UNFILTERED = 0b01 << 6;
+const uint8_t DA217_INT_SET1_INT_SOURCE_FILTERED = 0b10 << 6;
+const uint8_t DA217_INT_SET1_ENABLE_SINGLE_TAP = 1 << 5;
+const uint8_t DA217_INT_SET1_ENABLE_DOUBLE_TAP = 1 << 4;
+
+const uint8_t DA217_REGISTER_INT_MAP1 = 0x19;
+const uint8_t DA217_INT_MAP1_SM = 1 << 7;
+const uint8_t DA217_INT_MAP1_ORIENT = 1 << 6;
+const uint8_t DA217_INT_MAP1_SINGLE_TAP = 1 << 5;
+const uint8_t DA217_INT_MAP1_DOUBLE_TAP = 1 << 4;
+const uint8_t DA217_INT_MAP1_TILT = 1 << 3;
+const uint8_t DA217_INT_MAP1_ACTIVE = 1 << 2;
+const uint8_t DA217_INT_MAP1_STEP = 1 << 1;
+const uint8_t DA217_INT_MAP1_FREEFALL = 1;
+
+
+const uint8_t DA217_REGISTER_INT_LATCH = 0x21;
+const uint8_t DA217_INT_LATCH_INT1_LATCH_100MS = 0b1110;
+const uint8_t DA217_INT_LATCH_INT2_LATCH_100MS = 0b1110 << 4;
+
+const uint8_t DA217_REGISTER_TAP_DUR = 0x2A;
+const uint8_t DA217_TAP_DUR_QUIET_30MS = 0b0 << 7;
+const uint8_t DA217_TAP_DUR_QUIET_20MS = 0b1 << 7;
+const uint8_t DA217_TAP_DUR_SHOCK_50MS = 0b0 << 6;
+const uint8_t DA217_TAP_DUR_SHOCK_70MS = 0b1 << 6;
+const uint8_t DA217_TAP_DUR_50MS = 0b000;
+const uint8_t DA217_TAP_DUR_100MS = 0b001;
+const uint8_t DA217_TAP_DUR_150MS = 0b010;
+const uint8_t DA217_TAP_DUR_200MS = 0b011;
+const uint8_t DA217_TAP_DUR_250MS = 0b100;
+const uint8_t DA217_TAP_DUR_370MS = 0b101;
+const uint8_t DA217_TAP_DUR_500MS = 0b110;
+const uint8_t DA217_TAP_DUR_700MS = 0b111;
+
+const uint8_t DA217_REGISTER_TAP_THS = 0x2B;
+const uint8_t DA217_TAP_THS_TAP_TH_MASK = 0b11111;
+
+const float GRAVITY_EARTH = 9.80665f;
+
+void DA217Component::setup() {
+  ESP_LOGCONFIG(TAG, "Setting up DA217...");
+  uint8_t chip_id;
+  if (!this->read_byte(DA217_REGISTER_CHIP_ID, &chip_id) ||
+      (chip_id != 0x13)) {
+    this->mark_failed();
+    return;
+  }
+
+  ESP_LOGV(TAG, "  Setting up bus config...");
+  if (!this->write_byte(DA217_REGISTER_SPI_CONFIG, DA217_SPI_CONFIG_SDO_ACTIVE | DA217_SPI_CONFIG_SOFT_RESET)) {
+    this->mark_failed();
+    return;
+  }
+
+  ESP_LOGV(TAG, "  Setting up resolution...");
+  set_register_(DA217_REGISTER_RESOLUTION_RANGE, resolution_range_);
+
+  ESP_LOGV(TAG, "  Setting up axes and frequency...");
+  set_register_(DA217_REGISTER_ODR_AXIS, odr_axis_);
+
+  ESP_LOGV(TAG, "  Setting up interrupt latching...");
+  if (!this->write_byte(DA217_REGISTER_INT_LATCH, DA217_INT_LATCH_INT1_LATCH_100MS | DA217_INT_LATCH_INT2_LATCH_100MS)) {
+    this->mark_failed();
+    return;
+  }
+
+  ESP_LOGV(TAG, "  Setting up tap duration...");
+  set_register_(DA217_REGISTER_TAP_DUR, tap_dur_);
+
+  ESP_LOGV(TAG, "  Setting up tap threshold...");
+  set_register_(DA217_REGISTER_TAP_THS, tap_ths_);
+
+  ESP_LOGV(TAG, "  Setting up interrupt mapping...");
+  set_register_(DA217_REGISTER_INT_MAP1, int_map1_);
+
+  ESP_LOGV(TAG, "  Setting up interrupt settings...");
+  set_register_(DA217_REGISTER_INT_SET1, int_set1_);
+
+  ESP_LOGV(TAG, "  Setting power mode...");
+  if (!this->write_byte(DA217_REGISTER_MODE_BW, DA217_MODE_BW_NORMAL_MODE)) {
+    this->mark_failed();
+    return;
+  }
+}
+
+void DA217Component::dump_config() {
+  ESP_LOGCONFIG(TAG, "DA217:");
+  LOG_I2C_DEVICE(this);
+  if (this->is_failed()) {
+    ESP_LOGE(TAG, "Communication with DA217 failed!");
+  }
+  LOG_UPDATE_INTERVAL(this);
+  LOG_SENSOR("  ", "Acceleration X", this->accel_x_sensor_);
+  LOG_SENSOR("  ", "Acceleration Y", this->accel_y_sensor_);
+  LOG_SENSOR("  ", "Acceleration Z", this->accel_z_sensor_);
+
+  ESP_LOGCONFIG(TAG, "  resolution_range (0x%x) = 0x%x", DA217_REGISTER_RESOLUTION_RANGE, resolution_range_);
+  ESP_LOGCONFIG(TAG, "  odr_axis (0x%x) =0x%x", DA217_REGISTER_ODR_AXIS, odr_axis_);
+  ESP_LOGCONFIG(TAG, "  int_set1 (0x%x) =0x%x", DA217_REGISTER_INT_SET1, int_set1_);
+  ESP_LOGCONFIG(TAG, "  int_map1 (0x%x)=0x%x", DA217_REGISTER_INT_MAP1, int_map1_);
+  ESP_LOGCONFIG(TAG, "  tap_dur (0x%x) =0x%x", DA217_REGISTER_TAP_DUR, tap_dur_);
+  ESP_LOGCONFIG(TAG, "  tap_ths (0x%x) =0x%x", DA217_REGISTER_TAP_THS, tap_ths_);
+}
+
+void DA217Component::update() {
+  ESP_LOGV(TAG, "    Updating DA217...");
+
+
+  uint8_t status = 0;
+  this->read_byte(0x11, &status);
+  ESP_LOGD(TAG, "Register 0x11 is %d", status);
+
+  int16_t raw_accel_x;
+  int16_t raw_accel_y;
+  int16_t raw_accel_z;
+
+  uint8_t * raw_accel_x_lsb_ptr = reinterpret_cast<uint8_t *>(&raw_accel_x);
+  uint8_t * raw_accel_x_msb_ptr = raw_accel_x_lsb_ptr + 1;
+  uint8_t * raw_accel_y_lsb_ptr = reinterpret_cast<uint8_t *>(&raw_accel_y);
+  uint8_t * raw_accel_y_msb_ptr = raw_accel_y_lsb_ptr + 1;
+  uint8_t * raw_accel_z_lsb_ptr = reinterpret_cast<uint8_t *>(&raw_accel_z);
+  uint8_t * raw_accel_z_msb_ptr = raw_accel_z_lsb_ptr + 1;
+
+  if (!this->read_byte(DA217_REGISTER_ACC_X_LSB, raw_accel_x_lsb_ptr) ||
+      !this->read_byte(DA217_REGISTER_ACC_X_MSB, raw_accel_x_msb_ptr) ||
+      !this->read_byte(DA217_REGISTER_ACC_Y_LSB, raw_accel_y_lsb_ptr) ||
+      !this->read_byte(DA217_REGISTER_ACC_Y_MSB, raw_accel_y_msb_ptr) ||
+      !this->read_byte(DA217_REGISTER_ACC_Z_LSB, raw_accel_z_lsb_ptr) ||
+      !this->read_byte(DA217_REGISTER_ACC_Z_MSB, raw_accel_z_msb_ptr)) {
+    this->status_set_warning();
+    return;
+  }
+
+  // The sensor has been configured to use a scale of ±4g, so a span of 8g.
+  // It also "left-justifies" the data it outputs, so no matter its actual
+  // resolution, the reported values will use the full 16 bit span.
+  float g_per_bit = 8.0f/(1<<16);
+  float accel_x = raw_accel_x * g_per_bit * GRAVITY_EARTH;
+  float accel_y = raw_accel_y * g_per_bit * GRAVITY_EARTH;
+  float accel_z = raw_accel_z * g_per_bit * GRAVITY_EARTH;
+
+  ESP_LOGD(TAG,
+           "Got accel={x=%.3f m/s², y=%.3f m/s², z=%.3f m/s²}, ",
+           accel_x, accel_y, accel_z);
+
+  if (this->accel_x_sensor_ != nullptr)
+    this->accel_x_sensor_->publish_state(accel_x);
+  if (this->accel_y_sensor_ != nullptr)
+    this->accel_y_sensor_->publish_state(accel_y);
+  if (this->accel_z_sensor_ != nullptr)
+    this->accel_z_sensor_->publish_state(accel_z);
+
+  this->status_clear_warning();
+}
+
+float DA217Component::get_setup_priority() const { return setup_priority::DATA; }
+
+void DA217Component::set_resolution_range(bool hp_en, bool wdt_en, WatchdogTime wdt_time, Resolution resolution, FullScale fs) {
+  resolution_range_ =
+    hp_en << 7 |
+    wdt_en << 6 |
+    wdt_time << 5 |
+    resolution << 2 |
+    fs;
+}
+
+void DA217Component::set_odr_axis(bool x_axis_disable, bool y_axis_disable, bool z_axis_disable, OutputDataRate odr) {
+  odr_axis_ =
+    x_axis_disable << 7 |
+    y_axis_disable << 6 |
+    z_axis_disable << 5 |
+    odr;
+}
+
+void DA217Component::set_int_set1(InterruptSource int_source, bool s_tap_int_en, bool d_tap_int_en, bool orient_int_en, bool active_int_en_z, bool active_int_en_y, bool active_int_en_x) {
+  int_set1_ =
+    int_source << 6 |
+    s_tap_int_en << 5 |
+    d_tap_int_en << 4 |
+    orient_int_en << 3 |
+    active_int_en_z << 2 |
+    active_int_en_y << 1 |
+    active_int_en_x;
+}
+
+void DA217Component::set_int_map1(bool int1_sm, bool int1_orient, bool int1_s_tap, bool int1_d_tap, bool int1_tilt, bool int1_active, bool int1_step, bool int1_freefall) {
+  int_map1_ =
+    int1_sm << 7 |
+    int1_orient << 6 |
+    int1_s_tap << 5 |
+    int1_d_tap << 4 |
+    int1_tilt << 3 |
+    int1_active << 2 |
+    int1_step << 1 |
+    int1_freefall;
+}
+
+void DA217Component::set_tap_dur(TapQuietDuration tap_quiet, TapShockDuration tap_shock, DoubleTapDuration tap_dur) {
+  tap_dur_ =
+    tap_quiet << 7 |
+    tap_shock << 6 |
+    tap_dur;
+}
+
+void DA217Component::set_tap_ths(StableTiltTime tilt_time, uint8_t tap_th) {
+  // The datasheet uses a weird K constant to explain a simple concept. In fact
+  // tap_th uses 5 bits to describe the sensor's whole acceleration range. For
+  // instance, in the ±4g range, a value of 0x1F for tap_th will mean a tap
+  // threshold of 4g, and a value of 0 would mean 0g.
+  tap_ths_ =
+    tilt_time << 5 |
+    (tap_th & DA217_TAP_THS_TAP_TH_MASK);
+}
+
+void DA217Component::set_register_(uint8_t a_register, uint8_t data) {
+  ESP_LOGD(TAG, "Set register %x to %x", a_register, data);
+  if (!this->write_byte(a_register, data)) {
+    ESP_LOGE(TAG, "Error setting register %x to %x", a_register, data);
+    this->mark_failed();
+    return;
+  }
+}
+
+}  // namespace da217
+}  // namespace esphome

--- a/esphome/components/da217/da217.h
+++ b/esphome/components/da217/da217.h
@@ -11,24 +11,11 @@
 namespace esphome {
 namespace da217 {
 
-enum WatchdogTime {
-  Time1ms = 0,
-  Time50ms = 1
-};
+enum WatchdogTime { Time1ms = 0, Time50ms = 1 };
 
-enum Resolution {
-  Resolution14bits = 0b00,
-  Resolution12bits = 0b01,
-  Resolution10bits = 0b10,
-  Resolution8bits = 0b11
-};
+enum Resolution { Resolution14bits = 0b00, Resolution12bits = 0b01, Resolution10bits = 0b10, Resolution8bits = 0b11 };
 
-enum FullScale {
-  PlusMinus2g = 0b00,
-  PlusMinus4g = 0b01,
-  PlusMinus8g = 0b10,
-  PlusMinus16g = 0b11
-};
+enum FullScale { PlusMinus2g = 0b00, PlusMinus4g = 0b01, PlusMinus8g = 0b10, PlusMinus16g = 0b11 };
 
 enum OutputDataRate {
   Rate1Hz = 0b0000,
@@ -44,21 +31,14 @@ enum OutputDataRate {
   Unconfigured = 0b1111
 };
 
-enum InterruptSource {
-  Oversampling = 0b00,
-  Unfiltered = 0b01,
-  Filtered = 0b10
-};
+enum InterruptSource { Oversampling = 0b00, Unfiltered = 0b01, Filtered = 0b10 };
 
 enum TapQuietDuration {
   Quiet30ms = 0,
   Quiet20ms = 1,
 };
 
-enum TapShockDuration {
-  Shock50ms = 0,
-  Shock70ms = 1
-};
+enum TapShockDuration { Shock50ms = 0, Shock70ms = 1 };
 
 enum DoubleTapDuration {
   DoubleTap50ms = 0b000,
@@ -71,12 +51,7 @@ enum DoubleTapDuration {
   DoubleTap700ms = 0b111,
 };
 
-enum StableTiltTime {
-  ODR32 = 0b00,
-  ODR96 = 0b01,
-  ODR160 = 0b10,
-  ODR224 = 0b11
-};
+enum StableTiltTime { ODR32 = 0b00, ODR96 = 0b01, ODR160 = 0b10, ODR224 = 0b11 };
 
 class DA217Component : public PollingComponent, public i2c::I2CDevice {
  public:
@@ -89,8 +64,10 @@ class DA217Component : public PollingComponent, public i2c::I2CDevice {
   void set_accel_z_sensor(sensor::Sensor *accel_z_sensor) { accel_z_sensor_ = accel_z_sensor; }
   void set_resolution_range(bool hp_en, bool wdt_en, WatchdogTime wdt_time, Resolution resolution, FullScale fs);
   void set_odr_axis(bool x_axis_disable, bool y_axis_disable, bool z_axis_disable, OutputDataRate odr);
-  void set_int_set1(InterruptSource int_source, bool s_tap_int_en, bool d_tap_int_en, bool orient_int_en, bool active_int_en_z, bool active_int_en_y, bool active_int_en_x);
-  void set_int_map1(bool int1_sm, bool int1_orient, bool int1_s_tap, bool int1_d_tap, bool int1_tilt, bool int1_active, bool int1_step, bool int1_freefall);
+  void set_int_set1(InterruptSource int_source, bool s_tap_int_en, bool d_tap_int_en, bool orient_int_en,
+                    bool active_int_en_z, bool active_int_en_y, bool active_int_en_x);
+  void set_int_map1(bool int1_sm, bool int1_orient, bool int1_s_tap, bool int1_d_tap, bool int1_tilt, bool int1_active,
+                    bool int1_step, bool int1_freefall);
   void set_tap_dur(TapQuietDuration tap_quiet, TapShockDuration tap_shock, DoubleTapDuration tap_dur);
   void set_tap_ths(StableTiltTime tilt_time, uint8_t tap_th);
 
@@ -107,5 +84,5 @@ class DA217Component : public PollingComponent, public i2c::I2CDevice {
   uint8_t tap_ths_;
 };
 
-} // namespace da217
-} // namespace esphome
+}  // namespace da217
+}  // namespace esphome

--- a/esphome/components/da217/da217.h
+++ b/esphome/components/da217/da217.h
@@ -1,0 +1,111 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/components/sensor/sensor.h"
+#include "esphome/components/i2c/i2c.h"
+
+// Support for MiraMEMS DA2xx accelerometers
+// https://resource.heltec.cn/download/sensor/DA217/DA217-%E8%BF%90%E5%8A%A8.pdf
+// This code is both Public Domain and MIT licensed
+
+namespace esphome {
+namespace da217 {
+
+enum WatchdogTime {
+  Time1ms = 0,
+  Time50ms = 1
+};
+
+enum Resolution {
+  Resolution14bits = 0b00,
+  Resolution12bits = 0b01,
+  Resolution10bits = 0b10,
+  Resolution8bits = 0b11
+};
+
+enum FullScale {
+  PlusMinus2g = 0b00,
+  PlusMinus4g = 0b01,
+  PlusMinus8g = 0b10,
+  PlusMinus16g = 0b11
+};
+
+enum OutputDataRate {
+  Rate1Hz = 0b0000,
+  Rate1p95Hz = 0b0001,
+  Rate3p9Hz = 0b0010,
+  Rate7p81Hz = 0b0011,
+  Rate15p63Hz = 0b0100,
+  Rate31p25Hz = 0b0101,
+  Rate62p5Hz = 0b0110,
+  Rate125Hz = 0b0111,
+  Rate250Hz = 0b1000,
+  Rate500Hz = 0b1001,
+  Unconfigured = 0b1111
+};
+
+enum InterruptSource {
+  Oversampling = 0b00,
+  Unfiltered = 0b01,
+  Filtered = 0b10
+};
+
+enum TapQuietDuration {
+  Quiet30ms = 0,
+  Quiet20ms = 1,
+};
+
+enum TapShockDuration {
+  Shock50ms = 0,
+  Shock70ms = 1
+};
+
+enum DoubleTapDuration {
+  DoubleTap50ms = 0b000,
+  DoubleTap100ms = 0b001,
+  DoubleTap150ms = 0b010,
+  DoubleTap200ms = 0b011,
+  DoubleTap250ms = 0b100,
+  DoubleTap375ms = 0b101,
+  DoubleTap500ms = 0b110,
+  DoubleTap700ms = 0b111,
+};
+
+enum StableTiltTime {
+  ODR32 = 0b00,
+  ODR96 = 0b01,
+  ODR160 = 0b10,
+  ODR224 = 0b11
+};
+
+class DA217Component : public PollingComponent, public i2c::I2CDevice {
+ public:
+  void setup() override;
+  void dump_config() override;
+  void update() override;
+  float get_setup_priority() const override;
+  void set_accel_x_sensor(sensor::Sensor *accel_x_sensor) { accel_x_sensor_ = accel_x_sensor; }
+  void set_accel_y_sensor(sensor::Sensor *accel_y_sensor) { accel_y_sensor_ = accel_y_sensor; }
+  void set_accel_z_sensor(sensor::Sensor *accel_z_sensor) { accel_z_sensor_ = accel_z_sensor; }
+  void set_resolution_range(bool hp_en, bool wdt_en, WatchdogTime wdt_time, Resolution resolution, FullScale fs);
+  void set_odr_axis(bool x_axis_disable, bool y_axis_disable, bool z_axis_disable, OutputDataRate odr);
+  void set_int_set1(InterruptSource int_source, bool s_tap_int_en, bool d_tap_int_en, bool orient_int_en, bool active_int_en_z, bool active_int_en_y, bool active_int_en_x);
+  void set_int_map1(bool int1_sm, bool int1_orient, bool int1_s_tap, bool int1_d_tap, bool int1_tilt, bool int1_active, bool int1_step, bool int1_freefall);
+  void set_tap_dur(TapQuietDuration tap_quiet, TapShockDuration tap_shock, DoubleTapDuration tap_dur);
+  void set_tap_ths(StableTiltTime tilt_time, uint8_t tap_th);
+
+ protected:
+  sensor::Sensor *accel_x_sensor_{nullptr};
+  sensor::Sensor *accel_y_sensor_{nullptr};
+  sensor::Sensor *accel_z_sensor_{nullptr};
+  void set_register_(uint8_t a_register, uint8_t data);
+  uint8_t resolution_range_;
+  uint8_t odr_axis_;
+  uint8_t int_set1_;
+  uint8_t int_map1_;
+  uint8_t tap_dur_;
+  uint8_t tap_ths_;
+};
+
+} // namespace da217
+} // namespace esphome

--- a/esphome/components/da217/da217.h
+++ b/esphome/components/da217/da217.h
@@ -11,44 +11,44 @@
 namespace esphome {
 namespace da217 {
 
-enum WatchdogTime { Time1ms = 0, Time50ms = 1 };
+enum WatchdogTime { TIME1MS = 0, TIME50MS = 1 };
 
-enum Resolution { Resolution14bits = 0b00, Resolution12bits = 0b01, Resolution10bits = 0b10, Resolution8bits = 0b11 };
+enum Resolution { RESOLUTION14BITS = 0b00, RESOLUTION12BITS = 0b01, RESOLUTION10BITS = 0b10, RESOLUTION8BITS = 0b11 };
 
-enum FullScale { PlusMinus2g = 0b00, PlusMinus4g = 0b01, PlusMinus8g = 0b10, PlusMinus16g = 0b11 };
+enum FullScale { PLUS_MINUS2G = 0b00, PLUS_MINUS4G = 0b01, PLUS_MINUS8G = 0b10, PLUS_MINUS16G = 0b11 };
 
 enum OutputDataRate {
-  Rate1Hz = 0b0000,
-  Rate1p95Hz = 0b0001,
-  Rate3p9Hz = 0b0010,
-  Rate7p81Hz = 0b0011,
-  Rate15p63Hz = 0b0100,
-  Rate31p25Hz = 0b0101,
-  Rate62p5Hz = 0b0110,
-  Rate125Hz = 0b0111,
-  Rate250Hz = 0b1000,
-  Rate500Hz = 0b1001,
-  Unconfigured = 0b1111
+  RATE1_HZ = 0b0000,
+  RATE1P95_HZ = 0b0001,
+  RATE3P9_HZ = 0b0010,
+  RATE7P81_HZ = 0b0011,
+  RATE15P63_HZ = 0b0100,
+  RATE31P25_HZ = 0b0101,
+  RATE62P5_HZ = 0b0110,
+  RATE125_HZ = 0b0111,
+  RATE250_HZ = 0b1000,
+  RATE500_HZ = 0b1001,
+  UNCONFIGURED = 0b1111
 };
 
-enum InterruptSource { Oversampling = 0b00, Unfiltered = 0b01, Filtered = 0b10 };
+enum InterruptSource { OVERSAMPLING = 0b00, UNFILTERED = 0b01, FILTERED = 0b10 };
 
 enum TapQuietDuration {
-  Quiet30ms = 0,
-  Quiet20ms = 1,
+  QUIET30MS = 0,
+  QUIET20MS = 1,
 };
 
-enum TapShockDuration { Shock50ms = 0, Shock70ms = 1 };
+enum TapShockDuration { SHOCK50MS = 0, SHOCK70MS = 1 };
 
 enum DoubleTapDuration {
-  DoubleTap50ms = 0b000,
-  DoubleTap100ms = 0b001,
-  DoubleTap150ms = 0b010,
-  DoubleTap200ms = 0b011,
-  DoubleTap250ms = 0b100,
-  DoubleTap375ms = 0b101,
-  DoubleTap500ms = 0b110,
-  DoubleTap700ms = 0b111,
+  DOUBLE_TAP50MS = 0b000,
+  DOUBLE_TAP100MS = 0b001,
+  DOUBLE_TAP150MS = 0b010,
+  DOUBLE_TAP200MS = 0b011,
+  DOUBLE_TAP250MS = 0b100,
+  DOUBLE_TAP375MS = 0b101,
+  DOUBLE_TAP500MS = 0b110,
+  DOUBLE_TAP700MS = 0b111,
 };
 
 enum StableTiltTime { ODR32 = 0b00, ODR96 = 0b01, ODR160 = 0b10, ODR224 = 0b11 };

--- a/esphome/components/da217/sensor.py
+++ b/esphome/components/da217/sensor.py
@@ -4,6 +4,7 @@ from esphome.components import i2c, sensor
 from esphome.const import (
     CONF_ID,
     ICON_BRIEFCASE_DOWNLOAD,
+    CONF_RESOLUTION,
     STATE_CLASS_MEASUREMENT,
     UNIT_METER_PER_SECOND_SQUARED,
 )
@@ -21,7 +22,6 @@ CONF_ACCEL_Z = "accel_z"
 CONF_ENABLE_HIGH_PASS_FILTER = "enable_high_pass_filter"
 CONF_ENABLE_WATCHDOG = "enable_watchdog"
 CONF_WATCHDOG_TIME = "watchdog_time"
-CONF_RESOLUTION = "resolution"
 CONF_FULL_SCALE = "full_scale"
 
 WatchdogTime = da217_ns.enum("WatchdogTime")

--- a/esphome/components/da217/sensor.py
+++ b/esphome/components/da217/sensor.py
@@ -40,10 +40,10 @@ RESOLUTIONS = {
 
 FullScale = da217_ns.enum("WatchdogTime")
 FULL_SCALES = {
-    "2G": FullScale.PLUSMINUS2G,
-    "4G": FullScale.PLUSMINUS4G,
-    "8G": FullScale.PLUSMINUS8G,
-    "16G": FullScale.PLUSMINUS16G,
+    "2G": FullScale.PLUS_MINUS2G,
+    "4G": FullScale.PLUS_MINUS4G,
+    "8G": FullScale.PLUS_MINUS8G,
+    "16G": FullScale.PLUS_MINUS16G,
 }
 
 # ODR_AXIS
@@ -118,14 +118,14 @@ TAP_SHOCK_DURATIONS = {
 
 DoubleTapDuration = da217_ns.enum("DoubleTapDuration")
 DOUBLE_TAP_DURATIONS = {
-    "50MS": DoubleTapDuration.DOUBLETAP50MS,
-    "100MS": DoubleTapDuration.DOUBLETAP100MS,
-    "150MS": DoubleTapDuration.DOUBLETAP150MS,
-    "200MS": DoubleTapDuration.DOUBLETAP200MS,
-    "250MS": DoubleTapDuration.DOUBLETAP250MS,
-    "375MS": DoubleTapDuration.DOUBLETAP375MS,
-    "500MS": DoubleTapDuration.DOUBLETAP500MS,
-    "700MS": DoubleTapDuration.DOUBLETAP700MS,
+    "50MS": DoubleTapDuration.DOUBLE_TAP50MS,
+    "100MS": DoubleTapDuration.DOUBLE_TAP100MS,
+    "150MS": DoubleTapDuration.DOUBLE_TAP150MS,
+    "200MS": DoubleTapDuration.DOUBLE_TAP200MS,
+    "250MS": DoubleTapDuration.DOUBLE_TAP250MS,
+    "375MS": DoubleTapDuration.DOUBLE_TAP375MS,
+    "500MS": DoubleTapDuration.DOUBLE_TAP500MS,
+    "700MS": DoubleTapDuration.DOUBLE_TAP700MS,
 }
 
 # TAP_THS

--- a/esphome/components/da217/sensor.py
+++ b/esphome/components/da217/sensor.py
@@ -65,7 +65,7 @@ OUTPUT_DATA_RATES = {
     "125HZ": OutputDataRate.Rate125Hz,
     "250HZ": OutputDataRate.Rate250Hz,
     "500HZ": OutputDataRate.Rate500Hz,
-    "UNCONFIGURED": OutputDataRate.Unconfigured
+    "UNCONFIGURED": OutputDataRate.Unconfigured,
 }
 
 # INT_SET1
@@ -87,7 +87,9 @@ INTERRUPT_SOURCES = {
 
 # INT_MAP1
 
-CONF_MAP_SIGNIFICANT_MOVEMENT_INTERRUPT_TO_INT1 = "map_significant_movement_interrupt_to_int1"
+CONF_MAP_SIGNIFICANT_MOVEMENT_INTERRUPT_TO_INT1 = (
+    "map_significant_movement_interrupt_to_int1"
+)
 CONF_MAP_ORIENTATION_INTERRUPT_TO_INT1 = "map_orientation_interrupt_to_int1"
 CONF_MAP_SINGLE_TAP_INTERRUPT_TO_INT1 = "map_single_tap_interrupt_to_int1"
 CONF_MAP_DOUBLE_TAP_INTERRUPT_TO_INT1 = "map_double_tap_interrupt_to_int1"
@@ -139,9 +141,7 @@ STABLE_TILT_TIMES = {
     "224_ODR_PERIODS": StableTiltTime.ODR224,
 }
 
-DA217Component = da217_ns.class_(
-    "DA217Component", cg.PollingComponent, i2c.I2CDevice
-)
+DA217Component = da217_ns.class_("DA217Component", cg.PollingComponent, i2c.I2CDevice)
 
 accel_schema = sensor.sensor_schema(
     unit_of_measurement=UNIT_METER_PER_SECOND_SQUARED,
@@ -187,13 +187,23 @@ CONFIG_SCHEMA = (
             cv.Optional(CONF_ENABLE_ACTIVE_INTERRUPT_Y_AXIS, default=False): cv.boolean,
             cv.Optional(CONF_ENABLE_ACTIVE_INTERRUPT_X_AXIS, default=False): cv.boolean,
             # INT_MAP1
-            cv.Optional(CONF_MAP_SIGNIFICANT_MOVEMENT_INTERRUPT_TO_INT1, default=False): cv.boolean,
-            cv.Optional(CONF_MAP_ORIENTATION_INTERRUPT_TO_INT1, default=False): cv.boolean,
-            cv.Optional(CONF_MAP_SINGLE_TAP_INTERRUPT_TO_INT1, default=False): cv.boolean,
-            cv.Optional(CONF_MAP_DOUBLE_TAP_INTERRUPT_TO_INT1, default=False): cv.boolean,
+            cv.Optional(
+                CONF_MAP_SIGNIFICANT_MOVEMENT_INTERRUPT_TO_INT1, default=False
+            ): cv.boolean,
+            cv.Optional(
+                CONF_MAP_ORIENTATION_INTERRUPT_TO_INT1, default=False
+            ): cv.boolean,
+            cv.Optional(
+                CONF_MAP_SINGLE_TAP_INTERRUPT_TO_INT1, default=False
+            ): cv.boolean,
+            cv.Optional(
+                CONF_MAP_DOUBLE_TAP_INTERRUPT_TO_INT1, default=False
+            ): cv.boolean,
             cv.Optional(CONF_MAP_TILT_INTERRUPT_TO_INT1, default=False): cv.boolean,
             cv.Optional(CONF_MAP_ACTIVE_INTERRUPT_TO_INT1, default=False): cv.boolean,
-            cv.Optional(CONF_MAP_STEP_COUNTER_INTERRUPT_TO_INT1, default=False): cv.boolean,
+            cv.Optional(
+                CONF_MAP_STEP_COUNTER_INTERRUPT_TO_INT1, default=False
+            ): cv.boolean,
             cv.Optional(CONF_MAP_FREEFALL_INTERRUPT_TO_INT1, default=False): cv.boolean,
             # TAP_DUR
             cv.Optional(CONF_TAP_QUIET_DURATION, default="30MS"): cv.enum(
@@ -209,12 +219,15 @@ CONFIG_SCHEMA = (
             cv.Optional(CONF_STABLE_TILT_TIME, default="32_ODR_PERIODS"): cv.enum(
                 STABLE_TILT_TIMES, upper=True
             ),
-            cv.Optional(CONF_TAP_ACCELERATION_THRESHOLD, default=0.32): cv.float_range(min=0.0, max=1.0), # Default aims at tap_th=0xA, per datasheet
+            cv.Optional(CONF_TAP_ACCELERATION_THRESHOLD, default=0.32): cv.float_range(
+                min=0.0, max=1.0
+            ),  # Default aims at tap_th=0xA, per datasheet
         }
     )
     .extend(cv.polling_component_schema("60s"))
     .extend(i2c.i2c_device_schema(0x27))
 )
+
 
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
@@ -227,9 +240,56 @@ async def to_code(config):
             sens = await sensor.new_sensor(config[accel_key])
             cg.add(getattr(var, f"set_accel_{d}_sensor")(sens))
 
-    cg.add(var.set_resolution_range(config[CONF_ENABLE_HIGH_PASS_FILTER], config[CONF_ENABLE_WATCHDOG], config[CONF_WATCHDOG_TIME], config[CONF_RESOLUTION], config[CONF_FULL_SCALE]));
-    cg.add(var.set_odr_axis(not config[CONF_ENABLE_X_AXIS], not config[CONF_ENABLE_Y_AXIS], not config[CONF_ENABLE_Z_AXIS], config[CONF_OUTPUT_DATA_RATE]));
-    cg.add(var.set_int_set1(config[CONF_INTERRUPT_SOURCE], config[CONF_ENABLE_SINGLE_TAP_INTERRUPT], config[CONF_ENABLE_DOUBLE_TAP_INTERRUPT], config[CONF_ENABLE_ORIENTATION_INTERRUPT], config[CONF_ENABLE_ACTIVE_INTERRUPT_Z_AXIS], config[CONF_ENABLE_ACTIVE_INTERRUPT_Y_AXIS], config[CONF_ENABLE_ACTIVE_INTERRUPT_X_AXIS]));
-    cg.add(var.set_int_map1(config[CONF_MAP_SIGNIFICANT_MOVEMENT_INTERRUPT_TO_INT1], config[CONF_MAP_ORIENTATION_INTERRUPT_TO_INT1], config[CONF_MAP_SINGLE_TAP_INTERRUPT_TO_INT1], config[CONF_MAP_DOUBLE_TAP_INTERRUPT_TO_INT1], config[CONF_MAP_TILT_INTERRUPT_TO_INT1], config[CONF_MAP_ACTIVE_INTERRUPT_TO_INT1], config[CONF_MAP_STEP_COUNTER_INTERRUPT_TO_INT1], config[CONF_MAP_FREEFALL_INTERRUPT_TO_INT1]));
-    cg.add(var.set_tap_dur(config[CONF_TAP_QUIET_DURATION], config[CONF_TAP_SHOCK_DURATION], config[CONF_DOUBLE_TAP_DURATION]));
-    cg.add(var.set_tap_ths(config[CONF_STABLE_TILT_TIME], int(config[CONF_TAP_ACCELERATION_THRESHOLD]*31+0.5)));
+    cg.add(
+        var.set_resolution_range(
+            config[CONF_ENABLE_HIGH_PASS_FILTER],
+            config[CONF_ENABLE_WATCHDOG],
+            config[CONF_WATCHDOG_TIME],
+            config[CONF_RESOLUTION],
+            config[CONF_FULL_SCALE],
+        )
+    )
+    cg.add(
+        var.set_odr_axis(
+            not config[CONF_ENABLE_X_AXIS],
+            not config[CONF_ENABLE_Y_AXIS],
+            not config[CONF_ENABLE_Z_AXIS],
+            config[CONF_OUTPUT_DATA_RATE],
+        )
+    )
+    cg.add(
+        var.set_int_set1(
+            config[CONF_INTERRUPT_SOURCE],
+            config[CONF_ENABLE_SINGLE_TAP_INTERRUPT],
+            config[CONF_ENABLE_DOUBLE_TAP_INTERRUPT],
+            config[CONF_ENABLE_ORIENTATION_INTERRUPT],
+            config[CONF_ENABLE_ACTIVE_INTERRUPT_Z_AXIS],
+            config[CONF_ENABLE_ACTIVE_INTERRUPT_Y_AXIS],
+            config[CONF_ENABLE_ACTIVE_INTERRUPT_X_AXIS],
+        )
+    )
+    cg.add(
+        var.set_int_map1(
+            config[CONF_MAP_SIGNIFICANT_MOVEMENT_INTERRUPT_TO_INT1],
+            config[CONF_MAP_ORIENTATION_INTERRUPT_TO_INT1],
+            config[CONF_MAP_SINGLE_TAP_INTERRUPT_TO_INT1],
+            config[CONF_MAP_DOUBLE_TAP_INTERRUPT_TO_INT1],
+            config[CONF_MAP_TILT_INTERRUPT_TO_INT1],
+            config[CONF_MAP_ACTIVE_INTERRUPT_TO_INT1],
+            config[CONF_MAP_STEP_COUNTER_INTERRUPT_TO_INT1],
+            config[CONF_MAP_FREEFALL_INTERRUPT_TO_INT1],
+        )
+    )
+    cg.add(
+        var.set_tap_dur(
+            config[CONF_TAP_QUIET_DURATION],
+            config[CONF_TAP_SHOCK_DURATION],
+            config[CONF_DOUBLE_TAP_DURATION],
+        )
+    )
+    cg.add(
+        var.set_tap_ths(
+            config[CONF_STABLE_TILT_TIME],
+            int(config[CONF_TAP_ACCELERATION_THRESHOLD] * 31 + 0.5),
+        )
+    )

--- a/esphome/components/da217/sensor.py
+++ b/esphome/components/da217/sensor.py
@@ -1,0 +1,235 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import i2c, sensor
+from esphome.const import (
+    CONF_ID,
+    ICON_BRIEFCASE_DOWNLOAD,
+    STATE_CLASS_MEASUREMENT,
+    UNIT_METER_PER_SECOND_SQUARED,
+)
+
+DEPENDENCIES = ["i2c"]
+
+da217_ns = cg.esphome_ns.namespace("da217")
+
+CONF_ACCEL_X = "accel_x"
+CONF_ACCEL_Y = "accel_y"
+CONF_ACCEL_Z = "accel_z"
+
+# RESOLUTION_RANGE
+
+CONF_ENABLE_HIGH_PASS_FILTER = "enable_high_pass_filter"
+CONF_ENABLE_WATCHDOG = "enable_watchdog"
+CONF_WATCHDOG_TIME = "watchdog_time"
+CONF_RESOLUTION = "resolution"
+CONF_FULL_SCALE = "full_scale"
+
+WatchdogTime = da217_ns.enum("WatchdogTime")
+WATCHDOG_TIMES = {
+    "1MS": WatchdogTime.Time1ms,
+    "50MS": WatchdogTime.Time50ms,
+}
+
+Resolution = da217_ns.enum("Resolution")
+RESOLUTIONS = {
+    "14BITS": Resolution.Resolution14bits,
+    "12BITS": Resolution.Resolution12bits,
+    "10BITS": Resolution.Resolution10bits,
+    "8BITS": Resolution.Resolution8bits,
+}
+
+FullScale = da217_ns.enum("WatchdogTime")
+FULL_SCALES = {
+    "2G": FullScale.PlusMinus2g,
+    "4G": FullScale.PlusMinus4g,
+    "8G": FullScale.PlusMinus8g,
+    "16G": FullScale.PlusMinus16g,
+}
+
+# ODR_AXIS
+
+CONF_ENABLE_X_AXIS = "enable_x_axis"
+CONF_ENABLE_Y_AXIS = "enable_y_axis"
+CONF_ENABLE_Z_AXIS = "enable_z_axis"
+CONF_OUTPUT_DATA_RATE = "output_data_rate"
+
+OutputDataRate = da217_ns.enum("OutputDataRate")
+OUTPUT_DATA_RATES = {
+    "1HZ": OutputDataRate.Rate1Hz,
+    "1.95HZ": OutputDataRate.Rate1p95Hz,
+    "3.9HZ": OutputDataRate.Rate3p9Hz,
+    "7.81HZ": OutputDataRate.Rate7p81Hz,
+    "15.63HZ": OutputDataRate.Rate15p63Hz,
+    "31.25HZ": OutputDataRate.Rate31p25Hz,
+    "62.5HZ": OutputDataRate.Rate62p5Hz,
+    "125HZ": OutputDataRate.Rate125Hz,
+    "250HZ": OutputDataRate.Rate250Hz,
+    "500HZ": OutputDataRate.Rate500Hz,
+    "UNCONFIGURED": OutputDataRate.Unconfigured
+}
+
+# INT_SET1
+
+CONF_INTERRUPT_SOURCE = "interrupt_source"
+CONF_ENABLE_SINGLE_TAP_INTERRUPT = "enable_single_tap_interrupt"
+CONF_ENABLE_DOUBLE_TAP_INTERRUPT = "enable_double_tap_interrupt"
+CONF_ENABLE_ORIENTATION_INTERRUPT = "enable_orientation_interrupt"
+CONF_ENABLE_ACTIVE_INTERRUPT_Z_AXIS = "enable_active_interrupt_z_axis"
+CONF_ENABLE_ACTIVE_INTERRUPT_Y_AXIS = "enable_active_interrupt_y_axis"
+CONF_ENABLE_ACTIVE_INTERRUPT_X_AXIS = "enable_active_interrupt_x_axis"
+
+InterruptSource = da217_ns.enum("InterruptSource")
+INTERRUPT_SOURCES = {
+    "OVERSAMPLING": InterruptSource.Oversampling,
+    "UNFILTERED": InterruptSource.Unfiltered,
+    "FILTERED": InterruptSource.Filtered,
+}
+
+# INT_MAP1
+
+CONF_MAP_SIGNIFICANT_MOVEMENT_INTERRUPT_TO_INT1 = "map_significant_movement_interrupt_to_int1"
+CONF_MAP_ORIENTATION_INTERRUPT_TO_INT1 = "map_orientation_interrupt_to_int1"
+CONF_MAP_SINGLE_TAP_INTERRUPT_TO_INT1 = "map_single_tap_interrupt_to_int1"
+CONF_MAP_DOUBLE_TAP_INTERRUPT_TO_INT1 = "map_double_tap_interrupt_to_int1"
+CONF_MAP_TILT_INTERRUPT_TO_INT1 = "map_tilt_interrupt_to_int1"
+CONF_MAP_ACTIVE_INTERRUPT_TO_INT1 = "map_active_interrupt_to_int1"
+CONF_MAP_STEP_COUNTER_INTERRUPT_TO_INT1 = "map_step_counter_interrupt_to_int1"
+CONF_MAP_FREEFALL_INTERRUPT_TO_INT1 = "map_freefall_interrupt_to_int1"
+
+# TAP_DUR
+
+CONF_TAP_QUIET_DURATION = "tap_quiet_duration"
+CONF_TAP_SHOCK_DURATION = "tap_shock_duration"
+CONF_DOUBLE_TAP_DURATION = "double_tap_duration"
+
+TapQuietDuration = da217_ns.enum("TapQuietDuration")
+TAP_QUIET_DURATIONS = {
+    "30MS": TapQuietDuration.Quiet30ms,
+    "20MS": TapQuietDuration.Quiet20ms,
+}
+
+TapShockDuration = da217_ns.enum("TapShockDuration")
+TAP_SHOCK_DURATIONS = {
+    "50MS": TapShockDuration.Shock50ms,
+    "70MS": TapShockDuration.Shock70ms,
+}
+
+DoubleTapDuration = da217_ns.enum("DoubleTapDuration")
+DOUBLE_TAP_DURATIONS = {
+    "50MS": DoubleTapDuration.DoubleTap50ms,
+    "100MS": DoubleTapDuration.DoubleTap100ms,
+    "150MS": DoubleTapDuration.DoubleTap150ms,
+    "200MS": DoubleTapDuration.DoubleTap200ms,
+    "250MS": DoubleTapDuration.DoubleTap250ms,
+    "375MS": DoubleTapDuration.DoubleTap375ms,
+    "500MS": DoubleTapDuration.DoubleTap500ms,
+    "700MS": DoubleTapDuration.DoubleTap700ms,
+}
+
+# TAP_THS
+
+CONF_STABLE_TILT_TIME = "stable_tilt_time"
+CONF_TAP_ACCELERATION_THRESHOLD = "tap_acceleration_threshold"
+
+StableTiltTime = da217_ns.enum("StableTiltTime")
+STABLE_TILT_TIMES = {
+    "32_ODR_PERIODS": StableTiltTime.ODR32,
+    "96_ODR_PERIODS": StableTiltTime.ODR96,
+    "160_ODR_PERIODS": StableTiltTime.ODR160,
+    "224_ODR_PERIODS": StableTiltTime.ODR224,
+}
+
+DA217Component = da217_ns.class_(
+    "DA217Component", cg.PollingComponent, i2c.I2CDevice
+)
+
+accel_schema = sensor.sensor_schema(
+    unit_of_measurement=UNIT_METER_PER_SECOND_SQUARED,
+    icon=ICON_BRIEFCASE_DOWNLOAD,
+    accuracy_decimals=2,
+    state_class=STATE_CLASS_MEASUREMENT,
+)
+
+CONFIG_SCHEMA = (
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.declare_id(DA217Component),
+            cv.Optional(CONF_ACCEL_X): accel_schema,
+            cv.Optional(CONF_ACCEL_Y): accel_schema,
+            cv.Optional(CONF_ACCEL_Z): accel_schema,
+            # RESOLUTION_RANGE
+            cv.Optional(CONF_ENABLE_HIGH_PASS_FILTER, default=False): cv.boolean,
+            cv.Optional(CONF_ENABLE_WATCHDOG, default=True): cv.boolean,
+            cv.Optional(CONF_WATCHDOG_TIME, default="1MS"): cv.enum(
+                WATCHDOG_TIMES, upper=True
+            ),
+            cv.Optional(CONF_RESOLUTION, default="14BITS"): cv.enum(
+                RESOLUTIONS, upper=True
+            ),
+            cv.Optional(CONF_FULL_SCALE, default="2G"): cv.enum(
+                FULL_SCALES, upper=True
+            ),
+            # ODR_AXIS
+            cv.Optional(CONF_ENABLE_X_AXIS, default=True): cv.boolean,
+            cv.Optional(CONF_ENABLE_Y_AXIS, default=True): cv.boolean,
+            cv.Optional(CONF_ENABLE_Z_AXIS, default=True): cv.boolean,
+            cv.Optional(CONF_OUTPUT_DATA_RATE, default="UNCONFIGURED"): cv.enum(
+                OUTPUT_DATA_RATES, upper=True
+            ),
+            # INT_SET1
+            cv.Optional(CONF_INTERRUPT_SOURCE, default="OVERSAMPLING"): cv.enum(
+                INTERRUPT_SOURCES, upper=True
+            ),
+            cv.Optional(CONF_ENABLE_SINGLE_TAP_INTERRUPT, default=False): cv.boolean,
+            cv.Optional(CONF_ENABLE_DOUBLE_TAP_INTERRUPT, default=False): cv.boolean,
+            cv.Optional(CONF_ENABLE_ORIENTATION_INTERRUPT, default=False): cv.boolean,
+            cv.Optional(CONF_ENABLE_ACTIVE_INTERRUPT_Z_AXIS, default=False): cv.boolean,
+            cv.Optional(CONF_ENABLE_ACTIVE_INTERRUPT_Y_AXIS, default=False): cv.boolean,
+            cv.Optional(CONF_ENABLE_ACTIVE_INTERRUPT_X_AXIS, default=False): cv.boolean,
+            # INT_MAP1
+            cv.Optional(CONF_MAP_SIGNIFICANT_MOVEMENT_INTERRUPT_TO_INT1, default=False): cv.boolean,
+            cv.Optional(CONF_MAP_ORIENTATION_INTERRUPT_TO_INT1, default=False): cv.boolean,
+            cv.Optional(CONF_MAP_SINGLE_TAP_INTERRUPT_TO_INT1, default=False): cv.boolean,
+            cv.Optional(CONF_MAP_DOUBLE_TAP_INTERRUPT_TO_INT1, default=False): cv.boolean,
+            cv.Optional(CONF_MAP_TILT_INTERRUPT_TO_INT1, default=False): cv.boolean,
+            cv.Optional(CONF_MAP_ACTIVE_INTERRUPT_TO_INT1, default=False): cv.boolean,
+            cv.Optional(CONF_MAP_STEP_COUNTER_INTERRUPT_TO_INT1, default=False): cv.boolean,
+            cv.Optional(CONF_MAP_FREEFALL_INTERRUPT_TO_INT1, default=False): cv.boolean,
+            # TAP_DUR
+            cv.Optional(CONF_TAP_QUIET_DURATION, default="30MS"): cv.enum(
+                TAP_QUIET_DURATIONS, upper=True
+            ),
+            cv.Optional(CONF_TAP_SHOCK_DURATION, default="50MS"): cv.enum(
+                TAP_SHOCK_DURATIONS, upper=True
+            ),
+            cv.Optional(CONF_DOUBLE_TAP_DURATION, default="250MS"): cv.enum(
+                DOUBLE_TAP_DURATIONS, upper=True
+            ),
+            # TAP_THS
+            cv.Optional(CONF_STABLE_TILT_TIME, default="32_ODR_PERIODS"): cv.enum(
+                STABLE_TILT_TIMES, upper=True
+            ),
+            cv.Optional(CONF_TAP_ACCELERATION_THRESHOLD, default=0.32): cv.float_range(min=0.0, max=1.0), # Default aims at tap_th=0xA, per datasheet
+        }
+    )
+    .extend(cv.polling_component_schema("60s"))
+    .extend(i2c.i2c_device_schema(0x27))
+)
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+    await i2c.register_i2c_device(var, config)
+
+    for d in ["x", "y", "z"]:
+        accel_key = f"accel_{d}"
+        if accel_key in config:
+            sens = await sensor.new_sensor(config[accel_key])
+            cg.add(getattr(var, f"set_accel_{d}_sensor")(sens))
+
+    cg.add(var.set_resolution_range(config[CONF_ENABLE_HIGH_PASS_FILTER], config[CONF_ENABLE_WATCHDOG], config[CONF_WATCHDOG_TIME], config[CONF_RESOLUTION], config[CONF_FULL_SCALE]));
+    cg.add(var.set_odr_axis(not config[CONF_ENABLE_X_AXIS], not config[CONF_ENABLE_Y_AXIS], not config[CONF_ENABLE_Z_AXIS], config[CONF_OUTPUT_DATA_RATE]));
+    cg.add(var.set_int_set1(config[CONF_INTERRUPT_SOURCE], config[CONF_ENABLE_SINGLE_TAP_INTERRUPT], config[CONF_ENABLE_DOUBLE_TAP_INTERRUPT], config[CONF_ENABLE_ORIENTATION_INTERRUPT], config[CONF_ENABLE_ACTIVE_INTERRUPT_Z_AXIS], config[CONF_ENABLE_ACTIVE_INTERRUPT_Y_AXIS], config[CONF_ENABLE_ACTIVE_INTERRUPT_X_AXIS]));
+    cg.add(var.set_int_map1(config[CONF_MAP_SIGNIFICANT_MOVEMENT_INTERRUPT_TO_INT1], config[CONF_MAP_ORIENTATION_INTERRUPT_TO_INT1], config[CONF_MAP_SINGLE_TAP_INTERRUPT_TO_INT1], config[CONF_MAP_DOUBLE_TAP_INTERRUPT_TO_INT1], config[CONF_MAP_TILT_INTERRUPT_TO_INT1], config[CONF_MAP_ACTIVE_INTERRUPT_TO_INT1], config[CONF_MAP_STEP_COUNTER_INTERRUPT_TO_INT1], config[CONF_MAP_FREEFALL_INTERRUPT_TO_INT1]));
+    cg.add(var.set_tap_dur(config[CONF_TAP_QUIET_DURATION], config[CONF_TAP_SHOCK_DURATION], config[CONF_DOUBLE_TAP_DURATION]));
+    cg.add(var.set_tap_ths(config[CONF_STABLE_TILT_TIME], int(config[CONF_TAP_ACCELERATION_THRESHOLD]*31+0.5)));

--- a/esphome/components/da217/sensor.py
+++ b/esphome/components/da217/sensor.py
@@ -26,24 +26,24 @@ CONF_FULL_SCALE = "full_scale"
 
 WatchdogTime = da217_ns.enum("WatchdogTime")
 WATCHDOG_TIMES = {
-    "1MS": WatchdogTime.Time1ms,
-    "50MS": WatchdogTime.Time50ms,
+    "1MS": WatchdogTime.TIME1MS,
+    "50MS": WatchdogTime.TIME50MS,
 }
 
 Resolution = da217_ns.enum("Resolution")
 RESOLUTIONS = {
-    "14BITS": Resolution.Resolution14bits,
-    "12BITS": Resolution.Resolution12bits,
-    "10BITS": Resolution.Resolution10bits,
-    "8BITS": Resolution.Resolution8bits,
+    "14BITS": Resolution.RESOLUTION14BITS,
+    "12BITS": Resolution.RESOLUTION12BITS,
+    "10BITS": Resolution.RESOLUTION10BITS,
+    "8BITS": Resolution.RESOLUTION8BITS,
 }
 
 FullScale = da217_ns.enum("WatchdogTime")
 FULL_SCALES = {
-    "2G": FullScale.PlusMinus2g,
-    "4G": FullScale.PlusMinus4g,
-    "8G": FullScale.PlusMinus8g,
-    "16G": FullScale.PlusMinus16g,
+    "2G": FullScale.PLUSMINUS2G,
+    "4G": FullScale.PLUSMINUS4G,
+    "8G": FullScale.PLUSMINUS8G,
+    "16G": FullScale.PLUSMINUS16G,
 }
 
 # ODR_AXIS
@@ -55,17 +55,17 @@ CONF_OUTPUT_DATA_RATE = "output_data_rate"
 
 OutputDataRate = da217_ns.enum("OutputDataRate")
 OUTPUT_DATA_RATES = {
-    "1HZ": OutputDataRate.Rate1Hz,
-    "1.95HZ": OutputDataRate.Rate1p95Hz,
-    "3.9HZ": OutputDataRate.Rate3p9Hz,
-    "7.81HZ": OutputDataRate.Rate7p81Hz,
-    "15.63HZ": OutputDataRate.Rate15p63Hz,
-    "31.25HZ": OutputDataRate.Rate31p25Hz,
-    "62.5HZ": OutputDataRate.Rate62p5Hz,
-    "125HZ": OutputDataRate.Rate125Hz,
-    "250HZ": OutputDataRate.Rate250Hz,
-    "500HZ": OutputDataRate.Rate500Hz,
-    "UNCONFIGURED": OutputDataRate.Unconfigured,
+    "1HZ": OutputDataRate.RATE1HZ,
+    "1.95HZ": OutputDataRate.RATE1P95HZ,
+    "3.9HZ": OutputDataRate.RATE3P9HZ,
+    "7.81HZ": OutputDataRate.RATE7P81HZ,
+    "15.63HZ": OutputDataRate.RATE15P63HZ,
+    "31.25HZ": OutputDataRate.RATE31P25HZ,
+    "62.5HZ": OutputDataRate.RATE62P5HZ,
+    "125HZ": OutputDataRate.RATE125HZ,
+    "250HZ": OutputDataRate.RATE250HZ,
+    "500HZ": OutputDataRate.RATE500HZ,
+    "UNCONFIGURED": OutputDataRate.UNCONFIGURED,
 }
 
 # INT_SET1
@@ -80,9 +80,9 @@ CONF_ENABLE_ACTIVE_INTERRUPT_X_AXIS = "enable_active_interrupt_x_axis"
 
 InterruptSource = da217_ns.enum("InterruptSource")
 INTERRUPT_SOURCES = {
-    "OVERSAMPLING": InterruptSource.Oversampling,
-    "UNFILTERED": InterruptSource.Unfiltered,
-    "FILTERED": InterruptSource.Filtered,
+    "OVERSAMPLING": InterruptSource.OVERSAMPLING,
+    "UNFILTERED": InterruptSource.UNFILTERED,
+    "FILTERED": InterruptSource.FILTERED,
 }
 
 # INT_MAP1
@@ -106,26 +106,26 @@ CONF_DOUBLE_TAP_DURATION = "double_tap_duration"
 
 TapQuietDuration = da217_ns.enum("TapQuietDuration")
 TAP_QUIET_DURATIONS = {
-    "30MS": TapQuietDuration.Quiet30ms,
-    "20MS": TapQuietDuration.Quiet20ms,
+    "30MS": TapQuietDuration.QUIET30MS,
+    "20MS": TapQuietDuration.QUIET20MS,
 }
 
 TapShockDuration = da217_ns.enum("TapShockDuration")
 TAP_SHOCK_DURATIONS = {
-    "50MS": TapShockDuration.Shock50ms,
-    "70MS": TapShockDuration.Shock70ms,
+    "50MS": TapShockDuration.SHOCK50MS,
+    "70MS": TapShockDuration.SHOCK70MS,
 }
 
 DoubleTapDuration = da217_ns.enum("DoubleTapDuration")
 DOUBLE_TAP_DURATIONS = {
-    "50MS": DoubleTapDuration.DoubleTap50ms,
-    "100MS": DoubleTapDuration.DoubleTap100ms,
-    "150MS": DoubleTapDuration.DoubleTap150ms,
-    "200MS": DoubleTapDuration.DoubleTap200ms,
-    "250MS": DoubleTapDuration.DoubleTap250ms,
-    "375MS": DoubleTapDuration.DoubleTap375ms,
-    "500MS": DoubleTapDuration.DoubleTap500ms,
-    "700MS": DoubleTapDuration.DoubleTap700ms,
+    "50MS": DoubleTapDuration.DOUBLETAP50MS,
+    "100MS": DoubleTapDuration.DOUBLETAP100MS,
+    "150MS": DoubleTapDuration.DOUBLETAP150MS,
+    "200MS": DoubleTapDuration.DOUBLETAP200MS,
+    "250MS": DoubleTapDuration.DOUBLETAP250MS,
+    "375MS": DoubleTapDuration.DOUBLETAP375MS,
+    "500MS": DoubleTapDuration.DOUBLETAP500MS,
+    "700MS": DoubleTapDuration.DOUBLETAP700MS,
 }
 
 # TAP_THS

--- a/tests/test1.1.yaml
+++ b/tests/test1.1.yaml
@@ -223,6 +223,9 @@ canbus:
     can_id: 4
     bit_rate: 50kbps
 
+sensor:
+  - platform: da217
+
 button:
   - platform: template
     name: Canbus Actions


### PR DESCRIPTION
# What does this implement/fix?

This PR adds support for the DA217 family of MEMS accelerometers.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):**
- Fixes tap control for esphome/feature-requests/issues/1096

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#3597

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [X] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
sensor:
  - platform: da217
    address: 0x27
    resolution: 14bits
    full_scale: 4g
    tap_quiet_duration: 30ms
    tap_shock_duration: 70ms
    double_tap_duration: 500ms
    interrupt_source: unfiltered
#    enable_single_tap_interrupt: true
#    map_single_tap_interrupt_to_int1: true
    enable_double_tap_interrupt: true
    map_double_tap_interrupt_to_int1: true
    tap_acceleration_threshold: 0.0625
    output_data_rate: 125Hz
    accel_x:
      name: "Acceleration X"
    accel_y:
      name: "Acceleration Y"
    accel_z:
      name: "Acceleration z"
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
