### PR TITLE
[sun] Implements `is_above_horizon()`

### DIFF
--- a/esphome/components/sun/sun.h
+++ b/esphome/components/sun/sun.h
@@ -59,6 +59,9 @@ class Sun {
   void set_latitude(double latitude) { location_.latitude = latitude; }
   void set_longitude(double longitude) { location_.longitude = longitude; }
 
+  // Check if the sun is above the horizon, with a default elevation angle of -0.83333 (standard for sunrise/set).
+  bool is_above_horizon(double elevation = -0.83333) { return this->elevation() > elevation; }
+
   optional<ESPTime> sunrise(double elevation);
   optional<ESPTime> sunset(double elevation);
   optional<ESPTime> sunrise(ESPTime date, double elevation);


### PR DESCRIPTION
# What does this implement/fix?

This adds `is_above_horizon()` to the API, which will return `true` when the Sun is above the horizon (or given/optional elevation).
A similar condition is already available for yaml, but not in the API in a way it could be used inside a lambda.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [X] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
N/A
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
