### PR TITLE
Add enum option to typed_schema

### DIFF
--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -1590,6 +1590,9 @@ def typed_schema(schemas, **kwargs):
     """Create a schema that has a key to distinguish between schemas"""
     key = kwargs.pop("key", CONF_TYPE)
     default_schema_option = kwargs.pop("default_type", None)
+    enum_mapping = kwargs.pop("enum", None)
+    if enum_mapping is not None:
+        assert isinstance(enum_mapping, dict)
     key_validator = one_of(*schemas, **kwargs)
 
     def validator(value):
@@ -1600,6 +1603,9 @@ def typed_schema(schemas, **kwargs):
         if schema_option is None:
             raise Invalid(f"{key} not specified!")
         key_v = key_validator(schema_option)
+        if enum_mapping is not None:
+            key_v = add_class_to_obj(key_v, core.EnumValue)
+            key_v.enum_value = enum_mapping[key_v]
         value = Schema(schemas[key_v])(value)
         value[key] = key_v
         return value

--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -1593,6 +1593,7 @@ def typed_schema(schemas, **kwargs):
     enum_mapping = kwargs.pop("enum", None)
     if enum_mapping is not None:
         assert isinstance(enum_mapping, dict)
+        assert set(enum_mapping.keys()) == set(schemas.keys())
     key_validator = one_of(*schemas, **kwargs)
 
     def validator(value):


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

This allows the type value of a `cv.typed_schema` to automatically become a supplied enum value.

```py

TestEnum = test_ns.enum("TestEnum")
TESTS = {
  "test1": TestEnum.TEST1,
  "test2": TestEnum.TEST2,
}

CONFIG_SCHEMA = cv.typed_schema(
  {
    "test1": cv.Schema(...),
    "test2": cv.Schema(...),
  },
  enum=TESTS,
)
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
