### PR TITLE
Datetime date initial value fix

### DIFF
--- a/esphome/components/template/datetime/__init__.py
+++ b/esphome/components/template/datetime/__init__.py
@@ -91,7 +91,7 @@ async def to_code(config):
                 ("month", initial_value[CONF_MONTH]),
                 ("year", initial_value[CONF_YEAR]),
             )
-            cg.add(var.set_date(date_struct))
+            cg.add(var.set_initial_value(date_struct))
 
     if CONF_SET_ACTION in config:
         await automation.build_automation(

--- a/esphome/components/template/datetime/__init__.py
+++ b/esphome/components/template/datetime/__init__.py
@@ -8,6 +8,9 @@ from esphome.const import (
     CONF_OPTIMISTIC,
     CONF_RESTORE_VALUE,
     CONF_SET_ACTION,
+    CONF_DAY,
+    CONF_MONTH,
+    CONF_YEAR,
 )
 
 from esphome.core import coroutine_with_priority
@@ -82,7 +85,13 @@ async def to_code(config):
         cg.add(var.set_restore_value(config[CONF_RESTORE_VALUE]))
 
         if initial_value := config.get(CONF_INITIAL_VALUE):
-            cg.add(var.set_initial_value(initial_value))
+            date_struct = cg.StructInitializer(
+                cg.ESPTime,
+                ("day_of_month", initial_value[CONF_DAY]),
+                ("month", initial_value[CONF_MONTH]),
+                ("year", initial_value[CONF_YEAR]),
+            )
+            cg.add(var.set_date(date_struct))
 
     if CONF_SET_ACTION in config:
         await automation.build_automation(

--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -914,7 +914,7 @@ void WebServer::handle_date_request(AsyncWebServerRequest *request, const UrlMat
 std::string WebServer::date_json(datetime::DateEntity *obj, JsonDetail start_config) {
   return json::build_json([obj, start_config](JsonObject root) {
     set_json_id(root, obj, "date-" + obj->get_object_id(), start_config);
-    std::string value = str_sprintf("%d-%d-%d", obj->year, obj->month, obj->day);
+    std::string value = str_sprintf("%d-%02d-%02d", obj->year, obj->month, obj->day);
     root["value"] = value;
     root["state"] = value;
   });


### PR DESCRIPTION
# What does this implement/fix?

Fixes the python error when setting a initial value.
Also sends the date with leading zeros to the webserver client

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
datetime:
  - platform: template
    name: Time to open the door
    type: date
    optimistic: True
    initial_value: "2024-04-30"

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
