### PR TITLE
Fix build for esp32h2 using esp-idf 5.3

### DIFF
--- a/esphome/components/debug/debug_esp32.cpp
+++ b/esphome/components/debug/debug_esp32.cpp
@@ -16,6 +16,8 @@
 #include <esp32s2/rom/rtc.h>
 #elif defined(USE_ESP32_VARIANT_ESP32S3)
 #include <esp32s3/rom/rtc.h>
+#elif defined(USE_ESP32_VARIANT_ESP32H2)
+#include <esp32h2/rom/rtc.h>
 #endif
 #ifdef USE_ARDUINO
 #include <Esp.h>
@@ -61,7 +63,7 @@ std::string DebugComponent::get_reset_reason_() {
     case RTCWDT_SYS_RESET:
       reset_reason = "RTC Watch Dog Reset Digital Core";
       break;
-#if !defined(USE_ESP32_VARIANT_ESP32C6)
+#if !defined(USE_ESP32_VARIANT_ESP32C6) && !defined(USE_ESP32_VARIANT_ESP32H2)
     case INTRUSION_RESET:
       reset_reason = "Intrusion Reset CPU";
       break;


### PR DESCRIPTION
# What does this implement/fix?
When building for an esp32h2, a few compile errors can be seen due to a missing import for this particular variant.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
esphome:
  name: ott-h2

esp32:
  board: esp32-h2-devkitm-1
  variant: esp32h2
  framework:
    type: esp-idf
    version: "5.3.0"
    # This contains the esp32-h2-devkit board
    platform_version: "https://github.com/pioarduino/platform-espressif32/releases/download/53.03.10%%2Brc1/platform-espressif32.zip"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
