### PR TITLE
Use uint8_t instead of uint32_t for 8-bit values on mitsubishi

### DIFF
--- a/esphome/components/mitsubishi/mitsubishi.cpp
+++ b/esphome/components/mitsubishi/mitsubishi.cpp
@@ -6,7 +6,7 @@ namespace mitsubishi {
 
 static const char *const TAG = "mitsubishi.climate";
 
-const uint32_t MITSUBISHI_OFF = 0x00;
+const uint8_t MITSUBISHI_OFF = 0x00;
 
 const uint8_t MITSUBISHI_MODE_AUTO = 0x20;
 const uint8_t MITSUBISHI_MODE_COOL = 0x18;
@@ -109,8 +109,8 @@ void MitsubishiClimate::transmit_state() {
   // Byte 15: HVAC specfic, i.e. POWERFUL, SMART SET, PLASMA, always 0x00
   // Byte 16: Constant 0x00
   // Byte 17: Checksum: SUM[Byte0...Byte16]
-  uint32_t remote_state[18] = {0x23, 0xCB, 0x26, 0x01, 0x00, 0x20, 0x08, 0x00, 0x00,
-                               0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+  uint8_t remote_state[18] = {0x23, 0xCB, 0x26, 0x01, 0x00, 0x20, 0x08, 0x00, 0x00,
+                              0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
 
   switch (this->mode) {
     case climate::CLIMATE_MODE_HEAT:
@@ -249,7 +249,7 @@ void MitsubishiClimate::transmit_state() {
 
   data->set_carrier_frequency(38000);
   // repeat twice
-  for (uint16_t r = 0; r < 2; r++) {
+  for (uint8_t r = 0; r < 2; r++) {
     // Header
     data->mark(MITSUBISHI_HEADER_MARK);
     data->space(MITSUBISHI_HEADER_SPACE);


### PR DESCRIPTION
# What does this implement/fix?

The `mitsubishi` component was using a uint32_t array to build & process 8-bit messages.
This was causing some printf formatting issues on ESP-IDF, and wastes RAM on all platforms.

This PR switches to using uint8_t instead, solving both issues. 

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Test Environment

- [ ] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
esphome:
  name: esp32c6test1
  friendly_name: esp32c6test1

esp32:
  board: esp32-c6-devkitc-1
  variant: esp32c6
  framework:
    type: esp-idf
    version: 5.2.1 # Need at least 5.1 for ESP32-C6
    platform_version: 6.7.0 # Need at least 6.4 for ESP32-C6
    sdkconfig_options:
      CONFIG_ESPTOOLPY_FLASHSIZE_4MB: y # default is 4MB but https://github.com/esphome/issues/issues/5404

logger:
  level: VERY_VERBOSE

api:
wifi:
  ssid: !secret wifi_ssid
  password: !secret wifi_password
  ap:
captive_portal:


climate:
  - platform: mitsubishi
    name: Mitsubishi
    supports_dry: "true"
    supports_fan_only: "true"
    horizontal_default: "left"
    vertical_default: "down"
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
