### PR TITLE
time_based_cover.cpp with manual control fix

### DIFF
--- a/esphome/components/time_based/time_based_cover.cpp
+++ b/esphome/components/time_based/time_based_cover.cpp
@@ -96,6 +96,9 @@ void TimeBasedCover::control(const CoverCall &call) {
       }
     } else {
       auto op = pos < this->position ? COVER_OPERATION_CLOSING : COVER_OPERATION_OPENING;
+      if (this->manual_control_ && (pos == COVER_OPEN || pos == COVER_CLOSED)) {
+        this->position = pos == COVER_CLOSED ? COVER_OPEN : COVER_CLOSED;
+      }
       this->target_position_ = pos;
       this->start_direction_(op);
     }


### PR DESCRIPTION
# What does this implement/fix?

When we launch an open or close with the current status in a middle point and the manual control is enabled, ESPHome assumes the current status is correct, but this is not sure when we have manual control. The best way to have it working always is to assume that the current state is the opposite to the desired state, so the operation will be always completed.

**WHEN** 
manual_control for time based cover is enabled 
AND 
set to fully open or fully close
AND 
current status is not fully open or close

**THEN** 
current status is the opposite to the desired status, so execute full cycle.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other


## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx


## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
