### PR TITLE
[config_validation] Fix bug with extras on schemas

### DIFF
--- a/esphome/voluptuous_schema.py
+++ b/esphome/voluptuous_schema.py
@@ -226,4 +226,6 @@ class _Schema(vol.Schema):
         if isinstance(schema, vol.Schema):
             schema = schema.schema
         ret = super().extend(schema, extra=extra)
-        return _Schema(ret.schema, extra=ret.extra, extra_schemas=self._extra_schemas)
+        return _Schema(
+            ret.schema, extra=ret.extra, extra_schemas=self._extra_schemas.copy()
+        )


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

The extra_schemas list was being copied by reference (default for python) so any modifications when completely different components were using a shared base schema (like `cv.ENTITY_BASE_SCHEMA`) would be applied to all of the schemas.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
