### PR TITLE
Allow parse_json to return a boolean result

### DIFF
--- a/esphome/components/json/json_util.cpp
+++ b/esphome/components/json/json_util.cpp
@@ -62,7 +62,7 @@ std::string build_json(const json_build_t &f) {
   }
 }
 
-void parse_json(const std::string &data, const json_parse_t &f) {
+bool parse_json(const std::string &data, const json_parse_t &f) {
   // Here we are allocating 1.5 times the data size,
   // with the heap size minus 2kb to be safe if less than that
   // as we can not have a true dynamic sized document.
@@ -83,7 +83,7 @@ void parse_json(const std::string &data, const json_parse_t &f) {
     if (json_document.capacity() == 0) {
       ESP_LOGE(TAG, "Could not allocate memory for JSON document! Requested %u bytes, free heap: %u", request_size,
                free_heap);
-      return;
+      return false;
     }
     DeserializationError err = deserializeJson(json_document, data);
     json_document.shrinkToFit();
@@ -92,20 +92,21 @@ void parse_json(const std::string &data, const json_parse_t &f) {
 
     if (err == DeserializationError::Ok) {
       pass = true;
-      f(root);
+      return f(root);
     } else if (err == DeserializationError::NoMemory) {
       if (request_size * 2 >= free_heap) {
         ESP_LOGE(TAG, "Can not allocate more memory for deserialization. Consider making source string smaller");
-        return;
+        return false;
       }
       ESP_LOGV(TAG, "Increasing memory allocation.");
       request_size *= 2;
       continue;
     } else {
       ESP_LOGE(TAG, "JSON parse error: %s", err.c_str());
-      return;
+      return false;
     }
   } while (!pass);
+  return false;
 }
 
 }  // namespace json

--- a/esphome/components/json/json_util.cpp
+++ b/esphome/components/json/json_util.cpp
@@ -76,9 +76,8 @@ bool parse_json(const std::string &data, const json_parse_t &f) {
 #elif defined(USE_LIBRETINY)
   const size_t free_heap = lt_heap_get_free();
 #endif
-  bool pass = false;
   size_t request_size = std::min(free_heap, (size_t) (data.size() * 1.5));
-  do {
+  while (true) {
     DynamicJsonDocument json_document(request_size);
     if (json_document.capacity() == 0) {
       ESP_LOGE(TAG, "Could not allocate memory for JSON document! Requested %u bytes, free heap: %u", request_size,
@@ -91,7 +90,6 @@ bool parse_json(const std::string &data, const json_parse_t &f) {
     JsonObject root = json_document.as<JsonObject>();
 
     if (err == DeserializationError::Ok) {
-      pass = true;
       return f(root);
     } else if (err == DeserializationError::NoMemory) {
       if (request_size * 2 >= free_heap) {
@@ -105,7 +103,7 @@ bool parse_json(const std::string &data, const json_parse_t &f) {
       ESP_LOGE(TAG, "JSON parse error: %s", err.c_str());
       return false;
     }
-  } while (!pass);
+  };
   return false;
 }
 

--- a/esphome/components/json/json_util.h
+++ b/esphome/components/json/json_util.h
@@ -14,7 +14,7 @@ namespace esphome {
 namespace json {
 
 /// Callback function typedef for parsing JsonObjects.
-using json_parse_t = std::function<void(JsonObject)>;
+using json_parse_t = std::function<bool(JsonObject)>;
 
 /// Callback function typedef for building JsonObjects.
 using json_build_t = std::function<void(JsonObject)>;
@@ -23,7 +23,7 @@ using json_build_t = std::function<void(JsonObject)>;
 std::string build_json(const json_build_t &f);
 
 /// Parse a JSON string and run the provided json parse function if it's valid.
-void parse_json(const std::string &data, const json_parse_t &f);
+bool parse_json(const std::string &data, const json_parse_t &f);
 
 }  // namespace json
 }  // namespace esphome

--- a/esphome/components/mqtt/mqtt_client.cpp
+++ b/esphome/components/mqtt/mqtt_client.cpp
@@ -410,7 +410,10 @@ void MQTTClientComponent::subscribe(const std::string &topic, mqtt_callback_t ca
 
 void MQTTClientComponent::subscribe_json(const std::string &topic, const mqtt_json_callback_t &callback, uint8_t qos) {
   auto f = [callback](const std::string &topic, const std::string &payload) {
-    json::parse_json(payload, [topic, callback](JsonObject root) { callback(topic, root); });
+    json::parse_json(payload, [topic, callback](JsonObject root) -> bool {
+      callback(topic, root);
+      return true;
+    });
   };
   MQTTSubscription subscription{
       .topic = topic,


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->
This allows for returning true/false if the json parsing was missing a required field for example. This is a breaking change as the callback needs to have a boolean return value now.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
