### PR TITLE
Fix sending packets to uponor_smatrix devices

### DIFF
--- a/esphome/components/uponor_smatrix/uponor_smatrix.cpp
+++ b/esphome/components/uponor_smatrix/uponor_smatrix.cpp
@@ -173,7 +173,9 @@ bool UponorSmatrixComponent::send(uint16_t device_address, const UponorSmatrixDa
     return false;
 
   // Assemble packet for send queue. All fields are big-endian except for the little-endian checksum.
-  std::vector<uint8_t> packet(6 + 3 * data_len);
+  std::vector<uint8_t> packet;
+  packet.reserve(6 + 3 * data_len);
+
   packet.push_back(this->address_ >> 8);
   packet.push_back(this->address_ >> 0);
   packet.push_back(device_address >> 8);


### PR DESCRIPTION
# What does this implement/fix?

While testing the beta, I just noticed a lot of unnecessary zero bytes being sent on the bus before the actual packets.
It turns out that the `vector(size_type count)` constructor does not only reserve a number of elements, but "Constructs the container with `count` default-inserted instances of T."
I therefore replaced this initialization with a call to `reserve` instead.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
