### PR TITLE
Add setting to use default interface for Zeroconf

### DIFF
--- a/esphome/dashboard/core.py
+++ b/esphome/dashboard/core.py
@@ -136,7 +136,7 @@ class ESPHomeDashboard:
         else:
             from .status.mdns import MDNSStatus
 
-            mdns_status = MDNSStatus()
+            mdns_status = MDNSStatus(settings.zeroconf_default_interface)
             await mdns_status.async_refresh_hosts()
             self.mdns_status = mdns_status
             mdns_task = asyncio.create_task(mdns_status.async_run())

--- a/esphome/dashboard/core.py
+++ b/esphome/dashboard/core.py
@@ -136,7 +136,7 @@ class ESPHomeDashboard:
         else:
             from .status.mdns import MDNSStatus
 
-            mdns_status = MDNSStatus(settings.zeroconf_default_interface)
+            mdns_status = MDNSStatus()
             await mdns_status.async_refresh_hosts()
             self.mdns_status = mdns_status
             mdns_task = asyncio.create_task(mdns_status.async_run())

--- a/esphome/dashboard/settings.py
+++ b/esphome/dashboard/settings.py
@@ -55,6 +55,10 @@ class DashboardSettings:
         return os.getenv("ESPHOME_DASHBOARD_RELATIVE_URL") or "/"
 
     @property
+    def zeroconf_default_interface(self):
+        return get_bool_env("ESPHOME_DASHBOARD_ZEROCONF_DEFAULT_INTERFACE")
+
+    @property
     def status_use_ping(self):
         return get_bool_env("ESPHOME_DASHBOARD_USE_PING")
 

--- a/esphome/dashboard/status/mdns.py
+++ b/esphome/dashboard/status/mdns.py
@@ -18,11 +18,10 @@ from ..entries import DashboardEntry, bool_to_entry_state
 class MDNSStatus:
     """Class that updates the mdns status."""
 
-    def __init__(self, default_interface=False) -> None:
+    def __init__(self) -> None:
         """Initialize the MDNSStatus class."""
         super().__init__()
         self.aiozc: AsyncEsphomeZeroconf | None = None
-        self._zc_default_interface: bool = default_interface
         # This is the current mdns state for each host (True, False, None)
         self.host_mdns_state: dict[str, bool | None] = {}
         self._loop = asyncio.get_running_loop()
@@ -65,7 +64,9 @@ class MDNSStatus:
     async def async_run(self) -> None:
         dashboard = DASHBOARD
         entries = dashboard.entries
-        aiozc = AsyncEsphomeZeroconf(default_interface=self._zc_default_interface)
+        aiozc = AsyncEsphomeZeroconf(
+            default_interface=dashboard.settings.zeroconf_default_interface
+        )
         self.aiozc = aiozc
         host_mdns_state = self.host_mdns_state
 

--- a/esphome/dashboard/status/mdns.py
+++ b/esphome/dashboard/status/mdns.py
@@ -18,10 +18,11 @@ from ..entries import DashboardEntry, bool_to_entry_state
 class MDNSStatus:
     """Class that updates the mdns status."""
 
-    def __init__(self) -> None:
+    def __init__(self, default_interface=False) -> None:
         """Initialize the MDNSStatus class."""
         super().__init__()
         self.aiozc: AsyncEsphomeZeroconf | None = None
+        self._zc_default_interface: bool = default_interface
         # This is the current mdns state for each host (True, False, None)
         self.host_mdns_state: dict[str, bool | None] = {}
         self._loop = asyncio.get_running_loop()
@@ -64,7 +65,7 @@ class MDNSStatus:
     async def async_run(self) -> None:
         dashboard = DASHBOARD
         entries = dashboard.entries
-        aiozc = AsyncEsphomeZeroconf()
+        aiozc = AsyncEsphomeZeroconf(default_interface=self._zc_default_interface)
         self.aiozc = aiozc
         host_mdns_state = self.host_mdns_state
 

--- a/esphome/helpers.py
+++ b/esphome/helpers.py
@@ -101,10 +101,13 @@ def is_ip_address(host):
 
 def _resolve_with_zeroconf(host):
     from esphome.core import EsphomeError
+    from esphome.dashboard.core import DASHBOARD
     from esphome.zeroconf import EsphomeZeroconf
 
     try:
-        zc = EsphomeZeroconf()
+        zc = EsphomeZeroconf(
+            default_interface=DASHBOARD.settings.zeroconf_default_interface
+        )
     except Exception as err:
         raise EsphomeError(
             "Cannot start mDNS sockets, is this a docker container without "

--- a/esphome/zeroconf.py
+++ b/esphome/zeroconf.py
@@ -5,7 +5,13 @@ from dataclasses import dataclass
 import logging
 from typing import Callable
 
-from zeroconf import IPVersion, ServiceInfo, ServiceStateChange, Zeroconf
+from zeroconf import (
+    InterfaceChoice,
+    IPVersion,
+    ServiceInfo,
+    ServiceStateChange,
+    Zeroconf,
+)
 from zeroconf.asyncio import AsyncServiceBrowser, AsyncServiceInfo, AsyncZeroconf
 
 from esphome.storage_json import StorageJSON, ext_storage_path
@@ -176,6 +182,13 @@ def _make_host_resolver(host: str) -> HostResolver:
 
 
 class EsphomeZeroconf(Zeroconf):
+    def __init__(self, default_interface=False) -> None:
+        super().__init__(
+            interfaces=(
+                InterfaceChoice.Default if default_interface else InterfaceChoice.All
+            )
+        )
+
     def resolve_host(self, host: str, timeout: float = 3.0) -> str | None:
         """Resolve a host name to an IP address."""
         info = _make_host_resolver(host)
@@ -188,6 +201,13 @@ class EsphomeZeroconf(Zeroconf):
 
 
 class AsyncEsphomeZeroconf(AsyncZeroconf):
+    def __init__(self, default_interface=False) -> None:
+        super().__init__(
+            interfaces=(
+                InterfaceChoice.Default if default_interface else InterfaceChoice.All
+            )
+        )
+
     async def async_resolve_host(self, host: str, timeout: float = 3.0) -> str | None:
         """Resolve a host name to an IP address."""
         info = _make_host_resolver(host)


### PR DESCRIPTION
# What does this implement/fix?

Add a setting (via environment vars) to use the default interface for Zeroconf instead of all interfaces.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/issues/issues/6411

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment
N/A

## Example entry for `config.yaml`:
N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

Are these env vars documented anywhere?
