### PR TITLE
ESP32 Arduino WiFi: misc bug fixes

### DIFF
--- a/esphome/components/wifi/wifi_component_esp32_arduino.cpp
+++ b/esphome/components/wifi/wifi_component_esp32_arduino.cpp
@@ -582,14 +582,14 @@ void WiFiComponent::wifi_pre_setup_() {
 }
 WiFiSTAConnectStatus WiFiComponent::wifi_sta_connect_status_() {
   auto status = WiFiClass::status();
-  if (status == WL_CONNECTED) {
-    return WiFiSTAConnectStatus::CONNECTED;
-  } else if (status == WL_CONNECT_FAILED || status == WL_CONNECTION_LOST) {
+  if (status == WL_CONNECT_FAILED || status == WL_CONNECTION_LOST) {
     return WiFiSTAConnectStatus::ERROR_CONNECT_FAILED;
   } else if (status == WL_NO_SSID_AVAIL) {
     return WiFiSTAConnectStatus::ERROR_NETWORK_NOT_FOUND;
   } else if (s_sta_connecting) {
     return WiFiSTAConnectStatus::CONNECTING;
+  } else if (status == WL_CONNECTED) {
+    return WiFiSTAConnectStatus::CONNECTED;
   }
   return WiFiSTAConnectStatus::IDLE;
 }

--- a/esphome/components/wifi/wifi_component_esp32_arduino.cpp
+++ b/esphome/components/wifi/wifi_component_esp32_arduino.cpp
@@ -707,7 +707,7 @@ bool WiFiComponent::wifi_start_ap_(const WiFiAP &ap) {
     *conf.ap.password = 0;
   } else {
     conf.ap.authmode = WIFI_AUTH_WPA2_PSK;
-    strncpy(reinterpret_cast<char *>(conf.ap.password), ap.get_password().c_str(), sizeof(conf.ap.ssid));
+    strncpy(reinterpret_cast<char *>(conf.ap.password), ap.get_password().c_str(), sizeof(conf.ap.password));
   }
 
   conf.ap.pairwise_cipher = WIFI_CIPHER_TYPE_CCMP;


### PR DESCRIPTION
# What does this implement/fix?

This includes fixes for a couple bugs that I found in the  ESP32-Arduino WiFi component. (They are tiny, so to reduce review overhead, I bundled them in one PR. If you'd rather see them all in separate PRs, let me know.)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
```yaml
esphome:
  name: testesp

esp32:
  board: esp-wrover-kit
  framework:
    type: arduino

network:
    enable_ipv6: true
    min_ipv6_addr_count: 2

wifi:
  ssid: !secret wifi_ssid
  password: !secret wifi_password

  ap:
    ssid: "fallback hotspot"
    password: !secret wifi_ap_password

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - ~~Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).~~
