### PR TITLE
Add log for wake word detection probability

### DIFF
--- a/esphome/components/micro_wake_word/micro_wake_word.cpp
+++ b/esphome/components/micro_wake_word/micro_wake_word.cpp
@@ -353,6 +353,7 @@ bool MicroWakeWord::detect_wake_word_() {
 
   // Detect the wake word if the sliding window average is above the cutoff
   if (sliding_window_average > this->probability_cutoff_) {
+    ESP_LOGD(TAG, "  Detection Probability: %.3f", sliding_window_average);
     this->ignore_windows_ = -MIN_SLICES_BEFORE_DETECTION;
     for (auto &prob : this->recent_streaming_probabilities_) {
       prob = 0;


### PR DESCRIPTION
Added log for the detection probability when a wake word is detected.


# What does this implement/fix?
When i get false positive activation, it's helpful to see on what probability the wake word was detected.
So i can modify the probability_cutoff accordingly for no longer getting these false activations.

This modifications adds a new line in the logs when the wake word is detected with micro wake word, the line is named : Detection Probability.

![image](https://github.com/esphome/esphome/assets/161524919/4ced8474-460f-4c86-bfca-c4823d096cd8)

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
micro_wake_word:
  model: okay_nabu
  probability_cutoff: 70%
  on_wake_word_detected:
    then:
      - voice_assistant.start:

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
