### PR TITLE
[core] Remove old style platform configuration

### DIFF
--- a/tests/component_tests/binary_sensor/test_binary_sensor.yaml
+++ b/tests/component_tests/binary_sensor/test_binary_sensor.yaml
@@ -1,7 +1,8 @@
 ---
 esphome:
   name: test
-  platform: ESP8266
+
+esp8266:
   board: d1_mini_lite
 
 binary_sensor:

--- a/tests/component_tests/button/test_button.yaml
+++ b/tests/component_tests/button/test_button.yaml
@@ -1,7 +1,8 @@
 ---
 esphome:
   name: test
-  platform: ESP8266
+
+esp8266:
   board: d1_mini_lite
 
 wifi:

--- a/tests/component_tests/deep_sleep/test_deep_sleep1.yaml
+++ b/tests/component_tests/deep_sleep/test_deep_sleep1.yaml
@@ -1,7 +1,8 @@
 ---
 esphome:
   name: test
-  platform: ESP32
+
+esp32:
   board: nodemcu-32s
 
 deep_sleep:

--- a/tests/component_tests/deep_sleep/test_deep_sleep2.yaml
+++ b/tests/component_tests/deep_sleep/test_deep_sleep2.yaml
@@ -1,7 +1,8 @@
 ---
 esphome:
   name: test
-  platform: ESP32
+
+esp32:
   board: nodemcu-32s
 
 deep_sleep:

--- a/tests/component_tests/sensor/test_sensor.yaml
+++ b/tests/component_tests/sensor/test_sensor.yaml
@@ -1,7 +1,8 @@
 ---
 esphome:
   name: test
-  platform: ESP8266
+
+esp8266:
   board: d1_mini_lite
 
 sensor:

--- a/tests/component_tests/text_sensor/test_text_sensor.yaml
+++ b/tests/component_tests/text_sensor/test_text_sensor.yaml
@@ -1,7 +1,8 @@
 ---
 esphome:
   name: test
-  platform: ESP8266
+
+esp8266:
   board: d1_mini_lite
 
 text_sensor:

--- a/tests/unit_tests/fixtures/yaml_util/broken_includetest.yaml
+++ b/tests/unit_tests/fixtures/yaml_util/broken_includetest.yaml
@@ -12,7 +12,7 @@ esphome:
   # not overwritten by vars in the !include above
   name: ${name}
   name_add_mac_suffix: true
-  platform: esp8266
-  board: !include {file: includes/scalar.yaml, vars: {var1: nodemcu}}
-
   libraries: !include {file: includes/list.yaml, vars: {var1: Wire}}
+
+esp8266:
+  board: !include {file: includes/scalar.yaml, vars: {var1: nodemcu}}

--- a/tests/unit_tests/fixtures/yaml_util/includetest.yaml
+++ b/tests/unit_tests/fixtures/yaml_util/includetest.yaml
@@ -12,7 +12,7 @@ esphome:
   # not overwritten by vars in the !include above
   name: ${name}
   name_add_mac_suffix: true
-  platform: esp8266
-  board: !include {file: includes/scalar.yaml, vars: {var1: nodemcu}}
-
   libraries: !include {file: includes/list.yaml, vars: {var1: Wire}}
+
+esp8266:
+  board: !include {file: includes/scalar.yaml, vars: {var1: nodemcu}}

--- a/tests/unit_tests/test_yaml_util.py
+++ b/tests/unit_tests/test_yaml_util.py
@@ -10,7 +10,7 @@ def test_include_with_vars(fixture_path):
     substitutions.do_substitution_pass(actual, None)
     assert actual["esphome"]["name"] == "original"
     assert actual["esphome"]["libraries"][0] == "Wire"
-    assert actual["esphome"]["board"] == "nodemcu"
+    assert actual["esp8266"]["board"] == "nodemcu"
     assert actual["wifi"]["ssid"] == "my_custom_ssid"
 
 


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

This removes the old style of platform configuration:
```yaml
esphome:
  name: Living Room
  platform: ESP32
  board: esp32dev
```

That configuration style was replaced 3 years ago in #2303 and is now being removed.

The current format is:
```yaml
esphome:
  name: Living Room

esp32:
  board: esp32dev
```

Closes #7865

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
