### PR TITLE
2024.6.1

### DIFF
--- a/esphome/components/debug/debug_libretiny.cpp
+++ b/esphome/components/debug/debug_libretiny.cpp
@@ -12,7 +12,7 @@ std::string DebugComponent::get_reset_reason_() { return lt_get_reboot_reason_na
 uint32_t DebugComponent::get_free_heap_() { return lt_heap_get_free(); }
 
 void DebugComponent::get_device_info_(std::string &device_info) {
-  str::string reset_reason = get_reset_reason_();
+  std::string reset_reason = get_reset_reason_();
   ESP_LOGD(TAG, "LibreTiny Version: %s", lt_get_version());
   ESP_LOGD(TAG, "Chip: %s (%04x) @ %u MHz", lt_cpu_get_model_name(), lt_cpu_get_model(), lt_cpu_get_freq_mhz());
   ESP_LOGD(TAG, "Chip ID: 0x%06X", lt_cpu_get_mac_id());

--- a/esphome/const.py
+++ b/esphome/const.py
@@ -1,6 +1,6 @@
 """Constants used by esphome."""
 
-__version__ = "2024.6.0"
+__version__ = "2024.6.1"
 
 ALLOWED_NAME_CHARS = "abcdefghijklmnopqrstuvwxyz0123456789-_"
 VALID_SUBSTITUTIONS_CHARACTERS = (

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ pyserial==3.5
 platformio==6.1.15  # When updating platformio, also update Dockerfile
 esptool==4.7.0
 click==8.1.7
-esphome-dashboard==20240613.0
+esphome-dashboard==20240620.0
 aioesphomeapi==24.3.0
 zeroconf==0.132.2
 python-magic==0.4.27


### PR DESCRIPTION
**Do not merge, release script will automatically merge**
- debug_libretiny - Fix typo [esphome#6942](https://github.com/esphome/esphome/pull/6942)
- Bump esphome-dashboard to 20240620.0 [esphome#6944](https://github.com/esphome/esphome/pull/6944)

<details>
<summary>Metadata</summary>

@coderabbitai ignore
</details>
