### PR TITLE
Better support for task blocking ring buffer reads and writes

### DIFF
--- a/esphome/core/ring_buffer.cpp
+++ b/esphome/core/ring_buffer.cpp
@@ -26,6 +26,8 @@ std::unique_ptr<RingBuffer> RingBuffer::create(size_t len) {
 }
 
 size_t RingBuffer::read(void *data, size_t len, TickType_t ticks_to_wait) {
+  if (ticks_to_wait > 0)
+    xStreamBufferSetTriggerLevel(this->handle_, len);
   return xStreamBufferReceive(this->handle_, data, len, ticks_to_wait);
 }
 
@@ -37,6 +39,10 @@ size_t RingBuffer::write(void *data, size_t len) {
     xStreamBufferReceive(this->handle_, discard, needed, 0);
   }
   return xStreamBufferSend(this->handle_, data, len, 0);
+}
+
+size_t RingBuffer::write_without_replacement(void *data, size_t len, TickType_t ticks_to_wait) {
+  return xStreamBufferSend(this->handle_, data, len, ticks_to_wait);
 }
 
 size_t RingBuffer::available() const { return xStreamBufferBytesAvailable(this->handle_); }

--- a/esphome/core/ring_buffer.cpp
+++ b/esphome/core/ring_buffer.cpp
@@ -20,7 +20,7 @@ std::unique_ptr<RingBuffer> RingBuffer::create(size_t len) {
     return nullptr;
   }
 
-  rb->handle_ = xStreamBufferCreateStatic(len + 1, 0, rb->storage_, &rb->structure_);
+  rb->handle_ = xStreamBufferCreateStatic(len + 1, 1, rb->storage_, &rb->structure_);
   ESP_LOGD(TAG, "Created ring buffer with size %u", len);
   return rb;
 }
@@ -28,7 +28,12 @@ std::unique_ptr<RingBuffer> RingBuffer::create(size_t len) {
 size_t RingBuffer::read(void *data, size_t len, TickType_t ticks_to_wait) {
   if (ticks_to_wait > 0)
     xStreamBufferSetTriggerLevel(this->handle_, len);
-  return xStreamBufferReceive(this->handle_, data, len, ticks_to_wait);
+
+  size_t bytes_read = xStreamBufferReceive(this->handle_, data, len, ticks_to_wait);
+
+  xStreamBufferSetTriggerLevel(this->handle_, 1);
+
+  return bytes_read;
 }
 
 size_t RingBuffer::write(void *data, size_t len) {

--- a/esphome/core/ring_buffer.h
+++ b/esphome/core/ring_buffer.h
@@ -12,13 +12,69 @@ namespace esphome {
 
 class RingBuffer {
  public:
+  /**
+   * @brief Reads from the ring buffer, waiting up to a specified number of ticks if necessary.
+   *
+   * Available bytes are read into the provided data pointer. If not enough bytes are available,
+   * the function will wait up to `ticks_to_wait` FreeRTOS ticks before reading what is available.
+   *
+   * @param data Pointer to copy read data into
+   * @param len Number of bytes to read
+   * @param ticks_to_wait Maximum number of FreeRTOS ticks to wait (default: 0)
+   * @return Number of bytes read
+   */
   size_t read(void *data, size_t len, TickType_t ticks_to_wait = 0);
 
+  /**
+   * @brief Writes to the ring buffer, overwriting oldest data if necessary.
+   *
+   * The provided data is written to the ring buffer. If not enough space is available,
+   * the function will overwrite the oldest data in the ring buffer.
+   *
+   * @param data Pointer to data for writing
+   * @param len Number of bytes to write
+   * @return Number of bytes written
+   */
   size_t write(void *data, size_t len);
 
+  /**
+   * @brief Writes to the ring buffer without overwriting oldest data.
+   *
+   * The provided data is written to the ring buffer. If not enough space is available,
+   * the function will wait up to `ticks_to_wait` FreeRTOS ticks before writing as much as possible.
+   *
+   * @param data Pointer to data for writing
+   * @param len Number of bytes to write
+   * @param ticks_to_wait Maximum number of FreeRTOS ticks to wait (default: 0)
+   * @return Number of bytes written
+   */
+  size_t write_without_replacement(void *data, size_t len, TickType_t ticks_to_wait = 0);
+
+  /**
+   * @brief Returns the number of available bytes in the ring buffer.
+   *
+   * This function provides the number of bytes that can be read from the ring buffer
+   * without blocking the calling FreeRTOS task.
+   *
+   * @return Number of available bytes
+   */
   size_t available() const;
+
+  /**
+   * @brief Returns the number of free bytes in the ring buffer.
+   *
+   * This function provides the number of bytes that can be written to the ring buffer
+   * without overwriting data or blocking the calling FreeRTOS task.
+   *
+   * @return Number of free bytes
+   */
   size_t free() const;
 
+  /**
+   * @brief Resets the ring buffer, discarding all stored data.
+   *
+   * @return pdPASS if successful, pdFAIL otherwise
+   */
   BaseType_t reset();
 
   static std::unique_ptr<RingBuffer> create(size_t len);


### PR DESCRIPTION
# What does this implement/fix?

Adds better support for task blocking when reading and writing. This allows FreeRTOS tasks to be set up more efficiently, as they don't need to run until they have enough data to proceed. 

When reading, if ``ticks_to_wait`` is nonzero, it will block until the requested amount of data is available or the amount of ticks has passed. If it is the default 0 ticks, then it will continue to use the current behavior and return as much data that is available instantly. The new ``write_without_replacement`` function never overwrites the oldest data in the ring buffer. It has an optional ``ticks_to_wait`` parameter so that the calling task blocks until the requested amount of data is free or the amounts of ticks has passed. Finally, I added comments to better describe what each function does.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** not applicable

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** not applicable

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
