### PR TITLE
[nextion] Brightness control tweaks

### DIFF
--- a/esphome/components/nextion/automation.h
+++ b/esphome/components/nextion/automation.h
@@ -49,6 +49,23 @@ class TouchTrigger : public Trigger<uint8_t, uint8_t, bool> {
   }
 };
 
+template<typename... Ts> class NextionSetBrightnessAction : public Action<Ts...> {
+ public:
+  explicit NextionSetBrightnessAction(Nextion *component) : component_(component) {}
+
+  TEMPLATABLE_VALUE(float, brightness)
+
+  void play(Ts... x) override {
+    this->component_->set_brightness(this->brightness_.value(x...));
+    this->component_->set_backlight_brightness(this->brightness_.value(x...));
+  }
+
+  void set_brightness(std::function<void(Ts..., float)> brightness) { this->brightness_ = brightness; }
+
+ protected:
+  Nextion *component_;
+};
+
 template<typename... Ts> class NextionPublishFloatAction : public Action<Ts...> {
  public:
   explicit NextionPublishFloatAction(NextionComponent *component) : component_(component) {}

--- a/esphome/components/nextion/nextion.cpp
+++ b/esphome/components/nextion/nextion.cpp
@@ -273,7 +273,9 @@ void Nextion::loop() {
     this->sent_setup_commands_ = true;
     this->send_command_("bkcmd=3");  // Always, returns 0x00 to 0x23 result of serial command.
 
-    this->set_backlight_brightness(this->brightness_);
+    if (this->brightness_.has_value()) {
+      this->set_backlight_brightness(this->brightness_.value());
+    }
 
     // Check if a startup page has been set and send the command
     if (this->start_up_page_ != -1) {

--- a/esphome/components/nextion/nextion.h
+++ b/esphome/components/nextion/nextion.h
@@ -1339,7 +1339,7 @@ class Nextion : public NextionBase, public PollingComponent, public uart::UARTDe
   CallbackManager<void()> buffer_overflow_callback_{};
 
   optional<nextion_writer_t> writer_;
-  float brightness_{1.0};
+  optional<float> brightness_;
 
   std::string device_model_;
   std::string firmware_version_;

--- a/tests/components/nextion/common.yaml
+++ b/tests/components/nextion/common.yaml
@@ -2,6 +2,8 @@ esphome:
   on_boot:
     - lambda: 'ESP_LOGD("display","is_connected(): %s", YESNO(id(main_lcd).is_connected()));'
 
+    - display.nextion.set_brightness: 80%
+
     # Binary sensor publish action tests
     - binary_sensor.nextion.publish:
         id: r0_sensor


### PR DESCRIPTION
# What does this implement/fix?

I noticed recently that my displays would "pop" their brightness to 100% and then immediately reduce it back down (as configured) shortly after boot. I realized that this is because we were *always* setting the brightness as part of start-up. Since I'm managing display brightness...another way...this behavior is not desirable. This PR only sets the display brightness at start-up if `brightness` is in the config -- otherwise, it leaves it alone.

In addition, this PR adds an action which can be used to set the brightness (as opposed to having to use a lambda).

I've labeled this as a breaking change only because it *may* result in a change of behavior when `brightness` is not set in config. That said, I believe the displays default to 100% brightness unless the `dims` command was used on the display at some point to change it.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#4550

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
