### PR TITLE
[wifi] Hostname may not be set as expected on Arduino platform

### DIFF
--- a/esphome/components/wifi/wifi_component_esp32_arduino.cpp
+++ b/esphome/components/wifi/wifi_component_esp32_arduino.cpp
@@ -495,6 +495,7 @@ void WiFiComponent::wifi_event_callback_(esphome_wifi_event_id_t event, esphome_
     case ESPHOME_EVENT_ID_WIFI_STA_START: {
       ESP_LOGV(TAG, "Event: WiFi STA start");
       // apply hostname
+      s_sta_netif = esp_netif_get_handle_from_ifkey("WIFI_STA_DEF");
       esp_err_t err = esp_netif_set_hostname(s_sta_netif, App.get_name().c_str());
       if (err != ERR_OK) {
         ESP_LOGW(TAG, "esp_netif_set_hostname failed: %s", esp_err_to_name(err));

--- a/esphome/components/wifi/wifi_component_esp32_arduino.cpp
+++ b/esphome/components/wifi/wifi_component_esp32_arduino.cpp
@@ -82,8 +82,8 @@ bool WiFiComponent::wifi_mode_(optional<bool> sta, optional<bool> ap) {
 
   // WiFiClass::mode above calls esp_netif_create_default_wifi_sta() and
   // esp_netif_create_default_wifi_ap(), which creates the interfaces.
-  if (set_sta)
-    s_sta_netif = esp_netif_get_handle_from_ifkey("WIFI_STA_DEF");
+  // s_sta_netif handle is set during ESPHOME_EVENT_ID_WIFI_STA_START event
+
 #ifdef USE_WIFI_AP
   if (set_ap)
     s_ap_netif = esp_netif_get_handle_from_ifkey("WIFI_AP_DEF");


### PR DESCRIPTION
# What does this implement/fix?

fixes https://github.com/esphome/issues/issues/6014
It looks like this workarounds problem that hostname is not set correcly on esp32c3 on wifi connection.
the problem started with 2024.6.0 version after changes to wifi code. I observe the problem on 2024.6.6 version as well.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

esphome:
  name: curtains-02
  friendly_name: Curtains 02
  on_boot:
    - lambda: |-
        id(device_ota).set_auth_password("${ota_old_password}");

esp32: 
  board: esp32-c3-devkitm-1
  framework:
    type: arduino
    version: recommended

wifi:
  domain: .lan
  networks:
    - ssid: ${wifi_ssid}
      password: ${wifi_password}

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
