### PR TITLE
2024.7.1

### DIFF
--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -695,7 +695,8 @@ def command_rename(args, config):
         os.remove(new_path)
         return 1
 
-    os.remove(CORE.config_path)
+    if CORE.config_path != new_path:
+        os.remove(CORE.config_path)
 
     print(color(Fore.BOLD_GREEN, "SUCCESS"))
     print()

--- a/esphome/components/heatpumpir/climate.py
+++ b/esphome/components/heatpumpir/climate.py
@@ -8,6 +8,7 @@ from esphome.const import (
     CONF_PROTOCOL,
     CONF_VISUAL,
 )
+from esphome.core import CORE
 
 CODEOWNERS = ["@rob-deutsch"]
 
@@ -127,3 +128,5 @@ def to_code(config):
     cg.add(var.set_min_temperature(config[CONF_MIN_TEMPERATURE]))
 
     cg.add_library("tonia/HeatpumpIR", "1.0.27")
+    if CORE.is_libretiny:
+        CORE.add_platformio_option("lib_ignore", "IRremoteESP8266")

--- a/esphome/components/http_request/http_request_idf.cpp
+++ b/esphome/components/http_request/http_request_idf.cpp
@@ -52,6 +52,7 @@ std::shared_ptr<HttpContainer> HttpRequestIDF::start(std::string url, std::strin
   config.timeout_ms = this->timeout_;
   config.disable_auto_redirect = !this->follow_redirects_;
   config.max_redirection_count = this->redirect_limit_;
+  config.auth_type = HTTP_AUTH_TYPE_BASIC;
 #if CONFIG_MBEDTLS_CERTIFICATE_BUNDLE
   if (secure) {
     config.crt_bundle_attach = esp_crt_bundle_attach;

--- a/esphome/components/i2s_audio/microphone/i2s_audio_microphone.cpp
+++ b/esphome/components/i2s_audio/microphone/i2s_audio_microphone.cpp
@@ -174,7 +174,8 @@ size_t I2SAudioMicrophone::read(int16_t *buf, size_t len) {
     size_t samples_read = bytes_read / sizeof(int32_t);
     samples.resize(samples_read);
     for (size_t i = 0; i < samples_read; i++) {
-      samples[i] = reinterpret_cast<int32_t *>(buf)[i] >> 16;
+      int32_t temp = reinterpret_cast<int32_t *>(buf)[i] >> 14;
+      samples[i] = clamp<int16_t>(temp, INT16_MIN, INT16_MAX);
     }
     memcpy(buf, samples.data(), samples_read * sizeof(int16_t));
     return samples_read * sizeof(int16_t);

--- a/esphome/components/sml/sml_parser.cpp
+++ b/esphome/components/sml/sml_parser.cpp
@@ -27,7 +27,7 @@ bool SmlFile::setup_node(SmlNode *node) {
   uint8_t parse_length = length;
   if (has_extended_length) {
     length = (length << 4) + (this->buffer_[this->pos_ + 1] & 0x0f);
-    parse_length = length - 1;
+    parse_length = length;
     this->pos_ += 1;
   }
 
@@ -37,7 +37,9 @@ bool SmlFile::setup_node(SmlNode *node) {
   node->type = type & 0x07;
   node->nodes.clear();
   node->value_bytes.clear();
-  if (this->buffer_[this->pos_] == 0x00) {  // end of message
+
+  // if the list is a has_extended_length list with e.g. 16 elements this is a 0x00 byte but not the end of message
+  if (!has_extended_length && this->buffer_[this->pos_] == 0x00) {  // end of message
     this->pos_ += 1;
   } else if (is_list) {  // list
     this->pos_ += 1;

--- a/esphome/const.py
+++ b/esphome/const.py
@@ -1,6 +1,6 @@
 """Constants used by esphome."""
 
-__version__ = "2024.7.0"
+__version__ = "2024.7.1"
 
 ALLOWED_NAME_CHARS = "abcdefghijklmnopqrstuvwxyz0123456789-_"
 VALID_SUBSTITUTIONS_CHARACTERS = (

--- a/tests/components/heatpumpir/test.bk72xx-ard.yaml
+++ b/tests/components/heatpumpir/test.bk72xx-ard.yaml
@@ -4,6 +4,13 @@ remote_transmitter:
 
 climate:
   - platform: heatpumpir
+    protocol: mitsubishi_heavy_zm
+    horizontal_default: left
+    vertical_default: up
+    name: HeatpumpIR Climate
+    min_temperature: 18
+    max_temperature: 30
+  - platform: heatpumpir
     protocol: daikin
     horizontal_default: mleft
     vertical_default: mup


### PR DESCRIPTION
**Do not merge, release script will automatically merge**
- Prevent rename from deleting new config [esphome#7104](https://github.com/esphome/esphome/pull/7104)
- [i2s_microphone] Partially revert #7092 so microphone volume doesn't change [esphome#7109](https://github.com/esphome/esphome/pull/7109)
- [heatpumpir] Fix BK72XX Compile error with IRremoteESP8266 [esphome#6955](https://github.com/esphome/esphome/pull/6955)
- [http_request] allow basic auth for idf  [esphome#7086](https://github.com/esphome/esphome/pull/7086)
- Fixes sml parser to process extended length lists with a number of items that is dividable by 16 [esphome#6148](https://github.com/esphome/esphome/pull/6148)

<details>
<summary>Metadata</summary>

@coderabbitai ignore
</details>
