### PR TITLE
Drop max BLE client connections limitation

### DIFF
--- a/esphome/components/ble_client/__init__.py
+++ b/esphome/components/ble_client/__init__.py
@@ -65,9 +65,7 @@ CONF_ON_PASSKEY_NOTIFICATION = "on_passkey_notification"
 CONF_ON_NUMERIC_COMPARISON_REQUEST = "on_numeric_comparison_request"
 CONF_AUTO_CONNECT = "auto_connect"
 
-# Espressif platformio framework is built with MAX_BLE_CONN to 3, so
-# enforce this in yaml checks.
-MULTI_CONF = 3
+MULTI_CONF = True
 
 CONFIG_SCHEMA = (
     cv.Schema(


### PR DESCRIPTION
# What does this implement/fix?

In the past an ESP32 wasn't able to handle more than 3 simultaneous BLE client connections because of limited resources. More powerful ESP32 models are able to handle more than 3 connections. Also the ESP32-WROOM model can talk to a bunch of devices if you establish the connections sequentially. 

In other words: The limit is pretty hard and should be relaxed.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** No official issue

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** None

The explicit limitation isn't mentioned at the docs anymore. The general warning is still valid:

> The BLE software stack on the ESP32 consumes a significant amount of RAM on the device.

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
