### PR TITLE
Set FEATURE_API_AUDIO flag also if the speaker component is not used

### DIFF
--- a/esphome/components/voice_assistant/voice_assistant.h
+++ b/esphome/components/voice_assistant/voice_assistant.h
@@ -94,10 +94,10 @@ class VoiceAssistant : public Component {
   uint32_t get_feature_flags() const {
     uint32_t flags = 0;
     flags |= VoiceAssistantFeature::FEATURE_VOICE_ASSISTANT;
+    flags |= VoiceAssistantFeature::FEATURE_API_AUDIO;
 #ifdef USE_SPEAKER
     if (this->speaker_ != nullptr) {
       flags |= VoiceAssistantFeature::FEATURE_SPEAKER;
-      flags |= VoiceAssistantFeature::FEATURE_API_AUDIO;
     }
 #endif
     return flags;


### PR DESCRIPTION
# What does this implement/fix?
In the current implementation of voice_assistant both flags FEATURE_API_AUDIO and FEATURE_SPEAKER are only set if the speaker component is used to play TTS responses. It is desirable to use the API for sending mic data to HA also when the media_player is used for TTS responses.  
On the HA side, the TTS is only send via API if the FEATURE_SPEAKER is set, so from my understanding it is desirable to always set the FEATURE_API_AUDIO flag.

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
