### PR TITLE
Add IRK support to ble_rssi

### DIFF
--- a/esphome/components/ble_rssi/sensor.py
+++ b/esphome/components/ble_rssi/sensor.py
@@ -12,6 +12,8 @@ from esphome.const import (
     UNIT_DECIBEL_MILLIWATT,
 )
 
+CONF_IRK = "irk"
+
 DEPENDENCIES = ["esp32_ble_tracker"]
 
 ble_rssi_ns = cg.esphome_ns.namespace("ble_rssi")
@@ -39,6 +41,7 @@ CONFIG_SCHEMA = cv.All(
     .extend(
         {
             cv.Optional(CONF_MAC_ADDRESS): cv.mac_address,
+            cv.Optional(CONF_IRK): cv.uuid,
             cv.Optional(CONF_SERVICE_UUID): esp32_ble_tracker.bt_uuid,
             cv.Optional(CONF_IBEACON_MAJOR): cv.uint16_t,
             cv.Optional(CONF_IBEACON_MINOR): cv.uint16_t,
@@ -47,7 +50,9 @@ CONFIG_SCHEMA = cv.All(
     )
     .extend(esp32_ble_tracker.ESP_BLE_DEVICE_SCHEMA)
     .extend(cv.COMPONENT_SCHEMA),
-    cv.has_exactly_one_key(CONF_MAC_ADDRESS, CONF_SERVICE_UUID, CONF_IBEACON_UUID),
+    cv.has_exactly_one_key(
+        CONF_MAC_ADDRESS, CONF_IRK, CONF_SERVICE_UUID, CONF_IBEACON_UUID
+    ),
     _validate,
 )
 
@@ -59,6 +64,10 @@ async def to_code(config):
 
     if mac_address := config.get(CONF_MAC_ADDRESS):
         cg.add(var.set_address(mac_address.as_hex))
+
+    if irk := config.get(CONF_IRK):
+        irk = esp32_ble_tracker.as_hex_array(str(irk))
+        cg.add(var.set_irk(irk))
 
     if service_uuid := config.get(CONF_SERVICE_UUID):
         if len(service_uuid) == len(esp32_ble_tracker.bt_uuid16_format):

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
@@ -721,8 +721,7 @@ bool ESPBTDevice::resolve_irk(const uint8_t *irk) const {
     return false;
   }
 
-  if (mbedtls_aes_crypt_ecb(&ctx, ESP_AES_ENCRYPT,
-                            ecb_plaintext, ecb_ciphertext) != 0) {
+  if (mbedtls_aes_crypt_ecb(&ctx, ESP_AES_ENCRYPT, ecb_plaintext, ecb_ciphertext) != 0) {
     mbedtls_aes_free(&ctx);
     return false;
   }

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
@@ -23,14 +23,10 @@
 
 #ifdef USE_ARDUINO
 #include <esp32-hal-bt.h>
-#include "mbedtls/aes.h"
-#include "mbedtls/base64.h"
 #endif
 
-#ifdef USE_ESP_IDF
 #define MBEDTLS_AES_ALT
 #include <aes_alt.h>
-#endif
 
 // bt_trace.h
 #undef TAG

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
@@ -721,12 +721,7 @@ bool ESPBTDevice::resolve_irk(const uint8_t *irk) const {
     return false;
   }
 
-  if (mbedtls_aes_crypt_ecb(&ctx,
-#ifdef USE_ARDUINO
-                            MBEDTLS_AES_ENCRYPT,
-#elif defined(USE_ESP_IDF)
-                            ESP_AES_ENCRYPT,
-#endif
+  if (mbedtls_aes_crypt_ecb(&ctx, ESP_AES_ENCRYPT,
                             ecb_plaintext, ecb_ciphertext) != 0) {
     mbedtls_aes_free(&ctx);
     return false;

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
@@ -86,6 +86,8 @@ class ESPBTDevice {
 
   const esp_ble_gap_cb_param_t::ble_scan_result_evt_param &get_scan_result() const { return scan_result_; }
 
+  bool resolve_irk(const uint8_t *irk) const;
+
   optional<ESPBLEiBeacon> get_ibeacon() const {
     for (auto &it : this->manufacturer_datas_) {
       auto res = ESPBLEiBeacon::from_manufacturer_data(it);

--- a/tests/components/ble_rssi/common.yaml
+++ b/tests/components/ble_rssi/common.yaml
@@ -16,3 +16,6 @@ sensor:
   - platform: ble_rssi
     service_uuid: 11223344-5566-7788-99aa-bbccddeeff00
     name: BLE Test iBeacon UUID
+  - platform: ble_rssi
+    irk: 1234567890abcdef1234567890abcdef
+    name: "BLE Tracker with Identity Resolving Key"


### PR DESCRIPTION
# What does this implement/fix?

Most modern smartphones use use a privacy feature called Resolvable Private Addresses to avoid BLE tracking. However if you know the devices "Identity Resolving Key" (IRK), you can check if the generated private MAC address belongs to the device with the IRK.

This PR adds an option to the `ble_rssi` sensor to configure the IRK.

There is no support to obtain the key. You will have to use one of the options described here: https://espresense.com/beacons

Once you have the IRK, configuration is similar to the other methods for the `ble_rssi` binary sensor.

Implementation is almost the same as in `ble_presence` (#6335).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** feature (as requested in https://github.com/esphome/feature-requests/issues/2285)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation:** esphome/esphome-docs#3707

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
```yaml
# Example configuration entry
esp32_ble_tracker:

sensor:
  # RSSI based on IRK
  - platform: ble_rssi
    irk: 1234567890abcdef1234567890abcdef
    name: "BLE Tracker with Identity Resolving Key"

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
