### PR TITLE
WIP: Add support for multiple wakeword/vad models

### DIFF
--- a/esphome/components/micro_wake_word/__init__.py
+++ b/esphome/components/micro_wake_word/__init__.py
@@ -348,23 +348,6 @@ async def to_code(config):
             on_wake_word_detection_config,
         )
 
-    esp32.add_idf_component(
-        name="esp-tflite-micro",
-        repo="https://github.com/espressif/esp-tflite-micro",
-        ref="v1.3.1",
-    )
-
-    cg.add_build_flag("-DTF_LITE_STATIC_MEMORY")
-    cg.add_build_flag("-DTF_LITE_DISABLE_X86_NEON")
-    cg.add_build_flag("-DESP_NN")
-
-    if on_wake_word_detection_config := config.get(CONF_ON_WAKE_WORD_DETECTED):
-        await automation.build_automation(
-            var.get_wake_word_detected_trigger(),
-            [(cg.std_string, "wake_word")],
-            on_wake_word_detection_config,
-        )
-
     if vad_model := config.get(CONF_VAD_MODEL):
         cg.add_define("USE_MWW_VAD")
         model_config = vad_model.get(CONF_MODEL)
@@ -425,7 +408,7 @@ async def to_code(config):
             file: Path = base_dir / h.hexdigest()[:8] / model_config[CONF_FILE]
 
         elif model_config[CONF_TYPE] == TYPE_LOCAL:
-            file = model_config[CONF_PATH]
+            file = Path(model_config[CONF_PATH])
 
         elif model_config[CONF_TYPE] == TYPE_HTTP:
             file = _compute_local_file_path(model_config) / "manifest.json"

--- a/esphome/components/micro_wake_word/micro_wake_word.cpp
+++ b/esphome/components/micro_wake_word/micro_wake_word.cpp
@@ -1,4 +1,5 @@
 #include "micro_wake_word.h"
