### PR TITLE
Fix project version longer than 30 characters breaking compilation

### DIFF
--- a/esphome/core/base_automation.h
+++ b/esphome/core/base_automation.h
@@ -134,7 +134,7 @@ class ProjectUpdateTrigger : public Trigger<std::string>, public Component {
     uint32_t hash = fnv1_hash(ESPHOME_PROJECT_NAME);
     ESPPreferenceObject pref = global_preferences->make_preference<char[30]>(hash, true);
     char previous_version[30];
-    char current_version[30] = ESPHOME_PROJECT_VERSION;
+    char current_version[30] = ESPHOME_PROJECT_VERSION_30;
     if (pref.load(&previous_version)) {
       int cmp = strcmp(previous_version, current_version);
       if (cmp < 0) {

--- a/esphome/core/config.py
+++ b/esphome/core/config.py
@@ -394,6 +394,7 @@ async def to_code(config):
     if project_conf := config.get(CONF_PROJECT):
         cg.add_define("ESPHOME_PROJECT_NAME", project_conf[CONF_NAME])
         cg.add_define("ESPHOME_PROJECT_VERSION", project_conf[CONF_VERSION])
+        cg.add_define("ESPHOME_PROJECT_VERSION_30", project_conf[CONF_VERSION][:30])
         for conf in project_conf.get(CONF_ON_UPDATE, []):
             trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID])
             await cg.register_component(trigger, conf)

--- a/esphome/core/defines.h
+++ b/esphome/core/defines.h
@@ -11,6 +11,7 @@
 #define ESPHOME_BOARD "dummy_board"
 #define ESPHOME_PROJECT_NAME "dummy project"
 #define ESPHOME_PROJECT_VERSION "v2"
+#define ESPHOME_PROJECT_VERSION_30 "v2"
 #define ESPHOME_VARIANT "ESP32"
 
 // Feature flags


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

This fixes some compilations where configs are using a version longer than 30 characters.
This means these configs wont compare the full version correctly because the characters after the 30th are dropped.



## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
