### PR TITLE
Added HX710 component to esphome simular to HX711 but different

### DIFF
--- a/esphome/components/hx710/hx710.cpp
+++ b/esphome/components/hx710/hx710.cpp
@@ -1,0 +1,83 @@
+#include "hx710.h"
+#include "esphome/core/log.h"
+#include "esphome/core/helpers.h"
+
+namespace esphome {
+namespace hx710 {
+
+static const char *const TAG = "hx710";
+
+void HX710Sensor::setup() {
+  ESP_LOGCONFIG(TAG, "Setting up HX710 '%s'...", this->name_.c_str());
+  this->sck_pin_->setup();
+  this->dout_pin_->setup();
+  this->sck_pin_->digital_write(false);
+
+  // Read sensor once without publishing to set the gain
+  this->read_sensor_(nullptr);
+}
+
+void HX710Sensor::dump_config() {
+  LOG_SENSOR("", "HX710", this);
+  LOG_PIN("  DOUT Pin: ", this->dout_pin_);
+  LOG_PIN("  SCK Pin: ", this->sck_pin_);
+  LOG_UPDATE_INTERVAL(this);
+}
+float HX710Sensor::get_setup_priority() const { return setup_priority::DATA; }
+void HX710Sensor::update() {
+  uint32_t result;
+  if (this->read_sensor_(&result)) {
+    int32_t value = static_cast<int32_t>(result);
+    ESP_LOGD(TAG, "'%s': Got value %" PRId32, this->name_.c_str(), value);
+    this->publish_state(value);
+  }
+}
+bool HX710Sensor::read_sensor_(uint32_t *result) {
+  if (this->dout_pin_->digital_read()) {
+    ESP_LOGW(TAG, "HX710 is not ready for new measurements yet!");
+    this->status_set_warning();
+    return false;
+  }
+
+  uint32_t data = 0;
+  bool final_dout;
+
+  {
+    InterruptLock lock;
+    for (uint8_t i = 0; i < 24; i++) {
+      this->sck_pin_->digital_write(true);
+      delayMicroseconds(1);
+      data |= uint32_t(this->dout_pin_->digital_read()) << (23 - i);
+      this->sck_pin_->digital_write(false);
+      delayMicroseconds(1);
+    }
+
+    // Cycle clock pin for gain setting
+    for (uint8_t i = 0; i < this->gain_; i++) {
+      this->sck_pin_->digital_write(true);
+      delayMicroseconds(1);
+      this->sck_pin_->digital_write(false);
+      delayMicroseconds(1);
+    }
+    final_dout = this->dout_pin_->digital_read();
+  }
+
+  if (!final_dout) {
+    ESP_LOGW(TAG, "HX710 DOUT pin not high after reading (data 0x%" PRIx32 ")!", data);
+    this->status_set_warning();
+    return false;
+  }
+
+  this->status_clear_warning();
+
+  if (data & 0x800000ULL) {
+    data |= 0xFF000000ULL;
+  }
+
+  if (result != nullptr)
+    *result = data;
+  return true;
+}
+
+}  // namespace hx710
+}  // namespace esphome

--- a/esphome/components/hx710/hx710.h
+++ b/esphome/components/hx710/hx710.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/core/hal.h"
+#include "esphome/components/sensor/sensor.h"
+
+#include <cinttypes>
+
+namespace esphome {
+namespace hx710 {
+
+enum HX710Mode {
+  HX710_DIFFERENTIAL_INPUT_10HZ = 1,
+  HX710_OTHER_INPUT_40HZ = 2,
+  HX710_DIFFERENTIAL_INPUT_40HZ = 3
+};
+
+class HX710Sensor : public sensor::Sensor, public PollingComponent {
+ public:
+  void set_dout_pin(GPIOPin *dout_pin) { dout_pin_ = dout_pin; }
+  void set_sck_pin(GPIOPin *sck_pin) { sck_pin_ = sck_pin; }
+  void set_gain(HX710Mode gain) { gain_ = gain; }
+
+  void setup() override;
+  void dump_config() override;
+  float get_setup_priority() const override;
+  void update() override;
+
+ protected:
+  bool read_sensor_(uint32_t *result);
+
+  GPIOPin *dout_pin_;
+  GPIOPin *sck_pin_;
+  HX710Mode gain_{HX710_DIFFERENTIAL_INPUT_10HZ};
+};
+
+}  // namespace hx710
+}  // namespace esphome

