### PR TITLE
[waveshare_epaper] Add color support for 7.5in

### DIFF
--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -2567,19 +2567,31 @@ void HOT WaveshareEPaper7P5InBC::display() {
   this->command(0x10);
   this->start_data_();
 
-  for (size_t i = 0; i < this->get_buffer_length_(); i++) {
+  const uint32_t buf_half_len = this->get_buffer_length_() / 2u;
+
+  for (size_t i = 0; i < buf_half_len; i++) {
     // A line of eight source pixels (each a bit in this byte)
-    uint8_t eight_pixels = this->buffer_[i];
+    // logic for black is flipped.
+    uint8_t eight_black_pixels = ~(this->buffer_[i]);
+    uint8_t eight_red_pixels = this->buffer_[i + buf_half_len];
 
     for (uint8_t j = 0; j < 8; j += 2) {
       /* For bichromatic displays, each byte represents two pixels. Each nibble encodes a pixel: 0=white, 3=black,
-      4=color. Therefore, e.g. 0x44 = two adjacent color pixels, 0x33 is two adjacent black pixels, etc. If you want
-      to draw using the color pixels, change '0x30' with '0x40' and '0x03' with '0x04' below. */
-      uint8_t left_nibble = (eight_pixels & 0x80) ? 0x30 : 0x00;
-      eight_pixels <<= 1;
-      uint8_t right_nibble = (eight_pixels & 0x80) ? 0x03 : 0x00;
-      eight_pixels <<= 1;
-      this->write_byte(left_nibble | right_nibble);
+      4=color. Therefore, e.g. 0x44 = two adjacent color pixels, 0x33 is two adjacent black pixels, etc. */
+      uint8_t data = 0x00;
+      if (eight_red_pixels & 0x80) {
+        data |= 0x40;
+      } else if (eight_black_pixels & 0x80) {
+        data |= 0x30;
+      }
+      if (eight_red_pixels & 0x40) {
+        data |= 0x04;
+      } else if (eight_black_pixels & 0x40) {
+        data |= 0x03;
+      }
+      eight_black_pixels <<= 2;
+      eight_red_pixels <<= 2;
+      this->write_byte(data);
     }
     App.feed_wdt();
   }

--- a/esphome/components/waveshare_epaper/waveshare_epaper.h
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.h
@@ -594,7 +594,7 @@ class WaveshareEPaper7P5InBV3 : public WaveshareEPaper {
   void init_display_();
 };
 
-class WaveshareEPaper7P5InBC : public WaveshareEPaper {
+class WaveshareEPaper7P5InBC : public WaveshareEPaperBWR {
  public:
   void initialize() override;
 


### PR DESCRIPTION
# What does this implement/fix?

The 7.5in displays are available in a red and yellow variant, but we normally only have support for red, so this is the red support for the 7.5in. If it has yellow, then everything painted red will be shown in yellow.
## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#3844

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
