### PR TITLE
Mopeka Pro Check improvement to allow user to configure the sensor reporting for lower quality readings

### DIFF
--- a/esphome/components/mopeka_pro_check/mopeka_pro_check.h
+++ b/esphome/components/mopeka_pro_check/mopeka_pro_check.h
@@ -24,9 +24,9 @@ enum SensorType {
 };
 
 // Sensor read quality.  If sensor is poorly placed or tank level
-// gets too low the read quality will show and the distanace
+// gets too low the read quality will show and the distance
 // measurement may be inaccurate.
-enum SensorReadQuality { QUALITY_HIGH = 0x3, QUALITY_MED = 0x2, QUALITY_LOW = 0x1, QUALITY_NONE = 0x0 };
+enum SensorReadQuality { QUALITY_HIGH = 0x3, QUALITY_MED = 0x2, QUALITY_LOW = 0x1, QUALITY_ZERO = 0x0 };
 
 class MopekaProCheck : public Component, public esp32_ble_tracker::ESPBTDeviceListener {
  public:
@@ -35,11 +35,14 @@ class MopekaProCheck : public Component, public esp32_ble_tracker::ESPBTDeviceLi
   bool parse_device(const esp32_ble_tracker::ESPBTDevice &device) override;
   void dump_config() override;
   float get_setup_priority() const override { return setup_priority::DATA; }
+  void set_min_signal_quality(SensorReadQuality min) { this->min_signal_quality_ = min; };
 
   void set_level(sensor::Sensor *level) { level_ = level; };
   void set_temperature(sensor::Sensor *temperature) { temperature_ = temperature; };
   void set_battery_level(sensor::Sensor *bat) { battery_level_ = bat; };
   void set_distance(sensor::Sensor *distance) { distance_ = distance; };
+  void set_signal_quality(sensor::Sensor *rq) { read_quality_ = rq; };
+  void set_ignored_reads(sensor::Sensor *ir) { ignored_reads_ = ir; };
   void set_tank_full(float full) { full_mm_ = full; };
   void set_tank_empty(float empty) { empty_mm_ = empty; };
 
@@ -49,9 +52,13 @@ class MopekaProCheck : public Component, public esp32_ble_tracker::ESPBTDeviceLi
   sensor::Sensor *temperature_{nullptr};
   sensor::Sensor *distance_{nullptr};
   sensor::Sensor *battery_level_{nullptr};
+  sensor::Sensor *read_quality_{nullptr};
+  sensor::Sensor *ignored_reads_{nullptr};
 
   uint32_t full_mm_;
   uint32_t empty_mm_;
+  uint32_t ignored_read_count_ = 0;
+  SensorReadQuality min_signal_quality_ = QUALITY_MED;
 
   uint8_t parse_battery_level_(const std::vector<uint8_t> &message);
   uint32_t parse_distance_(const std::vector<uint8_t> &message);

--- a/tests/components/mopeka_pro_check/common.yaml
+++ b/tests/components/mopeka_pro_check/common.yaml
@@ -14,3 +14,20 @@ sensor:
       name: Propane test distance
     battery_level:
       name: Propane test battery level
+
+  - platform: mopeka_pro_check
+    mac_address: AA:BB:CC:DD:EE:FF
+    tank_type: 20LB_V
+    temperature:
+      name: "Propane test2 temp"
+    level:
+      name: "Propane test2 level"
+    distance:
+      name: "Propane test2 distance"
+    battery_level:
+      name: "Propane test2 battery level"
+    signal_quality:
+      name: "propane test2 read quality"
+    ignored_reads:
+      name: "propane test2 ignored reads"
+    minimum_signal_quality: "LOW"


### PR DESCRIPTION
# What does this implement/fix?

Originally this integration made a choice to not report level or distance sensors when the read quality was below a 2 (scale of 0-3, 3 being highest).  Many users have reported that despite moving their sensor, cleaning their tank, and adding grease their device reports lower quality readings.  They also report that these measurements are still accurate enough to be useful for their use cases.  Additionally, the integration zeroed the sensors when the reading quality was bad.  Both of these conditions made it harder to use their device in automations or for alerts.  This PR provides more configuration options to the end user while still maintaining a default that is similar.  

<!-- Quick description and explanation of changes -->

- Remove hardcoded zero and no report quality levels.  
- Never zero the sensor level or distance. (minor change in behavior but still not considered "breaking change")
- Provide new configuration option for min reported quality level and only report level and distance sensors when quality is greater than or equal to min.  
- Create new diagnostic sensor that reports the quality level so that additional filtering could be done if desired.
- Create new diagnostic sensor for the count of contiguous bad readings so there is visibility into the performance of the sensor. 


## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/4145

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** https://github.com/esphome/esphome-docs/pull/4281


## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
- platform: mopeka_pro_check
    mac_address: AA:BB:CC:DD:EE:FF
    tank_type: 20LB_V
    temperature:
        name: "Propane test2 temp"
    level:
        name: "Propane test2 level"
    distance:
        name: "Propane test2 distance"
    battery_level:
        name: "Propane test2 battery level"
    # new options below here
    signal_quality:
        name: "propane test2 read quality"
    ignored_reads:
        name: "propane test2 ignored reads"
    minimum_signal_quality: "LOW"
    
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
