### PR TITLE
Add device_class to text_sensor in API

### DIFF
--- a/esphome/components/api/api.proto
+++ b/esphome/components/api/api.proto
@@ -600,6 +600,7 @@ message ListEntitiesTextSensorResponse {
   string icon = 5;
   bool disabled_by_default = 6;
   EntityCategory entity_category = 7;
+  string device_class = 8;
 }
 message TextSensorStateResponse {
   option (id) = 27;

--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -543,6 +543,7 @@ bool APIConnection::send_text_sensor_info(text_sensor::TextSensor *text_sensor) 
   msg.icon = text_sensor->get_icon();
   msg.disabled_by_default = text_sensor->is_disabled_by_default();
   msg.entity_category = static_cast<enums::EntityCategory>(text_sensor->get_entity_category());
+  msg.device_class = text_sensor->get_device_class();
   return this->send_list_entities_text_sensor_response(msg);
 }
 #endif

--- a/esphome/components/api/api_pb2.cpp
+++ b/esphome/components/api/api_pb2.cpp
@@ -2785,7 +2785,6 @@ void ListEntitiesTextSensorResponse::dump_to(std::string &out) const {
   out.append("  device_class: ");
   out.append("'").append(this->device_class).append("'");
   out.append("\n");
-  
   out.append("}");
 }
 #endif

--- a/esphome/components/api/api_pb2.cpp
+++ b/esphome/components/api/api_pb2.cpp
@@ -2721,6 +2721,10 @@ bool ListEntitiesTextSensorResponse::decode_length(uint32_t field_id, ProtoLengt
       this->icon = value.as_string();
       return true;
     }
+    case 8: {
+      this->device_class = value.as_string();
+      return true;
+    }
     default:
       return false;
   }
@@ -2743,6 +2747,7 @@ void ListEntitiesTextSensorResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_string(5, this->icon);
   buffer.encode_bool(6, this->disabled_by_default);
   buffer.encode_enum<enums::EntityCategory>(7, this->entity_category);
