### PR TITLE
[max31856] Use cv.frequency as validator

### DIFF
--- a/esphome/components/max31856/sensor.py
+++ b/esphome/components/max31856/sensor.py
@@ -1,6 +1,6 @@
 import esphome.codegen as cg
-import esphome.config_validation as cv
 from esphome.components import sensor, spi
+import esphome.config_validation as cv
 from esphome.const import (
     CONF_MAINS_FILTER,
     DEVICE_CLASS_TEMPERATURE,
@@ -15,8 +15,8 @@ MAX31856Sensor = max31856_ns.class_(
 
 MAX31865ConfigFilter = max31856_ns.enum("MAX31856ConfigFilter")
 FILTER = {
-    "50HZ": MAX31865ConfigFilter.FILTER_50HZ,
-    "60HZ": MAX31865ConfigFilter.FILTER_60HZ,
+    50: MAX31865ConfigFilter.FILTER_50HZ,
+    60: MAX31865ConfigFilter.FILTER_60HZ,
 }
 
 CONFIG_SCHEMA = (
@@ -29,8 +29,8 @@ CONFIG_SCHEMA = (
     )
     .extend(
         {
-            cv.Optional(CONF_MAINS_FILTER, default="60HZ"): cv.enum(
-                FILTER, upper=True, space=""
+            cv.Optional(CONF_MAINS_FILTER, default="60Hz"): cv.All(
+                cv.frequency, cv.enum(FILTER, int=True)
             ),
         }
     )


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Use the `frequency` validator before converting to an integer for the enum.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
