### PR TITLE
Move ``USE_CAPTIVE_PORTAL`` into all define groups it can be used with

### DIFF
--- a/esphome/core/defines.h
+++ b/esphome/core/defines.h
@@ -84,7 +84,6 @@
 
 // Arduino-specific feature flags
 #ifdef USE_ARDUINO
-#define USE_CAPTIVE_PORTAL
 #define USE_PROMETHEUS
 #define USE_WIFI_WPA2_EAP
 #endif
@@ -97,6 +96,7 @@
 // ESP32-specific feature flags
 #ifdef USE_ESP32
 #define USE_BLUETOOTH_PROXY
+#define USE_CAPTIVE_PORTAL
 #define USE_ESP32_BLE
 #define USE_ESP32_BLE_CLIENT
 #define USE_ESP32_BLE_SERVER
@@ -135,6 +135,7 @@
 #ifdef USE_ESP8266
 #define USE_ADC_SENSOR_VCC
 #define USE_ARDUINO_VERSION_CODE VERSION_CODE(3, 1, 2)
+#define USE_CAPTIVE_PORTAL
 #define USE_ESP8266_PREFERENCES_FLASH
 #define USE_HTTP_REQUEST_ESP8266_HTTPS
 #define USE_SOCKET_IMPL_LWIP_TCP
@@ -159,6 +160,7 @@
 #endif
 
 #ifdef USE_LIBRETINY
+#define USE_CAPTIVE_PORTAL
 #define USE_SOCKET_IMPL_LWIP_SOCKETS
 #define USE_WEBSERVER
 #define USE_WEBSERVER_PORT 80  // NOLINT


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
