### PR TITLE
web_server: Return early if no clients connected

### DIFF
--- a/esphome/components/web_server/list_entities.cpp
+++ b/esphome/components/web_server/list_entities.cpp
@@ -12,6 +12,8 @@ ListEntitiesIterator::ListEntitiesIterator(WebServer *web_server) : web_server_(
 
 #ifdef USE_BINARY_SENSOR
 bool ListEntitiesIterator::on_binary_sensor(binary_sensor::BinarySensor *binary_sensor) {
+  if (this->web_server_->events_.count() == 0)
+    return true;
   this->web_server_->events_.send(
       this->web_server_->binary_sensor_json(binary_sensor, binary_sensor->state, DETAIL_ALL).c_str(), "state");
   return true;
@@ -19,30 +21,40 @@ bool ListEntitiesIterator::on_binary_sensor(binary_sensor::BinarySensor *binary_
 #endif
 #ifdef USE_COVER
 bool ListEntitiesIterator::on_cover(cover::Cover *cover) {
+  if (this->web_server_->events_.count() == 0)
+    return true;
   this->web_server_->events_.send(this->web_server_->cover_json(cover, DETAIL_ALL).c_str(), "state");
   return true;
 }
 #endif
 #ifdef USE_FAN
 bool ListEntitiesIterator::on_fan(fan::Fan *fan) {
+  if (this->web_server_->events_.count() == 0)
+    return true;
   this->web_server_->events_.send(this->web_server_->fan_json(fan, DETAIL_ALL).c_str(), "state");
   return true;
 }
 #endif
 #ifdef USE_LIGHT
 bool ListEntitiesIterator::on_light(light::LightState *light) {
+  if (this->web_server_->events_.count() == 0)
+    return true;
   this->web_server_->events_.send(this->web_server_->light_json(light, DETAIL_ALL).c_str(), "state");
   return true;
 }
 #endif
 #ifdef USE_SENSOR
 bool ListEntitiesIterator::on_sensor(sensor::Sensor *sensor) {
+  if (this->web_server_->events_.count() == 0)
+    return true;
   this->web_server_->events_.send(this->web_server_->sensor_json(sensor, sensor->state, DETAIL_ALL).c_str(), "state");
   return true;
 }
 #endif
 #ifdef USE_SWITCH
 bool ListEntitiesIterator::on_switch(switch_::Switch *a_switch) {
+  if (this->web_server_->events_.count() == 0)
+    return true;
   this->web_server_->events_.send(this->web_server_->switch_json(a_switch, a_switch->state, DETAIL_ALL).c_str(),
                                   "state");
   return true;
@@ -50,12 +62,16 @@ bool ListEntitiesIterator::on_switch(switch_::Switch *a_switch) {
 #endif
 #ifdef USE_BUTTON
 bool ListEntitiesIterator::on_button(button::Button *button) {
+  if (this->web_server_->events_.count() == 0)
+    return true;
   this->web_server_->events_.send(this->web_server_->button_json(button, DETAIL_ALL).c_str(), "state");
   return true;
 }
 #endif
 #ifdef USE_TEXT_SENSOR
 bool ListEntitiesIterator::on_text_sensor(text_sensor::TextSensor *text_sensor) {
+  if (this->web_server_->events_.count() == 0)
+    return true;
   this->web_server_->events_.send(
       this->web_server_->text_sensor_json(text_sensor, text_sensor->state, DETAIL_ALL).c_str(), "state");
   return true;
@@ -63,6 +79,8 @@ bool ListEntitiesIterator::on_text_sensor(text_sensor::TextSensor *text_sensor) 
 #endif
 #ifdef USE_LOCK
 bool ListEntitiesIterator::on_lock(lock::Lock *a_lock) {
+  if (this->web_server_->events_.count() == 0)
+    return true;
   this->web_server_->events_.send(this->web_server_->lock_json(a_lock, a_lock->state, DETAIL_ALL).c_str(), "state");
   return true;
 }
@@ -70,6 +88,8 @@ bool ListEntitiesIterator::on_lock(lock::Lock *a_lock) {
 
 #ifdef USE_CLIMATE
 bool ListEntitiesIterator::on_climate(climate::Climate *climate) {
+  if (this->web_server_->events_.count() == 0)
+    return true;
   this->web_server_->events_.send(this->web_server_->climate_json(climate, DETAIL_ALL).c_str(), "state");
   return true;
 }
@@ -77,6 +97,8 @@ bool ListEntitiesIterator::on_climate(climate::Climate *climate) {
 
 #ifdef USE_NUMBER
 bool ListEntitiesIterator::on_number(number::Number *number) {
+  if (this->web_server_->events_.count() == 0)
+    return true;
   this->web_server_->events_.send(this->web_server_->number_json(number, number->state, DETAIL_ALL).c_str(), "state");
   return true;
 }
@@ -84,6 +106,8 @@ bool ListEntitiesIterator::on_number(number::Number *number) {
 
 #ifdef USE_DATETIME_DATE
 bool ListEntitiesIterator::on_date(datetime::DateEntity *date) {
+  if (this->web_server_->events_.count() == 0)
+    return true;
   this->web_server_->events_.send(this->web_server_->date_json(date, DETAIL_ALL).c_str(), "state");
   return true;
 }
@@ -91,6 +115,8 @@ bool ListEntitiesIterator::on_date(datetime::DateEntity *date) {
 
 #ifdef USE_TEXT
 bool ListEntitiesIterator::on_text(text::Text *text) {
+  if (this->web_server_->events_.count() == 0)
+    return true;
   this->web_server_->events_.send(this->web_server_->text_json(text, text->state, DETAIL_ALL).c_str(), "state");
   return true;
 }
@@ -98,6 +124,8 @@ bool ListEntitiesIterator::on_text(text::Text *text) {
 
 #ifdef USE_SELECT
 bool ListEntitiesIterator::on_select(select::Select *select) {
+  if (this->web_server_->events_.count() == 0)
+    return true;
   this->web_server_->events_.send(this->web_server_->select_json(select, select->state, DETAIL_ALL).c_str(), "state");
   return true;
 }
@@ -105,6 +133,8 @@ bool ListEntitiesIterator::on_select(select::Select *select) {
 
 #ifdef USE_ALARM_CONTROL_PANEL
 bool ListEntitiesIterator::on_alarm_control_panel(alarm_control_panel::AlarmControlPanel *a_alarm_control_panel) {
+  if (this->web_server_->events_.count() == 0)
+    return true;
   this->web_server_->events_.send(
       this->web_server_->alarm_control_panel_json(a_alarm_control_panel, a_alarm_control_panel->get_state(), DETAIL_ALL)
           .c_str(),

--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -416,6 +416,8 @@ void WebServer::handle_js_request(AsyncWebServerRequest *request) {
 
 #ifdef USE_SENSOR
 void WebServer::on_sensor_update(sensor::Sensor *obj, float state) {
+  if (this->events_.count() == 0)
+    return;
   this->events_.send(this->sensor_json(obj, state, DETAIL_STATE).c_str(), "state");
 }
 void WebServer::handle_sensor_request(AsyncWebServerRequest *request, const UrlMatch &match) {
@@ -449,6 +451,8 @@ std::string WebServer::sensor_json(sensor::Sensor *obj, float value, JsonDetail 
 
 #ifdef USE_TEXT_SENSOR
 void WebServer::on_text_sensor_update(text_sensor::TextSensor *obj, const std::string &state) {
+  if (this->events_.count() == 0)
+    return;
   this->events_.send(this->text_sensor_json(obj, state, DETAIL_STATE).c_str(), "state");
 }
 void WebServer::handle_text_sensor_request(AsyncWebServerRequest *request, const UrlMatch &match) {
@@ -471,6 +475,8 @@ std::string WebServer::text_sensor_json(text_sensor::TextSensor *obj, const std:
 
 #ifdef USE_SWITCH
 void WebServer::on_switch_update(switch_::Switch *obj, bool state) {
+  if (this->events_.count() == 0)
+    return;
   this->events_.send(this->switch_json(obj, state, DETAIL_STATE).c_str(), "state");
 }
 std::string WebServer::switch_json(switch_::Switch *obj, bool value, JsonDetail start_config) {
@@ -532,6 +538,8 @@ void WebServer::handle_button_request(AsyncWebServerRequest *request, const UrlM
 
 #ifdef USE_BINARY_SENSOR
 void WebServer::on_binary_sensor_update(binary_sensor::BinarySensor *obj, bool state) {
+  if (this->events_.count() == 0)
+    return;
   this->events_.send(this->binary_sensor_json(obj, state, DETAIL_STATE).c_str(), "state");
 }
 std::string WebServer::binary_sensor_json(binary_sensor::BinarySensor *obj, bool value, JsonDetail start_config) {
@@ -553,7 +561,11 @@ void WebServer::handle_binary_sensor_request(AsyncWebServerRequest *request, con
 #endif
 
 #ifdef USE_FAN
-void WebServer::on_fan_update(fan::Fan *obj) { this->events_.send(this->fan_json(obj, DETAIL_STATE).c_str(), "state"); }
+void WebServer::on_fan_update(fan::Fan *obj) {
+  if (this->events_.count() == 0)
+    return;
+  this->events_.send(this->fan_json(obj, DETAIL_STATE).c_str(), "state");
+}
 std::string WebServer::fan_json(fan::Fan *obj, JsonDetail start_config) {
   return json::build_json([obj, start_config](JsonObject root) {
     set_json_icon_state_value(root, obj, "fan-" + obj->get_object_id(), obj->state ? "ON" : "OFF", obj->state,
@@ -623,6 +635,8 @@ void WebServer::handle_fan_request(AsyncWebServerRequest *request, const UrlMatc
 
 #ifdef USE_LIGHT
 void WebServer::on_light_update(light::LightState *obj) {
+  if (this->events_.count() == 0)
+    return;
   this->events_.send(this->light_json(obj, DETAIL_STATE).c_str(), "state");
 }
 void WebServer::handle_light_request(AsyncWebServerRequest *request, const UrlMatch &match) {
@@ -729,6 +743,8 @@ std::string WebServer::light_json(light::LightState *obj, JsonDetail start_confi
 
 #ifdef USE_COVER
 void WebServer::on_cover_update(cover::Cover *obj) {
+  if (this->events_.count() == 0)
+    return;
   this->events_.send(this->cover_json(obj, DETAIL_STATE).c_str(), "state");
 }
 void WebServer::handle_cover_request(AsyncWebServerRequest *request, const UrlMatch &match) {
@@ -798,6 +814,8 @@ std::string WebServer::cover_json(cover::Cover *obj, JsonDetail start_config) {
 
 #ifdef USE_NUMBER
 void WebServer::on_number_update(number::Number *obj, float state) {
+  if (this->events_.count() == 0)
+    return;
   this->events_.send(this->number_json(obj, state, DETAIL_STATE).c_str(), "state");
 }
 void WebServer::handle_number_request(AsyncWebServerRequest *request, const UrlMatch &match) {
@@ -856,6 +874,8 @@ std::string WebServer::number_json(number::Number *obj, float value, JsonDetail 
 
 #ifdef USE_DATETIME_DATE
 void WebServer::on_date_update(datetime::DateEntity *obj) {
+  if (this->events_.count() == 0)
+    return;
   this->events_.send(this->date_json(obj, DETAIL_STATE).c_str(), "state");
 }
 void WebServer::handle_date_request(AsyncWebServerRequest *request, const UrlMatch &match) {
@@ -903,6 +923,8 @@ std::string WebServer::date_json(datetime::DateEntity *obj, JsonDetail start_con
 
 #ifdef USE_TEXT
 void WebServer::on_text_update(text::Text *obj, const std::string &state) {
+  if (this->events_.count() == 0)
+    return;
   this->events_.send(this->text_json(obj, state, DETAIL_STATE).c_str(), "state");
 }
 void WebServer::handle_text_request(AsyncWebServerRequest *request, const UrlMatch &match) {
@@ -954,6 +976,8 @@ std::string WebServer::text_json(text::Text *obj, const std::string &value, Json
 
 #ifdef USE_SELECT
 void WebServer::on_select_update(select::Select *obj, const std::string &state, size_t index) {
+  if (this->events_.count() == 0)
+    return;
   this->events_.send(this->select_json(obj, state, DETAIL_STATE).c_str(), "state");
 }
 void WebServer::handle_select_request(AsyncWebServerRequest *request, const UrlMatch &match) {
@@ -1008,6 +1032,8 @@ std::string WebServer::select_json(select::Select *obj, const std::string &value
 
 #ifdef USE_CLIMATE
 void WebServer::on_climate_update(climate::Climate *obj) {
+  if (this->events_.count() == 0)
+    return;
   this->events_.send(this->climate_json(obj, DETAIL_STATE).c_str(), "state");
 }
 
@@ -1149,6 +1175,8 @@ std::string WebServer::climate_json(climate::Climate *obj, JsonDetail start_conf
 
 #ifdef USE_LOCK
 void WebServer::on_lock_update(lock::Lock *obj) {
+  if (this->events_.count() == 0)
+    return;
   this->events_.send(this->lock_json(obj, obj->state, DETAIL_STATE).c_str(), "state");
 }
 std::string WebServer::lock_json(lock::Lock *obj, lock::LockState value, JsonDetail start_config) {
@@ -1185,6 +1213,8 @@ void WebServer::handle_lock_request(AsyncWebServerRequest *request, const UrlMat
 
 #ifdef USE_ALARM_CONTROL_PANEL
 void WebServer::on_alarm_control_panel_update(alarm_control_panel::AlarmControlPanel *obj) {
+  if (this->events_.count() == 0)
+    return;
   this->events_.send(this->alarm_control_panel_json(obj, obj->get_state(), DETAIL_STATE).c_str(), "state");
 }
 std::string WebServer::alarm_control_panel_json(alarm_control_panel::AlarmControlPanel *obj,

--- a/esphome/components/web_server_idf/web_server_idf.h
+++ b/esphome/components/web_server_idf/web_server_idf.h
@@ -3,11 +3,11 @@
 
 #include <esp_http_server.h>
 
-#include <string>
 #include <functional>
-#include <vector>
 #include <map>
 #include <set>
+#include <string>
+#include <vector>
 
 namespace esphome {
 namespace web_server_idf {
@@ -250,6 +250,8 @@ class AsyncEventSource : public AsyncWebHandler {
   void onConnect(connect_handler_t cb) { this->on_connect_ = std::move(cb); }
 
   void send(const char *message, const char *event = nullptr, uint32_t id = 0, uint32_t reconnect = 0);
+
+  size_t count() const { return this->sessions_.size(); }
 
  protected:
   std::string url_;


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->
Even when no clients are connected to the `/events` endpoint, the JSON is still being generated. This adds an early return to not do anything if there are no clients.

The `size_t count()` function exists already in the Arduino library, and this PR adds it to the esp-idf implementation.

```
[19:14:20][V][json:038]: Attempting to allocate 512 bytes for JSON serialization
[19:14:20][V][json:058]: Size after shrink 64 bytes
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
