### PR TITLE
Initial ESP-IDF buildgen

### DIFF
--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -228,9 +228,13 @@ def write_cpp_file():
     code_s = indent(CORE.cpp_main_section)
     writer.write_cpp(code_s)
 
-    from esphome.build_gen import platformio
+    from esphome.build_gen import esp_idf, platformio
 
-    platformio.write_project()
+    if CORE.using_esp_idf:
+        esp_idf.Generator().write_project()
+    else:
+        platformio.write_project()
+
     return 0
 
 
@@ -238,11 +242,16 @@ def compile_program(args, config):
     from esphome import platformio_api
 
     _LOGGER.info("Compiling app...")
-    rc = platformio_api.run_compile(config, CORE.verbose)
-    if rc != 0:
-        return rc
-    idedata = platformio_api.get_idedata(config)
-    return 0 if idedata is not None else 1
+    if CORE.using_esp_idf:
+        from esphome.build_gen import esp_idf
+
+        esp_idf.Builder().build()
+    else:
+        rc = platformio_api.run_compile(config, CORE.verbose)
+        if rc != 0:
+            return rc
+        idedata = platformio_api.get_idedata(config)
+        return 0 if idedata is not None else 1
 
 
 def upload_using_esptool(config, port, file):

--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -66,7 +66,7 @@ def choose_prompt(options, purpose: str = None):
         return options[0][1]
 
     safe_print(
-        f'Found multiple options{f" for {purpose}" if purpose else ""}, please choose one:'
+        f"Found multiple options{f' for {purpose}' if purpose else ''}, please choose one:"
     )
     for i, (desc, _) in enumerate(options):
         safe_print(f"  [{i + 1}] {desc}")
@@ -225,7 +225,9 @@ def generate_cpp_contents(config):
 
 
 def write_cpp_file():
-    writer.write_platformio_project()
+    from esphome.build_gen import platformio
+
+    platformio.write_project()
 
     code_s = indent(CORE.cpp_main_section)
     writer.write_cpp(code_s)

--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -225,12 +225,12 @@ def generate_cpp_contents(config):
 
 
 def write_cpp_file():
+    code_s = indent(CORE.cpp_main_section)
+    writer.write_cpp(code_s)
+
     from esphome.build_gen import platformio
 
     platformio.write_project()
-
-    code_s = indent(CORE.cpp_main_section)
-    writer.write_cpp(code_s)
     return 0
 
 

