### PR TITLE
[docker] Bump versions inside armv7 block

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -46,8 +46,8 @@ RUN \
           python3-dev=3.11.2-1+b1 \
           zlib1g-dev=1:1.2.13.dfsg-1 \
           libjpeg-dev=1:2.1.5-2 \
-          libfreetype-dev=2.12.1+dfsg-5 \
-          libssl-dev=3.0.11-1~deb12u2 \
+          libfreetype-dev=2.12.1+dfsg-5+deb12u3 \
+          libssl-dev=3.0.13-1~deb12u1 \
           libffi-dev=3.4.4-1 \
           libopenjp2-7=2.5.0-2 \
           libtiff6=4.5.0-6+deb12u1 \


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

- Bump libfreetype-dev to 2.12.1+dfsg-5+deb12u3
- Bump libssl-dev to 3.0.13-1~deb12u1


Needed for #7021 

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
