### PR TITLE
Make USE_HOST compilable on msys2

### DIFF
--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -12,9 +12,11 @@
 #include <cstring>
 
 #ifdef USE_HOST
+#ifndef _WIN32
 #include <net/if.h>
 #include <netinet/in.h>
 #include <sys/ioctl.h>
+#endif
 #include <unistd.h>
 #endif
 #if defined(USE_ESP8266)


### PR DESCRIPTION
# What does this implement/fix?

Makes it possible to compile parts of esphome when using `USE_HOST` from within msys2. This is used by https://github.com/maruel/ellee to simulate an `addressable_lambda` effect at the console.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):**

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [x] USE_HOST :)

## Example entry for `config.yaml`:

```yaml
light:
  - effects:
      - addressable_lambda:
          lambda: |-
            const auto v = half_sin8(128);
            printf("%d\n", v);
            exit(0);
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
