### PR TITLE
Enable text wrapping for printf on displays

### DIFF
--- a/esphome/components/display/display.cpp
+++ b/esphome/components/display/display.cpp
@@ -376,7 +376,7 @@ void Display::print(int x, int y, int width, int height, BaseFont *font, Color c
       this->get_text_bounds(line_x, line_y, w.c_str(), font, align, &word_x1, &word_y1, &word_width, &word_height);
 
       if (line_x + word_width >= x_max) {
-        // If the next line would overspill the height box, get ready to stop.
+        // If the next line would overspill the height box, get ready to stop
         if (line_y + 2 * static_cast<int>(word_height * line_height) > y_max) {
           last = true;
           size_t length = line.length();

--- a/esphome/components/display/display.cpp
+++ b/esphome/components/display/display.cpp
@@ -346,7 +346,7 @@ void Display::print(int x, int y, BaseFont *font, Color color, TextAlign align, 
 void Display::print(int x, int y, int width, int height, BaseFont *font, Color color, TextAlign align, const char *text,
                     Color background, float line_height, bool wrap) {
   int x_start, y_start;
-  if (wrap == false) {
+  if (!wrap) {
     this->get_text_bounds(x, y, text, font, align, &x_start, &y_start, &width, &height);
     font->print(x_start, y_start, this, color, text, background);
   } else {

--- a/esphome/components/display/display.cpp
+++ b/esphome/components/display/display.cpp
@@ -496,6 +496,7 @@ void Display::printf(int x, int y, int width, int height, BaseFont *font, float 
 
   char buffer[256];
   int ret = vsnprintf(buffer, sizeof(buffer), format, arg);
+  va_end(arg);
   if (ret == 0)
     return;
 
@@ -555,8 +556,6 @@ void Display::printf(int x, int y, int width, int height, BaseFont *font, float 
   if (!line.empty()) {
     this->printf(x, line_y, font, align, "%s", line.c_str());
   }
-
-  va_end(arg);
 }
 
 void Display::set_writer(display_writer_t &&writer) { this->writer_ = writer; }

--- a/esphome/components/display/display.cpp
+++ b/esphome/components/display/display.cpp
@@ -1,5 +1,7 @@
 #include "display.h"
 #include "display_color_utils.h"
+#include <cstdarg>
+#include <sstream>
 #include <utility>
 #include "esphome/core/hal.h"
 #include "esphome/core/log.h"
@@ -480,6 +482,83 @@ void Display::printf(int x, int y, BaseFont *font, const char *format, ...) {
   this->vprintf_(x, y, font, COLOR_ON, COLOR_OFF, TextAlign::TOP_LEFT, format, arg);
   va_end(arg);
 }
+
+void Display::printf(int x, int y, int width, int height, BaseFont *font, float line_height, const char *format, ...) {
+  // Text wrapping printf based on https://gist.github.com/alvesvaren/767d9585f0ecbef18ef1c7c0492c4332
+  va_list arg;
+  va_start(arg, format);
+
+  TextAlign align = TextAlign::TOP_LEFT;
+
+  // Calculate the bounds of a single space character
+  int space_x1, space_y1, space_width, space_height;
+  this->get_text_bounds(x, y, " ", font, align, &space_x1, &space_y1, &space_width, &space_height);
+
+  char buffer[256];
+  int ret = vsnprintf(buffer, sizeof(buffer), format, arg);
+  if (ret == 0)
+    return;
+
+  // Break text into words
+  std::vector<std::string> words;
+  std::stringstream ss(buffer);
+  std::string word;
+  while (std::getline(ss, word, ' ')) {
+    words.push_back(word);
+  }
+
+  // Initialize variables for the wrapped text
+  int line_x = x;
+  int line_y = y;
+  int x_max = x + width;
+  int y_max = y + height;
+  int word_x1, word_y1, word_width, word_height;
+  bool last = false;
+  std::string line;
+
+  // Iterate through the words and wrap them
+  for (const auto &w : words) {
+    this->get_text_bounds(line_x, line_y, w.c_str(), font, align, &word_x1, &word_y1, &word_width, &word_height);
+
+    if (line_x + word_width >= x_max) {
+      // If the next line would overspill the height box, get ready to stop.
+      if (line_y + 2 * static_cast<int>(word_height * line_height) > y_max) {
+        last = true;
+        size_t length = line.length();
+        const std::string cont = "...";
+        if (length >= cont.length()) {
+          line.replace(length - cont.length(), cont.length(), cont);
+        }
+      }
+      // Print the current line and move to the next line
+      this->printf(x, line_y, font, align, "%s", line.c_str());
+      if (last) {
+        break;
+      }
+      line_y += static_cast<int>(word_height * line_height);
+      line_x = x;
+      // Clear the line buffer
+      line.clear();
+    }
+
+    // Add the word to the line buffer and move the cursor
+    line += w;
+    line_x += word_width + space_width;
+
+    // If it's not the last word, add a space
+    if (!line.empty() && &w != &words.back()) {
+      line += " ";
+    }
+  }
+
+  // Print the last line
+  if (!line.empty()) {
+    this->printf(x, line_y, font, align, "%s", line.c_str());
+  }
+
+  va_end(arg);
+}
+
 void Display::set_writer(display_writer_t &&writer) { this->writer_ = writer; }
 void Display::set_pages(std::vector<DisplayPage *> pages) {
   for (auto *page : pages)

--- a/esphome/components/display/display.h
+++ b/esphome/components/display/display.h
@@ -340,6 +340,21 @@ class Display : public PollingComponent {
   void print(int x, int y, BaseFont *font, Color color, TextAlign align, const char *text,
              Color background = COLOR_OFF);
 
+  /** Print `text` with the anchor point at [x,y] with `font`.
+   *
+   * @param x The x coordinate of the text alignment anchor point.
+   * @param y The y coordinate of the text alignment anchor point.
+   * @param width The width of the bounding box to print text into.
+   * @param height The height of the bounding box to print text into.
+   * @param font The font to draw the text with.
+   * @param color The color to draw the text with.
+   * @param align The alignment of the text.
+   * @param text The text to draw.
+   * @param background When using multi-bit (anti-aliased) fonts, blend this background color into pixels
+   */
+  void print(int x, int y, int width, int height, BaseFont *font, Color color, TextAlign align, const char *text,
+             Color background = COLOR_OFF, float line_height = 1.0, bool wrap = true);
+
   /** Print `text` with the top left at [x,y] with `font`.
    *
    * @param x The x coordinate of the upper left corner.
@@ -438,12 +453,14 @@ class Display : public PollingComponent {
    * @param width The x width of the  of the box to to fill before word-wrapping.
    * @param height The y height of the  of the box to to fill before truncating with a '...'.
    * @param font The font to draw the text with.
+   * @param color The color to draw the text with.
+   * @param background The background color to use for antialiasing.
    * @param line_height A multiplier for the line height. Set to 1.0 for standard line spacing.
    * @param format The format to use.
    * @param ... The arguments to use for the text formatting.
    */
-  void printf(int x, int y, int width, int height, BaseFont *font, float line_height, const char *format, ...)
-      __attribute__((format(printf, 8, 9)));
+  void printf(int x, int y, int width, int height, BaseFont *font, Color color, Color background, float line_height,
+              const char *format, ...) __attribute__((format(printf, 10, 11)));
 
   /** Evaluate the strftime-format `format` and print the result with the anchor point at [x,y] with `font`.
    *

--- a/esphome/components/display/display.h
+++ b/esphome/components/display/display.h
@@ -430,6 +430,21 @@ class Display : public PollingComponent {
    */
   void printf(int x, int y, BaseFont *font, const char *format, ...) __attribute__((format(printf, 5, 6)));
 
+  /** Evaluate the printf-format `format` and print the result in a word-wrapping text box, with the anchor point at
+   * [x,y] with `font`.
+   *
+   * @param x The x coordinate of the text alignment anchor point.
+   * @param y The y coordinate of the text alignment anchor point.
+   * @param width The x width of the  of the box to to fill before word-wrapping.
+   * @param height The y height of the  of the box to to fill before truncating with a '...'.
+   * @param font The font to draw the text with.
+   * @param line_height A multiplier for the line height. Set to 1.0 for standard line spacing.
+   * @param format The format to use.
+   * @param ... The arguments to use for the text formatting.
+   */
+  void printf(int x, int y, int width, int height, BaseFont *font, float line_height, const char *format, ...)
+      __attribute__((format(printf, 8, 9)));
+
   /** Evaluate the strftime-format `format` and print the result with the anchor point at [x,y] with `font`.
    *
    * @param x The x coordinate of the text alignment anchor point.


### PR DESCRIPTION
# What does this implement/fix?
For matrix style graphical displays, sometimes there is a need to display a block of text.
The exact newline points depend on the text, and this might vary depending on sensors.

This PR implements the ability to printf to a text box defined by its x, y, coordinates and width,height.

It automatically wraps words onto new lines.
When the text would vertically overspill the box provided, the final characters are replaced by '...'.

It has the ability to set the font and adjust the line spacing from the nominal value of 1.0.

![image](https://github.com/user-attachments/assets/bd2c0796-2a5b-4bf3-a754-cc02a0f2f268)

Thanks to @alvesvaren who provided the initial version of this and agreed to allow it to be added to esphome core.
https://gist.github.com/alvesvaren/767d9585f0ecbef18ef1c7c0492c4332

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

display:
  - platform: st7735
    model: "INITR_MINI160X80"
    reset_pin: 1
    cs_pin: 4
    dc_pin: 2
    rotation: 270
    device_width: 82
    device_height: 161
    col_start: 0
    row_start: 0
    eight_bit_color: true
    update_interval: 5s
    invert_colors: True
    use_bgr: True
    lambda: |-
      int x = 0;
      int y = 0;
      int w = 120;
      int h = 80;
      it.fill(Color::BLACK);
      auto green = Color(0, 255, 0);
      it.rectangle(x, y, w, h, green);
      it.printf(1, 1, w-2, h-2, id(font_roboto), 1.0, "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.");
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
