### PR TITLE
NEC IR protocol: add padding bytes

### DIFF
--- a/esphome/components/remote_base/nec_protocol.cpp
+++ b/esphome/components/remote_base/nec_protocol.cpp
@@ -16,14 +16,11 @@ void NECProtocol::encode(RemoteTransmitData *dst, const NECData &data) {
   // If the address or command is <= 0xFF the user has only supplied one byte
   // We need to generate parity bits to pad the value to 2 bytes
   // The NEC protocol requires us to prepend the inverse byte, e.g. 0x21 -> 0xDE21
-  uint16_t address = data.address <= 0xFF
-    ? data.address | ((uint16_t)(~data.address) << 8)
-    : data.address;
-  uint16_t command = data.command <= 0xFF
-    ? data.command | ((uint16_t)(~data.command) << 8)
-    : data.command;
+  uint16_t address = data.address <= 0xFF ? data.address | ((uint16_t) (~data.address) << 8) : data.address;
+  uint16_t command = data.command <= 0xFF ? data.command | ((uint16_t) (~data.command) << 8) : data.command;
 
-  ESP_LOGD(TAG, "Sending NEC: address=0x%04X, command=0x%04X command_repeats=%d", address, command, data.command_repeats);
+  ESP_LOGD(TAG, "Sending NEC: address=0x%04X, command=0x%04X command_repeats=%d", address, command,
+           data.command_repeats);
 
   dst->reserve(2 + 32 + 32 * data.command_repeats + 2);
   dst->set_carrier_frequency(38000);

--- a/tests/components/remote_transmitter/common-buttons.yaml
+++ b/tests/components/remote_transmitter/common-buttons.yaml
@@ -18,6 +18,12 @@ button:
         address: 0x4242
         command: 0x8484
   - platform: template
+    name: NEC short
+    on_press:
+      remote_transmitter.transmit_nec:
+        address: 0x32
+        command: 0x02
+  - platform: template
     name: LG
     on_press:
       remote_transmitter.transmit_lg:


### PR DESCRIPTION
# What does this implement/fix?

Normally, the NEC protocol is made of 4 bytes: 2 address bytes and 2 command bytes. However, both are often really just 1 byte with a padding byte (which is the inverse of the actual byte).

This means in many product manuals and other documentation only the one byte is provided. This has lead to confusion setting up the integration (as seen via Home Assistant forum posts), and requires people read the long note in the docs.

This PR pads addresses automatically, provided they are given as just one byte. This would make setting up IR control with ESPHome easier.

This is different to a previous PR, https://github.com/esphome/esphome/pull/3515, which enforced the use of 1 byte (8 bit) codes. That PR would prevent users from entering in 2 (or even 4) byte custom NEC codes, breaking compatibility with some devices. Whereas this PR just automatically pads addresses and commands provided as just a single byte. It doesn't touch them otherwise, so longer codes still work just fine.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#WIP - plan to delete 'Additionally, ESPHome does not automatically generate parity bits or pad values to 2 bytes. So, in order to send command 0x0, you need to use 0xFF00 (0x00 being the command and 0xFF being the logical inverse).', and update the address and command parameters to say '8-bit or 16-bit'

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
button:
  - platform: template
    name: NEC short
    on_press:
      remote_transmitter.transmit_nec:
        address: 0x32
        command: 0x02
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
