### PR TITLE
Use abspath for config path dir

### DIFF
--- a/esphome/core/__init__.py
+++ b/esphome/core/__init__.py
@@ -582,7 +582,7 @@ class EsphomeCore:
 
     @property
     def config_dir(self):
-        return os.path.dirname(self.config_path)
+        return os.path.dirname(os.path.abspath(self.config_path))
 
     @property
     def data_dir(self):


### PR DESCRIPTION
# What does this implement/fix?
When the command line is used with a relative path for the config file, the created `.esphome/storage/conf.yaml.json` file is different than the one used when the command line is used with an absolute path, or when it is triggered using the Dashboard:

- using `/config$ esphome compile conf.yaml`, the `.esphome/storage/conf.yaml.json` file contains:
  ```yaml
  ...
  "build_path": ".esphome/build/esp-ventilo",
  "firmware_bin_path": ".esphome/build/esp-ventilo/.pioenvs/esp-ventilo/firmware.bin",
  ...
  ```

- using `/config$ esphome compile /config/conf.yaml`, or using the dashboard, the `.esphome/storage/conf.yaml.json` file contains:
  ```yaml
  ...
  "build_path": "/config/.esphome/build/esp-ventilo",
  "firmware_bin_path": "/config/.esphome/build/esp-ventilo/.pioenvs/esp-ventilo/firmware.bin",
  ...
  ```

As a consequence, using a build from the dashboard (or with an absolute path in the command line) after a build in the command line with a relative path triggers a full clean and rebuild as a global change is detected, and same for the reverse.

The goal of this PR is to use the `os.path.abspath` to normalize this path and avoid useless rebuilds.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- None

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- None

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

None, as irrelevant

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
