### PR TITLE
Added Htu21d model option

### DIFF
--- a/esphome/components/htu21d/htu21d.cpp
+++ b/esphome/components/htu21d/htu21d.cpp
@@ -83,14 +83,20 @@ void HTU21DComponent::update() {
 
       int8_t heater_level;
 
-      // HTU21D does not have heater level
+      // HTU21D does have a heater module but does not have heater level
+      // Setting heater level to 1 in case the heater is ON
       if (this->sensor_model_ == HTU21D_SENSOR_MODEL_HTU21D) {
-        heater_level = 0;
+        if(is_heater_enabled) {
+          heater_level = 1;
+        } else {
+          heater_level = 0;
+        }
       } else {
         heater_level = this->get_heater_level();
-        ESP_LOGD(TAG, "Heater Level=%d", heater_level);
       }
 
+      ESP_LOGD(TAG, "Heater Level=%d", heater_level);
+      
       if (this->heater_ != nullptr)
         this->heater_->publish_state(heater_level);
       this->status_clear_warning();

--- a/esphome/components/htu21d/htu21d.cpp
+++ b/esphome/components/htu21d/htu21d.cpp
@@ -76,12 +76,21 @@ void HTU21DComponent::update() {
 
       float humidity = (float(raw_humidity & 0xFFFC)) * 125.0f / 65536.0f - 6.0f;
 
-      int8_t heater_level = this->get_heater_level();
-
-      ESP_LOGD(TAG, "Got Humidity=%.1f%% Heater Level=%d", humidity, heater_level);
+      ESP_LOGD(TAG, "Got Humidity=%.1f%%", humidity);
 
       if (this->humidity_ != nullptr)
         this->humidity_->publish_state(humidity);
+
+      int8_t heater_level;
+
+      // HTU21D does not have heater level
+      if (this->sensor_model_ == HTU21D_SENSOR_MODEL_HTU21D) {
+        heater_level = 0;
+      } else {
+        heater_level = this->get_heater_level();
+        ESP_LOGD(TAG, "Heater Level=%d", heater_level);
+      }
+
       if (this->heater_ != nullptr)
         this->heater_->publish_state(heater_level);
       this->status_clear_warning();

--- a/esphome/components/htu21d/htu21d.cpp
+++ b/esphome/components/htu21d/htu21d.cpp
@@ -86,7 +86,7 @@ void HTU21DComponent::update() {
       // HTU21D does have a heater module but does not have heater level
       // Setting heater level to 1 in case the heater is ON
       if (this->sensor_model_ == HTU21D_SENSOR_MODEL_HTU21D) {
-        if (is_heater_enabled) {
+        if (this->is_heater_enabled()) {
           heater_level = 1;
         } else {
           heater_level = 0;

--- a/esphome/components/htu21d/htu21d.cpp
+++ b/esphome/components/htu21d/htu21d.cpp
@@ -86,7 +86,7 @@ void HTU21DComponent::update() {
       // HTU21D does have a heater module but does not have heater level
       // Setting heater level to 1 in case the heater is ON
       if (this->sensor_model_ == HTU21D_SENSOR_MODEL_HTU21D) {
-        if(is_heater_enabled) {
+        if (is_heater_enabled) {
           heater_level = 1;
         } else {
           heater_level = 0;
@@ -96,7 +96,7 @@ void HTU21DComponent::update() {
       }
 
       ESP_LOGD(TAG, "Heater Level=%d", heater_level);
-      
+
       if (this->heater_ != nullptr)
         this->heater_->publish_state(heater_level);
       this->status_clear_warning();

--- a/esphome/components/htu21d/htu21d.h
+++ b/esphome/components/htu21d/htu21d.h
@@ -8,6 +8,8 @@
 namespace esphome {
 namespace htu21d {
 
+enum HTU21DSensorModels { HTU21D_SENSOR_MODEL_HTU21D = 0, HTU21D_SENSOR_MODEL_SI7021, HTU21D_SENSOR_MODEL_SHT21 };
+
 class HTU21DComponent : public PollingComponent, public i2c::I2CDevice {
  public:
   void set_temperature(sensor::Sensor *temperature) { temperature_ = temperature; }
@@ -17,6 +19,7 @@ class HTU21DComponent : public PollingComponent, public i2c::I2CDevice {
   /// Setup (reset) the sensor and check connection.
   void setup() override;
   void dump_config() override;
+  void set_sensor_model(HTU21DSensorModels sensor_model) { sensor_model_ = sensor_model; }
   /// Update the sensor values (temperature+humidity).
   void update() override;
 
@@ -31,6 +34,7 @@ class HTU21DComponent : public PollingComponent, public i2c::I2CDevice {
   sensor::Sensor *temperature_{nullptr};
   sensor::Sensor *humidity_{nullptr};
   sensor::Sensor *heater_{nullptr};
+  HTU21DSensorModels sensor_model_{HTU21D_SENSOR_MODEL_HTU21D};
 };
 
 template<typename... Ts> class SetHeaterLevelAction : public Action<Ts...>, public Parented<HTU21DComponent> {

--- a/esphome/components/htu21d/sensor.py
+++ b/esphome/components/htu21d/sensor.py
@@ -5,6 +5,7 @@ from esphome import automation
 from esphome.const import (
     CONF_HUMIDITY,
     CONF_ID,
+    CONF_MODEL,
     CONF_TEMPERATURE,
     DEVICE_CLASS_HUMIDITY,
     DEVICE_CLASS_TEMPERATURE,
@@ -23,10 +24,15 @@ htu21d_ns = cg.esphome_ns.namespace("htu21d")
 HTU21DComponent = htu21d_ns.class_(
     "HTU21DComponent", cg.PollingComponent, i2c.I2CDevice
 )
-
 SetHeaterLevelAction = htu21d_ns.class_("SetHeaterLevelAction", automation.Action)
 SetHeaterAction = htu21d_ns.class_("SetHeaterAction", automation.Action)
+HTU21DSensorModels = htu21d_ns.enum("HTU21DSensorModels")
 
+MODELS = {
+    "HTU21D": HTU21DSensorModels.HTU21D_SENSOR_MODEL_HTU21D,
+    "SI7021": HTU21DSensorModels.HTU21D_SENSOR_MODEL_SI7021,
+    "SHT21": HTU21DSensorModels.HTU21D_SENSOR_MODEL_SHT21,
+}
 
 CONFIG_SCHEMA = (
     cv.Schema(
@@ -49,6 +55,7 @@ CONFIG_SCHEMA = (
                 accuracy_decimals=1,
                 state_class=STATE_CLASS_MEASUREMENT,
             ),
+            cv.Optional(CONF_MODEL, default="HTU21D"): cv.enum(MODELS, upper=True),
         }
     )
     .extend(cv.polling_component_schema("60s"))
@@ -72,6 +79,8 @@ async def to_code(config):
     if CONF_HEATER in config:
         sens = await sensor.new_sensor(config[CONF_HEATER])
         cg.add(var.set_heater(sens))
+
+    cg.add(var.set_sensor_model(config[CONF_MODEL]))
 
 
 @automation.register_action(

--- a/tests/components/htu21d/test.esp32-c3-idf.yaml
+++ b/tests/components/htu21d/test.esp32-c3-idf.yaml
@@ -5,6 +5,7 @@ i2c:
 
 sensor:
   - platform: htu21d
+    model: htu21d
     temperature:
       name: Temperature
     humidity:

--- a/tests/components/htu21d/test.esp32-c3.yaml
+++ b/tests/components/htu21d/test.esp32-c3.yaml
@@ -5,6 +5,7 @@ i2c:
 
 sensor:
   - platform: htu21d
+    model: htu21d
     temperature:
       name: Temperature
     humidity:

--- a/tests/components/htu21d/test.esp32-idf.yaml
+++ b/tests/components/htu21d/test.esp32-idf.yaml
@@ -5,6 +5,7 @@ i2c:
 
 sensor:
   - platform: htu21d
+    model: htu21d
     temperature:
       name: Temperature
     humidity:

--- a/tests/components/htu21d/test.esp32.yaml
+++ b/tests/components/htu21d/test.esp32.yaml
@@ -5,6 +5,7 @@ i2c:
 
 sensor:
   - platform: htu21d
+    model: htu21d
     temperature:
       name: Temperature
     humidity:

--- a/tests/components/htu21d/test.esp8266.yaml
+++ b/tests/components/htu21d/test.esp8266.yaml
@@ -5,6 +5,7 @@ i2c:
 
 sensor:
   - platform: htu21d
+    model: htu21d
     temperature:
       name: Temperature
     humidity:

--- a/tests/components/htu21d/test.rp2040.yaml
+++ b/tests/components/htu21d/test.rp2040.yaml
@@ -5,6 +5,7 @@ i2c:
 
 sensor:
   - platform: htu21d
+    model: htu21d
     temperature:
       name: Temperature
     humidity:


### PR DESCRIPTION
# What does this implement/fix?

Added models to the HTU21D because the HTU21D sensor does not support heater_level
## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#3742

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
