### PR TITLE
Inherit `esp32_ble_beacon` from `esp32_ble`

### DIFF
--- a/esphome/components/esp32_ble/__init__.py
+++ b/esphome/components/esp32_ble/__init__.py
@@ -10,6 +10,7 @@ CODEOWNERS = ["@jesserockz", "@Rapsssito"]
 
 CONF_BLE_ID = "ble_id"
 CONF_IO_CAPABILITY = "io_capability"
+CONF_ADVERTISING_CYCLE_TIME = "advertising_cycle_time"
 
 NO_BLUETOOTH_VARIANTS = [const.VARIANT_ESP32S2]
 
@@ -33,6 +34,19 @@ IO_CAPABILITY = {
     "display_yes_no": IoCapability.IO_CAP_IO,
 }
 
+esp_power_level_t = cg.global_ns.enum("esp_power_level_t")
+
+TX_POWER_LEVELS = {
+    -12: esp_power_level_t.ESP_PWR_LVL_N12,
+    -9: esp_power_level_t.ESP_PWR_LVL_N9,
+    -6: esp_power_level_t.ESP_PWR_LVL_N6,
+    -3: esp_power_level_t.ESP_PWR_LVL_N3,
+    0: esp_power_level_t.ESP_PWR_LVL_N0,
+    3: esp_power_level_t.ESP_PWR_LVL_P3,
+    6: esp_power_level_t.ESP_PWR_LVL_P6,
+    9: esp_power_level_t.ESP_PWR_LVL_P9,
+}
+
 CONFIG_SCHEMA = cv.Schema(
     {
         cv.GenerateID(): cv.declare_id(ESP32BLE),
@@ -40,6 +54,9 @@ CONFIG_SCHEMA = cv.Schema(
             IO_CAPABILITY, lower=True
         ),
         cv.Optional(CONF_ENABLE_ON_BOOT, default=True): cv.boolean,
+        cv.Optional(
+            CONF_ADVERTISING_CYCLE_TIME, default="10s"
+        ): cv.positive_time_period_milliseconds,
     }
 ).extend(cv.COMPONENT_SCHEMA)
 
@@ -57,6 +74,7 @@ async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     cg.add(var.set_enable_on_boot(config[CONF_ENABLE_ON_BOOT]))
     cg.add(var.set_io_capability(config[CONF_IO_CAPABILITY]))
+    cg.add(var.set_advertising_cycle_time(config[CONF_ADVERTISING_CYCLE_TIME]))
     await cg.register_component(var, config)
 
     if CORE.using_esp_idf:

--- a/esphome/components/esp32_ble/__init__.py
+++ b/esphome/components/esp32_ble/__init__.py
@@ -7,7 +7,6 @@ from esphome.components.esp32 import add_idf_sdkconfig_option, get_esp32_variant
 
 DEPENDENCIES = ["esp32"]
 CODEOWNERS = ["@jesserockz", "@Rapsssito"]
-CONFLICTS_WITH = ["esp32_ble_beacon"]
 
 CONF_BLE_ID = "ble_id"
 CONF_IO_CAPABILITY = "io_capability"

--- a/esphome/components/esp32_ble/ble.cpp
+++ b/esphome/components/esp32_ble/ble.cpp
@@ -78,6 +78,12 @@ void ESP32BLE::advertising_set_manufacturer_data(const std::vector<uint8_t> &dat
   this->advertising_start();
 }
 
