### PR TITLE
Bump LibreTiny recommended version to 1.7.0

### DIFF
--- a/esphome/components/libretiny/__init__.py
+++ b/esphome/components/libretiny/__init__.py
@@ -170,13 +170,11 @@ def _notify_old_style(config):
     return config
 
 
-# NOTE: Keep this in mind when updating the recommended version:
-#  * For all constants below, update platformio.ini (in this repo)
 # The dev and latest branches will be at *least* this version, which is what matters.
 ARDUINO_VERSIONS = {
     "dev": (cv.Version(1, 7, 0), "https://github.com/libretiny-eu/libretiny.git"),
     "latest": (cv.Version(1, 7, 0), "libretiny"),
-    "recommended": (cv.Version(1, 5, 1), None),
+    "recommended": (cv.Version(1, 7, 0), None),
 }
 
 


### PR DESCRIPTION
# What does this implement/fix?

Libretiny 1.7.0 has been released, with minor fixes. Switch to it as recommended version.

The comment about updating platformio.ini when we change the recommended version appears to be nonsense. Delete it.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [x] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
