### PR TITLE
Fixed the issue that graph draws out of the boundary.

### DIFF
--- a/esphome/components/graph/graph.cpp
+++ b/esphome/components/graph/graph.cpp
@@ -177,22 +177,26 @@ void Graph::draw(Display *buff, uint16_t x_offset, uint16_t y_offset, Color colo
         bool b = (trace->get_line_type() & bit) == bit;
         if (b) {
           int16_t y = (int16_t) roundf((this->height_ - 1) * (1.0 - v)) - thick / 2 + y_offset;
+          auto draw_pixel_at = [&buff, c, y_offset, this](int16_t x, int16_t y) {
+            if (y >= y_offset && y < y_offset + this->height_)
+              buff->draw_pixel_at(x, y, c);
+          };
           if (!continuous || !has_prev || !prev_b || (abs(y - prev_y) <= thick)) {
             for (int16_t t = 0; t < thick; t++) {
-              buff->draw_pixel_at(x, y + t, c);
+              draw_pixel_at(x, y + t);
             }
           } else {
             int16_t mid_y = (y + prev_y + thick) / 2;
             if (y > prev_y) {
               for (int16_t t = prev_y + thick; t <= mid_y; t++)
-                buff->draw_pixel_at(x + 1, t, c);
+                draw_pixel_at(x + 1, t);
               for (int16_t t = mid_y + 1; t < y + thick; t++)
-                buff->draw_pixel_at(x, t, c);
+                draw_pixel_at(x, t);
             } else {
               for (int16_t t = prev_y - 1; t >= mid_y; t--)
-                buff->draw_pixel_at(x + 1, t, c);
+                draw_pixel_at(x + 1, t);
               for (int16_t t = mid_y - 1; t >= y; t--)
-                buff->draw_pixel_at(x, t, c);
+                draw_pixel_at(x, t);
             }
           }
           prev_y = y;


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/5748

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
esphome:
  name: debug

logger:

network:

ota:

wifi:
  ssid: !secret wifi_ssid
  password: !secret wifi_password
  fast_connect: true

api:
  encryption:
    key: !secret api_key

esp32:
  board: esp32dev

spi:
  mosi_pin: GPIO23
  clk_pin: GPIO18

debug:
  update_interval: 5s

sensor:
  - platform: uptime
    id: uptime_sensor
    update_interval: 1s
  - platform: template
    id: template_sensor
    update_interval: 1s
    lambda: |-
      return static_cast<int>(id(uptime_sensor).state) % 16;

graph:
  - id: template_graph
    duration: 1min
    width: 100
    height: 100
    x_grid: 15s
    y_grid: 5
    min_value: 5
    max_value: 10
    traces:
      - sensor: template_sensor
        continuous: true

display:
  - platform: waveshare_epaper
    cs_pin: GPIO26
    dc_pin: GPIO27
    reset_pin: GPIO14
    busy_pin: GPIO12
    model: 2.13inv3
    update_interval: 1s
    lambda: |-
      it.graph(20, 20, id(template_graph));
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
