### PR TITLE
[midea] Add temperature validation in do_follow_me method (bugfix)

### DIFF
--- a/esphome/components/midea/air_conditioner.cpp
+++ b/esphome/components/midea/air_conditioner.cpp
@@ -130,9 +130,8 @@ void AirConditioner::do_follow_me(float temperature, bool beeper) {
   }
 
   // Round and convert temperature to long, then clamp and convert it to uint8_t
-  uint8_t temp_uint8 = static_cast<uint8_t>(std::max(0L,
-                                                     std::min(static_cast<long>(UINT8_MAX),
-                                                              std::lroundf(temperature))));
+  uint8_t temp_uint8 =
+      static_cast<uint8_t>(std::max(0L, std::min(static_cast<long>(UINT8_MAX), std::lroundf(temperature))));
 
   ESP_LOGD(Constants::TAG, "Follow me action called with temperature: %f °C, rounded to: %u °C", temperature,
            temp_uint8);

--- a/esphome/components/midea/air_conditioner.cpp
+++ b/esphome/components/midea/air_conditioner.cpp
@@ -125,8 +125,8 @@ void AirConditioner::do_follow_me(float temperature, bool beeper) {
 #ifdef USE_REMOTE_TRANSMITTER
   // Check if temperature is finite (not NaN or infinite)
   if (!std::isfinite(temperature)) {
-      ESP_LOGW(Constants::TAG, "Follow me action requires a finite temperature, got: %f", temperature);
-      return;
+    ESP_LOGW(Constants::TAG, "Follow me action requires a finite temperature, got: %f", temperature);
+    return;
   }
 
   // Round the temperature
@@ -134,16 +134,15 @@ void AirConditioner::do_follow_me(float temperature, bool beeper) {
 
   // Check if rounded temperature is within the uint8_t range
   if (rounded_temp < 0 || rounded_temp > UINT8_MAX) {
-      ESP_LOGW(Constants::TAG, "Rounded temperature out of range: %ld", rounded_temp);
-      return;
+    ESP_LOGW(Constants::TAG, "Rounded temperature out of range: %ld", rounded_temp);
+    return;
   }
 
   // Safely cast to uint8_t after all checks
   uint8_t rounded_temp_uint8 = static_cast<uint8_t>(rounded_temp);
 
-  ESP_LOGD(Constants::TAG, "Follow me action called with temperature: %f, sending rounded temperature: %u", temperature, rounded_temp_uint8);
-
-
+  ESP_LOGD(Constants::TAG, "Follow me action called with temperature: %f, sending rounded temperature: %u", temperature,
+           rounded_temp_uint8);
   // Create and transmit the data
   IrFollowMeData data(rounded_temp_uint8, beeper);
   this->transmitter_.transmit(data);

--- a/esphome/components/midea/air_conditioner.cpp
+++ b/esphome/components/midea/air_conditioner.cpp
@@ -141,8 +141,9 @@ void AirConditioner::do_follow_me(float temperature, bool beeper) {
   // Safely cast to uint8_t after all checks
   uint8_t rounded_temp_uint8 = static_cast<uint8_t>(rounded_temp);
 
-  ESP_LOGD(Constants::TAG, "Follow me action called with temperature: %f, sending rounded temperature: %u", temperature,
+  ESP_LOGD(Constants::TAG, "Follow me action called with temperature: %f °C, rounded to: %u °C", temperature,
            rounded_temp_uint8);
+
   // Create and transmit the data
   IrFollowMeData data(rounded_temp_uint8, beeper);
   this->transmitter_.transmit(data);

--- a/esphome/components/midea/air_conditioner.cpp
+++ b/esphome/components/midea/air_conditioner.cpp
@@ -129,23 +129,16 @@ void AirConditioner::do_follow_me(float temperature, bool beeper) {
     return;
   }
 
-  // Round the temperature
-  long int rounded_temp = std::lroundf(temperature);
-
-  // Check if rounded temperature is within the uint8_t range
-  if (rounded_temp < 0 || rounded_temp > UINT8_MAX) {
-    ESP_LOGW(Constants::TAG, "Rounded temperature out of range: %ld", rounded_temp);
-    return;
-  }
-
-  // Safely cast to uint8_t after all checks
-  uint8_t rounded_temp_uint8 = static_cast<uint8_t>(rounded_temp);
+  // Round and convert temperature to long, then clamp and convert it to uint8_t
+  uint8_t temp_uint8 = static_cast<uint8_t>(std::max(0L, 
+                                                     std::min(static_cast<long>(UINT8_MAX), 
+                                                              std::lroundf(temperature))));
 
   ESP_LOGD(Constants::TAG, "Follow me action called with temperature: %f °C, rounded to: %u °C", temperature,
-           rounded_temp_uint8);
+           temp_uint8);
 
   // Create and transmit the data
-  IrFollowMeData data(rounded_temp_uint8, beeper);
+  IrFollowMeData data(temp_uint8, beeper);
   this->transmitter_.transmit(data);
 #else
   ESP_LOGW(Constants::TAG, "Action needs remote_transmitter component");

--- a/esphome/components/midea/air_conditioner.cpp
+++ b/esphome/components/midea/air_conditioner.cpp
@@ -3,6 +3,8 @@
 #include "esphome/core/log.h"
 #include "air_conditioner.h"
 #include "ac_adapter.h"
+#include <cmath>
+#include <cstdint>
 
 namespace esphome {
 namespace midea {
@@ -121,7 +123,29 @@ void AirConditioner::dump_config() {
 
 void AirConditioner::do_follow_me(float temperature, bool beeper) {
 #ifdef USE_REMOTE_TRANSMITTER
-  IrFollowMeData data(static_cast<uint8_t>(lroundf(temperature)), beeper);
+  // Check if temperature is finite (not NaN or infinite)
+  if (!std::isfinite(temperature)) {
+      ESP_LOGW(Constants::TAG, "Follow me action requires a finite temperature, got: %f", temperature);
+      return;
+  }
+
+  // Round the temperature
+  long int rounded_temp = std::lroundf(temperature);
+
+  // Check if rounded temperature is within the uint8_t range
+  if (rounded_temp < 0 || rounded_temp > UINT8_MAX) {
+      ESP_LOGW(Constants::TAG, "Rounded temperature out of range: %ld", rounded_temp);
+      return;
+  }
+
+  // Safely cast to uint8_t after all checks
+  uint8_t rounded_temp_uint8 = static_cast<uint8_t>(rounded_temp);
+
+  ESP_LOGD(Constants::TAG, "Follow me action called with temperature: %f, sending rounded temperature: %u", temperature, rounded_temp_uint8);
+
+
+  // Create and transmit the data
+  IrFollowMeData data(rounded_temp_uint8, beeper);
   this->transmitter_.transmit(data);
 #else
   ESP_LOGW(Constants::TAG, "Action needs remote_transmitter component");

--- a/esphome/components/midea/air_conditioner.cpp
+++ b/esphome/components/midea/air_conditioner.cpp
@@ -130,8 +130,8 @@ void AirConditioner::do_follow_me(float temperature, bool beeper) {
   }
 
   // Round and convert temperature to long, then clamp and convert it to uint8_t
-  uint8_t temp_uint8 = static_cast<uint8_t>(std::max(0L, 
-                                                     std::min(static_cast<long>(UINT8_MAX), 
+  uint8_t temp_uint8 = static_cast<uint8_t>(std::max(0L,
+                                                     std::min(static_cast<long>(UINT8_MAX),
                                                               std::lroundf(temperature))));
 
   ESP_LOGD(Constants::TAG, "Follow me action called with temperature: %f °C, rounded to: %u °C", temperature,


### PR DESCRIPTION
**Description:**

- The `do_follow_me` method now checks if the provided temperature is finite.
- The temperature is rounded and clamped to fit within the `uint8_t` range before being used.
- Added logging to aid in debugging and provide transparency about the temperature conversion process.
- These changes improve the method's safety and prevent issues caused by invalid temperature inputs.

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/issues/issues/6413

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
