### PR TITLE
Allow setting htop for ledc

### DIFF
--- a/esphome/components/ledc/ledc_output.h
+++ b/esphome/components/ledc/ledc_output.h
@@ -19,6 +19,7 @@ class LEDCOutput : public output::FloatOutput, public Component {
 
   void set_channel(uint8_t channel) { this->channel_ = channel; }
   void set_frequency(float frequency) { this->frequency_ = frequency; }
+  void set_phase_angle(float angle) { this->phase_angle_ = angle; }
   /// Dynamically change frequency at runtime
   void update_frequency(float frequency) override;
 
@@ -35,6 +36,7 @@ class LEDCOutput : public output::FloatOutput, public Component {
   InternalGPIOPin *pin_;
   uint8_t channel_{};
   uint8_t bit_depth_{};
+  float phase_angle_{0.0f};
   float frequency_{};
   float duty_{0.0f};
   bool initialized_ = false;

--- a/esphome/components/ledc/output.py
+++ b/esphome/components/ledc/output.py
@@ -3,6 +3,7 @@ from esphome.components import output
 import esphome.config_validation as cv
 import esphome.codegen as cg
 from esphome.const import (
+    CONF_PHASE_ANGLE,
     CONF_CHANNEL,
     CONF_FREQUENCY,
     CONF_ID,
@@ -46,6 +47,9 @@ CONFIG_SCHEMA = output.FLOAT_OUTPUT_SCHEMA.extend(
         cv.Required(CONF_PIN): pins.internal_gpio_output_pin_schema,
         cv.Optional(CONF_FREQUENCY, default="1kHz"): cv.frequency,
         cv.Optional(CONF_CHANNEL): cv.int_range(min=0, max=15),
+        cv.Optional(CONF_PHASE_ANGLE): cv.All(
+            cv.only_with_esp_idf, cv.angle, cv.float_range(min=0.0, max=360.0)
+        ),
     }
 ).extend(cv.COMPONENT_SCHEMA)
 
@@ -58,6 +62,8 @@ async def to_code(config):
     if CONF_CHANNEL in config:
         cg.add(var.set_channel(config[CONF_CHANNEL]))
     cg.add(var.set_frequency(config[CONF_FREQUENCY]))
+    if CONF_PHASE_ANGLE in config:
+        cg.add(var.set_phase_angle(config[CONF_PHASE_ANGLE]))
 
 
 @automation.register_action(

--- a/tests/components/cwww/test.esp32-c3-idf.yaml
+++ b/tests/components/cwww/test.esp32-c3-idf.yaml
@@ -2,9 +2,12 @@ output:
   - platform: ledc
     id: light_output_1
     pin: 1
+    channel: 0
   - platform: ledc
     id: light_output_2
     pin: 2
+    channel: 1
+    phase_angle: 180°
 
 light:
   - platform: cwww

--- a/tests/components/cwww/test.esp32-idf.yaml
+++ b/tests/components/cwww/test.esp32-idf.yaml
@@ -2,9 +2,12 @@ output:
   - platform: ledc
     id: light_output_1
     pin: 12
+    channel: 0
   - platform: ledc
     id: light_output_2
     pin: 13
+    channel: 1
+    phase_angle: 180°
 
 light:
   - platform: cwww


### PR DESCRIPTION
# What does this implement/fix?

This allows for setting of the htop register in the ledc component.
The setting is given as an angle in the range of 0-360°.

This only works for the esp-idf framework, because the arduino framework does not expose the htop register.

This is useful for example when using the wwwc component to offset the warm and cold leds.
Sadly this is not so useful for RGB or RGBW leds, because the timing between timers is inconsistent.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes esphome/feature-requests#2624

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#3671

## Test Environment

- [X] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
output:
  - platform: ledc
    pin: 32
    id: led_warm
    channel: 0
  - platform: ledc
    pin: 33
    id: led_cold
    channel: 1
    phase_angle: 180°

light:
  - platform: cwww
    name: "Phase Light"
    id: light1
    cold_white: led_cold
    warm_white: led_warm
    cold_white_color_temperature: 6000 K
    warm_white_color_temperature: 2300 K
    constant_brightness: true

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
