### PR TITLE
[tm1638] Fix linting and formatting issues

### DIFF
--- a/esphome/components/tm1638/binary_sensor/__init__.py
+++ b/esphome/components/tm1638/binary_sensor/__init__.py
@@ -1,8 +1,9 @@
 import esphome.codegen as cg
-import esphome.config_validation as cv
 from esphome.components import binary_sensor
+import esphome.config_validation as cv
 from esphome.const import CONF_KEY
-from ..display import tm1638_ns, TM1638Component, CONF_TM1638_ID
+
+from ..display import CONF_TM1638_ID, TM1638Component, tm1638_ns
 
 TM1638Key = tm1638_ns.class_("TM1638Key", binary_sensor.BinarySensor)
 

--- a/esphome/components/tm1638/display.py
+++ b/esphome/components/tm1638/display.py
@@ -1,13 +1,13 @@
-import esphome.codegen as cg
-import esphome.config_validation as cv
 from esphome import pins
+import esphome.codegen as cg
 from esphome.components import display
+import esphome.config_validation as cv
 from esphome.const import (
+    CONF_CLK_PIN,
+    CONF_DIO_PIN,
     CONF_ID,
     CONF_INTENSITY,
     CONF_LAMBDA,
-    CONF_CLK_PIN,
-    CONF_DIO_PIN,
     CONF_STB_PIN,
 )
 
@@ -51,4 +51,4 @@ async def to_code(config):
             config[CONF_LAMBDA], [(TM1638ComponentRef, "it")], return_type=cg.void
         )
 
-    cg.add(var.set_writer(lambda_))
+        cg.add(var.set_writer(lambda_))

--- a/esphome/components/tm1638/output/__init__.py
+++ b/esphome/components/tm1638/output/__init__.py
@@ -1,8 +1,9 @@
 import esphome.codegen as cg
-import esphome.config_validation as cv
 from esphome.components import output
+import esphome.config_validation as cv
 from esphome.const import CONF_ID, CONF_LED
-from ..display import tm1638_ns, TM1638Component, CONF_TM1638_ID
+
+from ..display import CONF_TM1638_ID, TM1638Component, tm1638_ns
 
 TM1638OutputLed = tm1638_ns.class_("TM1638OutputLed", output.BinaryOutput, cg.Component)
 

--- a/esphome/components/tm1638/switch/__init__.py
+++ b/esphome/components/tm1638/switch/__init__.py
@@ -1,8 +1,9 @@
 import esphome.codegen as cg
-import esphome.config_validation as cv
 from esphome.components import switch
+import esphome.config_validation as cv
 from esphome.const import CONF_LED
-from ..display import tm1638_ns, TM1638Component, CONF_TM1638_ID
+
+from ..display import CONF_TM1638_ID, TM1638Component, tm1638_ns
 
 TM1638SwitchLed = tm1638_ns.class_("TM1638SwitchLed", switch.Switch, cg.Component)
 


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

```
************* Module esphome.components.tm1638.display
esphome/components/tm1638/display.py:54: [E0606(possibly-used-before-assignment), to_code] Possibly using variable 'lambda_' before assignment
```
Also organizing imports while touching this component

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
