### PR TITLE
Fixed libretiny preference wrongly detecting change in the data to store

### DIFF
--- a/esphome/components/libretiny/preferences.cpp
+++ b/esphome/components/libretiny/preferences.cpp
@@ -147,7 +147,7 @@ class LibreTinyPreferences : public ESPPreferences {
       ESP_LOGV(TAG, "fdb_kv_get_obj('%s'): nullptr - the key might not be set yet", to_save.key.c_str());
       return true;
     }
-    stored_data.data.reserve(kv.value_len);
+    stored_data.data.resize(kv.value_len);
     fdb_blob_make(&blob, stored_data.data.data(), kv.value_len);
     size_t actual_len = fdb_kv_get_blob(db, to_save.key.c_str(), &blob);
     if (actual_len != kv.value_len) {


### PR DESCRIPTION
# What does this implement/fix?
stored_data.data was never properly resized and the pointer returned by stored_data.data.data() was invalid, so fetching data from flash always failed. Thus also the is_changed() method always returned true, forcing frequent flash writes.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**
- fixes esphome/issues#6585

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [x] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
