### PR TITLE
Fix to RF receiver for Drayton Digistat heating controller

### DIFF
--- a/esphome/components/remote_base/drayton_protocol.cpp
+++ b/esphome/components/remote_base/drayton_protocol.cpp
@@ -14,7 +14,7 @@ static const uint8_t NBITS_ADDRESS = 16;
 static const uint8_t NBITS_CHANNEL = 5;
 static const uint8_t NBITS_COMMAND = 7;
 static const uint8_t NDATABITS = NBITS_ADDRESS + NBITS_CHANNEL + NBITS_COMMAND;
-static const uint8_t MIN_RX_SRC = (NDATABITS * 2 + NBITS_SYNC / 2);
+static const uint8_t MIN_RX_SRC = (NDATABITS + NBITS_SYNC / 2);
 
 static const uint8_t CMD_ON = 0x41;
 static const uint8_t CMD_OFF = 0x02;
@@ -135,7 +135,7 @@ optional<DraytonData> DraytonProtocol::decode(RemoteReceiveData src) {
       .command = 0,
   };
 
-  while (src.size() - src.get_index() > MIN_RX_SRC) {
+  while (src.size() - src.get_index() >= MIN_RX_SRC) {
     ESP_LOGVV(TAG,
               "Decode Drayton: %" PRId32 ", %" PRId32 " %" PRId32 " %" PRId32 " %" PRId32 " %" PRId32 " %" PRId32
               " %" PRId32 " %" PRId32 " %" PRId32 " %" PRId32 " %" PRId32 " %" PRId32 " %" PRId32 " %" PRId32
@@ -150,7 +150,7 @@ optional<DraytonData> DraytonProtocol::decode(RemoteReceiveData src) {
     }
 
     // Look for sync pulse, after. If sucessful index points to space of sync symbol
-    while (src.size() - src.get_index() >= NDATABITS) {
+    while (src.size() - src.get_index() >= MIN_RX_SRC) {
       ESP_LOGVV(TAG, "Decode Drayton: sync search %d, %" PRId32 " %" PRId32, src.size() - src.get_index(), src.peek(),
                 src.peek(1));
       if (src.peek_mark(2 * BIT_TIME_US) &&


### PR DESCRIPTION
# What does this implement/fix?

v2024.2.0b1 includes PR https://github.com/esphome/esphome/pull/5504 . During testing of the beta I noticed that sometimes valid RF data from a Drayton controller is not decoded and is discarded. I have found that there were a couple of minor error in PR 5504 which I didn't spot during my testing. This PR corrects those errors.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [ ] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
remote_receiver:
  pin: 
    number: GPIO37      
    inverted: false
  dump: 
    - drayton
  tolerance: 30%
  filter: 250us
  idle: 3ms
  buffer_size: 32kb     # default 10kb for esp32
  memory_blocks: 3      # default 3 for esp32
  on_drayton:
      then:
        ...
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
