### PR TITLE
Update radon_eye_listener.cpp for more possible variants

### DIFF
--- a/esphome/components/radon_eye_ble/radon_eye_listener.cpp
+++ b/esphome/components/radon_eye_ble/radon_eye_listener.cpp
@@ -14,14 +14,13 @@ bool RadonEyeListener::parse_device(const esp32_ble_tracker::ESPBTDevice &device
   if (not device.get_name().empty()) {
     // Vector containing the prefixes to search for
     std::vector<std::string> prefixes = {"FR:R", "FR:I", "FR:H"};
-    
+
     // Check if the device name starts with any of the prefixes
-    if (std::any_of(prefixes.begin(), prefixes.end(), [&](const std::string &prefix) {
-          return device.get_name().rfind(prefix, 0) == 0;
-        })) {
-      // Device found
-      ESP_LOGD(TAG, "Found Radon Eye device Name: %s (MAC: %s)", device.get_name().c_str(),
-               device.address_str().c_str());
+  if (std::any_of(prefixes.begin(), prefixes.end(),
+    [&](const std::string &prefix) { return device.get_name().rfind(prefix, 0) == 0; })) {
+       // Device found
+       ESP_LOGD(TAG, "Found Radon Eye device Name: %s (MAC: %s)", device.get_name().c_str(),
+                device.address_str().c_str());
     }
   }
   return false;

--- a/esphome/components/radon_eye_ble/radon_eye_listener.cpp
+++ b/esphome/components/radon_eye_ble/radon_eye_listener.cpp
@@ -10,26 +10,23 @@ namespace radon_eye_ble {
 
 static const char *const TAG = "radon_eye_ble";
 
-bool RadonEyeListener::parse_device(
-    const esp32_ble_tracker::ESPBTDevice &device) {
+bool RadonEyeListener::parse_device(const esp32_ble_tracker::ESPBTDevice &device) {
   if (not device.get_name().empty()) {
     // Vector containing the prefixes to search for
     std::vector<std::string> prefixes = {"FR:R", "FR:I", "FR:H"};
 
     // Check if the device name starts with any of the prefixes
     if (std::any_of(prefixes.begin(), prefixes.end(),
-                    [&](const std::string &prefix) {
-                      return device.get_name().rfind(prefix, 0) == 0;
-                    })) {
+                    [&](const std::string &prefix) { return device.get_name().rfind(prefix, 0) == 0; })) {
       // Device found
-      ESP_LOGD(TAG, "Found Radon Eye device Name: %s (MAC: %s)",
-               device.get_name().c_str(), device.address_str().c_str());
+      ESP_LOGD(TAG, "Found Radon Eye device Name: %s (MAC: %s)", device.get_name().c_str(),
+               device.address_str().c_str());
     }
   }
   return false;
 }
 
-} // namespace radon_eye_ble
-} // namespace esphome
+}  // namespace radon_eye_ble
+}  // namespace esphome
 
 #endif

--- a/esphome/components/radon_eye_ble/radon_eye_listener.cpp
+++ b/esphome/components/radon_eye_ble/radon_eye_listener.cpp
@@ -1,5 +1,7 @@
 #include "radon_eye_listener.h"
 #include "esphome/core/log.h"
+#include <vector>
+#include <algorithm>
 
 #ifdef USE_ESP32
 
@@ -10,9 +12,15 @@ static const char *const TAG = "radon_eye_ble";
 
 bool RadonEyeListener::parse_device(const esp32_ble_tracker::ESPBTDevice &device) {
   if (not device.get_name().empty()) {
-    if (device.get_name().rfind("FR:R", 0) == 0) {
-      // This is an RD200, I think
-      ESP_LOGD(TAG, "Found Radon Eye RD200 device Name: %s (MAC: %s)", device.get_name().c_str(),
+    // Vector containing the prefixes to search for
+    std::vector<std::string> prefixes = {"FR:R", "FR:I", "FR:H"};
+    
+    // Check if the device name starts with any of the prefixes
+    if (std::any_of(prefixes.begin(), prefixes.end(), [&](const std::string &prefix) {
+          return device.get_name().rfind(prefix, 0) == 0;
+        })) {
+      // Device found
+      ESP_LOGD(TAG, "Found Radon Eye device Name: %s (MAC: %s)", device.get_name().c_str(),
                device.address_str().c_str());
     }
   }

--- a/esphome/components/radon_eye_ble/radon_eye_listener.cpp
+++ b/esphome/components/radon_eye_ble/radon_eye_listener.cpp
@@ -1,7 +1,7 @@
 #include "radon_eye_listener.h"
 #include "esphome/core/log.h"
-#include <vector>
 #include <algorithm>
+#include <vector>
 
 #ifdef USE_ESP32
 
@@ -10,23 +10,26 @@ namespace radon_eye_ble {
 
 static const char *const TAG = "radon_eye_ble";
 
-bool RadonEyeListener::parse_device(const esp32_ble_tracker::ESPBTDevice &device) {
+bool RadonEyeListener::parse_device(
+    const esp32_ble_tracker::ESPBTDevice &device) {
   if (not device.get_name().empty()) {
     // Vector containing the prefixes to search for
     std::vector<std::string> prefixes = {"FR:R", "FR:I", "FR:H"};
 
     // Check if the device name starts with any of the prefixes
-  if (std::any_of(prefixes.begin(), prefixes.end(),
-    [&](const std::string &prefix) { return device.get_name().rfind(prefix, 0) == 0; })) {
-       // Device found
-       ESP_LOGD(TAG, "Found Radon Eye device Name: %s (MAC: %s)", device.get_name().c_str(),
-                device.address_str().c_str());
+    if (std::any_of(prefixes.begin(), prefixes.end(),
+                    [&](const std::string &prefix) {
+                      return device.get_name().rfind(prefix, 0) == 0;
+                    })) {
+      // Device found
+      ESP_LOGD(TAG, "Found Radon Eye device Name: %s (MAC: %s)",
+               device.get_name().c_str(), device.address_str().c_str());
     }
   }
   return false;
 }
 
-}  // namespace radon_eye_ble
-}  // namespace esphome
+} // namespace radon_eye_ble
+} // namespace esphome
 
 #endif


### PR DESCRIPTION
# What does this implement/fix?

Fix for [#5655](https://github.com/esphome/issues/issues/5655). Putting the possible MAC prefixes in a vector makes it easier to add new devices.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes [#5655](https://github.com/esphome/issues/issues/5655)

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
logger:
  level: DEBUG # Required for the tracker to show the device

esp32_ble_tracker:
radon_eye_ble:

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

## Log output from test:
```
# Log Output from a previously unsupported Radon Eye V3 (FR:H), which is now found:
[19:36:48][D][radon_eye_ble:024]: Found Radon Eye device Name: FR:HG04RE000465 (MAC: 94:B5:55:7F:51:26)
```