### PR TITLE
Add wake word phrase to voice assistant start command

### DIFF
--- a/esphome/components/api/api.proto
+++ b/esphome/components/api/api.proto
@@ -1450,6 +1450,7 @@ message VoiceAssistantRequest {
   string conversation_id = 2;
   uint32 flags = 3;
   VoiceAssistantAudioSettings audio_settings = 4;
+  string wake_word_phrase = 5;
 }
 
 message VoiceAssistantResponse {

--- a/esphome/components/api/api_pb2.cpp
+++ b/esphome/components/api/api_pb2.cpp
@@ -6603,6 +6603,10 @@ bool VoiceAssistantRequest::decode_length(uint32_t field_id, ProtoLengthDelimite
       this->audio_settings = value.as_message<VoiceAssistantAudioSettings>();
       return true;
     }
+    case 5: {
+      this->wake_word_phrase = value.as_string();
+      return true;
+    }
     default:
       return false;
   }
@@ -6612,6 +6616,7 @@ void VoiceAssistantRequest::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_string(2, this->conversation_id);
   buffer.encode_uint32(3, this->flags);
   buffer.encode_message<VoiceAssistantAudioSettings>(4, this->audio_settings);
+  buffer.encode_string(5, this->wake_word_phrase);
 }
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void VoiceAssistantRequest::dump_to(std::string &out) const {
@@ -6632,6 +6637,10 @@ void VoiceAssistantRequest::dump_to(std::string &out) const {
 
   out.append("  audio_settings: ");
   this->audio_settings.dump_to(out);
+  out.append("\n");
+
+  out.append("  wake_word_phrase: ");
+  out.append("'").append(this->wake_word_phrase).append("'");
   out.append("\n");
   out.append("}");
 }

--- a/esphome/components/api/api_pb2.h
+++ b/esphome/components/api/api_pb2.h
@@ -1702,6 +1702,7 @@ class VoiceAssistantRequest : public ProtoMessage {
   std::string conversation_id{};
   uint32_t flags{0};
   VoiceAssistantAudioSettings audio_settings{};
+  std::string wake_word_phrase{};
   void encode(ProtoWriteBuffer buffer) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;

--- a/esphome/components/micro_wake_word/micro_wake_word.cpp
+++ b/esphome/components/micro_wake_word/micro_wake_word.cpp
@@ -134,7 +134,7 @@ void MicroWakeWord::loop() {
         this->set_state_(State::IDLE);
         if (this->detected_) {
           this->detected_ = false;
-          this->wake_word_detected_trigger_->trigger("");
+          this->wake_word_detected_trigger_->trigger(this->wake_word_);
         }
       }
       break;

--- a/esphome/components/voice_assistant/__init__.py
+++ b/esphome/components/voice_assistant/__init__.py
@@ -42,6 +42,8 @@ CONF_AUTO_GAIN = "auto_gain"
 CONF_NOISE_SUPPRESSION_LEVEL = "noise_suppression_level"
 CONF_VOLUME_MULTIPLIER = "volume_multiplier"
 
+CONF_WAKE_WORD = "wake_word"
+
 
 voice_assistant_ns = cg.esphome_ns.namespace("voice_assistant")
 VoiceAssistant = voice_assistant_ns.class_("VoiceAssistant", cg.Component)
@@ -285,6 +287,7 @@ VOICE_ASSISTANT_ACTION_SCHEMA = cv.Schema({cv.GenerateID(): cv.use_id(VoiceAssis
     VOICE_ASSISTANT_ACTION_SCHEMA.extend(
         {
             cv.Optional(CONF_SILENCE_DETECTION, default=True): cv.boolean,
+            cv.Optional(CONF_WAKE_WORD): cv.templatable(cv.string),
         }
     ),
 )
@@ -293,6 +296,9 @@ async def voice_assistant_listen_to_code(config, action_id, template_arg, args):
     await cg.register_parented(var, config[CONF_ID])
     if CONF_SILENCE_DETECTION in config:
         cg.add(var.set_silence_detection(config[CONF_SILENCE_DETECTION]))
+    if wake_word := config.get(CONF_WAKE_WORD):
+        templ = await cg.templatable(wake_word, args, cg.std_string)
+        cg.add(var.set_wake_word(templ))
     return var
 
 

--- a/esphome/components/voice_assistant/voice_assistant.cpp
+++ b/esphome/components/voice_assistant/voice_assistant.cpp
@@ -215,6 +215,8 @@ void VoiceAssistant::loop() {
       msg.conversation_id = this->conversation_id_;
       msg.flags = flags;
       msg.audio_settings = audio_settings;
+      msg.wake_word_phrase = this->wake_word_;
+      this->wake_word_ = "";
 
       if (this->api_client_ == nullptr || !this->api_client_->send_voice_assistant_request(msg)) {
         ESP_LOGW(TAG, "Could not request start");

--- a/esphome/components/voice_assistant/voice_assistant.h
+++ b/esphome/components/voice_assistant/voice_assistant.h
@@ -124,6 +124,8 @@ class VoiceAssistant : public Component {
   void client_subscription(api::APIConnection *client, bool subscribe);
   api::APIConnection *get_api_connection() const { return this->api_client_; }
 
+  void set_wake_word(const std::string &wake_word) { this->wake_word_ = wake_word; }
+
  protected:
   int read_microphone_();
   void set_state_(State state);
@@ -175,6 +177,8 @@ class VoiceAssistant : public Component {
 
   std::string conversation_id_{""};
 
+  std::string wake_word_{""};
+
   HighFrequencyLoopRequester high_freq_;
 
 #ifdef USE_ESP_ADF
@@ -200,8 +204,13 @@ class VoiceAssistant : public Component {
 };
 
 template<typename... Ts> class StartAction : public Action<Ts...>, public Parented<VoiceAssistant> {
+  TEMPLATABLE_VALUE(std::string, wake_word);
+
  public:
-  void play(Ts... x) override { this->parent_->request_start(false, this->silence_detection_); }
+  void play(Ts... x) override {
+    this->parent_->set_wake_word(this->wake_word_.value(x...));
+    this->parent_->request_start(false, this->silence_detection_);
+  }
 
   void set_silence_detection(bool silence_detection) { this->silence_detection_ = silence_detection; }
 


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

This sends the on device wake word phrase to Home Assistant so it can then "block" multiple assistants from activating at the same time within a small timeframe.

Related PRs:
- https://github.com/home-assistant/core/pull/111585
- https://github.com/esphome/aioesphomeapi/pull/830

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
micro_wake_word:
  on_wake_word_detected:
    - voice_assistant.start:
        wake_word: !lambda return wake_word;
  model: okay_nabu
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
