### PR TITLE
Require xsrf/csrf when using a password

### DIFF
--- a/esphome/dashboard/web_server.py
+++ b/esphome/dashboard/web_server.py
@@ -688,6 +688,11 @@ class MainRequestHandler(BaseHandler):
     @authenticated
     def get(self) -> None:
         begin = bool(self.get_argument("begin", False))
+        if settings.using_password:
+            # Simply accessing the xsrf_token sets the cookie for us
+            self.xsrf_token  # pylint: disable=pointless-statement
+        else:
+            self.clear_cookie("_xsrf")
 
         self.render(
             "index.template.html",
@@ -1102,6 +1107,7 @@ def make_app(debug=get_bool_env(ENV_DEV)) -> tornado.web.Application:
         "log_function": log_function,
         "websocket_ping_interval": 30.0,
         "template_path": get_base_frontend_path(),
+        "xsrf_cookies": settings.using_password,
     }
     rel = settings.relative_url
     return tornado.web.Application(

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ pyserial==3.5
 platformio==6.1.13  # When updating platformio, also update Dockerfile
 esptool==4.7.0
 click==8.1.7
-esphome-dashboard==20231107.0
+esphome-dashboard==20240319.0
 aioesphomeapi==23.1.1
 zeroconf==0.131.0
 python-magic==0.4.27


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

This adds an extra layer of security to the ESPHome dashboard calls when using a password.

https://github.com/esphome/dashboard/releases/tag/20240319.0

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
