### PR TITLE
[modbus_controller] Fix linting and formatting issues

### DIFF
--- a/esphome/components/modbus_controller/__init__.py
+++ b/esphome/components/modbus_controller/__init__.py
@@ -1,27 +1,29 @@
 import binascii
-import esphome.codegen as cg
-import esphome.config_validation as cv
+
 from esphome import automation
+import esphome.codegen as cg
 from esphome.components import modbus
+import esphome.config_validation as cv
 from esphome.const import (
     CONF_ADDRESS,
     CONF_ID,
-    CONF_NAME,
     CONF_LAMBDA,
+    CONF_NAME,
     CONF_OFFSET,
     CONF_TRIGGER_ID,
 )
 from esphome.cpp_helpers import logging
+
 from .const import (
     CONF_ALLOW_DUPLICATE_COMMANDS,
     CONF_BITMASK,
     CONF_BYTE_OFFSET,
     CONF_COMMAND_THROTTLE,
-    CONF_OFFLINE_SKIP_UPDATES,
     CONF_CUSTOM_COMMAND,
     CONF_FORCE_NEW_RANGE,
-    CONF_MODBUS_CONTROLLER_ID,
     CONF_MAX_CMD_RETRIES,
+    CONF_MODBUS_CONTROLLER_ID,
+    CONF_OFFLINE_SKIP_UPDATES,
     CONF_ON_COMMAND_SENT,
     CONF_REGISTER_COUNT,
     CONF_REGISTER_TYPE,

--- a/esphome/components/modbus_controller/binary_sensor/__init__.py
+++ b/esphome/components/modbus_controller/binary_sensor/__init__.py
@@ -1,16 +1,16 @@
+import esphome.codegen as cg
 from esphome.components import binary_sensor
 import esphome.config_validation as cv
-import esphome.codegen as cg
-
 from esphome.const import CONF_ADDRESS, CONF_ID
+
 from .. import (
-    add_modbus_base_properties,
-    modbus_controller_ns,
-    modbus_calc_properties,
-    validate_modbus_register,
+    MODBUS_REGISTER_TYPE,
     ModbusItemBaseSchema,
     SensorItem,
-    MODBUS_REGISTER_TYPE,
+    add_modbus_base_properties,
+    modbus_calc_properties,
+    modbus_controller_ns,
+    validate_modbus_register,
 )
 from ..const import (
     CONF_BITMASK,

--- a/esphome/components/modbus_controller/number/__init__.py
+++ b/esphome/components/modbus_controller/number/__init__.py
@@ -1,6 +1,6 @@
 import esphome.codegen as cg
-import esphome.config_validation as cv
 from esphome.components import number
+import esphome.config_validation as cv
 from esphome.const import (
     CONF_ADDRESS,
     CONF_ID,
@@ -12,14 +12,13 @@ from esphome.const import (
 
 from .. import (
     MODBUS_WRITE_REGISTER_TYPE,
-    add_modbus_base_properties,
-    modbus_controller_ns,
-    modbus_calc_properties,
+    SENSOR_VALUE_TYPE,
     ModbusItemBaseSchema,
     SensorItem,
-    SENSOR_VALUE_TYPE,
+    add_modbus_base_properties,
+    modbus_calc_properties,
+    modbus_controller_ns,
 )
-
 from ..const import (
     CONF_BITMASK,
     CONF_CUSTOM_COMMAND,

--- a/esphome/components/modbus_controller/select/__init__.py
+++ b/esphome/components/modbus_controller/select/__init__.py
@@ -1,6 +1,6 @@
 import esphome.codegen as cg
-import esphome.config_validation as cv
 from esphome.components import select
+import esphome.config_validation as cv
 from esphome.const import CONF_ADDRESS, CONF_ID, CONF_LAMBDA, CONF_OPTIMISTIC
 
 from .. import (

--- a/esphome/components/modbus_controller/sensor/__init__.py
+++ b/esphome/components/modbus_controller/sensor/__init__.py
@@ -1,17 +1,17 @@
+import esphome.codegen as cg
 from esphome.components import sensor
 import esphome.config_validation as cv
-import esphome.codegen as cg
+from esphome.const import CONF_ADDRESS, CONF_ID
 
-from esphome.const import CONF_ID, CONF_ADDRESS
 from .. import (
-    add_modbus_base_properties,
-    modbus_controller_ns,
-    modbus_calc_properties,
-    validate_modbus_register,
-    ModbusItemBaseSchema,
-    SensorItem,
     MODBUS_REGISTER_TYPE,
     SENSOR_VALUE_TYPE,
+    ModbusItemBaseSchema,
+    SensorItem,
+    add_modbus_base_properties,
+    modbus_calc_properties,
+    modbus_controller_ns,
+    validate_modbus_register,
 )
 from ..const import (
     CONF_BITMASK,

--- a/esphome/components/modbus_controller/switch/__init__.py
+++ b/esphome/components/modbus_controller/switch/__init__.py
@@ -1,17 +1,16 @@
+import esphome.codegen as cg
 from esphome.components import switch
 import esphome.config_validation as cv
-import esphome.codegen as cg
+from esphome.const import CONF_ADDRESS, CONF_ID
 
-
-from esphome.const import CONF_ID, CONF_ADDRESS
 from .. import (
-    add_modbus_base_properties,
-    modbus_controller_ns,
-    modbus_calc_properties,
-    validate_modbus_register,
+    MODBUS_REGISTER_TYPE,
     ModbusItemBaseSchema,
     SensorItem,
-    MODBUS_REGISTER_TYPE,
+    add_modbus_base_properties,
+    modbus_calc_properties,
+    modbus_controller_ns,
+    validate_modbus_register,
 )
 from ..const import (
     CONF_BITMASK,

--- a/esphome/components/modbus_controller/text_sensor/__init__.py
+++ b/esphome/components/modbus_controller/text_sensor/__init__.py
@@ -1,26 +1,25 @@
+import esphome.codegen as cg
 from esphome.components import text_sensor
 import esphome.config_validation as cv
-import esphome.codegen as cg
-
-
 from esphome.const import CONF_ADDRESS, CONF_ID
+
 from .. import (
-    add_modbus_base_properties,
-    modbus_controller_ns,
-    modbus_calc_properties,
-    validate_modbus_register,
+    MODBUS_REGISTER_TYPE,
     ModbusItemBaseSchema,
     SensorItem,
-    MODBUS_REGISTER_TYPE,
+    add_modbus_base_properties,
+    modbus_calc_properties,
+    modbus_controller_ns,
+    validate_modbus_register,
 )
 from ..const import (
     CONF_FORCE_NEW_RANGE,
     CONF_MODBUS_CONTROLLER_ID,
+    CONF_RAW_ENCODE,
     CONF_REGISTER_COUNT,
+    CONF_REGISTER_TYPE,
     CONF_RESPONSE_SIZE,
     CONF_SKIP_UPDATES,
-    CONF_RAW_ENCODE,
-    CONF_REGISTER_TYPE,
 )
 
 DEPENDENCIES = ["modbus_controller"]


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

```
************* Module esphome.components.modbus_controller.output
esphome/components/modbus_controller/output/__init__.py:109: [E0601(used-before-assignment), to_code] Using variable 'template_' before assignment
```

Also organizing imports while touching this component

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
