### PR TITLE
Fix garbled graphics on LILYGO T4-S3 display

### DIFF
--- a/esphome/components/qspi_amoled/display.py
+++ b/esphome/components/qspi_amoled/display.py
@@ -45,7 +45,7 @@ DATA_PIN_SCHEMA = pins.internal_gpio_output_pin_schema
 
 def validate_dimension(value):
     if value % 2 != 0:
-        raise cv.Invalid("Width/height must be divisible by 2")
+        raise cv.Invalid("Width/height/offset must be divisible by 2")
     return value
 
 
@@ -65,8 +65,12 @@ CONFIG_SCHEMA = cv.All(
                             cv.Required(CONF_HEIGHT): cv.All(
                                 cv.int_, validate_dimension
                             ),
-                            cv.Optional(CONF_OFFSET_HEIGHT, default=0): cv.int_,
-                            cv.Optional(CONF_OFFSET_WIDTH, default=0): cv.int_,
+                            cv.Optional(CONF_OFFSET_HEIGHT, default=0): cv.All(
+                                cv.int_, validate_dimension
+                            ),
+                            cv.Optional(CONF_OFFSET_WIDTH, default=0): cv.All(
+                                cv.int_, validate_dimension
+                            ),
                         }
                     ),
                 ),

--- a/esphome/components/qspi_amoled/display.py
+++ b/esphome/components/qspi_amoled/display.py
@@ -42,6 +42,13 @@ COLOR_ORDERS = {
 }
 DATA_PIN_SCHEMA = pins.internal_gpio_output_pin_schema
 
+
+def validate_dimension(value):
+    if value % 2 != 0:
+        raise cv.Invalid("Width/height must be divisible by 2")
+    return value
+
+
 CONFIG_SCHEMA = cv.All(
     display.FULL_DISPLAY_SCHEMA.extend(
         cv.Schema(
@@ -52,8 +59,12 @@ CONFIG_SCHEMA = cv.All(
                     cv.dimensions,
                     cv.Schema(
                         {
-                            cv.Required(CONF_WIDTH): cv.int_,
-                            cv.Required(CONF_HEIGHT): cv.int_,
+                            cv.Required(CONF_WIDTH): cv.All(
+                                cv.int_, validate_dimension
+                            ),
+                            cv.Required(CONF_HEIGHT): cv.All(
+                                cv.int_, validate_dimension
+                            ),
                             cv.Optional(CONF_OFFSET_HEIGHT, default=0): cv.int_,
                             cv.Optional(CONF_OFFSET_WIDTH, default=0): cv.int_,
                         }

--- a/esphome/components/qspi_amoled/display.py
+++ b/esphome/components/qspi_amoled/display.py
@@ -44,6 +44,7 @@ DATA_PIN_SCHEMA = pins.internal_gpio_output_pin_schema
 
 
 def validate_dimension(value):
+    value = cv.positive_int(value)
     if value % 2 != 0:
         raise cv.Invalid("Width/height/offset must be divisible by 2")
     return value
@@ -59,18 +60,14 @@ CONFIG_SCHEMA = cv.All(
                     cv.dimensions,
                     cv.Schema(
                         {
-                            cv.Required(CONF_WIDTH): cv.All(
-                                cv.int_, validate_dimension
-                            ),
-                            cv.Required(CONF_HEIGHT): cv.All(
-                                cv.int_, validate_dimension
-                            ),
-                            cv.Optional(CONF_OFFSET_HEIGHT, default=0): cv.All(
-                                cv.int_, validate_dimension
-                            ),
-                            cv.Optional(CONF_OFFSET_WIDTH, default=0): cv.All(
-                                cv.int_, validate_dimension
-                            ),
+                            cv.Required(CONF_WIDTH): validate_dimension,
+                            cv.Required(CONF_HEIGHT): validate_dimension,
+                            cv.Optional(
+                                CONF_OFFSET_HEIGHT, default=0
+                            ): validate_dimension,
+                            cv.Optional(
+                                CONF_OFFSET_WIDTH, default=0
+                            ): validate_dimension,
                         }
                     ),
                 ),

--- a/esphome/components/qspi_amoled/qspi_amoled.cpp
+++ b/esphome/components/qspi_amoled/qspi_amoled.cpp
@@ -30,13 +30,13 @@ void QspiAmoLed::update() {
   if (this->x_low_ % 2 == 1) {
     this->x_low_--;
   }
-  if (this->x_high_ % 2 == 0 && this->x_high_ < this->get_width_internal() - 1) {
+  if (this->x_high_ % 2 == 0) {
     this->x_high_++;
   }
   if (this->y_low_ % 2 == 1) {
     this->y_low_--;
   }
-  if (this->y_high_ % 2 == 0 && this->y_high_ < this->get_height_internal() - 1) {
+  if (this->y_high_ % 2 == 0) {
     this->y_high_++;
   }
   int w = this->x_high_ - this->x_low_ + 1;

--- a/esphome/components/qspi_amoled/qspi_amoled.cpp
+++ b/esphome/components/qspi_amoled/qspi_amoled.cpp
@@ -26,6 +26,19 @@ void QspiAmoLed::setup() {
 
 void QspiAmoLed::update() {
   this->do_update_();
+  // Start addresses and widths/heights must be divisible by 2 (CASET/RASET restriction in datasheet)
+  if (this->x_low_ % 2 == 1) {
+    this->x_low_--;
+  }
+  if (this->x_high_ % 2 == 0 && this->x_high_ < this->get_width_internal() - 1) {
+    this->x_high_++;
+  }
+  if (this->y_low_ % 2 == 1) {
+    this->y_low_--;
+  }
+  if (this->y_high_ % 2 == 0 && this->y_high_ < this->get_height_internal() - 1) {
+    this->y_high_++;
+  }
   int w = this->x_high_ - this->x_low_ + 1;
   int h = this->y_high_ - this->y_low_ + 1;
   this->draw_pixels_at(this->x_low_, this->y_low_, w, h, this->buffer_, this->color_mode_, display::COLOR_BITNESS_565,


### PR DESCRIPTION
# What does this implement/fix?

On my LILYGO T4-S3, shapes drawn on the display often become garbled, with each consecutive line shifted to the left (see photo, generated by the config.yaml below).

The issue seems to be that the `qspi_amoled` driver does not honor the restriction of the RM690B0 and RM67162 that the x/y start coordinates and width/height set using CASET/RASET must be divisible by 2 according to the datasheet.

My patch grows the update "window" as necessary to get even values.

<img src="https://github.com/esphome/esphome/assets/496413/ea1d594b-b234-42be-a252-9c417a6c9a6d" width="250">

Note: I don't have a LILYGO T-Display S3 AMOLED (RM67162) to test with.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
display:
  - platform: qspi_amoled
    id: amoled_display
    model: RM690B0
    data_rate: 80MHz
    dimensions:
      width: 450
      height: 600
      offset_width: 16
    color_order: rgb
    invert_colors: false
    brightness: 255
    cs_pin: 11
    reset_pin: 13
    enable_pin: 9
    update_interval: 5s
    auto_clear_enabled: false
    lambda: |-
      it.clear();
      auto red = Color(255, 0, 0);
      auto green = Color(0, 255, 0);
      auto blue = Color(0, 0, 255);
      it.filled_circle(100, 110, 50, red);
      it.filled_circle(100, 220, 50, green);
      it.filled_circle(100, 330, 50, blue);

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
