### PR TITLE
[ds1307] Initialize uninitialized struct members

### DIFF
--- a/esphome/components/ds1307/ds1307.cpp
+++ b/esphome/components/ds1307/ds1307.cpp
@@ -44,7 +44,10 @@ void DS1307Component::read_time() {
                    .day_of_month = uint8_t(ds1307_.reg.day + 10u * ds1307_.reg.day_10),
                    .day_of_year = 1,  // ignored by recalc_timestamp_utc(false)
                    .month = uint8_t(ds1307_.reg.month + 10u * ds1307_.reg.month_10),
-                   .year = uint16_t(ds1307_.reg.year + 10u * ds1307_.reg.year_10 + 2000)};
+                   .year = uint16_t(ds1307_.reg.year + 10u * ds1307_.reg.year_10 + 2000),
+                   .is_dst = false,  // not used
+                   .timestamp = 0  // overwritten by recalc_timestamp_utc(false)
+  };
   rtc_time.recalc_timestamp_utc(false);
   if (!rtc_time.is_valid()) {
     ESP_LOGE(TAG, "Invalid RTC time, not syncing to system clock.");

--- a/esphome/components/ds1307/ds1307.cpp
+++ b/esphome/components/ds1307/ds1307.cpp
@@ -37,16 +37,17 @@ void DS1307Component::read_time() {
     ESP_LOGW(TAG, "RTC halted, not syncing to system clock.");
     return;
   }
-  ESPTime rtc_time{.second = uint8_t(ds1307_.reg.second + 10 * ds1307_.reg.second_10),
-                   .minute = uint8_t(ds1307_.reg.minute + 10u * ds1307_.reg.minute_10),
-                   .hour = uint8_t(ds1307_.reg.hour + 10u * ds1307_.reg.hour_10),
-                   .day_of_week = uint8_t(ds1307_.reg.weekday),
-                   .day_of_month = uint8_t(ds1307_.reg.day + 10u * ds1307_.reg.day_10),
-                   .day_of_year = 1,  // ignored by recalc_timestamp_utc(false)
-                   .month = uint8_t(ds1307_.reg.month + 10u * ds1307_.reg.month_10),
-                   .year = uint16_t(ds1307_.reg.year + 10u * ds1307_.reg.year_10 + 2000),
-                   .is_dst = false,  // not used
-                   .timestamp = 0  // overwritten by recalc_timestamp_utc(false)
+  ESPTime rtc_time{
+      .second = uint8_t(ds1307_.reg.second + 10 * ds1307_.reg.second_10),
+      .minute = uint8_t(ds1307_.reg.minute + 10u * ds1307_.reg.minute_10),
+      .hour = uint8_t(ds1307_.reg.hour + 10u * ds1307_.reg.hour_10),
+      .day_of_week = uint8_t(ds1307_.reg.weekday),
+      .day_of_month = uint8_t(ds1307_.reg.day + 10u * ds1307_.reg.day_10),
+      .day_of_year = 1,  // ignored by recalc_timestamp_utc(false)
+      .month = uint8_t(ds1307_.reg.month + 10u * ds1307_.reg.month_10),
+      .year = uint16_t(ds1307_.reg.year + 10u * ds1307_.reg.year_10 + 2000),
+      .is_dst = false,  // not used
+      .timestamp = 0    // overwritten by recalc_timestamp_utc(false)
   };
   rtc_time.recalc_timestamp_utc(false);
   if (!rtc_time.is_valid()) {


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

```console
src/esphome/components/ds1307/ds1307.cpp: In member function 'void esphome::ds1307::DS1307Component::read_time()':
src/esphome/components/ds1307/ds1307.cpp:47:89: warning: missing initializer for member 'esphome::ESPTime::is_dst' [-Wmissing-field-initializers]
                    .year = uint16_t(ds1307_.reg.year + 10u * ds1307_.reg.year_10 + 2000)};
                                                                                         ^
src/esphome/components/ds1307/ds1307.cpp:47:89: warning: missing initializer for member 'esphome::ESPTime::timestamp' [-Wmissing-field-initializers]
```

Followed the same initialization pattern for `ESPTime` as used in other instances.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Add to common.yaml time configuration
# https://esphome.io/components/time
time:

  # DS3231 is compatible with DS1307 RTC
  # https://esphome.io/components/time/ds1307
  - platform: ds1307
    id: ds1307_time
    address: 0x68
    # Use HA for time sync
    update_interval: never

  # https://esphome.io/components/time/homeassistant
  - platform: homeassistant
    # Update RTC on time sync
    on_time_sync:
      then:
        ds1307.write_time:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
