### PR TITLE
[spi] relay on KEY_TARGET_PLATFORM as the other platforms does

### DIFF
--- a/esphome/components/spi/__init__.py
+++ b/esphome/components/spi/__init__.py
@@ -97,11 +97,7 @@ RP_SPI_PINSETS = [
 
 
 def get_target_platform():
-    return (
-        CORE.data[KEY_CORE][KEY_TARGET_PLATFORM]
-        if KEY_TARGET_PLATFORM in CORE.data[KEY_CORE]
-        else ""
-    )
+    return CORE.data[KEY_CORE][KEY_TARGET_PLATFORM]
 
 
 def get_target_variant():

--- a/script/build_codeowners.py
+++ b/script/build_codeowners.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import sys
 
 from esphome.config import get_component, get_platform
-from esphome.const import KEY_CORE, KEY_TARGET_FRAMEWORK
+from esphome.const import KEY_CORE, KEY_TARGET_FRAMEWORK, KEY_TARGET_PLATFORM
 from esphome.core import CORE
 from esphome.helpers import write_file_if_changed
 
@@ -39,7 +39,7 @@ parts = [BASE]
 
 # Fake some directory so that get_component works
 CORE.config_path = str(root)
-CORE.data[KEY_CORE] = {KEY_TARGET_FRAMEWORK: None}
+CORE.data[KEY_CORE] = {KEY_TARGET_FRAMEWORK: None, KEY_TARGET_PLATFORM: None}
 
 codeowners = defaultdict(list)
 

--- a/script/build_language_schema.py
+++ b/script/build_language_schema.py
@@ -85,12 +85,12 @@ def load_components():
 
 
 # pylint: disable=wrong-import-position
-from esphome.const import CONF_TYPE, KEY_CORE
+from esphome.const import CONF_TYPE, KEY_CORE, KEY_TARGET_PLATFORM
 from esphome.core import CORE
 
 # pylint: enable=wrong-import-position
 
-CORE.data[KEY_CORE] = {}
+CORE.data[KEY_CORE] = {KEY_TARGET_PLATFORM: None}
 load_components()
 
 # Import esphome after loading components (so schema is tracked)


### PR DESCRIPTION
make spi to assume that KEY_TARGET_PLATFORM exist as all other platform does. In attempt to get https://github.com/esphome/esphome/pull/7616 merged.

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