--- a/esphome/build_gen/cmake.py
+++ b/esphome/build_gen/cmake.py
@@ -1,0 +1,125 @@
+import os
+from pathlib import Path
+
+from esphome.const import ENV_NOGITIGNORE
+from esphome.core import CORE
+from esphome.helpers import get_bool_env, mkdir_p, read_file, write_file_if_changed
+from esphome.writer import find_begin_end, update_storage_json, write_gitignore
+
+AUTO_GENERATE_BEGIN = "# ========== AUTO GENERATED CODE BEGIN ==========="
+AUTO_GENERATE_END = "# =========== AUTO GENERATED CODE END ============"
+
+REQUIRED_VERSION_MIN = "3.26"
+
+BASE_FORMAT = (
+    f"""# Auto generated code by esphome
+cmake_minimum_required(VERSION {REQUIRED_VERSION_MIN})
+
+""",
+    """
+
+""",
+)
+
+
+def get_compile_defines() -> set[str]:
+    return {x[2:] for x in sorted(CORE.build_flags) if x.startswith("-D")}
+
+
+def get_compile_options() -> set[str]:
+    return {x for x in sorted(CORE.build_flags) if not x.startswith("-D")}
+
+
+class Formatter:
+    def project(self, name: str, description=None) -> str:
+        return (
+            f"project({name}"
+            + (f"\n DESCRIPTION {description}" if description else "")
+            + ")"
+        )
+
+    def target(self, name: str, type: str = "library") -> str:
+        return f"add_{type}({name})"
+
+    def target_sources(self, target: str, sources: list[str]) -> str:
+        return f"target_sources({target} PRIVATE \n\t{'\n\t'.join(sources)}\n)"
+
+    def target_compile_options(self, target: str, flags: list[str]) -> str:
+        return f"target_compile_options({target} PRIVATE \n\t{'\n\t'.join(flags)}\n)"
+
+    def target_compile_definitions(
+        self, target: str, definitions: dict[str, str]
+    ) -> str:
+        return f"target_compile_definitions({target} PRIVATE \n\t{'\n\t'.join(definitions)}\n)"
+
+    def compile_options(self, flags: list[str]) -> str:
+        return f"add_compile_options(\n\t{'\n\t'.join(flags)}\n)"
+
+    def compile_definitions(self, definitions: dict[str, str]) -> str:
+        return f"add_compile_definitions(\n\t{'\n\t'.join(definitions)}\n)"
+
+    def fetchcontent_git(self, name: str, repo: str, tag: str) -> str:
+        self.fetchcontent_included = True
+        prelude = "include(FetchContent)" if not self.fetchcontent_included else ""
+        return (
+            prelude
+            + f"""FetchContent_Declare({name}
+    GIT_REPOSITORY {repo}
+    GIT_TAG {tag}
+    GIT_SHALLOW YES
+)
+FetchContent_MakeAvailable({name})"""
+        )
+
+
+class Generator:
+    def get_content(self, f: Formatter = Formatter()) -> str:
+        # CORE.add_platformio_option(
+        #    "lib_deps",
+        #    [x.as_lib_dep for x in CORE.platformio_libraries] + ["${common.lib_deps}"],
+        # )
+        # Sort to avoid changing build flags order
+
+        src_path = Path(CORE.build_path)  # / "src"
+
+        sources = [
+            str(cpp_path.relative_to(src_path).as_posix())
+            for cpp_path in src_path.rglob("*.cpp")
+        ]
+
+        content = [
+            f.project(CORE.name),
+            *[
+                f.fetchcontent_git(lib.name, lib.repository, lib.version)
+                for lib in CORE.platformio_libraries
+            ],
+            f.compile_definitions(get_compile_defines()),
+            f.compile_options(get_compile_options()),
+            f.target(CORE.name, "executable"),
+            f.target_sources(CORE.name, sources),
+        ]
+
+        return "\n\n".join(content) + "\n"
+
+    def write_cmakelists(self, content: str):
+        update_storage_json()
+        path = CORE.relative_build_path("CMakeLists.txt")
+
+        if os.path.isfile(path):
+            text = read_file(path)
+            content_format = find_begin_end(
+                text, AUTO_GENERATE_BEGIN, AUTO_GENERATE_END
+            )
+        else:
+            content_format = BASE_FORMAT
+        full_file = f"{content_format[0] + AUTO_GENERATE_BEGIN}\n{content}"
+        full_file += AUTO_GENERATE_END + content_format[1]
+        write_file_if_changed(path, full_file)
+
+    def write_project(self):
+        mkdir_p(CORE.build_path)
+
+        content = self.get_content()
+        if not get_bool_env(ENV_NOGITIGNORE):
+            write_gitignore()
+        self.write_cmakelists(content)

--- a/esphome/build_gen/esp_idf.py
+++ b/esphome/build_gen/esp_idf.py
@@ -1,0 +1,31 @@
+from esphome.core import CORE
+
+from . import cmake
+
+
+class Formatter(cmake.Formatter):
+    def include_espidf_project(self) -> str:
+        return "include($ENV{IDF_PATH}/tools/cmake/project.cmake)"
+
+    def compile_definitions(self, definitions: list[str]) -> str:
+        return f"idf_build_set_property(COMPILE_DEFINITIONS \n\t{'\n\t'.join(definitions)}\n\tAPPEND\n)"
+
+    def compile_options(self, flags: list[str]) -> str:
+        return f"idf_build_set_property(COMPILE_OPTIONS \n\t{'\n\t'.join(flags)}\n\tAPPEND\n)"
+
+
+class Generator(cmake.Generator):
+    def get_content(self, f: Formatter = Formatter()) -> str:
+        # CORE.add_platformio_option(
+        #    "lib_deps",
+        #    [x.as_lib_dep for x in CORE.platformio_libraries] + ["${common.lib_deps}"],
+        # )
+        # Sort to avoid changing build flags order
+        content = [
+            f.project(CORE.name),
+            f.include_espidf_project(),
+            f.compile_definitions(cmake.get_compile_defines()),
+            f.compile_options(cmake.get_compile_options()),
+        ]
+
+        return "\n\n".join(content) + "\n"

