### PR TITLE
Add remote transmitter triggers

### DIFF
--- a/esphome/components/remote_transmitter/__init__.py
+++ b/esphome/components/remote_transmitter/__init__.py
@@ -1,10 +1,14 @@
+from esphome import automation, pins
 import esphome.codegen as cg
+from esphome.components import esp32_rmt, remote_base
 import esphome.config_validation as cv
-from esphome import pins
-from esphome.components import remote_base, esp32_rmt
 from esphome.const import CONF_CARRIER_DUTY_PERCENT, CONF_ID, CONF_PIN, CONF_RMT_CHANNEL
 
 AUTO_LOAD = ["remote_base"]
+
+CONF_ON_TRANSMIT = "on_transmit"
+CONF_ON_COMPLETE = "on_complete"
+
 remote_transmitter_ns = cg.esphome_ns.namespace("remote_transmitter")
 RemoteTransmitterComponent = remote_transmitter_ns.class_(
     "RemoteTransmitterComponent", remote_base.RemoteTransmitterBase, cg.Component
@@ -19,6 +23,8 @@ CONFIG_SCHEMA = cv.Schema(
             cv.percentage_int, cv.Range(min=1, max=100)
         ),
         cv.Optional(CONF_RMT_CHANNEL): esp32_rmt.validate_rmt_channel(tx=True),
+        cv.Optional(CONF_ON_TRANSMIT): automation.validate_automation(single=True),
+        cv.Optional(CONF_ON_COMPLETE): automation.validate_automation(single=True),
     }
 ).extend(cv.COMPONENT_SCHEMA)
 
@@ -32,3 +38,13 @@ async def to_code(config):
     await cg.register_component(var, config)
 
     cg.add(var.set_carrier_duty_percent(config[CONF_CARRIER_DUTY_PERCENT]))
+
+    if on_transmit_config := config.get(CONF_ON_TRANSMIT):
+        await automation.build_automation(
+            var.get_transmit_trigger(), [], on_transmit_config
+        )
+
+    if on_complete_config := config.get(CONF_ON_COMPLETE):
+        await automation.build_automation(
+            var.get_complete_trigger(), [], on_complete_config
+        )

--- a/esphome/components/remote_transmitter/remote_transmitter.h
+++ b/esphome/components/remote_transmitter/remote_transmitter.h
@@ -33,6 +33,9 @@ class RemoteTransmitterComponent : public remote_base::RemoteTransmitterBase,
 
   void set_carrier_duty_percent(uint8_t carrier_duty_percent) { this->carrier_duty_percent_ = carrier_duty_percent; }
 
+  Trigger<> *get_transmit_trigger() const { return this->transmit_trigger_; };
+  Trigger<> *get_complete_trigger() const { return this->complete_trigger_; };
+
  protected:
   void send_internal(uint32_t send_times, uint32_t send_wait) override;
 #if defined(USE_ESP8266) || defined(USE_LIBRETINY)
@@ -57,6 +60,9 @@ class RemoteTransmitterComponent : public remote_base::RemoteTransmitterBase,
   bool inverted_{false};
 #endif
   uint8_t carrier_duty_percent_;
+
+  Trigger<> *transmit_trigger_{new Trigger<>()};
+  Trigger<> *complete_trigger_{new Trigger<>()};
 };
 
 }  // namespace remote_transmitter

--- a/esphome/components/remote_transmitter/remote_transmitter_esp32.cpp
+++ b/esphome/components/remote_transmitter/remote_transmitter_esp32.cpp
@@ -124,6 +124,7 @@ void RemoteTransmitterComponent::send_internal(uint32_t send_times, uint32_t sen
     ESP_LOGE(TAG, "Empty data");
     return;
   }
+  this->transmit_trigger_->trigger();
   for (uint32_t i = 0; i < send_times; i++) {
     esp_err_t error = rmt_write_items(this->channel_, this->rmt_temp_.data(), this->rmt_temp_.size(), true);
     if (error != ESP_OK) {
@@ -135,6 +136,7 @@ void RemoteTransmitterComponent::send_internal(uint32_t send_times, uint32_t sen
     if (i + 1 < send_times)
       delayMicroseconds(send_wait);
   }
+  this->complete_trigger_->trigger();
 }
 
 }  // namespace remote_transmitter

