### PR TITLE
Move setting global voice assistant to constructor

### DIFF
--- a/esphome/components/voice_assistant/voice_assistant.cpp
+++ b/esphome/components/voice_assistant/voice_assistant.cpp
@@ -65,14 +65,12 @@ bool VoiceAssistant::start_udp_socket_() {
   }
 #endif
   this->udp_socket_running_ = true;
+
+  global_voice_assistant = this;
   return true;
 }
 
-void VoiceAssistant::setup() {
-  ESP_LOGCONFIG(TAG, "Setting up Voice Assistant...");
-
-  global_voice_assistant = this;
-}
+void VoiceAssistant::setup() { ESP_LOGCONFIG(TAG, "Setting up Voice Assistant..."); }
 
 bool VoiceAssistant::allocate_buffers_() {
   if (this->send_buffer_ != nullptr) {

--- a/esphome/components/voice_assistant/voice_assistant.cpp
+++ b/esphome/components/voice_assistant/voice_assistant.cpp
@@ -878,6 +878,8 @@ void VoiceAssistant::on_announce(const api::VoiceAssistantAnnounceRequest &msg) 
 #endif
 }
 
+VoiceAssistant *global_voice_assistant = nullptr;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+
 }  // namespace voice_assistant
 }  // namespace esphome
 

--- a/esphome/components/voice_assistant/voice_assistant.cpp
+++ b/esphome/components/voice_assistant/voice_assistant.cpp
@@ -23,8 +23,6 @@ static const size_t SEND_BUFFER_SIZE = INPUT_BUFFER_SIZE * sizeof(int16_t);
 static const size_t RECEIVE_SIZE = 1024;
 static const size_t SPEAKER_BUFFER_SIZE = 16 * RECEIVE_SIZE;
 
