### PR TITLE
2024.5.0b2

### DIFF
--- a/.github/actions/build-image/action.yaml
+++ b/.github/actions/build-image/action.yaml
@@ -57,14 +57,6 @@ runs:
         digest="${{ steps.build-ghcr.outputs.digest }}"
         touch "/tmp/digests/${{ inputs.target }}/ghcr/${digest#sha256:}"
 
-    - name: Upload ghcr digest
-      uses: actions/upload-artifact@v3.1.3
-      with:
-        name: digests-${{ inputs.target }}-ghcr
-        path: /tmp/digests/${{ inputs.target }}/ghcr/*
-        if-no-files-found: error
-        retention-days: 1
-
     - name: Build and push to dockerhub by digest
       id: build-dockerhub
       uses: docker/build-push-action@v5.3.0
@@ -87,11 +79,3 @@ runs:
         mkdir -p /tmp/digests/${{ inputs.target }}/dockerhub
         digest="${{ steps.build-dockerhub.outputs.digest }}"
         touch "/tmp/digests/${{ inputs.target }}/dockerhub/${digest#sha256:}"
-
-    - name: Upload dockerhub digest
-      uses: actions/upload-artifact@v3.1.3
-      with:
-        name: digests-${{ inputs.target }}-dockerhub
-        path: /tmp/digests/${{ inputs.target }}/dockerhub/*
-        if-no-files-found: error
-        retention-days: 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,6 +132,13 @@ jobs:
           suffix: lint
           version: ${{ needs.init.outputs.tag }}
 
+      - name: Upload digests
+        uses: actions/upload-artifact@v4.3.3
+        with:
+          name: digests-${{ matrix.platform }}
+          path: /tmp/digests
+          retention-days: 1
+
   deploy-manifest:
     name: Publish ESPHome ${{ matrix.image.title }} to ${{ matrix.registry }}
     runs-on: ubuntu-latest
@@ -160,11 +167,14 @@ jobs:
           - dockerhub
     steps:
       - uses: actions/checkout@v4.1.5
+
       - name: Download digests
-        uses: actions/download-artifact@v3.0.2
+        uses: actions/download-artifact@v4.1.7
         with:
-          name: digests-${{ matrix.image.target }}-${{ matrix.registry }}
+          pattern: digests-*
           path: /tmp/digests
+          merge-multiple: true
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3.3.0
 
@@ -195,7 +205,7 @@ jobs:
           done
 
       - name: Create manifest list and push
-        working-directory: /tmp/digests
+        working-directory: /tmp/digests/${{ matrix.image.target }}/${{ matrix.registry }}
         run: |
           docker buildx imagetools create $(jq -Rcnr 'inputs | . / "," | map("-t " + .) | join(" ")' <<< "${{ steps.tags.outputs.tags}}") \
             $(printf '${{ steps.tags.outputs.image }}@sha256:%s ' *)

--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -227,7 +227,7 @@ ARDUINO_PLATFORM_VERSION = cv.Version(5, 4, 0)
 # The default/recommended esp-idf framework version
 #  - https://github.com/espressif/esp-idf/releases
 #  - https://api.registry.platformio.org/v3/packages/platformio/tool/framework-espidf
-RECOMMENDED_ESP_IDF_FRAMEWORK_VERSION = cv.Version(4, 4, 6)
+RECOMMENDED_ESP_IDF_FRAMEWORK_VERSION = cv.Version(4, 4, 7)
 # The platformio/espressif32 version to use for esp-idf frameworks
 #  - https://github.com/platformio/platform-espressif32/releases
 #  - https://api.registry.platformio.org/v3/packages/platformio/platform/espressif32

--- a/esphome/components/ethernet/ethernet_component.cpp
+++ b/esphome/components/ethernet/ethernet_component.cpp
@@ -184,6 +184,10 @@ void EthernetComponent::setup() {
     // KSZ8081RNA default is incorrect. It expects a 25MHz clock instead of the 50MHz we provide.
     this->ksz8081_set_clock_reference_(mac);
   }
+  if (this->type_ == ETHERNET_TYPE_RTL8201 && this->clk_mode_ == EMAC_CLK_EXT_IN) {
+    // Change in default behavior of RTL8201FI may require register setting to enable external clock
+    this->rtl8201_set_rmii_mode_(mac);
+  }
 #endif
 
   // use ESP internal eth mac
@@ -583,6 +587,46 @@ void EthernetComponent::ksz8081_set_clock_reference_(esp_eth_mac_t *mac) {
     ESP_LOGVV(TAG, "KSZ8081 PHY Control 2: %s", format_hex_pretty((u_int8_t *) &phy_control_2, 2).c_str());
   }
 }
+constexpr uint8_t RTL8201_RMSR_REG_ADDR = 0x10;
+void EthernetComponent::rtl8201_set_rmii_mode_(esp_eth_mac_t *mac) {
+  esp_err_t err;
+  uint32_t phy_rmii_mode;
+  err = mac->write_phy_reg(mac, this->phy_addr_, 0x1f, 0x07);
+  ESPHL_ERROR_CHECK(err, "Setting Page 7 failed");
+
+  /*
+   * RTL8201 RMII Mode Setting Register (RMSR)
+   * Page 7 Register 16
+   *
+   * bit 0      Reserved            0
+   * bit 1      Rg_rmii_rxdsel      1 (default)
+   * bit 2      Rg_rmii_rxdv_sel:   0 (default)
+   * bit 3      RMII Mode:          1 (RMII Mode)
+   * bit 4~7    Rg_rmii_rx_offset:  1111 (default)
+   * bit 8~11   Rg_rmii_tx_offset:  1111 (default)
+   * bit 12     Rg_rmii_clkdir:     1 (Input)
+   * bit 13~15  Reserved            000
+   *
+   * Binary: 0001 1111 1111 1010
+   * Hex: 0x1FFA
+   *
+   */
+
+  err = mac->read_phy_reg(mac, this->phy_addr_, RTL8201_RMSR_REG_ADDR, &(phy_rmii_mode));
+  ESPHL_ERROR_CHECK(err, "Read PHY RMSR Register failed");
+  ESP_LOGV(TAG, "Hardware default RTL8201 RMII Mode Register is: 0x%04X", phy_rmii_mode);
+
+  err = mac->write_phy_reg(mac, this->phy_addr_, RTL8201_RMSR_REG_ADDR, 0x1FFA);
+  ESPHL_ERROR_CHECK(err, "Setting Register 16 RMII Mode Setting failed");
+
+  err = mac->read_phy_reg(mac, this->phy_addr_, RTL8201_RMSR_REG_ADDR, &(phy_rmii_mode));
+  ESPHL_ERROR_CHECK(err, "Read PHY RMSR Register failed");
+  ESP_LOGV(TAG, "Setting RTL8201 RMII Mode Register to: 0x%04X", phy_rmii_mode);
+
+  err = mac->write_phy_reg(mac, this->phy_addr_, 0x1f, 0x0);
+  ESPHL_ERROR_CHECK(err, "Setting Page 0 failed");
+}
+
 #endif
 
 }  // namespace ethernet

