### PR TITLE
Fix MQTT dashboard discovery (Exception in MqttStatusThread).

### DIFF
--- a/esphome/dashboard/status/mqtt.py
+++ b/esphome/dashboard/status/mqtt.py
@@ -18,7 +18,7 @@ class MqttStatusThread(threading.Thread):
         """Run the status thread."""
         dashboard = DASHBOARD
         entries = dashboard.entries
-        current_entries = entries.all()
+        current_entries = entries.async_all()
 
         config = mqtt.config_from_env()
         topic = "esphome/discover/#"
@@ -33,7 +33,7 @@ class MqttStatusThread(threading.Thread):
                     return
                 for entry in current_entries:
                     if entry.name == data["name"]:
-                        entries.set_state(entry, EntryState.ONLINE)
+                        entries.async_set_state(entry, EntryState.ONLINE)
                         return
 
         def on_connect(client, userdata, flags, return_code):
@@ -53,11 +53,11 @@ class MqttStatusThread(threading.Thread):
         client.loop_start()
 
         while not dashboard.stop_event.wait(2):
-            current_entries = entries.all()
+            current_entries = entries.async_all()
             # will be set to true on on_message
             for entry in current_entries:
                 if entry.no_mdns:
-                    entries.set_state(entry, EntryState.OFFLINE)
+                    entries.async_set_state(entry, EntryState.OFFLINE)
 
             client.publish("esphome/discover", None, retain=False)
             dashboard.mqtt_ping_request.wait()


### PR DESCRIPTION
# What does this implement/fix?

Fix MqttStatusThread for dashboard.

starting the dashboard with MQTT support results in a Exception

```
$ ESPHOME_DASHBOARD_USE_MQTT=1 ESPHOME_DASHBOARD_MQTT_BROKER="mqtt.iot.local.setup" python3 -m esphome dashboard ../data

2024-05-19 11:36:41,085 INFO Starting dashboard web server on http://0.0.0.0:6052 and configuration dir ../data...
Exception in thread Thread-1:
Traceback (most recent call last):
  File "/usr/lib/python3.12/threading.py", line 1073, in _bootstrap_inner
    self.run()
  File "/home/links/code/esphome/esphome/esphome/dashboard/status/mqtt.py", line 21, in run
    current_entries = entries.all()
                      ^^^^^^^^^^^^^
  File "/home/links/code/esphome/esphome/esphome/dashboard/entries.py", line 106, in all
    return asyncio.run_coroutine_threadsafe(self._async_all, self._loop).result()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/asyncio/tasks.py", line 937, in run_coroutine_threadsafe
    raise TypeError('A coroutine object is required')
TypeError: A coroutine object is required
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
N/A dashboard fix
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
