### PR TITLE
[rtttl] fix STOPPED state

### DIFF
--- a/esphome/components/rtttl/rtttl.cpp
+++ b/esphome/components/rtttl/rtttl.cpp
@@ -32,7 +32,7 @@ void Rtttl::play(std::string rtttl) {
   if (this->state_ != State::STATE_STOPPED && this->state_ != State::STATE_STOPPING) {
     int pos = this->rtttl_.find(':');
     auto name = this->rtttl_.substr(0, pos);
-    ESP_LOGW(TAG, "RTTL Component is already playing: %s", name.c_str());
+    ESP_LOGW(TAG, "RTTTL Component is already playing: %s", name.c_str());
     return;
   }
 
@@ -122,6 +122,7 @@ void Rtttl::stop() {
 #ifdef USE_OUTPUT
   if (this->output_ != nullptr) {
     this->output_->set_level(0.0);
+    this->set_state_(STATE_STOPPED);
   }
 #endif
 #ifdef USE_SPEAKER
@@ -129,10 +130,10 @@ void Rtttl::stop() {
     if (this->speaker_->is_running()) {
       this->speaker_->stop();
     }
+    this->set_state_(STATE_STOPPING);
   }
 #endif
   this->note_duration_ = 0;
-  this->set_state_(STATE_STOPPING);
 }
 
 void Rtttl::loop() {
@@ -342,6 +343,7 @@ void Rtttl::finish_() {
 #ifdef USE_OUTPUT
   if (this->output_ != nullptr) {
     this->output_->set_level(0.0);
+    this->set_state_(State::STATE_STOPPED);
   }
 #endif
 #ifdef USE_SPEAKER
@@ -354,9 +356,9 @@ void Rtttl::finish_() {
     this->speaker_->play((uint8_t *) (&sample), 8);
 
     this->speaker_->finish();
+    this->set_state_(State::STATE_STOPPING);
   }
 #endif
-  this->set_state_(State::STATE_STOPPING);
   this->note_duration_ = 0;
   this->on_finished_playback_callback_.call();
   ESP_LOGD(TAG, "Playback finished");


### PR DESCRIPTION
  - id: beeping_signal
    mode: restart
    then:
      - while:
          condition:
              lambda: return(1);
          then:
            # prevent interference with button presses
           - if:
                 condition:
                    not: rtttl.is_playing
                 then:
                    - rtttl.play: "wait:d=10,o=5,b=180:g"
           - delay: 1000 ms

# In the condition above - rtttl.is_playng is always true as RTTTL does not enter the stopped state correctly

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx


## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user-exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
