### PR TITLE
[platformio] Add environments for ESP-IDF 5.3 for development

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -337,6 +337,18 @@ build_flags =
     ${flags:runtime.build_flags}
     -DUSE_ESP32_VARIANT_ESP32S3
 
+[env:esp32s3-idf-5_3]
+extends = common:esp32-idf
+platform = platformio/espressif32@6.8.0
+platform_packages =
+    platformio/framework-espidf@~3.50300.0
+board = esp32-s3-devkitc-1
+board_build.esp-idf.sdkconfig_path = .temp/sdkconfig-esp32s3-idf
+build_flags =
+    ${common:esp32-idf.build_flags}
+    ${flags:runtime.build_flags}
+    -DUSE_ESP32_VARIANT_ESP32S3
+
 [env:esp32s3-idf-tidy]
 extends = common:esp32-idf
 board = esp32-s3-devkitc-1

--- a/platformio.ini
+++ b/platformio.ini
@@ -153,6 +153,13 @@ build_flags =
     -DUSE_ESP32_FRAMEWORK_ESP_IDF
 extra_scripts = post:esphome/components/esp32/post_build.py.script
 
+; This are common settings for the ESP32 using the latest ESP-IDF version.
+[common:esp32-idf-5_3]
+extends = common:esp32-idf
+platform = platformio/espressif32@6.8.0
+platform_packages =
+    platformio/framework-espidf@~3.50300.0
+
 ; These are common settings for the RP2040 using Arduino.
 [common:rp2040-arduino]
 extends = common:arduino
@@ -229,6 +236,15 @@ build_flags =
     ${flags:runtime.build_flags}
     -DUSE_ESP32_VARIANT_ESP32
 
+[env:esp32-idf-5_3]
+extends = common:esp32-idf-5_3
+board = esp32dev
+board_build.esp-idf.sdkconfig_path = .temp/sdkconfig-esp32-idf
+build_flags =
+    ${common:esp32-idf.build_flags}
+    ${flags:runtime.build_flags}
+    -DUSE_ESP32_VARIANT_ESP32
+
 [env:esp32-idf-tidy]
 extends = common:esp32-idf
 board = esp32dev
@@ -265,6 +281,15 @@ build_flags =
     ${flags:runtime.build_flags}
     -DUSE_ESP32_VARIANT_ESP32C3
 
+[env:esp32c3-idf-5_3]
+extends = common:esp32-idf-5_3
+board = esp32-c3-devkitm-1
+board_build.esp-idf.sdkconfig_path = .temp/sdkconfig-esp32c3-idf
+build_flags =
+    ${common:esp32-idf.build_flags}
+    ${flags:runtime.build_flags}
+    -DUSE_ESP32_VARIANT_ESP32C3
+
 [env:esp32c3-idf-tidy]
 extends = common:esp32-idf
 board = esp32-c3-devkitm-1
@@ -294,6 +319,15 @@ build_flags =
 
 [env:esp32s2-idf]
 extends = common:esp32-idf
+board = esp32-s2-kaluga-1
+board_build.esp-idf.sdkconfig_path = .temp/sdkconfig-esp32s2-idf
+build_flags =
+    ${common:esp32-idf.build_flags}
+    ${flags:runtime.build_flags}
+    -DUSE_ESP32_VARIANT_ESP32S2
+
+[env:esp32s2-idf-5_3]
+extends = common:esp32-idf-5_3
 board = esp32-s2-kaluga-1
 board_build.esp-idf.sdkconfig_path = .temp/sdkconfig-esp32s2-idf
 build_flags =
@@ -338,9 +372,7 @@ build_flags =
     -DUSE_ESP32_VARIANT_ESP32S3
 
 [env:esp32s3-idf-5_3]
-extends = common:esp32-idf
-platform = platformio/espressif32@6.8.0
-platform_packages =
+extends = common:esp32-idf-5_3
     platformio/framework-espidf@~3.50300.0
 board = esp32-s3-devkitc-1
 board_build.esp-idf.sdkconfig_path = .temp/sdkconfig-esp32s3-idf

--- a/platformio.ini
+++ b/platformio.ini
@@ -373,7 +373,6 @@ build_flags =
 
 [env:esp32s3-idf-5_3]
 extends = common:esp32-idf-5_3
-    platformio/framework-espidf@~3.50300.0
 board = esp32-s3-devkitc-1
 board_build.esp-idf.sdkconfig_path = .temp/sdkconfig-esp32s3-idf
 build_flags =


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

To facilitate transitioning towards ESP-IDF 5.3, this adds environments in the `platformio.ini` to load the latest platformio package for ESP-IDF, allowing testing with ESP-IDF 5.3.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
