### PR TITLE
Increase Daly-BMS coltage cells from 16 to 18 cells

### DIFF
--- a/esphome/components/daly_bms/daly_bms.cpp
+++ b/esphome/components/daly_bms/daly_bms.cpp
@@ -298,6 +298,12 @@ void DalyBmsComponent::decode_data_(std::vector<uint8_t> data) {
                 if (this->cell_16_voltage_sensor_) {
                   this->cell_16_voltage_sensor_->publish_state((float) encode_uint16(it[5], it[6]) / 1000);
                 }
+                if (this->cell_17_voltage_sensor_) {
+                  this->cell_17_voltage_sensor_->publish_state((float) encode_uint16(it[7], it[8]) / 1000);
+                }
+                if (this->cell_18_voltage_sensor_) {
+                  this->cell_18_voltage_sensor_->publish_state((float) encode_uint16(it[9], it[10]) / 1000);
+                }
                 break;
             }
             break;

--- a/esphome/components/daly_bms/daly_bms.h
+++ b/esphome/components/daly_bms/daly_bms.h
@@ -54,6 +54,8 @@ class DalyBmsComponent : public PollingComponent, public uart::UARTDevice {
   SUB_SENSOR(cell_14_voltage)
   SUB_SENSOR(cell_15_voltage)
   SUB_SENSOR(cell_16_voltage)
+  SUB_SENSOR(cell_17_voltage)
+  SUB_SENSOR(cell_18_voltage)
 #endif
 
 #ifdef USE_TEXT_SENSOR

--- a/esphome/components/daly_bms/sensor.py
+++ b/esphome/components/daly_bms/sensor.py
@@ -52,6 +52,8 @@ CONF_CELL_13_VOLTAGE = "cell_13_voltage"
 CONF_CELL_14_VOLTAGE = "cell_14_voltage"
 CONF_CELL_15_VOLTAGE = "cell_15_voltage"
 CONF_CELL_16_VOLTAGE = "cell_16_voltage"
+CONF_CELL_17_VOLTAGE = "cell_17_voltage"
+CONF_CELL_18_VOLTAGE = "cell_18_voltage"
 ICON_CURRENT_DC = "mdi:current-dc"
 ICON_BATTERY_OUTLINE = "mdi:battery-outline"
 ICON_THERMOMETER_CHEVRON_UP = "mdi:thermometer-chevron-up"
@@ -92,6 +94,8 @@ TYPES = [
     CONF_CELL_14_VOLTAGE,
     CONF_CELL_15_VOLTAGE,
     CONF_CELL_16_VOLTAGE,
+    CONF_CELL_17_VOLTAGE,
+    CONF_CELL_18_VOLTAGE,
 ]
 
 CELL_VOLTAGE_SCHEMA = sensor.sensor_schema(
@@ -212,6 +216,8 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_CELL_14_VOLTAGE): CELL_VOLTAGE_SCHEMA,
             cv.Optional(CONF_CELL_15_VOLTAGE): CELL_VOLTAGE_SCHEMA,
             cv.Optional(CONF_CELL_16_VOLTAGE): CELL_VOLTAGE_SCHEMA,
+            cv.Optional(CONF_CELL_17_VOLTAGE): CELL_VOLTAGE_SCHEMA,
+            cv.Optional(CONF_CELL_18_VOLTAGE): CELL_VOLTAGE_SCHEMA,
         }
     ).extend(cv.COMPONENT_SCHEMA)
 )


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->
Increasing the number of cells from 16 to 18 for the Voltage request.  

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [*] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes [3018](https://github.com/esphome/feature-requests/issues/3018)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#[4571](https://github.com/esphome/esphome-docs/pull/4571)

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [*] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
