### PR TITLE
[CI] Bump GHA runners to ``ubuntu-24.04``

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ concurrency:
 jobs:
   common:
     name: Create common environment
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       cache-key: ${{ steps.cache-key.outputs.key }}
     steps:
@@ -62,7 +62,7 @@ jobs:
 
   black:
     name: Check black
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs:
       - common
     steps:
@@ -83,7 +83,7 @@ jobs:
 
   flake8:
     name: Check flake8
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs:
       - common
     steps:
@@ -104,7 +104,7 @@ jobs:
 
   pylint:
     name: Check pylint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs:
       - common
     steps:
@@ -125,7 +125,7 @@ jobs:
 
   pyupgrade:
     name: Check pyupgrade
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs:
       - common
     steps:
@@ -146,7 +146,7 @@ jobs:
 
   ci-custom:
     name: Run script/ci-custom
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs:
       - common
     steps:
@@ -225,7 +225,7 @@ jobs:
 
   clang-format:
     name: Check clang-format
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs:
       - common
     steps:
@@ -251,7 +251,7 @@ jobs:
 
   clang-tidy:
     name: ${{ matrix.name }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs:
       - common
       - black
@@ -345,7 +345,7 @@ jobs:
         if: always()
 
   list-components:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs:
       - common
     if: github.event_name == 'pull_request'
@@ -387,7 +387,7 @@ jobs:
 
   test-build-components:
     name: Component test ${{ matrix.file }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs:
       - common
       - list-components
@@ -421,7 +421,7 @@ jobs:
 
   test-build-components-splitter:
     name: Split components for testing into 20 groups maximum
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs:
       - common
       - list-components
@@ -439,7 +439,7 @@ jobs:
 
   test-build-components-split:
     name: Test split components
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs:
       - common
       - list-components
@@ -483,7 +483,7 @@ jobs:
 
   ci-status:
     name: CI Status
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs:
       - common
       - black


### PR DESCRIPTION
# What does this implement/fix?

SSIA -- related to #7822

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
