### PR TITLE
[core] Fix some extends cases

### DIFF
--- a/esphome/components/substitutions/__init__.py
+++ b/esphome/components/substitutions/__init__.py
@@ -4,7 +4,7 @@ import esphome.config_validation as cv
 from esphome import core
 from esphome.const import CONF_SUBSTITUTIONS, VALID_SUBSTITUTIONS_CHARACTERS
 from esphome.yaml_util import ESPHomeDataBase, make_data_base
-from esphome.config_helpers import merge_config
+from esphome.config_helpers import merge_config, Extend, Remove
 
 CODEOWNERS = ["@esphome/core"]
 _LOGGER = logging.getLogger(__name__)
@@ -105,7 +105,7 @@ def _substitute_item(substitutions, item, path, ignore_missing):
         sub = _expand_substitutions(substitutions, item, path, ignore_missing)
         if sub != item:
             return sub
-    elif isinstance(item, core.Lambda):
+    elif isinstance(item, (core.Lambda, Extend, Remove)):
         sub = _expand_substitutions(substitutions, item.value, path, ignore_missing)
         if sub != item:
             item.value = sub

--- a/esphome/config_helpers.py
+++ b/esphome/config_helpers.py
@@ -50,14 +50,19 @@ def merge_config(full_old, full_new):
                 return new
             res = old.copy()
             ids = {
-                v[CONF_ID]: i
+                v_id: i
                 for i, v in enumerate(res)
-                if CONF_ID in v and isinstance(v[CONF_ID], str)
+                if (v_id := v.get(CONF_ID)) and isinstance(v_id, str)
             }
+            extend_ids = {
+                v_id.value: i
+                for i, v in enumerate(res)
+                if (v_id := v.get(CONF_ID)) and isinstance(v_id, Extend)
+            }
+
             ids_to_delete = []
             for v in new:
-                if CONF_ID in v:
-                    new_id = v[CONF_ID]
+                if new_id := v.get(CONF_ID):
                     if isinstance(new_id, Extend):
                         new_id = new_id.value
                         if new_id in ids:
@@ -69,6 +74,14 @@ def merge_config(full_old, full_new):
                         if new_id in ids:
                             ids_to_delete.append(ids[new_id])
                             continue
+                    elif (
+                        new_id in extend_ids
+                    ):  # When a package is extending a non-packaged item
+                        extend_res = res[extend_ids[new_id]]
+                        extend_res[CONF_ID] = new_id
+                        new_v = merge(v, extend_res)
+                        res[extend_ids[new_id]] = new_v
+                        continue
                     else:
                         ids[new_id] = len(res)
                 res.append(v)

--- a/esphome/config_helpers.py
+++ b/esphome/config_helpers.py
@@ -8,6 +8,9 @@ class Extend:
     def __str__(self):
         return f"!extend {self.value}"
 
+    def __repr__(self):
+        return f"Extend({self.value})"
+
     def __eq__(self, b):
         """
         Check if two Extend objects contain the same ID.
@@ -23,6 +26,9 @@ class Remove:
 
     def __str__(self):
         return f"!remove {self.value}"
+
+    def __repr__(self):
+        return f"Remove({self.value})"
 
     def __eq__(self, b):
         """


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

- `!extend` could not previously handle substitutions as the value because it was never checked in the substitution passes.

- Also allow the extend to exist inside the package to extend the root yaml if desired.


## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
