### PR TITLE
Added update_interval to flicker light effect

### DIFF
--- a/esphome/components/light/base_light_effects.h
+++ b/esphome/components/light/base_light_effects.h
@@ -193,6 +193,11 @@ class FlickerLightEffect : public LightEffect {
   explicit FlickerLightEffect(const std::string &name) : LightEffect(name) {}
 
   void apply() override {
+    const uint32_t now = millis();
+    if (now - this->last_change_ < this->update_interval_) {
+      return;
+    }
+
     LightColorValues remote = this->state_->remote_values;
     LightColorValues current = this->state_->current_values;
     LightColorValues out;
@@ -217,14 +222,19 @@ class FlickerLightEffect : public LightEffect {
     call.from_light_color_values(out);
     call.set_state(true);
     call.perform();
+
+    this->last_change_ = now;
   }
 
   void set_alpha(float alpha) { this->alpha_ = alpha; }
   void set_intensity(float intensity) { this->intensity_ = intensity; }
+  void set_update_interval(uint32_t update_interval) { this->update_interval_ = update_interval; }
 
  protected:
   float intensity_{};
   float alpha_{};
+  uint32_t last_change_{0};
+  uint32_t update_interval_{};
 };
 
 }  // namespace light

--- a/esphome/components/light/effects.py
+++ b/esphome/components/light/effects.py
@@ -327,12 +327,14 @@ async def strobe_effect_to_code(config, effect_id):
     {
         cv.Optional(CONF_ALPHA, default=0.95): cv.percentage,
         cv.Optional(CONF_INTENSITY, default=0.015): cv.percentage,
+        cv.Optional(CONF_UPDATE_INTERVAL, default="0ms"): cv.update_interval,
     },
 )
 async def flicker_effect_to_code(config, effect_id):
     var = cg.new_Pvariable(effect_id, config[CONF_NAME])
     cg.add(var.set_alpha(config[CONF_ALPHA]))
     cg.add(var.set_intensity(config[CONF_INTENSITY]))
+    cg.add(var.set_update_interval(config[CONF_UPDATE_INTERVAL]))
     return var
 
 


### PR DESCRIPTION
# What does this implement/fix?
Adds the ability to adjust the flicker speed of a light by adding the optional configuration variable of update_interval to the Flicker Effect for a light component.
<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
light:
  - platform: neopixelbus
    id: rgbw_led
    name: "Candle"
    type: GRBW
    variant: SK6812
    pin: GPIO21
    num_leds: 1
    effects:
      - flicker:
          name: "Custom Flicker"
          alpha: 90%
          intensity: 5%
          update_interval: 250ms # NEW
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
