### PR TITLE
[nextion] Replace flags to `USE_ARDUINO`

### DIFF
--- a/esphome/components/nextion/nextion.h
+++ b/esphome/components/nextion/nextion.h
@@ -12,7 +12,7 @@
 #include "esphome/components/display/display_color_utils.h"
 
 #ifdef USE_NEXTION_TFT_UPLOAD
-#ifdef ARDUINO
+#ifdef USE_ARDUINO
 #ifdef USE_ESP32
 #include <HTTPClient.h>
 #endif  // USE_ESP32
@@ -22,7 +22,7 @@
 #endif  // USE_ESP8266
 #elif defined(USE_ESP_IDF)
 #include <esp_http_client.h>
-#endif  // ARDUINO vs ESP-IDF
+#endif  // ARDUINO vs USE_ESP_IDF
 #endif  // USE_NEXTION_TFT_UPLOAD
 
 namespace esphome {
@@ -987,7 +987,7 @@ class Nextion : public NextionBase, public PollingComponent, public uart::UARTDe
 
 #ifdef USE_NEXTION_TFT_UPLOAD
   /**
-   * Set the tft file URL. https seems problematic with arduino..
+   * Set the tft file URL. https seems problematic with Arduino..
    */
   void set_tft_url(const std::string &tft_url) { this->tft_url_ = tft_url; }
 
@@ -1190,7 +1190,7 @@ class Nextion : public NextionBase, public PollingComponent, public uart::UARTDe
   uint32_t original_baud_rate_ = 0;
   bool upload_first_chunk_sent_ = false;
 
-#ifdef ARDUINO
+#ifdef USE_ARDUINO
   /**
    * will request chunk_size chunks from the web server
    * and send each to the nextion
@@ -1208,7 +1208,7 @@ class Nextion : public NextionBase, public PollingComponent, public uart::UARTDe
    * @return position of last byte transferred, -1 for failure.
    */
   int upload_by_chunks_(esp_http_client_handle_t http_client, uint32_t &range_start);
-#endif  // ARDUINO vs USE_ESP_IDF
+#endif  // USE_ARDUINO vs USE_ESP_IDF
 
   /**
    * Ends the upload process, restart Nextion and, if successful,

--- a/esphome/components/nextion/nextion_upload_arduino.cpp
+++ b/esphome/components/nextion/nextion_upload_arduino.cpp
@@ -1,7 +1,7 @@
 #include "nextion.h"
 
 #ifdef USE_NEXTION_TFT_UPLOAD
-#ifdef ARDUINO
+#ifdef USE_ARDUINO
 
 #include "esphome/core/application.h"
 #include "esphome/core/defines.h"
@@ -383,5 +383,5 @@ WiFiClient *Nextion::get_wifi_client_() {
 }  // namespace nextion
 }  // namespace esphome
 
-#endif  // ARDUINO
+#endif  // USE_ARDUINO
 #endif  // USE_NEXTION_TFT_UPLOAD


### PR DESCRIPTION
# What does this implement/fix?

There are no functional changes to the component itself, but I'm replacing the use of `ARDUINO` flags by `USE_ARDUINO` as standard for ESPHome.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
N/A

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
