### PR TITLE
Revert #6095 but retain improvements from #6180

### DIFF
--- a/esphome/components/cse7766/cse7766.h
+++ b/esphome/components/cse7766/cse7766.h
@@ -7,7 +7,7 @@
 namespace esphome {
 namespace cse7766 {
 
-class CSE7766Component : public Component, public uart::UARTDevice {
+class CSE7766Component : public PollingComponent, public uart::UARTDevice {
  public:
   void set_voltage_sensor(sensor::Sensor *voltage_sensor) { voltage_sensor_ = voltage_sensor; }
   void set_current_sensor(sensor::Sensor *current_sensor) { current_sensor_ = current_sensor; }
@@ -16,6 +16,7 @@ class CSE7766Component : public Component, public uart::UARTDevice {
 
   void loop() override;
   float get_setup_priority() const override;
+  void update() override;
   void dump_config() override;
 
  protected:
@@ -30,8 +31,16 @@ class CSE7766Component : public Component, public uart::UARTDevice {
   sensor::Sensor *current_sensor_{nullptr};
   sensor::Sensor *power_sensor_{nullptr};
   sensor::Sensor *energy_sensor_{nullptr};
+  float voltage_acc_{0.0f};
+  float current_acc_{0.0f};
+  float power_acc_{0.0f};
   float energy_total_{0.0f};
   uint32_t cf_pulses_last_{0};
+  uint32_t voltage_counts_{0};
+  uint32_t current_counts_{0};
+  uint32_t power_counts_{0};
+  // Setting this to 1 means it will always publish 0 once at startup
+  uint32_t energy_total_counts_{1};
 };
 
 }  // namespace cse7766

--- a/esphome/components/cse7766/sensor.py
+++ b/esphome/components/cse7766/sensor.py
@@ -22,37 +22,43 @@ from esphome.const import (
 DEPENDENCIES = ["uart"]
 
 cse7766_ns = cg.esphome_ns.namespace("cse7766")
-CSE7766Component = cse7766_ns.class_("CSE7766Component", cg.Component, uart.UARTDevice)
+CSE7766Component = cse7766_ns.class_(
+    "CSE7766Component", cg.PollingComponent, uart.UARTDevice
+)
 
-CONFIG_SCHEMA = cv.Schema(
-    {
-        cv.GenerateID(): cv.declare_id(CSE7766Component),
-        cv.Optional(CONF_VOLTAGE): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            accuracy_decimals=1,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CURRENT): sensor.sensor_schema(
-            unit_of_measurement=UNIT_AMPERE,
-            accuracy_decimals=2,
-            device_class=DEVICE_CLASS_CURRENT,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_POWER): sensor.sensor_schema(
-            unit_of_measurement=UNIT_WATT,
-            accuracy_decimals=1,
-            device_class=DEVICE_CLASS_POWER,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_ENERGY): sensor.sensor_schema(
-            unit_of_measurement=UNIT_WATT_HOURS,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_ENERGY,
-            state_class=STATE_CLASS_TOTAL_INCREASING,
-        ),
-    }
-).extend(uart.UART_DEVICE_SCHEMA)
+CONFIG_SCHEMA = (
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.declare_id(CSE7766Component),
+            cv.Optional(CONF_VOLTAGE): sensor.sensor_schema(
+                unit_of_measurement=UNIT_VOLT,
+                accuracy_decimals=1,
+                device_class=DEVICE_CLASS_VOLTAGE,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ),
+            cv.Optional(CONF_CURRENT): sensor.sensor_schema(
+                unit_of_measurement=UNIT_AMPERE,
+                accuracy_decimals=2,
+                device_class=DEVICE_CLASS_CURRENT,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ),
+            cv.Optional(CONF_POWER): sensor.sensor_schema(
+                unit_of_measurement=UNIT_WATT,
+                accuracy_decimals=1,
+                device_class=DEVICE_CLASS_POWER,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ),
+            cv.Optional(CONF_ENERGY): sensor.sensor_schema(
+                unit_of_measurement=UNIT_WATT_HOURS,
+                accuracy_decimals=3,
+                device_class=DEVICE_CLASS_ENERGY,
+                state_class=STATE_CLASS_TOTAL_INCREASING,
+            ),
+        }
+    )
+    .extend(cv.polling_component_schema("60s"))
+    .extend(uart.UART_DEVICE_SCHEMA)
+)
 FINAL_VALIDATE_SCHEMA = uart.final_validate_device_schema(
     "cse7766", baud_rate=4800, require_rx=True
 )


### PR DESCRIPTION
# What does this implement/fix?

#6095 was a breaking change that converted CSE7766 to non-polling, but in the process introduced bugs around how energy was handled, and more subtle bugs around the time period that measurements were taken over.

The subtle change in the timing of measurements made certain downstream calculations (specifically power factor and apparent power) impossible to do accurately.

And since the CSE7766 updates at almost 10 Hz, any sane use of it will require a filter to throttle that down to something Home Assistant won't be unhappy about, which means the benefits of moving away from averaging over an arbitrary period were entirely theoretical.

As such, this reverts #6095 to restore the old behavior that could be used for downstream calculations.
I retained the improvements made in #6180 though, so it is not merely rolling the code back to how it was.

I am marking this as a breaking change because #6095 was a breaking change and undoing that is also a breaking change, but for people coming from ESPHome prior to 2024.2.0 this is not actually a breaking change.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):**
- fixes esphome/issues#5501
- fixes esphome/issues#5504

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#3622

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [X] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
external_components:
  - source: github://pr#6265
    components: [ cse7766 ]

sensor:
  - platform: cse7766
    update_interval: 30s
    current:
      name: Current
      id: current
    voltage:
      name: Voltage
      id: voltage
    power:
      name: Power
      id: power
      on_value:
        then:
          - component.update: apparent_power
          - component.update: pf
    energy:
      name: Energy
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
