### PR TITLE
[http_request] on_response body must be owned

### DIFF
--- a/esphome/components/http_request/__init__.py
+++ b/esphome/components/http_request/__init__.py
@@ -35,12 +35,6 @@ HttpContainer = http_request_ns.class_("HttpContainer")
 HttpRequestSendAction = http_request_ns.class_(
     "HttpRequestSendAction", automation.Action
 )
-HttpRequestResponseTrigger = http_request_ns.class_(
-    "HttpRequestResponseTrigger",
-    automation.Trigger.template(
-        cg.std_shared_ptr.template(HttpContainer), cg.std_string
-    ),
-)
 
 CONF_HTTP_REQUEST_ID = "http_request_id"
 
@@ -305,7 +299,7 @@ async def http_request_action_to_code(config, action_id, template_arg, args):
                 var.get_success_trigger_with_response(),
                 [
                     (cg.std_shared_ptr.template(HttpContainer), "response"),
-                    (cg.std_string_ref, "body"),
+                    (cg.std_string, "body"),
                     *args,
                 ],
                 response_conf,

--- a/esphome/components/http_request/http_request.h
+++ b/esphome/components/http_request/http_request.h
@@ -111,13 +111,6 @@ class HttpContainer : public Parented<HttpRequestComponent> {
   std::map<std::string, std::list<std::string>> response_headers_{};
 };
 
-class HttpRequestResponseTrigger : public Trigger<std::shared_ptr<HttpContainer>, std::string &> {
- public:
-  void process(const std::shared_ptr<HttpContainer> &container, std::string &response_body) {
-    this->trigger(container, response_body);
-  }
-};
-
 class HttpRequestComponent : public Component {
  public:
   void dump_config() override;
@@ -198,7 +191,7 @@ template<typename... Ts> class HttpRequestSendAction : public Action<Ts...> {
   void set_json(std::function<void(Ts..., JsonObject)> json_func) { this->json_func_ = json_func; }
 
 #ifdef USE_HTTP_REQUEST_RESPONSE
-  Trigger<std::shared_ptr<HttpContainer>, std::string &, Ts...> *get_success_trigger_with_response() const {
+  Trigger<std::shared_ptr<HttpContainer>, std::string, Ts...> *get_success_trigger_with_response() const {
     return this->success_trigger_with_response_;
   }
 #endif
@@ -259,7 +252,6 @@ template<typename... Ts> class HttpRequestSendAction : public Action<Ts...> {
           yield();
           read_index += read;
         }
-        response_body.reserve(read_index);
         response_body.assign((char *) buf, read_index);
         allocator.deallocate(buf, max_length);
       }
@@ -292,8 +284,8 @@ template<typename... Ts> class HttpRequestSendAction : public Action<Ts...> {
   std::map<const char *, TemplatableValue<std::string, Ts...>> json_{};
   std::function<void(Ts..., JsonObject)> json_func_{nullptr};
 #ifdef USE_HTTP_REQUEST_RESPONSE
-  Trigger<std::shared_ptr<HttpContainer>, std::string &, Ts...> *success_trigger_with_response_ =
-      new Trigger<std::shared_ptr<HttpContainer>, std::string &, Ts...>();
+  Trigger<std::shared_ptr<HttpContainer>, std::string, Ts...> *success_trigger_with_response_ =
+      new Trigger<std::shared_ptr<HttpContainer>, std::string, Ts...>();
 #endif
   Trigger<std::shared_ptr<HttpContainer>, Ts...> *success_trigger_ =
       new Trigger<std::shared_ptr<HttpContainer>, Ts...>();


### PR DESCRIPTION
# What does this implement/fix?

https://github.com/esphome/esphome/pull/6968 changed the response_body to a reference of string to avoid copies when passing the string by value. However, the owned string will be deallocated right after the call to process(), so actions such as delay and wait_until would be passed an invalid reference. ~Additionally, wait_until, while and repeat will not compile anymore, since they store their arguments in a default-constructed member - which fails for references.~ (fixed by #7972)

~This PR instead uses a shared_ptr, which will still avoid the copies between each action. However, users must now dereference the body argument in their on_response lambdas to get the std::string, therefore it is a breaking change.~ (fixed by #11704)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/issues/issues/5987

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [x] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
esphome:
  name: reproduce
  platform: ESP8266
  board: d1_mini
  on_boot:
    - priority: -100
      then:
        - http_request.get:
            url: "https://example.com/"
            on_response:
              then:
                - repeat:
                    count: 3
                    then:

wifi:
  ssid: !secret wifi_ssid
  password: !secret wifi_psk

http_request:
  useragent: esphome
  timeout: 2s
  id: http_request_data
  verify_ssl: false
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
