### PR TITLE
CSE7766 needs even parity

### DIFF
--- a/esphome/components/cse7766/sensor.py
+++ b/esphome/components/cse7766/sensor.py
@@ -79,7 +79,7 @@ CONFIG_SCHEMA = cv.Schema(
     }
 ).extend(uart.UART_DEVICE_SCHEMA)
 FINAL_VALIDATE_SCHEMA = uart.final_validate_device_schema(
-    "cse7766", baud_rate=4800, require_rx=True
+    "cse7766", baud_rate=4800, parity="EVEN", require_rx=True
 )
 
 

--- a/tests/components/cse7766/test.esp32-ard.yaml
+++ b/tests/components/cse7766/test.esp32-ard.yaml
@@ -5,6 +5,7 @@ uart:
     rx_pin:
       number: 16
     baud_rate: 4800
+    parity: EVEN
 
 sensor:
   - platform: cse7766

--- a/tests/components/cse7766/test.esp32-c3-ard.yaml
+++ b/tests/components/cse7766/test.esp32-c3-ard.yaml
@@ -5,6 +5,7 @@ uart:
     rx_pin:
       number: 5
     baud_rate: 4800
+    parity: EVEN
 
 sensor:
   - platform: cse7766

--- a/tests/components/cse7766/test.esp32-c3-idf.yaml
+++ b/tests/components/cse7766/test.esp32-c3-idf.yaml
@@ -5,6 +5,7 @@ uart:
     rx_pin:
       number: 5
     baud_rate: 4800
+    parity: EVEN
 
 sensor:
   - platform: cse7766

--- a/tests/components/cse7766/test.esp32-idf.yaml
+++ b/tests/components/cse7766/test.esp32-idf.yaml
@@ -5,6 +5,7 @@ uart:
     rx_pin:
       number: 16
     baud_rate: 4800
+    parity: EVEN
 
 sensor:
   - platform: cse7766

--- a/tests/components/cse7766/test.esp8266-ard.yaml
+++ b/tests/components/cse7766/test.esp8266-ard.yaml
@@ -5,6 +5,7 @@ uart:
     rx_pin:
       number: 5
     baud_rate: 4800
+    parity: EVEN
 
 sensor:
   - platform: cse7766

--- a/tests/components/cse7766/test.rp2040-ard.yaml
+++ b/tests/components/cse7766/test.rp2040-ard.yaml
@@ -5,6 +5,7 @@ uart:
     rx_pin:
       number: 5
     baud_rate: 4800
+    parity: EVEN
 
 sensor:
   - platform: cse7766


### PR DESCRIPTION
# What does this implement/fix?

The CSE7766 and CSE7759B use even parity.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/4529

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#4308

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
