### PR TITLE
Fix command line substitutions without any yaml substitutions

### DIFF
--- a/esphome/components/substitutions/__init__.py
+++ b/esphome/components/substitutions/__init__.py
@@ -116,7 +116,7 @@ def do_substitution_pass(config, command_line_substitutions, ignore_missing=Fals
     if CONF_SUBSTITUTIONS not in config and not command_line_substitutions:
         return
 
-    substitutions = config[CONF_SUBSTITUTIONS]
+    substitutions = config.get(CONF_SUBSTITUTIONS)
     if substitutions is None:
         substitutions = command_line_substitutions
     elif command_line_substitutions:

--- a/esphome/config.py
+++ b/esphome/config.py
@@ -756,11 +756,11 @@ def validate_config(
     CORE.raw_config = config
 
     # 1. Load substitutions
-    if CONF_SUBSTITUTIONS in config:
+    if CONF_SUBSTITUTIONS in config or command_line_substitutions:
         from esphome.components import substitutions
 
         result[CONF_SUBSTITUTIONS] = {
-            **config[CONF_SUBSTITUTIONS],
+            **config.get(CONF_SUBSTITUTIONS, {}),
             **command_line_substitutions,
         }
         result.add_output_path([CONF_SUBSTITUTIONS], CONF_SUBSTITUTIONS)

--- a/script/test_build_components
+++ b/script/test_build_components
@@ -37,9 +37,9 @@ start_esphome() {
 
   # Start esphome process
   echo "> [$target_component] [$test_name] [$target_platform]"
-  echo "esphome -s component_name $target_component -s test_name $test_name -s target_platform $target_platform $esphome_command $component_test_file"
+  echo "esphome -s component_name $target_component -s component_dir ../../components/$target_component -s test_name $test_name -s target_platform $target_platform $esphome_command $component_test_file"
   # TODO: Validate escape of Command line substitution value
-  esphome -s component_name $target_component -s test_name $test_name -s target_platform $target_platform $esphome_command $component_test_file
+  esphome -s component_name $target_component -s component_dir ../../components/$target_component -s test_name $test_name -s target_platform $target_platform $esphome_command $component_test_file
 }
 
 # Find all test yaml files.

--- a/tests/test_build_components/build_components_base.bk72xx.yaml
+++ b/tests/test_build_components/build_components_base.bk72xx.yaml
@@ -12,8 +12,4 @@ packages:
   component_under_test: !include
     file: $component_test_file
     vars:
-      component_name: $component_name
-      test_name: $test_name
-      target_platform: $target_platform
       component_test_file: $component_test_file
-      component_dir: "../../components/$component_name"

--- a/tests/test_build_components/build_components_base.esp32-ard.yaml
+++ b/tests/test_build_components/build_components_base.esp32-ard.yaml
@@ -14,8 +14,4 @@ packages:
   component_under_test: !include
     file: $component_test_file
     vars:
-      component_name: $component_name
-      test_name: $test_name
-      target_platform: $target_platform
       component_test_file: $component_test_file
-      component_dir: "../../components/$component_name"

--- a/tests/test_build_components/build_components_base.esp32-c3-ard.yaml
+++ b/tests/test_build_components/build_components_base.esp32-c3-ard.yaml
@@ -14,8 +14,4 @@ packages:
   component_under_test: !include
     file: $component_test_file
     vars:
-      component_name: $component_name
-      test_name: $test_name
-      target_platform: $target_platform
       component_test_file: $component_test_file
-      component_dir: "../../components/$component_name"

--- a/tests/test_build_components/build_components_base.esp32-c3-idf.yaml
+++ b/tests/test_build_components/build_components_base.esp32-c3-idf.yaml
@@ -14,8 +14,4 @@ packages:
   component_under_test: !include
     file: $component_test_file
     vars:
-      component_name: $component_name
-      test_name: $test_name
-      target_platform: $target_platform
       component_test_file: $component_test_file
-      component_dir: "../../components/$component_name"

--- a/tests/test_build_components/build_components_base.esp32-idf.yaml
+++ b/tests/test_build_components/build_components_base.esp32-idf.yaml
@@ -14,8 +14,4 @@ packages:
   component_under_test: !include
     file: $component_test_file
     vars:
-      component_name: $component_name
-      test_name: $test_name
-      target_platform: $target_platform
       component_test_file: $component_test_file
-      component_dir: "../../components/$component_name"

--- a/tests/test_build_components/build_components_base.esp32-s2-ard.yaml
+++ b/tests/test_build_components/build_components_base.esp32-s2-ard.yaml
@@ -15,8 +15,4 @@ packages:
   component_under_test: !include
     file: $component_test_file
     vars:
-      component_name: $component_name
-      test_name: $test_name
-      target_platform: $target_platform
       component_test_file: $component_test_file
-      component_dir: "../../components/$component_name"

--- a/tests/test_build_components/build_components_base.esp32-s2-idf.yaml
+++ b/tests/test_build_components/build_components_base.esp32-s2-idf.yaml
@@ -15,8 +15,4 @@ packages:
   component_under_test: !include
     file: $component_test_file
     vars:
-      component_name: $component_name
-      test_name: $test_name
-      target_platform: $target_platform
       component_test_file: $component_test_file
-      component_dir: "../../components/$component_name"

--- a/tests/test_build_components/build_components_base.esp32-s3-ard.yaml
+++ b/tests/test_build_components/build_components_base.esp32-s3-ard.yaml
@@ -15,8 +15,4 @@ packages:
   component_under_test: !include
     file: $component_test_file
     vars:
-      component_name: $component_name
-      test_name: $test_name
-      target_platform: $target_platform
       component_test_file: $component_test_file
-      component_dir: "../../components/$component_name"

--- a/tests/test_build_components/build_components_base.esp32-s3-idf.yaml
+++ b/tests/test_build_components/build_components_base.esp32-s3-idf.yaml
@@ -15,8 +15,4 @@ packages:
   component_under_test: !include
     file: $component_test_file
     vars:
-      component_name: $component_name
-      test_name: $test_name
-      target_platform: $target_platform
       component_test_file: $component_test_file
-      component_dir: "../../components/$component_name"

--- a/tests/test_build_components/build_components_base.esp8266.yaml
+++ b/tests/test_build_components/build_components_base.esp8266.yaml
@@ -12,8 +12,4 @@ packages:
   component_under_test: !include
     file: $component_test_file
     vars:
-      component_name: $component_name
-      test_name: $test_name
-      target_platform: $target_platform
       component_test_file: $component_test_file
-      component_dir: "../../components/$component_name"

--- a/tests/test_build_components/build_components_base.host.yaml
+++ b/tests/test_build_components/build_components_base.host.yaml
@@ -12,8 +12,4 @@ packages:
   component_under_test: !include
     file: $component_test_file
     vars:
-      component_name: $component_name
-      test_name: $test_name
-      target_platform: $target_platform
       component_test_file: $component_test_file
-      component_dir: "../../components/$component_name"

--- a/tests/test_build_components/build_components_base.rp2040.yaml
+++ b/tests/test_build_components/build_components_base.rp2040.yaml
@@ -15,8 +15,4 @@ packages:
   component_under_test: !include
     file: $component_test_file
     vars:
-      component_name: $component_name
-      test_name: $test_name
-      target_platform: $target_platform
       component_test_file: $component_test_file
-      component_dir: "../../components/$component_name"


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Command line substitutions were being ignored if there was no `substitutions` block in the YAML configuration.

This also removes the extra vars on the test package that were not being set because packages are expanded with their vars before substitutions are replaced.
This also moves the `$component_dir` substitution to a cli substitution.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
