### PR TITLE
enable rp2040 for online_image

### DIFF
--- a/esphome/components/online_image/__init__.py
+++ b/esphome/components/online_image/__init__.py
@@ -98,6 +98,7 @@ CONFIG_SCHEMA = cv.Schema(
             # esp8266_arduino=cv.Version(2, 7, 0),
             esp32_arduino=cv.Version(0, 0, 0),
             esp_idf=cv.Version(4, 0, 0),
+            rp2040_arduino=cv.Version(0, 0, 0),
         ),
     )
 )

--- a/tests/components/online_image/common-rp2040.yaml
+++ b/tests/components/online_image/common-rp2040.yaml
@@ -1,0 +1,19 @@
+<<: !include common.yaml
+
+spi:
+  - id: spi_main_lcd
+    clk_pin: 18
+    mosi_pin: 19
+    miso_pin: 16
+
+display:
+  - platform: ili9xxx
+    id: main_lcd
+    model: ili9342
+    cs_pin: 20
+    dc_pin: 17
+    reset_pin: 21
+    invert_colors: true
+    lambda: |-
+      it.fill(Color(0, 0, 0));
+      it.image(0, 0, id(online_rgba_image));

--- a/tests/components/online_image/test.rp2040-ard.yaml
+++ b/tests/components/online_image/test.rp2040-ard.yaml
@@ -1,0 +1,4 @@
+<<: !include common-rp2040.yaml
+
+http_request:
+  verify_ssl: false


### PR DESCRIPTION
# What does this implement/fix?

`online_image` did not support `rp2040` targets. It does now.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [x] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
rp2040:
  board: rpipicow

online_image:
  - id: online_binary_image
    url: http://www.libpng.org/pub/png/img_png/pnglogo-blk-tiny.png
    format: PNG
    type: BINARY
    resize: 50x50


```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
