### PR TITLE
Bump arduino-mlx90393 to 1.0.2

### DIFF
--- a/esphome/components/mlx90393/sensor.py
+++ b/esphome/components/mlx90393/sensor.py
@@ -132,4 +132,4 @@ async def to_code(config):
         pin = await cg.gpio_pin_expression(config[CONF_DRDY_PIN])
         cg.add(var.set_drdy_gpio(pin))
 
-    cg.add_library("functionpointer/arduino-MLX90393", "1.0.0")
+    cg.add_library("functionpointer/arduino-MLX90393", "1.0.2")

--- a/platformio.ini
+++ b/platformio.ini
@@ -38,7 +38,7 @@ lib_deps =
     improv/Improv@1.2.4                    ; improv_serial / esp32_improv
     bblanchon/ArduinoJson@6.18.5           ; json
     wjtje/qr-code-generator-library@1.7.0  ; qr_code
-    functionpointer/arduino-MLX90393@1.0.0 ; mlx90393
+    functionpointer/arduino-MLX90393@1.0.2 ; mlx90393
     pavlodn/HaierProtocol@0.9.31           ; haier
     kikuchan98/pngle@1.0.2                 ; online_image
     ; This is using the repository until a new release is published to PlatformIO


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Dump dependency [arduino-mlx90393](https://github.com/functionpointer/arduino-MLX90393) to version 1.0.2.
This enables use in any framework, including nrf52 https://github.com/esphome/esphome/pull/7049.

This removes the need to restrict the mlx90393 component like suggested in https://github.com/esphome/esphome/pull/7613

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Other

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
