### PR TITLE
Fixed comment typo in light_color_values.h

### DIFF
--- a/esphome/components/light/light_color_values.h
+++ b/esphome/components/light/light_color_values.h
@@ -36,7 +36,7 @@ inline static uint8_t to_uint8_scale(float x) { return static_cast<uint8_t>(roun
  *   range as set in the traits, so the output needs to do this.
  *
  * For COLD_WARM_WHITE capability:
- * - cold_white, warm_white: The brightness of the cald and warm white channels of the light.
+ * - cold_white, warm_white: The brightness of the light's cold and warm white channels.
  *
  * All values (except color temperature) are represented using floats in the range 0.0 (off) to 1.0 (on), and are
  * automatically clamped to this range. Properties not used in the current color mode can still have (invalid) values


### PR DESCRIPTION
# What does this implement/fix?

Fixed comment typo in `light_color_values.h`.
Corrected "cald" to "cold" and reversed the sentence structure.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
