### PR TITLE
fix: arduino media player still sets wrong state.

### DIFF
--- a/esphome/components/i2s_audio/media_player/i2s_audio_media_player.cpp
+++ b/esphome/components/i2s_audio/media_player/i2s_audio_media_player.cpp
@@ -28,7 +28,7 @@ void I2SAudioMediaPlayer::control(const media_player::MediaPlayerCall &call) {
     }
   }
 
-  if (this->state == media_player::MEDIA_PLAYER_STATE_ANNOUNCING) {
+  if (play_state == media_player::MEDIA_PLAYER_STATE_ANNOUNCING) {
     this->is_announcement_ = true;
   }
 


### PR DESCRIPTION
# What does this implement/fix?

Embarrassing, but I managed to create even another bug in such a few code changes ;(
Now, it should really compare the right variables for setting `is_announcement_`

<!-- Quick description and explanation of changes -->

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
