### PR TITLE
add possibility to provide different conversion times for Bus Voltage…

### DIFF
--- a/esphome/components/ina226/ina226.cpp
+++ b/esphome/components/ina226/ina226.cpp
@@ -55,10 +55,10 @@ void INA226Component::setup() {
   config.avg_samples = this->adc_avg_samples_;
 
   // Bus Voltage Conversion Time VBUSCT Bit Settings [8:6] (100 -> 1.1ms, 111 -> 8.244 ms)
-  config.bus_voltage_conversion_time = this->adc_time_;
+  config.bus_voltage_conversion_time = this->adc_time_voltage_;
 
   // Shunt Voltage Conversion Time VSHCT Bit Settings [5:3] (100 -> 1.1ms, 111 -> 8.244 ms)
-  config.shunt_voltage_conversion_time = this->adc_time_;
+  config.shunt_voltage_conversion_time = this->adc_time_current_;
 
   // Mode Settings [2:0] Combinations (111 -> Shunt and Bus, Continuous)
   config.mode = 0b111;
@@ -93,7 +93,8 @@ void INA226Component::dump_config() {
   }
   LOG_UPDATE_INTERVAL(this);
 
-  ESP_LOGCONFIG(TAG, "  ADC Conversion Time: %d", INA226_ADC_TIMES[this->adc_time_ & 0b111]);
+  ESP_LOGCONFIG(TAG, "  ADC Conversion Time Bus Voltage: %d", INA226_ADC_TIMES[this->adc_time_voltage_ & 0b111]);
+  ESP_LOGCONFIG(TAG, "  ADC Conversion Time Shunt Voltage: %d", INA226_ADC_TIMES[this->adc_time_current_ & 0b111]);
   ESP_LOGCONFIG(TAG, "  ADC Averaging Samples: %d", INA226_ADC_AVG_SAMPLES[this->adc_avg_samples_ & 0b111]);
 
   LOG_SENSOR("  ", "Bus Voltage", this->bus_voltage_sensor_);

--- a/esphome/components/ina226/ina226.h
+++ b/esphome/components/ina226/ina226.h
@@ -50,7 +50,8 @@ class INA226Component : public PollingComponent, public i2c::I2CDevice {
 
   void set_shunt_resistance_ohm(float shunt_resistance_ohm) { shunt_resistance_ohm_ = shunt_resistance_ohm; }
   void set_max_current_a(float max_current_a) { max_current_a_ = max_current_a; }
-  void set_adc_time(AdcTime time) { adc_time_ = time; }
+  void set_adc_time_voltage(AdcTime time) { adc_time_voltage_ = time; }
+  void set_adc_time_current(AdcTime time) { adc_time_current_ = time; }
   void set_adc_avg_samples(AdcAvgSamples samples) { adc_avg_samples_ = samples; }
 
   void set_bus_voltage_sensor(sensor::Sensor *bus_voltage_sensor) { bus_voltage_sensor_ = bus_voltage_sensor; }
@@ -61,7 +62,8 @@ class INA226Component : public PollingComponent, public i2c::I2CDevice {
  protected:
   float shunt_resistance_ohm_;
   float max_current_a_;
-  AdcTime adc_time_{AdcTime::ADC_TIME_1100US};
+  AdcTime adc_time_voltage_{AdcTime::ADC_TIME_1100US};
+  AdcTime adc_time_current_{AdcTime::ADC_TIME_1100US};
   AdcAvgSamples adc_avg_samples_{AdcAvgSamples::ADC_AVG_SAMPLES_4};
   uint32_t calibration_lsb_;
   sensor::Sensor *bus_voltage_sensor_{nullptr};

--- a/esphome/components/ina226/sensor.py
+++ b/esphome/components/ina226/sensor.py
@@ -15,7 +15,8 @@ from esphome.const import (
     STATE_CLASS_MEASUREMENT,
     UNIT_VOLT,
     UNIT_AMPERE,
-    UNIT_WATT, CONF_VOLTAGE,
+    UNIT_WATT,
+    CONF_VOLTAGE,
 )
 
 DEPENDENCIES = ["i2c"]

--- a/esphome/components/ina226/sensor.py
+++ b/esphome/components/ina226/sensor.py
@@ -21,7 +21,8 @@ from esphome.const import (
 DEPENDENCIES = ["i2c"]
 
 CONF_ADC_AVERAGING = "adc_averaging"
-CONF_ADC_TIME = "adc_time"
+CONF_ADC_TIME_V = "adc_time_voltage"
+CONF_ADC_TIME_C = "adc_time_current"
 
 ina226_ns = cg.esphome_ns.namespace("ina226")
 INA226Component = ina226_ns.class_(
@@ -92,7 +93,8 @@ CONFIG_SCHEMA = (
             cv.Optional(CONF_MAX_CURRENT, default=3.2): cv.All(
                 cv.current, cv.Range(min=0.0)
             ),
-            cv.Optional(CONF_ADC_TIME, default="1100 us"): validate_adc_time,
+            cv.Optional(CONF_ADC_TIME_V, default="1100 us"): validate_adc_time,
+            cv.Optional(CONF_ADC_TIME_C, default="1100 us"): validate_adc_time,
             cv.Optional(CONF_ADC_AVERAGING, default=4): cv.enum(
                 ADC_AVG_SAMPLES, int=True
             ),
@@ -110,7 +112,8 @@ async def to_code(config):
 
     cg.add(var.set_shunt_resistance_ohm(config[CONF_SHUNT_RESISTANCE]))
     cg.add(var.set_max_current_a(config[CONF_MAX_CURRENT]))
-    cg.add(var.set_adc_time(config[CONF_ADC_TIME]))
+    cg.add(var.set_adc_time_voltage(config[CONF_ADC_TIME_V]))
+    cg.add(var.set_adc_time_current(config[CONF_ADC_TIME_C]))
     cg.add(var.set_adc_avg_samples(config[CONF_ADC_AVERAGING]))
 
     if CONF_BUS_VOLTAGE in config:

--- a/esphome/components/ina226/sensor.py
+++ b/esphome/components/ina226/sensor.py
@@ -15,14 +15,13 @@ from esphome.const import (
     STATE_CLASS_MEASUREMENT,
     UNIT_VOLT,
     UNIT_AMPERE,
-    UNIT_WATT,
+    UNIT_WATT, CONF_VOLTAGE,
 )
 
 DEPENDENCIES = ["i2c"]
 
 CONF_ADC_AVERAGING = "adc_averaging"
-CONF_ADC_TIME_VOLTAGE = "adc_time_voltage"
-CONF_ADC_TIME_CURRENT = "adc_time_current"
+CONF_ADC_TIME = "adc_time"
 
 ina226_ns = cg.esphome_ns.namespace("ina226")
 INA226Component = ina226_ns.class_(
@@ -93,8 +92,15 @@ CONFIG_SCHEMA = (
             cv.Optional(CONF_MAX_CURRENT, default=3.2): cv.All(
                 cv.current, cv.Range(min=0.0)
             ),
-            cv.Optional(CONF_ADC_TIME_VOLTAGE, default="1100 us"): validate_adc_time,
-            cv.Optional(CONF_ADC_TIME_CURRENT, default="1100 us"): validate_adc_time,
+            cv.Optional(CONF_ADC_TIME, default="1100 us"): cv.Any(
+                validate_adc_time,
+                cv.Schema(
+                    {
+                        cv.Required(CONF_VOLTAGE): validate_adc_time,
+                        cv.Required(CONF_CURRENT): validate_adc_time,
+                    }
+                ),
+            ),
             cv.Optional(CONF_ADC_AVERAGING, default=4): cv.enum(
                 ADC_AVG_SAMPLES, int=True
             ),
@@ -112,8 +118,15 @@ async def to_code(config):
 
     cg.add(var.set_shunt_resistance_ohm(config[CONF_SHUNT_RESISTANCE]))
     cg.add(var.set_max_current_a(config[CONF_MAX_CURRENT]))
-    cg.add(var.set_adc_time_voltage(config[CONF_ADC_TIME_VOLTAGE]))
-    cg.add(var.set_adc_time_current(config[CONF_ADC_TIME_CURRENT]))
+
+    adc_time_config = config[CONF_ADC_TIME]
+    if isinstance(adc_time_config, dict):
+        cg.add(var.set_adc_time_voltage(adc_time_config[CONF_VOLTAGE]))
+        cg.add(var.set_adc_time_current(adc_time_config[CONF_CURRENT]))
+    else:
+        cg.add(var.set_adc_time_voltage(adc_time_config))
+        cg.add(var.set_adc_time_current(adc_time_config))
+
     cg.add(var.set_adc_avg_samples(config[CONF_ADC_AVERAGING]))
 
     if CONF_BUS_VOLTAGE in config:

--- a/esphome/components/ina226/sensor.py
+++ b/esphome/components/ina226/sensor.py
@@ -21,8 +21,8 @@ from esphome.const import (
 DEPENDENCIES = ["i2c"]
 
 CONF_ADC_AVERAGING = "adc_averaging"
-CONF_ADC_TIME_V = "adc_time_voltage"
-CONF_ADC_TIME_C = "adc_time_current"
+CONF_ADC_TIME_VOLTAGE = "adc_time_voltage"
+CONF_ADC_TIME_CURRENT = "adc_time_current"
 
 ina226_ns = cg.esphome_ns.namespace("ina226")
 INA226Component = ina226_ns.class_(
@@ -93,8 +93,8 @@ CONFIG_SCHEMA = (
             cv.Optional(CONF_MAX_CURRENT, default=3.2): cv.All(
                 cv.current, cv.Range(min=0.0)
             ),
-            cv.Optional(CONF_ADC_TIME_V, default="1100 us"): validate_adc_time,
-            cv.Optional(CONF_ADC_TIME_C, default="1100 us"): validate_adc_time,
+            cv.Optional(CONF_ADC_TIME_VOLTAGE, default="1100 us"): validate_adc_time,
+            cv.Optional(CONF_ADC_TIME_CURRENT, default="1100 us"): validate_adc_time,
             cv.Optional(CONF_ADC_AVERAGING, default=4): cv.enum(
                 ADC_AVG_SAMPLES, int=True
             ),
@@ -112,8 +112,8 @@ async def to_code(config):
 
     cg.add(var.set_shunt_resistance_ohm(config[CONF_SHUNT_RESISTANCE]))
     cg.add(var.set_max_current_a(config[CONF_MAX_CURRENT]))
-    cg.add(var.set_adc_time_voltage(config[CONF_ADC_TIME_V]))
-    cg.add(var.set_adc_time_current(config[CONF_ADC_TIME_C]))
+    cg.add(var.set_adc_time_voltage(config[CONF_ADC_TIME_VOLTAGE]))
+    cg.add(var.set_adc_time_current(config[CONF_ADC_TIME_CURRENT]))
     cg.add(var.set_adc_avg_samples(config[CONF_ADC_AVERAGING]))
 
     if CONF_BUS_VOLTAGE in config:


### PR DESCRIPTION
… and Shunt Voltage (Current)

# What does this implement/fix?

The INA266 provides the possibility to set different conversion times for bus voltage and shunt voltage.
I suggest we should also do that (and I need it. :-p)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other (improvement)


**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#3661

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
adc_time_voltage: 140us
adc_time_current: 332us

```yaml
sensor:
  - platform: ina226
    address: 0x40
    shunt_resistance: 0.1 ohm
    adc_time_voltage: 140us
    adc_time_current: 332us
    current:
      name: "INA226 Current"
    power:
      name: "INA226 Power"
    bus_voltage:
      name: "INA226 Bus Voltage"
    shunt_voltage:
      name: "INA226 Shunt Voltage"
    max_current: 3.2A
    update_interval: 60s

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
