### PR TITLE
uart: allow setting the UART id in final_validate_device_schema

### DIFF
--- a/esphome/components/uart/__init__.py
+++ b/esphome/components/uart/__init__.py
@@ -258,6 +258,7 @@ KEY_UART_DEVICES = "uart_devices"
 def final_validate_device_schema(
     name: str,
     *,
+    uart_bus: str = CONF_UART_ID,
     baud_rate: Optional[int] = None,
     require_tx: bool = False,
     require_rx: bool = False,
@@ -268,7 +269,7 @@ def final_validate_device_schema(
     def validate_baud_rate(value):
         if value != baud_rate:
             raise cv.Invalid(
-                f"Component {name} requires baud rate {baud_rate} for the uart bus"
+                f"Component {name} requires baud rate {baud_rate} for the uart referenced by {uart_bus}"
             )
         return value
 
@@ -287,21 +288,21 @@ def final_validate_device_schema(
     def validate_data_bits(value):
         if value != data_bits:
             raise cv.Invalid(
-                f"Component {name} requires {data_bits} data bits for the uart bus"
+                f"Component {name} requires {data_bits} data bits for the uart referenced by {uart_bus}"
             )
         return value
 
     def validate_parity(value):
         if value != parity:
             raise cv.Invalid(
-                f"Component {name} requires parity {parity} for the uart bus"
+                f"Component {name} requires parity {parity} for the uart referenced by {uart_bus}"
             )
         return value
 
     def validate_stop_bits(value):
         if value != stop_bits:
             raise cv.Invalid(
-                f"Component {name} requires {stop_bits} stop bits for the uart bus"
+                f"Component {name} requires {stop_bits} stop bits for the uart referenced by {uart_bus}"
             )
         return value
 
@@ -316,14 +317,14 @@ def final_validate_device_schema(
             hub_schema[
                 cv.Required(
                     CONF_TX_PIN,
-                    msg=f"Component {name} requires this uart bus to declare a tx_pin",
+                    msg=f"Component {name} requires uart referenced by {uart_bus} to declare a tx_pin",
                 )
             ] = validate_pin(CONF_TX_PIN, device)
         if require_rx and uart_id_type_str in NATIVE_UART_CLASSES:
             hub_schema[
                 cv.Required(
                     CONF_RX_PIN,
-                    msg=f"Component {name} requires this uart bus to declare a rx_pin",
+                    msg=f"Component {name} requires uart referenced by {uart_bus} to declare a rx_pin",
                 )
             ] = validate_pin(CONF_RX_PIN, device)
         if baud_rate is not None:
@@ -337,7 +338,7 @@ def final_validate_device_schema(
         return cv.Schema(hub_schema, extra=cv.ALLOW_EXTRA)(hub_config)
 
     return cv.Schema(
-        {cv.Required(CONF_UART_ID): fv.id_declaration_match_schema(validate_hub)},
+        {cv.Required(uart_bus): fv.id_declaration_match_schema(validate_hub)},
         extra=cv.ALLOW_EXTRA,
     )
 


### PR DESCRIPTION
# What does this implement/fix?

`uart.final_validate_device_schema()` currently expects to validate a device referenced by `CONF_UART_ID` (i.e. `uart_id`). This is limiting, as it doesn't allow components to define their own variable for defining the UART ID. (This in turn may be useful in particular if a component supports or needs multiple UARTs).

Allow defining the UART bus variable name, defaulting to `CONF_UART_ID` for ease of use and backwards compatibility.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

~~**Related issue or feature (if applicable):** ~~

~~**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**~~

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
This requires an extra third-party component, plus uncommited/unsubmitted code for it. Hopefully it demonstrates how it could work!

```yaml
climate:
  - platform: mitsubishi_itp
    uart_heatpump: hp_uart
    uart_thermostat: tm_uart

uart:
  - id: hp_uart
    baud_rate: 2400
    # no parity defined => config validation error
    rx_pin:
        number: 21
    tx_pin:
        number: 22
  - id: tm_uart
    baud_rate: 2400
    parity: EVEN
    rx_pin:
        number: 3
    tx_pin:
        number: 4
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] ~~Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).~~
