### PR TITLE
added Waveshare BWR Mode for the 7.5in Display

### DIFF
--- a/esphome/components/waveshare_epaper/display.py
+++ b/esphome/components/waveshare_epaper/display.py
@@ -74,7 +74,10 @@ WaveshareEPaper7P5InBV2 = waveshare_epaper_ns.class_(
     "WaveshareEPaper7P5InBV2", WaveshareEPaper
 )
 WaveshareEPaper7P5InBV3 = waveshare_epaper_ns.class_(
-    "WaveshareEPaper7P5InBV3", WaveshareEPaperBWR
+    "WaveshareEPaper7P5InBV3", WaveshareEPaper
+)
+WaveshareEPaper7P5InBV3BWR = waveshare_epaper_ns.class_(
+    "WaveshareEPaper7P5InBV3BWR", WaveshareEPaperBWR
 )
 WaveshareEPaper7P5InV2 = waveshare_epaper_ns.class_(
     "WaveshareEPaper7P5InV2", WaveshareEPaper
@@ -129,6 +132,7 @@ MODELS = {
     "7.50in": ("b", WaveshareEPaper7P5In),
     "7.50in-bv2": ("b", WaveshareEPaper7P5InBV2),
     "7.50in-bv3": ("b", WaveshareEPaper7P5InBV3),
+    "7.50in-bv3-bwr": ("b", WaveshareEPaper7P5InBV3BWR),
     "7.50in-bc": ("b", WaveshareEPaper7P5InBC),
     "7.50inv2": ("b", WaveshareEPaper7P5InV2),
     "7.50inv2alt": ("b", WaveshareEPaper7P5InV2alt),

--- a/esphome/components/waveshare_epaper/display.py
+++ b/esphome/components/waveshare_epaper/display.py
@@ -1,7 +1,7 @@
-import esphome.codegen as cg
-import esphome.config_validation as cv
 from esphome import core, pins
+import esphome.codegen as cg
 from esphome.components import display, spi
+import esphome.config_validation as cv
 from esphome.const import (
     CONF_BUSY_PIN,
     CONF_DC_PIN,
@@ -74,7 +74,7 @@ WaveshareEPaper7P5InBV2 = waveshare_epaper_ns.class_(
     "WaveshareEPaper7P5InBV2", WaveshareEPaper
 )
 WaveshareEPaper7P5InBV3 = waveshare_epaper_ns.class_(
-    "WaveshareEPaper7P5InBV3", WaveshareEPaper
+    "WaveshareEPaper7P5InBV3", WaveshareEPaperBWR
 )
 WaveshareEPaper7P5InV2 = waveshare_epaper_ns.class_(
     "WaveshareEPaper7P5InV2", WaveshareEPaper

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -2213,7 +2213,7 @@ void WaveshareEPaper7P5InBV3::init_display_() {
   this->wait_until_idle_();
   // COMMAND PANEL SETTING
   this->command(0x00);
-  this->data(0x3F);  // KW-3f   KWR-2F BWROTP 0f BWOTP 1f
+  this->data(0x0F);  // KW-3f   KWR-2F BWROTP 0f BWOTP 1f
 
   // COMMAND RESOLUTION SETTING
   this->command(0x61);
@@ -2226,7 +2226,7 @@ void WaveshareEPaper7P5InBV3::init_display_() {
   this->data(0x00);
   // COMMAND VCOM AND DATA INTERVAL SETTING
   this->command(0x50);
-  this->data(0x10);
+  this->data(0x20);
   this->data(0x00);
   // COMMAND TCON SETTING
   this->command(0x60);
@@ -2286,17 +2286,23 @@ void WaveshareEPaper7P5InBV3::init_display_() {
 };
 void HOT WaveshareEPaper7P5InBV3::display() {
   this->init_display_();
-  uint32_t buf_len = this->get_buffer_length_();
+  const uint32_t buf_len = this->get_buffer_length_() / 2u;
 
-  this->command(0x10);
+  /*this->command(0x10);
   for (uint32_t i = 0; i < buf_len; i++) {
     this->data(0xFF);
+  }*/
+
+  this->command(0x10);  // Start Transmission
+  delay(2);
+  for (uint32_t i = 0; i < buf_len; i++) {
+    this->data(this->buffer_[i]);
   }
 
   this->command(0x13);  // Start Transmission
   delay(2);
   for (uint32_t i = 0; i < buf_len; i++) {
-    this->data(~this->buffer_[i]);
+    this->data(this->buffer_[i + buf_len]);
   }
 
   this->command(0x12);  // Display Refresh

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -2213,7 +2213,7 @@ void WaveshareEPaper7P5InBV3::init_display_() {
   this->wait_until_idle_();
   // COMMAND PANEL SETTING
   this->command(0x00);
-  this->data(0x0F);  // KW-3f   KWR-2F BWROTP 0f BWOTP 1f
+  this->data(0x3F);  // KW-3f   KWR-2F BWROTP 0f BWOTP 1f
 
   // COMMAND RESOLUTION SETTING
   this->command(0x61);
@@ -2226,7 +2226,7 @@ void WaveshareEPaper7P5InBV3::init_display_() {
   this->data(0x00);
   // COMMAND VCOM AND DATA INTERVAL SETTING
   this->command(0x50);
-  this->data(0x20);
+  this->data(0x10);
   this->data(0x00);
   // COMMAND TCON SETTING
   this->command(0x60);
@@ -2286,23 +2286,17 @@ void WaveshareEPaper7P5InBV3::init_display_() {
 };
 void HOT WaveshareEPaper7P5InBV3::display() {
   this->init_display_();
-  const uint32_t buf_len = this->get_buffer_length_() / 2u;
+  uint32_t buf_len = this->get_buffer_length_();
 
-  /*this->command(0x10);
+  this->command(0x10);
   for (uint32_t i = 0; i < buf_len; i++) {
     this->data(0xFF);
-  }*/
-
-  this->command(0x10);  // Start Transmission
-  delay(2);
-  for (uint32_t i = 0; i < buf_len; i++) {
-    this->data(this->buffer_[i]);
   }
 
   this->command(0x13);  // Start Transmission
   delay(2);
   for (uint32_t i = 0; i < buf_len; i++) {
-    this->data(this->buffer_[i + buf_len]);
+    this->data(~this->buffer_[i]);
   }
 
   this->command(0x12);  // Display Refresh
@@ -2315,6 +2309,113 @@ int WaveshareEPaper7P5InBV3::get_height_internal() { return 480; }
 void WaveshareEPaper7P5InBV3::dump_config() {
   LOG_DISPLAY("", "Waveshare E-Paper", this);
   ESP_LOGCONFIG(TAG, "  Model: 7.5in-bv3");
+  LOG_PIN("  Reset Pin: ", this->reset_pin_);
+  LOG_PIN("  DC Pin: ", this->dc_pin_);
+  LOG_PIN("  Busy Pin: ", this->busy_pin_);
+  LOG_UPDATE_INTERVAL(this);
+}
+
+void WaveshareEPaper7P5InBV3BWR::initialize() { this->init_display_(); }
+bool WaveshareEPaper7P5InBV3BWR::wait_until_idle_() {
+  if (this->busy_pin_ == nullptr) {
+    return true;
+  }
+
+  const uint32_t start = millis();
+  while (this->busy_pin_->digital_read()) {
+    this->command(0x71);
+    if (millis() - start > this->idle_timeout_()) {
+      ESP_LOGI(TAG, "Timeout while displaying image!");
+      return false;
+    }
+    App.feed_wdt();
+    delay(10);
+  }
+  delay(200);  // NOLINT
+  return true;
+};
+void WaveshareEPaper7P5InBV3BWR::init_display_() {
+  this->reset_();
+
+  // COMMAND POWER SETTING
+  this->command(0x01);
+
+  // 1-0=11: internal power
+  this->data(0x07);
+  this->data(0x17);  // VGH&VGL
+  this->data(0x3F);  // VSH
+  this->data(0x26);  // VSL
+  this->data(0x11);  // VSHR
+
+  // VCOM DC Setting
+  this->command(0x82);
+  this->data(0x24);  // VCOM
+
+  // Booster Setting
+  this->command(0x06);
+  this->data(0x27);
+  this->data(0x27);
+  this->data(0x2F);
+  this->data(0x17);
+
+  // POWER ON
+  this->command(0x04);
+
+  delay(100);  // NOLINT
+  this->wait_until_idle_();
+  // COMMAND PANEL SETTING
+  this->command(0x00);
+  this->data(0x0F);  // KW-3f   KWR-2F BWROTP 0f BWOTP 1f
+
+  // COMMAND RESOLUTION SETTING
+  this->command(0x61);
+  this->data(0x03);  // source 800
+  this->data(0x20);
+  this->data(0x01);  // gate 480
+  this->data(0xE0);
+  // COMMAND ...?
+  this->command(0x15);
+  this->data(0x00);
+  // COMMAND VCOM AND DATA INTERVAL SETTING
+  this->command(0x50);
+  this->data(0x20);
+  this->data(0x00);
+  // COMMAND TCON SETTING
+  this->command(0x60);
+  this->data(0x22);
+  // Resolution setting
+  this->command(0x65);
+  this->data(0x00);
+  this->data(0x00);  // 800*480
+  this->data(0x00);
+  this->data(0x00);
+};
+void HOT WaveshareEPaper7P5InBV3BWR::display() {
+  this->init_display_();
+  const uint32_t buf_len = this->get_buffer_length_() / 2u;
+
+  this->command(0x10);  // Send BW data Transmission
+  delay(2);
+  for (uint32_t i = 0; i < buf_len; i++) {
+    this->data(this->buffer_[i]);
+  }
+
+  this->command(0x13);  // Send red data Transmission
+  delay(2);
+  for (uint32_t i = 0; i < buf_len; i++) {
+    this->data(this->buffer_[i + buf_len]);
+  }
+
+  this->command(0x12);  // Display Refresh
+  delay(100);           // NOLINT
+  this->wait_until_idle_();
+  this->deep_sleep();
+}
+int WaveshareEPaper7P5InBV3BWR::get_width_internal() { return 800; }
+int WaveshareEPaper7P5InBV3BWR::get_height_internal() { return 480; }
+void WaveshareEPaper7P5InBV3BWR::dump_config() {
+  LOG_DISPLAY("", "Waveshare E-Paper", this);
+  ESP_LOGCONFIG(TAG, "  Model: 7.5in-bv3 BWR-Mode");
   LOG_PIN("  Reset Pin: ", this->reset_pin_);
   LOG_PIN("  DC Pin: ", this->dc_pin_);
   LOG_PIN("  Busy Pin: ", this->busy_pin_);

--- a/esphome/components/waveshare_epaper/waveshare_epaper.h
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.h
@@ -581,7 +581,7 @@ class WaveshareEPaper7P5InBV2 : public WaveshareEPaper {
   int get_height_internal() override;
 };
 
-class WaveshareEPaper7P5InBV3 : public WaveshareEPaper {
+class WaveshareEPaper7P5InBV3 : public WaveshareEPaperBWR {
  public:
   bool wait_until_idle_();
 

--- a/esphome/components/waveshare_epaper/waveshare_epaper.h
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.h
@@ -581,7 +581,45 @@ class WaveshareEPaper7P5InBV2 : public WaveshareEPaper {
   int get_height_internal() override;
 };
 
-class WaveshareEPaper7P5InBV3 : public WaveshareEPaperBWR {
+class WaveshareEPaper7P5InBV3 : public WaveshareEPaper {
+ public:
+  bool wait_until_idle_();
+
+  void initialize() override;
+
+  void display() override;
+
+  void dump_config() override;
+
+  void deep_sleep() override {
+    this->command(0x02);  // Power off
+    this->wait_until_idle_();
+    this->command(0x07);  // Deep sleep
+    this->data(0xA5);
+  }
+
+  void clear_screen();
+
+ protected:
+  int get_width_internal() override;
+
+  int get_height_internal() override;
+
+  void reset_() {
+    if (this->reset_pin_ != nullptr) {
+      this->reset_pin_->digital_write(true);
+      delay(200);  // NOLINT
+      this->reset_pin_->digital_write(false);
+      delay(5);
+      this->reset_pin_->digital_write(true);
+      delay(200);  // NOLINT
+    }
+  };
+
+  void init_display_();
+};
+
+class WaveshareEPaper7P5InBV3BWR : public WaveshareEPaperBWR {
  public:
   bool wait_until_idle_();
 

--- a/tests/components/waveshare_epaper/test.esp32-ard.yaml
+++ b/tests/components/waveshare_epaper/test.esp32-ard.yaml
@@ -203,6 +203,5 @@ display:
     reset_pin:
       allow_other_uses: true
       number: GPIO32
-    full_update_every: 30
     lambda: |-
       it.rectangle(0, 0, it.get_width(), it.get_height());

--- a/tests/components/waveshare_epaper/test.esp32-ard.yaml
+++ b/tests/components/waveshare_epaper/test.esp32-ard.yaml
@@ -188,3 +188,21 @@ display:
     full_update_every: 30
     lambda: |-
       it.rectangle(0, 0, it.get_width(), it.get_height());
+  - platform: waveshare_epaper
+    model: 7.50in-bv3-bwr
+    spi_id: spi_id_1
+    cs_pin:
+      allow_other_uses: true
+      number: GPIO25
+    dc_pin:
+      allow_other_uses: true
+      number: GPIO26
+    busy_pin:
+      allow_other_uses: true
+      number: GPIO27
+    reset_pin:
+      allow_other_uses: true
+      number: GPIO32
+    full_update_every: 30
+    lambda: |-
+      it.rectangle(0, 0, it.get_width(), it.get_height());

--- a/tests/components/waveshare_epaper/test.esp32-c3-ard.yaml
+++ b/tests/components/waveshare_epaper/test.esp32-c3-ard.yaml
@@ -105,3 +105,19 @@ display:
     model: 1.54in-m5coreink-m09
     lambda: |-
       it.rectangle(0, 0, it.get_width(), it.get_height());
+  - platform: waveshare_epaper
+    cs_pin:
+      allow_other_uses: true
+      number: 4
+    dc_pin:
+      allow_other_uses: true
+      number: 4
+    busy_pin:
+      allow_other_uses: true
+      number: 4
+    reset_pin:
+      allow_other_uses: true
+      number: 4
+    model: 7.50in-bv3-bwr
+    lambda: |-
+      it.rectangle(0, 0, it.get_width(), it.get_height());

--- a/tests/components/waveshare_epaper/test.esp32-c3-idf.yaml
+++ b/tests/components/waveshare_epaper/test.esp32-c3-idf.yaml
@@ -105,3 +105,19 @@ display:
     model: 1.54in-m5coreink-m09
     lambda: |-
       it.rectangle(0, 0, it.get_width(), it.get_height());
+  - platform: waveshare_epaper
+    cs_pin:
+      allow_other_uses: true
+      number: 4
+    dc_pin:
+      allow_other_uses: true
+      number: 4
+    busy_pin:
+      allow_other_uses: true
+      number: 4
+    reset_pin:
+      allow_other_uses: true
+      number: 4
+    model: 7.50in-bv3-bwr
+    lambda: |-
+      it.rectangle(0, 0, it.get_width(), it.get_height());

--- a/tests/components/waveshare_epaper/test.esp32-idf.yaml
+++ b/tests/components/waveshare_epaper/test.esp32-idf.yaml
@@ -105,3 +105,19 @@ display:
     model: 1.54in-m5coreink-m09
     lambda: |-
       it.rectangle(0, 0, it.get_width(), it.get_height());
+  - platform: waveshare_epaper
+    cs_pin:
+      allow_other_uses: true
+      number: 4
+    dc_pin:
+      allow_other_uses: true
+      number: 4
+    busy_pin:
+      allow_other_uses: true
+      number: 4
+    reset_pin:
+      allow_other_uses: true
+      number: 4
+    model: 7.50in-bv3-bwr
+    lambda: |-
+      it.rectangle(0, 0, it.get_width(), it.get_height());

--- a/tests/components/waveshare_epaper/test.esp8266-ard.yaml
+++ b/tests/components/waveshare_epaper/test.esp8266-ard.yaml
@@ -105,3 +105,19 @@ display:
     model: 1.54in-m5coreink-m09
     lambda: |-
       it.rectangle(0, 0, it.get_width(), it.get_height());
+  - platform: waveshare_epaper
+    cs_pin:
+      allow_other_uses: true
+      number: 4
+    dc_pin:
+      allow_other_uses: true
+      number: 4
+    busy_pin:
+      allow_other_uses: true
+      number: 4
+    reset_pin:
+      allow_other_uses: true
+      number: 4
+    model: 7.50in-bv3-bwr
+    lambda: |-
+      it.rectangle(0, 0, it.get_width(), it.get_height());

--- a/tests/components/waveshare_epaper/test.rp2040-ard.yaml
+++ b/tests/components/waveshare_epaper/test.rp2040-ard.yaml
@@ -105,3 +105,19 @@ display:
     model: 1.54in-m5coreink-m09
     lambda: |-
       it.rectangle(0, 0, it.get_width(), it.get_height());
+  - platform: waveshare_epaper
+    cs_pin:
+      allow_other_uses: true
+      number: 5
+    dc_pin:
+      allow_other_uses: true
+      number: 5
+    busy_pin:
+      allow_other_uses: true
+      number: 5
+    reset_pin:
+      allow_other_uses: true
+      number: 5
+    model: 7.50in-bv3-bwr
+    lambda: |-
+      it.rectangle(0, 0, it.get_width(), it.get_height());


### PR DESCRIPTION
# What does this implement/fix?

- duplicated class WaveshareEPaper7P5InBV3 and changed baseclass to get the bigger buffer needed for BWR mode
    - duplicated instead of extended as the BWR mode results in a considerable longer refresh time (~26s vs ~3s) which might not be wanted by most users
- changed to LUT from OTP and KWR Mode
- removed custom LUTs as they did not work in KWR mode and the official driver does not seem use them
    - I might add new custom LUTs in a future pull request if the currently used ones are too distracting for my dashboard project
- updated the register values in the `display()` function and added the register for red values
- as noted below no new tests have been added as they are missing for most of the other displays as well

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#4394

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
spi:
  clk_pin: 14
  mosi_pin: 13

font:
  - file: 'fonts/Literata-Black.ttf'
    id: font_title
    size: 200

color:
  - id: my_red
    red: 100%
    green: 0%
    blue: 0%
    white: 0%

display:
  - platform: waveshare_epaper
    id: eink
    cs_pin: 2
    dc_pin: 4
    busy_pin:
      number: 0
      inverted: true
    reset_pin: 16
    model: 7.50in-bv3-bwr
    update_interval: 3600s
    lambda: |-
      it.print(it.get_width()/2, 0, id(font_title), COLOR_ON, TextAlign::TOP_CENTER, "Hello");
      it.print(it.get_width()/2, it.get_height()/2, id(font_title), id(my_red), TextAlign::TOP_CENTER, "World");

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
