### PR TITLE
microWakeWord: Fix model path joining

### DIFF
--- a/esphome/components/micro_wake_word/__init__.py
+++ b/esphome/components/micro_wake_word/__init__.py
@@ -287,7 +287,7 @@ def _load_model_data(manifest_path: Path):
     except cv.Invalid as e:
         raise EsphomeError(f"Invalid manifest file: {e}") from e
 
-    model_path = urljoin(str(manifest_path), manifest[CONF_MODEL])
+    model_path = manifest_path.parent / manifest[CONF_MODEL]
 
     with open(model_path, "rb") as f:
         model = f.read()


### PR DESCRIPTION
There is probably a good reason to use `urllib.parse.urljoin` but in my case (windows, esphome installed with pip) it doesn't work and this simple solution does.

# What does this implement/fix?

It fixes issue [5556](https://github.com/esphome/issues/issues/5556)

## Types of changes

- [] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other
I mentionned above I'm not sure why `urllib.parse.urljoin` is used for this join instead of pathlib `/`. So this change could break something.
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

fixes  [5556](https://github.com/esphome/issues/issues/5556)

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
esphome:
  name: kitchen-proxy

esp32:
  board: esp32s3box
  variant: esp32s3
  framework:
    type: esp-idf

micro_wake_word:
  model: okay_nabu
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
