### PR TITLE
Make substitutions work for any YAML type, not only strings

### DIFF
--- a/esphome/components/substitutions/__init__.py
+++ b/esphome/components/substitutions/__init__.py
@@ -62,7 +62,7 @@ def _find_tokens(value):
         if name.startswith("{") and name.endswith("}"):
             name = name[1:-1]
 
-        yield match.group(1), (start - last_end, end - start)
+        yield name, (start - last_end, end - start)
         last_end = end
 
 

--- a/esphome/components/substitutions/__init__.py
+++ b/esphome/components/substitutions/__init__.py
@@ -79,13 +79,13 @@ def _expand_substitutions(substitutions, value, path, ignore_missing):
                     "->".join(str(x) for x in path),
                     name,
                 )
-            substituted += value[start_from : ignored_chars + length]
-            start_from = ignored_chars + length
+            substituted += value[start_from : start_from + ignored_chars + length]
+            start_from += ignored_chars + length
             continue
 
         sub = substitutions[name]
         if isinstance(sub, str):
-            substituted += value[start_from:ignored_chars] + sub
+            substituted += value[start_from : start_from + ignored_chars] + sub
             start_from += ignored_chars + length
             continue
 

--- a/esphome/yaml_util.py
+++ b/esphome/yaml_util.py
@@ -279,8 +279,6 @@ class ESPHomeLoaderMixin:
             if file is None:
                 raise yaml.MarkedYAMLError("Must include 'file'", node.start_mark)
             vars = fields.get("vars")
-            if vars:
-                vars = {k: str(v) for k, v in vars.items()}
             return file, vars
 
         def substitute_vars(config, vars):

--- a/tests/components/substitutions/included.yaml
+++ b/tests/components/substitutions/included.yaml
@@ -1,0 +1,5 @@
+sensor:
+  - id: $included_sensor_id
+    platform: template
+    name: Inlcuded sensor
+  - $included_sensor

--- a/tests/components/substitutions/test.all.yaml
+++ b/tests/components/substitutions/test.all.yaml
@@ -10,6 +10,17 @@ substitutions:
   double_nested_def: $nested_def
   name: Normal switch
   valid_interpolation: "1"
+  included_sensor_name: Included sensor 2
+
+packages:
+  included: !include
+    file: included.yaml
+    vars:
+      included_sensor_id: included_sensor
+      included_sensor:
+        name: $included_sensor_name
+        id: included_sensor2
+        platform: template
 
 switch:
   - $double_nested_def

--- a/tests/components/substitutions/test.all.yaml
+++ b/tests/components/substitutions/test.all.yaml
@@ -6,14 +6,17 @@ substitutions:
     platform: template
     name: $name
     optimistic: true
+  nested_def: $switch_def
+  double_nested_def: $nested_def
   name: Normal switch
   valid_interpolation: "1"
 
 switch:
+  - $double_nested_def
+  - $switch_def
   - platform: template
     name: $name
     optimistic: true
-  - $switch_def
   - platform: template
     name: Switch ${name} ${valid_interpolation} ${name} ${name}
     optimistic: true

--- a/tests/components/substitutions/test.all.yaml
+++ b/tests/components/substitutions/test.all.yaml
@@ -17,5 +17,3 @@ switch:
   - platform: template
     name: Switch ${name} ${valid_interpolation} ${name} ${name}
     optimistic: true
-
-host:

--- a/tests/components/substitutions/test.all.yaml
+++ b/tests/components/substitutions/test.all.yaml
@@ -15,7 +15,7 @@ switch:
   optimistic: True
 - $switch_def
 - platform: template
-  name: Switch $invalid_interpolation
+  name: Switch ${name} ${invalid} ${name} ${name}
   optimistic: True
 
 host:

--- a/tests/components/substitutions/test.all.yaml
+++ b/tests/components/substitutions/test.all.yaml
@@ -5,17 +5,17 @@ substitutions:
   switch_def:
     platform: template
     name: $name
