### PR TITLE
[helpers, optional] clang-tidy fixes for #7822

### DIFF
--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -293,7 +293,7 @@ std::string str_sanitize(const std::string &str) {
   std::replace_if(
       out.begin(), out.end(),
       [](const char &c) {
-        return !(c == '-' || c == '_' || (c >= '0' && c <= '9') || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z'));
+        return c != '-' && c != '_' && (c < '0' || c > '9') && (c < 'a' || c > 'z') && (c < 'A' || c > 'Z');
       },
       '_');
   return out;

--- a/esphome/core/optional.h
+++ b/esphome/core/optional.h
@@ -59,7 +59,7 @@ template<typename T> class optional {  // NOLINT
     return *this;
   }
 
-  void swap(optional &rhs) {
+  void swap(optional &rhs) noexcept {
     using std::swap;
     if (has_value() && rhs.has_value()) {
       swap(**this, *rhs);
@@ -206,7 +206,7 @@ template<typename T, typename U> inline bool operator>=(U const &v, optional<T> 
 
 // Specialized algorithms
 
-template<typename T> void swap(optional<T> &x, optional<T> &y) { x.swap(y); }
+template<typename T> void swap(optional<T> &x, optional<T> &y) noexcept { x.swap(y); }
 
 // Convenience function to create an optional.
 


### PR DESCRIPTION
# What does this implement/fix?

`clang-tidy` issue found as part of #7822

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
