### PR TITLE
Add verbose logging for pulse width calculation in pulse_meter

### DIFF
--- a/esphome/components/pulse_meter/pulse_meter_sensor.cpp
+++ b/esphome/components/pulse_meter/pulse_meter_sensor.cpp
@@ -75,7 +75,7 @@ void PulseMeterSensor::loop() {
       case MeterState::RUNNING: {
         uint32_t delta_us = this->get_->last_detected_edge_us_ - this->last_processed_edge_us_;
         float pulse_width_us = delta_us / float(this->get_->count_);
-        ESP_LOGV(TAG, "New pulse, delta: " PRIu32 " us, count: " PRIu32 ", width: %.5f us", delta_us,
+        ESP_LOGV(TAG, "New pulse, delta: %" PRIu32 " µs, count: %" PRIu32 ", width: %.5f µs", delta_us,
                  this->get_->count_, pulse_width_us);
         this->publish_state((60.0f * 1000000.0f) / pulse_width_us);
       } break;

--- a/esphome/components/pulse_meter/pulse_meter_sensor.cpp
+++ b/esphome/components/pulse_meter/pulse_meter_sensor.cpp
@@ -75,8 +75,8 @@ void PulseMeterSensor::loop() {
       case MeterState::RUNNING: {
         uint32_t delta_us = this->get_->last_detected_edge_us_ - this->last_processed_edge_us_;
         float pulse_width_us = delta_us / float(this->get_->count_);
-        ESP_LOGV(TAG, "New pulse, delta: " PRIu32 " us, count: " PRIu32 ", width: %.5f us",
-                 delta_us, this->get_->count_, pulse_width_us);
+        ESP_LOGV(TAG, "New pulse, delta: " PRIu32 " us, count: " PRIu32 ", width: %.5f us", delta_us,
+                 this->get_->count_, pulse_width_us);
         this->publish_state((60.0f * 1000000.0f) / pulse_width_us);
       } break;
     }

--- a/esphome/components/pulse_meter/pulse_meter_sensor.cpp
+++ b/esphome/components/pulse_meter/pulse_meter_sensor.cpp
@@ -75,6 +75,8 @@ void PulseMeterSensor::loop() {
       case MeterState::RUNNING: {
         uint32_t delta_us = this->get_->last_detected_edge_us_ - this->last_processed_edge_us_;
         float pulse_width_us = delta_us / float(this->get_->count_);
+        ESP_LOGV(TAG, "New pulse, delta: " PRIu32 " us, count: " PRIu32 ", width: %.5f us",
+                 delta_us, this->get_->count_, pulse_width_us);
         this->publish_state((60.0f * 1000000.0f) / pulse_width_us);
       } break;
     }


### PR DESCRIPTION
# What does this implement/fix?

This PR enhances the logging for the pulse_meter sensor to aid in diagnosing and resolving an issue where inf values are occasionally reported as the state. The updated code adds detailed logging of the pulse width and associated calculations, enabling easier identification of potential division by zero errors or other anomalies in the pulse width computation.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- does NOT fix: https://github.com/esphome/issues/issues/6683

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
