### PR TITLE
[font] Be more explanatory in missing glyph error message

### DIFF
--- a/esphome/components/font/__init__.py
+++ b/esphome/components/font/__init__.py
@@ -108,7 +108,7 @@ def check_missing_glyphs(file, codepoints: Iterable, warning: bool = False):
         )
         if count > 10:
             missing_str += f"\n    and {count - 10} more."
-        message = f"Font {Path(file).name} is missing {count} glyph{'s' if count != 1 else ''}:\n    {missing_str}"
+        message = f"Font {Path(file).name} is missing {count} glyph{'s' if count != 1 else ''}:\n    {missing_str}\nESPHome version 2024.11.0 introduced testing for missing glyphs in the compilation phase. Missing glyphs are most likely a problem of the font itself."
         if warning:
             _LOGGER.warning(message)
         else:


### PR DESCRIPTION
# What does this implement/fix?

When ESPHome https://github.com/esphome/esphome/pull/7429 introduced checking for missing glyphs with 2024.11.0, in some scenarios users would get an error message on compilation (e.g. https://github.com/esphome/issues/issues/6472) which would get attributed to ESPHome itself instead of highlighting longer-standing problems with the used font.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [X] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/issues/issues/6472

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

Not applicable.

## Test Environment

- [ ] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

Not applicable

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
