### PR TITLE
Fix NOLINT on inclusive-language check

### DIFF
--- a/esphome/components/pmsx003/pmsx003.h
+++ b/esphome/components/pmsx003/pmsx003.h
@@ -1,16 +1,17 @@
 #pragma once
 
-#include "esphome/core/component.h"
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/uart/uart.h"
+#include "esphome/core/component.h"
 
 namespace esphome {
 namespace pmsx003 {
 
 // known command bytes
-#define PMS_CMD_AUTO_MANUAL 0xE1  // data=0: perform measurement manually, data=1: perform measurement automatically
-#define PMS_CMD_TRIG_MANUAL 0xE2  // trigger a manual measurement
-#define PMS_CMD_ON_STANDBY 0xE4   // data=0: go to standby mode, data=1: go to normal mode
+static const uint8_t PMS_CMD_AUTO_MANUAL =
+    0xE1;  // data=0: perform measurement manually, data=1: perform measurement automatically
+static const uint8_t PMS_CMD_TRIG_MANUAL = 0xE2;  // trigger a manual measurement
+static const uint8_t PMS_CMD_ON_STANDBY = 0xE4;   // data=0: go to standby mode, data=1: go to normal mode
 
 static const uint16_t PMS_STABILISING_MS = 30000;  // time taken for the sensor to become stable after power on
 

--- a/script/ci-custom.py
+++ b/script/ci-custom.py
@@ -57,6 +57,7 @@ file_types = (
     "",
 )
 cpp_include = ("*.h", "*.c", "*.cpp", "*.tcc")
+py_include = ("*.py",)
 ignore_types = (".ico", ".png", ".woff", ".woff2", "")
 
 LINT_FILE_CHECKS = []
@@ -265,7 +266,8 @@ def lint_end_newline(fname, content):
     return None
 
 
-CPP_RE_EOL = r"\s*?(?://.*?)?$"
+CPP_RE_EOL = r".*?(?://.*?)?$"
+PY_RE_EOL = r".*?(?:#.*?)?$"
 
 
 def highlight(s):
@@ -574,11 +576,6 @@ def lint_pragma_once(fname, content):
     return None
 
 
-@lint_re_check(
-    r"(whitelist|blacklist|slave)",
-    exclude=["script/ci-custom.py"],
-    flags=re.IGNORECASE | re.MULTILINE,
-)
 def lint_inclusive_language(fname, match):
     # From https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=49decddd39e5f6132ccd7d9fdc3d7c470b0061bb
     return (
@@ -594,6 +591,21 @@ def lint_inclusive_language(fname, match):
         "    'denylist / allowlist'\n"
         "    'blocklist / passlist'"
     )
+
+
+lint_re_check(
+    r"(whitelist|blacklist|slave)" + PY_RE_EOL,
+    include=py_include,
+    exclude=["script/ci-custom.py"],
+    flags=re.IGNORECASE | re.MULTILINE,
+)(lint_inclusive_language)
+
+
+lint_re_check(
+    r"(whitelist|blacklist|slave)" + CPP_RE_EOL,
+    include=cpp_include,
+    flags=re.IGNORECASE | re.MULTILINE,
+)(lint_inclusive_language)
 
 
 @lint_re_check(r"[\t\r\f\v ]+$")

--- a/script/ci-custom.py
+++ b/script/ci-custom.py
@@ -275,7 +275,7 @@ def highlight(s):
 
 
 @lint_re_check(
-    r"^#define\s+([a-zA-Z0-9_]+)\s+([0-9bx]+)" + CPP_RE_EOL,
+    r"^#define\s+([a-zA-Z0-9_]+)\s+(0b[10]+|0x[0-9a-fA-F]+|\d+)\s*?(?:\/\/.*?)?$",
     include=cpp_include,
     exclude=[
         "esphome/core/log.h",


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Sometimes we have to reference library/sdk variables that use the terms whitelist/blacklist/slave so we need to be able to ignore this until those references are updated upstream.

See #6463 for an example

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
