### PR TITLE
fixed ili9xxx dimensions after hardware rotation

### DIFF
--- a/esphome/components/ili9xxx/ili9xxx_display.cpp
+++ b/esphome/components/ili9xxx/ili9xxx_display.cpp
@@ -100,6 +100,17 @@ void ILI9XXXDisplay::dump_config() {
 }
 
 float ILI9XXXDisplay::get_setup_priority() const { return setup_priority::HARDWARE; }
+int ILI9XXXDisplay::get_width() {
+  if (rotation_ == 0 && swap_xy_)
+    return height_;
+  return DisplayBuffer::get_width();
+}
+
+int ILI9XXXDisplay::get_height() {
+  if (rotation_ == 0 && swap_xy_)
+    return width_;
+  return DisplayBuffer::get_height();
+}
 
 void ILI9XXXDisplay::fill(Color color) {
   uint16_t new_color = 0;

--- a/esphome/components/ili9xxx/ili9xxx_display.h
+++ b/esphome/components/ili9xxx/ili9xxx_display.h
@@ -87,6 +87,8 @@ class ILI9XXXDisplay : public display::DisplayBuffer,
   display::DisplayType get_display_type() override { return display::DisplayType::DISPLAY_TYPE_COLOR; }
   void draw_pixels_at(int x_start, int y_start, int w, int h, const uint8_t *ptr, display::ColorOrder order,
                       display::ColorBitness bitness, bool big_endian, int x_offset, int y_offset, int x_pad) override;
+  int get_width() override;
+  int get_height() override;
 
  protected:
   void draw_absolute_pixel_internal(int x, int y, Color color) override;


### PR DESCRIPTION
# What does this implement/fix?

Fix width and height when hardware rotation is used on ili9xxx display.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:


```yaml
# Example config.yaml
display:
  - platform: ili9xxx
    model: ILI9341
    id: screen
    dc_pin: 13
    reset_pin: 14
    auto_clear_enabled: false
    update_interval: never
    cs_pin: 10
    data_rate: 20MHz
    transform:
      swap_xy: true
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

