### PR TITLE
[CI] Use a list when reading idedata for includes

### DIFF
--- a/script/clang-tidy
+++ b/script/clang-tidy
@@ -98,7 +98,7 @@ def clang_options(idedata):
             cmd.extend(["-isystem", directory])
 
     # add library include directories using -isystem to suppress their errors
-    for directory in set(idedata["includes"]["build"]):
+    for directory in list(idedata["includes"]["build"]):
         # skip our own directories, we add those later
         if (
             not directory.startswith(f"{root_path}/")


### PR DESCRIPTION
# What does this implement/fix?

The problem with using a `set` is that it's unordered. Includes appear to be placed into `idedata` in a specific order which was not maintained due to the use of a `set`. Using a `list` maintains the order and seems to fix the CI issue where clang-tidy randomly fails.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
