### PR TITLE
[ili9xxx] psram and 8 bit changes

### DIFF
--- a/esphome/components/ili9xxx/ili9xxx_display.cpp
+++ b/esphome/components/ili9xxx/ili9xxx_display.cpp
@@ -66,12 +66,9 @@ void ILI9XXXDisplay::setup() {
 void ILI9XXXDisplay::alloc_buffer_() {
   if (this->buffer_color_mode_ == BITS_16) {
     this->init_internal_(this->get_buffer_length_() * 2);
-    if (this->buffer_ != nullptr) {
-      return;
-    }
-    this->buffer_color_mode_ = BITS_8;
+  } else {
+    this->init_internal_(this->get_buffer_length_());
   }
-  this->init_internal_(this->get_buffer_length_());
   if (this->buffer_ == nullptr) {
     this->mark_failed();
   }

--- a/esphome/components/ili9xxx/ili9xxx_display.h
+++ b/esphome/components/ili9xxx/ili9xxx_display.h
@@ -98,7 +98,8 @@ class ILI9XXXDisplay : public display::DisplayBuffer,
  protected:
   inline bool check_buffer_() {
     if (this->buffer_ == nullptr) {
-      this->alloc_buffer_();
+      if (!this->is_failed())
+        this->alloc_buffer_();
       return !this->is_failed();
     }
     return true;

--- a/tests/components/ili9xxx/test.esp32-ard.yaml
+++ b/tests/components/ili9xxx/test.esp32-ard.yaml
@@ -20,6 +20,7 @@ display:
       it.rectangle(0, 0, it.get_width(), it.get_height());
   - platform: ili9xxx
     invert_colors: false
+    color_palette: 8bit
     dimensions:
       width: 320
       height: 240


### PR DESCRIPTION
* Remove automatic 8 bit mode
* Enable manual 8 bit mode
* Remove psram auto-load
* Add advisory message about psram

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/issues/issues/6669
- 

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#4581

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] host

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
