### PR TITLE
[lvgl] light schema should require `widget:` not `led:` (Bugfix)

### DIFF
--- a/esphome/components/lvgl/light/__init__.py
+++ b/esphome/components/lvgl/light/__init__.py
@@ -2,9 +2,9 @@ import esphome.codegen as cg
 from esphome.components import light
 from esphome.components.light import LightOutput
 import esphome.config_validation as cv
-from esphome.const import CONF_GAMMA_CORRECT, CONF_LED, CONF_OUTPUT_ID
+from esphome.const import CONF_GAMMA_CORRECT, CONF_OUTPUT_ID
 
-from ..defines import CONF_LVGL_ID
+from ..defines import CONF_LVGL_ID, CONF_WIDGET
 from ..lvcode import LvContext
 from ..schemas import LVGL_SCHEMA
 from ..types import LvType, lvgl_ns
@@ -15,7 +15,7 @@ LVLight = lvgl_ns.class_("LVLight", LightOutput)
 CONFIG_SCHEMA = light.RGB_LIGHT_SCHEMA.extend(
     {
         cv.Optional(CONF_GAMMA_CORRECT, default=0.0): cv.positive_float,
-        cv.Required(CONF_LED): cv.use_id(lv_led_t),
+        cv.Required(CONF_WIDGET): cv.use_id(lv_led_t),
         cv.GenerateID(CONF_OUTPUT_ID): cv.declare_id(LVLight),
     }
 ).extend(LVGL_SCHEMA)
@@ -26,7 +26,7 @@ async def to_code(config):
     await light.register_light(var, config)
 
     paren = await cg.get_variable(config[CONF_LVGL_ID])
-    widget = await get_widgets(config, CONF_LED)
+    widget = await get_widgets(config, CONF_WIDGET)
     widget = widget[0]
     await wait_for_widgets()
     async with LvContext(paren) as ctx:

--- a/tests/components/lvgl/common.yaml
+++ b/tests/components/lvgl/common.yaml
@@ -93,7 +93,7 @@ light:
   - platform: lvgl
     name: LVGL LED
     id: lv_light
-    led: lv_led
+    widget: lv_led
 
 binary_sensor:
   - platform: lvgl


### PR DESCRIPTION
# What does this implement/fix?

To match documentation, and for consistency with other usage.

<!-- Quick description and explanation of changes -->

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- closes esphome/esphome-docs#4362

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- 

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
