### PR TITLE
Fix return value in `core/automation.h`

### DIFF
--- a/esphome/core/automation.h
+++ b/esphome/core/automation.h
@@ -218,7 +218,7 @@ template<typename... Ts> class ActionList {
   /// Return the number of actions in this action list that are currently running.
   int num_running() {
     if (this->actions_begin_ == nullptr)
-      return false;
+      return 0;
     return this->actions_begin_->num_running_total();
   }
 


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->
A small change in the file automation.h,change the returning value from 'false' to '0'.
## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <[link to issue](https://github.com/esphome/issues/issues/5385)>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
