### PR TITLE
Add waveshare 1 45 in v2 b support

### DIFF
--- a/esphome/components/waveshare_epaper/display.py
+++ b/esphome/components/waveshare_epaper/display.py
@@ -27,11 +27,9 @@ WaveshareEPaperBWR = waveshare_epaper_ns.class_(
 WaveshareEPaperTypeA = waveshare_epaper_ns.class_(
     "WaveshareEPaperTypeA", WaveshareEPaper
 )
-
 WaveshareEpaper1P54INBV2 = waveshare_epaper_ns.class_(
     "WaveshareEPaper1P54InBV2", WaveshareEPaperBWR
 )
-
 WaveshareEPaper2P7In = waveshare_epaper_ns.class_(
     "WaveshareEPaper2P7In", WaveshareEPaper
 )

--- a/esphome/components/waveshare_epaper/display.py
+++ b/esphome/components/waveshare_epaper/display.py
@@ -110,7 +110,7 @@ WaveshareEPaperTypeBModel = waveshare_epaper_ns.enum("WaveshareEPaperTypeBModel"
 MODELS = {
     "1.54in": ("a", WaveshareEPaperTypeAModel.WAVESHARE_EPAPER_1_54_IN),
     "1.54inv2": ("a", WaveshareEPaperTypeAModel.WAVESHARE_EPAPER_1_54_IN_V2),
-    "1.54.inv2-b" : ("b", WaveshareEpaper1P54INBV2),
+    "1.54inv2-b" : ("b", WaveshareEpaper1P54INBV2),
     "2.13in": ("a", WaveshareEPaperTypeAModel.WAVESHARE_EPAPER_2_13_IN),
     "2.13inv2": ("a", WaveshareEPaperTypeAModel.WAVESHARE_EPAPER_2_13_IN_V2),
     "2.13in-ttgo": ("a", WaveshareEPaperTypeAModel.TTGO_EPAPER_2_13_IN),

--- a/esphome/components/waveshare_epaper/display.py
+++ b/esphome/components/waveshare_epaper/display.py
@@ -110,7 +110,7 @@ WaveshareEPaperTypeBModel = waveshare_epaper_ns.enum("WaveshareEPaperTypeBModel"
 MODELS = {
     "1.54in": ("a", WaveshareEPaperTypeAModel.WAVESHARE_EPAPER_1_54_IN),
     "1.54inv2": ("a", WaveshareEPaperTypeAModel.WAVESHARE_EPAPER_1_54_IN_V2),
-    "1.54inv2-b" : ("b", WaveshareEpaper1P54INBV2),
+    "1.54inv2-b": ("b", WaveshareEpaper1P54INBV2),
     "2.13in": ("a", WaveshareEPaperTypeAModel.WAVESHARE_EPAPER_2_13_IN),
     "2.13inv2": ("a", WaveshareEPaperTypeAModel.WAVESHARE_EPAPER_2_13_IN_V2),
     "2.13in-ttgo": ("a", WaveshareEPaperTypeAModel.TTGO_EPAPER_2_13_IN),

--- a/esphome/components/waveshare_epaper/display.py
+++ b/esphome/components/waveshare_epaper/display.py
@@ -27,6 +27,11 @@ WaveshareEPaperBWR = waveshare_epaper_ns.class_(
 WaveshareEPaperTypeA = waveshare_epaper_ns.class_(
     "WaveshareEPaperTypeA", WaveshareEPaper
 )
+
+WaveshareEpaper1P54INBV2 = waveshare_epaper_ns.class_(
+    "WaveshareEPaper1P54InBV2", WaveshareEPaperBWR
+)
+
 WaveshareEPaper2P7In = waveshare_epaper_ns.class_(
     "WaveshareEPaper2P7In", WaveshareEPaper
 )
@@ -105,6 +110,7 @@ WaveshareEPaperTypeBModel = waveshare_epaper_ns.enum("WaveshareEPaperTypeBModel"
 MODELS = {
     "1.54in": ("a", WaveshareEPaperTypeAModel.WAVESHARE_EPAPER_1_54_IN),
     "1.54inv2": ("a", WaveshareEPaperTypeAModel.WAVESHARE_EPAPER_1_54_IN_V2),
+    "1.54.inv2-b" : ("b", WaveshareEpaper1P54INBV2),
     "2.13in": ("a", WaveshareEPaperTypeAModel.WAVESHARE_EPAPER_2_13_IN),
     "2.13inv2": ("a", WaveshareEPaperTypeAModel.WAVESHARE_EPAPER_2_13_IN_V2),
     "2.13in-ttgo": ("a", WaveshareEPaperTypeAModel.TTGO_EPAPER_2_13_IN),

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -154,8 +154,7 @@ bool WaveshareEPaperBase::wait_until_idle_() {
   }
 
   const uint32_t start = millis();
-
-  while (bool test = this->busy_pin_->digital_read()) {
+  while (this->busy_pin_->digital_read()) {
     if (millis() - start > this->idle_timeout_()) {
       ESP_LOGE(TAG, "Timeout while displaying image!");
       return false;

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -645,7 +645,6 @@ static const uint8_t LUT_BLACK_TO_BLACK_2_7[42] = {
 };
 
 void WaveshareEPaper2P7In::initialize() {
-
   // command power setting
   this->command(0x01);
   this->data(0x03);  // VDS_EN, VDG_EN
@@ -838,7 +837,7 @@ void WaveshareEPaper1P54InBV2::initialize() {
   this->data(0x18);  // 0x18-->(24+1)*8=200
 
   this->command(0x45);  // set Ram-Y address start/end position
-  this->data(0xC7);  // 0xC7-->(199+1)=200
+  this->data(0xC7);     // 0xC7-->(199+1)=200
   this->data(0x00);
   this->data(0x00);
   this->data(0x00);
@@ -856,7 +855,6 @@ void WaveshareEPaper1P54InBV2::initialize() {
   this->data(0x00);
 
   this->wait_until_idle_();
-
 }
 
 void HOT WaveshareEPaper1P54InBV2::display() {

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -644,6 +644,7 @@ static const uint8_t LUT_BLACK_TO_BLACK_2_7[42] = {
 };
 
 void WaveshareEPaper2P7In::initialize() {
+  
   // command power setting
   this->command(0x01);
   this->data(0x03);  // VDS_EN, VDG_EN
@@ -816,7 +817,10 @@ void WaveshareEPaper2P7InV2::dump_config() {
 //  - 
 
 void WaveshareEPaper1P54InBV2::initialize(){
+  ESP_LOGI(TAG, 'Reseting Display');
   this->reset_();
+
+  ESP_LOGI(TAG, 'Initializing Display');
   this->wait_until_idle_();
 
   this->command(0x12);
@@ -851,7 +855,10 @@ void WaveshareEPaper1P54InBV2::initialize(){
   this->command(0x4F);   // set RAM y address count to 0X199;    
   this->data(0xC7);
   this->data(0x00);
+
+  ESP_LOGI(TAG, 'Waiting for idle');
   this->wait_until_idle_();
+  ESP_LOGI(TAG, 'Waiting done');
 
 }
 

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -872,7 +872,7 @@ void HOT WaveshareEPaper1P54InBV2::display(){
   this->command(0x24);
   delay(2);
   for (uint32_t i = 0; i < buf_len_half; i++) {
-    this->data(this->buffer_[i]);
+    this->data(~this->buffer_[i]);
   }
   delay(2);
 
@@ -880,7 +880,7 @@ void HOT WaveshareEPaper1P54InBV2::display(){
   this->command(0x26);
   delay(2);
   for (uint32_t i = buf_len_half; i < buf_len_half * 2u; i++) {
-    this->data(this->buffer_[i]);
+    this->data(~this->buffer_[i]);
   }
   this->command(0x22);
   this->data(0xf7);

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -817,10 +817,10 @@ void WaveshareEPaper2P7InV2::dump_config() {
 //  - 
 
 void WaveshareEPaper1P54InBV2::initialize(){
-  ESP_LOGD(TAG, 'Reseting Display');
+  ESP_LOGD(TAG, "Reseting Display");
   this->reset_();
 
-  ESP_LOGD(TAG, 'Initializing Display');
+  ESP_LOGD(TAG, "Initializing Display");
   this->wait_until_idle_();
 
   this->command(0x12);
@@ -856,9 +856,9 @@ void WaveshareEPaper1P54InBV2::initialize(){
   this->data(0xC7);
   this->data(0x00);
 
-  ESP_LOGD(TAG, 'Waiting for idle');
+  ESP_LOGD(TAG, "Waiting for idle");
   this->wait_until_idle_();
-  ESP_LOGD(TAG, 'Waiting done');
+  ESP_LOGD(TAG, "Waiting done");
 
 }
 

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -809,6 +809,91 @@ void WaveshareEPaper2P7InV2::dump_config() {
 }
 
 // ========================================================
+//                          1.45inch_v2_e-paper_b
+// ========================================================
+// Datasheet:
+//  - 
+//  - 
+
+void WaveshareEPaper1P54InBV2::initialize(){
+  this->reset_();
+  this->wait_until_idle_();
+
+  this->command(0x12);
+  this->wait_until_idle_();
+
+  this->command(0x01);
+  this->data(0xC7);
+  this->data(0x00);
+  this->data(0x01);
+
+  this->command(0x11); //data entry mode       
+  this->data(0x01);
+
+  this->command(0x44); //set Ram-X address start/end position   
+  this->data(0x00);
+  this->data(0x18);    //0x18-->(24+1)*8=200
+
+  this->command(0x45); //set Ram-Y address start/end position          
+  this->data(0xC7);    //0xC7-->(199+1)=200
+  this->data(0x00);
+  this->data(0x00);
+  this->data(0x00);
+
+  this->command(0x3C); //BorderWavefrom
+  this->data(0x05);
+
+  this->command(0x18); //Read built-in temperature sensor
+  this->data(0x80);
+
+  this->command(0x4E);   // set RAM x address count to 0;
+  this->data(0x00);
+  this->command(0x4F);   // set RAM y address count to 0X199;    
+  this->data(0xC7);
+  this->data(0x00);
+  this->wait_until_idle_();
+
+}
+
+void HOT WaveshareEPaper1P54InBV2::display(){
+  uint32_t buf_len_half = this->get_buffer_length_() >> 1;
+  this->initialize();
+
+  // COMMAND DATA START TRANSMISSION 1 (BLACK)
+  this->command(24);
+  delay(2);
+  for (uint32_t i = 0; i < buf_len_half; i++) {
+    this->data(this->buffer_[i]);
+  }
+  delay(2);
+
+  // COMMAND DATA START TRANSMISSION 2  (RED)
+  this->command(0x26);
+  delay(2);
+  for (uint32_t i = buf_len_half; i < buf_len_half * 2u; i++) {
+    this->data(this->buffer_[i]);
+  }
+  this->command(0x22);
+  this->data(0xf7);
+  this->command(0x20);
+  this->wait_until_idle_();
+
+  this->deep_sleep();
+}
+int WaveshareEPaper1P54InBV2::get_height_internal() { return 200; }
+int WaveshareEPaper1P54InBV2::get_width_internal() { return 200; }
+void WaveshareEPaper1P54InBV2::dump_config() {
+  LOG_DISPLAY("", "Waveshare E-Paper", this);
+  ESP_LOGCONFIG(TAG, "  Model: 1.54in V2 B");
+  LOG_PIN("  Reset Pin: ", this->reset_pin_);
+  LOG_PIN("  DC Pin: ", this->dc_pin_);
+  LOG_PIN("  Busy Pin: ", this->busy_pin_);
+  LOG_UPDATE_INTERVAL(this);
+}
+
+
+
+// ========================================================
 //                          2.7inch_e-paper_b
 // ========================================================
 // Datasheet:

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -154,7 +154,8 @@ bool WaveshareEPaperBase::wait_until_idle_() {
   }
 
   const uint32_t start = millis();
-  while (!this->busy_pin_->digital_read()) {
+  while (boolt test = this->busy_pin_->digital_read()) {
+    ESP_LOGD(TAG, "BUSY PIN is %d", test);
     if (millis() - start > this->idle_timeout_()) {
       ESP_LOGE(TAG, "Timeout while displaying image!");
       return false;

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -154,7 +154,7 @@ bool WaveshareEPaperBase::wait_until_idle_() {
   }
 
   const uint32_t start = millis();
-  while (this->busy_pin_->digital_read()) {
+  while (!this->busy_pin_->digital_read()) {
     if (millis() - start > this->idle_timeout_()) {
       ESP_LOGE(TAG, "Timeout while displaying image!");
       return false;

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -814,8 +814,8 @@ void WaveshareEPaper2P7InV2::dump_config() {
 //                          1.45inch_v2_e-paper_b
 // ========================================================
 // Datasheet:
-//  - 
-//  - 
+//  - https://files.waveshare.com/upload/9/9e/1.54inch-e-paper-b-v2-specification.pdf
+//  - https://www.waveshare.com/wiki/1.54inch_e-Paper_Module_(B)_Manual
 
 void WaveshareEPaper1P54InBV2::initialize(){
   this->reset_();

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -830,23 +830,23 @@ void WaveshareEPaper1P54InBV2::initialize() {
   this->data(0x00);
   this->data(0x01);
 
-  this->command(0x11);  //data entry mode
+  this->command(0x11);  // data entry mode
   this->data(0x01);
 
-  this->command(0x44);  //set Ram-X address start/end position
+  this->command(0x44);  // set Ram-X address start/end position
   this->data(0x00);
-  this->data(0x18);  //0x18-->(24+1)*8=200
+  this->data(0x18);  // 0x18-->(24+1)*8=200
 
-  this->command(0x45);  //set Ram-Y address start/end position
-  this->data(0xC7);  //0xC7-->(199+1)=200
+  this->command(0x45);  // set Ram-Y address start/end position
+  this->data(0xC7);  // 0xC7-->(199+1)=200
   this->data(0x00);
   this->data(0x00);
   this->data(0x00);
 
-  this->command(0x3C);  //BorderWavefrom
+  this->command(0x3C);  // BorderWavefrom
   this->data(0x05);
 
-  this->command(0x18);  //Read built-in temperature sensor
+  this->command(0x18);  // Read built-in temperature sensor
   this->data(0x80);
 
   this->command(0x4E);  // set RAM x address count to 0;

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -154,13 +154,15 @@ bool WaveshareEPaperBase::wait_until_idle_() {
   }
 
   const uint32_t start = millis();
-  while (boolt test = this->busy_pin_->digital_read()) {
+  boolt test = this->busy_pin_->digital_read()
+  while (test) {
     ESP_LOGD(TAG, "BUSY PIN is %d", test);
     if (millis() - start > this->idle_timeout_()) {
       ESP_LOGE(TAG, "Timeout while displaying image!");
       return false;
     }
     delay(1);
+    test = this->busy_pin_->digital_read()
   }
   return true;
 }

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -869,7 +869,7 @@ void HOT WaveshareEPaper1P54InBV2::display(){
   this->initialize();
 
   // COMMAND DATA START TRANSMISSION 1 (BLACK)
-  this->command(24);
+  this->command(0x24);
   delay(2);
   for (uint32_t i = 0; i < buf_len_half; i++) {
     this->data(this->buffer_[i]);

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -154,7 +154,7 @@ bool WaveshareEPaperBase::wait_until_idle_() {
   }
 
   const uint32_t start = millis();
-  
+
   while (bool test = this->busy_pin_->digital_read()) {
     if (millis() - start > this->idle_timeout_()) {
       ESP_LOGE(TAG, "Timeout while displaying image!");
@@ -645,7 +645,7 @@ static const uint8_t LUT_BLACK_TO_BLACK_2_7[42] = {
 };
 
 void WaveshareEPaper2P7In::initialize() {
-  
+
   // command power setting
   this->command(0x01);
   this->data(0x03);  // VDS_EN, VDG_EN
@@ -817,7 +817,7 @@ void WaveshareEPaper2P7InV2::dump_config() {
 //  - https://files.waveshare.com/upload/9/9e/1.54inch-e-paper-b-v2-specification.pdf
 //  - https://www.waveshare.com/wiki/1.54inch_e-Paper_Module_(B)_Manual
 
-void WaveshareEPaper1P54InBV2::initialize(){
+void WaveshareEPaper1P54InBV2::initialize() {
   this->reset_();
 
   this->wait_until_idle_();
@@ -830,28 +830,28 @@ void WaveshareEPaper1P54InBV2::initialize(){
   this->data(0x00);
   this->data(0x01);
 
-  this->command(0x11); //data entry mode       
+  this->command(0x11);  //data entry mode
   this->data(0x01);
 
-  this->command(0x44); //set Ram-X address start/end position   
+  this->command(0x44);  //set Ram-X address start/end position
   this->data(0x00);
-  this->data(0x18);    //0x18-->(24+1)*8=200
+  this->data(0x18);  //0x18-->(24+1)*8=200
 
-  this->command(0x45); //set Ram-Y address start/end position          
-  this->data(0xC7);    //0xC7-->(199+1)=200
+  this->command(0x45);  //set Ram-Y address start/end position
+  this->data(0xC7);  //0xC7-->(199+1)=200
   this->data(0x00);
   this->data(0x00);
   this->data(0x00);
 
-  this->command(0x3C); //BorderWavefrom
+  this->command(0x3C);  //BorderWavefrom
   this->data(0x05);
 
-  this->command(0x18); //Read built-in temperature sensor
+  this->command(0x18);  //Read built-in temperature sensor
   this->data(0x80);
 
-  this->command(0x4E);   // set RAM x address count to 0;
+  this->command(0x4E);  // set RAM x address count to 0;
   this->data(0x00);
-  this->command(0x4F);   // set RAM y address count to 0X199;    
+  this->command(0x4F);  // set RAM y address count to 0X199;
   this->data(0xC7);
   this->data(0x00);
 
@@ -859,7 +859,7 @@ void WaveshareEPaper1P54InBV2::initialize(){
 
 }
 
-void HOT WaveshareEPaper1P54InBV2::display(){
+void HOT WaveshareEPaper1P54InBV2::display() {
   uint32_t buf_len_half = this->get_buffer_length_() >> 1;
   this->initialize();
 
@@ -894,8 +894,6 @@ void WaveshareEPaper1P54InBV2::dump_config() {
   LOG_PIN("  Busy Pin: ", this->busy_pin_);
   LOG_UPDATE_INTERVAL(this);
 }
-
-
 
 // ========================================================
 //                          2.7inch_e-paper_b

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -817,10 +817,10 @@ void WaveshareEPaper2P7InV2::dump_config() {
 //  - 
 
 void WaveshareEPaper1P54InBV2::initialize(){
-  ESP_LOGI(TAG, 'Reseting Display');
+  ESP_LOGD(TAG, 'Reseting Display');
   this->reset_();
 
-  ESP_LOGI(TAG, 'Initializing Display');
+  ESP_LOGD(TAG, 'Initializing Display');
   this->wait_until_idle_();
 
   this->command(0x12);
@@ -856,9 +856,9 @@ void WaveshareEPaper1P54InBV2::initialize(){
   this->data(0xC7);
   this->data(0x00);
 
-  ESP_LOGI(TAG, 'Waiting for idle');
+  ESP_LOGD(TAG, 'Waiting for idle');
   this->wait_until_idle_();
-  ESP_LOGI(TAG, 'Waiting done');
+  ESP_LOGD(TAG, 'Waiting done');
 
 }
 

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -872,7 +872,7 @@ void HOT WaveshareEPaper1P54InBV2::display(){
   this->command(0x24);
   delay(2);
   for (uint32_t i = 0; i < buf_len_half; i++) {
-    this->data(~this->buffer_[i]);
+    this->data(this->buffer_[i]);
   }
   delay(2);
 
@@ -880,7 +880,7 @@ void HOT WaveshareEPaper1P54InBV2::display(){
   this->command(0x26);
   delay(2);
   for (uint32_t i = buf_len_half; i < buf_len_half * 2u; i++) {
-    this->data(~this->buffer_[i]);
+    this->data(this->buffer_[i]);
   }
   this->command(0x22);
   this->data(0xf7);

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -156,7 +156,6 @@ bool WaveshareEPaperBase::wait_until_idle_() {
   const uint32_t start = millis();
   
   while (bool test = this->busy_pin_->digital_read()) {
-    ESP_LOGD(TAG, "BUSY PIN is %d", test);
     if (millis() - start > this->idle_timeout_()) {
       ESP_LOGE(TAG, "Timeout while displaying image!");
       return false;
@@ -819,10 +818,8 @@ void WaveshareEPaper2P7InV2::dump_config() {
 //  - 
 
 void WaveshareEPaper1P54InBV2::initialize(){
-  ESP_LOGD(TAG, "Reseting Display");
   this->reset_();
 
-  ESP_LOGD(TAG, "Initializing Display");
   this->wait_until_idle_();
 
   this->command(0x12);
@@ -858,9 +855,7 @@ void WaveshareEPaper1P54InBV2::initialize(){
   this->data(0xC7);
   this->data(0x00);
 
-  ESP_LOGD(TAG, "Waiting for idle");
   this->wait_until_idle_();
-  ESP_LOGD(TAG, "Waiting done");
 
 }
 

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -154,15 +154,14 @@ bool WaveshareEPaperBase::wait_until_idle_() {
   }
 
   const uint32_t start = millis();
-  boolt test = this->busy_pin_->digital_read()
-  while (test) {
+  
+  while (bool test = this->busy_pin_->digital_read()) {
     ESP_LOGD(TAG, "BUSY PIN is %d", test);
     if (millis() - start > this->idle_timeout_()) {
       ESP_LOGE(TAG, "Timeout while displaying image!");
       return false;
     }
     delay(1);
-    test = this->busy_pin_->digital_read()
   }
   return true;
 }

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -811,7 +811,7 @@ void WaveshareEPaper2P7InV2::dump_config() {
 }
 
 // ========================================================
-//                          1.45inch_v2_e-paper_b
+//                          1.54inch_v2_e-paper_b
 // ========================================================
 // Datasheet:
 //  - https://files.waveshare.com/upload/9/9e/1.54inch-e-paper-b-v2-specification.pdf

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -880,7 +880,7 @@ void HOT WaveshareEPaper1P54InBV2::display(){
   this->command(0x26);
   delay(2);
   for (uint32_t i = buf_len_half; i < buf_len_half * 2u; i++) {
-    this->data(~this->buffer_[i]);
+    this->data(this->buffer_[i]);
   }
   this->command(0x22);
   this->data(0xf7);

--- a/esphome/components/waveshare_epaper/waveshare_epaper.h
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.h
@@ -167,7 +167,7 @@ enum WaveshareEPaperTypeBModel {
 };
 
 class WaveshareEPaper1P54InBV2 : public WaveshareEPaperBWR {
-  public:
+ public:
   void initialize() override;
 
   void display() override;

--- a/esphome/components/waveshare_epaper/waveshare_epaper.h
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.h
@@ -166,6 +166,24 @@ enum WaveshareEPaperTypeBModel {
   WAVESHARE_EPAPER_13_3_IN_K,
 };
 
+class WaveshareEPaper1P54InBV2 : public WaveshareEPaperBWR {
+  public:
+  void initialize() override;
+
+  void display() override;
+
+  void dump_config() override;
+
+  void deep_sleep() override {
+    this->command(0x10);
+    this->data(0x01);
+  }
+
+ protected:
+  int get_width_internal() override;
+  int get_height_internal() override;
+};
+
 class WaveshareEPaper2P7In : public WaveshareEPaper {
  public:
   void initialize() override;


### PR DESCRIPTION
# Implementation for the Waveshare 1.54 in V2 B Display

Add Waveshare 1.54 in V2 B Display support to the waveshare_epaper component. 

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#4025

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
```yaml
# Example config.yaml  
font:
  - file: 'fonts/Comic Sans MS.ttf'
    id: font1
    size: 12

color:
  - id: my_red
    red: 100%

spi:
  mosi_pin: GPIO10
  miso_pin: GPIO9
  clk_pin: GPIO8

display:
  - platform: waveshare_epaper
    cs_pin: GPIO20
    dc_pin: GPIO21
    reset_pin: GPIO5
    busy_pin:
      number: GPIO4
      inverted: False
    model: 1.54.inv2-b
    reset_duration: 2ms
    rotation: 90°
    update_interval: 60s
    lambda: |-
      it.print(10,10, id(font1), id(my_red), "Hello World");
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).