### PR TITLE
Only give error for connected sensors at startup

### DIFF
--- a/esphome/components/dallas/dallas_component.cpp
+++ b/esphome/components/dallas/dallas_component.cpp
@@ -60,7 +60,7 @@ void DallasComponent::setup() {
   for (auto *sensor : this->sensors_) {
     if (sensor->get_index().has_value()) {
       if (*sensor->get_index() >= this->found_sensors_.size()) {
-        this->status_set_error();
+        this->status_set_error("Sensor configured by index but not found");
         continue;
       }
       sensor->set_address(this->found_sensors_[*sensor->get_index()]);
@@ -109,8 +109,12 @@ void DallasComponent::update() {
     result = this->one_wire_->reset();
   }
   if (!result) {
-    ESP_LOGE(TAG, "Requesting conversion failed");
-    this->status_set_warning();
+    if (this->found_sensors_.size() > 0) {
+      // Only log error if at the start sensors were found (and thus are disconnected during uptime)
+      ESP_LOGE(TAG, "Requesting conversion failed");
+      this->status_set_warning();
+    }
+
     for (auto *sensor : this->sensors_) {
       sensor->publish_state(NAN);
     }
@@ -124,6 +128,12 @@ void DallasComponent::update() {
   }
 
   for (auto *sensor : this->sensors_) {
+    if (sensor->get_address() == 0) {
+      ESP_LOGV(TAG, "'%s' - Indexed sensor not found at startup, skipping update", sensor->get_name().c_str());
+      sensor->publish_state(NAN);
+      continue;
+    }
+
     this->set_timeout(sensor->get_address_name(), sensor->millis_to_wait_for_conversion(), [this, sensor] {
       bool res = sensor->read_scratch_pad();
 
@@ -152,6 +162,8 @@ void DallasTemperatureSensor::set_resolution(uint8_t resolution) { this->resolut
 optional<uint8_t> DallasTemperatureSensor::get_index() const { return this->index_; }
 void DallasTemperatureSensor::set_index(uint8_t index) { this->index_ = index; }
 uint8_t *DallasTemperatureSensor::get_address8() { return reinterpret_cast<uint8_t *>(&this->address_); }
+uint64_t DallasTemperatureSensor::get_address() { return this->address_; }
+
 const std::string &DallasTemperatureSensor::get_address_name() {
   if (this->address_name_.empty()) {
     this->address_name_ = std::string("0x") + format_hex(this->address_);

--- a/esphome/components/dallas/dallas_component.cpp
+++ b/esphome/components/dallas/dallas_component.cpp
@@ -109,7 +109,7 @@ void DallasComponent::update() {
     result = this->one_wire_->reset();
   }
   if (!result) {
-    if (this->found_sensors_.size() > 0) {
+    if (!this->found_sensors_.empty()) {
       // Only log error if at the start sensors were found (and thus are disconnected during uptime)
       ESP_LOGE(TAG, "Requesting conversion failed");
       this->status_set_warning();

--- a/esphome/components/dallas/dallas_component.h
+++ b/esphome/components/dallas/dallas_component.h
@@ -37,6 +37,7 @@ class DallasTemperatureSensor : public sensor::Sensor {
   void set_parent(DallasComponent *parent) { parent_ = parent; }
   /// Helper to get a pointer to the address as uint8_t.
   uint8_t *get_address8();
+  uint64_t get_address();
   /// Helper to create (and cache) the name for this sensor. For example "0xfe0000031f1eaf29".
   const std::string &get_address_name();
 


### PR DESCRIPTION
# What does this implement/fix?

When no sensors are connected at startup the error **Requesting conversion failed** is not thrown
Only sensors that are found during startup are updated (to solve errors when for example 3 indexed sensors are configured but only 1 is connected).

This fix is intended for pre configured devices for which it is not clear wether all sensors will be connected.

## Types of changesa

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).