### PR TITLE
dashboard: move storage json update to a background task in edit save

### DIFF
--- a/esphome/dashboard/const.py
+++ b/esphome/dashboard/const.py
@@ -8,3 +8,5 @@ MAX_EXECUTOR_WORKERS = 48
 
 
 SENTINEL = object()
+
+DASHBOARD_COMMAND = ["esphome", "--dashboard"]

--- a/esphome/dashboard/core.py
+++ b/esphome/dashboard/core.py
@@ -7,6 +7,7 @@ import threading
 from dataclasses import dataclass
 from functools import partial
 from typing import TYPE_CHECKING, Any, Callable
+from collections.abc import Coroutine
 
 from ..zeroconf import DiscoveredImport
 from .dns import DNSCache
@@ -141,9 +142,11 @@ class ESPHomeDashboard:
                     await task
             await asyncio.sleep(0)
 
-    def async_create_background_task(self, coro: Callable[[], Any]) -> asyncio.Task:
+    def async_create_background_task(
+        self, coro: Coroutine[Any, Any, Any]
+    ) -> asyncio.Task:
         """Create a background task."""
-        task = self.loop.create_task(coro())
+        task = self.loop.create_task(coro)
         task.add_done_callback(self._background_tasks.discard)
         return task
 

--- a/esphome/dashboard/core.py
+++ b/esphome/dashboard/core.py
@@ -72,6 +72,7 @@ class ESPHomeDashboard:
         "mdns_status",
         "settings",
         "dns_cache",
+        "_background_tasks",
     )
 
     def __init__(self) -> None:

--- a/esphome/dashboard/entries.py
+++ b/esphome/dashboard/entries.py
@@ -238,7 +238,7 @@ class DashboardEntries:
         return path_to_cache_key
 
     def async_schedule_storage_json_update(self, filename: str) -> None:
-        # Ensure the StorageJSON is updated as well
+        """Schedule a task to update the storage JSON file."""
         self._dashboard.async_create_background_task(
             async_run_system_command(
                 [*DASHBOARD_COMMAND, "compile", "--only-generate", filename]

--- a/esphome/dashboard/entries.py
+++ b/esphome/dashboard/entries.py
@@ -10,12 +10,14 @@ from esphome import const, util
 from esphome.storage_json import StorageJSON, ext_storage_path
 
 from .const import (
+    DASHBOARD_COMMAND,
     EVENT_ENTRY_ADDED,
     EVENT_ENTRY_REMOVED,
     EVENT_ENTRY_STATE_CHANGED,
     EVENT_ENTRY_UPDATED,
 )
 from .enum import StrEnum
+from .util.subprocess import async_run_system_command
 
 if TYPE_CHECKING:
     from .core import ESPHomeDashboard
@@ -234,6 +236,14 @@ class DashboardEntries:
                 stat.st_size,
             )
         return path_to_cache_key
+
+    def async_schedule_storage_json_update(self, filename: str) -> None:
+        # Ensure the StorageJSON is updated as well
+        self._dashboard.async_create_background_task(
+            async_run_system_command(
+                [*DASHBOARD_COMMAND, "compile", "--only-generate", filename]
+            )
+        )
 
 
 class DashboardEntry:

--- a/esphome/dashboard/web_server.py
+++ b/esphome/dashboard/web_server.py
@@ -852,6 +852,7 @@ class EditRequestHandler(BaseHandler):
 
         loop = asyncio.get_running_loop()
         await loop.run_in_executor(None, self._write_file, filename, self.request.body)
+        # Ensure the StorageJSON is updated as well
         DASHBOARD.entries.async_schedule_storage_json_update(filename)
         self.set_status(200)
 

--- a/esphome/dashboard/web_server.py
+++ b/esphome/dashboard/web_server.py
@@ -9,11 +9,11 @@ import hashlib
 import json
 import logging
 import os
-import time
 import secrets
 import shutil
 import subprocess
 import threading
+import time
 from collections.abc import Iterable
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, TypeVar
@@ -40,6 +40,7 @@ from esphome.storage_json import StorageJSON, ext_storage_path, trash_storage_pa
 from esphome.util import get_serial_ports, shlex_quote
 from esphome.yaml_util import FastestAvailableSafeLoader
 
+from .const import DASHBOARD_COMMAND
 from .core import DASHBOARD
 from .entries import EntryState, entry_state_to_bool
 from .util.file import write_file
@@ -284,9 +285,6 @@ class EsphomeCommandWebSocket(tornado.websocket.WebSocketHandler):
 
     async def build_command(self, json_message: dict[str, Any]) -> list[str]:
         raise NotImplementedError
-
-
-DASHBOARD_COMMAND = ["esphome", "--dashboard"]
 
 
 class EsphomePortCommandWebSocket(EsphomeCommandWebSocket):
@@ -854,10 +852,7 @@ class EditRequestHandler(BaseHandler):
 
         loop = asyncio.get_running_loop()
         await loop.run_in_executor(None, self._write_file, filename, self.request.body)
-        # Ensure the StorageJSON is updated as well
-        await async_run_system_command(
-            [*DASHBOARD_COMMAND, "compile", "--only-generate", filename]
-        )
+        DASHBOARD.entries.async_schedule_storage_json_update(filename)
         self.set_status(200)
 
 


### PR DESCRIPTION
# What does this implement/fix?

Move the StorageJSON update on edit to a background task so the webserver responded right away.
fixes https://github.com/esphome/issues/issues/5342


## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
