### PR TITLE
[sntp] Resolve warnings from ESP-IDF 5.x

### DIFF
--- a/esphome/components/sntp/sntp_component.cpp
+++ b/esphome/components/sntp/sntp_component.cpp
@@ -9,11 +9,6 @@
 #include "lwip/apps/sntp.h"
 #endif
 
-// Yes, the server names are leaked, but that's fine.
-#ifdef CLANG_TIDY
-#define strdup(x) (const_cast<char *>(x))
-#endif
-
 namespace esphome {
 namespace sntp {
 
@@ -26,30 +21,29 @@ void SNTPComponent::setup() {
     esp_sntp_stop();
   }
   esp_sntp_setoperatingmode(ESP_SNTP_OPMODE_POLL);
+  size_t i = 0;
+  for (auto &server : this->servers_) {
+    esp_sntp_setservername(i++, server.c_str());
+  }
+  esp_sntp_set_sync_interval(this->get_update_interval());
+  esp_sntp_init();
 #else
   sntp_stop();
   sntp_setoperatingmode(SNTP_OPMODE_POLL);
-#endif
 
-  sntp_setservername(0, strdup(this->server_1_.c_str()));
-  if (!this->server_2_.empty()) {
-    sntp_setservername(1, strdup(this->server_2_.c_str()));
+  size_t i = 0;
+  for (auto &server : this->servers_) {
+    sntp_setservername(i++, server.c_str());
   }
-  if (!this->server_3_.empty()) {
-    sntp_setservername(2, strdup(this->server_3_.c_str()));
-  }
-#ifdef USE_ESP_IDF
-  esp_sntp_set_sync_interval(this->get_update_interval());
-#endif
-
   sntp_init();
+#endif
 }
 void SNTPComponent::dump_config() {
   ESP_LOGCONFIG(TAG, "SNTP Time:");
-  ESP_LOGCONFIG(TAG, "  Server 1: '%s'", this->server_1_.c_str());
-  ESP_LOGCONFIG(TAG, "  Server 2: '%s'", this->server_2_.c_str());
-  ESP_LOGCONFIG(TAG, "  Server 3: '%s'", this->server_3_.c_str());
-  ESP_LOGCONFIG(TAG, "  Timezone: '%s'", this->timezone_.c_str());
+  size_t i = 0;
+  for (auto &server : this->servers_) {
+    ESP_LOGCONFIG(TAG, "  Server %zu: '%s'", i++, server.c_str());
+  }
 }
 void SNTPComponent::update() {
 #if !defined(USE_ESP_IDF)

--- a/esphome/components/sntp/sntp_component.h
+++ b/esphome/components/sntp/sntp_component.h
@@ -14,23 +14,20 @@ namespace sntp {
 /// \see https://www.gnu.org/software/libc/manual/html_node/TZ-Variable.html
 class SNTPComponent : public time::RealTimeClock {
  public:
+  SNTPComponent(const std::vector<std::string> &servers) : servers_(std::move(servers)) {}
+
+  // Note: set_servers() has been removed and replaced by a constructor - calling set_servers after setup would
+  // have had no effect anyway, and making the strings immutable avoids the need to strdup their contents.
+
   void setup() override;
   void dump_config() override;
-  /// Change the servers used by SNTP for timekeeping
-  void set_servers(const std::string &server_1, const std::string &server_2, const std::string &server_3) {
-    this->server_1_ = server_1;
-    this->server_2_ = server_2;
-    this->server_3_ = server_3;
-  }
   float get_setup_priority() const override { return setup_priority::BEFORE_CONNECTION; }
 
   void update() override;
   void loop() override;
 
  protected:
-  std::string server_1_;
-  std::string server_2_;
-  std::string server_3_;
+  std::vector<std::string> servers_;
   bool has_time_{false};
 };
 

--- a/esphome/components/sntp/sntp_component.h
+++ b/esphome/components/sntp/sntp_component.h
@@ -14,7 +14,7 @@ namespace sntp {
 /// \see https://www.gnu.org/software/libc/manual/html_node/TZ-Variable.html
 class SNTPComponent : public time::RealTimeClock {
  public:
-  SNTPComponent(const std::vector<std::string> &servers) : servers_(std::move(servers)) {}
+  SNTPComponent(const std::vector<std::string> &servers) : servers_(servers) {}
 
   // Note: set_servers() has been removed and replaced by a constructor - calling set_servers after setup would
   // have had no effect anyway, and making the strings immutable avoids the need to strdup their contents.

--- a/esphome/components/sntp/time.py
+++ b/esphome/components/sntp/time.py
@@ -1,16 +1,16 @@
+import esphome.codegen as cg
 from esphome.components import time as time_
 import esphome.config_validation as cv
-import esphome.codegen as cg
-from esphome.core import CORE
 from esphome.const import (
     CONF_ID,
     CONF_SERVERS,
+    PLATFORM_BK72XX,
     PLATFORM_ESP32,
     PLATFORM_ESP8266,
     PLATFORM_RP2040,
     PLATFORM_RTL87XX,
-    PLATFORM_BK72XX,
 )
+from esphome.core import CORE
 
 DEPENDENCIES = ["network"]
 sntp_ns = cg.esphome_ns.namespace("sntp")
@@ -40,11 +40,8 @@ CONFIG_SCHEMA = cv.All(
 
 
 async def to_code(config):
-    var = cg.new_Pvariable(config[CONF_ID])
-
     servers = config[CONF_SERVERS]
-    servers += [""] * (3 - len(servers))
-    cg.add(var.set_servers(*servers))
+    var = cg.new_Pvariable(config[CONF_ID], servers)
 
     await cg.register_component(var, config)
     await time_.register_time(var, config)


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

1. Fixes warnings from sntp component when compiling for ESP-IDF 5.x
2. Eliminate need for `strdup()` calls and associated CI tomfoolery.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/issues/issues/6458

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040
- [x] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
