### PR TITLE
[code-quality] fix clang-tidy ota

### DIFF
--- a/esphome/components/esphome/ota/ota_esphome.cpp
+++ b/esphome/components/esphome/ota/ota_esphome.cpp
@@ -1,5 +1,5 @@
 #include "ota_esphome.h"
-
+#ifdef USE_OTA
 #include "esphome/components/md5/md5.h"
 #include "esphome/components/network/util.h"
 #include "esphome/components/ota/ota_backend.h"
@@ -410,3 +410,4 @@ float ESPHomeOTAComponent::get_setup_priority() const { return setup_priority::A
 uint16_t ESPHomeOTAComponent::get_port() const { return this->port_; }
 void ESPHomeOTAComponent::set_port(uint16_t port) { this->port_ = port; }
 }  // namespace esphome
+#endif

--- a/esphome/components/esphome/ota/ota_esphome.h
+++ b/esphome/components/esphome/ota/ota_esphome.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "esphome/core/defines.h"
+#ifdef USE_OTA
 #include "esphome/core/helpers.h"
 #include "esphome/core/preferences.h"
 #include "esphome/components/ota/ota_backend.h"
@@ -41,3 +42,4 @@ class ESPHomeOTAComponent : public ota::OTAComponent {
 };
 
 }  // namespace esphome
+#endif


### PR DESCRIPTION
# What does this implement/fix?

```
### File /esphome/.temp/all-include.cpp

/esphome/esphome/components/esphome/ota/ota_esphome.h:39:19: error: use of undeclared identifier 'socket' [clang-diagnostic-error]
  std::unique_ptr<socket::Socket> server_;
                  ^
/esphome/esphome/components/esphome/ota/ota_esphome.h:40:19: error: use of undeclared identifier 'socket' [clang-diagnostic-error]
  std::unique_ptr<socket::Socket> client_;

```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
