### PR TITLE
Change priority of ili9xxx from HARDWARE to HARDWARE_LATE 

### DIFF
--- a/esphome/components/ili9xxx/ili9xxx_display.cpp
+++ b/esphome/components/ili9xxx/ili9xxx_display.cpp
@@ -126,7 +126,7 @@ void ILI9XXXDisplay::dump_config() {
   LOG_UPDATE_INTERVAL(this);
 }
 
-float ILI9XXXDisplay::get_setup_priority() const { return setup_priority::HARDWARE; }
+float ILI9XXXDisplay::get_setup_priority() const { return setup_priority::HARDWARE_LATE; }
 
 void ILI9XXXDisplay::fill(Color color) {
   if (!this->check_buffer_())


### PR DESCRIPTION


# What does this implement/fix?

Simple fix to prevent too early calls to the SPI bus I changed the priority of the ili9xxx display component from HARDWARE to HARDWARE_LATE. 

This resolved an issue where the ili9341 display on the [mch2022 badge](https://badge.team/docs/badges/mch2022/) tried to use the SPI bus too early, causing error ```[15:29:06][W][spi-esp-idf:041]: spi_setup called before initialisation ```
As suggested [in the component source here](https://github.com/esphome/esphome/blob/21fbbc5fb9477704be8b1ec8293d2a729f7a0072/esphome/core/component.h#L27) I changed the priority from ``` HARDWARE``` to ```HARDWARE_LATE``` which resolved the issue. I suspect this will prevent similar issues for others in the future and I don't think it likely will cause issues for existing users. 

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

No user facing changes in configuration or documentation for this fix.

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
