### PR TITLE
MH-Z19: Add detection range

### DIFF
--- a/esphome/components/mhz19/mhz19.cpp
+++ b/esphome/components/mhz19/mhz19.cpp
@@ -11,6 +11,9 @@ static const uint8_t MHZ19_COMMAND_GET_PPM[] = {0xFF, 0x01, 0x86, 0x00, 0x00, 0x
 static const uint8_t MHZ19_COMMAND_ABC_ENABLE[] = {0xFF, 0x01, 0x79, 0xA0, 0x00, 0x00, 0x00, 0x00};
 static const uint8_t MHZ19_COMMAND_ABC_DISABLE[] = {0xFF, 0x01, 0x79, 0x00, 0x00, 0x00, 0x00, 0x00};
 static const uint8_t MHZ19_COMMAND_CALIBRATE_ZERO[] = {0xFF, 0x01, 0x87, 0x00, 0x00, 0x00, 0x00, 0x00};
+static const uint8_t MHZ19_COMMAND_DETECTION_RANGE_0_2000PPM[] = {0xFF, 0x01, 0x99, 0x00, 0x00, 0x00, 0x07, 0xD0};
+static const uint8_t MHZ19_COMMAND_DETECTION_RANGE_0_5000PPM[] = {0xFF, 0x01, 0x99, 0x00, 0x00, 0x00, 0x13, 0x88};
+static const uint8_t MHZ19_COMMAND_DETECTION_RANGE_0_10000PPM[] = {0xFF, 0x01, 0x99, 0x00, 0x00, 0x00, 0x27, 0x10};
 
 uint8_t mhz19_checksum(const uint8_t *command) {
   uint8_t sum = 0;
@@ -25,6 +28,24 @@ void MHZ19Component::setup() {
     this->abc_enable();
   } else if (this->abc_boot_logic_ == MHZ19_ABC_DISABLED) {
     this->abc_disable();
+  }
+
+  switch (this->detection_range_) {
+    case MHZ19_DETECTION_RANGE_DEFAULT:
+      ESP_LOGD(TAG, "Using previously set detection range (no change)");
+      break;
+    case MHZ19_DETECTION_RANGE_0_2000PPM:
+      ESP_LOGD(TAG, "Setting detection range to 0 to 2000ppm");
+      this->mhz19_write_command_(MHZ19_COMMAND_DETECTION_RANGE_0_2000PPM, nullptr);
+      break;
+    case MHZ19_DETECTION_RANGE_0_5000PPM:
+      ESP_LOGD(TAG, "Setting detection range to 0 to 5000ppm");
+      this->mhz19_write_command_(MHZ19_COMMAND_DETECTION_RANGE_0_5000PPM, nullptr);
+      break;
+    case MHZ19_DETECTION_RANGE_0_10000PPM:
+      ESP_LOGD(TAG, "Setting detection range to 0 to 10000ppm");
+      this->mhz19_write_command_(MHZ19_COMMAND_DETECTION_RANGE_0_10000PPM, nullptr);
+      break;
   }
 }
 
@@ -97,7 +118,9 @@ bool MHZ19Component::mhz19_write_command_(const uint8_t *command, uint8_t *respo
 
   return this->read_array(response, MHZ19_RESPONSE_LENGTH);
 }
+
 float MHZ19Component::get_setup_priority() const { return setup_priority::DATA; }
+
 void MHZ19Component::dump_config() {
   ESP_LOGCONFIG(TAG, "MH-Z19:");
   LOG_SENSOR("  ", "CO2", this->co2_sensor_);
@@ -111,6 +134,23 @@ void MHZ19Component::dump_config() {
   }
 
   ESP_LOGCONFIG(TAG, "  Warmup seconds: %ds", this->warmup_seconds_);
+
+  const char *range_str;
+  switch (this->detection_range_) {
+    case MHZ19_DETECTION_RANGE_DEFAULT:
+      range_str = "default";
+      break;
+    case MHZ19_DETECTION_RANGE_0_2000PPM:
+      range_str = "0 to 2000ppm";
+      break;
+    case MHZ19_DETECTION_RANGE_0_5000PPM:
+      range_str = "0 to 5000ppm";
+      break;
+    case MHZ19_DETECTION_RANGE_0_10000PPM:
+      range_str = "0 to 10000ppm";
+      break;
+  }
+  ESP_LOGCONFIG(TAG, "  Detection range: %s", range_str);
 }
 
 }  // namespace mhz19

