### PR TITLE
External components: optional configurable path for git source

### DIFF
--- a/esphome/components/external_components/__init__.py
+++ b/esphome/components/external_components/__init__.py
@@ -49,8 +49,7 @@ def _process_git_config(config: dict, refresh) -> str:
         password=config.get(CONF_PASSWORD),
     )
 
-    path = config.get(CONF_PATH)
-    if path is not None:
+    if path := config.get(CONF_PATH):
         if (repo_dir / path).is_dir():
             components_dir = repo_dir / path
         else:

--- a/esphome/components/external_components/__init__.py
+++ b/esphome/components/external_components/__init__.py
@@ -49,7 +49,17 @@ def _process_git_config(config: dict, refresh) -> str:
         password=config.get(CONF_PASSWORD),
     )
 
-    if (repo_dir / "esphome" / "components").is_dir():
+    path = config.get(CONF_PATH)
+    if path is not None:
+        if (repo_dir / path).is_dir():
+            components_dir = repo_dir / path
+        else:
+            raise cv.Invalid(
+                "Could not find components folder for source. Please check the source contains a '"
+                + path
+                + "' folder"
+            )
+    elif (repo_dir / "esphome" / "components").is_dir():
         components_dir = repo_dir / "esphome" / "components"
     elif (repo_dir / "components").is_dir():
         components_dir = repo_dir / "components"

--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -2124,6 +2124,7 @@ GIT_SCHEMA = Schema(
         Optional(CONF_REF): git_ref,
         Optional(CONF_USERNAME): string,
         Optional(CONF_PASSWORD): string,
+        Optional(CONF_PATH): string,
     }
 )
 LOCAL_SCHEMA = Schema(


### PR DESCRIPTION
# What does this implement/fix?

Adds optional `path` for external component's git source.

This enables pulling custom external components from other folders than `components` and `esphome/components` in the top level directory of a git repository. This flexibility allows better organization for projects that keep more than just firmware in their repo.

Example folder structure in my repo:
- firmware/
  - node.yaml
  - components/...
- electronics/... (KiCad)
- mechanical/... (3D printing)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#3815

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
external_components:
  - source:
      type: git
      url: ssh://git@github.com/twasilczyk/my-project.git
      path: firmware/components
  - source:
      type: local
      path: components
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
