### PR TITLE
mpr121: Add GPIO support

### DIFF
--- a/esphome/components/mpr121/__init__.py
+++ b/esphome/components/mpr121/__init__.py
@@ -1,8 +1,11 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
+import esphome.final_validate as fv
 from esphome import pins
 from esphome.components import i2c
 from esphome.const import (
+    CONF_BINARY_SENSOR,
+    CONF_CHANNEL,
     CONF_ID,
     CONF_INPUT,
     CONF_INVERTED,
@@ -15,12 +18,13 @@ CONF_TOUCH_THRESHOLD = "touch_threshold"
 CONF_RELEASE_THRESHOLD = "release_threshold"
 CONF_TOUCH_DEBOUNCE = "touch_debounce"
 CONF_RELEASE_DEBOUNCE = "release_debounce"
+CONF_MAX_TOUCH_CHANNEL = "max_touch_channel"
+CONF_MPR121 = "mpr121"
+CONF_MPR121_ID = "mpr121_id"
 
 DEPENDENCIES = ["i2c"]
-AUTO_LOAD = ["binary_sensor"]
 
 mpr121_ns = cg.esphome_ns.namespace("mpr121")
-CONF_MPR121_ID = "mpr121_id"
 MPR121Component = mpr121_ns.class_("MPR121Component", cg.Component, i2c.I2CDevice)
 MPR121GPIOPin = mpr121_ns.class_("MPR121GPIOPin", cg.GPIOPin)
 
@@ -37,11 +41,33 @@ CONFIG_SCHEMA = (
             cv.Optional(CONF_RELEASE_THRESHOLD, default=0x06): cv.int_range(
                 min=0x05, max=0x30
             ),
+            cv.Optional(CONF_MAX_TOUCH_CHANNEL): cv.int_range(min=3, max=11),
         }
     )
     .extend(cv.COMPONENT_SCHEMA)
     .extend(i2c.i2c_device_schema(0x5A))
 )
+
+
+def _final_validate(config):
+    fconf = fv.full_config.get()
+    max_touch_channel = 3
+    if CONF_BINARY_SENSOR in fconf:
+        for binary_sensor in fconf[CONF_BINARY_SENSOR]:
+            if binary_sensor[CONF_MPR121_ID] == config[CONF_ID]:
+                max_touch_channel = max(max_touch_channel, binary_sensor[CONF_CHANNEL])
+    if max_touch_channel_in_config := config.get(CONF_MAX_TOUCH_CHANNEL):
+        if max_touch_channel != max_touch_channel_in_config:
+            raise cv.Invalid(
+                "Max touch channel must equal the highest binary sensor channel or be removed for auto calculation",
+                path=[CONF_MAX_TOUCH_CHANNEL],
+            )
+    path = fconf.get_path_for_id(config[CONF_ID])[:-1]
+    this_config = fconf.get_config_for_path(path)
+    this_config[CONF_MAX_TOUCH_CHANNEL] = max_touch_channel
+
+
+FINAL_VALIDATE_SCHEMA = _final_validate
 
 
 async def to_code(config):
@@ -50,6 +76,7 @@ async def to_code(config):
     cg.add(var.set_release_debounce(config[CONF_RELEASE_DEBOUNCE]))
     cg.add(var.set_touch_threshold(config[CONF_TOUCH_THRESHOLD]))
     cg.add(var.set_release_threshold(config[CONF_RELEASE_THRESHOLD]))
+    cg.add(var.set_max_touch_channel(config[CONF_MAX_TOUCH_CHANNEL]))
     await cg.register_component(var, config)
     await i2c.register_i2c_device(var, config)
 
@@ -65,27 +92,31 @@ def validate_mode(value):
 # Among the 12 electrode inputs, 8 inputs are designed as multifunctional pins. When these pins are
 # not configured as electrodes, they may be used to drive LEDs or used for general purpose input or
 # output.
