### PR TITLE
Pull in new AsyncTCP for IPv6 on BK72xx

### DIFF
--- a/esphome/components/async_tcp/__init__.py
+++ b/esphome/components/async_tcp/__init__.py
@@ -1,13 +1,13 @@
 # Dummy integration to allow relying on AsyncTCP
 import esphome.codegen as cg
 import esphome.config_validation as cv
-from esphome.core import CORE, coroutine_with_priority
 from esphome.const import (
+    PLATFORM_BK72XX,
     PLATFORM_ESP32,
     PLATFORM_ESP8266,
-    PLATFORM_BK72XX,
     PLATFORM_RTL87XX,
 )
+from esphome.core import CORE, coroutine_with_priority
 
 CODEOWNERS = ["@OttoWinter"]
 
@@ -22,7 +22,7 @@ CONFIG_SCHEMA = cv.All(
 async def to_code(config):
     if CORE.is_esp32 or CORE.is_libretiny:
         # https://github.com/esphome/AsyncTCP/blob/master/library.json
-        cg.add_library("esphome/AsyncTCP-esphome", "2.1.3")
+        cg.add_library("esphome/AsyncTCP-esphome", "2.1.4")
     elif CORE.is_esp8266:
         # https://github.com/esphome/ESPAsyncTCP
         cg.add_library("esphome/ESPAsyncTCP-esphome", "2.0.0")

--- a/platformio.ini
+++ b/platformio.ini
@@ -119,7 +119,7 @@ lib_deps =
     WiFi                                 ; wifi,web_server_base,ethernet (Arduino built-in)
     Update                               ; ota,web_server_base (Arduino built-in)
     ${common:arduino.lib_deps}
-    esphome/AsyncTCP-esphome@2.1.3       ; async_tcp
+    esphome/AsyncTCP-esphome@2.1.4       ; async_tcp
     WiFiClientSecure                     ; http_request,nextion (Arduino built-in)
     HTTPClient                           ; http_request,nextion (Arduino built-in)
     ESPmDNS                              ; mdns (Arduino built-in)


### PR DESCRIPTION
Needs the IPADDR6_INIT fix from https://github.com/esphome/AsyncTCP/pull/14

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other


## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [x] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
