### PR TITLE
[bedjet_codec] Remove ``assert()``

### DIFF
--- a/esphome/components/bedjet/bedjet_codec.cpp
+++ b/esphome/components/bedjet/bedjet_codec.cpp
@@ -13,8 +13,10 @@ float bedjet_temp_to_f(const uint8_t temp) {
 
 /** Cleans up the packet before sending. */
 BedjetPacket *BedjetCodec::clean_packet_() {
-  // So far no commands require more than 2 bytes of data.
-  assert(this->packet_.data_length <= 2);
+  // So far no commands require more than 2 bytes of data
+  if (this->packet_.data_length > 2) {
+    ESP_LOGW(TAG, "Packet may be malformed");
+  }
   for (int i = this->packet_.data_length; i < 2; i++) {
     this->packet_.data[i] = '\0';
   }


### PR DESCRIPTION
# What does this implement/fix?

Removes an `assert()` from bedjet_codec -- this doesn't need to crash the device here. Changed to print a warning and move along.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
