### PR TITLE
Fix logger compile error on ESP32-C6

### DIFF
--- a/esphome/components/logger/logger_esp32.cpp
+++ b/esphome/components/logger/logger_esp32.cpp
@@ -129,7 +129,7 @@ void Logger::pre_setup() {
         this->uart_num_ = UART_NUM_2;
         break;
 #endif
-#if defined(USE_ESP32_VARIANT_ESP32S2) || defined(USE_ESP32_VARIANT_ESP32S3)
+#ifdef USE_LOGGER_USB_CDC
       case UART_SELECTION_USB_CDC:
         this->uart_num_ = -1;
         break;


### PR DESCRIPTION
# What does this implement/fix?

Logging was refactored with esphome/esphome#6167, but it broke compile on the ESP32-C6.

In `__init__.py`, any ESP32 with USB_CDC in UART_SELECTION_ESP32 will cause codegen to define USE_LOGGER_USB_CDC.
In `logger.h` the enum will get the value `UART_SELECTION_USB_CDC` due to `#ifdef USE_LOGGER_USB_CDC`.
But in `logger_esp32.cpp` the switch case doesn't test on `USE_LOGGER_USB_CDC`, but rather an old hard-coded list of specific ESP32 variants. This mismatch causes a compile error:

```
src/esphome/components/logger/logger_esp32.cpp: In member function 'void esphome::logger::Logger::pre_setup()':
src/esphome/components/logger/logger_esp32.cpp:120:12: error: enumeration value 'UART_SELECTION_USB_CDC' not handled in switch [-Werror=switch]
  120 |     switch (this->uart_) {
      |            ^
cc1plus: some warnings being treated as errors
```

This change updates `logger_esp32.cpp` to also test on the new `#ifdef USE_LOGGER_USB_CDC` value like the enum definition does, bringing the files back in sync.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
esphome:
  name: test
  friendly_name: test

esp32:
  board: esp32-c6-devkitc-1
  variant: esp32c6
  framework:
    type: esp-idf
    version: 5.1.2
    platform_version: 6.5.0 # Need at least 6.4 for ESP32-C6

logger:

api:

ota:

wifi:
  ssid: !secret wifi_ssid
  password: !secret wifi_password
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
