### PR TITLE
Check for min_version earlier in validation

### DIFF
--- a/esphome/core/config.py
+++ b/esphome/core/config.py
@@ -116,9 +116,6 @@ CONF_ESP8266_RESTORE_FROM_FLASH = "esp8266_restore_from_flash"
 CONFIG_SCHEMA = cv.All(
     cv.Schema(
         {
-            cv.Optional(CONF_MIN_VERSION, default=ESPHOME_VERSION): cv.All(
-                cv.version_number, cv.validate_esphome_version
-            ),
             cv.Required(CONF_NAME): cv.valid_name,
             cv.Optional(CONF_FRIENDLY_NAME, ""): cv.string,
             cv.Optional(CONF_AREA, ""): cv.string,
@@ -164,6 +161,9 @@ CONFIG_SCHEMA = cv.All(
                     ),
                 }
             ),
+            cv.Optional(CONF_MIN_VERSION, default=ESPHOME_VERSION): cv.All(
+                cv.version_number, cv.validate_esphome_version
+            ),
             cv.Optional(
                 CONF_COMPILE_PROCESS_LIMIT, default=_compile_process_limit_default
             ): cv.int_range(min=1, max=multiprocessing.cpu_count()),
@@ -184,6 +184,9 @@ PRELOAD_CONFIG_SCHEMA = cv.Schema(
         cv.Optional(CONF_ESP8266_RESTORE_FROM_FLASH): cv.valid,
         cv.Optional(CONF_BOARD_FLASH_MODE): cv.valid,
         cv.Optional(CONF_ARDUINO_VERSION): cv.valid,
+        cv.Optional(CONF_MIN_VERSION, default=ESPHOME_VERSION): cv.All(
+            cv.version_number, cv.validate_esphome_version
+        ),
     },
     extra=cv.ALLOW_EXTRA,
 )

--- a/esphome/core/config.py
+++ b/esphome/core/config.py
@@ -116,6 +116,9 @@ CONF_ESP8266_RESTORE_FROM_FLASH = "esp8266_restore_from_flash"
 CONFIG_SCHEMA = cv.All(
     cv.Schema(
         {
+            cv.Optional(CONF_MIN_VERSION, default=ESPHOME_VERSION): cv.All(
+                cv.version_number, cv.validate_esphome_version
+            ),
             cv.Required(CONF_NAME): cv.valid_name,
             cv.Optional(CONF_FRIENDLY_NAME, ""): cv.string,
             cv.Optional(CONF_AREA, ""): cv.string,
@@ -160,9 +163,6 @@ CONFIG_SCHEMA = cv.All(
                         }
                     ),
                 }
-            ),
-            cv.Optional(CONF_MIN_VERSION, default=ESPHOME_VERSION): cv.All(
-                cv.version_number, cv.validate_esphome_version
             ),
             cv.Optional(
                 CONF_COMPILE_PROCESS_LIMIT, default=_compile_process_limit_default


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->
Change ordering so `min_version` happens during preload

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

Discord Discussion: https://discord.com/channels/429907082951524364/429907082955718657/1309209332780367892

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
esphome:
  name: foobar
  min_version: 2024.11.1 #This should error _before_ the mqtt enable_on_boot error

mqtt:
  enable_on_boot: false #This wasn't introduced until 2024.11.0, it should cause an error
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
