### PR TITLE
Add optional minimum esphome version to microWakeWord manifest

### DIFF
--- a/esphome/components/micro_wake_word/__init__.py
+++ b/esphome/components/micro_wake_word/__init__.py
@@ -103,6 +103,7 @@ KEY_AUTHOR = "author"
 KEY_WEBSITE = "website"
 KEY_VERSION = "version"
 KEY_MICRO = "micro"
+KEY_MINIMUM_ESPHOME_VERSION = "minimum_esphome_version"
 
 MANIFEST_SCHEMA_V1 = cv.Schema(
     {
@@ -117,6 +118,9 @@ MANIFEST_SCHEMA_V1 = cv.Schema(
                 cv.Required(CONF_PROBABILITY_CUTOFF): cv.float_,
                 cv.Required(CONF_SLIDING_WINDOW_AVERAGE_SIZE): cv.positive_int,
             }
+        ),
+        cv.Optional(KEY_MINIMUM_ESPHOME_VERSION): cv.All(
+            cv.version_number, cv.validate_esphome_version
         ),
     }
 )

--- a/esphome/components/micro_wake_word/__init__.py
+++ b/esphome/components/micro_wake_word/__init__.py
@@ -117,10 +117,10 @@ MANIFEST_SCHEMA_V1 = cv.Schema(
             {
                 cv.Required(CONF_PROBABILITY_CUTOFF): cv.float_,
                 cv.Required(CONF_SLIDING_WINDOW_AVERAGE_SIZE): cv.positive_int,
+                cv.Optional(KEY_MINIMUM_ESPHOME_VERSION): cv.All(
+                    cv.version_number, cv.validate_esphome_version
+                ),
             }
-        ),
-        cv.Optional(KEY_MINIMUM_ESPHOME_VERSION): cv.All(
-            cv.version_number, cv.validate_esphome_version
         ),
     }
 )

--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -57,6 +57,7 @@ from esphome.const import (
     TYPE_GIT,
     TYPE_LOCAL,
     VALID_SUBSTITUTIONS_CHARACTERS,
+    __version__ as ESPHOME_VERSION,
 )
 from esphome.core import (
     CORE,
@@ -1893,6 +1894,16 @@ def version_number(value):
         return str(Version.parse(value))
     except ValueError as e:
         raise Invalid("Not a valid version number") from e
+
+
+def validate_esphome_version(value: str):
+    min_version = Version.parse(value)
+    current_version = Version.parse(ESPHOME_VERSION)
+    if current_version < min_version:
+        raise Invalid(
+            f"Your ESPHome version is too old. Please update to at least {min_version}"
+        )
+    return value
 
 
 def platformio_version_constraint(value):

--- a/esphome/core/config.py
+++ b/esphome/core/config.py
@@ -102,16 +102,6 @@ def valid_project_name(value: str):
     return value
 
 
-def validate_version(value: str):
-    min_version = cv.Version.parse(value)
-    current_version = cv.Version.parse(ESPHOME_VERSION)
-    if current_version < min_version:
-        raise cv.Invalid(
-            f"Your ESPHome version is too old. Please update to at least {min_version}"
-        )
-    return value
-
-
 if "ESPHOME_DEFAULT_COMPILE_PROCESS_LIMIT" in os.environ:
     _compile_process_limit_default = min(
         int(os.environ["ESPHOME_DEFAULT_COMPILE_PROCESS_LIMIT"]),
@@ -164,7 +154,7 @@ CONFIG_SCHEMA = cv.All(
                 }
             ),
             cv.Optional(CONF_MIN_VERSION, default=ESPHOME_VERSION): cv.All(
-                cv.version_number, validate_version
+                cv.version_number, cv.validate_esphome_version
             ),
             cv.Optional(
                 CONF_COMPILE_PROCESS_LIMIT, default=_compile_process_limit_default


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

In case there are features added to a model that require changes in the ESPHome component, we can require a minimum version of ESPHome with this change.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#3612

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
