### PR TITLE
Mhz19 warmup

### DIFF
--- a/esphome/components/mhz19/mhz19.cpp
+++ b/esphome/components/mhz19/mhz19.cpp
@@ -29,6 +29,14 @@ void MHZ19Component::setup() {
 }
 
 void MHZ19Component::update() {
+  uint32_t now_ms = millis();
+  uint32_t warmup_ms = this->warmup_seconds_ * 1000;
+  if (now_ms < warmup_ms) {
+    ESP_LOGW(TAG, "MHZ19 warming up, %ds left", (warmup_ms - now_ms) / 1000);
+    this->status_set_warning();
+    return;
+  }
+
   uint8_t response[MHZ19_RESPONSE_LENGTH];
   if (!this->mhz19_write_command_(MHZ19_COMMAND_GET_PPM, response)) {
     ESP_LOGW(TAG, "Reading data from MHZ19 failed!");
@@ -101,6 +109,8 @@ void MHZ19Component::dump_config() {
   } else if (this->abc_boot_logic_ == MHZ19_ABC_DISABLED) {
     ESP_LOGCONFIG(TAG, "  Automatic baseline calibration disabled on boot");
   }
+
+  ESP_LOGCONFIG(TAG, "  Warmup seconds: %ds", this->warmup_seconds_);
 }
 
 }  // namespace mhz19

--- a/esphome/components/mhz19/mhz19.h
+++ b/esphome/components/mhz19/mhz19.h
@@ -25,6 +25,7 @@ class MHZ19Component : public PollingComponent, public uart::UARTDevice {
   void set_temperature_sensor(sensor::Sensor *temperature_sensor) { temperature_sensor_ = temperature_sensor; }
   void set_co2_sensor(sensor::Sensor *co2_sensor) { co2_sensor_ = co2_sensor; }
   void set_abc_enabled(bool abc_enabled) { abc_boot_logic_ = abc_enabled ? MHZ19_ABC_ENABLED : MHZ19_ABC_DISABLED; }
+  void set_warmup_seconds(uint32_t seconds) { warmup_seconds_ = seconds; }
 
  protected:
   bool mhz19_write_command_(const uint8_t *command, uint8_t *response);
@@ -32,6 +33,7 @@ class MHZ19Component : public PollingComponent, public uart::UARTDevice {
   sensor::Sensor *temperature_sensor_{nullptr};
   sensor::Sensor *co2_sensor_{nullptr};
   MHZ19ABCLogic abc_boot_logic_{MHZ19_ABC_NONE};
+  uint32_t warmup_seconds_;
 };
 
 template<typename... Ts> class MHZ19CalibrateZeroAction : public Action<Ts...> {

--- a/esphome/components/mhz19/sensor.py
+++ b/esphome/components/mhz19/sensor.py
@@ -18,6 +18,7 @@ from esphome.const import (
 DEPENDENCIES = ["uart"]
 
 CONF_AUTOMATIC_BASELINE_CALIBRATION = "automatic_baseline_calibration"
+CONF_WARMUP_TIME = "warmup_time"
 
 mhz19_ns = cg.esphome_ns.namespace("mhz19")
 MHZ19Component = mhz19_ns.class_("MHZ19Component", cg.PollingComponent, uart.UARTDevice)
@@ -45,6 +46,9 @@ CONFIG_SCHEMA = (
                 state_class=STATE_CLASS_MEASUREMENT,
             ),
             cv.Optional(CONF_AUTOMATIC_BASELINE_CALIBRATION): cv.boolean,
+            cv.Optional(
+                CONF_WARMUP_TIME, default="75s"
+            ): cv.positive_time_period_seconds,
         }
     )
     .extend(cv.polling_component_schema("60s"))
@@ -67,6 +71,8 @@ async def to_code(config):
 
     if CONF_AUTOMATIC_BASELINE_CALIBRATION in config:
         cg.add(var.set_abc_enabled(config[CONF_AUTOMATIC_BASELINE_CALIBRATION]))
+
+    cg.add(var.set_warmup_seconds(config[CONF_WARMUP_TIME]))
 
 
 CALIBRATION_ACTION_SCHEMA = maybe_simple_id(


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

MHZ-19C seems to take somewhere between 60-75s to warm up after power on. Until that, the reported CO2 concentration seems to be rubbish, sometimes 500... sometimes 505... and it seems there's no way to know when it finishes warming up, other than... waiting.

This PR adds a configuration option to accomodate for this warmup time, and return NAN until warmup is finished, thus avoiding reporting bougus sensor readings.

The default value of 75s was empirically determined, after a series of tests.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

Any standard configuration as described https://esphome.io/components/sensor/mhz19.html should work.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs): https://github.com/esphome/esphome-docs/pull/3604