### PR TITLE
Update cover.h for open() and close() compiler warnings

### DIFF
--- a/esphome/components/cover/cover.h
+++ b/esphome/components/cover/cover.h
@@ -129,13 +129,13 @@ class Cover : public EntityBase, public EntityBase_DeviceClass {
    *
    * This is a legacy method and may be removed later, please use `.make_call()` instead.
    */
-  ESPDEPRECATED("open() is deprecated, use make_call().set_command_open() instead.", "2021.9")
+  ESPDEPRECATED("open() is deprecated, use make_call().set_command_open().perform() instead.", "2021.9")
   void open();
   /** Close the cover.
    *
    * This is a legacy method and may be removed later, please use `.make_call()` instead.
    */
-  ESPDEPRECATED("close() is deprecated, use make_call().set_command_close() instead.", "2021.9")
+  ESPDEPRECATED("close() is deprecated, use make_call().set_command_close().perform() instead.", "2021.9")
   void close();
   /** Stop the cover.
    *


### PR DESCRIPTION
Corrected deprecation warnings for open() and close().

# What does this implement/fix?

https://github.com/esphome/issues/issues/2885 led to PR #4879 correcting the disfunctional guidance provided in the compiler warning for the deprecated stop() method by appending .perform(). This PR does the same for open() and close().

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature:** fixes https://github.com/esphome/issues/issues/2885


## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
