### PR TITLE
[gree] Add support for YAG remotes

### DIFF
--- a/esphome/components/gree/climate.py
+++ b/esphome/components/gree/climate.py
@@ -18,6 +18,7 @@ MODELS = {
     "yac": Model.GREE_YAC,
     "yac1fb9": Model.GREE_YAC1FB9,
     "yx1ff": Model.GREE_YX1FF,
+    "yag": Model.GREE_YAG,
 }
 
 CONFIG_SCHEMA = climate_ir.CLIMATE_IR_WITH_RECEIVER_SCHEMA.extend(

--- a/esphome/components/gree/gree.h
+++ b/esphome/components/gree/gree.h
@@ -58,7 +58,7 @@ const uint8_t GREE_VDIR_MIDDLE = 0x04;
 const uint8_t GREE_VDIR_MDOWN = 0x05;
 const uint8_t GREE_VDIR_DOWN = 0x06;
 
-// Only available on YAC
+// Only available on YAC/YAG
 // Horizontal air directions. Note that these cannot be set on all heat pumps
 const uint8_t GREE_HDIR_AUTO = 0x00;
 const uint8_t GREE_HDIR_MANUAL = 0x00;
@@ -78,7 +78,7 @@ const uint8_t GREE_PRESET_SLEEP = 0x01;
 const uint8_t GREE_PRESET_SLEEP_BIT = 0x80;
 
 // Model codes
-enum Model { GREE_GENERIC, GREE_YAN, GREE_YAA, GREE_YAC, GREE_YAC1FB9, GREE_YX1FF };
+enum Model { GREE_GENERIC, GREE_YAN, GREE_YAA, GREE_YAC, GREE_YAC1FB9, GREE_YX1FF, GREE_YAG };
 
 class GreeClimate : public climate_ir::ClimateIR {
  public:


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

This PR adds support for Gree YAGxxx remotes.

Similar to other Gree remotes except for a few different default parameters. Current implemented checksum failed with YAG when enabling horizontal swing (possibly a bug, but no other Gree devices to test this with).

Edit: 
Found issue that may be related to checksum issue noted:
- https://github.com/esphome/issues/issues/6149

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#4232

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
climate:
  - platform: gree
    model: yag
    name: "Living Room AC"
    sensor: dht_temperature
    visual:
      min_temperature: 18
      max_temperature: 25
      temperature_step: 1

remote_transmitter:
  - pin: 4
    carrier_duty_percent: 50%

sensor:
  - platform: dht
    pin: 5
    temperature: 
      name: "Living Room Temperature"
      id: dht_temperature
    humidity: 
      name: "Living Room Humidity"
    update_interval: 60s
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
