### PR TITLE
[ethernet] Use constexpr instead of inline define for KSZ80XX_PC2R_REG_ADDR

### DIFF
--- a/esphome/components/ethernet/ethernet_component.cpp
+++ b/esphome/components/ethernet/ethernet_component.cpp
@@ -554,9 +554,10 @@ bool EthernetComponent::powerdown() {
 }
 
 #ifndef USE_ETHERNET_SPI
-void EthernetComponent::ksz8081_set_clock_reference_(esp_eth_mac_t *mac) {
-  constexpr uint8_t KSZ80XX_PC2R_REG_ADDR = 0x1F;
 
+constexpr uint8_t KSZ80XX_PC2R_REG_ADDR = 0x1F;
+
+void EthernetComponent::ksz8081_set_clock_reference_(esp_eth_mac_t *mac) {
   esp_err_t err;
 
   uint32_t phy_control_2;

--- a/esphome/components/ethernet/ethernet_component.cpp
+++ b/esphome/components/ethernet/ethernet_component.cpp
@@ -1,12 +1,12 @@
 #include "ethernet_component.h"
+#include "esphome/core/application.h"
 #include "esphome/core/log.h"
 #include "esphome/core/util.h"
-#include "esphome/core/application.h"
 
 #ifdef USE_ESP32
 
-#include <cinttypes>
 #include <lwip/dns.h>
+#include <cinttypes>
 #include "esp_event.h"
 
 #ifdef USE_ETHERNET_SPI
@@ -555,7 +555,7 @@ bool EthernetComponent::powerdown() {
 
 #ifndef USE_ETHERNET_SPI
 void EthernetComponent::ksz8081_set_clock_reference_(esp_eth_mac_t *mac) {
-#define KSZ80XX_PC2R_REG_ADDR (0x1F)
+  constexpr uint8_t KSZ80XX_PC2R_REG_ADDR = 0x1F;
 
   esp_err_t err;
 
@@ -581,8 +581,6 @@ void EthernetComponent::ksz8081_set_clock_reference_(esp_eth_mac_t *mac) {
     ESPHL_ERROR_CHECK(err, "Read PHY Control 2 failed");
     ESP_LOGVV(TAG, "KSZ8081 PHY Control 2: %s", format_hex_pretty((u_int8_t *) &phy_control_2, 2).c_str());
   }
-
-#undef KSZ80XX_PC2R_REG_ADDR
 }
 #endif
 


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

A minor tidy up to remove an inline define and replace with a constexpr

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
