### PR TITLE
[core] Bugfix: Implement ring buffer with xRingbuffer

### DIFF
--- a/esphome/core/ring_buffer.cpp
+++ b/esphome/core/ring_buffer.cpp
@@ -13,8 +13,8 @@ static const char *const TAG = "ring_buffer";
 
 RingBuffer::~RingBuffer() {
   if (this->handle_ != nullptr) {
-    vStreamBufferDelete(this->handle_);
-    ExternalRAMAllocator<uint8_t> allocator(ExternalRAMAllocator<uint8_t>::ALLOW_FAILURE);
+    vRingbufferDelete(this->handle_);
+    RAMAllocator<uint8_t> allocator(RAMAllocator<uint8_t>::ALLOW_FAILURE);
     allocator.deallocate(this->storage_, this->size_);
   }
 }
@@ -22,26 +22,49 @@ RingBuffer::~RingBuffer() {
 std::unique_ptr<RingBuffer> RingBuffer::create(size_t len) {
   std::unique_ptr<RingBuffer> rb = make_unique<RingBuffer>();
 
-  rb->size_ = len + 1;
+  rb->size_ = len;
 
-  ExternalRAMAllocator<uint8_t> allocator(ExternalRAMAllocator<uint8_t>::ALLOW_FAILURE);
+  RAMAllocator<uint8_t> allocator(RAMAllocator<uint8_t>::ALLOW_FAILURE);
   rb->storage_ = allocator.allocate(rb->size_);
   if (rb->storage_ == nullptr) {
     return nullptr;
   }
 
-  rb->handle_ = xStreamBufferCreateStatic(rb->size_, 1, rb->storage_, &rb->structure_);
+  rb->handle_ = xRingbufferCreateStatic(rb->size_, RINGBUF_TYPE_BYTEBUF, rb->storage_, &rb->structure_);
   ESP_LOGD(TAG, "Created ring buffer with size %u", len);
+
   return rb;
 }
 
 size_t RingBuffer::read(void *data, size_t len, TickType_t ticks_to_wait) {
-  if (ticks_to_wait > 0)
-    xStreamBufferSetTriggerLevel(this->handle_, len);
+  size_t bytes_read = 0;
 
-  size_t bytes_read = xStreamBufferReceive(this->handle_, data, len, ticks_to_wait);
+  void *buffer_data = xRingbufferReceiveUpTo(this->handle_, &bytes_read, ticks_to_wait, len);
 
-  xStreamBufferSetTriggerLevel(this->handle_, 1);
+  if (buffer_data == nullptr) {
+    return 0;
+  }
+
+  std::memcpy(data, buffer_data, bytes_read);
+
+  vRingbufferReturnItem(this->handle_, buffer_data);
+
+  if (bytes_read < len) {
+    // Data may have wrapped around, so read a second time to receive the remainder
+    size_t follow_up_bytes_read = 0;
+    size_t bytes_remaining = len - bytes_read;
+
+    buffer_data = xRingbufferReceiveUpTo(this->handle_, &follow_up_bytes_read, 0, bytes_remaining);
+
+    if (buffer_data == nullptr) {
+      return bytes_read;
+    }
+
+    std::memcpy(data + bytes_read, buffer_data, follow_up_bytes_read);
+
+    vRingbufferReturnItem(this->handle_, buffer_data);
+    bytes_read += follow_up_bytes_read;
+  }
 
   return bytes_read;
 }
@@ -49,22 +72,55 @@ size_t RingBuffer::read(void *data, size_t len, TickType_t ticks_to_wait) {
 size_t RingBuffer::write(const void *data, size_t len) {
   size_t free = this->free();
   if (free < len) {
-    size_t needed = len - free;
-    uint8_t discard[needed];
-    xStreamBufferReceive(this->handle_, discard, needed, 0);
+    // Free enough space in the ring buffer to fit the new data
+    this->discard_bytes_(len - free);
   }
-  return xStreamBufferSend(this->handle_, data, len, 0);
+  return this->write_without_replacement(data, len, 0);
 }
 
 size_t RingBuffer::write_without_replacement(const void *data, size_t len, TickType_t ticks_to_wait) {
-  return xStreamBufferSend(this->handle_, data, len, ticks_to_wait);
+  if (!xRingbufferSend(this->handle_, data, len, ticks_to_wait)) {
+    // Couldn't fit all the data, so only write what will fit
+    size_t free = std::min(this->free(), len);
+    if (xRingbufferSend(this->handle_, data, free, 0)) {
+      return free;
+    }
+    return 0;
+  }
+  return len;
 }
 
-size_t RingBuffer::available() const { return xStreamBufferBytesAvailable(this->handle_); }
+size_t RingBuffer::available() const {
+  UBaseType_t uxItemsWaiting = 0;
+  vRingbufferGetInfo(this->handle_, nullptr, nullptr, nullptr, nullptr, &uxItemsWaiting);
+  return uxItemsWaiting;
+}
 
-size_t RingBuffer::free() const { return xStreamBufferSpacesAvailable(this->handle_); }
+size_t RingBuffer::free() const { return xRingbufferGetCurFreeSize(this->handle_); }
 
-BaseType_t RingBuffer::reset() { return xStreamBufferReset(this->handle_); }
+BaseType_t RingBuffer::reset() {
+  // Discards all the available data
+  return this->discard_bytes_(this->available());
+}
+
+bool RingBuffer::discard_bytes_(size_t discard_bytes) {
+  size_t bytes_read = 0;
+
+  void *buffer_data = xRingbufferReceiveUpTo(this->handle_, &bytes_read, 0, discard_bytes);
+  if (buffer_data != nullptr)
+    vRingbufferReturnItem(this->handle_, buffer_data);
+
+  if (bytes_read < discard_bytes) {
+    size_t wrapped_bytes_read = 0;
+    buffer_data = xRingbufferReceiveUpTo(this->handle_, &wrapped_bytes_read, 0, discard_bytes - bytes_read);
+    if (buffer_data != nullptr) {
+      vRingbufferReturnItem(this->handle_, buffer_data);
+      bytes_read += wrapped_bytes_read;
+    }
+  }
+
+  return (bytes_read == discard_bytes);
+}
 
 }  // namespace esphome
 

--- a/esphome/core/ring_buffer.cpp
+++ b/esphome/core/ring_buffer.cpp
@@ -60,7 +60,7 @@ size_t RingBuffer::read(void *data, size_t len, TickType_t ticks_to_wait) {
       return bytes_read;
     }
 
-    std::memcpy(data + bytes_read, buffer_data, follow_up_bytes_read);
+    std::memcpy((void *) ((uint8_t *) (data) + bytes_read), buffer_data, follow_up_bytes_read);
 
     vRingbufferReturnItem(this->handle_, buffer_data);
     bytes_read += follow_up_bytes_read;

--- a/esphome/core/ring_buffer.cpp
+++ b/esphome/core/ring_buffer.cpp
@@ -91,8 +91,8 @@ size_t RingBuffer::write_without_replacement(const void *data, size_t len, TickT
 }
 
 size_t RingBuffer::available() const {
-  UBaseType_t uxItemsWaiting = 0;
-  vRingbufferGetInfo(this->handle_, nullptr, nullptr, nullptr, nullptr, &uxItemsWaiting);
+  UBaseType_t ux_items_waiting = 0;
+  vRingbufferGetInfo(this->handle_, nullptr, nullptr, nullptr, nullptr, &ux_items_waiting);
   return uxItemsWaiting;
 }
 

--- a/esphome/core/ring_buffer.cpp
+++ b/esphome/core/ring_buffer.cpp
@@ -93,7 +93,7 @@ size_t RingBuffer::write_without_replacement(const void *data, size_t len, TickT
 size_t RingBuffer::available() const {
   UBaseType_t ux_items_waiting = 0;
   vRingbufferGetInfo(this->handle_, nullptr, nullptr, nullptr, nullptr, &ux_items_waiting);
-  return uxItemsWaiting;
+  return ux_items_waiting;
 }
 
 size_t RingBuffer::free() const { return xRingbufferGetCurFreeSize(this->handle_); }

--- a/esphome/core/ring_buffer.h
+++ b/esphome/core/ring_buffer.h
@@ -3,7 +3,7 @@
 #ifdef USE_ESP32
 
 #include <freertos/FreeRTOS.h>
-#include <freertos/stream_buffer.h>
+#include <freertos/ringbuf.h>
 
 #include <cinttypes>
 #include <memory>
@@ -82,9 +82,14 @@ class RingBuffer {
   static std::unique_ptr<RingBuffer> create(size_t len);
 
  protected:
-  StreamBufferHandle_t handle_;
-  StaticStreamBuffer_t structure_;
-  uint8_t *storage_;
+  /// @brief Discards data from the ring buffer.
+  /// @param discard_bytes amount of bytes to discard
+  /// @return True if all bytes were successfully discarded, false otherwise
+  bool discard_bytes_(size_t discard_bytes);
+
+  RingbufHandle_t handle_{nullptr};
+  StaticRingbuffer_t structure_;
+  uint8_t *storage_{nullptr};
   size_t size_{0};
 };
 


### PR DESCRIPTION
# What does this implement/fix?

Implements the core ring buffer class using Espressif's [xRingbuffer](https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-reference/system/freertos_additions.html#ring-buffers) structure instead of a FreeRTOS stream buffer. All methods are compatible with the current stream buffer version, so no modifications are necessary for components using the ring buffer class.

The current stream buffer implementation causes a rare crash when the read and write tasks run on different cores and one task's operation timed out while the other task blocked. The crash requires very unlucky timing, but if you play audio continuously, then you will eventually encounter it (typically it happened within 5 hours).

Tested on the Voice PE where the ``i2s_audio`` and ``nabu`` media player use ring buffers across different tasks. Additionally tested on the S3 Box Lite wake word voice assistant ready made project where the ``esp-adf`` component uses a ring buffer. 

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** not applicable

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** not applicable

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
