### PR TITLE
Fix printf compile errors in remote_base for long 32bit values

### DIFF
--- a/esphome/components/remote_base/abbwelcome_protocol.h
+++ b/esphome/components/remote_base/abbwelcome_protocol.h
@@ -144,7 +144,7 @@ class ABBWelcomeData {
   std::string to_string(uint8_t max_print_bytes = 255) const {
     std::string info;
     if (this->is_valid()) {
-      info = str_sprintf(this->get_three_byte_address() ? "[%06X %s %06X] Type: %02X" : "[%04X %s %04X] Type: %02X",
+      info = str_sprintf(this->get_three_byte_address() ? "[%06lX %s %06lX] Type: %02X" : "[%04lX %s %04lX] Type: %02X",
                          this->get_source_address(), this->get_retransmission() ? "»" : ">",
                          this->get_destination_address(), this->get_message_type());
       if (this->get_data_size())

--- a/esphome/components/remote_base/byronsx_protocol.cpp
+++ b/esphome/components/remote_base/byronsx_protocol.cpp
@@ -57,7 +57,7 @@ void ByronSXProtocol::encode(RemoteTransmitData *dst, const ByronSXData &data) {
   out_data <<= NBITS_COMMAND;
   out_data |= data.command;
 
-  ESP_LOGV(TAG, "Send ByronSX: out_data %03x", out_data);
+  ESP_LOGV(TAG, "Send ByronSX: out_data %03lx", out_data);
 
   // Initial Mark start bit
   dst->mark(1 * BIT_TIME_US);
@@ -90,12 +90,12 @@ optional<ByronSXData> ByronSXProtocol::decode(RemoteReceiveData src) {
     return {};
   }
 
-  ESP_LOGVV(TAG, "%3d: %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d", src.size(), src.peek(0),
+  ESP_LOGVV(TAG, "%3ld: %ld %ld %ld %ld %ld %ld %ld %ld %ld %ld %ld %ld %ld %ld %ld %ld %ld %ld %ld %ld", src.size(), src.peek(0),
             src.peek(1), src.peek(2), src.peek(3), src.peek(4), src.peek(5), src.peek(6), src.peek(7), src.peek(8),
             src.peek(9), src.peek(10), src.peek(11), src.peek(12), src.peek(13), src.peek(14), src.peek(15),
             src.peek(16), src.peek(17), src.peek(18), src.peek(19));
 
-  ESP_LOGVV(TAG, "     %d %d %d %d %d %d", src.peek(20), src.peek(21), src.peek(22), src.peek(23), src.peek(24),
+  ESP_LOGVV(TAG, "     %ld %ld %ld %ld %ld %ld", src.peek(20), src.peek(21), src.peek(22), src.peek(23), src.peek(24),
             src.peek(25));
 
   // Read data bits
@@ -107,10 +107,10 @@ optional<ByronSXData> ByronSXProtocol::decode(RemoteReceiveData src) {
     } else if (src.expect_space(BIT_TIME_US) && src.expect_mark(2 * BIT_TIME_US)) {
       out_data |= 0 << bit;
     } else {
-      ESP_LOGV(TAG, "Decode ByronSX: Fail 2, %2d %08x", bit, out_data);
+      ESP_LOGV(TAG, "Decode ByronSX: Fail 2, %2d %08lx", bit, out_data);
       return {};
     }
-    ESP_LOGVV(TAG, "Decode ByronSX: Data, %2d %08x", bit, out_data);
+    ESP_LOGVV(TAG, "Decode ByronSX: Data, %2d %08lx", bit, out_data);
   }
 
   // last bit followed by a long space

--- a/esphome/components/remote_base/drayton_protocol.cpp
+++ b/esphome/components/remote_base/drayton_protocol.cpp
@@ -151,12 +151,12 @@ optional<DraytonData> DraytonProtocol::decode(RemoteReceiveData src) {
 
     // Look for sync pulse, after. If sucessful index points to space of sync symbol
     while (src.size() - src.get_index() >= MIN_RX_SRC) {
-      ESP_LOGVV(TAG, "Decode Drayton: sync search %d, %" PRId32 " %" PRId32, src.size() - src.get_index(), src.peek(),
+      ESP_LOGVV(TAG, "Decode Drayton: sync search %ld, %" PRId32 " %" PRId32, src.size() - src.get_index(), src.peek(),
                 src.peek(1));
       if (src.peek_mark(2 * BIT_TIME_US) &&
           (src.peek_space(2 * BIT_TIME_US, 1) || src.peek_space(3 * BIT_TIME_US, 1))) {
         src.advance(1);
-        ESP_LOGVV(TAG, "Decode Drayton: Found SYNC, - %d", src.get_index());
+        ESP_LOGVV(TAG, "Decode Drayton: Found SYNC, - %ld", src.get_index());
         break;
       } else {
         src.advance(2);
@@ -174,14 +174,14 @@ optional<DraytonData> DraytonProtocol::decode(RemoteReceiveData src) {
     // Checks next bit to leave index pointing correctly
     uint32_t out_data = 0;
     uint8_t bit = NDATABITS - 1;
-    ESP_LOGVV(TAG, "Decode Drayton: first bit %d  %" PRId32 ", %" PRId32, src.peek(0), src.peek(1), src.peek(2));
+    ESP_LOGVV(TAG, "Decode Drayton: first bit %ld  %" PRId32 ", %" PRId32, src.peek(0), src.peek(1), src.peek(2));
     if (src.expect_space(3 * BIT_TIME_US) && (src.expect_mark(BIT_TIME_US) || src.peek_mark(2 * BIT_TIME_US))) {
       out_data |= 0 << bit;
     } else if (src.expect_space(2 * BIT_TIME_US) && src.expect_mark(BIT_TIME_US) &&
                (src.expect_space(BIT_TIME_US) || src.peek_space(2 * BIT_TIME_US))) {
       out_data |= 1 << bit;
     } else {
-      ESP_LOGV(TAG, "Decode Drayton: Fail 2, - %d %d %d", src.peek(-1), src.peek(0), src.peek(1));
+      ESP_LOGV(TAG, "Decode Drayton: Fail 2, - %ld %ld %ld", src.peek(-1), src.peek(0), src.peek(1));
       continue;
     }
 
@@ -202,7 +202,7 @@ optional<DraytonData> DraytonProtocol::decode(RemoteReceiveData src) {
     }
 
     if (bit > 0) {
-      ESP_LOGVV(TAG, "Decode Drayton: Fail 3, %d %" PRId32 " %" PRId32, src.peek(-1), src.peek(0), src.peek(1));
+      ESP_LOGVV(TAG, "Decode Drayton: Fail 3, %ld %" PRId32 " %" PRId32, src.peek(-1), src.peek(0), src.peek(1));
       continue;
     }
 
@@ -214,7 +214,7 @@ optional<DraytonData> DraytonProtocol::decode(RemoteReceiveData src) {
       continue;
     }
 
-    ESP_LOGV(TAG, "Decode Drayton: Data, %2d %08x", bit, out_data);
+    ESP_LOGV(TAG, "Decode Drayton: Data, %2d %08lx", bit, out_data);
 
     out.channel = (uint8_t) (out_data & 0x1F);
     out_data >>= NBITS_CHANNEL;

--- a/esphome/components/remote_base/keeloq_protocol.cpp
+++ b/esphome/components/remote_base/keeloq_protocol.cpp
@@ -52,7 +52,7 @@ void KeeloqProtocol::encode(RemoteTransmitData *dst, const KeeloqData &data) {
   // Encrypted field
   out_data = data.encrypted;
 
-  ESP_LOGV(TAG, "Send Keeloq: Encrypted data %04x", out_data);
+  ESP_LOGV(TAG, "Send Keeloq: Encrypted data %04lx", out_data);
 
   for (uint32_t mask = 1, cnt = 0; cnt < NBITS_ENCRYPTED_DATA; cnt++, mask <<= 1) {
     if (out_data & mask) {
@@ -68,7 +68,7 @@ void KeeloqProtocol::encode(RemoteTransmitData *dst, const KeeloqData &data) {
   out_data = (data.command & 0x0f);
   out_data <<= NBITS_SERIAL;
   out_data |= data.address;
-  ESP_LOGV(TAG, "Send Keeloq: Fixed data %04x", out_data);
+  ESP_LOGV(TAG, "Send Keeloq: Fixed data %04lx", out_data);
 
   for (uint32_t mask = 1, cnt = 0; cnt < (NBITS_FIXED_DATA - 2); cnt++, mask <<= 1) {
     if (out_data & mask) {
@@ -111,7 +111,7 @@ optional<KeeloqData> KeeloqProtocol::decode(RemoteReceiveData src) {
     return {};
   }
 
-  ESP_LOGVV(TAG, "%2d: %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d", src.size(), src.peek(0),
+  ESP_LOGVV(TAG, "%2ld: %ld %ld %ld %ld %ld %ld %ld %ld %ld %ld %ld %ld %ld %ld %ld %ld %ld %ld %ld %ld", src.size(), src.peek(0),
             src.peek(1), src.peek(2), src.peek(3), src.peek(4), src.peek(5), src.peek(6), src.peek(7), src.peek(8),
             src.peek(9), src.peek(10), src.peek(11), src.peek(12), src.peek(13), src.peek(14), src.peek(15),
             src.peek(16), src.peek(17), src.peek(18), src.peek(19));
@@ -120,12 +120,12 @@ optional<KeeloqData> KeeloqProtocol::decode(RemoteReceiveData src) {
   int8_t bit = NBITS_PREAMBLE - 1;
   while (--bit >= 0) {
     if (!src.expect_mark(BIT_TIME_US) || !src.expect_space(BIT_TIME_US)) {
-      ESP_LOGV(TAG, "Decode KeeLoq: Fail 1, %d %d", bit + 1, src.peek());
+      ESP_LOGV(TAG, "Decode KeeLoq: Fail 1, %d %ld", bit + 1, src.peek());
       return {};
     }
   }
   if (!src.expect_mark(BIT_TIME_US) || !src.expect_space(10 * BIT_TIME_US)) {
-    ESP_LOGV(TAG, "Decode KeeLoq: Fail 1, %d %d", bit + 1, src.peek());
+    ESP_LOGV(TAG, "Decode KeeLoq: Fail 1, %d %ld", bit + 1, src.peek());
     return {};
   }
 
@@ -137,11 +137,11 @@ optional<KeeloqData> KeeloqProtocol::decode(RemoteReceiveData src) {
     } else if (src.expect_mark(BIT_TIME_US) && src.expect_space(2 * BIT_TIME_US)) {
       out_data |= 1 << bit;
     } else {
-      ESP_LOGV(TAG, "Decode KeeLoq: Fail 2, %d %d", src.get_index(), src.peek());
+      ESP_LOGV(TAG, "Decode KeeLoq: Fail 2, %ld %ld", src.get_index(), src.peek());
       return {};
     }
   }
-  ESP_LOGVV(TAG, "Decode KeeLoq: Data, %d %08x", bit, out_data);
+  ESP_LOGVV(TAG, "Decode KeeLoq: Data, %d %08lx", bit, out_data);
   out.encrypted = out_data;
 
   // Read Serial Number and Button Status
@@ -152,11 +152,11 @@ optional<KeeloqData> KeeloqProtocol::decode(RemoteReceiveData src) {
     } else if (src.expect_mark(BIT_TIME_US) && src.expect_space(2 * BIT_TIME_US)) {
       out_data |= 1 << bit;
     } else {
-      ESP_LOGV(TAG, "Decode KeeLoq: Fail 3, %d %d", src.get_index(), src.peek());
+      ESP_LOGV(TAG, "Decode KeeLoq: Fail 3, %ld %ld", src.get_index(), src.peek());
       return {};
     }
   }
-  ESP_LOGVV(TAG, "Decode KeeLoq: Data, %2d %08x", bit, out_data);
+  ESP_LOGVV(TAG, "Decode KeeLoq: Data, %2d %08lx", bit, out_data);
   out.command = (out_data >> 28) & 0xf;
   out.address = out_data & 0xfffffff;
 
@@ -166,7 +166,7 @@ optional<KeeloqData> KeeloqProtocol::decode(RemoteReceiveData src) {
   } else if (src.expect_mark(BIT_TIME_US) && src.expect_space(2 * BIT_TIME_US)) {
     out.vlow = true;
   } else {
-    ESP_LOGV(TAG, "Decode KeeLoq: Fail 4, %08x", src.peek());
+    ESP_LOGV(TAG, "Decode KeeLoq: Fail 4, %08lx", src.peek());
     return {};
   }
 
@@ -176,7 +176,7 @@ optional<KeeloqData> KeeloqProtocol::decode(RemoteReceiveData src) {
   } else if (src.expect_mark(BIT_TIME_US) && src.peek_space_at_least(2 * BIT_TIME_US)) {
     out.repeat = true;
   } else {
-    ESP_LOGV(TAG, "Decode KeeLoq: Fail 5, %08x", src.peek());
+    ESP_LOGV(TAG, "Decode KeeLoq: Fail 5, %08lx", src.peek());
     return {};
   }
 


### PR DESCRIPTION
# What does this implement/fix?

printf is complaining that non long specifiers are used for long/32bit values.
Something like this just for remote_base protocols. I Have no exact Log for remote_base at hand right now.
```
src/esphome/components/cc1101/cc1101.cpp: In member function 'virtual void esphome::cc1101::CC1101::dump_config()':
src/esphome/components/cc1101/cc1101.cpp:209:22: error: format '%u' expects argument of type 'unsigned int', but argument 5 has type 'uint32_t' {aka 'long unsigned int'} [-Werror=format=]
  209 |   ESP_LOGCONFIG(TAG, "  CC1101 Bandwith: %u KHz", this->bandwidth_);
      |                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~
src/esphome/core/log.h:72:36: note: in definition of macro 'ESPHOME_LOG_FORMAT'
   72 | #define ESPHOME_LOG_FORMAT(format) format
      |                                    ^~~~~~
src/esphome/core/log.h:153:33: note: in expansion of macro 'esph_log_config'
  153 | #define ESP_LOGCONFIG(tag, ...) esph_log_config(tag, __VA_ARGS__)
      |                                 ^~~~~~~~~~~~~~~
src/esphome/components/cc1101/cc1101.cpp:209:3: note: in expansion of macro 'ESP_LOGCONFIG'
  209 |   ESP_LOGCONFIG(TAG, "  CC1101 Bandwith: %u KHz", this->bandwidth_);
      |   ^~~~~~~~~~~~~
src/esphome/components/cc1101/cc1101.cpp:209:43: note: format string is defined here
  209 |   ESP_LOGCONFIG(TAG, "  CC1101 Bandwith: %u KHz", this->bandwidth_);
      |                                          ~^
      |                                           |
      |                                           unsigned int
      |                                          %lu


```


## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
substitutions:
  name: gateway2
  friendly_name: Gateway2

esphome:
  name: ${name}
  friendly_name: ${friendly_name}

external_components:
  - source:
      type: git
      url: https://github.com/fightforlife/esphome
      ref: eth_spi_idf5
    components: [ ethernet ]
    refresh: 0s

  - source:
      type: git
      url: https://github.com/fightforlife/esphome
      ref: fix_remote_printf
    components: [ remote_base ]
    refresh: 0s

esp32:
  board: esp32doit-devkit-v1
  variant: esp32
  framework:
    type: esp-idf
    version: 5.2.1
    platform_version: 6.7.0

      
esp32_ble_tracker:
  scan_parameters:
    active: false
    interval: 1100ms
    window: 1100ms

bluetooth_proxy:
  active: true
  cache_services: true

logger:
  level: VERY_VERBOSE 
  baud_rate: 115200

api:
  encryption:
    key: !secret api_secret

ota:
  platform: esphome
  password: !secret api_secret

ethernet:
  type: W5500
  clk_pin: GPIO18
  mosi_pin: GPIO23
  miso_pin: GPIO19
  cs_pin: GPIO5
  interrupt_pin: GPIO21
  reset_pin: GPIO22
  #clock_speed: 16Mhz

remote_transmitter:
  pin: GPIO2  
  carrier_duty_percent: 100%

remote_receiver:
  pin: GPIO4  # GDO2
  dump: all

web_server:
  port: 80

button:
  - platform: restart
    name: "Reboot"     

debug:


```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
