### PR TITLE
WLED Sync fix and BK72XX support

### DIFF
--- a/esphome/components/wled/__init__.py
+++ b/esphome/components/wled/__init__.py
@@ -9,6 +9,7 @@ WLEDLightEffect = wled_ns.class_("WLEDLightEffect", AddressableLightEffect)
 
 CONFIG_SCHEMA = cv.All(cv.Schema({}), cv.only_with_arduino)
 CONF_SYNC_GROUP_MASK = "sync_group_mask"
+CONF_BLANK_ON_START = "blank_on_start"
 
 
 @register_addressable_effect(
@@ -18,10 +19,12 @@ CONF_SYNC_GROUP_MASK = "sync_group_mask"
     {
         cv.Optional(CONF_PORT, default=21324): cv.port,
         cv.Optional(CONF_SYNC_GROUP_MASK, default=0): cv.int_range(min=0, max=255),
+        cv.Optional(CONF_BLANK_ON_START, default=True): cv.boolean,
     },
 )
 async def wled_light_effect_to_code(config, effect_id):
     effect = cg.new_Pvariable(effect_id, config[CONF_NAME])
     cg.add(effect.set_port(config[CONF_PORT]))
     cg.add(effect.set_sync_group_mask(config[CONF_SYNC_GROUP_MASK]))
+    cg.add(effect.set_blank_on_start(config[CONF_BLANK_ON_START]))
     return effect

--- a/esphome/components/wled/__init__.py
+++ b/esphome/components/wled/__init__.py
@@ -8,6 +8,7 @@ wled_ns = cg.esphome_ns.namespace("wled")
 WLEDLightEffect = wled_ns.class_("WLEDLightEffect", AddressableLightEffect)
 
 CONFIG_SCHEMA = cv.All(cv.Schema({}), cv.only_with_arduino)
+CONF_SYNC_GROUP_MASK = "sync_group_mask"
 
 
 @register_addressable_effect(
@@ -16,10 +17,11 @@ CONFIG_SCHEMA = cv.All(cv.Schema({}), cv.only_with_arduino)
     "WLED",
     {
         cv.Optional(CONF_PORT, default=21324): cv.port,
+        cv.Optional(CONF_SYNC_GROUP_MASK, default=0): cv.int_range(min=0, max=255),
     },
 )
 async def wled_light_effect_to_code(config, effect_id):
     effect = cg.new_Pvariable(effect_id, config[CONF_NAME])
     cg.add(effect.set_port(config[CONF_PORT]))
-
+    cg.add(effect.set_sync_group_mask(config[CONF_SYNC_GROUP_MASK]))
     return effect

--- a/esphome/components/wled/wled_light_effect.cpp
+++ b/esphome/components/wled/wled_light_effect.cpp
@@ -162,20 +162,12 @@ bool WLEDLightEffect::parse_notifier_frame_(light::AddressableLight &it, const u
     return false;
   }
 
-  //uint8_t payload_sync_group_mask = payload[34];
-
-  //if (sync_group_mask_ != 0 && payload_sync_group_mask != sync_group_mask_) {
-  //  ESP_LOGD(TAG, "sync group mask does not match");
-  //  return false;
-  //}
-
   uint8_t payload_sync_group_mask = payload[34];
 
   if ((payload_sync_group_mask & sync_group_mask_) != sync_group_mask_) {
     ESP_LOGD(TAG, "sync group mask does not match");
     return false;
   }
-
 
   uint8_t bri = payload[0];
   uint8_t r = esp_scale8(payload[1], bri);

