### PR TITLE
[rtttl] Add ``get_gain()``

### DIFF
--- a/esphome/components/rtttl/rtttl.cpp
+++ b/esphome/components/rtttl/rtttl.cpp
@@ -26,7 +26,10 @@ inline double deg2rad(double degrees) {
   return degrees * PI_ON_180;
 }
 
-void Rtttl::dump_config() { ESP_LOGCONFIG(TAG, "Rtttl"); }
+void Rtttl::dump_config() {
+  ESP_LOGCONFIG(TAG, "Rtttl:");
+  ESP_LOGCONFIG(TAG, "  Gain: %f", gain_);
+}
 
 void Rtttl::play(std::string rtttl) {
   if (this->state_ != State::STATE_STOPPED && this->state_ != State::STATE_STOPPING) {

--- a/esphome/components/rtttl/rtttl.h
+++ b/esphome/components/rtttl/rtttl.h
@@ -39,6 +39,9 @@ class Rtttl : public Component {
 #ifdef USE_SPEAKER
   void set_speaker(speaker::Speaker *speaker) { this->speaker_ = speaker; }
 #endif
+  float get_gain() {
+    return gain_;
+  }
   void set_gain(float gain) {
     if (gain < 0.1f)
       gain = 0.1f;

--- a/esphome/components/rtttl/rtttl.h
+++ b/esphome/components/rtttl/rtttl.h
@@ -39,9 +39,7 @@ class Rtttl : public Component {
 #ifdef USE_SPEAKER
   void set_speaker(speaker::Speaker *speaker) { this->speaker_ = speaker; }
 #endif
-  float get_gain() {
-    return gain_;
-  }
+  float get_gain() { return gain_; }
   void set_gain(float gain) {
     if (gain < 0.1f)
       gain = 0.1f;


### PR DESCRIPTION
# What does this implement/fix?

This adds the capability to get the selected gain value for the RTTTL component.
This is useful when creating a gain control in the UI, so one can show the current gain in a slider and allow users to adjust it.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment
- [X] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
output:
  # Buzzer output
  - id: buzzer_out
    platform: ledc
    pin:
      number: 21

rtttl:
  id: buzzer
  output: buzzer_out

esphome:
  on_boot:
    - priority: -100.44
      then:
        - lambda: |-
            id(buzzer).set_gain(id(buzzer_gain).state/100.0f);

number:
  - id: buzzer_gain
    name: Buzzer gain
    platform: template
    max_value: 100
    min_value: 0
    step: 1
    unit_of_measurement: "%"
    entity_category: config
    device_class: sound_pressure
    restore_value: true
    initial_value: 60
    optimistic: true
    set_action: 
      then:
        - lambda: |-
            id(buzzer).set_gain(x/100.0f);
            if (x > 0)
              id(buzzer).play("scale_up:d=32,o=5,b=100:c,c#,d#,e,f#,g#,a#,b");
            id(buzzer).dump_config();

sensor:
  - id: rtttl_gain
    name: Buzzer gain
    platform: template
    lambda: return id(buzzer).get_gain()*100;
    unit_of_measurement: "%"
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
