### PR TITLE
Don't test for IPv6 addresses when min_ipv6_addr_count is 0

### DIFF
--- a/esphome/components/wifi/wifi_component_esp_idf.cpp
+++ b/esphome/components/wifi/wifi_component_esp_idf.cpp
@@ -757,7 +757,7 @@ void WiFiComponent::wifi_process_event_(IDFWiFiEvent *data) {
 
 WiFiSTAConnectStatus WiFiComponent::wifi_sta_connect_status_() {
   if (s_sta_connected && this->got_ipv4_address_) {
-#if USE_NETWORK_IPV6
+#if USE_NETWORK_IPV6 && (USE_NETWORK_MIN_IPV6_ADDR_COUNT > 0)
     if (this->num_ipv6_addresses_ >= USE_NETWORK_MIN_IPV6_ADDR_COUNT) {
       return WiFiSTAConnectStatus::CONNECTED;
     }


### PR DESCRIPTION
Alter the `#if` slightly here to avoid this test when `min_ipv6_addr_count` is zero.

# What does this implement/fix?

Avoids the trivial comparison when the number of required IPv6 addresses is set to zero (eliminating a source of compiler warnings).

As things stand, if IPv6 is enabled but `min_ipv6_addr_count == 0` (the default), we are here testing whether a `uint8_t` value is greater or equal to zero here. This is of course always true, so the compiler emits a warning (due to `-Wtype-limits`). Adding a test to the `#ifdef` to avoid making this comparison when the RHS is zero.

Trivially tested.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Test Environment

- [ ] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Checklist:

  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
