### PR TITLE
Add sample_bytes to media player supported format

### DIFF
--- a/esphome/components/api/api.proto
+++ b/esphome/components/api/api.proto
@@ -1118,6 +1118,7 @@ message MediaPlayerSupportedFormat {
   uint32 sample_rate = 2;
   uint32 num_channels = 3;
   MediaPlayerFormatPurpose purpose = 4;
+  uint32 sample_bytes = 5;
 }
 message ListEntitiesMediaPlayerResponse {
   option (id) = 63;

--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -1032,6 +1032,7 @@ bool APIConnection::send_media_player_info(media_player::MediaPlayer *media_play
     media_format.sample_rate = supported_format.sample_rate;
     media_format.num_channels = supported_format.num_channels;
     media_format.purpose = static_cast<enums::MediaPlayerFormatPurpose>(supported_format.purpose);
+    media_format.sample_bytes = supported_format.sample_bytes;
     msg.supported_formats.push_back(media_format);
   }
 

--- a/esphome/components/api/api_pb2.cpp
+++ b/esphome/components/api/api_pb2.cpp
@@ -5149,6 +5149,10 @@ bool MediaPlayerSupportedFormat::decode_varint(uint32_t field_id, ProtoVarInt va
       this->purpose = value.as_enum<enums::MediaPlayerFormatPurpose>();
       return true;
     }
+    case 5: {
+      this->sample_bytes = value.as_uint32();
+      return true;
+    }
     default:
       return false;
   }
@@ -5168,6 +5172,7 @@ void MediaPlayerSupportedFormat::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint32(2, this->sample_rate);
   buffer.encode_uint32(3, this->num_channels);
   buffer.encode_enum<enums::MediaPlayerFormatPurpose>(4, this->purpose);
+  buffer.encode_uint32(5, this->sample_bytes);
 }
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void MediaPlayerSupportedFormat::dump_to(std::string &out) const {
@@ -5189,6 +5194,11 @@ void MediaPlayerSupportedFormat::dump_to(std::string &out) const {
 
   out.append("  purpose: ");
   out.append(proto_enum_to_string<enums::MediaPlayerFormatPurpose>(this->purpose));
+  out.append("\n");
+
+  out.append("  sample_bytes: ");
+  sprintf(buffer, "%" PRIu32, this->sample_bytes);
+  out.append(buffer);
   out.append("\n");
   out.append("}");
 }

--- a/esphome/components/api/api_pb2.h
+++ b/esphome/components/api/api_pb2.h
@@ -1277,6 +1277,7 @@ class MediaPlayerSupportedFormat : public ProtoMessage {
   uint32_t sample_rate{0};
   uint32_t num_channels{0};
   enums::MediaPlayerFormatPurpose purpose{};
+  uint32_t sample_bytes{0};
   void encode(ProtoWriteBuffer buffer) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;

--- a/esphome/components/media_player/media_player.h
+++ b/esphome/components/media_player/media_player.h
@@ -37,6 +37,7 @@ struct MediaPlayerSupportedFormat {
   uint32_t sample_rate;
   uint32_t num_channels;
   MediaPlayerFormatPurpose purpose;
+  uint32_t sample_bytes;
 };
 
 class MediaPlayer;


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->
Adds a `sample_bytes` field to `MediaPlayerSupportedFormat` and copies the field over in `api_connection`. This field represents the supported width of audio samples in bytes, and is already present in `aioesphomeapi`.

Requires:
* https://github.com/home-assistant/core/pull/126016
* https://github.com/esphome/voice-kit/pull/110

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
