### PR TITLE
[esp32] Fix crash with empty `platformio_options:` value

### DIFF
--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -355,24 +355,20 @@ def _detect_variant(value):
 
 
 def final_validate(config):
-    if CONF_PLATFORMIO_OPTIONS not in fv.full_config.get()[CONF_ESPHOME]:
+    if not (
+        pio_options := fv.full_config.get()[CONF_ESPHOME].get(CONF_PLATFORMIO_OPTIONS)
+    ):
+        # Not specified or empty
         return config
 
     pio_flash_size_key = "board_upload.flash_size"
     pio_partitions_key = "board_build.partitions"
-    if (
-        CONF_PARTITIONS in config
-        and pio_partitions_key
-        in fv.full_config.get()[CONF_ESPHOME][CONF_PLATFORMIO_OPTIONS]
-    ):
+    if CONF_PARTITIONS in config and pio_partitions_key in pio_options:
         raise cv.Invalid(
             f"Do not specify '{pio_partitions_key}' in '{CONF_PLATFORMIO_OPTIONS}' with '{CONF_PARTITIONS}' in esp32"
         )
 
-    if (
-        pio_flash_size_key
-        in fv.full_config.get()[CONF_ESPHOME][CONF_PLATFORMIO_OPTIONS]
-    ):
+    if pio_flash_size_key in pio_options:
         raise cv.Invalid(
             f"Please specify {CONF_FLASH_SIZE} within esp32 configuration only"
         )


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Providing `platformio_options:` with no value causes a build-time crash.
It should give a sensible error message.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
esphome:
  name: "${name}"
  platformio_options:

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
