### PR TITLE
[code-quality] fix performance-unnecessary-value-param

### DIFF
--- a/esphome/components/lvgl/number/lvgl_number.h
+++ b/esphome/components/lvgl/number/lvgl_number.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <utility>
+
 #include "esphome/components/number/number.h"
 #include "esphome/core/automation.h"
 #include "esphome/core/component.h"
@@ -11,7 +13,7 @@ namespace lvgl {
 class LVGLNumber : public number::Number {
  public:
   void set_control_lambda(std::function<void(float)> control_lambda) {
-    this->control_lambda_ = control_lambda;
+    this->control_lambda_ = std::move(control_lambda);
     if (this->initial_state_.has_value()) {
       this->control_lambda_(this->initial_state_.value());
       this->initial_state_.reset();

--- a/esphome/components/lvgl/select/lvgl_select.h
+++ b/esphome/components/lvgl/select/lvgl_select.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <utility>
+
 #include "esphome/components/select/select.h"
 #include "esphome/core/automation.h"
 #include "esphome/core/component.h"
@@ -28,7 +30,7 @@ static std::vector<std::string> split_string(const std::string &str) {
 class LVGLSelect : public select::Select {
  public:
   void set_control_lambda(std::function<void(size_t)> lambda) {
-    this->control_lambda_ = lambda;
+    this->control_lambda_ = std::move(lambda);
     if (this->initial_state_.has_value()) {
       this->control(this->initial_state_.value());
       this->initial_state_.reset();

--- a/esphome/components/lvgl/switch/lvgl_switch.h
+++ b/esphome/components/lvgl/switch/lvgl_switch.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <utility>
+
 #include "esphome/components/switch/switch.h"
 #include "esphome/core/automation.h"
 #include "esphome/core/component.h"
@@ -11,7 +13,7 @@ namespace lvgl {
 class LVGLSwitch : public switch_::Switch {
  public:
   void set_control_lambda(std::function<void(bool)> state_lambda) {
-    this->state_lambda_ = state_lambda;
+    this->state_lambda_ = std::move(state_lambda);
     if (this->initial_state_.has_value()) {
       this->state_lambda_(this->initial_state_.value());
       this->initial_state_.reset();

--- a/esphome/components/lvgl/text/lvgl_text.h
+++ b/esphome/components/lvgl/text/lvgl_text.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <utility>
+
 #include "esphome/components/text/text.h"
 #include "esphome/core/automation.h"
 #include "esphome/core/component.h"
@@ -11,7 +13,7 @@ namespace lvgl {
 class LVGLText : public text::Text {
  public:
   void set_control_lambda(std::function<void(const std::string)> control_lambda) {
-    this->control_lambda_ = control_lambda;
+    this->control_lambda_ = std::move(control_lambda);
     if (this->initial_state_.has_value()) {
       this->control_lambda_(this->initial_state_.value());
       this->initial_state_.reset();


### PR DESCRIPTION
# What does this implement/fix?

part of https://github.com/esphome/esphome/pull/7049

```
### File .temp/all-include.cpp

esphome/components/lvgl/number/lvgl_number.h:14:29: error: parameter 'control_lambda' is passed by value and only copied once; consider moving it to avoid unnecessary copies [performance-unnecessary-value-param,-warnings-as-errors]
    this->control_lambda_ = control_lambda;
                            ^
                            std::move(    )
esphome/components/lvgl/select/lvgl_select.h:31:29: error: parameter 'lambda' is passed by value and only copied once; consider moving it to avoid unnecessary copies [performance-unnecessary-value-param,-warnings-as-errors]
    this->control_lambda_ = lambda;
                            ^
                            std::move( )
esphome/components/lvgl/switch/lvgl_switch.h:14:27: error: parameter 'state_lambda' is passed by value and only copied once; consider moving it to avoid unnecessary copies [performance-unnecessary-value-param,-warnings-as-errors]
    this->state_lambda_ = state_lambda;
                          ^
                          std::move(  )
esphome/components/lvgl/text/lvgl_text.h:14:29: error: parameter 'control_lambda' is passed by value and only copied once; consider moving it to avoid unnecessary copies [performance-unnecessary-value-param,-warnings-as-errors]
    this->control_lambda_ = control_lambda;
                            ^
                            std::move(    )


```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
