### PR TITLE
[core] add ring buffer destructor

### DIFF
--- a/esphome/core/ring_buffer.h
+++ b/esphome/core/ring_buffer.h
@@ -12,6 +12,8 @@ namespace esphome {
 
 class RingBuffer {
  public:
+  ~RingBuffer();
+
   /**
    * @brief Reads from the ring buffer, waiting up to a specified number of ticks if necessary.
    *
@@ -83,6 +85,7 @@ class RingBuffer {
   StreamBufferHandle_t handle_;
   StaticStreamBuffer_t structure_;
   uint8_t *storage_;
+  size_t size_{0};
 };
 
 }  // namespace esphome


### PR DESCRIPTION
# What does this implement/fix?

Adds a destructor to the RingBuffer class. It is called when a ring buffer's unique_ptr calls ``ring_buffer.reset()``. This properly frees the memory used, which is useful for devices with limited RAM.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** not applicable

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** not applicable

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
