### PR TITLE
Fix RP2040 Neopixel flickering issue

### DIFF
--- a/esphome/components/rp2040_pio_led_strip/led_strip.cpp
+++ b/esphome/components/rp2040_pio_led_strip/led_strip.cpp
@@ -199,7 +199,7 @@ light::ESPColorView RP2040PIOLEDStripLightOutput::get_view_internal(int32_t inde
 }
 
 void RP2040PIOLEDStripLightOutput::dump_config() {
-  ESP_LOGCONFIG(TAG, "RP2040 PIO LED Strip Light Outputs:");
+  ESP_LOGCONFIG(TAG, "RP2040 PIO LED Strip Light Output:");
   ESP_LOGCONFIG(TAG, "  Pin: GPIO%d", this->pin_);
   ESP_LOGCONFIG(TAG, "  Number of LEDs: %d", this->num_leds_);
   ESP_LOGCONFIG(TAG, "  RGBW: %s", YESNO(this->is_rgbw_));

--- a/esphome/components/rp2040_pio_led_strip/led_strip.cpp
+++ b/esphome/components/rp2040_pio_led_strip/led_strip.cpp
@@ -17,24 +17,24 @@ namespace rp2040_pio_led_strip {
 
 static const char *TAG = "rp2040_pio_led_strip";
 
-static uint8_t num_instance_[2] = {0, 0};
-static std::map<Chipset, uint> chipset_offsets_ = {
+static uint8_t RP2040PIOLEDStripLightOutput::num_instance_[2] = {0, 0};
+static std::map<Chipset, uint> RP2040PIOLEDStripLightOutput::chipset_offsets_ = {
     {CHIPSET_WS2812, 0}, {CHIPSET_WS2812B, 0}, {CHIPSET_SK6812, 0}, {CHIPSET_SM16703, 0}, {CHIPSET_CUSTOM, 0},
 };
-static std::map<Chipset, bool> conf_count_ = {
+static std::map<Chipset, bool> RP2040PIOLEDStripLightOutput::conf_count_ = {
     {CHIPSET_WS2812, false},  {CHIPSET_WS2812B, false}, {CHIPSET_SK6812, false},
     {CHIPSET_SM16703, false}, {CHIPSET_CUSTOM, false},
 };
-static bool dma_chan_active_[12];
-static struct semaphore dma_write_complete_sem_[12];
+static bool RP2040PIOLEDStripLightOutput::dma_chan_active_[12];
+static struct semaphore RP2040PIOLEDStripLightOutput::dma_write_complete_sem_[12];
 
 // DMA interrupt service routine
 void RP2040PIOLEDStripLightOutput::dma_write_complete_handler_() {
   uint32_t channel = dma_hw->ints0;
   for (uint dma_chan = 0; dma_chan < 12; ++dma_chan) {
-    if (dma_chan_active_[dma_chan] && (channel & (1u << dma_chan))) {
+    if (RP2040PIOLEDStripLightOutput::dma_chan_active_[dma_chan] && (channel & (1u << dma_chan))) {
       dma_hw->ints0 = (1u << dma_chan);                 // Clear the interrupt
-      sem_release(&dma_write_complete_sem_[dma_chan]);  // Handle the interrupt
+      sem_release(&RP2040PIOLEDStripLightOutput::dma_write_complete_sem_[dma_chan]);  // Handle the interrupt
     }
   }
 }
@@ -72,22 +72,22 @@ void RP2040PIOLEDStripLightOutput::setup() {
   // but there are only 4 state machines on each PIO so we can only have 4 strips per PIO
   uint offset = 0;
 
-  if (num_instance_[this->pio_ == pio0 ? 0 : 1] > 4) {
+  if (RP2040PIOLEDStripLightOutput::num_instance_[this->pio_ == pio0 ? 0 : 1] > 4) {
     ESP_LOGE(TAG, "Too many instances of PIO program");
     this->mark_failed();
     return;
   }
   // keep track of how many instances of the PIO program are running on each PIO
-  num_instance_[this->pio_ == pio0 ? 0 : 1]++;
+  RP2040PIOLEDStripLightOutput::num_instance_[this->pio_ == pio0 ? 0 : 1]++;
 
   // if there are multiple strips of the same chipset, we can reuse the same PIO program and save space
   if (this->conf_count_[this->chipset_]) {
-    offset = chipset_offsets_[this->chipset_];
+    offset = RP2040PIOLEDStripLightOutput::chipset_offsets_[this->chipset_];
   } else {
     // Load the assembled program into the PIO and get its location in the PIO's instruction memory and save it
     offset = pio_add_program(this->pio_, this->program_);
-    chipset_offsets_[this->chipset_] = offset;
-    conf_count_[this->chipset_] = true;
+    RP2040PIOLEDStripLightOutput::chipset_offsets_[this->chipset_] = offset;
+    RP2040PIOLEDStripLightOutput::conf_count_[this->chipset_] = true;
   }
 
   // Configure the state machine's PIO, and start it
@@ -109,7 +109,7 @@ void RP2040PIOLEDStripLightOutput::setup() {
   }
 
   // Mark the DMA channel as active
-  dma_chan_active_[this->dma_chan_] = true;
+  RP2040PIOLEDStripLightOutput::dma_chan_active_[this->dma_chan_] = true;
 
   this->dma_config_ = dma_channel_get_default_config(this->dma_chan_);
   channel_config_set_transfer_data_size(
@@ -128,7 +128,7 @@ void RP2040PIOLEDStripLightOutput::setup() {
   );
 
   // Initialize the semaphore for this DMA channel
-  sem_init(&dma_write_complete_sem_[this->dma_chan_], 1, 1);
+  sem_init(&RP2040PIOLEDStripLightOutput::dma_write_complete_sem_[this->dma_chan_], 1, 1);
 
   irq_set_exclusive_handler(DMA_IRQ_0, dma_write_complete_handler_);  // after DMA all data, raise an interrupt
   dma_channel_set_irq0_enabled(this->dma_chan_, true);                // map DMA channel to interrupt
@@ -151,7 +151,7 @@ void RP2040PIOLEDStripLightOutput::write_state(light::LightState *state) {
   }
 
   // the bits are already in the correct order for the pio program so we can just copy the buffer using DMA
-  sem_acquire_blocking(&dma_write_complete_sem_[this->dma_chan_]);
+  sem_acquire_blocking(&RP2040PIOLEDStripLightOutput::dma_write_complete_sem_[this->dma_chan_]);
   dma_channel_transfer_from_buffer_now(this->dma_chan_, this->buf_, this->get_buffer_size_());
 }
 

--- a/esphome/components/rp2040_pio_led_strip/led_strip.cpp
+++ b/esphome/components/rp2040_pio_led_strip/led_strip.cpp
@@ -130,9 +130,9 @@ void RP2040PIOLEDStripLightOutput::setup() {
   // Initialize the semaphore for this DMA channel
   sem_init(&dma_write_complete_sem_[this->dma_chan_], 1, 1);
 
-  irq_set_exclusive_handler(DMA_IRQ_0, dma_write_complete_handler_); // after DMA all data, raise an interrupt
-  dma_channel_set_irq0_enabled(this->dma_chan_, true);               // map DMA channel to interrupt
-  irq_set_enabled(DMA_IRQ_0, true);                                  // enable interrupt
+  irq_set_exclusive_handler(DMA_IRQ_0, dma_write_complete_handler_);  // after DMA all data, raise an interrupt
+  dma_channel_set_irq0_enabled(this->dma_chan_, true);                // map DMA channel to interrupt
+  irq_set_enabled(DMA_IRQ_0, true);                                   // enable interrupt
 
   this->init_(this->pio_, this->sm_, offset, this->pin_, this->max_refresh_rate_);
 }

--- a/esphome/components/rp2040_pio_led_strip/led_strip.cpp
+++ b/esphome/components/rp2040_pio_led_strip/led_strip.cpp
@@ -27,10 +27,10 @@ static std::map<Chipset, bool> conf_count_ = {
 };
 
 // Global flag to indicate completion
-static struct semaphore reset_delay_complete_sem;
+struct semaphore reset_delay_complete_sem;
 
 // DMA interrupt service routine
-static void RP2040PIOLEDStripLightOutput::dma_complete_handler_() {
+void RP2040PIOLEDStripLightOutput::dma_complete_handler_() {
     // Clear the interrupt request
     uint32_t channel = dma_hw->ints0;
     if( channel & (1u<<this->dma_chan_) ) {

--- a/esphome/components/rp2040_pio_led_strip/led_strip.cpp
+++ b/esphome/components/rp2040_pio_led_strip/led_strip.cpp
@@ -10,6 +10,7 @@
 #include <hardware/irq.h>
 #include <hardware/pio.h>
 #include <pico/stdlib.h>
+#include <pico/sem.h>
 
 namespace esphome {
 namespace rp2040_pio_led_strip {
@@ -192,7 +193,7 @@ light::ESPColorView RP2040PIOLEDStripLightOutput::get_view_internal(int32_t inde
 }
 
 void RP2040PIOLEDStripLightOutput::dump_config() {
-  ESP_LOGCONFIG(TAG, "RP2040 PIO LED Strip Light Output:");
+  ESP_LOGCONFIG(TAG, "RP2040 PIO LED Strip Light Outputs:");
   ESP_LOGCONFIG(TAG, "  Pin: GPIO%d", this->pin_);
   ESP_LOGCONFIG(TAG, "  Number of LEDs: %d", this->num_leds_);
   ESP_LOGCONFIG(TAG, "  RGBW: %s", YESNO(this->is_rgbw_));

--- a/esphome/components/rp2040_pio_led_strip/led_strip.cpp
+++ b/esphome/components/rp2040_pio_led_strip/led_strip.cpp
@@ -33,7 +33,7 @@ void RP2040PIOLEDStripLightOutput::dma_complete_handler_() {
     for (uint dma_chan = 0; dma_chan < 12; ++dma_chan) {
       if (dma_channel_active_[dma_chan] && (channel & (1u << dma_chan))) {
         dma_hw->ints0 = (1u << dma_chan); // Clear the interrupt
-        sem_release(&reset_delay_complete_sem[dma_chan]); // Handle the interrupt
+        sem_release(&reset_delay_complete_sem_[dma_chan]); // Handle the interrupt
       }
     }
 }
@@ -150,7 +150,7 @@ void RP2040PIOLEDStripLightOutput::write_state(light::LightState *state) {
   }
 
   // the bits are already in the correct order for the pio program so we can just copy the buffer using DMA
-  sem_acquire_blocking(&reset_delay_complete_sem[this->dma_chan_]);
+  sem_acquire_blocking(&reset_delay_complete_sem_[this->dma_chan_]);
   dma_channel_transfer_from_buffer_now(this->dma_chan_, this->buf_, this->get_buffer_size_());
 }
 

--- a/esphome/components/rp2040_pio_led_strip/led_strip.cpp
+++ b/esphome/components/rp2040_pio_led_strip/led_strip.cpp
@@ -30,13 +30,13 @@ static struct semaphore dma_write_complete_sem_[12];
 
 // DMA interrupt service routine
 void RP2040PIOLEDStripLightOutput::dma_write_complete_handler_() {
-    uint32_t channel = dma_hw->ints0;
-    for (uint dma_chan = 0; dma_chan < 12; ++dma_chan) {
-      if (dma_chan_active_[dma_chan] && (channel & (1u << dma_chan))) {
-        dma_hw->ints0 = (1u << dma_chan); // Clear the interrupt
-        sem_release(&dma_write_complete_sem_[dma_chan]); // Handle the interrupt
-      }
+  uint32_t channel = dma_hw->ints0;
+  for (uint dma_chan = 0; dma_chan < 12; ++dma_chan) {
+    if (dma_chan_active_[dma_chan] && (channel & (1u << dma_chan))) {
+      dma_hw->ints0 = (1u << dma_chan);                 // Clear the interrupt
+      sem_release(&dma_write_complete_sem_[dma_chan]);  // Handle the interrupt
     }
+  }
 }
 
 void RP2040PIOLEDStripLightOutput::setup() {
@@ -130,9 +130,9 @@ void RP2040PIOLEDStripLightOutput::setup() {
   // Initialize the semaphore for this DMA channel
   sem_init(&dma_write_complete_sem_[this->dma_chan_], 1, 1);
 
-  irq_set_exclusive_handler(DMA_IRQ_0, dma_write_complete_handler_); /* after DMA all data, raise an interrupt */
-  dma_channel_set_irq0_enabled(this->dma_chan_, true); /* map DMA channel to interrupt */
-  irq_set_enabled(DMA_IRQ_0, true); /* enable interrupt */
+  irq_set_exclusive_handler(DMA_IRQ_0, dma_write_complete_handler_); // after DMA all data, raise an interrupt
+  dma_channel_set_irq0_enabled(this->dma_chan_, true);               // map DMA channel to interrupt
+  irq_set_enabled(DMA_IRQ_0, true);                                  // enable interrupt
 
   this->init_(this->pio_, this->sm_, offset, this->pin_, this->max_refresh_rate_);
 }

--- a/esphome/components/rp2040_pio_led_strip/led_strip.cpp
+++ b/esphome/components/rp2040_pio_led_strip/led_strip.cpp
@@ -33,7 +33,7 @@ void RP2040PIOLEDStripLightOutput::dma_write_complete_handler_() {
   uint32_t channel = dma_hw->ints0;
   for (uint dma_chan = 0; dma_chan < 12; ++dma_chan) {
     if (RP2040PIOLEDStripLightOutput::dma_chan_active_[dma_chan] && (channel & (1u << dma_chan))) {
-      dma_hw->ints0 = (1u << dma_chan);                 // Clear the interrupt
+      dma_hw->ints0 = (1u << dma_chan);                                               // Clear the interrupt
       sem_release(&RP2040PIOLEDStripLightOutput::dma_write_complete_sem_[dma_chan]);  // Handle the interrupt
     }
   }

--- a/esphome/components/rp2040_pio_led_strip/led_strip.cpp
+++ b/esphome/components/rp2040_pio_led_strip/led_strip.cpp
@@ -25,6 +25,9 @@ static std::map<Chipset, bool> conf_count_ = {
     {CHIPSET_WS2812, false},  {CHIPSET_WS2812B, false}, {CHIPSET_SK6812, false},
     {CHIPSET_SM16703, false}, {CHIPSET_CUSTOM, false},
 };
+static bool dma_channel_active_[12];
+// Global flag to indicate completion
+static struct semaphore reset_delay_complete_sem_[12];
 
 // DMA interrupt service routine
 void RP2040PIOLEDStripLightOutput::dma_complete_handler_() {

--- a/esphome/components/rp2040_pio_led_strip/led_strip.cpp
+++ b/esphome/components/rp2040_pio_led_strip/led_strip.cpp
@@ -27,10 +27,10 @@ static std::map<Chipset, bool> conf_count_ = {
 };
 
 // Global flag to indicate completion
-struct semaphore reset_delay_complete_sem;
+static struct semaphore reset_delay_complete_sem;
 
 // DMA interrupt service routine
-void RP2040PIOLEDStripLightOutput::dma_complete_handler_() {
+static void RP2040PIOLEDStripLightOutput::dma_complete_handler_() {
     // Clear the interrupt request
     uint32_t channel = dma_hw->ints0;
     if( channel & (1u<<this->dma_chan_) ) {

--- a/esphome/components/rp2040_pio_led_strip/led_strip.cpp
+++ b/esphome/components/rp2040_pio_led_strip/led_strip.cpp
@@ -17,16 +17,16 @@ namespace rp2040_pio_led_strip {
 
 static const char *TAG = "rp2040_pio_led_strip";
 
-static uint8_t RP2040PIOLEDStripLightOutput::num_instance_[2] = {0, 0};
-static std::map<Chipset, uint> RP2040PIOLEDStripLightOutput::chipset_offsets_ = {
+static uint8_t num_instance_[2] = {0, 0};
+static std::map<Chipset, uint> chipset_offsets_ = {
     {CHIPSET_WS2812, 0}, {CHIPSET_WS2812B, 0}, {CHIPSET_SK6812, 0}, {CHIPSET_SM16703, 0}, {CHIPSET_CUSTOM, 0},
 };
-static std::map<Chipset, bool> RP2040PIOLEDStripLightOutput::conf_count_ = {
+static std::map<Chipset, bool> conf_count_ = {
     {CHIPSET_WS2812, false},  {CHIPSET_WS2812B, false}, {CHIPSET_SK6812, false},
     {CHIPSET_SM16703, false}, {CHIPSET_CUSTOM, false},
 };
-static bool RP2040PIOLEDStripLightOutput::dma_chan_active_[12];
-static struct semaphore RP2040PIOLEDStripLightOutput::dma_write_complete_sem_[12];
+static bool dma_chan_active_[12];
+static struct semaphore dma_write_complete_sem_[12];
 
 // DMA interrupt service routine
 void RP2040PIOLEDStripLightOutput::dma_write_complete_handler_() {

--- a/esphome/components/rp2040_pio_led_strip/led_strip.cpp
+++ b/esphome/components/rp2040_pio_led_strip/led_strip.cpp
@@ -26,9 +26,6 @@ static std::map<Chipset, bool> conf_count_ = {
     {CHIPSET_SM16703, false}, {CHIPSET_CUSTOM, false},
 };
 
-// Global flag to indicate completion
-static struct semaphore reset_delay_complete_sem[12];
-
 // DMA interrupt service routine
 void RP2040PIOLEDStripLightOutput::dma_complete_handler_() {
     uint32_t channel = dma_hw->ints0;

--- a/esphome/components/rp2040_pio_led_strip/led_strip.h
+++ b/esphome/components/rp2040_pio_led_strip/led_strip.h
@@ -13,6 +13,7 @@
 #include <hardware/pio.h>
 #include <hardware/structs/pio.h>
 #include <pico/stdio.h>
+#include <pico/sem.h>
 #include <map>
 
 namespace esphome {
@@ -98,7 +99,7 @@ class RP2040PIOLEDStripLightOutput : public light::AddressableLight {
   static bool dma_channel_active_[12];
   // Global flag to indicate completion
   static struct semaphore reset_delay_complete_sem[12];
-  
+
   static void dma_complete_handler_();
 
   uint8_t *buf_{nullptr};

--- a/esphome/components/rp2040_pio_led_strip/led_strip.h
+++ b/esphome/components/rp2040_pio_led_strip/led_strip.h
@@ -96,7 +96,7 @@ class RP2040PIOLEDStripLightOutput : public light::AddressableLight {
 
   size_t get_buffer_size_() const { return this->num_leds_ * (3 + this->is_rgbw_); }
 
-  static void dma_complete_handler_();
+  static void dma_write_complete_handler_();
 
   uint8_t *buf_{nullptr};
   uint8_t *effect_data_{nullptr};
@@ -123,8 +123,8 @@ class RP2040PIOLEDStripLightOutput : public light::AddressableLight {
   inline static int num_instance_[2];
   inline static std::map<Chipset, bool> conf_count_;
   inline static std::map<Chipset, int> chipset_offsets_;
-  inline static bool dma_channel_active_[12];
-  inline static struct semaphore reset_delay_complete_sem_[12];
+  inline static bool dma_chan_active_[12];
+  inline static struct semaphore dma_write_complete_sem_[12];
 };
 
 }  // namespace rp2040_pio_led_strip

--- a/esphome/components/rp2040_pio_led_strip/led_strip.h
+++ b/esphome/components/rp2040_pio_led_strip/led_strip.h
@@ -95,7 +95,7 @@ class RP2040PIOLEDStripLightOutput : public light::AddressableLight {
 
   size_t get_buffer_size_() const { return this->num_leds_ * (3 + this->is_rgbw_); }
 
-  static void dma_complete_handler_();
+  void dma_complete_handler_();
 
   uint8_t *buf_{nullptr};
   uint8_t *effect_data_{nullptr};

--- a/esphome/components/rp2040_pio_led_strip/led_strip.h
+++ b/esphome/components/rp2040_pio_led_strip/led_strip.h
@@ -95,7 +95,11 @@ class RP2040PIOLEDStripLightOutput : public light::AddressableLight {
 
   size_t get_buffer_size_() const { return this->num_leds_ * (3 + this->is_rgbw_); }
 
-  void dma_complete_handler_();
+  static bool dma_channel_active_[12];
+  // Global flag to indicate completion
+  static struct semaphore reset_delay_complete_sem[12];
+  
+  static void dma_complete_handler_();
 
   uint8_t *buf_{nullptr};
   uint8_t *effect_data_{nullptr};

--- a/esphome/components/rp2040_pio_led_strip/led_strip.h
+++ b/esphome/components/rp2040_pio_led_strip/led_strip.h
@@ -95,7 +95,7 @@ class RP2040PIOLEDStripLightOutput : public light::AddressableLight {
 
   size_t get_buffer_size_() const { return this->num_leds_ * (3 + this->is_rgbw_); }
 
-  void dma_complete_handler_();
+  static void dma_complete_handler_();
 
   uint8_t *buf_{nullptr};
   uint8_t *effect_data_{nullptr};

--- a/esphome/components/rp2040_pio_led_strip/led_strip.h
+++ b/esphome/components/rp2040_pio_led_strip/led_strip.h
@@ -13,7 +13,6 @@
 #include <hardware/pio.h>
 #include <hardware/structs/pio.h>
 #include <pico/stdio.h>
-#include <pico/sem.h>
 #include <map>
 
 namespace esphome {
@@ -96,10 +95,6 @@ class RP2040PIOLEDStripLightOutput : public light::AddressableLight {
 
   size_t get_buffer_size_() const { return this->num_leds_ * (3 + this->is_rgbw_); }
 
-  static bool dma_channel_active_[12];
-  // Global flag to indicate completion
-  static struct semaphore reset_delay_complete_sem_[12];
-
   static void dma_complete_handler_();
 
   uint8_t *buf_{nullptr};
@@ -127,6 +122,8 @@ class RP2040PIOLEDStripLightOutput : public light::AddressableLight {
   inline static int num_instance_[2];
   inline static std::map<Chipset, bool> conf_count_;
   inline static std::map<Chipset, int> chipset_offsets_;
+  inline static bool dma_channel_active_[12];
+  inline static struct semaphore reset_delay_complete_sem_[12];
 };
 
 }  // namespace rp2040_pio_led_strip

--- a/esphome/components/rp2040_pio_led_strip/led_strip.h
+++ b/esphome/components/rp2040_pio_led_strip/led_strip.h
@@ -13,6 +13,7 @@
 #include <hardware/pio.h>
 #include <hardware/structs/pio.h>
 #include <pico/stdio.h>
+#include <pico/sem.h>
 #include <map>
 
 namespace esphome {

--- a/esphome/components/rp2040_pio_led_strip/led_strip.h
+++ b/esphome/components/rp2040_pio_led_strip/led_strip.h
@@ -95,6 +95,8 @@ class RP2040PIOLEDStripLightOutput : public light::AddressableLight {
 
   size_t get_buffer_size_() const { return this->num_leds_ * (3 + this->is_rgbw_); }
 
+  void dma_complete_handler_();
+
   uint8_t *buf_{nullptr};
   uint8_t *effect_data_{nullptr};
 

--- a/esphome/components/rp2040_pio_led_strip/led_strip.h
+++ b/esphome/components/rp2040_pio_led_strip/led_strip.h
@@ -98,7 +98,7 @@ class RP2040PIOLEDStripLightOutput : public light::AddressableLight {
 
   static bool dma_channel_active_[12];
   // Global flag to indicate completion
-  static struct semaphore reset_delay_complete_sem[12];
+  static struct semaphore reset_delay_complete_sem_[12];
 
   static void dma_complete_handler_();
 


### PR DESCRIPTION
# What does this implement/fix?

Fixes Raspberry Pi Pico W ( RP2040 ) flickering issue for the following cases:
- Any addressable effect used to cause random flickering along with random color leds in between.
- Flickering during normal color change transitions

The dma writes were missing interrupt handling causing writes to fire faster than the previous writes used to complete ending up with flickering and random colors. This patch adds interrupt handling for dma writes.

Tested the patch with 2 Neopixel Strips.
![Flickering Fixed](https://github.com/user-attachments/assets/08e1c3d2-eb95-4a71-bfc4-b17ab97e890c)


## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes [esphome/issues#6083](https://github.com/esphome/issues/issues/6083)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [x] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
light:
  - platform: rp2040_pio_led_strip
    name: led_strip
    id: led_strip
    pin: GPIO18
    num_leds: 10
    pio: 0
    rgb_order: GRB
    chipset: WS2812B
    effects:
      - addressable_rainbow:

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
