### PR TITLE
[mlx90614] Fix frozen values in case of i2c communication error

### DIFF
--- a/esphome/components/i2c/i2c_bus.h
+++ b/esphome/components/i2c/i2c_bus.h
@@ -91,6 +91,8 @@ class I2CBus {
   /// @details This is a pure virtual method that must be implemented in the subclass.
   virtual ErrorCode writev(uint8_t address, WriteBuffer *buffers, size_t count, bool stop) = 0;
 
+  virtual void recover() = 0;
+
  protected:
   /// @brief Scans the I2C bus for devices. Devices presence is kept in an array of std::pair
   /// that contains the address and the corresponding bool presence flag.

--- a/esphome/components/i2c/i2c_bus.h
+++ b/esphome/components/i2c/i2c_bus.h
@@ -32,6 +32,14 @@ struct WriteBuffer {
   size_t len;           ///< length of the buffer
 };
 
+/// @brief Error codes returned by I2CBus::recover method
+enum RecoveryCode {
+  RECOVERY_COMPLETED = 0,
+  RECOVERY_FAILURE_OTHER,
+  RECOVERY_FAILED_SCL_LOW,
+  RECOVERY_FAILED_SDA_LOW,
+};
+
 /// @brief This Class provides the methods to read and write bytes from an I2CBus.
 /// @note The I2CBus virtual class follows a *Factory design pattern* that provides all the interfaces methods required
 /// by clients while deferring the actual implementation of these methods to a subclasses. I2C-bus specification and
@@ -91,7 +99,7 @@ class I2CBus {
   /// @details This is a pure virtual method that must be implemented in the subclass.
   virtual ErrorCode writev(uint8_t address, WriteBuffer *buffers, size_t count, bool stop) = 0;
 
-  virtual void recover() = 0;
+  virtual RecoveryCode recover() = 0;
 
  protected:
   /// @brief Scans the I2C bus for devices. Devices presence is kept in an array of std::pair

--- a/esphome/components/i2c/i2c_bus_arduino.cpp
+++ b/esphome/components/i2c/i2c_bus_arduino.cpp
@@ -212,8 +212,17 @@ ErrorCode ArduinoI2CBus::writev(uint8_t address, WriteBuffer *buffers, size_t cn
 }
 
 RecoveryCode ArduinoI2CBus::recover() {
+#if defined(USE_ESP8266)
+  delete wire_;
+#else
   wire_->end();
+#endif
+
   auto result = this->recover_();
+
+#if defined(USE_ESP8266)
+  wire_ = new TwoWire();
+#endif
   wire_->begin();
   return result;
 }

--- a/esphome/components/i2c/i2c_bus_arduino.cpp
+++ b/esphome/components/i2c/i2c_bus_arduino.cpp
@@ -13,7 +13,7 @@ namespace i2c {
 static const char *const TAG = "i2c.arduino";
 
 void ArduinoI2CBus::setup() {
-  recover_();
+  this->initial_recovery_result_ = recover_();
 
 #if defined(USE_ESP32)
   static uint8_t next_bus_num = 0;
@@ -81,7 +81,7 @@ void ArduinoI2CBus::dump_config() {
     ESP_LOGCONFIG(TAG, "  Timeout: %u ms", this->timeout_ / 1000);
 #endif
   }
-  switch (this->recovery_result_) {
+  switch (this->initial_recovery_result_) {
     case RECOVERY_COMPLETED:
       ESP_LOGCONFIG(TAG, "  Recovery: bus successfully recovered");
       break;
@@ -90,6 +90,9 @@ void ArduinoI2CBus::dump_config() {
       break;
     case RECOVERY_FAILED_SDA_LOW:
       ESP_LOGCONFIG(TAG, "  Recovery: failed, SDA is held low on the bus");
+      break;
+    case RECOVERY_FAILURE_OTHER:
+      ESP_LOGCONFIG(TAG, "  Recovery: failed");
       break;
   }
   if (this->scan_) {

--- a/esphome/components/i2c/i2c_bus_arduino.cpp
+++ b/esphome/components/i2c/i2c_bus_arduino.cpp
@@ -212,18 +212,13 @@ ErrorCode ArduinoI2CBus::writev(uint8_t address, WriteBuffer *buffers, size_t cn
 }
 
 RecoveryCode ArduinoI2CBus::recover() {
-#if defined(USE_ESP8266)
-  delete wire_;
-#else
+#if !defined(USE_ESP8266)
   wire_->end();
 #endif
 
   auto result = this->recover_();
 
-#if defined(USE_ESP8266)
-  wire_ = new TwoWire();
-#endif
-  wire_->begin();
+  this->set_pins_and_clock_();
   return result;
 }
 

--- a/esphome/components/i2c/i2c_bus_arduino.cpp
+++ b/esphome/components/i2c/i2c_bus_arduino.cpp
@@ -211,6 +211,12 @@ ErrorCode ArduinoI2CBus::writev(uint8_t address, WriteBuffer *buffers, size_t cn
   }
 }
 
+void ArduinoI2CBus::recover() {
+  wire_->end();
+  this->recover_();
+  wire_->begin();
+}
+
 /// Perform I2C bus recovery, see:
 /// https://www.nxp.com/docs/en/user-guide/UM10204.pdf
 /// https://www.analog.com/media/en/technical-documentation/application-notes/54305147357414AN686_0.pdf

--- a/esphome/components/i2c/i2c_bus_arduino.h
+++ b/esphome/components/i2c/i2c_bus_arduino.h
@@ -22,6 +22,7 @@ class ArduinoI2CBus : public I2CBus, public Component {
   ErrorCode readv(uint8_t address, ReadBuffer *buffers, size_t cnt) override;
   ErrorCode writev(uint8_t address, WriteBuffer *buffers, size_t cnt, bool stop) override;
   float get_setup_priority() const override { return setup_priority::BUS; }
+  void recover() override { _recover(); }
 
   void set_scan(bool scan) { scan_ = scan; }
   void set_sda_pin(uint8_t sda_pin) { sda_pin_ = sda_pin; }

--- a/esphome/components/i2c/i2c_bus_arduino.h
+++ b/esphome/components/i2c/i2c_bus_arduino.h
@@ -27,6 +27,7 @@ class ArduinoI2CBus : public I2CBus, public Component {
  private:
   RecoveryCode recover_();
   void set_pins_and_clock_();
+  RecoveryCode initial_recovery_result_;
 
  protected:
   TwoWire *wire_;

--- a/esphome/components/i2c/i2c_bus_arduino.h
+++ b/esphome/components/i2c/i2c_bus_arduino.h
@@ -22,7 +22,7 @@ class ArduinoI2CBus : public I2CBus, public Component {
   ErrorCode readv(uint8_t address, ReadBuffer *buffers, size_t cnt) override;
   ErrorCode writev(uint8_t address, WriteBuffer *buffers, size_t cnt, bool stop) override;
   float get_setup_priority() const override { return setup_priority::BUS; }
-  void recover() override { this->recover_(); }
+  void recover() override;
 
   void set_scan(bool scan) { scan_ = scan; }
   void set_sda_pin(uint8_t sda_pin) { sda_pin_ = sda_pin; }

--- a/esphome/components/i2c/i2c_bus_arduino.h
+++ b/esphome/components/i2c/i2c_bus_arduino.h
@@ -22,7 +22,7 @@ class ArduinoI2CBus : public I2CBus, public Component {
   ErrorCode readv(uint8_t address, ReadBuffer *buffers, size_t cnt) override;
   ErrorCode writev(uint8_t address, WriteBuffer *buffers, size_t cnt, bool stop) override;
   float get_setup_priority() const override { return setup_priority::BUS; }
-  void recover() override { _recover(); }
+  void recover() override { this->recover_(); }
 
   void set_scan(bool scan) { scan_ = scan; }
   void set_sda_pin(uint8_t sda_pin) { sda_pin_ = sda_pin; }

--- a/esphome/components/i2c/i2c_bus_arduino.h
+++ b/esphome/components/i2c/i2c_bus_arduino.h
@@ -9,12 +9,6 @@
 namespace esphome {
 namespace i2c {
 
-enum RecoveryCode {
-  RECOVERY_FAILED_SCL_LOW,
-  RECOVERY_FAILED_SDA_LOW,
-  RECOVERY_COMPLETED,
-};
-
 class ArduinoI2CBus : public I2CBus, public Component {
  public:
   void setup() override;
@@ -22,7 +16,7 @@ class ArduinoI2CBus : public I2CBus, public Component {
   ErrorCode readv(uint8_t address, ReadBuffer *buffers, size_t cnt) override;
   ErrorCode writev(uint8_t address, WriteBuffer *buffers, size_t cnt, bool stop) override;
   float get_setup_priority() const override { return setup_priority::BUS; }
-  void recover() override;
+  RecoveryCode recover() override;
 
   void set_scan(bool scan) { scan_ = scan; }
   void set_sda_pin(uint8_t sda_pin) { sda_pin_ = sda_pin; }
@@ -31,9 +25,8 @@ class ArduinoI2CBus : public I2CBus, public Component {
   void set_timeout(uint32_t timeout) { timeout_ = timeout; }
 
  private:
-  void recover_();
+  RecoveryCode recover_();
   void set_pins_and_clock_();
-  RecoveryCode recovery_result_;
 
  protected:
   TwoWire *wire_;

--- a/esphome/components/i2c/i2c_bus_esp_idf.cpp
+++ b/esphome/components/i2c/i2c_bus_esp_idf.cpp
@@ -245,26 +245,28 @@ ErrorCode IDFI2CBus::writev(uint8_t address, WriteBuffer *buffers, size_t cnt, b
   return ERROR_OK;
 }
 
-void IDFI2CBus::recover() {
+RecoveryCode IDFI2CBus::recover() {
   auto err = i2c_driver_delete(port_);
   if (err != ESP_OK) {
     ESP_LOGW(TAG, "i2c_driver_delete failed: %s", esp_err_to_name(err));
     this->mark_failed();
   }
 
-  this->recover_();
+  auto result = this->recover_();
 
   err = i2c_driver_install(port_, I2C_MODE_MASTER, 0, 0, ESP_INTR_FLAG_IRAM);
   if (err != ESP_OK) {
     ESP_LOGW(TAG, "i2c_driver_install failed: %s", esp_err_to_name(err));
     this->mark_failed();
   }
+
+  return result;
 }
 
 /// Perform I2C bus recovery, see:
 /// https://www.nxp.com/docs/en/user-guide/UM10204.pdf
 /// https://www.analog.com/media/en/technical-documentation/application-notes/54305147357414AN686_0.pdf
-void IDFI2CBus::recover_() {
+RecoveryCode IDFI2CBus::recover_() {
   ESP_LOGI(TAG, "Performing I2C bus recovery");
 
   const gpio_num_t scl_pin = static_cast<gpio_num_t>(scl_pin_);
@@ -303,8 +305,7 @@ void IDFI2CBus::recover_() {
   delayMicroseconds(half_period_usec);
   if (gpio_get_level(scl_pin) == 0) {
     ESP_LOGE(TAG, "Recovery failed: SCL is held LOW on the I2C bus");
-    recovery_result_ = RECOVERY_FAILED_SCL_LOW;
-    return;
+    return RECOVERY_FAILED_SCL_LOW;
   }
 
   // From the specification:
@@ -334,8 +335,7 @@ void IDFI2CBus::recover_() {
     }
     if (gpio_get_level(scl_pin) == 0) {
       ESP_LOGE(TAG, "Recovery failed: SCL is held LOW during clock pulse cycle");
-      recovery_result_ = RECOVERY_FAILED_SCL_LOW;
-      return;
+      return RECOVERY_FAILED_SCL_LOW;
     }
   }
 
@@ -344,8 +344,7 @@ void IDFI2CBus::recover_() {
   // in SDA being pulled up.
   if (gpio_get_level(sda_pin) == 0) {
     ESP_LOGE(TAG, "Recovery failed: SDA is held LOW after clock pulse cycle");
-    recovery_result_ = RECOVERY_FAILED_SDA_LOW;
-    return;
+    return RECOVERY_FAILED_SDA_LOW;
   }
 
   // From the specification:
@@ -371,7 +370,7 @@ void IDFI2CBus::recover_() {
   delayMicroseconds(half_period_usec);
   gpio_set_level(sda_pin, 1);
 
-  recovery_result_ = RECOVERY_COMPLETED;
+  return RECOVERY_COMPLETED;
 }
 
 }  // namespace i2c

--- a/esphome/components/i2c/i2c_bus_esp_idf.cpp
+++ b/esphome/components/i2c/i2c_bus_esp_idf.cpp
@@ -245,6 +245,22 @@ ErrorCode IDFI2CBus::writev(uint8_t address, WriteBuffer *buffers, size_t cnt, b
   return ERROR_OK;
 }
 
+void IDFI2CBus::recover() {
+  auto err = i2c_driver_delete(port_);
+  if (err != ESP_OK) {
+    ESP_LOGW(TAG, "i2c_driver_delete failed: %s", esp_err_to_name(err));
+    this->mark_failed();
+  }
+
+  this->recover_();
+
+  err = i2c_driver_install(port_, I2C_MODE_MASTER, 0, 0, ESP_INTR_FLAG_IRAM);
+  if (err != ESP_OK) {
+    ESP_LOGW(TAG, "i2c_driver_install failed: %s", esp_err_to_name(err));
+    this->mark_failed();
+  }
+}
+
 /// Perform I2C bus recovery, see:
 /// https://www.nxp.com/docs/en/user-guide/UM10204.pdf
 /// https://www.analog.com/media/en/technical-documentation/application-notes/54305147357414AN686_0.pdf

--- a/esphome/components/i2c/i2c_bus_esp_idf.cpp
+++ b/esphome/components/i2c/i2c_bus_esp_idf.cpp
@@ -29,7 +29,7 @@ void IDFI2CBus::setup() {
     return;
   }
 
-  recover_();
+  this->initial_recovery_result_ = recover_();
 
   i2c_config_t conf{};
   memset(&conf, 0, sizeof(conf));
@@ -79,7 +79,7 @@ void IDFI2CBus::dump_config() {
   if (timeout_ > 0) {
     ESP_LOGCONFIG(TAG, "  Timeout: %" PRIu32 "us", this->timeout_);
   }
-  switch (this->recovery_result_) {
+  switch (this->initial_recovery_result_) {
     case RECOVERY_COMPLETED:
       ESP_LOGCONFIG(TAG, "  Recovery: bus successfully recovered");
       break;
@@ -88,6 +88,9 @@ void IDFI2CBus::dump_config() {
       break;
     case RECOVERY_FAILED_SDA_LOW:
       ESP_LOGCONFIG(TAG, "  Recovery: failed, SDA is held low on the bus");
+      break;
+    case RECOVERY_FAILURE_OTHER:
+      ESP_LOGCONFIG(TAG, "  Recovery: failed");
       break;
   }
   if (this->scan_) {

--- a/esphome/components/i2c/i2c_bus_esp_idf.h
+++ b/esphome/components/i2c/i2c_bus_esp_idf.h
@@ -22,6 +22,7 @@ class IDFI2CBus : public I2CBus, public Component {
   ErrorCode readv(uint8_t address, ReadBuffer *buffers, size_t cnt) override;
   ErrorCode writev(uint8_t address, WriteBuffer *buffers, size_t cnt, bool stop) override;
   float get_setup_priority() const override { return setup_priority::BUS; }
+  void recover() override { _recover(); }
 
   void set_scan(bool scan) { scan_ = scan; }
   void set_sda_pin(uint8_t sda_pin) { sda_pin_ = sda_pin; }

--- a/esphome/components/i2c/i2c_bus_esp_idf.h
+++ b/esphome/components/i2c/i2c_bus_esp_idf.h
@@ -22,7 +22,7 @@ class IDFI2CBus : public I2CBus, public Component {
   ErrorCode readv(uint8_t address, ReadBuffer *buffers, size_t cnt) override;
   ErrorCode writev(uint8_t address, WriteBuffer *buffers, size_t cnt, bool stop) override;
   float get_setup_priority() const override { return setup_priority::BUS; }
-  void recover() override { this->recover_(); }
+  void recover() override;
 
   void set_scan(bool scan) { scan_ = scan; }
   void set_sda_pin(uint8_t sda_pin) { sda_pin_ = sda_pin; }

--- a/esphome/components/i2c/i2c_bus_esp_idf.h
+++ b/esphome/components/i2c/i2c_bus_esp_idf.h
@@ -28,6 +28,7 @@ class IDFI2CBus : public I2CBus, public Component {
 
  private:
   RecoveryCode recover_();
+  RecoveryCode initial_recovery_result_;
 
  protected:
   i2c_port_t port_;

--- a/esphome/components/i2c/i2c_bus_esp_idf.h
+++ b/esphome/components/i2c/i2c_bus_esp_idf.h
@@ -9,12 +9,6 @@
 namespace esphome {
 namespace i2c {
 
-enum RecoveryCode {
-  RECOVERY_FAILED_SCL_LOW,
-  RECOVERY_FAILED_SDA_LOW,
-  RECOVERY_COMPLETED,
-};
-
 class IDFI2CBus : public I2CBus, public Component {
  public:
   void setup() override;
@@ -22,7 +16,7 @@ class IDFI2CBus : public I2CBus, public Component {
   ErrorCode readv(uint8_t address, ReadBuffer *buffers, size_t cnt) override;
   ErrorCode writev(uint8_t address, WriteBuffer *buffers, size_t cnt, bool stop) override;
   float get_setup_priority() const override { return setup_priority::BUS; }
-  void recover() override;
+  RecoveryCode recover() override;
 
   void set_scan(bool scan) { scan_ = scan; }
   void set_sda_pin(uint8_t sda_pin) { sda_pin_ = sda_pin; }
@@ -31,10 +25,6 @@ class IDFI2CBus : public I2CBus, public Component {
   void set_scl_pullup_enabled(bool scl_pullup_enabled) { scl_pullup_enabled_ = scl_pullup_enabled; }
   void set_frequency(uint32_t frequency) { frequency_ = frequency; }
   void set_timeout(uint32_t timeout) { timeout_ = timeout; }
-
- private:
-  void recover_();
-  RecoveryCode recovery_result_;
 
  protected:
   i2c_port_t port_;

--- a/esphome/components/i2c/i2c_bus_esp_idf.h
+++ b/esphome/components/i2c/i2c_bus_esp_idf.h
@@ -22,7 +22,7 @@ class IDFI2CBus : public I2CBus, public Component {
   ErrorCode readv(uint8_t address, ReadBuffer *buffers, size_t cnt) override;
   ErrorCode writev(uint8_t address, WriteBuffer *buffers, size_t cnt, bool stop) override;
   float get_setup_priority() const override { return setup_priority::BUS; }
-  void recover() override { _recover(); }
+  void recover() override { this->recover_(); }
 
   void set_scan(bool scan) { scan_ = scan; }
   void set_sda_pin(uint8_t sda_pin) { sda_pin_ = sda_pin; }

--- a/esphome/components/i2c/i2c_bus_esp_idf.h
+++ b/esphome/components/i2c/i2c_bus_esp_idf.h
@@ -26,6 +26,9 @@ class IDFI2CBus : public I2CBus, public Component {
   void set_frequency(uint32_t frequency) { frequency_ = frequency; }
   void set_timeout(uint32_t timeout) { timeout_ = timeout; }
 
+ private:
+  RecoveryCode recover_();
+
  protected:
   i2c_port_t port_;
   uint8_t sda_pin_;

--- a/esphome/components/mlx90614/mlx90614.cpp
+++ b/esphome/components/mlx90614/mlx90614.cpp
@@ -38,16 +38,7 @@ void MLX90614Component::setup() {
 bool MLX90614Component::write_emissivity_() {
   if (std::isnan(this->emissivity_))
     return true;
-  uint16_t value = (uint16_t) (this->emissivity_ * 65535);
-  if (!this->write_bytes_(MLX90614_EMISSIVITY, 0)) {
-    return false;
-  }
-  delay(10);
-  if (!this->write_bytes_(MLX90614_EMISSIVITY, value)) {
-    return false;
-  }
-  delay(10);
-  return true;
+  return this->write_register_(MLX90614_EMISSIVITY, this->emissivity_ * 0xFFFF);
 }
 
 uint8_t MLX90614Component::crc8_pec_(const uint8_t *data, uint8_t len) {
@@ -65,14 +56,95 @@ uint8_t MLX90614Component::crc8_pec_(const uint8_t *data, uint8_t len) {
   return crc;
 }
 
-bool MLX90614Component::write_bytes_(uint8_t reg, uint16_t data) {
+i2c::ErrorCode MLX90614Component::write_register_(uint8_t reg, uint16_t data, uint8_t max_try) {
   uint8_t buf[5];
-  buf[0] = this->address_ << 1;
-  buf[1] = reg;
-  buf[2] = data & 0xFF;
-  buf[3] = data >> 8;
-  buf[4] = this->crc8_pec_(buf, 4);
-  return this->write_bytes(reg, buf + 2, 3);
+  i2c::ErrorCode ec = i2c::ERROR_UNKNOWN;
+  auto init_buffer = [&]() {
+    buf[0] = this->address_ << 1;
+    buf[1] = reg;
+  };
+
+  // See 8.3.3.1. ERPROM write sequence
+  // 1. Power up the device
+  const uint8_t delay_ms = 10;
+  for (uint8_t i_try = 0; i_try < max_try; ++i_try) {
+    init_buffer();
+
+    // 2. Write 0x0000 into the cell of interest (effectively erasing the cell)
+    buf[2] = buf[3] = 0;
+    buf[4] = this->crc8_pec_(buf, 4);
+    if (!this->write_bytes(reg, buf + 2, 3)) {
+      ESP_LOGW(TAG, "Try %d: Can't clean register %x", i_try, reg);
+      ec = i2c::ERROR_UNKNOWN;
+      continue;
+    }
+
+    // 3. Wait at least 5ms (10ms to be on the safe side)
+    delay(delay_ms);
+
+    // 4. Write the new value
+    if (data != 0) {
+      buf[2] = data & 0xFF;
+      buf[3] = data >> 8;
+      buf[4] = this->crc8_pec_(buf, 4);
+      if (!this->write_bytes(reg, buf + 2, 3)) {
+        ESP_LOGW(TAG, "Try %d: Can't write register %x", i_try, reg);
+        ec = i2c::ERROR_UNKNOWN;
+        continue;
+      }
+
+      // 5. Wait at least 5ms (10ms to be on the safe side)
+      delay(delay_ms);
+    }
+
+    uint8_t read_buf[3];
+    // 6. Read back and compare if the write was successful
+    ec = this->read_register(reg, read_buf, 3, false);
+    if (ec != i2c::ERROR_OK) {
+      ESP_LOGW(TAG, "Try %d: Can't check register value %x", i_try, reg);
+      continue;
+    }
+
+    if (read_buf[0] != buf[2] || read_buf[1] != buf[3] || read_buf[2] != buf[4]) {
+      ESP_LOGW(TAG, "Try %d: Read back value is not the same. Expected %x%x%x. Actual %x%x%x", i_try, buf[2], buf[3],
+               buf[4], read_buf[0], read_buf[1], read_buf[2]);
+      ec = i2c::ERROR_CRC;
+      continue;
+    }
+
+    return i2c::ERROR_OK;
+  }
+
+  ESP_LOGE(TAG, "Out of tries");
+  return ec;
+}
+
+uint16_t MLX90614Component::read_register_(uint8_t reg, i2c::ErrorCode &ec, uint8_t max_try) {
+  uint8_t buf[6] = {
+      uint8_t(this->address_ << 1),
+      reg,
+      uint8_t(0x01 | (this->address_ << 1)),
+  };
+  for (uint8_t i_try = 0; i_try < max_try; ++i_try) {
+    ec = this->read_register(reg, buf + 3, 3, false);
+
+    if (ec != i2c::ERROR_OK) {
+      ESP_LOGW(TAG, "Try %d: i2c read error %d", i_try, ec);
+      continue;
+    }
+
+    const auto expected_pec = this->crc8_pec_(buf, 5);
+    if (buf[5] != expected_pec) {
+      ESP_LOGW(TAG, "Try %d: i2c CRC error. Expected %x. Actual %x", i_try, expected_pec, buf[4]);
+      ec = i2c::ERROR_CRC;
+      continue;
+    }
+
+    ec = i2c::ERROR_OK;
+    return encode_uint16(buf[4], buf[3]);
+  }
+
+  return 0;
 }
 
 void MLX90614Component::dump_config() {
@@ -89,33 +161,46 @@ void MLX90614Component::dump_config() {
 float MLX90614Component::get_setup_priority() const { return setup_priority::DATA; }
 
 void MLX90614Component::update() {
-  uint8_t emissivity[3];
-  if (this->read_register(MLX90614_EMISSIVITY, emissivity, 3, false) != i2c::ERROR_OK) {
-    this->status_set_warning();
-    return;
+  bool write_emissivity_status = true;
+  if (!std::isnan(this->emissivity_)) {
+    i2c::ErrorCode ec = i2c::ERROR_OK;
+    const auto read_emissivity = read_register_(MLX90614_EMISSIVITY, ec);
+    if (ec == i2c::ERROR_OK) {
+      const auto desired_emissivity = uint16_t(this->emissivity_ * 0xFFFF);
+      if (read_emissivity != desired_emissivity) {
+        if (i2c::ERROR_OK != this->write_register_(MLX90614_EMISSIVITY, desired_emissivity)) {
+          write_emissivity_status = false;
+        }
+      }
+    } else {
+      write_emissivity_status = false;
+    }
   }
-  uint8_t raw_object[3];
-  if (this->read_register(MLX90614_TEMPERATURE_OBJECT_1, raw_object, 3, false) != i2c::ERROR_OK) {
+
+  auto publish_sensor = [&](sensor::Sensor *sensor, uint8_t reg) {
+    if (nullptr == sensor) {
+      return true;
+    }
+
+    i2c::ErrorCode ec = i2c::ERROR_OK;
+    const auto raw = read_register_(reg, ec);
+    if (ec != i2c::ERROR_OK) {
+      sensor->publish_state(NAN);
+      return false;
+    }
+    float value = raw & 0x8000 ? NAN : raw * 0.02f - 273.15f;
+    sensor->publish_state(value);
+    return true;
+  };
+
+  const auto object_updated = publish_sensor(this->object_sensor_, MLX90614_TEMPERATURE_OBJECT_1);
+  const auto ambient_updated = publish_sensor(this->ambient_sensor_, MLX90614_TEMPERATURE_AMBIENT);
+
+  if (object_updated && ambient_updated && write_emissivity_status) {
+    this->status_clear_warning();
+  } else {
     this->status_set_warning();
-    return;
   }
-
-  uint8_t raw_ambient[3];
-  if (this->read_register(MLX90614_TEMPERATURE_AMBIENT, raw_ambient, 3, false) != i2c::ERROR_OK) {
-    this->status_set_warning();
-    return;
-  }
-
-  float ambient = raw_ambient[1] & 0x80 ? NAN : encode_uint16(raw_ambient[1], raw_ambient[0]) * 0.02f - 273.15f;
-  float object = raw_object[1] & 0x80 ? NAN : encode_uint16(raw_object[1], raw_object[0]) * 0.02f - 273.15f;
-
-  ESP_LOGD(TAG, "Got Temperature=%.1f°C Ambient=%.1f°C", object, ambient);
-
-  if (this->ambient_sensor_ != nullptr && !std::isnan(ambient))
-    this->ambient_sensor_->publish_state(ambient);
-  if (this->object_sensor_ != nullptr && !std::isnan(object))
-    this->object_sensor_->publish_state(object);
-  this->status_clear_warning();
 }
 
 }  // namespace mlx90614

--- a/esphome/components/mlx90614/mlx90614.cpp
+++ b/esphome/components/mlx90614/mlx90614.cpp
@@ -177,7 +177,7 @@ void MLX90614Component::update() {
   }
 
   float ambient = raw_ambient & 0x8000 ? NAN : raw_ambient * 0.02f - 273.15f;
-  float object = raw_object & 0x8000 ? NAN : raw_ambient * 0.02f - 273.15f;
+  float object = raw_object & 0x8000 ? NAN : raw_object * 0.02f - 273.15f;
 
   ESP_LOGD(TAG, "Got Temperature=%.1f°C Ambient=%.1f°C", object, ambient);
 

--- a/esphome/components/mlx90614/mlx90614.cpp
+++ b/esphome/components/mlx90614/mlx90614.cpp
@@ -131,7 +131,7 @@ uint16_t MLX90614Component::read_register_(uint8_t reg, i2c::ErrorCode &ec, uint
     if (ec == i2c::ERROR_TIMEOUT) {
       // Recover bus
       ESP_LOGW(TAG, "Recovering bus on read timeout.");
-      bus_->setup();
+      bus_->recover();
       continue;
     }
 

--- a/esphome/components/mlx90614/mlx90614.cpp
+++ b/esphome/components/mlx90614/mlx90614.cpp
@@ -39,15 +39,7 @@ bool MLX90614Component::write_emissivity_() {
   if (std::isnan(this->emissivity_))
     return true;
   uint16_t value = (uint16_t) (this->emissivity_ * 65535);
-  if (!this->write_bytes_(MLX90614_EMISSIVITY, 0)) {
-    return false;
-  }
-  delay(10);
-  if (!this->write_bytes_(MLX90614_EMISSIVITY, value)) {
-    return false;
-  }
-  delay(10);
-  return true;
+  return this->write_bytes_(MLX90614_EMISSIVITY, 0));
 }
 
 uint8_t MLX90614Component::crc8_pec_(const uint8_t *data, uint8_t len) {
@@ -65,14 +57,90 @@ uint8_t MLX90614Component::crc8_pec_(const uint8_t *data, uint8_t len) {
   return crc;
 }
 
-bool MLX90614Component::write_bytes_(uint8_t reg, uint16_t data) {
+bool MLX90614Component::write_regiser_(const uint8_t reg, const uint16_t data, const uint8_t max_try) {
   uint8_t buf[5];
-  buf[0] = this->address_ << 1;
-  buf[1] = reg;
-  buf[2] = data & 0xFF;
-  buf[3] = data >> 8;
-  buf[4] = this->crc8_pec_(buf, 4);
-  return this->write_bytes(reg, buf + 2, 3);
+
+  auto init_buffer = [&]() {
+    buf[0] = this->address_ << 1;
+    buf[1] = reg;
+  };
+
+  // See 8.3.3.1. ERPROMwritesequence sequence sequence
+  // 1. Power up the device
+  uint8_t delay_ms = 10;
+  for (uint8_t i_try = 0; i_try < max_try; ++i) {
+    init_buffer();
+
+    // 2. Write 0x0000 into the cell of interest (effectively erasing the cell)
+    buf[2] = buf[3] = 0;
+    buf[4] = this->crc8_pec_(buf, 4);
+    if (!this->write_bytes(reg, buf + 2, 3)) {
+      ESP_LOGW(TAG, "Try %d: Can't clean register %x", i_try, reg);
+      continue;
+    }
+
+    // 3. Wait at least 5ms (10ms to be on the safe side)
+    delay(delay_ms);
+
+    // 4. Write the new value
+    if (data != 0) {
+      buf[2] = data & 0xFF;
+      buf[3] = data >> 8;
+      buf[4] = this->crc8_pec_(buf, 4);
+      if (!this->write_bytes(reg, buf + 2, 3)) {
+        ESP_LOGW(TAG, "Try %d: Can't write register %x", i_try, reg);
+        continue;
+      }
+
+      // 5. Wait at least 5ms (10ms to be on the safe side)
+      delay(delay_ms);
+    }
+
+    uint8_t read_buf[3];
+    // 6. Read back and compare if the write was successful
+    if (this->read_register(red, read_buff, 3, false) != i2c::ERROR_OK) {
+      ESP_LOGW(TAG, "Try %d: Can't check register value %x", i_try, reg);
+      continue;
+    }
+
+    if (read_buff[0] != buff[2] || read_buff[1] != buff[3] || read_buff[2] != buff[4]) {
+      ESP_LOGW(TAG, "Try %d: Read back value is not the same. Expected %x%x%x. Actural %x%x%x", i_try, buff[2], buff[3],
+               buff[4], read_buff[0], read_buff[1], read_buff[2]);
+      continue;
+    }
+
+    return true;
+  }
+
+  ESP_LOGE(TAG, "Out of tries");
+  return false;
+}
+
+uint16_t MLX90614Component::read_regiser_(uint8_t reg, i2c::ErrorCode &ec, max_try = 1) {
+  uint8_t delay_ms = 5;
+  uint8_t buf[5] = {
+      this->address_ << 1,
+      reg,
+  };
+  for (uint8_t i_try = 0; i_try < max_try; ++i, ++delay_ms) {
+    ec = this->read_register(reg, buf[2], 3, false) != i2c::ERROR_OK)
+    if(ec != i2c::ERROR_OK) {
+      ESP_LOGW(TAG, "Try %d: i2c read error %d", i_try, ec);
+      continue;
+    }
+
+    const auto expected_pec = this->crc8_pec_(buf, 4);
+    if (buf[4] != expected_pec) {
+      ESP_LOGW(TAG, "Try %d: i2c CRC error. Expected %x. Actural %x", i_try, expected_pec, buff[4]);
+      ec = i2c::ERROR_CRC;
+      continue;
+    }
+
+    ec = i2c::ERROR_OK;
+    return encode_uint16(buf[4], buf[3]);
+  }
+
+  return 0;
 }
 
 void MLX90614Component::dump_config() {
@@ -89,25 +157,27 @@ void MLX90614Component::dump_config() {
 float MLX90614Component::get_setup_priority() const { return setup_priority::DATA; }
 
 void MLX90614Component::update() {
-  uint8_t emissivity[3];
-  if (this->read_register(MLX90614_EMISSIVITY, emissivity, 3, false) != i2c::ERROR_OK) {
-    this->status_set_warning();
-    return;
-  }
-  uint8_t raw_object[3];
-  if (this->read_register(MLX90614_TEMPERATURE_OBJECT_1, raw_object, 3, false) != i2c::ERROR_OK) {
+  i2c::ErrorCode ec = ERROR_OK;
+  const auto emissivity = read_regiser_(MLX90614_EMISSIVITY, ec);
+  if (ec != ERROR_OK) {
     this->status_set_warning();
     return;
   }
 
-  uint8_t raw_ambient[3];
-  if (this->read_register(MLX90614_TEMPERATURE_AMBIENT, raw_ambient, 3, false) != i2c::ERROR_OK) {
+  const auto raw_object = read_regiser_(MLX90614_TEMPERATURE_OBJECT_1, ec);
+  if (ec != i2c::ERROR_OK) {
     this->status_set_warning();
     return;
   }
 
-  float ambient = raw_ambient[1] & 0x80 ? NAN : encode_uint16(raw_ambient[1], raw_ambient[0]) * 0.02f - 273.15f;
-  float object = raw_object[1] & 0x80 ? NAN : encode_uint16(raw_object[1], raw_object[0]) * 0.02f - 273.15f;
+  const auto raw_ambient = read_regiser_(MLX90614_TEMPERATURE_AMBIENT, ec);
+  if (ec != i2c::ERROR_OK) {
+    this->status_set_warning();
+    return;
+  }
+
+  float ambient = raw_ambient & 0x8000 ? NAN : raw_ambient * 0.02f - 273.15f;
+  float object = raw_object & 0x8000 ? NAN : raw_ambient * 0.02f - 273.15f;
 
   ESP_LOGD(TAG, "Got Temperature=%.1f°C Ambient=%.1f°C", object, ambient);
 

--- a/esphome/components/mlx90614/mlx90614.cpp
+++ b/esphome/components/mlx90614/mlx90614.cpp
@@ -128,6 +128,12 @@ uint16_t MLX90614Component::read_register_(uint8_t reg, i2c::ErrorCode &ec, uint
   };
   for (uint8_t i_try = 0; i_try < max_try; ++i_try) {
     ec = this->read_register(reg, buf + 3, 3, false);
+    if (ec == i2c::ERROR_TIMEOUT) {
+      // Recover bus
+      ESP_LOGW(TAG, "Recovering bus on read timeout.");
+      bus_->setup();
+      continue;
+    }
 
     if (ec != i2c::ERROR_OK) {
       ESP_LOGW(TAG, "Try %d: i2c read error %d", i_try, ec);

--- a/esphome/components/mlx90614/mlx90614.cpp
+++ b/esphome/components/mlx90614/mlx90614.cpp
@@ -106,7 +106,7 @@ i2c::ErrorCode MLX90614Component::write_register_(uint8_t reg, uint16_t data, ui
     }
 
     if (read_buf[0] != buf[2] || read_buf[1] != buf[3] || read_buf[2] != buf[4]) {
-      ESP_LOGW(TAG, "Try %d: Read back value is not the same. Expected %x%x%x. Actural %x%x%x", i_try, buf[2], buf[3],
+      ESP_LOGW(TAG, "Try %d: Read back value is not the same. Expected %x%x%x. Actual %x%x%x", i_try, buf[2], buf[3],
                buf[4], read_buf[0], read_buf[1], read_buf[2]);
       ec = i2c::ERROR_CRC;
       continue;
@@ -122,7 +122,7 @@ i2c::ErrorCode MLX90614Component::write_register_(uint8_t reg, uint16_t data, ui
 uint16_t MLX90614Component::read_register_(uint8_t reg, i2c::ErrorCode &ec, uint8_t max_try) {
   const uint8_t delay_ms = 5;
   uint8_t buf[5] = {
-      uint8_t(0x01) & uint8_t(this->address_ << 1),
+      uint8_t(0x01) | uint8_t(this->address_ << 1),
       reg,
   };
   for (uint8_t i_try = 0; i_try < max_try; ++i_try) {
@@ -135,7 +135,7 @@ uint16_t MLX90614Component::read_register_(uint8_t reg, i2c::ErrorCode &ec, uint
 
     const auto expected_pec = this->crc8_pec_(buf, 4);
     if (buf[4] != expected_pec) {
-      ESP_LOGW(TAG, "Try %d: i2c CRC error. Expected %x. Actural %x", i_try, expected_pec, buf[4]);
+      ESP_LOGW(TAG, "Try %d: i2c CRC error. Expected %x. Actual %x", i_try, expected_pec, buf[4]);
       ec = i2c::ERROR_CRC;
       continue;
     }

--- a/esphome/components/mlx90614/mlx90614.cpp
+++ b/esphome/components/mlx90614/mlx90614.cpp
@@ -186,6 +186,7 @@ void MLX90614Component::update() {
     i2c::ErrorCode ec = i2c::ERROR_OK;
     const auto raw = read_register_(reg, ec);
     if (ec != i2c::ERROR_OK) {
+      sensor->publish_state(NAN);
       return false;
     }
     float value = raw & 0x8000 ? NAN : raw * 0.02f - 273.15f;

--- a/esphome/components/mlx90614/mlx90614.cpp
+++ b/esphome/components/mlx90614/mlx90614.cpp
@@ -156,7 +156,7 @@ void MLX90614Component::dump_config() {
 float MLX90614Component::get_setup_priority() const { return setup_priority::DATA; }
 
 void MLX90614Component::update() {
-  i2c::ErrorCode ec = ERROR_OK;
+  i2c::ErrorCode ec = i2c::ERROR_OK;
 
   const auto raw_object = read_regiser_(MLX90614_TEMPERATURE_OBJECT_1, ec);
   if (ec != i2c::ERROR_OK) {

--- a/esphome/components/mlx90614/mlx90614.cpp
+++ b/esphome/components/mlx90614/mlx90614.cpp
@@ -66,8 +66,8 @@ i2c::ErrorCode MLX90614Component::write_register_(uint8_t reg, uint16_t data, ui
 
   // See 8.3.3.1. ERPROMwritesequence sequence sequence
   // 1. Power up the device
-  uint8_t delay_ms = 10;
-  for (uint8_t i_try = 0; i_try < max_try; ++i) {
+  const uint8_t delay_ms = 10;
+  for (uint8_t i_try = 0; i_try < max_try; ++i_try) {
     init_buffer();
 
     // 2. Write 0x0000 into the cell of interest (effectively erasing the cell)
@@ -98,7 +98,7 @@ i2c::ErrorCode MLX90614Component::write_register_(uint8_t reg, uint16_t data, ui
 
     uint8_t read_buf[3];
     // 6. Read back and compare if the write was successful
-    ec = this->read_register(red, read_buff, 3, false);
+    ec = this->read_register(reg, read_buff, 3, false);
     if (ec != i2c::ERROR_OK) {
       ESP_LOGW(TAG, "Try %d: Can't check register value %x", i_try, reg);
       continue;
@@ -119,12 +119,12 @@ i2c::ErrorCode MLX90614Component::write_register_(uint8_t reg, uint16_t data, ui
 }
 
 uint16_t MLX90614Component::read_register_(uint8_t reg, i2c::ErrorCode &ec, uint8_t max_try) {
-  uint8_t delay_ms = 5;
+  const uint8_t delay_ms = 5;
   uint8_t buf[5] = {
       this->address_ << 1,
       reg,
   };
-  for (uint8_t i_try = 0; i_try < max_try; ++i, ++delay_ms) {
+  for (uint8_t i_try = 0; i_try < max_try; ++i_try) {
     ec = this->read_register(reg, buf[2], 3, false) != i2c::ERROR_OK)
     if(ec != i2c::ERROR_OK) {
       ESP_LOGW(TAG, "Try %d: i2c read error %d", i_try, ec);

--- a/esphome/components/mlx90614/mlx90614.cpp
+++ b/esphome/components/mlx90614/mlx90614.cpp
@@ -105,9 +105,9 @@ i2c::ErrorCode MLX90614Component::write_register_(uint8_t reg, uint16_t data, ui
       continue;
     }
 
-    if (read_buf[0] != buff[2] || read_buf[1] != buff[3] || read_buf[2] != buff[4]) {
-      ESP_LOGW(TAG, "Try %d: Read back value is not the same. Expected %x%x%x. Actural %x%x%x", i_try, buff[2], buff[3],
-               buff[4], read_buf[0], read_buf[1], read_buf[2]);
+    if (read_buf[0] != buf[2] || read_buf[1] != buf[3] || read_buf[2] != buf[4]) {
+      ESP_LOGW(TAG, "Try %d: Read back value is not the same. Expected %x%x%x. Actural %x%x%x", i_try, buf[2], buf[3],
+               buf[4], read_buf[0], read_buf[1], read_buf[2]);
       ec = i2c::ERROR_CRC;
       continue;
     }
@@ -134,7 +134,7 @@ uint16_t MLX90614Component::read_register_(uint8_t reg, i2c::ErrorCode &ec, uint
 
     const auto expected_pec = this->crc8_pec_(buf, 4);
     if (buf[4] != expected_pec) {
-      ESP_LOGW(TAG, "Try %d: i2c CRC error. Expected %x. Actural %x", i_try, expected_pec, buff[4]);
+      ESP_LOGW(TAG, "Try %d: i2c CRC error. Expected %x. Actural %x", i_try, expected_pec, buf[4]);
       ec = i2c::ERROR_CRC;
       continue;
     }

--- a/esphome/components/mlx90614/mlx90614.cpp
+++ b/esphome/components/mlx90614/mlx90614.cpp
@@ -38,7 +38,7 @@ void MLX90614Component::setup() {
 bool MLX90614Component::write_emissivity_() {
   if (std::isnan(this->emissivity_))
     return true;
-  return this->write_register_(MLX90614_EMISSIVITY, this->emissivity_ * 65535));
+  return this->write_register_(MLX90614_EMISSIVITY, this->emissivity_ * 65535);
 }
 
 uint8_t MLX90614Component::crc8_pec_(const uint8_t *data, uint8_t len) {

--- a/esphome/components/mlx90614/mlx90614.cpp
+++ b/esphome/components/mlx90614/mlx90614.cpp
@@ -122,7 +122,7 @@ i2c::ErrorCode MLX90614Component::write_register_(uint8_t reg, uint16_t data, ui
 uint16_t MLX90614Component::read_register_(uint8_t reg, i2c::ErrorCode &ec, uint8_t max_try) {
   const uint8_t delay_ms = 5;
   uint8_t buf[5] = {
-      this->address_ << 1,
+      uint8_t(0x01) & uint8_t(this->address_ << 1),
       reg,
   };
   for (uint8_t i_try = 0; i_try < max_try; ++i_try) {

--- a/esphome/components/mlx90614/mlx90614.cpp
+++ b/esphome/components/mlx90614/mlx90614.cpp
@@ -131,7 +131,7 @@ uint16_t MLX90614Component::read_register_(uint8_t reg, i2c::ErrorCode &ec, uint
       // Recover bus
       ESP_LOGW(TAG, "Recovering bus on read timeout.");
       const auto recover_code = bus_->recover();
-      if (recover_code != RECOVERY_COMPLETED) {
+      if (recover_code != i2c::RECOVERY_COMPLETED) {
         ESP_LOGE(TAG, "Recovering failed with code %d.", recover_code);
       }
       continue;

--- a/esphome/components/mlx90614/mlx90614.cpp
+++ b/esphome/components/mlx90614/mlx90614.cpp
@@ -31,7 +31,7 @@ void MLX90614Component::setup() {
   this->emissivity_write_ec_ = this->write_emissivity_();
   if (this->emissivity_write_ec_ != i2c::ERROR_OK) {
     ESP_LOGE(TAG, "Communication with MLX90614 failed! Error code %d", this->emissivity_write_ec_);
-    this->mark_failed();
+    this->status_set_warning();
     return;
   }
 }

--- a/esphome/components/mlx90614/mlx90614.cpp
+++ b/esphome/components/mlx90614/mlx90614.cpp
@@ -29,7 +29,7 @@ static const char *const TAG = "mlx90614";
 void MLX90614Component::setup() {
   ESP_LOGCONFIG(TAG, "Setting up MLX90614...");
   this->emissivity_write_ec_ = this->write_emissivity_();
-  if(this->emissivity_write_ec_ != i2c::ERROR_OK) {
+  if (this->emissivity_write_ec_ != i2c::ERROR_OK) {
     ESP_LOGE(TAG, "Communication with MLX90614 failed!");
     this->mark_failed();
     return;
@@ -134,13 +134,13 @@ i2c::ErrorCode MLX90614Component::read_register_(uint8_t reg, uint16_t &data) {
   const auto ec = this->read_register(reg, buf + 3, 3, false);
 
   if (i2c::ERROR_OK != ec) {
-    ESP_LOGW(TAG, "Try %d: i2c read error %d", i_try, ec);
+    ESP_LOGW(TAG, "i2c read error %d", ec);
     return ec;
   }
 
   const auto expected_pec = this->crc8_pec_(buf, 5);
   if (buf[5] != expected_pec) {
-    ESP_LOGW(TAG, "Try %d: i2c CRC error. Expected %x. Actual %x", i_try, expected_pec, buf[4]);
+    ESP_LOGW(TAG, "i2c CRC error. Expected %x. Actual %x", expected_pec, buf[4]);
     return i2c::ERROR_CRC;
   }
 
@@ -154,16 +154,16 @@ void MLX90614Component::dump_config() {
   if (this->is_failed()) {
     ESP_LOGE(TAG, "Communication with MLX90614 failed!");
   }
-  
-  if(i2c::ERROR_OK != this->emissivity_write_ec_) {
+
+  if (i2c::ERROR_OK != this->emissivity_write_ec_) {
     ESP_LOGE(TAG, "Emissivity update error %d", this->emissivity_write_ec_);
   }
 
-  if(i2c::ERROR_OK != this->object_read_ec_) {
+  if (i2c::ERROR_OK != this->object_read_ec_) {
     ESP_LOGE(TAG, "Object temperature read error %d", this->object_read_ec_);
   }
 
-  if(i2c::ERROR_OK != this->ambient_read_ec_) {
+  if (i2c::ERROR_OK != this->ambient_read_ec_) {
     ESP_LOGE(TAG, "Ambient temperature read error %d", this->ambient_read_ec_);
   }
 

--- a/esphome/components/mlx90614/mlx90614.cpp
+++ b/esphome/components/mlx90614/mlx90614.cpp
@@ -89,7 +89,8 @@ i2c::ErrorCode MLX90614Component::write_register_(uint8_t reg, uint16_t data, ui
       buf[4] = this->crc8_pec_(buf, 4);
       if (!this->write_bytes(reg, buf + 2, 3)) {
         ESP_LOGW(TAG, "Try %d: Can't write register %x", i_try, reg);
-        ec = i2c::ERROR_UNKNOWN continue;
+        ec = i2c::ERROR_UNKNOWN;
+        continue;
       }
 
       // 5. Wait at least 5ms (10ms to be on the safe side)
@@ -98,16 +99,16 @@ i2c::ErrorCode MLX90614Component::write_register_(uint8_t reg, uint16_t data, ui
 
     uint8_t read_buf[3];
     // 6. Read back and compare if the write was successful
-    ec = this->read_register(reg, read_buff, 3, false);
+    ec = this->read_register(reg, read_buf, 3, false);
     if (ec != i2c::ERROR_OK) {
       ESP_LOGW(TAG, "Try %d: Can't check register value %x", i_try, reg);
       continue;
     }
 
-    if (read_buff[0] != buff[2] || read_buff[1] != buff[3] || read_buff[2] != buff[4]) {
+    if (read_buf[0] != buff[2] || read_buf[1] != buff[3] || read_buf[2] != buff[4]) {
       ESP_LOGW(TAG, "Try %d: Read back value is not the same. Expected %x%x%x. Actural %x%x%x", i_try, buff[2], buff[3],
-               buff[4], read_buff[0], read_buff[1], read_buff[2]);
-      ec = i2c : ERROR_CRC;
+               buff[4], read_buf[0], read_buf[1], read_buf[2]);
+      ec = i2c::ERROR_CRC;
       continue;
     }
 
@@ -125,7 +126,7 @@ uint16_t MLX90614Component::read_register_(uint8_t reg, i2c::ErrorCode &ec, uint
       reg,
   };
   for (uint8_t i_try = 0; i_try < max_try; ++i_try) {
-    ec = this->read_register(reg, buf[2], 3, false) != i2c::ERROR_OK)
+    ec = this->read_register(reg, buf + 2, 3, false) != i2c::ERROR_OK)
     if(ec != i2c::ERROR_OK) {
       ESP_LOGW(TAG, "Try %d: i2c read error %d", i_try, ec);
       continue;
@@ -139,7 +140,7 @@ uint16_t MLX90614Component::read_register_(uint8_t reg, i2c::ErrorCode &ec, uint
     }
 
     ec = i2c::ERROR_OK;
-    return encode_uint16(buf[4], buf[3]);
+    return encode_uint16(buf[3], buf[2]);
   }
 
   return 0;

--- a/esphome/components/mlx90614/mlx90614.cpp
+++ b/esphome/components/mlx90614/mlx90614.cpp
@@ -142,7 +142,7 @@ uint16_t MLX90614Component::read_register_(uint8_t reg, i2c::ErrorCode &ec, uint
     }
 
     ec = i2c::ERROR_OK;
-    return encode_uint16(buf[3], buf[2]);
+    return encode_uint16(buf[4], buf[3]);
   }
 
   return 0;

--- a/esphome/components/mlx90614/mlx90614.cpp
+++ b/esphome/components/mlx90614/mlx90614.cpp
@@ -30,7 +30,7 @@ void MLX90614Component::setup() {
   ESP_LOGCONFIG(TAG, "Setting up MLX90614...");
   this->emissivity_write_ec_ = this->write_emissivity_();
   if (this->emissivity_write_ec_ != i2c::ERROR_OK) {
-    ESP_LOGE(TAG, "Communication with MLX90614 failed!");
+    ESP_LOGE(TAG, "Communication with MLX90614 failed! Error code %d", this->emissivity_write_ec_);
     this->mark_failed();
     return;
   }
@@ -44,6 +44,7 @@ i2c::ErrorCode MLX90614Component::write_emissivity_() {
   uint16_t read_emissivity;
   const auto ec = read_register_(MLX90614_EMISSIVITY, read_emissivity);
   if (i2c::ERROR_OK != ec) {
+    ESP_LOGW(TAG, "Failed to read emissivity, error %d", ec);
     return ec;
   }
 

--- a/esphome/components/mlx90614/mlx90614.cpp
+++ b/esphome/components/mlx90614/mlx90614.cpp
@@ -56,7 +56,7 @@ uint8_t MLX90614Component::crc8_pec_(const uint8_t *data, uint8_t len) {
   return crc;
 }
 
-bool MLX90614Component::write_regiser_(uint8_t reg, uint16_t data, uint8_t max_try) {
+bool MLX90614Component::write_register_(uint8_t reg, uint16_t data, uint8_t max_try) {
   uint8_t buf[5];
 
   auto init_buffer = [&]() {
@@ -115,7 +115,7 @@ bool MLX90614Component::write_regiser_(uint8_t reg, uint16_t data, uint8_t max_t
   return false;
 }
 
-uint16_t MLX90614Component::read_regiser_(uint8_t reg, i2c::ErrorCode &ec, uint8_t max_try) {
+uint16_t MLX90614Component::read_register_(uint8_t reg, i2c::ErrorCode &ec, uint8_t max_try) {
   uint8_t delay_ms = 5;
   uint8_t buf[5] = {
       this->address_ << 1,
@@ -158,13 +158,13 @@ float MLX90614Component::get_setup_priority() const { return setup_priority::DAT
 void MLX90614Component::update() {
   i2c::ErrorCode ec = i2c::ERROR_OK;
 
-  const auto raw_object = read_regiser_(MLX90614_TEMPERATURE_OBJECT_1, ec);
+  const auto raw_object = read_register_(MLX90614_TEMPERATURE_OBJECT_1, ec);
   if (ec != i2c::ERROR_OK) {
     this->status_set_warning();
     return;
   }
 
-  const auto raw_ambient = read_regiser_(MLX90614_TEMPERATURE_AMBIENT, ec);
+  const auto raw_ambient = read_register_(MLX90614_TEMPERATURE_AMBIENT, ec);
   if (ec != i2c::ERROR_OK) {
     this->status_set_warning();
     return;

--- a/esphome/components/mlx90614/mlx90614.cpp
+++ b/esphome/components/mlx90614/mlx90614.cpp
@@ -64,7 +64,7 @@ i2c::ErrorCode MLX90614Component::write_register_(uint8_t reg, uint16_t data, ui
     buf[1] = reg;
   };
 
-  // See 8.3.3.1. ERPROMwritesequence sequence sequence
+  // See 8.3.3.1. ERPROM write sequence
   // 1. Power up the device
   const uint8_t delay_ms = 10;
   for (uint8_t i_try = 0; i_try < max_try; ++i_try) {
@@ -168,7 +168,7 @@ void MLX90614Component::update() {
     const auto read_emissivity = read_register_(MLX90614_EMISSIVITY, ec);
     if (ec == i2c::ERROR_OK) {
       const auto desired_emissivity = uint16_t(this->emissivity_ * 0xFFFF);
-      if (read_emisivity != desired_emissivity) {
+      if (read_emissivity != desired_emissivity) {
         if (i2c::ERROR_OK != this->write_register_(MLX90614_EMISSIVITY, desired_emissivity)) {
           write_emissivity_status = false;
         }

--- a/esphome/components/mlx90614/mlx90614.cpp
+++ b/esphome/components/mlx90614/mlx90614.cpp
@@ -121,20 +121,21 @@ i2c::ErrorCode MLX90614Component::write_register_(uint8_t reg, uint16_t data, ui
 
 uint16_t MLX90614Component::read_register_(uint8_t reg, i2c::ErrorCode &ec, uint8_t max_try) {
   const uint8_t delay_ms = 5;
-  uint8_t buf[5] = {
+  uint8_t buf[6] = {
       uint8_t(this->address_ << 1),
       reg,
+      uint8_t(0x01 | (this->address_ << 1)),
   };
   for (uint8_t i_try = 0; i_try < max_try; ++i_try) {
-    ec = this->read_register(reg, buf + 2, 3, false);
+    ec = this->read_register(reg, buf + 3, 3, false);
 
     if (ec != i2c::ERROR_OK) {
       ESP_LOGW(TAG, "Try %d: i2c read error %d", i_try, ec);
       continue;
     }
 
-    const auto expected_pec = this->crc8_pec_(buf, 4);
-    if (buf[4] != expected_pec) {
+    const auto expected_pec = this->crc8_pec_(buf, 5);
+    if (buf[5] != expected_pec) {
       ESP_LOGW(TAG, "Try %d: i2c CRC error. Expected %x. Actual %x", i_try, expected_pec, buf[4]);
       ec = i2c::ERROR_CRC;
       continue;

--- a/esphome/components/mlx90614/mlx90614.cpp
+++ b/esphome/components/mlx90614/mlx90614.cpp
@@ -122,7 +122,7 @@ i2c::ErrorCode MLX90614Component::write_register_(uint8_t reg, uint16_t data, ui
 uint16_t MLX90614Component::read_register_(uint8_t reg, i2c::ErrorCode &ec, uint8_t max_try) {
   const uint8_t delay_ms = 5;
   uint8_t buf[5] = {
-      uint8_t(0x01) | uint8_t(this->address_ << 1),
+      uint8_t(0x01 | (this->address_ << 1)),
       reg,
   };
   for (uint8_t i_try = 0; i_try < max_try; ++i_try) {

--- a/esphome/components/mlx90614/mlx90614.cpp
+++ b/esphome/components/mlx90614/mlx90614.cpp
@@ -38,8 +38,7 @@ void MLX90614Component::setup() {
 bool MLX90614Component::write_emissivity_() {
   if (std::isnan(this->emissivity_))
     return true;
-  uint16_t value = (uint16_t) (this->emissivity_ * 65535);
-  return this->write_bytes_(MLX90614_EMISSIVITY, 0));
+  return this->write_register_(MLX90614_EMISSIVITY, this->emissivity_ * 65535));
 }
 
 uint8_t MLX90614Component::crc8_pec_(const uint8_t *data, uint8_t len) {

--- a/esphome/components/mlx90614/mlx90614.cpp
+++ b/esphome/components/mlx90614/mlx90614.cpp
@@ -122,7 +122,7 @@ i2c::ErrorCode MLX90614Component::write_register_(uint8_t reg, uint16_t data, ui
 uint16_t MLX90614Component::read_register_(uint8_t reg, i2c::ErrorCode &ec, uint8_t max_try) {
   const uint8_t delay_ms = 5;
   uint8_t buf[5] = {
-      uint8_t(0x01 | (this->address_ << 1)),
+      uint8_t(this->address_ << 1),
       reg,
   };
   for (uint8_t i_try = 0; i_try < max_try; ++i_try) {

--- a/esphome/components/mlx90614/mlx90614.cpp
+++ b/esphome/components/mlx90614/mlx90614.cpp
@@ -126,8 +126,9 @@ uint16_t MLX90614Component::read_register_(uint8_t reg, i2c::ErrorCode &ec, uint
       reg,
   };
   for (uint8_t i_try = 0; i_try < max_try; ++i_try) {
-    ec = this->read_register(reg, buf + 2, 3, false) != i2c::ERROR_OK)
-    if(ec != i2c::ERROR_OK) {
+    ec = this->read_register(reg, buf + 2, 3, false);
+
+    if (ec != i2c::ERROR_OK) {
       ESP_LOGW(TAG, "Try %d: i2c read error %d", i_try, ec);
       continue;
     }

--- a/esphome/components/mlx90614/mlx90614.cpp
+++ b/esphome/components/mlx90614/mlx90614.cpp
@@ -84,10 +84,10 @@ i2c::ErrorCode MLX90614Component::write_register_(uint8_t reg, uint16_t data) {
   buf[2] = buf[3] = 0;
   buf[4] = this->crc8_pec_(buf, 4);
   ec = this->write_register(reg, buf + 2, 3);
-  if (i2c::ERROR_OK != ec)) {
-      ESP_LOGW(TAG, "Can't clean register %x, error %d", reg, ec);
-      return ec;
-    }
+  if (i2c::ERROR_OK != ec) {
+    ESP_LOGW(TAG, "Can't clean register %x, error %d", reg, ec);
+    return ec;
+  }
 
   // 3. Wait at least 5ms (10ms to be on the safe side)
   delay(delay_ms);
@@ -191,7 +191,7 @@ void MLX90614Component::update() {
   this->object_read_ec_ = publish_sensor(this->object_sensor_, MLX90614_TEMPERATURE_OBJECT_1);
   this->ambient_read_ec_ = publish_sensor(this->ambient_sensor_, MLX90614_TEMPERATURE_AMBIENT);
 
-  if (this->ambient_read_ec_ == Зi2c::ERROR_OK && this->object_read_ec_ == i2c::ERROR_OK &&
+  if (this->ambient_read_ec_ == i2c::ERROR_OK && this->object_read_ec_ == i2c::ERROR_OK &&
       this->emissivity_write_ec_ == i2c::ERROR_OK) {
     this->status_clear_warning();
   } else {

--- a/esphome/components/mlx90614/mlx90614.cpp
+++ b/esphome/components/mlx90614/mlx90614.cpp
@@ -120,7 +120,6 @@ i2c::ErrorCode MLX90614Component::write_register_(uint8_t reg, uint16_t data, ui
 }
 
 uint16_t MLX90614Component::read_register_(uint8_t reg, i2c::ErrorCode &ec, uint8_t max_try) {
-  const uint8_t delay_ms = 5;
   uint8_t buf[6] = {
       uint8_t(this->address_ << 1),
       reg,
@@ -184,7 +183,7 @@ void MLX90614Component::update() {
     }
   }
 
-  auto publishSensor = [&](sensor::Sensor *sensor, uint8_t reg) {
+  auto publish_sensor = [&](sensor::Sensor *sensor, uint8_t reg) {
     if (nullptr == sensor) {
       return true;
     }
@@ -200,8 +199,8 @@ void MLX90614Component::update() {
     return true;
   };
 
-  const auto object_updated = publishSensor(this->object_sensor_, MLX90614_TEMPERATURE_OBJECT_1);
-  const auto ambient_updated = publishSensor(this->ambient_sensor_, MLX90614_TEMPERATURE_AMBIENT);
+  const auto object_updated = publish_sensor(this->object_sensor_, MLX90614_TEMPERATURE_OBJECT_1);
+  const auto ambient_updated = publish_sensor(this->ambient_sensor_, MLX90614_TEMPERATURE_AMBIENT);
 
   if (object_updated && ambient_updated && write_emissivity_status) {
     this->status_clear_warning();

--- a/esphome/components/mlx90614/mlx90614.cpp
+++ b/esphome/components/mlx90614/mlx90614.cpp
@@ -56,7 +56,7 @@ uint8_t MLX90614Component::crc8_pec_(const uint8_t *data, uint8_t len) {
   return crc;
 }
 
-bool MLX90614Component::write_regiser_(const uint8_t reg, const uint16_t data, const uint8_t max_try) {
+bool MLX90614Component::write_regiser_(uint8_t reg, uint16_t data, uint8_t max_try) {
   uint8_t buf[5];
 
   auto init_buffer = [&]() {
@@ -115,7 +115,7 @@ bool MLX90614Component::write_regiser_(const uint8_t reg, const uint16_t data, c
   return false;
 }
 
-uint16_t MLX90614Component::read_regiser_(const uint8_t reg, i2c::ErrorCode &ec, const uint8_t max_try) {
+uint16_t MLX90614Component::read_regiser_(uint8_t reg, i2c::ErrorCode &ec, uint8_t max_try) {
   uint8_t delay_ms = 5;
   uint8_t buf[5] = {
       this->address_ << 1,

--- a/esphome/components/mlx90614/mlx90614.cpp
+++ b/esphome/components/mlx90614/mlx90614.cpp
@@ -115,7 +115,7 @@ bool MLX90614Component::write_regiser_(const uint8_t reg, const uint16_t data, c
   return false;
 }
 
-uint16_t MLX90614Component::read_regiser_(uint8_t reg, i2c::ErrorCode &ec, max_try = 1) {
+uint16_t MLX90614Component::read_regiser_(const uint8_t reg, i2c::ErrorCode &ec, const uint8_t max_try) {
   uint8_t delay_ms = 5;
   uint8_t buf[5] = {
       this->address_ << 1,

--- a/esphome/components/mlx90614/mlx90614.cpp
+++ b/esphome/components/mlx90614/mlx90614.cpp
@@ -28,17 +28,31 @@ static const char *const TAG = "mlx90614";
 
 void MLX90614Component::setup() {
   ESP_LOGCONFIG(TAG, "Setting up MLX90614...");
-  if (!this->write_emissivity_()) {
+  this->emissivity_write_ec_ = this->write_emissivity_();
+  if(this->emissivity_write_ec_ != i2c::ERROR_OK) {
     ESP_LOGE(TAG, "Communication with MLX90614 failed!");
     this->mark_failed();
     return;
   }
 }
 
-bool MLX90614Component::write_emissivity_() {
-  if (std::isnan(this->emissivity_))
-    return true;
-  return this->write_register_(MLX90614_EMISSIVITY, this->emissivity_ * 0xFFFF);
+i2c::ErrorCode MLX90614Component::write_emissivity_() {
+  if (std::isnan(this->emissivity_)) {
+    return i2c::ERROR_OK;
+  }
+
+  uint16_t read_emissivity;
+  const auto ec = read_register_(MLX90614_EMISSIVITY, read_emissivity);
+  if (i2c::ERROR_OK != ec) {
+    return ec;
+  }
+
+  const auto desired_emissivity = uint16_t(this->emissivity_ * 0xFFFF);
+  if (read_emissivity == desired_emissivity) {
+    return ec;
+  }
+
+  return this->write_register_(MLX90614_EMISSIVITY, desired_emissivity);
 }
 
 uint8_t MLX90614Component::crc8_pec_(const uint8_t *data, uint8_t len) {
@@ -56,95 +70,82 @@ uint8_t MLX90614Component::crc8_pec_(const uint8_t *data, uint8_t len) {
   return crc;
 }
 
-i2c::ErrorCode MLX90614Component::write_register_(uint8_t reg, uint16_t data, uint8_t max_try) {
+i2c::ErrorCode MLX90614Component::write_register_(uint8_t reg, uint16_t data) {
   uint8_t buf[5];
   i2c::ErrorCode ec = i2c::ERROR_UNKNOWN;
-  auto init_buffer = [&]() {
-    buf[0] = this->address_ << 1;
-    buf[1] = reg;
-  };
 
   // See 8.3.3.1. ERPROM write sequence
   // 1. Power up the device
   const uint8_t delay_ms = 10;
-  for (uint8_t i_try = 0; i_try < max_try; ++i_try) {
-    init_buffer();
+  buf[0] = this->address_ << 1;
+  buf[1] = reg;
 
-    // 2. Write 0x0000 into the cell of interest (effectively erasing the cell)
-    buf[2] = buf[3] = 0;
+  // 2. Write 0x0000 into the cell of interest (effectively erasing the cell)
+  buf[2] = buf[3] = 0;
+  buf[4] = this->crc8_pec_(buf, 4);
+  ec = this->write_register(reg, buf + 2, 3);
+  if (i2c::ERROR_OK != ec)) {
+      ESP_LOGW(TAG, "Can't clean register %x, error %d", reg, ec);
+      return ec;
+    }
+
+  // 3. Wait at least 5ms (10ms to be on the safe side)
+  delay(delay_ms);
+
+  // 4. Write the new value
+  if (data != 0) {
+    buf[2] = data & 0xFF;
+    buf[3] = data >> 8;
     buf[4] = this->crc8_pec_(buf, 4);
-    if (!this->write_bytes(reg, buf + 2, 3)) {
-      ESP_LOGW(TAG, "Try %d: Can't clean register %x", i_try, reg);
-      ec = i2c::ERROR_UNKNOWN;
-      continue;
+    ec = this->write_register(reg, buf + 2, 3);
+    if (i2c::ERROR_OK != ec) {
+      ESP_LOGW(TAG, "Can't write register %x, error %d", reg, ec);
+      return ec;
     }
-
-    // 3. Wait at least 5ms (10ms to be on the safe side)
+    // 5. Wait at least 5ms (10ms to be on the safe side)
     delay(delay_ms);
-
-    // 4. Write the new value
-    if (data != 0) {
-      buf[2] = data & 0xFF;
-      buf[3] = data >> 8;
-      buf[4] = this->crc8_pec_(buf, 4);
-      if (!this->write_bytes(reg, buf + 2, 3)) {
-        ESP_LOGW(TAG, "Try %d: Can't write register %x", i_try, reg);
-        ec = i2c::ERROR_UNKNOWN;
-        continue;
-      }
-
-      // 5. Wait at least 5ms (10ms to be on the safe side)
-      delay(delay_ms);
-    }
-
-    uint8_t read_buf[3];
-    // 6. Read back and compare if the write was successful
-    ec = this->read_register(reg, read_buf, 3, false);
-    if (ec != i2c::ERROR_OK) {
-      ESP_LOGW(TAG, "Try %d: Can't check register value %x", i_try, reg);
-      continue;
-    }
-
-    if (read_buf[0] != buf[2] || read_buf[1] != buf[3] || read_buf[2] != buf[4]) {
-      ESP_LOGW(TAG, "Try %d: Read back value is not the same. Expected %x%x%x. Actual %x%x%x", i_try, buf[2], buf[3],
-               buf[4], read_buf[0], read_buf[1], read_buf[2]);
-      ec = i2c::ERROR_CRC;
-      continue;
-    }
-
-    return i2c::ERROR_OK;
   }
 
-  ESP_LOGE(TAG, "Out of tries");
-  return ec;
+  uint8_t read_buf[3];
+  // 6. Read back and compare if the write was successful
+  ec = this->read_register(reg, read_buf, 3, false);
+  if (i2c::ERROR_OK != ec) {
+    ESP_LOGW(TAG, "Can't check register %x value", reg);
+    return ec;
+  }
+
+  if (read_buf[0] != buf[2] || read_buf[1] != buf[3] || read_buf[2] != buf[4]) {
+    ESP_LOGW(TAG, "Read back value is not the same. Expected %x%x%x. Actual %x%x%x", buf[2], buf[3], buf[4],
+             read_buf[0], read_buf[1], read_buf[2]);
+    return i2c::ERROR_CRC;
+  }
+
+  return i2c::ERROR_OK;
 }
 
-uint16_t MLX90614Component::read_register_(uint8_t reg, i2c::ErrorCode &ec, uint8_t max_try) {
-  uint8_t buf[6] = {
-      uint8_t(this->address_ << 1),
-      reg,
-      uint8_t(0x01 | (this->address_ << 1)),
-  };
-  for (uint8_t i_try = 0; i_try < max_try; ++i_try) {
-    ec = this->read_register(reg, buf + 3, 3, false);
+i2c::ErrorCode MLX90614Component::read_register_(uint8_t reg, uint16_t &data) {
+  uint8_t buf[6];
+  // master write
+  buf[0] = this->address_ << 1;
+  buf[1] = reg;
+  // master read
+  buf[2] = (this->address_ << 1) | 0x01;
 
-    if (ec != i2c::ERROR_OK) {
-      ESP_LOGW(TAG, "Try %d: i2c read error %d", i_try, ec);
-      continue;
-    }
+  const auto ec = this->read_register(reg, buf + 3, 3, false);
 
-    const auto expected_pec = this->crc8_pec_(buf, 5);
-    if (buf[5] != expected_pec) {
-      ESP_LOGW(TAG, "Try %d: i2c CRC error. Expected %x. Actual %x", i_try, expected_pec, buf[4]);
-      ec = i2c::ERROR_CRC;
-      continue;
-    }
-
-    ec = i2c::ERROR_OK;
-    return encode_uint16(buf[4], buf[3]);
+  if (i2c::ERROR_OK != ec) {
+    ESP_LOGW(TAG, "Try %d: i2c read error %d", i_try, ec);
+    return ec;
   }
 
-  return 0;
+  const auto expected_pec = this->crc8_pec_(buf, 5);
+  if (buf[5] != expected_pec) {
+    ESP_LOGW(TAG, "Try %d: i2c CRC error. Expected %x. Actual %x", i_try, expected_pec, buf[4]);
+    return i2c::ERROR_CRC;
+  }
+
+  data = encode_uint16(buf[4], buf[3]);
+  return i2c::ERROR_OK;
 }
 
 void MLX90614Component::dump_config() {
@@ -153,6 +154,19 @@ void MLX90614Component::dump_config() {
   if (this->is_failed()) {
     ESP_LOGE(TAG, "Communication with MLX90614 failed!");
   }
+  
+  if(i2c::ERROR_OK != this->emissivity_write_ec_) {
+    ESP_LOGE(TAG, "Emissivity update error %d", this->emissivity_write_ec_);
+  }
+
+  if(i2c::ERROR_OK != this->object_read_ec_) {
+    ESP_LOGE(TAG, "Object temperature read error %d", this->object_read_ec_);
+  }
+
+  if(i2c::ERROR_OK != this->ambient_read_ec_) {
+    ESP_LOGE(TAG, "Ambient temperature read error %d", this->ambient_read_ec_);
+  }
+
   LOG_UPDATE_INTERVAL(this);
   LOG_SENSOR("  ", "Ambient", this->ambient_sensor_);
   LOG_SENSOR("  ", "Object", this->object_sensor_);
@@ -161,42 +175,24 @@ void MLX90614Component::dump_config() {
 float MLX90614Component::get_setup_priority() const { return setup_priority::DATA; }
 
 void MLX90614Component::update() {
-  bool write_emissivity_status = true;
-  if (!std::isnan(this->emissivity_)) {
-    i2c::ErrorCode ec = i2c::ERROR_OK;
-    const auto read_emissivity = read_register_(MLX90614_EMISSIVITY, ec);
-    if (ec == i2c::ERROR_OK) {
-      const auto desired_emissivity = uint16_t(this->emissivity_ * 0xFFFF);
-      if (read_emissivity != desired_emissivity) {
-        if (i2c::ERROR_OK != this->write_register_(MLX90614_EMISSIVITY, desired_emissivity)) {
-          write_emissivity_status = false;
-        }
-      }
-    } else {
-      write_emissivity_status = false;
-    }
-  }
+  this->emissivity_write_ec_ = this->write_emissivity_();
 
   auto publish_sensor = [&](sensor::Sensor *sensor, uint8_t reg) {
     if (nullptr == sensor) {
-      return true;
+      return i2c::ERROR_OK;
     }
 
-    i2c::ErrorCode ec = i2c::ERROR_OK;
-    const auto raw = read_register_(reg, ec);
-    if (ec != i2c::ERROR_OK) {
-      sensor->publish_state(NAN);
-      return false;
-    }
-    float value = raw & 0x8000 ? NAN : raw * 0.02f - 273.15f;
-    sensor->publish_state(value);
-    return true;
+    uint16_t raw;
+    const auto ec = read_register_(reg, raw);
+    sensor->publish_state(ec != i2c::ERROR_OK || (raw & 0x8000) ? NAN : float(raw) * 0.02f - 273.15f);
+    return ec;
   };
 
-  const auto object_updated = publish_sensor(this->object_sensor_, MLX90614_TEMPERATURE_OBJECT_1);
-  const auto ambient_updated = publish_sensor(this->ambient_sensor_, MLX90614_TEMPERATURE_AMBIENT);
+  this->object_read_ec_ = publish_sensor(this->object_sensor_, MLX90614_TEMPERATURE_OBJECT_1);
+  this->ambient_read_ec_ = publish_sensor(this->ambient_sensor_, MLX90614_TEMPERATURE_AMBIENT);
 
-  if (object_updated && ambient_updated && write_emissivity_status) {
+  if (this->ambient_read_ec_ == Зi2c::ERROR_OK && this->object_read_ec_ == i2c::ERROR_OK &&
+      this->emissivity_write_ec_ == i2c::ERROR_OK) {
     this->status_clear_warning();
   } else {
     this->status_set_warning();

--- a/esphome/components/mlx90614/mlx90614.cpp
+++ b/esphome/components/mlx90614/mlx90614.cpp
@@ -130,7 +130,10 @@ uint16_t MLX90614Component::read_register_(uint8_t reg, i2c::ErrorCode &ec, uint
     if (ec == i2c::ERROR_TIMEOUT) {
       // Recover bus
       ESP_LOGW(TAG, "Recovering bus on read timeout.");
-      bus_->recover();
+      const auto recover_code = bus_->recover();
+      if (recover_code != RECOVERY_COMPLETED) {
+        ESP_LOGE(TAG, "Recovering failed with code %d.", recover_code);
+      }
       continue;
     }
 

--- a/esphome/components/mlx90614/mlx90614.cpp
+++ b/esphome/components/mlx90614/mlx90614.cpp
@@ -158,11 +158,6 @@ float MLX90614Component::get_setup_priority() const { return setup_priority::DAT
 
 void MLX90614Component::update() {
   i2c::ErrorCode ec = ERROR_OK;
-  const auto emissivity = read_regiser_(MLX90614_EMISSIVITY, ec);
-  if (ec != ERROR_OK) {
-    this->status_set_warning();
-    return;
-  }
 
   const auto raw_object = read_regiser_(MLX90614_TEMPERATURE_OBJECT_1, ec);
   if (ec != i2c::ERROR_OK) {

--- a/esphome/components/mlx90614/mlx90614.h
+++ b/esphome/components/mlx90614/mlx90614.h
@@ -32,7 +32,7 @@ class MLX90614Component : public PollingComponent, public i2c::I2CDevice {
   float emissivity_{NAN};
   i2c::ErrorCode emissivity_write_ec_{i2c::ERROR_OK};
   i2c::ErrorCode object_read_ec_{i2c::ERROR_OK};
-  i2c::ErrorCode ambient_read_ec_{i2c::ERROR_OK}З;
+  i2c::ErrorCode ambient_read_ec_{i2c::ERROR_OK};
 };
 }  // namespace mlx90614
 }  // namespace esphome

--- a/esphome/components/mlx90614/mlx90614.h
+++ b/esphome/components/mlx90614/mlx90614.h
@@ -23,8 +23,8 @@ class MLX90614Component : public PollingComponent, public i2c::I2CDevice {
   bool write_emissivity_();
 
   uint8_t crc8_pec_(const uint8_t *data, uint8_t len);
-  i2c::ErrorCode write_register_(uint8_t reg, uint16_t data, uint8_t max_try = 3);
-  uint16_t read_register_(uint8_t reg, i2c::ErrorCode &ec, uint8_t max_try = 3);
+  i2c::ErrorCode write_register_(uint8_t reg, uint16_t data, uint8_t max_try = 2);
+  uint16_t read_register_(uint8_t reg, i2c::ErrorCode &ec, uint8_t max_try = 2);
 
   sensor::Sensor *ambient_sensor_{nullptr};
   sensor::Sensor *object_sensor_{nullptr};

--- a/esphome/components/mlx90614/mlx90614.h
+++ b/esphome/components/mlx90614/mlx90614.h
@@ -23,7 +23,8 @@ class MLX90614Component : public PollingComponent, public i2c::I2CDevice {
   bool write_emissivity_();
 
   uint8_t crc8_pec_(const uint8_t *data, uint8_t len);
-  bool write_bytes_(uint8_t reg, uint16_t data);
+  i2c::ErrorCode write_regiser_(uint8_t reg, uint16_t data, uint8_t max_try = 8);
+  uint16_t read_regiser_(uint8_t reg, i2c::ErrorCode &ec, uint8_t max_try = 8);
 
   sensor::Sensor *ambient_sensor_{nullptr};
   sensor::Sensor *object_sensor_{nullptr};

--- a/esphome/components/mlx90614/mlx90614.h
+++ b/esphome/components/mlx90614/mlx90614.h
@@ -23,7 +23,8 @@ class MLX90614Component : public PollingComponent, public i2c::I2CDevice {
   bool write_emissivity_();
 
   uint8_t crc8_pec_(const uint8_t *data, uint8_t len);
-  bool write_bytes_(uint8_t reg, uint16_t data);
+  i2c::ErrorCode write_register_(uint8_t reg, uint16_t data, uint8_t max_try = 2);
+  uint16_t read_register_(uint8_t reg, i2c::ErrorCode &ec, uint8_t max_try = 2);
 
   sensor::Sensor *ambient_sensor_{nullptr};
   sensor::Sensor *object_sensor_{nullptr};

--- a/esphome/components/mlx90614/mlx90614.h
+++ b/esphome/components/mlx90614/mlx90614.h
@@ -23,8 +23,8 @@ class MLX90614Component : public PollingComponent, public i2c::I2CDevice {
   bool write_emissivity_();
 
   uint8_t crc8_pec_(const uint8_t *data, uint8_t len);
-  i2c::ErrorCode write_regiser_(uint8_t reg, uint16_t data, uint8_t max_try = 8);
-  uint16_t read_regiser_(uint8_t reg, i2c::ErrorCode &ec, uint8_t max_try = 8);
+  i2c::ErrorCode write_register_(uint8_t reg, uint16_t data, uint8_t max_try = 8);
+  uint16_t read_register_(uint8_t reg, i2c::ErrorCode &ec, uint8_t max_try = 8);
 
   sensor::Sensor *ambient_sensor_{nullptr};
   sensor::Sensor *object_sensor_{nullptr};

--- a/esphome/components/mlx90614/mlx90614.h
+++ b/esphome/components/mlx90614/mlx90614.h
@@ -20,16 +20,19 @@ class MLX90614Component : public PollingComponent, public i2c::I2CDevice {
   void set_emissivity(float emissivity) { emissivity_ = emissivity; }
 
  protected:
-  bool write_emissivity_();
+  i2c::ErrorCode write_emissivity_();
 
   uint8_t crc8_pec_(const uint8_t *data, uint8_t len);
-  i2c::ErrorCode write_register_(uint8_t reg, uint16_t data, uint8_t max_try = 2);
-  uint16_t read_register_(uint8_t reg, i2c::ErrorCode &ec, uint8_t max_try = 2);
+  i2c::ErrorCode write_register_(uint8_t reg, uint16_t data);
+  i2c::ErrorCode read_register_(uint8_t reg, uint16_t &data);
 
   sensor::Sensor *ambient_sensor_{nullptr};
   sensor::Sensor *object_sensor_{nullptr};
 
   float emissivity_{NAN};
+  i2c::ErrorCode emissivity_write_ec_{i2c::ERROR_OK};
+  i2c::ErrorCode object_read_ec_{i2c::ERROR_OK};
+  i2c::ErrorCode ambient_read_ec_{i2c::ERROR_OK}З;
 };
 }  // namespace mlx90614
 }  // namespace esphome

--- a/esphome/components/mlx90614/mlx90614.h
+++ b/esphome/components/mlx90614/mlx90614.h
@@ -23,8 +23,8 @@ class MLX90614Component : public PollingComponent, public i2c::I2CDevice {
   bool write_emissivity_();
 
   uint8_t crc8_pec_(const uint8_t *data, uint8_t len);
-  i2c::ErrorCode write_register_(uint8_t reg, uint16_t data, uint8_t max_try = 8);
-  uint16_t read_register_(uint8_t reg, i2c::ErrorCode &ec, uint8_t max_try = 8);
+  i2c::ErrorCode write_register_(uint8_t reg, uint16_t data, uint8_t max_try = 3);
+  uint16_t read_register_(uint8_t reg, i2c::ErrorCode &ec, uint8_t max_try = 3);
 
   sensor::Sensor *ambient_sensor_{nullptr};
   sensor::Sensor *object_sensor_{nullptr};

--- a/esphome/components/tca9548a/tca9548a.cpp
+++ b/esphome/components/tca9548a/tca9548a.cpp
@@ -22,7 +22,7 @@ i2c::ErrorCode TCA9548AChannel::writev(uint8_t address, i2c::WriteBuffer *buffer
   this->parent_->disable_all_channels();
   return err;
 }
-RecoveryCode TCA9548AComponent::recover() {
+i2c::RecoveryCode TCA9548AComponent::recover() {
   auto err = this->parent_->switch_to_channel(channel_);
 
   if (err == i2c::ERROR_TIMEOUT) {

--- a/esphome/components/tca9548a/tca9548a.cpp
+++ b/esphome/components/tca9548a/tca9548a.cpp
@@ -22,7 +22,7 @@ i2c::ErrorCode TCA9548AChannel::writev(uint8_t address, i2c::WriteBuffer *buffer
   this->parent_->disable_all_channels();
   return err;
 }
-i2c::RecoveryCode TCA9548AComponent::recover() {
+i2c::RecoveryCode TCA9548AChannel::recover() {
   auto err = this->parent_->switch_to_channel(channel_);
 
   if (err == i2c::ERROR_TIMEOUT) {

--- a/esphome/components/tca9548a/tca9548a.cpp
+++ b/esphome/components/tca9548a/tca9548a.cpp
@@ -22,6 +22,29 @@ i2c::ErrorCode TCA9548AChannel::writev(uint8_t address, i2c::WriteBuffer *buffer
   this->parent_->disable_all_channels();
   return err;
 }
+RecoveryCode TCA9548AComponent::recover() {
+  auto err = this->parent_->switch_to_channel(channel_);
+
+  if (err == i2c::ERROR_TIMEOUT) {
+    ESP_LOGW(TAG, "TCA9548A is not answering. Recovering parent bus.");
+    auto recover_result = this->parent_->recover();
+    if (recover_result != i2c::RECOVERY_COMPLETED) {
+      ESP_LOGE(TAG, "Recovering parent bus failed with code %d.", recover_result);
+      return recover_result;
+    }
+    err = this->parent_->switch_to_channel(channel_);
+  }
+
+  if (err != i2c::ERROR_OK) {
+    ESP_LOGE(TAG, "Can't switch channel to recover. Returned %d.", err);
+    return RECOVERY_FAILURE_OTHER;
+  }
+
+  auto recover_result = this->parent_->recover();
+
+  this->parent_->disable_all_channels();
+  return recover_result;
+}
 
 void TCA9548AComponent::setup() {
   ESP_LOGCONFIG(TAG, "Setting up TCA9548A...");
@@ -33,6 +56,7 @@ void TCA9548AComponent::setup() {
   }
   ESP_LOGD(TAG, "Channels currently open: %d", status);
 }
+
 void TCA9548AComponent::dump_config() {
   ESP_LOGCONFIG(TAG, "TCA9548A:");
   LOG_I2C_DEVICE(this);

--- a/esphome/components/tca9548a/tca9548a.h
+++ b/esphome/components/tca9548a/tca9548a.h
@@ -16,7 +16,7 @@ class TCA9548AChannel : public i2c::I2CBus {
 
   i2c::ErrorCode readv(uint8_t address, i2c::ReadBuffer *buffers, size_t cnt) override;
   i2c::ErrorCode writev(uint8_t address, i2c::WriteBuffer *buffers, size_t cnt, bool stop) override;
-  RecoveryCode recover() override;
+  i2c::RecoveryCode recover() override;
 
  protected:
   uint8_t channel_;

--- a/esphome/components/tca9548a/tca9548a.h
+++ b/esphome/components/tca9548a/tca9548a.h
@@ -16,6 +16,7 @@ class TCA9548AChannel : public i2c::I2CBus {
 
   i2c::ErrorCode readv(uint8_t address, i2c::ReadBuffer *buffers, size_t cnt) override;
   i2c::ErrorCode writev(uint8_t address, i2c::WriteBuffer *buffers, size_t cnt, bool stop) override;
+  RecoveryCode recover() override;
 
  protected:
   uint8_t channel_;


### PR DESCRIPTION
# What does this implement/fix?

Contains https://github.com/esphome/esphome/pull/6689

### mlx90614 fix stuck values

* Recovers the i2c connection if sensor is not answering

### i2c recover

* Adds i2c recover routine to be called from bus interface
* Implemented for Arduino and esp-idf
  * Deactivates i2c driver
  * Performs recover sequence
  * Activates i2c driver back

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
sensor:
- platform: mlx90614
  id: furnace_temperature
  update_interval: 5s
  ambient:
    name: Ambient temperature
    id: furnace_ambient_temperature
    entity_category: "diagnostic"
    filters:
      - delta: 
          value: 0.05
  object:
    name: Furnace temperature
    id: furnace_object_temperature
    emissivity: 0.93
    filters:
      - delta: 
          value: 0.05

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
