### PR TITLE
[tests] Run yaml tests in groups if over 100 to run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,338 +59,338 @@ jobs:
           pip install -r requirements.txt -r requirements_optional.txt -r requirements_test.txt
           pip install -e .
 
-  # black:
-  #   name: Check black
-  #   runs-on: ubuntu-latest
-  #   needs:
-  #     - common
-  #   steps:
-  #     - name: Check out code from GitHub
-  #       uses: actions/checkout@v4.1.1
-  #     - name: Restore Python
-  #       uses: ./.github/actions/restore-python
-  #       with:
-  #         python-version: ${{ env.DEFAULT_PYTHON }}
-  #         cache-key: ${{ needs.common.outputs.cache-key }}
-  #     - name: Run black
-  #       run: |
-  #         . venv/bin/activate
-  #         black --verbose esphome tests
-  #     - name: Suggested changes
-  #       run: script/ci-suggest-changes
-  #       if: always()
+  black:
+    name: Check black
+    runs-on: ubuntu-latest
+    needs:
+      - common
+    steps:
+      - name: Check out code from GitHub
+        uses: actions/checkout@v4.1.1
+      - name: Restore Python
+        uses: ./.github/actions/restore-python
+        with:
+          python-version: ${{ env.DEFAULT_PYTHON }}
+          cache-key: ${{ needs.common.outputs.cache-key }}
+      - name: Run black
+        run: |
+          . venv/bin/activate
+          black --verbose esphome tests
+      - name: Suggested changes
+        run: script/ci-suggest-changes
+        if: always()
 
-  # flake8:
-  #   name: Check flake8
-  #   runs-on: ubuntu-latest
-  #   needs:
-  #     - common
-  #   steps:
-  #     - name: Check out code from GitHub
-  #       uses: actions/checkout@v4.1.1
-  #     - name: Restore Python
-  #       uses: ./.github/actions/restore-python
-  #       with:
-  #         python-version: ${{ env.DEFAULT_PYTHON }}
-  #         cache-key: ${{ needs.common.outputs.cache-key }}
-  #     - name: Run flake8
-  #       run: |
-  #         . venv/bin/activate
-  #         flake8 esphome
-  #     - name: Suggested changes
-  #       run: script/ci-suggest-changes
-  #       if: always()
+  flake8:
+    name: Check flake8
+    runs-on: ubuntu-latest
+    needs:
+      - common
+    steps:
+      - name: Check out code from GitHub
+        uses: actions/checkout@v4.1.1
+      - name: Restore Python
+        uses: ./.github/actions/restore-python
+        with:
+          python-version: ${{ env.DEFAULT_PYTHON }}
+          cache-key: ${{ needs.common.outputs.cache-key }}
+      - name: Run flake8
+        run: |
+          . venv/bin/activate
+          flake8 esphome
+      - name: Suggested changes
+        run: script/ci-suggest-changes
+        if: always()
 
-  # pylint:
-  #   name: Check pylint
-  #   runs-on: ubuntu-latest
-  #   needs:
-  #     - common
-  #   steps:
-  #     - name: Check out code from GitHub
-  #       uses: actions/checkout@v4.1.1
-  #     - name: Restore Python
-  #       uses: ./.github/actions/restore-python
-  #       with:
-  #         python-version: ${{ env.DEFAULT_PYTHON }}
-  #         cache-key: ${{ needs.common.outputs.cache-key }}
-  #     - name: Run pylint
-  #       run: |
-  #         . venv/bin/activate
-  #         pylint -f parseable --persistent=n esphome
-  #     - name: Suggested changes
-  #       run: script/ci-suggest-changes
-  #       if: always()
+  pylint:
+    name: Check pylint
+    runs-on: ubuntu-latest
+    needs:
+      - common
+    steps:
+      - name: Check out code from GitHub
+        uses: actions/checkout@v4.1.1
+      - name: Restore Python
+        uses: ./.github/actions/restore-python
+        with:
+          python-version: ${{ env.DEFAULT_PYTHON }}
+          cache-key: ${{ needs.common.outputs.cache-key }}
+      - name: Run pylint
+        run: |
+          . venv/bin/activate
+          pylint -f parseable --persistent=n esphome
+      - name: Suggested changes
+        run: script/ci-suggest-changes
+        if: always()
 
-  # pyupgrade:
-  #   name: Check pyupgrade
-  #   runs-on: ubuntu-latest
-  #   needs:
-  #     - common
-  #   steps:
-  #     - name: Check out code from GitHub
-  #       uses: actions/checkout@v4.1.1
-  #     - name: Restore Python
-  #       uses: ./.github/actions/restore-python
-  #       with:
-  #         python-version: ${{ env.DEFAULT_PYTHON }}
-  #         cache-key: ${{ needs.common.outputs.cache-key }}
-  #     - name: Run pyupgrade
-  #       run: |
-  #         . venv/bin/activate
-  #         pyupgrade ${{ env.PYUPGRADE_TARGET }} `find esphome -name "*.py" -type f`
-  #     - name: Suggested changes
-  #       run: script/ci-suggest-changes
-  #       if: always()
+  pyupgrade:
+    name: Check pyupgrade
+    runs-on: ubuntu-latest
+    needs:
+      - common
+    steps:
+      - name: Check out code from GitHub
+        uses: actions/checkout@v4.1.1
+      - name: Restore Python
+        uses: ./.github/actions/restore-python
+        with:
+          python-version: ${{ env.DEFAULT_PYTHON }}
+          cache-key: ${{ needs.common.outputs.cache-key }}
+      - name: Run pyupgrade
+        run: |
+          . venv/bin/activate
+          pyupgrade ${{ env.PYUPGRADE_TARGET }} `find esphome -name "*.py" -type f`
+      - name: Suggested changes
+        run: script/ci-suggest-changes
+        if: always()
 
-  # ci-custom:
-  #   name: Run script/ci-custom
-  #   runs-on: ubuntu-latest
-  #   needs:
-  #     - common
-  #   steps:
-  #     - name: Check out code from GitHub
-  #       uses: actions/checkout@v4.1.1
-  #     - name: Restore Python
-  #       uses: ./.github/actions/restore-python
-  #       with:
-  #         python-version: ${{ env.DEFAULT_PYTHON }}
-  #         cache-key: ${{ needs.common.outputs.cache-key }}
-  #     - name: Register matcher
-  #       run: echo "::add-matcher::.github/workflows/matchers/ci-custom.json"
-  #     - name: Run script/ci-custom
-  #       run: |
-  #         . venv/bin/activate
-  #         script/ci-custom.py
-  #         script/build_codeowners.py --check
+  ci-custom:
+    name: Run script/ci-custom
+    runs-on: ubuntu-latest
+    needs:
+      - common
+    steps:
+      - name: Check out code from GitHub
+        uses: actions/checkout@v4.1.1
+      - name: Restore Python
+        uses: ./.github/actions/restore-python
+        with:
+          python-version: ${{ env.DEFAULT_PYTHON }}
+          cache-key: ${{ needs.common.outputs.cache-key }}
+      - name: Register matcher
+        run: echo "::add-matcher::.github/workflows/matchers/ci-custom.json"
+      - name: Run script/ci-custom
+        run: |
+          . venv/bin/activate
+          script/ci-custom.py
+          script/build_codeowners.py --check
 
