### PR TITLE
[fix] ESP32-C6 Reset Reasons

### DIFF
--- a/esphome/components/debug/debug_esp32.cpp
+++ b/esphome/components/debug/debug_esp32.cpp
@@ -36,7 +36,7 @@ std::string DebugComponent::get_reset_reason_() {
       break;
 #if defined(USE_ESP32_VARIANT_ESP32)
     case SW_RESET:
-#elif defined(USE_ESP32_VARIANT_ESP32C3) || defined(USE_ESP32_VARIANT_ESP32S2) || defined(USE_ESP32_VARIANT_ESP32S3)
+#elif defined(USE_ESP32_VARIANT_ESP32C3) || defined(USE_ESP32_VARIANT_ESP32S2) || defined(USE_ESP32_VARIANT_ESP32S3) || defined(USE_ESP32_VARIANT_ESP32C6)
     case RTC_SW_SYS_RESET:
 #endif
       reset_reason = "Software Reset Digital Core";
@@ -72,14 +72,14 @@ std::string DebugComponent::get_reset_reason_() {
     case TGWDT_CPU_RESET:
       reset_reason = "Timer Group Reset CPU";
       break;
-#elif defined(USE_ESP32_VARIANT_ESP32C3) || defined(USE_ESP32_VARIANT_ESP32S2) || defined(USE_ESP32_VARIANT_ESP32S3)
+#elif defined(USE_ESP32_VARIANT_ESP32C3) || defined(USE_ESP32_VARIANT_ESP32S2) || defined(USE_ESP32_VARIANT_ESP32S3) || defined(USE_ESP32_VARIANT_ESP32C6)
     case TG0WDT_CPU_RESET:
       reset_reason = "Timer Group 0 Reset CPU";
       break;
 #endif
 #if defined(USE_ESP32_VARIANT_ESP32)
     case SW_CPU_RESET:
-#elif defined(USE_ESP32_VARIANT_ESP32C3) || defined(USE_ESP32_VARIANT_ESP32S2) || defined(USE_ESP32_VARIANT_ESP32S3)
+#elif defined(USE_ESP32_VARIANT_ESP32C3) || defined(USE_ESP32_VARIANT_ESP32S2) || defined(USE_ESP32_VARIANT_ESP32S3) || defined(USE_ESP32_VARIANT_ESP32C6)
     case RTC_SW_CPU_RESET:
 #endif
       reset_reason = "Software Reset CPU";
@@ -98,27 +98,31 @@ std::string DebugComponent::get_reset_reason_() {
     case RTCWDT_RTC_RESET:
       reset_reason = "RTC Watch Dog Reset Digital Core And RTC Module";
       break;
-#if defined(USE_ESP32_VARIANT_ESP32C3) || defined(USE_ESP32_VARIANT_ESP32S2) || defined(USE_ESP32_VARIANT_ESP32S3)
+#if defined(USE_ESP32_VARIANT_ESP32C3) || defined(USE_ESP32_VARIANT_ESP32S2) || defined(USE_ESP32_VARIANT_ESP32S3) || defined(USE_ESP32_VARIANT_ESP32C6)
     case TG1WDT_CPU_RESET:
       reset_reason = "Timer Group 1 Reset CPU";
       break;
     case SUPER_WDT_RESET:
       reset_reason = "Super Watchdog Reset Digital Core And RTC Module";
       break;
-    case GLITCH_RTC_RESET:
-      reset_reason = "Glitch Reset Digital Core And RTC Module";
-      break;
     case EFUSE_RESET:
       reset_reason = "eFuse Reset Digital Core";
       break;
 #endif
-#if defined(USE_ESP32_VARIANT_ESP32C3) || defined(USE_ESP32_VARIANT_ESP32S3)
+#if defined(USE_ESP32_VARIANT_ESP32C3) || defined(USE_ESP32_VARIANT_ESP32S2) || defined(USE_ESP32_VARIANT_ESP32S3)
+    case GLITCH_RTC_RESET:
+      reset_reason = "Glitch Reset Digital Core And RTC Module";
+      break;
+#endif
+#if defined(USE_ESP32_VARIANT_ESP32C3) || defined(USE_ESP32_VARIANT_ESP32S3) || defined(USE_ESP32_VARIANT_ESP32C6)
     case USB_UART_CHIP_RESET:
       reset_reason = "USB UART Reset Digital Core";
       break;
     case USB_JTAG_CHIP_RESET:
       reset_reason = "USB JTAG Reset Digital Core";
       break;
+#endif
+#if defined(USE_ESP32_VARIANT_ESP32C3) || defined(USE_ESP32_VARIANT_ESP32S3)
     case POWER_GLITCH_RESET:
       reset_reason = "Power Glitch Reset Digital Core And RTC Module";
       break;

--- a/esphome/components/debug/debug_esp32.cpp
+++ b/esphome/components/debug/debug_esp32.cpp
@@ -36,7 +36,8 @@ std::string DebugComponent::get_reset_reason_() {
       break;
 #if defined(USE_ESP32_VARIANT_ESP32)
     case SW_RESET:
-#elif defined(USE_ESP32_VARIANT_ESP32C3) || defined(USE_ESP32_VARIANT_ESP32S2) || defined(USE_ESP32_VARIANT_ESP32S3) || defined(USE_ESP32_VARIANT_ESP32C6)
+#elif defined(USE_ESP32_VARIANT_ESP32C3) || defined(USE_ESP32_VARIANT_ESP32S2) || \
+    defined(USE_ESP32_VARIANT_ESP32S3) || defined(USE_ESP32_VARIANT_ESP32C6)
     case RTC_SW_SYS_RESET:
 #endif
       reset_reason = "Software Reset Digital Core";
@@ -72,14 +73,16 @@ std::string DebugComponent::get_reset_reason_() {
     case TGWDT_CPU_RESET:
       reset_reason = "Timer Group Reset CPU";
       break;
-#elif defined(USE_ESP32_VARIANT_ESP32C3) || defined(USE_ESP32_VARIANT_ESP32S2) || defined(USE_ESP32_VARIANT_ESP32S3) || defined(USE_ESP32_VARIANT_ESP32C6)
+#elif defined(USE_ESP32_VARIANT_ESP32C3) || defined(USE_ESP32_VARIANT_ESP32S2) || \
+    defined(USE_ESP32_VARIANT_ESP32S3) || defined(USE_ESP32_VARIANT_ESP32C6)
     case TG0WDT_CPU_RESET:
       reset_reason = "Timer Group 0 Reset CPU";
       break;
 #endif
 #if defined(USE_ESP32_VARIANT_ESP32)
     case SW_CPU_RESET:
-#elif defined(USE_ESP32_VARIANT_ESP32C3) || defined(USE_ESP32_VARIANT_ESP32S2) || defined(USE_ESP32_VARIANT_ESP32S3) || defined(USE_ESP32_VARIANT_ESP32C6)
+#elif defined(USE_ESP32_VARIANT_ESP32C3) || defined(USE_ESP32_VARIANT_ESP32S2) || \
+    defined(USE_ESP32_VARIANT_ESP32S3) || defined(USE_ESP32_VARIANT_ESP32C6)
     case RTC_SW_CPU_RESET:
 #endif
       reset_reason = "Software Reset CPU";
@@ -98,7 +101,8 @@ std::string DebugComponent::get_reset_reason_() {
     case RTCWDT_RTC_RESET:
       reset_reason = "RTC Watch Dog Reset Digital Core And RTC Module";
       break;
-#if defined(USE_ESP32_VARIANT_ESP32C3) || defined(USE_ESP32_VARIANT_ESP32S2) || defined(USE_ESP32_VARIANT_ESP32S3) || defined(USE_ESP32_VARIANT_ESP32C6)
+#if defined(USE_ESP32_VARIANT_ESP32C3) || defined(USE_ESP32_VARIANT_ESP32S2) || defined(USE_ESP32_VARIANT_ESP32S3) || \
+    defined(USE_ESP32_VARIANT_ESP32C6)
     case TG1WDT_CPU_RESET:
       reset_reason = "Timer Group 1 Reset CPU";
       break;


### PR DESCRIPTION
# What does this implement/fix?

The component `debug` does not handle all reset reasons for ESP32-C6. It reports `Unknown Reset Reason` for several unhandled cases. This PR adds support for all available ESP32-C6 Reset Reasons.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/6318

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
esphome:
  name: bt-proxy
  friendly_name: Bluetooth Proxy
  platformio_options:
    board_build.flash_mode: dio 

esp32:
  board: esp32-c6-devkitc-1
  variant: ESP32C6
  flash_size: 8MB
  framework:
    type: esp-idf
    version: 5.3.1
    platform_version: 6.9.0
    sdkconfig_options:
      CONFIG_ESPTOOLPY_FLASHSIZE_8MB: y
      CONFIG_OPENTHREAD_ENABLED: n
      CONFIG_ENABLE_WIFI_STATION: y
      CONFIG_USE_MINIMAL_MDNS: y
debug:
  update_interval: 30s

wifi:
  ssid: "secret"
  password: "secret"

text_sensor:
  - platform: debug
    reset_reason:
      name: "Reset Reason"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
