### PR TITLE
Add ccache to ESPHome builds

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -28,6 +28,7 @@ RUN \
     apt-get update \
     # Use pinned versions so that we get updates with build caching
     && apt-get install -y --no-install-recommends \
+        ccache \
         python3-pip=23.0.1+dfsg-1 \
         python3-setuptools=66.1.1-1 \
         python3-venv=3.11.2-1+b1 \

--- a/esphome/use_ccache.py.script
+++ b/esphome/use_ccache.py.script
@@ -5,8 +5,10 @@
 # pylint: disable=E0602
 Import("env")  # noqa
 
-env.Replace(
-  AS="ccache %s" % env["AS"],
-  CC="ccache %s" % env["CC"],
-  CXX="ccache %s" % env["CXX"],
-)
+ccache = env.WhereIs("ccache")
+if ccache is not None:
+    env.Replace(
+      AS="%s %s" % (ccache, env["AS"]),
+      CC="%s %s" % (ccache, env["CC"]),
+      CXX="%s %s" % (ccache, env["CXX"]),
+    )

--- a/esphome/use_ccache.py.script
+++ b/esphome/use_ccache.py.script
@@ -1,0 +1,12 @@
+# Derived from
+#   - https://github.com/platformio/platformio-core/issues/4592
+#   - https://github.com/platformio/platform-espressif32/issues/1073
+
+# pylint: disable=E0602
+Import("env")  # noqa
+
+env.Replace(
+  AS="ccache %s" % env["AS"],
+  CC="ccache %s" % env["CC"],
+  CXX="ccache %s" % env["CXX"],
+)

--- a/esphome/writer.py
+++ b/esphome/writer.py
@@ -142,6 +142,9 @@ def get_ini_content():
     # Sort to avoid changing build flags order
     CORE.add_platformio_option("build_flags", sorted(CORE.build_flags))
 
+    CORE.add_platformio_option("board_build.cmake_extra_args", "-DCCACHE_ENABLE=ON")
+    CORE.add_platformio_option("extra_scripts", ["post:use_ccache.py"])
+
     content = "[platformio]\n"
     content += f"description = ESPHome {__version__}\n"
 
@@ -290,6 +293,10 @@ def copy_src_tree():
     write_file_if_changed(
         CORE.relative_src_path("esphome", "core", "version.h"), generate_version_h()
     )
+
+    dir = os.path.dirname(__file__)
+    use_ccache_file = os.path.join(dir, "use_ccache.py.script")
+    copy_file_if_changed(use_ccache_file, CORE.relative_build_path("use_ccache.py"))
 
     if CORE.is_esp32:
         from esphome.components.esp32 import copy_files


### PR DESCRIPTION
# What does this implement/fix?

This PR adds support for ccache, which speeds up compilation to detect if the same code is being compiled.

My local testing showed a ~65% cache hit rate on the first build of a random mix of ESP8266 and ESP32 devices, actual wall clock time improvement depends a lot on available CPU and how much time is spend linking/uploading/flashing the final images.

Right now, the compiler cache is stored in its default location which is `$USER/.ccache` so it is cleared whenever the Docker container is recreated or replaced.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes esphome/feature-requests#975

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

No changes necessary, this is completely transparent to the end user.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
