### PR TITLE
add cert-pem configurable

### DIFF
--- a/esphome/components/http_request/http_request_idf.cpp
+++ b/esphome/components/http_request/http_request_idf.cpp
@@ -57,6 +57,7 @@ std::shared_ptr<HttpContainer> HttpRequestIDF::start(std::string url, std::strin
     config.crt_bundle_attach = esp_crt_bundle_attach;
   }
 #endif
+  config.cert_pem = this->cert_pem_;
 
   if (this->useragent_ != nullptr) {
     config.user_agent = this->useragent_;

--- a/esphome/components/http_request/http_request_idf.h
+++ b/esphome/components/http_request/http_request_idf.h
@@ -26,6 +26,11 @@ class HttpRequestIDF : public HttpRequestComponent {
  public:
   std::shared_ptr<HttpContainer> start(std::string url, std::string method, std::string body,
                                        std::list<Header> headers) override;
+
+  void set_certificate_pem(const char *cert_pem) { this->cert_pem_ = cert_pem; }
+
+ protected:
+  const char *cert_pem_{nullptr};
 };
 
 }  // namespace http_request


### PR DESCRIPTION
# What does this implement/fix?

add option to set the cert_pem for http request, in that case the full certs are not required, hence I added a weird condition on the python side.

I guess this component should be MULTI_CONF to support different servers properly.

Let me know if you want me to add more validation python side, or any other requirements, etc. then I'll do docs.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
