### PR TITLE
[font et. al.] Remove explicit check for pillow installed.

### DIFF
--- a/esphome/components/animation/__init__.py
+++ b/esphome/components/animation/__init__.py
@@ -2,7 +2,6 @@ import logging
 
 from esphome import automation, core
 import esphome.codegen as cg
-from esphome.components import font
 import esphome.components.image as espImage
 from esphome.components.image import (
     CONF_USE_TRANSPARENCY,
@@ -131,7 +130,7 @@ ANIMATION_SCHEMA = cv.Schema(
     )
 )
 
-CONFIG_SCHEMA = cv.All(font.validate_pillow_installed, ANIMATION_SCHEMA)
+CONFIG_SCHEMA = ANIMATION_SCHEMA
 
 NEXT_FRAME_SCHEMA = automation.maybe_simple_id(
     {

--- a/esphome/components/font/__init__.py
+++ b/esphome/components/font/__init__.py
@@ -1,4 +1,3 @@
-from collections.abc import Iterable
 import functools
 import hashlib
 import logging
@@ -8,7 +7,6 @@ import re
 
 import freetype
 import glyphsets
-from packaging import version
 import requests
 
 from esphome import core, external_files
@@ -88,7 +86,7 @@ def flatten(lists) -> list:
     return list(chain.from_iterable(lists))
 
 
-def check_missing_glyphs(file, codepoints: Iterable, warning: bool = False):
+def check_missing_glyphs(file, codepoints, warning: bool = False):
     """
     Check that the given font file actually contains the requested glyphs
     :param file: A Truetype font file
@@ -175,24 +173,6 @@ def validate_glyphs(config):
             ]
 
     return config
-
-
-def validate_pillow_installed(value):
-    try:
-        import PIL
-    except ImportError as err:
-        raise cv.Invalid(
-            "Please install the pillow python package to use this feature. "
-            '(pip install "pillow==10.4.0")'
-        ) from err
-
-    if version.parse(PIL.__version__) != version.parse("10.4.0"):
-        raise cv.Invalid(
-            "Please update your pillow installation to 10.4.0. "
-            '(pip install "pillow==10.4.0")'
-        )
-
-    return value
 
 
 FONT_EXTENSIONS = (".ttf", ".woff", ".otf")
@@ -421,7 +401,7 @@ FONT_SCHEMA = cv.Schema(
     },
 )
 
-CONFIG_SCHEMA = cv.All(validate_pillow_installed, FONT_SCHEMA, validate_glyphs)
+CONFIG_SCHEMA = cv.All(FONT_SCHEMA, validate_glyphs)
 
 
 # PIL doesn't provide a consistent interface for both TrueType and bitmap

--- a/esphome/components/ili9xxx/display.py
+++ b/esphome/components/ili9xxx/display.py
@@ -1,6 +1,6 @@
 from esphome import core, pins
 import esphome.codegen as cg
-from esphome.components import display, font, spi
+from esphome.components import display, spi
 from esphome.components.display import validate_rotation
 import esphome.config_validation as cv
 from esphome.const import (
@@ -147,7 +147,6 @@ def _validate(config):
 
 
 CONFIG_SCHEMA = cv.All(
-    font.validate_pillow_installed,
     display.FULL_DISPLAY_SCHEMA.extend(
         {
             cv.GenerateID(): cv.declare_id(ILI9XXXDisplay),

--- a/esphome/components/image/__init__.py
+++ b/esphome/components/image/__init__.py
@@ -10,7 +10,6 @@ import puremagic
 
 from esphome import core, external_files
 import esphome.codegen as cg
-from esphome.components import font
 import esphome.config_validation as cv
 from esphome.const import (
     CONF_DITHER,
@@ -233,7 +232,7 @@ IMAGE_SCHEMA = cv.Schema(
     )
 )
 
-CONFIG_SCHEMA = cv.All(font.validate_pillow_installed, IMAGE_SCHEMA)
+CONFIG_SCHEMA = IMAGE_SCHEMA
 
 
 def load_svg_image(file: bytes, resize: tuple[int, int]):


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Since `pillow` is now automatically installed via `requirements.txt`, no need to explicitly check. Removes some component cross-dependencies.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
