### PR TITLE
[docker] Leave run-time required libraries installed.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -99,15 +99,17 @@ BUILD_DEPS="
     libfreetype-dev=2.12.1+dfsg-5+deb12u3
     libssl-dev=3.0.15-1~deb12u1
     libffi-dev=3.4.4-1
-    libopenjp2-7=2.5.0-2
-    libtiff6=4.5.0-6+deb12u1
     cargo=0.66.0+ds1-1
     pkg-config=1.8.1-1
+"
+LIB_DEPS="
+    libtiff6=4.5.0-6+deb12u1
+    libopenjp2-7=2.5.0-2
 "
 if [ "$TARGETARCH$TARGETVARIANT" = "arm64" ] || [ "$TARGETARCH$TARGETVARIANT" = "armv7" ]
 then
     apt-get update
-    apt-get install -y --no-install-recommends $BUILD_DEPS
+    apt-get install -y --no-install-recommends $BUILD_DEPS $LIB_DEPS
 fi
 
 CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse CARGO_HOME=/root/.cargo


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

For undetermined reasons, the arm7 docker images require some libraries installed at runtime that are apparently not needed by the arm64 and amd64 images.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/issues/issues/6467

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