--- a/esphome/components/wled/wled_light_effect.cpp
+++ b/esphome/components/wled/wled_light_effect.cpp
@@ -33,10 +33,10 @@ WLEDLightEffect::WLEDLightEffect(const std::string &name) : AddressableLightEffe
 void WLEDLightEffect::start() {
   AddressableLightEffect::start();
 
-  if (blank_on_start_) {
-    blank_at_ = 0;
+  if (this->blank_on_start_) {
+    this->blank_at_ = 0;
   } else {
-    blank_at_ = UINT32_MAX;
+    this->blank_at_ = UINT32_MAX;
   }
 }
 
@@ -164,7 +164,7 @@ bool WLEDLightEffect::parse_notifier_frame_(light::AddressableLight &it, const u
 
   uint8_t payload_sync_group_mask = payload[34];
 
-  if ((payload_sync_group_mask & sync_group_mask_) != sync_group_mask_) {
+  if ((payload_sync_group_mask & this->sync_group_mask_) != this->sync_group_mask_) {
     ESP_LOGD(TAG, "sync group mask does not match");
     return false;
   }

--- a/esphome/components/wled/wled_light_effect.cpp
+++ b/esphome/components/wled/wled_light_effect.cpp
@@ -13,6 +13,10 @@
 #include <WiFiUdp.h>
 #endif
 
+#ifdef USE_BK72XX
+#include <WiFiUdp.h>
+#endif
+
 namespace esphome {
 namespace wled {
 
@@ -101,8 +105,11 @@ bool WLEDLightEffect::parse_frame_(light::AddressableLight &it, const uint8_t *p
         if (!parse_drgb_frame_(it, payload, size))
           return false;
       } else {
-        if (!parse_notifier_frame_(it, payload, size))
+        if (!parse_notifier_frame_(it, payload, size)) {
           return false;
+        } else {
+          timeout = UINT8_MAX;
+        }
       }
       break;
 
@@ -143,8 +150,32 @@ bool WLEDLightEffect::parse_frame_(light::AddressableLight &it, const uint8_t *p
 }
 
 bool WLEDLightEffect::parse_notifier_frame_(light::AddressableLight &it, const uint8_t *payload, uint16_t size) {
-  // Packet needs to be empty
-  return size == 0;
+  // Receive at least RGBW and Brightness for all LEDs from WLED Sync Notification
+  // https://kno.wled.ge/interfaces/udp-notifier/
+  // https://github.com/Aircoookie/WLED/blob/main/wled00/udp.cpp
+
+  if (size < 34) {
+    return false;
+  }
+
+  uint8_t payload_sync_group_mask = payload[34];
+
+  if (sync_group_mask_ != 0 && payload_sync_group_mask != sync_group_mask_) {
+    ESP_LOGD(TAG, "sync group mask does not match");
+    return false;
+  }
+
+  uint8_t bri = payload[0];
+  uint8_t r = esp_scale8(payload[1], bri);
+  uint8_t g = esp_scale8(payload[2], bri);
+  uint8_t b = esp_scale8(payload[3], bri);
+  uint8_t w = esp_scale8(payload[8], bri);
+
+  for (auto &&led : it) {
+    led.set(Color(r, g, b, w));
+  }
+
+  return true;
 }
 
 bool WLEDLightEffect::parse_warls_frame_(light::AddressableLight &it, const uint8_t *payload, uint16_t size) {

--- a/esphome/components/wled/wled_light_effect.cpp
+++ b/esphome/components/wled/wled_light_effect.cpp
@@ -33,7 +33,11 @@ WLEDLightEffect::WLEDLightEffect(const std::string &name) : AddressableLightEffe
 void WLEDLightEffect::start() {
   AddressableLightEffect::start();
 
-  blank_at_ = 0;
+  if (blank_on_start_) {
+    blank_at_ = 0;
+  } else {
+    blank_at_ = UINT32_MAX;
+  }
 }
 
 void WLEDLightEffect::stop() {
@@ -158,12 +162,20 @@ bool WLEDLightEffect::parse_notifier_frame_(light::AddressableLight &it, const u
     return false;
   }
 
+  //uint8_t payload_sync_group_mask = payload[34];
+
+  //if (sync_group_mask_ != 0 && payload_sync_group_mask != sync_group_mask_) {
+  //  ESP_LOGD(TAG, "sync group mask does not match");
+  //  return false;
+  //}
+
   uint8_t payload_sync_group_mask = payload[34];
 
-  if (sync_group_mask_ != 0 && payload_sync_group_mask != sync_group_mask_) {
+  if ((payload_sync_group_mask & sync_group_mask_) != sync_group_mask_) {
     ESP_LOGD(TAG, "sync group mask does not match");
     return false;
   }
+
 
   uint8_t bri = payload[0];
   uint8_t r = esp_scale8(payload[1], bri);

--- a/esphome/components/wled/wled_light_effect.h
+++ b/esphome/components/wled/wled_light_effect.h
@@ -22,6 +22,7 @@ class WLEDLightEffect : public light::AddressableLightEffect {
   void apply(light::AddressableLight &it, const Color &current_color) override;
   void set_port(uint16_t port) { this->port_ = port; }
   void set_sync_group_mask(uint8_t mask) { this->sync_group_mask_ = mask; }
+  void set_blank_on_start(bool blank) { this->blank_on_start_ = blank; }
 
  protected:
   void blank_all_leds_(light::AddressableLight &it);
@@ -37,6 +38,7 @@ class WLEDLightEffect : public light::AddressableLightEffect {
   uint32_t blank_at_{0};
   uint32_t dropped_{0};
   uint8_t sync_group_mask_{0};
+  bool blank_on_start_{true};
 };
 
 }  // namespace wled

--- a/esphome/components/wled/wled_light_effect.h
+++ b/esphome/components/wled/wled_light_effect.h
@@ -21,6 +21,7 @@ class WLEDLightEffect : public light::AddressableLightEffect {
   void stop() override;
   void apply(light::AddressableLight &it, const Color &current_color) override;
   void set_port(uint16_t port) { this->port_ = port; }
+  void set_sync_group_mask(uint8_t mask) { this->sync_group_mask_ = mask; }
 
  protected:
   void blank_all_leds_(light::AddressableLight &it);
@@ -35,6 +36,7 @@ class WLEDLightEffect : public light::AddressableLightEffect {
   std::unique_ptr<UDP> udp_;
   uint32_t blank_at_{0};
   uint32_t dropped_{0};
+  uint8_t sync_group_mask_{0};
 };
 
 }  // namespace wled


### PR DESCRIPTION
# What does this implement/fix?

1. Fixes/Adds support for WLED Sync Notifications and Sync Groups
2. Adds BK72XX support to WLED component
3. Adds blank on start config option
 
The best I can tell, the Light Component WLED effect does not currently actually support WLED Sync notification as described.
https://esphome.io/components/light/#wled-effect
https://github.com/esphome/esphome/blob/dev/esphome/components/wled/wled_light_effect.cpp#L145-L148

The other protocols in wled_light_effect.cpp are for real time UDP control of LEDs.

But the WLED UDP Sync protocol is used to notify other devices of what status or light effect they should be showing, and does not send any real time control for using with LEDs. (WLED DDP should be used for this)
https://kno.wled.ge/advanced/ddp/
https://kno.wled.ge/interfaces/ddp/
http://www.3waylabs.com/ddp/

In addition to adding BK72XX support to wled_light_effect, this PR implements the basics for correctly receiving WLED Sync Notifications for Brightness and RGBW values, applying them to the whole of the addressable strip.

It allows for the setting of a sync group mask in order to facilitate receiving sync notifications only from select sync group(s) as specified in WLED Sync settings.  (https://i.imgur.com/6ExLCyr.png)


## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>
https://github.com/esphome/issues/issues/3296
https://github.com/esphome/issues/issues/3586

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [X] ESP8266
- [ ] RP2040
- [X] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
```yaml

esphome:
  name: esptest
  name_add_mac_suffix: False

esp8266:
  board: d1_mini

external_components:
  - source:
      type: git
      url: https://github.com/ChuckMash/esphome
      ref: wled-sync-fix
    components: [ wled ]
    refresh: always

logger:

web_server:

captive_portal:

mdns:

api:
  password: "secret_api_password"

ota:
  password: "secret_ota_password"

wifi:
  ssid: !secret wifi_ssid
  password: !secret wifi_password

wled:

sensor:
  - platform: uptime
    name: Uptime

light:
  - platform: neopixelbus
    type: GRB
    variant: WS2811
    pin: GPIO2
    num_leds: 60
    name: "NeoPixel Light"
    effects:
      wled:
        #sync_group_mask: 1 # Default is 0 (all groups) groups 1-8 are masked 1, 2, 4, 8, 16, 32, 64, 128
        #blank_on_start: True # Default is True, which was default before this config
        


```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
