### PR TITLE
[Deep sleep] Compilation error with IDF >= 5.*

### DIFF
--- a/esphome/components/deep_sleep/deep_sleep_component.h
+++ b/esphome/components/deep_sleep/deep_sleep_component.h
@@ -34,10 +34,12 @@ enum WakeupPinMode {
   WAKEUP_PIN_MODE_INVERT_WAKEUP,
 };
 
+#if defined(USE_ESP32) && !defined(USE_ESP32_VARIANT_ESP32C3)
 struct Ext1Wakeup {
   uint64_t mask;
   esp_sleep_ext1_wakeup_mode_t wakeup_mode;
 };
+#endif
 
 struct WakeupCauseToRunDuration {
   // Run duration if woken up by timer or any other reason besides those below.

--- a/esphome/components/deep_sleep/deep_sleep_component.h
+++ b/esphome/components/deep_sleep/deep_sleep_component.h
@@ -116,7 +116,11 @@ class DeepSleepComponent : public Component {
 #ifdef USE_ESP32
   InternalGPIOPin *wakeup_pin_;
   WakeupPinMode wakeup_pin_mode_{WAKEUP_PIN_MODE_IGNORE};
+
+#if !defined(USE_ESP32_VARIANT_ESP32C3)
   optional<Ext1Wakeup> ext1_wakeup_;
+#endif
+
   optional<bool> touch_wakeup_;
   optional<WakeupCauseToRunDuration> wakeup_cause_to_run_duration_;
 #endif


### PR DESCRIPTION
# What does this implement/fix?

Quick fix to remove `esp_sleep_ext1_wakeup_mode_t` usage in case it's not needed.

There is a [better way to handle that](https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-reference/system/soc_caps.html) but I want make diff minimal.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
```yaml
esp32:
  board: esp32-c3-devkitm-1
  framework:
    type: esp-idf
    platform_version: 6.5.0
    version: latest

deep_sleep:
  id: deep_sleep_component
  run_duration: 1000ms
  sleep_duration: 5000ms
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
