### PR TITLE
Enable devcontainer linters

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,9 @@
 {
   "name": "ESPHome Dev",
   "image": "ghcr.io/esphome/esphome-lint:dev",
-  "postCreateCommand": ["script/devcontainer-post-create"],
+  "postCreateCommand": [
+    "script/devcontainer-post-create"
+  ],
   "containerEnv": {
     "DEVCONTAINER": "1",
     "PIP_BREAK_SYSTEM_PACKAGES": "1",
@@ -27,6 +29,9 @@
       "extensions": [
         // python
         "ms-python.python",
+        "ms-python.pylint",
+        "ms-python.flake8",
+        "ms-python.black-formatter",
         "visualstudioexptteam.vscodeintellicode",
         // yaml
         "redhat.vscode-yaml",
@@ -38,9 +43,21 @@
       "settings": {
         "python.languageServer": "Pylance",
         "python.pythonPath": "/usr/bin/python3",
-        "python.linting.pylintEnabled": true,
-        "python.linting.enabled": true,
-        "python.formatting.provider": "black",
+        "pylint.args": [
+          "--rcfile=${workspaceFolder}/pyproject.toml"
+        ],
+        "flake8.args": [
+          "--config=${workspaceFolder}/.flake8"
+        ],
+        "black-formatter.args": [
+          "--config",
+          "${workspaceFolder}/pyproject.toml"
+        ],
+        "[python]": {
+          // VS will say "Value is not accepted" before building the devcontainer, but the warning
+          // should go away after build is completed.
+          "editor.defaultFormatter": "ms-python.black-formatter"
+        },
         "editor.formatOnPaste": false,
         "editor.formatOnSave": true,
         "editor.formatOnType": true,


### PR DESCRIPTION
# What does this implement/fix?

* Devcontainer improvements

## Types of changes

- [] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other - devcontainer linters

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test VS devcontainer
Tested locally with dev container:
* Ran negative test with flake8/pylint by editing config and confirming errors/warnings show up (screenshots below).
* Tested black auto format on save (video below).

https://github.com/esphome/esphome/assets/3383373/a25af5e4-43e4-45ea-a559-761e2f975130

<img width="1003" alt="flake8_negative_test" src="https://github.com/esphome/esphome/assets/3383373/d6b3d237-b62a-4450-a36c-b23cfcf00793">
<img width="998" alt="pylint_negative_test" src="https://github.com/esphome/esphome/assets/3383373/dea3414a-1feb-45da-9faf-4488ef2786a7">

## Checklist:
  - [x] The code change is tested and works locally.
  - [N/A] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [N/A] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
