### PR TITLE
allow multiple emc2101

### DIFF
--- a/esphome/components/emc2101/__init__.py
+++ b/esphome/components/emc2101/__init__.py
@@ -7,6 +7,8 @@ CODEOWNERS = ["@ellull"]
 
 DEPENDENCIES = ["i2c"]
 
+MULTI_CONF = True
+
 CONF_PWM = "pwm"
 CONF_DIVIDER = "divider"
 CONF_DAC = "dac"


### PR DESCRIPTION
# What does this implement/fix?

Allow multiple instances of the emc2101 component.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/5512

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
