### PR TITLE
Add ``--version`` handler to cli

### DIFF
--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -753,7 +753,7 @@ def parse_args(argv):
     parser.add_argument(
         "--version",
         action="version",
-        version=f"ESPHome: {const.__version__}",
+        version=f"Version: {const.__version__}",
         help="Print the ESPHome version and exit.",
     )
 

--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -747,7 +747,14 @@ def parse_args(argv):
     )
 
     parser = argparse.ArgumentParser(
-        description=f"ESPHome v{const.__version__}", parents=[options_parser]
+        description=f"ESPHome {const.__version__}", parents=[options_parser]
+    )
+
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"ESPHome: {const.__version__}",
+        help="Print the ESPHome version and exit.",
     )
 
     mqtt_options = argparse.ArgumentParser(add_help=False)


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

```sh
$ esphome --version
Version: 2024.8.0-dev
$ esphome version  
Version: 2024.8.0-dev
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
