### PR TITLE
Clear UART read buffer before sending next command

### DIFF
--- a/esphome/components/fingerprint_grow/fingerprint_grow.cpp
+++ b/esphome/components/fingerprint_grow/fingerprint_grow.cpp
@@ -336,7 +336,8 @@ void FingerprintGrowComponent::aura_led_control(uint8_t state, uint8_t speed, ui
 }
 
 uint8_t FingerprintGrowComponent::send_command_() {
-  while (this->available()) this->read();           //clear UART read buffer
+  while (this->available())
+    this->read();           // clear UART read buffer
   this->write((uint8_t) (START_CODE >> 8));
   this->write((uint8_t) (START_CODE & 0xFF));
   this->write(this->address_[0]);

--- a/esphome/components/fingerprint_grow/fingerprint_grow.cpp
+++ b/esphome/components/fingerprint_grow/fingerprint_grow.cpp
@@ -336,6 +336,7 @@ void FingerprintGrowComponent::aura_led_control(uint8_t state, uint8_t speed, ui
 }
 
 uint8_t FingerprintGrowComponent::send_command_() {
+  while (this->available()) this->read();           //clear UART read buffer
   this->write((uint8_t) (START_CODE >> 8));
   this->write((uint8_t) (START_CODE & 0xFF));
   this->write(this->address_[0]);

--- a/esphome/components/fingerprint_grow/fingerprint_grow.cpp
+++ b/esphome/components/fingerprint_grow/fingerprint_grow.cpp
@@ -337,7 +337,7 @@ void FingerprintGrowComponent::aura_led_control(uint8_t state, uint8_t speed, ui
 
 uint8_t FingerprintGrowComponent::send_command_() {
   while (this->available())
-    this->read();           // clear UART read buffer
+    this->read();
   this->write((uint8_t) (START_CODE >> 8));
   this->write((uint8_t) (START_CODE & 0xFF));
   this->write(this->address_[0]);


### PR DESCRIPTION
Clear UART read buffer before sending next command, this fixes issue  when all fingers became authorized after first AuraLed command is used on some sensors.
Discussions about this issue can be found here:  https://github.com/esphome/issues/issues/2542  


# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/2542

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ x] ESP32
- [ x] ESP32 IDF
- [ x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx


## Checklist:
  - [ x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).