### PR TITLE
socket: socket::set_sockaddr() for IPv4 addresses in IPv6 builds

### DIFF
--- a/esphome/components/socket/socket.cpp
+++ b/esphome/components/socket/socket.cpp
@@ -19,24 +19,22 @@ std::unique_ptr<Socket> socket_ip(int type, int protocol) {
 
 socklen_t set_sockaddr(struct sockaddr *addr, socklen_t addrlen, const std::string &ip_address, uint16_t port) {
 #if USE_NETWORK_IPV6
-  if (addrlen < sizeof(sockaddr_in6)) {
-    errno = EINVAL;
-    return 0;
-  }
-  auto *server = reinterpret_cast<sockaddr_in6 *>(addr);
-  memset(server, 0, sizeof(sockaddr_in6));
-  server->sin6_family = AF_INET6;
-  server->sin6_port = htons(port);
+  if (ip_address.find(':') != std::string::npos) {
+    if (addrlen < sizeof(sockaddr_in6)) {
+      errno = EINVAL;
+      return 0;
+    }
+    auto *server = reinterpret_cast<sockaddr_in6 *>(addr);
+    memset(server, 0, sizeof(sockaddr_in6));
+    server->sin6_family = AF_INET6;
+    server->sin6_port = htons(port);
 
-  if (ip_address.find('.') != std::string::npos) {
-    server->sin6_addr.un.u32_addr[3] = inet_addr(ip_address.c_str());
-  } else {
     ip6_addr_t ip6;
     inet6_aton(ip_address.c_str(), &ip6);
     memcpy(server->sin6_addr.un.u32_addr, ip6.addr, sizeof(ip6.addr));
+    return sizeof(sockaddr_in6);
   }
-  return sizeof(sockaddr_in6);
-#else
+#endif /* USE_NETWORK_IPV6 */
   if (addrlen < sizeof(sockaddr_in)) {
     errno = EINVAL;
     return 0;
@@ -47,7 +45,6 @@ socklen_t set_sockaddr(struct sockaddr *addr, socklen_t addrlen, const std::stri
   server->sin_addr.s_addr = inet_addr(ip_address.c_str());
   server->sin_port = htons(port);
   return sizeof(sockaddr_in);
-#endif /* USE_NETWORK_IPV6 */
 }
 
 socklen_t set_sockaddr_any(struct sockaddr *addr, socklen_t addrlen, uint16_t port) {


### PR DESCRIPTION
While testing https://github.com/TheStaticTurtle/esphome_syslog/pull/17 I spotted that logging to Legacy IP addresses while IPv6 is enabled doesn't work, because `socket::set_sockaddr()` still populates a `sockaddr_sin6`.

When passed a Legacy IP address as the input address string, set_sockaddr() should populate the output with a struct sockaddr_in.

<!-- Quick description and explanation of changes -->

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
