### PR TITLE
Default ILI9xxx SPI speed now works with ESP-IDF

### DIFF
--- a/esphome/components/ili9xxx/display.py
+++ b/esphome/components/ili9xxx/display.py
@@ -152,7 +152,7 @@ CONFIG_SCHEMA = cv.All(
         }
     )
     .extend(cv.polling_component_schema("1s"))
-    .extend(spi.spi_device_schema(False, "40MHz")),
+    .extend(spi.spi_device_schema(False, "20MHz")),
     cv.has_at_most_one_key(CONF_PAGES, CONF_LAMBDA),
     _validate,
 )


### PR DESCRIPTION
# What does this implement/fix?

Default SPI speed (40 MHz) for ILI9xxx gav the following message:
```
E (296) spi_hal: spi_hal_cal_clock_conf(102): When work in full-duplex mode at frequency > 26.7MHz, device cannot read correct data.
[08:40:58]Try to use IOMUX pins to increase the frequency limit, or use the half duplex mode.
[08:40:58]Please note the SPI master can only work at divisors of 80MHz, and the driver always tries to find the closest frequency to your configuration.
[08:40:58]Specify ``SPI_DEVICE_NO_DUMMY`` to ignore this checking. Then you can output data at higher speed, or read data at you
[08:40:58][D][esp-idf:000]: E (335) spi_master: spi_bus_add_device(362): assigned clock speed not supported
```

Changed to 20MHz
## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
esphome:
  name: ilidisplay

esp32:
  board: esp32dev
  framework:
    type: esp-idf

logger:

spi:
  clk_pin: 18
  miso_pin: 12
  mosi_pin: 23
  interface: any


display:
  - platform: ili9xxx
    model: TFT_2.4
    cs_pin: 27
    dc_pin: 32
    reset_pin: 14

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
