### PR TITLE
Add get_disable_led() to HydreonRGxxComponent

### DIFF
--- a/esphome/components/hydreon_rgxx/hydreon_rgxx.h
+++ b/esphome/components/hydreon_rgxx/hydreon_rgxx.h
@@ -56,6 +56,7 @@ class HydreonRGxxComponent : public PollingComponent, public uart::UARTDevice {
   float get_setup_priority() const override;
 
   void set_disable_led(bool disable_led) { this->disable_led_ = disable_led; }
+  bool get_disable_led(return this->disabled_led_);
 
  protected:
   void process_line_();


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