--- a/esphome/components/mhz19/mhz19.h
+++ b/esphome/components/mhz19/mhz19.h
@@ -8,7 +8,18 @@
 namespace esphome {
 namespace mhz19 {
 
-enum MHZ19ABCLogic { MHZ19_ABC_NONE = 0, MHZ19_ABC_ENABLED, MHZ19_ABC_DISABLED };
+enum MHZ19ABCLogic {
+  MHZ19_ABC_NONE = 0,
+  MHZ19_ABC_ENABLED,
+  MHZ19_ABC_DISABLED,
+};
+
+enum MHZ19DetectionRange {
+  MHZ19_DETECTION_RANGE_DEFAULT = 0,
+  MHZ19_DETECTION_RANGE_0_2000PPM,
+  MHZ19_DETECTION_RANGE_0_5000PPM,
+  MHZ19_DETECTION_RANGE_0_10000PPM,
+};
 
 class MHZ19Component : public PollingComponent, public uart::UARTDevice {
  public:
@@ -27,13 +38,18 @@ class MHZ19Component : public PollingComponent, public uart::UARTDevice {
   void set_abc_enabled(bool abc_enabled) { abc_boot_logic_ = abc_enabled ? MHZ19_ABC_ENABLED : MHZ19_ABC_DISABLED; }
   void set_warmup_seconds(uint32_t seconds) { warmup_seconds_ = seconds; }
 
+  void set_detection_range(MHZ19DetectionRange detection_range) { detection_range_ = detection_range; }
+
  protected:
   bool mhz19_write_command_(const uint8_t *command, uint8_t *response);
 
   sensor::Sensor *temperature_sensor_{nullptr};
   sensor::Sensor *co2_sensor_{nullptr};
   MHZ19ABCLogic abc_boot_logic_{MHZ19_ABC_NONE};
+
   uint32_t warmup_seconds_;
+
+  MHZ19DetectionRange detection_range_{MHZ19_DETECTION_RANGE_DEFAULT};
 };
 
 template<typename... Ts> class MHZ19CalibrateZeroAction : public Action<Ts...> {

--- a/esphome/components/mhz19/sensor.py
+++ b/esphome/components/mhz19/sensor.py
@@ -19,6 +19,7 @@ DEPENDENCIES = ["uart"]
 
 CONF_AUTOMATIC_BASELINE_CALIBRATION = "automatic_baseline_calibration"
 CONF_WARMUP_TIME = "warmup_time"
+CONF_DETECTION_RANGE = "detection_range"
 
 mhz19_ns = cg.esphome_ns.namespace("mhz19")
 MHZ19Component = mhz19_ns.class_("MHZ19Component", cg.PollingComponent, uart.UARTDevice)
@@ -49,6 +50,10 @@ CONFIG_SCHEMA = (
             cv.Optional(
                 CONF_WARMUP_TIME, default="75s"
             ): cv.positive_time_period_seconds,
+            cv.Optional(CONF_DETECTION_RANGE): cv.All(
+                cv.float_with_unit("parts per million", "(ppm)"),
+                cv.one_of(2000, 5000, 10000, int=True),
+            ),
         }
     )
     .extend(cv.polling_component_schema("60s"))
@@ -73,6 +78,9 @@ async def to_code(config):
         cg.add(var.set_abc_enabled(config[CONF_AUTOMATIC_BASELINE_CALIBRATION]))
 
     cg.add(var.set_warmup_seconds(config[CONF_WARMUP_TIME]))
+
+    if CONF_DETECTION_RANGE in config:
+        cg.add(var.set_detection_range(config[CONF_DETECTION_RANGE]))
 
 
 CALIBRATION_ACTION_SCHEMA = maybe_simple_id(


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Add detection range setting support. It seem datasheets out there for the MH-Z19 family aren't always complete, but this one has it:

https://emariete.com/wp-content/uploads/2020/12/MH-Z19B%20(Datasheet%20del%20MH-Z19B%20en%20ingl%C3%A9s%20del%2023-09-2019).pdf

![image](https://github.com/esphome/esphome/assets/1386232/6e9f57c2-6daf-46b4-a6c6-1afa7ca5fb31)


## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here> https://github.com/esphome/esphome-docs/pull/3636

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
substitutions:
  mhz19_warmup: "75"

esphome:
  name: "environmental"
  friendly_name: "Environmental"
  name_add_mac_suffix: true
  on_boot:
    - priority: 600.0
      then:
        - lambda: |-
            // Default: Connecting
            id(wifi_led_pwm).set_level(0.5);
            id(wifi_led_pwm).set_period(1000);
            id(wifi_led_pwm).turn_on();
        - script.execute: fast_reboot_factory_reset
    - priority: 800.0
      then:
        - lambda: |-
            // mhz19
            if(id(mhz19_abc))
              id(mhz19_sensor).abc_enable();
            else
              id(mhz19_sensor).abc_disable();
            id(mhz19_hd).turn_on();

            // pmsx003
            id(pmsx003_reset).turn_off();
            id(pmsx003_set).turn_off();
            delay(20);
            id(pmsx003_reset).turn_on();
            id(pmsx003_set).turn_on();

            // aqi_led
            id(aqi_led).set_level(0.0);
            id(aqi_led).turn_on();

  on_loop:
    then:
      - lambda: |-
          // Captive portal
          if(id(wifi_component).has_ap() && !id(wifi_component).has_sta()) {
            id(wifi_led_pwm).set_level(0.5);
            id(wifi_led_pwm).set_period(200);
          } else {
            id(wifi_led_pwm).set_period(1000);
            // Connected
            if(id(wifi_component).is_connected())
              id(wifi_led_pwm).set_level(1);
            // Connecting
            else
              id(wifi_led_pwm).set_level(0.5);
          }

esp32:
  board: esp32-c3-devkitm-1

external_components:
  - source:
      type: git
      url: https://github.com/fornellas/esphome
      ref: mhz19_patches
    components: [ mhz19 ]
    refresh: 0s

globals:
  - id: fast_reboot
    type: int
    restore_value: yes
    initial_value: '0'

  - id: factory_reset_reboot_counter
    type: int
    initial_value: '5'

  - id: mhz19_calibrate_zero_unix_timestamp
    type: time_t
    restore_value: yes
    initial_value: '0'

  - id: mhz19_abc
    type: bool
    restore_value: yes
    initial_value: 'false'

logger:
  baud_rate: 0
  level: info

script:
  - id: fast_reboot_factory_reset
    then:
      - if:
          condition:
            lambda: return ( id(fast_reboot) >= id(factory_reset_reboot_counter) );
          then:
            - lambda: |-
                ESP_LOGI("Fast Boot Factory Reset", "Performing factotry reset");
                id(fast_reboot) = 0;
                fast_reboot->loop();
                global_preferences->sync();
            - button.press: factory_reset_button
      - lambda: |-
          if(id(fast_reboot) > 0)
            ESP_LOGI("Fast Boot Factory Reset", "Quick reboot %d/%d, do it %d more times to factory reset", id(fast_reboot), id(factory_reset_reboot_counter), id(factory_reset_reboot_counter) - id(fast_reboot));
          id(fast_reboot) += 1;
          fast_reboot->loop();
          global_preferences->sync();
      - delay: 10s
      - lambda: |-
          id(fast_reboot) = 0;
          fast_reboot->loop();
          global_preferences->sync();

  - id: mhz19_calibrate_zero
    then:
      - output.turn_on: mhz19_calibration_led
      - mhz19.calibrate_zero: mhz19_sensor
      - lambda: |-
          auto time = id(sntp_time).utcnow();
          if(time.is_valid()) {
            id(mhz19_calibrate_zero_unix_timestamp) = time.timestamp;
            mhz19_calibrate_zero_unix_timestamp->loop();
            global_preferences->sync();
            ESP_LOGD("MH-Z19", "Saved zero calibration timestamp");
          } else {
            ESP_LOGW("MH-Z19", "Time unavailable, can't save zero calibration timestamp");
          }
      - delay: 2s
      - output.turn_off: mhz19_calibration_led

wifi:
  id: wifi_component
  ap:
    ap_timeout: 0s
  reboot_timeout: 0s
  power_save_mode: none

captive_portal:
    
web_server:

api:
  reboot_timeout: 0s

ota:
  safe_mode: false

uart:
  - id: uart_mhz19
    rx_pin: 5
    tx_pin: 4
    baud_rate: 9600

  - id: uart_pmsx003
    rx_pin: 1
    tx_pin:
      number: 2
      ignore_strapping_warning: true
    baud_rate: 9600

i2c:
  sda: 19
  scl: 10
  scan: false

binary_sensor:
  - platform: status
    name: "Status"

  - platform: gpio
    id: mhz19_sensor_calibrate_zero
    pin:
      number: 18
      mode: INPUT_PULLUP
    on_press:
      then:
        - script.execute:  mhz19_calibrate_zero

select:
  - platform: template
    name: "MH-Z19: Detection range"
    id: mhz19_detection_range
    icon: mdi:dots-horizontal
    entity_category: config
    optimistic: true
    options:
      - "Default"
      - "0-2000ppm"
      - "0-5000ppm"
      - "0-10000ppm"
    initial_option: "Default"
    restore_value: true
    on_value:
      then:
      - lambda: |-
          if ("0-2000ppm" == x)
            id(mhz19_sensor).detection_range(esphome::mhz19::MHZ19_DETECTION_RANGE_0_2000PPM);
          else if ("0-5000ppm" == x)
            id(mhz19_sensor).detection_range(esphome::mhz19::MHZ19_DETECTION_RANGE_0_5000PPM);
          else if ("0-10000ppm" == x)
            id(mhz19_sensor).detection_range(esphome::mhz19::MHZ19_DETECTION_RANGE_0_10000PPM);

sensor:
  - platform: uptime
    name: 'Uptime'
    update_interval: 15s

  - platform: wifi_signal
    name: "WiFi Signal"
    update_interval: 15s

  - platform: mhz19
    id: mhz19_sensor
    uart_id: uart_mhz19
    co2:
      id: mhz19_sensor_co2
      name: "CO₂ (UART)"
      filters:
        - lambda: |-
            return id(mhz19_non_linearity_slope).state * x + id(mhz19_non_linearity_offset).state;
    update_interval: 1s
    automatic_baseline_calibration: true
    warmup_time: "${mhz19_warmup}s"

  - platform: duty_cycle
    name: "CO₂ (PWM)"
    unit_of_measurement: "ppm"
    icon: "mdi:molecule-co2"
    accuracy_decimals: 0
    pin:
      number: 7
      mode:
        input: true
    update_interval: 1s
    filters:
      - lambda: |-
          if(millis() < ${mhz19_warmup} * 1000)
            return NAN;

          if (id(mhz19_detection_range).state == "Default")
            return NAN;
          double mul;
          if (id(mhz19_detection_range).state == "0-2000ppm")
            mul = 2.0;
          else if (id(mhz19_detection_range).state == "0-5000ppm")
            mul = 5.0;
          else if (id(mhz19_detection_range).state == "0-10000ppm")
            mul = 10.0;

          auto ppm = (x/100.0*1004.0-2.0)*mul;

          return id(mhz19_non_linearity_slope).state * ppm + id(mhz19_non_linearity_offset).state;

  - platform: template
    name: "MH-Z19: Last zero calibration unix timestamp"
    entity_category: diagnostic
    unit_of_measurement: "s"
    lambda: |-
      time_t timestamp = id(mhz19_calibrate_zero_unix_timestamp);
      if (timestamp == 0)
        return NAN;
      return timestamp;
    update_interval: 1s

  - platform: template
    name: "MH-Z19: Last zero calibration time ago"
    entity_category: diagnostic
    unit_of_measurement: "s"
    lambda: |-
      time_t timestamp = id(mhz19_calibrate_zero_unix_timestamp);
      if (timestamp == 0)
        return NAN;
      esphome::ESPTime now = id(sntp_time).utcnow();
      if(!now.is_valid())
        return NAN;
      return now.timestamp - timestamp;
    update_interval: 1s

  - platform: sht3xd
    temperature:
      name: "Temperature"
    humidity:
      name: "Humidity"
    address: 0x44
    update_interval: 1s

  - platform: pmsx003
    type: PMSX003
    uart_id: uart_pmsx003
    pm_1_0_std:
      name: "PM1.0 (CF=1，standard particle)"
      unit_of_measurement: "μg/m³"
    pm_2_5_std:
      name: "PM2.5 (CF=1，standard particle)"
      unit_of_measurement: "μg/m³"
    pm_10_0_std:
      name: "PM10.0 (CF=1，standard particle)"
      unit_of_measurement: "μg/m³"
    pm_1_0:
      name: "PM1.0 (under atmospheric environment)"
      unit_of_measurement: "μg/m³"
    pm_2_5:
      name: "PM2.5 (under atmospheric environment)"
      unit_of_measurement: "μg/m³"
      id: pmsx003_pm25
    pm_10_0:
      name: "PM10.0 (under atmospheric environment)"
      unit_of_measurement: "μg/m³"
      id: pmsx003_pm10
    pm_0_3um:
      name: "Number of particles with diameter beyond 0.3μm in 0.1 L of air"
      unit_of_measurement: ""
    pm_0_5um:
      name: "Number of particles with diameter beyond 0.5μm in 0.1 L of air"
      unit_of_measurement: ""
    pm_1_0um:
      name: "Number of particles with diameter beyond 1.0μm in 0.1 L of air"
      unit_of_measurement: ""
    pm_2_5um:
      name: "Number of particles with diameter beyond 2.5μm in 0.1 L of air"
      unit_of_measurement: ""
    pm_5_0um:
      name: "Number of particles with diameter beyond 5.0μm in 0.1 L of air"
      unit_of_measurement: ""
    pm_10_0um:
      name: "Number of particles with diameter beyond 10.0μm in 0.1 L of air"
      unit_of_measurement: ""
    update_interval: 60s

  - platform: template
    name: "AQI"
    unit_of_measurement: "AQI"
    lambda: |-
      double aqi = -1;

      // mhz19
      double co2_ppm = id(mhz19_sensor_co2).state;
      if(!std::isnan(co2_ppm)) {
        double aqi_co2 = 0.0;
        if(co2_ppm < 400.0)
          aqi_co2 = co2_ppm / 400.0;
        else if(co2_ppm < 1000.0)
          aqi_co2 = 1.0 + (co2_ppm - 400.0) / 600.0;
        else if(co2_ppm < 1500.0)
          aqi_co2 = 2.0 + (co2_ppm - 1000.0) / 500.0;
        else if(co2_ppm < 2000.0)
          aqi_co2 = 3.0 + (co2_ppm - 1500.0) / 500.0;
        else if(co2_ppm < 5000.0)
          aqi_co2 = 4.0 + (co2_ppm - 2000.0) / 3000.0;
        else
          aqi_co2 = 6.0;
        if(aqi_co2 > aqi)
          aqi = aqi_co2;
      }

      // pmsx003 pm25
      double pm25 = id(pmsx003_pm25).state;
      if(!std::isnan(pm25)) {
        double aqi_pm25 = 0.0;
        if(pm25 < 10.0)
          aqi_pm25 = pm25 / 10.0;
        else if(pm25 < 20.0)
          aqi_pm25 = 1.0 + (pm25 - 10.0) / 10.0;
        else if(pm25 < 25.0)
          aqi_pm25 = 2.0 + (pm25 - 20.0) / 5.0;
        else if(pm25 < 50.0)
          aqi_pm25 = 3.0 + (pm25 - 25.0) / 25.0;
        else if(pm25 < 75.0)
          aqi_pm25 = 4.0 + (pm25 - 50.0) / 25.0;
        else
          aqi_pm25 = 6.0;
        if(aqi_pm25 > aqi)
          aqi = aqi_pm25;
      }

      // pmsx003 pm10
      double pm10 = id(pmsx003_pm10).state;
      if(!std::isnan(pm10)) {
        double aqi_pm10 = 0.0;
        if(pm10 < 20.0)
          aqi_pm10 = pm10 / 20.0;
        else if(pm10 < 40.0)
          aqi_pm10 = 1.0 + (pm10 - 20.0) / 20.0;
        else if(pm10 < 50.0)
          aqi_pm10 = 2.0 + (pm10 - 40.0) / 10.0;
        else if(pm10 < 100.0)
          aqi_pm10 = 3.0 + (pm10 - 50.0) / 50.0;
        else if(pm10 < 150.0)
          aqi_pm10 = 4.0 + (pm10 - 100.0) / 50.0;
        else
          aqi_pm10 = 6.0;
        if(aqi_pm10 > aqi)
          aqi = aqi_pm10;
      }

      if(aqi >= 0.0)
        return aqi;
      return NAN;
    update_interval: 1s
    on_value:
      then:
        - lambda: |-
            double level = (x - 1.0) / 5.0;
            id(aqi_led).set_level(level);

output:
  - platform: slow_pwm
    id: wifi_led_pwm
    period: 1s
    pin:
      inverted: true
      number: 9
      ignore_strapping_warning: true

  - platform: gpio
    id: mhz19_hd
    pin: 6

  - platform: gpio
    id: pmsx003_set
    pin: 0

  - platform: gpio
    id: pmsx003_reset
    pin: 3

  - platform: gpio
    id: mhz19_calibration_led
    pin: 21

  - platform: slow_pwm
    id: aqi_led
    period: 1s
    pin: 20

button:
  - platform: factory_reset
    id: factory_reset_button
    name: "Factory reset"

  - platform: restart
    name: "Restart"

  - platform: safe_mode
    name: "Safe Mode"

  - platform: template
    name: "MH19: Calibrate Zero"
    entity_category: config
    on_press:
      then:
        - script.execute:  mhz19_calibrate_zero

text_sensor:
  - platform: wifi_info
    ip_address:
      name: "Wifi Info: IP Address"
    ssid:
      name: "Wifi Info: SSID"
    bssid:
      name: "Wifi Info: BSSID"
    mac_address:
      name: "Wifi Info: MAC Address"
    dns_address:
      name: "Wifi Info: DNS Address"

  - platform: template
    name: "MH-Z19: Last zero calibration"
    lambda: |-
      char buffer[32];
      auto espTime = ESPTime::from_epoch_utc(id(mhz19_calibrate_zero_unix_timestamp));
      if(!espTime.is_valid())
        return {"Never"};
      espTime.strftime(buffer, sizeof(buffer), "%a, %d %b %Y %H:%M:%S %z");
      return {buffer};
    update_interval: 1s

switch:
  - platform: template
    name: "MH-Z19: ABC"
    entity_category: config
    lambda: |-
      return id(mhz19_abc);
    turn_on_action:
      - mhz19.abc_enable: mhz19_sensor
      - globals.set:
          id: mhz19_abc
          value: 'true'
    turn_off_action:
      - mhz19.abc_disable: mhz19_sensor
      - globals.set:
          id: mhz19_abc
          value: 'false'

number:
  - platform: template
    name: "MH-Z19: Non linearity slope"
    id: mhz19_non_linearity_slope
    entity_category: config
    icon: mdi:palette
    mode: box
    min_value: 0
    max_value: 2
    step: 0.00001
    optimistic: true
    restore_value: true
    initial_value: 1

  - platform: template
    name: "MH-Z19: Non linearity offset"
    id: mhz19_non_linearity_offset
    entity_category: config
    icon: mdi:palette
    mode: box
    min_value: -410
    max_value: 410
    step: 0.00001
    optimistic: true
    restore_value: true
    initial_value: 0

time:
  - platform: sntp
    id: sntp_time
    timezone: Etc/UTC
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
