### PR TITLE
Add mac address filtering to bluetooth_proxy

### DIFF
--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.h
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.h
@@ -47,11 +47,13 @@ enum BluetoothProxySubscriptionFlag : uint32_t {
 class BluetoothProxy : public esp32_ble_tracker::ESPBTDeviceListener, public Component {
  public:
   BluetoothProxy();
+  bool check_bda_matches(esp_ble_gap_cb_param_t::ble_scan_result_evt_param &adv);
   bool parse_device(const esp32_ble_tracker::ESPBTDevice &device) override;
   bool parse_devices(esp_ble_gap_cb_param_t::ble_scan_result_evt_param *advertisements, size_t count) override;
   void dump_config() override;
   void loop() override;
   esp32_ble_tracker::AdvertisementParserType get_advertisement_parser_type() override;
+  void set_addresses(const std::vector<uint64_t> &addresses) { this->address_vec_ = addresses; }
 
   void register_connection(BluetoothConnection *connection) {
     this->connections_.push_back(connection);
@@ -124,6 +126,7 @@ class BluetoothProxy : public esp32_ble_tracker::ESPBTDeviceListener, public Com
   std::vector<BluetoothConnection *> connections_{};
   api::APIConnection *api_connection_{nullptr};
   bool raw_advertisements_{false};
+  std::vector<uint64_t> address_vec_;
 };
 
 extern BluetoothProxy *global_bluetooth_proxy;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)


### PR DESCRIPTION
# What does this implement/fix?

This adds support for filtering mac addresses in the bluetooth proxy. This can be useful for environments where a user only needs to proxy a small number of BLE devices.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** https://github.com/esphome/esphome-docs/pull/4118

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
bluetooth_proxy:
  active: true
  mac_address:
    - "12:34:56:AB:CD:EF"

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
