### PR TITLE
[image] Add Invert Colors option

### DIFF
--- a/esphome/components/image/__init__.py
+++ b/esphome/components/image/__init__.py
@@ -313,7 +313,7 @@ async def to_code(config):
         )
 
     transparent = config[CONF_USE_TRANSPARENCY]
-    invert_colors = config.get(CONF_REVERSE_COLORS)
+    reverse_colors = config.get(CONF_REVERSE_COLORS)
 
     dither = (
         Image.Dither.NONE
@@ -337,7 +337,7 @@ async def to_code(config):
 
     elif config[CONF_TYPE] == "RGBA":
         image = image.convert("RGBA")
-        if invert_colors:
+        if reverse_colors:
             image = invert_image_colors(image)
 
         pixels = list(image.getdata())
@@ -355,7 +355,7 @@ async def to_code(config):
 
     elif config[CONF_TYPE] == "RGB24":
         image = image.convert("RGBA")
-        if invert_colors:
+        if reverse_colors:
             image = invert_image_colors(image)
 
         pixels = list(image.getdata())
@@ -379,7 +379,7 @@ async def to_code(config):
 
     elif config[CONF_TYPE] in ["RGB565"]:
         image = image.convert("RGBA")
-        if invert_colors:
+        if reverse_colors:
             image = invert_image_colors(image)
 
         pixels = list(image.getdata())

--- a/esphome/components/image/__init__.py
+++ b/esphome/components/image/__init__.py
@@ -260,6 +260,7 @@ def load_svg_image(file: bytes, resize: tuple[int, int]):
 
     return Image.open(io.BytesIO(svg_image))
 
+
 def invert_image_colors(image):
     from PIL import Image
 
@@ -270,6 +271,7 @@ def invert_image_colors(image):
 
     r, g, b = map(invert, (r, g, b))
     return Image.merge(image.mode, (r, g, b, a))
+
 
 async def to_code(config):
     # Local import only to allow "validate_pillow_installed" to run *before* importing it

--- a/esphome/components/image/__init__.py
+++ b/esphome/components/image/__init__.py
@@ -47,6 +47,7 @@ IMAGE_TYPE = {
 }
 
 CONF_USE_TRANSPARENCY = "use_transparency"
+CONF_INVERT_COLORS = "invert_colors"
 
 # If the MDI file cannot be downloaded within this time, abort.
 IMAGE_DOWNLOAD_TIMEOUT = 30  # seconds
@@ -225,6 +226,7 @@ IMAGE_SCHEMA = cv.Schema(
             # Not setting default here on purpose; the default depends on the image type,
             # and thus will be set in the "validate_cross_dependencies" validator.
             cv.Optional(CONF_USE_TRANSPARENCY): cv.boolean,
+            cv.Optional(CONF_INVERT_COLORS default=False): cv.boolean,
             cv.Optional(CONF_DITHER, default="NONE"): cv.one_of(
                 "NONE", "FLOYDSTEINBERG", upper=True
             ),
@@ -258,6 +260,16 @@ def load_svg_image(file: bytes, resize: tuple[int, int]):
 
     return Image.open(io.BytesIO(svg_image))
 
+def invert_image_colors(image):
+    from PIL import Image
+
+    r, g, b, a = image.split()
+
+    def invert(image):
+        return image.point(lambda p: 255 - p)
+
+    r, g, b = map(invert, (r, g, b))
+    return Image.merge(image.mode, (r, g, b, a))
 
 async def to_code(config):
     # Local import only to allow "validate_pillow_installed" to run *before* importing it
@@ -301,6 +313,7 @@ async def to_code(config):
         )
 
     transparent = config[CONF_USE_TRANSPARENCY]
+    invert_colors = config.get(CONF_INVERT_COLORS)
 
     dither = (
         Image.Dither.NONE
@@ -324,6 +337,9 @@ async def to_code(config):
 
     elif config[CONF_TYPE] == "RGBA":
         image = image.convert("RGBA")
+        if invert_colors:
+            image = invert_image_colors(image)
+
         pixels = list(image.getdata())
         data = [0 for _ in range(height * width * 4)]
         pos = 0
@@ -339,6 +355,9 @@ async def to_code(config):
 
     elif config[CONF_TYPE] == "RGB24":
         image = image.convert("RGBA")
+        if invert_colors:
+            image = invert_image_colors(image)
+
         pixels = list(image.getdata())
         data = [0 for _ in range(height * width * 3)]
         pos = 0
@@ -360,6 +379,9 @@ async def to_code(config):
 
     elif config[CONF_TYPE] in ["RGB565"]:
         image = image.convert("RGBA")
+        if invert_colors:
+            image = invert_image_colors(image)
+
         pixels = list(image.getdata())
         data = [0 for _ in range(height * width * 2)]
         pos = 0

--- a/esphome/components/image/__init__.py
+++ b/esphome/components/image/__init__.py
@@ -47,7 +47,7 @@ IMAGE_TYPE = {
 }
 
 CONF_USE_TRANSPARENCY = "use_transparency"
-CONF_INVERT_COLORS = "invert_colors"
+CONF_REVERSE_COLORS = "reverse_colors"
 
 # If the MDI file cannot be downloaded within this time, abort.
 IMAGE_DOWNLOAD_TIMEOUT = 30  # seconds
@@ -226,7 +226,7 @@ IMAGE_SCHEMA = cv.Schema(
             # Not setting default here on purpose; the default depends on the image type,
             # and thus will be set in the "validate_cross_dependencies" validator.
             cv.Optional(CONF_USE_TRANSPARENCY): cv.boolean,
-            cv.Optional(CONF_INVERT_COLORS default=False): cv.boolean,
+            cv.Optional(CONF_REVERSE_COLORS, default=False): cv.boolean,
             cv.Optional(CONF_DITHER, default="NONE"): cv.one_of(
                 "NONE", "FLOYDSTEINBERG", upper=True
             ),
@@ -313,7 +313,7 @@ async def to_code(config):
         )
 
     transparent = config[CONF_USE_TRANSPARENCY]
-    invert_colors = config.get(CONF_INVERT_COLORS)
+    invert_colors = config.get(CONF_REVERSE_COLORS)
 
     dither = (
         Image.Dither.NONE


### PR DESCRIPTION
# What does this implement/fix?

This PR add a new  configuration variable to to invert the image colors. This is useful when drawing a dark image on dark background for example.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#4217

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [x] host

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
image:
  - file: fan.png
    id: ac_button_image
    resize: 50x50
    type: RGB565
    use_transparency: true
    reverse_colors: true


```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
