### PR TITLE
[nextion] Add publish actions

### DIFF
--- a/esphome/components/nextion/__init__.py
+++ b/esphome/components/nextion/__init__.py
@@ -6,3 +6,5 @@ Nextion = nextion_ns.class_("Nextion", cg.PollingComponent, uart.UARTDevice)
 nextion_ref = Nextion.operator("ref")
 
 CONF_NEXTION_ID = "nextion_id"
+CONF_PUBLISH_STATE = "publish_state"
+CONF_SEND_TO_NEXTION = "send_to_nextion"

--- a/esphome/components/nextion/automation.h
+++ b/esphome/components/nextion/automation.h
@@ -5,6 +5,13 @@
 namespace esphome {
 namespace nextion {
 
+class BufferOverflowTrigger : public Trigger<> {
+ public:
+  explicit BufferOverflowTrigger(Nextion *nextion) {
+    nextion->add_buffer_overflow_event_callback([this]() { this->trigger(); });
+  }
+};
+
 class SetupTrigger : public Trigger<> {
  public:
   explicit SetupTrigger(Nextion *nextion) {
@@ -42,11 +49,73 @@ class TouchTrigger : public Trigger<uint8_t, uint8_t, bool> {
   }
 };
 
-class BufferOverflowTrigger : public Trigger<> {
+template<typename... Ts> class NextionPublishFloatAction : public Action<Ts...> {
  public:
-  explicit BufferOverflowTrigger(Nextion *nextion) {
-    nextion->add_buffer_overflow_event_callback([this]() { this->trigger(); });
+  explicit NextionPublishFloatAction(NextionComponent *component) : component_(component) {}
+
+  TEMPLATABLE_VALUE(float, state)
+  TEMPLATABLE_VALUE(bool, publish_state)
+  TEMPLATABLE_VALUE(bool, send_to_nextion)
+
+  void play(Ts... x) override {
+    this->component_->set_state(this->state_.value(x...), this->publish_state_.value(x...),
+                                this->send_to_nextion_.value(x...));
   }
+
+  void set_state(std::function<void(Ts..., float)> state) { this->state_ = state; }
+  void set_publish_state(std::function<void(Ts..., bool)> publish_state) { this->publish_state_ = publish_state; }
+  void set_send_to_nextion(std::function<void(Ts..., bool)> send_to_nextion) {
+    this->send_to_nextion_ = send_to_nextion;
+  }
+
+ protected:
+  NextionComponent *component_;
+};
+
+template<typename... Ts> class NextionPublishTextAction : public Action<Ts...> {
+ public:
+  explicit NextionPublishTextAction(NextionComponent *component) : component_(component) {}
+
+  TEMPLATABLE_VALUE(const char *, state)
+  TEMPLATABLE_VALUE(bool, publish_state)
+  TEMPLATABLE_VALUE(bool, send_to_nextion)
+
+  void play(Ts... x) override {
+    this->component_->set_state(this->state_.value(x...), this->publish_state_.value(x...),
+                                this->send_to_nextion_.value(x...));
+  }
+
+  void set_state(std::function<void(Ts..., const char *)> state) { this->state_ = state; }
+  void set_publish_state(std::function<void(Ts..., bool)> publish_state) { this->publish_state_ = publish_state; }
+  void set_send_to_nextion(std::function<void(Ts..., bool)> send_to_nextion) {
+    this->send_to_nextion_ = send_to_nextion;
+  }
+
+ protected:
+  NextionComponent *component_;
+};
+
+template<typename... Ts> class NextionPublishBoolAction : public Action<Ts...> {
+ public:
+  explicit NextionPublishBoolAction(NextionComponent *component) : component_(component) {}
+
+  TEMPLATABLE_VALUE(bool, state)
+  TEMPLATABLE_VALUE(bool, publish_state)
+  TEMPLATABLE_VALUE(bool, send_to_nextion)
+
+  void play(Ts... x) override {
+    this->component_->set_state(this->state_.value(x...), this->publish_state_.value(x...),
+                                this->send_to_nextion_.value(x...));
+  }
+
+  void set_state(std::function<void(Ts..., bool)> state) { this->state_ = state; }
+  void set_publish_state(std::function<void(Ts..., bool)> publish_state) { this->publish_state_ = publish_state; }
+  void set_send_to_nextion(std::function<void(Ts..., bool)> send_to_nextion) {
+    this->send_to_nextion_ = send_to_nextion;
+  }
+
+ protected:
+  NextionComponent *component_;
 };
 
 }  // namespace nextion

--- a/esphome/components/nextion/binary_sensor/__init__.py
+++ b/esphome/components/nextion/binary_sensor/__init__.py
@@ -6,16 +6,11 @@ from esphome.components import binary_sensor
 from esphome.const import (
     CONF_ID,
     CONF_STATE,
-    CONF_COMPONENT_ID, 
-    CONF_PAGE_ID, 
+    CONF_COMPONENT_ID,
+    CONF_PAGE_ID,
 )
 
-from .. import (
-    nextion_ns,
-    CONF_NEXTION_ID,
-    CONF_PUBLISH_STATE,
-    CONF_SEND_TO_NEXTION
-)
+from .. import nextion_ns, CONF_NEXTION_ID, CONF_PUBLISH_STATE, CONF_SEND_TO_NEXTION
 
 
 from ..base_component import (
@@ -31,7 +26,9 @@ NextionBinarySensor = nextion_ns.class_(
     "NextionBinarySensor", binary_sensor.BinarySensor, cg.PollingComponent
 )
 
-NextionPublishBoolAction = nextion_ns.class_("NextionPublishBoolAction", automation.Action)
+NextionPublishBoolAction = nextion_ns.class_(
+    "NextionPublishBoolAction", automation.Action
+)
 
 CONFIG_SCHEMA = cv.All(
     binary_sensor.binary_sensor_schema(NextionBinarySensor)
@@ -67,6 +64,7 @@ async def to_code(config):
         await setup_component_core_(var, config, ".val")
         cg.add(hub.register_binarysensor_component(var))
 
+
 @automation.register_action(
     "binary_sensor.nextion.publish",
     NextionPublishBoolAction,
@@ -75,7 +73,9 @@ async def to_code(config):
             cv.Required(CONF_ID): cv.use_id(NextionBinarySensor),
             cv.Required(CONF_STATE): cv.templatable(cv.boolean),
             cv.Optional(CONF_PUBLISH_STATE, default="true"): cv.templatable(cv.boolean),
-            cv.Optional(CONF_SEND_TO_NEXTION, default="true"): cv.templatable(cv.boolean)
+            cv.Optional(CONF_SEND_TO_NEXTION, default="true"): cv.templatable(
+                cv.boolean
+            ),
         }
     ),
 )

--- a/esphome/components/nextion/binary_sensor/__init__.py
+++ b/esphome/components/nextion/binary_sensor/__init__.py
@@ -1,9 +1,21 @@
+from esphome import automation
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import binary_sensor
 
-from esphome.const import CONF_COMPONENT_ID, CONF_PAGE_ID, CONF_ID
-from .. import nextion_ns, CONF_NEXTION_ID
+from esphome.const import (
+    CONF_ID,
+    CONF_STATE,
+    CONF_COMPONENT_ID, 
+    CONF_PAGE_ID, 
+)
+
+from .. import (
+    nextion_ns,
+    CONF_NEXTION_ID,
+    CONF_PUBLISH_STATE,
+    CONF_SEND_TO_NEXTION
+)
 
 
 from ..base_component import (
@@ -18,6 +30,8 @@ CODEOWNERS = ["@senexcrenshaw"]
 NextionBinarySensor = nextion_ns.class_(
     "NextionBinarySensor", binary_sensor.BinarySensor, cg.PollingComponent
 )
+
+NextionPublishBoolAction = nextion_ns.class_("NextionPublishBoolAction", automation.Action)
 
 CONFIG_SCHEMA = cv.All(
     binary_sensor.binary_sensor_schema(NextionBinarySensor)
@@ -52,3 +66,30 @@ async def to_code(config):
     if CONF_COMPONENT_NAME in config or CONF_VARIABLE_NAME in config:
         await setup_component_core_(var, config, ".val")
         cg.add(hub.register_binarysensor_component(var))
+
+@automation.register_action(
+    "binary_sensor.nextion.publish",
+    NextionPublishBoolAction,
+    cv.Schema(
+        {
+            cv.Required(CONF_ID): cv.use_id(NextionBinarySensor),
+            cv.Required(CONF_STATE): cv.templatable(cv.boolean),
+            cv.Optional(CONF_PUBLISH_STATE, default="true"): cv.templatable(cv.boolean),
+            cv.Optional(CONF_SEND_TO_NEXTION, default="true"): cv.templatable(cv.boolean)
+        }
+    ),
+)
+async def sensor_nextion_publish_to_code(config, action_id, template_arg, args):
+    paren = await cg.get_variable(config[CONF_ID])
+    var = cg.new_Pvariable(action_id, template_arg, paren)
+
+    template_ = await cg.templatable(config[CONF_STATE], args, bool)
+    cg.add(var.set_state(template_))
+
+    template_ = await cg.templatable(config[CONF_PUBLISH_STATE], args, bool)
+    cg.add(var.set_publish_state(template_))
+
+    template_ = await cg.templatable(config[CONF_SEND_TO_NEXTION], args, bool)
+    cg.add(var.set_send_to_nextion(template_))
+
+    return var

--- a/esphome/components/nextion/sensor/__init__.py
+++ b/esphome/components/nextion/sensor/__init__.py
@@ -1,3 +1,4 @@
+from esphome import automation
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import sensor
@@ -5,8 +6,15 @@ from esphome.components import sensor
 from esphome.const import (
     CONF_ID,
     CONF_COMPONENT_ID,
+    CONF_STATE
 )
-from .. import nextion_ns, CONF_NEXTION_ID
+
+from .. import (
+    nextion_ns,
+    CONF_NEXTION_ID,
+    CONF_PUBLISH_STATE,
+    CONF_SEND_TO_NEXTION
+)
 
 from ..base_component import (
     setup_component_core_,
@@ -25,6 +33,7 @@ CODEOWNERS = ["@senexcrenshaw"]
 
 NextionSensor = nextion_ns.class_("NextionSensor", sensor.Sensor, cg.PollingComponent)
 
+NextionPublishFloatAction = nextion_ns.class_("NextionPublishFloatAction", automation.Action)
 
 def CheckWaveID(value):
     value = cv.int_(value)
@@ -40,7 +49,6 @@ def _validate(config):
         )
 
     return config
-
 
 CONFIG_SCHEMA = cv.All(
     sensor.sensor_schema(
@@ -95,3 +103,30 @@ async def to_code(config):
 
     if CONF_WAVE_MAX_LENGTH in config:
         cg.add(var.set_wave_max_length(config[CONF_WAVE_MAX_LENGTH]))
+
+@automation.register_action(
+    "sensor.nextion.publish",
+    NextionPublishFloatAction,
+    cv.Schema(
+        {
+            cv.Required(CONF_ID): cv.use_id(NextionSensor),
+            cv.Required(CONF_STATE): cv.templatable(cv.float_),
+            cv.Optional(CONF_PUBLISH_STATE, default="true"): cv.templatable(cv.boolean),
+            cv.Optional(CONF_SEND_TO_NEXTION, default="true"): cv.templatable(cv.boolean)
+        }
+    ),
+)
+async def sensor_nextion_publish_to_code(config, action_id, template_arg, args):
+    paren = await cg.get_variable(config[CONF_ID])
+    var = cg.new_Pvariable(action_id, template_arg, paren)
+
+    template_ = await cg.templatable(config[CONF_STATE], args, float)
+    cg.add(var.set_state(template_))
+
+    template_ = await cg.templatable(config[CONF_PUBLISH_STATE], args, bool)
+    cg.add(var.set_publish_state(template_))
+
+    template_ = await cg.templatable(config[CONF_SEND_TO_NEXTION], args, bool)
+    cg.add(var.set_send_to_nextion(template_))
+
+    return var

--- a/esphome/components/nextion/sensor/__init__.py
+++ b/esphome/components/nextion/sensor/__init__.py
@@ -3,18 +3,9 @@ import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import sensor
 
-from esphome.const import (
-    CONF_ID,
-    CONF_COMPONENT_ID,
-    CONF_STATE
-)
+from esphome.const import CONF_ID, CONF_COMPONENT_ID, CONF_STATE
 
-from .. import (
-    nextion_ns,
-    CONF_NEXTION_ID,
-    CONF_PUBLISH_STATE,
-    CONF_SEND_TO_NEXTION
-)
+from .. import nextion_ns, CONF_NEXTION_ID, CONF_PUBLISH_STATE, CONF_SEND_TO_NEXTION
 
 from ..base_component import (
     setup_component_core_,
@@ -33,7 +24,10 @@ CODEOWNERS = ["@senexcrenshaw"]
 
 NextionSensor = nextion_ns.class_("NextionSensor", sensor.Sensor, cg.PollingComponent)
 
-NextionPublishFloatAction = nextion_ns.class_("NextionPublishFloatAction", automation.Action)
+NextionPublishFloatAction = nextion_ns.class_(
+    "NextionPublishFloatAction", automation.Action
+)
+
 
 def CheckWaveID(value):
     value = cv.int_(value)
@@ -49,6 +43,7 @@ def _validate(config):
         )
 
     return config
+
 
 CONFIG_SCHEMA = cv.All(
     sensor.sensor_schema(
@@ -104,6 +99,7 @@ async def to_code(config):
     if CONF_WAVE_MAX_LENGTH in config:
         cg.add(var.set_wave_max_length(config[CONF_WAVE_MAX_LENGTH]))
 
+
 @automation.register_action(
     "sensor.nextion.publish",
     NextionPublishFloatAction,
@@ -112,7 +108,9 @@ async def to_code(config):
             cv.Required(CONF_ID): cv.use_id(NextionSensor),
             cv.Required(CONF_STATE): cv.templatable(cv.float_),
             cv.Optional(CONF_PUBLISH_STATE, default="true"): cv.templatable(cv.boolean),
-            cv.Optional(CONF_SEND_TO_NEXTION, default="true"): cv.templatable(cv.boolean)
+            cv.Optional(CONF_SEND_TO_NEXTION, default="true"): cv.templatable(
+                cv.boolean
+            ),
         }
     ),
 )

--- a/esphome/components/nextion/switch/__init__.py
+++ b/esphome/components/nextion/switch/__init__.py
@@ -3,17 +3,9 @@ import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import switch
 
-from esphome.const import (
-    CONF_ID,
-    CONF_STATE
-)
+from esphome.const import CONF_ID, CONF_STATE
 
-from .. import (
-    nextion_ns,
-    CONF_NEXTION_ID,
-    CONF_PUBLISH_STATE,
-    CONF_SEND_TO_NEXTION
-)
+from .. import nextion_ns, CONF_NEXTION_ID, CONF_PUBLISH_STATE, CONF_SEND_TO_NEXTION
 
 from ..base_component import (
     setup_component_core_,
@@ -26,7 +18,9 @@ CODEOWNERS = ["@senexcrenshaw"]
 
 NextionSwitch = nextion_ns.class_("NextionSwitch", switch.Switch, cg.PollingComponent)
 
-NextionPublishBoolAction = nextion_ns.class_("NextionPublishBoolAction", automation.Action)
+NextionPublishBoolAction = nextion_ns.class_(
+    "NextionPublishBoolAction", automation.Action
+)
 
 CONFIG_SCHEMA = cv.All(
     switch.switch_schema(NextionSwitch)
@@ -46,6 +40,7 @@ async def to_code(config):
 
     await setup_component_core_(var, config, ".val")
 
+
 @automation.register_action(
     "switch.nextion.publish",
     NextionPublishBoolAction,
@@ -54,7 +49,9 @@ async def to_code(config):
             cv.Required(CONF_ID): cv.use_id(NextionSwitch),
             cv.Required(CONF_STATE): cv.templatable(cv.boolean),
             cv.Optional(CONF_PUBLISH_STATE, default="true"): cv.templatable(cv.boolean),
-            cv.Optional(CONF_SEND_TO_NEXTION, default="true"): cv.templatable(cv.boolean)
+            cv.Optional(CONF_SEND_TO_NEXTION, default="true"): cv.templatable(
+                cv.boolean
+            ),
         }
     ),
 )

--- a/esphome/components/nextion/switch/__init__.py
+++ b/esphome/components/nextion/switch/__init__.py
@@ -1,9 +1,19 @@
+from esphome import automation
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import switch
 
-from esphome.const import CONF_ID
-from .. import nextion_ns, CONF_NEXTION_ID
+from esphome.const import (
+    CONF_ID,
+    CONF_STATE
+)
+
+from .. import (
+    nextion_ns,
+    CONF_NEXTION_ID,
+    CONF_PUBLISH_STATE,
+    CONF_SEND_TO_NEXTION
+)
 
 from ..base_component import (
     setup_component_core_,
@@ -15,6 +25,8 @@ from ..base_component import (
 CODEOWNERS = ["@senexcrenshaw"]
 
 NextionSwitch = nextion_ns.class_("NextionSwitch", switch.Switch, cg.PollingComponent)
+
+NextionPublishBoolAction = nextion_ns.class_("NextionPublishBoolAction", automation.Action)
 
 CONFIG_SCHEMA = cv.All(
     switch.switch_schema(NextionSwitch)
@@ -33,3 +45,30 @@ async def to_code(config):
     cg.add(hub.register_switch_component(var))
 
     await setup_component_core_(var, config, ".val")
+
+@automation.register_action(
+    "switch.nextion.publish",
+    NextionPublishBoolAction,
+    cv.Schema(
+        {
+            cv.Required(CONF_ID): cv.use_id(NextionSwitch),
+            cv.Required(CONF_STATE): cv.templatable(cv.boolean),
+            cv.Optional(CONF_PUBLISH_STATE, default="true"): cv.templatable(cv.boolean),
+            cv.Optional(CONF_SEND_TO_NEXTION, default="true"): cv.templatable(cv.boolean)
+        }
+    ),
+)
+async def sensor_nextion_publish_to_code(config, action_id, template_arg, args):
+    paren = await cg.get_variable(config[CONF_ID])
+    var = cg.new_Pvariable(action_id, template_arg, paren)
+
+    template_ = await cg.templatable(config[CONF_STATE], args, bool)
+    cg.add(var.set_state(template_))
+
+    template_ = await cg.templatable(config[CONF_PUBLISH_STATE], args, bool)
+    cg.add(var.set_publish_state(template_))
+
+    template_ = await cg.templatable(config[CONF_SEND_TO_NEXTION], args, bool)
+    cg.add(var.set_send_to_nextion(template_))
+
+    return var

--- a/esphome/components/nextion/text_sensor/__init__.py
+++ b/esphome/components/nextion/text_sensor/__init__.py
@@ -2,17 +2,9 @@ from esphome import automation
 from esphome.components import text_sensor
 import esphome.config_validation as cv
 import esphome.codegen as cg
-from esphome.const import (
-    CONF_ID,
-    CONF_STATE
-)
+from esphome.const import CONF_ID, CONF_STATE
 
-from .. import (
-    nextion_ns,
-    CONF_NEXTION_ID,
-    CONF_PUBLISH_STATE,
-    CONF_SEND_TO_NEXTION
-)
+from .. import nextion_ns, CONF_NEXTION_ID, CONF_PUBLISH_STATE, CONF_SEND_TO_NEXTION
 
 from ..base_component import (
     setup_component_core_,
@@ -25,7 +17,9 @@ NextionTextSensor = nextion_ns.class_(
     "NextionTextSensor", text_sensor.TextSensor, cg.PollingComponent
 )
 
-NextionPublishTextAction = nextion_ns.class_("NextionPublishTextAction", automation.Action)
+NextionPublishTextAction = nextion_ns.class_(
+    "NextionPublishTextAction", automation.Action
+)
 
 CONFIG_SCHEMA = (
     text_sensor.text_sensor_schema(NextionTextSensor)
@@ -44,6 +38,7 @@ async def to_code(config):
 
     await setup_component_core_(var, config, ".txt")
 
+
 @automation.register_action(
     "text_sensor.nextion.publish",
     NextionPublishTextAction,
@@ -52,9 +47,11 @@ async def to_code(config):
             cv.Required(CONF_ID): cv.use_id(NextionTextSensor),
             cv.Required(CONF_STATE): cv.templatable(cv.string_strict),
             cv.Optional(CONF_PUBLISH_STATE, default="true"): cv.templatable(cv.boolean),
-            cv.Optional(CONF_SEND_TO_NEXTION, default="true"): cv.templatable(cv.boolean)
+            cv.Optional(CONF_SEND_TO_NEXTION, default="true"): cv.templatable(
+                cv.boolean
+            ),
         }
-    )
+    ),
 )
 async def sensor_nextion_publish_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])

--- a/esphome/components/nextion/text_sensor/__init__.py
+++ b/esphome/components/nextion/text_sensor/__init__.py
@@ -1,9 +1,18 @@
+from esphome import automation
 from esphome.components import text_sensor
 import esphome.config_validation as cv
 import esphome.codegen as cg
-from esphome.const import CONF_ID
+from esphome.const import (
+    CONF_ID,
+    CONF_STATE
+)
 
-from .. import nextion_ns, CONF_NEXTION_ID
+from .. import (
+    nextion_ns,
+    CONF_NEXTION_ID,
+    CONF_PUBLISH_STATE,
+    CONF_SEND_TO_NEXTION
+)
 
 from ..base_component import (
     setup_component_core_,
@@ -15,6 +24,8 @@ CODEOWNERS = ["@senexcrenshaw"]
 NextionTextSensor = nextion_ns.class_(
     "NextionTextSensor", text_sensor.TextSensor, cg.PollingComponent
 )
+
+NextionPublishTextAction = nextion_ns.class_("NextionPublishTextAction", automation.Action)
 
 CONFIG_SCHEMA = (
     text_sensor.text_sensor_schema(NextionTextSensor)
@@ -32,3 +43,30 @@ async def to_code(config):
     cg.add(hub.register_textsensor_component(var))
 
     await setup_component_core_(var, config, ".txt")
+
+@automation.register_action(
+    "text_sensor.nextion.publish",
+    NextionPublishTextAction,
+    cv.Schema(
+        {
+            cv.Required(CONF_ID): cv.use_id(NextionTextSensor),
+            cv.Required(CONF_STATE): cv.templatable(cv.string_strict),
+            cv.Optional(CONF_PUBLISH_STATE, default="true"): cv.templatable(cv.boolean),
+            cv.Optional(CONF_SEND_TO_NEXTION, default="true"): cv.templatable(cv.boolean)
+        }
+    )
+)
+async def sensor_nextion_publish_to_code(config, action_id, template_arg, args):
+    paren = await cg.get_variable(config[CONF_ID])
+    var = cg.new_Pvariable(action_id, template_arg, paren)
+
+    template_ = await cg.templatable(config[CONF_STATE], args, cg.std_string)
+    cg.add(var.set_state(template_))
+
+    template_ = await cg.templatable(config[CONF_PUBLISH_STATE], args, cg.bool_)
+    cg.add(var.set_publish_state(template_))
+
+    template_ = await cg.templatable(config[CONF_SEND_TO_NEXTION], args, cg.bool_)
+    cg.add(var.set_send_to_nextion(template_))
+
+    return var

--- a/esphome/components/nextion/text_sensor/__init__.py
+++ b/esphome/components/nextion/text_sensor/__init__.py
@@ -60,7 +60,7 @@ async def sensor_nextion_publish_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
     var = cg.new_Pvariable(action_id, template_arg, paren)
 
-    template_ = await cg.templatable(config[CONF_STATE], args, cg.std_string)
+    template_ = await cg.templatable(config[CONF_STATE], args, cg.const_char_ptr)
     cg.add(var.set_state(template_))
 
     template_ = await cg.templatable(config[CONF_PUBLISH_STATE], args, cg.bool_)

--- a/tests/components/nextion/common.yaml
+++ b/tests/components/nextion/common.yaml
@@ -1,0 +1,293 @@
+esphome:
+  on_boot:
+    # Binary sensor publish action tests
+    - binary_sensor.nextion.publish:
+        id: r0
+        state: True
+
+    - binary_sensor.nextion.publish:
+        id: r0
+        state: True
+        publish_state: True
+        send_to_nextion: True
+
+    - binary_sensor.nextion.publish:
+        id: r0
+        state: True
+        publish_state: False
+        send_to_nextion: True
+
+    - binary_sensor.nextion.publish:
+        id: r0
+        state: True
+        publish_state: True
+        send_to_nextion: False
+
+    - binary_sensor.nextion.publish:
+        id: r0
+        state: True
+        publish_state: False
+        send_to_nextion: False
+
+    # Templated
+    - binary_sensor.nextion.publish:
+        id: r0
+        state: !lambda 'return true;'
+
+    - binary_sensor.nextion.publish:
+        id: r0
+        state: !lambda 'return true;'
+        publish_state: !lambda 'return true;'
+        send_to_nextion: !lambda 'return true;'
+
+    - binary_sensor.nextion.publish:
+        id: r0
+        state: !lambda 'return true;'
+        publish_state: !lambda 'return false;'
+        send_to_nextion: !lambda 'return true;'
+
+    - binary_sensor.nextion.publish:
+        id: r0
+        state: !lambda 'return true;'
+        publish_state: !lambda 'return true;'
+        send_to_nextion: !lambda 'return false;'
+
+    - binary_sensor.nextion.publish:
+        id: r0
+        state: !lambda 'return true;'
+        publish_state: !lambda 'return false;'
+        send_to_nextion: !lambda 'return false;'
+
+    # Sensor publish action tests
+    - sensor.nextion.publish:
+        id: testnumber
+        state: 42.0
+
+    - sensor.nextion.publish:
+        id: testnumber
+        state: 42.0
+        publish_state: True
+        send_to_nextion: True
+
+    - sensor.nextion.publish:
+        id: testnumber
+        state: 42.0
+        publish_state: False
+        send_to_nextion: True
+
+    - sensor.nextion.publish:
+        id: testnumber
+        state: 42.0
+        publish_state: True
+        send_to_nextion: False
+
+    - sensor.nextion.publish:
+        id: testnumber
+        state: 42.0
+        publish_state: False
+        send_to_nextion: False
+
+    # Templated
+    - sensor.nextion.publish:
+        id: testnumber
+        state: !lambda 'return 42.0;'
+
+    - sensor.nextion.publish:
+        id: testnumber
+        state: !lambda 'return 42.0;'
+        publish_state: !lambda 'return true;'
+        send_to_nextion: !lambda 'return true;'
+
+    - sensor.nextion.publish:
+        id: testnumber
+        state: !lambda 'return 42.0;'
+        publish_state: !lambda 'return false;'
+        send_to_nextion: !lambda 'return true;'
+
+    - sensor.nextion.publish:
+        id: testnumber
+        state: !lambda 'return 42.0;'
+        publish_state: !lambda 'return true;'
+        send_to_nextion: !lambda 'return false;'
+
+    - sensor.nextion.publish:
+        id: testnumber
+        state: !lambda 'return 42.0;'
+        publish_state: !lambda 'return false;'
+        send_to_nextion: !lambda 'return false;'
+
+    # Switch publish action tests
+    - switch.nextion.publish:
+        id: r0
+        state: True
+
+    - switch.nextion.publish:
+        id: r0
+        state: True
+        publish_state: true
+        send_to_nextion: true
+
+    - switch.nextion.publish:
+        id: r0
+        state: True
+        publish_state: false
+        send_to_nextion: true
+
+    - switch.nextion.publish:
+        id: r0
+        state: True
+        publish_state: true
+        send_to_nextion: false
+
+    - switch.nextion.publish:
+        id: r0
+        state: True
+        publish_state: false
+        send_to_nextion: false
+
+    # Templated
+    - switch.nextion.publish:
+        id: r0
+        state: !lambda 'return true;'
+
+    - switch.nextion.publish:
+        id: r0
+        state: !lambda 'return true;'
+        publish_state: !lambda 'return true;'
+        send_to_nextion: !lambda 'return true;'
+
+    - switch.nextion.publish:
+        id: r0
+        state: !lambda 'return true;'
+        publish_state: !lambda 'return false;'
+        send_to_nextion: !lambda 'return true;'
+
+    - switch.nextion.publish:
+        id: r0
+        state: !lambda 'return true;'
+        publish_state: !lambda 'return true;'
+        send_to_nextion: !lambda 'return false;'
+
+    - switch.nextion.publish:
+        id: r0
+        state: !lambda 'return true;'
+        publish_state: !lambda 'return false;'
+        send_to_nextion: !lambda 'return false;'
+
+    # Test sensor publish action tests
+    - text_sensor.nextion.publish:
+        id: text0
+        state: 'Test'
+        publish_state: true
+        send_to_nextion: true
+
+    - text_sensor.nextion.publish:
+        id: text0
+        state: 'Test'
+        publish_state: false
+        send_to_nextion: true
+
+    - text_sensor.nextion.publish:
+        id: text0
+        state: 'Test'
+        publish_state: true
+        send_to_nextion: false
+
+    - text_sensor.nextion.publish:
+        id: text0
+        state: 'Test'
+        publish_state: false
+        send_to_nextion: false
+
+    # Templated
+    - text_sensor.nextion.publish:
+        id: text0
+        state: !lambda 'return "Test";'
+
+    - text_sensor.nextion.publish:
+        id: text0
+        state: !lambda 'return "Test";'
+        publish_state: !lambda 'return true;'
+        send_to_nextion: !lambda 'return true;'
+
+    - text_sensor.nextion.publish:
+        id: text0
+        state: !lambda 'return "Test";'
+        publish_state: !lambda 'return false;'
+        send_to_nextion: !lambda 'return true;'
+
+    - text_sensor.nextion.publish:
+        id: text0
+        state: !lambda 'return "Test";'
+        publish_state: !lambda 'return true;'
+        send_to_nextion: !lambda 'return false;'
+
+    - text_sensor.nextion.publish:
+        id: text0
+        state: !lambda 'return "Test";'
+        publish_state: !lambda 'return false;'
+        send_to_nextion: !lambda 'return false;'
+
+wifi:
+  ssid: MySSID
+  password: password1
+
+uart:
+  - id: uart_nextion
+    tx_pin: ${tx_pin}
+    rx_pin: ${rx_pin}
+    baud_rate: 115200
+
+binary_sensor:
+  - platform: nextion
+    page_id: 0
+    component_id: 2
+    name: Nextion Touch Component
+  - platform: nextion
+    id: r0_sensor
+    name: R0 Sensor
+    component_name: page0.r0
+
+sensor:
+  - platform: nextion
+    id: testnumber
+    name: testnumber
+    variable_name: testnumber
+  - platform: nextion
+    id: testwave
+    name: testwave
+    component_id: 2
+    wave_channel_id: 1
+
+switch:
+  - platform: nextion
+    id: r0
+    name: R0 Switch
+    component_name: page0.r0
+
+text_sensor:
+  - platform: nextion
+    name: text0
+    id: text0
+    update_interval: 4s
+    component_name: text0
+
+display:
+  - platform: nextion
+    tft_url: http://esphome.io/default35.tft
+    update_interval: 5s
+    on_sleep:
+      then:
+        lambda: 'ESP_LOGD("display","Display went to sleep");'
+    on_wake:
+      then:
+        lambda: 'ESP_LOGD("display","Display woke up");'
+    on_setup:
+      then:
+        lambda: 'ESP_LOGD("display","Display setup completed");'
+    on_page:
+      then:
+        lambda: 'ESP_LOGD("display","Display shows new page %u", x);'
+    on_buffer_overflow:
+      then:
+        logger.log: "Nextion reported a buffer overflow!"

--- a/tests/components/nextion/common.yaml
+++ b/tests/components/nextion/common.yaml
@@ -2,58 +2,58 @@ esphome:
   on_boot:
     # Binary sensor publish action tests
     - binary_sensor.nextion.publish:
-        id: r0
+        id: r0_sensor
         state: True
 
     - binary_sensor.nextion.publish:
-        id: r0
+        id: r0_sensor
         state: True
         publish_state: True
         send_to_nextion: True
 
     - binary_sensor.nextion.publish:
-        id: r0
+        id: r0_sensor
         state: True
         publish_state: False
         send_to_nextion: True
 
     - binary_sensor.nextion.publish:
-        id: r0
+        id: r0_sensor
         state: True
         publish_state: True
         send_to_nextion: False
 
     - binary_sensor.nextion.publish:
-        id: r0
+        id: r0_sensor
         state: True
         publish_state: False
         send_to_nextion: False
 
     # Templated
     - binary_sensor.nextion.publish:
-        id: r0
+        id: r0_sensor
         state: !lambda 'return true;'
 
     - binary_sensor.nextion.publish:
-        id: r0
+        id: r0_sensor
         state: !lambda 'return true;'
         publish_state: !lambda 'return true;'
         send_to_nextion: !lambda 'return true;'
 
     - binary_sensor.nextion.publish:
-        id: r0
+        id: r0_sensor
         state: !lambda 'return true;'
         publish_state: !lambda 'return false;'
         send_to_nextion: !lambda 'return true;'
 
     - binary_sensor.nextion.publish:
-        id: r0
+        id: r0_sensor
         state: !lambda 'return true;'
         publish_state: !lambda 'return true;'
         send_to_nextion: !lambda 'return false;'
 
     - binary_sensor.nextion.publish:
-        id: r0
+        id: r0_sensor
         state: !lambda 'return true;'
         publish_state: !lambda 'return false;'
         send_to_nextion: !lambda 'return false;'

--- a/tests/components/nextion/common.yaml
+++ b/tests/components/nextion/common.yaml
@@ -274,7 +274,7 @@ text_sensor:
 
 display:
   - platform: nextion
-    tft_url: http://esphome.io/default35.tft
+    id: main_lcd
     update_interval: 5s
     on_sleep:
       then:

--- a/tests/components/nextion/test.esp32-ard.yaml
+++ b/tests/components/nextion/test.esp32-ard.yaml
@@ -1,6 +1,6 @@
 substitutions:
-  tx_pin: 17
-  rx_pin: 16
+  tx_pin: GPIO17
+  rx_pin: GPIO16
 
 packages:
   base: !include common.yaml

--- a/tests/components/nextion/test.esp32-ard.yaml
+++ b/tests/components/nextion/test.esp32-ard.yaml
@@ -1,63 +1,6 @@
-wifi:
-  ssid: MySSID
-  password: password1
+substitutions:
+  tx_pin: 17
+  rx_pin: 16
 
-uart:
-  - id: uart_nextion
-    tx_pin: 17
-    rx_pin: 16
-    baud_rate: 115200
-
-binary_sensor:
-  - platform: nextion
-    page_id: 0
-    component_id: 2
-    name: Nextion Touch Component
-  - platform: nextion
-    id: r0_sensor
-    name: R0 Sensor
-    component_name: page0.r0
-
-sensor:
-  - platform: nextion
-    id: testnumber
-    name: testnumber
-    variable_name: testnumber
-  - platform: nextion
-    id: testwave
-    name: testwave
-    component_id: 2
-    wave_channel_id: 1
-
-switch:
-  - platform: nextion
-    id: r0
-    name: R0 Switch
-    component_name: page0.r0
-
-text_sensor:
-  - platform: nextion
-    name: text0
-    id: text0
-    update_interval: 4s
-    component_name: text0
-
-display:
-  - platform: nextion
-    tft_url: http://esphome.io/default35.tft
-    update_interval: 5s
-    on_sleep:
-      then:
-        lambda: 'ESP_LOGD("display","Display went to sleep");'
-    on_wake:
-      then:
-        lambda: 'ESP_LOGD("display","Display woke up");'
-    on_setup:
-      then:
-        lambda: 'ESP_LOGD("display","Display setup completed");'
-    on_page:
-      then:
-        lambda: 'ESP_LOGD("display","Display shows new page %u", x);'
-    on_buffer_overflow:
-      then:
-        logger.log: "Nextion reported a buffer overflow!"
+packages:
+  base: !include common.yaml

--- a/tests/components/nextion/test.esp32-ard.yaml
+++ b/tests/components/nextion/test.esp32-ard.yaml
@@ -4,3 +4,7 @@ substitutions:
 
 packages:
   base: !include common.yaml
+
+display:
+  - id: !extend main_lcd
+    tft_url: http://esphome.io/default35.tft

--- a/tests/components/nextion/test.esp32-c3-ard.yaml
+++ b/tests/components/nextion/test.esp32-c3-ard.yaml
@@ -1,6 +1,6 @@
 substitutions:
-  tx_pin: 4
-  rx_pin: 5
+  tx_pin: GPIO4
+  rx_pin: GPIO5
 
 packages:
   base: !include common.yaml

--- a/tests/components/nextion/test.esp32-c3-ard.yaml
+++ b/tests/components/nextion/test.esp32-c3-ard.yaml
@@ -1,63 +1,6 @@
-wifi:
-  ssid: MySSID
-  password: password1
+substitutions:
+  tx_pin: 4
+  rx_pin: 5
 
-uart:
-  - id: uart_nextion
-    tx_pin: 4
-    rx_pin: 5
-    baud_rate: 115200
-
-binary_sensor:
-  - platform: nextion
-    page_id: 0
-    component_id: 2
-    name: Nextion Touch Component
-  - platform: nextion
-    id: r0_sensor
-    name: R0 Sensor
-    component_name: page0.r0
-
-sensor:
-  - platform: nextion
-    id: testnumber
-    name: testnumber
-    variable_name: testnumber
-  - platform: nextion
-    id: testwave
-    name: testwave
-    component_id: 2
-    wave_channel_id: 1
-
-switch:
-  - platform: nextion
-    id: r0
-    name: R0 Switch
-    component_name: page0.r0
-
-text_sensor:
-  - platform: nextion
-    name: text0
-    id: text0
-    update_interval: 4s
-    component_name: text0
-
-display:
-  - platform: nextion
-    tft_url: http://esphome.io/default35.tft
-    update_interval: 5s
-    on_sleep:
-      then:
-        lambda: 'ESP_LOGD("display","Display went to sleep");'
-    on_wake:
-      then:
-        lambda: 'ESP_LOGD("display","Display woke up");'
-    on_setup:
-      then:
-        lambda: 'ESP_LOGD("display","Display setup completed");'
-    on_page:
-      then:
-        lambda: 'ESP_LOGD("display","Display shows new page %u", x);'
-    on_buffer_overflow:
-      then:
-        logger.log: "Nextion reported a buffer overflow!"
+packages:
+  base: !include common.yaml

--- a/tests/components/nextion/test.esp32-c3-ard.yaml
+++ b/tests/components/nextion/test.esp32-c3-ard.yaml
@@ -4,3 +4,7 @@ substitutions:
 
 packages:
   base: !include common.yaml
+
+display:
+  - id: !extend main_lcd
+    tft_url: http://esphome.io/default35.tft

--- a/tests/components/nextion/test.esp32-c3-idf.yaml
+++ b/tests/components/nextion/test.esp32-c3-idf.yaml
@@ -1,6 +1,6 @@
 substitutions:
-  tx_pin: 4
-  rx_pin: 5
+  tx_pin: GPIO4
+  rx_pin: GPIO5
 
 packages:
   base: !include common.yaml

--- a/tests/components/nextion/test.esp32-c3-idf.yaml
+++ b/tests/components/nextion/test.esp32-c3-idf.yaml
@@ -1,63 +1,6 @@
-wifi:
-  ssid: MySSID
-  password: password1
+substitutions:
+  tx_pin: 4
+  rx_pin: 5
 
-uart:
-  - id: uart_nextion
-    tx_pin: 4
-    rx_pin: 5
-    baud_rate: 115200
-
-binary_sensor:
-  - platform: nextion
-    page_id: 0
-    component_id: 2
-    name: Nextion Touch Component
-  - platform: nextion
-    id: r0_sensor
-    name: R0 Sensor
-    component_name: page0.r0
-
-sensor:
-  - platform: nextion
-    id: testnumber
-    name: testnumber
-    variable_name: testnumber
-  - platform: nextion
-    id: testwave
-    name: testwave
-    component_id: 2
-    wave_channel_id: 1
-
-switch:
-  - platform: nextion
-    id: r0
-    name: R0 Switch
-    component_name: page0.r0
-
-text_sensor:
-  - platform: nextion
-    name: text0
-    id: text0
-    update_interval: 4s
-    component_name: text0
-
-display:
-  - platform: nextion
-    tft_url: http://esphome.io/default35.tft
-    update_interval: 5s
-    on_sleep:
-      then:
-        lambda: 'ESP_LOGD("display","Display went to sleep");'
-    on_wake:
-      then:
-        lambda: 'ESP_LOGD("display","Display woke up");'
-    on_setup:
-      then:
-        lambda: 'ESP_LOGD("display","Display setup completed");'
-    on_page:
-      then:
-        lambda: 'ESP_LOGD("display","Display shows new page %u", x);'
-    on_buffer_overflow:
-      then:
-        logger.log: "Nextion reported a buffer overflow!"
+packages:
+  base: !include common.yaml

--- a/tests/components/nextion/test.esp32-c3-idf.yaml
+++ b/tests/components/nextion/test.esp32-c3-idf.yaml
@@ -4,3 +4,7 @@ substitutions:
 
 packages:
   base: !include common.yaml
+
+display:
+  - id: !extend main_lcd
+    tft_url: http://esphome.io/default35.tft

--- a/tests/components/nextion/test.esp32-idf.yaml
+++ b/tests/components/nextion/test.esp32-idf.yaml
@@ -1,6 +1,6 @@
 substitutions:
-  tx_pin: 17
-  rx_pin: 16
+  tx_pin: GPIO17
+  rx_pin: GPIO16
 
 packages:
   base: !include common.yaml

--- a/tests/components/nextion/test.esp32-idf.yaml
+++ b/tests/components/nextion/test.esp32-idf.yaml
@@ -1,63 +1,6 @@
-wifi:
-  ssid: MySSID
-  password: password1
+substitutions:
+  tx_pin: 17
+  rx_pin: 16
 
-uart:
-  - id: uart_nextion
-    tx_pin: 17
-    rx_pin: 16
-    baud_rate: 115200
-
-binary_sensor:
-  - platform: nextion
-    page_id: 0
-    component_id: 2
-    name: Nextion Touch Component
-  - platform: nextion
-    id: r0_sensor
-    name: R0 Sensor
-    component_name: page0.r0
-
-sensor:
-  - platform: nextion
-    id: testnumber
-    name: testnumber
-    variable_name: testnumber
-  - platform: nextion
-    id: testwave
-    name: testwave
-    component_id: 2
-    wave_channel_id: 1
-
-switch:
-  - platform: nextion
-    id: r0
-    name: R0 Switch
-    component_name: page0.r0
-
-text_sensor:
-  - platform: nextion
-    name: text0
-    id: text0
-    update_interval: 4s
-    component_name: text0
-
-display:
-  - platform: nextion
-    tft_url: http://esphome.io/default35.tft
-    update_interval: 5s
-    on_sleep:
-      then:
-        lambda: 'ESP_LOGD("display","Display went to sleep");'
-    on_wake:
-      then:
-        lambda: 'ESP_LOGD("display","Display woke up");'
-    on_setup:
-      then:
-        lambda: 'ESP_LOGD("display","Display setup completed");'
-    on_page:
-      then:
-        lambda: 'ESP_LOGD("display","Display shows new page %u", x);'
-    on_buffer_overflow:
-      then:
-        logger.log: "Nextion reported a buffer overflow!"
+packages:
+  base: !include common.yaml

--- a/tests/components/nextion/test.esp32-idf.yaml
+++ b/tests/components/nextion/test.esp32-idf.yaml
@@ -4,3 +4,7 @@ substitutions:
 
 packages:
   base: !include common.yaml
+
+display:
+  - id: !extend main_lcd
+    tft_url: http://esphome.io/default35.tft

--- a/tests/components/nextion/test.esp8266-ard.yaml
+++ b/tests/components/nextion/test.esp8266-ard.yaml
@@ -1,6 +1,6 @@
 substitutions:
-  tx_pin: 4
-  rx_pin: 5
+  tx_pin: GPIO4
+  rx_pin: GPIO5
 
 packages:
   base: !include common.yaml

--- a/tests/components/nextion/test.esp8266-ard.yaml
+++ b/tests/components/nextion/test.esp8266-ard.yaml
@@ -1,63 +1,6 @@
-wifi:
-  ssid: MySSID
-  password: password1
+substitutions:
+  tx_pin: 4
+  rx_pin: 5
 
-uart:
-  - id: uart_nextion
-    tx_pin: 4
-    rx_pin: 5
-    baud_rate: 115200
-
-binary_sensor:
-  - platform: nextion
-    page_id: 0
-    component_id: 2
-    name: Nextion Touch Component
-  - platform: nextion
-    id: r0_sensor
-    name: R0 Sensor
-    component_name: page0.r0
-
-sensor:
-  - platform: nextion
-    id: testnumber
-    name: testnumber
-    variable_name: testnumber
-  - platform: nextion
-    id: testwave
-    name: testwave
-    component_id: 2
-    wave_channel_id: 1
-
-switch:
-  - platform: nextion
-    id: r0
-    name: R0 Switch
-    component_name: page0.r0
-
-text_sensor:
-  - platform: nextion
-    name: text0
-    id: text0
-    update_interval: 4s
-    component_name: text0
-
-display:
-  - platform: nextion
-    tft_url: http://esphome.io/default35.tft
-    update_interval: 5s
-    on_sleep:
-      then:
-        lambda: 'ESP_LOGD("display","Display went to sleep");'
-    on_wake:
-      then:
-        lambda: 'ESP_LOGD("display","Display woke up");'
-    on_setup:
-      then:
-        lambda: 'ESP_LOGD("display","Display setup completed");'
-    on_page:
-      then:
-        lambda: 'ESP_LOGD("display","Display shows new page %u", x);'
-    on_buffer_overflow:
-      then:
-        logger.log: "Nextion reported a buffer overflow!"
+packages:
+  base: !include common.yaml

--- a/tests/components/nextion/test.esp8266-ard.yaml
+++ b/tests/components/nextion/test.esp8266-ard.yaml
@@ -4,3 +4,7 @@ substitutions:
 
 packages:
   base: !include common.yaml
+
+display:
+  - id: !extend main_lcd
+    tft_url: http://esphome.io/default35.tft

--- a/tests/components/nextion/test.rp2040-ard.yaml
+++ b/tests/components/nextion/test.rp2040-ard.yaml
@@ -5,4 +5,3 @@ substitutions:
 packages:
   base: !include common.yaml
 
-wifi: !remove

--- a/tests/components/nextion/test.rp2040-ard.yaml
+++ b/tests/components/nextion/test.rp2040-ard.yaml
@@ -1,6 +1,6 @@
 substitutions:
-  tx_pin: 4
-  rx_pin: 5
+  tx_pin: GPIO4
+  rx_pin: GPIO5
 
 packages:
   base: !include common.yaml

--- a/tests/components/nextion/test.rp2040-ard.yaml
+++ b/tests/components/nextion/test.rp2040-ard.yaml
@@ -1,58 +1,8 @@
-uart:
-  - id: uart_nextion
-    tx_pin: 4
-    rx_pin: 5
-    baud_rate: 115200
+substitutions:
+  tx_pin: 4
+  rx_pin: 5
 
-binary_sensor:
-  - platform: nextion
-    page_id: 0
-    component_id: 2
-    name: Nextion Touch Component
-  - platform: nextion
-    id: r0_sensor
-    name: R0 Sensor
-    component_name: page0.r0
+packages:
+  base: !include common.yaml
 
-sensor:
-  - platform: nextion
-    id: testnumber
-    name: testnumber
-    variable_name: testnumber
-  - platform: nextion
-    id: testwave
-    name: testwave
-    component_id: 2
-    wave_channel_id: 1
-
-switch:
-  - platform: nextion
-    id: r0
-    name: R0 Switch
-    component_name: page0.r0
-
-text_sensor:
-  - platform: nextion
-    name: text0
-    id: text0
-    update_interval: 4s
-    component_name: text0
-
-display:
-  - platform: nextion
-    update_interval: 5s
-    on_sleep:
-      then:
-        lambda: 'ESP_LOGD("display","Display went to sleep");'
-    on_wake:
-      then:
-        lambda: 'ESP_LOGD("display","Display woke up");'
-    on_setup:
-      then:
-        lambda: 'ESP_LOGD("display","Display setup completed");'
-    on_page:
-      then:
-        lambda: 'ESP_LOGD("display","Display shows new page %u", x);'
-    on_buffer_overflow:
-      then:
-        logger.log: "Nextion reported a buffer overflow!"
+wifi: !remove


### PR DESCRIPTION
# What does this implement/fix?

Adds YAML actions for publishing states of various Nextion sensors. This functionality was available only in lambdas.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

none

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#4368

## Test Environment

- [X] ESP32
- [X] ESP32 IDF
- [X] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
esphome:
  name: test2
  on_boot: 
    then:
      - sensor.nextion.publish:
          id: nex_float
          state: 1
          publish_state: false
          send_to_nextion: true

      - binary_sensor.nextion.publish:
          id: nex_binary
          state: True

      - text_sensor.nextion.publish:
          id: nex_text
          state: "TEST"

      - switch.nextion.publish:
          id: nex_switch
          state: True

esp32:
  board: wemos_d1_mini32
  framework:
    type: esp-idf

logger:
api:
ota:
  platform: esphome

wifi:
  ssid: !secret wifi
  password: !secret wifi_pass
  reboot_timeout: 0s

external_components:
  - source: github://pr#7646
    components: [ nextion ]

sensor:
  - platform: nextion
    id: nex_float
    nextion_id: nex
    component_name: test.float
    precision: 0

binary_sensor:
  - platform: nextion
    id: nex_binary
    component_name: test.binary

text_sensor:
  - platform: nextion
    id: nex_text
    component_name: test.text

switch:
  - platform: nextion
    id: nex_switch
    component_name: test.switch

uart:
  - id: ser
    rx_pin: GPIO16
    tx_pin: GPIO17
    baud_rate: 115200

display:
  - platform: nextion
    id: nex
    uart_id: ser
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
