### PR TITLE
Add support for doing update entity refresh/check via API.

### DIFF
--- a/esphome/components/api/api.proto
+++ b/esphome/components/api/api.proto
@@ -1872,6 +1872,11 @@ message UpdateStateResponse {
   string release_summary = 9;
   string release_url = 10;
 }
+enum UpdateCommand {
+  UPDATE_COMMAND_NONE = 0;
+  UPDATE_COMMAND_UPDATE = 1;
+  UPDATE_COMMAND_CHECK = 2;
+}
 message UpdateCommandRequest {
   option (id) = 118;
   option (source) = SOURCE_CLIENT;
@@ -1879,5 +1884,5 @@ message UpdateCommandRequest {
   option (no_delay) = true;
 
   fixed32 key = 1;
-  bool install = 2;
+  UpdateCommand command = 2;
 }

--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -1328,7 +1328,17 @@ void APIConnection::update_command(const UpdateCommandRequest &msg) {
   if (update == nullptr)
     return;
 
-  update->perform();
+  switch (msg.command) {
+    case enums::UPDATE_COMMAND_UPDATE:
+      update->perform();
+      break;
+    case enums::UPDATE_COMMAND_CHECK:
+      update->check();
+      break;
+    default:
+      ESP_LOGW(TAG, "Unknown update command: %d", msg.command);
+      break;
+  }
 }
 #endif
 

--- a/esphome/components/api/api_pb2.cpp
+++ b/esphome/components/api/api_pb2.cpp
@@ -567,6 +567,20 @@ template<> const char *proto_enum_to_string<enums::ValveOperation>(enums::ValveO
   }
 }
 #endif
+#ifdef HAS_PROTO_MESSAGE_DUMP
+template<> const char *proto_enum_to_string<enums::UpdateCommand>(enums::UpdateCommand value) {
+  switch (value) {
+    case enums::UPDATE_COMMAND_NONE:
+      return "UPDATE_COMMAND_NONE";
+    case enums::UPDATE_COMMAND_UPDATE:
+      return "UPDATE_COMMAND_UPDATE";
+    case enums::UPDATE_COMMAND_CHECK:
+      return "UPDATE_COMMAND_CHECK";
+    default:
+      return "UNKNOWN";
+  }
+}
+#endif
 bool HelloRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 2: {
@@ -8596,7 +8610,7 @@ void UpdateStateResponse::dump_to(std::string &out) const {
 bool UpdateCommandRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 2: {
-      this->install = value.as_bool();
+      this->command = value.as_enum<enums::UpdateCommand>();
       return true;
     }
     default:
@@ -8615,7 +8629,7 @@ bool UpdateCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
 }
 void UpdateCommandRequest::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_fixed32(1, this->key);
-  buffer.encode_bool(2, this->install);
+  buffer.encode_enum<enums::UpdateCommand>(2, this->command);
 }
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void UpdateCommandRequest::dump_to(std::string &out) const {
@@ -8626,8 +8640,8 @@ void UpdateCommandRequest::dump_to(std::string &out) const {
   out.append(buffer);
   out.append("\n");
 
-  out.append("  install: ");
-  out.append(YESNO(this->install));
+  out.append("  command: ");
+  out.append(proto_enum_to_string<enums::UpdateCommand>(this->command));
   out.append("\n");
   out.append("}");
 }

--- a/esphome/components/api/api_pb2.h
+++ b/esphome/components/api/api_pb2.h
@@ -227,6 +227,11 @@ enum ValveOperation : uint32_t {
   VALVE_OPERATION_IS_OPENING = 1,
   VALVE_OPERATION_IS_CLOSING = 2,
 };
+enum UpdateCommand : uint32_t {
+  UPDATE_COMMAND_NONE = 0,
+  UPDATE_COMMAND_UPDATE = 1,
+  UPDATE_COMMAND_CHECK = 2,
+};
 
 }  // namespace enums
 
@@ -2175,7 +2180,7 @@ class UpdateStateResponse : public ProtoMessage {
 class UpdateCommandRequest : public ProtoMessage {
  public:
   uint32_t key{0};
-  bool install{false};
+  enums::UpdateCommand command{};
   void encode(ProtoWriteBuffer buffer) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;

--- a/esphome/components/http_request/update/http_request_update.h
+++ b/esphome/components/http_request/update/http_request_update.h
@@ -16,6 +16,7 @@ class HttpRequestUpdate : public update::UpdateEntity, public PollingComponent {
   void update() override;
 
   void perform(bool force) override;
+  void check() override { this->update(); }
 
   void set_source_url(const std::string &source_url) { this->source_url_ = source_url; }
 

--- a/esphome/components/update/update_entity.h
+++ b/esphome/components/update/update_entity.h
@@ -33,8 +33,8 @@ class UpdateEntity : public EntityBase, public EntityBase_DeviceClass {
   void publish_state();
 
   void perform() { this->perform(false); }
-
   virtual void perform(bool force) = 0;
+  virtual void check() = 0;
 
   const UpdateInfo &update_info = update_info_;
   const UpdateState &state = state_;


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

This allows the API to tell the update entity to refresh its metadata and check for an update.

Related PRs:
- https://github.com/home-assistant/core/pull/123161
- https://github.com/esphome/aioesphomeapi/pull/914

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
