### PR TITLE
tcs34725: Remove IR compensation and improve illuminance and color temperature handling in extreme conditions

### DIFF
--- a/esphome/components/tcs34725/tcs34725.cpp
+++ b/esphome/components/tcs34725/tcs34725.cpp
@@ -75,20 +75,21 @@ float TCS34725Component::get_setup_priority() const { return setup_priority::DAT
  *  @return Color temperature in degrees Kelvin
  */
 void TCS34725Component::calculate_temperature_and_lux_(uint16_t r, uint16_t g, uint16_t b, uint16_t c) {
-  float r2, g2, b2; /* RGB values minus IR component */
-  float sat;        /* Digital saturation level */
-  float ir;         /* Inferred IR content */
+  float sat; /* Digital saturation level */
 
-  this->illuminance_ = 0;  // Assign 0 value before calculation
-  this->color_temperature_ = 0;
+  this->illuminance_ = NAN;
+  this->color_temperature_ = NAN;
 
-  const float ga = this->glass_attenuation_;  // Glass Attenuation Factor
-  static const float DF = 310.f;              // Device Factor
-  static const float R_COEF = 0.136f;         //
-  static const float G_COEF = 1.f;            // used in lux computation
-  static const float B_COEF = -0.444f;        //
-  static const float CT_COEF = 3810.f;        // Color Temperature Coefficient
-  static const float CT_OFFSET = 1391.f;      // Color Temperatuer Offset
+  const float ga = this->glass_attenuation_;            // Glass Attenuation Factor
+  static const float DF = 310.f;                        // Device Factor
+  static const float R_COEF = 0.136f;                   //
+  static const float G_COEF = 1.f;                      // used in lux computation
+  static const float B_COEF = -0.444f;                  //
+  static const float CT_COEF = 3810.f;                  // Color Temperature Coefficient
+  static const float CT_OFFSET = 1391.f;                // Color Temperatuer Offset
+  static const float MAX_ILLUMINANCE = 100000.0f;       // Cap illuminance at 100,000 lux
+  static const float MAX_COLOR_TEMPERATURE = 15000.0f;  // Maximum expected color temperature in Kelvin
+  static const float MIN_COLOR_TEMPERATURE = 1000.0f;   // Maximum reasonable color temperature in Kelvin
 
   if (c == 0) {
     return;
@@ -139,45 +140,48 @@ void TCS34725Component::calculate_temperature_and_lux_(uint16_t r, uint16_t g, u
   if (c >= sat) {
     if (this->integration_time_auto_) {
       ESP_LOGI(TAG, "Saturation too high, sample discarded, autogain ongoing");
+      return;
     } else {
-      ESP_LOGW(
-          TAG,
-          "Saturation too high, sample with saturation %.1f and clear %d treat values carefully or use grey filter",
-          sat, c);
-    }
-  }
-
-  /* AMS RGB sensors have no IR channel, so the IR content must be */
-  /* calculated indirectly. */
-  ir = ((r + g + b) > c) ? (r + g + b - c) / 2 : 0;
-
-  /* Remove the IR component from the raw RGB values */
-  r2 = r - ir;
-  g2 = g - ir;
-  b2 = b - ir;
-
-  // discarding super low values? not recemmonded, and avoided by using auto gain.
-  if (r2 == 0) {
-    // legacy code
-    if (!this->integration_time_auto_) {
       ESP_LOGW(TAG,
-               "No light detected on red channel, switch to auto gain or adjust timing, values will be unreliable");
+               "Saturation too high, sample with saturation %.1f and clear %d lux/color temperature cannot reliably "
+               "calculated, reduce integration/gain or use a grey filter.",
+               sat, c);
       return;
     }
   }
 
   // Lux Calculation (DN40 3.2)
 
-  float g1 = R_COEF * r2 + G_COEF * g2 + B_COEF * b2;
+  float g1 = R_COEF * (float) r + G_COEF * (float) g + B_COEF * (float) b;
   float cpl = (this->integration_time_ * this->gain_) / (ga * DF);
-  this->illuminance_ = g1 / cpl;
+
+  this->illuminance_ = std::max(g1 / cpl, 0.0f);
+
+  if (this->illuminance_ > MAX_ILLUMINANCE) {
+    ESP_LOGW(TAG, "Calculated illuminance greater than limit (%f), setting to NAN", this->illuminance_);
+    this->illuminance_ = NAN;
+    return;
+  }
+
+  if (r == 0) {
+    ESP_LOGW(TAG, "Red channel is zero, cannot compute color temperature");
+    return;
+  }
 
   // Color Temperature Calculation (DN40)
   /* A simple method of measuring color temp is to use the ratio of blue */
-  /* to red light, taking IR cancellation into account. */
-  this->color_temperature_ = (CT_COEF * b2) / /** Color temp coefficient. */
-                                 r2 +
-                             CT_OFFSET; /** Color temp offset. */
+  /* to red light. */
+
+  this->color_temperature_ = (CT_COEF * (float) b) / (float) r + CT_OFFSET;
+
+  // Ensure the color temperature stays within reasonable bounds
+  if (this->color_temperature_ < MIN_COLOR_TEMPERATURE) {
+    ESP_LOGW(TAG, "Calculated color temperature value too low (%f), setting to NAN", this->color_temperature_);
+    this->color_temperature_ = NAN;
+  } else if (this->color_temperature_ > MAX_COLOR_TEMPERATURE) {
+    ESP_LOGW(TAG, "Calculated color temperature value too high (%f), setting to NAN", this->color_temperature_);
+    this->color_temperature_ = NAN;
+  }
 }
 
 void TCS34725Component::update() {


### PR DESCRIPTION
# What does this implement/fix?

- Removed IR component calculation since the sensor includes an IR filter. (see [datasheet](https://cdn-shop.adafruit.com/datasheets/TCS34725.pdf))
- Added handling to ensure illuminance never drops below 0.0
- Capped illuminance at a maximum value of 100,000 lux; set to NAN if exceeded.
- Added validation for color temperature with a range check (1000 K to 15,000 K); set to NAN if outside this range.
- Updated log messages to reflect changes and provide more accurate warnings for saturation and invalid values.

Additional notes for the reviewer which may not be familiar with the limits of this sensor:

Depending on the integration interval of 153-614 ms and the gain of 1x to 60x (which can be compared to switching the ISO on a camera) the sensor will peak at different maximum values of light hitting the sensor. But it's never ever anywhere close to 100,000 lux. Depending on the composition of the light, it will start to overexposure at around 20-30,000 lux. So setting 100,000 lux as a safeguard is just a safety precaution, as we gave back infinity in some instances in the past. So everything past 100,000 lux are calculation errors, no real data would ever go so high.

Integration times below 153 ms btw are equally sensitive to light, aka will result in the same reported lux as 153 ms. They exist (as far as I can tell) just to get more measurements per second with reduced accuracy — or with reduced power requirements.

The safeguard below 0.0 lux is a different topic: The lux calculation is done based on a correction factor for the chip and a correction factor for each of the 3 color channels. The correction factor given by the vendor for the blue channel is negative, so very large amounts of blue light will return a negative lux value, which is unexpected.

This PR will implement at least, that we don't return a negative lux value (which is never correct).

The next PR will fix the calculation itself, so mainly blue light is handled correctly.

Color temperature between 1000 K and 15000 K is plenty, and will probably lead to still weird results at the ends. I may look at this in the future, to either put tighter limits on that or correct the calculation. But as of now I don't have the hardware to measure the correct color temperature in this range, so let's just cut the calculation off when it makes absolutely no sense anymore - which is 1000 K and 15000 K, so we don't report -1 million K anymore ;)

![189741719-b4d0b656-7fb0-47de-b048-c2d3cae9bc27](https://github.com/user-attachments/assets/3b201378-b7b7-4fae-9d0a-ae6b7403b4a4)

 
## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes [3575](https://github.com/esphome/issues/issues/3575) (mostly - another PR will follow up with some additional fixes)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

<details>

```yaml
esphome:
  name: $devicename
  platform: ESP8266
  board: d1_mini
  friendly_name: $friendly_name

substitutions:
  devicename: ambient-light-sensor
  friendly_name: "Ambient Light Sensor"

logger:
  level: DEBUG

mdns:
  
time:
  - platform: homeassistant

api:
  encryption: 
    key: !secret api_key-ambient-light-sensor

ota:
  platform: esphome
  password: !secret ota_password_ambient-light-sensor

wifi:
  networks:
    ssid: !secret wifi_ssid
    password: !secret wifi_password
    manual_ip:
      static_ip: !secret ip-ambient-light-sensor
      gateway: !secret wifi_gateway
      subnet: !secret wifi_subnet
      dns1: !secret wifi_dns1

i2c:
  sda: D1
  scl: D2
  scan: true
  id: bus_a

sensor:
  - platform: tcs34725
    i2c_id: bus_a
    red_channel:
      name: "$friendly_name Red Channel relative"
      accuracy_decimals: 1
    green_channel:
      name: "$friendly_name Green Channel relative"
      accuracy_decimals: 1
    blue_channel:
      name: "$friendly_name Blue Channel relative"
      accuracy_decimals: 1
    clear_channel:
      name: "$friendly_name Clear Channel"
      accuracy_decimals: 1
    illuminance:
      name: "$friendly_name Illuminance"
      accuracy_decimals: 0
    color_temperature:
      name: "$friendly_name Color Temperature"
      accuracy_decimals: 0
    gain: 1x
    integration_time: auto
    glass_attenuation_factor: 1.0
    address: 0x29   

output:
  - platform: gpio
    pin: D3
    id: white_led
    inverted: false
  
light:
  - platform: binary
    output: white_led
    name: "$friendly_name White LED"
```

</details>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
