### PR TITLE
Enable IPv6 when manual IPv4 is enabled

### DIFF
--- a/esphome/components/ethernet/ethernet_component.cpp
+++ b/esphome/components/ethernet/ethernet_component.cpp
@@ -457,6 +457,12 @@ void EthernetComponent::start_connect_() {
   ESPHL_ERROR_CHECK(err, "DHCPC set IP info error");
 
   if (this->manual_ip_.has_value()) {
+#if USE_NETWORK_IPV6
+    err = esp_netif_create_ip6_linklocal(this->eth_netif_);
+    if (err != ESP_OK) {
+      ESPHL_ERROR_CHECK(err, "Enable IPv6 link local failed");
+    }
+#endif /* USE_NETWORK_IPV6 */
     if (this->manual_ip_->dns1.is_set()) {
       ip_addr_t d;
       d = this->manual_ip_->dns1;

--- a/esphome/components/ethernet/ethernet_component.cpp
+++ b/esphome/components/ethernet/ethernet_component.cpp
@@ -457,12 +457,6 @@ void EthernetComponent::start_connect_() {
   ESPHL_ERROR_CHECK(err, "DHCPC set IP info error");
 
   if (this->manual_ip_.has_value()) {
-#if USE_NETWORK_IPV6
-    err = esp_netif_create_ip6_linklocal(this->eth_netif_);
-    if (err != ESP_OK) {
-      ESPHL_ERROR_CHECK(err, "Enable IPv6 link local failed");
-    }
-#endif /* USE_NETWORK_IPV6 */
     if (this->manual_ip_->dns1.is_set()) {
       ip_addr_t d;
       d = this->manual_ip_->dns1;
@@ -478,13 +472,13 @@ void EthernetComponent::start_connect_() {
     if (err != ESP_ERR_ESP_NETIF_DHCP_ALREADY_STARTED) {
       ESPHL_ERROR_CHECK(err, "DHCPC start error");
     }
-#if USE_NETWORK_IPV6
-    err = esp_netif_create_ip6_linklocal(this->eth_netif_);
-    if (err != ESP_OK) {
-      ESPHL_ERROR_CHECK(err, "Enable IPv6 link local failed");
-    }
-#endif /* USE_NETWORK_IPV6 */
   }
+#if USE_NETWORK_IPV6
+  err = esp_netif_create_ip6_linklocal(this->eth_netif_);
+  if (err != ESP_OK) {
+    ESPHL_ERROR_CHECK(err, "Enable IPv6 link local failed");
+  }
+#endif /* USE_NETWORK_IPV6 */
 
   this->connect_begin_ = millis();
   this->status_set_warning();


### PR DESCRIPTION
# What does this implement/fix?

IPv6 gets enable even with a static IPv4 address configured.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/6126

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
esphome:
  name: ipv6ethidfstatic

esp32:
  board: esp32dev
  framework:
    type: esp-idf

network:
  enable_ipv6: true

ethernet:
  type: LAN8720
  mdc_pin: GPIO23
  mdio_pin: GPIO18
  clk_mode: GPIO17_OUT
  phy_addr: 0
  manual_ip:
    static_ip: 192.168.20.106
    gateway: 192.168.20.1
    subnet: 255.255.255.0
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
