### PR TITLE
[display] auto_clear_enabled defaults 

### DIFF
--- a/esphome/components/display/__init__.py
+++ b/esphome/components/display/__init__.py
@@ -39,6 +39,7 @@ DisplayOnPageChangeTrigger = display_ns.class_(
 
 CONF_ON_PAGE_CHANGE = "on_page_change"
 CONF_SHOW_TEST_CARD = "show_test_card"
+CONF_UNSPECIFIED = "unspecified"
 
 DISPLAY_ROTATIONS = {
     0: display_ns.DISPLAY_ROTATION_0_DEGREES,
@@ -55,16 +56,22 @@ def validate_rotation(value):
     return cv.enum(DISPLAY_ROTATIONS, int=True)(value)
 
 
+def validate_auto_clear(value):
+    if value == CONF_UNSPECIFIED:
+        return value
+    return cv.boolean(value)
+
+
 BASIC_DISPLAY_SCHEMA = cv.Schema(
     {
-        cv.Optional(CONF_LAMBDA): cv.lambda_,
+        cv.Exclusive(CONF_LAMBDA, CONF_LAMBDA): cv.lambda_,
     }
 ).extend(cv.polling_component_schema("1s"))
 
 FULL_DISPLAY_SCHEMA = BASIC_DISPLAY_SCHEMA.extend(
     {
         cv.Optional(CONF_ROTATION): validate_rotation,
-        cv.Optional(CONF_PAGES): cv.All(
+        cv.Exclusive(CONF_PAGES, CONF_LAMBDA): cv.All(
             cv.ensure_list(
                 {
                     cv.GenerateID(): cv.declare_id(DisplayPage),
@@ -82,7 +89,9 @@ FULL_DISPLAY_SCHEMA = BASIC_DISPLAY_SCHEMA.extend(
                 cv.Optional(CONF_TO): cv.use_id(DisplayPage),
             }
         ),
-        cv.Optional(CONF_AUTO_CLEAR_ENABLED, default=True): cv.boolean,
+        cv.Optional(
+            CONF_AUTO_CLEAR_ENABLED, default=CONF_UNSPECIFIED
+        ): validate_auto_clear,
         cv.Optional(CONF_SHOW_TEST_CARD): cv.boolean,
     }
 )
@@ -92,8 +101,12 @@ async def setup_display_core_(var, config):
     if CONF_ROTATION in config:
         cg.add(var.set_rotation(DISPLAY_ROTATIONS[config[CONF_ROTATION]]))
 
-    if CONF_AUTO_CLEAR_ENABLED in config:
-        cg.add(var.set_auto_clear(config[CONF_AUTO_CLEAR_ENABLED]))
+    if auto_clear := config.get(CONF_AUTO_CLEAR_ENABLED):
+        # Default to true if pages or lambda is specified. Ideally this would be done during validation, but
+        # the possible schemas are too complex to do this easily.
+        if auto_clear == CONF_UNSPECIFIED:
+            auto_clear = CONF_LAMBDA in config or CONF_PAGES in config
+        cg.add(var.set_auto_clear(auto_clear))
 
     if CONF_PAGES in config:
         pages = []

--- a/esphome/components/lvgl/__init__.py
+++ b/esphome/components/lvgl/__init__.py
@@ -197,11 +197,11 @@ def final_validation(configs):
         for display_id in config[df.CONF_DISPLAYS]:
             path = global_config.get_path_for_id(display_id)[:-1]
             display = global_config.get_config_for_path(path)
-            if CONF_LAMBDA in display:
+            if CONF_LAMBDA in display or CONF_PAGES in display:
                 raise cv.Invalid(
-                    "Using lambda: in display config not compatible with LVGL"
+                    "Using lambda: or pages: in display config is not compatible with LVGL"
                 )
-            if display[CONF_AUTO_CLEAR_ENABLED]:
+            if display.get(CONF_AUTO_CLEAR_ENABLED) is True:
                 raise cv.Invalid(
                     "Using auto_clear_enabled: true in display config not compatible with LVGL"
                 )

--- a/tests/components/lvgl/test.host.yaml
+++ b/tests/components/lvgl/test.host.yaml
@@ -7,7 +7,6 @@ display:
       height: 320
   - platform: sdl
     id: sdl1
-    auto_clear_enabled: false
     dimensions:
       width: 480
       height: 480
@@ -40,4 +39,3 @@ lvgl:
                 text: Click ME
           on_click:
             logger.log: Clicked
-


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

The `auto_clear_enabled` flag for a display config defaults to true; this is unwanted for LVGL, so currently requires the user to explicitly set it to false. Instead, default to true only if the display config includes a drawing lambda or pages.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#4522

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [x] host
## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
