### PR TITLE
[lvgl] Fix keyboard module not compiling

### DIFF
--- a/esphome/components/lvgl/widgets/keyboard.py
+++ b/esphome/components/lvgl/widgets/keyboard.py
@@ -41,7 +41,8 @@ class KeyboardType(WidgetType):
         lvgl_components_required.add("KEY_LISTENER")
         lvgl_components_required.add(CONF_KEYBOARD)
         add_lv_use("btnmatrix")
-        await w.set_property(CONF_MODE, await KEYBOARD_MODES.process(config[CONF_MODE]))
+        if mode := config.get(CONF_MODE):
+            await w.set_property(CONF_MODE, await KEYBOARD_MODES.process(mode))
         if ta := await get_widgets(config, CONF_TEXTAREA):
             await w.set_property(CONF_TEXTAREA, ta[0].obj)
 


### PR DESCRIPTION
# What does this implement/fix?

While compiling keyboard module an error is thrown:

Error: 'mode'
![image](https://github.com/user-attachments/assets/2133ee6a-7a85-46ef-a71c-2bc88ed9620b)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**


**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**



## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
- keyboard:
    id: keyboardID
    x: 0
    y: 0
    align: LV_ALIGN_BOTTOM_MID

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
