### PR TITLE
Add support for Waveshare 7.3" ACeP 7-Color display

### DIFF
--- a/esphome/components/display/display_buffer.h
+++ b/esphome/components/display/display_buffer.h
@@ -25,7 +25,7 @@ class DisplayBuffer : public Display {
  protected:
   virtual void draw_absolute_pixel_internal(int x, int y, Color color) = 0;
 
-  virtual void init_internal_(uint32_t buffer_length);
+  void init_internal_(uint32_t buffer_length);
 
   uint8_t *buffer_{nullptr};
 };

--- a/esphome/components/display/display_buffer.h
+++ b/esphome/components/display/display_buffer.h
@@ -25,7 +25,7 @@ class DisplayBuffer : public Display {
  protected:
   virtual void draw_absolute_pixel_internal(int x, int y, Color color) = 0;
 
-  void init_internal_(uint32_t buffer_length);
+  virtual void init_internal_(uint32_t buffer_length);
 
   uint8_t *buffer_{nullptr};
 };

--- a/esphome/components/waveshare_epaper/display.py
+++ b/esphome/components/waveshare_epaper/display.py
@@ -24,9 +24,7 @@ WaveshareEPaper = waveshare_epaper_ns.class_("WaveshareEPaper", WaveshareEPaperB
 WaveshareEPaperBWR = waveshare_epaper_ns.class_(
     "WaveshareEPaperBWR", WaveshareEPaperBase
 )
-WaveshareEPaper7C = waveshare_epaper_ns.class_(
-    "WaveshareEPaper7C", WaveshareEPaperBase
-)
+WaveshareEPaper7C = waveshare_epaper_ns.class_("WaveshareEPaper7C", WaveshareEPaperBase)
 WaveshareEPaperTypeA = waveshare_epaper_ns.class_(
     "WaveshareEPaperTypeA", WaveshareEPaper
 )

--- a/esphome/components/waveshare_epaper/display.py
+++ b/esphome/components/waveshare_epaper/display.py
@@ -24,6 +24,9 @@ WaveshareEPaper = waveshare_epaper_ns.class_("WaveshareEPaper", WaveshareEPaperB
 WaveshareEPaperBWR = waveshare_epaper_ns.class_(
     "WaveshareEPaperBWR", WaveshareEPaperBase
 )
+WaveshareEPaper7C = waveshare_epaper_ns.class_(
+    "WaveshareEPaper7C", WaveshareEPaperBase
+)
 WaveshareEPaperTypeA = waveshare_epaper_ns.class_(
     "WaveshareEPaperTypeA", WaveshareEPaper
 )
@@ -63,6 +66,9 @@ WaveshareEPaper5P8In = waveshare_epaper_ns.class_(
 )
 WaveshareEPaper5P8InV2 = waveshare_epaper_ns.class_(
     "WaveshareEPaper5P8InV2", WaveshareEPaper
+)
+WaveshareEPaper7P3InF = waveshare_epaper_ns.class_(
+    "WaveshareEPaper7P3InF", WaveshareEPaper7C
 )
 WaveshareEPaper7P5In = waveshare_epaper_ns.class_(
     "WaveshareEPaper7P5In", WaveshareEPaper
@@ -126,6 +132,7 @@ MODELS = {
     "4.20in-bv2": ("b", WaveshareEPaper4P2InBV2),
     "5.83in": ("b", WaveshareEPaper5P8In),
     "5.83inv2": ("b", WaveshareEPaper5P8InV2),
+    "7.30in-f": ("b", WaveshareEPaper7P3InF),
     "7.50in": ("b", WaveshareEPaper7P5In),
     "7.50in-bv2": ("b", WaveshareEPaper7P5InBV2),
     "7.50in-bv3": ("b", WaveshareEPaper7P5InBV3),

--- a/esphome/components/waveshare_epaper/waveshare_213v3.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_213v3.cpp
@@ -86,7 +86,11 @@ void WaveshareEPaper2P13InV3::send_reset_() {
 }
 
 void WaveshareEPaper2P13InV3::setup() {
-  setup_pins_();
+  this->init_internal_(this->get_buffer_length_());
+  this->setup_pins_();
+  this->spi_setup();
+  this->reset_();
+
   delay(20);
   this->send_reset_();
   // as a one-off delay this is not worth working around.

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -111,6 +111,7 @@ static const uint8_t PARTIAL_UPD_2IN9_LUT[PARTIAL_UPD_2IN9_LUT_SIZE] =
 // clang-format on
 
 void WaveshareEPaperBase::setup_pins_() {
+  ESP_LOGI(TAG, "Will create buffer of size: %d", this->get_buffer_length_());//debug
   this->init_internal_(this->get_buffer_length_());
   this->dc_pin_->setup();  // OUTPUT
   this->dc_pin_->digital_write(false);
@@ -173,6 +174,121 @@ void WaveshareEPaper::fill(Color color) {
   for (uint32_t i = 0; i < this->get_buffer_length_(); i++)
     this->buffer_[i] = fill;
 }
+void WaveshareEPaper7C::init_internal_(uint32_t buffer_length) {
+  ESP_LOGI(TAG, "Buffer n°0 points to: %d", this->buffers_[0]);
+  ESP_LOGI(TAG, "EXEC CUSTOM WaveshareEPaper7C::init_internal_, creating splitted buffer");//debug
+  for (int i = 0; i < NUM_BUFFERS; i++)
+    this->buffers_[i] = nullptr;
+
+
+
+  ESP_LOGI(TAG, "EXEC CUSTOM WaveshareEPaper7C::init_internal_, creating splitted buffer");//debug
+  ESP_LOGI(TAG, "Available ram before allocation: %d", heap_caps_get_free_size(MALLOC_CAP_INTERNAL));//debug
+  //Same as DisplayBuffer::init_internal_, but here we split the buffer because of heap fragmentation
+  
+  if (heap_caps_get_free_size(MALLOC_CAP_INTERNAL) < buffer_length){
+    ESP_LOGE(TAG, "Could not allocate buffers, not enough ram!");
+    return;
+  }
+
+  ExternalRAMAllocator<uint8_t> allocator(ExternalRAMAllocator<uint8_t>::ALLOW_FAILURE);
+  //ExternalRAMAllocator<uint8_t> allocator;
+
+  uint32_t small_buffer_length = buffer_length / NUM_BUFFERS;
+  ESP_LOGI(TAG, "We want %d buffers of size %d", NUM_BUFFERS, small_buffer_length);//debug
+
+  for (int i = 0; i < NUM_BUFFERS; i++)
+    this->buffers_[i] = nullptr;
+  ESP_LOGI(TAG, "Buffer n°0 points to: %d", this->buffers_[0]);
+
+  uint8_t * tmp = nullptr;
+  for (int i = 0; i < NUM_BUFFERS; i++) {
+    ESP_LOGI(TAG, "");//debug
+    ESP_LOGI(TAG, "Available ram: %d", heap_caps_get_free_size(MALLOC_CAP_INTERNAL));//debug
+    ESP_LOGI(TAG, "Biggest block: %d", heap_caps_get_largest_free_block(MALLOC_CAP_INTERNAL));//debug
+    ESP_LOGI(TAG, "Wanted alloc: %d", small_buffer_length);//debug
+    
+    this->buffers_[i] = allocator.allocate(small_buffer_length);;
+    
+    if (this->buffers_[i] == nullptr) {
+      ESP_LOGE(TAG, "Could not allocate buffer %d for display!", NUM_BUFFERS);
+      ESP_LOGI(TAG, "Biggest block was: %d", heap_caps_get_largest_free_block(MALLOC_CAP_INTERNAL));//debug
+      
+      //TODO : desallocate before nullptr
+      ESP_LOGE(TAG, "Deleting all buffers");
+      for (int k = 0; k < NUM_BUFFERS; k++)
+        this->buffers_[k] = nullptr;
+      ESP_LOGI(TAG, "Buffer n°0 points to: %d", this->buffers_[0]);
+      return;
+    }
+    ESP_LOGI(TAG, "Buffer n°%d points to: %d", i, this->buffers_[i]);
+
+    ESP_LOGI(TAG, "ok");//debug
+  }
+
+  ESP_LOGI(TAG, "init_internal_ : %d buffers allocated with success", NUM_BUFFERS);
+  ESP_LOGI(TAG, "Available ram after allocation: %d", heap_caps_get_free_size(MALLOC_CAP_INTERNAL));//debug
+
+  this->clear();
+}
+uint8_t WaveshareEPaper7C::color_to_hex(Color color) {
+  uint8_t hex_code;
+  if (((color.red < 127) && (color.green < 127) && (color.blue < 127))) {
+    hex_code = 0x0; //Black
+  } else if (((color.red > 127) && (color.green > 127) && (color.blue > 127))) {
+    hex_code = 0x1; //White
+  } else if (((color.red < 127) && (color.green > 127) && (color.blue < 127))) {
+    hex_code = 0x2; //Green
+  } else if (((color.red < 127) && (color.green < 127) && (color.blue > 127))) {
+    hex_code = 0x3; //Blue
+  } else if (((color.red > 127) && (color.green < 127) && (color.blue < 127))) {
+    hex_code = 0x4; //Red
+  } else if (((color.red > 127) && (color.green > 127) && (color.blue < 127))) {
+    hex_code = 0x5; //Yellow
+  } else if (((color.red > 127) && (color.green > 64) && (color.green < 191) && (color.blue < 127))) {
+    hex_code = 0x6; //Orange
+  } else {
+    hex_code = 0x1; //White
+  }
+  return hex_code;
+}
+void WaveshareEPaper7C::fill(Color color) {
+  ESP_LOGI(TAG, "EXEC WaveshareEPaper7C::fill");
+  ESP_LOGI(TAG, "this->get_width_internal() : %d", this->get_width_internal());
+  ESP_LOGI(TAG, "this->get_height_internal() : %d", this->get_height_internal());
+  ESP_LOGI(TAG, "this->get_buffer_length_() : %d", this->get_buffer_length_());
+
+  uint8_t fill;
+  if (!color.is_on()) { 
+    fill = 0x11; //White background by default
+  }
+  else{
+    uint8_t hex_color = this->color_to_hex(color);
+    fill = (hex_color << 4) | hex_color;
+    ESP_LOGI(TAG, "Color: (%d,%d,%d) converted to 0x%X", color.red, color.green, color.blue, fill);
+  }  
+
+  ESP_LOGI(TAG, "Check buffers");
+  if (this->buffers_ == nullptr) {
+    ESP_LOGE(TAG, "Buffer unavailable!");
+  }
+  else{
+    uint32_t small_buffer_length = this->get_buffer_length_() / NUM_BUFFERS;
+    ESP_LOGI(TAG, "small_buffer_length : %d",small_buffer_length);
+    for (int buffer_index = 0; buffer_index < NUM_BUFFERS; buffer_index++) {
+      ESP_LOGI(TAG, "Buffer n°%d points to: %d", buffer_index, this->buffers_[buffer_index]);
+      for (uint32_t buffer_pos = 0; buffer_pos < small_buffer_length; buffer_pos++) {
+        this->buffers_[buffer_index][buffer_pos] = fill;
+        if (buffer_pos<5){
+          ESP_LOGI(TAG, "Buffer n°%d pos %d points to: %d, value is 0x%X", buffer_index, buffer_pos, &(this->buffers_[buffer_index][buffer_pos]), fill);
+        }
+      }
+      App.feed_wdt();
+      ESP_LOGI(TAG, "ok");
+    }
+  }
+  ESP_LOGI(TAG, "fill done");
+}
 void HOT WaveshareEPaper::draw_absolute_pixel_internal(int x, int y, Color color) {
   if (x >= this->get_width_internal() || y >= this->get_height_internal() || x < 0 || y < 0)
     return;
@@ -193,6 +309,9 @@ uint32_t WaveshareEPaper::get_buffer_length_() {
 uint32_t WaveshareEPaperBWR::get_buffer_length_() {
   return this->get_width_controller() * this->get_height_internal() / 4u;
 }  // black and red buffer
+uint32_t WaveshareEPaper7C::get_buffer_length_() {
+  return this->get_width_controller() * this->get_height_internal() / 2u;//The goal is to put 2u here instead of 4u
+}  // 7 colors buffer
 
 void WaveshareEPaperBWR::fill(Color color) {
   this->filled_rectangle(0, 0, this->get_width(), this->get_height(), color);
@@ -217,6 +336,38 @@ void HOT WaveshareEPaperBWR::draw_absolute_pixel_internal(int x, int y, Color co
     this->buffer_[pos + buf_half_len] |= 0x80 >> subpos;
   } else {
     this->buffer_[pos + buf_half_len] &= ~(0x80 >> subpos);
+  }
+}
+void HOT WaveshareEPaper7C::draw_absolute_pixel_internal(int x, int y, Color color) {
+  ESP_LOGI(TAG, "EXEC WaveshareEPaper7C::draw_absolute_pixel_internal");
+  if (x >= this->get_width_internal() || y >= this->get_height_internal() || x < 0 || y < 0)
+    return;
+
+  uint8_t hex_color = this->color_to_hex(color);
+
+  const uint32_t pos = (x + y * this->get_width_controller()) / 2u;
+  const uint8_t subpos = x % 2;
+  const uint32_t small_buffer_length = this->get_buffer_length_() / NUM_BUFFERS;
+  const uint32_t buffer_index = pos / small_buffer_length; //dividing integers = rounded down
+  const uint32_t buffer_pos = pos % small_buffer_length;
+
+  if (this->buffers_ == nullptr) {
+      ESP_LOGE(TAG, "draw_absolute_pixel_internal, buffer unavailable 1");
+      return;
+  }
+  if (this->buffers_[buffer_index] == nullptr) {
+      ESP_LOGE(TAG, "draw_absolute_pixel_internal, buffer unavailable 2");
+      return;
+  }
+  if (this->buffers_[buffer_index][buffer_pos]) {
+      ESP_LOGE(TAG, "draw_absolute_pixel_internal, buffer unavailable 3");
+      return;
+  }
+
+  if (subpos == 0) {  // Pixel on the left side of the byte
+    this->buffers_[buffer_index][buffer_pos] = (this->buffers_[buffer_index][buffer_pos] & 0x0F) | (hex_color << 4);
+  } else {  // Pixel on the right side of the byte
+    this->buffers_[buffer_index][buffer_pos] = (this->buffers_[buffer_index][buffer_pos] & 0xF0) | hex_color;
   }
 }
 
@@ -2085,6 +2236,196 @@ void WaveshareEPaper5P8InV2::dump_config() {
   LOG_PIN("  DC Pin: ", this->dc_pin_);
   LOG_PIN("  Busy Pin: ", this->busy_pin_);
   LOG_UPDATE_INTERVAL(this);
+}
+void WaveshareEPaper7P3InF::initialize() {
+  this->reset_();
+  delay(20);
+
+  if (this->buffers_ == nullptr) {
+    ESP_LOGE(TAG, "Buffer unavailable!");
+    return;
+  }
+  // COMMAND CMDH
+  this->command(0xAA); 
+  this->data(0x49);
+  this->data(0x55);
+  this->data(0x20);
+  this->data(0x08);
+  this->data(0x09);
+  this->data(0x18);
+
+  this->command(0x01);
+  this->data(0x3F);
+  this->data(0x00);
+  this->data(0x32);
+  this->data(0x2A);
+  this->data(0x0E);
+  this->data(0x2A);
+
+  this->command(0x00);
+  this->data(0x5F);
+  this->data(0x69);
+
+  this->command(0x03);
+  this->data(0x00);
+  this->data(0x54);
+  this->data(0x00);
+  this->data(0x44); 
+
+  this->command(0x05);
+  this->data(0x40);
+  this->data(0x1F);
+  this->data(0x1F);
+  this->data(0x2C);
+
+  this->command(0x06);
+  this->data(0x6F);
+  this->data(0x1F);
+  this->data(0x1F);
+  this->data(0x22);
+
+  this->command(0x08);
+  this->data(0x6F);
+  this->data(0x1F);
+  this->data(0x1F);
+  this->data(0x22);
+
+  // COMMAND IPC
+  this->command(0x13);
+  this->data(0x00);
+  this->data(0x04);
+
+  this->command(0x30);
+  this->data(0x3C);
+
+  // COMMAND TSE
+  this->command(0x41);
+  this->data(0x00);
+
+  this->command(0x50);
+  this->data(0x3F);
+
+  this->command(0x60);
+  this->data(0x02);
+  this->data(0x00);
+
+  this->command(0x61);
+  this->data(0x03);
+  this->data(0x20);
+  this->data(0x01); 
+  this->data(0xE0);
+
+  this->command(0x82);
+  this->data(0x1E); 
+
+  this->command(0x84);
+  this->data(0x00);
+
+  // COMMAND AGID
+  this->command(0x86);
+  this->data(0x00);
+
+  this->command(0xE3);
+  this->data(0x2F);
+
+  // COMMAND CCSET
+  this->command(0xE0);
+  this->data(0x00); 
+
+  // COMMAND TSSET
+  this->command(0xE6);
+  this->data(0x00);
+  ESP_LOGI(TAG, "Display initialized successfully");//debug
+}
+void HOT WaveshareEPaper7P3InF::display() {
+  ESP_LOGI(TAG, "EXEC DISPLAY");//debug
+  if (this->buffers_ == nullptr) {
+    ESP_LOGE(TAG, "Buffer unavailable!");
+    return;
+  }
+  uint32_t buf_len = this->get_buffer_length_();
+
+  // WAKE UP FROM DEEP SLEEP
+  if (this->deep_sleep_between_updates_) {
+    ESP_LOGI(TAG, "Wake up the display from deep sleep");
+    this->reset_();
+    this->wait_until_idle_();
+    this->initialize();
+  }
+
+  // COMMAND DATA START TRANSMISSION
+  ESP_LOGI(TAG, "Sending data to the display");
+  ESP_LOGI(TAG, "buf_len : %d", buf_len);//debug
+  this->command(0x10);
+  delay(2);
+  uint32_t small_buffer_length = this->get_buffer_length_() / NUM_BUFFERS;
+  ESP_LOGI(TAG, "small_buffer_length : %d",small_buffer_length);
+  for (int buffer_index = 0; buffer_index < NUM_BUFFERS; buffer_index++) {
+    ESP_LOGI(TAG, "Buffer n°%d points to: %d", buffer_index, this->buffers_[buffer_index]);
+    for (uint32_t buffer_pos = 0; buffer_pos < small_buffer_length; buffer_pos++) {
+      //this->buffers_[buffer_index][buffer_pos] = 0x22;
+      this->data(this->buffers_[buffer_index][buffer_pos]);
+      if (buffer_pos<5){
+        ESP_LOGI(TAG, "Buffer n°%d pos %d points to: %d, value is 0x%X", buffer_index, buffer_pos, &(this->buffers_[buffer_index][buffer_pos]), this->buffers_[buffer_index][buffer_pos]);
+      }
+    }
+    App.feed_wdt();
+    ESP_LOGI(TAG, "ok");
+  }
+  this->wait_until_idle_();
+
+  // COMMAND POWER ON
+  ESP_LOGI(TAG, "Power on the display");
+  this->command(0x04);
+  this->wait_until_idle_();
+
+  // COMMAND REFRESH SCREEN
+  ESP_LOGI(TAG, "Refresh the display");
+  this->command(0x12);
+  this->data(0x00);
+  this->wait_until_idle_();
+
+  // COMMAND POWER OFF
+  ESP_LOGI(TAG, "Power off the display");
+  this->command(0x02);
+  this->data(0x00);
+  this->wait_until_idle_();
+
+
+  if (this->deep_sleep_between_updates_) {
+    ESP_LOGI(TAG, "Set the display to deep sleep");
+    this->command(0x07);
+    this->data(0xA5);
+  }
+}
+int WaveshareEPaper7P3InF::get_width_internal() { return 800; }
+int WaveshareEPaper7P3InF::get_height_internal() { return 480; }
+uint32_t WaveshareEPaper7P3InF::idle_timeout_() { return 35000; }
+void WaveshareEPaper7P3InF::dump_config() {
+  LOG_DISPLAY("", "Waveshare E-Paper", this);
+  ESP_LOGCONFIG(TAG, "  Model: 7.3in-F");
+  LOG_PIN("  Reset Pin: ", this->reset_pin_);
+  LOG_PIN("  DC Pin: ", this->dc_pin_);
+  LOG_PIN("  Busy Pin: ", this->busy_pin_);
+  LOG_UPDATE_INTERVAL(this);
+}
+
+bool WaveshareEPaper7P3InF::wait_until_idle_() {
+  if (this->busy_pin_ == nullptr) {
+    return true;
+  }
+  const uint32_t start = millis();
+  while (this->busy_pin_->digital_read()) {
+    if (millis() - start > this->idle_timeout_()) {
+      ESP_LOGI(TAG, "Timeout while displaying image!");
+      return false;
+    }
+    App.feed_wdt();
+    delay(10);
+  }
+  delay(200);
+  //ESP_LOGI(TAG, "Was in 7P3::wait_until_idle_() for %d ms", millis() - start);
+  return true;
 }
 
 void WaveshareEPaper7P5InBV2::initialize() {

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -198,9 +198,7 @@ void WaveshareEPaper7C::init_internal_(uint32_t buffer_length) {
 }
 uint8_t WaveshareEPaper7C::color_to_hex(Color color) {
   uint8_t hex_code;
-  if (!color.is_on()) {
-    hex_code = 0x1; //White background by default
-  } else if (((color.red < 127) && (color.green < 127) && (color.blue < 127))) {
+  if (((color.red < 127) && (color.green < 127) && (color.blue < 127))) {
     hex_code = 0x0; //Black
   } else if (((color.red > 127) && (color.green > 127) && (color.blue > 127))) {
     hex_code = 0x1; //White
@@ -220,7 +218,14 @@ uint8_t WaveshareEPaper7C::color_to_hex(Color color) {
   return hex_code;
 }
 void WaveshareEPaper7C::fill(Color color) {
-  uint8_t pixel_color = this->color_to_hex(color);
+  uint8_t pixel_color;
+  if (color.is_on()) {
+    pixel_color = this->color_to_hex(color);
+  }
+  else{
+    pixel_color = 0x1;
+  }
+  
   if (this->buffers_ == nullptr) {
     ESP_LOGE(TAG, "Buffer unavailable!");
   }

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -111,8 +111,14 @@ static const uint8_t PARTIAL_UPD_2IN9_LUT[PARTIAL_UPD_2IN9_LUT_SIZE] =
 };
 // clang-format on
 
-void WaveshareEPaperBase::setup_pins_() {
+void WaveshareEPaperBase::setup() {
   this->init_internal_(this->get_buffer_length_());
+  this->setup_pins_();//was in setup
+  this->spi_setup();
+  this->reset_();
+  this->initialize();//was in setup
+}
+void WaveshareEPaperBase::setup_pins_() {
   this->dc_pin_->setup();  // OUTPUT
   this->dc_pin_->digital_write(false);
   if (this->reset_pin_ != nullptr) {
@@ -122,9 +128,6 @@ void WaveshareEPaperBase::setup_pins_() {
   if (this->busy_pin_ != nullptr) {
     this->busy_pin_->setup();  // INPUT
   }
-  this->spi_setup();
-
-  this->reset_();
 }
 float WaveshareEPaperBase::get_setup_priority() const { return setup_priority::PROCESSOR; }
 void WaveshareEPaperBase::command(uint8_t value) {

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -187,7 +187,7 @@ void WaveshareEPaper7C::init_internal_(uint32_t buffer_length) {
     this->buffers_[i] = allocator.allocate(small_buffer_length);
     if (this->buffers_[i] == nullptr) {
       ESP_LOGE(TAG, "Could not allocate buffer %d for display!", i);
-      for (auto & buffer : this->buffers_) {
+      for (auto &buffer : this->buffers_) {
         allocator.deallocate(buffer, small_buffer_length);
         buffer = nullptr;
       }
@@ -229,14 +229,13 @@ void WaveshareEPaper7C::fill(Color color) {
     ESP_LOGE(TAG, "Buffer unavailable!");
   } else {
     uint32_t small_buffer_length = this->get_buffer_length_() / NUM_BUFFERS;
-    for (auto & buffer : this->buffers_) {
+    for (auto &buffer : this->buffers_) {
       for (uint32_t buffer_pos = 0; buffer_pos < small_buffer_length; buffer_pos += 3) {
         // We store 8 bitset<3> in 3 bytes
         // | byte 1 | byte 2 | byte 3 |
         // |aaabbbaa|abbbaaab|bbaaabbb|
         buffer[buffer_pos + 0] = pixel_color << 5 | pixel_color << 2 | pixel_color >> 1;
-        buffer[buffer_pos + 1] =
-            pixel_color << 7 | pixel_color << 4 | pixel_color << 1 | pixel_color >> 2;
+        buffer[buffer_pos + 1] = pixel_color << 7 | pixel_color << 4 | pixel_color << 1 | pixel_color >> 2;
         buffer[buffer_pos + 2] = pixel_color << 6 | pixel_color << 3 | pixel_color << 0;
       }
       App.feed_wdt();
@@ -2615,11 +2614,10 @@ void HOT WaveshareEPaper7P3InF::display() {
   this->command(0x10);
   uint32_t small_buffer_length = this->get_buffer_length_() / NUM_BUFFERS;
   uint8_t byte_to_send;
-  for (auto & buffer : this->buffers_) {
+  for (auto &buffer : this->buffers_) {
     for (uint32_t buffer_pos = 0; buffer_pos < small_buffer_length; buffer_pos += 3) {
-      std::bitset<24> triplet = buffer[buffer_pos + 0] << 16 |
-                                buffer[buffer_pos + 1] << 8 |
-                                buffer[buffer_pos + 2] << 0;
+      std::bitset<24> triplet = 
+          buffer[buffer_pos + 0] << 16 | buffer[buffer_pos + 1] << 8 | buffer[buffer_pos + 2] << 0;
       // 8 bitset<3> are stored in 3 bytes
       // |aaabbbaa|abbbaaab|bbaaabbb|
       // | byte 1 | byte 2 | byte 3 |

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -113,10 +113,10 @@ static const uint8_t PARTIAL_UPD_2IN9_LUT[PARTIAL_UPD_2IN9_LUT_SIZE] =
 
 void WaveshareEPaperBase::setup() {
   this->init_internal_(this->get_buffer_length_());
-  this->setup_pins_();//was in setup
+  this->setup_pins_();
   this->spi_setup();
   this->reset_();
-  this->initialize();//was in setup
+  this->initialize();
 }
 void WaveshareEPaperBase::setup_pins_() {
   this->dc_pin_->setup();  // OUTPUT
@@ -177,7 +177,14 @@ void WaveshareEPaper::fill(Color color) {
   for (uint32_t i = 0; i < this->get_buffer_length_(); i++)
     this->buffer_[i] = fill;
 }
-void WaveshareEPaper7C::init_internal_(uint32_t buffer_length) {
+void WaveshareEPaper7C::setup() {
+  this->init_internal_7c_(this->get_buffer_length_());
+  this->setup_pins_();
+  this->spi_setup();
+  this->reset_();
+  this->initialize();
+}
+void WaveshareEPaper7C::init_internal_7c_(uint32_t buffer_length) {
   ExternalRAMAllocator<uint8_t> allocator(ExternalRAMAllocator<uint8_t>::ALLOW_FAILURE);
   uint32_t small_buffer_length = buffer_length / NUM_BUFFERS;
 

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -187,9 +187,9 @@ void WaveshareEPaper7C::init_internal_(uint32_t buffer_length) {
     this->buffers_[i] = allocator.allocate(small_buffer_length);
     if (this->buffers_[i] == nullptr) {
       ESP_LOGE(TAG, "Could not allocate buffer %d for display!", i);
-      for (int k = 0; k < NUM_BUFFERS; k++) {
-        allocator.deallocate(this->buffers_[k], small_buffer_length);
-        this->buffers_[k] = nullptr;
+      for (auto & buffer : this->buffers_) {
+        allocator.deallocate(buffer, small_buffer_length);
+        buffer = nullptr;
       }
       return;
     }
@@ -229,15 +229,15 @@ void WaveshareEPaper7C::fill(Color color) {
     ESP_LOGE(TAG, "Buffer unavailable!");
   } else {
     uint32_t small_buffer_length = this->get_buffer_length_() / NUM_BUFFERS;
-    for (int buffer_index = 0; buffer_index < NUM_BUFFERS; buffer_index++) {
+    for (auto & buffer : this->buffers_) {
       for (uint32_t buffer_pos = 0; buffer_pos < small_buffer_length; buffer_pos += 3) {
         // We store 8 bitset<3> in 3 bytes
         // | byte 1 | byte 2 | byte 3 |
         // |aaabbbaa|abbbaaab|bbaaabbb|
-        this->buffers_[buffer_index][buffer_pos + 0] = pixel_color << 5 | pixel_color << 2 | pixel_color >> 1;
-        this->buffers_[buffer_index][buffer_pos + 1] =
+        buffer[buffer_pos + 0] = pixel_color << 5 | pixel_color << 2 | pixel_color >> 1;
+        buffer[buffer_pos + 1] =
             pixel_color << 7 | pixel_color << 4 | pixel_color << 1 | pixel_color >> 2;
-        this->buffers_[buffer_index][buffer_pos + 2] = pixel_color << 6 | pixel_color << 3 | pixel_color << 0;
+        buffer[buffer_pos + 2] = pixel_color << 6 | pixel_color << 3 | pixel_color << 0;
       }
       App.feed_wdt();
     }
@@ -2615,24 +2615,24 @@ void HOT WaveshareEPaper7P3InF::display() {
   this->command(0x10);
   uint32_t small_buffer_length = this->get_buffer_length_() / NUM_BUFFERS;
   uint8_t byte_to_send;
-  for (int buffer_index = 0; buffer_index < NUM_BUFFERS; buffer_index++) {
+  for (auto & buffer : this->buffers_) {
     for (uint32_t buffer_pos = 0; buffer_pos < small_buffer_length; buffer_pos += 3) {
-      std::bitset<24> triplet = this->buffers_[buffer_index][buffer_pos + 0] << 16 |
-                                this->buffers_[buffer_index][buffer_pos + 1] << 8 |
-                                this->buffers_[buffer_index][buffer_pos + 2] << 0;
+      std::bitset<24> triplet = buffer[buffer_pos + 0] << 16 |
+                                buffer[buffer_pos + 1] << 8 |
+                                buffer[buffer_pos + 2] << 0;
       // 8 bitset<3> are stored in 3 bytes
       // |aaabbbaa|abbbaaab|bbaaabbb|
       // | byte 1 | byte 2 | byte 3 |
-      byte_to_send = (triplet >> 17).to_ulong() & 0b01110000 | (triplet >> 18).to_ulong() & 0b00000111;
+      byte_to_send = ((triplet >> 17).to_ulong() & 0b01110000) | ((triplet >> 18).to_ulong() & 0b00000111);
       this->data(byte_to_send);
 
-      byte_to_send = (triplet >> 11).to_ulong() & 0b01110000 | (triplet >> 12).to_ulong() & 0b00000111;
+      byte_to_send = ((triplet >> 11).to_ulong() & 0b01110000) | ((triplet >> 12).to_ulong() & 0b00000111);
       this->data(byte_to_send);
 
-      byte_to_send = (triplet >> 5).to_ulong() & 0b01110000 | (triplet >> 6).to_ulong() & 0b00000111;
+      byte_to_send = ((triplet >> 5).to_ulong() & 0b01110000) | ((triplet >> 6).to_ulong() & 0b00000111);
       this->data(byte_to_send);
 
-      byte_to_send = (triplet << 1).to_ulong() & 0b01110000 | (triplet << 0).to_ulong() & 0b00000111;
+      byte_to_send = ((triplet << 1).to_ulong() & 0b01110000) | ((triplet << 0).to_ulong() & 0b00000111);
       this->data(byte_to_send);
     }
     App.feed_wdt();

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -181,12 +181,10 @@ void WaveshareEPaper7C::init_internal_(uint32_t buffer_length) {
   }
 
   ExternalRAMAllocator<uint8_t> allocator(ExternalRAMAllocator<uint8_t>::ALLOW_FAILURE);
-
   uint32_t small_buffer_length = buffer_length / NUM_BUFFERS;
 
   for (int i = 0; i < NUM_BUFFERS; i++) {
     this->buffers_[i] = allocator.allocate(small_buffer_length);
-    
     if (this->buffers_[i] == nullptr) {
       ESP_LOGE(TAG, "Could not allocate buffer %d for display!", i);
       for (int k = 0; k < NUM_BUFFERS; k++){
@@ -302,7 +300,6 @@ void HOT WaveshareEPaper7C::draw_absolute_pixel_internal(int x, int y, Color col
     return;
 
   uint8_t pixel_bits = this->color_to_hex(color);
-
   uint32_t small_buffer_length = this->get_buffer_length_() / NUM_BUFFERS;
   uint32_t pixel_position = x + y * this->get_width_controller(); //xème pixel
   uint32_t first_bit_position = pixel_position * 3; //xème bit (début du pixel)
@@ -326,7 +323,6 @@ void HOT WaveshareEPaper7C::draw_absolute_pixel_internal(int x, int y, Color col
         | (pixel_bits << (13 - byte_subposition));
   }
 }
-
 void WaveshareEPaperBase::start_command_() {
   this->dc_pin_->digital_write(false);
   this->enable();
@@ -1428,7 +1424,8 @@ void WaveshareEPaper2P9InBV3::dump_config() {
   LOG_UPDATE_INTERVAL(this);
 }
 
-// ========================================================//               2.90in v2 rev2
+// ========================================================
+//               2.90in v2 rev2
 // based on SDK and examples in ZIP file from:
 // https://www.waveshare.com/pico-epaper-2.9.htm
 // ========================================================
@@ -2648,7 +2645,6 @@ void HOT WaveshareEPaper7P3InF::display() {
     }
     App.feed_wdt();
   }
-  //this->wait_until_idle_();
 
   // COMMAND POWER ON
   ESP_LOGI(TAG, "Power on the display");
@@ -2671,8 +2667,6 @@ void HOT WaveshareEPaper7P3InF::display() {
   ESP_LOGE(TAG, "GO TO DEEP SLEEP");
   this->command(0x07);
   this->data(0xA5);
-
-  //this->reset_();
 }
 int WaveshareEPaper7P3InF::get_width_internal() { return 800; }
 int WaveshareEPaper7P3InF::get_height_internal() { return 480; }

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -2662,7 +2662,6 @@ void HOT WaveshareEPaper7P3InF::display() {
   this->wait_until_idle_();
 
   ESP_LOGI(TAG, "Set the display to deep sleep");
-  ESP_LOGE(TAG, "GO TO DEEP SLEEP");
   this->command(0x07);
   this->data(0xA5);
 }

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -198,23 +198,37 @@ void WaveshareEPaper7C::init_internal_(uint32_t buffer_length) {
 }
 uint8_t WaveshareEPaper7C::color_to_hex(Color color) {
   uint8_t hex_code;
-  if (((color.red < 127) && (color.green < 127) && (color.blue < 127))) {
-    hex_code = 0x0;  // Black
-  } else if (((color.red > 127) && (color.green > 127) && (color.blue > 127))) {
-    hex_code = 0x1;  // White
-  } else if (((color.red < 127) && (color.green > 127) && (color.blue < 127))) {
-    hex_code = 0x2;  // Green
-  } else if (((color.red < 127) && (color.green < 127) && (color.blue > 127))) {
-    hex_code = 0x3;  // Blue
-  } else if (((color.red > 127) && (color.green < 127) && (color.blue < 127))) {
-    hex_code = 0x4;  // Red
-  } else if (((color.red > 127) && (color.green > 127) && (color.blue < 127))) {
-    hex_code = 0x5;  // Yellow
-  } else if (((color.red > 127) && (color.green > 64) && (color.green < 191) && (color.blue < 127))) {
-    hex_code = 0x6;  // Orange
+
+  if (color.red > 127) {
+    if (color.blue > 127) {
+      if (color.green > 127) {
+        hex_code = 0x1;  // White
+      } else {
+        hex_code = 0x5;  // Yellow
+      }
+    } else {
+      if (color.green > 85 && color.green < 170 ) {
+        hex_code = 0x6;  // Orange
+      } else {
+        hex_code = 0x4;  // Red
+      }
+    }
   } else {
-    hex_code = 0x1;  // White
+    if (color.green > 127) {
+      if (color.blue > 127) {
+        hex_code = 0x3;  // Blue
+      } else {
+        hex_code = 0x2;  // Green
+      }
+    } else {
+      if (color.blue > 127) {
+        hex_code = 0x3;  // Blue
+      } else {
+        hex_code = 0x0;  // Black
+      }
+    }
   }
+
   return hex_code;
 }
 void WaveshareEPaper7C::fill(Color color) {
@@ -225,7 +239,7 @@ void WaveshareEPaper7C::fill(Color color) {
     pixel_color = 0x1;
   }
 
-  if (this->buffers_ == nullptr) {
+  if (this->buffers_[0] == nullptr) {
     ESP_LOGE(TAG, "Buffer unavailable!");
   } else {
     uint32_t small_buffer_length = this->get_buffer_length_() / NUM_BUFFERS;
@@ -2496,7 +2510,7 @@ void WaveshareEPaper7P5In::dump_config() {
   LOG_UPDATE_INTERVAL(this);
 }
 void WaveshareEPaper7P3InF::initialize() {
-  if (this->buffers_ == nullptr) {
+  if (this->buffers_[0] == nullptr) {
     ESP_LOGE(TAG, "Buffer unavailable!");
     return;
   }
@@ -2599,11 +2613,10 @@ void WaveshareEPaper7P3InF::initialize() {
   ESP_LOGI(TAG, "Display initialized successfully");
 }
 void HOT WaveshareEPaper7P3InF::display() {
-  if (this->buffers_ == nullptr) {
+  if (this->buffers_[0] == nullptr) {
     ESP_LOGE(TAG, "Buffer unavailable!");
     return;
   }
-  uint32_t buf_len = this->get_buffer_length_();
 
   // INITIALIZATION
   ESP_LOGI(TAG, "Initialise the display");

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -193,25 +193,22 @@ void WaveshareEPaper7C::init_internal_(uint32_t buffer_length) {
 }
 uint8_t WaveshareEPaper7C::color_to_hex(Color color) {
   uint8_t hex_code;
-
   if (color.red > 127) {
-    if (color.blue > 127) {
-      if (color.green > 127) {
+    if (color.green > 170) {
+      if (color.blue > 127) {
         hex_code = 0x1;  // White
       } else {
         hex_code = 0x5;  // Yellow
       }
+    } else if (color.green > 85) {
+      hex_code = 0x6;  // Orange
     } else {
-      if (color.green > 85 && color.green < 170) {
-        hex_code = 0x6;  // Orange
-      } else {
-        hex_code = 0x4;  // Red
-      }
+      hex_code = 0x4;  // Red (or Magenta)
     }
   } else {
     if (color.green > 127) {
       if (color.blue > 127) {
-        hex_code = 0x3;  // Blue
+        hex_code = 0x3;  // Cyan -> Blue
       } else {
         hex_code = 0x2;  // Green
       }

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -2616,7 +2616,7 @@ void HOT WaveshareEPaper7P3InF::display() {
   uint8_t byte_to_send;
   for (auto &buffer : this->buffers_) {
     for (uint32_t buffer_pos = 0; buffer_pos < small_buffer_length; buffer_pos += 3) {
-      std::bitset<24> triplet = 
+      std::bitset<24> triplet =
           buffer[buffer_pos + 0] << 16 | buffer[buffer_pos + 1] << 8 | buffer[buffer_pos + 2] << 0;
       // 8 bitset<3> are stored in 3 bytes
       // |aaabbbaa|abbbaaab|bbaaabbb|

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -199,21 +199,21 @@ void WaveshareEPaper7C::init_internal_(uint32_t buffer_length) {
 uint8_t WaveshareEPaper7C::color_to_hex(Color color) {
   uint8_t hex_code;
   if (((color.red < 127) && (color.green < 127) && (color.blue < 127))) {
-    hex_code = 0x0;  //Black
+    hex_code = 0x0;  // Black
   } else if (((color.red > 127) && (color.green > 127) && (color.blue > 127))) {
-    hex_code = 0x1;  //White
+    hex_code = 0x1;  // White
   } else if (((color.red < 127) && (color.green > 127) && (color.blue < 127))) {
-    hex_code = 0x2;  //Green
+    hex_code = 0x2;  // Green
   } else if (((color.red < 127) && (color.green < 127) && (color.blue > 127))) {
-    hex_code = 0x3;  //Blue
+    hex_code = 0x3;  // Blue
   } else if (((color.red > 127) && (color.green < 127) && (color.blue < 127))) {
-    hex_code = 0x4;  //Red
+    hex_code = 0x4;  // Red
   } else if (((color.red > 127) && (color.green > 127) && (color.blue < 127))) {
-    hex_code = 0x5;  //Yellow
+    hex_code = 0x5;  // Yellow
   } else if (((color.red > 127) && (color.green > 64) && (color.green < 191) && (color.blue < 127))) {
-    hex_code = 0x6;  //Orange
+    hex_code = 0x6;  // Orange
   } else {
-    hex_code = 0x1;  //White
+    hex_code = 0x1;  // White
   }
   return hex_code;
 }
@@ -235,7 +235,7 @@ void WaveshareEPaper7C::fill(Color color) {
         // | byte 1 | byte 2 | byte 3 |
         // |aaabbbaa|abbbaaab|bbaaabbb|
         this->buffers_[buffer_index][buffer_pos + 0] = pixel_color << 5 | pixel_color << 2 | pixel_color >> 1;
-        this->buffers_[buffer_index][buffer_pos + 1] = 
+        this->buffers_[buffer_index][buffer_pos + 1] =
             pixel_color << 7 | pixel_color << 4 | pixel_color << 1 | pixel_color >> 2;
         this->buffers_[buffer_index][buffer_pos + 2] = pixel_color << 6 | pixel_color << 3 | pixel_color << 0;
       }
@@ -305,7 +305,7 @@ void HOT WaveshareEPaper7C::draw_absolute_pixel_internal(int x, int y, Color col
   uint32_t buffer_position = byte_position / small_buffer_length;
   uint32_t buffer_subposition = byte_position % small_buffer_length;
 
-   if (byte_subposition <= 5) {
+  if (byte_subposition <= 5) {
     this->buffers_[buffer_position][buffer_subposition] =
         (this->buffers_[buffer_position][buffer_subposition] & (0xFF ^ (0b111 << (5 - byte_subposition)))) |
         (pixel_bits << (5 - byte_subposition));
@@ -2615,7 +2615,8 @@ void HOT WaveshareEPaper7P3InF::display() {
   this->command(0x10);
   uint32_t small_buffer_length = this->get_buffer_length_() / NUM_BUFFERS;
   uint8_t byte_to_send;
-  for (uint32_t buffer_pos = 0; buffer_pos < small_buffer_length; buffer_pos += 3) {
+  for (int buffer_index = 0; buffer_index < NUM_BUFFERS; buffer_index++) {
+    for (uint32_t buffer_pos = 0; buffer_pos < small_buffer_length; buffer_pos += 3) {
       std::bitset<24> triplet = this->buffers_[buffer_index][buffer_pos + 0] << 16 |
                                 this->buffers_[buffer_index][buffer_pos + 1] << 8 |
                                 this->buffers_[buffer_index][buffer_pos + 2] << 0;

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -175,14 +175,11 @@ void WaveshareEPaper::fill(Color color) {
     this->buffer_[i] = fill;
 }
 void WaveshareEPaper7C::init_internal_(uint32_t buffer_length) {
-  ESP_LOGI(TAG, "Buffer n°0 points to: %d", this->buffers_[0]);
+  ESP_LOGI(TAG, "Buffer n°0 points to: %d", this->buffers_[0]);//debug
   ESP_LOGI(TAG, "EXEC CUSTOM WaveshareEPaper7C::init_internal_, creating splitted buffer");//debug
   for (int i = 0; i < NUM_BUFFERS; i++)
     this->buffers_[i] = nullptr;
 
-
-
-  ESP_LOGI(TAG, "EXEC CUSTOM WaveshareEPaper7C::init_internal_, creating splitted buffer");//debug
   ESP_LOGI(TAG, "Available ram before allocation: %d", heap_caps_get_free_size(MALLOC_CAP_INTERNAL));//debug
   //Same as DisplayBuffer::init_internal_, but here we split the buffer because of heap fragmentation
   
@@ -191,15 +188,16 @@ void WaveshareEPaper7C::init_internal_(uint32_t buffer_length) {
     return;
   }
 
+  //return;//debug
   ExternalRAMAllocator<uint8_t> allocator(ExternalRAMAllocator<uint8_t>::ALLOW_FAILURE);
-  //ExternalRAMAllocator<uint8_t> allocator;
+  //ExternalRAMAllocator<uint8_t> allocator;//test debug
 
   uint32_t small_buffer_length = buffer_length / NUM_BUFFERS;
   ESP_LOGI(TAG, "We want %d buffers of size %d", NUM_BUFFERS, small_buffer_length);//debug
 
   for (int i = 0; i < NUM_BUFFERS; i++)
     this->buffers_[i] = nullptr;
-  ESP_LOGI(TAG, "Buffer n°0 points to: %d", this->buffers_[0]);
+  ESP_LOGI(TAG, "Buffer n°0 points to: %d", this->buffers_[0]);//debug
 
   uint8_t * tmp = nullptr;
   for (int i = 0; i < NUM_BUFFERS; i++) {
@@ -208,25 +206,23 @@ void WaveshareEPaper7C::init_internal_(uint32_t buffer_length) {
     ESP_LOGI(TAG, "Biggest block: %d", heap_caps_get_largest_free_block(MALLOC_CAP_INTERNAL));//debug
     ESP_LOGI(TAG, "Wanted alloc: %d", small_buffer_length);//debug
     
-    this->buffers_[i] = allocator.allocate(small_buffer_length);;
+    this->buffers_[i] = allocator.allocate(small_buffer_length);
     
     if (this->buffers_[i] == nullptr) {
       ESP_LOGE(TAG, "Could not allocate buffer %d for display!", NUM_BUFFERS);
       ESP_LOGI(TAG, "Biggest block was: %d", heap_caps_get_largest_free_block(MALLOC_CAP_INTERNAL));//debug
-      
-      //TODO : desallocate before nullptr
-      ESP_LOGE(TAG, "Deleting all buffers");
+
+      //TODO : desallocate before setting to nullptr
+      ESP_LOGE(TAG, "Deleting all buffers");//debug
       for (int k = 0; k < NUM_BUFFERS; k++)
         this->buffers_[k] = nullptr;
-      ESP_LOGI(TAG, "Buffer n°0 points to: %d", this->buffers_[0]);
+      ESP_LOGI(TAG, "Buffer n°0 points to: %d", this->buffers_[0]);//debug, should be null
       return;
     }
-    ESP_LOGI(TAG, "Buffer n°%d points to: %d", i, this->buffers_[i]);
-
-    ESP_LOGI(TAG, "ok");//debug
+    ESP_LOGI(TAG, "Buffer n°%d points to: %d", i, this->buffers_[i]);//debug
   }
 
-  ESP_LOGI(TAG, "init_internal_ : %d buffers allocated with success", NUM_BUFFERS);
+  ESP_LOGI(TAG, "init_internal_ : %d buffers allocated with success", NUM_BUFFERS);//debug
   ESP_LOGI(TAG, "Available ram after allocation: %d", heap_caps_get_free_size(MALLOC_CAP_INTERNAL));//debug
 
   this->clear();
@@ -257,6 +253,7 @@ void WaveshareEPaper7C::fill(Color color) {
   ESP_LOGI(TAG, "this->get_width_internal() : %d", this->get_width_internal());
   ESP_LOGI(TAG, "this->get_height_internal() : %d", this->get_height_internal());
   ESP_LOGI(TAG, "this->get_buffer_length_() : %d", this->get_buffer_length_());
+  return;//debug
 
   uint8_t fill;
   if (!color.is_on()) { 
@@ -268,26 +265,26 @@ void WaveshareEPaper7C::fill(Color color) {
     ESP_LOGI(TAG, "Color: (%d,%d,%d) converted to 0x%X", color.red, color.green, color.blue, fill);
   }  
 
-  ESP_LOGI(TAG, "Check buffers");
+  ESP_LOGI(TAG, "Check buffers");//debug
   if (this->buffers_ == nullptr) {
     ESP_LOGE(TAG, "Buffer unavailable!");
   }
   else{
     uint32_t small_buffer_length = this->get_buffer_length_() / NUM_BUFFERS;
-    ESP_LOGI(TAG, "small_buffer_length : %d",small_buffer_length);
+    ESP_LOGI(TAG, "small_buffer_length : %d",small_buffer_length);//debug
     for (int buffer_index = 0; buffer_index < NUM_BUFFERS; buffer_index++) {
-      ESP_LOGI(TAG, "Buffer n°%d points to: %d", buffer_index, this->buffers_[buffer_index]);
+      ESP_LOGI(TAG, "Buffer n°%d points to: %d", buffer_index, this->buffers_[buffer_index]);//debug
       for (uint32_t buffer_pos = 0; buffer_pos < small_buffer_length; buffer_pos++) {
         this->buffers_[buffer_index][buffer_pos] = fill;
         if (buffer_pos<5){
-          ESP_LOGI(TAG, "Buffer n°%d pos %d points to: %d, value is 0x%X", buffer_index, buffer_pos, &(this->buffers_[buffer_index][buffer_pos]), fill);
+          ESP_LOGI(TAG, "Buffer n°%d pos %d points to: %d, value is 0x%X", buffer_index, buffer_pos, &(this->buffers_[buffer_index][buffer_pos]), fill);//debug
         }
       }
       App.feed_wdt();
-      ESP_LOGI(TAG, "ok");
+      ESP_LOGI(TAG, "ok");//debug
     }
   }
-  ESP_LOGI(TAG, "fill done");
+  ESP_LOGI(TAG, "fill done");//debug
 }
 void HOT WaveshareEPaper::draw_absolute_pixel_internal(int x, int y, Color color) {
   if (x >= this->get_width_internal() || y >= this->get_height_internal() || x < 0 || y < 0)
@@ -310,7 +307,7 @@ uint32_t WaveshareEPaperBWR::get_buffer_length_() {
   return this->get_width_controller() * this->get_height_internal() / 4u;
 }  // black and red buffer
 uint32_t WaveshareEPaper7C::get_buffer_length_() {
-  return this->get_width_controller() * this->get_height_internal() / 2u;//The goal is to put 2u here instead of 4u
+  return this->get_width_controller() * this->get_height_internal() / 3u;//2u make wifi crash, 3u is ok
 }  // 7 colors buffer
 
 void WaveshareEPaperBWR::fill(Color color) {
@@ -340,6 +337,7 @@ void HOT WaveshareEPaperBWR::draw_absolute_pixel_internal(int x, int y, Color co
 }
 void HOT WaveshareEPaper7C::draw_absolute_pixel_internal(int x, int y, Color color) {
   ESP_LOGI(TAG, "EXEC WaveshareEPaper7C::draw_absolute_pixel_internal");
+  return;//debug
   if (x >= this->get_width_internal() || y >= this->get_height_internal() || x < 0 || y < 0)
     return;
 
@@ -1472,8 +1470,7 @@ void WaveshareEPaper2P9InBV3::dump_config() {
   LOG_UPDATE_INTERVAL(this);
 }
 
-// ========================================================
-//               2.90in v2 rev2
+// ========================================================//               2.90in v2 rev2
 // based on SDK and examples in ZIP file from:
 // https://www.waveshare.com/pico-epaper-2.9.htm
 // ========================================================
@@ -2237,196 +2234,6 @@ void WaveshareEPaper5P8InV2::dump_config() {
   LOG_PIN("  Busy Pin: ", this->busy_pin_);
   LOG_UPDATE_INTERVAL(this);
 }
-void WaveshareEPaper7P3InF::initialize() {
-  this->reset_();
-  delay(20);
-
-  if (this->buffers_ == nullptr) {
-    ESP_LOGE(TAG, "Buffer unavailable!");
-    return;
-  }
-  // COMMAND CMDH
-  this->command(0xAA); 
-  this->data(0x49);
-  this->data(0x55);
-  this->data(0x20);
-  this->data(0x08);
-  this->data(0x09);
-  this->data(0x18);
-
-  this->command(0x01);
-  this->data(0x3F);
-  this->data(0x00);
-  this->data(0x32);
-  this->data(0x2A);
-  this->data(0x0E);
-  this->data(0x2A);
-
-  this->command(0x00);
-  this->data(0x5F);
-  this->data(0x69);
-
-  this->command(0x03);
-  this->data(0x00);
-  this->data(0x54);
-  this->data(0x00);
-  this->data(0x44); 
-
-  this->command(0x05);
-  this->data(0x40);
-  this->data(0x1F);
-  this->data(0x1F);
-  this->data(0x2C);
-
-  this->command(0x06);
-  this->data(0x6F);
-  this->data(0x1F);
-  this->data(0x1F);
-  this->data(0x22);
-
-  this->command(0x08);
-  this->data(0x6F);
-  this->data(0x1F);
-  this->data(0x1F);
-  this->data(0x22);
-
-  // COMMAND IPC
-  this->command(0x13);
-  this->data(0x00);
-  this->data(0x04);
-
-  this->command(0x30);
-  this->data(0x3C);
-
-  // COMMAND TSE
-  this->command(0x41);
-  this->data(0x00);
-
-  this->command(0x50);
-  this->data(0x3F);
-
-  this->command(0x60);
-  this->data(0x02);
-  this->data(0x00);
-
-  this->command(0x61);
-  this->data(0x03);
-  this->data(0x20);
-  this->data(0x01); 
-  this->data(0xE0);
-
-  this->command(0x82);
-  this->data(0x1E); 
-
-  this->command(0x84);
-  this->data(0x00);
-
-  // COMMAND AGID
-  this->command(0x86);
-  this->data(0x00);
-
-  this->command(0xE3);
-  this->data(0x2F);
-
-  // COMMAND CCSET
-  this->command(0xE0);
-  this->data(0x00); 
-
-  // COMMAND TSSET
-  this->command(0xE6);
-  this->data(0x00);
-  ESP_LOGI(TAG, "Display initialized successfully");//debug
-}
-void HOT WaveshareEPaper7P3InF::display() {
-  ESP_LOGI(TAG, "EXEC DISPLAY");//debug
-  if (this->buffers_ == nullptr) {
-    ESP_LOGE(TAG, "Buffer unavailable!");
-    return;
-  }
-  uint32_t buf_len = this->get_buffer_length_();
-
-  // WAKE UP FROM DEEP SLEEP
-  if (this->deep_sleep_between_updates_) {
-    ESP_LOGI(TAG, "Wake up the display from deep sleep");
-    this->reset_();
-    this->wait_until_idle_();
-    this->initialize();
-  }
-
-  // COMMAND DATA START TRANSMISSION
-  ESP_LOGI(TAG, "Sending data to the display");
-  ESP_LOGI(TAG, "buf_len : %d", buf_len);//debug
-  this->command(0x10);
-  delay(2);
-  uint32_t small_buffer_length = this->get_buffer_length_() / NUM_BUFFERS;
-  ESP_LOGI(TAG, "small_buffer_length : %d",small_buffer_length);
-  for (int buffer_index = 0; buffer_index < NUM_BUFFERS; buffer_index++) {
-    ESP_LOGI(TAG, "Buffer n°%d points to: %d", buffer_index, this->buffers_[buffer_index]);
-    for (uint32_t buffer_pos = 0; buffer_pos < small_buffer_length; buffer_pos++) {
-      //this->buffers_[buffer_index][buffer_pos] = 0x22;
-      this->data(this->buffers_[buffer_index][buffer_pos]);
-      if (buffer_pos<5){
-        ESP_LOGI(TAG, "Buffer n°%d pos %d points to: %d, value is 0x%X", buffer_index, buffer_pos, &(this->buffers_[buffer_index][buffer_pos]), this->buffers_[buffer_index][buffer_pos]);
-      }
-    }
-    App.feed_wdt();
-    ESP_LOGI(TAG, "ok");
-  }
-  this->wait_until_idle_();
-
-  // COMMAND POWER ON
-  ESP_LOGI(TAG, "Power on the display");
-  this->command(0x04);
-  this->wait_until_idle_();
-
-  // COMMAND REFRESH SCREEN
-  ESP_LOGI(TAG, "Refresh the display");
-  this->command(0x12);
-  this->data(0x00);
-  this->wait_until_idle_();
-
-  // COMMAND POWER OFF
-  ESP_LOGI(TAG, "Power off the display");
-  this->command(0x02);
-  this->data(0x00);
-  this->wait_until_idle_();
-
-
-  if (this->deep_sleep_between_updates_) {
-    ESP_LOGI(TAG, "Set the display to deep sleep");
-    this->command(0x07);
-    this->data(0xA5);
-  }
-}
-int WaveshareEPaper7P3InF::get_width_internal() { return 800; }
-int WaveshareEPaper7P3InF::get_height_internal() { return 480; }
-uint32_t WaveshareEPaper7P3InF::idle_timeout_() { return 35000; }
-void WaveshareEPaper7P3InF::dump_config() {
-  LOG_DISPLAY("", "Waveshare E-Paper", this);
-  ESP_LOGCONFIG(TAG, "  Model: 7.3in-F");
-  LOG_PIN("  Reset Pin: ", this->reset_pin_);
-  LOG_PIN("  DC Pin: ", this->dc_pin_);
-  LOG_PIN("  Busy Pin: ", this->busy_pin_);
-  LOG_UPDATE_INTERVAL(this);
-}
-
-bool WaveshareEPaper7P3InF::wait_until_idle_() {
-  if (this->busy_pin_ == nullptr) {
-    return true;
-  }
-  const uint32_t start = millis();
-  while (this->busy_pin_->digital_read()) {
-    if (millis() - start > this->idle_timeout_()) {
-      ESP_LOGI(TAG, "Timeout while displaying image!");
-      return false;
-    }
-    App.feed_wdt();
-    delay(10);
-  }
-  delay(200);
-  //ESP_LOGI(TAG, "Was in 7P3::wait_until_idle_() for %d ms", millis() - start);
-  return true;
-}
 
 void WaveshareEPaper7P5InBV2::initialize() {
   // COMMAND POWER SETTING
@@ -2737,6 +2544,202 @@ void WaveshareEPaper7P5In::dump_config() {
   LOG_PIN("  DC Pin: ", this->dc_pin_);
   LOG_PIN("  Busy Pin: ", this->busy_pin_);
   LOG_UPDATE_INTERVAL(this);
+}
+void WaveshareEPaper7P3InF::initialize() {
+  ESP_LOGI(TAG, "initialize");
+  return;//debug
+  this->reset_();
+  delay(20);
+
+  if (this->buffers_ == nullptr) {
+    ESP_LOGE(TAG, "Buffer unavailable!");
+    return;
+  }
+  // COMMAND CMDH
+  this->command(0xAA); 
+  this->data(0x49);
+  this->data(0x55);
+  this->data(0x20);
+  this->data(0x08);
+  this->data(0x09);
+  this->data(0x18);
+
+  this->command(0x01);
+  this->data(0x3F);
+  this->data(0x00);
+  this->data(0x32);
+  this->data(0x2A);
+  this->data(0x0E);
+  this->data(0x2A);
+
+  this->command(0x00);
+  this->data(0x5F);
+  this->data(0x69);
+
+  this->command(0x03);
+  this->data(0x00);
+  this->data(0x54);
+  this->data(0x00);
+  this->data(0x44); 
+
+  this->command(0x05);
+  this->data(0x40);
+  this->data(0x1F);
+  this->data(0x1F);
+  this->data(0x2C);
+
+  this->command(0x06);
+  this->data(0x6F);
+  this->data(0x1F);
+  this->data(0x1F);
+  this->data(0x22);
+
+  this->command(0x08);
+  this->data(0x6F);
+  this->data(0x1F);
+  this->data(0x1F);
+  this->data(0x22);
+
+  // COMMAND IPC
+  this->command(0x13);
+  this->data(0x00);
+  this->data(0x04);
+
+  this->command(0x30);
+  this->data(0x3C);
+
+  // COMMAND TSE
+  this->command(0x41);
+  this->data(0x00);
+
+  this->command(0x50);
+  this->data(0x3F);
+
+  this->command(0x60);
+  this->data(0x02);
+  this->data(0x00);
+
+  this->command(0x61);
+  this->data(0x03);
+  this->data(0x20);
+  this->data(0x01); 
+  this->data(0xE0);
+
+  this->command(0x82);
+  this->data(0x1E); 
+
+  this->command(0x84);
+  this->data(0x00);
+
+  // COMMAND AGID
+  this->command(0x86);
+  this->data(0x00);
+
+  this->command(0xE3);
+  this->data(0x2F);
+
+  // COMMAND CCSET
+  this->command(0xE0);
+  this->data(0x00); 
+
+  // COMMAND TSSET
+  this->command(0xE6);
+  this->data(0x00);
+
+  ESP_LOGI(TAG, "Display initialized successfully");
+}
+void HOT WaveshareEPaper7P3InF::display() {
+  ESP_LOGI(TAG, "EXEC DISPLAY");//debug
+  return;
+  if (this->buffers_ == nullptr) {
+    ESP_LOGE(TAG, "Buffer unavailable!");
+    return;
+  }
+  uint32_t buf_len = this->get_buffer_length_();
+
+  // WAKE UP FROM DEEP SLEEP
+  if (this->deep_sleep_between_updates_) {
+    ESP_LOGI(TAG, "Wake up the display from deep sleep");
+    this->reset_();
+    this->wait_until_idle_();
+    this->initialize();
+  }
+
+  // COMMAND DATA START TRANSMISSION
+  ESP_LOGI(TAG, "Sending data to the display");
+  ESP_LOGI(TAG, "buf_len : %d", buf_len);//debug
+  this->command(0x10);
+  delay(2);
+  uint32_t small_buffer_length = this->get_buffer_length_() / NUM_BUFFERS;
+  ESP_LOGI(TAG, "small_buffer_length : %d",small_buffer_length);//debug
+  for (int buffer_index = 0; buffer_index < NUM_BUFFERS; buffer_index++) {
+    ESP_LOGI(TAG, "Buffer n°%d points to: %d", buffer_index, this->buffers_[buffer_index]);//debug
+    for (uint32_t buffer_pos = 0; buffer_pos < small_buffer_length; buffer_pos++) {
+      //this->buffers_[buffer_index][buffer_pos] = 0x22;
+      this->data(this->buffers_[buffer_index][buffer_pos]);
+      if (buffer_pos<5){
+        ESP_LOGI(TAG, "Buffer n°%d pos %d points to: %d, value is 0x%X", buffer_index, buffer_pos, &(this->buffers_[buffer_index][buffer_pos]), this->buffers_[buffer_index][buffer_pos]);//debug
+      }
+    }
+    App.feed_wdt();
+    ESP_LOGI(TAG, "ok");//debug
+  }
+  this->wait_until_idle_();
+
+  // COMMAND POWER ON
+  ESP_LOGI(TAG, "Power on the display");
+  this->command(0x04);
+  this->wait_until_idle_();
+
+  // COMMAND REFRESH SCREEN
+  ESP_LOGI(TAG, "Refresh the display");
+  this->command(0x12);
+  this->data(0x00);
+  this->wait_until_idle_();
+
+  // COMMAND POWER OFF
+  ESP_LOGI(TAG, "Power off the display");
+  this->command(0x02);
+  this->data(0x00);
+  this->wait_until_idle_();
+
+
+  if (this->deep_sleep_between_updates_) {
+    ESP_LOGI(TAG, "Set the display to deep sleep");
+    this->command(0x07);
+    this->data(0xA5);
+  }
+}
+int WaveshareEPaper7P3InF::get_width_internal() { return 800; }
+int WaveshareEPaper7P3InF::get_height_internal() { return 480; }
+uint32_t WaveshareEPaper7P3InF::idle_timeout_() { return 35000; }
+void WaveshareEPaper7P3InF::dump_config() {
+  LOG_DISPLAY("", "Waveshare E-Paper", this);
+  ESP_LOGCONFIG(TAG, "  Model: 7.3in-F");
+  LOG_PIN("  Reset Pin: ", this->reset_pin_);
+  LOG_PIN("  DC Pin: ", this->dc_pin_);
+  LOG_PIN("  Busy Pin: ", this->busy_pin_);
+  LOG_UPDATE_INTERVAL(this);
+}
+
+bool WaveshareEPaper7P3InF::wait_until_idle_() {
+  ESP_LOGI(TAG, "wifi wait_until_idle_");//debug
+  return true;
+  if (this->busy_pin_ == nullptr) {
+    return true;
+  }
+  const uint32_t start = millis();
+  while (this->busy_pin_->digital_read()) {
+    if (millis() - start > this->idle_timeout_()) {
+      ESP_LOGI(TAG, "Timeout while displaying image!");
+      return false;
+    }
+    App.feed_wdt();
+    delay(10);
+  }
+  delay(200);
+  //ESP_LOGI(TAG, "Was in 7P3::wait_until_idle_() for %d ms", millis() - start);
+  return true;
 }
 bool WaveshareEPaper7P5InV2::wait_until_idle_() {
   if (this->busy_pin_ == nullptr) {

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -175,11 +175,6 @@ void WaveshareEPaper::fill(Color color) {
     this->buffer_[i] = fill;
 }
 void WaveshareEPaper7C::init_internal_(uint32_t buffer_length) {
-  if (heap_caps_get_free_size(MALLOC_CAP_INTERNAL) < buffer_length) {
-    ESP_LOGE(TAG, "Could not allocate buffers, not enough ram!");
-    return;
-  }
-
   ExternalRAMAllocator<uint8_t> allocator(ExternalRAMAllocator<uint8_t>::ALLOW_FAILURE);
   uint32_t small_buffer_length = buffer_length / NUM_BUFFERS;
 
@@ -207,7 +202,7 @@ uint8_t WaveshareEPaper7C::color_to_hex(Color color) {
         hex_code = 0x5;  // Yellow
       }
     } else {
-      if (color.green > 85 && color.green < 170 ) {
+      if (color.green > 85 && color.green < 170) {
         hex_code = 0x6;  // Orange
       } else {
         hex_code = 0x4;  // Red

--- a/esphome/components/waveshare_epaper/waveshare_epaper.h
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.h
@@ -98,7 +98,7 @@ class WaveshareEPaper7C : public WaveshareEPaperBase {
  protected:
   void draw_absolute_pixel_internal(int x, int y, Color color) override;
   uint32_t get_buffer_length_() override;
-  void init_internal_(uint32_t buffer_length);
+  void init_internal_(uint32_t buffer_length) override;
 
   static const int NUM_BUFFERS = 10;
   uint8_t *buffers_[NUM_BUFFERS];

--- a/esphome/components/waveshare_epaper/waveshare_epaper.h
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.h
@@ -93,7 +93,8 @@ class WaveshareEPaper7C : public WaveshareEPaperBase {
  protected:
   void draw_absolute_pixel_internal(int x, int y, Color color) override;
   uint32_t get_buffer_length_() override;
-  void init_internal_(uint32_t buffer_length);
+  void setup() override;
+  void init_internal_7c_(uint32_t buffer_length);
 
   static const int NUM_BUFFERS = 10;
   uint8_t *buffers_[NUM_BUFFERS];

--- a/esphome/components/waveshare_epaper/waveshare_epaper.h
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.h
@@ -101,7 +101,7 @@ class WaveshareEPaper7C : public WaveshareEPaperBase {
   void init_internal_(uint32_t buffer_length);
 
   static const int NUM_BUFFERS = 10;
-  uint8_t * buffers_[NUM_BUFFERS];
+  uint8_t *buffers_[NUM_BUFFERS];
 };
 
 enum WaveshareEPaperTypeAModel {
@@ -566,10 +566,10 @@ class WaveshareEPaper7P3InF : public WaveshareEPaper7C {
   int get_width_internal() override;
 
   int get_height_internal() override;
-  
+
   uint32_t idle_timeout_() override;
-  
-  void deep_sleep() override {;}
+
+  void deep_sleep() override { ; }
 
   bool wait_until_idle_();
 

--- a/esphome/components/waveshare_epaper/waveshare_epaper.h
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.h
@@ -62,8 +62,6 @@ class WaveshareEPaperBase : public display::DisplayBuffer,
   GPIOPin *dc_pin_;
   GPIOPin *busy_pin_{nullptr};
   virtual uint32_t idle_timeout_() { return 1000u; }  // NOLINT(readability-identifier-naming)
-
-  virtual void init_internal_(uint32_t buffer_length);
 };
 
 class WaveshareEPaper : public WaveshareEPaperBase {
@@ -98,7 +96,7 @@ class WaveshareEPaper7C : public WaveshareEPaperBase {
  protected:
   void draw_absolute_pixel_internal(int x, int y, Color color) override;
   uint32_t get_buffer_length_() override;
-  void init_internal_(uint32_t buffer_length) override;
+  void init_internal_(uint32_t buffer_length);
 
   static const int NUM_BUFFERS = 10;
   uint8_t *buffers_[NUM_BUFFERS];
@@ -289,7 +287,6 @@ class GDEW0154M09 : public WaveshareEPaper {
   void display() override;
   void dump_config() override;
   void deep_sleep() override;
-  using WaveshareEPaper::init_internal_;
 
  protected:
   int get_width_internal() override;

--- a/esphome/components/waveshare_epaper/waveshare_epaper.h
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.h
@@ -289,6 +289,7 @@ class GDEW0154M09 : public WaveshareEPaper {
   void display() override;
   void dump_config() override;
   void deep_sleep() override;
+  using WaveshareEPaper::init_internal_;
 
  protected:
   int get_width_internal() override;

--- a/esphome/components/waveshare_epaper/waveshare_epaper.h
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.h
@@ -62,6 +62,8 @@ class WaveshareEPaperBase : public display::DisplayBuffer,
   GPIOPin *dc_pin_;
   GPIOPin *busy_pin_{nullptr};
   virtual uint32_t idle_timeout_() { return 1000u; }  // NOLINT(readability-identifier-naming)
+
+  virtual void init_internal_(uint32_t buffer_length);
 };
 
 class WaveshareEPaper : public WaveshareEPaperBase {
@@ -84,6 +86,22 @@ class WaveshareEPaperBWR : public WaveshareEPaperBase {
  protected:
   void draw_absolute_pixel_internal(int x, int y, Color color) override;
   uint32_t get_buffer_length_() override;
+};
+
+class WaveshareEPaper7C : public WaveshareEPaperBase {
+ public:
+  uint8_t color_to_hex(Color color);
+  void fill(Color color) override;
+
+  display::DisplayType get_display_type() override { return display::DisplayType::DISPLAY_TYPE_COLOR; }
+
+ protected:
+  void draw_absolute_pixel_internal(int x, int y, Color color) override;
+  uint32_t get_buffer_length_() override;
+  void init_internal_(uint32_t buffer_length);
+
+  static const int NUM_BUFFERS = 20;
+  uint8_t * buffers_[NUM_BUFFERS];
 };
 
 enum WaveshareEPaperTypeAModel {
@@ -160,6 +178,7 @@ enum WaveshareEPaperTypeBModel {
   WAVESHARE_EPAPER_2_7_IN_B_V2,
   WAVESHARE_EPAPER_4_2_IN,
   WAVESHARE_EPAPER_4_2_IN_B_V2,
+  WAVESHARE_EPAPER_7_3_IN_F,
   WAVESHARE_EPAPER_7_5_IN,
   WAVESHARE_EPAPER_7_5_INV2,
   WAVESHARE_EPAPER_7_5_IN_B_V2,
@@ -533,6 +552,28 @@ class WaveshareEPaper5P8InV2 : public WaveshareEPaper {
   int get_width_internal() override;
 
   int get_height_internal() override;
+};
+
+class WaveshareEPaper7P3InF : public WaveshareEPaper7C {
+ public:
+  void initialize() override;
+
+  void display() override;
+
+  void dump_config() override;
+
+ protected:
+  int get_width_internal() override;
+
+  int get_height_internal() override;
+  
+  uint32_t idle_timeout_() override;
+  
+  void deep_sleep() override {;}
+
+  bool wait_until_idle_();
+
+  bool deep_sleep_between_updates_{true};
 };
 
 class WaveshareEPaper7P5In : public WaveshareEPaper {

--- a/esphome/components/waveshare_epaper/waveshare_epaper.h
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.h
@@ -100,7 +100,7 @@ class WaveshareEPaper7C : public WaveshareEPaperBase {
   uint32_t get_buffer_length_() override;
   void init_internal_(uint32_t buffer_length);
 
-  static const int NUM_BUFFERS = 20;
+  static const int NUM_BUFFERS = 10;
   uint8_t * buffers_[NUM_BUFFERS];
 };
 
@@ -574,6 +574,17 @@ class WaveshareEPaper7P3InF : public WaveshareEPaper7C {
   bool wait_until_idle_();
 
   bool deep_sleep_between_updates_{true};
+
+  void reset_() {
+    if (this->reset_pin_ != nullptr) {
+      this->reset_pin_->digital_write(true);
+      delay(20);
+      this->reset_pin_->digital_write(false);
+      delay(1);
+      this->reset_pin_->digital_write(true);
+      delay(20);
+    }
+  };
 };
 
 class WaveshareEPaper7P5In : public WaveshareEPaper {

--- a/esphome/components/waveshare_epaper/waveshare_epaper.h
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.h
@@ -27,10 +27,7 @@ class WaveshareEPaperBase : public display::DisplayBuffer,
 
   void update() override;
 
-  void setup() override {
-    this->setup_pins_();
-    this->initialize();
-  }
+  void setup() override;
 
   void on_safe_shutdown() override;
 


### PR DESCRIPTION
# What does this implement/fix?

Add support for Waveshare 7.3" ACeP 7-Color e-paper display.

The display size is 480x800 pixels, and support 7 colors (black, white, red, green, blue, orange and yellow).

I've splitted the buffer in chunks to avoid problems due to heap fragmentation.

I've also optimized the allocated ram so it requires only 144,2kB of ram (each pixel requires 3 bits of ram)

Note: Also works with the Pimoroni Inky Frame 7.3 display (tested by @aeroniemi).

![demo](https://github.com/esphome/esphome/assets/55683504/d4b570c5-ed73-4f43-9bb8-0e2b0faad913)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#3806

## Test Environment

- [x] ESP32
- [x] ESP-WROOM-32 (tested by me)
- [x] ESP32 Lolin S2 mini (tested by @francisbesset)
- [x] Pi Pico W (tested by @aeroniemi)
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
```yaml
# Example config.yaml
font:
  - file: 'epaper/myfont.ttf'
    id: font1
    size: 40

spi:
  clk_pin: 18
  mosi_pin: 23

display:
  - platform: waveshare_epaper
    id: eink_display
    cs_pin: 5
    dc_pin: 26
    busy_pin: 
      number: 27
      inverted: True
    reset_pin: 25
    model: 7.30in-f
    update_interval: 900s
    lambda: |- 
      const auto BLACK   = Color(0,   0,   0,   0);
      const auto RED     = Color(255, 0,   0,   0);
      const auto GREEN   = Color(0,   255, 0,   0);
      const auto BLUE    = Color(0,   0,   255, 0);
      const auto YELLOW  = Color(255, 255, 0,   0);
      const auto ORANGE  = Color(255, 127, 0,   0);
      const auto WHITE   = Color(255, 255, 255, 0);

      it.print(0, 0, id(font1), BLACK, "Hello world!");
      it.print(80, 80, id(font1), BLUE, "Hello world!");
      it.print(160, 160, id(font1), GREEN, "Hello world!");
      it.print(240, 240, id(font1), YELLOW, "Hello world!");
      it.print(320, 320, id(font1), ORANGE, "Hello world!");
      it.print(400, 400, id(font1), RED, "Hello world!");
```

You can already use (and test) this screen by adding this to the esphome code:
```yaml
external_components:
  - source: github://pr#6380
    components: [ waveshare_epaper, display ]
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs): [esphome/esphome-docs#3805](https://github.com/esphome/esphome-docs/pull/3806)
