### PR TITLE
Fix display of update state in webinterfae

### DIFF
--- a/esphome/components/http_request/update/http_request_update.cpp
+++ b/esphome/components/http_request/update/http_request_update.cpp
@@ -116,19 +116,18 @@ void HttpRequestUpdate::update() {
     }
   }
 
-  std::string current_version = this->current_version_;
-  if (current_version.empty()) {
+  std::string current_version;
 #ifdef ESPHOME_PROJECT_VERSION
-    current_version = ESPHOME_PROJECT_VERSION;
+  current_version = ESPHOME_PROJECT_VERSION;
 #else
-    current_version = ESPHOME_VERSION;
+  current_version = ESPHOME_VERSION;
 #endif
-  }
+
   this->update_info_.current_version = current_version;
 
-  if (this->update_info_.latest_version.empty()) {
+  if (this->update_info_.latest_version.empty() || this->update_info_.latest_version == update_info_.current_version) {
     this->state_ = update::UPDATE_STATE_NO_UPDATE;
-  } else if (this->update_info_.latest_version != this->current_version_) {
+  } else {
     this->state_ = update::UPDATE_STATE_AVAILABLE;
   }
 

--- a/esphome/components/http_request/update/http_request_update.h
+++ b/esphome/components/http_request/update/http_request_update.h
@@ -22,7 +22,6 @@ class HttpRequestUpdate : public update::UpdateEntity, public PollingComponent {
   void set_request_parent(HttpRequestComponent *request_parent) { this->request_parent_ = request_parent; }
   void set_ota_parent(OtaHttpRequestComponent *ota_parent) { this->ota_parent_ = ota_parent; }
 
-
   float get_setup_priority() const override { return setup_priority::AFTER_WIFI; }
 
  protected:

--- a/esphome/components/http_request/update/http_request_update.h
+++ b/esphome/components/http_request/update/http_request_update.h
@@ -22,7 +22,6 @@ class HttpRequestUpdate : public update::UpdateEntity, public PollingComponent {
   void set_request_parent(HttpRequestComponent *request_parent) { this->request_parent_ = request_parent; }
   void set_ota_parent(OtaHttpRequestComponent *ota_parent) { this->ota_parent_ = ota_parent; }
 
-  void set_current_version(const std::string &current_version) { this->current_version_ = current_version; }
 
   float get_setup_priority() const override { return setup_priority::AFTER_WIFI; }
 
@@ -30,7 +29,6 @@ class HttpRequestUpdate : public update::UpdateEntity, public PollingComponent {
   HttpRequestComponent *request_parent_;
   OtaHttpRequestComponent *ota_parent_;
   std::string source_url_;
-  std::string current_version_{""};
 };
 
 }  // namespace http_request


### PR DESCRIPTION
# What does this implement/fix?

When using the update component and the version in the manifest JSON is equal to the current installed version the state in the webinterface is not shown as "NO UPDATE".

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
