### PR TITLE
web_server: Adds REST API POST endpoints to arm and disarm

### DIFF
--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -1415,6 +1415,30 @@ void WebServer::handle_alarm_control_panel_request(AsyncWebServerRequest *reques
       request->send(200, "application/json", data.c_str());
       return;
     }
+
+    auto call = obj->make_call();
+    if (request->hasParam("code")) {
+      call.set_code(request->getParam("code")->value().c_str());
+    }
+
+    if (match.method == "disarm") {
+      call.disarm();
+    } else if (match.method == "arm_away") {
+      call.arm_away();
+    } else if (match.method == "arm_home") {
+      call.arm_home();
+    } else if (match.method == "arm_night") {
+      call.arm_night();
+    } else if (match.method == "arm_vacation") {
+      call.arm_vacation();
+    } else {
+      request->send(404);
+      return;
+    }
+
+    this->schedule_([call]() mutable { call.perform(); });
+    request->send(200);
+    return;
   }
   request->send(404);
 }
@@ -1664,7 +1688,7 @@ bool WebServer::canHandle(AsyncWebServerRequest *request) {
 #endif
 
 #ifdef USE_ALARM_CONTROL_PANEL
-  if (request->method() == HTTP_GET && match.domain == "alarm_control_panel")
+  if ((request->method() == HTTP_GET || request->method() == HTTP_POST) && match.domain == "alarm_control_panel")
     return true;
 #endif
 


### PR DESCRIPTION
# What does this implement/fix?

Adds POST endpoints to the REST API to issue arming and disarming commands to an Alarm Control Panel component.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#4517

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
binary_sensor:
  - id: zone1
    name: Zone 1
    pin:
      number: GPIO4
      mode: INPUT_PULLUP
    platform: gpio   
  - id: zone2
    name: Zone 2
    pin:
      number: GPIO2
      mode: INPUT_PULLUP
    platform: gpio   

alarm_control_panel:
  platform: template
  name: My Alarm
  codes:
  - '1234'
  binary_sensors:
  - input: zone1
  - input: zone2

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
