### PR TITLE
[animation] Allow loading external url at build time

### DIFF
--- a/esphome/components/animation/__init__.py
+++ b/esphome/components/animation/__init__.py
@@ -171,7 +171,7 @@ async def to_code(config):
     if conf_file[CONF_SOURCE] == SOURCE_LOCAL:
         path = CORE.relative_config_path(conf_file[CONF_PATH])
     elif conf_file[CONF_SOURCE] == SOURCE_WEB:
-        path = espImage._compute_local_image_path(conf_file).as_posix()
+        path = espImage.compute_local_image_path(conf_file).as_posix()
     try:
         image = Image.open(path)
     except Exception as e:

--- a/esphome/components/animation/__init__.py
+++ b/esphome/components/animation/__init__.py
@@ -3,7 +3,13 @@ import logging
 from esphome import automation, core
 from esphome.components import font
 import esphome.components.image as espImage
-from esphome.components.image import CONF_USE_TRANSPARENCY
+from esphome.components.image import (
+    CONF_USE_TRANSPARENCY,
+    LOCAL_SCHEMA,
+    WEB_SCHEMA,
+    SOURCE_WEB,
+    SOURCE_LOCAL,
+)
 import esphome.config_validation as cv
 import esphome.codegen as cg
 from esphome.const import (
@@ -13,6 +19,9 @@ from esphome.const import (
     CONF_REPEAT,
     CONF_RESIZE,
     CONF_TYPE,
+    CONF_SOURCE,
+    CONF_PATH,
+    CONF_URL,
 )
 from esphome.core import CORE, HexInt
 
@@ -43,6 +52,40 @@ SetFrameAction = animation_ns.class_(
     "AnimationSetFrameAction", automation.Action, cg.Parented.template(Animation_)
 )
 
+TYPED_FILE_SCHEMA = cv.typed_schema(
+    {
+        SOURCE_LOCAL: LOCAL_SCHEMA,
+        SOURCE_WEB: WEB_SCHEMA,
+    },
+    key=CONF_SOURCE,
+)
+
+
+def _file_schema(value):
+    if isinstance(value, str):
+        return validate_file_shorthand(value)
+    return TYPED_FILE_SCHEMA(value)
+
+
+FILE_SCHEMA = cv.Schema(_file_schema)
+
+
+def validate_file_shorthand(value):
+    value = cv.string_strict(value)
+    if value.startswith("http://") or value.startswith("https://"):
+        return FILE_SCHEMA(
+            {
+                CONF_SOURCE: SOURCE_WEB,
+                CONF_URL: value,
+            }
+        )
+    return FILE_SCHEMA(
+        {
+            CONF_SOURCE: SOURCE_LOCAL,
+            CONF_PATH: value,
+        }
+    )
+
 
 def validate_cross_dependencies(config):
     """
@@ -67,7 +110,7 @@ ANIMATION_SCHEMA = cv.Schema(
     cv.All(
         {
             cv.Required(CONF_ID): cv.declare_id(Animation_),
-            cv.Required(CONF_FILE): cv.file_,
+            cv.Required(CONF_FILE): FILE_SCHEMA,
             cv.Optional(CONF_RESIZE): cv.dimensions,
             cv.Optional(CONF_TYPE, default="BINARY"): cv.enum(
                 espImage.IMAGE_TYPE, upper=True
@@ -124,7 +167,11 @@ async def animation_action_to_code(config, action_id, template_arg, args):
 async def to_code(config):
     from PIL import Image
 
-    path = CORE.relative_config_path(config[CONF_FILE])
+    conf_file = config[CONF_FILE]
+    if conf_file[CONF_SOURCE] == SOURCE_LOCAL:
+        path = CORE.relative_config_path(conf_file[CONF_PATH])
+    elif conf_file[CONF_SOURCE] == SOURCE_WEB:
+        path = espImage._compute_local_image_path(conf_file).as_posix()
     try:
         image = Image.open(path)
     except Exception as e:
@@ -157,7 +204,7 @@ async def to_code(config):
             pixels = list(frame.getdata())
             if len(pixels) != height * width:
                 raise core.EsphomeError(
-                    f"Unexpected number of pixels in {path} frame {frameIndex}: ({len(pixels)} != {height*width})"
+                    f"Unexpected number of pixels in {path} frame {frameIndex}: ({len(pixels)} != {height * width})"
                 )
             for pix, a in pixels:
                 if transparent:
@@ -180,7 +227,7 @@ async def to_code(config):
             pixels = list(frame.getdata())
             if len(pixels) != height * width:
                 raise core.EsphomeError(
-                    f"Unexpected number of pixels in {path} frame {frameIndex}: ({len(pixels)} != {height*width})"
+                    f"Unexpected number of pixels in {path} frame {frameIndex}: ({len(pixels)} != {height * width})"
                 )
             for pix in pixels:
                 data[pos] = pix[0]
@@ -203,7 +250,7 @@ async def to_code(config):
             pixels = list(frame.getdata())
             if len(pixels) != height * width:
                 raise core.EsphomeError(
-                    f"Unexpected number of pixels in {path} frame {frameIndex}: ({len(pixels)} != {height*width})"
+                    f"Unexpected number of pixels in {path} frame {frameIndex}: ({len(pixels)} != {height * width})"
                 )
             for r, g, b, a in pixels:
                 if transparent:
@@ -232,7 +279,7 @@ async def to_code(config):
             pixels = list(frame.getdata())
             if len(pixels) != height * width:
                 raise core.EsphomeError(
-                    f"Unexpected number of pixels in {path} frame {frameIndex}: ({len(pixels)} != {height*width})"
+                    f"Unexpected number of pixels in {path} frame {frameIndex}: ({len(pixels)} != {height * width})"
                 )
             for r, g, b, a in pixels:
                 R = r >> 3

--- a/esphome/components/image/__init__.py
+++ b/esphome/components/image/__init__.py
@@ -68,7 +68,7 @@ def _compute_local_icon_path(value: dict) -> Path:
     return base_dir / f"{value[CONF_ICON]}.svg"
 
 
-def _compute_local_image_path(value: dict) -> Path:
+def compute_local_image_path(value: dict) -> Path:
     url = value[CONF_URL]
     h = hashlib.new("sha256")
     h.update(url.encode())
@@ -117,7 +117,7 @@ def download_mdi(value):
 
 def download_image(value):
     url = value[CONF_URL]
-    path = _compute_local_image_path(value)
+    path = compute_local_image_path(value)
 
     download_content(url, path)
 
@@ -295,7 +295,7 @@ async def to_code(config):
         path = _compute_local_icon_path(conf_file).as_posix()
 
     elif conf_file[CONF_SOURCE] == SOURCE_WEB:
-        path = _compute_local_image_path(conf_file).as_posix()
+        path = compute_local_image_path(conf_file).as_posix()
 
     try:
         with open(path, "rb") as f:


### PR DESCRIPTION
# Download animations from url, like other images and fonts

Support downloading remote GIF images on build

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** 
- remote images https://github.com/esphome/esphome/pull/5214
- remote fonts https://github.com/esphome/esphome/pull/5254
- issue https://github.com/esphome/issues/issues/5232

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
external_components:
  - source: github://pr#6876
    components: [ animation ]

animation:
  - file: https://upload.wikimedia.org/wikipedia/commons/2/2c/Rotating_earth_%28large%29.gif
    type: RGB24
    id: dummy
    resize: 100x100
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
