### PR TITLE
Optimize QMC5883L reads

### DIFF
--- a/esphome/components/qmc5883l/qmc5883l.cpp
+++ b/esphome/components/qmc5883l/qmc5883l.cpp
@@ -82,14 +82,31 @@ void QMC5883LComponent::dump_config() {
 float QMC5883LComponent::get_setup_priority() const { return setup_priority::DATA; }
 void QMC5883LComponent::update() {
   uint8_t status = false;
-  this->read_byte(QMC5883L_REGISTER_STATUS, &status);
+  // Status byte gets cleared when data is read, so we have to read this first.
+  // If status and two axes are desired, it's possible to save one byte of traffic by enabling
+  // ROL_PNT in setup and reading 7 bytes starting at the status register.
+  // If status and all three axes are desired, using ROL_PNT saves you 3 bytes.
+  // But simply not reading status saves you 4 bytes always and is much simpler.
+  if (ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_DEBUG) {
+    this->read_byte(QMC5883L_REGISTER_STATUS, &status);
+  }
 
-  // Always request X,Y,Z regardless if there are sensors for them
-  // to avoid https://github.com/esphome/issues/issues/5731
-  uint16_t raw_x, raw_y, raw_z;
-  if (!this->read_byte_16_(QMC5883L_REGISTER_DATA_X_LSB, &raw_x) ||
-      !this->read_byte_16_(QMC5883L_REGISTER_DATA_Y_LSB, &raw_y) ||
-      !this->read_byte_16_(QMC5883L_REGISTER_DATA_Z_LSB, &raw_z)) {
+  uint16_t raw[3] = {0};
+  // Z must always be requested, otherwise the data registers will remain locked against updates.
+  // Skipping the Y axis if X and Z are needed actually requires an additional byte of comms.
+  // Starting partway through the axes does save you traffic.
+  uint8_t start, dest;
+  if (this->heading_sensor_ != nullptr || this->x_sensor_ != nullptr) {
+    start = QMC5883L_REGISTER_DATA_X_LSB;
+    dest = 0;
+  } else if (this->y_sensor_ != nullptr) {
+    start = QMC5883L_REGISTER_DATA_Y_LSB;
+    dest = 1;
+  } else {
+    start = QMC5883L_REGISTER_DATA_Z_LSB;
+    dest = 2;
+  }
+  if (!this->read_bytes_16_le_(start, &raw[dest], 3 - dest)) {
     this->status_set_warning();
     return;
   }
@@ -107,16 +124,16 @@ void QMC5883LComponent::update() {
   }
 
   // in µT
-  const float x = int16_t(raw_x) * mg_per_bit * 0.1f;
-  const float y = int16_t(raw_y) * mg_per_bit * 0.1f;
-  const float z = int16_t(raw_z) * mg_per_bit * 0.1f;
+  const float x = int16_t(raw[0]) * mg_per_bit * 0.1f;
+  const float y = int16_t(raw[1]) * mg_per_bit * 0.1f;
+  const float z = int16_t(raw[2]) * mg_per_bit * 0.1f;
 
   float heading = atan2f(0.0f - x, y) * 180.0f / M_PI;
 
   float temp = NAN;
   if (this->temperature_sensor_ != nullptr) {
     uint16_t raw_temp;
-    if (!this->read_byte_16_(QMC5883L_REGISTER_TEMPERATURE_LSB, &raw_temp)) {
+    if (!this->read_bytes_16_le_(QMC5883L_REGISTER_TEMPERATURE_LSB, &raw_temp)) {
       this->status_set_warning();
       return;
     }
@@ -138,10 +155,13 @@ void QMC5883LComponent::update() {
     this->temperature_sensor_->publish_state(temp);
 }
 
-bool QMC5883LComponent::read_byte_16_(uint8_t a_register, uint16_t *data) {
-  if (!this->read_byte_16(a_register, data))
+bool QMC5883LComponent::read_bytes_16_le_(uint8_t a_register, uint16_t *data, uint8_t len) {
+  if (!this->read_bytes_16(a_register, data, len))
     return false;
-  *data = (*data & 0x00FF) << 8 | (*data & 0xFF00) >> 8;  // Flip Byte order, LSB first;
+  // read_bytes_16 assumes big-endian
+  for (; len; len--, data++) {
+    *data = byteswap(*data);
+  }
   return true;
 }
 

--- a/esphome/components/qmc5883l/qmc5883l.cpp
+++ b/esphome/components/qmc5883l/qmc5883l.cpp
@@ -81,6 +81,7 @@ void QMC5883LComponent::dump_config() {
 }
 float QMC5883LComponent::get_setup_priority() const { return setup_priority::DATA; }
 void QMC5883LComponent::update() {
+  i2c::ErrorCode err;
   uint8_t status = false;
   // Status byte gets cleared when data is read, so we have to read this first.
   // If status and two axes are desired, it's possible to save one byte of traffic by enabling
@@ -88,7 +89,11 @@ void QMC5883LComponent::update() {
   // If status and all three axes are desired, using ROL_PNT saves you 3 bytes.
   // But simply not reading status saves you 4 bytes always and is much simpler.
   if (ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_DEBUG) {
-    this->read_byte(QMC5883L_REGISTER_STATUS, &status);
+    err = this->read_register(QMC5883L_REGISTER_STATUS, &status, 1);
+    if (err != i2c::ERROR_OK) {
+      this->status_set_warning(str_sprintf("status read failed (%d)", err).c_str());
+      return;
+    }
   }
 
   uint16_t raw[3] = {0};
@@ -106,8 +111,9 @@ void QMC5883LComponent::update() {
     start = QMC5883L_REGISTER_DATA_Z_LSB;
     dest = 2;
   }
-  if (!this->read_bytes_16_le_(start, &raw[dest], 3 - dest)) {
-    this->status_set_warning();
+  err = this->read_bytes_16_le_(start, &raw[dest], 3 - dest);
+  if (err != i2c::ERROR_OK) {
+    this->status_set_warning(str_sprintf("mag read failed (%d)", err).c_str());
     return;
   }
 
@@ -133,8 +139,9 @@ void QMC5883LComponent::update() {
   float temp = NAN;
   if (this->temperature_sensor_ != nullptr) {
     uint16_t raw_temp;
-    if (!this->read_bytes_16_le_(QMC5883L_REGISTER_TEMPERATURE_LSB, &raw_temp)) {
-      this->status_set_warning();
+    err = this->read_bytes_16_le_(QMC5883L_REGISTER_TEMPERATURE_LSB, &raw_temp);
+    if (err != i2c::ERROR_OK) {
+      this->status_set_warning(str_sprintf("temp read failed (%d)", err).c_str());
       return;
     }
     temp = int16_t(raw_temp) * 0.01f;
@@ -155,14 +162,13 @@ void QMC5883LComponent::update() {
     this->temperature_sensor_->publish_state(temp);
 }
 
-bool QMC5883LComponent::read_bytes_16_le_(uint8_t a_register, uint16_t *data, uint8_t len) {
-  if (!this->read_bytes_16(a_register, data, len))
-    return false;
-  // read_bytes_16 assumes big-endian
-  for (; len; len--, data++) {
-    *data = byteswap(*data);
-  }
-  return true;
+i2c::ErrorCode QMC5883LComponent::read_bytes_16_le_(uint8_t a_register, uint16_t *data, uint8_t len) {
+  i2c::ErrorCode err = this->read_register(a_register, reinterpret_cast<uint8_t *>(data), len * 2);
+  if (err != i2c::ERROR_OK)
+    return err;
+  for (size_t i = 0; i < len; i++)
+    data[i] = convert_little_endian(data[i]);
+  return err;
 }
 
 }  // namespace qmc5883l

--- a/esphome/components/qmc5883l/qmc5883l.h
+++ b/esphome/components/qmc5883l/qmc5883l.h
@@ -55,7 +55,7 @@ class QMC5883LComponent : public PollingComponent, public i2c::I2CDevice {
     NONE = 0,
     COMMUNICATION_FAILED,
   } error_code_;
-  bool read_bytes_16_le_(uint8_t a_register, uint16_t *data, uint8_t len = 1);
+  i2c::ErrorCode read_bytes_16_le_(uint8_t a_register, uint16_t *data, uint8_t len = 1);
   HighFrequencyLoopRequester high_freq_;
 };
 

--- a/esphome/components/qmc5883l/qmc5883l.h
+++ b/esphome/components/qmc5883l/qmc5883l.h
@@ -55,7 +55,7 @@ class QMC5883LComponent : public PollingComponent, public i2c::I2CDevice {
     NONE = 0,
     COMMUNICATION_FAILED,
   } error_code_;
-  bool read_byte_16_(uint8_t a_register, uint16_t *data);
+  bool read_bytes_16_le_(uint8_t a_register, uint16_t *data, uint8_t len = 1);
   HighFrequencyLoopRequester high_freq_;
 };
 


### PR DESCRIPTION
Avoids esphome/issues#5731 by always reading the Z axis

Skipping unneeded axes is nice, but the major savings are from combining the axis reads into a single operation.  Each read has 3 bytes of overhead (write address, register, read address) as well as a ~1ms delay depending on the bus speed, so with all three axes you reduce the transfers from 15 bytes to 9 bytes and a lot less idle time.  If you don't need X, that's 7 bytes.  If you don't need X or Y, that's 5 bytes.

Also includes the status byte skip from #6458, along with additional notes about how status read could be optimized if desired.

Here's some performance data calculated and spot-checked with an ESP32:

| Scenario         | Reads | Bytes | Tot.B | Cycles | ms @ 20k | ms @ 50k | ms @ 85k | ms @ 100k | ms @ 200k | ms @ 400k |
| ---------------- | ----- | ------| ----- | ------ | -------- | -------- | -------- | --------- | --------- | --------- |
| old code         |   4   |   7   |   19  |   187  |   13.11  |   7.50   |   2.20   |   1.87    |   0.94    |   0.47    |
| old code + temp  |   5   |   9   |   24  |   236  |   16.50  |   9.42   |   2.78   |   2.36    |   1.18    |   0.59    |
| XYZ + log        |   2   |   7   |   13  |   125  |    8.13  |   4.38   |   1.47   |   1.25    |   0.63    |   0.31    |
| XYZ              |   1   |   6   |    9  |    85  |    5.19  |   2.64   |   1.00   |   0.85    |   0.43    |   0.21    |
| XYZ + temp + log |   3   |   9   |   18  |   174  |   11.52  |   6.30   |   2.05   |   1.74    |   0.87    |   0.44    |
| XYZ + temp       |   2   |   8   |   14  |   134  |    8.58  |   4.56   |   1.58   |   1.34    |   0.67    |   0.34    |
| YZ + log         |   2   |   5   |   11  |   107  |    7.23  |   4.02   |   1.26   |   1.07    |   0.54    |   0.27    |
| YZ               |   1   |   4   |    7  |    67  |    4.29  |   2.28   |   0.79   |   0.67    |   0.34    |   0.17    |
| YZ + temp + log  |   3   |   7   |   16  |   156  |   10.62  |   5.94   |   1.84   |   1.56    |   0.78    |   0.39    |
| YZ + temp        |   2   |   6   |   12  |   116  |    7.68  |   4.20   |   1.36   |   1.16    |   0.58    |   0.29    |
| Z + log          |   2   |   3   |    9  |    89  |    6.33  |   3.66   |   1.05   |   0.89    |   0.45    |   0.22    |
| Z                |   1   |   2   |    5  |    49  |    3.39  |   1.92   |   0.58   |   0.49    |   0.25    |   0.12    |
| Z + temp + log   |   3   |   5   |   14  |   138  |    9.72  |   5.58   |   1.62   |   1.38    |   0.69    |   0.35    |
| Z + temp         |   2   |   4   |   10  |    98  |    6.78  |   3.84   |   1.15   |   0.98    |   0.49    |   0.25    |

In testing, it was found that at bus speeds of 85KHz and above, the ~1ms penalty per transaction disappears.

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
logger:
  level: WARN

i2c:
  - id: i2c_bus
    scl: GPIO16
    sda: GPIO13
    frequency: 50khz
    scan: False

sensor:
  - platform: qmc5883l
    i2c_id: i2c_bus
    address: 0x0D
    update_interval: 1s
    oversampling: 64x
    field_strength_z: 
      name: Z-Axis
    temperature:
      name: Temperature
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
