### PR TITLE
[es7243e] Add support for ES7243E audio ADC

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -133,6 +133,7 @@ esphome/components/ens160_i2c/* @latonita
 esphome/components/ens160_spi/* @latonita
 esphome/components/ens210/* @itn3rd77
 esphome/components/es7210/* @kahrendt
+esphome/components/es7243e/* @kbx81
 esphome/components/es8156/* @kbx81
 esphome/components/es8311/* @kahrendt @kroimon
 esphome/components/esp32/* @esphome/core

--- a/esphome/components/es7243e/audio_adc.py
+++ b/esphome/components/es7243e/audio_adc.py
@@ -1,0 +1,33 @@
+import esphome.codegen as cg
+from esphome.components import i2c
+from esphome.components.audio_adc import AudioAdc
+import esphome.config_validation as cv
+from esphome.const import CONF_ID, CONF_MIC_GAIN
+
+CODEOWNERS = ["@kbx81"]
+DEPENDENCIES = ["i2c"]
+
+es7243e_ns = cg.esphome_ns.namespace("es7243e")
+ES7243E = es7243e_ns.class_("ES7243E", AudioAdc, cg.Component, i2c.I2CDevice)
+
+
+CONFIG_SCHEMA = (
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.declare_id(ES7243E),
+            cv.Optional(CONF_MIC_GAIN, default="24db"): cv.All(
+                cv.decibel, cv.float_range(min=0, max=37.5)
+            ),
+        }
+    )
+    .extend(cv.COMPONENT_SCHEMA)
+    .extend(i2c.i2c_device_schema(0x10))
+)
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+    await i2c.register_i2c_device(var, config)
+
+    cg.add(var.set_mic_gain(config[CONF_MIC_GAIN]))

--- a/esphome/components/es7243e/audio_adc.py
+++ b/esphome/components/es7243e/audio_adc.py
@@ -10,13 +10,14 @@ DEPENDENCIES = ["i2c"]
 es7243e_ns = cg.esphome_ns.namespace("es7243e")
 ES7243E = es7243e_ns.class_("ES7243E", AudioAdc, cg.Component, i2c.I2CDevice)
 
+ES7243E_MIC_GAINS = [0, 3, 6, 9, 12, 15, 18, 21, 24, 27, 30, 33, 34.5, 36, 37.5]
 
 CONFIG_SCHEMA = (
     cv.Schema(
         {
             cv.GenerateID(): cv.declare_id(ES7243E),
             cv.Optional(CONF_MIC_GAIN, default="24db"): cv.All(
-                cv.decibel, cv.float_range(min=0, max=37.5)
+                cv.decibel, cv.one_of(*ES7243E_MIC_GAINS)
             ),
         }
     )

--- a/esphome/components/es7243e/es7243e.cpp
+++ b/esphome/components/es7243e/es7243e.cpp
@@ -69,7 +69,7 @@ void ES7243E::setup() {
   ES7243E_ERROR_FAILED(this->write_byte(0x20, 0x1A));  // PGA gain +30dB
   ES7243E_ERROR_FAILED(this->write_byte(0x21, 0x1A));
 
-  ES7243E_ERROR_FAILED(this->write_byte(0x00, 0x80));  // Slave  Mode
+  ES7243E_ERROR_FAILED(this->write_byte(0x00, 0x80));
   ES7243E_ERROR_FAILED(this->write_byte(0x01, 0x3A));
   ES7243E_ERROR_FAILED(this->write_byte(0x16, 0x3F));
   ES7243E_ERROR_FAILED(this->write_byte(0x16, 0x00));

--- a/esphome/components/es7243e/es7243e.cpp
+++ b/esphome/components/es7243e/es7243e.cpp
@@ -1,0 +1,122 @@
+#include "es7243e.h"
+#include "esphome/core/hal.h"
+#include "esphome/core/log.h"
+#include <cinttypes>
+
+namespace esphome {
+namespace es7243e {
+
+static const char *const TAG = "es7243e";
+
+// Mark the component as failed; use only in setup
+#define ES7243E_ERROR_FAILED(func) \
+  if (!(func)) { \
+    this->mark_failed(); \
+    return; \
+  }
+
+// Return false; use outside of setup
+#define ES7243E_ERROR_CHECK(func) \
+  if (!(func)) { \
+    return false; \
+  }
+
+void ES7243E::dump_config() {
+  ESP_LOGCONFIG(TAG, "ES7243E audio ADC:");
+
+  if (this->is_failed()) {
+    ESP_LOGE(TAG, "  Failed to initialize");
+    return;
+  }
+}
+
+void ES7243E::setup() {
+  ESP_LOGCONFIG(TAG, "Setting up ES7243E...");
+
+  ES7243E_ERROR_FAILED(this->write_byte(0x01, 0x3A));
+  ES7243E_ERROR_FAILED(this->write_byte(0x00, 0x80));
+  ES7243E_ERROR_FAILED(this->write_byte(0xF9, 0x00));
+  ES7243E_ERROR_FAILED(this->write_byte(0x04, 0x02));
+  ES7243E_ERROR_FAILED(this->write_byte(0x04, 0x01));
+  ES7243E_ERROR_FAILED(this->write_byte(0xF9, 0x01));
+  ES7243E_ERROR_FAILED(this->write_byte(0x00, 0x1E));
+  ES7243E_ERROR_FAILED(this->write_byte(0x01, 0x00));
+
+  ES7243E_ERROR_FAILED(this->write_byte(0x02, 0x00));
+  ES7243E_ERROR_FAILED(this->write_byte(0x03, 0x20));
+  ES7243E_ERROR_FAILED(this->write_byte(0x04, 0x01));
+  ES7243E_ERROR_FAILED(this->write_byte(0x0D, 0x00));
+  ES7243E_ERROR_FAILED(this->write_byte(0x05, 0x00));
+  ES7243E_ERROR_FAILED(this->write_byte(0x06, 0x03));  // SCLK=MCLK/4
+  ES7243E_ERROR_FAILED(this->write_byte(0x07, 0x00));  // LRCK=MCLK/256
+  ES7243E_ERROR_FAILED(this->write_byte(0x08, 0xFF));  // LRCK=MCLK/256
+
+  ES7243E_ERROR_FAILED(this->write_byte(0x09, 0xCA));
+  ES7243E_ERROR_FAILED(this->write_byte(0x0A, 0x85));
+  ES7243E_ERROR_FAILED(this->write_byte(0x0B, 0x00));
+  ES7243E_ERROR_FAILED(this->write_byte(0x0E, 0xBF));
+  ES7243E_ERROR_FAILED(this->write_byte(0x0F, 0x80));
+  ES7243E_ERROR_FAILED(this->write_byte(0x14, 0x0C));
+  ES7243E_ERROR_FAILED(this->write_byte(0x15, 0x0C));
+  ES7243E_ERROR_FAILED(this->write_byte(0x17, 0x02));
+  ES7243E_ERROR_FAILED(this->write_byte(0x18, 0x26));
+  ES7243E_ERROR_FAILED(this->write_byte(0x19, 0x77));
+  ES7243E_ERROR_FAILED(this->write_byte(0x1A, 0xF4));
+  ES7243E_ERROR_FAILED(this->write_byte(0x1B, 0x66));
+  ES7243E_ERROR_FAILED(this->write_byte(0x1C, 0x44));
+  ES7243E_ERROR_FAILED(this->write_byte(0x1E, 0x00));
+  ES7243E_ERROR_FAILED(this->write_byte(0x1F, 0x0C));
+  ES7243E_ERROR_FAILED(this->write_byte(0x20, 0x1A));  // PGA gain +30dB
+  ES7243E_ERROR_FAILED(this->write_byte(0x21, 0x1A));
+
+  ES7243E_ERROR_FAILED(this->write_byte(0x00, 0x80));  // Slave  Mode
+  ES7243E_ERROR_FAILED(this->write_byte(0x01, 0x3A));
+  ES7243E_ERROR_FAILED(this->write_byte(0x16, 0x3F));
+  ES7243E_ERROR_FAILED(this->write_byte(0x16, 0x00));
+
+  ES7243E_ERROR_FAILED(this->write_byte(0xF9, 0x00));
+  ES7243E_ERROR_FAILED(this->write_byte(0x04, 0x01));
+  ES7243E_ERROR_FAILED(this->write_byte(0x17, 0x01));
+  ES7243E_ERROR_FAILED(this->configure_mic_gain_());
+  ES7243E_ERROR_FAILED(this->write_byte(0x00, 0x80));
+  ES7243E_ERROR_FAILED(this->write_byte(0x01, 0x3A));
+  ES7243E_ERROR_FAILED(this->write_byte(0x16, 0x3F));
+  ES7243E_ERROR_FAILED(this->write_byte(0x16, 0x00));
+
+  this->setup_complete_ = true;
+}
+
+bool ES7243E::set_mic_gain(float mic_gain) {
+  this->mic_gain_ = clamp<float>(mic_gain, 0, 37.5);
+  if (this->setup_complete_) {
+    return this->configure_mic_gain_();
+  }
+  return true;
+}
+
+bool ES7243E::configure_mic_gain_() {
+  auto regv = this->es7243e_gain_reg_value_(this->mic_gain_);
+
+  ES7243E_ERROR_CHECK(this->write_byte(0x20, 0x10 | regv));
+  ES7243E_ERROR_CHECK(this->write_byte(0x21, 0x10 | regv));
+
+  return true;
+}
+
+uint8_t ES7243E::es7243e_gain_reg_value_(float mic_gain) {
+  // reg: 12 - 34.5dB, 13 - 36dB, 14 - 37.5dB
+  mic_gain += 0.5;
+  if (mic_gain <= 33.0) {
+    return (uint8_t) mic_gain / 3;
+  }
+  if (mic_gain < 36.0) {
+    return 12;
+  }
+  if (mic_gain < 37.0) {
+    return 13;
+  }
+  return 14;
+}
+
+}  // namespace es7243e
+}  // namespace esphome

--- a/esphome/components/es7243e/es7243e.cpp
+++ b/esphome/components/es7243e/es7243e.cpp
@@ -1,6 +1,9 @@
 #include "es7243e.h"
+#include "es7243e_const.h"
+
 #include "esphome/core/hal.h"
 #include "esphome/core/log.h"
+
 #include <cinttypes>
 
 namespace esphome {
@@ -33,55 +36,55 @@ void ES7243E::dump_config() {
 void ES7243E::setup() {
   ESP_LOGCONFIG(TAG, "Setting up ES7243E...");
 
-  ES7243E_ERROR_FAILED(this->write_byte(0x01, 0x3A));
-  ES7243E_ERROR_FAILED(this->write_byte(0x00, 0x80));
-  ES7243E_ERROR_FAILED(this->write_byte(0xF9, 0x00));
-  ES7243E_ERROR_FAILED(this->write_byte(0x04, 0x02));
-  ES7243E_ERROR_FAILED(this->write_byte(0x04, 0x01));
-  ES7243E_ERROR_FAILED(this->write_byte(0xF9, 0x01));
-  ES7243E_ERROR_FAILED(this->write_byte(0x00, 0x1E));
-  ES7243E_ERROR_FAILED(this->write_byte(0x01, 0x00));
+  ES7243E_ERROR_FAILED(this->write_byte(ES7243E_CLOCK_MGR_REG01, 0x3A));
+  ES7243E_ERROR_FAILED(this->write_byte(ES7243E_RESET_REG00, 0x80));
+  ES7243E_ERROR_FAILED(this->write_byte(ES7243E_TEST_MODE_REGF9, 0x00));
+  ES7243E_ERROR_FAILED(this->write_byte(ES7243E_CLOCK_MGR_REG04, 0x02));
+  ES7243E_ERROR_FAILED(this->write_byte(ES7243E_CLOCK_MGR_REG04, 0x01));
+  ES7243E_ERROR_FAILED(this->write_byte(ES7243E_TEST_MODE_REGF9, 0x01));
+  ES7243E_ERROR_FAILED(this->write_byte(ES7243E_RESET_REG00, 0x1E));
+  ES7243E_ERROR_FAILED(this->write_byte(ES7243E_CLOCK_MGR_REG01, 0x00));
 
-  ES7243E_ERROR_FAILED(this->write_byte(0x02, 0x00));
-  ES7243E_ERROR_FAILED(this->write_byte(0x03, 0x20));
-  ES7243E_ERROR_FAILED(this->write_byte(0x04, 0x01));
-  ES7243E_ERROR_FAILED(this->write_byte(0x0D, 0x00));
-  ES7243E_ERROR_FAILED(this->write_byte(0x05, 0x00));
-  ES7243E_ERROR_FAILED(this->write_byte(0x06, 0x03));  // SCLK=MCLK/4
-  ES7243E_ERROR_FAILED(this->write_byte(0x07, 0x00));  // LRCK=MCLK/256
-  ES7243E_ERROR_FAILED(this->write_byte(0x08, 0xFF));  // LRCK=MCLK/256
+  ES7243E_ERROR_FAILED(this->write_byte(ES7243E_CLOCK_MGR_REG02, 0x00));
+  ES7243E_ERROR_FAILED(this->write_byte(ES7243E_CLOCK_MGR_REG03, 0x20));
+  ES7243E_ERROR_FAILED(this->write_byte(ES7243E_CLOCK_MGR_REG04, 0x01));
+  ES7243E_ERROR_FAILED(this->write_byte(ES7243E_ADC_CTRL_REG0D, 0x00));
+  ES7243E_ERROR_FAILED(this->write_byte(ES7243E_CLOCK_MGR_REG05, 0x00));
+  ES7243E_ERROR_FAILED(this->write_byte(ES7243E_CLOCK_MGR_REG06, 0x03));  // SCLK=MCLK/4
+  ES7243E_ERROR_FAILED(this->write_byte(ES7243E_CLOCK_MGR_REG07, 0x00));  // LRCK=MCLK/256
+  ES7243E_ERROR_FAILED(this->write_byte(ES7243E_CLOCK_MGR_REG08, 0xFF));  // LRCK=MCLK/256
 
-  ES7243E_ERROR_FAILED(this->write_byte(0x09, 0xCA));
-  ES7243E_ERROR_FAILED(this->write_byte(0x0A, 0x85));
-  ES7243E_ERROR_FAILED(this->write_byte(0x0B, 0x00));
-  ES7243E_ERROR_FAILED(this->write_byte(0x0E, 0xBF));
-  ES7243E_ERROR_FAILED(this->write_byte(0x0F, 0x80));
-  ES7243E_ERROR_FAILED(this->write_byte(0x14, 0x0C));
-  ES7243E_ERROR_FAILED(this->write_byte(0x15, 0x0C));
-  ES7243E_ERROR_FAILED(this->write_byte(0x17, 0x02));
-  ES7243E_ERROR_FAILED(this->write_byte(0x18, 0x26));
-  ES7243E_ERROR_FAILED(this->write_byte(0x19, 0x77));
-  ES7243E_ERROR_FAILED(this->write_byte(0x1A, 0xF4));
-  ES7243E_ERROR_FAILED(this->write_byte(0x1B, 0x66));
-  ES7243E_ERROR_FAILED(this->write_byte(0x1C, 0x44));
-  ES7243E_ERROR_FAILED(this->write_byte(0x1E, 0x00));
-  ES7243E_ERROR_FAILED(this->write_byte(0x1F, 0x0C));
-  ES7243E_ERROR_FAILED(this->write_byte(0x20, 0x1A));  // PGA gain +30dB
-  ES7243E_ERROR_FAILED(this->write_byte(0x21, 0x1A));
+  ES7243E_ERROR_FAILED(this->write_byte(ES7243E_CLOCK_MGR_REG09, 0xCA));
+  ES7243E_ERROR_FAILED(this->write_byte(ES7243E_SDP_REG0A, 0x85));
+  ES7243E_ERROR_FAILED(this->write_byte(ES7243E_SDP_REG0B, 0x00));
+  ES7243E_ERROR_FAILED(this->write_byte(ES7243E_ADC_CTRL_REG0E, 0xBF));
+  ES7243E_ERROR_FAILED(this->write_byte(ES7243E_ADC_CTRL_REG0F, 0x80));
+  ES7243E_ERROR_FAILED(this->write_byte(ES7243E_ADC_CTRL_REG14, 0x0C));
+  ES7243E_ERROR_FAILED(this->write_byte(ES7243E_ADC_CTRL_REG15, 0x0C));
+  ES7243E_ERROR_FAILED(this->write_byte(ES7243E_ANALOG_REG17, 0x02));
+  ES7243E_ERROR_FAILED(this->write_byte(ES7243E_ANALOG_REG18, 0x26));
+  ES7243E_ERROR_FAILED(this->write_byte(ES7243E_ANALOG_REG19, 0x77));
+  ES7243E_ERROR_FAILED(this->write_byte(ES7243E_ANALOG_REG1A, 0xF4));
+  ES7243E_ERROR_FAILED(this->write_byte(ES7243E_ANALOG_REG1B, 0x66));
+  ES7243E_ERROR_FAILED(this->write_byte(ES7243E_ANALOG_REG1C, 0x44));
+  ES7243E_ERROR_FAILED(this->write_byte(ES7243E_ANALOG_REG1E, 0x00));
+  ES7243E_ERROR_FAILED(this->write_byte(ES7243E_ANALOG_REG1F, 0x0C));
+  ES7243E_ERROR_FAILED(this->write_byte(ES7243E_ANALOG_REG20, 0x1A));  // PGA gain +30dB
+  ES7243E_ERROR_FAILED(this->write_byte(ES7243E_ANALOG_REG21, 0x1A));
 
-  ES7243E_ERROR_FAILED(this->write_byte(0x00, 0x80));
-  ES7243E_ERROR_FAILED(this->write_byte(0x01, 0x3A));
-  ES7243E_ERROR_FAILED(this->write_byte(0x16, 0x3F));
-  ES7243E_ERROR_FAILED(this->write_byte(0x16, 0x00));
+  ES7243E_ERROR_FAILED(this->write_byte(ES7243E_RESET_REG00, 0x80));
+  ES7243E_ERROR_FAILED(this->write_byte(ES7243E_CLOCK_MGR_REG01, 0x3A));
+  ES7243E_ERROR_FAILED(this->write_byte(ES7243E_ANALOG_REG16, 0x3F));
+  ES7243E_ERROR_FAILED(this->write_byte(ES7243E_ANALOG_REG16, 0x00));
 
-  ES7243E_ERROR_FAILED(this->write_byte(0xF9, 0x00));
-  ES7243E_ERROR_FAILED(this->write_byte(0x04, 0x01));
-  ES7243E_ERROR_FAILED(this->write_byte(0x17, 0x01));
+  ES7243E_ERROR_FAILED(this->write_byte(ES7243E_TEST_MODE_REGF9, 0x00));
+  ES7243E_ERROR_FAILED(this->write_byte(ES7243E_CLOCK_MGR_REG04, 0x01));
+  ES7243E_ERROR_FAILED(this->write_byte(ES7243E_ANALOG_REG17, 0x01));
   ES7243E_ERROR_FAILED(this->configure_mic_gain_());
-  ES7243E_ERROR_FAILED(this->write_byte(0x00, 0x80));
-  ES7243E_ERROR_FAILED(this->write_byte(0x01, 0x3A));
-  ES7243E_ERROR_FAILED(this->write_byte(0x16, 0x3F));
-  ES7243E_ERROR_FAILED(this->write_byte(0x16, 0x00));
+  ES7243E_ERROR_FAILED(this->write_byte(ES7243E_RESET_REG00, 0x80));
+  ES7243E_ERROR_FAILED(this->write_byte(ES7243E_CLOCK_MGR_REG01, 0x3A));
+  ES7243E_ERROR_FAILED(this->write_byte(ES7243E_ANALOG_REG16, 0x3F));
+  ES7243E_ERROR_FAILED(this->write_byte(ES7243E_ANALOG_REG16, 0x00));
 
   this->setup_complete_ = true;
 }
@@ -97,8 +100,8 @@ bool ES7243E::set_mic_gain(float mic_gain) {
 bool ES7243E::configure_mic_gain_() {
   auto regv = this->es7243e_gain_reg_value_(this->mic_gain_);
 
-  ES7243E_ERROR_CHECK(this->write_byte(0x20, 0x10 | regv));
-  ES7243E_ERROR_CHECK(this->write_byte(0x21, 0x10 | regv));
+  ES7243E_ERROR_CHECK(this->write_byte(ES7243E_ANALOG_REG20, 0x10 | regv));
+  ES7243E_ERROR_CHECK(this->write_byte(ES7243E_ANALOG_REG21, 0x10 | regv));
 
   return true;
 }

--- a/esphome/components/es7243e/es7243e.h
+++ b/esphome/components/es7243e/es7243e.h
@@ -24,7 +24,7 @@ class ES7243E : public audio_adc::AudioAdc, public Component, public i2c::I2CDev
  protected:
   /// @brief Convert floating point mic gain value to register value
   /// @param mic_gain Gain value to convert
-  /// @return Corresponding register value closest to but not exceeding specified gain
+  /// @return Corresponding register value for specified gain
   uint8_t es7243e_gain_reg_value_(float mic_gain);
 
   bool configure_mic_gain_();

--- a/esphome/components/es7243e/es7243e.h
+++ b/esphome/components/es7243e/es7243e.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "esphome/components/audio_adc/audio_adc.h"
+#include "esphome/components/i2c/i2c.h"
+#include "esphome/core/component.h"
+
+namespace esphome {
+namespace es7243e {
+
+class ES7243E : public audio_adc::AudioAdc, public Component, public i2c::I2CDevice {
+  /* Class for configuring an ES7243E ADC for microphone input.
+   * Based on code from:
+   * - https://github.com/espressif/esp-adf/ (accessed 20250116)
+   */
+ public:
+  void setup() override;
+  float get_setup_priority() const override { return setup_priority::DATA; }
+  void dump_config() override;
+
+  bool set_mic_gain(float mic_gain) override;
+
+  float mic_gain() override { return this->mic_gain_; };
+
+ protected:
+  /// @brief Convert floating point mic gain value to register value
+  /// @param mic_gain Gain value to convert
+  /// @return Corresponding register value closest to but not exceeding specified gain
+  uint8_t es7243e_gain_reg_value_(float mic_gain);
+
+  bool configure_mic_gain_();
+
+  bool setup_complete_{false};
+  float mic_gain_{0};
+};
+
+}  // namespace es7243e
+}  // namespace esphome

