### PR TITLE
Ble client fixes for proxy

### DIFF
--- a/esphome/components/alpha3/alpha3.cpp
+++ b/esphome/components/alpha3/alpha3.cpp
@@ -97,9 +97,11 @@ void Alpha3::handle_geni_response_(const uint8_t *response, uint16_t length) {
 void Alpha3::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if, esp_ble_gattc_cb_param_t *param) {
   switch (event) {
     case ESP_GATTC_OPEN_EVT: {
-      this->response_offset_ = 0;
-      this->response_length_ = 0;
-      ESP_LOGI(TAG, "[%s] connection open", this->parent_->address_str().c_str());
+      if (param->open.status == ESP_GATT_OK) {
+        this->response_offset_ = 0;
+        this->response_length_ = 0;
+        ESP_LOGI(TAG, "[%s] connection open", this->parent_->address_str().c_str());
+      }
       break;
     }
     case ESP_GATTC_CONNECT_EVT: {

--- a/esphome/components/am43/sensor/am43_sensor.cpp
+++ b/esphome/components/am43/sensor/am43_sensor.cpp
@@ -26,7 +26,9 @@ void Am43::setup() {
 void Am43::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if, esp_ble_gattc_cb_param_t *param) {
   switch (event) {
     case ESP_GATTC_OPEN_EVT: {
-      this->logged_in_ = false;
+      if (param->open.status == ESP_GATT_OK) {
+        this->logged_in_ = false;
+      }
       break;
     }
     case ESP_GATTC_DISCONNECT_EVT: {

--- a/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
@@ -19,8 +19,8 @@ bool BluetoothConnection::gattc_event_handler(esp_gattc_cb_event_t event, esp_ga
     return false;
 
   switch (event) {
-    case ESP_GATTC_DISCONNECT_EVT: {
-      this->proxy_->send_device_connection(this->address_, false, 0, param->disconnect.reason);
+    case ESP_GATTC_CLOSE_EVT: {
+      this->proxy_->send_device_connection(this->address_, false, 0, param->close.reason);
       this->set_address(0);
       this->proxy_->send_connections_free();
       break;

--- a/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
@@ -26,8 +26,6 @@ bool BluetoothConnection::gattc_event_handler(esp_gattc_cb_event_t event, esp_ga
       break;
     }
     case ESP_GATTC_OPEN_EVT: {
-      if (param->open.conn_id != this->conn_id_)
-        break;
       if (param->open.status != ESP_GATT_OK && param->open.status != ESP_GATT_ALREADY_OPEN) {
         this->proxy_->send_device_connection(this->address_, false, 0, param->open.status);
         this->set_address(0);
@@ -40,8 +38,6 @@ bool BluetoothConnection::gattc_event_handler(esp_gattc_cb_event_t event, esp_ga
       break;
     }
     case ESP_GATTC_CFG_MTU_EVT: {
-      if (param->cfg_mtu.conn_id != this->conn_id_)
-        break;
       if (!this->seen_mtu_or_services_) {
         // We don't know if we will get the MTU or the services first, so
         // only send the device connection true if we have already received
@@ -54,8 +50,6 @@ bool BluetoothConnection::gattc_event_handler(esp_gattc_cb_event_t event, esp_ga
       break;
     }
     case ESP_GATTC_SEARCH_CMPL_EVT: {
-      if (param->search_cmpl.conn_id != this->conn_id_)
-        break;
       if (!this->seen_mtu_or_services_) {
         // We don't know if we will get the MTU or the services first, so
         // only send the device connection true if we have already received
@@ -69,8 +63,6 @@ bool BluetoothConnection::gattc_event_handler(esp_gattc_cb_event_t event, esp_ga
     }
     case ESP_GATTC_READ_DESCR_EVT:
     case ESP_GATTC_READ_CHAR_EVT: {
-      if (param->read.conn_id != this->conn_id_)
-        break;
       if (param->read.status != ESP_GATT_OK) {
         ESP_LOGW(TAG, "[%d] [%s] Error reading char/descriptor at handle 0x%2X, status=%d", this->connection_index_,
                  this->address_str_.c_str(), param->read.handle, param->read.status);
@@ -89,8 +81,6 @@ bool BluetoothConnection::gattc_event_handler(esp_gattc_cb_event_t event, esp_ga
     }
     case ESP_GATTC_WRITE_CHAR_EVT:
     case ESP_GATTC_WRITE_DESCR_EVT: {
-      if (param->write.conn_id != this->conn_id_)
-        break;
       if (param->write.status != ESP_GATT_OK) {
         ESP_LOGW(TAG, "[%d] [%s] Error writing char/descriptor at handle 0x%2X, status=%d", this->connection_index_,
                  this->address_str_.c_str(), param->write.handle, param->write.status);
@@ -131,8 +121,6 @@ bool BluetoothConnection::gattc_event_handler(esp_gattc_cb_event_t event, esp_ga
       break;
     }
     case ESP_GATTC_NOTIFY_EVT: {
-      if (param->notify.conn_id != this->conn_id_)
-        break;
       ESP_LOGV(TAG, "[%d] [%s] ESP_GATTC_NOTIFY_EVT: handle=0x%2X", this->connection_index_, this->address_str_.c_str(),
                param->notify.handle);
       api::BluetoothGATTNotifyDataResponse resp;

--- a/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
@@ -37,23 +37,12 @@ bool BluetoothConnection::gattc_event_handler(esp_gattc_cb_event_t event, esp_ga
       this->seen_mtu_or_services_ = false;
       break;
     }
-    case ESP_GATTC_CFG_MTU_EVT: {
-      if (!this->seen_mtu_or_services_) {
-        // We don't know if we will get the MTU or the services first, so
-        // only send the device connection true if we have already received
-        // the services.
-        this->seen_mtu_or_services_ = true;
-        break;
-      }
-      this->proxy_->send_device_connection(this->address_, true, this->mtu_);
-      this->proxy_->send_connections_free();
-      break;
-    }
+    case ESP_GATTC_CFG_MTU_EVT:
     case ESP_GATTC_SEARCH_CMPL_EVT: {
       if (!this->seen_mtu_or_services_) {
         // We don't know if we will get the MTU or the services first, so
         // only send the device connection true if we have already received
-        // the mtu.
+        // the services.
         this->seen_mtu_or_services_ = true;
         break;
       }

--- a/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
@@ -19,6 +19,12 @@ bool BluetoothConnection::gattc_event_handler(esp_gattc_cb_event_t event, esp_ga
     return false;
 
   switch (event) {
+    case ESP_GATTC_DISCONNECT_EVT: {
+      this->proxy_->send_device_connection(this->address_, false, 0, param->disconnect.reason);
+      this->set_address(0);
+      this->proxy_->send_connections_free();
+      break;
+    }
     case ESP_GATTC_CLOSE_EVT: {
       this->proxy_->send_device_connection(this->address_, false, 0, param->close.reason);
       this->set_address(0);

--- a/esphome/components/esp32_ble_client/ble_client_base.cpp
+++ b/esphome/components/esp32_ble_client/ble_client_base.cpp
@@ -142,7 +142,7 @@ bool BLEClientBase::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_
         ESP_LOGW(TAG, "[%d] [%s] Connection failed, status=%d", this->connection_index_, this->address_str_.c_str(),
                  param->open.status);
         this->set_state(espbt::ClientState::IDLE);
-        return false;
+        break;
       }
       auto ret = esp_ble_gattc_send_mtu_req(this->gattc_if_, param->open.conn_id);
       if (ret) {

--- a/esphome/components/pvvx_mithermometer/display/pvvx_display.cpp
+++ b/esphome/components/pvvx_mithermometer/display/pvvx_display.cpp
@@ -24,8 +24,10 @@ void PVVXDisplay::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t 
                                       esp_ble_gattc_cb_param_t *param) {
   switch (event) {
     case ESP_GATTC_OPEN_EVT:
-      ESP_LOGV(TAG, "[%s] Connected successfully!", this->parent_->address_str().c_str());
-      this->delayed_disconnect_();
+      if (param->open.status == ESP_GATT_OK) {
+        ESP_LOGV(TAG, "[%s] Connected successfully!", this->parent_->address_str().c_str());
+        this->delayed_disconnect_();
+      }
       break;
     case ESP_GATTC_DISCONNECT_EVT:
       ESP_LOGV(TAG, "[%s] Disconnected", this->parent_->address_str().c_str());


### PR DESCRIPTION
# What does this implement/fix?

- Makes sure bluetooth proxy get open failure indication (broken since #5277)
- Makes sure bluetooth proxy detect closes even when there are multiple virtual connections
- Removes unneeded checks from bluetooth proxy (redundant since #5277)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** Related to #5277 and replaces #6590

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
