### PR TITLE
Add voice assistant announce

### DIFF
--- a/esphome/components/api/api.proto
+++ b/esphome/components/api/api.proto
@@ -1553,12 +1553,27 @@ message VoiceAssistantTimerEventResponse {
   bool is_active = 6;
 }
 
-message VoiceAssistantAnnounce {
+message VoiceAssistantAnnounceRequest {
   option (id) = 120;
   option (source) = SOURCE_CLIENT;
   option (ifdef) = "USE_VOICE_ASSISTANT";
 
   string media_id = 1;
+  string text = 2;
+}
+
+message VoiceAssistantAnnounceFinished {
+  option (id) = 121;
+  option (source) = SOURCE_SERVER;
+  option (ifdef) = "USE_VOICE_ASSISTANT";
+
+  string media_id = 1;
+}
+
+message VoiceAssistantTextToSpeechFormat {
+  string format = 1;
+  uint32 sample_rate = 2;
+  uint32 num_channels = 3;
 }
 
 // ==================== ALARM CONTROL PANEL ====================

--- a/esphome/components/api/api.proto
+++ b/esphome/components/api/api.proto
@@ -1566,6 +1566,8 @@ message VoiceAssistantAnnounceFinished {
   option (id) = 120;
   option (source) = SOURCE_SERVER;
   option (ifdef) = "USE_VOICE_ASSISTANT";
+
+  bool success = 1;
 }
 
 // ==================== ALARM CONTROL PANEL ====================

--- a/esphome/components/api/api.proto
+++ b/esphome/components/api/api.proto
@@ -1471,6 +1471,13 @@ message VoiceAssistantAudioSettings {
   float volume_multiplier = 3;
 }
 
+enum VoiceAssistantPipelineStage {
+  VOICE_ASSISTANT_PIPELINE_STAGE_WAKE_WORD = 0;
+  VOICE_ASSISTANT_PIPELINE_STAGE_STT = 1;
+  VOICE_ASSISTANT_PIPELINE_STAGE_INTENT = 2;
+  VOICE_ASSISTANT_PIPELINE_STAGE_TTS = 3;
+}
+
 message VoiceAssistantRequest {
   option (id) = 90;
   option (source) = SOURCE_SERVER;
@@ -1481,6 +1488,10 @@ message VoiceAssistantRequest {
   uint32 flags = 3;
   VoiceAssistantAudioSettings audio_settings = 4;
   string wake_word_phrase = 5;
+  VoiceAssistantPipelineStage start_stage = 6;
+  VoiceAssistantPipelineStage end_stage = 7;
+  repeated string wake_word_names = 8;
+  string tts_input = 9;
 }
 
 message VoiceAssistantResponse {
@@ -1551,6 +1562,18 @@ message VoiceAssistantTimerEventResponse {
   uint32 total_seconds = 4;
   uint32 seconds_left = 5;
   bool is_active = 6;
+}
+
+message VoiceAssistantTriggerPipeline {
+  option (id) = 120;
+  option (source) = SOURCE_SERVER;
+  option (ifdef) = "USE_VOICE_ASSISTANT";
+
+  VoiceAssistantPipelineStage start_stage = 1;
+  VoiceAssistantPipelineStage end_stage = 2;
+  string wake_word_phrase = 3;
+  repeated string wake_word_names = 4;
+  string tts_input = 5;
 }
 
 // ==================== ALARM CONTROL PANEL ====================

--- a/esphome/components/api/api.proto
+++ b/esphome/components/api/api.proto
@@ -1471,13 +1471,6 @@ message VoiceAssistantAudioSettings {
   float volume_multiplier = 3;
 }
 
-enum VoiceAssistantPipelineStage {
-  VOICE_ASSISTANT_PIPELINE_STAGE_WAKE_WORD = 0;
-  VOICE_ASSISTANT_PIPELINE_STAGE_STT = 1;
-  VOICE_ASSISTANT_PIPELINE_STAGE_INTENT = 2;
-  VOICE_ASSISTANT_PIPELINE_STAGE_TTS = 3;
-}
-
 message VoiceAssistantRequest {
   option (id) = 90;
   option (source) = SOURCE_SERVER;
@@ -1488,9 +1481,6 @@ message VoiceAssistantRequest {
   uint32 flags = 3;
   VoiceAssistantAudioSettings audio_settings = 4;
   string wake_word_phrase = 5;
-  VoiceAssistantPipelineStage start_stage = 6;
-  VoiceAssistantPipelineStage end_stage = 7;
-  string announce_text = 8;
 }
 
 message VoiceAssistantResponse {
@@ -1563,38 +1553,12 @@ message VoiceAssistantTimerEventResponse {
   bool is_active = 6;
 }
 
-message VoiceAssistantTriggerPipeline {
+message VoiceAssistantAnnounce {
   option (id) = 120;
-  option (source) = SOURCE_SERVER;
-  option (ifdef) = "USE_VOICE_ASSISTANT";
-
-  VoiceAssistantPipelineStage start_stage = 1;
-  VoiceAssistantPipelineStage end_stage = 2;
-  string wake_word_phrase = 3;
-  string announce_text = 4;
-}
-
-message VoiceAssistantSetConfiguration {
-  option (id) = 121;
-  option (source) = SOURCE_SERVER;
-  option (ifdef) = "USE_VOICE_ASSISTANT";
-
-  repeated string active_wake_words = 1;
-}
-
-message VoiceAssistantAvailableWakeWord {
-  string wake_word = 1;
-  bool is_active = 2;
-  repeated string trained_languages = 3;
-}
-
-message VoiceAssistantConfiguration {
-  option (id) = 122;
   option (source) = SOURCE_CLIENT;
   option (ifdef) = "USE_VOICE_ASSISTANT";
 
-  repeated VoiceAssistantAvailableWakeWord available_wake_words = 1;
-  uint32 max_active_wake_words = 2;
+  string media_id = 1;
 }
 
 // ==================== ALARM CONTROL PANEL ====================

--- a/esphome/components/api/api.proto
+++ b/esphome/components/api/api.proto
@@ -1570,12 +1570,6 @@ message VoiceAssistantAnnounceFinished {
   string media_id = 1;
 }
 
-message VoiceAssistantTextToSpeechFormat {
-  string format = 1;
-  uint32 sample_rate = 2;
-  uint32 num_channels = 3;
-}
-
 // ==================== ALARM CONTROL PANEL ====================
 enum AlarmControlPanelState {
   ALARM_STATE_DISARMED = 0;

--- a/esphome/components/api/api.proto
+++ b/esphome/components/api/api.proto
@@ -1554,7 +1554,7 @@ message VoiceAssistantTimerEventResponse {
 }
 
 message VoiceAssistantAnnounceRequest {
-  option (id) = 120;
+  option (id) = 119;
   option (source) = SOURCE_CLIENT;
   option (ifdef) = "USE_VOICE_ASSISTANT";
 
@@ -1563,11 +1563,9 @@ message VoiceAssistantAnnounceRequest {
 }
 
 message VoiceAssistantAnnounceFinished {
-  option (id) = 121;
+  option (id) = 120;
   option (source) = SOURCE_SERVER;
   option (ifdef) = "USE_VOICE_ASSISTANT";
-
-  string media_id = 1;
 }
 
 // ==================== ALARM CONTROL PANEL ====================

--- a/esphome/components/api/api.proto
+++ b/esphome/components/api/api.proto
@@ -1491,7 +1491,7 @@ message VoiceAssistantRequest {
   VoiceAssistantPipelineStage start_stage = 6;
   VoiceAssistantPipelineStage end_stage = 7;
   repeated string wake_word_names = 8;
-  string tts_input = 9;
+  string announce_text = 9;
 }
 
 message VoiceAssistantResponse {
@@ -1573,7 +1573,7 @@ message VoiceAssistantTriggerPipeline {
   VoiceAssistantPipelineStage end_stage = 2;
   string wake_word_phrase = 3;
   repeated string wake_word_names = 4;
-  string tts_input = 5;
+  string announce_text = 5;
 }
 
 // ==================== ALARM CONTROL PANEL ====================

--- a/esphome/components/api/api.proto
+++ b/esphome/components/api/api.proto
@@ -1490,8 +1490,7 @@ message VoiceAssistantRequest {
   string wake_word_phrase = 5;
   VoiceAssistantPipelineStage start_stage = 6;
   VoiceAssistantPipelineStage end_stage = 7;
-  repeated string wake_word_names = 8;
-  string announce_text = 9;
+  string announce_text = 8;
 }
 
 message VoiceAssistantResponse {
@@ -1572,8 +1571,30 @@ message VoiceAssistantTriggerPipeline {
   VoiceAssistantPipelineStage start_stage = 1;
   VoiceAssistantPipelineStage end_stage = 2;
   string wake_word_phrase = 3;
-  repeated string wake_word_names = 4;
-  string announce_text = 5;
+  string announce_text = 4;
+}
+
+message VoiceAssistantSetConfiguration {
+  option (id) = 121;
+  option (source) = SOURCE_SERVER;
+  option (ifdef) = "USE_VOICE_ASSISTANT";
+
+  repeated string active_wake_words = 1;
+}
+
+message VoiceAssistantAvailableWakeWord {
+  string wake_word = 1;
+  bool is_active = 2;
+  repeated string trained_languages = 3;
+}
+
+message VoiceAssistantConfiguration {
+  option (id) = 122;
+  option (source) = SOURCE_CLIENT;
+  option (ifdef) = "USE_VOICE_ASSISTANT";
+
+  repeated VoiceAssistantAvailableWakeWord available_wake_words = 1;
+  uint32 max_active_wake_words = 2;
 }
 
 // ==================== ALARM CONTROL PANEL ====================

--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -1213,7 +1213,7 @@ void APIConnection::on_voice_assistant_timer_event_response(const VoiceAssistant
   }
 };
 
-void APIConnection::on_voice_assistant_announce(const VoiceAssistantAnnounce &msg) {
+void APIConnection::on_voice_assistant_announce_request(const VoiceAssistantAnnounceRequest &msg) {
   if (voice_assistant::global_voice_assistant != nullptr) {
     if (voice_assistant::global_voice_assistant->get_api_connection() != this) {
       return;

--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -1213,6 +1213,16 @@ void APIConnection::on_voice_assistant_timer_event_response(const VoiceAssistant
   }
 };
 
+void APIConnection::on_voice_assistant_announce(const VoiceAssistantAnnounce &msg) {
+  if (voice_assistant::global_voice_assistant != nullptr) {
+    if (voice_assistant::global_voice_assistant->get_api_connection() != this) {
+      return;
+    }
+
+    voice_assistant::global_voice_assistant->on_announce(msg);
+  }
+}
+
 #endif
 
 #ifdef USE_ALARM_CONTROL_PANEL

--- a/esphome/components/api/api_connection.h
+++ b/esphome/components/api/api_connection.h
@@ -151,6 +151,7 @@ class APIConnection : public APIServerConnection {
   void on_voice_assistant_event_response(const VoiceAssistantEventResponse &msg) override;
   void on_voice_assistant_audio(const VoiceAssistantAudio &msg) override;
   void on_voice_assistant_timer_event_response(const VoiceAssistantTimerEventResponse &msg) override;
+  void on_voice_assistant_announce(const VoiceAssistantAnnounce &msg) override;
 #endif
 
 #ifdef USE_ALARM_CONTROL_PANEL

--- a/esphome/components/api/api_connection.h
+++ b/esphome/components/api/api_connection.h
@@ -151,7 +151,7 @@ class APIConnection : public APIServerConnection {
   void on_voice_assistant_event_response(const VoiceAssistantEventResponse &msg) override;
   void on_voice_assistant_audio(const VoiceAssistantAudio &msg) override;
   void on_voice_assistant_timer_event_response(const VoiceAssistantTimerEventResponse &msg) override;
-  void on_voice_assistant_announce(const VoiceAssistantAnnounce &msg) override;
+  void on_voice_assistant_announce_request(const VoiceAssistantAnnounceRequest &msg) override;
 #endif
 
 #ifdef USE_ALARM_CONTROL_PANEL

--- a/esphome/components/api/api_pb2.cpp
+++ b/esphome/components/api/api_pb2.cpp
@@ -6828,10 +6828,6 @@ bool VoiceAssistantRequest::decode_length(uint32_t field_id, ProtoLengthDelimite
       return true;
     }
     case 8: {
-      this->wake_word_names.push_back(value.as_string());
-      return true;
-    }
-    case 9: {
       this->announce_text = value.as_string();
       return true;
     }
@@ -6847,10 +6843,7 @@ void VoiceAssistantRequest::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_string(5, this->wake_word_phrase);
   buffer.encode_enum<enums::VoiceAssistantPipelineStage>(6, this->start_stage);
   buffer.encode_enum<enums::VoiceAssistantPipelineStage>(7, this->end_stage);
-  for (auto &it : this->wake_word_names) {
-    buffer.encode_string(8, it, true);
-  }
-  buffer.encode_string(9, this->announce_text);
+  buffer.encode_string(8, this->announce_text);
 }
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void VoiceAssistantRequest::dump_to(std::string &out) const {
@@ -6884,12 +6877,6 @@ void VoiceAssistantRequest::dump_to(std::string &out) const {
   out.append("  end_stage: ");
   out.append(proto_enum_to_string<enums::VoiceAssistantPipelineStage>(this->end_stage));
   out.append("\n");
-
-  for (const auto &it : this->wake_word_names) {
-    out.append("  wake_word_names: ");
-    out.append("'").append(it).append("'");
-    out.append("\n");
-  }
 
   out.append("  announce_text: ");
   out.append("'").append(this->announce_text).append("'");
@@ -7139,10 +7126,6 @@ bool VoiceAssistantTriggerPipeline::decode_length(uint32_t field_id, ProtoLength
       return true;
     }
     case 4: {
-      this->wake_word_names.push_back(value.as_string());
-      return true;
-    }
-    case 5: {
       this->announce_text = value.as_string();
       return true;
     }
@@ -7154,10 +7137,7 @@ void VoiceAssistantTriggerPipeline::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_enum<enums::VoiceAssistantPipelineStage>(1, this->start_stage);
   buffer.encode_enum<enums::VoiceAssistantPipelineStage>(2, this->end_stage);
   buffer.encode_string(3, this->wake_word_phrase);
-  for (auto &it : this->wake_word_names) {
-    buffer.encode_string(4, it, true);
-  }
-  buffer.encode_string(5, this->announce_text);
+  buffer.encode_string(4, this->announce_text);
 }
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void VoiceAssistantTriggerPipeline::dump_to(std::string &out) const {
@@ -7175,14 +7155,129 @@ void VoiceAssistantTriggerPipeline::dump_to(std::string &out) const {
   out.append("'").append(this->wake_word_phrase).append("'");
   out.append("\n");
 
-  for (const auto &it : this->wake_word_names) {
-    out.append("  wake_word_names: ");
+  out.append("  announce_text: ");
+  out.append("'").append(this->announce_text).append("'");
+  out.append("\n");
+  out.append("}");
+}
+#endif
+bool VoiceAssistantSetConfiguration::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
+  switch (field_id) {
+    case 1: {
+      this->active_wake_words.push_back(value.as_string());
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void VoiceAssistantSetConfiguration::encode(ProtoWriteBuffer buffer) const {
+  for (auto &it : this->active_wake_words) {
+    buffer.encode_string(1, it, true);
+  }
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void VoiceAssistantSetConfiguration::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("VoiceAssistantSetConfiguration {\n");
+  for (const auto &it : this->active_wake_words) {
+    out.append("  active_wake_words: ");
     out.append("'").append(it).append("'");
     out.append("\n");
   }
+  out.append("}");
+}
+#endif
+bool VoiceAssistantAvailableWakeWord::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 2: {
+      this->is_active = value.as_bool();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool VoiceAssistantAvailableWakeWord::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
+  switch (field_id) {
+    case 1: {
+      this->wake_word = value.as_string();
+      return true;
+    }
+    case 3: {
+      this->trained_languages.push_back(value.as_string());
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void VoiceAssistantAvailableWakeWord::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_string(1, this->wake_word);
+  buffer.encode_bool(2, this->is_active);
+  for (auto &it : this->trained_languages) {
+    buffer.encode_string(3, it, true);
+  }
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void VoiceAssistantAvailableWakeWord::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("VoiceAssistantAvailableWakeWord {\n");
+  out.append("  wake_word: ");
+  out.append("'").append(this->wake_word).append("'");
+  out.append("\n");
 
-  out.append("  announce_text: ");
-  out.append("'").append(this->announce_text).append("'");
+  out.append("  is_active: ");
+  out.append(YESNO(this->is_active));
+  out.append("\n");
+
+  for (const auto &it : this->trained_languages) {
+    out.append("  trained_languages: ");
+    out.append("'").append(it).append("'");
+    out.append("\n");
+  }
+  out.append("}");
+}
+#endif
+bool VoiceAssistantConfiguration::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 2: {
+      this->max_active_wake_words = value.as_uint32();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool VoiceAssistantConfiguration::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
+  switch (field_id) {
+    case 1: {
+      this->available_wake_words.push_back(value.as_message<VoiceAssistantAvailableWakeWord>());
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void VoiceAssistantConfiguration::encode(ProtoWriteBuffer buffer) const {
+  for (auto &it : this->available_wake_words) {
+    buffer.encode_message<VoiceAssistantAvailableWakeWord>(1, it, true);
+  }
+  buffer.encode_uint32(2, this->max_active_wake_words);
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void VoiceAssistantConfiguration::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("VoiceAssistantConfiguration {\n");
+  for (const auto &it : this->available_wake_words) {
+    out.append("  available_wake_words: ");
+    it.dump_to(out);
+    out.append("\n");
+  }
+
+  out.append("  max_active_wake_words: ");
+  sprintf(buffer, "%" PRIu32, this->max_active_wake_words);
+  out.append(buffer);
   out.append("\n");
   out.append("}");
 }

--- a/esphome/components/api/api_pb2.cpp
+++ b/esphome/components/api/api_pb2.cpp
@@ -7061,7 +7061,39 @@ void VoiceAssistantTimerEventResponse::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
-bool VoiceAssistantAnnounce::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
+bool VoiceAssistantAnnounceRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
+  switch (field_id) {
+    case 1: {
+      this->media_id = value.as_string();
+      return true;
+    }
+    case 2: {
+      this->text = value.as_string();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void VoiceAssistantAnnounceRequest::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_string(1, this->media_id);
+  buffer.encode_string(2, this->text);
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void VoiceAssistantAnnounceRequest::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("VoiceAssistantAnnounceRequest {\n");
+  out.append("  media_id: ");
+  out.append("'").append(this->media_id).append("'");
+  out.append("\n");
+
+  out.append("  text: ");
+  out.append("'").append(this->text).append("'");
+  out.append("\n");
+  out.append("}");
+}
+#endif
+bool VoiceAssistantAnnounceFinished::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 1: {
       this->media_id = value.as_string();
@@ -7071,13 +7103,62 @@ bool VoiceAssistantAnnounce::decode_length(uint32_t field_id, ProtoLengthDelimit
       return false;
   }
 }
-void VoiceAssistantAnnounce::encode(ProtoWriteBuffer buffer) const { buffer.encode_string(1, this->media_id); }
+void VoiceAssistantAnnounceFinished::encode(ProtoWriteBuffer buffer) const { buffer.encode_string(1, this->media_id); }
 #ifdef HAS_PROTO_MESSAGE_DUMP
-void VoiceAssistantAnnounce::dump_to(std::string &out) const {
+void VoiceAssistantAnnounceFinished::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
-  out.append("VoiceAssistantAnnounce {\n");
+  out.append("VoiceAssistantAnnounceFinished {\n");
   out.append("  media_id: ");
   out.append("'").append(this->media_id).append("'");
+  out.append("\n");
+  out.append("}");
+}
+#endif
+bool VoiceAssistantTextToSpeechFormat::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 2: {
+      this->sample_rate = value.as_uint32();
+      return true;
+    }
+    case 3: {
+      this->num_channels = value.as_uint32();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool VoiceAssistantTextToSpeechFormat::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
+  switch (field_id) {
+    case 1: {
+      this->format = value.as_string();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void VoiceAssistantTextToSpeechFormat::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_string(1, this->format);
+  buffer.encode_uint32(2, this->sample_rate);
+  buffer.encode_uint32(3, this->num_channels);
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void VoiceAssistantTextToSpeechFormat::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("VoiceAssistantTextToSpeechFormat {\n");
+  out.append("  format: ");
+  out.append("'").append(this->format).append("'");
+  out.append("\n");
+
+  out.append("  sample_rate: ");
+  sprintf(buffer, "%" PRIu32, this->sample_rate);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  num_channels: ");
+  sprintf(buffer, "%" PRIu32, this->num_channels);
+  out.append(buffer);
   out.append("\n");
   out.append("}");
 }

--- a/esphome/components/api/api_pb2.cpp
+++ b/esphome/components/api/api_pb2.cpp
@@ -449,23 +449,6 @@ template<> const char *proto_enum_to_string<enums::VoiceAssistantRequestFlag>(en
 }
 #endif
 #ifdef HAS_PROTO_MESSAGE_DUMP
-template<>
-const char *proto_enum_to_string<enums::VoiceAssistantPipelineStage>(enums::VoiceAssistantPipelineStage value) {
-  switch (value) {
-    case enums::VOICE_ASSISTANT_PIPELINE_STAGE_WAKE_WORD:
-      return "VOICE_ASSISTANT_PIPELINE_STAGE_WAKE_WORD";
-    case enums::VOICE_ASSISTANT_PIPELINE_STAGE_STT:
-      return "VOICE_ASSISTANT_PIPELINE_STAGE_STT";
-    case enums::VOICE_ASSISTANT_PIPELINE_STAGE_INTENT:
-      return "VOICE_ASSISTANT_PIPELINE_STAGE_INTENT";
-    case enums::VOICE_ASSISTANT_PIPELINE_STAGE_TTS:
-      return "VOICE_ASSISTANT_PIPELINE_STAGE_TTS";
-    default:
-      return "UNKNOWN";
-  }
-}
-#endif
-#ifdef HAS_PROTO_MESSAGE_DUMP
 template<> const char *proto_enum_to_string<enums::VoiceAssistantEvent>(enums::VoiceAssistantEvent value) {
   switch (value) {
     case enums::VOICE_ASSISTANT_ERROR:
@@ -6801,14 +6784,6 @@ bool VoiceAssistantRequest::decode_varint(uint32_t field_id, ProtoVarInt value) 
       this->flags = value.as_uint32();
       return true;
     }
-    case 6: {
-      this->start_stage = value.as_enum<enums::VoiceAssistantPipelineStage>();
-      return true;
-    }
-    case 7: {
-      this->end_stage = value.as_enum<enums::VoiceAssistantPipelineStage>();
-      return true;
-    }
     default:
       return false;
   }
@@ -6827,10 +6802,6 @@ bool VoiceAssistantRequest::decode_length(uint32_t field_id, ProtoLengthDelimite
       this->wake_word_phrase = value.as_string();
       return true;
     }
-    case 8: {
-      this->announce_text = value.as_string();
-      return true;
-    }
     default:
       return false;
   }
@@ -6841,9 +6812,6 @@ void VoiceAssistantRequest::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint32(3, this->flags);
   buffer.encode_message<VoiceAssistantAudioSettings>(4, this->audio_settings);
   buffer.encode_string(5, this->wake_word_phrase);
-  buffer.encode_enum<enums::VoiceAssistantPipelineStage>(6, this->start_stage);
-  buffer.encode_enum<enums::VoiceAssistantPipelineStage>(7, this->end_stage);
-  buffer.encode_string(8, this->announce_text);
 }
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void VoiceAssistantRequest::dump_to(std::string &out) const {
@@ -6868,18 +6836,6 @@ void VoiceAssistantRequest::dump_to(std::string &out) const {
 
   out.append("  wake_word_phrase: ");
   out.append("'").append(this->wake_word_phrase).append("'");
-  out.append("\n");
-
-  out.append("  start_stage: ");
-  out.append(proto_enum_to_string<enums::VoiceAssistantPipelineStage>(this->start_stage));
-  out.append("\n");
-
-  out.append("  end_stage: ");
-  out.append(proto_enum_to_string<enums::VoiceAssistantPipelineStage>(this->end_stage));
-  out.append("\n");
-
-  out.append("  announce_text: ");
-  out.append("'").append(this->announce_text).append("'");
   out.append("\n");
   out.append("}");
 }
@@ -7105,179 +7061,23 @@ void VoiceAssistantTimerEventResponse::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
-bool VoiceAssistantTriggerPipeline::decode_varint(uint32_t field_id, ProtoVarInt value) {
+bool VoiceAssistantAnnounce::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 1: {
-      this->start_stage = value.as_enum<enums::VoiceAssistantPipelineStage>();
-      return true;
-    }
-    case 2: {
-      this->end_stage = value.as_enum<enums::VoiceAssistantPipelineStage>();
+      this->media_id = value.as_string();
       return true;
     }
     default:
       return false;
   }
 }
-bool VoiceAssistantTriggerPipeline::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
-  switch (field_id) {
-    case 3: {
-      this->wake_word_phrase = value.as_string();
-      return true;
-    }
-    case 4: {
-      this->announce_text = value.as_string();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
-void VoiceAssistantTriggerPipeline::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_enum<enums::VoiceAssistantPipelineStage>(1, this->start_stage);
-  buffer.encode_enum<enums::VoiceAssistantPipelineStage>(2, this->end_stage);
-  buffer.encode_string(3, this->wake_word_phrase);
-  buffer.encode_string(4, this->announce_text);
-}
+void VoiceAssistantAnnounce::encode(ProtoWriteBuffer buffer) const { buffer.encode_string(1, this->media_id); }
 #ifdef HAS_PROTO_MESSAGE_DUMP
-void VoiceAssistantTriggerPipeline::dump_to(std::string &out) const {
+void VoiceAssistantAnnounce::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
-  out.append("VoiceAssistantTriggerPipeline {\n");
-  out.append("  start_stage: ");
-  out.append(proto_enum_to_string<enums::VoiceAssistantPipelineStage>(this->start_stage));
-  out.append("\n");
-
-  out.append("  end_stage: ");
-  out.append(proto_enum_to_string<enums::VoiceAssistantPipelineStage>(this->end_stage));
-  out.append("\n");
-
-  out.append("  wake_word_phrase: ");
-  out.append("'").append(this->wake_word_phrase).append("'");
-  out.append("\n");
-
-  out.append("  announce_text: ");
-  out.append("'").append(this->announce_text).append("'");
-  out.append("\n");
-  out.append("}");
-}
-#endif
-bool VoiceAssistantSetConfiguration::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
-  switch (field_id) {
-    case 1: {
-      this->active_wake_words.push_back(value.as_string());
-      return true;
-    }
-    default:
-      return false;
-  }
-}
-void VoiceAssistantSetConfiguration::encode(ProtoWriteBuffer buffer) const {
-  for (auto &it : this->active_wake_words) {
-    buffer.encode_string(1, it, true);
-  }
-}
-#ifdef HAS_PROTO_MESSAGE_DUMP
-void VoiceAssistantSetConfiguration::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
-  out.append("VoiceAssistantSetConfiguration {\n");
-  for (const auto &it : this->active_wake_words) {
-    out.append("  active_wake_words: ");
-    out.append("'").append(it).append("'");
-    out.append("\n");
-  }
-  out.append("}");
-}
-#endif
-bool VoiceAssistantAvailableWakeWord::decode_varint(uint32_t field_id, ProtoVarInt value) {
-  switch (field_id) {
-    case 2: {
-      this->is_active = value.as_bool();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
-bool VoiceAssistantAvailableWakeWord::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
-  switch (field_id) {
-    case 1: {
-      this->wake_word = value.as_string();
-      return true;
-    }
-    case 3: {
-      this->trained_languages.push_back(value.as_string());
-      return true;
-    }
-    default:
-      return false;
-  }
-}
-void VoiceAssistantAvailableWakeWord::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_string(1, this->wake_word);
-  buffer.encode_bool(2, this->is_active);
-  for (auto &it : this->trained_languages) {
-    buffer.encode_string(3, it, true);
-  }
-}
-#ifdef HAS_PROTO_MESSAGE_DUMP
-void VoiceAssistantAvailableWakeWord::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
-  out.append("VoiceAssistantAvailableWakeWord {\n");
-  out.append("  wake_word: ");
-  out.append("'").append(this->wake_word).append("'");
-  out.append("\n");
-
-  out.append("  is_active: ");
-  out.append(YESNO(this->is_active));
-  out.append("\n");
-
-  for (const auto &it : this->trained_languages) {
-    out.append("  trained_languages: ");
-    out.append("'").append(it).append("'");
-    out.append("\n");
-  }
-  out.append("}");
-}
-#endif
-bool VoiceAssistantConfiguration::decode_varint(uint32_t field_id, ProtoVarInt value) {
-  switch (field_id) {
-    case 2: {
-      this->max_active_wake_words = value.as_uint32();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
-bool VoiceAssistantConfiguration::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
-  switch (field_id) {
-    case 1: {
-      this->available_wake_words.push_back(value.as_message<VoiceAssistantAvailableWakeWord>());
-      return true;
-    }
-    default:
-      return false;
-  }
-}
-void VoiceAssistantConfiguration::encode(ProtoWriteBuffer buffer) const {
-  for (auto &it : this->available_wake_words) {
-    buffer.encode_message<VoiceAssistantAvailableWakeWord>(1, it, true);
-  }
-  buffer.encode_uint32(2, this->max_active_wake_words);
-}
-#ifdef HAS_PROTO_MESSAGE_DUMP
-void VoiceAssistantConfiguration::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
-  out.append("VoiceAssistantConfiguration {\n");
-  for (const auto &it : this->available_wake_words) {
-    out.append("  available_wake_words: ");
-    it.dump_to(out);
-    out.append("\n");
-  }
-
-  out.append("  max_active_wake_words: ");
-  sprintf(buffer, "%" PRIu32, this->max_active_wake_words);
-  out.append(buffer);
+  out.append("VoiceAssistantAnnounce {\n");
+  out.append("  media_id: ");
+  out.append("'").append(this->media_id).append("'");
   out.append("\n");
   out.append("}");
 }

--- a/esphome/components/api/api_pb2.cpp
+++ b/esphome/components/api/api_pb2.cpp
@@ -7093,74 +7093,10 @@ void VoiceAssistantAnnounceRequest::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
-bool VoiceAssistantAnnounceFinished::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
-  switch (field_id) {
-    case 1: {
-      this->media_id = value.as_string();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
-void VoiceAssistantAnnounceFinished::encode(ProtoWriteBuffer buffer) const { buffer.encode_string(1, this->media_id); }
+void VoiceAssistantAnnounceFinished::encode(ProtoWriteBuffer buffer) const {}
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void VoiceAssistantAnnounceFinished::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
-  out.append("VoiceAssistantAnnounceFinished {\n");
-  out.append("  media_id: ");
-  out.append("'").append(this->media_id).append("'");
-  out.append("\n");
-  out.append("}");
-}
-#endif
-bool VoiceAssistantTextToSpeechFormat::decode_varint(uint32_t field_id, ProtoVarInt value) {
-  switch (field_id) {
-    case 2: {
-      this->sample_rate = value.as_uint32();
-      return true;
-    }
-    case 3: {
-      this->num_channels = value.as_uint32();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
-bool VoiceAssistantTextToSpeechFormat::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
-  switch (field_id) {
-    case 1: {
-      this->format = value.as_string();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
-void VoiceAssistantTextToSpeechFormat::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_string(1, this->format);
-  buffer.encode_uint32(2, this->sample_rate);
-  buffer.encode_uint32(3, this->num_channels);
-}
-#ifdef HAS_PROTO_MESSAGE_DUMP
-void VoiceAssistantTextToSpeechFormat::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
-  out.append("VoiceAssistantTextToSpeechFormat {\n");
-  out.append("  format: ");
-  out.append("'").append(this->format).append("'");
-  out.append("\n");
-
-  out.append("  sample_rate: ");
-  sprintf(buffer, "%" PRIu32, this->sample_rate);
-  out.append(buffer);
-  out.append("\n");
-
-  out.append("  num_channels: ");
-  sprintf(buffer, "%" PRIu32, this->num_channels);
-  out.append(buffer);
-  out.append("\n");
-  out.append("}");
+  out.append("VoiceAssistantAnnounceFinished {}");
 }
 #endif
 bool ListEntitiesAlarmControlPanelResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {

--- a/esphome/components/api/api_pb2.cpp
+++ b/esphome/components/api/api_pb2.cpp
@@ -449,6 +449,23 @@ template<> const char *proto_enum_to_string<enums::VoiceAssistantRequestFlag>(en
 }
 #endif
 #ifdef HAS_PROTO_MESSAGE_DUMP
+template<>
+const char *proto_enum_to_string<enums::VoiceAssistantPipelineStage>(enums::VoiceAssistantPipelineStage value) {
+  switch (value) {
+    case enums::VOICE_ASSISTANT_PIPELINE_STAGE_WAKE_WORD:
+      return "VOICE_ASSISTANT_PIPELINE_STAGE_WAKE_WORD";
+    case enums::VOICE_ASSISTANT_PIPELINE_STAGE_STT:
+      return "VOICE_ASSISTANT_PIPELINE_STAGE_STT";
+    case enums::VOICE_ASSISTANT_PIPELINE_STAGE_INTENT:
+      return "VOICE_ASSISTANT_PIPELINE_STAGE_INTENT";
+    case enums::VOICE_ASSISTANT_PIPELINE_STAGE_TTS:
+      return "VOICE_ASSISTANT_PIPELINE_STAGE_TTS";
+    default:
+      return "UNKNOWN";
+  }
+}
+#endif
+#ifdef HAS_PROTO_MESSAGE_DUMP
 template<> const char *proto_enum_to_string<enums::VoiceAssistantEvent>(enums::VoiceAssistantEvent value) {
   switch (value) {
     case enums::VOICE_ASSISTANT_ERROR:
@@ -6784,6 +6801,14 @@ bool VoiceAssistantRequest::decode_varint(uint32_t field_id, ProtoVarInt value) 
       this->flags = value.as_uint32();
       return true;
     }
+    case 6: {
+      this->start_stage = value.as_enum<enums::VoiceAssistantPipelineStage>();
+      return true;
+    }
+    case 7: {
+      this->end_stage = value.as_enum<enums::VoiceAssistantPipelineStage>();
+      return true;
+    }
     default:
       return false;
   }
@@ -6802,6 +6827,14 @@ bool VoiceAssistantRequest::decode_length(uint32_t field_id, ProtoLengthDelimite
       this->wake_word_phrase = value.as_string();
       return true;
     }
+    case 8: {
+      this->wake_word_names.push_back(value.as_string());
+      return true;
+    }
+    case 9: {
+      this->tts_input = value.as_string();
+      return true;
+    }
     default:
       return false;
   }
@@ -6812,6 +6845,12 @@ void VoiceAssistantRequest::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint32(3, this->flags);
   buffer.encode_message<VoiceAssistantAudioSettings>(4, this->audio_settings);
   buffer.encode_string(5, this->wake_word_phrase);
+  buffer.encode_enum<enums::VoiceAssistantPipelineStage>(6, this->start_stage);
+  buffer.encode_enum<enums::VoiceAssistantPipelineStage>(7, this->end_stage);
+  for (auto &it : this->wake_word_names) {
+    buffer.encode_string(8, it, true);
+  }
+  buffer.encode_string(9, this->tts_input);
 }
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void VoiceAssistantRequest::dump_to(std::string &out) const {
@@ -6836,6 +6875,24 @@ void VoiceAssistantRequest::dump_to(std::string &out) const {
 
   out.append("  wake_word_phrase: ");
   out.append("'").append(this->wake_word_phrase).append("'");
+  out.append("\n");
+
+  out.append("  start_stage: ");
+  out.append(proto_enum_to_string<enums::VoiceAssistantPipelineStage>(this->start_stage));
+  out.append("\n");
+
+  out.append("  end_stage: ");
+  out.append(proto_enum_to_string<enums::VoiceAssistantPipelineStage>(this->end_stage));
+  out.append("\n");
+
+  for (const auto &it : this->wake_word_names) {
+    out.append("  wake_word_names: ");
+    out.append("'").append(it).append("'");
+    out.append("\n");
+  }
+
+  out.append("  tts_input: ");
+  out.append("'").append(this->tts_input).append("'");
   out.append("\n");
   out.append("}");
 }
@@ -7057,6 +7114,75 @@ void VoiceAssistantTimerEventResponse::dump_to(std::string &out) const {
 
   out.append("  is_active: ");
   out.append(YESNO(this->is_active));
+  out.append("\n");
+  out.append("}");
+}
+#endif
+bool VoiceAssistantTriggerPipeline::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 1: {
+      this->start_stage = value.as_enum<enums::VoiceAssistantPipelineStage>();
+      return true;
+    }
+    case 2: {
+      this->end_stage = value.as_enum<enums::VoiceAssistantPipelineStage>();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+bool VoiceAssistantTriggerPipeline::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
+  switch (field_id) {
+    case 3: {
+      this->wake_word_phrase = value.as_string();
+      return true;
+    }
+    case 4: {
+      this->wake_word_names.push_back(value.as_string());
+      return true;
+    }
+    case 5: {
+      this->tts_input = value.as_string();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void VoiceAssistantTriggerPipeline::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_enum<enums::VoiceAssistantPipelineStage>(1, this->start_stage);
+  buffer.encode_enum<enums::VoiceAssistantPipelineStage>(2, this->end_stage);
+  buffer.encode_string(3, this->wake_word_phrase);
+  for (auto &it : this->wake_word_names) {
+    buffer.encode_string(4, it, true);
+  }
+  buffer.encode_string(5, this->tts_input);
+}
+#ifdef HAS_PROTO_MESSAGE_DUMP
+void VoiceAssistantTriggerPipeline::dump_to(std::string &out) const {
+  __attribute__((unused)) char buffer[64];
+  out.append("VoiceAssistantTriggerPipeline {\n");
+  out.append("  start_stage: ");
+  out.append(proto_enum_to_string<enums::VoiceAssistantPipelineStage>(this->start_stage));
+  out.append("\n");
+
+  out.append("  end_stage: ");
+  out.append(proto_enum_to_string<enums::VoiceAssistantPipelineStage>(this->end_stage));
+  out.append("\n");
+
+  out.append("  wake_word_phrase: ");
+  out.append("'").append(this->wake_word_phrase).append("'");
+  out.append("\n");
+
+  for (const auto &it : this->wake_word_names) {
+    out.append("  wake_word_names: ");
+    out.append("'").append(it).append("'");
+    out.append("\n");
+  }
+
+  out.append("  tts_input: ");
+  out.append("'").append(this->tts_input).append("'");
   out.append("\n");
   out.append("}");
 }

--- a/esphome/components/api/api_pb2.cpp
+++ b/esphome/components/api/api_pb2.cpp
@@ -6832,7 +6832,7 @@ bool VoiceAssistantRequest::decode_length(uint32_t field_id, ProtoLengthDelimite
       return true;
     }
     case 9: {
-      this->tts_input = value.as_string();
+      this->announce_text = value.as_string();
       return true;
     }
     default:
@@ -6850,7 +6850,7 @@ void VoiceAssistantRequest::encode(ProtoWriteBuffer buffer) const {
   for (auto &it : this->wake_word_names) {
     buffer.encode_string(8, it, true);
   }
-  buffer.encode_string(9, this->tts_input);
+  buffer.encode_string(9, this->announce_text);
 }
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void VoiceAssistantRequest::dump_to(std::string &out) const {
@@ -6891,8 +6891,8 @@ void VoiceAssistantRequest::dump_to(std::string &out) const {
     out.append("\n");
   }
 
-  out.append("  tts_input: ");
-  out.append("'").append(this->tts_input).append("'");
+  out.append("  announce_text: ");
+  out.append("'").append(this->announce_text).append("'");
   out.append("\n");
   out.append("}");
 }
@@ -7143,7 +7143,7 @@ bool VoiceAssistantTriggerPipeline::decode_length(uint32_t field_id, ProtoLength
       return true;
     }
     case 5: {
-      this->tts_input = value.as_string();
+      this->announce_text = value.as_string();
       return true;
     }
     default:
@@ -7157,7 +7157,7 @@ void VoiceAssistantTriggerPipeline::encode(ProtoWriteBuffer buffer) const {
   for (auto &it : this->wake_word_names) {
     buffer.encode_string(4, it, true);
   }
-  buffer.encode_string(5, this->tts_input);
+  buffer.encode_string(5, this->announce_text);
 }
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void VoiceAssistantTriggerPipeline::dump_to(std::string &out) const {
@@ -7181,8 +7181,8 @@ void VoiceAssistantTriggerPipeline::dump_to(std::string &out) const {
     out.append("\n");
   }
 
-  out.append("  tts_input: ");
-  out.append("'").append(this->tts_input).append("'");
+  out.append("  announce_text: ");
+  out.append("'").append(this->announce_text).append("'");
   out.append("\n");
   out.append("}");
 }

--- a/esphome/components/api/api_pb2.cpp
+++ b/esphome/components/api/api_pb2.cpp
@@ -7093,10 +7093,25 @@ void VoiceAssistantAnnounceRequest::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
-void VoiceAssistantAnnounceFinished::encode(ProtoWriteBuffer buffer) const {}
+bool VoiceAssistantAnnounceFinished::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 1: {
+      this->success = value.as_bool();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
+void VoiceAssistantAnnounceFinished::encode(ProtoWriteBuffer buffer) const { buffer.encode_bool(1, this->success); }
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void VoiceAssistantAnnounceFinished::dump_to(std::string &out) const {
-  out.append("VoiceAssistantAnnounceFinished {}");
+  __attribute__((unused)) char buffer[64];
+  out.append("VoiceAssistantAnnounceFinished {\n");
+  out.append("  success: ");
+  out.append(YESNO(this->success));
+  out.append("\n");
+  out.append("}");
 }
 #endif
 bool ListEntitiesAlarmControlPanelResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {

--- a/esphome/components/api/api_pb2.h
+++ b/esphome/components/api/api_pb2.h
@@ -1839,12 +1839,14 @@ class VoiceAssistantAnnounceRequest : public ProtoMessage {
 };
 class VoiceAssistantAnnounceFinished : public ProtoMessage {
  public:
+  bool success{false};
   void encode(ProtoWriteBuffer buffer) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
 #endif
 
  protected:
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
 class ListEntitiesAlarmControlPanelResponse : public ProtoMessage {
  public:

--- a/esphome/components/api/api_pb2.h
+++ b/esphome/components/api/api_pb2.h
@@ -1758,7 +1758,7 @@ class VoiceAssistantRequest : public ProtoMessage {
   enums::VoiceAssistantPipelineStage start_stage{};
   enums::VoiceAssistantPipelineStage end_stage{};
   std::vector<std::string> wake_word_names{};
-  std::string tts_input{};
+  std::string announce_text{};
   void encode(ProtoWriteBuffer buffer) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
@@ -1841,7 +1841,7 @@ class VoiceAssistantTriggerPipeline : public ProtoMessage {
   enums::VoiceAssistantPipelineStage end_stage{};
   std::string wake_word_phrase{};
   std::vector<std::string> wake_word_names{};
-  std::string tts_input{};
+  std::string announce_text{};
   void encode(ProtoWriteBuffer buffer) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;

--- a/esphome/components/api/api_pb2.h
+++ b/esphome/components/api/api_pb2.h
@@ -1825,7 +1825,19 @@ class VoiceAssistantTimerEventResponse : public ProtoMessage {
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
-class VoiceAssistantAnnounce : public ProtoMessage {
+class VoiceAssistantAnnounceRequest : public ProtoMessage {
+ public:
+  std::string media_id{};
+  std::string text{};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
+};
+class VoiceAssistantAnnounceFinished : public ProtoMessage {
  public:
   std::string media_id{};
   void encode(ProtoWriteBuffer buffer) const override;
@@ -1835,6 +1847,20 @@ class VoiceAssistantAnnounce : public ProtoMessage {
 
  protected:
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
+};
+class VoiceAssistantTextToSpeechFormat : public ProtoMessage {
+ public:
+  std::string format{};
+  uint32_t sample_rate{0};
+  uint32_t num_channels{0};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
 class ListEntitiesAlarmControlPanelResponse : public ProtoMessage {
  public:

--- a/esphome/components/api/api_pb2.h
+++ b/esphome/components/api/api_pb2.h
@@ -178,12 +178,6 @@ enum VoiceAssistantRequestFlag : uint32_t {
   VOICE_ASSISTANT_REQUEST_USE_VAD = 1,
   VOICE_ASSISTANT_REQUEST_USE_WAKE_WORD = 2,
 };
-enum VoiceAssistantPipelineStage : uint32_t {
-  VOICE_ASSISTANT_PIPELINE_STAGE_WAKE_WORD = 0,
-  VOICE_ASSISTANT_PIPELINE_STAGE_STT = 1,
-  VOICE_ASSISTANT_PIPELINE_STAGE_INTENT = 2,
-  VOICE_ASSISTANT_PIPELINE_STAGE_TTS = 3,
-};
 enum VoiceAssistantEvent : uint32_t {
   VOICE_ASSISTANT_ERROR = 0,
   VOICE_ASSISTANT_RUN_START = 1,
@@ -1755,9 +1749,6 @@ class VoiceAssistantRequest : public ProtoMessage {
   uint32_t flags{0};
   VoiceAssistantAudioSettings audio_settings{};
   std::string wake_word_phrase{};
-  enums::VoiceAssistantPipelineStage start_stage{};
-  enums::VoiceAssistantPipelineStage end_stage{};
-  std::string announce_text{};
   void encode(ProtoWriteBuffer buffer) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
@@ -1834,12 +1825,9 @@ class VoiceAssistantTimerEventResponse : public ProtoMessage {
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
-class VoiceAssistantTriggerPipeline : public ProtoMessage {
+class VoiceAssistantAnnounce : public ProtoMessage {
  public:
-  enums::VoiceAssistantPipelineStage start_stage{};
-  enums::VoiceAssistantPipelineStage end_stage{};
-  std::string wake_word_phrase{};
-  std::string announce_text{};
+  std::string media_id{};
   void encode(ProtoWriteBuffer buffer) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
@@ -1847,45 +1835,6 @@ class VoiceAssistantTriggerPipeline : public ProtoMessage {
 
  protected:
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
-};
-class VoiceAssistantSetConfiguration : public ProtoMessage {
- public:
-  std::vector<std::string> active_wake_words{};
-  void encode(ProtoWriteBuffer buffer) const override;
-#ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
-#endif
-
- protected:
-  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-};
-class VoiceAssistantAvailableWakeWord : public ProtoMessage {
- public:
-  std::string wake_word{};
-  bool is_active{false};
-  std::vector<std::string> trained_languages{};
-  void encode(ProtoWriteBuffer buffer) const override;
-#ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
-#endif
-
- protected:
-  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
-};
-class VoiceAssistantConfiguration : public ProtoMessage {
- public:
-  std::vector<VoiceAssistantAvailableWakeWord> available_wake_words{};
-  uint32_t max_active_wake_words{0};
-  void encode(ProtoWriteBuffer buffer) const override;
-#ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
-#endif
-
- protected:
-  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
 class ListEntitiesAlarmControlPanelResponse : public ProtoMessage {
  public:

--- a/esphome/components/api/api_pb2.h
+++ b/esphome/components/api/api_pb2.h
@@ -1757,7 +1757,6 @@ class VoiceAssistantRequest : public ProtoMessage {
   std::string wake_word_phrase{};
   enums::VoiceAssistantPipelineStage start_stage{};
   enums::VoiceAssistantPipelineStage end_stage{};
-  std::vector<std::string> wake_word_names{};
   std::string announce_text{};
   void encode(ProtoWriteBuffer buffer) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
@@ -1840,8 +1839,45 @@ class VoiceAssistantTriggerPipeline : public ProtoMessage {
   enums::VoiceAssistantPipelineStage start_stage{};
   enums::VoiceAssistantPipelineStage end_stage{};
   std::string wake_word_phrase{};
-  std::vector<std::string> wake_word_names{};
   std::string announce_text{};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+};
+class VoiceAssistantSetConfiguration : public ProtoMessage {
+ public:
+  std::vector<std::string> active_wake_words{};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
+};
+class VoiceAssistantAvailableWakeWord : public ProtoMessage {
+ public:
+  std::string wake_word{};
+  bool is_active{false};
+  std::vector<std::string> trained_languages{};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+};
+class VoiceAssistantConfiguration : public ProtoMessage {
+ public:
+  std::vector<VoiceAssistantAvailableWakeWord> available_wake_words{};
+  uint32_t max_active_wake_words{0};
   void encode(ProtoWriteBuffer buffer) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;

--- a/esphome/components/api/api_pb2.h
+++ b/esphome/components/api/api_pb2.h
@@ -178,6 +178,12 @@ enum VoiceAssistantRequestFlag : uint32_t {
   VOICE_ASSISTANT_REQUEST_USE_VAD = 1,
   VOICE_ASSISTANT_REQUEST_USE_WAKE_WORD = 2,
 };
+enum VoiceAssistantPipelineStage : uint32_t {
+  VOICE_ASSISTANT_PIPELINE_STAGE_WAKE_WORD = 0,
+  VOICE_ASSISTANT_PIPELINE_STAGE_STT = 1,
+  VOICE_ASSISTANT_PIPELINE_STAGE_INTENT = 2,
+  VOICE_ASSISTANT_PIPELINE_STAGE_TTS = 3,
+};
 enum VoiceAssistantEvent : uint32_t {
   VOICE_ASSISTANT_ERROR = 0,
   VOICE_ASSISTANT_RUN_START = 1,
@@ -1749,6 +1755,10 @@ class VoiceAssistantRequest : public ProtoMessage {
   uint32_t flags{0};
   VoiceAssistantAudioSettings audio_settings{};
   std::string wake_word_phrase{};
+  enums::VoiceAssistantPipelineStage start_stage{};
+  enums::VoiceAssistantPipelineStage end_stage{};
+  std::vector<std::string> wake_word_names{};
+  std::string tts_input{};
   void encode(ProtoWriteBuffer buffer) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
@@ -1816,6 +1826,22 @@ class VoiceAssistantTimerEventResponse : public ProtoMessage {
   uint32_t total_seconds{0};
   uint32_t seconds_left{0};
   bool is_active{false};
+  void encode(ProtoWriteBuffer buffer) const override;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+};
+class VoiceAssistantTriggerPipeline : public ProtoMessage {
+ public:
+  enums::VoiceAssistantPipelineStage start_stage{};
+  enums::VoiceAssistantPipelineStage end_stage{};
+  std::string wake_word_phrase{};
+  std::vector<std::string> wake_word_names{};
+  std::string tts_input{};
   void encode(ProtoWriteBuffer buffer) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;

--- a/esphome/components/api/api_pb2.h
+++ b/esphome/components/api/api_pb2.h
@@ -1839,28 +1839,12 @@ class VoiceAssistantAnnounceRequest : public ProtoMessage {
 };
 class VoiceAssistantAnnounceFinished : public ProtoMessage {
  public:
-  std::string media_id{};
   void encode(ProtoWriteBuffer buffer) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
 #endif
 
  protected:
-  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-};
-class VoiceAssistantTextToSpeechFormat : public ProtoMessage {
- public:
-  std::string format{};
-  uint32_t sample_rate{0};
-  uint32_t num_channels{0};
-  void encode(ProtoWriteBuffer buffer) const override;
-#ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
-#endif
-
- protected:
-  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
 class ListEntitiesAlarmControlPanelResponse : public ProtoMessage {
  public:

--- a/esphome/components/api/api_pb2_service.cpp
+++ b/esphome/components/api/api_pb2_service.cpp
@@ -493,7 +493,7 @@ bool APIServerConnectionBase::send_voice_assistant_announce_finished(const Voice
 #ifdef HAS_PROTO_MESSAGE_DUMP
   ESP_LOGVV(TAG, "send_voice_assistant_announce_finished: %s", msg.dump().c_str());
 #endif
-  return this->send_message_<VoiceAssistantAnnounceFinished>(msg, 121);
+  return this->send_message_<VoiceAssistantAnnounceFinished>(msg, 120);
 }
 #endif
 #ifdef USE_ALARM_CONTROL_PANEL
@@ -1149,17 +1149,6 @@ bool APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       break;
     }
     case 119: {
-#ifdef USE_MEDIA_PLAYER
-      MediaPlayerSupportedFormat msg;
-      msg.decode(msg_data, msg_size);
-#ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_media_player_supported_format: %s", msg.dump().c_str());
-#endif
-      this->on_media_player_supported_format(msg);
-#endif
-      break;
-    }
-    case 120: {
 #ifdef USE_VOICE_ASSISTANT
       VoiceAssistantAnnounceRequest msg;
       msg.decode(msg_data, msg_size);

--- a/esphome/components/api/api_pb2_service.cpp
+++ b/esphome/components/api/api_pb2_service.cpp
@@ -1164,6 +1164,9 @@ bool APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       ESP_LOGVV(TAG, "on_media_player_supported_format: %s", msg.dump().c_str());
 #endif
       this->on_media_player_supported_format(msg);
+#endif
+      break;
+    }
     case 122: {
 #ifdef USE_VOICE_ASSISTANT
       VoiceAssistantConfiguration msg;

--- a/esphome/components/api/api_pb2_service.cpp
+++ b/esphome/components/api/api_pb2_service.cpp
@@ -486,6 +486,14 @@ bool APIServerConnectionBase::send_voice_assistant_audio(const VoiceAssistantAud
 #endif
 #ifdef USE_VOICE_ASSISTANT
 #endif
+#ifdef USE_VOICE_ASSISTANT
+bool APIServerConnectionBase::send_voice_assistant_trigger_pipeline(const VoiceAssistantTriggerPipeline &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  ESP_LOGVV(TAG, "send_voice_assistant_trigger_pipeline: %s", msg.dump().c_str());
+#endif
+  return this->send_message_<VoiceAssistantTriggerPipeline>(msg, 120);
+}
+#endif
 #ifdef USE_ALARM_CONTROL_PANEL
 bool APIServerConnectionBase::send_list_entities_alarm_control_panel_response(
     const ListEntitiesAlarmControlPanelResponse &msg) {

--- a/esphome/components/api/api_pb2_service.cpp
+++ b/esphome/components/api/api_pb2_service.cpp
@@ -487,22 +487,6 @@ bool APIServerConnectionBase::send_voice_assistant_audio(const VoiceAssistantAud
 #ifdef USE_VOICE_ASSISTANT
 #endif
 #ifdef USE_VOICE_ASSISTANT
-bool APIServerConnectionBase::send_voice_assistant_trigger_pipeline(const VoiceAssistantTriggerPipeline &msg) {
-#ifdef HAS_PROTO_MESSAGE_DUMP
-  ESP_LOGVV(TAG, "send_voice_assistant_trigger_pipeline: %s", msg.dump().c_str());
-#endif
-  return this->send_message_<VoiceAssistantTriggerPipeline>(msg, 120);
-}
-#endif
-#ifdef USE_VOICE_ASSISTANT
-bool APIServerConnectionBase::send_voice_assistant_set_configuration(const VoiceAssistantSetConfiguration &msg) {
-#ifdef HAS_PROTO_MESSAGE_DUMP
-  ESP_LOGVV(TAG, "send_voice_assistant_set_configuration: %s", msg.dump().c_str());
-#endif
-  return this->send_message_<VoiceAssistantSetConfiguration>(msg, 121);
-}
-#endif
-#ifdef USE_VOICE_ASSISTANT
 #endif
 #ifdef USE_ALARM_CONTROL_PANEL
 bool APIServerConnectionBase::send_list_entities_alarm_control_panel_response(
@@ -1167,14 +1151,14 @@ bool APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
 #endif
       break;
     }
-    case 122: {
+    case 120: {
 #ifdef USE_VOICE_ASSISTANT
-      VoiceAssistantConfiguration msg;
+      VoiceAssistantAnnounce msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_voice_assistant_configuration: %s", msg.dump().c_str());
+      ESP_LOGVV(TAG, "on_voice_assistant_announce: %s", msg.dump().c_str());
 #endif
-      this->on_voice_assistant_configuration(msg);
+      this->on_voice_assistant_announce(msg);
 #endif
       break;
     }

--- a/esphome/components/api/api_pb2_service.cpp
+++ b/esphome/components/api/api_pb2_service.cpp
@@ -494,6 +494,16 @@ bool APIServerConnectionBase::send_voice_assistant_trigger_pipeline(const VoiceA
   return this->send_message_<VoiceAssistantTriggerPipeline>(msg, 120);
 }
 #endif
+#ifdef USE_VOICE_ASSISTANT
+bool APIServerConnectionBase::send_voice_assistant_set_configuration(const VoiceAssistantSetConfiguration &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  ESP_LOGVV(TAG, "send_voice_assistant_set_configuration: %s", msg.dump().c_str());
+#endif
+  return this->send_message_<VoiceAssistantSetConfiguration>(msg, 121);
+}
+#endif
+#ifdef USE_VOICE_ASSISTANT
+#endif
 #ifdef USE_ALARM_CONTROL_PANEL
 bool APIServerConnectionBase::send_list_entities_alarm_control_panel_response(
     const ListEntitiesAlarmControlPanelResponse &msg) {
@@ -1143,6 +1153,25 @@ bool APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       ESP_LOGVV(TAG, "on_update_command_request: %s", msg.dump().c_str());
 #endif
       this->on_update_command_request(msg);
+#endif
+      break;
+    }
+    case 119: {
+#ifdef USE_MEDIA_PLAYER
+      MediaPlayerSupportedFormat msg;
+      msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
+      ESP_LOGVV(TAG, "on_media_player_supported_format: %s", msg.dump().c_str());
+#endif
+      this->on_media_player_supported_format(msg);
+    case 122: {
+#ifdef USE_VOICE_ASSISTANT
+      VoiceAssistantConfiguration msg;
+      msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
+      ESP_LOGVV(TAG, "on_voice_assistant_configuration: %s", msg.dump().c_str());
+#endif
+      this->on_voice_assistant_configuration(msg);
 #endif
       break;
     }

--- a/esphome/components/api/api_pb2_service.cpp
+++ b/esphome/components/api/api_pb2_service.cpp
@@ -488,6 +488,14 @@ bool APIServerConnectionBase::send_voice_assistant_audio(const VoiceAssistantAud
 #endif
 #ifdef USE_VOICE_ASSISTANT
 #endif
+#ifdef USE_VOICE_ASSISTANT
+bool APIServerConnectionBase::send_voice_assistant_announce_finished(const VoiceAssistantAnnounceFinished &msg) {
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  ESP_LOGVV(TAG, "send_voice_assistant_announce_finished: %s", msg.dump().c_str());
+#endif
+  return this->send_message_<VoiceAssistantAnnounceFinished>(msg, 121);
+}
+#endif
 #ifdef USE_ALARM_CONTROL_PANEL
 bool APIServerConnectionBase::send_list_entities_alarm_control_panel_response(
     const ListEntitiesAlarmControlPanelResponse &msg) {
@@ -1153,12 +1161,12 @@ bool APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
     }
     case 120: {
 #ifdef USE_VOICE_ASSISTANT
-      VoiceAssistantAnnounce msg;
+      VoiceAssistantAnnounceRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_voice_assistant_announce: %s", msg.dump().c_str());
+      ESP_LOGVV(TAG, "on_voice_assistant_announce_request: %s", msg.dump().c_str());
 #endif
-      this->on_voice_assistant_announce(msg);
+      this->on_voice_assistant_announce_request(msg);
 #endif
       break;
     }

--- a/esphome/components/api/api_pb2_service.h
+++ b/esphome/components/api/api_pb2_service.h
@@ -248,7 +248,10 @@ class APIServerConnectionBase : public ProtoService {
   virtual void on_voice_assistant_timer_event_response(const VoiceAssistantTimerEventResponse &value){};
 #endif
 #ifdef USE_VOICE_ASSISTANT
-  virtual void on_voice_assistant_announce(const VoiceAssistantAnnounce &value){};
+  virtual void on_voice_assistant_announce_request(const VoiceAssistantAnnounceRequest &value){};
+#endif
+#ifdef USE_VOICE_ASSISTANT
+  bool send_voice_assistant_announce_finished(const VoiceAssistantAnnounceFinished &msg);
 #endif
 #ifdef USE_ALARM_CONTROL_PANEL
   bool send_list_entities_alarm_control_panel_response(const ListEntitiesAlarmControlPanelResponse &msg);

--- a/esphome/components/api/api_pb2_service.h
+++ b/esphome/components/api/api_pb2_service.h
@@ -247,6 +247,9 @@ class APIServerConnectionBase : public ProtoService {
 #ifdef USE_VOICE_ASSISTANT
   virtual void on_voice_assistant_timer_event_response(const VoiceAssistantTimerEventResponse &value){};
 #endif
+#ifdef USE_VOICE_ASSISTANT
+  bool send_voice_assistant_trigger_pipeline(const VoiceAssistantTriggerPipeline &msg);
+#endif
 #ifdef USE_ALARM_CONTROL_PANEL
   bool send_list_entities_alarm_control_panel_response(const ListEntitiesAlarmControlPanelResponse &msg);
 #endif

--- a/esphome/components/api/api_pb2_service.h
+++ b/esphome/components/api/api_pb2_service.h
@@ -250,6 +250,12 @@ class APIServerConnectionBase : public ProtoService {
 #ifdef USE_VOICE_ASSISTANT
   bool send_voice_assistant_trigger_pipeline(const VoiceAssistantTriggerPipeline &msg);
 #endif
+#ifdef USE_VOICE_ASSISTANT
+  bool send_voice_assistant_set_configuration(const VoiceAssistantSetConfiguration &msg);
+#endif
+#ifdef USE_VOICE_ASSISTANT
+  virtual void on_voice_assistant_configuration(const VoiceAssistantConfiguration &value){};
+#endif
 #ifdef USE_ALARM_CONTROL_PANEL
   bool send_list_entities_alarm_control_panel_response(const ListEntitiesAlarmControlPanelResponse &msg);
 #endif

--- a/esphome/components/api/api_pb2_service.h
+++ b/esphome/components/api/api_pb2_service.h
@@ -248,13 +248,7 @@ class APIServerConnectionBase : public ProtoService {
   virtual void on_voice_assistant_timer_event_response(const VoiceAssistantTimerEventResponse &value){};
 #endif
 #ifdef USE_VOICE_ASSISTANT
-  bool send_voice_assistant_trigger_pipeline(const VoiceAssistantTriggerPipeline &msg);
-#endif
-#ifdef USE_VOICE_ASSISTANT
-  bool send_voice_assistant_set_configuration(const VoiceAssistantSetConfiguration &msg);
-#endif
-#ifdef USE_VOICE_ASSISTANT
-  virtual void on_voice_assistant_configuration(const VoiceAssistantConfiguration &value){};
+  virtual void on_voice_assistant_announce(const VoiceAssistantAnnounce &value){};
 #endif
 #ifdef USE_ALARM_CONTROL_PANEL
   bool send_list_entities_alarm_control_panel_response(const ListEntitiesAlarmControlPanelResponse &msg);

--- a/esphome/components/voice_assistant/voice_assistant.cpp
+++ b/esphome/components/voice_assistant/voice_assistant.cpp
@@ -294,6 +294,13 @@ void VoiceAssistant::loop() {
       msg.flags = flags;
       msg.audio_settings = audio_settings;
       msg.wake_word_phrase = this->wake_word_;
+
+      if (this->use_wake_word_) {
+        msg.start_stage = VOICE_ASSISTANT_PIPELINE_STAGE_WAKE_WORD;
+      } else {
+        msg.start_stage = VOICE_ASSISTANT_PIPELINE_STAGE_STT;
+      }
+      msg.end_stage = VOICE_ASSISTANT_PIPELINE_STAGE_TTS;
       this->wake_word_ = "";
 
       if (this->api_client_ == nullptr || !this->api_client_->send_voice_assistant_request(msg)) {

--- a/esphome/components/voice_assistant/voice_assistant.cpp
+++ b/esphome/components/voice_assistant/voice_assistant.cpp
@@ -396,6 +396,9 @@ void VoiceAssistant::loop() {
         this->set_timeout("playing", 2000, [this]() {
           this->cancel_timeout("speaker-timeout");
           this->set_state_(State::IDLE, State::IDLE);
+
+          api::VoiceAssistantAnnounceFinished msg;
+          this->api_client_->send_voice_assistant_announce_finished(msg);
         });
       }
       break;
@@ -870,7 +873,6 @@ void VoiceAssistant::on_announce(const api::VoiceAssistantAnnounceRequest &msg) 
 #ifdef USE_MEDIA_PLAYER
   if (this->media_player_ != nullptr) {
     this->tts_start_trigger_->trigger(msg.text);
-    this->announce_media_id_ = msg.media_id;
     this->media_player_->make_call().set_media_url(msg.media_id).set_announcement(true).perform();
     this->set_state_(State::STREAMING_RESPONSE, State::STREAMING_RESPONSE);
     this->tts_end_trigger_->trigger(msg.media_id);

--- a/esphome/components/voice_assistant/voice_assistant.cpp
+++ b/esphome/components/voice_assistant/voice_assistant.cpp
@@ -296,11 +296,11 @@ void VoiceAssistant::loop() {
       msg.wake_word_phrase = this->wake_word_;
 
       if (this->use_wake_word_) {
-        msg.start_stage = VOICE_ASSISTANT_PIPELINE_STAGE_WAKE_WORD;
+        msg.start_stage = api::enums::VOICE_ASSISTANT_PIPELINE_STAGE_WAKE_WORD;
       } else {
-        msg.start_stage = VOICE_ASSISTANT_PIPELINE_STAGE_STT;
+        msg.start_stage = api::enums::VOICE_ASSISTANT_PIPELINE_STAGE_STT;
       }
-      msg.end_stage = VOICE_ASSISTANT_PIPELINE_STAGE_TTS;
+      msg.end_stage = api::enums::VOICE_ASSISTANT_PIPELINE_STAGE_TTS;
       this->wake_word_ = "";
 
       if (this->api_client_ == nullptr || !this->api_client_->send_voice_assistant_request(msg)) {

--- a/esphome/components/voice_assistant/voice_assistant.cpp
+++ b/esphome/components/voice_assistant/voice_assistant.cpp
@@ -398,6 +398,7 @@ void VoiceAssistant::loop() {
           this->set_state_(State::IDLE, State::IDLE);
 
           api::VoiceAssistantAnnounceFinished msg;
+          msg.success = true;
           this->api_client_->send_voice_assistant_announce_finished(msg);
         });
       }

--- a/esphome/components/voice_assistant/voice_assistant.cpp
+++ b/esphome/components/voice_assistant/voice_assistant.cpp
@@ -866,6 +866,19 @@ void VoiceAssistant::timer_tick_() {
   this->timer_tick_trigger_->trigger(res);
 }
 
+void VoiceAssistant::on_announce(const api::VoiceAssistantAnnounceRequest &msg) {
+#ifdef USE_MEDIA_PLAYER
+  if (this->media_player_ != nullptr) {
+    this->tts_start_trigger_->trigger(msg.text);
+    this->announce_media_id_ = msg.media_id;
+    this->media_player_->make_call().set_media_url(msg.media_id).set_announcement(true).perform();
+    this->set_state_(State::STREAMING_RESPONSE, State::STREAMING_RESPONSE);
+    this->tts_end_trigger_->trigger(msg.media_id);
+    this->end_trigger_->trigger();
+  }
+#endif
+}
+
 VoiceAssistant *global_voice_assistant = nullptr;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
 }  // namespace voice_assistant

--- a/esphome/components/voice_assistant/voice_assistant.cpp
+++ b/esphome/components/voice_assistant/voice_assistant.cpp
@@ -294,13 +294,6 @@ void VoiceAssistant::loop() {
       msg.flags = flags;
       msg.audio_settings = audio_settings;
       msg.wake_word_phrase = this->wake_word_;
-
-      if (this->use_wake_word_) {
-        msg.start_stage = api::enums::VOICE_ASSISTANT_PIPELINE_STAGE_WAKE_WORD;
-      } else {
-        msg.start_stage = api::enums::VOICE_ASSISTANT_PIPELINE_STAGE_STT;
-      }
-      msg.end_stage = api::enums::VOICE_ASSISTANT_PIPELINE_STAGE_TTS;
       this->wake_word_ = "";
 
       if (this->api_client_ == nullptr || !this->api_client_->send_voice_assistant_request(msg)) {

--- a/esphome/components/voice_assistant/voice_assistant.h
+++ b/esphome/components/voice_assistant/voice_assistant.h
@@ -132,6 +132,7 @@ class VoiceAssistant : public Component {
   void on_event(const api::VoiceAssistantEventResponse &msg);
   void on_audio(const api::VoiceAssistantAudio &msg);
   void on_timer_event(const api::VoiceAssistantTimerEventResponse &msg);
+  void on_announce(const api::VoiceAssistantAnnounceRequest &msg){};
 
   bool is_running() const { return this->state_ != State::IDLE; }
   void set_continuous(bool continuous) { this->continuous_ = continuous; }

--- a/esphome/components/voice_assistant/voice_assistant.h
+++ b/esphome/components/voice_assistant/voice_assistant.h
@@ -132,7 +132,7 @@ class VoiceAssistant : public Component {
   void on_event(const api::VoiceAssistantEventResponse &msg);
   void on_audio(const api::VoiceAssistantAudio &msg);
   void on_timer_event(const api::VoiceAssistantTimerEventResponse &msg);
-  void on_announce(const api::VoiceAssistantAnnounceRequest &msg){};
+  void on_announce(const api::VoiceAssistantAnnounceRequest &msg);
 
   bool is_running() const { return this->state_ != State::IDLE; }
   void set_continuous(bool continuous) { this->continuous_ = continuous; }


### PR DESCRIPTION
# What does this implement/fix?

Adds a new `VoiceAssistantAnnounce` message that will allow media URLs to be announced if the device supports it.

* https://github.com/esphome/aioesphomeapi/pull/939
* https://github.com/home-assistant/core/pull/125157
* https://github.com/esphome/voice-kit/pull/64

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
