### PR TITLE
[sgp30] Set default update interval to 60s

### DIFF
--- a/esphome/components/sgp30/sensor.py
+++ b/esphome/components/sgp30/sensor.py
@@ -1,23 +1,22 @@
 import esphome.codegen as cg
+from esphome.components import i2c, sensirion_common, sensor
 import esphome.config_validation as cv
-from esphome.components import i2c, sensor, sensirion_common
-
 from esphome.const import (
-    CONF_COMPENSATION,
-    CONF_ID,
     CONF_BASELINE,
+    CONF_COMPENSATION,
     CONF_ECO2,
+    CONF_ID,
     CONF_STORE_BASELINE,
     CONF_TEMPERATURE_SOURCE,
     CONF_TVOC,
-    ICON_RADIATOR,
     DEVICE_CLASS_CARBON_DIOXIDE,
     DEVICE_CLASS_VOLATILE_ORGANIC_COMPOUNDS_PARTS,
-    STATE_CLASS_MEASUREMENT,
-    UNIT_PARTS_PER_MILLION,
-    UNIT_PARTS_PER_BILLION,
-    ICON_MOLECULE_CO2,
     ENTITY_CATEGORY_DIAGNOSTIC,
+    ICON_MOLECULE_CO2,
+    ICON_RADIATOR,
+    STATE_CLASS_MEASUREMENT,
+    UNIT_PARTS_PER_BILLION,
+    UNIT_PARTS_PER_MILLION,
 )
 
 DEPENDENCIES = ["i2c"]
@@ -77,7 +76,7 @@ CONFIG_SCHEMA = (
             ),
         }
     )
-    .extend(cv.polling_component_schema("1s"))
+    .extend(cv.polling_component_schema("60s"))
     .extend(i2c.i2c_device_schema(0x58))
 )
 

--- a/esphome/components/sgp30/sgp30.cpp
+++ b/esphome/components/sgp30/sgp30.cpp
@@ -1,8 +1,8 @@
 #include "sgp30.h"
+#include <cinttypes>
+#include "esphome/core/application.h"
 #include "esphome/core/hal.h"
 #include "esphome/core/log.h"
-#include "esphome/core/application.h"
-#include <cinttypes>
 
 namespace esphome {
 namespace sgp30 {
@@ -294,10 +294,6 @@ void SGP30Component::update() {
       this->eco2_sensor_->publish_state(eco2);
     if (this->tvoc_sensor_ != nullptr)
       this->tvoc_sensor_->publish_state(tvoc);
-
-    if (this->get_update_interval() != 1000) {
-      ESP_LOGW(TAG, "Update interval for SGP30 sensor must be set to 1s for optimized readout");
-    }
 
     this->status_clear_warning();
     this->send_env_data_();


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

All sensors in ESPHome should be on a 60s default update interval if they are polling sensors. Users can override this in YAML if desired.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
