### PR TITLE
md5 checksum of firmware, and 'esphome publish' command

### DIFF
--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -6,6 +6,8 @@ import os
 import re
 import sys
 import time
+import hashlib
+import gzip
 from datetime import datetime
 
 import argcomplete
@@ -37,7 +39,7 @@ from esphome.const import (
     SECRETS_FILES,
 )
 from esphome.core import CORE, EsphomeError, coroutine
-from esphome.helpers import indent, is_ip_address
+from esphome.helpers import indent, is_ip_address, copy_file_if_changed
 from esphome.util import (
     run_external_command,
     run_external_process,
@@ -220,7 +222,25 @@ def compile_program(args, config):
     if rc != 0:
         return rc
     idedata = platformio_api.get_idedata(config)
-    return 0 if idedata is not None else 1
+    if idedata is None:
+        return 1
+
+    with open(CORE.firmware_bin, "rb") as firmware_bin:
+        bin_content = firmware_bin.read()
+
+    md5 = hashlib.md5(bin_content).hexdigest()
+    with open(CORE.firmware_md5, "w", encoding="ascii") as firmware_md5:
+        firmware_md5.write(md5)
+
+    gz_content = gzip.compress(bin_content, compresslevel=9)
+    with open(CORE.firmware_gz, "wb") as firmware_gz:
+        firmware_gz.write(gz_content)
+
+    md5_gz = hashlib.md5(gz_content).hexdigest()
+    with open(CORE.firmware_gz_md5, "w", encoding="ascii") as firmware_gz_md5:
+        firmware_gz_md5.write(md5_gz)
+
+    return 0
 
 
 def upload_using_esptool(config, port, file):
@@ -686,6 +706,22 @@ def command_rename(args, config):
     print()
     return 0
 
+def command_publish(args, config):
+    files = [ CORE.firmware_bin, CORE.firmware_md5, CORE.firmware_gz, CORE.firmware_gz_md5]
+    if not all(map(lambda f: os.path.isfile(f), files)):
+        exit_code = compile_program(args, config)
+        if exit_code != 0:
+            return exit_code
+
+    topdir = os.path.join(args.directory, CORE.name)
+    _LOGGER.info(f"Copying firmware files to {topdir}...")
+    for src_file in files:
+        dst_file = os.path.join(args.directory, CORE.name, os.path.basename(src_file))
+        copy_file_if_changed(src_file, dst_file)
+
+
+    return 0
+
 
 PRE_CONFIG_ACTIONS = {
     "wizard": command_wizard,
@@ -707,6 +743,7 @@ POST_CONFIG_ACTIONS = {
     "idedata": command_idedata,
     "rename": command_rename,
     "discover": command_discover,
+    "publish": command_publish,
 }
 
 
@@ -802,6 +839,19 @@ def parse_args(argv):
     )
     parser_discover.add_argument(
         "configuration", help="Your YAML configuration file.", nargs=1
+    )
+
+    parser_publish = subparsers.add_parser(
+        "publish",
+        help="Publish compiled binary. (currently copy binary to directory)",
+    )
+    parser_publish.add_argument(
+        "configuration", help="Your YAML configuration file(s).", nargs="+"
+    )
+    parser_publish.add_argument(
+        "--directory",
+        default=os.path.join(os.path.sep, "config", "www"),
+        help="Destination directory",
     )
 
     parser_run = subparsers.add_parser(

--- a/esphome/core/__init__.py
+++ b/esphome/core/__init__.py
@@ -628,6 +628,18 @@ class EsphomeCore:
         return self.relative_pioenvs_path(self.name, "firmware.bin")
 
     @property
+    def firmware_md5(self):
+        return self.firmware_bin + '.md5'
+
+    @property
+    def firmware_gz(self):
+        return self.firmware_bin + '.gz'
+
+    @property
+    def firmware_gz_md5(self):
+        return self.firmware_gz + '.md5'
+
+    @property
     def target_platform(self):
         return self.data[KEY_CORE][KEY_TARGET_PLATFORM]
 

--- a/esphome/dashboard/web_server.py
+++ b/esphome/dashboard/web_server.py
@@ -375,6 +375,11 @@ class EsphomeRunHandler(EsphomePortCommandWebSocket):
         """Build the command to run."""
         return await self.build_device_command(["run"], json_message)
 
+class EsphomePublishHandler(EsphomePortCommandWebSocket):
+    async def build_command(self, json_message: dict[str, Any]) -> list[str]:
+        config_file = settings.rel_path(json_message["configuration"])
+        return [*DASHBOARD_COMMAND, "publish", config_file]
+
 
 class EsphomeCompileHandler(EsphomeCommandWebSocket):
     async def build_command(self, json_message: dict[str, Any]) -> list[str]:
@@ -1038,6 +1043,8 @@ def get_base_frontend_path() -> str:
     if not static_path.endswith("/"):
         static_path += "/"
 
+    _LOGGER.warning("esphome_dashboard %s" % os.path.abspath(os.path.join(os.getcwd(), static_path, "esphome_dashboard")))
+
     # This path can be relative, so resolve against the root or else templates don't work
     return os.path.abspath(os.path.join(os.getcwd(), static_path, "esphome_dashboard"))
 
@@ -1118,6 +1125,7 @@ def make_app(debug=get_bool_env(ENV_DEV)) -> tornado.web.Application:
             (f"{rel}logs", EsphomeLogsHandler),
             (f"{rel}upload", EsphomeUploadHandler),
             (f"{rel}run", EsphomeRunHandler),
+            (f"{rel}publish", EsphomePublishHandler),
             (f"{rel}compile", EsphomeCompileHandler),
             (f"{rel}validate", EsphomeValidateHandler),
             (f"{rel}clean-mqtt", EsphomeCleanMqttHandler),


### PR DESCRIPTION
# What does this implement/fix?

This PR compute the md5 of the firmware, and add an `esphome publish config.yaml --directory /path/to` that moves the firmware files to `/path/to/device_name`.

Using Home Assistant esphome addon, `/path/to` can be `/config/ww`, so the firmware file can be made available by the integrated http server.

This work is related to https://github.com/esphome/esphome/pull/5586

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
