### PR TITLE
[esp32_rmt] Use USE_ESP_IDF & USE_ARDUINO to match config code

### DIFF
--- a/esphome/components/esp32_rmt_led_strip/led_strip.cpp
+++ b/esphome/components/esp32_rmt_led_strip/led_strip.cpp
@@ -42,7 +42,7 @@ void ESP32RMTLEDStripLightOutput::setup() {
     return;
   }
 
-#if ESP_IDF_VERSION_MAJOR >= 5
+#ifdef USE_ESP_IDF
   RAMAllocator<rmt_symbol_word_t> rmt_allocator(this->use_psram_ ? 0 : RAMAllocator<rmt_symbol_word_t>::ALLOC_INTERNAL);
 
   // 8 bits per byte, 1 rmt_symbol_word_t per bit + 1 rmt_symbol_word_t for reset
@@ -145,7 +145,7 @@ void ESP32RMTLEDStripLightOutput::write_state(light::LightState *state) {
 
   ESP_LOGVV(TAG, "Writing RGB values to bus...");
 
-#if ESP_IDF_VERSION_MAJOR >= 5
+#ifdef USE_ESP_IDF
   esp_err_t error = rmt_tx_wait_all_done(this->channel_, 1000);
 #else
   esp_err_t error = rmt_wait_tx_done(this->channel_, pdMS_TO_TICKS(1000));
@@ -162,7 +162,7 @@ void ESP32RMTLEDStripLightOutput::write_state(light::LightState *state) {
   size_t size = 0;
   size_t len = 0;
   uint8_t *psrc = this->buf_;
-#if ESP_IDF_VERSION_MAJOR >= 5
+#ifdef USE_ESP_IDF
   rmt_symbol_word_t *pdest = this->rmt_buf_;
 #else
   rmt_item32_t *pdest = this->rmt_buf_;
@@ -184,7 +184,7 @@ void ESP32RMTLEDStripLightOutput::write_state(light::LightState *state) {
     len++;
   }
 
-#if ESP_IDF_VERSION_MAJOR >= 5
+#ifdef USE_ESP_IDF
   rmt_transmit_config_t config;
   memset(&config, 0, sizeof(config));
   config.loop_count = 0;
@@ -249,7 +249,7 @@ light::ESPColorView ESP32RMTLEDStripLightOutput::get_view_internal(int32_t index
 void ESP32RMTLEDStripLightOutput::dump_config() {
   ESP_LOGCONFIG(TAG, "ESP32 RMT LED Strip:");
   ESP_LOGCONFIG(TAG, "  Pin: %u", this->pin_);
-#if ESP_IDF_VERSION_MAJOR >= 5
+#ifdef USE_ESP_IDF
   ESP_LOGCONFIG(TAG, "  RMT Symbols: %" PRIu32, this->rmt_symbols_);
 #else
   ESP_LOGCONFIG(TAG, "  Channel: %u", this->channel_);

--- a/esphome/components/esp32_rmt_led_strip/led_strip.h
+++ b/esphome/components/esp32_rmt_led_strip/led_strip.h
@@ -12,7 +12,7 @@
 #include <esp_err.h>
 #include <esp_idf_version.h>
 
-#if ESP_IDF_VERSION_MAJOR >= 5
+#ifdef USE_ESP_IDF
 #include <driver/rmt_tx.h>
 #else
 #include <driver/rmt.h>
@@ -60,7 +60,7 @@ class ESP32RMTLEDStripLightOutput : public light::AddressableLight {
                       uint32_t reset_time_high, uint32_t reset_time_low);
 
   void set_rgb_order(RGBOrder rgb_order) { this->rgb_order_ = rgb_order; }
-#if ESP_IDF_VERSION_MAJOR >= 5
+#ifdef USE_ESP_IDF
   void set_rmt_symbols(uint32_t rmt_symbols) { this->rmt_symbols_ = rmt_symbols; }
 #else
   void set_rmt_channel(rmt_channel_t channel) { this->channel_ = channel; }
@@ -80,7 +80,7 @@ class ESP32RMTLEDStripLightOutput : public light::AddressableLight {
 
   uint8_t *buf_{nullptr};
   uint8_t *effect_data_{nullptr};
-#if ESP_IDF_VERSION_MAJOR >= 5
+#ifdef USE_ESP_IDF
   rmt_channel_handle_t channel_{nullptr};
   rmt_encoder_handle_t encoder_{nullptr};
   rmt_symbol_word_t *rmt_buf_{nullptr};

--- a/esphome/components/remote_base/remote_base.cpp
+++ b/esphome/components/remote_base/remote_base.cpp
@@ -8,7 +8,7 @@ namespace remote_base {
 
 static const char *const TAG = "remote_base";
 
-#if defined(USE_ESP32) && ESP_IDF_VERSION_MAJOR < 5
+#if defined(USE_ESP32) && defined(USE_ARDUINO)
 RemoteRMTChannel::RemoteRMTChannel(uint8_t mem_block_num) : mem_block_num_(mem_block_num) {
   static rmt_channel_t next_rmt_channel = RMT_CHANNEL_0;
   this->channel_ = next_rmt_channel;

--- a/esphome/components/remote_base/remote_base.h
+++ b/esphome/components/remote_base/remote_base.h
@@ -8,7 +8,7 @@
 #include "esphome/core/component.h"
 #include "esphome/core/hal.h"
 
-#if defined(USE_ESP32) && ESP_IDF_VERSION_MAJOR < 5
+#if defined(USE_ESP32) && defined(USE_ARDUINO)
 #include <driver/rmt.h>
 #endif
 
@@ -112,7 +112,7 @@ class RemoteComponentBase {
 #ifdef USE_ESP32
 class RemoteRMTChannel {
  public:
-#if ESP_IDF_VERSION_MAJOR >= 5
+#ifdef USE_ESP_IDF
   void set_clock_resolution(uint32_t clock_resolution) { this->clock_resolution_ = clock_resolution; }
   void set_rmt_symbols(uint32_t rmt_symbols) { this->rmt_symbols_ = rmt_symbols; }
 #else
@@ -125,7 +125,7 @@ class RemoteRMTChannel {
 
  protected:
   uint32_t from_microseconds_(uint32_t us) {
-#if ESP_IDF_VERSION_MAJOR >= 5
+#ifdef USE_ESP_IDF
     const uint32_t ticks_per_ten_us = this->clock_resolution_ / 100000u;
 #else
     const uint32_t ticks_per_ten_us = 80000000u / this->clock_divider_ / 100000u;
@@ -133,7 +133,7 @@ class RemoteRMTChannel {
     return us * ticks_per_ten_us / 10;
   }
   uint32_t to_microseconds_(uint32_t ticks) {
-#if ESP_IDF_VERSION_MAJOR >= 5
+#ifdef USE_ESP_IDF
     const uint32_t ticks_per_ten_us = this->clock_resolution_ / 100000u;
 #else
     const uint32_t ticks_per_ten_us = 80000000u / this->clock_divider_ / 100000u;
@@ -141,7 +141,7 @@ class RemoteRMTChannel {
     return (ticks * 10) / ticks_per_ten_us;
   }
   RemoteComponentBase *remote_base_;
-#if ESP_IDF_VERSION_MAJOR >= 5
+#ifdef USE_ESP_IDF
   uint32_t clock_resolution_{1000000};
   uint32_t rmt_symbols_;
 #else

--- a/esphome/components/remote_receiver/remote_receiver.h
+++ b/esphome/components/remote_receiver/remote_receiver.h
@@ -5,7 +5,7 @@
 
 #include <cinttypes>
 
-#if defined(USE_ESP32) && ESP_IDF_VERSION_MAJOR >= 5
+#if defined(USE_ESP32) && defined(USE_ESP_IDF)
 #include <driver/rmt_rx.h>
 #endif
 
@@ -29,7 +29,7 @@ struct RemoteReceiverComponentStore {
   uint32_t filter_us{10};
   ISRInternalGPIOPin pin;
 };
-#elif defined(USE_ESP32) && ESP_IDF_VERSION_MAJOR >= 5
+#elif defined(USE_ESP32) && defined(USE_ESP_IDF)
 struct RemoteReceiverComponentStore {
   /// Stores RMT symbols and rx done event data
   volatile uint8_t *buffer{nullptr};
@@ -55,7 +55,7 @@ class RemoteReceiverComponent : public remote_base::RemoteReceiverBase,
 
 {
  public:
-#if defined(USE_ESP32) && ESP_IDF_VERSION_MAJOR < 5
+#if defined(USE_ESP32) && defined(USE_ARDUINO)
   RemoteReceiverComponent(InternalGPIOPin *pin, uint8_t mem_block_num = 1)
       : RemoteReceiverBase(pin), remote_base::RemoteRMTChannel(mem_block_num) {}
 
@@ -69,7 +69,7 @@ class RemoteReceiverComponent : public remote_base::RemoteReceiverBase,
   void loop() override;
   float get_setup_priority() const override { return setup_priority::DATA; }
 
-#if defined(USE_ESP32) && ESP_IDF_VERSION_MAJOR >= 5
+#if defined(USE_ESP32) && defined(USE_ESP_IDF)
   void set_filter_symbols(uint32_t filter_symbols) { this->filter_symbols_ = filter_symbols; }
   void set_receive_symbols(uint32_t receive_symbols) { this->receive_symbols_ = receive_symbols; }
   void set_with_dma(bool with_dma) { this->with_dma_ = with_dma; }
@@ -80,7 +80,7 @@ class RemoteReceiverComponent : public remote_base::RemoteReceiverBase,
 
  protected:
 #ifdef USE_ESP32
-#if ESP_IDF_VERSION_MAJOR >= 5
+#ifdef USE_ESP_IDF
   void decode_rmt_(rmt_symbol_word_t *item, size_t item_count);
   rmt_channel_handle_t channel_{NULL};
   uint32_t filter_symbols_{0};
@@ -94,7 +94,7 @@ class RemoteReceiverComponent : public remote_base::RemoteReceiverBase,
   std::string error_string_{""};
 #endif
 
-#if defined(USE_ESP8266) || defined(USE_LIBRETINY) || (defined(USE_ESP32) && ESP_IDF_VERSION_MAJOR >= 5)
+#if defined(USE_ESP8266) || defined(USE_LIBRETINY) || (defined(USE_ESP32) && defined(USE_ESP_IDF))
   RemoteReceiverComponentStore store_;
   HighFrequencyLoopRequester high_freq_;
 #endif

--- a/esphome/components/remote_receiver/remote_receiver_esp32.cpp
+++ b/esphome/components/remote_receiver/remote_receiver_esp32.cpp
@@ -13,7 +13,7 @@ static const uint32_t RMT_CLK_FREQ = 32000000;
 static const uint32_t RMT_CLK_FREQ = 80000000;
 #endif
 
-#if ESP_IDF_VERSION_MAJOR >= 5
+#ifdef USE_ESP_IDF
 static bool IRAM_ATTR HOT rmt_callback(rmt_channel_handle_t channel, const rmt_rx_done_event_data_t *event, void *arg) {
   RemoteReceiverComponentStore *store = (RemoteReceiverComponentStore *) arg;
   rmt_rx_done_event_data_t *event_buffer = (rmt_rx_done_event_data_t *) (store->buffer + store->buffer_write);
@@ -40,7 +40,7 @@ static bool IRAM_ATTR HOT rmt_callback(rmt_channel_handle_t channel, const rmt_r
 
 void RemoteReceiverComponent::setup() {
   ESP_LOGCONFIG(TAG, "Setting up Remote Receiver...");
-#if ESP_IDF_VERSION_MAJOR >= 5
+#ifdef USE_ESP_IDF
   rmt_rx_channel_config_t channel;
   memset(&channel, 0, sizeof(channel));
   channel.clk_src = RMT_CLK_SRC_DEFAULT;
@@ -154,7 +154,7 @@ void RemoteReceiverComponent::setup() {
 void RemoteReceiverComponent::dump_config() {
   ESP_LOGCONFIG(TAG, "Remote Receiver:");
   LOG_PIN("  Pin: ", this->pin_);
-#if ESP_IDF_VERSION_MAJOR >= 5
+#ifdef USE_ESP_IDF
   ESP_LOGCONFIG(TAG, "  Clock resolution: %" PRIu32 " hz", this->clock_resolution_);
   ESP_LOGCONFIG(TAG, "  RMT symbols: %" PRIu32, this->rmt_symbols_);
   ESP_LOGCONFIG(TAG, "  Filter symbols: %" PRIu32, this->filter_symbols_);
@@ -179,7 +179,7 @@ void RemoteReceiverComponent::dump_config() {
 }
 
 void RemoteReceiverComponent::loop() {
-#if ESP_IDF_VERSION_MAJOR >= 5
+#ifdef USE_ESP_IDF
   if (this->store_.error != ESP_OK) {
     ESP_LOGE(TAG, "Receive error");
     this->error_code_ = this->store_.error;
@@ -222,7 +222,7 @@ void RemoteReceiverComponent::loop() {
 #endif
 }
 
-#if ESP_IDF_VERSION_MAJOR >= 5
+#ifdef USE_ESP_IDF
 void RemoteReceiverComponent::decode_rmt_(rmt_symbol_word_t *item, size_t item_count) {
 #else
 void RemoteReceiverComponent::decode_rmt_(rmt_item32_t *item, size_t item_count) {

--- a/esphome/components/remote_transmitter/remote_transmitter.h
+++ b/esphome/components/remote_transmitter/remote_transmitter.h
@@ -5,7 +5,7 @@
 
 #include <vector>
 
-#if defined(USE_ESP32) && ESP_IDF_VERSION_MAJOR >= 5
+#if defined(USE_ESP32) && defined(USE_ESP_IDF)
 #include <driver/rmt_tx.h>
 #endif
 
@@ -20,7 +20,7 @@ class RemoteTransmitterComponent : public remote_base::RemoteTransmitterBase,
 #endif
 {
  public:
-#if defined(USE_ESP32) && ESP_IDF_VERSION_MAJOR < 5
+#if defined(USE_ESP32) && defined(USE_ARDUINO)
   RemoteTransmitterComponent(InternalGPIOPin *pin, uint8_t mem_block_num = 1)
       : remote_base::RemoteTransmitterBase(pin), remote_base::RemoteRMTChannel(mem_block_num) {}
 
@@ -38,7 +38,7 @@ class RemoteTransmitterComponent : public remote_base::RemoteTransmitterBase,
 
   void set_carrier_duty_percent(uint8_t carrier_duty_percent) { this->carrier_duty_percent_ = carrier_duty_percent; }
 
-#if defined(USE_ESP32) && ESP_IDF_VERSION_MAJOR >= 5
+#if defined(USE_ESP32) && defined(USE_ESP_IDF)
   void set_with_dma(bool with_dma) { this->with_dma_ = with_dma; }
   void set_one_wire(bool one_wire) { this->one_wire_ = one_wire; }
   void set_eot_level(bool eot_level) { this->eot_level_ = eot_level; }
@@ -66,7 +66,7 @@ class RemoteTransmitterComponent : public remote_base::RemoteTransmitterBase,
 
   uint32_t current_carrier_frequency_{38000};
   bool initialized_{false};
-#if ESP_IDF_VERSION_MAJOR >= 5
+#ifdef USE_ESP_IDF
   std::vector<rmt_symbol_word_t> rmt_temp_;
   bool with_dma_{false};
   bool one_wire_{false};

--- a/esphome/components/remote_transmitter/remote_transmitter_esp32.cpp
+++ b/esphome/components/remote_transmitter/remote_transmitter_esp32.cpp
@@ -17,7 +17,7 @@ void RemoteTransmitterComponent::setup() {
 
 void RemoteTransmitterComponent::dump_config() {
   ESP_LOGCONFIG(TAG, "Remote Transmitter:");
-#if ESP_IDF_VERSION_MAJOR >= 5
+#ifdef USE_ESP_IDF
   ESP_LOGCONFIG(TAG, "  One wire: %s", this->one_wire_ ? "true" : "false");
   ESP_LOGCONFIG(TAG, "  Clock resolution: %" PRIu32 " hz", this->clock_resolution_);
   ESP_LOGCONFIG(TAG, "  RMT symbols: %" PRIu32, this->rmt_symbols_);
@@ -38,7 +38,7 @@ void RemoteTransmitterComponent::dump_config() {
   }
 }
 
-#if ESP_IDF_VERSION_MAJOR >= 5
+#ifdef USE_ESP_IDF
 void RemoteTransmitterComponent::digital_write(bool value) {
   rmt_symbol_word_t symbol = {
       .duration0 = 1,
@@ -64,7 +64,7 @@ void RemoteTransmitterComponent::digital_write(bool value) {
 #endif
 
 void RemoteTransmitterComponent::configure_rmt_() {
-#if ESP_IDF_VERSION_MAJOR >= 5
+#ifdef USE_ESP_IDF
   esp_err_t error;
 
   if (!this->initialized_) {
@@ -192,7 +192,7 @@ void RemoteTransmitterComponent::send_internal(uint32_t send_times, uint32_t sen
   this->rmt_temp_.clear();
   this->rmt_temp_.reserve((this->temp_.get_data().size() + 1) / 2);
   uint32_t rmt_i = 0;
-#if ESP_IDF_VERSION_MAJOR >= 5
+#ifdef USE_ESP_IDF
   rmt_symbol_word_t rmt_item;
 #else
   rmt_item32_t rmt_item;
@@ -231,7 +231,7 @@ void RemoteTransmitterComponent::send_internal(uint32_t send_times, uint32_t sen
     return;
   }
   this->transmit_trigger_->trigger();
-#if ESP_IDF_VERSION_MAJOR >= 5
+#ifdef USE_ESP_IDF
   for (uint32_t i = 0; i < send_times; i++) {
     rmt_transmit_config_t config;
     memset(&config, 0, sizeof(config));


### PR DESCRIPTION
# What does this implement/fix?

Switch from ESP_IDF_VERSION_MAJOR to USE_ESP_IDF & USE_ARDUINO to match config code and avoid confusion about IDF 4 support. 

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
