### PR TITLE
[modbus_controller] Clang fixes

### DIFF
--- a/esphome/components/modbus_controller/modbus_controller.h
+++ b/esphome/components/modbus_controller/modbus_controller.h
@@ -240,14 +240,14 @@ class SensorItem {
   }
   // Override register size for modbus devices not using 1 register for one dword
   void set_register_size(uint8_t register_size) { response_bytes = register_size; }
-  ModbusRegisterType register_type;
-  SensorValueType sensor_value_type;
-  uint16_t start_address;
-  uint32_t bitmask;
-  uint8_t offset;
-  uint8_t register_count;
+  ModbusRegisterType register_type{ModbusRegisterType::CUSTOM};
+  SensorValueType sensor_value_type{SensorValueType::RAW};
+  uint16_t start_address{0};
+  uint32_t bitmask{0};
+  uint8_t offset{0};
+  uint8_t register_count{0};
   uint8_t response_bytes{0};
-  uint16_t skip_updates;
+  uint16_t skip_updates{0};
   std::vector<uint8_t> custom_data{};
   bool force_new_range{false};
 };
@@ -261,9 +261,9 @@ class ServerRegister {
     this->register_count = register_count;
     this->read_lambda = std::move(read_lambda);
   }
-  uint16_t address;
-  SensorValueType value_type;
-  uint8_t register_count;
+  uint16_t address{0};
+  SensorValueType value_type{SensorValueType::RAW};
+  uint8_t register_count{0};
   std::function<float()> read_lambda;
 };
 
