### PR TITLE
Convert IPAddress to use Pythonmodule ipaddress

### DIFF
--- a/esphome/components/ethernet/__init__.py
+++ b/esphome/components/ethernet/__init__.py
@@ -94,11 +94,11 @@ CLK_MODES = {
 
 MANUAL_IP_SCHEMA = cv.Schema(
     {
-        cv.Required(CONF_STATIC_IP): cv.ipv4,
-        cv.Required(CONF_GATEWAY): cv.ipv4,
-        cv.Required(CONF_SUBNET): cv.ipv4,
-        cv.Optional(CONF_DNS1, default="0.0.0.0"): cv.ipv4,
-        cv.Optional(CONF_DNS2, default="0.0.0.0"): cv.ipv4,
+        cv.Required(CONF_STATIC_IP): cv.ipaddress,
+        cv.Required(CONF_GATEWAY): cv.ipaddress,
+        cv.Required(CONF_SUBNET): cv.ipaddress,
+        cv.Optional(CONF_DNS1, default="0.0.0.0"): cv.ipaddress,
+        cv.Optional(CONF_DNS2, default="0.0.0.0"): cv.ipaddress,
     }
 )
 

--- a/esphome/components/ethernet/__init__.py
+++ b/esphome/components/ethernet/__init__.py
@@ -255,11 +255,11 @@ FINAL_VALIDATE_SCHEMA = _final_validate
 def manual_ip(config):
     return cg.StructInitializer(
         ManualIP,
-        ("static_ip", IPAddress(config[CONF_STATIC_IP].args)),
-        ("gateway", IPAddress(config[CONF_GATEWAY].args)),
-        ("subnet", IPAddress(config[CONF_SUBNET].args)),
-        ("dns1", IPAddress(config[CONF_DNS1].args)),
-        ("dns2", IPAddress(config[CONF_DNS2].args)),
+        ("static_ip", IPAddress(str(config[CONF_STATIC_IP]))),
+        ("gateway", IPAddress(str(config[CONF_GATEWAY]))),
+        ("subnet", IPAddress(str(config[CONF_SUBNET]))),
+        ("dns1", IPAddress(str(config[CONF_DNS1]))),
+        ("dns2", IPAddress(str(config[CONF_DNS2]))),
     )
 
 

--- a/esphome/components/ethernet/__init__.py
+++ b/esphome/components/ethernet/__init__.py
@@ -94,11 +94,11 @@ CLK_MODES = {
 
 MANUAL_IP_SCHEMA = cv.Schema(
     {
-        cv.Required(CONF_STATIC_IP): cv.ipaddress,
-        cv.Required(CONF_GATEWAY): cv.ipaddress,
-        cv.Required(CONF_SUBNET): cv.ipaddress,
-        cv.Optional(CONF_DNS1, default="0.0.0.0"): cv.ipaddress,
-        cv.Optional(CONF_DNS2, default="0.0.0.0"): cv.ipaddress,
+        cv.Required(CONF_STATIC_IP): cv.ipv4address,
+        cv.Required(CONF_GATEWAY): cv.ipv4address,
+        cv.Required(CONF_SUBNET): cv.ipv4address,
+        cv.Optional(CONF_DNS1, default="0.0.0.0"): cv.ipv4address,
+        cv.Optional(CONF_DNS2, default="0.0.0.0"): cv.ipv4address,
     }
 )
 
@@ -255,11 +255,11 @@ FINAL_VALIDATE_SCHEMA = _final_validate
 def manual_ip(config):
     return cg.StructInitializer(
         ManualIP,
-        ("static_ip", IPAddress(*config[CONF_STATIC_IP].args)),
-        ("gateway", IPAddress(*config[CONF_GATEWAY].args)),
-        ("subnet", IPAddress(*config[CONF_SUBNET].args)),
-        ("dns1", IPAddress(*config[CONF_DNS1].args)),
-        ("dns2", IPAddress(*config[CONF_DNS2].args)),
+        ("static_ip", IPAddress(config[CONF_STATIC_IP].args)),
+        ("gateway", IPAddress(config[CONF_GATEWAY].args)),
+        ("subnet", IPAddress(config[CONF_SUBNET].args)),
+        ("dns1", IPAddress(config[CONF_DNS1].args)),
+        ("dns2", IPAddress(config[CONF_DNS2].args)),
     )
 
 

--- a/esphome/components/udp/__init__.py
+++ b/esphome/components/udp/__init__.py
@@ -85,7 +85,7 @@ CONFIG_SCHEMA = cv.All(
             cv.GenerateID(): cv.declare_id(UDPComponent),
             cv.Optional(CONF_PORT, default=18511): cv.port,
             cv.Optional(CONF_ADDRESSES, default=["255.255.255.255"]): cv.ensure_list(
-                cv.ipv4
+                cv.ipv4address,
             ),
             cv.Optional(CONF_ROLLING_CODE_ENABLE, default=False): cv.boolean,
             cv.Optional(CONF_PING_PONG_ENABLE, default=False): cv.boolean,

--- a/esphome/components/wifi/__init__.py
+++ b/esphome/components/wifi/__init__.py
@@ -93,16 +93,16 @@ def validate_channel(value):
 
 AP_MANUAL_IP_SCHEMA = cv.Schema(
     {
-        cv.Required(CONF_STATIC_IP): cv.ipv4,
-        cv.Required(CONF_GATEWAY): cv.ipv4,
-        cv.Required(CONF_SUBNET): cv.ipv4,
+        cv.Required(CONF_STATIC_IP): cv.ipaddress,
+        cv.Required(CONF_GATEWAY): cv.ipaddress,
+        cv.Required(CONF_SUBNET): cv.ipaddress,
     }
 )
 
 STA_MANUAL_IP_SCHEMA = AP_MANUAL_IP_SCHEMA.extend(
     {
-        cv.Optional(CONF_DNS1, default="0.0.0.0"): cv.ipv4,
-        cv.Optional(CONF_DNS2, default="0.0.0.0"): cv.ipv4,
+        cv.Optional(CONF_DNS1, default="0.0.0.0"): cv.ipaddress,
+        cv.Optional(CONF_DNS2, default="0.0.0.0"): cv.ipaddress,
     }
 )
 
@@ -364,7 +364,7 @@ def eap_auth(config):
 def safe_ip(ip):
     if ip is None:
         return IPAddress(0, 0, 0, 0)
-    return IPAddress(*ip.args)
+    return IPAddress(str(ip))
 
 
 def manual_ip(config):

--- a/esphome/components/wifi/__init__.py
+++ b/esphome/components/wifi/__init__.py
@@ -93,16 +93,16 @@ def validate_channel(value):
 
 AP_MANUAL_IP_SCHEMA = cv.Schema(
     {
-        cv.Required(CONF_STATIC_IP): cv.ipaddress,
-        cv.Required(CONF_GATEWAY): cv.ipaddress,
-        cv.Required(CONF_SUBNET): cv.ipaddress,
+        cv.Required(CONF_STATIC_IP): cv.ipv4address,
+        cv.Required(CONF_GATEWAY): cv.ipv4address,
+        cv.Required(CONF_SUBNET): cv.ipv4address,
     }
 )
 
 STA_MANUAL_IP_SCHEMA = AP_MANUAL_IP_SCHEMA.extend(
     {
-        cv.Optional(CONF_DNS1, default="0.0.0.0"): cv.ipaddress,
-        cv.Optional(CONF_DNS2, default="0.0.0.0"): cv.ipaddress,
+        cv.Optional(CONF_DNS1, default="0.0.0.0"): cv.ipv4address,
+        cv.Optional(CONF_DNS2, default="0.0.0.0"): cv.ipv4address,
     }
 )
 

--- a/esphome/components/wireguard/__init__.py
+++ b/esphome/components/wireguard/__init__.py
@@ -67,8 +67,8 @@ CONFIG_SCHEMA = cv.Schema(
     {
         cv.GenerateID(): cv.declare_id(Wireguard),
         cv.GenerateID(CONF_TIME_ID): cv.use_id(time.RealTimeClock),
-        cv.Required(CONF_ADDRESS): cv.ipv4,
-        cv.Optional(CONF_NETMASK, default="255.255.255.255"): cv.ipv4,
+        cv.Required(CONF_ADDRESS): cv.ipv4address,
+        cv.Optional(CONF_NETMASK, default="255.255.255.255"): cv.ipv4address,
         cv.Required(CONF_PRIVATE_KEY): _wireguard_key,
         cv.Required(CONF_PEER_ENDPOINT): cv.string,
         cv.Required(CONF_PEER_PUBLIC_KEY): _wireguard_key,

--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -3,6 +3,7 @@
 from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime
+from ipaddress import AddressValueError, IPv4Address, ip_address
 import logging
 import os
 import re
@@ -67,7 +68,6 @@ from esphome.const import (
 from esphome.core import (
     CORE,
     HexInt,
-    IPAddress,
     Lambda,
     TimePeriod,
     TimePeriodMicroseconds,
@@ -1161,11 +1161,19 @@ def ssid(value):
 
 
 def ipv4address(value):
-    return IPAddress(value, allow_ipv6=False)
+    try:
+        address = IPv4Address(value)
+    except AddressValueError as exc:
+        raise Invalid(f"{value} is not a valid IPv4 address") from exc
+    return address
 
 
 def ipaddress(value):
-    return IPAddress(value, allow_ipv6=True)
+    try:
+        address = ip_address(value)
+    except ValueError as exc:
+        raise Invalid(f"{value} is not a valid IP address") from exc
+    return address
 
 
 def _valid_topic(value):

--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -1130,7 +1130,7 @@ def domain(value):
     if re.match(vol.DOMAIN_REGEX, value) is not None:
         return value
     try:
-        return str(ipv4(value))
+        return str(ipaddress(value))
     except Invalid as err:
         raise Invalid(f"Invalid domain: {value}") from err
 
@@ -1160,21 +1160,8 @@ def ssid(value):
     return value
 
 
-def ipv4(value):
-    if isinstance(value, list):
-        parts = value
-    elif isinstance(value, str):
-        parts = value.split(".")
-    elif isinstance(value, IPAddress):
-        return value
-    else:
-        raise Invalid("IPv4 address must consist of either string or integer list")
-    if len(parts) != 4:
-        raise Invalid("IPv4 address must consist of four point-separated integers")
-    parts_ = list(map(int, parts))
-    if not all(0 <= x < 256 for x in parts_):
-        raise Invalid("IPv4 address parts must be in range from 0 to 255")
-    return IPAddress(*parts_)
+def ipaddress(value):
+    return IPAddress(value)
 
 
 def _valid_topic(value):

--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -1160,8 +1160,12 @@ def ssid(value):
     return value
 
 
+def ipv4address(value):
+    return IPAddress(value, allow_ipv6=False)
+
+
 def ipaddress(value):
-    return IPAddress(value)
+    return IPAddress(value, allow_ipv6=True)
 
 
 def _valid_topic(value):

--- a/esphome/core/__init__.py
+++ b/esphome/core/__init__.py
@@ -1,4 +1,5 @@
 import logging
+import ipaddress
 import math
 import os
 import re
@@ -55,13 +56,11 @@ class HexInt(int):
 
 
 class IPAddress:
-    def __init__(self, *args):
-        if len(args) != 4:
-            raise ValueError("IPAddress must consist of 4 items")
-        self.args = args
+    def __init__(self, arg):
+        self.args = ipaddress.ip_address(arg)
 
     def __str__(self):
-        return ".".join(str(x) for x in self.args)
+        return str(self.args)
 
 
 class MACAddress:

--- a/esphome/core/__init__.py
+++ b/esphome/core/__init__.py
@@ -1,5 +1,5 @@
-import logging
 import ipaddress
+import logging
 import math
 import os
 import re
@@ -56,11 +56,14 @@ class HexInt(int):
 
 
 class IPAddress:
-    def __init__(self, arg):
-        self.args = ipaddress.ip_address(arg)
+    def __init__(self, arg, allow_ipv6=False):
+        if allow_ipv6:
+            self.args = str(ipaddress.ip_address(arg))
+        else:
+            self.args = str(ipaddress.IPv4Address(arg))
 
     def __str__(self):
-        return str(self.args)
+        return self.args
 
 
 class MACAddress:

--- a/esphome/core/__init__.py
+++ b/esphome/core/__init__.py
@@ -1,4 +1,3 @@
-import ipaddress
 import logging
 import math
 import os
@@ -53,17 +52,6 @@ class HexInt(int):
         if 0 <= value <= 255:
             return f"{sign}0x{value:02X}"
         return f"{sign}0x{value:X}"
-
-
-class IPAddress:
-    def __init__(self, arg, allow_ipv6=False):
-        if allow_ipv6:
-            self.args = str(ipaddress.ip_address(arg))
-        else:
-            self.args = str(ipaddress.IPv4Address(arg))
-
-    def __str__(self):
-        return self.args
 
 
 class MACAddress:

--- a/esphome/yaml_util.py
+++ b/esphome/yaml_util.py
@@ -4,6 +4,7 @@ import fnmatch
 import functools
 import inspect
 from io import TextIOWrapper
+from ipaddress import _BaseAddress
 import logging
 import math
 import os
@@ -25,7 +26,6 @@ from esphome.core import (
     CORE,
     DocumentRange,
     EsphomeError,
-    IPAddress,
     Lambda,
     MACAddress,
     TimePeriod,
@@ -576,7 +576,7 @@ ESPHomeDumper.add_multi_representer(bool, ESPHomeDumper.represent_bool)
 ESPHomeDumper.add_multi_representer(str, ESPHomeDumper.represent_stringify)
 ESPHomeDumper.add_multi_representer(int, ESPHomeDumper.represent_int)
 ESPHomeDumper.add_multi_representer(float, ESPHomeDumper.represent_float)
-ESPHomeDumper.add_multi_representer(IPAddress, ESPHomeDumper.represent_stringify)
+ESPHomeDumper.add_multi_representer(_BaseAddress, ESPHomeDumper.represent_stringify)
 ESPHomeDumper.add_multi_representer(MACAddress, ESPHomeDumper.represent_stringify)
 ESPHomeDumper.add_multi_representer(TimePeriod, ESPHomeDumper.represent_stringify)
 ESPHomeDumper.add_multi_representer(Lambda, ESPHomeDumper.represent_lambda)

--- a/tests/unit_tests/test_config_validation.py
+++ b/tests/unit_tests/test_config_validation.py
@@ -1,12 +1,12 @@
-import pytest
 import string
 
-from hypothesis import given, example
-from hypothesis.strategies import one_of, text, integers, builds
+from hypothesis import example, given
+from hypothesis.strategies import builds, integers, ip_addresses, one_of, text
+import pytest
 
 from esphome import config_validation
 from esphome.config_validation import Invalid
-from esphome.core import CORE, Lambda, HexInt
+from esphome.core import CORE, HexInt, Lambda
 
 
 def test_check_not_templatable__invalid():
@@ -143,6 +143,28 @@ def test_boolean__valid_false(value):
 def test_boolean__invalid(value):
     with pytest.raises(Invalid, match="Expected boolean value"):
         config_validation.boolean(value)
+
+
+@given(value=ip_addresses(v=4).map(str))
+def test_ipv4__valid(value):
+    config_validation.ipv4address(value)
+
+
+@pytest.mark.parametrize("value", ("127.0.0", "localhost", ""))
+def test_ipv4__invalid(value):
+    with pytest.raises(Invalid, match="is not a valid IPv4 address"):
+        config_validation.ipv4address(value)
+
+
+@given(value=ip_addresses(v=6).map(str))
+def test_ipv6__valid(value):
+    config_validation.ipaddress(value)
+
+
+@pytest.mark.parametrize("value", ("127.0.0", "localhost", "", "2001:db8::2::3"))
+def test_ipv6__invalid(value):
+    with pytest.raises(Invalid, match="is not a valid IP address"):
+        config_validation.ipaddress(value)
 
 
 # TODO: ensure_list

--- a/tests/unit_tests/test_core.py
+++ b/tests/unit_tests/test_core.py
@@ -27,18 +27,20 @@ class TestHexInt:
 
 
 class TestIPAddress:
-    @given(value=ip_addresses(v=4).map(str))
+    @given(value=ip_addresses().map(str))
     def test_init__valid(self, value):
-        core.IPAddress(*value.split("."))
+        core.IPAddress(value)
 
     @pytest.mark.parametrize("value", ("127.0.0", "localhost", ""))
     def test_init__invalid(self, value):
-        with pytest.raises(ValueError, match="IPAddress must consist of 4 items"):
-            core.IPAddress(*value.split("."))
+        with pytest.raises(
+            ValueError, match=f"'{value}' does not appear to be an IPv4 or IPv6 address"
+        ):
+            core.IPAddress(value)
 
-    @given(value=ip_addresses(v=4).map(str))
+    @given(value=ip_addresses().map(str))
     def test_str(self, value):
-        target = core.IPAddress(*value.split("."))
+        target = core.IPAddress(value)
 
         actual = str(target)
 

--- a/tests/unit_tests/test_core.py
+++ b/tests/unit_tests/test_core.py
@@ -1,7 +1,4 @@
-from ipaddress import AddressValueError
-
 from hypothesis import given
-from hypothesis.strategies import ip_addresses
 import pytest
 from strategies import mac_addr_strings
 
@@ -25,44 +22,6 @@ class TestHexInt:
         actual = str(target)
 
         assert actual == expected
-
-
-class TestIP4Address:
-    @given(value=ip_addresses(v=4).map(str))
-    def test_init__valid(self, value):
-        core.IPAddress(value, allow_ipv6=False)
-
-    @pytest.mark.parametrize("value", ("127.0.0", "localhost", ""))
-    def test_init__invalid(self, value):
-        with pytest.raises((ValueError, AddressValueError)):
-            core.IPAddress(value, allow_ipv6=False)
-
-    @given(value=ip_addresses(v=4).map(str))
-    def test_str(self, value):
-        target = core.IPAddress(value, allow_ipv6=False)
-
-        actual = str(target)
-
-        assert actual == value
-
-
-class TestIP6Address:
-    @given(value=ip_addresses(v=6).map(str))
-    def test_init__valid(self, value):
-        core.IPAddress(value, allow_ipv6=True)
-
-    @pytest.mark.parametrize("value", ("127.0.0", "localhost", "", "2001:db8::2::3"))
-    def test_init__invalid(self, value):
-        with pytest.raises((ValueError, AddressValueError)):
-            core.IPAddress(value, allow_ipv6=True)
-
-    @given(value=ip_addresses(v=6).map(str))
-    def test_str(self, value):
-        target = core.IPAddress(value, allow_ipv6=True)
-
-        actual = str(target)
-
-        assert actual == value
 
 
 class TestMACAddress:


### PR DESCRIPTION
Validates ip addresses with the built-in Python module ipaddress,  which handles both IPv4 and IPv6 addresses.
Breaking: This renames the ipv4 validator to ipv4validator, and add new validator called ipvalidator that validates both IPv4 and IPv6 addresses.

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
