### PR TITLE
CH422G support

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -83,6 +83,7 @@ esphome/components/cap1188/* @mreditor97
 esphome/components/captive_portal/* @OttoWinter
 esphome/components/ccs811/* @habbie
 esphome/components/cd74hc4067/* @asoehlke
+esphome/components/ch422g/* @jesterret
 esphome/components/climate/* @esphome/core
 esphome/components/climate_ir/* @glmnet
 esphome/components/color_temperature/* @jesserockz

--- a/esphome/components/ch422g/__init__.py
+++ b/esphome/components/ch422g/__init__.py
@@ -1,0 +1,75 @@
+from esphome import pins
+import esphome.codegen as cg
+from esphome.components import i2c
+import esphome.config_validation as cv
+from esphome.const import (
+    CONF_ID,
+    CONF_INPUT,
+    CONF_INVERTED,
+    CONF_MODE,
+    CONF_NUMBER,
+    CONF_OUTPUT,
+    CONF_RESTORE_VALUE,
+)
+
+CODEOWNERS = ["@jesterret"]
+DEPENDENCIES = ["i2c"]
+MULTI_CONF = True
+ch422g_ns = cg.esphome_ns.namespace("ch422g")
+
+CH422GComponent = ch422g_ns.class_("CH422GComponent", cg.Component, i2c.I2CDevice)
+CH422GGPIOPin = ch422g_ns.class_(
+    "CH422GGPIOPin", cg.GPIOPin, cg.Parented.template(CH422GComponent)
+)
+
+CONF_CH422G = "ch422g"
+CONFIG_SCHEMA = (
+    cv.Schema(
+        {
+            cv.Required(CONF_ID): cv.declare_id(CH422GComponent),
+            cv.Optional(CONF_RESTORE_VALUE, default=False): cv.boolean,
+        }
+    )
+    .extend(cv.COMPONENT_SCHEMA)
+    .extend(i2c.i2c_device_schema(0x24))
+)
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    cg.add(var.set_restore_value(config[CONF_RESTORE_VALUE]))
+    await cg.register_component(var, config)
+    await i2c.register_i2c_device(var, config)
+
+
+CH422G_PIN_SCHEMA = pins.gpio_base_schema(
+    CH422GGPIOPin,
+    cv.int_range(min=0, max=7),
+    modes=[CONF_INPUT, CONF_OUTPUT],
+).extend(
+    {
+        cv.Required(CONF_CH422G): cv.use_id(CH422GComponent),
+    }
+)
+
+
+def ch422g_pin_final_validate(pin_config, parent_config):
+    count = 8
+    if pin_config[CONF_NUMBER] >= count:
+        raise cv.Invalid(f"Pin number must be in range 0-{count - 1}")
+
+
+@pins.PIN_SCHEMA_REGISTRY.register(
+    CONF_CH422G, CH422G_PIN_SCHEMA, ch422g_pin_final_validate
+)
+async def ch422g_pin_to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    parent = await cg.get_variable(config[CONF_CH422G])
+
+    cg.add(var.set_parent(parent))
+
+    num = config[CONF_NUMBER]
+    cg.add(var.set_pin(num))
+    cg.add(var.set_inverted(config[CONF_INVERTED]))
+    cg.add(var.set_flags(pins.gpio_flags_expr(config[CONF_MODE])))
+    return var

--- a/esphome/components/ch422g/__init__.py
+++ b/esphome/components/ch422g/__init__.py
@@ -53,15 +53,7 @@ CH422G_PIN_SCHEMA = pins.gpio_base_schema(
 )
 
 
-def ch422g_pin_final_validate(pin_config, parent_config):
-    count = 8
-    if pin_config[CONF_NUMBER] >= count:
-        raise cv.Invalid(f"Pin number must be in range 0-{count - 1}")
-
-
-@pins.PIN_SCHEMA_REGISTRY.register(
-    CONF_CH422G, CH422G_PIN_SCHEMA, ch422g_pin_final_validate
-)
+@pins.PIN_SCHEMA_REGISTRY.register(CONF_CH422G, CH422G_PIN_SCHEMA)
 async def ch422g_pin_to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     parent = await cg.get_variable(config[CONF_CH422G])

--- a/esphome/components/ch422g/ch422g.cpp
+++ b/esphome/components/ch422g/ch422g.cpp
@@ -1,0 +1,143 @@
+#include "ch422g.h"
+#include "esphome/core/log.h"
+
+namespace esphome {
+namespace ch422g {
+
+const uint8_t CH422G_REG_IN = 0x26;
+const uint8_t CH422G_REG_OUT = 0x38;
+const uint8_t OUT_REG_DEFAULT_VAL = 0xdf;
+
+static const char *const TAG = "ch422g";
+
+void CH422GComponent::setup() {
+  ESP_LOGCONFIG(TAG, "Setting up CH422G...");
+  // Test to see if device exists
+  if (!this->read_inputs_()) {
+    ESP_LOGE(TAG, "CH422G not detected at 0x%02X", this->address_);
+    this->mark_failed();
+    return;
+  }
+
+  // restore defaults over whatever got saved on last boot
+  // this->write_output_(OUT_REG_DEFAULT_VAL);
+
+  ESP_LOGD(TAG, "Initialization complete. Warning: %d, Error: %d", this->status_has_warning(),
+           this->status_has_error());
+}
+
+void CH422GComponent::loop() {
+  // The read_inputs_() method will cache the input values from the chip.
+  this->read_inputs_();
+  // Clear all the previously read flags.
+  this->was_previously_read_ = 0x00;
+}
+
+void CH422GComponent::dump_config() {
+  ESP_LOGCONFIG(TAG, "CH422G:");
+  LOG_I2C_DEVICE(this)
+  if (this->is_failed()) {
+    ESP_LOGE(TAG, "Communication with CH422G failed!");
+  }
+}
+
+// ch422g doesn't have any flag support
+void CH422GComponent::pin_mode(uint8_t pin, gpio::Flags flags) {}
+
+bool CH422GComponent::digital_read(uint8_t pin) {
+  // Note: We want to try and avoid doing any I2C bus read transactions here
+  // to conserve I2C bus bandwidth. So what we do is check to see if we
+  // have seen a read during the time esphome is running this loop. If we have,
+  // we do an I2C bus transaction to get the latest value. If we haven't
+  // we return a cached value which was read at the time loop() was called.
+  if (this->was_previously_read_ & (1 << pin))
+    this->read_inputs_();  // Force a read of a new value
+  // Indicate we saw a read request for this pin in case a
+  // read happens later in the same loop.
+  this->was_previously_read_ |= (1 << pin);
+
+  ESP_LOGV(TAG, "digital_read(%d). Mask: %d, Contains: %d", (int) pin, (int) this->state_mask_,
+           (int) (this->state_mask_ & (1 << pin)));
+  return this->state_mask_ & (1 << pin);
+}
+
+bool CH422GComponent::read_inputs_() {
+  if (this->is_failed()) {
+    ESP_LOGE(TAG, "Device marked failed");
+    return false;
+  }
+
+  uint8_t temp = 0;
+  if ((this->last_error_ = this->read(&temp, 1)) != esphome::i2c::ERROR_OK) {
+    this->status_set_warning();
+    ESP_LOGE(TAG, "read_register_(): I2C I/O error: %d", (int) this->last_error_);
+    return false;
+  }
+
+  uint8_t output = 0;
+  if ((this->last_error_ = this->bus_->read(CH422G_REG_IN, &output, 1)) != esphome::i2c::ERROR_OK) {
+    this->status_set_warning();
+    ESP_LOGE(TAG, "read_register_(): I2C I/O error: %d", (int) this->last_error_);
+    return false;
+  }
+
+  ESP_LOGV(TAG, "read_inputs_() output: %d", (int) output);
+  this->state_mask_ = output;
+  this->status_clear_warning();
+
+  return true;
+}
+
+void CH422GComponent::digital_write(uint8_t pin, bool value) {
+  if (value) {
+    this->state_mask_ |= (1 << pin);
+  } else {
+    this->state_mask_ &= ~(1 << pin);
+  }
+  ESP_LOGV(TAG, "digital_write(%d, %d) mask: %d", (int) pin, (int) value, (int) this->state_mask_);
+  this->write_output_(this->state_mask_);
+}
+
+bool CH422GComponent::write_output_(uint8_t value) {
+  const uint8_t temp = 1;
+  if ((this->last_error_ = this->write(&temp, 1, false)) != esphome::i2c::ERROR_OK) {
+    this->status_set_warning();
+    ESP_LOGE(TAG, "write_output_(): I2C I/O error: %d", (int) this->last_error_);
+    return false;
+  }
+
+  uint8_t writeValue = value;
+  if ((this->last_error_ = this->bus_->write(CH422G_REG_OUT, &writeValue, 1)) != esphome::i2c::ERROR_OK) {
+    this->status_set_warning();
+    ESP_LOGE(TAG, "write_output_(): I2C I/O error: %d writeValue: %d", (int) this->last_error_, (int) writeValue);
+    return false;
+  }
+
+  this->state_mask_ = value;
+  this->status_clear_warning();
+  return true;
+}
+
+float CH422GComponent::get_setup_priority() const { return setup_priority::IO; }
+
+// Run our loop() method very early in the loop, so that we cache read values
+// before other components call our digital_read() method.
+float CH422GComponent::get_loop_priority() const { return 9.0f; }  // Just after WIFI
+
+void CH422GGPIOPin::setup() { pin_mode(flags_); }
+void CH422GGPIOPin::pin_mode(gpio::Flags flags) { this->parent_->pin_mode(this->pin_, flags); }
+bool CH422GGPIOPin::digital_read() {
+  bool ret = this->parent_->digital_read(this->pin_);
+  ESP_LOGV(TAG, "Reading state of pin %d: %d", (int) this->pin_, (int) ret);
+  return ret != this->inverted_;
+}
+
+void CH422GGPIOPin::digital_write(bool value) { this->parent_->digital_write(this->pin_, value != this->inverted_); }
+std::string CH422GGPIOPin::dump_summary() const {
+  char buffer[32];
+  snprintf(buffer, sizeof(buffer), "%u via CH422G", pin_);
+  return buffer;
+}
+
+}  // namespace ch422g
+}  // namespace esphome

--- a/esphome/components/ch422g/ch422g.cpp
+++ b/esphome/components/ch422g/ch422g.cpp
@@ -1,6 +1,5 @@
 #include "ch422g.h"
 #include "esphome/core/log.h"
-#include "Helpers/Helpers.h"
 
 namespace esphome {
 namespace ch422g {

--- a/esphome/components/ch422g/ch422g.h
+++ b/esphome/components/ch422g/ch422g.h
@@ -1,0 +1,70 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/core/hal.h"
+#include "esphome/components/i2c/i2c.h"
+
+namespace esphome {
+namespace ch422g {
+
+class CH422GComponent : public Component, public i2c::I2CDevice {
+ public:
+  CH422GComponent() = default;
+
+  /// Check i2c availability and setup masks
+  void setup() override;
+  /// Poll for input changes periodically
+  void loop() override;
+  /// Helper function to read the value of a pin.
+  bool digital_read(uint8_t pin);
+  /// Helper function to write the value of a pin.
+  void digital_write(uint8_t pin, bool value);
+  /// Helper function to set the pin mode of a pin.
+  void pin_mode(uint8_t pin, gpio::Flags flags);
+
+  float get_setup_priority() const override;
+
+  float get_loop_priority() const override;
+
+  void dump_config() override;
+
+  void set_restore_value(bool restore_value) { this->restore_value_ = restore_value; }
+
+ protected:
+  bool read_inputs_();
+
+  bool write_output_(uint8_t value);
+
+  /// The mask to write as output state - 1 means HIGH, 0 means LOW
+  uint8_t state_mask_{0x00};
+  /// Flags to check if read previously during this loop
+  uint8_t was_previously_read_ = {0x00};
+  /// Storage for last I2C error seen
+  esphome::i2c::ErrorCode last_error_;
+  /// Whether we want to override stored values on expander
+  bool restore_value_{false};
+};
+
+/// Helper class to expose a CH422G pin as an internal input GPIO pin.
+class CH422GGPIOPin : public GPIOPin {
+ public:
+  void setup() override;
+  void pin_mode(gpio::Flags flags) override;
+  bool digital_read() override;
+  void digital_write(bool value) override;
+  std::string dump_summary() const override;
+
+  void set_parent(CH422GComponent *parent) { parent_ = parent; }
+  void set_pin(uint8_t pin) { pin_ = pin; }
+  void set_inverted(bool inverted) { inverted_ = inverted; }
+  void set_flags(gpio::Flags flags) { flags_ = flags; }
+
+ protected:
+  CH422GComponent *parent_;
+  uint8_t pin_;
+  bool inverted_;
+  gpio::Flags flags_;
+};
+
+}  // namespace ch422g
+}  // namespace esphome

--- a/esphome/components/ch422g/ch422g.h
+++ b/esphome/components/ch422g/ch422g.h
@@ -38,7 +38,7 @@ class CH422GComponent : public Component, public i2c::I2CDevice {
   /// The mask to write as output state - 1 means HIGH, 0 means LOW
   uint8_t state_mask_{0x00};
   /// Flags to check if read previously during this loop
-  uint8_t was_previously_read_ = {0x00};
+  uint8_t pin_read_cache_ = {0x00};
   /// Storage for last I2C error seen
   esphome::i2c::ErrorCode last_error_;
   /// Whether we want to override stored values on expander

--- a/tests/components/ch422g/common.yaml
+++ b/tests/components/ch422g/common.yaml
@@ -1,0 +1,20 @@
+ch422g:
+  - id: ch422g_hub
+    address: 0x24
+
+binary_sensor:
+  - platform: gpio
+    id: ch422g_input
+    name: CH422G Binary Sensor
+    pin:
+      ch422g: ch422g_hub
+      number: 1
+      mode: INPUT
+      inverted: true
+  - platform: gpio
+    id: ch422g_output
+    pin:
+      ch422g: ch422g_hub
+      number: 0
+      mode: OUTPUT
+      inverted: false

--- a/tests/components/ch422g/test.esp32-ard.yaml
+++ b/tests/components/ch422g/test.esp32-ard.yaml
@@ -1,0 +1,25 @@
+i2c:
+  - id: i2c_ch422g
+    scl: 16
+    sda: 17
+
+ch422g:
+  - id: ch422g_hub
+    address: 0x24
+
+binary_sensor:
+  - platform: gpio
+    id: ch422g_input
+    name: CH422G Binary Sensor
+    pin:
+      ch422g: ch422g_hub
+      number: 1
+      mode: INPUT
+      inverted: true
+  - platform: gpio
+    id: ch422g_output
+    pin:
+      ch422g: ch422g_hub
+      number: 0
+      mode: OUTPUT
+      inverted: false

--- a/tests/components/ch422g/test.esp32-ard.yaml
+++ b/tests/components/ch422g/test.esp32-ard.yaml
@@ -3,23 +3,4 @@ i2c:
     scl: 16
     sda: 17
 
-ch422g:
-  - id: ch422g_hub
-    address: 0x24
-
-binary_sensor:
-  - platform: gpio
-    id: ch422g_input
-    name: CH422G Binary Sensor
-    pin:
-      ch422g: ch422g_hub
-      number: 1
-      mode: INPUT
-      inverted: true
-  - platform: gpio
-    id: ch422g_output
-    pin:
-      ch422g: ch422g_hub
-      number: 0
-      mode: OUTPUT
-      inverted: false
+<<: !include common.yaml

--- a/tests/components/ch422g/test.esp32-c3-ard.yaml
+++ b/tests/components/ch422g/test.esp32-c3-ard.yaml
@@ -3,23 +3,4 @@ i2c:
     scl: 5
     sda: 4
 
-ch422g:
-  - id: ch422g_hub
-    address: 0x24
-
-binary_sensor:
-  - platform: gpio
-    id: ch422g_input
-    name: CH422G Binary Sensor
-    pin:
-      ch422g: ch422g_hub
-      number: 1
-      mode: INPUT
-      inverted: true
-  - platform: gpio
-    id: ch422g_output
-    pin:
-      ch422g: ch422g_hub
-      number: 0
-      mode: OUTPUT
-      inverted: false
+<<: !include common.yaml

--- a/tests/components/ch422g/test.esp32-c3-ard.yaml
+++ b/tests/components/ch422g/test.esp32-c3-ard.yaml
@@ -1,0 +1,25 @@
+i2c:
+  - id: i2c_ch422g
+    scl: 5
+    sda: 4
+
+ch422g:
+  - id: ch422g_hub
+    address: 0x24
+
+binary_sensor:
+  - platform: gpio
+    id: ch422g_input
+    name: CH422G Binary Sensor
+    pin:
+      ch422g: ch422g_hub
+      number: 1
+      mode: INPUT
+      inverted: true
+  - platform: gpio
+    id: ch422g_output
+    pin:
+      ch422g: ch422g_hub
+      number: 0
+      mode: OUTPUT
+      inverted: false

--- a/tests/components/ch422g/test.esp32-c3-idf.yaml
+++ b/tests/components/ch422g/test.esp32-c3-idf.yaml
@@ -3,23 +3,4 @@ i2c:
     scl: 5
     sda: 4
 
-ch422g:
-  - id: ch422g_hub
-    address: 0x24
-
-binary_sensor:
-  - platform: gpio
-    id: ch422g_input
-    name: CH422G Binary Sensor
-    pin:
-      ch422g: ch422g_hub
-      number: 1
-      mode: INPUT
-      inverted: true
-  - platform: gpio
-    id: ch422g_output
-    pin:
-      ch422g: ch422g_hub
-      number: 0
-      mode: OUTPUT
-      inverted: false
+<<: !include common.yaml

--- a/tests/components/ch422g/test.esp32-c3-idf.yaml
+++ b/tests/components/ch422g/test.esp32-c3-idf.yaml
@@ -1,0 +1,25 @@
+i2c:
+  - id: i2c_ch422g
+    scl: 5
+    sda: 4
+
+ch422g:
+  - id: ch422g_hub
+    address: 0x24
+
+binary_sensor:
+  - platform: gpio
+    id: ch422g_input
+    name: CH422G Binary Sensor
+    pin:
+      ch422g: ch422g_hub
+      number: 1
+      mode: INPUT
+      inverted: true
+  - platform: gpio
+    id: ch422g_output
+    pin:
+      ch422g: ch422g_hub
+      number: 0
+      mode: OUTPUT
+      inverted: false

--- a/tests/components/ch422g/test.esp32-idf.yaml
+++ b/tests/components/ch422g/test.esp32-idf.yaml
@@ -1,0 +1,25 @@
+i2c:
+  - id: i2c_ch422g
+    scl: 16
+    sda: 17
+
+ch422g:
+  - id: ch422g_hub
+    address: 0x24
+
+binary_sensor:
+  - platform: gpio
+    id: ch422g_input
+    name: CH422G Binary Sensor
+    pin:
+      ch422g: ch422g_hub
+      number: 1
+      mode: INPUT
+      inverted: true
+  - platform: gpio
+    id: ch422g_output
+    pin:
+      ch422g: ch422g_hub
+      number: 0
+      mode: OUTPUT
+      inverted: false

--- a/tests/components/ch422g/test.esp32-idf.yaml
+++ b/tests/components/ch422g/test.esp32-idf.yaml
@@ -3,23 +3,4 @@ i2c:
     scl: 16
     sda: 17
 
-ch422g:
-  - id: ch422g_hub
-    address: 0x24
-
-binary_sensor:
-  - platform: gpio
-    id: ch422g_input
-    name: CH422G Binary Sensor
-    pin:
-      ch422g: ch422g_hub
-      number: 1
-      mode: INPUT
-      inverted: true
-  - platform: gpio
-    id: ch422g_output
-    pin:
-      ch422g: ch422g_hub
-      number: 0
-      mode: OUTPUT
-      inverted: false
+<<: !include common.yaml

--- a/tests/components/ch422g/test.esp8266-ard.yaml
+++ b/tests/components/ch422g/test.esp8266-ard.yaml
@@ -3,23 +3,4 @@ i2c:
     scl: 5
     sda: 4
 
-ch422g:
-  - id: ch422g_hub
-    address: 0x24
-
-binary_sensor:
-  - platform: gpio
-    id: ch422g_input
-    name: CH422G Binary Sensor
-    pin:
-      ch422g: ch422g_hub
-      number: 1
-      mode: INPUT
-      inverted: true
-  - platform: gpio
-    id: ch422g_output
-    pin:
-      ch422g: ch422g_hub
-      number: 0
-      mode: OUTPUT
-      inverted: false
+<<: !include common.yaml

--- a/tests/components/ch422g/test.esp8266-ard.yaml
+++ b/tests/components/ch422g/test.esp8266-ard.yaml
@@ -1,0 +1,25 @@
+i2c:
+  - id: i2c_ch422g
+    scl: 5
+    sda: 4
+
+ch422g:
+  - id: ch422g_hub
+    address: 0x24
+
+binary_sensor:
+  - platform: gpio
+    id: ch422g_input
+    name: CH422G Binary Sensor
+    pin:
+      ch422g: ch422g_hub
+      number: 1
+      mode: INPUT
+      inverted: true
+  - platform: gpio
+    id: ch422g_output
+    pin:
+      ch422g: ch422g_hub
+      number: 0
+      mode: OUTPUT
+      inverted: false

--- a/tests/components/ch422g/test.rp2040-ard.yaml
+++ b/tests/components/ch422g/test.rp2040-ard.yaml
@@ -3,23 +3,4 @@ i2c:
     scl: 5
     sda: 4
 
-ch422g:
-  - id: ch422g_hub
-    address: 0x24
-
-binary_sensor:
-  - platform: gpio
-    id: ch422g_input
-    name: CH422G Binary Sensor
-    pin:
-      ch422g: ch422g_hub
-      number: 1
-      mode: INPUT
-      inverted: true
-  - platform: gpio
-    id: ch422g_output
-    pin:
-      ch422g: ch422g_hub
-      number: 0
-      mode: OUTPUT
-      inverted: false
+<<: !include common.yaml

--- a/tests/components/ch422g/test.rp2040-ard.yaml
+++ b/tests/components/ch422g/test.rp2040-ard.yaml
@@ -1,0 +1,25 @@
+i2c:
+  - id: i2c_ch422g
+    scl: 5
+    sda: 4
+
+ch422g:
+  - id: ch422g_hub
+    address: 0x24
+
+binary_sensor:
+  - platform: gpio
+    id: ch422g_input
+    name: CH422G Binary Sensor
+    pin:
+      ch422g: ch422g_hub
+      number: 1
+      mode: INPUT
+      inverted: true
+  - platform: gpio
+    id: ch422g_output
+    pin:
+      ch422g: ch422g_hub
+      number: 0
+      mode: OUTPUT
+      inverted: false


### PR DESCRIPTION
# What does this implement/fix?

Adds support for CH422G I/O Expander
Still bound to get some changes as I try to figure out the codebase, but the base functionality is working.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** 
[Feature Request](https://github.com/esphome/feature-requests/issues/2671)

to try this PR for feedback:
```yaml
external_components:
  - source: github://pr#7356
    components: [ch422g]
```

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#4210

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040
- [x] BK72xx
- [x] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
ch422g:
  - id: io_ex
    address: 0x24

# Toggles backlight of Waveshare ESP32-S3-Touch-LCD-4.3
switch:
  - platform: gpio
    name: "Backlight Toggle"
    pin: 
      ch422g: io_ex
      number: 2
# CH422G saves the last state internally, but gpio switch sets state as off except when using RESTORE_ modes
    restore_mode: ALWAYS_ON
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
