### PR TITLE
Allow one timing to cancel others

### DIFF
--- a/esphome/components/binary_sensor/automation.cpp
+++ b/esphome/components/binary_sensor/automation.cpp
@@ -98,6 +98,11 @@ void binary_sensor::MultiClickTrigger::schedule_is_not_valid_(uint32_t max_lengt
     this->schedule_cooldown_();
   });
 }
+void binary_sensor::MultiClickTrigger::cancel() {
+  ESP_LOGV(TAG, "Multi Click: Sequence explicitly cancelled.");
+  this->is_valid_ = false;
+  this->schedule_cooldown_();
+}
 void binary_sensor::MultiClickTrigger::trigger_() {
   ESP_LOGV(TAG, "Multi Click: Hooray, multi click is valid. Triggering!");
   this->at_index_.reset();

--- a/esphome/components/binary_sensor/automation.h
+++ b/esphome/components/binary_sensor/automation.h
@@ -105,6 +105,8 @@ class MultiClickTrigger : public Trigger<>, public Component {
 
   void set_invalid_cooldown(uint32_t invalid_cooldown) { this->invalid_cooldown_ = invalid_cooldown; }
 
+  void cancel();
+
  protected:
   void on_state_(bool state);
   void schedule_cooldown_();


### PR DESCRIPTION

# What does this implement/fix?

See [feature request #985](https://github.com/esphome/feature-requests/issues/985)

Adds a method `cancel´ to `MultiClickTrigger` so that one trigger can conditionally cancel others when it fires.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** (partially) fixes https://github.com/esphome/feature-requests/issues/985

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# ...
binary_sensor:
  - platform: gpio
    name: Momentary Switch
    id: sensor_momentary_switch
    pin:
      number: GPIO14
      mode: INPUT
    internal: false
    on_multi_click:
      # Single click, light is on -> wait to make sure it's not a long press / double click, then turn off
      - timing:
          - ON for 50ms to 300ms
          - OFF for at least 500ms
        trigger_id: sensor_momentary_switch_multi_click_trigger_short_press_when_off
        then:
          - if:
              condition:
                - light.is_on: dimmer
              then:
                - light.turn_off: dimmer
      # Single click, light is off -> turn on immediately, don't wait for long press / double click
      - timing:
          - ON for 50ms to 300ms
        then:
          - if:
              condition:
                - light.is_off: dimmer
              then:
                - lambda: |-
                    id(sensor_momentary_switch_multi_click_trigger_short_press_when_off).cancel();
                - light.turn_on:
                    id: dimmer
                    brightness: !lambda |-
                      return id(dimmer).remote_values.get_brightness();
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
    I did not find any tests for the multi-click trigger. As I'm new to the codebase, I am not sure how I would go about testing this.
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
    Please give me an indication if this PR is likely to be merged, then I will write some docs.