### PR TITLE
[lvgl] Remap image to img in "set_style_*"

### DIFF
--- a/esphome/components/lvgl/styles.py
+++ b/esphome/components/lvgl/styles.py
@@ -12,7 +12,7 @@ from .defines import (
 )
 from .helpers import add_lv_use
 from .lvcode import LambdaContext, LocalVariable, lv, lv_assign, lv_variable
-from .schemas import ALL_STYLES
+from .schemas import ALL_STYLES, STYLE_REMAP
 from .types import lv_lambda_t, lv_obj_t, lv_obj_t_ptr
 from .widgets import Widget, add_widgets, set_obj_properties, theme_widget_map
 from .widgets.obj import obj_spec
@@ -31,7 +31,8 @@ async def styles_to_code(config):
                     value = await validator.process(value)
                 if isinstance(value, list):
                     value = "|".join(value)
-                lv.call(f"style_set_{prop}", svar, literal(value))
+                remapped_prop = STYLE_REMAP.get(prop, prop)
+                lv.call(f"style_set_{remapped_prop}", svar, literal(value))
 
 
 async def theme_to_code(config):

--- a/tests/components/lvgl/lvgl-package.yaml
+++ b/tests/components/lvgl/lvgl-package.yaml
@@ -67,6 +67,9 @@ lvgl:
       border_width: 2
       pad_all: 4
       align: center
+    - id: image_recolor
+      image_recolor: 0x10ca1e
+      image_recolor_opa: cover
 
   touchscreens:
     - touchscreen_id: tft_touch


### PR DESCRIPTION
# What does this implement/fix?

If updating a style that contains e.g. `image_recolor`, the compilation fails with an error
```
In lambda function:
lvgl/weather-station-ui-full.yaml:188:7: error: 'lv_style_set_image_recolor' was not declared in this scope
lvgl/weather-station-ui-full.yaml:188:7: note: suggested alternative: 'lv_style_set_img_recolor'
``` 

On the lv_set_style calls "image" needs to be rewritten to "img", so that the right LVGL methods are generated.

<!-- Quick description and explanation of changes -->

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
