### PR TITLE
Fix broken ibeacon_uuid config in ble_rssi

### DIFF
--- a/esphome/components/ble_rssi/sensor.py
+++ b/esphome/components/ble_rssi/sensor.py
@@ -45,7 +45,7 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_SERVICE_UUID): esp32_ble_tracker.bt_uuid,
             cv.Optional(CONF_IBEACON_MAJOR): cv.uint16_t,
             cv.Optional(CONF_IBEACON_MINOR): cv.uint16_t,
-            cv.Optional(CONF_IBEACON_UUID): cv.uuid,
+            cv.Optional(CONF_IBEACON_UUID): esp32_ble_tracker.bt_uuid,
         }
     )
     .extend(esp32_ble_tracker.ESP_BLE_DEVICE_SCHEMA)
@@ -79,7 +79,7 @@ async def to_code(config):
             cg.add(var.set_service_uuid128(uuid128))
 
     if ibeacon_uuid := config.get(CONF_IBEACON_UUID):
-        ibeacon_uuid = esp32_ble_tracker.as_hex_array(str(ibeacon_uuid))
+        ibeacon_uuid = esp32_ble_tracker.as_reversed_hex_array(ibeacon_uuid)
         cg.add(var.set_ibeacon_uuid(ibeacon_uuid))
 
         if (ibeacon_major := config.get(CONF_IBEACON_MAJOR)) is not None:


### PR DESCRIPTION
# What does this implement/fix?

Fixes `ble_rssi` not reporting on iBeacon devices by incorporating the changes introduced to `ble_presence` in https://github.com/esphome/esphome/pull/7332 to `ble_rssi` too.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/6259

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
  - platform: ble_rssi
    ibeacon_uuid: 2715d766-4afa-4197-862e-41370aa949a7
    name: "HA App BLE Tracker"

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
