### PR TITLE
[validation] Allow ``maybe_simple_value`` to not have default key in complex value

### DIFF
--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -1850,7 +1850,7 @@ def maybe_simple_value(*validators, **kwargs):
         if value == SCHEMA_EXTRACT:
             return (validator, key)
 
-        if isinstance(value, dict) and key in value:
+        if isinstance(value, dict):
             return validator(value)
         return validator({key: value})
 


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->
AFAICT, there are no use cases in the ESPHome codebase that changing this would break.

This allows configs where the `key` is optional, and the user does not want to specify that key. Right now it fails due to the entire value being converted to a dict with the key.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
