### PR TITLE
2024.12.4

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -29,7 +29,7 @@ RUN \
     # Use pinned versions so that we get updates with build caching
     && apt-get install -y --no-install-recommends \
         python3-pip=23.0.1+dfsg-1 \
-        python3-setuptools=66.1.1-1 \
+        python3-setuptools=66.1.1-1+deb12u1 \
         python3-venv=3.11.2-1+b1 \
         python3-wheel=0.38.4-2 \
         iputils-ping=3:20221126-1+deb12u1 \

--- a/esphome/const.py
+++ b/esphome/const.py
@@ -1,6 +1,6 @@
 """Constants used by esphome."""
 
-__version__ = "2024.12.3"
+__version__ = "2024.12.4"
 
 ALLOWED_NAME_CHARS = "abcdefghijklmnopqrstuvwxyz0123456789-_"
 VALID_SUBSTITUTIONS_CHARACTERS = (


### PR DESCRIPTION
**Do not merge, release script will automatically merge**
- Bump python3-setuptools to 66.1.1-1+deb12u1 [esphome#8074](https://github.com/esphome/esphome/pull/8074)

<details>
<summary>Metadata</summary>

@coderabbitai ignore
</details>
