### PR TITLE
[core] Eliminate nuisance messages from `build_codeowners`

### DIFF
--- a/esphome/loader.py
+++ b/esphome/loader.py
@@ -1,3 +1,4 @@
+from contextlib import AbstractContextManager
 from dataclasses import dataclass
 import importlib
 import importlib.abc
@@ -7,7 +8,7 @@ import logging
 from pathlib import Path
 import sys
 from types import ModuleType
-from typing import Any, Callable, ContextManager, Optional
+from typing import Any, Callable, Optional
 
 from esphome.const import SOURCE_FILE_EXTENSIONS
 from esphome.core import CORE
@@ -22,7 +23,7 @@ class FileResource:
     package: str
     resource: str
 
-    def path(self) -> ContextManager[Path]:
+    def path(self) -> AbstractContextManager[Path]:
         return importlib.resources.as_file(
             importlib.resources.files(self.package) / self.resource
         )
@@ -176,7 +177,7 @@ def _lookup_module(domain):
         module = importlib.import_module(f"esphome.components.{domain}")
     except ImportError as e:
         if "No module named" in str(e):
-            _LOGGER.error(
+            _LOGGER.info(
                 "Unable to import component %s: %s", domain, str(e), exc_info=False
             )
         else:


### PR DESCRIPTION

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Note - import change was required by ruff.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
