### PR TITLE
[image]Rename option "use_transparency"

### DIFF
--- a/esphome/components/image/__init__.py
+++ b/esphome/components/image/__init__.py
@@ -282,7 +282,7 @@ IMAGE_TYPE = {
 
 TransparencyType = image_ns.enum("TransparencyType")
 
-CONF_USE_TRANSPARENCY = "use_transparency"
+CONF_TRANSPARENCY = "transparency"
 
 # If the MDI file cannot be downloaded within this time, abort.
 IMAGE_DOWNLOAD_TIMEOUT = 30  # seconds
@@ -417,7 +417,7 @@ def validate_type(image_types):
 
 def validate_settings(value):
     type = value[CONF_TYPE]
-    transparency = value[CONF_USE_TRANSPARENCY].lower()
+    transparency = value[CONF_TRANSPARENCY].lower()
     allow_config = IMAGE_TYPE[type].allow_config
     if transparency not in allow_config:
         raise cv.Invalid(
@@ -458,9 +458,7 @@ BASE_SCHEMA = cv.Schema(
 IMAGE_SCHEMA = BASE_SCHEMA.extend(
     {
         cv.Required(CONF_TYPE): validate_type(IMAGE_TYPE),
-        cv.Optional(
-            CONF_USE_TRANSPARENCY, default=CONF_OPAQUE
-        ): validate_transparency(),
+        cv.Optional(CONF_TRANSPARENCY, default=CONF_OPAQUE): validate_transparency(),
     }
 )
 
@@ -476,7 +474,7 @@ def typed_image_schema(image_type):
                     BASE_SCHEMA.extend(
                         {
                             cv.Optional(
-                                CONF_USE_TRANSPARENCY, default=t
+                                CONF_TRANSPARENCY, default=t
                             ): validate_transparency((t,)),
                             cv.Optional(CONF_TYPE, default=image_type): validate_type(
                                 (image_type,)
@@ -494,7 +492,7 @@ def typed_image_schema(image_type):
             BASE_SCHEMA.extend(
                 {
                     cv.Optional(
-                        CONF_USE_TRANSPARENCY, default=CONF_OPAQUE
+                        CONF_TRANSPARENCY, default=CONF_OPAQUE
                     ): validate_transparency(),
                     cv.Optional(CONF_TYPE, default=image_type): validate_type(
                         (image_type,)
@@ -556,7 +554,7 @@ async def write_image(config, all_frames=False):
         else Image.Dither.FLOYDSTEINBERG
     )
     type = config[CONF_TYPE]
-    transparency = config[CONF_USE_TRANSPARENCY]
+    transparency = config[CONF_TRANSPARENCY]
     invert_alpha = config[CONF_INVERT_ALPHA]
     frame_count = 1
     if all_frames:

--- a/esphome/components/online_image/__init__.py
+++ b/esphome/components/online_image/__init__.py
@@ -5,7 +5,7 @@ import esphome.codegen as cg
 from esphome.components.http_request import CONF_HTTP_REQUEST_ID, HttpRequestComponent
 from esphome.components.image import (
     CONF_INVERT_ALPHA,
-    CONF_USE_TRANSPARENCY,
+    CONF_TRANSPARENCY,
     IMAGE_SCHEMA,
     Image_,
     get_image_type_enum,
@@ -168,7 +168,7 @@ async def to_code(config):
 
     url = config[CONF_URL]
     width, height = config.get(CONF_RESIZE, (0, 0))
-    transparent = get_transparency_enum(config[CONF_USE_TRANSPARENCY])
+    transparent = get_transparency_enum(config[CONF_TRANSPARENCY])
 
     var = cg.new_Pvariable(
         config[CONF_ID],

--- a/tests/components/animation/common.yaml
+++ b/tests/components/animation/common.yaml
@@ -2,12 +2,12 @@ animation:
   - id: rgb565_animation
     file: $component_dir/anim.gif
     type: RGB565
-    use_transparency: opaque
+    transparency: opaque
     resize: 50x50
   - id: rgb_animation
     file: $component_dir/anim.apng
     type: RGB
-    use_transparency: chroma_key
+    transparency: chroma_key
     resize: 50x50
   - id: grayscale_animation
     file: $component_dir/anim.apng

--- a/tests/components/image/common.yaml
+++ b/tests/components/image/common.yaml
@@ -6,54 +6,54 @@ image:
   - id: transparent_transparent_image
     file: ../../pnglogo.png
     type: BINARY
-    use_transparency: chroma_key
+    transparency: chroma_key
 
   - id: rgba_image
     file: ../../pnglogo.png
     type: RGB
-    use_transparency: alpha_channel
+    transparency: alpha_channel
     resize: 50x50
   - id: rgb24_image
     file: ../../pnglogo.png
     type: RGB
-    use_transparency: chroma_key
+    transparency: chroma_key
   - id: rgb_image
     file: ../../pnglogo.png
     type: RGB
-    use_transparency: opaque
+    transparency: opaque
 
   - id: rgb565_image
     file: ../../pnglogo.png
     type: RGB565
-    use_transparency: opaque
+    transparency: opaque
   - id: rgb565_ck_image
     file: ../../pnglogo.png
     type: RGB565
-    use_transparency: chroma_key
+    transparency: chroma_key
   - id: rgb565_alpha_image
     file: ../../pnglogo.png
     type: RGB565
-    use_transparency: alpha_channel
+    transparency: alpha_channel
 
   - id: grayscale_alpha_image
     file: ../../pnglogo.png
     type: grayscale
-    use_transparency: alpha_channel
+    transparency: alpha_channel
     resize: 50x50
   - id: grayscale_ck_image
     file: ../../pnglogo.png
     type: grayscale
-    use_transparency: chroma_key
+    transparency: chroma_key
   - id: grayscale_image
     file: ../../pnglogo.png
     type: grayscale
-    use_transparency: opaque
+    transparency: opaque
 
   - id: web_svg_image
     file: https://raw.githubusercontent.com/esphome/esphome-docs/a62d7ab193c1a464ed791670170c7d518189109b/images/logo.svg
     resize: 256x48
     type: BINARY
-    use_transparency: chroma_key
+    transparency: chroma_key
   - id: web_tiff_image
     file: https://upload.wikimedia.org/wikipedia/commons/b/b6/SIPI_Jelly_Beans_4.1.07.tiff
     type: RGB

--- a/tests/components/image/test.host.yaml
+++ b/tests/components/image/test.host.yaml
@@ -12,7 +12,7 @@ image:
       dither: FloydSteinberg
     - id: transparent_transparent_image
       file: ../../pnglogo.png
-      use_transparency: chroma_key
+      transparency: chroma_key
   rgb:
     alpha_channel:
       - id: rgba_image
@@ -28,21 +28,21 @@ image:
   rgb565:
     - id: rgb565_image
       file: ../../pnglogo.png
-      use_transparency: opaque
+      transparency: opaque
     - id: rgb565_ck_image
       file: ../../pnglogo.png
-      use_transparency: chroma_key
+      transparency: chroma_key
     - id: rgb565_alpha_image
       file: ../../pnglogo.png
-      use_transparency: alpha_channel
+      transparency: alpha_channel
   grayscale:
     - id: grayscale_alpha_image
       file: ../../pnglogo.png
-      use_transparency: alpha_channel
+      transparency: alpha_channel
       resize: 50x50
     - id: grayscale_ck_image
       file: ../../pnglogo.png
-      use_transparency: chroma_key
+      transparency: chroma_key
     - id: grayscale_image
       file: ../../pnglogo.png
-      use_transparency: opaque
+      transparency: opaque

--- a/tests/components/online_image/common.yaml
+++ b/tests/components/online_image/common.yaml
@@ -14,18 +14,18 @@ online_image:
   - id: online_binary_transparent_image
     url: http://www.libpng.org/pub/png/img_png/pnglogo-blk-tiny.png
     type: BINARY
-    use_transparency: chroma_key
+    transparency: chroma_key
     format: png
   - id: online_rgba_image
     url: http://www.libpng.org/pub/png/img_png/pnglogo-blk-tiny.png
     format: PNG
     type: RGB
-    use_transparency: alpha_channel
+    transparency: alpha_channel
   - id: online_rgb24_image
     url: http://www.libpng.org/pub/png/img_png/pnglogo-blk-tiny.png
     format: PNG
     type: RGB
-    use_transparency: chroma_key
+    transparency: chroma_key
 
 # Check the set_url action
 esphome:


### PR DESCRIPTION
# What does this implement/fix?

PR #7908 changed the "use_transparency" parameter from a boolean to an enum. "use_" as a prefix makes less sense now than with a boolean previously, and since the enum change is already a breaking change, we might as well rename the option altogether.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#4595

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
