### PR TITLE
add rx_buffer_size config property to logger

### DIFF
--- a/esphome/components/logger/__init__.py
+++ b/esphome/components/logger/__init__.py
@@ -26,6 +26,7 @@ from esphome.const import (
     CONF_LEVEL,
     CONF_LOGS,
     CONF_ON_MESSAGE,
+    CONF_RX_BUFFER_SIZE,
     CONF_TAG,
     CONF_TRIGGER_ID,
     CONF_TX_BUFFER_SIZE,
@@ -176,6 +177,7 @@ CONFIG_SCHEMA = cv.All(
             cv.GenerateID(): cv.declare_id(Logger),
             cv.Optional(CONF_BAUD_RATE, default=115200): cv.positive_int,
             cv.Optional(CONF_TX_BUFFER_SIZE, default=512): cv.validate_bytes,
+            cv.Optional(CONF_RX_BUFFER_SIZE, default=512): cv.validate_bytes,
             cv.Optional(CONF_DEASSERT_RTS_DTR, default=False): cv.boolean,
             cv.SplitDefault(
                 CONF_HARDWARE_UART,
@@ -225,7 +227,12 @@ CONFIG_SCHEMA = cv.All(
 @coroutine_with_priority(90.0)
 async def to_code(config):
     baud_rate = config[CONF_BAUD_RATE]
-    log = cg.new_Pvariable(config[CONF_ID], baud_rate, config[CONF_TX_BUFFER_SIZE])
+    log = cg.new_Pvariable(
+        config[CONF_ID],
+        baud_rate,
+        config[CONF_TX_BUFFER_SIZE],
+        config[CONF_RX_BUFFER_SIZE],
+    )
     if CONF_HARDWARE_UART in config:
         cg.add(
             log.set_uart_selection(

--- a/esphome/components/logger/logger.cpp
+++ b/esphome/components/logger/logger.cpp
@@ -140,7 +140,8 @@ void HOT Logger::log_message_(int level, const char *tag, int offset) {
   this->log_callback_.call(level, tag, msg);
 }
 
-Logger::Logger(uint32_t baud_rate, size_t tx_buffer_size) : baud_rate_(baud_rate), tx_buffer_size_(tx_buffer_size) {
+Logger::Logger(uint32_t baud_rate, size_t tx_buffer_size, size_t rx_buffer_size)
+    : baud_rate_(baud_rate), tx_buffer_size_(tx_buffer_size), rx_buffer_size_(rx_buffer_size) {
   // add 1 to buffer size for null terminator
   this->tx_buffer_ = new char[this->tx_buffer_size_ + 1];  // NOLINT
 #if defined(USE_ESP32) || defined(USE_LIBRETINY)

--- a/esphome/components/logger/logger.h
+++ b/esphome/components/logger/logger.h
@@ -55,7 +55,7 @@ enum UARTSelection {
 
 class Logger : public Component {
  public:
-  explicit Logger(uint32_t baud_rate, size_t tx_buffer_size);
+  explicit Logger(uint32_t baud_rate, size_t tx_buffer_size, size_t rx_buffer_size);
 #ifdef USE_LOGGER_USB_CDC
   void loop() override;
 #endif
@@ -147,6 +147,7 @@ class Logger : public Component {
   char *tx_buffer_{nullptr};
   int tx_buffer_at_{0};
   int tx_buffer_size_{0};
+  int rx_buffer_size_{0};
 #if defined(USE_ESP32) || defined(USE_ESP8266) || defined(USE_RP2040)
   UARTSelection uart_{UART_SELECTION_UART0};
 #endif

--- a/esphome/components/logger/logger_esp32.cpp
+++ b/esphome/components/logger/logger_esp32.cpp
@@ -33,7 +33,7 @@ static const char *const TAG = "logger";
 #ifdef USE_ESP_IDF
 
 #ifdef USE_LOGGER_USB_SERIAL_JTAG
-static void init_usb_serial_jtag_() {
+static void init_usb_serial_jtag_(int tx_buffer_size, int rx_buffer_size) {
   setvbuf(stdin, NULL, _IONBF, 0);  // Disable buffering on stdin
 
   // Minicom, screen, idf_monitor send CR when ENTER key is pressed
@@ -46,8 +46,8 @@ static void init_usb_serial_jtag_() {
   fcntl(fileno(stdin), F_SETFL, 0);
 
   usb_serial_jtag_driver_config_t usb_serial_jtag_config{};
-  usb_serial_jtag_config.rx_buffer_size = 512;
-  usb_serial_jtag_config.tx_buffer_size = 512;
+  usb_serial_jtag_config.tx_buffer_size = tx_buffer_size;
+  usb_serial_jtag_config.rx_buffer_size = rx_buffer_size;
 
   esp_err_t ret = ESP_OK;
   // Install USB-SERIAL-JTAG driver for interrupt-driven reads and writes
@@ -138,7 +138,7 @@ void Logger::pre_setup() {
 #endif
 #ifdef USE_LOGGER_USB_SERIAL_JTAG
       case UART_SELECTION_USB_SERIAL_JTAG:
-        init_usb_serial_jtag_();
+        init_usb_serial_jtag_(this->tx_buffer_size_, this->rx_buffer_size_);
         break;
 #endif
     }

--- a/tests/dummy_main.cpp
+++ b/tests/dummy_main.cpp
@@ -13,7 +13,7 @@ using namespace esphome;
 
 void setup() {
   App.pre_setup("livingroom", "LivingRoom", "LivingRoomArea", "comment", __DATE__ ", " __TIME__, false);
-  auto *log = new logger::Logger(115200, 512);  // NOLINT
+  auto *log = new logger::Logger(115200, 512, 512);  // NOLINT
   log->pre_setup();
   log->set_uart_selection(logger::UART_SELECTION_UART0);
   App.register_component(log);


### PR DESCRIPTION
It introduces new logger parameter `rx_buffer_size`, used when USB_SERIAL_JTAG hardware uart is selected. It is useful when data is read from USB_SERIAL_JTAG device as data may be lost if buffer size is too small.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#4201

## Test Environment

- [ ] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
logger:
  hardware_uart: USB_SERIAL_JTAG
  rx_buffer_size: 16k
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
