### PR TITLE
[adc] Fix 11db deprecation warning

### DIFF
--- a/esphome/components/adc/__init__.py
+++ b/esphome/components/adc/__init__.py
@@ -18,11 +18,23 @@ from esphome.components.esp32.const import (
 
 CODEOWNERS = ["@esphome/core"]
 
+adc_ns = cg.esphome_ns.namespace("adc")
+
+
+"""
+From the below patch versions (and 5.2+) ADC_ATTEN_DB_11 is deprecated and replaced with ADC_ATTEN_DB_12.
+4.4.7
+5.0.5
+5.1.3
+5.2+
+"""
+
 ATTENUATION_MODES = {
     "0db": cg.global_ns.ADC_ATTEN_DB_0,
     "2.5db": cg.global_ns.ADC_ATTEN_DB_2_5,
     "6db": cg.global_ns.ADC_ATTEN_DB_6,
-    "11db": cg.global_ns.ADC_ATTEN_DB_11,
+    "11db": adc_ns.ADC_ATTEN_DB_12_COMPAT,
+    "12db": adc_ns.ADC_ATTEN_DB_12_COMPAT,
     "auto": "auto",
 }
 

--- a/esphome/components/adc/adc_sensor.h
+++ b/esphome/components/adc/adc_sensor.h
@@ -1,18 +1,33 @@
 #pragma once
 
-#include "esphome/core/component.h"
-#include "esphome/core/hal.h"
-#include "esphome/core/defines.h"
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/voltage_sampler/voltage_sampler.h"
+#include "esphome/core/component.h"
+#include "esphome/core/defines.h"
+#include "esphome/core/hal.h"
 
 #ifdef USE_ESP32
-#include "driver/adc.h"
 #include <esp_adc_cal.h>
+#include "driver/adc.h"
 #endif
 
 namespace esphome {
 namespace adc {
+
+#ifdef USE_ESP32
+// clang-format off
+#if (ESP_IDF_VERSION_MAJOR == 4 && ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 4, 7)) || \
+    (ESP_IDF_VERSION_MAJOR == 5 && \
+     ((ESP_IDF_VERSION_MINOR == 0 && ESP_IDF_VERSION_PATCH >= 5) || \
+      (ESP_IDF_VERSION_MINOR == 1 && ESP_IDF_VERSION_PATCH >= 3) || \
+      (ESP_IDF_VERSION_MINOR >= 2)) \
+    )
+// clang-format on
+static const adc_atten_t ADC_ATTEN_DB_12_COMPAT = ADC_ATTEN_DB_12;
+#else
+static const adc_atten_t ADC_ATTEN_DB_12_COMPAT = ADC_ATTEN_DB_11;
+#endif
+#endif  // USE_ESP32
 
 class ADCSensor : public sensor::Sensor, public PollingComponent, public voltage_sampler::VoltageSampler {
  public:


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

From the below patch versions ADC_ATTEN_DB_11 is deprecated and replaced with ADC_ATTEN_DB_12.
- 4.4.7
- 5.0.5
- 5.1.3
- 5.2+

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/5787

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#3837

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
