### PR TITLE
[tests] make test_build_components work with venv without installing esphome

### DIFF
--- a/script/test_build_components
+++ b/script/test_build_components
@@ -40,7 +40,7 @@ start_esphome() {
   set -x
   # TODO: Validate escape of Command line substitution value
   python -m esphome -s component_name $target_component -s component_dir ../../components/$target_component -s test_name $test_name -s target_platform $target_platform $esphome_command $component_test_file
-  set +x
+  { set +x; } 2>/dev/null
 }
 
 # Find all test yaml files.

--- a/script/test_build_components
+++ b/script/test_build_components
@@ -37,9 +37,10 @@ start_esphome() {
 
   # Start esphome process
   echo "> [$target_component] [$test_name] [$target_platform]"
-  echo "esphome -s component_name $target_component -s component_dir ../../components/$target_component -s test_name $test_name -s target_platform $target_platform $esphome_command $component_test_file"
+  set -x
   # TODO: Validate escape of Command line substitution value
   python -m esphome -s component_name $target_component -s component_dir ../../components/$target_component -s test_name $test_name -s target_platform $target_platform $esphome_command $component_test_file
+  set +x
 }
 
 # Find all test yaml files.

--- a/script/test_build_components
+++ b/script/test_build_components
@@ -39,7 +39,7 @@ start_esphome() {
   echo "> [$target_component] [$test_name] [$target_platform]"
   echo "esphome -s component_name $target_component -s component_dir ../../components/$target_component -s test_name $test_name -s target_platform $target_platform $esphome_command $component_test_file"
   # TODO: Validate escape of Command line substitution value
-  esphome -s component_name $target_component -s component_dir ../../components/$target_component -s test_name $test_name -s target_platform $target_platform $esphome_command $component_test_file
+  python -m esphome -s component_name $target_component -s component_dir ../../components/$target_component -s test_name $test_name -s target_platform $target_platform $esphome_command $component_test_file
 }
 
 # Find all test yaml files.


### PR DESCRIPTION
# What does this implement/fix?

make test_build_components work with venv without installing esphome

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
