### PR TITLE
Rework tlc5947 to remove AUTO_LOAD

### DIFF
--- a/esphome/components/tlc5947/__init__.py
+++ b/esphome/components/tlc5947/__init__.py
@@ -14,7 +14,6 @@ from esphome.const import (
 CONF_LAT_PIN = "lat_pin"
 CONF_OE_PIN = "oe_pin"
 
-AUTO_LOAD = ["output"]
 CODEOWNERS = ["@rnauber"]
 
 tlc5947_ns = cg.esphome_ns.namespace("tlc5947")

--- a/esphome/components/tlc5947/output/__init__.py
+++ b/esphome/components/tlc5947/output/__init__.py
@@ -2,18 +2,20 @@ import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import output
 from esphome.const import CONF_CHANNEL, CONF_ID
-from . import TLC5947
+from .. import TLC5947, tlc5947_ns
 
 DEPENDENCIES = ["tlc5947"]
 CODEOWNERS = ["@rnauber"]
 
-Channel = TLC5947.class_("Channel", output.FloatOutput)
+TLC5947Channel = tlc5947_ns.class_(
+    "TLC5947Channel", output.FloatOutput, cg.Parented.template(TLC5947)
+)
 
 CONF_TLC5947_ID = "tlc5947_id"
 CONFIG_SCHEMA = output.FLOAT_OUTPUT_SCHEMA.extend(
     {
         cv.GenerateID(CONF_TLC5947_ID): cv.use_id(TLC5947),
-        cv.Required(CONF_ID): cv.declare_id(Channel),
+        cv.Required(CONF_ID): cv.declare_id(TLC5947Channel),
         cv.Required(CONF_CHANNEL): cv.int_range(min=0, max=65535),
     }
 ).extend(cv.COMPONENT_SCHEMA)
@@ -22,7 +24,5 @@ CONFIG_SCHEMA = output.FLOAT_OUTPUT_SCHEMA.extend(
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await output.register_output(var, config)
-
-    parent = await cg.get_variable(config[CONF_TLC5947_ID])
-    cg.add(var.set_parent(parent))
+    await cg.register_parented(var, config[CONF_TLC5947_ID])
     cg.add(var.set_channel(config[CONF_CHANNEL]))

--- a/esphome/components/tlc5947/output/__init__.py
+++ b/esphome/components/tlc5947/output/__init__.py
@@ -5,7 +5,6 @@ from esphome.const import CONF_CHANNEL, CONF_ID
 from .. import TLC5947, tlc5947_ns
 
 DEPENDENCIES = ["tlc5947"]
-CODEOWNERS = ["@rnauber"]
 
 TLC5947Channel = tlc5947_ns.class_(
     "TLC5947Channel", output.FloatOutput, cg.Parented.template(TLC5947)

--- a/esphome/components/tlc5947/output/tlc5947_output.cpp
+++ b/esphome/components/tlc5947/output/tlc5947_output.cpp
@@ -1,0 +1,12 @@
+#include "tlc5947_output.h"
+
+namespace esphome {
+namespace tlc5947 {
+
+void TLC5947Channel::write_state(float state) {
+  auto amount = static_cast<uint16_t>(state * 0xfff);
+  this->parent_->set_channel_value(this->channel_, amount);
+}
+
+}  // namespace tlc5947
+}  // namespace esphome

--- a/esphome/components/tlc5947/output/tlc5947_output.h
+++ b/esphome/components/tlc5947/output/tlc5947_output.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "esphome/core/helpers.h"
+
+#include "esphome/components/output/float_output.h"
+
+#include "../tlc5947.h"
+
+namespace esphome {
+namespace tlc5947 {
+
+class TLC5947Channel : public output::FloatOutput, public Parented<TLC5947> {
+ public:
+  void set_channel(uint8_t channel) { this->channel_ = channel; }
+
+ protected:
+  void write_state(float state) override;
+  uint8_t channel_;
+};
+
+}  // namespace tlc5947
+}  // namespace esphome

--- a/esphome/components/tlc5947/tlc5947.cpp
+++ b/esphome/components/tlc5947/tlc5947.cpp
@@ -60,5 +60,14 @@ void TLC5947::loop() {
   this->update_ = false;
 }
 
+void TLC5947::set_channel_value(uint16_t channel, uint16_t value) {
+  if (channel >= this->num_chips_ * N_CHANNELS_PER_CHIP)
+    return;
+  if (this->pwm_amounts_[channel] != value) {
+    this->update_ = true;
+  }
+  this->pwm_amounts_[channel] = value;
+}
+
 }  // namespace tlc5947
 }  // namespace esphome

--- a/esphome/components/tlc5947/tlc5947.h
+++ b/esphome/components/tlc5947/tlc5947.h
@@ -2,18 +2,16 @@
 // TLC5947 24-Channel, 12-Bit PWM LED Driver
 // https://www.ti.com/lit/ds/symlink/tlc5947.pdf
 
+#include <vector>
+#include "esphome/components/output/float_output.h"
 #include "esphome/core/component.h"
 #include "esphome/core/hal.h"
-#include "esphome/components/output/float_output.h"
-#include <vector>
 
 namespace esphome {
 namespace tlc5947 {
 
 class TLC5947 : public Component {
  public:
-  class Channel;
-
   const uint8_t N_CHANNELS_PER_CHIP = 24;
 
   void set_data_pin(GPIOPin *data_pin) { data_pin_ = data_pin; }
@@ -31,31 +29,9 @@ class TLC5947 : public Component {
   /// Send new values if they were updated.
   void loop() override;
 
-  class Channel : public output::FloatOutput {
-   public:
-    void set_parent(TLC5947 *parent) { parent_ = parent; }
-    void set_channel(uint8_t channel) { channel_ = channel; }
-
-   protected:
-    void write_state(float state) override {
-      auto amount = static_cast<uint16_t>(state * 0xfff);
-      this->parent_->set_channel_value_(this->channel_, amount);
-    }
-
-    TLC5947 *parent_;
-    uint8_t channel_;
-  };
+  void set_channel_value(uint16_t channel, uint16_t value);
 
  protected:
-  void set_channel_value_(uint16_t channel, uint16_t value) {
-    if (channel >= this->num_chips_ * N_CHANNELS_PER_CHIP)
-      return;
-    if (this->pwm_amounts_[channel] != value) {
-      this->update_ = true;
-    }
-    this->pwm_amounts_[channel] = value;
-  }
-
   GPIOPin *data_pin_;
   GPIOPin *clock_pin_;
   GPIOPin *lat_pin_;

--- a/tests/components/tlc5947/common.yaml
+++ b/tests/components/tlc5947/common.yaml
@@ -1,0 +1,13 @@
+tlc5947:
+  clock_pin: ${clock_pin}
+  data_pin: ${data_pin}
+  lat_pin: ${lat_pin}
+
+output:
+  - platform: tlc5947
+    id: output_1
+    channel: 0
+    max_power: 0.8
+  - platform: tlc5947
+    id: output_2
+    channel: 1

--- a/tests/components/tlc5947/test.esp32-c3-idf.yaml
+++ b/tests/components/tlc5947/test.esp32-c3-idf.yaml
@@ -1,0 +1,7 @@
+substitutions:
+  clock_pin: GPIO5
+  data_pin: GPIO4
+  lat_pin: GPIO3
+
+packages:
+  common: !include common.yaml

--- a/tests/components/tlc5947/test.esp32-c3.yaml
+++ b/tests/components/tlc5947/test.esp32-c3.yaml
@@ -1,0 +1,7 @@
+substitutions:
+  clock_pin: GPIO5
+  data_pin: GPIO4
+  lat_pin: GPIO3
+
+packages:
+  common: !include common.yaml

--- a/tests/components/tlc5947/test.esp32-idf.yaml
+++ b/tests/components/tlc5947/test.esp32-idf.yaml
@@ -1,0 +1,7 @@
+substitutions:
+  clock_pin: GPIO15
+  data_pin: GPIO14
+  lat_pin: GPIO13
+
+packages:
+  common: !include common.yaml

--- a/tests/components/tlc5947/test.esp32.yaml
+++ b/tests/components/tlc5947/test.esp32.yaml
@@ -1,0 +1,7 @@
+substitutions:
+  clock_pin: GPIO15
+  data_pin: GPIO14
+  lat_pin: GPIO13
+
+packages:
+  common: !include common.yaml

--- a/tests/components/tlc5947/test.esp8266.yaml
+++ b/tests/components/tlc5947/test.esp8266.yaml
@@ -1,0 +1,7 @@
+substitutions:
+  clock_pin: GPIO5
+  data_pin: GPIO4
+  lat_pin: GPIO13
+
+packages:
+  common: !include common.yaml

--- a/tests/components/tlc5947/test.rp2040.yaml
+++ b/tests/components/tlc5947/test.rp2040.yaml
@@ -1,0 +1,7 @@
+substitutions:
+  clock_pin: GPIO5
+  data_pin: GPIO4
+  lat_pin: GPIO3
+
+packages:
+  common: !include common.yaml


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

This removes an unnecessary AUTO_LOAD from the codebase by splitting the output into it's own directory.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
