### PR TITLE
tcs34725: Add check for Division by Zero

### DIFF
--- a/esphome/components/tcs34725/tcs34725.cpp
+++ b/esphome/components/tcs34725/tcs34725.cpp
@@ -1,6 +1,7 @@
 #include "tcs34725.h"
 #include "esphome/core/log.h"
 #include "esphome/core/hal.h"
+#include <algorithm>
 
 namespace esphome {
 namespace tcs34725 {
@@ -254,7 +255,8 @@ void TCS34725Component::update() {
     // change integration time an gain to achieve maximum resolution an dynamic range
     // calculate optimal integration time to achieve 70% satuaration
     float integration_time_ideal;
-    integration_time_ideal = 60 / ((float) raw_c / 655.35) * this->integration_time_;
+
+    integration_time_ideal = 60 / ((float) std::max((uint16_t) 1, raw_c) / 655.35f) * this->integration_time_;
 
     uint8_t gain_reg_val_new = this->gain_reg_;
     // increase gain if less than 20% of white channel used and high integration time


### PR DESCRIPTION
# What does this implement/fix?

A potential division by zero in TCS34725Component::update was fixed. The values raw_c was previously unchecked for zero, which could cause a crash. A check and handling for this condition has been added to prevent this issue.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:


<details>

```yaml
esphome:
  name: $devicename
  platform: ESP8266
  board: d1_mini
  friendly_name: $friendly_name

substitutions:
  devicename: ambient-light-sensor
  friendly_name: "Ambient Light Sensor"

logger:
  level: DEBUG

mdns:
  
time:
  - platform: homeassistant

api:
  encryption: 
    key: !secret api_key-ambient-light-sensor

ota:
  platform: esphome
  password: !secret ota_password_ambient-light-sensor

wifi:
  networks:
    ssid: !secret wifi_ssid
    password: !secret wifi_password
    manual_ip:
      static_ip: !secret ip-ambient-light-sensor
      gateway: !secret wifi_gateway
      subnet: !secret wifi_subnet
      dns1: !secret wifi_dns1

i2c:
  sda: D1
  scl: D2
  scan: true
  id: bus_a

sensor:
  - platform: tcs34725
    i2c_id: bus_a
    red_channel:
      name: "$friendly_name Red Channel relative"
      accuracy_decimals: 1
    green_channel:
      name: "$friendly_name Green Channel relative"
      accuracy_decimals: 1
    blue_channel:
      name: "$friendly_name Blue Channel relative"
      accuracy_decimals: 1
    clear_channel:
      name: "$friendly_name Clear Channel"
      accuracy_decimals: 1
    illuminance:
      name: "$friendly_name Illuminance"
      accuracy_decimals: 0
    color_temperature:
      name: "$friendly_name Color Temperature"
      accuracy_decimals: 0
    gain: 1x
    integration_time: auto
    glass_attenuation_factor: 1.0
    address: 0x29   

output:
  - platform: gpio
    pin: D3
    id: white_led
    inverted: false
  
light:
  - platform: binary
    output: white_led
    name: "$friendly_name White LED"
```

</details>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
