### PR TITLE
[speaker] Removing the Finish() method. It is not needed anymore.

### DIFF
--- a/esphome/components/i2s_audio/speaker/i2s_audio_speaker.cpp
+++ b/esphome/components/i2s_audio/speaker/i2s_audio_speaker.cpp
@@ -26,7 +26,6 @@ static const char *const TAG = "i2s_audio.speaker";
 enum SpeakerEventGroupBits : uint32_t {
   COMMAND_START = (1 << 0),                           // Starts the main task purpose
   COMMAND_STOP = (1 << 1),                            // stops the main task
-  COMMAND_STOP_GRACEFULLY = (1 << 2),                 // Stops the task once all data has been written
   MESSAGE_RING_BUFFER_AVAILABLE_TO_WRITE = (1 << 5),  // Locks the ring buffer when not set
   STATE_STARTING = (1 << 10),
   STATE_RUNNING = (1 << 11),
@@ -184,15 +183,14 @@ bool I2SAudioSpeaker::has_buffered_data() const {
 
 void I2SAudioSpeaker::speaker_task(void *params) {
   I2SAudioSpeaker *this_speaker = (I2SAudioSpeaker *) params;
-  uint32_t event_group_bits =
-      xEventGroupWaitBits(this_speaker->event_group_,
-                          SpeakerEventGroupBits::COMMAND_START | SpeakerEventGroupBits::COMMAND_STOP |
-                              SpeakerEventGroupBits::COMMAND_STOP_GRACEFULLY,  // Bit message to read
-                          pdTRUE,                                              // Clear the bits on exit
-                          pdFALSE,                                             // Don't wait for all the bits,
-                          portMAX_DELAY);                                      // Block indefinitely until a bit is set
+  uint32_t event_group_bits = xEventGroupWaitBits(
+      this_speaker->event_group_,
+      SpeakerEventGroupBits::COMMAND_START | SpeakerEventGroupBits::COMMAND_STOP,  // Bit message to read
+      pdTRUE,                                                                      // Clear the bits on exit
+      pdFALSE,                                                                     // Don't wait for all the bits,
+      portMAX_DELAY);  // Block indefinitely until a bit is set
 
-  if (event_group_bits & (SpeakerEventGroupBits::COMMAND_STOP | SpeakerEventGroupBits::COMMAND_STOP_GRACEFULLY)) {
+  if (event_group_bits & (SpeakerEventGroupBits::COMMAND_STOP)) {
     // Received a stop signal before the task was requested to start
     this_speaker->delete_task_(0);
   }
@@ -225,7 +223,6 @@ void I2SAudioSpeaker::speaker_task(void *params) {
 
     xEventGroupSetBits(this_speaker->event_group_, SpeakerEventGroupBits::STATE_RUNNING);
 
-    bool stop_gracefully = false;
     uint32_t last_data_received_time = millis();
 
     while ((millis() - last_data_received_time) <= this_speaker->timeout_) {
@@ -234,16 +231,12 @@ void I2SAudioSpeaker::speaker_task(void *params) {
       if (event_group_bits & SpeakerEventGroupBits::COMMAND_STOP) {
         break;
       }
-      if (event_group_bits & SpeakerEventGroupBits::COMMAND_STOP_GRACEFULLY) {
-        stop_gracefully = true;
-      }
 
       size_t bytes_to_read = dma_buffers_size;
       size_t bytes_read = this_speaker->audio_ring_buffer_->read((void *) this_speaker->data_buffer_, bytes_to_read,
                                                                  pdMS_TO_TICKS(TASK_DELAY_MS));
 
       if (bytes_read > 0) {
-        last_data_received_time = millis();
         size_t bytes_written = 0;
 
         if ((audio_stream_info.bits_per_sample == 16) && (this_speaker->q15_volume_factor_ < INT16_MAX)) {
@@ -261,18 +254,11 @@ void I2SAudioSpeaker::speaker_task(void *params) {
                            portMAX_DELAY);
         }
 
-        if (bytes_written != bytes_read) {
+        if (bytes_written == bytes_read) {
+          last_data_received_time = millis();
+        } else {
           xEventGroupSetBits(this_speaker->event_group_, SpeakerEventGroupBits::ERR_ESP_INVALID_SIZE);
         }
-
-      } else {
-        // No data received
-
-        if (stop_gracefully) {
-          break;
-        }
-
-        i2s_zero_dma_buffer(this_speaker->parent_->get_port());
       }
     }
   }
@@ -280,7 +266,6 @@ void I2SAudioSpeaker::speaker_task(void *params) {
 
   xEventGroupSetBits(this_speaker->event_group_, SpeakerEventGroupBits::STATE_STOPPING);
 
-  i2s_stop(this_speaker->parent_->get_port());
   i2s_driver_uninstall(this_speaker->parent_->get_port());
 
   this_speaker->parent_->unlock();
@@ -306,21 +291,13 @@ void I2SAudioSpeaker::start() {
   }
 }
 
-void I2SAudioSpeaker::stop() { this->stop_(false); }
-
-void I2SAudioSpeaker::finish() { this->stop_(true); }
-
-void I2SAudioSpeaker::stop_(bool wait_on_empty) {
+void I2SAudioSpeaker::stop() {
   if (this->is_failed())
     return;
   if (this->state_ == speaker::STATE_STOPPED)
     return;
 
-  if (wait_on_empty) {
-    xEventGroupSetBits(this->event_group_, SpeakerEventGroupBits::COMMAND_STOP_GRACEFULLY);
-  } else {
-    xEventGroupSetBits(this->event_group_, SpeakerEventGroupBits::COMMAND_STOP);
-  }
+  xEventGroupSetBits(this->event_group_, SpeakerEventGroupBits::COMMAND_STOP);
 }
 
 bool I2SAudioSpeaker::send_esp_err_to_event_group_(esp_err_t err) {

--- a/esphome/components/i2s_audio/speaker/i2s_audio_speaker.h
+++ b/esphome/components/i2s_audio/speaker/i2s_audio_speaker.h
@@ -36,7 +36,6 @@ class I2SAudioSpeaker : public I2SAudioOut, public speaker::Speaker, public Comp
 
   void start() override;
   void stop() override;
-  void finish() override;
 
   /// @brief Plays the provided audio data.
   /// Starts the speaker task, if necessary. Writes the audio data to the ring buffer.

--- a/esphome/components/rtttl/rtttl.cpp
+++ b/esphome/components/rtttl/rtttl.cpp
@@ -145,11 +145,7 @@ void Rtttl::loop() {
 
 #ifdef USE_SPEAKER
   if (this->speaker_ != nullptr) {
-    if (this->state_ == State::STATE_STOPPING) {
-      if (this->speaker_->is_stopped()) {
-        this->set_state_(State::STATE_STOPPED);
-      }
-    } else if (this->state_ == State::STATE_INIT) {
+    if (this->state_ == State::STATE_INIT) {
       if (this->speaker_->is_stopped()) {
         this->speaker_->start();
         this->set_state_(State::STATE_STARTING);
@@ -346,22 +342,9 @@ void Rtttl::finish_() {
 #ifdef USE_OUTPUT
   if (this->output_ != nullptr) {
     this->output_->set_level(0.0);
-    this->set_state_(State::STATE_STOPPED);
   }
 #endif
-#ifdef USE_SPEAKER
-  if (this->speaker_ != nullptr) {
-    SpeakerSample sample[2];
-    sample[0].left = 0;
-    sample[0].right = 0;
-    sample[1].left = 0;
-    sample[1].right = 0;
-    this->speaker_->play((uint8_t *) (&sample), 8);
-
-    this->speaker_->finish();
-    this->set_state_(State::STATE_STOPPING);
-  }
-#endif
+  this->set_state_(State::STATE_STOPPED);
   this->note_duration_ = 0;
   this->on_finished_playback_callback_.call();
   ESP_LOGD(TAG, "Playback finished");

--- a/esphome/components/speaker/__init__.py
+++ b/esphome/components/speaker/__init__.py
@@ -81,9 +81,6 @@ async def speaker_play_action(config, action_id, template_arg, args):
 automation.register_action("speaker.stop", StopAction, SPEAKER_AUTOMATION_SCHEMA)(
     speaker_action
 )
-automation.register_action("speaker.finish", FinishAction, SPEAKER_AUTOMATION_SCHEMA)(
-    speaker_action
-)
 
 automation.register_condition(
     "speaker.is_playing", IsPlayingCondition, SPEAKER_AUTOMATION_SCHEMA

--- a/esphome/components/speaker/automation.h
+++ b/esphome/components/speaker/automation.h
@@ -44,11 +44,6 @@ template<typename... Ts> class StopAction : public Action<Ts...>, public Parente
   void play(Ts... x) override { this->parent_->stop(); }
 };
 
-template<typename... Ts> class FinishAction : public Action<Ts...>, public Parented<Speaker> {
- public:
-  void play(Ts... x) override { this->parent_->finish(); }
-};
-
 template<typename... Ts> class IsPlayingCondition : public Condition<Ts...>, public Parented<Speaker> {
  public:
   bool check(Ts... x) override { return this->parent_->is_running(); }

--- a/esphome/components/speaker/speaker.h
+++ b/esphome/components/speaker/speaker.h
@@ -46,10 +46,6 @@ class Speaker {
 
   virtual void start() = 0;
   virtual void stop() = 0;
-  // In compare between *STOP()* and *FINISH()*; *FINISH()* will stop after emptying the play buffer,
-  // while *STOP()* will break directly.
-  // When finish() is not implemented on the platform component it should just do a normal stop.
-  virtual void finish() { this->stop(); }
 
   virtual bool has_buffered_data() const = 0;
 

--- a/tests/components/speaker/test.esp32-ard.yaml
+++ b/tests/components/speaker/test.esp32-ard.yaml
@@ -9,8 +9,7 @@ esphome:
       - if:
           condition: speaker.is_playing
           then:
-            - speaker.finish:
-      - speaker.stop:
+            - speaker.stop:
 
 i2s_audio:
   i2s_lrclk_pin: 16

--- a/tests/components/speaker/test.esp32-c3-ard.yaml
+++ b/tests/components/speaker/test.esp32-c3-ard.yaml
@@ -9,8 +9,7 @@ esphome:
       - if:
           condition: speaker.is_playing
           then:
-            - speaker.finish:
-      - speaker.stop:
+            - speaker.stop:
 
 i2s_audio:
   i2s_lrclk_pin: 6

--- a/tests/components/speaker/test.esp32-c3-idf.yaml
+++ b/tests/components/speaker/test.esp32-c3-idf.yaml
@@ -9,8 +9,7 @@ esphome:
       - if:
           condition: speaker.is_playing
           then:
-            - speaker.finish:
-      - speaker.stop:
+            - speaker.stop:
 
 i2s_audio:
   i2s_lrclk_pin: 6

--- a/tests/components/speaker/test.esp32-idf.yaml
+++ b/tests/components/speaker/test.esp32-idf.yaml
@@ -9,8 +9,7 @@ esphome:
       - if:
           condition: speaker.is_playing
           then:
-            - speaker.finish:
-      - speaker.stop:
+            - speaker.stop:
 
 i2s_audio:
   i2s_lrclk_pin: 16


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->
After deliberation with @kahrendt we came to the conclusion that Finish() procedure is not needed anymore. You can now just wait until everything is played and the speaker stops automatically.

This PR fixes also the issue that not everything was played at the end. 

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
