### PR TITLE
[sn74hc595] Enforce type field to distinguish gpio vs spi mode

### DIFF
--- a/tests/components/sn74hc595/test.esp32-c3-idf.yaml
+++ b/tests/components/sn74hc595/test.esp32-c3-idf.yaml
@@ -1,0 +1,27 @@
+spi:
+  - id: spi_sn74hc595
+    clk_pin: 6
+    mosi_pin: 7
+    miso_pin: 5
+
+sn74hc595:
+  - id: sn74hc595_hub
+    clock_pin: 0
+    data_pin: 1
+    latch_pin: 2
+    oe_pin: 3
+    sr_count: 2
+  - id: sn74hc595_hub_2
+    latch_pin: 8
+    oe_pin: 9
+    spi_id: spi_sn74hc595
+    type: spi
+    sr_count: 2
+
+switch:
+  - platform: gpio
+    name: SN74HC595 Pin 0
+    pin:
+      sn74hc595: sn74hc595_hub_2
+      number: 0
+      inverted: false

--- a/tests/components/sn74hc595/test.esp32-c3.yaml
+++ b/tests/components/sn74hc595/test.esp32-c3.yaml
@@ -1,0 +1,27 @@
+spi:
+  - id: spi_sn74hc595
+    clk_pin: 6
+    mosi_pin: 7
+    miso_pin: 5
+
+sn74hc595:
+  - id: sn74hc595_hub
+    clock_pin: 0
+    data_pin: 1
+    latch_pin: 2
+    oe_pin: 3
+    sr_count: 2
+  - id: sn74hc595_hub_2
+    latch_pin: 8
+    oe_pin: 9
+    spi_id: spi_sn74hc595
+    type: spi
+    sr_count: 2
+
+switch:
+  - platform: gpio
+    name: SN74HC595 Pin 0
+    pin:
+      sn74hc595: sn74hc595_hub_2
+      number: 0
+      inverted: false

--- a/tests/components/sn74hc595/test.esp32-idf.yaml
+++ b/tests/components/sn74hc595/test.esp32-idf.yaml
@@ -1,0 +1,27 @@
+spi:
+  - id: spi_sn74hc595
+    clk_pin: 16
+    mosi_pin: 17
+    miso_pin: 15
+
+sn74hc595:
+  - id: sn74hc595_hub
+    clock_pin: 12
+    data_pin: 13
+    latch_pin: 14
+    oe_pin: 18
+    sr_count: 2
+  - id: sn74hc595_hub_2
+    latch_pin: 21
+    oe_pin: 22
+    spi_id: spi_sn74hc595
+    type: spi
+    sr_count: 2
+
+switch:
+  - platform: gpio
+    name: SN74HC595 Pin 0
+    pin:
+      sn74hc595: sn74hc595_hub_2
+      number: 0
+      inverted: false

--- a/tests/components/sn74hc595/test.esp32.yaml
+++ b/tests/components/sn74hc595/test.esp32.yaml
@@ -1,0 +1,27 @@
+spi:
+  - id: spi_sn74hc595
+    clk_pin: 16
+    mosi_pin: 17
+    miso_pin: 15
+
+sn74hc595:
+  - id: sn74hc595_hub
+    clock_pin: 12
+    data_pin: 13
+    latch_pin: 14
+    oe_pin: 18
+    sr_count: 2
+  - id: sn74hc595_hub_2
+    latch_pin: 21
+    oe_pin: 22
+    spi_id: spi_sn74hc595
+    type: spi
+    sr_count: 2
+
+switch:
+  - platform: gpio
+    name: SN74HC595 Pin 0
+    pin:
+      sn74hc595: sn74hc595_hub_2
+      number: 0
+      inverted: false

--- a/tests/components/sn74hc595/test.esp8266.yaml
+++ b/tests/components/sn74hc595/test.esp8266.yaml
@@ -1,0 +1,27 @@
+spi:
+  - id: spi_sn74hc595
+    clk_pin: 14
+    mosi_pin: 13
+    miso_pin: 12
+
+sn74hc595:
+  - id: sn74hc595_hub
+    clock_pin: 0
+    data_pin: 2
+    latch_pin: 4
+    oe_pin: 5
+    sr_count: 2
+  - id: sn74hc595_hub_2
+    latch_pin: 15
+    oe_pin: 16
+    spi_id: spi_sn74hc595
+    type: spi
+    sr_count: 2
+
+switch:
+  - platform: gpio
+    name: SN74HC595 Pin 0
+    pin:
+      sn74hc595: sn74hc595_hub_2
+      number: 0
+      inverted: false

--- a/tests/components/sn74hc595/test.rp2040.yaml
+++ b/tests/components/sn74hc595/test.rp2040.yaml
@@ -1,0 +1,27 @@
+spi:
+  - id: spi_sn74hc595
+    clk_pin: 6
+    mosi_pin: 5
+    miso_pin: 4
+
+sn74hc595:
+  - id: sn74hc595_hub
+    clock_pin: 0
+    data_pin: 1
+    latch_pin: 2
+    oe_pin: 3
+    sr_count: 2
+  - id: sn74hc595_hub_2
+    latch_pin: 8
+    oe_pin: 9
+    spi_id: spi_sn74hc595
+    type: spi
+    sr_count: 2
+
+switch:
+  - platform: gpio
+    name: SN74HC595 Pin 0
+    pin:
+      sn74hc595: sn74hc595_hub_2
+      number: 0
+      inverted: false

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -3996,6 +3996,7 @@ sn74hc595:
       number: GPIO32
     sr_count: 2
     spi_id: spi_bus
+    type: spi
 
 rtttl:
   output: gpio_19


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

This alters the sn74hc595 schema to be a `typed_schema`, meaning if you want to use it with an SPI component, you need to specify `type: spi` alongside the `spi_id`.

Fixes a pin reuse error showing up, noticed in https://github.com/esphome/esphome/pull/6227

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#3787

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
