### PR TITLE
Voice-Assistant: Start-order change for VAD disabled: start va-pipeline when microphon…

### DIFF
--- a/esphome/components/voice_assistant/voice_assistant.cpp
+++ b/esphome/components/voice_assistant/voice_assistant.cpp
@@ -144,7 +144,7 @@ void VoiceAssistant::loop() {
         } else
 #endif
         {
-          this->set_state_(State::START_PIPELINE, State::START_MICROPHONE);
+          this->set_state_(State::START_MICROPHONE, State::START_PIPELINE);
         }
       } else {
         this->high_freq_.stop();
@@ -474,7 +474,7 @@ void VoiceAssistant::request_start(bool continuous, bool silence_detection) {
     } else
 #endif
     {
-      this->set_state_(State::START_PIPELINE, State::START_MICROPHONE);
+      this->set_state_(State::START_MICROPHONE, State::START_PIPELINE);
     }
   }
 }


### PR DESCRIPTION
Changes the start order of VA-pipeline and microphone in voice assistant when VAD is disabled.

# What does this implement/fix?

Currently, when VAD is disabled the VA-pipeline is started first and then the microphone component is started.
In the case the microphone is not ready yet, it would be desirable to wait with starting the VA-pipeline until the mic becomes available. This PR changes this. 
 
<!-- Quick description and explanation of changes -->

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
