### PR TITLE
2024.5.0b4

### DIFF
--- a/esphome/components/voice_assistant/voice_assistant.h
+++ b/esphome/components/voice_assistant/voice_assistant.h
@@ -94,10 +94,10 @@ class VoiceAssistant : public Component {
   uint32_t get_feature_flags() const {
     uint32_t flags = 0;
     flags |= VoiceAssistantFeature::FEATURE_VOICE_ASSISTANT;
+    flags |= VoiceAssistantFeature::FEATURE_API_AUDIO;
 #ifdef USE_SPEAKER
     if (this->speaker_ != nullptr) {
       flags |= VoiceAssistantFeature::FEATURE_SPEAKER;
-      flags |= VoiceAssistantFeature::FEATURE_API_AUDIO;
     }
 #endif
     return flags;

--- a/esphome/const.py
+++ b/esphome/const.py
@@ -1,6 +1,6 @@
 """Constants used by esphome."""
 
-__version__ = "2024.5.0b3"
+__version__ = "2024.5.0b4"
 
 ALLOWED_NAME_CHARS = "abcdefghijklmnopqrstuvwxyz0123456789-_"
 VALID_SUBSTITUTIONS_CHARACTERS = (

--- a/esphome/core/config.py
+++ b/esphome/core/config.py
@@ -394,7 +394,7 @@ async def to_code(config):
     if project_conf := config.get(CONF_PROJECT):
         cg.add_define("ESPHOME_PROJECT_NAME", project_conf[CONF_NAME])
         cg.add_define("ESPHOME_PROJECT_VERSION", project_conf[CONF_VERSION])
-        cg.add_define("ESPHOME_PROJECT_VERSION_30", project_conf[CONF_VERSION][:30])
+        cg.add_define("ESPHOME_PROJECT_VERSION_30", project_conf[CONF_VERSION][:29])
         for conf in project_conf.get(CONF_ON_UPDATE, []):
             trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID])
             await cg.register_component(trigger, conf)

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ tornado==6.4
 tzlocal==5.2    # from time
 tzdata>=2021.1  # from time
 pyserial==3.5
-platformio==6.1.13  # When updating platformio, also update Dockerfile
+platformio==6.1.15  # When updating platformio, also update Dockerfile
 esptool==4.7.0
 click==8.1.7
 esphome-dashboard==20240412.0


### PR DESCRIPTION
**Do not merge, release script will automatically merge**
## Full list of changes

### All changes

- fix(ltr390): stuck ALS values when configured for ALS+UV readings [esphome#6723](https://github.com/esphome/esphome/pull/6723)
- Set FEATURE_API_AUDIO flag also if the speaker component is not used [esphome#6712](https://github.com/esphome/esphome/pull/6712)
- Bump platformio from 6.1.13 to 6.1.15 [esphome#6634](https://github.com/esphome/esphome/pull/6634)
- Fix ESPHOME_PROJECT_VERSION_30 [esphome#6731](https://github.com/esphome/esphome/pull/6731)
