### PR TITLE
fix: changing the content source when playing is paused blocks the player

### DIFF
--- a/esphome/components/i2s_audio/media_player/i2s_audio_media_player.cpp
+++ b/esphome/components/i2s_audio/media_player/i2s_audio_media_player.cpp
@@ -12,12 +12,12 @@ static const char *const TAG = "audio";
 void I2SAudioMediaPlayer::control(const media_player::MediaPlayerCall &call) {
   if (call.get_media_url().has_value()) {
     this->current_url_ = call.get_media_url();
-
-    if (this->state == media_player::MEDIA_PLAYER_STATE_PLAYING && this->audio_ != nullptr) {
+    if (this->i2s_state_ != I2S_STATE_STOPPED && this->audio_ != nullptr) {
       if (this->audio_->isRunning()) {
         this->audio_->stopSong();
       }
       this->audio_->connecttohost(this->current_url_.value().c_str());
+      this->state = media_player::MEDIA_PLAYER_STATE_PLAYING;
     } else {
       this->start();
     }


### PR DESCRIPTION
# What does this implement/fix?
fixes: https://github.com/esphome/issues/issues/5069

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
