### PR TITLE
[ota-esphome] Merge configurations by port

### DIFF
--- a/esphome/components/esphome/ota/__init__.py
+++ b/esphome/components/esphome/ota/__init__.py
@@ -43,6 +43,29 @@ def ota_esphome_final_validate(config):
             ) not in merged_ota_esphome_configs_by_port:
                 merged_ota_esphome_configs_by_port[conf_port] = ota_conf
             else:
+                if merged_ota_esphome_configs_by_port[conf_port][
+                    CONF_VERSION
+                ] != ota_conf.get(CONF_VERSION):
+                    raise cv.Invalid(
+                        f"Found multiple configurations but {CONF_VERSION} is inconsistent"
+                    )
+                if (
+                    merged_ota_esphome_configs_by_port[conf_port][CONF_ID].is_manual
+                    and ota_conf.get(CONF_ID).is_manual
+                ):
+                    raise cv.Invalid(
+                        f"Found multiple configurations but {CONF_ID} is inconsistent"
+                    )
+                if (
+                    CONF_PASSWORD in merged_ota_esphome_configs_by_port[conf_port]
+                    and CONF_PASSWORD in ota_conf
+                    and merged_ota_esphome_configs_by_port[conf_port][CONF_PASSWORD]
+                    != ota_conf.get(CONF_PASSWORD)
+                ):
+                    raise cv.Invalid(
+                        f"Found multiple configurations but {CONF_PASSWORD} is inconsistent"
+                    )
+
                 ports_with_merged_configs.append(conf_port)
                 merged_ota_esphome_configs_by_port[conf_port] = merge_config(
                     merged_ota_esphome_configs_by_port[conf_port], ota_conf

--- a/esphome/components/esphome/ota/__init__.py
+++ b/esphome/components/esphome/ota/__init__.py
@@ -1,7 +1,10 @@
+import logging
+
 import esphome.codegen as cg
 import esphome.config_validation as cv
 import esphome.final_validate as fv
 from esphome.components.ota import BASE_OTA_SCHEMA, ota_to_code, OTAComponent
+from esphome.config_helpers import merge_config
 from esphome.const import (
     CONF_ESPHOME,
     CONF_ID,
@@ -16,6 +19,8 @@ from esphome.const import (
 )
 from esphome.core import coroutine_with_priority
 
+_LOGGER = logging.getLogger(__name__)
+
 
 CODEOWNERS = ["@esphome/core"]
 AUTO_LOAD = ["md5", "socket"]
@@ -26,16 +31,39 @@ ESPHomeOTAComponent = esphome.class_("ESPHomeOTAComponent", OTAComponent)
 
 
 def ota_esphome_final_validate(config):
-    fconf = fv.full_config.get()[CONF_OTA]
-    used_ports = []
-    for ota_conf in fconf:
+    full_conf = fv.full_config.get()
+    full_ota_conf = full_conf[CONF_OTA]
+    new_ota_conf = []
+    merged_ota_esphome_configs_by_port = {}
+    ports_with_merged_configs = []
+    for ota_conf in full_ota_conf:
         if ota_conf.get(CONF_PLATFORM) == CONF_ESPHOME:
-            if (plat_port := ota_conf.get(CONF_PORT)) not in used_ports:
-                used_ports.append(plat_port)
+            if (
+                conf_port := ota_conf.get(CONF_PORT)
+            ) not in merged_ota_esphome_configs_by_port:
+                merged_ota_esphome_configs_by_port[conf_port] = ota_conf
             else:
-                raise cv.Invalid(
-                    f"Only one instance of the {CONF_ESPHOME} {CONF_OTA} {CONF_PLATFORM} is allowed per port. Note that this error may result from OTA specified in packages"
+                ports_with_merged_configs.append(conf_port)
+                merged_ota_esphome_configs_by_port[conf_port] = merge_config(
+                    merged_ota_esphome_configs_by_port[conf_port], ota_conf
                 )
+        else:
+            new_ota_conf.append(ota_conf)
+
+    for port_conf in merged_ota_esphome_configs_by_port.values():
+        new_ota_conf.append(port_conf)
+
+    full_conf[CONF_OTA] = new_ota_conf
+    fv.full_config.set(full_conf)
+
+    if len(ports_with_merged_configs) > 0:
+        _LOGGER.warning(
+            "Found and merged multiple configurations for %s %s %s port(s) %s",
+            CONF_OTA,
+            CONF_PLATFORM,
+            CONF_ESPHOME,
+            ports_with_merged_configs,
+        )
 
 
 CONFIG_SCHEMA = (


### PR DESCRIPTION
# What does this implement/fix?

Recent changes to the `ota` component result in different behavior when `ota` appears multiple times in the final configuration. In particular, this prevents modification by the user to an `ota` configuration that already exists in a package they consume.

This PR will restore the original/expected behavior where multiple `ota` configurations are merged; however, it only does so where multiple `esphome` `ota` platforms are specified and each is using the same port, same version, and if specified in both, same password.

It also prints a warning when merging is done to alert the user that this action is being taken.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
