### PR TITLE
LD2410 remove NaN state in engineering mode

### DIFF
--- a/esphome/components/ld2410/ld2410.cpp
+++ b/esphome/components/ld2410/ld2410.cpp
@@ -255,16 +255,16 @@ void LD2410Component::handle_periodic_data_(uint8_t *buffer, int len) {
   } else {
     for (auto *s : this->gate_move_sensors_) {
       if (s != nullptr && !std::isnan(s->get_state())) {
-        s->publish_state(NAN);
+        s->publish_state(0);
       }
     }
     for (auto *s : this->gate_still_sensors_) {
       if (s != nullptr && !std::isnan(s->get_state())) {
-        s->publish_state(NAN);
+        s->publish_state(0);
       }
     }
     if (this->light_sensor_ != nullptr && !std::isnan(this->light_sensor_->get_state())) {
-      this->light_sensor_->publish_state(NAN);
+      this->light_sensor_->publish_state(0);
     }
   }
 #endif


### PR DESCRIPTION
# What does this implement/fix?

When engineering mode is disabled set state to 0 instead of NaN for move & still energy sensors, since Hass's MQTT integration doesn't seem to like them NaN values and its spamming the logs e.g.

> ValueError: Sensor sensor.ld2410_sensor_g8_move_energy has device class 'None', state class 'None' unit '%' and suggested precision 'None' thus indicating it has a numeric value; however, it has the non-finite value: 'nan'
> 2024-11-08 15:43:41.169 ERROR (MainThread) [homeassistant] Error doing job: Task exception was never retrieved (None)
> Traceback (most recent call last):
>   File "/usr/src/homeassistant/homeassistant/components/mqtt/entity.py", line 856, in _async_process_discovery_update
>     await discovery_update(payload)
>   File "/usr/src/homeassistant/homeassistant/components/mqtt/entity.py", line 1137, in discovery_update
>     self.async_write_ha_state()
>   File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 1005, in async_write_ha_state
>     self._async_write_ha_state()
>   File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 1130, in _async_write_ha_state
>     self.__async_calculate_state()
>   File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 1067, in __async_calculate_state
>     state = self._stringify_state(available)
>             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
>   File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 1011, in _stringify_state
>     if (state := self.state) is None:
>                  ^^^^^^^^^^
>   File "/usr/src/homeassistant/homeassistant/components/sensor/__init__.py", line 675, in state
>     raise ValueError(
> ValueError: Sensor sensor.ld2410_sensor_g8_still_energy has device class 'None', state class 'None' unit '%' and suggested precision 'None' thus indicating it has a numeric value; however, it has the non-finite value: 'nan'

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
