### PR TITLE
[lvgl] Don't just throw key error if someone types a bad layout type

### DIFF
--- a/esphome/components/lvgl/schemas.py
+++ b/esphome/components/lvgl/schemas.py
@@ -391,7 +391,9 @@ def container_validator(schema, widget_type: WidgetType):
             add_lv_use(ltype)
         if value == SCHEMA_EXTRACT:
             return result
-        result = result.extend(LAYOUT_SCHEMAS.get(ltype.lower(), LAYOUT_SCHEMAS[df.TYPE_NONE]))
+        result = result.extend(
+            LAYOUT_SCHEMAS.get(ltype.lower(), LAYOUT_SCHEMAS[df.TYPE_NONE])
+        )
         return result(value)
 
     return validator

--- a/esphome/components/lvgl/schemas.py
+++ b/esphome/components/lvgl/schemas.py
@@ -391,6 +391,8 @@ def container_validator(schema, widget_type: WidgetType):
             add_lv_use(ltype)
         if value == SCHEMA_EXTRACT:
             return result
+        with cv.prepend_path([df.CONF_LAYOUT, CONF_TYPE]):
+            ltype = cv.one_of(*LAYOUT_SCHEMAS.keys())(ltype)
         result = result.extend(LAYOUT_SCHEMAS[ltype.lower()])
         return result(value)
 

--- a/esphome/components/lvgl/schemas.py
+++ b/esphome/components/lvgl/schemas.py
@@ -391,9 +391,7 @@ def container_validator(schema, widget_type: WidgetType):
             add_lv_use(ltype)
         if value == SCHEMA_EXTRACT:
             return result
-        with cv.prepend_path([df.CONF_LAYOUT, CONF_TYPE]):
-            ltype = cv.one_of(*LAYOUT_SCHEMAS.keys())(ltype)
-        result = result.extend(LAYOUT_SCHEMAS[ltype.lower()])
+        result = result.extend(LAYOUT_SCHEMAS.get(ltype.lower(), LAYOUT_SCHEMAS[df.TYPE_NONE]))
         return result(value)
 
     return validator


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

From:
```
  File "/home/jesse/workspace/esphome/esphome/esphome/components/lvgl/schemas.py", line 394, in validator
    result = result.extend(LAYOUT_SCHEMAS[ltype.lower()])
                           ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
KeyError: 'blah'
```

to:

```
lvgl: [source config/dining-switch-display.yaml:124]
  ...
  pages: 
    - ...
      widgets: 
        - obj: 
            ...
            layout: 
              
              Unknown value 'blah', valid options are 'grid', 'flex', 'none'.
              type: blah
            widgets: 
              ...
```
## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
