### PR TITLE
update logs for bluetooth proxy

### DIFF
--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
@@ -93,7 +93,7 @@ void BluetoothProxy::send_api_packet_(const esp32_ble_tracker::ESPBTDevice &devi
 void BluetoothProxy::dump_config() {
   ESP_LOGCONFIG(TAG, "Bluetooth Proxy:");
   ESP_LOGCONFIG(TAG, "  Active: %s", YESNO(this->active_));
-  ESP_LOGCONFIG(TAG, "  Connections: %d", this->connections_);
+  ESP_LOGCONFIG(TAG, "  Connections: %d", this->connections_.size());
   ESP_LOGCONFIG(TAG, "  Raw advertisements: %s", YESNO(this->raw_advertisements_));
 }
 

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
@@ -55,11 +55,11 @@ bool BluetoothProxy::parse_devices(esp_ble_gap_cb_param_t::ble_scan_result_evt_p
 
     resp.advertisements.push_back(std::move(adv));
 
-    ESP_LOGV(TAG, "Proxying packet from %s. RSSI: %d dB",
+    ESP_LOGV(TAG, "Proxying packet from %s, length %d. RSSI: %d dB",
              str_snprintf("%02X:%02X:%02X:%02X:%02X:%02X", 17, result.bda[0], result.bda[1], result.bda[2],
                           result.bda[3], result.bda[4], result.bda[5])
                  .c_str(),
-             adv.rssi);
+             length, adv.rssi);
   }
   ESP_LOGV(TAG, "Proxying %d packets", count);
   this->api_connection_->send_bluetooth_le_raw_advertisements_response(resp);

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
@@ -54,6 +54,7 @@ bool BluetoothProxy::parse_devices(esp_ble_gap_cb_param_t::ble_scan_result_evt_p
     }
 
     resp.advertisements.push_back(std::move(adv));
+    ESP_LOGV(TAG, "Proxying packet from %s. RSSI: %d dB", adv.address.c_str(), adv.rssi);
   }
   ESP_LOGV(TAG, "Proxying %d packets", count);
   this->api_connection_->send_bluetooth_le_raw_advertisements_response(resp);

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
@@ -55,11 +55,8 @@ bool BluetoothProxy::parse_devices(esp_ble_gap_cb_param_t::ble_scan_result_evt_p
 
     resp.advertisements.push_back(std::move(adv));
 
-    ESP_LOGV(TAG, "Proxying raw packet from %s, length %d. RSSI: %d dB",
-             str_snprintf("%02X:%02X:%02X:%02X:%02X:%02X", 17, result.bda[0], result.bda[1], result.bda[2],
-                          result.bda[3], result.bda[4], result.bda[5])
-                 .c_str(),
-             length, result.rssi);
+    ESP_LOGV(TAG, "Proxying raw packet from %02X:%02X:%02X:%02X:%02X:%02X, length %d. RSSI: %d dB", result.bda[0],
+             result.bda[1], result.bda[2], result.bda[3], result.bda[4], result.bda[5], length, result.rssi);
   }
   ESP_LOGV(TAG, "Proxying %d packets", count);
   this->api_connection_->send_bluetooth_le_raw_advertisements_response(resp);

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
@@ -54,7 +54,12 @@ bool BluetoothProxy::parse_devices(esp_ble_gap_cb_param_t::ble_scan_result_evt_p
     }
 
     resp.advertisements.push_back(std::move(adv));
-    ESP_LOGV(TAG, "Proxying packet from %s. RSSI: %d dB", adv.address.c_str(), adv.rssi);
+
+    ESP_LOGV(TAG, "Proxying packet from %s. RSSI: %d dB",
+             str_snprintf("%02X:%02X:%02X:%02X:%02X:%02X", 17, result.bda[0], result.bda[1], result.bda[2],
+                          result.bda[3], result.bda[4], result.bda[5])
+                 .c_str(),
+             adv.rssi);
   }
   ESP_LOGV(TAG, "Proxying %d packets", count);
   this->api_connection_->send_bluetooth_le_raw_advertisements_response(resp);

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
@@ -93,6 +93,8 @@ void BluetoothProxy::send_api_packet_(const esp32_ble_tracker::ESPBTDevice &devi
 void BluetoothProxy::dump_config() {
   ESP_LOGCONFIG(TAG, "Bluetooth Proxy:");
   ESP_LOGCONFIG(TAG, "  Active: %s", YESNO(this->active_));
+  ESP_LOGCONFIG(TAG, "  Connections: %d", this->connections_);
+  ESP_LOGCONFIG(TAG, "  Raw advertisements: %s", YESNO(this->raw_advertisements_));
 }
 
 int BluetoothProxy::get_bluetooth_connections_free() {

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
@@ -55,11 +55,11 @@ bool BluetoothProxy::parse_devices(esp_ble_gap_cb_param_t::ble_scan_result_evt_p
 
     resp.advertisements.push_back(std::move(adv));
 
-    ESP_LOGV(TAG, "Proxying packet from %s, length %d. RSSI: %d dB",
+    ESP_LOGV(TAG, "Proxying raw packet from %s, length %d. RSSI: %d dB",
              str_snprintf("%02X:%02X:%02X:%02X:%02X:%02X", 17, result.bda[0], result.bda[1], result.bda[2],
                           result.bda[3], result.bda[4], result.bda[5])
                  .c_str(),
-             length, adv.rssi);
+             length, result.rssi);
   }
   ESP_LOGV(TAG, "Proxying %d packets", count);
   this->api_connection_->send_bluetooth_le_raw_advertisements_response(resp);


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->
HA stop showing new data from bluetooth_proxy randomly. Without logs it is hard to understand at which stage data get lost.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
