### PR TITLE
feat(MQTT): Add `mqtt.subscribe` action

### DIFF
--- a/esphome/components/mqtt/__init__.py
+++ b/esphome/components/mqtt/__init__.py
@@ -623,9 +623,7 @@ async def mqtt_subscribe_to_code(config, action_id, template_arg, args):
     if CONF_PAYLOAD in config:
         template_ = await cg.templatable(config[CONF_PAYLOAD], args, cg.std_string)
         cg.add(var.set_payload(template_))
-    await automation.build_automation(
-        var.get_trigger(), [(cg.std_string, "x")], config
-    )
+    await automation.build_automation(var.get_trigger(), [(cg.std_string, "x")], config)
     return var
 
 

--- a/esphome/components/mqtt/__init__.py
+++ b/esphome/components/mqtt/__init__.py
@@ -436,7 +436,11 @@ async def to_code(config):
     for conf in config.get(CONF_ON_MESSAGE, []):
         trig = cg.new_Pvariable(conf[CONF_TRIGGER_ID])
         if CONF_PAYLOAD in conf:
-            cg.add(trig.subscribe(var, conf[CONF_TOPIC], conf[CONF_QOS], conf[CONF_PAYLOAD]))
+            cg.add(
+                trig.subscribe(
+                    var, conf[CONF_TOPIC], conf[CONF_QOS], conf[CONF_PAYLOAD]
+                )
+            )
         else:
             cg.add(trig.subscribe(var, conf[CONF_TOPIC], conf[CONF_QOS]))
         await automation.build_automation(trig, [(cg.std_string, "x")], conf)
@@ -606,7 +610,7 @@ async def mqtt_disable_to_code(config, action_id, template_arg, args):
             cv.Optional(CONF_QOS, default=0): cv.templatable(cv.mqtt_qos),
             cv.Optional(CONF_PAYLOAD): cv.templatable(cv.string_strict),
         },
-        single=True
+        single=True,
     ),
 )
 async def mqtt_subscribe_to_code(config, action_id, template_arg, args):
@@ -619,7 +623,9 @@ async def mqtt_subscribe_to_code(config, action_id, template_arg, args):
     if CONF_PAYLOAD in config:
         template_ = await cg.templatable(config[CONF_PAYLOAD], args, cg.std_string)
         cg.add(var.set_payload(template_))
-    await automation.build_automation(var.get_trigger(), [(cg.std_string, "x")], config)
+    await automation.build_automation(
+        var.get_trigger(), [(cg.std_string, "x")], config
+    )
     return var
 
 
@@ -633,7 +639,7 @@ async def mqtt_subscribe_to_code(config, action_id, template_arg, args):
             cv.Required(CONF_TOPIC): cv.templatable(cv.subscribe_topic),
             cv.Optional(CONF_QOS, default=0): cv.templatable(cv.mqtt_qos),
         },
-        single=True
+        single=True,
     ),
 )
 async def mqtt_subscribe_json_to_code(config, action_id, template_arg, args):
@@ -643,5 +649,7 @@ async def mqtt_subscribe_json_to_code(config, action_id, template_arg, args):
     cg.add(var.set_topic(template_))
     template_ = await cg.templatable(config[CONF_QOS], args, cg.uint8)
     cg.add(var.set_qos(template_))
-    await automation.build_automation(var.get_trigger(), [(cg.JsonObjectConst, "x")], config)
+    await automation.build_automation(
+        var.get_trigger(), [(cg.JsonObjectConst, "x")], config
+    )
     return var

--- a/esphome/components/mqtt/__init__.py
+++ b/esphome/components/mqtt/__init__.py
@@ -64,6 +64,7 @@ def AUTO_LOAD():
     return ["json"]
 
 
+CONF_MQTT_CLIENT_ID = "mqtt_client_id"
 CONF_DISCOVER_IP = "discover_ip"
 CONF_IDF_SEND_ASYNC = "idf_send_async"
 CONF_SKIP_CERT_CN_CHECK = "skip_cert_cn_check"
