### PR TITLE
fix build error

### DIFF
--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -1336,7 +1336,7 @@ void APIConnection::update_command(const UpdateCommandRequest &msg) {
       update->check();
       break;
     default:
-      ESP_LOGW(TAG, "Unknown update command: %d", msg.command);
+      ESP_LOGW(TAG, "Unknown update command: %lu", msg.command);
       break;
   }
 }

--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -1336,7 +1336,7 @@ void APIConnection::update_command(const UpdateCommandRequest &msg) {
       update->check();
       break;
     default:
-      ESP_LOGW(TAG, "Unknown update command: %lu", msg.command);
+      ESP_LOGW(TAG, "Unknown update command: %" PRIu32, msg.command);
       break;
   }
 }


### PR DESCRIPTION
# What does this implement/fix?

```
src/esphome/components/api/api_connection.cpp: In member function 'virtual void esphome::api::APIConnection::update_command(const esphome::api::UpdateCommandRequest&)':
src/esphome/components/api/api_connection.cpp:1339:21: error: format '%u' expects argument of type 'unsigned int', but argument 5 has type 'long unsigned int' [-Werror=format=]
 1339 |       ESP_LOGW(TAG, "Unknown update command: %ud", msg.command);
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
