### PR TITLE
2024.9.0b3

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -33,7 +33,7 @@ RUN \
         python3-venv=3.11.2-1+b1 \
         python3-wheel=0.38.4-2 \
         iputils-ping=3:20221126-1 \
-        git=1:2.39.2-1.1 \
+        git=1:2.39.5-0+deb12u1 \
         curl=7.88.1-10+deb12u7 \
         openssh-client=1:9.2p1-2+deb12u3 \
         python3-cffi=1.15.1-5 \

--- a/esphome/components/api/api.proto
+++ b/esphome/components/api/api.proto
@@ -1118,6 +1118,7 @@ message MediaPlayerSupportedFormat {
   uint32 sample_rate = 2;
   uint32 num_channels = 3;
   MediaPlayerFormatPurpose purpose = 4;
+  uint32 sample_bytes = 5;
 }
 message ListEntitiesMediaPlayerResponse {
   option (id) = 63;

--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -1032,6 +1032,7 @@ bool APIConnection::send_media_player_info(media_player::MediaPlayer *media_play
     media_format.sample_rate = supported_format.sample_rate;
     media_format.num_channels = supported_format.num_channels;
     media_format.purpose = static_cast<enums::MediaPlayerFormatPurpose>(supported_format.purpose);
+    media_format.sample_bytes = supported_format.sample_bytes;
     msg.supported_formats.push_back(media_format);
   }
 

--- a/esphome/components/api/api_pb2.cpp
+++ b/esphome/components/api/api_pb2.cpp
@@ -5149,6 +5149,10 @@ bool MediaPlayerSupportedFormat::decode_varint(uint32_t field_id, ProtoVarInt va
       this->purpose = value.as_enum<enums::MediaPlayerFormatPurpose>();
       return true;
     }
+    case 5: {
+      this->sample_bytes = value.as_uint32();
+      return true;
+    }
     default:
       return false;
   }
@@ -5168,6 +5172,7 @@ void MediaPlayerSupportedFormat::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint32(2, this->sample_rate);
   buffer.encode_uint32(3, this->num_channels);
   buffer.encode_enum<enums::MediaPlayerFormatPurpose>(4, this->purpose);
+  buffer.encode_uint32(5, this->sample_bytes);
 }
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void MediaPlayerSupportedFormat::dump_to(std::string &out) const {
@@ -5189,6 +5194,11 @@ void MediaPlayerSupportedFormat::dump_to(std::string &out) const {
 
   out.append("  purpose: ");
   out.append(proto_enum_to_string<enums::MediaPlayerFormatPurpose>(this->purpose));
+  out.append("\n");
+
+  out.append("  sample_bytes: ");
+  sprintf(buffer, "%" PRIu32, this->sample_bytes);
+  out.append(buffer);
   out.append("\n");
   out.append("}");
 }

--- a/esphome/components/api/api_pb2.h
+++ b/esphome/components/api/api_pb2.h
@@ -1277,6 +1277,7 @@ class MediaPlayerSupportedFormat : public ProtoMessage {
   uint32_t sample_rate{0};
   uint32_t num_channels{0};
   enums::MediaPlayerFormatPurpose purpose{};
+  uint32_t sample_bytes{0};
   void encode(ProtoWriteBuffer buffer) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;

--- a/esphome/components/media_player/media_player.h
+++ b/esphome/components/media_player/media_player.h
@@ -37,6 +37,7 @@ struct MediaPlayerSupportedFormat {
   uint32_t sample_rate;
   uint32_t num_channels;
   MediaPlayerFormatPurpose purpose;
+  uint32_t sample_bytes;
 };
 
 class MediaPlayer;

--- a/esphome/const.py
+++ b/esphome/const.py
@@ -1,6 +1,6 @@
 """Constants used by esphome."""
 
-__version__ = "2024.9.0b2"
+__version__ = "2024.9.0b3"
 
 ALLOWED_NAME_CHARS = "abcdefghijklmnopqrstuvwxyz0123456789-_"
 VALID_SUBSTITUTIONS_CHARACTERS = (


### PR DESCRIPTION
**Do not merge, release script will automatically merge**
## Full list of changes

### All changes

- Add sample_bytes to media player supported format [esphome#7451](https://github.com/esphome/esphome/pull/7451)
- [docker] Bump git from 1:2.39.2-1.1 to 1:2.39.5-0+deb12u1 [esphome#7452](https://github.com/esphome/esphome/pull/7452)

<details>
<summary>Metadata</summary>

@coderabbitai ignore
</details>
