### PR TITLE
fix: modbus_textsensor response is too long in some cases

### DIFF
--- a/esphome/components/modbus_controller/text_sensor/modbus_textsensor.cpp
+++ b/esphome/components/modbus_controller/text_sensor/modbus_textsensor.cpp
@@ -13,10 +13,10 @@ void ModbusTextSensor::dump_config() { LOG_TEXT_SENSOR("", "Modbus Controller Te
 
 void ModbusTextSensor::parse_and_publish(const std::vector<uint8_t> &data) {
   std::ostringstream output;
-  uint8_t max_items = this->response_bytes;
+  uint8_t items_left = this->response_bytes;
   uint8_t index = this->offset;
   char buffer[4];
-  while ((max_items != 0) && index < data.size()) {
+  while ((items_left > 0) && index < data.size()) {
     uint8_t b = data[index];
     switch (this->encode_) {
       case RawEncoding::HEXBYTES:
@@ -33,7 +33,7 @@ void ModbusTextSensor::parse_and_publish(const std::vector<uint8_t> &data) {
         output << (char) b;
         break;
     }
-
+    items_left--;
     index++;
   }
 


### PR DESCRIPTION
# What does this implement/fix?

modbus_controller, text_sensor: fix: the component does not honor response_size config parameter. if modbus reads series of data for optimizations, text sensor does not limit output to the sensor size and returns full string of unrelated registers

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>
not reported

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [X] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
  - platform: modbus_controller
    name: "Program version"
    register_type: holding
    address: 0x00
    response_size: 2
    raw_encode: COMMA

  - platform: modbus_controller
    name: "Serial Number"
    register_type: holding
    address: 0x01
    response_size: 2
    raw_encode: HEXBYTES
```



## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
