### PR TITLE
WRGB Use correct multiplier

### DIFF
--- a/esphome/components/esp32_rmt_led_strip/led_strip.cpp
+++ b/esphome/components/esp32_rmt_led_strip/led_strip.cpp
@@ -160,7 +160,7 @@ light::ESPColorView ESP32RMTLEDStripLightOutput::get_view_internal(int32_t index
       b = 0;
       break;
   }
-  uint8_t multiplier = this->is_rgbw_ ? 4 : 3;
+  uint8_t multiplier = this->is_rgbw_ || this->is_wrgb_ ? 4 : 3;
   uint8_t white = this->is_wrgb_ ? 0 : 3;
 
   return {this->buf_ + (index * multiplier) + r + this->is_wrgb_,


### PR DESCRIPTION
# What does this implement/fix?

Hi,
Retried my wrgb string with a dev docker image and saw that i forgot to commit my latest change in the last pull-request.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
light:
  - platform: esp32_rmt_led_strip
    rgb_order: GRB
    pin: GPIO26
    num_leds: 30
    rmt_channel: 0
    chipset: SK6812
    name: "Neon Strip"
```

## Checklist:
  - [ X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
