### PR TITLE
Add null GPIO pin 

### DIFF
--- a/esphome/components/cst226/touchscreen/cst226_touchscreen.cpp
+++ b/esphome/components/cst226/touchscreen/cst226_touchscreen.cpp
@@ -5,17 +5,13 @@ namespace cst226 {
 
 void CST226Touchscreen::setup() {
   esph_log_config(TAG, "Setting up CST226 Touchscreen...");
-  if (this->reset_pin_ != nullptr) {
-    this->reset_pin_->setup();
-    this->reset_pin_->digital_write(true);
-    delay(5);
-    this->reset_pin_->digital_write(false);
-    delay(5);
-    this->reset_pin_->digital_write(true);
-    this->set_timeout(30, [this] { this->continue_setup_(); });
-  } else {
-    this->continue_setup_();
-  }
+  this->reset_pin_->setup();
+  this->reset_pin_->digital_write(true);
+  delay(5);
+  this->reset_pin_->digital_write(false);
+  delay(5);
+  this->reset_pin_->digital_write(true);
+  this->set_timeout(30, [this] { this->continue_setup_(); });
 }
 
 void CST226Touchscreen::update_touches() {

--- a/esphome/components/cst226/touchscreen/cst226_touchscreen.h
+++ b/esphome/components/cst226/touchscreen/cst226_touchscreen.h
@@ -35,7 +35,7 @@ class CST226Touchscreen : public touchscreen::Touchscreen, public i2c::I2CDevice
   void continue_setup_();
 
   InternalGPIOPin *interrupt_pin_{};
-  GPIOPin *reset_pin_{};
+  GPIOPin *reset_pin_{NULL_PIN};
   uint8_t chip_id_{};
   bool setup_complete_{};
 };

--- a/esphome/core/gpio.h
+++ b/esphome/core/gpio.h
@@ -62,6 +62,24 @@ class GPIOPin {
   virtual bool is_internal() { return false; }
 };
 
+/**
+ * A pin to replace those that don't exist.
+ */
+class NullPin : public GPIOPin {
+ public:
+  void setup() override {}
+
+  void pin_mode(gpio::Flags _) override {}
+
+  bool digital_read() override { return false; }
+
+  void digital_write(bool _) override {}
+
+  std::string dump_summary() const override { return {"Not used"}; }
+};
+
+static GPIOPin const *const NULL_PIN = new NullPin();
+
 /// Copy of GPIOPin that is safe to use from ISRs (with no virtual functions)
 class ISRInternalGPIOPin {
  public:

--- a/esphome/core/gpio.h
+++ b/esphome/core/gpio.h
@@ -5,7 +5,7 @@
 namespace esphome {
 
 #define LOG_PIN(prefix, pin) \
-  if ((pin) != nullptr) { \
+  if ((pin) != nullptr && (pin != NULL_PIN)) { \
     ESP_LOGCONFIG(TAG, prefix "%s", (pin)->dump_summary().c_str()); \
   }
 
@@ -78,7 +78,7 @@ class NullPin : public GPIOPin {
   std::string dump_summary() const override { return {"Not used"}; }
 };
 
-static GPIOPin const *const NULL_PIN = new NullPin();
+static GPIOPin *const NULL_PIN = new NullPin();
 
 /// Copy of GPIOPin that is safe to use from ISRs (with no virtual functions)
 class ISRInternalGPIOPin {

--- a/esphome/core/gpio.h
+++ b/esphome/core/gpio.h
@@ -5,7 +5,7 @@
 namespace esphome {
 
 #define LOG_PIN(prefix, pin) \
-  if ((pin) != nullptr && (pin != NULL_PIN)) { \
+  if ((pin) != nullptr) { \
     ESP_LOGCONFIG(TAG, prefix "%s", (pin)->dump_summary().c_str()); \
   }
 


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

This is for use in places where no pin has been specified, and avoids having to check for null pointers all the time.

So allows this code:

```
  if (this->sleep_pin_ != nullptr) {
    this->sleep_pin_->setup();
    this->sleep_pin_->digital_write(false);
    this->sleep_pin_state_ = false;
  }

...

protected:
  GPIOPin *sleep_pin_{nullptr};

```

To be refined to:

```
  this->sleep_pin_->setup();
  this->sleep_pin_->digital_write(false);
  this->sleep_pin_state_ = false;

...

protected:
  GPIOPin *sleep_pin_{NULL_PIN};
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
