### PR TITLE
Update mitsubishi.cpp

### DIFF
--- a/esphome/components/mitsubishi/mitsubishi.cpp
+++ b/esphome/components/mitsubishi/mitsubishi.cpp
@@ -52,6 +52,7 @@ const uint8_t MITSUBISHI_BYTE16 = 0X00;
 
 climate::ClimateTraits MitsubishiClimate::traits() {
   auto traits = climate::ClimateTraits();
+  traits.set_supports_current_temperature(this->sensor_ != nullptr);
   traits.set_supports_action(false);
   traits.set_visual_min_temperature(MITSUBISHI_TEMP_MIN);
   traits.set_visual_max_temperature(MITSUBISHI_TEMP_MAX);


### PR DESCRIPTION
The "Current Temperature" appears as 0 degrees in HomeAssistant. Adding this line shows correct values.

Source: https://community.home-assistant.io/t/ha-sensor-shows-0-degrees-in-frontend-of-esphome-ir-remote-climate-card/714618/7

# What does this implement/fix?
The current temperature reported in HomeAssistant Dashboard appears to be 0 without this line. On adding this, the correct temperatures are being reported.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
