### PR TITLE
Show component warnings and errors in the log;

### DIFF
--- a/esphome/core/component.cpp
+++ b/esphome/core/component.cpp
@@ -141,18 +141,35 @@ bool Component::is_ready() {
          (this->component_state_ & COMPONENT_STATE_MASK) == COMPONENT_STATE_SETUP;
 }
 bool Component::can_proceed() { return true; }
-bool Component::status_has_warning() { return this->component_state_ & STATUS_LED_WARNING; }
-bool Component::status_has_error() { return this->component_state_ & STATUS_LED_ERROR; }
-void Component::status_set_warning() {
+bool Component::status_has_warning() const { return this->component_state_ & STATUS_LED_WARNING; }
+bool Component::status_has_error() const { return this->component_state_ & STATUS_LED_ERROR; }
+void Component::status_set_warning(const char *message) {
+  // Don't spam the log. This risks missing different warning messages though.
+  if ((this->component_state_ & STATUS_LED_WARNING) != 0)
+    return;
   this->component_state_ |= STATUS_LED_WARNING;
   App.app_state_ |= STATUS_LED_WARNING;
+  ESP_LOGW(this->get_component_source(), "Warning set: %s", message);
 }
-void Component::status_set_error() {
+void Component::status_set_error(const char *message) {
+  if ((this->component_state_ & STATUS_LED_ERROR) != 0)
+    return;
   this->component_state_ |= STATUS_LED_ERROR;
   App.app_state_ |= STATUS_LED_ERROR;
+  ESP_LOGE(this->get_component_source(), "Error set: %s", message);
 }
-void Component::status_clear_warning() { this->component_state_ &= ~STATUS_LED_WARNING; }
-void Component::status_clear_error() { this->component_state_ &= ~STATUS_LED_ERROR; }
+void Component::status_clear_warning() {
+  if ((this->component_state_ & STATUS_LED_WARNING) == 0)
+    return;
+  this->component_state_ &= ~STATUS_LED_WARNING;
+  ESP_LOGW(this->get_component_source(), "Warning cleared");
+}
+void Component::status_clear_error() {
+  if ((this->component_state_ & STATUS_LED_ERROR) == 0)
+    return;
+  this->component_state_ &= ~STATUS_LED_ERROR;
+  ESP_LOGE(this->get_component_source(), "Error cleared");
+}
 void Component::status_momentary_warning(const std::string &name, uint32_t length) {
   this->status_set_warning();
   this->set_timeout(name, length, [this]() { this->status_clear_warning(); });

--- a/esphome/core/component.h
+++ b/esphome/core/component.h
@@ -124,13 +124,13 @@ class Component {
 
   virtual bool can_proceed();
 
-  bool status_has_warning();
+  bool status_has_warning() const;
 
-  bool status_has_error();
+  bool status_has_error() const;
 
-  void status_set_warning();
+  void status_set_warning(const char *message = "unspecified");
 
-  void status_set_error();
+  void status_set_error(const char *message = "unspecified");
 
   void status_clear_warning();
 


### PR DESCRIPTION
Allow customised message.

# What does this implement/fix?

Put something in the log when a component flags error or warning. An optional message can be associated with it.

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
