### PR TITLE
Fix no-release bug on ft6x36

### DIFF
--- a/esphome/components/ft63x6/ft63x6.cpp
+++ b/esphome/components/ft63x6/ft63x6.cpp
@@ -84,7 +84,6 @@ void FT63X6Touchscreen::update_touches() {
     return;
   }
 
-
   for (auto point = 0; point < touches; point++) {
     if (((this->read_touch_event_(point)) & 0x01) == 0) {  // checking event flag bit 6 if it is null
       touch_id = this->read_touch_id_(point);              // id1 = 0 or 1

--- a/esphome/components/ft63x6/ft63x6.cpp
+++ b/esphome/components/ft63x6/ft63x6.cpp
@@ -32,7 +32,7 @@ void FT63X6Touchscreen::setup() {
   if (this->interrupt_pin_ != nullptr) {
     this->interrupt_pin_->pin_mode(gpio::FLAG_INPUT | gpio::FLAG_PULLUP);
     this->interrupt_pin_->setup();
-    this->attach_interrupt_(this->interrupt_pin_, gpio::INTERRUPT_FALLING_EDGE);
+    this->attach_interrupt_(this->interrupt_pin_, gpio::INTERRUPT_ANY_EDGE);
   }
 
   if (this->reset_pin_ != nullptr) {
@@ -78,12 +78,12 @@ void FT63X6Touchscreen::update_touches() {
   uint16_t touch_id, x, y;
 
   uint8_t touches = this->read_touch_number_();
+  ESP_LOGV(TAG, "Touches found: %d", touches);
   if ((touches == 0x00) || (touches == 0xff)) {
     // ESP_LOGD(TAG, "No touches detected");
     return;
   }
 
-  ESP_LOGV(TAG, "Touches found: %d", touches);
 
   for (auto point = 0; point < touches; point++) {
     if (((this->read_touch_event_(point)) & 0x01) == 0) {  // checking event flag bit 6 if it is null


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

The ft63x6 touchscreen component when used with an interrupt pin, sometimes does not send a release notification after a finger is lifted. This fixes that by triggering the interrupt on either a falling or a rising edge.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
