### PR TITLE
[remote_receiver] Add better error message for tolerance breaking change

### DIFF
--- a/esphome/components/remote_receiver/__init__.py
+++ b/esphome/components/remote_receiver/__init__.py
@@ -63,7 +63,13 @@ def validate_tolerance(value):
     if "%" in str(value):
         type_ = TYPE_PERCENTAGE
     else:
-        type_ = TYPE_TIME
+        try:
+            cv.positive_time_period_microseconds(value)
+            type_ = TYPE_TIME
+        except cv.Invalid as exc:
+            raise cv.Invalid(
+                "Tolerance must be a percentage or time. Configurations made before 2024.5.0 treated the value as a percentage."
+            ) from exc
 
     return TOLERANCE_SCHEMA(
         {

--- a/tests/components/remote_receiver/esp32-common.yaml
+++ b/tests/components/remote_receiver/esp32-common.yaml
@@ -3,6 +3,7 @@ remote_receiver:
   pin: ${pin}
   rmt_channel: ${rmt_channel}
   dump: all
+  tolerance: 25%
   on_abbwelcome:
     then:
       - logger.log:


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

#4642 introduced a breaking change which gave a misleading error message with older configurations.

<details>
<summary>Before</summary>

```
Failed config

remote_receiver: [source ./tests/test_build_components/build/../../../tests/components/remote_receiver/esp32-common.yaml:1]
  - id: rcvr
    pin: GPIO2
    rmt_channel: 2
    dump: all
    
    Don't know what '25' means as it has no time *unit*! Did you mean '25s'?.
    tolerance: 25
    on_abbwelcome: 
      then: 
        - logger.log: 
            format: on_abbwelcome: %u
            args: 
              - x.data()[0]
    on_aeha:
```

</details>

<details>
<summary>After</summary>

```
Failed config

remote_receiver: [source ./tests/test_build_components/build/../../../tests/components/remote_receiver/esp32-common.yaml:1]
  - id: rcvr
    pin: GPIO2
    rmt_channel: 2
    dump: all
    
    Tolerance must be a percentage or time. Configurations made before 2024.5.0 treated the value as a percentage.
    tolerance: 25
    on_abbwelcome: 
      then: 
        - logger.log: 
            format: on_abbwelcome: %u
            args: 
              - x.data()[0]
    on_aeha: 
```

</details>

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
