### PR TITLE
[Dockerfile] Sync platformio version with requirements.txt

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -81,7 +81,7 @@ RUN \
     fi; \
     pip3 install \
     --break-system-packages --no-cache-dir \
-    platformio==6.1.13 \
+    platformio==6.1.15 \ # Keep in sync with requirements.txt
     # Change some platformio settings
     && platformio settings set enable_telemetry No \
     && platformio settings set check_platformio_interval 1000000 \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -81,7 +81,8 @@ RUN \
     fi; \
     pip3 install \
     --break-system-packages --no-cache-dir \
-    platformio==6.1.15 \ # Keep in sync with requirements.txt
+    # Keep platformio version in sync with requirements.txt
+    platformio==6.1.15 \
     # Change some platformio settings
     && platformio settings set enable_telemetry No \
     && platformio settings set check_platformio_interval 1000000 \


### PR DESCRIPTION
platformio version is not in sync with requirements.txt

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

`platformio` version being installed in `Dockerfile` is out of sync with version installed using `requirements.txt`.

Per requirements.txt: `platformio==6.1.15  # When updating platformio, also update Dockerfile`. 
Dockerfile: `platformio==6.1.13`.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
