### PR TITLE
Enabling python linters in devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,9 @@
 {
   "name": "ESPHome Dev",
   "image": "ghcr.io/esphome/esphome-lint:dev",
-  "postCreateCommand": ["script/devcontainer-post-create"],
+  "postCreateCommand": [
+    "script/devcontainer-post-create"
+  ],
   "containerEnv": {
     "DEVCONTAINER": "1",
     "PIP_BREAK_SYSTEM_PACKAGES": "1",
@@ -27,6 +29,9 @@
       "extensions": [
         // python
         "ms-python.python",
+        "ms-python.pylint",
+        "ms-python.flake8",
+        "ms-python.black-formatter",
         "visualstudioexptteam.vscodeintellicode",
         // yaml
         "redhat.vscode-yaml",
@@ -38,9 +43,21 @@
       "settings": {
         "python.languageServer": "Pylance",
         "python.pythonPath": "/usr/bin/python3",
-        "python.linting.pylintEnabled": true,
-        "python.linting.enabled": true,
-        "python.formatting.provider": "black",
+        "pylint.args": [
+          "--rcfile=${workspaceFolder}/pyproject.toml"
+        ],
+        "flake8.args": [
+          "--config=${workspaceFolder}/.flake8"
+        ],
+        "black-formatter.args": [
+          "--config",
+          "${workspaceFolder}/pyproject.toml"
+        ],
+        "[python]": {
+          // VS will say "Value is not accepted" before building the devcontainer, but the warning
+          // should go away after build is completed.
+          "editor.defaultFormatter": "ms-python.black-formatter"
+        },
         "editor.formatOnPaste": false,
         "editor.formatOnSave": true,
         "editor.formatOnType": true,

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,4 +1,8 @@
 # Useful stuff when working in a development environment
 clang-format==13.0.1  # also change in .pre-commit-config.yaml and Dockerfile when updating
+# If using VS dev container: clang-tidy build takes ~12GB of RAM. The OMM failure is
+# not very clear if it does happen. Similar issue: https://github.com/llvm/llvm-project/issues/55369
+# Symptom: "c++: fatal error: Killed signal terminated program cc1plus"
+# Workaround: Go to [Docker dashboard -> Settings -> Resources] and allow RAM to grow to 13GB+
 clang-tidy==14.0.6  # When updating clang-tidy, also update Dockerfile
 yamllint==1.35.1  # also change in .pre-commit-config.yaml when updating


### PR DESCRIPTION
Changes:
- Updated dev container configuration to enable python linters in IDE (pylint, flake8, black)
- Added small comment in dev requirements in case others also face memory issues when building dev container

# What does this implement/fix?

Fixing linter configuration in dev container

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other - devcontainer fix

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

Tested locally with dev container:
* Ran negative test with flake8/pylint by editing config and confirming errors/warnings show up.
* Tested black auto format on save

https://github.com/esphome/esphome/assets/3383373/a25af5e4-43e4-45ea-a559-761e2f975130

<img width="1003" alt="flake8_negative_test" src="https://github.com/esphome/esphome/assets/3383373/d6b3d237-b62a-4450-a36c-b23cfcf00793">
<img width="998" alt="pylint_negative_test" src="https://github.com/esphome/esphome/assets/3383373/dea3414a-1feb-45da-9faf-4488ef2786a7">

## Example entry for `config.yaml`:
N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [N/A] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [N/A] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
