### PR TITLE
[wifi] Fix error message when no custom MAC is set

### DIFF
--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -44,10 +44,10 @@
 #endif
 #ifdef USE_ESP32
 #include "esp32/rom/crc.h"
-#endif
 
 #include "esp_efuse.h"
 #include "esp_efuse_table.h"
+#endif
 
 #ifdef USE_LIBRETINY
 #include <WiFi.h>  // for macAddress()

--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -712,8 +712,7 @@ bool has_custom_mac_address() {
 #ifdef USE_ESP32
   uint8_t mac[6];
   // do not use 'esp_efuse_mac_get_custom(mac)' because it drops an error in the logs whenever it fails
-#if defined(USE_ESP32_VARIANT_ESP32C2) || defined(USE_ESP32_VARIANT_ESP32C3) || defined(USE_ESP32_VARIANT_ESP32C6) || \
-    defined(USE_ESP32_VARIANT_ESP32H2) || defined(USE_ESP32_VARIANT_ESP32S2) || defined(USE_ESP32_VARIANT_ESP32S3)
+#ifndef USE_ESP32_VARIANT_ESP32
   return (esp_efuse_read_field_blob(ESP_EFUSE_USER_DATA_MAC_CUSTOM, mac, 48) == ESP_OK) && mac_address_is_valid(mac);
 #else
   return (esp_efuse_read_field_blob(ESP_EFUSE_MAC_CUSTOM, mac, 48) == ESP_OK) && mac_address_is_valid(mac);

--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -712,7 +712,11 @@ bool has_custom_mac_address() {
 #ifdef USE_ESP32
   uint8_t mac[6];
   // do not use 'esp_efuse_mac_get_custom(mac)' because it drops an error in the logs whenever it fails
+#if defined(USE_ESP32_VARIANT_ESP32C3)  // fixed in IDF 5+
+  return (esp_efuse_read_field_blob(ESP_EFUSE_USER_DATA_MAC_CUSTOM, mac, 48) == ESP_OK) && mac_address_is_valid(mac);
+#else
   return (esp_efuse_read_field_blob(ESP_EFUSE_MAC_CUSTOM, mac, 48) == ESP_OK) && mac_address_is_valid(mac);
+#endif
 #else
   return false;
 #endif

--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -46,10 +46,8 @@
 #include "esp32/rom/crc.h"
 #endif
 
-#if defined(CONFIG_SOC_IEEE802154_SUPPORTED) || defined(USE_ESP32_IGNORE_EFUSE_MAC_CRC)
 #include "esp_efuse.h"
 #include "esp_efuse_table.h"
-#endif
 
 #ifdef USE_LIBRETINY
 #include <WiFi.h>  // for macAddress()
@@ -713,11 +711,8 @@ void set_mac_address(uint8_t *mac) { esp_base_mac_addr_set(mac); }
 bool has_custom_mac_address() {
 #ifdef USE_ESP32
   uint8_t mac[6];
-#if defined(CONFIG_SOC_IEEE802154_SUPPORTED) || defined(USE_ESP32_IGNORE_EFUSE_MAC_CRC)
+  // do not use 'esp_efuse_mac_get_custom(mac)' because it drops an error in the logs whenever it fails
   return (esp_efuse_read_field_blob(ESP_EFUSE_MAC_CUSTOM, mac, 48) == ESP_OK) && mac_address_is_valid(mac);
-#else
-  return (esp_efuse_mac_get_custom(mac) == ESP_OK) && mac_address_is_valid(mac);
-#endif
 #else
   return false;
 #endif

--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -712,7 +712,8 @@ bool has_custom_mac_address() {
 #ifdef USE_ESP32
   uint8_t mac[6];
   // do not use 'esp_efuse_mac_get_custom(mac)' because it drops an error in the logs whenever it fails
-#if defined(USE_ESP32_VARIANT_ESP32C3)  // fixed in IDF 5+
+#if defined(USE_ESP32_VARIANT_ESP32C2) || defined(USE_ESP32_VARIANT_ESP32C3) || defined(USE_ESP32_VARIANT_ESP32C6) || \
+    defined(USE_ESP32_VARIANT_ESP32H2) || defined(USE_ESP32_VARIANT_ESP32S2) || defined(USE_ESP32_VARIANT_ESP32S3)
   return (esp_efuse_read_field_blob(ESP_EFUSE_USER_DATA_MAC_CUSTOM, mac, 48) == ESP_OK) && mac_address_is_valid(mac);
 #else
   return (esp_efuse_read_field_blob(ESP_EFUSE_MAC_CUSTOM, mac, 48) == ESP_OK) && mac_address_is_valid(mac);


### PR DESCRIPTION
# What does this implement/fix?

SSIA -- builds on #7498 to mitigate displaying unnecessary errors in the device's log.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
