### PR TITLE
[code-quality] fix clang-tidy socket

### DIFF
--- a/esphome/components/socket/socket.cpp
+++ b/esphome/components/socket/socket.cpp
@@ -1,4 +1,5 @@
 #include "socket.h"
+#if defined(USE_SOCKET_IMPL_LWIP_TCP) || defined(USE_SOCKET_IMPL_LWIP_SOCKETS) || defined(USE_SOCKET_IMPL_BSD_SOCKETS)
 #include <cerrno>
 #include <cstring>
 #include <string>
@@ -74,3 +75,4 @@ socklen_t set_sockaddr_any(struct sockaddr *addr, socklen_t addrlen, uint16_t po
 }
 }  // namespace socket
 }  // namespace esphome
+#endif

--- a/esphome/components/socket/socket.h
+++ b/esphome/components/socket/socket.h
@@ -5,6 +5,7 @@
 #include "esphome/core/optional.h"
 #include "headers.h"
 
+#if defined(USE_SOCKET_IMPL_LWIP_TCP) || defined(USE_SOCKET_IMPL_LWIP_SOCKETS) || defined(USE_SOCKET_IMPL_BSD_SOCKETS)
 namespace esphome {
 namespace socket {
 
@@ -57,3 +58,4 @@ socklen_t set_sockaddr_any(struct sockaddr *addr, socklen_t addrlen, uint16_t po
 
 }  // namespace socket
 }  // namespace esphome
+#endif


### PR DESCRIPTION
# What does this implement/fix?

```
### File /esphome/.temp/all-include.cpp

/esphome/esphome/components/socket/socket.h:18:65: error: unknown type name 'socklen_t'; did you mean '__socklen_t'? [clang-diagnostic-error]
  virtual std::unique_ptr<Socket> accept(struct sockaddr *addr, socklen_t *addrlen) = 0;
                                                                ^~~~~~~~~
                                                                __socklen_t
.platformio/packages/toolchain-gccarmnoneeabi/zephyr-sdk-0.16.1/arm-zephyr-eabi/bin/../lib/gcc/arm-zephyr-eabi/12.2.0/../../../../arm-zephyr-eabi/sys-include/sys/_types.h:205:20: note: '__socklen_t' declared here
typedef __uint32_t      __socklen_t;
                        ^
/esphome/esphome/components/socket/socket.h:19:49: error: unknown type name 'socklen_t'; did you mean '__socklen_t'? [clang-diagnostic-error]
  virtual int bind(const struct sockaddr *addr, socklen_t addrlen) = 0;
                                                ^~~~~~~~~
                                                __socklen_t
.platformio/packages/toolchain-gccarmnoneeabi/zephyr-sdk-0.16.1/arm-zephyr-eabi/bin/../lib/gcc/arm-zephyr-eabi/12.2.0/../../../../arm-zephyr-eabi/sys-include/sys/_types.h:205:20: note: '__socklen_t' declared here
typedef __uint32_t      __socklen_t;
                        ^
/esphome/esphome/components/socket/socket.h:26:50: error: unknown type name 'socklen_t'; did you mean '__socklen_t'? [clang-diagnostic-error]
  virtual int getpeername(struct sockaddr *addr, socklen_t *addrlen) = 0;
                                                 ^~~~~~~~~
                                                 __socklen_t
.platformio/packages/toolchain-gccarmnoneeabi/zephyr-sdk-0.16.1/arm-zephyr-eabi/bin/../lib/gcc/arm-zephyr-eabi/12.2.0/../../../../arm-zephyr-eabi/sys-include/sys/_types.h:205:20: note: '__socklen_t' declared here
typedef __uint32_t      __socklen_t;
                        ^
/esphome/esphome/components/socket/socket.h:28:50: error: unknown type name 'socklen_t'; did you mean '__socklen_t'? [clang-diagnostic-error]
  virtual int getsockname(struct sockaddr *addr, socklen_t *addrlen) = 0;
                                                 ^~~~~~~~~
                                                 __socklen_t
.platformio/packages/toolchain-gccarmnoneeabi/zephyr-sdk-0.16.1/arm-zephyr-eabi/bin/../lib/gcc/arm-zephyr-eabi/12.2.0/../../../../arm-zephyr-eabi/sys-include/sys/_types.h:205:20: note: '__socklen_t' declared here
typedef __uint32_t      __socklen_t;
                        ^
/esphome/esphome/components/socket/socket.h:30:64: error: unknown type name 'socklen_t'; did you mean '__socklen_t'? [clang-diagnostic-error]
  virtual int getsockopt(int level, int optname, void *optval, socklen_t *optlen) = 0;
                                                               ^~~~~~~~~
                                                               __socklen_t
.platformio/packages/toolchain-gccarmnoneeabi/zephyr-sdk-0.16.1/arm-zephyr-eabi/bin/../lib/gcc/arm-zephyr-eabi/12.2.0/../../../../arm-zephyr-eabi/sys-include/sys/_types.h:205:20: note: '__socklen_t' declared here
typedef __uint32_t      __socklen_t;
                        ^
/esphome/esphome/components/socket/socket.h:31:70: error: unknown type name 'socklen_t'; did you mean '__socklen_t'? [clang-diagnostic-error]
  virtual int setsockopt(int level, int optname, const void *optval, socklen_t optlen) = 0;
                                                                     ^~~~~~~~~
                                                                     __socklen_t
.platformio/packages/toolchain-gccarmnoneeabi/zephyr-sdk-0.16.1/arm-zephyr-eabi/bin/../lib/gcc/arm-zephyr-eabi/12.2.0/../../../../arm-zephyr-eabi/sys-include/sys/_types.h:205:20: note: '__socklen_t' declared here
typedef __uint32_t      __socklen_t;
                        ^
/esphome/esphome/components/socket/socket.h:40:93: error: unknown type name 'socklen_t'; did you mean '__socklen_t'? [clang-diagnostic-error]
  virtual ssize_t sendto(const void *buf, size_t len, int flags, const struct sockaddr *to, socklen_t tolen) = 0;
                                                                                            ^~~~~~~~~
                                                                                            __socklen_t
.platformio/packages/toolchain-gccarmnoneeabi/zephyr-sdk-0.16.1/arm-zephyr-eabi/bin/../lib/gcc/arm-zephyr-eabi/12.2.0/../../../../arm-zephyr-eabi/sys-include/sys/_types.h:205:20: note: '__socklen_t' declared here
typedef __uint32_t      __socklen_t;
                        ^
/esphome/esphome/components/socket/socket.h:53:1: error: unknown type name 'socklen_t'; did you mean '__socklen_t'? [clang-diagnostic-error]
socklen_t set_sockaddr(struct sockaddr *addr, socklen_t addrlen, const std::string &ip_address, uint16_t port);
^~~~~~~~~
__socklen_t
.platformio/packages/toolchain-gccarmnoneeabi/zephyr-sdk-0.16.1/arm-zephyr-eabi/bin/../lib/gcc/arm-zephyr-eabi/12.2.0/../../../../arm-zephyr-eabi/sys-include/sys/_types.h:205:20: note: '__socklen_t' declared here
typedef __uint32_t      __socklen_t;
                        ^
/esphome/esphome/components/socket/socket.h:53:47: error: unknown type name 'socklen_t'; did you mean '__socklen_t'? [clang-diagnostic-error]
socklen_t set_sockaddr(struct sockaddr *addr, socklen_t addrlen, const std::string &ip_address, uint16_t port);
                                              ^~~~~~~~~
                                              __socklen_t
.platformio/packages/toolchain-gccarmnoneeabi/zephyr-sdk-0.16.1/arm-zephyr-eabi/bin/../lib/gcc/arm-zephyr-eabi/12.2.0/../../../../arm-zephyr-eabi/sys-include/sys/_types.h:205:20: note: '__socklen_t' declared here
typedef __uint32_t      __socklen_t;
                        ^
/esphome/esphome/components/socket/socket.h:56:1: error: unknown type name 'socklen_t'; did you mean '__socklen_t'? [clang-diagnostic-error]
socklen_t set_sockaddr_any(struct sockaddr *addr, socklen_t addrlen, uint16_t port);
^~~~~~~~~
__socklen_t
.platformio/packages/toolchain-gccarmnoneeabi/zephyr-sdk-0.16.1/arm-zephyr-eabi/bin/../lib/gcc/arm-zephyr-eabi/12.2.0/../../../../arm-zephyr-eabi/sys-include/sys/_types.h:205:20: note: '__socklen_t' declared here
typedef __uint32_t      __socklen_t;
                        ^
/esphome/esphome/components/socket/socket.h:56:51: error: unknown type name 'socklen_t'; did you mean '__socklen_t'? [clang-diagnostic-error]
socklen_t set_sockaddr_any(struct sockaddr *addr, socklen_t addrlen, uint16_t port);
                                                  ^~~~~~~~~
                                                  __socklen_t
.platformio/packages/toolchain-gccarmnoneeabi/zephyr-sdk-0.16.1/arm-zephyr-eabi/bin/../lib/gcc/arm-zephyr-eabi/12.2.0/../../../../arm-zephyr-eabi/sys-include/sys/_types.h:205:20: note: '__socklen_t' declared here
typedef __uint32_t      __socklen_t;
                        ^

```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
