### PR TITLE
fix(ltr390): stuck ALS values when configured for ALS+UV readings

### DIFF
--- a/esphome/components/ltr390/ltr390.cpp
+++ b/esphome/components/ltr390/ltr390.cpp
@@ -104,7 +104,7 @@ void LTR390Component::read_mode_(int mode_index) {
 
   std::bitset<8> ctrl = this->reg(LTR390_MAIN_CTRL).get();
   ctrl[LTR390_CTRL_MODE] = mode;
-  ctrl[LTR390_CTRL_EN] = 1;
+  ctrl[LTR390_CTRL_EN] = true;
   this->reg(LTR390_MAIN_CTRL) = ctrl.to_ulong();
 
   // After the sensor integration time do the following
@@ -120,7 +120,7 @@ void LTR390Component::read_mode_(int mode_index) {
                       } else {
                         // put sensor in standby
                         std::bitset<8> ctrl = this->reg(LTR390_MAIN_CTRL).get();
-                        ctrl[LTR390_CTRL_EN] = 0;
+                        ctrl[LTR390_CTRL_EN] = false;
                         this->reg(LTR390_MAIN_CTRL) = ctrl.to_ulong();
                         this->reading_ = false;
                       }

--- a/esphome/components/ltr390/ltr390.cpp
+++ b/esphome/components/ltr390/ltr390.cpp
@@ -8,6 +8,9 @@ namespace ltr390 {
 
 static const char *const TAG = "ltr390";
 
+static const uint8_t LTR390_WAKEUP_TIME = 10;
+static const uint8_t LTR390_SETTLE_TIME = 5;
+
 static const uint8_t LTR390_MAIN_CTRL = 0x00;
 static const uint8_t LTR390_MEAS_RATE = 0x04;
 static const uint8_t LTR390_GAIN = 0x05;
@@ -101,21 +104,27 @@ void LTR390Component::read_mode_(int mode_index) {
 
   std::bitset<8> ctrl = this->reg(LTR390_MAIN_CTRL).get();
   ctrl[LTR390_CTRL_MODE] = mode;
+  ctrl[LTR390_CTRL_EN] = 1;
   this->reg(LTR390_MAIN_CTRL) = ctrl.to_ulong();
 
   // After the sensor integration time do the following
-  this->set_timeout(((uint32_t) RESOLUTIONVALUE[this->res_]) * 100, [this, mode_index]() {
-    // Read from the sensor
-    std::get<1>(this->mode_funcs_[mode_index])();
+  this->set_timeout(((uint32_t) RESOLUTIONVALUE[this->res_]) * 100 + LTR390_WAKEUP_TIME + LTR390_SETTLE_TIME,
+                    [this, mode_index]() {
+                      // Read from the sensor
+                      std::get<1>(this->mode_funcs_[mode_index])();
 
-    // If there are more modes to read then begin the next
-    // otherwise stop
-    if (mode_index + 1 < (int) this->mode_funcs_.size()) {
-      this->read_mode_(mode_index + 1);
-    } else {
-      this->reading_ = false;
-    }
-  });
+                      // If there are more modes to read then begin the next
+                      // otherwise stop
+                      if (mode_index + 1 < (int) this->mode_funcs_.size()) {
+                        this->read_mode_(mode_index + 1);
+                      } else {
+                        // put sensor in standby
+                        std::bitset<8> ctrl = this->reg(LTR390_MAIN_CTRL).get();
+                        ctrl[LTR390_CTRL_EN] = 0;
+                        this->reg(LTR390_MAIN_CTRL) = ctrl.to_ulong();
+                        this->reading_ = false;
+                      }
+                    });
 }
 
 void LTR390Component::setup() {


### PR DESCRIPTION
# What does this implement/fix?

I have been experiencing stuck values for ALS readings when the sensor was configured to provide ALS & UV readings. By stuck values, I mean that only the first sample of ALS readings is taken and subsequent values are always exactly the same as the first while UV readings were changing as expected.

(ALS at the top, UV at the bottom)
<img width="1393" alt="image" src="https://github.com/esphome/esphome/assets/17021300/b3e366a1-17e5-4bf8-bc2e-5066d66970d4">

If the sensor is configured for ALS only, the problem isn't there. So the issue isn't the sensor itself but how we interact with it.

I have made multiple experiments but it's still not exactly clear why the sensor behaves likes it does. The datasheet does mention a few interesting facts.

<img width="768" alt="image" src="https://github.com/esphome/esphome/assets/17021300/8267aecc-942f-4b49-8fb1-4086b9c79b4b">
<img width="800" alt="image" src="https://github.com/esphome/esphome/assets/17021300/9924edc4-433a-417a-a4d2-fe3a53cd48db">
<img width="436" alt="image" src="https://github.com/esphome/esphome/assets/17021300/d6970256-4208-4aba-b95e-4ceab9122377">
<img width="772" alt="image" src="https://github.com/esphome/esphome/assets/17021300/3a841935-43ae-4022-9c2d-fd7f51a6b8be">

The datasheet is very vague. But my theory is the following:

1. The device is configured
2. The `update` method is triggered, setting the FSM to ALS mode
3. Device is configured for ALS mode, we get ALS measurement n°1
4. The FSM state is set to UV mode
5. The device is configured for UV mode, we get UV measurement n°1
6. we wait `update_interval`
7. `update` method is triggered again, setting FSM to ALS mode
8. Device is configured for ALS mode, we get the same values as measurement n°1
9. The FSM state is set to UV mode
10. The device is configured for UV mode, we get UV measurement n°2

The "error" would be somewhere between step 5 and 8. After step 5, the device is still in measurement mode and would produce an UV measurement that we won't read before changing the mode to ALS. 
The device only clears the `UVS/ALS Data Status` after a read.

So we're actively reading `MAIN_STATUS`, possibly preventing the sensor from updating the stored measurement. Then we're possibly assuming that the 'UVS/ALS Data Status' is reset after changing measurement modes. 

To boil it down:
- An UV measurement is ready, that we do not read
- We change measurement mode and the data available bit is still set from the UV reading
- We interpret this data ready bit as valid data for ALS measurements (while it's still in progress)
- Directly after reading ALS data, we change measurement mode to UV, cancelling the in-progress ALS measurement

I am not sure this is exactly what happens but I have experimented with a few fixes and the most elegant one is pretty obvious: when we're done with measurements, just put the sensor in standby.

This is done by setting `LTR390_CTRL_EN` to 0. When we want to take new measurements, we set it to `1` in addition to the measurement mode. I have added two extra delays: one for wakeup and one for the ADC settle time (taken from the datasheet)
<img width="772" alt="image" src="https://github.com/esphome/esphome/assets/17021300/d2040c10-443d-4ccb-be2a-5503cf6d827a">

In addition to fixing stuck values for ALS, the sensor is only pulling 1uA (in standby) compared to 100-110uA.

Data after the fix
<img width="1506" alt="image" src="https://github.com/esphome/esphome/assets/17021300/ef9e1e6e-949b-4bab-b7df-a17d3e3507b1">


## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
```yaml
- platform: ltr390
    i2c_id: bus_a
    update_interval: 5s
    uv_index:
      name: "UV Index"
    light:
      name: "Light"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
