### PR TITLE
Fix editor live validation

### DIFF
--- a/esphome/config_helpers.py
+++ b/esphome/config_helpers.py
@@ -1,9 +1,4 @@
-import json
-import os
-
 from esphome.const import CONF_ID
-from esphome.core import CORE
-from esphome.helpers import read_file
 
 
 class Extend:
@@ -36,25 +31,6 @@ class Remove:
         Only used in unit tests.
         """
         return isinstance(b, Remove) and self.value == b.value
-
-
-def read_config_file(path: str) -> str:
-    if CORE.vscode and (
-        not CORE.ace or os.path.abspath(path) == os.path.abspath(CORE.config_path)
-    ):
-        print(
-            json.dumps(
-                {
-                    "type": "read_file",
-                    "path": path,
-                }
-            )
-        )
-        data = json.loads(input())
-        assert data["type"] == "file_response"
-        return data["content"]
-
-    return read_file(path)
 
 
 def merge_config(full_old, full_new):

--- a/esphome/yaml_util.py
+++ b/esphome/yaml_util.py
@@ -417,20 +417,25 @@ def load_yaml(fname: str, clear_secrets: bool = True) -> Any:
     return _load_yaml_internal(fname)
 
 
+def parse_yaml(file_name: str, file_handle: TextIOWrapper) -> Any:
+    """Parse a YAML file."""
+    try:
+        return _load_yaml_internal_with_type(ESPHomeLoader, file_name, file_handle)
+    except EsphomeError:
+        # Loading failed, so we now load with the Python loader which has more
+        # readable exceptions
+        # Rewind the stream so we can try again
+        file_handle.seek(0, 0)
+        return _load_yaml_internal_with_type(
+            ESPHomePurePythonLoader, file_name, file_handle
+        )
+
+
 def _load_yaml_internal(fname: str) -> Any:
     """Load a YAML file."""
     try:
         with open(fname, encoding="utf-8") as f_handle:
-            try:
-                return _load_yaml_internal_with_type(ESPHomeLoader, fname, f_handle)
-            except EsphomeError:
-                # Loading failed, so we now load with the Python loader which has more
-                # readable exceptions
-                # Rewind the stream so we can try again
-                f_handle.seek(0, 0)
-                return _load_yaml_internal_with_type(
-                    ESPHomePurePythonLoader, fname, f_handle
-                )
+            return parse_yaml(fname, f_handle)
     except (UnicodeDecodeError, OSError) as err:
         raise EsphomeError(f"Error reading file {fname}: {err}") from err
 


### PR DESCRIPTION
# What does this implement/fix?

This broke in 25ab6f0297fcf3a21e07644854db5083ba5a0eed because `read_config_file` was no longer being called. It was missed that `read_config_file` will check the `CORE.vscode` and `CORE.ace` globals, and in some cases instead of reading a config file from disk, it will print an event to stdout, and than decode json from stdin to get the contents of the yaml.

```python
def read_config_file(path: str) -> str:
    if CORE.vscode and (
        not CORE.ace or os.path.abspath(path) == os.path.abspath(CORE.config_path)
    ):
```

This PR removes `read_config_file` since its no longer used, which removes more of the global `CORE.ace` and `CORE.vscode` checks.

There are still two places where these global checks remain that should be removed, but they are a bit harder to remove and not contemplated in this PR
```python
esphome/config_validation.py:        not CORE.ace or os.path.abspath(path) == os.path.abspath(CORE.config_path)
esphome/config_validation.py:        not CORE.ace or os.path.abspath(path) == os.path.abspath(CORE.config_path)
```

I added some more typing since it was very hard to follow what was going on as the variables names were not obvious.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/5533

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
