### PR TITLE
Remove outdated version block

### DIFF
--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -972,13 +972,6 @@ def run_esphome(argv):
         args.command == "dashboard",
     )
 
-    if sys.version_info < (3, 8, 0):
-        _LOGGER.error(
-            "You're running ESPHome with Python <3.8. ESPHome is no longer compatible "
-            "with this Python version. Please reinstall ESPHome with Python 3.8+"
-        )
-        return 1
-
     if args.command in PRE_CONFIG_ACTIONS:
         try:
             return PRE_CONFIG_ACTIONS[args.command](args)


### PR DESCRIPTION
# What does this implement/fix?

```
- hook id: ruff
- exit code: 1

esphome/__main__.py:976:8: UP036 Version block is outdated for minimum Python version
    |
976 |     if sys.version_info < (3, 8, 0):
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ UP036
977 |         _LOGGER.error(
978 |             "You're running ESPHome with Python <3.8. ESPHome is no longer compatible "
    |
    = help: Remove outdated version block
```
It is already checked here.
```
requires-python = ">=3.9.0"
```


## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
