### PR TITLE
hydreon_rgxx: Fix parsing of data line

### DIFF
--- a/esphome/components/hydreon_rgxx/hydreon_rgxx.cpp
+++ b/esphome/components/hydreon_rgxx/hydreon_rgxx.cpp
@@ -236,7 +236,7 @@ void HydreonRGxxComponent::process_line_() {
   }
   bool is_data_line = false;
   for (int i = 0; i < NUM_SENSORS; i++) {
-    if (this->sensors_[i] != nullptr && this->buffer_starts_with_(PROTOCOL_NAMES[i])) {
+    if (this->sensors_[i] != nullptr && this->buffer_.find(PROTOCOL_NAMES[i]) != std::string::npos) {
       is_data_line = true;
       break;
     }


### PR DESCRIPTION
# What does this implement/fix?

This fixes parsing of received data lines from a RG-15 sensor with the `hydreon_rgxx` component.  In the situation that the `Acc` sensor is not enabled in the yaml configuration, the data line (which starts with `Acc` as the first reported value) would not have been detected as an actual data line, and instead treated as unparsable, with the values not filled into the sensors that are configured.

The error logged in that case is:

    [hydreon_rgxx.sensor:288]: Got unknown line: Acc  0.00 mm, EventAcc  0.00 mm, TotalAcc  0.23 mm, RInt  0.00 mmph

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
sensor:
  - platform: hydreon_rgxx
    model: RG_15
    id: hydreon
    uart_id: uart_rg15
    resolution: high
    # acc: is intentionally not configured here
    total_acc:
      name: "RG-15 Rain Total"
    r_int:
      name: "RG-15 Rain Intensity"
    update_interval: 60s
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