--- a/esphome/components/ethernet/ethernet_component.cpp
+++ b/esphome/components/ethernet/ethernet_component.cpp
@@ -1,12 +1,12 @@
 #include "ethernet_component.h"
+#include "esphome/core/application.h"
 #include "esphome/core/log.h"
 #include "esphome/core/util.h"
-#include "esphome/core/application.h"
 
 #ifdef USE_ESP32
 
-#include <cinttypes>
 #include <lwip/dns.h>
+#include <cinttypes>
 #include "esp_event.h"
 
 #ifdef USE_ETHERNET_SPI
@@ -554,9 +554,10 @@ bool EthernetComponent::powerdown() {
 }
 
 #ifndef USE_ETHERNET_SPI
-void EthernetComponent::ksz8081_set_clock_reference_(esp_eth_mac_t *mac) {
-#define KSZ80XX_PC2R_REG_ADDR (0x1F)
 
+constexpr uint8_t KSZ80XX_PC2R_REG_ADDR = 0x1F;
+
+void EthernetComponent::ksz8081_set_clock_reference_(esp_eth_mac_t *mac) {
   esp_err_t err;
 
   uint32_t phy_control_2;
@@ -581,8 +582,6 @@ void EthernetComponent::ksz8081_set_clock_reference_(esp_eth_mac_t *mac) {
     ESPHL_ERROR_CHECK(err, "Read PHY Control 2 failed");
     ESP_LOGVV(TAG, "KSZ8081 PHY Control 2: %s", format_hex_pretty((u_int8_t *) &phy_control_2, 2).c_str());
   }
-
-#undef KSZ80XX_PC2R_REG_ADDR
 }
 #endif
 

--- a/esphome/components/ethernet/ethernet_component.h
+++ b/esphome/components/ethernet/ethernet_component.h
@@ -86,6 +86,8 @@ class EthernetComponent : public Component {
   void dump_connect_params_();
   /// @brief Set `RMII Reference Clock Select` bit for KSZ8081.
   void ksz8081_set_clock_reference_(esp_eth_mac_t *mac);
+  /// @brief Set `RMII Mode Setting Register` for RTL8201.
+  void rtl8201_set_rmii_mode_(esp_eth_mac_t *mac);
 
   std::string use_address_;
 #ifdef USE_ETHERNET_SPI

--- a/esphome/components/nextion/nextion.h
+++ b/esphome/components/nextion/nextion.h
@@ -12,7 +12,7 @@
 #include "esphome/components/display/display_color_utils.h"
 
 #ifdef USE_NEXTION_TFT_UPLOAD
-#ifdef ARDUINO
+#ifdef USE_ARDUINO
 #ifdef USE_ESP32
 #include <HTTPClient.h>
 #endif  // USE_ESP32
@@ -22,7 +22,7 @@
 #endif  // USE_ESP8266
 #elif defined(USE_ESP_IDF)
 #include <esp_http_client.h>
-#endif  // ARDUINO vs ESP-IDF
+#endif  // ARDUINO vs USE_ESP_IDF
 #endif  // USE_NEXTION_TFT_UPLOAD
 
 namespace esphome {
@@ -987,7 +987,7 @@ class Nextion : public NextionBase, public PollingComponent, public uart::UARTDe
 
 #ifdef USE_NEXTION_TFT_UPLOAD
   /**
-   * Set the tft file URL. https seems problematic with arduino..
+   * Set the tft file URL. https seems problematic with Arduino..
    */
   void set_tft_url(const std::string &tft_url) { this->tft_url_ = tft_url; }
 
@@ -1190,7 +1190,7 @@ class Nextion : public NextionBase, public PollingComponent, public uart::UARTDe
   uint32_t original_baud_rate_ = 0;
   bool upload_first_chunk_sent_ = false;
 
-#ifdef ARDUINO
+#ifdef USE_ARDUINO
   /**
    * will request chunk_size chunks from the web server
    * and send each to the nextion
@@ -1208,7 +1208,7 @@ class Nextion : public NextionBase, public PollingComponent, public uart::UARTDe
    * @return position of last byte transferred, -1 for failure.
    */
   int upload_by_chunks_(esp_http_client_handle_t http_client, uint32_t &range_start);
-#endif  // ARDUINO vs USE_ESP_IDF
+#endif  // USE_ARDUINO vs USE_ESP_IDF
 
   /**
    * Ends the upload process, restart Nextion and, if successful,

--- a/esphome/components/nextion/nextion_upload_arduino.cpp
+++ b/esphome/components/nextion/nextion_upload_arduino.cpp
@@ -1,7 +1,7 @@
 #include "nextion.h"
 
 #ifdef USE_NEXTION_TFT_UPLOAD
-#ifdef ARDUINO
+#ifdef USE_ARDUINO
 
 #include "esphome/core/application.h"
 #include "esphome/core/defines.h"
@@ -383,5 +383,5 @@ WiFiClient *Nextion::get_wifi_client_() {
 }  // namespace nextion
 }  // namespace esphome
 
-#endif  // ARDUINO
+#endif  // USE_ARDUINO
 #endif  // USE_NEXTION_TFT_UPLOAD

--- a/esphome/components/remote_receiver/remote_receiver.h
+++ b/esphome/components/remote_receiver/remote_receiver.h
@@ -58,6 +58,7 @@ class RemoteReceiverComponent : public remote_base::RemoteReceiverBase,
   void decode_rmt_(rmt_item32_t *item, size_t len);
   RingbufHandle_t ringbuf_;
   esp_err_t error_code_{ESP_OK};
+  std::string error_string_{""};
 #endif
 
 #if defined(USE_ESP8266) || defined(USE_LIBRETINY)

--- a/esphome/components/remote_transmitter/remote_transmitter.h
+++ b/esphome/components/remote_transmitter/remote_transmitter.h
@@ -53,6 +53,7 @@ class RemoteTransmitterComponent : public remote_base::RemoteTransmitterBase,
   bool initialized_{false};
   std::vector<rmt_item32_t> rmt_temp_;
   esp_err_t error_code_{ESP_OK};
+  std::string error_string_{""};
   bool inverted_{false};
 #endif
   uint8_t carrier_duty_percent_;

--- a/esphome/const.py
+++ b/esphome/const.py
@@ -1,6 +1,6 @@
 """Constants used by esphome."""
 
-__version__ = "2024.5.0b1"
+__version__ = "2024.5.0b2"
 
 ALLOWED_NAME_CHARS = "abcdefghijklmnopqrstuvwxyz0123456789-_"
 VALID_SUBSTITUTIONS_CHARACTERS = (

--- a/platformio.ini
+++ b/platformio.ini
@@ -137,7 +137,7 @@ extra_scripts = post:esphome/components/esp32/post_build.py.script
 extends = common:idf
 platform = platformio/espressif32@5.4.0
 platform_packages =
-    platformio/framework-espidf@~3.40406.0
+    platformio/framework-espidf@~3.40407.0
 
 framework = espidf
 lib_deps =


### PR DESCRIPTION
**Do not merge, release script will automatically merge**
## Full list of changes

### All changes

- [github] Upgrade to actions/[upload,download]-artifact v4 [esphome#6698](https://github.com/esphome/esphome/pull/6698)
- [nextion] Replace flags to `USE_ARDUINO` [esphome#6700](https://github.com/esphome/esphome/pull/6700)
- [remote_receiver, remote_transmitter] Improve error messages on the ESP32 [esphome#6701](https://github.com/esphome/esphome/pull/6701)
- [ethernet] Use constexpr instead of inline define for KSZ80XX_PC2R_REG_ADDR [esphome#6705](https://github.com/esphome/esphome/pull/6705)
- Add PHY register writes to enable external clock on Ethernet with RTL8201 [esphome#6704](https://github.com/esphome/esphome/pull/6704)
- Bump recommended ESP-IDF to 4.4.7 [esphome#6703](https://github.com/esphome/esphome/pull/6703)
