### PR TITLE
[modbus_text_sensor] new default ANSI encoding type

### DIFF
--- a/esphome/components/modbus_controller/text_sensor/__init__.py
+++ b/esphome/components/modbus_controller/text_sensor/__init__.py
@@ -37,6 +37,7 @@ RAW_ENCODING = {
     "NONE": RawEncoding.NONE,
     "HEXBYTES": RawEncoding.HEXBYTES,
     "COMMA": RawEncoding.COMMA,
+    "ASCII": RawEncoding.ASCII,
 }
 
 CONFIG_SCHEMA = cv.All(
@@ -49,7 +50,7 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_REGISTER_TYPE): cv.enum(MODBUS_REGISTER_TYPE),
             cv.Optional(CONF_REGISTER_COUNT, default=0): cv.positive_int,
             cv.Optional(CONF_RESPONSE_SIZE, default=2): cv.positive_int,
-            cv.Optional(CONF_RAW_ENCODE, default="NONE"): cv.enum(RAW_ENCODING),
+            cv.Optional(CONF_RAW_ENCODE, default="ASCII"): cv.enum(RAW_ENCODING),
         }
     ),
     validate_modbus_register,

--- a/esphome/components/modbus_controller/text_sensor/__init__.py
+++ b/esphome/components/modbus_controller/text_sensor/__init__.py
@@ -37,7 +37,7 @@ RAW_ENCODING = {
     "NONE": RawEncoding.NONE,
     "HEXBYTES": RawEncoding.HEXBYTES,
     "COMMA": RawEncoding.COMMA,
-    "ASCII": RawEncoding.ASCII,
+    "ANSI": RawEncoding.ANSI,
 }
 
 CONFIG_SCHEMA = cv.All(
@@ -50,7 +50,7 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_REGISTER_TYPE): cv.enum(MODBUS_REGISTER_TYPE),
             cv.Optional(CONF_REGISTER_COUNT, default=0): cv.positive_int,
             cv.Optional(CONF_RESPONSE_SIZE, default=2): cv.positive_int,
-            cv.Optional(CONF_RAW_ENCODE, default="ASCII"): cv.enum(RAW_ENCODING),
+            cv.Optional(CONF_RAW_ENCODE, default="ANSI"): cv.enum(RAW_ENCODING),
         }
     ),
     validate_modbus_register,

--- a/esphome/components/modbus_controller/text_sensor/modbus_textsensor.cpp
+++ b/esphome/components/modbus_controller/text_sensor/modbus_textsensor.cpp
@@ -28,7 +28,7 @@ void ModbusTextSensor::parse_and_publish(const std::vector<uint8_t> &data) {
         output << buffer;
         break;
       case RawEncoding::ASCII:
-        if (b == 0)
+        if (b < 0x20 || b > 0x7E)
           break;
       // FALLTHROUGH
       // Anything else no encoding

--- a/esphome/components/modbus_controller/text_sensor/modbus_textsensor.cpp
+++ b/esphome/components/modbus_controller/text_sensor/modbus_textsensor.cpp
@@ -32,7 +32,6 @@ void ModbusTextSensor::parse_and_publish(const std::vector<uint8_t> &data) {
           break;
       // FALLTHROUGH
       // Anything else no encoding
-      case RawEncoding::NONE:
       default:
         output << (char) b;
         break;

--- a/esphome/components/modbus_controller/text_sensor/modbus_textsensor.cpp
+++ b/esphome/components/modbus_controller/text_sensor/modbus_textsensor.cpp
@@ -27,11 +27,14 @@ void ModbusTextSensor::parse_and_publish(const std::vector<uint8_t> &data) {
         sprintf(buffer, index != this->offset ? ",%d" : "%d", b);
         output << buffer;
         break;
+      case RawEncoding::ASCII:
+        if (b == 0)
+          break;
+      // FALLTHROUGH
       // Anything else no encoding
       case RawEncoding::NONE:
       default:
-        if (b != 0)
-          output << (char) b;
+        output << (char) b;
         break;
     }
     items_left--;

--- a/esphome/components/modbus_controller/text_sensor/modbus_textsensor.cpp
+++ b/esphome/components/modbus_controller/text_sensor/modbus_textsensor.cpp
@@ -27,8 +27,8 @@ void ModbusTextSensor::parse_and_publish(const std::vector<uint8_t> &data) {
         sprintf(buffer, index != this->offset ? ",%d" : "%d", b);
         output << buffer;
         break;
-      case RawEncoding::ASCII:
-        if (b < 0x20 || b > 0x7E)
+      case RawEncoding::ANSI:
+        if (b < 0x20)
           break;
       // FALLTHROUGH
       // Anything else no encoding

--- a/esphome/components/modbus_controller/text_sensor/modbus_textsensor.cpp
+++ b/esphome/components/modbus_controller/text_sensor/modbus_textsensor.cpp
@@ -30,7 +30,8 @@ void ModbusTextSensor::parse_and_publish(const std::vector<uint8_t> &data) {
       // Anything else no encoding
       case RawEncoding::NONE:
       default:
-        output << (char) b;
+        if (b != 0)
+          output << (char) b;
         break;
     }
     items_left--;

--- a/esphome/components/modbus_controller/text_sensor/modbus_textsensor.h
+++ b/esphome/components/modbus_controller/text_sensor/modbus_textsensor.h
@@ -9,7 +9,7 @@
 namespace esphome {
 namespace modbus_controller {
 
-enum class RawEncoding { NONE = 0, HEXBYTES = 1, COMMA = 2 };
+enum class RawEncoding { NONE = 0, HEXBYTES = 1, COMMA = 2, ASCII = 3 };
 
 class ModbusTextSensor : public Component, public text_sensor::TextSensor, public SensorItem {
  public:

--- a/esphome/components/modbus_controller/text_sensor/modbus_textsensor.h
+++ b/esphome/components/modbus_controller/text_sensor/modbus_textsensor.h
@@ -9,7 +9,7 @@
 namespace esphome {
 namespace modbus_controller {
 
-enum class RawEncoding { NONE = 0, HEXBYTES = 1, COMMA = 2, ASCII = 3 };
+enum class RawEncoding { NONE = 0, HEXBYTES = 1, COMMA = 2, ANSI = 3 };
 
 class ModbusTextSensor : public Component, public text_sensor::TextSensor, public SensorItem {
  public:


### PR DESCRIPTION
# What does this implement/fix?

New default `ANSI` encoding.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#3994

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
