### PR TITLE
handle bad pin schemas

### DIFF
--- a/esphome/components/esp32/gpio.py
+++ b/esphome/components/esp32/gpio.py
@@ -69,6 +69,8 @@ def _translate_pin(value):
         )
     if isinstance(value, int):
         return value
+    if isinstance(value, list):
+        raise cv.Invalid("A pin schema can't be a list.")
     try:
         return int(value)
     except ValueError:

--- a/esphome/components/esp32/gpio.py
+++ b/esphome/components/esp32/gpio.py
@@ -67,10 +67,10 @@ def _translate_pin(value):
             "This variable only supports pin numbers, not full pin schemas "
             "(with inverted and mode)."
         )
-    if isinstance(value, int):
+    if isinstance(value, int) and not isinstance(value, bool):
         return value
-    if isinstance(value, list):
-        raise cv.Invalid("A pin schema can't be a list.")
+    if not isinstance(value, str):
+        raise cv.Invalid(f"Invalid pin number: {value}")
     try:
         return int(value)
     except ValueError:

--- a/esphome/components/esp8266/gpio.py
+++ b/esphome/components/esp8266/gpio.py
@@ -1,6 +1,9 @@
-import logging
 from dataclasses import dataclass
+import logging
 
+from esphome import pins
+import esphome.codegen as cg
+import esphome.config_validation as cv
 from esphome.const import (
     CONF_ANALOG,
     CONF_ID,
@@ -14,10 +17,7 @@ from esphome.const import (
     CONF_PULLUP,
     PLATFORM_ESP8266,
 )
-from esphome import pins
 from esphome.core import CORE, coroutine_with_priority
-import esphome.config_validation as cv
-import esphome.codegen as cg
 
 from . import boards
 from .const import KEY_BOARD, KEY_ESP8266, KEY_PIN_INITIAL_STATES, esp8266_ns
@@ -50,6 +50,8 @@ def _translate_pin(value):
         )
     if isinstance(value, int):
         return value
+    if isinstance(value, list):
+        raise cv.Invalid("A pin schema can't be a list.")
     try:
         return int(value)
     except ValueError:

--- a/esphome/components/esp8266/gpio.py
+++ b/esphome/components/esp8266/gpio.py
@@ -48,10 +48,10 @@ def _translate_pin(value):
             "This variable only supports pin numbers, not full pin schemas "
             "(with inverted and mode)."
         )
-    if isinstance(value, int):
+    if isinstance(value, int) and not isinstance(value, bool):
         return value
-    if isinstance(value, list):
-        raise cv.Invalid("A pin schema can't be a list.")
+    if not isinstance(value, str):
+        raise cv.Invalid(f"Invalid pin number: {value}")
     try:
         return int(value)
     except ValueError:

--- a/esphome/components/host/gpio.py
+++ b/esphome/components/host/gpio.py
@@ -1,5 +1,8 @@
 import logging
 
+from esphome import pins
+import esphome.codegen as cg
+import esphome.config_validation as cv
 from esphome.const import (
     CONF_ID,
     CONF_INPUT,
@@ -11,9 +14,6 @@ from esphome.const import (
     CONF_PULLDOWN,
     CONF_PULLUP,
 )
-from esphome import pins
-import esphome.config_validation as cv
-import esphome.codegen as cg
 
 from .const import host_ns
 
@@ -30,6 +30,8 @@ def _translate_pin(value):
         )
     if isinstance(value, int):
         return value
+    if isinstance(value, list):
+        raise cv.Invalid("A pin schema can't be a list.")
     try:
         return int(value)
     except ValueError:

--- a/esphome/components/host/gpio.py
+++ b/esphome/components/host/gpio.py
@@ -28,10 +28,10 @@ def _translate_pin(value):
             "This variable only supports pin numbers, not full pin schemas "
             "(with inverted and mode)."
         )
-    if isinstance(value, int):
+    if isinstance(value, int) and not isinstance(value, bool):
         return value
-    if isinstance(value, list):
-        raise cv.Invalid("A pin schema can't be a list.")
+    if not isinstance(value, str):
+        raise cv.Invalid(f"Invalid pin number: {value}")
     try:
         return int(value)
     except ValueError:

--- a/esphome/components/libretiny/gpio.py
+++ b/esphome/components/libretiny/gpio.py
@@ -1,8 +1,8 @@
 import logging
 
+from esphome import pins
 import esphome.codegen as cg
 import esphome.config_validation as cv
-from esphome import pins
 from esphome.const import (
     CONF_ANALOG,
     CONF_ID,
@@ -105,6 +105,8 @@ def _translate_pin(value):
         )
     if isinstance(value, int):
         return value
+    if isinstance(value, list):
+        raise cv.Invalid("A pin schema can't be a list.")
     try:
         return int(value)
     except ValueError:

--- a/esphome/components/libretiny/gpio.py
+++ b/esphome/components/libretiny/gpio.py
@@ -103,10 +103,10 @@ def _translate_pin(value):
             "This variable only supports pin numbers, not full pin schemas "
             "(with inverted and mode)."
         )
-    if isinstance(value, int):
+    if isinstance(value, int) and not isinstance(value, bool):
         return value
-    if isinstance(value, list):
-        raise cv.Invalid("A pin schema can't be a list.")
+    if not isinstance(value, str):
+        raise cv.Invalid(f"Invalid pin number: {value}")
     try:
         return int(value)
     except ValueError:

--- a/esphome/components/rp2040/gpio.py
+++ b/esphome/components/rp2040/gpio.py
@@ -41,10 +41,10 @@ def _translate_pin(value):
             "This variable only supports pin numbers, not full pin schemas "
             "(with inverted and mode)."
         )
-    if isinstance(value, int):
+    if isinstance(value, int) and not isinstance(value, bool):
         return value
-    if isinstance(value, list):
-        raise cv.Invalid("A pin schema can't be a list.")
+    if not isinstance(value, str):
+        raise cv.Invalid(f"Invalid pin number: {value}")
     try:
         return int(value)
     except ValueError:

--- a/esphome/components/rp2040/gpio.py
+++ b/esphome/components/rp2040/gpio.py
@@ -1,6 +1,8 @@
+from esphome import pins
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.const import (
+    CONF_ANALOG,
     CONF_ID,
     CONF_INPUT,
     CONF_INVERTED,
@@ -10,10 +12,8 @@ from esphome.const import (
     CONF_OUTPUT,
     CONF_PULLDOWN,
     CONF_PULLUP,
-    CONF_ANALOG,
 )
 from esphome.core import CORE
-from esphome import pins
 
 from . import boards
 from .const import KEY_BOARD, KEY_RP2040, rp2040_ns
@@ -43,6 +43,8 @@ def _translate_pin(value):
         )
     if isinstance(value, int):
         return value
+    if isinstance(value, list):
+        raise cv.Invalid("A pin schema can't be a list.")
     try:
         return int(value)
     except ValueError:


### PR DESCRIPTION
# What does this implement/fix?

If a pin schema is a list, the validation shouldn't crash.

e.g.
```yaml
pin:
  - number: 4
```

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
