### PR TITLE
[datetime] datetime-datetime  strptime support value string without seconds

### DIFF
--- a/esphome/core/time.cpp
+++ b/esphome/core/time.cpp
@@ -84,6 +84,16 @@ bool ESPTime::strptime(const std::string &time_to_parse, ESPTime &esp_time) {
     esp_time.hour = hour;
     esp_time.minute = minute;
     esp_time.second = second;
+  } else if (sscanf(time_to_parse.c_str(), "%04hu-%02hhu-%02hhu %02hhu:%02hhu %n", &year, &month, &day,  // NOLINT
+                    &hour,                                                                               // NOLINT
+                    &minute, &num) == 5 &&                                                               // NOLINT
+             num == time_to_parse.size()) {
+    esp_time.year = year;
+    esp_time.month = month;
+    esp_time.day_of_month = day;
+    esp_time.hour = hour;
+    esp_time.minute = minute;
+    esp_time.second = 0;
   } else if (sscanf(time_to_parse.c_str(), "%02hhu:%02hhu:%02hhu %n", &hour, &minute, &second, &num) == 3 &&  // NOLINT
              num == time_to_parse.size()) {
     esp_time.hour = hour;


### PR DESCRIPTION
# What does this implement/fix?

Fixes datetime-datetime value string not including a second value failing to parse to ESPTime object.
https://github.com/esphome/esphome-webserver/pull/103

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
esphome:
  name: "sorting-test"

esp32:
  board: wemos_d1_mini32

wifi:
  ssid: !secret wifi_ssid
  password: !secret wifi_password

logger:
  level: DEBUG

web_server:
  version: 3

time:
  - platform: sntp
    id: my_time

datetime:
  - platform: template
    id: my_datetime_date
    type: date
    name: "Pick a Date 22"
    optimistic: yes
    initial_value: "2024-01-30"
    restore_value: true

  - platform: template
    id: my_datetime_time
    type: time
    name: "Pick a Time 23"
    optimistic: yes
    initial_value: "12:34:56"
    restore_value: true

  - platform: template
    id: my_datetime_datetime
    type: datetime
    name: "Pick a Datetime 24"
    optimistic: yes
    initial_value: "2024-04-23 13:45"
    restore_value: true

```

## Checklist:
  - [ x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
