### PR TITLE
separate deep_sleep component for each platform in different file

### DIFF
--- a/esphome/components/deep_sleep/deep_sleep_component.cpp
+++ b/esphome/components/deep_sleep/deep_sleep_component.cpp
@@ -63,7 +63,7 @@ void DeepSleepComponent::begin_sleep(bool manual) {
   }
   App.run_safe_shutdown_hooks();
 
-  deep_sleep_();
+  this->deep_sleep_();
 }
 
 float DeepSleepComponent::get_setup_priority() const { return setup_priority::LATE; }

--- a/esphome/components/deep_sleep/deep_sleep_component.cpp
+++ b/esphome/components/deep_sleep/deep_sleep_component.cpp
@@ -31,7 +31,7 @@ void DeepSleepComponent::dump_config() {
   if (this->run_duration_.has_value()) {
     ESP_LOGCONFIG(TAG, "  Run Duration: %" PRIu32 " ms", *this->run_duration_);
   }
-  dump_config_platform_();
+  this->dump_config_platform_();
 }
 
 void DeepSleepComponent::loop() {

--- a/esphome/components/deep_sleep/deep_sleep_component.cpp
+++ b/esphome/components/deep_sleep/deep_sleep_component.cpp
@@ -1,11 +1,6 @@
 #include "deep_sleep_component.h"
-#include <cinttypes>
 #include "esphome/core/application.h"
 #include "esphome/core/log.h"
-
-#ifdef USE_ESP8266
-#include <Esp.h>
-#endif
 
 namespace esphome {
 namespace deep_sleep {
@@ -13,25 +8,6 @@ namespace deep_sleep {
 static const char *const TAG = "deep_sleep";
 
 bool global_has_deep_sleep = false;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
-
-optional<uint32_t> DeepSleepComponent::get_run_duration_() const {
-#ifdef USE_ESP32
-  if (this->wakeup_cause_to_run_duration_.has_value()) {
-    esp_sleep_wakeup_cause_t wakeup_cause = esp_sleep_get_wakeup_cause();
-    switch (wakeup_cause) {
-      case ESP_SLEEP_WAKEUP_EXT0:
-      case ESP_SLEEP_WAKEUP_EXT1:
-      case ESP_SLEEP_WAKEUP_GPIO:
-        return this->wakeup_cause_to_run_duration_->gpio_cause;
-      case ESP_SLEEP_WAKEUP_TOUCHPAD:
-        return this->wakeup_cause_to_run_duration_->touch_cause;
-      default:
-        return this->wakeup_cause_to_run_duration_->default_cause;
-    }
-  }
-#endif
-  return this->run_duration_;
-}
 
 void DeepSleepComponent::setup() {
   ESP_LOGCONFIG(TAG, "Setting up Deep Sleep...");
@@ -45,6 +21,7 @@ void DeepSleepComponent::setup() {
     ESP_LOGD(TAG, "Not scheduling Deep Sleep, as no run duration is configured.");
   }
 }
+
 void DeepSleepComponent::dump_config() {
   ESP_LOGCONFIG(TAG, "Setting up Deep Sleep...");
   if (this->sleep_duration_.has_value()) {
@@ -54,65 +31,31 @@ void DeepSleepComponent::dump_config() {
   if (this->run_duration_.has_value()) {
     ESP_LOGCONFIG(TAG, "  Run Duration: %" PRIu32 " ms", *this->run_duration_);
   }
-#ifdef USE_ESP32
-  if (wakeup_pin_ != nullptr) {
-    LOG_PIN("  Wakeup Pin: ", this->wakeup_pin_);
-  }
-  if (this->wakeup_cause_to_run_duration_.has_value()) {
-    ESP_LOGCONFIG(TAG, "  Default Wakeup Run Duration: %" PRIu32 " ms",
-                  this->wakeup_cause_to_run_duration_->default_cause);
-    ESP_LOGCONFIG(TAG, "  Touch Wakeup Run Duration: %" PRIu32 " ms", this->wakeup_cause_to_run_duration_->touch_cause);
-    ESP_LOGCONFIG(TAG, "  GPIO Wakeup Run Duration: %" PRIu32 " ms", this->wakeup_cause_to_run_duration_->gpio_cause);
-  }
-#endif
+  dump_config_platform_();
 }
+
 void DeepSleepComponent::loop() {
   if (this->next_enter_deep_sleep_)
     this->begin_sleep();
 }
+
 float DeepSleepComponent::get_loop_priority() const {
   return -100.0f;  // run after everything else is ready
 }
+
 void DeepSleepComponent::set_sleep_duration(uint32_t time_ms) { this->sleep_duration_ = uint64_t(time_ms) * 1000; }
-#if defined(USE_ESP32)
-void DeepSleepComponent::set_wakeup_pin_mode(WakeupPinMode wakeup_pin_mode) {
-  this->wakeup_pin_mode_ = wakeup_pin_mode;
-}
-#endif
-
-#if defined(USE_ESP32)
-#if !defined(USE_ESP32_VARIANT_ESP32C3) && !defined(USE_ESP32_VARIANT_ESP32C6)
-
-void DeepSleepComponent::set_ext1_wakeup(Ext1Wakeup ext1_wakeup) { this->ext1_wakeup_ = ext1_wakeup; }
-
-void DeepSleepComponent::set_touch_wakeup(bool touch_wakeup) { this->touch_wakeup_ = touch_wakeup; }
-
-#endif
-
-void DeepSleepComponent::set_run_duration(WakeupCauseToRunDuration wakeup_cause_to_run_duration) {
-  wakeup_cause_to_run_duration_ = wakeup_cause_to_run_duration;
-}
-
-#endif
 
 void DeepSleepComponent::set_run_duration(uint32_t time_ms) { this->run_duration_ = time_ms; }
+
 void DeepSleepComponent::begin_sleep(bool manual) {
   if (this->prevent_ && !manual) {
     this->next_enter_deep_sleep_ = true;
     return;
   }
-#ifdef USE_ESP32
-  if (this->wakeup_pin_mode_ == WAKEUP_PIN_MODE_KEEP_AWAKE && this->wakeup_pin_ != nullptr &&
-      !this->sleep_duration_.has_value() && this->wakeup_pin_->digital_read()) {
-    // Defer deep sleep until inactive
-    if (!this->next_enter_deep_sleep_) {
-      this->status_set_warning();
-      ESP_LOGW(TAG, "Waiting for pin_ to switch state to enter deep sleep...");
-    }
-    this->next_enter_deep_sleep_ = true;
+
+  if (!prepare_to_sleep_()) {
     return;
   }
-#endif
 
   ESP_LOGI(TAG, "Beginning Deep Sleep");
   if (this->sleep_duration_.has_value()) {
@@ -120,47 +63,13 @@ void DeepSleepComponent::begin_sleep(bool manual) {
   }
   App.run_safe_shutdown_hooks();
 
-#if defined(USE_ESP32)
-#if !defined(USE_ESP32_VARIANT_ESP32C3) && !defined(USE_ESP32_VARIANT_ESP32C6)
-  if (this->sleep_duration_.has_value())
-    esp_sleep_enable_timer_wakeup(*this->sleep_duration_);
-  if (this->wakeup_pin_ != nullptr) {
-    bool level = !this->wakeup_pin_->is_inverted();
-    if (this->wakeup_pin_mode_ == WAKEUP_PIN_MODE_INVERT_WAKEUP && this->wakeup_pin_->digital_read()) {
-      level = !level;
-    }
-    esp_sleep_enable_ext0_wakeup(gpio_num_t(this->wakeup_pin_->get_pin()), level);
-  }
-  if (this->ext1_wakeup_.has_value()) {
-    esp_sleep_enable_ext1_wakeup(this->ext1_wakeup_->mask, this->ext1_wakeup_->wakeup_mode);
-  }
-
-  if (this->touch_wakeup_.has_value() && *(this->touch_wakeup_)) {
-    esp_sleep_enable_touchpad_wakeup();
-    esp_sleep_pd_config(ESP_PD_DOMAIN_RTC_PERIPH, ESP_PD_OPTION_ON);
-  }
-#endif
-#if defined(USE_ESP32_VARIANT_ESP32C3) || defined(USE_ESP32_VARIANT_ESP32C6)
-  if (this->sleep_duration_.has_value())
-    esp_sleep_enable_timer_wakeup(*this->sleep_duration_);
-  if (this->wakeup_pin_ != nullptr) {
-    bool level = !this->wakeup_pin_->is_inverted();
-    if (this->wakeup_pin_mode_ == WAKEUP_PIN_MODE_INVERT_WAKEUP && this->wakeup_pin_->digital_read()) {
-      level = !level;
-    }
-    esp_deep_sleep_enable_gpio_wakeup(1 << this->wakeup_pin_->get_pin(),
-                                      static_cast<esp_deepsleep_gpio_wake_up_mode_t>(level));
-  }
-#endif
-  esp_deep_sleep_start();
-#endif
-
-#ifdef USE_ESP8266
-  ESP.deepSleep(*this->sleep_duration_);  // NOLINT(readability-static-accessed-through-instance)
-#endif
+  deep_sleep_();
 }
+
 float DeepSleepComponent::get_setup_priority() const { return setup_priority::LATE; }
+
 void DeepSleepComponent::prevent_deep_sleep() { this->prevent_ = true; }
+
 void DeepSleepComponent::allow_deep_sleep() { this->prevent_ = false; }
 
 }  // namespace deep_sleep

--- a/esphome/components/deep_sleep/deep_sleep_component.cpp
+++ b/esphome/components/deep_sleep/deep_sleep_component.cpp
@@ -53,7 +53,7 @@ void DeepSleepComponent::begin_sleep(bool manual) {
     return;
   }
 
-  if (!prepare_to_sleep_()) {
+  if (!this->prepare_to_sleep_()) {
     return;
   }
 

--- a/esphome/components/deep_sleep/deep_sleep_component.h
+++ b/esphome/components/deep_sleep/deep_sleep_component.h
@@ -106,6 +106,10 @@ class DeepSleepComponent : public Component {
   // duration before entering deep sleep.
   optional<uint32_t> get_run_duration_() const;
 
+  void dump_config_platform_();
+  bool prepare_to_sleep_();
+  void deep_sleep_();
+
   optional<uint64_t> sleep_duration_;
 #ifdef USE_ESP32
   InternalGPIOPin *wakeup_pin_;

--- a/esphome/components/deep_sleep/deep_sleep_esp32.cpp
+++ b/esphome/components/deep_sleep/deep_sleep_esp32.cpp
@@ -1,0 +1,104 @@
+#ifdef USE_ESP32
+#include "deep_sleep_component.h"
+#include "esphome/core/log.h"
+
+namespace esphome {
+namespace deep_sleep {
+
+static const char *const TAG = "deep_sleep";
+
+optional<uint32_t> DeepSleepComponent::get_run_duration_() const {
+  if (this->wakeup_cause_to_run_duration_.has_value()) {
+    esp_sleep_wakeup_cause_t wakeup_cause = esp_sleep_get_wakeup_cause();
+    switch (wakeup_cause) {
+      case ESP_SLEEP_WAKEUP_EXT0:
+      case ESP_SLEEP_WAKEUP_EXT1:
+      case ESP_SLEEP_WAKEUP_GPIO:
+        return this->wakeup_cause_to_run_duration_->gpio_cause;
+      case ESP_SLEEP_WAKEUP_TOUCHPAD:
+        return this->wakeup_cause_to_run_duration_->touch_cause;
+      default:
+        return this->wakeup_cause_to_run_duration_->default_cause;
+    }
+  }
+  return this->run_duration_;
+}
+
+void DeepSleepComponent::set_wakeup_pin_mode(WakeupPinMode wakeup_pin_mode) {
+  this->wakeup_pin_mode_ = wakeup_pin_mode;
+}
+
+#if !defined(USE_ESP32_VARIANT_ESP32C3) && !defined(USE_ESP32_VARIANT_ESP32C6)
+void DeepSleepComponent::set_ext1_wakeup(Ext1Wakeup ext1_wakeup) { this->ext1_wakeup_ = ext1_wakeup; }
+
+void DeepSleepComponent::set_touch_wakeup(bool touch_wakeup) { this->touch_wakeup_ = touch_wakeup; }
+#endif
+
+void DeepSleepComponent::set_run_duration(WakeupCauseToRunDuration wakeup_cause_to_run_duration) {
+  wakeup_cause_to_run_duration_ = wakeup_cause_to_run_duration;
+}
+
+void DeepSleepComponent::dump_config_platform_() {
+  if (wakeup_pin_ != nullptr) {
+    LOG_PIN("  Wakeup Pin: ", this->wakeup_pin_);
+  }
+  if (this->wakeup_cause_to_run_duration_.has_value()) {
+    ESP_LOGCONFIG(TAG, "  Default Wakeup Run Duration: %" PRIu32 " ms",
+                  this->wakeup_cause_to_run_duration_->default_cause);
+    ESP_LOGCONFIG(TAG, "  Touch Wakeup Run Duration: %" PRIu32 " ms", this->wakeup_cause_to_run_duration_->touch_cause);
+    ESP_LOGCONFIG(TAG, "  GPIO Wakeup Run Duration: %" PRIu32 " ms", this->wakeup_cause_to_run_duration_->gpio_cause);
+  }
+}
+
+bool DeepSleepComponent::prepare_to_sleep_() {
+  if (this->wakeup_pin_mode_ == WAKEUP_PIN_MODE_KEEP_AWAKE && this->wakeup_pin_ != nullptr &&
+      !this->sleep_duration_.has_value() && this->wakeup_pin_->digital_read()) {
+    // Defer deep sleep until inactive
+    if (!this->next_enter_deep_sleep_) {
+      this->status_set_warning();
+      ESP_LOGW(TAG, "Waiting for pin_ to switch state to enter deep sleep...");
+    }
+    this->next_enter_deep_sleep_ = true;
+    return false;
+  }
+  return true;
+}
+
+void DeepSleepComponent::deep_sleep_() {
+#if !defined(USE_ESP32_VARIANT_ESP32C3) && !defined(USE_ESP32_VARIANT_ESP32C6)
+  if (this->sleep_duration_.has_value())
+    esp_sleep_enable_timer_wakeup(*this->sleep_duration_);
+  if (this->wakeup_pin_ != nullptr) {
+    bool level = !this->wakeup_pin_->is_inverted();
+    if (this->wakeup_pin_mode_ == WAKEUP_PIN_MODE_INVERT_WAKEUP && this->wakeup_pin_->digital_read()) {
+      level = !level;
+    }
+    esp_sleep_enable_ext0_wakeup(gpio_num_t(this->wakeup_pin_->get_pin()), level);
+  }
+  if (this->ext1_wakeup_.has_value()) {
+    esp_sleep_enable_ext1_wakeup(this->ext1_wakeup_->mask, this->ext1_wakeup_->wakeup_mode);
+  }
+
+  if (this->touch_wakeup_.has_value() && *(this->touch_wakeup_)) {
+    esp_sleep_enable_touchpad_wakeup();
+    esp_sleep_pd_config(ESP_PD_DOMAIN_RTC_PERIPH, ESP_PD_OPTION_ON);
+  }
+#endif
+#if defined(USE_ESP32_VARIANT_ESP32C3) || defined(USE_ESP32_VARIANT_ESP32C6)
+  if (this->sleep_duration_.has_value())
+    esp_sleep_enable_timer_wakeup(*this->sleep_duration_);
+  if (this->wakeup_pin_ != nullptr) {
+    bool level = !this->wakeup_pin_->is_inverted();
+    if (this->wakeup_pin_mode_ == WAKEUP_PIN_MODE_INVERT_WAKEUP && this->wakeup_pin_->digital_read()) {
+      level = !level;
+    }
+    esp_deep_sleep_enable_gpio_wakeup(1 << this->wakeup_pin_->get_pin(),
+                                      static_cast<esp_deepsleep_gpio_wake_up_mode_t>(level));
+  }
+#endif
+  esp_deep_sleep_start();
+}
+
+}  // namespace deep_sleep
+}  // namespace esphome
+#endif

--- a/esphome/components/deep_sleep/deep_sleep_esp8266.cpp
+++ b/esphome/components/deep_sleep/deep_sleep_esp8266.cpp
@@ -1,0 +1,23 @@
+#ifdef USE_ESP8266
+#include "deep_sleep_component.h"
+
+#include <Esp.h>
+
+namespace esphome {
+namespace deep_sleep {
+
+static const char *const TAG = "deep_sleep";
+
+optional<uint32_t> DeepSleepComponent::get_run_duration_() const { return this->run_duration_; }
+
+void DeepSleepComponent::dump_config_platform_() {}
+
+bool DeepSleepComponent::prepare_to_sleep_() { return true; }
+
+void DeepSleepComponent::deep_sleep_() {
+  ESP.deepSleep(*this->sleep_duration_);  // NOLINT(readability-static-accessed-through-instance)
+}
+
+}  // namespace deep_sleep
+}  // namespace esphome
+#endif


### PR DESCRIPTION
# What does this implement/fix?

separate deep_sleep component for each platform in different file

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32-S3
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
