### PR TITLE
Fix xl9535 pin reads

### DIFF
--- a/esphome/components/xl9535/xl9535.cpp
+++ b/esphome/components/xl9535/xl9535.cpp
@@ -36,14 +36,14 @@ bool XL9535Component::digital_read(uint8_t pin) {
       return state;
     }
 
-    state = (port & (pin - 10)) != 0;
+    state = (port & (1 << (pin - 10))) != 0;
   } else {
     if (this->read_register(XL9535_INPUT_PORT_0_REGISTER, &port, 1) != i2c::ERROR_OK) {
       this->status_set_warning();
       return state;
     }
 
-    state = (port & pin) != 0;
+    state = (port & (1 << pin)) != 0;
   }
 
   this->status_clear_warning();


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Digital reads were incorrect because it was not checking per bit, but just against the pin number itself

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
