### PR TITLE
[code-quality] __attribute__((packed))

### DIFF
--- a/esphome/components/climate/climate.h
+++ b/esphome/components/climate/climate.h
@@ -141,7 +141,7 @@ struct ClimateDeviceRestoreState {
       float target_temperature_low;
       float target_temperature_high;
     };
-  };
+  } __attribute__((packed));
   float target_humidity;
 
   /// Convert this struct to a climate call that can be performed.


### PR DESCRIPTION
# What does this implement/fix?

https://github.com/esphome/esphome/actions/runs/10287952345/job/28472545741?pr=7049

```
### File esphome/components/logger/logger.cpp

Error: /home/runner/work/esphome/esphome/esphome/components/climate/climate.h:138:3: error: field  within 'esphome::climate::ClimateDeviceRestoreState' is less aligned than 'esphome::climate::ClimateDeviceRestoreState::(anonymous union at /home/runner/work/esphome/esphome/esphome/components/climate/climate.h:138:3)' and is usually due to 'esphome::climate::ClimateDeviceRestoreState' being packed, which can lead to unaligned accesses [clang-diagnostic-unaligned-access,-warnings-as-errors]
  union {
  ^

```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
