### PR TITLE
ES8388 component

### DIFF
--- a/esphome/components/es8388/__init__.py
+++ b/esphome/components/es8388/__init__.py
@@ -1,0 +1,21 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+
+from esphome.components import i2c
+from esphome.const import CONF_ID
+
+es8388_ns = cg.esphome_ns.namespace("es8388")
+ES8388Component = es8388_ns.class_("ES8388Component", cg.Component, i2c.I2CDevice)
+
+
+CONFIG_SCHEMA = (
+    cv.Schema({cv.GenerateID(): cv.declare_id(ES8388Component)})
+    .extend(i2c.i2c_device_schema(0x10))
+    .extend(cv.COMPONENT_SCHEMA)
+)
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+    await i2c.register_i2c_device(var, config)

--- a/esphome/components/es8388/__init__.py
+++ b/esphome/components/es8388/__init__.py
@@ -78,5 +78,5 @@ async def execute_macro_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
     await cg.register_parented(var, config[CONF_ES8388_ID])
 
-    cg.add(var.set_id(config[CONF_ID]))
+    cg.add(var.set_macro_id(config[CONF_ID]))
     return var

--- a/esphome/components/es8388/__init__.py
+++ b/esphome/components/es8388/__init__.py
@@ -27,10 +27,7 @@ ES8388_PRESETS = {
 
 
 def validate_instruction_list():
-    return cv.ensure_list(
-        cv.Length(min=2, max=2),
-        cv.ensure_list(int)
-    )
+    return cv.ensure_list(cv.Length(min=2, max=2), cv.ensure_list(int))
 
 
 CONFIG_SCHEMA = (
@@ -38,10 +35,12 @@ CONFIG_SCHEMA = (
         cv.GenerateID(): cv.declare_id(ES8388Component),
         cv.Optional(CONF_PRESET): cv.enum(ES8388_PRESETS, lower=True),
         cv.Optional(CONF_INIT_INSTRUCTIONS): validate_instruction_list(),
-        cv.Optional(CONF_MACROS): cv.ensure_list({
-            cv.Required(CONF_ID): cv.string,
-            cv.Required(CONF_INSTRUCTIONS): validate_instruction_list(),
-        }),
+        cv.Optional(CONF_MACROS): cv.ensure_list(
+            {
+                cv.Required(CONF_ID): cv.string,
+                cv.Required(CONF_INSTRUCTIONS): validate_instruction_list(),
+            }
+        ),
     })
     .extend(i2c.i2c_device_schema(0x10))
     .extend(cv.COMPONENT_SCHEMA)
@@ -58,10 +57,14 @@ async def to_code(config):
         cg.add(var.set_init_instructions(config[CONF_INIT_INSTRUCTIONS]))
     if CONF_MACROS in config:
         for macro in config[CONF_MACROS]:
-            ES8388_MACROS.register(macro[CONF_ID], Macro, {
-                cv.Required(CONF_ID): cv.declare_id(Macro),
-                cv.Required(CONF_INSTRUCTIONS): validate_instruction_list(),
-            })
+            ES8388_MACROS.register(
+                macro[CONF_ID],
+                Macro,
+                {
+                    cv.Required(CONF_ID): cv.declare_id(Macro),
+                    cv.Required(CONF_INSTRUCTIONS): validate_instruction_list(),
+                }
+            )
             cg.add(var.register_macro(macro[CONF_ID], macro[CONF_INSTRUCTIONS]))
 
 

--- a/esphome/components/es8388/__init__.py
+++ b/esphome/components/es8388/__init__.py
@@ -3,12 +3,11 @@ from esphome.automation import maybe_simple_id
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import i2c
-from esphome.const import CONF_ID
+from esphome.const import CONF_ID, CONF_PRESET
 from esphome.util import Registry
 
 CONF_ES8388_ID = "es8388_id"
 
-CONF_PRESET = "preset"
 CONF_INIT_INSTRUCTIONS = "init_instructions"
 CONF_MACROS = "macros"
 CONF_INSTRUCTIONS = "instructions"

--- a/esphome/components/es8388/__init__.py
+++ b/esphome/components/es8388/__init__.py
@@ -31,17 +31,19 @@ def validate_instruction_list():
 
 
 CONFIG_SCHEMA = (
-    cv.Schema({
-        cv.GenerateID(): cv.declare_id(ES8388Component),
-        cv.Optional(CONF_PRESET): cv.enum(ES8388_PRESETS, lower=True),
-        cv.Optional(CONF_INIT_INSTRUCTIONS): validate_instruction_list(),
-        cv.Optional(CONF_MACROS): cv.ensure_list(
-            {
-                cv.Required(CONF_ID): cv.string,
-                cv.Required(CONF_INSTRUCTIONS): validate_instruction_list(),
-            }
-        ),
-    })
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.declare_id(ES8388Component),
+            cv.Optional(CONF_PRESET): cv.enum(ES8388_PRESETS, lower=True),
+            cv.Optional(CONF_INIT_INSTRUCTIONS): validate_instruction_list(),
+            cv.Optional(CONF_MACROS): cv.ensure_list(
+                {
+                    cv.Required(CONF_ID): cv.string,
+                    cv.Required(CONF_INSTRUCTIONS): validate_instruction_list(),
+                }
+            ),
+        }
+    )
     .extend(i2c.i2c_device_schema(0x10))
     .extend(cv.COMPONENT_SCHEMA)
 )
