### PR TITLE
Fix incorrect naming of the AdaFruit MagTag display.

### DIFF
--- a/esphome/components/waveshare_epaper/display.py
+++ b/esphome/components/waveshare_epaper/display.py
@@ -48,7 +48,7 @@ WaveshareEPaper2P9InBV3 = waveshare_epaper_ns.class_(
 WaveshareEPaper2P9InV2R2 = waveshare_epaper_ns.class_(
     "WaveshareEPaper2P9InV2R2", WaveshareEPaper
 )
-GDEY029T94 = waveshare_epaper_ns.class_("GDEY029T94", WaveshareEPaper)
+GDEW029T5 = waveshare_epaper_ns.class_("GDEW029T5", WaveshareEPaper)
 WaveshareEPaper2P9InDKE = waveshare_epaper_ns.class_(
     "WaveshareEPaper2P9InDKE", WaveshareEPaper
 )
@@ -110,7 +110,7 @@ MODELS = {
     "2.13in-ttgo-b74": ("a", WaveshareEPaperTypeAModel.TTGO_EPAPER_2_13_IN_B74),
     "2.90in": ("a", WaveshareEPaperTypeAModel.WAVESHARE_EPAPER_2_9_IN),
     "2.90inv2": ("a", WaveshareEPaperTypeAModel.WAVESHARE_EPAPER_2_9_IN_V2),
-    "gdey029t94": ("c", GDEY029T94),
+    "gdew029t5": ("c", GDEW029T5),
     "2.70in": ("b", WaveshareEPaper2P7In),
     "2.70in-b": ("b", WaveshareEPaper2P7InB),
     "2.70in-bv2": ("b", WaveshareEPaper2P7InBV2),

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -1514,7 +1514,7 @@ void WaveshareEPaper2P9InV2R2::set_full_update_every(uint32_t full_update_every)
 //  - https://github.com/adafruit/Adafruit_EPD/blob/master/src/panels/ThinkInk_290_Grayscale4_T5.h
 // ========================================================
 
-void GDEY029T94::initialize() {
+void GDEW029T5::initialize() {
   // from https://www.waveshare.com/w/upload/b/bb/2.9inch-e-paper-b-specification.pdf, page 37
   // EPD hardware init start
   this->reset_();
@@ -1560,7 +1560,7 @@ void GDEY029T94::initialize() {
 
   // EPD hardware init end
 }
-void HOT GDEY029T94::display() {
+void HOT GDEW029T5::display() {
   // COMMAND DATA START TRANSMISSION 2 (B/W only)
   this->command(0x13);
   delay(2);
@@ -1580,11 +1580,11 @@ void HOT GDEY029T94::display() {
   // NOTE: power off < deep sleep
   this->command(0x02);
 }
-int GDEY029T94::get_width_internal() { return 128; }
-int GDEY029T94::get_height_internal() { return 296; }
-void GDEY029T94::dump_config() {
+int GDEW029T5::get_width_internal() { return 128; }
+int GDEW029T5::get_height_internal() { return 296; }
+void GDEW029T5::dump_config() {
   LOG_DISPLAY("", "Waveshare E-Paper (Good Display)", this);
-  ESP_LOGCONFIG(TAG, "  Model: 2.9in Greyscale GDEY029T94");
+  ESP_LOGCONFIG(TAG, "  Model: 2.9in Greyscale GDEW029T5");
   LOG_PIN("  Reset Pin: ", this->reset_pin_);
   LOG_PIN("  DC Pin: ", this->dc_pin_);
   LOG_PIN("  Busy Pin: ", this->busy_pin_);

--- a/esphome/components/waveshare_epaper/waveshare_epaper.h
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.h
@@ -227,7 +227,7 @@ class WaveshareEPaper2P7InBV2 : public WaveshareEPaperBWR {
   int get_height_internal() override;
 };
 
-class GDEY029T94 : public WaveshareEPaper {
+class GDEW029T5 : public WaveshareEPaper {
  public:
   void initialize() override;
 


### PR DESCRIPTION
# What does this implement/fix?

After unsuccessfully trying to configure my GDEY029T94 e-paper display, I looked into the code, and realized, that the implemented display is a different model GDEW029T5. This was confirmed on Discord by the author of the original pull request, as well as in the [issue 3514](https://github.com/esphome/issues/issues/3514), whose author also owns the MagTag. This is a breaking change for anyone using the display, since it renames the config option, but the config option is misleading since the actual GDEY029T94 does not work with it.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** /

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#3871

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
spi:
  clk_pin: 18
  mosi_pin: 23

display:
  - platform: waveshare_epaper
    cs_pin: 5
    dc_pin: 17
    busy_pin: 4
    reset_pin: 16
    model: gdew029t5
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
