### PR TITLE
[online_image] Use RAMAllocator

### DIFF
--- a/esphome/components/online_image/image_decoder.h
+++ b/esphome/components/online_image/image_decoder.h
@@ -100,7 +100,7 @@ class DownloadBuffer {
   void reset() { this->unread_ = 0; }
 
  protected:
-  RAMAllocator<uint8_t> allocator_;
+  RAMAllocator<uint8_t> allocator_{};
   uint8_t *buffer_;
   size_t size_;
   /** Total number of downloaded bytes not yet read. */

--- a/esphome/components/online_image/image_decoder.h
+++ b/esphome/components/online_image/image_decoder.h
@@ -100,7 +100,7 @@ class DownloadBuffer {
   void reset() { this->unread_ = 0; }
 
  protected:
-  ExternalRAMAllocator<uint8_t> allocator_;
+  RAMAllocator<uint8_t> allocator_;
   uint8_t *buffer_;
   size_t size_;
   /** Total number of downloaded bytes not yet read. */

--- a/esphome/components/online_image/online_image.h
+++ b/esphome/components/online_image/online_image.h
@@ -83,7 +83,7 @@ class OnlineImage : public PollingComponent,
  protected:
   bool validate_url_(const std::string &url);
 
-  RAMAllocator<uint8_t> allocator_;
+  RAMAllocator<uint8_t> allocator_{};
 
   uint32_t get_buffer_size_() const { return get_buffer_size_(this->buffer_width_, this->buffer_height_); }
   int get_buffer_size_(int width, int height) const { return (this->get_bpp() * width + 7u) / 8u * height; }

--- a/esphome/components/online_image/online_image.h
+++ b/esphome/components/online_image/online_image.h
@@ -83,8 +83,7 @@ class OnlineImage : public PollingComponent,
  protected:
   bool validate_url_(const std::string &url);
 
-  using Allocator = ExternalRAMAllocator<uint8_t>;
-  Allocator allocator_{Allocator::Flags::ALLOW_FAILURE};
+  RAMAllocator<uint8_t> allocator_;
 
   uint32_t get_buffer_size_() const { return get_buffer_size_(this->buffer_width_, this->buffer_height_); }
   int get_buffer_size_(int width, int height) const { return (this->get_bpp() * width + 7u) / 8u * height; }


### PR DESCRIPTION
# What does this implement/fix?

ExternalRAMAllocator has been renamed to just RAMAllocator, and some of its flags deprecated/changed meaning.
Update the online_image code to use the new RAMAllocator

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
