### PR TITLE
feedback component: Support for overshoot_duration

### DIFF
--- a/esphome/components/feedback/cover.py
+++ b/esphome/components/feedback/cover.py
@@ -23,6 +23,7 @@ CONF_HAS_BUILT_IN_ENDSTOP = "has_built_in_endstop"
 CONF_INFER_ENDSTOP_FROM_MOVEMENT = "infer_endstop_from_movement"
 CONF_DIRECTION_CHANGE_WAIT_TIME = "direction_change_wait_time"
 CONF_ACCELERATION_WAIT_TIME = "acceleration_wait_time"
+CONF_OVERSHOOT_DURATION = "overshoot_duration"
 CONF_OBSTACLE_ROLLBACK = "obstacle_rollback"
 
 endstop_ns = cg.esphome_ns.namespace("feedback")
@@ -80,6 +81,9 @@ CONFIG_FEEDBACK_COVER_BASE_SCHEMA = (
             ): cv.positive_time_period_milliseconds,
             cv.Optional(
                 CONF_ACCELERATION_WAIT_TIME, "0s"
+            ): cv.positive_time_period_milliseconds,
+            cv.Optional(
+                CONF_OVERSHOOT_DURATION, "0s"
             ): cv.positive_time_period_milliseconds,
             cv.Optional(CONF_OBSTACLE_ROLLBACK, default="10%"): cv.percentage,
         },
@@ -159,4 +163,5 @@ async def to_code(config):
             var.set_direction_change_waittime(config[CONF_DIRECTION_CHANGE_WAIT_TIME])
         )
     cg.add(var.set_acceleration_wait_time(config[CONF_ACCELERATION_WAIT_TIME]))
+    cg.add(var.set_overshoot_duration(config[CONF_OVERSHOOT_DURATION]))
     cg.add(var.set_obstacle_rollback(config[CONF_OBSTACLE_ROLLBACK]))

