### PR TITLE
Allow wireguard to bind to PPP interface

### DIFF
--- a/esphome/components/wireguard/__init__.py
+++ b/esphome/components/wireguard/__init__.py
@@ -132,7 +132,7 @@ async def to_code(config):
     # the '+1' modifier is relative to the device's own address that will
     # be automatically added to the provided list.
     cg.add_build_flag(f"-DCONFIG_WIREGUARD_MAX_SRC_IPS={len(allowed_ips) + 1}")
-    cg.add_library("droscy/esp_wireguard", "0.4.1")
+    cg.add_library("droscy/esp_wireguard", "0.4.2")
 
     await cg.register_component(var, config)
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -94,7 +94,7 @@ lib_deps =
     ESP8266mDNS                           ; mdns (Arduino built-in)
     DNSServer                             ; captive_portal (Arduino built-in)
     crankyoldgit/IRremoteESP8266@2.8.6    ; heatpumpir
-    droscy/esp_wireguard@0.4.1            ; wireguard
+    droscy/esp_wireguard@0.4.2            ; wireguard
 build_flags =
     ${common:arduino.build_flags}
     -Wno-nonnull-compare
@@ -124,7 +124,7 @@ lib_deps =
     DNSServer                            ; captive_portal (Arduino built-in)
     esphome/ESP32-audioI2S@2.0.7         ; i2s_audio
     crankyoldgit/IRremoteESP8266@2.8.6   ; heatpumpir
-    droscy/esp_wireguard@0.4.1           ; wireguard
+    droscy/esp_wireguard@0.4.2          ; wireguard
 build_flags =
     ${common:arduino.build_flags}
     -DUSE_ESP32
@@ -142,7 +142,7 @@ platform_packages =
 framework = espidf
 lib_deps =
     ${common:idf.lib_deps}
-    droscy/esp_wireguard@0.4.1    ; wireguard
+    droscy/esp_wireguard@0.4.2    ; wireguard
 build_flags =
     ${common:idf.build_flags}
     -Wno-nonnull-compare
@@ -174,7 +174,7 @@ extends = common:arduino
 platform = libretiny
 framework = arduino
 lib_deps =
-    droscy/esp_wireguard@0.4.1    ; wireguard
+    droscy/esp_wireguard@0.4.2    ; wireguard
 build_flags =
     ${common:arduino.build_flags}
     -DUSE_LIBRETINY


### PR DESCRIPTION
# What does this implement/fix?

Bump `esp_wireguard` library to version 0.4.2 which adds support for PPP interface.

These are the changes since version currently in use by esphome https://github.com/droscy/esp_wireguard/compare/v0.4.1...v0.4.2

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** none

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** not needed

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [x] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
Same as usual.

## Checklist:
  - [x] The code change is tested and works locally -> I have done only no-regression-tests with wifi connection
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
