### PR TITLE
[speaker] Fix header includes

### DIFF
--- a/esphome/components/speaker/speaker.h
+++ b/esphome/components/speaker/speaker.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include "esphome/core/entity_base.h"
+#include "esphome/core/helpers.h"
+
 namespace esphome {
 namespace speaker {
 

--- a/esphome/components/speaker/speaker.h
+++ b/esphome/components/speaker/speaker.h
@@ -1,7 +1,8 @@
 #pragma once
 
-#include "esphome/core/entity_base.h"
-#include "esphome/core/helpers.h"
+#include <stddef.h>
+#include <cstdint>
+#include <vector>
 
 namespace esphome {
 namespace speaker {


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->
It seems that using the speaker component together with the adf_pipeline external component from @gnumpi the speaker component did not compile correctly. It was just missing 2 includes.

Strangely it works fine using the i2s_audio component directly.


## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
