### PR TITLE
add the ability to add more idf components to an existing setup

### DIFF
--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -169,28 +169,27 @@ def add_idf_component(
             KEY_REF: ref,
             KEY_PATH: path,
             KEY_REFRESH: refresh,
-            KEY_COMPONENTS: components if components is not None else [],
-            KEY_SUBMODULES: submodules if submodules is not None else [],
+            KEY_COMPONENTS: components,
+            KEY_SUBMODULES: submodules,
         }
     else:
         if components is not None:
-            for comp in components:
-                if (
-                    comp
-                    not in CORE.data[KEY_ESP32][KEY_COMPONENTS][name][KEY_COMPONENTS]
-                ):
-                    CORE.data[KEY_ESP32][KEY_COMPONENTS][name][KEY_COMPONENTS].append(
-                        comp
-                    )
+            CORE.data[KEY_ESP32][KEY_COMPONENTS][name][KEY_COMPONENTS] = list(
+                set(
+                    CORE.data[KEY_ESP32][KEY_COMPONENTS][name][KEY_COMPONENTS]
+                    + components
+                )
+            )
         if submodules is not None:
-            for comp in submodules:
-                if (
-                    comp
-                    not in CORE.data[KEY_ESP32][KEY_COMPONENTS][name][KEY_SUBMODULES]
-                ):
-                    CORE.data[KEY_ESP32][KEY_COMPONENTS][name][KEY_SUBMODULES].append(
-                        comp
+            if CORE.data[KEY_ESP32][KEY_COMPONENTS][name][KEY_SUBMODULES] is None:
+                CORE.data[KEY_ESP32][KEY_COMPONENTS][name][KEY_SUBMODULES] = submodules
+            else:
+                CORE.data[KEY_ESP32][KEY_COMPONENTS][name][KEY_SUBMODULES] = list(
+                    set(
+                        CORE.data[KEY_ESP32][KEY_COMPONENTS][name][KEY_SUBMODULES]
+                        + submodules
                     )
+                )
 
 
 def add_extra_script(stage: str, filename: str, path: str):

--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -169,9 +169,28 @@ def add_idf_component(
             KEY_REF: ref,
             KEY_PATH: path,
             KEY_REFRESH: refresh,
-            KEY_COMPONENTS: components,
-            KEY_SUBMODULES: submodules,
+            KEY_COMPONENTS: components if components is not None else [],
+            KEY_SUBMODULES: submodules if submodules is not None else [],
         }
+    else:
+        if components is not None:
+            for comp in components:
+                if (
+                    comp
+                    not in CORE.data[KEY_ESP32][KEY_COMPONENTS][name][KEY_COMPONENTS]
+                ):
+                    CORE.data[KEY_ESP32][KEY_COMPONENTS][name][KEY_COMPONENTS].append(
+                        comp
+                    )
+        if submodules is not None:
+            for comp in submodules:
+                if (
+                    comp
+                    not in CORE.data[KEY_ESP32][KEY_COMPONENTS][name][KEY_SUBMODULES]
+                ):
+                    CORE.data[KEY_ESP32][KEY_COMPONENTS][name][KEY_SUBMODULES].append(
+                        comp
+                    )
 
 
 def add_extra_script(stage: str, filename: str, path: str):

--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -173,22 +173,17 @@ def add_idf_component(
             KEY_SUBMODULES: submodules,
         }
     else:
+        component_config = CORE.data[KEY_ESP32][KEY_COMPONENTS][name]
         if components is not None:
-            CORE.data[KEY_ESP32][KEY_COMPONENTS][name][KEY_COMPONENTS] = list(
-                set(
-                    CORE.data[KEY_ESP32][KEY_COMPONENTS][name][KEY_COMPONENTS]
-                    + components
-                )
+            component_config[KEY_COMPONENTS] = list(
+                set(component_config[KEY_COMPONENTS] + components)
             )
         if submodules is not None:
-            if CORE.data[KEY_ESP32][KEY_COMPONENTS][name][KEY_SUBMODULES] is None:
-                CORE.data[KEY_ESP32][KEY_COMPONENTS][name][KEY_SUBMODULES] = submodules
+            if component_config[KEY_SUBMODULES] is None:
+                component_config[KEY_SUBMODULES] = submodules
             else:
-                CORE.data[KEY_ESP32][KEY_COMPONENTS][name][KEY_SUBMODULES] = list(
-                    set(
-                        CORE.data[KEY_ESP32][KEY_COMPONENTS][name][KEY_SUBMODULES]
-                        + submodules
-                    )
+                component_config[KEY_SUBMODULES] = list(
+                    set([KEY_SUBMODULES] + submodules)
                 )
 
 

--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -183,7 +183,7 @@ def add_idf_component(
                 component_config[KEY_SUBMODULES] = submodules
             else:
                 component_config[KEY_SUBMODULES] = list(
-                    set([KEY_SUBMODULES] + submodules)
+                    set(component_config[KEY_SUBMODULES] + submodules)
                 )
 
 


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->
When a one component added some extra esp_idf components a second attempt was ignored.
With this PR the new components and submodules are bying added to the earlier request.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
