### PR TITLE
AHT10: fix temperature-only operation; add warning/error messages

### DIFF
--- a/esphome/components/aht10/aht10.cpp
+++ b/esphome/components/aht10/aht10.cpp
@@ -94,7 +94,8 @@ void AHT10Component::restart_read_() {
 
 void AHT10Component::read_data_() {
   uint8_t data[6];
-  ESP_LOGD(TAG, "Read attempt %d at %ums", this->read_count_, (unsigned) (millis() - this->start_time_));
+  if (this->read_count_ > 1)
+    ESP_LOGD(TAG, "Read attempt %d at %ums", this->read_count_, (unsigned) (millis() - this->start_time_));
   if (this->read(data, 6) != i2c::ERROR_OK) {
     this->status_set_warning("AHT10 read failed, retrying soon");
     this->restart_read_();
@@ -119,7 +120,8 @@ void AHT10Component::read_data_() {
       return;
     }
   }
-  ESP_LOGD(TAG, "Success at %ums", (unsigned) (millis() - this->start_time_));
+  if (this->read_count_ > 1)
+    ESP_LOGD(TAG, "Success at %ums", (unsigned) (millis() - this->start_time_));
   uint32_t raw_temperature = ((data[3] & 0x0F) << 16) | (data[4] << 8) | data[5];
   uint32_t raw_humidity = ((data[1] << 16) | (data[2] << 8) | data[3]) >> 4;
 

--- a/esphome/components/aht10/aht10.cpp
+++ b/esphome/components/aht10/aht10.cpp
@@ -123,7 +123,6 @@ void AHT10Component::read_data_() {
       return;
     }
   }
-  // data is valid, we can break the loop
   ESP_LOGD(TAG, "Success at %ums", (unsigned) (millis() - this->start_time_));
   uint32_t raw_temperature = ((data[3] & 0x0F) << 16) | (data[4] << 8) | data[5];
   uint32_t raw_humidity = ((data[1] << 16) | (data[2] << 8) | data[3]) >> 4;

--- a/esphome/components/aht10/aht10.cpp
+++ b/esphome/components/aht10/aht10.cpp
@@ -96,7 +96,7 @@ void AHT10Component::read_data_() {
   uint8_t data[6];
   ESP_LOGD(TAG, "Read attempt %d at %ums", this->read_count_, (unsigned) (millis() - this->start_time_));
   if (this->read(data, 6) != i2c::ERROR_OK) {
-    ESP_LOGD(TAG, "Communication with AHT10 failed, waiting...");
+    this->status_set_warning("AHT10 read failed, retrying soon");
     this->restart_read_();
     return;
   }

--- a/esphome/components/aht10/aht10.h
+++ b/esphome/components/aht10/aht10.h
@@ -27,7 +27,6 @@ class AHT10Component : public PollingComponent, public i2c::I2CDevice {
   sensor::Sensor *humidity_sensor_{nullptr};
   AHT10Variant variant_{};
   unsigned read_count_{};
-  unsigned read_delay_{};
   void read_data_();
   void restart_read_();
   uint32_t start_time_{};

--- a/esphome/components/aht10/aht10.h
+++ b/esphome/components/aht10/aht10.h
@@ -30,6 +30,7 @@ class AHT10Component : public PollingComponent, public i2c::I2CDevice {
   unsigned read_delay_{};
   void read_data_();
   void restart_read_();
+  uint32_t start_time_{};
 };
 
 }  // namespace aht10

--- a/esphome/components/aht10/aht10.h
+++ b/esphome/components/aht10/aht10.h
@@ -26,6 +26,10 @@ class AHT10Component : public PollingComponent, public i2c::I2CDevice {
   sensor::Sensor *temperature_sensor_{nullptr};
   sensor::Sensor *humidity_sensor_{nullptr};
   AHT10Variant variant_{};
+  unsigned read_count_{};
+  unsigned read_delay_{};
+  void read_data_();
+  void restart_read_();
 };
 
 }  // namespace aht10


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

The delay used by the component for temperature-only (humidity not configured) is much less than the datasheet spec, and results in timeouts. Change this to use the same delay, as per the datasheet, for all conversions.

Also update warnings and errors to use the new `status_set_warning(<msg>)` scheme.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
