### PR TITLE
Fix Microphone IsCapturingCondition

### DIFF
--- a/esphome/components/microphone/automation.h
+++ b/esphome/components/microphone/automation.h
@@ -23,7 +23,7 @@ class DataTrigger : public Trigger<const std::vector<int16_t> &> {
   }
 };
 
-template<typename... Ts> class IsCapturingActon : public Condition<Ts...>, public Parented<Microphone> {
+template<typename... Ts> class IsCapturingCondition : public Condition<Ts...>, public Parented<Microphone> {
  public:
   bool check(Ts... x) override { return this->parent_->is_running(); }
 };


### PR DESCRIPTION
# What does this implement/fix?

Microphone `IsCapturingCondition` is named `IsCapturingActon` in the `components/microphone/automation.h` header. Using the automation like so:

```
on_...
    if:
      condition:
        microphone.is_capturing: mic_id
```

does not work, the compilation fails:

```
src/main.cpp:29:13: error: 'IsCapturingCondition' in namespace 'esphome::microphone' does not name a template type
 microphone::IsCapturingCondition<> *microphone_iscapturingcondition;
             ^~~~~~~~~~~~~~~~~~~~
src/main.cpp:29:1: note: suggested alternative: 'IsCapturingActon'
 microphone::IsCapturingCondition<> *microphone_iscapturingcondition;
 ^~~~~~~~~~
 IsCapturingActon
src/main.cpp: In function 'void setup()':
src/main.cpp:287:3: error: 'microphone_iscapturingcondition' was not declared in this scope
```

This change renames the template to match with the correct name in the python files and documentation.

The documentation is already correct, no change needed there.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>


## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx


## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
