### PR TITLE
2024.11.3

### DIFF
--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -363,7 +363,7 @@ def upload_program(config, args, host):
 
     from esphome import espota2
 
-    remote_port = ota_conf[CONF_PORT]
+    remote_port = int(ota_conf[CONF_PORT])
     password = ota_conf.get(CONF_PASSWORD, "")
 
     if (

--- a/esphome/components/datetime/datetime_entity.cpp
+++ b/esphome/components/datetime/datetime_entity.cpp
@@ -60,9 +60,7 @@ ESPTime DateTimeEntity::state_as_esptime() const {
   obj.hour = this->hour_;
   obj.minute = this->minute_;
   obj.second = this->second_;
-  obj.day_of_week = 1;  // Required to be valid for recalc_timestamp_local but not used.
-  obj.day_of_year = 1;  // Required to be valid for recalc_timestamp_local but not used.
-  obj.recalc_timestamp_local(false);
+  obj.recalc_timestamp_local();
   return obj;
 }
 

--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -355,24 +355,20 @@ def _detect_variant(value):
 
 
 def final_validate(config):
-    if CONF_PLATFORMIO_OPTIONS not in fv.full_config.get()[CONF_ESPHOME]:
+    if not (
+        pio_options := fv.full_config.get()[CONF_ESPHOME].get(CONF_PLATFORMIO_OPTIONS)
+    ):
+        # Not specified or empty
         return config
 
     pio_flash_size_key = "board_upload.flash_size"
     pio_partitions_key = "board_build.partitions"
-    if (
-        CONF_PARTITIONS in config
-        and pio_partitions_key
-        in fv.full_config.get()[CONF_ESPHOME][CONF_PLATFORMIO_OPTIONS]
-    ):
+    if CONF_PARTITIONS in config and pio_partitions_key in pio_options:
         raise cv.Invalid(
             f"Do not specify '{pio_partitions_key}' in '{CONF_PLATFORMIO_OPTIONS}' with '{CONF_PARTITIONS}' in esp32"
         )
 
-    if (
-        pio_flash_size_key
-        in fv.full_config.get()[CONF_ESPHOME][CONF_PLATFORMIO_OPTIONS]
-    ):
+    if pio_flash_size_key in pio_options:
         raise cv.Invalid(
             f"Please specify {CONF_FLASH_SIZE} within esp32 configuration only"
         )

--- a/esphome/components/lvgl/defines.py
+++ b/esphome/components/lvgl/defines.py
@@ -38,7 +38,7 @@ def literal(arg):
 def call_lambda(lamb: LambdaExpression):
     expr = lamb.content.strip()
     if expr.startswith("return") and expr.endswith(";"):
-        return expr[7:][:-1]
+        return expr[6:][:-1].strip()
     return f"{lamb}()"
 
 

--- a/esphome/components/lvgl/lvgl_esphome.h
+++ b/esphome/components/lvgl/lvgl_esphome.h
@@ -56,6 +56,9 @@ static const display::ColorBitness LV_BITNESS = display::ColorBitness::COLOR_BIT
 inline void lv_img_set_src(lv_obj_t *obj, esphome::image::Image *image) {
   lv_img_set_src(obj, image->get_lv_img_dsc());
 }
+inline void lv_disp_set_bg_image(lv_disp_t *disp, esphome::image::Image *image) {
+  lv_disp_set_bg_image(disp, image->get_lv_img_dsc());
+}
 #endif  // USE_LVGL_IMAGE
 
 // Parent class for things that wrap an LVGL object

--- a/esphome/components/lvgl/widgets/line.py
+++ b/esphome/components/lvgl/widgets/line.py
@@ -35,6 +35,11 @@ LINE_SCHEMA = {
     cv.GenerateID(CONF_POINT_LIST_ID): cv.declare_id(lv_point_t),
 }
 
+LINE_MODIFY_SCHEMA = {
+    cv.Optional(CONF_POINTS): cv_point_list,
+    cv.GenerateID(CONF_POINT_LIST_ID): cv.declare_id(lv_point_t),
+}
+
 
 class LineType(WidgetType):
     def __init__(self):
@@ -43,6 +48,7 @@ class LineType(WidgetType):
             LvType("lv_line_t"),
             (CONF_MAIN,),
             LINE_SCHEMA,
+            modify_schema=LINE_MODIFY_SCHEMA,
         )
 
     async def to_code(self, w: Widget, config):

