### PR TITLE
fix build error

### DIFF
--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -693,7 +693,7 @@ void get_mac_address_raw(uint8_t *mac) {  // NOLINT(readability-non-const-parame
 }
 #elif defined(USE_RP2040)
 void get_mac_address_raw(uint8_t *mac) {  // NOLINT(readability-non-const-parameter)
-#if USE_WIFI
+#ifdef USE_WIFI
   WiFi.macAddress(mac);
 #endif
 }

--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -691,9 +691,11 @@ void get_mac_address_raw(uint8_t *mac) {  // NOLINT(readability-non-const-parame
 void get_mac_address_raw(uint8_t *mac) {  // NOLINT(readability-non-const-parameter)
   wifi_get_macaddr(STATION_IF, mac);
 }
-#elif defined(USE_RP2040) && defined(USE_WIFI)
+#elif defined(USE_RP2040)
 void get_mac_address_raw(uint8_t *mac) {  // NOLINT(readability-non-const-parameter)
+#if USE_WIFI
   WiFi.macAddress(mac);
+#endif
 }
 #elif defined(USE_LIBRETINY)
 void get_mac_address_raw(uint8_t *mac) {  // NOLINT(readability-non-const-parameter)


### PR DESCRIPTION
# What does this implement/fix?

Fix bulid error after https://github.com/esphome/esphome/pull/7615. Previously it was implemented like this.

```
#else
// this should be an error, but that messes with CI checks. #error No mac address method defined
#endif
```

```
/home/runner/.platformio/packages/toolchain-rp2040-earlephilhower/bin/../lib/gcc/arm-none-eabi/12.3.0/../../../../arm-none-eabi/bin/ld: .pioenvs/componenttestrp2040ard/src/esphome/core/helpers.cpp.o: in function `_ZN7esphome15get_mac_addressB5cxx11Ev':
helpers.cpp:(.text._ZN7esphome15get_mac_addressB5cxx11Ev+0xa): undefined reference to `_ZN7esphome19get_mac_address_rawEPh'
collect2: error: ld returned 1 exit status
*** [.pioenvs/componenttestrp2040ard/firmware.elf] Error 1
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
