### PR TITLE
AHT10: Use state machine to avoid blocking delay

### DIFF
--- a/esphome/components/aht10/aht10.cpp
+++ b/esphome/components/aht10/aht10.cpp
@@ -123,7 +123,6 @@ void AHT10Component::read_data_() {
       return;
     }
   }
-  // data is valid, we can break the loop
   ESP_LOGD(TAG, "Success at %ums", (unsigned) (millis() - this->start_time_));
   uint32_t raw_temperature = ((data[3] & 0x0F) << 16) | (data[4] << 8) | data[5];
   uint32_t raw_humidity = ((data[1] << 16) | (data[2] << 8) | data[3]) >> 4;

--- a/esphome/components/aht10/aht10.h
+++ b/esphome/components/aht10/aht10.h
@@ -30,6 +30,7 @@ class AHT10Component : public PollingComponent, public i2c::I2CDevice {
   unsigned read_delay_{};
   void read_data_();
   void restart_read_();
+  uint32_t start_time_{};
 };
 
 }  // namespace aht10

--- a/esphome/components/aht10/aht10.h
+++ b/esphome/components/aht10/aht10.h
@@ -26,6 +26,10 @@ class AHT10Component : public PollingComponent, public i2c::I2CDevice {
   sensor::Sensor *temperature_sensor_{nullptr};
   sensor::Sensor *humidity_sensor_{nullptr};
   AHT10Variant variant_{};
+  unsigned read_count_{};
+  unsigned read_delay_{};
+  void read_data_();
+  void restart_read_();
 };
 
 }  // namespace aht10


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

The `aht10` sensor uses delays in `update()` to wait for the chip to become ready to read. This causes unacceptable blocking of the `loop()` thread.

This PR replaces the in-line delays with scheduled callbacks to eliminate the thread blocking.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
sensor:
  - platform: aht10
    variant: aht20
    update_interval: 15s
    humidity:
      name: "Humidity"
    temperature:
      name: "Temperature"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
