### PR TITLE
[core] Rename ALWAYS_INLINE to ESPHOME_ALWAYS_INLINE

### DIFF
--- a/esphome/components/display/rect.h
+++ b/esphome/components/display/rect.h
@@ -15,11 +15,11 @@ class Rect {
   int16_t h;  ///< Height of region
 
   Rect() : x(VALUE_NO_SET), y(VALUE_NO_SET), w(VALUE_NO_SET), h(VALUE_NO_SET) {}  // NOLINT
-  inline Rect(int16_t x, int16_t y, int16_t w, int16_t h) ALWAYS_INLINE : x(x), y(y), w(w), h(h) {}
+  inline Rect(int16_t x, int16_t y, int16_t w, int16_t h) ESPHOME_ALWAYS_INLINE : x(x), y(y), w(w), h(h) {}
   inline int16_t x2() const { return this->x + this->w; };  ///< X coordinate of corner
   inline int16_t y2() const { return this->y + this->h; };  ///< Y coordinate of corner
 
-  inline bool is_set() const ALWAYS_INLINE { return (this->h != VALUE_NO_SET) && (this->w != VALUE_NO_SET); }
+  inline bool is_set() const ESPHOME_ALWAYS_INLINE { return (this->h != VALUE_NO_SET) && (this->w != VALUE_NO_SET); }
 
   void expand(int16_t horizontal, int16_t vertical);
 

--- a/esphome/components/light/esp_color_correction.h
+++ b/esphome/components/light/esp_color_correction.h
@@ -11,54 +11,54 @@ class ESPColorCorrection {
   void set_max_brightness(const Color &max_brightness) { this->max_brightness_ = max_brightness; }
   void set_local_brightness(uint8_t local_brightness) { this->local_brightness_ = local_brightness; }
   void calculate_gamma_table(float gamma);
-  inline Color color_correct(Color color) const ALWAYS_INLINE {
+  inline Color color_correct(Color color) const ESPHOME_ALWAYS_INLINE {
     // corrected = (uncorrected * max_brightness * local_brightness) ^ gamma
     return Color(this->color_correct_red(color.red), this->color_correct_green(color.green),
                  this->color_correct_blue(color.blue), this->color_correct_white(color.white));
   }
-  inline uint8_t color_correct_red(uint8_t red) const ALWAYS_INLINE {
+  inline uint8_t color_correct_red(uint8_t red) const ESPHOME_ALWAYS_INLINE {
     uint8_t res = esp_scale8(esp_scale8(red, this->max_brightness_.red), this->local_brightness_);
     return this->gamma_table_[res];
   }
-  inline uint8_t color_correct_green(uint8_t green) const ALWAYS_INLINE {
+  inline uint8_t color_correct_green(uint8_t green) const ESPHOME_ALWAYS_INLINE {
     uint8_t res = esp_scale8(esp_scale8(green, this->max_brightness_.green), this->local_brightness_);
     return this->gamma_table_[res];
   }
-  inline uint8_t color_correct_blue(uint8_t blue) const ALWAYS_INLINE {
+  inline uint8_t color_correct_blue(uint8_t blue) const ESPHOME_ALWAYS_INLINE {
     uint8_t res = esp_scale8(esp_scale8(blue, this->max_brightness_.blue), this->local_brightness_);
     return this->gamma_table_[res];
   }
-  inline uint8_t color_correct_white(uint8_t white) const ALWAYS_INLINE {
+  inline uint8_t color_correct_white(uint8_t white) const ESPHOME_ALWAYS_INLINE {
     uint8_t res = esp_scale8(esp_scale8(white, this->max_brightness_.white), this->local_brightness_);
     return this->gamma_table_[res];
   }
-  inline Color color_uncorrect(Color color) const ALWAYS_INLINE {
+  inline Color color_uncorrect(Color color) const ESPHOME_ALWAYS_INLINE {
     // uncorrected = corrected^(1/gamma) / (max_brightness * local_brightness)
     return Color(this->color_uncorrect_red(color.red), this->color_uncorrect_green(color.green),
                  this->color_uncorrect_blue(color.blue), this->color_uncorrect_white(color.white));
   }
-  inline uint8_t color_uncorrect_red(uint8_t red) const ALWAYS_INLINE {
+  inline uint8_t color_uncorrect_red(uint8_t red) const ESPHOME_ALWAYS_INLINE {
     if (this->max_brightness_.red == 0 || this->local_brightness_ == 0)
       return 0;
     uint16_t uncorrected = this->gamma_reverse_table_[red] * 255UL;
     uint8_t res = ((uncorrected / this->max_brightness_.red) * 255UL) / this->local_brightness_;
     return res;
   }
-  inline uint8_t color_uncorrect_green(uint8_t green) const ALWAYS_INLINE {
+  inline uint8_t color_uncorrect_green(uint8_t green) const ESPHOME_ALWAYS_INLINE {
     if (this->max_brightness_.green == 0 || this->local_brightness_ == 0)
       return 0;
     uint16_t uncorrected = this->gamma_reverse_table_[green] * 255UL;
     uint8_t res = ((uncorrected / this->max_brightness_.green) * 255UL) / this->local_brightness_;
     return res;
   }
-  inline uint8_t color_uncorrect_blue(uint8_t blue) const ALWAYS_INLINE {
+  inline uint8_t color_uncorrect_blue(uint8_t blue) const ESPHOME_ALWAYS_INLINE {
     if (this->max_brightness_.blue == 0 || this->local_brightness_ == 0)
       return 0;
     uint16_t uncorrected = this->gamma_reverse_table_[blue] * 255UL;
     uint8_t res = ((uncorrected / this->max_brightness_.blue) * 255UL) / this->local_brightness_;
     return res;
   }
-  inline uint8_t color_uncorrect_white(uint8_t white) const ALWAYS_INLINE {
+  inline uint8_t color_uncorrect_white(uint8_t white) const ESPHOME_ALWAYS_INLINE {
     if (this->max_brightness_.white == 0 || this->local_brightness_ == 0)
       return 0;
     uint16_t uncorrected = this->gamma_reverse_table_[white] * 255UL;

--- a/esphome/components/light/esp_hsv_color.h
+++ b/esphome/components/light/esp_hsv_color.h
@@ -24,11 +24,11 @@ struct ESPHSVColor {
     };
     uint8_t raw[3];
   };
-  inline ESPHSVColor() ALWAYS_INLINE : h(0), s(0), v(0) {  // NOLINT
+  inline ESPHSVColor() ESPHOME_ALWAYS_INLINE : h(0), s(0), v(0) {  // NOLINT
   }
-  inline ESPHSVColor(uint8_t hue, uint8_t saturation, uint8_t value) ALWAYS_INLINE : hue(hue),
-                                                                                     saturation(saturation),
-                                                                                     value(value) {}
+  inline ESPHSVColor(uint8_t hue, uint8_t saturation, uint8_t value) ESPHOME_ALWAYS_INLINE : hue(hue),
+                                                                                             saturation(saturation),
+                                                                                             value(value) {}
   Color to_rgb() const;
 };
 

--- a/esphome/core/color.h
+++ b/esphome/core/color.h
@@ -31,19 +31,19 @@ struct Color {
     uint32_t raw_32;
   };
 
-  inline Color() ALWAYS_INLINE : r(0), g(0), b(0), w(0) {}  // NOLINT
-  inline Color(uint8_t red, uint8_t green, uint8_t blue) ALWAYS_INLINE : r(red), g(green), b(blue), w(0) {}
+  inline Color() ESPHOME_ALWAYS_INLINE : r(0), g(0), b(0), w(0) {}  // NOLINT
+  inline Color(uint8_t red, uint8_t green, uint8_t blue) ESPHOME_ALWAYS_INLINE : r(red), g(green), b(blue), w(0) {}
 
-  inline Color(uint8_t red, uint8_t green, uint8_t blue, uint8_t white) ALWAYS_INLINE : r(red),
-                                                                                        g(green),
-                                                                                        b(blue),
-                                                                                        w(white) {}
-  inline explicit Color(uint32_t colorcode) ALWAYS_INLINE : r((colorcode >> 16) & 0xFF),
-                                                            g((colorcode >> 8) & 0xFF),
-                                                            b((colorcode >> 0) & 0xFF),
-                                                            w((colorcode >> 24) & 0xFF) {}
+  inline Color(uint8_t red, uint8_t green, uint8_t blue, uint8_t white) ESPHOME_ALWAYS_INLINE : r(red),
+                                                                                                g(green),
+                                                                                                b(blue),
+                                                                                                w(white) {}
+  inline explicit Color(uint32_t colorcode) ESPHOME_ALWAYS_INLINE : r((colorcode >> 16) & 0xFF),
+                                                                    g((colorcode >> 8) & 0xFF),
+                                                                    b((colorcode >> 0) & 0xFF),
+                                                                    w((colorcode >> 24) & 0xFF) {}
 
-  inline bool is_on() ALWAYS_INLINE { return this->raw_32 != 0; }
+  inline bool is_on() ESPHOME_ALWAYS_INLINE { return this->raw_32 != 0; }
 
   inline bool operator==(const Color &rhs) {  // NOLINT
     return this->raw_32 == rhs.raw_32;
@@ -57,31 +57,33 @@ struct Color {
   inline bool operator!=(uint32_t colorcode) {  // NOLINT
     return this->raw_32 != colorcode;
   }
-  inline uint8_t &operator[](uint8_t x) ALWAYS_INLINE { return this->raw[x]; }
-  inline Color operator*(uint8_t scale) const ALWAYS_INLINE {
+  inline uint8_t &operator[](uint8_t x) ESPHOME_ALWAYS_INLINE { return this->raw[x]; }
+  inline Color operator*(uint8_t scale) const ESPHOME_ALWAYS_INLINE {
     return Color(esp_scale8(this->red, scale), esp_scale8(this->green, scale), esp_scale8(this->blue, scale),
                  esp_scale8(this->white, scale));
   }
-  inline Color operator~() const ALWAYS_INLINE { return Color(255 - this->red, 255 - this->green, 255 - this->blue); }
-  inline Color &operator*=(uint8_t scale) ALWAYS_INLINE {
+  inline Color operator~() const ESPHOME_ALWAYS_INLINE {
+    return Color(255 - this->red, 255 - this->green, 255 - this->blue);
+  }
+  inline Color &operator*=(uint8_t scale) ESPHOME_ALWAYS_INLINE {
     this->red = esp_scale8(this->red, scale);
     this->green = esp_scale8(this->green, scale);
     this->blue = esp_scale8(this->blue, scale);
     this->white = esp_scale8(this->white, scale);
     return *this;
   }
-  inline Color operator*(const Color &scale) const ALWAYS_INLINE {
+  inline Color operator*(const Color &scale) const ESPHOME_ALWAYS_INLINE {
     return Color(esp_scale8(this->red, scale.red), esp_scale8(this->green, scale.green),
                  esp_scale8(this->blue, scale.blue), esp_scale8(this->white, scale.white));
   }
-  inline Color &operator*=(const Color &scale) ALWAYS_INLINE {
+  inline Color &operator*=(const Color &scale) ESPHOME_ALWAYS_INLINE {
     this->red = esp_scale8(this->red, scale.red);
     this->green = esp_scale8(this->green, scale.green);
     this->blue = esp_scale8(this->blue, scale.blue);
     this->white = esp_scale8(this->white, scale.white);
     return *this;
   }
-  inline Color operator+(const Color &add) const ALWAYS_INLINE {
+  inline Color operator+(const Color &add) const ESPHOME_ALWAYS_INLINE {
     Color ret;
     if (uint8_t(add.r + this->r) < this->r)
       ret.r = 255;
@@ -101,10 +103,10 @@ struct Color {
       ret.w = this->w + add.w;
     return ret;
   }
-  inline Color &operator+=(const Color &add) ALWAYS_INLINE { return *this = (*this) + add; }
-  inline Color operator+(uint8_t add) const ALWAYS_INLINE { return (*this) + Color(add, add, add, add); }
-  inline Color &operator+=(uint8_t add) ALWAYS_INLINE { return *this = (*this) + add; }
-  inline Color operator-(const Color &subtract) const ALWAYS_INLINE {
+  inline Color &operator+=(const Color &add) ESPHOME_ALWAYS_INLINE { return *this = (*this) + add; }
+  inline Color operator+(uint8_t add) const ESPHOME_ALWAYS_INLINE { return (*this) + Color(add, add, add, add); }
+  inline Color &operator+=(uint8_t add) ESPHOME_ALWAYS_INLINE { return *this = (*this) + add; }
+  inline Color operator-(const Color &subtract) const ESPHOME_ALWAYS_INLINE {
     Color ret;
     if (subtract.r > this->r)
       ret.r = 0;
@@ -124,11 +126,11 @@ struct Color {
       ret.w = this->w - subtract.w;
     return ret;
   }
-  inline Color &operator-=(const Color &subtract) ALWAYS_INLINE { return *this = (*this) - subtract; }
-  inline Color operator-(uint8_t subtract) const ALWAYS_INLINE {
+  inline Color &operator-=(const Color &subtract) ESPHOME_ALWAYS_INLINE { return *this = (*this) - subtract; }
+  inline Color operator-(uint8_t subtract) const ESPHOME_ALWAYS_INLINE {
     return (*this) - Color(subtract, subtract, subtract, subtract);
   }
-  inline Color &operator-=(uint8_t subtract) ALWAYS_INLINE { return *this = (*this) - subtract; }
+  inline Color &operator-=(uint8_t subtract) ESPHOME_ALWAYS_INLINE { return *this = (*this) - subtract; }
   static Color random_color() {
     uint32_t rand = random_uint32();
     uint8_t w = rand >> 24;

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -24,7 +24,7 @@
 
 #define HOT __attribute__((hot))
 #define ESPDEPRECATED(msg, when) __attribute__((deprecated(msg)))
-#define ALWAYS_INLINE __attribute__((always_inline))
+#define ESPHOME_ALWAYS_INLINE __attribute__((always_inline))
 #define PACKED __attribute__((packed))
 
 // Various functions can be constexpr in C++14, but not in C++11 (because their body isn't just a return statement).


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
