### PR TITLE
[i2s_speaker] A few fixes

### DIFF
--- a/esphome/components/i2s_audio/speaker/i2s_audio_speaker.cpp
+++ b/esphome/components/i2s_audio/speaker/i2s_audio_speaker.cpp
@@ -38,15 +38,22 @@ void I2SAudioSpeaker::start() {
     ESP_LOGE(TAG, "Cannot start audio, speaker failed to setup");
     return;
   }
+  if (this->task_created_) {
+    ESP_LOGW(TAG, "Called start while task has been already created.");
+    return;
+  }
   this->state_ = speaker::STATE_STARTING;
 }
 void I2SAudioSpeaker::start_() {
+  if (this->task_created_) {
+    return;
+  }
   if (!this->parent_->try_lock()) {
     return;  // Waiting for another i2s component to return lock
   }
-  this->state_ = speaker::STATE_RUNNING;
 
   xTaskCreate(I2SAudioSpeaker::player_task, "speaker_task", 8192, (void *) this, 1, &this->player_task_handle_);
+  this->task_created_ = true;
 }
 
 void I2SAudioSpeaker::player_task(void *params) {
@@ -131,7 +138,16 @@ void I2SAudioSpeaker::player_task(void *params) {
                                 (10 / portTICK_PERIOD_MS));
       if (err != ESP_OK) {
         event = {.type = TaskEventType::WARNING, .err = err};
-        xQueueSend(this_speaker->event_queue_, &event, portMAX_DELAY);
+        if (xQueueSend(this_speaker->event_queue_, &event, 10 / portTICK_PERIOD_MS) != pdTRUE) {
+          ESP_LOGW(TAG, "Failed to send WARNING event");
+        }
+        continue;
+      }
+      if (bytes_written == 0 || bytes_written != sizeof(sample)) {
+        event = {.type = TaskEventType::WARNING, .err = ESP_FAIL};
+        if (xQueueSend(this_speaker->event_queue_, &event, 10 / portTICK_PERIOD_MS) != pdTRUE) {
+          ESP_LOGW(TAG, "Failed to send WARNING event");
+        }
         continue;
       }
       remaining--;
@@ -139,18 +155,25 @@ void I2SAudioSpeaker::player_task(void *params) {
     }
 
     event.type = TaskEventType::PLAYING;
-    xQueueSend(this_speaker->event_queue_, &event, portMAX_DELAY);
+    event.err = current;
+    if (xQueueSend(this_speaker->event_queue_, &event, 10 / portTICK_PERIOD_MS) != pdTRUE) {
+      ESP_LOGW(TAG, "Failed to send PLAYING event");
+    }
+  }
+
+  event.type = TaskEventType::STOPPING;
+  if (xQueueSend(this_speaker->event_queue_, &event, 10 / portTICK_PERIOD_MS) != pdTRUE) {
+    ESP_LOGW(TAG, "Failed to send STOPPING event");
   }
 
   i2s_zero_dma_buffer(this_speaker->parent_->get_port());
 
-  event.type = TaskEventType::STOPPING;
-  xQueueSend(this_speaker->event_queue_, &event, portMAX_DELAY);
-
   i2s_driver_uninstall(this_speaker->parent_->get_port());
 
   event.type = TaskEventType::STOPPED;
-  xQueueSend(this_speaker->event_queue_, &event, portMAX_DELAY);
+  if (xQueueSend(this_speaker->event_queue_, &event, 10 / portTICK_PERIOD_MS) != pdTRUE) {
+    ESP_LOGW(TAG, "Failed to send STOPPED event");
+  }
 
   while (true) {
     delay(10);
@@ -181,6 +204,7 @@ void I2SAudioSpeaker::watch_() {
         break;
       case TaskEventType::STARTED:
         ESP_LOGD(TAG, "Started I2S Audio Speaker");
+        this->state_ = speaker::STATE_RUNNING;
         break;
       case TaskEventType::STOPPING:
         ESP_LOGD(TAG, "Stopping I2S Audio Speaker");
@@ -191,6 +215,7 @@ void I2SAudioSpeaker::watch_() {
       case TaskEventType::STOPPED:
         this->state_ = speaker::STATE_STOPPED;
         vTaskDelete(this->player_task_handle_);
+        this->task_created_ = false;
         this->player_task_handle_ = nullptr;
         this->parent_->unlock();
         xQueueReset(this->buffer_queue_);
@@ -208,7 +233,6 @@ void I2SAudioSpeaker::loop() {
   switch (this->state_) {
     case speaker::STATE_STARTING:
       this->start_();
-      break;
     case speaker::STATE_RUNNING:
     case speaker::STATE_STOPPING:
       this->watch_();

--- a/esphome/components/i2s_audio/speaker/i2s_audio_speaker.cpp
+++ b/esphome/components/i2s_audio/speaker/i2s_audio_speaker.cpp
@@ -143,7 +143,7 @@ void I2SAudioSpeaker::player_task(void *params) {
         }
         continue;
       }
-      if (bytes_written == 0 || bytes_written != sizeof(sample)) {
+      if (bytes_written != sizeof(sample)) {
         event = {.type = TaskEventType::WARNING, .err = ESP_FAIL};
         if (xQueueSend(this_speaker->event_queue_, &event, 10 / portTICK_PERIOD_MS) != pdTRUE) {
           ESP_LOGW(TAG, "Failed to send WARNING event");

--- a/esphome/components/i2s_audio/speaker/i2s_audio_speaker.h
+++ b/esphome/components/i2s_audio/speaker/i2s_audio_speaker.h
@@ -60,7 +60,6 @@ class I2SAudioSpeaker : public Component, public speaker::Speaker, public I2SAud
 
  protected:
   void start_();
-  // void stop_();
   void watch_();
 
   static void player_task(void *params);
@@ -70,6 +69,7 @@ class I2SAudioSpeaker : public Component, public speaker::Speaker, public I2SAud
   QueueHandle_t event_queue_;
 
   uint8_t dout_pin_{0};
+  bool task_created_{false};
 
 #if SOC_I2S_SUPPORTS_DAC
   i2s_dac_mode_t internal_dac_mode_{I2S_DAC_CHANNEL_DISABLE};


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

- Don't set speaker running state until speaker task is fully started. (Extracted from esphome/esphome#6718)
- Send log from task if queueing events fails
- Move STOPPING event earlier

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
