### PR TITLE
[pulse_counter] Fix volatile increment/decrement deprecation warnings

### DIFF
--- a/esphome/components/pulse_counter/pulse_counter_sensor.cpp
+++ b/esphome/components/pulse_counter/pulse_counter_sensor.cpp
@@ -28,18 +28,14 @@ void IRAM_ATTR BasicPulseCounterStorage::gpio_intr(BasicPulseCounterStorage *arg
   switch (mode) {
     case PULSE_COUNTER_DISABLE:
       break;
-    case PULSE_COUNTER_INCREMENT:
-      {
-        auto x = arg->counter + 1;
-        arg->counter = x;
-      }
-      break;
-    case PULSE_COUNTER_DECREMENT:
-      {
-        auto x = arg->counter - 1;
-        arg->counter = x;
-      }
-      break;
+    case PULSE_COUNTER_INCREMENT: {
+      auto x = arg->counter + 1;
+      arg->counter = x;
+    } break;
+    case PULSE_COUNTER_DECREMENT: {
+      auto x = arg->counter - 1;
+      arg->counter = x;
+    } break;
   }
 }
 
@@ -52,7 +48,6 @@ bool BasicPulseCounterStorage::pulse_counter_setup(InternalGPIOPin *pin) {
 }
 
 pulse_counter_t BasicPulseCounterStorage::read_raw_value() {
-  esphome::InterruptLock lock;
   pulse_counter_t counter = this->counter;
   pulse_counter_t ret = counter - this->last_value;
   this->last_value = counter;

--- a/esphome/components/pulse_counter/pulse_counter_sensor.cpp
+++ b/esphome/components/pulse_counter/pulse_counter_sensor.cpp
@@ -19,31 +19,27 @@ PulseCounterStorageBase *get_storage(bool) { return new BasicPulseCounterStorage
 
 void IRAM_ATTR BasicPulseCounterStorage::gpio_intr(BasicPulseCounterStorage *arg) {
   const uint32_t now = micros();
-  bool skip_pulse;
-
-  {
-    esphome::InterruptLock lock;
-    skip_pulse = (now - arg->last_pulse < arg->filter_us);
-    arg->last_pulse = now;
-  }
-
-  if (skip_pulse)
+  const bool discard = now - arg->last_pulse < arg->filter_us;
+  arg->last_pulse = now;
+  if (discard)
     return;
 
   PulseCounterCountMode mode = arg->isr_pin.digital_read() ? arg->rising_edge_mode : arg->falling_edge_mode;
-
-  {
-    esphome::InterruptLock lock;
-    switch (mode) {
-      case PULSE_COUNTER_DISABLE:
-        break;
-      case PULSE_COUNTER_INCREMENT:
-        arg->counter += 1;
-        break;
-      case PULSE_COUNTER_DECREMENT:
-        arg->counter -= 1;
-        break;
-    }
+  switch (mode) {
+    case PULSE_COUNTER_DISABLE:
+      break;
+    case PULSE_COUNTER_INCREMENT:
+      {
+        auto x = arg->counter + 1;
+        arg->counter = x;
+      }
+      break;
+    case PULSE_COUNTER_DECREMENT:
+      {
+        auto x = arg->counter - 1;
+        arg->counter = x;
+      }
+      break;
   }
 }
 

--- a/esphome/components/pulse_counter/pulse_counter_sensor.cpp
+++ b/esphome/components/pulse_counter/pulse_counter_sensor.cpp
@@ -13,25 +13,25 @@ PulseCounterStorageBase *get_storage(bool hw_pcnt) {
   return (hw_pcnt ? (PulseCounterStorageBase *) (new HwPulseCounterStorage)
                   : (PulseCounterStorageBase *) (new BasicPulseCounterStorage));
 }
-#else  // HAS_PCNT
+#else   // HAS_PCNT
 PulseCounterStorageBase *get_storage(bool) { return new BasicPulseCounterStorage; }
 #endif  // HAS_PCNT
 
 void IRAM_ATTR BasicPulseCounterStorage::gpio_intr(BasicPulseCounterStorage *arg) {
   const uint32_t now = micros();
   bool skip_pulse;
-  
+
   {
     esphome::InterruptLock lock;
     skip_pulse = (now - arg->last_pulse < arg->filter_us);
     arg->last_pulse = now;
   }
-  
+
   if (skip_pulse)
     return;
 
   PulseCounterCountMode mode = arg->isr_pin.digital_read() ? arg->rising_edge_mode : arg->falling_edge_mode;
-  
+
   {
     esphome::InterruptLock lock;
     switch (mode) {

--- a/esphome/components/pulse_counter/pulse_counter_sensor.cpp
+++ b/esphome/components/pulse_counter/pulse_counter_sensor.cpp
@@ -13,29 +13,40 @@ PulseCounterStorageBase *get_storage(bool hw_pcnt) {
   return (hw_pcnt ? (PulseCounterStorageBase *) (new HwPulseCounterStorage)
                   : (PulseCounterStorageBase *) (new BasicPulseCounterStorage));
 }
-#else
+#else  // HAS_PCNT
 PulseCounterStorageBase *get_storage(bool) { return new BasicPulseCounterStorage; }
-#endif
+#endif  // HAS_PCNT
 
 void IRAM_ATTR BasicPulseCounterStorage::gpio_intr(BasicPulseCounterStorage *arg) {
   const uint32_t now = micros();
-  const bool discard = now - arg->last_pulse < arg->filter_us;
-  arg->last_pulse = now;
-  if (discard)
+  bool skip_pulse;
+  
+  {
+    esphome::InterruptLock lock;
+    skip_pulse = (now - arg->last_pulse < arg->filter_us);
+    arg->last_pulse = now;
+  }
+  
+  if (skip_pulse)
     return;
 
   PulseCounterCountMode mode = arg->isr_pin.digital_read() ? arg->rising_edge_mode : arg->falling_edge_mode;
-  switch (mode) {
-    case PULSE_COUNTER_DISABLE:
-      break;
-    case PULSE_COUNTER_INCREMENT:
-      arg->counter++;
-      break;
-    case PULSE_COUNTER_DECREMENT:
-      arg->counter--;
-      break;
+  
+  {
+    esphome::InterruptLock lock;
+    switch (mode) {
+      case PULSE_COUNTER_DISABLE:
+        break;
+      case PULSE_COUNTER_INCREMENT:
+        arg->counter += 1;
+        break;
+      case PULSE_COUNTER_DECREMENT:
+        arg->counter -= 1;
+        break;
+    }
   }
 }
+
 bool BasicPulseCounterStorage::pulse_counter_setup(InternalGPIOPin *pin) {
   this->pin = pin;
   this->pin->setup();
@@ -43,7 +54,9 @@ bool BasicPulseCounterStorage::pulse_counter_setup(InternalGPIOPin *pin) {
   this->pin->attach_interrupt(BasicPulseCounterStorage::gpio_intr, this, gpio::INTERRUPT_ANY_EDGE);
   return true;
 }
+
 pulse_counter_t BasicPulseCounterStorage::read_raw_value() {
+  esphome::InterruptLock lock;
   pulse_counter_t counter = this->counter;
   pulse_counter_t ret = counter - this->last_value;
   this->last_value = counter;
@@ -141,6 +154,7 @@ bool HwPulseCounterStorage::pulse_counter_setup(InternalGPIOPin *pin) {
   }
   return true;
 }
+
 pulse_counter_t HwPulseCounterStorage::read_raw_value() {
   pulse_counter_t counter;
   pcnt_get_counter_value(this->pcnt_unit, &counter);
@@ -148,7 +162,7 @@ pulse_counter_t HwPulseCounterStorage::read_raw_value() {
   this->last_value = counter;
   return ret;
 }
-#endif
+#endif  // HAS_PCNT
 
 void PulseCounterSensor::setup() {
   ESP_LOGCONFIG(TAG, "Setting up pulse counter '%s'...", this->name_.c_str());

--- a/esphome/components/pulse_counter/pulse_counter_sensor.h
+++ b/esphome/components/pulse_counter/pulse_counter_sensor.h
@@ -22,7 +22,7 @@ enum PulseCounterCountMode {
 
 #ifdef HAS_PCNT
 using pulse_counter_t = int16_t;
-#else  // HAS_PCNT
+#else   // HAS_PCNT
 using pulse_counter_t = int32_t;
 #endif  // HAS_PCNT
 

--- a/esphome/components/pulse_counter/pulse_counter_sensor.h
+++ b/esphome/components/pulse_counter/pulse_counter_sensor.h
@@ -43,8 +43,8 @@ struct BasicPulseCounterStorage : public PulseCounterStorageBase {
   bool pulse_counter_setup(InternalGPIOPin *pin) override;
   pulse_counter_t read_raw_value() override;
 
-  pulse_counter_t counter{0};
-  uint32_t last_pulse{0};
+  volatile pulse_counter_t counter{0};
+  volatile uint32_t last_pulse{0};
 
   ISRInternalGPIOPin isr_pin;
 };

--- a/esphome/components/pulse_counter/pulse_counter_sensor.h
+++ b/esphome/components/pulse_counter/pulse_counter_sensor.h
@@ -9,7 +9,7 @@
 #if defined(USE_ESP32) && !defined(USE_ESP32_VARIANT_ESP32C3)
 #include <driver/pcnt.h>
 #define HAS_PCNT
-#endif
+#endif  // defined(USE_ESP32) && !defined(USE_ESP32_VARIANT_ESP32C3)
 
 namespace esphome {
 namespace pulse_counter {
@@ -22,9 +22,9 @@ enum PulseCounterCountMode {
 
 #ifdef HAS_PCNT
 using pulse_counter_t = int16_t;
-#else
+#else  // HAS_PCNT
 using pulse_counter_t = int32_t;
-#endif
+#endif  // HAS_PCNT
 
 struct PulseCounterStorageBase {
   virtual bool pulse_counter_setup(InternalGPIOPin *pin) = 0;
@@ -43,8 +43,8 @@ struct BasicPulseCounterStorage : public PulseCounterStorageBase {
   bool pulse_counter_setup(InternalGPIOPin *pin) override;
   pulse_counter_t read_raw_value() override;
 
-  volatile pulse_counter_t counter{0};
-  volatile uint32_t last_pulse{0};
+  pulse_counter_t counter{0};
+  uint32_t last_pulse{0};
 
   ISRInternalGPIOPin isr_pin;
 };
@@ -57,7 +57,7 @@ struct HwPulseCounterStorage : public PulseCounterStorageBase {
   pcnt_unit_t pcnt_unit;
   pcnt_channel_t pcnt_channel;
 };
-#endif
+#endif  // HAS_PCNT
 
 PulseCounterStorageBase *get_storage(bool hw_pcnt = false);
 


### PR DESCRIPTION
# What does this implement/fix?

Fixes warnings about deprecated use of ++ and -- operators on volatile-qualified types in the pulse counter component. Replaces volatile variables with proper interrupt-safe access using ESPHome's InterruptLock.

The warnings being fixed are:
```log
src/esphome/components/pulse_counter/pulse_counter_sensor.cpp:32:12: warning: '++' expression of 'volatile'-qualified type is deprecated [-Wvolatile]
src/esphome/components/pulse_counter/pulse_counter_sensor.cpp:35:12: warning: '--' expression of 'volatile'-qualified type is deprecated [-Wvolatile]
```
Changes:
- Keep the volatile qualifier as it's important for interrupt context
- Replace increment/decrement operations with load/store approach

This change maintains the same functionality.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes esphome/issues#6544

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [ ] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`: N/A

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
