### PR TITLE
[config] Retain path information in validated configuration

### DIFF
--- a/esphome/config.py
+++ b/esphome/config.py
@@ -1123,4 +1123,4 @@ def read_config(command_line_substitutions):
             safe_print("")
 
         return None
-    return OrderedDict(res)
+    return res

--- a/esphome/config.py
+++ b/esphome/config.py
@@ -23,7 +23,7 @@ from esphome.const import (
     CONF_EXTERNAL_COMPONENTS,
     TARGET_PLATFORMS,
 )
-from esphome.core import CORE, EsphomeError
+from esphome.core import CORE, EsphomeError, DocumentRange
 from esphome.helpers import indent
 from esphome.util import safe_print, OrderedDict
 
@@ -184,7 +184,7 @@ class Config(OrderedDict, fv.FinalValidateConfig):
 
     def get_deepest_document_range_for_path(
         self, path: ConfigPath, get_key: bool = False
-    ) -> ESPHomeDataBase | None:
+    ) -> DocumentRange | None:
         data = self
         doc_range = None
         for index, path_item in enumerate(path):


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->


Currently  `read_config()` in `esphome/config.py` strips the path information from its validated config before returning.

By retaining that information, components can retrieve the source file and line associated with Ids during code generation, allowing line number directives to be inserted - e.g.:

```
      #line 462 "lvgl-package.yaml"
      lv_button = lv_btn_create(main_page->page);
```
This is already done in ESPHome for lambdas, which capture the path information which can be very helpful in identifying C++ code errors.

This is used by the LVGL PR, broken out here to keep core changes from the component PR.


## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
