### PR TITLE
[wifi] Replace ``USE_ESP32_IGNORE_EFUSE_MAC_CRC`` with IDF's ``CONFIG_ESP_MAC_IGNORE_MAC_CRC_ERROR``

### DIFF
--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -379,7 +379,8 @@ def final_validate(config):
 
     if (
         config[CONF_VARIANT] != VARIANT_ESP32
-        and CONF_IGNORE_EFUSE_MAC_CRC in config[CONF_FRAMEWORK][CONF_ADVANCED]
+        and CONF_ADVANCED in (conf_fw := config[CONF_FRAMEWORK])
+        and CONF_IGNORE_EFUSE_MAC_CRC in conf_fw[CONF_ADVANCED]
     ):
         raise cv.Invalid(
             f"{CONF_IGNORE_EFUSE_MAC_CRC} is not supported on {config[CONF_VARIANT]}"

--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -53,6 +53,7 @@ from .const import (  # noqa
     KEY_SDKCONFIG_OPTIONS,
     KEY_SUBMODULES,
     KEY_VARIANT,
+    VARIANT_ESP32,
     VARIANT_FRIENDLY,
     VARIANTS,
 )
@@ -376,6 +377,14 @@ def final_validate(config):
             f"Please specify {CONF_FLASH_SIZE} within esp32 configuration only"
         )
 
+    if (
+        config[CONF_VARIANT] != VARIANT_ESP32
+        and CONF_IGNORE_EFUSE_MAC_CRC in config[CONF_FRAMEWORK][CONF_ADVANCED]
+    ):
+        raise cv.Invalid(
+            f"{CONF_IGNORE_EFUSE_MAC_CRC} is not supported on {config[CONF_VARIANT]}"
+        )
+
     return config
 
 
@@ -405,7 +414,7 @@ ESP_IDF_FRAMEWORK_SCHEMA = cv.All(
                     cv.Optional(
                         CONF_IGNORE_EFUSE_CUSTOM_MAC, default=False
                     ): cv.boolean,
-                    cv.Optional(CONF_IGNORE_EFUSE_MAC_CRC, default=False): cv.boolean,
+                    cv.Optional(CONF_IGNORE_EFUSE_MAC_CRC): cv.boolean,
                 }
             ),
             cv.Optional(CONF_COMPONENTS, default=[]): cv.ensure_list(
@@ -532,8 +541,8 @@ async def to_code(config):
 
         if conf[CONF_ADVANCED][CONF_IGNORE_EFUSE_CUSTOM_MAC]:
             cg.add_define("USE_ESP32_IGNORE_EFUSE_CUSTOM_MAC")
-        if conf[CONF_ADVANCED][CONF_IGNORE_EFUSE_MAC_CRC]:
-            cg.add_define("USE_ESP32_IGNORE_EFUSE_MAC_CRC")
+        if conf[CONF_ADVANCED].get(CONF_IGNORE_EFUSE_MAC_CRC):
+            add_idf_sdkconfig_option("CONFIG_ESP_MAC_IGNORE_MAC_CRC_ERROR", True)
             if (framework_ver.major, framework_ver.minor) >= (4, 4):
                 add_idf_sdkconfig_option(
                     "CONFIG_ESP_PHY_CALIBRATION_AND_DATA_STORAGE", False

--- a/esphome/components/wifi/wifi_component_esp_idf.cpp
+++ b/esphome/components/wifi/wifi_component_esp_idf.cpp
@@ -131,16 +131,10 @@ void event_handler(void *arg, esp_event_base_t event_base, int32_t event_id, voi
 
 void WiFiComponent::wifi_pre_setup_() {
   uint8_t mac[6];
-#ifdef USE_ESP32_IGNORE_EFUSE_MAC_CRC
-  get_mac_address_raw(mac);
-  set_mac_address(mac);
-  ESP_LOGV(TAG, "Use EFuse MAC without checking CRC: %s", get_mac_address_pretty().c_str());
-#else
   if (has_custom_mac_address()) {
     get_mac_address_raw(mac);
     set_mac_address(mac);
   }
-#endif
   esp_err_t err = esp_netif_init();
   if (err != ERR_OK) {
     ESP_LOGE(TAG, "esp_netif_init failed: %s", esp_err_to_name(err));

--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -662,13 +662,9 @@ void get_mac_address_raw(uint8_t *mac) {  // NOLINT(readability-non-const-parame
   static const uint8_t esphome_host_mac_address[6] = USE_ESPHOME_HOST_MAC_ADDRESS;
   memcpy(mac, esphome_host_mac_address, sizeof(esphome_host_mac_address));
 #elif defined(USE_ESP32)
-#if defined(CONFIG_SOC_IEEE802154_SUPPORTED) || defined(USE_ESP32_IGNORE_EFUSE_MAC_CRC)
+#if defined(CONFIG_SOC_IEEE802154_SUPPORTED)
   // When CONFIG_SOC_IEEE802154_SUPPORTED is defined, esp_efuse_mac_get_default
-  // returns the 802.15.4 EUI-64 address. Read directly from eFuse instead.
-  // On some devices, the MAC address that is burnt into EFuse does not
-  // match the CRC that goes along with it. For those devices, this
-  // work-around reads and uses the MAC address as-is from EFuse,
-  // without doing the CRC check.
+  // returns the 802.15.4 EUI-64 address, so we read directly from eFuse instead.
   if (has_custom_mac_address()) {
     esp_efuse_read_field_blob(ESP_EFUSE_MAC_CUSTOM, mac, 48);
   } else {


### PR DESCRIPTION
# What does this implement/fix?

The define `USE_ESP32_IGNORE_EFUSE_MAC_CRC` is redundant and we can just use IDF's native `CONFIG_ESP_MAC_IGNORE_MAC_CRC_ERROR` flag, instead. See IDF's code [here](https://github.com/espressif/esp-idf/blob/e499576efdb086551abe309a72899302f82077b7/components/esp_hw_support/mac_addr.c#L131-L144) and [here](https://github.com/espressif/esp-idf/blob/e499576efdb086551abe309a72899302f82077b7/components/esp_hw_support/mac_addr.c#L98-L105).

This is effectively a streamlining of #2399; note that only the ESP32 (not variants) supports CRC checking of the MAC address.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
