### PR TITLE
ESP-IDF 4.x expects seconds for esp_task_wdt_init(), not milliseconds.

### DIFF
--- a/esphome/components/http_request/watchdog.cpp
+++ b/esphome/components/http_request/watchdog.cpp
@@ -46,7 +46,7 @@ void WatchdogManager::set_timeout_(uint32_t timeout_ms) {
   };
   esp_task_wdt_reconfigure(&wdt_config);
 #else
-  esp_task_wdt_init(timeout_ms, true);
+  esp_task_wdt_init(timeout_ms / 1000, true);
 #endif  // ESP_IDF_VERSION_MAJOR
 #endif  // USE_ESP32
 


### PR DESCRIPTION
# What does this implement/fix?

Corrects watchdog timeout setting in http_request when using ESP-IDF 4.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Test Environment

- [ ] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).