--- a/esphome/components/lvgl/widgets/msgbox.py
+++ b/esphome/components/lvgl/widgets/msgbox.py
@@ -29,7 +29,7 @@ from ..lvcode import (
 )
 from ..schemas import STYLE_SCHEMA, STYLED_TEXT_SCHEMA, container_schema, part_schema
 from ..types import LV_EVENT, char_ptr, lv_obj_t
-from . import Widget, set_obj_properties
+from . import Widget, add_widgets, set_obj_properties
 from .button import button_spec
 from .buttonmatrix import (
     BUTTONMATRIX_BUTTON_SCHEMA,
@@ -119,6 +119,7 @@ async def msgbox_to_code(top_layer, conf):
         button_style = {CONF_ITEMS: button_style}
         await set_obj_properties(buttonmatrix_widget, button_style)
     await set_obj_properties(msgbox_widget, conf)
+    await add_widgets(msgbox_widget, conf)
     async with LambdaContext(EVENT_ARG, where=messagebox_id) as close_action:
         outer_widget.add_flag("LV_OBJ_FLAG_HIDDEN")
     if close_button:

--- a/esphome/components/online_image/png_image.cpp
+++ b/esphome/components/online_image/png_image.cpp
@@ -49,6 +49,10 @@ void PngDecoder::prepare(uint32_t download_size) {
 }
 
 int HOT PngDecoder::decode(uint8_t *buffer, size_t size) {
+  if (!this->pngle_) {
+    ESP_LOGE(TAG, "PNG decoder engine not initialized!");
+    return -1;
+  }
   if (size < 256 && size < this->download_size_ - this->decoded_bytes_) {
     ESP_LOGD(TAG, "Waiting for data");
     return 0;

--- a/esphome/components/opentherm/hub.cpp
+++ b/esphome/components/opentherm/hub.cpp
@@ -138,7 +138,7 @@ OpenthermHub::OpenthermHub() : Component(), in_pin_{}, out_pin_{} {}
 void OpenthermHub::process_response(OpenthermData &data) {
   ESP_LOGD(TAG, "Received OpenTherm response with id %d (%s)", data.id,
            this->opentherm_->message_id_to_str((MessageId) data.id));
-  ESP_LOGD(TAG, "%s", this->opentherm_->debug_data(data).c_str());
+  this->opentherm_->debug_data(data);
 
   switch (data.id) {
     OPENTHERM_SENSOR_MESSAGE_HANDLERS(OPENTHERM_MESSAGE_RESPONSE_MESSAGE, OPENTHERM_MESSAGE_RESPONSE_ENTITY, ,
@@ -315,7 +315,7 @@ void OpenthermHub::start_conversation_() {
 
   ESP_LOGD(TAG, "Sending request with id %d (%s)", request.id,
            this->opentherm_->message_id_to_str((MessageId) request.id));
-  ESP_LOGD(TAG, "%s", this->opentherm_->debug_data(request).c_str());
+  this->opentherm_->debug_data(request);
   // Send the request
   this->last_conversation_start_ = millis();
   this->opentherm_->send(request);
@@ -340,19 +340,18 @@ void OpenthermHub::stop_opentherm_() {
   this->opentherm_->stop();
   this->last_conversation_end_ = millis();
 }
-
 void OpenthermHub::handle_protocol_write_error_() {
   ESP_LOGW(TAG, "Error while sending request: %s",
            this->opentherm_->operation_mode_to_str(this->opentherm_->get_mode()));
-  ESP_LOGW(TAG, "%s", this->opentherm_->debug_data(this->last_request_).c_str());
+  this->opentherm_->debug_data(this->last_request_);
 }
-
 void OpenthermHub::handle_protocol_read_error_() {
   OpenThermError error;
   this->opentherm_->get_protocol_error(error);
-  ESP_LOGW(TAG, "Protocol error occured while receiving response: %s", this->opentherm_->debug_error(error).c_str());
+  ESP_LOGW(TAG, "Protocol error occured while receiving response: %s",
+           this->opentherm_->protocol_error_to_to_str(error.error_type));
+  this->opentherm_->debug_error(error);
 }
-
 void OpenthermHub::handle_timeout_error_() {
   ESP_LOGW(TAG, "Receive response timed out at a protocol level");
   this->stop_opentherm_();

--- a/esphome/components/opentherm/opentherm.cpp
+++ b/esphome/components/opentherm/opentherm.cpp
@@ -220,7 +220,7 @@ void IRAM_ATTR OpenTherm::bit_read_(uint8_t value) {
   this->bit_pos_++;
 }
 
-ProtocolErrorType OpenTherm::verify_stop_bit_(uint8_t value) {
+ProtocolErrorType IRAM_ATTR OpenTherm::verify_stop_bit_(uint8_t value) {
   if (value) {  // stop bit detected
     return check_parity_(this->data_) ? ProtocolErrorType::NO_ERROR : ProtocolErrorType::PARITY_ERROR;
   } else {  // no stop bit detected, error
@@ -365,7 +365,7 @@ void IRAM_ATTR OpenTherm::stop_timer_() {
 
 #ifdef ESP8266
 // 5 kHz timer_
-void OpenTherm::start_read_timer_() {
+void IRAM_ATTR OpenTherm::start_read_timer_() {
   InterruptLock const lock;
   timer1_attachInterrupt(OpenTherm::esp8266_timer_isr);
   timer1_enable(TIM_DIV16, TIM_EDGE, TIM_LOOP);  // 5MHz (5 ticks/us - 1677721.4 us max)
@@ -373,14 +373,14 @@ void OpenTherm::start_read_timer_() {
 }
 
 // 2 kHz timer_
-void OpenTherm::start_write_timer_() {
+void IRAM_ATTR OpenTherm::start_write_timer_() {
   InterruptLock const lock;
   timer1_attachInterrupt(OpenTherm::esp8266_timer_isr);
   timer1_enable(TIM_DIV16, TIM_EDGE, TIM_LOOP);  // 5MHz (5 ticks/us - 1677721.4 us max)
   timer1_write(2500);                            // 2kHz
 }
 
-void OpenTherm::stop_timer_() {
+void IRAM_ATTR OpenTherm::stop_timer_() {
   InterruptLock const lock;
   timer1_disable();
   timer1_detachInterrupt();
@@ -389,7 +389,7 @@ void OpenTherm::stop_timer_() {
 #endif  // END ESP8266
 
 // https://stackoverflow.com/questions/21617970/how-to-check-if-value-has-even-parity-of-bits-or-odd
-bool OpenTherm::check_parity_(uint32_t val) {
+bool IRAM_ATTR OpenTherm::check_parity_(uint32_t val) {
   val ^= val >> 16;
   val ^= val >> 8;
   val ^= val >> 4;

--- a/esphome/components/opentherm/opentherm.cpp
+++ b/esphome/components/opentherm/opentherm.cpp
@@ -15,15 +15,11 @@
 #include "Arduino.h"
 #endif
 #include <string>
-#include <sstream>
-#include <bitset>
 
 namespace esphome {
 namespace opentherm {
 
 using std::string;
-using std::bitset;
-using std::stringstream;
 using std::to_string;
 
 static const char *const TAG = "opentherm";
@@ -545,29 +541,17 @@ const char *OpenTherm::message_id_to_str(MessageId id) {
   }
 }
 
-string OpenTherm::debug_data(OpenthermData &data) {
-  stringstream result;
-  result << bitset<8>(data.type) << " " << bitset<8>(data.id) << " " << bitset<8>(data.valueHB) << " "
-         << bitset<8>(data.valueLB) << "\n";
-  result << "type: " << this->message_type_to_str((MessageType) data.type) << "; ";
-  result << "id: " << to_string(data.id) << "; ";
-  result << "HB: " << to_string(data.valueHB) << "; ";
-  result << "LB: " << to_string(data.valueLB) << "; ";
-  result << "uint_16: " << to_string(data.u16()) << "; ";
-  result << "float: " << to_string(data.f88());
-
-  return result.str();
+void OpenTherm::debug_data(OpenthermData &data) {
+  ESP_LOGD(TAG, "%s %s %s %s", format_bin(data.type).c_str(), format_bin(data.id).c_str(),
+           format_bin(data.valueHB).c_str(), format_bin(data.valueLB).c_str());
+  ESP_LOGD(TAG, "type: %s; id: %s; HB: %s; LB: %s; uint_16: %s; float: %s",
+           this->message_type_to_str((MessageType) data.type), to_string(data.id).c_str(),
+           to_string(data.valueHB).c_str(), to_string(data.valueLB).c_str(), to_string(data.u16()).c_str(),
+           to_string(data.f88()).c_str());
 }
-std::string OpenTherm::debug_error(OpenThermError &error) {
-  stringstream result;
-  result << "type: " << this->protocol_error_to_to_str(error.error_type) << "; ";
-  result << "data: ";
-  result << format_hex(error.data);
-  result << "; clock: " << to_string(clock_);
-  result << "; capture: " << bitset<32>(error.capture);
-  result << "; bit_pos: " << to_string(error.bit_pos);
-
-  return result.str();
+void OpenTherm::debug_error(OpenThermError &error) const {
+  ESP_LOGD(TAG, "data: %s; clock: %s; capture: %s; bit_pos: %s", format_hex(error.data).c_str(),
+           to_string(clock_).c_str(), format_bin(error.capture).c_str(), to_string(error.bit_pos).c_str());
 }
 
 float OpenthermData::f88() { return ((float) this->s16()) / 256.0; }

--- a/esphome/components/opentherm/opentherm.h
+++ b/esphome/components/opentherm/opentherm.h
@@ -8,10 +8,9 @@
 #pragma once
 
 #include <string>
-#include <sstream>
-#include <iomanip>
 #include "esphome/core/hal.h"
 #include "esphome/core/log.h"
+#include "esphome/core/helpers.h"
 
 #if defined(ESP32) || defined(USE_ESP_IDF)
 #include "driver/timer.h"
@@ -318,8 +317,8 @@ class OpenTherm {
 
   OperationMode get_mode() { return mode_; }
 
-  std::string debug_data(OpenthermData &data);
-  std::string debug_error(OpenThermError &error);
+  void debug_data(OpenthermData &data);
+  void debug_error(OpenThermError &error) const;
 
   const char *protocol_error_to_to_str(ProtocolErrorType error_type);
   const char *message_type_to_str(MessageType message_type);

--- a/esphome/components/st7920/st7920.cpp
+++ b/esphome/components/st7920/st7920.cpp
@@ -1,7 +1,7 @@
 #include "st7920.h"
-#include "esphome/core/log.h"
-#include "esphome/core/application.h"
 #include "esphome/components/display/display_buffer.h"
+#include "esphome/core/application.h"
+#include "esphome/core/log.h"
 
 namespace esphome {
 namespace st7920 {
@@ -118,7 +118,6 @@ size_t ST7920::get_buffer_length_() {
 
 void HOT ST7920::draw_absolute_pixel_internal(int x, int y, Color color) {
   if (x >= this->get_width_internal() || x < 0 || y >= this->get_height_internal() || y < 0) {
-    ESP_LOGW(TAG, "Position out of area: %dx%d", x, y);
     return;
   }
   int width = this->get_width_internal() / 8u;

--- a/esphome/const.py
+++ b/esphome/const.py
@@ -1,6 +1,6 @@
 """Constants used by esphome."""
 
-__version__ = "2024.11.2"
+__version__ = "2024.11.3"
 
 ALLOWED_NAME_CHARS = "abcdefghijklmnopqrstuvwxyz0123456789-_"
 VALID_SUBSTITUTIONS_CHARACTERS = (

--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -397,6 +397,18 @@ std::string format_hex_pretty(const uint16_t *data, size_t length) {
 }
 std::string format_hex_pretty(const std::vector<uint16_t> &data) { return format_hex_pretty(data.data(), data.size()); }
 
+std::string format_bin(const uint8_t *data, size_t length) {
+  std::string result;
+  result.resize(length * 8);
+  for (size_t byte_idx = 0; byte_idx < length; byte_idx++) {
+    for (size_t bit_idx = 0; bit_idx < 8; bit_idx++) {
+      result[byte_idx * 8 + bit_idx] = ((data[byte_idx] >> (7 - bit_idx)) & 1) + '0';
+    }
+  }
+
+  return result;
+}
+
 ParseOnOffState parse_on_off(const char *str, const char *on, const char *off) {
   if (on == nullptr && strcasecmp(str, "on") == 0)
     return PARSE_ON;

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -420,6 +420,14 @@ template<typename T, enable_if_t<std::is_unsigned<T>::value, int> = 0> std::stri
   return format_hex_pretty(reinterpret_cast<uint8_t *>(&val), sizeof(T));
 }
 
+/// Format the byte array \p data of length \p len in binary.
+std::string format_bin(const uint8_t *data, size_t length);
+/// Format an unsigned integer in binary, starting with the most significant byte.
+template<typename T, enable_if_t<std::is_unsigned<T>::value, int> = 0> std::string format_bin(T val) {
+  val = convert_big_endian(val);
+  return format_bin(reinterpret_cast<uint8_t *>(&val), sizeof(T));
+}
+
 /// Return values for parse_on_off().
 enum ParseOnOffState {
   PARSE_NONE = 0,

--- a/esphome/core/time.cpp
+++ b/esphome/core/time.cpp
@@ -169,7 +169,7 @@ void ESPTime::recalc_timestamp_utc(bool use_day_of_year) {
   }
 
   for (int i = 1970; i < this->year; i++)
-    res += (year % 4 == 0) ? 366 : 365;
+    res += (i % 4 == 0) ? 366 : 365;
 
   if (use_day_of_year) {
     res += this->day_of_year - 1;

--- a/esphome/core/time.h
+++ b/esphome/core/time.h
@@ -9,8 +9,6 @@ namespace esphome {
 
 template<typename T> bool increment_time_value(T &current, uint16_t begin, uint16_t end);
 
-bool is_leap_year(uint32_t year);
-
 uint8_t days_in_month(uint8_t month, uint16_t year);
 
 /// A more user-friendly version of struct tm from time.h
@@ -100,7 +98,7 @@ struct ESPTime {
   void recalc_timestamp_utc(bool use_day_of_year = true);
 
   /// Recalculate the timestamp field from the other fields of this ESPTime instance assuming local fields.
-  void recalc_timestamp_local(bool use_day_of_year = true);
+  void recalc_timestamp_local();
 
   /// Convert this ESPTime instance back to a tm struct.
   struct tm to_c_tm();

--- a/tests/components/lvgl/lvgl-package.yaml
+++ b/tests/components/lvgl/lvgl-package.yaml
@@ -109,6 +109,10 @@ lvgl:
       close_button: true
       title: Messagebox
       bg_color: 0xffff
+      widgets:
+        - label:
+            text: Hello Msgbox
+            id: msgbox_label
       body:
         text: This is a sample messagebox
         bg_color: 0x808080
@@ -137,6 +141,9 @@ lvgl:
         - lvgl.widget.focus: mark
         - lvgl.widget.redraw: hello_label
         - lvgl.widget.redraw:
+        - lvgl.label.update:
+            id: msgbox_label
+            text: Unloaded
       on_all_events:
         logger.log:
           format: "Event %s"

--- a/tests/components/lvgl/lvgl-package.yaml
+++ b/tests/components/lvgl/lvgl-package.yaml
@@ -333,7 +333,7 @@ lvgl:
             id: button_button
             width: 20%
             height: 10%
-            transform_angle: !lambda return 180*100;
+            transform_angle: !lambda return(180*100);
             arc_width: !lambda return 4;
             border_width: !lambda return 6;
             shadow_ofs_x: !lambda return 6;
@@ -577,7 +577,7 @@ lvgl:
               - 180, 60
               - 240, 10
             on_click:
-              - lvgl.widget.update:
+              - lvgl.line.update:
                   id: lv_line_id
                   line_color: 0xFFFF
               - lvgl.page.next:


### PR DESCRIPTION
**Do not merge, release script will automatically merge**
- [opentherm] Fix out of memory errors on ESP8266 [esphome#7835](https://github.com/esphome/esphome/pull/7835)
- fix local time timestamp calculation [esphome#7807](https://github.com/esphome/esphome/pull/7807)
- [online_image]Don't access decoder if not initialized [esphome#7882](https://github.com/esphome/esphome/pull/7882)
- Add IRAM_ATTR to all functions used during interrupts on esp8266 chips. [esphome#7840](https://github.com/esphome/esphome/pull/7840)
- [st7920] Remove unnecessary warning when drawing outside display bounds [esphome#7868](https://github.com/esphome/esphome/pull/7868)
- Fix recalc_timestamp_utc [esphome#7894](https://github.com/esphome/esphome/pull/7894)
- Cast port to int for ota pushing [esphome#7888](https://github.com/esphome/esphome/pull/7888)
- [lvgl] Bugfixes [esphome#7896](https://github.com/esphome/esphome/pull/7896)
- [lvgl] Fix msgbox content [esphome#7912](https://github.com/esphome/esphome/pull/7912)
- [esp32] Fix crash with empty `platformio_options:` value [esphome#7920](https://github.com/esphome/esphome/pull/7920)

<details>
<summary>Metadata</summary>

@coderabbitai ignore
</details>
