### PR TITLE
chore: bump platformio to 6.1.16 to support py3.13 build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -86,7 +86,7 @@ RUN \
     pip3 install \
     --break-system-packages --no-cache-dir \
     # Keep platformio version in sync with requirements.txt
-    platformio==6.1.15 \
+    platformio==6.1.16 \
     # Change some platformio settings
     && platformio settings set enable_telemetry No \
     && platformio settings set check_platformio_interval 1000000 \

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ tornado==6.4
 tzlocal==5.2    # from time
 tzdata>=2021.1  # from time
 pyserial==3.5
-platformio==6.1.15  # When updating platformio, also update Dockerfile
+platformio==6.1.16  # When updating platformio, also update Dockerfile
 esptool==4.7.0
 click==8.1.7
 esphome-dashboard==20240620.0


### PR DESCRIPTION
bump platformio and PyYAML to build with py3.13

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

----

relates to https://github.com/Homebrew/homebrew-core/pull/193910