### PR TITLE
Add a core audio struct

### DIFF
--- a/esphome/core/audio.h
+++ b/esphome/core/audio.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <cstdint>
+#include <stddef.h>
+
+namespace esphome {
+
+struct AudioStreamInfo {
+  bool operator==(const AudioStreamInfo &rhs) const {
+    return (channels == rhs.channels) && (bits_per_sample == rhs.bits_per_sample) && (sample_rate == rhs.sample_rate);
+  }
+  bool operator!=(const AudioStreamInfo &rhs) const { return !operator==(rhs); }
+  size_t get_bytes_per_sample() const { return bits_per_sample / 8; }
+  uint8_t channels = 1;
+  uint8_t bits_per_sample = 16;
+  uint32_t sample_rate = 16000;
+};
+
+}  // namespace esphome


### PR DESCRIPTION
# What does this implement/fix?

Adds a new struct to the core to describe an audio stream. This will be used to help communicate the audio being passed from one component to another; e.g., a media player component will send audio to a speaker component, and this struct will let the speaker know what format the audio is in.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** not applicable

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** not applicable

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
