### PR TITLE
[remote_base] Fix extra comma in dump raw

### DIFF
--- a/esphome/components/remote_base/raw_protocol.cpp
+++ b/esphome/components/remote_base/raw_protocol.cpp
@@ -28,7 +28,7 @@ bool RawDumper::dump(RemoteReceiveData src) {
       ESP_LOGI(TAG, "%s", buffer);
       buffer_offset = 0;
       written = sprintf(buffer, "  ");
-      if (i + 1 < src.size()) {
+      if (i + 1 < src.size() - 1) {
         written += sprintf(buffer + written, "%" PRId32 ", ", value);
       } else {
         written += sprintf(buffer + written, "%" PRId32, value);


### PR DESCRIPTION
# What does this implement/fix?

If there is a single item on the last line there will be an extra comma printed. The first print in the loop will fail as the buffer is out of room. That print is redone but the conditional is different for the second print. Should be size - 1 for both if statements:

[22:30:00][I][remote.raw:029]: Received Raw: 13, -457, 13, -432, 13, -65, 13, -496, 13, -496, 14, -26, 13, -392, 13, -91, 13, -405, 13, -65, 14, -496, 13, -26, 13, -470, 13, -27, 13, -470, 13, -26, 13, -483, 14, -25, 13, -471, 13, -26, 13, -509, 13, -483, 14, -26, 13, -509, 13, -510,
[22:30:00][I][remote.raw:045]:   13,


## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
