### PR TITLE
Fix or filter

### DIFF
--- a/esphome/components/sensor/filter.cpp
+++ b/esphome/components/sensor/filter.cpp
@@ -360,12 +360,17 @@ OrFilter::PhiNode::PhiNode(OrFilter *or_parent) : or_parent_(or_parent) {}
 
 optional<float> OrFilter::PhiNode::new_value(float value) {
   this->or_parent_->output(value);
-
+  this->or_parent_->has_value_ = true;
   return {};
 }
 optional<float> OrFilter::new_value(float value) {
-  for (Filter *filter : this->filters_)
+  this->has_value_ = false;
+  for (Filter *filter : this->filters_) {
     filter->input(value);
+    if (this->has_value_) {
+      break;
+    }
+  }
 
   return {};
 }

--- a/esphome/components/sensor/filter.cpp
+++ b/esphome/components/sensor/filter.cpp
@@ -359,18 +359,17 @@ OrFilter::OrFilter(std::vector<Filter *> filters) : filters_(std::move(filters))
 OrFilter::PhiNode::PhiNode(OrFilter *or_parent) : or_parent_(or_parent) {}
 
 optional<float> OrFilter::PhiNode::new_value(float value) {
-  this->or_parent_->output(value);
-  this->or_parent_->has_value_ = true;
+  if (!this->or_parent_->has_value_) {
+    this->or_parent_->output(value);
+    this->or_parent_->has_value_ = true;
+  }
+
   return {};
 }
 optional<float> OrFilter::new_value(float value) {
   this->has_value_ = false;
-  for (Filter *filter : this->filters_) {
+  for (Filter *filter : this->filters_)
     filter->input(value);
-    if (this->has_value_) {
-      break;
-    }
-  }
 
   return {};
 }

--- a/esphome/components/sensor/filter.h
+++ b/esphome/components/sensor/filter.h
@@ -388,6 +388,7 @@ class OrFilter : public Filter {
   };
 
   std::vector<Filter *> filters_;
+  bool has_value_;
   PhiNode phi_;
 };
 

--- a/esphome/components/sensor/filter.h
+++ b/esphome/components/sensor/filter.h
@@ -388,7 +388,7 @@ class OrFilter : public Filter {
   };
 
   std::vector<Filter *> filters_;
-  bool has_value_;
+  bool has_value_{false};
   PhiNode phi_;
 };
 


### PR DESCRIPTION
# What does this implement/fix?

Docs for the "or" filter say: "Pass forward a value with the first child filter that returns. Below example will only pass forward values that are either at least 1s old or are if the absolute difference is at least 5.0."

The actual implementation would pass forward a value for every filter that returned. That resulted in duplicating the value and sending it up multiple times. This PR fixes that bug. 

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
