### PR TITLE
[esp32_touch] Fix deprecated warning

### DIFF
--- a/esphome/components/esp32_touch/esp32_touch.cpp
+++ b/esphome/components/esp32_touch/esp32_touch.cpp
@@ -52,7 +52,12 @@ void ESP32TouchComponent::setup() {
   }
 #endif
 
+#if ESP_IDF_VERSION_MAJOR >= 5
+  touch_pad_set_measurement_clock_cycles(this->meas_cycle_);
+  touch_pad_set_measurement_interval(this->sleep_cycle_);
+#else
   touch_pad_set_meas_time(this->sleep_cycle_, this->meas_cycle_);
+#endif
   touch_pad_set_voltage(this->high_voltage_reference_, this->low_voltage_reference_, this->voltage_attenuation_);
 
   for (auto *child : this->children_) {


### PR DESCRIPTION
# What does this implement/fix?

Fix this warning:

src/esphome/components/esp32_touch/esp32_touch.cpp:55:26: warning: 'esp_err_t touch_pad_set_meas_time(uint16_t, uint16_t)' is deprecated: please use 'touch_pad_set_measurement_clock_cycles' and 'touch_pad_set_measurement_interval' instead [-Wdeprecated-declarations]

Can see implementation of touch_pad_set_meas_time here, it just calls those two functions:
https://github.com/espressif/esp-idf/blob/0f0068fff3ab159f082133aadfa9baf4fc0c7b8d/components/driver/touch_sensor/esp32/touch_sensor.c#L160

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
