### PR TITLE
x9c: fix off by 1 error

### DIFF
--- a/esphome/components/x9c/x9c.cpp
+++ b/esphome/components/x9c/x9c.cpp
@@ -49,17 +49,17 @@ void X9cOutput::setup() {
 
   if (this->initial_value_ <= 0.50) {
     this->trim_value(-101);  // Set min value (beyond 0)
-    this->trim_value((int) (this->initial_value_ * 100));
+    this->trim_value(static_cast<uint32_t>(roundf(this->initial_value_ * 100)));
   } else {
     this->trim_value(101);  // Set max value (beyond 100)
-    this->trim_value((int) (this->initial_value_ * 100) - 100);
+    this->trim_value(static_cast<uint32_t>(roundf(this->initial_value_ * 100) - 100));
   }
   this->pot_value_ = this->initial_value_;
   this->write_state(this->initial_value_);
 }
 
 void X9cOutput::write_state(float state) {
-  this->trim_value((int) ((state - this->pot_value_) * 100));
+  this->trim_value(static_cast<uint32_t>(roundf((state - this->pot_value_) * 100)));
   this->pot_value_ = state;
 }
 


### PR DESCRIPTION
# What does this implement/fix?

There is an off by 1 error which causes the wiper to be moved 1 less step than requested.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable): N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
substitutions:
  device_name: esphome-test
  friendly_name: ESPHome Test
  comment: ESPHome Test System

esphome:
  name: ${device_name}
  friendly_name: ${friendly_name}
  comment: ${comment}

esp8266:
  board: d1_mini

# Enable logging
logger:

# Enable Home Assistant API
api:
  encryption:
    key: "VGhpc0lzQUZha2VFbmNyeXB0aW9uS2V5WFhYWFhYWAo="

ota:

wifi:
  ssid: !secret wifi_ssid
  password: !secret wifi_password
  fast_connect: True # XXX remove me for production stuff

  # Enable fallback hotspot (captive portal) in case wifi connection fails
  ap:
    ssid: ${device_name}
    password: "12345678"

captive_portal:

fan:
  - platform: speed
    id: manual_fan_control
    output: x9c104_pot
    name: "Manual Fan Speed"

output:
  - platform: x9c
    id: x9c104_pot
    cs_pin: D8
    inc_pin: D6
    ud_pin: D7
    initial_value: 0.01
    min_power: 0.01
    max_power: 1.00

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
