### PR TITLE
Allow starting and stopping intervals

### DIFF
--- a/esphome/components/interval/__init__.py
+++ b/esphome/components/interval/__init__.py
@@ -1,25 +1,59 @@
+from esphome import automation
 import esphome.codegen as cg
 import esphome.config_validation as cv
-from esphome import automation
 from esphome.const import CONF_ID, CONF_INTERVAL, CONF_STARTUP_DELAY
 
 CODEOWNERS = ["@esphome/core"]
+CONF_AUTOSTART = "autostart"
+CONF_START_CONDITIONS = "start_conditions"
+
 interval_ns = cg.esphome_ns.namespace("interval")
 IntervalTrigger = interval_ns.class_(
     "IntervalTrigger", automation.Trigger.template(), cg.PollingComponent
+)
+
+# Actions
+StartIntervalAction = interval_ns.class_(
+    "IntervalStartAction", automation.Action, cg.Parented.template(IntervalTrigger)
+)
+StopIntervalAction = interval_ns.class_(
+    "IntervalStopAction", automation.Action, cg.Parented.template(IntervalTrigger)
 )
 
 CONFIG_SCHEMA = automation.validate_automation(
     cv.Schema(
         {
             cv.GenerateID(): cv.declare_id(IntervalTrigger),
-            cv.Optional(
-                CONF_STARTUP_DELAY, default="0s"
+            cv.Exclusive(
+                CONF_STARTUP_DELAY, CONF_START_CONDITIONS
             ): cv.positive_time_period_milliseconds,
+            cv.Exclusive(CONF_AUTOSTART, CONF_START_CONDITIONS): cv.boolean,
             cv.Required(CONF_INTERVAL): cv.positive_time_period_milliseconds,
-        }
+        },
     ).extend(cv.COMPONENT_SCHEMA)
 )
+
+START_INTERVAL_SCHEMA = automation.maybe_simple_id(
+    {
+        CONF_ID: cv.use_id(IntervalTrigger),
+    }
+)
+
+STOP_INTERVAL_SCHEMA = automation.maybe_simple_id(
+    {
+        CONF_ID: cv.use_id(IntervalTrigger),
+    }
+)
+
+
+@automation.register_action(
+    "interval.start", StartIntervalAction, START_INTERVAL_SCHEMA
+)
+@automation.register_action("interval.stop", StopIntervalAction, STOP_INTERVAL_SCHEMA)
+async def interval_action_to_code(config, action_id, template_arg, args):
+    parent = await cg.get_variable(config[CONF_ID])
+    var = cg.new_Pvariable(action_id, template_arg, parent)
+    return var
 
 
 async def to_code(config):
@@ -29,4 +63,5 @@ async def to_code(config):
         await automation.build_automation(var, [], conf)
 
         cg.add(var.set_update_interval(conf[CONF_INTERVAL]))
-        cg.add(var.set_startup_delay(conf[CONF_STARTUP_DELAY]))
+        cg.add(var.set_autostart(conf.get(CONF_AUTOSTART, True)))
+        cg.add(var.set_startup_delay(conf.get(CONF_STARTUP_DELAY, 0)))

--- a/tests/components/interval/common.yaml
+++ b/tests/components/interval/common.yaml
@@ -2,3 +2,21 @@ interval:
   - interval: 1s
     then:
       - logger.log: Tick
+  - interval: 2s
+    id: toggleable_interval
+    autostart: false
+    then:
+      - logger.log: "Not ticking"
+  - interval: 3s
+    startup_delay: 10s
+    then:
+      - logger.log: "delayed ticking"
+
+switch:
+  - platform: template
+    id: pause_interval
+    optimistic: true
+    turn_on_action:
+      - interval.start: toggleable_interval
+    turn_off_action:
+      - interval.stop: toggleable_interval


### PR DESCRIPTION
# What does this implement/fix?

Add actions to start/stop a specific interval, so that its actions are not executed while stopped.
This can be used e.g. to pause a running animation, to stop automatic page changes in displays, ...

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#4268
## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
interval:
  - interval: 1s
    id: toggleable_interval
    autostart: false
    then:
      - logger.log: Tick

switch:
  - platform: template
    id: pause_interval
    optimistic: true
    turn_on_action:
      - interval.start: toggleable_interval
    turn_off_action:
      - interval.stop: toggleable_interval
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
