### PR TITLE
[hlw8012]: new counter impl

### DIFF
--- a/esphome/components/hlw8012/hlw8012.h
+++ b/esphome/components/hlw8012/hlw8012.h
@@ -3,7 +3,6 @@
 #include "esphome/core/component.h"
 #include "esphome/core/hal.h"
 #include "esphome/components/sensor/sensor.h"
-#include "esphome/components/pulse_counter/pulse_counter_sensor.h"
 
 #include <cinttypes>
 
@@ -18,16 +17,9 @@ enum HLW8012SensorModels {
   HLW8012_SENSOR_MODEL_BL0937
 };
 
-#ifdef HAS_PCNT
-#define USE_PCNT true
-#else
-#define USE_PCNT false
-#endif
-
 class HLW8012Component : public PollingComponent {
  public:
-  HLW8012Component()
-      : cf_store_(*pulse_counter::get_storage(USE_PCNT)), cf1_store_(*pulse_counter::get_storage(USE_PCNT)) {}
+  HLW8012Component() {}
 
   void setup() override;
   void dump_config() override;
@@ -49,6 +41,9 @@ class HLW8012Component : public PollingComponent {
   void set_power_sensor(sensor::Sensor *power_sensor) { power_sensor_ = power_sensor; }
   void set_energy_sensor(sensor::Sensor *energy_sensor) { energy_sensor_ = energy_sensor; }
 
+  static void cf_intr(HLW8012Component *arg);
+  static void cf1_intr(HLW8012Component *arg);
+
  protected:
   uint32_t nth_value_{0};
   bool current_mode_{false};
@@ -60,9 +55,13 @@ class HLW8012Component : public PollingComponent {
   uint64_t cf_total_pulses_{0};
   GPIOPin *sel_pin_;
   InternalGPIOPin *cf_pin_;
-  pulse_counter::PulseCounterStorageBase &cf_store_;
+  uint32_t cf_first_pulse_micros_{0};
+  uint32_t cf_last_pulse_micros_{0};
+  uint32_t cf_pulses_{0};
   InternalGPIOPin *cf1_pin_;
-  pulse_counter::PulseCounterStorageBase &cf1_store_;
+  uint32_t cf1_first_pulse_micros_{0};
+  uint32_t cf1_last_pulse_micros_{0};
+  uint32_t cf1_pulses_{0};
   sensor::Sensor *voltage_sensor_{nullptr};
   sensor::Sensor *current_sensor_{nullptr};
   sensor::Sensor *power_sensor_{nullptr};

--- a/esphome/components/hlw8012/sensor.py
+++ b/esphome/components/hlw8012/sensor.py
@@ -26,8 +26,6 @@ from esphome.const import (
     UNIT_WATT_HOURS,
 )
 
-AUTO_LOAD = ["pulse_counter"]
-
 hlw8012_ns = cg.esphome_ns.namespace("hlw8012")
 HLW8012Component = hlw8012_ns.class_("HLW8012Component", cg.PollingComponent)
 HLW8012InitialMode = hlw8012_ns.enum("HLW8012InitialMode")


### PR DESCRIPTION
# What does this implement/fix?
Replace the pulse counter with a specialized implementation.
The old implementation had worse resolution with low loads and fast update intervals.
Additionally, jitter in the update interval, caused by other components doesn't cause measurement errors anymore.
The new implementation reduces flash usage as long as the pulse counter isn't used somewhere else.
## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** -

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** -

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
Tested with a BL0937

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
sensor:
  - platform: hlw8012
    model: BL0937
    sel_pin: GPIO12
    cf_pin: GPIO04
    cf1_pin: GPIO05
    change_mode_every: 4
    current_resistor: 0.001
    voltage_divider: 1700
    update_interval: 3s

    current:
      name: "Test - Ampere"
      unit_of_measurement: A
      accuracy_decimals: 3
      icon: mdi:current-ac

    voltage:
      name: "Test - Volt"
      unit_of_measurement: V
      accuracy_decimals: 1
      icon: mdi:flash-outline

    power:
      name: "Test - Watt"
      unit_of_measurement: W
      id: "power_wattage"
      icon: mdi:gauge

    energy:
      name: "Test - Energy"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
