### PR TITLE
Fix feedback cover to keep 'direction_change_waittime' functionality with 'obstacle_rollback'

### DIFF
--- a/esphome/components/feedback/feedback_cover.cpp
+++ b/esphome/components/feedback/feedback_cover.cpp
@@ -189,7 +189,7 @@ void FeedbackCover::set_close_obstacle_sensor(binary_sensor::BinarySensor *close
     if (state && (this->current_operation == COVER_OPERATION_CLOSING ||
                   this->current_trigger_operation_ == COVER_OPERATION_CLOSING)) {
       ESP_LOGD(TAG, "'%s' - Obstacle collision detected while closing.", this->name_.c_str());
-      
+
       if (this->obstacle_rollback_) {
         this->target_position_ = clamp(this->position + this->obstacle_rollback_, COVER_CLOSED, COVER_OPEN);
         this->start_direction_(COVER_OPERATION_OPENING);
@@ -207,7 +207,7 @@ void FeedbackCover::set_open_obstacle_sensor(binary_sensor::BinarySensor *open_o
     if (state && (this->current_operation == COVER_OPERATION_OPENING ||
                   this->current_trigger_operation_ == COVER_OPERATION_OPENING)) {
       ESP_LOGD(TAG, "'%s' - Obstacle collision detected while opening.", this->name_.c_str());
-   
+
       if (this->obstacle_rollback_) {
         this->target_position_ = clamp(this->position - this->obstacle_rollback_, COVER_CLOSED, COVER_OPEN);
         this->start_direction_(COVER_OPERATION_CLOSING);

--- a/esphome/components/feedback/feedback_cover.cpp
+++ b/esphome/components/feedback/feedback_cover.cpp
@@ -188,12 +188,13 @@ void FeedbackCover::set_close_obstacle_sensor(binary_sensor::BinarySensor *close
   close_obstacle->add_on_state_callback([this](bool state) {
     if (state && (this->current_operation == COVER_OPERATION_CLOSING ||
                   this->current_trigger_operation_ == COVER_OPERATION_CLOSING)) {
-      ESP_LOGD(TAG, "'%s' - Close obstacle detected.", this->name_.c_str());
-      this->start_direction_(COVER_OPERATION_IDLE);
-
+      ESP_LOGD(TAG, "'%s' - Obstacle collision detected while closing.", this->name_.c_str());
+      
       if (this->obstacle_rollback_) {
         this->target_position_ = clamp(this->position + this->obstacle_rollback_, COVER_CLOSED, COVER_OPEN);
         this->start_direction_(COVER_OPERATION_OPENING);
+      } else {
+        this->start_direction_(COVER_OPERATION_IDLE);
       }
     }
   });
@@ -205,12 +206,13 @@ void FeedbackCover::set_open_obstacle_sensor(binary_sensor::BinarySensor *open_o
   open_obstacle->add_on_state_callback([this](bool state) {
     if (state && (this->current_operation == COVER_OPERATION_OPENING ||
                   this->current_trigger_operation_ == COVER_OPERATION_OPENING)) {
-      ESP_LOGD(TAG, "'%s' - Open obstacle detected.", this->name_.c_str());
-      this->start_direction_(COVER_OPERATION_IDLE);
-
+      ESP_LOGD(TAG, "'%s' - Obstacle collision detected while opening.", this->name_.c_str());
+   
       if (this->obstacle_rollback_) {
         this->target_position_ = clamp(this->position - this->obstacle_rollback_, COVER_CLOSED, COVER_OPEN);
         this->start_direction_(COVER_OPERATION_CLOSING);
+      } else {
+        this->start_direction_(COVER_OPERATION_IDLE);
       }
     }
   });


### PR DESCRIPTION
# What does this fix?

When executing the current implementation of the feedback cover together with the 'direction_change_wait_time' and 'obstacle_rollback' variable set, the wait time is ignored because the obstacle collision callback initially stops the movement of the cover instead of issuing a direction change.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable): -

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** -

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
```yaml
cover:
  - platform: feedback
    id: hallentor_main_cover
    name: Hallentor Main
    device_class: garage
    open_duration: 12s
    close_duration: 12s
    close_obstacle_sensor: ose_present
    obstacle_rollback: 100%
    direction_change_wait_time: 1s
    open_action:
      - switch.turn_on: open_relay  
    close_action:
      - switch.turn_on: close_relay
    stop_action:
      - switch.turn_off: close_relay
      - switch.turn_off: open_relay
      - switch.turn_on: stop_relay
      - delay: 300ms
      - switch.turn_off: stop_relay
    update_interval: 500ms
    assumed_state: true
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
