### PR TITLE
Fix uart to work with new enum definition in esp-idf-v5.2.1

### DIFF
--- a/esphome/components/logger/logger_esp32.cpp
+++ b/esphome/components/logger/logger_esp32.cpp
@@ -120,29 +120,27 @@ void Logger::pre_setup() {
     switch (this->uart_) {
       case UART_SELECTION_UART0:
         this->uart_num_ = UART_NUM_0;
+        init_uart(this->uart_num_, baud_rate_, tx_buffer_size_);
         break;
       case UART_SELECTION_UART1:
         this->uart_num_ = UART_NUM_1;
+        init_uart(this->uart_num_, baud_rate_, tx_buffer_size_);
         break;
 #ifdef USE_ESP32_VARIANT_ESP32
       case UART_SELECTION_UART2:
         this->uart_num_ = UART_NUM_2;
+        init_uart(this->uart_num_, baud_rate_, tx_buffer_size_);
         break;
 #endif
 #ifdef USE_LOGGER_USB_CDC
       case UART_SELECTION_USB_CDC:
-        this->uart_num_ = -1;
         break;
 #endif
 #ifdef USE_LOGGER_USB_SERIAL_JTAG
       case UART_SELECTION_USB_SERIAL_JTAG:
-        this->uart_num_ = -1;
         init_usb_serial_jtag_();
         break;
 #endif
-    }
-    if (this->uart_num_ >= 0) {
-      init_uart(this->uart_num_, baud_rate_, tx_buffer_size_);
     }
 #endif  // USE_ESP_IDF
   }


### PR DESCRIPTION
# What does this implement/fix?

In esp-idf-v5.2.1 the definition of uart_port_t changed from typedef int to enum. Therefor setting uart_num_=-1 is not valid anymore.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/5672

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
