### PR TITLE
SM2135 - Use standard channel ordering.

### DIFF
--- a/esphome/components/sm2135/sm2135.cpp
+++ b/esphome/components/sm2135/sm2135.cpp
@@ -106,23 +106,23 @@ void SM2135::loop() {
       delay(1);
       this->sm2135_start_();
       this->write_byte_(SM2135_ADDR_C);
-      this->write_byte_(this->pwm_amounts_[4]);  // Warm
-      this->write_byte_(this->pwm_amounts_[3]);  // Cold
+      this->write_byte_(this->pwm_amounts_[3]);
+      this->write_byte_(this->pwm_amounts_[4]);
     } else {
       // Color
 
       this->write_byte_(SM2135_RGB);
-      this->write_byte_(this->pwm_amounts_[1]);  // Green
-      this->write_byte_(this->pwm_amounts_[0]);  // Red
-      this->write_byte_(this->pwm_amounts_[2]);  // Blue
+      this->write_byte_(this->pwm_amounts_[0]);
+      this->write_byte_(this->pwm_amounts_[1]);
+      this->write_byte_(this->pwm_amounts_[2]);
     }
   } else {
     this->write_byte_(SM2135_RGB);
-    this->write_byte_(this->pwm_amounts_[1]);  // Green
-    this->write_byte_(this->pwm_amounts_[0]);  // Red
-    this->write_byte_(this->pwm_amounts_[2]);  // Blue
-    this->write_byte_(this->pwm_amounts_[4]);  // Warm
-    this->write_byte_(this->pwm_amounts_[3]);  // Cold
+    this->write_byte_(this->pwm_amounts_[0]);
+    this->write_byte_(this->pwm_amounts_[1]);
+    this->write_byte_(this->pwm_amounts_[2]);
+    this->write_byte_(this->pwm_amounts_[3]);
+    this->write_byte_(this->pwm_amounts_[4]);
   }
 
   this->sm2135_stop_();


### PR DESCRIPTION
# What does this implement/fix?

The LED driver was writing channels out of order.  The output config already allows for custom mapping of channels independent of the driver.  This is a breaking change, in that mapped channels may become incorrect based on previously having to compensate for the unusual order based on the design of a specific bulb, but this bring the driver in-line with other drivers such as BP5758/BP1658/SM2335 in that internally the same channel orders will be written to the driver, and mapping should be done in the output configuration alone.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [X] ESP8266
- [ ] RP2040
- [X] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
sm2135:
  data_pin: GPIO6
  clock_pin: GPIO7
  rgb_current: 45mA
  cw_current: 60mA

output:
  - platform: sm2135
    id: output_red
    channel: 2
  - platform: sm2135
    id: output_green
    channel: 1
  - platform: sm2135
    id: output_blue
    channel: 0
  - platform: sm2135
    id: output_cold_white
    channel: 4
  - platform: sm2135
    id: output_warm_white
    channel: 3
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
