### PR TITLE
Rename legacy/modern to ota/factory

### DIFF
--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -96,16 +96,16 @@ def get_board(core_obj=None):
 def get_download_types(storage_json):
     return [
         {
-            "title": "Modern format",
+            "title": "Factory format",
             "description": "For use with ESPHome Web and other tools.",
-            "file": "firmware-factory.bin",
-            "download": f"{storage_json.name}-factory.bin",
+            "file": "firmware.factory.bin",
+            "download": f"{storage_json.name}.factory.bin",
         },
         {
-            "title": "Legacy format",
-            "description": "For use with ESPHome Flasher.",
-            "file": "firmware.bin",
-            "download": f"{storage_json.name}.bin",
+            "title": "OTA format",
+            "description": "For OTA updating a device.",
+            "file": "firmware.ota.bin",
+            "download": f"{storage_json.name}.ota.bin",
         },
     ]
 

--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -96,13 +96,13 @@ def get_board(core_obj=None):
 def get_download_types(storage_json):
     return [
         {
-            "title": "Factory format",
+            "title": "Factory format (Previously Modern)",
             "description": "For use with ESPHome Web and other tools.",
             "file": "firmware.factory.bin",
             "download": f"{storage_json.name}.factory.bin",
         },
         {
-            "title": "OTA format",
+            "title": "OTA format (Previously Legacy)",
             "description": "For OTA updating a device.",
             "file": "firmware.ota.bin",
             "download": f"{storage_json.name}.ota.bin",

--- a/esphome/components/esp32/post_build.py.script
+++ b/esphome/components/esp32/post_build.py.script
@@ -17,9 +17,11 @@ from SCons.Script import ARGUMENTS
 
 # Copy over the default sdkconfig.
 from os import path
+
 if path.exists("./sdkconfig.defaults"):
     os.makedirs(".temp", exist_ok=True)
     shutil.copy("./sdkconfig.defaults", "./.temp/sdkconfig-esp32-idf")
+
 
 def esp32_create_combined_bin(source, target, env):
     verbose = bool(int(ARGUMENTS.get("PIOVERBOSE", "0")))
@@ -27,7 +29,7 @@ def esp32_create_combined_bin(source, target, env):
         print("Generating combined binary for serial flashing")
     app_offset = 0x10000
 
-    new_file_name = env.subst("$BUILD_DIR/${PROGNAME}-factory.bin")
+    new_file_name = env.subst("$BUILD_DIR/${PROGNAME}.factory.bin")
     sections = env.subst(env.get("FLASH_EXTRA_IMAGES"))
     firmware_name = env.subst("$BUILD_DIR/${PROGNAME}.bin")
     chip = env.get("BOARD_MCU")
@@ -62,5 +64,14 @@ def esp32_create_combined_bin(source, target, env):
     else:
         subprocess.run(["esptool.py", *cmd])
 
+
+def esp32_copy_ota_bin(source, target, env):
+    firmware_name = env.subst("$BUILD_DIR/${PROGNAME}.bin")
+    new_file_name = env.subst("$BUILD_DIR/${PROGNAME}.ota.bin")
+
+    shutil.copyfile(firmware_name, new_file_name)
+
+
 # pylint: disable=E0602
 env.AddPostAction("$BUILD_DIR/${PROGNAME}.bin", esp32_create_combined_bin)  # noqa
+env.AddPostAction("$BUILD_DIR/${PROGNAME}.bin", esp32_copy_ota_bin)  # noqa

--- a/esphome/components/esp8266/post_build.py.script
+++ b/esphome/components/esp8266/post_build.py.script
@@ -6,10 +6,18 @@ Import("env")  # noqa
 
 def esp8266_copy_factory_bin(source, target, env):
     firmware_name = env.subst("$BUILD_DIR/${PROGNAME}.bin")
-    new_file_name = env.subst("$BUILD_DIR/${PROGNAME}-factory.bin")
+    new_file_name = env.subst("$BUILD_DIR/${PROGNAME}.factory.bin")
+
+    shutil.copyfile(firmware_name, new_file_name)
+
+
+def esp8266_copy_ota_bin(source, target, env):
+    firmware_name = env.subst("$BUILD_DIR/${PROGNAME}.bin")
+    new_file_name = env.subst("$BUILD_DIR/${PROGNAME}.ota.bin")
 
     shutil.copyfile(firmware_name, new_file_name)
 
 
 # pylint: disable=E0602
 env.AddPostAction("$BUILD_DIR/${PROGNAME}.bin", esp8266_copy_factory_bin)  # noqa
+env.AddPostAction("$BUILD_DIR/${PROGNAME}.bin", esp8266_copy_ota_bin)  # noqa

--- a/esphome/components/rp2040/__init__.py
+++ b/esphome/components/rp2040/__init__.py
@@ -47,10 +47,16 @@ def set_core_data(config):
 def get_download_types(storage_json):
     return [
         {
-            "title": "UF2 format",
+            "title": "UF2 factory format",
             "description": "For copying to RP2040 over USB.",
             "file": "firmware.uf2",
-            "download": f"{storage_json.name}.uf2",
+            "download": f"{storage_json.name}.factory.uf2",
+        },
+        {
+            "title": "OTA format",
+            "description": "For OTA updating a device.",
+            "file": "firmware.ota.bin",
+            "download": f"{storage_json.name}.ota.bin",
         },
     ]
 
@@ -160,6 +166,8 @@ async def to_code(config):
     cg.add_define("ESPHOME_BOARD", config[CONF_BOARD])
     cg.add_define("ESPHOME_VARIANT", "RP2040")
 
+    cg.add_platformio_option("extra_scripts", ["post:post_build.py"])
+
     conf = config[CONF_FRAMEWORK]
     cg.add_platformio_option("framework", "arduino")
     cg.add_build_flag("-DUSE_ARDUINO")
@@ -225,4 +233,10 @@ def generate_pio_files() -> bool:
 
 # Called by writer.py
 def copy_files() -> bool:
+    dir = os.path.dirname(__file__)
+    post_build_file = os.path.join(dir, "post_build.py.script")
+    copy_file_if_changed(
+        post_build_file,
+        CORE.relative_build_path("post_build.py"),
+    )
     return generate_pio_files()

--- a/esphome/components/rp2040/post_build.py.script
+++ b/esphome/components/rp2040/post_build.py.script
@@ -1,0 +1,23 @@
+import shutil
+
+# pylint: disable=E0602
+Import("env")  # noqa
+
+
+def rp2040_copy_factory_uf2(source, target, env):
+    firmware_name = env.subst("$BUILD_DIR/${PROGNAME}.uf2")
+    new_file_name = env.subst("$BUILD_DIR/${PROGNAME}.factory.uf2")
+
+    shutil.copyfile(firmware_name, new_file_name)
+
+
+def rp2040_copy_ota_bin(source, target, env):
+    firmware_name = env.subst("$BUILD_DIR/${PROGNAME}.bin")
+    new_file_name = env.subst("$BUILD_DIR/${PROGNAME}.ota.bin")
+
+    shutil.copyfile(firmware_name, new_file_name)
+
+
+# pylint: disable=E0602
+env.AddPostAction("$BUILD_DIR/${PROGNAME}.bin", rp2040_copy_factory_uf2)  # noqa
+env.AddPostAction("$BUILD_DIR/${PROGNAME}.bin", rp2040_copy_ota_bin)  # noqa


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

This renames the UI elements from Legacy/Modern to OTA/Factory and also the downloaded binary filenames from `firmware-factory.bin`/`firmware.bin` to `firmware.factory.bin`/`firmware.ota.bin`


## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
