### PR TITLE
Fix waveshare 2.13" epaper stride calculation error

### DIFF
--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -480,7 +480,7 @@ void HOT WaveshareEPaperTypeA::display() {
   this->start_data_();
   switch (this->model_) {
     case TTGO_EPAPER_2_13_IN_B1: {  // block needed because of variable initializations
-      int16_t wb = ((this->get_width_internal()) >> 3);
+      int16_t wb = ((this->get_width_controller()) >> 3);
       for (int i = 0; i < this->get_height_internal(); i++) {
         for (int j = 0; j < wb; j++) {
           int idx = j + (this->get_height_internal() - 1 - i) * wb;
@@ -766,7 +766,7 @@ void WaveshareEPaper2P7InV2::initialize() {
   // XRAM_START_AND_END_POSITION
   this->command(0x44);
   this->data(0x00);
-  this->data(((get_width_internal() - 1) >> 3) & 0xFF);
+  this->data(((get_width_controller() - 1) >> 3) & 0xFF);
   // YRAM_START_AND_END_POSITION
   this->command(0x45);
   this->data(0x00);
@@ -928,8 +928,8 @@ void HOT WaveshareEPaper2P7InB::display() {
 
   // TCON_RESOLUTION
   this->command(0x61);
-  this->data(this->get_width_internal() >> 8);
-  this->data(this->get_width_internal() & 0xff);  // 176
+  this->data(this->get_width_controller() >> 8);
+  this->data(this->get_width_controller() & 0xff);  // 176
   this->data(this->get_height_internal() >> 8);
   this->data(this->get_height_internal() & 0xff);  // 264
 
@@ -994,7 +994,7 @@ void WaveshareEPaper2P7InBV2::initialize() {
   // self.SetWindows(0, 0, self.width-1, self.height-1)
   // SetWindows(self, Xstart, Ystart, Xend, Yend):
 
-  uint32_t xend = this->get_width_internal() - 1;
+  uint32_t xend = this->get_width_controller() - 1;
   uint32_t yend = this->get_height_internal() - 1;
   this->command(0x44);
   this->data(0x00);

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -766,7 +766,7 @@ void WaveshareEPaper2P7InV2::initialize() {
   // XRAM_START_AND_END_POSITION
   this->command(0x44);
   this->data(0x00);
-  this->data(((get_width_controller() - 1) >> 3) & 0xFF);
+  this->data(((this->get_width_controller() - 1) >> 3) & 0xFF);
   // YRAM_START_AND_END_POSITION
   this->command(0x45);
   this->data(0x00);


### PR DESCRIPTION
# What does this implement/fix?

This fixes non-working waveshare 2.13" e-paper displays. The bug was introduced by b5fbe0b1451ac6f709c2aced14918977d284f584

Sample code:
```cpp
it.line(0, 0, 100, 100);
it.filled_rectangle(50, 0, 128, 250);
```

Before change:
![before](https://github.com/user-attachments/assets/30357326-3360-4ae1-baea-face8f159351)

After change:
![after](https://github.com/user-attachments/assets/9675ce66-e77e-40d7-adb4-8dbce2ee3410)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Module: DFRobot FireBeetle Covers-ePaper Black&White Display Module
# Display Module: GDE0213B1
# URL: https://wiki.dfrobot.com/FireBeetle_Covers-ePaper_Black%26White_Display_Module_SKU__DFR0511

font:
  - file: "gfonts://Roboto"
    id: font1
    size: 8

spi:
  clk_pin: GPIO18
  mosi_pin: GPIO23
  miso_pin: GPIO19

output:
  - platform: gpio
    pin:
      number: GPIO10
      inverted: true
      mode:
        output: true
        pulldown: true
    id: font_chip_cs

display:
  - platform: waveshare_epaper
    cs_pin: GPIO26  # D3
    dc_pin: GPIO5  # D8
    busy_pin: GPIO13  # D7
    model: 2.13in-ttgo-b1
    full_update_every: 3
    update_interval: 5s
    lambda: |-
      it.line(0, 0, 100, 100);
      it.filled_rectangle(50, 0, 128, 250);
```

## Checklist:
  - [x] The code change is tested and works locally.