### PR TITLE
Do not build mDNS when mDNS is disabled via yaml

### DIFF
--- a/esphome/components/mdns/__init__.py
+++ b/esphome/components/mdns/__init__.py
@@ -74,6 +74,9 @@ def mdns_service(
 
 @coroutine_with_priority(55.0)
 async def to_code(config):
+    if config[CONF_DISABLED] is True:
+        return
+
     if CORE.using_arduino:
         if CORE.is_esp32:
             cg.add_library("ESPmDNS", None)
@@ -91,9 +94,6 @@ async def to_code(config):
             ref="mdns-v1.2.5",
             path="components/mdns",
         )
-
-    if config[CONF_DISABLED]:
-        return
 
     cg.add_define("USE_MDNS")
 

--- a/esphome/components/mdns/mdns_component.cpp
+++ b/esphome/components/mdns/mdns_component.cpp
@@ -1,5 +1,6 @@
-#include "mdns_component.h"
 #include "esphome/core/defines.h"
+#ifdef USE_MDNS
+#include "mdns_component.h"
 #include "esphome/core/version.h"
 #include "esphome/core/application.h"
 #include "esphome/core/log.h"
@@ -125,3 +126,4 @@ void MDNSComponent::dump_config() {
 
 }  // namespace mdns
 }  // namespace esphome
+#endif

--- a/esphome/components/mdns/mdns_component.h
+++ b/esphome/components/mdns/mdns_component.h
@@ -1,5 +1,6 @@
 #pragma once
-
+#include "esphome/core/defines.h"
+#ifdef USE_MDNS
 #include <string>
 #include <vector>
 #include "esphome/core/component.h"
@@ -46,3 +47,4 @@ class MDNSComponent : public Component {
 
 }  // namespace mdns
 }  // namespace esphome
+#endif

--- a/esphome/components/mdns/mdns_esp32.cpp
+++ b/esphome/components/mdns/mdns_esp32.cpp
@@ -1,4 +1,5 @@
-#ifdef USE_ESP32
+#include "esphome/core/defines.h"
+#if defined(USE_ESP32) && defined(USE_MDNS)
 
 #include <mdns.h>
 #include <cstring>

--- a/esphome/components/mdns/mdns_esp8266.cpp
+++ b/esphome/components/mdns/mdns_esp8266.cpp
@@ -1,4 +1,5 @@
-#if defined(USE_ESP8266) && defined(USE_ARDUINO)
+#include "esphome/core/defines.h"
+#if defined(USE_ESP8266) && defined(USE_ARDUINO) && defined(USE_MDNS)
 
 #include <ESP8266mDNS.h>
 #include "esphome/components/network/ip_address.h"

--- a/esphome/components/mdns/mdns_host.cpp
+++ b/esphome/components/mdns/mdns_host.cpp
@@ -1,4 +1,5 @@
-#ifdef USE_HOST
+#include "esphome/core/defines.h"
+#if defined(USE_HOST) && defined(USE_MDNS)
 
 #include "esphome/components/network/ip_address.h"
 #include "esphome/components/network/util.h"

--- a/esphome/components/mdns/mdns_libretiny.cpp
+++ b/esphome/components/mdns/mdns_libretiny.cpp
@@ -1,4 +1,5 @@
-#ifdef USE_LIBRETINY
+#include "esphome/core/defines.h"
+#if defined(USE_LIBRETINY) && defined(USE_MDNS)
 
 #include "esphome/components/network/ip_address.h"
 #include "esphome/components/network/util.h"

--- a/esphome/components/mdns/mdns_rp2040.cpp
+++ b/esphome/components/mdns/mdns_rp2040.cpp
@@ -1,4 +1,5 @@
-#ifdef USE_RP2040
+#include "esphome/core/defines.h"
+#if defined(USE_RP2040) && defined(USE_MDNS)
 
 #include "esphome/components/network/ip_address.h"
 #include "esphome/components/network/util.h"


### PR DESCRIPTION
# What does this implement/fix?

Change mDNS build to not build or download component/library when mDNS is disabled via yaml.
This change speeds up the build and saves bandwidth.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

mdns:
  disabled: true
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
