### PR TITLE
Add getter for font glyph data

### DIFF
--- a/esphome/components/font/font.h
+++ b/esphome/components/font/font.h
@@ -30,6 +30,8 @@ class Glyph {
 
   void scan_area(int *x1, int *y1, int *width, int *height) const;
 
+  const GlyphData *get_glyph_data() const { return this->glyph_data_; }
+
  protected:
   friend Font;
 


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

This slipped through the cracks in the recent font PR. Just adds a public getter for the internal glyph data, will be needed for LVGL.


## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
