### PR TITLE
[bytebuffer] Use existing bit_cast operations.

### DIFF
--- a/esphome/core/bytebuffer.cpp
+++ b/esphome/core/bytebuffer.cpp
@@ -1,12 +1,16 @@
 #include "bytebuffer.h"
 #include <cassert>
-#include <cstring>
+#include <bit>
+#include "esphome/core/helpers.h"
+
+#include <list>
+#include <vector>
 
 namespace esphome {
 
 ByteBuffer ByteBuffer::wrap(const uint8_t *ptr, size_t len, Endian endianness) {
   // there is a double copy happening here, could be optimized but at cost of clarity.
-  std::vector<uint8_t> data(ptr, ptr + len);
+  std::vector data(ptr, ptr + len);
   ByteBuffer buffer = {data};
   buffer.endianness_ = endianness;
   return buffer;
@@ -110,18 +114,13 @@ uint32_t ByteBuffer::get_int24() {
 }
 float ByteBuffer::get_float() {
   assert(this->get_remaining() >= sizeof(float));
-  auto ui_value = this->get_uint32();
-  float value;
-  memcpy(&value, &ui_value, sizeof(float));
-  return value;
+  return bit_cast<float>(this->get_uint32());
 }
 double ByteBuffer::get_double() {
   assert(this->get_remaining() >= sizeof(double));
-  auto ui_value = this->get_uint64();
-  double value;
-  memcpy(&value, &ui_value, sizeof(double));
-  return value;
+  return bit_cast<double>(this->get_uint64());
 }
+
 std::vector<uint8_t> ByteBuffer::get_vector(size_t length) {
   assert(this->get_remaining() >= length);
   auto start = this->data_.begin() + this->position_;
@@ -154,16 +153,12 @@ void ByteBuffer::put_uint(uint64_t value, size_t length) {
 void ByteBuffer::put_float(float value) {
   static_assert(sizeof(float) == sizeof(uint32_t), "Float sizes other than 32 bit not supported");
   assert(this->get_remaining() >= sizeof(float));
-  uint32_t ui_value;
-  memcpy(&ui_value, &value, sizeof(float));  // this work-around required to silence compiler warnings
-  this->put_uint32(ui_value);
+  this->put_uint32(bit_cast<uint32_t>(value));
 }
 void ByteBuffer::put_double(double value) {
   static_assert(sizeof(double) == sizeof(uint64_t), "Double sizes other than 64 bit not supported");
   assert(this->get_remaining() >= sizeof(double));
-  uint64_t ui_value;
-  memcpy(&ui_value, &value, sizeof(double));
-  this->put_uint64(ui_value);
+  this->put_uint64(bit_cast<uint64_t>(value));
 }
 void ByteBuffer::put_vector(const std::vector<uint8_t> &value) {
   assert(this->get_remaining() >= value.size());

--- a/esphome/core/bytebuffer.cpp
+++ b/esphome/core/bytebuffer.cpp
@@ -1,6 +1,5 @@
 #include "bytebuffer.h"
 #include <cassert>
-#include <bit>
 #include "esphome/core/helpers.h"
 
 #include <list>

--- a/esphome/core/bytebuffer.cpp
+++ b/esphome/core/bytebuffer.cpp
@@ -9,7 +9,7 @@ namespace esphome {
 
 ByteBuffer ByteBuffer::wrap(const uint8_t *ptr, size_t len, Endian endianness) {
   // there is a double copy happening here, could be optimized but at cost of clarity.
-  std::vector data(ptr, ptr + len);
+  std::vector<uint8_t> data(ptr, ptr + len);
   ByteBuffer buffer = {data};
   buffer.endianness_ = endianness;
   return buffer;


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Turns out there are already standard ways of converting bit representations into equal-sized types.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
