### PR TITLE
Revert "Fix MQTT dashboard discovery (Exception in MqttStatusThread)."

### DIFF
--- a/esphome/dashboard/status/mqtt.py
+++ b/esphome/dashboard/status/mqtt.py
@@ -18,7 +18,7 @@ class MqttStatusThread(threading.Thread):
         """Run the status thread."""
         dashboard = DASHBOARD
         entries = dashboard.entries
-        current_entries = entries.async_all()
+        current_entries = entries.all()
 
         config = mqtt.config_from_env()
         topic = "esphome/discover/#"
@@ -33,7 +33,7 @@ class MqttStatusThread(threading.Thread):
                     return
                 for entry in current_entries:
                     if entry.name == data["name"]:
-                        entries.async_set_state(entry, EntryState.ONLINE)
+                        entries.set_state(entry, EntryState.ONLINE)
                         return
 
         def on_connect(client, userdata, flags, return_code):
@@ -53,11 +53,11 @@ class MqttStatusThread(threading.Thread):
         client.loop_start()
 
         while not dashboard.stop_event.wait(2):
-            current_entries = entries.async_all()
+            current_entries = entries.all()
             # will be set to true on on_message
             for entry in current_entries:
                 if entry.no_mdns:
-                    entries.async_set_state(entry, EntryState.OFFLINE)
+                    entries.set_state(entry, EntryState.OFFLINE)
 
             client.publish("esphome/discover", None, retain=False)
             dashboard.mqtt_ping_request.wait()


### PR DESCRIPTION
Reverts esphome/esphome#6775

This change introduced non-thread-safe operations by calling the async API from a thread.

https://docs.python.org/3/library/asyncio-dev.html#concurrency-and-multithreading
> Almost all asyncio objects are not thread safe, which is typically not a problem unless there is code that works with them from outside of a Task or a callback.

https://github.com/esphome/esphome/pull/6783 fixes the error in `DashboardEntries.all()`