-  # pytest:
-  #   name: Run pytest
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       python-version:
-  #         - "3.9"
-  #         - "3.10"
-  #         - "3.11"
-  #         - "3.12"
-  #       os:
-  #         - ubuntu-latest
-  #         - macOS-latest
-  #         - windows-latest
-  #       exclude:
-  #         # Minimize CI resource usage
-  #         # by only running the Python version
-  #         # version used for docker images on Windows and macOS
-  #         - python-version: "3.12"
-  #           os: windows-latest
-  #         - python-version: "3.10"
-  #           os: windows-latest
-  #         - python-version: "3.9"
-  #           os: windows-latest
-  #         - python-version: "3.12"
-  #           os: macOS-latest
-  #         - python-version: "3.10"
-  #           os: macOS-latest
-  #         - python-version: "3.9"
-  #           os: macOS-latest
-  #   runs-on: ${{ matrix.os }}
-  #   needs:
-  #     - common
-  #   steps:
-  #     - name: Check out code from GitHub
-  #       uses: actions/checkout@v4.1.1
-  #     - name: Restore Python
-  #       uses: ./.github/actions/restore-python
-  #       with:
-  #         python-version: ${{ matrix.python-version }}
-  #         cache-key: ${{ needs.common.outputs.cache-key }}
-  #     - name: Register matcher
-  #       run: echo "::add-matcher::.github/workflows/matchers/pytest.json"
-  #     - name: Run pytest
-  #       if: matrix.os == 'windows-latest'
-  #       run: |
-  #         ./venv/Scripts/activate
-  #         pytest -vv --cov-report=xml --tb=native tests
-  #     - name: Run pytest
-  #       if: matrix.os == 'ubuntu-latest' || matrix.os == 'macOS-latest'
-  #       run: |
-  #         . venv/bin/activate
-  #         pytest -vv --cov-report=xml --tb=native tests
-  #     - name: Upload coverage to Codecov
-  #       uses: codecov/codecov-action@v4
-  #       with:
-  #         token: ${{ secrets.CODECOV_TOKEN }}
+  pytest:
+    name: Run pytest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version:
+          - "3.9"
+          - "3.10"
+          - "3.11"
+          - "3.12"
+        os:
+          - ubuntu-latest
+          - macOS-latest
+          - windows-latest
+        exclude:
+          # Minimize CI resource usage
+          # by only running the Python version
+          # version used for docker images on Windows and macOS
+          - python-version: "3.12"
+            os: windows-latest
+          - python-version: "3.10"
+            os: windows-latest
+          - python-version: "3.9"
+            os: windows-latest
+          - python-version: "3.12"
+            os: macOS-latest
+          - python-version: "3.10"
+            os: macOS-latest
+          - python-version: "3.9"
+            os: macOS-latest
+    runs-on: ${{ matrix.os }}
+    needs:
+      - common
+    steps:
+      - name: Check out code from GitHub
+        uses: actions/checkout@v4.1.1
+      - name: Restore Python
+        uses: ./.github/actions/restore-python
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache-key: ${{ needs.common.outputs.cache-key }}
+      - name: Register matcher
+        run: echo "::add-matcher::.github/workflows/matchers/pytest.json"
+      - name: Run pytest
+        if: matrix.os == 'windows-latest'
+        run: |
+          ./venv/Scripts/activate
+          pytest -vv --cov-report=xml --tb=native tests
+      - name: Run pytest
+        if: matrix.os == 'ubuntu-latest' || matrix.os == 'macOS-latest'
+        run: |
+          . venv/bin/activate
+          pytest -vv --cov-report=xml --tb=native tests
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
 
-  # clang-format:
-  #   name: Check clang-format
-  #   runs-on: ubuntu-latest
-  #   needs:
-  #     - common
-  #   steps:
-  #     - name: Check out code from GitHub
-  #       uses: actions/checkout@v4.1.1
-  #     - name: Restore Python
-  #       uses: ./.github/actions/restore-python
-  #       with:
-  #         python-version: ${{ env.DEFAULT_PYTHON }}
-  #         cache-key: ${{ needs.common.outputs.cache-key }}
-  #     - name: Install clang-format
-  #       run: |
-  #         . venv/bin/activate
-  #         pip install clang-format -c requirements_dev.txt
-  #     - name: Run clang-format
-  #       run: |
-  #         . venv/bin/activate
-  #         script/clang-format -i
-  #         git diff-index --quiet HEAD --
-  #     - name: Suggested changes
-  #       run: script/ci-suggest-changes
-  #       if: always()
+  clang-format:
+    name: Check clang-format
+    runs-on: ubuntu-latest
+    needs:
+      - common
+    steps:
+      - name: Check out code from GitHub
+        uses: actions/checkout@v4.1.1
+      - name: Restore Python
+        uses: ./.github/actions/restore-python
+        with:
+          python-version: ${{ env.DEFAULT_PYTHON }}
+          cache-key: ${{ needs.common.outputs.cache-key }}
+      - name: Install clang-format
+        run: |
+          . venv/bin/activate
+          pip install clang-format -c requirements_dev.txt
+      - name: Run clang-format
+        run: |
+          . venv/bin/activate
+          script/clang-format -i
+          git diff-index --quiet HEAD --
+      - name: Suggested changes
+        run: script/ci-suggest-changes
+        if: always()
 
-  # compile-tests-list:
-  #   runs-on: ubuntu-latest
-  #   outputs:
-  #     matrix: ${{ steps.set-matrix.outputs.matrix }}
-  #   steps:
-  #     - name: Check out code from GitHub
-  #       uses: actions/checkout@v4.1.1
-  #     - name: Find all YAML test files
-  #       id: set-matrix
-  #       run: echo "matrix=$(ls tests/test*.yaml | jq -R -s -c 'split("\n")[:-1]')" >> $GITHUB_OUTPUT
+  compile-tests-list:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - name: Check out code from GitHub
+        uses: actions/checkout@v4.1.1
+      - name: Find all YAML test files
+        id: set-matrix
+        run: echo "matrix=$(ls tests/test*.yaml | jq -R -s -c 'split("\n")[:-1]')" >> $GITHUB_OUTPUT
 
-  # validate-tests:
-  #   name: Validate YAML test ${{ matrix.file }}
-  #   runs-on: ubuntu-latest
-  #   needs:
-  #     - common
-  #     - compile-tests-list
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       file: ${{ fromJson(needs.compile-tests-list.outputs.matrix) }}
-  #   steps:
-  #     - name: Check out code from GitHub
-  #       uses: actions/checkout@v4.1.1
-  #     - name: Restore Python
-  #       uses: ./.github/actions/restore-python
-  #       with:
-  #         python-version: ${{ env.DEFAULT_PYTHON }}
-  #         cache-key: ${{ needs.common.outputs.cache-key }}
-  #     - name: Run esphome config ${{ matrix.file }}
-  #       run: |
-  #         . venv/bin/activate
-  #         esphome config ${{ matrix.file }}
+  validate-tests:
+    name: Validate YAML test ${{ matrix.file }}
+    runs-on: ubuntu-latest
+    needs:
+      - common
+      - compile-tests-list
+    strategy:
+      fail-fast: false
+      matrix:
+        file: ${{ fromJson(needs.compile-tests-list.outputs.matrix) }}
+    steps:
+      - name: Check out code from GitHub
+        uses: actions/checkout@v4.1.1
+      - name: Restore Python
+        uses: ./.github/actions/restore-python
+        with:
+          python-version: ${{ env.DEFAULT_PYTHON }}
+          cache-key: ${{ needs.common.outputs.cache-key }}
+      - name: Run esphome config ${{ matrix.file }}
+        run: |
+          . venv/bin/activate
+          esphome config ${{ matrix.file }}
 
