### PR TITLE
Added i2s_comm_fmt parameter to i2s speaker component

### DIFF
--- a/esphome/components/i2s_audio/speaker/__init__.py
+++ b/esphome/components/i2s_audio/speaker/__init__.py
@@ -25,12 +25,27 @@ I2SAudioSpeaker = i2s_audio_ns.class_(
 
 
 CONF_DAC_TYPE = "dac_type"
+CONF_I2S_COMM_FMT = "i2s_comm_fmt"
 
 i2s_dac_mode_t = cg.global_ns.enum("i2s_dac_mode_t")
 INTERNAL_DAC_OPTIONS = {
     CONF_LEFT: i2s_dac_mode_t.I2S_DAC_CHANNEL_LEFT_EN,
     CONF_RIGHT: i2s_dac_mode_t.I2S_DAC_CHANNEL_RIGHT_EN,
     CONF_STEREO: i2s_dac_mode_t.I2S_DAC_CHANNEL_BOTH_EN,
+}
+
+i2s_comm_format_t = cg.global_ns.enum("i2s_comm_format_t")
+I2C_COMM_FMT_OPTIONS = {
+    "stand_i2s": i2s_comm_format_t.I2S_COMM_FORMAT_STAND_I2S,
+    "stand_msb": i2s_comm_format_t.I2S_COMM_FORMAT_STAND_MSB,
+    "stand_pcm_short": i2s_comm_format_t.I2S_COMM_FORMAT_STAND_PCM_SHORT,
+    "stand_pcm_long": i2s_comm_format_t.I2S_COMM_FORMAT_STAND_PCM_LONG,
+    "stand_max": i2s_comm_format_t.I2S_COMM_FORMAT_STAND_MAX,
+    "i2s_msb": i2s_comm_format_t.I2S_COMM_FORMAT_I2S_MSB,
+    "i2s_lsb": i2s_comm_format_t.I2S_COMM_FORMAT_I2S_LSB,
+    "pcm": i2s_comm_format_t.I2S_COMM_FORMAT_PCM,
+    "pcm_short": i2s_comm_format_t.I2S_COMM_FORMAT_PCM_SHORT,
+    "pcm_long": i2s_comm_format_t.I2S_COMM_FORMAT_PCM_LONG
 }
 
 NO_INTERNAL_DAC_VARIANTS = [esp32.const.VARIANT_ESP32S2]
@@ -77,6 +92,9 @@ CONFIG_SCHEMA = cv.All(
                     cv.Required(
                         CONF_I2S_DOUT_PIN
                     ): pins.internal_gpio_output_pin_number,
+                    cv.Optional(CONF_I2S_COMM_FMT, default="stand_i2s"): cv.enum(
+                        I2C_COMM_FMT_OPTIONS, lower=True
+                    ),
                 }
             ),
         },
@@ -96,4 +114,5 @@ async def to_code(config):
         cg.add(var.set_internal_dac_mode(config[CONF_CHANNEL]))
     else:
         cg.add(var.set_dout_pin(config[CONF_I2S_DOUT_PIN]))
+        cg.add(var.set_i2s_comm_fmt(config[CONF_I2S_COMM_FMT]))
     cg.add(var.set_timeout(config[CONF_TIMEOUT]))

--- a/esphome/components/i2s_audio/speaker/__init__.py
+++ b/esphome/components/i2s_audio/speaker/__init__.py
@@ -45,7 +45,7 @@ I2C_COMM_FMT_OPTIONS = {
     "i2s_lsb": i2s_comm_format_t.I2S_COMM_FORMAT_I2S_LSB,
     "pcm": i2s_comm_format_t.I2S_COMM_FORMAT_PCM,
     "pcm_short": i2s_comm_format_t.I2S_COMM_FORMAT_PCM_SHORT,
-    "pcm_long": i2s_comm_format_t.I2S_COMM_FORMAT_PCM_LONG
+    "pcm_long": i2s_comm_format_t.I2S_COMM_FORMAT_PCM_LONG,
 }
 
 NO_INTERNAL_DAC_VARIANTS = [esp32.const.VARIANT_ESP32S2]

--- a/esphome/components/i2s_audio/speaker/i2s_audio_speaker.cpp
+++ b/esphome/components/i2s_audio/speaker/i2s_audio_speaker.cpp
@@ -83,7 +83,7 @@ void I2SAudioSpeaker::player_task(void *params) {
       .sample_rate = this_speaker->sample_rate_,
       .bits_per_sample = this_speaker->bits_per_sample_,
       .channel_format = this_speaker->channel_,
-      .communication_format = I2S_COMM_FORMAT_STAND_I2S,
+      .communication_format = this_speaker->i2s_comm_fmt_,
       .intr_alloc_flags = ESP_INTR_FLAG_LEVEL1,
       .dma_buf_count = 8,
       .dma_buf_len = 256,

--- a/esphome/components/i2s_audio/speaker/i2s_audio_speaker.h
+++ b/esphome/components/i2s_audio/speaker/i2s_audio_speaker.h
@@ -49,6 +49,7 @@ class I2SAudioSpeaker : public I2SAudioOut, public speaker::Speaker, public Comp
 #if SOC_I2S_SUPPORTS_DAC
   void set_internal_dac_mode(i2s_dac_mode_t mode) { this->internal_dac_mode_ = mode; }
 #endif
+  void set_i2s_comm_fmt(i2s_comm_format_t mode) { this->i2s_comm_fmt_ = mode; }
 
   void start() override;
   void stop() override;
@@ -76,6 +77,7 @@ class I2SAudioSpeaker : public I2SAudioOut, public speaker::Speaker, public Comp
 #if SOC_I2S_SUPPORTS_DAC
   i2s_dac_mode_t internal_dac_mode_{I2S_DAC_CHANNEL_DISABLE};
 #endif
+  i2s_comm_format_t i2s_comm_fmt_;
 };
 
 }  // namespace i2s_audio


### PR DESCRIPTION
# What does this implement/fix?

With this implementation it's possible to change the communication format used in the i2S Speaker component. This allows devices like Sonoff TX Ultimate to work correctly by setting the param to I2S_COMM_FORMAT_STAND_MSB (stand_msb in yaml file).
The param name is i2s_comm_fmt (to be similar to the respective setting in the media_player component). The allowed parameters are taken from the ESP32 SDK Documentation:
- stand_i2s: I2S_COMM_FORMAT_STAND_I2S
- stand_msb: I2S_COMM_FORMAT_STAND_MSB
- stand_pcm_short: I2S_COMM_FORMAT_STAND_PCM_SHORT
- stand_pcm_long: I2S_COMM_FORMAT_STAND_PCM_LONG
- stand_max: I2S_COMM_FORMAT_STAND_MAX
- i2s_msb: I2S_COMM_FORMAT_I2S_MSB
- i2s_lsb: I2S_COMM_FORMAT_I2S_LSB
- pcm: I2S_COMM_FORMAT_PCM
- pcm_short: I2S_COMM_FORMAT_PCM_SHORT
- pcm_long: I2S_COMM_FORMAT_PCM_LONG


## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#4250

## Test Environment

- [ ] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
speaker:
  - id: audio_out
    platform: i2s_audio
    dac_type: external
    i2s_dout_pin: ${audio_sdata_pin}
    i2s_audio_id: audio_i2s
    i2s_comm_fmt: stand_msb
    channel: mono

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
