### PR TITLE
[network] Always allow ``enable_ipv6: false``

### DIFF
--- a/esphome/components/network/__init__.py
+++ b/esphome/components/network/__init__.py
@@ -18,13 +18,18 @@ IPAddress = network_ns.class_("IPAddress")
 
 CONFIG_SCHEMA = cv.Schema(
     {
+        cv.Optional(CONF_ENABLE_IPV6, default=False): cv.boolean,
         cv.SplitDefault(
             CONF_ENABLE_IPV6,
             esp8266=False,
             esp32=False,
             rp2040=False,
         ): cv.All(
-            cv.boolean, cv.only_on([PLATFORM_ESP32, PLATFORM_ESP8266, PLATFORM_RP2040])
+            cv.boolean,
+            cv.Any(
+                cv.only_on([PLATFORM_ESP32, PLATFORM_ESP8266, PLATFORM_RP2040]),
+                cv.boolean_false,
+            ),
         ),
         cv.Optional(CONF_MIN_IPV6_ADDR_COUNT, default=0): cv.positive_int,
     }

--- a/esphome/components/network/__init__.py
+++ b/esphome/components/network/__init__.py
@@ -18,7 +18,6 @@ IPAddress = network_ns.class_("IPAddress")
 
 CONFIG_SCHEMA = cv.Schema(
     {
-        cv.Optional(CONF_ENABLE_IPV6, default=False): cv.boolean,
         cv.SplitDefault(
             CONF_ENABLE_IPV6,
             esp8266=False,

--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -370,6 +370,20 @@ def boolean(value):
     )
 
 
+def boolean_false(value):
+    """Validate the given config option to be a boolean, set to False.
+
+    This option allows a bunch of different ways of expressing boolean values:
+     - instance of boolean
+     - 'true'/'false'
+     - 'yes'/'no'
+     - 'enable'/disable
+    """
+    if boolean(value):
+        raise Invalid("Expected boolean value to be false")
+    return False
+
+
 @schema_extractor_list
 def ensure_list(*validators):
     """Validate this configuration option to be a list.

--- a/tests/components/network/test-ipv6.bk72xx-ard.yaml
+++ b/tests/components/network/test-ipv6.bk72xx-ard.yaml
@@ -1,0 +1,4 @@
+substitutions:
+  network_enable_ipv6: "false"
+
+<<: !include common.yaml


### PR DESCRIPTION
I have a default configuration which uses IPv6, but some platforms only support Legacy IP. It doesn't suffice just to override enable_ipv6=false in their own config; we are never even allowed to *mention* IPv6 or the build fails.
# What does this implement/fix?
Fix that, by adding a boolean_false validator. And put it first, so that the error the user actually sees if they *do* set it to true, is the one about it not being supported on that platform.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):**  fixes https://github.com/esphome/issues/issues/6144


## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [x] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
network:
  enable_ipv6: false
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
