### PR TITLE
[CI] Allow clang-tidy to see IDF components

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -387,6 +387,13 @@ jobs:
           echo "::add-matcher::.github/workflows/matchers/gcc.json"
           echo "::add-matcher::.github/workflows/matchers/clang-tidy.json"
 
+      - name: Run 'pio run --list-targets -e esp32-idf-tidy'
+        if: matrix.name == 'Run script/clang-tidy for ESP32 IDF'
+        run: |
+          . venv/bin/activate
+          mkdir -p .temp
+          pio run --list-targets -e esp32-idf-tidy
+
       - name: Run clang-tidy
         run: |
           . venv/bin/activate

--- a/esphome/idf_component.yml
+++ b/esphome/idf_component.yml
@@ -1,0 +1,10 @@
+dependencies:
+  esp32_camera:
+    git: https://github.com/espressif/esp32-camera.git
+    version: v2.0.9
+  mdns:
+    git: https://github.com/espressif/esp-protocols.git
+    version: mdns-v1.2.5
+    path: components/mdns
+    rules:
+      - if: "idf_version >=5.0"

--- a/esphome/idf_component.yml
+++ b/esphome/idf_component.yml
@@ -1,7 +1,6 @@
 dependencies:
-  esp32_camera:
-    git: https://github.com/espressif/esp32-camera.git
-    version: v2.0.9
+  esp-tflite-micro:
+    git: https://github.com/espressif/esp-tflite-micro.git
   mdns:
     git: https://github.com/espressif/esp-protocols.git
     version: mdns-v1.2.5

--- a/script/clang-tidy
+++ b/script/clang-tidy
@@ -101,8 +101,10 @@ def clang_options(idedata):
     # add library include directories using -isystem to suppress their errors
     for directory in sorted(set(idedata["includes"]["build"])):
         # skip our own directories, we add those later
-        if not directory.startswith(f"{root_path}/") or directory.startswith(
-            f"{root_path}/.pio/"
+        if (
+            not directory.startswith(f"{root_path}/")
+            or directory.startswith(f"{root_path}/.pio/")
+            or directory.startswith(f"{root_path}/managed_components/")
         ):
             cmd.extend(["-isystem", directory])
 


### PR DESCRIPTION
# What does this implement/fix?

Allow clang-tidy to see IDF components so CI can succeed.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/5868

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