--- a/esphome/components/feedback/feedback_cover.cpp
+++ b/esphome/components/feedback/feedback_cover.cpp
@@ -78,6 +78,9 @@ void FeedbackCover::dump_config() {
   if (this->acceleration_wait_time_) {
     ESP_LOGCONFIG(TAG, "  Acceleration wait time: %.1fs", this->acceleration_wait_time_ / 1e3f);
   }
+  if (this->overshoot_duration_) {
+    ESP_LOGCONFIG(TAG, "  Overshoot duration: %.1fs", this->overshoot_duration_ / 1e3f);
+  }
 #ifdef USE_BINARY_SENSOR
   if (this->obstacle_rollback_ && (this->open_obstacle_ != nullptr || this->close_obstacle_ != nullptr)) {
     ESP_LOGCONFIG(TAG, "  Obstacle rollback: %.1f%%", this->obstacle_rollback_ * 100);
@@ -230,11 +233,26 @@ void FeedbackCover::loop() {
   // (stoping from endstop sensor is handled in callback)
   if (this->current_trigger_operation_ != COVER_OPERATION_IDLE) {
     if (this->is_at_target_()) {
-      if (this->has_built_in_endstop_ &&
-          (this->target_position_ == COVER_OPEN || this->target_position_ == COVER_CLOSED)) {
-        // Don't trigger stop, let the cover stop by itself.
-        this->set_current_operation_(COVER_OPERATION_IDLE, true);
+      if (this->target_position_ == COVER_OPEN || this->target_position_ == COVER_CLOSED) {
+        if (this->has_built_in_endstop_) {
+          // Don't trigger stop, let the cover stop by itself.
+          this->set_current_operation_(COVER_OPERATION_IDLE, true);
+        } else if (this->overshoot_duration_) {
+          // We want to overshoot a bit on cover being totaly open or closed, in order to make sure cover is synced
+          if (!this->start_overshoot_time_) {
+            // We just started overshooting, save time for comparison
+            this->start_overshoot_time_ = now;
+          } else if (now - this->start_overshoot_time_ > this->overshoot_duration_) {
+            // We overshot enough, stop the cover
+            ESP_LOGD(TAG, "'%s' - Overshoot duration reached. Stopping cover.", this->name_.c_str());
+            this->start_direction_(COVER_OPERATION_IDLE);
+          }
+        } else {
+          // No overshoot_duration, stop immediately at open-close
+          this->start_direction_(COVER_OPERATION_IDLE);
+        }
       } else {
+        // Not on open-close position, stop immediately
         this->start_direction_(COVER_OPERATION_IDLE);
       }
     } else if (now - this->start_dir_time_ > this->max_duration_) {
@@ -336,6 +354,7 @@ void FeedbackCover::start_direction_(CoverOperation dir) {
   switch (dir) {
     case COVER_OPERATION_IDLE:
       trig = this->stop_trigger_;
+      this->start_overshoot_time_ = 0;
       break;
     case COVER_OPERATION_OPENING:
       this->last_operation_ = dir;

--- a/esphome/components/feedback/feedback_cover.h
+++ b/esphome/components/feedback/feedback_cover.h
@@ -34,6 +34,7 @@ class FeedbackCover : public cover::Cover, public Component {
   void set_has_built_in_endstop(bool value) { this->has_built_in_endstop_ = value; }
   void set_assumed_state(bool value) { this->assumed_state_ = value; }
   void set_max_duration(uint32_t max_duration) { this->max_duration_ = max_duration; }
+  void set_overshoot_duration(uint32_t overshoot_duration) { this->overshoot_duration_ = overshoot_duration; }
   void set_obstacle_rollback(float obstacle_rollback) { this->obstacle_rollback_ = obstacle_rollback; }
   void set_update_interval(uint32_t interval) { this->update_interval_ = interval; }
   void set_infer_endstop(bool infer_endstop) { this->infer_endstop_ = infer_endstop; }
@@ -68,6 +69,7 @@ class FeedbackCover : public cover::Cover, public Component {
   uint32_t open_duration_{0};
   uint32_t close_duration_{0};
   uint32_t max_duration_{UINT32_MAX};
+  uint32_t overshoot_duration_{0};
   optional<uint32_t> direction_change_waittime_{};
   uint32_t acceleration_wait_time_{0};
   bool has_built_in_endstop_{false};
@@ -81,6 +83,7 @@ class FeedbackCover : public cover::Cover, public Component {
   uint32_t last_recompute_time_{0};
   uint32_t start_dir_time_{0};
   uint32_t last_publish_time_{0};
+  uint32_t start_overshoot_time_{0};
   float target_position_{0};
   uint32_t update_interval_{1000};
 };

--- a/tests/components/feedback/common.yaml
+++ b/tests/components/feedback/common.yaml
@@ -31,6 +31,7 @@ cover:
     close_endstop: close_endstop_sensor
     close_sensor: close_sensor
     close_obstacle_sensor: close_obstacle_sensor
+    overshoot_duration: 2s
     open_action:
       - logger.log: Open Action
     close_action:


### PR DESCRIPTION
# What does this implement?

Allows the cover to overshoot max open-closed positions by some specific duration. This helps sync the cover from minor errors that are introduced by multiple open-close commands, when cover doesn't have any end-stops implemented, making sure that a completely open or closed cover is indeed at the correct position.
If end-stops are implemented, this does nothing. 

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#4298

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
cover:
  - platform: feedback
    name: Office Shutter
    id: Office_Shutter

    open_action:
      - switch.turn_on: Office_Shutter_Up
    open_duration: 22sec
  
    close_action:
      - switch.turn_on: Office_Shutter_Down
    close_duration: 20sec
  
    stop_action:
      - switch.turn_off: Office_Shutter_Up
      - switch.turn_off: Office_Shutter_Down
    
    direction_change_wait_time: 1s
    acceleration_wait_time: 0.2s
    overshoot_duration: 2s

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
