### PR TITLE
[modbus-text-sensor] fix potential buffer overflow

### DIFF
--- a/esphome/components/modbus_controller/text_sensor/modbus_textsensor.cpp
+++ b/esphome/components/modbus_controller/text_sensor/modbus_textsensor.cpp
@@ -15,7 +15,7 @@ void ModbusTextSensor::parse_and_publish(const std::vector<uint8_t> &data) {
   std::ostringstream output;
   uint8_t items_left = this->response_bytes;
   uint8_t index = this->offset;
-  char buffer[4];
+  char buffer[5];
   while ((items_left > 0) && index < data.size()) {
     uint8_t b = data[index];
     switch (this->encode_) {


### PR DESCRIPTION
# What does this implement/fix?

In [this code](https://github.com/esphome/esphome/blob/91766afb64e804db97cc03f8ba6174e13968f742/esphome/components/modbus_controller/text_sensor/modbus_textsensor.cpp#L27) `sprintf` function needs 5 bytes buffer (including null) in case `byte >= 100` with comma `",%d"`. But buffer is 4 bytes long.

https://github.com/esphome/esphome/blob/91766afb64e804db97cc03f8ba6174e13968f742/esphome/components/modbus_controller/text_sensor/modbus_textsensor.cpp#L27

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
