### PR TITLE
SPI schema now uses typed_schema with `type` key 

### DIFF
--- a/esphome/components/spi/__init__.py
+++ b/esphome/components/spi/__init__.py
@@ -271,31 +271,31 @@ SPI_SCHEMA = cv.All(
     cv.Schema(
         {
             cv.GenerateID(): cv.declare_id(SPIComponent),
+            cv.Required(CONF_CLK_PIN): clk_pin_validator,
             cv.Optional(CONF_MISO_PIN): pins.gpio_input_pin_schema,
             cv.Optional(CONF_MOSI_PIN): pins.gpio_output_pin_schema,
             cv.Optional(CONF_FORCE_SW): cv.invalid(
                 "force_sw is deprecated - use interface: software"
             ),
-            cv.Required(CONF_CLK_PIN): clk_pin_validator,
-            cv.Optional(CONF_INTERFACE, default="hardware"): cv.one_of(
-                *sum(get_hw_interface_list(), ["software", "any", "hardware"]),
+            cv.Optional(CONF_INTERFACE, default="any"): cv.one_of(
+                *sum(get_hw_interface_list(), ["software", "hardware", "any"]),
                 lower=True,
             ),
         }
     ),
-    cv.only_on([PLATFORM_ESP32, PLATFORM_ESP8266, PLATFORM_RP2040]),
     cv.has_at_least_one_key(CONF_MISO_PIN, CONF_MOSI_PIN),
+    cv.only_on([PLATFORM_ESP32, PLATFORM_ESP8266, PLATFORM_RP2040]),
 )
 
 SPI_QUAD_SCHEMA = cv.All(
     cv.Schema(
         {
             cv.GenerateID(): cv.declare_id(QuadSPIComponent),
+            cv.Required(CONF_CLK_PIN): clk_pin_validator,
             cv.Required(CONF_DATA_PINS): cv.All(
                 cv.ensure_list(pins.internal_gpio_output_pin_number),
                 cv.Length(min=4, max=4),
             ),
-            cv.Required(CONF_CLK_PIN): clk_pin_validator,
             cv.Optional(CONF_INTERFACE, default="hardware"): cv.one_of(
                 *sum(get_hw_interface_list(), ["hardware"]),
                 lower=True,

--- a/tests/components/spi/test.esp32-s3-idf.yaml
+++ b/tests/components/spi/test.esp32-s3-idf.yaml
@@ -20,4 +20,4 @@ spi:
     clk_pin: 8
     mosi_pin: 9
     interface: any
-    
+

--- a/tests/components/spi/test.esp32-s3-idf.yaml
+++ b/tests/components/spi/test.esp32-s3-idf.yaml
@@ -1,0 +1,23 @@
+spi:
+  - id: spi_id_1
+    type: single
+    clk_pin:
+      number: GPIO7
+      allow_other_uses: false
+    mosi_pin: GPIO6
+    interface: hardware
+  - id: quad_spi
+    type: quad
+    clk_pin: 47
+    interface: spi3
+    data_pins:
+      - number: 40
+        allow_other_uses: false
+      - 41
+      - 42
+      - 43
+  - id: spi_id_3
+    clk_pin: 8
+    mosi_pin: 9
+    interface: any
+    

--- a/tests/test8.1.yaml
+++ b/tests/test8.1.yaml
@@ -21,22 +21,6 @@ debug:
 
 psram:
 
-spi:
-  - id: spi_id_1
-    clk_pin:
-      number: GPIO7
-      allow_other_uses: false
-    mosi_pin: GPIO6
-    interface: any
-  - id: quad_spi
-    clk_pin: 47
-    data_pins:
-      - number: 40
-        allow_other_uses: false
-      - 41
-      - 42
-      - 43
-
 spi_device:
   id: spidev
   data_rate: 2MHz

--- a/tests/test8.1.yaml
+++ b/tests/test8.1.yaml
@@ -21,6 +21,14 @@ debug:
 
 psram:
 
+spi:
+  - id: spi_id_1
+    type: single
+    clk_pin:
+      number: GPIO7
+      allow_other_uses: false
+    mosi_pin: GPIO6
+    interface: hardware
 spi_device:
   id: spidev
   data_rate: 2MHz


### PR DESCRIPTION

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

SPI schema now uses typed_schema with `type` key to choose between `single` and `quad`. This improves
error reporting.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#3676
## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
spi:
  - id: spi_id_1
    clk_pin:
      number: GPIO7
      allow_other_uses: false
    mosi_pin: GPIO6
    interface: hardware
  - id: quad_spi
    type: quad
    clk_pin: 47
    interface: spi3
    data_pins:
      - number: 40
        allow_other_uses: false
      - 41
      - 42
      - 43
  - id: spi_id_3
    clk_pin: 8
    mosi_pin: 9
    interface: any
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
