### PR TITLE
Integration sensor reset to specific value initial test

### DIFF
--- a/esphome/components/integration/integration_sensor.h
+++ b/esphome/components/integration/integration_sensor.h
@@ -33,6 +33,7 @@ class IntegrationSensor : public sensor::Sensor, public Component {
   void set_method(IntegrationMethod method) { method_ = method; }
   void set_restore(bool restore) { restore_ = restore; }
   void reset() { this->publish_and_save_(0.0f); }
+  void reset_to_value(float value) { this->publish_and_save_(value); }
 
  protected:
   void process_sensor_value_(float value);


### PR DESCRIPTION
# What does this implement/fix?

Integration sensor reset to a specific value over lambda.
Currently, there was only possiblity to 

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other - extending functionality of existing Integration sensor.



**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:


```yaml
# Example config.yaml
  - platform: template
    name: "Test integrator reset"
    id: "test_integrator_switch"
    turn_on_action:
        - lambda: |-
            id(MyIntegrationSensor).reset_to_value(1234);
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
