### PR TITLE
Use clang-apply-replacements when clang-apply-replacements-14 does not exist

### DIFF
--- a/script/clang-tidy
+++ b/script/clang-tidy
@@ -266,7 +266,12 @@ def main():
     if args.fix and failed_files:
         print("Applying fixes ...")
         try:
-            subprocess.call(["clang-apply-replacements-14", tmpdir])
+            try:
+                subprocess.call(["clang-apply-replacements-14", tmpdir])
+            except FileNotFoundError:
+                subprocess.call(["clang-apply-replacements", tmpdir])
+        except FileNotFoundError:
+                print("Error please install clang-apply-replacements-14 or clang-apply-replacements.\n", file=sys.stderr)
         except:
             print("Error applying fixes.\n", file=sys.stderr)
             raise


### PR DESCRIPTION
# What does this implement/fix?

Use clang-apply-replacements when clang-apply-replacements-14 does not exsists

e.g. on Arch Linux

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
N/A
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
