### PR TITLE
[he60r] Don't publish state unless it has changed. [BUGFIX]

### DIFF
--- a/esphome/components/he60r/he60r.h
+++ b/esphome/components/he60r/he60r.h
@@ -25,15 +25,14 @@ class HE60rCover : public cover::Cover, public Component, public uart::UARTDevic
   void control(const cover::CoverCall &call) override;
   bool is_at_target_() const;
   void start_direction_(cover::CoverOperation dir);
-  void update_operation_(cover::CoverOperation dir);
   void endstop_reached_(cover::CoverOperation operation);
   void recompute_position_();
   void set_current_operation_(cover::CoverOperation operation);
   void process_rx_(uint8_t data);
 
-  uint32_t open_duration_{0};
-  uint32_t close_duration_{0};
-  uint32_t toggles_needed_{0};
+  unsigned open_duration_{0};
+  unsigned close_duration_{0};
+  unsigned toggles_needed_{0};
   cover::CoverOperation next_direction_{cover::COVER_OPERATION_IDLE};
   cover::CoverOperation last_command_{cover::COVER_OPERATION_IDLE};
   uint32_t last_recompute_time_{0};


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

State was being published even when it had not changed, which e.g. resulted in spurious triggering of `on_closed`.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
