### PR TITLE
[tuya] add support for extended services

### DIFF
--- a/esphome/components/tuya/tuya.cpp
+++ b/esphome/components/tuya/tuya.cpp
@@ -270,8 +270,8 @@ void Tuya::handle_command_(uint8_t command, uint8_t version, const uint8_t *buff
       break;
     }
     case TuyaCommandType::EXTENDED_SERVICES: {
-      TuyaExtendedServicesCommandType subcommand = (TuyaExtendedServicesCommandType) buffer[0];
-      switch (subcommand) {
+      uint8_t subcommand = buffer[0];
+      switch ((TuyaExtendedServicesCommandType) subcommand) {
         case TuyaExtendedServicesCommandType::RESET_NOTIFICATION: {
           this->send_command_(
               TuyaCommand{.cmd = TuyaCommandType::EXTENDED_SERVICES,
@@ -289,7 +289,7 @@ void Tuya::handle_command_(uint8_t command, uint8_t version, const uint8_t *buff
           break;
         }
         default:
-          ESP_LOGE(TAG, "Invalid extended services subcommand (0x%02X) received", static_cast<uint8_t>(subcommand));
+          ESP_LOGE(TAG, "Invalid extended services subcommand (0x%02X) received", subcommand);
           break;
       }
     }

--- a/esphome/components/tuya/tuya.cpp
+++ b/esphome/components/tuya/tuya.cpp
@@ -290,8 +290,8 @@ void Tuya::handle_command_(uint8_t command, uint8_t version, const uint8_t *buff
         }
         default:
           ESP_LOGE(TAG, "Invalid extended services subcommand (0x%02X) received", subcommand);
-          break;
       }
+      break;
     }
     default:
       ESP_LOGE(TAG, "Invalid command (0x%02X) received", command);

--- a/esphome/components/tuya/tuya.cpp
+++ b/esphome/components/tuya/tuya.cpp
@@ -289,7 +289,8 @@ void Tuya::handle_command_(uint8_t command, uint8_t version, const uint8_t *buff
           break;
         }
         default:
-          ESP_LOGE(TAG, "Invalid extended services subcommand (0x%02X) received", subcommand);
+          ESP_LOGE(TAG, "Invalid extended services subcommand (0x%02X) received", static_cast<uint8_t>(subcommand));
+          break;
       }
     }
     default:

--- a/esphome/components/tuya/tuya.cpp
+++ b/esphome/components/tuya/tuya.cpp
@@ -269,6 +269,29 @@ void Tuya::handle_command_(uint8_t command, uint8_t version, const uint8_t *buff
       ESP_LOGV(TAG, "Network status requested, reported as %i", wifi_status);
       break;
     }
+    case TuyaCommandType::EXTENDED_SERVICES: {
+      TuyaExtendedServicesCommandType subcommand = (TuyaExtendedServicesCommandType) buffer[0];
+      switch (subcommand) {
+        case TuyaExtendedServicesCommandType::RESET_NOTIFICATION: {
+          this->send_command_(
+              TuyaCommand{.cmd = TuyaCommandType::EXTENDED_SERVICES,
+                          .payload = std::vector<uint8_t>{
+                              static_cast<uint8_t>(TuyaExtendedServicesCommandType::RESET_NOTIFICATION), 0x00}});
+          ESP_LOGV(TAG, "Reset status notification enabled");
+          break;
+        }
+        case TuyaExtendedServicesCommandType::MODULE_RESET: {
+          ESP_LOGE(TAG, "EXTENDED_SERVICES::MODULE_RESET is not handled");
+          break;
+        }
+        case TuyaExtendedServicesCommandType::UPDATE_IN_PROGRESS: {
+          ESP_LOGE(TAG, "EXTENDED_SERVICES::UPDATE_IN_PROGRESS is not handled");
+          break;
+        }
+        default:
+          ESP_LOGE(TAG, "Invalid extended services subcommand (0x%02X) received", subcommand);
+      }
+    }
     default:
       ESP_LOGE(TAG, "Invalid command (0x%02X) received", command);
   }

--- a/esphome/components/tuya/tuya.h
+++ b/esphome/components/tuya/tuya.h
@@ -60,6 +60,13 @@ enum class TuyaCommandType : uint8_t {
   WIFI_RSSI = 0x24,
   VACUUM_MAP_UPLOAD = 0x28,
   GET_NETWORK_STATUS = 0x2B,
+  EXTENDED_SERVICES = 0x34,
+};
+
+enum class TuyaExtendedServicesCommandType : uint8_t {
+  RESET_NOTIFICATION = 0x04,
+  MODULE_RESET = 0x05,
+  UPDATE_IN_PROGRESS = 0x0A,
 };
 
 enum class TuyaInitState : uint8_t {


### PR DESCRIPTION
# What does this implement/fix?

Add support for [Tuya Serial Protocol Extended Services](https://developer.tuya.com/en/docs/iot/serial-port-protocol?id=Kaabj8xagrchw#title-123-Extended%20services) to suppress errors like the following:

`[21:36:05][E][tuya:273]: Invalid command (0x34) received`

see discussion on https://www.reddit.com/r/Esphome/comments/1cxq6m4/milfra_mfa05f_motion_switch/ 

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** N/A
**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [x] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
uart:
  rx_pin: RX1
  tx_pin: TX1
  baud_rate: 9600

tuya:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
