### PR TITLE
Fix SHT3xd fails sometimes in 2024.4.0

### DIFF
--- a/esphome/components/sht3xd/sht3xd.cpp
+++ b/esphome/components/sht3xd/sht3xd.cpp
@@ -6,9 +6,14 @@ namespace sht3xd {
 
 static const char *const TAG = "sht3xd";
 
-// use read serial number register with clock stretching disabled as per other SHT3XD_COMMAND registers
-// which provides support for SHT85 sensor
-// SHT85 does not support clock stretching and uses same registers as SHT3xd with clock stretching disabled
+// https://sensirion.com/media/documents/E5762713/63D103C2/Sensirion_electronic_identification_code_SHT3x.pdf
+// indicates two possible read serial number registers either with clock stretching enabled or disabled.
+// Other SHT3XD_COMMAND registers use the clock stretching disabled register.
+// To ensure compatibility, reading serial number using the register with clock stretching register enabled
+// (used originally in this component) is tried first and if that fails the alternate register address
+// with clock stretching disabled is read.
+
+static const uint16_t SHT3XD_COMMAND_READ_SERIAL_NUMBER_CLOCK_STRETCHING = 0x3780;
 static const uint16_t SHT3XD_COMMAND_READ_SERIAL_NUMBER = 0x3682;
 
 static const uint16_t SHT3XD_COMMAND_READ_STATUS = 0xF32D;
@@ -22,13 +27,19 @@ static const uint16_t SHT3XD_COMMAND_FETCH_DATA = 0xE000;
 void SHT3XDComponent::setup() {
   ESP_LOGCONFIG(TAG, "Setting up SHT3xD...");
   uint16_t raw_serial_number[2];
-  if (!this->get_register(SHT3XD_COMMAND_READ_SERIAL_NUMBER, raw_serial_number, 2)) {
-    this->mark_failed();
-    return;
+  if (!this->get_register(SHT3XD_COMMAND_READ_SERIAL_NUMBER_CLOCK_STRETCHING, raw_serial_number, 2)) {
+    this->error_code_ = READ_SERIAL_STRETCHED_FAILED;
+    if (!this->get_register(SHT3XD_COMMAND_READ_SERIAL_NUMBER, raw_serial_number, 2)) {
+      this->error_code_ = READ_SERIAL_FAILED;
+      this->mark_failed();
+      return;
+    }
   }
+
   this->serial_number_ = (uint32_t(raw_serial_number[0]) << 16) | uint32_t(raw_serial_number[1]);
 
   if (!this->write_command(heater_enabled_ ? SHT3XD_COMMAND_HEATER_ENABLE : SHT3XD_COMMAND_HEATER_DISABLE)) {
+    this->error_code_ = WRITE_HEATER_MODE_FAILED;
     this->mark_failed();
     return;
   }
@@ -36,10 +47,24 @@ void SHT3XDComponent::setup() {
 
 void SHT3XDComponent::dump_config() {
   ESP_LOGCONFIG(TAG, "SHT3xD:");
+  switch (this->error_code_) {
+    case READ_SERIAL_STRETCHED_FAILED:
+      ESP_LOGD(TAG, "  Error reading serial number - trying alternate register");
+      break;
+    case READ_SERIAL_FAILED:
+      ESP_LOGD(TAG, "  Error reading serial number");
+      break;
+    case WRITE_HEATER_MODE_FAILED:
+      ESP_LOGD(TAG, "  Error writing heater mode");
+      break;
+    default:
+      break;
+  }
   if (this->is_failed()) {
     ESP_LOGE(TAG, "  Communication with SHT3xD failed!");
     return;
   }
+  ESP_LOGD(TAG, "  Setup successful");
   ESP_LOGD(TAG, "  Serial Number: 0x%08" PRIX32, this->serial_number_);
   ESP_LOGD(TAG, "  Heater Enabled: %s", this->heater_enabled_ ? "true" : "false");
 

--- a/esphome/components/sht3xd/sht3xd.cpp
+++ b/esphome/components/sht3xd/sht3xd.cpp
@@ -48,9 +48,6 @@ void SHT3XDComponent::setup() {
 void SHT3XDComponent::dump_config() {
   ESP_LOGCONFIG(TAG, "SHT3xD:");
   switch (this->error_code_) {
-    case READ_SERIAL_STRETCHED_FAILED:
-      ESP_LOGD(TAG, "  Error reading serial number - trying alternate register");
-      break;
     case READ_SERIAL_FAILED:
       ESP_LOGD(TAG, "  Error reading serial number");
       break;

--- a/esphome/components/sht3xd/sht3xd.h
+++ b/esphome/components/sht3xd/sht3xd.h
@@ -22,6 +22,13 @@ class SHT3XDComponent : public PollingComponent, public sensirion_common::Sensir
   void set_heater_enabled(bool heater_enabled) { heater_enabled_ = heater_enabled; }
 
  protected:
+  enum ErrorCode {
+    NONE = 0,
+    READ_SERIAL_STRETCHED_FAILED,
+    READ_SERIAL_FAILED,
+    WRITE_HEATER_MODE_FAILED,
+  } error_code_{NONE};
+  
   sensor::Sensor *temperature_sensor_{nullptr};
   sensor::Sensor *humidity_sensor_{nullptr};
   bool heater_enabled_{true};

--- a/esphome/components/sht3xd/sht3xd.h
+++ b/esphome/components/sht3xd/sht3xd.h
@@ -28,7 +28,7 @@ class SHT3XDComponent : public PollingComponent, public sensirion_common::Sensir
     READ_SERIAL_FAILED,
     WRITE_HEATER_MODE_FAILED,
   } error_code_{NONE};
-  
+
   sensor::Sensor *temperature_sensor_{nullptr};
   sensor::Sensor *humidity_sensor_{nullptr};
   bool heater_enabled_{true};


### PR DESCRIPTION
# What does this implement/fix?
Update to this component in release 2024.4.0 caused failure for some users on reading serial number. 
This fix reinstates original register for reading serial number and if this fails the alternate is used. Error codes have been added to setup and are shown in dump_config  

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes [esphome/issues issue#5710](https://github.com/esphome/issues/issues/5710)
User that raised issue has tested fix successfully plus another user

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** NA

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
NA

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
