### PR TITLE
[uart] `void` functions should return nothing

### DIFF
--- a/esphome/components/uart/uart.h
+++ b/esphome/components/uart/uart.h
@@ -40,7 +40,7 @@ class UARTDevice {
 
   int available() { return this->parent_->available(); }
 
-  void flush() { return this->parent_->flush(); }
+  void flush() { this->parent_->flush(); }
 
   // Compat APIs
   int read() {


### PR DESCRIPTION
# What does this implement/fix?

`clang-tidy` issue found as part of #7822

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
