### PR TITLE
[online_image] Code Improvements

### DIFF
--- a/esphome/components/online_image/__init__.py
+++ b/esphome/components/online_image/__init__.py
@@ -52,6 +52,14 @@ class Format:
         pass
 
 
+class BMPFormat(Format):
+    def __init__(self):
+        super().__init__("BMP")
+
+    def actions(self):
+        cg.add_define("USE_ONLINE_IMAGE_BMP_SUPPORT")
+
+
 class PNGFormat(Format):
     def __init__(self):
         super().__init__("PNG")
@@ -61,20 +69,12 @@ class PNGFormat(Format):
         cg.add_library("pngle", "1.0.2")
 
 
-class BMPFormat(Format):
-    def __init__(self):
-        super().__init__("BMP")
-
-    def actions(self):
-        cg.add_define("USE_ONLINE_IMAGE_BMP_SUPPORT")
-
-
 # New formats can be added here.
 IMAGE_FORMATS = {
     x.image_type: x
     for x in (
-        PNGFormat(),
         BMPFormat(),
+        PNGFormat(),
     )
 }
 

--- a/esphome/components/online_image/image_decoder.h
+++ b/esphome/components/online_image/image_decoder.h
@@ -30,7 +30,7 @@ class ImageDecoder {
    *
    * @param download_size The total number of bytes that need to be downloaded for the image.
    */
-  virtual void prepare(uint32_t download_size) { this->download_size_ = download_size; }
+  virtual void prepare(size_t download_size) { this->download_size_ = download_size; }
 
   /**
    * @brief Decode a part of the image. It will try reading from the buffer.
@@ -75,8 +75,8 @@ class ImageDecoder {
   OnlineImage *image_;
   // Initializing to 1, to ensure it is distinguishable from initial "decoded_bytes_".
   // Will be overwritten anyway once the download size is known.
-  uint32_t download_size_ = 1;
-  uint32_t decoded_bytes_ = 0;
+  size_t download_size_ = 1;
+  size_t decoded_bytes_ = 0;
   double x_scale_ = 1.0;
   double y_scale_ = 1.0;
 };

--- a/esphome/components/online_image/online_image.cpp
+++ b/esphome/components/online_image/online_image.cpp
@@ -6,12 +6,11 @@ static const char *const TAG = "online_image";
 
 #include "image_decoder.h"
 
-#ifdef USE_ONLINE_IMAGE_PNG_SUPPORT
-#include "png_image.h"
-#endif
-
 #ifdef USE_ONLINE_IMAGE_BMP_SUPPORT
 #include "bmp_image.h"
+#endif
+#ifdef USE_ONLINE_IMAGE_PNG_SUPPORT
+#include "png_image.h"
 #endif
 
 namespace esphome {
@@ -122,16 +121,16 @@ void OnlineImage::update() {
   ESP_LOGD(TAG, "Starting download");
   size_t total_size = this->downloader_->content_length;
 
-#ifdef USE_ONLINE_IMAGE_PNG_SUPPORT
-  if (this->format_ == ImageFormat::PNG) {
-    this->decoder_ = make_unique<PngDecoder>(this);
-  }
-#endif  // ONLINE_IMAGE_PNG_SUPPORT
 #ifdef USE_ONLINE_IMAGE_BMP_SUPPORT
   if (this->format_ == ImageFormat::BMP) {
     this->decoder_ = make_unique<BmpDecoder>(this);
   }
 #endif  // ONLINE_IMAGE_BMP_SUPPORT
+#ifdef USE_ONLINE_IMAGE_PNG_SUPPORT
+  if (this->format_ == ImageFormat::PNG) {
+    this->decoder_ = make_unique<PngDecoder>(this);
+  }
+#endif  // ONLINE_IMAGE_PNG_SUPPORT
 
   if (!this->decoder_) {
     ESP_LOGE(TAG, "Could not instantiate decoder. Image format unsupported.");

--- a/esphome/components/online_image/png_image.cpp
+++ b/esphome/components/online_image/png_image.cpp
@@ -41,7 +41,7 @@ static void draw_callback(pngle_t *pngle, uint32_t x, uint32_t y, uint32_t w, ui
   decoder->draw(x, y, w, h, color);
 }
 
-void PngDecoder::prepare(uint32_t download_size) {
+void PngDecoder::prepare(size_t download_size) {
   ImageDecoder::prepare(download_size);
   pngle_set_user_data(this->pngle_, this);
   pngle_set_init_callback(this->pngle_, init_callback);
@@ -51,7 +51,7 @@ void PngDecoder::prepare(uint32_t download_size) {
 int HOT PngDecoder::decode(uint8_t *buffer, size_t size) {
   if (!this->pngle_) {
     ESP_LOGE(TAG, "PNG decoder engine not initialized!");
-    return -1;
+    return DECODE_ERROR_OUT_OF_MEMORY;
   }
   if (size < 256 && size < this->download_size_ - this->decoded_bytes_) {
     ESP_LOGD(TAG, "Waiting for data");

--- a/esphome/components/online_image/png_image.h
+++ b/esphome/components/online_image/png_image.h
@@ -21,7 +21,7 @@ class PngDecoder : public ImageDecoder {
   PngDecoder(OnlineImage *image) : ImageDecoder(image), pngle_(pngle_new()) {}
   ~PngDecoder() override { pngle_destroy(this->pngle_); }
 
-  void prepare(uint32_t download_size) override;
+  void prepare(size_t download_size) override;
   int HOT decode(uint8_t *buffer, size_t size) override;
 
  protected:


### PR DESCRIPTION
# What does this implement/fix?

Small code improvements in the online_image component:

 - Reorder different formats alphabetically
 - use "size_t" type where appropiate
 - use the new error constants in PNG decoder

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/R

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/R

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