--- a/esphome/components/es7243e/es7243e_const.h
+++ b/esphome/components/es7243e/es7243e_const.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#include <cinttypes>
+
+namespace esphome {
+namespace es7243e {
+
+// ES7243E register addresses
+static const uint8_t ES7243E_RESET_REG00 = 0x00;      // Reset control
+static const uint8_t ES7243E_CLOCK_MGR_REG01 = 0x01;  // MCLK/BCLK/ADCCLK/Analog clocks on/off
+static const uint8_t ES7243E_CLOCK_MGR_REG02 = 0x02;  // MCLK & BCLK configuration, source selection
+
+static const uint8_t ES7243E_CLOCK_MGR_REG03 = 0x03;  // ADC Over-sample rate control
+static const uint8_t ES7243E_CLOCK_MGR_REG04 = 0x04;  // Pre-divide/Pre-multiplication
+static const uint8_t ES7243E_CLOCK_MGR_REG05 = 0x05;  // CF/DSP clock divider
+static const uint8_t ES7243E_CLOCK_MGR_REG06 = 0x06;  // BCLK divider at master mode
+static const uint8_t ES7243E_CLOCK_MGR_REG07 = 0x07;  // BCLK/LRCK/SDOUT tri-state control/LRCK divider bit 11->8
+static const uint8_t ES7243E_CLOCK_MGR_REG08 = 0x08;  // Master LRCK divider bit 7 to bit 0
+static const uint8_t ES7243E_CLOCK_MGR_REG09 = 0x09;  // SEL S1/Timer for S1
+static const uint8_t ES7243E_SDP_REG0A = 0x0A;        // SEL S3/Timer for S3
+static const uint8_t ES7243E_SDP_REG0B = 0x0B;        // SDP out mute control/I2S/left-justify case/word length/format
+static const uint8_t ES7243E_SDP_REG0C = 0x0C;        // NFS flag at slot0/LSB/TDM mode selection
+static const uint8_t ES7243E_ADC_CTRL_REG0D = 0x0D;   // data mux/pol. inv./ram clear on lrck/mclk active/gain scale up
+static const uint8_t ES7243E_ADC_CTRL_REG0E = 0x0E;   // volume control
+static const uint8_t ES7243E_ADC_CTRL_REG0F = 0x0F;   // offset freeze/auto level control/automute control/VC ramp rate
+static const uint8_t ES7243E_ADC_CTRL_REG10 = 0x10;   // automute noise gate/detection
+static const uint8_t ES7243E_ADC_CTRL_REG11 = 0x11;   // automute SDP control/out gain select
+static const uint8_t ES7243E_ADC_CTRL_REG12 = 0x12;   // controls for automute PDN_PGA/MOD/reset/digital circuit
+static const uint8_t ES7243E_ADC_CTRL_REG13 = 0x13;   // ALC rate selection/ALC target level
+static const uint8_t ES7243E_ADC_CTRL_REG14 = 0x14;   // ADCHPF stage1 coeff
+static const uint8_t ES7243E_ADC_CTRL_REG15 = 0x15;   // ADCHPF stage2 coeff
+static const uint8_t ES7243E_ANALOG_REG16 = 0x16;     // power-down/reset
+static const uint8_t ES7243E_ANALOG_REG17 = 0x17;     // VMIDSEL
+static const uint8_t ES7243E_ANALOG_REG18 = 0x18;     // ADC/ADCFL bias
+static const uint8_t ES7243E_ANALOG_REG19 = 0x19;     // PGA1/PGA2 bias
+static const uint8_t ES7243E_ANALOG_REG1A = 0x1A;     // ADCI1/ADCI23 bias
+static const uint8_t ES7243E_ANALOG_REG1B = 0x1B;     // ADCSM/ADCCM bias
+static const uint8_t ES7243E_ANALOG_REG1C = 0x1C;     // ADCVRP/ADCCPP bias
+static const uint8_t ES7243E_ANALOG_REG1D = 0x1D;     // low power bits
+static const uint8_t ES7243E_ANALOG_REG1E = 0x1E;     // low power bits
+static const uint8_t ES7243E_ANALOG_REG1F = 0x1F;     // ADC_DMIC_ON/REFSEL/VX2OFF/VX1SEL/VMIDLVL
+static const uint8_t ES7243E_ANALOG_REG20 = 0x20;     // select MIC1 as PGA1 input/PGA1 gain
+static const uint8_t ES7243E_ANALOG_REG21 = 0x21;     // select MIC2 as PGA1 input/PGA2 gain
+static const uint8_t ES7243E_TEST_MODE_REGF7 = 0xF7;
+static const uint8_t ES7243E_TEST_MODE_REGF8 = 0xF8;
+static const uint8_t ES7243E_TEST_MODE_REGF9 = 0xF9;
+static const uint8_t ES7243E_I2C_CONF_REGFA = 0xFA;      // I2C signals retime/reset registers to default
+static const uint8_t ES7243E_FLAG_REGFC = 0xFC;          // CSM flag/ADC automute flag (RO)
+static const uint8_t ES7243E_CHIP_ID1_REGFD = 0xFD;      // chip ID 1, reads 0x7A (RO)
+static const uint8_t ES7243E_CHIP_ID2_REGFE = 0xFE;      // chip ID 2, reads 0x43 (RO)
+static const uint8_t ES7243E_CHIP_VERSION_REGFF = 0xFF;  // chip version, reads 0x00 (RO)
+
+}  // namespace es7243e
+}  // namespace esphome

