### PR TITLE
[micro_wake_word] Bump ESPMicroSpeechFeatures version to 1.1.0

### DIFF
--- a/esphome/components/micro_wake_word/__init__.py
+++ b/esphome/components/micro_wake_word/__init__.py
@@ -1,39 +1,34 @@
-import logging
-
-import json
 import hashlib
-from urllib.parse import urljoin
+import json
+import logging
 from pathlib import Path
+from urllib.parse import urljoin
+
 import requests
 
-import esphome.config_validation as cv
-import esphome.codegen as cg
-
-from esphome.core import CORE, HexInt
-
-from esphome.components import esp32, microphone
-from esphome import automation, git, external_files
+from esphome import automation, external_files, git
 from esphome.automation import register_action, register_condition
-
-
+import esphome.codegen as cg
+from esphome.components import esp32, microphone
+import esphome.config_validation as cv
 from esphome.const import (
-    __version__,
+    CONF_FILE,
     CONF_ID,
     CONF_MICROPHONE,
     CONF_MODEL,
-    CONF_URL,
-    CONF_FILE,
+    CONF_PASSWORD,
     CONF_PATH,
+    CONF_RAW_DATA_ID,
     CONF_REF,
     CONF_REFRESH,
     CONF_TYPE,
+    CONF_URL,
     CONF_USERNAME,
-    CONF_PASSWORD,
-    CONF_RAW_DATA_ID,
     TYPE_GIT,
     TYPE_LOCAL,
+    __version__,
 )
-
+from esphome.core import CORE, HexInt
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -174,12 +169,12 @@ def _convert_manifest_v1_to_v2(v1_manifest):
         CONF_SLIDING_WINDOW_AVERAGE_SIZE
     ]
     del v2_manifest[KEY_MICRO][CONF_SLIDING_WINDOW_AVERAGE_SIZE]
-    v2_manifest[KEY_MICRO][
-        CONF_TENSOR_ARENA_SIZE
-    ] = 45672  # Original Inception-based V1 manifest models require a minimum of 45672 bytes
-    v2_manifest[KEY_MICRO][
-        CONF_FEATURE_STEP_SIZE
-    ] = 20  # Original Inception-based V1 manifest models use a 20 ms feature step size
+
+    # Original Inception-based V1 manifest models require a minimum of 45672 bytes
+    v2_manifest[KEY_MICRO][CONF_TENSOR_ARENA_SIZE] = 45672
+
+    # Original Inception-based V1 manifest models use a 20 ms feature step size
+    v2_manifest[KEY_MICRO][CONF_FEATURE_STEP_SIZE] = 20
 
     return v2_manifest
 
@@ -502,7 +497,7 @@ async def to_code(config):
             )
 
     cg.add(var.set_features_step_size(manifest[KEY_MICRO][CONF_FEATURE_STEP_SIZE]))
-    cg.add_library("kahrendt/ESPMicroSpeechFeatures", "1.0.0")
+    cg.add_library("kahrendt/ESPMicroSpeechFeatures", "1.1.0")
 
 
 MICRO_WAKE_WORD_ACTION_SCHEMA = cv.Schema({cv.GenerateID(): cv.use_id(MicroWakeWord)})

--- a/platformio.ini
+++ b/platformio.ini
@@ -145,7 +145,7 @@ framework = espidf
 lib_deps =
     ${common:idf.lib_deps}
     droscy/esp_wireguard@0.4.2              ; wireguard
-    kahrendt/ESPMicroSpeechFeatures@1.0.0   ; micro_wake_word
+    kahrendt/ESPMicroSpeechFeatures@1.1.0   ; micro_wake_word
 build_flags =
     ${common:idf.build_flags}
     -Wno-nonnull-compare


### PR DESCRIPTION
# What does this implement/fix?

Bumps the ESPMicroSpeechFeatures PlatformIO library to version 1.1.0, which supports allocating the spectrogram generation buffers to external PSRAM. It falls back to using internal memory if that fails. It also fixes a warning during compilation. I have sucsessfully tested this locally with an ATOM Echo (ESP32 with no PSRAM) and an S3 Box (ESP32-S3 with PSRAM).

(https://registry.platformio.org/libraries/kahrendt/ESPMicroSpeechFeatures
https://github.com/kahrendt/ESPMicroSpeechFeatures

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** not applicable

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** not applicable

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
