### PR TITLE
[pmwcs3] Add delay after sending REG_READ_START

### DIFF
--- a/esphome/components/pmwcs3/pmwcs3.cpp
+++ b/esphome/components/pmwcs3/pmwcs3.cpp
@@ -72,11 +72,7 @@ void PMWCS3Component::dump_config() {
   LOG_SENSOR("  ", "vwc", this->vwc_sensor_);
 }
 void PMWCS3Component::read_data_() {
-  uint8_t data[8];
-  float e25, ec, temperature, vwc;
-
   /////// Super important !!!! first activate reading PMWCS3_REG_READ_START (if not, return always the same values) ////
-
   if (!this->write_bytes(PMWCS3_REG_READ_START, nullptr, 0)) {
     this->status_set_warning();
     ESP_LOGVV(TAG, "Failed to write into REG_READ_START register !!!");
@@ -85,33 +81,35 @@ void PMWCS3Component::read_data_() {
 
   // Wait for the sensor to be ready.
   // 80ms empirically determined (conservative).
-  delay(80);
-
-  if (!this->read_bytes(PMWCS3_REG_GET_DATA, (uint8_t *) &data, 8)) {
-    ESP_LOGVV(TAG, "Error reading PMWCS3_REG_GET_DATA registers");
-    this->mark_failed();
-    return;
-  }
-  if (this->e25_sensor_ != nullptr) {
-    e25 = ((data[1] << 8) | data[0]) / 100.0;
-    this->e25_sensor_->publish_state(e25);
-    ESP_LOGVV(TAG, "e25: data[0]=%d, data[1]=%d, result=%f", data[0], data[1], e25);
-  }
-  if (this->ec_sensor_ != nullptr) {
-    ec = ((data[3] << 8) | data[2]) / 10.0;
-    this->ec_sensor_->publish_state(ec);
-    ESP_LOGVV(TAG, "ec: data[2]=%d, data[3]=%d, result=%f", data[2], data[3], ec);
-  }
-  if (this->temperature_sensor_ != nullptr) {
-    temperature = ((data[5] << 8) | data[4]) / 100.0;
-    this->temperature_sensor_->publish_state(temperature);
-    ESP_LOGVV(TAG, "temp: data[4]=%d, data[5]=%d, result=%f", data[4], data[5], temperature);
-  }
-  if (this->vwc_sensor_ != nullptr) {
-    vwc = ((data[7] << 8) | data[6]) / 10.0;
-    this->vwc_sensor_->publish_state(vwc);
-    ESP_LOGVV(TAG, "vwc: data[6]=%d, data[7]=%d, result=%f", data[6], data[7], vwc);
-  }
+  this->set_timeout(80, [this] {
+    uint8_t data[8];
+    float e25, ec, temperature, vwc;
+    if (!this->read_bytes(PMWCS3_REG_GET_DATA, (uint8_t *) &data, 8)) {
+      ESP_LOGVV(TAG, "Error reading PMWCS3_REG_GET_DATA registers");
+      this->mark_failed();
+      return;
+    }
+    if (this->e25_sensor_ != nullptr) {
+      e25 = ((data[1] << 8) | data[0]) / 100.0;
+      this->e25_sensor_->publish_state(e25);
+      ESP_LOGVV(TAG, "e25: data[0]=%d, data[1]=%d, result=%f", data[0], data[1], e25);
+    }
+    if (this->ec_sensor_ != nullptr) {
+      ec = ((data[3] << 8) | data[2]) / 10.0;
+      this->ec_sensor_->publish_state(ec);
+      ESP_LOGVV(TAG, "ec: data[2]=%d, data[3]=%d, result=%f", data[2], data[3], ec);
+    }
+    if (this->temperature_sensor_ != nullptr) {
+      temperature = ((data[5] << 8) | data[4]) / 100.0;
+      this->temperature_sensor_->publish_state(temperature);
+      ESP_LOGVV(TAG, "temp: data[4]=%d, data[5]=%d, result=%f", data[4], data[5], temperature);
+    }
+    if (this->vwc_sensor_ != nullptr) {
+      vwc = ((data[7] << 8) | data[6]) / 10.0;
+      this->vwc_sensor_->publish_state(vwc);
+      ESP_LOGVV(TAG, "vwc: data[6]=%d, data[7]=%d, result=%f", data[6], data[7], vwc);
+    }
+  });
 }
 
 }  // namespace pmwcs3

--- a/esphome/components/pmwcs3/pmwcs3.cpp
+++ b/esphome/components/pmwcs3/pmwcs3.cpp
@@ -82,7 +82,10 @@ void PMWCS3Component::read_data_() {
     ESP_LOGVV(TAG, "Failed to write into REG_READ_START register !!!");
     return;
   }
-  // NOLINT  delay(100);
+
+  // Wait for the sensor to be ready.
+  // 80ms empirically determined (conservative).
+  delay(80);
 
   if (!this->read_bytes(PMWCS3_REG_GET_DATA, (uint8_t *) &data, 8)) {
     ESP_LOGVV(TAG, "Error reading PMWCS3_REG_GET_DATA registers");


### PR DESCRIPTION
# What does this implement/fix?

The PMWCS3 sensor does not send values if there is no delay between sending REG_READ_START (request new values to be prepared by the sensor) and REG_GET_DATA (request the new values to be sent)

The delay was actually already in the code, but commented out.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes esphome/issues#6020

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
i2c:

sensor:
  platform: pmwcs3
  update_interval: 15s
  e25:
    name: "pmwcs3 e25"
  ec:
    name: "pmwcs3 ec"
  temperature:
    name: "pmwcs3 temperature"
  vwc:
    name: "pmwcs3 vwc"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
