### PR TITLE
Add default icon to restart button

### DIFF
--- a/esphome/components/restart/button/__init__.py
+++ b/esphome/components/restart/button/__init__.py
@@ -5,6 +5,7 @@ from esphome.const import (
     CONF_ID,
     DEVICE_CLASS_RESTART,
     ENTITY_CATEGORY_CONFIG,
+    ICON_RESTART,
 )
 
 restart_ns = cg.esphome_ns.namespace("restart")
@@ -12,6 +13,7 @@ RestartButton = restart_ns.class_("RestartButton", button.Button, cg.Component)
 
 CONFIG_SCHEMA = button.button_schema(
     RestartButton,
+    icon=ICON_RESTART,
     device_class=DEVICE_CLASS_RESTART,
     entity_category=ENTITY_CATEGORY_CONFIG,
 ).extend(cv.COMPONENT_SCHEMA)


### PR DESCRIPTION
# What does this implement/fix?

Added the same default icon to the restart button as the restart switch

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).