### PR TITLE
2024.3.0b2

### DIFF
--- a/esphome/components/servo/servo.cpp
+++ b/esphome/components/servo/servo.cpp
@@ -19,13 +19,28 @@ void Servo::dump_config() {
   ESP_LOGCONFIG(TAG, "  run duration: %" PRIu32 " ms", this->transition_length_);
 }
 
+void Servo::setup() {
+  float v;
+  if (this->restore_) {
+    this->rtc_ = global_preferences->make_preference<float>(global_servo_id);
+    global_servo_id++;
+    if (this->rtc_.load(&v)) {
+      this->target_value_ = v;
+      this->internal_write(v);
+      this->state_ = STATE_ATTACHED;
+      this->start_millis_ = millis();
+      return;
+    }
+  }
+  this->detach();
+}
+
 void Servo::loop() {
   // check if auto_detach_time_ is set and servo reached target
   if (this->auto_detach_time_ && this->state_ == STATE_TARGET_REACHED) {
     if (millis() - this->start_millis_ > this->auto_detach_time_) {
       this->detach();
       this->start_millis_ = 0;
-      this->state_ = STATE_DETACHED;
       ESP_LOGD(TAG, "Servo detached on auto_detach_time");
     }
   }
@@ -54,8 +69,11 @@ void Servo::loop() {
 
 void Servo::write(float value) {
   value = clamp(value, -1.0f, 1.0f);
-  if (this->target_value_ == value)
+  if ((this->state_ == STATE_DETACHED) && (this->target_value_ == value)) {
     this->internal_write(value);
+  } else {
+    this->save_level_(value);
+  }
   this->target_value_ = value;
   this->source_value_ = this->current_value_;
   this->state_ = STATE_ATTACHED;
@@ -72,10 +90,17 @@ void Servo::internal_write(float value) {
     level = lerp(value, this->idle_level_, this->max_level_);
   }
   this->output_->set_level(level);
-  if (this->target_value_ == this->current_value_) {
-    this->save_level_(level);
-  }
   this->current_value_ = value;
+}
+
+void Servo::detach() {
+  this->state_ = STATE_DETACHED;
+  this->output_->set_level(0.0f);
+}
+
+void Servo::save_level_(float v) {
+  if (this->restore_)
+    this->rtc_.save(&v);
 }
 
 }  // namespace servo

--- a/esphome/components/servo/servo.h
+++ b/esphome/components/servo/servo.h
@@ -17,22 +17,8 @@ class Servo : public Component {
   void loop() override;
   void write(float value);
   void internal_write(float value);
-  void detach() {
-    this->output_->set_level(0.0f);
-    this->save_level_(0.0f);
-  }
-  void setup() override {
-    float v;
-    if (this->restore_) {
-      this->rtc_ = global_preferences->make_preference<float>(global_servo_id);
-      global_servo_id++;
-      if (this->rtc_.load(&v)) {
-        this->output_->set_level(v);
-        return;
-      }
-    }
-    this->detach();
-  }
+  void detach();
+  void setup() override;
   void dump_config() override;
   float get_setup_priority() const override { return setup_priority::DATA; }
   void set_min_level(float min_level) { min_level_ = min_level; }
@@ -42,8 +28,10 @@ class Servo : public Component {
   void set_auto_detach_time(uint32_t auto_detach_time) { auto_detach_time_ = auto_detach_time; }
   void set_transition_length(uint32_t transition_length) { transition_length_ = transition_length; }
 
+  bool has_reached_target() { return this->current_value_ == this->target_value_; }
+
  protected:
-  void save_level_(float v) { this->rtc_.save(&v); }
+  void save_level_(float v);
 
   output::FloatOutput *output_;
   float min_level_ = 0.0300f;

--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -486,7 +486,7 @@ void WebServer::handle_switch_request(AsyncWebServerRequest *request, const UrlM
     if (obj->get_object_id() != match.id)
       continue;
 
-    if (request->method() == HTTP_GET) {
+    if (request->method() == HTTP_GET && match.method.empty()) {
       std::string data = this->switch_json(obj, obj->state, DETAIL_STATE);
       request->send(200, "application/json", data.c_str());
     } else if (match.method == "toggle") {
@@ -517,7 +517,7 @@ void WebServer::handle_button_request(AsyncWebServerRequest *request, const UrlM
   for (button::Button *obj : App.get_buttons()) {
     if (obj->get_object_id() != match.id)
       continue;
-    if (request->method() == HTTP_POST && match.method == "press") {
+    if (match.method == "press") {
       this->schedule_([obj]() { obj->press(); });
       request->send(200);
       return;
@@ -572,7 +572,7 @@ void WebServer::handle_fan_request(AsyncWebServerRequest *request, const UrlMatc
     if (obj->get_object_id() != match.id)
       continue;
 
-    if (request->method() == HTTP_GET) {
+    if (request->method() == HTTP_GET && match.method.empty()) {
       std::string data = this->fan_json(obj, DETAIL_STATE);
       request->send(200, "application/json", data.c_str());
     } else if (match.method == "toggle") {
@@ -630,7 +630,7 @@ void WebServer::handle_light_request(AsyncWebServerRequest *request, const UrlMa
     if (obj->get_object_id() != match.id)
       continue;
 
-    if (request->method() == HTTP_GET) {
+    if (request->method() == HTTP_GET && match.method.empty()) {
       std::string data = this->light_json(obj, DETAIL_STATE);
       request->send(200, "application/json", data.c_str());
     } else if (match.method == "toggle") {
@@ -736,7 +736,7 @@ void WebServer::handle_cover_request(AsyncWebServerRequest *request, const UrlMa
     if (obj->get_object_id() != match.id)
       continue;
 
-    if (request->method() == HTTP_GET) {
+    if (request->method() == HTTP_GET && match.method.empty()) {
       std::string data = this->cover_json(obj, DETAIL_STATE);
       request->send(200, "application/json", data.c_str());
       continue;
@@ -805,7 +805,7 @@ void WebServer::handle_number_request(AsyncWebServerRequest *request, const UrlM
     if (obj->get_object_id() != match.id)
       continue;
 
-    if (request->method() == HTTP_GET) {
+    if (request->method() == HTTP_GET && match.method.empty()) {
       std::string data = this->number_json(obj, obj->state, DETAIL_STATE);
       request->send(200, "application/json", data.c_str());
       return;
@@ -910,7 +910,7 @@ void WebServer::handle_text_request(AsyncWebServerRequest *request, const UrlMat
     if (obj->get_object_id() != match.id)
       continue;
 
-    if (request->method() == HTTP_GET) {
+    if (request->method() == HTTP_GET && match.method.empty()) {
       std::string data = this->text_json(obj, obj->state, DETAIL_STATE);
       request->send(200, "text/json", data.c_str());
       return;
@@ -961,7 +961,7 @@ void WebServer::handle_select_request(AsyncWebServerRequest *request, const UrlM
     if (obj->get_object_id() != match.id)
       continue;
 
-    if (request->method() == HTTP_GET) {
+    if (request->method() == HTTP_GET && match.method.empty()) {
       auto detail = DETAIL_STATE;
       auto *param = request->getParam("detail");
       if (param && param->value() == "all") {
@@ -1016,7 +1016,7 @@ void WebServer::handle_climate_request(AsyncWebServerRequest *request, const Url
     if (obj->get_object_id() != match.id)
       continue;
 
-    if (request->method() == HTTP_GET) {
+    if (request->method() == HTTP_GET && match.method.empty()) {
       std::string data = this->climate_json(obj, DETAIL_STATE);
       request->send(200, "application/json", data.c_str());
       return;
@@ -1162,7 +1162,7 @@ void WebServer::handle_lock_request(AsyncWebServerRequest *request, const UrlMat
     if (obj->get_object_id() != match.id)
       continue;
 
-    if (request->method() == HTTP_GET) {
+    if (request->method() == HTTP_GET && match.method.empty()) {
       std::string data = this->lock_json(obj, obj->state, DETAIL_STATE);
       request->send(200, "application/json", data.c_str());
     } else if (match.method == "lock") {
@@ -1201,7 +1201,7 @@ void WebServer::handle_alarm_control_panel_request(AsyncWebServerRequest *reques
     if (obj->get_object_id() != match.id)
       continue;
 
-    if (request->method() == HTTP_GET) {
+    if (request->method() == HTTP_GET && match.method.empty()) {
       std::string data = this->alarm_control_panel_json(obj, obj->get_state(), DETAIL_STATE);
       request->send(200, "application/json", data.c_str());
       return;
@@ -1251,7 +1251,7 @@ bool WebServer::canHandle(AsyncWebServerRequest *request) {
 #endif
 
 #ifdef USE_BUTTON
-  if (request->method() == HTTP_POST && match.domain == "button")
+  if ((request->method() == HTTP_POST || request->method() == HTTP_GET) && match.domain == "button")
     return true;
 #endif
 

--- a/esphome/components/wifi/wifi_component_esp32_arduino.cpp
+++ b/esphome/components/wifi/wifi_component_esp32_arduino.cpp
@@ -157,7 +157,7 @@ network::IPAddresses WiFiComponent::wifi_sta_ip_addresses() {
   } else {
     addresses[0] = network::IPAddress(&ip.ip);
   }
-#if LWIP_IPV6
+#if USE_NETWORK_IPV6
   ip6_addr_t ipv6;
   err = tcpip_adapter_get_ip6_global(TCPIP_ADAPTER_IF_STA, &ipv6);
   if (err != ESP_OK) {
@@ -171,7 +171,7 @@ network::IPAddresses WiFiComponent::wifi_sta_ip_addresses() {
   } else {
     addresses[2] = network::IPAddress(&ipv6);
   }
-#endif /* LWIP_IPV6 */
+#endif /* USE_NETWORK_IPV6 */
 
   return addresses;
 }

--- a/esphome/const.py
+++ b/esphome/const.py
@@ -1,6 +1,6 @@
 """Constants used by esphome."""
 
-__version__ = "2024.3.0b1"
+__version__ = "2024.3.0b2"
 
 ALLOWED_NAME_CHARS = "abcdefghijklmnopqrstuvwxyz0123456789-_"
 VALID_SUBSTITUTIONS_CHARACTERS = (

--- a/tests/components/spi/test.esp32-s3-idf.yaml
+++ b/tests/components/spi/test.esp32-s3-idf.yaml
@@ -2,7 +2,8 @@ spi:
   - id: spi_id_1
     type: single
     clk_pin:
-      number: GPIO7
+      number: GPIO0
+      ignore_strapping_warning: true
       allow_other_uses: false
     mosi_pin: GPIO6
     interface: hardware


### PR DESCRIPTION
**Do not merge, release script will automatically merge**
## Full list of changes

### All changes

- SPI: Revert clk_pin to standard output pin schema [esphome#6368](https://github.com/esphome/esphome/pull/6368)
- Allow actions in web_server to be executed via GET method [esphome#5938](https://github.com/esphome/esphome/pull/5938)
- fix servo restore [esphome#6370](https://github.com/esphome/esphome/pull/6370)
- Don't try to get IPv6 addresses when disabled [esphome#6366](https://github.com/esphome/esphome/pull/6366)
