### PR TITLE
[honeywell] use warning instead of failing

### DIFF
--- a/esphome/components/honeywellabp2_i2c/honeywellabp2.cpp
+++ b/esphome/components/honeywellabp2_i2c/honeywellabp2.cpp
@@ -15,7 +15,7 @@ static const char *const TAG = "honeywellabp2";
 void HONEYWELLABP2Sensor::read_sensor_data() {
   if (this->read(raw_data_, 7) != i2c::ERROR_OK) {
     ESP_LOGE(TAG, "Communication with ABP2 failed!");
-    this->mark_failed();
+    this->status_set_warning("couldn't read sensor data");
     return;
   }
   float press_counts = encode_uint24(raw_data_[1], raw_data_[2], raw_data_[3]);  // calculate digital pressure counts
@@ -25,12 +25,13 @@ void HONEYWELLABP2Sensor::read_sensor_data() {
                           (this->max_pressure_ - this->min_pressure_)) +
                          this->min_pressure_;
   this->last_temperature_ = (temp_counts * 200 / 16777215) - 50;
+  this->status_clear_warning();
 }
 
 void HONEYWELLABP2Sensor::start_measurement() {
   if (this->write(i2c_cmd_, 3) != i2c::ERROR_OK) {
     ESP_LOGE(TAG, "Communication with ABP2 failed!");
-    this->mark_failed();
+    this->status_set_warning("couldn't start measurement");
     return;
   }
   this->measurement_running_ = true;
@@ -39,7 +40,7 @@ void HONEYWELLABP2Sensor::start_measurement() {
 bool HONEYWELLABP2Sensor::is_measurement_ready() {
   if (this->read(raw_data_, 1) != i2c::ERROR_OK) {
     ESP_LOGE(TAG, "Communication with ABP2 failed!");
-    this->mark_failed();
+    this->status_set_warning("couldn't check measurement");
     return false;
   }
   if ((raw_data_[0] & (0x1 << STATUS_BIT_BUSY)) > 0) {
@@ -52,7 +53,7 @@ bool HONEYWELLABP2Sensor::is_measurement_ready() {
 void HONEYWELLABP2Sensor::measurement_timeout() {
   ESP_LOGE(TAG, "Timeout!");
   this->measurement_running_ = false;
-  this->mark_failed();
+  this->status_set_warning("measurement timed out");
 }
 
 float HONEYWELLABP2Sensor::get_pressure() { return this->last_pressure_; }
@@ -79,7 +80,7 @@ void HONEYWELLABP2Sensor::update() {
   ESP_LOGV(TAG, "Update Honeywell ABP2 Sensor");
 
   this->start_measurement();
-  this->set_timeout("meas_timeout", 50, [this] { this->measurement_timeout(); });
+  this->set_timeout("meas_timeout", 100, [this] { this->measurement_timeout(); });
 }
 
 void HONEYWELLABP2Sensor::dump_config() {


### PR DESCRIPTION
# What does this implement/fix?

If there's an i2c error, the component goes to failed mode and can't recover.  Warning is better.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
