### PR TITLE
Always publish energy to address esphome/issues#5501

### DIFF
--- a/esphome/components/cse7766/cse7766.cpp
+++ b/esphome/components/cse7766/cse7766.cpp
@@ -161,11 +161,9 @@ void CSE7766Component::parse_data_() {
 
     energy = cf_diff * float(power_coeff) / 1000000.0f / 3600.0f;
     this->energy_total_ += energy;
-    if (this->energy_sensor_ != nullptr)
-      this->energy_sensor_->publish_state(this->energy_total_);
-  } else if ((this->energy_sensor_ != nullptr) && !this->energy_sensor_->has_state()) {
-    this->energy_sensor_->publish_state(0);
   }
+  if (this->energy_sensor_ != nullptr)
+    this->energy_sensor_->publish_state(this->energy_total_);
 
   float current = 0.0f;
   float calculated_current = 0.0f;


### PR DESCRIPTION
# What does this implement/fix?

Energy would not be published after startup/reboot. All other sensors of the CSE7766 publish at \~10 Hz, so publish energy at the same time and let the user handle it the same way. It would publish at \~10 Hz when power is being consumed anyway, so they needed a filter regardless.

**HOWEVER** I believe reverting the original breaking change change (esphome/esphome#6095) is the correct solution here, not this band-aid: #6265 

The way the component works, the individual outputs drift out of sync with each other, which makes calculating things like power factor or apparent power impossible, since they have to be measured over the same time period.

The original implementation intentionally averaged everything together over a _single_ time period, which enabled calculating downstream values (power factor, apparent power) that had meaning. Notice how after only 2 hours of uptime, the sensors are now reporting over a 15-second window, instead of simultaneously as they should:

```
[12:05:09][D][sensor:093]: 'Uptime': Sending state 10122.79492 s with 0 decimals of accuracy
[12:05:22][D][sensor:093]: 'Energy': Sending state 0.53937 Wh with 0 decimals of accuracy
[12:05:25][D][sensor:093]: 'Voltage': Sending state 120.19772 V with 1 decimals of accuracy
[12:05:32][D][sensor:093]: 'Current': Sending state 0.20806 A with 2 decimals of accuracy
[12:05:37][D][sensor:093]: 'Power': Sending state 23.99924 W with 1 decimals of accuracy
```

I don't know how to solve this with filters, and think the original solution of building the averaging into the component itself was the right answer.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes esphome/issues#5501

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#3620

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [X] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
external_components:
  - source: github://pr#6261
    components: [ cse7766 ]

sensor:
  - platform: cse7766
    current:
      name: Current
      id: current
      filters:
        - throttle_average: 60s
    voltage:
      name: Voltage
      id: voltage
      filters:
        - throttle_average: 60s
    power:
      name: Power
      id: power
      filters:
        - throttle_average: 60s
    energy:
      name: Energy
      filters:
        - throttle: 60s
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
