### PR TITLE
[touchscreen] Allow binary sensor to have multiple pages in config

### DIFF
--- a/esphome/components/touchscreen/binary_sensor/__init__.py
+++ b/esphome/components/touchscreen/binary_sensor/__init__.py
@@ -1,10 +1,9 @@
 import esphome.codegen as cg
-import esphome.config_validation as cv
-
 from esphome.components import binary_sensor, display
+import esphome.config_validation as cv
 from esphome.const import CONF_PAGE_ID, CONF_PAGES
 
-from .. import touchscreen_ns, CONF_TOUCHSCREEN_ID, Touchscreen, TouchListener
+from .. import CONF_TOUCHSCREEN_ID, TouchListener, Touchscreen, touchscreen_ns
 
 DEPENDENCIES = ["touchscreen"]
 

--- a/esphome/components/touchscreen/binary_sensor/__init__.py
+++ b/esphome/components/touchscreen/binary_sensor/__init__.py
@@ -2,7 +2,7 @@ import esphome.codegen as cg
 import esphome.config_validation as cv
 
 from esphome.components import binary_sensor, display
-from esphome.const import CONF_PAGE_ID
+from esphome.const import CONF_PAGE_ID, CONF_PAGES
 
 from .. import touchscreen_ns, CONF_TOUCHSCREEN_ID, Touchscreen, TouchListener
 
@@ -22,7 +22,7 @@ CONF_Y_MIN = "y_min"
 CONF_Y_MAX = "y_max"
 
 
-def validate_coords(config):
+def _validate_coords(config):
     if (
         config[CONF_X_MAX] < config[CONF_X_MIN]
         or config[CONF_Y_MAX] < config[CONF_Y_MIN]
@@ -30,6 +30,15 @@ def validate_coords(config):
         raise cv.Invalid(
             f"{CONF_X_MAX} is less than {CONF_X_MIN} or {CONF_Y_MAX} is less than {CONF_Y_MIN}"
         )
+    return config
+
+
+def _set_pages(config: dict) -> dict:
+    if CONF_PAGES in config or CONF_PAGE_ID not in config:
+        return config
+
+    config = config.copy()
+    config[CONF_PAGES] = [config.pop(CONF_PAGE_ID)]
     return config
 
 
@@ -42,11 +51,17 @@ CONFIG_SCHEMA = cv.All(
             cv.Required(CONF_X_MAX): cv.int_range(min=0, max=2000),
             cv.Required(CONF_Y_MIN): cv.int_range(min=0, max=2000),
             cv.Required(CONF_Y_MAX): cv.int_range(min=0, max=2000),
-            cv.Optional(CONF_PAGE_ID): cv.use_id(display.DisplayPage),
+            cv.Exclusive(CONF_PAGE_ID, group_of_exclusion=CONF_PAGES): cv.use_id(
+                display.DisplayPage
+            ),
+            cv.Exclusive(CONF_PAGES, group_of_exclusion=CONF_PAGES): cv.ensure_list(
+                cv.use_id(display.DisplayPage)
+            ),
         }
     )
     .extend(cv.COMPONENT_SCHEMA),
-    validate_coords,
+    _validate_coords,
+    _set_pages,
 )
 
 
@@ -64,6 +79,6 @@ async def to_code(config):
         )
     )
 
-    if CONF_PAGE_ID in config:
-        page = await cg.get_variable(config[CONF_PAGE_ID])
-        cg.add(var.set_page(page))
+    for page_id in config.get(CONF_PAGES, []):
+        page = await cg.get_variable(page_id)
+        cg.add(var.add_page(page))

--- a/esphome/components/touchscreen/binary_sensor/touchscreen_binary_sensor.cpp
+++ b/esphome/components/touchscreen/binary_sensor/touchscreen_binary_sensor.cpp
@@ -11,8 +11,9 @@ void TouchscreenBinarySensor::setup() {
 void TouchscreenBinarySensor::touch(TouchPoint tp) {
   bool touched = (tp.x >= this->x_min_ && tp.x <= this->x_max_ && tp.y >= this->y_min_ && tp.y <= this->y_max_);
 
-  if (this->page_ != nullptr) {
-    touched &= this->page_ == this->parent_->get_display()->get_active_page();
+  if (!this->pages_.empty()) {
+    auto *current_page = this->parent_->get_display()->get_active_page();
+    touched &= std::find(this->pages_.begin(), this->pages_.end(), current_page) != this->pages_.end();
   }
   if (touched) {
     this->publish_state(true);

--- a/esphome/components/touchscreen/binary_sensor/touchscreen_binary_sensor.h
+++ b/esphome/components/touchscreen/binary_sensor/touchscreen_binary_sensor.h
@@ -6,6 +6,8 @@
 #include "esphome/core/component.h"
 #include "esphome/core/helpers.h"
 
+#include <vector>
+
 namespace esphome {
 namespace touchscreen {
 
@@ -30,14 +32,14 @@ class TouchscreenBinarySensor : public binary_sensor::BinarySensor,
   int16_t get_width() { return this->x_max_ - this->x_min_; }
   int16_t get_height() { return this->y_max_ - this->y_min_; }
 
-  void set_page(display::DisplayPage *page) { this->page_ = page; }
+  void add_page(display::DisplayPage *page) { this->pages_.push_back(page); }
 
   void touch(TouchPoint tp) override;
   void release() override;
 
  protected:
   int16_t x_min_, x_max_, y_min_, y_max_;
-  display::DisplayPage *page_{nullptr};
+  std::vector<display::DisplayPage *> pages_{};
 };
 
 }  // namespace touchscreen


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#4072

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
