### PR TITLE
Increase the upload OTA timeout after successful connection

### DIFF
--- a/esphome/espota2.py
+++ b/esphome/espota2.py
@@ -331,9 +331,13 @@ def run_ota_impl_(remote_host, remote_port, password, filename):
         _LOGGER.info(" -> %s", ip)
 
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    # 10 second connection timeout
     sock.settimeout(10.0)
     try:
         sock.connect((ip, remote_port))
+        # Once connected, increase transfer timeout to 120 seconds to accomidate for
+        # slow connection speed, larger files, and erase/write time.
+        sock.settimeout(120.0)
     except OSError as err:
         sock.close()
         _LOGGER.error("Connecting to %s:%s failed: %s", remote_host, remote_port, err)


### PR DESCRIPTION
Increase the upload OTA timeout after successful connection to accommodate larger files.

# What does this implement/fix?

`esphome upload` can timeout while sending the file when the file is large or the connection is slow when using the OTA method.
I left the connection timeout at the default 10 seconds, only increasing after a connection has been successfully established.

Reasoning:
using `esphome upload` a large ESPHome build or with `--file` for a Tasmota bin on ESP32-C3 devices could run into timeout limits before the tool would finish sending the file.  A 2MB file seems to take around 12-15 seconds.  I chose 120 after established connection to accommodate larger flash sizes, assuming a 16MB flash could potentially take 90-120 seconds.

Notes: `esp-idf` currently has a 15 second WDT limit, and ardiuno maybe be as small as 5 seconds, and may require users install a smaller shim firmware with `CONFIG_ESP_TASK_WDT_TIMEOUT_S` set to a higher value.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# N/A

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
