### PR TITLE
[esp32_improv] Update Improv library to reference new repo/version

### DIFF
--- a/esphome/components/esp32_improv/__init__.py
+++ b/esphome/components/esp32_improv/__init__.py
@@ -1,8 +1,7 @@
 import esphome.codegen as cg
+from esphome.components import binary_sensor, esp32_ble_server, output
 import esphome.config_validation as cv
-from esphome.components import binary_sensor, output, esp32_ble_server
 from esphome.const import CONF_ID
-
 
 AUTO_LOAD = ["esp32_ble_server"]
 CODEOWNERS = ["@jesserockz"]
@@ -50,7 +49,7 @@ async def to_code(config):
     cg.add(ble_server.register_service_component(var))
 
     cg.add_define("USE_IMPROV")
-    cg.add_library("esphome/Improv", "1.2.3")
+    cg.add_library("improv/Improv", "1.2.4")
 
     cg.add(var.set_identify_duration(config[CONF_IDENTIFY_DURATION]))
     cg.add(var.set_authorized_duration(config[CONF_AUTHORIZED_DURATION]))


### PR DESCRIPTION
# What does this implement/fix?

PR #7174 bumped the Improv library, but it didn't get changed here causing builds to fail when ``esp32_improv`` was enabled when on the dev branch of ESPHome. This PR makes the same modification in the ``esp32_improv`` component.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** not applicable

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** not applicable

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

esp32_improv:

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
