### PR TITLE
[homeassistant-switch] Support different entity domains

### DIFF
--- a/esphome/components/homeassistant/__init__.py
+++ b/esphome/components/homeassistant/__init__.py
@@ -5,6 +5,19 @@ from esphome.const import CONF_ATTRIBUTE, CONF_ENTITY_ID, CONF_INTERNAL
 CODEOWNERS = ["@OttoWinter", "@esphome/core"]
 homeassistant_ns = cg.esphome_ns.namespace("homeassistant")
 
+
+def validate_entity_domain(platform, supported_domains):
+    def validator(config):
+        domain = config[CONF_ENTITY_ID].split(".", 1)[0]
+        if domain not in supported_domains:
+            raise cv.Invalid(
+                f"Entity ID {config[CONF_ENTITY_ID]} is not supported by the {platform} platform."
+            )
+        return config
+
+    return validator
+
+
 HOME_ASSISTANT_IMPORT_SCHEMA = cv.Schema(
     {
         cv.Required(CONF_ENTITY_ID): cv.entity_id,

--- a/esphome/components/homeassistant/switch/__init__.py
+++ b/esphome/components/homeassistant/switch/__init__.py
@@ -7,19 +7,32 @@ from .. import (
     HOME_ASSISTANT_IMPORT_CONTROL_SCHEMA,
     homeassistant_ns,
     setup_home_assistant_entity,
+    validate_entity_domain,
 )
 
 CODEOWNERS = ["@Links2004"]
 DEPENDENCIES = ["api"]
 
+SUPPORTED_DOMAINS = [
+    "automation",
+    "fan",
+    "humidifier",
+    "input_boolean",
+    "light",
+    "remote",
+    "siren",
+    "switch",
+]
+
 HomeassistantSwitch = homeassistant_ns.class_(
     "HomeassistantSwitch", switch.Switch, cg.Component
 )
 
-CONFIG_SCHEMA = (
+CONFIG_SCHEMA = cv.All(
     switch.switch_schema(HomeassistantSwitch)
-    .extend(cv.COMPONENT_SCHEMA)
     .extend(HOME_ASSISTANT_IMPORT_CONTROL_SCHEMA)
+    .extend(cv.COMPONENT_SCHEMA),
+    validate_entity_domain("switch", SUPPORTED_DOMAINS),
 )
 
 

--- a/esphome/components/homeassistant/switch/homeassistant_switch.cpp
+++ b/esphome/components/homeassistant/switch/homeassistant_switch.cpp
@@ -42,9 +42,9 @@ void HomeassistantSwitch::write_state(bool state) {
 
   api::HomeassistantServiceResponse resp;
   if (state) {
-    resp.service = "switch.turn_on";
+    resp.service = "homeassistant.turn_on";
   } else {
-    resp.service = "switch.turn_off";
+    resp.service = "homeassistant.turn_off";
   }
 
   api::HomeassistantServiceMap entity_id_kv;

--- a/tests/components/homeassistant/common.yaml
+++ b/tests/components/homeassistant/common.yaml
@@ -34,6 +34,27 @@ api:
 
 switch:
   - platform: homeassistant
+    entity_id: automation.my_cool_automation
+    id: my_cool_automation
+  - platform: homeassistant
+    entity_id: fan.my_cool_fan
+    id: my_cool_fan
+  - platform: homeassistant
+    entity_id: humidifier.my_cool_humidifier
+    id: my_cool_humidifier
+  - platform: homeassistant
+    entity_id: input_boolean.my_cool_input_boolean
+    id: my_cool_input_boolean
+  - platform: homeassistant
+    entity_id: light.my_cool_light
+    id: my_cool_light
+  - platform: homeassistant
+    entity_id: remote.my_cool_remote
+    id: my_cool_remote
+  - platform: homeassistant
+    entity_id: siren.my_cool_siren
+    id: my_cool_siren
+  - platform: homeassistant
     entity_id: switch.my_cool_switch
     id: my_cool_switch
 


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->
Right now the `homeassistant` switch platform will silently fail (probably with an error in HA logs) if you tried to use an entity that isn't a `switch` because it uses the `switch.turn_on/off` action.

This extends the platform to use `homeassistant.turn_on/off` instead and limits the entities that are simply `ToggleEntities` in Home Assistant Core.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#4215

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
