### PR TITLE
[wifi] Only set default ttls phase 2 on esp-idf

### DIFF
--- a/esphome/components/wifi/__init__.py
+++ b/esphome/components/wifi/__init__.py
@@ -114,7 +114,7 @@ EAP_AUTH_SCHEMA = cv.All(
             cv.Optional(CONF_USERNAME): cv.string_strict,
             cv.Optional(CONF_PASSWORD): cv.string_strict,
             cv.Optional(CONF_CERTIFICATE_AUTHORITY): wpa2_eap.validate_certificate,
-            cv.Optional(CONF_TTLS_PHASE_2): cv.All(
+            cv.SplitDefault(CONF_TTLS_PHASE_2, esp32_idf="mschapv2"): cv.All(
                 cv.enum(TTLS_PHASE_2), cv.only_with_esp_idf
             ),
             cv.Inclusive(
@@ -350,7 +350,7 @@ def eap_auth(config):
         ("ca_cert", ca_cert),
         ("client_cert", client_cert),
         ("client_key", key),
-        ("ttls_phase_2", config.get(CONF_TTLS_PHASE_2, TTLS_PHASE_2["mschapv2"])),
+        ("ttls_phase_2", config.get(CONF_TTLS_PHASE_2)),
     )
 
 

--- a/tests/components/wifi/test-eap.esp32-ard.yaml
+++ b/tests/components/wifi/test-eap.esp32-ard.yaml
@@ -1,0 +1,7 @@
+wifi:
+  networks:
+    - ssid: MySSID
+      eap:
+        username: username
+        password: password
+        identity: identity


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->
The codegen was trying to set the `.ttls_phase_2` field of the struct even when using Arduino framework.

I have added a test for arduino, but esp-idf was failing to compile on idf5.1 so I have left it out of this PR

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/5933

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
