### PR TITLE
Fix pmsa003i cold boot marked as failed on ESP32 et al

### DIFF
--- a/esphome/components/pmsa003i/pmsa003i.cpp
+++ b/esphome/components/pmsa003i/pmsa003i.cpp
@@ -15,7 +15,7 @@ void PMSA003IComponent::setup() {
   bool successful_read = this->read_data_(&data);
 
   if (!successful_read) {
-    for (int i = 0; i < 4; i++) {
+    for (int i = 0; i < 3; i++) {
       ESP_LOGW(TAG, "Setup read failed. Trying again.");
       successful_read = this->read_data_(&data);
       if (successful_read) {

--- a/esphome/components/pmsa003i/pmsa003i.cpp
+++ b/esphome/components/pmsa003i/pmsa003i.cpp
@@ -17,12 +17,12 @@ void PMSA003IComponent::setup() {
   if (!successful_read) {
     for (int i = 0; i < 10; i++) {
       ESP_LOGW(TAG, "Setup read failed. Trying again.");
-      delay(100);
+      delay(100); // NOLINT
       successful_read = this->read_data_(&data);
       if (successful_read) {
         break;
       }
-    } 
+    }
   }
 
   if (!successful_read) {

--- a/esphome/components/pmsa003i/pmsa003i.cpp
+++ b/esphome/components/pmsa003i/pmsa003i.cpp
@@ -15,9 +15,8 @@ void PMSA003IComponent::setup() {
   bool successful_read = this->read_data_(&data);
 
   if (!successful_read) {
-    for (int i = 0; i < 10; i++) {
+    for (int i = 0; i < 4; i++) {
       ESP_LOGW(TAG, "Setup read failed. Trying again.");
-      delay(100);  // NOLINT
       successful_read = this->read_data_(&data);
       if (successful_read) {
         break;

--- a/esphome/components/pmsa003i/pmsa003i.cpp
+++ b/esphome/components/pmsa003i/pmsa003i.cpp
@@ -15,8 +15,7 @@ void PMSA003IComponent::setup() {
   bool successful_read = this->read_data_(&data);
 
   if (!successful_read) {
-    for (int i = 0; i < 2; i++) {
-      ESP_LOGW(TAG, "_Setup read failed. Trying again.");
+    for (int i = 0; i < 2; i++) {      
       successful_read = this->read_data_(&data);
       if (successful_read) {
         break;

--- a/esphome/components/pmsa003i/pmsa003i.cpp
+++ b/esphome/components/pmsa003i/pmsa003i.cpp
@@ -15,7 +15,7 @@ void PMSA003IComponent::setup() {
   bool successful_read = this->read_data_(&data);
 
   if (!successful_read) {
-    for (int i = 0; i < 4; i++) {      
+    for (int i = 0; i < 2; i++) {      
       successful_read = this->read_data_(&data);
       if (successful_read) {
         break;

--- a/esphome/components/pmsa003i/pmsa003i.cpp
+++ b/esphome/components/pmsa003i/pmsa003i.cpp
@@ -15,7 +15,7 @@ void PMSA003IComponent::setup() {
   bool successful_read = this->read_data_(&data);
 
   if (!successful_read) {
-    for (int i = 0; i < 3; i++) {      
+    for (int i = 0; i < 3; i++) {
       successful_read = this->read_data_(&data);
       if (successful_read) {
         break;

--- a/esphome/components/pmsa003i/pmsa003i.cpp
+++ b/esphome/components/pmsa003i/pmsa003i.cpp
@@ -1,6 +1,5 @@
 #include "pmsa003i.h"
 #include "esphome/core/log.h"
-#include "esphome/core/hal.h"
 #include <cstring>
 
 namespace esphome {

--- a/esphome/components/pmsa003i/pmsa003i.cpp
+++ b/esphome/components/pmsa003i/pmsa003i.cpp
@@ -15,7 +15,7 @@ void PMSA003IComponent::setup() {
   bool successful_read = this->read_data_(&data);
 
   if (!successful_read) {
-    for (int i = 0; i < 2; i++) {      
+    for (int i = 0; i < 3; i++) {      
       successful_read = this->read_data_(&data);
       if (successful_read) {
         break;

--- a/esphome/components/pmsa003i/pmsa003i.cpp
+++ b/esphome/components/pmsa003i/pmsa003i.cpp
@@ -19,7 +19,7 @@ void PMSA003IComponent::setup() {
       ESP_LOGW(TAG, "Setup read failed. Trying again.");
       delay(100);
       successful_read = this->read_data_(&data);
-      if (succussful_read) {
+      if (successful_read) {
         break;
       }
     } 

--- a/esphome/components/pmsa003i/pmsa003i.cpp
+++ b/esphome/components/pmsa003i/pmsa003i.cpp
@@ -1,5 +1,6 @@
 #include "pmsa003i.h"
 #include "esphome/core/log.h"
+#include "esphome/core/hal.h"
 #include <cstring>
 
 namespace esphome {
@@ -12,6 +13,17 @@ void PMSA003IComponent::setup() {
 
   PM25AQIData data;
   bool successful_read = this->read_data_(&data);
+
+  if (!successful_read) {
+    for (int i = 0; i < 10; i++) {
+      ESP_LOGW(TAG, "Setup read failed. Trying again.");
+      delay(100);
+      successful_read = this->read_data_(&data);
+      if (succussful_read) {
+        break;
+      }
+    } 
+  }
 
   if (!successful_read) {
     this->mark_failed();

--- a/esphome/components/pmsa003i/pmsa003i.cpp
+++ b/esphome/components/pmsa003i/pmsa003i.cpp
@@ -15,7 +15,7 @@ void PMSA003IComponent::setup() {
   bool successful_read = this->read_data_(&data);
 
   if (!successful_read) {
-    for (int i = 0; i < 2; i++) {      
+    for (int i = 0; i < 4; i++) {      
       successful_read = this->read_data_(&data);
       if (successful_read) {
         break;

--- a/esphome/components/pmsa003i/pmsa003i.cpp
+++ b/esphome/components/pmsa003i/pmsa003i.cpp
@@ -17,7 +17,7 @@ void PMSA003IComponent::setup() {
   if (!successful_read) {
     for (int i = 0; i < 10; i++) {
       ESP_LOGW(TAG, "Setup read failed. Trying again.");
-      delay(100); // NOLINT
+      delay(100);  // NOLINT
       successful_read = this->read_data_(&data);
       if (successful_read) {
         break;

--- a/esphome/components/pmsa003i/pmsa003i.cpp
+++ b/esphome/components/pmsa003i/pmsa003i.cpp
@@ -15,8 +15,8 @@ void PMSA003IComponent::setup() {
   bool successful_read = this->read_data_(&data);
 
   if (!successful_read) {
-    for (int i = 0; i < 3; i++) {
-      ESP_LOGW(TAG, "Setup read failed. Trying again.");
+    for (int i = 0; i < 2; i++) {
+      ESP_LOGW(TAG, "_Setup read failed. Trying again.");
       successful_read = this->read_data_(&data);
       if (successful_read) {
         break;


### PR DESCRIPTION
# What does this implement/fix?

On ESP32 (and likely other faster devices), the pmsa003i gets marked as failed when cold booted.  See https://github.com/esphome/issues/issues/6031 for full description.

This is similar to the issue for the pn532, which required a second attempt and check during setup.  However, in testing, I've observed between 2-4 failed attempts on an Olimex ESP32-POE-ISO board before the pmsa003i responds.  Since it might take more attempts on faster/newer devices, I gave it some buffer in terms of attempts (10 max).  Once the read works, it continues on with normal setup.  So, if the device is functioning, the impact will be absolutely minimal.  If the device is legitimately failed or disconnected, it will have a minor impact on setup time.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes  https://github.com/esphome/issues/issues/6031

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
```yaml
esphome:
  name: test-esp32
  friendly_name: test_esp32

esp32:
  board: esp32dev
  framework:
    type: arduino

# Enable logging
logger:
  level: VERY_VERBOSE

i2c:
  sda: GPIO13
  scl: GPIO16
  scan: true

external_components:
  - source:
      type: git
      url: https://github.com/z3liff/esphome
      ref: dev
    components: [ pmsa003i ]

sensor:
  - platform: pmsa003i
    pm_1_0:
      name: "PM1.0"
    pm_2_5:
      name: "PM2.5"
    pm_10_0:
      name: "PM10.0"
    pmc_0_3:
      name: "PMC >0.3µm"
    pmc_0_5:
      name: "PMC >0.5µm"
    pmc_1_0:
      name: "PMC >1µm"
    pmc_2_5:
      name: "PMC >2.5µm"
    pmc_5_0:
      name: "PMC >5µm"
    pmc_10_0:
      name: "PMC >10µm"
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
