### PR TITLE
[core] Ring buffer write functions use const pointer parameter

### DIFF
--- a/esphome/core/ring_buffer.cpp
+++ b/esphome/core/ring_buffer.cpp
@@ -46,7 +46,7 @@ size_t RingBuffer::read(void *data, size_t len, TickType_t ticks_to_wait) {
   return bytes_read;
 }
 
-size_t RingBuffer::write(void *data, size_t len) {
+size_t RingBuffer::write(const void *data, size_t len) {
   size_t free = this->free();
   if (free < len) {
     size_t needed = len - free;
@@ -56,7 +56,7 @@ size_t RingBuffer::write(void *data, size_t len) {
   return xStreamBufferSend(this->handle_, data, len, 0);
 }
 
-size_t RingBuffer::write_without_replacement(void *data, size_t len, TickType_t ticks_to_wait) {
+size_t RingBuffer::write_without_replacement(const void *data, size_t len, TickType_t ticks_to_wait) {
   return xStreamBufferSend(this->handle_, data, len, ticks_to_wait);
 }
 

--- a/esphome/core/ring_buffer.h
+++ b/esphome/core/ring_buffer.h
@@ -37,7 +37,7 @@ class RingBuffer {
    * @param len Number of bytes to write
    * @return Number of bytes written
    */
-  size_t write(void *data, size_t len);
+  size_t write(const void *data, size_t len);
 
   /**
    * @brief Writes to the ring buffer without overwriting oldest data.
@@ -50,7 +50,7 @@ class RingBuffer {
    * @param ticks_to_wait Maximum number of FreeRTOS ticks to wait (default: 0)
    * @return Number of bytes written
    */
-  size_t write_without_replacement(void *data, size_t len, TickType_t ticks_to_wait = 0);
+  size_t write_without_replacement(const void *data, size_t len, TickType_t ticks_to_wait = 0);
 
   /**
    * @brief Returns the number of available bytes in the ring buffer.


### PR DESCRIPTION
# What does this implement/fix?

Specifies data pointers in the ring buffers are const.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** 

not applicable

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

not applicable

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
