### PR TITLE
2024.7.0b3

### DIFF
--- a/esphome/components/i2s_audio/__init__.py
+++ b/esphome/components/i2s_audio/__init__.py
@@ -25,12 +25,22 @@ CONF_I2S_LRCLK_PIN = "i2s_lrclk_pin"
 CONF_I2S_AUDIO = "i2s_audio"
 CONF_I2S_AUDIO_ID = "i2s_audio_id"
 
+CONF_I2S_MODE = "i2s_mode"
+CONF_PRIMARY = "primary"
+CONF_SECONDARY = "secondary"
+
 i2s_audio_ns = cg.esphome_ns.namespace("i2s_audio")
 I2SAudioComponent = i2s_audio_ns.class_("I2SAudioComponent", cg.Component)
 I2SAudioIn = i2s_audio_ns.class_("I2SAudioIn", cg.Parented.template(I2SAudioComponent))
 I2SAudioOut = i2s_audio_ns.class_(
     "I2SAudioOut", cg.Parented.template(I2SAudioComponent)
 )
+
+i2s_mode_t = cg.global_ns.enum("i2s_mode_t")
+I2S_MODE_OPTIONS = {
+    CONF_PRIMARY: i2s_mode_t.I2S_MODE_MASTER,  # NOLINT
+    CONF_SECONDARY: i2s_mode_t.I2S_MODE_SLAVE,  # NOLINT
+}
 
 # https://github.com/espressif/esp-idf/blob/master/components/soc/{variant}/include/soc/soc_caps.h
 I2S_PORTS = {

--- a/esphome/components/i2s_audio/microphone/__init__.py
+++ b/esphome/components/i2s_audio/microphone/__init__.py
@@ -7,6 +7,9 @@ from esphome.components import microphone, esp32
 from esphome.components.adc import ESP32_VARIANT_ADC1_PIN_TO_CHANNEL, validate_adc_pin
 
 from .. import (
+    CONF_I2S_MODE,
+    CONF_PRIMARY,
+    I2S_MODE_OPTIONS,
     i2s_audio_ns,
     I2SAudioComponent,
     I2SAudioIn,
@@ -68,6 +71,9 @@ BASE_SCHEMA = microphone.MICROPHONE_SCHEMA.extend(
             _validate_bits, cv.enum(BITS_PER_SAMPLE)
         ),
         cv.Optional(CONF_USE_APLL, default=False): cv.boolean,
+        cv.Optional(CONF_I2S_MODE, default=CONF_PRIMARY): cv.enum(
+            I2S_MODE_OPTIONS, lower=True
+        ),
     }
 ).extend(cv.COMPONENT_SCHEMA)
 
@@ -107,6 +113,7 @@ async def to_code(config):
         cg.add(var.set_din_pin(config[CONF_I2S_DIN_PIN]))
         cg.add(var.set_pdm(config[CONF_PDM]))
 
+    cg.add(var.set_i2s_mode(config[CONF_I2S_MODE]))
     cg.add(var.set_channel(config[CONF_CHANNEL]))
     cg.add(var.set_sample_rate(config[CONF_SAMPLE_RATE]))
     cg.add(var.set_bits_per_sample(config[CONF_BITS_PER_SAMPLE]))

--- a/esphome/components/i2s_audio/microphone/i2s_audio_microphone.cpp
+++ b/esphome/components/i2s_audio/microphone/i2s_audio_microphone.cpp
@@ -46,7 +46,7 @@ void I2SAudioMicrophone::start_() {
     return;  // Waiting for another i2s to return lock
   }
   i2s_driver_config_t config = {
-      .mode = (i2s_mode_t) (I2S_MODE_MASTER | I2S_MODE_RX),
+      .mode = (i2s_mode_t) (this->i2s_mode_ | I2S_MODE_RX),
       .sample_rate = this->sample_rate_,
       .bits_per_sample = this->bits_per_sample_,
       .channel_format = this->channel_,
@@ -174,8 +174,7 @@ size_t I2SAudioMicrophone::read(int16_t *buf, size_t len) {
     size_t samples_read = bytes_read / sizeof(int32_t);
     samples.resize(samples_read);
     for (size_t i = 0; i < samples_read; i++) {
-      int32_t temp = reinterpret_cast<int32_t *>(buf)[i] >> 14;
-      samples[i] = clamp<int16_t>(temp, INT16_MIN, INT16_MAX);
+      samples[i] = reinterpret_cast<int32_t *>(buf)[i] >> 16;
     }
     memcpy(buf, samples.data(), samples_read * sizeof(int16_t));
     return samples_read * sizeof(int16_t);

--- a/esphome/components/i2s_audio/microphone/i2s_audio_microphone.h
+++ b/esphome/components/i2s_audio/microphone/i2s_audio_microphone.h
@@ -30,6 +30,8 @@ class I2SAudioMicrophone : public I2SAudioIn, public microphone::Microphone, pub
   }
 #endif
 
+  void set_i2s_mode(i2s_mode_t mode) { this->i2s_mode_ = mode; }
+
   void set_channel(i2s_channel_fmt_t channel) { this->channel_ = channel; }
   void set_sample_rate(uint32_t sample_rate) { this->sample_rate_ = sample_rate; }
   void set_bits_per_sample(i2s_bits_per_sample_t bits_per_sample) { this->bits_per_sample_ = bits_per_sample; }
@@ -46,6 +48,7 @@ class I2SAudioMicrophone : public I2SAudioIn, public microphone::Microphone, pub
   bool adc_{false};
 #endif
   bool pdm_{false};
+  i2s_mode_t i2s_mode_{};
   i2s_channel_fmt_t channel_;
   uint32_t sample_rate_;
   i2s_bits_per_sample_t bits_per_sample_;

--- a/esphome/components/improv_serial/improv_serial_component.cpp
+++ b/esphome/components/improv_serial/improv_serial_component.cpp
@@ -57,7 +57,7 @@ optional<uint8_t> ImprovSerialComponent::read_byte_() {
         }
       }
       break;
