### PR TITLE
[midea] fix fan speed compatibility with some models

### DIFF
--- a/esphome/components/midea/climate.py
+++ b/esphome/components/midea/climate.py
@@ -293,4 +293,4 @@ async def to_code(config):
     if CONF_HUMIDITY_SETPOINT in config:
         sens = await sensor.new_sensor(config[CONF_HUMIDITY_SETPOINT])
         cg.add(var.set_humidity_setpoint_sensor(sens))
-    cg.add_library("dudanov/MideaUART", "1.1.8")
+    cg.add_library("dudanov/MideaUART", "1.1.9")

--- a/platformio.ini
+++ b/platformio.ini
@@ -64,7 +64,7 @@ lib_deps =
     freekode/TM1651@1.0.1                                 ; tm1651
     glmnet/Dsmr@0.7                                       ; dsmr
     rweather/Crypto@0.4.0                                 ; dsmr
-    dudanov/MideaUART@1.1.8                               ; midea
+    dudanov/MideaUART@1.1.9                               ; midea
     tonia/HeatpumpIR@1.0.23                               ; heatpumpir
 build_flags =
     ${common.build_flags}


### PR DESCRIPTION
# What does this implement/fix?

Fix compatibility with some AC models.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
