### PR TITLE
[CI] add web_server v1 test

### DIFF
--- a/tests/components/web_server/common.yaml
+++ b/tests/components/web_server/common.yaml
@@ -2,10 +2,6 @@ wifi:
   ssid: MySSID
   password: password1
 
-web_server:
-  port: 8080
-  version: 2
-
 binary_sensor:
 cover:
 fan:

--- a/tests/components/web_server/common_v1.yaml
+++ b/tests/components/web_server/common_v1.yaml
@@ -1,0 +1,42 @@
+wifi:
+  ssid: MySSID
+  password: password1
+
+web_server:
+  port: 8080
+  version: 1
+
+binary_sensor:
+cover:
+fan:
+light:
+sensor:
+switch:
+button:
+text_sensor:
+climate:
+number:
+text:
+select:
+lock:
+valve:
+alarm_control_panel:
+api:
+time:
+  - platform: homeassistant
+    id: homeassistant_time
+datetime:
+  - platform: template
+    id: my_datetime_date
+    type: date
+    optimistic: yes
+  - platform: template
+    id: my_datetime_time
+    type: time
+    optimistic: yes
+  - platform: template
+    id: my_datetime
+    type: datetime
+    optimistic: yes
+event:
+update:

--- a/tests/components/web_server/common_v2.yaml
+++ b/tests/components/web_server/common_v2.yaml
@@ -2,4 +2,4 @@
 
 web_server:
   port: 8080
-  version: 1
+  version: 2

--- a/tests/components/web_server/test.esp32-ard.yaml
+++ b/tests/components/web_server/test.esp32-ard.yaml
@@ -1,1 +1,1 @@
-<<: !include common.yaml
+<<: !include common_v2.yaml

--- a/tests/components/web_server/test.esp32-c3-ard.yaml
+++ b/tests/components/web_server/test.esp32-c3-ard.yaml
@@ -1,1 +1,1 @@
-<<: !include common.yaml
+<<: !include common_v2.yaml

--- a/tests/components/web_server/test.esp32-c3-idf.yaml
+++ b/tests/components/web_server/test.esp32-c3-idf.yaml
@@ -1,1 +1,1 @@
-<<: !include common.yaml
+<<: !include common_v2.yaml

--- a/tests/components/web_server/test.esp32-idf.yaml
+++ b/tests/components/web_server/test.esp32-idf.yaml
@@ -1,1 +1,1 @@
-<<: !include common.yaml
+<<: !include common_v2.yaml

--- a/tests/components/web_server/test.esp8266-ard.yaml
+++ b/tests/components/web_server/test.esp8266-ard.yaml
@@ -1,1 +1,1 @@
-<<: !include common.yaml
+<<: !include common_v2.yaml

--- a/tests/components/web_server/test_v1.esp32-ard.yaml
+++ b/tests/components/web_server/test_v1.esp32-ard.yaml
@@ -1,0 +1,1 @@
+<<: !include common_v1.yaml


### PR DESCRIPTION
# What does this implement/fix?

enables web_server v1 test

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
