### PR TITLE
[cse7766] Remove ``stream`` dependency

### DIFF
--- a/esphome/components/cse7766/cse7766.cpp
+++ b/esphome/components/cse7766/cse7766.cpp
@@ -71,12 +71,12 @@ bool CSE7766Component::check_byte_() {
 void CSE7766Component::parse_data_() {
 #if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERY_VERBOSE
   {
-  	std::string s = "Raw data:";
-  	char buff[4] = {0};
-  	for (uint8_t i = 0; i <= 23; i++) {
-  		snprintf(buff, sizeof(buff), " %02X", this->raw_data_[i]);
-  		s += buff;
-  	}
+    std::string s = "Raw data:";
+    char buff[4] = {0};
+    for (uint8_t i = 0; i <= 23; i++) {
+      snprintf(buff, sizeof(buff), " %02X", this->raw_data_[i]);
+      s += buff;
+    }
     ESP_LOGVV(TAG, "%s", s.c_str());
   }
 #endif

--- a/esphome/components/cse7766/cse7766.cpp
+++ b/esphome/components/cse7766/cse7766.cpp
@@ -1,7 +1,6 @@
 #include "cse7766.h"
 #include "esphome/core/log.h"
 #include <cinttypes>
-#include <iomanip>
 #include <sstream>
 
 namespace esphome {
@@ -72,12 +71,13 @@ bool CSE7766Component::check_byte_() {
 void CSE7766Component::parse_data_() {
 #if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERY_VERBOSE
   {
-    std::stringstream ss;
-    ss << "Raw data:" << std::hex << std::uppercase << std::setfill('0');
-    for (uint8_t i = 0; i < 23; i++) {
-      ss << ' ' << std::setw(2) << static_cast<unsigned>(this->raw_data_[i]);
-    }
-    ESP_LOGVV(TAG, "%s", ss.str().c_str());
+  	std::string s = "Raw data:";
+  	char buff[4] = {0};
+  	for (uint8_t i = 0; i <= 23; i++) {
+  		snprintf(buff, sizeof(buff), " %02X", this->raw_data_[i]);
+  		s += buff;
+  	}
+    ESP_LOGVV(TAG, "%s", s.c_str());
   }
 #endif
 

--- a/esphome/components/cse7766/cse7766.cpp
+++ b/esphome/components/cse7766/cse7766.cpp
@@ -1,7 +1,5 @@
 #include "cse7766.h"
 #include "esphome/core/log.h"
-#include <cinttypes>
-#include <sstream>
 
 namespace esphome {
 namespace cse7766 {
@@ -71,13 +69,8 @@ bool CSE7766Component::check_byte_() {
 void CSE7766Component::parse_data_() {
 #if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERY_VERBOSE
   {
-    std::string s = "Raw data:";
-    char buff[4] = {0};
-    for (uint8_t i = 0; i <= 23; i++) {
-      snprintf(buff, sizeof(buff), " %02X", this->raw_data_[i]);
-      s += buff;
-    }
-    ESP_LOGVV(TAG, "%s", s.c_str());
+    std::string s = format_hex_pretty(this->raw_data_, sizeof(this->raw_data_));
+    ESP_LOGVV(TAG, "Raw data: %s", s.c_str());
   }
 #endif
 
@@ -211,21 +204,25 @@ void CSE7766Component::parse_data_() {
 
 #if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERY_VERBOSE
   {
-    std::stringstream ss;
-    ss << "Parsed:";
+    std::string s = "Parsed:";
+    char buff[64] = {0};
     if (have_voltage) {
-      ss << " V=" << voltage << "V";
+      snprintf(buff, sizeof(buff), " V=%.2fV", voltage);
+      s += buff;
     }
     if (have_current) {
-      ss << " I=" << current * 1000.0f << "mA (~" << calculated_current * 1000.0f << "mA)";
+      snprintf(buff, sizeof(buff), " I=%.2fmA (~%fmA)", current * 1000.0f, calculated_current * 1000.0f);
+      s += buff;
     }
     if (have_power) {
-      ss << " P=" << power << "W";
+      snprintf(buff, sizeof(buff), " P=%.2fW", power);
+      s += buff;
     }
     if (energy != 0.0f) {
-      ss << " E=" << energy << "kWh (" << cf_pulses << ")";
+      snprintf(buff, sizeof(buff), " E=%dkWh", cf_pulses);
+      s += buff;
     }
-    ESP_LOGVV(TAG, "%s", ss.str().c_str());
+    ESP_LOGVV(TAG, "%s", s.c_str());
   }
 #endif
 }

--- a/esphome/components/cse7766/cse7766.cpp
+++ b/esphome/components/cse7766/cse7766.cpp
@@ -204,25 +204,20 @@ void CSE7766Component::parse_data_() {
 
 #if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERY_VERBOSE
   {
-    std::string s = "Parsed:";
-    char buff[64] = {0};
+    std::string buf = "Parsed:";
     if (have_voltage) {
-      snprintf(buff, sizeof(buff), " V=%.2fV", voltage);
-      s += buff;
+      buf += str_sprintf(" V=%fV", voltage);
     }
     if (have_current) {
-      snprintf(buff, sizeof(buff), " I=%.2fmA (~%fmA)", current * 1000.0f, calculated_current * 1000.0f);
-      s += buff;
+      buf += str_sprintf(" I=%fmA (~%fmA)", current * 1000.0f, calculated_current * 1000.0f);
     }
     if (have_power) {
-      snprintf(buff, sizeof(buff), " P=%.2fW", power);
-      s += buff;
+      buf += str_sprintf(" P=%fW", power);
     }
     if (energy != 0.0f) {
-      snprintf(buff, sizeof(buff), " E=%dkWh", cf_pulses);
-      s += buff;
+      buf += str_sprintf(" E=%fkWh (%u)", energy, cf_pulses);
     }
-    ESP_LOGVV(TAG, "%s", s.c_str());
+    ESP_LOGVV(TAG, "%s", buf.c_str());
   }
 #endif
 }


### PR DESCRIPTION
# What does this implement/fix?

Shave off 200k from the firmware when you log the raw measurement data.

iomanip includes everything not just the kitchen sink. 

I tried debugging my smart plug (somehow only reports voltage), and with a barebone config, debug level none, the firmware is over half the flash size with this.

The fix is to use regular snprintf to dump those bytes.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
