### PR TITLE
[font] Fix failure with bitmap fonts

### DIFF
--- a/esphome/components/font/__init__.py
+++ b/esphome/components/font/__init__.py
@@ -344,7 +344,7 @@ class TrueTypeFontWrapper:
         return offset_x, offset_y
 
     def getmask(self, glyph, **kwargs):
-        return self.font.getmask(glyph, **kwargs)
+        return self.font.getmask(str(glyph), **kwargs)
 
     def getmetrics(self, glyphs):
         return self.font.getmetrics()
@@ -359,7 +359,7 @@ class BitmapFontWrapper:
         return 0, 0
 
     def getmask(self, glyph, **kwargs):
-        return self.font.getmask(glyph, **kwargs)
+        return self.font.getmask(str(glyph), **kwargs)
 
     def getmetrics(self, glyphs):
         max_height = 0


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Using bitmap fonts with an array of glyphs silently fails to render anything.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/issues/issues/6371

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [x] host

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
  - file: MatrixChunky8X.bdf
    glyphs:
      - T
      - e
      - x
      - t
    id: chunky
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
