### PR TITLE
[web_server] send init_entity event on iteration

### DIFF
--- a/esphome/components/web_server/list_entities.cpp
+++ b/esphome/components/web_server/list_entities.cpp
@@ -48,7 +48,8 @@ bool ListEntitiesIterator::on_light(light::LightState *light) {
 bool ListEntitiesIterator::on_sensor(sensor::Sensor *sensor) {
   if (this->web_server_->events_.count() == 0)
     return true;
-  this->web_server_->events_.send(this->web_server_->sensor_json(sensor, sensor->state, DETAIL_ALL).c_str(), "init_entity");
+  this->web_server_->events_.send(this->web_server_->sensor_json(sensor, sensor->state, DETAIL_ALL).c_str(),
+                                  "init_entity");
   return true;
 }
 #endif
@@ -82,7 +83,8 @@ bool ListEntitiesIterator::on_text_sensor(text_sensor::TextSensor *text_sensor) 
 bool ListEntitiesIterator::on_lock(lock::Lock *a_lock) {
   if (this->web_server_->events_.count() == 0)
     return true;
-  this->web_server_->events_.send(this->web_server_->lock_json(a_lock, a_lock->state, DETAIL_ALL).c_str(), "init_entity");
+  this->web_server_->events_.send(this->web_server_->lock_json(a_lock, a_lock->state, DETAIL_ALL).c_str(),
+                                  "init_entity");
   return true;
 }
 #endif
@@ -109,7 +111,8 @@ bool ListEntitiesIterator::on_climate(climate::Climate *climate) {
 bool ListEntitiesIterator::on_number(number::Number *number) {
   if (this->web_server_->events_.count() == 0)
     return true;
-  this->web_server_->events_.send(this->web_server_->number_json(number, number->state, DETAIL_ALL).c_str(), "init_entity");
+  this->web_server_->events_.send(this->web_server_->number_json(number, number->state, DETAIL_ALL).c_str(),
+                                  "init_entity");
   return true;
 }
 #endif
@@ -152,7 +155,8 @@ bool ListEntitiesIterator::on_text(text::Text *text) {
 bool ListEntitiesIterator::on_select(select::Select *select) {
   if (this->web_server_->events_.count() == 0)
     return true;
-  this->web_server_->events_.send(this->web_server_->select_json(select, select->state, DETAIL_ALL).c_str(), "init_entity");
+  this->web_server_->events_.send(this->web_server_->select_json(select, select->state, DETAIL_ALL).c_str(),
+                                  "init_entity");
   return true;
 }
 #endif
@@ -173,7 +177,8 @@ bool ListEntitiesIterator::on_alarm_control_panel(alarm_control_panel::AlarmCont
 bool ListEntitiesIterator::on_event(event::Event *event) {
   // Null event type, since we are just iterating over entities
   const std::string null_event_type = "";
-  this->web_server_->events_.send(this->web_server_->event_json(event, null_event_type, DETAIL_ALL).c_str(), "init_entity");
+  this->web_server_->events_.send(this->web_server_->event_json(event, null_event_type, DETAIL_ALL).c_str(),
+                                  "init_entity");
   return true;
 }
 #endif

--- a/esphome/components/web_server/list_entities.cpp
+++ b/esphome/components/web_server/list_entities.cpp
@@ -16,7 +16,7 @@ bool ListEntitiesIterator::on_binary_sensor(binary_sensor::BinarySensor *binary_
   if (this->web_server_->events_.count() == 0)
     return true;
   this->web_server_->events_.send(
-      this->web_server_->binary_sensor_json(binary_sensor, binary_sensor->state, DETAIL_ALL).c_str(), "state");
+      this->web_server_->binary_sensor_json(binary_sensor, binary_sensor->state, DETAIL_ALL).c_str(), "init_entity");
   return true;
 }
 #endif
@@ -24,7 +24,7 @@ bool ListEntitiesIterator::on_binary_sensor(binary_sensor::BinarySensor *binary_
 bool ListEntitiesIterator::on_cover(cover::Cover *cover) {
   if (this->web_server_->events_.count() == 0)
     return true;
-  this->web_server_->events_.send(this->web_server_->cover_json(cover, DETAIL_ALL).c_str(), "state");
+  this->web_server_->events_.send(this->web_server_->cover_json(cover, DETAIL_ALL).c_str(), "init_entity");
   return true;
 }
 #endif
@@ -32,7 +32,7 @@ bool ListEntitiesIterator::on_cover(cover::Cover *cover) {
 bool ListEntitiesIterator::on_fan(fan::Fan *fan) {
   if (this->web_server_->events_.count() == 0)
     return true;
-  this->web_server_->events_.send(this->web_server_->fan_json(fan, DETAIL_ALL).c_str(), "state");
+  this->web_server_->events_.send(this->web_server_->fan_json(fan, DETAIL_ALL).c_str(), "init_entity");
   return true;
 }
 #endif
@@ -40,7 +40,7 @@ bool ListEntitiesIterator::on_fan(fan::Fan *fan) {
 bool ListEntitiesIterator::on_light(light::LightState *light) {
   if (this->web_server_->events_.count() == 0)
     return true;
-  this->web_server_->events_.send(this->web_server_->light_json(light, DETAIL_ALL).c_str(), "state");
+  this->web_server_->events_.send(this->web_server_->light_json(light, DETAIL_ALL).c_str(), "init_entity");
   return true;
 }
 #endif
@@ -48,7 +48,7 @@ bool ListEntitiesIterator::on_light(light::LightState *light) {
 bool ListEntitiesIterator::on_sensor(sensor::Sensor *sensor) {
   if (this->web_server_->events_.count() == 0)
     return true;
-  this->web_server_->events_.send(this->web_server_->sensor_json(sensor, sensor->state, DETAIL_ALL).c_str(), "state");
+  this->web_server_->events_.send(this->web_server_->sensor_json(sensor, sensor->state, DETAIL_ALL).c_str(), "init_entity");
   return true;
 }
 #endif
@@ -57,7 +57,7 @@ bool ListEntitiesIterator::on_switch(switch_::Switch *a_switch) {
   if (this->web_server_->events_.count() == 0)
     return true;
   this->web_server_->events_.send(this->web_server_->switch_json(a_switch, a_switch->state, DETAIL_ALL).c_str(),
-                                  "state");
+                                  "init_entity");
   return true;
 }
 #endif
@@ -65,7 +65,7 @@ bool ListEntitiesIterator::on_switch(switch_::Switch *a_switch) {
 bool ListEntitiesIterator::on_button(button::Button *button) {
   if (this->web_server_->events_.count() == 0)
     return true;
-  this->web_server_->events_.send(this->web_server_->button_json(button, DETAIL_ALL).c_str(), "state");
+  this->web_server_->events_.send(this->web_server_->button_json(button, DETAIL_ALL).c_str(), "init_entity");
   return true;
 }
 #endif
@@ -74,7 +74,7 @@ bool ListEntitiesIterator::on_text_sensor(text_sensor::TextSensor *text_sensor) 
   if (this->web_server_->events_.count() == 0)
     return true;
   this->web_server_->events_.send(
-      this->web_server_->text_sensor_json(text_sensor, text_sensor->state, DETAIL_ALL).c_str(), "state");
+      this->web_server_->text_sensor_json(text_sensor, text_sensor->state, DETAIL_ALL).c_str(), "init_entity");
   return true;
 }
 #endif
@@ -82,7 +82,7 @@ bool ListEntitiesIterator::on_text_sensor(text_sensor::TextSensor *text_sensor) 
 bool ListEntitiesIterator::on_lock(lock::Lock *a_lock) {
   if (this->web_server_->events_.count() == 0)
     return true;
-  this->web_server_->events_.send(this->web_server_->lock_json(a_lock, a_lock->state, DETAIL_ALL).c_str(), "state");
+  this->web_server_->events_.send(this->web_server_->lock_json(a_lock, a_lock->state, DETAIL_ALL).c_str(), "init_entity");
   return true;
 }
 #endif
@@ -91,7 +91,7 @@ bool ListEntitiesIterator::on_lock(lock::Lock *a_lock) {
 bool ListEntitiesIterator::on_valve(valve::Valve *valve) {
   if (this->web_server_->events_.count() == 0)
     return true;
-  this->web_server_->events_.send(this->web_server_->valve_json(valve, DETAIL_ALL).c_str(), "state");
+  this->web_server_->events_.send(this->web_server_->valve_json(valve, DETAIL_ALL).c_str(), "init_entity");
   return true;
 }
 #endif
@@ -100,7 +100,7 @@ bool ListEntitiesIterator::on_valve(valve::Valve *valve) {
 bool ListEntitiesIterator::on_climate(climate::Climate *climate) {
   if (this->web_server_->events_.count() == 0)
     return true;
-  this->web_server_->events_.send(this->web_server_->climate_json(climate, DETAIL_ALL).c_str(), "state");
+  this->web_server_->events_.send(this->web_server_->climate_json(climate, DETAIL_ALL).c_str(), "init_entity");
   return true;
 }
 #endif
@@ -109,7 +109,7 @@ bool ListEntitiesIterator::on_climate(climate::Climate *climate) {
 bool ListEntitiesIterator::on_number(number::Number *number) {
   if (this->web_server_->events_.count() == 0)
     return true;
-  this->web_server_->events_.send(this->web_server_->number_json(number, number->state, DETAIL_ALL).c_str(), "state");
+  this->web_server_->events_.send(this->web_server_->number_json(number, number->state, DETAIL_ALL).c_str(), "init_entity");
   return true;
 }
 #endif
@@ -118,14 +118,14 @@ bool ListEntitiesIterator::on_number(number::Number *number) {
 bool ListEntitiesIterator::on_date(datetime::DateEntity *date) {
   if (this->web_server_->events_.count() == 0)
     return true;
-  this->web_server_->events_.send(this->web_server_->date_json(date, DETAIL_ALL).c_str(), "state");
+  this->web_server_->events_.send(this->web_server_->date_json(date, DETAIL_ALL).c_str(), "init_entity");
   return true;
 }
 #endif
 
 #ifdef USE_DATETIME_TIME
 bool ListEntitiesIterator::on_time(datetime::TimeEntity *time) {
-  this->web_server_->events_.send(this->web_server_->time_json(time, DETAIL_ALL).c_str(), "state");
+  this->web_server_->events_.send(this->web_server_->time_json(time, DETAIL_ALL).c_str(), "init_entity");
   return true;
 }
 #endif
@@ -134,7 +134,7 @@ bool ListEntitiesIterator::on_time(datetime::TimeEntity *time) {
 bool ListEntitiesIterator::on_datetime(datetime::DateTimeEntity *datetime) {
   if (this->web_server_->events_.count() == 0)
     return true;
-  this->web_server_->events_.send(this->web_server_->datetime_json(datetime, DETAIL_ALL).c_str(), "state");
+  this->web_server_->events_.send(this->web_server_->datetime_json(datetime, DETAIL_ALL).c_str(), "init_entity");
   return true;
 }
 #endif
@@ -143,7 +143,7 @@ bool ListEntitiesIterator::on_datetime(datetime::DateTimeEntity *datetime) {
 bool ListEntitiesIterator::on_text(text::Text *text) {
   if (this->web_server_->events_.count() == 0)
     return true;
-  this->web_server_->events_.send(this->web_server_->text_json(text, text->state, DETAIL_ALL).c_str(), "state");
+  this->web_server_->events_.send(this->web_server_->text_json(text, text->state, DETAIL_ALL).c_str(), "init_entity");
   return true;
 }
 #endif
@@ -152,7 +152,7 @@ bool ListEntitiesIterator::on_text(text::Text *text) {
 bool ListEntitiesIterator::on_select(select::Select *select) {
   if (this->web_server_->events_.count() == 0)
     return true;
-  this->web_server_->events_.send(this->web_server_->select_json(select, select->state, DETAIL_ALL).c_str(), "state");
+  this->web_server_->events_.send(this->web_server_->select_json(select, select->state, DETAIL_ALL).c_str(), "init_entity");
   return true;
 }
 #endif
@@ -164,7 +164,7 @@ bool ListEntitiesIterator::on_alarm_control_panel(alarm_control_panel::AlarmCont
   this->web_server_->events_.send(
       this->web_server_->alarm_control_panel_json(a_alarm_control_panel, a_alarm_control_panel->get_state(), DETAIL_ALL)
           .c_str(),
-      "state");
+      "init_entity");
   return true;
 }
 #endif
@@ -173,7 +173,7 @@ bool ListEntitiesIterator::on_alarm_control_panel(alarm_control_panel::AlarmCont
 bool ListEntitiesIterator::on_event(event::Event *event) {
   // Null event type, since we are just iterating over entities
   const std::string null_event_type = "";
-  this->web_server_->events_.send(this->web_server_->event_json(event, null_event_type, DETAIL_ALL).c_str(), "state");
+  this->web_server_->events_.send(this->web_server_->event_json(event, null_event_type, DETAIL_ALL).c_str(), "init_entity");
   return true;
 }
 #endif
@@ -182,7 +182,7 @@ bool ListEntitiesIterator::on_event(event::Event *event) {
 bool ListEntitiesIterator::on_update(update::UpdateEntity *update) {
   if (this->web_server_->events_.count() == 0)
     return true;
-  this->web_server_->events_.send(this->web_server_->update_json(update, DETAIL_ALL).c_str(), "state");
+  this->web_server_->events_.send(this->web_server_->update_json(update, DETAIL_ALL).c_str(), "init_entity");
   return true;
 }
 #endif


### PR DESCRIPTION
# What does this implement/fix?

Send a `init_entity` event on iteration of entitys instead of a `state` event

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/esphome-webserver/issues/125

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
