### PR TITLE
web_server: Add a position property for cover entities that have the supports position trait

### DIFF
--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -785,6 +785,8 @@ std::string WebServer::cover_json(cover::Cover *obj, JsonDetail start_config) {
                               obj->position, start_config);
     root["current_operation"] = cover::cover_operation_to_str(obj->current_operation);
 
+    if (obj->get_traits().get_supports_position())
+      root["position"] = obj->position;
     if (obj->get_traits().get_supports_tilt())
       root["tilt"] = obj->tilt;
   });


### PR DESCRIPTION
This PR fixes https://github.com/esphome/issues/issues/5472

# What does this implement/fix?

Adds a position trait for cover entities that have supports position trait.
Before it wasn't possible to distinguish cover entities that do support the position trait from entities that do not, making it impossible for applications utilizing the web_server API to be able to tell if a given cover entity can have the cover position arbitrarily set or not.

With this change, covers that support the position trait will report the position value as a separate field. This does duplicate the value of the position of those entities in the payload. Alternatively a property, e.g. "supports_position: false" could be added. That way there's no duplication of data and older versions that do not have this change can be distinguished from cover entities that do have this change, but simply do not support position i.e. for older entities applications could make the choice to assume that a cover entity supports the position trait

Thoughts?

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes [<link to issue>](https://github.com/esphome/issues/issues/5472)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** Will provide.

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
cover:
  - platform: template
    name: 'cover_name'
    optimistic: True
  - platform: template
    id: cover_with_tilt_and_pos
    name: 'cover_with_tilt_and_pos'
    optimistic: True
    has_position: True
    tilt_action:
      - lambda: |-
          id(cover_with_tilt_and_pos).tilt = tilt;
          id(cover_with_tilt_and_pos).publish_state();
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  N/A

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
  Will do.
