### PR TITLE
Initialize esp32_rmt_led_strip buffer

### DIFF
--- a/esphome/components/esp32_rmt_led_strip/led_strip.cpp
+++ b/esphome/components/esp32_rmt_led_strip/led_strip.cpp
@@ -33,6 +33,7 @@ void ESP32RMTLEDStripLightOutput::setup() {
     this->mark_failed();
     return;
   }
+  memset(this->buf_, 0, buffer_size);
 
   this->effect_data_ = allocator.allocate(this->num_leds_);
   if (this->effect_data_ == nullptr) {


### PR DESCRIPTION
# What does this implement/fix?

When powering on / resetting, `esp32_rmt_led_strip` strips would start with seemingly random colors and then fade to black using `default_transition_length`. It seems something in the setup/initialization uses `this->buf_` as the starting value and then transitions to off.

Also tested using `restore_mode: ALWAYS_ON` and `light.turn_on` in `on_boot` and they both worked as expected (i.e. the light is turned on).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**



**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
light:
  - platform: esp32_rmt_led_strip
    id: strip
    name: "Strip"
    chipset: WS2812
    rgb_order: RGB
    pin: GPIO13
    num_leds: 60
    rmt_channel: 1
    # restore_mode: ALWAYS_ON
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
