### PR TITLE
SPI: Revert clk_pin to standard output pin schema

### DIFF
--- a/esphome/components/spi/__init__.py
+++ b/esphome/components/spi/__init__.py
@@ -198,7 +198,6 @@ def get_hw_spi(config, available):
 def validate_spi_config(config):
     available = list(range(len(get_hw_interface_list())))
     for spi in config:
-        # map pin number to schema
         interface = spi[CONF_INTERFACE]
         if interface == "software":
             pass

--- a/esphome/components/spi/__init__.py
+++ b/esphome/components/spi/__init__.py
@@ -29,7 +29,6 @@ from esphome.const import (
     PLATFORM_ESP32,
     PLATFORM_ESP8266,
     PLATFORM_RP2040,
-    CONF_ALLOW_OTHER_USES,
     CONF_DATA_PINS,
 )
 from esphome.core import (
@@ -200,7 +199,6 @@ def validate_spi_config(config):
     available = list(range(len(get_hw_interface_list())))
     for spi in config:
         # map pin number to schema
-        spi[CONF_CLK_PIN] = pins.gpio_output_pin_schema(spi[CONF_CLK_PIN])
         interface = spi[CONF_INTERFACE]
         if interface == "software":
             pass
@@ -257,21 +255,11 @@ def get_spi_interface(index):
     return "new SPIClass(HSPI)"
 
 
-# Do not use a pin schema for the number, as that will trigger a pin reuse error due to duplication of the
-# clock pin in the standard and quad schemas.
-clk_pin_validator = cv.maybe_simple_value(
-    {
-        cv.Required(CONF_NUMBER): cv.Any(cv.int_, cv.string),
-        cv.Optional(CONF_ALLOW_OTHER_USES): cv.boolean,
-    },
-    key=CONF_NUMBER,
-)
-
 SPI_SCHEMA = cv.All(
     cv.Schema(
         {
             cv.GenerateID(): cv.declare_id(SPIComponent),
-            cv.Required(CONF_CLK_PIN): clk_pin_validator,
+            cv.Required(CONF_CLK_PIN): pins.gpio_output_pin_schema,
             cv.Optional(CONF_MISO_PIN): pins.gpio_input_pin_schema,
             cv.Optional(CONF_MOSI_PIN): pins.gpio_output_pin_schema,
             cv.Optional(CONF_FORCE_SW): cv.invalid(
@@ -291,7 +279,7 @@ SPI_QUAD_SCHEMA = cv.All(
     cv.Schema(
         {
             cv.GenerateID(): cv.declare_id(QuadSPIComponent),
-            cv.Required(CONF_CLK_PIN): clk_pin_validator,
+            cv.Required(CONF_CLK_PIN): pins.gpio_output_pin_schema,
             cv.Required(CONF_DATA_PINS): cv.All(
                 cv.ensure_list(pins.internal_gpio_output_pin_number),
                 cv.Length(min=4, max=4),

--- a/tests/components/spi/test.esp32-s3-idf.yaml
+++ b/tests/components/spi/test.esp32-s3-idf.yaml
@@ -2,7 +2,8 @@ spi:
   - id: spi_id_1
     type: single
     clk_pin:
-      number: GPIO7
+      number: GPIO0
+      ignore_strapping_warning: true
       allow_other_uses: false
     mosi_pin: GPIO6
     interface: hardware


### PR DESCRIPTION

# What does this implement/fix?
now that the single/quad choice is handled by a typed schema the clock pin can be a standard output pin schema

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
