### PR TITLE
Calibrate Beken internal temperature

### DIFF
--- a/esphome/components/internal_temperature/internal_temperature.cpp
+++ b/esphome/components/internal_temperature/internal_temperature.cpp
@@ -59,7 +59,7 @@ void InternalTemperatureSensor::update() {
   temperature = raw * -0.38f + 156.0f;
 #elif defined(USE_LIBRETINY_VARIANT_BK7231T)
   temperature = raw * 0.04f;
-#else  // USE_LIBRETINY_VARIANT
+#else   // USE_LIBRETINY_VARIANT
   temperature = raw * 0.128f;
 #endif  // USE_LIBRETINY_VARIANT
 #endif  // USE_BK72XX

--- a/esphome/components/internal_temperature/internal_temperature.cpp
+++ b/esphome/components/internal_temperature/internal_temperature.cpp
@@ -55,11 +55,13 @@ void InternalTemperatureSensor::update() {
   uint32_t raw, result;
   result = temp_single_get_current_temperature(&raw);
   success = (result == 0);
-#ifdef USE_LIBRETINY_VARIANT_BK7231T
+#if defined(USE_LIBRETINY_VARIANT_BK7231N)
+  temperature = raw * -0.38f + 156.0f;
+#elif defined(USE_LIBRETINY_VARIANT_BK7231T)
   temperature = raw * 0.04f;
-#else
+#else  // USE_LIBRETINY_VARIANT
   temperature = raw * 0.128f;
-#endif  // USE_LIBRETINY_VARIANT_BK7231T
+#endif  // USE_LIBRETINY_VARIANT
 #endif  // USE_BK72XX
   if (success && std::isfinite(temperature)) {
     this->publish_state(temperature);

--- a/tests/components/internal_temperature/test.bk72xx.yaml
+++ b/tests/components/internal_temperature/test.bk72xx.yaml
@@ -1,0 +1,3 @@
+sensor:
+  - platform: internal_temperature
+    name: "Internal Temperature"

--- a/tests/components/internal_temperature/test.esp32-c3-idf.yaml
+++ b/tests/components/internal_temperature/test.esp32-c3-idf.yaml
@@ -1,0 +1,3 @@
+sensor:
+  - platform: internal_temperature
+    name: "Internal Temperature"

--- a/tests/components/internal_temperature/test.esp32-c3.yaml
+++ b/tests/components/internal_temperature/test.esp32-c3.yaml
@@ -1,0 +1,3 @@
+sensor:
+  - platform: internal_temperature
+    name: "Internal Temperature"

--- a/tests/components/internal_temperature/test.esp32-idf.yaml
+++ b/tests/components/internal_temperature/test.esp32-idf.yaml
@@ -1,0 +1,3 @@
+sensor:
+  - platform: internal_temperature
+    name: "Internal Temperature"

--- a/tests/components/internal_temperature/test.esp32.yaml
+++ b/tests/components/internal_temperature/test.esp32.yaml
@@ -1,0 +1,3 @@
+sensor:
+  - platform: internal_temperature
+    name: "Internal Temperature"

--- a/tests/components/internal_temperature/test.rp2040.yaml
+++ b/tests/components/internal_temperature/test.rp2040.yaml
@@ -1,0 +1,3 @@
+sensor:
+  - platform: internal_temperature
+    name: "Internal Temperature"


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->
Internal temperature readings on the BK7231N are wrong. This change should give more accurate readings in the range 20-65℃ on the BK7231N. Other Beken chip variants should be calibrated too but I don't have any at the moment.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [x] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
