### PR TITLE
Fix Nextion set_component_picture call

### DIFF
--- a/esphome/components/nextion/nextion.h
+++ b/esphome/components/nextion/nextion.h
@@ -82,16 +82,16 @@ class Nextion : public NextionBase, public PollingComponent, public uart::UARTDe
   /**
    * Set the picture of an image component.
    * @param component The component name.
-   * @param value The picture name.
+   * @param value The picture id.
    *
    * Example:
    * ```cpp
-   * it.set_component_picture("pic", "4");
+   * it.set_component_picture("pic", 4);
    * ```
    *
    * This will change the image of the component `pic` to the image with ID `4`.
    */
-  void set_component_picture(const char *component, const char *picture);
+  void set_component_picture(const char *component, uint8_t picture_id);
   /**
    * Set the background color of a component.
    * @param component The component name.

--- a/esphome/components/nextion/nextion_commands.cpp
+++ b/esphome/components/nextion/nextion_commands.cpp
@@ -197,8 +197,8 @@ void Nextion::disable_component_touch(const char *component) {
   this->add_no_result_to_queue_with_printf_("disable_component_touch", "tsw %s,0", component);
 }
 
-void Nextion::set_component_picture(const char *component, const char *picture) {
-  this->add_no_result_to_queue_with_printf_("set_component_picture", "%s.val=%s", component, picture);
+void Nextion::set_component_picture(const char *component, uint8_t picture_id) {
+  this->add_no_result_to_queue_with_printf_("set_component_picture", "%s.pic=%d", component, picture_id);
 }
 
 void Nextion::set_component_text(const char *component, const char *text) {


### PR DESCRIPTION
# What does this implement/fix?

This fixes the call to the Nextion display to change the pic id from a component. It was previously changing the attribute `val`, which is related to something else. In addition, I've changed the parameter for picture_id to be uint_8, as Nextion requires an integer from 0 to 255 on this attribute.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [X] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
N/A

API inline doc updated.

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
