### PR TITLE
[rp2040] Always use maxgerhardt platform fork

### DIFF
--- a/esphome/components/rp2040/__init__.py
+++ b/esphome/components/rp2040/__init__.py
@@ -71,6 +71,14 @@ def _format_framework_arduino_version(ver: cv.Version) -> str:
     # return f"~1.{ver.major}{ver.minor:02d}{ver.patch:02d}.0"
 
 
+def _parse_platform_version(value):
+    value = cv.string(value)
+    if value.startswith("http"):
+        return value
+
+    return f"https://github.com/maxgerhardt/platform-raspberrypi.git#{value}"
+
+
 # NOTE: Keep this in mind when updating the recommended version:
 #  * The new version needs to be thoroughly validated before changing the
 #    recommended version as otherwise a bunch of devices could be bricked
@@ -82,10 +90,9 @@ def _format_framework_arduino_version(ver: cv.Version) -> str:
 #  - https://api.registry.platformio.org/v3/packages/earlephilhower/tool/framework-arduinopico
 RECOMMENDED_ARDUINO_FRAMEWORK_VERSION = cv.Version(3, 9, 4)
 
-# The platformio/raspberrypi version to use for arduino frameworks
-#  - https://github.com/platformio/platform-raspberrypi/releases
-#  - https://api.registry.platformio.org/v3/packages/platformio/platform/raspberrypi
-ARDUINO_PLATFORM_VERSION = cv.Version(1, 13, 0)
+# The raspberrypi platform version to use for arduino frameworks
+#  - https://github.com/maxgerhardt/platform-raspberrypi/tags
+RECOMMENDED_ARDUINO_PLATFORM_VERSION = "v1.2.0-gcc12"
 
 
 def _arduino_check_versions(value):
@@ -111,7 +118,8 @@ def _arduino_check_versions(value):
     value[CONF_SOURCE] = source or _format_framework_arduino_version(version)
 
     value[CONF_PLATFORM_VERSION] = value.get(
-        CONF_PLATFORM_VERSION, _parse_platform_version(str(ARDUINO_PLATFORM_VERSION))
+        CONF_PLATFORM_VERSION,
+        _parse_platform_version(RECOMMENDED_ARDUINO_PLATFORM_VERSION),
     )
 
     if version != RECOMMENDED_ARDUINO_FRAMEWORK_VERSION:
@@ -120,15 +128,6 @@ def _arduino_check_versions(value):
         )
 
     return value
-
-
-def _parse_platform_version(value):
-    try:
-        # if platform version is a valid version constraint, prefix the default package
-        cv.platformio_version_constraint(value)
-        return f"platformio/raspberrypi@{value}"
-    except cv.Invalid:
-        return value
 
 
 ARDUINO_FRAMEWORK_SCHEMA = cv.All(

--- a/esphome/wizard.py
+++ b/esphome/wizard.py
@@ -90,9 +90,6 @@ esp32:
 RP2040_CONFIG = """
 rp2040:
   board: {board}
-  framework:
-    # Required until https://github.com/platformio/platform-raspberrypi/pull/36 is merged
-    platform_version: https://github.com/maxgerhardt/platform-raspberrypi.git#5e87ae34ca025274df25b3303e9e9cb6c120123c
 """
 
 BK72XX_CONFIG = """
@@ -184,18 +181,14 @@ def wizard_file(**kwargs):
     password: "{fallback_psk}"
 
 captive_portal:
-    """.format(
-            **kwargs
-        )
+    """.format(**kwargs)
     else:
         config += """
   # Enable fallback hotspot in case wifi connection fails
   ap:
     ssid: "{fallback_name}"
     password: "{fallback_psk}"
-    """.format(
-            **kwargs
-        )
+    """.format(**kwargs)
 
     return config
 

--- a/esphome/wizard.py
+++ b/esphome/wizard.py
@@ -181,14 +181,18 @@ def wizard_file(**kwargs):
     password: "{fallback_psk}"
 
 captive_portal:
-    """.format(**kwargs)
+    """.format(
+            **kwargs
+        )
     else:
         config += """
   # Enable fallback hotspot in case wifi connection fails
   ap:
     ssid: "{fallback_name}"
     password: "{fallback_psk}"
-    """.format(**kwargs)
+    """.format(
+            **kwargs
+        )
 
     return config
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -165,7 +165,7 @@ platform_packages =
 extends = common:arduino
 board_build.filesystem_size = 0.5m
 
-platform = https://github.com/maxgerhardt/platform-raspberrypi.git#5e87ae34ca025274df25b3303e9e9cb6c120123c
+platform = https://github.com/maxgerhardt/platform-raspberrypi.git#v1.2.0-gcc12
 platform_packages =
     ; earlephilhower/framework-arduinopico@~1.20602.0 ; Cannot use the platformio package until old releases stop getting deleted
     earlephilhower/framework-arduinopico@https://github.com/earlephilhower/arduino-pico/releases/download/3.9.4/rp2040-3.9.4.zip

--- a/tests/test_build_components/build_components_base.rp2040-ard.yaml
+++ b/tests/test_build_components/build_components_base.rp2040-ard.yaml
@@ -4,9 +4,6 @@ esphome:
 
 rp2040:
   board: rpipicow
-  framework:
-    # Waiting for https://github.com/platformio/platform-raspberrypi/pull/36
-    platform_version: https://github.com/maxgerhardt/platform-raspberrypi.git#5e87ae34ca025274df25b3303e9e9cb6c120123c
 
 logger:
   level: VERY_VERBOSE


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Following on from #7507, this moves to a tag added on the repo (the same commit sha) and always uses the github repository as the source of the platform going forward as platformio/platform-raspberrypi#36 was closed and will probably never be merged in.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/6291

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#4291

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
