### PR TITLE
Nextion - Review set_protocol_reparse_mode()

### DIFF
--- a/esphome/components/nextion/nextion.h
+++ b/esphome/components/nextion/nextion.h
@@ -878,12 +878,24 @@ class Nextion : public NextionBase, public PollingComponent, public uart::UARTDe
    */
   void sleep(bool sleep);
   /**
-   * Sets Nextion Protocol Reparse mode between active or passive
-   * @param True or false.
-   * active_mode=true to enter active protocol reparse mode
-   * active_mode=false to enter passive protocol reparse mode.
+   * @brief Sets the Nextion display's protocol reparse mode.
+   *
+   * This function toggles the Nextion display's protocol reparse mode between active and passive.
+   * In active mode, the display actively parses incoming data.
+   * In passive mode, it does not parse data unless specifically instructed to do so.
+   * This is useful for managing how the Nextion display interprets incoming commands,
+   * especially during initialization or in scenarios where precise control over command processing is needed.
+   *
+   * @param active_mode A boolean value indicating the desired reparse mode.
+   *        - true to set the display to active protocol reparse mode, where it actively parses incoming commands.
+   *        - false to set the display to passive protocol reparse mode, where command parsing is done only on explicit
+   * instruction.
+   *
+   * @return bool Returns true if all commands were sent successfully to the Nextion display, indicating that the mode
+   * was set as expected. Returns false if any of the commands failed to send, indicating that the desired reparse mode
+   * may not be correctly set.
    */
-  void set_protocol_reparse_mode(bool active_mode);
+  bool set_protocol_reparse_mode(bool active_mode);
 
   // ========== INTERNAL METHODS ==========
   // (In most use cases you won't need these)

--- a/esphome/components/nextion/nextion_commands.cpp
+++ b/esphome/components/nextion/nextion_commands.cpp
@@ -36,22 +36,23 @@ void Nextion::sleep(bool sleep) {
 // End sleep safe commands
 
 // Protocol reparse mode
-void Nextion::set_protocol_reparse_mode(bool active_mode) {
-  const uint8_t to_send[3] = {0xFF, 0xFF, 0xFF};
+bool Nextion::set_protocol_reparse_mode(bool active_mode) {
+  ESP_LOGV(TAG, "Set Nextion protocol reparse mode: %s", YESNO(active_mode));
+  this->ignore_is_setup_ = true;  // if not in reparse mode setup will fail, so it should be ignored
+  bool all_commands_sent = true;
   if (active_mode) {  // Sets active protocol reparse mode
-    this->write_str(
-        "recmod=1");  // send_command_ cannot be used as Nextion might not be setup if incorrect reparse mode
-    this->write_array(to_send, sizeof(to_send));
-  } else {                                        // Sets passive protocol reparse mode
-    this->write_str("DRAKJHSUYDGBNCJHGJKSHBDN");  // To exit active reparse mode this sequence must be sent
-    this->write_array(to_send, sizeof(to_send));
-    this->write_str("recmod=0");  // Sending recmode=0 twice is recommended
-    this->write_array(to_send, sizeof(to_send));
-    this->write_str("recmod=0");
-    this->write_array(to_send, sizeof(to_send));
+    all_commands_sent &= this->send_command_("recmod=1");
+  } else {  // Sets passive protocol reparse mode
+    all_commands_sent &=
+        this->send_command_("DRAKJHSUYDGBNCJHGJKSHBDN");   // To exit active reparse mode this sequence must be sent
+    all_commands_sent &= this->send_command_("recmod=0");  // Sending recmode=0 twice is recommended
+    all_commands_sent &= this->send_command_("recmod=0");
   }
-  this->write_str("connect");
-  this->write_array(to_send, sizeof(to_send));
+  if (!this->nextion_reports_is_setup_) {  // No need to connect if is already setup
+    all_commands_sent &= this->send_command_("connect");
+  }
+  this->ignore_is_setup_ = false;
+  return all_commands_sent;
 }
 void Nextion::set_exit_reparse_on_start(bool exit_reparse) { this->exit_reparse_on_start_ = exit_reparse; }
 


### PR DESCRIPTION
# What does this implement/fix?

This rebuilds the `set_protocol_reparse_mode()` to use the `send_command_` call, avoiding direct calls to uart and standardizing the library as much as possible. It also returns the status of sending the commands to Nextion, so it will return `false` if any of the commands fails.

This is part of the break down of #6192

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [X] ESP32
- [X] ESP32 IDF
- [X] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

N/A

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
