### PR TITLE
add model a02yytw (uart controlled) to the A02YY distance sensor

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -12,7 +12,7 @@ esphome/core/* @esphome/core
 
 # Integrations
 esphome/components/a01nyub/* @MrSuicideParrot
-esphome/components/a02yyuw/* @TH-Braemer
+esphome/components/a02yyuw/* @TH-Braemer @alexandrezia
 esphome/components/absolute_humidity/* @DAVe3283
 esphome/components/ac_dimmer/* @glmnet
 esphome/components/adc/* @esphome/core

--- a/esphome/components/a02yyuw/__init__.py
+++ b/esphome/components/a02yyuw/__init__.py
@@ -1,1 +1,1 @@
-CODEOWNERS = ["@TH-Braemer"]
+CODEOWNERS = ["@TH-Braemer", "@alexandrezia"]

--- a/esphome/components/a02yyuw/a02yyuw.cpp
+++ b/esphome/components/a02yyuw/a02yyuw.cpp
@@ -1,4 +1,4 @@
-// Datasheet https://wiki.dfrobot.com/_A02YYUW_Waterproof_Ultrasonic_Sensor_SKU_SEN0311
+// Datasheet https://www.dypcn.com/uploads/A02-Datasheet.pdf
 
 #include "a02yyuw.h"
 #include "esphome/core/helpers.h"
@@ -8,6 +8,13 @@ namespace esphome {
 namespace a02yyuw {
 
 static const char *const TAG = "a02yyuw.sensor";
+
+void A02yyuwComponent::update() {
+  if (this->model_ == A02YYTW) {
+    this->write_byte(0xFF);
+    ESP_LOGV(TAG, "Request read out from sensor");
+  }
+}
 
 void A02yyuwComponent::loop() {
   uint8_t data;
@@ -37,7 +44,17 @@ void A02yyuwComponent::check_buffer_() {
   this->buffer_.clear();
 }
 
-void A02yyuwComponent::dump_config() { LOG_SENSOR("", "A02yyuw Sensor", this); }
+void A02yyuwComponent::dump_config() {
+  switch (this->model_) {
+    case A02YYUW:
+      ESP_LOGCONFIG(TAG, "  sensor model: a02yyuw");
+      break;
+    case A02YYTW:
+      ESP_LOGCONFIG(TAG, "  sensor model: a02yytw");
+      LOG_UPDATE_INTERVAL(this);
+      break;
+  }
+}
 
 }  // namespace a02yyuw
 }  // namespace esphome

--- a/esphome/components/a02yyuw/a02yyuw.h
+++ b/esphome/components/a02yyuw/a02yyuw.h
@@ -9,16 +9,23 @@
 namespace esphome {
 namespace a02yyuw {
 
-class A02yyuwComponent : public sensor::Sensor, public Component, public uart::UARTDevice {
+enum Model {
+  A02YYUW,
+  A02YYTW,
+};
+
+class A02yyuwComponent : public sensor::Sensor, public PollingComponent, public uart::UARTDevice {
  public:
-  // Nothing really public.
+  void set_model(Model model) { this->model_ = model; }
 
   // ========== INTERNAL METHODS ==========
+  void update() override;
   void loop() override;
   void dump_config() override;
 
  protected:
   void check_buffer_();
+  Model model_;
 
   std::vector<uint8_t> buffer_;
 };

--- a/esphome/components/a02yyuw/sensor.py
+++ b/esphome/components/a02yyuw/sensor.py
@@ -1,41 +1,71 @@
 import esphome.codegen as cg
 from esphome.components import sensor, uart
+import esphome.config_validation as cv
 from esphome.const import (
-    STATE_CLASS_MEASUREMENT,
-    ICON_ARROW_EXPAND_VERTICAL,
+    CONF_MODEL,
+    CONF_UPDATE_INTERVAL,
     DEVICE_CLASS_DISTANCE,
+    ICON_ARROW_EXPAND_VERTICAL,
+    STATE_CLASS_MEASUREMENT,
     UNIT_MILLIMETER,
 )
 
-CODEOWNERS = ["@TH-Braemer"]
+CODEOWNERS = ["@TH-Braemer", "@alexandrezia"]
 DEPENDENCIES = ["uart"]
 
 a02yyuw_ns = cg.esphome_ns.namespace("a02yyuw")
 A02yyuwComponent = a02yyuw_ns.class_(
-    "A02yyuwComponent", sensor.Sensor, cg.Component, uart.UARTDevice
+    "A02yyuwComponent", sensor.Sensor, cg.PollingComponent, uart.UARTDevice
+)
+Model = a02yyuw_ns.enum("Model")
+MODEL = {
+    "a02yyuw": Model.A02YYUW,
+    "a02yytw": Model.A02YYTW,
+}
+
+CONFIG_SCHEMA = (
+    sensor.sensor_schema(
+        A02yyuwComponent,
+        unit_of_measurement=UNIT_MILLIMETER,
+        icon=ICON_ARROW_EXPAND_VERTICAL,
+        accuracy_decimals=0,
+        state_class=STATE_CLASS_MEASUREMENT,
+        device_class=DEVICE_CLASS_DISTANCE,
+    )
+    .extend(cv.polling_component_schema("100ms"))
+    .extend(uart.UART_DEVICE_SCHEMA)
+    .extend(
+        {
+            cv.Optional(CONF_MODEL, default="a02yyuw"): cv.enum(MODEL, upper=False),
+        }
+    )
 )
 
-CONFIG_SCHEMA = sensor.sensor_schema(
-    A02yyuwComponent,
-    unit_of_measurement=UNIT_MILLIMETER,
-    icon=ICON_ARROW_EXPAND_VERTICAL,
-    accuracy_decimals=0,
-    state_class=STATE_CLASS_MEASUREMENT,
-    device_class=DEVICE_CLASS_DISTANCE,
-).extend(uart.UART_DEVICE_SCHEMA)
 
-FINAL_VALIDATE_SCHEMA = uart.final_validate_device_schema(
-    "a02yyuw",
-    baud_rate=9600,
-    require_tx=False,
-    require_rx=True,
-    data_bits=8,
-    parity=None,
-    stop_bits=1,
-)
+def final_validation(config):
+    require_tx = True
+    if config[CONF_MODEL] == "a02yyuw":
+        config.pop(CONF_UPDATE_INTERVAL, None)
+        require_tx = False
+    schema = uart.final_validate_device_schema(
+        "a02yyuw",
+        baud_rate=9600,
+        require_tx=require_tx,
+        require_rx=True,
+        data_bits=8,
+        parity=None,
+        stop_bits=1,
+    )
+    schema(config)
+
+
+FINAL_VALIDATE_SCHEMA = final_validation
 
 
 async def to_code(config):
     var = await sensor.new_sensor(config)
     await cg.register_component(var, config)
     await uart.register_uart_device(var, config)
+    cg.add(var.set_model(config[CONF_MODEL]))
+    if CONF_UPDATE_INTERVAL in config:
+        cg.add(var.set_update_interval(config[CONF_UPDATE_INTERVAL]))

--- a/tests/components/a02yyuw/common.yaml
+++ b/tests/components/a02yyuw/common.yaml
@@ -1,7 +1,22 @@
 uart:
   - id: uart_a02yyuw
-    tx_pin: ${tx_pin}
-    rx_pin: ${rx_pin}
+    tx_pin: ${tx_pin_uw}
+    rx_pin: ${rx_pin_uw}
+    baud_rate: 9600
+
+  - id: uart_a02yyuw_model
+    tx_pin: ${tx_pin_uw_model}
+    rx_pin: ${rx_pin_uw_model}
+    baud_rate: 9600
+
+  - id: uart_02yytw_model
+    tx_pin: ${tx_pin_tw_model}
+    rx_pin: ${rx_pin_tw_model}
+    baud_rate: 9600
+
+  - id: uart_a02yytw_model_interval
+    tx_pin: ${tx_pin_tw_model_interval}
+    rx_pin: ${rx_pin_tw_model_interval}
     baud_rate: 9600
 
 sensor:
@@ -14,18 +29,18 @@ sensor:
     model: a02yyuw
     id: a02yyuw_sensor_model
     name: a02yyuw Distance Model
-    uart_id: uart_a02yyuw
+    uart_id: uart_a02yyuw_model
 
   - platform: a02yyuw
     model: a02yytw
     id: a02yytw_sensor_model
     name: a02yytw Distance Model
-    uart_id: uart_a02yyuw
+    uart_id: uart_02yytw_model
 
   - platform: a02yyuw
     model: a02yytw
     update_interval: 500ms
     id: a02yytw_sensor_model_interval
     name: a02yyuw Distance Model Interval
-    uart_id: uart_a02yyuw
+    uart_id: uart_a02yytw_model_interval
 

--- a/tests/components/a02yyuw/common.yaml
+++ b/tests/components/a02yyuw/common.yaml
@@ -1,0 +1,31 @@
+uart:
+  - id: uart_a02yyuw
+    tx_pin: ${tx_pin}
+    rx_pin: ${rx_pin}
+    baud_rate: 9600
+
+sensor:
+  - platform: a02yyuw
+    id: a02yyuw_sensor
+    name: a02yyuw Distance
+    uart_id: uart_a02yyuw
+
+  - platform: a02yyuw
+    model: a02yyuw
+    id: a02yyuw_sensor_model
+    name: a02yyuw Distance Model
+    uart_id: uart_a02yyuw
+
+  - platform: a02yyuw
+    model: a02yytw
+    id: a02yytw_sensor_model
+    name: a02yytw Distance Model
+    uart_id: uart_a02yyuw
+
+  - platform: a02yyuw
+    model: a02yytw
+    update_interval: 500ms
+    id: a02yytw_sensor_model_interval
+    name: a02yyuw Distance Model Interval
+    uart_id: uart_a02yyuw
+

--- a/tests/components/a02yyuw/test.esp32-ard.yaml
+++ b/tests/components/a02yyuw/test.esp32-ard.yaml
@@ -1,13 +1,5 @@
-uart:
-  - id: uart_a02yyuw
-    tx_pin:
-      number: 17
-    rx_pin:
-      number: 16
-    baud_rate: 9600
+substitutions:
+  tx_pin: GPIO17
+  rx_pin: GPIO16
 
-sensor:
-  - platform: a02yyuw
-    id: a02yyuw_sensor
-    name: a02yyuw Distance
-    uart_id: uart_a02yyuw
+<<: !include common.yaml

--- a/tests/components/a02yyuw/test.esp32-ard.yaml
+++ b/tests/components/a02yyuw/test.esp32-ard.yaml
@@ -1,5 +1,15 @@
 substitutions:
-  tx_pin: GPIO17
-  rx_pin: GPIO16
+
+  tx_pin_uw: GPIO17
+  rx_pin_uw: GPIO16
+
+  tx_pin_uw_model: GPIO18
+  rx_pin_uw_model: GPIO19
+
+  tx_pin_tw_model: GPIO20
+  rx_pin_tw_model: GPIO21
+
+  tx_pin_tw_model_interval: GPIO22
+  rx_pin_tw_model_interval: GPIO23
 
 <<: !include common.yaml

--- a/tests/components/a02yyuw/test.esp32-c3-ard.yaml
+++ b/tests/components/a02yyuw/test.esp32-c3-ard.yaml
@@ -1,13 +1,5 @@
-uart:
-  - id: uart_a02yyuw
-    tx_pin:
-      number: 4
-    rx_pin:
-      number: 5
-    baud_rate: 9600
+substitutions:
+  tx_pin: GPIO4
+  rx_pin: GPIO5
 
-sensor:
-  - platform: a02yyuw
-    id: a02yyuw_sensor
-    name: a02yyuw Distance
-    uart_id: uart_a02yyuw
+<<: !include common.yaml

--- a/tests/components/a02yyuw/test.esp32-c3-ard.yaml
+++ b/tests/components/a02yyuw/test.esp32-c3-ard.yaml
@@ -1,5 +1,15 @@
 substitutions:
-  tx_pin: GPIO4
-  rx_pin: GPIO5
+
+  tx_pin_uw: GPIO4
+  rx_pin_uw: GPIO5
+
+  tx_pin_uw_model: GPIO6
+  rx_pin_uw_model: GPIO7
+
+  tx_pin_tw_model: GPIO10
+  rx_pin_tw_model: GPIO11
+
+  tx_pin_tw_model_interval: GPIO1
+  rx_pin_tw_model_interval: GPIO3
 
 <<: !include common.yaml

--- a/tests/components/a02yyuw/test.esp32-c3-idf.yaml
+++ b/tests/components/a02yyuw/test.esp32-c3-idf.yaml
@@ -1,13 +1,5 @@
-uart:
-  - id: uart_a02yyuw
-    tx_pin:
-      number: 4
-    rx_pin:
-      number: 5
-    baud_rate: 9600
+substitutions:
+  tx_pin: GPIO4
+  rx_pin: GPIO5
 
-sensor:
-  - platform: a02yyuw
-    id: a02yyuw_sensor
-    name: a02yyuw Distance
-    uart_id: uart_a02yyuw
+<<: !include common.yaml

--- a/tests/components/a02yyuw/test.esp32-c3-idf.yaml
+++ b/tests/components/a02yyuw/test.esp32-c3-idf.yaml
@@ -1,5 +1,15 @@
 substitutions:
-  tx_pin: GPIO4
-  rx_pin: GPIO5
+
+  tx_pin_uw: GPIO4
+  rx_pin_uw: GPIO5
+
+  tx_pin_uw_model: GPIO6
+  rx_pin_uw_model: GPIO7
+
+  tx_pin_tw_model: GPIO10
+  rx_pin_tw_model: GPIO11
+
+  tx_pin_tw_model_interval: GPIO1
+  rx_pin_tw_model_interval: GPIO3
 
 <<: !include common.yaml

--- a/tests/components/a02yyuw/test.esp32-idf.yaml
+++ b/tests/components/a02yyuw/test.esp32-idf.yaml
@@ -1,6 +1,15 @@
 substitutions:
-  tx_pin: GPIO17
-  rx_pin: GPIO16
+
+  tx_pin_uw: GPIO17
+  rx_pin_uw: GPIO16
+
+  tx_pin_uw_model: GPIO18
+  rx_pin_uw_model: GPIO19
+
+  tx_pin_tw_model: GPIO20
+  rx_pin_tw_model: GPIO21
+
+  tx_pin_tw_model_interval: GPIO22
+  rx_pin_tw_model_interval: GPIO23
 
 <<: !include common.yaml
-

--- a/tests/components/a02yyuw/test.esp32-idf.yaml
+++ b/tests/components/a02yyuw/test.esp32-idf.yaml
@@ -1,13 +1,6 @@
-uart:
-  - id: uart_a02yyuw
-    tx_pin:
-      number: 17
-    rx_pin:
-      number: 16
-    baud_rate: 9600
+substitutions:
+  tx_pin: GPIO17
+  rx_pin: GPIO16
 
-sensor:
-  - platform: a02yyuw
-    id: a02yyuw_sensor
-    name: a02yyuw Distance
-    uart_id: uart_a02yyuw
+<<: !include common.yaml
+

--- a/tests/components/a02yyuw/test.esp8266-ard.yaml
+++ b/tests/components/a02yyuw/test.esp8266-ard.yaml
@@ -1,13 +1,5 @@
-uart:
-  - id: uart_a02yyuw
-    tx_pin:
-      number: 4
-    rx_pin:
-      number: 5
-    baud_rate: 9600
+substitutions:
+  tx_pin: GPIO4
+  rx_pin: GPIO5
 
-sensor:
-  - platform: a02yyuw
-    id: a02yyuw_sensor
-    name: a02yyuw Distance
-    uart_id: uart_a02yyuw
+<<: !include common.yaml

--- a/tests/components/a02yyuw/test.esp8266-ard.yaml
+++ b/tests/components/a02yyuw/test.esp8266-ard.yaml
@@ -1,5 +1,15 @@
 substitutions:
-  tx_pin: GPIO4
-  rx_pin: GPIO5
+
+  tx_pin_uw: GPIO1
+  rx_pin_uw: GPIO3
+
+  tx_pin_uw_model: GPIO4
+  rx_pin_uw_model: GPIO5
+
+  tx_pin_tw_model: GPIO13
+  rx_pin_tw_model: GPIO14
+
+  tx_pin_tw_model_interval: GPIO16
+  rx_pin_tw_model_interval: GPIO15
 
 <<: !include common.yaml

--- a/tests/components/a02yyuw/test.rp2040-ard.yaml
+++ b/tests/components/a02yyuw/test.rp2040-ard.yaml
@@ -1,13 +1,5 @@
-uart:
-  - id: uart_a02yyuw
-    tx_pin:
-      number: 4
-    rx_pin:
-      number: 5
-    baud_rate: 9600
+substitutions:
+  tx_pin: GPIO4
+  rx_pin: GPIO5
 
-sensor:
-  - platform: a02yyuw
-    id: a02yyuw_sensor
-    name: a02yyuw Distance
-    uart_id: uart_a02yyuw
+<<: !include common.yaml

--- a/tests/components/a02yyuw/test.rp2040-ard.yaml
+++ b/tests/components/a02yyuw/test.rp2040-ard.yaml
@@ -1,5 +1,15 @@
 substitutions:
-  tx_pin: GPIO4
-  rx_pin: GPIO5
+
+  tx_pin_uw: GPIO4
+  rx_pin_uw: GPIO5
+
+  tx_pin_uw_model: GPIO6
+  rx_pin_uw_model: GPIO7
+
+  tx_pin_tw_model: GPIO10
+  rx_pin_tw_model: GPIO11
+
+  tx_pin_tw_model_interval: GPIO1
+  rx_pin_tw_model_interval: GPIO3
 
 <<: !include common.yaml


### PR DESCRIPTION
# What does this implement/fix?

The component sensor A02YYUW currently present in esphome works with one of of the five A02 distance sensor models.
The existent module is intended to work with the A02YYUW model, which is outputs to UART interface automatically, every 100ms it will output a distance reading.
However, the documentation  only mentions UART and there are two types of UART models:

- A02YYUW - UART automatic output - automatic output
- A02YYTW - UART controlled output - one needs to request for a distance reading output explicitly 

And as the documentation does not explicitly states that it is meant to work with the UW (auto output) model, I bought the TW (controlled output) model.
So this PR is implementing the TW model functionality, were a reading request is sent to the device on a pre-determined time period (defaults to 100ms)

New attributes:
```
  model: a02yyuw | a02yytw  - defaults to a02yyuw if ommited
  update_interval: <time> - defaults to 100ms if ommited, only relevant to model: a02yytw will be ignored if model is: a02yyuw
``` 

I kept the same platform name and if the new attributes are ommited will default to the initial a02yyuw model, in order to maintain compatibility with already existing configurations, 

Strictly speaking, according to the Datasheet, the platform name of this sensor should be: `a02` or even `a02yy` but I think renaming now would create confusion in end users.

https://www.dypcn.com/uploads/A02-Datasheet.pdf

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**


**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#4567

## Test Environment

- [X] ESP32
- [X] ESP32 IDF
- [X] ESP8266
- [X] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

sensor:

  # compatible with existing configurations, defaults to the UW auto output model
  - id: uw_distance_sensor
    platform: a02yyuw

  # specify model: UW auto output model
  - id: uw_distance_sensor_model
    platform: a02yyuw
    model: a02yyuw

  # uart controlled model TW, defaults to 100ms readings like the UW auto model
  - id: tw_distance_sensor
    platform: a02yyuw
    model: a02yytw

  # uart controlled model TW, with custom 500ms readings
  - id: tw_distance_sensor_500
    platform: a02yyuw
    model: a02yytw
    update_interval: 500ms
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
