### PR TITLE
Allow project name and version as improv_serial identity

### DIFF
--- a/esphome/components/improv_serial/__init__.py
+++ b/esphome/components/improv_serial/__init__.py
@@ -1,12 +1,10 @@
+import esphome.codegen as cg
 from esphome.components import improv_base
 from esphome.components.esp32 import get_esp32_variant
-from esphome.components.esp32.const import (
-    VARIANT_ESP32S3,
-)
+from esphome.components.esp32.const import VARIANT_ESP32S3
 from esphome.components.logger import USB_CDC
-from esphome.const import CONF_BAUD_RATE, CONF_HARDWARE_UART, CONF_ID, CONF_LOGGER
-import esphome.codegen as cg
 import esphome.config_validation as cv
+from esphome.const import CONF_BAUD_RATE, CONF_HARDWARE_UART, CONF_ID, CONF_LOGGER
 from esphome.core import CORE
 import esphome.final_validate as fv
 
@@ -19,11 +17,7 @@ improv_serial_ns = cg.esphome_ns.namespace("improv_serial")
 ImprovSerialComponent = improv_serial_ns.class_("ImprovSerialComponent", cg.Component)
 
 CONFIG_SCHEMA = (
-    cv.Schema(
-        {
-            cv.GenerateID(): cv.declare_id(ImprovSerialComponent),
-        }
-    )
+    cv.Schema({cv.GenerateID(): cv.declare_id(ImprovSerialComponent)})
     .extend(improv_base.IMPROV_SCHEMA)
     .extend(cv.COMPONENT_SCHEMA)
 )

--- a/esphome/components/improv_serial/improv_serial_component.cpp
+++ b/esphome/components/improv_serial/improv_serial_component.cpp
@@ -171,6 +171,9 @@ std::vector<uint8_t> ImprovSerialComponent::build_rpc_settings_response_(improv:
 
 std::vector<uint8_t> ImprovSerialComponent::build_version_info_() {
   std::vector<std::string> infos = {"ESPHome", ESPHOME_VERSION, ESPHOME_VARIANT, App.get_name()};
+#ifdef ESPHOME_PROJECT_NAME
+  infos = {ESPHOME_PROJECT_NAME, ESPHOME_PROJECT_VERSION, ESPHOME_VARIANT, App.get_name()};
+#endif
   std::vector<uint8_t> data = improv::build_rpc_response(improv::GET_DEVICE_INFO, infos, false);
   return data;
 };

--- a/esphome/components/improv_serial/improv_serial_component.cpp
+++ b/esphome/components/improv_serial/improv_serial_component.cpp
@@ -170,9 +170,10 @@ std::vector<uint8_t> ImprovSerialComponent::build_rpc_settings_response_(improv:
 }
 
 std::vector<uint8_t> ImprovSerialComponent::build_version_info_() {
-  std::vector<std::string> infos = {"ESPHome", ESPHOME_VERSION, ESPHOME_VARIANT, App.get_name()};
 #ifdef ESPHOME_PROJECT_NAME
-  infos = {ESPHOME_PROJECT_NAME, ESPHOME_PROJECT_VERSION, ESPHOME_VARIANT, App.get_name()};
+  std::vector<std::string> infos = {ESPHOME_PROJECT_NAME, ESPHOME_PROJECT_VERSION, ESPHOME_VARIANT, App.get_name()};
+#else
+  std::vector<std::string> infos = {"ESPHome", ESPHOME_VERSION, ESPHOME_VARIANT, App.get_name()};
 #endif
   std::vector<uint8_t> data = improv::build_rpc_response(improv::GET_DEVICE_INFO, infos, false);
   return data;


### PR DESCRIPTION
# What does this implement/fix?

With this change the improv_serial component will use the project name and version as identify whenever project data is available.

When using ESP Web Tools it's possible to show the project name and version instead of ESPHome. This allows the use of the same firmware check paired with the manifest.json.

Without this change it's not possible to determine if the same ESPHome project firmware is running on the ESP, thus not possible to see the update button. Also it's not possible to install a firmware without erasing first because it's always a new firmware for ESP Web Tools.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** resolves https://github.com/esphome/feature-requests/issues/2591
**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#4125

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

improv_serial:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