--- a/tests/components/es7243e/common.yaml
+++ b/tests/components/es7243e/common.yaml
@@ -1,0 +1,14 @@
+esphome:
+  on_boot:
+    then:
+      - audio_adc.set_mic_gain: 0db
+      - audio_adc.set_mic_gain: !lambda 'return 4;'
+
+i2c:
+  - id: i2c_es7243e
+    scl: ${scl_pin}
+    sda: ${sda_pin}
+
+audio_adc:
+  - platform: es7243e
+    id: es7243e_adc

--- a/tests/components/es7243e/test.esp32-ard.yaml
+++ b/tests/components/es7243e/test.esp32-ard.yaml
@@ -1,0 +1,5 @@
+substitutions:
+  scl_pin: GPIO16
+  sda_pin: GPIO17
+
+<<: !include common.yaml

--- a/tests/components/es7243e/test.esp32-c3-ard.yaml
+++ b/tests/components/es7243e/test.esp32-c3-ard.yaml
@@ -1,0 +1,5 @@
+substitutions:
+  scl_pin: GPIO5
+  sda_pin: GPIO4
+
+<<: !include common.yaml

--- a/tests/components/es7243e/test.esp32-c3-idf.yaml
+++ b/tests/components/es7243e/test.esp32-c3-idf.yaml
@@ -1,0 +1,5 @@
+substitutions:
+  scl_pin: GPIO5
+  sda_pin: GPIO4
+
+<<: !include common.yaml

--- a/tests/components/es7243e/test.esp32-idf.yaml
+++ b/tests/components/es7243e/test.esp32-idf.yaml
@@ -1,0 +1,5 @@
+substitutions:
+  scl_pin: GPIO16
+  sda_pin: GPIO17
+
+<<: !include common.yaml


### PR DESCRIPTION
# What does this implement/fix?

SSIA -- this is the ADC used in the S3-Box-Lite.

This PR depends on #8094

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#4597

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
audio_adc:
  - platform: es7243e
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