-VoiceAssistant::VoiceAssistant() { global_voice_assistant = this; }
-
 float VoiceAssistant::get_setup_priority() const { return setup_priority::AFTER_CONNECTION; }
 
 bool VoiceAssistant::start_udp_socket_() {

--- a/esphome/components/voice_assistant/voice_assistant.cpp
+++ b/esphome/components/voice_assistant/voice_assistant.cpp
@@ -23,6 +23,8 @@ static const size_t SEND_BUFFER_SIZE = INPUT_BUFFER_SIZE * sizeof(int16_t);
 static const size_t RECEIVE_SIZE = 1024;
 static const size_t SPEAKER_BUFFER_SIZE = 16 * RECEIVE_SIZE;
 
+VoiceAssistant::VoiceAssistant() { global_voice_assistant = this; }
+
 float VoiceAssistant::get_setup_priority() const { return setup_priority::AFTER_CONNECTION; }
 
 bool VoiceAssistant::start_udp_socket_() {
@@ -65,12 +67,8 @@ bool VoiceAssistant::start_udp_socket_() {
   }
 #endif
   this->udp_socket_running_ = true;
-
-  global_voice_assistant = this;
   return true;
 }
-
-void VoiceAssistant::setup() { ESP_LOGCONFIG(TAG, "Setting up Voice Assistant..."); }
 
 bool VoiceAssistant::allocate_buffers_() {
   if (this->send_buffer_ != nullptr) {

--- a/esphome/components/voice_assistant/voice_assistant.cpp
+++ b/esphome/components/voice_assistant/voice_assistant.cpp
@@ -23,6 +23,8 @@ static const size_t SEND_BUFFER_SIZE = INPUT_BUFFER_SIZE * sizeof(int16_t);
 static const size_t RECEIVE_SIZE = 1024;
 static const size_t SPEAKER_BUFFER_SIZE = 16 * RECEIVE_SIZE;
 
+VoiceAssistant::VoiceAssistant() { global_voice_assistant = this; }
+
 float VoiceAssistant::get_setup_priority() const { return setup_priority::AFTER_CONNECTION; }
 
 bool VoiceAssistant::start_udp_socket_() {

--- a/esphome/components/voice_assistant/voice_assistant.cpp
+++ b/esphome/components/voice_assistant/voice_assistant.cpp
@@ -876,8 +876,6 @@ void VoiceAssistant::on_announce(const api::VoiceAssistantAnnounceRequest &msg) 
 #endif
 }
 
-VoiceAssistant *global_voice_assistant = nullptr;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
-
 }  // namespace voice_assistant
 }  // namespace esphome
 

--- a/esphome/components/voice_assistant/voice_assistant.h
+++ b/esphome/components/voice_assistant/voice_assistant.h
@@ -91,6 +91,7 @@ struct Configuration {
 
 class VoiceAssistant : public Component {
  public:
+  VoiceAssistant();
   void setup() override;
   void loop() override;
   float get_setup_priority() const override;

--- a/esphome/components/voice_assistant/voice_assistant.h
+++ b/esphome/components/voice_assistant/voice_assistant.h
@@ -93,7 +93,6 @@ class VoiceAssistant : public Component {
  public:
   VoiceAssistant();
 
-  void setup() override;
   void loop() override;
   float get_setup_priority() const override;
   void start_streaming();
@@ -147,7 +146,7 @@ class VoiceAssistant : public Component {
   void on_audio(const api::VoiceAssistantAudio &msg);
   void on_timer_event(const api::VoiceAssistantTimerEventResponse &msg);
   void on_announce(const api::VoiceAssistantAnnounceRequest &msg);
-  void on_set_configuration(const std::vector<std::string> &active_wake_words){};
+  void on_set_configuration(const std::vector<std::string> &active_wake_words) {};
   const Configuration &get_configuration() { return this->config_; };
 
   bool is_running() const { return this->state_ != State::IDLE; }

--- a/esphome/components/voice_assistant/voice_assistant.h
+++ b/esphome/components/voice_assistant/voice_assistant.h
@@ -30,8 +30,6 @@
 namespace esphome {
 namespace voice_assistant {
 
-VoiceAssistant *global_voice_assistant = nullptr;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
-
 // Version 1: Initial version
 // Version 2: Adds raw speaker support
 static const uint32_t LEGACY_INITIAL_VERSION = 1;
@@ -93,7 +91,7 @@ struct Configuration {
 
 class VoiceAssistant : public Component {
  public:
-  VoiceAssistant() { global_voice_assistant = this; }
+  VoiceAssistant();
 
   void setup() override;
   void loop() override;

--- a/esphome/components/voice_assistant/voice_assistant.h
+++ b/esphome/components/voice_assistant/voice_assistant.h
@@ -91,7 +91,8 @@ struct Configuration {
 
 class VoiceAssistant : public Component {
  public:
-  VoiceAssistant();
+  VoiceAssistant::VoiceAssistant() { global_voice_assistant = this; }
+
   void setup() override;
   void loop() override;
   float get_setup_priority() const override;

--- a/esphome/components/voice_assistant/voice_assistant.h
+++ b/esphome/components/voice_assistant/voice_assistant.h
@@ -30,6 +30,8 @@
 namespace esphome {
 namespace voice_assistant {
 
+VoiceAssistant *global_voice_assistant = nullptr;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+
 // Version 1: Initial version
 // Version 2: Adds raw speaker support
 static const uint32_t LEGACY_INITIAL_VERSION = 1;
@@ -91,7 +93,7 @@ struct Configuration {
 
 class VoiceAssistant : public Component {
  public:
-  VoiceAssistant::VoiceAssistant() { global_voice_assistant = this; }
+  VoiceAssistant() { global_voice_assistant = this; }
 
   void setup() override;
   void loop() override;

--- a/esphome/components/voice_assistant/voice_assistant.h
+++ b/esphome/components/voice_assistant/voice_assistant.h
@@ -146,7 +146,7 @@ class VoiceAssistant : public Component {
   void on_audio(const api::VoiceAssistantAudio &msg);
   void on_timer_event(const api::VoiceAssistantTimerEventResponse &msg);
   void on_announce(const api::VoiceAssistantAnnounceRequest &msg);
-  void on_set_configuration(const std::vector<std::string> &active_wake_words) {};
+  void on_set_configuration(const std::vector<std::string> &active_wake_words){};
   const Configuration &get_configuration() { return this->config_; };
 
   bool is_running() const { return this->state_ != State::IDLE; }


### PR DESCRIPTION
# What does this implement/fix?

Sets the global voice assistant in the constructor rather than in `setup()` so that the voice assistant feature flags will always be present in the device info.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
