### PR TITLE
2024.11.0b4

### DIFF
--- a/esphome/components/http_request/http_request_arduino.cpp
+++ b/esphome/components/http_request/http_request_arduino.cpp
@@ -104,7 +104,9 @@ std::shared_ptr<HttpContainer> HttpRequestArduino::start(std::string url, std::s
   static const size_t HEADER_COUNT = sizeof(header_keys) / sizeof(header_keys[0]);
   container->client_.collectHeaders(header_keys, HEADER_COUNT);
 
+  App.feed_wdt();
   container->status_code = container->client_.sendRequest(method.c_str(), body.c_str());
+  App.feed_wdt();
   if (container->status_code < 0) {
     ESP_LOGW(TAG, "HTTP Request failed; URL: %s; Error: %s", url.c_str(),
              HTTPClient::errorToString(container->status_code).c_str());

--- a/esphome/components/http_request/http_request_idf.cpp
+++ b/esphome/components/http_request/http_request_idf.cpp
@@ -117,8 +117,11 @@ std::shared_ptr<HttpContainer> HttpRequestIDF::start(std::string url, std::strin
     return nullptr;
   }
 
+  App.feed_wdt();
   container->content_length = esp_http_client_fetch_headers(client);
+  App.feed_wdt();
   container->status_code = esp_http_client_get_status_code(client);
+  App.feed_wdt();
   if (is_success(container->status_code)) {
     container->duration_ms = millis() - start;
     return container;
@@ -148,8 +151,11 @@ std::shared_ptr<HttpContainer> HttpRequestIDF::start(std::string url, std::strin
         return nullptr;
       }
 
+      App.feed_wdt();
       container->content_length = esp_http_client_fetch_headers(client);
+      App.feed_wdt();
       container->status_code = esp_http_client_get_status_code(client);
+      App.feed_wdt();
       if (is_success(container->status_code)) {
         container->duration_ms = millis() - start;
         return container;

--- a/esphome/const.py
+++ b/esphome/const.py
@@ -1,6 +1,6 @@
 """Constants used by esphome."""
 
-__version__ = "2024.11.0b3"
+__version__ = "2024.11.0b4"
 
 ALLOWED_NAME_CHARS = "abcdefghijklmnopqrstuvwxyz0123456789-_"
 VALID_SUBSTITUTIONS_CHARACTERS = (

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ pyserial==3.5
 platformio==6.1.16  # When updating platformio, also update Dockerfile
 esptool==4.7.0
 click==8.1.7
-esphome-dashboard==20241118.0
+esphome-dashboard==20241120.0
 aioesphomeapi==24.6.2
 zeroconf==0.132.2
 puremagic==1.27


### PR DESCRIPTION
**Do not merge, release script will automatically merge**
## Full list of changes

### All changes

- [http_request] Feed watchdog timeout around http request functions [esphome#7786](https://github.com/esphome/esphome/pull/7786)
- Bump esphome-dashboard to 20241120.0 [esphome#7787](https://github.com/esphome/esphome/pull/7787)

<details>
<summary>Metadata</summary>

@coderabbitai ignore
</details>
