### PR TITLE
esp32_can: suppress compiler warning

### DIFF
--- a/esphome/components/esp32_can/esp32_can.cpp
+++ b/esphome/components/esp32_can/esp32_can.cpp
@@ -111,6 +111,7 @@ canbus::Error ESP32Can::send_message(struct canbus::CanFrame *frame) {
       .flags = flags,
       .identifier = frame->can_id,
       .data_length_code = frame->can_data_length_code,
+      .data = {},  // to suppress warning, data is initialized properly below
   };
   if (!frame->remote_transmission_request) {
     memcpy(message.data, frame->data, frame->can_data_length_code);


### PR DESCRIPTION
# What does this implement/fix?

It silents following compilation warning:
```
src/esphome/components/esp32_can/esp32_can.cpp:114:3: warning: missing initializer for member 'twai_message_t::data' [-Wmissing-field-initializers]
```

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes esphome/issues#3386

## Test Environment

- [ ] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
