### PR TITLE
Tuya integration no longer waits for wifi

### DIFF
--- a/esphome/components/tuya/tuya.cpp
+++ b/esphome/components/tuya/tuya.cpp
@@ -1,17 +1,8 @@
 #include "tuya.h"
-#include "esphome/components/network/util.h"
 #include "esphome/core/gpio.h"
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 #include "esphome/core/util.h"
-
-#ifdef USE_WIFI
-#include "esphome/components/wifi/wifi_component.h"
-#endif
-
-#ifdef USE_CAPTIVE_PORTAL
-#include "esphome/components/captive_portal/captive_portal.h"
-#endif
 
 namespace esphome {
 namespace tuya {
@@ -20,6 +11,10 @@ static const char *const TAG = "tuya";
 static const int COMMAND_DELAY = 10;
 static const int RECEIVE_TIMEOUT = 300;
 static const int MAX_RETRIES = 5;
+
+static const uint8_t NET_STATUS_WIFI_CONNECTED = 0x03;
+static const uint8_t NET_STATUS_CLOUD_CONNECTED = 0x04;
+static const uint8_t FAKE_WIFI_RSSI = 100;
 
 void Tuya::setup() {
   this->set_interval("heartbeat", 15000, [this] { this->send_empty_command_(TuyaCommandType::HEARTBEAT); });
@@ -244,7 +239,7 @@ void Tuya::handle_command_(uint8_t command, uint8_t version, const uint8_t *buff
       break;
     case TuyaCommandType::WIFI_RSSI:
       this->send_command_(
-          TuyaCommand{.cmd = TuyaCommandType::WIFI_RSSI, .payload = std::vector<uint8_t>{get_wifi_rssi_()}});
+          TuyaCommand{.cmd = TuyaCommandType::WIFI_RSSI, .payload = std::vector<uint8_t>{FAKE_WIFI_RSSI}});
       break;
     case TuyaCommandType::LOCAL_TIME_QUERY:
 #ifdef USE_TIME
@@ -494,37 +489,18 @@ void Tuya::set_status_pin_() {
 }
 
 uint8_t Tuya::get_wifi_status_code_() {
-  uint8_t status = 0x02;
+  uint8_t status = NET_STATUS_WIFI_CONNECTED;
 
-  if (network::is_connected()) {
-    status = 0x03;
-
-    // Protocol version 3 also supports specifying when connected to "the cloud"
-    if (this->protocol_version_ >= 0x03 && remote_is_connected()) {
-      status = 0x04;
-    }
-  } else {
-#ifdef USE_CAPTIVE_PORTAL
-    if (captive_portal::global_captive_portal != nullptr && captive_portal::global_captive_portal->is_active()) {
-      status = 0x01;
-    }
-#endif
-  };
+  // Protocol version 3 also supports specifying when connected to "the cloud"
+  if (this->protocol_version_ >= 0x03 && remote_is_connected()) {
+    status = NET_STATUS_CLOUD_CONNECTED;
+  }
 
   return status;
 }
 
-uint8_t Tuya::get_wifi_rssi_() {
-#ifdef USE_WIFI
-  if (wifi::global_wifi_component != nullptr)
-    return wifi::global_wifi_component->wifi_rssi();
-#endif
-
-  return 0;
-}
-
 void Tuya::send_wifi_status_() {
-  uint8_t status = this->get_wifi_status_code_();
+  const uint8_t status = get_wifi_status_code_();
 
   if (status == this->wifi_status_) {
     return;

--- a/esphome/components/tuya/tuya.cpp
+++ b/esphome/components/tuya/tuya.cpp
@@ -482,9 +482,7 @@ void Tuya::send_empty_command_(TuyaCommandType command) {
   send_command_(TuyaCommand{.cmd = command, .payload = std::vector<uint8_t>{}});
 }
 
-void Tuya::set_status_pin_() {
-  this->status_pin_->digital_write(true);
-}
+void Tuya::set_status_pin_() { this->status_pin_->digital_write(true); }
 
 uint8_t Tuya::get_wifi_status_code_() {
   uint8_t status = NET_STATUS_WIFI_CONNECTED;

--- a/esphome/components/tuya/tuya.cpp
+++ b/esphome/components/tuya/tuya.cpp
@@ -2,7 +2,6 @@
 #include "esphome/core/gpio.h"
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
-#include "esphome/core/util.h"
 
 namespace esphome {
 namespace tuya {
@@ -484,15 +483,14 @@ void Tuya::send_empty_command_(TuyaCommandType command) {
 }
 
 void Tuya::set_status_pin_() {
-  bool is_network_ready = network::is_connected() && remote_is_connected();
-  this->status_pin_->digital_write(is_network_ready);
+  this->status_pin_->digital_write(true);
 }
 
 uint8_t Tuya::get_wifi_status_code_() {
   uint8_t status = NET_STATUS_WIFI_CONNECTED;
 
   // Protocol version 3 also supports specifying when connected to "the cloud"
-  if (this->protocol_version_ >= 0x03 && remote_is_connected()) {
+  if (this->protocol_version_ >= 0x03) {
     status = NET_STATUS_CLOUD_CONNECTED;
   }
 

--- a/esphome/components/tuya/tuya.h
+++ b/esphome/components/tuya/tuya.h
@@ -87,7 +87,7 @@ struct TuyaCommand {
 
 class Tuya : public Component, public uart::UARTDevice {
  public:
-  float get_setup_priority() const override { return setup_priority::LATE; }
+  float get_setup_priority() const override { return setup_priority::DATA; }
   void setup() override;
   void loop() override;
   void dump_config() override;
@@ -135,7 +135,6 @@ class Tuya : public Component, public uart::UARTDevice {
   void set_status_pin_();
   void send_wifi_status_();
   uint8_t get_wifi_status_code_();
-  uint8_t get_wifi_rssi_();
 
 #ifdef USE_TIME
   void send_local_time_();

--- a/esphome/core/util.cpp
+++ b/esphome/core/util.cpp
@@ -32,6 +32,4 @@ bool mqtt_is_connected() {
   return false;
 }
 
-bool remote_is_connected() { return api_is_connected() || mqtt_is_connected(); }
-
 }  // namespace esphome


### PR DESCRIPTION
# What does this implement/fix?

In the original implementation Tuya integration setup priority was LATE, which means it wasn't started until after wifi was connected. This was probably because the integration author wanted real wifi state to be sent to Tuya mcu.
There are 2 problems with this:
1) It might take a long time for the real wifi to connect - and during this time tuyamcu expects the module to respond to notifications. If there is no response - tuyamcu assumes errornous state and might require a reset.
2) There is really no point to forward real wifi state to tuya mcu. These devices were designed to be controlled via cloud and some of them even block their functionality until the cloud is connected. The esphome users might want to use these devices even without connecting them to wifi. Why not let them?

TLDR:
This PR moves the initialization of Tuya integration from LATE to DATA (before wifi) and fakes the network status when asked by Tuya MCU.


## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [x] BK72xx
- [ ] RTL87xx

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
