### PR TITLE
Remove black-formatter from pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,14 +11,6 @@ repos:
         args: [--fix]
       # Run the formatter.
       - id: ruff-format
-  - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 24.4.2
-    hooks:
-      - id: black
-        args:
-          - --safe
-          - --quiet
-        files: ^((esphome|script|tests)/.+)?[^/]+\.py$
   - repo: https://github.com/PyCQA/flake8
     rev: 6.1.0
     hooks:


### PR DESCRIPTION
Instead, use only ruff-formatter

# What does this implement/fix?

Removes the black-formatter from the pre-commit hooks, in an ongoing effort to transition to ruff-formatter per discussion on Discord. There are some files that have black-formatter and ruff-formatter in direct opposition (i.e. writer.py) which are currently unable to be committed as either pre-commit hook fails.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other - Dev infrastructure

**Related issue or feature (if applicable):**

N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