-  # compile-tests:
-  #   name: Run YAML test ${{ matrix.file }}
-  #   runs-on: ubuntu-latest
-  #   needs:
-  #     - common
-  #     - black
-  #     - ci-custom
-  #     - clang-format
-  #     - flake8
-  #     - pylint
-  #     - pytest
-  #     - pyupgrade
-  #     - compile-tests-list
-  #     - validate-tests
-  #   strategy:
-  #     fail-fast: false
-  #     max-parallel: 2
-  #     matrix:
-  #       file: ${{ fromJson(needs.compile-tests-list.outputs.matrix) }}
-  #   steps:
-  #     - name: Check out code from GitHub
-  #       uses: actions/checkout@v4.1.1
-  #     - name: Restore Python
-  #       uses: ./.github/actions/restore-python
-  #       with:
-  #         python-version: ${{ env.DEFAULT_PYTHON }}
-  #         cache-key: ${{ needs.common.outputs.cache-key }}
-  #     - name: Run esphome compile ${{ matrix.file }}
-  #       run: |
-  #         . venv/bin/activate
-  #         esphome compile ${{ matrix.file }}
+  compile-tests:
+    name: Run YAML test ${{ matrix.file }}
+    runs-on: ubuntu-latest
+    needs:
+      - common
+      - black
+      - ci-custom
+      - clang-format
+      - flake8
+      - pylint
+      - pytest
+      - pyupgrade
+      - compile-tests-list
+      - validate-tests
+    strategy:
+      fail-fast: false
+      max-parallel: 2
+      matrix:
+        file: ${{ fromJson(needs.compile-tests-list.outputs.matrix) }}
+    steps:
+      - name: Check out code from GitHub
+        uses: actions/checkout@v4.1.1
+      - name: Restore Python
+        uses: ./.github/actions/restore-python
+        with:
+          python-version: ${{ env.DEFAULT_PYTHON }}
+          cache-key: ${{ needs.common.outputs.cache-key }}
+      - name: Run esphome compile ${{ matrix.file }}
+        run: |
+          . venv/bin/activate
+          esphome compile ${{ matrix.file }}
 
-  # clang-tidy:
-  #   name: ${{ matrix.name }}
-  #   runs-on: ubuntu-latest
-  #   needs:
-  #     - common
-  #     - black
-  #     - ci-custom
-  #     - clang-format
-  #     - flake8
-  #     - pylint
-  #     - pytest
-  #     - pyupgrade
-  #   strategy:
-  #     fail-fast: false
-  #     max-parallel: 2
-  #     matrix:
-  #       include:
-  #         - id: clang-tidy
-  #           name: Run script/clang-tidy for ESP8266
-  #           options: --environment esp8266-arduino-tidy --grep USE_ESP8266
-  #           pio_cache_key: tidyesp8266
-  #         - id: clang-tidy
-  #           name: Run script/clang-tidy for ESP32 Arduino 1/4
-  #           options: --environment esp32-arduino-tidy --split-num 4 --split-at 1
-  #           pio_cache_key: tidyesp32
-  #         - id: clang-tidy
-  #           name: Run script/clang-tidy for ESP32 Arduino 2/4
-  #           options: --environment esp32-arduino-tidy --split-num 4 --split-at 2
-  #           pio_cache_key: tidyesp32
-  #         - id: clang-tidy
-  #           name: Run script/clang-tidy for ESP32 Arduino 3/4
-  #           options: --environment esp32-arduino-tidy --split-num 4 --split-at 3
-  #           pio_cache_key: tidyesp32
-  #         - id: clang-tidy
-  #           name: Run script/clang-tidy for ESP32 Arduino 4/4
-  #           options: --environment esp32-arduino-tidy --split-num 4 --split-at 4
-  #           pio_cache_key: tidyesp32
-  #         - id: clang-tidy
-  #           name: Run script/clang-tidy for ESP32 IDF
-  #           options: --environment esp32-idf-tidy --grep USE_ESP_IDF
-  #           pio_cache_key: tidyesp32-idf
+  clang-tidy:
+    name: ${{ matrix.name }}
+    runs-on: ubuntu-latest
+    needs:
+      - common
+      - black
+      - ci-custom
+      - clang-format
+      - flake8
+      - pylint
+      - pytest
+      - pyupgrade
+    strategy:
+      fail-fast: false
+      max-parallel: 2
+      matrix:
+        include:
+          - id: clang-tidy
+            name: Run script/clang-tidy for ESP8266
+            options: --environment esp8266-arduino-tidy --grep USE_ESP8266
+            pio_cache_key: tidyesp8266
+          - id: clang-tidy
+            name: Run script/clang-tidy for ESP32 Arduino 1/4
+            options: --environment esp32-arduino-tidy --split-num 4 --split-at 1
+            pio_cache_key: tidyesp32
+          - id: clang-tidy
+            name: Run script/clang-tidy for ESP32 Arduino 2/4
+            options: --environment esp32-arduino-tidy --split-num 4 --split-at 2
+            pio_cache_key: tidyesp32
+          - id: clang-tidy
+            name: Run script/clang-tidy for ESP32 Arduino 3/4
+            options: --environment esp32-arduino-tidy --split-num 4 --split-at 3
+            pio_cache_key: tidyesp32
+          - id: clang-tidy
+            name: Run script/clang-tidy for ESP32 Arduino 4/4
+            options: --environment esp32-arduino-tidy --split-num 4 --split-at 4
+            pio_cache_key: tidyesp32
+          - id: clang-tidy
+            name: Run script/clang-tidy for ESP32 IDF
+            options: --environment esp32-idf-tidy --grep USE_ESP_IDF
+            pio_cache_key: tidyesp32-idf
 
-  #   steps:
-  #     - name: Check out code from GitHub
-  #       uses: actions/checkout@v4.1.1
-  #     - name: Restore Python
-  #       uses: ./.github/actions/restore-python
-  #       with:
-  #         python-version: ${{ env.DEFAULT_PYTHON }}
-  #         cache-key: ${{ needs.common.outputs.cache-key }}
-  #     - name: Cache platformio
-  #       uses: actions/cache@v4.0.2
-  #       with:
-  #         path: ~/.platformio
-  #         # yamllint disable-line rule:line-length
-  #         key: platformio-${{ matrix.pio_cache_key }}-${{ hashFiles('platformio.ini') }}
+    steps:
+      - name: Check out code from GitHub
+        uses: actions/checkout@v4.1.1
+      - name: Restore Python
+        uses: ./.github/actions/restore-python
+        with:
+          python-version: ${{ env.DEFAULT_PYTHON }}
+          cache-key: ${{ needs.common.outputs.cache-key }}
+      - name: Cache platformio
+        uses: actions/cache@v4.0.2
+        with:
+          path: ~/.platformio
+          # yamllint disable-line rule:line-length
+          key: platformio-${{ matrix.pio_cache_key }}-${{ hashFiles('platformio.ini') }}
 
-  #     - name: Install clang-tidy
-  #       run: sudo apt-get install clang-tidy-14
+      - name: Install clang-tidy
+        run: sudo apt-get install clang-tidy-14
 
-  #     - name: Register problem matchers
-  #       run: |
-  #         echo "::add-matcher::.github/workflows/matchers/gcc.json"
-  #         echo "::add-matcher::.github/workflows/matchers/clang-tidy.json"
+      - name: Register problem matchers
+        run: |
+          echo "::add-matcher::.github/workflows/matchers/gcc.json"
+          echo "::add-matcher::.github/workflows/matchers/clang-tidy.json"
 
