### PR TITLE
auto load output for now

### DIFF
--- a/esphome/components/speed/fan/__init__.py
+++ b/esphome/components/speed/fan/__init__.py
@@ -14,6 +14,8 @@ from esphome.const import (
 
 from .. import speed_ns
 
+AUTO_LOAD = ["output"]
+
 SpeedFan = speed_ns.class_("SpeedFan", cg.Component, fan.Fan)
 
 CONFIG_SCHEMA = fan.FAN_SCHEMA.extend(


### PR DESCRIPTION
# What does this implement/fix?

The output is optional for the speed fan but there was a compile error if there were no outputs defined.
This is a temporary fix until the template fan in https://github.com/esphome/esphome/pull/6310 is added.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/5541

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#3654

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
