### PR TITLE
[psram] Improve total PSRAM display in logs by using rounded KB values

### DIFF
--- a/esphome/components/psram/psram.cpp
+++ b/esphome/components/psram/psram.cpp
@@ -27,7 +27,7 @@ void PsramComponent::dump_config() {
     if (abs(round(psram_total_size_kb) - psram_total_size_kb) < 0.05f) {
       ESP_LOGCONFIG(TAG, "  Size: %.0f KB", psram_total_size_kb);
     } else {
-      ESP_LOGCONFIG(TAG, "  Size: %.0f bytes", (float)psram_total_size_bytes);
+      ESP_LOGCONFIG(TAG, "  Size: %.0f bytes", (float) psram_total_size_bytes);
     }
   }
 #endif

--- a/esphome/components/psram/psram.cpp
+++ b/esphome/components/psram/psram.cpp
@@ -27,7 +27,7 @@ void PsramComponent::dump_config() {
     if (abs(std::round(psram_total_size_kb) - psram_total_size_kb) < 0.05f) {
       ESP_LOGCONFIG(TAG, "  Size: %.0f KB", psram_total_size_kb);
     } else {
-      ESP_LOGCONFIG(TAG, "  Size: %.0f bytes", (float) psram_total_size_bytes);
+      ESP_LOGCONFIG(TAG, "  Size: %zu bytes", psram_total_size_bytes);
     }
   }
 #endif

--- a/esphome/components/psram/psram.cpp
+++ b/esphome/components/psram/psram.cpp
@@ -24,7 +24,7 @@ void PsramComponent::dump_config() {
     const size_t psram_total_size_bytes = heap_caps_get_total_size(MALLOC_CAP_SPIRAM);
     const float psram_total_size_kb = psram_total_size_bytes / 1024.0f;
 
-    if (abs(round(psram_total_size_kb) - psram_total_size_kb) < 0.05f) {
+    if (abs(std::round(psram_total_size_kb) - psram_total_size_kb) < 0.05f) {
       ESP_LOGCONFIG(TAG, "  Size: %.0f KB", psram_total_size_kb);
     } else {
       ESP_LOGCONFIG(TAG, "  Size: %.0f bytes", (float) psram_total_size_bytes);

--- a/esphome/components/psram/psram.cpp
+++ b/esphome/components/psram/psram.cpp
@@ -21,7 +21,14 @@ void PsramComponent::dump_config() {
   ESP_LOGCONFIG(TAG, "  Available: %s", YESNO(available));
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 1, 0)
   if (available) {
-    ESP_LOGCONFIG(TAG, "  Size: %d KB", heap_caps_get_total_size(MALLOC_CAP_SPIRAM) / 1024);
+    const size_t psram_total_size_bytes = heap_caps_get_total_size(MALLOC_CAP_SPIRAM);
+    const float psram_total_size_kb = psram_total_size_bytes / 1024.0f;
+
+    if (abs(round(psram_total_size_kb) - psram_total_size_kb) < 0.05f) {
+      ESP_LOGCONFIG(TAG, "  Size: %.0f KB", psram_total_size_kb);
+    } else {
+      ESP_LOGCONFIG(TAG, "  Size: %.0f bytes", (float)psram_total_size_bytes);
+    }
   }
 #endif
 }

--- a/tests/components/psram/test.esp32-s2-ard.yaml
+++ b/tests/components/psram/test.esp32-s2-ard.yaml
@@ -1,0 +1,1 @@
+<<: !include common.yaml

--- a/tests/components/psram/test.esp32-s2-idf.yaml
+++ b/tests/components/psram/test.esp32-s2-idf.yaml
@@ -1,0 +1,1 @@
+<<: !include common.yaml

--- a/tests/components/psram/test.esp32-s3-ard.yaml
+++ b/tests/components/psram/test.esp32-s3-ard.yaml
@@ -1,0 +1,1 @@
+<<: !include common.yaml

--- a/tests/components/psram/test.esp32-s3-idf.yaml
+++ b/tests/components/psram/test.esp32-s3-idf.yaml
@@ -1,0 +1,1 @@
+<<: !include common.yaml


### PR DESCRIPTION
# What does this implement/fix?

When displaying the total PSRAM size at the `dump_config`, round to the nearest KB value if within 0.05KB threshold. Otherwise show in bytes. This makes the logs clearer and more precise.

In a real case example, where `heap_caps_get_total_size(MALLOC_CAP_SPIRAM)` returns 2097151 bytes:

- Before: `Size: 2047 KB` (off by 1023 bytes)
- After: `Size: 2048 KB` (off by 1 byte)

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [X] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`: N/A

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
