### PR TITLE
Add text_align_to_string

### DIFF
--- a/esphome/components/display/display.cpp
+++ b/esphome/components/display/display.cpp
@@ -675,5 +675,36 @@ void DisplayPage::set_prev(DisplayPage *prev) { this->prev_ = prev; }
 void DisplayPage::set_next(DisplayPage *next) { this->next_ = next; }
 const display_writer_t &DisplayPage::get_writer() const { return this->writer_; }
 
+const LogString *text_align_to_string(TextAlign textalign) {
+  switch (textalign) {
+    case TextAlign::TOP_LEFT:
+      return LOG_STR("TOP_LEFT");
+    case TextAlign::TOP_CENTER:
+      return LOG_STR("TOP_CENTER");
+    case TextAlign::TOP_RIGHT:
+      return LOG_STR("TOP_RIGHT");
+    case TextAlign::CENTER_LEFT:
+      return LOG_STR("CENTER_LEFT");
+    case TextAlign::CENTER:
+      return LOG_STR("CENTER");
+    case TextAlign::CENTER_RIGHT:
+      return LOG_STR("CENTER_RIGHT");
+    case TextAlign::BASELINE_LEFT:
+      return LOG_STR("BASELINE_LEFT");
+    case TextAlign::BASELINE_CENTER:
+      return LOG_STR("BASELINE_CENTER");
+    case TextAlign::BASELINE_RIGHT:
+      return LOG_STR("BASELINE_RIGHT");
+    case TextAlign::BOTTOM_LEFT:
+      return LOG_STR("BOTTOM_LEFT");
+    case TextAlign::BOTTOM_CENTER:
+      return LOG_STR("BOTTOM_CENTER");
+    case TextAlign::BOTTOM_RIGHT:
+      return LOG_STR("BOTTOM_RIGHT");
+    default:
+      return LOG_STR("UNKNOWN");
+  }
+}
+
 }  // namespace display
 }  // namespace esphome

--- a/esphome/components/display/display.h
+++ b/esphome/components/display/display.h
@@ -8,6 +8,7 @@
 #include "esphome/core/color.h"
 #include "esphome/core/automation.h"
 #include "esphome/core/time.h"
+#include "esphome/core/log.h"
 #include "display_color_utils.h"
 
 #ifdef USE_GRAPH
@@ -736,6 +737,8 @@ class DisplayOnPageChangeTrigger : public Trigger<DisplayPage *, DisplayPage *> 
   DisplayPage *from_{nullptr};
   DisplayPage *to_{nullptr};
 };
+
+const LogString *text_align_to_string(TextAlign textalign);
 
 }  // namespace display
 }  // namespace esphome


### PR DESCRIPTION
Useful for dump_config implementations

# What does this implement/fix?

Helper method `text_align_to_string(TextAlign textalign)`. Useful for implementations of `Component::dump_config()`

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** Relates to #5949 

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A internal helper method

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