-  #     - name: Run clang-tidy
-  #       run: |
-  #         . venv/bin/activate
-  #         script/clang-tidy --all-headers --fix ${{ matrix.options }}
-  #       env:
-  #         # Also cache libdeps, store them in a ~/.platformio subfolder
-  #         PLATFORMIO_LIBDEPS_DIR: ~/.platformio/libdeps
+      - name: Run clang-tidy
+        run: |
+          . venv/bin/activate
+          script/clang-tidy --all-headers --fix ${{ matrix.options }}
+        env:
+          # Also cache libdeps, store them in a ~/.platformio subfolder
+          PLATFORMIO_LIBDEPS_DIR: ~/.platformio/libdeps
 
-  #     - name: Suggested changes
-  #       run: script/ci-suggest-changes
-  #       # yamllint disable-line rule:line-length
-  #       if: always()
+      - name: Suggested changes
+        run: script/ci-suggest-changes
+        # yamllint disable-line rule:line-length
+        if: always()
 
   list-components:
     runs-on: ubuntu-latest
@@ -528,15 +528,15 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - common
-      # - black
-      # - ci-custom
-      # - clang-format
-      # - flake8
-      # - pylint
-      # - pytest
-      # - pyupgrade
-      # - compile-tests
-      # - clang-tidy
+      - black
+      - ci-custom
+      - clang-format
+      - flake8
+      - pylint
+      - pytest
+      - pyupgrade
+      - compile-tests
+      - clang-tidy
       - list-components
       - test-build-components
       - test-build-components-splitter

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -424,8 +424,8 @@ jobs:
         run: |
           . venv/bin/activate
           components=$(script/list-components.py --changed --branch ${{ steps.target-branch.outputs.branch }})
-          output_components=$(echo "$components" | jq -R -s -c 'split("\n")[:-1] | map(select(length > 0))')"
-          count=$(echo "$output_components" | jq length)"
+          output_components=$(echo "$components" | jq -R -s -c 'split("\n")[:-1] | map(select(length > 0))')
+          count=$(echo "$output_components" | jq length)
 
           echo "components=$output_components" >> $GITHUB_OUTPUT
           echo "count=$count" >> $GITHUB_OUTPUT

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -518,31 +518,31 @@ jobs:
             ./script/test_build_components -e compile -c $component
           done
 
-  # ci-status:
-  #   name: CI Status
-  #   runs-on: ubuntu-latest
-  #   needs:
-  #     - common
-  #     - black
-  #     - ci-custom
-  #     - clang-format
-  #     - flake8
-  #     - pylint
-  #     - pytest
-  #     - pyupgrade
-  #     - compile-tests
-  #     - clang-tidy
-  #     - test-build-components
-  #     - list-components
-  #   if: always()
-  #   steps:
-  #     - name: Success
-  #       if: ${{ !(contains(needs.*.result, 'failure')) }}
-  #       run: exit 0
-  #     - name: Failure
-  #       if: ${{ contains(needs.*.result, 'failure') }}
-  #       env:
-  #         JSON_DOC: ${{ toJSON(needs) }}
-  #       run: |
-  #         echo $JSON_DOC | jq
-  #         exit 1
+  ci-status:
+    name: CI Status
+    runs-on: ubuntu-latest
+    needs:
+      - common
+      # - black
+      # - ci-custom
+      # - clang-format
+      # - flake8
+      # - pylint
+      # - pytest
+      # - pyupgrade
+      # - compile-tests
+      # - clang-tidy
+      # - test-build-components
+      - list-components
+    if: always()
+    steps:
+      - name: Success
+        if: ${{ !(contains(needs.*.result, 'failure')) }}
+        run: exit 0
+      - name: Failure
+        if: ${{ contains(needs.*.result, 'failure') }}
+        env:
+          JSON_DOC: ${{ toJSON(needs) }}
+        run: |
+          echo $JSON_DOC | jq
+          exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -424,11 +424,14 @@ jobs:
         run: |
           . venv/bin/activate
           components=$(script/list-components.py --changed --branch ${{ steps.target-branch.outputs.branch }})
-          count=$(echo "$components" | wc -l)
-          echo "components=$(echo "$components" | jq -R -s -c 'split("\n")[:-1]')" >> $GITHUB_OUTPUT
+          output_components=$(echo "$components" | jq -R -s -c 'split("\n")[:-1] | map(select(length > 0))')"
+          count=$(echo "$output_components" | jq length)"
+
+          echo "components=$output_components" >> $GITHUB_OUTPUT
           echo "count=$count" >> $GITHUB_OUTPUT
 
