### PR TITLE
fix local time timestamp calculation

### DIFF
--- a/esphome/components/datetime/datetime_entity.cpp
+++ b/esphome/components/datetime/datetime_entity.cpp
@@ -60,9 +60,7 @@ ESPTime DateTimeEntity::state_as_esptime() const {
   obj.hour = this->hour_;
   obj.minute = this->minute_;
   obj.second = this->second_;
-  obj.day_of_week = 1;  // Required to be valid for recalc_timestamp_local but not used.
-  obj.day_of_year = 1;  // Required to be valid for recalc_timestamp_local but not used.
-  obj.recalc_timestamp_local(false);
+  obj.recalc_timestamp_local();
   return obj;
 }
 

--- a/esphome/core/time.cpp
+++ b/esphome/core/time.cpp
@@ -189,7 +189,6 @@ void ESPTime::recalc_timestamp_utc(bool use_day_of_year) {
 }
 
 void ESPTime::recalc_timestamp_local() {
-  time_t res = 0;
   struct tm tm;
 
   tm.tm_year = this->year - 1900;

--- a/esphome/core/time.cpp
+++ b/esphome/core/time.cpp
@@ -5,20 +5,18 @@
 
 namespace esphome {
 
-bool is_leap_year(uint32_t year) { return (year % 4) == 0 && ((year % 100) != 0 || (year % 400) == 0); }
-
 uint8_t days_in_month(uint8_t month, uint16_t year) {
   static const uint8_t DAYS_IN_MONTH[] = {0, 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
-  uint8_t days = DAYS_IN_MONTH[month];
-  if (month == 2 && is_leap_year(year))
+  if (month == 2 && (year % 4 == 0))
     return 29;
-  return days;
+  return DAYS_IN_MONTH[month];
 }
 
 size_t ESPTime::strftime(char *buffer, size_t buffer_len, const char *format) {
   struct tm c_tm = this->to_c_tm();
   return ::strftime(buffer, buffer_len, format, &c_tm);
 }
+
 ESPTime ESPTime::from_c_tm(struct tm *c_tm, time_t c_time) {
   ESPTime res{};
   res.second = uint8_t(c_tm->tm_sec);
@@ -33,6 +31,7 @@ ESPTime ESPTime::from_c_tm(struct tm *c_tm, time_t c_time) {
   res.timestamp = c_time;
   return res;
 }
+
 struct tm ESPTime::to_c_tm() {
   struct tm c_tm {};
   c_tm.tm_sec = this->second;
@@ -46,6 +45,7 @@ struct tm ESPTime::to_c_tm() {
   c_tm.tm_isdst = this->is_dst;
   return c_tm;
 }
+
 std::string ESPTime::strftime(const std::string &format) {
   std::string timestr;
   timestr.resize(format.size() * 4);
@@ -142,6 +142,7 @@ void ESPTime::increment_second() {
     this->year++;
   }
 }
+
 void ESPTime::increment_day() {
   this->timestamp += 86400;
 
@@ -159,23 +160,22 @@ void ESPTime::increment_day() {
     this->year++;
   }
 }
+
 void ESPTime::recalc_timestamp_utc(bool use_day_of_year) {
   time_t res = 0;
-
   if (!this->fields_in_range()) {
     this->timestamp = -1;
     return;
   }
 
   for (int i = 1970; i < this->year; i++)
-    res += is_leap_year(i) ? 366 : 365;
+    res += (year % 4 == 0) ? 366 : 365;
 
   if (use_day_of_year) {
     res += this->day_of_year - 1;
   } else {
     for (int i = 1; i < this->month; i++)
       res += days_in_month(i, this->year);
-
     res += this->day_of_month - 1;
   }
 
@@ -188,13 +188,18 @@ void ESPTime::recalc_timestamp_utc(bool use_day_of_year) {
   this->timestamp = res;
 }
 
-void ESPTime::recalc_timestamp_local(bool use_day_of_year) {
-  this->recalc_timestamp_utc(use_day_of_year);
-  this->timestamp -= ESPTime::timezone_offset();
-  ESPTime temp = ESPTime::from_epoch_local(this->timestamp);
-  if (temp.is_dst) {
-    this->timestamp -= 3600;
-  }
+void ESPTime::recalc_timestamp_local() {
+  time_t res = 0;
+  struct tm tm;
+
+  tm.tm_year = this->year - 1900;
+  tm.tm_mon = this->month - 1;
+  tm.tm_mday = this->day_of_month;
+  tm.tm_hour = this->hour;
+  tm.tm_min = this->minute;
+  tm.tm_sec = this->second;
+
+  this->timestamp = mktime(&tm);
 }
 
 int32_t ESPTime::timezone_offset() {

--- a/esphome/core/time.h
+++ b/esphome/core/time.h
@@ -9,8 +9,6 @@ namespace esphome {
 
 template<typename T> bool increment_time_value(T &current, uint16_t begin, uint16_t end);
 
-bool is_leap_year(uint32_t year);
-
 uint8_t days_in_month(uint8_t month, uint16_t year);
 
 /// A more user-friendly version of struct tm from time.h
@@ -100,7 +98,7 @@ struct ESPTime {
   void recalc_timestamp_utc(bool use_day_of_year = true);
 
   /// Recalculate the timestamp field from the other fields of this ESPTime instance assuming local fields.
-  void recalc_timestamp_local(bool use_day_of_year = true);
+  void recalc_timestamp_local();
 
   /// Convert this ESPTime instance back to a tm struct.
   struct tm to_c_tm();


### PR DESCRIPTION
# What does this implement/fix?

The recalc local timestamp method would sometimes get the wrong value.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
