### PR TITLE
[helpers] Provide calls to get free heap and largest available block.

### DIFF
--- a/esphome/components/json/json_util.cpp
+++ b/esphome/components/json/json_util.cpp
@@ -7,7 +7,7 @@ namespace json {
 static const char *const TAG = "json";
 
 static std::vector<char> global_json_build_buffer;  // NOLINT
-static auto allocator = RAMAllocator<uint8_t>(RAMAllocator<uint8_t>::ALLOC_INTERNAL);
+static const auto allocator = RAMAllocator<uint8_t>(RAMAllocator<uint8_t>::ALLOC_INTERNAL);
 
 std::string build_json(const json_build_t &f) {
   // Here we are allocating up to 5kb of memory,

--- a/esphome/components/json/json_util.cpp
+++ b/esphome/components/json/json_util.cpp
@@ -1,38 +1,20 @@
 #include "json_util.h"
 #include "esphome/core/log.h"
 
-#ifdef USE_ESP8266
-#include <Esp.h>
-#endif
-#ifdef USE_ESP32
-#include <esp_heap_caps.h>
-#endif
-#ifdef USE_RP2040
-#include <Arduino.h>
-#endif
-
 namespace esphome {
 namespace json {
 
 static const char *const TAG = "json";
 
 static std::vector<char> global_json_build_buffer;  // NOLINT
+static auto allocator = RAMAllocator<uint8_t>(RAMAllocator<uint8_t>::ALLOC_INTERNAL);
 
 std::string build_json(const json_build_t &f) {
   // Here we are allocating up to 5kb of memory,
   // with the heap size minus 2kb to be safe if less than 5kb
   // as we can not have a true dynamic sized document.
   // The excess memory is freed below with `shrinkToFit()`
-#ifdef USE_ESP8266
-  const size_t free_heap = ESP.getMaxFreeBlockSize();  // NOLINT(readability-static-accessed-through-instance)
-#elif defined(USE_ESP32)
-  const size_t free_heap = heap_caps_get_largest_free_block(MALLOC_CAP_8BIT);
-#elif defined(USE_RP2040)
-  const size_t free_heap = rp2040.getFreeHeap();
-#elif defined(USE_LIBRETINY)
-  const size_t free_heap = lt_heap_get_free();
-#endif
-
+  auto free_heap = allocator.get_max_free_block_size();
   size_t request_size = std::min(free_heap, (size_t) 512);
   while (true) {
     ESP_LOGV(TAG, "Attempting to allocate %u bytes for JSON serialization", request_size);
@@ -67,20 +49,12 @@ bool parse_json(const std::string &data, const json_parse_t &f) {
   // with the heap size minus 2kb to be safe if less than that
   // as we can not have a true dynamic sized document.
   // The excess memory is freed below with `shrinkToFit()`
-#ifdef USE_ESP8266
-  const size_t free_heap = ESP.getMaxFreeBlockSize();  // NOLINT(readability-static-accessed-through-instance)
-#elif defined(USE_ESP32)
-  const size_t free_heap = heap_caps_get_largest_free_block(MALLOC_CAP_8BIT);
-#elif defined(USE_RP2040)
-  const size_t free_heap = rp2040.getFreeHeap();
-#elif defined(USE_LIBRETINY)
-  const size_t free_heap = lt_heap_get_free();
-#endif
+  auto free_heap = allocator.get_max_free_block_size();
   size_t request_size = std::min(free_heap, (size_t) (data.size() * 1.5));
   while (true) {
     DynamicJsonDocument json_document(request_size);
     if (json_document.capacity() == 0) {
-      ESP_LOGE(TAG, "Could not allocate memory for JSON document! Requested %u bytes, free heap: %u", request_size,
+      ESP_LOGE(TAG, "Could not allocate memory for JSON document! Requested %zu bytes, free heap: %zu", request_size,
                free_heap);
       return false;
     }

--- a/esphome/components/json/json_util.cpp
+++ b/esphome/components/json/json_util.cpp
@@ -7,14 +7,14 @@ namespace json {
 static const char *const TAG = "json";
 
 static std::vector<char> global_json_build_buffer;  // NOLINT
-static const auto allocator = RAMAllocator<uint8_t>(RAMAllocator<uint8_t>::ALLOC_INTERNAL);
+static const auto ALLOCATOR = RAMAllocator<uint8_t>(RAMAllocator<uint8_t>::ALLOC_INTERNAL);
 
 std::string build_json(const json_build_t &f) {
   // Here we are allocating up to 5kb of memory,
   // with the heap size minus 2kb to be safe if less than 5kb
   // as we can not have a true dynamic sized document.
   // The excess memory is freed below with `shrinkToFit()`
-  auto free_heap = allocator.get_max_free_block_size();
+  auto free_heap = ALLOCATOR.get_max_free_block_size();
   size_t request_size = std::min(free_heap, (size_t) 512);
   while (true) {
     ESP_LOGV(TAG, "Attempting to allocate %u bytes for JSON serialization", request_size);
@@ -49,7 +49,7 @@ bool parse_json(const std::string &data, const json_parse_t &f) {
   // with the heap size minus 2kb to be safe if less than that
   // as we can not have a true dynamic sized document.
   // The excess memory is freed below with `shrinkToFit()`
-  auto free_heap = allocator.get_max_free_block_size();
+  auto free_heap = ALLOCATOR.get_max_free_block_size();
   size_t request_size = std::min(free_heap, (size_t) (data.size() * 1.5));
   while (true) {
     DynamicJsonDocument json_document(request_size);

--- a/esphome/components/online_image/online_image.cpp
+++ b/esphome/components/online_image/online_image.cpp
@@ -80,15 +80,7 @@ bool OnlineImage::resize_(int width_in, int height_in) {
     this->width_ = width;
     ESP_LOGD(TAG, "New size: (%d, %d)", width, height);
   } else {
-#if defined(USE_ESP8266)
-    // NOLINTNEXTLINE(readability-static-accessed-through-instance)
-    int max_block = ESP.getMaxFreeBlockSize();
-#elif defined(USE_ESP32)
-    int max_block = heap_caps_get_largest_free_block(MALLOC_CAP_INTERNAL);
-#else
-    int max_block = -1;
-#endif
-    ESP_LOGE(TAG, "allocation failed. Biggest block in heap: %d Bytes", max_block);
+    ESP_LOGE(TAG, "allocation failed. Biggest block in heap: %zu Bytes", this->allocator_.get_max_free_block_size());
     this->end_connection_();
     return false;
   }

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -11,6 +11,14 @@
 
 #include "esphome/core/optional.h"
 
+#ifdef USE_ESP8266
+#include <Esp.h>
+#endif
+
+#ifdef USE_RP2040
+#include <Arduino.h>
+#endif
+
 #ifdef USE_ESP32
 #include <esp_heap_caps.h>
 #endif
@@ -684,7 +692,12 @@ template<class T> class RAMAllocator {
   };
 
   RAMAllocator() = default;
-  RAMAllocator(uint8_t flags) : flags_{flags} {}
+  RAMAllocator(uint8_t flags) {
+    // default is both external and internal
+    flags &= ALLOC_INTERNAL | ALLOC_EXTERNAL;
+    if (flags != 0)
+      this->flags_ = flags;
+  }
   template<class U> constexpr RAMAllocator(const RAMAllocator<U> &other) : flags_{other.flags_} {}
 
   T *allocate(size_t n) {
@@ -692,11 +705,11 @@ template<class T> class RAMAllocator {
     T *ptr = nullptr;
 #ifdef USE_ESP32
     // External allocation by default or if explicitely requested
-    if ((this->flags_ & Flags::ALLOC_EXTERNAL) || ((this->flags_ & Flags::ALLOC_INTERNAL) == 0)) {
+    if (this->flags_ & Flags::ALLOC_EXTERNAL) {
       ptr = static_cast<T *>(heap_caps_malloc(size, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT));
     }
-    // Fallback to internal allocation if explicitely requested or no flag is specified
-    if (ptr == nullptr && ((this->flags_ & Flags::ALLOC_INTERNAL) || (this->flags_ & Flags::ALLOC_EXTERNAL) == 0)) {
+    // Fallback to internal allocation if explicitly requested or no flag is specified
+    if (ptr == nullptr && this->flags_ & Flags::ALLOC_INTERNAL) {
       ptr = static_cast<T *>(malloc(size));  // NOLINT(cppcoreguidelines-owning-memory,cppcoreguidelines-no-malloc)
     }
 #else
@@ -710,8 +723,46 @@ template<class T> class RAMAllocator {
     free(p);  // NOLINT(cppcoreguidelines-owning-memory,cppcoreguidelines-no-malloc)
   }
 
+  /**
+   * Return the total heap space available via this allocator
+   */
+  size_t get_free_heap_size() const {
+#ifdef USE_ESP8266
+    return ESP.getFreeHeap();  // NOLINT(readability-static-accessed-through-instance)
+#elif defined(USE_ESP32)
+    auto max_internal =
+        this->flags_ & ALLOC_INTERNAL ? heap_caps_get_free_size(MALLOC_CAP_8BIT | MALLOC_CAP_INTERNAL) : 0;
+    auto max_external =
+        this->flags_ & ALLOC_EXTERNAL ? heap_caps_get_free_size(MALLOC_CAP_8BIT | MALLOC_CAP_SPIRAM) : 0;
+    return std::max(max_internal, max_external);
+#elif defined(USE_RP2040)
+    return ::rp2040.getFreeHeap();
+#elif defined(USE_LIBRETINY)
+    return lt_heap_get_free();
+#else
+    return 100000;
+#endif
+  }
+
+  /**
+   * Return the maximum size block this allocator could allocate. This may be an approximation on some platforms
+   */
+  size_t get_max_free_block_size() const {
+#ifdef USE_ESP8266
+    return ESP.getMaxFreeBlockSize();  // NOLINT(readability-static-accessed-through-instance)
+#elif defined(USE_ESP32)
+    auto max_internal =
+        this->flags_ & ALLOC_INTERNAL ? heap_caps_get_largest_free_block(MALLOC_CAP_8BIT | MALLOC_CAP_INTERNAL) : 0;
+    auto max_external =
+        this->flags_ & ALLOC_EXTERNAL ? heap_caps_get_largest_free_block(MALLOC_CAP_8BIT | MALLOC_CAP_SPIRAM) : 0;
+    return std::max(max_internal, max_external);
+#else
+    return this->get_free_heap_size();
+#endif
+  }
+
  private:
-  uint8_t flags_{Flags::ALLOW_FAILURE};
+  uint8_t flags_{ALLOC_INTERNAL | ALLOC_EXTERNAL};
 };
 
 template<class T> using ExternalRAMAllocator = RAMAllocator<T>;

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -732,7 +732,7 @@ template<class T> class RAMAllocator {
         this->flags_ & ALLOC_INTERNAL ? heap_caps_get_free_size(MALLOC_CAP_8BIT | MALLOC_CAP_INTERNAL) : 0;
     auto max_external =
         this->flags_ & ALLOC_EXTERNAL ? heap_caps_get_free_size(MALLOC_CAP_8BIT | MALLOC_CAP_SPIRAM) : 0;
-    return std::max(max_internal, max_external);
+    return max_internal + max_external;
 #elif defined(USE_RP2040)
     return ::rp2040.getFreeHeap();
 #elif defined(USE_LIBRETINY)

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -704,13 +704,11 @@ template<class T> class RAMAllocator {
     size_t size = n * sizeof(T);
     T *ptr = nullptr;
 #ifdef USE_ESP32
-    // External allocation by default or if explicitely requested
     if (this->flags_ & Flags::ALLOC_EXTERNAL) {
       ptr = static_cast<T *>(heap_caps_malloc(size, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT));
     }
-    // Fallback to internal allocation if explicitly requested or no flag is specified
     if (ptr == nullptr && this->flags_ & Flags::ALLOC_INTERNAL) {
-      ptr = static_cast<T *>(malloc(size));  // NOLINT(cppcoreguidelines-owning-memory,cppcoreguidelines-no-malloc)
+      ptr = static_cast<T *>(heap_caps_malloc(size, MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT));
     }
 #else
     // Ignore ALLOC_EXTERNAL/ALLOC_INTERNAL flags if external allocation is not supported


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040
- [x] BK72xx
- [x] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
