### PR TITLE
handling with the negative number in the sensor tmp102

### DIFF
--- a/esphome/components/tmp102/tmp102.cpp
+++ b/esphome/components/tmp102/tmp102.cpp
@@ -28,7 +28,7 @@ void TMP102Component::dump_config() {
 }
 
 void TMP102Component::update() {
-  uint16_t raw_temperature;
+  int16_t raw_temperature;
   if (this->write(&TMP102_REGISTER_TEMPERATURE, 1) != i2c::ERROR_OK) {
     this->status_set_warning();
     return;
@@ -39,7 +39,10 @@ void TMP102Component::update() {
     return;
   }
   raw_temperature = i2c::i2ctohs(raw_temperature);
-
+  //handling with the negative number
+  if (raw_temperature & 0x8000) {
+    raw_temperature |= 0xF000;
+  }
   raw_temperature = raw_temperature >> 4;
   float temperature = raw_temperature * TMP102_CONVERSION_FACTOR;
   ESP_LOGD(TAG, "Got Temperature=%.1f°C", temperature);


### PR DESCRIPTION
# What does this implement/fix?
handling with the negative number in the sensor tmp102
<!-- Quick description and explanation of changes -->

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <[link to issue](https://github.com/esphome/issues/issues/5189)>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
