### PR TITLE
[micro_wake_word] Ensure model string is Path

### DIFF
--- a/esphome/components/micro_wake_word/__init__.py
+++ b/esphome/components/micro_wake_word/__init__.py
@@ -334,7 +334,10 @@ async def to_code(config):
     elif model_config[CONF_TYPE] == TYPE_HTTP:
         file = _compute_local_file_path(model_config) / "manifest.json"
 
-    manifest, data = _load_model_data(file)
+    else:
+        raise ValueError("Unsupported config type: {model_config[CONF_TYPE]}")
+
+    manifest, data = _load_model_data(Path(file))
 
     rhs = [HexInt(x) for x in data]
     prog_arr = cg.progmem_array(config[CONF_RAW_DATA_ID], rhs)

--- a/esphome/components/micro_wake_word/__init__.py
+++ b/esphome/components/micro_wake_word/__init__.py
@@ -329,7 +329,7 @@ async def to_code(config):
         file: Path = base_dir / h.hexdigest()[:8] / model_config[CONF_FILE]
 
     elif model_config[CONF_TYPE] == TYPE_LOCAL:
-        file = model_config[CONF_PATH]
+        file = Path(model_config[CONF_PATH])
 
     elif model_config[CONF_TYPE] == TYPE_HTTP:
         file = _compute_local_file_path(model_config) / "manifest.json"
@@ -337,7 +337,7 @@ async def to_code(config):
     else:
         raise ValueError("Unsupported config type: {model_config[CONF_TYPE]}")
 
-    manifest, data = _load_model_data(Path(file))
+    manifest, data = _load_model_data(file)
 
     rhs = [HexInt(x) for x in data]
     prog_arr = cg.progmem_array(config[CONF_RAW_DATA_ID], rhs)


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->
Ensure that when using a local path for microWakeWord models, the result is a `Path`.
Also, raise `ValueError` if an unsupported config type for the model is used.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
