### PR TITLE
Fix recent definitions into `defines.h`

### DIFF
--- a/esphome/core/defines.h
+++ b/esphome/core/defines.h
@@ -65,7 +65,6 @@
 // Arduino-specific feature flags
 #ifdef USE_ARDUINO
 #define USE_CAPTIVE_PORTAL
-#define USE_NEXTION_TFT_UPLOAD
 #define USE_PROMETHEUS
 #define USE_WEBSERVER
 #define USE_WEBSERVER_PORT 80  // NOLINT

--- a/esphome/core/defines.h
+++ b/esphome/core/defines.h
@@ -35,6 +35,7 @@
 #define USE_MDNS
 #define USE_MEDIA_PLAYER
 #define USE_MQTT
+#define USE_NEXTION_TFT_UPLOAD
 #define USE_NUMBER
 #define USE_DATETIME
 #define USE_DATETIME_DATE
@@ -78,10 +79,12 @@
 
 // ESP32-specific feature flags
 #ifdef USE_ESP32
+#define USE_ESP32_BLE
 #define USE_ESP32_BLE_CLIENT
 #define USE_ESP32_BLE_SERVER
 #define USE_ESP32_CAMERA
 #define USE_IMPROV
+#define USE_PSRAM
 #define USE_SOCKET_IMPL_BSD_SOCKETS
 #define USE_WIFI_11KV_SUPPORT
 #define USE_BLUETOOTH_PROXY


### PR DESCRIPTION
# What does this implement/fix?

This fixes missing definitions on `defines.h`:

- `USE_ESP32_BLE`: Should have be added by #6585 
- `USE_NEXTION_TFT_UPLOAD`: Should have be moved by #5667 
- `USE_PSRAM`: Should have be added by #6526 

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** N/A, but looks like this was being reported in some clang.

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [X] ESP32
- [X] ESP32 IDF
- [X] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
N/A

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
