### PR TITLE
fix: arduino media player sets wrong state for announcements

### DIFF
--- a/esphome/components/i2s_audio/media_player/i2s_audio_media_player.cpp
+++ b/esphome/components/i2s_audio/media_player/i2s_audio_media_player.cpp
@@ -28,7 +28,7 @@ void I2SAudioMediaPlayer::control(const media_player::MediaPlayerCall &call) {
     }
   }
 
-  if (this->state = media_player::MEDIA_PLAYER_STATE_ANNOUNCING) {
+  if ((this->state = media_player::MEDIA_PLAYER_STATE_ANNOUNCING)) {
     this->is_announcement_ = true;
   }
 

--- a/esphome/components/i2s_audio/media_player/i2s_audio_media_player.cpp
+++ b/esphome/components/i2s_audio/media_player/i2s_audio_media_player.cpp
@@ -27,6 +27,11 @@ void I2SAudioMediaPlayer::control(const media_player::MediaPlayerCall &call) {
       this->start();
     }
   }
+
+  if (this->state = media_player::MEDIA_PLAYER_STATE_ANNOUNCING) {
+    this->is_announcement_ = true;
+  }
+
   if (call.get_volume().has_value()) {
     this->volume = call.get_volume().value();
     this->set_volume_(volume);
@@ -171,9 +176,8 @@ void I2SAudioMediaPlayer::start_() {
   if (this->current_url_.has_value()) {
     this->audio_->connecttohost(this->current_url_.value().c_str());
     this->state = media_player::MEDIA_PLAYER_STATE_PLAYING;
-    if (this->is_announcement_.has_value()) {
-      this->state = this->is_announcement_.value() ? media_player::MEDIA_PLAYER_STATE_ANNOUNCING
-                                                   : media_player::MEDIA_PLAYER_STATE_PLAYING;
+    if (this->is_announcement_) {
+      this->state = media_player::MEDIA_PLAYER_STATE_ANNOUNCING;
     }
     this->publish_state();
   }
@@ -202,6 +206,7 @@ void I2SAudioMediaPlayer::stop_() {
   this->high_freq_.stop();
   this->state = media_player::MEDIA_PLAYER_STATE_IDLE;
   this->publish_state();
+  this->is_announcement_ = false;
 }
 
 media_player::MediaPlayerTraits I2SAudioMediaPlayer::get_traits() {

--- a/esphome/components/i2s_audio/media_player/i2s_audio_media_player.cpp
+++ b/esphome/components/i2s_audio/media_player/i2s_audio_media_player.cpp
@@ -28,7 +28,7 @@ void I2SAudioMediaPlayer::control(const media_player::MediaPlayerCall &call) {
     }
   }
 
-  if ((this->state = media_player::MEDIA_PLAYER_STATE_ANNOUNCING)) {
+  if (this->state == media_player::MEDIA_PLAYER_STATE_ANNOUNCING) {
     this->is_announcement_ = true;
   }
 

--- a/esphome/components/i2s_audio/media_player/i2s_audio_media_player.h
+++ b/esphome/components/i2s_audio/media_player/i2s_audio_media_player.h
@@ -78,7 +78,7 @@ class I2SAudioMediaPlayer : public Component, public media_player::MediaPlayer, 
   HighFrequencyLoopRequester high_freq_;
 
   optional<std::string> current_url_{};
-  optional<bool> is_announcement_{};
+  bool is_announcement_{false};
 };
 
 }  // namespace i2s_audio


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->
Fixes an issue that was introduced when adding the additional announcement state to the media_player component.
The new state was not always set correctly in the I2S-Arduino media player.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/5794

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
