### PR TITLE
Allow use of all pulse count unit channels if needed.

### DIFF
--- a/esphome/components/pulse_counter/pulse_counter_sensor.cpp
+++ b/esphome/components/pulse_counter/pulse_counter_sensor.cpp
@@ -55,8 +55,8 @@ bool HwPulseCounterStorage::pulse_counter_setup(InternalGPIOPin *pin) {
   static pcnt_unit_t next_pcnt_unit = PCNT_UNIT_0;
   this->pin = pin;
   this->pin->setup();
-  this->pcnt_unit = (next_pcnt_unit - PCNT_UNIT_0) % PCNT_UNIT_MAX;
-  this->pcnt_channel = PCNT_CHANNEL_0 + (int)((next_pcnt_unit - PCNT_UNIT_0) / PCNT_UNIT_MAX);
+  this->pcnt_unit = pcnt_unit_t((next_pcnt_unit - PCNT_UNIT_0) % PCNT_UNIT_MAX);
+  this->pcnt_channel = pcnt_channel_t(PCNT_CHANNEL_0 + (int) ((next_pcnt_unit - PCNT_UNIT_0) / PCNT_UNIT_MAX));
   next_pcnt_unit = pcnt_unit_t(int(next_pcnt_unit) + 1);
 
   ESP_LOGCONFIG(TAG, "    PCNT Unit Number: %u", this->pcnt_unit);

--- a/esphome/components/pulse_counter/pulse_counter_sensor.cpp
+++ b/esphome/components/pulse_counter/pulse_counter_sensor.cpp
@@ -55,10 +55,12 @@ bool HwPulseCounterStorage::pulse_counter_setup(InternalGPIOPin *pin) {
   static pcnt_unit_t next_pcnt_unit = PCNT_UNIT_0;
   this->pin = pin;
   this->pin->setup();
-  this->pcnt_unit = next_pcnt_unit;
+  this->pcnt_unit = (next_pcnt_unit - PCNT_UNIT_0) % PCNT_UNIT_MAX;
+  this->pcnt_channel = PCNT_CHANNEL_0 + (int)((next_pcnt_unit - PCNT_UNIT_0) / PCNT_UNIT_MAX);
   next_pcnt_unit = pcnt_unit_t(int(next_pcnt_unit) + 1);
 
   ESP_LOGCONFIG(TAG, "    PCNT Unit Number: %u", this->pcnt_unit);
+  ESP_LOGCONFIG(TAG, "    PCNT Channel Number: %u", this->pcnt_channel);
 
   pcnt_count_mode_t rising = PCNT_COUNT_DIS, falling = PCNT_COUNT_DIS;
   switch (this->rising_edge_mode) {
@@ -94,7 +96,7 @@ bool HwPulseCounterStorage::pulse_counter_setup(InternalGPIOPin *pin) {
       .counter_h_lim = 0,
       .counter_l_lim = 0,
       .unit = this->pcnt_unit,
-      .channel = PCNT_CHANNEL_0,
+      .channel = this->pcnt_channel,
   };
   esp_err_t error = pcnt_unit_config(&pcnt_config);
   if (error != ESP_OK) {

--- a/esphome/components/pulse_counter/pulse_counter_sensor.cpp
+++ b/esphome/components/pulse_counter/pulse_counter_sensor.cpp
@@ -53,11 +53,16 @@ pulse_counter_t BasicPulseCounterStorage::read_raw_value() {
 #ifdef HAS_PCNT
 bool HwPulseCounterStorage::pulse_counter_setup(InternalGPIOPin *pin) {
   static pcnt_unit_t next_pcnt_unit = PCNT_UNIT_0;
+  static pcnt_channel_t next_pcnt_channel = PCNT_CHANNEL_0;
   this->pin = pin;
   this->pin->setup();
-  this->pcnt_unit = pcnt_unit_t((next_pcnt_unit - PCNT_UNIT_0) % PCNT_UNIT_MAX);
-  this->pcnt_channel = pcnt_channel_t(PCNT_CHANNEL_0 + (int) ((next_pcnt_unit - PCNT_UNIT_0) / PCNT_UNIT_MAX));
+  this->pcnt_unit = next_pcnt_unit;
+  this->pcnt_channel = next_pcnt_channel;
   next_pcnt_unit = pcnt_unit_t(int(next_pcnt_unit) + 1);
+  if (int(next_pcnt_unit) >= PCNT_UNIT_0 + PCNT_UNIT_MAX) {
+    next_pcnt_unit = PCNT_UNIT_0;
+    next_pcnt_channel = pcnt_channel_t(int(next_pcnt_channel) + 1);
+  }
 
   ESP_LOGCONFIG(TAG, "    PCNT Unit Number: %u", this->pcnt_unit);
   ESP_LOGCONFIG(TAG, "    PCNT Channel Number: %u", this->pcnt_channel);

--- a/esphome/components/pulse_counter/pulse_counter_sensor.h
+++ b/esphome/components/pulse_counter/pulse_counter_sensor.h
@@ -55,6 +55,7 @@ struct HwPulseCounterStorage : public PulseCounterStorageBase {
   pulse_counter_t read_raw_value() override;
 
   pcnt_unit_t pcnt_unit;
+  pcnt_channel_t pcnt_channel;
 };
 #endif
 


### PR DESCRIPTION
Use PCNT_CHANNEL_0 across all units and switch to PCTN_CHANNEL_1 when all units are already in use restarting with PCNT_UNIT_0.

Known limitation: filter settings can't be set independently for each channel, hence all channels in a unit use the same filter settings.

# What does this implement/fix?

The current implementation limits the use of PCNT channels to channel 0 for each unit - limiting the number of possible counters to 8 for esp32 chips with 8 units even if each unit has two independent channels which would allow 16 counters.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
No change to existing pulse_count configuration - purely internal change.

## Checklist:
  - [X] The code change is tested and works locally.
  - [n/a] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [n/a] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
