### PR TITLE
datetime fix build_language_schema

### DIFF
--- a/esphome/components/datetime/__init__.py
+++ b/esphome/components/datetime/__init__.py
@@ -70,8 +70,6 @@ def _validate_time_present(config):
 
 
 _DATETIME_SCHEMA = cv.ENTITY_BASE_SCHEMA.extend(
-    web_server.WEBSERVER_SORTING_SCHEMA,
-    cv.MQTT_COMMAND_COMPONENT_SCHEMA,
     cv.Schema(
         {
             cv.Optional(CONF_ON_VALUE): automation.validate_automation(
@@ -81,7 +79,9 @@ _DATETIME_SCHEMA = cv.ENTITY_BASE_SCHEMA.extend(
             ),
             cv.Optional(CONF_TIME_ID): cv.use_id(time.RealTimeClock),
         }
-    ),
+    )
+    .add_extra(web_server.WEBSERVER_SORTING_SCHEMA)
+    .add_extra(cv.MQTT_COMMAND_COMPONENT_SCHEMA),
 ).add_extra(_validate_time_present)
 
 

--- a/esphome/components/datetime/__init__.py
+++ b/esphome/components/datetime/__init__.py
@@ -80,8 +80,8 @@ _DATETIME_SCHEMA = cv.ENTITY_BASE_SCHEMA.extend(
             cv.Optional(CONF_TIME_ID): cv.use_id(time.RealTimeClock),
         }
     )
-    .add_extra(web_server.WEBSERVER_SORTING_SCHEMA)
-    .add_extra(cv.MQTT_COMMAND_COMPONENT_SCHEMA),
+    .extend(web_server.WEBSERVER_SORTING_SCHEMA)
+    .extend(cv.MQTT_COMMAND_COMPONENT_SCHEMA)
 ).add_extra(_validate_time_present)
 
 

--- a/tests/components/mqtt/common.yaml
+++ b/tests/components/mqtt/common.yaml
@@ -230,6 +230,7 @@ datetime:
     id: test_date
     type: date
     state_topic: some/topic/date
+    command_topic: test_date/custom_command_topic
     qos: 2
     subscribe_qos: 2
     set_action:

--- a/tests/components/web_server/common_v3.yaml
+++ b/tests/components/web_server/common_v3.yaml
@@ -35,3 +35,11 @@ switch:
     web_server:
       sorting_group_id: sorting_group_2
       sorting_weight: -10
+datetime:
+  - platform: template
+    name: Pick a Date
+    type: datetime
+    optimistic: yes
+    web_server:
+      sorting_group_id: sorting_group_3
+      sorting_weight: -5


### PR DESCRIPTION
# What does this implement/fix?

build_language_schema.py does not like current schema

```
Unable to load component datetime:
Traceback (most recent call last):
  File "/config/esphome/./script/../esphome/loader.py", line 177, in _lookup_module
    module = importlib.import_module(f"esphome.components.{domain}")
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/importlib/__init__.py", line 90, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1387, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 995, in exec_module
  File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
  File "/config/esphome/./script/../esphome/components/datetime/__init__.py", line 72, in <module>
    _DATETIME_SCHEMA = cv.ENTITY_BASE_SCHEMA.extend(
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/config/esphome/./script/../esphome/schema_extractors.py", line 45, in decorate
    assert len(args) == 2
           ^^^^^^^^^^^^^^
AssertionError
Building schema
Config var without type: core.positive_float
Config var without type: core.zero_to_one_float
Config var without type: core.negative_one_to_one_float
Config var without type: core.positive_not_null_float
Config var without type: core.hex_uint8_t
Config var without type: core.hex_uint16_t
Config var without type: core.hex_uint32_t
Config var without type: core.hex_uint64_t
Traceback (most recent call last):
  File "/config/esphome/./script/build_language_schema.py", line 1007, in <module>
    build_schema()
  File "/config/esphome/./script/build_language_schema.py", line 590, in build_schema
    if manifest.is_platform_component:
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'is_platform_component'
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
