### PR TITLE
[http_request] Fix follow_redirects on arduino

### DIFF
--- a/esphome/components/http_request/http_request_arduino.cpp
+++ b/esphome/components/http_request/http_request_arduino.cpp
@@ -32,6 +32,13 @@ std::shared_ptr<HttpContainer> HttpRequestArduino::start(std::string url, std::s
 
   watchdog::WatchdogManager wdm(this->get_watchdog_timeout());
 
+  if (this->follow_redirects_) {
+    container->client_.setFollowRedirects(HTTPC_FORCE_FOLLOW_REDIRECTS);
+    container->client_.setRedirectLimit(this->redirect_limit_);
+  } else {
+    container->client_.setFollowRedirects(HTTPC_DISABLE_FOLLOW_REDIRECTS);
+  }
+
 #if defined(USE_ESP8266)
   std::unique_ptr<WiFiClient> stream_ptr;
 #ifdef USE_HTTP_REQUEST_ESP8266_HTTPS
@@ -59,8 +66,6 @@ std::shared_ptr<HttpContainer> HttpRequestArduino::start(std::string url, std::s
                   "in your YAML, or use HTTPS");
   }
 #endif  // USE_ARDUINO_VERSION_CODE
-
-  container->client_.setFollowRedirects(HTTPC_STRICT_FOLLOW_REDIRECTS);
   bool status = container->client_.begin(*stream_ptr, url.c_str());
 
 #elif defined(USE_RP2040)


### PR DESCRIPTION
# What does this implement/fix?

On the http_request arduino implementation, the "follow_redirects" option was only being set in an "#if defined(ESP8266)" block; which prevented ESP32 boards from following redirects.

Also changed the option from `HTTPC_STRICT_FOLLOW_REDIRECTS` to `HTTPC_FORCE_FOLLOW_REDIRECTS`, since in some cases the "STRICT" version would not follow the redirect as the standard requires user confirmation for that.

Finally, added the missing code to actually use the `redirect_limit` if present.

<!-- Quick description and explanation of changes -->

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
http_request:
  follow_redirects: true

button:
  - platform: template
     on_press:
        - http_request.get: https://some.url/that/redirects

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
