### PR TITLE
Add font anti-aliasing for grayscale display

### DIFF
--- a/esphome/components/font/font.cpp
+++ b/esphome/components/font/font.cpp
@@ -133,9 +133,11 @@ void Font::print(int x_start, int y_start, display::Display *display, Color colo
     auto diff_r = (float) color.r - (float) background.r;
     auto diff_g = (float) color.g - (float) background.g;
     auto diff_b = (float) color.b - (float) background.b;
+    auto diff_w = (float) color.w - (float) background.w;
     auto b_r = (float) background.r;
     auto b_g = (float) background.g;
-    auto b_b = (float) background.g;
+    auto b_b = (float) background.b;
+    auto b_w = (float) background.w;
     for (int glyph_y = y_start + scan_y1; glyph_y != max_y; glyph_y++) {
       for (int glyph_x = x_at + scan_x1; glyph_x != max_x; glyph_x++) {
         uint8_t pixel = 0;
@@ -153,8 +155,8 @@ void Font::print(int x_start, int y_start, display::Display *display, Color colo
           display->draw_pixel_at(glyph_x, glyph_y, color);
         } else if (pixel != 0) {
           auto on = (float) pixel / (float) bpp_max;
-          auto blended =
-              Color((uint8_t) (diff_r * on + b_r), (uint8_t) (diff_g * on + b_g), (uint8_t) (diff_b * on + b_b));
+          auto blended = Color((uint8_t) (diff_r * on + b_r), (uint8_t) (diff_g * on + b_g),
+                               (uint8_t) (diff_b * on + b_b), (uint8_t) (diff_w * on + b_w));
           display->draw_pixel_at(glyph_x, glyph_y, blended);
         }
       }


### PR DESCRIPTION
# What does this implement/fix?

Small fix to support anti-aliasing on grayscale display. Tested with SSD1327.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- No related issues.

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- Not required

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

- Not required

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
