### PR TITLE
Update sm2135.cpp / fixed lights flickering

### DIFF
--- a/esphome/components/sm2135/sm2135.cpp
+++ b/esphome/components/sm2135/sm2135.cpp
@@ -144,7 +144,6 @@ void SM2135::sm2135_set_low_(GPIOPin *pin) {
 }
 
 void SM2135::sm2135_set_high_(GPIOPin *pin) {
-  pin->digital_write(true);
   pin->pin_mode(gpio::FLAG_PULLUP);
 }
 


### PR DESCRIPTION
# What does this implement/fix?

fixed sm2135_set_high_ which caused flicker while color changes.

the pin was set to mode output and high (strong drive) before going to open drain / pull up. this caused transmission errors (maybe just on certain hardware with open drain configuration).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
sm2135:
  data_pin: GPIO12
  clock_pin: GPIO14
  rgb_current: 20mA
  cw_current: 55mA
  
output:
  - platform: sm2135
    id: output_red
    channel: 0
  - platform: sm2135
    id: output_green
    channel: 1
  - platform: sm2135
    id: output_blue
    channel: 2
  - platform: sm2135
    id: output_white
    channel: 3
  - platform: sm2135
    id: output_warmwhite
    channel: 4
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