@@ -102,8 +103,11 @@ MQTTPublishAction = mqtt_ns.class_("MQTTPublishAction", automation.Action)
 MQTTPublishJsonAction = mqtt_ns.class_("MQTTPublishJsonAction", automation.Action)
 MQTTEnableAction = mqtt_ns.class_("MQTTEnableAction", automation.Action)
 MQTTDisableAction = mqtt_ns.class_("MQTTDisableAction", automation.Action)
+MQTTSubscribeAction = mqtt_ns.class_("MQTTSubscribeAction", automation.Action)
+MQTTSubscribeJsonAction = mqtt_ns.class_("MQTTSubscribeJsonAction", automation.Action)
+MQTTUnsubscribeAction = mqtt_ns.class_("MQTTUnsubscribeAction", automation.Action)
 MQTTMessageTrigger = mqtt_ns.class_(
-    "MQTTMessageTrigger", automation.Trigger.template(cg.std_string), cg.Component
+    "MQTTMessageTrigger", automation.Trigger.template(cg.std_string)
 )
 MQTTJsonMessageTrigger = mqtt_ns.class_(
     "MQTTJsonMessageTrigger", automation.Trigger.template(cg.JsonObjectConst)
@@ -430,15 +434,16 @@ async def to_code(config):
     # end esp-idf
 
     for conf in config.get(CONF_ON_MESSAGE, []):
-        trig = cg.new_Pvariable(conf[CONF_TRIGGER_ID], conf[CONF_TOPIC])
-        cg.add(trig.set_qos(conf[CONF_QOS]))
+        trig = cg.new_Pvariable(conf[CONF_TRIGGER_ID])
         if CONF_PAYLOAD in conf:
-            cg.add(trig.set_payload(conf[CONF_PAYLOAD]))
-        await cg.register_component(trig, conf)
+            cg.add(trig.subscribe(var, conf[CONF_TOPIC], conf[CONF_QOS], conf[CONF_PAYLOAD]))
+        else:
+            cg.add(trig.subscribe(var, conf[CONF_TOPIC], conf[CONF_QOS]))
         await automation.build_automation(trig, [(cg.std_string, "x")], conf)
 
     for conf in config.get(CONF_ON_JSON_MESSAGE, []):
-        trig = cg.new_Pvariable(conf[CONF_TRIGGER_ID], conf[CONF_TOPIC], conf[CONF_QOS])
+        trig = cg.new_Pvariable(conf[CONF_TRIGGER_ID])
+        cg.add(trig.subscribe(var, conf[CONF_TOPIC], conf[CONF_QOS]))
         await automation.build_automation(trig, [(cg.JsonObjectConst, "x")], conf)
 
     for conf in config.get(CONF_ON_CONNECT, []):
@@ -588,3 +593,55 @@ async def mqtt_enable_to_code(config, action_id, template_arg, args):
 async def mqtt_disable_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
     return cg.new_Pvariable(action_id, template_arg, paren)
+
+
+@automation.register_action(
+    "mqtt.subscribe",
+    MQTTSubscribeAction,
+    automation.validate_automation(
+        {
+            cv.GenerateID(CONF_MQTT_CLIENT_ID): cv.use_id(MQTTClientComponent),
+            cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(MQTTMessageTrigger),
+            cv.Required(CONF_TOPIC): cv.templatable(cv.subscribe_topic),
+            cv.Optional(CONF_QOS, default=0): cv.templatable(cv.mqtt_qos),
+            cv.Optional(CONF_PAYLOAD): cv.templatable(cv.string_strict),
+        },
+        single=True
+    ),
+)
+async def mqtt_subscribe_to_code(config, action_id, template_arg, args):
+    paren = await cg.get_variable(config[CONF_MQTT_CLIENT_ID])
+    var = cg.new_Pvariable(action_id, template_arg, paren)
+    template_ = await cg.templatable(config[CONF_TOPIC], args, cg.std_string)
+    cg.add(var.set_topic(template_))
+    template_ = await cg.templatable(config[CONF_QOS], args, cg.uint8)
+    cg.add(var.set_qos(template_))
+    if CONF_PAYLOAD in config:
+        template_ = await cg.templatable(config[CONF_PAYLOAD], args, cg.std_string)
+        cg.add(var.set_payload(template_))
+    await automation.build_automation(var.get_trigger(), [(cg.std_string, "x")], config)
+    return var
+
+
+@automation.register_action(
+    "mqtt.subscribe_json",
+    MQTTSubscribeJsonAction,
+    automation.validate_automation(
+        {
+            cv.GenerateID(CONF_MQTT_CLIENT_ID): cv.use_id(MQTTClientComponent),
+            cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(MQTTJsonMessageTrigger),
+            cv.Required(CONF_TOPIC): cv.templatable(cv.subscribe_topic),
+            cv.Optional(CONF_QOS, default=0): cv.templatable(cv.mqtt_qos),
+        },
+        single=True
+    ),
+)
+async def mqtt_subscribe_json_to_code(config, action_id, template_arg, args):
+    paren = await cg.get_variable(config[CONF_MQTT_CLIENT_ID])
+    var = cg.new_Pvariable(action_id, template_arg, paren)
+    template_ = await cg.templatable(config[CONF_TOPIC], args, cg.std_string)
+    cg.add(var.set_topic(template_))
+    template_ = await cg.templatable(config[CONF_QOS], args, cg.uint8)
+    cg.add(var.set_qos(template_))
+    await automation.build_automation(var.get_trigger(), [(cg.JsonObjectConst, "x")], config)
+    return var

--- a/esphome/components/mqtt/mqtt_client.cpp
+++ b/esphome/components/mqtt/mqtt_client.cpp
@@ -690,29 +690,6 @@ void MQTTClientComponent::add_ssl_fingerprint(const std::array<uint8_t, SHA1_SIZ
 
 MQTTClientComponent *global_mqtt_client = nullptr;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
-// MQTTMessageTrigger
-MQTTMessageTrigger::MQTTMessageTrigger(std::string topic) : topic_(std::move(topic)) {}
-void MQTTMessageTrigger::set_qos(uint8_t qos) { this->qos_ = qos; }
-void MQTTMessageTrigger::set_payload(const std::string &payload) { this->payload_ = payload; }
-void MQTTMessageTrigger::setup() {
-  global_mqtt_client->subscribe(
-      this->topic_,
-      [this](const std::string &topic, const std::string &payload) {
-        if (this->payload_.has_value() && payload != *this->payload_) {
-          return;
-        }
-
-        this->trigger(payload);
-      },
-      this->qos_);
-}
-void MQTTMessageTrigger::dump_config() {
-  ESP_LOGCONFIG(TAG, "MQTT Message Trigger:");
-  ESP_LOGCONFIG(TAG, "  Topic: '%s'", this->topic_.c_str());
-  ESP_LOGCONFIG(TAG, "  QoS: %u", this->qos_);
-}
-float MQTTMessageTrigger::get_setup_priority() const { return setup_priority::AFTER_CONNECTION; }
-
 }  // namespace mqtt
 }  // namespace esphome
 

