### PR TITLE
fix throttle average nan handling

### DIFF
--- a/esphome/components/sensor/filter.h
+++ b/esphome/components/sensor/filter.h
@@ -245,6 +245,7 @@ class ThrottleAverageFilter : public Filter, public Component {
   uint32_t time_period_;
   float sum_{0.0f};
   unsigned int n_{0};
+  bool have_nan_{false};
 };
 
 using lambda_filter_t = std::function<optional<float>(float)>;


### PR DESCRIPTION
# What does this implement/fix?

If the `throttle_average` filter receives no values during the interval, it publishes a NaN value.  That can break things and doesn't really make sense.  Now it won't publish a value if it didn't receive any.
I don't think this would be a breaking change, since it's very unlikely that anyone would be relying on this.
The current functionality is breaking configs.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
