### PR TITLE
Remove the choice for MQTT logging if it is disabled

### DIFF
--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -100,10 +100,10 @@ def choose_upload_log_host(
             return CORE.address
     if (
         show_mqtt
-        and CONF_MQTT in CORE.config
-        and mqtt_logging_enabled(CORE.config[CONF_MQTT])
+        and (mqtt_config := CORE.config.get(CONF_MQTT))
+        and mqtt_logging_enabled(mqtt_config)
     ):
-        options.append((f"MQTT ({CORE.config[CONF_MQTT][CONF_BROKER]})", "MQTT"))
+        options.append((f"MQTT ({mqtt_config[CONF_BROKER]})", "MQTT"))
         if default == "OTA":
             return "MQTT"
     if default is not None:
@@ -114,11 +114,12 @@ def choose_upload_log_host(
 
 
 def mqtt_logging_enabled(mqtt_config):
-    if mqtt_config[CONF_LOG_TOPIC] is None:
+    log_topic = mqtt_config[CONF_LOG_TOPIC]
+    if log_topic is None:
         return False
-    if CONF_TOPIC not in mqtt_config[CONF_LOG_TOPIC]:
+    if CONF_TOPIC not in log_topic:
         return False
-    if mqtt_config[CONF_LOG_TOPIC].get(CONF_LEVEL, None) == "NONE":
+    if log_topic.get(CONF_LEVEL, None) == "NONE":
         return False
     return True
 


### PR DESCRIPTION
This is a second pass at https://github.com/esphome/issues/issues/6046

I have a situation where sometimes I have MQTT logging enabled, but sometimes not depending on the device.

This PR removes the choice so that one doesn't have to remember that MQTT logging is disabled, so that `esphome logs` goes right for the API method (if available).

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** 

- fixes https://github.com/esphome/issues/issues/6046

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#4412

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
