### PR TITLE
Wireguard support for bk72 microcontrollers

### DIFF
--- a/esphome/components/wireguard/__init__.py
+++ b/esphome/components/wireguard/__init__.py
@@ -122,7 +122,7 @@ async def to_code(config):
     # the '+1' modifier is relative to the device's own address that will
     # be automatically added to the provided list.
     cg.add_build_flag(f"-DCONFIG_WIREGUARD_MAX_SRC_IPS={len(allowed_ips) + 1}")
-    cg.add_library("droscy/esp_wireguard", "0.4.0")
+    cg.add_library("droscy/esp_wireguard", "0.4.1")
 
     await cg.register_component(var, config)
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -94,7 +94,7 @@ lib_deps =
     ESP8266mDNS                           ; mdns (Arduino built-in)
     DNSServer                             ; captive_portal (Arduino built-in)
     crankyoldgit/IRremoteESP8266@~2.8.4   ; heatpumpir
-    droscy/esp_wireguard@0.4.0            ; wireguard
+    droscy/esp_wireguard@0.4.1            ; wireguard
 build_flags =
     ${common:arduino.build_flags}
     -Wno-nonnull-compare
@@ -124,7 +124,7 @@ lib_deps =
     DNSServer                            ; captive_portal (Arduino built-in)
     esphome/ESP32-audioI2S@2.0.7         ; i2s_audio
     crankyoldgit/IRremoteESP8266@~2.8.4  ; heatpumpir
-    droscy/esp_wireguard@0.4.0           ; wireguard
+    droscy/esp_wireguard@0.4.1           ; wireguard
 build_flags =
     ${common:arduino.build_flags}
     -DUSE_ESP32
@@ -143,7 +143,7 @@ framework = espidf
 lib_deps =
     ${common:idf.lib_deps}
     espressif/esp32-camera@1.0.0  ; esp32_camera
-    droscy/esp_wireguard@0.4.0    ; wireguard
+    droscy/esp_wireguard@0.4.1    ; wireguard
 build_flags =
     ${common:idf.build_flags}
     -Wno-nonnull-compare
@@ -174,6 +174,8 @@ build_flags =
 extends = common:arduino
 platform = libretiny
 framework = arduino
+lib_deps =
+    droscy/esp_wireguard@0.4.1    ; wireguard
 build_flags =
     ${common:arduino.build_flags}
     -DUSE_LIBRETINY

--- a/tests/components/wireguard/test.bk72xx.yaml
+++ b/tests/components/wireguard/test.bk72xx.yaml
@@ -1,0 +1,62 @@
+wifi:
+  ssid: "MySSID1"
+  password: "password1"
+
+network:
+  enable_ipv6: true
+
+time:
+  - platform: sntp
+
+wireguard:
+  address: 172.16.34.100
+  netmask: 255.255.255.0
+  # NEVER use the following keys for your vpn, they are now public!
+  private_key: wPBMxtNYH3mChicrbpsRpZIasIdPq3yZuthn23FbGG8=
+  peer_public_key: Hs2JfikvYU03/Kv3YoAs1hrUIPPTEkpsZKSPUljE9yc=
+  peer_preshared_key: 20fjM5GRnSolGPC5SRj9ljgIUyQfruv0B0bvLl3Yt60=
+  peer_endpoint: wg.server.example
+  peer_persistent_keepalive: 25s
+  peer_allowed_ips:
+    - 172.16.34.0/24
+    - 192.168.4.0/24
+
+binary_sensor:
+  - platform: wireguard
+    status:
+      name: 'WireGuard Status'
+    enabled:
+      name: 'WireGuard Enabled'
+
+sensor:
+  - platform: wireguard
+    latest_handshake:
+      name: 'WireGuard Latest Handshake'
+
+text_sensor:
+  - platform: wireguard
+    address:
+      name: 'WireGuard Address'
+
+button:
+  - platform: template
+    name: 'Toggle WireGuard'
+    entity_category: config
+    on_press:
+      - if:
+          condition: wireguard.enabled
+          then:
+            - wireguard.disable:
+          else:
+            - wireguard.enable:
+
+  - platform: template
+    name: 'Log WireGuard status'
+    entity_category: config
+    on_press:
+      - if:
+          condition: wireguard.peer_online
+          then:
+            - logger.log: 'wireguard remote peer is online'
+          else:
+            - logger.log: 'wireguard remote peer is offline'

--- a/tests/components/wireguard/test.bk72xx.yaml
+++ b/tests/components/wireguard/test.bk72xx.yaml
@@ -3,7 +3,7 @@ wifi:
   password: "password1"
 
 network:
-  enable_ipv6: true
+  enable_ipv6: false
 
 time:
   - platform: sntp

--- a/tests/components/wireguard/test.bk72xx.yaml
+++ b/tests/components/wireguard/test.bk72xx.yaml
@@ -2,9 +2,6 @@ wifi:
   ssid: "MySSID1"
   password: "password1"
 
-network:
-  enable_ipv6: false
-
 time:
   - platform: sntp
 


### PR DESCRIPTION
# What does this implement/fix?

Bump `esp_wireguard` lib to v0.4.1 with the following changes:

* add support for bk72 microcontrollers (thanks to @kuba2k2)
* fix compilation error using esp-idf v5 (thanks to @kbx81)
* fix crash on vpn disconnection with alive tcp connection (thanks to @jefftharris)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** none

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#3889

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [x] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
Configure as usual

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
