### PR TITLE
debug_libretiny - Fix typo

### DIFF
--- a/esphome/components/debug/debug_libretiny.cpp
+++ b/esphome/components/debug/debug_libretiny.cpp
@@ -12,7 +12,7 @@ std::string DebugComponent::get_reset_reason_() { return lt_get_reboot_reason_na
 uint32_t DebugComponent::get_free_heap_() { return lt_heap_get_free(); }
 
 void DebugComponent::get_device_info_(std::string &device_info) {
-  str::string reset_reason = get_reset_reason_();
+  std::string reset_reason = get_reset_reason_();
   ESP_LOGD(TAG, "LibreTiny Version: %s", lt_get_version());
   ESP_LOGD(TAG, "Chip: %s (%04x) @ %u MHz", lt_cpu_get_model_name(), lt_cpu_get_model(), lt_cpu_get_freq_mhz());
   ESP_LOGD(TAG, "Chip ID: 0x%06X", lt_cpu_get_mac_id());


### PR DESCRIPTION
# What does this implement/fix?

`debug` component doesn't compile on LibreTiny on 2024.6.0

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/5920 #6806 

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [X] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
esphome:
  name: bk7231test

bk72xx:
  board: cbu

logger:
debug:

text_sensor:
  - platform: debug
    device:
      name: Device Info
    reset_reason:
      name: Reset Reason

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
