### PR TITLE
[update] Set entity_category to config & Publish state to logs

### DIFF
--- a/esphome/components/update/__init__.py
+++ b/esphome/components/update/__init__.py
@@ -4,11 +4,13 @@ import esphome.config_validation as cv
 import esphome.codegen as cg
 from esphome.const import (
     CONF_DEVICE_CLASS,
+    CONF_ENTITY_CATEGORY,
     CONF_ID,
     CONF_MQTT_ID,
     CONF_WEB_SERVER_ID,
     DEVICE_CLASS_EMPTY,
     DEVICE_CLASS_FIRMWARE,
+    ENTITY_CATEGORY_CONFIG,
 )
 from esphome.core import CORE, coroutine_with_priority
 from esphome.cpp_helpers import setup_entity
@@ -41,6 +43,9 @@ UPDATE_SCHEMA = (
             cv.Optional(CONF_ON_UPDATE_AVAILABLE): automation.validate_automation(
                 single=True
             ),
+            cv.Optional(
+                CONF_ENTITY_CATEGORY, default=ENTITY_CATEGORY_CONFIG
+            ): cv.entity_category,
         }
     )
 )

--- a/esphome/components/update/update_entity.cpp
+++ b/esphome/components/update/update_entity.cpp
@@ -1,9 +1,35 @@
 #include "update_entity.h"
 
+#include "esphome/core/log.h"
+
 namespace esphome {
 namespace update {
 
+static const char *const TAG = "update";
+
 void UpdateEntity::publish_state() {
+  ESP_LOGD(TAG, "'%s' - Publishing:", this->name_.c_str());
+  ESP_LOGD(TAG, "  Current Version: %s", this->update_info_.current_version.c_str());
+
+  if (!this->update_info_.md5.empty()) {
+    ESP_LOGD(TAG, "  Latest Version: %s", this->update_info_.latest_version.c_str());
+  }
+  if (!this->update_info_.firmware_url.empty()) {
+    ESP_LOGD(TAG, "  Firmware URL: %s", this->update_info_.firmware_url.c_str());
+  }
+
+  ESP_LOGD(TAG, "  Title: %s", this->update_info_.title.c_str());
+  if (!this->update_info_.summary.empty()) {
+    ESP_LOGD(TAG, "  Summary: %s", this->update_info_.summary.c_str());
+  }
+  if (!this->update_info_.release_url.empty()) {
+    ESP_LOGD(TAG, "  Release URL: %s", this->update_info_.release_url.c_str());
+  }
+
+  if (this->update_info_.has_progress) {
+    ESP_LOGD(TAG, "  Progress: %.0f%%", this->update_info_.progress);
+  }
+
   this->has_state_ = true;
   this->state_callback_.call();
 }


### PR DESCRIPTION
# What does this implement/fix?

Some minor tweaks to the new ``update`` component:
- Adds more logging
- Set entity_category to config by default

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
