### PR TITLE
[cst816] Allow skipping i2c probe

### DIFF
--- a/esphome/components/cst816/touchscreen/__init__.py
+++ b/esphome/components/cst816/touchscreen/__init__.py
@@ -1,11 +1,10 @@
-import esphome.codegen as cg
-import esphome.config_validation as cv
-
 from esphome import pins
+import esphome.codegen as cg
 from esphome.components import i2c, touchscreen
-from esphome.const import CONF_INTERRUPT_PIN, CONF_ID, CONF_RESET_PIN
-from .. import cst816_ns
+import esphome.config_validation as cv
+from esphome.const import CONF_ID, CONF_INTERRUPT_PIN, CONF_RESET_PIN
 
+from .. import cst816_ns
 
 CST816Touchscreen = cst816_ns.class_(
     "CST816Touchscreen",
@@ -14,11 +13,14 @@ CST816Touchscreen = cst816_ns.class_(
 )
 
 CST816ButtonListener = cst816_ns.class_("CST816ButtonListener")
+
+CONF_SKIP_PROBE = "skip_probe"
 CONFIG_SCHEMA = touchscreen.TOUCHSCREEN_SCHEMA.extend(
     {
         cv.GenerateID(): cv.declare_id(CST816Touchscreen),
         cv.Optional(CONF_INTERRUPT_PIN): pins.internal_gpio_input_pin_schema,
         cv.Optional(CONF_RESET_PIN): pins.gpio_output_pin_schema,
+        cv.Optional(CONF_SKIP_PROBE, default=False): bool,
     }
 ).extend(i2c.i2c_device_schema(0x15))
 
@@ -28,6 +30,7 @@ async def to_code(config):
     await touchscreen.register_touchscreen(var, config)
     await i2c.register_i2c_device(var, config)
 
+    cg.add(var.set_skip_probe(config[CONF_SKIP_PROBE]))
     if interrupt_pin := config.get(CONF_INTERRUPT_PIN):
         cg.add(var.set_interrupt_pin(await cg.gpio_pin_expression(interrupt_pin)))
     if reset_pin := config.get(CONF_RESET_PIN):

--- a/esphome/components/cst816/touchscreen/__init__.py
+++ b/esphome/components/cst816/touchscreen/__init__.py
@@ -20,7 +20,7 @@ CONFIG_SCHEMA = touchscreen.TOUCHSCREEN_SCHEMA.extend(
         cv.GenerateID(): cv.declare_id(CST816Touchscreen),
         cv.Optional(CONF_INTERRUPT_PIN): pins.internal_gpio_input_pin_schema,
         cv.Optional(CONF_RESET_PIN): pins.gpio_output_pin_schema,
-        cv.Optional(CONF_SKIP_PROBE, default=False): bool,
+        cv.Optional(CONF_SKIP_PROBE, default=False): cv.boolean,
     }
 ).extend(i2c.i2c_device_schema(0x15))
 

--- a/esphome/components/cst816/touchscreen/cst816_touchscreen.cpp
+++ b/esphome/components/cst816/touchscreen/cst816_touchscreen.cpp
@@ -8,7 +8,7 @@ void CST816Touchscreen::continue_setup_() {
     this->interrupt_pin_->setup();
     this->attach_interrupt_(this->interrupt_pin_, gpio::INTERRUPT_FALLING_EDGE);
   }
