### PR TITLE
Fix update sequence when update is set to false (#5225)

### DIFF
--- a/esphome/components/shelly_dimmer/shelly_dimmer.cpp
+++ b/esphome/components/shelly_dimmer/shelly_dimmer.cpp
@@ -66,16 +66,15 @@ uint16_t shelly_dimmer_checksum(const uint8_t *buf, int len) {
 
 bool ShellyDimmer::is_running_configured_version() const {
   return this->version_major_ == USE_SHD_FIRMWARE_MAJOR_VERSION &&
-      this->version_minor_ == USE_SHD_FIRMWARE_MINOR_VERSION;
-
+         this->version_minor_ == USE_SHD_FIRMWARE_MINOR_VERSION;
 }
 
 void ShellyDimmer::handle_firmware() {
   // Reset the STM32 and check the firmware version.
   this->reset_normal_boot_();
   this->send_command_(SHELLY_DIMMER_PROTO_CMD_VERSION, nullptr, 0);
-    ESP_LOGI(TAG, "STM32 current firmware version: %d.%d, desired version: %d.%d", this->version_major_,
-             this->version_minor_, USE_SHD_FIRMWARE_MAJOR_VERSION, USE_SHD_FIRMWARE_MINOR_VERSION);
+  ESP_LOGI(TAG, "STM32 current firmware version: %d.%d, desired version: %d.%d", this->version_major_,
+           this->version_minor_, USE_SHD_FIRMWARE_MAJOR_VERSION, USE_SHD_FIRMWARE_MINOR_VERSION);
 
   if (!is_running_configured_version()) {
 #ifdef USE_SHD_FIRMWARE_DATA
@@ -88,7 +87,7 @@ void ShellyDimmer::handle_firmware() {
     this->reset_normal_boot_();
     this->send_command_(SHELLY_DIMMER_PROTO_CMD_VERSION, nullptr, 0);
     if (!is_running_configured_version()) {
-        ESP_LOGE(TAG, "STM32 firmware upgrade already performed, but version is still incorrect");
+      ESP_LOGE(TAG, "STM32 firmware upgrade already performed, but version is still incorrect");
       this->mark_failed();
       return;
     }
@@ -103,7 +102,6 @@ void ShellyDimmer::setup() {
   this->pin_boot0_->setup();
 
   ESP_LOGI(TAG, "Initializing Shelly Dimmer...");
-
 
   this->handle_firmware();
 

--- a/esphome/components/shelly_dimmer/shelly_dimmer.cpp
+++ b/esphome/components/shelly_dimmer/shelly_dimmer.cpp
@@ -64,46 +64,48 @@ uint16_t shelly_dimmer_checksum(const uint8_t *buf, int len) {
   return std::accumulate<decltype(buf), uint16_t>(buf, buf + len, 0);
 }
 
+void ShellyDimmer::is_running_configured_version() const {
+  return this->version_major_ == USE_SHD_FIRMWARE_MAJOR_VERSION &&
+      this->version_minor_ == USE_SHD_FIRMWARE_MINOR_VERSION;
+
+}
+
+void ShellyDimmer::handle_firmware() {
+  // Reset the STM32 and check the firmware version.
+  this->reset_normal_boot_();
+  this->send_command_(SHELLY_DIMMER_PROTO_CMD_VERSION, nullptr, 0);
+    ESP_LOGI(TAG, "STM32 current firmware version: %d.%d, desired version: %d.%d", this->version_major_,
+             this->version_minor_, USE_SHD_FIRMWARE_MAJOR_VERSION, USE_SHD_FIRMWARE_MINOR_VERSION);
+
+  if (!is_running_configured_version()) {
+#ifdef USE_SHD_FIRMWARE_DATA
+    if (!this->upgrade_firmware_()) {
+      ESP_LOGW(TAG, "Failed to upgrade firmware");
+      this->mark_failed();
+      return;
+    }
+
+    this->reset_normal_boot_();
+    this->send_command_(SHELLY_DIMMER_PROTO_CMD_VERSION, nullptr, 0);
+    if (!is_running_configured_version()) {
+        ESP_LOGE(TAG, "STM32 firmware upgrade already performed, but version is still incorrect");
+      this->mark_failed();
+      return;
+    }
+#else
+    ESP_LOGW(TAG, "Firmware version mismatch, put 'update: true' in the yaml to flash an update.");
+#endif
+  }
+}
+
 void ShellyDimmer::setup() {
   this->pin_nrst_->setup();
   this->pin_boot0_->setup();
 
   ESP_LOGI(TAG, "Initializing Shelly Dimmer...");
 
-  // Reset the STM32 and check the firmware version.
-  for (int i = 0; i < 2; i++) {
-    this->reset_normal_boot_();
-    this->send_command_(SHELLY_DIMMER_PROTO_CMD_VERSION, nullptr, 0);
-    ESP_LOGI(TAG, "STM32 current firmware version: %d.%d, desired version: %d.%d", this->version_major_,
-             this->version_minor_, USE_SHD_FIRMWARE_MAJOR_VERSION, USE_SHD_FIRMWARE_MINOR_VERSION);
-    if (this->version_major_ != USE_SHD_FIRMWARE_MAJOR_VERSION ||
-        this->version_minor_ != USE_SHD_FIRMWARE_MINOR_VERSION) {
-#ifdef USE_SHD_FIRMWARE_DATA
-      // Update firmware if needed.
-      ESP_LOGW(TAG, "Unsupported STM32 firmware version, flashing");
-      if (i > 0) {
-        // Upgrade was already performed but the reported version is still not right.
-        ESP_LOGE(TAG, "STM32 firmware upgrade already performed, but version is still incorrect");
-        this->mark_failed();
-        return;
-      }
 
-      if (!this->upgrade_firmware_()) {
-        ESP_LOGW(TAG, "Failed to upgrade firmware");
-        this->mark_failed();
-        return;
-      }
-
-      // Firmware upgrade completed, do the checks again.
-      continue;
-#else
-      ESP_LOGW(TAG, "Firmware version mismatch, put 'update: true' in the yaml to flash an update.");
-      this->mark_failed();
-      return;
-#endif
-    }
-    break;
-  }
+  this->handle_firmware();
 
   this->send_settings_();
   // Do an immediate poll to refresh current state.

--- a/esphome/components/shelly_dimmer/shelly_dimmer.cpp
+++ b/esphome/components/shelly_dimmer/shelly_dimmer.cpp
@@ -64,7 +64,7 @@ uint16_t shelly_dimmer_checksum(const uint8_t *buf, int len) {
   return std::accumulate<decltype(buf), uint16_t>(buf, buf + len, 0);
 }
 
-void ShellyDimmer::is_running_configured_version() const {
+bool ShellyDimmer::is_running_configured_version() const {
   return this->version_major_ == USE_SHD_FIRMWARE_MAJOR_VERSION &&
       this->version_minor_ == USE_SHD_FIRMWARE_MINOR_VERSION;
 

--- a/esphome/components/shelly_dimmer/shelly_dimmer.h
+++ b/esphome/components/shelly_dimmer/shelly_dimmer.h
@@ -20,7 +20,7 @@ class ShellyDimmer : public PollingComponent, public light::LightOutput, public 
  public:
   float get_setup_priority() const override { return setup_priority::LATE; }
 
-  void is_running_configured_version() const;
+  bool is_running_configured_version() const;
   void handle_firmware();
   void setup() override;
   void update() override;

--- a/esphome/components/shelly_dimmer/shelly_dimmer.h
+++ b/esphome/components/shelly_dimmer/shelly_dimmer.h
@@ -20,6 +20,8 @@ class ShellyDimmer : public PollingComponent, public light::LightOutput, public 
  public:
   float get_setup_priority() const override { return setup_priority::LATE; }
 
+  void is_running_configured_version() const;
+  void handle_firmware();
   void setup() override;
   void update() override;
   void dump_config() override;


### PR DESCRIPTION
# What does this implement/fix?
The component is marked as failed when (firmware) update is set to false.



<!-- Quick description and explanation of changes -->

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/5225

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
