### PR TITLE
[nextion] Fix type on sprintf for IDF v5

### DIFF
--- a/esphome/components/nextion/nextion_upload_idf.cpp
+++ b/esphome/components/nextion/nextion_upload_idf.cpp
@@ -260,7 +260,7 @@ bool Nextion::upload_tft(uint32_t baud_rate, bool exit_reparse) {
   // Tells the Nextion the content length of the tft file and baud rate it will be sent at
   // Once the Nextion accepts the command it will wait until the file is successfully uploaded
   // If it fails for any reason a power cycle of the display will be needed
-  sprintf(command, "whmi-wris %d,%" PRIu32 ",1", this->content_length_, baud_rate);
+  sprintf(command, "whmi-wris %" PRIu32 ",%" PRIu32 ",1", this->content_length_, baud_rate);
 
   // Clear serial receive buffer
   ESP_LOGV(TAG, "Clear serial receive buffer");


### PR DESCRIPTION
# What does this implement/fix?

Fix a compiling issue with IDF v5 related to invalid type used with sprintf on the TFT upload:

```log
.pioenvs/nspanel/src/esphome/components/nspanel_ha_blueprint/hardware.o\nCompiling .pioenvs/nspanel/src/esphome/components/nspanel_ha_blueprint/icons.o\nsrc/esphome/components/nextion/nextion_upload_idf.cpp: In member function \'bool esphome::nextion::Nextion::upload_tft(uint32_t, bool)\':\nsrc/esphome/components/nextion/nextion_upload_idf.cpp:263:20: error: format \'%d\' expects argument of type \'int\', but argument 3 has type \'uint32_t\' {aka \'long unsigned int\'} [-Werror=format=]\n  263 |   sprintf(command, "whmi-wris %d,%" PRIu32 ",1", this->content_length_, baud_rate);\n      |                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~  ~~~~~~~~~~~~~~~~~~~~~\n      |                                                        |\n      |                                                        uint32_t {aka long unsigned int}\nCompiling .pioenvs/nspanel/src/esphome/components/nspanel_ha_blueprint/mdiicons.o\ncc1plus: some warnings being treated as errors\n*** [.pioenvs/nspanel/src/esphome/components/nextion/nextion_upload_idf.o] Error 1\n========================= [FAILED] Took 74.50 seconds =========================\n')
  Error: Process completed with exit code 1.
```

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [ ] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
N/A

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
