### PR TITLE
[touchscreen] Fix coordinates when using rotation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -315,7 +315,9 @@ jobs:
           key: platformio-${{ matrix.pio_cache_key }}
 
       - name: Install clang-tidy
-        run: sudo apt-get install clang-tidy-14
+        run: |
+          sudo apt-get update
+          sudo apt-get install clang-tidy-14
 
       - name: Register problem matchers
         run: |
@@ -397,7 +399,9 @@ jobs:
         file: ${{ fromJson(needs.list-components.outputs.components) }}
     steps:
       - name: Install dependencies
-        run: sudo apt-get install libsdl2-dev
+        run: |
+          sudo apt-get update
+          sudo apt-get install libsdl2-dev
 
       - name: Check out code from GitHub
         uses: actions/checkout@v4.1.7
@@ -451,7 +455,9 @@ jobs:
         run: echo ${{ matrix.components }}
 
       - name: Install dependencies
-        run: sudo apt-get install libsdl2-dev
+        run: |
+          sudo apt-get update
+          sudo apt-get install libsdl2-dev
 
       - name: Check out code from GitHub
         uses: actions/checkout@v4.1.7

--- a/esphome/components/touchscreen/touchscreen.cpp
+++ b/esphome/components/touchscreen/touchscreen.cpp
@@ -18,8 +18,8 @@ void Touchscreen::attach_interrupt_(InternalGPIOPin *irq_pin, esphome::gpio::Int
 
 void Touchscreen::call_setup() {
   if (this->display_ != nullptr) {
-    this->display_width_ = this->display_->get_native_width();
-    this->display_height_ = this->display_->get_native_height();
+    this->display_width_ = this->display_->get_width();
+    this->display_height_ = this->display_->get_height();
   }
   PollingComponent::call_setup();
 }


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

When the display is rotated in software by 90 or 270 the x and y axes are swapped. This is managed by setting `transform` in the touchscreen config, and this works, however when the result is scaled to the display size, the scaling is currently done with the native (unrotated) screen dimensions whereas it should be done using the effective screen dimensions.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
