### PR TITLE
[code-quality] fix clang-tidy improv_serial

### DIFF
--- a/esphome/components/improv_serial/improv_serial_component.cpp
+++ b/esphome/components/improv_serial/improv_serial_component.cpp
@@ -1,5 +1,5 @@
 #include "improv_serial_component.h"
-
+#ifdef USE_WIFI
 #include "esphome/core/application.h"
 #include "esphome/core/defines.h"
 #include "esphome/core/hal.h"
@@ -313,3 +313,4 @@ ImprovSerialComponent *global_improv_serial_component =  // NOLINT(cppcoreguidel
 
 }  // namespace improv_serial
 }  // namespace esphome
+#endif

--- a/esphome/components/improv_serial/improv_serial_component.h
+++ b/esphome/components/improv_serial/improv_serial_component.h
@@ -5,7 +5,7 @@
 #include "esphome/core/component.h"
 #include "esphome/core/defines.h"
 #include "esphome/core/helpers.h"
-
+#ifdef USE_WIFI
 #include <improv.h>
 #include <vector>
 
@@ -78,3 +78,4 @@ extern ImprovSerialComponent
 
 }  // namespace improv_serial
 }  // namespace esphome
+#endif


### PR DESCRIPTION
# What does this implement/fix?

`USE_WIFI` since `DEPENDENCIES = ["logger", "wifi"]`

part of https://github.com/esphome/esphome/pull/7049/

