### PR TITLE
ILI9XXX: Lazily allocate buffer

### DIFF
--- a/esphome/components/ili9xxx/ili9xxx_display.cpp
+++ b/esphome/components/ili9xxx/ili9xxx_display.cpp
@@ -42,7 +42,9 @@ void ILI9XXXDisplay::setup() {
   this->y_low_ = this->height_;
   this->x_high_ = 0;
   this->y_high_ = 0;
+}
 
+void ILI9XXXDisplay::alloc_buffer_() {
   if (this->buffer_color_mode_ == BITS_16) {
     this->init_internal_(this->get_buffer_length_() * 2);
     if (this->buffer_ != nullptr) {
@@ -107,6 +109,8 @@ void ILI9XXXDisplay::dump_config() {
 float ILI9XXXDisplay::get_setup_priority() const { return setup_priority::HARDWARE; }
 
 void ILI9XXXDisplay::fill(Color color) {
+  if (!this->check_buffer_())
+    return;
   uint16_t new_color = 0;
   this->x_low_ = 0;
   this->y_low_ = 0;
@@ -124,7 +128,6 @@ void ILI9XXXDisplay::fill(Color color) {
           // Upper and lower is equal can use quicker memset operation. Takes ~20ms.
           memset(this->buffer_, (uint8_t) new_color, buffer_length_16_bits);
         } else {
-          // Slower set of both buffers. Takes ~30ms.
           for (uint32_t i = 0; i < buffer_length_16_bits; i = i + 2) {
             this->buffer_[i] = (uint8_t) (new_color >> 8);
             this->buffer_[i + 1] = (uint8_t) new_color;
@@ -144,6 +147,8 @@ void HOT ILI9XXXDisplay::draw_absolute_pixel_internal(int x, int y, Color color)
   if (x >= this->get_width_internal() || x < 0 || y >= this->get_height_internal() || y < 0) {
     return;
   }
+  if (!this->check_buffer_())
+    return;
   uint32_t pos = (y * width_) + x;
   uint16_t new_color;
   bool updated = false;

--- a/esphome/components/ili9xxx/ili9xxx_display.h
+++ b/esphome/components/ili9xxx/ili9xxx_display.h
@@ -86,6 +86,14 @@ class ILI9XXXDisplay : public display::DisplayBuffer,
                       display::ColorBitness bitness, bool big_endian, int x_offset, int y_offset, int x_pad) override;
 
  protected:
+  inline bool check_buffer_() {
+    if (this->buffer_ == nullptr) {
+      this->alloc_buffer_();
+      return !this->is_failed();
+    }
+    return true;
+  }
+
   void draw_absolute_pixel_internal(int x, int y, Color color) override;
   void setup_pins_();
 
@@ -116,6 +124,7 @@ class ILI9XXXDisplay : public display::DisplayBuffer,
   void end_command_();
   void start_data_();
   void end_data_();
+  void alloc_buffer_();
 
   GPIOPin *reset_pin_{nullptr};
   GPIOPin *dc_pin_{nullptr};


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

The ili9xxx driver allocates a screen-size buffer to draw into. This is required for pixel-by-pixel drawing, but a renderer that uses only the direct draw (`draw_pixels_at()`) function does not need this.

By deferring the buffer allocation until it is needed (which may be never) this allows the driver to run on chips without PSRAM since the memory requirement is less.

Since this is a run-time change only, no additional CI tests are applicable, and no doc changes are required since it is transparent to the user.

The motivation for this is primarily the implementation of LVGL which can operate with a buffer less than the full screen size. It will have negligible impact on other use cases.

The code has been extensively tested in the LVGL development branch. It enables e.g. LVGL to run on a GC9A01A display on an ESP32-C3.


![PXL_20240311_022429134 MP](https://github.com/esphome/esphome/assets/2366188/00cf5f9e-30ba-4f3a-a242-5ae18bc43226)



## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [x] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
