### PR TITLE
Remove Arduino dependency of bme68x_bsec2_i2c

### DIFF
--- a/esphome/components/bme68x_bsec2/__init__.py
+++ b/esphome/components/bme68x_bsec2/__init__.py
@@ -145,7 +145,6 @@ CONFIG_SCHEMA_BASE = (
             ): cv.positive_time_period_minutes,
         },
     )
-    .add_extra(cv.only_with_arduino)
     .add_extra(validate_bme68x)
     .add_extra(download_bme68x_blob)
 )
@@ -179,8 +178,6 @@ async def to_code_base(config):
     bsec2_arr = cg.progmem_array(config[CONF_RAW_DATA_ID], rhs)
     cg.add(var.set_bsec2_configuration(bsec2_arr, len(rhs)))
 
-    # Although this component does not use SPI, the BSEC2 library requires the SPI library
-    cg.add_library("SPI", None)
     cg.add_library(
         "BME68x Sensor library",
         "1.1.40407",

--- a/esphome/components/bme68x_bsec2/bme68x_bsec2.h
+++ b/esphome/components/bme68x_bsec2/bme68x_bsec2.h
@@ -2,6 +2,7 @@
 
 #include "esphome/core/component.h"
 #include "esphome/core/defines.h"
+#include "esphome/core/hal.h"
 #include "esphome/core/preferences.h"
 
 #ifdef USE_BSEC2
@@ -17,7 +18,13 @@
 #include <cinttypes>
 #include <queue>
 
-#include <bsec2.h>
+#include <bsec_interface_multi.h>
+#include <bme68x.h>
+
+#define BSEC_CHECK_INPUT(x, shift) (x & (1 << (shift - 1)))
+#define BSEC_TOTAL_HEAT_DUR UINT16_C(140)
+#define BSEC_INSTANCE_SIZE 3272
+#define BSEC_E_INSUFFICIENT_INSTANCE_SIZE (bsec_library_return_t) - 105
 
 namespace esphome {
 namespace bme68x_bsec2 {


### PR DESCRIPTION
# What does this implement/fix?

Remove Arduino dependency of bme68x_bsec2_i2c component and allow to build with esp-idf.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/feature-requests/issues/2431

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
