### PR TITLE
Adds MQTT component to Alarm Control panel component

### DIFF
--- a/esphome/components/mqtt/__init__.py
+++ b/esphome/components/mqtt/__init__.py
@@ -1,10 +1,11 @@
 import re
 
-import esphome.codegen as cg
-import esphome.config_validation as cv
 from esphome import automation
 from esphome.automation import Condition
+import esphome.codegen as cg
 from esphome.components import logger
+from esphome.components.esp32 import add_idf_sdkconfig_option
+import esphome.config_validation as cv
 from esphome.const import (
     CONF_AVAILABILITY,
     CONF_BIRTH_MESSAGE,
@@ -13,21 +14,21 @@ from esphome.const import (
     CONF_CLIENT_CERTIFICATE,
     CONF_CLIENT_CERTIFICATE_KEY,
     CONF_CLIENT_ID,
-    CONF_COMMAND_TOPIC,
     CONF_COMMAND_RETAIN,
+    CONF_COMMAND_TOPIC,
     CONF_DISCOVERY,
+    CONF_DISCOVERY_OBJECT_ID_GENERATOR,
     CONF_DISCOVERY_PREFIX,
     CONF_DISCOVERY_RETAIN,
     CONF_DISCOVERY_UNIQUE_ID_GENERATOR,
-    CONF_DISCOVERY_OBJECT_ID_GENERATOR,
     CONF_ID,
     CONF_KEEPALIVE,
     CONF_LEVEL,
     CONF_LOG_TOPIC,
-    CONF_ON_JSON_MESSAGE,
-    CONF_ON_MESSAGE,
     CONF_ON_CONNECT,
     CONF_ON_DISCONNECT,
+    CONF_ON_JSON_MESSAGE,
+    CONF_ON_MESSAGE,
     CONF_PASSWORD,
     CONF_PAYLOAD,
     CONF_PAYLOAD_AVAILABLE,
@@ -45,12 +46,11 @@ from esphome.const import (
     CONF_USE_ABBREVIATIONS,
     CONF_USERNAME,
     CONF_WILL_MESSAGE,
+    PLATFORM_BK72XX,
     PLATFORM_ESP32,
     PLATFORM_ESP8266,
-    PLATFORM_BK72XX,
 )
-from esphome.core import coroutine_with_priority, CORE
-from esphome.components.esp32 import add_idf_sdkconfig_option
+from esphome.core import CORE, coroutine_with_priority
 
 DEPENDENCIES = ["network"]
 
@@ -110,6 +110,9 @@ MQTTDisconnectTrigger = mqtt_ns.class_(
 MQTTComponent = mqtt_ns.class_("MQTTComponent", cg.Component)
 MQTTConnectedCondition = mqtt_ns.class_("MQTTConnectedCondition", Condition)
 
+MQTTAlarmControlPanelComponent = mqtt_ns.class_(
+    "MQTTAlarmControlPanelComponent", MQTTComponent
+)
 MQTTBinarySensorComponent = mqtt_ns.class_("MQTTBinarySensorComponent", MQTTComponent)
 MQTTClimateComponent = mqtt_ns.class_("MQTTClimateComponent", MQTTComponent)
 MQTTCoverComponent = mqtt_ns.class_("MQTTCoverComponent", MQTTComponent)

--- a/esphome/components/mqtt/mqtt_alarm_control_panel.cpp
+++ b/esphome/components/mqtt/mqtt_alarm_control_panel.cpp
@@ -45,8 +45,16 @@ void MQTTAlarmControlPanelComponent::setup() {
 void MQTTAlarmControlPanelComponent::dump_config() {
   ESP_LOGCONFIG(TAG, "MQTT alarm_control_panel '%s':", this->alarm_control_panel_->get_name().c_str());
   LOG_MQTT_COMPONENT(true, true)
+  ESP_LOGCONFIG(TAG, "  Supported Features: %" PRIu32, this->alarm_control_panel_->get_supported_features());
+  ESP_LOGCONFIG(TAG, "  Requires Code to Disarm: %s", YESNO(this->alarm_control_panel_->get_requires_code()));
+  ESP_LOGCONFIG(TAG, "  Requires Code To Arm: %s", YESNO(this->alarm_control_panel_->get_requires_code_to_arm()));
 }
-void MQTTAlarmControlPanelComponent::send_discovery(JsonObject root, mqtt::SendDiscoveryConfig &config) {}
+
+void MQTTAlarmControlPanelComponent::send_discovery(JsonObject root, mqtt::SendDiscoveryConfig &config) {
+  root[MQTT_SUPPORTED_FEATURES] = this->alarm_control_panel_->get_supported_features();
+  root[MQTT_CODE_DISARM_REQUIRED] = this->alarm_control_panel_->get_requires_code();
+  root[MQTT_CODE_ARM_REQUIRED] = this->alarm_control_panel_->get_requires_code_to_arm();
+}
 
 std::string MQTTAlarmControlPanelComponent::component_type() const { return "alarm_control_panel"; }
 const EntityBase *MQTTAlarmControlPanelComponent::get_entity() const { return this->alarm_control_panel_; }

--- a/esphome/components/mqtt/mqtt_alarm_control_panel.cpp
+++ b/esphome/components/mqtt/mqtt_alarm_control_panel.cpp
@@ -81,9 +81,41 @@ const EntityBase *MQTTAlarmControlPanelComponent::get_entity() const { return th
 bool MQTTAlarmControlPanelComponent::send_initial_state() { return this->publish_state(); }
 bool MQTTAlarmControlPanelComponent::publish_state() {
   bool success = true;
-  const auto state = this->alarm_control_panel_->get_state();
-  const std::string state_lower = str_lower_case(LOG_STR_ARG(alarm_control_panel_state_to_string(state)));
-  const char *state_s = state_lower.c_str();
+  const char *state_s = "";
+  switch (this->alarm_control_panel_->get_state()) {
+    case ACP_STATE_DISARMED:
+      state_s = "disarmed";
+      break;
+    case ACP_STATE_ARMED_HOME:
+      state_s = "armed_home";
+      break;
+    case ACP_STATE_ARMED_AWAY:
+      state_s = "armed_away";
+      break;
+    case ACP_STATE_ARMED_NIGHT:
+      state_s = "armed_night";
+      break;
+    case ACP_STATE_ARMED_VACATION:
+      state_s = "armed_vacation";
+      break;
+    case ACP_STATE_ARMED_CUSTOM_BYPASS:
+      state_s = "armed_custom_bypass";
+      break;
+    case ACP_STATE_PENDING:
+      state_s = "pending";
+      break;
+    case ACP_STATE_ARMING:
+      state_s = "arming";
+      break;
+    case ACP_STATE_DISARMING:
+      state_s = "disarming";
+      break;
+    case ACP_STATE_TRIGGERED:
+      state_s = "triggered";
+      break;
+    default:
+      state_s = "unknown";
+  }
   if (!this->publish(this->get_state_topic_(), state_s))
     success = false;
   return success;

--- a/esphome/components/mqtt/mqtt_alarm_control_panel.cpp
+++ b/esphome/components/mqtt/mqtt_alarm_control_panel.cpp
@@ -1,0 +1,68 @@
+#include "mqtt_alarm_control_panel.h"
+#include "esphome/core/log.h"
+
+#include "mqtt_const.h"
+
+#ifdef USE_MQTT
+#ifdef USE_ALARM_CONTROL_PANEL
+
+namespace esphome {
+namespace mqtt {
+
+static const char *const TAG = "mqtt.alarm_control_panel";
+
+using namespace esphome::alarm_control_panel;
+
+MQTTAlarmControlPanelComponent::MQTTAlarmControlPanelComponent(AlarmControlPanel *alarm_control_panel)
+    : alarm_control_panel_(alarm_control_panel) {}
+void MQTTAlarmControlPanelComponent::setup() {
+  this->alarm_control_panel_->add_on_state_callback([this]() { this->publish_state(); });
+  this->subscribe(this->get_command_topic_(), [this](const std::string &topic, const std::string &payload) {
+    auto call = this->alarm_control_panel_->make_call();
+    if (strcasecmp(payload.c_str(), "ARM_AWAY") == 0) {
+      call.arm_away();
+    } else if (strcasecmp(payload.c_str(), "ARM_HOME") == 0) {
+      call.arm_home();
+    } else if (strcasecmp(payload.c_str(), "ARM_NIGHT") == 0) {
+      call.arm_night();
+    } else if (strcasecmp(payload.c_str(), "ARM_VACATION") == 0) {
+      call.arm_vacation();
+    } else if (strcasecmp(payload.c_str(), "ARM_CUSTOM_BYPASS") == 0) {
+      call.arm_custom_bypass();
+    } else if (strcasecmp(payload.c_str(), "DISARM") == 0) {
+      call.disarm();
+    } else if (strcasecmp(payload.c_str(), "PENDING") == 0) {
+      call.pending();
+    } else if (strcasecmp(payload.c_str(), "TRIGGERED") == 0) {
+      call.triggered();
+    } else {
+      ESP_LOGW(TAG, "'%s': Received unknown command payload %s", this->friendly_name().c_str(), payload.c_str());
+    }
+    call.perform();
+  });
+}
+
+void MQTTAlarmControlPanelComponent::dump_config() {
+  ESP_LOGCONFIG(TAG, "MQTT alarm_control_panel '%s':", this->alarm_control_panel_->get_name().c_str());
+  LOG_MQTT_COMPONENT(true, true)
+}
+void MQTTAlarmControlPanelComponent::send_discovery(JsonObject root, mqtt::SendDiscoveryConfig &config) {}
+
+std::string MQTTAlarmControlPanelComponent::component_type() const { return "alarm_control_panel"; }
+const EntityBase *MQTTAlarmControlPanelComponent::get_entity() const { return this->alarm_control_panel_; }
+
+bool MQTTAlarmControlPanelComponent::send_initial_state() { return this->publish_state(); }
+bool MQTTAlarmControlPanelComponent::publish_state() {
+  bool success = true;
+  const auto state = this->alarm_control_panel_->get_state();
+  const char *state_s = LOG_STR_ARG(alarm_control_panel_state_to_string(state));
+  if (!this->publish(this->get_state_topic_(), state_s))
+    success = false;
+  return success;
+}
+
+}  // namespace mqtt
+}  // namespace esphome
+
+#endif
+#endif  // USE_MQTT

--- a/esphome/components/mqtt/mqtt_alarm_control_panel.cpp
+++ b/esphome/components/mqtt/mqtt_alarm_control_panel.cpp
@@ -51,7 +51,26 @@ void MQTTAlarmControlPanelComponent::dump_config() {
 }
 
 void MQTTAlarmControlPanelComponent::send_discovery(JsonObject root, mqtt::SendDiscoveryConfig &config) {
-  root[MQTT_SUPPORTED_FEATURES] = this->alarm_control_panel_->get_supported_features();
+  JsonArray supported_features = root.createNestedArray(MQTT_SUPPORTED_FEATURES);
+  const uint32_t acp_supported_features = this->alarm_control_panel_->get_supported_features();
+  if (acp_supported_features & ACP_FEAT_ARM_AWAY) {
+    supported_features.add("arm_away");
+  }
+  if (acp_supported_features & ACP_FEAT_ARM_HOME) {
+    supported_features.add("arm_home");
+  }
+  if (acp_supported_features & ACP_FEAT_ARM_NIGHT) {
+    supported_features.add("arm_night");
+  }
+  if (acp_supported_features & ACP_FEAT_ARM_VACATION) {
+    supported_features.add("arm_vacation");
+  }
+  if (acp_supported_features & ACP_FEAT_ARM_CUSTOM_BYPASS) {
+    supported_features.add("arm_custom_bypass");
+  }
+  if (acp_supported_features & ACP_FEAT_TRIGGER) {
+    supported_features.add("trigger");
+  }
   root[MQTT_CODE_DISARM_REQUIRED] = this->alarm_control_panel_->get_requires_code();
   root[MQTT_CODE_ARM_REQUIRED] = this->alarm_control_panel_->get_requires_code_to_arm();
 }

--- a/esphome/components/mqtt/mqtt_alarm_control_panel.cpp
+++ b/esphome/components/mqtt/mqtt_alarm_control_panel.cpp
@@ -82,7 +82,8 @@ bool MQTTAlarmControlPanelComponent::send_initial_state() { return this->publish
 bool MQTTAlarmControlPanelComponent::publish_state() {
   bool success = true;
   const auto state = this->alarm_control_panel_->get_state();
-  const char *state_s = str_lower_case(LOG_STR_ARG(alarm_control_panel_state_to_string(state))).c_str();
+  const std::string state_lower = str_lower_case(LOG_STR_ARG(alarm_control_panel_state_to_string(state)));
+  const char *state_s = state_lower.c_str();
   if (!this->publish(this->get_state_topic_(), state_s))
     success = false;
   return success;

--- a/esphome/components/mqtt/mqtt_alarm_control_panel.cpp
+++ b/esphome/components/mqtt/mqtt_alarm_control_panel.cpp
@@ -55,7 +55,7 @@ bool MQTTAlarmControlPanelComponent::send_initial_state() { return this->publish
 bool MQTTAlarmControlPanelComponent::publish_state() {
   bool success = true;
   const auto state = this->alarm_control_panel_->get_state();
-  const char *state_s = LOG_STR_ARG(alarm_control_panel_state_to_string(state));
+  const char *state_s = str_lower_case(LOG_STR_ARG(alarm_control_panel_state_to_string(state))).c_str();
   if (!this->publish(this->get_state_topic_(), state_s))
     success = false;
   return success;

--- a/esphome/components/mqtt/mqtt_alarm_control_panel.h
+++ b/esphome/components/mqtt/mqtt_alarm_control_panel.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include "esphome/core/defines.h"
+
+#ifdef USE_MQTT
+#ifdef USE_ALARM_CONTROL_PANEL
+
+#include "mqtt_component.h"
+#include "esphome/components/alarm_control_panel/alarm_control_panel.h"
+
+namespace esphome {
+namespace mqtt {
+
+class MQTTAlarmControlPanelComponent : public mqtt::MQTTComponent {
+ public:
+  explicit MQTTAlarmControlPanelComponent(alarm_control_panel::AlarmControlPanel *alarm_control_panel);
+
+  void setup() override;
+
+  void send_discovery(JsonObject root, mqtt::SendDiscoveryConfig &config) override;
+
+  bool send_initial_state() override;
+
+  bool publish_state();
+
+  void dump_config() override;
+
+ protected:
+  std::string component_type() const override;
+  const EntityBase *get_entity() const override;
+
+  alarm_control_panel::AlarmControlPanel *alarm_control_panel_;
+};
+
+}  // namespace mqtt
+}  // namespace esphome
+
+#endif
+#endif  // USE_MQTT

--- a/tests/components/mqtt/common.yaml
+++ b/tests/components/mqtt/common.yaml
@@ -426,3 +426,9 @@ valve:
       } else {
         return VALVE_CLOSED;
       }
+
+alarm_control_panel:
+  - platform: template
+    name: Alarm Control Panel
+    binary_sensors:
+      - input: some_binary_sensor


### PR DESCRIPTION
# What does this implement/fix?

Makes the Alarm Panel Component implement MQTT using the MQTT component.

After this change, when MQTT is enabled, the Alarm Control Panel component will publish its state to a MQTT state topic and receive commands by subscribing to a MQTT command topic, following the conventions in the MQTT component.

States are published as strings matching these [HA states](https://www.home-assistant.io/integrations/alarm_control_panel.mqtt/).
Valid command strings are (case insensitive): `ARM_AWAY`, `ARM_HOME`, `ARM_NIGHT`, `ARM_VACATION`, `ARM_CUSTOM_BYPASS`, `DISARM`, `PENDING`, and `TRIGGERED`

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#4107

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
mqtt:
  broker: $mqtt_addr

alarm_control_panel:
  - platform: template
    name: Alarm Panel
    binary_sensors:
      - input: zone1
      - input: zone2

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
