### PR TITLE
[touchscreen] Calibration fixes

### DIFF
--- a/esphome/components/touchscreen/__init__.py
+++ b/esphome/components/touchscreen/__init__.py
@@ -60,25 +60,25 @@ def validate_calibration(calibration_config):
     return calibration_config
 
 
-def calibration_schema(default_max_values):
-    return cv.All(
-        cv.Schema(
-            {
-                cv.Optional(CONF_X_MIN, default=0): cv.int_range(min=0, max=4095),
-                cv.Optional(CONF_X_MAX, default=default_max_values): cv.int_range(
-                    min=0, max=4095
-                ),
-                cv.Optional(CONF_Y_MIN, default=0): cv.int_range(min=0, max=4095),
-                cv.Optional(CONF_Y_MAX, default=default_max_values): cv.int_range(
-                    min=0, max=4095
-                ),
-            }
-        ),
-        validate_calibration,
+CALIBRATION_SCHEMA = cv.All(
+    cv.Schema(
+        {
+            cv.Required(CONF_X_MIN): cv.int_range(min=0, max=4095),
+            cv.Required(CONF_X_MAX): cv.int_range(min=0, max=4095),
+            cv.Required(CONF_Y_MIN): cv.int_range(min=0, max=4095),
+            cv.Required(CONF_Y_MAX): cv.int_range(min=0, max=4095),
+        }
+    ),
+    validate_calibration,
+)
+
+
+def touchscreen_schema(default_touch_timeout=cv.UNDEFINED, calibration_required=False):
+    calibration = (
+        cv.Required(CONF_CALIBRATION)
+        if calibration_required
+        else cv.Optional(CONF_CALIBRATION)
     )
-
-
-def touchscreen_schema(default_touch_timeout):
     return cv.Schema(
         {
             cv.GenerateID(CONF_DISPLAY): cv.use_id(display.Display),
@@ -93,7 +93,7 @@ def touchscreen_schema(default_touch_timeout):
                 cv.positive_time_period_milliseconds,
                 cv.Range(max=cv.TimePeriod(milliseconds=65535)),
             ),
-            cv.Optional(CONF_CALIBRATION): calibration_schema(0),
+            calibration: CALIBRATION_SCHEMA,
             cv.Optional(CONF_ON_TOUCH): automation.validate_automation(single=True),
             cv.Optional(CONF_ON_UPDATE): automation.validate_automation(single=True),
             cv.Optional(CONF_ON_RELEASE): automation.validate_automation(single=True),

--- a/esphome/components/touchscreen/__init__.py
+++ b/esphome/components/touchscreen/__init__.py
@@ -1,21 +1,18 @@
-import esphome.config_validation as cv
-import esphome.codegen as cg
-
-from esphome.components import display
 from esphome import automation
-
+import esphome.codegen as cg
+from esphome.components import display
+import esphome.config_validation as cv
 from esphome.const import (
+    CONF_CALIBRATION,
     CONF_DISPLAY,
-    CONF_ON_TOUCH,
-    CONF_ON_RELEASE,
-    CONF_ON_UPDATE,
-    CONF_SWAP_XY,
     CONF_MIRROR_X,
     CONF_MIRROR_Y,
+    CONF_ON_RELEASE,
+    CONF_ON_TOUCH,
+    CONF_ON_UPDATE,
+    CONF_SWAP_XY,
     CONF_TRANSFORM,
-    CONF_CALIBRATION,
 )
-
 from esphome.core import coroutine_with_priority
 
 CODEOWNERS = ["@jesserockz", "@nielsnl68"]
@@ -43,46 +40,40 @@ CONF_Y_MIN = "y_min"
 CONF_Y_MAX = "y_max"
 
 
-def validate_calibration(config):
-    if CONF_CALIBRATION in config:
-        calibration_config = config[CONF_CALIBRATION]
-        if (
-            cv.int_([CONF_X_MIN]) != 0
-            and cv.int_(calibration_config[CONF_X_MAX]) != 0
-            and abs(
-                cv.int_(calibration_config[CONF_X_MIN])
-                - cv.int_(calibration_config[CONF_X_MAX])
-            )
-            < 10
-        ):
-            raise cv.Invalid("Calibration X values difference must be more than 10")
-
-        if (
-            cv.int_(calibration_config[CONF_Y_MIN]) != 0
-            and cv.int_(calibration_config[CONF_Y_MAX]) != 0
-            and abs(
-                cv.int_(calibration_config[CONF_Y_MIN])
-                - cv.int_(calibration_config[CONF_Y_MAX])
-            )
-            < 10
-        ):
-            raise cv.Invalid("Calibration Y values difference must be more than 10")
-
-    return config
+def validate_calibration(calibration_config):
+    x_min = calibration_config[CONF_X_MIN]
+    x_max = calibration_config[CONF_X_MAX]
+    y_min = calibration_config[CONF_Y_MIN]
+    y_max = calibration_config[CONF_Y_MAX]
+    if x_max < x_min:
+        raise cv.Invalid(
+            "x_min must be smaller than x_max. To mirror the direction use the 'transform' options"
+        )
+    if y_max < y_min:
+        raise cv.Invalid(
+            "y_min must be smaller than y_max. To mirror the direction use the 'transform' options"
+        )
+    x_delta = x_max - x_min
+    y_delta = y_max - y_min
+    if x_delta < 10 or y_delta < 10:
+        raise cv.Invalid("Calibration value range must be greater than 10")
+    return calibration_config
 
 
 def calibration_schema(default_max_values):
-    return cv.Schema(
-        {
-            cv.Optional(CONF_X_MIN, default=0): cv.int_range(min=0, max=4095),
-            cv.Optional(CONF_X_MAX, default=default_max_values): cv.int_range(
-                min=0, max=4095
-            ),
-            cv.Optional(CONF_Y_MIN, default=0): cv.int_range(min=0, max=4095),
-            cv.Optional(CONF_Y_MAX, default=default_max_values): cv.int_range(
-                min=0, max=4095
-            ),
-        },
+    return cv.All(
+        cv.Schema(
+            {
+                cv.Optional(CONF_X_MIN, default=0): cv.int_range(min=0, max=4095),
+                cv.Optional(CONF_X_MAX, default=default_max_values): cv.int_range(
+                    min=0, max=4095
+                ),
+                cv.Optional(CONF_Y_MIN, default=0): cv.int_range(min=0, max=4095),
+                cv.Optional(CONF_Y_MAX, default=default_max_values): cv.int_range(
+                    min=0, max=4095
+                ),
+            }
+        ),
         validate_calibration,
     )
 

--- a/esphome/components/touchscreen/touchscreen.h
+++ b/esphome/components/touchscreen/touchscreen.h
@@ -53,14 +53,10 @@ class Touchscreen : public PollingComponent {
   void set_swap_xy(bool swap) { this->swap_x_y_ = swap; }
 
   void set_calibration(int16_t x_min, int16_t x_max, int16_t y_min, int16_t y_max) {
-    this->x_raw_min_ = std::min(x_min, x_max);
-    this->x_raw_max_ = std::max(x_min, x_max);
-    this->y_raw_min_ = std::min(y_min, y_max);
-    this->y_raw_max_ = std::max(y_min, y_max);
-    if (x_min > x_max)
-      this->invert_x_ = true;
-    if (y_min > y_max)
-      this->invert_y_ = true;
+    this->x_raw_min_ = x_min;
+    this->x_raw_max_ = x_max;
+    this->y_raw_min_ = y_min;
+    this->y_raw_max_ = y_max;
   }
 
   Trigger<TouchPoint, const TouchPoints_t &> *get_touch_trigger() { return &this->touch_trigger_; }

--- a/esphome/components/xpt2046/touchscreen/__init__.py
+++ b/esphome/components/xpt2046/touchscreen/__init__.py
@@ -1,9 +1,8 @@
-import esphome.codegen as cg
-import esphome.config_validation as cv
-
 from esphome import pins
+import esphome.codegen as cg
 from esphome.components import spi, touchscreen
-from esphome.const import CONF_ID, CONF_THRESHOLD, CONF_INTERRUPT_PIN
+import esphome.config_validation as cv
+from esphome.const import CONF_ID, CONF_INTERRUPT_PIN, CONF_THRESHOLD
 
 CODEOWNERS = ["@numo68", "@nielsnl68"]
 DEPENDENCIES = ["spi"]
@@ -15,13 +14,9 @@ XPT2046Component = XPT2046_ns.class_(
     spi.SPIDevice,
 )
 
-CONF_CALIBRATION_X_MIN = "calibration_x_min"
-CONF_CALIBRATION_X_MAX = "calibration_x_max"
-CONF_CALIBRATION_Y_MIN = "calibration_y_min"
-CONF_CALIBRATION_Y_MAX = "calibration_y_max"
-
 CONFIG_SCHEMA = cv.All(
-    touchscreen.TOUCHSCREEN_SCHEMA.extend(
+    touchscreen.touchscreen_schema(calibration_required=True)
+    .extend(
         cv.Schema(
             {
                 cv.GenerateID(): cv.declare_id(XPT2046Component),
@@ -29,30 +24,10 @@ CONFIG_SCHEMA = cv.All(
                     pins.internal_gpio_input_pin_schema
                 ),
                 cv.Optional(CONF_THRESHOLD, default=400): cv.int_range(min=0, max=4095),
-                cv.Optional(
-                    touchscreen.CONF_CALIBRATION
-                ): touchscreen.calibration_schema(4095),
-                cv.Optional(CONF_CALIBRATION_X_MIN): cv.invalid(
-                    "Deprecated: use the new 'calibration' configuration variable"
-                ),
-                cv.Optional(CONF_CALIBRATION_X_MAX): cv.invalid(
-                    "Deprecated: use the new 'calibration' configuration variable"
-                ),
-                cv.Optional(CONF_CALIBRATION_Y_MIN): cv.invalid(
-                    "Deprecated: use the new 'calibration' configuration variable"
-                ),
-                cv.Optional(CONF_CALIBRATION_Y_MAX): cv.invalid(
-                    "Deprecated: use the new 'calibration' configuration variable"
-                ),
-                cv.Optional(CONF_CALIBRATION_Y_MAX): cv.invalid(
-                    "Deprecated: use the new 'calibration' configuration variable"
-                ),
-                cv.Optional("report_interval"): cv.invalid(
-                    "Deprecated: use the 'update_interval' configuration variable"
-                ),
             },
         )
-    ).extend(spi.spi_device_schema()),
+    )
+    .extend(spi.spi_device_schema()),
 )
 
 

--- a/tests/components/xpt2046/test.esp32-ard.yaml
+++ b/tests/components/xpt2046/test.esp32-ard.yaml
@@ -25,8 +25,8 @@ touchscreen:
     update_interval: 50ms
     threshold: 400
     calibration:
-      x_min: 3860
-      x_max: 280
+      x_min: 280
+      x_max: 3860
       y_min: 340
       y_max: 3860
     on_touch:

--- a/tests/components/xpt2046/test.esp32-c3-ard.yaml
+++ b/tests/components/xpt2046/test.esp32-c3-ard.yaml
@@ -25,7 +25,7 @@ touchscreen:
     update_interval: 50ms
     threshold: 400
     calibration:
-      x_min: 3860
+      x_min: 28
       x_max: 280
       y_min: 340
       y_max: 3860

--- a/tests/components/xpt2046/test.esp32-c3-idf.yaml
+++ b/tests/components/xpt2046/test.esp32-c3-idf.yaml
@@ -25,7 +25,7 @@ touchscreen:
     update_interval: 50ms
     threshold: 400
     calibration:
-      x_min: 3860
+      x_min: 50
       x_max: 280
       y_min: 340
       y_max: 3860

--- a/tests/components/xpt2046/test.esp32-idf.yaml
+++ b/tests/components/xpt2046/test.esp32-idf.yaml
@@ -25,7 +25,7 @@ touchscreen:
     update_interval: 50ms
     threshold: 400
     calibration:
-      x_min: 3860
+      x_min: 50
       x_max: 280
       y_min: 340
       y_max: 3860

--- a/tests/components/xpt2046/test.esp8266-ard.yaml
+++ b/tests/components/xpt2046/test.esp8266-ard.yaml
@@ -25,7 +25,7 @@ touchscreen:
     update_interval: 50ms
     threshold: 400
     calibration:
-      x_min: 3860
+      x_min: 50
       x_max: 280
       y_min: 340
       y_max: 3860

--- a/tests/components/xpt2046/test.rp2040-ard.yaml
+++ b/tests/components/xpt2046/test.rp2040-ard.yaml
@@ -25,8 +25,8 @@ touchscreen:
     update_interval: 50ms
     threshold: 400
     calibration:
-      x_min: 3860
-      x_max: 280
+      x_min: 280
+      x_max: 3860
       y_min: 340
       y_max: 3860
     on_touch:


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

* The validation function in the touchscreen init code was never being called due to incorrect schema construction;
* Inverted calibration values (max < min) were implicitly setting the `mirror_x/y` values, overriding explicit configuration.

This PR fixes the validation, and disallows inverted calibration values. In addition the `calibration` config block now, if present, requires all values to be set.

A `calibration` config is now required for the XPT2046 component, since it *always* needs calibration.


## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/issues/issues/5582#issuecomment-2448594048

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#4403

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [x] host

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
