### PR TITLE
Ensure storage I/O for ignored devices runs in the executor

### DIFF
--- a/esphome/dashboard/core.py
+++ b/esphome/dashboard/core.py
@@ -103,7 +103,7 @@ class ESPHomeDashboard:
         self.loop = asyncio.get_running_loop()
         self.ping_request = asyncio.Event()
         self.entries = DashboardEntries(self)
-        self.load_ignored_devices()
+        await self.loop.run_in_executor(None, self.load_ignored_devices)
 
     def load_ignored_devices(self) -> None:
         storage_path = Path(ignored_devices_storage_path())

--- a/esphome/dashboard/web_server.py
+++ b/esphome/dashboard/web_server.py
@@ -544,7 +544,7 @@ class ImportRequestHandler(BaseHandler):
 
 class IgnoreDeviceRequestHandler(BaseHandler):
     @authenticated
-    def post(self) -> None:
+    async def post(self) -> None:
         dashboard = DASHBOARD
         try:
             args = json.loads(self.request.body.decode())
@@ -576,7 +576,8 @@ class IgnoreDeviceRequestHandler(BaseHandler):
         else:
             dashboard.ignored_devices.discard(ignored_device.device_name)
 
-        dashboard.save_ignored_devices()
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(None, dashboard.save_ignored_devices)
 
         self.set_status(204)
         self.finish()


### PR DESCRIPTION
# What does this implement/fix?

Ensure I/O from reading and writing ignored devices runs in the executor to avoid blocking the event loop.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other


**Related issue or feature (if applicable):**

n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

n/a

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
N/A

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
