### PR TITLE
[debug] fix debug_esp32 printf for partition size and address

### DIFF
--- a/esphome/components/debug/debug_esp32.cpp
+++ b/esphome/components/debug/debug_esp32.cpp
@@ -35,7 +35,7 @@ void DebugComponent::log_partition_info_() {
   esp_partition_iterator_t it = esp_partition_find(ESP_PARTITION_TYPE_ANY, ESP_PARTITION_SUBTYPE_ANY, NULL);
   while (it != NULL) {
     const esp_partition_t *partition = esp_partition_get(it);
-    ESP_LOGCONFIG(TAG, "  %-12s %-4d %-8d 0x%08X 0x%08X", partition->label, partition->type, partition->subtype,
+    ESP_LOGCONFIG(TAG, "  %-12s %-4d %-8d 0x%08lX 0x%08lX", partition->label, partition->type, partition->subtype,
                   partition->address, partition->size);
     it = esp_partition_next(it);
   }

--- a/esphome/components/debug/debug_esp32.cpp
+++ b/esphome/components/debug/debug_esp32.cpp
@@ -35,8 +35,8 @@ void DebugComponent::log_partition_info_() {
   esp_partition_iterator_t it = esp_partition_find(ESP_PARTITION_TYPE_ANY, ESP_PARTITION_SUBTYPE_ANY, NULL);
   while (it != NULL) {
     const esp_partition_t *partition = esp_partition_get(it);
-    ESP_LOGCONFIG(TAG, "  %-12s %-4d %-8d 0x%08" PRIX32 " 0x%08" PRIX32, partition->label, partition->type, partition->subtype,
-                  partition->address, partition->size);
+    ESP_LOGCONFIG(TAG, "  %-12s %-4d %-8d 0x%08" PRIX32 " 0x%08" PRIX32, partition->label, partition->type,
+                  partition->subtype, partition->address, partition->size);
     it = esp_partition_next(it);
   }
   esp_partition_iterator_release(it);

--- a/esphome/components/debug/debug_esp32.cpp
+++ b/esphome/components/debug/debug_esp32.cpp
@@ -35,7 +35,7 @@ void DebugComponent::log_partition_info_() {
   esp_partition_iterator_t it = esp_partition_find(ESP_PARTITION_TYPE_ANY, ESP_PARTITION_SUBTYPE_ANY, NULL);
   while (it != NULL) {
     const esp_partition_t *partition = esp_partition_get(it);
-    ESP_LOGCONFIG(TAG, "  %-12s %-4d %-8d 0x%08lX 0x%08lX", partition->label, partition->type, partition->subtype,
+    ESP_LOGCONFIG(TAG, "  %-12s %-4d %-8d 0x%08" PRIX32 " 0x%08" PRIX32, partition->label, partition->type, partition->subtype,
                   partition->address, partition->size);
     it = esp_partition_next(it);
   }


### PR DESCRIPTION
# What does this implement/fix?

When compiling the current debug component for ESP32 is complaining that 'partition->address, partition->size' are long unsigned integers and sprintf can not print them as normal unsigned integer.
I just added the l specifier to the two affected paramters.
Tested locally on my esp32 with latest dev.

according to the ESP_IDF, address and size are uint32:
https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-reference/storage/partition.html

I still have to test if there is a dependency to a specificIDF version. But at a quick glance I could not find it.

Error:
```

Compiling .pioenvs/gateway2/src/main.cpp.o
In file included from src/esphome/components/sensor/sensor.h:3,
                 from src/esphome/components/debug/debug_component.h:9,
                 from src/esphome/components/debug/debug_esp32.cpp:1:
src/esphome/components/debug/debug_esp32.cpp: In member function 'void esphome::debug::DebugComponent::log_partition_info_()':
src/esphome/components/debug/debug_esp32.cpp:38:24: error: format '%X' expects argument of type 'unsigned int', but argument 8 has type 'long unsigned int' [-Werror=format=]
   38 |     ESP_LOGCONFIG(TAG, "  %-12s %-4d %-8d 0x%08X 0x%08X", partition->label, partition->type, partition->subtype,
      |                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/esphome/core/log.h:72:36: note: in definition of macro 'ESPHOME_LOG_FORMAT'
   72 | #define ESPHOME_LOG_FORMAT(format) format
      |                                    ^~~~~~
src/esphome/core/log.h:153:33: note: in expansion of macro 'esph_log_config'
  153 | #define ESP_LOGCONFIG(tag, ...) esph_log_config(tag, __VA_ARGS__)
      |                                 ^~~~~~~~~~~~~~~
src/esphome/components/debug/debug_esp32.cpp:38:5: note: in expansion of macro 'ESP_LOGCONFIG'
   38 |     ESP_LOGCONFIG(TAG, "  %-12s %-4d %-8d 0x%08X 0x%08X", partition->label, partition->type, partition->subtype,
      |     ^~~~~~~~~~~~~
src/esphome/components/debug/debug_esp32.cpp:38:48: note: format string is defined here
   38 |     ESP_LOGCONFIG(TAG, "  %-12s %-4d %-8d 0x%08X 0x%08X", partition->label, partition->type, partition->subtype,
      |                                             ~~~^
      |                                                |
      |                                                unsigned int
      |                                             %08lX
src/esphome/components/debug/debug_esp32.cpp:38:24: error: format '%X' expects argument of type 'unsigned int', but argument 9 has type 'long unsigned int' [-Werror=format=]
   38 |     ESP_LOGCONFIG(TAG, "  %-12s %-4d %-8d 0x%08X 0x%08X", partition->label, partition->type, partition->subtype,
      |                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/esphome/core/log.h:72:36: note: in definition of macro 'ESPHOME_LOG_FORMAT'
   72 | #define ESPHOME_LOG_FORMAT(format) format
      |                                    ^~~~~~
src/esphome/core/log.h:153:33: note: in expansion of macro 'esph_log_config'
  153 | #define ESP_LOGCONFIG(tag, ...) esph_log_config(tag, __VA_ARGS__)
      |                                 ^~~~~~~~~~~~~~~
src/esphome/components/debug/debug_esp32.cpp:38:5: note: in expansion of macro 'ESP_LOGCONFIG'
   38 |     ESP_LOGCONFIG(TAG, "  %-12s %-4d %-8d 0x%08X 0x%08X", partition->label, partition->type, partition->subtype,
      |     ^~~~~~~~~~~~~
src/esphome/components/debug/debug_esp32.cpp:38:55: note: format string is defined here
   38 |     ESP_LOGCONFIG(TAG, "  %-12s %-4d %-8d 0x%08X 0x%08X", partition->label, partition->type, partition->subtype,
      |                                                    ~~~^
      |                                                       |
      |                                                       unsigned int
      |                                                    %08lX
cc1plus: some warnings being treated as errors
*** [.pioenvs/gateway2/src/esphome/components/debug/debug_esp32.cpp.o] Error 1
========================== [FAILED] Took 4.95 seconds ==========================

```
## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- not yet created

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- No documentation change

## Test Environment

- [ ] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