-    optimistic: True
+    optimistic: true
   name: Normal switch
   valid_interpolation: "1"
 
 switch:
-- platform: template
-  name: $name
-  optimistic: True
-- $switch_def
-- platform: template
-  name: Switch ${name} ${invalid} ${name} ${name}
-  optimistic: True
+  - platform: template
+    name: $name
+    optimistic: true
+  - $switch_def
+  - platform: template
+    name: Switch ${name} ${valid_interpolation} ${name} ${name}
+    optimistic: true
 
 host:

--- a/tests/components/substitutions/test.all.yaml
+++ b/tests/components/substitutions/test.all.yaml
@@ -1,0 +1,21 @@
+esphome:
+  name: test
+
+substitutions:
+  switch_def:
+    platform: template
+    name: $name
+    optimistic: True
+  name: Normal switch
+  valid_interpolation: "1"
+
+switch:
+- platform: template
+  name: $name
+  optimistic: True
+- $switch_def
+- platform: template
+  name: Switch $invalid_interpolation
+  optimistic: True
+
+host:


### PR DESCRIPTION
# What does this implement/fix?

Substitutions only allow variables to be strings, this makes sense since they are implemented as string interpolation, however this is rather limiting for cases where YAML anchors cannot be used, like in anchors defined across files (as seen in [issues/1011](https://github.com/esphome/issues/issues/1011)). This PR allows substitutions of any other YAML types besides strings when the substitution takes over the entire field, meaning that no string interpolation is intended, just a straight replacement.

Here's an example of what is valid before this PR:

```yaml
substitutions:
  my_pin: D8

binary_sensor:
- platform: gpio
  name: My pin sensor
  pin: $my_pin
```

Now, say for example that instead we need our pin to be in pull up mode, or to be inverted, without this PR we would need to do something like this:

```yaml
substitutions:
  my_pin_number: D8
  my_pin_inverted: "True"

binary_sensor:
- platform: gpio
  name: My pin sensor
  pin:
    number: $my_pin_number
    inverted: $my_pin_inverted
```

This is because we can't directly substitute an entire pin schema, as it's a YAML record and not a plain string. With this patch, `my_pin` will be able to hold a pin schema like so:

```yaml
substitutions:
  my_pin: 
    number: D8
    inverted: True

binary_sensor:
- platform: gpio
  name: My pin sensor
  pin: $my_pin
```

Notice that the binary sensor definition is the same as in the first example, meaning that `my_pin` can now either be a pin number as we originally intended, or it can be a pin schema, without having to modify the sensor definition. However, if the definition of the sensor does string interpolation with `my_pin`, verification will fail since only strings can be interpolated.

```yaml
substitutions:
  my_pin: 
    number: D8
    inverted: True

binary_sensor:
- platform: gpio
  # this interpolation will break validation
  name: My pin sensor number $my_pin
  pin: $my_pin
```

In this case, we can be more specific while still using substitutions:

```yaml
substitutions:
  my_pin_number: D8
  my_pin:
    number: $my_pin_number
    inverted: True

binary_sensor:
- platform: gpio
  # works just fine, although it'd be nice to have a way to access fields like `${my_pin_number.number}`
  name: My pin sensor number $my_pin_number
  pin: $my_pin
```

Notice the nested substitution in `my_pin`, my understanding is that this "just works" without doing any changes to the other parts of the substitution code since it will substitute stuff until the result of the substitution is the same as what we started with, checking all the nested elements (this is what python does by default with `__eq__` for `OrderedDict`s, `list`s and `set`s).

I was thinking maybe adding some stringification or basic evaluation of algebraic expressions for numeric types, or merging for dicts, but that felt like it could derail into a jinja2 clone. I feel like this is a sensible middleground between implementation complexity and usefulness.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes 

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#3659

## Test Environment

Not device specific

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
host: {}
# Example config.yaml
substitutions:
  pin_data:
    number: D8
    inverted: True
binary_sensor:
  - platform: gpio
    name: Parametric pin
    pin: $pin_data
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
