### PR TITLE
[INA219] Add sleep/wake_up actions

### DIFF
--- a/esphome/components/ina219/ina219.h
+++ b/esphome/components/ina219/ina219.h
@@ -3,6 +3,7 @@
 #include "esphome/core/component.h"
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/i2c/i2c.h"
+#include "esphome/core/automation.h"
 
 #include <cinttypes>
 
@@ -15,6 +16,8 @@ class INA219Component : public PollingComponent, public i2c::I2CDevice {
   void dump_config() override;
   float get_setup_priority() const override;
   void update() override;
+  void sleep();
+  void wake_up();
 
   void set_shunt_resistance_ohm(float shunt_resistance_ohm) { shunt_resistance_ohm_ = shunt_resistance_ohm; }
   void set_max_current_a(float max_current_a) { max_current_a_ = max_current_a; }
@@ -28,11 +31,19 @@ class INA219Component : public PollingComponent, public i2c::I2CDevice {
   float shunt_resistance_ohm_;
   float max_current_a_;
   float max_voltage_v_;
+  bool sleeping_{false};
   uint32_t calibration_lsb_;
   sensor::Sensor *bus_voltage_sensor_{nullptr};
   sensor::Sensor *shunt_voltage_sensor_{nullptr};
   sensor::Sensor *current_sensor_{nullptr};
   sensor::Sensor *power_sensor_{nullptr};
+};
+template<typename... Ts> class SleepAction : public Action<Ts...>, public Parented<INA219Component> {
+  void play(Ts... x) override { this->parent_->sleep(); }
+};
+
+template<typename... Ts> class WakeUpAction : public Action<Ts...>, public Parented<INA219Component> {
+  void play(Ts... x) override { this->parent_->wake_up(); }
 };
 
 }  // namespace ina219

--- a/esphome/components/ina219/sensor.py
+++ b/esphome/components/ina219/sensor.py
@@ -1,6 +1,7 @@
+from esphome import automation
 import esphome.codegen as cg
-import esphome.config_validation as cv
 from esphome.components import i2c, sensor
+import esphome.config_validation as cv
 from esphome.const import (
     CONF_BUS_VOLTAGE,
     CONF_CURRENT,
@@ -14,8 +15,8 @@ from esphome.const import (
     DEVICE_CLASS_POWER,
     DEVICE_CLASS_VOLTAGE,
     STATE_CLASS_MEASUREMENT,
-    UNIT_VOLT,
     UNIT_AMPERE,
+    UNIT_VOLT,
     UNIT_WATT,
 )
 
@@ -68,6 +69,40 @@ CONFIG_SCHEMA = (
     .extend(cv.polling_component_schema("60s"))
     .extend(i2c.i2c_device_schema(0x40))
 )
+
+
+SleepAction = ina219_ns.class_("SleepAction", automation.Action)
+WakeUpAction = ina219_ns.class_("WakeUpAction", automation.Action)
+
+
+@automation.register_action(
+    "ina219.sleep",
+    SleepAction,
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.use_id(INA219Component),
+        }
+    ),
+)
+async def ina219_sleep_to_code(config, action_id, template_arg, args):
+    var = cg.new_Pvariable(action_id, template_arg)
+    await cg.register_parented(var, config[CONF_ID])
+    return var
+
+
+@automation.register_action(
+    "ina219.wake_up",
+    WakeUpAction,
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.use_id(INA219Component),
+        }
+    ),
+)
+async def ina219_wake_up_to_code(config, action_id, template_arg, args):
+    var = cg.new_Pvariable(action_id, template_arg)
+    await cg.register_parented(var, config[CONF_ID])
+    return var
 
 
 async def to_code(config):


### PR DESCRIPTION
# What does this implement/fix?

Implements `sleep`/`wake_up` actions in INA219 by utilizing the [INA219 Mode Settings Configuration Register 8.6.2.1](https://www.ti.com/lit/ds/symlink/ina219.pdf)

![Screenshot from 2024-11-17 23-46-45](https://github.com/user-attachments/assets/470a64bd-b619-4d72-a7ae-67c75b0c58d8)

## Types of changes


- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- https://github.com/esphome/esphome-docs/pull/4449

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
on_...:
  - ina219.sleep
  - ina219.wake_up

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder). `N/A`

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
