### PR TITLE
Allow platform dependencies

### DIFF
--- a/esphome/config.py
+++ b/esphome/config.py
@@ -464,18 +464,16 @@ class MetadataValidationStep(ConfigValidationStep):
                     self.path,
                 )
                 success = False
-            elif component_dep != platform_dep:
-                # there is a platform dependency, too
-                if (
-                    not isinstance(platform_list := result.get(component_dep), list)
-                    or not any(CONF_PLATFORM in p for p in platform_list)
-                    or not any(p[CONF_PLATFORM] == platform_dep for p in platform_list)
-                ):
-                    result.add_str_error(
-                        f"Component {self.domain} requires 'platform: {platform_dep}' in component '{component_dep}'",
-                        self.path,
-                    )
-                    success = False
+            elif component_dep != platform_dep and (
+                not isinstance(platform_list := result.get(component_dep), list)
+                or not any(CONF_PLATFORM in p for p in platform_list)
+                or not any(p[CONF_PLATFORM] == platform_dep for p in platform_list)
+            ):
+                result.add_str_error(
+                    f"Component {self.domain} requires 'platform: {platform_dep}' in component '{component_dep}'",
+                    self.path,
+                )
+                success = False
         if not success:
             return
 

--- a/esphome/config.py
+++ b/esphome/config.py
@@ -374,7 +374,10 @@ class LoadValidationStep(ConfigValidationStep):
                         path + [CONF_ID],
                     )
                     continue
-                result.add_str_error("No platform specified! See 'platform' key.", path)
+                result.add_str_error(
+                    f"'{self.domain}' requires a 'platform' key but it was not specified.",
+                    path,
+                )
                 continue
             # Remove temp output path and construct new one
             result.remove_output_path(path, p_domain)

--- a/esphome/config.py
+++ b/esphome/config.py
@@ -449,9 +449,21 @@ class MetadataValidationStep(ConfigValidationStep):
 
         success = True
         for dependency in self.comp.dependencies:
-            if dependency not in result:
+            dependency_parts = dependency.split(".")
+            component_dep = dependency_parts[-1]
+            platform_dep = dependency_parts[0]
+            if component_dep not in result:
                 result.add_str_error(
-                    f"Component {self.domain} requires component {dependency}",
+                    f"Component {self.domain} requires component {component_dep}",
+                    self.path,
+                )
+                success = False
+            elif (
+                component_dep != platform_dep
+                and platform_dep not in result[component_dep]
+            ):
+                result.add_str_error(
+                    f"Component {self.domain} requires 'platform: {platform_dep}' in component '{component_dep}'",
                     self.path,
                 )
                 success = False

--- a/script/list-components.py
+++ b/script/list-components.py
@@ -69,7 +69,9 @@ def create_components_graph():
             sys.exit(1)
 
         for dependency in comp.dependencies:
-            add_item_to_components_graph(components_graph, dependency, name)
+            add_item_to_components_graph(
+                components_graph, dependency.split(".")[0], name
+            )
 
         for target_config in TARGET_CONFIGURATIONS:
             CORE.data[KEY_CORE] = target_config
@@ -87,7 +89,9 @@ def create_components_graph():
             add_item_to_components_graph(components_graph, platform_name, name)
 
             for dependency in platform.dependencies:
-                add_item_to_components_graph(components_graph, dependency, name)
+                add_item_to_components_graph(
+                    components_graph, dependency.split(".")[0], name
+                )
 
             for target_config in TARGET_CONFIGURATIONS:
                 CORE.data[KEY_CORE] = target_config


### PR DESCRIPTION
# What does this implement/fix?

Small PR that enables the ability to specify platform dependencies. For example:

```python
DEPENDENCIES = ["ota.esphome"]
```

...would require the platform `esphome` be present within the `ota` component configuration:

```yaml
ota:
  - platform: esphome
```

This enables more user-friendly validation errors should a required platform not be present.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