+#include "streaming_model.h"
 
 /**
  * This is a workaround until we can figure out a way to get
@@ -29,7 +30,7 @@ namespace micro_wake_word {
 static const char *const TAG = "micro_wake_word";
 
 static const size_t SAMPLE_RATE_HZ = 16000;  // 16 kHz
-static const size_t BUFFER_LENGTH = 500;     // 0.5 seconds
+static const size_t BUFFER_LENGTH = 100;     // 0.1 seconds
 static const size_t BUFFER_SIZE = SAMPLE_RATE_HZ / 1000 * BUFFER_LENGTH;
 static const size_t INPUT_BUFFER_SIZE = 32 * SAMPLE_RATE_HZ / 1000;  // 32ms * 16kHz / 1000ms
 
@@ -55,32 +56,24 @@ static const LogString *micro_wake_word_state_to_string(State state) {
 }
 
 void MicroWakeWord::dump_config() {
-  ESP_LOGCONFIG(TAG, "microWakeWord:");
-  ESP_LOGCONFIG(TAG, "  Wake Word: %s", this->get_wake_word().c_str());
-  ESP_LOGCONFIG(TAG, "  Probability cutoff: %.3f", this->probability_cutoff_);
-  ESP_LOGCONFIG(TAG, "  Sliding window size: %d", this->sliding_window_average_size_);
+  ESP_LOGCONFIG(TAG, "microWakeWord models:");
+  for (auto &model : this->wake_word_models_) {
+    model.log_model_config();
+  }
+#ifdef USE_MWW_VAD
+  this->vad_model_->log_model_config();
+#endif
 }
 
 void MicroWakeWord::setup() {
   ESP_LOGCONFIG(TAG, "Setting up microWakeWord...");
 
-  if (!this->initialize_models()) {
-    ESP_LOGE(TAG, "Failed to initialize models");
+  if (!this->register_streaming_ops_(this->streaming_op_resolver_)) {
     this->mark_failed();
     return;
   }
 
-  ExternalRAMAllocator<int16_t> allocator(ExternalRAMAllocator<int16_t>::ALLOW_FAILURE);
-  this->input_buffer_ = allocator.allocate(INPUT_BUFFER_SIZE * sizeof(int16_t));
-  if (this->input_buffer_ == nullptr) {
-    ESP_LOGW(TAG, "Could not allocate input buffer");
-    this->mark_failed();
-    return;
-  }
-
-  this->ring_buffer_ = RingBuffer::create(BUFFER_SIZE * sizeof(int16_t));
-  if (this->ring_buffer_ == nullptr) {
-    ESP_LOGW(TAG, "Could not allocate ring buffer");
+  if (!this->register_preprocessor_ops_(this->preprocessor_op_resolver_)) {
     this->mark_failed();
     return;
   }
@@ -88,25 +81,20 @@ void MicroWakeWord::setup() {
   ESP_LOGCONFIG(TAG, "Micro Wake Word initialized");
 }
 
-int MicroWakeWord::read_microphone_() {
-  size_t bytes_read = this->microphone_->read(this->input_buffer_, INPUT_BUFFER_SIZE * sizeof(int16_t));
-  if (bytes_read == 0) {
-    return 0;
-  }
-
-  size_t bytes_free = this->ring_buffer_->free();
-
-  if (bytes_free < bytes_read) {
-    ESP_LOGW(TAG,
-             "Not enough free bytes in ring buffer to store incoming audio data (free bytes=%d, incoming bytes=%d). "
-             "Resetting the ring buffer. Wake word detection accuracy will be reduced.",
-             bytes_free, bytes_read);
-
-    this->ring_buffer_->reset();
-  }
-
-  return this->ring_buffer_->write((void *) this->input_buffer_, bytes_read);
+void MicroWakeWord::add_wake_word_model(const uint8_t *model_start, float probability_cutoff,
+                                        size_t sliding_window_average_size, const std::string &wake_word,
+                                        size_t tensor_arena_size) {
+  this->wake_word_models_.push_back(
+      WakeWordModel(model_start, probability_cutoff, sliding_window_average_size, wake_word, tensor_arena_size));
 }
+
+#ifdef USE_MWW_VAD
+void MicroWakeWord::add_vad_model(const uint8_t *model_start, float upper_threshold, float lower_threshold,
+                                  size_t sliding_window_size, size_t tensor_arena_size) {
+  this->vad_model_ =
+      new VADModel(model_start, upper_threshold, lower_threshold, sliding_window_size, tensor_arena_size);
+}
+#endif
 
 void MicroWakeWord::loop() {
   switch (this->state_) {
@@ -125,8 +113,9 @@ void MicroWakeWord::loop() {
       break;
     case State::DETECTING_WAKE_WORD:
       this->read_microphone_();
-      if (this->detect_wake_word_()) {
-        ESP_LOGD(TAG, "Wake Word Detected");
+      this->update_model_probabilities_();
+      if (this->detect_wake_words_()) {
+        ESP_LOGD(TAG, "Wake Word '%s' Detected", (this->detected_wake_word_).c_str());
         this->detected_ = true;
         this->set_state_(State::STOP_MICROPHONE);
       }
@@ -136,13 +125,16 @@ void MicroWakeWord::loop() {
       this->microphone_->stop();
       this->set_state_(State::STOPPING_MICROPHONE);
       this->high_freq_.stop();
+      this->unload_models_();
+      this->deallocate_buffers_();
       break;
     case State::STOPPING_MICROPHONE:
       if (this->microphone_->is_stopped()) {
         this->set_state_(State::IDLE);
         if (this->detected_) {
+          this->wake_word_detected_trigger_->trigger(this->detected_wake_word_);
           this->detected_ = false;
-          this->wake_word_detected_trigger_->trigger(this->wake_word_);
+          this->detected_wake_word_ = "";
         }
       }
       break;
@@ -154,10 +146,25 @@ void MicroWakeWord::start() {
     ESP_LOGW(TAG, "Wake word component is marked as failed. Please check setup logs");
     return;
   }
+
+  if (!this->load_models_() || !this->allocate_buffers_()) {
+    ESP_LOGE(TAG, "Failed to load the wake word model(s) or allocate buffers");
+    this->status_set_error();
+  } else {
+    this->status_clear_error();
+  }
+
+  if (this->status_has_error()) {
+    ESP_LOGW(TAG, "Wake word component has an error. Please check logs");
+    return;
+  }
+
   if (this->state_ != State::IDLE) {
     ESP_LOGW(TAG, "Wake word is already running");
     return;
   }
+
+  this->reset_states_();
   this->set_state_(State::START_MICROPHONE);
 }
 
@@ -179,142 +186,113 @@ void MicroWakeWord::set_state_(State state) {
   this->state_ = state;
 }
 
-bool MicroWakeWord::initialize_models() {
-  ExternalRAMAllocator<uint8_t> arena_allocator(ExternalRAMAllocator<uint8_t>::ALLOW_FAILURE);
-  ExternalRAMAllocator<int8_t> features_allocator(ExternalRAMAllocator<int8_t>::ALLOW_FAILURE);
+size_t MicroWakeWord::read_microphone_() {
+  size_t bytes_read = this->microphone_->read(this->input_buffer_, INPUT_BUFFER_SIZE * sizeof(int16_t));
+  if (bytes_read == 0) {
+    return 0;
+  }
+
+  size_t bytes_free = this->ring_buffer_->free();
+
+  if (bytes_free < bytes_read) {
+    ESP_LOGW(TAG,
+             "Not enough free bytes in ring buffer to store incoming audio data (free bytes=%d, incoming bytes=%d). "
+             "Resetting the ring buffer. Wake word detection accuracy will be reduced.",
+             bytes_free, bytes_read);
+
+    this->ring_buffer_->reset();
+  }
+
+  return this->ring_buffer_->write((void *) this->input_buffer_, bytes_read);
+}
+
+bool MicroWakeWord::allocate_buffers_() {
   ExternalRAMAllocator<int16_t> audio_samples_allocator(ExternalRAMAllocator<int16_t>::ALLOW_FAILURE);
 
-  this->streaming_tensor_arena_ = arena_allocator.allocate(STREAMING_MODEL_ARENA_SIZE);
-  if (this->streaming_tensor_arena_ == nullptr) {
-    ESP_LOGE(TAG, "Could not allocate the streaming model's tensor arena.");
-    return false;
+  if (this->input_buffer_ == nullptr) {
+    this->input_buffer_ = audio_samples_allocator.allocate(INPUT_BUFFER_SIZE * sizeof(int16_t));
+    if (this->input_buffer_ == nullptr) {
+      ESP_LOGE(TAG, "Could not allocate input buffer");
+      return false;
+    }
   }
 
-  this->streaming_var_arena_ = arena_allocator.allocate(STREAMING_MODEL_VARIABLE_ARENA_SIZE);
-  if (this->streaming_var_arena_ == nullptr) {
-    ESP_LOGE(TAG, "Could not allocate the streaming model variable's tensor arena.");
-    return false;
-  }
-
-  this->preprocessor_tensor_arena_ = arena_allocator.allocate(PREPROCESSOR_ARENA_SIZE);
-  if (this->preprocessor_tensor_arena_ == nullptr) {
-    ESP_LOGE(TAG, "Could not allocate the audio preprocessor model's tensor arena.");
-    return false;
-  }
-
-  this->new_features_data_ = features_allocator.allocate(PREPROCESSOR_FEATURE_SIZE);
-  if (this->new_features_data_ == nullptr) {
-    ESP_LOGE(TAG, "Could not allocate the audio features buffer.");
-    return false;
-  }
-
-  this->preprocessor_audio_buffer_ = audio_samples_allocator.allocate(SAMPLE_DURATION_COUNT);
   if (this->preprocessor_audio_buffer_ == nullptr) {
-    ESP_LOGE(TAG, "Could not allocate the audio preprocessor's buffer.");
-    return false;
+    this->preprocessor_audio_buffer_ = audio_samples_allocator.allocate(SAMPLE_DURATION_COUNT);
+    if (this->preprocessor_audio_buffer_ == nullptr) {
+      ESP_LOGE(TAG, "Could not allocate the audio preprocessor's buffer.");
+      return false;
+    }
   }
 
-  this->preprocessor_model_ = tflite::GetModel(G_AUDIO_PREPROCESSOR_INT8_TFLITE);
-  if (this->preprocessor_model_->version() != TFLITE_SCHEMA_VERSION) {
-    ESP_LOGE(TAG, "Wake word's audio preprocessor model's schema is not supported");
-    return false;
-  }
-
-  this->streaming_model_ = tflite::GetModel(this->model_start_);
-  if (this->streaming_model_->version() != TFLITE_SCHEMA_VERSION) {
-    ESP_LOGE(TAG, "Wake word's streaming model's schema is not supported");
-    return false;
-  }
-
-  static tflite::MicroMutableOpResolver<18> preprocessor_op_resolver;
-  static tflite::MicroMutableOpResolver<17> streaming_op_resolver;
-
-  if (!this->register_preprocessor_ops_(preprocessor_op_resolver))
-    return false;
-  if (!this->register_streaming_ops_(streaming_op_resolver))
-    return false;
-
-  tflite::MicroAllocator *ma =
-      tflite::MicroAllocator::Create(this->streaming_var_arena_, STREAMING_MODEL_VARIABLE_ARENA_SIZE);
-  this->mrv_ = tflite::MicroResourceVariables::Create(ma, 15);
-
-  static tflite::MicroInterpreter static_preprocessor_interpreter(
-      this->preprocessor_model_, preprocessor_op_resolver, this->preprocessor_tensor_arena_, PREPROCESSOR_ARENA_SIZE);
-
-  static tflite::MicroInterpreter static_streaming_interpreter(this->streaming_model_, streaming_op_resolver,
-                                                               this->streaming_tensor_arena_,
-                                                               STREAMING_MODEL_ARENA_SIZE, this->mrv_);
-
-  this->preprocessor_interperter_ = &static_preprocessor_interpreter;
-  this->streaming_interpreter_ = &static_streaming_interpreter;
-
-  // Allocate tensors for each models.
-  if (this->preprocessor_interperter_->AllocateTensors() != kTfLiteOk) {
-    ESP_LOGE(TAG, "Failed to allocate tensors for the audio preprocessor");
-    return false;
-  }
-  if (this->streaming_interpreter_->AllocateTensors() != kTfLiteOk) {
-    ESP_LOGE(TAG, "Failed to allocate tensors for the streaming model");
-    return false;
-  }
-
-  // Verify input tensor matches expected values
-  TfLiteTensor *input = this->streaming_interpreter_->input(0);
-  if ((input->dims->size != 3) || (input->dims->data[0] != 1) || (input->dims->data[0] != 1) ||
-      (input->dims->data[1] != 1) || (input->dims->data[2] != PREPROCESSOR_FEATURE_SIZE)) {
-    ESP_LOGE(TAG, "Wake word detection model tensor input dimensions is not 1x1x%u", input->dims->data[2]);
-    return false;
-  }
-
-  if (input->type != kTfLiteInt8) {
-    ESP_LOGE(TAG, "Wake word detection model tensor input is not int8.");
-    return false;
-  }
-
-  // Verify output tensor matches expected values
-  TfLiteTensor *output = this->streaming_interpreter_->output(0);
-  if ((output->dims->size != 2) || (output->dims->data[0] != 1) || (output->dims->data[1] != 1)) {
-    ESP_LOGE(TAG, "Wake word detection model tensor output dimensions is not 1x1.");
-  }
-
-  if (output->type != kTfLiteUInt8) {
-    ESP_LOGE(TAG, "Wake word detection model tensor input is not uint8.");
-    return false;
-  }
-
-  this->recent_streaming_probabilities_.resize(this->sliding_window_average_size_, 0.0);
-
-  return true;
-}
-
-bool MicroWakeWord::update_features_() {
-  // Retrieve strided audio samples
-  int16_t *audio_samples = nullptr;
-  if (!this->stride_audio_samples_(&audio_samples)) {
-    return false;
-  }
-
-  // Compute the features for the newest audio samples
-  if (!this->generate_single_feature_(audio_samples, SAMPLE_DURATION_COUNT, this->new_features_data_)) {
-    return false;
+  if (this->ring_buffer_ == nullptr) {
+    this->ring_buffer_ = RingBuffer::create(BUFFER_SIZE * sizeof(int16_t));
+    if (this->ring_buffer_ == nullptr) {
+      ESP_LOGE(TAG, "Could not allocate ring buffer");
+      return false;
+    }
   }
 
   return true;
 }
 
-float MicroWakeWord::perform_streaming_inference_() {
-  TfLiteTensor *input = this->streaming_interpreter_->input(0);
+void MicroWakeWord::deallocate_buffers_() {
+  ExternalRAMAllocator<int16_t> audio_samples_allocator(ExternalRAMAllocator<int16_t>::ALLOW_FAILURE);
+  audio_samples_allocator.deallocate(this->input_buffer_, PREPROCESSOR_ARENA_SIZE);
+  this->input_buffer_ = nullptr;
+  audio_samples_allocator.deallocate(this->preprocessor_audio_buffer_, PREPROCESSOR_ARENA_SIZE);
+  this->preprocessor_audio_buffer_ = nullptr;
+}
 
-  size_t bytes_to_copy = input->bytes;
+bool MicroWakeWord::load_models_() {
+  // Setup preprocesor feature generator
+  if (this->preprocessor_tensor_arena_ == nullptr) {
+    ExternalRAMAllocator<uint8_t> arena_allocator(ExternalRAMAllocator<uint8_t>::ALLOW_FAILURE);
+    this->preprocessor_tensor_arena_ = arena_allocator.allocate(PREPROCESSOR_ARENA_SIZE);
+    if (this->preprocessor_tensor_arena_ == nullptr) {
+      ESP_LOGE(TAG, "Could not allocate the audio preprocessor model's tensor arena.");
+      return false;
+    }
+  }
+  if (this->preprocessor_interpreter_ == nullptr) {
+    this->preprocessor_interpreter_ = new tflite::MicroInterpreter(
+        tflite::GetModel(G_AUDIO_PREPROCESSOR_INT8_TFLITE), this->preprocessor_op_resolver_,
+        this->preprocessor_tensor_arena_, PREPROCESSOR_ARENA_SIZE);
 
-  memcpy((void *) (tflite::GetTensorData<int8_t>(input)), (const void *) (this->new_features_data_), bytes_to_copy);
+    if (this->preprocessor_interpreter_->AllocateTensors() != kTfLiteOk) {
+      ESP_LOGE(TAG, "Failed to allocate tensors for the audio preprocessor");
+      return false;
+    }
+  }
 
-  uint32_t prior_invoke = millis();
-
-  TfLiteStatus invoke_status = this->streaming_interpreter_->Invoke();
-  if (invoke_status != kTfLiteOk) {
-    ESP_LOGW(TAG, "Streaming Interpreter Invoke failed");
+  // Setup streaming models
+  for (auto &model : this->wake_word_models_) {
+    if (!model.load_model(this->streaming_op_resolver_)) {
+      ESP_LOGE(TAG, "Failed to initialize a wake word model.");
+      return false;
+    }
+  }
+#ifdef USE_MWW_VAD
+  if (!this->vad_model_->load_model(this->streaming_op_resolver_)) {
+    ESP_LOGE(TAG, "Failed to initialize VAD model.");
     return false;
+  }
+#endif
+
+  return true;
+}
+
+void MicroWakeWord::unload_models_() {
+  delete (this->preprocessor_interpreter_);
+  this->preprocessor_interpreter_ = nullptr;
+
+  ExternalRAMAllocator<uint8_t> arena_allocator(ExternalRAMAllocator<uint8_t>::ALLOW_FAILURE);
+
+  arena_allocator.deallocate(this->preprocessor_tensor_arena_, PREPROCESSOR_ARENA_SIZE);
+  this->preprocessor_tensor_arena_ = nullptr;
+
+  for (auto &model : this->wake_word_models_) {
+    model.unload_model();
   }
 
   ESP_LOGV(TAG, "Streaming Inference Latency=%" PRIu32 " ms", (millis() - prior_invoke));
@@ -328,177 +306,194 @@ bool MicroWakeWord::detect_wake_word_() {
   // Preprocess the newest audio samples into features
   if (!this->update_features_()) {
     return false;
+#ifdef USE_MWW_VAD
+    this->vad_model_->unload_model();
+#endif
   }
 
-  // Perform inference
-  float streaming_prob = this->perform_streaming_inference_();
+  void MicroWakeWord::update_model_probabilities_() {
+    if (!this->stride_audio_samples_()) {
+      return;
+    }
 
-  // Add the most recent probability to the sliding window
-  this->recent_streaming_probabilities_[this->last_n_index_] = streaming_prob;
-  ++this->last_n_index_;
-  if (this->last_n_index_ == this->sliding_window_average_size_)
-    this->last_n_index_ = 0;
+    int8_t audio_features[PREPROCESSOR_FEATURE_SIZE];
 
-  float sum = 0.0;
-  for (auto &prob : this->recent_streaming_probabilities_) {
-    sum += prob;
+    if (!this->generate_features_for_window_(audio_features)) {
+      return;
+    }
+
+    // Increase the counter since the last positive detection
+    this->ignore_windows_ = std::min(this->ignore_windows_ + 1, 0);
+
+    for (auto &model : this->wake_word_models_) {
+      // Perform inference
+      model.perform_streaming_inference(audio_features);
+    }
+#ifdef USE_MWW_VAD
+    this->vad_model_->perform_streaming_inference(audio_features);
+#endif
   }
 
-  float sliding_window_average = sum / static_cast<float>(this->sliding_window_average_size_);
+  bool MicroWakeWord::detect_wake_words_() {
+    // Verify we have processed samples since the last positive detection
+    if (this->ignore_windows_ < 0) {
+      return false;
+    }
 
-  // Ensure we have enough samples since the last positive detection
-  this->ignore_windows_ = std::min(this->ignore_windows_ + 1, 0);
-  if (this->ignore_windows_ < 0) {
+#ifdef USE_MWW_VAD
+    bool vad_state = this->vad_model_->determine_detected();
+#endif
+
+    for (auto &model : this->wake_word_models_) {
+      if (model.determine_detected()) {
+#ifdef USE_MWW_VAD
+        if (vad_state) {
+#endif
+          this->detected_wake_word_ = model.get_wake_word();
+          return true;
+#ifdef USE_MWW_VAD
+        } else {
+          ESP_LOGD(TAG, "Wake word model predicts %s, but VAD model doesn't.", model.get_wake_word().c_str());
+        }
+#endif
+      }
+    }
+
     return false;
   }
 
-  // Detect the wake word if the sliding window average is above the cutoff
-  if (sliding_window_average > this->probability_cutoff_) {
-    this->ignore_windows_ = -MIN_SLICES_BEFORE_DETECTION;
-    for (auto &prob : this->recent_streaming_probabilities_) {
-      prob = 0;
+  bool MicroWakeWord::stride_audio_samples_() {
+    // Ensure we have enough new audio samples in the ring buffer for a full window
+    if (this->ring_buffer_->available() < NEW_SAMPLES_TO_GET * sizeof(int16_t)) {
+      return false;
     }
 
-    ESP_LOGD(TAG, "Wake word sliding average probability is %.3f and most recent probability is %.3f",
-             sliding_window_average, streaming_prob);
+    // Copy the last 320 bytes (160 samples over 10 ms) from the audio buffer to the start of the audio buffer
+    memcpy((void *) (this->preprocessor_audio_buffer_),
+           (void *) (this->preprocessor_audio_buffer_ + NEW_SAMPLES_TO_GET), HISTORY_SAMPLES_TO_KEEP * sizeof(int16_t));
+
+    // Copy 640 bytes (320 samples over 20 ms) from the ring buffer into the audio buffer offset 320 bytes (160 samples
+    // over 10 ms)
+    size_t bytes_read = this->ring_buffer_->read((void *) (this->preprocessor_audio_buffer_ + HISTORY_SAMPLES_TO_KEEP),
+                                                 NEW_SAMPLES_TO_GET * sizeof(int16_t), pdMS_TO_TICKS(200));
+
+    if (bytes_read == 0) {
+      ESP_LOGE(TAG, "Could not read data from Ring Buffer");
+    } else if (bytes_read < NEW_SAMPLES_TO_GET * sizeof(int16_t)) {
+      ESP_LOGD(TAG, "Partial Read of Data by Model");
+      ESP_LOGD(TAG, "Could only read %d bytes when required %d bytes ", bytes_read,
+               (int) (NEW_SAMPLES_TO_GET * sizeof(int16_t)));
+      return false;
+    }
+
     return true;
   }
 
-  return false;
-}
+  bool MicroWakeWord::generate_features_for_window_(int8_t features[PREPROCESSOR_FEATURE_SIZE]) {
+    TfLiteTensor *input = this->preprocessor_interpreter_->input(0);
+    TfLiteTensor *output = this->preprocessor_interpreter_->output(0);
+    std::copy_n(this->preprocessor_audio_buffer_, SAMPLE_DURATION_COUNT, tflite::GetTensorData<int16_t>(input));
 
-void MicroWakeWord::set_sliding_window_average_size(size_t size) {
-  this->sliding_window_average_size_ = size;
-  this->recent_streaming_probabilities_.resize(this->sliding_window_average_size_, 0.0);
-}
+    if (this->preprocessor_interpreter_->Invoke() != kTfLiteOk) {
+      ESP_LOGE(TAG, "Failed to preprocess audio for local wake word.");
+      return false;
+    }
+    std::memcpy(features, tflite::GetTensorData<int8_t>(output), PREPROCESSOR_FEATURE_SIZE * sizeof(int8_t));
 
-bool MicroWakeWord::slice_available_() {
-  size_t available = this->ring_buffer_->available();
-
-  return available > (NEW_SAMPLES_TO_GET * sizeof(int16_t));
-}
-
-bool MicroWakeWord::stride_audio_samples_(int16_t **audio_samples) {
-  if (!this->slice_available_()) {
-    return false;
+    return true;
   }
 
-  // Copy the last 320 bytes (160 samples over 10 ms) from the audio buffer to the start of the audio buffer
-  memcpy((void *) (this->preprocessor_audio_buffer_), (void *) (this->preprocessor_audio_buffer_ + NEW_SAMPLES_TO_GET),
-         HISTORY_SAMPLES_TO_KEEP * sizeof(int16_t));
-
-  // Copy 640 bytes (320 samples over 20 ms) from the ring buffer into the audio buffer offset 320 bytes (160 samples
-  // over 10 ms)
-  size_t bytes_read = this->ring_buffer_->read((void *) (this->preprocessor_audio_buffer_ + HISTORY_SAMPLES_TO_KEEP),
-                                               NEW_SAMPLES_TO_GET * sizeof(int16_t), pdMS_TO_TICKS(200));
-
-  if (bytes_read == 0) {
-    ESP_LOGE(TAG, "Could not read data from Ring Buffer");
-  } else if (bytes_read < NEW_SAMPLES_TO_GET * sizeof(int16_t)) {
-    ESP_LOGD(TAG, "Partial Read of Data by Model");
-    ESP_LOGD(TAG, "Could only read %d bytes when required %d bytes ", bytes_read,
-             (int) (NEW_SAMPLES_TO_GET * sizeof(int16_t)));
-    return false;
+  void MicroWakeWord::reset_states_() {
+    ESP_LOGD(TAG, "Resetting buffers and probabilities");
+    this->ring_buffer_->reset();
+    this->ignore_windows_ = -MIN_SLICES_BEFORE_DETECTION;
+    for (auto &model : this->wake_word_models_) {
+      model.reset_probabilities();
+    }
+#ifdef USE_MWW_VAD
+    this->vad_model_->reset_probabilities();
+#endif
   }
 
-  *audio_samples = this->preprocessor_audio_buffer_;
-  return true;
-}
+  bool MicroWakeWord::register_preprocessor_ops_(tflite::MicroMutableOpResolver<18> & op_resolver) {
+    if (op_resolver.AddReshape() != kTfLiteOk)
+      return false;
+    if (op_resolver.AddCast() != kTfLiteOk)
+      return false;
+    if (op_resolver.AddStridedSlice() != kTfLiteOk)
+      return false;
+    if (op_resolver.AddConcatenation() != kTfLiteOk)
+      return false;
+    if (op_resolver.AddMul() != kTfLiteOk)
+      return false;
+    if (op_resolver.AddAdd() != kTfLiteOk)
+      return false;
+    if (op_resolver.AddDiv() != kTfLiteOk)
+      return false;
+    if (op_resolver.AddMinimum() != kTfLiteOk)
+      return false;
+    if (op_resolver.AddMaximum() != kTfLiteOk)
+      return false;
+    if (op_resolver.AddWindow() != kTfLiteOk)
+      return false;
+    if (op_resolver.AddFftAutoScale() != kTfLiteOk)
+      return false;
+    if (op_resolver.AddRfft() != kTfLiteOk)
+      return false;
+    if (op_resolver.AddEnergy() != kTfLiteOk)
+      return false;
+    if (op_resolver.AddFilterBank() != kTfLiteOk)
+      return false;
+    if (op_resolver.AddFilterBankSquareRoot() != kTfLiteOk)
+      return false;
+    if (op_resolver.AddFilterBankSpectralSubtraction() != kTfLiteOk)
+      return false;
+    if (op_resolver.AddPCAN() != kTfLiteOk)
+      return false;
+    if (op_resolver.AddFilterBankLog() != kTfLiteOk)
+      return false;
 
-bool MicroWakeWord::generate_single_feature_(const int16_t *audio_data, const int audio_data_size,
-                                             int8_t feature_output[PREPROCESSOR_FEATURE_SIZE]) {
-  TfLiteTensor *input = this->preprocessor_interperter_->input(0);
-  TfLiteTensor *output = this->preprocessor_interperter_->output(0);
-  std::copy_n(audio_data, audio_data_size, tflite::GetTensorData<int16_t>(input));
-
-  if (this->preprocessor_interperter_->Invoke() != kTfLiteOk) {
-    ESP_LOGE(TAG, "Failed to preprocess audio for local wake word.");
-    return false;
+    return true;
   }
-  std::memcpy(feature_output, tflite::GetTensorData<int8_t>(output), PREPROCESSOR_FEATURE_SIZE * sizeof(int8_t));
 
-  return true;
-}
+  bool MicroWakeWord::register_streaming_ops_(tflite::MicroMutableOpResolver<17> & op_resolver) {
+    if (op_resolver.AddCallOnce() != kTfLiteOk)
+      return false;
+    if (op_resolver.AddVarHandle() != kTfLiteOk)
+      return false;
+    if (op_resolver.AddReshape() != kTfLiteOk)
+      return false;
+    if (op_resolver.AddReadVariable() != kTfLiteOk)
+      return false;
+    if (op_resolver.AddStridedSlice() != kTfLiteOk)
+      return false;
+    if (op_resolver.AddConcatenation() != kTfLiteOk)
+      return false;
+    if (op_resolver.AddAssignVariable() != kTfLiteOk)
+      return false;
+    if (op_resolver.AddConv2D() != kTfLiteOk)
+      return false;
+    if (op_resolver.AddMul() != kTfLiteOk)
+      return false;
+    if (op_resolver.AddAdd() != kTfLiteOk)
+      return false;
+    if (op_resolver.AddMean() != kTfLiteOk)
+      return false;
+    if (op_resolver.AddFullyConnected() != kTfLiteOk)
+      return false;
+    if (op_resolver.AddLogistic() != kTfLiteOk)
+      return false;
+    if (op_resolver.AddQuantize() != kTfLiteOk)
+      return false;
+    if (op_resolver.AddDepthwiseConv2D() != kTfLiteOk)
+      return false;
+    if (op_resolver.AddAveragePool2D() != kTfLiteOk)
+      return false;
+    if (op_resolver.AddMaxPool2D() != kTfLiteOk)
+      return false;
 
-bool MicroWakeWord::register_preprocessor_ops_(tflite::MicroMutableOpResolver<18> &op_resolver) {
-  if (op_resolver.AddReshape() != kTfLiteOk)
-    return false;
-  if (op_resolver.AddCast() != kTfLiteOk)
-    return false;
-  if (op_resolver.AddStridedSlice() != kTfLiteOk)
-    return false;
-  if (op_resolver.AddConcatenation() != kTfLiteOk)
-    return false;
-  if (op_resolver.AddMul() != kTfLiteOk)
-    return false;
-  if (op_resolver.AddAdd() != kTfLiteOk)
-    return false;
-  if (op_resolver.AddDiv() != kTfLiteOk)
-    return false;
-  if (op_resolver.AddMinimum() != kTfLiteOk)
-    return false;
-  if (op_resolver.AddMaximum() != kTfLiteOk)
-    return false;
-  if (op_resolver.AddWindow() != kTfLiteOk)
-    return false;
-  if (op_resolver.AddFftAutoScale() != kTfLiteOk)
-    return false;
-  if (op_resolver.AddRfft() != kTfLiteOk)
-    return false;
-  if (op_resolver.AddEnergy() != kTfLiteOk)
-    return false;
-  if (op_resolver.AddFilterBank() != kTfLiteOk)
-    return false;
-  if (op_resolver.AddFilterBankSquareRoot() != kTfLiteOk)
-    return false;
-  if (op_resolver.AddFilterBankSpectralSubtraction() != kTfLiteOk)
-    return false;
-  if (op_resolver.AddPCAN() != kTfLiteOk)
-    return false;
-  if (op_resolver.AddFilterBankLog() != kTfLiteOk)
-    return false;
-
-  return true;
-}
-
-bool MicroWakeWord::register_streaming_ops_(tflite::MicroMutableOpResolver<17> &op_resolver) {
-  if (op_resolver.AddCallOnce() != kTfLiteOk)
-    return false;
-  if (op_resolver.AddVarHandle() != kTfLiteOk)
-    return false;
-  if (op_resolver.AddReshape() != kTfLiteOk)
-    return false;
-  if (op_resolver.AddReadVariable() != kTfLiteOk)
-    return false;
-  if (op_resolver.AddStridedSlice() != kTfLiteOk)
-    return false;
-  if (op_resolver.AddConcatenation() != kTfLiteOk)
-    return false;
-  if (op_resolver.AddAssignVariable() != kTfLiteOk)
-    return false;
-  if (op_resolver.AddConv2D() != kTfLiteOk)
-    return false;
-  if (op_resolver.AddMul() != kTfLiteOk)
-    return false;
-  if (op_resolver.AddAdd() != kTfLiteOk)
-    return false;
-  if (op_resolver.AddMean() != kTfLiteOk)
-    return false;
-  if (op_resolver.AddFullyConnected() != kTfLiteOk)
-    return false;
-  if (op_resolver.AddLogistic() != kTfLiteOk)
-    return false;
-  if (op_resolver.AddQuantize() != kTfLiteOk)
-    return false;
-  if (op_resolver.AddDepthwiseConv2D() != kTfLiteOk)
-    return false;
-  if (op_resolver.AddAveragePool2D() != kTfLiteOk)
-    return false;
-  if (op_resolver.AddMaxPool2D() != kTfLiteOk)
-    return false;
-
-  return true;
-}
+    return true;
+  }
 
 }  // namespace micro_wake_word
 }  // namespace esphome

--- a/esphome/components/micro_wake_word/micro_wake_word.cpp
+++ b/esphome/components/micro_wake_word/micro_wake_word.cpp
@@ -142,6 +142,11 @@ void MicroWakeWord::loop() {
 }
 
 void MicroWakeWord::start() {
+  if (!this->is_ready()) {
+    ESP_LOGW(TAG, "Wake word detection can't start as the component hasn't been setup yet");
+    return;
+  }
+
   if (this->is_failed()) {
     ESP_LOGW(TAG, "Wake word component is marked as failed. Please check setup logs");
     return;

--- a/esphome/components/micro_wake_word/micro_wake_word.cpp
+++ b/esphome/components/micro_wake_word/micro_wake_word.cpp
@@ -461,7 +461,7 @@ bool MicroWakeWord::detect_wake_word_() {
     return true;
   }
 
-  bool MicroWakeWord::register_streaming_ops_(tflite::MicroMutableOpResolver<17> & op_resolver) {
+  bool MicroWakeWord::register_streaming_ops_(tflite::MicroMutableOpResolver<20> & op_resolver) {
     if (op_resolver.AddCallOnce() != kTfLiteOk)
       return false;
     if (op_resolver.AddVarHandle() != kTfLiteOk)
@@ -495,6 +495,12 @@ bool MicroWakeWord::detect_wake_word_() {
     if (op_resolver.AddAveragePool2D() != kTfLiteOk)
       return false;
     if (op_resolver.AddMaxPool2D() != kTfLiteOk)
+      return false;
+    if (op_resolver.AddPad() != kTfLiteOk)
+      return false;
+    if (op_resolver.AddPack() != kTfLiteOk)
+      return false;
+    if (op_resolver.AddSplitV() != kTfLiteOk)
       return false;
 
     return true;

--- a/esphome/components/micro_wake_word/micro_wake_word.h
+++ b/esphome/components/micro_wake_word/micro_wake_word.h
@@ -10,6 +10,9 @@
 
 #ifdef USE_ESP_IDF
 
+#include "preprocessor_settings.h"
+#include "streaming_model.h"
+
 #include "esphome/core/automation.h"
 #include "esphome/core/component.h"
 #include "esphome/core/ring_buffer.h"
@@ -23,35 +26,6 @@
 namespace esphome {
 namespace micro_wake_word {
 
-// The following are dictated by the preprocessor model
-//
-// The number of features the audio preprocessor generates per slice
-static const uint8_t PREPROCESSOR_FEATURE_SIZE = 40;
-// How frequently the preprocessor generates a new set of features
-static const uint8_t FEATURE_STRIDE_MS = 20;
-// Duration of each slice used as input into the preprocessor
-static const uint8_t FEATURE_DURATION_MS = 30;
-// Audio sample frequency in hertz
-static const uint16_t AUDIO_SAMPLE_FREQUENCY = 16000;
-// The number of old audio samples that are saved to be part of the next feature window
-static const uint16_t HISTORY_SAMPLES_TO_KEEP =
-    ((FEATURE_DURATION_MS - FEATURE_STRIDE_MS) * (AUDIO_SAMPLE_FREQUENCY / 1000));
-// The number of new audio samples to receive to be included with the next feature window
-static const uint16_t NEW_SAMPLES_TO_GET = (FEATURE_STRIDE_MS * (AUDIO_SAMPLE_FREQUENCY / 1000));
-// The total number of audio samples included in the feature window
-static const uint16_t SAMPLE_DURATION_COUNT = FEATURE_DURATION_MS * AUDIO_SAMPLE_FREQUENCY / 1000;
-// Number of bytes in memory needed for the preprocessor arena
-static const uint32_t PREPROCESSOR_ARENA_SIZE = 9528;
-
-// The following configure the streaming wake word model
-//
-// The number of audio slices to process before accepting a positive detection
-static const uint8_t MIN_SLICES_BEFORE_DETECTION = 74;
-
-// Number of bytes in memory needed for the streaming wake word model
-static const uint32_t STREAMING_MODEL_ARENA_SIZE = 64000;
-static const uint32_t STREAMING_MODEL_VARIABLE_ARENA_SIZE = 1024;
-
 enum State {
   IDLE,
   START_MICROPHONE,
@@ -60,6 +34,9 @@ enum State {
   STOP_MICROPHONE,
   STOPPING_MICROPHONE,
 };
+
+// The number of audio slices to process before accepting a positive detection
+static const uint8_t MIN_SLICES_BEFORE_DETECTION = 74;
 
 class MicroWakeWord : public Component {
  public:
@@ -73,28 +50,19 @@ class MicroWakeWord : public Component {
 
   bool is_running() const { return this->state_ != State::IDLE; }
 
-  bool initialize_models();
-
-  std::string get_wake_word() { return this->wake_word_; }
-
-  // Increasing either of these will reduce the rate of false acceptances while increasing the false rejection rate
-  void set_probability_cutoff(float probability_cutoff) { this->probability_cutoff_ = probability_cutoff; }
-  void set_sliding_window_average_size(size_t size);
-
   void set_microphone(microphone::Microphone *microphone) { this->microphone_ = microphone; }
 
   Trigger<std::string> *get_wake_word_detected_trigger() const { return this->wake_word_detected_trigger_; }
 
-  void set_model_start(const uint8_t *model_start) { this->model_start_ = model_start; }
-  void set_wake_word(const std::string &wake_word) { this->wake_word_ = wake_word; }
+  void add_wake_word_model(const uint8_t *model_start, float probability_cutoff, size_t sliding_window_average_size,
+                           const std::string &wake_word, size_t tensor_arena_size);
+
+#ifdef USE_MWW_VAD
+  void add_vad_model(const uint8_t *model_start, float upper_threshold, float lower_threshold,
+                     size_t sliding_window_size, size_t tensor_arena_size);
+#endif
 
  protected:
-  void set_state_(State state);
-  int read_microphone_();
-
-  const uint8_t *model_start_;
-  std::string wake_word_;
-
   microphone::Microphone *microphone_{nullptr};
   Trigger<std::string> *wake_word_detected_trigger_ = new Trigger<std::string>();
   State state_{State::IDLE};
@@ -102,79 +70,92 @@ class MicroWakeWord : public Component {
 
   std::unique_ptr<RingBuffer> ring_buffer_;
 
-  int16_t *input_buffer_;
+  std::vector<WakeWordModel> wake_word_models_;
 
-  const tflite::Model *preprocessor_model_{nullptr};
-  const tflite::Model *streaming_model_{nullptr};
-  tflite::MicroInterpreter *streaming_interpreter_{nullptr};
-  tflite::MicroInterpreter *preprocessor_interperter_{nullptr};
+#ifdef USE_MWW_VAD
+  VADModel *vad_model_;
+#endif
 
-  std::vector<float> recent_streaming_probabilities_;
-  size_t last_n_index_{0};
+  tflite::MicroMutableOpResolver<17> streaming_op_resolver_;
+  tflite::MicroMutableOpResolver<18> preprocessor_op_resolver_;
 
-  float probability_cutoff_{0.5};
-  size_t sliding_window_average_size_{10};
+  tflite::MicroInterpreter *preprocessor_interpreter_{nullptr};
 
-  // When the wake word detection first starts or after the word has been detected once, we ignore this many audio
-  // feature slices before accepting a positive detection again
+  // When the wake word detection first starts, we ignore this many audio
+  // feature slices before accepting a positive detection
   int16_t ignore_windows_{-MIN_SLICES_BEFORE_DETECTION};
 
-  uint8_t *streaming_var_arena_{nullptr};
-  uint8_t *streaming_tensor_arena_{nullptr};
   uint8_t *preprocessor_tensor_arena_{nullptr};
-  int8_t *new_features_data_{nullptr};
 
-  tflite::MicroResourceVariables *mrv_{nullptr};
-
-  // Stores audio fed into feature generator preprocessor
-  int16_t *preprocessor_audio_buffer_;
+  // Stores audio read from the microphone before being added to the ring buffer.
+  int16_t *input_buffer_{nullptr};
+  // Stores audio fed into feature generator preprocessor. Also used for striding samples in each window.
+  int16_t *preprocessor_audio_buffer_{nullptr};
 
   bool detected_{false};
+  std::string detected_wake_word_{""};
 
-  /** Detects if wake word has been said
+  void set_state_(State state);
+
+  /** Reads audio from microphone into the ring buffer
+   *
+   * Audio data (16000 kHz with int16 samples) is read into the input_buffer_.
+   * Verifies the ring buffer has enough space for all audio data. If not, it logs
+   * a warning and resets the ring buffer entirely.
+   * @return Number of bytes written to the ring buffer
+   */
+  size_t read_microphone_();
+
+  /// @brief Allocates memory for input_buffer_, preprocessor_audio_buffer_, and ring_buffer_
+  /// @return True if successful, false otherwise
+  bool allocate_buffers_();
+
+  /// @brief Frees memory allocated for input_buffer_ and preprocessor_audio_buffer_
+  void deallocate_buffers_();
+
+  /// @brief Loads streaming models
+  /// @return True if successful, false otherwise
+  bool load_models_();
+
+  /// @brief Deletes each model's TFLite interpreters and frees tensor arena memory
+  void unload_models_();
+
+  /** Performs inference with each configured model
    *
    * If enough audio samples are available, it will generate one slice of new features.
-   * If the streaming model predicts the wake word, then the nonstreaming model confirms it.
-   * @param ring_Buffer Ring buffer containing raw audio samples
-   * @return True if the wake word is detected, false otherwise
+   * It then loops through and performs inference with each of the loaded models.
    */
