### PR TITLE
[sensor] Add confirmation filter

### DIFF
--- a/esphome/components/sensor/__init__.py
+++ b/esphome/components/sensor/__init__.py
@@ -243,6 +243,7 @@ ThrottleFilter = sensor_ns.class_("ThrottleFilter", Filter)
 TimeoutFilter = sensor_ns.class_("TimeoutFilter", Filter, cg.Component)
 DebounceFilter = sensor_ns.class_("DebounceFilter", Filter, cg.Component)
 HeartbeatFilter = sensor_ns.class_("HeartbeatFilter", Filter, cg.Component)
+ConfirmationFilter = sensor_ns.class_("ConfirmationFilter", Filter)
 DeltaFilter = sensor_ns.class_("DeltaFilter", Filter)
 OrFilter = sensor_ns.class_("OrFilter", Filter)
 CalibrateLinearFilter = sensor_ns.class_("CalibrateLinearFilter", Filter)
@@ -521,6 +522,46 @@ async def lambda_filter_to_code(config, filter_id):
         config, [(float, "x")], return_type=cg.optional.template(float)
     )
     return cg.new_Pvariable(filter_id, lambda_)
+
+
+CONFIRMATION_SCHEMA = cv.Schema(
+    {
+        cv.Required(CONF_VALUE): cv.positive_float,
+        cv.Optional(CONF_TYPE, default="absolute"): cv.one_of(
+            "absolute", "percentage", lower=True
+        ),
+    }
+)
+
+
+def validate_confirmation(config):
+    try:
+        value = cv.positive_float(config)
+        return CONFIRMATION_SCHEMA({CONF_VALUE: value, CONF_TYPE: "absolute"})
+    except cv.Invalid:
+        pass
+    try:
+        value = cv.percentage(config)
+        return CONFIRMATION_SCHEMA({CONF_VALUE: value, CONF_TYPE: "percentage"})
+    except cv.Invalid:
+        pass
+    raise cv.Invalid(
+        "confirmation filter requires a positive number or percentage value."
+    )
+
+
+@FILTER_REGISTRY.register(
+    "confirmation",
+    ConfirmationFilter,
+    cv.Any(CONFIRMATION_SCHEMA, validate_confirmation),
+)
+async def confirmation_filter_to_code(config, filter_id):
+    percentage = config[CONF_TYPE] == "percentage"
+    return cg.new_Pvariable(
+        filter_id,
+        config[CONF_VALUE],
+        percentage,
+    )
 
 
 DELTA_SCHEMA = cv.Schema(

--- a/esphome/components/sensor/filter.cpp
+++ b/esphome/components/sensor/filter.cpp
@@ -331,6 +331,27 @@ optional<float> ThrottleFilter::new_value(float value) {
   return {};
 }
 
+// ConfirmationFilter
+ConfirmationFilter::ConfirmationFilter(float delta, bool percentage_mode)
+    : delta_(delta), current_delta_(delta), percentage_mode_(percentage_mode), last_value_(NAN) {}
+optional<float> ConfirmationFilter::new_value(float value) {
+  optional<float> ret = {};
+  if (std::isnan(value)) {
+    if (std::isnan(this->last_value_)) {
+      ret = value;
+    }
+  } else if (!std::isnan(this->last_value_)) {
+    if (this->percentage_mode_) {
+      this->current_delta_ = fabsf(this->last_value_ * this->delta_);
+    }
+    if (fabsf(value - this->last_value_) <= this->current_delta_) {
+      ret = value;
+    }
+  }
+  this->last_value_ = value;
+  return ret;
+}
+
 // DeltaFilter
 DeltaFilter::DeltaFilter(float delta, bool percentage_mode)
     : delta_(delta), current_delta_(delta), percentage_mode_(percentage_mode), last_value_(NAN) {}

--- a/esphome/components/sensor/filter.h
+++ b/esphome/components/sensor/filter.h
@@ -355,6 +355,19 @@ class HeartbeatFilter : public Filter, public Component {
   bool has_value_{false};
 };
 
+class ConfirmationFilter : public Filter {
+ public:
+  explicit ConfirmationFilter(float delta, bool percentage_mode);
+
+  optional<float> new_value(float value) override;
+
+ protected:
+  float delta_;
+  float current_delta_;
+  bool percentage_mode_;
+  float last_value_{NAN};
+};
+
 class DeltaFilter : public Filter {
  public:
   explicit DeltaFilter(float delta, bool percentage_mode);


### PR DESCRIPTION
# What does this implement/fix?

This filter stores the last value and only passes incoming values through if the incoming value is sufficiently similar to the previously one, basically an inverse delta filter. 

Useful to filter out corrupted values, e.g. a false CRC pass from a wireless sensor. Corrupted values tend to vary significantly and happen infrequently, easy to filter out in slower moving data or wireless sensors that repeat the same value multiple times. 

I had implemented this in a lambda filter but I think others would find it useful. 

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#4586

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
