### PR TITLE
[bme68x_bsec2_i2c] Remove arduino dependency

### DIFF
--- a/esphome/components/bme68x_bsec2/__init__.py
+++ b/esphome/components/bme68x_bsec2/__init__.py
@@ -145,7 +145,6 @@ CONFIG_SCHEMA_BASE = (
             ): cv.positive_time_period_minutes,
         },
     )
-    .add_extra(cv.only_with_arduino)
     .add_extra(validate_bme68x)
     .add_extra(download_bme68x_blob)
 )
@@ -179,16 +178,18 @@ async def to_code_base(config):
     bsec2_arr = cg.progmem_array(config[CONF_RAW_DATA_ID], rhs)
     cg.add(var.set_bsec2_configuration(bsec2_arr, len(rhs)))
 
-    # Although this component does not use SPI, the BSEC2 library requires the SPI library
-    cg.add_library("SPI", None)
+    # Although this component does not use SPI, the BSEC2 Arduino library requires the SPI library
+    if core.CORE.using_arduino:
+        cg.add_library("SPI", None)
     cg.add_library(
         "BME68x Sensor library",
-        "1.1.40407",
+        None,
+        "https://github.com/luar123/Bosch-BME68x-Library",
     )
     cg.add_library(
         "BSEC2 Software Library",
         None,
-        f"https://github.com/boschsensortec/Bosch-BSEC2-Library.git#{BSEC2_LIBRARY_VERSION}",
+        "https://github.com/luar123/Bosch-BSEC2-Library",
     )
 
     cg.add_define("USE_BSEC2")

--- a/esphome/components/bme68x_bsec2/__init__.py
+++ b/esphome/components/bme68x_bsec2/__init__.py
@@ -16,7 +16,7 @@ CODEOWNERS = ["@neffs", "@kbx81"]
 
 DOMAIN = "bme68x_bsec2"
 
-BSEC2_LIBRARY_VERSION = "v1.8.2610"
+BSEC2_LIBRARY_VERSION = "1.10.2610"
 
 CONF_ALGORITHM_OUTPUT = "algorithm_output"
 CONF_BME68X_BSEC2_ID = "bme68x_bsec2_id"
@@ -183,13 +183,13 @@ async def to_code_base(config):
         cg.add_library("SPI", None)
     cg.add_library(
         "BME68x Sensor library",
-        None,
-        "https://github.com/luar123/Bosch-BME68x-Library",
+        "1.3.40408",
+        "https://github.com/boschsensortec/Bosch-BME68x-Library",
     )
     cg.add_library(
         "BSEC2 Software Library",
         None,
-        "https://github.com/luar123/Bosch-BSEC2-Library",
+        f"https://github.com/boschsensortec/Bosch-BSEC2-Library.git#{BSEC2_LIBRARY_VERSION}",
     )
 
     cg.add_define("USE_BSEC2")

--- a/esphome/components/bme68x_bsec2/bme68x_bsec2.cpp
+++ b/esphome/components/bme68x_bsec2/bme68x_bsec2.cpp
@@ -1,4 +1,5 @@
 #include "esphome/core/defines.h"
+#include "esphome/core/hal.h"
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 

--- a/esphome/components/bme68x_bsec2_i2c/bme68x_bsec2_i2c.cpp
+++ b/esphome/components/bme68x_bsec2_i2c/bme68x_bsec2_i2c.cpp
@@ -1,4 +1,5 @@
 #include "esphome/core/defines.h"
+#include "esphome/core/hal.h"
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 

--- a/tests/components/bme68x_bsec2_i2c/test.esp32-c3-idf.yaml
+++ b/tests/components/bme68x_bsec2_i2c/test.esp32-c3-idf.yaml
@@ -1,0 +1,5 @@
+substitutions:
+  scl_pin: GPIO6
+  sda_pin: GPIO7
+
+<<: !include common.yaml

--- a/tests/components/bme68x_bsec2_i2c/test.esp32-idf.yaml
+++ b/tests/components/bme68x_bsec2_i2c/test.esp32-idf.yaml
@@ -1,0 +1,5 @@
+substitutions:
+  scl_pin: GPIO16
+  sda_pin: GPIO17
+
+<<: !include common.yaml

--- a/tests/components/bme68x_bsec2_i2c/test.esp32-s2-idf.yaml
+++ b/tests/components/bme68x_bsec2_i2c/test.esp32-s2-idf.yaml
@@ -1,0 +1,5 @@
+substitutions:
+  scl_pin: GPIO16
+  sda_pin: GPIO17
+
+<<: !include common.yaml

--- a/tests/components/bme68x_bsec2_i2c/test.esp32-s3-idf.yaml
+++ b/tests/components/bme68x_bsec2_i2c/test.esp32-s3-idf.yaml
@@ -1,0 +1,5 @@
+substitutions:
+  scl_pin: GPIO16
+  sda_pin: GPIO17
+
+<<: !include common.yaml

--- a/tests/components/bme68x_bsec2_i2c/test.rp2040-ard.yaml
+++ b/tests/components/bme68x_bsec2_i2c/test.rp2040-ard.yaml
@@ -1,0 +1,5 @@
+substitutions:
+  scl_pin: GPIO5
+  sda_pin: GPIO4
+
+<<: !include common.yaml


### PR DESCRIPTION
# What does this implement/fix?

Remove Arduino dependency of bme68x_bsec2_i2c component and allow to build with esp-idf.
~~I will keep this in draft state until PRs https://github.com/boschsensortec/Bosch-BME68x-Library/pull/8 and https://github.com/boschsensortec/Bosch-BSEC2-Library/pull/50 are merged. For now, my forks are used.~~

BSEC2 library update to v1.10.2610 also allows to build for currently unsupported esp32 variants like C6, H2, P4, etc. as well as some arm variants like RP2040.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/feature-requests/issues/2431

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
