### PR TITLE
2024.4.0b2

### DIFF
--- a/esphome/components/ads1115/__init__.py
+++ b/esphome/components/ads1115/__init__.py
@@ -4,13 +4,14 @@ from esphome.components import i2c
 from esphome.const import CONF_ID
 
 DEPENDENCIES = ["i2c"]
-AUTO_LOAD = ["sensor", "voltage_sampler"]
 MULTI_CONF = True
 
 ads1115_ns = cg.esphome_ns.namespace("ads1115")
 ADS1115Component = ads1115_ns.class_("ADS1115Component", cg.Component, i2c.I2CDevice)
 
 CONF_CONTINUOUS_MODE = "continuous_mode"
+CONF_ADS1115_ID = "ads1115_id"
+
 CONFIG_SCHEMA = (
     cv.Schema(
         {

--- a/esphome/components/ads1115/ads1115.h
+++ b/esphome/components/ads1115/ads1115.h
@@ -1,9 +1,7 @@
 #pragma once
 
-#include "esphome/core/component.h"
-#include "esphome/components/sensor/sensor.h"
 #include "esphome/components/i2c/i2c.h"
-#include "esphome/components/voltage_sampler/voltage_sampler.h"
+#include "esphome/core/component.h"
 
 #include <vector>
 
@@ -35,12 +33,8 @@ enum ADS1115Resolution {
   ADS1015_12_BITS = 12,
 };
 
-class ADS1115Sensor;
-
 class ADS1115Component : public Component, public i2c::I2CDevice {
  public:
-  void register_sensor(ADS1115Sensor *obj) { this->sensors_.push_back(obj); }
-  /// Set up the internal sensor array.
   void setup() override;
   void dump_config() override;
   /// HARDWARE_LATE setup priority
@@ -48,32 +42,11 @@ class ADS1115Component : public Component, public i2c::I2CDevice {
   void set_continuous_mode(bool continuous_mode) { continuous_mode_ = continuous_mode; }
 
   /// Helper method to request a measurement from a sensor.
-  float request_measurement(ADS1115Sensor *sensor);
+  float request_measurement(ADS1115Multiplexer multiplexer, ADS1115Gain gain, ADS1115Resolution resolution);
 
  protected:
-  std::vector<ADS1115Sensor *> sensors_;
   uint16_t prev_config_{0};
   bool continuous_mode_;
-};
-
-/// Internal holder class that is in instance of Sensor so that the hub can create individual sensors.
-class ADS1115Sensor : public sensor::Sensor, public PollingComponent, public voltage_sampler::VoltageSampler {
- public:
-  ADS1115Sensor(ADS1115Component *parent) : parent_(parent) {}
-  void update() override;
-  void set_multiplexer(ADS1115Multiplexer multiplexer) { multiplexer_ = multiplexer; }
-  void set_gain(ADS1115Gain gain) { gain_ = gain; }
-  void set_resolution(ADS1115Resolution resolution) { resolution_ = resolution; }
-  float sample() override;
-  uint8_t get_multiplexer() const { return multiplexer_; }
-  uint8_t get_gain() const { return gain_; }
-  uint8_t get_resolution() const { return resolution_; }
-
- protected:
-  ADS1115Component *parent_;
-  ADS1115Multiplexer multiplexer_;
-  ADS1115Gain gain_;
-  ADS1115Resolution resolution_;
 };
 
 }  // namespace ads1115

--- a/esphome/components/ads1115/sensor/ads1115_sensor.cpp
+++ b/esphome/components/ads1115/sensor/ads1115_sensor.cpp
@@ -1,0 +1,30 @@
+#include "ads1115_sensor.h"
+
+#include "esphome/core/log.h"
+
+namespace esphome {
+namespace ads1115 {
+
+static const char *const TAG = "ads1115.sensor";
+
+float ADS1115Sensor::sample() {
+  return this->parent_->request_measurement(this->multiplexer_, this->gain_, this->resolution_);
+}
+
+void ADS1115Sensor::update() {
+  float v = this->sample();
+  if (!std::isnan(v)) {
+    ESP_LOGD(TAG, "'%s': Got Voltage=%fV", this->get_name().c_str(), v);
+    this->publish_state(v);
+  }
+}
+
+void ADS1115Sensor::dump_config() {
+  LOG_SENSOR("  ", "ADS1115 Sensor", this);
+  ESP_LOGCONFIG(TAG, "    Multiplexer: %u", this->multiplexer_);
+  ESP_LOGCONFIG(TAG, "    Gain: %u", this->gain_);
+  ESP_LOGCONFIG(TAG, "    Resolution: %u", this->resolution_);
+}
+
+}  // namespace ads1115
+}  // namespace esphome

--- a/esphome/components/ads1115/sensor/ads1115_sensor.h
+++ b/esphome/components/ads1115/sensor/ads1115_sensor.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/core/helpers.h"
+
+#include "esphome/components/sensor/sensor.h"
+#include "esphome/components/voltage_sampler/voltage_sampler.h"
+
+#include "../ads1115.h"
+
+namespace esphome {
+namespace ads1115 {
+
+/// Internal holder class that is in instance of Sensor so that the hub can create individual sensors.
+class ADS1115Sensor : public sensor::Sensor,
+                      public PollingComponent,
+                      public voltage_sampler::VoltageSampler,
+                      public Parented<ADS1115Component> {
+ public:
+  void update() override;
+  void set_multiplexer(ADS1115Multiplexer multiplexer) { this->multiplexer_ = multiplexer; }
+  void set_gain(ADS1115Gain gain) { this->gain_ = gain; }
+  void set_resolution(ADS1115Resolution resolution) { this->resolution_ = resolution; }
+  float sample() override;
+
+  void dump_config() override;
+
+ protected:
+  ADS1115Multiplexer multiplexer_;
+  ADS1115Gain gain_;
+  ADS1115Resolution resolution_;
+};
+
+}  // namespace ads1115
+}  // namespace esphome

--- a/esphome/const.py
+++ b/esphome/const.py
@@ -1,6 +1,6 @@
 """Constants used by esphome."""
 
-__version__ = "2024.4.0b1"
+__version__ = "2024.4.0b2"
 
 ALLOWED_NAME_CHARS = "abcdefghijklmnopqrstuvwxyz0123456789-_"
 VALID_SUBSTITUTIONS_CHARACTERS = (

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ pyserial==3.5
 platformio==6.1.13  # When updating platformio, also update Dockerfile
 esptool==4.7.0
 click==8.1.7
-esphome-dashboard==20240319.0
+esphome-dashboard==20240412.0
 aioesphomeapi==23.2.0
 zeroconf==0.131.0
 python-magic==0.4.27

--- a/tests/components/remote_transmitter/common-buttons.yaml
+++ b/tests/components/remote_transmitter/common-buttons.yaml
@@ -176,3 +176,11 @@ button:
             0x00,
             0x05,
           ]
+  - platform: template
+    name: Dooya
+    on_press:
+      remote_transmitter.transmit_dooya:
+        id: 0x123456
+        channel: 1
+        button: 1
+        check: 1


### PR DESCRIPTION
**Do not merge, release script will automatically merge**
## Full list of changes

### New Platforms

- ads1115: remove auto-load and split sensor into platform folder [esphome#5981](https://github.com/esphome/esphome/pull/5981) (new-platform)

### All changes

- Add dooya remote transmitter test [esphome#6508](https://github.com/esphome/esphome/pull/6508)
- ads1115: remove auto-load and split sensor into platform folder [esphome#5981](https://github.com/esphome/esphome/pull/5981) (new-platform)
- Bump esphome-dashboard to 20240412.0 [esphome#6517](https://github.com/esphome/esphome/pull/6517)
