### PR TITLE
TMP117 fix polling period config

### DIFF
--- a/esphome/components/tmp117/sensor.py
+++ b/esphome/components/tmp117/sensor.py
@@ -30,37 +30,37 @@ CONFIG_SCHEMA = cv.All(
 
 
 def determine_config_register(polling_period):
-    if polling_period >= 16.0:
+    if polling_period >= 16000:
         # 64 averaged conversions, max conversion time
         # 0000 00 111 11 00000
         # 0000 0011 1110 0000
         return 0x03E0
-    if polling_period >= 8.0:
+    if polling_period >= 8000:
         # 64 averaged conversions, high conversion time
         # 0000 00 110 11 00000
         # 0000 0011 0110 0000
         return 0x0360
-    if polling_period >= 4.0:
+    if polling_period >= 4000:
         # 64 averaged conversions, mid conversion time
         # 0000 00 101 11 00000
         # 0000 0010 1110 0000
         return 0x02E0
-    if polling_period >= 1.0:
+    if polling_period >= 1000:
         # 64 averaged conversions, min conversion time
         # 0000 00 000 11 00000
         # 0000 0000 0110 0000
         return 0x0060
-    if polling_period >= 0.5:
+    if polling_period >= 500:
         # 32 averaged conversions, min conversion time
         # 0000 00 000 10 00000
         # 0000 0000 0100 0000
         return 0x0040
-    if polling_period >= 0.25:
+    if polling_period >= 250:
         # 8 averaged conversions, mid conversion time
         # 0000 00 010 01 00000
         # 0000 0001 0010 0000
         return 0x0120
-    if polling_period >= 0.125:
+    if polling_period >= 125:
         # 8 averaged conversions, min conversion time
         # 0000 00 000 01 00000
         # 0000 0000 0010 0000
@@ -76,5 +76,5 @@ async def to_code(config):
     await cg.register_component(var, config)
     await i2c.register_i2c_device(var, config)
 
-    update_period = config[CONF_UPDATE_INTERVAL].total_seconds
+    update_period = config[CONF_UPDATE_INTERVAL].total_milliseconds
     cg.add(var.set_config(determine_config_register(update_period)))


### PR DESCRIPTION
## What does this implement/fix?

Bug is only evident in update intervals less than 1 second - correct config polling period are not assigned correctly for update intervals 1-0.5sec, 0.5-0.25sec, 0.25-0.125sec. Polling period is set in sensor.py using the CONF_UPDATE_INTERVAL total_seconds but total_seconds does not support fractions of second which are used in polling_period if statements. Minor fix is to use CONF_UPDATE_INTERVAL total_milliseconds and use milliseconds in polling period if statements.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes 

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** 

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
