### PR TITLE
Add all missing `remote_receiver` `on_...` tests

### DIFF
--- a/tests/components/remote_receiver/esp32-common.yaml
+++ b/tests/components/remote_receiver/esp32-common.yaml
@@ -3,12 +3,146 @@ remote_receiver:
   pin: ${pin}
   rmt_channel: ${rmt_channel}
   dump: all
+  on_abbwelcome:
+    then:
+      - logger.log:
+          format: "on_abbwelcome: %u"
+          args: ["x.data()[0]"]
+  on_aeha:
+    then:
+      - logger.log:
+          format: "on_aeha: %u %u"
+          args: ["x.address", "x.data.front()"]
+  on_byronsx:
+    then:
+      - logger.log:
+          format: "on_byronsx: %u %u"
+          args: ["x.address", "x.command"]
+  on_canalsat:
+    then:
+      - logger.log:
+          format: "on_canalsat: %u %u"
+          args: ["x.address", "x.command"]
+  # on_canalsatld:
+  #   then:
+  #     - logger.log:
+  #         format: "on_canalsatld: %u %u"
+  #         args: ["x.address", "x.command"]
   on_coolix:
     then:
-      delay: !lambda "return x.first + x.second;"
+      - logger.log:
+          format: "on_coolix: %u %u"
+          args: ["x.first", "x.second"]
+  on_dish:
+    then:
+      - logger.log:
+          format: "on_dish: %u %u"
+          args: ["x.address", "x.command"]
+  on_dooya:
+    then:
+      - logger.log:
+          format: "on_dooya: %u %u %u"
+          args: ["x.channel", "x.button", "x.check"]
+  on_drayton:
+    then:
+      - logger.log:
+          format: "on_drayton: %u %u %u"
+          args: ["x.address", "x.channel", "x.command"]
+  on_jvc:
+    then:
+      - logger.log:
+          format: "on_jvc: %u"
+          args: ["x.data"]
+  on_keeloq:
+    then:
+      - logger.log:
+          format: "on_keeloq: %u %u %u"
+          args: ["x.encrypted", "x.address", "x.command"]
+  on_haier:
+    then:
+      - logger.log:
+          format: "on_haier: %u"
+          args: ["x.data.front()"]
+  on_lg:
+    then:
+      - logger.log:
+          format: "on_lg: %u %u"
+          args: ["x.data", "x.nbits"]
+  on_magiquest:
+    then:
+      - logger.log:
+          format: "on_magiquest: %u %u"
+          args: ["x.magnitude", "x.wand_id"]
+  on_midea:
+    then:
+      - logger.log:
+          format: "on_midea: %u %u"
+          args: ["x.size()", "x.data()[0]"]
+  on_nec:
+    then:
+      - logger.log:
+          format: "on_nec: %u %u"
+          args: ["x.address", "x.command"]
+  on_nexa:
+    then:
+      - logger.log:
+          format: "on_nexa: %u %u %u %u %u"
+          args: ["x.device", "x.group", "x.state", "x.channel", "x.level"]
+  on_panasonic:
+    then:
+      - logger.log:
+          format: "on_panasonic: %u %u"
+          args: ["x.address", "x.command"]
+  on_pioneer:
+    then:
+      - logger.log:
+          format: "on_pioneer: %u %u"
+          args: ["x.rc_code_1", "x.rc_code_2"]
+  on_pronto:
+    then:
+      - logger.log:
+          format: "on_pronto: %s"
+          args: ["x.data.c_str()"]
+  on_raw:
+    then:
+      - logger.log:
+          format: "on_raw: %u"
+          args: ["x.front()"]
+  on_rc5:
+    then:
+      - logger.log:
+          format: "on_rc5: %u %u"
+          args: ["x.address", "x.command"]
+  on_rc6:
+    then:
+      - logger.log:
+          format: "on_rc6: %u %u"
+          args: ["x.address", "x.command"]
   on_rc_switch:
     then:
-      delay: !lambda "return uint32_t(x.code) + x.protocol;"
+      - logger.log:
+          format: "on_rc_switch: %llu %u"
+          args: ["x.code", "x.protocol"]
+  on_samsung:
+    then:
+      - logger.log:
+          format: "on_samsung: %llu %u"
+          args: ["x.data", "x.nbits"]
+  on_samsung36:
+    then:
+      - logger.log:
+          format: "on_samsung36: %u %u"
+          args: ["x.address", "x.command"]
+  on_sony:
+    then:
+      - logger.log:
+          format: "on_sony: %u %u"
+          args: ["x.data", "x.nbits"]
+  on_toshiba_ac:
+    then:
+      - logger.log:
+          format: "on_toshiba_ac: %llu %llu"
+          args: ["x.rc_code_1", "x.rc_code_2"]
 
 binary_sensor:
   - platform: remote_receiver

--- a/tests/components/remote_receiver/test.esp8266.yaml
+++ b/tests/components/remote_receiver/test.esp8266.yaml
@@ -2,12 +2,146 @@ remote_receiver:
   id: rcvr
   pin: GPIO5
   dump: all
