### PR TITLE
[http_request] Feed watchdog timeout around http request functions

### DIFF
--- a/esphome/components/http_request/http_request_arduino.cpp
+++ b/esphome/components/http_request/http_request_arduino.cpp
@@ -104,7 +104,9 @@ std::shared_ptr<HttpContainer> HttpRequestArduino::start(std::string url, std::s
   static const size_t HEADER_COUNT = sizeof(header_keys) / sizeof(header_keys[0]);
   container->client_.collectHeaders(header_keys, HEADER_COUNT);
 
+  App.feed_wdt();
   container->status_code = container->client_.sendRequest(method.c_str(), body.c_str());
+  App.feed_wdt();
   if (container->status_code < 0) {
     ESP_LOGW(TAG, "HTTP Request failed; URL: %s; Error: %s", url.c_str(),
              HTTPClient::errorToString(container->status_code).c_str());

--- a/esphome/components/http_request/http_request_idf.cpp
+++ b/esphome/components/http_request/http_request_idf.cpp
@@ -117,8 +117,11 @@ std::shared_ptr<HttpContainer> HttpRequestIDF::start(std::string url, std::strin
     return nullptr;
   }
 
+  App.feed_wdt();
   container->content_length = esp_http_client_fetch_headers(client);
+  App.feed_wdt();
   container->status_code = esp_http_client_get_status_code(client);
+  App.feed_wdt();
   if (is_success(container->status_code)) {
     container->duration_ms = millis() - start;
     return container;
@@ -148,8 +151,11 @@ std::shared_ptr<HttpContainer> HttpRequestIDF::start(std::string url, std::strin
         return nullptr;
       }
 
+      App.feed_wdt();
       container->content_length = esp_http_client_fetch_headers(client);
+      App.feed_wdt();
       container->status_code = esp_http_client_get_status_code(client);
+      App.feed_wdt();
       if (is_success(container->status_code)) {
         container->duration_ms = millis() - start;
         return container;


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

On high latency connections, some of these functions, when combined were taking longer than the watchdog would allow. Feeding in between them allows the application to continue.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
