### PR TITLE
build host with debug to show usefull callstack in gdb

### DIFF
--- a/esphome/components/host/__init__.py
+++ b/esphome/components/host/__init__.py
@@ -1,15 +1,15 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
 from esphome.const import (
+    CONF_MAC_ADDRESS,
     KEY_CORE,
     KEY_FRAMEWORK_VERSION,
     KEY_TARGET_FRAMEWORK,
     KEY_TARGET_PLATFORM,
     PLATFORM_HOST,
-    CONF_MAC_ADDRESS,
 )
 from esphome.core import CORE
 from esphome.helpers import IS_MACOS
-import esphome.config_validation as cv
-import esphome.codegen as cg
 
 from .const import KEY_HOST
 
@@ -43,6 +43,7 @@ async def to_code(config):
     cg.add_define("USE_ESPHOME_HOST_MAC_ADDRESS", config[CONF_MAC_ADDRESS].parts)
     cg.add_build_flag("-std=c++17")
     cg.add_build_flag("-lsodium")
+    cg.add_build_flag("-g3")
     if IS_MACOS:
         cg.add_build_flag("-L/opt/homebrew/lib")
     cg.add_define("ESPHOME_BOARD", "host")


### PR DESCRIPTION
# What does this implement/fix?

gdb show proper lines number that way. It is useful for debugging.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
