### PR TITLE
[adc] Restore missing LIBRETINY code in a separated file

### DIFF
--- a/esphome/components/adc/adc_sensor_libretiny.cpp
+++ b/esphome/components/adc/adc_sensor_libretiny.cpp
@@ -1,0 +1,48 @@
+#ifdef USE_LIBRETINY
+
+#include "adc_sensor.h"
+#include "esphome/core/log.h"
+
+namespace esphome {
+namespace adc {
+
+static const char *const TAG = "adc.libretiny";
+
+void ADCSensor::setup() {
+  ESP_LOGCONFIG(TAG, "Setting up ADC '%s'...", this->get_name().c_str());
+#ifndef USE_ADC_SENSOR_VCC
+  this->pin_->setup();
+#endif  // !USE_ADC_SENSOR_VCC
+}
+
+void ADCSensor::dump_config() {
+  LOG_SENSOR("", "ADC Sensor", this);
+#ifdef USE_ADC_SENSOR_VCC
+  ESP_LOGCONFIG(TAG, "  Pin: VCC");
+#else   // USE_ADC_SENSOR_VCC
+  LOG_PIN("  Pin: ", this->pin_);
+#endif  // USE_ADC_SENSOR_VCC
+  ESP_LOGCONFIG(TAG, "  Samples: %i", this->sample_count_);
+  LOG_UPDATE_INTERVAL(this);
+}
+
+float ADCSensor::sample() {
+  uint32_t raw = 0;
+  if (this->output_raw_) {
+    for (uint8_t sample = 0; sample < this->sample_count_; sample++) {
+      raw += analogRead(this->pin_->get_pin());  // NOLINT
+    }
+    raw = (raw + (this->sample_count_ >> 1)) / this->sample_count_;  // NOLINT(clang-analyzer-core.DivideZero)
+    return raw;
+  }
+  for (uint8_t sample = 0; sample < this->sample_count_; sample++) {
+    raw += analogReadVoltage(this->pin_->get_pin());  // NOLINT
+  }
+  raw = (raw + (this->sample_count_ >> 1)) / this->sample_count_;  // NOLINT(clang-analyzer-core.DivideZero)
+  return raw / 1000.0f;
+}
+
+}  // namespace adc
+}  // namespace esphome
+
+#endif  // USE_LIBRETINY

--- a/tests/components/adc/test.bk72xx-ard.yaml
+++ b/tests/components/adc/test.bk72xx-ard.yaml
@@ -1,0 +1,4 @@
+sensor:
+  - platform: adc
+    pin: P23
+    name: Basic ADC Test


### PR DESCRIPTION
# What does this implement/fix?

This code was removed by mistake on PR#7940, but it is required for LIBRETINY support.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes esphome/issues#6541

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [X] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`: N/A

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
