### PR TITLE
[http_request] Allow configure buffer size on ESP-IDF

### DIFF
--- a/esphome/components/http_request/__init__.py
+++ b/esphome/components/http_request/__init__.py
@@ -145,10 +145,8 @@ async def to_code(config):
 
     if CORE.is_esp32:
         if CORE.using_esp_idf:
-            if buffer_size := config.get(CONF_BUFFER_SIZE_RX):
-                cg.add(var.set_buffer_size_rx(buffer_size))
-            if buffer_size := config.get(CONF_BUFFER_SIZE_TX):
-                cg.add(var.set_buffer_size_tx(buffer_size))
+            cg.add(var.set_buffer_size_rx(config[CONF_BUFFER_SIZE_RX]))
+            cg.add(var.set_buffer_size_tx(config[CONF_BUFFER_SIZE_TX]))
 
             esp32.add_idf_sdkconfig_option(
                 "CONFIG_MBEDTLS_CERTIFICATE_BUNDLE",

--- a/esphome/components/http_request/__init__.py
+++ b/esphome/components/http_request/__init__.py
@@ -40,6 +40,8 @@ CONF_VERIFY_SSL = "verify_ssl"
 CONF_FOLLOW_REDIRECTS = "follow_redirects"
 CONF_REDIRECT_LIMIT = "redirect_limit"
 CONF_WATCHDOG_TIMEOUT = "watchdog_timeout"
+CONF_BUFFER_SIZE_RX = "buffer_size_rx"
+CONF_BUFFER_SIZE_TX = "buffer_size_tx"
 
 CONF_MAX_RESPONSE_BUFFER_SIZE = "max_response_buffer_size"
 CONF_ON_RESPONSE = "on_response"
@@ -110,6 +112,12 @@ CONFIG_SCHEMA = cv.All(
                 cv.positive_not_null_time_period,
                 cv.positive_time_period_milliseconds,
             ),
+            cv.SplitDefault(CONF_BUFFER_SIZE_RX, esp32_idf=512): cv.All(
+                cv.uint16_t, cv.only_with_esp_idf
+            ),
+            cv.SplitDefault(CONF_BUFFER_SIZE_TX, esp32_idf=512): cv.All(
+                cv.uint16_t, cv.only_with_esp_idf
+            ),
         }
     ).extend(cv.COMPONENT_SCHEMA),
     cv.require_framework_version(
@@ -137,6 +145,11 @@ async def to_code(config):
 
     if CORE.is_esp32:
         if CORE.using_esp_idf:
+            if buffer_size := config.get(CONF_BUFFER_SIZE_RX):
+                cg.add(var.set_buffer_size_rx(buffer_size))
+            if buffer_size := config.get(CONF_BUFFER_SIZE_TX):
+                cg.add(var.set_buffer_size_tx(buffer_size))
+
             esp32.add_idf_sdkconfig_option(
                 "CONFIG_MBEDTLS_CERTIFICATE_BUNDLE",
                 config.get(CONF_VERIFY_SSL),

--- a/esphome/components/http_request/http_request_idf.cpp
+++ b/esphome/components/http_request/http_request_idf.cpp
@@ -18,6 +18,12 @@ namespace http_request {
 
 static const char *const TAG = "http_request.idf";
 
+void HttpRequestIDF::dump_config() {
+  HttpRequestComponent::dump_config();
+  ESP_LOGCONFIG(TAG, "  Buffer Size RX: %u", this->buffer_size_rx_);
+  ESP_LOGCONFIG(TAG, "  Buffer Size TX: %u", this->buffer_size_tx_);
+}
+
 std::shared_ptr<HttpContainer> HttpRequestIDF::start(std::string url, std::string method, std::string body,
                                                      std::list<Header> headers) {
   if (!network::is_connected()) {
@@ -62,6 +68,9 @@ std::shared_ptr<HttpContainer> HttpRequestIDF::start(std::string url, std::strin
   if (this->useragent_ != nullptr) {
     config.user_agent = this->useragent_;
   }
+
+  config.buffer_size = this->buffer_size_rx_;
+  config.buffer_size_tx = this->buffer_size_tx_;
 
   const uint32_t start = millis();
   watchdog::WatchdogManager wdm(this->get_watchdog_timeout());

--- a/esphome/components/http_request/http_request_idf.h
+++ b/esphome/components/http_request/http_request_idf.h
@@ -24,8 +24,18 @@ class HttpContainerIDF : public HttpContainer {
 
 class HttpRequestIDF : public HttpRequestComponent {
  public:
+  void dump_config() override;
+
   std::shared_ptr<HttpContainer> start(std::string url, std::string method, std::string body,
                                        std::list<Header> headers) override;
+
+  void set_buffer_size_rx(uint16_t buffer_size_rx) { this->buffer_size_rx_ = buffer_size_rx; }
+  void set_buffer_size_tx(uint16_t buffer_size_tx) { this->buffer_size_tx_ = buffer_size_tx; }
+
+ protected:
+  // if zero ESP-IDF will use DEFAULT_HTTP_BUF_SIZE
+  uint16_t buffer_size_rx_{};
+  uint16_t buffer_size_tx_{};
 };
 
 }  // namespace http_request


### PR DESCRIPTION
# What does this implement/fix?

This PR adds the ability to increase the size of buffers when receiving and sending data. For example, it freezes and appears as an addition to PR #7101 and, when configured, allows you to correctly process long redirects from Github.

Will be draft unit PR #7101 accepted.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#4078

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
http_request:
  buffer_size_rx: 1024
  buffer_size_tx: 1024
ota:
  - platform: http_request
    id: ota_http_request
update:
  - platform: http_request
    name: Firmware
    device_class: firmware
    source: https://github.com/$OWNER/$REPO/releases/latest/download/manifest.json
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