+  buffer.encode_string(8, this->device_class);
 }
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void ListEntitiesTextSensorResponse::dump_to(std::string &out) const {
@@ -2776,6 +2781,11 @@ void ListEntitiesTextSensorResponse::dump_to(std::string &out) const {
   out.append("  entity_category: ");
   out.append(proto_enum_to_string<enums::EntityCategory>(this->entity_category));
   out.append("\n");
+
+  out.append("  device_class: ");
+  out.append("'").append(this->device_class).append("'");
+  out.append("\n");
+  
   out.append("}");
 }
 #endif

--- a/esphome/components/api/api_pb2.h
+++ b/esphome/components/api/api_pb2.h
@@ -713,6 +713,7 @@ class ListEntitiesTextSensorResponse : public ProtoMessage {
   std::string icon{};
   bool disabled_by_default{false};
   enums::EntityCategory entity_category{};
+  std::string device_class{};
   void encode(ProtoWriteBuffer buffer) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;

--- a/esphome/components/text_sensor/__init__.py
+++ b/esphome/components/text_sensor/__init__.py
@@ -3,6 +3,7 @@ import esphome.config_validation as cv
 from esphome import automation
 from esphome.components import mqtt
 from esphome.const import (
+    CONF_DEVICE_CLASS,
     CONF_ENTITY_CATEGORY,
     CONF_FILTERS,
     CONF_ICON,
@@ -14,11 +15,20 @@ from esphome.const import (
     CONF_STATE,
     CONF_FROM,
     CONF_TO,
+    DEVICE_CLASS_DATE,
+    DEVICE_CLASS_EMPTY,
+    DEVICE_CLASS_TIMESTAMP,
 )
 from esphome.core import CORE, coroutine_with_priority
 from esphome.cpp_generator import MockObjClass
 from esphome.cpp_helpers import setup_entity
 from esphome.util import Registry
+
+DEVICE_CLASSES = [
+    DEVICE_CLASS_DATE,
+    DEVICE_CLASS_EMPTY,
+    DEVICE_CLASS_TIMESTAMP,
+]
 
 
 IS_PLATFORM_COMPONENT = True
@@ -111,11 +121,13 @@ async def map_filter_to_code(config, filter_id):
         filter_id, map_([(item[CONF_FROM], item[CONF_TO]) for item in config])
     )
 
+validate_device_class = cv.one_of(*DEVICE_CLASSES, lower=True, space="_")
 
 TEXT_SENSOR_SCHEMA = cv.ENTITY_BASE_SCHEMA.extend(cv.MQTT_COMPONENT_SCHEMA).extend(
     {
         cv.OnlyWith(CONF_MQTT_ID, "mqtt"): cv.declare_id(mqtt.MQTTTextSensor),
         cv.GenerateID(): cv.declare_id(TextSensor),
+        cv.Optional(CONF_DEVICE_CLASS): validate_device_class,
         cv.Optional(CONF_FILTERS): validate_filters,
         cv.Optional(CONF_ON_VALUE): automation.validate_automation(
             {
@@ -140,12 +152,15 @@ def text_sensor_schema(
     *,
     icon: str = _UNDEF,
     entity_category: str = _UNDEF,
+    device_class: str = _UNDEF,
 ) -> cv.Schema:
     schema = TEXT_SENSOR_SCHEMA
     if class_ is not _UNDEF:
         schema = schema.extend({cv.GenerateID(): cv.declare_id(class_)})
     if icon is not _UNDEF:
         schema = schema.extend({cv.Optional(CONF_ICON, default=icon): cv.icon})
+    if device_class is not _UNDEF:
+        schema = schema.extend({cv.Optional(CONF_DEVICE_CLASS, default=device_class): cv.string})
     if entity_category is not _UNDEF:
         schema = schema.extend(
             {
@@ -163,6 +178,9 @@ async def build_filters(config):
 
 async def setup_text_sensor_core_(var, config):
     await setup_entity(var, config)
+
+    if CONF_DEVICE_CLASS in config:
+        cg.add(var.set_device_class(config[CONF_DEVICE_CLASS]))
 
     if config.get(CONF_FILTERS):  # must exist and not be empty
         filters = await build_filters(config[CONF_FILTERS])

--- a/esphome/components/text_sensor/__init__.py
+++ b/esphome/components/text_sensor/__init__.py
@@ -121,6 +121,7 @@ async def map_filter_to_code(config, filter_id):
         filter_id, map_([(item[CONF_FROM], item[CONF_TO]) for item in config])
     )
 
+
 validate_device_class = cv.one_of(*DEVICE_CLASSES, lower=True, space="_")
 
 TEXT_SENSOR_SCHEMA = cv.ENTITY_BASE_SCHEMA.extend(cv.MQTT_COMPONENT_SCHEMA).extend(
@@ -160,7 +161,9 @@ def text_sensor_schema(
     if icon is not _UNDEF:
         schema = schema.extend({cv.Optional(CONF_ICON, default=icon): cv.icon})
     if device_class is not _UNDEF:
-        schema = schema.extend({cv.Optional(CONF_DEVICE_CLASS, default=device_class): cv.string})
+        schema = schema.extend(
+            {cv.Optional(CONF_DEVICE_CLASS, default=device_class): cv.string}
+        )
     if entity_category is not _UNDEF:
         schema = schema.extend(
             {

--- a/esphome/components/text_sensor/text_sensor.h
+++ b/esphome/components/text_sensor/text_sensor.h
@@ -13,6 +13,9 @@ namespace text_sensor {
 #define LOG_TEXT_SENSOR(prefix, type, obj) \
   if ((obj) != nullptr) { \
     ESP_LOGCONFIG(TAG, "%s%s '%s'", prefix, LOG_STR_LITERAL(type), (obj)->get_name().c_str()); \
+    if (!(obj)->get_device_class().empty()) { \
+      ESP_LOGCONFIG(TAG, "%s  Device Class: '%s'", prefix, (obj)->get_device_class().c_str()); \
+    } \
     if (!(obj)->get_icon().empty()) { \
       ESP_LOGCONFIG(TAG, "%s  Icon: '%s'", prefix, (obj)->get_icon().c_str()); \
     } \
@@ -28,7 +31,7 @@ namespace text_sensor {
  public: \
   void set_##name##_text_sensor(text_sensor::TextSensor *text_sensor) { this->name##_text_sensor_ = text_sensor; }
 
-class TextSensor : public EntityBase {
+class TextSensor : public EntityBase, public EntityBase_DeviceClass {
  public:
   /// Getter-syntax for .state.
   std::string get_state() const;


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->
Following the implementation of https://github.com/esphome/esphome/pull/6202

Related PR:
- [ ] `aiosphomeapi`: https://github.com/esphome/aioesphomeapi/compare/main...dougiteixeira:aioesphomeapi:text_sensor-device_class
- [ ] ESPHome integration in core: https://github.com/home-assistant/core/compare/dev...dougiteixeira:core:esphome-text_sensor-device_class-ha

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
