### PR TITLE
[http_request] Implement `on_error` trigger for requests

### DIFF
--- a/tests/components/http_request/common.yaml
+++ b/tests/components/http_request/common.yaml
@@ -12,6 +12,8 @@ esphome:
           url: https://esphome.io
           headers:
             Content-Type: application/json
+          on_error:
+            logger.log: "Request failed"
           on_response:
             then:
               - logger.log:


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/issues/issues/6010#issuecomment-2444532523

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#4401

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
    - http_request.get:
        url: "http://10.10.10.254/bad"
        capture_response: true
        on_error:
          - then:
              logger.log: "Http request failed"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
