### PR TITLE
keypad binary sensors should be initially off

### DIFF
--- a/esphome/components/binary_sensor/binary_sensor.h
+++ b/esphome/components/binary_sensor/binary_sensor.h
@@ -58,7 +58,7 @@ class BinarySensor : public EntityBase, public EntityBase_DeviceClass {
   void publish_initial_state(bool state);
 
   /// The current reported state of the binary sensor.
-  bool state;
+  bool state{false};
 
   void add_filter(Filter *filter);
   void add_filters(const std::vector<Filter *> &filters);

--- a/esphome/components/matrix_keypad/binary_sensor/matrix_keypad_binary_sensor.h
+++ b/esphome/components/matrix_keypad/binary_sensor/matrix_keypad_binary_sensor.h
@@ -6,7 +6,7 @@
 namespace esphome {
 namespace matrix_keypad {
 
-class MatrixKeypadBinarySensor : public MatrixKeypadListener, public binary_sensor::BinarySensor {
+class MatrixKeypadBinarySensor : public MatrixKeypadListener, public binary_sensor::BinarySensorInitiallyOff {
  public:
   MatrixKeypadBinarySensor(uint8_t key) : has_key_(true), key_(key){};
   MatrixKeypadBinarySensor(const char *key) : has_key_(true), key_((uint8_t) key[0]){};


### PR DESCRIPTION
# What does this implement/fix?

Makes sure that keypad binary sensors start with a valid state.
Also makes sure that the state variable is initialized.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
