### PR TITLE
[rpi_dpi_rgb] Add bounce_buffer config for ESP-IDF 5.x

### DIFF
--- a/esphome/components/rpi_dpi_rgb/display.py
+++ b/esphome/components/rpi_dpi_rgb/display.py
@@ -1,31 +1,28 @@
-import esphome.codegen as cg
-import esphome.config_validation as cv
 from esphome import pins
+import esphome.codegen as cg
 from esphome.components import display
+from esphome.components.esp32 import const, only_on_variant
+import esphome.config_validation as cv
 from esphome.const import (
-    CONF_ENABLE_PIN,
-    CONF_HSYNC_PIN,
-    CONF_RESET_PIN,
+    CONF_BLUE,
+    CONF_COLOR_ORDER,
     CONF_DATA_PINS,
+    CONF_DIMENSIONS,
+    CONF_ENABLE_PIN,
+    CONF_GREEN,
+    CONF_HEIGHT,
+    CONF_HSYNC_PIN,
     CONF_ID,
     CONF_IGNORE_STRAPPING_WARNING,
-    CONF_DIMENSIONS,
-    CONF_VSYNC_PIN,
-    CONF_WIDTH,
-    CONF_HEIGHT,
+    CONF_INVERT_COLORS,
     CONF_LAMBDA,
-    CONF_COLOR_ORDER,
-    CONF_RED,
-    CONF_GREEN,
-    CONF_BLUE,
     CONF_NUMBER,
     CONF_OFFSET_HEIGHT,
     CONF_OFFSET_WIDTH,
-    CONF_INVERT_COLORS,
-)
-from esphome.components.esp32 import (
-    only_on_variant,
-    const,
+    CONF_RED,
+    CONF_RESET_PIN,
+    CONF_VSYNC_PIN,
+    CONF_WIDTH,
 )
 
 DEPENDENCIES = ["esp32"]

--- a/esphome/components/rpi_dpi_rgb/rpi_dpi_rgb.h
+++ b/esphome/components/rpi_dpi_rgb/rpi_dpi_rgb.h
@@ -23,6 +23,7 @@ class RpiDpiRgb : public display::Display {
  public:
   void update() override { this->do_update_(); }
   void setup() override;
+  void loop() override;
   void draw_pixels_at(int x_start, int y_start, int w, int h, const uint8_t *ptr, display::ColorOrder order,
                       display::ColorBitness bitness, bool big_endian, int x_offset, int y_offset, int x_pad) override;
   void draw_pixel_at(int x, int y, Color color) override;


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

The newer ESP-IDF SDK has additional modes for the RGB DPI LCD interface, which reduces the PSRAM bandwidth used by the display interface. This enables higher pixel clock rates, and improves reliability of WiFi and OTA.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
