### PR TITLE
Fix parsing of µs time periods in config

### DIFF
--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -750,6 +750,7 @@ def time_period_str_unit(value):
         "ns": "nanoseconds",
         "nanoseconds": "nanoseconds",
         "us": "microseconds",
+        "µs": "microseconds",
         "microseconds": "microseconds",
         "ms": "milliseconds",
         "milliseconds": "milliseconds",

--- a/tests/components/esp32_rmt_led_strip/test.esp32-c3-idf.yaml
+++ b/tests/components/esp32_rmt_led_strip/test.esp32-c3-idf.yaml
@@ -12,7 +12,7 @@ light:
     num_leds: 60
     rmt_channel: 1
     rgb_order: RGB
-    bit0_high: 100us
-    bit0_low: 100us
-    bit1_high: 100us
-    bit1_low: 100us
+    bit0_high: 100µs
+    bit0_low: 100µs
+    bit1_high: 100µs
+    bit1_low: 100µs

--- a/tests/components/esp32_rmt_led_strip/test.esp32-idf.yaml
+++ b/tests/components/esp32_rmt_led_strip/test.esp32-idf.yaml
@@ -12,7 +12,7 @@ light:
     num_leds: 60
     rmt_channel: 2
     rgb_order: RGB
-    bit0_high: 100us
-    bit0_low: 100us
-    bit1_high: 100us
-    bit1_low: 100us
+    bit0_high: 100µs
+    bit0_low: 100µs
+    bit1_high: 100µs
+    bit1_low: 100µs


### PR DESCRIPTION
The correct SI prefix for micro is µ. In the 1980s where computers only really had ASCII, some people got used to using 'u' instead, but it was always technically wrong. In the 1990s, we had the legacy 8-bit character sets so using anything outside the ASCII range was still problematic, and people stuck with the 'u' approximation.

In the 21st century we have Unicode, the µ character is trivial to type on many keyboards (it's just <Right-Alt + m> on my British keyboard).

I find myself typing time periods like '50µs' *correctly*, then getting a build failure and having to adjust it to the 20th century version.

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
remote_receiver:
 - id: proxy_rx
   pin:
     number: GPIO10
     inverted: true
   dump: raw
   rmt_channel: 4
   clock_divider: 40
   filter: 5µs

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
