### PR TITLE
Add toggle command to cover web_server endpoint

### DIFF
--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -748,6 +748,8 @@ void WebServer::handle_cover_request(AsyncWebServerRequest *request, const UrlMa
       call.set_command_close();
     } else if (match.method == "stop") {
       call.set_command_stop();
+    } else if (match.method == "toggle") {
+      call.set_command_toggle();
     } else if (match.method != "set") {
       request->send(404);
       return;


### PR DESCRIPTION
# What does this implement/fix?

Adds the `toggle` command to the web_server REST API for the cover component.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#3658

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
