### PR TITLE
[fan] fix initial FanCall to properly set speed

### DIFF
--- a/esphome/components/fan/fan.cpp
+++ b/esphome/components/fan/fan.cpp
@@ -45,8 +45,8 @@ void FanCall::validate_() {
     this->speed_ = clamp(*this->speed_, 1, traits.supported_speed_count());
 
   if (this->binary_state_.has_value() && *this->binary_state_) {
-    // when turning on, if current speed is zero, set speed to 100%
-    if (traits.supports_speed() && !this->parent_.state && this->parent_.speed == 0) {
+    // when turning on, if neither current nor new speed available, set speed to 100%
+    if (traits.supports_speed() && !this->parent_.state && this->parent_.speed == 0 && !this->speed_.has_value()) {
       this->speed_ = traits.supported_speed_count();
     }
   }


### PR DESCRIPTION
# What does this implement/fix?

Speed settings were ignored for the first FanCall, if no speed has been restored before. This commit changes the behaviour to: set speed to 100%, iff current speed AND new speed are not set.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/6062

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** n/a

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
```yaml
fan:
  - platform: template
    name: my_fan
    id: my_fan
    speed_count: 3
    restore_mode: NO_RESTORE
    on_speed_set:
      - lambda: |-
          const auto fan_speed = std::min(3, x);
          // send a CAN message
    on_turn_off:
      - lambda: |-
          ESP_LOGI("fan", "Fan Turned Off!");
          // send a CAN message
    on_turn_on:
      - logger.log: "Fan Turned On!"

esphome:
  on_boot:
    priority: -100
    then:
      - lambda: |-
              const auto fan_speed = 2
              id(my_fan).turn_on().set_speed(fan_speed).perform();
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
