### PR TITLE
Shows component operation time in `ms`

### DIFF
--- a/esphome/core/component.cpp
+++ b/esphome/core/component.cpp
@@ -5,6 +5,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 #include <utility>
+#include <inttypes.h>
 
 namespace esphome {
 
@@ -211,7 +212,7 @@ WarnIfComponentBlockingGuard::~WarnIfComponentBlockingGuard() {
   uint32_t now = millis();
   if (now - started_ > 50) {
     const char *src = component_ == nullptr ? "<null>" : component_->get_component_source();
-    ESP_LOGW(TAG, "Component %s took a long time for an operation (%u ms).", src, (now - started_));
+    ESP_LOGW(TAG, "Component %s took a long time for an operation (%" PRIu32 " ms).", src, (now - started_));
     ESP_LOGW(TAG, "Components should block for at most 30 ms.");
     ;
   }

--- a/esphome/core/component.cpp
+++ b/esphome/core/component.cpp
@@ -212,7 +212,7 @@ WarnIfComponentBlockingGuard::~WarnIfComponentBlockingGuard() {
   if (now - started_ > 50) {
     const char *src = component_ == nullptr ? "<null>" : component_->get_component_source();
     ESP_LOGW(TAG, "Component %s took a long time for an operation (%u ms).", src, (now - started_));
-    ESP_LOGW(TAG, "Components should block for at most 20-30ms.");
+    ESP_LOGW(TAG, "Components should block for at most 30 ms.");
     ;
   }
 }

--- a/esphome/core/component.cpp
+++ b/esphome/core/component.cpp
@@ -211,7 +211,7 @@ WarnIfComponentBlockingGuard::~WarnIfComponentBlockingGuard() {
   uint32_t now = millis();
   if (now - started_ > 50) {
     const char *src = component_ == nullptr ? "<null>" : component_->get_component_source();
-    ESP_LOGW(TAG, "Component %s took a long time for an operation (%.2f s).", src, (now - started_) / 1e3f);
+    ESP_LOGW(TAG, "Component %s took a long time for an operation (%u ms).", src, (now - started_));
     ESP_LOGW(TAG, "Components should block for at most 20-30ms.");
     ;
   }

--- a/esphome/core/component.cpp
+++ b/esphome/core/component.cpp
@@ -5,7 +5,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 #include <utility>
-#include <inttypes.h>
+#include <cinttypes>
 
 namespace esphome {
 


### PR DESCRIPTION
# What does this implement/fix?

This aligns the message with the following one with refence values. Also, we shouldn't be using "seconds" to measure time in this context. If precision is a concern, then we should add that to the message, and that should be the case regardless if using `ms` or `s`,

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Other

**Related issue or feature (if applicable):** I could find just a mention about this unit mismatch: https://github.com/esphome/esphome/issues/9517

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
N/A

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
