### PR TITLE
[uptime] Cosmetic improvements for uptime text_sensor

### DIFF
--- a/esphome/components/uptime/text_sensor/__init__.py
+++ b/esphome/components/uptime/text_sensor/__init__.py
@@ -11,7 +11,7 @@ CONFIG_SCHEMA = text_sensor.text_sensor_schema(
     UptimeTextSensor,
     icon=ICON_TIMER,
     entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
-).extend(cv.polling_component_schema("60s"))
+).extend(cv.polling_component_schema("30s"))
 
 
 async def to_code(config):

--- a/esphome/components/uptime/text_sensor/uptime_text_sensor.cpp
+++ b/esphome/components/uptime/text_sensor/uptime_text_sensor.cpp
@@ -21,8 +21,7 @@ void UptimeTextSensor::update() {
   // get whole seconds since last update. Note that even if the millis count has overflowed between updates,
   // the difference will still be correct due to the way twos-complement arithmetic works.
   const uint32_t delta = (now - this->last_ms_) / 1000;
-  // set last_ms_ to the last second boundary
-  this->last_ms_ = now - (now % 1000);
+  this->last_ms_ = now;
   this->uptime_ += delta;
   auto uptime = this->uptime_;
   unsigned interval = this->get_update_interval() / 1000;

--- a/esphome/components/uptime/text_sensor/uptime_text_sensor.cpp
+++ b/esphome/components/uptime/text_sensor/uptime_text_sensor.cpp
@@ -20,8 +20,9 @@ void UptimeTextSensor::update() {
   auto now = millis();
   // get whole seconds since last update. Note that even if the millis count has overflowed between updates,
   // the difference will still be correct due to the way twos-complement arithmetic works.
-  const uint32_t delta = (now - this->last_ms_) / 1000;
-  this->last_ms_ = now;
+  uint32_t delta = now - this->last_ms_;
+  this->last_ms_ = now - delta % 1000;  // save remainder for next update
+  delta /= 1000;
   this->uptime_ += delta;
   auto uptime = this->uptime_;
   unsigned interval = this->get_update_interval() / 1000;

--- a/esphome/components/uptime/text_sensor/uptime_text_sensor.cpp
+++ b/esphome/components/uptime/text_sensor/uptime_text_sensor.cpp
@@ -9,34 +9,51 @@ namespace uptime {
 
 static const char *const TAG = "uptime.sensor";
 
-void UptimeTextSensor::setup() { this->last_ms_ = millis(); }
+void UptimeTextSensor::setup() {
+  this->last_ms_ = millis();
+  if (this->last_ms_ < 60 * 1000)
+    this->last_ms_ = 0;
+  this->update();
+}
 
 void UptimeTextSensor::update() {
-  const auto now = millis();
+  auto now = millis();
   // get whole seconds since last update. Note that even if the millis count has overflowed between updates,
   // the difference will still be correct due to the way twos-complement arithmetic works.
   const uint32_t delta = (now - this->last_ms_) / 1000;
-  if (delta == 0)
-    return;
   // set last_ms_ to the last second boundary
   this->last_ms_ = now - (now % 1000);
   this->uptime_ += delta;
   auto uptime = this->uptime_;
-  unsigned days = uptime / (24 * 3600);
-  unsigned seconds = uptime % (24 * 3600);
-  unsigned hours = seconds / 3600;
-  seconds %= 3600;
-  unsigned minutes = seconds / 60;
-  seconds %= 60;
-  if (days != 0) {
-    this->publish_state(str_sprintf("%dd%dh%dm%ds", days, hours, minutes, seconds));
-  } else if (hours != 0) {
-    this->publish_state(str_sprintf("%dh%dm%ds", hours, minutes, seconds));
-  } else if (minutes != 0) {
-    this->publish_state(str_sprintf("%dm%ds", minutes, seconds));
-  } else {
-    this->publish_state(str_sprintf("%ds", seconds));
+  unsigned interval = this->get_update_interval() / 1000;
+  std::string buffer{};
+  // display from the largest unit that corresponds to the update interval, drop larger units that are zero.
+  while (true) {  // enable use of break for early exit
+    unsigned remainder = uptime % 60;
+    uptime /= 60;
+    if (interval < 30) {
+      buffer.insert(0, str_sprintf("%us", remainder));
+      if (uptime == 0)
+        break;
+    }
+    remainder = uptime % 60;
+    uptime /= 60;
+    if (interval < 1800) {
+      buffer.insert(0, str_sprintf("%um", remainder));
+      if (uptime == 0)
+        break;
+    }
+    remainder = uptime % 24;
+    uptime /= 24;
+    if (interval < 12 * 3600) {
+      buffer.insert(0, str_sprintf("%uh", remainder));
+      if (uptime == 0)
+        break;
+    }
+    buffer.insert(0, str_sprintf("%ud", (unsigned) uptime));
+    break;
   }
+  this->publish_state(buffer);
 }
 
 float UptimeTextSensor::get_setup_priority() const { return setup_priority::HARDWARE; }

--- a/esphome/components/uptime/text_sensor/uptime_text_sensor.h
+++ b/esphome/components/uptime/text_sensor/uptime_text_sensor.h
@@ -17,8 +17,8 @@ class UptimeTextSensor : public text_sensor::TextSensor, public PollingComponent
   float get_setup_priority() const override;
 
  protected:
-  uint64_t uptime_{0};
-  uint64_t last_ms_{0};
+  uint32_t uptime_{0};  // uptime in seconds, will overflow after 136 years
+  uint32_t last_ms_{0};
 };
 
 }  // namespace uptime


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Cosmetic changes after experience of real-world use.

* Use the component update interval to determine what resolution of uptime to show.  No point in showing seconds if we only update every minute.
* * Include time from boot to setup if possible.
* Data types do not need to be 64 bit since 32 bits worth of seconds is 136 years. 
* Ensure valid data after boot before next update interval.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#4590

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [x] host

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
