### PR TITLE
web_server: Add error and workaround for web_server v3 when local: true

### DIFF
--- a/esphome/components/web_server/__init__.py
+++ b/esphome/components/web_server/__init__.py
@@ -55,6 +55,21 @@ def default_url(config):
 def validate_local(config):
     if CONF_LOCAL in config and config[CONF_VERSION] == 1:
         raise cv.Invalid("'local' is not supported in version 1")
+    if CONF_LOCAL in config and config[CONF_VERSION] == 3:
+        raise cv.Invalid(
+            "'local' is not (yet) supported in version 3\n"
+            "\n"
+            "As a workaround download https://oi.esphome.io/v3/www.js\n"
+            "and use the following configuration:\n"
+            "\n"
+            "web_server:\n"
+            "  version: 3\n"
+            "  local: false\n"
+            '  js_include: "www.js"\n'
+            '  js_url: ""\n'
+            "\n"
+            "See https://github.com/esphome/issues/issues/5692 for updates"
+        )
     return config
 
 


### PR DESCRIPTION
# What does this implement/fix?

Currently using `web_server` with `version: 3` and `local: true` does not work https://github.com/esphome/issues/issues/5692 (you get version 2 instead).

I think the way `local` works should be reworked and decoupled from the static inline build https://github.com/esphome/issues/issues/5704 but in the interim, the described workaround lets you get the latest v3 locally.

This adds a `cv.Invalid()` when `CONF_LOCAL in config and config[CONF_VERSION] == 3` with the following message:

![local v3 error](https://github.com/esphome/esphome/assets/706138/1a314469-8432-4f2f-a17e-6bf1087039fb)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):**
https://github.com/esphome/issues/issues/5692
https://github.com/esphome/issues/issues/5704

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>
Should the workaround go in the docs instead and be linked to from the `cv.Invalid()`? 🤔

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
web_server:
  version: 3
  local: true
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
