### PR TITLE
[i2s_audio] I2S speaker improvements

### DIFF
--- a/esphome/components/i2s_audio/speaker/__init__.py
+++ b/esphome/components/i2s_audio/speaker/__init__.py
@@ -2,7 +2,7 @@ from esphome import pins
 import esphome.codegen as cg
 from esphome.components import esp32, speaker
 import esphome.config_validation as cv
-from esphome.const import CONF_CHANNEL, CONF_ID, CONF_MODE, CONF_TIMEOUT
+from esphome.const import CONF_CHANNEL, CONF_DISABLED, CONF_ID, CONF_MODE, CONF_TIMEOUT
 
 from .. import (
     CONF_I2S_DOUT_PIN,
@@ -72,9 +72,10 @@ BASE_SCHEMA = (
     )
     .extend(
         {
-            cv.Optional(
-                CONF_TIMEOUT, default="500ms"
-            ): cv.positive_time_period_milliseconds,
+            cv.Optional(CONF_TIMEOUT, default="500ms"): cv.Any(
+                cv.positive_time_period_milliseconds,
+                cv.one_of(CONF_DISABLED, lower=True),
+            ),
         }
     )
     .extend(cv.COMPONENT_SCHEMA)
@@ -116,4 +117,5 @@ async def to_code(config):
     else:
         cg.add(var.set_dout_pin(config[CONF_I2S_DOUT_PIN]))
         cg.add(var.set_i2s_comm_fmt(config[CONF_I2S_COMM_FMT]))
-    cg.add(var.set_timeout(config[CONF_TIMEOUT]))
+    if config[CONF_TIMEOUT] != CONF_DISABLED:
+        cg.add(var.set_timeout(config[CONF_TIMEOUT]))

--- a/esphome/components/i2s_audio/speaker/__init__.py
+++ b/esphome/components/i2s_audio/speaker/__init__.py
@@ -2,7 +2,7 @@ from esphome import pins
 import esphome.codegen as cg
 from esphome.components import esp32, speaker
 import esphome.config_validation as cv
-from esphome.const import CONF_CHANNEL, CONF_DISABLED, CONF_ID, CONF_MODE, CONF_TIMEOUT
+from esphome.const import CONF_CHANNEL, CONF_ID, CONF_MODE, CONF_TIMEOUT
 
 from .. import (
     CONF_I2S_DOUT_PIN,
@@ -27,6 +27,7 @@ I2SAudioSpeaker = i2s_audio_ns.class_(
 CONF_BUFFER_DURATION = "buffer_duration"
 CONF_DAC_TYPE = "dac_type"
 CONF_I2S_COMM_FMT = "i2s_comm_fmt"
+CONF_NEVER = "never"
 
 i2s_dac_mode_t = cg.global_ns.enum("i2s_dac_mode_t")
 INTERNAL_DAC_OPTIONS = {
@@ -77,7 +78,7 @@ BASE_SCHEMA = (
             ): cv.positive_time_period_milliseconds,
             cv.Optional(CONF_TIMEOUT, default="500ms"): cv.Any(
                 cv.positive_time_period_milliseconds,
-                cv.one_of(CONF_DISABLED, lower=True),
+                cv.one_of(CONF_NEVER, lower=True),
             ),
         }
     )
@@ -120,6 +121,6 @@ async def to_code(config):
     else:
         cg.add(var.set_dout_pin(config[CONF_I2S_DOUT_PIN]))
         cg.add(var.set_i2s_comm_fmt(config[CONF_I2S_COMM_FMT]))
-    if config[CONF_TIMEOUT] != CONF_DISABLED:
+    if config[CONF_TIMEOUT] != CONF_NEVER:
         cg.add(var.set_timeout(config[CONF_TIMEOUT]))
     cg.add(var.set_buffer_duration(config[CONF_BUFFER_DURATION]))

--- a/esphome/components/i2s_audio/speaker/__init__.py
+++ b/esphome/components/i2s_audio/speaker/__init__.py
@@ -24,7 +24,7 @@ I2SAudioSpeaker = i2s_audio_ns.class_(
     "I2SAudioSpeaker", cg.Component, speaker.Speaker, I2SAudioOut
 )
 
-
+CONF_BUFFER_DURATION = "buffer_duration"
 CONF_DAC_TYPE = "dac_type"
 CONF_I2S_COMM_FMT = "i2s_comm_fmt"
 
@@ -72,6 +72,9 @@ BASE_SCHEMA = (
     )
     .extend(
         {
+            cv.Optional(
+                CONF_BUFFER_DURATION, default="500ms"
+            ): cv.positive_time_period_milliseconds,
             cv.Optional(CONF_TIMEOUT, default="500ms"): cv.Any(
                 cv.positive_time_period_milliseconds,
                 cv.one_of(CONF_DISABLED, lower=True),
@@ -119,3 +122,4 @@ async def to_code(config):
         cg.add(var.set_i2s_comm_fmt(config[CONF_I2S_COMM_FMT]))
     if config[CONF_TIMEOUT] != CONF_DISABLED:
         cg.add(var.set_timeout(config[CONF_TIMEOUT]))
+    cg.add(var.set_buffer_duration(config[CONF_BUFFER_DURATION]))

--- a/esphome/components/i2s_audio/speaker/i2s_audio_speaker.cpp
+++ b/esphome/components/i2s_audio/speaker/i2s_audio_speaker.cpp
@@ -17,7 +17,6 @@ static const uint8_t DMA_BUFFER_DURATION_MS = 15;
 static const size_t DMA_BUFFERS_COUNT = 4;
 
 static const size_t TASK_DELAY_MS = DMA_BUFFER_DURATION_MS * DMA_BUFFERS_COUNT / 2;
-static const uint32_t RING_BUFFER_DURATION_MS = 500;
 
 static const size_t TASK_STACK_SIZE = 4096;
 static const ssize_t TASK_PRIORITY = 23;
@@ -251,7 +250,7 @@ void I2SAudioSpeaker::speaker_task(void *params) {
   const size_t dma_buffers_size = DMA_BUFFERS_COUNT * DMA_BUFFER_DURATION_MS * this_speaker->sample_rate_ / 1000 *
                                   bytes_per_sample * number_of_channels;
   const size_t ring_buffer_size =
-      RING_BUFFER_DURATION_MS * this_speaker->sample_rate_ / 1000 * bytes_per_sample * number_of_channels;
+      this_speaker->buffer_duration_ms_ * this_speaker->sample_rate_ / 1000 * bytes_per_sample * number_of_channels;
 
   if (this_speaker->send_esp_err_to_event_group_(this_speaker->allocate_buffers_(dma_buffers_size, ring_buffer_size))) {
     // Failed to allocate buffers

--- a/esphome/components/i2s_audio/speaker/i2s_audio_speaker.cpp
+++ b/esphome/components/i2s_audio/speaker/i2s_audio_speaker.cpp
@@ -208,7 +208,10 @@ size_t I2SAudioSpeaker::play(const uint8_t *data, size_t length, TickType_t tick
   }
 
   size_t bytes_written = 0;
-  if (this->audio_ring_buffer_.use_count() == 1) {
+  if ((this->state_ == speaker::STATE_RUNNING) && (this->audio_ring_buffer_.use_count() == 1)) {
+    // Only one owner of the ring buffer (the speaker task), so the ring buffer is allocated and no other components are
+    // attempting to write to it.
+
     // Temporarily share ownership of the ring buffer so it won't be deallocated while writing
     std::shared_ptr<RingBuffer> temp_ring_buffer = this->audio_ring_buffer_;
     bytes_written = temp_ring_buffer->write_without_replacement((void *) data, length, ticks_to_wait);

--- a/esphome/components/i2s_audio/speaker/i2s_audio_speaker.cpp
+++ b/esphome/components/i2s_audio/speaker/i2s_audio_speaker.cpp
@@ -13,11 +13,12 @@
 namespace esphome {
 namespace i2s_audio {
 
-static const size_t DMA_BUFFER_SIZE = 512;
+static const uint8_t DMA_BUFFER_DURATION_MS = 15;
 static const size_t DMA_BUFFERS_COUNT = 4;
-static const size_t FRAMES_IN_ALL_DMA_BUFFERS = DMA_BUFFER_SIZE * DMA_BUFFERS_COUNT;
-static const size_t RING_BUFFER_SAMPLES = 8192;
-static const size_t TASK_DELAY_MS = 10;
+
+static const size_t TASK_DELAY_MS = DMA_BUFFER_DURATION_MS * DMA_BUFFERS_COUNT / 2;
+static const uint32_t RING_BUFFER_DURATION_MS = 2 * DMA_BUFFER_DURATION_MS * DMA_BUFFERS_COUNT;
+
 static const size_t TASK_STACK_SIZE = 4096;
 static const ssize_t TASK_PRIORITY = 23;
 
@@ -244,10 +245,12 @@ void I2SAudioSpeaker::speaker_task(void *params) {
   const ssize_t bytes_per_sample = audio_stream_info.get_bytes_per_sample();
   const uint8_t number_of_channels = audio_stream_info.channels;
 
-  const size_t dma_buffers_size = FRAMES_IN_ALL_DMA_BUFFERS * bytes_per_sample * number_of_channels;
+  const size_t dma_buffers_size = DMA_BUFFERS_COUNT * DMA_BUFFER_DURATION_MS * this_speaker->sample_rate_ / 1000 *
+                                  bytes_per_sample * number_of_channels;
+  const size_t ring_buffer_size =
+      RING_BUFFER_DURATION_MS * this_speaker->sample_rate_ / 1000 * bytes_per_sample * number_of_channels;
 
-  if (this_speaker->send_esp_err_to_event_group_(
-          this_speaker->allocate_buffers_(dma_buffers_size, RING_BUFFER_SAMPLES * bytes_per_sample))) {
+  if (this_speaker->send_esp_err_to_event_group_(this_speaker->allocate_buffers_(dma_buffers_size, ring_buffer_size))) {
     // Failed to allocate buffers
     xEventGroupSetBits(this_speaker->event_group_, SpeakerEventGroupBits::ERR_ESP_NO_MEM);
     this_speaker->delete_task_(dma_buffers_size);
@@ -419,6 +422,8 @@ esp_err_t I2SAudioSpeaker::start_i2s_driver_() {
     return ESP_ERR_INVALID_STATE;
   }
 
+  int dma_buffer_length = DMA_BUFFER_DURATION_MS * this->sample_rate_ / 1000;
+
   i2s_driver_config_t config = {
     .mode = (i2s_mode_t) (this->i2s_mode_ | I2S_MODE_TX),
     .sample_rate = this->sample_rate_,
@@ -427,7 +432,7 @@ esp_err_t I2SAudioSpeaker::start_i2s_driver_() {
     .communication_format = this->i2s_comm_fmt_,
     .intr_alloc_flags = ESP_INTR_FLAG_LEVEL1,
     .dma_buf_count = DMA_BUFFERS_COUNT,
-    .dma_buf_len = DMA_BUFFER_SIZE,
+    .dma_buf_len = dma_buffer_length,
     .use_apll = this->use_apll_,
     .tx_desc_auto_clear = true,
     .fixed_mclk = I2S_PIN_NO_CHANGE,

--- a/esphome/components/i2s_audio/speaker/i2s_audio_speaker.cpp
+++ b/esphome/components/i2s_audio/speaker/i2s_audio_speaker.cpp
@@ -24,10 +24,9 @@ static const ssize_t TASK_PRIORITY = 23;
 static const char *const TAG = "i2s_audio.speaker";
 
 enum SpeakerEventGroupBits : uint32_t {
-  COMMAND_START = (1 << 0),                           // Starts the main task purpose
-  COMMAND_STOP = (1 << 1),                            // stops the main task
-  COMMAND_STOP_GRACEFULLY = (1 << 2),                 // Stops the task once all data has been written
-  MESSAGE_RING_BUFFER_AVAILABLE_TO_WRITE = (1 << 5),  // Locks the ring buffer when not set
+  COMMAND_START = (1 << 0),            // starts the speaker task
+  COMMAND_STOP = (1 << 1),             // stops the speaker task
+  COMMAND_STOP_GRACEFULLY = (1 << 2),  // Stops the speaker task once all data has been written
   STATE_STARTING = (1 << 10),
   STATE_RUNNING = (1 << 11),
   STATE_STOPPING = (1 << 12),
@@ -199,23 +198,14 @@ size_t I2SAudioSpeaker::play(const uint8_t *data, size_t length, TickType_t tick
     this->start();
   }
 
-  // Wait for the ring buffer to be available
-  uint32_t event_bits =
-      xEventGroupWaitBits(this->event_group_, SpeakerEventGroupBits::MESSAGE_RING_BUFFER_AVAILABLE_TO_WRITE, pdFALSE,
-                          pdFALSE, pdMS_TO_TICKS(TASK_DELAY_MS));
-
-  if (event_bits & SpeakerEventGroupBits::MESSAGE_RING_BUFFER_AVAILABLE_TO_WRITE) {
-    // Ring buffer is available to write
-
-    // Lock the ring buffer, write to it, then unlock it
-    xEventGroupClearBits(this->event_group_, SpeakerEventGroupBits::MESSAGE_RING_BUFFER_AVAILABLE_TO_WRITE);
-    size_t bytes_written = this->audio_ring_buffer_->write_without_replacement((void *) data, length, ticks_to_wait);
-    xEventGroupSetBits(this->event_group_, SpeakerEventGroupBits::MESSAGE_RING_BUFFER_AVAILABLE_TO_WRITE);
-
-    return bytes_written;
+  size_t bytes_written = 0;
+  if (this->audio_ring_buffer_.use_count() == 1) {
+    // Temporarily share ownership of the ring buffer so it won't be deallocated while writing
+    std::shared_ptr<RingBuffer> temp_ring_buffer = this->audio_ring_buffer_;
+    bytes_written = temp_ring_buffer->write_without_replacement((void *) data, length, ticks_to_wait);
   }
 
-  return 0;
+  return bytes_written;
 }
 
 bool I2SAudioSpeaker::has_buffered_data() const {
@@ -258,9 +248,6 @@ void I2SAudioSpeaker::speaker_task(void *params) {
   if (this_speaker->send_esp_err_to_event_group_(this_speaker->start_i2s_driver_())) {
     // Failed to start I2S driver
     this_speaker->delete_task_(dma_buffers_size);
-  } else {
-    // Ring buffer is allocated, so indicate its can be written to
-    xEventGroupSetBits(this_speaker->event_group_, SpeakerEventGroupBits::MESSAGE_RING_BUFFER_AVAILABLE_TO_WRITE);
   }
 
   if (!this_speaker->send_esp_err_to_event_group_(this_speaker->reconfigure_i2s_stream_info_(audio_stream_info))) {
@@ -402,9 +389,9 @@ esp_err_t I2SAudioSpeaker::allocate_buffers_(size_t data_buffer_size, size_t rin
     return ESP_ERR_NO_MEM;
   }
 
-  if (this->audio_ring_buffer_ == nullptr) {
-    // Allocate ring buffer
-    this->audio_ring_buffer_ = RingBuffer::create(ring_buffer_size);
+  if (this->audio_ring_buffer_.use_count() == 0) {
+    // Allocate ring buffer. Moves the created unique_ptr to a shared_ptr to ensure it isn't improperly deallocated.
+    this->audio_ring_buffer_ = std::move(RingBuffer::create(ring_buffer_size));
   }
 
   if (this->audio_ring_buffer_ == nullptr) {
@@ -502,16 +489,7 @@ esp_err_t I2SAudioSpeaker::reconfigure_i2s_stream_info_(audio::AudioStreamInfo &
 }
 
 void I2SAudioSpeaker::delete_task_(size_t buffer_size) {
-  if (this->audio_ring_buffer_ != nullptr) {
-    xEventGroupWaitBits(this->event_group_,
-                        MESSAGE_RING_BUFFER_AVAILABLE_TO_WRITE,  // Bit message to read
-                        pdFALSE,                                 // Don't clear the bits on exit
-                        pdTRUE,                                  // Don't wait for all the bits,
-                        portMAX_DELAY);                          // Block indefinitely until a command bit is set
-
-    this->audio_ring_buffer_.reset();  // Deallocates the ring buffer stored in the unique_ptr
-    this->audio_ring_buffer_ = nullptr;
-  }
+  this->audio_ring_buffer_.reset();  // Releases onwership of the shared_ptr
 
   if (this->data_buffer_ != nullptr) {
     ExternalRAMAllocator<uint8_t> allocator(ExternalRAMAllocator<uint8_t>::ALLOW_FAILURE);

--- a/esphome/components/i2s_audio/speaker/i2s_audio_speaker.cpp
+++ b/esphome/components/i2s_audio/speaker/i2s_audio_speaker.cpp
@@ -21,6 +21,8 @@ static const size_t TASK_DELAY_MS = 10;
 static const size_t TASK_STACK_SIZE = 4096;
 static const ssize_t TASK_PRIORITY = 23;
 
+static const size_t I2S_EVENT_QUEUE_COUNT = DMA_BUFFERS_COUNT + 1;
+
 static const char *const TAG = "i2s_audio.speaker";
 
 enum SpeakerEventGroupBits : uint32_t {
@@ -90,12 +92,18 @@ static const std::vector<int16_t> Q15_VOLUME_SCALING_FACTORS = {
 void I2SAudioSpeaker::setup() {
   ESP_LOGCONFIG(TAG, "Setting up I2S Audio Speaker...");
 
-  if (this->event_group_ == nullptr) {
-    this->event_group_ = xEventGroupCreate();
-  }
+  this->event_group_ = xEventGroupCreate();
 
   if (this->event_group_ == nullptr) {
     ESP_LOGE(TAG, "Failed to create event group");
+    this->mark_failed();
+    return;
+  }
+
+  this->i2s_event_queue_ = xQueueCreate(I2S_EVENT_QUEUE_COUNT, sizeof(i2s_event_t));
+
+  if (this->i2s_event_queue_ == nullptr) {
+    ESP_LOGE(TAG, "Failed to create I2S event queue");
     this->mark_failed();
     return;
   }
@@ -257,6 +265,7 @@ void I2SAudioSpeaker::speaker_task(void *params) {
 
     bool stop_gracefully = false;
     uint32_t last_data_received_time = millis();
+    bool tx_dma_underflow = false;
 
     while ((millis() - last_data_received_time) <= this_speaker->timeout_) {
       event_group_bits = xEventGroupGetBits(this_speaker->event_group_);
@@ -268,12 +277,18 @@ void I2SAudioSpeaker::speaker_task(void *params) {
         stop_gracefully = true;
       }
 
+      i2s_event_t i2s_event;
+      while (xQueueReceive(this_speaker->i2s_event_queue_, &i2s_event, 0)) {
+        if (i2s_event.type == I2S_EVENT_TX_Q_OVF) {
+          tx_dma_underflow = true;
+        }
+      }
+
       size_t bytes_to_read = dma_buffers_size;
       size_t bytes_read = this_speaker->audio_ring_buffer_->read((void *) this_speaker->data_buffer_, bytes_to_read,
                                                                  pdMS_TO_TICKS(TASK_DELAY_MS));
 
       if (bytes_read > 0) {
-        last_data_received_time = millis();
         size_t bytes_written = 0;
 
         if ((audio_stream_info.bits_per_sample == 16) && (this_speaker->q15_volume_factor_ < INT16_MAX)) {
@@ -294,15 +309,13 @@ void I2SAudioSpeaker::speaker_task(void *params) {
         if (bytes_written != bytes_read) {
           xEventGroupSetBits(this_speaker->event_group_, SpeakerEventGroupBits::ERR_ESP_INVALID_SIZE);
         }
-
+        tx_dma_underflow = false;
+        last_data_received_time = millis();
       } else {
         // No data received
-
-        if (stop_gracefully) {
+        if (stop_gracefully && tx_dma_underflow) {
           break;
         }
-
-        i2s_zero_dma_buffer(this_speaker->parent_->get_port());
       }
     }
   } else {
@@ -313,7 +326,6 @@ void I2SAudioSpeaker::speaker_task(void *params) {
 
   xEventGroupSetBits(this_speaker->event_group_, SpeakerEventGroupBits::STATE_STOPPING);
 
-  i2s_stop(this_speaker->parent_->get_port());
   i2s_driver_uninstall(this_speaker->parent_->get_port());
 
   this_speaker->parent_->unlock();
@@ -435,7 +447,8 @@ esp_err_t I2SAudioSpeaker::start_i2s_driver_() {
   }
 #endif
 
-  esp_err_t err = i2s_driver_install(this->parent_->get_port(), &config, 0, nullptr);
+  esp_err_t err =
+      i2s_driver_install(this->parent_->get_port(), &config, I2S_EVENT_QUEUE_COUNT, &this->i2s_event_queue_);
   if (err != ESP_OK) {
     // Failed to install the driver, so unlock the I2S port
     this->parent_->unlock();
@@ -498,6 +511,7 @@ void I2SAudioSpeaker::delete_task_(size_t buffer_size) {
   }
 
   xEventGroupSetBits(this->event_group_, SpeakerEventGroupBits::STATE_STOPPED);
+  xQueueReset(this->i2s_event_queue_);
 
   this->task_created_ = false;
   vTaskDelete(nullptr);

--- a/esphome/components/i2s_audio/speaker/i2s_audio_speaker.cpp
+++ b/esphome/components/i2s_audio/speaker/i2s_audio_speaker.cpp
@@ -267,7 +267,8 @@ void I2SAudioSpeaker::speaker_task(void *params) {
     uint32_t last_data_received_time = millis();
     bool tx_dma_underflow = false;
 
-    while ((millis() - last_data_received_time) <= this_speaker->timeout_) {
+    while (!this_speaker->timeout_.has_value() ||
+           (millis() - last_data_received_time) <= this_speaker->timeout_.value()) {
       event_group_bits = xEventGroupGetBits(this_speaker->event_group_);
 
       if (event_group_bits & SpeakerEventGroupBits::COMMAND_STOP) {

--- a/esphome/components/i2s_audio/speaker/i2s_audio_speaker.cpp
+++ b/esphome/components/i2s_audio/speaker/i2s_audio_speaker.cpp
@@ -406,8 +406,8 @@ esp_err_t I2SAudioSpeaker::allocate_buffers_(size_t data_buffer_size, size_t rin
   }
 
   if (this->audio_ring_buffer_.use_count() == 0) {
-    // Allocate ring buffer. Moves the created unique_ptr to a shared_ptr to ensure it isn't improperly deallocated.
-    this->audio_ring_buffer_ = std::move(RingBuffer::create(ring_buffer_size));
+    // Allocate ring buffer. Uses a shared_ptr to ensure it isn't improperly deallocated.
+    this->audio_ring_buffer_ = RingBuffer::create(ring_buffer_size);
   }
 
   if (this->audio_ring_buffer_ == nullptr) {

--- a/esphome/components/i2s_audio/speaker/i2s_audio_speaker.cpp
+++ b/esphome/components/i2s_audio/speaker/i2s_audio_speaker.cpp
@@ -17,7 +17,7 @@ static const uint8_t DMA_BUFFER_DURATION_MS = 15;
 static const size_t DMA_BUFFERS_COUNT = 4;
 
 static const size_t TASK_DELAY_MS = DMA_BUFFER_DURATION_MS * DMA_BUFFERS_COUNT / 2;
-static const uint32_t RING_BUFFER_DURATION_MS = 2 * DMA_BUFFER_DURATION_MS * DMA_BUFFERS_COUNT;
+static const uint32_t RING_BUFFER_DURATION_MS = 500;
 
 static const size_t TASK_STACK_SIZE = 4096;
 static const ssize_t TASK_PRIORITY = 23;

--- a/esphome/components/i2s_audio/speaker/i2s_audio_speaker.h
+++ b/esphome/components/i2s_audio/speaker/i2s_audio_speaker.h
@@ -123,7 +123,7 @@ class I2SAudioSpeaker : public I2SAudioOut, public speaker::Speaker, public Comp
   uint8_t *data_buffer_;
   std::shared_ptr<RingBuffer> audio_ring_buffer_;
 
-  uint32_t timeout_;
+  optional<uint32_t> timeout_;
   uint8_t dout_pin_;
 
   bool task_created_{false};

--- a/esphome/components/i2s_audio/speaker/i2s_audio_speaker.h
+++ b/esphome/components/i2s_audio/speaker/i2s_audio_speaker.h
@@ -7,6 +7,7 @@
 #include <driver/i2s.h>
 
 #include <freertos/event_groups.h>
+#include <freertos/queue.h>
 #include <freertos/FreeRTOS.h>
 
 #include "esphome/components/audio/audio.h"
@@ -116,6 +117,8 @@ class I2SAudioSpeaker : public I2SAudioOut, public speaker::Speaker, public Comp
 
   TaskHandle_t speaker_task_handle_{nullptr};
   EventGroupHandle_t event_group_{nullptr};
+
+  QueueHandle_t i2s_event_queue_;
 
   uint8_t *data_buffer_;
   std::shared_ptr<RingBuffer> audio_ring_buffer_;

--- a/esphome/components/i2s_audio/speaker/i2s_audio_speaker.h
+++ b/esphome/components/i2s_audio/speaker/i2s_audio_speaker.h
@@ -28,6 +28,7 @@ class I2SAudioSpeaker : public I2SAudioOut, public speaker::Speaker, public Comp
   void setup() override;
   void loop() override;
 
+  void set_buffer_duration(uint32_t buffer_duration_ms) { this->buffer_duration_ms_ = buffer_duration_ms; }
   void set_timeout(uint32_t ms) { this->timeout_ = ms; }
   void set_dout_pin(uint8_t pin) { this->dout_pin_ = pin; }
 #if SOC_I2S_SUPPORTS_DAC
@@ -122,6 +123,8 @@ class I2SAudioSpeaker : public I2SAudioOut, public speaker::Speaker, public Comp
 
   uint8_t *data_buffer_;
   std::shared_ptr<RingBuffer> audio_ring_buffer_;
+
+  uint32_t buffer_duration_ms_;
 
   optional<uint32_t> timeout_;
   uint8_t dout_pin_;

--- a/esphome/components/i2s_audio/speaker/i2s_audio_speaker.h
+++ b/esphome/components/i2s_audio/speaker/i2s_audio_speaker.h
@@ -118,7 +118,7 @@ class I2SAudioSpeaker : public I2SAudioOut, public speaker::Speaker, public Comp
   EventGroupHandle_t event_group_{nullptr};
 
   uint8_t *data_buffer_;
-  std::unique_ptr<RingBuffer> audio_ring_buffer_;
+  std::shared_ptr<RingBuffer> audio_ring_buffer_;
 
   uint32_t timeout_;
   uint8_t dout_pin_;


### PR DESCRIPTION
# What does this implement/fix?

- (Bugfix) Fixes a rare crash when the speaker tries to stop while another component is writing to the ring buffer. Uses a ``shared_ptr`` to manage the ring buffer to prevent this instead of using an event group bit to lock the ring buffer.
- (Bugfix) Properly detects DMA buffer underflows so that the ``finish`` function behaves correctly. Attaches a queue during the I2S driver installation to monitor this.
- (New feature) Adds a yaml configuration option to disable stopping the speaker due to a timeout.
- (New feature) Allocates the DMA buffers and ring buffers based on the configured audio stream information. Instead of using fixed sample numbers, it takes into account the number of channels, bytes per sample, and the sample rate for consistent behavior with different settings.

Tested successfully on an ATOM Echo, Voice PE, and S3 box.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- closes #7677, as the finish function now behaves properly and will avoid a breaking change

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#4426

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

speaker:
  - platform: i2s_audio
    i2s_dout_pin: GPIO15
    dac_type: external
    sample_rate: 16000
    bits_per_sample: 16bit
    channel: stereo
    timeout: never

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
