### PR TITLE
Add get_contrast() and get_brightness() to SSD1306 class to get protected variables

### DIFF
--- a/esphome/components/ssd1306_base/ssd1306_base.cpp
+++ b/esphome/components/ssd1306_base/ssd1306_base.cpp
@@ -236,6 +236,7 @@ void SSD1306::set_invert(bool invert) {
   // Inverse display mode (0xA6, 0xA7)
   this->command(SSD1306_COMMAND_NORMAL_DISPLAY | this->invert_);
 }
+float SSD1306::get_contrast() { return this->contrast_; };
 void SSD1306::set_contrast(float contrast) {
   // validation
   this->contrast_ = clamp(contrast, 0.0F, 1.0F);
@@ -243,6 +244,7 @@ void SSD1306::set_contrast(float contrast) {
   this->command(SSD1306_COMMAND_SET_CONTRAST);
   this->command(int(SSD1306_MAX_CONTRAST * (this->contrast_)));
 }
+float SSD1306::get_brightness() { return this->brightness_; };
 void SSD1306::set_brightness(float brightness) {
   // validation
   if (!this->is_ssd1305_())

--- a/esphome/components/ssd1306_base/ssd1306_base.h
+++ b/esphome/components/ssd1306_base/ssd1306_base.h
@@ -36,7 +36,9 @@ class SSD1306 : public display::DisplayBuffer {
   void set_reset_pin(GPIOPin *reset_pin) { this->reset_pin_ = reset_pin; }
   void set_external_vcc(bool external_vcc) { this->external_vcc_ = external_vcc; }
   void init_contrast(float contrast) { this->contrast_ = contrast; }
+  float get_contrast();
   void set_contrast(float contrast);
+  float get_brightness();
   void init_brightness(float brightness) { this->brightness_ = brightness; }
   void set_brightness(float brightness);
   void init_flip_x(bool flip_x) { this->flip_x_ = flip_x; }


### PR DESCRIPTION
# What does this implement/fix?

This adds `get_contrast()` and `get_brightness()` public methods to the `SSD1306` class in the C++ API. They can then be used in lambdas or components to read the protected class variables `contrast_` and `brightness_`, in order to represent the current `brightness`/`contrast` values without [trying to keep track of the state](https://www.sudo.is/docs/esphome/components/ssd1306/#brightness-control) yourself. 

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**~~Related issue or feature (if applicable)~~:** Not applicable

**~~Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable)~~:** Not applicable

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
display: 
 - platform: ssd1306_i2c
   id: ssd1306
   model: "SSD1306 128x64"
   contrast: "33%"
   lambda: |-
      float contrast = id(ssd1306).get_contrast();
      it.printf(0, 0, id(font), TextAlign::BASELINE_LEFT, "%3.0f %%", contrast*100);

number:
  - platform: template
    id: "ssd1306_contrast"
    name: "SSD1306 contrast"
    min_value: 0
    max_value: 100
    step: 0
    entity_category: ""
    unit_of_measurement: "%"
    device_class: power_factor
    mode: slider
    lambda: |-
      float contrast = id(ssd1306).get_contrast();
      return int(contrast*100);
    set_action: 
      - lambda: |-
          id(ssd1306).set_contrast(x/100);
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] ~~Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).~~
