### PR TITLE
Fix media_player.volume_set when media player is not started

### DIFF
--- a/esphome/components/i2s_audio/media_player/i2s_audio_media_player.cpp
+++ b/esphome/components/i2s_audio/media_player/i2s_audio_media_player.cpp
@@ -56,6 +56,8 @@ void I2SAudioMediaPlayer::control(const media_player::MediaPlayerCall &call) {
         this->unmute_();
         break;
       }
+      default:
+        break;
     }
     if (this->i2s_state_ != I2S_STATE_RUNNING) {
       return;
@@ -81,6 +83,8 @@ void I2SAudioMediaPlayer::control(const media_player::MediaPlayerCall &call) {
         } else {
           this->state = media_player::MEDIA_PLAYER_STATE_PAUSED;
         }
+        break;
+      default:
         break;
     }
   }

--- a/esphome/components/i2s_audio/media_player/i2s_audio_media_player.cpp
+++ b/esphome/components/i2s_audio/media_player/i2s_audio_media_player.cpp
@@ -32,37 +32,13 @@ void I2SAudioMediaPlayer::control(const media_player::MediaPlayerCall &call) {
     this->set_volume_(volume);
     this->unmute_();
   }
-  if (this->i2s_state_ != I2S_STATE_RUNNING) {
-    return;
-  }
   if (call.get_command().has_value()) {
     switch (call.get_command().value()) {
-      case media_player::MEDIA_PLAYER_COMMAND_PLAY:
-        if (!this->audio_->isRunning())
-          this->audio_->pauseResume();
-        this->state = play_state;
-        break;
-      case media_player::MEDIA_PLAYER_COMMAND_PAUSE:
-        if (this->audio_->isRunning())
-          this->audio_->pauseResume();
-        this->state = media_player::MEDIA_PLAYER_STATE_PAUSED;
-        break;
-      case media_player::MEDIA_PLAYER_COMMAND_STOP:
-        this->stop();
-        break;
       case media_player::MEDIA_PLAYER_COMMAND_MUTE:
         this->mute_();
         break;
       case media_player::MEDIA_PLAYER_COMMAND_UNMUTE:
         this->unmute_();
-        break;
-      case media_player::MEDIA_PLAYER_COMMAND_TOGGLE:
-        this->audio_->pauseResume();
-        if (this->audio_->isRunning()) {
-          this->state = media_player::MEDIA_PLAYER_STATE_PLAYING;
-        } else {
-          this->state = media_player::MEDIA_PLAYER_STATE_PAUSED;
-        }
         break;
       case media_player::MEDIA_PLAYER_COMMAND_VOLUME_UP: {
         float new_volume = this->volume + 0.1f;
@@ -80,6 +56,32 @@ void I2SAudioMediaPlayer::control(const media_player::MediaPlayerCall &call) {
         this->unmute_();
         break;
       }
+    }
+    if (this->i2s_state_ != I2S_STATE_RUNNING) {
+      return;
+    }
+    switch (call.get_command().value()) {
+      case media_player::MEDIA_PLAYER_COMMAND_PLAY:
+        if (!this->audio_->isRunning())
+          this->audio_->pauseResume();
+        this->state = play_state;
+        break;
+      case media_player::MEDIA_PLAYER_COMMAND_PAUSE:
+        if (this->audio_->isRunning())
+          this->audio_->pauseResume();
+        this->state = media_player::MEDIA_PLAYER_STATE_PAUSED;
+        break;
+      case media_player::MEDIA_PLAYER_COMMAND_STOP:
+        this->stop();
+        break;
+      case media_player::MEDIA_PLAYER_COMMAND_TOGGLE:
+        this->audio_->pauseResume();
+        if (this->audio_->isRunning()) {
+          this->state = media_player::MEDIA_PLAYER_STATE_PLAYING;
+        } else {
+          this->state = media_player::MEDIA_PLAYER_STATE_PAUSED;
+        }
+        break;
     }
   }
   this->publish_state();


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->
When the `media_player` was idle and the volume was changed, the change would not trigger all of the required logic inside the `media_player`.

Now the volume control code is placed before checking whether the `media_player` is playing.

Test in a config using

```yaml
external_components:
  - source: github://pr#6859
    components: i2s_audio
    refresh: 0s
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/5877

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
