### PR TITLE
Fix some printf formats for size_t.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -410,6 +410,7 @@ jobs:
         id: target-branch
         run: |
           echo "branch=${{ github.event.pull_request.base.ref }}" >> $GITHUB_OUTPUT
+          echo "Target branch is $GITHUB_OUTPUT"
       - name: Fetch ${{ steps.target-branch.outputs.branch }} branch
         run: |
           git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +refs/heads/${{ steps.target-branch.outputs.branch }}:refs/remotes/origin/${{ steps.target-branch.outputs.branch }}
@@ -472,6 +473,7 @@ jobs:
       - compile-tests
       - clang-tidy
       - test-build-components
+      - list-components
     if: always()
     steps:
       - name: Success
@@ -479,4 +481,8 @@ jobs:
         run: exit 0
       - name: Failure
         if: ${{ contains(needs.*.result, 'failure') }}
-        run: exit 1
+        env:
+          JSON_DOC: ${{ toJSON(needs) }}
+        run: |
+          echo $JSON_DOC | jq
+          exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -410,7 +410,6 @@ jobs:
         id: target-branch
         run: |
           echo "branch=${{ github.event.pull_request.base.ref }}" >> $GITHUB_OUTPUT
-          echo "Target branch is $GITHUB_OUTPUT"
       - name: Fetch ${{ steps.target-branch.outputs.branch }} branch
         run: |
           git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +refs/heads/${{ steps.target-branch.outputs.branch }}:refs/remotes/origin/${{ steps.target-branch.outputs.branch }}

--- a/esphome/components/select/select.cpp
+++ b/esphome/components/select/select.cpp
@@ -12,7 +12,7 @@ void Select::publish_state(const std::string &state) {
   if (index.has_value()) {
     this->has_state_ = true;
     this->state = state;
-    ESP_LOGD(TAG, "'%s': Sending state %s (index %d)", name, state.c_str(), index.value());
+    ESP_LOGD(TAG, "'%s': Sending state %s (index %zu)", name, state.c_str(), index.value());
     this->state_callback_.call(state, index.value());
   } else {
     ESP_LOGE(TAG, "'%s': invalid state for publish_state(): %s", name, state.c_str());

--- a/esphome/components/select/select_call.cpp
+++ b/esphome/components/select/select_call.cpp
@@ -71,7 +71,7 @@ void SelectCall::perform() {
       return;
     }
     if (this->index_.value() >= options.size()) {
-      ESP_LOGW(TAG, "'%s' - Index value %d out of bounds", name, this->index_.value());
+      ESP_LOGW(TAG, "'%s' - Index value %zu out of bounds", name, this->index_.value());
       return;
     }
     target_value = options[this->index_.value()];

--- a/esphome/components/sensor/filter.cpp
+++ b/esphome/components/sensor/filter.cpp
@@ -79,7 +79,7 @@ SkipInitialFilter::SkipInitialFilter(size_t num_to_ignore) : num_to_ignore_(num_
 optional<float> SkipInitialFilter::new_value(float value) {
   if (num_to_ignore_ > 0) {
     num_to_ignore_--;
-    ESP_LOGV(TAG, "SkipInitialFilter(%p)::new_value(%f) SKIPPING, %u left", this, value, num_to_ignore_);
+    ESP_LOGV(TAG, "SkipInitialFilter(%p)::new_value(%f) SKIPPING, %zu left", this, value, num_to_ignore_);
     return {};
   }
 


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Where `size_t` values are printed, they should use the `%zu` format.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
