### PR TITLE
[external_files] Move common ``download_content`` function to ``external_files.py``

### DIFF
--- a/esphome/components/font/__init__.py
+++ b/esphome/components/font/__init__.py
@@ -17,7 +17,6 @@ from esphome.helpers import (
     cpp_string_escape,
 )
 from esphome.const import (
-    __version__,
     CONF_FAMILY,
     CONF_FILE,
     CONF_GLYPHS,
@@ -185,31 +184,6 @@ def get_font_path(value, type) -> Path:
     return None
 
 
-def download_content(url: str, path: Path) -> None:
-    if not external_files.has_remote_file_changed(url, path):
-        _LOGGER.debug("Remote file has not changed %s", url)
-        return
-
-    _LOGGER.debug(
-        "Remote file has changed, downloading from %s to %s",
-        url,
-        path,
-    )
-
-    try:
-        req = requests.get(
-            url,
-            timeout=external_files.NETWORK_TIMEOUT,
-            headers={"User-agent": f"ESPHome/{__version__} (https://esphome.io)"},
-        )
-        req.raise_for_status()
-    except requests.exceptions.RequestException as e:
-        raise cv.Invalid(f"Could not download from {url}: {e}")
-
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_bytes(req.content)
-
-
 def download_gfont(value):
     name = (
         f"{value[CONF_FAMILY]}:ital,wght@{int(value[CONF_ITALIC])},{value[CONF_WEIGHT]}"
@@ -236,7 +210,7 @@ def download_gfont(value):
     ttf_url = match.group(1)
     _LOGGER.debug("download_gfont: ttf_url=%s", ttf_url)
 
-    download_content(ttf_url, path)
+    external_files.download_content(ttf_url, path)
     return value
 
 
@@ -244,7 +218,7 @@ def download_web_font(value):
     url = value[CONF_URL]
     path = get_font_path(value, TYPE_WEB)
 
-    download_content(url, path)
+    external_files.download_content(url, path)
     _LOGGER.debug("download_web_font: path=%s", path)
     return value
 

--- a/esphome/external_files.py
+++ b/esphome/external_files.py
@@ -7,6 +7,7 @@ from datetime import datetime
 import requests
 import esphome.config_validation as cv
 from esphome.core import CORE, TimePeriodSeconds
+from esphome.const import __version__
 
 _LOGGER = logging.getLogger(__name__)
 CODEOWNERS = ["@landonr"]
@@ -75,3 +76,28 @@ def compute_local_file_dir(domain: str) -> Path:
     base_directory.mkdir(parents=True, exist_ok=True)
 
     return base_directory
+
+
+def download_content(url: str, path: Path, timeout=NETWORK_TIMEOUT) -> None:
+    if not has_remote_file_changed(url, path):
+        _LOGGER.debug("Remote file has not changed %s", url)
+        return
+
+    _LOGGER.debug(
+        "Remote file has changed, downloading from %s to %s",
+        url,
+        path,
+    )
+
+    try:
+        req = requests.get(
+            url,
+            timeout=timeout,
+            headers={"User-agent": f"ESPHome/{__version__} (https://esphome.io)"},
+        )
+        req.raise_for_status()
+    except requests.exceptions.RequestException as e:
+        raise cv.Invalid(f"Could not download from {url}: {e}")
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(req.content)


### PR DESCRIPTION
# What does this implement/fix?

This just moves the function so as it was the same content twice. The timeout is the 3rd argument now.

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
