### PR TITLE
Fix Incorrect Time Function recalc_timestamp_local()

### DIFF
--- a/esphome/core/time.cpp
+++ b/esphome/core/time.cpp
@@ -191,10 +191,6 @@ void ESPTime::recalc_timestamp_utc(bool use_day_of_year) {
 void ESPTime::recalc_timestamp_local(bool use_day_of_year) {
   this->recalc_timestamp_utc(use_day_of_year);
   this->timestamp -= ESPTime::timezone_offset();
-  ESPTime temp = ESPTime::from_epoch_local(this->timestamp);
-  if (temp.is_dst) {
-    this->timestamp -= 3600;
-  }
 }
 
 int32_t ESPTime::timezone_offset() {


### PR DESCRIPTION
# What does this implement/fix?

When DST is on, the `recalc_timestamp_local()` was adding an extra 3600 seconds to the timestamp. This isn't needed because when the `timezone_offset()` function checks the offset, it already counts for DST. (It compares the time between a `from_epoch_local()` and a `from_epoch_utc()` and the local one will have the DST set.)

See discord for more info https://discord.com/channels/429907082951524364/1235853053022830632/1277121372799238196

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
