### PR TITLE
Add total_daily_energy mode:lifetime option

### DIFF
--- a/esphome/components/total_daily_energy/sensor.py
+++ b/esphome/components/total_daily_energy/sensor.py
@@ -8,6 +8,7 @@ from esphome.const import (
     CONF_TIME_ID,
     DEVICE_CLASS_ENERGY,
     CONF_METHOD,
+    CONF_MODE,
     STATE_CLASS_TOTAL_INCREASING,
     CONF_UNIT_OF_MEASUREMENT,
     CONF_ACCURACY_DECIMALS,
@@ -19,10 +20,15 @@ DEPENDENCIES = ["time"]
 CONF_POWER_ID = "power_id"
 total_daily_energy_ns = cg.esphome_ns.namespace("total_daily_energy")
 TotalDailyEnergyMethod = total_daily_energy_ns.enum("TotalDailyEnergyMethod")
+TotalDailyEnergyMode = total_daily_energy_ns.enum("TotalDailyEnergyMode")
 TOTAL_DAILY_ENERGY_METHODS = {
     "trapezoid": TotalDailyEnergyMethod.TOTAL_DAILY_ENERGY_METHOD_TRAPEZOID,
     "left": TotalDailyEnergyMethod.TOTAL_DAILY_ENERGY_METHOD_LEFT,
     "right": TotalDailyEnergyMethod.TOTAL_DAILY_ENERGY_METHOD_RIGHT,
+}
+TOTAL_DAILY_ENERGY_MODES = {
+    "daily": TotalDailyEnergyMode.TOTAL_DAILY_ENERGY_MODE_DAILY,
+    "lifetime": TotalDailyEnergyMode.TOTAL_DAILY_ENERGY_MODE_LIFETIME,
 }
 TotalDailyEnergy = total_daily_energy_ns.class_(
     "TotalDailyEnergy", sensor.Sensor, cg.Component
@@ -53,6 +59,9 @@ CONFIG_SCHEMA = (
             ),
             cv.Optional(CONF_METHOD, default="right"): cv.enum(
                 TOTAL_DAILY_ENERGY_METHODS, lower=True
+            ),
+            cv.Optional(CONF_MODE, default="daily"): cv.enum(
+                TOTAL_DAILY_ENERGY_MODES, lower=True
             ),
         }
     )
@@ -90,3 +99,4 @@ async def to_code(config):
     cg.add(var.set_time(time_))
     cg.add(var.set_restore(config[CONF_RESTORE]))
     cg.add(var.set_method(config[CONF_METHOD]))
+    cg.add(var.set_mode(config[CONF_MODE]))

--- a/esphome/components/total_daily_energy/total_daily_energy.h
+++ b/esphome/components/total_daily_energy/total_daily_energy.h
@@ -15,12 +15,18 @@ enum TotalDailyEnergyMethod {
   TOTAL_DAILY_ENERGY_METHOD_RIGHT,
 };
 
+enum TotalDailyEnergyMode {
+  TOTAL_DAILY_ENERGY_MODE_DAILY = 0,
+  TOTAL_DAILY_ENERGY_MODE_LIFETIME,
+};
+
 class TotalDailyEnergy : public sensor::Sensor, public Component {
  public:
   void set_restore(bool restore) { restore_ = restore; }
   void set_time(time::RealTimeClock *time) { time_ = time; }
   void set_parent(Sensor *parent) { parent_ = parent; }
   void set_method(TotalDailyEnergyMethod method) { method_ = method; }
+  void set_mode(TotalDailyEnergyMode mode) { mode_ = mode; }
   void setup() override;
   void dump_config() override;
   float get_setup_priority() const override { return setup_priority::DATA; }
@@ -35,10 +41,12 @@ class TotalDailyEnergy : public sensor::Sensor, public Component {
   time::RealTimeClock *time_;
   Sensor *parent_;
   TotalDailyEnergyMethod method_;
+  TotalDailyEnergyMode mode_;
   uint16_t last_day_of_year_{};
   uint32_t last_update_{0};
   bool restore_;
-  float total_energy_{0.0f};
+  float today_energy_{0.0f};
+  float lifetime_energy_{0.0f};
   float last_power_state_{0.0f};
 };
 


### PR DESCRIPTION
# What does this implement/fix?

Added an optional mode to the **total_daily_energy** component which allows it to never reset back to zero.  

In order to facilitate this, the variable **total_energy_** was renamed to **today_energy_** and then **lifetime_energy_** was added.  This allows the existing logic to remain almost completely unchanged, the only difference is, when mode is set to lifetime:
* If restore:true then the value is restored to **lifetime_energy_** instead of **today_energy_**
* On publish and save, **lifetime_energy_** is added back into **today_energy_** before processing the value
* When the day ticks over at midnight, **today_energy_** is still zeroed, but is first added into **lifetime_energy_**

This implementation also avoids the "adding a really small value to a really large value in floating point sometimes does nothing" issue.  It does so preserving the existing logic around **today_energy_** (was: **total_energy_**) by still zeroing it every day.  But then adds a "second level" of aggregation, once a day, into **lifetime_energy_**.  

I'm not sure if that issue with floating point is the reason why there's a **total_daily_energy** component but not a **total_energy** version?  Either way, this basically sidesteps the issue.  Sampling once per second, it would take 236 years for the difference in magnitude between **today_energy_** and **lifetime_energy_** to equal the magnitude difference between **[new reading to add]** and **today_energy_** just before midnight each day.  For lower sample rates that would be an even larger number of centuries.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#4131

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

  - source:
      type: git
      url: https://github.com/nkinnan/esphome
      ref: "add-tde-lifetime"
    components: [ total_daily_energy ]
    refresh: 60s


  - platform: total_daily_energy
    name: "Active Energy Resets to Zero At Midnight And On Reboot"
    power_id: active_power_sensor
    restore: false

  - platform: total_daily_energy
    name: "Active Energy Resets to Zero At Midnight"
    power_id: active_power_sensor
    restore: true

  - platform: total_daily_energy
    name: "Active Energy Lifetime"
    power_id: active_power_sensor
    restore: true
    mode: lifetime

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
