### PR TITLE
Fix wifi compile error on IDF 5.1+

### DIFF
--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -3,7 +3,11 @@
 #include <map>
 
 #ifdef USE_ESP_IDF
+#if (ESP_IDF_VERSION_MAJOR >= 5 && ESP_IDF_VERSION_MINOR >= 1)
+#include <esp_eap_client.h>
+#else
 #include <esp_wpa2.h>
+#endif
 #endif
 
 #if defined(USE_ESP32) || defined(USE_ESP_IDF)


### PR DESCRIPTION
# What does this implement/fix?

When building with IDF ≥ 5.1:

```
In file included from src/esphome/components/wifi/wifi_component.cpp:9:
~/.platformio/packages/framework-espidf@3.50102.240122/components/wpa_supplicant/esp_supplicant/include/esp_wpa2.h:10:74: note: '#pragma message: esp_wpa2.h is deprecated. Use esp_eap_client.h instead.'
   10 | #pragma message("esp_wpa2.h is deprecated. Use esp_eap_client.h instead.")
      |                                                                          ^
~/.platformio/packages/framework-espidf@3.50102.240122/components/wpa_supplicant/esp_supplicant/include/esp_wpa2.h:327:1: error: expected declaration before '}' token
  327 | }
      | ^
*** [.pioenvs/esp32-base/src/esphome/components/wifi/wifi_component.o] Error 1
```

This fixes the compile error.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