-#ifdef USE_LOGGER_USB_CDC
+#if defined(USE_LOGGER_USB_CDC) && defined(CONFIG_ESP_CONSOLE_USB_CDC)
     case logger::UART_SELECTION_USB_CDC:
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0)
       if (esp_usb_console_available_for_read()) {
@@ -99,7 +99,7 @@ void ImprovSerialComponent::write_data_(std::vector<uint8_t> &data) {
 #endif  // !USE_ESP32_VARIANT_ESP32C3 && !USE_ESP32_VARIANT_ESP32S2 && !USE_ESP32_VARIANT_ESP32S3
       uart_write_bytes(this->uart_num_, data.data(), data.size());
       break;
-#ifdef USE_LOGGER_USB_CDC
+#if defined(USE_LOGGER_USB_CDC) && defined(CONFIG_ESP_CONSOLE_USB_CDC)
     case logger::UART_SELECTION_USB_CDC: {
       const char *msg = (char *) data.data();
       esp_usb_console_write_buf(msg, data.size());
@@ -109,6 +109,7 @@ void ImprovSerialComponent::write_data_(std::vector<uint8_t> &data) {
 #ifdef USE_LOGGER_USB_SERIAL_JTAG
     case logger::UART_SELECTION_USB_SERIAL_JTAG:
       usb_serial_jtag_write_bytes((char *) data.data(), data.size(), 20 / portTICK_PERIOD_MS);
+      delay(10);
       usb_serial_jtag_ll_txfifo_flush();  // fixes for issue in IDF 4.4.7
       break;
 #endif  // USE_LOGGER_USB_SERIAL_JTAG

--- a/esphome/components/micro_wake_word/__init__.py
+++ b/esphome/components/micro_wake_word/__init__.py
@@ -357,7 +357,9 @@ CONFIG_SCHEMA = cv.All(
         {
             cv.GenerateID(): cv.declare_id(MicroWakeWord),
             cv.GenerateID(CONF_MICROPHONE): cv.use_id(microphone.Microphone),
-            cv.Required(CONF_MODELS): cv.ensure_list(MODEL_SCHEMA),
+            cv.Required(CONF_MODELS): cv.ensure_list(
+                cv.maybe_simple_value(MODEL_SCHEMA, key=CONF_MODEL)
+            ),
             cv.Optional(CONF_ON_WAKE_WORD_DETECTED): automation.validate_automation(
                 single=True
             ),

--- a/esphome/const.py
+++ b/esphome/const.py
@@ -1,6 +1,6 @@
 """Constants used by esphome."""
 
-__version__ = "2024.7.0b2"
+__version__ = "2024.7.0b3"
 
 ALLOWED_NAME_CHARS = "abcdefghijklmnopqrstuvwxyz0123456789-_"
 VALID_SUBSTITUTIONS_CHARACTERS = (


### PR DESCRIPTION
**Do not merge, release script will automatically merge**
## Full list of changes

### All changes

- [improv_serial] Fix linker error created in #6998 [esphome#7082](https://github.com/esphome/esphome/pull/7082)
- [i2s_audio] Allow config for primary/secondary i2s mode [esphome#7092](https://github.com/esphome/esphome/pull/7092)
- [micro_wake_word] Allow simpler model config [esphome#7094](https://github.com/esphome/esphome/pull/7094)

<details>
<summary>Metadata</summary>

@coderabbitai ignore
</details>
