### PR TITLE
[docker] Avoid unsafe git error when container user and file config volume permissions don't match

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -101,7 +101,7 @@ RUN --mount=type=tmpfs,target=/root/.cargo if [ "$TARGETARCH$TARGETVARIANT" = "a
     && /platformio_install_deps.py /platformio.ini --libraries
 
 # Avoid unsafe git error when container user and file config volume permissions don't match
-RUN git config --system --add safe.directory '/config/*'
+RUN git config --system --add safe.directory '*'
 
 
 # ======================= docker-type image =======================


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

This is a rework of esphome/esphome/#6843 where during code review at the request of @jesserockz the safe path was changed from `*` to `/config/*`.  
While looking for a way to move the `.esphome` folder out of `/config`, @ssieb made me aware of `/data` (that can be set by users and is used by the HA addon), and investigating the code I also found a `/cache` path in use.  
To avoid any further path specific dependencies, I am proposing to just disable the safe ownership check by using `*`, as I see no harm in doing so in this use of docker, and adding explicit paths may break in future as paths are changed, especially undocumented paths. (more brittle alternative is to exclude `/config/*`, and `/data/*`, etc.)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** reworks esphome/esphome/#6843

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
