### PR TITLE
Limit Rx wait loop time to 3 seconds.

### DIFF
--- a/esphome/components/ld2420/ld2420.cpp
+++ b/esphome/components/ld2420/ld2420.cpp
@@ -493,19 +493,16 @@ void LD2420Component::handle_ack_data_(uint8_t *buffer, int len) {
 }
 
 int LD2420Component::send_cmd_from_array(CmdFrameT frame) {
+  uint32_t start_millis = millis();
   uint8_t error = 0;
   uint8_t ack_buffer[64];
   uint8_t cmd_buffer[64];
-  uint16_t loop_count;
   this->cmd_reply_.ack = false;
   if (frame.command != CMD_RESTART)
     this->set_cmd_active_(true);  // Restart does not reply, thus no ack state required.
   uint8_t retry = 3;
   while (retry) {
-    // TODO setup a dynamic method e.g. millis time count etc. to tune for non ESP32 240Mhz devices
-    // this is ok for now since the module firmware is changing like the weather atm
     frame.length = 0;
-    loop_count = 1250;
     uint16_t frame_data_bytes = frame.data_length + 2;  // Always add two bytes for the cmd size
 
     memcpy(&cmd_buffer[frame.length], &frame.header, sizeof(frame.header));
@@ -538,12 +535,12 @@ int LD2420Component::send_cmd_from_array(CmdFrameT frame) {
         this->readline_(read(), ack_buffer, sizeof(ack_buffer));
       }
       delay_microseconds_safe(1450);
-      if (loop_count <= 0) {
+      // Wait on an Rx from the LD2420 for up to 3 1 second loops, otherwise it could trigger a WDT.
+      if ((millis() - start_millis) > 1000) {
         error = LD2420_ERROR_TIMEOUT;
         retry--;
         break;
       }
-      loop_count--;
     }
     if (this->cmd_reply_.ack)
       retry = 0;

--- a/esphome/components/ld2420/ld2420.cpp
+++ b/esphome/components/ld2420/ld2420.cpp
@@ -537,6 +537,7 @@ int LD2420Component::send_cmd_from_array(CmdFrameT frame) {
       delay_microseconds_safe(1450);
       // Wait on an Rx from the LD2420 for up to 3 1 second loops, otherwise it could trigger a WDT.
       if ((millis() - start_millis) > 1000) {
+        start_millis = millis();
         error = LD2420_ERROR_TIMEOUT;
         retry--;
         break;


### PR DESCRIPTION
# What does this implement/fix?

Addresses a TODO
Limits an LD2420 send cmd wait time to 3 seconds.
Previously it used a count which could exceed a WDT.  

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)

**Related issue or feature (if applicable):** fixes <link to issue>

Discord

## Test Environment

- [X] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Checklist:
  - [X] The code change is tested and works locally.

