### PR TITLE
Update esp-idf i2c timeout unit conversion

### DIFF
--- a/esphome/components/i2c/i2c_bus_esp_idf.cpp
+++ b/esphome/components/i2c/i2c_bus_esp_idf.cpp
@@ -50,13 +50,14 @@ void IDFI2CBus::setup() {
       ESP_LOGW(TAG, "i2c timeout of %" PRIu32 "us greater than max of 13ms on esp-idf, setting to max", timeout_);
       timeout_ = 13000;
     }
-    err = i2c_set_timeout(port_, timeout_ / (APB_CLK_FREQ / 1000000));
+    uint32_t timeout_ticks = timeout_ / (APB_CLK_FREQ / 1000000);
+    err = i2c_set_timeout(port_, timeout_ticks);
     if (err != ESP_OK) {
       ESP_LOGW(TAG, "i2c_set_timeout failed: %s", esp_err_to_name(err));
       this->mark_failed();
       return;
     } else {
-      ESP_LOGV(TAG, "i2c_timeout set to %" PRIu32 " ticks (%" PRIu32 " us)", timeout_ / (APB_CLK_FREQ / 1000000), timeout_);
+      ESP_LOGV(TAG, "i2c_timeout set to %" PRIu32 " ticks (%" PRIu32 " us)", timeout_ticks, timeout_);
     }
   }
   err = i2c_driver_install(port_, I2C_MODE_MASTER, 0, 0, ESP_INTR_FLAG_IRAM);

--- a/esphome/components/i2c/i2c_bus_esp_idf.cpp
+++ b/esphome/components/i2c/i2c_bus_esp_idf.cpp
@@ -50,13 +50,13 @@ void IDFI2CBus::setup() {
       ESP_LOGW(TAG, "i2c timeout of %" PRIu32 "us greater than max of 13ms on esp-idf, setting to max", timeout_);
       timeout_ = 13000;
     }
-    err = i2c_set_timeout(port_, timeout_ * 80);  // unit: APB 80MHz clock cycle
+    err = i2c_set_timeout(port_, timeout_ / (APB_CLK_FREQ / 1000000));
     if (err != ESP_OK) {
       ESP_LOGW(TAG, "i2c_set_timeout failed: %s", esp_err_to_name(err));
       this->mark_failed();
       return;
     } else {
-      ESP_LOGV(TAG, "i2c_timeout set to %" PRIu32 " ticks (%" PRIu32 " us)", timeout_ * 80, timeout_);
+      ESP_LOGV(TAG, "i2c_timeout set to %" PRIu32 " ticks (%" PRIu32 " us)", timeout_ / (APB_CLK_FREQ / 1000000), timeout_);
     }
   }
   err = i2c_driver_install(port_, I2C_MODE_MASTER, 0, 0, ESP_INTR_FLAG_IRAM);

--- a/tests/components/i2c/test.esp32-c3-idf.yaml
+++ b/tests/components/i2c/test.esp32-c3-idf.yaml
@@ -2,3 +2,6 @@ i2c:
   - id: i2c_i2c
     scl: 5
     sda: 4
+    scan: true
+    frequency: "280kHz"
+    timeout: "1000us"

--- a/tests/components/i2c/test.esp32-idf.yaml
+++ b/tests/components/i2c/test.esp32-idf.yaml
@@ -2,3 +2,6 @@ i2c:
   - id: i2c_i2c
     scl: 16
     sda: 17
+    scan: true
+    frequency: "280kHz"
+    timeout: "1000us"


### PR DESCRIPTION
# What does this implement/fix?

When using ESP-IDF framework with the i2c component, setting any timeout value higher than zero on variants esp32c6 and esp32h2 results in the error `i2c timing value error`.

The I2C component integration with ESP-IDF multiplies the `timeout` value (in us) by 80 before passing it to `i2c_set_timeout()`. According to the [ESP-IDF documentation](https://docs.espressif.com/projects/esp-idf/en/v4.4.7/esp32/api-reference/peripherals/i2c.html#_CPPv415i2c_set_timeout10i2c_port_ti), the unit of the timeout value should be APB 80 MHz clock cycles. However, different ESP32 variants have different Advanced Peripheral Bus clock frequencies (ex: the [C6](https://github.com/espressif/esp-idf/blob/5ca9f2a49aaabbfaf726da1cc3597c0edb3c4d37/components/soc/esp32c6/include/soc/soc.h#L142) and [H2](https://github.com/espressif/esp-idf/blob/5ca9f2a49aaabbfaf726da1cc3597c0edb3c4d37/components/soc/esp32h2/include/soc/soc.h#L140) have 40 MHz and 32 MHz APB cloud frequencies respectively).

Testing with the C6, I noted that the timeout value returned by `i2c_get_timeout()` defaults to 10 (400 us @ 40 MHz). Further testing showed that the valid range of values that could be passed to `i2c_set_timeout()` were 1 to 31 (inclusive) (40 us - 1240 us).

This change updates the `i2c_set_timeout()` call to divide by the selected variant's `APB_CLK_FREQ` (in MHz) instead of multiplying by 80 MHz, allowing the timeout value specified in the ESPHome config to accurately reflect the value set on the ESP32.

This PR could alter the behavior of ESPHome projects that meet the following conditions:
* Using ESP-IDF framework
* Using ESP32
* Using `i2c` component with a non-zero value for `timeout`

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
esphome:
  name: "esp-idf-i2c-timeout-test"
  platformio_options:
    platform: "https://github.com/platformio/platform-espressif32/archive/refs/tags/v6.7.0.zip"

esp32:
  board: "esp32-c6-devkitm-1"
  variant: "esp32c6"
  flash_size: "4MB"
  framework:
    type: "esp-idf"
    version: "5.2.2"
    sdkconfig_options:
      CONFIG_ESPTOOLPY_FLASHSIZE_4MB: "y"

i2c:
- sda: "GPIO10"
  scl: "GPIO11"
  scan: true
  frequency: "280kHz"
  timeout: "1240us"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
