### PR TITLE
Fix list-components when PR is not targeting dev

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -398,6 +398,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - common
+    if: github.event_name == 'pull_request'
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
@@ -406,10 +407,14 @@ jobs:
         with:
           # Fetch enough history so `git merge-base refs/remotes/origin/dev HEAD` works.
           fetch-depth: 500
-      - name: Fetch dev branch
+      - name: Get target branch
+        id: target-branch
         run: |
-          git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +refs/heads/dev*:refs/remotes/origin/dev* +refs/tags/dev*:refs/tags/dev*
-          git merge-base refs/remotes/origin/dev HEAD
+          echo "branch=${{ github.event.pull_request.base.ref }}" >> $GITHUB_OUTPUT
+      - name: Fetch ${{ steps.target-branch.outputs.branch }} branch
+        run: |
+          git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +refs/heads/${{ steps.target-branch.outputs.branch }}:refs/remotes/origin/${{ steps.target-branch.outputs.branch }}
+          git merge-base refs/remotes/origin/${{ steps.target-branch.outputs.branch }} HEAD
       - name: Restore Python
         uses: ./.github/actions/restore-python
         with:
@@ -419,7 +424,7 @@ jobs:
         id: set-matrix
         run: |
           . venv/bin/activate
-          echo "matrix=$(script/list-components.py --changed | jq -R -s -c 'split("\n")[:-1]')" >> $GITHUB_OUTPUT
+          echo "matrix=$(script/list-components.py --changed --branch ${{ steps.target-branch.outputs.branch }} | jq -R -s -c 'split("\n")[:-1]')" >> $GITHUB_OUTPUT
 
   test-build-components:
     name: Component test ${{ matrix.file }}
@@ -427,7 +432,7 @@ jobs:
     needs:
       - common
       - list-components
-    if: ${{ needs.list-components.outputs.matrix != '[]' && needs.list-components.outputs.matrix != '' }}
+    if: ${{ github.event_name == 'pull_request' && needs.list-components.outputs.matrix != '[]' && needs.list-components.outputs.matrix != '' }}
     strategy:
       fail-fast: false
       max-parallel: 2

--- a/script/helpers.py
+++ b/script/helpers.py
@@ -70,11 +70,11 @@ def splitlines_no_ends(string):
     return [s.strip() for s in string.splitlines()]
 
 
-def changed_files():
+def changed_files(branch="dev"):
     check_remotes = ["upstream", "origin"]
     check_remotes.extend(splitlines_no_ends(get_output("git", "remote")))
     for remote in check_remotes:
-        command = ["git", "merge-base", f"refs/remotes/{remote}/dev", "HEAD"]
+        command = ["git", "merge-base", f"refs/remotes/{remote}/{branch}", "HEAD"]
         try:
             merge_base = splitlines_no_ends(get_output(*command))[0]
             break

--- a/script/list-components.py
+++ b/script/list-components.py
@@ -120,13 +120,22 @@ def main():
     parser.add_argument(
         "-c", "--changed", action="store_true", help="Only run on changed files"
     )
+    parser.add_argument(
+        "-b", "--branch", help="Branch to compare changed files against"
+    )
     args = parser.parse_args()
+
+    if args.branch and not args.changed:
+        parser.error("--branch requires --changed")
 
     files = git_ls_files()
     files = filter(filter_component_files, files)
 
     if args.changed:
-        changed = changed_files()
+        if args.branch:
+            changed = changed_files(args.branch)
+        else:
+            changed = changed_files()
         files = [f for f in files if f in changed]
 
     components = extract_component_names_array_from_files_array(files)


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Release PRs were failing the list components steps because the ref was not available, and they should be targeting `release` or `beta` anyway

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