-  if (!this->read_byte(REG_CHIP_ID, &this->chip_id_)) {
+  if (!this->skip_probe_ && !this->read_byte(REG_CHIP_ID, &this->chip_id_)) {
     this->mark_failed();
     esph_log_e(TAG, "Failed to read chip id");
     return;
@@ -22,9 +22,11 @@ void CST816Touchscreen::continue_setup_() {
     case CST816T_CHIP_ID:
       break;
     default:
-      this->mark_failed();
-      esph_log_e(TAG, "Unknown chip ID 0x%02X", this->chip_id_);
-      return;
+      if (!this->skip_probe_) {
+        this->mark_failed();
+        esph_log_e(TAG, "Unknown chip ID 0x%02X", this->chip_id_);
+        return;
+      }
   }
   this->write_byte(REG_IRQ_CTL, IRQ_EN_MOTION);
   if (this->x_raw_max_ == this->x_raw_min_) {

--- a/esphome/components/cst816/touchscreen/cst816_touchscreen.cpp
+++ b/esphome/components/cst816/touchscreen/cst816_touchscreen.cpp
@@ -8,34 +8,33 @@ void CST816Touchscreen::continue_setup_() {
     this->interrupt_pin_->setup();
     this->attach_interrupt_(this->interrupt_pin_, gpio::INTERRUPT_FALLING_EDGE);
   }
-  if (!this->skip_probe_ && !this->read_byte(REG_CHIP_ID, &this->chip_id_)) {
+  if (this->read_byte(REG_CHIP_ID, &this->chip_id_)) {
+    switch (this->chip_id_) {
+      case CST820_CHIP_ID:
+      case CST826_CHIP_ID:
+      case CST716_CHIP_ID:
+      case CST816S_CHIP_ID:
+      case CST816D_CHIP_ID:
+      case CST816T_CHIP_ID:
+        break;
+      default:
+        this->mark_failed();
+        this->status_set_error(str_sprintf("Unknown chip ID 0x%02X", this->chip_id_).c_str());
+        return;
+    }
+    this->write_byte(REG_IRQ_CTL, IRQ_EN_MOTION);
+  } else if (!this->skip_probe_) {
+    this->status_set_error("Failed to read chip id");
     this->mark_failed();
-    esph_log_e(TAG, "Failed to read chip id");
     return;
   }
-  switch (this->chip_id_) {
-    case CST820_CHIP_ID:
-    case CST826_CHIP_ID:
-    case CST716_CHIP_ID:
-    case CST816S_CHIP_ID:
-    case CST816D_CHIP_ID:
-    case CST816T_CHIP_ID:
-      break;
-    default:
-      if (!this->skip_probe_) {
-        this->mark_failed();
-        esph_log_e(TAG, "Unknown chip ID 0x%02X", this->chip_id_);
-        return;
-      }
-  }
-  this->write_byte(REG_IRQ_CTL, IRQ_EN_MOTION);
   if (this->x_raw_max_ == this->x_raw_min_) {
     this->x_raw_max_ = this->display_->get_native_width();
   }
   if (this->y_raw_max_ == this->y_raw_min_) {
     this->y_raw_max_ = this->display_->get_native_height();
   }
-  esph_log_config(TAG, "CST816 Touchscreen setup complete");
+  ESP_LOGCONFIG(TAG, "CST816 Touchscreen setup complete");
 }
 
 void CST816Touchscreen::update_button_state_(bool state) {
@@ -47,7 +46,7 @@ void CST816Touchscreen::update_button_state_(bool state) {
 }
 
 void CST816Touchscreen::setup() {
-  esph_log_config(TAG, "Setting up CST816 Touchscreen...");
+  ESP_LOGCONFIG(TAG, "Setting up CST816 Touchscreen...");
   if (this->reset_pin_ != nullptr) {
     this->reset_pin_->setup();
     this->reset_pin_->digital_write(true);
@@ -75,7 +74,7 @@ void CST816Touchscreen::update_touches() {
 
   uint16_t x = encode_uint16(data[REG_XPOS_HIGH] & 0xF, data[REG_XPOS_LOW]);
   uint16_t y = encode_uint16(data[REG_YPOS_HIGH] & 0xF, data[REG_YPOS_LOW]);
-  esph_log_v(TAG, "Read touch %d/%d", x, y);
+  ESP_LOGV(TAG, "Read touch %d/%d", x, y);
   if (x >= this->x_raw_max_) {
     this->update_button_state_(true);
   } else {

--- a/esphome/components/cst816/touchscreen/cst816_touchscreen.h
+++ b/esphome/components/cst816/touchscreen/cst816_touchscreen.h
@@ -45,6 +45,7 @@ class CST816Touchscreen : public touchscreen::Touchscreen, public i2c::I2CDevice
 
   void set_interrupt_pin(InternalGPIOPin *pin) { this->interrupt_pin_ = pin; }
   void set_reset_pin(GPIOPin *pin) { this->reset_pin_ = pin; }
+  void set_skip_probe(bool skip_probe) { this->skip_probe_ = skip_probe; }
 
  protected:
   void continue_setup_();
@@ -53,6 +54,7 @@ class CST816Touchscreen : public touchscreen::Touchscreen, public i2c::I2CDevice
   InternalGPIOPin *interrupt_pin_{};
   GPIOPin *reset_pin_{};
   uint8_t chip_id_{};
+  bool skip_probe_{};  // if set, do not expect to be able to probe the controller on the i2c bus.
   std::vector<CST816ButtonListener *> button_listeners_;
   bool button_touched_{};
 };

--- a/tests/components/cst816/common.yaml
+++ b/tests/components/cst816/common.yaml
@@ -12,14 +12,14 @@ touchscreen:
 
 i2c:
   sda: 3
-  scl: 2
+  scl: 4
 
 display:
   - id: my_display
     platform: ili9xxx
     dimensions: 480x320
     model: ST7796
-    cs_pin: 15
+    cs_pin: 18
     dc_pin: 20
     reset_pin: 22
     transform:

--- a/tests/components/cst816/common.yaml
+++ b/tests/components/cst816/common.yaml
@@ -4,6 +4,7 @@ touchscreen:
     interrupt_pin:
       number: 21
     reset_pin: GPIO16
+    skip_probe: false
     transform:
       mirror_x: false
       mirror_y: false


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/6293

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#4312
## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
