### PR TITLE
[http_request] allow basic auth for idf 

### DIFF
--- a/esphome/components/http_request/http_request_idf.cpp
+++ b/esphome/components/http_request/http_request_idf.cpp
@@ -52,6 +52,7 @@ std::shared_ptr<HttpContainer> HttpRequestIDF::start(std::string url, std::strin
   config.timeout_ms = this->timeout_;
   config.disable_auto_redirect = !this->follow_redirects_;
   config.max_redirection_count = this->redirect_limit_;
+  config.auth_type = HTTP_AUTH_TYPE_BASIC;
 #if CONFIG_MBEDTLS_CERTIFICATE_BUNDLE
   if (secure) {
     config.crt_bundle_attach = esp_crt_bundle_attach;


### PR DESCRIPTION
# What does this implement/fix?

Since the refactoring of the `http_request.ota` to use `http_request` code, it is no longer possible to use basic auth with esp-idf, as the documentation says at https://esphome.io/components/ota/http_request.html#id2  

(There is no issue with Arduino).

I simply added `config.auth_type = HTTP_AUTH_TYPE_BASIC`, and I tested that it had no effect if authentication is not used.


## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
