### PR TITLE
Remove text_sensor from sync-device-class job

### DIFF
--- a/script/sync-device_class.py
+++ b/script/sync-device_class.py
@@ -10,7 +10,6 @@ from homeassistant.components.event import EventDeviceClass
 from homeassistant.components.number import NumberDeviceClass
 from homeassistant.components.sensor import SensorDeviceClass
 from homeassistant.components.switch import SwitchDeviceClass
-from homeassistant.components.text_sensor import TextSensorDeviceClass
 from homeassistant.components.valve import ValveDeviceClass
 
 # pylint: enable=import-error
@@ -28,7 +27,6 @@ DOMAINS = {
     "number": NumberDeviceClass,
     "sensor": SensorDeviceClass,
     "switch": SwitchDeviceClass,
-    "text_sensor": TextSensorDeviceClass,
     "valve": ValveDeviceClass,
 }
 


### PR DESCRIPTION
# What does this implement/fix?

Remove text_sensor from sync-device-class job -- it shouldn't have been added.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
