### PR TITLE
[addressable_light] Remove rmt channel from idf tests

### DIFF
--- a/tests/components/addressable_light/test.esp32-c3-idf.yaml
+++ b/tests/components/addressable_light/test.esp32-c3-idf.yaml
@@ -6,7 +6,6 @@ light:
     rgb_order: GRB
     num_leds: 256
     pin: 2
-    rmt_channel: 0
 
 display:
   - platform: addressable_light

--- a/tests/components/addressable_light/test.esp32-idf.yaml
+++ b/tests/components/addressable_light/test.esp32-idf.yaml
@@ -6,7 +6,6 @@ light:
     rgb_order: GRB
     num_leds: 256
     pin: 2
-    rmt_channel: 0
 
 display:
   - platform: addressable_light


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Fixes CI failure triggered by #7770 

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
