### PR TITLE
[image] Fix compile time problem with host image not using lvgl

### DIFF
--- a/esphome/components/image/image.h
+++ b/esphome/components/image/image.h
@@ -3,12 +3,7 @@
 #include "esphome/components/display/display.h"
 
 #ifdef USE_LVGL
-// required for clang-tidy
-#ifndef LV_CONF_H
-#define LV_CONF_SKIP 1  // NOLINT
-#endif                  // LV_CONF_H
-
-#include <lvgl.h>
+#include "esphome/components/lvgl/lvgl_proxy.h"
 #endif  // USE_LVGL
 
 namespace esphome {

--- a/esphome/components/lvgl/lvgl_proxy.h
+++ b/esphome/components/lvgl/lvgl_proxy.h
@@ -1,0 +1,17 @@
+#pragma once
+/**
+* This header is for use in components that might or might not use LVGL. There is a platformio bug where
+the mere mention of a header file, even if ifdefed, causes the build to fail. This is a workaround, since if this
+file is included in the build, LVGL is always included.
+*/
+#ifdef USE_LVGL
+// required for clang-tidy
+#ifndef LV_CONF_H
+#define LV_CONF_SKIP 1  // NOLINT
+#endif                  // LV_CONF_H
+
+#include <lvgl.h>
+namespace esphome {
+namespace lvgl {}  // namespace lvgl
+}  // namespace esphome
+#endif  // USE_LVGL


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Split from #7631 
## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [x] host

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
