### PR TITLE
[image] Make PIL import local

### DIFF
--- a/esphome/components/image/__init__.py
+++ b/esphome/components/image/__init__.py
@@ -9,8 +9,6 @@ import re
 import requests
 from magic import Magic
 
-from PIL import Image
-
 from esphome import core
 from esphome.components import font
 from esphome import external_files
@@ -267,6 +265,9 @@ CONFIG_SCHEMA = cv.All(font.validate_pillow_installed, IMAGE_SCHEMA)
 
 
 def load_svg_image(file: bytes, resize: tuple[int, int]):
+    # Local import only to allow "validate_pillow_installed" to run *before* importing it
+    from PIL import Image
+
     # This import is only needed in case of SVG images; adding it
     # to the top would force configurations not using SVG to also have it
     # installed for no reason.
@@ -286,6 +287,9 @@ def load_svg_image(file: bytes, resize: tuple[int, int]):
 
 
 async def to_code(config):
+    # Local import only to allow "validate_pillow_installed" to run *before* importing it
+    from PIL import Image
+
     conf_file = config[CONF_FILE]
 
     if conf_file[CONF_SOURCE] == SOURCE_LOCAL:


### PR DESCRIPTION
# What does this implement/fix?

Pillow is an ESPHome optional dependency, which if present needs to be installed in a specific version. Importing the module at the top prevents the `validate_pillow_installed` validator to run before the import and thus no helpful error message can be issued to the user.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes [#5428](https://github.com/esphome/issues/issues/5428)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/R

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
image:
  - id: test
    file: mdi:alert-circle
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
