### PR TITLE
Add Several I2S Configuration Options and VolumeSetAction for Speakers

### DIFF
--- a/esphome/components/i2s_audio/__init__.py
+++ b/esphome/components/i2s_audio/__init__.py
@@ -39,8 +39,8 @@ I2SAudioOut = i2s_audio_ns.class_(
 )
 i2s_mode_t = cg.global_ns.enum("i2s_mode_t")
 I2S_MODE_OPTIONS = {
-    CONF_PRIMARY: i2s_mode_t.I2S_MODE_MASTER,  // NOLINT
-    CONF_SECONDARY: i2s_mode_t.I2S_MODE_SLAVE,  // NOLINT
+    CONF_PRIMARY: i2s_mode_t.I2S_MODE_MASTER,  # NOLINT
+    CONF_SECONDARY: i2s_mode_t.I2S_MODE_SLAVE,  # NOLINT
 }
 i2s_bits_per_sample_t = cg.global_ns.enum("i2s_bits_per_sample_t")
 BITS_PER_SAMPLE = {

--- a/esphome/components/i2s_audio/__init__.py
+++ b/esphome/components/i2s_audio/__init__.py
@@ -22,6 +22,10 @@ CONF_I2S_MCLK_PIN = "i2s_mclk_pin"
 CONF_I2S_BCLK_PIN = "i2s_bclk_pin"
 CONF_I2S_LRCLK_PIN = "i2s_lrclk_pin"
 
+CONF_I2S_MODE = "i2s_mode"
+CONF_PRIMARY = "primary"
+CONF_SECONDARY = "secondary"
+
 CONF_I2S_AUDIO = "i2s_audio"
 CONF_I2S_AUDIO_ID = "i2s_audio_id"
 
@@ -31,6 +35,11 @@ I2SAudioIn = i2s_audio_ns.class_("I2SAudioIn", cg.Parented.template(I2SAudioComp
 I2SAudioOut = i2s_audio_ns.class_(
     "I2SAudioOut", cg.Parented.template(I2SAudioComponent)
 )
+i2s_mode_t = cg.global_ns.enum("i2s_mode_t")
+I2S_MODE_OPTIONS = {
+    CONF_PRIMARY: i2s_mode_t.I2S_MODE_MASTER,
+    CONF_SECONDARY: i2s_mode_t.I2S_MODE_SLAVE,
+}
 
 # https://github.com/espressif/esp-idf/blob/master/components/soc/{variant}/include/soc/soc_caps.h
 I2S_PORTS = {
@@ -46,6 +55,9 @@ CONFIG_SCHEMA = cv.Schema(
         cv.Required(CONF_I2S_LRCLK_PIN): pins.internal_gpio_output_pin_number,
         cv.Optional(CONF_I2S_BCLK_PIN): pins.internal_gpio_output_pin_number,
         cv.Optional(CONF_I2S_MCLK_PIN): pins.internal_gpio_output_pin_number,
+        cv.Optional(CONF_I2S_MODE, default=CONF_PRIMARY): cv.enum(
+            I2S_MODE_OPTIONS, lower=True
+        ),
     }
 )
 
@@ -68,6 +80,7 @@ async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
 
+    cg.add(var.set_i2s_mode(config[CONF_I2S_MODE]))
     cg.add(var.set_lrclk_pin(config[CONF_I2S_LRCLK_PIN]))
     if CONF_I2S_BCLK_PIN in config:
         cg.add(var.set_bclk_pin(config[CONF_I2S_BCLK_PIN]))

--- a/esphome/components/i2s_audio/__init__.py
+++ b/esphome/components/i2s_audio/__init__.py
@@ -22,6 +22,8 @@ CONF_I2S_MCLK_PIN = "i2s_mclk_pin"
 CONF_I2S_BCLK_PIN = "i2s_bclk_pin"
 CONF_I2S_LRCLK_PIN = "i2s_lrclk_pin"
 
+CONF_BITS_PER_SAMPLE = "bits_per_sample"
+
 CONF_I2S_MODE = "i2s_mode"
 CONF_PRIMARY = "primary"
 CONF_SECONDARY = "secondary"
@@ -40,6 +42,13 @@ I2S_MODE_OPTIONS = {
     CONF_PRIMARY: i2s_mode_t.I2S_MODE_MASTER,
     CONF_SECONDARY: i2s_mode_t.I2S_MODE_SLAVE,
 }
+i2s_bits_per_sample_t = cg.global_ns.enum("i2s_bits_per_sample_t")
+BITS_PER_SAMPLE = {
+    16: i2s_bits_per_sample_t.I2S_BITS_PER_SAMPLE_16BIT,
+    32: i2s_bits_per_sample_t.I2S_BITS_PER_SAMPLE_32BIT,
+}
+
+_validate_bits = cv.float_with_unit("bits", "bit")
 
 # https://github.com/espressif/esp-idf/blob/master/components/soc/{variant}/include/soc/soc_caps.h
 I2S_PORTS = {

--- a/esphome/components/i2s_audio/__init__.py
+++ b/esphome/components/i2s_audio/__init__.py
@@ -39,8 +39,8 @@ I2SAudioOut = i2s_audio_ns.class_(
 )
 i2s_mode_t = cg.global_ns.enum("i2s_mode_t")
 I2S_MODE_OPTIONS = {
-    CONF_PRIMARY: i2s_mode_t.I2S_MODE_MASTER,
-    CONF_SECONDARY: i2s_mode_t.I2S_MODE_SLAVE,
+    CONF_PRIMARY: i2s_mode_t.I2S_MODE_MASTER,  // NOLINT
+    CONF_SECONDARY: i2s_mode_t.I2S_MODE_SLAVE,  // NOLINT
 }
 i2s_bits_per_sample_t = cg.global_ns.enum("i2s_bits_per_sample_t")
 BITS_PER_SAMPLE = {

--- a/esphome/components/i2s_audio/i2s_audio.h
+++ b/esphome/components/i2s_audio/i2s_audio.h
@@ -33,6 +33,9 @@ class I2SAudioComponent : public Component {
   void set_bclk_pin(int pin) { this->bclk_pin_ = pin; }
   void set_lrclk_pin(int pin) { this->lrclk_pin_ = pin; }
 
+  void set_i2s_mode(i2s_mode_t mode) { this->mode_ = mode; }
+  i2s_mode_t get_i2s_mode() { return this->mode_; }
+
   void lock() { this->lock_.lock(); }
   bool try_lock() { return this->lock_.try_lock(); }
   void unlock() { this->lock_.unlock(); }
@@ -49,6 +52,7 @@ class I2SAudioComponent : public Component {
   int bclk_pin_{I2S_PIN_NO_CHANGE};
   int lrclk_pin_;
   i2s_port_t port_{};
+  i2s_mode_t mode_{};
 };
 
 }  // namespace i2s_audio

--- a/esphome/components/i2s_audio/microphone/__init__.py
+++ b/esphome/components/i2s_audio/microphone/__init__.py
@@ -10,8 +10,11 @@ from .. import (
     i2s_audio_ns,
     I2SAudioComponent,
     I2SAudioIn,
+    BITS_PER_SAMPLE,
+    CONF_BITS_PER_SAMPLE,
     CONF_I2S_AUDIO_ID,
     CONF_I2S_DIN_PIN,
+    _validate_bits,
 )
 
 CODEOWNERS = ["@jesserockz"]
@@ -21,7 +24,6 @@ CONF_ADC_PIN = "adc_pin"
 CONF_ADC_TYPE = "adc_type"
 CONF_PDM = "pdm"
 CONF_SAMPLE_RATE = "sample_rate"
-CONF_BITS_PER_SAMPLE = "bits_per_sample"
 CONF_USE_APLL = "use_apll"
 
 I2SAudioMicrophone = i2s_audio_ns.class_(
@@ -33,16 +35,9 @@ CHANNELS = {
     "left": i2s_channel_fmt_t.I2S_CHANNEL_FMT_ONLY_LEFT,
     "right": i2s_channel_fmt_t.I2S_CHANNEL_FMT_ONLY_RIGHT,
 }
-i2s_bits_per_sample_t = cg.global_ns.enum("i2s_bits_per_sample_t")
-BITS_PER_SAMPLE = {
-    16: i2s_bits_per_sample_t.I2S_BITS_PER_SAMPLE_16BIT,
-    32: i2s_bits_per_sample_t.I2S_BITS_PER_SAMPLE_32BIT,
-}
 
 INTERNAL_ADC_VARIANTS = [esp32.const.VARIANT_ESP32]
 PDM_VARIANTS = [esp32.const.VARIANT_ESP32, esp32.const.VARIANT_ESP32S3]
-
-_validate_bits = cv.float_with_unit("bits", "bit")
 
 
 def validate_esp32_variant(config):

--- a/esphome/components/i2s_audio/microphone/i2s_audio_microphone.cpp
+++ b/esphome/components/i2s_audio/microphone/i2s_audio_microphone.cpp
@@ -46,7 +46,7 @@ void I2SAudioMicrophone::start_() {
     return;  // Waiting for another i2s to return lock
   }
   i2s_driver_config_t config = {
-      .mode = (i2s_mode_t) (I2S_MODE_MASTER | I2S_MODE_RX),
+      .mode = (i2s_mode_t) (this->parent_->get_i2s_mode() | I2S_MODE_RX),
       .sample_rate = this->sample_rate_,
       .bits_per_sample = this->bits_per_sample_,
       .channel_format = this->channel_,

--- a/esphome/components/i2s_audio/microphone/i2s_audio_microphone.cpp
+++ b/esphome/components/i2s_audio/microphone/i2s_audio_microphone.cpp
@@ -46,19 +46,27 @@ void I2SAudioMicrophone::start_() {
     return;  // Waiting for another i2s to return lock
   }
   i2s_driver_config_t config = {
-      .mode = (i2s_mode_t) (this->parent_->get_i2s_mode() | I2S_MODE_RX),
-      .sample_rate = this->sample_rate_,
-      .bits_per_sample = this->bits_per_sample_,
-      .channel_format = this->channel_,
-      .communication_format = I2S_COMM_FORMAT_STAND_I2S,
-      .intr_alloc_flags = ESP_INTR_FLAG_LEVEL1,
-      .dma_buf_count = 4,
-      .dma_buf_len = 256,
-      .use_apll = this->use_apll_,
-      .tx_desc_auto_clear = false,
-      .fixed_mclk = 0,
-      .mclk_multiple = I2S_MCLK_MULTIPLE_DEFAULT,
-      .bits_per_chan = I2S_BITS_PER_CHAN_DEFAULT,
+    .mode = (i2s_mode_t) (this->parent_->get_i2s_mode() | I2S_MODE_RX),
+    .sample_rate = this->sample_rate_,
+    .bits_per_sample = this->bits_per_sample_,
+    .channel_format = this->channel_,
+    .communication_format = I2S_COMM_FORMAT_STAND_I2S,
+    .intr_alloc_flags = ESP_INTR_FLAG_LEVEL1,
+    .dma_buf_count = 4,
+    .dma_buf_len = 256,
+    .use_apll = this->use_apll_,
+    .tx_desc_auto_clear = false,
+    .fixed_mclk = 0,
+    .mclk_multiple = I2S_MCLK_MULTIPLE_DEFAULT,
+    .bits_per_chan = I2S_BITS_PER_CHAN_DEFAULT,
+#if SOC_I2S_SUPPORTS_TDM
+    .chan_mask = (i2s_channel_t) (I2S_TDM_ACTIVE_CH0 | I2S_TDM_ACTIVE_CH1),
+    .total_chan = 2,
+    .left_align = false,
+    .big_edin = false,
+    .bit_order_msb = false,
+    .skip_msk = false,
+#endif
   };
 
 #if SOC_I2S_SUPPORTS_ADC

--- a/esphome/components/i2s_audio/speaker/__init__.py
+++ b/esphome/components/i2s_audio/speaker/__init__.py
@@ -5,11 +5,14 @@ from esphome.const import CONF_ID, CONF_MODE
 from esphome.components import esp32, speaker
 
 from .. import (
+    BITS_PER_SAMPLE,
+    CONF_BITS_PER_SAMPLE,
     CONF_I2S_AUDIO_ID,
     CONF_I2S_DOUT_PIN,
     I2SAudioComponent,
     I2SAudioOut,
     i2s_audio_ns,
+    _validate_bits,
 )
 
 CODEOWNERS = ["@jesserockz"]
@@ -64,6 +67,9 @@ CONFIG_SCHEMA = cv.All(
                     cv.Optional(CONF_MODE, default="mono"): cv.one_of(
                         *EXTERNAL_DAC_OPTIONS, lower=True
                     ),
+                    cv.Optional(CONF_BITS_PER_SAMPLE, default="16bit"): cv.All(
+                        _validate_bits, cv.enum(BITS_PER_SAMPLE)
+                    ),
                 }
             ).extend(cv.COMPONENT_SCHEMA),
         },
@@ -85,3 +91,4 @@ async def to_code(config):
     else:
         cg.add(var.set_dout_pin(config[CONF_I2S_DOUT_PIN]))
         cg.add(var.set_external_dac_channels(2 if config[CONF_MODE] == "stereo" else 1))
+        cg.add(var.set_bits_per_sample(config[CONF_BITS_PER_SAMPLE]))

--- a/esphome/components/i2s_audio/speaker/i2s_audio_speaker.cpp
+++ b/esphome/components/i2s_audio/speaker/i2s_audio_speaker.cpp
@@ -40,19 +40,27 @@ void I2SAudioSpeaker::player_task(void *params) {
   xQueueSend(this_speaker->event_queue_, &event, portMAX_DELAY);
 
   i2s_driver_config_t config = {
-      .mode = (i2s_mode_t) (this_speaker->parent_->get_i2s_mode() | I2S_MODE_TX),
-      .sample_rate = 16000,
-      .bits_per_sample = this_speaker->bits_per_sample_,
-      .channel_format = I2S_CHANNEL_FMT_RIGHT_LEFT,
-      .communication_format = I2S_COMM_FORMAT_STAND_I2S,
-      .intr_alloc_flags = ESP_INTR_FLAG_LEVEL1,
-      .dma_buf_count = 8,
-      .dma_buf_len = 128,
-      .use_apll = false,
-      .tx_desc_auto_clear = true,
-      .fixed_mclk = I2S_PIN_NO_CHANGE,
-      .mclk_multiple = I2S_MCLK_MULTIPLE_DEFAULT,
-      .bits_per_chan = I2S_BITS_PER_CHAN_DEFAULT,
+    .mode = (i2s_mode_t) (this_speaker->parent_->get_i2s_mode() | I2S_MODE_TX),
+    .sample_rate = 16000,
+    .bits_per_sample = this_speaker->bits_per_sample_,
+    .channel_format = I2S_CHANNEL_FMT_RIGHT_LEFT,
+    .communication_format = I2S_COMM_FORMAT_STAND_I2S,
+    .intr_alloc_flags = ESP_INTR_FLAG_LEVEL1,
+    .dma_buf_count = 8,
+    .dma_buf_len = 128,
+    .use_apll = false,
+    .tx_desc_auto_clear = true,
+    .fixed_mclk = I2S_PIN_NO_CHANGE,
+    .mclk_multiple = I2S_MCLK_MULTIPLE_DEFAULT,
+    .bits_per_chan = I2S_BITS_PER_CHAN_DEFAULT,
+#if SOC_I2S_SUPPORTS_TDM
+    .chan_mask = (i2s_channel_t) (I2S_TDM_ACTIVE_CH0 | I2S_TDM_ACTIVE_CH1),
+    .total_chan = 2,
+    .left_align = false,
+    .big_edin = false,
+    .bit_order_msb = false,
+    .skip_msk = false,
+#endif
   };
 #if SOC_I2S_SUPPORTS_DAC
   if (this_speaker->internal_dac_mode_ != I2S_DAC_CHANNEL_DISABLE) {

--- a/esphome/components/i2s_audio/speaker/i2s_audio_speaker.cpp
+++ b/esphome/components/i2s_audio/speaker/i2s_audio_speaker.cpp
@@ -40,7 +40,7 @@ void I2SAudioSpeaker::player_task(void *params) {
   xQueueSend(this_speaker->event_queue_, &event, portMAX_DELAY);
 
   i2s_driver_config_t config = {
-      .mode = (i2s_mode_t) (I2S_MODE_MASTER | I2S_MODE_TX),
+      .mode = (i2s_mode_t) (this_speaker->parent_->get_i2s_mode() | I2S_MODE_TX),
       .sample_rate = 16000,
       .bits_per_sample = I2S_BITS_PER_SAMPLE_16BIT,
       .channel_format = I2S_CHANNEL_FMT_RIGHT_LEFT,

--- a/esphome/components/i2s_audio/speaker/i2s_audio_speaker.cpp
+++ b/esphome/components/i2s_audio/speaker/i2s_audio_speaker.cpp
@@ -68,10 +68,11 @@ void I2SAudioSpeaker::player_task(void *params) {
 
   if ((err_driver != ESP_OK) || (err_clk != ESP_OK)) {
     event.type = TaskEventType::WARNING;
-    if (err_driver != ESP_OK)
+    if (err_driver != ESP_OK) {
       event.err = err_driver;
-    else
+    } else {
       event.err = err_clk;
+    }
     xQueueSend(this_speaker->event_queue_, &event, 0);
     event.type = TaskEventType::STOPPED;
     xQueueSend(this_speaker->event_queue_, &event, 0);

--- a/esphome/components/i2s_audio/speaker/i2s_audio_speaker.cpp
+++ b/esphome/components/i2s_audio/speaker/i2s_audio_speaker.cpp
@@ -43,7 +43,7 @@ void I2SAudioSpeaker::player_task(void *params) {
     .mode = (i2s_mode_t) (this_speaker->parent_->get_i2s_mode() | I2S_MODE_TX),
     .sample_rate = 16000,
     .bits_per_sample = this_speaker->bits_per_sample_,
-    .channel_format = I2S_CHANNEL_FMT_RIGHT_LEFT,
+    .channel_format = I2S_CHANNEL_FMT_ONLY_RIGHT,
     .communication_format = I2S_COMM_FORMAT_STAND_I2S,
     .intr_alloc_flags = ESP_INTR_FLAG_LEVEL1,
     .dma_buf_count = 8,
@@ -70,17 +70,10 @@ void I2SAudioSpeaker::player_task(void *params) {
 
   esp_err_t err_driver = i2s_driver_install(this_speaker->parent_->get_port(), &config, 0, nullptr);
 
-  // Specify incoming audio stream is mono channel so it gets converted automatically when written to DMA buffer
-  uint32_t bits_cfg = (this_speaker->bits_per_sample_ << 16) | this_speaker->bits_per_sample_;
-  esp_err_t err_clk = i2s_set_clk(this_speaker->parent_->get_port(), 16000, bits_cfg, I2S_CHANNEL_MONO);
-
-  if ((err_driver != ESP_OK) || (err_clk != ESP_OK)) {
+  if ((err_driver != ESP_OK)) {  //|| (err_clk != ESP_OK)) {
     event.type = TaskEventType::WARNING;
-    if (err_driver != ESP_OK) {
-      event.err = err_driver;
-    } else {
-      event.err = err_clk;
-    }
+    event.err = err_driver;
+
     xQueueSend(this_speaker->event_queue_, &event, 0);
     event.type = TaskEventType::STOPPED;
     xQueueSend(this_speaker->event_queue_, &event, 0);

--- a/esphome/components/i2s_audio/speaker/i2s_audio_speaker.h
+++ b/esphome/components/i2s_audio/speaker/i2s_audio_speaker.h
@@ -18,6 +18,10 @@ namespace i2s_audio {
 
 static const size_t BUFFER_SIZE = 1024;
 
+// Volume table is borrowed from https://github.com/schreibfaul1/ESP32-audioI2S
+static const uint8_t VOLUME_TABLE[22] = {0,  1,  2,  3,  4,  6,  8,  10, 12, 14, 17,
+                                         20, 23, 27, 30, 34, 38, 43, 48, 52, 58, 64};
+
 enum class TaskEventType : uint8_t {
   STARTING = 0,
   STARTED,

--- a/esphome/components/i2s_audio/speaker/i2s_audio_speaker.h
+++ b/esphome/components/i2s_audio/speaker/i2s_audio_speaker.h
@@ -60,7 +60,6 @@ class I2SAudioSpeaker : public Component, public speaker::Speaker, public I2SAud
 
  protected:
   void start_();
-  // void stop_();
   void watch_();
 
   static void player_task(void *params);

--- a/esphome/components/i2s_audio/speaker/i2s_audio_speaker.h
+++ b/esphome/components/i2s_audio/speaker/i2s_audio_speaker.h
@@ -50,6 +50,7 @@ class I2SAudioSpeaker : public Component, public speaker::Speaker, public I2SAud
   void set_internal_dac_mode(i2s_dac_mode_t mode) { this->internal_dac_mode_ = mode; }
 #endif
   void set_external_dac_channels(uint8_t channels) { this->external_dac_channels_ = channels; }
+  void set_bits_per_sample(i2s_bits_per_sample_t bits_per_sample) { this->bits_per_sample_ = bits_per_sample; }
 
   void start() override;
   void stop() override;
@@ -67,6 +68,8 @@ class I2SAudioSpeaker : public Component, public speaker::Speaker, public I2SAud
   TaskHandle_t player_task_handle_{nullptr};
   QueueHandle_t buffer_queue_;
   QueueHandle_t event_queue_;
+
+  i2s_bits_per_sample_t bits_per_sample_;
 
   uint8_t dout_pin_{0};
 

--- a/esphome/components/speaker/automation.h
+++ b/esphome/components/speaker/automation.h
@@ -39,6 +39,11 @@ template<typename... Ts> class StopAction : public Action<Ts...>, public Parente
   void play(Ts... x) override { this->parent_->stop(); }
 };
 
+template<typename... Ts> class VolumeSetAction : public Action<Ts...>, public Parented<Speaker> {
+  TEMPLATABLE_VALUE(float, volume)
+  void play(Ts... x) override { this->parent_->set_volume(this->volume_.value(x...)); }
+};
+
 template<typename... Ts> class IsPlayingCondition : public Condition<Ts...>, public Parented<Speaker> {
  public:
   bool check(Ts... x) override { return this->parent_->is_running(); }

--- a/esphome/components/speaker/speaker.h
+++ b/esphome/components/speaker/speaker.h
@@ -20,10 +20,15 @@ class Speaker {
 
   virtual bool has_buffered_data() const = 0;
 
+  void set_volume(float volume) { this->volume_ = volume; }
+  float get_volume() { return this->volume_; }
+
   bool is_running() const { return this->state_ == STATE_RUNNING; }
 
  protected:
   State state_{STATE_STOPPED};
+
+  float volume_{1.0f};
 };
 
 }  // namespace speaker

--- a/tests/components/i2s_audio/test.esp32-c3-idf.yaml
+++ b/tests/components/i2s_audio/test.esp32-c3-idf.yaml
@@ -1,0 +1,34 @@
+esphome:
+  on_boot:
+    then:
+      - speaker.volume_set: 0.5
+      - speaker.stop:
+      - speaker.play: [0x18, 0x20]
+      - wait_until:
+          not:
+            speaker.is_playing:
+      - lambda: |-
+          id(i2s_mic).start();
+
+i2s_audio:
+  - id: i2s_primary
+    i2s_lrclk_pin: 6
+    i2s_bclk_pin: 7
+    i2s_mclk_pin: 5
+    i2s_mode: primary
+
+microphone:
+  - platform: i2s_audio
+    id: i2s_mic
+    i2s_audio_id: i2s_primary
+    i2s_din_pin: 3
+    adc_type: external
+    pdm: false
+
+speaker:
+  - platform: i2s_audio
+    i2s_audio_id: i2s_primary
+    dac_type: external
+    i2s_dout_pin: 1
+    mode: mono
+    bits_per_sample: 32bit

--- a/tests/components/i2s_audio/test.esp32-c3.yaml
+++ b/tests/components/i2s_audio/test.esp32-c3.yaml
@@ -1,0 +1,34 @@
+esphome:
+  on_boot:
+    then:
+      - speaker.volume_set: 0.5
+      - speaker.stop:
+      - speaker.play: [0x18, 0x20]
+      - wait_until:
+          not:
+            speaker.is_playing:
+      - lambda: |-
+          id(i2s_mic).start();
+
+i2s_audio:
+  - id: i2s_primary
+    i2s_lrclk_pin: 6
+    i2s_bclk_pin: 7
+    i2s_mclk_pin: 5
+    i2s_mode: primary
+
+microphone:
+  - platform: i2s_audio
+    id: i2s_mic
+    i2s_audio_id: i2s_primary
+    i2s_din_pin: 3
+    adc_type: external
+    pdm: false
+
+speaker:
+  - platform: i2s_audio
+    i2s_audio_id: i2s_primary
+    dac_type: external
+    i2s_dout_pin: 1
+    mode: mono
+    bits_per_sample: 32bit

--- a/tests/components/i2s_audio/test.esp32-idf.yaml
+++ b/tests/components/i2s_audio/test.esp32-idf.yaml
@@ -1,0 +1,39 @@
+esphome:
+  on_boot:
+    then:
+      - speaker.volume_set: 0.5
+      - speaker.stop:
+      - speaker.play: [0x18, 0x20]
+      - wait_until:
+          not:
+            speaker.is_playing:
+      - lambda: |-
+          id(i2s_mic).start();
+
+i2s_audio:
+  - id: i2s_primary
+    i2s_lrclk_pin: 19
+    i2s_bclk_pin: 14
+    i2s_mclk_pin: 16
+    i2s_mode: primary
+  - id: i2s_secondary
+    i2s_lrclk_pin: 13
+    i2s_bclk_pin: 17
+    i2s_mclk_pin: 18
+    i2s_mode: secondary
+
+microphone:
+  - platform: i2s_audio
+    id: i2s_mic
+    i2s_audio_id: i2s_primary
+    i2s_din_pin: 3
+    adc_type: external
+    pdm: false
+
+speaker:
+  - platform: i2s_audio
+    i2s_audio_id: i2s_secondary
+    dac_type: external
+    i2s_dout_pin: 1
+    mode: mono
+    bits_per_sample: 32bit

--- a/tests/components/i2s_audio/test.esp32-s3-idf.yaml
+++ b/tests/components/i2s_audio/test.esp32-s3-idf.yaml
@@ -1,0 +1,39 @@
+esphome:
+  on_boot:
+    then:
+      - speaker.volume_set: 0.5
+      - speaker.stop:
+      - speaker.play: [0x18, 0x20]
+      - wait_until:
+          not:
+            speaker.is_playing:
+      - lambda: |-
+          id(i2s_mic).start();
+
+i2s_audio:
+  - id: i2s_primary
+    i2s_lrclk_pin: 19
+    i2s_bclk_pin: 14
+    i2s_mclk_pin: 16
+    i2s_mode: primary
+  - id: i2s_secondary
+    i2s_lrclk_pin: 13
+    i2s_bclk_pin: 17
+    i2s_mclk_pin: 18
+    i2s_mode: secondary
+
+microphone:
+  - platform: i2s_audio
+    id: i2s_mic
+    i2s_audio_id: i2s_primary
+    i2s_din_pin: 20
+    adc_type: external
+    pdm: false
+
+speaker:
+  - platform: i2s_audio
+    i2s_audio_id: i2s_secondary
+    dac_type: external
+    i2s_dout_pin: 1
+    mode: mono
+    bits_per_sample: 32bit

--- a/tests/components/i2s_audio/test.esp32-s3.yaml
+++ b/tests/components/i2s_audio/test.esp32-s3.yaml
@@ -1,0 +1,39 @@
+esphome:
+  on_boot:
+    then:
+      - speaker.volume_set: 0.5
+      - speaker.stop:
+      - speaker.play: [0x18, 0x20]
+      - wait_until:
+          not:
+            speaker.is_playing:
+      - lambda: |-
+          id(i2s_mic).start();
+
+i2s_audio:
+  - id: i2s_primary
+    i2s_lrclk_pin: 19
+    i2s_bclk_pin: 14
+    i2s_mclk_pin: 16
+    i2s_mode: primary
+  - id: i2s_secondary
+    i2s_lrclk_pin: 13
+    i2s_bclk_pin: 17
+    i2s_mclk_pin: 18
+    i2s_mode: secondary
+
+microphone:
+  - platform: i2s_audio
+    id: i2s_mic
+    i2s_audio_id: i2s_primary
+    i2s_din_pin: 20
+    adc_type: external
+    pdm: false
+
+speaker:
+  - platform: i2s_audio
+    i2s_audio_id: i2s_secondary
+    dac_type: external
+    i2s_dout_pin: 1
+    mode: mono
+    bits_per_sample: 32bit

--- a/tests/components/i2s_audio/test.esp32.yaml
+++ b/tests/components/i2s_audio/test.esp32.yaml
@@ -1,0 +1,39 @@
+esphome:
+  on_boot:
+    then:
+      - speaker.volume_set: 0.5
+      - speaker.stop:
+      - speaker.play: [0x18, 0x20]
+      - wait_until:
+          not:
+            speaker.is_playing:
+      - lambda: |-
+          id(i2s_mic).start();
+
+i2s_audio:
+  - id: i2s_primary
+    i2s_lrclk_pin: 19
+    i2s_bclk_pin: 14
+    i2s_mclk_pin: 16
+    i2s_mode: primary
+  - id: i2s_secondary
+    i2s_lrclk_pin: 13
+    i2s_bclk_pin: 17
+    i2s_mclk_pin: 18
+    i2s_mode: secondary
+
+microphone:
+  - platform: i2s_audio
+    id: i2s_mic
+    i2s_audio_id: i2s_primary
+    i2s_din_pin: 3
+    adc_type: external
+    pdm: false
+
+speaker:
+  - platform: i2s_audio
+    i2s_audio_id: i2s_secondary
+    dac_type: external
+    i2s_dout_pin: 1
+    mode: mono
+    bits_per_sample: 32bit


### PR DESCRIPTION
# What does this implement/fix?

Adds several features and simplifies some of the ``i2s_audio`` code:

- Ability to select primary or secondary mode for an I2S audio parent config (default matches current behavior as the primary controller)
- Uses ``i2s_set_clk`` function to automatically handle splitting the expected mono channel audio into stereo audio instead of doing so manually
- Removes the commented out ``stop_`` function in the i2s_speaker header file
- Adds ``bits_per_sample`` configuration option for I2S speakers. The code uses ``i2s_write_expand`` function to automatically convert the expected 16 bits per sample audio into the appropriate format.
- Adds a volume attribute to the parent ``speaker`` component along with a corresponding ``speaker.volume_set`` action. The ``i2s_speaker`` uses this attribute to scale the audio volume.
- Defines the TDM parameters in ``i2s_driver_config_t`` on supported variants, eliminating several compilation warnings.
- Adds component tests for ``i2s_audio``.

The default behavior shouldn't be different with these modifications, so it isn't a breaking change. I tested these changes on an ATOM Echo without modifying the YAML with no issues.

The volume attribute and set action could be moved into the ``i2s_speaker`` component, as that is where the volume scaling actually happens. I moved the ``bits_per_sample`` codegen into the parent component. The ``i2s_microphone`` and ``i2s_speaker`` components import it to avoid code duplication.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** not applicable

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#3739

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
i2s_audio:
  - id: i2s_output
    i2s_lrclk_pin: GPIO7
    i2s_bclk_pin: GPIO8
    i2s_mclk_pin: GPIO9
    i2s_mode: secondary

speaker:
  - platform: i2s_audio
    id: xiao_speaker
    i2s_audio_id: i2s_output
    dac_type: external
    i2s_dout_pin: GPIO43
    mode: stereo
    bits_per_sample: 32bit

wifi:
  on_connect:
    - speaker.volume_set: 0.1



```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
