### PR TITLE
[camera_web_server] Add ``NOLINT`` due to naming

### DIFF
--- a/esphome/components/esp32_camera_web_server/camera_web_server.h
+++ b/esphome/components/esp32_camera_web_server/camera_web_server.h
@@ -11,7 +11,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/preferences.h"
 
-struct httpd_req;
+struct httpd_req;  // NOLINT(readability-identifier-naming)
 
 namespace esphome {
 namespace esp32_camera_web_server {


### PR DESCRIPTION
# What does this implement/fix?

`clang-tidy` issue found as part of #7822

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
