### PR TITLE
2024.11.0b3

### DIFF
--- a/esphome/components/tuya/fan/tuya_fan.cpp
+++ b/esphome/components/tuya/fan/tuya_fan.cpp
@@ -86,7 +86,7 @@ void TuyaFan::control(const fan::FanCall &call) {
   if (this->oscillation_id_.has_value() && call.get_oscillating().has_value()) {
     if (this->oscillation_type_ == TuyaDatapointType::ENUM) {
       this->parent_->set_enum_datapoint_value(*this->oscillation_id_, *call.get_oscillating());
-    } else if (this->speed_type_ == TuyaDatapointType::BOOLEAN) {
+    } else if (this->oscillation_type_ == TuyaDatapointType::BOOLEAN) {
       this->parent_->set_boolean_datapoint_value(*this->oscillation_id_, *call.get_oscillating());
     }
   }

--- a/esphome/const.py
+++ b/esphome/const.py
@@ -1,6 +1,6 @@
 """Constants used by esphome."""
 
-__version__ = "2024.11.0b2"
+__version__ = "2024.11.0b3"
 
 ALLOWED_NAME_CHARS = "abcdefghijklmnopqrstuvwxyz0123456789-_"
 VALID_SUBSTITUTIONS_CHARACTERS = (

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ pyserial==3.5
 platformio==6.1.16  # When updating platformio, also update Dockerfile
 esptool==4.7.0
 click==8.1.7
-esphome-dashboard==20241025.0
+esphome-dashboard==20241118.0
 aioesphomeapi==24.6.2
 zeroconf==0.132.2
 puremagic==1.27


### PR DESCRIPTION
**Do not merge, release script will automatically merge**
## Full list of changes

### All changes

- TuyaFan control should use oscillation_type [esphome#7776](https://github.com/esphome/esphome/pull/7776)
- Bump esphome-dashboard to 20241118.0 [esphome#7782](https://github.com/esphome/esphome/pull/7782)

<details>
<summary>Metadata</summary>

@coderabbitai ignore
</details>
