### PR TITLE
[rpi_dpi_rgb] Fix get_width and height (Bugfix)

### DIFF
--- a/esphome/components/rpi_dpi_rgb/rpi_dpi_rgb.cpp
+++ b/esphome/components/rpi_dpi_rgb/rpi_dpi_rgb.cpp
@@ -84,6 +84,26 @@ void RpiDpiRgb::draw_pixels_at(int x_start, int y_start, int w, int h, const uin
     ESP_LOGE(TAG, "lcd_lcd_panel_draw_bitmap failed: %s", esp_err_to_name(err));
 }
 
+int RpiDpiRgb::get_width() {
+  switch (this->rotation_) {
+    case display::DISPLAY_ROTATION_90_DEGREES:
+    case display::DISPLAY_ROTATION_270_DEGREES:
+      return this->get_height_internal();
+    default:
+      return this->get_width_internal();
+  }
+}
+
+int RpiDpiRgb::get_height() {
+  switch (this->rotation_) {
+    case display::DISPLAY_ROTATION_90_DEGREES:
+    case display::DISPLAY_ROTATION_270_DEGREES:
+      return this->get_width_internal();
+    default:
+      return this->get_height_internal();
+  }
+}
+
 void RpiDpiRgb::draw_pixel_at(int x, int y, Color color) {
   if (!this->get_clipping().inside(x, y))
     return;  // NOLINT

--- a/esphome/components/rpi_dpi_rgb/rpi_dpi_rgb.h
+++ b/esphome/components/rpi_dpi_rgb/rpi_dpi_rgb.h
@@ -24,6 +24,7 @@ class RpiDpiRgb : public display::Display {
   void update() override { this->do_update_(); }
   void setup() override;
   void loop() override;
+  float get_setup_priority() const override { return setup_priority::HARDWARE; }
   void draw_pixels_at(int x_start, int y_start, int w, int h, const uint8_t *ptr, display::ColorOrder order,
                       display::ColorBitness bitness, bool big_endian, int x_offset, int y_offset, int x_pad) override;
   void draw_pixel_at(int x, int y, Color color) override;
@@ -44,8 +45,8 @@ class RpiDpiRgb : public display::Display {
     this->width_ = width;
     this->height_ = height;
   }
-  int get_width() override { return this->width_; }
-  int get_height() override { return this->height_; }
+  int get_width() override;
+  int get_height() override;
   void set_hsync_back_porch(uint16_t hsync_back_porch) { this->hsync_back_porch_ = hsync_back_porch; }
   void set_hsync_front_porch(uint16_t hsync_front_porch) { this->hsync_front_porch_ = hsync_front_porch; }
   void set_hsync_pulse_width(uint16_t hsync_pulse_width) { this->hsync_pulse_width_ = hsync_pulse_width; }


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

The methods `get_width()` and `get_height()` were not taking rotation into account as expected.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://discord.com/channels/429907082951524364/1299089178818252863

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
