### PR TITLE
[one-wire] fix potential hang

### DIFF
--- a/esphome/components/gpio/one_wire/gpio_one_wire.cpp
+++ b/esphome/components/gpio/one_wire/gpio_one_wire.cpp
@@ -94,13 +94,15 @@ bool HOT IRAM_ATTR GPIOOneWireBus::read_bit_() {
 
   // measure from start value directly, to get best accurate timing no matter
   // how long pin_mode/delayMicroseconds took
-  delayMicroseconds(12 - (micros() - start));
+  uint32_t now = micros();
+  if (now - start < 12)
+    delayMicroseconds(12 - (now - start));
 
   // sample bus to read bit from peer
   bool r = pin_.digital_read();
 
   // read slot is at least 60µs; get as close to 60µs to spend less time with interrupts locked
-  uint32_t now = micros();
+  now = micros();
   if (now - start < 60)
     delayMicroseconds(60 - (now - start));
 


### PR DESCRIPTION
# What does this implement/fix?

If the CPU has to do a code read from flash at the wrong point, then the delay will overflow to a negative value.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/5947  fixes https://github.com/esphome/issues/issues/5939

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
