### PR TITLE
http_request watchdog as a component

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -427,6 +427,7 @@ esphome/components/veml7700/* @latonita
 esphome/components/version/* @esphome/core
 esphome/components/voice_assistant/* @jesserockz
 esphome/components/wake_on_lan/* @clydebarrow @willwill2will54
+esphome/components/watchdog/* @oarcher
 esphome/components/waveshare_epaper/* @clydebarrow
 esphome/components/web_server_base/* @OttoWinter
 esphome/components/web_server_idf/* @dentra

--- a/esphome/components/http_request/__init__.py
+++ b/esphome/components/http_request/__init__.py
@@ -14,7 +14,7 @@ from esphome.const import (
 from esphome.core import CORE, Lambda
 
 DEPENDENCIES = ["network"]
-AUTO_LOAD = ["json"]
+AUTO_LOAD = ["json", "watchdog"]
 
 http_request_ns = cg.esphome_ns.namespace("http_request")
 HttpRequestComponent = http_request_ns.class_("HttpRequestComponent", cg.Component)

--- a/esphome/components/http_request/http_request_arduino.cpp
+++ b/esphome/components/http_request/http_request_arduino.cpp
@@ -3,11 +3,11 @@
 #ifdef USE_ARDUINO
 
 #include "esphome/components/network/util.h"
+#include "esphome/components/watchdog/watchdog.h"
+
 #include "esphome/core/application.h"
 #include "esphome/core/defines.h"
 #include "esphome/core/log.h"
-
-#include "watchdog.h"
 
 namespace esphome {
 namespace http_request {

--- a/esphome/components/http_request/http_request_idf.cpp
+++ b/esphome/components/http_request/http_request_idf.cpp
@@ -3,6 +3,8 @@
 #ifdef USE_ESP_IDF
 
 #include "esphome/components/network/util.h"
+#include "esphome/components/watchdog/watchdog.h"
+
 #include "esphome/core/application.h"
 #include "esphome/core/defines.h"
 #include "esphome/core/log.h"
@@ -10,8 +12,6 @@
 #if CONFIG_MBEDTLS_CERTIFICATE_BUNDLE
 #include "esp_crt_bundle.h"
 #endif
-
-#include "watchdog.h"
 
 namespace esphome {
 namespace http_request {

--- a/esphome/components/http_request/ota/ota_http_request.cpp
+++ b/esphome/components/http_request/ota/ota_http_request.cpp
@@ -1,11 +1,11 @@
 #include "ota_http_request.h"
-#include "../watchdog.h"
 
 #include "esphome/core/application.h"
 #include "esphome/core/defines.h"
 #include "esphome/core/log.h"
 
 #include "esphome/components/md5/md5.h"
+#include "esphome/components/watchdog/watchdog.h"
 #include "esphome/components/ota/ota_backend.h"
 #include "esphome/components/ota/ota_backend_arduino_esp32.h"
 #include "esphome/components/ota/ota_backend_arduino_esp8266.h"

--- a/esphome/components/watchdog/__init__.py
+++ b/esphome/components/watchdog/__init__.py
@@ -1,0 +1,1 @@
+CODEOWNERS = ["@oarcher"]

--- a/esphome/components/watchdog/watchdog.cpp
+++ b/esphome/components/watchdog/watchdog.cpp
@@ -15,7 +15,6 @@
 #endif
 
 namespace esphome {
-namespace http_request {
 namespace watchdog {
 
 static const char *const TAG = "http_request.watchdog";
@@ -72,5 +71,4 @@ uint32_t WatchdogManager::get_timeout_() {
 }
 
 }  // namespace watchdog
-}  // namespace http_request
 }  // namespace esphome

--- a/esphome/components/watchdog/watchdog.h
+++ b/esphome/components/watchdog/watchdog.h
@@ -5,7 +5,6 @@
 #include <cstdint>
 
 namespace esphome {
-namespace http_request {
 namespace watchdog {
 
 class WatchdogManager {
@@ -22,5 +21,4 @@ class WatchdogManager {
 };
 
 }  // namespace watchdog
-}  // namespace http_request
 }  // namespace esphome


### PR DESCRIPTION
# What does this implement/fix?

This PR move the watchdog manager out of http_request, so it can be used by other components.



## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [x] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->
Not applicable. the watchdog component is supposed to be used by other components by adding to `__init__.py`
```python
AUTO_LOAD = ["watchdog"]
```

and in cpp files:
```cpp
#include "esphome/components/watchdog/watchdog.h"

{
  // local scope watchdog change in ms
  watchdog::WatchdogManager wdm(7000);
}
```



## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
