### PR TITLE
[bluetooth_proxy] make max characteristics retreive configurable

### DIFF
--- a/esphome/components/bluetooth_proxy/__init__.py
+++ b/esphome/components/bluetooth_proxy/__init__.py
@@ -50,7 +50,7 @@ CONFIG_SCHEMA = cv.All(
             cv.SplitDefault(CONF_CACHE_SERVICES, esp32_idf=True): cv.All(
                 cv.only_with_esp_idf, cv.boolean
             ),
-            cv.SplitDefault(CONF_MAX_CHARACTERISTICS, esp32_idf=True): cv.All(
+            cv.SplitDefault(CONF_MAX_CHARACTERISTICS, esp32_idf=40): cv.All(
                 cv.only_with_esp_idf, cv.int_range(min=1, max=500)
             ),
             cv.Optional(CONF_CONNECTIONS): cv.All(

--- a/esphome/components/bluetooth_proxy/__init__.py
+++ b/esphome/components/bluetooth_proxy/__init__.py
@@ -9,7 +9,7 @@ DEPENDENCIES = ["api", "esp32"]
 CODEOWNERS = ["@jesserockz"]
 
 CONF_CACHE_SERVICES = "cache_services"
-CONF_MAX_CARACTERISTICS = "max_characteristics"
+CONF_MAX_CHARACTERISTICS = "max_characteristics"
 CONF_CONNECTIONS = "connections"
 MAX_CONNECTIONS = 3
 
@@ -50,7 +50,7 @@ CONFIG_SCHEMA = cv.All(
             cv.SplitDefault(CONF_CACHE_SERVICES, esp32_idf=True): cv.All(
                 cv.only_with_esp_idf, cv.boolean
             ),
-            cv.SplitDefault(CONF_MAX_CARACTERISTICS, esp32_idf=True): cv.All(
+            cv.SplitDefault(CONF_MAX_CHARACTERISTICS, esp32_idf=True): cv.All(
                 cv.only_with_esp_idf, cv.int_range(min=1, max=500)
             ),
             cv.Optional(CONF_CONNECTIONS): cv.All(
@@ -81,9 +81,9 @@ async def to_code(config):
     if config.get(CONF_CACHE_SERVICES):
         add_idf_sdkconfig_option("CONFIG_BT_GATTC_CACHE_NVS_FLASH", True)
 
-    if CONF_MAX_CARACTERISTICS in config:
+    if CONF_MAX_CHARACTERISTICS in config:
         add_idf_sdkconfig_option(
-            "CONFIG_BT_GATTC_MAX_CACHE_CHAR", config[CONF_MAX_CARACTERISTICS]
+            "CONFIG_BT_GATTC_MAX_CACHE_CHAR", config[CONF_MAX_CHARACTERISTICS]
         )
 
     cg.add_define("USE_BLUETOOTH_PROXY")


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->
Add a parameter to set the max number of  characteristics retreive : set CONFIG_BT_GATTC_MAX_CACHE_CHAR in configuration

Some device have a lot of characteristic and the default maximum of ESP-IDF is not enougth to read all. This new parameter adjust the configuration variable CONFIG_BT_GATTC_MAX_CACHE_CHAR




## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

No related issue created

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#4575

## Test Environment

- [ ] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
esphome:
  name: ble-proxy-1

esp32:
  board: esp32dev
  framework:
    type: esp-idf

logger:
  level: DEBUG
#  baud_rate: 0
  
api:
  encryption:
    key: "cjLlr/V5PsDx3jbakgTYyR3YzUwMO6SubcsHdg8YA5w="

wifi:
  ssid: !secret wifi_ssid
  password: !secret wifi_password

bluetooth_proxy:
  active: True
  cache_services: True
  max_characteristics: 80

esp32_ble_tracker:
  scan_parameters:
    interval: 1100ms
    window: 1100ms
    active: false

```

Tested with the following python code. It show the number of characteristic read. after a change of `max_characteristics`, `cache_need_to_be_cleared` must be set to `True` if `cache_services` is `True`

Test code : 
```python
import asyncio

from bleak_esphome import connect_scanner
from bleak_esphome.backend.client import ESPHomeClient
from aioesphomeapi import (
    APIClient,
)
from bleak_retry_connector import BleakSlotManager
from bluetooth_adapters import BluetoothAdapters
from habluetooth import BluetoothManager, set_manager, get_manager

MAC = "9C:9E:6E:D1:44:71"

async def test():
    api = APIClient(
        "ble-proxy-1.local",
        6053,
        "",
        noise_psk="cjLlr/V5PsDx3jbakgTYyR3YzUwMO6SubcsHdg8YA5w=",
    )
    await api.connect(login=True)
    client_data = connect_scanner(api, await api.device_info(), True)
    client_data.scanner.async_setup()

    manager = get_manager()
    manager.async_register_scanner(client_data.scanner)

    bledevice = None
    while bledevice is None:
        bledevice = manager.async_ble_device_from_address(MAC, True)
        print("bledevice ", bledevice)
        if bledevice is None:
            await asyncio.sleep(1)

    client = ESPHomeClient(bledevice, client_data=client_data, timeout=30)

    cache_need_to_be_cleared = True
    if cache_need_to_be_cleared:
        await client.connect()
        await client.clear_cache()
        await client.disconnect()

    await asyncio.sleep(1)
    await client.connect()
    total= 0
    for s in await client.get_services():
        print(f"{s.uuid} {len(s.characteristics)}")
        total += len(s.characteristics)
    print("Total characteristics: ", total)

slot_manager = BleakSlotManager()
bluetooth_adapters = BluetoothAdapters()
set_manager(BluetoothManager(bluetooth_adapters, slot_manager))

loop = asyncio.get_event_loop()
tasks = list()
loop.run_until_complete(test())
loop.close()
```


## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
