### PR TITLE
bme680_bsec: use BOSCH BSEC Library 1.8.1492

### DIFF
--- a/esphome/components/bme680_bsec/__init__.py
+++ b/esphome/components/bme680_bsec/__init__.py
@@ -1,7 +1,7 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import i2c, esp32
-from esphome.const import CONF_ID
+from esphome.const import CONF_ID, CONF_SAMPLE_RATE, CONF_TEMPERATURE_OFFSET
 
 CODEOWNERS = ["@trvrnrth"]
 DEPENDENCIES = ["i2c"]
@@ -9,10 +9,8 @@ AUTO_LOAD = ["sensor", "text_sensor"]
 MULTI_CONF = True
 
 CONF_BME680_BSEC_ID = "bme680_bsec_id"
-CONF_TEMPERATURE_OFFSET = "temperature_offset"
 CONF_IAQ_MODE = "iaq_mode"
 CONF_SUPPLY_VOLTAGE = "supply_voltage"
-CONF_SAMPLE_RATE = "sample_rate"
 CONF_STATE_SAVE_INTERVAL = "state_save_interval"
 
 bme680_bsec_ns = cg.esphome_ns.namespace("bme680_bsec")

--- a/esphome/components/bme680_bsec/__init__.py
+++ b/esphome/components/bme680_bsec/__init__.py
@@ -1,7 +1,7 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import i2c, esp32
-from esphome.const import CONF_ID, CONF_SAMPLE_RATE, CONF_TEMPERATURE_OFFSET
+from esphome.const import CONF_ID
 
 CODEOWNERS = ["@trvrnrth"]
 DEPENDENCIES = ["i2c"]
@@ -9,8 +9,10 @@ AUTO_LOAD = ["sensor", "text_sensor"]
 MULTI_CONF = True
 
 CONF_BME680_BSEC_ID = "bme680_bsec_id"
+CONF_TEMPERATURE_OFFSET = "temperature_offset"
 CONF_IAQ_MODE = "iaq_mode"
 CONF_SUPPLY_VOLTAGE = "supply_voltage"
+CONF_SAMPLE_RATE = "sample_rate"
 CONF_STATE_SAVE_INTERVAL = "state_save_interval"
 
 bme680_bsec_ns = cg.esphome_ns.namespace("bme680_bsec")
@@ -85,4 +87,4 @@ async def to_code(config):
     cg.add_library("SPI", None)
 
     cg.add_define("USE_BSEC")
-    cg.add_library("boschsensortec/BSEC Software Library", "1.6.1480")
+    cg.add_library("boschsensortec/BSEC Software Library", "1.8.1492")

--- a/esphome/components/bme680_bsec/bme680_bsec.h
+++ b/esphome/components/bme680_bsec/bme680_bsec.h
@@ -58,9 +58,9 @@ class BME680BSECComponent : public Component, public i2c::I2CDevice {
   void set_breath_voc_equivalent_sensor(sensor::Sensor *sensor) { this->breath_voc_equivalent_sensor_ = sensor; }
 
   static std::vector<BME680BSECComponent *> instances;
-  static int8_t read_bytes_wrapper(uint8_t devid, uint8_t a_register, uint8_t *data, uint16_t len);
-  static int8_t write_bytes_wrapper(uint8_t devid, uint8_t a_register, uint8_t *data, uint16_t len);
-  static void delay_ms(uint32_t period);
+  static BME68X_INTF_RET_TYPE read_bytes_wrapper(uint8_t reg_addr, uint8_t *reg_data, uint32_t len, void *ptr);
+  static BME68X_INTF_RET_TYPE write_bytes_wrapper(uint8_t reg_addr, const uint8_t *reg_data, uint32_t len, void *ptr);
+  static void delay_us(uint32_t period, void *ptr);
 
   void setup() override;
   void dump_config() override;
@@ -95,9 +95,9 @@ class BME680BSECComponent : public Component, public i2c::I2CDevice {
   void queue_push_(std::function<void()> &&f) { this->queue_.push(std::move(f)); }
 
   static uint8_t work_buffer_[BSEC_MAX_WORKBUFFER_SIZE];
-  struct bme680_dev bme680_;
+  struct bme68x_dev bme68x_;
   bsec_library_return_t bsec_status_{BSEC_OK};
-  int8_t bme680_status_{BME680_OK};
+  int8_t bme68x_status_{BME68X_OK};
 
   int64_t last_time_ms_{0};
   uint32_t millis_overflow_counter_{0};
@@ -109,8 +109,8 @@ class BME680BSECComponent : public Component, public i2c::I2CDevice {
   uint8_t bsec_state_data_[BSEC_MAX_STATE_BLOB_SIZE];  // This is the current snapshot of the BSEC library state
   ESPPreferenceObject bsec_state_;
   uint32_t state_save_interval_ms_{21600000};  // 6 hours - 4 times a day
-  uint32_t last_state_save_ms_ = 0;
-  bsec_bme_settings_t bme680_settings_;
+  uint32_t last_state_save_ms_{0};
+  bsec_bme_settings_t bseclib_settings_;
 
   std::string device_id_;
   float temperature_offset_{0};


### PR DESCRIPTION
# What does this implement/fix?

Use BOSCH BSEC Library version 1.8.1492, which includes some fixes and adds support for BME688

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes [#2110](https://github.com/esphome/feature-requests/issues/2110) [#2449](https://github.com/esphome/feature-requests/issues/2449)


## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx


## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Test with new BME688 sensor (I don't own a BME688)
  - [ ] Test on ESP8266 (I don't own a ESP8266)
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs) stating that this component supports the BME688 sensor too (to be added after confirmation from tests).
