### PR TITLE
Add thermocouple type, autoconversion, averaging, and has_fault to max31856

### DIFF
--- a/esphome/components/max31856/max31856.h
+++ b/esphome/components/max31856/max31856.h
@@ -4,96 +4,79 @@
 #include "esphome/components/spi/spi.h"
 #include "esphome/core/component.h"
 
+#ifdef USE_BINARY_SENSOR
+#include "esphome/components/binary_sensor/binary_sensor.h"
+#endif
+
 #include <cinttypes>
 
 namespace esphome {
 namespace max31856 {
 
-enum MAX31856RegisterMasks { SPI_WRITE_M = 0x80 };
-
-enum MAX31856Registers {
-  MAX31856_CR0_REG = 0x00,          ///< Config 0 register
-  MAX31856_CR0_AUTOCONVERT = 0x80,  ///< Config 0 Auto convert flag
-  MAX31856_CR0_1SHOT = 0x40,        ///< Config 0 one shot convert flag
-  MAX31856_CR0_OCFAULT00 = 0x00,    ///< Config 0 open circuit fault 00 flag
-  MAX31856_CR0_OCFAULT01 = 0x10,    ///< Config 0 open circuit fault 01 flag
-  MAX31856_CR0_OCFAULT10 = 0x20,    ///< Config 0 open circuit fault 10 flag
-  MAX31856_CR0_CJ = 0x08,           ///< Config 0 cold junction disable flag
-  MAX31856_CR0_FAULT = 0x04,        ///< Config 0 fault mode flag
-  MAX31856_CR0_FAULTCLR = 0x02,     ///< Config 0 fault clear flag
-
-  MAX31856_CR1_REG = 0x01,     ///< Config 1 register
-  MAX31856_MASK_REG = 0x02,    ///< Fault Mask register
-  MAX31856_CJHF_REG = 0x03,    ///< Cold junction High temp fault register
-  MAX31856_CJLF_REG = 0x04,    ///< Cold junction Low temp fault register
-  MAX31856_LTHFTH_REG = 0x05,  ///< Linearized Temperature High Fault Threshold Register, MSB
-  MAX31856_LTHFTL_REG = 0x06,  ///< Linearized Temperature High Fault Threshold Register, LSB
-  MAX31856_LTLFTH_REG = 0x07,  ///< Linearized Temperature Low Fault Threshold Register, MSB
-  MAX31856_LTLFTL_REG = 0x08,  ///< Linearized Temperature Low Fault Threshold Register, LSB
-  MAX31856_CJTO_REG = 0x09,    ///< Cold-Junction Temperature Offset Register
-  MAX31856_CJTH_REG = 0x0A,    ///< Cold-Junction Temperature Register, MSB
-  MAX31856_CJTL_REG = 0x0B,    ///< Cold-Junction Temperature Register, LSB
-  MAX31856_LTCBH_REG = 0x0C,   ///< Linearized TC Temperature, Byte 2
-  MAX31856_LTCBM_REG = 0x0D,   ///< Linearized TC Temperature, Byte 1
-  MAX31856_LTCBL_REG = 0x0E,   ///< Linearized TC Temperature, Byte 0
-  MAX31856_SR_REG = 0x0F,      ///< Fault Status Register
-
-  MAX31856_FAULT_CJRANGE = 0x80,  ///< Fault status Cold Junction Out-of-Range flag
-  MAX31856_FAULT_TCRANGE = 0x40,  ///< Fault status Thermocouple Out-of-Range flag
-  MAX31856_FAULT_CJHIGH = 0x20,   ///< Fault status Cold-Junction High Fault flag
-  MAX31856_FAULT_CJLOW = 0x10,    ///< Fault status Cold-Junction Low Fault flag
-  MAX31856_FAULT_TCHIGH = 0x08,   ///< Fault status Thermocouple Temperature High Fault flag
-  MAX31856_FAULT_TCLOW = 0x04,    ///< Fault status Thermocouple Temperature Low Fault flag
-  MAX31856_FAULT_OVUV = 0x02,     ///< Fault status Overvoltage or Undervoltage Input Fault flag
-  MAX31856_FAULT_OPEN = 0x01,     ///< Fault status Thermocouple Open-Circuit Fault flag
-};
-
 /**
  * Multiple types of thermocouples supported by the chip.
- * Currently only K type implemented here.
  */
-enum MAX31856ThermocoupleType {
-  MAX31856_TCTYPE_B = 0b0000,   // 0x00
-  MAX31856_TCTYPE_E = 0b0001,   // 0x01
-  MAX31856_TCTYPE_J = 0b0010,   // 0x02
-  MAX31856_TCTYPE_K = 0b0011,   // 0x03
-  MAX31856_TCTYPE_N = 0b0100,   // 0x04
-  MAX31856_TCTYPE_R = 0b0101,   // 0x05
-  MAX31856_TCTYPE_S = 0b0110,   // 0x06
-  MAX31856_TCTYPE_T = 0b0111,   // 0x07
-  MAX31856_VMODE_G8 = 0b1000,   // 0x08
-  MAX31856_VMODE_G32 = 0b1100,  // 0x12
+enum MAX31856ThermocoupleType : uint8_t {
+  MAX31856_TCTYPE_B = 0b0000,  // 0x00
+  MAX31856_TCTYPE_E = 0b0001,  // 0x01
+  MAX31856_TCTYPE_J = 0b0010,  // 0x02
+  MAX31856_TCTYPE_K = 0b0011,  // 0x03
+  MAX31856_TCTYPE_N = 0b0100,  // 0x04
+  MAX31856_TCTYPE_R = 0b0101,  // 0x05
+  MAX31856_TCTYPE_S = 0b0110,  // 0x06
+  MAX31856_TCTYPE_T = 0b0111,  // 0x07
 };
 
-enum MAX31856ConfigFilter {
+enum MAX31856ConfigFilter : uint8_t {
   FILTER_60HZ = 0,
   FILTER_50HZ = 1,
+};
+
+enum MAX31856SamplesPerValue : uint8_t {
+  AVE_SAMPLES_1 = 0 << 4,
+  AVE_SAMPLES_2 = 1 << 4,
+  AVE_SAMPLES_4 = 2 << 4,
+  AVE_SAMPLES_8 = 3 << 4,
+  AVE_SAMPLES_16 = 4 << 4,
 };
 
 class MAX31856Sensor : public sensor::Sensor,
                        public PollingComponent,
                        public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARITY_LOW,
                                              spi::CLOCK_PHASE_TRAILING, spi::DATA_RATE_4MHZ> {
+#ifdef USE_BINARY_SENSOR
+  SUB_BINARY_SENSOR(has_fault)
+#endif
+
  public:
   void setup() override;
+  void loop() override;
+  void update() override;
+  void call_setup() override;
   void dump_config() override;
   float get_setup_priority() const override;
+
+  void set_type(MAX31856ThermocoupleType type) { type_ = type; }
   void set_filter(MAX31856ConfigFilter filter) { filter_ = filter; }
-  void update() override;
+  void set_samples_per_value(MAX31856SamplesPerValue value) { samples_per_value_ = value; }
+  void set_data_ready_pin(GPIOPin *pin) { data_ready_ = pin; }
 
  protected:
-  MAX31856ConfigFilter filter_;
+  MAX31856ThermocoupleType type_{};
+  MAX31856ConfigFilter filter_{};
+  MAX31856SamplesPerValue samples_per_value_{};
+  GPIOPin *data_ready_{};
+  uint8_t cr0_{};
+
+  void read_oneshot_temperature_();
+  void read_thermocouple_temperature_();
+  bool have_faults_();
 
   uint8_t read_register_(uint8_t reg);
+  uint16_t read_register16_(uint8_t reg);
   uint32_t read_register24_(uint8_t reg);
   void write_register_(uint8_t reg, uint8_t value);
-
-  void one_shot_temperature_();
-  bool has_fault_();
-  void clear_fault_();
-  void read_thermocouple_temperature_();
-  void set_thermocouple_type_();
-  void set_noise_filter_();
+  void write_bits_(uint8_t reg, uint8_t bits);
 };
 
 }  // namespace max31856

--- a/esphome/components/max31856/sensor.py
+++ b/esphome/components/max31856/sensor.py
@@ -1,12 +1,21 @@
+from esphome import pins
 import esphome.codegen as cg
 import esphome.config_validation as cv
-from esphome.components import sensor, spi
+from esphome.components import binary_sensor, sensor, spi
 from esphome.const import (
     CONF_MAINS_FILTER,
+    CONF_TYPE,
+    CONF_UPDATE_INTERVAL,
+    DEVICE_CLASS_PROBLEM,
     DEVICE_CLASS_TEMPERATURE,
+    ENTITY_CATEGORY_DIAGNOSTIC,
     STATE_CLASS_MEASUREMENT,
     UNIT_CELSIUS,
 )
+
+CONF_DATA_READY_PIN = "data_ready_pin"
+CONF_HAS_FAULT = "has_fault"
+CONF_SAMPLES_PER_VALUE = "samples_per_value"
 
 max31856_ns = cg.esphome_ns.namespace("max31856")
 MAX31856Sensor = max31856_ns.class_(
@@ -19,22 +28,68 @@ FILTER = {
     "60HZ": MAX31865ConfigFilter.FILTER_60HZ,
 }
 
+MAX31856ThermocoupleType = max31856_ns.enum("MAX31856ThermocoupleType")
+TYPE = {
+    "B": MAX31856ThermocoupleType.MAX31856_TCTYPE_B,
+    "E": MAX31856ThermocoupleType.MAX31856_TCTYPE_E,
+    "J": MAX31856ThermocoupleType.MAX31856_TCTYPE_J,
+    "K": MAX31856ThermocoupleType.MAX31856_TCTYPE_K,
+    "N": MAX31856ThermocoupleType.MAX31856_TCTYPE_N,
+    "R": MAX31856ThermocoupleType.MAX31856_TCTYPE_R,
+    "S": MAX31856ThermocoupleType.MAX31856_TCTYPE_S,
+    "T": MAX31856ThermocoupleType.MAX31856_TCTYPE_T,
+}
+
+MAX31856SamplesPerValue = max31856_ns.enum("MAX31856SamplesPerValue")
+SAMPLES_PER_VALUE = {
+    1: MAX31856SamplesPerValue.AVE_SAMPLES_1,
+    2: MAX31856SamplesPerValue.AVE_SAMPLES_2,
+    4: MAX31856SamplesPerValue.AVE_SAMPLES_4,
+    8: MAX31856SamplesPerValue.AVE_SAMPLES_8,
+    16: MAX31856SamplesPerValue.AVE_SAMPLES_16,
+}
+
+exclusive_err_msg = "Use only one of data_ready_pin or update_interval"
+
+# Unfortunately, Exclusive doesn't pass a default through to the base Optional so we have to set it manually
+exclusive_update_interval_with_default = cv.Exclusive(
+    CONF_UPDATE_INTERVAL,
+    "mode",
+    exclusive_err_msg,
+    "update_interval will enable polling mode",
+)
+exclusive_update_interval_with_default.default = lambda: "60s"
+
 CONFIG_SCHEMA = (
     sensor.sensor_schema(
         MAX31856Sensor,
         unit_of_measurement=UNIT_CELSIUS,
-        accuracy_decimals=1,
+        accuracy_decimals=3,
         device_class=DEVICE_CLASS_TEMPERATURE,
         state_class=STATE_CLASS_MEASUREMENT,
     )
     .extend(
         {
+            cv.Optional(CONF_HAS_FAULT): binary_sensor.binary_sensor_schema(
+                entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+                device_class=DEVICE_CLASS_PROBLEM,
+            ),
             cv.Optional(CONF_MAINS_FILTER, default="60HZ"): cv.enum(
                 FILTER, upper=True, space=""
             ),
+            cv.Optional(CONF_TYPE, default="K"): cv.enum(TYPE, upper=True, space=""),
+            cv.Optional(CONF_SAMPLES_PER_VALUE, default=1): cv.enum(
+                SAMPLES_PER_VALUE, int=True, space=""
+            ),
+            cv.Exclusive(
+                CONF_DATA_READY_PIN,
+                "mode",
+                exclusive_err_msg,
+                "data_ready_pin will enable autoconversion mode",
+            ): pins.gpio_input_pullup_pin_schema,
+            exclusive_update_interval_with_default: cv.update_interval,
         }
     )
-    .extend(cv.polling_component_schema("60s"))
     .extend(spi.spi_device_schema())
 )
 
@@ -44,3 +99,13 @@ async def to_code(config):
     await cg.register_component(var, config)
     await spi.register_spi_device(var, config)
     cg.add(var.set_filter(config[CONF_MAINS_FILTER]))
+    cg.add(var.set_samples_per_value(config[CONF_SAMPLES_PER_VALUE]))
+    cg.add(var.set_type(config[CONF_TYPE]))
+    data_ready_config = config.get(CONF_DATA_READY_PIN)
+    if data_ready_config is not None:
+        pin = await cg.gpio_pin_expression(data_ready_config)
+        cg.add(var.set_data_ready_pin(pin))
+    has_fault = config.get(CONF_HAS_FAULT)
+    if has_fault is not None:
+        sens = await binary_sensor.new_binary_sensor(has_fault)
+        cg.add(var.set_has_fault_binary_sensor(sens))


### PR DESCRIPTION
# What does this implement/fix?

It adds thermocouple type, autoconversion, averaging, and has_fault to the max31856 sensor while maintaining backwards compatibility with polling mode if the `data_ready_pin` is not specified.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#3803

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
sensor:
  - platform: max31856
    id: temperature_1
    name: "Temperature 1"
    has_fault:
      name: Temperature 1 Fault
    cs_pin: GPIO12
    data_ready_pin: GPIO13
    type: K
    samples_per_value: 16
  - platform: max31856
    id: temperature_2
    name: "Temperature 2"
    cs_pin: GPIO33
    type: T
    samples_per_value: 2
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
