### PR TITLE
[deep_sleep] touch_wakeup capability on ESP32

### DIFF
--- a/esphome/components/deep_sleep/deep_sleep_esp32.cpp
+++ b/esphome/components/deep_sleep/deep_sleep_esp32.cpp
@@ -81,7 +81,7 @@ void DeepSleepComponent::deep_sleep_() {
 
   if (this->touch_wakeup_.has_value() && *(this->touch_wakeup_)) {
     esp_sleep_enable_touchpad_wakeup();
-    esp_sleep_pd_config(ESP_PD_DOMAIN_RTC_PERIPH, ESP_PD_OPTION_ON);
+    esp_sleep_pd_config(ESP_PD_DOMAIN_RTC_PERIPH, ESP_PD_OPTION_AUTO);
   }
 #endif
 #if defined(USE_ESP32_VARIANT_ESP32C3) || defined(USE_ESP32_VARIANT_ESP32C6)


### PR DESCRIPTION
# What does this implement/fix?

When using the `touch_wakeup` option in the `deep_sleep` component on an ESP32, even with the corresponding `binary_sensor` configured with a `wakeup_threshold`, the ESP does not wake up on touch events. (see linked [issue 3440](https://github.com/esphome/issues/issues/3440)).
As @lhac5vet pointed out in the issue's thread, changing the `esp_sleep_pd_config` from `ESP_PD_OPTION_ON` to `ESP_PD_OPTION_AUTO` fixed this issue, according to a note in the ESP32 API-Sleep Modes ([source](https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-reference/system/sleep_modes.html#_CPPv432esp_sleep_enable_touchpad_wakeupv)): 

> On ESP32, touch wakeup source can not be used when RTC_PERIPH power domain is forced to be powered on (ESP_PD_OPTION_ON) or when ext0 wakeup source is used.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes [issue 3440](https://github.com/esphome/issues/issues/3440)

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
esp32_touch:

binary_sensor:
  - platform: esp32_touch
    id: touch_test
    pin: GPIO4
    threshold: 400
    wakeup_threshold: 400

deep_sleep:
  touch_wakeup: True

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
