### PR TITLE
Add IRAM_ATTR to all functions used during interrupts on esp8266 chips.

### DIFF
--- a/esphome/components/opentherm/opentherm.cpp
+++ b/esphome/components/opentherm/opentherm.cpp
@@ -220,7 +220,7 @@ void IRAM_ATTR OpenTherm::bit_read_(uint8_t value) {
   this->bit_pos_++;
 }
 
-ProtocolErrorType OpenTherm::verify_stop_bit_(uint8_t value) {
+ProtocolErrorType IRAM_ATTR OpenTherm::verify_stop_bit_(uint8_t value) {
   if (value) {  // stop bit detected
     return check_parity_(this->data_) ? ProtocolErrorType::NO_ERROR : ProtocolErrorType::PARITY_ERROR;
   } else {  // no stop bit detected, error
@@ -365,7 +365,7 @@ void IRAM_ATTR OpenTherm::stop_timer_() {
 
 #ifdef ESP8266
 // 5 kHz timer_
-void OpenTherm::start_read_timer_() {
+void IRAM_ATTR OpenTherm::start_read_timer_() {
   InterruptLock const lock;
   timer1_attachInterrupt(OpenTherm::esp8266_timer_isr);
   timer1_enable(TIM_DIV16, TIM_EDGE, TIM_LOOP);  // 5MHz (5 ticks/us - 1677721.4 us max)
@@ -373,14 +373,14 @@ void OpenTherm::start_read_timer_() {
 }
 
 // 2 kHz timer_
-void OpenTherm::start_write_timer_() {
+void IRAM_ATTR OpenTherm::start_write_timer_() {
   InterruptLock const lock;
   timer1_attachInterrupt(OpenTherm::esp8266_timer_isr);
   timer1_enable(TIM_DIV16, TIM_EDGE, TIM_LOOP);  // 5MHz (5 ticks/us - 1677721.4 us max)
   timer1_write(2500);                            // 2kHz
 }
 
-void OpenTherm::stop_timer_() {
+void IRAM_ATTR OpenTherm::stop_timer_() {
   InterruptLock const lock;
   timer1_disable();
   timer1_detachInterrupt();
@@ -389,7 +389,7 @@ void OpenTherm::stop_timer_() {
 #endif  // END ESP8266
 
 // https://stackoverflow.com/questions/21617970/how-to-check-if-value-has-even-parity-of-bits-or-odd
-bool OpenTherm::check_parity_(uint32_t val) {
+bool IRAM_ATTR OpenTherm::check_parity_(uint32_t val) {
   val ^= val >> 16;
   val ^= val >> 8;
   val ^= val >> 4;


### PR DESCRIPTION
Add IRAM_ATTR to all functions used during interrupts on esp8266 chips.
check_parity_() is also called on ESP32 builds.

# What does this implement/fix?

Experienced random disconnects triggered by an "illegal instruction". This could happen after just
five minutes, or a couple of hours. Running on an ESP32-C3, would still experience an occasional
disconnect after 10-70 hours of running.

This issue is mentioned in PR7835, but appears to have been missed in the patch.

## Types of changes

- [* ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [* ] ESP32-C3
- [ ] ESP32 IDF
- [ *] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [* ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
