### PR TITLE
[esp32_rmt] IDF 5+ update fixes

### DIFF
--- a/esphome/components/remote_receiver/remote_receiver_esp32.cpp
+++ b/esphome/components/remote_receiver/remote_receiver_esp32.cpp
@@ -154,16 +154,16 @@ void RemoteReceiverComponent::setup() {
 void RemoteReceiverComponent::dump_config() {
   ESP_LOGCONFIG(TAG, "Remote Receiver:");
   LOG_PIN("  Pin: ", this->pin_);
-  if (this->pin_->digital_read()) {
-    ESP_LOGW(TAG, "Remote Receiver Signal starts with a HIGH value. Usually this means you have to "
-                  "invert the signal using 'inverted: True' in the pin schema!");
-  }
 #if ESP_IDF_VERSION_MAJOR >= 5
   ESP_LOGCONFIG(TAG, "  Clock resolution: %" PRIu32 " hz", this->clock_resolution_);
   ESP_LOGCONFIG(TAG, "  RMT symbols: %" PRIu32, this->rmt_symbols_);
   ESP_LOGCONFIG(TAG, "  Filter symbols: %" PRIu32, this->filter_symbols_);
   ESP_LOGCONFIG(TAG, "  Receive symbols: %" PRIu32, this->receive_symbols_);
 #else
+  if (this->pin_->digital_read()) {
+    ESP_LOGW(TAG, "Remote Receiver Signal starts with a HIGH value. Usually this means you have to "
+                  "invert the signal using 'inverted: True' in the pin schema!");
+  }
   ESP_LOGCONFIG(TAG, "  Channel: %d", this->channel_);
   ESP_LOGCONFIG(TAG, "  RMT memory blocks: %d", this->mem_block_num_);
   ESP_LOGCONFIG(TAG, "  Clock divider: %u", this->clock_divider_);

--- a/esphome/components/remote_transmitter/__init__.py
+++ b/esphome/components/remote_transmitter/__init__.py
@@ -7,6 +7,7 @@ from esphome.const import (
     CONF_CLOCK_DIVIDER,
     CONF_CLOCK_RESOLUTION,
     CONF_ID,
+    CONF_INVERTED,
     CONF_PIN,
     CONF_RMT_CHANNEL,
     CONF_RMT_SYMBOLS,
@@ -16,6 +17,7 @@ from esphome.core import CORE
 
 AUTO_LOAD = ["remote_base"]
 
+CONF_EOT_LEVEL = "eot_level"
 CONF_ON_TRANSMIT = "on_transmit"
 CONF_ON_COMPLETE = "on_complete"
 CONF_ONE_WIRE = "one_wire"
@@ -41,6 +43,7 @@ CONFIG_SCHEMA = cv.Schema(
         cv.Optional(CONF_CLOCK_DIVIDER): cv.All(
             cv.only_on_esp32, cv.only_with_arduino, cv.int_range(min=1, max=255)
         ),
+        cv.Optional(CONF_EOT_LEVEL): cv.All(cv.only_with_esp_idf, cv.boolean),
         cv.Optional(CONF_ONE_WIRE): cv.All(cv.only_with_esp_idf, cv.boolean),
         cv.Optional(CONF_USE_DMA): cv.All(cv.only_with_esp_idf, cv.boolean),
         cv.SplitDefault(
@@ -73,6 +76,12 @@ async def to_code(config):
                 cg.add(var.set_with_dma(config[CONF_USE_DMA]))
             if CONF_ONE_WIRE in config:
                 cg.add(var.set_one_wire(config[CONF_ONE_WIRE]))
+            if CONF_EOT_LEVEL in config:
+                cg.add(var.set_eot_level(config[CONF_EOT_LEVEL]))
+            elif CONF_ONE_WIRE in config and config[CONF_ONE_WIRE]:
+                cg.add(var.set_eot_level(True))
+            elif CONF_INVERTED in config[CONF_PIN] and config[CONF_PIN][CONF_INVERTED]:
+                cg.add(var.set_eot_level(True))
         else:
             if (rmt_channel := config.get(CONF_RMT_CHANNEL, None)) is not None:
                 var = cg.new_Pvariable(config[CONF_ID], pin, rmt_channel)

--- a/esphome/components/remote_transmitter/remote_transmitter.h
+++ b/esphome/components/remote_transmitter/remote_transmitter.h
@@ -70,6 +70,7 @@ class RemoteTransmitterComponent : public remote_base::RemoteTransmitterBase,
   bool one_wire_{false};
   rmt_channel_handle_t channel_{NULL};
   rmt_encoder_handle_t encoder_{NULL};
+  rmt_transmit_config_t transmit_;
 #else
   std::vector<rmt_item32_t> rmt_temp_;
 #endif

--- a/esphome/components/remote_transmitter/remote_transmitter.h
+++ b/esphome/components/remote_transmitter/remote_transmitter.h
@@ -41,6 +41,8 @@ class RemoteTransmitterComponent : public remote_base::RemoteTransmitterBase,
 #if defined(USE_ESP32) && ESP_IDF_VERSION_MAJOR >= 5
   void set_with_dma(bool with_dma) { this->with_dma_ = with_dma; }
   void set_one_wire(bool one_wire) { this->one_wire_ = one_wire; }
+  void set_eot_level(bool eot_level) { this->eot_level_ = eot_level; }
+  void digital_write(bool value);
 #endif
 
   Trigger<> *get_transmit_trigger() const { return this->transmit_trigger_; };
@@ -68,9 +70,9 @@ class RemoteTransmitterComponent : public remote_base::RemoteTransmitterBase,
   std::vector<rmt_symbol_word_t> rmt_temp_;
   bool with_dma_{false};
   bool one_wire_{false};
+  bool eot_level_{false};
   rmt_channel_handle_t channel_{NULL};
   rmt_encoder_handle_t encoder_{NULL};
-  rmt_transmit_config_t transmit_;
 #else
   std::vector<rmt_item32_t> rmt_temp_;
 #endif

--- a/esphome/components/remote_transmitter/remote_transmitter_esp32.cpp
+++ b/esphome/components/remote_transmitter/remote_transmitter_esp32.cpp
@@ -84,7 +84,7 @@ void RemoteTransmitterComponent::configure_rmt_() {
       return;
     }
 
-    // setup transmit config and send a dummy symbol to set eot level
+    // setup transmit config and send a dummy symbol to apply eot level
     bool eot_level = this->one_wire_ || this->inverted_;
     memset(&this->transmit_, 0, sizeof(this->transmit_));
     this->transmit_.loop_count = 0;

--- a/esphome/components/remote_transmitter/remote_transmitter_esp32.cpp
+++ b/esphome/components/remote_transmitter/remote_transmitter_esp32.cpp
@@ -38,6 +38,7 @@ void RemoteTransmitterComponent::dump_config() {
   }
 }
 
+#if ESP_IDF_VERSION_MAJOR >= 5
 void RemoteTransmitterComponent::digital_write(bool value) {
   rmt_symbol_word_t symbol = {
       .duration0 = 1,
@@ -60,6 +61,7 @@ void RemoteTransmitterComponent::digital_write(bool value) {
     this->status_set_warning();
   }
 }
+#endif
 
 void RemoteTransmitterComponent::configure_rmt_() {
 #if ESP_IDF_VERSION_MAJOR >= 5

--- a/esphome/components/remote_transmitter/remote_transmitter_esp32.cpp
+++ b/esphome/components/remote_transmitter/remote_transmitter_esp32.cpp
@@ -109,7 +109,7 @@ void RemoteTransmitterComponent::configure_rmt_() {
       this->mark_failed();
       return;
     }
-    this->digital_write(this->eot_level_);
+    this->digital_write(this->one_wire_ || this->inverted_);
     this->initialized_ = true;
   }
 

--- a/esphome/components/remote_transmitter/remote_transmitter_esp32.cpp
+++ b/esphome/components/remote_transmitter/remote_transmitter_esp32.cpp
@@ -210,7 +210,7 @@ void RemoteTransmitterComponent::send_internal(uint32_t send_times, uint32_t sen
     rmt_transmit_config_t config;
     memset(&config, 0, sizeof(config));
     config.loop_count = 0;
-    config.flags.eot_level = this->inverted_;
+    config.flags.eot_level = this->one_wire_ || this->inverted_;
     esp_err_t error = rmt_transmit(this->channel_, this->encoder_, this->rmt_temp_.data(),
                                    this->rmt_temp_.size() * sizeof(rmt_symbol_word_t), &config);
     if (error != ESP_OK) {

--- a/esphome/components/remote_transmitter/remote_transmitter_esp32.cpp
+++ b/esphome/components/remote_transmitter/remote_transmitter_esp32.cpp
@@ -83,6 +83,32 @@ void RemoteTransmitterComponent::configure_rmt_() {
       this->mark_failed();
       return;
     }
+
+    // setup transmit config and send a dummy symbol to set eot level
+    bool eot_level = this->one_wire_ || this->inverted_;
+    memset(&this->transmit_, 0, sizeof(this->transmit_));
+    this->transmit_.loop_count = 0;
+    this->transmit_.flags.eot_level = eot_level;
+    rmt_symbol_word_t rmt_item = {
+        .duration0 = 1,
+        .level0 = eot_level,
+        .duration1 = 0,
+        .level1 = eot_level,
+    };
+    error = rmt_transmit(this->channel_, this->encoder_, &rmt_item, sizeof(rmt_item), &this->transmit_);
+    if (error != ESP_OK) {
+      this->error_code_ = error;
+      this->error_string_ = "in rmt_transmit";
+      this->mark_failed();
+      return;
+    }
+    error = rmt_tx_wait_all_done(this->channel_, -1);
+    if (error != ESP_OK) {
+      this->error_code_ = error;
+      this->error_string_ = "in rmt_tx_wait_all_done";
+      this->mark_failed();
+      return;
+    }
     this->initialized_ = true;
   }
 
@@ -207,12 +233,8 @@ void RemoteTransmitterComponent::send_internal(uint32_t send_times, uint32_t sen
   this->transmit_trigger_->trigger();
 #if ESP_IDF_VERSION_MAJOR >= 5
   for (uint32_t i = 0; i < send_times; i++) {
-    rmt_transmit_config_t config;
-    memset(&config, 0, sizeof(config));
-    config.loop_count = 0;
-    config.flags.eot_level = this->one_wire_ || this->inverted_;
     esp_err_t error = rmt_transmit(this->channel_, this->encoder_, this->rmt_temp_.data(),
-                                   this->rmt_temp_.size() * sizeof(rmt_symbol_word_t), &config);
+                                   this->rmt_temp_.size() * sizeof(rmt_symbol_word_t), &this->transmit_);
     if (error != ESP_OK) {
       ESP_LOGW(TAG, "rmt_transmit failed: %s", esp_err_to_name(error));
       this->status_set_warning();

--- a/esphome/components/remote_transmitter/remote_transmitter_esp32.cpp
+++ b/esphome/components/remote_transmitter/remote_transmitter_esp32.cpp
@@ -86,15 +86,15 @@ void RemoteTransmitterComponent::configure_rmt_() {
 
     // setup transmit config and send a dummy symbol to apply eot level
     bool eot_level = this->one_wire_ || this->inverted_;
-    memset(&this->transmit_, 0, sizeof(this->transmit_));
-    this->transmit_.loop_count = 0;
-    this->transmit_.flags.eot_level = eot_level;
     rmt_symbol_word_t rmt_item = {
         .duration0 = 1,
         .level0 = eot_level,
         .duration1 = 0,
         .level1 = eot_level,
     };
+    memset(&this->transmit_, 0, sizeof(this->transmit_));
+    this->transmit_.loop_count = 0;
+    this->transmit_.flags.eot_level = eot_level;
     error = rmt_transmit(this->channel_, this->encoder_, &rmt_item, sizeof(rmt_item), &this->transmit_);
     if (error != ESP_OK) {
       this->error_code_ = error;

--- a/esphome/components/remote_transmitter/remote_transmitter_esp32.cpp
+++ b/esphome/components/remote_transmitter/remote_transmitter_esp32.cpp
@@ -53,15 +53,11 @@ void RemoteTransmitterComponent::digital_write(bool value) {
   if (error != ESP_OK) {
     ESP_LOGW(TAG, "rmt_transmit failed: %s", esp_err_to_name(error));
     this->status_set_warning();
-  } else {
-    this->status_clear_warning();
   }
   error = rmt_tx_wait_all_done(this->channel_, -1);
   if (error != ESP_OK) {
     ESP_LOGW(TAG, "rmt_tx_wait_all_done failed: %s", esp_err_to_name(error));
     this->status_set_warning();
-  } else {
-    this->status_clear_warning();
   }
 }
 
@@ -251,8 +247,6 @@ void RemoteTransmitterComponent::send_internal(uint32_t send_times, uint32_t sen
     if (error != ESP_OK) {
       ESP_LOGW(TAG, "rmt_tx_wait_all_done failed: %s", esp_err_to_name(error));
       this->status_set_warning();
-    } else {
-      this->status_clear_warning();
     }
     if (i + 1 < send_times)
       delayMicroseconds(send_wait);


### PR DESCRIPTION
# What does this implement/fix?

Fix a few issues:
1. Remove the digital_read call from remote receiver as setup is not run on that pin and the warning is confusing when RF is being used. 
2. Don't clear warnings after rmt_tx_wait_all_done as it may hide errors in rmt_transmit.
3. Fix inverted mode in remote transmitter on IDF 5+
4. When one_wire mode is enabled the gpio is both an input and an output in open drain mode. The pin is actively driven low or passively pulled high by pull up. After a transmit is complete it is important to release the pin by setting the level to high in order to not actively drive the pin low and fight the receiver. By default eot_level will now be true if one_wire is enabled. This may be inconvenient though as the pin will be high before, after or between transmits. Provide a way to override eot_level and provide a function to manually set the level. 

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/issues/issues/6589
- related https://github.com/esphome/esphome/pull/7770 

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#4531

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

Here is an example of how one_wire mode could be used while still keeping the pin low before/after/between transmits. The pin is manually driven/released between rf mode changes. 

```yaml
remote_receiver:
  id: rx_id
  pin:
    number: GPIO32
    allow_other_uses: true
  filter: 100us
  idle: 800us
  rmt_symbols: 256
  receive_symbols: 256
  filter_symbols: 50

remote_transmitter:
  id: tx_id
  pin:
    number: GPIO32
    allow_other_uses: true
  one_wire: true
  eot_level: false
  carrier_duty_percent: 100%
  on_transmit:
    then:
      - rfchip.set_mode_standby
      - lambda: 'id(tx_id)->digital_write(false);'
      - rfchip.set_mode_tx
  on_complete:
    then:
      - rfchip.set_mode_standby
      - lambda: 'id(tx_id)->digital_write(true);'
      - rfchip.set_mode_rx
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
