### PR TITLE
binary_sensor for switch state

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -408,6 +408,7 @@ esphome/components/substitutions/* @esphome/core
 esphome/components/sun/* @OttoWinter
 esphome/components/sun_gtil2/* @Mat931
 esphome/components/switch/* @esphome/core
+esphome/components/switch/binary_sensor/* @ssieb
 esphome/components/t6615/* @tylermenezes
 esphome/components/tc74/* @sethgirvan
 esphome/components/tca9548a/* @andreashergert1984

--- a/esphome/components/switch/binary_sensor/__init__.py
+++ b/esphome/components/switch/binary_sensor/__init__.py
@@ -1,0 +1,31 @@
+import esphome.codegen as cg
+from esphome.components import binary_sensor
+import esphome.config_validation as cv
+from esphome.const import CONF_SOURCE_ID
+
+from .. import Switch, switch_ns
+
+CODEOWNERS = ["@ssieb"]
+
+SwitchBinarySensor = switch_ns.class_(
+    "SwitchBinarySensor", binary_sensor.BinarySensor, cg.Component
+)
+
+
+CONFIG_SCHEMA = (
+    binary_sensor.binary_sensor_schema(SwitchBinarySensor)
+    .extend(
+        {
+            cv.Required(CONF_SOURCE_ID): cv.use_id(Switch),
+        }
+    )
+    .extend(cv.COMPONENT_SCHEMA)
+)
+
+
+async def to_code(config):
+    var = await binary_sensor.new_binary_sensor(config)
+    await cg.register_component(var, config)
+
+    source = await cg.get_variable(config[CONF_SOURCE_ID])
+    cg.add(var.set_source(source))

--- a/esphome/components/switch/binary_sensor/switch_binary_sensor.cpp
+++ b/esphome/components/switch/binary_sensor/switch_binary_sensor.cpp
@@ -1,0 +1,17 @@
+#include "switch_binary_sensor.h"
+#include "esphome/core/log.h"
+
+namespace esphome {
+namespace switch_ {
+
+static const char *const TAG = "switch.binary_sensor";
+
+void SwitchBinarySensor::setup() {
+  source_->add_on_state_callback([this](bool value) { this->publish_state(value); });
+  this->publish_state(source_->state);
+}
+
+void SwitchBinarySensor::dump_config() { LOG_BINARY_SENSOR("", "Switch Binary Sensor", this); }
+
+}  // namespace switch_
+}  // namespace esphome

--- a/esphome/components/switch/binary_sensor/switch_binary_sensor.h
+++ b/esphome/components/switch/binary_sensor/switch_binary_sensor.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "../switch.h"
+#include "esphome/core/component.h"
+#include "esphome/components/binary_sensor/binary_sensor.h"
+
+namespace esphome {
+namespace switch_ {
+
+class SwitchBinarySensor : public binary_sensor::BinarySensor, public Component {
+ public:
+  void set_source(Switch *source) { source_ = source; }
+  void setup() override;
+  void dump_config() override;
+  float get_setup_priority() const override { return setup_priority::DATA; }
+
+ protected:
+  Switch *source_;
+};
+
+}  // namespace switch_
+}  // namespace esphome

--- a/tests/components/switch/common.yaml
+++ b/tests/components/switch/common.yaml
@@ -1,0 +1,11 @@
+binary_sensor:
+  - platform: switch
+    id: some_binary_sensor
+    name: "Template Switch State"
+    source_id: the_switch
+
+switch:
+  - platform: template
+    name: "Template Switch"
+    id: the_switch
+    optimistic: true

--- a/tests/components/switch/test.bk72xx-ard.yaml
+++ b/tests/components/switch/test.bk72xx-ard.yaml
@@ -1,0 +1,2 @@
+packages:
+  common: !include common.yaml

--- a/tests/components/switch/test.esp32-ard.yaml
+++ b/tests/components/switch/test.esp32-ard.yaml
@@ -1,0 +1,2 @@
+packages:
+  common: !include common.yaml

--- a/tests/components/switch/test.esp32-c3-ard.yaml
+++ b/tests/components/switch/test.esp32-c3-ard.yaml
@@ -1,0 +1,2 @@
+packages:
+  common: !include common.yaml

--- a/tests/components/switch/test.esp32-c3-idf.yaml
+++ b/tests/components/switch/test.esp32-c3-idf.yaml
@@ -1,0 +1,2 @@
+packages:
+  common: !include common.yaml

--- a/tests/components/switch/test.esp32-idf.yaml
+++ b/tests/components/switch/test.esp32-idf.yaml
@@ -1,0 +1,2 @@
+packages:
+  common: !include common.yaml

--- a/tests/components/switch/test.esp32-s3-idf.yaml
+++ b/tests/components/switch/test.esp32-s3-idf.yaml
@@ -1,0 +1,2 @@
+packages:
+  common: !include common.yaml

--- a/tests/components/switch/test.esp8266-ard.yaml
+++ b/tests/components/switch/test.esp8266-ard.yaml
@@ -1,0 +1,2 @@
+packages:
+  common: !include common.yaml

--- a/tests/components/switch/test.rp2040-ard.yaml
+++ b/tests/components/switch/test.rp2040-ard.yaml
@@ -1,0 +1,2 @@
+packages:
+  common: !include common.yaml


### PR DESCRIPTION
# What does this implement/fix?

Adds a binary sensor that tracks the state of a switch.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/feature-requests/issues/2957

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#4465

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