+void ESP32BLE::advertising_set_ibeacon_data(std::array<uint8_t, 16> uuid, uint16_t major, uint16_t minor,
+                                            int8_t measured_power) {
+  this->advertising_init_();
+  this->advertising_->set_ibeacon_data(uuid, major, minor, measured_power);
+}
+
 void ESP32BLE::advertising_add_service_uuid(ESPBTUUID uuid) {
   this->advertising_init_();
   this->advertising_->add_service_uuid(uuid);

--- a/esphome/components/esp32_ble/ble.h
+++ b/esphome/components/esp32_ble/ble.h
@@ -89,6 +89,8 @@ class ESP32BLE : public Component {
   void advertising_set_manufacturer_data(const std::vector<uint8_t> &data);
   void advertising_add_service_uuid(ESPBTUUID uuid);
   void advertising_remove_service_uuid(ESPBTUUID uuid);
+  void advertising_set_ibeacon_data(std::array<uint8_t, 16> uuid, uint16_t major, uint16_t minor,
+                                    int8_t measured_power);
 
   void register_gap_event_handler(GAPEventHandler *handler) { this->gap_event_handlers_.push_back(handler); }
   void register_gattc_event_handler(GATTcEventHandler *handler) { this->gattc_event_handlers_.push_back(handler); }

--- a/esphome/components/esp32_ble/ble.h
+++ b/esphome/components/esp32_ble/ble.h
@@ -3,6 +3,8 @@
 #include "ble_advertising.h"
 #include "ble_uuid.h"
 
+#include <functional>
+
 #include "esphome/core/automation.h"
 #include "esphome/core/component.h"
 #include "esphome/core/defines.h"
@@ -76,6 +78,11 @@ class ESP32BLE : public Component {
  public:
   void set_io_capability(IoCapability io_capability) { this->io_cap_ = (esp_ble_io_cap_t) io_capability; }
 
+  void set_advertising_cycle_time(uint32_t advertising_cycle_time) {
+    this->advertising_cycle_time_ = advertising_cycle_time;
+  }
+  uint32_t get_advertising_cycle_time() const { return this->advertising_cycle_time_; }
+
   void enable();
   void disable();
   bool is_active();
@@ -89,8 +96,7 @@ class ESP32BLE : public Component {
   void advertising_set_manufacturer_data(const std::vector<uint8_t> &data);
   void advertising_add_service_uuid(ESPBTUUID uuid);
   void advertising_remove_service_uuid(ESPBTUUID uuid);
-  void advertising_set_ibeacon_data(std::array<uint8_t, 16> uuid, uint16_t major, uint16_t minor,
-                                    int8_t measured_power);
+  void advertising_register_raw_advertisement_callback(std::function<void(bool)> &&callback);
 
   void register_gap_event_handler(GAPEventHandler *handler) { this->gap_event_handlers_.push_back(handler); }
   void register_gattc_event_handler(GATTcEventHandler *handler) { this->gattc_event_handlers_.push_back(handler); }
@@ -123,6 +129,7 @@ class ESP32BLE : public Component {
   Queue<BLEEvent> ble_events_;
   BLEAdvertising *advertising_;
   esp_ble_io_cap_t io_cap_{ESP_IO_CAP_NONE};
+  uint32_t advertising_cycle_time_;
   bool enable_on_boot_;
 };
 

--- a/esphome/components/esp32_ble/ble_advertising.h
+++ b/esphome/components/esp32_ble/ble_advertising.h
@@ -13,7 +13,7 @@
 namespace esphome {
 namespace esp32_ble {
 
-struct raw_adv_data_t {
+using raw_adv_data_t = struct {
   uint8_t *data;
   size_t length;
   esp_power_level_t power_level;

--- a/esphome/components/esp32_ble/ble_advertising.h
+++ b/esphome/components/esp32_ble/ble_advertising.h
@@ -1,44 +1,31 @@
 #pragma once
 
-#include <vector>
 #include <array>
+#include <functional>
+#include <vector>
 
 #ifdef USE_ESP32
 
+#include <esp_bt.h>
 #include <esp_gap_ble_api.h>
 #include <esp_gatts_api.h>
 
 namespace esphome {
 namespace esp32_ble {
 
-// NOLINTNEXTLINE(modernize-use-using)
-typedef struct {
-  uint8_t flags[3];
-  uint8_t length;
-  uint8_t type;
-  uint8_t company_id[2];
-  uint8_t beacon_type[2];
-} __attribute__((packed)) esp_ble_ibeacon_head_t;
-
-// NOLINTNEXTLINE(modernize-use-using)
-typedef struct {
-  uint8_t proximity_uuid[16];
-  uint16_t major;
-  uint16_t minor;
-  uint8_t measured_power;
-} __attribute__((packed)) esp_ble_ibeacon_vendor_t;
-
-// NOLINTNEXTLINE(modernize-use-using)
-typedef struct {
-  esp_ble_ibeacon_head_t ibeacon_head;
-  esp_ble_ibeacon_vendor_t ibeacon_vendor;
-} __attribute__((packed)) esp_ble_ibeacon_t;
+struct raw_adv_data_t {
+  uint8_t *data;
+  size_t length;
+  esp_power_level_t power_level;
+};
 
 class ESPBTUUID;
 
 class BLEAdvertising {
  public:
-  BLEAdvertising();
+  BLEAdvertising(uint32_t advertising_cycle_time);
+
+  void loop();
 
   void add_service_uuid(ESPBTUUID uuid);
   void remove_service_uuid(ESPBTUUID uuid);
@@ -46,17 +33,25 @@ class BLEAdvertising {
   void set_min_preferred_interval(uint16_t interval) { this->advertising_data_.min_interval = interval; }
   void set_manufacturer_data(const std::vector<uint8_t> &data);
   void set_service_data(const std::vector<uint8_t> &data);
-  void set_ibeacon_data(std::array<uint8_t, 16> uuid, uint16_t major, uint16_t minor, int8_t measured_power);
+  void register_raw_advertisement_callback(std::function<void(bool)> &&callback);
 
   void start();
   void stop();
 
  protected:
+  esp_err_t services_advertisement_();
+
   bool scan_response_;
   esp_ble_adv_data_t advertising_data_;
   esp_ble_adv_data_t scan_response_data_;
   esp_ble_adv_params_t advertising_params_;
   std::vector<ESPBTUUID> advertising_uuids_;
+
+  std::vector<std::function<void(bool)>> raw_advertisements_callbacks_;
+
+  const uint32_t advertising_cycle_time_;
+  uint32_t last_advertisement_time_{0};
+  int8_t current_adv_index_{-1};  // -1 means standard scan response
 };
 
 }  // namespace esp32_ble

--- a/esphome/components/esp32_ble/ble_advertising.h
+++ b/esphome/components/esp32_ble/ble_advertising.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <vector>
+#include <array>
 
 #ifdef USE_ESP32
 
@@ -9,6 +10,29 @@
 
 namespace esphome {
 namespace esp32_ble {
+
+// NOLINTNEXTLINE(modernize-use-using)
+typedef struct {
+  uint8_t flags[3];
+  uint8_t length;
+  uint8_t type;
+  uint8_t company_id[2];
+  uint8_t beacon_type[2];
+} __attribute__((packed)) esp_ble_ibeacon_head_t;
+
+// NOLINTNEXTLINE(modernize-use-using)
+typedef struct {
+  uint8_t proximity_uuid[16];
+  uint16_t major;
+  uint16_t minor;
+  uint8_t measured_power;
+} __attribute__((packed)) esp_ble_ibeacon_vendor_t;
+
+// NOLINTNEXTLINE(modernize-use-using)
+typedef struct {
+  esp_ble_ibeacon_head_t ibeacon_head;
+  esp_ble_ibeacon_vendor_t ibeacon_vendor;
+} __attribute__((packed)) esp_ble_ibeacon_t;
 
 class ESPBTUUID;
 
@@ -22,6 +46,7 @@ class BLEAdvertising {
   void set_min_preferred_interval(uint16_t interval) { this->advertising_data_.min_interval = interval; }
   void set_manufacturer_data(const std::vector<uint8_t> &data);
   void set_service_data(const std::vector<uint8_t> &data);
+  void set_ibeacon_data(std::array<uint8_t, 16> uuid, uint16_t major, uint16_t minor, int8_t measured_power);
 
   void start();
   void stop();

--- a/esphome/components/esp32_ble_beacon/__init__.py
+++ b/esphome/components/esp32_ble_beacon/__init__.py
@@ -1,16 +1,20 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
+from esphome.components.esp32_ble import CONF_BLE_ID
 from esphome.const import CONF_ID, CONF_TYPE, CONF_UUID, CONF_TX_POWER
 from esphome.core import CORE, TimePeriod
 from esphome.components.esp32 import add_idf_sdkconfig_option
 from esphome.components import esp32_ble
 
 DEPENDENCIES = ["esp32"]
-CONFLICTS_WITH = ["esp32_ble_tracker"]
 
 esp32_ble_beacon_ns = cg.esphome_ns.namespace("esp32_ble_beacon")
-ESP32BLEBeacon = esp32_ble_beacon_ns.class_("ESP32BLEBeacon", cg.Component)
-
+ESP32BLEBeacon = esp32_ble_beacon_ns.class_(
+    "ESP32BLEBeacon",
+    cg.Component,
+    esp32_ble.GAPEventHandler,
+    cg.Parented.template(esp32_ble.ESP32BLE),
+)
 CONF_MAJOR = "major"
 CONF_MINOR = "minor"
 CONF_MIN_INTERVAL = "min_interval"
@@ -28,6 +32,7 @@ CONFIG_SCHEMA = cv.All(
     cv.Schema(
         {
             cv.GenerateID(): cv.declare_id(ESP32BLEBeacon),
+            cv.GenerateID(CONF_BLE_ID): cv.use_id(esp32_ble.ESP32BLE),
             cv.Required(CONF_TYPE): cv.one_of("IBEACON", upper=True),
             cv.Required(CONF_UUID): cv.uuid,
             cv.Optional(CONF_MAJOR, default=10167): cv.uint16_t,
@@ -62,6 +67,10 @@ async def to_code(config):
     uuid = config[CONF_UUID].hex
     uuid_arr = [cg.RawExpression(f"0x{uuid[i:i + 2]}") for i in range(0, len(uuid), 2)]
     var = cg.new_Pvariable(config[CONF_ID], uuid_arr)
+
+    parent = await cg.get_variable(config[esp32_ble.CONF_BLE_ID])
+    cg.add(parent.register_gap_event_handler(var))
+
     await cg.register_component(var, config)
     cg.add(var.set_major(config[CONF_MAJOR]))
     cg.add(var.set_minor(config[CONF_MINOR]))

--- a/esphome/components/esp32_ble_beacon/__init__.py
+++ b/esphome/components/esp32_ble_beacon/__init__.py
@@ -6,6 +6,7 @@ from esphome.core import CORE, TimePeriod
 from esphome.components.esp32 import add_idf_sdkconfig_option
 from esphome.components import esp32_ble
 
+AUTO_LOAD = ["esp32_ble"]
 DEPENDENCIES = ["esp32"]
 
 esp32_ble_beacon_ns = cg.esphome_ns.namespace("esp32_ble_beacon")

--- a/esphome/components/esp32_ble_beacon/__init__.py
+++ b/esphome/components/esp32_ble_beacon/__init__.py
@@ -54,7 +54,7 @@ CONFIG_SCHEMA = cv.All(
                 min=-128, max=0
             ),
             cv.Optional(CONF_TX_POWER, default="3dBm"): cv.All(
-                cv.decibel, cv.one_of(-12, -9, -6, -3, 0, 3, 6, 9, int=True)
+                cv.decibel, cv.enum(esp32_ble.TX_POWER_LEVELS, int=True)
             ),
         }
     ).extend(cv.COMPONENT_SCHEMA),

--- a/esphome/components/esp32_ble_beacon/esp32_ble_beacon.cpp
+++ b/esphome/components/esp32_ble_beacon/esp32_ble_beacon.cpp
@@ -35,7 +35,7 @@ static esp_ble_adv_params_t ble_adv_params = {
     .adv_filter_policy = ADV_FILTER_ALLOW_SCAN_ANY_CON_ANY,
 };
 
-#define ENDIAN_CHANGE_U16(x) ((((x) &0xFF00) >> 8) + (((x) &0xFF) << 8))
+#define ENDIAN_CHANGE_U16(x) ((((x) & 0xFF00) >> 8) + (((x) & 0xFF) << 8))
 
 static const esp_ble_ibeacon_head_t IBEACON_COMMON_HEAD = {
     .flags = {0x02, 0x01, 0x06}, .length = 0x1A, .type = 0xFF, .company_id = {0x4C, 0x00}, .beacon_type = {0x02, 0x15}};
@@ -69,12 +69,11 @@ void ESP32BLEBeacon::setup() {
 float ESP32BLEBeacon::get_setup_priority() const { return setup_priority::BLUETOOTH; }
 
 void ESP32BLEBeacon::gap_event_handler(esp_gap_ble_cb_event_t event, esp_ble_gap_cb_param_t *param) {
-
   // init raw advertising data
   if (!init_finished) {
     ESP_LOGD(TAG, "Setting up BLE TX power");
-    esp_err_t err_tx = esp_ble_tx_power_set(ESP_BLE_PWR_TYPE_ADV,
-                               static_cast<esp_power_level_t>((global_esp32_ble_beacon->tx_power_ + 12) / 3));
+    esp_err_t err_tx = esp_ble_tx_power_set(
+        ESP_BLE_PWR_TYPE_ADV, static_cast<esp_power_level_t>((global_esp32_ble_beacon->tx_power_ + 12) / 3));
     if (err_tx != ESP_OK) {
       ESP_LOGE(TAG, "esp_ble_tx_power_set failed: %s", esp_err_to_name(err_tx));
       return;

--- a/esphome/components/esp32_ble_beacon/esp32_ble_beacon.cpp
+++ b/esphome/components/esp32_ble_beacon/esp32_ble_beacon.cpp
@@ -10,7 +10,9 @@
 #include <freertos/task.h>
 #include <nvs_flash.h>
 #include <cstring>
+
 #include "esphome/core/hal.h"
+#include "esphome/core/helpers.h"
 
 #ifdef USE_ARDUINO
 #include <esp32-hal-bt.h>
@@ -20,8 +22,6 @@ namespace esphome {
 namespace esp32_ble_beacon {
 
 static const char *const TAG = "esp32_ble_beacon";
-
-#define ENDIAN_CHANGE_U16(x) ((((x) & 0xFF00) >> 8) + (((x) & 0xFF) << 8))
 
 static const esp_ble_ibeacon_head_t IBEACON_COMMON_HEAD = {
     .flags = {0x02, 0x01, 0x06}, .length = 0x1A, .type = 0xFF, .company_id = {0x4C, 0x00}, .beacon_type = {0x02, 0x15}};
@@ -71,8 +71,8 @@ void ESP32BLEBeacon::on_advertise_() {
   memcpy(&ibeacon_adv_data.ibeacon_head, &IBEACON_COMMON_HEAD, sizeof(esp_ble_ibeacon_head_t));
   memcpy(&ibeacon_adv_data.ibeacon_vendor.proximity_uuid, this->uuid_.data(),
          sizeof(ibeacon_adv_data.ibeacon_vendor.proximity_uuid));
-  ibeacon_adv_data.ibeacon_vendor.minor = ENDIAN_CHANGE_U16(this->minor_);
-  ibeacon_adv_data.ibeacon_vendor.major = ENDIAN_CHANGE_U16(this->major_);
+  ibeacon_adv_data.ibeacon_vendor.minor = byteswap(this->minor_);
+  ibeacon_adv_data.ibeacon_vendor.major = byteswap(this->major_);
   ibeacon_adv_data.ibeacon_vendor.measured_power = static_cast<uint8_t>(this->measured_power_);
 
   ESP_LOGD(TAG, "Setting BLE TX power");

--- a/esphome/components/esp32_ble_beacon/esp32_ble_beacon.cpp
+++ b/esphome/components/esp32_ble_beacon/esp32_ble_beacon.cpp
@@ -35,7 +35,7 @@ static esp_ble_adv_params_t ble_adv_params = {
     .adv_filter_policy = ADV_FILTER_ALLOW_SCAN_ANY_CON_ANY,
 };
 
-#define ENDIAN_CHANGE_U16(x) ((((x) & 0xFF00) >> 8) + (((x) & 0xFF) << 8))
+#define ENDIAN_CHANGE_U16(x) ((((x) &0xFF00) >> 8) + (((x) &0xFF) << 8))
 
 static const esp_ble_ibeacon_head_t IBEACON_COMMON_HEAD = {
     .flags = {0x02, 0x01, 0x06}, .length = 0x1A, .type = 0xFF, .company_id = {0x4C, 0x00}, .beacon_type = {0x02, 0x15}};

--- a/esphome/components/esp32_ble_beacon/esp32_ble_beacon.cpp
+++ b/esphome/components/esp32_ble_beacon/esp32_ble_beacon.cpp
@@ -3,12 +3,12 @@
 
 #ifdef USE_ESP32
 
-#include <nvs_flash.h>
-#include <freertos/FreeRTOS.h>
-#include <esp_bt_main.h>
 #include <esp_bt.h>
-#include <freertos/task.h>
+#include <esp_bt_main.h>
 #include <esp_gap_ble_api.h>
+#include <freertos/FreeRTOS.h>
+#include <freertos/task.h>
+#include <nvs_flash.h>
 #include <cstring>
 #include "esphome/core/hal.h"
 
@@ -21,19 +21,10 @@ namespace esp32_ble_beacon {
 
 static const char *const TAG = "esp32_ble_beacon";
 
-// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
-static esp_ble_adv_params_t ble_adv_params = {
-    .adv_int_min = 0x20,
-    .adv_int_max = 0x40,
-    .adv_type = ADV_TYPE_NONCONN_IND,
-    .own_addr_type = BLE_ADDR_TYPE_PUBLIC,
-    .peer_addr = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
-    .peer_addr_type = BLE_ADDR_TYPE_PUBLIC,
-    .channel_map = ADV_CHNL_ALL,
-    .adv_filter_policy = ADV_FILTER_ALLOW_SCAN_ANY_CON_ANY,
-};
+#define ENDIAN_CHANGE_U16(x) ((((x) & 0xFF00) >> 8) + (((x) & 0xFF) << 8))
 
-#define ENDIAN_CHANGE_U16(x) ((((x) &0xFF00) >> 8) + (((x) &0xFF) << 8))
+static const esp_ble_ibeacon_head_t IBEACON_COMMON_HEAD = {
+    .flags = {0x02, 0x01, 0x06}, .length = 0x1A, .type = 0xFF, .company_id = {0x4C, 0x00}, .beacon_type = {0x02, 0x15}};
 
 void ESP32BLEBeacon::dump_config() {
   ESP_LOGCONFIG(TAG, "ESP32 BLE Beacon:");
@@ -50,46 +41,62 @@ void ESP32BLEBeacon::dump_config() {
                 "  UUID: %s, Major: %u, Minor: %u, Min Interval: %ums, Max Interval: %ums, Measured Power: %d"
                 ", TX Power: %ddBm",
                 uuid, this->major_, this->minor_, this->min_interval_, this->max_interval_, this->measured_power_,
-                this->tx_power_);
-}
-
-void ESP32BLEBeacon::setup() {
-  ESP_LOGCONFIG(TAG, "Setting up ESP32 BLE beacon...");
-  global_esp32_ble_beacon = this;
-
-  ble_adv_params.adv_int_min = static_cast<uint16_t>(global_esp32_ble_beacon->min_interval_ / 0.625f);
-  ble_adv_params.adv_int_max = static_cast<uint16_t>(global_esp32_ble_beacon->max_interval_ / 0.625f);
+                (this->tx_power_ * 3) - 12);
 }
 
 float ESP32BLEBeacon::get_setup_priority() const { return setup_priority::AFTER_BLUETOOTH; }
 
-void ESP32BLEBeacon::loop() {
-  if (!this->finished_init_) {
-    ESP_LOGD(TAG, "Setting BLE TX power");
-    esp_err_t err_tx = esp_ble_tx_power_set(
-        ESP_BLE_PWR_TYPE_ADV, static_cast<esp_power_level_t>((global_esp32_ble_beacon->tx_power_ + 12) / 3));
-    if (err_tx != ESP_OK) {
-      ESP_LOGE(TAG, "esp_ble_tx_power_set failed: %s", esp_err_to_name(err_tx));
-      return;
+void ESP32BLEBeacon::setup() {
+  this->ble_adv_params_ = {
+      .adv_int_min = static_cast<uint16_t>(this->min_interval_ / 0.625f),
+      .adv_int_max = static_cast<uint16_t>(this->max_interval_ / 0.625f),
+      .adv_type = ADV_TYPE_NONCONN_IND,
+      .own_addr_type = BLE_ADDR_TYPE_PUBLIC,
+      .peer_addr = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+      .peer_addr_type = BLE_ADDR_TYPE_PUBLIC,
+      .channel_map = ADV_CHNL_ALL,
+      .adv_filter_policy = ADV_FILTER_ALLOW_SCAN_ANY_CON_ANY,
+  };
+
+  global_ble->advertising_register_raw_advertisement_callback([this](bool advertise) {
+    this->advertising_ = advertise;
+    if (advertise) {
+      this->on_advertise_();
     }
+  });
+}
 
-    esp32_ble::global_ble->advertising_set_ibeacon_data(
-        global_esp32_ble_beacon->uuid_, ENDIAN_CHANGE_U16(global_esp32_ble_beacon->major_),
-        ENDIAN_CHANGE_U16(global_esp32_ble_beacon->minor_),
-        static_cast<uint8_t>(
-            global_esp32_ble_beacon->measured_power_));  // NOLINT(cppcoreguidelines-pro-type-cstyle-cast
+void ESP32BLEBeacon::on_advertise_() {
+  esp_ble_ibeacon_t ibeacon_adv_data;
+  memcpy(&ibeacon_adv_data.ibeacon_head, &IBEACON_COMMON_HEAD, sizeof(esp_ble_ibeacon_head_t));
+  memcpy(&ibeacon_adv_data.ibeacon_vendor.proximity_uuid, this->uuid_.data(),
+         sizeof(ibeacon_adv_data.ibeacon_vendor.proximity_uuid));
+  ibeacon_adv_data.ibeacon_vendor.minor = ENDIAN_CHANGE_U16(this->minor_);
+  ibeacon_adv_data.ibeacon_vendor.major = ENDIAN_CHANGE_U16(this->major_);
+  ibeacon_adv_data.ibeacon_vendor.measured_power = static_cast<uint8_t>(this->measured_power_);
 
-    this->finished_init_ = true;
+  ESP_LOGD(TAG, "Setting BLE TX power");
+  esp_err_t err = esp_ble_tx_power_set(ESP_BLE_PWR_TYPE_ADV, this->tx_power_);
+  if (err != ESP_OK) {
+    ESP_LOGW(TAG, "esp_ble_tx_power_set failed: %s", esp_err_to_name(err));
+  }
+  err = esp_ble_gap_config_adv_data_raw((uint8_t *) &ibeacon_adv_data, sizeof(ibeacon_adv_data));
+  if (err != ESP_OK) {
+    ESP_LOGE(TAG, "esp_ble_gap_config_adv_data_raw failed: %s", esp_err_to_name(err));
+    return;
   }
 }
 
 void ESP32BLEBeacon::gap_event_handler(esp_gap_ble_cb_event_t event, esp_ble_gap_cb_param_t *param) {
+  if (!this->advertising_)
+    return;
+
   esp_err_t err;
   switch (event) {
     case ESP_GAP_BLE_ADV_DATA_RAW_SET_COMPLETE_EVT: {
-      err = esp_ble_gap_start_advertising(&ble_adv_params);
+      err = esp_ble_gap_start_advertising(&this->ble_adv_params_);
       if (err != ESP_OK) {
-        ESP_LOGE(TAG, "esp_ble_gap_start_advertising failed: %d", err);
+        ESP_LOGE(TAG, "esp_ble_gap_start_advertising failed: %s", esp_err_to_name(err));
       }
       break;
     }
@@ -107,14 +114,13 @@ void ESP32BLEBeacon::gap_event_handler(esp_gap_ble_cb_event_t event, esp_ble_gap
       } else {
         ESP_LOGD(TAG, "BLE stopped advertising successfully");
       }
+      // this->advertising_ = false;
       break;
     }
     default:
       break;
   }
 }
-
-ESP32BLEBeacon *global_esp32_ble_beacon = nullptr;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
 }  // namespace esp32_ble_beacon
 }  // namespace esphome

--- a/esphome/components/esp32_ble_beacon/esp32_ble_beacon.cpp
+++ b/esphome/components/esp32_ble_beacon/esp32_ble_beacon.cpp
@@ -21,8 +21,6 @@ namespace esp32_ble_beacon {
 
 static const char *const TAG = "esp32_ble_beacon";
 
-static bool init_finished = false;
-
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 static esp_ble_adv_params_t ble_adv_params = {
     .adv_int_min = 0x20,

--- a/esphome/components/esp32_ble_beacon/esp32_ble_beacon.h
+++ b/esphome/components/esp32_ble_beacon/esp32_ble_beacon.h
@@ -36,10 +36,7 @@ typedef struct {
   esp_ble_ibeacon_vendor_t ibeacon_vendor;
 } __attribute__((packed)) esp_ble_ibeacon_t;
 
-class ESP32BLEBeacon : public Component,
-                       public GAPEventHandler,
-                       public Parented<ESP32BLE>
-{
+class ESP32BLEBeacon : public Component, public GAPEventHandler, public Parented<ESP32BLE> {
  public:
   explicit ESP32BLEBeacon(const std::array<uint8_t, 16> &uuid) : uuid_(uuid) {}
 

--- a/esphome/components/esp32_ble_beacon/esp32_ble_beacon.h
+++ b/esphome/components/esp32_ble_beacon/esp32_ble_beacon.h
@@ -13,34 +13,12 @@ namespace esp32_ble_beacon {
 
 using namespace esp32_ble;
 
-// NOLINTNEXTLINE(modernize-use-using)
-typedef struct {
-  uint8_t flags[3];
-  uint8_t length;
-  uint8_t type;
-  uint8_t company_id[2];
-  uint8_t beacon_type[2];
-} __attribute__((packed)) esp_ble_ibeacon_head_t;
-
-// NOLINTNEXTLINE(modernize-use-using)
-typedef struct {
-  uint8_t proximity_uuid[16];
-  uint16_t major;
-  uint16_t minor;
-  uint8_t measured_power;
-} __attribute__((packed)) esp_ble_ibeacon_vendor_t;
-
-// NOLINTNEXTLINE(modernize-use-using)
-typedef struct {
-  esp_ble_ibeacon_head_t ibeacon_head;
-  esp_ble_ibeacon_vendor_t ibeacon_vendor;
-} __attribute__((packed)) esp_ble_ibeacon_t;
-
 class ESP32BLEBeacon : public Component, public GAPEventHandler, public Parented<ESP32BLE> {
  public:
   explicit ESP32BLEBeacon(const std::array<uint8_t, 16> &uuid) : uuid_(uuid) {}
 
   void setup() override;
+  void loop() override;
   void dump_config() override;
   float get_setup_priority() const override;
 
@@ -60,6 +38,7 @@ class ESP32BLEBeacon : public Component, public GAPEventHandler, public Parented
   uint16_t max_interval_{};
   int8_t measured_power_{};
   int8_t tx_power_{};
+  bool finished_init_{false};
 };
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)

--- a/esphome/components/esp32_ble_beacon/esp32_ble_beacon.h
+++ b/esphome/components/esp32_ble_beacon/esp32_ble_beacon.h
@@ -1,15 +1,35 @@
 #pragma once
 
-#include "esphome/core/component.h"
 #include "esphome/components/esp32_ble/ble.h"
+#include "esphome/core/component.h"
 
 #ifdef USE_ESP32
 
-#include <esp_gap_ble_api.h>
 #include <esp_bt.h>
+#include <esp_gap_ble_api.h>
 
 namespace esphome {
 namespace esp32_ble_beacon {
+
+struct esp_ble_ibeacon_head_t {
+  uint8_t flags[3];
+  uint8_t length;
+  uint8_t type;
+  uint8_t company_id[2];
+  uint8_t beacon_type[2];
+} __attribute__((packed));
+
+struct esp_ble_ibeacon_vendor_t {
+  uint8_t proximity_uuid[16];
+  uint16_t major;
+  uint16_t minor;
+  uint8_t measured_power;
+} __attribute__((packed));
+
+struct esp_ble_ibeacon_t {
+  esp_ble_ibeacon_head_t ibeacon_head;
+  esp_ble_ibeacon_vendor_t ibeacon_vendor;
+} __attribute__((packed));
 
 using namespace esp32_ble;
 
@@ -18,7 +38,6 @@ class ESP32BLEBeacon : public Component, public GAPEventHandler, public Parented
   explicit ESP32BLEBeacon(const std::array<uint8_t, 16> &uuid) : uuid_(uuid) {}
 
   void setup() override;
-  void loop() override;
   void dump_config() override;
   float get_setup_priority() const override;
 
@@ -27,22 +46,22 @@ class ESP32BLEBeacon : public Component, public GAPEventHandler, public Parented
   void set_min_interval(uint16_t val) { this->min_interval_ = val; }
   void set_max_interval(uint16_t val) { this->max_interval_ = val; }
   void set_measured_power(int8_t val) { this->measured_power_ = val; }
-  void set_tx_power(int8_t val) { this->tx_power_ = val; }
+  void set_tx_power(esp_power_level_t val) { this->tx_power_ = val; }
   void gap_event_handler(esp_gap_ble_cb_event_t event, esp_ble_gap_cb_param_t *param) override;
 
  protected:
+  void on_advertise_();
+
   std::array<uint8_t, 16> uuid_;
   uint16_t major_{};
   uint16_t minor_{};
   uint16_t min_interval_{};
   uint16_t max_interval_{};
   int8_t measured_power_{};
-  int8_t tx_power_{};
-  bool finished_init_{false};
+  esp_power_level_t tx_power_{};
+  esp_ble_adv_params_t ble_adv_params_;
+  bool advertising_{false};
 };
-
-// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
-extern ESP32BLEBeacon *global_esp32_ble_beacon;
 
 }  // namespace esp32_ble_beacon
 }  // namespace esphome

--- a/esphome/components/esp32_ble_beacon/esp32_ble_beacon.h
+++ b/esphome/components/esp32_ble_beacon/esp32_ble_beacon.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "esphome/core/component.h"
+#include "esphome/components/esp32_ble/ble.h"
 
 #ifdef USE_ESP32
 
@@ -9,6 +10,8 @@
 
 namespace esphome {
 namespace esp32_ble_beacon {
+
+using namespace esp32_ble;
 
 // NOLINTNEXTLINE(modernize-use-using)
 typedef struct {
@@ -33,7 +36,10 @@ typedef struct {
   esp_ble_ibeacon_vendor_t ibeacon_vendor;
 } __attribute__((packed)) esp_ble_ibeacon_t;
 
-class ESP32BLEBeacon : public Component {
+class ESP32BLEBeacon : public Component,
+                       public GAPEventHandler,
+                       public Parented<ESP32BLE>
+{
  public:
   explicit ESP32BLEBeacon(const std::array<uint8_t, 16> &uuid) : uuid_(uuid) {}
 
@@ -47,12 +53,9 @@ class ESP32BLEBeacon : public Component {
   void set_max_interval(uint16_t val) { this->max_interval_ = val; }
   void set_measured_power(int8_t val) { this->measured_power_ = val; }
   void set_tx_power(int8_t val) { this->tx_power_ = val; }
+  void gap_event_handler(esp_gap_ble_cb_event_t event, esp_ble_gap_cb_param_t *param) override;
 
  protected:
-  static void gap_event_handler(esp_gap_ble_cb_event_t event, esp_ble_gap_cb_param_t *param);
-  static void ble_core_task(void *params);
-  static void ble_setup();
-
   std::array<uint8_t, 16> uuid_;
   uint16_t major_{};
   uint16_t minor_{};

--- a/esphome/components/esp32_ble_beacon/esp32_ble_beacon.h
+++ b/esphome/components/esp32_ble_beacon/esp32_ble_beacon.h
@@ -11,7 +11,7 @@
 namespace esphome {
 namespace esp32_ble_beacon {
 
-struct esp_ble_ibeacon_head_t {
+using esp_ble_ibeacon_head_t = struct {
   uint8_t flags[3];
   uint8_t length;
   uint8_t type;
@@ -19,14 +19,14 @@ struct esp_ble_ibeacon_head_t {
   uint8_t beacon_type[2];
 } __attribute__((packed));
 
-struct esp_ble_ibeacon_vendor_t {
+using esp_ble_ibeacon_vendor_t = struct {
   uint8_t proximity_uuid[16];
   uint16_t major;
   uint16_t minor;
   uint8_t measured_power;
 } __attribute__((packed));
 
-struct esp_ble_ibeacon_t {
+using esp_ble_ibeacon_t = struct {
   esp_ble_ibeacon_head_t ibeacon_head;
   esp_ble_ibeacon_vendor_t ibeacon_vendor;
 } __attribute__((packed));

--- a/esphome/components/esp32_ble_server/__init__.py
+++ b/esphome/components/esp32_ble_server/__init__.py
@@ -7,7 +7,6 @@ from esphome.components.esp32 import add_idf_sdkconfig_option
 
 AUTO_LOAD = ["esp32_ble"]
 CODEOWNERS = ["@jesserockz", "@clydebarrow", "@Rapsssito"]
-CONFLICTS_WITH = ["esp32_ble_beacon"]
 DEPENDENCIES = ["esp32"]
 
 CONF_MANUFACTURER = "manufacturer"

--- a/esphome/components/esp32_improv/__init__.py
+++ b/esphome/components/esp32_improv/__init__.py
@@ -6,7 +6,6 @@ from esphome.const import CONF_ID
 
 AUTO_LOAD = ["esp32_ble_server"]
 CODEOWNERS = ["@jesserockz"]
-CONFLICTS_WITH = ["esp32_ble_beacon"]
 DEPENDENCIES = ["wifi", "esp32"]
 
 CONF_AUTHORIZED_DURATION = "authorized_duration"


### PR DESCRIPTION
# What does this implement/fix?

Inherit the `esp32_ble_beacon` component from `esp32_ble` component, so the `esp32_ble_beacon` can be used along with `bluetooth_proxy` or something like that.

I hope the code fits, my C++ is a little bit older

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/feature-requests/issues/2689

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
