### PR TITLE
2024.12.0b3

### DIFF
--- a/esphome/components/esp32_ble/ble.cpp
+++ b/esphome/components/esp32_ble/ble.cpp
@@ -27,6 +27,9 @@ namespace esp32_ble {
 
 static const char *const TAG = "esp32_ble";
 
+static RAMAllocator<BLEEvent> EVENT_ALLOCATOR(  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+    RAMAllocator<BLEEvent>::ALLOW_FAILURE | RAMAllocator<BLEEvent>::ALLOC_INTERNAL);
+
 void ESP32BLE::setup() {
   global_ble = this;
   ESP_LOGCONFIG(TAG, "Setting up BLE...");
@@ -322,7 +325,8 @@ void ESP32BLE::loop() {
       default:
         break;
     }
-    delete ble_event;  // NOLINT(cppcoreguidelines-owning-memory)
+    ble_event->~BLEEvent();
+    EVENT_ALLOCATOR.deallocate(ble_event, 1);
     ble_event = this->ble_events_.pop();
   }
   if (this->advertising_ != nullptr) {
@@ -331,9 +335,14 @@ void ESP32BLE::loop() {
 }
 
 void ESP32BLE::gap_event_handler(esp_gap_ble_cb_event_t event, esp_ble_gap_cb_param_t *param) {
-  BLEEvent *new_event = new BLEEvent(event, param);  // NOLINT(cppcoreguidelines-owning-memory)
+  BLEEvent *new_event = EVENT_ALLOCATOR.allocate(1);
+  if (new_event == nullptr) {
+    // Memory too fragmented to allocate new event. Can only drop it until memory comes back
+    return;
+  }
+  new (new_event) BLEEvent(event, param);
   global_ble->ble_events_.push(new_event);
-}  // NOLINT(clang-analyzer-cplusplus.NewDeleteLeaks)
+}  // NOLINT(clang-analyzer-unix.Malloc)
 
 void ESP32BLE::real_gap_event_handler_(esp_gap_ble_cb_event_t event, esp_ble_gap_cb_param_t *param) {
   ESP_LOGV(TAG, "(BLE) gap_event_handler - %d", event);
@@ -344,9 +353,14 @@ void ESP32BLE::real_gap_event_handler_(esp_gap_ble_cb_event_t event, esp_ble_gap
 
 void ESP32BLE::gatts_event_handler(esp_gatts_cb_event_t event, esp_gatt_if_t gatts_if,
                                    esp_ble_gatts_cb_param_t *param) {
-  BLEEvent *new_event = new BLEEvent(event, gatts_if, param);  // NOLINT(cppcoreguidelines-owning-memory)
+  BLEEvent *new_event = EVENT_ALLOCATOR.allocate(1);
+  if (new_event == nullptr) {
+    // Memory too fragmented to allocate new event. Can only drop it until memory comes back
+    return;
+  }
+  new (new_event) BLEEvent(event, gatts_if, param);
   global_ble->ble_events_.push(new_event);
-}  // NOLINT(clang-analyzer-cplusplus.NewDeleteLeaks)
+}  // NOLINT(clang-analyzer-unix.Malloc)
 
 void ESP32BLE::real_gatts_event_handler_(esp_gatts_cb_event_t event, esp_gatt_if_t gatts_if,
                                          esp_ble_gatts_cb_param_t *param) {
@@ -358,9 +372,14 @@ void ESP32BLE::real_gatts_event_handler_(esp_gatts_cb_event_t event, esp_gatt_if
 
 void ESP32BLE::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if,
                                    esp_ble_gattc_cb_param_t *param) {
-  BLEEvent *new_event = new BLEEvent(event, gattc_if, param);  // NOLINT(cppcoreguidelines-owning-memory)
+  BLEEvent *new_event = EVENT_ALLOCATOR.allocate(1);
+  if (new_event == nullptr) {
+    // Memory too fragmented to allocate new event. Can only drop it until memory comes back
+    return;
+  }
+  new (new_event) BLEEvent(event, gattc_if, param);
   global_ble->ble_events_.push(new_event);
-}  // NOLINT(clang-analyzer-cplusplus.NewDeleteLeaks)
+}  // NOLINT(clang-analyzer-unix.Malloc)
 
 void ESP32BLE::real_gattc_event_handler_(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if,
                                          esp_ble_gattc_cb_param_t *param) {

--- a/esphome/components/font/__init__.py
+++ b/esphome/components/font/__init__.py
@@ -51,8 +51,11 @@ CONF_IGNORE_MISSING_GLYPHS = "ignore_missing_glyphs"
 # Cache loaded freetype fonts
 class FontCache(dict):
     def __missing__(self, key):
-        res = self[key] = freetype.Face(key)
-        return res
+        try:
+            res = self[key] = freetype.Face(key)
+            return res
+        except freetype.FT_Exception as e:
+            raise cv.Invalid(f"Could not load Font file {key}: {e}") from e
 
 
 FONT_CACHE = FontCache()

--- a/esphome/const.py
+++ b/esphome/const.py
@@ -1,6 +1,6 @@
 """Constants used by esphome."""
 
-__version__ = "2024.12.0b2"
+__version__ = "2024.12.0b3"
 
 ALLOWED_NAME_CHARS = "abcdefghijklmnopqrstuvwxyz0123456789-_"
 VALID_SUBSTITUTIONS_CHARACTERS = (

--- a/esphome/dashboard/web_server.py
+++ b/esphome/dashboard/web_server.py
@@ -108,6 +108,12 @@ def is_authenticated(handler: BaseHandler) -> bool:
             return True
 
     if settings.using_auth:
+        if auth_header := handler.request.headers.get("Authorization"):
+            assert isinstance(auth_header, str)
+            if auth_header.startswith("Basic "):
+                auth_decoded = base64.b64decode(auth_header[6:]).decode()
+                username, password = auth_decoded.split(":", 1)
+                return settings.check_password(username, password)
         return handler.get_secure_cookie(AUTH_COOKIE_NAME) == COOKIE_AUTHENTICATED_YES
 
     return True

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ pyserial==3.5
 platformio==6.1.16  # When updating platformio, also update Dockerfile
 esptool==4.7.0
 click==8.1.7
-esphome-dashboard==20241120.0
+esphome-dashboard==20241217.1
 aioesphomeapi==24.6.2
 zeroconf==0.132.2
 puremagic==1.27


### PR DESCRIPTION
**Do not merge, release script will automatically merge**
## Full list of changes

### All changes

- [font] cleanly handle font file format exception (Bugfix) [esphome#7970](https://github.com/esphome/esphome/pull/7970)
- [dashboard] Accept basic auth header [esphome#7965](https://github.com/esphome/esphome/pull/7965)
- Bump esphome-dashboard to 20241217.1 [esphome#7971](https://github.com/esphome/esphome/pull/7971)
- [esp32_ble] Use RAMAllocator to avoid panic abort from ``new`` [esphome#7936](https://github.com/esphome/esphome/pull/7936)

<details>
<summary>Metadata</summary>

@coderabbitai ignore
</details>
