### PR TITLE
IPv6 can't be enabled for libretiny

### DIFF
--- a/esphome/components/network/__init__.py
+++ b/esphome/components/network/__init__.py
@@ -6,6 +6,9 @@ from esphome.components.esp32 import add_idf_sdkconfig_option
 from esphome.const import (
     CONF_ENABLE_IPV6,
     CONF_MIN_IPV6_ADDR_COUNT,
+    PLATFORM_ESP32,
+    PLATFORM_ESP8266,
+    PLATFORM_RP2040,
 )
 
 CODEOWNERS = ["@esphome/core"]
@@ -16,25 +19,30 @@ IPAddress = network_ns.class_("IPAddress")
 
 CONFIG_SCHEMA = cv.Schema(
     {
-        cv.Optional(CONF_ENABLE_IPV6, default=False): cv.boolean,
+        cv.SplitDefault(CONF_ENABLE_IPV6): cv.All(
+            cv.boolean, cv.only_on([PLATFORM_ESP32, PLATFORM_ESP8266, PLATFORM_RP2040])
+        ),
         cv.Optional(CONF_MIN_IPV6_ADDR_COUNT, default=0): cv.positive_int,
     }
 )
 
 
 async def to_code(config):
-    cg.add_define("USE_NETWORK_IPV6", config[CONF_ENABLE_IPV6])
-    cg.add_define("USE_NETWORK_MIN_IPV6_ADDR_COUNT", config[CONF_MIN_IPV6_ADDR_COUNT])
-    if CORE.using_esp_idf:
-        add_idf_sdkconfig_option("CONFIG_LWIP_IPV6", config[CONF_ENABLE_IPV6])
-        add_idf_sdkconfig_option(
-            "CONFIG_LWIP_IPV6_AUTOCONFIG", config[CONF_ENABLE_IPV6]
+    if CONF_ENABLE_IPV6 in config:
+        cg.add_define("USE_NETWORK_IPV6", config[CONF_ENABLE_IPV6])
+        cg.add_define(
+            "USE_NETWORK_MIN_IPV6_ADDR_COUNT", config[CONF_MIN_IPV6_ADDR_COUNT]
         )
-    else:
-        if config[CONF_ENABLE_IPV6]:
-            cg.add_build_flag("-DCONFIG_LWIP_IPV6")
-            cg.add_build_flag("-DCONFIG_LWIP_IPV6_AUTOCONFIG")
-            if CORE.is_rp2040:
-                cg.add_build_flag("-DPIO_FRAMEWORK_ARDUINO_ENABLE_IPV6")
-            if CORE.is_esp8266:
-                cg.add_build_flag("-DPIO_FRAMEWORK_ARDUINO_LWIP2_IPV6_LOW_MEMORY")
+        if CORE.using_esp_idf:
+            add_idf_sdkconfig_option("CONFIG_LWIP_IPV6", config[CONF_ENABLE_IPV6])
+            add_idf_sdkconfig_option(
+                "CONFIG_LWIP_IPV6_AUTOCONFIG", config[CONF_ENABLE_IPV6]
+            )
+        else:
+            if config[CONF_ENABLE_IPV6]:
+                cg.add_build_flag("-DCONFIG_LWIP_IPV6")
+                cg.add_build_flag("-DCONFIG_LWIP_IPV6_AUTOCONFIG")
+                if CORE.is_rp2040:
+                    cg.add_build_flag("-DPIO_FRAMEWORK_ARDUINO_ENABLE_IPV6")
+                if CORE.is_esp8266:
+                    cg.add_build_flag("-DPIO_FRAMEWORK_ARDUINO_LWIP2_IPV6_LOW_MEMORY")


### PR DESCRIPTION
# What does this implement/fix?

Make `enable_ipv6` only work on platforms that supports IPv6.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040
- [x] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
