### PR TITLE
[core] Ensure that a generated ID name is distinct from its type.

### DIFF
--- a/esphome/core/__init__.py
+++ b/esphome/core/__init__.py
@@ -340,6 +340,8 @@ class ID:
 
         if self.id is None:
             base = str(self.type).replace("::", "_").lower()
+            if base == self.type:
+                base = base + "_id"
             name = "".join(c for c in base if c.isalnum() or c == "_")
             used = set(registered_ids) | set(RESERVED_IDS) | CORE.loaded_integrations
             self.id = ensure_unique_string(name, used)


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

If an ID is created with a type in the global namespace, i.e. without a `::` separator, the first instance generated will be identical to the type, leading to compile-time errors.

This PR checks for that case and disambiguates the name.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
