### PR TITLE
[network] Default ipv6 to false to always set the flags

### DIFF
--- a/esphome/components/network/__init__.py
+++ b/esphome/components/network/__init__.py
@@ -19,7 +19,12 @@ IPAddress = network_ns.class_("IPAddress")
 
 CONFIG_SCHEMA = cv.Schema(
     {
-        cv.SplitDefault(CONF_ENABLE_IPV6): cv.All(
+        cv.SplitDefault(
+            CONF_ENABLE_IPV6,
+            esp8266=False,
+            esp32=False,
+            rp2040=False,
+        ): cv.All(
             cv.boolean, cv.only_on([PLATFORM_ESP32, PLATFORM_ESP8266, PLATFORM_RP2040])
         ),
         cv.Optional(CONF_MIN_IPV6_ADDR_COUNT, default=0): cv.positive_int,
@@ -28,21 +33,20 @@ CONFIG_SCHEMA = cv.Schema(
 
 
 async def to_code(config):
-    if CONF_ENABLE_IPV6 in config:
-        cg.add_define("USE_NETWORK_IPV6", config[CONF_ENABLE_IPV6])
+    enable_ipv6 = config[CONF_ENABLE_IPV6]
+    cg.add_define("USE_NETWORK_IPV6", enable_ipv6)
+    if enable_ipv6:
         cg.add_define(
             "USE_NETWORK_MIN_IPV6_ADDR_COUNT", config[CONF_MIN_IPV6_ADDR_COUNT]
         )
-        if CORE.using_esp_idf:
-            add_idf_sdkconfig_option("CONFIG_LWIP_IPV6", config[CONF_ENABLE_IPV6])
-            add_idf_sdkconfig_option(
-                "CONFIG_LWIP_IPV6_AUTOCONFIG", config[CONF_ENABLE_IPV6]
-            )
-        else:
-            if config[CONF_ENABLE_IPV6]:
-                cg.add_build_flag("-DCONFIG_LWIP_IPV6")
-                cg.add_build_flag("-DCONFIG_LWIP_IPV6_AUTOCONFIG")
-                if CORE.is_rp2040:
-                    cg.add_build_flag("-DPIO_FRAMEWORK_ARDUINO_ENABLE_IPV6")
-                if CORE.is_esp8266:
-                    cg.add_build_flag("-DPIO_FRAMEWORK_ARDUINO_LWIP2_IPV6_LOW_MEMORY")
+    if CORE.using_esp_idf:
+        add_idf_sdkconfig_option("CONFIG_LWIP_IPV6", enable_ipv6)
+        add_idf_sdkconfig_option("CONFIG_LWIP_IPV6_AUTOCONFIG", enable_ipv6)
+    else:
+        if enable_ipv6:
+            cg.add_build_flag("-DCONFIG_LWIP_IPV6")
+            cg.add_build_flag("-DCONFIG_LWIP_IPV6_AUTOCONFIG")
+            if CORE.is_rp2040:
+                cg.add_build_flag("-DPIO_FRAMEWORK_ARDUINO_ENABLE_IPV6")
+            if CORE.is_esp8266:
+                cg.add_build_flag("-DPIO_FRAMEWORK_ARDUINO_LWIP2_IPV6_LOW_MEMORY")

--- a/esphome/components/network/__init__.py
+++ b/esphome/components/network/__init__.py
@@ -33,20 +33,20 @@ CONFIG_SCHEMA = cv.Schema(
 
 
 async def to_code(config):
-    enable_ipv6 = config[CONF_ENABLE_IPV6]
-    cg.add_define("USE_NETWORK_IPV6", enable_ipv6)
-    if enable_ipv6:
-        cg.add_define(
-            "USE_NETWORK_MIN_IPV6_ADDR_COUNT", config[CONF_MIN_IPV6_ADDR_COUNT]
-        )
-    if CORE.using_esp_idf:
-        add_idf_sdkconfig_option("CONFIG_LWIP_IPV6", enable_ipv6)
-        add_idf_sdkconfig_option("CONFIG_LWIP_IPV6_AUTOCONFIG", enable_ipv6)
-    else:
+    if (enable_ipv6 := config.get(CONF_ENABLE_IPV6, None)) is not None:
+        cg.add_define("USE_NETWORK_IPV6", enable_ipv6)
         if enable_ipv6:
-            cg.add_build_flag("-DCONFIG_LWIP_IPV6")
-            cg.add_build_flag("-DCONFIG_LWIP_IPV6_AUTOCONFIG")
-            if CORE.is_rp2040:
-                cg.add_build_flag("-DPIO_FRAMEWORK_ARDUINO_ENABLE_IPV6")
-            if CORE.is_esp8266:
-                cg.add_build_flag("-DPIO_FRAMEWORK_ARDUINO_LWIP2_IPV6_LOW_MEMORY")
+            cg.add_define(
+                "USE_NETWORK_MIN_IPV6_ADDR_COUNT", config[CONF_MIN_IPV6_ADDR_COUNT]
+            )
+        if CORE.using_esp_idf:
+            add_idf_sdkconfig_option("CONFIG_LWIP_IPV6", enable_ipv6)
+            add_idf_sdkconfig_option("CONFIG_LWIP_IPV6_AUTOCONFIG", enable_ipv6)
+        else:
+            if enable_ipv6:
+                cg.add_build_flag("-DCONFIG_LWIP_IPV6")
+                cg.add_build_flag("-DCONFIG_LWIP_IPV6_AUTOCONFIG")
+                if CORE.is_rp2040:
+                    cg.add_build_flag("-DPIO_FRAMEWORK_ARDUINO_ENABLE_IPV6")
+                if CORE.is_esp8266:
+                    cg.add_build_flag("-DPIO_FRAMEWORK_ARDUINO_LWIP2_IPV6_LOW_MEMORY")

--- a/tests/components/network/common.yaml
+++ b/tests/components/network/common.yaml
@@ -1,6 +1,9 @@
+substitutions:
+  network_enable_ipv6: "false"
+
 wifi:
   ssid: MySSID
   password: password1
 
 network:
-  enable_ipv6: true
+  enable_ipv6: ${network_enable_ipv6}

--- a/tests/components/network/test-ipv6.esp32-ard.yaml
+++ b/tests/components/network/test-ipv6.esp32-ard.yaml
@@ -1,0 +1,4 @@
+substitutions:
+  network_enable_ipv6: "true"
+
+<<: !include common.yaml

--- a/tests/components/network/test-ipv6.esp32-c3-ard.yaml
+++ b/tests/components/network/test-ipv6.esp32-c3-ard.yaml
@@ -1,0 +1,4 @@
+substitutions:
+  network_enable_ipv6: "true"
+
+<<: !include common.yaml

--- a/tests/components/network/test-ipv6.esp32-c3-idf.yaml
+++ b/tests/components/network/test-ipv6.esp32-c3-idf.yaml
@@ -1,0 +1,4 @@
+substitutions:
+  network_enable_ipv6: "true"
+
+<<: !include common.yaml

--- a/tests/components/network/test-ipv6.esp32-idf.yaml
+++ b/tests/components/network/test-ipv6.esp32-idf.yaml
@@ -1,0 +1,4 @@
+substitutions:
+  network_enable_ipv6: "true"
+
+<<: !include common.yaml

--- a/tests/components/network/test-ipv6.esp8266-ard.yaml
+++ b/tests/components/network/test-ipv6.esp8266-ard.yaml
@@ -1,0 +1,4 @@
+substitutions:
+  network_enable_ipv6: "true"
+
+<<: !include common.yaml

--- a/tests/components/network/test-ipv6.rp2040-ard.yaml
+++ b/tests/components/network/test-ipv6.rp2040-ard.yaml
@@ -1,0 +1,4 @@
+substitutions:
+  network_enable_ipv6: "true"
+
+<<: !include common.yaml

--- a/tests/components/network/test.host.yaml
+++ b/tests/components/network/test.host.yaml
@@ -1,0 +1,1 @@
+network:


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Some IP address operations use the `LWIP_IPV6` flag, but other places use the `USE_NETWORK_IPV6` flag, this tries to make it consistent by setting the default to False so that the flags match in cases where they wouldn't before.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
