### PR TITLE
i2c: fix format string specifiers

### DIFF
--- a/esphome/components/i2c/i2c_bus_esp_idf.cpp
+++ b/esphome/components/i2c/i2c_bus_esp_idf.cpp
@@ -56,7 +56,7 @@ void IDFI2CBus::setup() {
       this->mark_failed();
       return;
     } else {
-      ESP_LOGV(TAG, "i2c_timeout set to %d ticks (%d us)", timeout_ * 80, timeout_);
+      ESP_LOGV(TAG, "i2c_timeout set to %" PRIu32 " ticks (%" PRIu32 " us)", timeout_ * 80, timeout_);
     }
   }
   err = i2c_driver_install(port_, I2C_MODE_MASTER, 0, 0, ESP_INTR_FLAG_IRAM);


### PR DESCRIPTION
# What does this implement/fix?

Building for ESP32-C6 using `esp-idf` and `toolchain-riscv32-esp @ 12.2.0+20230208` fails:

```
In file included from src/esphome/components/sensor/sensor.h:3,
                 from src/esphome/core/application.h:16,
                 from src/esphome/components/i2c/i2c_bus_esp_idf.cpp:6:
src/esphome/components/i2c/i2c_bus_esp_idf.cpp: In member function 'virtual void esphome::i2c::IDFI2CBus::setup()':
src/esphome/components/i2c/i2c_bus_esp_idf.cpp:59:21: error: format '%d' expects argument of type 'int', but argument 5 has type 'long unsigned int' [-Werror=format=]
   59 |       ESP_LOGV(TAG, "i2c_timeout set to %d ticks (%d us)", timeout_ * 80, timeout_);
      |                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

src/esphome/components/i2c/i2c_bus_esp_idf.cpp:59:21: error: format '%d' expects argument of type 'int', but argument 6 has type 'uint32_t' {aka 'long unsigned int'} [-Werror=format=]
   59 |       ESP_LOGV(TAG, "i2c_timeout set to %d ticks (%d us)", timeout_ * 80, timeout_);
      |                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
This might be a RISC-V'ism - in any case the format string on line 50 uses the `PRIu32` macro to format `timeout_` - so let's just follow along.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** introduced in #4614

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
