### PR TITLE
[http_request] Bugfix: run update function in a task

### DIFF
--- a/esphome/components/http_request/http_request_idf.h
+++ b/esphome/components/http_request/http_request_idf.h
@@ -18,6 +18,9 @@ class HttpContainerIDF : public HttpContainer {
   int read(uint8_t *buf, size_t max_len) override;
   void end() override;
 
+  /// @brief Feeds the watchdog timer if the executing task has one attached
+  void feed_wdt();
+
  protected:
   esp_http_client_handle_t client_;
 };

--- a/esphome/components/http_request/update/http_request_update.cpp
+++ b/esphome/components/http_request/update/http_request_update.cpp
@@ -72,47 +72,51 @@ void HttpRequestUpdate::update_task(void *params) {
     read_index += read_bytes;
   }
 
-  std::string response((char *) data, read_index);
-  allocator.deallocate(data, container->content_length);
-
   container->end();
+  container.reset();  // Release ownership of the container's shared_ptr
 
-  bool valid = json::parse_json(response, [this_update](JsonObject root) -> bool {
-    if (!root.containsKey("name") || !root.containsKey("version") || !root.containsKey("builds")) {
-      ESP_LOGE(TAG, "Manifest does not contain required fields");
-      return false;
-    }
-    this_update->update_info_.title = root["name"].as<std::string>();
-    this_update->update_info_.latest_version = root["version"].as<std::string>();
+  bool valid = false;
+  {  // Ensures the response string falls out of scope and deallocates before the task ends
+    std::string response((char *) data, read_index);
+    allocator.deallocate(data, container->content_length);
 
-    for (auto build : root["builds"].as<JsonArray>()) {
-      if (!build.containsKey("chipFamily")) {
+    valid = json::parse_json(response, [this_update](JsonObject root) -> bool {
+      if (!root.containsKey("name") || !root.containsKey("version") || !root.containsKey("builds")) {
         ESP_LOGE(TAG, "Manifest does not contain required fields");
         return false;
       }
-      if (build["chipFamily"] == ESPHOME_VARIANT) {
-        if (!build.containsKey("ota")) {
+      this_update->update_info_.title = root["name"].as<std::string>();
+      this_update->update_info_.latest_version = root["version"].as<std::string>();
+
+      for (auto build : root["builds"].as<JsonArray>()) {
+        if (!build.containsKey("chipFamily")) {
           ESP_LOGE(TAG, "Manifest does not contain required fields");
           return false;
         }
-        auto ota = build["ota"];
-        if (!ota.containsKey("path") || !ota.containsKey("md5")) {
-          ESP_LOGE(TAG, "Manifest does not contain required fields");
-          return false;
+        if (build["chipFamily"] == ESPHOME_VARIANT) {
+          if (!build.containsKey("ota")) {
+            ESP_LOGE(TAG, "Manifest does not contain required fields");
+            return false;
+          }
+          auto ota = build["ota"];
+          if (!ota.containsKey("path") || !ota.containsKey("md5")) {
+            ESP_LOGE(TAG, "Manifest does not contain required fields");
+            return false;
+          }
+          this_update->update_info_.firmware_url = ota["path"].as<std::string>();
+          this_update->update_info_.md5 = ota["md5"].as<std::string>();
+
+          if (ota.containsKey("summary"))
+            this_update->update_info_.summary = ota["summary"].as<std::string>();
+          if (ota.containsKey("release_url"))
+            this_update->update_info_.release_url = ota["release_url"].as<std::string>();
+
+          return true;
         }
-        this_update->update_info_.firmware_url = ota["path"].as<std::string>();
-        this_update->update_info_.md5 = ota["md5"].as<std::string>();
-
-        if (ota.containsKey("summary"))
-          this_update->update_info_.summary = ota["summary"].as<std::string>();
-        if (ota.containsKey("release_url"))
-          this_update->update_info_.release_url = ota["release_url"].as<std::string>();
-
-        return true;
       }
-    }
-    return false;
-  });
+      return false;
+    });
+  }
 
   if (!valid) {
     std::string msg = str_sprintf("Failed to parse JSON from %s", this_update->source_url_.c_str());
@@ -132,14 +136,16 @@ void HttpRequestUpdate::update_task(void *params) {
     }
   }
 
-  std::string current_version;
+  {  // Ensures the current version string falls out of scope and deallocates before the task ends
+    std::string current_version;
 #ifdef ESPHOME_PROJECT_VERSION
-  current_version = ESPHOME_PROJECT_VERSION;
+    current_version = ESPHOME_PROJECT_VERSION;
 #else
-  current_version = ESPHOME_VERSION;
+    current_version = ESPHOME_VERSION;
 #endif
 
-  this_update->update_info_.current_version = current_version;
+    this_update->update_info_.current_version = current_version;
+  }
 
   if (this_update->update_info_.latest_version.empty() ||
       this_update->update_info_.latest_version == this_update->update_info_.current_version) {

--- a/esphome/components/http_request/update/http_request_update.cpp
+++ b/esphome/components/http_request/update/http_request_update.cpp
@@ -72,13 +72,13 @@ void HttpRequestUpdate::update_task(void *params) {
     read_index += read_bytes;
   }
 
-  container->end();
-  container.reset();  // Release ownership of the container's shared_ptr
-
   bool valid = false;
   {  // Ensures the response string falls out of scope and deallocates before the task ends
     std::string response((char *) data, read_index);
     allocator.deallocate(data, container->content_length);
+
+    container->end();
+    container.reset();  // Release ownership of the container's shared_ptr
 
     valid = json::parse_json(response, [this_update](JsonObject root) -> bool {
       if (!root.containsKey("name") || !root.containsKey("version") || !root.containsKey("builds")) {

--- a/esphome/components/http_request/update/http_request_update.cpp
+++ b/esphome/components/http_request/update/http_request_update.cpp
@@ -9,6 +9,13 @@
 namespace esphome {
 namespace http_request {
 
+// The update function runs in a task only on ESP32s.
+#ifdef USE_ESP32
+#define UPDATE_RETURN vTaskDelete(nullptr)  // Delete the current update task
+#else
+#define UPDATE_RETURN return
+#endif
+
 static const char *const TAG = "http_request.update";
 
 static const size_t MAX_READ_SIZE = 256;
@@ -29,28 +36,37 @@ void HttpRequestUpdate::setup() {
 }
 
 void HttpRequestUpdate::update() {
-  auto container = this->request_parent_->get(this->source_url_);
+#ifdef USE_ESP32
+  xTaskCreate(HttpRequestUpdate::update_task, "update_task", 4096, (void *) this, 1, &this->update_task_handle_);
+#else
+  this->update_task(this);
+#endif
+}
+
+void HttpRequestUpdate::update_task(void *params) {
+  HttpRequestUpdate *this_update = (HttpRequestUpdate *) params;
+
+  auto container = this_update->request_parent_->get(this_update->source_url_);
 
   if (container == nullptr || container->status_code != HTTP_STATUS_OK) {
-    std::string msg = str_sprintf("Failed to fetch manifest from %s", this->source_url_.c_str());
-    this->status_set_error(msg.c_str());
-    return;
+    std::string msg = str_sprintf("Failed to fetch manifest from %s", this_update->source_url_.c_str());
+    this_update->status_set_error(msg.c_str());
+    UPDATE_RETURN;
   }
 
   ExternalRAMAllocator<uint8_t> allocator(ExternalRAMAllocator<uint8_t>::ALLOW_FAILURE);
   uint8_t *data = allocator.allocate(container->content_length);
   if (data == nullptr) {
     std::string msg = str_sprintf("Failed to allocate %d bytes for manifest", container->content_length);
-    this->status_set_error(msg.c_str());
+    this_update->status_set_error(msg.c_str());
     container->end();
-    return;
+    UPDATE_RETURN;
   }
 
   size_t read_index = 0;
   while (container->get_bytes_read() < container->content_length) {
     int read_bytes = container->read(data + read_index, MAX_READ_SIZE);
 
-    App.feed_wdt();
     yield();
 
     read_index += read_bytes;
@@ -61,13 +77,13 @@ void HttpRequestUpdate::update() {
 
   container->end();
 
-  bool valid = json::parse_json(response, [this](JsonObject root) -> bool {
+  bool valid = json::parse_json(response, [this_update](JsonObject root) -> bool {
     if (!root.containsKey("name") || !root.containsKey("version") || !root.containsKey("builds")) {
       ESP_LOGE(TAG, "Manifest does not contain required fields");
       return false;
     }
-    this->update_info_.title = root["name"].as<std::string>();
-    this->update_info_.latest_version = root["version"].as<std::string>();
+    this_update->update_info_.title = root["name"].as<std::string>();
+    this_update->update_info_.latest_version = root["version"].as<std::string>();
 
     for (auto build : root["builds"].as<JsonArray>()) {
       if (!build.containsKey("chipFamily")) {
@@ -84,13 +100,13 @@ void HttpRequestUpdate::update() {
           ESP_LOGE(TAG, "Manifest does not contain required fields");
           return false;
         }
-        this->update_info_.firmware_url = ota["path"].as<std::string>();
-        this->update_info_.md5 = ota["md5"].as<std::string>();
+        this_update->update_info_.firmware_url = ota["path"].as<std::string>();
+        this_update->update_info_.md5 = ota["md5"].as<std::string>();
 
         if (ota.containsKey("summary"))
-          this->update_info_.summary = ota["summary"].as<std::string>();
+          this_update->update_info_.summary = ota["summary"].as<std::string>();
         if (ota.containsKey("release_url"))
-          this->update_info_.release_url = ota["release_url"].as<std::string>();
+          this_update->update_info_.release_url = ota["release_url"].as<std::string>();
 
         return true;
       }
@@ -99,20 +115,20 @@ void HttpRequestUpdate::update() {
   });
 
   if (!valid) {
-    std::string msg = str_sprintf("Failed to parse JSON from %s", this->source_url_.c_str());
-    this->status_set_error(msg.c_str());
-    return;
+    std::string msg = str_sprintf("Failed to parse JSON from %s", this_update->source_url_.c_str());
+    this_update->status_set_error(msg.c_str());
+    UPDATE_RETURN;
   }
 
-  // Merge source_url_ and this->update_info_.firmware_url
-  if (this->update_info_.firmware_url.find("http") == std::string::npos) {
-    std::string path = this->update_info_.firmware_url;
+  // Merge source_url_ and this_update->update_info_.firmware_url
+  if (this_update->update_info_.firmware_url.find("http") == std::string::npos) {
+    std::string path = this_update->update_info_.firmware_url;
     if (path[0] == '/') {
-      std::string domain = this->source_url_.substr(0, this->source_url_.find('/', 8));
-      this->update_info_.firmware_url = domain + path;
+      std::string domain = this_update->source_url_.substr(0, this_update->source_url_.find('/', 8));
+      this_update->update_info_.firmware_url = domain + path;
     } else {
-      std::string domain = this->source_url_.substr(0, this->source_url_.rfind('/') + 1);
-      this->update_info_.firmware_url = domain + path;
+      std::string domain = this_update->source_url_.substr(0, this_update->source_url_.rfind('/') + 1);
+      this_update->update_info_.firmware_url = domain + path;
     }
   }
 
@@ -123,19 +139,22 @@ void HttpRequestUpdate::update() {
   current_version = ESPHOME_VERSION;
 #endif
 
-  this->update_info_.current_version = current_version;
+  this_update->update_info_.current_version = current_version;
 
-  if (this->update_info_.latest_version.empty() || this->update_info_.latest_version == update_info_.current_version) {
-    this->state_ = update::UPDATE_STATE_NO_UPDATE;
+  if (this_update->update_info_.latest_version.empty() ||
+      this_update->update_info_.latest_version == this_update->update_info_.current_version) {
+    this_update->state_ = update::UPDATE_STATE_NO_UPDATE;
   } else {
-    this->state_ = update::UPDATE_STATE_AVAILABLE;
+    this_update->state_ = update::UPDATE_STATE_AVAILABLE;
   }
 
-  this->update_info_.has_progress = false;
-  this->update_info_.progress = 0.0f;
+  this_update->update_info_.has_progress = false;
+  this_update->update_info_.progress = 0.0f;
 
-  this->status_clear_error();
-  this->publish_state();
+  this_update->status_clear_error();
+  this_update->publish_state();
+
+  UPDATE_RETURN;
 }
 
 void HttpRequestUpdate::perform(bool force) {

--- a/esphome/components/http_request/update/http_request_update.cpp
+++ b/esphome/components/http_request/update/http_request_update.cpp
@@ -37,7 +37,7 @@ void HttpRequestUpdate::setup() {
 
 void HttpRequestUpdate::update() {
 #ifdef USE_ESP32
-  xTaskCreate(HttpRequestUpdate::update_task, "update_task", 4096, (void *) this, 1, &this->update_task_handle_);
+  xTaskCreate(HttpRequestUpdate::update_task, "update_task", 8192, (void *) this, 1, &this->update_task_handle_);
 #else
   this->update_task(this);
 #endif

--- a/esphome/components/http_request/update/http_request_update.h
+++ b/esphome/components/http_request/update/http_request_update.h
@@ -7,6 +7,10 @@
 #include "esphome/components/http_request/ota/ota_http_request.h"
 #include "esphome/components/update/update_entity.h"
 
+#ifdef USE_ESP32
+#include <freertos/FreeRTOS.h>
+#endif
+
 namespace esphome {
 namespace http_request {
 
@@ -29,6 +33,11 @@ class HttpRequestUpdate : public update::UpdateEntity, public PollingComponent {
   HttpRequestComponent *request_parent_;
   OtaHttpRequestComponent *ota_parent_;
   std::string source_url_;
+
+  static void update_task(void *params);
+#ifdef USE_ESP32
+  TaskHandle_t update_task_handle_{nullptr};
+#endif
 };
 
 }  // namespace http_request


### PR DESCRIPTION
# What does this implement/fix?

If the update function can't open the manifest url due to a bad/blocked internet connection, the device crashes with a watchdog timeout. This PR moves the update function into its own task to avoid the crash. This allows it to yield to the main task, giving the ``esp_http_client`` enough time to return with an error.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes esphome/home-assistant-voice-pe/issues/241

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** not applicable

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

ota:
  - platform: http_request
    id: ota_http_request

http_request:

update:
  - platform: http_request
    name: None
    id: update_http_request
    source: https://firmware.esphome.io/home-assistant-voice-pe/home-assistant-voice/manifest.json

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
