### PR TITLE
fix modbus crashing when bad data returned

### DIFF
--- a/esphome/components/modbus/modbus.cpp
+++ b/esphome/components/modbus/modbus.cpp
@@ -38,8 +38,9 @@ void Modbus::loop() {
 
     // stop blocking new send commands after sent_wait_time_ ms after response received
     if (now - this->last_send_ > send_wait_time_) {
-      if (waiting_for_response > 0)
+      if (waiting_for_response > 0) {
         ESP_LOGV(TAG, "Stop waiting for response from %d", waiting_for_response);
+      }
       waiting_for_response = 0;
     }
   }

--- a/esphome/components/modbus_controller/modbus_controller.cpp
+++ b/esphome/components/modbus_controller/modbus_controller.cpp
@@ -622,51 +622,84 @@ int64_t payload_to_number(const std::vector<uint8_t> &data, SensorValueType sens
                           uint32_t bitmask) {
   int64_t value = 0;  // int64_t because it can hold signed and unsigned 32 bits
 
+  size_t size = data.size() - offset;
+  bool error = false;
   switch (sensor_value_type) {
     case SensorValueType::U_WORD:
-      value = mask_and_shift_by_rightbit(get_data<uint16_t>(data, offset), bitmask);  // default is 0xFFFF ;
+      if (size >= 2)
+        value = mask_and_shift_by_rightbit(get_data<uint16_t>(data, offset), bitmask);  // default is 0xFFFF ;
+      else
+        error = true;
       break;
     case SensorValueType::U_DWORD:
     case SensorValueType::FP32:
-      value = get_data<uint32_t>(data, offset);
-      value = mask_and_shift_by_rightbit((uint32_t) value, bitmask);
+      if (size >= 4) {
+        value = get_data<uint32_t>(data, offset);
+        value = mask_and_shift_by_rightbit((uint32_t) value, bitmask);
+      } else {
+        error = true;
+      }
       break;
     case SensorValueType::U_DWORD_R:
     case SensorValueType::FP32_R:
-      value = get_data<uint32_t>(data, offset);
-      value = static_cast<uint32_t>(value & 0xFFFF) << 16 | (value & 0xFFFF0000) >> 16;
-      value = mask_and_shift_by_rightbit((uint32_t) value, bitmask);
+      if (size >= 4) {
+        value = get_data<uint32_t>(data, offset);
+        value = static_cast<uint32_t>(value & 0xFFFF) << 16 | (value & 0xFFFF0000) >> 16;
+        value = mask_and_shift_by_rightbit((uint32_t) value, bitmask);
+      } else {
+        error = true;
+      }
       break;
     case SensorValueType::S_WORD:
-      value = mask_and_shift_by_rightbit(get_data<int16_t>(data, offset),
-                                         bitmask);  // default is 0xFFFF ;
+      if (size >= 2) {
+        value = mask_and_shift_by_rightbit(get_data<int16_t>(data, offset),
+                                           bitmask);  // default is 0xFFFF ;
+      } else {
+        error = true;
+      }
       break;
     case SensorValueType::S_DWORD:
-      value = mask_and_shift_by_rightbit(get_data<int32_t>(data, offset), bitmask);
+      if (size >= 4)
+        value = mask_and_shift_by_rightbit(get_data<int32_t>(data, offset), bitmask);
+      else
+        error = true;
       break;
     case SensorValueType::S_DWORD_R: {
-      value = get_data<uint32_t>(data, offset);
-      // Currently the high word is at the low position
-      // the sign bit is therefore at low before the switch
-      uint32_t sign_bit = (value & 0x8000) << 16;
-      value = mask_and_shift_by_rightbit(
-          static_cast<int32_t>(((value & 0x7FFF) << 16 | (value & 0xFFFF0000) >> 16) | sign_bit), bitmask);
+      if (size >= 4) {
+        value = get_data<uint32_t>(data, offset);
+        // Currently the high word is at the low position
+        // the sign bit is therefore at low before the switch
+        uint32_t sign_bit = (value & 0x8000) << 16;
+        value = mask_and_shift_by_rightbit(
+            static_cast<int32_t>(((value & 0x7FFF) << 16 | (value & 0xFFFF0000) >> 16) | sign_bit), bitmask);
+      } else {
+        error = true;
+      }
     } break;
     case SensorValueType::U_QWORD:
     case SensorValueType::S_QWORD:
       // Ignore bitmask for QWORD
-      value = get_data<uint64_t>(data, offset);
+      if (size >= 8)
+        value = get_data<uint64_t>(data, offset);
+      else
+        error = true;
       break;
     case SensorValueType::U_QWORD_R:
     case SensorValueType::S_QWORD_R: {
       // Ignore bitmask for QWORD
-      uint64_t tmp = get_data<uint64_t>(data, offset);
-      value = (tmp << 48) | (tmp >> 48) | ((tmp & 0xFFFF0000) << 16) | ((tmp >> 16) & 0xFFFF0000);
+      if (size >= 8) {
+        uint64_t tmp = get_data<uint64_t>(data, offset);
+        value = (tmp << 48) | (tmp >> 48) | ((tmp & 0xFFFF0000) << 16) | ((tmp >> 16) & 0xFFFF0000);
+      } else {
+        error = true;
+      }
     } break;
     case SensorValueType::RAW:
     default:
       break;
   }
+  if (error)
+    ESP_LOGE(TAG, "not enough data for value");
   return value;
 }
 

--- a/esphome/components/modbus_controller/modbus_controller.cpp
+++ b/esphome/components/modbus_controller/modbus_controller.cpp
@@ -626,10 +626,11 @@ int64_t payload_to_number(const std::vector<uint8_t> &data, SensorValueType sens
   bool error = false;
   switch (sensor_value_type) {
     case SensorValueType::U_WORD:
-      if (size >= 2)
+      if (size >= 2) {
         value = mask_and_shift_by_rightbit(get_data<uint16_t>(data, offset), bitmask);  // default is 0xFFFF ;
-      else
+      } else {
         error = true;
+      }
       break;
     case SensorValueType::U_DWORD:
     case SensorValueType::FP32:
@@ -659,10 +660,11 @@ int64_t payload_to_number(const std::vector<uint8_t> &data, SensorValueType sens
       }
       break;
     case SensorValueType::S_DWORD:
-      if (size >= 4)
+      if (size >= 4) {
         value = mask_and_shift_by_rightbit(get_data<int32_t>(data, offset), bitmask);
-      else
+      } else {
         error = true;
+      }
       break;
     case SensorValueType::S_DWORD_R: {
       if (size >= 4) {
@@ -679,10 +681,11 @@ int64_t payload_to_number(const std::vector<uint8_t> &data, SensorValueType sens
     case SensorValueType::U_QWORD:
     case SensorValueType::S_QWORD:
       // Ignore bitmask for QWORD
-      if (size >= 8)
+      if (size >= 8) {
         value = get_data<uint64_t>(data, offset);
-      else
+      } else {
         error = true;
+      }
       break;
     case SensorValueType::U_QWORD_R:
     case SensorValueType::S_QWORD_R: {


### PR DESCRIPTION
# What does this implement/fix?

If the returned data is smaller than requested, the modbus component will crash.
Also fixes a compiler warning from #7674.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
