### PR TITLE
Add in area and device to the prometheus labels

### DIFF
--- a/esphome/components/prometheus/prometheus_handler.cpp
+++ b/esphome/components/prometheus/prometheus_handler.cpp
@@ -85,8 +85,7 @@ void PrometheusHandler::sensor_row_(AsyncResponseStream *stream, sensor::Sensor 
     stream->print(relabel_id_(obj).c_str());
     stream->print(F("\",name=\""));
     stream->print(relabel_name_(obj).c_str());
-    if stream
-      ->print(F("\"} 0\n"));
+    stream->print(F("\"} 0\n"));
     // Data itself
     stream->print(F("esphome_sensor_value{id=\""));
     stream->print(relabel_id_(obj).c_str());

--- a/esphome/components/prometheus/prometheus_handler.cpp
+++ b/esphome/components/prometheus/prometheus_handler.cpp
@@ -70,6 +70,13 @@ std::string PrometheusHandler::relabel_name_(EntityBase *obj) {
   return item == relabel_map_name_.end() ? obj->get_name() : item->second;
 }
 
+void PrometheusHandler::add_area_label_(AsyncResponseStream *stream, std::string &area) {
+  if (!area.empty()) {
+    stream->print(F("\",area=\""));
+    stream->print(area.c_str());
+  }
+}
+
 // Type-specific implementation
 #ifdef USE_SENSOR
 void PrometheusHandler::sensor_type_(AsyncResponseStream *stream) {
@@ -83,12 +90,14 @@ void PrometheusHandler::sensor_row_(AsyncResponseStream *stream, sensor::Sensor 
     // We have a valid value, output this value
     stream->print(F("esphome_sensor_failed{id=\""));
     stream->print(relabel_id_(obj).c_str());
+    add_area_label_(area);
     stream->print(F("\",name=\""));
     stream->print(relabel_name_(obj).c_str());
     stream->print(F("\"} 0\n"));
     // Data itself
     stream->print(F("esphome_sensor_value{id=\""));
     stream->print(relabel_id_(obj).c_str());
+    add_area_label_(area);
     stream->print(F("\",name=\""));
     stream->print(relabel_name_(obj).c_str());
     stream->print(F("\",unit=\""));
@@ -100,6 +109,7 @@ void PrometheusHandler::sensor_row_(AsyncResponseStream *stream, sensor::Sensor 
     // Invalid state
     stream->print(F("esphome_sensor_failed{id=\""));
     stream->print(relabel_id_(obj).c_str());
+    add_area_label_(area);
     stream->print(F("\",name=\""));
     stream->print(relabel_name_(obj).c_str());
     stream->print(F("\"} 1\n"));
@@ -121,12 +131,14 @@ void PrometheusHandler::binary_sensor_row_(AsyncResponseStream *stream, binary_s
     // We have a valid value, output this value
     stream->print(F("esphome_binary_sensor_failed{id=\""));
     stream->print(relabel_id_(obj).c_str());
+    add_area_label_(area);
     stream->print(F("\",name=\""));
     stream->print(relabel_name_(obj).c_str());
     stream->print(F("\"} 0\n"));
     // Data itself
     stream->print(F("esphome_binary_sensor_value{id=\""));
     stream->print(relabel_id_(obj).c_str());
+    add_area_label_(area);
     stream->print(F("\",name=\""));
     stream->print(relabel_name_(obj).c_str());
     stream->print(F("\"} "));
@@ -136,6 +148,7 @@ void PrometheusHandler::binary_sensor_row_(AsyncResponseStream *stream, binary_s
     // Invalid state
     stream->print(F("esphome_binary_sensor_failed{id=\""));
     stream->print(relabel_id_(obj).c_str());
+    add_area_label_(area);
     stream->print(F("\",name=\""));
     stream->print(relabel_name_(obj).c_str());
     stream->print(F("\"} 1\n"));
@@ -155,12 +168,14 @@ void PrometheusHandler::fan_row_(AsyncResponseStream *stream, fan::Fan *obj, std
     return;
   stream->print(F("esphome_fan_failed{id=\""));
   stream->print(relabel_id_(obj).c_str());
+  add_area_label_(area);
   stream->print(F("\",name=\""));
   stream->print(relabel_name_(obj).c_str());
   stream->print(F("\"} 0\n"));
   // Data itself
   stream->print(F("esphome_fan_value{id=\""));
   stream->print(relabel_id_(obj).c_str());
+  add_area_label_(area);
   stream->print(F("\",name=\""));
   stream->print(relabel_name_(obj).c_str());
   stream->print(F("\"} "));
@@ -170,6 +185,7 @@ void PrometheusHandler::fan_row_(AsyncResponseStream *stream, fan::Fan *obj, std
   if (obj->get_traits().supports_speed()) {
     stream->print(F("esphome_fan_speed{id=\""));
     stream->print(relabel_id_(obj).c_str());
+    add_area_label_(area);
     stream->print(F("\",name=\""));
     stream->print(relabel_name_(obj).c_str());
     stream->print(F("\"} "));
@@ -180,6 +196,7 @@ void PrometheusHandler::fan_row_(AsyncResponseStream *stream, fan::Fan *obj, std
   if (obj->get_traits().supports_oscillation()) {
     stream->print(F("esphome_fan_oscillation{id=\""));
     stream->print(relabel_id_(obj).c_str());
+    add_area_label_(area);
     stream->print(F("\",name=\""));
     stream->print(relabel_name_(obj).c_str());
     stream->print(F("\"} "));
@@ -201,6 +218,7 @@ void PrometheusHandler::light_row_(AsyncResponseStream *stream, light::LightStat
   // State
   stream->print(F("esphome_light_state{id=\""));
   stream->print(relabel_id_(obj).c_str());
+  add_area_label_(area);
   stream->print(F("\",name=\""));
   stream->print(relabel_name_(obj).c_str());
   stream->print(F("\"} "));
@@ -213,6 +231,7 @@ void PrometheusHandler::light_row_(AsyncResponseStream *stream, light::LightStat
   color.as_rgbw(&r, &g, &b, &w);
   stream->print(F("esphome_light_color{id=\""));
   stream->print(relabel_id_(obj).c_str());
+  add_area_label_(area);
   stream->print(F("\",name=\""));
   stream->print(relabel_name_(obj).c_str());
   stream->print(F("\",channel=\"brightness\"} "));
@@ -220,6 +239,7 @@ void PrometheusHandler::light_row_(AsyncResponseStream *stream, light::LightStat
   stream->print(F("\n"));
   stream->print(F("esphome_light_color{id=\""));
   stream->print(relabel_id_(obj).c_str());
+  add_area_label_(area);
   stream->print(F("\",name=\""));
   stream->print(relabel_name_(obj).c_str());
   stream->print(F("\",channel=\"r\"} "));
@@ -227,6 +247,7 @@ void PrometheusHandler::light_row_(AsyncResponseStream *stream, light::LightStat
   stream->print(F("\n"));
   stream->print(F("esphome_light_color{id=\""));
   stream->print(relabel_id_(obj).c_str());
+  add_area_label_(area);
   stream->print(F("\",name=\""));
   stream->print(relabel_name_(obj).c_str());
   stream->print(F("\",channel=\"g\"} "));
@@ -234,6 +255,7 @@ void PrometheusHandler::light_row_(AsyncResponseStream *stream, light::LightStat
   stream->print(F("\n"));
   stream->print(F("esphome_light_color{id=\""));
   stream->print(relabel_id_(obj).c_str());
+  add_area_label_(area);
   stream->print(F("\",name=\""));
   stream->print(relabel_name_(obj).c_str());
   stream->print(F("\",channel=\"b\"} "));
@@ -241,6 +263,7 @@ void PrometheusHandler::light_row_(AsyncResponseStream *stream, light::LightStat
   stream->print(F("\n"));
   stream->print(F("esphome_light_color{id=\""));
   stream->print(relabel_id_(obj).c_str());
+  add_area_label_(area);
   stream->print(F("\",name=\""));
   stream->print(relabel_name_(obj).c_str());
   stream->print(F("\",channel=\"w\"} "));
@@ -251,12 +274,14 @@ void PrometheusHandler::light_row_(AsyncResponseStream *stream, light::LightStat
   if (effect == "None") {
     stream->print(F("esphome_light_effect_active{id=\""));
     stream->print(relabel_id_(obj).c_str());
+    add_area_label_(area);
     stream->print(F("\",name=\""));
     stream->print(relabel_name_(obj).c_str());
     stream->print(F("\",effect=\"None\"} 0\n"));
   } else {
     stream->print(F("esphome_light_effect_active{id=\""));
     stream->print(relabel_id_(obj).c_str());
+    add_area_label_(area);
     stream->print(F("\",name=\""));
     stream->print(relabel_name_(obj).c_str());
     stream->print(F("\",effect=\""));
@@ -278,12 +303,14 @@ void PrometheusHandler::cover_row_(AsyncResponseStream *stream, cover::Cover *ob
     // We have a valid value, output this value
     stream->print(F("esphome_cover_failed{id=\""));
     stream->print(relabel_id_(obj).c_str());
+    add_area_label_(area);
     stream->print(F("\",name=\""));
     stream->print(relabel_name_(obj).c_str());
     stream->print(F("\"} 0\n"));
     // Data itself
     stream->print(F("esphome_cover_value{id=\""));
     stream->print(relabel_id_(obj).c_str());
+    add_area_label_(area);
     stream->print(F("\",name=\""));
     stream->print(relabel_name_(obj).c_str());
     stream->print(F("\"} "));
@@ -292,6 +319,7 @@ void PrometheusHandler::cover_row_(AsyncResponseStream *stream, cover::Cover *ob
     if (obj->get_traits().get_supports_tilt()) {
       stream->print(F("esphome_cover_tilt{id=\""));
       stream->print(relabel_id_(obj).c_str());
+      add_area_label_(area);
       stream->print(F("\",name=\""));
       stream->print(relabel_name_(obj).c_str());
       stream->print(F("\"} "));
@@ -302,6 +330,7 @@ void PrometheusHandler::cover_row_(AsyncResponseStream *stream, cover::Cover *ob
     // Invalid state
     stream->print(F("esphome_cover_failed{id=\""));
     stream->print(relabel_id_(obj).c_str());
+    add_area_label_(area);
     stream->print(F("\",name=\""));
     stream->print(relabel_name_(obj).c_str());
     stream->print(F("\"} 1\n"));
@@ -319,12 +348,14 @@ void PrometheusHandler::switch_row_(AsyncResponseStream *stream, switch_::Switch
     return;
   stream->print(F("esphome_switch_failed{id=\""));
   stream->print(relabel_id_(obj).c_str());
+  add_area_label_(area);
   stream->print(F("\",name=\""));
   stream->print(relabel_name_(obj).c_str());
   stream->print(F("\"} 0\n"));
   // Data itself
   stream->print(F("esphome_switch_value{id=\""));
   stream->print(relabel_id_(obj).c_str());
+  add_area_label_(area);
   stream->print(F("\",name=\""));
   stream->print(relabel_name_(obj).c_str());
   stream->print(F("\"} "));
@@ -343,12 +374,14 @@ void PrometheusHandler::lock_row_(AsyncResponseStream *stream, lock::Lock *obj, 
     return;
   stream->print(F("esphome_lock_failed{id=\""));
   stream->print(relabel_id_(obj).c_str());
+  add_area_label_(area);
   stream->print(F("\",name=\""));
   stream->print(relabel_name_(obj).c_str());
   stream->print(F("\"} 0\n"));
   // Data itself
   stream->print(F("esphome_lock_value{id=\""));
   stream->print(relabel_id_(obj).c_str());
+  add_area_label_(area);
   stream->print(F("\",name=\""));
   stream->print(relabel_name_(obj).c_str());
   stream->print(F("\"} "));
@@ -370,12 +403,14 @@ void PrometheusHandler::text_sensor_row_(AsyncResponseStream *stream, text_senso
     // We have a valid value, output this value
     stream->print(F("esphome_text_sensor_failed{id=\""));
     stream->print(relabel_id_(obj).c_str());
+    add_area_label_(area);
     stream->print(F("\",name=\""));
     stream->print(relabel_name_(obj).c_str());
     stream->print(F("\"} 0\n"));
     // Data itself
     stream->print(F("esphome_text_sensor_value{id=\""));
     stream->print(relabel_id_(obj).c_str());
+    add_area_label_(area);
     stream->print(F("\",name=\""));
     stream->print(relabel_name_(obj).c_str());
     stream->print(F("\",value=\""));
@@ -387,6 +422,7 @@ void PrometheusHandler::text_sensor_row_(AsyncResponseStream *stream, text_senso
     // Invalid state
     stream->print(F("esphome_text_sensor_failed{id=\""));
     stream->print(relabel_id_(obj).c_str());
+    add_area_label_(area);
     stream->print(F("\",name=\""));
     stream->print(relabel_name_(obj).c_str());
     stream->print(F("\"} 1\n"));

--- a/esphome/components/prometheus/prometheus_handler.cpp
+++ b/esphome/components/prometheus/prometheus_handler.cpp
@@ -8,53 +8,55 @@ namespace prometheus {
 void PrometheusHandler::handleRequest(AsyncWebServerRequest *req) {
   AsyncResponseStream *stream = req->beginResponseStream("text/plain; version=0.0.4; charset=utf-8");
   std::string area = App.get_area();
+  std::string node = App.get_name();
+  std::string friendly_name = App.get_friendly_name();
 
 #ifdef USE_SENSOR
   this->sensor_type_(stream);
   for (auto *obj : App.get_sensors())
-    this->sensor_row_(stream, obj, area);
+    this->sensor_row_(stream, obj, area, node, friendly_name);
 #endif
 
 #ifdef USE_BINARY_SENSOR
   this->binary_sensor_type_(stream);
   for (auto *obj : App.get_binary_sensors())
-    this->binary_sensor_row_(stream, obj, area);
+    this->binary_sensor_row_(stream, obj, area, node, friendly_name);
 #endif
 
 #ifdef USE_FAN
   this->fan_type_(stream);
   for (auto *obj : App.get_fans())
-    this->fan_row_(stream, obj, area);
+    this->fan_row_(stream, obj, area, node, friendly_name);
 #endif
 
 #ifdef USE_LIGHT
   this->light_type_(stream);
   for (auto *obj : App.get_lights())
-    this->light_row_(stream, obj, area);
+    this->light_row_(stream, obj, area, node, friendly_name);
 #endif
 
 #ifdef USE_COVER
   this->cover_type_(stream);
   for (auto *obj : App.get_covers())
-    this->cover_row_(stream, obj, area);
+    this->cover_row_(stream, obj, area, node, friendly_name);
 #endif
 
 #ifdef USE_SWITCH
   this->switch_type_(stream);
-  for (auto *obj : App.get_switches(), area)
+  for (auto *obj : App.get_switches(), area, node, friendly_name)
     this->switch_row_(stream, obj);
 #endif
 
 #ifdef USE_LOCK
   this->lock_type_(stream);
-  for (auto *obj : App.get_locks(), area)
+  for (auto *obj : App.get_locks(), area, node, friendly_name)
     this->lock_row_(stream, obj);
 #endif
 
 #ifdef USE_TEXT_SENSOR
   this->text_sensor_type_(stream);
   for (auto *obj : App.get_text_sensors())
-    this->text_sensor_row_(stream, obj, area);
+    this->text_sensor_row_(stream, obj, area, node, friendly_name);
 #endif
 
   req->send(stream);
@@ -70,10 +72,24 @@ std::string PrometheusHandler::relabel_name_(EntityBase *obj) {
   return item == relabel_map_name_.end() ? obj->get_name() : item->second;
 }
 
-void PrometheusHandler::add_area_label_(AsyncResponseStream *stream, std::string &area) {
+void PrometheusHandler::add_area_label_(AsyncResponseStream *stream, std::string &area, std::string &node) {
   if (!area.empty()) {
     stream->print(F("\",area=\""));
     stream->print(area.c_str());
+  }
+}
+
+void PrometheusHandler::add_node_label_(AsyncResponseStream *stream, std::string &node) {
+  if (!node.empty()) {
+    stream->print(F("\",node=\""));
+    stream->print(node.c_str());
+  }
+}
+
+void PrometheusHandler::add_friendly_name_label_(AsyncResponseStream *stream, std::string &friendly_name) {
+  if (!friendly_name.empty()) {
+    stream->print(F("\",friendly_name=\""));
+    stream->print(friendly_name.c_str());
   }
 }
 
@@ -83,7 +99,8 @@ void PrometheusHandler::sensor_type_(AsyncResponseStream *stream) {
   stream->print(F("#TYPE esphome_sensor_value gauge\n"));
   stream->print(F("#TYPE esphome_sensor_failed gauge\n"));
 }
-void PrometheusHandler::sensor_row_(AsyncResponseStream *stream, sensor::Sensor *obj, std::string &area) {
+void PrometheusHandler::sensor_row_(AsyncResponseStream *stream, sensor::Sensor *obj, std::string &area,
+                                    std::string &node, std::string &friendly_name) {
   if (obj->is_internal() && !this->include_internal_)
     return;
   if (!std::isnan(obj->state)) {
@@ -91,6 +108,8 @@ void PrometheusHandler::sensor_row_(AsyncResponseStream *stream, sensor::Sensor 
     stream->print(F("esphome_sensor_failed{id=\""));
     stream->print(relabel_id_(obj).c_str());
     add_area_label_(stream, area);
+    add_node_label_(stream, node);
+    add_friendly_name_label_(stream, friendly_name);
     stream->print(F("\",name=\""));
     stream->print(relabel_name_(obj).c_str());
     stream->print(F("\"} 0\n"));
@@ -98,6 +117,8 @@ void PrometheusHandler::sensor_row_(AsyncResponseStream *stream, sensor::Sensor 
     stream->print(F("esphome_sensor_value{id=\""));
     stream->print(relabel_id_(obj).c_str());
     add_area_label_(stream, area);
+    add_node_label_(stream, node);
+    add_friendly_name_label_(stream, friendly_name);
     stream->print(F("\",name=\""));
     stream->print(relabel_name_(obj).c_str());
     stream->print(F("\",unit=\""));
@@ -110,6 +131,8 @@ void PrometheusHandler::sensor_row_(AsyncResponseStream *stream, sensor::Sensor 
     stream->print(F("esphome_sensor_failed{id=\""));
     stream->print(relabel_id_(obj).c_str());
     add_area_label_(stream, area);
+    add_node_label_(stream, node);
+    add_friendly_name_label_(stream, friendly_name);
     stream->print(F("\",name=\""));
     stream->print(relabel_name_(obj).c_str());
     stream->print(F("\"} 1\n"));
@@ -124,7 +147,7 @@ void PrometheusHandler::binary_sensor_type_(AsyncResponseStream *stream) {
   stream->print(F("#TYPE esphome_binary_sensor_failed gauge\n"));
 }
 void PrometheusHandler::binary_sensor_row_(AsyncResponseStream *stream, binary_sensor::BinarySensor *obj,
-                                           std::string &area) {
+                                           std::string &area, std::string &node, std::string &friendly_name) {
   if (obj->is_internal() && !this->include_internal_)
     return;
   if (obj->has_state()) {
@@ -132,6 +155,8 @@ void PrometheusHandler::binary_sensor_row_(AsyncResponseStream *stream, binary_s
     stream->print(F("esphome_binary_sensor_failed{id=\""));
     stream->print(relabel_id_(obj).c_str());
     add_area_label_(stream, area);
+    add_node_label_(stream, node);
+    add_friendly_name_label_(stream, friendly_name);
     stream->print(F("\",name=\""));
     stream->print(relabel_name_(obj).c_str());
     stream->print(F("\"} 0\n"));
@@ -139,6 +164,8 @@ void PrometheusHandler::binary_sensor_row_(AsyncResponseStream *stream, binary_s
     stream->print(F("esphome_binary_sensor_value{id=\""));
     stream->print(relabel_id_(obj).c_str());
     add_area_label_(stream, area);
+    add_node_label_(stream, node);
+    add_friendly_name_label_(stream, friendly_name);
     stream->print(F("\",name=\""));
     stream->print(relabel_name_(obj).c_str());
     stream->print(F("\"} "));
@@ -149,6 +176,8 @@ void PrometheusHandler::binary_sensor_row_(AsyncResponseStream *stream, binary_s
     stream->print(F("esphome_binary_sensor_failed{id=\""));
     stream->print(relabel_id_(obj).c_str());
     add_area_label_(stream, area);
+    add_node_label_(stream, node);
+    add_friendly_name_label_(stream, friendly_name);
     stream->print(F("\",name=\""));
     stream->print(relabel_name_(obj).c_str());
     stream->print(F("\"} 1\n"));
@@ -163,12 +192,15 @@ void PrometheusHandler::fan_type_(AsyncResponseStream *stream) {
   stream->print(F("#TYPE esphome_fan_speed gauge\n"));
   stream->print(F("#TYPE esphome_fan_oscillation gauge\n"));
 }
-void PrometheusHandler::fan_row_(AsyncResponseStream *stream, fan::Fan *obj, std::string &area) {
+void PrometheusHandler::fan_row_(AsyncResponseStream *stream, fan::Fan *obj, std::string &area, std::string &node,
+                                 std::string &friendly_name) {
   if (obj->is_internal() && !this->include_internal_)
     return;
   stream->print(F("esphome_fan_failed{id=\""));
   stream->print(relabel_id_(obj).c_str());
   add_area_label_(stream, area);
+  add_node_label_(stream, node);
+  add_friendly_name_label_(stream, friendly_name);
   stream->print(F("\",name=\""));
   stream->print(relabel_name_(obj).c_str());
   stream->print(F("\"} 0\n"));
@@ -176,6 +208,8 @@ void PrometheusHandler::fan_row_(AsyncResponseStream *stream, fan::Fan *obj, std
   stream->print(F("esphome_fan_value{id=\""));
   stream->print(relabel_id_(obj).c_str());
   add_area_label_(stream, area);
+  add_node_label_(stream, node);
+  add_friendly_name_label_(stream, friendly_name);
   stream->print(F("\",name=\""));
   stream->print(relabel_name_(obj).c_str());
   stream->print(F("\"} "));
@@ -186,6 +220,8 @@ void PrometheusHandler::fan_row_(AsyncResponseStream *stream, fan::Fan *obj, std
     stream->print(F("esphome_fan_speed{id=\""));
     stream->print(relabel_id_(obj).c_str());
     add_area_label_(stream, area);
+    add_node_label_(stream, node);
+    add_friendly_name_label_(stream, friendly_name);
     stream->print(F("\",name=\""));
     stream->print(relabel_name_(obj).c_str());
     stream->print(F("\"} "));
@@ -197,6 +233,8 @@ void PrometheusHandler::fan_row_(AsyncResponseStream *stream, fan::Fan *obj, std
     stream->print(F("esphome_fan_oscillation{id=\""));
     stream->print(relabel_id_(obj).c_str());
     add_area_label_(stream, area);
+    add_node_label_(stream, node);
+    add_friendly_name_label_(stream, friendly_name);
     stream->print(F("\",name=\""));
     stream->print(relabel_name_(obj).c_str());
     stream->print(F("\"} "));
@@ -212,13 +250,16 @@ void PrometheusHandler::light_type_(AsyncResponseStream *stream) {
   stream->print(F("#TYPE esphome_light_color gauge\n"));
   stream->print(F("#TYPE esphome_light_effect_active gauge\n"));
 }
-void PrometheusHandler::light_row_(AsyncResponseStream *stream, light::LightState *obj, std::string &area) {
+void PrometheusHandler::light_row_(AsyncResponseStream *stream, light::LightState *obj, std::string &area,
+                                   std::string &node, std::string &friendly_name) {
   if (obj->is_internal() && !this->include_internal_)
     return;
   // State
   stream->print(F("esphome_light_state{id=\""));
   stream->print(relabel_id_(obj).c_str());
   add_area_label_(stream, area);
+  add_node_label_(stream, node);
+  add_friendly_name_label_(stream, friendly_name);
   stream->print(F("\",name=\""));
   stream->print(relabel_name_(obj).c_str());
   stream->print(F("\"} "));
@@ -232,6 +273,8 @@ void PrometheusHandler::light_row_(AsyncResponseStream *stream, light::LightStat
   stream->print(F("esphome_light_color{id=\""));
   stream->print(relabel_id_(obj).c_str());
   add_area_label_(stream, area);
+  add_node_label_(stream, node);
+  add_friendly_name_label_(stream, friendly_name);
   stream->print(F("\",name=\""));
   stream->print(relabel_name_(obj).c_str());
   stream->print(F("\",channel=\"brightness\"} "));
@@ -240,6 +283,8 @@ void PrometheusHandler::light_row_(AsyncResponseStream *stream, light::LightStat
   stream->print(F("esphome_light_color{id=\""));
   stream->print(relabel_id_(obj).c_str());
   add_area_label_(stream, area);
+  add_node_label_(stream, node);
+  add_friendly_name_label_(stream, friendly_name);
   stream->print(F("\",name=\""));
   stream->print(relabel_name_(obj).c_str());
   stream->print(F("\",channel=\"r\"} "));
@@ -248,6 +293,8 @@ void PrometheusHandler::light_row_(AsyncResponseStream *stream, light::LightStat
   stream->print(F("esphome_light_color{id=\""));
   stream->print(relabel_id_(obj).c_str());
   add_area_label_(stream, area);
+  add_node_label_(stream, node);
+  add_friendly_name_label_(stream, friendly_name);
   stream->print(F("\",name=\""));
   stream->print(relabel_name_(obj).c_str());
   stream->print(F("\",channel=\"g\"} "));
@@ -256,6 +303,8 @@ void PrometheusHandler::light_row_(AsyncResponseStream *stream, light::LightStat
   stream->print(F("esphome_light_color{id=\""));
   stream->print(relabel_id_(obj).c_str());
   add_area_label_(stream, area);
+  add_node_label_(stream, node);
+  add_friendly_name_label_(stream, friendly_name);
   stream->print(F("\",name=\""));
   stream->print(relabel_name_(obj).c_str());
   stream->print(F("\",channel=\"b\"} "));
@@ -264,6 +313,8 @@ void PrometheusHandler::light_row_(AsyncResponseStream *stream, light::LightStat
   stream->print(F("esphome_light_color{id=\""));
   stream->print(relabel_id_(obj).c_str());
   add_area_label_(stream, area);
+  add_node_label_(stream, node);
+  add_friendly_name_label_(stream, friendly_name);
   stream->print(F("\",name=\""));
   stream->print(relabel_name_(obj).c_str());
   stream->print(F("\",channel=\"w\"} "));
@@ -275,6 +326,8 @@ void PrometheusHandler::light_row_(AsyncResponseStream *stream, light::LightStat
     stream->print(F("esphome_light_effect_active{id=\""));
     stream->print(relabel_id_(obj).c_str());
     add_area_label_(stream, area);
+    add_node_label_(stream, node);
+    add_friendly_name_label_(stream, friendly_name);
     stream->print(F("\",name=\""));
     stream->print(relabel_name_(obj).c_str());
     stream->print(F("\",effect=\"None\"} 0\n"));
@@ -282,6 +335,8 @@ void PrometheusHandler::light_row_(AsyncResponseStream *stream, light::LightStat
     stream->print(F("esphome_light_effect_active{id=\""));
     stream->print(relabel_id_(obj).c_str());
     add_area_label_(stream, area);
+    add_node_label_(stream, node);
+    add_friendly_name_label_(stream, friendly_name);
     stream->print(F("\",name=\""));
     stream->print(relabel_name_(obj).c_str());
     stream->print(F("\",effect=\""));
@@ -296,7 +351,8 @@ void PrometheusHandler::cover_type_(AsyncResponseStream *stream) {
   stream->print(F("#TYPE esphome_cover_value gauge\n"));
   stream->print(F("#TYPE esphome_cover_failed gauge\n"));
 }
-void PrometheusHandler::cover_row_(AsyncResponseStream *stream, cover::Cover *obj, std::string &area) {
+void PrometheusHandler::cover_row_(AsyncResponseStream *stream, cover::Cover *obj, std::string &area, std::string &node,
+                                   std::string &friendly_name) {
   if (obj->is_internal() && !this->include_internal_)
     return;
   if (!std::isnan(obj->position)) {
@@ -304,6 +360,8 @@ void PrometheusHandler::cover_row_(AsyncResponseStream *stream, cover::Cover *ob
     stream->print(F("esphome_cover_failed{id=\""));
     stream->print(relabel_id_(obj).c_str());
     add_area_label_(stream, area);
+    add_node_label_(stream, node);
+    add_friendly_name_label_(stream, friendly_name);
     stream->print(F("\",name=\""));
     stream->print(relabel_name_(obj).c_str());
     stream->print(F("\"} 0\n"));
@@ -311,6 +369,8 @@ void PrometheusHandler::cover_row_(AsyncResponseStream *stream, cover::Cover *ob
     stream->print(F("esphome_cover_value{id=\""));
     stream->print(relabel_id_(obj).c_str());
     add_area_label_(stream, area);
+    add_node_label_(stream, node);
+    add_friendly_name_label_(stream, friendly_name);
     stream->print(F("\",name=\""));
     stream->print(relabel_name_(obj).c_str());
     stream->print(F("\"} "));
@@ -320,6 +380,8 @@ void PrometheusHandler::cover_row_(AsyncResponseStream *stream, cover::Cover *ob
       stream->print(F("esphome_cover_tilt{id=\""));
       stream->print(relabel_id_(obj).c_str());
       add_area_label_(stream, area);
+      add_node_label_(stream, node);
+      add_friendly_name_label_(stream, friendly_name);
       stream->print(F("\",name=\""));
       stream->print(relabel_name_(obj).c_str());
       stream->print(F("\"} "));
@@ -331,6 +393,8 @@ void PrometheusHandler::cover_row_(AsyncResponseStream *stream, cover::Cover *ob
     stream->print(F("esphome_cover_failed{id=\""));
     stream->print(relabel_id_(obj).c_str());
     add_area_label_(stream, area);
+    add_node_label_(stream, node);
+    add_friendly_name_label_(stream, friendly_name);
     stream->print(F("\",name=\""));
     stream->print(relabel_name_(obj).c_str());
     stream->print(F("\"} 1\n"));
@@ -343,12 +407,15 @@ void PrometheusHandler::switch_type_(AsyncResponseStream *stream) {
   stream->print(F("#TYPE esphome_switch_value gauge\n"));
   stream->print(F("#TYPE esphome_switch_failed gauge\n"));
 }
-void PrometheusHandler::switch_row_(AsyncResponseStream *stream, switch_::Switch *obj, std::string &area) {
+void PrometheusHandler::switch_row_(AsyncResponseStream *stream, switch_::Switch *obj, std::string &area,
+                                    std::string &node, std::string &friendly_name) {
   if (obj->is_internal() && !this->include_internal_)
     return;
   stream->print(F("esphome_switch_failed{id=\""));
   stream->print(relabel_id_(obj).c_str());
   add_area_label_(stream, area);
+  add_node_label_(stream, node);
+  add_friendly_name_label_(stream, friendly_name);
   stream->print(F("\",name=\""));
   stream->print(relabel_name_(obj).c_str());
   stream->print(F("\"} 0\n"));
@@ -356,6 +423,8 @@ void PrometheusHandler::switch_row_(AsyncResponseStream *stream, switch_::Switch
   stream->print(F("esphome_switch_value{id=\""));
   stream->print(relabel_id_(obj).c_str());
   add_area_label_(stream, area);
+  add_node_label_(stream, node);
+  add_friendly_name_label_(stream, friendly_name);
   stream->print(F("\",name=\""));
   stream->print(relabel_name_(obj).c_str());
   stream->print(F("\"} "));
@@ -369,12 +438,15 @@ void PrometheusHandler::lock_type_(AsyncResponseStream *stream) {
   stream->print(F("#TYPE esphome_lock_value gauge\n"));
   stream->print(F("#TYPE esphome_lock_failed gauge\n"));
 }
-void PrometheusHandler::lock_row_(AsyncResponseStream *stream, lock::Lock *obj, std::string &area) {
+void PrometheusHandler::lock_row_(AsyncResponseStream *stream, lock::Lock *obj, std::string &area, std::string &node,
+                                  std::string &friendly_name) {
   if (obj->is_internal() && !this->include_internal_)
     return;
   stream->print(F("esphome_lock_failed{id=\""));
   stream->print(relabel_id_(obj).c_str());
   add_area_label_(stream, area);
+  add_node_label_(stream, node);
+  add_friendly_name_label_(stream, friendly_name);
   stream->print(F("\",name=\""));
   stream->print(relabel_name_(obj).c_str());
   stream->print(F("\"} 0\n"));
@@ -382,6 +454,8 @@ void PrometheusHandler::lock_row_(AsyncResponseStream *stream, lock::Lock *obj, 
   stream->print(F("esphome_lock_value{id=\""));
   stream->print(relabel_id_(obj).c_str());
   add_area_label_(stream, area);
+  add_node_label_(stream, node);
+  add_friendly_name_label_(stream, friendly_name);
   stream->print(F("\",name=\""));
   stream->print(relabel_name_(obj).c_str());
   stream->print(F("\"} "));
@@ -396,7 +470,8 @@ void PrometheusHandler::text_sensor_type_(AsyncResponseStream *stream) {
   stream->print(F("#TYPE esphome_text_sensor_value gauge\n"));
   stream->print(F("#TYPE esphome_text_sensor_failed gauge\n"));
 }
-void PrometheusHandler::text_sensor_row_(AsyncResponseStream *stream, text_sensor::TextSensor *obj, std::string &area) {
+void PrometheusHandler::text_sensor_row_(AsyncResponseStream *stream, text_sensor::TextSensor *obj, std::string &area,
+                                         std::string &node, std::string &friendly_name) {
   if (obj->is_internal() && !this->include_internal_)
     return;
   if (obj->has_state()) {
@@ -404,6 +479,8 @@ void PrometheusHandler::text_sensor_row_(AsyncResponseStream *stream, text_senso
     stream->print(F("esphome_text_sensor_failed{id=\""));
     stream->print(relabel_id_(obj).c_str());
     add_area_label_(stream, area);
+    add_node_label_(stream, node);
+    add_friendly_name_label_(stream, friendly_name);
     stream->print(F("\",name=\""));
     stream->print(relabel_name_(obj).c_str());
     stream->print(F("\"} 0\n"));
@@ -411,6 +488,8 @@ void PrometheusHandler::text_sensor_row_(AsyncResponseStream *stream, text_senso
     stream->print(F("esphome_text_sensor_value{id=\""));
     stream->print(relabel_id_(obj).c_str());
     add_area_label_(stream, area);
+    add_node_label_(stream, node);
+    add_friendly_name_label_(stream, friendly_name);
     stream->print(F("\",name=\""));
     stream->print(relabel_name_(obj).c_str());
     stream->print(F("\",value=\""));
@@ -423,6 +502,8 @@ void PrometheusHandler::text_sensor_row_(AsyncResponseStream *stream, text_senso
     stream->print(F("esphome_text_sensor_failed{id=\""));
     stream->print(relabel_id_(obj).c_str());
     add_area_label_(stream, area);
+    add_node_label_(stream, node);
+    add_friendly_name_label_(stream, friendly_name);
     stream->print(F("\",name=\""));
     stream->print(relabel_name_(obj).c_str());
     stream->print(F("\"} 1\n"));

--- a/esphome/components/prometheus/prometheus_handler.cpp
+++ b/esphome/components/prometheus/prometheus_handler.cpp
@@ -90,14 +90,14 @@ void PrometheusHandler::sensor_row_(AsyncResponseStream *stream, sensor::Sensor 
     // We have a valid value, output this value
     stream->print(F("esphome_sensor_failed{id=\""));
     stream->print(relabel_id_(obj).c_str());
-    add_area_label_(area);
+    add_area_label_(stream, area);
     stream->print(F("\",name=\""));
     stream->print(relabel_name_(obj).c_str());
     stream->print(F("\"} 0\n"));
     // Data itself
     stream->print(F("esphome_sensor_value{id=\""));
     stream->print(relabel_id_(obj).c_str());
-    add_area_label_(area);
+    add_area_label_(stream, area);
     stream->print(F("\",name=\""));
     stream->print(relabel_name_(obj).c_str());
     stream->print(F("\",unit=\""));
@@ -109,7 +109,7 @@ void PrometheusHandler::sensor_row_(AsyncResponseStream *stream, sensor::Sensor 
     // Invalid state
     stream->print(F("esphome_sensor_failed{id=\""));
     stream->print(relabel_id_(obj).c_str());
-    add_area_label_(area);
+    add_area_label_(stream, area);
     stream->print(F("\",name=\""));
     stream->print(relabel_name_(obj).c_str());
     stream->print(F("\"} 1\n"));
@@ -131,14 +131,14 @@ void PrometheusHandler::binary_sensor_row_(AsyncResponseStream *stream, binary_s
     // We have a valid value, output this value
     stream->print(F("esphome_binary_sensor_failed{id=\""));
     stream->print(relabel_id_(obj).c_str());
-    add_area_label_(area);
+    add_area_label_(stream, area);
     stream->print(F("\",name=\""));
     stream->print(relabel_name_(obj).c_str());
     stream->print(F("\"} 0\n"));
     // Data itself
     stream->print(F("esphome_binary_sensor_value{id=\""));
     stream->print(relabel_id_(obj).c_str());
-    add_area_label_(area);
+    add_area_label_(stream, area);
     stream->print(F("\",name=\""));
     stream->print(relabel_name_(obj).c_str());
     stream->print(F("\"} "));
@@ -148,7 +148,7 @@ void PrometheusHandler::binary_sensor_row_(AsyncResponseStream *stream, binary_s
     // Invalid state
     stream->print(F("esphome_binary_sensor_failed{id=\""));
     stream->print(relabel_id_(obj).c_str());
-    add_area_label_(area);
+    add_area_label_(stream, area);
     stream->print(F("\",name=\""));
     stream->print(relabel_name_(obj).c_str());
     stream->print(F("\"} 1\n"));
@@ -168,14 +168,14 @@ void PrometheusHandler::fan_row_(AsyncResponseStream *stream, fan::Fan *obj, std
     return;
   stream->print(F("esphome_fan_failed{id=\""));
   stream->print(relabel_id_(obj).c_str());
-  add_area_label_(area);
+  add_area_label_(stream, area);
   stream->print(F("\",name=\""));
   stream->print(relabel_name_(obj).c_str());
   stream->print(F("\"} 0\n"));
   // Data itself
   stream->print(F("esphome_fan_value{id=\""));
   stream->print(relabel_id_(obj).c_str());
-  add_area_label_(area);
+  add_area_label_(stream, area);
   stream->print(F("\",name=\""));
   stream->print(relabel_name_(obj).c_str());
   stream->print(F("\"} "));
@@ -185,7 +185,7 @@ void PrometheusHandler::fan_row_(AsyncResponseStream *stream, fan::Fan *obj, std
   if (obj->get_traits().supports_speed()) {
     stream->print(F("esphome_fan_speed{id=\""));
     stream->print(relabel_id_(obj).c_str());
-    add_area_label_(area);
+    add_area_label_(stream, area);
     stream->print(F("\",name=\""));
     stream->print(relabel_name_(obj).c_str());
     stream->print(F("\"} "));
@@ -196,7 +196,7 @@ void PrometheusHandler::fan_row_(AsyncResponseStream *stream, fan::Fan *obj, std
   if (obj->get_traits().supports_oscillation()) {
     stream->print(F("esphome_fan_oscillation{id=\""));
     stream->print(relabel_id_(obj).c_str());
-    add_area_label_(area);
+    add_area_label_(stream, area);
     stream->print(F("\",name=\""));
     stream->print(relabel_name_(obj).c_str());
     stream->print(F("\"} "));
@@ -218,7 +218,7 @@ void PrometheusHandler::light_row_(AsyncResponseStream *stream, light::LightStat
   // State
   stream->print(F("esphome_light_state{id=\""));
   stream->print(relabel_id_(obj).c_str());
-  add_area_label_(area);
+  add_area_label_(stream, area);
   stream->print(F("\",name=\""));
   stream->print(relabel_name_(obj).c_str());
   stream->print(F("\"} "));
@@ -231,7 +231,7 @@ void PrometheusHandler::light_row_(AsyncResponseStream *stream, light::LightStat
   color.as_rgbw(&r, &g, &b, &w);
   stream->print(F("esphome_light_color{id=\""));
   stream->print(relabel_id_(obj).c_str());
-  add_area_label_(area);
+  add_area_label_(stream, area);
   stream->print(F("\",name=\""));
   stream->print(relabel_name_(obj).c_str());
   stream->print(F("\",channel=\"brightness\"} "));
@@ -239,7 +239,7 @@ void PrometheusHandler::light_row_(AsyncResponseStream *stream, light::LightStat
   stream->print(F("\n"));
   stream->print(F("esphome_light_color{id=\""));
   stream->print(relabel_id_(obj).c_str());
-  add_area_label_(area);
+  add_area_label_(stream, area);
   stream->print(F("\",name=\""));
   stream->print(relabel_name_(obj).c_str());
   stream->print(F("\",channel=\"r\"} "));
@@ -247,7 +247,7 @@ void PrometheusHandler::light_row_(AsyncResponseStream *stream, light::LightStat
   stream->print(F("\n"));
   stream->print(F("esphome_light_color{id=\""));
   stream->print(relabel_id_(obj).c_str());
-  add_area_label_(area);
+  add_area_label_(stream, area);
   stream->print(F("\",name=\""));
   stream->print(relabel_name_(obj).c_str());
   stream->print(F("\",channel=\"g\"} "));
@@ -255,7 +255,7 @@ void PrometheusHandler::light_row_(AsyncResponseStream *stream, light::LightStat
   stream->print(F("\n"));
   stream->print(F("esphome_light_color{id=\""));
   stream->print(relabel_id_(obj).c_str());
-  add_area_label_(area);
+  add_area_label_(stream, area);
   stream->print(F("\",name=\""));
   stream->print(relabel_name_(obj).c_str());
   stream->print(F("\",channel=\"b\"} "));
@@ -263,7 +263,7 @@ void PrometheusHandler::light_row_(AsyncResponseStream *stream, light::LightStat
   stream->print(F("\n"));
   stream->print(F("esphome_light_color{id=\""));
   stream->print(relabel_id_(obj).c_str());
-  add_area_label_(area);
+  add_area_label_(stream, area);
   stream->print(F("\",name=\""));
   stream->print(relabel_name_(obj).c_str());
   stream->print(F("\",channel=\"w\"} "));
@@ -274,14 +274,14 @@ void PrometheusHandler::light_row_(AsyncResponseStream *stream, light::LightStat
   if (effect == "None") {
     stream->print(F("esphome_light_effect_active{id=\""));
     stream->print(relabel_id_(obj).c_str());
-    add_area_label_(area);
+    add_area_label_(stream, area);
     stream->print(F("\",name=\""));
     stream->print(relabel_name_(obj).c_str());
     stream->print(F("\",effect=\"None\"} 0\n"));
   } else {
     stream->print(F("esphome_light_effect_active{id=\""));
     stream->print(relabel_id_(obj).c_str());
-    add_area_label_(area);
+    add_area_label_(stream, area);
     stream->print(F("\",name=\""));
     stream->print(relabel_name_(obj).c_str());
     stream->print(F("\",effect=\""));
@@ -303,14 +303,14 @@ void PrometheusHandler::cover_row_(AsyncResponseStream *stream, cover::Cover *ob
     // We have a valid value, output this value
     stream->print(F("esphome_cover_failed{id=\""));
     stream->print(relabel_id_(obj).c_str());
-    add_area_label_(area);
+    add_area_label_(stream, area);
     stream->print(F("\",name=\""));
     stream->print(relabel_name_(obj).c_str());
     stream->print(F("\"} 0\n"));
     // Data itself
     stream->print(F("esphome_cover_value{id=\""));
     stream->print(relabel_id_(obj).c_str());
-    add_area_label_(area);
+    add_area_label_(stream, area);
     stream->print(F("\",name=\""));
     stream->print(relabel_name_(obj).c_str());
     stream->print(F("\"} "));
@@ -319,7 +319,7 @@ void PrometheusHandler::cover_row_(AsyncResponseStream *stream, cover::Cover *ob
     if (obj->get_traits().get_supports_tilt()) {
       stream->print(F("esphome_cover_tilt{id=\""));
       stream->print(relabel_id_(obj).c_str());
-      add_area_label_(area);
+      add_area_label_(stream, area);
       stream->print(F("\",name=\""));
       stream->print(relabel_name_(obj).c_str());
       stream->print(F("\"} "));
@@ -330,7 +330,7 @@ void PrometheusHandler::cover_row_(AsyncResponseStream *stream, cover::Cover *ob
     // Invalid state
     stream->print(F("esphome_cover_failed{id=\""));
     stream->print(relabel_id_(obj).c_str());
-    add_area_label_(area);
+    add_area_label_(stream, area);
     stream->print(F("\",name=\""));
     stream->print(relabel_name_(obj).c_str());
     stream->print(F("\"} 1\n"));
@@ -348,14 +348,14 @@ void PrometheusHandler::switch_row_(AsyncResponseStream *stream, switch_::Switch
     return;
   stream->print(F("esphome_switch_failed{id=\""));
   stream->print(relabel_id_(obj).c_str());
-  add_area_label_(area);
+  add_area_label_(stream, area);
   stream->print(F("\",name=\""));
   stream->print(relabel_name_(obj).c_str());
   stream->print(F("\"} 0\n"));
   // Data itself
   stream->print(F("esphome_switch_value{id=\""));
   stream->print(relabel_id_(obj).c_str());
-  add_area_label_(area);
+  add_area_label_(stream, area);
   stream->print(F("\",name=\""));
   stream->print(relabel_name_(obj).c_str());
   stream->print(F("\"} "));
@@ -374,14 +374,14 @@ void PrometheusHandler::lock_row_(AsyncResponseStream *stream, lock::Lock *obj, 
     return;
   stream->print(F("esphome_lock_failed{id=\""));
   stream->print(relabel_id_(obj).c_str());
-  add_area_label_(area);
+  add_area_label_(stream, area);
   stream->print(F("\",name=\""));
   stream->print(relabel_name_(obj).c_str());
   stream->print(F("\"} 0\n"));
   // Data itself
   stream->print(F("esphome_lock_value{id=\""));
   stream->print(relabel_id_(obj).c_str());
-  add_area_label_(area);
+  add_area_label_(stream, area);
   stream->print(F("\",name=\""));
   stream->print(relabel_name_(obj).c_str());
   stream->print(F("\"} "));
@@ -403,14 +403,14 @@ void PrometheusHandler::text_sensor_row_(AsyncResponseStream *stream, text_senso
     // We have a valid value, output this value
     stream->print(F("esphome_text_sensor_failed{id=\""));
     stream->print(relabel_id_(obj).c_str());
-    add_area_label_(area);
+    add_area_label_(stream, area);
     stream->print(F("\",name=\""));
     stream->print(relabel_name_(obj).c_str());
     stream->print(F("\"} 0\n"));
     // Data itself
     stream->print(F("esphome_text_sensor_value{id=\""));
     stream->print(relabel_id_(obj).c_str());
-    add_area_label_(area);
+    add_area_label_(stream, area);
     stream->print(F("\",name=\""));
     stream->print(relabel_name_(obj).c_str());
     stream->print(F("\",value=\""));
@@ -422,7 +422,7 @@ void PrometheusHandler::text_sensor_row_(AsyncResponseStream *stream, text_senso
     // Invalid state
     stream->print(F("esphome_text_sensor_failed{id=\""));
     stream->print(relabel_id_(obj).c_str());
-    add_area_label_(area);
+    add_area_label_(stream, area);
     stream->print(F("\",name=\""));
     stream->print(relabel_name_(obj).c_str());
     stream->print(F("\"} 1\n"));

--- a/esphome/components/prometheus/prometheus_handler.cpp
+++ b/esphome/components/prometheus/prometheus_handler.cpp
@@ -7,53 +7,54 @@ namespace prometheus {
 
 void PrometheusHandler::handleRequest(AsyncWebServerRequest *req) {
   AsyncResponseStream *stream = req->beginResponseStream("text/plain; version=0.0.4; charset=utf-8");
+  std::string area = App.get_area();
 
 #ifdef USE_SENSOR
   this->sensor_type_(stream);
   for (auto *obj : App.get_sensors())
-    this->sensor_row_(stream, obj);
+    this->sensor_row_(stream, obj, area);
 #endif
 
 #ifdef USE_BINARY_SENSOR
   this->binary_sensor_type_(stream);
   for (auto *obj : App.get_binary_sensors())
-    this->binary_sensor_row_(stream, obj);
+    this->binary_sensor_row_(stream, obj, area);
 #endif
 
 #ifdef USE_FAN
   this->fan_type_(stream);
   for (auto *obj : App.get_fans())
-    this->fan_row_(stream, obj);
+    this->fan_row_(stream, obj, area);
 #endif
 
 #ifdef USE_LIGHT
   this->light_type_(stream);
   for (auto *obj : App.get_lights())
-    this->light_row_(stream, obj);
+    this->light_row_(stream, obj, area);
 #endif
 
 #ifdef USE_COVER
   this->cover_type_(stream);
   for (auto *obj : App.get_covers())
-    this->cover_row_(stream, obj);
+    this->cover_row_(stream, obj, area);
 #endif
 
 #ifdef USE_SWITCH
   this->switch_type_(stream);
-  for (auto *obj : App.get_switches())
+  for (auto *obj : App.get_switches(), area)
     this->switch_row_(stream, obj);
 #endif
 
 #ifdef USE_LOCK
   this->lock_type_(stream);
-  for (auto *obj : App.get_locks())
+  for (auto *obj : App.get_locks(), area)
     this->lock_row_(stream, obj);
 #endif
 
 #ifdef USE_TEXT_SENSOR
   this->text_sensor_type_(stream);
   for (auto *obj : App.get_text_sensors())
-    this->text_sensor_row_(stream, obj);
+    this->text_sensor_row_(stream, obj, area);
 #endif
 
   req->send(stream);
@@ -75,7 +76,7 @@ void PrometheusHandler::sensor_type_(AsyncResponseStream *stream) {
   stream->print(F("#TYPE esphome_sensor_value gauge\n"));
   stream->print(F("#TYPE esphome_sensor_failed gauge\n"));
 }
-void PrometheusHandler::sensor_row_(AsyncResponseStream *stream, sensor::Sensor *obj) {
+void PrometheusHandler::sensor_row_(AsyncResponseStream *stream, sensor::Sensor *obj, std::string &area) {
   if (obj->is_internal() && !this->include_internal_)
     return;
   if (!std::isnan(obj->state)) {
@@ -84,7 +85,8 @@ void PrometheusHandler::sensor_row_(AsyncResponseStream *stream, sensor::Sensor 
     stream->print(relabel_id_(obj).c_str());
     stream->print(F("\",name=\""));
     stream->print(relabel_name_(obj).c_str());
-    stream->print(F("\"} 0\n"));
+    if stream
+      ->print(F("\"} 0\n"));
     // Data itself
     stream->print(F("esphome_sensor_value{id=\""));
     stream->print(relabel_id_(obj).c_str());
@@ -112,7 +114,8 @@ void PrometheusHandler::binary_sensor_type_(AsyncResponseStream *stream) {
   stream->print(F("#TYPE esphome_binary_sensor_value gauge\n"));
   stream->print(F("#TYPE esphome_binary_sensor_failed gauge\n"));
 }
-void PrometheusHandler::binary_sensor_row_(AsyncResponseStream *stream, binary_sensor::BinarySensor *obj) {
+void PrometheusHandler::binary_sensor_row_(AsyncResponseStream *stream, binary_sensor::BinarySensor *obj,
+                                           std::string &area) {
   if (obj->is_internal() && !this->include_internal_)
     return;
   if (obj->has_state()) {
@@ -148,7 +151,7 @@ void PrometheusHandler::fan_type_(AsyncResponseStream *stream) {
   stream->print(F("#TYPE esphome_fan_speed gauge\n"));
   stream->print(F("#TYPE esphome_fan_oscillation gauge\n"));
 }
-void PrometheusHandler::fan_row_(AsyncResponseStream *stream, fan::Fan *obj) {
+void PrometheusHandler::fan_row_(AsyncResponseStream *stream, fan::Fan *obj, std::string &area) {
   if (obj->is_internal() && !this->include_internal_)
     return;
   stream->print(F("esphome_fan_failed{id=\""));
@@ -193,7 +196,7 @@ void PrometheusHandler::light_type_(AsyncResponseStream *stream) {
   stream->print(F("#TYPE esphome_light_color gauge\n"));
   stream->print(F("#TYPE esphome_light_effect_active gauge\n"));
 }
-void PrometheusHandler::light_row_(AsyncResponseStream *stream, light::LightState *obj) {
+void PrometheusHandler::light_row_(AsyncResponseStream *stream, light::LightState *obj, std::string &area) {
   if (obj->is_internal() && !this->include_internal_)
     return;
   // State
@@ -269,7 +272,7 @@ void PrometheusHandler::cover_type_(AsyncResponseStream *stream) {
   stream->print(F("#TYPE esphome_cover_value gauge\n"));
   stream->print(F("#TYPE esphome_cover_failed gauge\n"));
 }
-void PrometheusHandler::cover_row_(AsyncResponseStream *stream, cover::Cover *obj) {
+void PrometheusHandler::cover_row_(AsyncResponseStream *stream, cover::Cover *obj, std::string &area) {
   if (obj->is_internal() && !this->include_internal_)
     return;
   if (!std::isnan(obj->position)) {
@@ -312,7 +315,7 @@ void PrometheusHandler::switch_type_(AsyncResponseStream *stream) {
   stream->print(F("#TYPE esphome_switch_value gauge\n"));
   stream->print(F("#TYPE esphome_switch_failed gauge\n"));
 }
-void PrometheusHandler::switch_row_(AsyncResponseStream *stream, switch_::Switch *obj) {
+void PrometheusHandler::switch_row_(AsyncResponseStream *stream, switch_::Switch *obj, std::string &area) {
   if (obj->is_internal() && !this->include_internal_)
     return;
   stream->print(F("esphome_switch_failed{id=\""));
@@ -336,7 +339,7 @@ void PrometheusHandler::lock_type_(AsyncResponseStream *stream) {
   stream->print(F("#TYPE esphome_lock_value gauge\n"));
   stream->print(F("#TYPE esphome_lock_failed gauge\n"));
 }
-void PrometheusHandler::lock_row_(AsyncResponseStream *stream, lock::Lock *obj) {
+void PrometheusHandler::lock_row_(AsyncResponseStream *stream, lock::Lock *obj, std::string &area) {
   if (obj->is_internal() && !this->include_internal_)
     return;
   stream->print(F("esphome_lock_failed{id=\""));
@@ -361,7 +364,7 @@ void PrometheusHandler::text_sensor_type_(AsyncResponseStream *stream) {
   stream->print(F("#TYPE esphome_text_sensor_value gauge\n"));
   stream->print(F("#TYPE esphome_text_sensor_failed gauge\n"));
 }
-void PrometheusHandler::text_sensor_row_(AsyncResponseStream *stream, text_sensor::TextSensor *obj) {
+void PrometheusHandler::text_sensor_row_(AsyncResponseStream *stream, text_sensor::TextSensor *obj, std::string &area) {
   if (obj->is_internal() && !this->include_internal_)
     return;
   if (obj->has_state()) {

--- a/esphome/components/prometheus/prometheus_handler.cpp
+++ b/esphome/components/prometheus/prometheus_handler.cpp
@@ -72,7 +72,7 @@ std::string PrometheusHandler::relabel_name_(EntityBase *obj) {
   return item == relabel_map_name_.end() ? obj->get_name() : item->second;
 }
 
-void PrometheusHandler::add_area_label_(AsyncResponseStream *stream, std::string &area, std::string &node) {
+void PrometheusHandler::add_area_label_(AsyncResponseStream *stream, std::string &area) {
   if (!area.empty()) {
     stream->print(F("\",area=\""));
     stream->print(area.c_str());

--- a/esphome/components/prometheus/prometheus_handler.cpp
+++ b/esphome/components/prometheus/prometheus_handler.cpp
@@ -43,14 +43,14 @@ void PrometheusHandler::handleRequest(AsyncWebServerRequest *req) {
 
 #ifdef USE_SWITCH
   this->switch_type_(stream);
-  for (auto *obj : App.get_switches(), area, node, friendly_name)
-    this->switch_row_(stream, obj);
+  for (auto *obj : App.get_switches())
+    this->switch_row_(stream, obj, area, node, friendly_name);
 #endif
 
 #ifdef USE_LOCK
   this->lock_type_(stream);
-  for (auto *obj : App.get_locks(), area, node, friendly_name)
-    this->lock_row_(stream, obj);
+  for (auto *obj : App.get_locks())
+    this->lock_row_(stream, obj, area, node, friendly_name);
 #endif
 
 #ifdef USE_TEXT_SENSOR

--- a/esphome/components/prometheus/prometheus_handler.h
+++ b/esphome/components/prometheus/prometheus_handler.h
@@ -60,6 +60,7 @@ class PrometheusHandler : public AsyncWebHandler, public Component {
  protected:
   std::string relabel_id_(EntityBase *obj);
   std::string relabel_name_(EntityBase *obj);
+  void add_area_label_(AsyncResponseStream *stream, std::string &area);
 
 #ifdef USE_SENSOR
   /// Return the type for prometheus

--- a/esphome/components/prometheus/prometheus_handler.h
+++ b/esphome/components/prometheus/prometheus_handler.h
@@ -65,56 +65,56 @@ class PrometheusHandler : public AsyncWebHandler, public Component {
   /// Return the type for prometheus
   void sensor_type_(AsyncResponseStream *stream);
   /// Return the sensor state as prometheus data point
-  void sensor_row_(AsyncResponseStream *stream, sensor::Sensor *obj);
+  void sensor_row_(AsyncResponseStream *stream, sensor::Sensor *obj, std::string &area);
 #endif
 
 #ifdef USE_BINARY_SENSOR
   /// Return the type for prometheus
   void binary_sensor_type_(AsyncResponseStream *stream);
   /// Return the sensor state as prometheus data point
-  void binary_sensor_row_(AsyncResponseStream *stream, binary_sensor::BinarySensor *obj);
+  void binary_sensor_row_(AsyncResponseStream *stream, binary_sensor::BinarySensor *obj, std::string &area);
 #endif
 
 #ifdef USE_FAN
   /// Return the type for prometheus
   void fan_type_(AsyncResponseStream *stream);
   /// Return the sensor state as prometheus data point
-  void fan_row_(AsyncResponseStream *stream, fan::Fan *obj);
+  void fan_row_(AsyncResponseStream *stream, fan::Fan *obj, std::string &area);
 #endif
 
 #ifdef USE_LIGHT
   /// Return the type for prometheus
   void light_type_(AsyncResponseStream *stream);
   /// Return the Light Values state as prometheus data point
-  void light_row_(AsyncResponseStream *stream, light::LightState *obj);
+  void light_row_(AsyncResponseStream *stream, light::LightState *obj, std::string &area);
 #endif
 
 #ifdef USE_COVER
   /// Return the type for prometheus
   void cover_type_(AsyncResponseStream *stream);
   /// Return the switch Values state as prometheus data point
-  void cover_row_(AsyncResponseStream *stream, cover::Cover *obj);
+  void cover_row_(AsyncResponseStream *stream, cover::Cover *obj, std::string &area);
 #endif
 
 #ifdef USE_SWITCH
   /// Return the type for prometheus
   void switch_type_(AsyncResponseStream *stream);
   /// Return the switch Values state as prometheus data point
-  void switch_row_(AsyncResponseStream *stream, switch_::Switch *obj);
+  void switch_row_(AsyncResponseStream *stream, switch_::Switch *obj, std::string &area);
 #endif
 
 #ifdef USE_LOCK
   /// Return the type for prometheus
   void lock_type_(AsyncResponseStream *stream);
   /// Return the lock Values state as prometheus data point
-  void lock_row_(AsyncResponseStream *stream, lock::Lock *obj);
+  void lock_row_(AsyncResponseStream *stream, lock::Lock *obj, std::string &area);
 #endif
 
 #ifdef USE_TEXT_SENSOR
   /// Return the type for prometheus
   void text_sensor_type_(AsyncResponseStream *stream);
   /// Return the lock Values state as prometheus data point
-  void text_sensor_row_(AsyncResponseStream *stream, text_sensor::TextSensor *obj);
+  void text_sensor_row_(AsyncResponseStream *stream, text_sensor::TextSensor *obj, std::string &area);
 #endif
 
   web_server_base::WebServerBase *base_;

--- a/esphome/components/prometheus/prometheus_handler.h
+++ b/esphome/components/prometheus/prometheus_handler.h
@@ -61,61 +61,71 @@ class PrometheusHandler : public AsyncWebHandler, public Component {
   std::string relabel_id_(EntityBase *obj);
   std::string relabel_name_(EntityBase *obj);
   void add_area_label_(AsyncResponseStream *stream, std::string &area);
+  void add_node_label_(AsyncResponseStream *stream, std::string &name);
+  void add_friendly_name_label_(AsyncResponseStream *stream, std::string &friendly_name);
 
 #ifdef USE_SENSOR
   /// Return the type for prometheus
   void sensor_type_(AsyncResponseStream *stream);
   /// Return the sensor state as prometheus data point
-  void sensor_row_(AsyncResponseStream *stream, sensor::Sensor *obj, std::string &area);
+  void sensor_row_(AsyncResponseStream *stream, sensor::Sensor *obj, std::string &area, std::string &node,
+                   std::string &friendly_name);
 #endif
 
 #ifdef USE_BINARY_SENSOR
   /// Return the type for prometheus
   void binary_sensor_type_(AsyncResponseStream *stream);
   /// Return the sensor state as prometheus data point
-  void binary_sensor_row_(AsyncResponseStream *stream, binary_sensor::BinarySensor *obj, std::string &area);
+  void binary_sensor_row_(AsyncResponseStream *stream, binary_sensor::BinarySensor *obj, std::string &area,
+                          std::string &node, std::string &friendly_name);
 #endif
 
 #ifdef USE_FAN
   /// Return the type for prometheus
   void fan_type_(AsyncResponseStream *stream);
   /// Return the sensor state as prometheus data point
-  void fan_row_(AsyncResponseStream *stream, fan::Fan *obj, std::string &area);
+  void fan_row_(AsyncResponseStream *stream, fan::Fan *obj, std::string &area, std::string &node,
+                std::string &friendly_name);
 #endif
 
 #ifdef USE_LIGHT
   /// Return the type for prometheus
   void light_type_(AsyncResponseStream *stream);
   /// Return the Light Values state as prometheus data point
-  void light_row_(AsyncResponseStream *stream, light::LightState *obj, std::string &area);
+  void light_row_(AsyncResponseStream *stream, light::LightState *obj, std::string &area, std::string &node,
+                  std::string &friendly_name);
 #endif
 
 #ifdef USE_COVER
   /// Return the type for prometheus
   void cover_type_(AsyncResponseStream *stream);
   /// Return the switch Values state as prometheus data point
-  void cover_row_(AsyncResponseStream *stream, cover::Cover *obj, std::string &area);
+  void cover_row_(AsyncResponseStream *stream, cover::Cover *obj, std::string &area, std::string &node,
+                  std::string &friendly_name);
 #endif
 
 #ifdef USE_SWITCH
   /// Return the type for prometheus
   void switch_type_(AsyncResponseStream *stream);
   /// Return the switch Values state as prometheus data point
-  void switch_row_(AsyncResponseStream *stream, switch_::Switch *obj, std::string &area);
+  void switch_row_(AsyncResponseStream *stream, switch_::Switch *obj, std::string &area, std::string &node,
+                   std::string &friendly_name);
 #endif
 
 #ifdef USE_LOCK
   /// Return the type for prometheus
   void lock_type_(AsyncResponseStream *stream);
   /// Return the lock Values state as prometheus data point
-  void lock_row_(AsyncResponseStream *stream, lock::Lock *obj, std::string &area);
+  void lock_row_(AsyncResponseStream *stream, lock::Lock *obj, std::string &area, std::string &node,
+                 std::string &friendly_name);
 #endif
 
 #ifdef USE_TEXT_SENSOR
   /// Return the type for prometheus
   void text_sensor_type_(AsyncResponseStream *stream);
   /// Return the lock Values state as prometheus data point
-  void text_sensor_row_(AsyncResponseStream *stream, text_sensor::TextSensor *obj, std::string &area);
+  void text_sensor_row_(AsyncResponseStream *stream, text_sensor::TextSensor *obj, std::string &area, std::string &node,
+                        std::string &friendly_name);
 #endif
 
   web_server_base::WebServerBase *base_;

--- a/esphome/components/prometheus/prometheus_handler.h
+++ b/esphome/components/prometheus/prometheus_handler.h
@@ -61,7 +61,7 @@ class PrometheusHandler : public AsyncWebHandler, public Component {
   std::string relabel_id_(EntityBase *obj);
   std::string relabel_name_(EntityBase *obj);
   void add_area_label_(AsyncResponseStream *stream, std::string &area);
-  void add_node_label_(AsyncResponseStream *stream, std::string &name);
+  void add_node_label_(AsyncResponseStream *stream, std::string &node);
   void add_friendly_name_label_(AsyncResponseStream *stream, std::string &friendly_name);
 
 #ifdef USE_SENSOR

--- a/tests/components/prometheus/common.yaml
+++ b/tests/components/prometheus/common.yaml
@@ -64,6 +64,16 @@ cover:
         return COVER_CLOSED;
       }
 
+lock:
+  - platform: template
+    id: template_lock1
+    lambda: |-
+      if (millis() > 10000) {
+        return LOCK_STATE_LOCKED;
+      } else {
+        return LOCK_STATE_UNLOCKED;
+      }
+
 prometheus:
   include_internal: true
   relabel:

--- a/tests/components/prometheus/common.yaml
+++ b/tests/components/prometheus/common.yaml
@@ -63,7 +63,6 @@ cover:
       } else {
         return COVER_CLOSED;
       }
-    update_interval: 60s
 
 prometheus:
   include_internal: true

--- a/tests/components/prometheus/common.yaml
+++ b/tests/components/prometheus/common.yaml
@@ -29,6 +29,32 @@ text_sensor:
       }
     update_interval: 60s
 
+binary_sensor:
+  - platform: template
+    id: template_binary_sensor1
+    lambda: |-
+      if (millis() > 10000) {
+        return true;
+      } else {
+        return false;
+      }
+    update_interval: 60s
+
+switch:
+  - platform: template
+    id: template_switch1
+    lambda: |-
+      if (millis() > 10000) {
+        return true;
+      } else {
+        return false;
+      }
+    update_interval: 60s
+
+fan:
+  - platform: template
+    id: template_fan1
+
 prometheus:
   include_internal: true
   relabel:

--- a/tests/components/prometheus/common.yaml
+++ b/tests/components/prometheus/common.yaml
@@ -48,7 +48,6 @@ switch:
       } else {
         return false;
       }
-    update_interval: 60s
 
 fan:
   - platform: template

--- a/tests/components/prometheus/common.yaml
+++ b/tests/components/prometheus/common.yaml
@@ -19,6 +19,9 @@ sensor:
     update_interval: 60s
 
 text_sensor:
+  - platform: version
+    name: "ESPHome Version"
+    hide_timestamp: true
   - platform: template
     id: template_text_sensor1
     lambda: |-

--- a/tests/components/prometheus/common.yaml
+++ b/tests/components/prometheus/common.yaml
@@ -38,7 +38,6 @@ binary_sensor:
       } else {
         return false;
       }
-    update_interval: 60s
 
 switch:
   - platform: template

--- a/tests/components/prometheus/common.yaml
+++ b/tests/components/prometheus/common.yaml
@@ -73,6 +73,7 @@ lock:
       } else {
         return LOCK_STATE_UNLOCKED;
       }
+    optimistic: true
 
 prometheus:
   include_internal: true

--- a/tests/components/prometheus/common.yaml
+++ b/tests/components/prometheus/common.yaml
@@ -48,6 +48,7 @@ switch:
       } else {
         return false;
       }
+    optimistic: true
 
 fan:
   - platform: template

--- a/tests/components/prometheus/common.yaml
+++ b/tests/components/prometheus/common.yaml
@@ -55,6 +55,17 @@ fan:
   - platform: template
     id: template_fan1
 
+cover:
+  - platform: template
+    id: template_cover1
+    lambda: |-
+      if (millis() > 10000) {
+        return COVER_OPEN;
+      } else {
+        return COVER_CLOSED;
+      }
+    update_interval: 60s
+
 prometheus:
   include_internal: true
   relabel:

--- a/tests/components/prometheus/common.yaml
+++ b/tests/components/prometheus/common.yaml
@@ -1,3 +1,8 @@
+esphome:
+  name: livingroomdevice
+  friendly_name: Living Room Device
+  area: Living Room
+
 wifi:
   ssid: MySSID
   password: password1


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

I wanted a few more labels so I could sort by area or group metrics by device.

I also added a bunch more tests by adding a few more template components for the different prometheus metrics.

Here's an example

```
#TYPE esphome_binary_sensor_value gauge
#TYPE esphome_binary_sensor_failed gauge
esphome_binary_sensor_failed{id="dev_test_prometheus_goober_status",area="Dev",node="devtestprometheus",friendly_name="Dev Test Prometheus Goober",name="Dev Test Prometheus Goober Status"} 0
esphome_binary_sensor_value{id="dev_test_prometheus_goober_status",area="Dev",node="devtestprometheus",friendly_name="Dev Test Prometheus Goober",name="Dev Test Prometheus Goober Status"} 1
esphome_binary_sensor_failed{id="dev_test_prometheus_goober_button",area="Dev",node="devtestprometheus",friendly_name="Dev Test Prometheus Goober",name="Dev Test Prometheus Goober Button"} 0
esphome_binary_sensor_value{id="dev_test_prometheus_goober_button",area="Dev",node="devtestprometheus",friendly_name="Dev Test Prometheus Goober",name="Dev Test Prometheus Goober Button"} 0
#TYPE esphome_light_state gauge
#TYPE esphome_light_color gauge
#TYPE esphome_light_effect_active gauge
esphome_light_state{id="dev_test_prometheus_goober_light",area="Dev",node="devtestprometheus",friendly_name="Dev Test Prometheus Goober",name="Dev Test Prometheus Goober Light"} 0
esphome_light_color{id="dev_test_prometheus_goober_light",area="Dev",node="devtestprometheus",friendly_name="Dev Test Prometheus Goober",name="Dev Test Prometheus Goober Light",channel="brightness"} 0.00
esphome_light_color{id="dev_test_prometheus_goober_light",area="Dev",node="devtestprometheus",friendly_name="Dev Test Prometheus Goober",name="Dev Test Prometheus Goober Light",channel="r"} 0.00
esphome_light_color{id="dev_test_prometheus_goober_light",area="Dev",node="devtestprometheus",friendly_name="Dev Test Prometheus Goober",name="Dev Test Prometheus Goober Light",channel="g"} 0.00
esphome_light_color{id="dev_test_prometheus_goober_light",area="Dev",node="devtestprometheus",friendly_name="Dev Test Prometheus Goober",name="Dev Test Prometheus Goober Light",channel="b"} 0.00
esphome_light_color{id="dev_test_prometheus_goober_light",area="Dev",node="devtestprometheus",friendly_name="Dev Test Prometheus Goober",name="Dev Test Prometheus Goober Light",channel="w"} 0.00
esphome_light_effect_active{id="dev_test_prometheus_goober_light",area="Dev",node="devtestprometheus",friendly_name="Dev Test Prometheus Goober",name="Dev Test Prometheus Goober Light",effect="None"} 0
#TYPE esphome_text_sensor_value gauge
#TYPE esphome_text_sensor_failed gauge
esphome_text_sensor_failed{id="esphome_version_detailed",area="Dev",node="devtestprometheus",friendly_name="Dev Test Prometheus Goober",name="ESPHome Version Detailed"} 0
esphome_text_sensor_value{id="esphome_version_detailed",area="Dev",node="devtestprometheus",friendly_name="Dev Test Prometheus Goober",name="ESPHome Version Detailed",value="2024.10.1 Oct 28 2024, 22:51:56"} 1.0
```

If `area` or `friendly_name` is not set, then they will not be included. Whereas `node` will always be added going forward.

I'm open to changes or suggestions! Thanks for all of this so far. I really use it a lot!

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

prometheus:
  include_internal: true

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
