### PR TITLE
[hx711] clang-tidy fixes for #7822

### DIFF
--- a/esphome/components/hx711/hx711.cpp
+++ b/esphome/components/hx711/hx711.cpp
@@ -53,7 +53,7 @@ bool HX711Sensor::read_sensor_(uint32_t *result) {
     }
 
     // Cycle clock pin for gain setting
-    for (uint8_t i = 0; i < this->gain_; i++) {
+    for (uint8_t i = 0; i < static_cast<uint8_t>(this->gain_); i++) {
       this->sck_pin_->digital_write(true);
       delayMicroseconds(1);
       this->sck_pin_->digital_write(false);

--- a/esphome/components/hx711/hx711.h
+++ b/esphome/components/hx711/hx711.h
@@ -9,7 +9,7 @@
 namespace esphome {
 namespace hx711 {
 
-enum HX711Gain {
+enum HX711Gain : uint8_t {
   HX711_GAIN_128 = 1,
   HX711_GAIN_32 = 2,
   HX711_GAIN_64 = 3,


### PR DESCRIPTION
# What does this implement/fix?

`clang-tidy` issue found as part of #7822:

```
Error: /home/runner/work/esphome/esphome/esphome/components/hx711/hx711.cpp:56:25: error: loop variable has narrower type 'uint8_t' than iteration's upper bound 'HX711Gain' [bugprone-too-small-loop-variable,-warnings-as-errors]
   56 |     for (uint8_t i = 0; i < this->gain_; i++) {
      |                         ^
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
