### PR TITLE
[homeassistant] Add ``HOME_ASSISTANT_IMPORT_CONTROL_SCHEMA``

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -168,7 +168,7 @@ esphome/components/he60r/* @clydebarrow
 esphome/components/heatpumpir/* @rob-deutsch
 esphome/components/hitachi_ac424/* @sourabhjaiswal
 esphome/components/hm3301/* @freekode
-esphome/components/homeassistant/* @OttoWinter
+esphome/components/homeassistant/* @OttoWinter @esphome/core
 esphome/components/honeywell_hih_i2c/* @Benichou34
 esphome/components/honeywellabp/* @RubyBailey
 esphome/components/honeywellabp2_i2c/* @jpfaff

--- a/esphome/components/homeassistant/__init__.py
+++ b/esphome/components/homeassistant/__init__.py
@@ -2,13 +2,20 @@ import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.const import CONF_ATTRIBUTE, CONF_ENTITY_ID, CONF_INTERNAL
 
-CODEOWNERS = ["@OttoWinter"]
+CODEOWNERS = ["@OttoWinter", "@esphome/core"]
 homeassistant_ns = cg.esphome_ns.namespace("homeassistant")
 
 HOME_ASSISTANT_IMPORT_SCHEMA = cv.Schema(
     {
         cv.Required(CONF_ENTITY_ID): cv.entity_id,
         cv.Optional(CONF_ATTRIBUTE): cv.string,
+        cv.Optional(CONF_INTERNAL, default=True): cv.boolean,
+    }
+)
+
+HOME_ASSISTANT_IMPORT_CONTROL_SCHEMA = cv.Schema(
+    {
+        cv.Required(CONF_ENTITY_ID): cv.entity_id,
         cv.Optional(CONF_INTERNAL, default=True): cv.boolean,
     }
 )


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->
This adds a new ``HOME_ASSISTANT_IMPORT_CONTROL_SCHEMA`` which is a dependency of #6455 and #7018

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
