### PR TITLE
[lvgl] Allow strings to be interpreted as integers (Bugfix)

### DIFF
--- a/esphome/components/lvgl/lv_validation.py
+++ b/esphome/components/lvgl/lv_validation.py
@@ -274,10 +274,8 @@ def size_validator(value):
         return ["SIZE_CONTENT", "number of pixels", "percentage"]
     if isinstance(value, str) and value.lower().endswith("px"):
         value = cv.int_(value[:-2])
-    if isinstance(value, str) and not value.endswith("%"):
-        if value.upper() == "SIZE_CONTENT":
-            return "LV_SIZE_CONTENT"
-        raise cv.Invalid("must be 'size_content', a percentage or an integer (pixels)")
+    if isinstance(value, str) and value.upper() == "SIZE_CONTENT":
+        return "LV_SIZE_CONTENT"
     return pixels_or_percent_validator(value)
 
 

--- a/tests/components/lvgl/lvgl-package.yaml
+++ b/tests/components/lvgl/lvgl-package.yaml
@@ -422,7 +422,7 @@ lvgl:
             id: lv_image
             src: cat_image
             align: top_left
-            y: 50
+            y: "50" # Testing use of string that looks like an integer
         - tileview:
             id: tileview_id
             scrollbar_mode: active
@@ -461,7 +461,7 @@ lvgl:
               bg_opa: transp
             knob:
               radius: 1
-              width: 4
+              width: "4" # Testing use of string that looks like an integer
               height: 10%
               bg_color: 0x000000
             width: 100%

--- a/tests/components/lvgl/lvgl-package.yaml
+++ b/tests/components/lvgl/lvgl-package.yaml
@@ -422,7 +422,7 @@ lvgl:
             id: lv_image
             src: cat_image
             align: top_left
-            y: "50" # Testing use of string that looks like an integer
+            y: "50"
         - tileview:
             id: tileview_id
             scrollbar_mode: active
@@ -461,7 +461,7 @@ lvgl:
               bg_opa: transp
             knob:
               radius: 1
-              width: "4" # Testing use of string that looks like an integer
+              width: "4"
               height: 10%
               bg_color: 0x000000
             width: 100%


### PR DESCRIPTION
one.

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

When using substitutions, all replacement values are strings. This caused problems when using substitutions for numeric values, but the validators in `config_validation.py` already accommodate this by converting strings that look like integers to actual integers. This PR removes an earlier check that blocked this behaviour.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [x] host

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
lvgl:
  bg_color: 0xc0c0c0
  style_definitions:
    - id: btn_style
      width: "170"

  layout: # enable the GRID layout for the children widgets
    type: GRID # split the rows and the columns proportionally
    grid_columns:
      - ${clock_width}
      - 200
    grid_rows:
      - ${clock_height}
      - 50
      - 70
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
