### PR TITLE
libretiny: Allow specifying version of explicitly imported sources

### DIFF
--- a/esphome/components/libretiny/__init__.py
+++ b/esphome/components/libretiny/__init__.py
@@ -1,10 +1,6 @@
 import json
 import logging
-from os.path import (
-    dirname,
-    isfile,
-    join,
-)
+from os.path import dirname, isfile, join
 
 import esphome.codegen as cg
 import esphome.config_validation as cv
@@ -282,10 +278,10 @@ async def component_to_code(config):
     # if platform version is a valid version constraint, prefix the default package
     framework = config[CONF_FRAMEWORK]
     cv.platformio_version_constraint(framework[CONF_VERSION])
-    if str(framework[CONF_VERSION]) != "0.0.0":
-        cg.add_platformio_option("platform", f"libretiny @ {framework[CONF_VERSION]}")
-    elif framework[CONF_SOURCE]:
+    if framework[CONF_SOURCE]:
         cg.add_platformio_option("platform", framework[CONF_SOURCE])
+    elif str(framework[CONF_VERSION]) != "0.0.0":
+        cg.add_platformio_option("platform", f"libretiny @ {framework[CONF_VERSION]}")
     else:
         cg.add_platformio_option("platform", "libretiny")
 


### PR DESCRIPTION
IPv6 support will require a new enough version of LibreTiny. Having the dev version always reported as 0.0.0 makes that check fail, so allow an explicit import to also specify which version it is.

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [x] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

bk72xx:
  board: generic-bk7231n-qfn32-tuya
  framework:
    version: 1.6.1
    source: https://github.com/dwmw2/libretiny.git#ipv6

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
