### PR TITLE
Move docker oci labels to correct image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -163,6 +163,18 @@ ENTRYPOINT ["/entrypoint.sh"]
 CMD ["dashboard", "/config"]
 
 
+ARG BUILD_VERSION=dev
+
+# Labels
+LABEL \
+    org.opencontainers.image.authors="The ESPHome Authors" \
+    org.opencontainers.image.title="ESPHome" \
+    org.opencontainers.image.description="Manage and program ESP8266/ESP32 microcontrollers through YAML configuration files" \
+    org.opencontainers.image.url="https://esphome.io/" \
+    org.opencontainers.image.documentation="https://esphome.io/" \
+    org.opencontainers.image.source="https://github.com/esphome/esphome" \
+    org.opencontainers.image.licenses="ESPHome" \
+    org.opencontainers.image.version=${BUILD_VERSION}
 
 
 # ======================= hassio-type image =======================
@@ -196,16 +208,8 @@ LABEL \
     io.hass.name="ESPHome" \
     io.hass.description="Manage and program ESP8266/ESP32 microcontrollers through YAML configuration files" \
     io.hass.type="addon" \
-    io.hass.version="${BUILD_VERSION}" \
+    io.hass.version="${BUILD_VERSION}"
     # io.hass.arch is inherited from addon-debian-base
-    org.opencontainers.image.authors="The ESPHome Authors" \
-    org.opencontainers.image.title="ESPHome" \
-    org.opencontainers.image.description="Manage and program ESP8266/ESP32 microcontrollers through YAML configuration files" \
-    org.opencontainers.image.url="https://esphome.io/" \
-    org.opencontainers.image.documentation="https://esphome.io/" \
-    org.opencontainers.image.source="https://github.com/esphome/esphome" \
-    org.opencontainers.image.licenses="ESPHome" \
-    org.opencontainers.image.version=${BUILD_VERSION}
 
 
 


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Immediately after merging #7924 I realised that these labels should be on the regular "docker" image, not the hassio / HA add-on one.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
