### PR TITLE
[libretiny] Report version 1.7.0 for 'dev' and 'latest'

### DIFF
--- a/esphome/components/libretiny/__init__.py
+++ b/esphome/components/libretiny/__init__.py
@@ -1,10 +1,6 @@
 import json
 import logging
-from os.path import (
-    dirname,
-    isfile,
-    join,
-)
+from os.path import dirname, isfile, join
 
 import esphome.codegen as cg
 import esphome.config_validation as cv
@@ -177,8 +173,8 @@ def _notify_old_style(config):
 # NOTE: Keep this in mind when updating the recommended version:
 #  * For all constants below, update platformio.ini (in this repo)
 ARDUINO_VERSIONS = {
-    "dev": (cv.Version(0, 0, 0), "https://github.com/libretiny-eu/libretiny.git"),
-    "latest": (cv.Version(0, 0, 0), None),
+    "dev": (cv.Version(1, 7, 0), "https://github.com/libretiny-eu/libretiny.git"),
+    "latest": (cv.Version(1, 7, 0), "libretiny"),
     "recommended": (cv.Version(1, 5, 1), None),
 }
 

--- a/esphome/components/libretiny/__init__.py
+++ b/esphome/components/libretiny/__init__.py
@@ -172,7 +172,7 @@ def _notify_old_style(config):
 
 # NOTE: Keep this in mind when updating the recommended version:
 #  * For all constants below, update platformio.ini (in this repo)
-# The dev and latest branches will be at *least* this versiom, which is what matters.
+# The dev and latest branches will be at *least* this version, which is what matters.
 ARDUINO_VERSIONS = {
     "dev": (cv.Version(1, 7, 0), "https://github.com/libretiny-eu/libretiny.git"),
     "latest": (cv.Version(1, 7, 0), "libretiny"),

--- a/esphome/components/libretiny/__init__.py
+++ b/esphome/components/libretiny/__init__.py
@@ -172,6 +172,7 @@ def _notify_old_style(config):
 
 # NOTE: Keep this in mind when updating the recommended version:
 #  * For all constants below, update platformio.ini (in this repo)
+# The dev and latest branches will be at *least* this versiom, which is what matters.
 ARDUINO_VERSIONS = {
     "dev": (cv.Version(1, 7, 0), "https://github.com/libretiny-eu/libretiny.git"),
     "latest": (cv.Version(1, 7, 0), "libretiny"),


### PR DESCRIPTION
 - (Depends on https://github.com/esphome/esphome/pull/7408 )

Rather than reporting 0.0.0 for 'dev' and 'latest' branches, report 1.7.0 which is (currently) the truth.

Like other frameworks, this will be perpetually out of date because we don't update it at runtime (although perhaps we could have a script which updates it prior to making an ESPHome release). It's not that much of a problem though, as we mostly use this for requiring a new enough version for certain features, and those tend not to depend on *future* versions.

So reporting 1.7.0 is enough for the upcoming IPv6 support, and it's OK for it to stay on 1.7.0 even if the git respository has something newer, until such time as something in ESPHome actually *cares* about checking for a newer version.

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [x] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
