### PR TITLE
Add WS2811 to esp32_rmt_led_strip

### DIFF
--- a/esphome/components/esp32_rmt_led_strip/light.py
+++ b/esphome/components/esp32_rmt_led_strip/light.py
@@ -46,6 +46,7 @@ class LEDStripTimings:
 
 
 CHIPSETS = {
+    "WS2811": LEDStripTimings(300, 1090, 1090, 320),
     "WS2812": LEDStripTimings(400, 1000, 1000, 400),
     "SK6812": LEDStripTimings(300, 900, 600, 600),
     "APA106": LEDStripTimings(350, 1360, 1360, 350),


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** NA

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#4193

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
lights:
  - platform: esp32_rmt_led_strip
    rgb_order: RGB
    pin: D23
    num_leds: 100
    # https://www.tme.eu/Document/26d574b43ad9ddaffa4d5bcd140ec145/WS2811.pdf
    bit0_high: 300 ns
    bit0_low: 1090 ns
    bit1_high: 1090 ns
    bit1_low: 320 ns
    reset_low: 300 us
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
