### PR TITLE
[spi] Restore ``SPIDelegateDummy``

### DIFF
--- a/esphome/components/spi/spi.cpp
+++ b/esphome/components/spi/spi.cpp
@@ -7,6 +7,10 @@ namespace spi {
 
 const char *const TAG = "spi";
 
+SPIDelegate *const SPIDelegate::NULL_DELEGATE =  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+    new SPIDelegateDummy();
+// https://bugs.llvm.org/show_bug.cgi?id=48040
+
 bool SPIDelegate::is_ready() { return true; }
 
 GPIOPin *const NullPin::NULL_PIN = new NullPin();  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
@@ -74,6 +78,8 @@ void SPIComponent::dump_config() {
     ESP_LOGCONFIG(TAG, "  Using software SPI");
   }
 }
+
+void SPIDelegateDummy::begin_transaction() { ESP_LOGE(TAG, "SPIDevice not initialised - did you call spi_setup()?"); }
 
 uint8_t SPIDelegateBitBash::transfer(uint8_t data) { return this->transfer_(data, 8); }
 

--- a/esphome/components/spi/spi.h
+++ b/esphome/components/spi/spi.h
@@ -163,6 +163,8 @@ class Utility {
   }
 };
 
+class SPIDelegateDummy;
+
 // represents a device attached to an SPI bus, with a defined clock rate, mode and bit order. On Arduino this is
 // a thin wrapper over SPIClass.
 class SPIDelegate {
@@ -248,6 +250,21 @@ class SPIDelegate {
   uint32_t data_rate_{1000000};
   SPIMode mode_{MODE0};
   GPIOPin *cs_pin_{NullPin::NULL_PIN};
+  static SPIDelegate *const NULL_DELEGATE;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+};
+
+/**
+ * A dummy SPIDelegate that complains if it's used.
+ */
+
+class SPIDelegateDummy : public SPIDelegate {
+ public:
+  SPIDelegateDummy() = default;
+
+  uint8_t transfer(uint8_t data) override { return 0; }
+  void end_transaction() override{};
+
+  void begin_transaction() override;
 };
 
 /**
@@ -365,7 +382,7 @@ class SPIClient {
 
   virtual void spi_teardown() {
     this->parent_->unregister_device(this);
-    this->delegate_ = nullptr;
+    this->delegate_ = SPIDelegate::NULL_DELEGATE;
   }
 
   bool spi_is_ready() { return this->delegate_->is_ready(); }
@@ -376,7 +393,7 @@ class SPIClient {
   uint32_t data_rate_{1000000};
   SPIComponent *parent_{nullptr};
   GPIOPin *cs_{nullptr};
-  SPIDelegate *delegate_{nullptr};
+  SPIDelegate *delegate_{SPIDelegate::NULL_DELEGATE};
 };
 
 /**


### PR DESCRIPTION
This reverts commit ddd80272386c923db6043e3659997c1e34398b3f.

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Removal of the dummy delegate results in difficult to diagnose run-time crashes and consequent bootloops whenever something goes wrong with the SPI startup sequence, whether by user error or a bug in another component. With the dummy delegate in place errors are logged, but no bootloop, making it much easier to diagnose the problem.

There is IMO no apparent downside to using this approach.



## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Relates to https://github.com/esphome/issues/issues/6594#issuecomment-2562643683
- Relates to https://github.com/esphome/issues/issues/6435

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
