### PR TITLE
Fix compilation for uponor_smatrix without time component

### DIFF
--- a/esphome/components/uponor_smatrix/uponor_smatrix.cpp
+++ b/esphome/components/uponor_smatrix/uponor_smatrix.cpp
@@ -61,9 +61,11 @@ void UponorSmatrixComponent::loop() {
 
   // Send packets during bus silence
   if ((now - this->last_rx_ > 300) && (now - this->last_poll_start_ < 9500) && (now - this->last_tx_ > 200)) {
+#ifdef USE_TIME
     // Only build time packet when bus is silent and queue is empty to make sure we can send it right away
     if (this->send_time_requested_ && this->tx_queue_.empty() && this->do_send_time_())
       this->send_time_requested_ = false;
+#endif
     // Send the next packet in the queue
     if (!this->tx_queue_.empty()) {
       auto packet = std::move(this->tx_queue_.front());

--- a/esphome/components/uponor_smatrix/uponor_smatrix.h
+++ b/esphome/components/uponor_smatrix/uponor_smatrix.h
@@ -4,6 +4,8 @@
 #include "esphome/core/component.h"
 #include "esphome/core/helpers.h"
 
+#include "esphome/core/defines.h"
+
 #ifdef USE_TIME
 #include "esphome/components/time/real_time_clock.h"
 #include "esphome/core/time.h"


### PR DESCRIPTION
# What does this implement/fix?

Adds missing ifdef guard. Please also cherry-pick into current beta!

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
