### PR TITLE
[ota] `void` functions should return nothing

### DIFF
--- a/esphome/components/ota/automation.h
+++ b/esphome/components/ota/automation.h
@@ -12,7 +12,7 @@ class OTAStateChangeTrigger : public Trigger<OTAState> {
   explicit OTAStateChangeTrigger(OTAComponent *parent) {
     parent->add_on_state_callback([this, parent](OTAState state, float progress, uint8_t error) {
       if (!parent->is_failed()) {
-        return trigger(state);
+        trigger(state);
       }
     });
   }


### PR DESCRIPTION
# What does this implement/fix?

`clang-tidy` issue found as part of #7822

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
