### PR TITLE
Add strftime variant with background color

### DIFF
--- a/esphome/components/display/display.cpp
+++ b/esphome/components/display/display.cpp
@@ -662,20 +662,23 @@ void DisplayOnPageChangeTrigger::process(DisplayPage *from, DisplayPage *to) {
   if ((this->from_ == nullptr || this->from_ == from) && (this->to_ == nullptr || this->to_ == to))
     this->trigger(from, to);
 }
-void Display::strftime(int x, int y, BaseFont *font, Color color, TextAlign align, const char *format, ESPTime time) {
+void Display::strftime(int x, int y, BaseFont *font, Color color, Color background, TextAlign align, const char *format, ESPTime time) {
   char buffer[64];
   size_t ret = time.strftime(buffer, sizeof(buffer), format);
   if (ret > 0)
-    this->print(x, y, font, color, align, buffer);
+    this->print(x, y, font, color, align, buffer, background);
+}
+void Display::strftime(int x, int y, BaseFont *font, Color color, TextAlign align, const char *format, ESPTime time) {
+  this->strftime(x, y, font, color, COLOR_OFF, TextAlign::TOP_LEFT, format, time);
 }
 void Display::strftime(int x, int y, BaseFont *font, Color color, const char *format, ESPTime time) {
-  this->strftime(x, y, font, color, TextAlign::TOP_LEFT, format, time);
+  this->strftime(x, y, font, color, COLOR_OFF, TextAlign::TOP_LEFT, format, time);
 }
 void Display::strftime(int x, int y, BaseFont *font, TextAlign align, const char *format, ESPTime time) {
-  this->strftime(x, y, font, COLOR_ON, align, format, time);
+  this->strftime(x, y, font, COLOR_ON, COLOR_OFF, align, format, time);
 }
 void Display::strftime(int x, int y, BaseFont *font, const char *format, ESPTime time) {
-  this->strftime(x, y, font, COLOR_ON, TextAlign::TOP_LEFT, format, time);
+  this->strftime(x, y, font, COLOR_ON, COLOR_OFF, TextAlign::TOP_LEFT, format, time);
 }
 
 void Display::start_clipping(Rect rect) {

--- a/esphome/components/display/display.cpp
+++ b/esphome/components/display/display.cpp
@@ -662,7 +662,8 @@ void DisplayOnPageChangeTrigger::process(DisplayPage *from, DisplayPage *to) {
   if ((this->from_ == nullptr || this->from_ == from) && (this->to_ == nullptr || this->to_ == to))
     this->trigger(from, to);
 }
-void Display::strftime(int x, int y, BaseFont *font, Color color, Color background, TextAlign align, const char *format, ESPTime time) {
+void Display::strftime(int x, int y, BaseFont *font, Color color, Color background, TextAlign align, const char *format, 
+                       ESPTime time) {
   char buffer[64];
   size_t ret = time.strftime(buffer, sizeof(buffer), format);
   if (ret > 0)

--- a/esphome/components/display/display.cpp
+++ b/esphome/components/display/display.cpp
@@ -662,7 +662,7 @@ void DisplayOnPageChangeTrigger::process(DisplayPage *from, DisplayPage *to) {
   if ((this->from_ == nullptr || this->from_ == from) && (this->to_ == nullptr || this->to_ == to))
     this->trigger(from, to);
 }
-void Display::strftime(int x, int y, BaseFont *font, Color color, Color background, TextAlign align, const char *format, 
+void Display::strftime(int x, int y, BaseFont *font, Color color, Color background, TextAlign align, const char *format,
                        ESPTime time) {
   char buffer[64];
   size_t ret = time.strftime(buffer, sizeof(buffer), format);

--- a/esphome/components/display/display.h
+++ b/esphome/components/display/display.h
@@ -447,7 +447,7 @@ class Display : public PollingComponent {
    * @param format The strftime format to use.
    * @param time The time to format.
    */
-  void strftime(int x, int y, BaseFont *font, Color color, Color background TextAlign align, const char *format,
+  void strftime(int x, int y, BaseFont *font, Color color, Color background, TextAlign align, const char *format,
                 ESPTime time) __attribute__((format(strftime, 7, 0)));
 
   /** Evaluate the strftime-format `format` and print the result with the top left at [x,y] with `font`.

--- a/esphome/components/display/display.h
+++ b/esphome/components/display/display.h
@@ -437,16 +437,6 @@ class Display : public PollingComponent {
    */
   void printf(int x, int y, BaseFont *font, const char *format, ...) __attribute__((format(printf, 5, 6)));
 
-  /** Evaluate the strftime-format `format` and print the result with the anchor point at [x,y] with `font`.
-   *
-   * @param x The x coordinate of the text alignment anchor point.
-   * @param y The y coordinate of the text alignment anchor point.
-   * @param font The font to draw the text with.
-   * @param ... The arguments to use for the text formatting.
-   */
-  void strftime(int x, int y, BaseFont *font, Color color, Color background, TextAlign align, const char *format,
-                ESPTime time) __attribute__((format(strftime, 8, 0)));
-
   /** Evaluate the strftime-format `format` and print the result with the top left at [x,y] with `font`.
    *
    * @param x The x coordinate of the upper left corner.
@@ -454,6 +444,17 @@ class Display : public PollingComponent {
    * @param font The font to draw the text with.
    * @param color The color to draw the text with.
    * @param background The background color to draw the text with.
+   * @param ... The arguments to use for the text formatting.
+   */
+  void strftime(int x, int y, BaseFont *font, Color color, Color background, TextAlign align, const char *format,
+                ESPTime time) __attribute__((format(strftime, 8, 0)));
+
+  /** Evaluate the strftime-format `format` and print the result with the anchor point at [x,y] with `font`.
+   *
+   * @param x The x coordinate of the text alignment anchor point.
+   * @param y The y coordinate of the text alignment anchor point.
+   * @param font The font to draw the text with.
+   * @param color The color to draw the text with.
    * @param align The alignment of the text.
    * @param format The strftime format to use.
    * @param time The time to format.

--- a/esphome/components/display/display.h
+++ b/esphome/components/display/display.h
@@ -447,6 +447,20 @@ class Display : public PollingComponent {
    * @param format The strftime format to use.
    * @param time The time to format.
    */
+  void strftime(int x, int y, BaseFont *font, Color color, Color background TextAlign align, const char *format, 
+                ESPTime time)
+      __attribute__((format(strftime, 7, 0)));
+
+  /** Evaluate the strftime-format `format` and print the result with the top left at [x,y] with `font`.
+   *
+   * @param x The x coordinate of the upper left corner.
+   * @param y The y coordinate of the upper left corner.
+   * @param font The font to draw the text with.
+   * @param color The color to draw the text with.
+   * @param background The background color to draw the text with.
+   * @param format The strftime format to use.
+   * @param time The time to format.
+   */
   void strftime(int x, int y, BaseFont *font, Color color, TextAlign align, const char *format, ESPTime time)
       __attribute__((format(strftime, 7, 0)));
 

--- a/esphome/components/display/display.h
+++ b/esphome/components/display/display.h
@@ -448,7 +448,7 @@ class Display : public PollingComponent {
    * @param time The time to format.
    */
   void strftime(int x, int y, BaseFont *font, Color color, Color background, TextAlign align, const char *format,
-                ESPTime time) __attribute__((format(strftime, 7, 0)));
+                ESPTime time) __attribute__((format(strftime, 8, 0)));
 
   /** Evaluate the strftime-format `format` and print the result with the top left at [x,y] with `font`.
    *

--- a/esphome/components/display/display.h
+++ b/esphome/components/display/display.h
@@ -457,6 +457,7 @@ class Display : public PollingComponent {
    * @param font The font to draw the text with.
    * @param color The color to draw the text with.
    * @param background The background color to draw the text with.
+   * @param align The alignment of the text.
    * @param format The strftime format to use.
    * @param time The time to format.
    */

--- a/esphome/components/display/display.h
+++ b/esphome/components/display/display.h
@@ -442,10 +442,7 @@ class Display : public PollingComponent {
    * @param x The x coordinate of the text alignment anchor point.
    * @param y The y coordinate of the text alignment anchor point.
    * @param font The font to draw the text with.
-   * @param color The color to draw the text with.
-   * @param align The alignment of the text.
-   * @param format The strftime format to use.
-   * @param time The time to format.
+   * @param ... The arguments to use for the text formatting.
    */
   void strftime(int x, int y, BaseFont *font, Color color, Color background, TextAlign align, const char *format,
                 ESPTime time) __attribute__((format(strftime, 8, 0)));

--- a/esphome/components/display/display.h
+++ b/esphome/components/display/display.h
@@ -437,13 +437,15 @@ class Display : public PollingComponent {
    */
   void printf(int x, int y, BaseFont *font, const char *format, ...) __attribute__((format(printf, 5, 6)));
 
-  /** Evaluate the strftime-format `format` and print the result with the top left at [x,y] with `font`.
+  /** Evaluate the strftime-format `format` and print the result with the anchor point at [x,y] with `font`.
    *
-   * @param x The x coordinate of the upper left corner.
-   * @param y The y coordinate of the upper left corner.
+   * @param x The x coordinate of the text alignment anchor point.
+   * @param y The y coordinate of the text alignment anchor point.
    * @param font The font to draw the text with.
    * @param color The color to draw the text with.
    * @param background The background color to draw the text with.
+   * @param align The alignment of the text.
+   * @param format The format to use.
    * @param ... The arguments to use for the text formatting.
    */
   void strftime(int x, int y, BaseFont *font, Color color, Color background, TextAlign align, const char *format,

--- a/esphome/components/display/display.h
+++ b/esphome/components/display/display.h
@@ -447,9 +447,8 @@ class Display : public PollingComponent {
    * @param format The strftime format to use.
    * @param time The time to format.
    */
-  void strftime(int x, int y, BaseFont *font, Color color, Color background TextAlign align, const char *format, 
-                ESPTime time)
-      __attribute__((format(strftime, 7, 0)));
+  void strftime(int x, int y, BaseFont *font, Color color, Color background TextAlign align, const char *format,
+                ESPTime time) __attribute__((format(strftime, 7, 0)));
 
   /** Evaluate the strftime-format `format` and print the result with the top left at [x,y] with `font`.
    *


### PR DESCRIPTION
Add strftime variant with background color (useful for antialiased fonts with non black background)

# What does this implement/fix?

Adds strftime variant with background color (useful for antialiased fonts with non black background) 

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
