### PR TITLE
[qspi_amoled] Fix display remaining blank after update() before setup completion

### DIFF
--- a/esphome/components/qspi_amoled/qspi_amoled.cpp
+++ b/esphome/components/qspi_amoled/qspi_amoled.cpp
@@ -25,6 +25,9 @@ void QspiAmoLed::setup() {
 }
 
 void QspiAmoLed::update() {
+  if (!this->setup_complete_) {
+    return;
+  }
   this->do_update_();
   // Start addresses and widths/heights must be divisible by 2 (CASET/RASET restriction in datasheet)
   if (this->x_low_ % 2 == 1) {


### PR DESCRIPTION
# What does this implement/fix?

When using a fairly basic display setup like in the example below on my LILYGO T4 S3, nothing appears on the display. The reason is that `update()` is called before the asynchronous `setTimeout()` tasks started by `setup()` have completed. The desired updates to the display buffer are still made (via `do_update_()` => `draw_absolute_pixel_internal()`), but `draw_pixels_at()` will rightfully refuse to write the updated buffer to the display because `setup_complete_ == false`. However, `update()` will still invalidate the low/high watermarks.

When `update()` is called again later with the same graphics/lambda, no changes to the display buffer will be detected, the watermarks will not be set again, and the display will remain blank, no matter how many further updates are made, unless the content is different.

Admittedly this will only affect users with an `update_interval` who don't use `auto_clear_enabled` and who don't manually call `clear()` in the lambda, e.g. for efficiency reasons if only a small part of the display needs to change. It did bite me though and took some time to figure out.

My simple suggested change is for `update()` not to proceed and invalidate the watermarks if setup has not completed yet. In this way, the first update after setup completion will cause the desired display output, as expected.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
display:
  - platform: qspi_amoled
    id: amoled_display
    model: RM690B0
    data_rate: 80MHz
    dimensions:
      width: 450
      height: 600
      offset_width: 16
    cs_pin: 11
    reset_pin: 13
    enable_pin: 9
    update_interval: 5s
    auto_clear_enabled: false
    lambda: |-
      it.filled_circle(100, 110, 50);
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
