### PR TITLE
[debug] Add framework type to debug info

### DIFF
--- a/esphome/components/debug/debug_esp32.cpp
+++ b/esphome/components/debug/debug_esp32.cpp
@@ -276,6 +276,19 @@ void DebugComponent::get_device_info_(std::string &device_info) {
   device_info += " Cores:" + to_string(info.cores);
   device_info += " Revision:" + to_string(info.revision);
 
+  // Framework detection
+  device_info += "|Framework: ";
+#ifdef USE_ARDUINO
+  ESP_LOGD(TAG, "Framework: Arduino");
+  device_info += "Arduino";
+#elif defined(USE_ESP_IDF)
+  ESP_LOGD(TAG, "Framework: ESP-IDF");
+  device_info += "ESP-IDF";
+#else
+  ESP_LOGW(TAG, "Framework: UNKNOWN");
+  device_info += "UNKNOWN";
+#endif
+
   ESP_LOGD(TAG, "ESP-IDF Version: %s", esp_get_idf_version());
   device_info += "|ESP-IDF: ";
   device_info += esp_get_idf_version();


### PR DESCRIPTION
# What does this implement/fix?

This adds the framework type (`Arduino`  or `ESP-IDF`) to both the log (on dump config) and also to the text sensor on debug. This makes easier to troubleshoot by providing the info about the framework type used.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [X] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`: N/A

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
