### PR TITLE
Fix LEDC 100% is not 100% duty with ESP32 IDF

### DIFF
--- a/esphome/components/ledc/ledc_output.cpp
+++ b/esphome/components/ledc/ledc_output.cpp
@@ -115,12 +115,15 @@ void LEDCOutput::write_state(float state) {
   const uint32_t max_duty = (uint32_t(1) << this->bit_depth_) - 1;
   const float duty_rounded = roundf(state * max_duty);
   auto duty = static_cast<uint32_t>(duty_rounded);
-
 #ifdef USE_ARDUINO
   ESP_LOGV(TAG, "Setting duty: %u on channel %u", duty, this->channel_);
   ledcWrite(this->channel_, duty);
 #endif
 #ifdef USE_ESP_IDF
+  // ensure that 100% on is not 99.975% on
+  if ((duty == max_duty) && (max_duty != 1)) {
+    duty = max_duty + 1;
+  }
   auto speed_mode = get_speed_mode(channel_);
   auto chan_num = static_cast<ledc_channel_t>(channel_ % 8);
   int hpoint = ledc_angle_to_htop(this->phase_angle_, this->bit_depth_);


### PR DESCRIPTION
# What does this implement/fix?

The duty of the LED output is not 100% when light is set to 100% with ESP32 IDF.
This is especially noticeable when the pin is used inverted since then the LEDs will always "glim" when the requested to be 0% / off

the fix is a copy of the fix that ESP32 Arduino is using when calling the ledc:
https://github.com/espressif/arduino-esp32/blob/4a6437d3ea032abbe37940b7c0c5586f9c09949a/cores/esp32/esp32-hal-ledc.c#L141-L143
as a result the fix is only needed when using IDF directly.

the docs show the need of the "+1" too:
https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-reference/peripherals/ledc.html#_CPPv425ledc_set_duty_with_hpoint11ledc_mode_t14ledc_channel_t8uint32_t8uint32_t

```
duty -- Set the LEDC duty, the range of duty setting is [0, (2**duty_resolution)]
```


## current dev branch 
### 100%
![image](https://github.com/esphome/esphome/assets/974709/4025ff8f-4b2e-4088-b249-d9c5ef93d96a)

## after fix
### 100%
![image](https://github.com/esphome/esphome/assets/974709/04995786-840d-434e-bedf-635517ba53f4)

### 0%
![image](https://github.com/esphome/esphome/assets/974709/712b96e3-475b-476c-9e42-fac938e26d00)


## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
  - platform: ledc
    pin:
      number: 7
    frequency: 19531Hz
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
