### PR TITLE
Adjust HeatpumpIR dependency

### DIFF
--- a/esphome/components/heatpumpir/climate.py
+++ b/esphome/components/heatpumpir/climate.py
@@ -119,4 +119,4 @@ def to_code(config):
     cg.add_library("tonia/HeatpumpIR", "1.0.23")
 
     if CORE.is_esp8266 or CORE.is_esp32:
-        cg.add_library("crankyoldgit/IRremoteESP8266", "2.7.12")
+        cg.add_library("crankyoldgit/IRremoteESP8266", "2.8.4")

--- a/platformio.ini
+++ b/platformio.ini
@@ -93,7 +93,7 @@ lib_deps =
     ESP8266HTTPClient                     ; http_request (Arduino built-in)
     ESP8266mDNS                           ; mdns (Arduino built-in)
     DNSServer                             ; captive_portal (Arduino built-in)
-    crankyoldgit/IRremoteESP8266@2.7.12   ; heatpumpir
+    crankyoldgit/IRremoteESP8266@~2.8.4   ; heatpumpir
 build_flags =
     ${common:arduino.build_flags}
     -Wno-nonnull-compare
@@ -122,7 +122,7 @@ lib_deps =
     ESPmDNS                              ; mdns (Arduino built-in)
     DNSServer                            ; captive_portal (Arduino built-in)
     esphome/ESP32-audioI2S@2.0.7         ; i2s_audio
-    crankyoldgit/IRremoteESP8266@2.7.12  ; heatpumpir
+    crankyoldgit/IRremoteESP8266@~2.8.4  ; heatpumpir
     droscy/esp_wireguard@0.3.2           ; wireguard
 build_flags =
     ${common:arduino.build_flags}


### PR DESCRIPTION
You can remove implicit dependency (`crankyoldgit/IRremoteESP8266@~2.8.4`) later when PR is merged https://github.com/ToniA/arduino-heatpumpir/pull/167