### PR TITLE
[rtttl] Clamp gain between 0 and 1

### DIFF
--- a/esphome/components/rtttl/rtttl.h
+++ b/esphome/components/rtttl/rtttl.h
@@ -40,13 +40,7 @@ class Rtttl : public Component {
   void set_speaker(speaker::Speaker *speaker) { this->speaker_ = speaker; }
 #endif
   float get_gain() { return gain_; }
-  void set_gain(float gain) {
-    if (gain < 0.1f)
-      gain = 0.1f;
-    if (gain > 1.0f)
-      gain = 1.0f;
-    this->gain_ = gain;
-  }
+  void set_gain(float gain) { this->gain_ = clamp(gain, 0.0f, 1.0f); }
   void play(std::string rtttl);
   void stop();
   void dump_config() override;


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
