### PR TITLE
add PN532 new feature, now can read id card by any key

### DIFF
--- a/esphome/components/nfc/nfc.h
+++ b/esphome/components/nfc/nfc.h
@@ -49,9 +49,11 @@ static const char *const MIFARE_CLASSIC = "Mifare Classic";
 static const char *const NFC_FORUM_TYPE_2 = "NFC Forum Type 2";
 static const char *const ERROR = "Error";
 
-static const uint8_t DEFAULT_KEY[6] = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
-static const uint8_t NDEF_KEY[6] = {0xD3, 0xF7, 0xD3, 0xF7, 0xD3, 0xF7};
-static const uint8_t MAD_KEY[6] = {0xA0, 0xA1, 0xA2, 0xA3, 0xA4, 0xA5};
+constexpr uint8_t KEY_SIZE = 6;
+
+static const uint8_t DEFAULT_KEY[KEY_SIZE] = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
+static const uint8_t NDEF_KEY[KEY_SIZE] = {0xD3, 0xF7, 0xD3, 0xF7, 0xD3, 0xF7};
+static const uint8_t MAD_KEY[KEY_SIZE] = {0xA0, 0xA1, 0xA2, 0xA3, 0xA4, 0xA5};
 
 std::string format_uid(std::vector<uint8_t> &uid);
 std::string format_bytes(std::vector<uint8_t> &bytes);

