### PR TITLE
[CI] Run all tests when a base test changes

### DIFF
--- a/script/list-components.py
+++ b/script/list-components.py
@@ -140,7 +140,10 @@ def get_components(files: list[str], get_dependencies: bool = False):
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        "-c", "--changed", action="store_true", help="Only run on changed files"
+        "-c",
+        "--changed",
+        action="store_true",
+        help="List all components required for testing based on changes",
     )
     parser.add_argument(
         "-b", "--branch", help="Branch to compare changed files against"
@@ -158,7 +161,9 @@ def main():
             changed = changed_files(args.branch)
         else:
             changed = changed_files()
-        files = [f for f in files if f in changed]
+        # If any base test file(s) changed, there's no need to filter out components
+        if not any("tests/test_build_components" in file for file in changed):
+            files = [f for f in files if f in changed]
 
     for c in get_components(files, args.changed):
         print(c)


### PR DESCRIPTION
# What does this implement/fix?

When any base test is changed, all component tests should run.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
