### PR TITLE
i2c_device

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -198,6 +198,7 @@ esphome/components/htu31d/* @betterengineering
 esphome/components/hydreon_rgxx/* @functionpointer
 esphome/components/hyt271/* @Philippe12
 esphome/components/i2c/* @esphome/core
+esphome/components/i2c_device/* @gabest11
 esphome/components/i2s_audio/* @jesserockz
 esphome/components/i2s_audio/media_player/* @jesserockz
 esphome/components/i2s_audio/microphone/* @jesserockz

--- a/esphome/components/i2c_device/__init__.py
+++ b/esphome/components/i2c_device/__init__.py
@@ -1,0 +1,24 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import i2c
+from esphome.const import CONF_ID
+
+DEPENDENCIES = ["i2c"]
+CODEOWNERS = ["@gabest11"]
+
+MULTI_CONF = True
+i2c_device_ns = cg.esphome_ns.namespace("i2c_device")
+
+i2c_device = i2c_device_ns.class_("I2CDeviceComponent", cg.Component, i2c.I2CDevice)
+
+CONFIG_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(CONF_ID): cv.declare_id(i2c_device),
+    }
+).extend(i2c.i2c_device_schema(None))
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+    await i2c.register_i2c_device(var, config)

--- a/esphome/components/i2c_device/__init__.py
+++ b/esphome/components/i2c_device/__init__.py
@@ -9,7 +9,9 @@ MULTI_CONF = True
 
 i2c_device_ns = cg.esphome_ns.namespace("i2c_device")
 
-I2CDeviceComponent = i2c_device_ns.class_("I2CDeviceComponent", cg.Component, i2c.I2CDevice)
+I2CDeviceComponent = i2c_device_ns.class_(
+    "I2CDeviceComponent", cg.Component, i2c.I2CDevice
+)
 
 CONFIG_SCHEMA = cv.Schema(
     {

--- a/esphome/components/i2c_device/__init__.py
+++ b/esphome/components/i2c_device/__init__.py
@@ -5,15 +5,15 @@ from esphome.const import CONF_ID
 
 DEPENDENCIES = ["i2c"]
 CODEOWNERS = ["@gabest11"]
-
 MULTI_CONF = True
+
 i2c_device_ns = cg.esphome_ns.namespace("i2c_device")
 
-i2c_device = i2c_device_ns.class_("I2CDeviceComponent", cg.Component, i2c.I2CDevice)
+I2CDeviceComponent = i2c_device_ns.class_("I2CDeviceComponent", cg.Component, i2c.I2CDevice)
 
 CONFIG_SCHEMA = cv.Schema(
     {
-        cv.GenerateID(CONF_ID): cv.declare_id(i2c_device),
+        cv.GenerateID(CONF_ID): cv.declare_id(I2CDeviceComponent),
     }
 ).extend(i2c.i2c_device_schema(None))
 

--- a/esphome/components/i2c_device/i2c_device.cpp
+++ b/esphome/components/i2c_device/i2c_device.cpp
@@ -1,0 +1,17 @@
+#include "i2c_device.h"
+#include "esphome/core/log.h"
+#include "esphome/core/hal.h"
+#include <cinttypes>
+
+namespace esphome {
+namespace i2c_device {
+
+static const char *const TAG = "i2c_device";
+
+void I2CDeviceComponent::dump_config() {
+  ESP_LOGCONFIG(TAG, "I2CDevice");
+  LOG_I2C_DEVICE(this);
+}
+
+}  // namespace i2c_device
+}  // namespace esphome

--- a/esphome/components/i2c_device/i2c_device.h
+++ b/esphome/components/i2c_device/i2c_device.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/components/i2c/i2c.h"
+
+namespace esphome {
+namespace i2c_device {
+
+class I2CDeviceComponent : public Component, public i2c::I2CDevice {
+ public:
+  void dump_config() override;
+  float get_setup_priority() const override { return setup_priority::DATA; }
+
+ protected:
+};
+
+}  // namespace i2c_device
+}  // namespace esphome

--- a/tests/components/i2c_device/test.esp32-ard.yaml
+++ b/tests/components/i2c_device/test.esp32-ard.yaml
@@ -1,0 +1,8 @@
+i2c:
+  - id: i2c_i2c
+    scl: 16
+    sda: 17
+
+i2c_device:
+  id: i2cdev
+  address: 0x2C

--- a/tests/components/i2c_device/test.esp32-c3-ard.yaml
+++ b/tests/components/i2c_device/test.esp32-c3-ard.yaml
@@ -1,0 +1,8 @@
+i2c:
+  - id: i2c_i2c
+    scl: 5
+    sda: 4
+
+i2c_device:
+  id: i2cdev
+  address: 0x2C

--- a/tests/components/i2c_device/test.esp32-c3-idf.yaml
+++ b/tests/components/i2c_device/test.esp32-c3-idf.yaml
@@ -1,0 +1,8 @@
+i2c:
+  - id: i2c_i2c
+    scl: 5
+    sda: 4
+
+i2c_device:
+  id: i2cdev
+  address: 0x2C

--- a/tests/components/i2c_device/test.esp32-idf.yaml
+++ b/tests/components/i2c_device/test.esp32-idf.yaml
@@ -1,0 +1,8 @@
+i2c:
+  - id: i2c_i2c
+    scl: 16
+    sda: 17
+
+i2c_device:
+  id: i2cdev
+  address: 0x2C

--- a/tests/components/i2c_device/test.esp8266-ard.yaml
+++ b/tests/components/i2c_device/test.esp8266-ard.yaml
@@ -1,0 +1,8 @@
+i2c:
+  - id: i2c_i2c
+    scl: 5
+    sda: 4
+
+i2c_device:
+  id: i2cdev
+  address: 0x2C

--- a/tests/components/i2c_device/test.rp2040-ard.yaml
+++ b/tests/components/i2c_device/test.rp2040-ard.yaml
@@ -1,0 +1,8 @@
+i2c:
+  - id: i2c_i2c
+    scl: 5
+    sda: 4
+
+i2c_device:
+  id: i2cdev
+  address: 0x2C


### PR DESCRIPTION
# What does this implement/fix?

This is just a simple barebone i2c_device, similar to the spi_device, that can be used to quickly test i2c devices using lambdas, without writing a new component.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#4356

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

Quick setup of the QN8027 FM transmitter to broadcast a web stream from media_player.

```yaml

esphome:
  on_boot:
    then: 
      - wait_until:
          timeout: 15s
          condition:
            and:
              - wifi.connected
              - media_player.is_idle
      - media_player.play_media: 'INSERT_STREAM_URL_HERE'
      - media_player.volume_set: 50%
      - script.execute: 
          id: qn8027_setup
          freq: 87.50f

logger:

i2c:
  sda: 10
  scl: 9
  scan: True

i2c_device:
  id: i2cdev
  address: 0x2C

i2s_audio:
  i2s_lrclk_pin: 4
  i2s_bclk_pin: 6

media_player:
  - platform: i2s_audio
    name: "Media Player"
    dac_type: external
    i2s_dout_pin: 5
    mode: stereo
      
interval:
  - interval: 5s
    then:
    - lambda: |-
        if (auto b = id(i2cdev).read_byte(0x07)) {
          ESP_LOGD("QN8027", "QN8027 status %d", *b & 7);
        }

script:
  - id: qn8027_setup
    parameters:
      freq: float
    then:
      - lambda: |-
          uint8_t CID[5] = { 0, 0, 0, 0, 0 };
          if (auto b = id(i2cdev).read_byte(0x05)) {
            CID[2] = (*b >> 0) & 3;
            CID[1] = (*b >> 2) & 7;
            CID[0] = (*b >> 5) & 7;
          }
          if (auto b = id(i2cdev).read_byte(0x06)) {
            CID[4] = (*b >> 4) & 15;
            CID[3] = (*b >> 4) & 15;
          }
          if (CID[3] == 4 && CID[1] == 0) { // QN8027 && FM
            ESP_LOGD("QN8027", "QN8027 found");
            id(i2cdev).write_byte(0x00, 0x80); // reset
            delay_microseconds_safe(10000);
            id(i2cdev).write_byte(0x00, 0x40); // calibrate
            delay_microseconds_safe(10000);
            //float freq = 87.50f;
            uint16_t ch = (uint16_t) ((freq - 76) * 20);
            ESP_LOGD("QN8027", "QN8027 tuning to %.2f %d", freq, ch);
            id(i2cdev).write_byte(0x00, (1 << 5) | ((ch >> 8) & 3)); // tx enable | ch[9:8]
            id(i2cdev).write_byte(0x01, ch & 0xff); // ch[7:0]
            id(i2cdev).write_byte(0x02, 0b00111001);
            id(i2cdev).write_byte(0x03, 0b00010000);
            id(i2cdev).write_byte(0x04, 0b10110010);
            id(i2cdev).write_byte(0x10, 0b01111111);
            id(i2cdev).write_byte(0x11, 0b10000001);
          } else {
            ESP_LOGE("QN8027", "QN8027 was not found");
          }

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
