### PR TITLE
[http_request] Change default timeout to 4.5s

### DIFF
--- a/esphome/components/http_request/__init__.py
+++ b/esphome/components/http_request/__init__.py
@@ -99,7 +99,7 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_FOLLOW_REDIRECTS, True): cv.boolean,
             cv.Optional(CONF_REDIRECT_LIMIT, 3): cv.int_,
             cv.Optional(
-                CONF_TIMEOUT, default="5s"
+                CONF_TIMEOUT, default="4.5s"
             ): cv.positive_time_period_milliseconds,
             cv.SplitDefault(CONF_ESP8266_DISABLE_SSL_SUPPORT, esp8266=False): cv.All(
                 cv.only_on_esp8266, cv.boolean

--- a/esphome/components/http_request/http_request.h
+++ b/esphome/components/http_request/http_request.h
@@ -80,7 +80,7 @@ class HttpRequestComponent : public Component {
   const char *useragent_{nullptr};
   bool follow_redirects_;
   uint16_t redirect_limit_;
-  uint16_t timeout_{5000};
+  uint16_t timeout_{4500};
   uint32_t watchdog_timeout_{0};
 };
 


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

The default timeout of 5s is too long as it will trigger the watchdog timer (5s timeout) instead of failing gracefully.

This is a breaking change because it changes default configuration, but it required for devices to continue working.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** 
- fixes https://github.com/esphome/issues/issues/6069
- fixes https://github.com/esphome/issues/issues/6074
- fixes https://github.com/EverythingSmartHome/everything-presence-one/issues/200

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#4077

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
