### PR TITLE
[uart] Use ``SOC_UART_NUM`` as number of uarts instead of ``UART_NUM_MAX``

### DIFF
--- a/esphome/components/uart/uart_component_esp32_arduino.cpp
+++ b/esphome/components/uart/uart_component_esp32_arduino.cpp
@@ -1,9 +1,9 @@
 #ifdef USE_ESP32_FRAMEWORK_ARDUINO
+#include "uart_component_esp32_arduino.h"
 #include "esphome/core/application.h"
 #include "esphome/core/defines.h"
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
-#include "uart_component_esp32_arduino.h"
 
 #ifdef USE_LOGGER
 #include "esphome/components/logger/logger.h"
@@ -118,7 +118,7 @@ void ESP32ArduinoUARTComponent::setup() {
     }
 #endif  // USE_LOGGER
 
-    if (next_uart_num >= UART_NUM_MAX) {
+    if (next_uart_num >= SOC_UART_NUM) {
       ESP_LOGW(TAG, "Maximum number of UART components created already.");
       this->mark_failed();
       return;

--- a/esphome/components/uart/uart_component_esp_idf.cpp
+++ b/esphome/components/uart/uart_component_esp_idf.cpp
@@ -1,11 +1,11 @@
 #ifdef USE_ESP_IDF
 
 #include "uart_component_esp_idf.h"
+#include <cinttypes>
 #include "esphome/core/application.h"
 #include "esphome/core/defines.h"
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
-#include <cinttypes>
 
 #ifdef USE_LOGGER
 #include "esphome/components/logger/logger.h"
@@ -84,7 +84,7 @@ void IDFUARTComponent::setup() {
   }
 #endif  // USE_LOGGER
 
-  if (next_uart_num >= UART_NUM_MAX) {
+  if (next_uart_num >= SOC_UART_NUM) {
     ESP_LOGW(TAG, "Maximum number of UART components created already.");
     this->mark_failed();
     return;


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Following up to #7947 but for UART in case esp-idf changes ``UART_NUM_MAX`` to an enum as well.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
