### PR TITLE
[api] Remove id from ``MediaPlayerSupportedFormat``

### DIFF
--- a/esphome/components/api/api.proto
+++ b/esphome/components/api/api.proto
@@ -1112,7 +1112,6 @@ enum MediaPlayerFormatPurpose {
   MEDIA_PLAYER_FORMAT_PURPOSE_ANNOUNCEMENT = 1;
 }
 message MediaPlayerSupportedFormat {
-  option (id) = 119;
   option (ifdef) = "USE_MEDIA_PLAYER";
 
   string format = 1;

--- a/esphome/components/api/api_pb2_service.cpp
+++ b/esphome/components/api/api_pb2_service.cpp
@@ -311,14 +311,6 @@ bool APIServerConnectionBase::send_list_entities_button_response(const ListEntit
 #ifdef USE_BUTTON
 #endif
 #ifdef USE_MEDIA_PLAYER
-bool APIServerConnectionBase::send_media_player_supported_format(const MediaPlayerSupportedFormat &msg) {
-#ifdef HAS_PROTO_MESSAGE_DUMP
-  ESP_LOGVV(TAG, "send_media_player_supported_format: %s", msg.dump().c_str());
-#endif
-  return this->send_message_<MediaPlayerSupportedFormat>(msg, 119);
-}
-#endif
-#ifdef USE_MEDIA_PLAYER
 bool APIServerConnectionBase::send_list_entities_media_player_response(const ListEntitiesMediaPlayerResponse &msg) {
 #ifdef HAS_PROTO_MESSAGE_DUMP
   ESP_LOGVV(TAG, "send_list_entities_media_player_response: %s", msg.dump().c_str());
@@ -1143,17 +1135,6 @@ bool APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       ESP_LOGVV(TAG, "on_update_command_request: %s", msg.dump().c_str());
 #endif
       this->on_update_command_request(msg);
-#endif
-      break;
-    }
-    case 119: {
-#ifdef USE_MEDIA_PLAYER
-      MediaPlayerSupportedFormat msg;
-      msg.decode(msg_data, msg_size);
-#ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_media_player_supported_format: %s", msg.dump().c_str());
-#endif
-      this->on_media_player_supported_format(msg);
 #endif
       break;
     }

--- a/esphome/components/api/api_pb2_service.h
+++ b/esphome/components/api/api_pb2_service.h
@@ -146,10 +146,6 @@ class APIServerConnectionBase : public ProtoService {
   virtual void on_button_command_request(const ButtonCommandRequest &value){};
 #endif
 #ifdef USE_MEDIA_PLAYER
-  bool send_media_player_supported_format(const MediaPlayerSupportedFormat &msg);
-  virtual void on_media_player_supported_format(const MediaPlayerSupportedFormat &value){};
-#endif
-#ifdef USE_MEDIA_PLAYER
   bool send_list_entities_media_player_response(const ListEntitiesMediaPlayerResponse &msg);
 #endif
 #ifdef USE_MEDIA_PLAYER


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

This `Message` is not sent or received by itself, but always as part of the `ListEntitiesMediaPlayerResponse`, so it doesn't need an id (and corresponding functions)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
