### PR TITLE
[deep_sleep] fix deep_sleep not keeping awake when sleep_duration is defined

### DIFF
--- a/esphome/components/deep_sleep/deep_sleep_esp32.cpp
+++ b/esphome/components/deep_sleep/deep_sleep_esp32.cpp
@@ -56,7 +56,7 @@ bool DeepSleepComponent::prepare_to_sleep_() {
     // Defer deep sleep until inactive
     if (!this->next_enter_deep_sleep_) {
       this->status_set_warning();
-      ESP_LOGW(TAG, "Waiting for pin_ to switch state to enter deep sleep...");
+      ESP_LOGW(TAG, "Waiting wakeup pin state change to enter deep sleep...");
     }
     this->next_enter_deep_sleep_ = true;
     return false;

--- a/esphome/components/deep_sleep/deep_sleep_esp32.cpp
+++ b/esphome/components/deep_sleep/deep_sleep_esp32.cpp
@@ -51,8 +51,8 @@ void DeepSleepComponent::dump_config_platform_() {
 }
 
 bool DeepSleepComponent::prepare_to_sleep_() {
-  if (this->wakeup_pin_mode_ == WAKEUP_PIN_MODE_KEEP_AWAKE &&
-      this->wakeup_pin_ != nullptr && this->wakeup_pin_->digital_read()) {
+  if (this->wakeup_pin_mode_ == WAKEUP_PIN_MODE_KEEP_AWAKE && this->wakeup_pin_ != nullptr &&
+      this->wakeup_pin_->digital_read()) {
     // Defer deep sleep until inactive
     if (!this->next_enter_deep_sleep_) {
       this->status_set_warning();

--- a/esphome/components/deep_sleep/deep_sleep_esp32.cpp
+++ b/esphome/components/deep_sleep/deep_sleep_esp32.cpp
@@ -51,8 +51,8 @@ void DeepSleepComponent::dump_config_platform_() {
 }
 
 bool DeepSleepComponent::prepare_to_sleep_() {
-  if (this->wakeup_pin_mode_ == WAKEUP_PIN_MODE_KEEP_AWAKE && this->wakeup_pin_ != nullptr &&
-      !this->sleep_duration_.has_value() && this->wakeup_pin_->digital_read()) {
+  if (this->wakeup_pin_mode_ == WAKEUP_PIN_MODE_KEEP_AWAKE &&
+      this->wakeup_pin_ != nullptr && this->wakeup_pin_->digital_read()) {
     // Defer deep sleep until inactive
     if (!this->next_enter_deep_sleep_) {
       this->status_set_warning();


### PR DESCRIPTION
# What does this implement/fix?

When `sleep_duration` is defined together with `wakeup_pin_mode: KEEP_AWAKE`, deep sleep component will ignore the state of the `wakeup_pin` and go to sleep, and then it immediately wakes up. This removes the check for `sleep_duration` and allows the component to wait for the pin to be OFF, before going to sleep.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
deep_sleep:
  run_duration: 30sec
  sleep_duration: 10min
  wakeup_pin:
    number: GPIO13
    inverted: True
  wakeup_pin_mode: KEEP_AWAKE
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

