### PR TITLE
online_image: allow setting templatable headers on http request

### DIFF
--- a/esphome/components/online_image/__init__.py
+++ b/esphome/components/online_image/__init__.py
@@ -160,7 +160,9 @@ async def to_code(config):
 
     for key in config.get(CONF_HTTP_REQUEST_HEADERS, []):
         template_ = await cg.templatable(
-            config[CONF_HTTP_REQUEST_HEADERS][key], [], cg.optional.template(cg.const_char_ptr)
+            config[CONF_HTTP_REQUEST_HEADERS][key],
+            [],
+            cg.optional.template(cg.const_char_ptr),
         )
         cg.add(var.add_header(key, template_))
 

--- a/esphome/components/online_image/online_image.cpp
+++ b/esphome/components/online_image/online_image.cpp
@@ -104,10 +104,12 @@ void OnlineImage::update() {
   }
 
   std::list<http_request::Header> headers;
-  for (const auto &[key, value_template] : this->headers_) {
-    auto val = value_template();
-    if (val.has_value()) {
-      headers.push_back(http_request::Header{key, *val});
+  for (const auto &item : this->headers_) {
+    auto header_name = item.first;
+    auto header_value_template = item.second;
+    auto header_value = header_value_template();
+    if (header_value.has_value()) {
+      headers.push_back(http_request::Header{header_name, *header_value});
     }
   }
 

--- a/esphome/components/online_image/online_image.cpp
+++ b/esphome/components/online_image/online_image.cpp
@@ -103,12 +103,11 @@ void OnlineImage::update() {
     ESP_LOGI(TAG, "Updating image");
   }
 
-
   std::list<http_request::Header> headers;
-  for (const auto &item : this->headers_) {
-    auto val = item.second();
+  for (const auto &[key, value_template] : this->headers_) {
+    auto val = value_template();
     if (val.has_value()) {
-      headers.push_back(http_request::Header{item.first, *val});
+      headers.push_back(http_request::Header{key, *val});
     }
   }
 

--- a/esphome/components/online_image/online_image.cpp
+++ b/esphome/components/online_image/online_image.cpp
@@ -103,7 +103,16 @@ void OnlineImage::update() {
     ESP_LOGI(TAG, "Updating image");
   }
 
-  this->downloader_ = this->parent_->get(this->url_);
+
+  std::list<http_request::Header> headers;
+  for (const auto &item : this->headers_) {
+    auto val = item.second();
+    if (val.has_value()) {
+      headers.push_back(http_request::Header{item.first, *val});
+    }
+  }
+
+  this->downloader_ = this->parent_->get(this->url_, headers);
 
   if (this->downloader_ == nullptr) {
     ESP_LOGE(TAG, "Download failed.");

--- a/esphome/components/online_image/online_image.h
+++ b/esphome/components/online_image/online_image.h
@@ -62,6 +62,8 @@ class OnlineImage : public PollingComponent,
     }
   }
 
+  void add_header(const char *key, std::function<optional<const char*>()> &&f) { this->headers_.insert({key, f}); }
+
   /**
    * @brief Set the image that needs to be shown as long as the downloaded image
    *  is not available.
@@ -122,6 +124,7 @@ class OnlineImage : public PollingComponent,
   image::Image *placeholder_{nullptr};
 
   std::string url_{""};
+  std::map<const char *, std::function<optional<const char*>()>> headers_{};
 
   /** width requested on configuration, or 0 if non specified. */
   const int fixed_width_;

--- a/esphome/components/online_image/online_image.h
+++ b/esphome/components/online_image/online_image.h
@@ -62,7 +62,7 @@ class OnlineImage : public PollingComponent,
     }
   }
 
-  void add_header(const char *key, std::function<optional<const char*>()> &&f) { this->headers_.insert({key, f}); }
+  void add_header(const char *key, std::function<optional<const char *>()> &&f) { this->headers_.insert({key, f}); }
 
   /**
    * @brief Set the image that needs to be shown as long as the downloaded image
@@ -124,7 +124,7 @@ class OnlineImage : public PollingComponent,
   image::Image *placeholder_{nullptr};
 
   std::string url_{""};
-  std::map<const char *, std::function<optional<const char*>()>> headers_{};
+  std::map<const char *, std::function<optional<const char *>()>> headers_{};
 
   /** width requested on configuration, or 0 if non specified. */
   const int fixed_width_;

--- a/tests/components/online_image/common.yaml
+++ b/tests/components/online_image/common.yaml
@@ -24,10 +24,26 @@ online_image:
     format: PNG
     type: RGB24
     use_transparency: true
+  - id: online_image_headers
+    url: http://www.libpng.org/pub/png/img_png/pnglogo-blk-tiny.png
+    format: PNG
+    type: RGBA
+    http_request_headers:
+      If-Modified-Since: !lambda |-
+        char age_buf[64];
+        auto now = id(sntp_time)->timestamp_now();
+        auto time = ESPTime::from_epoch_utc(now - 10 * 60);
+        auto age_len = time.strftime(age_buf, sizeof(age_buf), "%a, %d %b %Y %H:%M:%S %z");
+        if (age_len != 0) {
+          return age_buf;
+        } else {
+          return {};
+        }
 
 # Check the set_url action
 time:
   - platform: sntp
+    id: sntp_time
     on_time:
       - at: "13:37:42"
         then:


### PR DESCRIPTION
# What does this implement/fix?

The HTTP requests by the `online_image` component did not give the user a config option to set the HTTP headers. This PR implements setting headers and supports templates.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#4441

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [x] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
online_image:
  - id: radar0
    url: http://.../rain/radar0.png
    on_error:
      - online_image.release: radar0
    format: PNG
    type: RGBA
    placeholder: bad_radar

    headers:
      If-Modified-Since: !lambda |-
        char age_buf[64];
        auto now = id(rtc)->timestamp_now();
        auto time = ESPTime::from_epoch_utc(now - 10 * 60);
        auto age_len = time.strftime(age_buf, sizeof(age_buf), "%a, %d %b %Y %H:%M:%S %z");
        if (age_len != 0) {
          return age_buf;
        } else {
          return {};
        }


```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
