### PR TITLE
Add new Error type to skip prepending path

### DIFF
--- a/esphome/config.py
+++ b/esphome/config.py
@@ -148,6 +148,8 @@ class Config(OrderedDict, fv.FinalValidateConfig):
         path = path or []
         try:
             yield
+        except cv.FinalExternalInvalid as e:
+            self.add_error(e)
         except vol.Invalid as e:
             e.prepend(path)
             self.add_error(e)

--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -267,6 +267,10 @@ class Required(vol.Required):
         super().__init__(key, msg=msg)
 
 
+class FinalExternalInvalid(Invalid):
+    """Represents an invalid value in the final validation phase where the path should not be prepended."""
+
+
 def check_not_templatable(value):
     if isinstance(value, Lambda):
         raise Invalid("This option is not templatable!")


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

When using FINAL_VALIDATE_SCHEMA, sometimes we may want to error to be raised on a config entry outside of the current one. This change allows for that.

Implemented in #6445.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
