### PR TITLE
[ledc] Change some logging lines from debug to verbose

### DIFF
--- a/esphome/components/ledc/ledc_output.cpp
+++ b/esphome/components/ledc/ledc_output.cpp
@@ -52,12 +52,12 @@ float ledc_min_frequency_for_bit_depth(uint8_t bit_depth, bool low_frequency) {
 }
 
 optional<uint8_t> ledc_bit_depth_for_frequency(float frequency) {
-  ESP_LOGD(TAG, "Calculating resolution bit-depth for frequency %f", frequency);
+  ESP_LOGV(TAG, "Calculating resolution bit-depth for frequency %f", frequency);
   for (int i = MAX_RES_BITS; i >= 1; i--) {
     const float min_frequency = ledc_min_frequency_for_bit_depth(i, (frequency < 100));
     const float max_frequency = ledc_max_frequency_for_bit_depth(i);
     if (min_frequency <= frequency && frequency <= max_frequency) {
-      ESP_LOGD(TAG, "Resolution calculated as %d", i);
+      ESP_LOGV(TAG, "Resolution calculated as %d", i);
       return i;
     }
   }


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

I noticed these lines being logged a lot when using rtttl which changes the frequency. They are not needed most of the time, so move them to VERBOSE level.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
