### PR TITLE
Update i2s_audio_speaker.cppi2s_audio/speaker: Fix fallthrough compiler warning

### DIFF
--- a/esphome/components/i2s_audio/speaker/i2s_audio_speaker.cpp
+++ b/esphome/components/i2s_audio/speaker/i2s_audio_speaker.cpp
@@ -233,7 +233,7 @@ void I2SAudioSpeaker::loop() {
   switch (this->state_) {
     case speaker::STATE_STARTING:
       this->start_();
-      [[fallthrough]]
+      [[fallthrough]];
     case speaker::STATE_RUNNING:
     case speaker::STATE_STOPPING:
       this->watch_();

--- a/esphome/components/i2s_audio/speaker/i2s_audio_speaker.cpp
+++ b/esphome/components/i2s_audio/speaker/i2s_audio_speaker.cpp
@@ -233,6 +233,7 @@ void I2SAudioSpeaker::loop() {
   switch (this->state_) {
     case speaker::STATE_STARTING:
       this->start_();
+      [[fallthrough]]
     case speaker::STATE_RUNNING:
     case speaker::STATE_STOPPING:
       this->watch_();


### PR DESCRIPTION
# What does this implement/fix?

The current startup code is relying on a fallthrough on startup. This is causing a compiler warning, which we fix by adding the [[fallthrough]] attribute to the respective switch statement.

**Requires C++17, no helper was added as local build of the firmware did work out of the box**

Warning addressed:
```
src/esphome/components/i2s_audio/speaker/i2s_audio_speaker.cpp: In member function 'virtual void esphome::i2s_audio::I2SAudioSpeaker::loop()':
src/esphome/components/i2s_audio/speaker/i2s_audio_speaker.cpp:235:19: warning: this statement may fall through [-Wimplicit-fallthrough=]
       this->start_();
       ~~~~~~~~~~~~^~
src/esphome/components/i2s_audio/speaker/i2s_audio_speaker.cpp:236:5: note: here
     case speaker::STATE_RUNNING:
     ^~~~
```

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Test Environment

- [X] ESP32 (Build test)
- [X] ESP32 IDF (Build test)
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
The ready made Voice assistand configuration for echo atom

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] ~~Tests have been added to verify that the new code works (under `tests/` folder).~~

If user exposed functionality or configuration variables are added/changed:
  - ~~[ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs)~~