--- a/esphome/components/mqtt/mqtt_client.h
+++ b/esphome/components/mqtt/mqtt_client.h
@@ -337,24 +337,21 @@ class MQTTMessageTrigger : public Trigger<std::string> {
  public:
   void subscribe(MQTTClientComponent *parent, const std::string &topic, uint8_t qos, const std::string &payload_) {
     parent->subscribe(
-      topic,
-      [this, payload_](const std::string &topic, const std::string &payload) {
-        if (payload != payload_) {
-          return;
-        }
+        topic,
+        [this, payload_](const std::string &topic, const std::string &payload) {
+          if (payload != payload_) {
+            return;
+          }
 
-        this->trigger(payload);
-      },
-      qos);
+          this->trigger(payload);
+        },
+        qos);
   }
 
   void subscribe(MQTTClientComponent *parent, const std::string &topic, uint8_t qos) {
     parent->subscribe(
       topic,
-      [this](const std::string &topic, const std::string &payload) {
-        this->trigger(payload);
-      },
-      qos);
+      [this](const std::string &topic, const std::string &payload) { this->trigger(payload); }, qos);
   }
 
  protected:
@@ -440,14 +437,15 @@ template<typename... Ts> class MQTTSubscribeAction : public Action<Ts...> {
   TEMPLATABLE_VALUE(std::string, payload)
 
   MQTTMessageTrigger *get_trigger() { return this->trigger_; }
-  
+
   void play(Ts... x) override {
-    this->trigger_->subscribe(this->parent_, this->topic_.value(x...), this->qos_.value(x...), this->payload_.value(x...));
+    this->trigger_->subscribe(this->parent_, this->topic_.value(x...), this->qos_.value(x...),
+                              this->payload_.value(x...));
   }
 
-  protected:
-    MQTTClientComponent *parent_;
-    MQTTMessageTrigger *trigger_ = new MQTTMessageTrigger();
+ protected:
+  MQTTClientComponent *parent_;
+  MQTTMessageTrigger *trigger_ = new MQTTMessageTrigger();
 };
 
 template<typename... Ts> class MQTTSubscribeJsonAction : public Action<Ts...> {

--- a/esphome/components/mqtt/mqtt_client.h
+++ b/esphome/components/mqtt/mqtt_client.h
@@ -334,7 +334,8 @@ extern MQTTClientComponent *global_mqtt_client;  // NOLINT(cppcoreguidelines-avo
 
 class MQTTMessageTrigger : public Trigger<std::string> {
  public:
-  void subscribe(MQTTClientComponent *parent, const std::string &topic, uint8_t qos, const std::string &filter_payload) {
+  void subscribe(MQTTClientComponent *parent, const std::string &topic, uint8_t qos,
+                 const std::string &filter_payload) {
     parent->subscribe(
         topic,
         [this, filter_payload](const std::string &topic, const std::string &payload) {

--- a/esphome/components/mqtt/mqtt_client.h
+++ b/esphome/components/mqtt/mqtt_client.h
@@ -332,7 +332,6 @@ class MQTTClientComponent : public Component {
 
 extern MQTTClientComponent *global_mqtt_client;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
-
 class MQTTMessageTrigger : public Trigger<std::string> {
  public:
   void subscribe(MQTTClientComponent *parent, const std::string &topic, uint8_t qos, const std::string &payload_) {

--- a/esphome/components/mqtt/mqtt_client.h
+++ b/esphome/components/mqtt/mqtt_client.h
@@ -332,26 +332,39 @@ class MQTTClientComponent : public Component {
 
 extern MQTTClientComponent *global_mqtt_client;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
-class MQTTMessageTrigger : public Trigger<std::string>, public Component {
- public:
-  explicit MQTTMessageTrigger(std::string topic);
 
-  void set_qos(uint8_t qos);
-  void set_payload(const std::string &payload);
-  void setup() override;
-  void dump_config() override;
-  float get_setup_priority() const override;
+class MQTTMessageTrigger : public Trigger<std::string> {
+ public:
+  void subscribe(MQTTClientComponent *parent, const std::string &topic, uint8_t qos, const std::string &payload_) {
+    parent->subscribe(
+      topic,
+      [this, payload_](const std::string &topic, const std::string &payload) {
+        if (payload != payload_) {
+          return;
+        }
+
+        this->trigger(payload);
+      },
+      qos);
+  }
+
+  void subscribe(MQTTClientComponent *parent, const std::string &topic, uint8_t qos) {
+    parent->subscribe(
+      topic,
+      [this](const std::string &topic, const std::string &payload) {
+        this->trigger(payload);
+      },
+      qos);
+  }
 
  protected:
-  std::string topic_;
-  uint8_t qos_{0};
-  optional<std::string> payload_;
+  MQTTClientComponent *parent_;
 };
 
 class MQTTJsonMessageTrigger : public Trigger<JsonObjectConst> {
  public:
-  explicit MQTTJsonMessageTrigger(const std::string &topic, uint8_t qos) {
-    global_mqtt_client->subscribe_json(
+  void subscribe(MQTTClientComponent *parent, const std::string &topic, uint8_t qos) {
+    parent->subscribe_json(
         topic, [this](const std::string &topic, JsonObject root) { this->trigger(root); }, qos);
   }
 };
@@ -417,6 +430,41 @@ template<typename... Ts> class MQTTConnectedCondition : public Condition<Ts...> 
 
  protected:
   MQTTClientComponent *parent_;
+};
+
+template<typename... Ts> class MQTTSubscribeAction : public Action<Ts...> {
+ public:
+  MQTTSubscribeAction(MQTTClientComponent *parent) : parent_(parent) {}
+  TEMPLATABLE_VALUE(std::string, topic)
+  TEMPLATABLE_VALUE(uint8_t, qos)
+  TEMPLATABLE_VALUE(std::string, payload)
+
+  MQTTMessageTrigger *get_trigger() { return this->trigger_; }
+  
+  void play(Ts... x) override {
+    this->trigger_->subscribe(this->parent_, this->topic_.value(x...), this->qos_.value(x...), this->payload_.value(x...));
+  }
+
+  protected:
+    MQTTClientComponent *parent_;
+    MQTTMessageTrigger *trigger_ = new MQTTMessageTrigger();
+};
+
+template<typename... Ts> class MQTTSubscribeJsonAction : public Action<Ts...> {
+ public:
+  MQTTSubscribeJsonAction(MQTTClientComponent *parent) : parent_(parent) {}
+  TEMPLATABLE_VALUE(std::string, topic)
+  TEMPLATABLE_VALUE(uint8_t, qos)
+
+  MQTTJsonMessageTrigger *get_trigger() { return this->trigger_; }
+
+  void play(Ts... x) override {
+    this->trigger_->subscribe(this->parent_, this->topic_.value(x...), this->qos_.value(x...));
+  }
+
+ protected:
+  MQTTClientComponent *parent_;
+  MQTTJsonMessageTrigger *trigger_ = new MQTTJsonMessageTrigger();
 };
 
 template<typename... Ts> class MQTTEnableAction : public Action<Ts...> {

--- a/esphome/components/mqtt/mqtt_client.h
+++ b/esphome/components/mqtt/mqtt_client.h
@@ -334,11 +334,11 @@ extern MQTTClientComponent *global_mqtt_client;  // NOLINT(cppcoreguidelines-avo
 
 class MQTTMessageTrigger : public Trigger<std::string> {
  public:
-  void subscribe(MQTTClientComponent *parent, const std::string &topic, uint8_t qos, const std::string &payload_) {
+  void subscribe(MQTTClientComponent *parent, const std::string &topic, uint8_t qos, const std::string &filter_payload) {
     parent->subscribe(
         topic,
-        [this, payload_](const std::string &topic, const std::string &payload) {
-          if (payload != payload_) {
+        [this, filter_payload](const std::string &topic, const std::string &payload) {
+          if (payload != filter_payload) {
             return;
           }
 

--- a/esphome/components/mqtt/mqtt_client.h
+++ b/esphome/components/mqtt/mqtt_client.h
@@ -350,8 +350,7 @@ class MQTTMessageTrigger : public Trigger<std::string> {
 
   void subscribe(MQTTClientComponent *parent, const std::string &topic, uint8_t qos) {
     parent->subscribe(
-      topic,
-      [this](const std::string &topic, const std::string &payload) { this->trigger(payload); }, qos);
+        topic, [this](const std::string &topic, const std::string &payload) { this->trigger(payload); }, qos);
   }
 
  protected:

--- a/tests/components/mqtt/common.yaml
+++ b/tests/components/mqtt/common.yaml
@@ -95,6 +95,11 @@ button:
           payload: Hello
           qos: 2
           retain: true
+      - mqtt.subscribe:
+          topic: !lambda return "dummy/topic";
+          then:
+            - lambda: |-
+                ESP_LOGD("MQTT", "Received message %s", x.c_str());
 
 climate:
   - platform: thermostat


### PR DESCRIPTION
# What does this implement/fix?

Adds `mqtt.subscribe` and `mqtt.subscribe_json` actions to subscribe to topics using templatable values.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
esphome:
    - priority: -100
      then:
        - mqtt.subscribe:
            topic: !lambda return "dummy/topic";
            then:
              - lambda: |-
                  ESP_LOGD("MQTT", "Received message %s", x.c_str());

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
