### PR TITLE
Fix the default NOx index offset

### DIFF
--- a/esphome/components/sen5x/sensor.py
+++ b/esphome/components/sen5x/sensor.py
@@ -82,6 +82,7 @@ GAS_SENSOR = cv.Schema(
                 ): cv.int_range(0, 3000),
                 cv.Optional(CONF_STD_INITIAL, default=50): cv.int_,
                 cv.Optional(CONF_GAIN_FACTOR, default=230): cv.int_range(1, 1000),
+                cv.Optional(CONF_INDEX_OFFSET_NOX, default=1): cv.int_range(1, 250),
             }
         )
     }
@@ -219,7 +220,7 @@ async def to_code(config):
         cfg = config[CONF_NOX][CONF_ALGORITHM_TUNING]
         cg.add(
             var.set_nox_algorithm_tuning(
-                cfg[CONF_INDEX_OFFSET],
+                cfg[CONF_INDEX_OFFSET_NOX],
                 cfg[CONF_LEARNING_TIME_OFFSET_HOURS],
                 cfg[CONF_LEARNING_TIME_GAIN_HOURS],
                 cfg[CONF_GATING_MAX_DURATION_MINUTES],


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->
Fix https://github.com/esphome/issues/issues/5895 by fixing the default NOx index offset according to the document provided.
## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/5895

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
