### PR TITLE
Add open drain output pins to sx1509

### DIFF
--- a/esphome/components/sx1509/__init__.py
+++ b/esphome/components/sx1509/__init__.py
@@ -11,6 +11,7 @@ from esphome.const import (
     CONF_OUTPUT,
     CONF_PULLDOWN,
     CONF_PULLUP,
+    CONF_OPEN_DRAIN,
 )
 
 CONF_KEYPAD = "keypad"
@@ -79,6 +80,8 @@ def validate_mode(value):
         raise cv.Invalid("Pulldown only available with input")
     if value[CONF_PULLUP] and value[CONF_PULLDOWN]:
         raise cv.Invalid("Can only have one of pullup or pulldown")
+    if value[CONF_OPEN_DRAIN] and not value[CONF_OUTPUT]:
+        raise cv.Invalid("Open drain available only with output")
     return value
 
 
@@ -94,6 +97,7 @@ SX1509_PIN_SCHEMA = cv.All(
                 cv.Optional(CONF_PULLUP, default=False): cv.boolean,
                 cv.Optional(CONF_PULLDOWN, default=False): cv.boolean,
                 cv.Optional(CONF_OUTPUT, default=False): cv.boolean,
+                cv.Optional(CONF_OPEN_DRAIN, default=False): cv.boolean,
             },
             validate_mode,
         ),

--- a/esphome/components/sx1509/sx1509.cpp
+++ b/esphome/components/sx1509/sx1509.cpp
@@ -102,6 +102,7 @@ void SX1509Component::pin_mode(uint8_t pin, gpio::Flags flags) {
       temp_word |= (1 << pin);
       this->write_byte_16(REG_OPEN_DRAIN_B, temp_word);
     }
+    this->write_byte_16(REG_DIR_B, this->ddr_mask_);
   } else {
     this->ddr_mask_ |= (1 << pin);
 

--- a/esphome/components/sx1509/sx1509.cpp
+++ b/esphome/components/sx1509/sx1509.cpp
@@ -101,6 +101,7 @@ void SX1509Component::pin_mode(uint8_t pin, gpio::Flags flags) {
       this->read_byte_16(REG_OPEN_DRAIN_B, &temp_word);
       temp_word |= (1 << pin);
       this->write_byte_16(REG_OPEN_DRAIN_B, temp_word);
+      ESP_LOGW(TAG, "Setting open drain mode pin %d", pin);
     }
     this->write_byte_16(REG_DIR_B, this->ddr_mask_);
   } else {

--- a/esphome/components/sx1509/sx1509.cpp
+++ b/esphome/components/sx1509/sx1509.cpp
@@ -90,16 +90,18 @@ void SX1509Component::pin_mode(uint8_t pin, gpio::Flags flags) {
   if (flags == gpio::FLAG_OUTPUT) {
     this->ddr_mask_ &= ~(1 << pin);
 
-    uint16_t temp_open_drain;
-    this->read_byte_16(REG_OPEN_DRAIN_B, &temp_open_drain);
-
     if (flags & gpio::FLAG_OPEN_DRAIN) {
-      temp_open_drain |= (1 << pin);
-    } else {
-      temp_open_drain &= ~(1 << pin);
+      uint16_t temp_word = 0;
+      this->read_byte_16(REG_INPUT_DISABLE_B, &temp_word);
+      temp_word |= (1 << pin);
+      this->write_byte_16(REG_INPUT_DISABLE_B, temp_word);
+      this->read_byte_16(REG_PULL_UP_B, &temp_word);
+      temp_word &= ~(1 << pin);
+      this->write_byte_16(REG_PULL_UP_B, temp_word);
+      this->read_byte_16(REG_OPEN_DRAIN_B, &temp_word);
+      temp_word |= (1 << pin);
+      this->write_byte_16(REG_OPEN_DRAIN_B, temp_word);
     }
-
-    this->write_byte_16(REG_OPEN_DRAIN_B, temp_open_drain);
   } else {
     this->ddr_mask_ |= (1 << pin);
 
@@ -122,8 +124,8 @@ void SX1509Component::pin_mode(uint8_t pin, gpio::Flags flags) {
 
     this->write_byte_16(REG_PULL_UP_B, temp_pullup);
     this->write_byte_16(REG_PULL_DOWN_B, temp_pulldown);
+    this->write_byte_16(REG_DIR_B, this->ddr_mask_);
   }
-  this->write_byte_16(REG_DIR_B, this->ddr_mask_);
 }
 
 void SX1509Component::setup_led_driver(uint8_t pin) {

--- a/esphome/components/sx1509/sx1509.cpp
+++ b/esphome/components/sx1509/sx1509.cpp
@@ -89,6 +89,17 @@ void SX1509Component::pin_mode(uint8_t pin, gpio::Flags flags) {
   this->read_byte_16(REG_DIR_B, &this->ddr_mask_);
   if (flags == gpio::FLAG_OUTPUT) {
     this->ddr_mask_ &= ~(1 << pin);
+
+    uint16_t temp_open_drain;
+    this->read_byte_16(REG_OPEN_DRAIN_B, &temp_open_drain);
+
+    if (flags & gpio::FLAG_OPEN_DRAIN) {
+      temp_open_drain |= (1 << pin);
+    } else {
+      temp_open_drain &= ~(1 << pin);
+    }
+
+    this->write_byte_16(REG_OPEN_DRAIN_B, temp_open_drain);
   } else {
     this->ddr_mask_ |= (1 << pin);
 


### PR DESCRIPTION
# What does this implement/fix?

Adds open drain mode for sx1509 output pins. 

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
