### PR TITLE
Add PHY register writes to enable external clock on Ethernet with RTL8201

### DIFF
--- a/esphome/components/ethernet/ethernet_component.cpp
+++ b/esphome/components/ethernet/ethernet_component.cpp
@@ -590,7 +590,6 @@ void EthernetComponent::ksz8081_set_clock_reference_(esp_eth_mac_t *mac) {
 }
 constexpr uint8_t RTL8201_RMSR_REG_ADDR = 0x10;
 void EthernetComponent::rtl8201_set_rmii_mode_(esp_eth_mac_t *mac) {
-
   esp_err_t err;
   uint32_t phy_rmii_mode;
   err = mac->write_phy_reg(mac, this->phy_addr_, 0x1f, 0x07);

--- a/esphome/components/ethernet/ethernet_component.cpp
+++ b/esphome/components/ethernet/ethernet_component.cpp
@@ -614,12 +614,17 @@ void EthernetComponent::rtl8201_set_rmii_mode_(esp_eth_mac_t *mac) {
    * Hex: 0x1FFA
    *
    */
+
+  err = mac->read_phy_reg(mac, this->phy_addr_, RTL8201_RMSR_REG_ADDR, &(phy_rmii_mode));
+  ESPHL_ERROR_CHECK(err, "Read PHY RMSR Register failed");
+  ESP_LOGV(TAG, "Hardware default RTL8201 RMII Mode Register is: 0x%04X", phy_rmii_mode);
+
   err = mac->write_phy_reg(mac, this->phy_addr_, RTL8201_RMSR_REG_ADDR, 0x1FFA);
   ESPHL_ERROR_CHECK(err, "Setting Register 16 RMII Mode Setting failed");
 
   err = mac->read_phy_reg(mac, this->phy_addr_, RTL8201_RMSR_REG_ADDR, &(phy_rmii_mode));
   ESPHL_ERROR_CHECK(err, "Read PHY RMSR Register failed");
-  ESP_LOGV(TAG, "Set RTL8201 RMII Mode Register: %s", format_hex_pretty((u_int8_t *) &phy_rmii_mode, 2).c_str());
+  ESP_LOGV(TAG, "Setting RTL8201 RMII Mode Register to: 0x%04X", phy_rmii_mode);
 
   err = mac->write_phy_reg(mac, this->phy_addr_, 0x1f, 0x0);
   ESPHL_ERROR_CHECK(err, "Setting Page 0 failed");

--- a/esphome/components/ethernet/ethernet_component.cpp
+++ b/esphome/components/ethernet/ethernet_component.cpp
@@ -588,9 +588,8 @@ void EthernetComponent::ksz8081_set_clock_reference_(esp_eth_mac_t *mac) {
 
 #undef KSZ80XX_PC2R_REG_ADDR
 }
-
+constexpr uint8_t RTL8201_RMSR_REG_ADDR = 0x10;
 void EthernetComponent::rtl8201_set_rmii_mode_(esp_eth_mac_t *mac) {
-  constexpr uint8_t RTL8201_RMSR_REG_ADDR = 0x10;
 
   esp_err_t err;
   uint32_t phy_rmii_mode;

--- a/esphome/components/ethernet/ethernet_component.cpp
+++ b/esphome/components/ethernet/ethernet_component.cpp
@@ -590,7 +590,7 @@ void EthernetComponent::ksz8081_set_clock_reference_(esp_eth_mac_t *mac) {
 }
 
 void EthernetComponent::rtl8201_set_rmii_mode_(esp_eth_mac_t *mac) {
-#define RTL8201_RMSR_REG_ADDR (0x10)
+  constexpr uint8_t RTL8201_RMSR_REG_ADDR = 0x10;
 
   esp_err_t err;
   uint32_t phy_rmii_mode;
@@ -628,8 +628,6 @@ void EthernetComponent::rtl8201_set_rmii_mode_(esp_eth_mac_t *mac) {
 
   err = mac->write_phy_reg(mac, this->phy_addr_, 0x1f, 0x0);
   ESPHL_ERROR_CHECK(err, "Setting Page 0 failed");
-
-#undef RTL8201_RMSR_REG_ADDR
 }
 
 #endif

--- a/esphome/components/ethernet/ethernet_component.h
+++ b/esphome/components/ethernet/ethernet_component.h
@@ -86,6 +86,8 @@ class EthernetComponent : public Component {
   void dump_connect_params_();
   /// @brief Set `RMII Reference Clock Select` bit for KSZ8081.
   void ksz8081_set_clock_reference_(esp_eth_mac_t *mac);
+  /// @brief Set `RMII Mode Setting Register` for RTL8201.
+  void rtl8201_set_rmii_mode_(esp_eth_mac_t *mac);
 
   std::string use_address_;
 #ifdef USE_ETHERNET_SPI


### PR DESCRIPTION
# What does this implement/fix?

When using Ethernet on a board with the `RTL8201` PHY and using an external clock (`clk_mode: GPIO_IN`), there's a good chance that the RMII Mode Setting Register is incorrect. This change fixes the problem by ensuring that the RMII clock mode is set correctly in the PHY register when initializing ethernet.

## Background

Two common IoT boards that use the RTL8201 PHY are the Konnected Alarm Panel Pro and wESP32. The Konnected panel based its design on the wESP32 as a reference, so the ethernet schematics between these two boards are the same. In recent production runs of these boards, suddenly Ethernet performance was severely degraded to the point of non-functional. After months of investigation, we tracked down the problem to a floating pin (pin 12) on the RTL8201FI that _should_ have been pulled up to correctly set the clock mode.

Apparently, there was a recent change in the default behavior of the RTL8201FI chip in date codes starting with _N_. We observed, in collaboration with @xorbit of Silicognition (maker of wESP32), that RTL8201FI chips with date codes _M_ and prior worked despite the floating pin, while those with _N_ and after did not.

Fortunately, we can compensate for the hardware change in firmware and set the PHY register for RMII Mode Settings in the ethernet initialization code, according to the datasheet for the RTL8201FI:
![Screenshot 2024-05-07 at 6 13 44 PM](https://github.com/esphome/esphome/assets/12016/555b0565-e2a1-409d-9efe-8fee7cfc83c0)

The incorrect setting here that we need to change is the _Rg_rmii_clkdir_ bit to 1 to indicate INPUT direction. 

Changing this is confirmed to fix Konnected Pro boards with RTL8201 chips with _N_ and later date codes.

Interestingly, I observed the hardware set defaults between newer and older boards were the same in both _M_ and _N_ variant chips, indicating that this mode setting is incorrect even on the functional Konnected and wESP32 boards out in the wild. So it's plausible that correctly setting it would improve the ethernet link quality for these boards. It may be that chips with the M and older date code are maybe just more tolerant in some way than the newer ones??

```
[16:39:42][V][ethernet:615]: Hardware default RTL8201 RMII Mode Register is: 0x0FFA
[16:39:42][V][ethernet:622]: Setting RTL8201 RMII Mode Register to: 0x1FFA
```

thank you to @xorbit and @h2zero for the immense help getting to the bottom of this

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
ethernet:
  type: RTL8201
  mdc_pin: GPIO16
  mdio_pin: GPIO17
  clk_mode: GPIO0_IN
  phy_addr: 0

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
