### PR TITLE
Fix for OTA mode not activating in safe_mode when OTA section has an on_xxxx action 

### DIFF
--- a/esphome/components/esphome/ota/__init__.py
+++ b/esphome/components/esphome/ota/__init__.py
@@ -124,7 +124,6 @@ FINAL_VALIDATE_SCHEMA = ota_esphome_final_validate
 @coroutine_with_priority(52.0)
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
-    await ota_to_code(var, config)
     cg.add(var.set_port(config[CONF_PORT]))
     if CONF_PASSWORD in config:
         cg.add(var.set_auth_password(config[CONF_PASSWORD]))
@@ -132,3 +131,4 @@ async def to_code(config):
     cg.add_define("USE_OTA_VERSION", config[CONF_VERSION])
 
     await cg.register_component(var, config)
+    await ota_to_code(var, config)

--- a/esphome/components/esphome/ota/__init__.py
+++ b/esphome/components/esphome/ota/__init__.py
@@ -1,10 +1,9 @@
 import logging
 
 import esphome.codegen as cg
-import esphome.config_validation as cv
-import esphome.final_validate as fv
-from esphome.components.ota import BASE_OTA_SCHEMA, ota_to_code, OTAComponent
+from esphome.components.ota import BASE_OTA_SCHEMA, OTAComponent, ota_to_code
 from esphome.config_helpers import merge_config
+import esphome.config_validation as cv
 from esphome.const import (
     CONF_ESPHOME,
     CONF_ID,
@@ -18,6 +17,7 @@ from esphome.const import (
     CONF_VERSION,
 )
 from esphome.core import coroutine_with_priority
+import esphome.final_validate as fv
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/esphome/components/ota/__init__.py
+++ b/esphome/components/ota/__init__.py
@@ -92,6 +92,7 @@ async def to_code(config):
 
 
 async def ota_to_code(var, config):
+    await cg.past_safe_mode()
     use_state_callback = False
     for conf in config.get(CONF_ON_STATE_CHANGE, []):
         trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)


### PR DESCRIPTION
# What does this implement/fix?

Latest changes related to safe_mode and OTA configuration seems to have broken the ability to do an OTA update if the device goes into safe_mode (either manually via a switch or via 10 failed boot attempts) when there is an on_begin action specified for the ota: section. I keep getting connection refused. When the on_begin section is on, the esphome.ota component does not load (no log dump display) during transition to safe_mode. The esphome.ota does show up fine and ota works when the offending on_begin is removed. 

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/issues/issues/5976

## Test Environment

- [x ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
ota:
   password: !secret ota_password
   platform: esphome
   on_begin:
          switch.turn_off: connection_status_switch 
          
safe_mode:

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
