### PR TITLE
Add ADF I2C Bus

### DIFF
--- a/esphome/components/i2c/i2c_bus_esp_idf.h
+++ b/esphome/components/i2c/i2c_bus_esp_idf.h
@@ -1,7 +1,9 @@
 #pragma once
 
 #ifdef USE_ESP_IDF
-
+#include "esphome/core/defines.h"
+// TODO Remove this once the ADF code is in
+//#define USE_ESP_ADF
 #include "i2c_bus.h"
 #include "esphome/core/component.h"
 #include <driver/i2c.h>
@@ -42,6 +44,10 @@ class IDFI2CBus : public I2CBus, public Component {
   bool scl_pullup_enabled_;
   uint32_t frequency_;
   bool initialized_ = false;
+
+#ifdef USE_ESP_ADF
+  void *handle_;
+#endif
 };
 
 }  // namespace i2c


### PR DESCRIPTION
# What does this implement/fix?

This should fix  when it's finished.

When using ESP-ADF for audio stack, it uses its own I2C bus handling and driver install that's incompatible with ESPHome default `IDFI2CBus`.

This PR is about an implementation for IDFI2CBus that's using ESP-ADF's I2C primitives (should be the same as ESP-IOT I2C primitives, but untested), so it doesn't conflict with ESP-ADF's component.
 

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes [#5296](https://github.com/esphome/issues/issues/5296#issue-2056315667)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** 

No documentation updated since nothing changes from the user point of view. It's only when esp-adf is included (from pr #5230) that the definition changes.

## Test Environment

- [ ] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
None. Use github://esphome/firmware/voice-assistant/esp32-s3-box-3.yaml@main

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
