### PR TITLE
Setting speaker states explicitly

### DIFF
--- a/esphome/components/i2s_audio/speaker/i2s_audio_speaker.cpp
+++ b/esphome/components/i2s_audio/speaker/i2s_audio_speaker.cpp
@@ -24,7 +24,7 @@ void I2SAudioSpeaker::setup() {
 
 void I2SAudioSpeaker::start() {
   if (this->task_created_) {
-    ESP_LOGD(TAG, "Called start while task has been already created.");
+    ESP_LOGW(TAG, "Called start while task has been already created.");
     return;
   }
   this->state_ = speaker::STATE_STARTING;

--- a/esphome/components/i2s_audio/speaker/i2s_audio_speaker.cpp
+++ b/esphome/components/i2s_audio/speaker/i2s_audio_speaker.cpp
@@ -207,8 +207,6 @@ void I2SAudioSpeaker::loop() {
       this->start_();
       break;
     case speaker::STATE_STARTING:
-      this->watch_();
-      break;
     case speaker::STATE_RUNNING:
     case speaker::STATE_STOPPING:
       this->watch_();

--- a/esphome/components/i2s_audio/speaker/i2s_audio_speaker.cpp
+++ b/esphome/components/i2s_audio/speaker/i2s_audio_speaker.cpp
@@ -23,7 +23,10 @@ void I2SAudioSpeaker::setup() {
 }
 
 void I2SAudioSpeaker::start() {
-  this->task_created_ = false;
+  if (this->task_created_) {
+    ESP_LOGD(TAG, "Called start while task has been already created.");
+    return;
+  }
   this->state_ = speaker::STATE_STARTING;
 }
 void I2SAudioSpeaker::start_() {

--- a/esphome/components/i2s_audio/speaker/i2s_audio_speaker.cpp
+++ b/esphome/components/i2s_audio/speaker/i2s_audio_speaker.cpp
@@ -218,7 +218,7 @@ void I2SAudioSpeaker::loop() {
 
 size_t I2SAudioSpeaker::play(const uint8_t *data, size_t length) {
   if (this->state_ != speaker::STATE_RUNNING && this->state_ != speaker::STATE_STARTING) {
-    esph_log_d(TAG, "Called play while speaker not running.");
+    ESP_LOGD(TAG, "Called play while speaker not running.");
     return 0;
   }
   size_t remaining = length;

--- a/esphome/components/i2s_audio/speaker/i2s_audio_speaker.h
+++ b/esphome/components/i2s_audio/speaker/i2s_audio_speaker.h
@@ -53,6 +53,7 @@ class I2SAudioSpeaker : public Component, public speaker::Speaker, public I2SAud
 
   void start() override;
   void stop() override;
+  void finish() override;
 
   size_t play(const uint8_t *data, size_t length) override;
 

--- a/esphome/components/i2s_audio/speaker/i2s_audio_speaker.h
+++ b/esphome/components/i2s_audio/speaker/i2s_audio_speaker.h
@@ -71,6 +71,7 @@ class I2SAudioSpeaker : public Component, public speaker::Speaker, public I2SAud
   QueueHandle_t event_queue_;
 
   uint8_t dout_pin_{0};
+  bool task_created_{false};
 
 #if SOC_I2S_SUPPORTS_DAC
   i2s_dac_mode_t internal_dac_mode_{I2S_DAC_CHANNEL_DISABLE};

--- a/esphome/components/rtttl/rtttl.cpp
+++ b/esphome/components/rtttl/rtttl.cpp
@@ -98,6 +98,7 @@ void Rtttl::play(std::string rtttl) {
   this->note_duration_ = 1;
 
 #ifdef USE_SPEAKER
+  this->speaker_->start();
   this->samples_sent_ = 0;
   this->samples_count_ = 0;
 #endif
@@ -125,6 +126,9 @@ void Rtttl::loop() {
 
 #ifdef USE_SPEAKER
   if (this->speaker_ != nullptr) {
+    if (!this->speaker_->is_running()) {
+      return;
+    }
     if (this->samples_sent_ != this->samples_count_) {
       SpeakerSample sample[SAMPLE_BUFFER_SIZE + 1];
       int x = 0;
@@ -174,6 +178,9 @@ void Rtttl::loop() {
     }
 #endif
     ESP_LOGD(TAG, "Playback finished");
+#ifdef USE_SPEAKER
+    this->speaker_->finish();
+#endif
     this->on_finished_playback_callback_.call();
     return;
   }

--- a/esphome/components/speaker/speaker.h
+++ b/esphome/components/speaker/speaker.h
@@ -5,6 +5,7 @@ namespace speaker {
 
 enum State : uint8_t {
   STATE_STOPPED = 0,
+  STATE_WAITING_FOR_LOCK,
   STATE_STARTING,
   STATE_RUNNING,
   STATE_STOPPING,
@@ -14,6 +15,7 @@ class Speaker {
  public:
   virtual size_t play(const uint8_t *data, size_t length) = 0;
   size_t play(const std::vector<uint8_t> &data) { return this->play(data.data(), data.size()); }
+  virtual void finish() {}
 
   virtual void start() = 0;
   virtual void stop() = 0;
@@ -21,6 +23,7 @@ class Speaker {
   virtual bool has_buffered_data() const = 0;
 
   bool is_running() const { return this->state_ == STATE_RUNNING; }
+  bool has_stopped() const { return this->state_ == STATE_STOPPED; }
 
  protected:
   State state_{STATE_STOPPED};

--- a/esphome/components/speaker/speaker.h
+++ b/esphome/components/speaker/speaker.h
@@ -23,7 +23,7 @@ class Speaker {
   virtual bool has_buffered_data() const = 0;
 
   bool is_running() const { return this->state_ == STATE_RUNNING; }
-  bool has_stopped() const { return this->state_ == STATE_STOPPED; }
+  bool is_stopped() const { return this->state_ == STATE_STOPPED; }
 
  protected:
   State state_{STATE_STOPPED};

--- a/esphome/components/speaker/speaker.h
+++ b/esphome/components/speaker/speaker.h
@@ -5,7 +5,6 @@ namespace speaker {
 
 enum State : uint8_t {
   STATE_STOPPED = 0,
-  STATE_WAITING_FOR_LOCK,
   STATE_STARTING,
   STATE_RUNNING,
   STATE_STOPPING,

--- a/esphome/components/voice_assistant/voice_assistant.cpp
+++ b/esphome/components/voice_assistant/voice_assistant.cpp
@@ -340,7 +340,7 @@ void VoiceAssistant::loop() {
           break;
         } else if (this->speaker_->is_running()) {
           this->speaker_->finish();
-        } else if (this->speaker_->has_stopped()) {
+        } else if (this->speaker_->is_stopped()) {
           ESP_LOGD(TAG, "Speaker has finished outputting all audio");
           this->cancel_timeout("speaker-timeout");
           this->cancel_timeout("playing");

--- a/esphome/components/voice_assistant/voice_assistant.cpp
+++ b/esphome/components/voice_assistant/voice_assistant.cpp
@@ -288,6 +288,9 @@ void VoiceAssistant::loop() {
 #ifdef USE_SPEAKER
       if (this->speaker_ != nullptr) {
         ssize_t received_len = 0;
+        if (!this->speaker_->is_running()) {
+          break;
+        }
         if (this->audio_mode_ == AUDIO_MODE_UDP) {
           if (this->speaker_buffer_index_ + RECEIVE_SIZE < SPEAKER_BUFFER_SIZE) {
             received_len = this->socket_->read(this->speaker_buffer_ + this->speaker_buffer_index_, RECEIVE_SIZE);
@@ -335,22 +338,23 @@ void VoiceAssistant::loop() {
         if (this->speaker_buffer_size_ > 0) {
           this->write_speaker_();
           break;
-        }
-        if (this->speaker_->has_buffered_data() || this->speaker_->is_running()) {
-          break;
-        }
-        ESP_LOGD(TAG, "Speaker has finished outputting all audio");
-        this->speaker_->stop();
-        this->cancel_timeout("speaker-timeout");
-        this->cancel_timeout("playing");
-        this->speaker_buffer_size_ = 0;
-        this->speaker_buffer_index_ = 0;
-        this->speaker_bytes_received_ = 0;
-        memset(this->speaker_buffer_, 0, SPEAKER_BUFFER_SIZE);
-        this->wait_for_stream_end_ = false;
-        this->stream_ended_ = false;
+        } else if (this->speaker_->is_running()) {
+          this->speaker_->finish();
+        } else if (this->speaker_->has_stopped()) {
+          ESP_LOGD(TAG, "Speaker has finished outputting all audio");
+          this->cancel_timeout("speaker-timeout");
+          this->cancel_timeout("playing");
+          this->speaker_buffer_size_ = 0;
+          this->speaker_buffer_index_ = 0;
+          this->speaker_bytes_received_ = 0;
+          memset(this->speaker_buffer_, 0, SPEAKER_BUFFER_SIZE);
+          this->wait_for_stream_end_ = false;
+          this->stream_ended_ = false;
 
-        this->tts_stream_end_trigger_->trigger();
+          this->tts_stream_end_trigger_->trigger();
+          this->set_state_(State::IDLE, State::IDLE);
+        }
+        break;
       }
 #endif
       this->set_state_(State::IDLE, State::IDLE);
@@ -363,8 +367,12 @@ void VoiceAssistant::loop() {
 
 #ifdef USE_SPEAKER
 void VoiceAssistant::write_speaker_() {
+  if (!this->speaker_->is_running()) {
+    return;
+  }
   if (this->speaker_buffer_size_ > 0) {
-    size_t written = this->speaker_->play(this->speaker_buffer_, this->speaker_buffer_size_);
+    size_t write_chunk = std::min<size_t>(this->speaker_buffer_size_, 4 * 1024);
+    size_t written = this->speaker_->play(this->speaker_buffer_, write_chunk);
     if (written > 0) {
       memmove(this->speaker_buffer_, this->speaker_buffer_ + written, this->speaker_buffer_size_ - written);
       this->speaker_buffer_size_ -= written;


### PR DESCRIPTION
# What does this implement/fix?

Solves timing issues introduced with sending TTS responses via API to speaker.

* set the speaker state to running only after receiving the started event.
* doesn't stop speaker task on no data timeout, creates warning instead
* finish() or stop() needs to be called explicitly to stop the speaker task.
* finish() is introduced, it stops the task as soon as the audio queue is empty
* VA writes only data to speaker if it is in running state
* VA: set maximum chunk size of writing to speaker to 4 * 1024 (prevents blocking the loop for too long)

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
