### PR TITLE
[nextion] Publishes `is_connected()`

### DIFF
--- a/esphome/components/nextion/nextion.cpp
+++ b/esphome/components/nextion/nextion.cpp
@@ -40,7 +40,7 @@ bool Nextion::send_command_(const std::string &command) {
 }
 
 bool Nextion::check_connect_() {
-  if (this->get_is_connected_())
+  if (this->is_connected_)
     return true;
 
   // Check if the handshake should be skipped for the Nextion connection

--- a/esphome/components/nextion/nextion.h
+++ b/esphome/components/nextion/nextion.h
@@ -1218,22 +1218,22 @@ class Nextion : public NextionBase, public PollingComponent, public uart::UARTDe
   bool is_updating() override;
 
   /**
-  * @brief Check if the Nextion display is successfully connected.
-  * 
-  * This method returns whether a successful connection has been established with 
-  * the Nextion display. A connection is considered established when:
-  * 
-  * - The initial handshake with the display is completed successfully, or
-  * - The handshake is skipped via skip_connection_handshake_ flag
-  * 
-  * The connection status is particularly useful when:
-  * - Troubleshooting communication issues
-  * - Ensuring the display is ready before sending commands
-  * - Implementing connection-dependent behaviors
-  * 
-  * @return true if the Nextion display is connected and ready to receive commands
-  * @return false if the display is not yet connected or connection was lost
-  */
+   * @brief Check if the Nextion display is successfully connected.
+   *
+   * This method returns whether a successful connection has been established with
+   * the Nextion display. A connection is considered established when:
+   *
+   * - The initial handshake with the display is completed successfully, or
+   * - The handshake is skipped via skip_connection_handshake_ flag
+   *
+   * The connection status is particularly useful when:
+   * - Troubleshooting communication issues
+   * - Ensuring the display is ready before sending commands
+   * - Implementing connection-dependent behaviors
+   *
+   * @return true if the Nextion display is connected and ready to receive commands
+   * @return false if the display is not yet connected or connection was lost
+   */
   bool is_connected() { return this->is_connected_; }
 
  protected:

--- a/esphome/components/nextion/nextion.h
+++ b/esphome/components/nextion/nextion.h
@@ -1217,6 +1217,25 @@ class Nextion : public NextionBase, public PollingComponent, public uart::UARTDe
    */
   bool is_updating() override;
 
+  /**
+  * @brief Check if the Nextion display is successfully connected.
+  * 
+  * This method returns whether a successful connection has been established with 
+  * the Nextion display. A connection is considered established when:
+  * 
+  * - The initial handshake with the display is completed successfully, or
+  * - The handshake is skipped via skip_connection_handshake_ flag
+  * 
+  * The connection status is particularly useful when:
+  * - Troubleshooting communication issues
+  * - Ensuring the display is ready before sending commands
+  * - Implementing connection-dependent behaviors
+  * 
+  * @return true if the Nextion display is connected and ready to receive commands
+  * @return false if the display is not yet connected or connection was lost
+  */
+  bool is_connected() { return this->is_connected_; }
+
  protected:
   std::deque<NextionQueue *> nextion_queue_;
   std::deque<NextionQueue *> waveform_queue_;
@@ -1314,8 +1333,6 @@ class Nextion : public NextionBase, public PollingComponent, public uart::UARTDe
   uint32_t get_free_heap_();
 
 #endif  // USE_NEXTION_TFT_UPLOAD
-
-  bool get_is_connected_() { return this->is_connected_; }
 
   bool check_connect_();
 

--- a/tests/components/nextion/common.yaml
+++ b/tests/components/nextion/common.yaml
@@ -1,5 +1,7 @@
 esphome:
   on_boot:
+    - lambda: 'ESP_LOGD("display","is_connected(): %s", YESNO(id(main_lcd).is_connected()));'
+
     # Binary sensor publish action tests
     - binary_sensor.nextion.publish:
         id: r0_sensor


### PR DESCRIPTION
# What does this implement/fix?

Check if the Nextion display is successfully connected.

This method returns whether a successful connection has been established with the Nextion display. A connection is considered established when:

- The initial handshake with the display is completed successfully, or
- The handshake is skipped via skip_connection_handshake_ flag

The connection status is particularly useful when:
- Troubleshooting communication issues
- Ensuring the display is ready before sending commands
- Implementing connection-dependent behaviors

* returns `true` if the Nextion display is connected and ready to receive commands
* returns `false` if the display is not yet connected or connection was lost

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [X] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
esphome:
  on_boot:
    - lambda: |-
        ESP_LOGD("display","is_connected(): %s", YESNO(id(main_lcd).is_connected()));
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
