### PR TITLE
esp32_rmt_led_strip bugfixes

### DIFF
--- a/esphome/components/esp32_rmt_led_strip/led_strip.h
+++ b/esphome/components/esp32_rmt_led_strip/led_strip.h
@@ -64,7 +64,7 @@ class ESP32RMTLEDStripLightOutput : public light::AddressableLight {
  protected:
   light::ESPColorView get_view_internal(int32_t index) const override;
 
-  size_t get_buffer_size_() const { return this->num_leds_ * (3 + this->is_rgbw_); }
+  size_t get_buffer_size_() const { return this->num_leds_ * (this->is_rgbw_ || this->is_wrgb_ ? 4 : 3); }
 
   uint8_t *buf_{nullptr};
   uint8_t *effect_data_{nullptr};

--- a/esphome/components/esp32_rmt_led_strip/light.py
+++ b/esphome/components/esp32_rmt_led_strip/light.py
@@ -48,7 +48,7 @@ CHIPSETS = {
     "WS2812": LEDStripTimings(400, 1000, 1000, 400),
     "SK6812": LEDStripTimings(300, 900, 600, 600),
     "APA106": LEDStripTimings(350, 1360, 1360, 350),
-    "SM16703": LEDStripTimings(300, 900, 1360, 350),
+    "SM16703": LEDStripTimings(300, 900, 900, 300),
 }
 
 


### PR DESCRIPTION
# What does this implement/fix?
- Fix SM16703 timings
- Fix buffer size calculation for WRGB led strips

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
