### PR TITLE
[online_image] add option to show placeholder while downloading

### DIFF
--- a/esphome/components/online_image/__init__.py
+++ b/esphome/components/online_image/__init__.py
@@ -154,8 +154,7 @@ async def to_code(config):
 
     cg.add(var.set_transparency(transparent))
 
-    placeholder_id = config.get(CONF_PLACEHOLDER, None)
-    if placeholder_id:
+    if placeholder_id := config.get(CONF_PLACEHOLDER)
         placeholder = await cg.get_variable(placeholder_id)
         cg.add(var.set_placeholder(placeholder))
 

--- a/esphome/components/online_image/__init__.py
+++ b/esphome/components/online_image/__init__.py
@@ -154,7 +154,7 @@ async def to_code(config):
 
     cg.add(var.set_transparency(transparent))
 
-    if placeholder_id := config.get(CONF_PLACEHOLDER)
+    if placeholder_id := config.get(CONF_PLACEHOLDER):
         placeholder = await cg.get_variable(placeholder_id)
         cg.add(var.set_placeholder(placeholder))
 

--- a/esphome/components/online_image/__init__.py
+++ b/esphome/components/online_image/__init__.py
@@ -27,6 +27,7 @@ CODEOWNERS = ["@guillempages"]
 MULTI_CONF = True
 
 CONF_ON_DOWNLOAD_FINISHED = "on_download_finished"
+CONF_PLACEHOLDER = "placeholder"
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -73,6 +74,7 @@ ONLINE_IMAGE_SCHEMA = cv.Schema(
         #
         cv.Required(CONF_URL): cv.url,
         cv.Required(CONF_FORMAT): cv.enum(IMAGE_FORMAT, upper=True),
+        cv.Optional(CONF_PLACEHOLDER): cv.use_id(Image_),
         cv.Optional(CONF_BUFFER_SIZE, default=2048): cv.int_range(256, 65536),
         cv.Optional(CONF_ON_DOWNLOAD_FINISHED): automation.validate_automation(
             {
@@ -151,6 +153,11 @@ async def to_code(config):
     await cg.register_parented(var, config[CONF_HTTP_REQUEST_ID])
 
     cg.add(var.set_transparency(transparent))
+
+    placeholder_id = config.get(CONF_PLACEHOLDER, None)
+    if placeholder_id:
+        placeholder = await cg.get_variable(placeholder_id)
+        cg.add(var.set_placeholder(placeholder))
 
     for conf in config.get(CONF_ON_DOWNLOAD_FINISHED, []):
         trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)

--- a/esphome/components/online_image/online_image.cpp
+++ b/esphome/components/online_image/online_image.cpp
@@ -35,6 +35,14 @@ OnlineImage::OnlineImage(const std::string &url, int width, int height, ImageFor
   this->set_url(url);
 }
 
+void OnlineImage::draw(int x, int y, display::Display *display, Color color_on, Color color_off) {
+  if (this->data_start_) {
+    Image::draw(x, y, display, color_on, color_off);
+  } else if (this->placeholder_) {
+    this->placeholder_->draw(x, y, display, color_on, color_off);
+  }
+}
+
 void OnlineImage::release() {
   if (this->buffer_) {
     ESP_LOGD(TAG, "Deallocating old buffer...");

--- a/esphome/components/online_image/online_image.h
+++ b/esphome/components/online_image/online_image.h
@@ -50,6 +50,8 @@ class OnlineImage : public PollingComponent,
   OnlineImage(const std::string &url, int width, int height, ImageFormat format, image::ImageType type,
               uint32_t buffer_size);
 
+  void draw(int x, int y, display::Display *display, Color color_on, Color color_off) override;
+
   void update() override;
   void loop() override;
 
@@ -59,6 +61,14 @@ class OnlineImage : public PollingComponent,
       this->url_ = url;
     }
   }
+
+  /**
+   * @brief Set the image that needs to be shown as long as the downloaded image
+   *  is not available.
+   *
+   * @param placeholder Pointer to the (@link Image) to show as placeholder.
+   */
+  void set_placeholder(image::Image *placeholder) { this->placeholder_ = placeholder; }
 
   /**
    * Release the buffer storing the image. The image will need to be downloaded again
@@ -113,6 +123,7 @@ class OnlineImage : public PollingComponent,
   DownloadBuffer download_buffer_;
 
   const ImageFormat format_;
+  image::Image *placeholder_{nullptr};
 
   std::string url_{""};
 


### PR DESCRIPTION
# What does this implement/fix?

Add the possibility of showing a placeholder image while an online image has not been fully downloaded/decoded

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable)**

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#4102

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

esphome:
  # ...
  on_boot:
    then:
      - wait_until: api.connected
      - component.update: example_image
      - 
#For Arduino framework only; http_request needs to be explicitly added and configured:
http_request:
  verify_ssl: false

image:
  - file: mdi:close-box-outline
    resize: 120x120
    id: placeholder

online_image:
  - url: "https://www.example.org/image.png"
    id: example_image
    type: RGB565
    placeholder: placeholder
    on_download_finished:
      - component.update: my_display

display:
  id: my_display
  # ...
  lambda: |-
    it.image(0, 0, id(example_image));
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
