### PR TITLE
[esp32_wifi] Enhance WiFi component with TCPIP core locking.

### DIFF
--- a/esphome/components/wifi/wifi_component_esp32_arduino.cpp
+++ b/esphome/components/wifi/wifi_component_esp32_arduino.cpp
@@ -15,6 +15,10 @@
 #include "lwip/dns.h"
 #include "lwip/err.h"
 
+#ifdef CONFIG_LWIP_TCPIP_CORE_LOCKING
+#include "lwip/priv/tcpip_priv.h"
+#endif
+
 #include "esphome/core/application.h"
 #include "esphome/core/hal.h"
 #include "esphome/core/helpers.h"
@@ -286,10 +290,25 @@ bool WiFiComponent::wifi_sta_ip_config_(optional<ManualIP> manual_ip) {
   }
 
   if (!manual_ip.has_value()) {
+// sntp_servermode_dhcp lwip/sntp.c (Required to lock TCPIP core functionality!)
+// https://github.com/esphome/issues/issues/6591
+// https://github.com/espressif/arduino-esp32/issues/10526
+#ifdef CONFIG_LWIP_TCPIP_CORE_LOCKING
+    if (!sys_thread_tcpip(LWIP_CORE_LOCK_QUERY_HOLDER)) {
+      LOCK_TCPIP_CORE();
+    }
+#endif
+
     // lwIP starts the SNTP client if it gets an SNTP server from DHCP. We don't need the time, and more importantly,
     // the built-in SNTP client has a memory leak in certain situations. Disable this feature.
     // https://github.com/esphome/issues/issues/2299
     sntp_servermode_dhcp(false);
+
+#ifdef CONFIG_LWIP_TCPIP_CORE_LOCKING
+    if (sys_thread_tcpip(LWIP_CORE_LOCK_QUERY_HOLDER)) {
+      UNLOCK_TCPIP_CORE();
+    }
+#endif
 
     // No manual IP is set; use DHCP client
     if (dhcp_status != ESP_NETIF_DHCP_STARTED) {


### PR DESCRIPTION
[esp32_wifi] Enhance WiFi component with TCPIP core locking.

# What does this implement/fix?
assert failed: sntp_servermode_dhcp sntp.c:770 (Required to lock TCPIP core functionality!) .

This is broken with future versions, but we can fix it now to split up the PRs.

RECOMMENDED_ESP_IDF_FRAMEWORK_VERSION = cv.Version(5, 3, 2)
ESP_IDF_PLATFORM_VERSION = cv.Version(53, 3, 10)

esp32:
  board: esp32dev
  framework:
    type: arduino
    platform_version: https://github.com/pioarduino/platform-espressif32


<!-- Quick description and explanation of changes -->
Following advice here:  https://github.com/espressif/arduino-esp32/issues/10526
Add:
 LOCK_TCPIP_CORE
 UNLOCK_TCPIP_CORE
 
## Types of changes

- [ x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>
https://github.com/esphome/issues/issues/6591

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

Verified uploads and runs on esp32s3.  Wifi connects and able to toggle a switch on the dashboad of HA.

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
esp32:
  board: seeed_xiao_esp32c6
  framework:
    type: arduino
    platform_version: https://github.com/pioarduino/platform-espressif32


```

## Checklist:
  - [x ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
