### PR TITLE
[code-quality] statsd component

### DIFF
--- a/esphome/components/statsd/statsd.cpp
+++ b/esphome/components/statsd/statsd.cpp
@@ -2,6 +2,7 @@
 
 #include "statsd.h"
 
+#ifdef USE_NETWORK
 namespace esphome {
 namespace statsd {
 
@@ -154,3 +155,4 @@ void StatsdComponent::send_(std::string *out) {
 
 }  // namespace statsd
 }  // namespace esphome
+#endif

--- a/esphome/components/statsd/statsd.h
+++ b/esphome/components/statsd/statsd.h
@@ -3,6 +3,7 @@
 #include <vector>
 
 #include "esphome/core/defines.h"
+#ifdef USE_NETWORK
 #include "esphome/core/component.h"
 #include "esphome/components/socket/socket.h"
 #include "esphome/components/network/ip_address.h"
@@ -84,3 +85,4 @@ class StatsdComponent : public PollingComponent {
 
 }  // namespace statsd
 }  // namespace esphome
+#endif


### PR DESCRIPTION
# What does this implement/fix?

There is `DEPENDENCIES = ["network"]` so USE_NETWORK.

```
/config/esphome/esphome/components/statsd/statsd.h:78:28: error: no member named 'socket' in namespace 'esphome' [clang-diagnostic-error]
  std::unique_ptr<esphome::socket::Socket> sock_;
                  ~~~~~~~~~^
/config/esphome/esphome/components/statsd/statsd.h:79:22: error: field has incomplete type 'struct sockaddr_in' [clang-diagnostic-error]
  struct sockaddr_in destination_;
                     ^
/config/esphome/esphome/components/statsd/statsd.h:79:10: note: forward declaration of 'esphome::statsd::sockaddr_in'
  struct sockaddr_in destination_;
         ^
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
