### PR TITLE
Add support for the DAC on the S2

### DIFF
--- a/esphome/components/esp32_dac/esp32_dac.cpp
+++ b/esphome/components/esp32_dac/esp32_dac.cpp
@@ -7,9 +7,6 @@
 #ifdef USE_ARDUINO
 #include <esp32-hal-dac.h>
 #endif
-#ifdef USE_ESP_IDF
-#include <driver/dac_oneshot.h>
-#endif
 
 namespace esphome {
 namespace esp32_dac {

--- a/esphome/components/esp32_dac/esp32_dac.cpp
+++ b/esphome/components/esp32_dac/esp32_dac.cpp
@@ -25,15 +25,15 @@ void ESP32DAC::setup() {
   this->turn_off();
 
 #ifdef USE_ESP_IDF
-  const dac_channel_t channel = pin_->get_pin() == DAC0_PIN ? DAC_CHAN_0 : DAC_CHAN_1;
+  const dac_channel_t channel = this->pin_->get_pin() == DAC0_PIN ? DAC_CHAN_0 : DAC_CHAN_1;
   const dac_oneshot_config_t oneshot_cfg{channel};
-  dac_oneshot_new_channel(&oneshot_cfg, &dac_handle_);
+  dac_oneshot_new_channel(&oneshot_cfg, &this->dac_handle_);
 #endif
 }
 
 void ESP32DAC::on_safe_shutdown() {
 #ifdef USE_ESP_IDF
-  dac_oneshot_del_channel(dac_handle_);
+  dac_oneshot_del_channel(this->dac_handle_);
 #endif
 }
 
@@ -50,7 +50,7 @@ void ESP32DAC::write_state(float state) {
   state = state * 255;
 
 #ifdef USE_ESP_IDF
-  dac_oneshot_output_voltage(dac_handle_, state);
+  dac_oneshot_output_voltage(this->dac_handle_, state);
 #endif
 #ifdef USE_ARDUINO
   dacWrite(this->pin_->get_pin(), state);

--- a/esphome/components/esp32_dac/esp32_dac.cpp
+++ b/esphome/components/esp32_dac/esp32_dac.cpp
@@ -8,11 +8,17 @@
 #include <esp32-hal-dac.h>
 #endif
 #ifdef USE_ESP_IDF
-#include <driver/dac.h>
+#include <driver/dac_oneshot.h>
 #endif
 
 namespace esphome {
 namespace esp32_dac {
+
+#ifdef USE_ESP32_VARIANT_ESP32S2
+  static constexpr uint8_t DAC0_PIN = 17;
+#else
+  static constexpr uint8_t DAC0_PIN = 25;
+#endif
 
 static const char *const TAG = "esp32_dac";
 
@@ -22,8 +28,15 @@ void ESP32DAC::setup() {
   this->turn_off();
 
 #ifdef USE_ESP_IDF
-  auto channel = pin_->get_pin() == 25 ? DAC_CHANNEL_1 : DAC_CHANNEL_2;
-  dac_output_enable(channel);
+  const dac_channel_t channel = pin_->get_pin() == DAC0_PIN ? DAC_CHAN_0 : DAC_CHAN_1;
+  const dac_oneshot_config_t oneshot_cfg{channel};
+  dac_oneshot_new_channel(&oneshot_cfg, &dac_handle_);
+#endif
+}
+
+void ESP32DAC::on_safe_shutdown() {
+#ifdef USE_ESP_IDF
+  dac_oneshot_del_channel(dac_handle_);
 #endif
 }
 
@@ -40,8 +53,7 @@ void ESP32DAC::write_state(float state) {
   state = state * 255;
 
 #ifdef USE_ESP_IDF
-  auto channel = pin_->get_pin() == 25 ? DAC_CHANNEL_1 : DAC_CHANNEL_2;
-  dac_output_voltage(channel, (uint8_t) state);
+  dac_oneshot_output_voltage(dac_handle_, state);
 #endif
 #ifdef USE_ARDUINO
   dacWrite(this->pin_->get_pin(), state);

--- a/esphome/components/esp32_dac/esp32_dac.cpp
+++ b/esphome/components/esp32_dac/esp32_dac.cpp
@@ -12,9 +12,9 @@ namespace esphome {
 namespace esp32_dac {
 
 #ifdef USE_ESP32_VARIANT_ESP32S2
-  static constexpr uint8_t DAC0_PIN = 17;
+static constexpr uint8_t DAC0_PIN = 17;
 #else
-  static constexpr uint8_t DAC0_PIN = 25;
+static constexpr uint8_t DAC0_PIN = 25;
 #endif
 
 static const char *const TAG = "esp32_dac";

--- a/esphome/components/esp32_dac/esp32_dac.h
+++ b/esphome/components/esp32_dac/esp32_dac.h
@@ -7,9 +7,9 @@
 
 #ifdef USE_ESP32
 
-// Forward declaration
-struct dac_oneshot_s;
-typedef struct dac_oneshot_s *dac_oneshot_handle_t;
+#ifdef USE_ESP_IDF
+#include <driver/dac_oneshot.h>
+#endif
 
 namespace esphome {
 namespace esp32_dac {

--- a/esphome/components/esp32_dac/esp32_dac.h
+++ b/esphome/components/esp32_dac/esp32_dac.h
@@ -7,6 +7,10 @@
 
 #ifdef USE_ESP32
 
+// Forward declaration
+struct dac_oneshot_s;
+typedef struct dac_oneshot_s *dac_oneshot_handle_t;
+
 namespace esphome {
 namespace esp32_dac {
 
@@ -16,6 +20,7 @@ class ESP32DAC : public output::FloatOutput, public Component {
 
   /// Initialize pin
   void setup() override;
+  void on_safe_shutdown() override;
   void dump_config() override;
   /// HARDWARE setup_priority
   float get_setup_priority() const override { return setup_priority::HARDWARE; }
@@ -24,6 +29,9 @@ class ESP32DAC : public output::FloatOutput, public Component {
   void write_state(float state) override;
 
   InternalGPIOPin *pin_;
+#ifdef USE_ESP_IDF
+  dac_oneshot_handle_t dac_handle_;
+#endif
 };
 
 }  // namespace esp32_dac

--- a/esphome/components/esp32_dac/output.py
+++ b/esphome/components/esp32_dac/output.py
@@ -5,7 +5,7 @@ import esphome.codegen as cg
 from esphome.core import CORE
 from esphome.components.esp32 import get_esp32_variant
 from esphome.components.esp32.const import VARIANT_ESP32S2
-from esphome.const import CONF_ID, CONF_NUMBER, CONF_PIN, KEY_CORE, KEY_TARGET_FRAMEWORK
+from esphome.const import CONF_ID, CONF_NUMBER, CONF_PIN
 
 DEPENDENCIES = ["esp32"]
 

--- a/esphome/components/esp32_dac/output.py
+++ b/esphome/components/esp32_dac/output.py
@@ -1,18 +1,27 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
 from esphome import pins
 from esphome.components import output
-import esphome.config_validation as cv
-import esphome.codegen as cg
 from esphome.components.esp32 import get_esp32_variant
-from esphome.components.esp32.const import VARIANT_ESP32S2
+from esphome.components.esp32.const import VARIANT_ESP32, VARIANT_ESP32S2
 from esphome.const import CONF_ID, CONF_NUMBER, CONF_PIN
 
 DEPENDENCIES = ["esp32"]
 
+DAC_PINS = {
+    VARIANT_ESP32: (25, 26),
+    VARIANT_ESP32S2: (17, 18),
+}
+
 
 def valid_dac_pin(value):
-    valid_pins = (17, 18) if get_esp32_variant() == VARIANT_ESP32S2 else (25, 26)
-    num = value[CONF_NUMBER]
-    cv.one_of(*valid_pins)(num)
+    variant = get_esp32_variant()
+    try:
+        valid_pins = DAC_PINS[variant]
+    except KeyError as ex:
+        raise cv.Invalid(f"DAC is not supported on {variant}") from ex
+    given_pin = value[CONF_NUMBER]
+    cv.one_of(*valid_pins)(given_pin)
     return value
 
 

--- a/esphome/components/esp32_dac/output.py
+++ b/esphome/components/esp32_dac/output.py
@@ -2,14 +2,17 @@ from esphome import pins
 from esphome.components import output
 import esphome.config_validation as cv
 import esphome.codegen as cg
-from esphome.const import CONF_ID, CONF_NUMBER, CONF_PIN
+from esphome.core import CORE
+from esphome.components.esp32 import get_esp32_variant
+from esphome.components.esp32.const import VARIANT_ESP32S2
+from esphome.const import CONF_ID, CONF_NUMBER, CONF_PIN, KEY_CORE, KEY_TARGET_FRAMEWORK
 
 DEPENDENCIES = ["esp32"]
 
-
 def valid_dac_pin(value):
+    valid_pins = (17, 18) if get_esp32_variant() == VARIANT_ESP32S2 else (25, 26)
     num = value[CONF_NUMBER]
-    cv.one_of(25, 26)(num)
+    cv.one_of(*valid_pins)(num)
     return value
 
 

--- a/esphome/components/esp32_dac/output.py
+++ b/esphome/components/esp32_dac/output.py
@@ -8,6 +8,7 @@ from esphome.const import CONF_ID, CONF_NUMBER, CONF_PIN
 
 DEPENDENCIES = ["esp32"]
 
+
 def valid_dac_pin(value):
     valid_pins = (17, 18) if get_esp32_variant() == VARIANT_ESP32S2 else (25, 26)
     num = value[CONF_NUMBER]

--- a/esphome/components/esp32_dac/output.py
+++ b/esphome/components/esp32_dac/output.py
@@ -2,7 +2,6 @@ from esphome import pins
 from esphome.components import output
 import esphome.config_validation as cv
 import esphome.codegen as cg
-from esphome.core import CORE
 from esphome.components.esp32 import get_esp32_variant
 from esphome.components.esp32.const import VARIANT_ESP32S2
 from esphome.const import CONF_ID, CONF_NUMBER, CONF_PIN


### PR DESCRIPTION
# What does this implement/fix?

Added support for DAC on the S2.
Start using dac_oneshot.h instead of the deprecated dac.h

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes [4123](https://github.com/esphome/esphome/issues/4123)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#4552

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
esp32:
  board: esp32-s2-saola-1
  framework:
    type: esp-idf
output:
  - platform: esp32_dac
     pin: GPIO17
     id: dac1_output

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
