### PR TITLE
update components/at581x/at581x.h

### DIFF
--- a/esphome/components/at581x/at581x.h
+++ b/esphome/components/at581x/at581x.h
@@ -25,6 +25,7 @@ class AT581XComponent : public Component, public i2c::I2CDevice {
   }
 #endif
 
+ public:
   void setup() override;
   void dump_config() override;
   //  float get_setup_priority() const override;

--- a/esphome/components/at581x/at581x.h
+++ b/esphome/components/at581x/at581x.h
@@ -15,14 +15,14 @@ namespace at581x {
 
 class AT581XComponent : public Component, public i2c::I2CDevice {
 #ifdef USE_SWITCH
- protected:
-  switch_::Switch *rf_power_switch_{nullptr};
-
  public:
   void set_rf_power_switch(switch_::Switch *s) {
     this->rf_power_switch_ = s;
     s->turn_on();
   }
+
+ protected:
+  switch_::Switch *rf_power_switch_{nullptr};
 #endif
 
  public:


### PR DESCRIPTION
a compiler block removes the `public` access specifier for most of the declared members; this leads to what I believe an unintentional side effect of not being able to access these members (being able to set them in a configuration) unless there is at least a `switch:` in the same configuration

this commit adds the public access identifier for these methods regardless if the conditional compiler block passes

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
esp32:
  board: esp32s3box
  flash_size: 16MB
  framework:
    type: esp-idf
    sdkconfig_options:
      CONFIG_ESP32S3_DEFAULT_CPU_FREQ_240: "y"
      CONFIG_ESP32S3_DATA_CACHE_64KB: "y"
      CONFIG_ESP32S3_DATA_CACHE_LINE_64B: "y"
      CONFIG_AUDIO_BOARD_CUSTOM: "y"
      CONFIG_ESP32_S3_BOX_3_BOARD: "y"
    components:
      - name: esp32_s3_box_3_board
        source: github://jesserockz/esp32-s3-box-3-board@main
        refresh: 0s
psram:
  mode: octal
  speed: 80MHz
external_components:
  - source: github://pr#7890
    components: [ at581x ]
    refresh: 0s
### Radar Sensor
spi:
  clk_pin: 7
  mosi_pin: 6
at581x:
  id: "Radar"
  i2c_id: bus_b
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
