### PR TITLE
[CI] Fix webserver defines to be present based on platform, not just framework

### DIFF
--- a/esphome/core/defines.h
+++ b/esphome/core/defines.h
@@ -86,8 +86,6 @@
 #ifdef USE_ARDUINO
 #define USE_CAPTIVE_PORTAL
 #define USE_PROMETHEUS
-#define USE_WEBSERVER
-#define USE_WEBSERVER_PORT 80  // NOLINT
 #define USE_WIFI_WPA2_EAP
 #endif
 
@@ -111,6 +109,8 @@
 #define USE_SPEAKER
 #define USE_SPI
 #define USE_VOICE_ASSISTANT
+#define USE_WEBSERVER
+#define USE_WEBSERVER_PORT 80  // NOLINT
 #define USE_WIFI_11KV_SUPPORT
 
 #ifdef USE_ARDUINO
@@ -147,6 +147,8 @@
 #define USE_SHD_FIRMWARE_DATA \
   {}
 
+#define USE_WEBSERVER
+#define USE_WEBSERVER_PORT 80  // NOLINT
 #endif
 
 #ifdef USE_RP2040
@@ -158,6 +160,8 @@
 
 #ifdef USE_LIBRETINY
 #define USE_SOCKET_IMPL_LWIP_SOCKETS
+#define USE_WEBSERVER
+#define USE_WEBSERVER_PORT 80  // NOLINT
 #endif
 
 #ifdef USE_HOST


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
