### PR TITLE
feat(MQTT): Add QoS option for each MQTT component

### DIFF
--- a/esphome/components/mqtt/__init__.py
+++ b/esphome/components/mqtt/__init__.py
@@ -489,6 +489,8 @@ def get_default_topic_for(data, component_type, name, suffix):
 async def register_mqtt_component(var, config):
     await cg.register_component(var, {})
 
+    if CONF_QOS in config:
+        cg.add(var.set_qos(config[CONF_QOS]))
     if CONF_RETAIN in config:
         cg.add(var.set_retain(config[CONF_RETAIN]))
     if not config.get(CONF_DISCOVERY, True):

--- a/esphome/components/mqtt/mqtt_client.cpp
+++ b/esphome/components/mqtt/mqtt_client.cpp
@@ -467,11 +467,11 @@ bool MQTTClientComponent::publish(const MQTTMessage &message) {
     ret = this->mqtt_backend_.publish(message);
     delay(0);
   }
-
+  
   if (!logging_topic) {
     if (ret) {
-      ESP_LOGV(TAG, "Publish(topic='%s' payload='%s' retain=%d)", message.topic.c_str(), message.payload.c_str(),
-               message.retain);
+      ESP_LOGV(TAG, "Publish(topic='%s' payload='%s' retain=%d qos=%d)", message.topic.c_str(), message.payload.c_str(),
+               message.retain, message.qos);
     } else {
       ESP_LOGV(TAG, "Publish failed for topic='%s' (len=%u). will retry later..", message.topic.c_str(),
                message.payload.length());

--- a/esphome/components/mqtt/mqtt_client.cpp
+++ b/esphome/components/mqtt/mqtt_client.cpp
@@ -467,7 +467,7 @@ bool MQTTClientComponent::publish(const MQTTMessage &message) {
     ret = this->mqtt_backend_.publish(message);
     delay(0);
   }
-  
+
   if (!logging_topic) {
     if (ret) {
       ESP_LOGV(TAG, "Publish(topic='%s' payload='%s' retain=%d qos=%d)", message.topic.c_str(), message.payload.c_str(),

--- a/esphome/components/mqtt/mqtt_component.cpp
+++ b/esphome/components/mqtt/mqtt_component.cpp
@@ -14,6 +14,8 @@ namespace mqtt {
 
 static const char *const TAG = "mqtt.component";
 
+void MQTTComponent::set_qos(uint8_t qos) { this->qos_ = qos; }
+
 void MQTTComponent::set_retain(bool retain) { this->retain_ = retain; }
 
 std::string MQTTComponent::get_discovery_topic_(const MQTTDiscoveryInfo &discovery_info) const {
@@ -47,13 +49,13 @@ std::string MQTTComponent::get_command_topic_() const {
 bool MQTTComponent::publish(const std::string &topic, const std::string &payload) {
   if (topic.empty())
     return false;
-  return global_mqtt_client->publish(topic, payload, 0, this->retain_);
+  return global_mqtt_client->publish(topic, payload, this->qos_, this->retain_);
 }
 
 bool MQTTComponent::publish_json(const std::string &topic, const json::json_build_t &f) {
   if (topic.empty())
     return false;
-  return global_mqtt_client->publish_json(topic, f, 0, this->retain_);
+  return global_mqtt_client->publish_json(topic, f, this->qos_, this->retain_);
 }
 
 bool MQTTComponent::send_discovery_() {
@@ -61,7 +63,7 @@ bool MQTTComponent::send_discovery_() {
 
   if (discovery_info.clean) {
     ESP_LOGV(TAG, "'%s': Cleaning discovery...", this->friendly_name().c_str());
-    return global_mqtt_client->publish(this->get_discovery_topic_(discovery_info), "", 0, 0, true);
+    return global_mqtt_client->publish(this->get_discovery_topic_(discovery_info), "", 0, this->qos_, true);
   }
 
   ESP_LOGV(TAG, "'%s': Sending discovery...", this->friendly_name().c_str());
@@ -155,8 +157,10 @@ bool MQTTComponent::send_discovery_() {
         device_info[MQTT_DEVICE_MANUFACTURER] = "espressif";
         device_info[MQTT_DEVICE_SUGGESTED_AREA] = node_area;
       },
-      0, discovery_info.retain);
+      this->qos_, discovery_info.retain);
 }
+
+uint8_t MQTTComponent::get_qos() const { return this->qos_; }
 
 bool MQTTComponent::get_retain() const { return this->retain_; }
 

--- a/esphome/components/mqtt/mqtt_component.h
+++ b/esphome/components/mqtt/mqtt_component.h
@@ -77,6 +77,10 @@ class MQTTComponent : public Component {
 
   virtual bool is_internal();
 
+  /// Set QOS for state messages.
+  void set_qos(uint8_t qos);
+  uint8_t get_qos() const;
+
   /// Set whether state message should be retained.
   void set_retain(bool retain);
   bool get_retain() const;
@@ -199,6 +203,7 @@ class MQTTComponent : public Component {
 
   bool command_retain_{false};
   bool retain_{true};
+  uint8_t qos_{0};
   bool discovery_enabled_{true};
   bool resend_state_{false};
 };

--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -29,6 +29,7 @@ from esphome.const import (
     CONF_PAYLOAD_AVAILABLE,
     CONF_PAYLOAD_NOT_AVAILABLE,
     CONF_RETAIN,
+    CONF_QOS,
     CONF_SETUP_PRIORITY,
     CONF_STATE_TOPIC,
     CONF_TOPIC,
@@ -1779,6 +1780,7 @@ MQTT_COMPONENT_AVAILABILITY_SCHEMA = Schema(
 
 MQTT_COMPONENT_SCHEMA = Schema(
     {
+        Optional(CONF_QOS): All(requires_component("mqtt"), int_range(min=0, max=2)),
         Optional(CONF_RETAIN): All(requires_component("mqtt"), boolean),
         Optional(CONF_DISCOVERY): All(requires_component("mqtt"), boolean),
         Optional(CONF_STATE_TOPIC): All(requires_component("mqtt"), publish_topic),

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -679,6 +679,7 @@ sensor:
     internal: true
     address: 0x23
     update_interval: 30s
+    qos: 2
     retain: false
     availability:
     state_topic: livingroom/custom_state_topic


### PR DESCRIPTION
# What does this implement/fix?

Adds QoS option to the MQTT components. It is not a breaking change as the default is still `0`.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** https://github.com/esphome/feature-requests/issues/544

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** https://github.com/esphome/esphome-docs/pull/3635

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
mqtt:
  broker: XXX.XXX.XXX.XXX
  username: user
  password: passwd
     
sensor:
  - platform: adc
    id: "battery_voltage"
    pin: GPIO3
    name: "Battery voltage"
    unit_of_measurement: "V"
    attenuation: auto
    qos: 1
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
