### PR TITLE
Add support for systemd-socket activation

### DIFF
--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -874,7 +874,7 @@ def parse_args(argv):
     )
     parser_dashboard.add_argument(
         "--address",
-        help="The address to bind to.",
+        help="The address to bind to. Defaults to 0.0.0.0",
         type=str,
         default="0.0.0.0",
     )
@@ -891,13 +891,23 @@ def parse_args(argv):
         default="",
     )
     parser_dashboard.add_argument(
-        "--open-ui", help="Open the dashboard UI in a browser.", action="store_true"
+        "--open-ui",
+        help="Open the dashboard UI in a browser.",
+        action="store_true",
+        default=False,
     )
     parser_dashboard.add_argument(
         "--ha-addon", help=argparse.SUPPRESS, action="store_true"
     )
-    parser_dashboard.add_argument(
+
+    socket_group = parser_dashboard.add_mutually_exclusive_group()
+    socket_group.add_argument(
         "--socket", help="Make the dashboard serve under a unix socket", type=str
+    )
+    socket_group.add_argument(
+        "--systemd-socket",
+        help="Serve the dashboard from a socket obtained via systemd's socket activation",
+        action="store_true",
     )
 
     parser_vscode = subparsers.add_parser("vscode")
@@ -1000,7 +1010,13 @@ def parse_args(argv):
     # and let it error out if the command is unparsable.
     parser.set_defaults(deprecated_argv_suggestion=deprecated_argv_suggestion)
     argcomplete.autocomplete(parser)
-    return parser.parse_args(arguments)
+    parsed_args = parser.parse_args(arguments)
+    if parsed_args.command == "dashboard" and parsed_args.open_ui:
+        if parsed_args.socket or parsed_args.systemd_socket:
+            parser.error(
+                "The --open-ui option cannot be used with --socket or --systemd-socket."
+            )
+    return parsed_args
 
 
 def run_esphome(argv):

--- a/esphome/dashboard/dashboard.py
+++ b/esphome/dashboard/dashboard.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
-import socket
 import threading
 import traceback
 from asyncio import events
@@ -135,11 +134,14 @@ async def async_start(args) -> None:
     """Start the dashboard."""
     dashboard = DASHBOARD
     await dashboard.async_setup()
-    sock: socket.socket | None = args.socket
+    sock: str | None = args.socket
     address: str | None = args.address
     port: int | None = args.port
+    systemd_sock: bool = args.systemd_socket
 
-    start_web_server(make_app(args.verbose), sock, address, port, settings.config_dir)
+    start_web_server(
+        make_app(args.verbose), sock, address, port, settings.config_dir, systemd_sock
+    )
 
     if args.open_ui:
         import webbrowser

--- a/esphome/dashboard/web_server.py
+++ b/esphome/dashboard/web_server.py
@@ -1154,9 +1154,18 @@ def start_web_server(
     address: str | None,
     port: int | None,
     config_dir: str,
+    systemd_sock: bool = False,
 ) -> None:
     """Start the web server listener."""
-    if socket is None:
+
+    trash_path = trash_storage_path()
+    if os.path.exists(trash_path):
+        _LOGGER.info("Renaming 'trash' folder to 'archive'")
+        archive_path = archive_storage_path()
+        shutil.move(trash_path, archive_path)
+
+    # Bind to TCP socket unless a socket was provided or systemd socket activation is being used
+    if not (socket or systemd_sock):
         _LOGGER.info(
             "Starting dashboard web server on http://%s:%s and configuration dir %s...",
             address,
@@ -1166,11 +1175,35 @@ def start_web_server(
         app.listen(port, address)
         return
 
-    _LOGGER.info(
-        "Starting dashboard web server on unix socket %s and configuration dir %s...",
-        socket,
-        config_dir,
-    )
-    server = tornado.httpserver.HTTPServer(app)
-    socket = tornado.netutil.bind_unix_socket(socket, mode=0o666)
-    server.add_socket(socket)
+    # If a socket path was provided, bind to that path
+    if socket is None:
+        _LOGGER.info(
+            "Starting dashboard web server on unix socket %s and configuration dir %s...",
+            sock,
+            config_dir,
+        )
+        unix_sock = tornado.netutil.bind_unix_socket(sock, mode=0o666)
+        server = tornado.httpserver.HTTPServer(app)
+        server.add_socket(unix_sock)
+        return
+
+    num_passed_fds = int(os.getenv("LISTEN_FDS", "0"))
+    # If systemd socket activation was requested, ensure that exactly one FD was passed
+    # by systemd.
+    if systemd_sock and num_passed_fds == 1:
+        socket_fd_num = 3
+        _LOGGER.info(
+            "Starting dashboard web server on socket from file descriptor %d and configuration dir %s...",
+            socket_fd_num,
+            config_dir,
+        )
+
+        import socket as socket_module
+        unix_sock = socket_module.socket(fileno=socket_fd_num, type=socket_module.AF_UNIX)
+        server = tornado.httpserver.HTTPServer(app)
+        server.add_socket(unix_sock)
+    else:
+        raise OSError(
+            "Unable to start server due to an unexpected number of sockets being passed in for "
+            "socket activation."
+        )

--- a/tests/unit_tests/test_argument_parsing.py
+++ b/tests/unit_tests/test_argument_parsing.py
@@ -1,0 +1,66 @@
+import pytest
+
+from esphome.__main__ import parse_args
+
+
+def test_socket_option_is_mutually_exclusive_with_systemd_socket():
+    with pytest.raises(SystemExit) as stop_ex:
+        parse_args(
+            [
+                "esphome",
+                "dashboard",
+                "--systemd-socket",
+                "--socket",
+                "/var/run/esphome.sock",
+                "/var/lib/esphome",
+            ]
+        )
+
+
+def test_open_ui_option_does_not_prevent_other_commands_from_working():
+    parse_args(
+        [
+            "esphome",
+            "version",
+        ]
+    )
+
+
+def test_open_ui_option_is_mutually_exclusive_with_socket():
+    with pytest.raises(SystemExit) as stop_ex:
+        parse_args(
+            [
+                "esphome",
+                "dashboard",
+                "--open-ui",
+                "--socket",
+                "/var/run/esphome.sock",
+                "/var/lib/esphome",
+            ]
+        )
+
+
+def test_open_ui_option_is_mutually_exclusive_with_systemd_socket():
+    with pytest.raises(SystemExit) as stop_ex:
+        parse_args(
+            [
+                "esphome",
+                "dashboard",
+                "--open-ui",
+                "--systemd-socket",
+                "/var/lib/esphome",
+            ]
+        )
+
+
+def test_socket_option_with_nonempty_path():
+    args = parse_args(
+        [
+            "esphome",
+            "dashboard",
+            "--socket",
+            "/run/esphome/esphome.sock",
+            "/var/lib/esphome",
+        ]
+    )
+    assert args.socket is "/run/esphome/esphome.sock"


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->
Allows the ESPHome dashboard to run under a socket provided by systemd, using systemd's socket activation.
This lets the service's socket configuration be consoliated to be homogenous with the rest of the system, and allows for other services to start esphome by connecting to the socket.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [x] ESPHome CLI dashboard command running under systemd.

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
