### PR TITLE
Allow unsetting of speaker and media player

### DIFF
--- a/esphome/components/voice_assistant/voice_assistant.h
+++ b/esphome/components/voice_assistant/voice_assistant.h
@@ -90,7 +90,7 @@ class VoiceAssistant : public Component {
 #ifdef USE_SPEAKER
   void set_speaker(speaker::Speaker *speaker) {
     this->speaker_ = speaker;
-    this->local_output_ = (this->speaker_ != nullptr)l
+    this->local_output_ = (this->speaker_ != nullptr);
   }
 #endif
 #ifdef USE_MEDIA_PLAYER

--- a/esphome/components/voice_assistant/voice_assistant.h
+++ b/esphome/components/voice_assistant/voice_assistant.h
@@ -96,12 +96,7 @@ class VoiceAssistant : public Component {
 #ifdef USE_MEDIA_PLAYER
   void set_media_player(media_player::MediaPlayer *media_player) {
     this->media_player_ = media_player;
-    if (this->media_player_ != nullptr) {
-      this->local_output_ = true;
-    } else {
-      this->local_output_ = false;
-    }
-  }
+    this->local_output_ = (this->media_player_ != nullptr);
 #endif
 
   uint32_t get_legacy_version() const {

--- a/esphome/components/voice_assistant/voice_assistant.h
+++ b/esphome/components/voice_assistant/voice_assistant.h
@@ -90,13 +90,21 @@ class VoiceAssistant : public Component {
 #ifdef USE_SPEAKER
   void set_speaker(speaker::Speaker *speaker) {
     this->speaker_ = speaker;
-    this->local_output_ = true;
+    if (this->speaker_ != nullptr) {
+      this->local_output_ = true;
+    } else {
+      this->local_output_ = false;
+    }
   }
 #endif
 #ifdef USE_MEDIA_PLAYER
   void set_media_player(media_player::MediaPlayer *media_player) {
     this->media_player_ = media_player;
-    this->local_output_ = true;
+    if (this->media_player_ != nullptr) {
+      this->local_output_ = true;
+    } else {
+      this->local_output_ = false;
+    }
   }
 #endif
 

--- a/esphome/components/voice_assistant/voice_assistant.h
+++ b/esphome/components/voice_assistant/voice_assistant.h
@@ -90,11 +90,7 @@ class VoiceAssistant : public Component {
 #ifdef USE_SPEAKER
   void set_speaker(speaker::Speaker *speaker) {
     this->speaker_ = speaker;
-    if (this->speaker_ != nullptr) {
-      this->local_output_ = true;
-    } else {
-      this->local_output_ = false;
-    }
+    this->local_output_ = (this->speaker_ != nullptr)l
   }
 #endif
 #ifdef USE_MEDIA_PLAYER


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->
```yaml
  on_start: 
    - if:
        condition:
          lambda: return id(reply_location).state != "Another Media Player";
        then: 
          - lambda: id(va).set_speaker(echo_speaker);
        else
          - lambda: id(va).set_speaker(nullptr); # does not work
```
Currently a user can set a speaker dynamically, however they cannot unset the speaker because `local_output_` will always be true once `set_speaker()` is called.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
