### PR TITLE
Fix test_build_components for macOS sed

### DIFF
--- a/script/test_build_components
+++ b/script/test_build_components
@@ -28,7 +28,12 @@ start_esphome() {
   component_test_file="./tests/test_build_components/build/$target_component.$test_name.$target_platform.yaml"
 
   cp $target_platform_file $component_test_file
-  sed -i "s!\$component_test_file!../../.$f!g" $component_test_file
+  if [[ "$OSTYPE" == "darwin"* ]]; then
+    # macOS sed is...different
+    sed -i '' "s!\$component_test_file!../../.$f!g" $component_test_file
+  else
+    sed -i "s!\$component_test_file!../../.$f!g" $component_test_file
+  fi
 
   # Start esphome process
   echo "> [$target_component] [$test_name] [$target_platform]"


### PR DESCRIPTION
# What does this implement/fix?

macOS `sed` is...different...

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
