### PR TITLE
2024.2.0b3

### DIFF
--- a/esphome/components/dallas/dallas_component.cpp
+++ b/esphome/components/dallas/dallas_component.cpp
@@ -168,10 +168,6 @@ bool IRAM_ATTR DallasTemperatureSensor::read_scratch_pad() {
     if (!wire->reset()) {
       return false;
     }
-  }
-
-  {
-    InterruptLock lock;
 
     wire->select(this->address_);
     wire->write8(DALLAS_COMMAND_READ_SCRATCH_PAD);

--- a/esphome/components/fingerprint_grow/fingerprint_grow.cpp
+++ b/esphome/components/fingerprint_grow/fingerprint_grow.cpp
@@ -336,6 +336,8 @@ void FingerprintGrowComponent::aura_led_control(uint8_t state, uint8_t speed, ui
 }
 
 uint8_t FingerprintGrowComponent::send_command_() {
+  while (this->available())
+    this->read();
   this->write((uint8_t) (START_CODE >> 8));
   this->write((uint8_t) (START_CODE & 0xFF));
   this->write(this->address_[0]);

--- a/esphome/components/tm1651/__init__.py
+++ b/esphome/components/tm1651/__init__.py
@@ -13,6 +13,7 @@ from esphome.const import (
 CODEOWNERS = ["@freekode"]
 
 tm1651_ns = cg.esphome_ns.namespace("tm1651")
+TM1651Brightness = tm1651_ns.enum("TM1651Brightness")
 TM1651Display = tm1651_ns.class_("TM1651Display", cg.Component)
 
 SetLevelPercentAction = tm1651_ns.class_("SetLevelPercentAction", automation.Action)
@@ -24,9 +25,9 @@ TurnOffAction = tm1651_ns.class_("SetLevelPercentAction", automation.Action)
 CONF_LEVEL_PERCENT = "level_percent"
 
 TM1651_BRIGHTNESS_OPTIONS = {
-    1: TM1651Display.TM1651_BRIGHTNESS_LOW,
-    2: TM1651Display.TM1651_BRIGHTNESS_MEDIUM,
-    3: TM1651Display.TM1651_BRIGHTNESS_HIGH,
+    1: TM1651Brightness.TM1651_BRIGHTNESS_LOW,
+    2: TM1651Brightness.TM1651_BRIGHTNESS_MEDIUM,
+    3: TM1651Brightness.TM1651_BRIGHTNESS_HIGH,
 }
 
 CONFIG_SCHEMA = cv.All(

--- a/esphome/components/tm1651/tm1651.cpp
+++ b/esphome/components/tm1651/tm1651.cpp
@@ -12,9 +12,9 @@ static const char *const TAG = "tm1651.display";
 static const uint8_t MAX_INPUT_LEVEL_PERCENT = 100;
 static const uint8_t TM1651_MAX_LEVEL = 7;
 
-static const uint8_t TM1651_BRIGHTNESS_LOW = 0;
-static const uint8_t TM1651_BRIGHTNESS_MEDIUM = 2;
-static const uint8_t TM1651_BRIGHTNESS_HIGH = 7;
+static const uint8_t TM1651_BRIGHTNESS_LOW_HW = 0;
+static const uint8_t TM1651_BRIGHTNESS_MEDIUM_HW = 2;
+static const uint8_t TM1651_BRIGHTNESS_HIGH_HW = 7;
 
 void TM1651Display::setup() {
   ESP_LOGCONFIG(TAG, "Setting up TM1651...");
@@ -78,14 +78,14 @@ uint8_t TM1651Display::calculate_level_(uint8_t new_level) {
 
 uint8_t TM1651Display::calculate_brightness_(uint8_t new_brightness) {
   if (new_brightness <= 1) {
-    return TM1651_BRIGHTNESS_LOW;
+    return TM1651_BRIGHTNESS_LOW_HW;
   } else if (new_brightness == 2) {
-    return TM1651_BRIGHTNESS_MEDIUM;
+    return TM1651_BRIGHTNESS_MEDIUM_HW;
   } else if (new_brightness >= 3) {
-    return TM1651_BRIGHTNESS_HIGH;
+    return TM1651_BRIGHTNESS_HIGH_HW;
   }
 
-  return TM1651_BRIGHTNESS_LOW;
+  return TM1651_BRIGHTNESS_LOW_HW;
 }
 
 }  // namespace tm1651

--- a/esphome/components/tm1651/tm1651.h
+++ b/esphome/components/tm1651/tm1651.h
@@ -13,6 +13,12 @@
 namespace esphome {
 namespace tm1651 {
 
+enum TM1651Brightness : uint8_t {
+  TM1651_BRIGHTNESS_LOW = 1,
+  TM1651_BRIGHTNESS_MEDIUM = 2,
+  TM1651_BRIGHTNESS_HIGH = 3,
+};
+
 class TM1651Display : public Component {
  public:
   void set_clk_pin(InternalGPIOPin *pin) { clk_pin_ = pin; }
@@ -24,6 +30,7 @@ class TM1651Display : public Component {
   void set_level_percent(uint8_t new_level);
   void set_level(uint8_t new_level);
   void set_brightness(uint8_t new_brightness);
+  void set_brightness(TM1651Brightness new_brightness) { this->set_brightness(static_cast<uint8_t>(new_brightness)); }
 
   void turn_on();
   void turn_off();

--- a/esphome/components/tuya/fan/tuya_fan.h
+++ b/esphome/components/tuya/fan/tuya_fan.h
@@ -29,6 +29,7 @@ class TuyaFan : public Component, public fan::Fan {
   optional<uint8_t> direction_id_{};
   int speed_count_{};
   TuyaDatapointType speed_type_{};
+  TuyaDatapointType oscillation_type_{};
 };
 
 }  // namespace tuya

--- a/esphome/components/voice_assistant/__init__.py
+++ b/esphome/components/voice_assistant/__init__.py
@@ -32,6 +32,7 @@ CONF_ON_TTS_START = "on_tts_start"
 CONF_ON_TTS_STREAM_START = "on_tts_stream_start"
 CONF_ON_TTS_STREAM_END = "on_tts_stream_end"
 CONF_ON_WAKE_WORD_DETECTED = "on_wake_word_detected"
+CONF_ON_IDLE = "on_idle"
 
 CONF_SILENCE_DETECTION = "silence_detection"
 CONF_USE_WAKE_WORD = "use_wake_word"
@@ -127,6 +128,7 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_ON_TTS_STREAM_END): automation.validate_automation(
                 single=True
             ),
+            cv.Optional(CONF_ON_IDLE): automation.validate_automation(single=True),
         }
     ).extend(cv.COMPONENT_SCHEMA),
     tts_stream_validate,
@@ -257,6 +259,13 @@ async def to_code(config):
             var.get_tts_stream_end_trigger(),
             [],
             config[CONF_ON_TTS_STREAM_END],
+        )
+
+    if CONF_ON_IDLE in config:
+        await automation.build_automation(
+            var.get_idle_trigger(),
+            [],
+            config[CONF_ON_IDLE],
         )
 
     cg.add_define("USE_VOICE_ASSISTANT")

--- a/esphome/components/voice_assistant/voice_assistant.cpp
+++ b/esphome/components/voice_assistant/voice_assistant.cpp
@@ -135,6 +135,8 @@ void VoiceAssistant::loop() {
   switch (this->state_) {
     case State::IDLE: {
       if (this->continuous_ && this->desired_state_ == State::IDLE) {
+        this->idle_trigger_->trigger();
+
         this->ring_buffer_->reset();
 #ifdef USE_ESP_ADF
         if (this->use_wake_word_) {
@@ -618,6 +620,9 @@ void VoiceAssistant::on_event(const api::VoiceAssistantEventResponse &msg) {
         {
           this->set_state_(State::IDLE, State::IDLE);
         }
+      } else if (this->state_ == State::AWAITING_RESPONSE) {
+        // No TTS start event ("nevermind")
+        this->set_state_(State::IDLE, State::IDLE);
       }
       this->defer([this]() { this->end_trigger_->trigger(); });
       break;

--- a/esphome/components/voice_assistant/voice_assistant.h
+++ b/esphome/components/voice_assistant/voice_assistant.h
@@ -116,6 +116,7 @@ class VoiceAssistant : public Component {
   Trigger<std::string> *get_tts_end_trigger() const { return this->tts_end_trigger_; }
   Trigger<std::string> *get_tts_start_trigger() const { return this->tts_start_trigger_; }
   Trigger<std::string, std::string> *get_error_trigger() const { return this->error_trigger_; }
+  Trigger<> *get_idle_trigger() const { return this->idle_trigger_; }
 
   Trigger<> *get_client_connected_trigger() const { return this->client_connected_trigger_; }
   Trigger<> *get_client_disconnected_trigger() const { return this->client_disconnected_trigger_; }
@@ -148,6 +149,7 @@ class VoiceAssistant : public Component {
   Trigger<std::string> *tts_end_trigger_ = new Trigger<std::string>();
   Trigger<std::string> *tts_start_trigger_ = new Trigger<std::string>();
   Trigger<std::string, std::string> *error_trigger_ = new Trigger<std::string, std::string>();
+  Trigger<> *idle_trigger_ = new Trigger<>();
 
   Trigger<> *client_connected_trigger_ = new Trigger<>();
   Trigger<> *client_disconnected_trigger_ = new Trigger<>();

--- a/esphome/const.py
+++ b/esphome/const.py
@@ -1,6 +1,6 @@
 """Constants used by esphome."""
 
-__version__ = "2024.2.0b2"
+__version__ = "2024.2.0b3"
 
 ALLOWED_NAME_CHARS = "abcdefghijklmnopqrstuvwxyz0123456789-_"
 VALID_SUBSTITUTIONS_CHARACTERS = (


### PR DESCRIPTION
**Do not merge, release script will automatically merge**
- hold interrupt disable for dallas one-wire [esphome#6244](https://github.com/esphome/esphome/pull/6244)
- Fix tm1651 enum [esphome#6248](https://github.com/esphome/esphome/pull/6248)
- Clear UART read buffer before sending next command [esphome#6200](https://github.com/esphome/esphome/pull/6200)
- Voice Assistant: add on_idle trigger and fix nevermind [esphome#6141](https://github.com/esphome/esphome/pull/6141)
- Tuya Fan component fix to handle enum datapoint type [esphome#6135](https://github.com/esphome/esphome/pull/6135)
