### PR TITLE
Add check for use of GPIOXX in config

### DIFF
--- a/esphome/pins.py
+++ b/esphome/pins.py
@@ -314,7 +314,7 @@ def gpio_base_schema(
     def _number_validator(value):
         if isinstance(value, str) and value.upper().startswith("GPIOX"):
             raise cv.Invalid(
-                f"Found '{value}' when expecting a GPIO pin number.\n"
+                f"Found placeholder '{value}' when expecting a GPIO pin number.\n"
                 "You must replace this with an actual pin number."
             )
         return number_validator(value)

--- a/esphome/pins.py
+++ b/esphome/pins.py
@@ -311,10 +311,18 @@ def gpio_base_schema(
         map(lambda m: (cv.Optional(m, default=mode_default), cv.boolean), modes)
     )
 
+    def _number_validator(value):
+        if isinstance(value, str) and value.upper().startswith("GPIOX"):
+            raise cv.Invalid(
+                f"Found '{value}' when expecting a GPIO pin number.\n"
+                "You must replace this with an actual pin number."
+            )
+        return number_validator(value)
+
     schema = cv.Schema(
         {
             cv.GenerateID(): cv.declare_id(pin_type),
-            cv.Required(CONF_NUMBER): number_validator,
+            cv.Required(CONF_NUMBER): _number_validator,
             cv.Optional(CONF_ALLOW_OTHER_USES): cv.boolean,
             cv.Optional(CONF_MODE, default={}): cv.All(mode_dict, mode_validator),
         }


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Adds feature as per discussion:
https://discord.com/channels/429907082951524364/1220144400877883422/1220572480184520785

To flag GPIOXX as similar to REPLACEME - but only in contexts where GPIO pin numbers are expected.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
spi:
  id: spi_bus
  clk_pin:
    number: GPIOXX
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
