### PR TITLE
[rotary_encoder] Fix volatile increment/decrement deprecation warnings

### DIFF
--- a/esphome/components/rotary_encoder/rotary_encoder.cpp
+++ b/esphome/components/rotary_encoder/rotary_encoder.cpp
@@ -92,14 +92,16 @@ void IRAM_ATTR HOT RotaryEncoderSensorStore::gpio_intr(RotaryEncoderSensorStore 
 
   int8_t rotation_dir = 0;
   uint16_t new_state = STATE_LOOKUP_TABLE[input_state];
+
+  esphome::InterruptLock lock;
   if ((new_state & arg->resolution & STATE_HAS_INCREMENTED) != 0) {
     if (arg->counter < arg->max_value)
-      arg->counter++;
+      arg->counter += 1;
     rotation_dir = 1;
   }
   if ((new_state & arg->resolution & STATE_HAS_DECREMENTED) != 0) {
     if (arg->counter > arg->min_value)
-      arg->counter--;
+      arg->counter -= 1;
     rotation_dir = -1;
   }
 

--- a/esphome/components/rotary_encoder/rotary_encoder.cpp
+++ b/esphome/components/rotary_encoder/rotary_encoder.cpp
@@ -92,16 +92,18 @@ void IRAM_ATTR HOT RotaryEncoderSensorStore::gpio_intr(RotaryEncoderSensorStore 
 
   int8_t rotation_dir = 0;
   uint16_t new_state = STATE_LOOKUP_TABLE[input_state];
-
-  esphome::InterruptLock lock;
   if ((new_state & arg->resolution & STATE_HAS_INCREMENTED) != 0) {
-    if (arg->counter < arg->max_value)
-      arg->counter += 1;
+    if (arg->counter < arg->max_value) {
+      auto x = arg->counter + 1;
+      arg->counter = x;
+    }
     rotation_dir = 1;
   }
   if ((new_state & arg->resolution & STATE_HAS_DECREMENTED) != 0) {
-    if (arg->counter > arg->min_value)
-      arg->counter -= 1;
+    if (arg->counter > arg->min_value) {
+      auto x = arg->counter - 1;
+      arg->counter = x;
+    }
     rotation_dir = -1;
   }
 

--- a/esphome/components/rotary_encoder/rotary_encoder.h
+++ b/esphome/components/rotary_encoder/rotary_encoder.h
@@ -28,7 +28,7 @@ struct RotaryEncoderSensorStore {
   ISRInternalGPIOPin pin_a;
   ISRInternalGPIOPin pin_b;
 
-  int32_t counter{0};
+  volatile int32_t counter{0};
   RotaryEncoderResolution resolution{ROTARY_ENCODER_1_PULSE_PER_CYCLE};
   int32_t min_value{INT32_MIN};
   int32_t max_value{INT32_MAX};

--- a/esphome/components/rotary_encoder/rotary_encoder.h
+++ b/esphome/components/rotary_encoder/rotary_encoder.h
@@ -28,7 +28,7 @@ struct RotaryEncoderSensorStore {
   ISRInternalGPIOPin pin_a;
   ISRInternalGPIOPin pin_b;
 
-  volatile int32_t counter{0};
+  int32_t counter{0};
   RotaryEncoderResolution resolution{ROTARY_ENCODER_1_PULSE_PER_CYCLE};
   int32_t min_value{INT32_MIN};
   int32_t max_value{INT32_MAX};


### PR DESCRIPTION
# What does this implement/fix?

Similar to the [pulse counter fix](https://github.com/esphome/esphome/pull/7954), this PR addresses warnings about deprecated use of increment/decrement operators on volatile-qualified types in the rotary encoder component. 

The warnings being fixed are:
```log
- warning: '++' expression of 'volatile'-qualified type is deprecated [-Wvolatile]
- warning: '--' expression of 'volatile'-qualified type is deprecated [-Wvolatile]
```

Changes:
- Keep the volatile qualifier as it's important for interrupt context
- Replace increment/decrement operations with load/store approach

This is a similar change to #7954 (pulse counter fix) but for the rotary encoder component.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [ ] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`: N/A

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
