### PR TITLE
[gree] Add support for YX1FF remote

### DIFF
--- a/esphome/components/gree/climate.py
+++ b/esphome/components/gree/climate.py
@@ -1,6 +1,6 @@
 import esphome.codegen as cg
-import esphome.config_validation as cv
 from esphome.components import climate_ir
+import esphome.config_validation as cv
 from esphome.const import CONF_ID, CONF_MODEL
 
 CODEOWNERS = ["@orestismers"]
@@ -17,6 +17,7 @@ MODELS = {
     "yaa": Model.GREE_YAA,
     "yac": Model.GREE_YAC,
     "yac1fb9": Model.GREE_YAC1FB9,
+    "yx1ff": Model.GREE_YX1FF,
 }
 
 CONFIG_SCHEMA = climate_ir.CLIMATE_IR_WITH_RECEIVER_SCHEMA.extend(

--- a/esphome/components/gree/gree.h
+++ b/esphome/components/gree/gree.h
@@ -25,7 +25,6 @@ const uint8_t GREE_FAN_AUTO = 0x00;
 const uint8_t GREE_FAN_1 = 0x10;
 const uint8_t GREE_FAN_2 = 0x20;
 const uint8_t GREE_FAN_3 = 0x30;
-const uint8_t GREE_FAN_TURBO = 0x80;
 
 // IR Transmission
 const uint32_t GREE_IR_FREQUENCY = 38000;
@@ -70,8 +69,16 @@ const uint8_t GREE_HDIR_MIDDLE = 0x04;
 const uint8_t GREE_HDIR_MRIGHT = 0x05;
 const uint8_t GREE_HDIR_RIGHT = 0x06;
 
+// Only available on YX1FF
+// Turbo (high) fan mode + sleep preset mode
+const uint8_t GREE_FAN_TURBO = 0x80;
+const uint8_t GREE_FAN_TURBO_BIT = 0x10;
+const uint8_t GREE_PRESET_NONE = 0x00;
+const uint8_t GREE_PRESET_SLEEP = 0x01;
+const uint8_t GREE_PRESET_SLEEP_BIT = 0x80;
+
 // Model codes
-enum Model { GREE_GENERIC, GREE_YAN, GREE_YAA, GREE_YAC, GREE_YAC1FB9 };
+enum Model { GREE_GENERIC, GREE_YAN, GREE_YAA, GREE_YAC, GREE_YAC1FB9, GREE_YX1FF };
 
 class GreeClimate : public climate_ir::ClimateIR {
  public:
@@ -93,6 +100,7 @@ class GreeClimate : public climate_ir::ClimateIR {
   uint8_t horizontal_swing_();
   uint8_t vertical_swing_();
   uint8_t temperature_();
+  uint8_t preset_();
 
   Model model_{};
 };


### PR DESCRIPTION
# What does this implement/fix?

This PR adds support for the Gree YX1FF remote. The most notable differences are 4 fan modes instead of 3, as well as the sleep preset mode.

To handle the 4 fan modes, we expose the `GREE_FAN_1` fan mode as `CLIMATE_FAN_QUIET` (instead of `CLIMATE_FAN_LOW`) and `GREE_FAN_TURBO` as `CLIMATE_FAN_HIGH`.

The sleep preset mode sets the relative "sleep" bit in the IR packet.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#4161

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
sensor:
  - platform: homeassistant
    internal: true
    id: current_temperature
    name: "Temperature Sensor From Home Assistant"
    entity_id: sensor.indoor_temperature

remote_transmitter:
  pin: D1
  carrier_duty_percent: 50%

climate:
  - platform: gree
    name: "AC"
    sensor: current_temperature
    model: "yx1ff"
    supports_heat: false
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
