### PR TITLE
Enable support for low power protocol v0 of Tuya MCU

### DIFF
--- a/esphome/components/tuya/tuya.h
+++ b/esphome/components/tuya/tuya.h
@@ -48,21 +48,17 @@ struct TuyaDatapointListener {
 enum class TuyaCommandType : uint8_t {
   HEARTBEAT = 0x00,
   PRODUCT_QUERY = 0x01,
-  CONF_QUERY = 0x02,
-  WIFI_STATE = 0x03,
-  WIFI_RESET = 0x04,
-  WIFI_SELECT = 0x05,
-  DATAPOINT_DELIVER = 0x06,
-  DATAPOINT_REPORT_ASYNC = 0x07,
-  DATAPOINT_QUERY = 0x08,
-  WIFI_TEST = 0x0E,
-  LOCAL_TIME_QUERY = 0x1C,
-  DATAPOINT_REPORT_SYNC = 0x22,
-  DATAPOINT_REPORT_ACK = 0x23,
-  WIFI_RSSI = 0x24,
-  VACUUM_MAP_UPLOAD = 0x28,
-  GET_NETWORK_STATUS = 0x2B,
-  EXTENDED_SERVICES = 0x34,
+  WIFI_STATE = 0x02,
+  DATAPOINT_REPORT = 0x05,
+  LOCAL_TIME_QUERY = 0x06,
+  DP_CACHE = 0x10
+};
+
+enum class TuyaLECommandType : uint8_t {
+  HEARTBEAT = 0x00,
+  PRODUCT_QUERY = 0x01,
+  WIFI_STATE = 0x02,
+  DATAPOINT_REPORT = 0x05
 };
 
 enum class TuyaExtendedServicesCommandType : uint8_t {
@@ -74,9 +70,7 @@ enum class TuyaExtendedServicesCommandType : uint8_t {
 enum class TuyaInitState : uint8_t {
   INIT_HEARTBEAT = 0x00,
   INIT_PRODUCT,
-  INIT_CONF,
   INIT_WIFI,
-  INIT_DATAPOINT,
   INIT_DONE,
 };
 
@@ -146,6 +140,7 @@ class Tuya : public Component, public uart::UARTDevice {
   bool init_failed_{false};
   int init_retries_{0};
   uint8_t protocol_version_ = -1;
+  bool low_power_mode_ = true;
   InternalGPIOPin *status_pin_{nullptr};
   int status_pin_reported_ = -1;
   int reset_pin_reported_ = -1;

--- a/esphome/components/tuya/tuya.h
+++ b/esphome/components/tuya/tuya.h
@@ -54,13 +54,6 @@ enum class TuyaCommandType : uint8_t {
   DP_CACHE = 0x10
 };
 
-enum class TuyaLECommandType : uint8_t {
-  HEARTBEAT = 0x00,
-  PRODUCT_QUERY = 0x01,
-  WIFI_STATE = 0x02,
-  DATAPOINT_REPORT = 0x05
-};
-
 enum class TuyaExtendedServicesCommandType : uint8_t {
   RESET_NOTIFICATION = 0x04,
   MODULE_RESET = 0x05,


### PR DESCRIPTION
# What does this implement/fix?
There is speciall category of TuyaMCU based devices that are battery powered.
In such scenario, an modified version of v0 protocol is used, which is deeply incompatible with v3.

WARNING:
At this point, the code is in a POC state. I was able to report humidity and temperature values to HA, with the cost of completly breaking v3 protocol support.
![image](https://github.com/user-attachments/assets/bd802f8d-a987-4892-8c37-65d95f10036b)
Both protocols share some of the code - datapoint handling, localtime handling
Main differences:
* command IDs
* initial configuration flow (no config retrieve, no datapoint list retrieve)
* custom WIFI reporting state (MCU must know that Module has API connection)
* custom state loop
It might be ctually reasonable to make it into a dedicated component like `tuya_le` aka `tuya low energy`

There is excelleng guide on LE protocol:
https://www.elektroda.com/rtvforum/topic3975583.html

The basic operation looks like this:
Module -> Wifi Module with ESPHome loaded
MCU -> Microcontroller that operated re sensors

MCU wakes  up on event (sensor value change, timer etc)
MCU power up Module
Module initializes MCU with current date and networks status
MCU sends data points updates
Module ACKs updated
MCU powers down Module & itself

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes 
https://github.com/esphome/feature-requests/issues/497
https://github.com/esphome/feature-requests/issues/352

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ x ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
esphome:
  name: tmp-hum-3ft6

bk72xx:
  board: cb3s

logger:
  level: VERBOSE
  hardware_uart: UART2


api:
  password: ""

ota:
  - platform: esphome
    password: ""

web_server:

wifi:
  ssid: <ssid>
  password: <passwd>
  ap:
    ssid: tmp-hum-3ft6
    password: ""

captive_portal:

time:
  - platform: sntp
    id: timer

uart:
  rx_pin: P10
  tx_pin: P11
  baud_rate: 9600

sensor:
  - platform: tuya
    name: temperature
    sensor_datapoint: 1
  - platform: tuya
    name: humidity
    sensor_datapoint: 2

tuya:
  time_id: timer
```

## Checklist:
  - [ x ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
