### PR TITLE
CSE7766: Fix energy calculation

### DIFF
--- a/esphome/components/cse7766/cse7766.cpp
+++ b/esphome/components/cse7766/cse7766.cpp
@@ -118,7 +118,7 @@ void CSE7766Component::parse_data_() {
   uint32_t power_coeff = this->get_24_bit_uint_(14);
   uint32_t power_cycle = this->get_24_bit_uint_(17);
   uint8_t adj = this->raw_data_[20];
-  uint32_t cf_pulses = (this->raw_data_[21] << 8) + this->raw_data_[22];
+  uint16_t cf_pulses = (this->raw_data_[21] << 8) + this->raw_data_[22];
 
   bool have_power = adj & 0x10;
   bool have_current = adj & 0x20;
@@ -132,8 +132,24 @@ void CSE7766Component::parse_data_() {
     }
   }
 
+  float energy = 0.0;
+  if (this->energy_sensor_ != nullptr) {
+    if (this->cf_pulses_last_ == 0 && !this->energy_sensor_->has_state()) {
+      this->cf_pulses_last_ = cf_pulses;
+    }
+    uint16_t cf_diff = cf_pulses - this->cf_pulses_last_;
+    this->cf_pulses_total_ += cf_diff;
+    this->cf_pulses_last_ = cf_pulses;
+    // Calculate CF pulses into total energy only if we have Power coefficient to multiply by
+    if (have_power) {
+      energy = this->cf_pulses_total_ * float(power_coeff) / 1000000.0f / 3600.0f;
+      this->energy_sensor_->publish_state(energy);
+    } else if (!this->energy_sensor_->has_state()) {
+      this->energy_sensor_->publish_state(0);
+    }
+  }
+
   float power = 0.0f;
-  float energy = 0.0f;
   if (power_cycle_exceeds_range) {
     // Datasheet: power cycle exceeding range means active power is 0
     if (this->power_sensor_ != nullptr) {
@@ -144,27 +160,6 @@ void CSE7766Component::parse_data_() {
     if (this->power_sensor_ != nullptr) {
       this->power_sensor_->publish_state(power);
     }
-
-    // Add CF pulses to the total energy only if we have Power coefficient to multiply by
-
-    if (this->cf_pulses_last_ == 0) {
-      this->cf_pulses_last_ = cf_pulses;
-    }
-
-    uint32_t cf_diff;
-    if (cf_pulses < this->cf_pulses_last_) {
-      cf_diff = cf_pulses + (0x10000 - this->cf_pulses_last_);
-    } else {
-      cf_diff = cf_pulses - this->cf_pulses_last_;
-    }
-    this->cf_pulses_last_ = cf_pulses;
-
-    energy = cf_diff * float(power_coeff) / 1000000.0f / 3600.0f;
-    this->energy_total_ += energy;
-    if (this->energy_sensor_ != nullptr)
-      this->energy_sensor_->publish_state(this->energy_total_);
-  } else if ((this->energy_sensor_ != nullptr) && !this->energy_sensor_->has_state()) {
-    this->energy_sensor_->publish_state(0);
   }
 
   float current = 0.0f;

--- a/esphome/components/cse7766/cse7766.cpp
+++ b/esphome/components/cse7766/cse7766.cpp
@@ -140,13 +140,8 @@ void CSE7766Component::parse_data_() {
     uint16_t cf_diff = cf_pulses - this->cf_pulses_last_;
     this->cf_pulses_total_ += cf_diff;
     this->cf_pulses_last_ = cf_pulses;
-    // Calculate CF pulses into total energy only if we have Power coefficient to multiply by
-    if (have_power) {
-      energy = this->cf_pulses_total_ * float(power_coeff) / 1000000.0f / 3600.0f;
-      this->energy_sensor_->publish_state(energy);
-    } else if (!this->energy_sensor_->has_state()) {
-      this->energy_sensor_->publish_state(0);
-    }
+    energy = this->cf_pulses_total_ * float(power_coeff) / 1000000.0f / 3600.0f;
+    this->energy_sensor_->publish_state(energy);
   }
 
   float power = 0.0f;

--- a/esphome/components/cse7766/cse7766.h
+++ b/esphome/components/cse7766/cse7766.h
@@ -30,8 +30,8 @@ class CSE7766Component : public Component, public uart::UARTDevice {
   sensor::Sensor *current_sensor_{nullptr};
   sensor::Sensor *power_sensor_{nullptr};
   sensor::Sensor *energy_sensor_{nullptr};
-  float energy_total_{0.0f};
-  uint32_t cf_pulses_last_{0};
+  uint32_t cf_pulses_total_{0};
+  uint16_t cf_pulses_last_{0};
 };
 
 }  // namespace cse7766


### PR DESCRIPTION
Adding small float values to a large float value is not a good idea. Due to the lack of accuracy, the small values may be completely ignored.

This commit uses an unsigned integer to sum the cf pulses and calculate the total energy from the total number of cf pulses.

# What does this implement/fix?

After some time the accumulation of energy does not fit to measured power.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
sensor:
  - platform: cse7766
    current:
      name: Current
      filters:
        - throttle_average: 30s
    voltage:
      name: Voltage
      filters:
        - filter_out: 0.0
        - throttle_average: 60s
    power:
      name: Power
      filters:
        - throttle_average: 30s
    energy:
      name: Energy
      filters:
        - throttle: 30s

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