--- a/esphome/build_gen/esp_idf.py
+++ b/esphome/build_gen/esp_idf.py
@@ -1,6 +1,40 @@
-from esphome.core import CORE
+import os
+from pathlib import Path
+import shutil
+
+from esphome.core import _LOGGER, CORE
 
 from . import cmake
+
+
+class SDKConfig:
+    def __init__(self, path: Path):
+        self.path = path
+        self.map = {}
+        if path.exists():
+            for line in path.read_text().split("\n"):
+                if "=" not in line:
+                    continue
+                key, value = line.split("=")
+                self.map[key] = value
+        else:
+            path.touch()
+            self.map = {}
+
+    def get_content(self) -> str:
+        return "\n".join([f"{k}={v}" for k, v in self.map.items()])
+
+    def write(self):
+        self.path.write_text(self.get_content())
+
+    def __getitem__(self, key: str) -> str:
+        return self.map[key]
+
+    def __setitem__(self, key: str, value: str):
+        self.map[key] = value
+
+    def __delitem__(self, key: str):
+        del self.map[key]
 
 
 class Formatter(cmake.Formatter):
@@ -8,10 +42,17 @@ class Formatter(cmake.Formatter):
         return "include($ENV{IDF_PATH}/tools/cmake/project.cmake)"
 
     def compile_definitions(self, definitions: list[str]) -> str:
-        return f"idf_build_set_property(COMPILE_DEFINITIONS \n\t{'\n\t'.join(definitions)}\n\tAPPEND\n)"
+        return "\n".join(
+            [
+                f'idf_build_set_property(COMPILE_DEFINITIONS "{d}" APPEND)'
+                for d in definitions
+            ]
+        )
 
     def compile_options(self, flags: list[str]) -> str:
-        return f"idf_build_set_property(COMPILE_OPTIONS \n\t{'\n\t'.join(flags)}\n\tAPPEND\n)"
+        return "\n".join(
+            [f'idf_build_set_property(COMPILE_OPTIONS "{f}" APPEND)' for f in flags]
+        )
 
 
 class Generator(cmake.Generator):
@@ -22,10 +63,51 @@ class Generator(cmake.Generator):
         # )
         # Sort to avoid changing build flags order
         content = [
-            f.project(CORE.name),
             f.include_espidf_project(),
+            f.project(CORE.name),
             f.compile_definitions(cmake.get_compile_defines()),
             f.compile_options(cmake.get_compile_options()),
         ]
 
         return "\n\n".join(content) + "\n"
+
+    def write_main_component_cmakelists(self):
+        path = Path(CORE.relative_src_path("CMakeLists.txt"))
+        if not path.exists():
+            path.write_text(
+                "\n".join(
+                    [
+                        "file(GLOB_RECURSE ESP_SRCS *.cpp)",
+                        'idf_component_register(SRCS ${ESP_SRCS} INCLUDE_DIRS ".")',
+                    ]
+                )
+            )
+
+    def write_project(self):
+        super().write_project()
+        shutil.copyfile(
+            CORE.relative_build_path(f"sdkconfig.{CORE.name}"),
+            CORE.relative_build_path("sdkconfig"),
+        )
+        self.write_main_component_cmakelists()
+        # self.write_sdkconfig()
+
+
+class Builder:
+    def build(self):
+        # get IDF_PATH environment variable
+        try:
+            # IDF_PATH =
+            Path(os.environ["IDF_PATH"])
+        except KeyError:
+            _LOGGER.error(
+                "$IDF_PATH environment variable not set, cannot build automatically. "
+                "You can either set IDF_PATH and re-run this command, or change to the build directory "
+                "and manually execute 'idf.py build' from an ESP-IDF terminal."
+            )
+            return
+
+        # os.chdir(CORE.build_path)
+        # process = subprocess.Popen(["cmake", "-B", "build", "-G", "Ninja"], shell=False)
+        # process.communicate()
+        # process.wait()

--- a/esphome/build_gen/platformio.py
+++ b/esphome/build_gen/platformio.py
@@ -39,7 +39,8 @@ def format_ini(data: dict[str, Union[str, list[str]]]) -> str:
 def get_ini_content():
     CORE.add_platformio_option(
         "lib_deps",
-        [x.as_lib_dep for x in CORE.platformio_libraries] + ["${common.lib_deps}"],
+        [x.as_lib_dep for x in CORE.platformio_libraries.values()]
+        + ["${common.lib_deps}"],
     )
     # Sort to avoid changing build flags order
     CORE.add_platformio_option("build_flags", sorted(CORE.build_flags))

