### PR TITLE
Fix tm1651 enum

### DIFF
--- a/esphome/components/tm1651/__init__.py
+++ b/esphome/components/tm1651/__init__.py
@@ -13,6 +13,7 @@ from esphome.const import (
 CODEOWNERS = ["@freekode"]
 
 tm1651_ns = cg.esphome_ns.namespace("tm1651")
+TM1651Brightness = tm1651_ns.enum("TM1651Brightness")
 TM1651Display = tm1651_ns.class_("TM1651Display", cg.Component)
 
 SetLevelPercentAction = tm1651_ns.class_("SetLevelPercentAction", automation.Action)
@@ -24,9 +25,9 @@ TurnOffAction = tm1651_ns.class_("SetLevelPercentAction", automation.Action)
 CONF_LEVEL_PERCENT = "level_percent"
 
 TM1651_BRIGHTNESS_OPTIONS = {
-    1: TM1651Display.TM1651_BRIGHTNESS_LOW,
-    2: TM1651Display.TM1651_BRIGHTNESS_MEDIUM,
-    3: TM1651Display.TM1651_BRIGHTNESS_HIGH,
+    1: TM1651Brightness.TM1651_BRIGHTNESS_LOW,
+    2: TM1651Brightness.TM1651_BRIGHTNESS_MEDIUM,
+    3: TM1651Brightness.TM1651_BRIGHTNESS_HIGH,
 }
 
 CONFIG_SCHEMA = cv.All(

--- a/esphome/components/tm1651/tm1651.cpp
+++ b/esphome/components/tm1651/tm1651.cpp
@@ -12,9 +12,9 @@ static const char *const TAG = "tm1651.display";
 static const uint8_t MAX_INPUT_LEVEL_PERCENT = 100;
 static const uint8_t TM1651_MAX_LEVEL = 7;
 
-static const uint8_t TM1651_BRIGHTNESS_LOW = 0;
-static const uint8_t TM1651_BRIGHTNESS_MEDIUM = 2;
-static const uint8_t TM1651_BRIGHTNESS_HIGH = 7;
+static const uint8_t TM1651_BRIGHTNESS_LOW_HW = 0;
+static const uint8_t TM1651_BRIGHTNESS_MEDIUM_HW = 2;
+static const uint8_t TM1651_BRIGHTNESS_HIGH_HW = 7;
 
 void TM1651Display::setup() {
   ESP_LOGCONFIG(TAG, "Setting up TM1651...");
@@ -78,14 +78,14 @@ uint8_t TM1651Display::calculate_level_(uint8_t new_level) {
 
 uint8_t TM1651Display::calculate_brightness_(uint8_t new_brightness) {
   if (new_brightness <= 1) {
-    return TM1651_BRIGHTNESS_LOW;
+    return TM1651_BRIGHTNESS_LOW_HW;
   } else if (new_brightness == 2) {
-    return TM1651_BRIGHTNESS_MEDIUM;
+    return TM1651_BRIGHTNESS_MEDIUM_HW;
   } else if (new_brightness >= 3) {
-    return TM1651_BRIGHTNESS_HIGH;
+    return TM1651_BRIGHTNESS_HIGH_HW;
   }
 
-  return TM1651_BRIGHTNESS_LOW;
+  return TM1651_BRIGHTNESS_LOW_HW;
 }
 
 }  // namespace tm1651

--- a/esphome/components/tm1651/tm1651.h
+++ b/esphome/components/tm1651/tm1651.h
@@ -13,6 +13,12 @@
 namespace esphome {
 namespace tm1651 {
 
+enum TM1651Brightness : uint8_t {
+  TM1651_BRIGHTNESS_LOW = 1,
+  TM1651_BRIGHTNESS_MEDIUM = 2,
+  TM1651_BRIGHTNESS_HIGH = 3,
+};
+
 class TM1651Display : public Component {
  public:
   void set_clk_pin(InternalGPIOPin *pin) { clk_pin_ = pin; }
@@ -24,6 +30,7 @@ class TM1651Display : public Component {
   void set_level_percent(uint8_t new_level);
   void set_level(uint8_t new_level);
   void set_brightness(uint8_t new_brightness);
+  void set_brightness(TM1651Brightness new_brightness) { this->set_brightness(static_cast<uint8_t>(new_brightness)); }
 
   void turn_on();
   void turn_off();


### PR DESCRIPTION
# What does this implement/fix?

Compilation fails if a template is not used for `set_brightness` -- this is a quick fix for the issue.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