-  bool detect_wake_word_();
+  void update_model_probabilities_();
 
-  /// @brief Returns true if there are enough audio samples in the buffer to generate another slice of features
-  bool slice_available_();
-
-  /** Shifts previous feature slices over by one and generates a new slice of features
+  /** Checks every model's recent probabilities to determine if the wake word has been predicted
    *
-   * @param ring_buffer ring buffer containing raw audio samples
-   * @return True if a new slice of features was generated, false otherwise
+   * Verifies the models have processed enough new samples for accurate predictions.
+   * Sets detected_wake_word_ to the wake word, if one is detected.
+   * @return True if a wake word is predicted, false otherwise
    */
-  bool update_features_();
+  bool detect_wake_words_();
 
-  /** Generates features from audio samples
+  /** Reads in new audio data from ring buffer to create the next sample window
    *
-   * Adapted from TFLite micro speech example
-   * @param audio_data Pointer to array with the audio samples
-   * @param audio_data_size The number of samples to use as input to the preprocessor model
-   * @param feature_output Array that will store the features
-   * @return True if successful, false otherwise.
-   */
-  bool generate_single_feature_(const int16_t *audio_data, int audio_data_size,
-                                int8_t feature_output[PREPROCESSOR_FEATURE_SIZE]);
-
-  /** Performs inference over the most recent feature slice with the streaming model
-   *
-   * @return Probability of the wake word between 0.0 and 1.0
-   */
-  float perform_streaming_inference_();
-
-  /** Strides the audio samples by keeping the last 10 ms of the previous slice
-   *
-   * Adapted from the TFLite micro speech example
-   * @param ring_buffer Ring buffer containing raw audio samples
-   * @param audio_samples Pointer to an array that will store the strided audio samples
+   * Moves the last 10 ms of audio from the previous window to the start of the new window.
+   * The next 20 ms of audio is copied from the ring buffer and inserted into the new window.
+   * The new window's audio samples are stored in preprocessor_audio_buffer_.
+   * Adapted from the TFLite micro speech example.
    * @return True if successful, false otherwise
    */
