### PR TITLE
[ads1115] Add sample rate control

### DIFF
--- a/esphome/components/ads1115/ads1115.cpp
+++ b/esphome/components/ads1115/ads1115.cpp
@@ -86,7 +86,7 @@ float ADS1115Component::request_measurement(ADS1115Multiplexer multiplexer, ADS1
   //        0bxxxxBBBxxxxxxxxx
   config &= 0b1111000111111111;
   config |= (gain & 0b111) << 9;
-  
+
   // Sample rate
   //        0bxxxxxxxxBBBxxxxx
   config &= 0b1111111100011111;
@@ -103,52 +103,52 @@ float ADS1115Component::request_measurement(ADS1115Multiplexer multiplexer, ADS1
       return NAN;
     }
     this->prev_config_ = config;
-    
+
+    // Delay calculated as: ceil((1000/SPS)+.5)
     if (resolution == ADS1015_12_BITS) {
       switch (samplerate) {
         case ADS1115_8SPS:
-          delay(9); // ceil((1000/128)+.5)
+          delay(9);
           break;
         case ADS1115_16SPS:
-          delay(5); // ceil((1000/250)+.5)
+          delay(5);
           break;
         case ADS1115_32SPS:
-          delay(3); // ceil((1000/475)+.5)
+          delay(3);
           break;
         case ADS1115_64SPS:
         case ADS1115_128SPS:
-          delay(2); // ceil((1000/1600)+.5)
+          delay(2);
           break;
         default:
-          delay(1); // ceil((2400/1600)+.5)
+          delay(1);
           break;
       }
-    }
-    else {
+    } else {
       switch (samplerate) {
         case ADS1115_8SPS:
-          delay(126); // ceil((1000/8)+.5)
+          delay(126);  // NOLINT
           break;
         case ADS1115_16SPS:
-          delay(63); // ceil((1000/16)+.5)
+          delay(63);  // NOLINT
           break;
         case ADS1115_32SPS:
-          delay(32); // ceil((1000/32)+.5)
+          delay(32);
           break;
         case ADS1115_64SPS:
-          delay(17); // ceil((1000/64)+.5)
+          delay(17);
           break;
         case ADS1115_128SPS:
-          delay(9); // ceil((1000/128)+.5)
+          delay(9);
           break;
         case ADS1115_250SPS:
-          delay(5); // ceil((1000/250)+.5)
+          delay(5);
           break;
         case ADS1115_475SPS:
-          delay(3); // ceil((1000/475)+.5)
+          delay(3);
           break;
         case ADS1115_860SPS:
-          delay(2); // ceil((1000/860)+.5)
+          delay(2);
           break;
       }
     }

--- a/esphome/components/ads1115/ads1115.cpp
+++ b/esphome/components/ads1115/ads1115.cpp
@@ -9,8 +9,6 @@ static const char *const TAG = "ads1115";
 static const uint8_t ADS1115_REGISTER_CONVERSION = 0x00;
 static const uint8_t ADS1115_REGISTER_CONFIG = 0x01;
 
-static const uint8_t ADS1115_DATA_RATE_860_SPS = 0b111;  // 3300_SPS for ADS1015
-
 void ADS1115Component::setup() {
   ESP_LOGCONFIG(TAG, "Setting up ADS1115...");
   uint16_t value;
@@ -43,9 +41,9 @@ void ADS1115Component::setup() {
     config |= 0b0000000100000000;
   }
 
-  // Set data rate - 860 samples per second (we're in singleshot mode)
+  // Set data rate - 860 samples per second
   //        0bxxxxxxxx100xxxxx
-  config |= ADS1115_DATA_RATE_860_SPS << 5;
+  config |= ADS1115_860SPS << 5;
 
   // Set comparator mode - hysteresis
   //        0bxxxxxxxxxxx0xxxx
@@ -77,7 +75,7 @@ void ADS1115Component::dump_config() {
   }
 }
 float ADS1115Component::request_measurement(ADS1115Multiplexer multiplexer, ADS1115Gain gain,
-                                            ADS1115Resolution resolution) {
+                                            ADS1115Resolution resolution, ADS1115Samplerate samplerate) {
   uint16_t config = this->prev_config_;
   // Multiplexer
   //        0bxBBBxxxxxxxxxxxx
@@ -88,6 +86,11 @@ float ADS1115Component::request_measurement(ADS1115Multiplexer multiplexer, ADS1
   //        0bxxxxBBBxxxxxxxxx
   config &= 0b1111000111111111;
   config |= (gain & 0b111) << 9;
+  
+  // Sample rate
+  //        0bxxxxxxxxBBBxxxxx
+  config &= 0b1111111100011111;
+  config |= (samplerate & 0b111) << 5;
 
   if (!this->continuous_mode_) {
     // Start conversion
@@ -100,9 +103,55 @@ float ADS1115Component::request_measurement(ADS1115Multiplexer multiplexer, ADS1
       return NAN;
     }
     this->prev_config_ = config;
-
-    // about 1.2 ms with 860 samples per second
-    delay(2);
+    
+    if (resolution == ADS1015_12_BITS) {
+      switch (samplerate) {
+        case ADS1115_8SPS:
+          delay(9); // ceil((1000/128)+.5)
+          break;
+        case ADS1115_16SPS:
+          delay(5); // ceil((1000/250)+.5)
+          break;
+        case ADS1115_32SPS:
+          delay(3); // ceil((1000/475)+.5)
+          break;
+        case ADS1115_64SPS:
+        case ADS1115_128SPS:
+          delay(2); // ceil((1000/1600)+.5)
+          break;
+        default:
+          delay(1); // ceil((2400/1600)+.5)
+          break;
+      }
+    }
+    else {
+      switch (samplerate) {
+        case ADS1115_8SPS:
+          delay(126); // ceil((1000/8)+.5)
+          break;
+        case ADS1115_16SPS:
+          delay(63); // ceil((1000/16)+.5)
+          break;
+        case ADS1115_32SPS:
+          delay(32); // ceil((1000/32)+.5)
+          break;
+        case ADS1115_64SPS:
+          delay(17); // ceil((1000/64)+.5)
+          break;
+        case ADS1115_128SPS:
+          delay(9); // ceil((1000/128)+.5)
+          break;
+        case ADS1115_250SPS:
+          delay(5); // ceil((1000/250)+.5)
+          break;
+        case ADS1115_475SPS:
+          delay(3); // ceil((1000/475)+.5)
+          break;
+        case ADS1115_860SPS:
+          delay(2); // ceil((1000/860)+.5)
+          break;
+      }
+    }
 
     // in continuous mode, conversion will always be running, rely on the delay
     // to ensure conversion is taking place with the correct settings

--- a/esphome/components/ads1115/ads1115.h
+++ b/esphome/components/ads1115/ads1115.h
@@ -33,6 +33,17 @@ enum ADS1115Resolution {
   ADS1015_12_BITS = 12,
 };
 
+enum ADS1115Samplerate {
+  ADS1115_8SPS = 0b000,
+  ADS1115_16SPS = 0b001,
+  ADS1115_32SPS = 0b010,
+  ADS1115_64SPS = 0b011,
+  ADS1115_128SPS = 0b100,
+  ADS1115_250SPS = 0b101,
+  ADS1115_475SPS = 0b110,
+  ADS1115_860SPS = 0b111
+};
+
 class ADS1115Component : public Component, public i2c::I2CDevice {
  public:
   void setup() override;
@@ -42,7 +53,7 @@ class ADS1115Component : public Component, public i2c::I2CDevice {
   void set_continuous_mode(bool continuous_mode) { continuous_mode_ = continuous_mode; }
 
   /// Helper method to request a measurement from a sensor.
-  float request_measurement(ADS1115Multiplexer multiplexer, ADS1115Gain gain, ADS1115Resolution resolution);
+  float request_measurement(ADS1115Multiplexer multiplexer, ADS1115Gain gain, ADS1115Resolution resolution, ADS1115Samplerate samplerate);
 
  protected:
   uint16_t prev_config_{0};

--- a/esphome/components/ads1115/ads1115.h
+++ b/esphome/components/ads1115/ads1115.h
@@ -53,7 +53,8 @@ class ADS1115Component : public Component, public i2c::I2CDevice {
   void set_continuous_mode(bool continuous_mode) { continuous_mode_ = continuous_mode; }
 
   /// Helper method to request a measurement from a sensor.
-  float request_measurement(ADS1115Multiplexer multiplexer, ADS1115Gain gain, ADS1115Resolution resolution, ADS1115Samplerate samplerate);
+  float request_measurement(ADS1115Multiplexer multiplexer, ADS1115Gain gain, ADS1115Resolution resolution,
+                            ADS1115Samplerate samplerate);
 
  protected:
   uint16_t prev_config_{0};

--- a/esphome/components/ads1115/sensor/__init__.py
+++ b/esphome/components/ads1115/sensor/__init__.py
@@ -5,6 +5,7 @@ from esphome.const import (
     CONF_GAIN,
     CONF_MULTIPLEXER,
     CONF_RESOLUTION,
+    CONF_SAMPLE_RATE,
     DEVICE_CLASS_VOLTAGE,
     STATE_CLASS_MEASUREMENT,
     UNIT_VOLT,
@@ -43,6 +44,17 @@ RESOLUTION = {
     "12_BITS": ADS1115Resolution.ADS1015_12_BITS,
 }
 
+ADS1115Samplerate = ads1115_ns.enum("ADS1115Samplerate")
+SAMPLERATE = {
+    "8": ADS1115Samplerate.ADS1115_8SPS,
+    "16": ADS1115Samplerate.ADS1115_16SPS,
+    "32": ADS1115Samplerate.ADS1115_32SPS,
+    "64": ADS1115Samplerate.ADS1115_64SPS,
+    "128": ADS1115Samplerate.ADS1115_128SPS,
+    "250": ADS1115Samplerate.ADS1115_250SPS,
+    "475": ADS1115Samplerate.ADS1115_475SPS,
+    "860": ADS1115Samplerate.ADS1115_860SPS
+}
 
 ADS1115Sensor = ads1115_ns.class_(
     "ADS1115Sensor", sensor.Sensor, cg.PollingComponent, voltage_sampler.VoltageSampler
@@ -64,6 +76,7 @@ CONFIG_SCHEMA = (
             cv.Optional(CONF_RESOLUTION, default="16_BITS"): cv.enum(
                 RESOLUTION, upper=True, space="_"
             ),
+            cv.Optional(CONF_SAMPLE_RATE, default="860"): cv.enum(SAMPLERATE, string=True),
         }
     )
     .extend(cv.polling_component_schema("60s"))
@@ -79,3 +92,4 @@ async def to_code(config):
     cg.add(var.set_multiplexer(config[CONF_MULTIPLEXER]))
     cg.add(var.set_gain(config[CONF_GAIN]))
     cg.add(var.set_resolution(config[CONF_RESOLUTION]))
+    cg.add(var.set_samplerate(config[CONF_SAMPLE_RATE]))

--- a/esphome/components/ads1115/sensor/__init__.py
+++ b/esphome/components/ads1115/sensor/__init__.py
@@ -53,7 +53,7 @@ SAMPLERATE = {
     "128": ADS1115Samplerate.ADS1115_128SPS,
     "250": ADS1115Samplerate.ADS1115_250SPS,
     "475": ADS1115Samplerate.ADS1115_475SPS,
-    "860": ADS1115Samplerate.ADS1115_860SPS
+    "860": ADS1115Samplerate.ADS1115_860SPS,
 }
 
 ADS1115Sensor = ads1115_ns.class_(
@@ -76,7 +76,9 @@ CONFIG_SCHEMA = (
             cv.Optional(CONF_RESOLUTION, default="16_BITS"): cv.enum(
                 RESOLUTION, upper=True, space="_"
             ),
-            cv.Optional(CONF_SAMPLE_RATE, default="860"): cv.enum(SAMPLERATE, string=True),
+            cv.Optional(CONF_SAMPLE_RATE, default="860"): cv.enum(
+                SAMPLERATE, string=True
+            ),
         }
     )
     .extend(cv.polling_component_schema("60s"))

--- a/esphome/components/ads1115/sensor/ads1115_sensor.cpp
+++ b/esphome/components/ads1115/sensor/ads1115_sensor.cpp
@@ -8,7 +8,7 @@ namespace ads1115 {
 static const char *const TAG = "ads1115.sensor";
 
 float ADS1115Sensor::sample() {
-  return this->parent_->request_measurement(this->multiplexer_, this->gain_, this->resolution_);
+  return this->parent_->request_measurement(this->multiplexer_, this->gain_, this->resolution_, this->samplerate_);
 }
 
 void ADS1115Sensor::update() {
@@ -24,6 +24,7 @@ void ADS1115Sensor::dump_config() {
   ESP_LOGCONFIG(TAG, "    Multiplexer: %u", this->multiplexer_);
   ESP_LOGCONFIG(TAG, "    Gain: %u", this->gain_);
   ESP_LOGCONFIG(TAG, "    Resolution: %u", this->resolution_);
+  ESP_LOGCONFIG(TAG, "    Sample rate: %u", this->samplerate_);
 }
 
 }  // namespace ads1115

--- a/esphome/components/ads1115/sensor/ads1115_sensor.h
+++ b/esphome/components/ads1115/sensor/ads1115_sensor.h
@@ -21,6 +21,7 @@ class ADS1115Sensor : public sensor::Sensor,
   void set_multiplexer(ADS1115Multiplexer multiplexer) { this->multiplexer_ = multiplexer; }
   void set_gain(ADS1115Gain gain) { this->gain_ = gain; }
   void set_resolution(ADS1115Resolution resolution) { this->resolution_ = resolution; }
+  void set_samplerate(ADS1115Samplerate samplerate) { this->samplerate_ = samplerate; }
   float sample() override;
 
   void dump_config() override;
@@ -29,6 +30,7 @@ class ADS1115Sensor : public sensor::Sensor,
   ADS1115Multiplexer multiplexer_;
   ADS1115Gain gain_;
   ADS1115Resolution resolution_;
+  ADS1115Samplerate samplerate_;
 };
 
 }  // namespace ads1115

--- a/tests/components/ads1115/test.esp32-ard.yaml
+++ b/tests/components/ads1115/test.esp32-ard.yaml
@@ -10,4 +10,5 @@ sensor:
   - platform: ads1115
     multiplexer: A0_A1
     gain: 1.024
+    sample_rate: 128
     id: ads1115_sensor

--- a/tests/components/ads1115/test.esp32-c3-ard.yaml
+++ b/tests/components/ads1115/test.esp32-c3-ard.yaml
@@ -10,4 +10,5 @@ sensor:
   - platform: ads1115
     multiplexer: A0_A1
     gain: 1.024
+    sample_rate: 128
     id: ads1115_sensor

--- a/tests/components/ads1115/test.esp32-c3-idf.yaml
+++ b/tests/components/ads1115/test.esp32-c3-idf.yaml
@@ -10,4 +10,5 @@ sensor:
   - platform: ads1115
     multiplexer: A0_A1
     gain: 1.024
+    sample_rate: 128
     id: ads1115_sensor

--- a/tests/components/ads1115/test.esp32-idf.yaml
+++ b/tests/components/ads1115/test.esp32-idf.yaml
@@ -10,4 +10,5 @@ sensor:
   - platform: ads1115
     multiplexer: A0_A1
     gain: 1.024
+    sample_rate: 128
     id: ads1115_sensor

--- a/tests/components/ads1115/test.esp8266-ard.yaml
+++ b/tests/components/ads1115/test.esp8266-ard.yaml
@@ -10,4 +10,5 @@ sensor:
   - platform: ads1115
     multiplexer: A0_A1
     gain: 1.024
+    sample_rate: 128
     id: ads1115_sensor

--- a/tests/components/ads1115/test.rp2040-ard.yaml
+++ b/tests/components/ads1115/test.rp2040-ard.yaml
@@ -10,4 +10,5 @@ sensor:
   - platform: ads1115
     multiplexer: A0_A1
     gain: 1.024
+    sample_rate: 128
     id: ads1115_sensor


### PR DESCRIPTION
# What does this implement/fix?

Add sample rate control to the ads1115 sensor, allow lower peak-to-peak noise.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

-

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#4591

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
ads1115:
  - address: 0x48
sensor:
  - platform: ads1115
    multiplexer: 'A0_GND'
    gain: 6.144
    sample_rate: 128
    name: "ADS1115 Channel A0-GND"

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
