### PR TITLE
`graphical_display_menu` requires a Display, not DisplayBuffer

### DIFF
--- a/esphome/components/graphical_display_menu/__init__.py
+++ b/esphome/components/graphical_display_menu/__init__.py
@@ -38,7 +38,7 @@ CONFIG_SCHEMA = DISPLAY_MENU_BASE_SCHEMA.extend(
     cv.Schema(
         {
             cv.GenerateID(): cv.declare_id(GraphicalDisplayMenu),
-            cv.Optional(CONF_DISPLAY): cv.use_id(display.DisplayBuffer),
+            cv.Optional(CONF_DISPLAY): cv.use_id(display.Display),
             cv.Required(CONF_FONT): cv.use_id(font.Font),
             cv.Optional(CONF_MENU_ITEM_VALUE): cv.templatable(cv.string),
             cv.Optional(CONF_FOREGROUND_COLOR): cv.use_id(color.ColorStruct),

--- a/esphome/components/graphical_display_menu/graphical_display_menu.cpp
+++ b/esphome/components/graphical_display_menu/graphical_display_menu.cpp
@@ -229,7 +229,8 @@ inline void GraphicalDisplayMenu::draw_item(display::Display *display, const dis
     label.append(this->menu_item_value_.value(&args));
   }
 
-  display->print(bounds->x, bounds->y, this->font_, foreground_color, display::TextAlign::TOP_LEFT, label.c_str());
+  display->print(bounds->x, bounds->y, this->font_, foreground_color, display::TextAlign::TOP_LEFT, label.c_str(),
+                 ~foreground_color);
 }
 
 void GraphicalDisplayMenu::draw_item(const display_menu_base::MenuItem *item, const uint8_t row, const bool selected) {

--- a/esphome/core/color.h
+++ b/esphome/core/color.h
@@ -62,6 +62,7 @@ struct Color {
     return Color(esp_scale8(this->red, scale), esp_scale8(this->green, scale), esp_scale8(this->blue, scale),
                  esp_scale8(this->white, scale));
   }
+  inline Color operator~() const ALWAYS_INLINE { return Color(255 - this->red, 255 - this->green, 255 - this->blue); }
   inline Color &operator*=(uint8_t scale) ALWAYS_INLINE {
     this->red = esp_scale8(this->red, scale);
     this->green = esp_scale8(this->green, scale);


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

The `graphical_display_menu` component config was expecting a `DisplayBuffer` when only a `Display` is needed.

Also enable `graphical_display_menu` to make effective use of anti-aliased fonts.


## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [x] Host

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
