### PR TITLE
Nextion - Do not refresh sensors while updating

### DIFF
--- a/esphome/components/nextion/binary_sensor/nextion_binarysensor.cpp
+++ b/esphome/components/nextion/binary_sensor/nextion_binarysensor.cpp
@@ -27,7 +27,7 @@ void NextionBinarySensor::process_touch(uint8_t page_id, uint8_t component_id, b
 }
 
 void NextionBinarySensor::update() {
-  if (!this->nextion_->is_setup())
+  if (!this->nextion_->is_setup() || this->nextion_->is_updating())
     return;
 
   if (this->variable_name_.empty())  // This is a touch component
@@ -37,7 +37,7 @@ void NextionBinarySensor::update() {
 }
 
 void NextionBinarySensor::set_state(bool state, bool publish, bool send_to_nextion) {
-  if (!this->nextion_->is_setup())
+  if (!this->nextion_->is_setup() || this->nextion_->is_updating())
     return;
 
   if (this->component_id_ == 0)  // This is a legacy touch component

--- a/esphome/components/nextion/nextion.cpp
+++ b/esphome/components/nextion/nextion.cpp
@@ -1137,5 +1137,7 @@ void Nextion::set_writer(const nextion_writer_t &writer) { this->writer_ = write
 ESPDEPRECATED("set_wait_for_ack(bool) is deprecated and has no effect", "v1.20")
 void Nextion::set_wait_for_ack(bool wait_for_ack) { ESP_LOGE(TAG, "This command is deprecated"); }
 
+bool Nextion::is_updating() { return this->is_updating_; }
+
 }  // namespace nextion
 }  // namespace esphome

--- a/esphome/components/nextion/nextion.h
+++ b/esphome/components/nextion/nextion.h
@@ -1019,6 +1019,26 @@ class Nextion : public NextionBase, public PollingComponent, public uart::UARTDe
    */
   size_t queue_size() { return this->nextion_queue_.size(); }
 
+  /**
+   * @brief Check if the TFT update process is currently running.
+   *
+   * This method provides a way to determine if the Nextion display is in the
+   * process of updating its TFT firmware. When a TFT update is in progress,
+   * certain operations or commands may be restricted or could interfere with the
+   * update process. By checking the state of the update process, the system can
+   * make informed decisions about performing actions that involve communication
+   * with the Nextion display.
+   *
+   * @return true if the TFT update process is active, indicating that the Nextion
+   *         display is currently updating its firmware. This implies that caution
+   *         should be taken with commands sent to the display to avoid interrupting
+   *         the update process.
+   * @return false if the TFT update process is not active, indicating that the Nextion
+   *         display is not currently updating its firmware and is in a normal operational
+   *         state, ready to receive and process commands as usual.
+   */
+  bool is_updating() override;
+
  protected:
   std::deque<NextionQueue *> nextion_queue_;
   std::deque<NextionQueue *> waveform_queue_;

--- a/esphome/components/nextion/nextion_base.h
+++ b/esphome/components/nextion/nextion_base.h
@@ -48,6 +48,8 @@ class NextionBase {
   virtual void show_component(const char *component) = 0;
   virtual void hide_component(const char *component) = 0;
 
+  virtual bool is_updating() { return false; }
+
   bool is_sleeping() { return this->is_sleeping_; }
   bool is_setup() { return this->is_setup_; }
   bool is_detected() { return this->is_detected_; }

--- a/esphome/components/nextion/sensor/nextion_sensor.cpp
+++ b/esphome/components/nextion/sensor/nextion_sensor.cpp
@@ -30,7 +30,7 @@ void NextionSensor::add_to_wave_buffer(float state) {
 }
 
 void NextionSensor::update() {
-  if (!this->nextion_->is_setup())
+  if (!this->nextion_->is_setup() || this->nextion_->is_updating())
     return;
 
   if (this->wave_chan_id_ == UINT8_MAX) {
@@ -45,7 +45,7 @@ void NextionSensor::update() {
 }
 
 void NextionSensor::set_state(float state, bool publish, bool send_to_nextion) {
-  if (!this->nextion_->is_setup())
+  if (!this->nextion_->is_setup() || this->nextion_->is_updating())
     return;
 
   if (std::isnan(state))

--- a/esphome/components/nextion/switch/nextion_switch.cpp
+++ b/esphome/components/nextion/switch/nextion_switch.cpp
@@ -18,13 +18,13 @@ void NextionSwitch::process_bool(const std::string &variable_name, bool on) {
 }
 
 void NextionSwitch::update() {
-  if (!this->nextion_->is_setup())
+  if (!this->nextion_->is_setup() || this->nextion_->is_updating())
     return;
   this->nextion_->add_to_get_queue(this);
 }
 
 void NextionSwitch::set_state(bool state, bool publish, bool send_to_nextion) {
-  if (!this->nextion_->is_setup())
+  if (!this->nextion_->is_setup() || this->nextion_->is_updating())
     return;
 
   if (send_to_nextion) {

--- a/esphome/components/nextion/text_sensor/nextion_textsensor.cpp
+++ b/esphome/components/nextion/text_sensor/nextion_textsensor.cpp
@@ -16,13 +16,13 @@ void NextionTextSensor::process_text(const std::string &variable_name, const std
 }
 
 void NextionTextSensor::update() {
-  if (!this->nextion_->is_setup())
+  if (!this->nextion_->is_setup() || this->nextion_->is_updating())
     return;
   this->nextion_->add_to_get_queue(this);
 }
 
 void NextionTextSensor::set_state(const std::string &state, bool publish, bool send_to_nextion) {
-  if (!this->nextion_->is_setup())
+  if (!this->nextion_->is_setup() || this->nextion_->is_updating())
     return;
 
   if (send_to_nextion) {


### PR DESCRIPTION
# What does this implement/fix?

This prevents Nextion to request sensors/switches updates while uploading TFT, preventing adding those requests to the queue and preserving memory. The device usually restarts after an update, so the queue will be cleaned up, so no reason to populate the queue during the upload.

This is part of #6192 which I'm breaking down.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [X] ESP32
- [X] ESP32 IDF
- [X] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

N/A

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
