### PR TITLE
[display] SDL2 display driver for host platform

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -455,7 +455,7 @@ jobs:
         file: ${{ fromJson(needs.list-components.outputs.components) }}
     steps:
       - name: Install libsodium
-        run: sudo apt-get install libsodium-dev
+        run: sudo apt-get install libsodium-dev libsdl2-dev
 
       - name: Check out code from GitHub
         uses: actions/checkout@v4.1.6

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -313,6 +313,7 @@ esphome/components/rtttl/* @glmnet
 esphome/components/safe_mode/* @jsuanet @kbx81 @paulmonigatti
 esphome/components/scd4x/* @martgras @sjtrny
 esphome/components/script/* @esphome/core
+esphome/components/sdl/* @clydebarrow
 esphome/components/sdm_meter/* @jesserockz @polyfaces
 esphome/components/sdp3x/* @Azimath
 esphome/components/seeed_mr24hpc1/* @limengdu

--- a/esphome/components/sdl/__init__.py
+++ b/esphome/components/sdl/__init__.py
@@ -1,1 +1,1 @@
-CODEPWNERS = ["@clydebarrow"]
+CODEOWNERS = ["@clydebarrow"]

--- a/esphome/components/sdl/__init__.py
+++ b/esphome/components/sdl/__init__.py
@@ -1,0 +1,1 @@
+CODEPWNERS = ["@clydebarrow"]

--- a/esphome/components/sdl/display.py
+++ b/esphome/components/sdl/display.py
@@ -17,6 +17,7 @@ Sdl = sdl_ns.class_("Sdl", display.Display, cg.Component)
 
 
 CONF_SDL_OPTIONS = "sdl_options"
+CONF_SDL_ID = "sdl_id"
 
 
 def get_sdl_options(value):
@@ -53,6 +54,7 @@ CONFIG_SCHEMA = cv.All(
 async def to_code(config):
     for option in config[CONF_SDL_OPTIONS].split():
         cg.add_build_flag(option)
+    cg.add_build_flag("-DSDL_BYTEORDER=4321")
     var = cg.new_Pvariable(config[CONF_ID])
     await display.register_display(var, config)
 

--- a/esphome/components/sdl/display.py
+++ b/esphome/components/sdl/display.py
@@ -26,7 +26,7 @@ def get_sdl_options(value):
     try:
         return subprocess.check_output(["sdl2-config", "--cflags", "--libs"]).decode()
     except Exception as e:
-        raise cv.Invalid("Unable to run sdld-config - have you installed sdl2?") from e
+        raise cv.Invalid("Unable to run sdl2-config - have you installed sdl2?") from e
 
 
 CONFIG_SCHEMA = cv.All(

--- a/esphome/components/sdl/display.py
+++ b/esphome/components/sdl/display.py
@@ -1,0 +1,70 @@
+import subprocess
+
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import display
+from esphome.const import (
+    CONF_ID,
+    CONF_DIMENSIONS,
+    CONF_WIDTH,
+    CONF_HEIGHT,
+    CONF_LAMBDA,
+    PLATFORM_HOST,
+)
+
+sdl_ns = cg.esphome_ns.namespace("sdl")
+Sdl = sdl_ns.class_("Sdl", display.Display, cg.Component)
+
+
+CONF_SDL_OPTIONS = "sdl_options"
+
+
+def get_sdl_options(value):
+    if value != "":
+        return value
+    try:
+        return subprocess.check_output(["sdl2-config", "--cflags", "--libs"]).decode()
+    except Exception as e:
+        raise cv.Invalid("Unable to run sdld-config - have you installed sdl2?") from e
+
+
+CONFIG_SCHEMA = cv.All(
+    display.FULL_DISPLAY_SCHEMA.extend(
+        cv.Schema(
+            {
+                cv.GenerateID(): cv.declare_id(Sdl),
+                cv.Optional(CONF_SDL_OPTIONS, default=""): get_sdl_options,
+                cv.Required(CONF_DIMENSIONS): cv.Any(
+                    cv.dimensions,
+                    cv.Schema(
+                        {
+                            cv.Required(CONF_WIDTH): cv.int_,
+                            cv.Required(CONF_HEIGHT): cv.int_,
+                        }
+                    ),
+                ),
+            }
+        )
+    ),
+    cv.only_on(PLATFORM_HOST),
+)
+
+
+async def to_code(config):
+    for option in config[CONF_SDL_OPTIONS].split():
+        cg.add_build_flag(option)
+    var = cg.new_Pvariable(config[CONF_ID])
+    await display.register_display(var, config)
+
+    dimensions = config[CONF_DIMENSIONS]
+    if isinstance(dimensions, dict):
+        cg.add(var.set_dimensions(dimensions[CONF_WIDTH], dimensions[CONF_HEIGHT]))
+    else:
+        (width, height) = dimensions
+        cg.add(var.set_dimensions(width, height))
+
+    if lamb := config.get(CONF_LAMBDA):
+        lambda_ = await cg.process_lambda(
+            lamb, [(display.DisplayRef, "it")], return_type=cg.void
+        )
+        cg.add(var.set_writer(lambda_))

--- a/esphome/components/sdl/sdl_esphome.cpp
+++ b/esphome/components/sdl/sdl_esphome.cpp
@@ -1,5 +1,5 @@
+#ifdef USE_HOST
 #include "sdl_esphome.h"
-#include "esphome/components/logger/logger.h"
 #include "esphome/components/display/display_color_utils.h"
 
 namespace esphome {
@@ -93,3 +93,5 @@ void Sdl::loop() {
 
 }  // namespace sdl
 }  // namespace esphome
+
+#endif

--- a/esphome/components/sdl/sdl_esphome.cpp
+++ b/esphome/components/sdl/sdl_esphome.cpp
@@ -1,0 +1,76 @@
+#include "sdl_esphome.h"
+#include "esphome/components/logger/logger.h"
+#include "esphome/components/display/display_color_utils.h"
+
+namespace esphome {
+namespace sdl {
+
+void Sdl::setup() {
+  ESP_LOGD(TAG, "Starting setup");
+  SDL_Init(SDL_INIT_VIDEO);
+  this->window_ =
+      SDL_CreateWindow("ESPHome", SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, this->width_, this->height_, 0);
+  this->renderer_ = SDL_CreateRenderer(this->window_, -1, SDL_RENDERER_SOFTWARE);
+  this->texture_ =
+      SDL_CreateTexture(this->renderer_, SDL_PIXELFORMAT_BGR565, SDL_TEXTUREACCESS_STATIC, this->width_, this->height_);
+  SDL_SetTextureBlendMode(this->texture_, SDL_BLENDMODE_BLEND);
+  ESP_LOGD(TAG, "Setup Complete");
+}
+void Sdl::update() {
+  this->do_update_();
+  if ((this->x_high_ < this->x_low_) || (this->y_high_ < this->y_low_))
+    return;
+  SDL_Rect rect{this->x_low_, this->y_low_, this->x_high_ + 1 - this->x_low_, this->y_high_ + 1 - this->y_low_};
+  this->x_low_ = this->width_;
+  this->y_low_ = this->height_;
+  this->x_high_ = 0;
+  this->y_high_ = 0;
+  SDL_RenderCopy(this->renderer_, this->texture_, &rect, &rect);
+  SDL_RenderPresent(this->renderer_);
+}
+
+void Sdl::draw_pixels_at(int x_start, int y_start, int w, int h, const uint8_t *ptr, display::ColorOrder order,
+                         display::ColorBitness bitness, bool big_endian, int x_offset, int y_offset, int x_pad) {
+  if (this->rotation_ != display::DISPLAY_ROTATION_0_DEGREES || bitness != display::COLOR_BITNESS_565 || !big_endian) {
+    return display::Display::draw_pixels_at(x_start, y_start, w, h, ptr, order, bitness, big_endian, x_offset, y_offset,
+                                            x_pad);
+  }
+  SDL_Rect rect{x_start, y_start, w, h};
+  auto stride = x_offset + w + x_pad;
+  auto data = ptr + (stride * y_offset + x_offset) * 2;
+  SDL_UpdateTexture(this->texture_, &rect, data, stride * 2);
+  SDL_RenderCopy(this->renderer_, this->texture_, &rect, &rect);
+  SDL_RenderPresent(this->renderer_);
+}
+
+void Sdl::draw_pixel_at(int x, int y, Color color) {
+  SDL_Rect rect{x, y, 1, 1};
+  auto data = display::ColorUtil::color_to_565(color, display::COLOR_ORDER_BGR);
+  SDL_UpdateTexture(this->texture_, &rect, &data, 2);
+  if (x < this->x_low_)
+    this->x_low_ = x;
+  if (y < this->y_low_)
+    this->y_low_ = y;
+  if (x > this->x_high_)
+    this->x_high_ = x;
+  if (y > this->y_high_)
+    this->y_high_ = y;
+}
+
+void Sdl::loop() {
+  SDL_Event e;
+  if (SDL_PollEvent(&e)) {
+    switch (e.type) {
+      case SDL_QUIT:
+        exit(0);
+        break;
+
+      default:
+        ESP_LOGD(TAG, "Event %d", e.type);
+        break;
+    }
+  }
+}
+
+}  // namespace sdl
+}  // namespace esphome

--- a/esphome/components/sdl/sdl_esphome.cpp
+++ b/esphome/components/sdl/sdl_esphome.cpp
@@ -93,5 +93,4 @@ void Sdl::loop() {
 
 }  // namespace sdl
 }  // namespace esphome
-
 #endif

--- a/esphome/components/sdl/sdl_esphome.cpp
+++ b/esphome/components/sdl/sdl_esphome.cpp
@@ -8,8 +8,8 @@ namespace sdl {
 void Sdl::setup() {
   ESP_LOGD(TAG, "Starting setup");
   SDL_Init(SDL_INIT_VIDEO);
-  this->window_ =
-      SDL_CreateWindow("ESPHome", SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, this->width_, this->height_, 0);
+  this->window_ = SDL_CreateWindow(App.get_name().c_str(), SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED,
+                                   this->width_, this->height_, 0);
   this->renderer_ = SDL_CreateRenderer(this->window_, -1, SDL_RENDERER_SOFTWARE);
   this->texture_ =
       SDL_CreateTexture(this->renderer_, SDL_PIXELFORMAT_RGB565, SDL_TEXTUREACCESS_STATIC, this->width_, this->height_);

--- a/esphome/components/sdl/sdl_esphome.h
+++ b/esphome/components/sdl/sdl_esphome.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include "esphome/core/component.h"
 #include "esphome/core/log.h"
 #include "esphome/core/application.h"
@@ -27,6 +29,10 @@ class Sdl : public display::Display {
   int get_height() override { return this->height_; }
   float get_setup_priority() const override { return setup_priority::HARDWARE; }
   void dump_config() override { LOG_DISPLAY("", "SDL", this); }
+
+  int mouse_x{};
+  int mouse_y{};
+  bool mouse_down{};
 
  protected:
   int get_width_internal() override { return this->width_; }

--- a/esphome/components/sdl/sdl_esphome.h
+++ b/esphome/components/sdl/sdl_esphome.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#ifdef USE_HOST
 #include "esphome/core/component.h"
 #include "esphome/core/log.h"
 #include "esphome/core/application.h"
@@ -49,3 +50,5 @@ class Sdl : public display::Display {
 };
 }  // namespace sdl
 }  // namespace esphome
+
+#endif

--- a/esphome/components/sdl/sdl_esphome.h
+++ b/esphome/components/sdl/sdl_esphome.h
@@ -1,0 +1,45 @@
+#include "esphome/core/component.h"
+#include "esphome/core/log.h"
+#include "esphome/core/application.h"
+#include "esphome/components/display/display.h"
+#define SDL_MAIN_HANDLED
+#include "SDL.h"
+
+namespace esphome {
+namespace sdl {
+
+constexpr static const char *const TAG = "sdl";
+
+class Sdl : public display::Display {
+ public:
+  display::DisplayType get_display_type() override { return display::DISPLAY_TYPE_COLOR; }
+  void update() override;
+  void loop() override;
+  void setup() override;
+  void draw_pixels_at(int x_start, int y_start, int w, int h, const uint8_t *ptr, display::ColorOrder order,
+                      display::ColorBitness bitness, bool big_endian, int x_offset, int y_offset, int x_pad) override;
+  void draw_pixel_at(int x, int y, Color color) override;
+  void set_dimensions(uint16_t width, uint16_t height) {
+    this->width_ = width;
+    this->height_ = height;
+  }
+  int get_width() override { return this->width_; }
+  int get_height() override { return this->height_; }
+  float get_setup_priority() const override { return setup_priority::HARDWARE; }
+  void dump_config() override { LOG_DISPLAY("", "SDL", this); }
+
+ protected:
+  int get_width_internal() override { return this->width_; }
+  int get_height_internal() override { return this->height_; }
+  int width_{};
+  int height_{};
+  SDL_Renderer *renderer_{};
+  SDL_Window *window_{};
+  SDL_Texture *texture_{};
+  uint16_t x_low_{0};
+  uint16_t y_low_{0};
+  uint16_t x_high_{0};
+  uint16_t y_high_{0};
+};
+}  // namespace sdl
+}  // namespace esphome

--- a/esphome/components/sdl/touchscreen/__init__.py
+++ b/esphome/components/sdl/touchscreen/__init__.py
@@ -1,0 +1,22 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.const import CONF_ID
+
+from esphome.components import touchscreen
+from ..display import Sdl, sdl_ns, CONF_SDL_ID
+
+SdlTouchscreen = sdl_ns.class_("SdlTouchscreen", touchscreen.Touchscreen)
+
+
+CONFIG_SCHEMA = touchscreen.TOUCHSCREEN_SCHEMA.extend(
+    {
+        cv.GenerateID(): cv.declare_id(SdlTouchscreen),
+        cv.GenerateID(CONF_SDL_ID): cv.use_id(Sdl),
+    }
+)
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_parented(var, config[CONF_SDL_ID])
+    await touchscreen.register_touchscreen(var, config)

--- a/esphome/components/sdl/touchscreen/sdl_touchscreen.h
+++ b/esphome/components/sdl/touchscreen/sdl_touchscreen.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#ifdef USE_HOST
 #include "../sdl_esphome.h"
 #include "esphome/components/touchscreen/touchscreen.h"
 
@@ -22,3 +23,4 @@ class SdlTouchscreen : public touchscreen::Touchscreen, public Parented<Sdl> {
 
 }  // namespace sdl
 }  // namespace esphome
+#endif

--- a/esphome/components/sdl/touchscreen/sdl_touchscreen.h
+++ b/esphome/components/sdl/touchscreen/sdl_touchscreen.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "../sdl_esphome.h"
+#include "esphome/components/touchscreen/touchscreen.h"
+
+namespace esphome {
+namespace sdl {
+
+class SdlTouchscreen : public touchscreen::Touchscreen, public Parented<Sdl> {
+ public:
+  void setup() override {
+    this->x_raw_max_ = this->display_->get_width();
+    this->y_raw_max_ = this->display_->get_height();
+  }
+
+  void update_touches() override {
+    if (this->parent_->mouse_down) {
+      add_raw_touch_position_(0, this->parent_->mouse_x, this->parent_->mouse_y);
+    }
+  }
+};
+
+}  // namespace sdl
+}  // namespace esphome

--- a/platformio.ini
+++ b/platformio.ini
@@ -389,6 +389,3 @@ build_flags =
     ${common.build_flags}
     -DUSE_HOST
     -std=c++17
-    -I/opt/homebrew/include/SDL2
-    -L/opt/homebrew/lib -lSDL2
-

--- a/platformio.ini
+++ b/platformio.ini
@@ -389,3 +389,6 @@ build_flags =
     ${common.build_flags}
     -DUSE_HOST
     -std=c++17
+    -I/opt/homebrew/include/SDL2
+    -L/opt/homebrew/lib -lSDL2
+

--- a/tests/components/sdl/common.yaml
+++ b/tests/components/sdl/common.yaml
@@ -1,0 +1,12 @@
+host:
+  mac_address: "62:23:45:AF:B3:DD"
+
+display:
+  - platform: sdl
+    id: sdl_display
+    update_interval: 1s
+    auto_clear_enabled: false
+    show_test_card: true
+    dimensions:
+      width: 450
+      height: 600

--- a/tests/components/sdl/common.yaml
+++ b/tests/components/sdl/common.yaml
@@ -1,13 +1,12 @@
 host:
   mac_address: "62:23:45:AF:B3:DD"
 
-# Disabled since the CI container does not have sdl2 installed.
-# display:
-#   - platform: sdl
-#     id: sdl_display
-#     update_interval: 1s
-#     auto_clear_enabled: false
-#     show_test_card: true
-#     dimensions:
-#       width: 450
-#       height: 600
+display:
+  - platform: sdl
+    id: sdl_display
+    update_interval: 1s
+    auto_clear_enabled: false
+    show_test_card: true
+    dimensions:
+      width: 450
+      height: 600

--- a/tests/components/sdl/common.yaml
+++ b/tests/components/sdl/common.yaml
@@ -1,12 +1,13 @@
 host:
   mac_address: "62:23:45:AF:B3:DD"
 
-display:
-  - platform: sdl
-    id: sdl_display
-    update_interval: 1s
-    auto_clear_enabled: false
-    show_test_card: true
-    dimensions:
-      width: 450
-      height: 600
+# Disabled since the CI container does not have sdl2 installed.
+# display:
+#   - platform: sdl
+#     id: sdl_display
+#     update_interval: 1s
+#     auto_clear_enabled: false
+#     show_test_card: true
+#     dimensions:
+#       width: 450
+#       height: 600

--- a/tests/components/sdl/test.host.yaml
+++ b/tests/components/sdl/test.host.yaml
@@ -1,0 +1,1 @@
+<<: !include common.yaml


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Adds a new display driver that enables a display when running an ESPHome binary on the host platform.
This is particularly useful for designing and testing display layouts.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#3880

Docs preview is here: https://deploy-preview-3880--esphome.netlify.app/components/display/sdl.html

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [x] host

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
display:
  - platform: sdl
    id: sdl_display
    update_interval: 1s
    auto_clear_enabled: false
    show_test_card: true
    dimensions:
      width: 450
      height: 600

touchscreen:
  platform: sdl
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
