### PR TITLE
[code-quality] fix clang-tidy prometheus

### DIFF
--- a/esphome/components/prometheus/prometheus_handler.cpp
+++ b/esphome/components/prometheus/prometheus_handler.cpp
@@ -1,4 +1,5 @@
 #include "prometheus_handler.h"
+#ifdef USE_NETWORK
 #include "esphome/core/application.h"
 
 namespace esphome {
@@ -350,3 +351,4 @@ void PrometheusHandler::lock_row_(AsyncResponseStream *stream, lock::Lock *obj) 
 
 }  // namespace prometheus
 }  // namespace esphome
+#endif

--- a/esphome/components/prometheus/prometheus_handler.h
+++ b/esphome/components/prometheus/prometheus_handler.h
@@ -4,6 +4,7 @@
 #include <utility>
 
 #include "esphome/components/web_server_base/web_server_base.h"
+#ifdef USE_NETWORK
 #include "esphome/core/component.h"
 #include "esphome/core/controller.h"
 #include "esphome/core/entity_base.h"
@@ -117,3 +118,4 @@ class PrometheusHandler : public AsyncWebHandler, public Component {
 
 }  // namespace prometheus
 }  // namespace esphome
+#endif

--- a/esphome/components/prometheus/prometheus_handler.h
+++ b/esphome/components/prometheus/prometheus_handler.h
@@ -1,10 +1,10 @@
 #pragma once
-
+#include "esphome/core/defines.h"
+#ifdef USE_NETWORK
 #include <map>
 #include <utility>
 
 #include "esphome/components/web_server_base/web_server_base.h"
-#ifdef USE_NETWORK
 #include "esphome/core/component.h"
 #include "esphome/core/controller.h"
 #include "esphome/core/entity_base.h"


### PR DESCRIPTION
# What does this implement/fix?

`USE_NETWORK` since `AUTO_LOAD = ["web_server_base"]` which has `DEPENDENCIES = ["network"]`

