### PR TITLE
Extract core comments from #6241

### DIFF
--- a/esphome/automation.py
+++ b/esphome/automation.py
@@ -18,10 +18,20 @@ from esphome.util import Registry
 
 
 def maybe_simple_id(*validators):
+    """Allow a raw ID to be specified in place of a config block.
+    If the value that's being validated is a dictionary, it's passed as-is to the specified validators. Otherwise, it's
+    wrapped in a dict that looks like ``{"id": <value>}``, and that dict is then handed off to the specified validators.
+    """
     return maybe_conf(CONF_ID, *validators)
 
 
 def maybe_conf(conf, *validators):
+    """Allow a raw value to be specified in place of a config block.
+    If the value that's being validated is a dictionary, it's passed as-is to the specified validators. Otherwise, it's
+    wrapped in a dict that looks like ``{<conf>: <value>}``, and that dict is then handed off to the specified
+    validators.
+    (This is a general case of ``maybe_simple_id`` that allows the wrapping key to be something other than ``id``.)
+    """
     validator = cv.All(*validators)
 
     @schema_extractor("maybe")

--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -304,7 +304,7 @@ def string(value):
     """Validate that a configuration value is a string. If not, automatically converts to a string.
 
     Note that this can be lossy, for example the input value 60.00 (float) will be turned into
-    "60.0" (string). For values where this could be a problem `string_string` has to be used.
+    "60.0" (string). For values where this could be a problem `string_strict` has to be used.
     """
     check_not_templatable(value)
     if isinstance(value, (dict, list)):

--- a/esphome/core/component.h
+++ b/esphome/core/component.h
@@ -85,7 +85,7 @@ class Component {
 
   /** priority of setup(). higher -> executed earlier
    *
-   * Defaults to 0.
+   * Defaults to setup_priority::DATA, i.e. 600.
    *
    * @return The setup priority of this component
    */


### PR DESCRIPTION
Add a few useful comments to ESPHome core.

These were extracted from https://github.com/esphome/esphome/pull/6241

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other - comment edits only

