### PR TITLE
Fix temperature and humidity for bme680 with bsec2

### DIFF
--- a/esphome/components/bme68x_bsec2/bme68x_bsec2.h
+++ b/esphome/components/bme68x_bsec2/bme68x_bsec2.h
@@ -113,13 +113,11 @@ class BME68xBSEC2Component : public Component {
 
   struct bme68x_heatr_conf bme68x_heatr_conf_;
   uint8_t op_mode_;  // operating mode of sensor
-  bool sleep_mode_;
   bsec_library_return_t bsec_status_{BSEC_OK};
   int8_t bme68x_status_{BME68X_OK};
 
   int64_t last_time_ms_{0};
   uint32_t millis_overflow_counter_{0};
-  int64_t next_call_ns_{0};
 
   std::queue<std::function<void()>> queue_;
 


### PR DESCRIPTION
# What does this implement/fix?
Align the run_() method with bsec2 library version. This fixes the issue that temperature is too high in LP mode and way too high in ULP mode.
Does not address the issue that setting sample rates for individual sensors doesn't work.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes esphome/issues/issues/6227
- fixes partially esphome/issues/issues/6369

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
bme68x_bsec2_i2c:
  address: 0x77
  model: bme680
  operating_age: 28d
  sample_rate: LP
  supply_voltage: 3.3V
  state_save_interval: 24h

[...]

  - platform: bme68x_bsec2
    temperature:
      name: "Temperatur"
    pressure:
      name: "Barometer"
    humidity:
      name: "rel. Luftfeuchte"
    gas_resistance:
      name: "BME68x Widerstand"
    iaq:
      name: "BME68x IAQ"
    iaq_static:
      name: "BME68x IAQ static"
    co2_equivalent:
      name: "BME68x CO2 Equivalent"
    breath_voc_equivalent:
      name: "BME68x Breath VOC Equivalent"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
