### PR TITLE
Don't activate venv in devcontainer

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,6 +45,6 @@ repos:
     hooks:
       - id: pylint
         name: pylint
-        entry: python script/run-in-env pylint
+        entry: python3 script/run-in-env.py pylint
         language: system
         types: [python]

--- a/script/run-in-env.py
+++ b/script/run-in-env.py
@@ -7,6 +7,13 @@ import sys
 
 
 def find_and_activate_virtualenv():
+    if (
+        ("VIRTUAL_ENV" in os.environ)
+        or os.environ.get("DEVCONTAINER", False)
+        or os.environ.get("ESPHOME_NO_VENV", False)
+    ):
+        return
+
     try:
         # Get the top-level directory of the git repository
         my_path = subprocess.check_output(
@@ -17,7 +24,7 @@ def find_and_activate_virtualenv():
             "Error: Not a git repository or unable to determine the top-level directory.",
             file=sys.stderr,
         )
-        sys.exit(1)
+        return
 
     # Check for virtual environments
     for venv in ["venv", ".venv", "."]:
@@ -29,25 +36,26 @@ def find_and_activate_virtualenv():
         )
         if activate_path.exists():
             # Activate the virtual environment by updating PATH
-            env = os.environ.copy()
             venv_bin_dir = activate_path.parent
-            env["PATH"] = f"{venv_bin_dir}{os.pathsep}{env['PATH']}"
-            env["VIRTUAL_ENV"] = str(venv_bin_dir.parent)
+            os.environ["PATH"] = f"{venv_bin_dir}{os.pathsep}{os.environ['PATH']}"
+            os.environ["VIRTUAL_ENV"] = str(venv_bin_dir.parent)
             print(f"Activated virtual environment: {venv_bin_dir.parent}")
-
-            # Execute the remaining arguments in the new environment
-            if len(sys.argv) > 1:
-                subprocess.run(sys.argv[1:], env=env, check=False)
-            else:
-                print(
-                    "No command provided to run in the virtual environment.",
-                    file=sys.stderr,
-                )
             return
 
     print("No virtual environment found.", file=sys.stderr)
-    sys.exit(1)
+
+
+def run_command():
+    # Execute the remaining arguments in the new environment
+    if len(sys.argv) > 1:
+        subprocess.run(sys.argv[1:], check=False)
+    else:
+        print(
+            "No command provided to run in the virtual environment.",
+            file=sys.stderr,
+        )
 
 
 if __name__ == "__main__":
     find_and_activate_virtualenv()
+    run_command()


### PR DESCRIPTION
# What does this implement/fix?

The pylint pre-commit hook currently fails in a devcontainer for two reasons:
- There is no symlink from `python` to `python3`
- There is no virtual environment inside the devcontainer

This PR tries to restore some of the behavior present before #8095.

**I could only really test this inside the devcontainer, so testing in other environments is necessary before merging!**

@stellar-aria Can you please have a look at this?

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