--- a/esphome/components/hx710/sensor.py
+++ b/esphome/components/hx710/sensor.py
@@ -1,0 +1,50 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome import pins
+from esphome.components import sensor
+from esphome.const import (
+    CONF_CLK_PIN,
+    CONF_MODE,
+    ICON_SCALE,
+    STATE_CLASS_MEASUREMENT,
+)
+
+hx710_ns = cg.esphome_ns.namespace("hx710")
+HX710Sensor = hx710_ns.class_("HX710Sensor", sensor.Sensor, cg.PollingComponent)
+
+CONF_DOUT_PIN = "dout_pin"
+
+HX710Mode = hx710_ns.enum("HX710Mode")
+MODES = {
+    1: HX710Mode.HX710_DIFFERENTIAL_INPUT_10HZ,
+    2: HX710Mode.HX710_OTHER_INPUT_40HZ,
+    3: HX710Mode.HX710_DIFFERENTIAL_INPUT_40HZ,
+}
+
+CONFIG_SCHEMA = (
+    sensor.sensor_schema(
+        HX710Sensor,
+        icon=ICON_SCALE,
+        accuracy_decimals=0,
+        state_class=STATE_CLASS_MEASUREMENT,
+    )
+    .extend(
+        {
+            cv.Required(CONF_DOUT_PIN): pins.gpio_input_pin_schema,
+            cv.Required(CONF_CLK_PIN): pins.gpio_output_pin_schema,
+            cv.Optional(CONF_MODE, default=1): cv.enum(MODES, int=True),
+        }
+    )
+    .extend(cv.polling_component_schema("60s"))
+)
+
+
+async def to_code(config):
+    var = await sensor.new_sensor(config)
+    await cg.register_component(var, config)
+
+    dout_pin = await cg.gpio_pin_expression(config[CONF_DOUT_PIN])
+    cg.add(var.set_dout_pin(dout_pin))
+    sck_pin = await cg.gpio_pin_expression(config[CONF_CLK_PIN])
+    cg.add(var.set_sck_pin(sck_pin))
+    cg.add(var.set_gain(config[CONF_MODE]))

--- a/tests/components/hx710/test.esp32-ard.yaml
+++ b/tests/components/hx710/test.esp32-ard.yaml
@@ -1,0 +1,7 @@
+sensor:
+  - platform: hx710
+    name: HX710 Value
+    dout_pin: 14
+    clk_pin: 15
+    mode: 1
+    update_interval: 15s

--- a/tests/components/hx710/test.esp32-c3-ard.yaml
+++ b/tests/components/hx710/test.esp32-c3-ard.yaml
@@ -1,0 +1,7 @@
+sensor:
+  - platform: hx710
+    name: HX710 Value
+    dout_pin: 4
+    clk_pin: 5
+    mode: 1
+    update_interval: 15s

--- a/tests/components/hx710/test.esp32-c3-idf.yaml
+++ b/tests/components/hx710/test.esp32-c3-idf.yaml
@@ -1,0 +1,7 @@
+sensor:
+  - platform: hx710
+    name: HX710 Value
+    dout_pin: 4
+    clk_pin: 5
+    mode: 1
+    update_interval: 15s

--- a/tests/components/hx710/test.esp32-idf.yaml
+++ b/tests/components/hx710/test.esp32-idf.yaml
@@ -1,0 +1,7 @@
+sensor:
+  - platform: hx710
+    name: HX710 Value
+    dout_pin: 14
+    clk_pin: 15
+    mode: 1
+    update_interval: 15s

--- a/tests/components/hx710/test.esp8266-ard.yaml
+++ b/tests/components/hx710/test.esp8266-ard.yaml
@@ -1,0 +1,7 @@
+sensor:
+  - platform: hx710
+    name: HX710 Value
+    dout_pin: 4
+    clk_pin: 5
+    mode: 1
+    update_interval: 15s

--- a/tests/components/hx710/test.rp2040-ard.yaml
+++ b/tests/components/hx710/test.rp2040-ard.yaml
@@ -1,0 +1,7 @@
+sensor:
+  - platform: hx710
+    name: HX710 Value
+    dout_pin: 4
+    clk_pin: 5
+    mode: 1
+    update_interval: 15s


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
