### PR TITLE
AUTO_LOAD `sensor` for `shelly_dimmer`

### DIFF
--- a/esphome/components/shelly_dimmer/light.py
+++ b/esphome/components/shelly_dimmer/light.py
@@ -29,7 +29,8 @@ from esphome.const import (
 from esphome.core import HexInt, CORE
 
 DOMAIN = "shelly_dimmer"
-DEPENDENCIES = ["sensor", "uart", "esp8266"]
+AUTO_LOAD = ["sensor"]
+DEPENDENCIES = ["uart", "esp8266"]
 
 shelly_dimmer_ns = cg.esphome_ns.namespace("shelly_dimmer")
 ShellyDimmer = shelly_dimmer_ns.class_(


### PR DESCRIPTION
# What does this implement/fix?

`sensor` should be auto loaded for `shelly_dimmer`, not a dependency.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
