### PR TITLE
[web_server] expose event compoent to REST

### DIFF
--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -1442,21 +1442,21 @@ void WebServer::on_event(event::Event *obj, const std::string &event_type) {
   this->events_.send(this->event_json(obj, event_type, DETAIL_STATE).c_str(), "state");
 }
 void WebServer::handle_event_request(AsyncWebServerRequest *request, const UrlMatch &match) {
-  for (event::Event *obj : App.get_events())) {
-      if (obj->get_object_id() != match.id)
-        continue;
+  for (event::Event *obj : App.get_events()) {
+    if (obj->get_object_id() != match.id)
+      continue;
 
-      if (request->method() == HTTP_GET && match.method.empty()) {
-        auto detail = DETAIL_STATE;
-        auto *param = request->getParam("detail");
-        if (param && param->value() == "all") {
-          detail = DETAIL_ALL;
-        }
-        std::string data = this->event_json(obj, "", detail);
-        request->send(200, "application/json", data.c_str());
-        return;
+    if (request->method() == HTTP_GET && match.method.empty()) {
+      auto detail = DETAIL_STATE;
+      auto *param = request->getParam("detail");
+      if (param && param->value() == "all") {
+        detail = DETAIL_ALL;
       }
+      std::string data = this->event_json(obj, "", detail);
+      request->send(200, "application/json", data.c_str());
+      return;
     }
+  }
   request->send(404);
 }
 std::string WebServer::event_json(event::Event *obj, const std::string &event_type, JsonDetail start_config) {

--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -1441,7 +1441,24 @@ std::string WebServer::alarm_control_panel_json(alarm_control_panel::AlarmContro
 void WebServer::on_event(event::Event *obj, const std::string &event_type) {
   this->events_.send(this->event_json(obj, event_type, DETAIL_STATE).c_str(), "state");
 }
+void WebServer::handle_event_request(AsyncWebServerRequest *request, const UrlMatch &match) {
+  for (event::Event *obj : App.get_events())) {
+      if (obj->get_object_id() != match.id)
+        continue;
 
+      if (request->method() == HTTP_GET && match.method.empty()) {
+        auto detail = DETAIL_STATE;
+        auto *param = request->getParam("detail");
+        if (param && param->value() == "all") {
+          detail = DETAIL_ALL;
+        }
+        std::string data = this->event_json(obj, "", detail);
+        request->send(200, "application/json", data.c_str());
+        return;
+      }
+    }
+  request->send(404);
+}
 std::string WebServer::event_json(event::Event *obj, const std::string &event_type, JsonDetail start_config) {
   return json::build_json([obj, event_type, start_config](JsonObject root) {
     set_json_id(root, obj, "event-" + obj->get_object_id(), start_config);
@@ -1642,6 +1659,11 @@ bool WebServer::canHandle(AsyncWebServerRequest *request) {
 
 #ifdef USE_ALARM_CONTROL_PANEL
   if (request->method() == HTTP_GET && match.domain == "alarm_control_panel")
+    return true;
+#endif
+
+#ifdef USE_EVENT
+  if (request->method() == HTTP_GET && match.domain == "event")
     return true;
 #endif
 

--- a/esphome/components/web_server/web_server.h
+++ b/esphome/components/web_server/web_server.h
@@ -322,6 +322,9 @@ class WebServer : public Controller, public Component, public AsyncWebHandler {
 #ifdef USE_EVENT
   void on_event(event::Event *obj, const std::string &event_type) override;
 
+  /// Handle a event request under '/event<id>'.
+  void handle_event_request(AsyncWebServerRequest *request, const UrlMatch &match);
+
   /// Dump the event details with its value as a JSON string.
   std::string event_json(event::Event *obj, const std::string &event_type, JsonDetail start_config);
 #endif


### PR DESCRIPTION
# What does this implement/fix?

Expose the event component via the REST API

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
