### PR TITLE
[various] clang-tidy fixes for #7822

### DIFF
--- a/esphome/components/hitachi_ac344/hitachi_ac344.cpp
+++ b/esphome/components/hitachi_ac344/hitachi_ac344.cpp
@@ -133,8 +133,10 @@ bool HitachiClimate::get_swing_v_() {
 }
 
 void HitachiClimate::set_swing_h_(uint8_t position) {
-  if (position > HITACHI_AC344_SWINGH_LEFT_MAX)
-    return set_swing_h_(HITACHI_AC344_SWINGH_MIDDLE);
+  if (position > HITACHI_AC344_SWINGH_LEFT_MAX) {
+    set_swing_h_(HITACHI_AC344_SWINGH_MIDDLE);
+    return;
+  }
   set_bits(&remote_state_[HITACHI_AC344_SWINGH_BYTE], HITACHI_AC344_SWINGH_OFFSET, HITACHI_AC344_SWINGH_SIZE, position);
   set_button_(HITACHI_AC344_BUTTON_SWINGH);
 }

--- a/esphome/components/hitachi_ac424/hitachi_ac424.cpp
+++ b/esphome/components/hitachi_ac424/hitachi_ac424.cpp
@@ -133,8 +133,10 @@ bool HitachiClimate::get_swing_v_() {
 }
 
 void HitachiClimate::set_swing_h_(uint8_t position) {
-  if (position > HITACHI_AC424_SWINGH_LEFT_MAX)
-    return set_swing_h_(HITACHI_AC424_SWINGH_MIDDLE);
+  if (position > HITACHI_AC424_SWINGH_LEFT_MAX) {
+    set_swing_h_(HITACHI_AC424_SWINGH_MIDDLE);
+    return;
+  }
   set_bits(&remote_state_[HITACHI_AC424_SWINGH_BYTE], HITACHI_AC424_SWINGH_OFFSET, HITACHI_AC424_SWINGH_SIZE, position);
   set_button_(HITACHI_AC424_BUTTON_SWINGH);
 }

--- a/esphome/components/ili9xxx/ili9xxx_display.cpp
+++ b/esphome/components/ili9xxx/ili9xxx_display.cpp
@@ -313,8 +313,9 @@ void ILI9XXXDisplay::draw_pixels_at(int x_start, int y_start, int w, int h, cons
   // do color conversion pixel-by-pixel into the buffer and draw it later. If this is happening the user has not
   // configured the renderer well.
   if (this->rotation_ != display::DISPLAY_ROTATION_0_DEGREES || bitness != display::COLOR_BITNESS_565 || !big_endian) {
-    return display::Display::draw_pixels_at(x_start, y_start, w, h, ptr, order, bitness, big_endian, x_offset, y_offset,
-                                            x_pad);
+    display::Display::draw_pixels_at(x_start, y_start, w, h, ptr, order, bitness, big_endian, x_offset, y_offset,
+                                     x_pad);
+    return;
   }
   this->set_addr_window_(x_start, y_start, x_start + w - 1, y_start + h - 1);
   // x_ and y_offset are offsets into the source buffer, unrelated to our own offsets into the display.

--- a/esphome/components/qspi_dbi/qspi_dbi.cpp
+++ b/esphome/components/qspi_dbi/qspi_dbi.cpp
@@ -146,7 +146,8 @@ void QspiDbi::draw_pixels_at(int x_start, int y_start, int w, int h, const uint8
     return;
   if (bitness != display::COLOR_BITNESS_565 || order != this->color_mode_ ||
       big_endian != (this->bit_order_ == spi::BIT_ORDER_MSB_FIRST)) {
-    return Display::draw_pixels_at(x_start, y_start, w, h, ptr, order, bitness, big_endian, x_offset, y_offset, x_pad);
+    Display::draw_pixels_at(x_start, y_start, w, h, ptr, order, bitness, big_endian, x_offset, y_offset, x_pad);
+    return;
   } else if (this->draw_from_origin_) {
     auto stride = x_offset + w + x_pad;
     for (int y = 0; y != h; y++) {

--- a/esphome/components/st7735/st7735.cpp
+++ b/esphome/components/st7735/st7735.cpp
@@ -484,7 +484,6 @@ void ST7735::spi_master_write_color_(uint16_t color, uint16_t size) {
 
   this->dc_pin_->digital_write(true);
   write_array(byte, size * 2);
-  return;
 }
 
 }  // namespace st7735

--- a/esphome/components/st7735/st7735.cpp
+++ b/esphome/components/st7735/st7735.cpp
@@ -483,7 +483,8 @@ void ST7735::spi_master_write_color_(uint16_t color, uint16_t size) {
   }
 
   this->dc_pin_->digital_write(true);
-  return write_array(byte, size * 2);
+  write_array(byte, size * 2);
+  return;
 }
 
 }  // namespace st7735

--- a/esphome/components/st7789v/st7789v.cpp
+++ b/esphome/components/st7789v/st7789v.cpp
@@ -252,7 +252,8 @@ void ST7789V::write_color_(uint16_t color, uint16_t size) {
   }
 
   this->dc_pin_->digital_write(true);
-  return write_array(byte, size * 2);
+  write_array(byte, size * 2);
+  return;
 }
 
 size_t ST7789V::get_buffer_length_() {

--- a/esphome/components/st7789v/st7789v.cpp
+++ b/esphome/components/st7789v/st7789v.cpp
@@ -253,7 +253,6 @@ void ST7789V::write_color_(uint16_t color, uint16_t size) {
 
   this->dc_pin_->digital_write(true);
   write_array(byte, size * 2);
-  return;
 }
 
 size_t ST7789V::get_buffer_length_() {

--- a/esphome/core/component.cpp
+++ b/esphome/core/component.cpp
@@ -67,7 +67,8 @@ bool Component::cancel_retry(const std::string &name) {  // NOLINT
 }
 
 void Component::set_timeout(const std::string &name, uint32_t timeout, std::function<void()> &&f) {  // NOLINT
-  return App.scheduler.set_timeout(this, name, timeout, std::move(f));
+  App.scheduler.set_timeout(this, name, timeout, std::move(f));
+  return;
 }
 
 bool Component::cancel_timeout(const std::string &name) {  // NOLINT

--- a/esphome/core/component.cpp
+++ b/esphome/core/component.cpp
@@ -68,7 +68,6 @@ bool Component::cancel_retry(const std::string &name) {  // NOLINT
 
 void Component::set_timeout(const std::string &name, uint32_t timeout, std::function<void()> &&f) {  // NOLINT
   App.scheduler.set_timeout(this, name, timeout, std::move(f));
-  return;
 }
 
 bool Component::cancel_timeout(const std::string &name) {  // NOLINT


### PR DESCRIPTION
# What does this implement/fix?

`clang-tidy` issues found as part of #7822 -- void functions/methods may not return any value.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
