### PR TITLE
[qspi_amoled] Improve drawing performance

### DIFF
--- a/esphome/components/display/display.h
+++ b/esphome/components/display/display.h
@@ -266,17 +266,17 @@ class Display : public PollingComponent {
   void line_at_angle(int x, int y, int angle, int start_radius, int stop_radius, Color color = COLOR_ON);
 
   /// Draw a horizontal line from the point [x,y] to [x+width,y] with the given color.
-  void horizontal_line(int x, int y, int width, Color color = COLOR_ON);
+  virtual void horizontal_line(int x, int y, int width, Color color = COLOR_ON);
 
   /// Draw a vertical line from the point [x,y] to [x,y+width] with the given color.
-  void vertical_line(int x, int y, int height, Color color = COLOR_ON);
+  virtual void vertical_line(int x, int y, int height, Color color = COLOR_ON);
 
   /// Draw the outline of a rectangle with the top left point at [x1,y1] and the bottom right point at
   /// [x1+width,y1+height].
   void rectangle(int x1, int y1, int width, int height, Color color = COLOR_ON);
 
   /// Fill a rectangle with the top left point at [x1,y1] and the bottom right point at [x1+width,y1+height].
-  void filled_rectangle(int x1, int y1, int width, int height, Color color = COLOR_ON);
+  virtual void filled_rectangle(int x1, int y1, int width, int height, Color color = COLOR_ON);
 
   /// Draw the outline of a circle centered around [center_x,center_y] with the radius radius with the given color.
   void circle(int center_x, int center_xy, int radius, Color color = COLOR_ON);

--- a/esphome/components/display/display.h
+++ b/esphome/components/display/display.h
@@ -266,17 +266,28 @@ class Display : public PollingComponent {
   void line_at_angle(int x, int y, int angle, int start_radius, int stop_radius, Color color = COLOR_ON);
 
   /// Draw a horizontal line from the point [x,y] to [x+width,y] with the given color.
-  virtual void horizontal_line(int x, int y, int width, Color color = COLOR_ON);
+  virtual void horizontal_line(int x, int y, int width, Color color);
+
+  // Convenience overload with default color
+  void horizontal_line(int x, int y, int width) { this->vertical_line(x, y, width, COLOR_ON); }
 
   /// Draw a vertical line from the point [x,y] to [x,y+width] with the given color.
-  virtual void vertical_line(int x, int y, int height, Color color = COLOR_ON);
+  virtual void vertical_line(int x, int y, int height, Color color);
+
+  // Convenience overload with default color
+  void vertical_line(int x, int y, int height) { this->vertical_line(x, y, height, COLOR_ON); }
 
   /// Draw the outline of a rectangle with the top left point at [x1,y1] and the bottom right point at
   /// [x1+width,y1+height].
   void rectangle(int x1, int y1, int width, int height, Color color = COLOR_ON);
 
   /// Fill a rectangle with the top left point at [x1,y1] and the bottom right point at [x1+width,y1+height].
-  virtual void filled_rectangle(int x1, int y1, int width, int height, Color color = COLOR_ON);
+  virtual void filled_rectangle(int x1, int y1, int width, int height, Color color);
+
+  /// Convenience overload with default color
+  void filled_rectangle(int x1, int y1, int width, int height) {
+    this->filled_rectangle(x1, y1, width, height, COLOR_ON);
+  }
 
   /// Draw the outline of a circle centered around [center_x,center_y] with the radius radius with the given color.
   void circle(int center_x, int center_xy, int radius, Color color = COLOR_ON);

--- a/esphome/components/display/display.h
+++ b/esphome/components/display/display.h
@@ -269,7 +269,7 @@ class Display : public PollingComponent {
   virtual void horizontal_line(int x, int y, int width, Color color);
 
   // Convenience overload with default color
-  void horizontal_line(int x, int y, int width) { this->vertical_line(x, y, width, COLOR_ON); }
+  void horizontal_line(int x, int y, int width) { this->horizontal_line(x, y, width, COLOR_ON); }
 
   /// Draw a vertical line from the point [x,y] to [x,y+width] with the given color.
   virtual void vertical_line(int x, int y, int height, Color color);

--- a/esphome/components/qspi_amoled/qspi_amoled.cpp
+++ b/esphome/components/qspi_amoled/qspi_amoled.cpp
@@ -125,6 +125,8 @@ void QspiAmoLed::filled_rectangle(int x1, int y1, int width, int height, Color c
       set_buffer_pixel_raw(x, y, new_color);
     }
   }
+
+  App.feed_wdt();
 }
 
 void QspiAmoLed::draw_absolute_pixel_internal(int x, int y, Color color) {

--- a/esphome/components/qspi_amoled/qspi_amoled.h
+++ b/esphome/components/qspi_amoled/qspi_amoled.h
@@ -60,6 +60,9 @@ class QspiAmoLed : public display::DisplayBuffer,
   void set_model(Model model) { this->model_ = model; }
   void update() override;
   void setup() override;
+  void horizontal_line(int x, int y, int width, Color color) override;
+  void vertical_line(int x, int y, int height, Color color) override;
+  void filled_rectangle(int x1, int y1, int width, int height, Color color) override;
   display::ColorOrder get_color_mode() { return this->color_mode_; }
   void set_color_mode(display::ColorOrder color_mode) { this->color_mode_ = color_mode; }
 


### PR DESCRIPTION
# What does this implement/fix?

When drawing large filled shapes (or using the very common `clear()` operation), the separate function calls for each pixel drawn cause a lot of overhead.

This PR reduces the processing time for drawing filled shapes in qspi_amoled by about an order of magnitude (see benchmarks below).

Due to the clipping and rotation logic, I have opted to optimize `filled_rectangle()`, and make `horizontal_line()`  and `vertical_line()` call it with a 1 pixel rect. `horizontal_line()` is used for drawing filled circles and polygons and significantly boosts performance there as well.

I had to make the three optimized drawing functions `virtual` in display.h to render this possible. In the event that this is not acceptable, I can make a new PR that at least overrides the (already virtual) `fill()` for better full-screen fill/clear performance.

### Benchmarks

Time spent drawing graphics to the buffer in `do_update_()`, not including the time taken to send the modified buffer to the display (QSPI). Test device: LILYGO T4 S3, rotation 0.

Test | Time before | Time after PR
---- | ------------ | ------------
test_card | 1407 ms | 147 ms
full screen fill, all pixels changed | 625 ms | 77 ms
full screen fill, nothing changed | 590 ms | 43 ms
draw filled circle with 200 px radius | 332 ms | 42 ms


## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