--- a/esphome/build_gen/platformio.py
+++ b/esphome/build_gen/platformio.py
@@ -1,0 +1,78 @@
+import os
+from typing import Union
+
+from esphome.const import ENV_NOGITIGNORE, __version__
+from esphome.core import CORE
+from esphome.helpers import get_bool_env, mkdir_p, read_file, write_file_if_changed
+from esphome.writer import find_begin_end, update_storage_json, write_gitignore
+
+INI_AUTO_GENERATE_BEGIN = "; ========== AUTO GENERATED CODE BEGIN ==========="
+INI_AUTO_GENERATE_END = "; =========== AUTO GENERATED CODE END ============"
+
+INI_BASE_FORMAT = (
+    """; Auto generated code by esphome
+
+[common]
+lib_deps =
+build_flags =
+upload_flags =
+
+""",
+    """
+
+""",
+)
+
+
+def format_ini(data: dict[str, Union[str, list[str]]]) -> str:
+    content = ""
+    for key, value in sorted(data.items()):
+        if isinstance(value, list):
+            content += f"{key} =\n"
+            for x in value:
+                content += f"    {x}\n"
+        else:
+            content += f"{key} = {value}\n"
+    return content
+
+
+def get_ini_content():
+    CORE.add_platformio_option(
+        "lib_deps",
+        [x.as_lib_dep for x in CORE.platformio_libraries] + ["${common.lib_deps}"],
+    )
+    # Sort to avoid changing build flags order
+    CORE.add_platformio_option("build_flags", sorted(CORE.build_flags))
+
+    content = "[platformio]\n"
+    content += f"description = ESPHome {__version__}\n"
+
+    content += f"[env:{CORE.name}]\n"
+    content += format_ini(CORE.platformio_options)
+
+    return content
+
+
+def write_ini(content):
+    update_storage_json()
+    path = CORE.relative_build_path("platformio.ini")
+
+    if os.path.isfile(path):
+        text = read_file(path)
+        content_format = find_begin_end(
+            text, INI_AUTO_GENERATE_BEGIN, INI_AUTO_GENERATE_END
+        )
+    else:
+        content_format = INI_BASE_FORMAT
+    full_file = f"{content_format[0] + INI_AUTO_GENERATE_BEGIN}\n{content}"
+    full_file += INI_AUTO_GENERATE_END + content_format[1]
+    write_file_if_changed(path, full_file)
+
+
+def write_project():
+    mkdir_p(CORE.build_path)
+
+    content = get_ini_content()
+    if not get_bool_env(ENV_NOGITIGNORE):
+        write_gitignore()
+    write_ini(content)

--- a/esphome/core/__init__.py
+++ b/esphome/core/__init__.py
@@ -659,7 +659,10 @@ class EsphomeCore:
         return os.path.join(self.build_path, path_)
 
     def relative_src_path(self, *path):
-        return self.relative_build_path("src", *path)
+        if CORE.using_esp_idf:
+            return self.relative_build_path("main", *path)
+        else:
+            return self.relative_build_path("src", *path)
 
     def relative_pioenvs_path(self, *path):
         return self.relative_build_path(".pioenvs", *path)

--- a/esphome/core/__init__.py
+++ b/esphome/core/__init__.py
@@ -504,7 +504,7 @@ class EsphomeCore:
         # A list of statements to insert in the global block (includes and global variables)
         self.global_statements: list[Statement] = []
         # A set of platformio libraries to add to the project
-        self.libraries: list[Library] = []
+        self.platformio_libraries: list[Library] = []
         # A set of build flags to set in the platformio project
         self.build_flags: set[str] = set()
         # A set of defines to set for the compile process in esphome/core/defines.h
@@ -536,7 +536,7 @@ class EsphomeCore:
         self.variables = {}
         self.main_statements = []
         self.global_statements = []
-        self.libraries = []
+        self.platformio_libraries = []
         self.build_flags = set()
         self.defines = set()
         self.platformio_options = {}
@@ -710,7 +710,7 @@ class EsphomeCore:
             raise ValueError(
                 f"Library {library} must be instance of Library, not {type(library)}"
             )
