### PR TITLE
make output optional for speed fan

### DIFF
--- a/esphome/components/speed/fan/__init__.py
+++ b/esphome/components/speed/fan/__init__.py
@@ -19,7 +19,7 @@ SpeedFan = speed_ns.class_("SpeedFan", cg.Component, fan.Fan)
 CONFIG_SCHEMA = fan.FAN_SCHEMA.extend(
     {
         cv.GenerateID(CONF_OUTPUT_ID): cv.declare_id(SpeedFan),
-        cv.Required(CONF_OUTPUT): cv.use_id(output.FloatOutput),
+        cv.Optional(CONF_OUTPUT): cv.use_id(output.FloatOutput),
         cv.Optional(CONF_OSCILLATION_OUTPUT): cv.use_id(output.BinaryOutput),
         cv.Optional(CONF_DIRECTION_OUTPUT): cv.use_id(output.BinaryOutput),
         cv.Optional(CONF_SPEED): cv.invalid(
@@ -32,10 +32,13 @@ CONFIG_SCHEMA = fan.FAN_SCHEMA.extend(
 
 
 async def to_code(config):
-    output_ = await cg.get_variable(config[CONF_OUTPUT])
-    var = cg.new_Pvariable(config[CONF_OUTPUT_ID], output_, config[CONF_SPEED_COUNT])
+    var = cg.new_Pvariable(config[CONF_OUTPUT_ID], config[CONF_SPEED_COUNT])
     await cg.register_component(var, config)
     await fan.register_fan(var, config)
+
+    if CONF_OUTPUT in config:
+        output_ = await cg.get_variable(config[CONF_OUTPUT])
+        cg.add(var.set_output(output_))
 
     if CONF_OSCILLATION_OUTPUT in config:
         oscillation_output = await cg.get_variable(config[CONF_OSCILLATION_OUTPUT])

--- a/esphome/components/speed/fan/speed_fan.cpp
+++ b/esphome/components/speed/fan/speed_fan.cpp
@@ -36,9 +36,10 @@ void SpeedFan::control(const fan::FanCall &call) {
 }
 
 void SpeedFan::write_state_() {
-  float speed = this->state ? static_cast<float>(this->speed) / static_cast<float>(this->speed_count_) : 0.0f;
-  this->output_->set_level(speed);
-
+  if (this->output_ != nullptr) {
+    float speed = this->state ? static_cast<float>(this->speed) / static_cast<float>(this->speed_count_) : 0.0f;
+    this->output_->set_level(speed);
+  }
   if (this->oscillating_ != nullptr)
     this->oscillating_->set_state(this->oscillating);
   if (this->direction_ != nullptr)

--- a/esphome/components/speed/fan/speed_fan.h
+++ b/esphome/components/speed/fan/speed_fan.h
@@ -12,9 +12,10 @@ namespace speed {
 
 class SpeedFan : public Component, public fan::Fan {
  public:
-  SpeedFan(output::FloatOutput *output, int speed_count) : output_(output), speed_count_(speed_count) {}
+  SpeedFan(int speed_count) : speed_count_(speed_count) {}
   void setup() override;
   void dump_config() override;
+  void set_output(output::FloatOutput *output) { this->output_ = output; }
   void set_oscillating(output::BinaryOutput *oscillating) { this->oscillating_ = oscillating; }
   void set_direction(output::BinaryOutput *direction) { this->direction_ = direction; }
   void set_preset_modes(const std::set<std::string> &presets) { this->preset_modes_ = presets; }
@@ -24,7 +25,7 @@ class SpeedFan : public Component, public fan::Fan {
   void control(const fan::FanCall &call) override;
   void write_state_();
 
-  output::FloatOutput *output_;
+  output::FloatOutput *output_{nullptr};
   output::BinaryOutput *oscillating_{nullptr};
   output::BinaryOutput *direction_{nullptr};
   int speed_count_{};


### PR DESCRIPTION
# What does this implement/fix?

Now that `fan` has triggers, the speed fan can be used as a "template" fan and the output is unnecessary but it still requires a dummy output to be configured.  This makes the output parameter optional.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#3633

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
