### PR TITLE
[spi] Remove ``SPIDelegateDummy``

### DIFF
--- a/esphome/components/spi/spi.cpp
+++ b/esphome/components/spi/spi.cpp
@@ -7,10 +7,6 @@ namespace spi {
 
 const char *const TAG = "spi";
 
-SPIDelegate *const SPIDelegate::NULL_DELEGATE =  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
-    new SPIDelegateDummy();
-// https://bugs.llvm.org/show_bug.cgi?id=48040
-
 bool SPIDelegate::is_ready() { return true; }
 
 GPIOPin *const NullPin::NULL_PIN = new NullPin();  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
@@ -78,8 +74,6 @@ void SPIComponent::dump_config() {
     ESP_LOGCONFIG(TAG, "  Using software SPI");
   }
 }
-
-void SPIDelegateDummy::begin_transaction() { ESP_LOGE(TAG, "SPIDevice not initialised - did you call spi_setup()?"); }
 
 uint8_t SPIDelegateBitBash::transfer(uint8_t data) { return this->transfer_(data, 8); }
 

--- a/esphome/components/spi/spi.h
+++ b/esphome/components/spi/spi.h
@@ -163,8 +163,6 @@ class Utility {
   }
 };
 
-class SPIDelegateDummy;
-
 // represents a device attached to an SPI bus, with a defined clock rate, mode and bit order. On Arduino this is
 // a thin wrapper over SPIClass.
 class SPIDelegate {
@@ -251,20 +249,6 @@ class SPIDelegate {
   SPIMode mode_{MODE0};
   GPIOPin *cs_pin_{NullPin::NULL_PIN};
   static SPIDelegate *const NULL_DELEGATE;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
-};
-
-/**
- * A dummy SPIDelegate that complains if it's used.
- */
-
-class SPIDelegateDummy : public SPIDelegate {
- public:
-  SPIDelegateDummy() = default;
-
-  uint8_t transfer(uint8_t data) override { return 0; }
-  void end_transaction() override{};
-
-  void begin_transaction() override;
 };
 
 /**

--- a/esphome/components/spi/spi.h
+++ b/esphome/components/spi/spi.h
@@ -248,7 +248,6 @@ class SPIDelegate {
   uint32_t data_rate_{1000000};
   SPIMode mode_{MODE0};
   GPIOPin *cs_pin_{NullPin::NULL_PIN};
-  static SPIDelegate *const NULL_DELEGATE;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 };
 
 /**
@@ -366,7 +365,7 @@ class SPIClient {
 
   virtual void spi_teardown() {
     this->parent_->unregister_device(this);
-    this->delegate_ = SPIDelegate::NULL_DELEGATE;
+    this->delegate_ = nullptr;
   }
 
   bool spi_is_ready() { return this->delegate_->is_ready(); }
@@ -377,7 +376,7 @@ class SPIClient {
   uint32_t data_rate_{1000000};
   SPIComponent *parent_{nullptr};
   GPIOPin *cs_{nullptr};
-  SPIDelegate *delegate_{SPIDelegate::NULL_DELEGATE};
+  SPIDelegate *delegate_{nullptr};
 };
 
 /**


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->
Having this dummy delegate is not useful and will only add confusion to the end users. 
It shows that a component was not developed correctly and should not have been merged in the first place as it clearly did not work and was not tested properly.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
