### PR TITLE
Fix Upload from Dashboard with MQTT discovery.

### DIFF
--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -351,7 +351,7 @@ def upload_program(config, args, host):
         not is_ip_address(CORE.address)  # pylint: disable=too-many-boolean-expressions
         and (get_port_type(host) == "MQTT" or config[CONF_MDNS][CONF_DISABLED])
         and CONF_MQTT in config
-        and (not args.device or args.device == "MQTT")
+        and (not args.device or args.device == "MQTT" or args.device == "OTA")
     ):
         from esphome import mqtt
 

--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -351,7 +351,7 @@ def upload_program(config, args, host):
         not is_ip_address(CORE.address)  # pylint: disable=too-many-boolean-expressions
         and (get_port_type(host) == "MQTT" or config[CONF_MDNS][CONF_DISABLED])
         and CONF_MQTT in config
-        and (not args.device or args.device == "MQTT" or args.device == "OTA")
+        and (not args.device or args.device in ("MQTT", "OTA"))
     ):
         from esphome import mqtt
 


### PR DESCRIPTION
# What does this implement/fix?

The Dashboard based Install / Upload where broken by this change:
https://github.com/esphome/esphome/pull/6371/files 
since the dashboard starts the upload with device arg `OTA`.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
N/A upload code fix

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
