### PR TITLE
Expose support for `toggle_action` in Cover API

### DIFF
--- a/esphome/components/api/api.proto
+++ b/esphome/components/api/api.proto
@@ -303,6 +303,7 @@ message ListEntitiesCoverResponse {
   string icon = 10;
   EntityCategory entity_category = 11;
   bool supports_stop = 12;
+  bool supports_toggle = 13;
 }
 
 enum LegacyCoverState {

--- a/esphome/components/api/api.proto
+++ b/esphome/components/api/api.proto
@@ -354,6 +354,7 @@ message CoverCommandRequest {
   bool has_tilt = 6;
   float tilt = 7;
   bool stop = 8;
+  bool toggle = 9;
 }
 
 // ==================== FAN ====================

--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -257,6 +257,7 @@ bool APIConnection::send_cover_info(cover::Cover *cover) {
     msg.name = cover->get_name();
   msg.unique_id = get_default_unique_id("cover", cover);
   msg.assumed_state = traits.get_is_assumed_state();
+  msg.supports_toggle = traits.get_supports_toggle();
   msg.supports_position = traits.get_supports_position();
   msg.supports_tilt = traits.get_supports_tilt();
   msg.supports_stop = traits.get_supports_stop();

--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -286,6 +286,8 @@ void APIConnection::cover_command(const CoverCommandRequest &msg) {
         break;
     }
   }
+  if (msg.toggle)
+    call.set_command_toggle();
   if (msg.has_position)
     call.set_position(msg.position);
   if (msg.has_tilt)

--- a/esphome/components/api/api_pb2.cpp
+++ b/esphome/components/api/api_pb2.cpp
@@ -1134,6 +1134,10 @@ bool ListEntitiesCoverResponse::decode_varint(uint32_t field_id, ProtoVarInt val
       this->supports_stop = value.as_bool();
       return true;
     }
+    case 13: {
+      this->supports_toggle = value.as_bool();
+      return true;
+    }
     default:
       return false;
   }
@@ -1187,6 +1191,7 @@ void ListEntitiesCoverResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_string(10, this->icon);
   buffer.encode_enum<enums::EntityCategory>(11, this->entity_category);
   buffer.encode_bool(12, this->supports_stop);
+  buffer.encode_bool(13, this->supports_toggle);
 }
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void ListEntitiesCoverResponse::dump_to(std::string &out) const {
@@ -1211,6 +1216,10 @@ void ListEntitiesCoverResponse::dump_to(std::string &out) const {
 
   out.append("  assumed_state: ");
   out.append(YESNO(this->assumed_state));
+  out.append("\n");
+
+  out.append("  supports_toggle: ");
+  out.append(YESNO(this->supports_toggle));
   out.append("\n");
 
   out.append("  supports_position: ");

--- a/esphome/components/api/api_pb2.h
+++ b/esphome/components/api/api_pb2.h
@@ -471,6 +471,7 @@ class CoverCommandRequest : public ProtoMessage {
   uint32_t key{0};
   bool has_legacy_command{false};
   enums::LegacyCoverCommand legacy_command{};
+  bool toggle{false};
   bool has_position{false};
   float position{0.0f};
   bool has_tilt{false};

--- a/esphome/components/api/api_pb2.h
+++ b/esphome/components/api/api_pb2.h
@@ -432,6 +432,7 @@ class ListEntitiesCoverResponse : public ProtoMessage {
   std::string name{};
   std::string unique_id{};
   bool assumed_state{false};
+  bool supports_toggle{false};
   bool supports_position{false};
   bool supports_tilt{false};
   std::string device_class{};

--- a/esphome/components/cover/cover_traits.h
+++ b/esphome/components/cover/cover_traits.h
@@ -9,6 +9,8 @@ class CoverTraits {
 
   bool get_is_assumed_state() const { return this->is_assumed_state_; }
   void set_is_assumed_state(bool is_assumed_state) { this->is_assumed_state_ = is_assumed_state; }
+  bool get_supports_toggle() const { return this->supports_toggle_; }
+  void set_supports_toggle(bool supports_toggle) { this->supports_toggle_ = supports_toggle; }
   bool get_supports_position() const { return this->supports_position_; }
   void set_supports_position(bool supports_position) { this->supports_position_ = supports_position; }
   bool get_supports_tilt() const { return this->supports_tilt_; }


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- refs https://github.com/home-assistant/core/issues/135099
- refs https://github.com/home-assistant/core/pull/135103
- refs https://github.com/esphome/aioesphomeapi/pull/1025

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
cover:
  - platform: template
    name: Garage Door
    device_class: garage
    open_action:
      logger.log: open_action called
    close_action:
      logger.log: close_action called
    toggle_action:
      logger.log: toggle_action called
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