```
### File /esphome/.temp/all-include.cpp

error: too many errors emitted, stopping now [clang-diagnostic-error]
/esphome/esphome/components/prometheus/prometheus_handler.h:14:34: error: expected class name [clang-diagnostic-error]
class PrometheusHandler : public AsyncWebHandler, public Component {
                                 ^
/esphome/esphome/components/prometheus/prometheus_handler.h:16:21: error: use of undeclared identifier 'web_server_base' [clang-diagnostic-error]
  PrometheusHandler(web_server_base::WebServerBase *base) : base_(base) {}
                    ^
/esphome/esphome/components/prometheus/prometheus_handler.h:39:18: error: unknown type name 'AsyncWebServerRequest' [clang-diagnostic-error]
  bool canHandle(AsyncWebServerRequest *request) override {
                 ^
/esphome/esphome/components/prometheus/prometheus_handler.h:48:22: error: unknown type name 'AsyncWebServerRequest' [clang-diagnostic-error]
  void handleRequest(AsyncWebServerRequest *req) override;
                     ^
/esphome/esphome/components/prometheus/prometheus_handler.h:65:21: error: unknown type name 'AsyncResponseStream' [clang-diagnostic-error]
  void sensor_type_(AsyncResponseStream *stream);
                    ^
/esphome/esphome/components/prometheus/prometheus_handler.h:67:20: error: unknown type name 'AsyncResponseStream' [clang-diagnostic-error]
  void sensor_row_(AsyncResponseStream *stream, sensor::Sensor *obj);
                   ^
/esphome/esphome/components/prometheus/prometheus_handler.h:72:28: error: unknown type name 'AsyncResponseStream' [clang-diagnostic-error]
  void binary_sensor_type_(AsyncResponseStream *stream);
                           ^
/esphome/esphome/components/prometheus/prometheus_handler.h:74:27: error: unknown type name 'AsyncResponseStream' [clang-diagnostic-error]
  void binary_sensor_row_(AsyncResponseStream *stream, binary_sensor::BinarySensor *obj);
                          ^
/esphome/esphome/components/prometheus/prometheus_handler.h:79:18: error: unknown type name 'AsyncResponseStream' [clang-diagnostic-error]
  void fan_type_(AsyncResponseStream *stream);
                 ^
/esphome/esphome/components/prometheus/prometheus_handler.h:81:17: error: unknown type name 'AsyncResponseStream' [clang-diagnostic-error]
  void fan_row_(AsyncResponseStream *stream, fan::Fan *obj);
                ^
/esphome/esphome/components/prometheus/prometheus_handler.h:86:20: error: unknown type name 'AsyncResponseStream' [clang-diagnostic-error]
  void light_type_(AsyncResponseStream *stream);
                   ^
/esphome/esphome/components/prometheus/prometheus_handler.h:88:19: error: unknown type name 'AsyncResponseStream' [clang-diagnostic-error]
  void light_row_(AsyncResponseStream *stream, light::LightState *obj);
                  ^
/esphome/esphome/components/prometheus/prometheus_handler.h:93:20: error: unknown type name 'AsyncResponseStream' [clang-diagnostic-error]
  void cover_type_(AsyncResponseStream *stream);
                   ^
/esphome/esphome/components/prometheus/prometheus_handler.h:95:19: error: unknown type name 'AsyncResponseStream' [clang-diagnostic-error]
  void cover_row_(AsyncResponseStream *stream, cover::Cover *obj);
                  ^
/esphome/esphome/components/prometheus/prometheus_handler.h:100:21: error: unknown type name 'AsyncResponseStream' [clang-diagnostic-error]
  void switch_type_(AsyncResponseStream *stream);
                    ^
/esphome/esphome/components/prometheus/prometheus_handler.h:102:20: error: unknown type name 'AsyncResponseStream' [clang-diagnostic-error]
  void switch_row_(AsyncResponseStream *stream, switch_::Switch *obj);
                   ^
/esphome/esphome/components/prometheus/prometheus_handler.h:107:19: error: unknown type name 'AsyncResponseStream' [clang-diagnostic-error]
  void lock_type_(AsyncResponseStream *stream);
                  ^
/esphome/esphome/components/prometheus/prometheus_handler.h:109:18: error: unknown type name 'AsyncResponseStream' [clang-diagnostic-error]
  void lock_row_(AsyncResponseStream *stream, lock::Lock *obj);
                 ^
/esphome/esphome/components/prometheus/prometheus_handler.h:112:3: error: use of undeclared identifier 'web_server_base' [clang-diagnostic-error]
  web_server_base::WebServerBase *base_;
  ^
/esphome/esphome/components/rtttl/rtttl.h:48:64: error: the parameter 'callback' is copied for each invocation but only used as a const reference; consider making it a const reference [performance-unnecessary-value-param,-warnings-as-errors]
  void add_on_finished_playback_callback(std::function<void()> callback) {
                                                               ^
                                         const                &
/esphome/esphome/components/sim800l/sim800l.h:67:71: error: the parameter 'callback' is copied for each invocation but only used as a const reference; consider making it a const reference [performance-unnecessary-value-param,-warnings-as-errors]
  void add_on_incoming_call_callback(std::function<void(std::string)> callback) {
                                                                      ^
                                     const                           &
/esphome/esphome/components/sim800l/sim800l.h:70:61: error: the parameter 'callback' is copied for each invocation but only used as a const reference; consider making it a const reference [performance-unnecessary-value-param,-warnings-as-errors]
  void add_on_call_connected_callback(std::function<void()> callback) {
                                                            ^
                                      const                &
/esphome/esphome/components/sim800l/sim800l.h:73:64: error: the parameter 'callback' is copied for each invocation but only used as a const reference; consider making it a const reference [performance-unnecessary-value-param,-warnings-as-errors]
  void add_on_call_disconnected_callback(std::function<void()> callback) {
                                                               ^
                                         const                &
/esphome/esphome/components/sim800l/sim800l.h:76:71: error: the parameter 'callback' is copied for each invocation but only used as a const reference; consider making it a const reference [performance-unnecessary-value-param,-warnings-as-errors]
  void add_on_ussd_received_callback(std::function<void(std::string)> callback) {
                                                                      ^
                                     const                           &
/esphome/esphome/components/tuya/tuya.h:115:58: error: the parameter 'callback' is copied for each invocation but only used as a const reference; consider making it a const reference [performance-unnecessary-value-param,-warnings-as-errors]
  void add_on_initialized_callback(std::function<void()> callback) {
                                                         ^
                                   const                &
/esphome/esphome/components/weikai/weikai.h:212:29: error: the parameter 'name' is copied for each invocation but only used as a const reference; consider making it a const reference [performance-unnecessary-value-param,-warnings-as-errors]
  void set_name(std::string name) { this->name_ = std::move(name); }
                            ^
                const      &
/esphome/esphome/components/weikai/weikai.h:311:37: error: the parameter 'name' is copied for each invocation but only used as a const reference; consider making it a const reference [performance-unnecessary-value-param,-warnings-as-errors]
  void set_channel_name(std::string name) { this->name_ = std::move(name); }
                                    ^
                        const      &
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
