### PR TITLE
[dooya] Flip bit timings

### DIFF
--- a/esphome/components/remote_base/dooya_protocol.cpp
+++ b/esphome/components/remote_base/dooya_protocol.cpp
@@ -8,10 +8,10 @@ static const char *const TAG = "remote.dooya";
 
 static const uint32_t HEADER_HIGH_US = 5000;
 static const uint32_t HEADER_LOW_US = 1500;
-static const uint32_t BIT_ZERO_HIGH_US = 750;
-static const uint32_t BIT_ZERO_LOW_US = 350;
-static const uint32_t BIT_ONE_HIGH_US = 350;
-static const uint32_t BIT_ONE_LOW_US = 750;
+static const uint32_t BIT_ZERO_HIGH_US = 350;
+static const uint32_t BIT_ZERO_LOW_US = 750;
+static const uint32_t BIT_ONE_HIGH_US = 750;
+static const uint32_t BIT_ONE_LOW_US = 350;
 
 void DooyaProtocol::encode(RemoteTransmitData *dst, const DooyaData &data) {
   dst->set_carrier_frequency(0);


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

According to captures in the linked issue from two different independant RF receiving tools, the bits were flipped in the ESPHome dooya protocol.

This PR corrects that, and as such is a breaking change because anyone already using it with what they thought was correct will now need to alter their config to be correct.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/5721

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
