### PR TITLE
[qspi_amoled] Fix clear/fill with rotation

### DIFF
--- a/esphome/components/qspi_amoled/qspi_amoled.h
+++ b/esphome/components/qspi_amoled/qspi_amoled.h
@@ -65,13 +65,10 @@ class QspiAmoLed : public display::DisplayBuffer,
 
   void set_reset_pin(GPIOPin *reset_pin) { this->reset_pin_ = reset_pin; }
   void set_enable_pin(GPIOPin *enable_pin) { this->enable_pin_ = enable_pin; }
-  void set_width(uint16_t width) { this->width_ = width; }
   void set_dimensions(uint16_t width, uint16_t height) {
     this->width_ = width;
     this->height_ = height;
   }
-  int get_width() override { return this->width_; }
-  int get_height() override { return this->height_; }
   void set_invert_colors(bool invert_colors) {
     this->invert_colors_ = invert_colors;
     this->reset_params_();


### PR DESCRIPTION
# What does this implement/fix?

When rotation 90 or 270 degrees is used with qspi_amoled, the `clear()`/`fill()` functions will not clear/fill the entire screen. The reason is that `QspiAmoLed` overrides `get_width()`/`get_height()` from `DisplayBuffer` to return the native/internal width/height without rotation applied. However, `Display::fill()` calls `fill_rectangle()` with those values, and `fill_rectangle()` expects "user" rather than native/internal coordinates.

The example config below leaves the lower part of the screen white, instead of all black.

My proposed fix is to remove the overridden functions from `QspiAmoLed`, so that it reverts to those from `DisplayBuffer`, which take rotation into account (as intended according to the definition/comment on these functions in display.h).

I'm also not sure what purpose the lone `set_width()` serves, as it doesn't seem to be called anywhere, and suggest removing it unless it is needed (and does not break rotation).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
display:
  - platform: qspi_amoled
    id: amoled_display
    model: RM690B0
    data_rate: 80MHz
    rotation: 90
    dimensions:
      width: 450
      height: 600
      offset_width: 16
    cs_pin: 11
    reset_pin: 13
    enable_pin: 9
    update_interval: 5s
    auto_clear_enabled: false
    lambda: |-
      it.filled_rectangle(0, 0, 599, 449);
      it.clear();
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
