### PR TITLE
Humanized the missing MQTT log topic error message

### DIFF
--- a/esphome/mqtt.py
+++ b/esphome/mqtt.py
@@ -209,6 +209,12 @@ def show_logs(config, topic=None, username=None, password=None, client_id=None):
     elif CONF_MQTT in config:
         conf = config[CONF_MQTT]
         if CONF_LOG_TOPIC in conf:
+            if config[CONF_MQTT][CONF_LOG_TOPIC] is None:
+                _LOGGER.error("MQTT log topic set to null, can't start MQTT logs")
+                return 1
+            if CONF_TOPIC not in config[CONF_MQTT][CONF_LOG_TOPIC]:
+                _LOGGER.error("MQTT log topic not available, can't start MQTT logs")
+                return 1
             topic = config[CONF_MQTT][CONF_LOG_TOPIC][CONF_TOPIC]
         elif CONF_TOPIC_PREFIX in config[CONF_MQTT]:
             topic = f"{config[CONF_MQTT][CONF_TOPIC_PREFIX]}/debug"


### PR DESCRIPTION
For https://github.com/esphome/issues/issues/6046, when MQTT logging is disabled (either via the `log_topic` or `topic_prefix` set to null), the error message a user sees is python exception.

This detects the configuration and prints a more human-readable error message, reminding the user why MQTT logs are unavailable.

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/6046

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
mqtt:
  broker: !secret mqtt_broker
  log_topic: null

# OR

mqtt:
  broker: !secret mqtt_broker
  log_prefix: null

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
