### PR TITLE
[code-quality] fix clang-tidy wireguard

### DIFF
--- a/esphome/components/wireguard/__init__.py
+++ b/esphome/components/wireguard/__init__.py
@@ -1,19 +1,20 @@
-import re
 import ipaddress
+import re
+
+from esphome import automation
 import esphome.codegen as cg
+from esphome.components import time
+from esphome.components.esp32 import CORE, add_idf_sdkconfig_option
 import esphome.config_validation as cv
 from esphome.const import (
-    CONF_ID,
-    CONF_TIME_ID,
     CONF_ADDRESS,
+    CONF_ID,
     CONF_REBOOT_TIMEOUT,
+    CONF_TIME_ID,
     KEY_CORE,
     KEY_FRAMEWORK_VERSION,
 )
-from esphome.components.esp32 import CORE, add_idf_sdkconfig_option
-from esphome.components import time
 from esphome.core import TimePeriod
-from esphome import automation
 
 CONF_NETMASK = "netmask"
 CONF_PRIVATE_KEY = "private_key"
@@ -90,6 +91,8 @@ CONFIG_SCHEMA = cv.Schema(
 
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
+
+    cg.add_define("USE_WIREGUARD")
 
     cg.add(var.set_address(str(config[CONF_ADDRESS])))
     cg.add(var.set_netmask(str(config[CONF_NETMASK])))

--- a/esphome/components/wireguard/wireguard.cpp
+++ b/esphome/components/wireguard/wireguard.cpp
@@ -1,5 +1,5 @@
 #include "wireguard.h"
-
+#ifdef USE_WIREGUARD
 #include <cinttypes>
 #include <ctime>
 #include <functional>
@@ -289,3 +289,4 @@ std::string mask_key(const std::string &key) { return (key.substr(0, 5) + "[...]
 
 }  // namespace wireguard
 }  // namespace esphome
+#endif

--- a/esphome/components/wireguard/wireguard.h
+++ b/esphome/components/wireguard/wireguard.h
@@ -1,5 +1,6 @@
 #pragma once
-
+#include "esphome/core/defines.h"
+#ifdef USE_WIREGUARD
 #include <ctime>
 #include <vector>
 #include <tuple>
@@ -170,3 +171,4 @@ template<typename... Ts> class WireguardDisableAction : public Action<Ts...>, pu
 
 }  // namespace wireguard
 }  // namespace esphome
+#endif

--- a/esphome/core/defines.h
+++ b/esphome/core/defines.h
@@ -75,6 +75,7 @@
 #define USE_VALVE
 #define USE_WIFI
 #define USE_WIFI_AP
+#define USE_WIREGUARD
 
 // Arduino-specific feature flags
 #ifdef USE_ARDUINO


### PR DESCRIPTION
# What does this implement/fix?

part of ub.com/esphome/esphome/pull/7049

```
### File /esphome/.temp/all-include.cpp

/esphome/esphome/components/wireguard/wireguard.h:22:10: error: 'esp_wireguard.h' file not found [clang-diagnostic-error]
#include <esp_wireguard.h>

```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
