### PR TITLE
[config] Ensure user-supplied build flags don't get silently overwritten

### DIFF
--- a/esphome/core/config.py
+++ b/esphome/core/config.py
@@ -318,6 +318,8 @@ async def add_includes(includes):
 async def _add_platformio_options(pio_options):
     # Add includes at the very end, so that they override everything
     for key, val in pio_options.items():
+        if key == "build_flags" and not isinstance(val, list):
+            val = [val]
         cg.add_platformio_option(key, val)
 
 


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Currently if a user specifies `build_flags` as a simple string in the config, it is silently discarded, as it is overwritten by the ESPHome generated build flags. Specifying the flag as a list works-around this, but when a single flag is provided it shouldn't be ignored.

The choices are to raise an error and force the user to write a list, or just turn it into a list anyway. This PR proposes the latter.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
esphome:
  name: build_flags
  platformio_options:
    build_flags: -DDONT_IGNORE_ME
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
