### PR TITLE
minor refactor to allow commit hash as ref value.

### DIFF
--- a/esphome/git.py
+++ b/esphome/git.py
@@ -59,17 +59,14 @@ def clone_or_update(
         )
 
     repo_dir = _compute_destination_path(key, domain)
-    fetch_pr_branch = ref is not None and ref.startswith("pull/")
     if not repo_dir.is_dir():
         _LOGGER.info("Cloning %s", key)
         _LOGGER.debug("Location: %s", repo_dir)
         cmd = ["git", "clone", "--depth=1"]
-        if ref is not None and not fetch_pr_branch:
-            cmd += ["--branch", ref]
         cmd += ["--", url, str(repo_dir)]
         run_git_command(cmd)
 
-        if fetch_pr_branch:
+        if ref is not None: 
             # We need to fetch the PR branch first, otherwise git will complain
             # about missing objects
             _LOGGER.info("Fetching %s", ref)

--- a/esphome/git.py
+++ b/esphome/git.py
@@ -66,7 +66,7 @@ def clone_or_update(
         cmd += ["--", url, str(repo_dir)]
         run_git_command(cmd)
 
-        if ref is not None: 
+        if ref is not None:
             # We need to fetch the PR branch first, otherwise git will complain
             # about missing objects
             _LOGGER.info("Fetching %s", ref)


### PR DESCRIPTION
# What does this implement/fix?
minor refactor to allow commit hash as ref value.
<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** closes https://github.com/esphome/feature-requests/issues/2507

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
external_components:
  - source:
      type: git
      url: https://github.com/ssieb/esphome_components
      ref: b922726dae9cbb0e7945446610ca7aab808559f2
    components: [ sen0177 ]
    #refresh: 10s
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

The documentation likely needs updated too but I wanted to get this PR in place before updating the docs.
