### PR TITLE
[ili9xxx] Rework delay handling

### DIFF
--- a/esphome/components/ili9xxx/ili9xxx_defines.h
+++ b/esphome/components/ili9xxx/ili9xxx_defines.h
@@ -92,7 +92,9 @@ static const uint8_t ILI9XXX_GMCTRN1 = 0xE1;
 
 static const uint8_t ILI9XXX_CSCON = 0xF0;
 static const uint8_t ILI9XXX_ADJCTL3 = 0xF7;
-static const uint8_t ILI9XXX_DELAY = 0xFF;  // followed by one byte of delay time in ms
+static const uint8_t ILI9XXX_DELAY_FLAG = 0xFF;
+// special marker for delay - command byte reprents ms, length byte is an impossible value
+#define ILI9XXX_DELAY(ms) ((uint8_t) ((ms) | 0x80)), ILI9XXX_DELAY_FLAG
 
 }  // namespace ili9xxx
 }  // namespace esphome

--- a/esphome/components/ili9xxx/ili9xxx_display.cpp
+++ b/esphome/components/ili9xxx/ili9xxx_display.cpp
@@ -34,8 +34,8 @@ void ILI9XXXDisplay::setup() {
   ESP_LOGD(TAG, "Setting up ILI9xxx");
 
   this->setup_pins_();
-  this->init_lcd(this->init_sequence_);
-  this->init_lcd(this->extra_init_sequence_.data());
+  this->init_lcd_(this->init_sequence_);
+  this->init_lcd_(this->extra_init_sequence_.data());
   switch (this->pixel_mode_) {
     case PIXEL_MODE_16:
       if (this->is_18bitdisplay_) {
@@ -405,7 +405,7 @@ void ILI9XXXDisplay::reset_() {
   }
 }
 
-void ILI9XXXDisplay::init_lcd(const uint8_t *addr) {
+void ILI9XXXDisplay::init_lcd_(const uint8_t *addr) {
   if (addr == nullptr)
     return;
   uint8_t cmd, x, num_args;
@@ -424,20 +424,6 @@ void ILI9XXXDisplay::init_lcd(const uint8_t *addr) {
         delay(150);  // NOLINT
       }
     }
-  }
-}
-
-void ILI9XXXGC9A01A::init_lcd(const uint8_t *addr) {
-  if (addr == nullptr)
-    return;
-  uint8_t cmd, x, num_args;
-  while ((cmd = *addr++) != 0) {
-    x = *addr++;
-    num_args = x & 0x7F;
-    this->send_command(cmd, addr, num_args);
-    addr += num_args;
-    if (x & 0x80)
-      delay(150);  // NOLINT
   }
 }
 

--- a/esphome/components/ili9xxx/ili9xxx_display.cpp
+++ b/esphome/components/ili9xxx/ili9xxx_display.cpp
@@ -411,9 +411,10 @@ void ILI9XXXDisplay::init_lcd_(const uint8_t *addr) {
   uint8_t cmd, x, num_args;
   while ((cmd = *addr++) != 0) {
     x = *addr++;
-    if (cmd == ILI9XXX_DELAY) {
-      ESP_LOGD(TAG, "Delay %dms", x);
-      delay(x);
+    if (x == ILI9XXX_DELAY_FLAG) {
+      cmd &= 0x7F;
+      ESP_LOGD(TAG, "Delay %dms", cmd);
+      delay(cmd);
     } else {
       num_args = x & 0x7F;
       ESP_LOGD(TAG, "Command %02X, length %d, bits %02X", cmd, num_args, *addr);

--- a/esphome/components/ili9xxx/ili9xxx_display.cpp
+++ b/esphome/components/ili9xxx/ili9xxx_display.cpp
@@ -413,15 +413,15 @@ void ILI9XXXDisplay::init_lcd_(const uint8_t *addr) {
     x = *addr++;
     if (x == ILI9XXX_DELAY_FLAG) {
       cmd &= 0x7F;
-      ESP_LOGD(TAG, "Delay %dms", cmd);
+      ESP_LOGV(TAG, "Delay %dms", cmd);
       delay(cmd);
     } else {
       num_args = x & 0x7F;
-      ESP_LOGD(TAG, "Command %02X, length %d, bits %02X", cmd, num_args, *addr);
+      ESP_LOGV(TAG, "Command %02X, length %d, bits %02X", cmd, num_args, *addr);
       this->send_command(cmd, addr, num_args);
       addr += num_args;
       if (x & 0x80) {
-        ESP_LOGD(TAG, "Delay 150ms");
+        ESP_LOGV(TAG, "Delay 150ms");
         delay(150);  // NOLINT
       }
     }

--- a/esphome/components/ili9xxx/ili9xxx_display.h
+++ b/esphome/components/ili9xxx/ili9xxx_display.h
@@ -109,7 +109,7 @@ class ILI9XXXDisplay : public display::DisplayBuffer,
 
   virtual void set_madctl();
   void display_();
-  virtual void init_lcd(const uint8_t *addr);
+  void init_lcd_(const uint8_t *addr);
   void set_addr_window_(uint16_t x, uint16_t y, uint16_t x2, uint16_t y2);
   void reset_();
 
@@ -269,7 +269,6 @@ class ILI9XXXS3BoxLite : public ILI9XXXDisplay {
 class ILI9XXXGC9A01A : public ILI9XXXDisplay {
  public:
   ILI9XXXGC9A01A() : ILI9XXXDisplay(INITCMD_GC9A01A, 240, 240, true) {}
-  void init_lcd(const uint8_t *addr) override;
 };
 
 //-----------   ILI9XXX_24_TFT display --------------

--- a/esphome/components/ili9xxx/ili9xxx_display.h
+++ b/esphome/components/ili9xxx/ili9xxx_display.h
@@ -33,7 +33,9 @@ class ILI9XXXDisplay : public display::DisplayBuffer,
     uint8_t cmd, num_args, bits;
     const uint8_t *addr = init_sequence;
     while ((cmd = *addr++) != 0) {
-      num_args = *addr++ & 0x7F;
+      num_args = *addr++;
+      if (num_args == ILI9XXX_DELAY_FLAG)
+        continue;
       bits = *addr;
       switch (cmd) {
         case ILI9XXX_MADCTL: {
@@ -50,13 +52,10 @@ class ILI9XXXDisplay : public display::DisplayBuffer,
           break;
         }
 
-        case ILI9XXX_DELAY:
-          continue;  // no args to skip
-
         default:
           break;
       }
-      addr += num_args;
+      addr += (num_args & 0x7F);
     }
   }
 

--- a/esphome/components/ili9xxx/ili9xxx_init.h
+++ b/esphome/components/ili9xxx/ili9xxx_init.h
@@ -372,9 +372,9 @@ static const uint8_t PROGMEM INITCMD_GC9A01A[] = {
 
 static const uint8_t PROGMEM INITCMD_ST7735[] = {
     ILI9XXX_SWRESET, 0,         // Soft reset, then delay 10ms
-    ILI9XXX_DELAY, 10,
+    ILI9XXX_DELAY(10),
     ILI9XXX_SLPOUT  , 0,                // Exit Sleep, delay
-    ILI9XXX_DELAY, 10,
+    ILI9XXX_DELAY(10),
     ILI9XXX_PIXFMT  , 1, 0x05,
     ILI9XXX_FRMCTR1, 3, //  4: Frame rate control, 3 args + delay:
     0x01, 0x2C, 0x2D,             //     Rate = fosc/(1x2+40) * (LINE+2C+2D)
@@ -415,9 +415,9 @@ static const uint8_t PROGMEM INITCMD_ST7735[] = {
     0x00, 0x00, 0x02, 0x10,
     ILI9XXX_MADCTL  , 1, 0x00,             // Memory Access Control, BGR
     ILI9XXX_NORON  , 0,
-    ILI9XXX_DELAY, 10,
+    ILI9XXX_DELAY(10),
     ILI9XXX_DISPON  , 0,                // Display on
-    ILI9XXX_DELAY, 10,
+    ILI9XXX_DELAY(10),
     00,   // endo of list
 };
 


### PR DESCRIPTION

<!-- Quick description and explanation of changes -->

Delays in the ili9xxx init sequences relied on a special 0xFF command byte, but some displays (GC9A01) actually have a 0xFF command. This PR uses the argument count byte to flag a delay, thus making all 256 command bytes available in init sequences.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
