### PR TITLE
Add fields/message for remote pipeline trigger

### DIFF
--- a/esphome/components/api/api.proto
+++ b/esphome/components/api/api.proto
@@ -1491,8 +1491,7 @@ message VoiceAssistantRequest {
   string wake_word_phrase = 5;
   VoiceAssistantPipelineStage start_stage = 6;
   VoiceAssistantPipelineStage end_stage = 7;
-  repeated string wake_word_names = 8;
-  string announce_text = 9;
+  string announce_text = 8;
 }
 
 message VoiceAssistantResponse {
@@ -1573,8 +1572,30 @@ message VoiceAssistantTriggerPipeline {
   VoiceAssistantPipelineStage start_stage = 1;
   VoiceAssistantPipelineStage end_stage = 2;
   string wake_word_phrase = 3;
-  repeated string wake_word_names = 4;
-  string announce_text = 5;
+  string announce_text = 4;
+}
+
+message VoiceAssistantSetConfiguration {
+  option (id) = 121;
+  option (source) = SOURCE_SERVER;
+  option (ifdef) = "USE_VOICE_ASSISTANT";
+
+  repeated string active_wake_words = 1;
+}
+
+message VoiceAssistantAvailableWakeWord {
+  string wake_word = 1;
+  bool is_active = 2;
+  repeated string trained_languages = 3;
+}
+
+message VoiceAssistantConfiguration {
+  option (id) = 122;
+  option (source) = SOURCE_CLIENT;
+  option (ifdef) = "USE_VOICE_ASSISTANT";
+
+  repeated VoiceAssistantAvailableWakeWord available_wake_words = 1;
+  uint32 max_active_wake_words = 2;
 }
 
 // ==================== ALARM CONTROL PANEL ====================

--- a/esphome/components/api/api.proto
+++ b/esphome/components/api/api.proto
@@ -1472,6 +1472,13 @@ message VoiceAssistantAudioSettings {
   float volume_multiplier = 3;
 }
 
+enum VoiceAssistantPipelineStage {
+  VOICE_ASSISTANT_PIPELINE_STAGE_WAKE_WORD = 0;
+  VOICE_ASSISTANT_PIPELINE_STAGE_STT = 1;
+  VOICE_ASSISTANT_PIPELINE_STAGE_INTENT = 2;
+  VOICE_ASSISTANT_PIPELINE_STAGE_TTS = 3;
+}
+
 message VoiceAssistantRequest {
   option (id) = 90;
   option (source) = SOURCE_SERVER;
@@ -1482,6 +1489,10 @@ message VoiceAssistantRequest {
   uint32 flags = 3;
   VoiceAssistantAudioSettings audio_settings = 4;
   string wake_word_phrase = 5;
+  VoiceAssistantPipelineStage start_stage = 6;
+  VoiceAssistantPipelineStage end_stage = 7;
+  repeated string wake_word_names = 8;
+  string tts_input = 9;
 }
 
 message VoiceAssistantResponse {
@@ -1552,6 +1563,18 @@ message VoiceAssistantTimerEventResponse {
   uint32 total_seconds = 4;
   uint32 seconds_left = 5;
   bool is_active = 6;
+}
+
+message VoiceAssistantTriggerPipeline {
+  option (id) = 120;
+  option (source) = SOURCE_SERVER;
+  option (ifdef) = "USE_VOICE_ASSISTANT";
+
+  VoiceAssistantPipelineStage start_stage = 1;
+  VoiceAssistantPipelineStage end_stage = 2;
+  string wake_word_phrase = 3;
+  repeated string wake_word_names = 4;
+  string tts_input = 5;
 }
 
 // ==================== ALARM CONTROL PANEL ====================

--- a/esphome/components/api/api.proto
+++ b/esphome/components/api/api.proto
@@ -1492,7 +1492,7 @@ message VoiceAssistantRequest {
   VoiceAssistantPipelineStage start_stage = 6;
   VoiceAssistantPipelineStage end_stage = 7;
   repeated string wake_word_names = 8;
-  string tts_input = 9;
+  string announce_text = 9;
 }
 
 message VoiceAssistantResponse {
@@ -1574,7 +1574,7 @@ message VoiceAssistantTriggerPipeline {
   VoiceAssistantPipelineStage end_stage = 2;
   string wake_word_phrase = 3;
   repeated string wake_word_names = 4;
-  string tts_input = 5;
+  string announce_text = 5;
 }
 
 // ==================== ALARM CONTROL PANEL ====================

--- a/esphome/components/api/api_pb2.cpp
+++ b/esphome/components/api/api_pb2.cpp
@@ -6828,10 +6828,6 @@ bool VoiceAssistantRequest::decode_length(uint32_t field_id, ProtoLengthDelimite
       return true;
     }
     case 8: {
-      this->wake_word_names.push_back(value.as_string());
-      return true;
-    }
-    case 9: {
       this->announce_text = value.as_string();
       return true;
     }
@@ -6847,10 +6843,7 @@ void VoiceAssistantRequest::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_string(5, this->wake_word_phrase);
   buffer.encode_enum<enums::VoiceAssistantPipelineStage>(6, this->start_stage);
   buffer.encode_enum<enums::VoiceAssistantPipelineStage>(7, this->end_stage);
-  for (auto &it : this->wake_word_names) {
-    buffer.encode_string(8, it, true);
-  }
-  buffer.encode_string(9, this->announce_text);
+  buffer.encode_string(8, this->announce_text);
 }
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void VoiceAssistantRequest::dump_to(std::string &out) const {
@@ -6884,12 +6877,6 @@ void VoiceAssistantRequest::dump_to(std::string &out) const {
   out.append("  end_stage: ");
   out.append(proto_enum_to_string<enums::VoiceAssistantPipelineStage>(this->end_stage));
   out.append("\n");
-
-  for (const auto &it : this->wake_word_names) {
-    out.append("  wake_word_names: ");
-    out.append("'").append(it).append("'");
-    out.append("\n");
-  }
 
   out.append("  announce_text: ");
   out.append("'").append(this->announce_text).append("'");
@@ -7139,10 +7126,6 @@ bool VoiceAssistantTriggerPipeline::decode_length(uint32_t field_id, ProtoLength
       return true;
     }
     case 4: {
-      this->wake_word_names.push_back(value.as_string());
-      return true;
-    }
-    case 5: {
       this->announce_text = value.as_string();
       return true;
     }
@@ -7154,10 +7137,7 @@ void VoiceAssistantTriggerPipeline::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_enum<enums::VoiceAssistantPipelineStage>(1, this->start_stage);
   buffer.encode_enum<enums::VoiceAssistantPipelineStage>(2, this->end_stage);
   buffer.encode_string(3, this->wake_word_phrase);
-  for (auto &it : this->wake_word_names) {
-    buffer.encode_string(4, it, true);
-  }
-  buffer.encode_string(5, this->announce_text);
+  buffer.encode_string(4, this->announce_text);
 }
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void VoiceAssistantTriggerPipeline::dump_to(std::string &out) const {
@@ -7175,14 +7155,129 @@ void VoiceAssistantTriggerPipeline::dump_to(std::string &out) const {
   out.append("'").append(this->wake_word_phrase).append("'");
   out.append("\n");
 
-  for (const auto &it : this->wake_word_names) {
-    out.append("  wake_word_names: ");
+  out.append("  announce_text: ");
+  out.append("'").append(this->announce_text).append("'");
+  out.append("\n");
+  out.append("}");
+}
+#endif
+bool VoiceAssistantSetConfiguration::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
+  switch (field_id) {
+    case 1: {
+      this->active_wake_words.push_back(value.as_string());
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void VoiceAssistantSetConfiguration::encode(ProtoWriteBuffer buffer) const {
+  for (auto &it : this->active_wake_words) {
+    buffer.encode_string(1, it, true);
+  }
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void VoiceAssistantSetConfiguration::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("VoiceAssistantSetConfiguration {\n");
+  for (const auto &it : this->active_wake_words) {
+    out.append("  active_wake_words: ");
     out.append("'").append(it).append("'");
     out.append("\n");
   }
+  out.append("}");
+}
+#endif
+bool VoiceAssistantAvailableWakeWord::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 2: {
+      this->is_active = value.as_bool();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool VoiceAssistantAvailableWakeWord::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
+  switch (field_id) {
+    case 1: {
+      this->wake_word = value.as_string();
+      return true;
+    }
+    case 3: {
+      this->trained_languages.push_back(value.as_string());
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void VoiceAssistantAvailableWakeWord::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_string(1, this->wake_word);
+  buffer.encode_bool(2, this->is_active);
+  for (auto &it : this->trained_languages) {
+    buffer.encode_string(3, it, true);
+  }
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void VoiceAssistantAvailableWakeWord::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("VoiceAssistantAvailableWakeWord {\n");
+  out.append("  wake_word: ");
+  out.append("'").append(this->wake_word).append("'");
+  out.append("\n");
 
-  out.append("  announce_text: ");
-  out.append("'").append(this->announce_text).append("'");
+  out.append("  is_active: ");
+  out.append(YESNO(this->is_active));
+  out.append("\n");
+
+  for (const auto &it : this->trained_languages) {
+    out.append("  trained_languages: ");
+    out.append("'").append(it).append("'");
+    out.append("\n");
+  }
+  out.append("}");
+}
+#endif
+bool VoiceAssistantConfiguration::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 2: {
+      this->max_active_wake_words = value.as_uint32();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool VoiceAssistantConfiguration::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
+  switch (field_id) {
+    case 1: {
+      this->available_wake_words.push_back(value.as_message<VoiceAssistantAvailableWakeWord>());
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void VoiceAssistantConfiguration::encode(ProtoWriteBuffer buffer) const {
+  for (auto &it : this->available_wake_words) {
+    buffer.encode_message<VoiceAssistantAvailableWakeWord>(1, it, true);
+  }
+  buffer.encode_uint32(2, this->max_active_wake_words);
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void VoiceAssistantConfiguration::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("VoiceAssistantConfiguration {\n");
+  for (const auto &it : this->available_wake_words) {
+    out.append("  available_wake_words: ");
+    it.dump_to(out);
+    out.append("\n");
+  }
+
+  out.append("  max_active_wake_words: ");
+  sprintf(buffer, "%" PRIu32, this->max_active_wake_words);
+  out.append(buffer);
   out.append("\n");
   out.append("}");
 }

--- a/esphome/components/api/api_pb2.cpp
+++ b/esphome/components/api/api_pb2.cpp
@@ -449,6 +449,23 @@ template<> const char *proto_enum_to_string<enums::VoiceAssistantRequestFlag>(en
 }
 #endif
 #ifdef HAS_PROTO_MESSAGE_DUMP
+template<>
+const char *proto_enum_to_string<enums::VoiceAssistantPipelineStage>(enums::VoiceAssistantPipelineStage value) {
+  switch (value) {
+    case enums::VOICE_ASSISTANT_PIPELINE_STAGE_WAKE_WORD:
+      return "VOICE_ASSISTANT_PIPELINE_STAGE_WAKE_WORD";
+    case enums::VOICE_ASSISTANT_PIPELINE_STAGE_STT:
+      return "VOICE_ASSISTANT_PIPELINE_STAGE_STT";
+    case enums::VOICE_ASSISTANT_PIPELINE_STAGE_INTENT:
+      return "VOICE_ASSISTANT_PIPELINE_STAGE_INTENT";
+    case enums::VOICE_ASSISTANT_PIPELINE_STAGE_TTS:
+      return "VOICE_ASSISTANT_PIPELINE_STAGE_TTS";
+    default:
+      return "UNKNOWN";
+  }
+}
+#endif
+#ifdef HAS_PROTO_MESSAGE_DUMP
 template<> const char *proto_enum_to_string<enums::VoiceAssistantEvent>(enums::VoiceAssistantEvent value) {
   switch (value) {
     case enums::VOICE_ASSISTANT_ERROR:
@@ -6784,6 +6801,14 @@ bool VoiceAssistantRequest::decode_varint(uint32_t field_id, ProtoVarInt value) 
       this->flags = value.as_uint32();
       return true;
     }
+    case 6: {
+      this->start_stage = value.as_enum<enums::VoiceAssistantPipelineStage>();
+      return true;
+    }
+    case 7: {
+      this->end_stage = value.as_enum<enums::VoiceAssistantPipelineStage>();
+      return true;
+    }
     default:
       return false;
   }
@@ -6802,6 +6827,14 @@ bool VoiceAssistantRequest::decode_length(uint32_t field_id, ProtoLengthDelimite
       this->wake_word_phrase = value.as_string();
       return true;
     }
+    case 8: {
+      this->wake_word_names.push_back(value.as_string());
+      return true;
+    }
+    case 9: {
+      this->tts_input = value.as_string();
+      return true;
+    }
     default:
       return false;
   }
@@ -6812,6 +6845,12 @@ void VoiceAssistantRequest::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint32(3, this->flags);
   buffer.encode_message<VoiceAssistantAudioSettings>(4, this->audio_settings);
   buffer.encode_string(5, this->wake_word_phrase);
+  buffer.encode_enum<enums::VoiceAssistantPipelineStage>(6, this->start_stage);
+  buffer.encode_enum<enums::VoiceAssistantPipelineStage>(7, this->end_stage);
+  for (auto &it : this->wake_word_names) {
+    buffer.encode_string(8, it, true);
+  }
+  buffer.encode_string(9, this->tts_input);
 }
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void VoiceAssistantRequest::dump_to(std::string &out) const {
@@ -6836,6 +6875,24 @@ void VoiceAssistantRequest::dump_to(std::string &out) const {
 
   out.append("  wake_word_phrase: ");
   out.append("'").append(this->wake_word_phrase).append("'");
+  out.append("\n");
+
+  out.append("  start_stage: ");
+  out.append(proto_enum_to_string<enums::VoiceAssistantPipelineStage>(this->start_stage));
+  out.append("\n");
+
+  out.append("  end_stage: ");
+  out.append(proto_enum_to_string<enums::VoiceAssistantPipelineStage>(this->end_stage));
+  out.append("\n");
+
+  for (const auto &it : this->wake_word_names) {
+    out.append("  wake_word_names: ");
+    out.append("'").append(it).append("'");
+    out.append("\n");
+  }
+
+  out.append("  tts_input: ");
+  out.append("'").append(this->tts_input).append("'");
   out.append("\n");
   out.append("}");
 }
@@ -7057,6 +7114,75 @@ void VoiceAssistantTimerEventResponse::dump_to(std::string &out) const {
 
   out.append("  is_active: ");
   out.append(YESNO(this->is_active));
+  out.append("\n");
+  out.append("}");
+}
+#endif
+bool VoiceAssistantTriggerPipeline::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 1: {
+      this->start_stage = value.as_enum<enums::VoiceAssistantPipelineStage>();
+      return true;
+    }
+    case 2: {
+      this->end_stage = value.as_enum<enums::VoiceAssistantPipelineStage>();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool VoiceAssistantTriggerPipeline::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
+  switch (field_id) {
+    case 3: {
+      this->wake_word_phrase = value.as_string();
+      return true;
+    }
+    case 4: {
+      this->wake_word_names.push_back(value.as_string());
+      return true;
+    }
+    case 5: {
+      this->tts_input = value.as_string();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void VoiceAssistantTriggerPipeline::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_enum<enums::VoiceAssistantPipelineStage>(1, this->start_stage);
+  buffer.encode_enum<enums::VoiceAssistantPipelineStage>(2, this->end_stage);
+  buffer.encode_string(3, this->wake_word_phrase);
+  for (auto &it : this->wake_word_names) {
+    buffer.encode_string(4, it, true);
+  }
+  buffer.encode_string(5, this->tts_input);
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void VoiceAssistantTriggerPipeline::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("VoiceAssistantTriggerPipeline {\n");
+  out.append("  start_stage: ");
+  out.append(proto_enum_to_string<enums::VoiceAssistantPipelineStage>(this->start_stage));
+  out.append("\n");
+
+  out.append("  end_stage: ");
+  out.append(proto_enum_to_string<enums::VoiceAssistantPipelineStage>(this->end_stage));
+  out.append("\n");
+
+  out.append("  wake_word_phrase: ");
+  out.append("'").append(this->wake_word_phrase).append("'");
+  out.append("\n");
+
+  for (const auto &it : this->wake_word_names) {
+    out.append("  wake_word_names: ");
+    out.append("'").append(it).append("'");
+    out.append("\n");
+  }
+
+  out.append("  tts_input: ");
+  out.append("'").append(this->tts_input).append("'");
   out.append("\n");
   out.append("}");
 }

--- a/esphome/components/api/api_pb2.cpp
+++ b/esphome/components/api/api_pb2.cpp
@@ -6832,7 +6832,7 @@ bool VoiceAssistantRequest::decode_length(uint32_t field_id, ProtoLengthDelimite
       return true;
     }
     case 9: {
-      this->tts_input = value.as_string();
+      this->announce_text = value.as_string();
       return true;
     }
     default:
@@ -6850,7 +6850,7 @@ void VoiceAssistantRequest::encode(ProtoWriteBuffer buffer) const {
   for (auto &it : this->wake_word_names) {
     buffer.encode_string(8, it, true);
   }
-  buffer.encode_string(9, this->tts_input);
+  buffer.encode_string(9, this->announce_text);
 }
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void VoiceAssistantRequest::dump_to(std::string &out) const {
@@ -6891,8 +6891,8 @@ void VoiceAssistantRequest::dump_to(std::string &out) const {
     out.append("\n");
   }
 
-  out.append("  tts_input: ");
-  out.append("'").append(this->tts_input).append("'");
+  out.append("  announce_text: ");
+  out.append("'").append(this->announce_text).append("'");
   out.append("\n");
   out.append("}");
 }
@@ -7143,7 +7143,7 @@ bool VoiceAssistantTriggerPipeline::decode_length(uint32_t field_id, ProtoLength
       return true;
     }
     case 5: {
-      this->tts_input = value.as_string();
+      this->announce_text = value.as_string();
       return true;
     }
     default:
@@ -7157,7 +7157,7 @@ void VoiceAssistantTriggerPipeline::encode(ProtoWriteBuffer buffer) const {
   for (auto &it : this->wake_word_names) {
     buffer.encode_string(4, it, true);
   }
-  buffer.encode_string(5, this->tts_input);
+  buffer.encode_string(5, this->announce_text);
 }
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void VoiceAssistantTriggerPipeline::dump_to(std::string &out) const {
@@ -7181,8 +7181,8 @@ void VoiceAssistantTriggerPipeline::dump_to(std::string &out) const {
     out.append("\n");
   }
 
-  out.append("  tts_input: ");
-  out.append("'").append(this->tts_input).append("'");
+  out.append("  announce_text: ");
+  out.append("'").append(this->announce_text).append("'");
   out.append("\n");
   out.append("}");
 }

--- a/esphome/components/api/api_pb2.h
+++ b/esphome/components/api/api_pb2.h
@@ -1758,7 +1758,7 @@ class VoiceAssistantRequest : public ProtoMessage {
   enums::VoiceAssistantPipelineStage start_stage{};
   enums::VoiceAssistantPipelineStage end_stage{};
   std::vector<std::string> wake_word_names{};
-  std::string tts_input{};
+  std::string announce_text{};
   void encode(ProtoWriteBuffer buffer) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
@@ -1841,7 +1841,7 @@ class VoiceAssistantTriggerPipeline : public ProtoMessage {
   enums::VoiceAssistantPipelineStage end_stage{};
   std::string wake_word_phrase{};
   std::vector<std::string> wake_word_names{};
-  std::string tts_input{};
+  std::string announce_text{};
   void encode(ProtoWriteBuffer buffer) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;

--- a/esphome/components/api/api_pb2.h
+++ b/esphome/components/api/api_pb2.h
@@ -1757,7 +1757,6 @@ class VoiceAssistantRequest : public ProtoMessage {
   std::string wake_word_phrase{};
   enums::VoiceAssistantPipelineStage start_stage{};
   enums::VoiceAssistantPipelineStage end_stage{};
-  std::vector<std::string> wake_word_names{};
   std::string announce_text{};
   void encode(ProtoWriteBuffer buffer) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
@@ -1840,8 +1839,45 @@ class VoiceAssistantTriggerPipeline : public ProtoMessage {
   enums::VoiceAssistantPipelineStage start_stage{};
   enums::VoiceAssistantPipelineStage end_stage{};
   std::string wake_word_phrase{};
-  std::vector<std::string> wake_word_names{};
   std::string announce_text{};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+};
+class VoiceAssistantSetConfiguration : public ProtoMessage {
+ public:
+  std::vector<std::string> active_wake_words{};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
+};
+class VoiceAssistantAvailableWakeWord : public ProtoMessage {
+ public:
+  std::string wake_word{};
+  bool is_active{false};
+  std::vector<std::string> trained_languages{};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+};
+class VoiceAssistantConfiguration : public ProtoMessage {
+ public:
+  std::vector<VoiceAssistantAvailableWakeWord> available_wake_words{};
+  uint32_t max_active_wake_words{0};
   void encode(ProtoWriteBuffer buffer) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;

--- a/esphome/components/api/api_pb2.h
+++ b/esphome/components/api/api_pb2.h
@@ -178,6 +178,12 @@ enum VoiceAssistantRequestFlag : uint32_t {
   VOICE_ASSISTANT_REQUEST_USE_VAD = 1,
   VOICE_ASSISTANT_REQUEST_USE_WAKE_WORD = 2,
 };
+enum VoiceAssistantPipelineStage : uint32_t {
+  VOICE_ASSISTANT_PIPELINE_STAGE_WAKE_WORD = 0,
+  VOICE_ASSISTANT_PIPELINE_STAGE_STT = 1,
+  VOICE_ASSISTANT_PIPELINE_STAGE_INTENT = 2,
+  VOICE_ASSISTANT_PIPELINE_STAGE_TTS = 3,
+};
 enum VoiceAssistantEvent : uint32_t {
   VOICE_ASSISTANT_ERROR = 0,
   VOICE_ASSISTANT_RUN_START = 1,
@@ -1749,6 +1755,10 @@ class VoiceAssistantRequest : public ProtoMessage {
   uint32_t flags{0};
   VoiceAssistantAudioSettings audio_settings{};
   std::string wake_word_phrase{};
+  enums::VoiceAssistantPipelineStage start_stage{};
+  enums::VoiceAssistantPipelineStage end_stage{};
+  std::vector<std::string> wake_word_names{};
+  std::string tts_input{};
   void encode(ProtoWriteBuffer buffer) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
@@ -1816,6 +1826,22 @@ class VoiceAssistantTimerEventResponse : public ProtoMessage {
   uint32_t total_seconds{0};
   uint32_t seconds_left{0};
   bool is_active{false};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+};
+class VoiceAssistantTriggerPipeline : public ProtoMessage {
+ public:
+  enums::VoiceAssistantPipelineStage start_stage{};
+  enums::VoiceAssistantPipelineStage end_stage{};
+  std::string wake_word_phrase{};
+  std::vector<std::string> wake_word_names{};
+  std::string tts_input{};
   void encode(ProtoWriteBuffer buffer) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;

--- a/esphome/components/api/api_pb2_service.cpp
+++ b/esphome/components/api/api_pb2_service.cpp
@@ -1172,6 +1172,9 @@ bool APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       ESP_LOGVV(TAG, "on_media_player_supported_format: %s", msg.dump().c_str());
 #endif
       this->on_media_player_supported_format(msg);
+#endif
+      break;
+    }
     case 122: {
 #ifdef USE_VOICE_ASSISTANT
       VoiceAssistantConfiguration msg;

--- a/esphome/components/api/api_pb2_service.cpp
+++ b/esphome/components/api/api_pb2_service.cpp
@@ -494,6 +494,14 @@ bool APIServerConnectionBase::send_voice_assistant_audio(const VoiceAssistantAud
 #endif
 #ifdef USE_VOICE_ASSISTANT
 #endif
+#ifdef USE_VOICE_ASSISTANT
+bool APIServerConnectionBase::send_voice_assistant_trigger_pipeline(const VoiceAssistantTriggerPipeline &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  ESP_LOGVV(TAG, "send_voice_assistant_trigger_pipeline: %s", msg.dump().c_str());
+#endif
+  return this->send_message_<VoiceAssistantTriggerPipeline>(msg, 120);
+}
+#endif
 #ifdef USE_ALARM_CONTROL_PANEL
 bool APIServerConnectionBase::send_list_entities_alarm_control_panel_response(
     const ListEntitiesAlarmControlPanelResponse &msg) {

--- a/esphome/components/api/api_pb2_service.cpp
+++ b/esphome/components/api/api_pb2_service.cpp
@@ -502,6 +502,16 @@ bool APIServerConnectionBase::send_voice_assistant_trigger_pipeline(const VoiceA
   return this->send_message_<VoiceAssistantTriggerPipeline>(msg, 120);
 }
 #endif
+#ifdef USE_VOICE_ASSISTANT
+bool APIServerConnectionBase::send_voice_assistant_set_configuration(const VoiceAssistantSetConfiguration &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  ESP_LOGVV(TAG, "send_voice_assistant_set_configuration: %s", msg.dump().c_str());
+#endif
+  return this->send_message_<VoiceAssistantSetConfiguration>(msg, 121);
+}
+#endif
+#ifdef USE_VOICE_ASSISTANT
+#endif
 #ifdef USE_ALARM_CONTROL_PANEL
 bool APIServerConnectionBase::send_list_entities_alarm_control_panel_response(
     const ListEntitiesAlarmControlPanelResponse &msg) {
@@ -1162,6 +1172,14 @@ bool APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       ESP_LOGVV(TAG, "on_media_player_supported_format: %s", msg.dump().c_str());
 #endif
       this->on_media_player_supported_format(msg);
+    case 122: {
+#ifdef USE_VOICE_ASSISTANT
+      VoiceAssistantConfiguration msg;
+      msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
+      ESP_LOGVV(TAG, "on_voice_assistant_configuration: %s", msg.dump().c_str());
+#endif
+      this->on_voice_assistant_configuration(msg);
 #endif
       break;
     }

--- a/esphome/components/api/api_pb2_service.h
+++ b/esphome/components/api/api_pb2_service.h
@@ -254,6 +254,12 @@ class APIServerConnectionBase : public ProtoService {
 #ifdef USE_VOICE_ASSISTANT
   bool send_voice_assistant_trigger_pipeline(const VoiceAssistantTriggerPipeline &msg);
 #endif
+#ifdef USE_VOICE_ASSISTANT
+  bool send_voice_assistant_set_configuration(const VoiceAssistantSetConfiguration &msg);
+#endif
+#ifdef USE_VOICE_ASSISTANT
+  virtual void on_voice_assistant_configuration(const VoiceAssistantConfiguration &value){};
+#endif
 #ifdef USE_ALARM_CONTROL_PANEL
   bool send_list_entities_alarm_control_panel_response(const ListEntitiesAlarmControlPanelResponse &msg);
 #endif

--- a/esphome/components/api/api_pb2_service.h
+++ b/esphome/components/api/api_pb2_service.h
@@ -251,6 +251,9 @@ class APIServerConnectionBase : public ProtoService {
 #ifdef USE_VOICE_ASSISTANT
   virtual void on_voice_assistant_timer_event_response(const VoiceAssistantTimerEventResponse &value){};
 #endif
+#ifdef USE_VOICE_ASSISTANT
+  bool send_voice_assistant_trigger_pipeline(const VoiceAssistantTriggerPipeline &msg);
+#endif
 #ifdef USE_ALARM_CONTROL_PANEL
   bool send_list_entities_alarm_control_panel_response(const ListEntitiesAlarmControlPanelResponse &msg);
 #endif

--- a/esphome/components/voice_assistant/voice_assistant.cpp
+++ b/esphome/components/voice_assistant/voice_assistant.cpp
@@ -289,6 +289,13 @@ void VoiceAssistant::loop() {
       msg.flags = flags;
       msg.audio_settings = audio_settings;
       msg.wake_word_phrase = this->wake_word_;
+
+      if (this->use_wake_word_) {
+        msg.start_stage = VOICE_ASSISTANT_PIPELINE_STAGE_WAKE_WORD;
+      } else {
+        msg.start_stage = VOICE_ASSISTANT_PIPELINE_STAGE_STT;
+      }
+      msg.end_stage = VOICE_ASSISTANT_PIPELINE_STAGE_TTS;
       this->wake_word_ = "";
 
       if (this->api_client_ == nullptr || !this->api_client_->send_voice_assistant_request(msg)) {

--- a/esphome/components/voice_assistant/voice_assistant.cpp
+++ b/esphome/components/voice_assistant/voice_assistant.cpp
@@ -291,11 +291,11 @@ void VoiceAssistant::loop() {
       msg.wake_word_phrase = this->wake_word_;
 
       if (this->use_wake_word_) {
-        msg.start_stage = VOICE_ASSISTANT_PIPELINE_STAGE_WAKE_WORD;
+        msg.start_stage = api::enums::VOICE_ASSISTANT_PIPELINE_STAGE_WAKE_WORD;
       } else {
-        msg.start_stage = VOICE_ASSISTANT_PIPELINE_STAGE_STT;
+        msg.start_stage = api::enums::VOICE_ASSISTANT_PIPELINE_STAGE_STT;
       }
-      msg.end_stage = VOICE_ASSISTANT_PIPELINE_STAGE_TTS;
+      msg.end_stage = api::enums::VOICE_ASSISTANT_PIPELINE_STAGE_TTS;
       this->wake_word_ = "";
 
       if (this->api_client_ == nullptr || !this->api_client_->send_voice_assistant_request(msg)) {


### PR DESCRIPTION
# What does this implement/fix?

Adds a new message `VoiceAssistantTriggerPipeline` and some fields to `VoiceAssistantRequest` to support [remote pipeline triggering](https://github.com/home-assistant/core/pull/124448) from Home Assistant.

This will allow HA to trigger a pipeline run on the ESPHome satellite from `start_stage` to `end_stage` with specific inputs:
* When start/end stages are both TTS, `announce_text` is the text to speak

Also adds:
* `VoiceAssistantSetConfiguration` - set active wake words
* `VoiceAssistantConfiguration` - lists available wake words

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
