### PR TITLE
[esp32_ble] Use RAMAllocator to avoid panic abort from ``new``

### DIFF
--- a/esphome/components/esp32_ble/ble.cpp
+++ b/esphome/components/esp32_ble/ble.cpp
@@ -27,6 +27,8 @@ namespace esp32_ble {
 
 static const char *const TAG = "esp32_ble";
 
+static RAMAllocator<BLEEvent> EVENT_ALLOCATOR(RAMAllocator<BLEEvent>::ALLOW_FAILURE);
+
 void ESP32BLE::setup() {
   global_ble = this;
   ESP_LOGCONFIG(TAG, "Setting up BLE...");
@@ -322,7 +324,8 @@ void ESP32BLE::loop() {
       default:
         break;
     }
-    delete ble_event;  // NOLINT(cppcoreguidelines-owning-memory)
+    ble_event->~BLEEvent();
+    EVENT_ALLOCATOR.deallocate(ble_event, 1);
     ble_event = this->ble_events_.pop();
   }
   if (this->advertising_ != nullptr) {
@@ -331,9 +334,14 @@ void ESP32BLE::loop() {
 }
 
 void ESP32BLE::gap_event_handler(esp_gap_ble_cb_event_t event, esp_ble_gap_cb_param_t *param) {
-  BLEEvent *new_event = new BLEEvent(event, param);  // NOLINT(cppcoreguidelines-owning-memory)
+  BLEEvent *new_event = EVENT_ALLOCATOR.allocate(1);
+  if (new_event == nullptr) {
+    // Memory too fragmented to allocate new event. Can only drop it until memory comes back
+    return;
+  }
+  new (new_event) BLEEvent(event, param);
   global_ble->ble_events_.push(new_event);
-}  // NOLINT(clang-analyzer-cplusplus.NewDeleteLeaks)
+}
 
 void ESP32BLE::real_gap_event_handler_(esp_gap_ble_cb_event_t event, esp_ble_gap_cb_param_t *param) {
   ESP_LOGV(TAG, "(BLE) gap_event_handler - %d", event);
@@ -344,9 +352,14 @@ void ESP32BLE::real_gap_event_handler_(esp_gap_ble_cb_event_t event, esp_ble_gap
 
 void ESP32BLE::gatts_event_handler(esp_gatts_cb_event_t event, esp_gatt_if_t gatts_if,
                                    esp_ble_gatts_cb_param_t *param) {
-  BLEEvent *new_event = new BLEEvent(event, gatts_if, param);  // NOLINT(cppcoreguidelines-owning-memory)
+  BLEEvent *new_event = EVENT_ALLOCATOR.allocate(1);
+  if (new_event == nullptr) {
+    // Memory too fragmented to allocate new event. Can only drop it until memory comes back
+    return;
+  }
+  new (new_event) BLEEvent(event, gatts_if, param);
   global_ble->ble_events_.push(new_event);
-}  // NOLINT(clang-analyzer-cplusplus.NewDeleteLeaks)
+}
 
 void ESP32BLE::real_gatts_event_handler_(esp_gatts_cb_event_t event, esp_gatt_if_t gatts_if,
                                          esp_ble_gatts_cb_param_t *param) {
@@ -358,9 +371,14 @@ void ESP32BLE::real_gatts_event_handler_(esp_gatts_cb_event_t event, esp_gatt_if
 
 void ESP32BLE::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if,
                                    esp_ble_gattc_cb_param_t *param) {
-  BLEEvent *new_event = new BLEEvent(event, gattc_if, param);  // NOLINT(cppcoreguidelines-owning-memory)
+  BLEEvent *new_event = EVENT_ALLOCATOR.allocate(1);
+  if (new_event == nullptr) {
+    // Memory too fragmented to allocate new event. Can only drop it until memory comes back
+    return;
+  }
+  new (new_event) BLEEvent(event, gattc_if, param);
   global_ble->ble_events_.push(new_event);
-}  // NOLINT(clang-analyzer-cplusplus.NewDeleteLeaks)
+}
 
 void ESP32BLE::real_gattc_event_handler_(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if,
                                          esp_ble_gattc_cb_param_t *param) {

--- a/esphome/components/esp32_ble/ble.cpp
+++ b/esphome/components/esp32_ble/ble.cpp
@@ -27,7 +27,8 @@ namespace esp32_ble {
 
 static const char *const TAG = "esp32_ble";
 
-static RAMAllocator<BLEEvent> EVENT_ALLOCATOR(RAMAllocator<BLEEvent>::ALLOW_FAILURE);
+static RAMAllocator<BLEEvent> EVENT_ALLOCATOR(  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+    RAMAllocator<BLEEvent>::ALLOW_FAILURE | RAMAllocator<BLEEvent>::ALLOC_INTERNAL);
 
 void ESP32BLE::setup() {
   global_ble = this;
@@ -341,7 +342,7 @@ void ESP32BLE::gap_event_handler(esp_gap_ble_cb_event_t event, esp_ble_gap_cb_pa
   }
   new (new_event) BLEEvent(event, param);
   global_ble->ble_events_.push(new_event);
-}
+}  // NOLINT(clang-analyzer-unix.Malloc)
 
 void ESP32BLE::real_gap_event_handler_(esp_gap_ble_cb_event_t event, esp_ble_gap_cb_param_t *param) {
   ESP_LOGV(TAG, "(BLE) gap_event_handler - %d", event);
@@ -359,7 +360,7 @@ void ESP32BLE::gatts_event_handler(esp_gatts_cb_event_t event, esp_gatt_if_t gat
   }
   new (new_event) BLEEvent(event, gatts_if, param);
   global_ble->ble_events_.push(new_event);
-}
+}  // NOLINT(clang-analyzer-unix.Malloc)
 
 void ESP32BLE::real_gatts_event_handler_(esp_gatts_cb_event_t event, esp_gatt_if_t gatts_if,
                                          esp_ble_gatts_cb_param_t *param) {
@@ -378,7 +379,7 @@ void ESP32BLE::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gat
   }
   new (new_event) BLEEvent(event, gattc_if, param);
   global_ble->ble_events_.push(new_event);
-}
+}  // NOLINT(clang-analyzer-unix.Malloc)
 
 void ESP32BLE::real_gattc_event_handler_(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if,
                                          esp_ble_gattc_cb_param_t *param) {


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

When the memory is too fragmented (as seen when a `http_request` is in progress) the BLEEvent allocation fails. We can catch this by using the RAMAllocator and then using that allocated memory for the new object and fail gracefully if it could not be allocated.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
