### PR TITLE
[speaker, i2s_audio] Support audio_dac component, mute actions, and improved logging

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -202,7 +202,7 @@ esphome/components/i2c_device/* @gabest11
 esphome/components/i2s_audio/* @jesserockz
 esphome/components/i2s_audio/media_player/* @jesserockz
 esphome/components/i2s_audio/microphone/* @jesserockz
-esphome/components/i2s_audio/speaker/* @jesserockz
+esphome/components/i2s_audio/speaker/* @jesserockz @kahrendt
 esphome/components/iaqcore/* @yozik04
 esphome/components/ili9xxx/* @clydebarrow @nielsnl68
 esphome/components/improv_base/* @esphome/core
@@ -377,7 +377,7 @@ esphome/components/smt100/* @piechade
 esphome/components/sn74hc165/* @jesserockz
 esphome/components/socket/* @esphome/core
 esphome/components/sonoff_d1/* @anatoly-savchenkov
-esphome/components/speaker/* @jesserockz
+esphome/components/speaker/* @jesserockz @kahrendt
 esphome/components/spi/* @clydebarrow @esphome/core
 esphome/components/spi_device/* @clydebarrow
 esphome/components/spi_led_strip/* @clydebarrow

--- a/esphome/components/i2s_audio/speaker/__init__.py
+++ b/esphome/components/i2s_audio/speaker/__init__.py
@@ -17,7 +17,7 @@ from .. import (
 )
 
 AUTO_LOAD = ["audio"]
-CODEOWNERS = ["@jesserockz"]
+CODEOWNERS = ["@jesserockz", "@kahrendt"]
 DEPENDENCIES = ["i2s_audio"]
 
 I2SAudioSpeaker = i2s_audio_ns.class_(

--- a/esphome/components/i2s_audio/speaker/i2s_audio_speaker.cpp
+++ b/esphome/components/i2s_audio/speaker/i2s_audio_speaker.cpp
@@ -143,8 +143,16 @@ void I2SAudioSpeaker::loop() {
 
 void I2SAudioSpeaker::set_volume(float volume) {
   this->volume_ = volume;
-  ssize_t decibel_index = remap<ssize_t, float>(volume, 0.0f, 1.0f, 0, Q15_VOLUME_SCALING_FACTORS.size() - 1);
-  this->q15_volume_factor_ = Q15_VOLUME_SCALING_FACTORS[decibel_index];
+#ifdef USE_AUDIO_DAC
+  if (this->audio_dac_ != nullptr) {
+    this->audio_dac_->set_volume(volume);
+  } else
+#endif
+  {
+    // Fallback to software volume control by using a Q15 fixed point scaling factor
+    ssize_t decibel_index = remap<ssize_t, float>(volume, 0.0f, 1.0f, 0, Q15_VOLUME_SCALING_FACTORS.size() - 1);
+    this->q15_volume_factor_ = Q15_VOLUME_SCALING_FACTORS[decibel_index];
+  }
 }
 
 size_t I2SAudioSpeaker::play(const uint8_t *data, size_t length, TickType_t ticks_to_wait) {

--- a/esphome/components/i2s_audio/speaker/i2s_audio_speaker.h
+++ b/esphome/components/i2s_audio/speaker/i2s_audio_speaker.h
@@ -49,8 +49,9 @@ class I2SAudioSpeaker : public I2SAudioOut, public speaker::Speaker, public Comp
 
   bool has_buffered_data() const override;
 
-  /// @brief Sets the volume of the speaker. It is implemented as a software volume control.
-  /// Overrides the default setter to convert the floating point volume to a Q15 fixed-point factor.
+  /// @brief Sets the volume of the speaker. Uses the speaker's configured audio dac component. If unavailble, it is
+  /// implemented as a software volume control. Overrides the default setter to convert the floating point volume to a
+  /// Q15 fixed-point factor.
   /// @param volume
   void set_volume(float volume) override;
   float get_volume() override { return this->volume_; }

--- a/esphome/components/i2s_audio/speaker/i2s_audio_speaker.h
+++ b/esphome/components/i2s_audio/speaker/i2s_audio_speaker.h
@@ -52,9 +52,14 @@ class I2SAudioSpeaker : public I2SAudioOut, public speaker::Speaker, public Comp
   /// @brief Sets the volume of the speaker. Uses the speaker's configured audio dac component. If unavailble, it is
   /// implemented as a software volume control. Overrides the default setter to convert the floating point volume to a
   /// Q15 fixed-point factor.
-  /// @param volume
+  /// @param volume between 0.0 and 1.0
   void set_volume(float volume) override;
-  float get_volume() override { return this->volume_; }
+
+  /// @brief Mutes or unmute the speaker. Uses the speaker's configured audio dac component. If unavailble, it is
+  /// implemented as a software volume control. Overrides the default setter to convert the floating point volume to a
+  /// Q15 fixed-point factor.
+  /// @param mute_state true for muting, false for unmuting
+  void set_mute_state(bool mute_state) override;
 
  protected:
   /// @brief Function for the FreeRTOS task handling audio output.

--- a/esphome/components/speaker/__init__.py
+++ b/esphome/components/speaker/__init__.py
@@ -7,7 +7,7 @@ from esphome.const import CONF_DATA, CONF_ID, CONF_VOLUME
 from esphome.core import CORE
 from esphome.coroutine import coroutine_with_priority
 
-CODEOWNERS = ["@jesserockz"]
+CODEOWNERS = ["@jesserockz", "@kahrendt"]
 
 IS_PLATFORM_COMPONENT = True
 

--- a/esphome/components/speaker/__init__.py
+++ b/esphome/components/speaker/__init__.py
@@ -127,7 +127,9 @@ async def speaker_volume_set_action(config, action_id, template_arg, args):
     return var
 
 
-@automation.register_action("speaker.mute_off", MuteOffAction, SPEAKER_AUTOMATION_SCHEMA)
+@automation.register_action(
+    "speaker.mute_off", MuteOffAction, SPEAKER_AUTOMATION_SCHEMA
+)
 @automation.register_action("speaker.mute_on", MuteOnAction, SPEAKER_AUTOMATION_SCHEMA)
 async def speaker_mute_action_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])

--- a/esphome/components/speaker/__init__.py
+++ b/esphome/components/speaker/__init__.py
@@ -61,12 +61,6 @@ SPEAKER_SCHEMA = cv.Schema(
 
 SPEAKER_AUTOMATION_SCHEMA = maybe_simple_id({cv.GenerateID(): cv.use_id(Speaker)})
 
-MUTE_ACTION_SCHEMA = maybe_simple_id(
-    {
-        cv.GenerateID(): cv.use_id(Speaker),
-    }
-)
-
 
 async def speaker_action(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)

--- a/esphome/components/speaker/__init__.py
+++ b/esphome/components/speaker/__init__.py
@@ -127,8 +127,8 @@ async def speaker_volume_set_action(config, action_id, template_arg, args):
     return var
 
 
-@automation.register_action("speaker.mute_off", MuteOffAction, MUTE_ACTION_SCHEMA)
-@automation.register_action("speaker.mute_on", MuteOnAction, MUTE_ACTION_SCHEMA)
+@automation.register_action("speaker.mute_off", MuteOffAction, SPEAKER_AUTOMATION_SCHEMA)
+@automation.register_action("speaker.mute_on", MuteOnAction, SPEAKER_AUTOMATION_SCHEMA)
 async def speaker_mute_action_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
     return cg.new_Pvariable(action_id, template_arg, paren)

--- a/esphome/components/speaker/__init__.py
+++ b/esphome/components/speaker/__init__.py
@@ -1,6 +1,7 @@
 from esphome import automation
 from esphome.automation import maybe_simple_id
 import esphome.codegen as cg
+from esphome.components import audio_dac
 import esphome.config_validation as cv
 from esphome.const import CONF_DATA, CONF_ID, CONF_VOLUME
 from esphome.core import CORE
@@ -9,6 +10,8 @@ from esphome.coroutine import coroutine_with_priority
 CODEOWNERS = ["@jesserockz"]
 
 IS_PLATFORM_COMPONENT = True
+
+CONF_AUDIO_DAC = "audio_dac"
 
 speaker_ns = cg.esphome_ns.namespace("speaker")
 
@@ -33,7 +36,9 @@ IsStoppedCondition = speaker_ns.class_("IsStoppedCondition", automation.Conditio
 
 
 async def setup_speaker_core_(var, config):
-    pass
+    if audio_dac_config := config.get(CONF_AUDIO_DAC):
+        aud_dac = await cg.get_variable(audio_dac_config)
+        cg.add(var.set_audio_dac(aud_dac))
 
 
 async def register_speaker(var, config):
@@ -42,8 +47,11 @@ async def register_speaker(var, config):
     await setup_speaker_core_(var, config)
 
 
-SPEAKER_SCHEMA = cv.Schema({})
-
+SPEAKER_SCHEMA = cv.Schema(
+    {
+        cv.Optional(CONF_AUDIO_DAC): cv.use_id(audio_dac.AudioDac),
+    }
+)
 
 SPEAKER_AUTOMATION_SCHEMA = maybe_simple_id({cv.GenerateID(): cv.use_id(Speaker)})
 

--- a/esphome/components/speaker/__init__.py
+++ b/esphome/components/speaker/__init__.py
@@ -29,6 +29,12 @@ FinishAction = speaker_ns.class_(
 VolumeSetAction = speaker_ns.class_(
     "VolumeSetAction", automation.Action, cg.Parented.template(Speaker)
 )
+MuteOnAction = speaker_ns.class_(
+    "MuteOnAction", automation.Action, cg.Parented.template(Speaker)
+)
+MuteOffAction = speaker_ns.class_(
+    "MuteOffAction", automation.Action, cg.Parented.template(Speaker)
+)
 
 
 IsPlayingCondition = speaker_ns.class_("IsPlayingCondition", automation.Condition)
@@ -54,6 +60,12 @@ SPEAKER_SCHEMA = cv.Schema(
 )
 
 SPEAKER_AUTOMATION_SCHEMA = maybe_simple_id({cv.GenerateID(): cv.use_id(Speaker)})
+
+MUTE_ACTION_SCHEMA = maybe_simple_id(
+    {
+        cv.GenerateID(): cv.use_id(Speaker),
+    }
+)
 
 
 async def speaker_action(config, action_id, template_arg, args):
@@ -119,6 +131,13 @@ async def speaker_volume_set_action(config, action_id, template_arg, args):
     volume = await cg.templatable(config[CONF_VOLUME], args, float)
     cg.add(var.set_volume(volume))
     return var
+
+
+@automation.register_action("speaker.mute_off", MuteOffAction, MUTE_ACTION_SCHEMA)
+@automation.register_action("speaker.mute_on", MuteOnAction, MUTE_ACTION_SCHEMA)
+async def speaker_mute_action_to_code(config, action_id, template_arg, args):
+    paren = await cg.get_variable(config[CONF_ID])
+    return cg.new_Pvariable(action_id, template_arg, paren)
 
 
 @coroutine_with_priority(100.0)

--- a/esphome/components/speaker/automation.h
+++ b/esphome/components/speaker/automation.h
@@ -39,6 +39,26 @@ template<typename... Ts> class VolumeSetAction : public Action<Ts...>, public Pa
   void play(Ts... x) override { this->parent_->set_volume(this->volume_.value(x...)); }
 };
 
+template<typename... Ts> class MuteOnAction : public Action<Ts...> {
+ public:
+  explicit MuteOnAction(Speaker *speaker) : speaker_(speaker) {}
+
+  void play(Ts... x) override { this->speaker_->set_mute_state(true); }
+
+ protected:
+  Speaker *speaker_;
+};
+
+template<typename... Ts> class MuteOffAction : public Action<Ts...> {
+ public:
+  explicit MuteOffAction(Speaker *speaker) : speaker_(speaker) {}
+
+  void play(Ts... x) override { this->speaker_->set_mute_state(false); }
+
+ protected:
+  Speaker *speaker_;
+};
+
 template<typename... Ts> class StopAction : public Action<Ts...>, public Parented<Speaker> {
  public:
   void play(Ts... x) override { this->parent_->stop(); }

--- a/esphome/components/speaker/speaker.h
+++ b/esphome/components/speaker/speaker.h
@@ -8,6 +8,8 @@
 #include <freertos/FreeRTOS.h>
 #endif
 
+#include "esphome/core/defines.h"
+
 #include "esphome/components/audio/audio.h"
 #ifdef USE_AUDIO_DAC
 #include "esphome/components/audio_dac/audio_dac.h"

--- a/esphome/components/speaker/speaker.h
+++ b/esphome/components/speaker/speaker.h
@@ -71,7 +71,21 @@ class Speaker {
     }
 #endif
   };
-  virtual float get_volume() { return this->volume_; }
+  float get_volume() { return this->volume_; }
+
+  virtual void set_mute_state(bool mute_state) {
+    this->mute_state_ = mute_state;
+#ifdef USE_AUDIO_DAC
+    if (this->audio_dac_) {
+      if (mute_state) {
+        this->audio_dac_->set_mute_on();
+      } else {
+        this->audio_dac_->set_mute_off();
+      }
+    }
+#endif
+  }
+  bool get_mute_state() { return this->mute_state_; }
 
 #ifdef USE_AUDIO_DAC
   void set_audio_dac(audio_dac::AudioDac *audio_dac) { this->audio_dac_ = audio_dac; }
@@ -85,6 +99,7 @@ class Speaker {
   State state_{STATE_STOPPED};
   audio::AudioStreamInfo audio_stream_info_;
   float volume_{1.0f};
+  bool mute_state_{false};
 
 #ifdef USE_AUDIO_DAC
   audio_dac::AudioDac *audio_dac_{nullptr};

--- a/tests/components/speaker/test.esp32-ard.yaml
+++ b/tests/components/speaker/test.esp32-ard.yaml
@@ -1,6 +1,8 @@
 esphome:
   on_boot:
     then:
+      - speaker.mute_on:
+      - speaker.mute_off:
       - if:
           condition: speaker.is_stopped
           then:

--- a/tests/components/speaker/test.esp32-c3-ard.yaml
+++ b/tests/components/speaker/test.esp32-c3-ard.yaml
@@ -1,6 +1,8 @@
 esphome:
   on_boot:
     then:
+      - speaker.mute_on:
+      - speaker.mute_off:
       - if:
           condition: speaker.is_stopped
           then:

--- a/tests/components/speaker/test.esp32-c3-idf.yaml
+++ b/tests/components/speaker/test.esp32-c3-idf.yaml
@@ -1,6 +1,8 @@
 esphome:
   on_boot:
     then:
+      - speaker.mute_on:
+      - speaker.mute_off:
       - if:
           condition: speaker.is_stopped
           then:

--- a/tests/components/speaker/test.esp32-idf.yaml
+++ b/tests/components/speaker/test.esp32-idf.yaml
@@ -1,6 +1,8 @@
 esphome:
   on_boot:
     then:
+      - speaker.mute_on:
+      - speaker.mute_off:
       - if:
           condition: speaker.is_stopped
           then:
@@ -17,8 +19,17 @@ i2s_audio:
   i2s_bclk_pin: 17
   i2s_mclk_pin: 15
 
+i2c:
+  scl: 12
+  sda: 10
+
+audio_dac:
+  - platform: aic3204
+    id: internal_dac
+
 speaker:
   - platform: i2s_audio
-    id: speaker_id
+    id: speaker_with_audio_dac_id
+    audio_dac: internal_dac
     dac_type: external
-    i2s_dout_pin: 13
+    i2s_dout_pin: 14


### PR DESCRIPTION
# What does this implement/fix?

Adds a configuration option for an optional ``audio_dac`` component to a speaker component for volume control. Adds speaker mute on and off actions. Updates the ``i2s_audio_speaker`` component  to primarily use the audio_dac for volume control before falling back to software volume control. Adds a better logging message when another component tries to send incompatible audio and fixes a crash that would happen only in this situation. Adds tests to cover these new cases. Updates the code owner fields since I am responsible for a large portion of the current code.

This centralizes all the volume control logic to the speaker component instead of having it spread across multiple components. Now a media player (or any other component) can just direct the speaker to set a volume or mute state, and the individual speaker component is responsible for implementing it based on the configuration.

The volume and mute setters are getting long... I'm happy to modify this if there is a better approach!

Tested on a Voice PE and and ATOM Echo.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

not applicable

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#4378

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

speaker:
  - platform: i2s_audio
    id: speaker_id
    dac_type: external
    i2s_dout_pin: GPIO10
    sample_rate: 48000
    bits_per_sample: 32bit
    i2s_mode: secondary
    channel: stereo
    audio_dac: internal_dac

i2s_audio:
  - id: i2s_output
    i2s_lrclk_pin: GPIO7
    i2s_bclk_pin: GPIO8

audio_dac:
  - platform: aic3204
    id: internal_dac

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
