### PR TITLE
[CI] Update tests to run against IDF 5.1

### DIFF
--- a/tests/test_build_components/build_components_base.esp32-c3-idf-51.yaml
+++ b/tests/test_build_components/build_components_base.esp32-c3-idf-51.yaml
@@ -1,14 +1,13 @@
 esphome:
-  name: componenttestesp32s2idf50
+  name: componenttestesp32c3idf51
   friendly_name: $component_name
 
 esp32:
-  board: esp32-s2-saola-1
-  variant: ESP32S2
+  board: lolin_c3_mini
   framework:
     type: esp-idf
-    version: 5.0.2
-    platform_version: 6.3.2
+    version: 5.1.2
+    platform_version: 6.6.0
 
 logger:
   level: VERY_VERBOSE

--- a/tests/test_build_components/build_components_base.esp32-idf-51.yaml
+++ b/tests/test_build_components/build_components_base.esp32-idf-51.yaml
@@ -1,13 +1,13 @@
 esphome:
-  name: componenttestesp32c3idf50
+  name: componenttestesp32idf51
   friendly_name: $component_name
 
 esp32:
-  board: lolin_c3_mini
+  board: nodemcu-32s
   framework:
     type: esp-idf
-    version: 5.0.2
-    platform_version: 6.3.2
+    version: 5.1.2
+    platform_version: 6.6.0
 
 logger:
   level: VERY_VERBOSE

--- a/tests/test_build_components/build_components_base.esp32-s2-idf-51.yaml
+++ b/tests/test_build_components/build_components_base.esp32-s2-idf-51.yaml
@@ -1,14 +1,14 @@
 esphome:
-  name: componenttestesp32s3idf50
+  name: componenttestesp32s2idf51
   friendly_name: $component_name
 
 esp32:
-  board: esp32s3box
-  variant: ESP32S3
+  board: esp32-s2-saola-1
+  variant: ESP32S2
   framework:
     type: esp-idf
-    version: 5.0.2
-    platform_version: 6.3.2
+    version: 5.1.2
+    platform_version: 6.6.0
 
 logger:
   level: VERY_VERBOSE

--- a/tests/test_build_components/build_components_base.esp32-s3-idf-51.yaml
+++ b/tests/test_build_components/build_components_base.esp32-s3-idf-51.yaml
@@ -1,13 +1,14 @@
 esphome:
-  name: componenttestesp32idf50
+  name: componenttestesp32s3idf51
   friendly_name: $component_name
 
 esp32:
-  board: nodemcu-32s
+  board: esp32s3box
+  variant: ESP32S3
   framework:
     type: esp-idf
-    version: 5.0.2
-    platform_version: 6.3.2
+    version: 5.1.2
+    platform_version: 6.6.0
 
 logger:
   level: VERY_VERBOSE


### PR DESCRIPTION
# What does this implement/fix?

Arduino 3.0+ appears to be using IDF 5.1; to be consistent, let's see how we handle IDF 5.1, as well...

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
