### PR TITLE
add "fan_mode" and "swing_mode" to REST API

### DIFF
--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -1012,6 +1012,16 @@ void WebServer::handle_climate_request(AsyncWebServerRequest *request, const Url
       call.set_mode(mode.c_str());
     }
 
+    if (request->hasParam("fan_mode")) {
+      auto mode = request->getParam("fan_mode")->value();
+      call.set_fan_mode(mode.c_str());
+    }
+
+    if (request->hasParam("swing_mode")) {
+      auto mode = request->getParam("swing_mode")->value();
+      call.set_swing_mode(mode.c_str());
+    }
+
     if (request->hasParam("target_temperature_high")) {
       auto target_temperature_high = parse_number<float>(request->getParam("target_temperature_high")->value().c_str());
       if (target_temperature_high.has_value())


### PR DESCRIPTION
# What does this implement/fix?

Added missing "fan_mode" and "swing_mode" for midea ac component in webserver REST API

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/4780

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
