### PR TITLE
[micro_wake_word] Workaround for failing IDF 5+ tests

### DIFF
--- a/esphome/components/micro_wake_word/__init__.py
+++ b/esphome/components/micro_wake_word/__init__.py
@@ -419,6 +419,8 @@ async def to_code(config):
         repo="https://github.com/espressif/esp-tflite-micro",
         ref="v1.3.1",
     )
+    # add esp-nn dependency for tflite-micro to work around https://github.com/espressif/esp-nn/issues/17
+    # ...remove after switching to IDF 5.1.4+
     esp32.add_idf_component(
         name="esp-nn",
         repo="https://github.com/espressif/esp-nn",

--- a/esphome/components/micro_wake_word/__init__.py
+++ b/esphome/components/micro_wake_word/__init__.py
@@ -419,6 +419,11 @@ async def to_code(config):
         repo="https://github.com/espressif/esp-tflite-micro",
         ref="v1.3.1",
     )
+    esp32.add_idf_component(
+        name="esp-nn",
+        repo="https://github.com/espressif/esp-nn",
+        ref="v1.1.0",
+    )
 
     cg.add_build_flag("-DTF_LITE_STATIC_MEMORY")
     cg.add_build_flag("-DTF_LITE_DISABLE_X86_NEON")

--- a/esphome/idf_component.yml
+++ b/esphome/idf_component.yml
@@ -1,4 +1,7 @@
 dependencies:
+  esp-nn:
+    git: https://github.com/espressif/esp-nn.git
+    version: v1.1.0
   esp-tflite-micro:
     git: https://github.com/espressif/esp-tflite-micro.git
     version: v1.3.1

--- a/esphome/idf_component.yml
+++ b/esphome/idf_component.yml
@@ -1,7 +1,4 @@
 dependencies:
-  esp-nn:
-    git: https://github.com/espressif/esp-nn.git
-    version: v1.1.0
   esp-tflite-micro:
     git: https://github.com/espressif/esp-tflite-micro.git
     version: v1.3.1


### PR DESCRIPTION
# What does this implement/fix?

SSIA -- Implements a workaround for https://github.com/espressif/esp-nn/issues/17

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
