### PR TITLE
Add device_class to valve core config

### DIFF
--- a/esphome/components/valve/__init__.py
+++ b/esphome/components/valve/__init__.py
@@ -14,6 +14,8 @@ from esphome.const import (
     CONF_STATE,
     CONF_STOP,
     CONF_TRIGGER_ID,
+    DEVICE_CLASS_GAS,
+    DEVICE_CLASS_WATER,
 )
 from esphome.core import CORE, coroutine_with_priority
 from esphome.cpp_helpers import setup_entity
@@ -21,6 +23,11 @@ from esphome.cpp_helpers import setup_entity
 IS_PLATFORM_COMPONENT = True
 
 CODEOWNERS = ["@esphome/core"]
+
+DEVICE_CLASSES = [
+    DEVICE_CLASS_GAS,
+    DEVICE_CLASS_WATER,
+]
 
 valve_ns = cg.esphome_ns.namespace("valve")
 
@@ -65,6 +72,7 @@ VALVE_SCHEMA = cv.ENTITY_BASE_SCHEMA.extend(cv.MQTT_COMMAND_COMPONENT_SCHEMA).ex
     {
         cv.GenerateID(): cv.declare_id(Valve),
         cv.OnlyWith(CONF_MQTT_ID, "mqtt"): cv.declare_id(mqtt.MQTTValveComponent),
+        cv.Optional(CONF_DEVICE_CLASS): cv.one_of(*DEVICE_CLASSES, lower=True),
         cv.Optional(CONF_POSITION_COMMAND_TOPIC): cv.All(
             cv.requires_component("mqtt"), cv.subscribe_topic
         ),


### PR DESCRIPTION
# What does this implement/fix?

This adds the `device_class` property to the valve core config. `device_class` is already implemented on the codegen side.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** *N/A - documentation already mentions `device_class`*

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
valve:
  - platform: template
    id: water_valve
    device_class: water
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder). *No tests have been added -- template valve already matches that of its nearest cousin: template cover.*

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs). *N/A - documentation already mentions `device_class`*
