### PR TITLE
[tests] ``test2.yaml`` has become too large

### DIFF
--- a/tests/test2.yaml
+++ b/tests/test2.yaml
@@ -1,9 +1,11 @@
 ---
 esphome:
   name: $devicename
-  platform: ESP32
-  board: nodemcu-32s
   build_path: build/test2
+
+esp32:
+  board: esp32dev
+  flash_size: 8MB
 
 globals:
   - id: my_global_string


### PR DESCRIPTION
# What does this implement/fix?

Quick fix for `test2.yaml` as it has become too large for the default flash size.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
