### PR TITLE
[st7701s] Make use of IDF5.x to speed up display operations

### DIFF
--- a/esphome/components/st7701s/st7701s.h
+++ b/esphome/components/st7701s/st7701s.h
@@ -33,6 +33,8 @@ class ST7701S : public display::Display,
  public:
   void update() override { this->do_update_(); }
   void setup() override;
+  void complete_setup_();
+  void loop() override;
   void draw_pixels_at(int x_start, int y_start, int w, int h, const uint8_t *ptr, display::ColorOrder order,
                       display::ColorBitness bitness, bool big_endian, int x_offset, int y_offset, int x_pad) override;
 


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

* Uses ESP-IDF 5.x features to improve display performance and reduce PSRAM stress
* Release SPI after setup - facilitates use on boards where SPI pins are shared with RGB
* 
## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