@@ -493,23 +493,23 @@ class ModbusController : public PollingComponent, public modbus::ModbusDevice {
   /// Collection of all sensors for this component
   SensorSet sensorset_;
   /// Collection of all server registers for this component
-  std::vector<ServerRegister *> server_registers_;
+  std::vector<ServerRegister *> server_registers_{};
   /// Continuous range of modbus registers
-  std::vector<RegisterRange> register_ranges_;
+  std::vector<RegisterRange> register_ranges_{};
   /// Hold the pending requests to be sent
   std::list<std::unique_ptr<ModbusCommandItem>> command_queue_;
   /// modbus response data waiting to get processed
   std::queue<std::unique_ptr<ModbusCommandItem>> incoming_queue_;
   /// if duplicate commands can be sent
-  bool allow_duplicate_commands_;
+  bool allow_duplicate_commands_{false};
   /// when was the last send operation
-  uint32_t last_command_timestamp_;
+  uint32_t last_command_timestamp_{0};
   /// min time in ms between sending modbus commands
-  uint16_t command_throttle_;
+  uint16_t command_throttle_{0};
   /// if module didn't respond the last command
-  bool module_offline_;
+  bool module_offline_{false};
   /// how many updates to skip if module is offline
-  uint16_t offline_skip_updates_;
+  uint16_t offline_skip_updates_{0};
   /// How many times we will retry a command if we get no response
   uint8_t max_cmd_retries_{4};
   /// Command sent callback

--- a/esphome/components/modbus_controller/modbus_controller.h
+++ b/esphome/components/modbus_controller/modbus_controller.h
@@ -312,11 +312,11 @@ struct RegisterRange {
 class ModbusCommandItem {
  public:
   static const size_t MAX_PAYLOAD_BYTES = 240;
-  ModbusController *modbusdevice;
-  uint16_t register_address;
-  uint16_t register_count;
-  ModbusFunctionCode function_code;
-  ModbusRegisterType register_type;
+  ModbusController *modbusdevice{nullptr};
+  uint16_t register_address{0};
+  uint16_t register_count{0};
+  ModbusFunctionCode function_code{ModbusFunctionCode::CUSTOM};
+  ModbusRegisterType register_type{ModbusRegisterType::CUSTOM};
   std::function<void(ModbusRegisterType register_type, uint16_t start_address, const std::vector<uint8_t> &data)>
       on_data_func;
   std::vector<uint8_t> payload = {};

--- a/esphome/components/modbus_controller/number/modbus_number.h
+++ b/esphome/components/modbus_controller/number/modbus_number.h
@@ -29,7 +29,7 @@ class ModbusNumber : public number::Number, public Component, public SensorItem 
   void parse_and_publish(const std::vector<uint8_t> &data) override;
   float get_setup_priority() const override { return setup_priority::HARDWARE; }
   void set_parent(ModbusController *parent) { this->parent_ = parent; }
-  void set_write_multiply(float factor) { multiply_by_ = factor; }
+  void set_write_multiply(float factor) { this->multiply_by_ = factor; }
 
   using transform_func_t = std::function<optional<float>(ModbusNumber *, float, const std::vector<uint8_t> &)>;
   using write_transform_func_t = std::function<optional<float>(ModbusNumber *, float, std::vector<uint16_t> &)>;
@@ -39,9 +39,9 @@ class ModbusNumber : public number::Number, public Component, public SensorItem 
 
  protected:
   void control(float value) override;
-  optional<transform_func_t> transform_func_;
-  optional<write_transform_func_t> write_transform_func_;
-  ModbusController *parent_;
+  optional<transform_func_t> transform_func_{nullopt};
+  optional<write_transform_func_t> write_transform_func_{nullopt};
+  ModbusController *parent_{nullptr};
   float multiply_by_{1.0};
   bool use_write_multiple_{false};
 };

--- a/esphome/components/modbus_controller/output/modbus_output.cpp
+++ b/esphome/components/modbus_controller/output/modbus_output.cpp
@@ -27,7 +27,7 @@ void ModbusFloatOutput::write_state(float value) {
       return;
     }
   } else {
-    value = multiply_by_ * value;
+    value = this->multiply_by_ * value;
   }
   // lambda didn't set payload
   if (data.empty()) {
@@ -40,12 +40,13 @@ void ModbusFloatOutput::write_state(float value) {
   // Create and send the write command
   ModbusCommandItem write_cmd;
   if (this->register_count == 1 && !this->use_write_multiple_) {
-    write_cmd = ModbusCommandItem::create_write_single_command(parent_, this->start_address + this->offset, data[0]);
+    write_cmd =
+        ModbusCommandItem::create_write_single_command(this->parent_, this->start_address + this->offset, data[0]);
   } else {
-    write_cmd = ModbusCommandItem::create_write_multiple_command(parent_, this->start_address + this->offset,
+    write_cmd = ModbusCommandItem::create_write_multiple_command(this->parent_, this->start_address + this->offset,
                                                                  this->register_count, data);
   }
-  parent_->queue_command(write_cmd);
+  this->parent_->queue_command(write_cmd);
 }
 
 void ModbusFloatOutput::dump_config() {
@@ -90,9 +91,9 @@ void ModbusBinaryOutput::write_state(bool state) {
     // offset for coil and discrete inputs is the coil/register number not bytes
     if (this->use_write_multiple_) {
       std::vector<bool> states{state};
-      cmd = ModbusCommandItem::create_write_multiple_coils(parent_, this->start_address + this->offset, states);
+      cmd = ModbusCommandItem::create_write_multiple_coils(this->parent_, this->start_address + this->offset, states);
     } else {
-      cmd = ModbusCommandItem::create_write_single_coil(parent_, this->start_address + this->offset, state);
+      cmd = ModbusCommandItem::create_write_single_coil(this->parent_, this->start_address + this->offset, state);
     }
   }
   this->parent_->queue_command(cmd);

--- a/esphome/components/modbus_controller/output/modbus_output.h
+++ b/esphome/components/modbus_controller/output/modbus_output.h
@@ -25,7 +25,7 @@ class ModbusFloatOutput : public output::FloatOutput, public Component, public S
   void dump_config() override;
 
   void set_parent(ModbusController *parent) { this->parent_ = parent; }
-  void set_write_multiply(float factor) { multiply_by_ = factor; }
+  void set_write_multiply(float factor) { this->multiply_by_ = factor; }
   // Do nothing
   void parse_and_publish(const std::vector<uint8_t> &data) override{};
 
@@ -37,9 +37,9 @@ class ModbusFloatOutput : public output::FloatOutput, public Component, public S
   void write_state(float value) override;
   optional<write_transform_func_t> write_transform_func_{nullopt};
 
-  ModbusController *parent_;
+  ModbusController *parent_{nullptr};
   float multiply_by_{1.0};
-  bool use_write_multiple_;
+  bool use_write_multiple_{false};
 };
 
 class ModbusBinaryOutput : public output::BinaryOutput, public Component, public SensorItem {
@@ -68,8 +68,8 @@ class ModbusBinaryOutput : public output::BinaryOutput, public Component, public
   void write_state(bool state) override;
   optional<write_transform_func_t> write_transform_func_{nullopt};
 
-  ModbusController *parent_;
-  bool use_write_multiple_;
+  ModbusController *parent_{nullptr};
+  bool use_write_multiple_{false};
 };
 
 }  // namespace modbus_controller

--- a/esphome/components/modbus_controller/select/modbus_select.cpp
+++ b/esphome/components/modbus_controller/select/modbus_select.cpp
@@ -74,12 +74,13 @@ void ModbusSelect::control(const std::string &value) {
   const uint16_t write_address = this->start_address + this->offset / 2;
   ModbusCommandItem write_cmd;
   if ((this->register_count == 1) && (!this->use_write_multiple_)) {
-    write_cmd = ModbusCommandItem::create_write_single_command(parent_, write_address, data[0]);
+    write_cmd = ModbusCommandItem::create_write_single_command(this->parent_, write_address, data[0]);
   } else {
-    write_cmd = ModbusCommandItem::create_write_multiple_command(parent_, write_address, this->register_count, data);
+    write_cmd =
+        ModbusCommandItem::create_write_multiple_command(this->parent_, write_address, this->register_count, data);
   }
 
-  parent_->queue_command(write_cmd);
+  this->parent_->queue_command(write_cmd);
 
   if (this->optimistic_)
     this->publish_state(value);

--- a/esphome/components/modbus_controller/select/modbus_select.h
+++ b/esphome/components/modbus_controller/select/modbus_select.h
@@ -42,12 +42,12 @@ class ModbusSelect : public Component, public select::Select, public SensorItem 
   void control(const std::string &value) override;
 
  protected:
-  std::vector<int64_t> mapping_;
-  ModbusController *parent_;
+  std::vector<int64_t> mapping_{};
+  ModbusController *parent_{nullptr};
   bool use_write_multiple_{false};
   bool optimistic_{false};
-  optional<transform_func_t> transform_func_;
-  optional<write_transform_func_t> write_transform_func_;
+  optional<transform_func_t> transform_func_{nullopt};
+  optional<write_transform_func_t> write_transform_func_{nullopt};
 };
 
 }  // namespace modbus_controller

--- a/esphome/components/modbus_controller/switch/modbus_switch.cpp
+++ b/esphome/components/modbus_controller/switch/modbus_switch.cpp
@@ -80,18 +80,18 @@ void ModbusSwitch::write_state(bool state) {
       // offset for coil and discrete inputs is the coil/register number not bytes
       if (this->use_write_multiple_) {
         std::vector<bool> states{state};
-        cmd = ModbusCommandItem::create_write_multiple_coils(parent_, this->start_address + this->offset, states);
+        cmd = ModbusCommandItem::create_write_multiple_coils(this->parent_, this->start_address + this->offset, states);
       } else {
-        cmd = ModbusCommandItem::create_write_single_coil(parent_, this->start_address + this->offset, state);
+        cmd = ModbusCommandItem::create_write_single_coil(this->parent_, this->start_address + this->offset, state);
       }
     } else {
       // since offset is in bytes and a register is 16 bits we get the start by adding offset/2
       if (this->use_write_multiple_) {
         std::vector<uint16_t> bool_states(1, state ? (0xFFFF & this->bitmask) : 0);
-        cmd = ModbusCommandItem::create_write_multiple_command(parent_, this->start_address + this->offset / 2, 1,
+        cmd = ModbusCommandItem::create_write_multiple_command(this->parent_, this->start_address + this->offset / 2, 1,
                                                                bool_states);
       } else {
-        cmd = ModbusCommandItem::create_write_single_command(parent_, this->start_address + this->offset / 2,
+        cmd = ModbusCommandItem::create_write_single_command(this->parent_, this->start_address + this->offset / 2,
                                                              state ? 0xFFFF & this->bitmask : 0u);
       }
     }

--- a/esphome/components/modbus_controller/switch/modbus_switch.h
+++ b/esphome/components/modbus_controller/switch/modbus_switch.h
@@ -40,8 +40,8 @@ class ModbusSwitch : public Component, public switch_::Switch, public SensorItem
   void set_use_write_mutiple(bool use_write_multiple) { this->use_write_multiple_ = use_write_multiple; }
 
  protected:
-  ModbusController *parent_;
-  bool use_write_multiple_;
+  ModbusController *parent_{nullptr};
+  bool use_write_multiple_{false};
   optional<transform_func_t> publish_transform_func_{nullopt};
   optional<write_transform_func_t> write_transform_func_{nullopt};
 };


### PR DESCRIPTION
# What does this implement/fix?

`clang-tidy` issue found as part of #7822 + additional clean-up:

```
/home/runner/work/esphome/esphome/esphome/components/modbus_controller/modbus_controller.h:312:7: error: Value assigned to field 'modbusdevice' in implicit constructor is garbage or undefined [clang-analyzer-core.uninitialized.Assign,-warnings-as-errors]
  312 | class ModbusCommandItem {
      |       ^
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
