### PR TITLE
Fix compile errors on ESP32-C6 with latest ESP-IDF

### DIFF
--- a/esphome/components/ade7880/ade7880.cpp
+++ b/esphome/components/ade7880/ade7880.cpp
@@ -10,6 +10,7 @@
 #include "ade7880.h"
 #include "ade7880_registers.h"
 #include "esphome/core/log.h"
+#include <cinttypes>
 
 namespace esphome {
 namespace ade7880 {
@@ -156,7 +157,7 @@ void ADE7880::update() {
     });
   }
 
-  ESP_LOGD(TAG, "update took %u ms", millis() - start);
+  ESP_LOGD(TAG, "update took %" PRIu32 " ms", millis() - start);
 }
 
 void ADE7880::dump_config() {
@@ -176,9 +177,9 @@ void ADE7880::dump_config() {
     LOG_SENSOR("    ", "Forward Active Energy", this->channel_a_->forward_active_energy);
     LOG_SENSOR("    ", "Reverse Active Energy", this->channel_a_->reverse_active_energy);
     ESP_LOGCONFIG(TAG, "    Calibration:");
-    ESP_LOGCONFIG(TAG, "     Current: %u", this->channel_a_->current_gain_calibration);
-    ESP_LOGCONFIG(TAG, "     Voltage: %d", this->channel_a_->voltage_gain_calibration);
-    ESP_LOGCONFIG(TAG, "     Power: %d", this->channel_a_->power_gain_calibration);
+    ESP_LOGCONFIG(TAG, "     Current: %" PRId32, this->channel_a_->current_gain_calibration);
+    ESP_LOGCONFIG(TAG, "     Voltage: %" PRId32, this->channel_a_->voltage_gain_calibration);
+    ESP_LOGCONFIG(TAG, "     Power: %" PRId32, this->channel_a_->power_gain_calibration);
     ESP_LOGCONFIG(TAG, "     Phase Angle: %u", this->channel_a_->phase_angle_calibration);
   }
 
@@ -192,9 +193,9 @@ void ADE7880::dump_config() {
     LOG_SENSOR("    ", "Forward Active Energy", this->channel_b_->forward_active_energy);
     LOG_SENSOR("    ", "Reverse Active Energy", this->channel_b_->reverse_active_energy);
     ESP_LOGCONFIG(TAG, "    Calibration:");
-    ESP_LOGCONFIG(TAG, "     Current: %u", this->channel_b_->current_gain_calibration);
-    ESP_LOGCONFIG(TAG, "     Voltage: %d", this->channel_b_->voltage_gain_calibration);
-    ESP_LOGCONFIG(TAG, "     Power: %d", this->channel_b_->power_gain_calibration);
+    ESP_LOGCONFIG(TAG, "     Current: %" PRId32, this->channel_b_->current_gain_calibration);
+    ESP_LOGCONFIG(TAG, "     Voltage: %" PRId32, this->channel_b_->voltage_gain_calibration);
+    ESP_LOGCONFIG(TAG, "     Power: %" PRId32, this->channel_b_->power_gain_calibration);
     ESP_LOGCONFIG(TAG, "     Phase Angle: %u", this->channel_b_->phase_angle_calibration);
   }
 
@@ -208,9 +209,9 @@ void ADE7880::dump_config() {
     LOG_SENSOR("    ", "Forward Active Energy", this->channel_c_->forward_active_energy);
     LOG_SENSOR("    ", "Reverse Active Energy", this->channel_c_->reverse_active_energy);
     ESP_LOGCONFIG(TAG, "    Calibration:");
-    ESP_LOGCONFIG(TAG, "     Current: %u", this->channel_c_->current_gain_calibration);
-    ESP_LOGCONFIG(TAG, "     Voltage: %d", this->channel_c_->voltage_gain_calibration);
-    ESP_LOGCONFIG(TAG, "     Power: %d", this->channel_c_->power_gain_calibration);
+    ESP_LOGCONFIG(TAG, "     Current: %" PRId32, this->channel_c_->current_gain_calibration);
+    ESP_LOGCONFIG(TAG, "     Voltage: %" PRId32, this->channel_c_->voltage_gain_calibration);
+    ESP_LOGCONFIG(TAG, "     Power: %" PRId32, this->channel_c_->power_gain_calibration);
     ESP_LOGCONFIG(TAG, "     Phase Angle: %u", this->channel_c_->phase_angle_calibration);
   }
 
@@ -218,7 +219,7 @@ void ADE7880::dump_config() {
     ESP_LOGCONFIG(TAG, "  Neutral:");
     LOG_SENSOR("    ", "Current", this->channel_n_->current);
     ESP_LOGCONFIG(TAG, "    Calibration:");
-    ESP_LOGCONFIG(TAG, "     Current: %u", this->channel_n_->current_gain_calibration);
+    ESP_LOGCONFIG(TAG, "     Current: %" PRId32, this->channel_n_->current_gain_calibration);
   }
 
   LOG_I2C_DEVICE(this);

--- a/esphome/components/ade7953_base/ade7953_base.cpp
+++ b/esphome/components/ade7953_base/ade7953_base.cpp
@@ -1,5 +1,6 @@
 #include "ade7953_base.h"
 #include "esphome/core/log.h"
+#include <cinttypes>
 
 namespace esphome {
 namespace ade7953_base {
@@ -105,7 +106,7 @@ void ADE7953::update() {
     this->last_update_ = now;
     // prevent DIV/0
     pf = ADE_WATTSEC_POWER_FACTOR * (diff < 10 ? 10 : diff) / 1000;
-    ESP_LOGVV(TAG, "ADE7953::update() diff=%d pf=%f", diff, pf);
+    ESP_LOGVV(TAG, "ADE7953::update() diff=%" PRIu32 " pf=%f", diff, pf);
   }
 
   // Apparent power

--- a/esphome/components/fingerprint_grow/fingerprint_grow.cpp
+++ b/esphome/components/fingerprint_grow/fingerprint_grow.cpp
@@ -541,34 +541,34 @@ void FingerprintGrowComponent::dump_config() {
   ESP_LOGCONFIG(TAG, "  Sensor Power Pin: %s",
                 this->has_power_pin_ ? this->sensor_power_pin_->dump_summary().c_str() : "None");
   if (this->idle_period_to_sleep_ms_ < UINT32_MAX) {
-    ESP_LOGCONFIG(TAG, "  Idle Period to Sleep: %u ms", this->idle_period_to_sleep_ms_);
+    ESP_LOGCONFIG(TAG, "  Idle Period to Sleep: %" PRIu32 " ms", this->idle_period_to_sleep_ms_);
   } else {
     ESP_LOGCONFIG(TAG, "  Idle Period to Sleep: Never");
   }
   LOG_UPDATE_INTERVAL(this);
   if (this->fingerprint_count_sensor_) {
     LOG_SENSOR("  ", "Fingerprint Count", this->fingerprint_count_sensor_);
-    ESP_LOGCONFIG(TAG, "    Current Value: %d", (uint16_t) this->fingerprint_count_sensor_->get_state());
+    ESP_LOGCONFIG(TAG, "    Current Value: %u", (uint16_t) this->fingerprint_count_sensor_->get_state());
   }
   if (this->status_sensor_) {
     LOG_SENSOR("  ", "Status", this->status_sensor_);
-    ESP_LOGCONFIG(TAG, "    Current Value: %d", (uint8_t) this->status_sensor_->get_state());
+    ESP_LOGCONFIG(TAG, "    Current Value: %u", (uint8_t) this->status_sensor_->get_state());
   }
   if (this->capacity_sensor_) {
     LOG_SENSOR("  ", "Capacity", this->capacity_sensor_);
-    ESP_LOGCONFIG(TAG, "    Current Value: %d", (uint16_t) this->capacity_sensor_->get_state());
+    ESP_LOGCONFIG(TAG, "    Current Value: %u", (uint16_t) this->capacity_sensor_->get_state());
   }
   if (this->security_level_sensor_) {
     LOG_SENSOR("  ", "Security Level", this->security_level_sensor_);
-    ESP_LOGCONFIG(TAG, "    Current Value: %d", (uint8_t) this->security_level_sensor_->get_state());
+    ESP_LOGCONFIG(TAG, "    Current Value: %u", (uint8_t) this->security_level_sensor_->get_state());
   }
   if (this->last_finger_id_sensor_) {
     LOG_SENSOR("  ", "Last Finger ID", this->last_finger_id_sensor_);
-    ESP_LOGCONFIG(TAG, "    Current Value: %d", (uint32_t) this->last_finger_id_sensor_->get_state());
+    ESP_LOGCONFIG(TAG, "    Current Value: %" PRIu32, (uint32_t) this->last_finger_id_sensor_->get_state());
   }
   if (this->last_confidence_sensor_) {
     LOG_SENSOR("  ", "Last Confidence", this->last_confidence_sensor_);
-    ESP_LOGCONFIG(TAG, "    Current Value: %d", (uint32_t) this->last_confidence_sensor_->get_state());
+    ESP_LOGCONFIG(TAG, "    Current Value: %" PRIu32, (uint32_t) this->last_confidence_sensor_->get_state());
   }
 }
 

--- a/esphome/components/he60r/he60r.cpp
+++ b/esphome/components/he60r/he60r.cpp
@@ -1,6 +1,7 @@
 #include "he60r.h"
 #include "esphome/core/hal.h"
 #include "esphome/core/log.h"
+#include <cinttypes>
 
 namespace esphome {
 namespace he60r {
@@ -127,7 +128,7 @@ void HE60rCover::update_() {
   if (toggles_needed_ != 0) {
     if ((this->counter_++ & 0x3) == 0) {
       toggles_needed_--;
-      ESP_LOGD(TAG, "Writing byte 0x30, still needed=%d", toggles_needed_);
+      ESP_LOGD(TAG, "Writing byte 0x30, still needed=%" PRIu32, toggles_needed_);
       this->write_byte(TOGGLE_BYTE);
     } else {
       this->write_byte(QUERY_BYTE);

--- a/esphome/components/mhz19/mhz19.cpp
+++ b/esphome/components/mhz19/mhz19.cpp
@@ -1,5 +1,6 @@
 #include "mhz19.h"
 #include "esphome/core/log.h"
+#include <cinttypes>
 
 namespace esphome {
 namespace mhz19 {
@@ -32,7 +33,7 @@ void MHZ19Component::update() {
   uint32_t now_ms = millis();
   uint32_t warmup_ms = this->warmup_seconds_ * 1000;
   if (now_ms < warmup_ms) {
-    ESP_LOGW(TAG, "MHZ19 warming up, %ds left", (warmup_ms - now_ms) / 1000);
+    ESP_LOGW(TAG, "MHZ19 warming up, %" PRIu32 " s left", (warmup_ms - now_ms) / 1000);
     this->status_set_warning();
     return;
   }
@@ -110,7 +111,7 @@ void MHZ19Component::dump_config() {
     ESP_LOGCONFIG(TAG, "  Automatic baseline calibration disabled on boot");
   }
 
-  ESP_LOGCONFIG(TAG, "  Warmup seconds: %ds", this->warmup_seconds_);
+  ESP_LOGCONFIG(TAG, "  Warmup time: %" PRIu32 " s", this->warmup_seconds_);
 }
 
 }  // namespace mhz19

--- a/esphome/components/remote_base/abbwelcome_protocol.h
+++ b/esphome/components/remote_base/abbwelcome_protocol.h
@@ -4,6 +4,7 @@
 #include "esphome/core/helpers.h"
 #include "remote_base.h"
 #include <array>
+#include <cinttypes>
 #include <utility>
 #include <vector>
 
@@ -144,7 +145,8 @@ class ABBWelcomeData {
   std::string to_string(uint8_t max_print_bytes = 255) const {
     std::string info;
     if (this->is_valid()) {
-      info = str_sprintf(this->get_three_byte_address() ? "[%06X %s %06X] Type: %02X" : "[%04X %s %04X] Type: %02X",
+      info = str_sprintf(this->get_three_byte_address() ? "[%06" PRIX32 " %s %06" PRIX32 "] Type: %02X"
+                                                        : "[%04" PRIX32 " %s %04" PRIX32 "] Type: %02X",
                          this->get_source_address(), this->get_retransmission() ? "»" : ">",
                          this->get_destination_address(), this->get_message_type());
       if (this->get_data_size())

--- a/esphome/components/remote_base/byronsx_protocol.cpp
+++ b/esphome/components/remote_base/byronsx_protocol.cpp
@@ -1,5 +1,6 @@
 #include "byronsx_protocol.h"
 #include "esphome/core/log.h"
+#include <cinttypes>
 
 namespace esphome {
 namespace remote_base {
@@ -57,7 +58,7 @@ void ByronSXProtocol::encode(RemoteTransmitData *dst, const ByronSXData &data) {
   out_data <<= NBITS_COMMAND;
   out_data |= data.command;
 
-  ESP_LOGV(TAG, "Send ByronSX: out_data %03x", out_data);
+  ESP_LOGV(TAG, "Send ByronSX: out_data %03" PRIx32, out_data);
 
   // Initial Mark start bit
   dst->mark(1 * BIT_TIME_US);
@@ -90,13 +91,16 @@ optional<ByronSXData> ByronSXProtocol::decode(RemoteReceiveData src) {
     return {};
   }
 
-  ESP_LOGVV(TAG, "%3d: %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d", src.size(), src.peek(0),
-            src.peek(1), src.peek(2), src.peek(3), src.peek(4), src.peek(5), src.peek(6), src.peek(7), src.peek(8),
-            src.peek(9), src.peek(10), src.peek(11), src.peek(12), src.peek(13), src.peek(14), src.peek(15),
-            src.peek(16), src.peek(17), src.peek(18), src.peek(19));
+  ESP_LOGVV(TAG,
+            "%3" PRId32 ": %" PRId32 " %" PRId32 " %" PRId32 " %" PRId32 " %" PRId32 " %" PRId32 " %" PRId32 " %" PRId32
+            " %" PRId32 " %" PRId32 " %" PRId32 " %" PRId32 " %" PRId32 " %" PRId32 " %" PRId32 " %" PRId32 " %" PRId32
+            " %" PRId32 " %" PRId32 " %" PRId32,
+            src.size(), src.peek(0), src.peek(1), src.peek(2), src.peek(3), src.peek(4), src.peek(5), src.peek(6),
+            src.peek(7), src.peek(8), src.peek(9), src.peek(10), src.peek(11), src.peek(12), src.peek(13), src.peek(14),
+            src.peek(15), src.peek(16), src.peek(17), src.peek(18), src.peek(19));
 
-  ESP_LOGVV(TAG, "     %d %d %d %d %d %d", src.peek(20), src.peek(21), src.peek(22), src.peek(23), src.peek(24),
-            src.peek(25));
+  ESP_LOGVV(TAG, "     %" PRId32 " %" PRId32 " %" PRId32 " %" PRId32 " %" PRId32 " %" PRId32, src.peek(20),
+            src.peek(21), src.peek(22), src.peek(23), src.peek(24), src.peek(25));
 
   // Read data bits
   uint32_t out_data = 0;
@@ -107,10 +111,10 @@ optional<ByronSXData> ByronSXProtocol::decode(RemoteReceiveData src) {
     } else if (src.expect_space(BIT_TIME_US) && src.expect_mark(2 * BIT_TIME_US)) {
       out_data |= 0 << bit;
     } else {
-      ESP_LOGV(TAG, "Decode ByronSX: Fail 2, %2d %08x", bit, out_data);
+      ESP_LOGV(TAG, "Decode ByronSX: Fail 2, %2d %08" PRIx32, bit, out_data);
       return {};
     }
-    ESP_LOGVV(TAG, "Decode ByronSX: Data, %2d %08x", bit, out_data);
+    ESP_LOGVV(TAG, "Decode ByronSX: Data, %2d %08" PRIx32, bit, out_data);
   }
 
   // last bit followed by a long space

--- a/esphome/components/remote_base/drayton_protocol.cpp
+++ b/esphome/components/remote_base/drayton_protocol.cpp
@@ -151,12 +151,12 @@ optional<DraytonData> DraytonProtocol::decode(RemoteReceiveData src) {
 
     // Look for sync pulse, after. If sucessful index points to space of sync symbol
     while (src.size() - src.get_index() >= MIN_RX_SRC) {
-      ESP_LOGVV(TAG, "Decode Drayton: sync search %d, %" PRId32 " %" PRId32, src.size() - src.get_index(), src.peek(),
-                src.peek(1));
+      ESP_LOGVV(TAG, "Decode Drayton: sync search %" PRIu32 ", %" PRId32 " %" PRId32, src.size() - src.get_index(),
+                src.peek(), src.peek(1));
       if (src.peek_mark(2 * BIT_TIME_US) &&
           (src.peek_space(2 * BIT_TIME_US, 1) || src.peek_space(3 * BIT_TIME_US, 1))) {
         src.advance(1);
-        ESP_LOGVV(TAG, "Decode Drayton: Found SYNC, - %d", src.get_index());
+        ESP_LOGVV(TAG, "Decode Drayton: Found SYNC, - %" PRIu32, src.get_index());
         break;
       } else {
         src.advance(2);
@@ -174,14 +174,16 @@ optional<DraytonData> DraytonProtocol::decode(RemoteReceiveData src) {
     // Checks next bit to leave index pointing correctly
     uint32_t out_data = 0;
     uint8_t bit = NDATABITS - 1;
-    ESP_LOGVV(TAG, "Decode Drayton: first bit %d  %" PRId32 ", %" PRId32, src.peek(0), src.peek(1), src.peek(2));
+    ESP_LOGVV(TAG, "Decode Drayton: first bit %" PRId32 "  %" PRId32 ", %" PRId32, src.peek(0), src.peek(1),
+              src.peek(2));
     if (src.expect_space(3 * BIT_TIME_US) && (src.expect_mark(BIT_TIME_US) || src.peek_mark(2 * BIT_TIME_US))) {
       out_data |= 0 << bit;
     } else if (src.expect_space(2 * BIT_TIME_US) && src.expect_mark(BIT_TIME_US) &&
                (src.expect_space(BIT_TIME_US) || src.peek_space(2 * BIT_TIME_US))) {
       out_data |= 1 << bit;
     } else {
-      ESP_LOGV(TAG, "Decode Drayton: Fail 2, - %d %d %d", src.peek(-1), src.peek(0), src.peek(1));
+      ESP_LOGV(TAG, "Decode Drayton: Fail 2, - %" PRId32 " %" PRId32 " %" PRId32, src.peek(-1), src.peek(0),
+               src.peek(1));
       continue;
     }
 
@@ -202,7 +204,8 @@ optional<DraytonData> DraytonProtocol::decode(RemoteReceiveData src) {
     }
 
     if (bit > 0) {
-      ESP_LOGVV(TAG, "Decode Drayton: Fail 3, %d %" PRId32 " %" PRId32, src.peek(-1), src.peek(0), src.peek(1));
+      ESP_LOGVV(TAG, "Decode Drayton: Fail 3, %" PRId32 " %" PRId32 " %" PRId32, src.peek(-1), src.peek(0),
+                src.peek(1));
       continue;
     }
 
@@ -214,7 +217,7 @@ optional<DraytonData> DraytonProtocol::decode(RemoteReceiveData src) {
       continue;
     }
 
-    ESP_LOGV(TAG, "Decode Drayton: Data, %2d %08x", bit, out_data);
+    ESP_LOGV(TAG, "Decode Drayton: Data, %2d %08" PRIx32, bit, out_data);
 
     out.channel = (uint8_t) (out_data & 0x1F);
     out_data >>= NBITS_CHANNEL;

--- a/esphome/components/remote_base/keeloq_protocol.cpp
+++ b/esphome/components/remote_base/keeloq_protocol.cpp
@@ -52,7 +52,7 @@ void KeeloqProtocol::encode(RemoteTransmitData *dst, const KeeloqData &data) {
   // Encrypted field
   out_data = data.encrypted;
 
-  ESP_LOGV(TAG, "Send Keeloq: Encrypted data %04x", out_data);
+  ESP_LOGV(TAG, "Send Keeloq: Encrypted data %04" PRIx32, out_data);
 
   for (uint32_t mask = 1, cnt = 0; cnt < NBITS_ENCRYPTED_DATA; cnt++, mask <<= 1) {
     if (out_data & mask) {
@@ -68,7 +68,7 @@ void KeeloqProtocol::encode(RemoteTransmitData *dst, const KeeloqData &data) {
   out_data = (data.command & 0x0f);
   out_data <<= NBITS_SERIAL;
   out_data |= data.address;
-  ESP_LOGV(TAG, "Send Keeloq: Fixed data %04x", out_data);
+  ESP_LOGV(TAG, "Send Keeloq: Fixed data %04" PRIx32, out_data);
 
   for (uint32_t mask = 1, cnt = 0; cnt < (NBITS_FIXED_DATA - 2); cnt++, mask <<= 1) {
     if (out_data & mask) {
@@ -111,21 +111,24 @@ optional<KeeloqData> KeeloqProtocol::decode(RemoteReceiveData src) {
     return {};
   }
 
-  ESP_LOGVV(TAG, "%2d: %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d %d", src.size(), src.peek(0),
-            src.peek(1), src.peek(2), src.peek(3), src.peek(4), src.peek(5), src.peek(6), src.peek(7), src.peek(8),
-            src.peek(9), src.peek(10), src.peek(11), src.peek(12), src.peek(13), src.peek(14), src.peek(15),
-            src.peek(16), src.peek(17), src.peek(18), src.peek(19));
+  ESP_LOGVV(TAG,
+            "%2" PRId32 ": %" PRId32 " %" PRId32 " %" PRId32 " %" PRId32 " %" PRId32 " %" PRId32 " %" PRId32 " %" PRId32
+            " %" PRId32 " %" PRId32 " %" PRId32 " %" PRId32 " %" PRId32 " %" PRId32 " %" PRId32 " %" PRId32 " %" PRId32
+            " %" PRId32 " %" PRId32 " %" PRId32,
+            src.size(), src.peek(0), src.peek(1), src.peek(2), src.peek(3), src.peek(4), src.peek(5), src.peek(6),
+            src.peek(7), src.peek(8), src.peek(9), src.peek(10), src.peek(11), src.peek(12), src.peek(13), src.peek(14),
+            src.peek(15), src.peek(16), src.peek(17), src.peek(18), src.peek(19));
 
   // Check preamble bits
   int8_t bit = NBITS_PREAMBLE - 1;
   while (--bit >= 0) {
     if (!src.expect_mark(BIT_TIME_US) || !src.expect_space(BIT_TIME_US)) {
-      ESP_LOGV(TAG, "Decode KeeLoq: Fail 1, %d %d", bit + 1, src.peek());
+      ESP_LOGV(TAG, "Decode KeeLoq: Fail 1, %d %" PRId32, bit + 1, src.peek());
       return {};
     }
   }
   if (!src.expect_mark(BIT_TIME_US) || !src.expect_space(10 * BIT_TIME_US)) {
-    ESP_LOGV(TAG, "Decode KeeLoq: Fail 1, %d %d", bit + 1, src.peek());
+    ESP_LOGV(TAG, "Decode KeeLoq: Fail 1, %d %" PRId32, bit + 1, src.peek());
     return {};
   }
 
@@ -137,11 +140,11 @@ optional<KeeloqData> KeeloqProtocol::decode(RemoteReceiveData src) {
     } else if (src.expect_mark(BIT_TIME_US) && src.expect_space(2 * BIT_TIME_US)) {
       out_data |= 1 << bit;
     } else {
-      ESP_LOGV(TAG, "Decode KeeLoq: Fail 2, %d %d", src.get_index(), src.peek());
+      ESP_LOGV(TAG, "Decode KeeLoq: Fail 2, %" PRIu32 " %" PRId32, src.get_index(), src.peek());
       return {};
     }
   }
-  ESP_LOGVV(TAG, "Decode KeeLoq: Data, %d %08x", bit, out_data);
+  ESP_LOGVV(TAG, "Decode KeeLoq: Data, %d %08" PRIx32, bit, out_data);
   out.encrypted = out_data;
 
   // Read Serial Number and Button Status
@@ -152,11 +155,11 @@ optional<KeeloqData> KeeloqProtocol::decode(RemoteReceiveData src) {
     } else if (src.expect_mark(BIT_TIME_US) && src.expect_space(2 * BIT_TIME_US)) {
       out_data |= 1 << bit;
     } else {
-      ESP_LOGV(TAG, "Decode KeeLoq: Fail 3, %d %d", src.get_index(), src.peek());
+      ESP_LOGV(TAG, "Decode KeeLoq: Fail 3, %" PRIu32 " %" PRId32, src.get_index(), src.peek());
       return {};
     }
   }
-  ESP_LOGVV(TAG, "Decode KeeLoq: Data, %2d %08x", bit, out_data);
+  ESP_LOGVV(TAG, "Decode KeeLoq: Data, %2d %08" PRIx32, bit, out_data);
   out.command = (out_data >> 28) & 0xf;
   out.address = out_data & 0xfffffff;
 
@@ -166,7 +169,7 @@ optional<KeeloqData> KeeloqProtocol::decode(RemoteReceiveData src) {
   } else if (src.expect_mark(BIT_TIME_US) && src.expect_space(2 * BIT_TIME_US)) {
     out.vlow = true;
   } else {
-    ESP_LOGV(TAG, "Decode KeeLoq: Fail 4, %08x", src.peek());
+    ESP_LOGV(TAG, "Decode KeeLoq: Fail 4, %" PRId32, src.peek());
     return {};
   }
 
@@ -176,7 +179,7 @@ optional<KeeloqData> KeeloqProtocol::decode(RemoteReceiveData src) {
   } else if (src.expect_mark(BIT_TIME_US) && src.peek_space_at_least(2 * BIT_TIME_US)) {
     out.repeat = true;
   } else {
-    ESP_LOGV(TAG, "Decode KeeLoq: Fail 5, %08x", src.peek());
+    ESP_LOGV(TAG, "Decode KeeLoq: Fail 5, %" PRId32, src.peek());
     return {};
   }
 

--- a/esphome/components/uart/uart_component_esp_idf.cpp
+++ b/esphome/components/uart/uart_component_esp_idf.cpp
@@ -69,7 +69,7 @@ void IDFUARTComponent::setup() {
     this->mark_failed();
     return;
   }
-  this->uart_num_ = next_uart_num++;
+  this->uart_num_ = static_cast<uart_port_t>(next_uart_num++);
   ESP_LOGCONFIG(TAG, "Setting up UART %u...", this->uart_num_);
 
   this->lock_ = xSemaphoreCreateMutex();

--- a/esphome/components/xgzp68xx/xgzp68xx.cpp
+++ b/esphome/components/xgzp68xx/xgzp68xx.cpp
@@ -3,6 +3,7 @@
 #include "esphome/core/hal.h"
 #include "esphome/core/helpers.h"
 #include "esphome/components/i2c/i2c.h"
+#include <cinttypes>
 
 namespace esphome {
 namespace xgzp68xx {
@@ -37,8 +38,8 @@ void XGZP68XXComponent::update() {
     temperature_raw = encode_uint16(data[3], data[4]);
 
     // Convert the pressure data to hPa
-    ESP_LOGV(TAG, "Got raw pressure=%d, raw temperature=%d ", pressure_raw, temperature_raw);
-    ESP_LOGV(TAG, "K value is %d ", this->k_value_);
+    ESP_LOGV(TAG, "Got raw pressure=%" PRIu32 ", raw temperature=%u", pressure_raw, temperature_raw);
+    ESP_LOGV(TAG, "K value is %u", this->k_value_);
 
     // The most significant bit of both pressure and temperature will be 1 to indicate a negative value.
     // This is directly from the datasheet, and the calculations below will handle this.


### PR DESCRIPTION
# What does this implement/fix?

Trying to compile with the latest esp-idf for an esp32c6 (specifically the OLIMEX ESP32-C6-EVB) with logging set to VERBOSE or VERY_VERBOSE resulted in a number of components failing to compile.

The compile problems are mostly printf modifiers for *int32_t types.
This PR addresses as many as I could get to compile on an esp32c6, which is hopefully most of them once again.

Tested on ESP32-C6 (esp-idf), ESP32 (arduino), and an ESP8266 (arduino).

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
esphome:
  name: esp32c6
  friendly_name: esp32c6
  comment: OLIMEX EPS32-C6-EVB
  platformio_options:
    board_upload.maximum_size: 4194304
  project:
    name: OLIMEX.ESP32-C6-EVB
    version: ESP32-C6-EVB

esp32:
  board: esp32-c6-devkitc-1 # at least until https://github.com/platformio/platform-espressif32/issues/1152 is added
  variant: esp32c6          # ditto ↑
  flash_size: 4MB # upload.flash_size
  framework:
    type: esp-idf
    version: 5.2.1 # Need at least 5.1 for ESP32-C6
    platform_version: 6.7.0 # Need at least 6.4 for ESP32-C6
    # See https://github.com/esphome/issues/issues/5404
    sdkconfig_options:
      CONFIG_ESPTOOLPY_FLASHSIZE_4MB: y

logger:
  hardware_uart: USB_SERIAL_JTAG # Use native USB C port
  level: VERY_VERBOSE

api:
  encryption:
    key: !secret esp32c6_key

ota:
  - platform: esphome
    password: !secret esp32c6_ota

wifi:
  ssid: !secret wifi_ssid
  password: !secret wifi_password
  domain: !secret domain
  ap:
    password: !secret esp32c6_ota

captive_portal:

time:
  - platform: homeassistant

uart:
  rx_pin: 4
  tx_pin: 5
  baud_rate: 9600

spi:
  miso_pin: 20
  mosi_pin: 18
  clk_pin: 19

i2c:
  sda: 6
  scl: 7

switch:
  - platform: gpio
    pin: 10 # REL1
    name: REL1
    restore_mode: RESTORE_DEFAULT_OFF
  - platform: gpio
    pin: 11 # REL2
    name: REL2
    restore_mode: RESTORE_DEFAULT_OFF
  - platform: gpio
    pin: 22 # REL3
    name: REL3
    restore_mode: RESTORE_DEFAULT_OFF
  - platform: gpio
    pin: 23 # REL4
    name: REL4
    restore_mode: RESTORE_DEFAULT_OFF

sensor:
  - platform: uptime
    name: Uptime
  - platform: wifi_signal
    name: WiFi RSSI

binary_sensor:
  # Button
  - platform: gpio
    name: BUT1
    entity_category: diagnostic
    pin:
      number: 9
      mode:
        input: true
        pullup: true
      inverted: true
      ignore_strapping_warning: true
  # Verified with a weak-ass 9V battery
  - platform: gpio
    name: OPT1
    entity_category: diagnostic
    pin:
      number: 1
      inverted: true
  - platform: gpio
    name: OPT2
    entity_category: diagnostic
    pin:
      number: 2
      inverted: true
  - platform: gpio
    name: OPT3
    entity_category: diagnostic
    pin:
      number: 3
      inverted: true
  - platform: gpio
    name: OPT4
    entity_category: diagnostic
    pin:
      number: 15
      inverted: true

light:
  - platform: status_led
    name: "Status LED"
    pin:
      inverted: true
      number: 8
      ignore_strapping_warning: true

button:
  - platform: restart
    name: Restart
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
