### PR TITLE
[i2s_audio] Add more options to speakers and microphones

### DIFF
--- a/esphome/components/i2s_audio/__init__.py
+++ b/esphome/components/i2s_audio/__init__.py
@@ -78,6 +78,7 @@ I2S_BITS_PER_SAMPLE = {
 
 i2s_bits_per_chan_t = cg.global_ns.enum("i2s_bits_per_chan_t")
 I2S_BITS_PER_CHANNEL = {
+    "default": i2s_bits_per_chan_t.I2S_BITS_PER_CHAN_DEFAULT,
     8: i2s_bits_per_chan_t.I2S_BITS_PER_CHAN_8BIT,
     16: i2s_bits_per_chan_t.I2S_BITS_PER_CHAN_16BIT,
     24: i2s_bits_per_chan_t.I2S_BITS_PER_CHAN_24BIT,
@@ -109,8 +110,9 @@ def i2s_audio_component_schema(
                 I2S_MODE_OPTIONS, lower=True
             ),
             cv.Optional(CONF_USE_APLL, default=False): cv.boolean,
-            cv.Optional(CONF_BITS_PER_CHANNEL): cv.All(
-                cv.float_with_unit("bits", "bit"), cv.enum(I2S_BITS_PER_CHANNEL)
+            cv.Optional(CONF_BITS_PER_CHANNEL, default="default"): cv.All(
+                cv.Any(cv.float_with_unit("bits", "bit"), "default"),
+                cv.enum(I2S_BITS_PER_CHANNEL),
             ),
         }
     )
@@ -123,10 +125,7 @@ async def register_i2s_audio_component(var, config):
     cg.add(var.set_channel(config[CONF_CHANNEL]))
     cg.add(var.set_sample_rate(config[CONF_SAMPLE_RATE]))
     cg.add(var.set_bits_per_sample(config[CONF_BITS_PER_SAMPLE]))
-    bits_per_channel = config.get(
-        CONF_BITS_PER_CHANNEL, i2s_bits_per_chan_t.I2S_BITS_PER_CHAN_DEFAULT
-    )
-    cg.add(var.set_bits_per_channel(bits_per_channel))
+    cg.add(var.set_bits_per_channel(config[CONF_BITS_PER_CHANNEL]))
     cg.add(var.set_use_apll(config[CONF_USE_APLL]))
 
 

--- a/esphome/components/i2s_audio/__init__.py
+++ b/esphome/components/i2s_audio/__init__.py
@@ -52,6 +52,14 @@ I2S_MODE_OPTIONS = {
     CONF_SECONDARY: i2s_mode_t.I2S_MODE_SLAVE,  # NOLINT
 }
 
+# https://github.com/espressif/esp-idf/blob/master/components/soc/{variant}/include/soc/soc_caps.h
+I2S_PORTS = {
+    VARIANT_ESP32: 2,
+    VARIANT_ESP32S2: 1,
+    VARIANT_ESP32S3: 2,
+    VARIANT_ESP32C3: 1,
+}
+
 i2s_channel_fmt_t = cg.global_ns.enum("i2s_channel_fmt_t")
 I2S_CHANNELS = {
     CONF_MONO: i2s_channel_fmt_t.I2S_CHANNEL_FMT_ALL_LEFT,
@@ -74,14 +82,6 @@ I2S_BITS_PER_CHANNEL = {
     16: i2s_bits_per_chan_t.I2S_BITS_PER_CHAN_16BIT,
     24: i2s_bits_per_chan_t.I2S_BITS_PER_CHAN_24BIT,
     32: i2s_bits_per_chan_t.I2S_BITS_PER_CHAN_32BIT,
-}
-
-# https://github.com/espressif/esp-idf/blob/master/components/soc/{variant}/include/soc/soc_caps.h
-I2S_PORTS = {
-    VARIANT_ESP32: 2,
-    VARIANT_ESP32S2: 1,
-    VARIANT_ESP32S3: 2,
-    VARIANT_ESP32C3: 1,
 }
 
 _validate_bits = cv.float_with_unit("bits", "bit")

--- a/esphome/components/i2s_audio/__init__.py
+++ b/esphome/components/i2s_audio/__init__.py
@@ -84,20 +84,6 @@ I2S_PORTS = {
     VARIANT_ESP32C3: 1,
 }
 
-i2s_channel_fmt_t = cg.global_ns.enum("i2s_channel_fmt_t")
-I2S_CHANNELS = {
-    CONF_LEFT: i2s_channel_fmt_t.I2S_CHANNEL_FMT_ONLY_LEFT,
-    CONF_RIGHT: i2s_channel_fmt_t.I2S_CHANNEL_FMT_ONLY_RIGHT,
-    CONF_STEREO: i2s_channel_fmt_t.I2S_CHANNEL_FMT_RIGHT_LEFT,
-}
-
-i2s_bits_per_sample_t = cg.global_ns.enum("i2s_bits_per_sample_t")
-I2S_BITS_PER_SAMPLE = {
-    8: i2s_bits_per_sample_t.I2S_BITS_PER_SAMPLE_8BIT,
-    16: i2s_bits_per_sample_t.I2S_BITS_PER_SAMPLE_16BIT,
-    32: i2s_bits_per_sample_t.I2S_BITS_PER_SAMPLE_32BIT,
-}
-
 _validate_bits = cv.float_with_unit("bits", "bit")
 
 

--- a/esphome/components/i2s_audio/i2s_audio.h
+++ b/esphome/components/i2s_audio/i2s_audio.h
@@ -17,12 +17,16 @@ class I2SAudioBase : public Parented<I2SAudioComponent> {
   void set_channel(i2s_channel_fmt_t channel) { this->channel_ = channel; }
   void set_sample_rate(uint32_t sample_rate) { this->sample_rate_ = sample_rate; }
   void set_bits_per_sample(i2s_bits_per_sample_t bits_per_sample) { this->bits_per_sample_ = bits_per_sample; }
+  void set_bits_per_channel(i2s_bits_per_chan_t bits_per_channel) { this->bits_per_channel_ = bits_per_channel; }
+  void set_use_apll(uint32_t use_apll) { this->use_apll_ = use_apll; }
 
  protected:
   i2s_mode_t i2s_mode_{};
   i2s_channel_fmt_t channel_;
   uint32_t sample_rate_;
   i2s_bits_per_sample_t bits_per_sample_;
+  i2s_bits_per_chan_t bits_per_channel_;
+  bool use_apll_;
 };
 
 class I2SAudioIn : public I2SAudioBase {};

--- a/esphome/components/i2s_audio/media_player/__init__.py
+++ b/esphome/components/i2s_audio/media_player/__init__.py
@@ -12,6 +12,10 @@ from .. import (
     I2SAudioOut,
     CONF_I2S_AUDIO_ID,
     CONF_I2S_DOUT_PIN,
+    CONF_LEFT,
+    CONF_RIGHT,
+    CONF_MONO,
+    CONF_STEREO,
 )
 
 CODEOWNERS = ["@jesserockz"]
@@ -30,12 +34,12 @@ CONF_DAC_TYPE = "dac_type"
 CONF_I2S_COMM_FMT = "i2s_comm_fmt"
 
 INTERNAL_DAC_OPTIONS = {
-    "left": i2s_dac_mode_t.I2S_DAC_CHANNEL_LEFT_EN,
-    "right": i2s_dac_mode_t.I2S_DAC_CHANNEL_RIGHT_EN,
-    "stereo": i2s_dac_mode_t.I2S_DAC_CHANNEL_BOTH_EN,
+    CONF_LEFT: i2s_dac_mode_t.I2S_DAC_CHANNEL_LEFT_EN,
+    CONF_RIGHT: i2s_dac_mode_t.I2S_DAC_CHANNEL_RIGHT_EN,
+    CONF_STEREO: i2s_dac_mode_t.I2S_DAC_CHANNEL_BOTH_EN,
 }
 
-EXTERNAL_DAC_OPTIONS = ["mono", "stereo"]
+EXTERNAL_DAC_OPTIONS = [CONF_MONO, CONF_STEREO]
 
 NO_INTERNAL_DAC_VARIANTS = [esp32.const.VARIANT_ESP32S2]
 

--- a/esphome/components/i2s_audio/media_player/i2s_audio_media_player.h
+++ b/esphome/components/i2s_audio/media_player/i2s_audio_media_player.h
@@ -23,7 +23,7 @@ enum I2SState : uint8_t {
   I2S_STATE_STOPPING,
 };
 
-class I2SAudioMediaPlayer : public Component, public media_player::MediaPlayer, public I2SAudioOut {
+class I2SAudioMediaPlayer : public Component, public Parented<I2SAudioComponent>, public media_player::MediaPlayer {
  public:
   void setup() override;
   float get_setup_priority() const override { return esphome::setup_priority::LATE; }

--- a/esphome/components/i2s_audio/microphone/__init__.py
+++ b/esphome/components/i2s_audio/microphone/__init__.py
@@ -8,8 +8,6 @@ from esphome.const import CONF_ID, CONF_NUMBER
 from .. import (
     CONF_I2S_DIN_PIN,
     CONF_RIGHT,
-    INTERNAL_ADC_VARIANTS,
-    PDM_VARIANTS,
     I2SAudioIn,
     i2s_audio_component_schema,
     i2s_audio_ns,
@@ -23,11 +21,12 @@ CONF_ADC_PIN = "adc_pin"
 CONF_ADC_TYPE = "adc_type"
 CONF_PDM = "pdm"
 
-CONF_USE_APLL = "use_apll"
-
 I2SAudioMicrophone = i2s_audio_ns.class_(
     "I2SAudioMicrophone", I2SAudioIn, microphone.Microphone, cg.Component
 )
+
+INTERNAL_ADC_VARIANTS = [esp32.const.VARIANT_ESP32]
+PDM_VARIANTS = [esp32.const.VARIANT_ESP32, esp32.const.VARIANT_ESP32S3]
 
 
 def validate_esp32_variant(config):
@@ -45,8 +44,14 @@ def validate_esp32_variant(config):
 
 
 BASE_SCHEMA = microphone.MICROPHONE_SCHEMA.extend(
-    i2s_audio_component_schema(I2SAudioMicrophone, 16000, CONF_RIGHT, "32bit")
+    i2s_audio_component_schema(
+        I2SAudioMicrophone,
+        default_sample_rate=16000,
+        default_channel=CONF_RIGHT,
+        default_bits_per_sample="32bit",
+    )
 ).extend(cv.COMPONENT_SCHEMA)
+
 
 CONFIG_SCHEMA = cv.All(
     cv.typed_schema(
@@ -59,8 +64,7 @@ CONFIG_SCHEMA = cv.All(
             "external": BASE_SCHEMA.extend(
                 {
                     cv.Required(CONF_I2S_DIN_PIN): pins.internal_gpio_input_pin_number,
-                    cv.Required(CONF_PDM): cv.boolean,
-                    cv.Optional(CONF_USE_APLL, default=False): cv.boolean,
+                    cv.Optional(CONF_PDM, default=False): cv.boolean,
                 }
             ),
         },
@@ -84,4 +88,3 @@ async def to_code(config):
     else:
         cg.add(var.set_din_pin(config[CONF_I2S_DIN_PIN]))
         cg.add(var.set_pdm(config[CONF_PDM]))
-        cg.add(var.set_use_apll(config[CONF_USE_APLL]))

--- a/esphome/components/i2s_audio/microphone/i2s_audio_microphone.h
+++ b/esphome/components/i2s_audio/microphone/i2s_audio_microphone.h
@@ -10,7 +10,7 @@
 namespace esphome {
 namespace i2s_audio {
 
-class I2SAudioMicrophone : public I2SAudioIn, public microphone::Microphone, public Component {
+class I2SAudioMicrophone : public microphone::Microphone, public I2SAudioIn {
  public:
   void setup() override;
   void start() override;
@@ -30,8 +30,6 @@ class I2SAudioMicrophone : public I2SAudioIn, public microphone::Microphone, pub
   }
 #endif
 
-  void set_use_apll(uint32_t use_apll) { this->use_apll_ = use_apll; }
-
  protected:
   void start_();
   void stop_();
@@ -43,8 +41,6 @@ class I2SAudioMicrophone : public I2SAudioIn, public microphone::Microphone, pub
   bool adc_{false};
 #endif
   bool pdm_{false};
-
-  bool use_apll_;
 
   HighFrequencyLoopRequester high_freq_;
 };

--- a/esphome/components/i2s_audio/microphone/i2s_audio_microphone.h
+++ b/esphome/components/i2s_audio/microphone/i2s_audio_microphone.h
@@ -10,7 +10,7 @@
 namespace esphome {
 namespace i2s_audio {
 
-class I2SAudioMicrophone : public microphone::Microphone, public I2SAudioIn {
+class I2SAudioMicrophone : public microphone::Microphone, public I2SAudioIn, public Component {
  public:
   void setup() override;
   void start() override;

--- a/esphome/components/i2s_audio/microphone/i2s_audio_microphone.h
+++ b/esphome/components/i2s_audio/microphone/i2s_audio_microphone.h
@@ -10,7 +10,7 @@
 namespace esphome {
 namespace i2s_audio {
 
-class I2SAudioMicrophone : public microphone::Microphone, public I2SAudioIn, public Component {
+class I2SAudioMicrophone : public I2SAudioIn, public microphone::Microphone, public Component {
  public:
   void setup() override;
   void start() override;

--- a/esphome/components/i2s_audio/speaker/__init__.py
+++ b/esphome/components/i2s_audio/speaker/__init__.py
@@ -2,11 +2,12 @@ from esphome import pins
 import esphome.codegen as cg
 from esphome.components import esp32, speaker
 import esphome.config_validation as cv
-from esphome.const import CONF_CHANNEL, CONF_ID
+from esphome.const import CONF_CHANNEL, CONF_ID, CONF_MODE, CONF_TIMEOUT
 
 from .. import (
     CONF_I2S_DOUT_PIN,
     CONF_LEFT,
+    CONF_MONO,
     CONF_RIGHT,
     CONF_STEREO,
     I2SAudioOut,
@@ -32,7 +33,6 @@ INTERNAL_DAC_OPTIONS = {
     CONF_STEREO: i2s_dac_mode_t.I2S_DAC_CHANNEL_BOTH_EN,
 }
 
-
 NO_INTERNAL_DAC_VARIANTS = [esp32.const.VARIANT_ESP32S2]
 
 
@@ -45,14 +45,33 @@ def validate_esp32_variant(config):
     return config
 
 
-BASE_SCHEMA = speaker.SPEAKER_SCHEMA.extend(
-    i2s_audio_component_schema(I2SAudioSpeaker, 16000, "stereo", "16bit")
-).extend(cv.COMPONENT_SCHEMA)
+BASE_SCHEMA = (
+    speaker.SPEAKER_SCHEMA.extend(
+        i2s_audio_component_schema(
+            I2SAudioSpeaker,
+            default_sample_rate=16000,
+            default_channel=CONF_MONO,
+            default_bits_per_sample="16bit",
+        )
+    )
+    .extend(
+        {
+            cv.Optional(
+                CONF_TIMEOUT, default="100ms"
+            ): cv.positive_time_period_milliseconds,
+        }
+    )
+    .extend(cv.COMPONENT_SCHEMA)
+)
 
 CONFIG_SCHEMA = cv.All(
     cv.typed_schema(
         {
-            "internal": BASE_SCHEMA,
+            "internal": BASE_SCHEMA.extend(
+                {
+                    cv.Required(CONF_MODE): cv.enum(INTERNAL_DAC_OPTIONS, lower=True),
+                }
+            ),
             "external": BASE_SCHEMA.extend(
                 {
                     cv.Required(
@@ -77,3 +96,4 @@ async def to_code(config):
         cg.add(var.set_internal_dac_mode(config[CONF_CHANNEL]))
     else:
         cg.add(var.set_dout_pin(config[CONF_I2S_DOUT_PIN]))
+    cg.add(var.set_timeout(config[CONF_TIMEOUT]))

--- a/esphome/components/i2s_audio/speaker/i2s_audio_speaker.cpp
+++ b/esphome/components/i2s_audio/speaker/i2s_audio_speaker.cpp
@@ -132,7 +132,8 @@ void I2SAudioSpeaker::player_task(void *params) {
   int32_t buffer[BUFFER_SIZE];
 
   while (true) {
-    if (xQueueReceive(this_speaker->buffer_queue_, &data_event, this_speaker->timeout_) != pdTRUE) {
+    if (xQueueReceive(this_speaker->buffer_queue_, &data_event, this_speaker->timeout_ / portTICK_PERIOD_MS) !=
+        pdTRUE) {
       break;  // End of audio from main thread
     }
     if (data_event.stop) {

--- a/esphome/components/i2s_audio/speaker/i2s_audio_speaker.cpp
+++ b/esphome/components/i2s_audio/speaker/i2s_audio_speaker.cpp
@@ -56,6 +56,21 @@ void I2SAudioSpeaker::start_() {
   this->task_created_ = true;
 }
 
+template<typename a, typename b> const uint8_t *convert_data_format(const a *from, b *to, size_t &bytes, bool repeat) {
+  if (sizeof(a) == sizeof(b) && !repeat) {
+    return reinterpret_cast<const uint8_t *>(from);
+  }
+  const b *result = to;
+  for (size_t i = 0; i < bytes; i += sizeof(a)) {
+    b value = static_cast<b>(*from++) << (sizeof(b) - sizeof(a)) * 8;
+    *to++ = value;
+    if (repeat)
+      *to++ = value;
+  }
+  bytes *= (sizeof(b) / sizeof(a)) * (repeat ? 2 : 1);
+  return reinterpret_cast<const uint8_t *>(result);
+}
+
 void I2SAudioSpeaker::player_task(void *params) {
   I2SAudioSpeaker *this_speaker = (I2SAudioSpeaker *) params;
 
@@ -71,12 +86,12 @@ void I2SAudioSpeaker::player_task(void *params) {
       .communication_format = I2S_COMM_FORMAT_STAND_I2S,
       .intr_alloc_flags = ESP_INTR_FLAG_LEVEL1,
       .dma_buf_count = 8,
-      .dma_buf_len = 128,
-      .use_apll = false,
+      .dma_buf_len = 256,
+      .use_apll = this_speaker->use_apll_,
       .tx_desc_auto_clear = true,
       .fixed_mclk = 0,
       .mclk_multiple = I2S_MCLK_MULTIPLE_256,
-      .bits_per_chan = I2S_BITS_PER_CHAN_DEFAULT,
+      .bits_per_chan = this_speaker->bits_per_channel_,
   };
 #if SOC_I2S_SUPPORTS_DAC
   if (this_speaker->internal_dac_mode_ != I2S_DAC_CHANNEL_DISABLE) {
@@ -114,10 +129,10 @@ void I2SAudioSpeaker::player_task(void *params) {
   event.type = TaskEventType::STARTED;
   xQueueSend(this_speaker->event_queue_, &event, portMAX_DELAY);
 
-  int16_t buffer[BUFFER_SIZE / 2];
+  int32_t buffer[BUFFER_SIZE];
 
   while (true) {
-    if (xQueueReceive(this_speaker->buffer_queue_, &data_event, 100 / portTICK_PERIOD_MS) != pdTRUE) {
+    if (xQueueReceive(this_speaker->buffer_queue_, &data_event, this_speaker->timeout_) != pdTRUE) {
       break;  // End of audio from main thread
     }
     if (data_event.stop) {
@@ -125,17 +140,28 @@ void I2SAudioSpeaker::player_task(void *params) {
       xQueueReset(this_speaker->buffer_queue_);  // Flush queue
       break;
     }
-    size_t bytes_written;
 
-    memmove(buffer, data_event.data, data_event.len);
-    size_t remaining = data_event.len / 2;
-    size_t current = 0;
+    const uint8_t *data = data_event.data;
+    size_t remaining = data_event.len;
+    switch (this_speaker->bits_per_sample_) {
+      case I2S_BITS_PER_SAMPLE_8BIT:
+      case I2S_BITS_PER_SAMPLE_16BIT: {
+        data = convert_data_format(reinterpret_cast<const int16_t *>(data), reinterpret_cast<int16_t *>(buffer),
+                                   remaining, this_speaker->channel_ == I2S_CHANNEL_FMT_ALL_LEFT);
+        break;
+      }
+      case I2S_BITS_PER_SAMPLE_24BIT:
+      case I2S_BITS_PER_SAMPLE_32BIT: {
+        data = convert_data_format(reinterpret_cast<const int16_t *>(data), reinterpret_cast<int32_t *>(buffer),
+                                   remaining, this_speaker->channel_ == I2S_CHANNEL_FMT_ALL_LEFT);
+        break;
+      }
+    }
 
-    while (remaining > 0) {
-      uint32_t sample = (buffer[current] << 16) | (buffer[current] & 0xFFFF);
-
-      esp_err_t err = i2s_write(this_speaker->parent_->get_port(), &sample, sizeof(sample), &bytes_written,
-                                (10 / portTICK_PERIOD_MS));
+    while (remaining != 0) {
+      size_t bytes_written;
+      esp_err_t err =
+          i2s_write(this_speaker->parent_->get_port(), data, remaining, &bytes_written, (32 / portTICK_PERIOD_MS));
       if (err != ESP_OK) {
         event = {.type = TaskEventType::WARNING, .err = err};
         if (xQueueSend(this_speaker->event_queue_, &event, 10 / portTICK_PERIOD_MS) != pdTRUE) {
@@ -143,19 +169,12 @@ void I2SAudioSpeaker::player_task(void *params) {
         }
         continue;
       }
-      if (bytes_written != sizeof(sample)) {
-        event = {.type = TaskEventType::WARNING, .err = ESP_FAIL};
-        if (xQueueSend(this_speaker->event_queue_, &event, 10 / portTICK_PERIOD_MS) != pdTRUE) {
-          ESP_LOGW(TAG, "Failed to send WARNING event");
-        }
-        continue;
-      }
-      remaining--;
-      current++;
+      data += bytes_written;
+      remaining -= bytes_written;
     }
 
     event.type = TaskEventType::PLAYING;
-    event.err = current;
+    event.err = data_event.len;
     if (xQueueSend(this_speaker->event_queue_, &event, 10 / portTICK_PERIOD_MS) != pdTRUE) {
       ESP_LOGW(TAG, "Failed to send PLAYING event");
     }

--- a/esphome/components/i2s_audio/speaker/i2s_audio_speaker.cpp
+++ b/esphome/components/i2s_audio/speaker/i2s_audio_speaker.cpp
@@ -172,12 +172,6 @@ void I2SAudioSpeaker::player_task(void *params) {
       data += bytes_written;
       remaining -= bytes_written;
     }
-
-    event.type = TaskEventType::PLAYING;
-    event.err = data_event.len;
-    if (xQueueSend(this_speaker->event_queue_, &event, 10 / portTICK_PERIOD_MS) != pdTRUE) {
-      ESP_LOGW(TAG, "Failed to send PLAYING event");
-    }
   }
 
   event.type = TaskEventType::STOPPING;
@@ -232,12 +226,10 @@ void I2SAudioSpeaker::watch_() {
       case TaskEventType::STARTED:
         ESP_LOGD(TAG, "Started I2S Audio Speaker");
         this->state_ = speaker::STATE_RUNNING;
+        this->status_clear_warning();
         break;
       case TaskEventType::STOPPING:
         ESP_LOGD(TAG, "Stopping I2S Audio Speaker");
-        break;
-      case TaskEventType::PLAYING:
-        this->status_clear_warning();
         break;
       case TaskEventType::STOPPED:
         this->state_ = speaker::STATE_STOPPED;

--- a/esphome/components/i2s_audio/speaker/i2s_audio_speaker.cpp
+++ b/esphome/components/i2s_audio/speaker/i2s_audio_speaker.cpp
@@ -67,7 +67,7 @@ template<typename a, typename b> const uint8_t *convert_data_format(const a *fro
     if (repeat)
       *to++ = value;
   }
-  bytes *= (sizeof(b) / sizeof(a)) * (repeat ? 2 : 1);
+  bytes *= (sizeof(b) / sizeof(a)) * (repeat ? 2 : 1);  // NOLINT
   return reinterpret_cast<const uint8_t *>(result);
 }
 

--- a/esphome/components/i2s_audio/speaker/i2s_audio_speaker.h
+++ b/esphome/components/i2s_audio/speaker/i2s_audio_speaker.h
@@ -45,6 +45,7 @@ class I2SAudioSpeaker : public I2SAudioOut, public speaker::Speaker, public Comp
   void setup() override;
   void loop() override;
 
+  void set_timeout(uint32_t ms) { this->timeout_ = ms / portTICK_PERIOD_MS; }
   void set_dout_pin(uint8_t pin) { this->dout_pin_ = pin; }
 #if SOC_I2S_SUPPORTS_DAC
   void set_internal_dac_mode(i2s_dac_mode_t mode) { this->internal_dac_mode_ = mode; }
@@ -69,6 +70,7 @@ class I2SAudioSpeaker : public I2SAudioOut, public speaker::Speaker, public Comp
   QueueHandle_t buffer_queue_;
   QueueHandle_t event_queue_;
 
+  uint32_t timeout_{0};
   uint8_t dout_pin_{0};
   bool task_created_{false};
 

--- a/esphome/components/i2s_audio/speaker/i2s_audio_speaker.h
+++ b/esphome/components/i2s_audio/speaker/i2s_audio_speaker.h
@@ -44,7 +44,7 @@ class I2SAudioSpeaker : public I2SAudioOut, public speaker::Speaker, public Comp
   void setup() override;
   void loop() override;
 
-  void set_timeout(uint32_t ms) { this->timeout_ = ms / portTICK_PERIOD_MS; }
+  void set_timeout(uint32_t ms) { this->timeout_ = ms; }
   void set_dout_pin(uint8_t pin) { this->dout_pin_ = pin; }
 #if SOC_I2S_SUPPORTS_DAC
   void set_internal_dac_mode(i2s_dac_mode_t mode) { this->internal_dac_mode_ = mode; }

--- a/esphome/components/i2s_audio/speaker/i2s_audio_speaker.h
+++ b/esphome/components/i2s_audio/speaker/i2s_audio_speaker.h
@@ -21,7 +21,6 @@ static const size_t BUFFER_SIZE = 1024;
 enum class TaskEventType : uint8_t {
   STARTING = 0,
   STARTED,
-  PLAYING,
   STOPPING,
   STOPPED,
   WARNING = 255,

--- a/tests/components/speaker/test.esp32-ard.yaml
+++ b/tests/components/speaker/test.esp32-ard.yaml
@@ -21,4 +21,3 @@ speaker:
     id: speaker_id
     dac_type: external
     i2s_dout_pin: 13
-    mode: mono

--- a/tests/components/speaker/test.esp32-c3-ard.yaml
+++ b/tests/components/speaker/test.esp32-c3-ard.yaml
@@ -21,4 +21,3 @@ speaker:
     id: speaker_id
     dac_type: external
     i2s_dout_pin: 3
-    mode: mono

--- a/tests/components/speaker/test.esp32-c3-idf.yaml
+++ b/tests/components/speaker/test.esp32-c3-idf.yaml
@@ -21,4 +21,3 @@ speaker:
     id: speaker_id
     dac_type: external
     i2s_dout_pin: 3
-    mode: mono

--- a/tests/components/speaker/test.esp32-idf.yaml
+++ b/tests/components/speaker/test.esp32-idf.yaml
@@ -21,4 +21,3 @@ speaker:
     id: speaker_id
     dac_type: external
     i2s_dout_pin: 13
-    mode: mono

--- a/tests/components/voice_assistant/test.esp32-ard.yaml
+++ b/tests/components/voice_assistant/test.esp32-ard.yaml
@@ -28,7 +28,6 @@ speaker:
     id: speaker_id
     dac_type: external
     i2s_dout_pin: 12
-    mode: mono
 
 voice_assistant:
   microphone: mic_id_external

--- a/tests/components/voice_assistant/test.esp32-c3-ard.yaml
+++ b/tests/components/voice_assistant/test.esp32-c3-ard.yaml
@@ -28,7 +28,6 @@ speaker:
     id: speaker_id
     dac_type: external
     i2s_dout_pin: 2
-    mode: mono
 
 voice_assistant:
   microphone: mic_id_external

--- a/tests/components/voice_assistant/test.esp32-c3-idf.yaml
+++ b/tests/components/voice_assistant/test.esp32-c3-idf.yaml
@@ -28,7 +28,6 @@ speaker:
     id: speaker_id
     dac_type: external
     i2s_dout_pin: 2
-    mode: mono
 
 voice_assistant:
   microphone: mic_id_external

--- a/tests/components/voice_assistant/test.esp32-idf.yaml
+++ b/tests/components/voice_assistant/test.esp32-idf.yaml
@@ -28,7 +28,6 @@ speaker:
     id: speaker_id
     dac_type: external
     i2s_dout_pin: 12
-    mode: mono
 
 voice_assistant:
   microphone: mic_id_external


### PR DESCRIPTION
# What does this implement/fix?

Now I2S speakers also have the following options that already exist for microphones:

 * `i2s_mode` (primary/secondary; default: primary)
 * `use_apll` (true/false, default: false)
 * `channel` (left/right/mono/stereo, default: mono)
 * `sample_rate` (default: 16000)
 * `bits_per_sample` (default: 16bit)

Both speakers and microphones also have:

 * `bits_per_channel` (default: equal to `bits_per_sample`)

`channel` has new values:

 * stereo: input/output data is interpreted as a sequence of (right, left) pairs (this option works for both speakers and microphones);
 * mono: for speakers, this is the old behavior - each sample from the input is sent to both left and right channels.

Also, speakers have an extra option:

 * `timeout` (default: 100ms) - how long the background tasks should wait before releasing the bus if the buffer is empty.

The `mode` option of speakers was removed, because it didn't actually do anything.

The `pdm` option for microphones is now optional and defaults to `false`.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#4166

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
i2s_audio:
- i2s_lrclk_pin: 26
  i2s_bclk_pin: 27
  id: i2so
- i2s_lrclk_pin: 33 # WS
  i2s_bclk_pin: 32 # SCK
  id: i2si

microphone:
- platform: i2s_audio
  id: sound_in
  adc_type: external
  i2s_din_pin: 25 # SD
  i2s_audio_id: i2si
  sample_rate: 24000
  bits_per_sample: 32bit
  channel: right
  on_data:
    lambda: |-
      id(sound_out)->play((const uint8_t*)x.data(), x.size() * sizeof(x[0]));

speaker:
- platform: i2s_audio
  id: sound_out
  dac_type: external
  i2s_dout_pin: 14
  i2s_audio_id: i2so
  sample_rate: 24000
  bits_per_sample: 32bit
  channel: mono
  timeout: 500ms
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
