### PR TITLE
[i2s_microphone] Partially revert #7092 so microphone volume doesn't change

### DIFF
--- a/esphome/components/i2s_audio/microphone/i2s_audio_microphone.cpp
+++ b/esphome/components/i2s_audio/microphone/i2s_audio_microphone.cpp
@@ -174,7 +174,8 @@ size_t I2SAudioMicrophone::read(int16_t *buf, size_t len) {
     size_t samples_read = bytes_read / sizeof(int32_t);
     samples.resize(samples_read);
     for (size_t i = 0; i < samples_read; i++) {
-      samples[i] = reinterpret_cast<int32_t *>(buf)[i] >> 16;
+      int32_t temp = reinterpret_cast<int32_t *>(buf)[i] >> 14;
+      samples[i] = clamp<int16_t>(temp, INT16_MIN, INT16_MAX);
     }
     memcpy(buf, samples.data(), samples_read * sizeof(int16_t));
     return samples_read * sizeof(int16_t);


### PR DESCRIPTION
# What does this implement/fix?

PR #7092 modified how 32 bit microphone audio samples are converted to 16 bits. Previously, a 32 bit sample was bit shifted by 14 and then clamped to fit into an ``int16_t``. This approach builds in a multiplication by a factor of 4. Most I2S microphone benefit for from this behavior. The PR changed it to bit shift by 16. While this new approach is the proper way to convert 32 bit audio samples to 16 bit, it has the unintended consequence of making a microphone samples quieter by a factor of 4 compared to before. This PR reverts to the old behavior of shifting by 14 bits and clamping so no other configuration changes are necessary to match the previous behavior.

We should eventually switch to shifting by 16 bits, but there needs to be a discussion on how to best handle that breaking change for existing configurations.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** not applicable

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
