### PR TITLE
[core] Only clean build files with esp-idf

### DIFF
--- a/esphome/storage_json.py
+++ b/esphome/storage_json.py
@@ -48,6 +48,8 @@ class StorageJSON:
         firmware_bin_path: str,
         loaded_integrations: set[str],
         no_mdns: bool,
+        framework: str | None = None,
+        core_platform: str | None = None,
     ) -> None:
         # Version of the storage JSON schema
         assert storage_version is None or isinstance(storage_version, int)
@@ -78,6 +80,10 @@ class StorageJSON:
         self.loaded_integrations = loaded_integrations
         # Is mDNS disabled
         self.no_mdns = no_mdns
+        # The framework used to compile the firmware
+        self.framework = framework
+        # The core platform of this firmware. Like "esp32", "rp2040", "host" etc.
+        self.core_platform = core_platform
 
     def as_dict(self):
         return {
@@ -94,6 +100,8 @@ class StorageJSON:
             "firmware_bin_path": self.firmware_bin_path,
             "loaded_integrations": sorted(self.loaded_integrations),
             "no_mdns": self.no_mdns,
+            "framework": self.framework,
+            "core_platform": self.core_platform,
         }
 
     def to_json(self):
@@ -127,6 +135,8 @@ class StorageJSON:
                 and CONF_DISABLED in esph.config[CONF_MDNS]
                 and esph.config[CONF_MDNS][CONF_DISABLED] is True
             ),
+            framework=esph.target_framework,
+            core_platform=esph.target_platform,
         )
 
     @staticmethod
@@ -147,6 +157,8 @@ class StorageJSON:
             firmware_bin_path=None,
             loaded_integrations=set(),
             no_mdns=False,
+            framework=None,
+            core_platform=platform.lower(),
         )
 
     @staticmethod
@@ -168,6 +180,8 @@ class StorageJSON:
         firmware_bin_path = storage.get("firmware_bin_path")
         loaded_integrations = set(storage.get("loaded_integrations", []))
         no_mdns = storage.get("no_mdns", False)
+        framework = storage.get("framework")
+        core_platform = storage.get("core_platform")
         return StorageJSON(
             storage_version,
             name,
@@ -182,6 +196,8 @@ class StorageJSON:
             firmware_bin_path,
             loaded_integrations,
             no_mdns,
+            framework,
+            core_platform,
         )
 
     @staticmethod

--- a/esphome/writer.py
+++ b/esphome/writer.py
@@ -211,7 +211,9 @@ def write_platformio_project():
     write_platformio_ini(content)
 
 
-DEFINES_H_FORMAT = ESPHOME_H_FORMAT = """\
+DEFINES_H_FORMAT = (
+    ESPHOME_H_FORMAT
+) = """\
 #pragma once
 #include "esphome/core/macros.h"
 {}

--- a/esphome/writer.py
+++ b/esphome/writer.py
@@ -9,6 +9,7 @@ from esphome.config import iter_component_configs, iter_components
 from esphome.const import (
     ENV_NOGITIGNORE,
     HEADER_FILE_EXTENSIONS,
+    PLATFORM_ESP32,
     SOURCE_FILE_EXTENSIONS,
     __version__,
 )
@@ -107,7 +108,10 @@ def storage_should_clean(old: StorageJSON, new: StorageJSON) -> bool:
     if old.build_path != new.build_path:
         return True
     if old.loaded_integrations != new.loaded_integrations:
-        return True
+        if new.core_platform == PLATFORM_ESP32:
+            from esphome.components.esp32 import FRAMEWORK_ESP_IDF
+
+            return new.framework == FRAMEWORK_ESP_IDF
     return False
 
 
@@ -207,9 +211,7 @@ def write_platformio_project():
     write_platformio_ini(content)
 
 
-DEFINES_H_FORMAT = (
-    ESPHOME_H_FORMAT
-) = """\
+DEFINES_H_FORMAT = ESPHOME_H_FORMAT = """\
 #pragma once
 #include "esphome/core/macros.h"
 {}


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->
#7344 added new logic to auto clean if the components list had changed, but this was happening for all devices and frameworks. This PR changes it to only clean on esp-idf.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
