### PR TITLE
[waveshare_epaper] Add support for 4.26inch display

### DIFF
--- a/esphome/components/waveshare_epaper/display.py
+++ b/esphome/components/waveshare_epaper/display.py
@@ -31,6 +31,9 @@ WaveshareEPaperTypeA = waveshare_epaper_ns.class_(
 WaveshareEpaper1P54INBV2 = waveshare_epaper_ns.class_(
     "WaveshareEPaper1P54InBV2", WaveshareEPaperBWR
 )
+WaveshareEPaper4P26In = waveshare_epaper_ns.class_(
+    "WaveshareEPaper4P26In", WaveshareEPaper
+)
 WaveshareEPaper2P7In = waveshare_epaper_ns.class_(
     "WaveshareEPaper2P7In", WaveshareEPaper
 )
@@ -139,6 +142,7 @@ MODELS = {
     "2.13in-ttgo-b74": ("a", WaveshareEPaperTypeAModel.TTGO_EPAPER_2_13_IN_B74),
     "2.90in": ("a", WaveshareEPaperTypeAModel.WAVESHARE_EPAPER_2_9_IN),
     "2.90inv2": ("a", WaveshareEPaperTypeAModel.WAVESHARE_EPAPER_2_9_IN_V2),
+    "4.26in": ("a", WaveshareEPaper4P26In),
     "gdew029t5": ("c", GDEW029T5),
     "2.70in": ("b", WaveshareEPaper2P7In),
     "2.70in-b": ("b", WaveshareEPaper2P7InB),
@@ -229,7 +233,10 @@ FINAL_VALIDATE_SCHEMA = spi.final_validate_device_schema(
 
 async def to_code(config):
     model_type, model = MODELS[config[CONF_MODEL]]
-    if model_type == "a":
+    if config[CONF_MODEL] == "4.26in":
+        rhs = model.new()
+        var = cg.Pvariable(config[CONF_ID], rhs, model)
+    elif model_type == "a":
         rhs = WaveshareEPaperTypeA.new(model)
         var = cg.Pvariable(config[CONF_ID], rhs, WaveshareEPaperTypeA)
     elif model_type in ("b", "c"):

--- a/esphome/components/waveshare_epaper/waveshare_4_24in.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_4_24in.cpp
@@ -13,10 +13,10 @@ WaveshareEPaper4P26In::WaveshareEPaper4P26In() : WaveshareEPaper() { reset_durat
 void WaveshareEPaper4P26In::init_display_async_(bool fast_update, const std::function<void()> &&f) {
   // Reset the display
   this->reset_();
-  wait_until_idle_async_([this, fast_update, f(std::move(f))] {
+  wait_until_idle_async_([this, fast_update, f] {
     this->command(0x12);  // SWRESET
 
-    wait_until_idle_async_([this, fast_update, f(std::move(f))] {
+    wait_until_idle_async_([this, fast_update, f] {
       // Use the internal temperature sensor
       this->command(0x18);
       this->data(0x80);
@@ -66,7 +66,7 @@ void WaveshareEPaper4P26In::init_display_async_(bool fast_update, const std::fun
       this->data(0x00);
 
       if (fast_update) {
-        this->wait_until_idle_async_([this, f(std::move(f))] {
+        this->wait_until_idle_async_([this, f] {
           this->command(0x1A);
           this->data(0x5A);
 

--- a/esphome/components/waveshare_epaper/waveshare_4_24in.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_4_24in.cpp
@@ -152,8 +152,6 @@ void WaveshareEPaper4P26In::deep_sleep() {
   // Set deep sleep mode
   this->command(0x10);
   this->data(0x01);
-
-  delay(50);
 }
 
 int WaveshareEPaper4P26In::get_width_internal() { return 800; }

--- a/esphome/components/waveshare_epaper/waveshare_4_24in.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_4_24in.cpp
@@ -1,0 +1,170 @@
+#include "waveshare_epaper.h"
+#include "esphome/core/log.h"
+#include "esphome/core/application.h"
+#include <cinttypes>
+
+namespace esphome {
+namespace waveshare_epaper {
+
+static const char *const TAG = "waveshare_epaper_4.26in";
+
+WaveshareEPaper4P26In::WaveshareEPaper4P26In() : WaveshareEPaper() { reset_duration_ = 20; }
+
+void WaveshareEPaper4P26In::init_display_async_(bool fast_update, const std::function<void()> f) {
+  // Reset the display
+  this->reset_();
+  wait_until_idle_async_([this, fast_update, f] {
+    this->command(0x12);  // SWRESET
+
+    wait_until_idle_async_([this, fast_update, f] {
+      // Use the internal temperature sensor
+      this->command(0x18);
+      this->data(0x80);
+
+      // Set soft start
+      this->command(0x0C);
+      this->data(0xAE);
+      this->data(0xC7);
+      this->data(0xC3);
+      this->data(0xC0);
+      this->data(0x80);
+
+      // Drive output control
+      this->command(0x01);
+      this->data((this->get_height_internal() - 1) % 256);  //  Y
+      this->data((this->get_height_internal() - 1) / 256);  //  Y
+      this->data(0x02);
+
+      // // Border settings
+      // this->command(0x3C);
+      // this->data(0x01);
+
+      // Data entry mode setting
+      this->command(0x11);
+      this->data(0x01);  // x increase, y decrease : as in demo code
+
+      // Set window, this is always the full screen for now
+      this->command(0x44);  // SET_RAM_X_ADDRESS_START_END_POSITION
+      this->data(0x00);
+      this->data(0x00);
+      this->data((this->get_width_internal() - 1) & 0xFF);
+      this->data(((this->get_width_internal() - 1) >> 8) & 0x03);
+
+      this->command(0x45);  // SET_RAM_Y_ADDRESS_START_END_POSITION
+      this->data((this->get_height_internal() - 1) & 0xFF);
+      this->data(((this->get_height_internal() - 1) >> 8) & 0x03);
+      this->data(0x00);
+      this->data(0x00);
+
+      // Set cursor
+      this->command(0x4E);  // SET_RAM_X_ADDRESS_COUNTER
+      this->data(0x00);
+      this->data(0x00);
+
+      this->command(0x4F);  // SET_RAM_Y_ADDRESS_COUNTER
+      this->data(0x00);
+      this->data(0x00);
+
+      if (fast_update) {
+        this->wait_until_idle_async_([this, f] {
+          this->command(0x1A);
+          this->data(0x5A);
+
+          this->command(0x22);
+          this->data(0x91);
+          this->command(0x20);
+
+          this->wait_until_idle_async_(std::move(f));
+        });
+      } else {
+        this->wait_until_idle_async_(std::move(f));
+      }
+    });
+  });
+}
+
+void WaveshareEPaper4P26In::initialize() {}
+
+void WaveshareEPaper4P26In::dump_config() {
+  LOG_DISPLAY("", "Waveshare E-Paper", this);
+  ESP_LOGCONFIG(TAG, "  Model: 4.26in");
+  ESP_LOGCONFIG(TAG, "  Full Update Every: %" PRIu32, this->full_update_every_);
+  LOG_PIN("  Reset Pin: ", this->reset_pin_);
+  LOG_PIN("  DC Pin: ", this->dc_pin_);
+  LOG_PIN("  Busy Pin: ", this->busy_pin_);
+  LOG_UPDATE_INTERVAL(this);
+}
+
+void HOT WaveshareEPaper4P26In::display() {
+  if (this->is_busy_) {
+    ESP_LOGE(TAG, "Skipping display, display is busy");
+    return;
+  }
+
+  this->is_busy_ = true;
+
+  bool full_update = this->at_update_ == 0;
+  bool prev_full_update = this->at_update_ == 1;
+
+  if (this->full_update_every_ >= 1) {
+    this->at_update_ = (this->at_update_ + 1) % this->full_update_every_;
+  }
+
+  ESP_LOGI(TAG, "Wake up the display");
+  this->init_display_async_(!full_update, [this, full_update] {
+    // Border settings
+    this->command(0x3C);
+    // this->data(full_update ? 0x01 : 0x80);
+    this->data(0x01);
+
+    // Write RAM
+    this->command(0x24);
+    this->start_data_();
+    this->write_array(this->buffer_, this->get_buffer_length_());
+    this->end_data_();
+
+    if (full_update) {
+      // Write base image again on full refresh
+      this->command(0x26);
+      this->start_data_();
+      this->write_array(this->buffer_, this->get_buffer_length_());
+      this->end_data_();
+    }
+
+    // Display Update Control
+    this->command(0x22);
+    this->data(full_update ? 0xF7 : 0xC7);  // 0xF7 = Full update, 0xC7 = Fast update, 0xFF = Partial update
+
+    // Activate Display Update Sequence
+    this->command(0x20);
+
+    this->wait_until_idle_async_([this] {
+      ESP_LOGI(TAG, "Display updated, set it back to deep sleep");
+      this->deep_sleep();
+      this->is_busy_ = false;
+    });
+
+    this->status_clear_warning();
+  });
+}
+
+void WaveshareEPaper4P26In::deep_sleep() {
+  // Set deep sleep mode
+  this->command(0x10);
+  this->data(0x01);
+
+  delay(50);
+}
+
+int WaveshareEPaper4P26In::get_width_internal() { return 800; }
+
+int WaveshareEPaper4P26In::get_height_internal() { return 480; }
+
+uint32_t WaveshareEPaper4P26In::idle_timeout_() { return 4000; }
+
+void WaveshareEPaper4P26In::set_full_update_every(uint32_t full_update_every) {
+  this->full_update_every_ = full_update_every;
+}
+
+}  // namespace waveshare_epaper
+}  // namespace esphome

--- a/esphome/components/waveshare_epaper/waveshare_4_24in.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_4_24in.cpp
@@ -10,13 +10,13 @@ static const char *const TAG = "waveshare_epaper_4.26in";
 
 WaveshareEPaper4P26In::WaveshareEPaper4P26In() : WaveshareEPaper() { reset_duration_ = 20; }
 
-void WaveshareEPaper4P26In::init_display_async_(bool fast_update, const std::function<void()> f) {
+void WaveshareEPaper4P26In::init_display_async_(bool fast_update, const std::function<void()> &&f) {
   // Reset the display
   this->reset_();
-  wait_until_idle_async_([this, fast_update, f] {
+  wait_until_idle_async_([this, fast_update, f(std::move(f))] {
     this->command(0x12);  // SWRESET
 
-    wait_until_idle_async_([this, fast_update, f] {
+    wait_until_idle_async_([this, fast_update, f(std::move(f))] {
       // Use the internal temperature sensor
       this->command(0x18);
       this->data(0x80);
@@ -66,7 +66,7 @@ void WaveshareEPaper4P26In::init_display_async_(bool fast_update, const std::fun
       this->data(0x00);
 
       if (fast_update) {
-        this->wait_until_idle_async_([this, f] {
+        this->wait_until_idle_async_([this, f(std::move(f))] {
           this->command(0x1A);
           this->data(0x5A);
 

--- a/esphome/components/waveshare_epaper/waveshare_4_24in.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_4_24in.cpp
@@ -104,7 +104,6 @@ void HOT WaveshareEPaper4P26In::display() {
   this->is_busy_ = true;
 
   bool full_update = this->at_update_ == 0;
-  bool prev_full_update = this->at_update_ == 1;
 
   if (this->full_update_every_ >= 1) {
     this->at_update_ = (this->at_update_ + 1) % this->full_update_every_;

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -173,7 +173,7 @@ void WaveshareEPaperBase::wait_until_idle_async_(const std::function<void()> &&f
     return f();
   }
 
-  this->set_timeout(20, [this, f(std::move(f))] { this->wait_until_idle_async_(std::move(f)); });
+  this->set_timeout(20, [this, f] { this->wait_until_idle_async_(std::move(f)); });
 }
 
 void WaveshareEPaperBase::update() {

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -167,6 +167,15 @@ bool WaveshareEPaperBase::wait_until_idle_() {
   }
   return true;
 }
+
+void WaveshareEPaperBase::wait_until_idle_async_(const std::function<void()> f) {
+  if (this->busy_pin_ == nullptr || !this->busy_pin_->digital_read()) {
+    return f();
+  }
+
+  this->set_timeout(20, [this, f] { this->wait_until_idle_async_(std::move(f)); });
+}
+
 void WaveshareEPaperBase::update() {
   this->do_update_();
   this->display();

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -168,12 +168,12 @@ bool WaveshareEPaperBase::wait_until_idle_() {
   return true;
 }
 
-void WaveshareEPaperBase::wait_until_idle_async_(const std::function<void()> f) {
+void WaveshareEPaperBase::wait_until_idle_async_(const std::function<void()> &&f) {
   if (this->busy_pin_ == nullptr || !this->busy_pin_->digital_read()) {
     return f();
   }
 
-  this->set_timeout(20, [this, f] { this->wait_until_idle_async_(std::move(f)); });
+  this->set_timeout(20, [this, f(std::move(f))] { this->wait_until_idle_async_(std::move(f)); });
 }
 
 void WaveshareEPaperBase::update() {

--- a/esphome/components/waveshare_epaper/waveshare_epaper.h
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.h
@@ -195,8 +195,6 @@ class WaveshareEPaper4P26In : public WaveshareEPaper {
   bool is_busy_ = false;
   uint32_t full_update_every_{30};
   uint32_t at_update_{0};
-
-  bool deep_sleep_between_updates_{true};
 };
 
 enum WaveshareEPaperTypeBModel {

--- a/esphome/components/waveshare_epaper/waveshare_epaper.h
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.h
@@ -33,6 +33,7 @@ class WaveshareEPaperBase : public display::DisplayBuffer,
 
  protected:
   bool wait_until_idle_();
+  void wait_until_idle_async_(const std::function<void()> f);
 
   void setup_pins_();
 
@@ -169,6 +170,33 @@ class WaveshareEPaperTypeA : public WaveshareEPaper {
   uint32_t idle_timeout_() override;
 
   bool deep_sleep_between_updates_{false};
+};
+
+class WaveshareEPaper4P26In : public WaveshareEPaper {
+ public:
+  WaveshareEPaper4P26In();
+
+  void initialize() override;
+  void display() override;
+  void deep_sleep() override;
+
+  void dump_config() override;
+  void set_full_update_every(uint32_t full_update_every);
+
+ protected:
+  void init_display_async_(bool fast_update, const std::function<void()> f);
+
+  int get_width_internal() override;
+  int get_height_internal() override;
+
+  uint32_t idle_timeout_() override;
+
+ private:
+  bool is_busy_ = false;
+  uint32_t full_update_every_{30};
+  uint32_t at_update_{0};
+
+  bool deep_sleep_between_updates_{true};
 };
 
 enum WaveshareEPaperTypeBModel {

--- a/esphome/components/waveshare_epaper/waveshare_epaper.h
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.h
@@ -33,7 +33,7 @@ class WaveshareEPaperBase : public display::DisplayBuffer,
 
  protected:
   bool wait_until_idle_();
-  void wait_until_idle_async_(const std::function<void()> f);
+  void wait_until_idle_async_(const std::function<void()> &&f);
 
   void setup_pins_();
 
@@ -184,7 +184,7 @@ class WaveshareEPaper4P26In : public WaveshareEPaper {
   void set_full_update_every(uint32_t full_update_every);
 
  protected:
-  void init_display_async_(bool fast_update, const std::function<void()> f);
+  void init_display_async_(bool fast_update, const std::function<void()> &&f);
 
   int get_width_internal() override;
   int get_height_internal() override;


### PR DESCRIPTION
# What does this implement/fix?

Add support for the Waveshare 4.26inch E-Paper display.

- [Manual](https://www.waveshare.com/wiki/4.26inch_e-Paper_HAT_Manual)
- [Manual PDF](https://files.waveshare.com/wiki/4.26inch-e-Paper-HAT/4.26inch_e-Paper_User_Manual.pdf)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#3968

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

Tested on [Waveshare Universal e-Paper Driver Board](https://www.waveshare.com/wiki/E-Paper_ESP32_Driver_Board)

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Relevant parts of config.yaml

spi:
  clk_pin: GPIO13
  mosi_pin: GPIO14

display:
  - platform: waveshare_epaper
    cs_pin: GPIO15
    dc_pin: GPIO27
    busy_pin: GPIO25
    reset_pin: GPIO26
    model: 4.26in
    full_update_every: 50
    update_interval: 30s
    lambda: |-
      static int i = 0;
      i = (i + 50) % 320;
      it.rectangle(1, 1, it.get_width() - 1, it.get_height() - 1);
      it.print(i, i, id(roboto_40), "Hello World!");

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
