### PR TITLE
Add MCP3221 i2c A-D-Converter

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -290,6 +290,7 @@ esphome/components/mcp23x17_base/* @jesserockz
 esphome/components/mcp23xxx_base/* @jesserockz
 esphome/components/mcp2515/* @danielschramm @mvturnho
 esphome/components/mcp3204/* @rsumner
+esphome/components/mcp3221/* @philippderdiedas
 esphome/components/mcp4461/* @p1ngb4ck
 esphome/components/mcp4728/* @berfenger
 esphome/components/mcp47a1/* @jesserockz

--- a/esphome/components/mcp3221/__init__.py
+++ b/esphome/components/mcp3221/__init__.py
@@ -1,0 +1,1 @@
+CODEOWNERS = ["@philippderdiedas"]

--- a/esphome/components/mcp3221/mcp3221_sensor.cpp
+++ b/esphome/components/mcp3221/mcp3221_sensor.cpp
@@ -1,0 +1,31 @@
+#include "mcp3221_sensor.h"
+#include "esphome/core/hal.h"
+#include "esphome/core/log.h"
+
+namespace esphome {
+namespace mcp3221 {
+
+static const char *const TAG = "mcp3221";
+
+float MCP3221Sensor::sample() {
+  uint8_t data[2];
+  if (this->read(data, 2) != i2c::ERROR_OK) {
+    ESP_LOGW(TAG, "Read failed");
+    this->status_set_warning();
+    return NAN;
+  }
+  this->status_clear_warning();
+
+  uint16_t value = encode_uint16(data[0], data[1]);
+  float voltage = value * this->reference_voltage_ / 4096.0f;
+
+  return voltage;
+}
+
+void MCP3221Sensor::update() {
+  float v = this->sample();
+  this->publish_state(v);
+}
+
+}  // namespace mcp3221
+}  // namespace esphome

--- a/esphome/components/mcp3221/mcp3221_sensor.h
+++ b/esphome/components/mcp3221/mcp3221_sensor.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/core/automation.h"
+#include "esphome/components/sensor/sensor.h"
+#include "esphome/components/i2c/i2c.h"
+#include "esphome/components/voltage_sampler/voltage_sampler.h"
+
+#include <cinttypes>
+
+namespace esphome {
+namespace mcp3221 {
+
+class MCP3221Sensor : public sensor::Sensor,
+                      public PollingComponent,
+                      public voltage_sampler::VoltageSampler,
+                      public i2c::I2CDevice {
+ public:
+  void set_reference_voltage(float reference_voltage) { this->reference_voltage_ = reference_voltage; }
+  void update() override;
+  float sample() override;
+
+ protected:
+  float reference_voltage_;
+};
+
+}  // namespace mcp3221
+}  // namespace esphome

--- a/esphome/components/mcp3221/sensor.py
+++ b/esphome/components/mcp3221/sensor.py
@@ -1,0 +1,49 @@
+import esphome.codegen as cg
+from esphome.components import i2c, sensor, voltage_sampler
+import esphome.config_validation as cv
+from esphome.const import (
+    CONF_REFERENCE_VOLTAGE,
+    DEVICE_CLASS_VOLTAGE,
+    ICON_SCALE,
+    STATE_CLASS_MEASUREMENT,
+    UNIT_VOLT,
+)
+
+AUTO_LOAD = ["voltage_sampler"]
+DEPENDENCIES = ["i2c"]
+
+
+mcp3221_ns = cg.esphome_ns.namespace("mcp3221")
+MCP3221Sensor = mcp3221_ns.class_(
+    "MCP3221Sensor",
+    sensor.Sensor,
+    voltage_sampler.VoltageSampler,
+    cg.PollingComponent,
+    i2c.I2CDevice,
+)
+
+
+CONFIG_SCHEMA = (
+    sensor.sensor_schema(
+        MCP3221Sensor,
+        icon=ICON_SCALE,
+        accuracy_decimals=2,
+        state_class=STATE_CLASS_MEASUREMENT,
+        device_class=DEVICE_CLASS_VOLTAGE,
+        unit_of_measurement=UNIT_VOLT,
+    )
+    .extend(
+        {
+            cv.Optional(CONF_REFERENCE_VOLTAGE, default="3.3V"): cv.voltage,
+        }
+    )
+    .extend(cv.polling_component_schema("60s"))
+    .extend(i2c.i2c_device_schema(0x48))
+)
+
+
+async def to_code(config):
+    var = await sensor.new_sensor(config)
+    cg.add(var.set_reference_voltage(config[CONF_REFERENCE_VOLTAGE]))
+    await cg.register_component(var, config)
+    await i2c.register_i2c_device(var, config)

--- a/tests/components/mcp3221/common.yaml
+++ b/tests/components/mcp3221/common.yaml
@@ -1,0 +1,6 @@
+sensor:
+  - platform: mcp3221
+    id: test_id
+    name: voltage
+    i2c_id: i2c_bus
+    reference_voltage: 3.3V

--- a/tests/components/mcp3221/test.esp32-c3-idf.yaml
+++ b/tests/components/mcp3221/test.esp32-c3-idf.yaml
@@ -1,0 +1,4 @@
+packages:
+  i2c: !include ../../test_build_components/common/i2c/esp32-c3-idf.yaml
+
+<<: !include common.yaml

--- a/tests/components/mcp3221/test.esp32-idf.yaml
+++ b/tests/components/mcp3221/test.esp32-idf.yaml
@@ -1,0 +1,4 @@
+packages:
+  i2c: !include ../../test_build_components/common/i2c/esp32-idf.yaml
+
+<<: !include common.yaml

--- a/tests/components/mcp3221/test.esp32-s3-idf.yaml
+++ b/tests/components/mcp3221/test.esp32-s3-idf.yaml
@@ -1,0 +1,4 @@
+packages:
+  i2c: !include ../../test_build_components/common/i2c/esp32-s3-idf.yaml
+
+<<: !include common.yaml

--- a/tests/components/mcp3221/test.esp8266-ard.yaml
+++ b/tests/components/mcp3221/test.esp8266-ard.yaml
@@ -1,0 +1,4 @@
+packages:
+  i2c: !include ../../test_build_components/common/i2c/esp8266-ard.yaml
+
+<<: !include common.yaml

--- a/tests/components/mcp3221/test.rp2040-ard.yaml
+++ b/tests/components/mcp3221/test.rp2040-ard.yaml
@@ -1,0 +1,4 @@
+packages:
+  i2c: !include ../../test_build_components/common/i2c/rp2040-ard.yaml
+
+<<: !include common.yaml


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

 none

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#4942

## Test Environment

- [X] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
esphome:
  name: esp-mcp
  friendly_name: esp-mcp

esp32:
  board: esp-wrover-kit
  framework:
    type: esp-idf

i2c:
  - sda: GPIO32
    scl: GPIO4
    scan: True
    frequency: 100khz # standard mode
    scl_pullup_enabled: True
    sda_pullup_enabled: True
    id: i2c_bus_a

sensor:
  - platform: mcp3221
    id: mcp_3221_one
    name: "MCP3221 1"
    reference_voltage: 3.3V # used to calculate voltage
    # 1001 device code
    # 000   address bits # see package info
    address: 0b1001000
    update_interval: 3s
    i2c_id: i2c_bus_a

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
