### PR TITLE
Fix compile errors on ESP32-C6 with W5500 SPI ethernet

### DIFF
--- a/esphome/components/ethernet/ethernet_component.cpp
+++ b/esphome/components/ethernet/ethernet_component.cpp
@@ -65,7 +65,7 @@ void EthernetComponent::setup() {
       .intr_flags = 0,
   };
 
-#if defined(USE_ESP32_VARIANT_ESP32C3) || defined(USE_ESP32_VARIANT_ESP32S2) || defined(USE_ESP32_VARIANT_ESP32S3)
+#if defined(USE_ESP32_VARIANT_ESP32C3) || defined(USE_ESP32_VARIANT_ESP32S2) || defined(USE_ESP32_VARIANT_ESP32S3) || defined(USE_ESP32_VARIANT_ESP32C6)
   auto host = SPI2_HOST;
 #else
   auto host = SPI3_HOST;

--- a/esphome/components/ethernet/ethernet_component.cpp
+++ b/esphome/components/ethernet/ethernet_component.cpp
@@ -65,7 +65,8 @@ void EthernetComponent::setup() {
       .intr_flags = 0,
   };
 
-#if defined(USE_ESP32_VARIANT_ESP32C3) || defined(USE_ESP32_VARIANT_ESP32S2) || defined(USE_ESP32_VARIANT_ESP32S3) || defined(USE_ESP32_VARIANT_ESP32C6)
+#if defined(USE_ESP32_VARIANT_ESP32C3) || defined(USE_ESP32_VARIANT_ESP32S2) || defined(USE_ESP32_VARIANT_ESP32S3) || \
+    defined(USE_ESP32_VARIANT_ESP32C6)
   auto host = SPI2_HOST;
 #else
   auto host = SPI3_HOST;


### PR DESCRIPTION
# What does this implement/fix?

I was compiling on esp32-c6, referring to #6822 
When setting up SPI ethernet with W5500, an error appeared saying that SPI3_HOST could not be found, so I fixed this.
I don't know much about esp32's system, but it looks like it probably has the same network hardware type as C3, S2, and S3.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** Complements #6822 

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
esphome:
  name: esp32-c6-w5500

esp32:
  board: esp32-c6-devkitm-1 # at least until https://github.com/platformio/platform-espressif32/issues/1152 is added
  variant: esp32c6          # ditto ↑
  flash_size: 4MB # upload.flash_size
  framework:
    type: esp-idf
    version: 5.2.2 # Need at least 5.1 for ESP32-C6
    platform_version: 6.7.0 # Need at least 6.4 for ESP32-C6
    # See https://github.com/esphome/issues/issues/5404
    sdkconfig_options:
      CONFIG_ESPTOOLPY_FLASHSIZE_4MB: y

ethernet:
  type: W5500
  mosi_pin: GPIO20
  miso_pin: GPIO19
  clk_pin: GPIO18
  cs_pin: GPIO21
  reset_pin: GPIO22
  interrupt_pin: GPIO23
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
