### PR TITLE
[ota] Increase socket timeout earlier in OTA script

### DIFF
--- a/esphome/espota2.py
+++ b/esphome/espota2.py
@@ -249,6 +249,9 @@ def perform_ota(
         send_check(sock, result, "auth result")
         receive_exactly(sock, 1, "auth result", RESPONSE_AUTH_OK)
 
+    # Set higher timeout during upload
+    sock.settimeout(30.0)
+
     upload_size = len(upload_contents)
     upload_size_encoded = [
         (upload_size >> 24) & 0xFF,
@@ -271,8 +274,6 @@ def perform_ota(
     # show the actual progress
 
     sock.setsockopt(socket.SOL_SOCKET, socket.SO_SNDBUF, UPLOAD_BUFFER_SIZE)
-    # Set higher timeout during upload
-    sock.settimeout(30.0)
     start_time = time.perf_counter()
 
     offset = 0


### PR DESCRIPTION
# What does this implement/fix?

Fixes OTA with larger binaries that some people have encountered:

    ERROR Error receiving acknowledge binary size: timed out

Increase socket timeout earlier

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/issues/issues/6695
- fixes https://github.com/esphome/issues/issues/6301

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
