### PR TITLE
tcs34725: fix color/clear channel percentage calculations on long exposures

### DIFF
--- a/esphome/components/tcs34725/tcs34725.cpp
+++ b/esphome/components/tcs34725/tcs34725.cpp
@@ -211,7 +211,7 @@ void TCS34725Component::update() {
   if (raw_c == 0) {
     channel_c = channel_r = channel_g = channel_b = 0.0f;
   } else {
-    float max_count = this->integration_time_ * 1024.0f / 2.4;
+    float max_count = this->integration_time_ <= 153.6f ? this->integration_time_ * 1024.0f / 2.4f : 65535.0f;
     float sum = raw_c;
     channel_r = raw_r / sum * 100.0f;
     channel_g = raw_g / sum * 100.0f;


### PR DESCRIPTION
# What does this implement/fix?

This sensor reaches it's 16 bit counter maximum on full exposure at 153.4 ms integration time. The calculation assumed that this counter would go higher, on even further exposure times, and thus underreported e.g. the clear channel with 25% on full exposure at 614.4 ms integration time.

To sum it up shortly, for the reviewer which may not be familiar with this chip how it works:

This sensor counts light up to 1024 for each 2.4 ms of exposure. So 100% exposure at 2.4 ms integration time is 1024. It's 2048 at 4.8 etc.

This maximum value goes up until 153.4 ms exposure time is reached, where the chip reaches it digital maximum, and the value cannot climb higher.

So we now calculate the maximum exposure time correctly, and don't assume higher values than 65535 above 153.4 ms integration time.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

<details>

```yaml
esphome:
  name: $devicename
  platform: ESP8266
  board: d1_mini
  friendly_name: $friendly_name

substitutions:
  devicename: ambient-light-sensor
  friendly_name: "Ambient Light Sensor"

logger:
  level: DEBUG

mdns:
  
time:
  - platform: homeassistant

api:
  encryption: 
    key: !secret api_key-ambient-light-sensor

ota:
  platform: esphome
  password: !secret ota_password_ambient-light-sensor

wifi:
  networks:
    ssid: !secret wifi_ssid
    password: !secret wifi_password
    manual_ip:
      static_ip: !secret ip-ambient-light-sensor
      gateway: !secret wifi_gateway
      subnet: !secret wifi_subnet
      dns1: !secret wifi_dns1

i2c:
  sda: D1
  scl: D2
  scan: true
  id: bus_a

sensor:
  - platform: tcs34725
    i2c_id: bus_a
    red_channel:
      name: "$friendly_name Red Channel relative"
      accuracy_decimals: 1
    green_channel:
      name: "$friendly_name Green Channel relative"
      accuracy_decimals: 1
    blue_channel:
      name: "$friendly_name Blue Channel relative"
      accuracy_decimals: 1
    clear_channel:
      name: "$friendly_name Clear Channel"
      accuracy_decimals: 1
    illuminance:
      name: "$friendly_name Illuminance"
      accuracy_decimals: 0
    color_temperature:
      name: "$friendly_name Color Temperature"
      accuracy_decimals: 0
    gain: 1x
    integration_time: auto
    glass_attenuation_factor: 1.0
    address: 0x29   

output:
  - platform: gpio
    pin: D3
    id: white_led
    inverted: false
  
light:
  - platform: binary
    output: white_led
    name: "$friendly_name White LED"
```

</details>

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
