### PR TITLE
Replace std::regex with sscanf calls

### DIFF
--- a/esphome/core/time.cpp
+++ b/esphome/core/time.cpp
@@ -73,9 +73,10 @@ bool ESPTime::strptime(const std::string &time_to_parse, ESPTime &esp_time) {
   uint8_t second;
   int num;
 
-  if (sscanf(time_to_parse.c_str(), "%04u-%02u-%02u %02u:%02u:%02u %n", &year, &month, &day, &hour, &minute,  // NOLINT
-             &second,                                                                                         // NOLINT
-             &num) == 6 &&                                                                                    // NOLINT
+  if (sscanf(time_to_parse.c_str(), "%04hu-%02hhu-%02hhu %02hhu:%02hhu:%02hhu %n", &year, &month, &day,  // NOLINT
+             &hour,                                                                                      // NOLINT
+             &minute,                                                                                    // NOLINT
+             &second, &num) == 6 &&                                                                      // NOLINT
       num == time_to_parse.size()) {
     esp_time.year = year;
     esp_time.month = month;
@@ -83,17 +84,17 @@ bool ESPTime::strptime(const std::string &time_to_parse, ESPTime &esp_time) {
     esp_time.hour = hour;
     esp_time.minute = minute;
     esp_time.second = second;
-  } else if (sscanf(time_to_parse.c_str(), "%02u:%02u:%02u %n", &hour, &minute, &second, &num) == 3 &&  // NOLINT
+  } else if (sscanf(time_to_parse.c_str(), "%02hhu:%02hhu:%02hhu %n", &hour, &minute, &second, &num) == 3 &&  // NOLINT
              num == time_to_parse.size()) {
     esp_time.hour = hour;
     esp_time.minute = minute;
     esp_time.second = second;
-  } else if (sscanf(time_to_parse.c_str(), "%02u:%02u %n", &hour, &minute, &num) == 2 &&  // NOLINT
+  } else if (sscanf(time_to_parse.c_str(), "%02hhu:%02hhu %n", &hour, &minute, &num) == 2 &&  // NOLINT
              num == time_to_parse.size()) {
     esp_time.hour = hour;
     esp_time.minute = minute;
     esp_time.second = 0;
-  } else if (sscanf(time_to_parse.c_str(), "%04u-%02u-%02u %n", &year, &month, &day, &num) == 3 &&  // NOLINT
+  } else if (sscanf(time_to_parse.c_str(), "%04hu-%02hhu-%02hhu %n", &year, &month, &day, &num) == 3 &&  // NOLINT
              num == time_to_parse.size()) {
     esp_time.year = year;
     esp_time.month = month;

--- a/esphome/core/time.cpp
+++ b/esphome/core/time.cpp
@@ -1,9 +1,7 @@
-#ifdef USE_DATETIME
-#include <regex>
-#endif
-
-#include "helpers.h"
 #include "time.h"  // NOLINT
+#include "helpers.h"
+
+#include <cinttypes>
 
 namespace esphome {
 
@@ -66,47 +64,46 @@ std::string ESPTime::strftime(const std::string &format) {
   return timestr;
 }
 
-#ifdef USE_DATETIME
-
 bool ESPTime::strptime(const std::string &time_to_parse, ESPTime &esp_time) {
-  // clang-format off
-  std::regex dt_regex(R"(^
-    (
-      (\d{4})-(\d{1,2})-(\d{1,2})
-      (?:\s(?=.+))
-    )?
-    (
-      (\d{1,2}):(\d{2})
-      (?::(\d{2}))?
-    )?
-  $)");
-  // clang-format on
+  uint16_t year;
+  uint8_t month;
+  uint8_t day;
+  uint8_t hour;
+  uint8_t minute;
+  uint8_t second;
+  uint8_t num;
 
-  std::smatch match;
-  if (std::regex_match(time_to_parse, match, dt_regex) == 0)
+  if (sscanf(time_to_parse.c_str(), "%04" SCNu16 "-%02" SCNu8 "-%02" SCNu8 " %02" SCNu8 ":%02" SCNu8 ":%02" SCNu8 " %n",
+             &year, &month, &day, &hour, &minute, &second, &num) == 6 &&
+      num == time_to_parse.size()) {
+    esp_time.year = year;
+    esp_time.month = month;
+    esp_time.day_of_month = day;
+    esp_time.hour = hour;
+    esp_time.minute = minute;
+    esp_time.second = second;
+  } else if (sscanf(time_to_parse.c_str(), "%02" SCNu8 ":%02" SCNu8 ":%02" SCNu8 " %n", &hour, &minute, &second,
+                    &num) == 3 &&
+             num == time_to_parse.size()) {
+    esp_time.hour = hour;
+    esp_time.minute = minute;
+    esp_time.second = second;
+  } else if (sscanf(time_to_parse.c_str(), "%02" SCNu8 ":%02" SCNu8 " %n", &hour, &minute, &num) == 2 &&
+             num == time_to_parse.size()) {
+    esp_time.hour = hour;
+    esp_time.minute = minute;
+    esp_time.second = 0;
+  } else if (sscanf(time_to_parse.c_str(), "%04" SCNu16 "-%02" SCNu8 "-%02" SCNu8 " %n", &year, &month, &day, &num) ==
+                 3 &&
+             num == time_to_parse.size()) {
+    esp_time.year = year;
+    esp_time.month = month;
+    esp_time.day_of_month = day;
+  } else {
     return false;
-
-  if (match[1].matched) {  // Has date parts
-
-    esp_time.year = parse_number<uint16_t>(match[2].str()).value_or(0);
-    esp_time.month = parse_number<uint8_t>(match[3].str()).value_or(0);
-    esp_time.day_of_month = parse_number<uint8_t>(match[4].str()).value_or(0);
   }
-  if (match[5].matched) {  // Has time parts
-
-    esp_time.hour = parse_number<uint8_t>(match[6].str()).value_or(0);
-    esp_time.minute = parse_number<uint8_t>(match[7].str()).value_or(0);
-    if (match[8].matched) {
-      esp_time.second = parse_number<uint8_t>(match[8].str()).value_or(0);
-    } else {
-      esp_time.second = 0;
-    }
-  }
-
   return true;
 }
-
-#endif
 
 void ESPTime::increment_second() {
   this->timestamp++;

--- a/esphome/core/time.cpp
+++ b/esphome/core/time.cpp
@@ -71,10 +71,11 @@ bool ESPTime::strptime(const std::string &time_to_parse, ESPTime &esp_time) {
   uint8_t hour;
   uint8_t minute;
   uint8_t second;
-  uint8_t num;
+  int num;
 
-  if (sscanf(time_to_parse.c_str(), "%04" SCNu16 "-%02" SCNu8 "-%02" SCNu8 " %02" SCNu8 ":%02" SCNu8 ":%02" SCNu8 " %n",
-             &year, &month, &day, &hour, &minute, &second, &num) == 6 &&
+  if (sscanf(time_to_parse.c_str(),
+             "%04" SCNu16 "-%02" SCNu8 "-%02" SCNu8 " %02" SCNu8 ":%02" SCNu8 ":%02" SCNu8 " %n",  // NOLINT
+             &year, &month, &day, &hour, &minute, &second, &num) == 6 &&                           // NOLINT
       num == time_to_parse.size()) {
     esp_time.year = year;
     esp_time.month = month;
@@ -82,18 +83,20 @@ bool ESPTime::strptime(const std::string &time_to_parse, ESPTime &esp_time) {
     esp_time.hour = hour;
     esp_time.minute = minute;
     esp_time.second = second;
-  } else if (sscanf(time_to_parse.c_str(), "%02" SCNu8 ":%02" SCNu8 ":%02" SCNu8 " %n", &hour, &minute, &second,
-                    &num) == 3 &&
+  } else if (sscanf(time_to_parse.c_str(), "%02" SCNu8 ":%02" SCNu8 ":%02" SCNu8 " %n", &hour, &minute,  // NOLINT
+                    &second,                                                                             // NOLINT
+                    &num) == 3 &&                                                                        // NOLINT
              num == time_to_parse.size()) {
     esp_time.hour = hour;
     esp_time.minute = minute;
     esp_time.second = second;
-  } else if (sscanf(time_to_parse.c_str(), "%02" SCNu8 ":%02" SCNu8 " %n", &hour, &minute, &num) == 2 &&
+  } else if (sscanf(time_to_parse.c_str(), "%02" SCNu8 ":%02" SCNu8 " %n", &hour, &minute, &num) == 2 &&  // NOLINT
              num == time_to_parse.size()) {
     esp_time.hour = hour;
     esp_time.minute = minute;
     esp_time.second = 0;
-  } else if (sscanf(time_to_parse.c_str(), "%04" SCNu16 "-%02" SCNu8 "-%02" SCNu8 " %n", &year, &month, &day, &num) ==
+  } else if (sscanf(time_to_parse.c_str(), "%04" SCNu16 "-%02" SCNu8 "-%02" SCNu8 " %n", &year, &month, &day,  // NOLINT
+                    &num) ==                                                                                   // NOLINT
                  3 &&
              num == time_to_parse.size()) {
     esp_time.year = year;

--- a/esphome/core/time.cpp
+++ b/esphome/core/time.cpp
@@ -73,9 +73,9 @@ bool ESPTime::strptime(const std::string &time_to_parse, ESPTime &esp_time) {
   uint8_t second;
   int num;
 
-  if (sscanf(time_to_parse.c_str(),
-             "%04" SCNu16 "-%02" SCNu8 "-%02" SCNu8 " %02" SCNu8 ":%02" SCNu8 ":%02" SCNu8 " %n",  // NOLINT
-             &year, &month, &day, &hour, &minute, &second, &num) == 6 &&                           // NOLINT
+  if (sscanf(time_to_parse.c_str(), "%04u-%02u-%02u %02u:%02u:%02u %n", &year, &month, &day, &hour, &minute,  // NOLINT
+             &second,                                                                                         // NOLINT
+             &num) == 6 &&                                                                                    // NOLINT
       num == time_to_parse.size()) {
     esp_time.year = year;
     esp_time.month = month;
@@ -83,21 +83,17 @@ bool ESPTime::strptime(const std::string &time_to_parse, ESPTime &esp_time) {
     esp_time.hour = hour;
     esp_time.minute = minute;
     esp_time.second = second;
-  } else if (sscanf(time_to_parse.c_str(), "%02" SCNu8 ":%02" SCNu8 ":%02" SCNu8 " %n", &hour, &minute,  // NOLINT
-                    &second,                                                                             // NOLINT
-                    &num) == 3 &&                                                                        // NOLINT
+  } else if (sscanf(time_to_parse.c_str(), "%02u:%02u:%02u %n", &hour, &minute, &second, &num) == 3 &&  // NOLINT
              num == time_to_parse.size()) {
     esp_time.hour = hour;
     esp_time.minute = minute;
     esp_time.second = second;
-  } else if (sscanf(time_to_parse.c_str(), "%02" SCNu8 ":%02" SCNu8 " %n", &hour, &minute, &num) == 2 &&  // NOLINT
+  } else if (sscanf(time_to_parse.c_str(), "%02u:%02u %n", &hour, &minute, &num) == 2 &&  // NOLINT
              num == time_to_parse.size()) {
     esp_time.hour = hour;
     esp_time.minute = minute;
     esp_time.second = 0;
-  } else if (sscanf(time_to_parse.c_str(), "%04" SCNu16 "-%02" SCNu8 "-%02" SCNu8 " %n", &year, &month, &day,  // NOLINT
-                    &num) ==                                                                                   // NOLINT
-                 3 &&
+  } else if (sscanf(time_to_parse.c_str(), "%04u-%02u-%02u %n", &year, &month, &day, &num) == 3 &&  // NOLINT
              num == time_to_parse.size()) {
     esp_time.year = year;
     esp_time.month = month;

--- a/esphome/core/time.h
+++ b/esphome/core/time.h
@@ -67,16 +67,12 @@ struct ESPTime {
            this->day_of_year < 367 && this->month > 0 && this->month < 13;
   }
 
-#ifdef USE_DATETIME
-
   /** Convert a string to ESPTime struct as specified by the format argument.
    * @param time_to_parse null-terminated c string formatet like this: 2020-08-25 05:30:00.
    * @param esp_time an instance of a ESPTime struct
    * @return the success sate of the parsing
    */
   static bool strptime(const std::string &time_to_parse, ESPTime &esp_time);
-
-#endif
 
   /// Convert a C tm struct instance with a C unix epoch timestamp to an ESPTime instance.
   static ESPTime from_c_tm(struct tm *c_tm, time_t c_time);


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

This replaces the import and calls provided by std::regex which brings in a lot of code for a small gain. With crafted sscanf statements we can parse the formats we need directly.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