-  bool stride_audio_samples_(int16_t **audio_samples);
+  bool stride_audio_samples_();
+
+  /** Generates features for a window of audio samples
+   *
+   * Feeds the strided audio samples in preprocessor_audio_buffer_ into the preprocessor.
+   * Adapted from TFLite micro speech example.
+   * @param features int8_t array to store the audio features
+   * @return True if successful, false otherwise.
+   */
+  bool generate_features_for_window_(int8_t features[PREPROCESSOR_FEATURE_SIZE]);
+
+  /// @brief Resets the ring buffer, ignore_windows_, and sliding window probabilities
+  void reset_states_();
 
   /// @brief Returns true if successfully registered the preprocessor's TensorFlow operations
   bool register_preprocessor_ops_(tflite::MicroMutableOpResolver<18> &op_resolver);

--- a/esphome/components/micro_wake_word/micro_wake_word.h
+++ b/esphome/components/micro_wake_word/micro_wake_word.h
@@ -76,7 +76,7 @@ class MicroWakeWord : public Component {
   VADModel *vad_model_;
 #endif
 
-  tflite::MicroMutableOpResolver<17> streaming_op_resolver_;
+  tflite::MicroMutableOpResolver<20> streaming_op_resolver_;
   tflite::MicroMutableOpResolver<18> preprocessor_op_resolver_;
 
   tflite::MicroInterpreter *preprocessor_interpreter_{nullptr};
@@ -161,7 +161,7 @@ class MicroWakeWord : public Component {
   bool register_preprocessor_ops_(tflite::MicroMutableOpResolver<18> &op_resolver);
 
   /// @brief Returns true if successfully registered the streaming model's TensorFlow operations
-  bool register_streaming_ops_(tflite::MicroMutableOpResolver<17> &op_resolver);
+  bool register_streaming_ops_(tflite::MicroMutableOpResolver<20> &op_resolver);
 };
 
 template<typename... Ts> class StartAction : public Action<Ts...>, public Parented<MicroWakeWord> {

--- a/esphome/components/micro_wake_word/preprocessor_settings.h
+++ b/esphome/components/micro_wake_word/preprocessor_settings.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#ifdef USE_ESP_IDF
+
+#include <cstdint>
+
+namespace esphome {
+namespace micro_wake_word {
+
+// The number of features the audio preprocessor generates per slice
+static const uint8_t PREPROCESSOR_FEATURE_SIZE = 40;
+// How frequently the preprocessor generates a new set of features
+static const uint8_t FEATURE_STRIDE_MS = 20;
+// Duration of each slice used as input into the preprocessor
+static const uint8_t FEATURE_DURATION_MS = 30;
+// Audio sample frequency in hertz
+static const uint16_t AUDIO_SAMPLE_FREQUENCY = 16000;
+// The number of old audio samples that are saved to be part of the next feature window
+static const uint16_t HISTORY_SAMPLES_TO_KEEP =
+    ((FEATURE_DURATION_MS - FEATURE_STRIDE_MS) * (AUDIO_SAMPLE_FREQUENCY / 1000));
+// The number of new audio samples to receive to be included with the next feature window
+static const uint16_t NEW_SAMPLES_TO_GET = (FEATURE_STRIDE_MS * (AUDIO_SAMPLE_FREQUENCY / 1000));
+// The total number of audio samples included in the feature window
+static const uint16_t SAMPLE_DURATION_COUNT = FEATURE_DURATION_MS * AUDIO_SAMPLE_FREQUENCY / 1000;
+// Number of bytes in memory needed for the preprocessor arena
+static const uint32_t PREPROCESSOR_ARENA_SIZE = 9528;
+
+}  // namespace micro_wake_word
+}  // namespace esphome
+
+#endif

--- a/esphome/components/micro_wake_word/streaming_model.cpp
+++ b/esphome/components/micro_wake_word/streaming_model.cpp
@@ -32,7 +32,7 @@ void VADModel::log_model_config() {
   ESP_LOGCONFIG(TAG, "    Sliding window size: %d", this->sliding_window_size_);
 }
 
-bool StreamingModel::load_model(tflite::MicroMutableOpResolver<17> &op_resolver) {
+bool StreamingModel::load_model(tflite::MicroMutableOpResolver<20> &op_resolver) {
   ExternalRAMAllocator<uint8_t> arena_allocator(ExternalRAMAllocator<uint8_t>::ALLOW_FAILURE);
 
   if (this->tensor_arena_ == nullptr) {

--- a/esphome/components/micro_wake_word/streaming_model.cpp
+++ b/esphome/components/micro_wake_word/streaming_model.cpp
@@ -27,7 +27,8 @@ void WakeWordModel::log_model_config() {
 
 void VADModel::log_model_config() {
   ESP_LOGCONFIG(TAG, "  - VAD Model");
-  ESP_LOGCONFIG(TAG, "    Probability cutoff: %.3f", this->probability_cutoff_);
+  ESP_LOGCONFIG(TAG, "    Upper threshold: %.3f", this->upper_threshold_);
+  ESP_LOGCONFIG(TAG, "    Lower threshold: %.3f", this->lower_threshold_);
   ESP_LOGCONFIG(TAG, "    Sliding window size: %d", this->sliding_window_size_);
 }
 

--- a/esphome/components/micro_wake_word/streaming_model.cpp
+++ b/esphome/components/micro_wake_word/streaming_model.cpp
@@ -1,0 +1,210 @@
+/**
+ * This is a workaround until we can figure out a way to get
+ * the tflite-micro idf component code available in CI
+ *
+ * */
+//
+#ifndef CLANG_TIDY
+
+#ifdef USE_ESP_IDF
+
+#include "streaming_model.h"
+
+#include "esphome/core/hal.h"
+#include "esphome/core/helpers.h"
+#include "esphome/core/log.h"
+
+static const char *const TAG = "micro_wake_word";
+
+namespace esphome {
+namespace micro_wake_word {
+
+void WakeWordModel::log_model_config() {
+  ESP_LOGCONFIG(TAG, "  - Wake Word: %s", this->wake_word_.c_str());
+  ESP_LOGCONFIG(TAG, "    Probability cutoff: %.3f", this->probability_cutoff_);
+  ESP_LOGCONFIG(TAG, "    Sliding window size: %d", this->sliding_window_size_);
+}
+
+void VADModel::log_model_config() {
+  ESP_LOGCONFIG(TAG, "  - VAD Model");
+  ESP_LOGCONFIG(TAG, "    Probability cutoff: %.3f", this->probability_cutoff_);
+  ESP_LOGCONFIG(TAG, "    Sliding window size: %d", this->sliding_window_size_);
+}
+
+bool StreamingModel::load_model(tflite::MicroMutableOpResolver<17> &op_resolver) {
+  ExternalRAMAllocator<uint8_t> arena_allocator(ExternalRAMAllocator<uint8_t>::ALLOW_FAILURE);
+
+  if (this->tensor_arena_ == nullptr) {
+    this->tensor_arena_ = arena_allocator.allocate(this->tensor_arena_size_);
+    if (this->tensor_arena_ == nullptr) {
+      ESP_LOGE(TAG, "Could not allocate the streaming model's tensor arena.");
+      return false;
+    }
+  }
+
+  if (this->var_arena_ == nullptr) {
+    this->var_arena_ = arena_allocator.allocate(STREAMING_MODEL_VARIABLE_ARENA_SIZE);
+    if (this->var_arena_ == nullptr) {
+      ESP_LOGE(TAG, "Could not allocate the streaming model's variable tensor arena.");
+      return false;
+    }
+    this->ma_ = tflite::MicroAllocator::Create(this->var_arena_, STREAMING_MODEL_VARIABLE_ARENA_SIZE);
+    this->mrv_ = tflite::MicroResourceVariables::Create(this->ma_, 20);
+  }
+
+  const tflite::Model *model = tflite::GetModel(this->model_start_);
+  if (model->version() != TFLITE_SCHEMA_VERSION) {
+    ESP_LOGE(TAG, "Streaming model's schema is not supported");
+    return false;
+  }
+
+  if (this->interpreter_ == nullptr) {
+    this->interpreter_ = new tflite::MicroInterpreter(tflite::GetModel(this->model_start_), op_resolver,
+                                                      this->tensor_arena_, this->tensor_arena_size_, this->mrv_);
+    if (this->interpreter_->AllocateTensors() != kTfLiteOk) {
+      ESP_LOGE(TAG, "Failed to allocate tensors for the streaming model");
+      return false;
+    }
+
+    // Verify input tensor matches expected values
+    TfLiteTensor *input = this->interpreter_->input(0);
+    if ((input->dims->size != 3) || (input->dims->data[0] != 1) || (input->dims->data[0] != 1) ||
+        (input->dims->data[1] != 1) || (input->dims->data[2] != PREPROCESSOR_FEATURE_SIZE)) {
+      ESP_LOGE(TAG, "Streaming model tensor input dimensions is not 1x1x%u", PREPROCESSOR_FEATURE_SIZE);
+      return false;
+    }
+
+    if (input->type != kTfLiteInt8) {
+      ESP_LOGE(TAG, "Streaming model tensor input is not int8.");
+      return false;
+    }
+
+    // Verify output tensor matches expected values
+    TfLiteTensor *output = this->interpreter_->output(0);
+    if ((output->dims->size != 2) || (output->dims->data[0] != 1) || (output->dims->data[1] != 1)) {
+      ESP_LOGE(TAG, "Streaming model tensor output dimension is not 1x1.");
+    }
+
+    if (output->type != kTfLiteUInt8) {
+      ESP_LOGE(TAG, "Streaming model tensor output is not uint8.");
+      return false;
+    }
+  }
+
+  return true;
+}
+
+void StreamingModel::unload_model() {
+  delete (this->interpreter_);
+  this->interpreter_ = nullptr;
+
+  ExternalRAMAllocator<uint8_t> arena_allocator(ExternalRAMAllocator<uint8_t>::ALLOW_FAILURE);
+
+  arena_allocator.deallocate(this->tensor_arena_, this->tensor_arena_size_);
+  this->tensor_arena_ = nullptr;
+  arena_allocator.deallocate(this->var_arena_, STREAMING_MODEL_VARIABLE_ARENA_SIZE);
+  this->var_arena_ = nullptr;
+}
+
+bool StreamingModel::perform_streaming_inference(const int8_t features[PREPROCESSOR_FEATURE_SIZE]) {
+  if (this->interpreter_ != nullptr) {
+    TfLiteTensor *input = this->interpreter_->input(0);
+
+    size_t bytes_to_copy = input->bytes;
+
+    memcpy((void *) (tflite::GetTensorData<int8_t>(input)), (const void *) (features), bytes_to_copy);
+
+    TfLiteStatus invoke_status = this->interpreter_->Invoke();
+    if (invoke_status != kTfLiteOk) {
+      ESP_LOGW(TAG, "Streaming interpreter invoke failed");
+      return false;
+    }
+
+    TfLiteTensor *output = this->interpreter_->output(0);
+
+    ++this->last_n_index_;
+    if (this->last_n_index_ == this->sliding_window_size_)
+      this->last_n_index_ = 0;
+    this->recent_streaming_probabilities_[this->last_n_index_] = output->data.uint8[0];  // probability;
+
+    return true;
+  }
+  ESP_LOGE(TAG, "Streaming interpreter is not initialized.");
+  return false;
+}
+
+void StreamingModel::reset_probabilities() {
+  for (auto &prob : this->recent_streaming_probabilities_) {
+    prob = 0;
+  }
+}
+
+WakeWordModel::WakeWordModel(const uint8_t *model_start, float probability_cutoff, size_t sliding_window_average_size,
+                             const std::string &wake_word, size_t tensor_arena_size) {
+  this->model_start_ = model_start;
+  this->probability_cutoff_ = probability_cutoff;
+  this->sliding_window_size_ = sliding_window_average_size;
+  this->recent_streaming_probabilities_.resize(sliding_window_average_size, 0);
+  this->wake_word_ = wake_word;
+  this->tensor_arena_size_ = tensor_arena_size;
+};
+
+VADModel::VADModel(const uint8_t *model_start, float upper_threshold, float lower_threshold, size_t sliding_window_size,
+                   size_t tensor_arena_size) {
+  this->model_start_ = model_start;
+  this->upper_threshold_ = upper_threshold;
+  this->lower_threshold_ = lower_threshold;
+  this->sliding_window_size_ = sliding_window_size;
+  this->recent_streaming_probabilities_.resize(sliding_window_size, 0);
+  this->tensor_arena_size_ = tensor_arena_size;
+};
+
+bool WakeWordModel::determine_detected() {
+  int32_t sum = 0;
+  for (auto &prob : this->recent_streaming_probabilities_) {
+    sum += prob;
+  }
+
+  float sliding_window_average = static_cast<float>(sum) / static_cast<float>(255 * this->sliding_window_size_);
+
+  // Detect the wake word if the sliding window average is above the cutoff
+  if (sliding_window_average > this->probability_cutoff_) {
+    ESP_LOGD(TAG, "The '%s' model sliding average probability is %.3f and most recent probability is %.3f",
+             this->wake_word_.c_str(), sliding_window_average,
+             this->recent_streaming_probabilities_[this->last_n_index_] / (255.0));
+    return true;
+  }
+  return false;
+}
+
+bool VADModel::determine_detected() {
+  int32_t sum = 0;
+  for (auto &prob : this->recent_streaming_probabilities_) {
+    sum += prob;
+  }
+
+  float sliding_window_average = static_cast<float>(sum) / static_cast<float>(255 * this->sliding_window_size_);
+
+  if (sliding_window_average > this->upper_threshold_) {
+    this->vad_state_ = true;
+    this->clear_countdown_ = 10;
+
+    return true;
+  } else if ((this->vad_state_) && (sliding_window_average > this->lower_threshold_)) {
+    return true;
+  } else {
+    if (this->clear_countdown_ > 0) {
+      --this->clear_countdown_;
+      return true;
+    }
+  }
+
+  this->vad_state_ = false;
+  return false;
+}
+
+}  // namespace micro_wake_word
+}  // namespace esphome
+
+#endif
+#endif

--- a/esphome/components/micro_wake_word/streaming_model.cpp
+++ b/esphome/components/micro_wake_word/streaming_model.cpp
@@ -14,6 +14,8 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
+#include <cinttypes>
+
 static const char *const TAG = "micro_wake_word";
 
 namespace esphome {
@@ -71,7 +73,8 @@ bool StreamingModel::load_model(tflite::MicroMutableOpResolver<20> &op_resolver)
     TfLiteTensor *input = this->interpreter_->input(0);
     if ((input->dims->size != 3) || (input->dims->data[0] != 1) || (input->dims->data[0] != 1) ||
         (input->dims->data[1] != 1) || (input->dims->data[2] != PREPROCESSOR_FEATURE_SIZE)) {
-      ESP_LOGE(TAG, "Streaming model tensor input dimensions is not 1x1x%u", PREPROCESSOR_FEATURE_SIZE);
+      ESP_LOGE(TAG, "Streaming model tensor input dimensions is not 1x1x%" PRIu8, PREPROCESSOR_FEATURE_SIZE);
+
       return false;
     }
 

--- a/esphome/components/micro_wake_word/streaming_model.h
+++ b/esphome/components/micro_wake_word/streaming_model.h
@@ -40,7 +40,6 @@ class StreamingModel {
   void unload_model();
 
  protected:
-  float probability_cutoff_;
   size_t sliding_window_size_;
   size_t last_n_index_{0};
   size_t tensor_arena_size_;
@@ -65,6 +64,7 @@ class WakeWordModel : public StreamingModel {
   std::string get_wake_word() { return this->wake_word_; }
 
  protected:
+  float probability_cutoff_;
   std::string wake_word_;
 };
 

--- a/esphome/components/micro_wake_word/streaming_model.h
+++ b/esphome/components/micro_wake_word/streaming_model.h
@@ -1,0 +1,90 @@
+#pragma once
+
+/**
+ * This is a workaround until we can figure out a way to get
+ * the tflite-micro idf component code available in CI
+ *
+ * */
+//
+#ifndef CLANG_TIDY
+
+#ifdef USE_ESP_IDF
+
+#include "preprocessor_settings.h"
+
+#include <tensorflow/lite/core/c/common.h>
+#include <tensorflow/lite/micro/micro_interpreter.h>
+#include <tensorflow/lite/micro/micro_mutable_op_resolver.h>
+
+namespace esphome {
+namespace micro_wake_word {
+
+static const uint32_t STREAMING_MODEL_VARIABLE_ARENA_SIZE = 1024;
+
+class StreamingModel {
+ public:
+  virtual void log_model_config() = 0;
+  virtual bool determine_detected() = 0;
+
+  bool perform_streaming_inference(const int8_t features[PREPROCESSOR_FEATURE_SIZE]);
+
+  /// @brief Sets all recent_streaming_probabilities to 0
+  void reset_probabilities();
+
+  /// @brief Allocates tensor and variable arenas and sets up the model interpreter
+  /// @param op_resolver MicroMutableOpResolver object that must exist until the model is unloaded
+  /// @return True if successful, false otherwise
+  bool load_model(tflite::MicroMutableOpResolver<17> &op_resolver);
+
+  /// @brief Destroys the TFLite interpreter and frees the tensor and variable arenas' memory
+  void unload_model();
+
+ protected:
+  float probability_cutoff_;
+  size_t sliding_window_size_;
+  size_t last_n_index_{0};
+  size_t tensor_arena_size_;
+  std::vector<uint8_t> recent_streaming_probabilities_;
+
+  const uint8_t *model_start_;
+  uint8_t *tensor_arena_{nullptr};
+  uint8_t *var_arena_{nullptr};
+  tflite::MicroInterpreter *interpreter_{nullptr};
+  tflite::MicroResourceVariables *mrv_{nullptr};
+  tflite::MicroAllocator *ma_{nullptr};
+};
+
+class WakeWordModel : public StreamingModel {
+ public:
+  WakeWordModel(const uint8_t *model_start, float probability_cutoff, size_t sliding_window_average_size,
+                const std::string &wake_word, size_t tensor_arena_size);
+
+  void log_model_config() override;
+  bool determine_detected() override;
+
+  std::string get_wake_word() { return this->wake_word_; }
+
+ protected:
+  std::string wake_word_;
+};
+
+class VADModel : public StreamingModel {
+ public:
+  VADModel(const uint8_t *model_start, float upper_threshold, float lower_threshold, size_t sliding_window_size,
+           size_t tensor_arena_size);
+
+  void log_model_config() override;
+  bool determine_detected() override;
+
+ protected:
+  uint8_t clear_countdown_{10};
+  bool vad_state_{false};
+  float upper_threshold_;
+  float lower_threshold_;
+};
+
+}  // namespace micro_wake_word
+}  // namespace esphome
+
+#endif
+#endif

--- a/esphome/components/micro_wake_word/streaming_model.h
+++ b/esphome/components/micro_wake_word/streaming_model.h
@@ -34,7 +34,7 @@ class StreamingModel {
   /// @brief Allocates tensor and variable arenas and sets up the model interpreter
   /// @param op_resolver MicroMutableOpResolver object that must exist until the model is unloaded
   /// @return True if successful, false otherwise
-  bool load_model(tflite::MicroMutableOpResolver<17> &op_resolver);
+  bool load_model(tflite::MicroMutableOpResolver<20> &op_resolver);
 
   /// @brief Destroys the TFLite interpreter and frees the tensor and variable arenas' memory
   void unload_model();

--- a/tests/components/micro_wake_word/common.yaml
+++ b/tests/components/micro_wake_word/common.yaml
@@ -10,6 +10,10 @@ microphone:
     pdm: true
 
 micro_wake_word:
-  model: hey_jarvis
   on_wake_word_detected:
     - logger.log: "Wake word detected"
+  models:
+    - model: hey_jarvis
+      probability_cutoff: 0.7
+    - model: okay_nabu
+      sliding_window_average_size: 5


### PR DESCRIPTION
# What does this implement/fix?

This is still a work in progress! I'd appreciate people testing this out and letting me know about any issues. It will be a breaking change due to changes in the yaml syntax for handling multiple wake word models.

This PR adds several features/performance improvements:

- Multiple wake word models can run simultaneously
  - At most two of the current models can run simultaneously without issue
- Adds support for running a Voice Activity Detection model to potentially reduce certain false accepts
  -  The current VAD model can only run with 1 model at the same time. If you try to run VAD and two models all at once, accuracy will suffer greatly
- Several memory improvements
  - Models are loaded and unloaded as mWW starts and stops to save memory when not actively running
  - All buffers (excluding the ring buffer) are freed when not actively running
  - Ring buffer size is reduced (if it filled up before, there was no chance of ever recovering and so 0.5 s of audio was dropped each time)
  - Makes the tensor arena's default allocated memory smaller. The exact space allocated can be set in the codegen stage.

Todo:

- Update the manifest format
  - Add a field for the necessary tensor arena size (currently the values are hardcoded in ``__init__.py``)
  - Add support for a VAD helper model along with its specific parameters
- Allow users to only enable VAD instead of having to point to a specific manifest file (also requires uploading the VAD model to the appropriate default repository) 
- ?Possibly better handle the VAD code? I have added a new preprocessor directive to only compile the relevant code if it is enabled, but I'm not sure if this is the best way to handle it. **Warning: Enabling/disabling a VAD model will require a full recompile when rebuilding, so if you have a slow computer, this may take awhile!**
- Update the documentation (see the example yaml at the end of this PR in the mean time)
- Fix any bugs people encounter in testing

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** not applicable

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** unfinished

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml for multiple models

micro_wake_word:
  on_wake_word_detected:
    - voice_assistant.start: 
        wake_word: !lambda return wake_word; 
  models:
    - model: okay_nabu
      sliding_window_average_size: 5
    - model: hey_jarvis
      probability_cutoff: 0.75

```

```yaml
# Example config.yaml for VAD

micro_wake_word:
  on_wake_word_detected:
    - voice_assistant.start: 
        wake_word: !lambda return wake_word; 
  vad_model: 
    model: https://github.com/kahrendt/microWakeWord/releases/download/model/vad_model.json
    sliding_window_average_size: 2
    threshold:
      upper: 0.95
      lower: 0.5
  models:
    - model: alexa

```


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
