### PR TITLE
[CI-esp32_hall] Remove IDF test

### DIFF
--- a/tests/components/esp32_hall/common.yaml
+++ b/tests/components/esp32_hall/common.yaml
@@ -1,3 +1,0 @@
-sensor:
-  - platform: esp32_hall
-    name: ESP32 Hall Sensor

--- a/tests/components/esp32_hall/test.esp32-idf.yaml
+++ b/tests/components/esp32_hall/test.esp32-idf.yaml
@@ -1,1 +1,0 @@
-<<: !include common.yaml

--- a/tests/components/esp32_hall/test.esp32.yaml
+++ b/tests/components/esp32_hall/test.esp32.yaml
@@ -1,1 +1,3 @@
-<<: !include common.yaml
+sensor:
+  - platform: esp32_hall
+    name: ESP32 Hall Sensor


### PR DESCRIPTION
# What does this implement/fix?

Support for the ESP32 hall sensor has been removed from ESP-IDF after v4. Since we won't be able to test it as we move to IDF 5, this PR removes the test.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
