### PR TITLE
[code-quality] fix readability-named-parameter

### DIFF
--- a/esphome/core/automation.h
+++ b/esphome/core/automation.h
@@ -82,7 +82,7 @@ template<typename... Ts> class Condition {
   }
 
  protected:
-  template<int... S> bool check_tuple_(const std::tuple<Ts...> &tuple, seq<S...>) {
+  template<int... S> bool check_tuple_(const std::tuple<Ts...> &tuple, seq<S...> /*unused*/) {
     return this->check(std::get<S>(tuple)...);
   }
 };
@@ -156,7 +156,7 @@ template<typename... Ts> class Action {
       }
     }
   }
-  template<int... S> void play_next_tuple_(const std::tuple<Ts...> &tuple, seq<S...>) {
+  template<int... S> void play_next_tuple_(const std::tuple<Ts...> &tuple, seq<S...> /*unused*/) {
     this->play_next_(std::get<S>(tuple)...);
   }
   void play_next_tuple_(const std::tuple<Ts...> &tuple) {
@@ -223,7 +223,9 @@ template<typename... Ts> class ActionList {
   }
 
  protected:
-  template<int... S> void play_tuple_(const std::tuple<Ts...> &tuple, seq<S...>) { this->play(std::get<S>(tuple)...); }
+  template<int... S> void play_tuple_(const std::tuple<Ts...> &tuple, seq<S...> /*unused*/) {
+    this->play(std::get<S>(tuple)...);
+  }
 
   Action<Ts...> *actions_begin_{nullptr};
   Action<Ts...> *actions_end_{nullptr};

--- a/esphome/core/optional.h
+++ b/esphome/core/optional.h
@@ -24,7 +24,7 @@ namespace esphome {
 
 struct nullopt_t {  // NOLINT
   struct init {};   // NOLINT
-  nullopt_t(init) {}
+  nullopt_t(init /*unused*/) {}
 };
 
 // extra parenthesis to prevent the most vexing parse:
@@ -42,13 +42,13 @@ template<typename T> class optional {  // NOLINT
 
   optional() {}
 
-  optional(nullopt_t) {}
+  optional(nullopt_t /*unused*/) {}
 
   optional(T const &arg) : has_value_(true), value_(arg) {}  // NOLINT
 
   template<class U> optional(optional<U> const &other) : has_value_(other.has_value()), value_(other.value()) {}
 
-  optional &operator=(nullopt_t) {
+  optional &operator=(nullopt_t /*unused*/) {
     reset();
     return *this;
   }
@@ -130,29 +130,29 @@ template<typename T, typename U> inline bool operator>=(optional<T> const &x, op
 
 // Comparison with nullopt
 
-template<typename T> inline bool operator==(optional<T> const &x, nullopt_t) { return (!x); }
+template<typename T> inline bool operator==(optional<T> const &x, nullopt_t /*unused*/) { return (!x); }
 
-template<typename T> inline bool operator==(nullopt_t, optional<T> const &x) { return (!x); }
+template<typename T> inline bool operator==(nullopt_t /*unused*/, optional<T> const &x) { return (!x); }
 
-template<typename T> inline bool operator!=(optional<T> const &x, nullopt_t) { return bool(x); }
+template<typename T> inline bool operator!=(optional<T> const &x, nullopt_t /*unused*/) { return bool(x); }
 
-template<typename T> inline bool operator!=(nullopt_t, optional<T> const &x) { return bool(x); }
+template<typename T> inline bool operator!=(nullopt_t /*unused*/, optional<T> const &x) { return bool(x); }
 
-template<typename T> inline bool operator<(optional<T> const &, nullopt_t) { return false; }
+template<typename T> inline bool operator<(optional<T> const & /*unused*/, nullopt_t /*unused*/) { return false; }
 
-template<typename T> inline bool operator<(nullopt_t, optional<T> const &x) { return bool(x); }
+template<typename T> inline bool operator<(nullopt_t /*unused*/, optional<T> const &x) { return bool(x); }
 
-template<typename T> inline bool operator<=(optional<T> const &x, nullopt_t) { return (!x); }
+template<typename T> inline bool operator<=(optional<T> const &x, nullopt_t /*unused*/) { return (!x); }
 
-template<typename T> inline bool operator<=(nullopt_t, optional<T> const &) { return true; }
+template<typename T> inline bool operator<=(nullopt_t /*unused*/, optional<T> const & /*unused*/) { return true; }
 
-template<typename T> inline bool operator>(optional<T> const &x, nullopt_t) { return bool(x); }
+template<typename T> inline bool operator>(optional<T> const &x, nullopt_t /*unused*/) { return bool(x); }
 
-template<typename T> inline bool operator>(nullopt_t, optional<T> const &) { return false; }
+template<typename T> inline bool operator>(nullopt_t /*unused*/, optional<T> const & /*unused*/) { return false; }
 
-template<typename T> inline bool operator>=(optional<T> const &, nullopt_t) { return true; }
+template<typename T> inline bool operator>=(optional<T> const & /*unused*/, nullopt_t /*unused*/) { return true; }
 
-template<typename T> inline bool operator>=(nullopt_t, optional<T> const &x) { return (!x); }
+template<typename T> inline bool operator>=(nullopt_t /*unused*/, optional<T> const &x) { return (!x); }
 
 // Comparison with T
 


### PR DESCRIPTION
# What does this implement/fix?

part of https://github.com/esphome/esphome/pull/7049

```
  [##############################]  100%
### File esphome/components/zephyr/preferences.cpp

esphome/core/optional.h:27:17: error: all parameters should be named in a function [readability-named-parameter,-warnings-as-errors]
  nullopt_t(init) {}
                ^
                 /*unused*/
esphome/core/optional.h:45:21: error: all parameters should be named in a function [readability-named-parameter,-warnings-as-errors]
  optional(nullopt_t) {}
                    ^
                     /*unused*/
esphome/core/optional.h:51:32: error: all parameters should be named in a function [readability-named-parameter,-warnings-as-errors]
  optional &operator=(nullopt_t) {
                               ^
                                /*unused*/
esphome/core/optional.h:133:76: error: all parameters should be named in a function [readability-named-parameter,-warnings-as-errors]
template<typename T> inline bool operator==(optional<T> const &x, nullopt_t) { return (!x); }
                                                                           ^
                                                                            /*unused*/
esphome/core/optional.h:135:54: error: all parameters should be named in a function [readability-named-parameter,-warnings-as-errors]
template<typename T> inline bool operator==(nullopt_t, optional<T> const &x) { return (!x); }
                                                     ^
                                                      /*unused*/
esphome/core/optional.h:137:76: error: all parameters should be named in a function [readability-named-parameter,-warnings-as-errors]
template<typename T> inline bool operator!=(optional<T> const &x, nullopt_t) { return bool(x); }
                                                                           ^
                                                                            /*unused*/
esphome/core/optional.h:139:54: error: all parameters should be named in a function [readability-named-parameter,-warnings-as-errors]
template<typename T> inline bool operator!=(nullopt_t, optional<T> const &x) { return bool(x); }
                                                     ^
                                                      /*unused*/
esphome/core/optional.h:141:63: error: all parameters should be named in a function [readability-named-parameter,-warnings-as-errors]
template<typename T> inline bool operator<(optional<T> const &, nullopt_t) { return false; }
                                                              ^
                                                               /*unused*/ /*unused*/
esphome/core/optional.h:143:53: error: all parameters should be named in a function [readability-named-parameter,-warnings-as-errors]
template<typename T> inline bool operator<(nullopt_t, optional<T> const &x) { return bool(x); }
                                                    ^
                                                     /*unused*/
esphome/core/optional.h:145:76: error: all parameters should be named in a function [readability-named-parameter,-warnings-as-errors]
template<typename T> inline bool operator<=(optional<T> const &x, nullopt_t) { return (!x); }
                                                                           ^
                                                                            /*unused*/
esphome/core/optional.h:147:54: error: all parameters should be named in a function [readability-named-parameter,-warnings-as-errors]
template<typename T> inline bool operator<=(nullopt_t, optional<T> const &) { return true; }
                                                     ^
                                                      /*unused*/           /*unused*/
esphome/core/optional.h:149:75: error: all parameters should be named in a function [readability-named-parameter,-warnings-as-errors]
template<typename T> inline bool operator>(optional<T> const &x, nullopt_t) { return bool(x); }
                                                                          ^
                                                                           /*unused*/
esphome/core/optional.h:151:53: error: all parameters should be named in a function [readability-named-parameter,-warnings-as-errors]
template<typename T> inline bool operator>(nullopt_t, optional<T> const &) { return false; }
                                                    ^
                                                     /*unused*/           /*unused*/
esphome/core/optional.h:153:64: error: all parameters should be named in a function [readability-named-parameter,-warnings-as-errors]
template<typename T> inline bool operator>=(optional<T> const &, nullopt_t) { return true; }
                                                               ^
                                                                /*unused*/ /*unused*/
esphome/core/optional.h:155:54: error: all parameters should be named in a function [readability-named-parameter,-warnings-as-errors]
template<typename T> inline bool operator>=(nullopt_t, optional<T> const &x) { return (!x); }
                                                     ^
                                                      /*unused*/


### File esphome/components/time/real_time_clock.cpp

esphome/core/automation.h:85:81: error: all parameters should be named in a function [readability-named-parameter,-warnings-as-errors]
  template<int... S> bool check_tuple_(const std::tuple<Ts...> &tuple, seq<S...>) {
                                                                                ^
                                                                                 /*unused*/
esphome/core/automation.h:159:85: error: all parameters should be named in a function [readability-named-parameter,-warnings-as-errors]
  template<int... S> void play_next_tuple_(const std::tuple<Ts...> &tuple, seq<S...>) {
                                                                                    ^
                                                                                     /*unused*/
esphome/core/automation.h:226:80: error: all parameters should be named in a function [readability-named-parameter,-warnings-as-errors]
  template<int... S> void play_tuple_(const std::tuple<Ts...> &tuple, seq<S...>) { this->play(std::get<S>(tuple)...); }
                                                                               ^
                                                                                /*unused*/
esphome/core/optional.h:27:17: error: all parameters should be named in a function [readability-named-parameter,-warnings-as-errors]
  nullopt_t(init) {}
                ^
                 /*unused*/
esphome/core/optional.h:45:21: error: all parameters should be named in a function [readability-named-parameter,-warnings-as-errors]
  optional(nullopt_t) {}
                    ^
                     /*unused*/
esphome/core/optional.h:51:32: error: all parameters should be named in a function [readability-named-parameter,-warnings-as-errors]
  optional &operator=(nullopt_t) {
                               ^
                                /*unused*/
esphome/core/optional.h:133:76: error: all parameters should be named in a function [readability-named-parameter,-warnings-as-errors]
template<typename T> inline bool operator==(optional<T> const &x, nullopt_t) { return (!x); }
                                                                           ^
                                                                            /*unused*/
esphome/core/optional.h:135:54: error: all parameters should be named in a function [readability-named-parameter,-warnings-as-errors]
template<typename T> inline bool operator==(nullopt_t, optional<T> const &x) { return (!x); }
                                                     ^
                                                      /*unused*/
esphome/core/optional.h:137:76: error: all parameters should be named in a function [readability-named-parameter,-warnings-as-errors]
template<typename T> inline bool operator!=(optional<T> const &x, nullopt_t) { return bool(x); }
                                                                           ^
                                                                            /*unused*/
esphome/core/optional.h:139:54: error: all parameters should be named in a function [readability-named-parameter,-warnings-as-errors]
template<typename T> inline bool operator!=(nullopt_t, optional<T> const &x) { return bool(x); }
                                                     ^
                                                      /*unused*/
esphome/core/optional.h:141:63: error: all parameters should be named in a function [readability-named-parameter,-warnings-as-errors]
template<typename T> inline bool operator<(optional<T> const &, nullopt_t) { return false; }
                                                              ^
                                                               /*unused*/ /*unused*/
esphome/core/optional.h:143:53: error: all parameters should be named in a function [readability-named-parameter,-warnings-as-errors]
template<typename T> inline bool operator<(nullopt_t, optional<T> const &x) { return bool(x); }
                                                    ^
                                                     /*unused*/
esphome/core/optional.h:145:76: error: all parameters should be named in a function [readability-named-parameter,-warnings-as-errors]
template<typename T> inline bool operator<=(optional<T> const &x, nullopt_t) { return (!x); }
                                                                           ^
                                                                            /*unused*/
esphome/core/optional.h:147:54: error: all parameters should be named in a function [readability-named-parameter,-warnings-as-errors]
template<typename T> inline bool operator<=(nullopt_t, optional<T> const &) { return true; }
                                                     ^
                                                      /*unused*/           /*unused*/
esphome/core/optional.h:149:75: error: all parameters should be named in a function [readability-named-parameter,-warnings-as-errors]
template<typename T> inline bool operator>(optional<T> const &x, nullopt_t) { return bool(x); }
                                                                          ^
                                                                           /*unused*/
esphome/core/optional.h:151:53: error: all parameters should be named in a function [readability-named-parameter,-warnings-as-errors]
template<typename T> inline bool operator>(nullopt_t, optional<T> const &) { return false; }
                                                    ^
                                                     /*unused*/           /*unused*/
esphome/core/optional.h:153:64: error: all parameters should be named in a function [readability-named-parameter,-warnings-as-errors]
template<typename T> inline bool operator>=(optional<T> const &, nullopt_t) { return true; }
                                                               ^
                                                                /*unused*/ /*unused*/
esphome/core/optional.h:155:54: error: all parameters should be named in a function [readability-named-parameter,-warnings-as-errors]
template<typename T> inline bool operator>=(nullopt_t, optional<T> const &x) { return (!x); }
                                                     ^
                                                      /*unused*/


### File esphome/core/helpers.cpp

esphome/core/optional.h:27:17: error: all parameters should be named in a function [readability-named-parameter,-warnings-as-errors]
  nullopt_t(init) {}
                ^
                 /*unused*/
esphome/core/optional.h:45:21: error: all parameters should be named in a function [readability-named-parameter,-warnings-as-errors]
  optional(nullopt_t) {}
                    ^
                     /*unused*/
esphome/core/optional.h:51:32: error: all parameters should be named in a function [readability-named-parameter,-warnings-as-errors]
  optional &operator=(nullopt_t) {
                               ^
                                /*unused*/
esphome/core/optional.h:133:76: error: all parameters should be named in a function [readability-named-parameter,-warnings-as-errors]
template<typename T> inline bool operator==(optional<T> const &x, nullopt_t) { return (!x); }
                                                                           ^
                                                                            /*unused*/
esphome/core/optional.h:135:54: error: all parameters should be named in a function [readability-named-parameter,-warnings-as-errors]
template<typename T> inline bool operator==(nullopt_t, optional<T> const &x) { return (!x); }
                                                     ^
                                                      /*unused*/
esphome/core/optional.h:137:76: error: all parameters should be named in a function [readability-named-parameter,-warnings-as-errors]
template<typename T> inline bool operator!=(optional<T> const &x, nullopt_t) { return bool(x); }
                                                                           ^
                                                                            /*unused*/
esphome/core/optional.h:139:54: error: all parameters should be named in a function [readability-named-parameter,-warnings-as-errors]
template<typename T> inline bool operator!=(nullopt_t, optional<T> const &x) { return bool(x); }
                                                     ^
                                                      /*unused*/
esphome/core/optional.h:141:63: error: all parameters should be named in a function [readability-named-parameter,-warnings-as-errors]
template<typename T> inline bool operator<(optional<T> const &, nullopt_t) { return false; }
                                                              ^
                                                               /*unused*/ /*unused*/
esphome/core/optional.h:143:53: error: all parameters should be named in a function [readability-named-parameter,-warnings-as-errors]
template<typename T> inline bool operator<(nullopt_t, optional<T> const &x) { return bool(x); }
                                                    ^
                                                     /*unused*/
esphome/core/optional.h:145:76: error: all parameters should be named in a function [readability-named-parameter,-warnings-as-errors]
template<typename T> inline bool operator<=(optional<T> const &x, nullopt_t) { return (!x); }
                                                                           ^
                                                                            /*unused*/
esphome/core/optional.h:147:54: error: all parameters should be named in a function [readability-named-parameter,-warnings-as-errors]
template<typename T> inline bool operator<=(nullopt_t, optional<T> const &) { return true; }
                                                     ^
                                                      /*unused*/           /*unused*/
esphome/core/optional.h:149:75: error: all parameters should be named in a function [readability-named-parameter,-warnings-as-errors]
template<typename T> inline bool operator>(optional<T> const &x, nullopt_t) { return bool(x); }
                                                                          ^
                                                                           /*unused*/
esphome/core/optional.h:151:53: error: all parameters should be named in a function [readability-named-parameter,-warnings-as-errors]
template<typename T> inline bool operator>(nullopt_t, optional<T> const &) { return false; }
                                                    ^
                                                     /*unused*/           /*unused*/
esphome/core/optional.h:153:64: error: all parameters should be named in a function [readability-named-parameter,-warnings-as-errors]
template<typename T> inline bool operator>=(optional<T> const &, nullopt_t) { return true; }
                                                               ^
                                                                /*unused*/ /*unused*/
esphome/core/optional.h:155:54: error: all parameters should be named in a function [readability-named-parameter,-warnings-as-errors]
template<typename T> inline bool operator>=(nullopt_t, optional<T> const &x) { return (!x); }
                                                     ^
                                                      /*unused*/




### File esphome/components/logger/logger_zephyr.cpp

esphome/core/automation.h:85:81: error: all parameters should be named in a function [readability-named-parameter,-warnings-as-errors]
  template<int... S> bool check_tuple_(const std::tuple<Ts...> &tuple, seq<S...>) {
                                                                                ^
                                                                                 /*unused*/
esphome/core/automation.h:159:85: error: all parameters should be named in a function [readability-named-parameter,-warnings-as-errors]
  template<int... S> void play_next_tuple_(const std::tuple<Ts...> &tuple, seq<S...>) {
                                                                                    ^
                                                                                     /*unused*/
esphome/core/automation.h:226:80: error: all parameters should be named in a function [readability-named-parameter,-warnings-as-errors]
  template<int... S> void play_tuple_(const std::tuple<Ts...> &tuple, seq<S...>) { this->play(std::get<S>(tuple)...); }
                                                                               ^
                                                                                /*unused*/
esphome/core/optional.h:27:17: error: all parameters should be named in a function [readability-named-parameter,-warnings-as-errors]
  nullopt_t(init) {}
                ^
                 /*unused*/
esphome/core/optional.h:45:21: error: all parameters should be named in a function [readability-named-parameter,-warnings-as-errors]
  optional(nullopt_t) {}
                    ^
                     /*unused*/
esphome/core/optional.h:51:32: error: all parameters should be named in a function [readability-named-parameter,-warnings-as-errors]
  optional &operator=(nullopt_t) {
                               ^
                                /*unused*/
esphome/core/optional.h:133:76: error: all parameters should be named in a function [readability-named-parameter,-warnings-as-errors]
template<typename T> inline bool operator==(optional<T> const &x, nullopt_t) { return (!x); }
                                                                           ^
                                                                            /*unused*/
esphome/core/optional.h:135:54: error: all parameters should be named in a function [readability-named-parameter,-warnings-as-errors]
template<typename T> inline bool operator==(nullopt_t, optional<T> const &x) { return (!x); }
                                                     ^
                                                      /*unused*/
esphome/core/optional.h:137:76: error: all parameters should be named in a function [readability-named-parameter,-warnings-as-errors]
template<typename T> inline bool operator!=(optional<T> const &x, nullopt_t) { return bool(x); }
                                                                           ^
                                                                            /*unused*/
esphome/core/optional.h:139:54: error: all parameters should be named in a function [readability-named-parameter,-warnings-as-errors]
template<typename T> inline bool operator!=(nullopt_t, optional<T> const &x) { return bool(x); }
                                                     ^
                                                      /*unused*/
esphome/core/optional.h:141:63: error: all parameters should be named in a function [readability-named-parameter,-warnings-as-errors]
template<typename T> inline bool operator<(optional<T> const &, nullopt_t) { return false; }
                                                              ^
                                                               /*unused*/ /*unused*/
esphome/core/optional.h:143:53: error: all parameters should be named in a function [readability-named-parameter,-warnings-as-errors]
template<typename T> inline bool operator<(nullopt_t, optional<T> const &x) { return bool(x); }
                                                    ^
                                                     /*unused*/
esphome/core/optional.h:145:76: error: all parameters should be named in a function [readability-named-parameter,-warnings-as-errors]
template<typename T> inline bool operator<=(optional<T> const &x, nullopt_t) { return (!x); }
                                                                           ^
                                                                            /*unused*/
esphome/core/optional.h:147:54: error: all parameters should be named in a function [readability-named-parameter,-warnings-as-errors]
template<typename T> inline bool operator<=(nullopt_t, optional<T> const &) { return true; }
                                                     ^
                                                      /*unused*/           /*unused*/
esphome/core/optional.h:149:75: error: all parameters should be named in a function [readability-named-parameter,-warnings-as-errors]
template<typename T> inline bool operator>(optional<T> const &x, nullopt_t) { return bool(x); }
                                                                          ^
                                                                           /*unused*/
esphome/core/optional.h:151:53: error: all parameters should be named in a function [readability-named-parameter,-warnings-as-errors]
template<typename T> inline bool operator>(nullopt_t, optional<T> const &) { return false; }
                                                    ^
                                                     /*unused*/           /*unused*/
esphome/core/optional.h:153:64: error: all parameters should be named in a function [readability-named-parameter,-warnings-as-errors]
template<typename T> inline bool operator>=(optional<T> const &, nullopt_t) { return true; }
                                                               ^
                                                                /*unused*/ /*unused*/
esphome/core/optional.h:155:54: error: all parameters should be named in a function [readability-named-parameter,-warnings-as-errors]
template<typename T> inline bool operator>=(nullopt_t, optional<T> const &x) { return (!x); }
                                                     ^
                                                      /*unused*/


### File esphome/components/logger/logger.cpp

esphome/core/automation.h:85:81: error: all parameters should be named in a function [readability-named-parameter,-warnings-as-errors]
  template<int... S> bool check_tuple_(const std::tuple<Ts...> &tuple, seq<S...>) {
                                                                                ^
                                                                                 /*unused*/
esphome/core/automation.h:159:85: error: all parameters should be named in a function [readability-named-parameter,-warnings-as-errors]
  template<int... S> void play_next_tuple_(const std::tuple<Ts...> &tuple, seq<S...>) {
                                                                                    ^
                                                                                     /*unused*/
esphome/core/automation.h:226:80: error: all parameters should be named in a function [readability-named-parameter,-warnings-as-errors]
  template<int... S> void play_tuple_(const std::tuple<Ts...> &tuple, seq<S...>) { this->play(std::get<S>(tuple)...); }
                                                                               ^
                                                                                /*unused*/
esphome/core/optional.h:27:17: error: all parameters should be named in a function [readability-named-parameter,-warnings-as-errors]
  nullopt_t(init) {}
                ^
                 /*unused*/
esphome/core/optional.h:45:21: error: all parameters should be named in a function [readability-named-parameter,-warnings-as-errors]
  optional(nullopt_t) {}
                    ^
                     /*unused*/
esphome/core/optional.h:51:32: error: all parameters should be named in a function [readability-named-parameter,-warnings-as-errors]
  optional &operator=(nullopt_t) {
                               ^
                                /*unused*/
esphome/core/optional.h:133:76: error: all parameters should be named in a function [readability-named-parameter,-warnings-as-errors]
template<typename T> inline bool operator==(optional<T> const &x, nullopt_t) { return (!x); }
                                                                           ^
                                                                            /*unused*/
esphome/core/optional.h:135:54: error: all parameters should be named in a function [readability-named-parameter,-warnings-as-errors]
template<typename T> inline bool operator==(nullopt_t, optional<T> const &x) { return (!x); }
                                                     ^
                                                      /*unused*/
esphome/core/optional.h:137:76: error: all parameters should be named in a function [readability-named-parameter,-warnings-as-errors]
template<typename T> inline bool operator!=(optional<T> const &x, nullopt_t) { return bool(x); }
                                                                           ^
                                                                            /*unused*/
esphome/core/optional.h:139:54: error: all parameters should be named in a function [readability-named-parameter,-warnings-as-errors]
template<typename T> inline bool operator!=(nullopt_t, optional<T> const &x) { return bool(x); }
                                                     ^
                                                      /*unused*/
esphome/core/optional.h:141:63: error: all parameters should be named in a function [readability-named-parameter,-warnings-as-errors]
template<typename T> inline bool operator<(optional<T> const &, nullopt_t) { return false; }
                                                              ^
                                                               /*unused*/ /*unused*/
esphome/core/optional.h:143:53: error: all parameters should be named in a function [readability-named-parameter,-warnings-as-errors]
template<typename T> inline bool operator<(nullopt_t, optional<T> const &x) { return bool(x); }
                                                    ^
                                                     /*unused*/
esphome/core/optional.h:145:76: error: all parameters should be named in a function [readability-named-parameter,-warnings-as-errors]
template<typename T> inline bool operator<=(optional<T> const &x, nullopt_t) { return (!x); }
                                                                           ^
                                                                            /*unused*/
esphome/core/optional.h:147:54: error: all parameters should be named in a function [readability-named-parameter,-warnings-as-errors]
template<typename T> inline bool operator<=(nullopt_t, optional<T> const &) { return true; }
                                                     ^
                                                      /*unused*/           /*unused*/
esphome/core/optional.h:149:75: error: all parameters should be named in a function [readability-named-parameter,-warnings-as-errors]
template<typename T> inline bool operator>(optional<T> const &x, nullopt_t) { return bool(x); }
                                                                          ^
                                                                           /*unused*/
esphome/core/optional.h:151:53: error: all parameters should be named in a function [readability-named-parameter,-warnings-as-errors]
template<typename T> inline bool operator>(nullopt_t, optional<T> const &) { return false; }
                                                    ^
                                                     /*unused*/           /*unused*/
esphome/core/optional.h:153:64: error: all parameters should be named in a function [readability-named-parameter,-warnings-as-errors]
template<typename T> inline bool operator>=(optional<T> const &, nullopt_t) { return true; }
                                                               ^
                                                                /*unused*/ /*unused*/
esphome/core/optional.h:155:54: error: all parameters should be named in a function [readability-named-parameter,-warnings-as-errors]
template<typename T> inline bool operator>=(nullopt_t, optional<T> const &x) { return (!x); }
                                                     ^
                                                      /*unused*/


### File .temp/all-include.cpp

esphome/core/automation.h:85:81: error: all parameters should be named in a function [readability-named-parameter,-warnings-as-errors]
  template<int... S> bool check_tuple_(const std::tuple<Ts...> &tuple, seq<S...>) {
                                                                                ^
                                                                                 /*unused*/
esphome/core/automation.h:159:85: error: all parameters should be named in a function [readability-named-parameter,-warnings-as-errors]
  template<int... S> void play_next_tuple_(const std::tuple<Ts...> &tuple, seq<S...>) {
                                                                                    ^
                                                                                     /*unused*/
esphome/core/automation.h:226:80: error: all parameters should be named in a function [readability-named-parameter,-warnings-as-errors]
  template<int... S> void play_tuple_(const std::tuple<Ts...> &tuple, seq<S...>) { this->play(std::get<S>(tuple)...); }
                                                                               ^
                                                                                /*unused*/
esphome/core/optional.h:27:17: error: all parameters should be named in a function [readability-named-parameter,-warnings-as-errors]
  nullopt_t(init) {}
                ^
                 /*unused*/
esphome/core/optional.h:45:21: error: all parameters should be named in a function [readability-named-parameter,-warnings-as-errors]
  optional(nullopt_t) {}
                    ^
                     /*unused*/
esphome/core/optional.h:51:32: error: all parameters should be named in a function [readability-named-parameter,-warnings-as-errors]
  optional &operator=(nullopt_t) {
                               ^
                                /*unused*/
esphome/core/optional.h:133:76: error: all parameters should be named in a function [readability-named-parameter,-warnings-as-errors]
template<typename T> inline bool operator==(optional<T> const &x, nullopt_t) { return (!x); }
                                                                           ^
                                                                            /*unused*/
esphome/core/optional.h:135:54: error: all parameters should be named in a function [readability-named-parameter,-warnings-as-errors]
template<typename T> inline bool operator==(nullopt_t, optional<T> const &x) { return (!x); }
                                                     ^
                                                      /*unused*/
esphome/core/optional.h:137:76: error: all parameters should be named in a function [readability-named-parameter,-warnings-as-errors]
template<typename T> inline bool operator!=(optional<T> const &x, nullopt_t) { return bool(x); }
                                                                           ^
                                                                            /*unused*/
esphome/core/optional.h:139:54: error: all parameters should be named in a function [readability-named-parameter,-warnings-as-errors]
template<typename T> inline bool operator!=(nullopt_t, optional<T> const &x) { return bool(x); }
                                                     ^
                                                      /*unused*/
esphome/core/optional.h:141:63: error: all parameters should be named in a function [readability-named-parameter,-warnings-as-errors]
template<typename T> inline bool operator<(optional<T> const &, nullopt_t) { return false; }
                                                              ^
                                                               /*unused*/ /*unused*/
esphome/core/optional.h:143:53: error: all parameters should be named in a function [readability-named-parameter,-warnings-as-errors]
template<typename T> inline bool operator<(nullopt_t, optional<T> const &x) { return bool(x); }
                                                    ^
                                                     /*unused*/
esphome/core/optional.h:145:76: error: all parameters should be named in a function [readability-named-parameter,-warnings-as-errors]
template<typename T> inline bool operator<=(optional<T> const &x, nullopt_t) { return (!x); }
                                                                           ^
                                                                            /*unused*/
esphome/core/optional.h:147:54: error: all parameters should be named in a function [readability-named-parameter,-warnings-as-errors]
template<typename T> inline bool operator<=(nullopt_t, optional<T> const &) { return true; }
                                                     ^
                                                      /*unused*/           /*unused*/
esphome/core/optional.h:149:75: error: all parameters should be named in a function [readability-named-parameter,-warnings-as-errors]
template<typename T> inline bool operator>(optional<T> const &x, nullopt_t) { return bool(x); }
                                                                          ^
                                                                           /*unused*/
esphome/core/optional.h:151:53: error: all parameters should be named in a function [readability-named-parameter,-warnings-as-errors]
template<typename T> inline bool operator>(nullopt_t, optional<T> const &) { return false; }
                                                    ^
                                                     /*unused*/           /*unused*/
esphome/core/optional.h:153:64: error: all parameters should be named in a function [readability-named-parameter,-warnings-as-errors]
template<typename T> inline bool operator>=(optional<T> const &, nullopt_t) { return true; }
                                                               ^
                                                                /*unused*/ /*unused*/
esphome/core/optional.h:155:54: error: all parameters should be named in a function [readability-named-parameter,-warnings-as-errors]
template<typename T> inline bool operator>=(nullopt_t, optional<T> const &x) { return (!x); }
                                                     ^
                                                      /*unused*/


Applying fixes ...

```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