--- a/esphome/components/remote_transmitter/remote_transmitter_esp8266.cpp
+++ b/esphome/components/remote_transmitter/remote_transmitter_esp8266.cpp
@@ -76,6 +76,7 @@ void RemoteTransmitterComponent::send_internal(uint32_t send_times, uint32_t sen
   uint32_t on_time, off_time;
   this->calculate_on_off_time_(this->temp_.get_carrier_frequency(), &on_time, &off_time);
   this->target_time_ = 0;
+  this->transmit_trigger_->trigger();
   for (uint32_t i = 0; i < send_times; i++) {
     for (int32_t item : this->temp_.get_data()) {
       if (item > 0) {
@@ -93,6 +94,7 @@ void RemoteTransmitterComponent::send_internal(uint32_t send_times, uint32_t sen
     if (i + 1 < send_times)
       this->target_time_ += send_wait;
   }
+  this->complete_trigger_->trigger();
 }
 
 }  // namespace remote_transmitter

--- a/esphome/components/remote_transmitter/remote_transmitter_libretiny.cpp
+++ b/esphome/components/remote_transmitter/remote_transmitter_libretiny.cpp
@@ -78,6 +78,7 @@ void RemoteTransmitterComponent::send_internal(uint32_t send_times, uint32_t sen
   uint32_t on_time, off_time;
   this->calculate_on_off_time_(this->temp_.get_carrier_frequency(), &on_time, &off_time);
   this->target_time_ = 0;
+  this->transmit_trigger_->trigger();
   for (uint32_t i = 0; i < send_times; i++) {
     InterruptLock lock;
     for (int32_t item : this->temp_.get_data()) {
@@ -96,6 +97,7 @@ void RemoteTransmitterComponent::send_internal(uint32_t send_times, uint32_t sen
     if (i + 1 < send_times)
       this->target_time_ += send_wait;
   }
+  this->complete_trigger_->trigger();
 }
 
 }  // namespace remote_transmitter


### PR DESCRIPTION
# What does this implement/fix?

Need a way to seamlessly turn radio hardware transmitters on / off or switch rx / tx modes. Add two triggers to accomplish this. 

Why this is needed:
- The transceiver could be locked to tx mode permanently but its generally not a good idea. Even in OOK there will be some leakage. If ASK or FSK are used its a really bad idea as it will be transmitting real power all the time.
- Many transceivers support both rx and tx (but not simultaneously). Without a way to switch modes the transceiver would have to be locked into rx or tx all the time. With this change the transceiver can be in rx mode and automatically switch to tx for a short period of time via these triggers.

These triggers will make supporting various radios / configurations much cleaner. Any state change can be done in one spot  now instead of everywhere around every transmit automation. In addition to being cleaner these radio state changes can happen right before / after the actual transmit. 

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#4275

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
remote_transmitter:
  pin: GPIO32
  carrier_duty_percent: 100%  
  on_transmit:
    then:
      - lambda: 'id(radio_id)->set_mode_tx();'
  on_complete:
    then:
      - lambda: 'id(radio_id)->set_mode_standby();'

interval:
  - interval: 20sec
    then:
      - remote_transmitter.transmit_raw:
          code: [614, -614, 600, -614, 614, -614, 601, -614, 405, -209, 405, -209, 209, -405, 209, -405, 209, -405, 405, -209, 209, -405, 405, -209, 209, -405, 405, -209, 209, -405, 405, -209, 209, -405, 209, -405, 209, -405, 405, -209, 209, -405, 405, -209, 405, -209, 405, -209, 405, -209, 209, -405, 209, -405, 209, -405, 209, -405, 209, -405, 209, -405, 209, -405, 209, -405, 209, -405, 209, -405, 209, -405, 405, -209, 209, -405, 209, -405, 209, -405, 209, -405, 405, -209, 405, -209, 405, -209, 405, -209, 405, -209, 405, -209, 405, -209, 405, -209, 209, -405, 209, -405, 405, -209, 405, -209, 209, -405, 209, -405, 405, -209, 405, -209, 405, -209, 209, -405, 209, -405, 405, -209, 209, -405, 405, -209, 209, -405, 405, -209, 209, -405, 405, -209, 209, -405]
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
