### PR TITLE
[sdl] Allow window to be resized.

### DIFF
--- a/esphome/components/sdl/sdl_esphome.cpp
+++ b/esphome/components/sdl/sdl_esphome.cpp
@@ -9,8 +9,9 @@ void Sdl::setup() {
   ESP_LOGD(TAG, "Starting setup");
   SDL_Init(SDL_INIT_VIDEO);
   this->window_ = SDL_CreateWindow(App.get_name().c_str(), SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED,
-                                   this->width_, this->height_, 0);
+                                   this->width_, this->height_, SDL_WINDOW_RESIZABLE);
   this->renderer_ = SDL_CreateRenderer(this->window_, -1, SDL_RENDERER_SOFTWARE);
+  SDL_RenderSetLogicalSize(this->renderer_, this->width_, this->height_);
   this->texture_ =
       SDL_CreateTexture(this->renderer_, SDL_PIXELFORMAT_RGB565, SDL_TEXTUREACCESS_STATIC, this->width_, this->height_);
   SDL_SetTextureBlendMode(this->texture_, SDL_BLENDMODE_BLEND);
@@ -25,6 +26,10 @@ void Sdl::update() {
   this->y_low_ = this->height_;
   this->x_high_ = 0;
   this->y_high_ = 0;
+  this->redraw_(rect);
+}
+
+void Sdl::redraw_(SDL_Rect &rect) {
   SDL_RenderCopy(this->renderer_, this->texture_, &rect, &rect);
   SDL_RenderPresent(this->renderer_);
 }
@@ -33,15 +38,13 @@ void Sdl::draw_pixels_at(int x_start, int y_start, int w, int h, const uint8_t *
                          display::ColorBitness bitness, bool big_endian, int x_offset, int y_offset, int x_pad) {
   SDL_Rect rect{x_start, y_start, w, h};
   if (this->rotation_ != display::DISPLAY_ROTATION_0_DEGREES || bitness != display::COLOR_BITNESS_565 || big_endian) {
-    display::Display::draw_pixels_at(x_start, y_start, w, h, ptr, order, bitness, big_endian, x_offset, y_offset,
-                                     x_pad);
+    Display::draw_pixels_at(x_start, y_start, w, h, ptr, order, bitness, big_endian, x_offset, y_offset, x_pad);
   } else {
     auto stride = x_offset + w + x_pad;
     auto data = ptr + (stride * y_offset + x_offset) * 2;
     SDL_UpdateTexture(this->texture_, &rect, data, stride * 2);
   }
-  SDL_RenderCopy(this->renderer_, this->texture_, &rect, &rect);
-  SDL_RenderPresent(this->renderer_);
+  this->redraw_(rect);
 }
 
 void Sdl::draw_pixel_at(int x, int y, Color color) {
@@ -84,8 +87,22 @@ void Sdl::loop() {
         }
         break;
 
+      case SDL_WINDOWEVENT:
+        switch (e.window.event) {
+          case SDL_WINDOWEVENT_SIZE_CHANGED:
+          case SDL_WINDOWEVENT_EXPOSED:
+          case SDL_WINDOWEVENT_RESIZED: {
+            SDL_Rect rect{0, 0, this->width_, this->height_};
+            this->redraw_(rect);
+            break;
+          }
+          default:
+            break;
+        }
+        break;
+
       default:
-        ESP_LOGV(TAG, "Event %d", e.type);
+        ESP_LOGD(TAG, "Event %d", e.type);
         break;
     }
   }

--- a/esphome/components/sdl/sdl_esphome.cpp
+++ b/esphome/components/sdl/sdl_esphome.cpp
@@ -102,7 +102,7 @@ void Sdl::loop() {
         break;
 
       default:
-        ESP_LOGD(TAG, "Event %d", e.type);
+        ESP_LOGV(TAG, "Event %d", e.type);
         break;
     }
   }

--- a/esphome/components/sdl/sdl_esphome.h
+++ b/esphome/components/sdl/sdl_esphome.h
@@ -38,6 +38,7 @@ class Sdl : public display::Display {
  protected:
   int get_width_internal() override { return this->width_; }
   int get_height_internal() override { return this->height_; }
+  void redraw_(SDL_Rect &rect);
   int width_{};
   int height_{};
   SDL_Renderer *renderer_{};


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Allow the window to be resized, but maintain the logical size as defined in the yaml.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/feature-requests/issues/2925

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [x] host

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
