### PR TITLE
[spi_device] rename mode to spi_mode

### DIFF
--- a/esphome/components/spi/__init__.py
+++ b/esphome/components/spi/__init__.py
@@ -1,40 +1,37 @@
 import re
 
+from esphome import pins
 import esphome.codegen as cg
-import esphome.config_validation as cv
-import esphome.final_validate as fv
 from esphome.components.esp32.const import (
     KEY_ESP32,
-    VARIANT_ESP32S2,
-    VARIANT_ESP32S3,
     VARIANT_ESP32C2,
     VARIANT_ESP32C3,
     VARIANT_ESP32C6,
     VARIANT_ESP32H2,
+    VARIANT_ESP32S2,
+    VARIANT_ESP32S3,
 )
-from esphome import pins
+import esphome.config_validation as cv
 from esphome.const import (
     CONF_CLK_PIN,
+    CONF_CS_PIN,
+    CONF_DATA_PINS,
+    CONF_DATA_RATE,
     CONF_ID,
+    CONF_INVERTED,
     CONF_MISO_PIN,
     CONF_MOSI_PIN,
-    CONF_SPI_ID,
-    CONF_CS_PIN,
     CONF_NUMBER,
-    CONF_INVERTED,
+    CONF_SPI_ID,
     KEY_CORE,
     KEY_TARGET_PLATFORM,
     KEY_VARIANT,
-    CONF_DATA_RATE,
     PLATFORM_ESP32,
     PLATFORM_ESP8266,
     PLATFORM_RP2040,
-    CONF_DATA_PINS,
 )
-from esphome.core import (
-    coroutine_with_priority,
-    CORE,
-)
+from esphome.core import CORE, coroutine_with_priority
+import esphome.final_validate as fv
 
 CODEOWNERS = ["@esphome/core", "@clydebarrow"]
 spi_ns = cg.esphome_ns.namespace("spi")
@@ -69,6 +66,10 @@ SPI_MODE_OPTIONS = {
     1: SPIMode.MODE1,
     2: SPIMode.MODE2,
     3: SPIMode.MODE3,
+    "0": SPIMode.MODE0,
+    "1": SPIMode.MODE1,
+    "2": SPIMode.MODE2,
+    "3": SPIMode.MODE3,
 }
 
 CONF_SPI_MODE = "spi_mode"

--- a/esphome/components/spi_device/__init__.py
+++ b/esphome/components/spi_device/__init__.py
@@ -1,6 +1,6 @@
 import esphome.codegen as cg
-import esphome.config_validation as cv
 from esphome.components import spi
+import esphome.config_validation as cv
 from esphome.const import CONF_ID, CONF_MODE
 
 DEPENDENCIES = ["spi"]
@@ -10,18 +10,6 @@ MULTI_CONF = True
 spi_device_ns = cg.esphome_ns.namespace("spi_device")
 
 spi_device = spi_device_ns.class_("SPIDeviceComponent", cg.Component, spi.SPIDevice)
-
-Mode = spi.spi_ns.enum("SPIMode")
-MODES = {
-    "0": Mode.MODE0,
-    "1": Mode.MODE1,
-    "2": Mode.MODE2,
-    "3": Mode.MODE3,
-    "MODE0": Mode.MODE0,
-    "MODE1": Mode.MODE1,
-    "MODE2": Mode.MODE2,
-    "MODE3": Mode.MODE3,
-}
 
 BitOrder = spi.spi_ns.enum("SPIBitOrder")
 ORDERS = {
@@ -34,7 +22,9 @@ CONFIG_SCHEMA = cv.Schema(
     {
         cv.GenerateID(CONF_ID): cv.declare_id(spi_device),
         cv.Optional(CONF_BIT_ORDER, default="msb_first"): cv.enum(ORDERS, lower=True),
-        cv.Optional(CONF_MODE, default="0"): cv.enum(MODES, upper=True),
+        cv.Optional(CONF_MODE): cv.invalid(
+            "The 'mode' option has been renamed to 'spi_mode'."
+        ),
     }
 ).extend(spi.spi_device_schema(False, "1MHz"))
 
@@ -42,6 +32,5 @@ CONFIG_SCHEMA = cv.Schema(
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
-    cg.add(var.set_mode(config[CONF_MODE]))
     cg.add(var.set_bit_order(config[CONF_BIT_ORDER]))
     await spi.register_spi_device(var, config)

--- a/tests/components/spi_device/test.esp32-ard.yaml
+++ b/tests/components/spi_device/test.esp32-ard.yaml
@@ -7,5 +7,5 @@ spi:
 spi_device:
   id: spi_device_test
   data_rate: 2MHz
-  mode: 3
+  spi_mode: 3
   bit_order: lsb_first

--- a/tests/components/spi_device/test.esp32-c3-ard.yaml
+++ b/tests/components/spi_device/test.esp32-c3-ard.yaml
@@ -7,5 +7,5 @@ spi:
 spi_device:
   id: spi_device_test
   data_rate: 2MHz
-  mode: 3
+  spi_mode: 3
   bit_order: lsb_first

--- a/tests/components/spi_device/test.esp32-c3-idf.yaml
+++ b/tests/components/spi_device/test.esp32-c3-idf.yaml
@@ -7,5 +7,5 @@ spi:
 spi_device:
   id: spi_device_test
   data_rate: 2MHz
-  mode: 3
+  spi_mode: 3
   bit_order: lsb_first

--- a/tests/components/spi_device/test.esp32-idf.yaml
+++ b/tests/components/spi_device/test.esp32-idf.yaml
@@ -7,5 +7,5 @@ spi:
 spi_device:
   id: spi_device_test
   data_rate: 2MHz
-  mode: 3
+  spi_mode: 3
   bit_order: lsb_first

--- a/tests/components/spi_device/test.esp8266-ard.yaml
+++ b/tests/components/spi_device/test.esp8266-ard.yaml
@@ -7,5 +7,5 @@ spi:
 spi_device:
   id: spi_device_test
   data_rate: 2MHz
-  mode: 3
+  spi_mode: 3
   bit_order: lsb_first

--- a/tests/components/spi_device/test.rp2040-ard.yaml
+++ b/tests/components/spi_device/test.rp2040-ard.yaml
@@ -7,5 +7,5 @@ spi:
 spi_device:
   id: spi_device_test
   data_rate: 2MHz
-  mode: 3
+  spi_mode: 3
   bit_order: lsb_first


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

For consistency with other spi schemas, and to avoid two options with the same function.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- fixes https://discord.com/channels/429907082951524364/524177279270780928/1303457887519248479

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#4414

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
