### PR TITLE
If the loop() took more than the required time, don't delay further

### DIFF
--- a/esphome/core/application.cpp
+++ b/esphome/core/application.cpp
@@ -81,13 +81,11 @@ void Application::loop() {
 
   const uint32_t now = millis();
 
-  if (HighFrequencyLoopRequester::is_high_frequency()) {
+  auto elapsed = now - this->last_loop_;
+  if (elapsed >= this->loop_interval_ || HighFrequencyLoopRequester::is_high_frequency()) {
     yield();
   } else {
-    uint32_t delay_time = this->loop_interval_;
-    if (now - this->last_loop_ < this->loop_interval_)
-      delay_time = this->loop_interval_ - (now - this->last_loop_);
-
+    uint32_t delay_time = this->loop_interval_ - elapsed;
     uint32_t next_schedule = this->scheduler.next_schedule_in().value_or(delay_time);
     // next_schedule is max 0.5*delay_time
     // otherwise interval=0 schedules result in constant looping with almost no sleep


### PR DESCRIPTION
next loop().

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Currently if the `loop()` takes more than `loop_interval`, then there will be a delay equal to the loop interval before the next loop starts. 

The same idea was proposed in #5869 but there has been no movement on that recently.

Closes #5869

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
