### PR TITLE
Require reset_pin for certain waveshare_epaper models in YAML validation

### DIFF
--- a/esphome/components/waveshare_epaper/display.py
+++ b/esphome/components/waveshare_epaper/display.py
@@ -131,6 +131,8 @@ MODELS = {
     "1.54in-m5coreink-m09": ("c", GDEW0154M09),
 }
 
+RESET_PIN_REQUIRED_MODELS = ("2.13inv2", "2.13in-ttgo-b74")
+
 
 def validate_full_update_every_only_types_ac(value):
     if CONF_FULL_UPDATE_EVERY not in value:
@@ -145,6 +147,14 @@ def validate_full_update_every_only_types_ac(value):
             + ", ".join(full_models)
         )
     return value
+
+
+def validate_reset_pin_required(config):
+    if config[CONF_MODEL] in RESET_PIN_REQUIRED_MODELS and CONF_RESET_PIN not in config:
+        raise cv.Invalid(
+            f"'{CONF_RESET_PIN}' is required for model {config[CONF_MODEL]}"
+        )
+    return config
 
 
 CONFIG_SCHEMA = cv.All(
@@ -165,6 +175,7 @@ CONFIG_SCHEMA = cv.All(
     .extend(cv.polling_component_schema("1s"))
     .extend(spi.spi_device_schema()),
     validate_full_update_every_only_types_ac,
+    validate_reset_pin_required,
     cv.has_at_most_one_key(CONF_PAGES, CONF_LAMBDA),
 )
 

--- a/tests/components/waveshare_epaper/test.esp32.yaml
+++ b/tests/components/waveshare_epaper/test.esp32.yaml
@@ -29,6 +29,24 @@ display:
     lambda: |-
       it.rectangle(0, 0, it.get_width(), it.get_height());
   - platform: waveshare_epaper
+    model: 2.13in-ttgo-b74
+    spi_id: spi_id_1
+    cs_pin:
+      allow_other_uses: true
+      number: GPIO25
+    dc_pin:
+      allow_other_uses: true
+      number: GPIO26
+    busy_pin:
+      allow_other_uses: true
+      number: GPIO27
+    reset_pin:
+      allow_other_uses: true
+      number: GPIO32
+    full_update_every: 30
+    lambda: |-
+      it.rectangle(0, 0, it.get_width(), it.get_height());
+  - platform: waveshare_epaper
     model: 2.90in
     spi_id: spi_id_1
     cs_pin:


### PR DESCRIPTION
# What does this implement/fix?

Following up on https://github.com/esphome/esphome/pull/6337#discussion_r1520263776, this adds a YAML validation check that `reset_pin` is set on the two models where this is required.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** https://github.com/esphome/esphome/pull/6337#discussion_r1520263776

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
