### PR TITLE
chore: bump pyyaml to 6.0.2 to support py3.13 build

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 async_timeout==4.0.3; python_version <= "3.10"
 cryptography==43.0.0
 voluptuous==0.14.2
-PyYAML==6.0.1
+PyYAML==6.0.2
 paho-mqtt==1.6.1
 colorama==0.4.6
 icmplib==3.0.4


### PR DESCRIPTION
split from #7590 

relates to https://github.com/Homebrew/homebrew-core/pull/194569

cc @jesserockz 