### PR TITLE
[CI] Allow running specific target test(s) only

### DIFF
--- a/script/test_build_components
+++ b/script/test_build_components
@@ -7,12 +7,13 @@ set -e
 # - `c` - Component folder name to test. Default `*`.
 esphome_command="compile"
 target_component="*"
-while getopts e:c: flag
+while getopts e:c:t: flag
 do
     case $flag in
         e) esphome_command=${OPTARG};;
         c) target_component=${OPTARG};;
-        \?) echo "Usage: $0 [-e <config|compile|clean>] [-c <string>]" 1>&2; exit 1;;
+        t) requested_target_platform=${OPTARG};;
+        \?) echo "Usage: $0 [-e <config|compile|clean>] [-c <string>] [-t <string>]" 1>&2; exit 1;;
     esac
 done
 
@@ -23,6 +24,10 @@ if ! [ -d "./tests/test_build_components/build" ]; then
 fi
 
 start_esphome() {
+  if [ -n "$requested_target_platform" ] && [ "$requested_target_platform" != "$target_platform" ]; then
+    echo "Skiping $target_platform"
+    return
+  fi
   # create dynamic yaml file in `build` folder.
   # `./tests/test_build_components/build/[target_component].[test_name].[target_platform_with_version].yaml`
   component_test_file="./tests/test_build_components/build/$target_component.$test_name.$target_platform_with_version.yaml"


### PR DESCRIPTION
# What does this implement/fix?

If some tests fails only in specific target it is faster to run just those instead of all of them.

```
./script/test_build_components -e compile -c gpio -t rp2040-ard
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
