### PR TITLE
[validation] Add ``host`` to ``require_framework_version``

### DIFF
--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -2065,7 +2065,7 @@ def require_framework_version(
                     msg += f". {extra_message}"
                 raise Invalid(msg)
             required = rp2040_arduino
-        elif CORE.is_host:
+        elif CORE.is_host and framework == "host":
             if host is None:
                 msg = "This feature is incompatible with host platform"
                 if extra_message:

--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -829,7 +829,6 @@ def time_of_day(value):
 
 
 def date_time(date: bool, time: bool):
-
     pattern_str = r"^"  # Start of string
     if date:
         pattern_str += r"\d{4}-\d{1,2}-\d{1,2}"
@@ -2031,6 +2030,7 @@ def require_framework_version(
     esp32_arduino=None,
     esp8266_arduino=None,
     rp2040_arduino=None,
+    host=None,
     max_version=False,
     extra_message=None,
 ):
@@ -2065,6 +2065,13 @@ def require_framework_version(
                     msg += f". {extra_message}"
                 raise Invalid(msg)
             required = rp2040_arduino
+        elif CORE.is_host:
+            if host is None:
+                msg = "This feature is incompatible with host platform"
+                if extra_message:
+                    msg += f". {extra_message}"
+                raise Invalid(msg)
+            required = host
         else:
             raise Invalid(
                 f"""


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Adds capability to validate against host framework where needed.

No other changes come with adding this optional argument.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
