### PR TITLE
Tiny fix in automation.h - unused return value removed

### DIFF
--- a/esphome/core/automation.h
+++ b/esphome/core/automation.h
@@ -233,7 +233,7 @@ template<typename... Ts> class Automation {
  public:
   explicit Automation(Trigger<Ts...> *trigger) : trigger_(trigger) { this->trigger_->set_automation_parent(this); }
 
-  Action<Ts...> *add_action(Action<Ts...> *action) { this->actions_.add_action(action); }
+  void add_action(Action<Ts...> *action) { this->actions_.add_action(action); }
   void add_actions(const std::vector<Action<Ts...> *> &actions) { this->actions_.add_actions(actions); }
 
   void stop() { this->actions_.stop(); }


### PR DESCRIPTION
# What does this implement/fix?
add_action() method in the template has return value, but it neither returned nor used.
Just replaced it with void

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/5385

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx



## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
