### PR TITLE
Add MPL115A2 Barometric Pressure/Temperature Sensor

### DIFF
--- a/esphome/components/mpl115a2/mpl115a2.cpp
+++ b/esphome/components/mpl115a2/mpl115a2.cpp
@@ -56,7 +56,7 @@ void MPL115A2Component::dump_config() {
 }
 
 void MPL115A2Component::update() {
-  uint16_t pressureRaw, tempRaw;
+  uint16_t pressureIn, tempIn;
   float pressureComp;
 
   uint8_t cmd[2] = {MPL115A2_REGISTER_STARTCONVERSION, 0};
@@ -71,22 +71,22 @@ void MPL115A2Component::update() {
   this->write(cmd, 1);
   this->read(buffer, 4);
 
-  pressureRaw = (((uint16_t) buffer[0] << 8) | buffer[1]) >> 6;
-  tempRaw = (((uint16_t) buffer[2] << 8) | buffer[3]) >> 6;
+  pressureIn = (((uint16_t) buffer[0] << 8) | buffer[1]) >> 6;
+  tempIn = (((uint16_t) buffer[2] << 8) | buffer[3]) >> 6;
 
   // See datasheet p.6 for evaluation sequence
-  pressureComp = _mpl115a2_a0 + (_mpl115a2_b1 + _mpl115a2_c12 * tempRaw) * pressureRaw + _mpl115a2_b2 * tempRaw;
+  pressureComp = _mpl115a2_a0 + (_mpl115a2_b1 + _mpl115a2_c12 * tempIn) * pressureIn + _mpl115a2_b2 * tempIn;
 
-  float pressure = ((65.0F / 1023.0F) * pressureComp) + 50.0F;
+  float pressureOut = ((65.0F / 1023.0F) * pressureComp) + 50.0F;
   if (this->pressure_ != nullptr)
-    this->pressure_->publish_state(pressure);
+    this->pressure_->publish_state(pressureOut);
   int16_t t = encode_uint16(buffer[3], buffer[4]);
 
-  float temperature = ((float) tempRaw - 498.0F) / -5.35F + 25.0F;
+  float temperatureOut = ((float) tempIn - 498.0F) / -5.35F + 25.0F;
   if (this->temperature_ != nullptr)
-    this->temperature_->publish_state(temperature);
+    this->temperature_->publish_state(temperatureOut);
 
-  ESP_LOGD(TAG, "Got Temperature=%.1f°C Pressure=%.1f", temperature, pressure);
+  ESP_LOGD(TAG, "Got Temperature=%.1f°C Pressure=%.1f", temperatureOut, pressureOut);
 
   this->status_clear_warning();
 }

--- a/esphome/components/mpl115a2/mpl115a2.cpp
+++ b/esphome/components/mpl115a2/mpl115a2.cpp
@@ -39,21 +39,8 @@ void MPL115A2Component::readCoefficients() {
 }
 
 void MPL115A2Component::dump_config() {
-  ESP_LOGCONFIG(TAG, "MPL3115A2:");
+  ESP_LOGCONFIG(TAG, "MPL115A2:");
   LOG_I2C_DEVICE(this);
-  if (this->is_failed()) {
-    switch (this->error_code_) {
-      case COMMUNICATION_FAILED:
-        ESP_LOGE(TAG, "Communication with MPL3115A2 failed!");
-        break;
-      case WRONG_ID:
-        ESP_LOGE(TAG, "MPL3115A2 has invalid id");
-        break;
-      default:
-        ESP_LOGE(TAG, "Setting up MPL3115A2 registers failed!");
-        break;
-    }
-  }
   LOG_UPDATE_INTERVAL(this);
   LOG_SENSOR("  ", "Temperature", this->temperature_);
   LOG_SENSOR("  ", "Pressure", this->pressure_);

--- a/esphome/components/mpl115a2/mpl115a2.cpp
+++ b/esphome/components/mpl115a2/mpl115a2.cpp
@@ -1,0 +1,95 @@
+#include "mpl115a2.h"
+#include "esphome/core/hal.h"
+#include "esphome/core/log.h"
+
+namespace esphome {
+namespace mpl115a2 {
+
+static const char *const TAG = "mpl115a2";
+
+void MPL115A2Component::setup() { ESP_LOGCONFIG(TAG, "Setting up MPL115A2..."); }
+
+void MPL115A2Component::readCoefficients() {
+  int16_t a0coeff;
+  int16_t b1coeff;
+  int16_t b2coeff;
+  int16_t c12coeff;
+
+  uint8_t cmd;
+  uint8_t buffer[8];
+
+  cmd = MPL115A2_REGISTER_A0_COEFF_MSB;
+  this->write(&cmd, 1);
+  this->read(buffer, 8);
+
+  a0coeff = (((uint16_t) buffer[0] << 8) | buffer[1]);
+  b1coeff = (((uint16_t) buffer[2] << 8) | buffer[3]);
+  b2coeff = (((uint16_t) buffer[4] << 8) | buffer[5]);
+  c12coeff = (((uint16_t) buffer[6] << 8) | buffer[7]) >> 2;
+
+  _mpl115a2_a0 = (float) a0coeff / 8;
+  _mpl115a2_b1 = (float) b1coeff / 8192;
+  _mpl115a2_b2 = (float) b2coeff / 16384;
+  _mpl115a2_c12 = (float) c12coeff;
+  _mpl115a2_c12 /= 4194304.0;
+}
+
+void MPL115A2Component::dump_config() {
+  ESP_LOGCONFIG(TAG, "MPL3115A2:");
+  LOG_I2C_DEVICE(this);
+  if (this->is_failed()) {
+    switch (this->error_code_) {
+      case COMMUNICATION_FAILED:
+        ESP_LOGE(TAG, "Communication with MPL3115A2 failed!");
+        break;
+      case WRONG_ID:
+        ESP_LOGE(TAG, "MPL3115A2 has invalid id");
+        break;
+      default:
+        ESP_LOGE(TAG, "Setting up MPL3115A2 registers failed!");
+        break;
+    }
+  }
+  LOG_UPDATE_INTERVAL(this);
+  LOG_SENSOR("  ", "Temperature", this->temperature_);
+  LOG_SENSOR("  ", "Pressure", this->pressure_);
+}
+
+void MPL115A2Component::update() {
+  uint16_t pressure, temp;
+  float pressureComp;
+
+  uint8_t cmd[2] = {MPL115A2_REGISTER_STARTCONVERSION, 0};
+  uint8_t buffer[4];
+
+  this->write(cmd, 2);
+
+  // Wait a bit for the conversion to complete (3ms max)
+  delay(5);
+
+  cmd[0] = MPL115A2_REGISTER_PRESSURE_MSB;
+  this->write(cmd, 1);
+  this->read(buffer, 4);
+
+  pressure = (((uint16_t) buffer[0] << 8) | buffer[1]) >> 6;
+  temp = (((uint16_t) buffer[2] << 8) | buffer[3]) >> 6;
+
+  // See datasheet p.6 for evaluation sequence
+  pressureComp = _mpl115a2_a0 + (_mpl115a2_b1 + _mpl115a2_c12 * temp) * pressure + _mpl115a2_b2 * temp;
+
+  float pressure = ((65.0F / 1023.0F) * pressureComp) + 50.0F;
+  if (this->pressure_ != nullptr)
+    this->pressure_->publish_state(pressure);
+  int16_t t = encode_uint16(buffer[3], buffer[4]);
+
+  float temperature = ((float) temp - 498.0F) / -5.35F + 25.0F;
+  if (this->temperature_ != nullptr)
+    this->temperature_->publish_state(temperature);
+
+  ESP_LOGD(TAG, "Got Temperature=%.1f°C Pressure=%.1f", temperature, pressure);
+
+  this->status_clear_warning();
+}
+
+}  // namespace mpl115a2
+}  // namespace esphome

--- a/esphome/components/mpl115a2/mpl115a2.cpp
+++ b/esphome/components/mpl115a2/mpl115a2.cpp
@@ -56,7 +56,7 @@ void MPL115A2Component::dump_config() {
 }
 
 void MPL115A2Component::update() {
-  uint16_t pressure, temp;
+  uint16_t pressureRaw, tempRaw;
   float pressureComp;
 
   uint8_t cmd[2] = {MPL115A2_REGISTER_STARTCONVERSION, 0};
@@ -71,18 +71,18 @@ void MPL115A2Component::update() {
   this->write(cmd, 1);
   this->read(buffer, 4);
 
-  pressure = (((uint16_t) buffer[0] << 8) | buffer[1]) >> 6;
-  temp = (((uint16_t) buffer[2] << 8) | buffer[3]) >> 6;
+  pressureRaw = (((uint16_t) buffer[0] << 8) | buffer[1]) >> 6;
+  tempRaw = (((uint16_t) buffer[2] << 8) | buffer[3]) >> 6;
 
   // See datasheet p.6 for evaluation sequence
-  pressureComp = _mpl115a2_a0 + (_mpl115a2_b1 + _mpl115a2_c12 * temp) * pressure + _mpl115a2_b2 * temp;
+  pressureComp = _mpl115a2_a0 + (_mpl115a2_b1 + _mpl115a2_c12 * tempRaw) * pressureRaw + _mpl115a2_b2 * tempRaw;
 
   float pressure = ((65.0F / 1023.0F) * pressureComp) + 50.0F;
   if (this->pressure_ != nullptr)
     this->pressure_->publish_state(pressure);
   int16_t t = encode_uint16(buffer[3], buffer[4]);
 
-  float temperature = ((float) temp - 498.0F) / -5.35F + 25.0F;
+  float temperature = ((float) tempRaw - 498.0F) / -5.35F + 25.0F;
   if (this->temperature_ != nullptr)
     this->temperature_->publish_state(temperature);
 

--- a/esphome/components/mpl115a2/mpl115a2.cpp
+++ b/esphome/components/mpl115a2/mpl115a2.cpp
@@ -7,7 +7,11 @@ namespace mpl115a2 {
 
 static const char *const TAG = "mpl115a2";
 
-void MPL115A2Component::setup() { ESP_LOGCONFIG(TAG, "Setting up MPL115A2..."); }
+void MPL115A2Component::setup() { 
+  ESP_LOGCONFIG(TAG, "Setting up MPL115A2...");
+
+  this->readCoefficients();
+}
 
 void MPL115A2Component::readCoefficients() {
   int16_t a0coeff;

--- a/esphome/components/mpl115a2/mpl115a2.h
+++ b/esphome/components/mpl115a2/mpl115a2.h
@@ -43,11 +43,6 @@ class MPL115A2Component : public PollingComponent, public i2c::I2CDevice {
  protected:
   sensor::Sensor *temperature_{nullptr};
   sensor::Sensor *pressure_{nullptr};
-  enum ErrorCode {
-    NONE = 0,
-    COMMUNICATION_FAILED,
-    WRONG_ID,
-  } error_code_{NONE};
 };
 
 }  // namespace mpl115a2

--- a/esphome/components/mpl115a2/mpl115a2.h
+++ b/esphome/components/mpl115a2/mpl115a2.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/components/sensor/sensor.h"
+#include "esphome/components/i2c/i2c.h"
+
+namespace esphome {
+namespace mpl115a2 {
+
+// enums from https://github.com/adafruit/Adafruit_MPL115A2/
+/** MPL115A2 registers **/
+enum {
+  MPL115A2_REGISTER_PRESSURE_MSB = (0x00),
+  MPL115A2_REGISTER_PRESSURE_LSB = (0x01),
+
+  MPL115A2_REGISTER_TEMP_MSB = (0x02),
+  MPL115A2_REGISTER_TEMP_LSB = (0x03),
+
+  MPL115A2_REGISTER_A0_COEFF_MSB = (0x04),
+
+  MPL115A2_REGISTER_STARTCONVERSION = (0x12),
+};
+
+class MPL115A2Component : public PollingComponent, public i2c::I2CDevice {
+ public:
+  void set_temperature(sensor::Sensor *temperature) { temperature_ = temperature; }
+  void set_pressure(sensor::Sensor *pressure) { pressure_ = pressure; }
+
+  void setup() override;
+  void dump_config() override;
+  void update() override;
+
+  float get_setup_priority() const override { return setup_priority::DATA; }
+
+ private:
+  float _mpl115a2_a0;
+  float _mpl115a2_b1;
+  float _mpl115a2_b2;
+  float _mpl115a2_c12;
+
+  void readCoefficients();
+
+ protected:
+  sensor::Sensor *temperature_{nullptr};
+  sensor::Sensor *pressure_{nullptr};
+  enum ErrorCode {
+    NONE = 0,
+    COMMUNICATION_FAILED,
+    WRONG_ID,
+  } error_code_{NONE};
+};
+
+}  // namespace mpl115a2
+}  // namespace esphome

--- a/esphome/components/mpl115a2/sensor.py
+++ b/esphome/components/mpl115a2/sensor.py
@@ -1,0 +1,58 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import i2c, sensor
+from esphome.const import (
+    CONF_ID,
+    CONF_PRESSURE,
+    CONF_TEMPERATURE,
+    DEVICE_CLASS_PRESSURE,
+    DEVICE_CLASS_TEMPERATURE,
+    STATE_CLASS_MEASUREMENT,
+    UNIT_CELSIUS,
+    UNIT_HECTOPASCAL,
+    UNIT_METER,
+)
+
+CODEOWNERS = ["@unic8s"]
+DEPENDENCIES = ["i2c"]
+
+mpl115a2_ns = cg.esphome_ns.namespace("mpl115a2")
+MPL115A2Component = mpl115a2_ns.class_(
+    "MPL115A2Component", cg.PollingComponent, i2c.I2CDevice
+)
+
+CONFIG_SCHEMA = (
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.declare_id(MPL115A2Component),
+            cv.Optional(CONF_PRESSURE): sensor.sensor_schema(
+                unit_of_measurement=UNIT_HECTOPASCAL,
+                accuracy_decimals=1,
+                device_class=DEVICE_CLASS_PRESSURE,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ),
+            cv.Optional(CONF_TEMPERATURE): sensor.sensor_schema(
+                unit_of_measurement=UNIT_CELSIUS,
+                accuracy_decimals=1,
+                device_class=DEVICE_CLASS_TEMPERATURE,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ),
+        }
+    )
+    .extend(cv.polling_component_schema("60s"))
+    .extend(i2c.i2c_device_schema(0x60))
+)
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+    await i2c.register_i2c_device(var, config)
+
+    if CONF_PRESSURE in config:
+        sens = await sensor.new_sensor(config[CONF_PRESSURE])
+        cg.add(var.set_pressure(sens))
+
+    if CONF_TEMPERATURE in config:
+        sens = await sensor.new_sensor(config[CONF_TEMPERATURE])
+        cg.add(var.set_temperature(sens))

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -1608,6 +1608,12 @@ sensor:
     object:
       name: Object
       emissivity: 1.0
+  - platform: mpl115a2
+    i2c_id: i2c_bus
+    temperature:
+      name: "MPL115A2 Temperature"
+    pressure:
+      name: "MPL115A2 Pressure"
   - platform: mpl3115a2
     i2c_id: i2c_bus
     temperature:


### PR DESCRIPTION
# What does this implement/fix?

Add support for the MPL115A2 pressure/temperature I²C sensor (https://github.com/adafruit/Adafruit_MPL115A2). This is the tinier version of the already exisiting implementation of the sensor MPL3115A2 but without the altitude metric. The code is partly ported from https://github.com/adafruit/Adafruit_MPL115A2

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
sensor:
- platform: mpl115a2
  temperature:
    name: "Temperature"
  pressure:
    name: "Pressure"
  update_interval: 10s
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
