### PR TITLE
Improve the error message on OTA version mismatch

### DIFF
--- a/esphome/espota2.py
+++ b/esphome/espota2.py
@@ -206,8 +206,11 @@ def perform_ota(
 
     _, version = receive_exactly(sock, 2, "version", RESPONSE_OK)
     _LOGGER.debug("Device support OTA version: %s", version)
-    if version not in (OTA_VERSION_1_0, OTA_VERSION_2_0):
-        raise OTAError(f"Unsupported OTA version {version}")
+    supported_versions = (OTA_VERSION_1_0, OTA_VERSION_2_0)
+    if version not in supported_versions:
+        raise OTAError(
+            f"Device uses unsupported OTA version {version}, this ESPHome supports {supported_versions}"
+        )
 
     # Features
     send_check(sock, FEATURE_SUPPORTS_COMPRESSION, "features")


### PR DESCRIPTION
This PR improves the error message that's shown when the device uses an unuspported OTA version. In the example below I'm using a fictional version 3, just to show what it would look like with the current ESPHome software on a fictional device from the future.

Instead of the old error:

> Unsupported OTA version 3

the message is now:

> Device uses unsupported OTA version 3, this ESPHome supports (1, 2).

The old error message had some issues:

- Unclear what is producing the error message (the device rejecting `esphome` using version 3, or `esphome` not understanding version 3 from the device).
- Unclear whether the version is too old or too new.

This is resolved by making the message a little more informative.

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
