### PR TITLE
Scan for zeroconf nodes for detecting log/upload devices when mac_suffix is enabled 

### DIFF
--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -50,7 +50,6 @@ from esphome.util import (
     run_external_process,
     safe_print,
 )
-
 from esphome.zeroconf import get_mac_suffix_nodes
 
 _LOGGER = logging.getLogger(__name__)
@@ -97,9 +96,9 @@ def choose_upload_log_host(
     if default == "SERIAL":
         return choose_prompt(options, purpose=purpose)
     if (show_ota and "ota" in CORE.config) or (show_api and "api" in CORE.config):
-        if CORE.config["esphome"]["name_add_mac_suffix"] :
+        if CORE.config["esphome"]["name_add_mac_suffix"]:
             for addr in get_mac_suffix_nodes(CORE.config["esphome"]["name"]):
-                options.append((f"Over The Air ({addr})", addr))    
+                options.append((f"Over The Air ({addr})", addr))
         else:
             options.append((f"Over The Air ({CORE.address})", CORE.address))
             if default == "OTA":

--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -51,6 +51,8 @@ from esphome.util import (
     safe_print,
 )
 
+from esphome.zeroconf import get_mac_suffix_nodes
+
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -95,9 +97,13 @@ def choose_upload_log_host(
     if default == "SERIAL":
         return choose_prompt(options, purpose=purpose)
     if (show_ota and "ota" in CORE.config) or (show_api and "api" in CORE.config):
-        options.append((f"Over The Air ({CORE.address})", CORE.address))
-        if default == "OTA":
-            return CORE.address
+        if CORE.config["esphome"]["name_add_mac_suffix"] :
+            for addr in get_mac_suffix_nodes(CORE.config["esphome"]["name"]):
+                options.append((f"Over The Air ({addr})", addr))    
+        else:
+            options.append((f"Over The Air ({CORE.address})", CORE.address))
+            if default == "OTA":
+                return CORE.address
     if (
         show_mqtt
         and (mqtt_config := CORE.config.get(CONF_MQTT))

--- a/esphome/zeroconf.py
+++ b/esphome/zeroconf.py
@@ -253,4 +253,4 @@ def get_mac_suffix_nodes(node_name: str) -> list[str]:
     except KeyboardInterrupt:
         loop.run_until_complete(runner.async_close())
 
-    return runner.found_nodes
+    return sorted(runner.found_nodes)

--- a/esphome/zeroconf.py
+++ b/esphome/zeroconf.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass
+import time
 import logging
-from typing import Callable
+from typing import Callable, Optional
 
 from zeroconf import IPVersion, ServiceInfo, ServiceStateChange, Zeroconf
 from zeroconf.asyncio import AsyncServiceBrowser, AsyncServiceInfo, AsyncZeroconf
@@ -199,3 +200,52 @@ class AsyncEsphomeZeroconf(AsyncZeroconf):
         ) and (addresses := info.parsed_scoped_addresses(IPVersion.All)):
             return addresses
         return None
+
+NODE_SCAN_TIME_SEC = 2
+
+class NodeScanner:
+    def __init__(self, node_raw_name: str) -> None:
+        self.node_raw_name = node_raw_name
+        self.aiobrowser: Optional[AsyncServiceBrowser] = None
+        self.aiozc: Optional[AsyncZeroconf] = None
+        self.found_nodes = []
+    
+    def async_on_service_state_change(self, 
+        zeroconf: Zeroconf, service_type: str, name: str, state_change: ServiceStateChange
+    ) -> None:
+        if state_change is not ServiceStateChange.Added:
+            return
+        if name.startswith(self.node_raw_name):
+            self.found_nodes.append(name.split(".")[0] + ".local")
+        
+
+    async def async_run(self) -> None:
+        self.aiozc = AsyncZeroconf(ip_version=IPVersion.V4Only)
+
+        services = ["_esphomelib._tcp.local."]
+        self.aiobrowser = AsyncServiceBrowser(
+            self.aiozc.zeroconf, services, handlers=[self.async_on_service_state_change]
+        )
+        
+        start_time = time.time()
+        while time.time() - start_time < NODE_SCAN_TIME_SEC:
+            await asyncio.sleep(1)
+        
+        await self.async_close()
+
+    async def async_close(self) -> None:
+        assert self.aiozc is not None
+        assert self.aiobrowser is not None
+        await self.aiobrowser.async_cancel()
+        await self.aiozc.async_close()
+
+
+def get_mac_suffix_nodes(node_name:str) -> list[str]:
+    loop = asyncio.get_event_loop()
+    runner = NodeScanner(node_name)
+    try:
+        loop.run_until_complete(runner.async_run())
+    except KeyboardInterrupt:
+        loop.run_until_complete(runner.async_close())
+    
+    return runner.found_nodes


### PR DESCRIPTION
# What does this implement/fix?

When the `name_add_mac_suffix` is set esphome can't receive the local network address purely from its config yaml.
Hence, ota updates and logs via the cli esphome are not working. 
This PR adds the feature to search for nodes on the network via zeroconf.  
Each found esphomelib device that starts with the given node name is added as an option to the upload/log list.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other


## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
