### PR TITLE
[github] Upgrade to actions/[upload,download]-artifact v4

### DIFF
--- a/.github/actions/build-image/action.yaml
+++ b/.github/actions/build-image/action.yaml
@@ -57,14 +57,6 @@ runs:
         digest="${{ steps.build-ghcr.outputs.digest }}"
         touch "/tmp/digests/${{ inputs.target }}/ghcr/${digest#sha256:}"
 
-    - name: Upload ghcr digest
-      uses: actions/upload-artifact@v3.1.3
-      with:
-        name: digests-${{ inputs.target }}-ghcr
-        path: /tmp/digests/${{ inputs.target }}/ghcr/*
-        if-no-files-found: error
-        retention-days: 1
-
     - name: Build and push to dockerhub by digest
       id: build-dockerhub
       uses: docker/build-push-action@v5.3.0
@@ -87,11 +79,3 @@ runs:
         mkdir -p /tmp/digests/${{ inputs.target }}/dockerhub
         digest="${{ steps.build-dockerhub.outputs.digest }}"
         touch "/tmp/digests/${{ inputs.target }}/dockerhub/${digest#sha256:}"
-
-    - name: Upload dockerhub digest
-      uses: actions/upload-artifact@v3.1.3
-      with:
-        name: digests-${{ inputs.target }}-dockerhub
-        path: /tmp/digests/${{ inputs.target }}/dockerhub/*
-        if-no-files-found: error
-        retention-days: 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,6 +132,13 @@ jobs:
           suffix: lint
           version: ${{ needs.init.outputs.tag }}
 
+      - name: Upload digests
+        uses: actions/upload-artifact@v4.3.3
+        with:
+          name: digests-${{ matrix.platform }}
+          path: /tmp/digests
+          retention-days: 1
+
   deploy-manifest:
     name: Publish ESPHome ${{ matrix.image.title }} to ${{ matrix.registry }}
     runs-on: ubuntu-latest
@@ -160,11 +167,14 @@ jobs:
           - dockerhub
     steps:
       - uses: actions/checkout@v4.1.5
+
       - name: Download digests
-        uses: actions/download-artifact@v3.0.2
+        uses: actions/download-artifact@v4.1.7
         with:
-          name: digests-${{ matrix.image.target }}-${{ matrix.registry }}
+          pattern: digests-*
           path: /tmp/digests
+          merge-multiple: true
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3.3.0
 
@@ -195,7 +205,7 @@ jobs:
           done
 
       - name: Create manifest list and push
-        working-directory: /tmp/digests
+        working-directory: /tmp/digests/${{ matrix.image.target }}/${{ matrix.registry }}
         run: |
           docker buildx imagetools create $(jq -Rcnr 'inputs | . / "," | map("-t " + .) | join(" ")' <<< "${{ steps.tags.outputs.tags}}") \
             $(printf '${{ steps.tags.outputs.image }}@sha256:%s ' *)


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

The v4 releases of these actions changed the artifacts to be immutable so this new set-up works.


<details>
<summary>Tested in a separate repo with the following workflow</summary>

```yaml
name: Test

on:
  pull_request:

permissions:
  contents: read

jobs:
  build:
    runs-on: ubuntu-latest
    strategy:
      fail-fast: false
      matrix:
        platform:
          - amd64
          - armv7
          - arm64
    steps:
      - run: mkdir -p /tmp/digests/{ghcr,dockerhub}/{docker,hassio,lint}
      - run: touch /tmp/digests/ghcr/docker/${{ matrix.platform }}
      - run: touch /tmp/digests/dockerhub/docker/${{ matrix.platform }}
      - run: touch /tmp/digests/ghcr/hassio/${{ matrix.platform }}
      - run: touch /tmp/digests/dockerhub/hassio/${{ matrix.platform }}
      - run: touch /tmp/digests/ghcr/lint/${{ matrix.platform }}
      - run: touch /tmp/digests/dockerhub/lint/${{ matrix.platform }}

      - uses: actions/upload-artifact@v4.3.3
        with:
          name: digests-${{ matrix.platform }}
          path: /tmp/digests

  manifest:
    runs-on: ubuntu-latest
    needs: build
    strategy:
      fail-fast: false
      matrix:
        image:
          - title: "ha-addon"
            target: "hassio"
            suffix: "hassio"
          - title: "docker"
            target: "docker"
            suffix: ""
          - title: "lint"
            target: "lint"
            suffix: "lint"
        registry:
          - ghcr
          - dockerhub

    steps:
      - uses: actions/download-artifact@v4.1.7
        with:
          pattern: digests-*
          path: /tmp/digests
          merge-multiple: true

      - working-directory: /tmp/digests
        run: |-
          tree
```

Which yielded the following output:

```text
> Run tree
.
├── dockerhub
│   ├── docker
│   │   ├── amd64
│   │   ├── arm64
│   │   └── armv7
│   ├── hassio
│   │   ├── amd64
│   │   ├── arm64
│   │   └── armv7
│   └── lint
│       ├── amd64
│       ├── arm64
│       └── armv7
└── ghcr
    ├── docker
    │   ├── amd64
    │   ├── arm64
    │   └── armv7
    ├── hassio
    │   ├── amd64
    │   ├── arm64
    │   └── armv7
    └── lint
        ├── amd64
        ├── arm64
        └── armv7
```


</details>



Closes #6603 and closes #6626

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