-MPR121_GPIO_PIN_SCHEMA = cv.All(
+MPR121_GPIO_PIN_SCHEMA = pins.gpio_base_schema(
+    MPR121GPIOPin,
+    cv.int_range(min=4, max=11),
+    modes=[CONF_INPUT, CONF_OUTPUT],
+    mode_validator=validate_mode,
+).extend(
     {
-        cv.GenerateID(): cv.declare_id(MPR121GPIOPin),
-        cv.Required(CONF_MPR121_ID): cv.use_id(MPR121Component),
-        cv.Required(CONF_NUMBER): cv.int_range(min=4, max=11),
-        cv.Optional(CONF_MODE, default={}): cv.All(
-            {
-                cv.Optional(CONF_INPUT, default=False): cv.boolean,
-                cv.Optional(CONF_OUTPUT, default=False): cv.boolean,
-            },
-            validate_mode,
-        ),
-        cv.Optional(CONF_INVERTED, default=False): cv.boolean,
+        cv.Required(CONF_MPR121): cv.use_id(MPR121Component),
     }
 )
 
 
-@pins.PIN_SCHEMA_REGISTRY.register(CONF_MPR121_ID, MPR121_GPIO_PIN_SCHEMA)
+def mpr121_pin_final_validate(pin_config, parent_config):
+    if pin_config[CONF_NUMBER] <= parent_config[CONF_MAX_TOUCH_CHANNEL]:
+        raise cv.Invalid(
+            "Pin number must be higher than the max touch channel of the MPR121 component",
+        )
+
+
+@pins.PIN_SCHEMA_REGISTRY.register(
+    CONF_MPR121, MPR121_GPIO_PIN_SCHEMA, mpr121_pin_final_validate
+)
 async def mpr121_gpio_pin_to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
-    parent = await cg.get_variable(config[CONF_MPR121_ID])
+    parent = await cg.get_variable(config[CONF_MPR121])
 
     cg.add(var.set_parent(parent))
 

--- a/esphome/components/mpr121/__init__.py
+++ b/esphome/components/mpr121/__init__.py
@@ -52,8 +52,8 @@ CONFIG_SCHEMA = (
 def _final_validate(config):
     fconf = fv.full_config.get()
     max_touch_channel = 3
-    if CONF_BINARY_SENSOR in fconf:
-        for binary_sensor in fconf[CONF_BINARY_SENSOR]:
+    if binary_sensors := fconf.get(CONF_BINARY_SENSOR) is not None:
+        for binary_sensor in binary_sensors:
             if binary_sensor.get(CONF_MPR121_ID) == config[CONF_ID]:
                 max_touch_channel = max(max_touch_channel, binary_sensor[CONF_CHANNEL])
     if max_touch_channel_in_config := config.get(CONF_MAX_TOUCH_CHANNEL):

--- a/esphome/components/mpr121/__init__.py
+++ b/esphome/components/mpr121/__init__.py
@@ -52,7 +52,7 @@ CONFIG_SCHEMA = (
 def _final_validate(config):
     fconf = fv.full_config.get()
     max_touch_channel = 3
-    if binary_sensors := fconf.get(CONF_BINARY_SENSOR) is not None:
+    if (binary_sensors := fconf.get(CONF_BINARY_SENSOR)) is not None:
         for binary_sensor in binary_sensors:
             if binary_sensor.get(CONF_MPR121_ID) == config[CONF_ID]:
                 max_touch_channel = max(max_touch_channel, binary_sensor[CONF_CHANNEL])

--- a/esphome/components/mpr121/__init__.py
+++ b/esphome/components/mpr121/__init__.py
@@ -54,7 +54,7 @@ def _final_validate(config):
     max_touch_channel = 3
     if CONF_BINARY_SENSOR in fconf:
         for binary_sensor in fconf[CONF_BINARY_SENSOR]:
-            if binary_sensor[CONF_MPR121_ID] == config[CONF_ID]:
+            if binary_sensor.get(CONF_MPR121_ID) == config[CONF_ID]:
                 max_touch_channel = max(max_touch_channel, binary_sensor[CONF_CHANNEL])
     if max_touch_channel_in_config := config.get(CONF_MAX_TOUCH_CHANNEL):
         if max_touch_channel != max_touch_channel_in_config:

--- a/esphome/components/mpr121/binary_sensor/__init__.py
+++ b/esphome/components/mpr121/binary_sensor/__init__.py
@@ -2,7 +2,7 @@ import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import binary_sensor
 from esphome.const import CONF_CHANNEL
-from . import (
+from .. import (
     mpr121_ns,
     MPR121Component,
     CONF_MPR121_ID,
@@ -11,9 +11,9 @@ from . import (
 )
 
 DEPENDENCIES = ["mpr121"]
-MPR121Channel = mpr121_ns.class_("MPR121Channel", binary_sensor.BinarySensor)
+MPR121BinarySensor = mpr121_ns.class_("MPR121BinarySensor", binary_sensor.BinarySensor)
 
-CONFIG_SCHEMA = binary_sensor.binary_sensor_schema(MPR121Channel).extend(
+CONFIG_SCHEMA = binary_sensor.binary_sensor_schema(MPR121BinarySensor).extend(
     {
         cv.GenerateID(CONF_MPR121_ID): cv.use_id(MPR121Component),
         cv.Required(CONF_CHANNEL): cv.int_range(min=0, max=11),

--- a/esphome/components/mpr121/binary_sensor/__init__.py
+++ b/esphome/components/mpr121/binary_sensor/__init__.py
@@ -27,7 +27,7 @@ async def to_code(config):
     var = await binary_sensor.new_binary_sensor(config)
     hub = await cg.get_variable(config[CONF_MPR121_ID])
     cg.add(var.set_channel(config[CONF_CHANNEL]))
-    cg.add(var.set_parent(hub))
+    cg.register_parented(var, hub)
 
     if CONF_TOUCH_THRESHOLD in config:
         cg.add(var.set_touch_threshold(config[CONF_TOUCH_THRESHOLD]))

--- a/esphome/components/mpr121/binary_sensor/__init__.py
+++ b/esphome/components/mpr121/binary_sensor/__init__.py
@@ -27,6 +27,7 @@ async def to_code(config):
     var = await binary_sensor.new_binary_sensor(config)
     hub = await cg.get_variable(config[CONF_MPR121_ID])
     cg.add(var.set_channel(config[CONF_CHANNEL]))
+    cg.add(var.set_parent(hub))
 
     if CONF_TOUCH_THRESHOLD in config:
         cg.add(var.set_touch_threshold(config[CONF_TOUCH_THRESHOLD]))

--- a/esphome/components/mpr121/binary_sensor/mpr121_binary_sensor.cpp
+++ b/esphome/components/mpr121/binary_sensor/mpr121_binary_sensor.cpp
@@ -1,0 +1,20 @@
+#include "mpr121_binary_sensor.h"
+
+namespace esphome {
+namespace mpr121 {
+
+void MPR121BinarySensor::setup() {
+  uint8_t touch_threshold = this->touch_threshold_.value_or(this->parent_->get_touch_threshold());
+  this->parent_->write_byte(MPR121_TOUCHTH_0 + 2 * this->channel_, touch_threshold);
+
+  uint8_t release_threshold = this->release_threshold_.value_or(this->parent_->get_release_threshold());
+  this->parent_->write_byte(MPR121_RELEASETH_0 + 2 * this->channel_, release_threshold);
+}
+
+void MPR121BinarySensor::process(uint16_t data) {
+  bool new_state = data & (1 << this->channel_);
+  this->publish_state(new_state);
+}
+
+}  // namespace mpr121
+}  // namespace esphome

--- a/esphome/components/mpr121/binary_sensor/mpr121_binary_sensor.h
+++ b/esphome/components/mpr121/binary_sensor/mpr121_binary_sensor.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "esphome/components/binary_sensor/binary_sensor.h"
+
+#include "../mpr121.h"
+
+namespace esphome {
+namespace mpr121 {
+
+class MPR121BinarySensor : public binary_sensor::BinarySensor, public MPR121Channel, public Parented<MPR121Component> {
+ public:
+  void set_channel(uint8_t channel) { this->channel_ = channel; }
+  void set_touch_threshold(uint8_t touch_threshold) { this->touch_threshold_ = touch_threshold; };
+  void set_release_threshold(uint8_t release_threshold) { this->release_threshold_ = release_threshold; };
+
+  void setup() override;
+  void process(uint16_t data) override;
+
+ protected:
+  uint8_t channel_{0};
+  optional<uint8_t> touch_threshold_{};
+  optional<uint8_t> release_threshold_{};
+};
+
+}  // namespace mpr121
+}  // namespace esphome

--- a/esphome/components/mpr121/binary_sensor/mpr121_binary_sensor.h
+++ b/esphome/components/mpr121/binary_sensor/mpr121_binary_sensor.h
@@ -9,7 +9,6 @@ namespace mpr121 {
 
 class MPR121BinarySensor : public binary_sensor::BinarySensor, public MPR121Channel, public Parented<MPR121Component> {
  public:
-  void set_parent(MPR121Component *parent) { this->parent_ = parent; }
   void set_channel(uint8_t channel) { this->channel_ = channel; }
   void set_touch_threshold(uint8_t touch_threshold) { this->touch_threshold_ = touch_threshold; };
   void set_release_threshold(uint8_t release_threshold) { this->release_threshold_ = release_threshold; };

--- a/esphome/components/mpr121/binary_sensor/mpr121_binary_sensor.h
+++ b/esphome/components/mpr121/binary_sensor/mpr121_binary_sensor.h
@@ -9,6 +9,7 @@ namespace mpr121 {
 
 class MPR121BinarySensor : public binary_sensor::BinarySensor, public MPR121Channel, public Parented<MPR121Component> {
  public:
+  void set_parent(MPR121Component *parent) { this->parent_ = parent; }
   void set_channel(uint8_t channel) { this->channel_ = channel; }
   void set_touch_threshold(uint8_t touch_threshold) { this->touch_threshold_ = touch_threshold; };
   void set_release_threshold(uint8_t release_threshold) { this->release_threshold_ = release_threshold; };

--- a/tests/components/mpr121/common.yaml
+++ b/tests/components/mpr121/common.yaml
@@ -1,0 +1,41 @@
+i2c:
+  - id: i2c_mpr121
+    scl: ${i2c_scl}
+    sda: ${i2c_sda}
+
+mpr121:
+  id: mpr121_first
+  address: 0x5A
+
+binary_sensor:
+  - platform: mpr121
+    id: touchkey0
+    name: touchkey0
+    channel: 0
+  - platform: mpr121
+    id: bin1
+    name: touchkey1
+    channel: 1
+  - platform: mpr121
+    id: bin2
+    name: touchkey2
+    channel: 2
+  - platform: mpr121
+    id: bin3
+    name: touchkey3
+    channel: 6
+
+output:
+  - platform: gpio
+    id: gpio1
+    pin:
+      mpr121: mpr121_first
+      number: 7
+      mode: OUTPUT
+  - platform: gpio
+    id: gpio2
+    pin:
+      mpr121: mpr121_first
+      number: 11
+      mode: OUTPUT
+      inverted: true

--- a/tests/components/mpr121/test.esp32-c3-idf.yaml
+++ b/tests/components/mpr121/test.esp32-c3-idf.yaml
@@ -1,41 +1,5 @@
-i2c:
-  - id: i2c_mpr121
-    scl: 5
-    sda: 4
+substitutions:
+  i2c_scl: GPIO5
+  i2c_sda: GPIO4
 
-mpr121:
-  id: mpr121_first
-  address: 0x5A
-
-binary_sensor:
-  - platform: mpr121
-    id: touchkey0
-    name: touchkey0
-    channel: 0
-  - platform: mpr121
-    id: bin1
-    name: touchkey1
-    channel: 1
-  - platform: mpr121
-    id: bin2
-    name: touchkey2
-    channel: 2
-  - platform: mpr121
-    id: bin3
-    name: touchkey3
-    channel: 3
-
-output:
-  - platform: gpio
-    id: gpio1
-    pin:
-      mpr121_id: mpr121_first
-      number: 4
-      mode: OUTPUT
-  - platform: gpio
-    id: gpio2
-    pin:
-      mpr121_id: mpr121_first
-      number: 11
-      mode: OUTPUT
-      inverted: true
+<<: !include common.yaml

--- a/tests/components/mpr121/test.esp32-c3-idf.yaml
+++ b/tests/components/mpr121/test.esp32-c3-idf.yaml
@@ -24,3 +24,18 @@ binary_sensor:
     id: bin3
     name: touchkey3
     channel: 3
+
+output:
+  - platform: gpio
+    id: gpio1
+    pin:
+      mpr121_id: mpr121_first
+      number: 4
+      mode: OUTPUT
+  - platform: gpio
+    id: gpio2
+    pin:
+      mpr121_id: mpr121_first
+      number: 11
+      mode: OUTPUT
+      inverted: true

--- a/tests/components/mpr121/test.esp32-c3.yaml
+++ b/tests/components/mpr121/test.esp32-c3.yaml
@@ -1,41 +1,5 @@
-i2c:
-  - id: i2c_mpr121
-    scl: 5
-    sda: 4
+substitutions:
+  i2c_scl: GPIO5
+  i2c_sda: GPIO4
 
-mpr121:
-  id: mpr121_first
-  address: 0x5A
-
-binary_sensor:
-  - platform: mpr121
-    id: touchkey0
-    name: touchkey0
-    channel: 0
-  - platform: mpr121
-    id: bin1
-    name: touchkey1
-    channel: 1
-  - platform: mpr121
-    id: bin2
-    name: touchkey2
-    channel: 2
-  - platform: mpr121
-    id: bin3
-    name: touchkey3
-    channel: 3
-
-output:
-  - platform: gpio
-    id: gpio1
-    pin:
-      mpr121_id: mpr121_first
-      number: 4
-      mode: OUTPUT
-  - platform: gpio
-    id: gpio2
-    pin:
-      mpr121_id: mpr121_first
-      number: 11
-      mode: OUTPUT
-      inverted: true
+<<: !include common.yaml

--- a/tests/components/mpr121/test.esp32-c3.yaml
+++ b/tests/components/mpr121/test.esp32-c3.yaml
@@ -24,3 +24,18 @@ binary_sensor:
     id: bin3
     name: touchkey3
     channel: 3
+
+output:
+  - platform: gpio
+    id: gpio1
+    pin:
+      mpr121_id: mpr121_first
+      number: 4
+      mode: OUTPUT
+  - platform: gpio
+    id: gpio2
+    pin:
+      mpr121_id: mpr121_first
+      number: 11
+      mode: OUTPUT
+      inverted: true

--- a/tests/components/mpr121/test.esp32-idf.yaml
+++ b/tests/components/mpr121/test.esp32-idf.yaml
@@ -1,41 +1,5 @@
-i2c:
-  - id: i2c_mpr121
-    scl: 16
-    sda: 17
+substitutions:
+  i2c_scl: GPIO16
+  i2c_sda: GPIO17
 
-mpr121:
-  id: mpr121_first
-  address: 0x5A
-
-binary_sensor:
-  - platform: mpr121
-    id: touchkey0
-    name: touchkey0
-    channel: 0
-  - platform: mpr121
-    id: bin1
-    name: touchkey1
-    channel: 1
-  - platform: mpr121
-    id: bin2
-    name: touchkey2
-    channel: 2
-  - platform: mpr121
-    id: bin3
-    name: touchkey3
-    channel: 3
-
-output:
-  - platform: gpio
-    id: gpio1
-    pin:
-      mpr121_id: mpr121_first
-      number: 4
-      mode: OUTPUT
-  - platform: gpio
-    id: gpio2
-    pin:
-      mpr121_id: mpr121_first
-      number: 11
-      mode: OUTPUT
-      inverted: true
+<<: !include common.yaml

--- a/tests/components/mpr121/test.esp32-idf.yaml
+++ b/tests/components/mpr121/test.esp32-idf.yaml
@@ -24,3 +24,18 @@ binary_sensor:
     id: bin3
     name: touchkey3
     channel: 3
+
+output:
+  - platform: gpio
+    id: gpio1
+    pin:
+      mpr121_id: mpr121_first
+      number: 4
+      mode: OUTPUT
+  - platform: gpio
+    id: gpio2
+    pin:
+      mpr121_id: mpr121_first
+      number: 11
+      mode: OUTPUT
+      inverted: true

--- a/tests/components/mpr121/test.esp32.yaml
+++ b/tests/components/mpr121/test.esp32.yaml
@@ -1,41 +1,5 @@
-i2c:
-  - id: i2c_mpr121
-    scl: 16
-    sda: 17
+substitutions:
+  i2c_scl: GPIO16
+  i2c_sda: GPIO17
 
-mpr121:
-  id: mpr121_first
-  address: 0x5A
-
-binary_sensor:
-  - platform: mpr121
-    id: touchkey0
-    name: touchkey0
-    channel: 0
-  - platform: mpr121
-    id: bin1
-    name: touchkey1
-    channel: 1
-  - platform: mpr121
-    id: bin2
-    name: touchkey2
-    channel: 2
-  - platform: mpr121
-    id: bin3
-    name: touchkey3
-    channel: 3
-
-output:
-  - platform: gpio
-    id: gpio1
-    pin:
-      mpr121_id: mpr121_first
-      number: 4
-      mode: OUTPUT
-  - platform: gpio
-    id: gpio2
-    pin:
-      mpr121_id: mpr121_first
-      number: 11
-      mode: OUTPUT
-      inverted: true
+<<: !include common.yaml

--- a/tests/components/mpr121/test.esp32.yaml
+++ b/tests/components/mpr121/test.esp32.yaml
@@ -24,3 +24,18 @@ binary_sensor:
     id: bin3
     name: touchkey3
     channel: 3
+
+output:
+  - platform: gpio
+    id: gpio1
+    pin:
+      mpr121_id: mpr121_first
+      number: 4
+      mode: OUTPUT
+  - platform: gpio
+    id: gpio2
+    pin:
+      mpr121_id: mpr121_first
+      number: 11
+      mode: OUTPUT
+      inverted: true

--- a/tests/components/mpr121/test.esp8266.yaml
+++ b/tests/components/mpr121/test.esp8266.yaml
@@ -1,41 +1,5 @@
-i2c:
-  - id: i2c_mpr121
-    scl: 5
-    sda: 4
+substitutions:
+  i2c_scl: GPIO5
+  i2c_sda: GPIO4
 
-mpr121:
-  id: mpr121_first
-  address: 0x5A
-
-binary_sensor:
-  - platform: mpr121
-    id: touchkey0
-    name: touchkey0
-    channel: 0
-  - platform: mpr121
-    id: bin1
-    name: touchkey1
-    channel: 1
-  - platform: mpr121
-    id: bin2
-    name: touchkey2
-    channel: 2
-  - platform: mpr121
-    id: bin3
-    name: touchkey3
-    channel: 3
-
-output:
-  - platform: gpio
-    id: gpio1
-    pin:
-      mpr121_id: mpr121_first
-      number: 4
-      mode: OUTPUT
-  - platform: gpio
-    id: gpio2
-    pin:
-      mpr121_id: mpr121_first
-      number: 11
-      mode: OUTPUT
-      inverted: true
+<<: !include common.yaml

--- a/tests/components/mpr121/test.esp8266.yaml
+++ b/tests/components/mpr121/test.esp8266.yaml
@@ -24,3 +24,18 @@ binary_sensor:
     id: bin3
     name: touchkey3
     channel: 3
+
+output:
+  - platform: gpio
+    id: gpio1
+    pin:
+      mpr121_id: mpr121_first
+      number: 4
+      mode: OUTPUT
+  - platform: gpio
+    id: gpio2
+    pin:
+      mpr121_id: mpr121_first
+      number: 11
+      mode: OUTPUT
+      inverted: true

--- a/tests/components/mpr121/test.rp2040.yaml
+++ b/tests/components/mpr121/test.rp2040.yaml
@@ -1,41 +1,5 @@
-i2c:
-  - id: i2c_mpr121
-    scl: 5
-    sda: 4
+substitutions:
+  i2c_scl: GPIO5
+  i2c_sda: GPIO4
 
-mpr121:
-  id: mpr121_first
-  address: 0x5A
-
-binary_sensor:
-  - platform: mpr121
-    id: touchkey0
-    name: touchkey0
-    channel: 0
-  - platform: mpr121
-    id: bin1
-    name: touchkey1
-    channel: 1
-  - platform: mpr121
-    id: bin2
-    name: touchkey2
-    channel: 2
-  - platform: mpr121
-    id: bin3
-    name: touchkey3
-    channel: 3
-
-output:
-  - platform: gpio
-    id: gpio1
-    pin:
-      mpr121_id: mpr121_first
-      number: 4
-      mode: OUTPUT
-  - platform: gpio
-    id: gpio2
-    pin:
-      mpr121_id: mpr121_first
-      number: 11
-      mode: OUTPUT
-      inverted: true
+<<: !include common.yaml

--- a/tests/components/mpr121/test.rp2040.yaml
+++ b/tests/components/mpr121/test.rp2040.yaml
@@ -24,3 +24,18 @@ binary_sensor:
     id: bin3
     name: touchkey3
     channel: 3
+
+output:
+  - platform: gpio
+    id: gpio1
+    pin:
+      mpr121_id: mpr121_first
+      number: 4
+      mode: OUTPUT
+  - platform: gpio
+    id: gpio2
+    pin:
+      mpr121_id: mpr121_first
+      number: 11
+      mode: OUTPUT
+      inverted: true

--- a/tests/test3.1.yaml
+++ b/tests/test3.1.yaml
@@ -344,10 +344,6 @@ apds9960:
   address: 0x20
   update_interval: 60s
 
-mpr121:
-  id: mpr121_first
-  address: 0x5A
-
 binary_sensor:
   - platform: apds9960
     direction: up
@@ -371,25 +367,6 @@ binary_sensor:
     direction: right
     name: APDS9960 Right
 
-  - platform: mpr121
-    id: touchkey0
-    channel: 0
-    name: touchkey0
-  - platform: mpr121
-    channel: 1
-    name: touchkey1
-    id: bin1
-  - platform: mpr121
-    channel: 2
-    name: touchkey2
-    id: bin2
-  - platform: mpr121
-    channel: 3
-    name: touchkey3
-    id: bin3
-    on_press:
-      then:
-        - switch.toggle: mpr121_toggle
   - platform: ttp229_lsf
     channel: 1
     name: TTP229 LSF Test
@@ -443,10 +420,6 @@ grove_tb6612fng:
   address: 0x14
 
 switch:
-  - platform: template
-    name: mpr121_toggle
-    id: mpr121_toggle
-    optimistic: true
   - platform: gpio
     id: gpio_switch1
     pin:


### PR DESCRIPTION
# What does this implement/fix?

The MPR121 touch controller also supports alternate modes of operation as GPIO controller on the upper 8 of its 12 input channels.

This patch makes it possible to configure such channels as GPIO.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes [esphome/feature-requests/issues/1838](https://github.com/esphome/feature-requests/issues/1838)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#3845

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

i2c:
  sda: 26
  scl: 27

mpr121:
  id: mpr121_component
  address: 0x5A
  touch_debounce: 1
  release_debounce: 1
  touch_threshold: 10
  release_threshold: 7

binary_sensor:
  - platform: mpr121
    id: touch_LEFT
    channel: 7
    name: "Touch Left"

output:
  - id: ext_5v_power
    platform: gpio
    pin:
      mpr121_id: mpr121_component
      number: 10
      mode: OUTPUT
      inverted: true
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs). -> https://github.com/esphome/esphome-docs/pull/3845
