### PR TITLE
Prevent rename from deleting new config

### DIFF
--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -695,7 +695,8 @@ def command_rename(args, config):
         os.remove(new_path)
         return 1
 
-    os.remove(CORE.config_path)
+    if CORE.config_path != new_path:
+        os.remove(CORE.config_path)
 
     print(color(Fore.BOLD_GREEN, "SUCCESS"))
     print()


### PR DESCRIPTION
# What does this implement/fix?

Prevent rename from deleting the only copy of the config file when old and new paths are the same.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

It happened to me.

## Test Environment

N/A

## Example entry for `config.yaml`:

N/A

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
