### PR TITLE
[remote_transmitter] Fix issues with 32bit rollover on esp8266 and libretiny

### DIFF
--- a/esphome/components/remote_transmitter/remote_transmitter_esp8266.cpp
+++ b/esphome/components/remote_transmitter/remote_transmitter_esp8266.cpp
@@ -37,7 +37,7 @@ void RemoteTransmitterComponent::await_target_time_() {
   const uint32_t current_time = micros();
   if (this->target_time_ == 0) {
     this->target_time_ = current_time;
-  } else if (this->target_time_ > current_time) {
+  } else if ((int32_t) (this->target_time_ - current_time) > 0) {
     delayMicroseconds(this->target_time_ - current_time);
   }
 }
@@ -50,13 +50,13 @@ void RemoteTransmitterComponent::mark_(uint32_t on_time, uint32_t off_time, uint
   if (this->carrier_duty_percent_ < 100 && (on_time > 0 || off_time > 0)) {
     while (true) {  // Modulate with carrier frequency
       this->target_time_ += on_time;
-      if (this->target_time_ >= target)
+      if ((int32_t) (this->target_time_ - target) >= 0)
         break;
       this->await_target_time_();
       this->pin_->digital_write(false);
 
       this->target_time_ += off_time;
-      if (this->target_time_ >= target)
+      if ((int32_t) (this->target_time_ - target) >= 0)
         break;
       this->await_target_time_();
       this->pin_->digital_write(true);

--- a/esphome/components/remote_transmitter/remote_transmitter_libretiny.cpp
+++ b/esphome/components/remote_transmitter/remote_transmitter_libretiny.cpp
@@ -38,7 +38,7 @@ void RemoteTransmitterComponent::await_target_time_() {
   if (this->target_time_ == 0) {
     this->target_time_ = current_time;
   } else {
-    while (this->target_time_ > micros()) {
+    while ((int32_t) (this->target_time_ - micros()) > 0) {
       // busy loop that ensures micros is constantly called
     }
   }
@@ -52,13 +52,13 @@ void RemoteTransmitterComponent::mark_(uint32_t on_time, uint32_t off_time, uint
   if (this->carrier_duty_percent_ < 100 && (on_time > 0 || off_time > 0)) {
     while (true) {  // Modulate with carrier frequency
       this->target_time_ += on_time;
-      if (this->target_time_ >= target)
+      if ((int32_t) (this->target_time_ - target) >= 0)
         break;
       this->await_target_time_();
       this->pin_->digital_write(false);
 
       this->target_time_ += off_time;
-      if (this->target_time_ >= target)
+      if ((int32_t) (this->target_time_ - target) >= 0)
         break;
       this->await_target_time_();
       this->pin_->digital_write(true);


### PR DESCRIPTION
# What does this implement/fix?

As values could have rolled over a simple > or >= will result in random failures. Subtraction, a cast to a signed integer and a comparison to zero can be done instead. A rollover will happen about once an hour. 

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32   
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [x] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
