### PR TITLE
Use "puremagic" instead of "magic" python module

### DIFF
--- a/esphome/components/image/__init__.py
+++ b/esphome/components/image/__init__.py
@@ -6,7 +6,7 @@ import logging
 from pathlib import Path
 import re
 
-from magic import Magic
+import puremagic
 
 from esphome import core, external_files
 import esphome.codegen as cg
@@ -237,8 +237,8 @@ CONFIG_SCHEMA = cv.All(font.validate_pillow_installed, IMAGE_SCHEMA)
 
 
 def load_svg_image(file: bytes, resize: tuple[int, int]):
-    # Local import only to allow "validate_pillow_installed" to run *before* importing it
-    # This import is only needed in case of SVG images; adding it
+    # Local imports only to allow "validate_pillow_installed" to run *before* importing it
+    # cairosvg is only needed in case of SVG images; adding it
     # to the top would force configurations not using SVG to also have it
     # installed for no reason.
     from cairosvg import svg2png
@@ -281,8 +281,7 @@ async def to_code(config):
     except Exception as e:
         raise core.EsphomeError(f"Could not load image file {path}: {e}")
 
-    mime = Magic(mime=True)
-    file_type = mime.from_buffer(file_contents)
+    file_type = puremagic.from_string(file_contents, mime=True)
 
     resize = config.get(CONF_RESIZE)
     if "svg" in file_type:

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ click==8.1.7
 esphome-dashboard==20240620.0
 aioesphomeapi==24.6.2
 zeroconf==0.132.2
-python-magic==0.4.27
+puremagic==1.27
 ruamel.yaml==0.18.6 # dashboard_import
 
 # esp-idf requires this, but doesn't bundle it by default


### PR DESCRIPTION
# What does this implement/fix?
Use the puremagic module to avoid extra dependencies, that sometimes cause problems in windows due to missing binary libraries. puremagic is a cross-platform pure python module that does not have binary dependencies.

The tradeoff is a lower number of detected files; for the current use-case should be enough though.
<!-- Quick description and explanation of changes -->

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/5896 

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
