### PR TITLE
TuyaFan control should use oscillation_type

### DIFF
--- a/esphome/components/tuya/fan/tuya_fan.cpp
+++ b/esphome/components/tuya/fan/tuya_fan.cpp
@@ -86,7 +86,7 @@ void TuyaFan::control(const fan::FanCall &call) {
   if (this->oscillation_id_.has_value() && call.get_oscillating().has_value()) {
     if (this->oscillation_type_ == TuyaDatapointType::ENUM) {
       this->parent_->set_enum_datapoint_value(*this->oscillation_id_, *call.get_oscillating());
-    } else if (this->speed_type_ == TuyaDatapointType::BOOLEAN) {
+    } else if (this->oscillation_type_ == TuyaDatapointType::BOOLEAN) {
       this->parent_->set_boolean_datapoint_value(*this->oscillation_id_, *call.get_oscillating());
     }
   }


### PR DESCRIPTION
...for oscillation

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Fan oscillation datapoint not being set using fan entity, but can be set with same datapoint via switch entity.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Fixes [#6161 Tuya Fan: oscillation_datapoint behaves read-only](https://github.com/esphome/issues/issues/6161)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
fan:
  - platform: "tuya"
    name: "Tuya Towerfan"
    switch_datapoint: 1
    speed_datapoint: 3
    oscillation_datapoint: 5
    speed_count: 5
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
