### PR TITLE
Updated dfplayer logging to be more user-friendly

### DIFF
--- a/esphome/components/dfplayer/dfplayer.cpp
+++ b/esphome/components/dfplayer/dfplayer.cpp
@@ -11,6 +11,7 @@ void DFPlayer::next() {
   ESP_LOGD(TAG, "Playing next track");
   this->send_cmd_(0x01);
 }
+
 void DFPlayer::previous() {
   this->ack_set_is_playing_ = true;
   ESP_LOGD(TAG, "Playing previous track");
@@ -21,66 +22,80 @@ void DFPlayer::play_mp3(uint16_t file) {
   ESP_LOGD(TAG, "Playing file %d in mp3 folder", file);
   this->send_cmd_(0x12, file);
 }
+
 void DFPlayer::play_file(uint16_t file) {
   this->ack_set_is_playing_ = true;
   ESP_LOGD(TAG, "Playing file %d", file);
   this->send_cmd_(0x03, file);
 }
+
 void DFPlayer::play_file_loop(uint16_t file) {
   this->ack_set_is_playing_ = true;
   ESP_LOGD(TAG, "Playing file %d in loop", file);
   this->send_cmd_(0x08, file);
 }
+
 void DFPlayer::play_folder_loop(uint16_t folder) {
   this->ack_set_is_playing_ = true;
   ESP_LOGD(TAG, "Playing folder %d in loop", folder);
   this->send_cmd_(0x17, folder);
 }
+
 void DFPlayer::volume_up() {
   ESP_LOGD(TAG, "Increasing volume");
   this->send_cmd_(0x04);
 }
+
 void DFPlayer::volume_down() {
   ESP_LOGD(TAG, "Decreasing volume");
   this->send_cmd_(0x05);
 }
+
 void DFPlayer::set_device(Device device) {
   ESP_LOGD(TAG, "Setting device to %d", device);
   this->send_cmd_(0x09, device);
 }
+
 void DFPlayer::set_volume(uint8_t volume) {
   ESP_LOGD(TAG, "Setting volume to %d", volume);
   this->send_cmd_(0x06, volume);
 }
+
 void DFPlayer::set_eq(EqPreset preset) {
   ESP_LOGD(TAG, "Setting EQ to %d", preset);
   this->send_cmd_(0x07, preset);
 }
+
 void DFPlayer::sleep() {
   this->ack_reset_is_playing_ = true;
   ESP_LOGD(TAG, "Putting DFPlayer to sleep");
   this->send_cmd_(0x0A);
 }
+
 void DFPlayer::reset() {
   this->ack_reset_is_playing_ = true;
   ESP_LOGD(TAG, "Resetting DFPlayer");
   this->send_cmd_(0x0C);
 }
+
 void DFPlayer::start() {
   this->ack_set_is_playing_ = true;
   ESP_LOGD(TAG, "Starting playback");
   this->send_cmd_(0x0D);
 }
+
 void DFPlayer::pause() {
   this->ack_reset_is_playing_ = true;
   ESP_LOGD(TAG, "Pausing playback");
   this->send_cmd_(0x0E);
 }
+
 void DFPlayer::stop() {
   this->ack_reset_is_playing_ = true;
   ESP_LOGD(TAG, "Stopping playback");
   this->send_cmd_(0x16);
 }
+
 void DFPlayer::random() {
   this->ack_set_is_playing_ = true;
   ESP_LOGD(TAG, "Playing random file");
@@ -183,27 +198,37 @@ void DFPlayer::loop() {
             ESP_LOGV(TAG, "Nack");
             this->ack_set_is_playing_ = false;
             this->ack_reset_is_playing_ = false;
-            if (argument == 0x01) {
-              ESP_LOGE(TAG, "Module is busy or uninitialized");
-            } else if (argument == 0x02) {
-              ESP_LOGE(TAG, "Module is in sleep mode");
-            } else if (argument == 0x03) {
-              ESP_LOGE(TAG, "Serial receive error");
-            } else if (argument == 0x04) {
-              ESP_LOGE(TAG, "Checksum incorrect");
-            } else if (argument == 0x05) {
-              ESP_LOGE(TAG, "Specified track is out of current track scope");
-              this->is_playing_ = false;
-            } else if (argument == 0x06) {
-              ESP_LOGE(TAG, "Specified track is not found");
-              this->is_playing_ = false;
-            } else if (argument == 0x07) {
-              ESP_LOGE(TAG, "Insertion error (an inserting operation only can be done when a track is being played)");
-            } else if (argument == 0x08) {
-              ESP_LOGE(TAG, "SD card reading failed (SD card pulled out or damaged)");
-            } else if (argument == 0x09) {
-              ESP_LOGE(TAG, "Entered into sleep mode");
-              this->is_playing_ = false;
+            switch (argument) {
+              case 0x01:
+                ESP_LOGE(TAG, "Module is busy or uninitialized");
+                break;
+              case 0x02:
+                ESP_LOGE(TAG, "Module is in sleep mode");
+                break;
+              case 0x03:
+                ESP_LOGE(TAG, "Serial receive error");
+                break;
+              case 0x04:
+                ESP_LOGE(TAG, "Checksum incorrect");
+                break;
+              case 0x05:
+                ESP_LOGE(TAG, "Specified track is out of current track scope");
+                this->is_playing_ = false;
+                break;
+              case 0x06:
+                ESP_LOGE(TAG, "Specified track is not found");
+                this->is_playing_ = false;
+                break;
+              case 0x07:
+                ESP_LOGE(TAG, "Insertion error (an inserting operation only can be done when a track is being played)");
+                break;
+              case 0x08:
+                ESP_LOGE(TAG, "SD card reading failed (SD card pulled out or damaged)");
+                break;
+              case 0x09:
+                ESP_LOGE(TAG, "Entered into sleep mode");
+                this->is_playing_ = false;
+                break;
             }
             break;
           case 0x41:

--- a/esphome/components/dfplayer/dfplayer.cpp
+++ b/esphome/components/dfplayer/dfplayer.cpp
@@ -4,6 +4,89 @@
 namespace esphome {
 namespace dfplayer {
 
+static const char *const TAG = "dfplayer";
+
+void DFPlayer::next() {
+  this->ack_set_is_playing_ = true;
+  ESP_LOGD(TAG, "Playing next track");
+  this->send_cmd_(0x01);
+}
+void DFPlayer::previous() {
+  this->ack_set_is_playing_ = true;
+  ESP_LOGD(TAG, "Playing previous track");
+  this->send_cmd_(0x02);
+}
+void DFPlayer::play_mp3(uint16_t file) {
+  this->ack_set_is_playing_ = true;
+  ESP_LOGD(TAG, "Playing file %d in mp3 folder", file);
+  this->send_cmd_(0x12, file);
+}
+void DFPlayer::play_file(uint16_t file) {
+  this->ack_set_is_playing_ = true;
+  ESP_LOGD(TAG, "Playing file %d", file);
+  this->send_cmd_(0x03, file);
+}
+void DFPlayer::play_file_loop(uint16_t file) {
+  this->ack_set_is_playing_ = true;
+  ESP_LOGD(TAG, "Playing file %d in loop", file);
+  this->send_cmd_(0x08, file);
+}
+void DFPlayer::play_folder_loop(uint16_t folder) {
+  this->ack_set_is_playing_ = true;
+  ESP_LOGD(TAG, "Playing folder %d in loop", folder);
+  this->send_cmd_(0x17, folder);
+}
+void DFPlayer::volume_up() {
+  ESP_LOGD(TAG, "Increasing volume");
+  this->send_cmd_(0x04);
+}
+void DFPlayer::volume_down() {
+  ESP_LOGD(TAG, "Decreasing volume");
+  this->send_cmd_(0x05);
+}
+void DFPlayer::set_device(Device device) {
+  ESP_LOGD(TAG, "Setting device to %d", device);
+  this->send_cmd_(0x09, device);
+}
+void DFPlayer::set_volume(uint8_t volume) {
+  ESP_LOGD(TAG, "Setting volume to %d", volume);
+  this->send_cmd_(0x06, volume);
+}
+void DFPlayer::set_eq(EqPreset preset) {
+  ESP_LOGD(TAG, "Setting EQ to %d", preset);
+  this->send_cmd_(0x07, preset);
+}
+void DFPlayer::sleep() {
+  this->ack_reset_is_playing_ = true;
+  ESP_LOGD(TAG, "Putting DFPlayer to sleep");
+  this->send_cmd_(0x0A);
+}
+void DFPlayer::reset() {
+  this->ack_reset_is_playing_ = true;
+  ESP_LOGD(TAG, "Resetting DFPlayer");
+  this->send_cmd_(0x0C);
+}
+void DFPlayer::start() {
+  this->ack_set_is_playing_ = true;
+  ESP_LOGD(TAG, "Starting playback");
+  this->send_cmd_(0x0D);
+}
+void DFPlayer::pause() {
+  this->ack_reset_is_playing_ = true;
+  ESP_LOGD(TAG, "Pausing playback");
+  this->send_cmd_(0x0E);
+}
+void DFPlayer::stop() {
+  this->ack_reset_is_playing_ = true;
+  ESP_LOGD(TAG, "Stopping playback");
+  this->send_cmd_(0x16);
+}
+void DFPlayer::random() {
+  this->ack_set_is_playing_ = true;
+  ESP_LOGD(TAG, "Playing random file");
+  this->send_cmd_(0x18);
+}
+
 void DFPlayer::play_folder(uint16_t folder, uint16_t file) {
   ESP_LOGD(TAG, "Playing file %d in folder %d", file, folder);
   if (folder < 100 && file < 256) {

--- a/esphome/components/dfplayer/dfplayer.h
+++ b/esphome/components/dfplayer/dfplayer.h
@@ -5,6 +5,7 @@
 #include "esphome/core/automation.h"
 
 const size_t DFPLAYER_READ_BUFFER_LENGTH = 25;  // two messages + some extra
+static const char *const TAG = "dfplayer";
 
 namespace esphome {
 namespace dfplayer {
@@ -23,62 +24,91 @@ enum Device {
   TF_CARD = 2,
 };
 
+// See the datasheet here:
+// https://github.com/DFRobot/DFRobotDFPlayerMini/blob/master/doc/FN-M16P%2BEmbedded%2BMP3%2BAudio%2BModule%2BDatasheet.pdf
 class DFPlayer : public uart::UARTDevice, public Component {
  public:
   void loop() override;
 
   void next() {
     this->ack_set_is_playing_ = true;
+    ESP_LOGD(TAG, "Playing next track");
     this->send_cmd_(0x01);
   }
   void previous() {
     this->ack_set_is_playing_ = true;
+    ESP_LOGD(TAG, "Playing previous track");
     this->send_cmd_(0x02);
   }
   void play_mp3(uint16_t file) {
     this->ack_set_is_playing_ = true;
+    ESP_LOGD(TAG, "Playing file %d in mp3 folder", file);
     this->send_cmd_(0x12, file);
   }
   void play_file(uint16_t file) {
     this->ack_set_is_playing_ = true;
+    ESP_LOGD(TAG, "Playing file %d", file);
     this->send_cmd_(0x03, file);
   }
   void play_file_loop(uint16_t file) {
     this->ack_set_is_playing_ = true;
+    ESP_LOGD(TAG, "Playing file %d in loop", file);
     this->send_cmd_(0x08, file);
   }
   void play_folder(uint16_t folder, uint16_t file);
   void play_folder_loop(uint16_t folder) {
     this->ack_set_is_playing_ = true;
+    ESP_LOGD(TAG, "Playing folder %d in loop", folder);
     this->send_cmd_(0x17, folder);
   }
-  void volume_up() { this->send_cmd_(0x04); }
-  void volume_down() { this->send_cmd_(0x05); }
-  void set_device(Device device) { this->send_cmd_(0x09, device); }
-  void set_volume(uint8_t volume) { this->send_cmd_(0x06, volume); }
-  void set_eq(EqPreset preset) { this->send_cmd_(0x07, preset); }
+  void volume_up() {
+    ESP_LOGD(TAG, "Increasing volume");
+    this->send_cmd_(0x04);
+  }
+  void volume_down() {
+    ESP_LOGD(TAG, "Decreasing volume");
+    this->send_cmd_(0x05);
+  }
+  void set_device(Device device) {
+    ESP_LOGD(TAG, "Setting device to %d", device);
+    this->send_cmd_(0x09, device);
+  }
+  void set_volume(uint8_t volume) {
+    ESP_LOGD(TAG, "Setting volume to %d", volume);
+    this->send_cmd_(0x06, volume);
+  }
+  void set_eq(EqPreset preset) {
+    ESP_LOGD(TAG, "Setting EQ to %d", preset);
+    this->send_cmd_(0x07, preset);
+  }
   void sleep() {
     this->ack_reset_is_playing_ = true;
+    ESP_LOGD(TAG, "Putting DFPlayer to sleep");
     this->send_cmd_(0x0A);
   }
   void reset() {
     this->ack_reset_is_playing_ = true;
+    ESP_LOGD(TAG, "Resetting DFPlayer");
     this->send_cmd_(0x0C);
   }
   void start() {
     this->ack_set_is_playing_ = true;
+    ESP_LOGD(TAG, "Starting playback");
     this->send_cmd_(0x0D);
   }
   void pause() {
     this->ack_reset_is_playing_ = true;
+    ESP_LOGD(TAG, "Pausing playback");
     this->send_cmd_(0x0E);
   }
   void stop() {
     this->ack_reset_is_playing_ = true;
+    ESP_LOGD(TAG, "Stopping playback");
     this->send_cmd_(0x16);
   }
   void random() {
     this->ack_set_is_playing_ = true;
+    ESP_LOGD(TAG, "Playing random file");
     this->send_cmd_(0x18);
   }
 

--- a/esphome/components/dfplayer/dfplayer.h
+++ b/esphome/components/dfplayer/dfplayer.h
@@ -5,7 +5,6 @@
 #include "esphome/core/automation.h"
 
 const size_t DFPLAYER_READ_BUFFER_LENGTH = 25;  // two messages + some extra
-static const char *const TAG = "dfplayer";
 
 namespace esphome {
 namespace dfplayer {
@@ -30,87 +29,24 @@ class DFPlayer : public uart::UARTDevice, public Component {
  public:
   void loop() override;
 
-  void next() {
-    this->ack_set_is_playing_ = true;
-    ESP_LOGD(TAG, "Playing next track");
-    this->send_cmd_(0x01);
-  }
-  void previous() {
-    this->ack_set_is_playing_ = true;
-    ESP_LOGD(TAG, "Playing previous track");
-    this->send_cmd_(0x02);
-  }
-  void play_mp3(uint16_t file) {
-    this->ack_set_is_playing_ = true;
-    ESP_LOGD(TAG, "Playing file %d in mp3 folder", file);
-    this->send_cmd_(0x12, file);
-  }
-  void play_file(uint16_t file) {
-    this->ack_set_is_playing_ = true;
-    ESP_LOGD(TAG, "Playing file %d", file);
-    this->send_cmd_(0x03, file);
-  }
-  void play_file_loop(uint16_t file) {
-    this->ack_set_is_playing_ = true;
-    ESP_LOGD(TAG, "Playing file %d in loop", file);
-    this->send_cmd_(0x08, file);
-  }
+  void next();
+  void previous();
+  void play_mp3(uint16_t file);
+  void play_file(uint16_t file);
+  void play_file_loop(uint16_t file);
   void play_folder(uint16_t folder, uint16_t file);
-  void play_folder_loop(uint16_t folder) {
-    this->ack_set_is_playing_ = true;
-    ESP_LOGD(TAG, "Playing folder %d in loop", folder);
-    this->send_cmd_(0x17, folder);
-  }
-  void volume_up() {
-    ESP_LOGD(TAG, "Increasing volume");
-    this->send_cmd_(0x04);
-  }
-  void volume_down() {
-    ESP_LOGD(TAG, "Decreasing volume");
-    this->send_cmd_(0x05);
-  }
-  void set_device(Device device) {
-    ESP_LOGD(TAG, "Setting device to %d", device);
-    this->send_cmd_(0x09, device);
-  }
-  void set_volume(uint8_t volume) {
-    ESP_LOGD(TAG, "Setting volume to %d", volume);
-    this->send_cmd_(0x06, volume);
-  }
-  void set_eq(EqPreset preset) {
-    ESP_LOGD(TAG, "Setting EQ to %d", preset);
-    this->send_cmd_(0x07, preset);
-  }
-  void sleep() {
-    this->ack_reset_is_playing_ = true;
-    ESP_LOGD(TAG, "Putting DFPlayer to sleep");
-    this->send_cmd_(0x0A);
-  }
-  void reset() {
-    this->ack_reset_is_playing_ = true;
-    ESP_LOGD(TAG, "Resetting DFPlayer");
-    this->send_cmd_(0x0C);
-  }
-  void start() {
-    this->ack_set_is_playing_ = true;
-    ESP_LOGD(TAG, "Starting playback");
-    this->send_cmd_(0x0D);
-  }
-  void pause() {
-    this->ack_reset_is_playing_ = true;
-    ESP_LOGD(TAG, "Pausing playback");
-    this->send_cmd_(0x0E);
-  }
-  void stop() {
-    this->ack_reset_is_playing_ = true;
-    ESP_LOGD(TAG, "Stopping playback");
-    this->send_cmd_(0x16);
-  }
-  void random() {
-    this->ack_set_is_playing_ = true;
-    ESP_LOGD(TAG, "Playing random file");
-    this->send_cmd_(0x18);
-  }
+  void play_folder_loop(uint16_t folder);
+  void volume_up();
+  void volume_down();
+  void set_device(Device device);
+  void set_volume(uint8_t volume);
+  void set_eq(EqPreset preset);
+  void sleep();
+  void reset();
+  void start();
+  void pause();
+  void stop();
+  void random();
 
   bool is_playing() { return is_playing_; }
   void dump_config() override;


### PR DESCRIPTION
# What does this implement/fix?

I spent a number of hours troubleshooting a dfplayer, decoding hex output and stuff.

I think the logging can be improved to save time in the future. Specifically:

* LOGD for all actual dfplayer actions in human-readable form
* LOGV for any hex dump (was LOGD previously)
* LOGE for all errors, and expand the coverage for error codes

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- https://github.com/esphome/issues/issues/5174 is an example of an issue that would probably be easily debuggable with this PR in place.

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
