### PR TITLE
fix conflict with EMPTY macro in zephyr

### DIFF
--- a/esphome/core/automation.h
+++ b/esphome/core/automation.h
@@ -24,7 +24,7 @@ template<int... S> struct gens<0, S...> { using type = seq<S...>; };  // NOLINT
 
 template<typename T, typename... X> class TemplatableValue {
  public:
-  TemplatableValue() : type_(EMPTY) {}
+  TemplatableValue() : type_(ESPHOME_EMPTY) {}
 
   template<typename F, enable_if_t<!is_invocable<F, X...>::value, int> = 0>
   TemplatableValue(F value) : type_(VALUE), value_(value) {}
@@ -32,7 +32,7 @@ template<typename T, typename... X> class TemplatableValue {
   template<typename F, enable_if_t<is_invocable<F, X...>::value, int> = 0>
   TemplatableValue(F f) : type_(LAMBDA), f_(f) {}
 
-  bool has_value() { return this->type_ != EMPTY; }
+  bool has_value() { return this->type_ != ESPHOME_EMPTY; }
 
   T value(X... x) {
     if (this->type_ == LAMBDA) {
@@ -58,7 +58,7 @@ template<typename T, typename... X> class TemplatableValue {
 
  protected:
   enum {
-    EMPTY,
+    ESPHOME_EMPTY,
     VALUE,
     LAMBDA,
   } type_;

--- a/esphome/core/automation.h
+++ b/esphome/core/automation.h
@@ -24,7 +24,7 @@ template<int... S> struct gens<0, S...> { using type = seq<S...>; };  // NOLINT
 
 template<typename T, typename... X> class TemplatableValue {
  public:
-  TemplatableValue() : type_(ESPHOME_EMPTY) {}
+  TemplatableValue() : type_(NONE) {}
 
   template<typename F, enable_if_t<!is_invocable<F, X...>::value, int> = 0>
   TemplatableValue(F value) : type_(VALUE), value_(value) {}
@@ -32,13 +32,13 @@ template<typename T, typename... X> class TemplatableValue {
   template<typename F, enable_if_t<is_invocable<F, X...>::value, int> = 0>
   TemplatableValue(F f) : type_(LAMBDA), f_(f) {}
 
-  bool has_value() { return this->type_ != ESPHOME_EMPTY; }
+  bool has_value() { return this->type_ != NONE; }
 
   T value(X... x) {
     if (this->type_ == LAMBDA) {
       return this->f_(x...);
     }
-    // return value also when empty
+    // return value also when none
     return this->value_;
   }
 
@@ -58,7 +58,7 @@ template<typename T, typename... X> class TemplatableValue {
 
  protected:
   enum {
-    ESPHOME_EMPTY,
+    NONE,
     VALUE,
     LAMBDA,
   } type_;


### PR DESCRIPTION
# What does this implement/fix?

Part of https://github.com/esphome/esphome/pull/6075 which solve name conflict with zephyr define.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
