### PR TITLE
feat(wifi): support to configure custom MAC address for WIFI interface

### DIFF
--- a/esphome/components/wifi/__init__.py
+++ b/esphome/components/wifi/__init__.py
@@ -23,6 +23,7 @@ from esphome.const import (
     CONF_ID,
     CONF_IDENTITY,
     CONF_KEY,
+    CONF_MAC_ADDRESS,
     CONF_MANUAL_IP,
     CONF_NETWORKS,
     CONF_ON_CONNECT,
@@ -311,6 +312,7 @@ CONFIG_SCHEMA = cv.All(
                 rtl87xx="none",
             ): cv.enum(WIFI_POWER_SAVE_MODES, upper=True),
             cv.Optional(CONF_FAST_CONNECT, default=False): cv.boolean,
+            cv.Optional(CONF_MAC_ADDRESS): cv.mac_address,
             cv.Optional(CONF_USE_ADDRESS): cv.string_strict,
             cv.SplitDefault(CONF_OUTPUT_POWER, esp8266=20.0): cv.All(
                 cv.decibel, cv.float_range(min=8.5, max=20.5)
@@ -405,6 +407,12 @@ def wifi_network(config, ap, static_ip):
 @coroutine_with_priority(60.0)
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
+    if CONF_MAC_ADDRESS in config:
+        cg.add(
+            var.set_custom_mac_address(
+                [HexInt(i) for i in config[CONF_MAC_ADDRESS].parts]
+            )
+        )
     cg.add(var.set_use_address(config[CONF_USE_ADDRESS]))
 
     def add_sta(ap, network):

--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -217,6 +217,10 @@ void WiFiComponent::set_fast_connect(bool fast_connect) { this->fast_connect_ = 
 void WiFiComponent::set_btm(bool btm) { this->btm_ = btm; }
 void WiFiComponent::set_rrm(bool rrm) { this->rrm_ = rrm; }
 #endif
+
+void WiFiComponent::set_custom_mac_address(mac_address_t mac) { this->custom_mac_address = mac; }
+void WiFiComponent::set_custom_mac_address(optional<mac_address_t> mac) { this->custom_mac_address = mac; }
+
 network::IPAddresses WiFiComponent::get_ip_addresses() {
   if (this->has_sta())
     return this->wifi_sta_ip_addresses();

--- a/esphome/components/wifi/wifi_component.h
+++ b/esphome/components/wifi/wifi_component.h
@@ -119,6 +119,7 @@ struct EAPAuth {
 #endif  // USE_WIFI_WPA2_EAP
 
 using bssid_t = std::array<uint8_t, 6>;
+using mac_address_t = std::array<uint8_t, 6>;
 
 class WiFiAP {
  public:
@@ -270,6 +271,10 @@ class WiFiComponent : public Component {
   void set_btm(bool btm);
   void set_rrm(bool rrm);
 #endif
+
+  optional<mac_address_t> custom_mac_address;
+  void set_custom_mac_address(mac_address_t mac);
+  void set_custom_mac_address(optional<mac_address_t> mac);
 
   network::IPAddress get_dns_address(int num);
   network::IPAddresses get_ip_addresses();

--- a/esphome/components/wifi/wifi_component_esp32_arduino.cpp
+++ b/esphome/components/wifi/wifi_component_esp32_arduino.cpp
@@ -44,7 +44,10 @@ static bool s_sta_connecting = false;  // NOLINT(cppcoreguidelines-avoid-non-con
 
 void WiFiComponent::wifi_pre_setup_() {
   uint8_t mac[6];
-  if (has_custom_mac_address()) {
+  if (this->custom_mac_address.has_value()) {
+    memcpy(mac, this->custom_mac_address->data(), 6);
+    set_mac_address(mac);
+  } else if (has_custom_mac_address()) {
     get_mac_address_raw(mac);
     set_mac_address(mac);
   }

--- a/esphome/components/wifi/wifi_component_esp_idf.cpp
+++ b/esphome/components/wifi/wifi_component_esp_idf.cpp
@@ -131,7 +131,10 @@ void event_handler(void *arg, esp_event_base_t event_base, int32_t event_id, voi
 
 void WiFiComponent::wifi_pre_setup_() {
   uint8_t mac[6];
-  if (has_custom_mac_address()) {
+  if (this->custom_mac_address.has_value()) {
+    memcpy(mac, this->custom_mac_address->data(), 6);
+    set_mac_address(mac);
+  } else if (has_custom_mac_address()) {
     get_mac_address_raw(mac);
     set_mac_address(mac);
   }

--- a/tests/components/wifi/common-eap.yaml
+++ b/tests/components/wifi/common-eap.yaml
@@ -1,4 +1,5 @@
 wifi:
+  mac_address: '00:00:5E:00:53:23'
   networks:
     - ssid: MySSID
       eap:


### PR DESCRIPTION
# What does this implement/fix?

Currently, a custom MAC address can only be set by burning the address into the ESP32 using efuses. This PR adds an alternative where a custom MAC address is stored in flash.

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
wifi:
  mac_address: '00:00:5E:00:53:23'
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs). Draft for now: https://github.com/ypid/esphome-docs/tree/feat/wifi-mac-from-config