### PR TITLE
fix servo restore

### DIFF
--- a/esphome/components/servo/servo.cpp
+++ b/esphome/components/servo/servo.cpp
@@ -25,7 +25,6 @@ void Servo::loop() {
     if (millis() - this->start_millis_ > this->auto_detach_time_) {
       this->detach();
       this->start_millis_ = 0;
-      this->state_ = STATE_DETACHED;
       ESP_LOGD(TAG, "Servo detached on auto_detach_time");
     }
   }
@@ -54,8 +53,10 @@ void Servo::loop() {
 
 void Servo::write(float value) {
   value = clamp(value, -1.0f, 1.0f);
-  if (this->target_value_ == value)
+  if ((this->state_ == STATE_DETACHED) && (this->target_value_ == value))
     this->internal_write(value);
+  else
+    this->save_level_(value);
   this->target_value_ = value;
   this->source_value_ = this->current_value_;
   this->state_ = STATE_ATTACHED;
@@ -72,9 +73,6 @@ void Servo::internal_write(float value) {
     level = lerp(value, this->idle_level_, this->max_level_);
   }
   this->output_->set_level(level);
-  if (this->target_value_ == this->current_value_) {
-    this->save_level_(level);
-  }
   this->current_value_ = value;
 }
 

--- a/esphome/components/servo/servo.cpp
+++ b/esphome/components/servo/servo.cpp
@@ -69,10 +69,11 @@ void Servo::loop() {
 
 void Servo::write(float value) {
   value = clamp(value, -1.0f, 1.0f);
-  if ((this->state_ == STATE_DETACHED) && (this->target_value_ == value))
+  if ((this->state_ == STATE_DETACHED) && (this->target_value_ == value)) {
     this->internal_write(value);
-  else
+  } else {
     this->save_level_(value);
+  }
   this->target_value_ = value;
   this->source_value_ = this->current_value_;
   this->state_ = STATE_ATTACHED;

--- a/esphome/components/servo/servo.cpp
+++ b/esphome/components/servo/servo.cpp
@@ -97,5 +97,10 @@ void Servo::detach() {
   this->output_->set_level(0.0f);
 }
 
+void Servo::save_level_(float v) {
+  if (this->restore_)
+    this->rtc_.save(&v);
+}
+
 }  // namespace servo
 }  // namespace esphome

--- a/esphome/components/servo/servo.h
+++ b/esphome/components/servo/servo.h
@@ -28,6 +28,8 @@ class Servo : public Component {
   void set_auto_detach_time(uint32_t auto_detach_time) { auto_detach_time_ = auto_detach_time; }
   void set_transition_length(uint32_t transition_length) { transition_length_ = transition_length; }
 
+  bool has_reached_target() { return this->current_value_ == this->target_value_; }
+
  protected:
   void save_level_(float v);
 

--- a/esphome/components/servo/servo.h
+++ b/esphome/components/servo/servo.h
@@ -17,25 +17,8 @@ class Servo : public Component {
   void loop() override;
   void write(float value);
   void internal_write(float value);
-  void detach() {
-    this->state_ = STATE_DETACHED;
-    this->output_->set_level(0.0f);
-  }
-  void setup() override {
-    float v;
-    if (this->restore_) {
-      this->rtc_ = global_preferences->make_preference<float>(global_servo_id);
-      global_servo_id++;
-      if (this->rtc_.load(&v)) {
-        this->target_value_ = v;
-        this->internal_write(v);
-        this->state_ = STATE_ATTACHED;
-        this->start_millis_ = millis();
-        return;
-      }
-    }
-    this->detach();
-  }
+  void detach();
+  void setup() override;
   void dump_config() override;
   float get_setup_priority() const override { return setup_priority::DATA; }
   void set_min_level(float min_level) { min_level_ = min_level; }

--- a/esphome/components/servo/servo.h
+++ b/esphome/components/servo/servo.h
@@ -18,8 +18,8 @@ class Servo : public Component {
   void write(float value);
   void internal_write(float value);
   void detach() {
+    this->state_ = STATE_DETACHED;
     this->output_->set_level(0.0f);
-    this->save_level_(0.0f);
   }
   void setup() override {
     float v;
@@ -27,7 +27,10 @@ class Servo : public Component {
       this->rtc_ = global_preferences->make_preference<float>(global_servo_id);
       global_servo_id++;
       if (this->rtc_.load(&v)) {
-        this->output_->set_level(v);
+        this->target_value_ = v;
+        this->internal_write(v);
+        this->state_ = STATE_ATTACHED;
+        this->start_millis_ = millis();
         return;
       }
     }

--- a/esphome/components/servo/servo.h
+++ b/esphome/components/servo/servo.h
@@ -29,7 +29,7 @@ class Servo : public Component {
   void set_transition_length(uint32_t transition_length) { transition_length_ = transition_length; }
 
  protected:
-  void save_level_(float v) { this->rtc_.save(&v); }
+  void save_level_(float v);
 
   output::FloatOutput *output_;
   float min_level_ = 0.0300f;


### PR DESCRIPTION
# What does this implement/fix?

Fixes the restore state handling of the servo component.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/5313
fixes https://github.com/esphome/issues/issues/5292

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
