### PR TITLE
[rpi_dpi_rgb] Add enable_pin and reset_display method to driver

### DIFF
--- a/esphome/components/rpi_dpi_rgb/display.py
+++ b/esphome/components/rpi_dpi_rgb/display.py
@@ -3,6 +3,7 @@ import esphome.config_validation as cv
 from esphome import pins
 from esphome.components import display
 from esphome.const import (
+    CONF_ENABLE_PIN,
     CONF_HSYNC_PIN,
     CONF_RESET_PIN,
     CONF_DATA_PINS,
@@ -112,6 +113,7 @@ CONFIG_SCHEMA = cv.All(
                 cv.Required(CONF_PCLK_PIN): pins.internal_gpio_output_pin_schema,
                 cv.Required(CONF_HSYNC_PIN): pins.internal_gpio_output_pin_schema,
                 cv.Required(CONF_VSYNC_PIN): pins.internal_gpio_output_pin_schema,
+                cv.Optional(CONF_ENABLE_PIN): pins.gpio_output_pin_schema,
                 cv.Optional(CONF_RESET_PIN): pins.gpio_output_pin_schema,
                 cv.Optional(CONF_HSYNC_PULSE_WIDTH, default=10): cv.int_,
                 cv.Optional(CONF_HSYNC_BACK_PORCH, default=10): cv.int_,
@@ -163,6 +165,10 @@ async def to_code(config):
         data_pin = await cg.gpio_pin_expression(pin)
         cg.add(var.add_data_pin(data_pin, index))
         index += 1
+
+    if enable_pin := config.get(CONF_ENABLE_PIN):
+        reset = await cg.gpio_pin_expression(enable_pin)
+        cg.add(var.set_reset_pin(reset))
 
     if reset_pin := config.get(CONF_RESET_PIN):
         reset = await cg.gpio_pin_expression(reset_pin)

--- a/esphome/components/rpi_dpi_rgb/display.py
+++ b/esphome/components/rpi_dpi_rgb/display.py
@@ -167,8 +167,8 @@ async def to_code(config):
         index += 1
 
     if enable_pin := config.get(CONF_ENABLE_PIN):
-        reset = await cg.gpio_pin_expression(enable_pin)
-        cg.add(var.set_reset_pin(reset))
+        enable = await cg.gpio_pin_expression(enable_pin)
+        cg.add(var.set_enable_pin(enable))
 
     if reset_pin := config.get(CONF_RESET_PIN):
         reset = await cg.gpio_pin_expression(reset_pin)

--- a/esphome/components/rpi_dpi_rgb/rpi_dpi_rgb.cpp
+++ b/esphome/components/rpi_dpi_rgb/rpi_dpi_rgb.cpp
@@ -104,7 +104,7 @@ void RpiDpiRgb::dump_config() {
   ESP_LOGCONFIG(TAG, "  Height: %u", this->height_);
   ESP_LOGCONFIG(TAG, "  Width: %u", this->width_);
   LOG_PIN("  DE Pin: ", this->de_pin_);
-  LOG_PIN("  Enable Pin: ", this->enable_pin_);  
+  LOG_PIN("  Enable Pin: ", this->enable_pin_);
   LOG_PIN("  Reset Pin: ", this->reset_pin_);
   size_t data_pin_count = sizeof(this->data_pins_) / sizeof(this->data_pins_[0]);
   for (size_t i = 0; i != data_pin_count; i++)

--- a/esphome/components/rpi_dpi_rgb/rpi_dpi_rgb.cpp
+++ b/esphome/components/rpi_dpi_rgb/rpi_dpi_rgb.cpp
@@ -104,6 +104,7 @@ void RpiDpiRgb::dump_config() {
   ESP_LOGCONFIG(TAG, "  Height: %u", this->height_);
   ESP_LOGCONFIG(TAG, "  Width: %u", this->width_);
   LOG_PIN("  DE Pin: ", this->de_pin_);
+  LOG_PIN("  Enable Pin: ", this->enable_pin_);  
   LOG_PIN("  Reset Pin: ", this->reset_pin_);
   size_t data_pin_count = sizeof(this->data_pins_) / sizeof(this->data_pins_[0]);
   for (size_t i = 0; i != data_pin_count; i++)

--- a/esphome/components/rpi_dpi_rgb/rpi_dpi_rgb.cpp
+++ b/esphome/components/rpi_dpi_rgb/rpi_dpi_rgb.cpp
@@ -111,6 +111,23 @@ void RpiDpiRgb::dump_config() {
     ESP_LOGCONFIG(TAG, "  Data pin %d: %s", i, (this->data_pins_[i])->dump_summary().c_str());
 }
 
+void RpiDpiRgb::reset_display_() const {
+  if (this->reset_pin_ != nullptr) {
+    this->reset_pin_->setup();
+    this->reset_pin_->digital_write(false);
+    if (this->enable_pin_ != nullptr) {
+      this->enable_pin_->setup();
+      this->enable_pin_->digital_write(false);
+    }
+    delay(1);
+    this->reset_pin_->digital_write(true);
+    if (this->enable_pin_ != nullptr) {
+      delay(11);
+      this->enable_pin_->digital_write(true);
+    }
+  }
+}
+
 }  // namespace rpi_dpi_rgb
 }  // namespace esphome
 

--- a/esphome/components/rpi_dpi_rgb/rpi_dpi_rgb.h
+++ b/esphome/components/rpi_dpi_rgb/rpi_dpi_rgb.h
@@ -63,6 +63,7 @@ class RpiDpiRgb : public display::Display {
  protected:
   int get_width_internal() override { return this->width_; }
   int get_height_internal() override { return this->height_; }
+  void reset_display_() const;
   InternalGPIOPin *de_pin_{nullptr};
   InternalGPIOPin *pclk_pin_{nullptr};
   InternalGPIOPin *hsync_pin_{nullptr};

--- a/esphome/components/rpi_dpi_rgb/rpi_dpi_rgb.h
+++ b/esphome/components/rpi_dpi_rgb/rpi_dpi_rgb.h
@@ -36,7 +36,7 @@ class RpiDpiRgb : public display::Display {
   void set_pclk_pin(InternalGPIOPin *pclk_pin) { this->pclk_pin_ = pclk_pin; }
   void set_vsync_pin(InternalGPIOPin *vsync_pin) { this->vsync_pin_ = vsync_pin; }
   void set_hsync_pin(InternalGPIOPin *hsync_pin) { this->hsync_pin_ = hsync_pin; }
-  void set_enable_pin(GPIOPin *enable_pin) { this->reset_pin_ = enable_pin; }
+  void set_enable_pin(GPIOPin *enable_pin) { this->enable_pin_ = enable_pin; }
   void set_reset_pin(GPIOPin *reset_pin) { this->reset_pin_ = reset_pin; }
   void set_width(uint16_t width) { this->width_ = width; }
   void set_dimensions(uint16_t width, uint16_t height) {

--- a/esphome/components/rpi_dpi_rgb/rpi_dpi_rgb.h
+++ b/esphome/components/rpi_dpi_rgb/rpi_dpi_rgb.h
@@ -36,6 +36,7 @@ class RpiDpiRgb : public display::Display {
   void set_pclk_pin(InternalGPIOPin *pclk_pin) { this->pclk_pin_ = pclk_pin; }
   void set_vsync_pin(InternalGPIOPin *vsync_pin) { this->vsync_pin_ = vsync_pin; }
   void set_hsync_pin(InternalGPIOPin *hsync_pin) { this->hsync_pin_ = hsync_pin; }
+  void set_enable_pin(GPIOPin *enable_pin) { this->reset_pin_ = enable_pin; }
   void set_reset_pin(GPIOPin *reset_pin) { this->reset_pin_ = reset_pin; }
   void set_width(uint16_t width) { this->width_ = width; }
   void set_dimensions(uint16_t width, uint16_t height) {
@@ -66,6 +67,7 @@ class RpiDpiRgb : public display::Display {
   InternalGPIOPin *pclk_pin_{nullptr};
   InternalGPIOPin *hsync_pin_{nullptr};
   InternalGPIOPin *vsync_pin_{nullptr};
+  GPIOPin *enable_pin_{nullptr};
   GPIOPin *reset_pin_{nullptr};
   InternalGPIOPin *data_pins_[16] = {};
   uint16_t hsync_front_porch_ = 8;


### PR DESCRIPTION
# What does this implement/fix?

- Add `enable_pin` to [RPI_DPI_RGB Display Driver](https://esphome.io/components/display/rpi_dpi_rgb.html)
- Add `reset_display` method to [RPI_DPI_RGB Display Driver](https://esphome.io/components/display/rpi_dpi_rgb.html)

Thanks for the help from @cly_de_barrow.

This is linked to the new composant [CH422G support #7356](https://github.com/esphome/esphome/pull/7356).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** [CH422G support #7356](https://github.com/esphome/esphome/pull/7356)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#4212

## Test Environment

[Waveshare ESP32-S3-Touch-LCD-4.3](https://www.waveshare.com/wiki/ESP32-S3-Touch-LCD-4.3) board

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
external_components:
  # CH422G I/O Expander
  - source: github://pr#7356
    components: [ch422g]

i2c:
  sda: 8
  scl: 9
  frequency: 400kHz
  scan: false
  id: bus_a

touchscreen:
  - platform: gt911
    address: 0x5D
    id: my_touchscreen
    update_interval: 16ms
    interrupt_pin: 4
    reset_pin:
      ch422g: io_ex
      number: 1
    on_touch:
      - lambda: |-
            ESP_LOGI("cal", "x=%d, y=%d, x_raw=%d, y_raw=%0d",
                touch.x,
                touch.y,
                touch.x_raw,
                touch.y_raw
                );

display:
  - platform: rpi_dpi_rgb
    id: rpi_disp
    update_interval: never
    auto_clear_enabled: false
    color_order: RGB
    pclk_frequency: 16MHz
    dimensions:
      width: 800
      height: 480
    reset_pin:
      ch422g: io_ex
      number: 3
    enable_pin:
      ch422g: io_ex
      number: 2
    de_pin:
      number: 5
    hsync_pin:
      number: 46
      ignore_strapping_warning: true
    vsync_pin:
      number: 3
      ignore_strapping_warning: true
    pclk_pin: 7
    pclk_inverted: true
    hsync_back_porch: 30
    hsync_front_porch: 210
    hsync_pulse_width: 30
    vsync_back_porch: 4
    vsync_front_porch: 4
    vsync_pulse_width: 4
    data_pins:
      red:
        - 1         #r3
        - 2         #r4
        - 42        #r5
        - 41        #r6
        - 40        #r7
      blue:
        - 14        #b3
        - 38        #b4
        - 18        #b5
        - 17        #b6
        - 10        #b7
      green:
        - 39        #g2
        - 0         #g3
        - 45        #g4
        - 48        #g5
        - 47        #g6
        - 21        #g7
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
