### PR TITLE
Bump improv library to 1.2.4

### DIFF
--- a/esphome/components/improv_base/__init__.py
+++ b/esphome/components/improv_base/__init__.py
@@ -1,8 +1,7 @@
 import re
 
-import esphome.config_validation as cv
 import esphome.codegen as cg
-
+import esphome.config_validation as cv
 from esphome.const import __version__
 
 CODEOWNERS = ["@esphome/core"]
@@ -39,4 +38,4 @@ def _process_next_url(url: str):
 async def setup_improv_core(var, config):
     if CONF_NEXT_URL in config:
         cg.add(var.set_next_url(_process_next_url(config[CONF_NEXT_URL])))
-    cg.add_library("esphome/Improv", "1.2.3")
+    cg.add_library("improv/Improv", "1.2.4")

--- a/platformio.ini
+++ b/platformio.ini
@@ -35,7 +35,7 @@ build_flags =
 lib_deps =
     esphome/noise-c@0.1.4                  ; api
     makuna/NeoPixelBus@2.7.3               ; neopixelbus
-    esphome/Improv@1.2.3                   ; improv_serial / esp32_improv
+    improv/Improv@1.2.4                    ; improv_serial / esp32_improv
     bblanchon/ArduinoJson@6.18.5           ; json
     wjtje/qr-code-generator-library@1.7.0  ; qr_code
     functionpointer/arduino-MLX90393@1.0.0 ; mlx90393


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

https://github.com/improv-wifi/sdk-cpp/releases/tag/v1.2.4

I have also published the library under the `improv` owner on platformio instead of ESPHome as technically it is a different project, but all under the [Open Home Foundation](https://www.openhomefoundation.org/)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
