### PR TITLE
[code-quality] fix clang-tidy e131

### DIFF
--- a/esphome/components/e131/e131.cpp
+++ b/esphome/components/e131/e131.cpp
@@ -1,4 +1,5 @@
 #include "e131.h"
+#ifdef USE_NETWORK
 #include "e131_addressable_light_effect.h"
 #include "esphome/core/log.h"
 
@@ -118,3 +119,4 @@ bool E131Component::process_(int universe, const E131Packet &packet) {
 
 }  // namespace e131
 }  // namespace esphome
+#endif

--- a/esphome/components/e131/e131.h
+++ b/esphome/components/e131/e131.h
@@ -1,5 +1,6 @@
 #pragma once
-
+#include "esphome/core/defines.h"
+#ifdef USE_NETWORK
 #include "esphome/components/socket/socket.h"
 #include "esphome/core/component.h"
 
@@ -53,3 +54,4 @@ class E131Component : public esphome::Component {
 
 }  // namespace e131
 }  // namespace esphome
+#endif

--- a/esphome/components/e131/e131_addressable_light_effect.cpp
+++ b/esphome/components/e131/e131_addressable_light_effect.cpp
@@ -1,5 +1,6 @@
 #include "e131_addressable_light_effect.h"
 #include "e131.h"
+#ifdef USE_NETWORK
 #include "esphome/core/log.h"
 
 namespace esphome {
@@ -90,3 +91,4 @@ bool E131AddressableLightEffect::process_(int universe, const E131Packet &packet
 
 }  // namespace e131
 }  // namespace esphome
+#endif

--- a/esphome/components/e131/e131_addressable_light_effect.h
+++ b/esphome/components/e131/e131_addressable_light_effect.h
@@ -2,7 +2,7 @@
 
 #include "esphome/core/component.h"
 #include "esphome/components/light/addressable_light_effect.h"
-
+#ifdef USE_NETWORK
 namespace esphome {
 namespace e131 {
 
@@ -42,3 +42,4 @@ class E131AddressableLightEffect : public light::AddressableLightEffect {
 
 }  // namespace e131
 }  // namespace esphome
+#endif

--- a/esphome/components/e131/e131_packet.cpp
+++ b/esphome/components/e131/e131_packet.cpp
@@ -1,5 +1,6 @@
 #include <cstring>
 #include "e131.h"
+#ifdef USE_NETWORK
 #include "esphome/components/network/ip_address.h"
 #include "esphome/core/log.h"
 #include "esphome/core/util.h"
@@ -137,3 +138,4 @@ bool E131Component::packet_(const std::vector<uint8_t> &data, int &universe, E13
 
 }  // namespace e131
 }  // namespace esphome
+#endif


### PR DESCRIPTION
# What does this implement/fix?

e131 has `DEPENDENCIES = ["network"]` so `USE_NETWORK` is enough/

```
### File /esphome/.temp/all-include.cpp

/esphome/esphome/components/e131/e131.h:48:19: error: use of undeclared identifier 'socket' [clang-diagnostic-error]
  std::unique_ptr<socket::Socket> socket_;
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
