### PR TITLE
[matrix_keypad] Add `pin->setup()` to rows and cols

### DIFF
--- a/esphome/components/matrix_keypad/matrix_keypad.cpp
+++ b/esphome/components/matrix_keypad/matrix_keypad.cpp
@@ -8,6 +8,7 @@ static const char *const TAG = "matrix_keypad";
 
 void MatrixKeypad::setup() {
   for (auto *pin : this->rows_) {
+    pin->setup();
     if (!has_diodes_) {
       pin->pin_mode(gpio::FLAG_INPUT);
     } else {
@@ -15,6 +16,7 @@ void MatrixKeypad::setup() {
     }
   }
   for (auto *pin : this->columns_) {
+    pin->setup();
     if (has_pulldowns_) {
       pin->pin_mode(gpio::FLAG_INPUT);
     } else {


### PR DESCRIPTION
# What does this implement/fix?

There is an issue with the `matrix_keypad` component that causes the keypad to only work intermittently.
We discovered this during the development of our [LocalDeck]

We found a workaround by defining an additional `binary_sensor` for each of the rows, however, this leads to log spam.
https://github.com/LocalBytes/localdeck-config/blob/9fa3704d7e8937e87561d747afbc43a770fdb94b/packages/localdeck-codegen/esphome-localdeck.yaml#L257-L300

This change adds a call to `pin->setup()` whilst initialising the matrix_keypad, thus removing the need for the additional sensors.

Presumably, this issue is due parts of `pin->setup()` missing in the mode selection whilst running on an ESP32
But that's just speculation.

Tested via compiling a version of the [LocalDeck] config with the `binary_sensor`'s removed, with no loss of functionality, compared to 2024.07.


<!-- Quick description and explanation of changes -->

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
matrix_keypad:
  id: keypad
  keys: ABCDEFGHIJKLMNOPQRSTUVWX
  rows:
    - pin:
        number: GPIO21
#        allow_other_uses: true
    - pin:
        number: GPIO20
#        allow_other_uses: true
    - pin:
        number: GPIO3
#        allow_other_uses: true
    - pin:
        number: GPIO7
#        allow_other_uses: true
  columns:
    - pin:
        number: GPIO0
        drive_strength: 5mA
    - pin:
        number: GPIO1
        drive_strength: 5mA
    - pin:
        number: GPIO10
        drive_strength: 5mA
    - pin:
        number: GPIO4
        drive_strength: 5mA
    - pin:
        number: GPIO5
        drive_strength: 5mA
    - pin:
        number: GPIO6
        drive_strength: 5mA
binary_sensor:
#  - platform: gpio
#    id: keypad_row_21
#    pin:
#      number: GPIO21
#      allow_other_uses: true
#  - platform: gpio
#    id: keypad_row_20
#    pin:
#      number: GPIO20
#      allow_other_uses: true
#  - platform: gpio
#    id: keypad_row_03
#    pin:
#      number: GPIO3
#      allow_other_uses: true
#  - platform: gpio
#    id: keypad_row_07
#    pin:
#      number: GPIO7
#      allow_other_uses: true
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

[LocalDeck]: https://www.mylocalbytes.com/products/localdeck
