### PR TITLE
Add on_safe_mode trigger

### DIFF
--- a/esphome/components/safe_mode/automation.h
+++ b/esphome/components/safe_mode/automation.h
@@ -1,0 +1,17 @@
+#pragma once
+#include "safe_mode.h"
+
+#include "esphome/core/automation.h"
+
+namespace esphome {
+namespace safe_mode {
+
+class SafeModeTrigger : public Trigger<> {
+ public:
+  explicit SafeModeTrigger(SafeModeComponent *parent) {
+    parent->add_on_safe_mode_callback([this, parent]() { trigger(); });
+  }
+};
+
+}  // namespace safe_mode
+}  // namespace esphome

--- a/esphome/components/safe_mode/safe_mode.cpp
+++ b/esphome/components/safe_mode/safe_mode.cpp
@@ -94,6 +94,8 @@ bool SafeModeComponent::should_enter_safe_mode(uint8_t num_attempts, uint32_t en
 
     ESP_LOGW(TAG, "SAFE MODE IS ACTIVE");
 
+    this->safe_mode_callback_.call();
+
     return true;
   } else {
     // increment counter

--- a/esphome/components/safe_mode/safe_mode.h
+++ b/esphome/components/safe_mode/safe_mode.h
@@ -25,6 +25,10 @@ class SafeModeComponent : public Component {
 
   void on_safe_shutdown() override;
 
+  void add_on_safe_mode_callback(std::function<void()> &&callback) {
+    this->safe_mode_callback_.add(std::move(callback));
+  }
+
  protected:
   void write_rtc_(uint32_t val);
   uint32_t read_rtc_();
@@ -35,6 +39,7 @@ class SafeModeComponent : public Component {
   uint32_t safe_mode_rtc_value_;
   uint8_t safe_mode_num_attempts_;
   ESPPreferenceObject rtc_;
+  CallbackManager<void()> safe_mode_callback_{};
 
   static const uint32_t ENTER_SAFE_MODE_MAGIC =
       0x5afe5afe;  ///< a magic number to indicate that safe mode should be entered on next boot

--- a/tests/components/safe_mode/common.yaml
+++ b/tests/components/safe_mode/common.yaml
@@ -5,6 +5,8 @@ wifi:
 safe_mode:
   num_attempts: 3
   reboot_timeout: 2min
+  on_safe_mode:
+    - logger.log: Time for safe mode
 
 button:
   - platform: safe_mode


### PR DESCRIPTION
# What does this implement/fix?

Adds an `on_safe_mode` trigger, called only when safe mode is invoked.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#3857

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
safe_mode:
  on_safe_mode:
    - logger.log: Time for safe mode...
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