+  on_abbwelcome:
+    then:
+      - logger.log:
+          format: "on_abbwelcome: %u"
+          args: ["x.data()[0]"]
+  on_aeha:
+    then:
+      - logger.log:
+          format: "on_aeha: %u %u"
+          args: ["x.address", "x.data.front()"]
+  on_byronsx:
+    then:
+      - logger.log:
+          format: "on_byronsx: %u %u"
+          args: ["x.address", "x.command"]
+  on_canalsat:
+    then:
+      - logger.log:
+          format: "on_canalsat: %u %u"
+          args: ["x.address", "x.command"]
+  # on_canalsatld:
+  #   then:
+  #     - logger.log:
+  #         format: "on_canalsatld: %u %u"
+  #         args: ["x.address", "x.command"]
   on_coolix:
     then:
-      delay: !lambda "return x.first + x.second;"
+      - logger.log:
+          format: "on_coolix: %u %u"
+          args: ["x.first", "x.second"]
+  on_dish:
+    then:
+      - logger.log:
+          format: "on_dish: %u %u"
+          args: ["x.address", "x.command"]
+  on_dooya:
+    then:
+      - logger.log:
+          format: "on_dooya: %u %u %u"
+          args: ["x.channel", "x.button", "x.check"]
+  on_drayton:
+    then:
+      - logger.log:
+          format: "on_drayton: %u %u %u"
+          args: ["x.address", "x.channel", "x.command"]
+  on_jvc:
+    then:
+      - logger.log:
+          format: "on_jvc: %u"
+          args: ["x.data"]
+  on_keeloq:
+    then:
+      - logger.log:
+          format: "on_keeloq: %u %u %u"
+          args: ["x.encrypted", "x.address", "x.command"]
+  on_haier:
+    then:
+      - logger.log:
+          format: "on_haier: %u"
+          args: ["x.data.front()"]
+  on_lg:
+    then:
+      - logger.log:
+          format: "on_lg: %u %u"
+          args: ["x.data", "x.nbits"]
+  on_magiquest:
+    then:
+      - logger.log:
+          format: "on_magiquest: %u %u"
+          args: ["x.magnitude", "x.wand_id"]
+  on_midea:
+    then:
+      - logger.log:
+          format: "on_midea: %u %u"
+          args: ["x.size()", "x.data()[0]"]
+  on_nec:
+    then:
+      - logger.log:
+          format: "on_nec: %u %u"
+          args: ["x.address", "x.command"]
+  on_nexa:
+    then:
+      - logger.log:
+          format: "on_nexa: %u %u %u %u %u"
+          args: ["x.device", "x.group", "x.state", "x.channel", "x.level"]
+  on_panasonic:
+    then:
+      - logger.log:
+          format: "on_panasonic: %u %u"
+          args: ["x.address", "x.command"]
+  on_pioneer:
+    then:
+      - logger.log:
+          format: "on_pioneer: %u %u"
+          args: ["x.rc_code_1", "x.rc_code_2"]
+  on_pronto:
+    then:
+      - logger.log:
+          format: "on_pronto: %s"
+          args: ["x.data.c_str()"]
+  on_raw:
+    then:
+      - logger.log:
+          format: "on_raw: %u"
+          args: ["x.front()"]
+  on_rc5:
+    then:
+      - logger.log:
+          format: "on_rc5: %u %u"
+          args: ["x.address", "x.command"]
+  on_rc6:
+    then:
+      - logger.log:
+          format: "on_rc6: %u %u"
+          args: ["x.address", "x.command"]
   on_rc_switch:
     then:
-      delay: !lambda "return uint32_t(x.code) + x.protocol;"
+      - logger.log:
+          format: "on_rc_switch: %llu %u"
+          args: ["x.code", "x.protocol"]
+  on_samsung:
+    then:
+      - logger.log:
+          format: "on_samsung: %llu %u"
+          args: ["x.data", "x.nbits"]
+  on_samsung36:
+    then:
+      - logger.log:
+          format: "on_samsung36: %u %u"
+          args: ["x.address", "x.command"]
+  on_sony:
+    then:
+      - logger.log:
+          format: "on_sony: %u %u"
+          args: ["x.data", "x.nbits"]
+  on_toshiba_ac:
+    then:
+      - logger.log:
+          format: "on_toshiba_ac: %llu %llu"
+          args: ["x.rc_code_1", "x.rc_code_2"]
 
 binary_sensor:
   - platform: remote_receiver


### PR DESCRIPTION
# What does this implement/fix?

Adds in all missing `remote_receiver` `on_...` tests.

`on_canalsatld` fails with `src/main.cpp:751:91: error: no matching function for call to 'esphome::Automation<esphome::remote_base::CanalSatLDData>::Automation(esphome::remote_base::CanalSatLDTrigger*&)'` -- this will be fixed and the test restored in a separate PR.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
