### PR TITLE
[esp32_ble] do not skip events if queue is blocked

### DIFF
--- a/esphome/components/esp32_ble/queue.h
+++ b/esphome/components/esp32_ble/queue.h
@@ -26,6 +26,7 @@ template<class T> class Queue {
   void push(T *element) {
     if (element == nullptr)
       return;
+    // It is not called from main loop. Thus it won't block main thread.
     xSemaphoreTake(m_, portMAX_DELAY);
     q_.push(element);
     xSemaphoreGive(m_);

--- a/esphome/components/esp32_ble/queue.h
+++ b/esphome/components/esp32_ble/queue.h
@@ -26,10 +26,9 @@ template<class T> class Queue {
   void push(T *element) {
     if (element == nullptr)
       return;
-    if (xSemaphoreTake(m_, portMAX_DELAY)) {
-      q_.push(element);
-      xSemaphoreGive(m_);
-    }
+    xSemaphoreTake(m_, portMAX_DELAY);
+    q_.push(element);
+    xSemaphoreGive(m_);
   }
 
   T *pop() {

--- a/esphome/components/esp32_ble/queue.h
+++ b/esphome/components/esp32_ble/queue.h
@@ -26,7 +26,7 @@ template<class T> class Queue {
   void push(T *element) {
     if (element == nullptr)
       return;
-    if (xSemaphoreTake(m_, 5L / portTICK_PERIOD_MS)) {
+    if (xSemaphoreTake(m_, portMAX_DELAY)) {
       q_.push(element);
       xSemaphoreGive(m_);
     }


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->
Do not skip events if queue is blocked. Before lock is taken with timeout. If semaphore is already taken it may happen that event is not added to queue.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- https://github.com/esphome/issues/issues/5119
- https://github.com/esphome/issues/issues/6270

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
