### PR TITLE
Warn about data loss on API communication

### DIFF
--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -1886,7 +1886,7 @@ bool APIConnection::send_buffer(ProtoWriteBuffer buffer, uint32_t message_type) 
     if (!this->helper_->can_write_without_blocking()) {
       // SubscribeLogsResponse
       if (message_type != 29) {
-        ESP_LOGV(TAG, "Cannot send message because of TCP buffer space");
+        ESP_LOGW(TAG, "Unable to send message: TX buffer not empty. Message discarded");
       }
       delay(0);
       return false;


### PR DESCRIPTION
# What does this implement/fix?

Every now and then (if a lot of sensors gets published very fast) the `tx_buf_` isn't empty and `can_write_without_blocking()` returns `false` two times in a row. In this case a message gets silently dropped. If it's a state update of a `binary_sensor` the sensor entity at Home Assistant doesn't get updated and will be out of sync. 

It's hard to get an idea what's going on because the issue disappear/is unlikely if you increase the log level.

This PR doesn't resolve the issue. It just helps to make the issue more visible if you experience loss of state updates too.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## How to reproduce the issue

[test.yaml.txt](https://github.com/user-attachments/files/16670706/test.yaml.txt)

Some states are out of sync because of dropped messages:
![states](https://github.com/user-attachments/assets/1aea9016-ad0d-437c-bffb-78bc810bdfc9)

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
