### PR TITLE
Enable udp to work (on ipv4) when ipv6 is enabled

### DIFF
--- a/esphome/components/udp/udp_component.cpp
+++ b/esphome/components/udp/udp_component.cpp
@@ -245,7 +245,9 @@ void UDPComponent::setup() {
     }
     struct sockaddr_in server {};
 
-    socklen_t sl = socket::set_sockaddr((struct sockaddr *) &server, sizeof(server), "0.0.0.0", this->port_);
+    server.sin_family = AF_INET;
+    server.sin_addr.s_addr = ESPHOME_INADDR_ANY;
+    server.sin_port = htons(this->port_);
     if (sl == 0) {
       ESP_LOGE(TAG, "Socket unable to set sockaddr: errno %d", errno);
       this->mark_failed();

--- a/esphome/components/udp/udp_component.cpp
+++ b/esphome/components/udp/udp_component.cpp
@@ -245,7 +245,7 @@ void UDPComponent::setup() {
     }
     struct sockaddr_in server {};
 
-    socklen_t sl = socket::set_sockaddr_any((struct sockaddr *) &server, sizeof(server), this->port_);
+    socklen_t sl = socket::set_sockaddr((struct sockaddr *) &server, sizeof(server), "0.0.0.0", this->port_);
     if (sl == 0) {
       ESP_LOGE(TAG, "Socket unable to set sockaddr: errno %d", errno);
       this->mark_failed();

--- a/esphome/components/udp/udp_component.cpp
+++ b/esphome/components/udp/udp_component.cpp
@@ -248,12 +248,6 @@ void UDPComponent::setup() {
     server.sin_family = AF_INET;
     server.sin_addr.s_addr = ESPHOME_INADDR_ANY;
     server.sin_port = htons(this->port_);
-    if (sl == 0) {
-      ESP_LOGE(TAG, "Socket unable to set sockaddr: errno %d", errno);
-      this->mark_failed();
-      this->status_set_error("Unable to set sockaddr");
-      return;
-    }
 
     err = this->listen_socket_->bind((struct sockaddr *) &server, sizeof(server));
     if (err != 0) {


### PR DESCRIPTION
# What does this implement/fix?

UDP component didn't work when IPv6 was enabled, not even on IPv4.

NOTE: UDP component listens to broadcast address 255.255.255.255 and IPv6 doesn't have the concept of broadcast at all. To be able to use anything similar UDP component need to have multicast support, which is not part of this PR.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