```
### File /esphome/.temp/all-include.cpp

/esphome/esphome/components/improv_serial/improv_serial_component.h:9:10: error: 'improv.h' file not found [clang-diagnostic-error]
#include <improv.h>
         ^~~~~~~~~~
/esphome/esphome/components/key_collector/key_collector.h:18:35: error: the parameter 'start_keys' is copied for each invocation but only used as a const reference; consider making it a const reference [performance-unnecessary-value-param,-warnings-as-errors]
  void set_start_keys(std::string start_keys) { this->start_keys_ = std::move(start_keys); };
                                  ^
                      const      &
/esphome/esphome/components/key_collector/key_collector.h:19:33: error: the parameter 'end_keys' is copied for each invocation but only used as a const reference; consider making it a const reference [performance-unnecessary-value-param,-warnings-as-errors]
  void set_end_keys(std::string end_keys) { this->end_keys_ = std::move(end_keys); };
                                ^
                    const      &
/esphome/esphome/components/key_collector/key_collector.h:21:34: error: the parameter 'back_keys' is copied for each invocation but only used as a const reference; consider making it a const reference [performance-unnecessary-value-param,-warnings-as-errors]
  void set_back_keys(std::string back_keys) { this->back_keys_ = std::move(back_keys); };
                                 ^
                     const      &
/esphome/esphome/components/key_collector/key_collector.h:22:35: error: the parameter 'clear_keys' is copied for each invocation but only used as a const reference; consider making it a const reference [performance-unnecessary-value-param,-warnings-as-errors]
  void set_clear_keys(std::string clear_keys) { this->clear_keys_ = std::move(clear_keys); };
                                  ^
                      const      &
/esphome/esphome/components/key_collector/key_collector.h:23:37: error: the parameter 'allowed_keys' is copied for each invocation but only used as a const reference; consider making it a const reference [performance-unnecessary-value-param,-warnings-as-errors]
  void set_allowed_keys(std::string allowed_keys) { this->allowed_keys_ = std::move(allowed_keys); };
                                    ^
                        const      &
/esphome/esphome/components/ltr_als_ps/ltr_als_ps.h:161:63: error: the parameter 'callback' is copied for each invocation but only used as a const reference; consider making it a const reference [performance-unnecessary-value-param,-warnings-as-errors]
  void add_on_ps_high_trigger_callback_(std::function<void()> callback) {
                                                              ^
                                        const                &
/esphome/esphome/components/ltr_als_ps/ltr_als_ps.h:165:62: error: the parameter 'callback' is copied for each invocation but only used as a const reference; consider making it a const reference [performance-unnecessary-value-param,-warnings-as-errors]
  void add_on_ps_low_trigger_callback_(std::function<void()> callback) {
                                                             ^
                                       const                &
/esphome/esphome/components/lvgl/switch/lvgl_switch.h:15:53: error: the parameter 'state_lambda' is copied for each invocation but only used as a const reference; consider making it a const reference [performance-unnecessary-value-param,-warnings-as-errors]
  void set_control_lambda(std::function<void(bool)> state_lambda) {
                                                    ^
                          const                    &
/esphome/esphome/components/lvgl/text/lvgl_text.h:15:66: error: the parameter 'control_lambda' is copied for each invocation but only used as a const reference; consider making it a const reference [performance-unnecessary-value-param,-warnings-as-errors]
  void set_control_lambda(std::function<void(const std::string)> control_lambda) {
                                                                 ^
                          const                                 &
/esphome/esphome/components/matrix_keypad/matrix_keypad.h:28:29: error: the parameter 'keys' is copied for each invocation but only used as a const reference; consider making it a const reference [performance-unnecessary-value-param,-warnings-as-errors]
  void set_keys(std::string keys) { keys_ = std::move(keys); };
                            ^
                const      &
/esphome/esphome/components/mdns/mdns_component.h:37:38: error: the parameter 'service' is copied for each invocation but only used as a const reference; consider making it a const reference [performance-unnecessary-value-param,-warnings-as-errors]
  void add_extra_service(MDNSService service) { services_extra_.push_back(std::move(service)); }
                                     ^
                         const      &
/esphome/esphome/components/partition/light_partition.h:82:5: error: if with identical then and else branches [bugprone-branch-clone,-warnings-as-errors]
    if (seg.is_reversed()) {
    ^
/esphome/esphome/components/partition/light_partition.h:84:7: note: else branch starts here
    } else {
      ^
/esphome/esphome/components/pid/pid_autotuner.h:34:37: error: the parameter 'id' is copied for each invocation but only used as a const reference; consider making it a const reference [performance-unnecessary-value-param,-warnings-as-errors]
  void set_autotuner_id(std::string id) { this->id_ = std::move(id); }
                                    ^
                        const      &
/esphome/esphome/components/pn532/pn532.h:47:61: error: the parameter 'callback' is copied for each invocation but only used as a const reference; consider making it a const reference [performance-unnecessary-value-param,-warnings-as-errors]
  void add_on_finished_write_callback(std::function<void()> callback) {
                                                            ^
                                      const                &
/esphome/esphome/components/pn7150/pn7150.h:170:64: error: the parameter 'callback' is copied for each invocation but only used as a const reference; consider making it a const reference [performance-unnecessary-value-param,-warnings-as-errors]
  void add_on_emulated_tag_scan_callback(std::function<void()> callback) {
                                                               ^
                                         const                &
/esphome/esphome/components/pn7150/pn7150.h:174:61: error: the parameter 'callback' is copied for each invocation but only used as a const reference; consider making it a const reference [performance-unnecessary-value-param,-warnings-as-errors]
  void add_on_finished_write_callback(std::function<void()> callback) {
                                                            ^
                                      const                &
/esphome/esphome/components/pn7160/pn7160.h:187:64: error: the parameter 'callback' is copied for each invocation but only used as a const reference; consider making it a const reference [performance-unnecessary-value-param,-warnings-as-errors]
  void add_on_emulated_tag_scan_callback(std::function<void()> callback) {
                                                               ^
                                         const                &
/esphome/esphome/components/pn7160/pn7160.h:191:61: error: the parameter 'callback' is copied for each invocation but only used as a const reference; consider making it a const reference [performance-unnecessary-value-param,-warnings-as-errors]
  void add_on_finished_write_callback(std::function<void()> callback) {
                                                            ^
                                      const                &
/esphome/esphome/components/rotary_encoder/rotary_encoder.h:87:56: error: the parameter 'callback' is copied for each invocation but only used as a const reference; consider making it a const reference [performance-unnecessary-value-param,-warnings-as-errors]
  void add_on_clockwise_callback(std::function<void()> callback) {
                                                       ^
                                 const                &
/esphome/esphome/components/rotary_encoder/rotary_encoder.h:91:60: error: the parameter 'callback' is copied for each invocation but only used as a const reference; consider making it a const reference [performance-unnecessary-value-param,-warnings-as-errors]
  void add_on_anticlockwise_callback(std::function<void()> callback) {
                                                           ^
                                     const                &
/esphome/esphome/components/rtttl/rtttl.h:48:64: error: the parameter 'callback' is copied for each invocation but only used as a const reference; consider making it a const reference [performance-unnecessary-value-param,-warnings-as-errors]
  void add_on_finished_playback_callback(std::function<void()> callback) {
                                                               ^
                                         const                &
/esphome/esphome/components/sim800l/sim800l.h:67:71: error: the parameter 'callback' is copied for each invocation but only used as a const reference; consider making it a const reference [performance-unnecessary-value-param,-warnings-as-errors]
  void add_on_incoming_call_callback(std::function<void(std::string)> callback) {
                                                                      ^
                                     const                           &
/esphome/esphome/components/sim800l/sim800l.h:70:61: error: the parameter 'callback' is copied for each invocation but only used as a const reference; consider making it a const reference [performance-unnecessary-value-param,-warnings-as-errors]
  void add_on_call_connected_callback(std::function<void()> callback) {
                                                            ^
                                      const                &
/esphome/esphome/components/sim800l/sim800l.h:73:64: error: the parameter 'callback' is copied for each invocation but only used as a const reference; consider making it a const reference [performance-unnecessary-value-param,-warnings-as-errors]
  void add_on_call_disconnected_callback(std::function<void()> callback) {
                                                               ^
                                         const                &
/esphome/esphome/components/sim800l/sim800l.h:76:71: error: the parameter 'callback' is copied for each invocation but only used as a const reference; consider making it a const reference [performance-unnecessary-value-param,-warnings-as-errors]
  void add_on_ussd_received_callback(std::function<void(std::string)> callback) {
                                                                      ^
                                     const                           &
/esphome/esphome/components/tuya/tuya.h:115:58: error: the parameter 'callback' is copied for each invocation but only used as a const reference; consider making it a const reference [performance-unnecessary-value-param,-warnings-as-errors]
  void add_on_initialized_callback(std::function<void()> callback) {
                                                         ^
                                   const                &
/esphome/esphome/components/weikai/weikai.h:212:29: error: the parameter 'name' is copied for each invocation but only used as a const reference; consider making it a const reference [performance-unnecessary-value-param,-warnings-as-errors]
  void set_name(std::string name) { this->name_ = std::move(name); }
                            ^
                const      &
/esphome/esphome/components/weikai/weikai.h:311:37: error: the parameter 'name' is copied for each invocation but only used as a const reference; consider making it a const reference [performance-unnecessary-value-param,-warnings-as-errors]
  void set_channel_name(std::string name) { this->name_ = std::move(name); }
                                    ^
                        const      &

```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
