### PR TITLE
let execute code owners in venv without installing esphome

### DIFF
--- a/script/build_codeowners.py
+++ b/script/build_codeowners.py
@@ -3,6 +3,9 @@ import argparse
 from collections import defaultdict
 from pathlib import Path
 import sys
+import os
+
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 
 from esphome.config import get_component, get_platform
 from esphome.const import KEY_CORE, KEY_TARGET_FRAMEWORK


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

it allows to execute build_code owners directly from venv without pip install.
```
(venv) $ ./script/build_codeowners.py
```
## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
