### PR TITLE
[color] Fix crash when hex color parses as int, improve error reporting.

### DIFF
--- a/esphome/components/color/__init__.py
+++ b/esphome/components/color/__init__.py
@@ -39,8 +39,12 @@ components = {
 
 
 def validate_color(config):
-    if CONF_HEX in config and set(config) & components:
+    has_components = set(config) & components
+    has_hex = CONF_HEX in config
+    if has_hex and has_components:
         raise cv.Invalid("Hex color value may not be combined with component values")
+    if not has_hex and not has_components:
+        raise cv.Invalid("Must provide at least one color option")
     return config
 
 

--- a/esphome/components/color/__init__.py
+++ b/esphome/components/color/__init__.py
@@ -26,8 +26,20 @@ def hex_color(value):
         raise cv.Invalid("Color must be hexadecimal") from exc
 
 
+components = {
+    CONF_RED,
+    CONF_RED_INT,
+    CONF_GREEN,
+    CONF_GREEN_INT,
+    CONF_BLUE,
+    CONF_BLUE_INT,
+    CONF_WHITE,
+    CONF_WHITE_INT,
+}
+
+
 def validate_color(config):
-    if CONF_HEX in config and len(config) != 2:
+    if CONF_HEX in config and set(config) & components:
         raise cv.Invalid("Hex color value may not be combined with component values")
     return config
 

--- a/esphome/components/color/__init__.py
+++ b/esphome/components/color/__init__.py
@@ -14,15 +14,25 @@ CONF_HEX = "hex"
 
 
 def hex_color(value):
+    if value is None:
+        raise cv.Invalid("Missing value for hex color")
+    if isinstance(value, int):
+        value = str(value)
     if len(value) != 6:
-        raise cv.Invalid("Color must have six digits")
+        raise cv.Invalid("Hex color must have six digits")
     try:
-        return (int(value[0:2], 16), int(value[2:4], 16), int(value[4:6], 16))
+        return int(value[0:2], 16), int(value[2:4], 16), int(value[4:6], 16)
     except ValueError as exc:
         raise cv.Invalid("Color must be hexadecimal") from exc
 
 
-CONFIG_SCHEMA = cv.Any(
+def validate_color(config):
+    if CONF_HEX in config and len(config) != 2:
+        raise cv.Invalid("Hex color value may not be combined with component values")
+    return config
+
+
+CONFIG_SCHEMA = cv.All(
     cv.Schema(
         {
             cv.Required(CONF_ID): cv.declare_id(ColorStruct),
@@ -34,14 +44,10 @@ CONFIG_SCHEMA = cv.Any(
             cv.Exclusive(CONF_BLUE_INT, "blue"): cv.uint8_t,
             cv.Exclusive(CONF_WHITE, "white"): cv.percentage,
             cv.Exclusive(CONF_WHITE_INT, "white"): cv.uint8_t,
+            cv.Optional(CONF_HEX): hex_color,
         }
     ).extend(cv.COMPONENT_SCHEMA),
-    cv.Schema(
-        {
-            cv.Required(CONF_ID): cv.declare_id(ColorStruct),
-            cv.Required(CONF_HEX): hex_color,
-        }
-    ).extend(cv.COMPONENT_SCHEMA),
+    validate_color,
 )
 
 

--- a/esphome/components/color/__init__.py
+++ b/esphome/components/color/__init__.py
@@ -14,10 +14,10 @@ CONF_HEX = "hex"
 
 
 def hex_color(value):
-    if value is None:
-        raise cv.Invalid("Missing value for hex color")
     if isinstance(value, int):
         value = str(value)
+    if not isinstance(value, str):
+        raise cv.Invalid("Invalid value for hex color")
     if len(value) != 6:
         raise cv.Invalid("Hex color must have six digits")
     try:

--- a/tests/components/color/common.yaml
+++ b/tests/components/color/common.yaml
@@ -9,3 +9,12 @@ color:
     blue: 100%
   - id: kbx_green
     hex: "3DEC55"
+  - id: kbx_green_1
+    hex: 3DEC55
+  - id: cps_red
+    hex: 800000
+  - id: cps_green
+    hex: 008000
+  - id: cps_blue
+    hex: 000080
+


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

The current `color` schema has two problems:
* `hex: 800000` causes a config-time crash since the value is parsed as an int:

```
    if len(value) != 6:
       ^^^^^^^^^^
TypeError: object of type 'EInt' has no len()
```

* An invalid hex value gives a misleading message:

```
  - id: kbx_green

    [hex] is an invalid option for [2]. Please check the indentation.
    hex: F800000
```

due to the use of `cv.Any()` which is indiscriminate in its error reporting.

This PR fixes both those.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
