### PR TITLE
[http_request] Get chunked content length and add some logs

### DIFF
--- a/esphome/components/http_request/http_request_idf.cpp
+++ b/esphome/components/http_request/http_request_idf.cpp
@@ -110,7 +110,7 @@ std::shared_ptr<HttpContainer> HttpRequestIDF::start(std::string url, std::strin
     return nullptr;
   }
 
-  ESP_LOGV(TAG, "HTTP Request body written: %" PRId32, body_len);
+  ESP_LOGV(TAG, "HTTP Request body written: %d", body_len);
 
   container->content_length = esp_http_client_fetch_headers(client);
   if (esp_http_client_is_chunked_response(client)) {
@@ -122,7 +122,7 @@ std::shared_ptr<HttpContainer> HttpRequestIDF::start(std::string url, std::strin
   const auto status_code = esp_http_client_get_status_code(client);
   container->status_code = status_code;
 
-  ESP_LOGD(TAG, "Status %" PRId32, status_code);
+  ESP_LOGD(TAG, "Status %d", status_code);
 
   if (status_code < 200 || status_code >= 300) {
     ESP_LOGE(TAG, "HTTP Request failed; URL: %s; Code: %d", url.c_str(), status_code);
@@ -160,7 +160,7 @@ void HttpContainerIDF::end() {
   esp_http_client_close(this->client_);
   esp_http_client_cleanup(this->client_);
 
-  ESP_LOGV(TAG, "HTTP Request ended: %" PRId32, this->status_code);
+  ESP_LOGV(TAG, "HTTP Request ended: %d", this->status_code);
 }
 
 }  // namespace http_request

--- a/esphome/components/http_request/http_request_idf.cpp
+++ b/esphome/components/http_request/http_request_idf.cpp
@@ -117,6 +117,12 @@ std::shared_ptr<HttpContainer> HttpRequestIDF::start(std::string url, std::strin
     ESP_LOGV(TAG, "HTTP Response is chunked");
     int length = 0;
     err = esp_http_client_get_chunk_length(client, &length);
+    if (err != ESP_OK) {
+      this->status_momentary_error("failed", 1000);
+      ESP_LOGE(TAG, "Failed to get chunk length: %s", esp_err_to_name(err));
+      esp_http_client_cleanup(client);
+      return nullptr;
+    }
     container->content_length = length;
   }
   const auto status_code = esp_http_client_get_status_code(client);


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
