### PR TITLE
fix streaming logs from MQTT for ESP32 devices using TLS

### DIFF
--- a/esphome/mqtt.py
+++ b/esphome/mqtt.py
@@ -10,6 +10,7 @@ import paho.mqtt.client as mqtt
 
 from esphome.const import (
     CONF_BROKER,
+    CONF_CERTIFICATE_AUTHORITY,
     CONF_DISCOVERY_PREFIX,
     CONF_ESPHOME,
     CONF_LOG_TOPIC,
@@ -99,7 +100,9 @@ def prepare(
     elif username:
         client.username_pw_set(username, password)
 
-    if config[CONF_MQTT].get(CONF_SSL_FINGERPRINTS):
+    if config[CONF_MQTT].get(CONF_SSL_FINGERPRINTS) or config[CONF_MQTT].get(
+        CONF_CERTIFICATE_AUTHORITY
+    ):
         if sys.version_info >= (2, 7, 13):
             tls_version = ssl.PROTOCOL_TLS  # pylint: disable=no-member
         else:


### PR DESCRIPTION
# What does this implement/fix?

`esphome logs --device MQTT` (and via the ESPHome web dashboard) would just continuously output `INFO Successfully reconnected to the MQTT server` over and over again for ESP32 devices using TLS to connect to MQTT, without actually connecting or streaming logs from the device.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
esphome:
  name: my_device
  friendly_name: "My Device"

esp32:
  board: esp32dev
  framework:
    type: esp-idf

logger:
  level: INFO

mqtt:
  broker: !secret mqtt_broker
  port: 8883
  username: esphome
  password: !secret mqtt_password
  discovery_unique_id_generator: mac
  topic_prefix: esphome/$name
  certificate_authority: !secret mqtt_ca_cert
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
