### PR TITLE
allow negative ppm for sensair

### DIFF
--- a/esphome/components/senseair/senseair.cpp
+++ b/esphome/components/senseair/senseair.cpp
@@ -54,7 +54,7 @@ void SenseAirComponent::update() {
   this->status_clear_warning();
   const uint8_t length = response[2];
   const uint16_t status = (uint16_t(response[3]) << 8) | response[4];
-  const int16_t ppm = (int16_t(response[length + 1]) << 8) | response[length + 2];
+  const int16_t ppm = int16_t((response[length + 1] << 8) | response[length + 2]);
 
   ESP_LOGD(TAG, "SenseAir Received CO₂=%dppm Status=0x%02X", ppm, status);
   if (this->co2_sensor_ != nullptr)

--- a/esphome/components/senseair/senseair.cpp
+++ b/esphome/components/senseair/senseair.cpp
@@ -54,7 +54,7 @@ void SenseAirComponent::update() {
   this->status_clear_warning();
   const uint8_t length = response[2];
   const uint16_t status = (uint16_t(response[3]) << 8) | response[4];
-  const uint16_t ppm = (uint16_t(response[length + 1]) << 8) | response[length + 2];
+  const int16_t ppm = (int16_t(response[length + 1]) << 8) | response[length + 2];
 
   ESP_LOGD(TAG, "SenseAir Received CO₂=%uppm Status=0x%02X", ppm, status);
   if (this->co2_sensor_ != nullptr)

--- a/esphome/components/senseair/senseair.cpp
+++ b/esphome/components/senseair/senseair.cpp
@@ -56,7 +56,7 @@ void SenseAirComponent::update() {
   const uint16_t status = (uint16_t(response[3]) << 8) | response[4];
   const int16_t ppm = (int16_t(response[length + 1]) << 8) | response[length + 2];
 
-  ESP_LOGD(TAG, "SenseAir Received CO₂=%uppm Status=0x%02X", ppm, status);
+  ESP_LOGD(TAG, "SenseAir Received CO₂=%dppm Status=0x%02X", ppm, status);
   if (this->co2_sensor_ != nullptr)
     this->co2_sensor_->publish_state(ppm);
 }


### PR DESCRIPTION
# What does this implement/fix?

The ppm values can go negative.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/5603

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
