### PR TITLE
Fixes modbus timing error

### DIFF
--- a/esphome/components/modbus/modbus.cpp
+++ b/esphome/components/modbus/modbus.cpp
@@ -15,31 +15,42 @@ void Modbus::setup() {
 void Modbus::loop() {
   const uint32_t now = millis();
 
-  if (now - this->last_modbus_byte_ > 50) {
-    this->rx_buffer_.clear();
-    this->last_modbus_byte_ = now;
-  }
-  // stop blocking new send commands after send_wait_time_ ms regardless if a response has been received since then
-  if (now - this->last_send_ > send_wait_time_) {
-    waiting_for_response = 0;
-  }
-
   while (this->available()) {
     uint8_t byte;
     this->read_byte(&byte);
     if (this->parse_modbus_byte_(byte)) {
       this->last_modbus_byte_ = now;
     } else {
+      size_t at = this->rx_buffer_.size();
+      if (at > 0) {
+        ESP_LOGV(TAG, "Clearing buffer of %d bytes - parse failed", at);
+        this->rx_buffer_.clear();
+      }
+    }
+  }
+
+  if (now - this->last_modbus_byte_ > 50) {
+    size_t at = this->rx_buffer_.size();
+    if (at > 0) {
+      ESP_LOGV(TAG, "Clearing buffer of %d bytes - timeout", at);
       this->rx_buffer_.clear();
     }
   }
+
+  // stop blocking new send commands after sent_wait_time_ ms regardless if a response has been received since then
+  if (now - this->last_send_ > send_wait_time_) {
+    if (waiting_for_response > 0)
+      ESP_LOGV(TAG, "Stop waiting for response from %d", waiting_for_response);
+    waiting_for_response = 0;
+  }
+
 }
 
 bool Modbus::parse_modbus_byte_(uint8_t byte) {
   size_t at = this->rx_buffer_.size();
   this->rx_buffer_.push_back(byte);
   const uint8_t *raw = &this->rx_buffer_[0];
-  ESP_LOGV(TAG, "Modbus received Byte  %d (0X%x)", byte, byte);
+  ESP_LOGVV(TAG, "Modbus received Byte  %d (0X%x)", byte, byte);
   // Byte 0: modbus address (match all)
   if (at == 0)
     return true;
@@ -144,8 +155,10 @@ bool Modbus::parse_modbus_byte_(uint8_t byte) {
     ESP_LOGW(TAG, "Got Modbus frame from unknown address 0x%02X! ", address);
   }
 
-  // return false to reset buffer
-  return false;
+  // reset buffer
+  ESP_LOGV(TAG, "Clearing buffer of %d bytes - parse succeeded", at);
+  this->rx_buffer_.clear();
+  return true;
 }
 
 void Modbus::dump_config() {

--- a/esphome/components/modbus/modbus.cpp
+++ b/esphome/components/modbus/modbus.cpp
@@ -35,13 +35,13 @@ void Modbus::loop() {
       ESP_LOGV(TAG, "Clearing buffer of %d bytes - timeout", at);
       this->rx_buffer_.clear();
     }
-  }
 
-  // stop blocking new send commands after sent_wait_time_ ms regardless if a response has been received since then
-  if (now - this->last_send_ > send_wait_time_) {
-    if (waiting_for_response > 0)
-      ESP_LOGV(TAG, "Stop waiting for response from %d", waiting_for_response);
-    waiting_for_response = 0;
+    // stop blocking new send commands after sent_wait_time_ ms after response received
+    if (now - this->last_send_ > send_wait_time_) {
+      if (waiting_for_response > 0)
+        ESP_LOGV(TAG, "Stop waiting for response from %d", waiting_for_response);
+      waiting_for_response = 0;
+    }
   }
 
 }

--- a/esphome/components/modbus/modbus.cpp
+++ b/esphome/components/modbus/modbus.cpp
@@ -43,7 +43,6 @@ void Modbus::loop() {
       waiting_for_response = 0;
     }
   }
-
 }
 
 bool Modbus::parse_modbus_byte_(uint8_t byte) {


### PR DESCRIPTION
# What does this implement/fix?

Fixes modbus timing error which deletes partial responses before they have had a chance to be received.

The root cause to the sdm_meter bug is a long response, which gets hosed by the timing bug in the current modbus implementation. The pull request fixes it for the current version of the arduino framework.

Additionally, send_wait_time modified to avoid clashes on the RS485 bus. Wait time behaves the same for no response, but will not allow sends to begin if a response has _started_ before send_wait_time but not yet finished. 

This should mean fewer occasions where send_wait_time ever needs to be increased (and docs may want to reflect this).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/issues/issues/3912#issuecomment-2425170701
- fixes https://github.com/esphome/issues/issues/3939
- might fix https://github.com/esphome/issues/issues/5927
- might fix https://github.com/esphome/issues/issues/5163
- might fix https://github.com/esphome/issues/issues/4746
- might fix https://github.com/esphome/issues/issues/3937

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
 
