### PR TITLE
[micro_wake_word] Fix VAD detection and modify detection computation

### DIFF
--- a/esphome/components/micro_wake_word/streaming_model.cpp
+++ b/esphome/components/micro_wake_word/streaming_model.cpp
@@ -148,7 +148,7 @@ WakeWordModel::WakeWordModel(const uint8_t *model_start, float probability_cutof
 };
 
 bool WakeWordModel::determine_detected() {
-  int32_t sum = 0;
+  uint32_t sum = 0;
   for (auto &prob : this->recent_streaming_probabilities_) {
     sum += prob;
   }
@@ -175,7 +175,7 @@ VADModel::VADModel(const uint8_t *model_start, float probability_cutoff, size_t 
 };
 
 bool VADModel::determine_detected() {
-  int32_t sum = 0;
+  uint32_t sum = 0;
   for (auto &prob : this->recent_streaming_probabilities_) {
     sum += prob;
   }

--- a/esphome/components/micro_wake_word/streaming_model.cpp
+++ b/esphome/components/micro_wake_word/streaming_model.cpp
@@ -175,12 +175,14 @@ VADModel::VADModel(const uint8_t *model_start, float probability_cutoff, size_t 
 };
 
 bool VADModel::determine_detected() {
-  uint8_t max = 0;
+  int32_t sum = 0;
   for (auto &prob : this->recent_streaming_probabilities_) {
-    max = std::max(prob, max);
+    sum += prob;
   }
 
-  return max > this->probability_cutoff_;
+  float sliding_window_average = static_cast<float>(sum) / static_cast<float>(255 * this->sliding_window_size_);
+
+  return sliding_window_average > this->probability_cutoff_;
 }
 
 }  // namespace micro_wake_word


### PR DESCRIPTION
# What does this implement/fix?

This PR fixes a bug where voice activity was nearly always detected. I originally compared the quantized unsigned integer output of the VAD model to a floating point number between 0 and 1. This PR computes the floating point equivalent of the quantized output before comparing.

Additionally, this PR now uses a sliding window average rather than the max over the sliding window for the VAD probability. This keeps the VAD detection result more stable.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** not applicable

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#4097

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

micro_wake_word:
  vad:
  models:
    - model: okay_nabu
    - model: hey_mycroft
  on_wake_word_detected:
    then:
      - voice_assistant.start:
          wake_word: !lambda return wake_word;

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
