### PR TITLE
[code-quality] fix clang-tidy wake_on_lan

### DIFF
--- a/esphome/components/wake_on_lan/wake_on_lan.cpp
+++ b/esphome/components/wake_on_lan/wake_on_lan.cpp
@@ -1,4 +1,5 @@
 #include "wake_on_lan.h"
+#ifdef USE_NETWORK
 #include "esphome/core/log.h"
 #include "esphome/components/network/ip_address.h"
 #include "esphome/components/network/util.h"
@@ -85,3 +86,4 @@ void WakeOnLanButton::setup() {
 
 }  // namespace wake_on_lan
 }  // namespace esphome
+#endif

--- a/esphome/components/wake_on_lan/wake_on_lan.h
+++ b/esphome/components/wake_on_lan/wake_on_lan.h
@@ -1,5 +1,6 @@
 #pragma once
-
+#include "esphome/core/defines.h"
+#ifdef USE_NETWORK
 #include "esphome/components/button/button.h"
 #include "esphome/core/component.h"
 #if defined(USE_SOCKET_IMPL_BSD_SOCKETS) || defined(USE_SOCKET_IMPL_LWIP_SOCKETS)
@@ -32,3 +33,4 @@ class WakeOnLanButton : public button::Button, public Component {
 
 }  // namespace wake_on_lan
 }  // namespace esphome
+#endif


### PR DESCRIPTION
# What does this implement/fix?

`USE_NETWORK` was used since the component have `DEPENDENCIES = ["network"]`

```
### File .temp/all-include.cpp

esphome/components/wake_on_lan/wake_on_lan.h:8:10: error: 'WiFiUdp.h' file not found [clang-diagnostic-error]
#include "WiFiUdp.h"
```

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
