### PR TITLE
Allow to specify global build directory

### DIFF
--- a/docker/docker_entrypoint.sh
+++ b/docker/docker_entrypoint.sh
@@ -21,4 +21,10 @@ export PLATFORMIO_PLATFORMS_DIR="${pio_cache_base}/platforms"
 export PLATFORMIO_PACKAGES_DIR="${pio_cache_base}/packages"
 export PLATFORMIO_CACHE_DIR="${pio_cache_base}/cache"
 
+# If /build is mounted, use that as the build path
+# otherwise use path in /config (so that builds aren't lost on container restart)
+if [[ -d /build ]]; then
+    export ESPHOME_BUILD_PATH=/build
+fi
+
 exec esphome "$@"

--- a/esphome/core/config.py
+++ b/esphome/core/config.py
@@ -190,11 +190,8 @@ def preload_core_config(config, result):
     CORE.data[KEY_CORE] = {}
 
     if CONF_BUILD_PATH not in conf:
-        if get_str_env("ESPHOME_BUILD_PATH", None) is not None:
-            conf[CONF_BUILD_PATH] = get_str_env("ESPHOME_BUILD_PATH", None)
-        # If the env var is not set, use the default
-        else:
-            conf[CONF_BUILD_PATH] = f"build/{CORE.name}"
+        build_path = get_str_env("ESPHOME_BUILD_PATH", "build")
+        conf[CONF_BUILD_PATH] = os.path.join(build_path, CORE.name)
     CORE.build_path = CORE.relative_internal_path(conf[CONF_BUILD_PATH])
 
     has_oldstyle = CONF_PLATFORM in conf

--- a/esphome/core/config.py
+++ b/esphome/core/config.py
@@ -38,7 +38,7 @@ from esphome.const import (
     __version__ as ESPHOME_VERSION,
 )
 from esphome.core import CORE, coroutine_with_priority
-from esphome.helpers import copy_file_if_changed, walk_files
+from esphome.helpers import copy_file_if_changed, get_str_env, walk_files
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -190,16 +190,12 @@ def preload_core_config(config, result):
     CORE.data[KEY_CORE] = {}
 
     if CONF_BUILD_PATH not in conf:
-        if "ESPHOME_BUILD_PATH" in os.environ:
-            build_path_env = os.environ["ESPHOME_BUILD_PATH"]
+        if get_str_env("ESPHOME_BUILD_PATH", None) is not None:
+            conf[CONF_BUILD_PATH] = get_str_env("ESPHOME_BUILD_PATH", None)
         # If the env var is not set, use the default
         else:
-            build_path_env = ".esphome/build"
-        # Always append the name to the build path, it will work for default and for env var
-        build_path_env = os.path.join(build_path_env, CORE.name)
-        build_path_env = os.path.expanduser(build_path_env)
-        conf[CONF_BUILD_PATH] = build_path_env
-    CORE.build_path = CORE.relative_config_path(conf[CONF_BUILD_PATH])
+            conf[CONF_BUILD_PATH] = f"build/{CORE.name}"
+    CORE.build_path = CORE.relative_internal_path(conf[CONF_BUILD_PATH])
 
     has_oldstyle = CONF_PLATFORM in conf
     newstyle_found = [key for key in TARGET_PLATFORMS if key in config]

--- a/esphome/core/config.py
+++ b/esphome/core/config.py
@@ -190,9 +190,10 @@ def preload_core_config(config, result):
     CORE.data[KEY_CORE] = {}
 
     if CONF_BUILD_PATH not in conf:
-        build_path_env = os.environ["ESPHOME_BUILD_PATH"]
+        if "ESPHOME_BUILD_PATH" in os.environ:
+            build_path_env = os.environ["ESPHOME_BUILD_PATH"]
         # If the env var is not set, use the default
-        if build_path_env is None or build_path_env == "":
+        else:
             build_path_env = ".esphome/build"
         # Always append the name to the build path, it will work for default and for env var
         build_path_env = os.path.join(build_path_env, CORE.name)

--- a/esphome/core/config.py
+++ b/esphome/core/config.py
@@ -190,8 +190,15 @@ def preload_core_config(config, result):
     CORE.data[KEY_CORE] = {}
 
     if CONF_BUILD_PATH not in conf:
-        conf[CONF_BUILD_PATH] = f"build/{CORE.name}"
-    CORE.build_path = CORE.relative_internal_path(conf[CONF_BUILD_PATH])
+        build_path_env = os.environ["ESPHOME_BUILD_PATH"]
+        # If the env var is not set, use the default
+        if build_path_env is None or build_path_env == "":
+            build_path_env = ".esphome/build"
+        # Always append the name to the build path, it will work for default and for env var
+        build_path_env = os.path.join(build_path_env, CORE.name)
+        build_path_env = os.path.expanduser(build_path_env)
+        conf[CONF_BUILD_PATH] = build_path_env
+    CORE.build_path = CORE.relative_config_path(conf[CONF_BUILD_PATH])
 
     has_oldstyle = CONF_PLATFORM in conf
     newstyle_found = [key for key in TARGET_PLATFORMS if key in config]


### PR DESCRIPTION
> [!NOTE]
> Reopen after rebase of #5387

# What does this implement/fix?

Default implementation use `.esphome/build` folder to store build artifacts. This folder can be relatively big. I run esphome container in kubernetes and all `/config` folder is mounted as remote storage. This is fine for small pregenerated json and `idedata`. But this is not best option for build temporary files. Instead I can use local storage for `.esphome/build` folders.

This PR allows to specify `ESPHOME_BUILD_PATH` environment variable that will be used as default build folder path. This build path still can be overridden by individual components over `build_path` option (as described in [doc](https://esphome.io/components/esphome.html)), but introduce default folder that can be specified.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other
**Related issue or feature (if applicable):**

Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable): https://github.com/esphome/esphome-docs/pull/3183

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
