### PR TITLE
WebSocket overrides check_origin for reverse proxy configuration

### DIFF
--- a/esphome/dashboard/web_server.py
+++ b/esphome/dashboard/web_server.py
@@ -172,7 +172,7 @@ class EsphomeCommandWebSocket(tornado.websocket.WebSocketHandler):
             return super().check_origin(origin)
         trusted_domains = [
             s.strip() for s in os.environ["ESPHOME_TRUSTED_DOMAINS"].split(",")
-        ]        
+        ]
         url = urlparse(origin)
         if url.hostname in trusted_domains:
             return True

--- a/esphome/dashboard/web_server.py
+++ b/esphome/dashboard/web_server.py
@@ -170,7 +170,9 @@ class EsphomeCommandWebSocket(tornado.websocket.WebSocketHandler):
     def check_origin(self, origin):
         if "ESPHOME_TRUSTED_DOMAINS" not in os.environ:
             return super().check_origin(origin)
-        trusted_domains = [s.strip() for s in os.environ['ESPHOME_TRUSTED_DOMAINS'].split(',')]
+        trusted_domains = [
+            s.strip() for s in os.environ["ESPHOME_TRUSTED_DOMAINS"].split(",")
+        ]        
         url = urlparse(origin)
         if url.hostname in trusted_domains:
             return True

--- a/esphome/dashboard/web_server.py
+++ b/esphome/dashboard/web_server.py
@@ -17,6 +17,7 @@ import time
 from collections.abc import Iterable
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, TypeVar
+from urllib.parse import urlparse
 
 import tornado
 import tornado.concurrent
@@ -165,6 +166,16 @@ class EsphomeCommandWebSocket(tornado.websocket.WebSocketHandler):
         # Windows doesn't support non-blocking pipes,
         # use Popen() with a reading thread instead
         self._use_popen = os.name == "nt"
+
+    def check_origin(self, origin):
+        if "ESPHOME_TRUSTED_DOMAINS" not in os.environ:
+            return super().check_origin(origin)
+        trusted_domains = [s.strip() for s in os.environ['ESPHOME_TRUSTED_DOMAINS'].split(',')]
+        url = urlparse(origin)
+        if url.hostname in trusted_domains:
+            return True
+        _LOGGER.info("check_origin %s, domain is not trusted", origin)
+        return False
 
     def open(self, *args: str, **kwargs: str) -> None:
         """Handle new WebSocket connection."""


### PR DESCRIPTION
WebSocket server checks the ESPHOME_TRUSTED_DOMAINS environment variable for a comma separated list of allowed domains, behind a reverse proxy.

# What does this implement/fix?

I could never get websockets work behind IIS's reverse proxy. This is what other docker containers use, I just adopted it for esphome. If the ESPHOME_TRUSTED_DOMAINS is set, the overriden check_origin compares it with the http origin header, otherwise it calls the parent and works just like before.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
