### PR TITLE
[i2s_audio.microphone] Fixing adc bug

### DIFF
--- a/esphome/components/i2s_audio/microphone/i2s_audio_microphone.cpp
+++ b/esphome/components/i2s_audio/microphone/i2s_audio_microphone.cpp
@@ -61,28 +61,57 @@ void I2SAudioMicrophone::start_() {
       .bits_per_chan = I2S_BITS_PER_CHAN_DEFAULT,
   };
 
+  esp_err_t err;
+
 #if SOC_I2S_SUPPORTS_ADC
   if (this->adc_) {
     config.mode = (i2s_mode_t) (config.mode | I2S_MODE_ADC_BUILT_IN);
-    i2s_driver_install(this->parent_->get_port(), &config, 0, nullptr);
+    err = i2s_driver_install(this->parent_->get_port(), &config, 0, nullptr);
+    if (err != ESP_OK) {
+      ESP_LOGW(TAG, "Error installing I2S driver: %s", esp_err_to_name(err));
+      this->status_set_error();
+      return;
+    }
 
-    i2s_set_adc_mode(ADC_UNIT_1, this->adc_channel_);
-    i2s_adc_enable(this->parent_->get_port());
+    err = i2s_set_adc_mode(ADC_UNIT_1, this->adc_channel_);
+    if (err != ESP_OK) {
+      ESP_LOGW(TAG, "Error setting ADC mode: %s", esp_err_to_name(err));
+      this->status_set_error();
+      return;
+    }
+    err = i2s_adc_enable(this->parent_->get_port());
+    if (err != ESP_OK) {
+      ESP_LOGW(TAG, "Error enabling ADC: %s", esp_err_to_name(err));
+      this->status_set_error();
+      return;
+    }
+
   } else
 #endif
   {
     if (this->pdm_)
       config.mode = (i2s_mode_t) (config.mode | I2S_MODE_PDM);
 
-    i2s_driver_install(this->parent_->get_port(), &config, 0, nullptr);
+    err = i2s_driver_install(this->parent_->get_port(), &config, 0, nullptr);
+    if (err != ESP_OK) {
+      ESP_LOGW(TAG, "Error installing I2S driver: %s", esp_err_to_name(err));
+      this->status_set_error();
+      return;
+    }
 
     i2s_pin_config_t pin_config = this->parent_->get_pin_config();
     pin_config.data_in_num = this->din_pin_;
 
-    i2s_set_pin(this->parent_->get_port(), &pin_config);
+    err = i2s_set_pin(this->parent_->get_port(), &pin_config);
+    if (err != ESP_OK) {
+      ESP_LOGW(TAG, "Error setting I2S pin: %s", esp_err_to_name(err));
+      this->status_set_error();
+      return;
+    }
   }
   this->state_ = microphone::STATE_RUNNING;
   this->high_freq_.start();
+  this->status_clear_error();
 }
 
 void I2SAudioMicrophone::stop() {
@@ -96,11 +125,33 @@ void I2SAudioMicrophone::stop() {
 }
 
 void I2SAudioMicrophone::stop_() {
-  i2s_stop(this->parent_->get_port());
-  i2s_driver_uninstall(this->parent_->get_port());
+  esp_err_t err;
+#if SOC_I2S_SUPPORTS_ADC
+  if (this->adc_) {
+    err = i2s_adc_disable(this->parent_->get_port());
+    if (err != ESP_OK) {
+      ESP_LOGW(TAG, "Error disabling ADC: %s", esp_err_to_name(err));
+      this->status_set_error();
+      return;
+    }
+  }
+#endif
+  err = i2s_stop(this->parent_->get_port());
+  if (err != ESP_OK) {
+    ESP_LOGW(TAG, "Error stopping I2S microphone: %s", esp_err_to_name(err));
+    this->status_set_error();
+    return;
+  }
+  err = i2s_driver_uninstall(this->parent_->get_port());
+  if (err != ESP_OK) {
+    ESP_LOGW(TAG, "Error uninstalling I2S driver: %s", esp_err_to_name(err));
+    this->status_set_error();
+    return;
+  }
   this->parent_->unlock();
   this->state_ = microphone::STATE_STOPPED;
   this->high_freq_.stop();
+  this->status_clear_error();
 }
 
 size_t I2SAudioMicrophone::read(int16_t *buf, size_t len) {


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

The adc was not being disabled (`i2s_adc_disable(...)`) in `stop_()` resulting in a watchdog timeout on subsequent starts.

Also add some error handling and logging when starting or stopping functions return errors.


## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/5718

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
