### PR TITLE
[micro_wake_word] Remove duplicated download code

### DIFF
--- a/esphome/external_files.py
+++ b/esphome/external_files.py
@@ -80,10 +80,10 @@ def compute_local_file_dir(domain: str) -> Path:
     return base_directory
 
 
-def download_content(url: str, path: Path, timeout=NETWORK_TIMEOUT) -> None:
+def download_content(url: str, path: Path, timeout=NETWORK_TIMEOUT) -> bytes:
     if not has_remote_file_changed(url, path):
         _LOGGER.debug("Remote file has not changed %s", url)
-        return
+        return path.read_bytes()
 
     _LOGGER.debug(
         "Remote file has changed, downloading from %s to %s",
@@ -102,4 +102,6 @@ def download_content(url: str, path: Path, timeout=NETWORK_TIMEOUT) -> None:
         raise cv.Invalid(f"Could not download from {url}: {e}")
 
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_bytes(req.content)
+    data = req.content
+    path.write_bytes(data)
+    return data


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->
Removes a method from the micro wake word component that was almost identical to the one provided in `external_files` and made slight changes to the shared one to return the data bytes

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
