### PR TITLE
Fix Waveshare 7in5bv3bwr image quality in BWR mode

### DIFF
--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -2450,12 +2450,12 @@ void WaveshareEPaper7P5InBV3BWR::init_display_() {
   this->data(0x20);
   this->data(0x01);  // gate 480
   this->data(0xE0);
-  
+
   // COMMAND VCOM AND DATA INTERVAL SETTING
   this->command(0x50);
   this->data(0x20);
   this->data(0x00);
-  
+
   // COMMAND TCON SETTING
   this->command(0x60);
   this->data(0x22);

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -2435,13 +2435,6 @@ void WaveshareEPaper7P5InBV3BWR::init_display_() {
   this->command(0x82);
   this->data(0x24);  // VCOM=-1.9V
 
-  // Booster Setting
-  this->command(0x06);
-  this->data(0x27);
-  this->data(0x27);
-  this->data(0x18);
-  this->data(0x17);
-  
   // POWER ON
   this->command(0x04);
   delay(100);  // NOLINT

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -2425,28 +2425,28 @@ void WaveshareEPaper7P5InBV3BWR::init_display_() {
   this->command(0x01);
 
   // 1-0=11: internal power
-  this->data(0x07);
-  this->data(0x17);  // VGH&VGL
-  this->data(0x3F);  // VSH
-  this->data(0x26);  // VSL
-  this->data(0x11);  // VSHR
+  this->data(0x07);  // VRS_EN=1, VS_EN=1, VG_EN=1
+  this->data(0x17);  // VGH&VGL ??? VCOM_SLEW=1 but this is fixed, VG_LVL[2:0]=111 => VGH=20V VGL=-20V, it could be 0x07
+  this->data(0x3F);  // VSH=15V?
+  this->data(0x26);  // VSL=-9.4V?
+  this->data(0x11);  // VSHR=5.8V?
 
   // VCOM DC Setting
   this->command(0x82);
-  this->data(0x24);  // VCOM
+  this->data(0x24);  // VCOM=-1.9V
 
   // Booster Setting
   this->command(0x06);
   this->data(0x27);
   this->data(0x27);
-  this->data(0x2F);
+  this->data(0x18);
   this->data(0x17);
-
+  
   // POWER ON
   this->command(0x04);
-
   delay(100);  // NOLINT
   this->wait_until_idle_();
+
   // COMMAND PANEL SETTING
   this->command(0x00);
   this->data(0x0F);  // KW-3f   KWR-2F BWROTP 0f BWOTP 1f
@@ -2457,16 +2457,16 @@ void WaveshareEPaper7P5InBV3BWR::init_display_() {
   this->data(0x20);
   this->data(0x01);  // gate 480
   this->data(0xE0);
-  // COMMAND ...?
-  this->command(0x15);
-  this->data(0x00);
+  
   // COMMAND VCOM AND DATA INTERVAL SETTING
   this->command(0x50);
   this->data(0x20);
   this->data(0x00);
+  
   // COMMAND TCON SETTING
   this->command(0x60);
   this->data(0x22);
+
   // Resolution setting
   this->command(0x65);
   this->data(0x00);


### PR DESCRIPTION
# What does this implement/fix?

Fixes pale blacks when in BWR mode
Fixes image artifacts when in BWR mode

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