--- a/esphome/components/pn532/pn532.cpp
+++ b/esphome/components/pn532/pn532.cpp
@@ -429,6 +429,7 @@ void PN532::write_mode(nfc::NdefMessage *message) {
 void PN532::read_by_auth_mode(const std::vector<std::array<uint8_t, nfc::KEY_SIZE>> &user_key, std::vector<std::array<uint8_t, nfc::MIFARE_CLASSIC_BLOCK_SIZE>>* data) {
   this->next_task_ = READ_BY_AUTH;
   this->user_define_key.assign(user_key.begin(), user_key.end());
+  this->raw_data = data;
   auto raw_data_read = this->read_data_auth_(this->current_uid_);
   data->assign((*raw_data_read).begin(), (*raw_data_read).end());
   ESP_LOGD(TAG, "Waiting to read next card");

--- a/esphome/components/pn532/pn532.cpp
+++ b/esphome/components/pn532/pn532.cpp
@@ -240,10 +240,10 @@ void PN532::loop() {
     // read raw data
     ESP_LOGD(TAG, "next task read by auth %d", nfcid.size());
     auto data = this->read_data_auth_(nfcid);
-    if (this->raw_data != nullptr) {
-      this->raw_data->assign((*data).begin(), (*data).end());
+    if (this->raw_data_ != nullptr) {
+      this->raw_data_->assign((*data).begin(), (*data).end());
     }
-    this->user_define_key.clear();
+    this->user_define_key_.clear();
   }
 
   this->read_mode();
@@ -365,7 +365,7 @@ void PN532::turn_off_rf_() {
   });
 }
 
-void PN532::in_release(const uint8_t target) {
+void PN532::in_release_(const uint8_t target) {
   this->write_command_({
       PN532_COMMAND_INRELEASE,
       target,
@@ -430,8 +430,8 @@ void PN532::write_mode(nfc::NdefMessage *message) {
 void PN532::read_by_auth_mode(const std::vector<std::array<uint8_t, nfc::KEY_SIZE>> &user_key,
                               std::vector<std::array<uint8_t, nfc::MIFARE_CLASSIC_BLOCK_SIZE>> *data) {
   this->next_task_ = READ_BY_AUTH;
-  this->user_define_key.assign(user_key.begin(), user_key.end());
-  this->raw_data = data;
+  this->user_define_key_.assign(user_key.begin(), user_key.end());
+  this->raw_data_ = data;
   auto raw_data_read = this->read_data_auth_(this->current_uid_);
   data->assign((*raw_data_read).begin(), (*raw_data_read).end());
   ESP_LOGD(TAG, "Waiting to read next card");

--- a/esphome/components/pn532/pn532.cpp
+++ b/esphome/components/pn532/pn532.cpp
@@ -392,7 +392,8 @@ std::unique_ptr<nfc::NfcTag> PN532::read_tag_(std::vector<uint8_t> &uid) {
   }
 }
 
-std::shared_ptr<std::vector<std::array<uint8_t, nfc::MIFARE_CLASSIC_BLOCK_SIZE>>> PN532::read_data_auth_(std::vector<uint8_t> &uid) {
+std::shared_ptr<std::vector<std::array<uint8_t, nfc::MIFARE_CLASSIC_BLOCK_SIZE>>> PN532::read_data_auth_(
+    std::vector<uint8_t> &uid) {
   uint8_t type = nfc::guess_tag_type(uid.size());
 
   if (type == nfc::TAG_TYPE_MIFARE_CLASSIC) {
@@ -426,7 +427,8 @@ void PN532::write_mode(nfc::NdefMessage *message) {
   this->next_task_message_to_write_ = message;
   ESP_LOGD(TAG, "Waiting to write next tag");
 }
-void PN532::read_by_auth_mode(const std::vector<std::array<uint8_t, nfc::KEY_SIZE>> &user_key, std::vector<std::array<uint8_t, nfc::MIFARE_CLASSIC_BLOCK_SIZE>>* data) {
+void PN532::read_by_auth_mode(const std::vector<std::array<uint8_t, nfc::KEY_SIZE>> &user_key,
+                              std::vector<std::array<uint8_t, nfc::MIFARE_CLASSIC_BLOCK_SIZE>> *data) {
   this->next_task_ = READ_BY_AUTH;
   this->user_define_key.assign(user_key.begin(), user_key.end());
   this->raw_data = data;

--- a/esphome/components/pn532/pn532.cpp
+++ b/esphome/components/pn532/pn532.cpp
@@ -238,8 +238,11 @@ void PN532::loop() {
     }
   } else if (next_task_ == READ_BY_AUTH) {
     // read raw data
+    ESP_LOGD(TAG, "next task read by auth %d", nfcid.size());
     auto data = this->read_data_auth_(nfcid);
-    this->raw_data.swap(data);
+    if (this->raw_data != nullptr) {
+      this->raw_data->assign((*data).begin(), (*data).end());
+    }
     this->user_define_key.clear();
   }
 
@@ -362,6 +365,16 @@ void PN532::turn_off_rf_() {
   });
 }
 
+void PN532::in_release(const uint8_t target) {
+  this->write_command_({
+      PN532_COMMAND_INRELEASE,
+      target,
+  });
+
+  std::vector<uint8_t> data;
+  this->read_data(data, 3);
+}
+
 std::unique_ptr<nfc::NfcTag> PN532::read_tag_(std::vector<uint8_t> &uid) {
   uint8_t type = nfc::guess_tag_type(uid.size());
 
@@ -413,10 +426,11 @@ void PN532::write_mode(nfc::NdefMessage *message) {
   this->next_task_message_to_write_ = message;
   ESP_LOGD(TAG, "Waiting to write next tag");
 }
-void PN532::read_by_auth_mode(std::vector<std::array<uint8_t, nfc::KEY_SIZE>> &user_key, std::shared_ptr<std::vector<std::array<uint8_t, nfc::MIFARE_CLASSIC_BLOCK_SIZE>>> data) {
+void PN532::read_by_auth_mode(const std::vector<std::array<uint8_t, nfc::KEY_SIZE>> &user_key, std::vector<std::array<uint8_t, nfc::MIFARE_CLASSIC_BLOCK_SIZE>>* data) {
   this->next_task_ = READ_BY_AUTH;
   this->user_define_key.assign(user_key.begin(), user_key.end());
-  this->raw_data = data;
+  auto raw_data_read = this->read_data_auth_(this->current_uid_);
+  data->assign((*raw_data_read).begin(), (*raw_data_read).end());
   ESP_LOGD(TAG, "Waiting to read next card");
 }
 

--- a/esphome/components/pn532/pn532.h
+++ b/esphome/components/pn532/pn532.h
@@ -74,7 +74,7 @@ class PN532 : public PollingComponent {
 
   std::unique_ptr<nfc::NfcTag> read_tag_(std::vector<uint8_t> &uid);
 
-  void in_release(const uint8_t target = 0x00);
+  void in_release_(uint8_t target = 0x00);
 
   std::shared_ptr<std::vector<std::array<uint8_t, nfc::MIFARE_CLASSIC_BLOCK_SIZE>>> read_data_auth_(
       std::vector<uint8_t> &uid);
@@ -110,8 +110,8 @@ class PN532 : public PollingComponent {
   std::vector<nfc::NfcOnTagTrigger *> triggers_ontag_;
   std::vector<nfc::NfcOnTagTrigger *> triggers_ontagremoved_;
   std::vector<uint8_t> current_uid_;
-  std::vector<std::array<uint8_t, nfc::KEY_SIZE>> user_define_key;
-  std::vector<std::array<uint8_t, nfc::MIFARE_CLASSIC_BLOCK_SIZE>> *raw_data;
+  std::vector<std::array<uint8_t, nfc::KEY_SIZE>> user_define_key_;
+  std::vector<std::array<uint8_t, nfc::MIFARE_CLASSIC_BLOCK_SIZE>> *raw_data_;
   nfc::NdefMessage *next_task_message_to_write_;
   uint32_t rd_start_time_{0};
   enum PN532ReadReady rd_ready_ { WOULDBLOCK };

--- a/esphome/components/pn532/pn532.h
+++ b/esphome/components/pn532/pn532.h
@@ -56,7 +56,8 @@ class PN532 : public PollingComponent {
   void format_mode();
   void write_mode(nfc::NdefMessage *message);
   bool powerdown();
-  void read_by_auth_mode(const std::vector<std::array<uint8_t, nfc::KEY_SIZE>> &user_key, std::vector<std::array<uint8_t, nfc::MIFARE_CLASSIC_BLOCK_SIZE>> *data);
+  void read_by_auth_mode(const std::vector<std::array<uint8_t, nfc::KEY_SIZE>> &user_key,
+                         std::vector<std::array<uint8_t, nfc::MIFARE_CLASSIC_BLOCK_SIZE>> *data);
 
  protected:
   void turn_off_rf_();
@@ -75,7 +76,8 @@ class PN532 : public PollingComponent {
 
   void in_release(const uint8_t target = 0x00);
 
-  std::shared_ptr<std::vector<std::array<uint8_t, nfc::MIFARE_CLASSIC_BLOCK_SIZE>>> read_data_auth_(std::vector<uint8_t> &uid);
+  std::shared_ptr<std::vector<std::array<uint8_t, nfc::MIFARE_CLASSIC_BLOCK_SIZE>>> read_data_auth_(
+      std::vector<uint8_t> &uid);
 
   bool format_tag_(std::vector<uint8_t> &uid);
   bool clean_tag_(std::vector<uint8_t> &uid);
@@ -99,7 +101,8 @@ class PN532 : public PollingComponent {
   bool write_mifare_ultralight_tag_(std::vector<uint8_t> &uid, nfc::NdefMessage *message);
   bool clean_mifare_ultralight_();
 
-  std::shared_ptr<std::vector<std::array<uint8_t, nfc::MIFARE_CLASSIC_BLOCK_SIZE>>> read_mifare_classic_data_(std::vector<uint8_t> &uid);
+  std::shared_ptr<std::vector<std::array<uint8_t, nfc::MIFARE_CLASSIC_BLOCK_SIZE>>> read_mifare_classic_data_(
+      std::vector<uint8_t> &uid);
 
   bool updates_enabled_{true};
   bool requested_read_{false};
@@ -108,7 +111,7 @@ class PN532 : public PollingComponent {
   std::vector<nfc::NfcOnTagTrigger *> triggers_ontagremoved_;
   std::vector<uint8_t> current_uid_;
   std::vector<std::array<uint8_t, nfc::KEY_SIZE>> user_define_key;
-  std::vector<std::array<uint8_t, nfc::MIFARE_CLASSIC_BLOCK_SIZE>>* raw_data;
+  std::vector<std::array<uint8_t, nfc::MIFARE_CLASSIC_BLOCK_SIZE>> *raw_data;
   nfc::NdefMessage *next_task_message_to_write_;
   uint32_t rd_start_time_{0};
   enum PN532ReadReady rd_ready_ { WOULDBLOCK };

--- a/esphome/components/pn532/pn532.h
+++ b/esphome/components/pn532/pn532.h
@@ -18,6 +18,7 @@ static const uint8_t PN532_COMMAND_SAMCONFIGURATION = 0x14;
 static const uint8_t PN532_COMMAND_RFCONFIGURATION = 0x32;
 static const uint8_t PN532_COMMAND_INDATAEXCHANGE = 0x40;
 static const uint8_t PN532_COMMAND_INLISTPASSIVETARGET = 0x4A;
+static const uint8_t PN532_COMMAND_INRELEASE = 0x52;
 static const uint8_t PN532_COMMAND_POWERDOWN = 0x16;
 
 enum PN532ReadReady {
@@ -55,7 +56,7 @@ class PN532 : public PollingComponent {
   void format_mode();
   void write_mode(nfc::NdefMessage *message);
   bool powerdown();
-  void read_by_auth_mode(std::vector<std::array<uint8_t, nfc::KEY_SIZE>> &user_key, std::shared_ptr<std::vector<std::array<uint8_t, nfc::MIFARE_CLASSIC_BLOCK_SIZE>>> data);
+  void read_by_auth_mode(const std::vector<std::array<uint8_t, nfc::KEY_SIZE>> &user_key, std::vector<std::array<uint8_t, nfc::MIFARE_CLASSIC_BLOCK_SIZE>> *data);
 
  protected:
   void turn_off_rf_();
@@ -71,6 +72,8 @@ class PN532 : public PollingComponent {
   virtual bool read_response(uint8_t command, std::vector<uint8_t> &data) = 0;
 
   std::unique_ptr<nfc::NfcTag> read_tag_(std::vector<uint8_t> &uid);
+
+  void in_release(const uint8_t target = 0x00);
 
   std::shared_ptr<std::vector<std::array<uint8_t, nfc::MIFARE_CLASSIC_BLOCK_SIZE>>> read_data_auth_(std::vector<uint8_t> &uid);
 
@@ -105,7 +108,6 @@ class PN532 : public PollingComponent {
   std::vector<nfc::NfcOnTagTrigger *> triggers_ontagremoved_;
   std::vector<uint8_t> current_uid_;
   std::vector<std::array<uint8_t, nfc::KEY_SIZE>> user_define_key;
-  std::shared_ptr<std::vector<std::array<uint8_t, nfc::MIFARE_CLASSIC_BLOCK_SIZE>>> raw_data;
   nfc::NdefMessage *next_task_message_to_write_;
   uint32_t rd_start_time_{0};
   enum PN532ReadReady rd_ready_ { WOULDBLOCK };

--- a/esphome/components/pn532/pn532.h
+++ b/esphome/components/pn532/pn532.h
@@ -108,6 +108,7 @@ class PN532 : public PollingComponent {
   std::vector<nfc::NfcOnTagTrigger *> triggers_ontagremoved_;
   std::vector<uint8_t> current_uid_;
   std::vector<std::array<uint8_t, nfc::KEY_SIZE>> user_define_key;
+  std::vector<std::array<uint8_t, nfc::MIFARE_CLASSIC_BLOCK_SIZE>>* raw_data;
   nfc::NdefMessage *next_task_message_to_write_;
   uint32_t rd_start_time_{0};
   enum PN532ReadReady rd_ready_ { WOULDBLOCK };

--- a/esphome/components/pn532/pn532.h
+++ b/esphome/components/pn532/pn532.h
@@ -55,6 +55,7 @@ class PN532 : public PollingComponent {
   void format_mode();
   void write_mode(nfc::NdefMessage *message);
   bool powerdown();
+  void read_by_auth_mode(std::vector<std::array<uint8_t, nfc::KEY_SIZE>> &user_key, std::shared_ptr<std::vector<std::array<uint8_t, nfc::MIFARE_CLASSIC_BLOCK_SIZE>>> data);
 
  protected:
   void turn_off_rf_();
@@ -70,6 +71,8 @@ class PN532 : public PollingComponent {
   virtual bool read_response(uint8_t command, std::vector<uint8_t> &data) = 0;
 
   std::unique_ptr<nfc::NfcTag> read_tag_(std::vector<uint8_t> &uid);
+
+  std::shared_ptr<std::vector<std::array<uint8_t, nfc::MIFARE_CLASSIC_BLOCK_SIZE>>> read_data_auth_(std::vector<uint8_t> &uid);
 
   bool format_tag_(std::vector<uint8_t> &uid);
   bool clean_tag_(std::vector<uint8_t> &uid);
@@ -93,12 +96,16 @@ class PN532 : public PollingComponent {
   bool write_mifare_ultralight_tag_(std::vector<uint8_t> &uid, nfc::NdefMessage *message);
   bool clean_mifare_ultralight_();
 
+  std::shared_ptr<std::vector<std::array<uint8_t, nfc::MIFARE_CLASSIC_BLOCK_SIZE>>> read_mifare_classic_data_(std::vector<uint8_t> &uid);
+
   bool updates_enabled_{true};
   bool requested_read_{false};
   std::vector<PN532BinarySensor *> binary_sensors_;
   std::vector<nfc::NfcOnTagTrigger *> triggers_ontag_;
   std::vector<nfc::NfcOnTagTrigger *> triggers_ontagremoved_;
   std::vector<uint8_t> current_uid_;
+  std::vector<std::array<uint8_t, nfc::KEY_SIZE>> user_define_key;
+  std::shared_ptr<std::vector<std::array<uint8_t, nfc::MIFARE_CLASSIC_BLOCK_SIZE>>> raw_data;
   nfc::NdefMessage *next_task_message_to_write_;
   uint32_t rd_start_time_{0};
   enum PN532ReadReady rd_ready_ { WOULDBLOCK };
@@ -107,6 +114,7 @@ class PN532 : public PollingComponent {
     CLEAN,
     FORMAT,
     WRITE,
+    READ_BY_AUTH,
   } next_task_{READ};
   enum PN532Error {
     NONE = 0,

--- a/esphome/components/pn532/pn532_mifare_classic.cpp
+++ b/esphome/components/pn532/pn532_mifare_classic.cpp
@@ -258,15 +258,15 @@ bool PN532::write_mifare_classic_tag_(std::vector<uint8_t> &uid, nfc::NdefMessag
   return true;
 }
 
-std::shared_ptr<std::vector<std::array<uint8_t, nfc::MIFARE_CLASSIC_BLOCK_SIZE>>> PN532::read_mifare_classic_data_(std::vector<uint8_t> &uid) {
-
+std::shared_ptr<std::vector<std::array<uint8_t, nfc::MIFARE_CLASSIC_BLOCK_SIZE>>> PN532::read_mifare_classic_data_(
+    std::vector<uint8_t> &uid) {
   uint8_t current_block = 0;
 
   if (user_define_key.empty()) {
     return std::make_shared<std::vector<std::array<uint8_t, nfc::MIFARE_CLASSIC_BLOCK_SIZE>>>();
   }
 
-  auto get_key = [this](uint8_t block)->std::array<uint8_t, nfc::KEY_SIZE> {
+  auto get_key = [this](uint8_t block) -> std::array<uint8_t, nfc::KEY_SIZE> {
     uint8_t current_key_index = block / 4;
     if (current_key_index >= user_define_key.size()) {
       return {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
@@ -282,9 +282,9 @@ std::shared_ptr<std::vector<std::array<uint8_t, nfc::MIFARE_CLASSIC_BLOCK_SIZE>>
   // must release and re read the card id
   this->in_release(0x00);
   if (!this->write_command_({
-          PN532_COMMAND_INLISTPASSIVETARGET, // read passive target ID
-          0x01,  // max 1 card
-          0x00,  // baud rate ISO14443A (106 kbit/s)
+          PN532_COMMAND_INLISTPASSIVETARGET,  // read passive target ID
+          0x01,                               // max 1 card
+          0x00,                               // baud rate ISO14443A (106 kbit/s)
       })) {
     ESP_LOGE(TAG, "ERROR in re read card");
     return std::make_shared<std::vector<std::array<uint8_t, nfc::MIFARE_CLASSIC_BLOCK_SIZE>>>();
@@ -297,7 +297,8 @@ std::shared_ptr<std::vector<std::array<uint8_t, nfc::MIFARE_CLASSIC_BLOCK_SIZE>>
       auth = false;
     }
     if (!auth) {
-      auth = this->auth_mifare_classic_block_(uid, current_block, nfc::MIFARE_CMD_AUTH_B, get_key(current_block).data());
+      auth =
+          this->auth_mifare_classic_block_(uid, current_block, nfc::MIFARE_CMD_AUTH_B, get_key(current_block).data());
     }
     std::vector<uint8_t> block_data;
     if (auth && this->read_mifare_classic_block_(current_block, block_data)) {
@@ -312,7 +313,6 @@ std::shared_ptr<std::vector<std::array<uint8_t, nfc::MIFARE_CLASSIC_BLOCK_SIZE>>
 
   return std::make_shared<std::vector<std::array<uint8_t, nfc::MIFARE_CLASSIC_BLOCK_SIZE>>>(buffer);
 }
-
 
 }  // namespace pn532
 }  // namespace esphome

--- a/esphome/components/pn532/pn532_mifare_classic.cpp
+++ b/esphome/components/pn532/pn532_mifare_classic.cpp
@@ -262,16 +262,16 @@ std::shared_ptr<std::vector<std::array<uint8_t, nfc::MIFARE_CLASSIC_BLOCK_SIZE>>
     std::vector<uint8_t> &uid) {
   uint8_t current_block = 0;
 
-  if (user_define_key.empty()) {
+  if (user_define_key_.empty()) {
     return std::make_shared<std::vector<std::array<uint8_t, nfc::MIFARE_CLASSIC_BLOCK_SIZE>>>();
   }
 
   auto get_key = [this](uint8_t block) -> std::array<uint8_t, nfc::KEY_SIZE> {
     uint8_t current_key_index = block / 4;
-    if (current_key_index >= user_define_key.size()) {
+    if (current_key_index >= user_define_key_.size()) {
       return {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
     }
-    return user_define_key[current_key_index];
+    return user_define_key_[current_key_index];
   };
 
   std::vector<std::array<uint8_t, nfc::MIFARE_CLASSIC_BLOCK_SIZE>> buffer;
@@ -280,7 +280,7 @@ std::shared_ptr<std::vector<std::array<uint8_t, nfc::MIFARE_CLASSIC_BLOCK_SIZE>>
   // because the first read (read_mifare_classic_tag_ function) is auth failed
   // the card will refuse to auth other block,
   // must release and re read the card id
-  this->in_release(0x00);
+  this->in_release_(0x00);
   if (!this->write_command_({
           PN532_COMMAND_INLISTPASSIVETARGET,  // read passive target ID
           0x01,                               // max 1 card


### PR DESCRIPTION
# What does this implement/fix?

add a support for PN532 read id card by user define password

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- 

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- 

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
esphome:
  name: test
  friendly_name: test

esp32:
  board: esp32-c3-m1i-kit
  flash_size: 4MB
  variant: ESP32C3
  framework:
    type: esp-idf

# Enable logging
logger:

# Enable Home Assistant API
wifi:
  ssid: !secret wifi_ssid
  password: !secret wifi_password

i2c:
  - scl: GPIO7
    sda: GPIO6

external_components:
  - source:
      type: git
      url: https://github.com/DeathSea/esphome
      ref: dev
    refresh: 5min
    components: [ nfc, pn532 ]

pn532_i2c:
  id: id_card_scanner
  on_tag:
    then:
      - lambda: |-
          auto cop = id(id_card_scanner);
          const static std::vector<std::array<uint8_t, nfc::KEY_SIZE>> key{
            {0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
            {0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
            {0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
            {0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
            {0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
            {0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
            {0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
            {0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
            {0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
            {0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
            {0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
            {0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
            {0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
            {0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
            {0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
            {0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
            {0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
          };
          auto data = new std::vector<std::array<uint8_t, nfc::MIFARE_CLASSIC_BLOCK_SIZE>>;
          cop->read_by_auth_mode(key, data);
          ESP_LOGI("PN532", "data size %d", (*data).size());
          for (auto block : (*data)) {
            ESP_LOGI("PN532", "read data: 0x%02x, 0x%02x, 0x%02x, 0x%02x, 0x%02x, 0x%02x, 0x%02x, 0x%02x, 0x%02x, 0x%02x, 0x%02x, 0x%02x, 0x%02x, 0x%02x, 0x%02x, 0x%02x",
              block[0], block[1], block[2], block[3], block[4], block[5], block[6], block[7],
              block[8], block[9], block[10], block[11], block[12], block[13], block[14], block[15]);
          }
          delete data;
      - wait_until:
          not:
            pn532.is_writing:
      - logger.log: "Done read all data"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

## Test Result:
when a not format id card tag on PN532 it will show :
![image](https://github.com/user-attachments/assets/67f0f76d-5aa4-4e59-a065-b527bc4c80b8)

