### PR TITLE
[ota] Print Arduino update errors

### DIFF
--- a/esphome/components/ota/ota_backend_arduino_esp32.cpp
+++ b/esphome/components/ota/ota_backend_arduino_esp32.cpp
@@ -1,13 +1,16 @@
 #ifdef USE_ESP32_FRAMEWORK_ARDUINO
 #include "esphome/core/defines.h"
+#include "esphome/core/log.h"
 
-#include "ota_backend_arduino_esp32.h"
 #include "ota_backend.h"
+#include "ota_backend_arduino_esp32.h"
 
 #include <Update.h>
 
 namespace esphome {
 namespace ota {
+
+static const char *const TAG = "ota.arduino_esp32";
 
 std::unique_ptr<ota::OTABackend> make_ota_backend() { return make_unique<ota::ArduinoESP32OTABackend>(); }
 
@@ -20,6 +23,9 @@ OTAResponseTypes ArduinoESP32OTABackend::begin(size_t image_size) {
   uint8_t error = Update.getError();
   if (error == UPDATE_ERROR_SIZE)
     return OTA_RESPONSE_ERROR_ESP32_NOT_ENOUGH_SPACE;
+
+  ESP_LOGE(TAG, "Begin error: %d", error);
+
   return OTA_RESPONSE_ERROR_UNKNOWN;
 }
 
@@ -27,16 +33,25 @@ void ArduinoESP32OTABackend::set_update_md5(const char *md5) { Update.setMD5(md5
 
 OTAResponseTypes ArduinoESP32OTABackend::write(uint8_t *data, size_t len) {
   size_t written = Update.write(data, len);
-  if (written != len) {
-    return OTA_RESPONSE_ERROR_WRITING_FLASH;
+  if (written == len) {
+    return OTA_RESPONSE_OK;
   }
-  return OTA_RESPONSE_OK;
+
+  uint8_t error = Update.getError();
+  ESP_LOGE(TAG, "Write error: %d", error);
+
+  return OTA_RESPONSE_ERROR_WRITING_FLASH;
 }
 
 OTAResponseTypes ArduinoESP32OTABackend::end() {
-  if (!Update.end())
-    return OTA_RESPONSE_ERROR_UPDATE_END;
-  return OTA_RESPONSE_OK;
+  if (Update.end()) {
+    return OTA_RESPONSE_OK;
+  }
+
+  uint8_t error = Update.getError();
+  ESP_LOGE(TAG, "End error: %d", error);
+
+  return OTA_RESPONSE_ERROR_UPDATE_END;
 }
 
 void ArduinoESP32OTABackend::abort() { Update.abort(); }

--- a/esphome/components/ota/ota_backend_arduino_esp8266.cpp
+++ b/esphome/components/ota/ota_backend_arduino_esp8266.cpp
@@ -1,15 +1,18 @@
 #ifdef USE_ARDUINO
 #ifdef USE_ESP8266
-#include "ota_backend.h"
 #include "ota_backend_arduino_esp8266.h"
+#include "ota_backend.h"
 
-#include "esphome/core/defines.h"
 #include "esphome/components/esp8266/preferences.h"
+#include "esphome/core/defines.h"
+#include "esphome/core/log.h"
 
 #include <Updater.h>
 
 namespace esphome {
 namespace ota {
+
+static const char *const TAG = "ota.arduino_esp8266";
 
 std::unique_ptr<ota::OTABackend> make_ota_backend() { return make_unique<ota::ArduinoESP8266OTABackend>(); }
 
@@ -29,6 +32,9 @@ OTAResponseTypes ArduinoESP8266OTABackend::begin(size_t image_size) {
     return OTA_RESPONSE_ERROR_WRONG_CURRENT_FLASH_CONFIG;
   if (error == UPDATE_ERROR_SPACE)
     return OTA_RESPONSE_ERROR_ESP8266_NOT_ENOUGH_SPACE;
+
+  ESP_LOGE(TAG, "Begin error: %d", error);
+
   return OTA_RESPONSE_ERROR_UNKNOWN;
 }
 
@@ -36,16 +42,25 @@ void ArduinoESP8266OTABackend::set_update_md5(const char *md5) { Update.setMD5(m
 
 OTAResponseTypes ArduinoESP8266OTABackend::write(uint8_t *data, size_t len) {
   size_t written = Update.write(data, len);
-  if (written != len) {
-    return OTA_RESPONSE_ERROR_WRITING_FLASH;
+  if (written == len) {
+    return OTA_RESPONSE_OK;
   }
-  return OTA_RESPONSE_OK;
+
+  uint8_t error = Update.getError();
+  ESP_LOGE(TAG, "Write error: %d", error);
+
+  return OTA_RESPONSE_ERROR_WRITING_FLASH;
 }
 
 OTAResponseTypes ArduinoESP8266OTABackend::end() {
-  if (!Update.end())
-    return OTA_RESPONSE_ERROR_UPDATE_END;
-  return OTA_RESPONSE_OK;
+  if (Update.end()) {
+    return OTA_RESPONSE_OK;
+  }
+
+  uint8_t error = Update.getError();
+  ESP_LOGE(TAG, "End error: %d", error);
+
+  return OTA_RESPONSE_ERROR_UPDATE_END;
 }
 
 void ArduinoESP8266OTABackend::abort() {

--- a/esphome/components/ota/ota_backend_arduino_libretiny.cpp
+++ b/esphome/components/ota/ota_backend_arduino_libretiny.cpp
@@ -1,13 +1,16 @@
 #ifdef USE_LIBRETINY
-#include "ota_backend.h"
 #include "ota_backend_arduino_libretiny.h"
+#include "ota_backend.h"
 
 #include "esphome/core/defines.h"
+#include "esphome/core/log.h"
 
 #include <Update.h>
 
 namespace esphome {
 namespace ota {
+
+static const char *const TAG = "ota.arduino_libretiny";
 
 std::unique_ptr<ota::OTABackend> make_ota_backend() { return make_unique<ota::ArduinoLibreTinyOTABackend>(); }
 
@@ -20,6 +23,9 @@ OTAResponseTypes ArduinoLibreTinyOTABackend::begin(size_t image_size) {
   uint8_t error = Update.getError();
   if (error == UPDATE_ERROR_SIZE)
     return OTA_RESPONSE_ERROR_ESP32_NOT_ENOUGH_SPACE;
+
+  ESP_LOGE(TAG, "Begin error: %d", error);
+
   return OTA_RESPONSE_ERROR_UNKNOWN;
 }
 
@@ -27,16 +33,25 @@ void ArduinoLibreTinyOTABackend::set_update_md5(const char *md5) { Update.setMD5
 
 OTAResponseTypes ArduinoLibreTinyOTABackend::write(uint8_t *data, size_t len) {
   size_t written = Update.write(data, len);
-  if (written != len) {
-    return OTA_RESPONSE_ERROR_WRITING_FLASH;
+  if (written == len) {
+    return OTA_RESPONSE_OK;
   }
-  return OTA_RESPONSE_OK;
+
+  uint8_t error = Update.getError();
+  ESP_LOGE(TAG, "Write error: %d", error);
+
+  return OTA_RESPONSE_ERROR_WRITING_FLASH;
 }
 
 OTAResponseTypes ArduinoLibreTinyOTABackend::end() {
-  if (!Update.end())
-    return OTA_RESPONSE_ERROR_UPDATE_END;
-  return OTA_RESPONSE_OK;
+  if (Update.end()) {
+    return OTA_RESPONSE_OK;
+  }
+
+  uint8_t error = Update.getError();
+  ESP_LOGE(TAG, "End error: %d", error);
+
+  return OTA_RESPONSE_ERROR_UPDATE_END;
 }
 
 void ArduinoLibreTinyOTABackend::abort() { Update.abort(); }


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

The errors set by the underlying Updater code are lost and we only return generic errors. This changes it to print an error to the logs with the actual error code.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
