### PR TITLE
[online_image]Don't access decoder if not initialized

### DIFF
--- a/esphome/components/online_image/png_image.cpp
+++ b/esphome/components/online_image/png_image.cpp
@@ -49,6 +49,10 @@ void PngDecoder::prepare(uint32_t download_size) {
 }
 
 int HOT PngDecoder::decode(uint8_t *buffer, size_t size) {
+  if (!this->pngle_) {
+    ESP_LOGE(TAG, "PNG decoder engine not initialized!");
+    return -1;
+  }
   if (size < 256 && size < this->download_size_ - this->decoded_bytes_) {
     ESP_LOGD(TAG, "Waiting for data");
     return 0;


### PR DESCRIPTION
# What does this implement/fix?

In some rare cases there seems ot be a crash in the online_image component. Some reports point to a possible issue in low memory situations/devices.

Added a check that the PNG decoder engine is actually initialized before accessing it.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
