### PR TITLE
[setup] create all-include.cpp when script/setup is run

### DIFF
--- a/script/helpers.py
+++ b/script/helpers.py
@@ -32,6 +32,7 @@ def print_error_for_file(file, body):
 def build_all_include():
     # Build a cpp file that includes all header files in this repo.
     # Otherwise header-only integrations would not be tested by clang-tidy
+    # Also helps pio find included files for the benefit of IDEs
     headers = []
     for path in walk_files(basepath):
         filetypes = (".h",)

--- a/script/platformio_install_deps.py
+++ b/script/platformio_install_deps.py
@@ -6,6 +6,8 @@ import argparse
 import configparser
 import subprocess
 
+from helpers import build_all_include
+
 config = configparser.ConfigParser(inline_comment_prefixes=(";",))
 
 parser = argparse.ArgumentParser(description="")
@@ -56,3 +58,4 @@ for section in config.sections():
             tools.append(tool)
 
 subprocess.check_call(["platformio", "pkg", "install", "-g", *libs, *platforms, *tools])
+build_all_include()


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

The top-level `platformio.ini` file refers to `.temp/all-include.cpp` but this file currently only gets created by `script/clang-tidy`. This means that when the project is imported into an IDE using pio, header-only components are not included.

This PR runs `build_all_include()` as part of `script/setup` to ensure the file exists.

Not included in the PR because I can't find a way to do it, but another useful addition is to create a file `.git/hooks/post-checkout` with the content:

```
#!/bin/sh

python3 -c 'from script.helpers import build_all_include; build_all_include()'
```

This will re-create `all-include.cpp` whenever the branch changes.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
