### PR TITLE
fix name conflict with zephyr macro

### DIFF
--- a/esphome/components/fingerprint_grow/fingerprint_grow.cpp
+++ b/esphome/components/fingerprint_grow/fingerprint_grow.cpp
@@ -307,7 +307,7 @@ void FingerprintGrowComponent::delete_fingerprint(uint16_t finger_id) {
 
 void FingerprintGrowComponent::delete_all_fingerprints() {
   ESP_LOGI(TAG, "Deleting all stored fingerprints");
-  this->data_ = {EMPTY};
+  this->data_ = {DELETE_ALL};
   switch (this->send_command_()) {
     case OK:
       ESP_LOGI(TAG, "Deleted all fingerprints");

--- a/esphome/components/fingerprint_grow/fingerprint_grow.h
+++ b/esphome/components/fingerprint_grow/fingerprint_grow.h
@@ -36,7 +36,7 @@ enum GrowCommand {
   LOAD = 0x07,
   UPLOAD = 0x08,
   DELETE = 0x0C,
-  EMPTY = 0x0D,
+  DELETE_ALL = 0x0D,  // aka EMPTY
   READ_SYS_PARAM = 0x0F,
   SET_PASSWORD = 0x12,
   VERIFY_PASSWORD = 0x13,


### PR DESCRIPTION
# What does this implement/fix?

part of https://github.com/esphome/esphome/pull/7049. EMPTY is defined in https://github.com/zephyrproject-rtos/zephyr/blob/0b87cb1545d5ec99b4f5e8368bb04dfbee4098b1/include/zephyr/sys/util_macro.h#L335 which causes build error.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