-          echo "$components" | jq -R -s 'split("\n")[:-1]'
+          echo "$count Components:"
+          echo "$output_components" | jq
 
   test-build-components:
     name: Component test ${{ matrix.file }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -439,7 +439,7 @@ jobs:
     needs:
       - common
       - list-components
-    if: github.event_name == 'pull_request' && needs.list-components.outputs.count > 0 && needs.list-components.outputs.count < 100
+    if: github.event_name == 'pull_request' && fromJSON(needs.list-components.outputs.count) > 0 && fromJSON(needs.list-components.outputs.count) < 100
     strategy:
       fail-fast: false
       max-parallel: 2
@@ -471,7 +471,7 @@ jobs:
     needs:
       - common
       - list-components
-    if: github.event_name == 'pull_request' && needs.list-components.outputs.count >= 100
+    if: github.event_name == 'pull_request' && fromJSON(needs.list-components.outputs.count) >= 100
     outputs:
       matrix: ${{ steps.split.outputs.components }}
     steps:
@@ -490,7 +490,7 @@ jobs:
       - common
       - list-components
       - test-build-components-splitter
-    if: github.event_name == 'pull_request' && needs.list-components.outputs.count >= 100
+    if: github.event_name == 'pull_request' && fromJSON(needs.list-components.outputs.count) >= 100
     strategy:
       fail-fast: false
       max-parallel: 4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -434,7 +434,7 @@ jobs:
     needs:
       - common
       - list-components
-    if: github.event_name == 'pull_request' && needs.list-components.outputs.count < 100
+    if: github.event_name == 'pull_request' && needs.list-components.outputs.count > 0 && needs.list-components.outputs.count < 100
     strategy:
       fail-fast: false
       max-parallel: 2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -480,7 +480,7 @@ jobs:
       - name: Split components into 20 groups
         id: split
         run: |
-          components=$(echo "${{ needs.list-components.outputs.components }}" | jq -c '.[]' | shuf | jq -s -c '[_nwise(20) | join(" ")]')
+          components=$(echo '${{ needs.list-components.outputs.components }}' | jq -c '.[]' | shuf | jq -s -c '[_nwise(20) | join(" ")]')
           echo "components=$components" >> $GITHUB_OUTPUT
 
   test-build-components-split:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -428,6 +428,8 @@ jobs:
           echo "components=$(echo "$components" | jq -R -s -c 'split("\n")[:-1]')" >> $GITHUB_OUTPUT
           echo "count=$count" >> $GITHUB_OUTPUT
 
+          echo "$components" | jq -R -s 'split("\n")[:-1]'
+
   test-build-components:
     name: Component test ${{ matrix.file }}
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -537,8 +537,10 @@ jobs:
       # - pyupgrade
       # - compile-tests
       # - clang-tidy
-      # - test-build-components
       - list-components
+      - test-build-components
+      - test-build-components-splitter
+      - test-build-components-split
     if: always()
     steps:
       - name: Success

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -398,7 +398,8 @@ jobs:
       - common
     if: github.event_name == 'pull_request'
     outputs:
-      matrix: ${{ steps.set-matrix.outputs.matrix }}
+      components: ${{ steps.list-components.outputs.components }}
+      count: ${{ steps.list-components.outputs.count }}
     steps:
       - name: Check out code from GitHub
         uses: actions/checkout@v4.1.1
@@ -419,10 +420,13 @@ jobs:
           python-version: ${{ env.DEFAULT_PYTHON }}
           cache-key: ${{ needs.common.outputs.cache-key }}
       - name: Find changed components
-        id: set-matrix
+        id: list-components
         run: |
           . venv/bin/activate
-          echo "matrix=$(script/list-components.py --changed --branch ${{ steps.target-branch.outputs.branch }} | jq -R -s -c 'split("\n")[:-1]')" >> $GITHUB_OUTPUT
+          components=$(script/list-components.py --changed --branch ${{ steps.target-branch.outputs.branch }})
+          count=$(echo "$components" | wc -l)
+          echo "components=$(echo "$components" | jq -R -s -c 'split("\n")[:-1]')" >> $GITHUB_OUTPUT
+          echo "count=$count" >> $GITHUB_OUTPUT
 
   test-build-components:
     name: Component test ${{ matrix.file }}
@@ -430,12 +434,12 @@ jobs:
     needs:
       - common
       - list-components
-    if: ${{ github.event_name == 'pull_request' && needs.list-components.outputs.matrix != '[]' && needs.list-components.outputs.matrix != '' }}
+    if: github.event_name == 'pull_request' && needs.list-components.outputs.count < 100
     strategy:
       fail-fast: false
       max-parallel: 2
       matrix:
-        file: ${{ fromJson(needs.list-components.outputs.matrix) }}
+        file: ${{ fromJson(needs.list-components.outputs.components) }}
     steps:
       - name: Install libsodium
         run: sudo apt-get install libsodium-dev
@@ -455,6 +459,64 @@ jobs:
         run: |
           . venv/bin/activate
           ./script/test_build_components -e compile -c ${{ matrix.file }}
+
+  test-build-components-splitter:
+    name: Split components for testing into 20 groups maximum
+    runs-on: ubuntu-latest
+    needs:
+      - common
+      - list-components
+    if: github.event_name == 'pull_request' && needs.list-components.outputs.count >= 100
+    outputs:
+      matrix: ${{ steps.split.outputs.components }}
+    steps:
+      - name: Check out code from GitHub
+        uses: actions/checkout@v4.1.1
+      - name: Split components into 20 groups
+        id: split
+        run: |
+          components=$(echo "${{ needs.list-components.outputs.components }}" | jq -c '.[]' | shuf | jq -s -c '[_nwise(20) | join(" ")]')
+          echo "components=$components" >> $GITHUB_OUTPUT
+
+  test-build-components-split:
+    name: Test split components
+    runs-on: ubuntu-latest
+    needs:
+      - common
+      - list-components
+      - test-build-components-splitter
+    if: github.event_name == 'pull_request' && needs.list-components.outputs.count >= 100
+    strategy:
+      fail-fast: false
+      max-parallel: 4
+      matrix:
+        components: ${{ fromJson(needs.test-build-components-splitter.outputs.matrix) }}
+    steps:
+      - name: List components
+        run: echo ${{ matrix.components }}
+
+      - name: Install libsodium
+        run: sudo apt-get install libsodium-dev
+
+      - name: Check out code from GitHub
+        uses: actions/checkout@v4.1.1
+      - name: Restore Python
+        uses: ./.github/actions/restore-python
+        with:
+          python-version: ${{ env.DEFAULT_PYTHON }}
+          cache-key: ${{ needs.common.outputs.cache-key }}
+      - name: Validate config
+        run: |
+          . venv/bin/activate
+          for component in ${{ matrix.components }}; do
+            ./script/test_build_components -e config -c $component
+          done
+      - name: Compile config
+        run: |
+          . venv/bin/activate
+          for component in ${{ matrix.components }}; do
+            ./script/test_build_components -e compile -c $component
+          done
 
   ci-status:
     name: CI Status

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,338 +59,338 @@ jobs:
           pip install -r requirements.txt -r requirements_optional.txt -r requirements_test.txt
           pip install -e .
 
-  black:
-    name: Check black
-    runs-on: ubuntu-latest
-    needs:
-      - common
-    steps:
-      - name: Check out code from GitHub
-        uses: actions/checkout@v4.1.1
-      - name: Restore Python
-        uses: ./.github/actions/restore-python
-        with:
-          python-version: ${{ env.DEFAULT_PYTHON }}
-          cache-key: ${{ needs.common.outputs.cache-key }}
-      - name: Run black
-        run: |
-          . venv/bin/activate
-          black --verbose esphome tests
-      - name: Suggested changes
-        run: script/ci-suggest-changes
-        if: always()
+  # black:
+  #   name: Check black
+  #   runs-on: ubuntu-latest
+  #   needs:
+  #     - common
+  #   steps:
+  #     - name: Check out code from GitHub
+  #       uses: actions/checkout@v4.1.1
+  #     - name: Restore Python
+  #       uses: ./.github/actions/restore-python
+  #       with:
+  #         python-version: ${{ env.DEFAULT_PYTHON }}
+  #         cache-key: ${{ needs.common.outputs.cache-key }}
+  #     - name: Run black
+  #       run: |
+  #         . venv/bin/activate
+  #         black --verbose esphome tests
+  #     - name: Suggested changes
+  #       run: script/ci-suggest-changes
+  #       if: always()
 
-  flake8:
-    name: Check flake8
-    runs-on: ubuntu-latest
-    needs:
-      - common
-    steps:
-      - name: Check out code from GitHub
-        uses: actions/checkout@v4.1.1
-      - name: Restore Python
-        uses: ./.github/actions/restore-python
-        with:
-          python-version: ${{ env.DEFAULT_PYTHON }}
-          cache-key: ${{ needs.common.outputs.cache-key }}
-      - name: Run flake8
-        run: |
-          . venv/bin/activate
-          flake8 esphome
-      - name: Suggested changes
-        run: script/ci-suggest-changes
-        if: always()
+  # flake8:
+  #   name: Check flake8
+  #   runs-on: ubuntu-latest
+  #   needs:
+  #     - common
+  #   steps:
+  #     - name: Check out code from GitHub
+  #       uses: actions/checkout@v4.1.1
+  #     - name: Restore Python
+  #       uses: ./.github/actions/restore-python
+  #       with:
+  #         python-version: ${{ env.DEFAULT_PYTHON }}
+  #         cache-key: ${{ needs.common.outputs.cache-key }}
+  #     - name: Run flake8
+  #       run: |
+  #         . venv/bin/activate
+  #         flake8 esphome
+  #     - name: Suggested changes
+  #       run: script/ci-suggest-changes
+  #       if: always()
 
-  pylint:
-    name: Check pylint
-    runs-on: ubuntu-latest
-    needs:
-      - common
-    steps:
-      - name: Check out code from GitHub
-        uses: actions/checkout@v4.1.1
-      - name: Restore Python
-        uses: ./.github/actions/restore-python
-        with:
-          python-version: ${{ env.DEFAULT_PYTHON }}
-          cache-key: ${{ needs.common.outputs.cache-key }}
-      - name: Run pylint
-        run: |
-          . venv/bin/activate
-          pylint -f parseable --persistent=n esphome
-      - name: Suggested changes
-        run: script/ci-suggest-changes
-        if: always()
+  # pylint:
+  #   name: Check pylint
+  #   runs-on: ubuntu-latest
+  #   needs:
+  #     - common
+  #   steps:
+  #     - name: Check out code from GitHub
+  #       uses: actions/checkout@v4.1.1
+  #     - name: Restore Python
+  #       uses: ./.github/actions/restore-python
+  #       with:
+  #         python-version: ${{ env.DEFAULT_PYTHON }}
+  #         cache-key: ${{ needs.common.outputs.cache-key }}
+  #     - name: Run pylint
+  #       run: |
+  #         . venv/bin/activate
+  #         pylint -f parseable --persistent=n esphome
+  #     - name: Suggested changes
+  #       run: script/ci-suggest-changes
+  #       if: always()
 
-  pyupgrade:
-    name: Check pyupgrade
-    runs-on: ubuntu-latest
-    needs:
-      - common
-    steps:
-      - name: Check out code from GitHub
-        uses: actions/checkout@v4.1.1
-      - name: Restore Python
-        uses: ./.github/actions/restore-python
-        with:
-          python-version: ${{ env.DEFAULT_PYTHON }}
-          cache-key: ${{ needs.common.outputs.cache-key }}
-      - name: Run pyupgrade
-        run: |
-          . venv/bin/activate
-          pyupgrade ${{ env.PYUPGRADE_TARGET }} `find esphome -name "*.py" -type f`
-      - name: Suggested changes
-        run: script/ci-suggest-changes
-        if: always()
+  # pyupgrade:
+  #   name: Check pyupgrade
+  #   runs-on: ubuntu-latest
+  #   needs:
+  #     - common
+  #   steps:
+  #     - name: Check out code from GitHub
+  #       uses: actions/checkout@v4.1.1
+  #     - name: Restore Python
+  #       uses: ./.github/actions/restore-python
+  #       with:
+  #         python-version: ${{ env.DEFAULT_PYTHON }}
+  #         cache-key: ${{ needs.common.outputs.cache-key }}
+  #     - name: Run pyupgrade
+  #       run: |
+  #         . venv/bin/activate
+  #         pyupgrade ${{ env.PYUPGRADE_TARGET }} `find esphome -name "*.py" -type f`
+  #     - name: Suggested changes
+  #       run: script/ci-suggest-changes
+  #       if: always()
 
-  ci-custom:
-    name: Run script/ci-custom
-    runs-on: ubuntu-latest
-    needs:
-      - common
-    steps:
-      - name: Check out code from GitHub
-        uses: actions/checkout@v4.1.1
-      - name: Restore Python
-        uses: ./.github/actions/restore-python
-        with:
-          python-version: ${{ env.DEFAULT_PYTHON }}
-          cache-key: ${{ needs.common.outputs.cache-key }}
-      - name: Register matcher
-        run: echo "::add-matcher::.github/workflows/matchers/ci-custom.json"
-      - name: Run script/ci-custom
-        run: |
-          . venv/bin/activate
-          script/ci-custom.py
-          script/build_codeowners.py --check
+  # ci-custom:
+  #   name: Run script/ci-custom
+  #   runs-on: ubuntu-latest
+  #   needs:
+  #     - common
+  #   steps:
+  #     - name: Check out code from GitHub
+  #       uses: actions/checkout@v4.1.1
+  #     - name: Restore Python
+  #       uses: ./.github/actions/restore-python
+  #       with:
+  #         python-version: ${{ env.DEFAULT_PYTHON }}
+  #         cache-key: ${{ needs.common.outputs.cache-key }}
+  #     - name: Register matcher
+  #       run: echo "::add-matcher::.github/workflows/matchers/ci-custom.json"
+  #     - name: Run script/ci-custom
+  #       run: |
+  #         . venv/bin/activate
+  #         script/ci-custom.py
+  #         script/build_codeowners.py --check
 
-  pytest:
-    name: Run pytest
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version:
-          - "3.9"
-          - "3.10"
-          - "3.11"
-          - "3.12"
-        os:
-          - ubuntu-latest
-          - macOS-latest
-          - windows-latest
-        exclude:
-          # Minimize CI resource usage
-          # by only running the Python version
-          # version used for docker images on Windows and macOS
-          - python-version: "3.12"
-            os: windows-latest
-          - python-version: "3.10"
-            os: windows-latest
-          - python-version: "3.9"
-            os: windows-latest
-          - python-version: "3.12"
-            os: macOS-latest
-          - python-version: "3.10"
-            os: macOS-latest
-          - python-version: "3.9"
-            os: macOS-latest
-    runs-on: ${{ matrix.os }}
-    needs:
-      - common
-    steps:
-      - name: Check out code from GitHub
-        uses: actions/checkout@v4.1.1
-      - name: Restore Python
-        uses: ./.github/actions/restore-python
-        with:
-          python-version: ${{ matrix.python-version }}
-          cache-key: ${{ needs.common.outputs.cache-key }}
-      - name: Register matcher
-        run: echo "::add-matcher::.github/workflows/matchers/pytest.json"
-      - name: Run pytest
-        if: matrix.os == 'windows-latest'
-        run: |
-          ./venv/Scripts/activate
-          pytest -vv --cov-report=xml --tb=native tests
-      - name: Run pytest
-        if: matrix.os == 'ubuntu-latest' || matrix.os == 'macOS-latest'
-        run: |
-          . venv/bin/activate
-          pytest -vv --cov-report=xml --tb=native tests
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+  # pytest:
+  #   name: Run pytest
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       python-version:
+  #         - "3.9"
+  #         - "3.10"
+  #         - "3.11"
+  #         - "3.12"
+  #       os:
+  #         - ubuntu-latest
+  #         - macOS-latest
+  #         - windows-latest
+  #       exclude:
+  #         # Minimize CI resource usage
+  #         # by only running the Python version
+  #         # version used for docker images on Windows and macOS
+  #         - python-version: "3.12"
+  #           os: windows-latest
+  #         - python-version: "3.10"
+  #           os: windows-latest
+  #         - python-version: "3.9"
+  #           os: windows-latest
+  #         - python-version: "3.12"
+  #           os: macOS-latest
+  #         - python-version: "3.10"
+  #           os: macOS-latest
+  #         - python-version: "3.9"
+  #           os: macOS-latest
+  #   runs-on: ${{ matrix.os }}
+  #   needs:
+  #     - common
+  #   steps:
+  #     - name: Check out code from GitHub
+  #       uses: actions/checkout@v4.1.1
+  #     - name: Restore Python
+  #       uses: ./.github/actions/restore-python
+  #       with:
+  #         python-version: ${{ matrix.python-version }}
+  #         cache-key: ${{ needs.common.outputs.cache-key }}
+  #     - name: Register matcher
+  #       run: echo "::add-matcher::.github/workflows/matchers/pytest.json"
+  #     - name: Run pytest
+  #       if: matrix.os == 'windows-latest'
+  #       run: |
+  #         ./venv/Scripts/activate
+  #         pytest -vv --cov-report=xml --tb=native tests
+  #     - name: Run pytest
+  #       if: matrix.os == 'ubuntu-latest' || matrix.os == 'macOS-latest'
+  #       run: |
+  #         . venv/bin/activate
+  #         pytest -vv --cov-report=xml --tb=native tests
+  #     - name: Upload coverage to Codecov
+  #       uses: codecov/codecov-action@v4
+  #       with:
+  #         token: ${{ secrets.CODECOV_TOKEN }}
 
-  clang-format:
-    name: Check clang-format
-    runs-on: ubuntu-latest
-    needs:
-      - common
-    steps:
-      - name: Check out code from GitHub
-        uses: actions/checkout@v4.1.1
-      - name: Restore Python
-        uses: ./.github/actions/restore-python
-        with:
-          python-version: ${{ env.DEFAULT_PYTHON }}
-          cache-key: ${{ needs.common.outputs.cache-key }}
-      - name: Install clang-format
-        run: |
-          . venv/bin/activate
-          pip install clang-format -c requirements_dev.txt
-      - name: Run clang-format
-        run: |
-          . venv/bin/activate
-          script/clang-format -i
-          git diff-index --quiet HEAD --
-      - name: Suggested changes
-        run: script/ci-suggest-changes
-        if: always()
+  # clang-format:
+  #   name: Check clang-format
+  #   runs-on: ubuntu-latest
+  #   needs:
+  #     - common
+  #   steps:
+  #     - name: Check out code from GitHub
+  #       uses: actions/checkout@v4.1.1
+  #     - name: Restore Python
+  #       uses: ./.github/actions/restore-python
+  #       with:
+  #         python-version: ${{ env.DEFAULT_PYTHON }}
+  #         cache-key: ${{ needs.common.outputs.cache-key }}
+  #     - name: Install clang-format
+  #       run: |
+  #         . venv/bin/activate
+  #         pip install clang-format -c requirements_dev.txt
+  #     - name: Run clang-format
+  #       run: |
+  #         . venv/bin/activate
+  #         script/clang-format -i
+  #         git diff-index --quiet HEAD --
+  #     - name: Suggested changes
+  #       run: script/ci-suggest-changes
+  #       if: always()
 
-  compile-tests-list:
-    runs-on: ubuntu-latest
-    outputs:
-      matrix: ${{ steps.set-matrix.outputs.matrix }}
-    steps:
-      - name: Check out code from GitHub
-        uses: actions/checkout@v4.1.1
-      - name: Find all YAML test files
-        id: set-matrix
-        run: echo "matrix=$(ls tests/test*.yaml | jq -R -s -c 'split("\n")[:-1]')" >> $GITHUB_OUTPUT
+  # compile-tests-list:
+  #   runs-on: ubuntu-latest
+  #   outputs:
+  #     matrix: ${{ steps.set-matrix.outputs.matrix }}
+  #   steps:
+  #     - name: Check out code from GitHub
+  #       uses: actions/checkout@v4.1.1
+  #     - name: Find all YAML test files
+  #       id: set-matrix
+  #       run: echo "matrix=$(ls tests/test*.yaml | jq -R -s -c 'split("\n")[:-1]')" >> $GITHUB_OUTPUT
 
-  validate-tests:
-    name: Validate YAML test ${{ matrix.file }}
-    runs-on: ubuntu-latest
-    needs:
-      - common
-      - compile-tests-list
-    strategy:
-      fail-fast: false
-      matrix:
-        file: ${{ fromJson(needs.compile-tests-list.outputs.matrix) }}
-    steps:
-      - name: Check out code from GitHub
-        uses: actions/checkout@v4.1.1
-      - name: Restore Python
-        uses: ./.github/actions/restore-python
-        with:
-          python-version: ${{ env.DEFAULT_PYTHON }}
-          cache-key: ${{ needs.common.outputs.cache-key }}
-      - name: Run esphome config ${{ matrix.file }}
-        run: |
-          . venv/bin/activate
-          esphome config ${{ matrix.file }}
+  # validate-tests:
+  #   name: Validate YAML test ${{ matrix.file }}
+  #   runs-on: ubuntu-latest
+  #   needs:
+  #     - common
+  #     - compile-tests-list
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       file: ${{ fromJson(needs.compile-tests-list.outputs.matrix) }}
+  #   steps:
+  #     - name: Check out code from GitHub
+  #       uses: actions/checkout@v4.1.1
+  #     - name: Restore Python
+  #       uses: ./.github/actions/restore-python
+  #       with:
+  #         python-version: ${{ env.DEFAULT_PYTHON }}
+  #         cache-key: ${{ needs.common.outputs.cache-key }}
+  #     - name: Run esphome config ${{ matrix.file }}
+  #       run: |
+  #         . venv/bin/activate
+  #         esphome config ${{ matrix.file }}
 
-  compile-tests:
-    name: Run YAML test ${{ matrix.file }}
-    runs-on: ubuntu-latest
-    needs:
-      - common
-      - black
-      - ci-custom
-      - clang-format
-      - flake8
-      - pylint
-      - pytest
-      - pyupgrade
-      - compile-tests-list
-      - validate-tests
-    strategy:
-      fail-fast: false
-      max-parallel: 2
-      matrix:
-        file: ${{ fromJson(needs.compile-tests-list.outputs.matrix) }}
-    steps:
-      - name: Check out code from GitHub
-        uses: actions/checkout@v4.1.1
-      - name: Restore Python
-        uses: ./.github/actions/restore-python
-        with:
-          python-version: ${{ env.DEFAULT_PYTHON }}
-          cache-key: ${{ needs.common.outputs.cache-key }}
-      - name: Run esphome compile ${{ matrix.file }}
-        run: |
-          . venv/bin/activate
-          esphome compile ${{ matrix.file }}
+  # compile-tests:
+  #   name: Run YAML test ${{ matrix.file }}
+  #   runs-on: ubuntu-latest
+  #   needs:
+  #     - common
+  #     - black
+  #     - ci-custom
+  #     - clang-format
+  #     - flake8
+  #     - pylint
+  #     - pytest
+  #     - pyupgrade
+  #     - compile-tests-list
+  #     - validate-tests
+  #   strategy:
+  #     fail-fast: false
+  #     max-parallel: 2
+  #     matrix:
+  #       file: ${{ fromJson(needs.compile-tests-list.outputs.matrix) }}
+  #   steps:
+  #     - name: Check out code from GitHub
+  #       uses: actions/checkout@v4.1.1
+  #     - name: Restore Python
+  #       uses: ./.github/actions/restore-python
+  #       with:
+  #         python-version: ${{ env.DEFAULT_PYTHON }}
+  #         cache-key: ${{ needs.common.outputs.cache-key }}
+  #     - name: Run esphome compile ${{ matrix.file }}
+  #       run: |
+  #         . venv/bin/activate
+  #         esphome compile ${{ matrix.file }}
 
-  clang-tidy:
-    name: ${{ matrix.name }}
-    runs-on: ubuntu-latest
-    needs:
-      - common
-      - black
-      - ci-custom
-      - clang-format
-      - flake8
-      - pylint
-      - pytest
-      - pyupgrade
-    strategy:
-      fail-fast: false
-      max-parallel: 2
-      matrix:
-        include:
-          - id: clang-tidy
-            name: Run script/clang-tidy for ESP8266
-            options: --environment esp8266-arduino-tidy --grep USE_ESP8266
-            pio_cache_key: tidyesp8266
-          - id: clang-tidy
-            name: Run script/clang-tidy for ESP32 Arduino 1/4
-            options: --environment esp32-arduino-tidy --split-num 4 --split-at 1
-            pio_cache_key: tidyesp32
-          - id: clang-tidy
-            name: Run script/clang-tidy for ESP32 Arduino 2/4
-            options: --environment esp32-arduino-tidy --split-num 4 --split-at 2
-            pio_cache_key: tidyesp32
-          - id: clang-tidy
-            name: Run script/clang-tidy for ESP32 Arduino 3/4
-            options: --environment esp32-arduino-tidy --split-num 4 --split-at 3
-            pio_cache_key: tidyesp32
-          - id: clang-tidy
-            name: Run script/clang-tidy for ESP32 Arduino 4/4
-            options: --environment esp32-arduino-tidy --split-num 4 --split-at 4
-            pio_cache_key: tidyesp32
-          - id: clang-tidy
-            name: Run script/clang-tidy for ESP32 IDF
-            options: --environment esp32-idf-tidy --grep USE_ESP_IDF
-            pio_cache_key: tidyesp32-idf
+  # clang-tidy:
+  #   name: ${{ matrix.name }}
+  #   runs-on: ubuntu-latest
+  #   needs:
+  #     - common
+  #     - black
+  #     - ci-custom
+  #     - clang-format
+  #     - flake8
+  #     - pylint
+  #     - pytest
+  #     - pyupgrade
+  #   strategy:
+  #     fail-fast: false
+  #     max-parallel: 2
+  #     matrix:
+  #       include:
+  #         - id: clang-tidy
+  #           name: Run script/clang-tidy for ESP8266
+  #           options: --environment esp8266-arduino-tidy --grep USE_ESP8266
+  #           pio_cache_key: tidyesp8266
+  #         - id: clang-tidy
+  #           name: Run script/clang-tidy for ESP32 Arduino 1/4
+  #           options: --environment esp32-arduino-tidy --split-num 4 --split-at 1
+  #           pio_cache_key: tidyesp32
+  #         - id: clang-tidy
+  #           name: Run script/clang-tidy for ESP32 Arduino 2/4
+  #           options: --environment esp32-arduino-tidy --split-num 4 --split-at 2
+  #           pio_cache_key: tidyesp32
+  #         - id: clang-tidy
+  #           name: Run script/clang-tidy for ESP32 Arduino 3/4
+  #           options: --environment esp32-arduino-tidy --split-num 4 --split-at 3
+  #           pio_cache_key: tidyesp32
+  #         - id: clang-tidy
+  #           name: Run script/clang-tidy for ESP32 Arduino 4/4
+  #           options: --environment esp32-arduino-tidy --split-num 4 --split-at 4
+  #           pio_cache_key: tidyesp32
+  #         - id: clang-tidy
+  #           name: Run script/clang-tidy for ESP32 IDF
+  #           options: --environment esp32-idf-tidy --grep USE_ESP_IDF
+  #           pio_cache_key: tidyesp32-idf
 
-    steps:
-      - name: Check out code from GitHub
-        uses: actions/checkout@v4.1.1
-      - name: Restore Python
-        uses: ./.github/actions/restore-python
-        with:
-          python-version: ${{ env.DEFAULT_PYTHON }}
-          cache-key: ${{ needs.common.outputs.cache-key }}
-      - name: Cache platformio
-        uses: actions/cache@v4.0.2
-        with:
-          path: ~/.platformio
-          # yamllint disable-line rule:line-length
-          key: platformio-${{ matrix.pio_cache_key }}-${{ hashFiles('platformio.ini') }}
+  #   steps:
+  #     - name: Check out code from GitHub
+  #       uses: actions/checkout@v4.1.1
+  #     - name: Restore Python
+  #       uses: ./.github/actions/restore-python
+  #       with:
+  #         python-version: ${{ env.DEFAULT_PYTHON }}
+  #         cache-key: ${{ needs.common.outputs.cache-key }}
+  #     - name: Cache platformio
+  #       uses: actions/cache@v4.0.2
+  #       with:
+  #         path: ~/.platformio
+  #         # yamllint disable-line rule:line-length
+  #         key: platformio-${{ matrix.pio_cache_key }}-${{ hashFiles('platformio.ini') }}
 
-      - name: Install clang-tidy
-        run: sudo apt-get install clang-tidy-14
+  #     - name: Install clang-tidy
+  #       run: sudo apt-get install clang-tidy-14
 
-      - name: Register problem matchers
-        run: |
-          echo "::add-matcher::.github/workflows/matchers/gcc.json"
-          echo "::add-matcher::.github/workflows/matchers/clang-tidy.json"
+  #     - name: Register problem matchers
+  #       run: |
+  #         echo "::add-matcher::.github/workflows/matchers/gcc.json"
+  #         echo "::add-matcher::.github/workflows/matchers/clang-tidy.json"
 
-      - name: Run clang-tidy
-        run: |
-          . venv/bin/activate
-          script/clang-tidy --all-headers --fix ${{ matrix.options }}
-        env:
-          # Also cache libdeps, store them in a ~/.platformio subfolder
-          PLATFORMIO_LIBDEPS_DIR: ~/.platformio/libdeps
+  #     - name: Run clang-tidy
+  #       run: |
+  #         . venv/bin/activate
+  #         script/clang-tidy --all-headers --fix ${{ matrix.options }}
+  #       env:
+  #         # Also cache libdeps, store them in a ~/.platformio subfolder
+  #         PLATFORMIO_LIBDEPS_DIR: ~/.platformio/libdeps
 
-      - name: Suggested changes
-        run: script/ci-suggest-changes
-        # yamllint disable-line rule:line-length
-        if: always()
+  #     - name: Suggested changes
+  #       run: script/ci-suggest-changes
+  #       # yamllint disable-line rule:line-length
+  #       if: always()
 
   list-components:
     runs-on: ubuntu-latest
@@ -518,31 +518,31 @@ jobs:
             ./script/test_build_components -e compile -c $component
           done
 
-  ci-status:
-    name: CI Status
-    runs-on: ubuntu-latest
-    needs:
-      - common
-      - black
-      - ci-custom
-      - clang-format
-      - flake8
-      - pylint
-      - pytest
-      - pyupgrade
-      - compile-tests
-      - clang-tidy
-      - test-build-components
-      - list-components
-    if: always()
-    steps:
-      - name: Success
-        if: ${{ !(contains(needs.*.result, 'failure')) }}
-        run: exit 0
-      - name: Failure
-        if: ${{ contains(needs.*.result, 'failure') }}
-        env:
-          JSON_DOC: ${{ toJSON(needs) }}
-        run: |
-          echo $JSON_DOC | jq
-          exit 1
+  # ci-status:
+  #   name: CI Status
+  #   runs-on: ubuntu-latest
+  #   needs:
+  #     - common
+  #     - black
+  #     - ci-custom
+  #     - clang-format
+  #     - flake8
+  #     - pylint
+  #     - pytest
+  #     - pyupgrade
+  #     - compile-tests
+  #     - clang-tidy
+  #     - test-build-components
+  #     - list-components
+  #   if: always()
+  #   steps:
+  #     - name: Success
+  #       if: ${{ !(contains(needs.*.result, 'failure')) }}
+  #       run: exit 0
+  #     - name: Failure
+  #       if: ${{ contains(needs.*.result, 'failure') }}
+  #       env:
+  #         JSON_DOC: ${{ toJSON(needs) }}
+  #       run: |
+  #         echo $JSON_DOC | jq
+  #         exit 1

--- a/esphome/components/sensor/sensor.cpp
+++ b/esphome/components/sensor/sensor.cpp
@@ -4,7 +4,7 @@
 namespace esphome {
 namespace sensor {
 
-static const char *const TAG = "sensor.testing";
+static const char *const TAG = "sensor";
 
 std::string state_class_to_string(StateClass state_class) {
   switch (state_class) {

--- a/esphome/components/sensor/sensor.cpp
+++ b/esphome/components/sensor/sensor.cpp
@@ -4,7 +4,7 @@
 namespace esphome {
 namespace sensor {
 
-static const char *const TAG = "sensor";
+static const char *const TAG = "sensor.testing";
 
 std::string state_class_to_string(StateClass state_class) {
   switch (state_class) {


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Implements alternate CI jobs for when there are too many components to test. 
For example, changing anything in the `components/sensor` folder will trigger every sensor platform, which then exceeds github workflow matrix limits. These new jobs will instead split the components into 20 random groups and test them in series there. 

In theory this is actually faster as the framework and libraries only need to be download once per group, not once per component.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
