### PR TITLE
Fix recalc_timestamp_utc

### DIFF
--- a/esphome/core/time.cpp
+++ b/esphome/core/time.cpp
@@ -169,7 +169,7 @@ void ESPTime::recalc_timestamp_utc(bool use_day_of_year) {
   }
 
   for (int i = 1970; i < this->year; i++)
-    res += (year % 4 == 0) ? 366 : 365;
+    res += (i % 4 == 0) ? 366 : 365;
 
   if (use_day_of_year) {
     res += this->day_of_year - 1;


### PR DESCRIPTION
# What does this implement/fix?

PR #7807 introduced a regression in `ESPTime::recalc_timestamp_utc` causing the timestamp to be off by roughly 40 days due to leap days being counted every day if the current year is a leap year.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- #7807 introduced the bug

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx


## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder). (not needed)

