### PR TITLE
Add braces to if statement to avoid compiler warning.

### DIFF
--- a/esphome/components/aht10/aht10.cpp
+++ b/esphome/components/aht10/aht10.cpp
@@ -93,8 +93,9 @@ void AHT10Component::restart_read_() {
 
 void AHT10Component::read_data_() {
   uint8_t data[6];
-  if (this->read_count_ > 1)
+  if (this->read_count_ > 1) {
     ESP_LOGD(TAG, "Read attempt %d at %ums", this->read_count_, (unsigned) (millis() - this->start_time_));
+  }
   if (this->read(data, 6) != i2c::ERROR_OK) {
     this->status_set_warning("AHT10 read failed, retrying soon");
     this->restart_read_();
@@ -119,8 +120,9 @@ void AHT10Component::read_data_() {
       return;
     }
   }
-  if (this->read_count_ > 1)
+  if (this->read_count_ > 1) {
     ESP_LOGD(TAG, "Success at %ums", (unsigned) (millis() - this->start_time_));
+  }
   uint32_t raw_temperature = ((data[3] & 0x0F) << 16) | (data[4] << 8) | data[5];
   uint32_t raw_humidity = ((data[1] << 16) | (data[2] << 8) | data[3]) >> 4;
 


### PR DESCRIPTION
It's possible that ESP_LOGD is #defined to empty, so add braces to avoid a warning on empty if() statements.

# What does this implement/fix?

When building for production, `ESP_LOGD` is `#define`d to be empty, so the compiler warns about empty if() statements in these two locations. Adding braces to remove this warning. Tested trivially.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other


## Test Environment

- [X] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
