### PR TITLE
Add carrier_frequency option to remote_transmitter.transmit_aeha

### DIFF
--- a/esphome/components/remote_base/__init__.py
+++ b/esphome/components/remote_base/__init__.py
@@ -1769,7 +1769,17 @@ def aeha_dumper(var, config):
     pass
 
 
-@register_action("aeha", AEHAAction, AEHA_SCHEMA)
+@register_action(
+    "aeha",
+    AEHAAction,
+    AEHA_SCHEMA.extend(
+        {
+            cv.Optional(CONF_CARRIER_FREQUENCY, default="38000Hz"): cv.All(
+                cv.frequency, cv.int_
+            ),
+        }
+    ),
+)
 async def aeha_action(var, config, args):
     template_ = await cg.templatable(config[CONF_ADDRESS], args, cg.uint16)
     cg.add(var.set_address(template_))
@@ -1777,6 +1787,8 @@ async def aeha_action(var, config, args):
         config[CONF_DATA], args, cg.std_vector.template(cg.uint8)
     )
     cg.add(var.set_data(template_))
+    templ = await cg.templatable(config[CONF_CARRIER_FREQUENCY], args, cg.uint32)
+    cg.add(var.set_carrier_frequency(templ))
 
 
 # Haier

--- a/esphome/components/remote_base/aeha_protocol.cpp
+++ b/esphome/components/remote_base/aeha_protocol.cpp
@@ -16,7 +16,6 @@ static const uint16_t BIT_ZERO_LOW_US = BITWISE;
 static const uint16_t TRAILER = BITWISE;
 
 void AEHAProtocol::encode(RemoteTransmitData *dst, const AEHAData &data) {
-  dst->set_carrier_frequency(38000);
   dst->reserve(2 + 32 + (data.data.size() * 2) + 1);
 
   dst->item(HEADER_HIGH_US, HEADER_LOW_US);

--- a/esphome/components/remote_base/aeha_protocol.h
+++ b/esphome/components/remote_base/aeha_protocol.h
@@ -30,12 +30,14 @@ template<typename... Ts> class AEHAAction : public RemoteTransmitterActionBase<T
  public:
   TEMPLATABLE_VALUE(uint16_t, address)
   TEMPLATABLE_VALUE(std::vector<uint8_t>, data)
+  TEMPLATABLE_VALUE(uint32_t, carrier_frequency);
 
   void set_data(const std::vector<uint8_t> &data) { data_ = data; }
   void encode(RemoteTransmitData *dst, Ts... x) override {
     AEHAData data{};
     data.address = this->address_.value(x...);
     data.data = this->data_.value(x...);
+    dst->set_carrier_frequency(this->carrier_frequency_.value(x...));
     AEHAProtocol().encode(dst, data);
   }
 };

--- a/tests/components/remote_transmitter/common-buttons.yaml
+++ b/tests/components/remote_transmitter/common-buttons.yaml
@@ -118,6 +118,7 @@ button:
     on_press:
       remote_transmitter.transmit_aeha:
         address: 0x8008
+        carrier_frequency: 36700Hz
         data:
           [
             0x00,

--- a/tests/test1.yaml
+++ b/tests/test1.yaml
@@ -2906,6 +2906,7 @@ switch:
     turn_on_action:
       remote_transmitter.transmit_aeha:
         address: 0x8008
+        carrier_frequency: 36700Hz
         data:
           [
             0x00,


### PR DESCRIPTION
# What does this implement/fix?

Add `carrier_frequency` option for `remote_transmitter.transmit_aeha`. Defaults to `38000Hz`, which is the previous value. No configuration changes are necessary for those who don't need the new functionality.

Many Panasonic devices use a carrier frequency of 36.7kHz. My device works best with AEHA transmissions. So far, the AEHA carrier frequency was hardcoded as 38kHz. This pull request now allows (optionally) specifying the carrier_frequency. 

Most changes were copy-pasted from the `transmit_raw` function.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#3859

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
button:
  - platform: template
    name: "Test AEHA transmission"
    on_press:
      then:
        - remote_transmitter.transmit_aeha:
            address: 0x4004
            data: [0x00,0x10,0x0F,0x34,0xCB,0x00,0x40]
            carrier_frequency: 36700Hz
            repeat:
              times: 2
              wait_time:
                milliseconds: 25
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
