### PR TITLE
[ledc] Fix maximum brightness on ESP-IDF 5.1

### DIFF
--- a/esphome/components/ledc/ledc_output.cpp
+++ b/esphome/components/ledc/ledc_output.cpp
@@ -115,8 +115,8 @@ void LEDCOutput::write_state(float state) {
   const uint32_t max_duty = (uint32_t(1) << this->bit_depth_) - 1;
   const float duty_rounded = roundf(state * max_duty);
   auto duty = static_cast<uint32_t>(duty_rounded);
+  ESP_LOGV(TAG, "Setting duty: %" PRIu32 " on channel %u", duty, this->channel_);
 #ifdef USE_ARDUINO
-  ESP_LOGV(TAG, "Setting duty: %u on channel %u", duty, this->channel_);
   ledcWrite(this->channel_, duty);
 #endif
 #ifdef USE_ESP_IDF
@@ -124,7 +124,9 @@ void LEDCOutput::write_state(float state) {
   auto chan_num = static_cast<ledc_channel_t>(channel_ % 8);
   int hpoint = ledc_angle_to_htop(this->phase_angle_, this->bit_depth_);
   if (duty == max_duty) {
-    ledc_stop(speed_mode, chan_num, !this->pin_->is_inverted());
+    ledc_stop(speed_mode, chan_num, 1);
+  } else if (duty == 0) {
+    ledc_stop(speed_mode, chan_num, 0);
   } else {
     ledc_set_duty_with_hpoint(speed_mode, chan_num, duty, hpoint);
     ledc_update_duty(speed_mode, chan_num);

--- a/esphome/components/ledc/ledc_output.cpp
+++ b/esphome/components/ledc/ledc_output.cpp
@@ -1,3 +1,4 @@
+#include <cinttypes>
 #include "ledc_output.h"
 #include "esphome/core/log.h"
 

--- a/esphome/components/ledc/ledc_output.cpp
+++ b/esphome/components/ledc/ledc_output.cpp
@@ -1,4 +1,3 @@
-#include <cinttypes>
 #include "ledc_output.h"
 #include "esphome/core/log.h"
 

--- a/esphome/components/ledc/ledc_output.cpp
+++ b/esphome/components/ledc/ledc_output.cpp
@@ -120,15 +120,15 @@ void LEDCOutput::write_state(float state) {
   ledcWrite(this->channel_, duty);
 #endif
 #ifdef USE_ESP_IDF
-  // ensure that 100% on is not 99.975% on
-  if ((duty == max_duty) && (max_duty != 1)) {
-    duty = max_duty + 1;
-  }
   auto speed_mode = get_speed_mode(channel_);
   auto chan_num = static_cast<ledc_channel_t>(channel_ % 8);
   int hpoint = ledc_angle_to_htop(this->phase_angle_, this->bit_depth_);
-  ledc_set_duty_with_hpoint(speed_mode, chan_num, duty, hpoint);
-  ledc_update_duty(speed_mode, chan_num);
+  if (duty == max_duty) {
+    ledc_stop(speed_mode, chan_num, !this->pin_->is_inverted());
+  } else {
+    ledc_set_duty_with_hpoint(speed_mode, chan_num, duty, hpoint);
+    ledc_update_duty(speed_mode, chan_num);
+  }
 #endif
 }
 


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

The LEDC component output drops to zero when at maximum brightness using ESP-IDF 5.1. This problem is not observed with ESP-IDF 4.x or with Arduino. I could find no reports of bugs in ESP-IDF or anything in the docs or source code to explain this.

This PR stops the PWM output in the ON state at maximum duty cycle, and in the OFF state at 0.

Testing with IDF 4.x and 5.1 demonstrates correct behaviour.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

output:
  - platform: ledc
    pin: GPIO15
    id: backlight_output
    frequency: 2441Hz

light:
  - platform: monochromatic
    output: backlight_output
    name: LCD Backlight
    id: led
    restore_mode: ALWAYS_ON
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