@@ -63,7 +65,7 @@ async def to_code(config):
                 {
                     cv.Required(CONF_ID): cv.declare_id(Macro),
                     cv.Required(CONF_INSTRUCTIONS): validate_instruction_list(),
-                }
+                },
             )
             cg.add(var.register_macro(macro[CONF_ID], macro[CONF_INSTRUCTIONS]))
 

--- a/esphome/components/es8388/__init__.py
+++ b/esphome/components/es8388/__init__.py
@@ -26,6 +26,7 @@ ES8388_PRESETS = {
     "raspiaudio_radio": Presets.RASPIAUDIO_RADIO,
 }
 
+
 def validate_instruction_list():
     return cv.ensure_list(
         cv.Length(min=2, max=2),
@@ -63,6 +64,7 @@ async def to_code(config):
                 cv.Required(CONF_INSTRUCTIONS): validate_instruction_list(),
             })
             cg.add(var.register_macro(macro[CONF_ID], macro[CONF_INSTRUCTIONS]))
+
 
 @automation.register_action(
     "es8388.execute_macro",

--- a/esphome/components/es8388/__init__.py
+++ b/esphome/components/es8388/__init__.py
@@ -1,15 +1,48 @@
+from esphome import automation
+from esphome.automation import maybe_simple_id
 import esphome.codegen as cg
 import esphome.config_validation as cv
-
 from esphome.components import i2c
 from esphome.const import CONF_ID
+from esphome.util import Registry
+
+CONF_ES8388_ID = "es8388_id"
+
+CONF_PRESET = "preset"
+CONF_INIT_INSTRUCTIONS = "init_instructions"
+CONF_MACROS = "macros"
+CONF_INSTRUCTIONS = "instructions"
+
+ES8388_MACROS = Registry()
 
 es8388_ns = cg.esphome_ns.namespace("es8388")
 ES8388Component = es8388_ns.class_("ES8388Component", cg.Component, i2c.I2CDevice)
+Presets = es8388_ns.enum("ES8388Preset")
+Macro = es8388_ns.class_("Macro")
+MacroAction = es8388_ns.class_("ES8388MacroAction", automation.Action)
+
+ES8388_PRESETS = {
+    "raspiaudio_muse_luxe": Presets.RASPIAUDIO_MUSE_LUXE,
+    "raspiaudio_radio": Presets.RASPIAUDIO_RADIO,
+}
+
+def validate_instruction_list():
+    return cv.ensure_list(
+        cv.Length(min=2, max=2),
+        cv.ensure_list(int)
+    )
 
 
 CONFIG_SCHEMA = (
-    cv.Schema({cv.GenerateID(): cv.declare_id(ES8388Component)})
+    cv.Schema({
+        cv.GenerateID(): cv.declare_id(ES8388Component),
+        cv.Optional(CONF_PRESET): cv.enum(ES8388_PRESETS, lower=True),
+        cv.Optional(CONF_INIT_INSTRUCTIONS): validate_instruction_list(),
+        cv.Optional(CONF_MACROS): cv.ensure_list({
+            cv.Required(CONF_ID): cv.string,
+            cv.Required(CONF_INSTRUCTIONS): validate_instruction_list(),
+        }),
+    })
     .extend(i2c.i2c_device_schema(0x10))
     .extend(cv.COMPONENT_SCHEMA)
 )
@@ -19,3 +52,31 @@ async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
     await i2c.register_i2c_device(var, config)
+    if CONF_PRESET in config:
+        cg.add(var.set_preset(config[CONF_PRESET]))
+    if CONF_INIT_INSTRUCTIONS in config:
+        cg.add(var.set_init_instructions(config[CONF_INIT_INSTRUCTIONS]))
+    if CONF_MACROS in config:
+        for macro in config[CONF_MACROS]:
+            ES8388_MACROS.register(macro[CONF_ID], Macro, {
+                cv.Required(CONF_ID): cv.declare_id(Macro),
+                cv.Required(CONF_INSTRUCTIONS): validate_instruction_list(),
+            })
+            cg.add(var.register_macro(macro[CONF_ID], macro[CONF_INSTRUCTIONS]))
+
+@automation.register_action(
+    "es8388.execute_macro",
+    MacroAction,
+    maybe_simple_id(
+        {
+            cv.GenerateID(CONF_ES8388_ID): cv.use_id(ES8388Component),
+            cv.Required(CONF_ID): cv.string,
+        },
+    ),
+)
+async def execute_macro_to_code(config, action_id, template_arg, args):
+    var = cg.new_Pvariable(action_id, template_arg)
+    await cg.register_parented(var, config[CONF_ES8388_ID])
+
+    cg.add(var.set_id(config[CONF_ID]))
+    return var

--- a/esphome/components/es8388/es8388_component.cpp
+++ b/esphome/components/es8388/es8388_component.cpp
@@ -9,9 +9,6 @@ namespace es8388 {
 
 static const char *const TAG = "es8388";
 
-#define ES8388_CLK_MODE_SLAVE 0
-#define ES8388_CLK_MODE_MASTER 1
-
 void ES8388Component::setup() {
   switch (this->preset_) {
     case ES8388Preset::RASPIAUDIO_MUSE_LUXE:
@@ -132,7 +129,7 @@ void ES8388Component::setup_raspiaudio_radio() {
   error = error || not this->write_byte(1, 0x50);
   // powerup
   error = error || not this->write_byte(2, 0x00);
-  // slave mode
+  // follower mode
   error = error || not this->write_byte(8, 0x00);
   // DAC powerdown
   error = error || not this->write_byte(4, 0xC0);

--- a/esphome/components/es8388/es8388_component.cpp
+++ b/esphome/components/es8388/es8388_component.cpp
@@ -1,75 +1,218 @@
 #include "es8388_component.h"
 #include "esphome/core/hal.h"
+#include "esphome/core/log.h"
 
 #include <soc/io_mux_reg.h>
 
 namespace esphome {
 namespace es8388 {
 
+#define ES8388_CLK_MODE_SLAVE 0
+#define ES8388_CLK_MODE_MASTER 1
+
 void ES8388Component::setup() {
-  PIN_FUNC_SELECT(PERIPHS_IO_MUX_GPIO0_U, FUNC_GPIO0_CLK_OUT1);
-  WRITE_PERI_REG(PIN_CTRL, READ_PERI_REG(PIN_CTRL) & 0xFFFFFFF0);
+  int zerooo = 0;
+  int val = 2 / zerooo;
+  ESP_LOGW("ES8388", "Writing I2C registers");
 
+  // PIN_FUNC_SELECT(PERIPHS_IO_MUX_GPIO0_U, FUNC_GPIO0_CLK_OUT1);
+  // PIN_FUNC_SELECT(PERIPHS_IO_MUX_GPIO0_U, 1);
+  // WRITE_PERI_REG(PIN_CTRL, READ_PERI_REG(PIN_CTRL) & 0xFFFFFFF0);
+
+  this->setup_raspiaudio_radio();
+}
+
+void ES8388Component::setup_raspiaudio_radio() {
+  bool error = false;
+  error = error || not this->write_byte(0, 0x80);
+  error = error || not this->write_byte(0, 0x00);
   // mute
-  this->write_byte(0x19, 0x04);
+  error = error || not this->write_byte(25, 0x04);
+  error = error || not this->write_byte(1, 0x50);
   // powerup
-  this->write_byte(0x01, 0x50);
-  this->write_byte(0x02, 0x00);
-  // worker mode
-  this->write_byte(0x08, 0x00);
+  error = error || not this->write_byte(2, 0x00);
+  // slave mode
+  error = error || not this->write_byte(8, 0x00);
   // DAC powerdown
-  this->write_byte(0x04, 0xC0);
+  error = error || not this->write_byte(4, 0xC0);
   // vmidsel/500k ADC/DAC idem
-  this->write_byte(0x00, 0x12);
+  error = error || not this->write_byte(0, 0x12);
 
+  error = error || not this->write_byte(1, 0x00);
   // i2s 16 bits
-  this->write_byte(0x17, 0x18);
+  error = error || not this->write_byte(23, 0x18);
   // sample freq 256
-  this->write_byte(0x18, 0x02);
+  error = error || not this->write_byte(24, 0x02);
   // LIN2/RIN2 for mixer
-  this->write_byte(0x26, 0x00);
+  error = error || not this->write_byte(38, 0x09);
   // left DAC to left mixer
-  this->write_byte(0x27, 0x90);
+  error = error || not this->write_byte(39, 0x80);
   // right DAC to right mixer
-  this->write_byte(0x2A, 0x90);
+  error = error || not this->write_byte(42, 0x80);
   // DACLRC ADCLRC idem
-  this->write_byte(0x2B, 0x80);
-  this->write_byte(0x2D, 0x00);
+  error = error || not this->write_byte(43, 0x80);
+  error = error || not this->write_byte(45, 0x00);
   // DAC volume max
-  this->write_byte(0x1B, 0x00);
-  this->write_byte(0x1A, 0x00);
+  error = error || not this->write_byte(27, 0x00);
+  error = error || not this->write_byte(26, 0x00);
+
+  // mono (L+R)/2
+  error = error || not this->write_byte(29, 0x00);
+
+  // DAC power-up LOUT1/ROUT1 ET 2 enabled
+  error = error || not this->write_byte(4, 0x39);
+
+  // DAC R phase inversion
+  error = error || not this->write_byte(28, 0x14);
 
   // ADC poweroff
-  this->write_byte(0x03, 0xFF);
-  // ADC amp 24dB
-  this->write_byte(0x09, 0x88);
-  // LINPUT1/RINPUT1
-  this->write_byte(0x0A, 0x00);
-  // ADC mono left
-  this->write_byte(0x0B, 0x02);
-  // i2S 16b
-  this->write_byte(0x0C, 0x0C);
-  // MCLK 256
-  this->write_byte(0x0D, 0x02);
-  // ADC Volume
-  this->write_byte(0x10, 0x00);
-  this->write_byte(0x11, 0x00);
-  // ALC OFF
-  this->write_byte(0x03, 0x09);
-  this->write_byte(0x2B, 0x80);
+  error = error || not this->write_byte(3, 0xFF);
 
-  this->write_byte(0x02, 0xF0);
-  delay(1);
-  this->write_byte(0x02, 0x00);
-  // DAC power-up LOUT1/ROUT1 enabled
-  this->write_byte(0x04, 0x30);
-  this->write_byte(0x03, 0x00);
-  // DAC volume max
-  this->write_byte(0x2E, 0x1C);
-  this->write_byte(0x2F, 0x1C);
+  // ADC amp 24dB
+  error = error || not this->write_byte(9, 0x88);
+
+  // differential input
+  error = error || not this->write_byte(10, 0xFC);
+  error = error || not this->write_byte(11, 0x02);
+
+  // Select LIN2and RIN2 as differential input pairs
+  // error = error || not this->write_byte(11,0x82);
+
+  // i2S 16b
+  error = error || not this->write_byte(12, 0x0C);
+  // MCLK 256
+  error = error || not this->write_byte(13, 0x02);
+  // ADC high pass filter
+  // error = error || not this->write_byte(14,0x30);
+
+  // ADC Volume LADC volume = 0dB
+  error = error || not this->write_byte(16, 0x00);
+
+  // ADC Volume RADC volume = 0dB
+  error = error || not this->write_byte(17, 0x00);
+
+  // ALC
+  error =
+      error || not this->write_byte(0x12, 0xfd);  // Reg 0x12 = 0xe2 (ALC enable, PGA Max. Gain=23.5dB, Min. Gain=0dB)
+  // error = error || not this->write_byte(0x12, 0x22); // Reg 0x12 = 0xe2 (ALC enable, PGA Max. Gain=23.5dB, Min.
+  // Gain=0dB)
+  error = error || not this->write_byte(0x13, 0xF9);  // Reg 0x13 = 0xc0 (ALC Target=-4.5dB, ALC Hold time =0 mS)
+  error = error || not this->write_byte(0x14, 0x02);  // Reg 0x14 = 0x12(Decay time =820uS , Attack time = 416 uS)
+  error = error || not this->write_byte(0x15, 0x06);  // Reg 0x15 = 0x06(ALC mode)
+  error = error || not this->write_byte(0x16, 0xc3);  // Reg 0x16 = 0xc3(nose gate = -40.5dB, NGG = 0x01(mute ADC))
+  error = error ||
+          not this->write_byte(0x02, 0x55);  // Reg 0x16 = 0x55 (Start up DLL, STM and Digital block for recording);
+
+  // error = error || not this->write_byte(3, 0x09);
+  error = error || not this->write_byte(3, 0x00);
+
+  // reset power DAC and ADC
+  error = error || not this->write_byte(2, 0xF0);
+  error = error || not this->write_byte(2, 0x00);
+
   // unmute
-  this->write_byte(0x19, 0x00);
+  error = error || not this->write_byte(25, 0x00);
+  // amp validation
+  error = error || not this->write_byte(46, 30);
+  error = error || not this->write_byte(47, 30);
+  error = error || not this->write_byte(48, 33);
+  error = error || not this->write_byte(49, 33);
+
+  if (error) {
+    ESP_LOGE("ES8388", "Error writing I2C registers!");
+  } else {
+    ESP_LOGW("ES8388", "I2C registers written successfully");
+  }
 }
+
+void ES8388Component::setup_raspiaudio_muse_luxe() {
+  // mute
+  this->mute();
+
+  // powerup
+  this->powerup();
+  this->clock_mode(ES8388_CLK_MODE_SLAVE);
+
+  bool error = false;
+
+  // DAC powerdown
+  this->powerdown_dac();
+  // vmidsel/500k ADC/DAC idem
+  error = error || not this->write_byte(0x00, 0x12);
+
+  // i2s 16 bits
+  error = error || not this->write_byte(0x17, 0x18);
+  // sample freq 256
+  error = error || not this->write_byte(0x18, 0x02);
+  // LIN2/RIN2 for mixer
+  error = error || not this->write_byte(0x26, 0x00);
+  // left DAC to left mixer
+  error = error || not this->write_byte(0x27, 0x90);
+  // right DAC to right mixer
+  error = error || not this->write_byte(0x2A, 0x90);
+  // DACLRC ADCLRC idem
+  error = error || not this->write_byte(0x2B, 0x80);
+  error = error || not this->write_byte(0x2D, 0x00);
+  // DAC volume max
+  error = error || not this->write_byte(0x1B, 0x00);
+  error = error || not this->write_byte(0x1A, 0x00);
+
+  // ADC poweroff
+  error = error || not this->write_byte(0x03, 0xFF);
+  // ADC amp 24dB
+  error = error || not this->write_byte(0x09, 0x88);
+  // LINPUT1/RINPUT1
+  error = error || not this->write_byte(0x0A, 0x00);
+  // ADC mono left
+  error = error || not this->write_byte(0x0B, 0x02);
+  // i2S 16b
+  error = error || not this->write_byte(0x0C, 0x0C);
+  // MCLK 256
+  error = error || not this->write_byte(0x0D, 0x02);
+  // ADC Volume
+  error = error || not this->write_byte(0x10, 0x00);
+  error = error || not this->write_byte(0x11, 0x00);
+  // ALC OFF
+  error = error || not this->write_byte(0x03, 0x09);
+  error = error || not this->write_byte(0x2B, 0x80);
+
+  error = error || not this->write_byte(0x02, 0xF0);
+  delay(1);
+  error = error || not this->write_byte(0x02, 0x00);
+  // DAC power-up LOUT1/ROUT1 enabled
+  error = error || not this->write_byte(0x04, 0x30);
+  error = error || not this->write_byte(0x03, 0x00);
+  // DAC volume max
+  error = error || not this->write_byte(0x2E, 0x1C);
+  error = error || not this->write_byte(0x2F, 0x1C);
+  // unmute
+  error = error || not this->write_byte(0x19, 0x00);
+}
+
+void ES8388Component::powerup_dac() { this->write_byte(0x04, 0x3B); }
+// void ES8388Component::powerup_adc() {}
+void ES8388Component::powerup() {
+  this->write_byte(0x01, 0x50);  // LPVrefBuf - low power
+  this->write_byte(0x02, 0x00);  // power up DAC/ADC without resetting DMS, DEM, filters & serial
+}
+
+void ES8388Component::powerdown_dac() { this->write_byte(0x04, 0xC0); }
+void ES8388Component::powerdown_adc() {}
+void ES8388Component::powerdown() {
+  this->powerdown_dac();
+  this->powerdown_adc();
+}
+
+void ES8388Component::clock_mode(uint8_t mode) {
+  if (mode == ES8388_CLK_MODE_SLAVE) {
+    this->write_byte(0x08, 0x00);
+  } else {
+    this->write_byte(0x08, 0x80);
+    // TODO multipliers
+  }
+}
+
+void ES8388Component::mute() { this->write_byte(0x19, 0x04); }
 
 }  // namespace es8388
 }  // namespace esphome

--- a/esphome/components/es8388/es8388_component.cpp
+++ b/esphome/components/es8388/es8388_component.cpp
@@ -1,0 +1,75 @@
+#include "es8388_component.h"
+#include "esphome/core/hal.h"
+
+#include <soc/io_mux_reg.h>
+
+namespace esphome {
+namespace es8388 {
+
+void ES8388Component::setup() {
+  PIN_FUNC_SELECT(PERIPHS_IO_MUX_GPIO0_U, FUNC_GPIO0_CLK_OUT1);
+  WRITE_PERI_REG(PIN_CTRL, READ_PERI_REG(PIN_CTRL) & 0xFFFFFFF0);
+
+  // mute
+  this->write_byte(0x19, 0x04);
+  // powerup
+  this->write_byte(0x01, 0x50);
+  this->write_byte(0x02, 0x00);
+  // worker mode
+  this->write_byte(0x08, 0x00);
+  // DAC powerdown
+  this->write_byte(0x04, 0xC0);
+  // vmidsel/500k ADC/DAC idem
+  this->write_byte(0x00, 0x12);
+
+  // i2s 16 bits
+  this->write_byte(0x17, 0x18);
+  // sample freq 256
+  this->write_byte(0x18, 0x02);
+  // LIN2/RIN2 for mixer
+  this->write_byte(0x26, 0x00);
+  // left DAC to left mixer
+  this->write_byte(0x27, 0x90);
+  // right DAC to right mixer
+  this->write_byte(0x2A, 0x90);
+  // DACLRC ADCLRC idem
+  this->write_byte(0x2B, 0x80);
+  this->write_byte(0x2D, 0x00);
+  // DAC volume max
+  this->write_byte(0x1B, 0x00);
+  this->write_byte(0x1A, 0x00);
+
+  // ADC poweroff
+  this->write_byte(0x03, 0xFF);
+  // ADC amp 24dB
+  this->write_byte(0x09, 0x88);
+  // LINPUT1/RINPUT1
+  this->write_byte(0x0A, 0x00);
+  // ADC mono left
+  this->write_byte(0x0B, 0x02);
+  // i2S 16b
+  this->write_byte(0x0C, 0x0C);
+  // MCLK 256
+  this->write_byte(0x0D, 0x02);
+  // ADC Volume
+  this->write_byte(0x10, 0x00);
+  this->write_byte(0x11, 0x00);
+  // ALC OFF
+  this->write_byte(0x03, 0x09);
+  this->write_byte(0x2B, 0x80);
+
+  this->write_byte(0x02, 0xF0);
+  delay(1);
+  this->write_byte(0x02, 0x00);
+  // DAC power-up LOUT1/ROUT1 enabled
+  this->write_byte(0x04, 0x30);
+  this->write_byte(0x03, 0x00);
+  // DAC volume max
+  this->write_byte(0x2E, 0x1C);
+  this->write_byte(0x2F, 0x1C);
+  // unmute
+  this->write_byte(0x19, 0x00);
+}
+
+}  // namespace es8388
+}  // namespace esphome

--- a/esphome/components/es8388/es8388_component.cpp
+++ b/esphome/components/es8388/es8388_component.cpp
@@ -214,10 +214,10 @@ void ES8388Component::setup_raspiaudio_radio() {
   // unmute
   error = error || not this->write_byte(25, 0x00);
   // amp validation
-  error = error || not this->write_byte(46, 30);
-  error = error || not this->write_byte(47, 30);
-  error = error || not this->write_byte(48, 33);
-  error = error || not this->write_byte(49, 33);
+  error = error || not this->write_byte(46, 24);
+  error = error || not this->write_byte(47, 24);
+  error = error || not this->write_byte(48, 24);
+  error = error || not this->write_byte(49, 24);
 
   if (error) {
     ESP_LOGE(TAG, "Error writing I2C registers for preset Raspiaudio Radio");

--- a/esphome/components/es8388/es8388_component.cpp
+++ b/esphome/components/es8388/es8388_component.cpp
@@ -239,7 +239,8 @@ void ES8388Component::execute_macro(std::string name) {
     return;
   }
 
-  ESP_LOGD(TAG, "Calling ES8388 macro `%s` with %d I2C instructions", name, this->macros_[name].instructions.size());
+  ESP_LOGD(TAG, "Calling ES8388 macro `%s` with %d I2C instructions", name.c_str(),
+           this->macros_[name].instructions.size());
 
   for (std::array<uint8_t, 2> instruction : this->macros_[name].instructions) {
     if (this->write_byte(instruction[0], instruction[1]))

--- a/esphome/components/es8388/es8388_component.cpp
+++ b/esphome/components/es8388/es8388_component.cpp
@@ -248,30 +248,5 @@ void ES8388Component::execute_macro(std::string name) {
   }
 }
 
-void ES8388Component::powerup_dac() { this->write_byte(0x04, 0x3B); }
-// void ES8388Component::powerup_adc() {}
-void ES8388Component::powerup() {
-  this->write_byte(0x01, 0x50);  // LPVrefBuf - low power
-  this->write_byte(0x02, 0x00);  // power up DAC/ADC without resetting DMS, DEM, filters & serial
-}
-
-void ES8388Component::powerdown_dac() { this->write_byte(0x04, 0xC0); }
-void ES8388Component::powerdown_adc() {}
-void ES8388Component::powerdown() {
-  this->powerdown_dac();
-  this->powerdown_adc();
-}
-
-void ES8388Component::clock_mode(uint8_t mode) {
-  if (mode == ES8388_CLK_MODE_SLAVE) {
-    this->write_byte(0x08, 0x00);
-  } else {
-    this->write_byte(0x08, 0x80);
-    // TODO multipliers
-  }
-}
-
-void ES8388Component::mute() { this->write_byte(0x19, 0x04); }
-
 }  // namespace es8388
 }  // namespace esphome

--- a/esphome/components/es8388/es8388_component.h
+++ b/esphome/components/es8388/es8388_component.h
@@ -9,8 +9,22 @@ namespace es8388 {
 class ES8388Component : public Component, public i2c::I2CDevice {
  public:
   void setup() override;
+  void setup_raspiaudio_radio();
+  void setup_raspiaudio_muse_luxe();
 
   float get_setup_priority() const override { return setup_priority::LATE - 1; }
+
+  void powerup_dac();
+  // void powerup_adc();
+  void powerup();
+
+  void powerdown_dac();
+  void powerdown_adc();
+  void powerdown();
+
+  void clock_mode(uint8_t mode);
+
+  void mute();
 };
 
 }  // namespace es8388

--- a/esphome/components/es8388/es8388_component.h
+++ b/esphome/components/es8388/es8388_component.h
@@ -30,18 +30,6 @@ class ES8388Component : public Component, public i2c::I2CDevice {
   void register_macro(std::string name, Instructions instructions);
   void execute_macro(std::string name);
 
-  void powerup_dac();
-  // void powerup_adc();
-  void powerup();
-
-  void powerdown_dac();
-  void powerdown_adc();
-  void powerdown();
-
-  void clock_mode(uint8_t mode);
-
-  void mute();
-
  protected:
   void setup_raspiaudio_radio();
   void setup_raspiaudio_muse_luxe();

--- a/esphome/components/es8388/es8388_component.h
+++ b/esphome/components/es8388/es8388_component.h
@@ -1,18 +1,34 @@
 #pragma once
 
+#include <map>
+
 #include "esphome/components/i2c/i2c.h"
 #include "esphome/core/component.h"
+#include "esphome/core/automation.h"
+#include "esphome/core/helpers.h"
 
 namespace esphome {
 namespace es8388 {
 
+enum ES8388Preset : uint8_t { NONE = 0x00, RASPIAUDIO_MUSE_LUXE = 0x01, RASPIAUDIO_RADIO = 0x02 };
+typedef std::vector<std::array<uint8_t, 2>> Instructions;
+struct Macro {
+  std::string name;
+  Instructions instructions;
+};
+typedef std::map<std::string, Macro> Macros;
+
 class ES8388Component : public Component, public i2c::I2CDevice {
  public:
   void setup() override;
-  void setup_raspiaudio_radio();
-  void setup_raspiaudio_muse_luxe();
+  void dump_config() override;
 
   float get_setup_priority() const override { return setup_priority::LATE - 1; }
+
+  void set_preset(ES8388Preset preset) { this->preset_ = preset; }
+  void set_init_instructions(Instructions instructions) { this->init_instructions_ = instructions; }
+  void register_macro(std::string name, Instructions instructions);
+  void execute_macro(std::string name);
 
   void powerup_dac();
   // void powerup_adc();
@@ -25,6 +41,33 @@ class ES8388Component : public Component, public i2c::I2CDevice {
   void clock_mode(uint8_t mode);
 
   void mute();
+
+ protected:
+  void setup_raspiaudio_radio();
+  void setup_raspiaudio_muse_luxe();
+  ES8388Preset preset_;
+  Instructions init_instructions_;
+  Macros macros_;
+};
+
+template<typename... Ts> class ES8388MacroAction : public Action<Ts...>, public Parented<ES8388Component> {
+ public:
+  //   TEMPLATABLE_VALUE(int8_t, hw_frontend_reset)
+  TEMPLATABLE_VALUE(std::string, macro_id)
+  //   TEMPLATABLE_VALUE(int, sensing_distance)
+  //   TEMPLATABLE_VALUE(int, poweron_selfcheck_time)
+  //   TEMPLATABLE_VALUE(int, power_consumption)
+  //   TEMPLATABLE_VALUE(int, protect_time)
+  //   TEMPLATABLE_VALUE(int, trigger_base)
+  //   TEMPLATABLE_VALUE(int, trigger_keep)
+  //   TEMPLATABLE_VALUE(int, stage_gain)
+
+  void play(Ts... x) {
+    if (this->macro_id_.has_value()) {
+      std::string macro_id = this->macro_.value(x...);
+      this->parent_->execute_macro(macro_id);
+    }
+  }
 };
 
 }  // namespace es8388

--- a/esphome/components/es8388/es8388_component.h
+++ b/esphome/components/es8388/es8388_component.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "esphome/components/i2c/i2c.h"
+#include "esphome/core/component.h"
+
+namespace esphome {
+namespace es8388 {
+
+class ES8388Component : public Component, public i2c::I2CDevice {
+ public:
+  void setup() override;
+
+  float get_setup_priority() const override { return setup_priority::LATE - 1; }
+};
+
+}  // namespace es8388
+}  // namespace esphome

--- a/esphome/components/es8388/es8388_component.h
+++ b/esphome/components/es8388/es8388_component.h
@@ -52,19 +52,11 @@ class ES8388Component : public Component, public i2c::I2CDevice {
 
 template<typename... Ts> class ES8388MacroAction : public Action<Ts...>, public Parented<ES8388Component> {
  public:
-  //   TEMPLATABLE_VALUE(int8_t, hw_frontend_reset)
   TEMPLATABLE_VALUE(std::string, macro_id)
-  //   TEMPLATABLE_VALUE(int, sensing_distance)
-  //   TEMPLATABLE_VALUE(int, poweron_selfcheck_time)
-  //   TEMPLATABLE_VALUE(int, power_consumption)
-  //   TEMPLATABLE_VALUE(int, protect_time)
-  //   TEMPLATABLE_VALUE(int, trigger_base)
-  //   TEMPLATABLE_VALUE(int, trigger_keep)
-  //   TEMPLATABLE_VALUE(int, stage_gain)
 
   void play(Ts... x) {
     if (this->macro_id_.has_value()) {
-      std::string macro_id = this->macro_.value(x...);
+      std::string macro_id = this->macro_id_.value(x...);
       this->parent_->execute_macro(macro_id);
     }
   }


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->
A more advanced version of #3552 where the Muse Luxe config is no longer hard-coded.

The component offers "presets" (available for the Raspiaudio Muse Luxe and the Raspiaudio Radio) which initialize the DAC in those speakers according to instructions developed together with the guys from @RASPIAUDIO

If you're using a different board, you can provide `init_instructions` as a custom list of octet pairs which will be sent using I2C. These instructions will be ignored if a `preset` is specified.

Additionally, you can define `macros` as list of I2C instructions represented as octet pairs. These macros can be called in your automations using the `es8388.execute_macro` service, taking the macro name as the sole parameter.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** replaces and closes #3552

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
external_components:
  - source: github://pr#6956
    components: [ es8388 ]

es8388:
  # preset: raspiaudio_muse_luxe
  # preset: raspiaudio_radio
  init_instructions:
    - [0x02, 0xFF]
    - [0x01, 0xCC]
  macros:
    - id: do_stuff
      instructions:
        - [0x01, 0x00]

some_component:
  on_some_event:
    - es8388.execute_macro: do_stuff

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
