### PR TITLE
Await cg.get_variable in Update component

### DIFF
--- a/esphome/components/update/__init__.py
+++ b/esphome/components/update/__init__.py
@@ -69,7 +69,7 @@ async def setup_update_core_(var, config):
         await mqtt.register_mqtt_component(mqtt_, config)
 
     if web_server_id_config := config.get(CONF_WEB_SERVER_ID):
-        web_server_ = cg.get_variable(web_server_id_config)
+        web_server_ = await cg.get_variable(web_server_id_config)
         web_server.add_entity_to_sorting_list(web_server_, var, config)
 
 


### PR DESCRIPTION
Fix compile error.

# What does this implement/fix?

Update can't be used with web_server right now or I can't get it to.  This change allows a compile.


Error:

```
INFO ESPHome 2024.6.1
INFO Reading configuration kauf-bulb-update.yaml...
INFO Updating https://github.com/KaufHA/kauf-rgbww-bulbs@None
INFO Generating C++ source...
Traceback (most recent call last):
  File "/home/bkaufx/.local/bin/esphome", line 8, in <module>
    sys.exit(main())
  File "/home/bkaufx/.local/lib/python3.10/site-packages/esphome/__main__.py", line 1079, in main
    return run_esphome(sys.argv)
  File "/home/bkaufx/.local/lib/python3.10/site-packages/esphome/__main__.py", line 1066, in run_esphome
    rc = POST_CONFIG_ACTIONS[args.command](args, config)
  File "/home/bkaufx/.local/lib/python3.10/site-packages/esphome/__main__.py", line 433, in command_compile
    exit_code = write_cpp(config)
  File "/home/bkaufx/.local/lib/python3.10/site-packages/esphome/__main__.py", line 193, in write_cpp
    generate_cpp_contents(config)
  File "/home/bkaufx/.local/lib/python3.10/site-packages/esphome/__main__.py", line 205, in generate_cpp_contents
    CORE.flush_tasks()
  File "/home/bkaufx/.local/lib/python3.10/site-packages/esphome/core/__init__.py", line 681, in flush_tasks
    self.event_loop.flush_tasks()
  File "/home/bkaufx/.local/lib/python3.10/site-packages/esphome/coroutine.py", line 246, in flush_tasks
    next(task.iterator)
  File "/home/bkaufx/.local/lib/python3.10/site-packages/esphome/__main__.py", line 185, in wrapped
    await coro(conf)
  File "/home/bkaufx/.local/lib/python3.10/site-packages/esphome/components/http_request/update/__init__.py", line 34, in to_code
    var = await update.new_update(config)
  File "/home/bkaufx/.local/lib/python3.10/site-packages/esphome/components/update/__init__.py", line 80, in new_update
    await register_update(var, config)
  File "/home/bkaufx/.local/lib/python3.10/site-packages/esphome/components/update/__init__.py", line 75, in register_update
    await setup_update_core_(var, config)
  File "/home/bkaufx/.local/lib/python3.10/site-packages/esphome/components/update/__init__.py", line 68, in setup_update_core_
    web_server.add_entity_to_sorting_list(web_server_, var, config)
  File "/home/bkaufx/kaufha-github/kauf-rgbww-bulbs/config/.esphome/external_components/060cee99/components/web_server/__init__.py", line 164, in add_entity_to_sorting_list
    web_server.add_entity_to_sorting_list(
AttributeError: 'coroutine' object has no attribute 'add_entity_to_sorting_list'
sys:1: RuntimeWarning: coroutine 'get_variable' was never awaited
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
# the following will error out without this PR and compile fine with it.


esphome:
  name: test
  friendly_name: test

esp32:
  board: esp32dev
  framework:
    type: arduino

ota:
  - platform: http_request
  - platform: esphome


wifi:
  ssid: !secret wifi_ssid
  password: !secret wifi_password

update:
  - platform: http_request
    name: Firmware Update
    source: http://example.com/manifest.json

http_request:
  verify_ssl: false

web_server:


```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
