### PR TITLE
[lvgl] Allow esphome::Image in lambda to update image source directly

### DIFF
--- a/esphome/components/lvgl/lvgl_esphome.h
+++ b/esphome/components/lvgl/lvgl_esphome.h
@@ -4,6 +4,9 @@
 #ifdef USE_BINARY_SENSOR
 #include "esphome/components/binary_sensor/binary_sensor.h"
 #endif  // USE_BINARY_SENSOR
+#ifdef USE_LVGL_IMAGE
+#include "esphome/components/image/image.h"
+#endif  // USE_LVGL_IMAGE
 #ifdef USE_LVGL_ROTARY_ENCODER
 #include "esphome/components/rotary_encoder/rotary_encoder.h"
 #endif  // USE_LVGL_ROTARY_ENCODER
@@ -46,6 +49,14 @@ static const display::ColorBitness LV_BITNESS = display::ColorBitness::COLOR_BIT
 #else   // LV_COLOR_DEPTH
 static const display::ColorBitness LV_BITNESS = display::ColorBitness::COLOR_BITNESS_332;
 #endif  // LV_COLOR_DEPTH
+
+#ifdef USE_LVGL_IMAGE
+// Shortcut / overload, so that the source of an image can easily be updated
+// from within a lambda.
+inline void lv_img_set_src(lv_obj_t *obj, esphome::image::Image *image) {
+  lv_img_set_src(obj, image->get_lv_img_dsc());
+}
+#endif  // USE_LVGL_IMAGE
 
 // Parent class for things that wrap an LVGL object
 class LvCompound {

--- a/tests/components/lvgl/common.yaml
+++ b/tests/components/lvgl/common.yaml
@@ -127,6 +127,11 @@ binary_sensor:
   - platform: lvgl
     name: LVGL checkbox
     widget: checkbox_id
+    on_state:
+      then:
+        - lvgl.image.update:
+            id: lv_image
+            src: !lambda if (x) return id(cat_image); else return id(dog_image);
 
 wifi:
   ssid: SSID

--- a/tests/components/lvgl/lvgl-package.yaml
+++ b/tests/components/lvgl/lvgl-package.yaml
@@ -419,6 +419,7 @@ lvgl:
             spin_time: 2s
             align: left_mid
         - image:
+            id: lv_image
             src: cat_image
             align: top_left
             y: 50


### PR DESCRIPTION
# What does this implement/fix?
If an `lvgl.image.update` needs to change the source of an image (e.g. switch between displaying a sun or a moon depending on the time), in order to do that within a lambda, the code currently needs to look something like that: 
```
text_sensor:
  - id: !extend some_sensor_id
    on_value:
      - lvgl.image.update:
          id: lv_image_daynight
          src: !lambda |-
              if (is_day)
                return sun_image->get_lv_img_dsc();
              else
                return moon_image->get_lv_img_dsc();
```

With this PR, this can be simplidied to
```
text_sensor:
  - id: !extend some_sensor_id
    on_value:
      - lvgl.image.update:
          id: lv_image_daynight
          src: !lambda |-
              if (is_day)
                return id(sun_image);
              else
                return id(moon_image);
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->
See description above

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).
Without the new code, the added test still compiles, but does not actually show the desired image.



If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
