### PR TITLE
[wireguard] Implement workaround for crash on IDF 5+

### DIFF
--- a/esphome/components/wireguard/__init__.py
+++ b/esphome/components/wireguard/__init__.py
@@ -7,7 +7,10 @@ from esphome.const import (
     CONF_TIME_ID,
     CONF_ADDRESS,
     CONF_REBOOT_TIMEOUT,
+    KEY_CORE,
+    KEY_FRAMEWORK_VERSION,
 )
+from esphome.components.esp32 import CORE, add_idf_sdkconfig_option
 from esphome.components import time
 from esphome.core import TimePeriod
 from esphome import automation
@@ -116,6 +119,13 @@ async def to_code(config):
 
     if config[CONF_REQUIRE_CONNECTION_TO_PROCEED]:
         cg.add(var.disable_auto_proceed())
+
+    # Workaround for crash on IDF 5+
+    # See https://github.com/trombik/esp_wireguard/issues/33#issuecomment-1568503651
+    if CORE.using_esp_idf and CORE.data[KEY_CORE][KEY_FRAMEWORK_VERSION] >= cv.Version(
+        5, 0, 0
+    ):
+        add_idf_sdkconfig_option("CONFIG_LWIP_PPP_SUPPORT", True)
 
     # This flag is added here because the esp_wireguard library statically
     # set the size of its allowed_ips list at compile time using this value;


### PR DESCRIPTION
# What does this implement/fix?

When using Wireguard on IDF 5+, a crash occurs as the tunnel comes up. This PR implements a workaround for the crash. See https://github.com/trombik/esp_wireguard/issues/33#issuecomment-1568503651

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF 5+
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
