### PR TITLE
Fix adc channel for ESP32-H2

### DIFF
--- a/esphome/components/adc/__init__.py
+++ b/esphome/components/adc/__init__.py
@@ -1,11 +1,6 @@
-import esphome.codegen as cg
-import esphome.config_validation as cv
 from esphome import pins
-from esphome.const import CONF_ANALOG, CONF_INPUT, CONF_NUMBER
-
-from esphome.core import CORE
+import esphome.codegen as cg
 from esphome.components.esp32 import get_esp32_variant
-from esphome.const import PLATFORM_ESP8266
 from esphome.components.esp32.const import (
     VARIANT_ESP32,
     VARIANT_ESP32C2,
@@ -15,6 +10,9 @@ from esphome.components.esp32.const import (
     VARIANT_ESP32S2,
     VARIANT_ESP32S3,
 )
+import esphome.config_validation as cv
+from esphome.const import CONF_ANALOG, CONF_INPUT, CONF_NUMBER, PLATFORM_ESP8266
+from esphome.core import CORE
 
 CODEOWNERS = ["@esphome/core"]
 
@@ -102,11 +100,11 @@ ESP32_VARIANT_ADC1_PIN_TO_CHANNEL = {
         6: adc1_channel_t.ADC1_CHANNEL_6,
     },
     VARIANT_ESP32H2: {
-        0: adc1_channel_t.ADC1_CHANNEL_0,
-        1: adc1_channel_t.ADC1_CHANNEL_1,
-        2: adc1_channel_t.ADC1_CHANNEL_2,
-        3: adc1_channel_t.ADC1_CHANNEL_3,
-        4: adc1_channel_t.ADC1_CHANNEL_4,
+        1: adc1_channel_t.ADC1_CHANNEL_0,
+        2: adc1_channel_t.ADC1_CHANNEL_1,
+        3: adc1_channel_t.ADC1_CHANNEL_2,
+        4: adc1_channel_t.ADC1_CHANNEL_3,
+        5: adc1_channel_t.ADC1_CHANNEL_4,
     },
 }
 


### PR DESCRIPTION
# What does this implement/fix?

Fix ADC channel <-> gpio mapping for esp32-h2. Discovered in #7942

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