-        for other in self.libraries[:]:
+        for other in self.platformio_libraries[:]:
             if other.name is None or library.name is None:
                 continue
             library_name = (
@@ -732,7 +732,7 @@ class EsphomeCore:
 
             if library.repository is not None:
                 # This is more specific since its using a repository
-                self.libraries.remove(other)
+                self.platformio_libraries.remove(other)
                 continue
 
             if library.version is None:
@@ -740,7 +740,7 @@ class EsphomeCore:
                 break
             if other.version is None:
                 # Found more specific version requirement
-                self.libraries.remove(other)
+                self.platformio_libraries.remove(other)
                 continue
             if other.version == library.version:
                 break
@@ -751,7 +751,7 @@ class EsphomeCore:
             )
         else:
             _LOGGER.debug("Adding library: %s", library)
-            self.libraries.append(library)
+            self.platformio_libraries.append(library)
         return library
 
     def add_build_flag(self, build_flag):

--- a/esphome/core/__init__.py
+++ b/esphome/core/__init__.py
@@ -467,6 +467,57 @@ class Library:
             return self.as_tuple == other.as_tuple
         return NotImplemented
 
+    def reconcile_with(self, other):
+        """Merge two libraries, reconciling any conflicts."""
+
+        if self.name != other.name:
+            # Different libraries, no reconciliation possible
+            raise ValueError(
+                f"Cannot reconcile libraries with different names: {self.name} and {other.name}"
+            )
+
+        # repository specificity takes precedence over version specificity
+        match (self.repository, other.repository):
+            case (None, None):
+                pass  # No repositories, no conflict, continue on
+
+            case (None, _):
+                # incoming library has a repository, use it
+                self.repository = other.repository
+                self.version = other.version
+                return self
+
+            case (_, None):
+                return self  # use the repository/version already present
+
+            case (this_repo, other_repo):
+                if this_repo != other_repo:
+                    raise ValueError(
+                        f"Reconciliation failed! Libraries {self} and {other} requested with conflicting repositories!"
+                    )
+                pass  # Repositories match, continue on
+
+        match (self.version, other.version):
+            case (None, None):
+                return self  # Arduino library reconciled against another Arduino library, current is acceptable
+
+            case (None, _):
+                # incoming library has a version, use it
+                self.version = other.version
+                return self
+
+            case (_, None):
+                return self  # incoming library has no version, current is acceptable
+
+            # Same versions, current library is acceptable
+            case (this_version, other_version):
+                if this_version != other_version:
+                    raise ValueError(
+                        f"Version pinning failed! Libraries {other} and {self} "
+                        "requested with conflicting versions!"
+                    )
+                return self
+
 
 # pylint: disable=too-many-public-methods
 class EsphomeCore:
@@ -503,8 +554,8 @@ class EsphomeCore:
         self.main_statements: list[Statement] = []
         # A list of statements to insert in the global block (includes and global variables)
         self.global_statements: list[Statement] = []
-        # A set of platformio libraries to add to the project
-        self.platformio_libraries: list[Library] = []
+        # A map of platformio libraries to add to the project (shortname: (name, version, repository))
+        self.platformio_libraries: dict[str, Library] = {}
         # A set of build flags to set in the platformio project
         self.build_flags: set[str] = set()
         # A set of defines to set for the compile process in esphome/core/defines.h
@@ -705,54 +756,21 @@ class EsphomeCore:
         _LOGGER.debug("Adding global: %s", expression)
         return expression
 
-    def add_library(self, library):
+    def add_library(self, library: Library):
         if not isinstance(library, Library):
