### PR TITLE
Include esp_mac.h and C++20 str_startswith/str_ends

### DIFF
--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -45,7 +45,9 @@
 #endif
 #ifdef USE_ESP32
 #include "esp32/rom/crc.h"
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 3, 2)
 #include "esp_mac.h"
+#endif
 #include "esp_efuse.h"
 #include "esp_efuse_table.h"
 #endif

--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -45,7 +45,7 @@
 #endif
 #ifdef USE_ESP32
 #include "esp32/rom/crc.h"
-
+#include "esp_mac.h"
 #include "esp_efuse.h"
 #include "esp_efuse_table.h"
 #endif
@@ -259,7 +259,7 @@ bool random_bytes(uint8_t *data, size_t len) {
 bool str_equals_case_insensitive(const std::string &a, const std::string &b) {
   return strcasecmp(a.c_str(), b.c_str()) == 0;
 }
-#if ESP_IDF_VERSION_MAJOR >= 5
+#if __cplusplus >= 202002L
 bool str_startswith(const std::string &str, const std::string &start) { return str.starts_with(start); }
 bool str_endswith(const std::string &str, const std::string &end) { return str.ends_with(end); }
 #else


### PR DESCRIPTION
# What does this implement/fix?

Compile errors with 
"platformio/toolchain-riscv32-esp@13.2.0+20240530",

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ x ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ x ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ x ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
