### PR TITLE
[event] Store ``last_event_type`` in class

### DIFF
--- a/esphome/components/event/event.cpp
+++ b/esphome/components/event/event.cpp
@@ -8,11 +8,13 @@ namespace event {
 static const char *const TAG = "event";
 
 void Event::trigger(const std::string &event_type) {
-  if (types_.find(event_type) == types_.end()) {
+  auto found = types_.find(event_type);
+  if (found == types_.end()) {
     ESP_LOGE(TAG, "'%s': invalid event type for trigger(): %s", this->get_name().c_str(), event_type.c_str());
     return;
   }
-  ESP_LOGD(TAG, "'%s' Triggered event '%s'", this->get_name().c_str(), event_type.c_str());
+  last_event_type = &(*found);
+  ESP_LOGD(TAG, "'%s' Triggered event '%s'", this->get_name().c_str(), last_event_type->c_str());
   this->event_callback_.call(event_type);
 }
 

--- a/esphome/components/event/event.h
+++ b/esphome/components/event/event.h
@@ -23,6 +23,8 @@ namespace event {
 
 class Event : public EntityBase, public EntityBase_DeviceClass {
  public:
+  const std::string *last_event_type;
+
   void trigger(const std::string &event_type);
   void set_event_types(const std::set<std::string> &event_types) { this->types_ = event_types; }
   std::set<std::string> get_event_types() const { return this->types_; }


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Stores the last event type triggered

Required for #7547 and #7538

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
