### PR TITLE
Allow CONF_RMT_CHANNEL parameter for IDF 4.X

### DIFF
--- a/esphome/components/esp32_rmt_led_strip/light.py
+++ b/esphome/components/esp32_rmt_led_strip/light.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+import logging
 
 from esphome import pins
 import esphome.codegen as cg
@@ -15,6 +16,9 @@ from esphome.const import (
     CONF_RMT_CHANNEL,
     CONF_RMT_SYMBOLS,
 )
+from esphome.core import CORE
+
+_LOGGER = logging.getLogger(__name__)
 
 CODEOWNERS = ["@jesserockz"]
 DEPENDENCIES = ["esp32"]
@@ -64,14 +68,52 @@ CONF_RESET_HIGH = "reset_high"
 CONF_RESET_LOW = "reset_low"
 
 
+class OptionalForIDF5(cv.SplitDefault):
+    @property
+    def default(self):
+        if not esp32_rmt.use_new_rmt_driver():
+            return cv.UNDEFINED
+        return super().default
+
+    @default.setter
+    def default(self, value):
+        # Ignore default set from vol.Optional
+        pass
+
+
+def only_with_new_rmt_driver(obj):
+    if not esp32_rmt.use_new_rmt_driver():
+        raise cv.Invalid(
+            "This feature is only available for the IDF framework version 5."
+        )
+    return obj
+
+
+def not_with_new_rmt_driver(obj):
+    if esp32_rmt.use_new_rmt_driver():
+        raise cv.Invalid(
+            "This feature is not available for the IDF framework version 5."
+        )
+    return obj
+
+
 def final_validation(config):
-    if not esp32_rmt.use_new_rmt_driver() and CONF_RMT_CHANNEL not in config:
-        raise cv.Invalid("rmt_channel is a required option.")
-    if esp32_rmt.use_new_rmt_driver() and CONF_RMT_CHANNEL in config:
-        cv.only_with_arduino(None)
+    if not esp32_rmt.use_new_rmt_driver():
+        if CONF_RMT_CHANNEL not in config:
+            if CORE.using_esp_idf:
+                raise cv.Invalid(
+                    "rmt_channel is a required option for IDF version < 5."
+                )
+            raise cv.Invalid(
+                "rmt_channel is a required option for the Arduino framework."
+            )
+        _LOGGER.warning(
+            "RMT_LED_STRIP support for IDF version < 5 is deprecated and will be removed soon."
+        )
 
 
 FINAL_VALIDATE_SCHEMA = final_validation
+
 
 CONFIG_SCHEMA = cv.All(
     light.ADDRESSABLE_LIGHT_SCHEMA.extend(
@@ -80,8 +122,10 @@ CONFIG_SCHEMA = cv.All(
             cv.Required(CONF_PIN): pins.internal_gpio_output_pin_number,
             cv.Required(CONF_NUM_LEDS): cv.positive_not_null_int,
             cv.Required(CONF_RGB_ORDER): cv.enum(RGB_ORDERS, upper=True),
-            cv.Optional(CONF_RMT_CHANNEL): esp32_rmt.validate_rmt_channel(tx=True),
-            cv.SplitDefault(
+            cv.Optional(CONF_RMT_CHANNEL): cv.All(
+                not_with_new_rmt_driver, esp32_rmt.validate_rmt_channel(tx=True)
+            ),
+            OptionalForIDF5(
                 CONF_RMT_SYMBOLS,
                 esp32_idf=64,
                 esp32_s2_idf=64,
@@ -89,7 +133,7 @@ CONFIG_SCHEMA = cv.All(
                 esp32_c3_idf=48,
                 esp32_c6_idf=48,
                 esp32_h2_idf=48,
-            ): cv.All(cv.only_with_esp_idf, cv.int_range(min=2)),
+            ): cv.All(only_with_new_rmt_driver, cv.int_range(min=2)),
             cv.Optional(CONF_MAX_REFRESH_RATE): cv.positive_time_period_microseconds,
             cv.Optional(CONF_CHIPSET): cv.one_of(*CHIPSETS, upper=True),
             cv.Optional(CONF_IS_RGBW, default=False): cv.boolean,

--- a/esphome/components/esp32_rmt_led_strip/light.py
+++ b/esphome/components/esp32_rmt_led_strip/light.py
@@ -67,6 +67,8 @@ CONF_RESET_LOW = "reset_low"
 def final_validation(config):
     if not esp32_rmt.use_new_rmt_driver() and CONF_RMT_CHANNEL not in config:
         raise cv.Invalid("rmt_channel is a required option.")
+    if esp32_rmt.use_new_rmt_driver() and CONF_RMT_CHANNEL in config:
+        cv.only_with_arduino(None)
 
 
 FINAL_VALIDATE_SCHEMA = final_validation
@@ -78,9 +80,7 @@ CONFIG_SCHEMA = cv.All(
             cv.Required(CONF_PIN): pins.internal_gpio_output_pin_number,
             cv.Required(CONF_NUM_LEDS): cv.positive_not_null_int,
             cv.Required(CONF_RGB_ORDER): cv.enum(RGB_ORDERS, upper=True),
-            cv.Optional(CONF_RMT_CHANNEL): cv.All(
-                cv.only_with_arduino, esp32_rmt.validate_rmt_channel(tx=True)
-            ),
+            cv.Optional(CONF_RMT_CHANNEL): esp32_rmt.validate_rmt_channel(tx=True),
             cv.SplitDefault(
                 CONF_RMT_SYMBOLS,
                 esp32_idf=64,


### PR DESCRIPTION
# What does this implement/fix?

Starting with PR #7770 the rmt_led_strip won't accept the config when compiling with IDF version 4.X.
It either requires IDF version 5.X or the Arduino Framework.

This PR allows setting the CONF_RMT_CHANNEL parameter when IDF version is 4.X. 

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
