### PR TITLE
[ili9xxx] Add 18bit mode selection and custom init sequence

### DIFF
--- a/esphome/components/ili9xxx/ili9xxx_display.h
+++ b/esphome/components/ili9xxx/ili9xxx_display.h
@@ -17,6 +17,12 @@ enum ILI9XXXColorMode {
   BITS_16 = 0x10,
 };
 
+enum PixelMode {
+  PIXEL_MODE_UNSPECIFIED,
+  PIXEL_MODE_16,
+  PIXEL_MODE_18,
+};
+
 class ILI9XXXDisplay : public display::DisplayBuffer,
                        public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARITY_LOW,
                                              spi::CLOCK_PHASE_LEADING, spi::DATA_RATE_40MHZ> {
@@ -52,6 +58,7 @@ class ILI9XXXDisplay : public display::DisplayBuffer,
     }
   }
 
+  void add_init_sequence(const std::vector<uint8_t> &sequence) { this->extra_init_sequence_ = sequence; }
   void set_dc_pin(GPIOPin *dc_pin) { dc_pin_ = dc_pin; }
   float get_setup_priority() const override;
   void set_reset_pin(GPIOPin *reset) { this->reset_pin_ = reset; }
@@ -73,6 +80,7 @@ class ILI9XXXDisplay : public display::DisplayBuffer,
   void set_swap_xy(bool swap_xy) { this->swap_xy_ = swap_xy; }
   void set_mirror_x(bool mirror_x) { this->mirror_x_ = mirror_x; }
   void set_mirror_y(bool mirror_y) { this->mirror_y_ = mirror_y; }
+  void set_pixel_mode(PixelMode mode) { this->pixel_mode_ = mode; }
 
   void update() override;
 
@@ -99,11 +107,12 @@ class ILI9XXXDisplay : public display::DisplayBuffer,
 
   virtual void set_madctl();
   void display_();
-  void init_lcd_();
+  void init_lcd_(const uint8_t *);
   void set_addr_window_(uint16_t x, uint16_t y, uint16_t x2, uint16_t y2);
   void reset_();
 
   uint8_t const *init_sequence_{};
+  std::vector<uint8_t> extra_init_sequence_;
   int16_t width_{0};   ///< Display width as modified by current rotation
   int16_t height_{0};  ///< Display height as modified by current rotation
   int16_t offset_x_{0};
@@ -112,7 +121,7 @@ class ILI9XXXDisplay : public display::DisplayBuffer,
   uint16_t y_low_{0};
   uint16_t x_high_{0};
   uint16_t y_high_{0};
-  const uint8_t *palette_;
+  const uint8_t *palette_{};
 
   ILI9XXXColorMode buffer_color_mode_{BITS_16};
 
@@ -133,6 +142,7 @@ class ILI9XXXDisplay : public display::DisplayBuffer,
   bool prossing_update_ = false;
   bool need_update_ = false;
   bool is_18bitdisplay_ = false;
+  PixelMode pixel_mode_{};
   bool pre_invertcolors_ = false;
   display::ColorOrder color_order_{display::COLOR_ORDER_BGR};
   bool swap_xy_{};

--- a/esphome/components/ili9xxx/ili9xxx_display.h
+++ b/esphome/components/ili9xxx/ili9xxx_display.h
@@ -107,7 +107,7 @@ class ILI9XXXDisplay : public display::DisplayBuffer,
 
   virtual void set_madctl();
   void display_();
-  void init_lcd_(const uint8_t *);
+  void init_lcd_(const uint8_t *addr);
   void set_addr_window_(uint16_t x, uint16_t y, uint16_t x2, uint16_t y2);
   void reset_();
 

