### PR TITLE
[homeassistant.number] Return when value not set

### DIFF
--- a/esphome/components/homeassistant/number/homeassistant_number.cpp
+++ b/esphome/components/homeassistant/number/homeassistant_number.cpp
@@ -27,6 +27,7 @@ void HomeassistantNumber::min_retrieved_(const std::string &min) {
   auto min_value = parse_number<float>(min);
   if (!min_value.has_value()) {
     ESP_LOGE(TAG, "'%s': Can't convert 'min' value '%s' to number!", this->entity_id_.c_str(), min.c_str());
+    return;
   }
   ESP_LOGD(TAG, "'%s': Min retrieved: %s", get_name().c_str(), min.c_str());
   this->traits.set_min_value(min_value.value());
@@ -36,6 +37,7 @@ void HomeassistantNumber::max_retrieved_(const std::string &max) {
   auto max_value = parse_number<float>(max);
   if (!max_value.has_value()) {
     ESP_LOGE(TAG, "'%s': Can't convert 'max' value '%s' to number!", this->entity_id_.c_str(), max.c_str());
+    return;
   }
   ESP_LOGD(TAG, "'%s': Max retrieved: %s", get_name().c_str(), max.c_str());
   this->traits.set_max_value(max_value.value());
@@ -45,6 +47,7 @@ void HomeassistantNumber::step_retrieved_(const std::string &step) {
   auto step_value = parse_number<float>(step);
   if (!step_value.has_value()) {
     ESP_LOGE(TAG, "'%s': Can't convert 'step' value '%s' to number!", this->entity_id_.c_str(), step.c_str());
+    return;
   }
   ESP_LOGD(TAG, "'%s': Step Retrieved %s", get_name().c_str(), step.c_str());
   this->traits.set_step(step_value.value());


### PR DESCRIPTION
# What does this implement/fix?

`clang-tidy` issue found as part of #7822

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
