### PR TITLE
[core] Add c6 and h2 to split default

### DIFF
--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -1660,6 +1660,12 @@ class SplitDefault(Optional):
         esp32_c3=vol.UNDEFINED,
         esp32_c3_arduino=vol.UNDEFINED,
         esp32_c3_idf=vol.UNDEFINED,
+        esp32_c6=vol.UNDEFINED,
+        esp32_c6_arduino=vol.UNDEFINED,
+        esp32_c6_idf=vol.UNDEFINED,
+        esp32_h2=vol.UNDEFINED,
+        esp32_h2_arduino=vol.UNDEFINED,
+        esp32_h2_idf=vol.UNDEFINED,
         rp2040=vol.UNDEFINED,
         bk72xx=vol.UNDEFINED,
         rtl87xx=vol.UNDEFINED,
@@ -1691,6 +1697,18 @@ class SplitDefault(Optional):
         self._esp32_c3_idf_default = vol.default_factory(
             _get_priority_default(esp32_c3_idf, esp32_c3, esp32_idf, esp32)
         )
+        self._esp32_c6_arduino_default = vol.default_factory(
+            _get_priority_default(esp32_c6_arduino, esp32_c6, esp32_arduino, esp32)
+        )
+        self._esp32_c6_idf_default = vol.default_factory(
+            _get_priority_default(esp32_c6_idf, esp32_c6, esp32_idf, esp32)
+        )
+        self._esp32_h2_arduino_default = vol.default_factory(
+            _get_priority_default(esp32_h2_arduino, esp32_h2, esp32_arduino, esp32)
+        )
+        self._esp32_h2_idf_default = vol.default_factory(
+            _get_priority_default(esp32_h2_idf, esp32_h2, esp32_idf, esp32)
+        )
         self._rp2040_default = vol.default_factory(rp2040)
         self._bk72xx_default = vol.default_factory(bk72xx)
         self._rtl87xx_default = vol.default_factory(rtl87xx)
@@ -1704,6 +1722,8 @@ class SplitDefault(Optional):
             from esphome.components.esp32 import get_esp32_variant
             from esphome.components.esp32.const import (
                 VARIANT_ESP32C3,
+                VARIANT_ESP32C6,
+                VARIANT_ESP32H2,
                 VARIANT_ESP32S2,
                 VARIANT_ESP32S3,
             )
@@ -1724,6 +1744,16 @@ class SplitDefault(Optional):
                     return self._esp32_c3_arduino_default
                 if CORE.using_esp_idf:
                     return self._esp32_c3_idf_default
+            elif variant == VARIANT_ESP32C6:
+                if CORE.using_arduino:
+                    return self._esp32_c6_arduino_default
+                if CORE.using_esp_idf:
+                    return self._esp32_c6_idf_default
+            elif variant == VARIANT_ESP32H2:
+                if CORE.using_arduino:
+                    return self._esp32_h2_arduino_default
+                if CORE.using_esp_idf:
+                    return self._esp32_h2_idf_default
             else:
                 if CORE.using_arduino:
                     return self._esp32_arduino_default


### PR DESCRIPTION
# What does this implement/fix?

Add c6 and h2 to split default

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
