### PR TITLE
[ledc] Tweak fix in #6997

### DIFF
--- a/esphome/components/ledc/ledc_output.cpp
+++ b/esphome/components/ledc/ledc_output.cpp
@@ -8,6 +8,8 @@
 #endif
 #include <driver/ledc.h>
 
+#include <cinttypes>
+
 #define CLOCK_FREQUENCY 80e6f
 
 #ifdef USE_ARDUINO
@@ -122,7 +124,7 @@ void LEDCOutput::write_state(float state) {
 #ifdef USE_ESP_IDF
 #if !defined(USE_ESP32_VARIANT_ESP32C3) || (ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 1, 0))
   // ensure that 100% on is not 99.975% on
-  // note: on the C3, this tweak will result in the outputs turning off, so it has been omitted
+  // note: on the C3, this tweak will result in the outputs turning off at 100%, so it has been omitted
   if ((duty == max_duty) && (max_duty != 1)) {
     duty = max_duty + 1;
   }

--- a/esphome/components/ledc/ledc_output.cpp
+++ b/esphome/components/ledc/ledc_output.cpp
@@ -120,8 +120,9 @@ void LEDCOutput::write_state(float state) {
   ledcWrite(this->channel_, duty);
 #endif
 #ifdef USE_ESP_IDF
-#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 1, 0)
+#if !defined(USE_ESP32_VARIANT_ESP32C3) || (ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 1, 0))
   // ensure that 100% on is not 99.975% on
+  // note: on the C3, this tweak will result in the outputs turning off, so it has been omitted
   if ((duty == max_duty) && (max_duty != 1)) {
     duty = max_duty + 1;
   }
@@ -129,6 +130,7 @@ void LEDCOutput::write_state(float state) {
   auto speed_mode = get_speed_mode(channel_);
   auto chan_num = static_cast<ledc_channel_t>(channel_ % 8);
   int hpoint = ledc_angle_to_htop(this->phase_angle_, this->bit_depth_);
+  ESP_LOGV(TAG, "Setting duty: %" PRIu32 " on channel %u", duty, this->channel_);
   ledc_set_duty_with_hpoint(speed_mode, chan_num, duty, hpoint);
   ledc_update_duty(speed_mode, chan_num);
 #endif

--- a/esphome/components/ledc/ledc_output.cpp
+++ b/esphome/components/ledc/ledc_output.cpp
@@ -120,10 +120,12 @@ void LEDCOutput::write_state(float state) {
   ledcWrite(this->channel_, duty);
 #endif
 #ifdef USE_ESP_IDF
+#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 1, 0)
   // ensure that 100% on is not 99.975% on
   if ((duty == max_duty) && (max_duty != 1)) {
     duty = max_duty + 1;
   }
+#endif
   auto speed_mode = get_speed_mode(channel_);
   auto chan_num = static_cast<ledc_channel_t>(channel_ % 8);
   int hpoint = ledc_angle_to_htop(this->phase_angle_, this->bit_depth_);


### PR DESCRIPTION
# What does this implement/fix?

The tweak in #6997 does not behave as expected on the C3 in IDF versions ≥ 5.1; when it is applied in versions of IDF ≥ 5.1 and the output is set to 100%, it instead causes the output to go to 0%.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
