### PR TITLE
Include "Failed" status in config log.

### DIFF
--- a/esphome/core/component.cpp
+++ b/esphome/core/component.cpp
@@ -76,7 +76,12 @@ bool Component::cancel_timeout(const std::string &name) {  // NOLINT
 
 void Component::call_loop() { this->loop(); }
 void Component::call_setup() { this->setup(); }
-void Component::call_dump_config() { this->dump_config(); }
+void Component::call_dump_config() {
+  this->dump_config();
+  if (this->is_failed()) {
+    ESP_LOGE(this->get_component_source(), "  Component is marked FAILED");
+  }
+}
 
 uint32_t Component::get_component_state() const { return this->component_state_; }
 void Component::call() {


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Since initial logs between boot and wifi connection are not available without a serial port, it's useful to know at least that a component failed during initial configuration. Some components do this already, but this ensures it is part of the config dump.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx


## Checklist:
  - [x] The code change is tested and works locally.

