### PR TITLE
Revert "[validation] Allow ``maybe_simple_value`` to not have default key in complex value"

### DIFF
--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -1864,7 +1864,7 @@ def maybe_simple_value(*validators, **kwargs):
         if value == SCHEMA_EXTRACT:
             return (validator, key)
 
-        if isinstance(value, dict):
+        if isinstance(value, dict) and key in value:
             return validator(value)
         return validator({key: value})
 


### PR DESCRIPTION
Reverts esphome/esphome#7294

Removing this broke existing configurations where some automations used it to "bypass" the `condition` key.

I will rework this in a further PR