### PR TITLE
Add more debugging logs to microWakeWord

### DIFF
--- a/esphome/components/micro_wake_word/__init__.py
+++ b/esphome/components/micro_wake_word/__init__.py
@@ -261,7 +261,7 @@ CONFIG_SCHEMA = cv.All(
         {
             cv.GenerateID(): cv.declare_id(MicroWakeWord),
             cv.GenerateID(CONF_MICROPHONE): cv.use_id(microphone.Microphone),
-            cv.Optional(CONF_PROBABILITY_CUTOFF): cv.float_,
+            cv.Optional(CONF_PROBABILITY_CUTOFF): cv.percentage,
             cv.Optional(CONF_SLIDING_WINDOW_AVERAGE_SIZE): cv.positive_int,
             cv.Optional(CONF_ON_WAKE_WORD_DETECTED): automation.validate_automation(
                 single=True

--- a/esphome/components/micro_wake_word/micro_wake_word.cpp
+++ b/esphome/components/micro_wake_word/micro_wake_word.cpp
@@ -382,7 +382,10 @@ bool MicroWakeWord::slice_available_() {
     //  4) the model uses operations that are not optimized
     ESP_LOGW(TAG,
              "Audio buffer is nearly full. Wake word detection may be less accurate and have slower reponse times. "
-             "Verify you are using an ESP32-S3 and that you do not have other resource intensive components enabled.");
+#if !defined(USE_ESP32_VARIANT_ESP32S3)
+             "microWakeWord is designed for the ESP32-S3. The current platform is too slow for this model."
+#endif
+    );
   }
 
   return available > (NEW_SAMPLES_TO_GET * sizeof(int16_t));

--- a/esphome/components/micro_wake_word/micro_wake_word.cpp
+++ b/esphome/components/micro_wake_word/micro_wake_word.cpp
@@ -53,8 +53,15 @@ static const LogString *micro_wake_word_state_to_string(State state) {
   }
 }
 
+void MicroWakeWord::dump_config() {
+  ESP_LOGCONFIG(TAG, "microWakeWord:");
+  ESP_LOGCONFIG(TAG, "  Wake Word: %s", this->get_wake_word().c_str());
+  ESP_LOGCONFIG(TAG, "  Probability cutoff: %.3f", this->probability_cutoff_);
+  ESP_LOGCONFIG(TAG, "  Sliding window size: %d", this->sliding_window_average_size_);
+}
+
 void MicroWakeWord::setup() {
-  ESP_LOGCONFIG(TAG, "Setting up Micro Wake Word...");
+  ESP_LOGCONFIG(TAG, "Setting up microWakeWord...");
 
   if (!this->initialize_models()) {
     ESP_LOGE(TAG, "Failed to initialize models");

--- a/esphome/components/micro_wake_word/micro_wake_word.h
+++ b/esphome/components/micro_wake_word/micro_wake_word.h
@@ -74,6 +74,8 @@ class MicroWakeWord : public Component {
 
   bool initialize_models();
 
+  std::string get_wake_word() { return this->wake_word_; }
+
   // Increasing either of these will reduce the rate of false acceptances while increasing the false rejection rate
   void set_probability_cutoff(float probability_cutoff) { this->probability_cutoff_ = probability_cutoff; }
   void set_sliding_window_average_size(size_t size);

--- a/esphome/components/micro_wake_word/micro_wake_word.h
+++ b/esphome/components/micro_wake_word/micro_wake_word.h
@@ -66,6 +66,7 @@ class MicroWakeWord : public Component {
   void setup() override;
   void loop() override;
   float get_setup_priority() const override;
+  void dump_config() override;
 
   void start();
   void stop();


### PR DESCRIPTION
# What does this implement/fix?

- Will fill the audio buffer and warn if it is too full; e.g., people run it on an ESP32 or have too many other slow components
- Add a basic ``dump_config`` output that logs the wake word, probability cutoff, and sliding window size
- Validate the probability_cutoff parameter as a percentage rather than a generic float (fixes an issue where people could define a cutoff not between 0%=0.0 and 100%=1.0
- Add a getter function for the wake word string. May be useful in lambdas to display the wake word.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** not applicable

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**  esphome/esphome-docs#3609

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

micro_wake_word:
  on_wake_word_detected:
    - voice_assistant.start:
  model: okay_nabu
  probability_cutoff: 50%

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
