### PR TITLE
[fix] deprecated functions warnings for logger component with ESP IDF version 5.3.0+

### DIFF
--- a/esphome/components/logger/logger_esp32.cpp
+++ b/esphome/components/logger/logger_esp32.cpp
@@ -10,8 +10,12 @@
 
 #ifdef USE_LOGGER_USB_SERIAL_JTAG
 #include <driver/usb_serial_jtag.h>
+#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 3, 0)
 #include <esp_vfs_dev.h>
 #include <esp_vfs_usb_serial_jtag.h>
+#else
+#include <driver/usb_serial_jtag_vfs.h>
+#endif
 #endif
 
 #include "freertos/FreeRTOS.h"
@@ -37,9 +41,14 @@ static void init_usb_serial_jtag_() {
   setvbuf(stdin, NULL, _IONBF, 0);  // Disable buffering on stdin
 
   // Minicom, screen, idf_monitor send CR when ENTER key is pressed
+#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 3, 0)
   esp_vfs_dev_usb_serial_jtag_set_rx_line_endings(ESP_LINE_ENDINGS_CR);
   // Move the caret to the beginning of the next line on '\n'
   esp_vfs_dev_usb_serial_jtag_set_tx_line_endings(ESP_LINE_ENDINGS_CRLF);
+#else
+  usb_serial_jtag_vfs_set_rx_line_endings(ESP_LINE_ENDINGS_CR);
+  usb_serial_jtag_vfs_set_tx_line_endings(ESP_LINE_ENDINGS_CRLF);
+#endif
 
   // Enable non-blocking mode on stdin and stdout
   fcntl(fileno(stdout), F_SETFL, 0);
@@ -57,7 +66,11 @@ static void init_usb_serial_jtag_() {
   }
 
   // Tell vfs to use usb-serial-jtag driver
+#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 3, 0)
   esp_vfs_usb_serial_jtag_use_driver();
+#else
+  usb_serial_jtag_vfs_use_driver();
+#endif
 }
 #endif
 

--- a/esphome/components/logger/logger_esp32.cpp
+++ b/esphome/components/logger/logger_esp32.cpp
@@ -40,13 +40,15 @@ static const char *const TAG = "logger";
 static void init_usb_serial_jtag_() {
   setvbuf(stdin, NULL, _IONBF, 0);  // Disable buffering on stdin
 
-  // Minicom, screen, idf_monitor send CR when ENTER key is pressed
 #if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 3, 0)
+  // Minicom, screen, idf_monitor send CR when ENTER key is pressed
   esp_vfs_dev_usb_serial_jtag_set_rx_line_endings(ESP_LINE_ENDINGS_CR);
   // Move the caret to the beginning of the next line on '\n'
   esp_vfs_dev_usb_serial_jtag_set_tx_line_endings(ESP_LINE_ENDINGS_CRLF);
 #else
+  // Minicom, screen, idf_monitor send CR when ENTER key is pressed
   usb_serial_jtag_vfs_set_rx_line_endings(ESP_LINE_ENDINGS_CR);
+  // Move the caret to the beginning of the next line on '\n'
   usb_serial_jtag_vfs_set_tx_line_endings(ESP_LINE_ENDINGS_CRLF);
 #endif
 


### PR DESCRIPTION
# What does this implement/fix?

Fixes compilation warnings for ESP IDF version 5.3.0+:
```
src/esphome/components/logger/logger_esp32.cpp: In function 'void esphome::logger::init_usb_serial_jtag_()':
src/esphome/components/logger/logger_esp32.cpp:40:50: warning: 'void esp_vfs_dev_usb_serial_jtag_set_rx_line_endings(esp_line_endings_t)' is deprecated: Please use usb_serial_jtag_vfs_set_rx_line_endings instead [-Wdeprecated-declarations]
   40 |   esp_vfs_dev_usb_serial_jtag_set_rx_line_endings(ESP_LINE_ENDINGS_CR);
      |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~
In file included from src/esphome/components/logger/logger_esp32.cpp:14:
.platformio/packages/framework-espidf/components/vfs/include/esp_vfs_usb_serial_jtag.h:19:6: note: declared here
   19 | void esp_vfs_dev_usb_serial_jtag_set_rx_line_endings(esp_line_endings_t mode) __attribute__((deprecated("Please use usb_serial_jtag_vfs_set_rx_line_endings instead")));
      |      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/esphome/components/logger/logger_esp32.cpp:42:50: warning: 'void esp_vfs_dev_usb_serial_jtag_set_tx_line_endings(esp_line_endings_t)' is deprecated: Please use usb_serial_jtag_vfs_set_tx_line_endings instead [-Wdeprecated-declarations]
   42 |   esp_vfs_dev_usb_serial_jtag_set_tx_line_endings(ESP_LINE_ENDINGS_CRLF);
      |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~
.platformio/packages/framework-espidf/components/vfs/include/esp_vfs_usb_serial_jtag.h:21:6: note: declared here
   21 | void esp_vfs_dev_usb_serial_jtag_set_tx_line_endings(esp_line_endings_t mode) __attribute__((deprecated("Please use usb_serial_jtag_vfs_set_tx_line_endings instead")));
      |      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/esphome/components/logger/logger_esp32.cpp:60:37: warning: 'void esp_vfs_usb_serial_jtag_use_driver()' is deprecated: Please use usb_serial_jtag_vfs_use_driver() instead [-Wdeprecated-declarations]
   60 |   esp_vfs_usb_serial_jtag_use_driver();
      |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
In file included from src/esphome/components/logger/logger_esp32.cpp:13:
.platformio/packages/framework-espidf/components/vfs/include/esp_vfs_dev.h:63:6: note: declared here
   63 | void esp_vfs_usb_serial_jtag_use_driver(void) __attribute__((deprecated("Please use usb_serial_jtag_vfs_use_driver() instead")));
```

I would like to resolve this issue to support newer ESP32 boards that require a newer version of ESP IDF other than officially supported by ESPHome.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/6325

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
esphome:
  name: esphome
  friendly_name: ESPHome
  platformio_options:
    board_build.flash_mode: dio 

esp32:
  board: esp32-c6-devkitc-1
  variant: ESP32C6
  flash_size: 8MB
  framework:
    type: esp-idf
    version: 5.3.1
    platform_version: 6.9.0
    sdkconfig_options:
      CONFIG_ESPTOOLPY_FLASHSIZE_8MB: y
     
# Enable logging
logger:
  level: VERBOSE
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
