### PR TITLE
[code-quality] NOLINT readability-identifier-naming

### DIFF
--- a/esphome/core/entity_base.h
+++ b/esphome/core/entity_base.h
@@ -63,7 +63,7 @@ class EntityBase {
   EntityCategory entity_category_{ENTITY_CATEGORY_NONE};
 };
 
-class EntityBase_DeviceClass {
+class EntityBase_DeviceClass {  // NOLINT(readability-identifier-naming)
  public:
   /// Get the device class, using the manual override if set.
   std::string get_device_class();
@@ -74,7 +74,7 @@ class EntityBase_DeviceClass {
   const char *device_class_{nullptr};  ///< Device class override
 };
 
-class EntityBase_UnitOfMeasurement {
+class EntityBase_UnitOfMeasurement {  // NOLINT(readability-identifier-naming)
  public:
   /// Get the unit of measurement, using the manual override if set.
   std::string get_unit_of_measurement();


### PR DESCRIPTION
# What does this implement/fix?

https://github.com/esphome/esphome/actions/runs/10287952345/job/28472545741?pr=7049

```
-class EntityBase_DeviceClass {
+class EntityBaseDeviceClass {
  public:
   /// Get the device class, using the manual override if set.
   std::string get_device_class();
@@ -74,7 +74,7 @@ class EntityBase_DeviceClass {
   const char *device_class_{nullptr};  ///< Device class override
 };
 
-class EntityBase_UnitOfMeasurement {
+class EntityBaseUnitOfMeasurement {
  public:
   /// Get the unit of measurement, using the manual override if set.
   std::string get_unit_of_measurement();

```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
