### PR TITLE
CSE7766 Apparent Power & Power Factor calculations

### DIFF
--- a/esphome/components/cse7766/cse7766.h
+++ b/esphome/components/cse7766/cse7766.h
@@ -13,6 +13,10 @@ class CSE7766Component : public Component, public uart::UARTDevice {
   void set_current_sensor(sensor::Sensor *current_sensor) { current_sensor_ = current_sensor; }
   void set_power_sensor(sensor::Sensor *power_sensor) { power_sensor_ = power_sensor; }
   void set_energy_sensor(sensor::Sensor *energy_sensor) { energy_sensor_ = energy_sensor; }
+  void set_apparent_power_sensor(sensor::Sensor *apparent_power_sensor) {
+    apparent_power_sensor_ = apparent_power_sensor;
+  }
+  void set_power_factor_sensor(sensor::Sensor *power_factor_sensor) { power_factor_sensor_ = power_factor_sensor; }
 
   void loop() override;
   float get_setup_priority() const override;
@@ -30,6 +34,8 @@ class CSE7766Component : public Component, public uart::UARTDevice {
   sensor::Sensor *current_sensor_{nullptr};
   sensor::Sensor *power_sensor_{nullptr};
   sensor::Sensor *energy_sensor_{nullptr};
+  sensor::Sensor *apparent_power_sensor_{nullptr};
+  sensor::Sensor *power_factor_sensor_{nullptr};
   uint32_t cf_pulses_total_{0};
   uint16_t cf_pulses_last_{0};
 };

--- a/esphome/components/cse7766/sensor.py
+++ b/esphome/components/cse7766/sensor.py
@@ -2,19 +2,24 @@ import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import sensor, uart
 from esphome.const import (
+    CONF_APPARENT_POWER,
     CONF_CURRENT,
     CONF_ENERGY,
     CONF_ID,
     CONF_POWER,
+    CONF_POWER_FACTOR,
     CONF_VOLTAGE,
+    DEVICE_CLASS_APPARENT_POWER,
     DEVICE_CLASS_CURRENT,
     DEVICE_CLASS_ENERGY,
     DEVICE_CLASS_POWER,
+    DEVICE_CLASS_POWER_FACTOR,
     DEVICE_CLASS_VOLTAGE,
     STATE_CLASS_MEASUREMENT,
     STATE_CLASS_TOTAL_INCREASING,
-    UNIT_VOLT,
     UNIT_AMPERE,
+    UNIT_VOLT,
+    UNIT_VOLT_AMPS,
     UNIT_WATT,
     UNIT_WATT_HOURS,
 )
@@ -51,6 +56,17 @@ CONFIG_SCHEMA = cv.Schema(
             device_class=DEVICE_CLASS_ENERGY,
             state_class=STATE_CLASS_TOTAL_INCREASING,
         ),
+        cv.Optional(CONF_APPARENT_POWER): sensor.sensor_schema(
+            unit_of_measurement=UNIT_VOLT_AMPS,
+            accuracy_decimals=1,
+            device_class=DEVICE_CLASS_APPARENT_POWER,
+            state_class=STATE_CLASS_MEASUREMENT,
+        ),
+        cv.Optional(CONF_POWER_FACTOR): sensor.sensor_schema(
+            accuracy_decimals=2,
+            device_class=DEVICE_CLASS_POWER_FACTOR,
+            state_class=STATE_CLASS_MEASUREMENT,
+        ),
     }
 ).extend(uart.UART_DEVICE_SCHEMA)
 FINAL_VALIDATE_SCHEMA = uart.final_validate_device_schema(
@@ -75,3 +91,9 @@ async def to_code(config):
     if energy_config := config.get(CONF_ENERGY):
         sens = await sensor.new_sensor(energy_config)
         cg.add(var.set_energy_sensor(sens))
+    if apparent_power_config := config.get(CONF_APPARENT_POWER):
+        sens = await sensor.new_sensor(apparent_power_config)
+        cg.add(var.set_apparent_power_sensor(sens))
+    if power_factor_config := config.get(CONF_POWER_FACTOR):
+        sens = await sensor.new_sensor(power_factor_config)
+        cg.add(var.set_power_factor_sensor(sens))

--- a/tests/test3.yaml
+++ b/tests/test3.yaml
@@ -634,7 +634,11 @@ sensor:
     current:
       name: CSE7766 Current
     power:
-      name: CSE776 Power
+      name: CSE7766 Power
+    apparent_power:
+      name: CSE7766 Apparent Power
+    power_factor:
+      name: CSE7766 Power Factor
 
   - platform: fingerprint_grow
     fingerprint_count:


### PR DESCRIPTION
# What does this implement/fix?

Since moving the averaging out of cse7766, calculating power factor & apparent power is much easier and more accurate when done inside the component. This adds optional Power Factor and Apparent Power sensors.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes esphome/issues#5501

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#3643

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [X] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Assuming a Sonoff S31, Athom PG03V2, or similar

substitutions:
  update_interval: 30s

external_components:
  - source: "github://pr#6292"
    components: [ cse7766 ]

sensor:
  - platform: cse7766
    current:
      name: Current
      id: current
      filters:
        - throttle_average: ${update_interval}
    voltage:
      name: Voltage
      id: voltage
      filters:
        - throttle_average: ${update_interval}
    power:
      name: Power
      id: power
      filters:
        - throttle_average: ${update_interval}
    energy:
      name: Energy
      filters:
        - throttle: ${update_interval}
    apparent_power:
      name: Apparent Power
      filters:
        - throttle_average: ${update_interval}
    power_factor:
      name: Power Factor
      filters:
        - throttle_average: ${update_interval}
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
