### PR TITLE
microWakeWord - add new ops and small improvements

### DIFF
--- a/esphome/components/micro_wake_word/micro_wake_word.cpp
+++ b/esphome/components/micro_wake_word/micro_wake_word.cpp
@@ -93,11 +93,18 @@ int MicroWakeWord::read_microphone_() {
     return 0;
   }
 
-  size_t bytes_written = this->ring_buffer_->write((void *) this->input_buffer_, bytes_read);
-  if (bytes_written != bytes_read) {
-    ESP_LOGW(TAG, "Failed to write some data to ring buffer (written=%d, expected=%d)", bytes_written, bytes_read);
+  size_t bytes_free = this->ring_buffer_->free();
+
+  if (bytes_free < bytes_read) {
+    ESP_LOGW(TAG,
+             "Not enough free bytes in ring buffer to store incoming audio data (free bytes=%d, incoming bytes=%d). "
+             "Resetting the ring buffer. Wake word detection accuracy will be reduced.",
+             bytes_free, bytes_read);
+
+    this->ring_buffer_->reset();
   }
-  return bytes_written;
+
+  return this->ring_buffer_->write((void *) this->input_buffer_, bytes_read);
 }
 
 void MicroWakeWord::loop() {
@@ -206,12 +213,6 @@ bool MicroWakeWord::initialize_models() {
     return false;
   }
 
-  this->preprocessor_stride_buffer_ = audio_samples_allocator.allocate(HISTORY_SAMPLES_TO_KEEP);
-  if (this->preprocessor_stride_buffer_ == nullptr) {
-    ESP_LOGE(TAG, "Could not allocate the audio preprocessor's stride buffer.");
-    return false;
-  }
-
   this->preprocessor_model_ = tflite::GetModel(G_AUDIO_PREPROCESSOR_INT8_TFLITE);
   if (this->preprocessor_model_->version() != TFLITE_SCHEMA_VERSION) {
     ESP_LOGE(TAG, "Wake word's audio preprocessor model's schema is not supported");
@@ -225,7 +226,7 @@ bool MicroWakeWord::initialize_models() {
   }
 
   static tflite::MicroMutableOpResolver<18> preprocessor_op_resolver;
-  static tflite::MicroMutableOpResolver<14> streaming_op_resolver;
+  static tflite::MicroMutableOpResolver<15> streaming_op_resolver;
 
   if (!this->register_preprocessor_ops_(preprocessor_op_resolver))
     return false;
@@ -371,23 +372,6 @@ void MicroWakeWord::set_sliding_window_average_size(size_t size) {
 bool MicroWakeWord::slice_available_() {
   size_t available = this->ring_buffer_->available();
 
-  size_t free = this->ring_buffer_->free();
-
-  if (free < NEW_SAMPLES_TO_GET * sizeof(int16_t)) {
-    // If the ring buffer is within one audio slice of being full, then wake word detection will have issues.
-    // If this is constantly occuring, then some possibilities why are
-    //  1) there are too many other slow components configured
-    //  2) the ESP32 isn't fast enough; e.g., an ESP32 is much slower than an ESP32-S3 at inferences.
-    //  3) the model is too large
-    //  4) the model uses operations that are not optimized
-    ESP_LOGW(TAG,
-             "Audio buffer is nearly full. Wake word detection may be less accurate and have slower reponse times. "
-#if !defined(USE_ESP32_VARIANT_ESP32S3)
-             "microWakeWord is designed for the ESP32-S3. The current platform is too slow for this model."
-#endif
-    );
-  }
-
   return available > (NEW_SAMPLES_TO_GET * sizeof(int16_t));
 }
 
@@ -396,9 +380,9 @@ bool MicroWakeWord::stride_audio_samples_(int16_t **audio_samples) {
     return false;
   }
 
-  // Copy 320 bytes (160 samples over 10 ms) into preprocessor_audio_buffer_ from history in
-  // preprocessor_stride_buffer_
-  memcpy((void *) (this->preprocessor_audio_buffer_), (void *) (this->preprocessor_stride_buffer_),
+  // Copy the last 320 bytes (160 samples over 10 ms) from the audio buffer into history stride buffer for the next
+  // iteration
+  memcpy((void *) (this->preprocessor_audio_buffer_), (void *) (this->preprocessor_audio_buffer_ + NEW_SAMPLES_TO_GET),
          HISTORY_SAMPLES_TO_KEEP * sizeof(int16_t));
 
   // Copy 640 bytes (320 samples over 20 ms) from the ring buffer
@@ -414,11 +398,6 @@ bool MicroWakeWord::stride_audio_samples_(int16_t **audio_samples) {
              (int) (NEW_SAMPLES_TO_GET * sizeof(int16_t)));
     return false;
   }
-
-  // Copy the last 320 bytes (160 samples over 10 ms) from the audio buffer into history stride buffer for the next
-  // iteration
-  memcpy((void *) (this->preprocessor_stride_buffer_), (void *) (this->preprocessor_audio_buffer_ + NEW_SAMPLES_TO_GET),
-         HISTORY_SAMPLES_TO_KEEP * sizeof(int16_t));
 
   *audio_samples = this->preprocessor_audio_buffer_;
   return true;
@@ -480,7 +459,7 @@ bool MicroWakeWord::register_preprocessor_ops_(tflite::MicroMutableOpResolver<18
   return true;
 }
 
-bool MicroWakeWord::register_streaming_ops_(tflite::MicroMutableOpResolver<14> &op_resolver) {
+bool MicroWakeWord::register_streaming_ops_(tflite::MicroMutableOpResolver<15> &op_resolver) {
   if (op_resolver.AddCallOnce() != kTfLiteOk)
     return false;
   if (op_resolver.AddVarHandle() != kTfLiteOk)
@@ -508,6 +487,8 @@ bool MicroWakeWord::register_streaming_ops_(tflite::MicroMutableOpResolver<14> &
   if (op_resolver.AddLogistic() != kTfLiteOk)
     return false;
   if (op_resolver.AddQuantize() != kTfLiteOk)
+    return false;
+  if (op_resolver.AddDepthwiseConv2D() != kTfLiteOk)
     return false;
 
   return true;

--- a/esphome/components/micro_wake_word/micro_wake_word.cpp
+++ b/esphome/components/micro_wake_word/micro_wake_word.cpp
@@ -358,6 +358,9 @@ bool MicroWakeWord::detect_wake_word_() {
     for (auto &prob : this->recent_streaming_probabilities_) {
       prob = 0;
     }
+
+    ESP_LOGD(TAG, "Wake word sliding average probability is %.3f and most recent probability is %.3f",
+             sliding_window_average, streaming_prob);
     return true;
   }
 

--- a/esphome/components/micro_wake_word/micro_wake_word.cpp
+++ b/esphome/components/micro_wake_word/micro_wake_word.cpp
@@ -226,7 +226,7 @@ bool MicroWakeWord::initialize_models() {
   }
 
   static tflite::MicroMutableOpResolver<18> preprocessor_op_resolver;
-  static tflite::MicroMutableOpResolver<15> streaming_op_resolver;
+  static tflite::MicroMutableOpResolver<18> streaming_op_resolver;
 
   if (!this->register_preprocessor_ops_(preprocessor_op_resolver))
     return false;
@@ -461,7 +461,7 @@ bool MicroWakeWord::register_preprocessor_ops_(tflite::MicroMutableOpResolver<18
   return true;
 }
 
-bool MicroWakeWord::register_streaming_ops_(tflite::MicroMutableOpResolver<15> &op_resolver) {
+bool MicroWakeWord::register_streaming_ops_(tflite::MicroMutableOpResolver<18> &op_resolver) {
   if (op_resolver.AddCallOnce() != kTfLiteOk)
     return false;
   if (op_resolver.AddVarHandle() != kTfLiteOk)
@@ -491,6 +491,12 @@ bool MicroWakeWord::register_streaming_ops_(tflite::MicroMutableOpResolver<15> &
   if (op_resolver.AddQuantize() != kTfLiteOk)
     return false;
   if (op_resolver.AddDepthwiseConv2D() != kTfLiteOk)
+    return false;
+  if (op_resolver.AddReduceMax() != kTfLiteOk)
+    return false;
+  if (op_resolver.AddAveragePool2D() != kTfLiteOk)
+    return false;
+  if (op_resolver.AddMaxPool2D() != kTfLiteOk)
     return false;
 
   return true;

--- a/esphome/components/micro_wake_word/micro_wake_word.cpp
+++ b/esphome/components/micro_wake_word/micro_wake_word.cpp
@@ -330,7 +330,6 @@ bool MicroWakeWord::detect_wake_word_() {
   }
 
   // Perform inference
-  uint32_t streaming_size = micros();
   float streaming_prob = this->perform_streaming_inference_();
 
   // Add the most recent probability to the sliding window

--- a/esphome/components/micro_wake_word/micro_wake_word.h
+++ b/esphome/components/micro_wake_word/micro_wake_word.h
@@ -128,7 +128,6 @@ class MicroWakeWord : public Component {
 
   // Stores audio fed into feature generator preprocessor
   int16_t *preprocessor_audio_buffer_;
-  int16_t *preprocessor_stride_buffer_;
 
   bool detected_{false};
 
@@ -181,7 +180,7 @@ class MicroWakeWord : public Component {
   bool register_preprocessor_ops_(tflite::MicroMutableOpResolver<18> &op_resolver);
 
   /// @brief Returns true if successfully registered the streaming model's TensorFlow operations
-  bool register_streaming_ops_(tflite::MicroMutableOpResolver<14> &op_resolver);
+  bool register_streaming_ops_(tflite::MicroMutableOpResolver<15> &op_resolver);
 };
 
 template<typename... Ts> class StartAction : public Action<Ts...>, public Parented<MicroWakeWord> {

--- a/esphome/components/micro_wake_word/micro_wake_word.h
+++ b/esphome/components/micro_wake_word/micro_wake_word.h
@@ -180,7 +180,7 @@ class MicroWakeWord : public Component {
   bool register_preprocessor_ops_(tflite::MicroMutableOpResolver<18> &op_resolver);
 
   /// @brief Returns true if successfully registered the streaming model's TensorFlow operations
-  bool register_streaming_ops_(tflite::MicroMutableOpResolver<15> &op_resolver);
+  bool register_streaming_ops_(tflite::MicroMutableOpResolver<18> &op_resolver);
 };
 
 template<typename... Ts> class StartAction : public Action<Ts...>, public Parented<MicroWakeWord> {

--- a/esphome/components/micro_wake_word/micro_wake_word.h
+++ b/esphome/components/micro_wake_word/micro_wake_word.h
@@ -180,7 +180,7 @@ class MicroWakeWord : public Component {
   bool register_preprocessor_ops_(tflite::MicroMutableOpResolver<18> &op_resolver);
 
   /// @brief Returns true if successfully registered the streaming model's TensorFlow operations
-  bool register_streaming_ops_(tflite::MicroMutableOpResolver<18> &op_resolver);
+  bool register_streaming_ops_(tflite::MicroMutableOpResolver<17> &op_resolver);
 };
 
 template<typename... Ts> class StartAction : public Action<Ts...>, public Parented<MicroWakeWord> {


### PR DESCRIPTION
# What does this implement/fix?

- Adds DepthwiseConv2D, AveragePool2D, and MaxPool2D ops for future model architectures.
- Moved the buffer full warning to ``read_microphone_``. Resets the ring buffer if it is too full to give mWW a chance to catch up if it falls too far behind (though roughly 500 ms of audio will be dropped entirely)
- Removed ``stride_audio_buffer_``, as the old audio used in the next window is already in the ``preprocessor_audio_buffer_``
- Logs the sliding window probability average and the most recent probability after the wake word is detected to help users tune the cutoff probability (replaces and closes esphome/esphome#6296)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** not applicable

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** not applicable

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

micro_wake_word:
  model: okay_nabu
  on_wake_word_detected:
    - voice_assistant.start:


```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
