### PR TITLE
Copy active wake words to message

### DIFF
--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -1242,6 +1242,9 @@ VoiceAssistantConfigurationResponse APIConnection::voice_assistant_get_configura
       }
       resp.available_wake_words.push_back(std::move(resp_wake_word));
     }
+    for (auto &wake_word_id : config.active_wake_words) {
+      resp.active_wake_words.push_back(wake_word_id);
+    }
     resp.max_active_wake_words = config.max_active_wake_words;
   }
   return resp;


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->
Active wake words were not being copied to the response message `voice_assistant_get_configuration`

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
