### PR TITLE
Cleanup the output of 'esphome config' command.

### DIFF
--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -414,7 +414,9 @@ def command_config(args, config):
     # add the console decoration so the front-end can hide the secrets
     if not args.show_secrets:
         output = re.sub(
-            r"(password|key|psk|ssid)\: (.+)", r"\1: \\033[5m\2\\033[6m", output
+            r"(password|key|psk|ssid)\: ((?!\!secret).+)",
+            r"\1: \\033[5m\2\\033[6m",
+            output,
         )
     if not CORE.quiet:
         safe_print(output)


### PR DESCRIPTION
When running `esphome config` as a CLI tool, the output adds some escaping to any config property that ends with 'password', 'key', 'psk', or 'ssid' so that the dashboard can redact secrets.  I was using `esphome config` for linting purposes and having the output transformed like this was causing problems for me.

I attempted to figure out how to tell when the tool was being run in a context where the output would be going to the dashboard so that it would only do that under those circumstances, but I wasn't able to determine if there was any way to detect that.

Since I couldn't figure that out I did what felt like the next best thing and just modified the regex so that only wraps those values when they don't start with `!secret`, which fixes the problem for my use case, and having the dashboard only redact values that actually contain secrets seems like a win to me too.

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
