### PR TITLE
[remote_receiver, remote_transmitter] Improve error messages on the ESP32

### DIFF
--- a/esphome/components/remote_receiver/remote_receiver.h
+++ b/esphome/components/remote_receiver/remote_receiver.h
@@ -58,6 +58,7 @@ class RemoteReceiverComponent : public remote_base::RemoteReceiverBase,
   void decode_rmt_(rmt_item32_t *item, size_t len);
   RingbufHandle_t ringbuf_;
   esp_err_t error_code_{ESP_OK};
+  std::string error_string_{""};
 #endif
 
 #if defined(USE_ESP8266) || defined(USE_LIBRETINY)

--- a/esphome/components/remote_receiver/remote_receiver_esp32.cpp
+++ b/esphome/components/remote_receiver/remote_receiver_esp32.cpp
@@ -29,6 +29,7 @@ void RemoteReceiverComponent::setup() {
   esp_err_t error = rmt_config(&rmt);
   if (error != ESP_OK) {
     this->error_code_ = error;
+    this->error_string_ = "in rmt_config";
     this->mark_failed();
     return;
   }
@@ -36,18 +37,25 @@ void RemoteReceiverComponent::setup() {
   error = rmt_driver_install(this->channel_, this->buffer_size_, 0);
   if (error != ESP_OK) {
     this->error_code_ = error;
+    if (error == ESP_ERR_INVALID_STATE) {
+      this->error_string_ = str_sprintf("RMT channel %i is already in use by another component", this->channel_);
+    } else {
+      this->error_string_ = "in rmt_driver_install";
+    }
     this->mark_failed();
     return;
   }
   error = rmt_get_ringbuf_handle(this->channel_, &this->ringbuf_);
   if (error != ESP_OK) {
     this->error_code_ = error;
+    this->error_string_ = "in rmt_get_ringbuf_handle";
     this->mark_failed();
     return;
   }
   error = rmt_rx_start(this->channel_, true);
   if (error != ESP_OK) {
     this->error_code_ = error;
+    this->error_string_ = "in rmt_rx_start";
     this->mark_failed();
     return;
   }
@@ -67,7 +75,7 @@ void RemoteReceiverComponent::dump_config() {
   ESP_LOGCONFIG(TAG, "  Filter out pulses shorter than: %" PRIu32 " us", this->filter_us_);
   ESP_LOGCONFIG(TAG, "  Signal is done after %" PRIu32 " us of no changes", this->idle_us_);
   if (this->is_failed()) {
-    ESP_LOGE(TAG, "Configuring RMT driver failed: %s", esp_err_to_name(this->error_code_));
+    ESP_LOGE(TAG, "Configuring RMT driver failed: %s (%s)", esp_err_to_name(this->error_code_), this->error_string_.c_str());
   }
 }
 

--- a/esphome/components/remote_receiver/remote_receiver_esp32.cpp
+++ b/esphome/components/remote_receiver/remote_receiver_esp32.cpp
@@ -75,7 +75,8 @@ void RemoteReceiverComponent::dump_config() {
   ESP_LOGCONFIG(TAG, "  Filter out pulses shorter than: %" PRIu32 " us", this->filter_us_);
   ESP_LOGCONFIG(TAG, "  Signal is done after %" PRIu32 " us of no changes", this->idle_us_);
   if (this->is_failed()) {
-    ESP_LOGE(TAG, "Configuring RMT driver failed: %s (%s)", esp_err_to_name(this->error_code_), this->error_string_.c_str());
+    ESP_LOGE(TAG, "Configuring RMT driver failed: %s (%s)", esp_err_to_name(this->error_code_),
+             this->error_string_.c_str());
   }
 }
 

--- a/esphome/components/remote_transmitter/remote_transmitter.h
+++ b/esphome/components/remote_transmitter/remote_transmitter.h
@@ -53,6 +53,7 @@ class RemoteTransmitterComponent : public remote_base::RemoteTransmitterBase,
   bool initialized_{false};
   std::vector<rmt_item32_t> rmt_temp_;
   esp_err_t error_code_{ESP_OK};
+  std::string error_string_{""};
   bool inverted_{false};
 #endif
   uint8_t carrier_duty_percent_;

--- a/esphome/components/remote_transmitter/remote_transmitter_esp32.cpp
+++ b/esphome/components/remote_transmitter/remote_transmitter_esp32.cpp
@@ -23,7 +23,7 @@ void RemoteTransmitterComponent::dump_config() {
   }
 
   if (this->is_failed()) {
-    ESP_LOGE(TAG, "Configuring RMT driver failed: %s", esp_err_to_name(this->error_code_));
+    ESP_LOGE(TAG, "Configuring RMT driver failed: %s (%s)", esp_err_to_name(this->error_code_), this->error_string_.c_str());
   }
 }
 
@@ -56,6 +56,7 @@ void RemoteTransmitterComponent::configure_rmt_() {
   esp_err_t error = rmt_config(&c);
   if (error != ESP_OK) {
     this->error_code_ = error;
+    this->error_string_ = "in rmt_config";
     this->mark_failed();
     return;
   }
@@ -64,6 +65,11 @@ void RemoteTransmitterComponent::configure_rmt_() {
     error = rmt_driver_install(this->channel_, 0, 0);
     if (error != ESP_OK) {
       this->error_code_ = error;
+      if (error == ESP_ERR_INVALID_STATE) {
+        this->error_string_ = str_sprintf("RMT channel %i is already in use by another component", this->channel_);
+      } else {
+        this->error_string_ = "in rmt_driver_install";
+      }
       this->mark_failed();
       return;
     }

--- a/esphome/components/remote_transmitter/remote_transmitter_esp32.cpp
+++ b/esphome/components/remote_transmitter/remote_transmitter_esp32.cpp
@@ -23,7 +23,8 @@ void RemoteTransmitterComponent::dump_config() {
   }
 
   if (this->is_failed()) {
-    ESP_LOGE(TAG, "Configuring RMT driver failed: %s (%s)", esp_err_to_name(this->error_code_), this->error_string_.c_str());
+    ESP_LOGE(TAG, "Configuring RMT driver failed: %s (%s)", esp_err_to_name(this->error_code_),
+             this->error_string_.c_str());
   }
 }
 


### PR DESCRIPTION
# What does this implement/fix?
When a RMT channel is already in use the error message doesn't tell the user what's wrong.
<!-- Quick description and explanation of changes -->

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