--- a/esphome/components/ili9xxx/ili9xxx_init.h
+++ b/esphome/components/ili9xxx/ili9xxx_init.h
@@ -157,7 +157,7 @@ static const uint8_t INITCMD_ILI9488[] = {
   0xE9, 1, 0x00,   // Set Image Functio. Disable 24 bit data
 
   ILI9XXX_ADJCTL3, 4, 0xA9, 0x51, 0x2C, 0x82,  // Adjust Control 3
-  ILI9XXX_PIXFMT, 1, 0x55,   //ILI9488 only supports 18-bit pixel format in 4/3 wire SPI mode
+  ILI9XXX_PIXFMT, 1, 0x66,   //ILI9488 only supports 18-bit pixel format in 4/3 wire SPI mode
   ILI9XXX_SLPOUT,  0x80,    // Exit sleep mode
   ILI9XXX_DISPON,  0x80,    // Set display on
   0x00 // end
@@ -194,8 +194,8 @@ static const uint8_t PROGMEM INITCMD_ILI9488_A[] = {
   ILI9XXX_ADJCTL3, 4, 0xA9, 0x51, 0x2C, 0x82,  // Adjust Control 3
 
   ILI9XXX_MADCTL,  1, 0x28,
-  ILI9XXX_PIXFMT,  1, 0x55,  // Interface Pixel Format = 16bit
-  //ILI9XXX_PIXFMT, 1, 0x66,   //ILI9488 only supports 18-bit pixel format in 4/3 wire SPI mode
+  //ILI9XXX_PIXFMT,  1, 0x55,  // Interface Pixel Format = 16bit
+  ILI9XXX_PIXFMT, 1, 0x66,   //ILI9488 only supports 18-bit pixel format in 4/3 wire SPI mode
 
 
 

--- a/esphome/components/ili9xxx/ili9xxx_init.h
+++ b/esphome/components/ili9xxx/ili9xxx_init.h
@@ -157,7 +157,7 @@ static const uint8_t INITCMD_ILI9488[] = {
   0xE9, 1, 0x00,   // Set Image Functio. Disable 24 bit data
 
   ILI9XXX_ADJCTL3, 4, 0xA9, 0x51, 0x2C, 0x82,  // Adjust Control 3
-  ILI9XXX_PIXFMT, 1, 0x66,   //ILI9488 only supports 18-bit pixel format in 4/3 wire SPI mode
+  ILI9XXX_PIXFMT, 1, 0x55,   //ILI9488 only supports 18-bit pixel format in 4/3 wire SPI mode
   ILI9XXX_SLPOUT,  0x80,    // Exit sleep mode
   ILI9XXX_DISPON,  0x80,    // Set display on
   0x00 // end
@@ -194,8 +194,8 @@ static const uint8_t PROGMEM INITCMD_ILI9488_A[] = {
   ILI9XXX_ADJCTL3, 4, 0xA9, 0x51, 0x2C, 0x82,  // Adjust Control 3
 
   ILI9XXX_MADCTL,  1, 0x28,
-  //ILI9XXX_PIXFMT,  1, 0x55,  // Interface Pixel Format = 16bit
-  ILI9XXX_PIXFMT, 1, 0x66,   //ILI9488 only supports 18-bit pixel format in 4/3 wire SPI mode
+  ILI9XXX_PIXFMT,  1, 0x55,  // Interface Pixel Format = 16bit
+  //ILI9XXX_PIXFMT, 1, 0x66,   //ILI9488 only supports 18-bit pixel format in 4/3 wire SPI mode
 
 
 

--- a/tests/components/ili9xxx/test.esp32-idf.yaml
+++ b/tests/components/ili9xxx/test.esp32-idf.yaml
@@ -12,24 +12,12 @@ display:
       swap_xy: true
       mirror_x: true
       mirror_y: false
-    model: TFT 2.4
-    color_palette: GRAYSCALE
+    model: custom
     cs_pin: 12
     dc_pin: 13
     reset_pin: 14
+    init_sequence:
+      - [0xFF, 0x77, 0x01, 0x00, 0x00, 0x10]
+
     lambda: |-
       it.rectangle(0, 0, it.get_width(), it.get_height());
-  - platform: ili9xxx
-    dimensions:
-      width: 320
-      height: 240
-      offset_width: 20
-      offset_height: 10
-    model: TFT 2.4
-    cs_pin: 25
-    dc_pin: 26
-    reset_pin: 27
-    auto_clear_enabled: false
-    rotation: 90
-    lambda: |-
-      it.fill(Color::WHITE);


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Add new options to the ili9xxx component.

* `pixel_mode` option to choose between 16 and 18 bit mode
* `init_sequence` option to specify custom inititialisation sequences
* Add CUSTOM model to allow supporting new displays without code changes, using `init_sequence`.
* Fix 18 bit mode drawing in `draw_pixels_at()`

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#3836

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->
```yaml

display:
  - platform: ili9xxx
    data_rate: 40MHz
    model: ili9481
    init_sequence:
      - [ 0xD0, 0x07, 0x42, 0x18]
      - [ 0xD1, 0x00, 0x07, 0x10]
      - [ 0xD2, 0x01, 0x02]
      - [ 0xC0, 0x10, 0x3B, 0x00, 0x02, 0x11]
      - [ 0xC5, 0x03]
      - [ 0xC8, 0x00, 0x32, 0x36, 0x45, 0x06, 0x16, 0x37, 0x75, 0x77, 0x54, 0x0C, 0x00]

    pixel_mode: 18bit
    invert_colors: true
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
