### PR TITLE
[ili9xxx] Fix init for GC9A01A

### DIFF
--- a/esphome/components/ili9xxx/ili9xxx_display.cpp
+++ b/esphome/components/ili9xxx/ili9xxx_display.cpp
@@ -34,8 +34,8 @@ void ILI9XXXDisplay::setup() {
   ESP_LOGD(TAG, "Setting up ILI9xxx");
 
   this->setup_pins_();
-  this->init_lcd_(this->init_sequence_);
-  this->init_lcd_(this->extra_init_sequence_.data());
+  this->init_lcd(this->init_sequence_);
+  this->init_lcd(this->extra_init_sequence_.data());
   switch (this->pixel_mode_) {
     case PIXEL_MODE_16:
       if (this->is_18bitdisplay_) {
@@ -405,7 +405,7 @@ void ILI9XXXDisplay::reset_() {
   }
 }
 
-void ILI9XXXDisplay::init_lcd_(const uint8_t *addr) {
+void ILI9XXXDisplay::init_lcd(const uint8_t *addr) {
   if (addr == nullptr)
     return;
   uint8_t cmd, x, num_args;
@@ -424,6 +424,20 @@ void ILI9XXXDisplay::init_lcd_(const uint8_t *addr) {
         delay(150);  // NOLINT
       }
     }
+  }
+}
+
+void ILI9XXXGC9A01A::init_lcd(const uint8_t *addr) {
+  if (addr == nullptr)
+    return;
+  uint8_t cmd, x, num_args;
+  while ((cmd = *addr++) != 0) {
+    x = *addr++;
+    num_args = x & 0x7F;
+    this->send_command(cmd, addr, num_args);
+    addr += num_args;
+    if (x & 0x80)
+      delay(150);  // NOLINT
   }
 }
 

--- a/esphome/components/ili9xxx/ili9xxx_display.h
+++ b/esphome/components/ili9xxx/ili9xxx_display.h
@@ -109,7 +109,7 @@ class ILI9XXXDisplay : public display::DisplayBuffer,
 
   virtual void set_madctl();
   void display_();
-  void init_lcd_(const uint8_t *addr);
+  virtual void init_lcd(const uint8_t *addr);
   void set_addr_window_(uint16_t x, uint16_t y, uint16_t x2, uint16_t y2);
   void reset_();
 
@@ -269,6 +269,7 @@ class ILI9XXXS3BoxLite : public ILI9XXXDisplay {
 class ILI9XXXGC9A01A : public ILI9XXXDisplay {
  public:
   ILI9XXXGC9A01A() : ILI9XXXDisplay(INITCMD_GC9A01A, 240, 240, true) {}
+  void init_lcd(const uint8_t *addr) override;
 };
 
 //-----------   ILI9XXX_24_TFT display --------------


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

This changes the `init_lcd` function to be virtual so that the GC9A01A can override it and not implement the `ILI9XXX_DELAY` instruction.

The `GC9A01A` has a function already that uses `0xFF` (it is not known what it means, but it is important).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
