### PR TITLE
fix(dallas): make recovery time for 1-bit equal to that of 0-bit

### DIFF
--- a/esphome/components/gpio/one_wire/gpio_one_wire.cpp
+++ b/esphome/components/gpio/one_wire/gpio_one_wire.cpp
@@ -60,7 +60,7 @@ void HOT IRAM_ATTR GPIOOneWireBus::write_bit_(bool bit) {
   // recovery time: t_rec: min=1µs
   // ds18b20 appears to read the bus after roughly 14µs
   uint32_t delay0 = bit ? 6 : 60;
-  uint32_t delay1 = bit ? 54 : 5;
+  uint32_t delay1 = bit ? 59 : 5;
 
   // delay A/C
   delayMicroseconds(delay0);


### PR DESCRIPTION
# What does this implement/fix?

Without this detection of DS18B20 sensors attached along a 10 meter wire fails on an ESP32-C3 ([Wemos C3 pico]). 58 μs also works when on 5V, on 3.3V however it starts to become unpredictable and fail somewhere between 1/3 and 2/3 of the time.

FYI: I've got 6 sensors in total for my setup. Soldered equidistant along a single cable (3 wires) of about 10m long. Tested both by powering from the board's 3V3 pin as well as the 5V pin. In both cases the data line had a single 4.7 kΩ pull-up resistor between the data and positive power line. (I've tried 2.2 kΩ @ 5V too before writing this patch, it didn't make a difference).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
esphome:
  name: temperature-sensors

esp32:
  board: lolin_c3_mini
  framework:
    type: arduino

dallas:
  - pin: GPIO6

sensor:
  - platform: dallas
    address: 0xXXXXXXXXXXXXXX28
    name: A
    accuracy_decimals: 2
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

[Wemos C3 pico]: https://www.wemos.cc/en/latest/c3/c3_pico.html