### PR TITLE
Add "log" alias for "logs" command

### DIFF
--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -785,6 +785,7 @@ def parse_args(argv):
     parser_logs = subparsers.add_parser(
         "logs",
         help="Validate the configuration and show all logs.",
+        aliases=["log"],
         parents=[mqtt_options],
     )
     parser_logs.add_argument(


### PR DESCRIPTION
# What does this implement/fix?

This is pretty minor addition. Essentially I find myself typing `esphome log <blah>` a lot and being shown a `esphome: error: argument command: invalid choice: 'log'` before remembering to add an `s`.

Not sure if there is a need to change documentation as this doesn't change the existing functionality, but can explicitly call out  the alias if desired.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

*Not applicable: Does not affect compilation/installation/etc.*
- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