-            raise ValueError(
+            raise TypeError(
                 f"Library {library} must be instance of Library, not {type(library)}"
             )
-        for other in self.platformio_libraries[:]:
-            if other.name is None or library.name is None:
-                continue
-            library_name = (
-                library.name if "/" not in library.name else library.name.split("/")[1]
-            )
-            other_name = (
-                other.name if "/" not in other.name else other.name.split("/")[1]
-            )
-            if other_name != library_name:
-                continue
-            if other.repository is not None:
-                if library.repository is None or other.repository == library.repository:
-                    # Other is using a/the same repository, takes precedence
-                    break
-                raise ValueError(
-                    f"Adding named Library with repository failed! Libraries {library} and {other} "
-                    "requested with conflicting repositories!"
-                )
+        short_name = (
+            library.name if "/" not in library.name else library.name.split("/")[-1]
+        )
 
-            if library.repository is not None:
-                # This is more specific since its using a repository
-                self.platformio_libraries.remove(other)
-                continue
-
-            if library.version is None:
-                # Other requirement is more specific
-                break
-            if other.version is None:
-                # Found more specific version requirement
-                self.platformio_libraries.remove(other)
-                continue
-            if other.version == library.version:
-                break
-
-            raise ValueError(
-                f"Version pinning failed! Libraries {library} and {other} "
-                "requested with conflicting versions!"
-            )
-        else:
+        if short_name not in self.platformio_libraries:
             _LOGGER.debug("Adding library: %s", library)
-            self.platformio_libraries.append(library)
-        return library
+            self.platformio_libraries[short_name] = library
+            return library
+
+        self.platformio_libraries[short_name].reconcile_with(library)
 
     def add_build_flag(self, build_flag):
         self.build_flags.add(build_flag)

--- a/esphome/cpp_generator.py
+++ b/esphome/cpp_generator.py
@@ -4,6 +4,7 @@ import inspect
 import math
 import re
 from typing import Any, Callable, Optional, Union
+import warnings
 
 from esphome.core import (
     CORE,
@@ -600,6 +601,13 @@ def add_library(name: str, version: Optional[str], repository: Optional[str] = N
     :param version: The version of the library, may be None.
     :param repository: The repository for the library
     """
+    if repository is None:
+        warnings.warn(
+            "Auto-resolution of the repository of a PlatformIO libraries is deprecated, "
+            "please use add_library() with an explicit repository instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
     CORE.add_library(Library(name, version, repository))
 
 

--- a/esphome/writer.py
+++ b/esphome/writer.py
@@ -3,12 +3,10 @@ import logging
 import os
 from pathlib import Path
 import re
-from typing import Union
 
 from esphome import loader
 from esphome.config import iter_component_configs, iter_components
 from esphome.const import (
-    ENV_NOGITIGNORE,
     HEADER_FILE_EXTENSIONS,
     PLATFORM_ESP32,
     SOURCE_FILE_EXTENSIONS,
@@ -17,8 +15,6 @@ from esphome.const import (
 from esphome.core import CORE, EsphomeError
 from esphome.helpers import (
     copy_file_if_changed,
-    get_bool_env,
-    mkdir_p,
     read_file,
     walk_files,
     write_file_if_changed,
@@ -31,8 +27,6 @@ CPP_AUTO_GENERATE_BEGIN = "// ========== AUTO GENERATED CODE BEGIN ==========="
 CPP_AUTO_GENERATE_END = "// =========== AUTO GENERATED CODE END ============"
 CPP_INCLUDE_BEGIN = "// ========== AUTO GENERATED INCLUDE BLOCK BEGIN ==========="
 CPP_INCLUDE_END = "// ========== AUTO GENERATED INCLUDE BLOCK END ==========="
-INI_AUTO_GENERATE_BEGIN = "; ========== AUTO GENERATED CODE BEGIN ==========="
-INI_AUTO_GENERATE_END = "; =========== AUTO GENERATED CODE END ============"
 
 CPP_BASE_FORMAT = (
     """// Auto generated code by esphome
@@ -48,20 +42,6 @@ void setup() {
 void loop() {
   App.loop();
 }
-""",
-)
-
-INI_BASE_FORMAT = (
-    """; Auto generated code by esphome
-
-[common]
-lib_deps =
-build_flags =
-upload_flags =
-
-""",
-    """
-
 """,
 )
 
@@ -132,34 +112,6 @@ def update_storage_json():
     new.save(path)
 
 
-def format_ini(data: dict[str, Union[str, list[str]]]) -> str:
-    content = ""
-    for key, value in sorted(data.items()):
-        if isinstance(value, list):
-            content += f"{key} =\n"
-            for x in value:
-                content += f"    {x}\n"
-        else:
-            content += f"{key} = {value}\n"
-    return content
-
-
-def get_ini_content():
-    CORE.add_platformio_option(
-        "lib_deps", [x.as_lib_dep for x in CORE.libraries] + ["${common.lib_deps}"]
-    )
-    # Sort to avoid changing build flags order
-    CORE.add_platformio_option("build_flags", sorted(CORE.build_flags))
-
-    content = "[platformio]\n"
-    content += f"description = ESPHome {__version__}\n"
-
-    content += f"[env:{CORE.name}]\n"
-    content += format_ini(CORE.platformio_options)
-
-    return content
-
-
 def find_begin_end(text, begin_s, end_s):
     begin_index = text.find(begin_s)
     if begin_index == -1:
@@ -187,34 +139,7 @@ def find_begin_end(text, begin_s, end_s):
     return text[:begin_index], text[(end_index + len(end_s)) :]
 
 
-def write_platformio_ini(content):
-    update_storage_json()
-    path = CORE.relative_build_path("platformio.ini")
-
-    if os.path.isfile(path):
-        text = read_file(path)
-        content_format = find_begin_end(
-            text, INI_AUTO_GENERATE_BEGIN, INI_AUTO_GENERATE_END
-        )
-    else:
-        content_format = INI_BASE_FORMAT
-    full_file = f"{content_format[0] + INI_AUTO_GENERATE_BEGIN}\n{content}"
-    full_file += INI_AUTO_GENERATE_END + content_format[1]
-    write_file_if_changed(path, full_file)
-
-
-def write_platformio_project():
-    mkdir_p(CORE.build_path)
-
-    content = get_ini_content()
-    if not get_bool_env(ENV_NOGITIGNORE):
-        write_gitignore()
-    write_platformio_ini(content)
-
-
-DEFINES_H_FORMAT = (
-    ESPHOME_H_FORMAT
-) = """\
+DEFINES_H_FORMAT = ESPHOME_H_FORMAT = """\
 #pragma once
 #include "esphome/core/macros.h"
 {}

--- a/tests/unit_tests/test_core.py
+++ b/tests/unit_tests/test_core.py
@@ -473,6 +473,61 @@ class TestLibrary:
 
         assert actual == expected
 
+    @pytest.mark.parametrize(
+        "target, other, result, exception",
+        (
+            (core.Library("libfoo", None), core.Library("libfoo", None), True, None),
+            (
+                core.Library("libfoo", "1.2.3"),
+                core.Library("libfoo", "1.2.3"),
+                True,  # target is unchanged
+                None,
+            ),
+            (
+                core.Library("libfoo", None),
+                core.Library("libfoo", "1.2.3"),
+                False,  # Use version from other
+                None,
+            ),
+            (
+                core.Library("libfoo", "1.2.3"),
+                core.Library("libfoo", "1.2.4"),
+                False,
+                ValueError,  # Version mismatch
+            ),
+            (
+                core.Library("libfoo", "1.2.3"),
+                core.Library("libbar", "1.2.3"),
+                False,
+                ValueError,  # Name mismatch
+            ),
+            (
+                core.Library(
+                    "libfoo", "1.2.4", "https://github.com/esphome/ESPAsyncWebServer"
+                ),
+                core.Library("libfoo", "1.2.3"),
+                True,  # target is unchanged due to having a repository
+                None,
+            ),
+            (
+                core.Library("libfoo", "1.2.3"),
+                core.Library(
+                    "libfoo", "1.2.4", "https://github.com/esphome/ESPAsyncWebServer"
+                ),
+                False,  # use other due to having a repository
+                None,
+            ),
+        ),
+    )
+    def test_reconcile(self, target, other, result, exception):
+        if exception is not None:
+            with pytest.raises(exception):
+                target.reconcile_with(other)
+        else:
+            expected = target if result else other
+            actual = target.reconcile_with(other)
+            assert actual == expected
+
 
 class TestEsphomeCore:
     @pytest.fixture


### PR DESCRIPTION
# What does this implement/fix?

Adding an ESP-IDF build support to the generated output of esphome.

This is an internal change, as to begin breaking away from builds relying on PlatformIO.

This PR will remain a living draft PR until merged, as my hope is to have this overarching feature done in small chunks to prevent pains merging it in. It's more for visibility and discussion purposes than anything.

# Breaking changes: 
None, but calling `add_library()` without a repository has been marked deprecated, as it will rely on querying PlatformIO's API (whether via REST or the python core) for a library's repository, and that won't be possible forever.

Caveats: I've used at least one f-string here, which is Python 3.12, per discussion with @jesserockz and @kbx81 that a few Python version bumps shouldn't be _too_ problematic. If it is, I'll backport it to 3.9