### PR TITLE
Replace hardcoded jtag buffer sizes with preprocessor macros

### DIFF
--- a/esphome/components/logger/logger_esp32.cpp
+++ b/esphome/components/logger/logger_esp32.cpp
@@ -33,6 +33,15 @@ static const char *const TAG = "logger";
 #ifdef USE_ESP_IDF
 
 #ifdef USE_LOGGER_USB_SERIAL_JTAG
+
+#ifndef USB_SERIAL_JTAG_RX_BUFFER_SIZE
+#define USB_SERIAL_JTAG_RX_BUFFER_SIZE 512
+#endif
+
+#ifndef USB_SERIAL_JTAG_TX_BUFFER_SIZE
+#define USB_SERIAL_JTAG_TX_BUFFER_SIZE 512
+#endif
+
 static void init_usb_serial_jtag_() {
   setvbuf(stdin, NULL, _IONBF, 0);  // Disable buffering on stdin
 
@@ -46,8 +55,8 @@ static void init_usb_serial_jtag_() {
   fcntl(fileno(stdin), F_SETFL, 0);
 
   usb_serial_jtag_driver_config_t usb_serial_jtag_config{};
-  usb_serial_jtag_config.rx_buffer_size = 512;
-  usb_serial_jtag_config.tx_buffer_size = 512;
+  usb_serial_jtag_config.rx_buffer_size = USB_SERIAL_JTAG_RX_BUFFER_SIZE;
+  usb_serial_jtag_config.tx_buffer_size = USB_SERIAL_JTAG_TX_BUFFER_SIZE;
 
   esp_err_t ret = ESP_OK;
   // Install USB-SERIAL-JTAG driver for interrupt-driven reads and writes


### PR DESCRIPTION
# What does this implement/fix?

TLDR: it replaces hardcoded USB_SERIAL_JTAG RX / TX buffer sizes with preprocessor macros.

Currently USB_SERIAL_JTAG interface is set up via logger, when `logger.hardware_uart` is set to `USB_SERIAL_JTAG`.
The rx and tx buffer sizes are not configurable and set to hard-coded values of 512 bytes. I created PR: https://github.com/esphome/esphome/pull/7364 adding `rx_buffer_size` property to logger config, but after short discussion on Reddit I abandoned it - it looks configuring USB_SERIAL_JTAG this way is not proper long-term solution (it should be done by implementing USB_SERIAL_JTAG UART interface and configured this way)

The proposed solution is intermediate one - it doesn't introduce any additional configuration properties in `logger`, but allows to change these defaults via preprocessor macros, until proper USB_SERIAL_JTAG UART interface is implemented.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Test Environment

- [ ] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
esphome:
  platformio_options:
    build_flags:
      - "-DUSB_SERIAL_JTAG_RX_BUFFER_SIZE=16384"
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
