### PR TITLE
Optimize QMC5883L: Read registers only for enabled sensors

### DIFF
--- a/esphome/components/qmc5883l/qmc5883l.cpp
+++ b/esphome/components/qmc5883l/qmc5883l.cpp
@@ -76,7 +76,8 @@ void QMC5883LComponent::dump_config() {
 float QMC5883LComponent::get_setup_priority() const { return setup_priority::DATA; }
 void QMC5883LComponent::update() {
   uint8_t status = false;
-  this->read_byte(QMC5883L_REGISTER_STATUS, &status);
+  if (ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_DEBUG)
+    this->read_byte(QMC5883L_REGISTER_STATUS, &status);
 
   float mg_per_bit;
   switch (this->range_) {

--- a/esphome/components/qmc5883l/qmc5883l.cpp
+++ b/esphome/components/qmc5883l/qmc5883l.cpp
@@ -78,14 +78,6 @@ void QMC5883LComponent::update() {
   uint8_t status = false;
   this->read_byte(QMC5883L_REGISTER_STATUS, &status);
 
-  uint16_t raw_x, raw_y, raw_z;
-  if (!this->read_byte_16_(QMC5883L_REGISTER_DATA_X_LSB, &raw_x) ||
-      !this->read_byte_16_(QMC5883L_REGISTER_DATA_Y_LSB, &raw_y) ||
-      !this->read_byte_16_(QMC5883L_REGISTER_DATA_Z_LSB, &raw_z)) {
-    this->status_set_warning();
-    return;
-  }
-
   float mg_per_bit;
   switch (this->range_) {
     case QMC5883L_RANGE_200_UT:
@@ -99,11 +91,37 @@ void QMC5883LComponent::update() {
   }
 
   // in µT
-  const float x = int16_t(raw_x) * mg_per_bit * 0.1f;
-  const float y = int16_t(raw_y) * mg_per_bit * 0.1f;
-  const float z = int16_t(raw_z) * mg_per_bit * 0.1f;
+  float x = NAN, y = NAN, z = NAN;
+  if (this->x_sensor_ != nullptr || this->heading_sensor_ != nullptr) {
+    uint16_t raw_x;
+    if (!this->read_byte_16_(QMC5883L_REGISTER_DATA_X_LSB, &raw_x)) {
+      this->status_set_warning();
+      return;
+    }
+    x = int16_t(raw_x) * mg_per_bit * 0.1f;
+  }
+  if (this->y_sensor_ != nullptr || this->heading_sensor_ != nullptr) {
+    uint16_t raw_y;
+    if (!this->read_byte_16_(QMC5883L_REGISTER_DATA_Y_LSB, &raw_y)) {
+      this->status_set_warning();
+      return;
+    }
+    y = int16_t(raw_y) * mg_per_bit * 0.1f;
+  }
+  if (this->z_sensor_ != nullptr) {
+    uint16_t raw_z;
+    if (!this->read_byte_16_(QMC5883L_REGISTER_DATA_Z_LSB, &raw_z)) {
+      this->status_set_warning();
+      return;
+    }
+    z = int16_t(raw_z) * mg_per_bit * 0.1f;
+  }
 
-  float heading = atan2f(0.0f - x, y) * 180.0f / M_PI;
+  float heading = NAN;
+  if (this->heading_sensor_ != nullptr) {
+    heading = atan2f(0.0f - x, y) * 180.0f / M_PI;
+  }
+
   ESP_LOGD(TAG, "Got x=%0.02fµT y=%0.02fµT z=%0.02fµT heading=%0.01f° status=%u", x, y, z, heading, status);
 
   if (this->x_sensor_ != nullptr)


### PR DESCRIPTION
# What does this implement/fix?

Optimize QMC5883L:
- Read registers only for enabled sensors
- Read status register only if logger is set at DEBUG or higher

This is to avoid overloading the i2c bus when e.g. you only need data for one axis.
My intention is to change i2c frequency all the way down to 10 kHz to be able to achieve i2c over long wires.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
