### PR TITLE
[waveshare_epaper] Add support for 13.3in-k

### DIFF
--- a/esphome/components/waveshare_epaper/display.py
+++ b/esphome/components/waveshare_epaper/display.py
@@ -94,6 +94,9 @@ WaveshareEPaper2P13InV2 = waveshare_epaper_ns.class_(
 WaveshareEPaper2P13InV3 = waveshare_epaper_ns.class_(
     "WaveshareEPaper2P13InV3", WaveshareEPaper
 )
+WaveshareEPaper13P3InK = waveshare_epaper_ns.class_(
+    "WaveshareEPaper13P3InK", WaveshareEPaper
+)
 GDEW0154M09 = waveshare_epaper_ns.class_("GDEW0154M09", WaveshareEPaper)
 
 WaveshareEPaperTypeAModel = waveshare_epaper_ns.enum("WaveshareEPaperTypeAModel")
@@ -133,6 +136,7 @@ MODELS = {
     "2.13in-ttgo-dke": ("c", WaveshareEPaper2P13InDKE),
     "2.13inv3": ("c", WaveshareEPaper2P13InV3),
     "1.54in-m5coreink-m09": ("c", GDEW0154M09),
+    "13.3in-k": ("b", WaveshareEPaper13P3InK),
 }
 
 RESET_PIN_REQUIRED_MODELS = ("2.13inv2", "2.13in-ttgo-b74")

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -2983,9 +2983,9 @@ void WaveshareEPaper13P3InK::initialize() {
   this->data(0xc0);
   this->data(0x80);
 
-  this->command(0x01);                          // driver output control
-  this->data((get_height_internal() - 1)%256);  // Y
-  this->data((get_height_internal() - 1)/256);  // Y
+  this->command(0x01);                            // driver output control
+  this->data((get_height_internal() - 1) % 256);  // Y
+  this->data((get_height_internal() - 1) / 256);  // Y
   this->data(0x00);
 
   this->command(0x11);  // data entry mode

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -2963,5 +2963,89 @@ void WaveshareEPaper2P13InDKE::set_full_update_every(uint32_t full_update_every)
   this->full_update_every_ = full_update_every;
 }
 
+// ========================================================
+//               13.3in (K version)
+// Datasheet/Specification/Reference:
+//  - https://files.waveshare.com/wiki/13.3inch-e-Paper-HAT-(K)/13.3-inch-e-Paper-(K)-user-manual.pdf
+//  - https://github.com/waveshareteam/e-Paper/tree/master/Arduino/epd13in3k
+// ========================================================
+
+// using default wait_until_idle_() function
+void WaveshareEPaper13P3InK::initialize() {
+  this->wait_until_idle_();
+  this->command(0x12);  // SWRESET
+  this->wait_until_idle_(); 
+
+  this->command(0x0c);  // set soft start
+  this->data(0xae);
+  this->data(0xc7);
+  this->data(0xc3);
+  this->data(0xc0);
+  this->data(0x80);
+
+  this->command(0x01);  // driver output control
+  this->data((get_height_internal() - 1)%256); // Y
+  this->data((get_height_internal() - 1)/256); // Y
+  this->data(0x00);
+
+  this->command(0x11);  // data entry mode
+  this->data(0x03);
+
+  // SET WINDOWS
+  // XRAM_START_AND_END_POSITION
+  this->command(0x44);
+  this->data(0 & 0xFF);
+  this->data((0 >> 8) & 0x03);
+  this->data((get_width_internal() - 1) & 0xFF);
+  this->data(((get_width_internal() - 1) >> 8) & 0x03);
+  // YRAM_START_AND_END_POSITION
+  this->command(0x45);
+  this->data(0 & 0xFF);
+  this->data((0 >> 8) & 0x03);
+  this->data((get_height_internal() - 1) & 0xFF);
+  this->data(((get_height_internal() - 1) >> 8) & 0x03);
+
+  this->command(0x3C);  // Border setting
+  this->data(0x01);
+
+  this->command(0x18);  // use the internal temperature sensor
+  this->data(0x80);
+
+  // SET CURSOR
+  // XRAM_ADDRESS
+  this->command(0x4E);
+  this->data(0 & 0xFF);
+  this->data((0 >> 8) & 0x03);
+  // YRAM_ADDRESS
+  this->command(0x4F);
+  this->data(0 & 0xFF);
+  this->data((0 >> 8) & 0x03);
+
+}
+void HOT WaveshareEPaper13P3InK::display() {
+  // do single full update
+  this->command(0x24);
+  this->start_data_();
+  this->write_array(this->buffer_, this->get_buffer_length_());
+  this->end_data_();
+
+  // COMMAND DISPLAY REFRESH
+  this->command(0x22);
+  this->data(0xF7);
+  this->command(0x20);
+}
+
+int WaveshareEPaper13P3InK::get_width_internal() { return 960; }
+int WaveshareEPaper13P3InK::get_height_internal() { return 680; }
+uint32_t WaveshareEPaper13P3InK::idle_timeout_() { return 10000; }
+void WaveshareEPaper13P3InK::dump_config() {
+  LOG_DISPLAY("", "Waveshare E-Paper", this);
+  ESP_LOGCONFIG(TAG, "  Model: 13.3inK");
+  LOG_PIN("  Reset Pin: ", this->reset_pin_);
+  LOG_PIN("  DC Pin: ", this->dc_pin_);
+  LOG_PIN("  Busy Pin: ", this->busy_pin_);
+  LOG_UPDATE_INTERVAL(this);
+}
+
 }  // namespace waveshare_epaper
 }  // namespace esphome

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -2974,7 +2974,7 @@ void WaveshareEPaper2P13InDKE::set_full_update_every(uint32_t full_update_every)
 void WaveshareEPaper13P3InK::initialize() {
   this->wait_until_idle_();
   this->command(0x12);  // SWRESET
-  this->wait_until_idle_(); 
+  this->wait_until_idle_();
 
   this->command(0x0c);  // set soft start
   this->data(0xae);

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -2983,9 +2983,9 @@ void WaveshareEPaper13P3InK::initialize() {
   this->data(0xc0);
   this->data(0x80);
 
-  this->command(0x01);  // driver output control
-  this->data((get_height_internal() - 1)%256); // Y
-  this->data((get_height_internal() - 1)/256); // Y
+  this->command(0x01);                          // driver output control
+  this->data((get_height_internal() - 1)%256);  // Y
+  this->data((get_height_internal() - 1)/256);  // Y
   this->data(0x00);
 
   this->command(0x11);  // data entry mode
@@ -3020,7 +3020,6 @@ void WaveshareEPaper13P3InK::initialize() {
   this->command(0x4F);
   this->data(0 & 0xFF);
   this->data((0 >> 8) & 0x03);
-
 }
 void HOT WaveshareEPaper13P3InK::display() {
   // do single full update

--- a/esphome/components/waveshare_epaper/waveshare_epaper.h
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.h
@@ -163,6 +163,7 @@ enum WaveshareEPaperTypeBModel {
   WAVESHARE_EPAPER_7_5_IN,
   WAVESHARE_EPAPER_7_5_INV2,
   WAVESHARE_EPAPER_7_5_IN_B_V2,
+  WAVESHARE_EPAPER_13_3_IN_K,
 };
 
 class WaveshareEPaper2P7In : public WaveshareEPaper {
@@ -769,5 +770,28 @@ class WaveshareEPaper2P13InV3 : public WaveshareEPaper {
   bool is_busy_{false};
   void write_lut_(const uint8_t *lut);
 };
+
+class WaveshareEPaper13P3InK : public WaveshareEPaper {
+ public:
+  void initialize() override;
+
+  void display() override;
+
+  void dump_config() override;
+
+  void deep_sleep() override {
+    // COMMAND DEEP SLEEP
+    this->command(0x10);
+    this->data(0x01);
+  }
+  
+ protected:
+  int get_width_internal() override;
+
+  int get_height_internal() override;
+
+  uint32_t idle_timeout_() override;
+};
+
 }  // namespace waveshare_epaper
 }  // namespace esphome

--- a/esphome/components/waveshare_epaper/waveshare_epaper.h
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.h
@@ -784,7 +784,7 @@ class WaveshareEPaper13P3InK : public WaveshareEPaper {
     this->command(0x10);
     this->data(0x01);
   }
-  
+
  protected:
   int get_width_internal() override;
 


### PR DESCRIPTION
# What does this implement/fix?

Adds support for Waveshare e-Paper 13.3in K version displays. 
- [Manual](https://www.waveshare.com/wiki/13.3inch_e-Paper_HAT_(K)_Manual)
- [Manual (PDF)](https://files.waveshare.com/wiki/13.3inch-e-Paper-HAT-(K)/13.3-inch-e-Paper-(K)-user-manual.pdf)
- [Waveshare support page](https://www.waveshare.com/wiki/13.3inch_e-Paper_HAT_(K))

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

link for documentation in `esphome-docs`:
https://github.com/esphome/esphome-docs/pull/3719

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx


Tested on [Waveshare Universal e-Paper Driver Board](https://www.waveshare.com/wiki/E-Paper_ESP32_Driver_Board)

## Example entry for `config.yaml`:

```yaml
esphome:
  name: epaperdisplay
  platform: ESP32
  board: esp32dev

spi:
  clk_pin: 13
  mosi_pin: 14

display:
  - platform: waveshare_epaper
    cs_pin: 15
    dc_pin: 27
    busy_pin:  25 
    reset_pin: 26
    model: 13.3in-k
    update_interval: 30s
    lambda: |-
      it.rectangle(0, 0, it.get_width(), it.get_height());
logger:
  baud_rate: 115200
  level: DEBUG
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
