### PR TITLE
Add ADC sampling method option

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,10 +41,10 @@ repos:
     hooks:
       - id: clang-format
         types_or: [c, c++]
-  # - repo: local
-  #   hooks:
-  #     - id: pylint
-  #       name: pylint
-  #       entry: python script/run-in-env pylint
-  #       language: system
-  #       types: [python]
+  - repo: local
+    hooks:
+      - id: pylint
+        name: pylint
+        entry: python script/run-in-env pylint
+        language: system
+        types: [python]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,10 +41,10 @@ repos:
     hooks:
       - id: clang-format
         types_or: [c, c++]
-  - repo: local
-    hooks:
-      - id: pylint
-        name: pylint
-        entry: python script/run-in-env pylint
-        language: system
-        types: [python]
+  # - repo: local
+  #   hooks:
+  #     - id: pylint
+  #       name: pylint
+  #       entry: python script/run-in-env pylint
+  #       language: system
+  #       types: [python]

--- a/esphome/components/adc/__init__.py
+++ b/esphome/components/adc/__init__.py
@@ -36,7 +36,7 @@ ATTENUATION_MODES = {
     "auto": "auto",
 }
 
-sampling_mode = adc_ns.enum("SamplingMode")
+sampling_mode = adc_ns.enum("SamplingMode", is_class=True)
 
 SAMPLING_MODES = {
     "avg": sampling_mode.AVG,

--- a/esphome/components/adc/__init__.py
+++ b/esphome/components/adc/__init__.py
@@ -36,10 +36,12 @@ ATTENUATION_MODES = {
     "auto": "auto",
 }
 
+sampling_mode = adc_ns.enum("SamplingMode")
+
 SAMPLING_MODES = {
-    "avg": 0,
-    "min": 1,
-    "max": 2,
+    "avg": sampling_mode.AVG,
+    "min": sampling_mode.MIN,
+    "max": sampling_mode.MAX,
 }
 
 adc1_channel_t = cg.global_ns.enum("adc1_channel_t")

--- a/esphome/components/adc/__init__.py
+++ b/esphome/components/adc/__init__.py
@@ -36,6 +36,12 @@ ATTENUATION_MODES = {
     "auto": "auto",
 }
 
+SAMPLING_MODES = {
+    "avg": 0,
+    "min": 1,
+    "max": 2,
+}
+
 adc1_channel_t = cg.global_ns.enum("adc1_channel_t")
 adc2_channel_t = cg.global_ns.enum("adc2_channel_t")
 

--- a/esphome/components/adc/adc_sensor.h
+++ b/esphome/components/adc/adc_sensor.h
@@ -37,7 +37,7 @@ class Aggregator {
   Aggregator(SamplingMode mode);
 
  protected:
-  SamplingMode mode_{0};
+  SamplingMode mode_{SamplingMode::AVG};
   uint32_t aggr_{0};
   uint32_t samples_{0};
 };

--- a/esphome/components/adc/adc_sensor.h
+++ b/esphome/components/adc/adc_sensor.h
@@ -28,6 +28,8 @@ static const adc_atten_t ADC_ATTEN_DB_12_COMPAT = ADC_ATTEN_DB_11;
 #endif
 #endif  // USE_ESP32
 
+enum class SamplingMode : uint8_t { AVG = 0, MIN = 1, MAX = 2 };
+
 class Aggregator {
  public:
   void add_sample(uint32_t value);

--- a/esphome/components/adc/adc_sensor.h
+++ b/esphome/components/adc/adc_sensor.h
@@ -66,7 +66,7 @@ class ADCSensor : public sensor::Sensor, public PollingComponent, public voltage
   void set_pin(InternalGPIOPin *pin) { this->pin_ = pin; }
   void set_output_raw(bool output_raw) { this->output_raw_ = output_raw; }
   void set_sample_count(uint8_t sample_count);
-  void set_sampling_mode(uint8_t sample_mode);
+  void set_sampling_mode(uint8_t sampling_mode);
   float sample() override;
 
 #ifdef USE_ESP8266

--- a/esphome/components/adc/adc_sensor.h
+++ b/esphome/components/adc/adc_sensor.h
@@ -29,7 +29,7 @@ static const adc_atten_t ADC_ATTEN_DB_12_COMPAT = ADC_ATTEN_DB_11;
 #endif  // USE_ESP32
 
 enum class SamplingMode : uint8_t { AVG = 0, MIN = 1, MAX = 2 };
-const char *sampling_mode_str(SamplingMode mode);
+const LogString *sampling_mode_to_str(SamplingMode mode);
 
 class Aggregator {
  public:

--- a/esphome/components/adc/adc_sensor.h
+++ b/esphome/components/adc/adc_sensor.h
@@ -83,7 +83,7 @@ class ADCSensor : public sensor::Sensor, public PollingComponent, public voltage
   InternalGPIOPin *pin_;
   bool output_raw_{false};
   uint8_t sample_count_{1};
-  SamplingMode sampling_mode_{0};
+  SamplingMode sampling_mode_{SamplingMode::AVG};
 
 #ifdef USE_RP2040
   bool is_temperature_{false};

--- a/esphome/components/adc/adc_sensor.h
+++ b/esphome/components/adc/adc_sensor.h
@@ -32,10 +32,10 @@ class Aggregator {
  public:
   void add_sample(uint32_t value);
   uint32_t aggregate();
-  Aggregator(uint8_t mode);
+  Aggregator(SamplingMode mode);
 
  protected:
-  uint8_t mode_{0};
+  SamplingMode mode_{0};
   uint32_t aggr_{0};
   uint32_t samples_{0};
 };
@@ -66,7 +66,7 @@ class ADCSensor : public sensor::Sensor, public PollingComponent, public voltage
   void set_pin(InternalGPIOPin *pin) { this->pin_ = pin; }
   void set_output_raw(bool output_raw) { this->output_raw_ = output_raw; }
   void set_sample_count(uint8_t sample_count);
-  void set_sampling_mode(uint8_t sampling_mode);
+  void set_sampling_mode(SamplingMode sampling_mode);
   float sample() override;
 
 #ifdef USE_ESP8266
@@ -81,7 +81,7 @@ class ADCSensor : public sensor::Sensor, public PollingComponent, public voltage
   InternalGPIOPin *pin_;
   bool output_raw_{false};
   uint8_t sample_count_{1};
-  uint8_t sampling_mode_{0};
+  SamplingMode sampling_mode_{0};
 
 #ifdef USE_RP2040
   bool is_temperature_{false};

--- a/esphome/components/adc/adc_sensor.h
+++ b/esphome/components/adc/adc_sensor.h
@@ -29,6 +29,7 @@ static const adc_atten_t ADC_ATTEN_DB_12_COMPAT = ADC_ATTEN_DB_11;
 #endif  // USE_ESP32
 
 enum class SamplingMode : uint8_t { AVG = 0, MIN = 1, MAX = 2 };
+const char *sampling_mode_str(SamplingMode mode);
 
 class Aggregator {
  public:

--- a/esphome/components/adc/adc_sensor.h
+++ b/esphome/components/adc/adc_sensor.h
@@ -31,7 +31,7 @@ static const adc_atten_t ADC_ATTEN_DB_12_COMPAT = ADC_ATTEN_DB_11;
 class Aggregator {
  public:
   void add_sample(uint32_t value);
-  uint32_t aggreate();
+  uint32_t aggregate();
   Aggregator(uint8_t mode);
 
  protected:

--- a/esphome/components/adc/adc_sensor.h
+++ b/esphome/components/adc/adc_sensor.h
@@ -28,6 +28,18 @@ static const adc_atten_t ADC_ATTEN_DB_12_COMPAT = ADC_ATTEN_DB_11;
 #endif
 #endif  // USE_ESP32
 
+class Aggregator {
+ public:
+  void add_sample(uint32_t value);
+  uint32_t aggreate();
+  Aggregator(uint8_t mode);
+
+ protected:
+  uint8_t mode_{0};
+  uint32_t aggr_{0};
+  uint32_t samples_{0};
+};
+
 class ADCSensor : public sensor::Sensor, public PollingComponent, public voltage_sampler::VoltageSampler {
  public:
 #ifdef USE_ESP32

--- a/esphome/components/adc/adc_sensor.h
+++ b/esphome/components/adc/adc_sensor.h
@@ -54,6 +54,7 @@ class ADCSensor : public sensor::Sensor, public PollingComponent, public voltage
   void set_pin(InternalGPIOPin *pin) { this->pin_ = pin; }
   void set_output_raw(bool output_raw) { this->output_raw_ = output_raw; }
   void set_sample_count(uint8_t sample_count);
+  void set_sampling_mode(uint8_t sample_mode);
   float sample() override;
 
 #ifdef USE_ESP8266
@@ -68,6 +69,7 @@ class ADCSensor : public sensor::Sensor, public PollingComponent, public voltage
   InternalGPIOPin *pin_;
   bool output_raw_{false};
   uint8_t sample_count_{1};
+  uint8_t sampling_mode_{0};
 
 #ifdef USE_RP2040
   bool is_temperature_{false};

--- a/esphome/components/adc/adc_sensor_common.cpp
+++ b/esphome/components/adc/adc_sensor_common.cpp
@@ -37,6 +37,10 @@ void Aggregator::add_sample(uint32_t value) {
 
 uint32_t Aggregator::aggregate() {
   if (this->mode_ == SamplingMode::AVG) {
+    if (this->samples_ == 0) {
+      return this->aggr_;
+    }
+
     return (this->aggr_ + (this->samples_ >> 1)) / this->samples_;  // NOLINT(clang-analyzer-core.DivideZero)
   }
 

--- a/esphome/components/adc/adc_sensor_common.cpp
+++ b/esphome/components/adc/adc_sensor_common.cpp
@@ -6,8 +6,6 @@ namespace adc {
 
 static const char *const TAG = "adc.common";
 
-enum class SamplingMode : uint8_t { AVG = 0, MIN = 1, MAX = 2 };
-
 Aggregator::Aggregator(SamplingMode mode) {
   mode_ = mode;
   // set to max uint if mode is "min"

--- a/esphome/components/adc/adc_sensor_common.cpp
+++ b/esphome/components/adc/adc_sensor_common.cpp
@@ -7,38 +7,40 @@ namespace adc {
 static const char *const TAG = "adc.common";
 
 Aggregator::Aggregator(SamplingMode mode) {
-  mode_ = mode;
+  this->mode_ = mode;
   // set to max uint if mode is "min"
   if (mode == SamplingMode::MIN) {
-    aggr_ = UINT32_MAX;
+    this->aggr_ = UINT32_MAX;
   }
 }
 
 void Aggregator::add_sample(uint32_t value) {
-  if (mode_ == SamplingMode::AVG) {
-    // avg
-    aggr_ += value;
-  } else if (mode_ == SamplingMode::MIN) {
-    // min
-    if (value < aggr_) {
-      aggr_ = value;
-    }
-  } else {
-    // max
-    if (value > aggr_) {
-      aggr_ = value;
-    }
-  }
+  this->samples_ += 1;
 
-  samples_ += 1;
+  switch (this->mode_) {
+    case SamplingMode::AVG:
+      this->aggr_ += value;
+      break;
+
+    case SamplingMode::MIN:
+      if (value < this->aggr_) {
+        this->aggr_ = value;
+      }
+      break;
+
+    case SamplingMode::MAX:
+      if (value > this->aggr_) {
+        this->aggr_ = value;
+      }
+  }
 }
 
 uint32_t Aggregator::aggregate() {
   if (this->mode_ == SamplingMode::AVG) {
-    return (aggr_ + (this->samples_ >> 1)) / this->samples_;  // NOLINT(clang-analyzer-core.DivideZero)
+    return (this->aggr_ + (this->samples_ >> 1)) / this->samples_;  // NOLINT(clang-analyzer-core.DivideZero)
   }
 
-  return aggr_;
+  return this->aggr_;
 }
 
 void ADCSensor::update() {

--- a/esphome/components/adc/adc_sensor_common.cpp
+++ b/esphome/components/adc/adc_sensor_common.cpp
@@ -6,19 +6,21 @@ namespace adc {
 
 static const char *const TAG = "adc.common";
 
-Aggregator::Aggregator(uint8_t mode) {
+enum class SamplingMode : uint8_t { AVG = 0, MIN = 1, MAX = 2 };
+
+Aggregator::Aggregator(SamplingMode mode) {
   mode_ = mode;
   // set to max uint if mode is "min"
-  if (mode == 1) {
+  if (mode == SamplingMode::MIN) {
     aggr_ = UINT32_MAX;
   }
 }
 
 void Aggregator::add_sample(uint32_t value) {
-  if (mode_ == 0) {
+  if (mode_ == SamplingMode::AVG) {
     // avg
     aggr_ += value;
-  } else if (mode_ == 1) {
+  } else if (mode_ == SamplingMode::MIN) {
     // min
     if (value < aggr_) {
       aggr_ = value;
@@ -34,7 +36,7 @@ void Aggregator::add_sample(uint32_t value) {
 }
 
 uint32_t Aggregator::aggregate() {
-  if (this->mode_ == 0) {
+  if (this->mode_ == SamplingMode::AVG) {
     return (aggr_ + (this->samples_ >> 1)) / this->samples_;  // NOLINT(clang-analyzer-core.DivideZero)
   }
 
@@ -53,11 +55,7 @@ void ADCSensor::set_sample_count(uint8_t sample_count) {
   }
 }
 
-void ADCSensor::set_sampling_mode(uint8_t sampling_mode) {
-  if (sampling_mode >= 0 && sampling_mode <= 2) {
-    this->sampling_mode_ = sampling_mode;
-  }
-}
+void ADCSensor::set_sampling_mode(SamplingMode sampling_mode) { this->sampling_mode_ = sampling_mode; }
 
 float ADCSensor::get_setup_priority() const { return setup_priority::DATA; }
 

--- a/esphome/components/adc/adc_sensor_common.cpp
+++ b/esphome/components/adc/adc_sensor_common.cpp
@@ -6,17 +6,16 @@ namespace adc {
 
 static const char *const TAG = "adc.common";
 
-const char *sampling_mode_str(SamplingMode mode) {
+const LogString *sampling_mode_to_str(SamplingMode mode) {
   switch (mode) {
     case SamplingMode::AVG:
-      return "average";
+      return LOG_STR("average");
     case SamplingMode::MIN:
-      return "minimum";
+      return LOG_STR("minimum");
     case SamplingMode::MAX:
-      return "maximum";
+      return LOG_STR("maximum");
   }
-
-  return "unknown";
+  return LOG_STR("unknown");
 }
 
 Aggregator::Aggregator(SamplingMode mode) {

--- a/esphome/components/adc/adc_sensor_common.cpp
+++ b/esphome/components/adc/adc_sensor_common.cpp
@@ -6,6 +6,41 @@ namespace adc {
 
 static const char *const TAG = "adc.common";
 
+Aggregator::Aggregator(uint8_t mode) {
+  mode_ = mode;
+  // set to max uint if mode is "min"
+  if (mode == 1) {
+    aggr_ = UINT32_MAX;
+  }
+}
+
+void Aggregator::add_sample(uint32_t value) {
+  if (mode_ == 0) {
+    // avg
+    aggr_ += value;
+  } else if (mode_ == 1) {
+    // min
+    if (value < aggr_) {
+      aggr_ = value;
+    }
+  } else {
+    // max
+    if (value > aggr_) {
+      aggr_ = value;
+    }
+  }
+
+  samples_ += 1;
+}
+
+uint32_t Aggregator::aggreate() {
+  if (this->mode_ == 0) {
+    return (aggr_ + (this->samples_ >> 1)) / this->samples_;  // NOLINT(clang-analyzer-core.DivideZero)
+  }
+
+  return aggr_;
+}
+
 void ADCSensor::update() {
   float value_v = this->sample();
   ESP_LOGV(TAG, "'%s': Got voltage=%.4fV", this->get_name().c_str(), value_v);

--- a/esphome/components/adc/adc_sensor_common.cpp
+++ b/esphome/components/adc/adc_sensor_common.cpp
@@ -6,6 +6,19 @@ namespace adc {
 
 static const char *const TAG = "adc.common";
 
+const char *sampling_mode_str(SamplingMode mode) {
+  switch (mode) {
+    case SamplingMode::AVG:
+      return "average";
+    case SamplingMode::MIN:
+      return "minimum";
+    case SamplingMode::MAX:
+      return "maximum";
+  }
+
+  return "unknown";
+}
+
 Aggregator::Aggregator(SamplingMode mode) {
   this->mode_ = mode;
   // set to max uint if mode is "min"

--- a/esphome/components/adc/adc_sensor_common.cpp
+++ b/esphome/components/adc/adc_sensor_common.cpp
@@ -33,7 +33,7 @@ void Aggregator::add_sample(uint32_t value) {
   samples_ += 1;
 }
 
-uint32_t Aggregator::aggreate() {
+uint32_t Aggregator::aggregate() {
   if (this->mode_ == 0) {
     return (aggr_ + (this->samples_ >> 1)) / this->samples_;  // NOLINT(clang-analyzer-core.DivideZero)
   }

--- a/esphome/components/adc/adc_sensor_common.cpp
+++ b/esphome/components/adc/adc_sensor_common.cpp
@@ -18,6 +18,12 @@ void ADCSensor::set_sample_count(uint8_t sample_count) {
   }
 }
 
+void ADCSensor::set_sampling_mode(uint8_t sampling_mode) {
+  if (sampling_mode >= 0 && sampling_mode <= 2) {
+    this->sampling_mode_ = sampling_mode;
+  }
+}
+
 float ADCSensor::get_setup_priority() const { return setup_priority::DATA; }
 
 }  // namespace adc

--- a/esphome/components/adc/adc_sensor_esp32.cpp
+++ b/esphome/components/adc/adc_sensor_esp32.cpp
@@ -78,6 +78,7 @@ void ADCSensor::dump_config() {
     }
   }
   ESP_LOGCONFIG(TAG, "  Samples: %i", this->sample_count_);
+  ESP_LOGCONFIG(TAG, "  Sampling mode: %i", this->sampling_mode_);
   LOG_UPDATE_INTERVAL(this);
 }
 

--- a/esphome/components/adc/adc_sensor_esp32.cpp
+++ b/esphome/components/adc/adc_sensor_esp32.cpp
@@ -105,12 +105,12 @@ float ADCSensor::sample() {
       } else if (this->sampling_mode_ == 1) {
         // min
         if (raw < aggr) {
-          aggr = raw
+          aggr = raw;
         }
       } else {
         // max
         if (raw > aggr) {
-          aggr = raw
+          aggr = raw;
         }
       }
     }

--- a/esphome/components/adc/adc_sensor_esp32.cpp
+++ b/esphome/components/adc/adc_sensor_esp32.cpp
@@ -78,7 +78,21 @@ void ADCSensor::dump_config() {
     }
   }
   ESP_LOGCONFIG(TAG, "  Samples: %i", this->sample_count_);
-  ESP_LOGCONFIG(TAG, "  Sampling mode: %hhu", static_cast<uint8_t>(this->sampling_mode_));
+  const char* samplingModeStr;
+  switch(this->sampling_mode_) {
+    case SamplingMode::AVG:
+      samplingModeStr = "average";
+      break;
+    case SamplingMode::MIN:
+      samplingModeStr = "minimum";
+      break;
+    case SamplingMode::MAX:
+      samplingModeStr = "maximum";
+      break;
+    default:
+      samplingModeStr = "unknown";
+  }
+  ESP_LOGCONFIG(TAG, "  Sampling mode: %s", samplingModeStr);
   LOG_UPDATE_INTERVAL(this);
 }
 

--- a/esphome/components/adc/adc_sensor_esp32.cpp
+++ b/esphome/components/adc/adc_sensor_esp32.cpp
@@ -78,7 +78,7 @@ void ADCSensor::dump_config() {
     }
   }
   ESP_LOGCONFIG(TAG, "  Samples: %i", this->sample_count_);
-  ESP_LOGCONFIG(TAG, "  Sampling mode: %s", sampling_mode_str(this->sampling_mode_));
+  ESP_LOGCONFIG(TAG, "  Sampling mode: %s", LOG_STR_ARG(sampling_mode_to_str(this->sampling_mode_)));
   LOG_UPDATE_INTERVAL(this);
 }
 

--- a/esphome/components/adc/adc_sensor_esp32.cpp
+++ b/esphome/components/adc/adc_sensor_esp32.cpp
@@ -83,7 +83,12 @@ void ADCSensor::dump_config() {
 
 float ADCSensor::sample() {
   if (!this->autorange_) {
-    uint32_t sum = 0;
+    uint32_t aggr = 0;
+    // min
+    if (this->sampling_mode_ == 1) {
+      aggr = UINT32_MAX;
+    }
+
     for (uint8_t sample = 0; sample < this->sample_count_; sample++) {
       int raw = -1;
       if (this->channel1_ != ADC1_CHANNEL_MAX) {
@@ -94,13 +99,28 @@ float ADCSensor::sample() {
       if (raw == -1) {
         return NAN;
       }
-      sum += raw;
+      if (this->sampling_mode_ == 0) {
+        // avg
+        aggr += raw;
+      } else if (this->sampling_mode_ == 1) {
+        // min
+        if (raw < aggr) {
+          aggr = raw
+        }
+      } else {
+        // max
+        if (raw > aggr) {
+          aggr = raw
+        }
+      }
     }
-    sum = (sum + (this->sample_count_ >> 1)) / this->sample_count_;  // NOLINT(clang-analyzer-core.DivideZero)
+    if (this->sampling_mode_ == 0) {
+      aggr = (aggr + (this->sample_count_ >> 1)) / this->sample_count_;  // NOLINT(clang-analyzer-core.DivideZero)
+    }
     if (this->output_raw_) {
-      return sum;
+      return aggr;
     }
-    uint32_t mv = esp_adc_cal_raw_to_voltage(sum, &this->cal_characteristics_[(int32_t) this->attenuation_]);
+    uint32_t mv = esp_adc_cal_raw_to_voltage(aggr, &this->cal_characteristics_[(int32_t) this->attenuation_]);
     return mv / 1000.0f;
   }
 

--- a/esphome/components/adc/adc_sensor_esp32.cpp
+++ b/esphome/components/adc/adc_sensor_esp32.cpp
@@ -78,7 +78,7 @@ void ADCSensor::dump_config() {
     }
   }
   ESP_LOGCONFIG(TAG, "  Samples: %i", this->sample_count_);
-  ESP_LOGCONFIG(TAG, "  Sampling mode: %i", this->sampling_mode_);
+  ESP_LOGCONFIG(TAG, "  Sampling mode: %hhu", static_cast<uint8_t>(this->sampling_mode_));
   LOG_UPDATE_INTERVAL(this);
 }
 

--- a/esphome/components/adc/adc_sensor_esp32.cpp
+++ b/esphome/components/adc/adc_sensor_esp32.cpp
@@ -83,11 +83,7 @@ void ADCSensor::dump_config() {
 
 float ADCSensor::sample() {
   if (!this->autorange_) {
-    uint32_t aggr = 0;
-    // min
-    if (this->sampling_mode_ == 1) {
-      aggr = UINT32_MAX;
-    }
+    auto aggr = Aggregator(this->sampling_mode_);
 
     for (uint8_t sample = 0; sample < this->sample_count_; sample++) {
       int raw = -1;
@@ -99,28 +95,14 @@ float ADCSensor::sample() {
       if (raw == -1) {
         return NAN;
       }
-      if (this->sampling_mode_ == 0) {
-        // avg
-        aggr += raw;
-      } else if (this->sampling_mode_ == 1) {
-        // min
-        if (raw < aggr) {
-          aggr = raw;
-        }
-      } else {
-        // max
-        if (raw > aggr) {
-          aggr = raw;
-        }
-      }
-    }
-    if (this->sampling_mode_ == 0) {
-      aggr = (aggr + (this->sample_count_ >> 1)) / this->sample_count_;  // NOLINT(clang-analyzer-core.DivideZero)
+
+      aggr.add_sample(raw);
     }
     if (this->output_raw_) {
-      return aggr;
+      return aggr.aggregate();
     }
-    uint32_t mv = esp_adc_cal_raw_to_voltage(aggr, &this->cal_characteristics_[(int32_t) this->attenuation_]);
+    uint32_t mv =
+        esp_adc_cal_raw_to_voltage(aggr.aggregate(), &this->cal_characteristics_[(int32_t) this->attenuation_]);
     return mv / 1000.0f;
   }
 

--- a/esphome/components/adc/adc_sensor_esp32.cpp
+++ b/esphome/components/adc/adc_sensor_esp32.cpp
@@ -78,21 +78,7 @@ void ADCSensor::dump_config() {
     }
   }
   ESP_LOGCONFIG(TAG, "  Samples: %i", this->sample_count_);
-  const char* samplingModeStr;
-  switch(this->sampling_mode_) {
-    case SamplingMode::AVG:
-      samplingModeStr = "average";
-      break;
-    case SamplingMode::MIN:
-      samplingModeStr = "minimum";
-      break;
-    case SamplingMode::MAX:
-      samplingModeStr = "maximum";
-      break;
-    default:
-      samplingModeStr = "unknown";
-  }
-  ESP_LOGCONFIG(TAG, "  Sampling mode: %s", samplingModeStr);
+  ESP_LOGCONFIG(TAG, "  Sampling mode: %s", sampling_mode_str(this->sampling_mode_));
   LOG_UPDATE_INTERVAL(this);
 }
 

--- a/esphome/components/adc/adc_sensor_esp8266.cpp
+++ b/esphome/components/adc/adc_sensor_esp8266.cpp
@@ -31,6 +31,7 @@ void ADCSensor::dump_config() {
   LOG_PIN("  Pin: ", this->pin_);
 #endif  // USE_ADC_SENSOR_VCC
   ESP_LOGCONFIG(TAG, "  Samples: %i", this->sample_count_);
+  ESP_LOGCONFIG(TAG, "  Sampling mode: %i", this->sampling_mode_);
   LOG_UPDATE_INTERVAL(this);
 }
 

--- a/esphome/components/adc/adc_sensor_esp8266.cpp
+++ b/esphome/components/adc/adc_sensor_esp8266.cpp
@@ -31,7 +31,7 @@ void ADCSensor::dump_config() {
   LOG_PIN("  Pin: ", this->pin_);
 #endif  // USE_ADC_SENSOR_VCC
   ESP_LOGCONFIG(TAG, "  Samples: %i", this->sample_count_);
-  ESP_LOGCONFIG(TAG, "  Sampling mode: %s", sampling_mode_str(this->sampling_mode_));
+  ESP_LOGCONFIG(TAG, "  Sampling mode: %s", LOG_STR_ARG(sampling_mode_to_str(this->sampling_mode_)));
   LOG_UPDATE_INTERVAL(this);
 }
 

--- a/esphome/components/adc/adc_sensor_esp8266.cpp
+++ b/esphome/components/adc/adc_sensor_esp8266.cpp
@@ -48,9 +48,9 @@ float ADCSensor::sample() {
   }
 
   if (this->output_raw_) {
-    return aggr.aggreate();
+    return aggr.aggregate();
   }
-  return aggr.aggreate() / 1024.0f;
+  return aggr.aggregate() / 1024.0f;
 }
 
 std::string ADCSensor::unique_id() { return get_mac_address() + "-adc"; }

--- a/esphome/components/adc/adc_sensor_esp8266.cpp
+++ b/esphome/components/adc/adc_sensor_esp8266.cpp
@@ -31,21 +31,7 @@ void ADCSensor::dump_config() {
   LOG_PIN("  Pin: ", this->pin_);
 #endif  // USE_ADC_SENSOR_VCC
   ESP_LOGCONFIG(TAG, "  Samples: %i", this->sample_count_);
-  const char *samplingModeStr;
-  switch (this->sampling_mode_) {
-    case SamplingMode::AVG:
-      samplingModeStr = "average";
-      break;
-    case SamplingMode::MIN:
-      samplingModeStr = "minimum";
-      break;
-    case SamplingMode::MAX:
-      samplingModeStr = "maximum";
-      break;
-    default:
-      samplingModeStr = "unknown";
-  }
-  ESP_LOGCONFIG(TAG, "  Sampling mode: %s", samplingModeStr);
+  ESP_LOGCONFIG(TAG, "  Sampling mode: %s", sampling_mode_str(this->sampling_mode_));
   LOG_UPDATE_INTERVAL(this);
 }
 

--- a/esphome/components/adc/adc_sensor_esp8266.cpp
+++ b/esphome/components/adc/adc_sensor_esp8266.cpp
@@ -31,7 +31,7 @@ void ADCSensor::dump_config() {
   LOG_PIN("  Pin: ", this->pin_);
 #endif  // USE_ADC_SENSOR_VCC
   ESP_LOGCONFIG(TAG, "  Samples: %i", this->sample_count_);
-  ESP_LOGCONFIG(TAG, "  Sampling mode: %i", this->sampling_mode_);
+  ESP_LOGCONFIG(TAG, "  Sampling mode: %hhu", static_cast<uint8_t>(this->sampling_mode_));
   LOG_UPDATE_INTERVAL(this);
 }
 

--- a/esphome/components/adc/adc_sensor_esp8266.cpp
+++ b/esphome/components/adc/adc_sensor_esp8266.cpp
@@ -35,19 +35,22 @@ void ADCSensor::dump_config() {
 }
 
 float ADCSensor::sample() {
-  uint32_t raw = 0;
+  auto aggr = Aggregator(this->sampling_mode_);
+
   for (uint8_t sample = 0; sample < this->sample_count_; sample++) {
+    uint32_t raw = 0;
 #ifdef USE_ADC_SENSOR_VCC
-    raw += ESP.getVcc();  // NOLINT(readability-static-accessed-through-instance)
+    raw = ESP.getVcc();  // NOLINT(readability-static-accessed-through-instance)
 #else
-    raw += analogRead(this->pin_->get_pin());  // NOLINT
+    raw = analogRead(this->pin_->get_pin());  // NOLINT
 #endif  // USE_ADC_SENSOR_VCC
+    aggr.add_sample(raw);
   }
-  raw = (raw + (this->sample_count_ >> 1)) / this->sample_count_;  // NOLINT(clang-analyzer-core.DivideZero)
+
   if (this->output_raw_) {
-    return raw;
+    return aggr.aggreate();
   }
-  return raw / 1024.0f;
+  return aggr.aggreate() / 1024.0f;
 }
 
 std::string ADCSensor::unique_id() { return get_mac_address() + "-adc"; }

--- a/esphome/components/adc/adc_sensor_esp8266.cpp
+++ b/esphome/components/adc/adc_sensor_esp8266.cpp
@@ -31,7 +31,21 @@ void ADCSensor::dump_config() {
   LOG_PIN("  Pin: ", this->pin_);
 #endif  // USE_ADC_SENSOR_VCC
   ESP_LOGCONFIG(TAG, "  Samples: %i", this->sample_count_);
-  ESP_LOGCONFIG(TAG, "  Sampling mode: %hhu", static_cast<uint8_t>(this->sampling_mode_));
+  const char *samplingModeStr;
+  switch (this->sampling_mode_) {
+    case SamplingMode::AVG:
+      samplingModeStr = "average";
+      break;
+    case SamplingMode::MIN:
+      samplingModeStr = "minimum";
+      break;
+    case SamplingMode::MAX:
+      samplingModeStr = "maximum";
+      break;
+    default:
+      samplingModeStr = "unknown";
+  }
+  ESP_LOGCONFIG(TAG, "  Sampling mode: %s", samplingModeStr);
   LOG_UPDATE_INTERVAL(this);
 }
 

--- a/esphome/components/adc/adc_sensor_libretiny.cpp
+++ b/esphome/components/adc/adc_sensor_libretiny.cpp
@@ -23,6 +23,7 @@ void ADCSensor::dump_config() {
   LOG_PIN("  Pin: ", this->pin_);
 #endif  // USE_ADC_SENSOR_VCC
   ESP_LOGCONFIG(TAG, "  Samples: %i", this->sample_count_);
+  ESP_LOGCONFIG(TAG, "  Sampling mode: %i", this->sampling_mode_);
   LOG_UPDATE_INTERVAL(this);
 }
 

--- a/esphome/components/adc/adc_sensor_libretiny.cpp
+++ b/esphome/components/adc/adc_sensor_libretiny.cpp
@@ -23,7 +23,7 @@ void ADCSensor::dump_config() {
   LOG_PIN("  Pin: ", this->pin_);
 #endif  // USE_ADC_SENSOR_VCC
   ESP_LOGCONFIG(TAG, "  Samples: %i", this->sample_count_);
-  ESP_LOGCONFIG(TAG, "  Sampling mode: %s", sampling_mode_str(this->sampling_mode_));
+  ESP_LOGCONFIG(TAG, "  Sampling mode: %s", LOG_STR_ARG(sampling_mode_to_str(this->sampling_mode_)));
   LOG_UPDATE_INTERVAL(this);
 }
 

--- a/esphome/components/adc/adc_sensor_libretiny.cpp
+++ b/esphome/components/adc/adc_sensor_libretiny.cpp
@@ -23,7 +23,21 @@ void ADCSensor::dump_config() {
   LOG_PIN("  Pin: ", this->pin_);
 #endif  // USE_ADC_SENSOR_VCC
   ESP_LOGCONFIG(TAG, "  Samples: %i", this->sample_count_);
-  ESP_LOGCONFIG(TAG, "  Sampling mode: %hhu", static_cast<uint8_t>(this->sampling_mode_));
+  const char *samplingModeStr;
+  switch (this->sampling_mode_) {
+    case SamplingMode::AVG:
+      samplingModeStr = "average";
+      break;
+    case SamplingMode::MIN:
+      samplingModeStr = "minimum";
+      break;
+    case SamplingMode::MAX:
+      samplingModeStr = "maximum";
+      break;
+    default:
+      samplingModeStr = "unknown";
+  }
+  ESP_LOGCONFIG(TAG, "  Sampling mode: %s", samplingModeStr);
   LOG_UPDATE_INTERVAL(this);
 }
 

--- a/esphome/components/adc/adc_sensor_libretiny.cpp
+++ b/esphome/components/adc/adc_sensor_libretiny.cpp
@@ -23,7 +23,7 @@ void ADCSensor::dump_config() {
   LOG_PIN("  Pin: ", this->pin_);
 #endif  // USE_ADC_SENSOR_VCC
   ESP_LOGCONFIG(TAG, "  Samples: %i", this->sample_count_);
-  ESP_LOGCONFIG(TAG, "  Sampling mode: %i", this->sampling_mode_);
+  ESP_LOGCONFIG(TAG, "  Sampling mode: %hhu", static_cast<uint8_t>(this->sampling_mode_));
   LOG_UPDATE_INTERVAL(this);
 }
 

--- a/esphome/components/adc/adc_sensor_libretiny.cpp
+++ b/esphome/components/adc/adc_sensor_libretiny.cpp
@@ -23,21 +23,7 @@ void ADCSensor::dump_config() {
   LOG_PIN("  Pin: ", this->pin_);
 #endif  // USE_ADC_SENSOR_VCC
   ESP_LOGCONFIG(TAG, "  Samples: %i", this->sample_count_);
-  const char *samplingModeStr;
-  switch (this->sampling_mode_) {
-    case SamplingMode::AVG:
-      samplingModeStr = "average";
-      break;
-    case SamplingMode::MIN:
-      samplingModeStr = "minimum";
-      break;
-    case SamplingMode::MAX:
-      samplingModeStr = "maximum";
-      break;
-    default:
-      samplingModeStr = "unknown";
-  }
-  ESP_LOGCONFIG(TAG, "  Sampling mode: %s", samplingModeStr);
+  ESP_LOGCONFIG(TAG, "  Sampling mode: %s", sampling_mode_str(this->sampling_mode_));
   LOG_UPDATE_INTERVAL(this);
 }
 

--- a/esphome/components/adc/adc_sensor_libretiny.cpp
+++ b/esphome/components/adc/adc_sensor_libretiny.cpp
@@ -28,18 +28,22 @@ void ADCSensor::dump_config() {
 
 float ADCSensor::sample() {
   uint32_t raw = 0;
+  auto aggr = Aggregator(this->sampling_mode_);
+
   if (this->output_raw_) {
     for (uint8_t sample = 0; sample < this->sample_count_; sample++) {
-      raw += analogRead(this->pin_->get_pin());  // NOLINT
+      raw = analogRead(this->pin_->get_pin());  // NOLINT
+      aggr.add_sample(raw);
     }
-    raw = (raw + (this->sample_count_ >> 1)) / this->sample_count_;  // NOLINT(clang-analyzer-core.DivideZero)
-    return raw;
+    return aggr.aggregate();
   }
+
   for (uint8_t sample = 0; sample < this->sample_count_; sample++) {
-    raw += analogReadVoltage(this->pin_->get_pin());  // NOLINT
+    raw = analogReadVoltage(this->pin_->get_pin());  // NOLINT
+    aggr.add_sample(raw);
   }
-  raw = (raw + (this->sample_count_ >> 1)) / this->sample_count_;  // NOLINT(clang-analyzer-core.DivideZero)
-  return raw / 1000.0f;
+
+  return aggr.aggregate() / 1000.0f;
 }
 
 }  // namespace adc

--- a/esphome/components/adc/adc_sensor_rp2040.cpp
+++ b/esphome/components/adc/adc_sensor_rp2040.cpp
@@ -34,6 +34,7 @@ void ADCSensor::dump_config() {
 #endif  // USE_ADC_SENSOR_VCC
   }
   ESP_LOGCONFIG(TAG, "  Samples: %i", this->sample_count_);
+  ESP_LOGCONFIG(TAG, "  Sampling mode: %i", this->sampling_mode_);
   LOG_UPDATE_INTERVAL(this);
 }
 

--- a/esphome/components/adc/adc_sensor_rp2040.cpp
+++ b/esphome/components/adc/adc_sensor_rp2040.cpp
@@ -34,7 +34,7 @@ void ADCSensor::dump_config() {
 #endif  // USE_ADC_SENSOR_VCC
   }
   ESP_LOGCONFIG(TAG, "  Samples: %i", this->sample_count_);
-  ESP_LOGCONFIG(TAG, "  Sampling mode: %s", sampling_mode_str(this->sampling_mode_));
+  ESP_LOGCONFIG(TAG, "  Sampling mode: %s", LOG_STR_ARG(sampling_mode_to_str(this->sampling_mode_)));
   LOG_UPDATE_INTERVAL(this);
 }
 

--- a/esphome/components/adc/adc_sensor_rp2040.cpp
+++ b/esphome/components/adc/adc_sensor_rp2040.cpp
@@ -34,21 +34,7 @@ void ADCSensor::dump_config() {
 #endif  // USE_ADC_SENSOR_VCC
   }
   ESP_LOGCONFIG(TAG, "  Samples: %i", this->sample_count_);
-  const char *samplingModeStr;
-  switch (this->sampling_mode_) {
-    case SamplingMode::AVG:
-      samplingModeStr = "average";
-      break;
-    case SamplingMode::MIN:
-      samplingModeStr = "minimum";
-      break;
-    case SamplingMode::MAX:
-      samplingModeStr = "maximum";
-      break;
-    default:
-      samplingModeStr = "unknown";
-  }
-  ESP_LOGCONFIG(TAG, "  Sampling mode: %s", samplingModeStr);
+  ESP_LOGCONFIG(TAG, "  Sampling mode: %s", sampling_mode_str(this->sampling_mode_));
   LOG_UPDATE_INTERVAL(this);
 }
 

--- a/esphome/components/adc/adc_sensor_rp2040.cpp
+++ b/esphome/components/adc/adc_sensor_rp2040.cpp
@@ -34,7 +34,7 @@ void ADCSensor::dump_config() {
 #endif  // USE_ADC_SENSOR_VCC
   }
   ESP_LOGCONFIG(TAG, "  Samples: %i", this->sample_count_);
-  ESP_LOGCONFIG(TAG, "  Sampling mode: %i", this->sampling_mode_);
+  ESP_LOGCONFIG(TAG, "  Sampling mode: %hhu", static_cast<uint8_t>(this->sampling_mode_));
   LOG_UPDATE_INTERVAL(this);
 }
 

--- a/esphome/components/adc/adc_sensor_rp2040.cpp
+++ b/esphome/components/adc/adc_sensor_rp2040.cpp
@@ -34,7 +34,21 @@ void ADCSensor::dump_config() {
 #endif  // USE_ADC_SENSOR_VCC
   }
   ESP_LOGCONFIG(TAG, "  Samples: %i", this->sample_count_);
-  ESP_LOGCONFIG(TAG, "  Sampling mode: %hhu", static_cast<uint8_t>(this->sampling_mode_));
+  const char *samplingModeStr;
+  switch (this->sampling_mode_) {
+    case SamplingMode::AVG:
+      samplingModeStr = "average";
+      break;
+    case SamplingMode::MIN:
+      samplingModeStr = "minimum";
+      break;
+    case SamplingMode::MAX:
+      samplingModeStr = "maximum";
+      break;
+    default:
+      samplingModeStr = "unknown";
+  }
+  ESP_LOGCONFIG(TAG, "  Sampling mode: %s", samplingModeStr);
   LOG_UPDATE_INTERVAL(this);
 }
 

--- a/esphome/components/adc/adc_sensor_rp2040.cpp
+++ b/esphome/components/adc/adc_sensor_rp2040.cpp
@@ -38,20 +38,23 @@ void ADCSensor::dump_config() {
 }
 
 float ADCSensor::sample() {
+  uint32_t raw = 0;
+  auto aggr = Aggregator(this->sampling_mode_);
+
   if (this->is_temperature_) {
     adc_set_temp_sensor_enabled(true);
     delay(1);
     adc_select_input(4);
-    uint32_t raw = 0;
+
     for (uint8_t sample = 0; sample < this->sample_count_; sample++) {
-      raw += adc_read();
+      raw = adc_read();
+      aggr.add_sample(raw);
     }
-    raw = (raw + (this->sample_count_ >> 1)) / this->sample_count_;  // NOLINT(clang-analyzer-core.DivideZero)
     adc_set_temp_sensor_enabled(false);
     if (this->output_raw_) {
-      return raw;
+      return aggr.aggregate();
     }
-    return raw * 3.3f / 4096.0f;
+    return aggr.aggregate() * 3.3f / 4096.0f;
   }
 
   uint8_t pin = this->pin_->get_pin();
@@ -68,11 +71,10 @@ float ADCSensor::sample() {
   adc_gpio_init(pin);
   adc_select_input(pin - 26);
 
-  uint32_t raw = 0;
   for (uint8_t sample = 0; sample < this->sample_count_; sample++) {
-    raw += adc_read();
+    raw = adc_read();
+    aggr.add_sample(raw);
   }
-  raw = (raw + (this->sample_count_ >> 1)) / this->sample_count_;  // NOLINT(clang-analyzer-core.DivideZero)
 
 #ifdef CYW43_USES_VSYS_PIN
   if (pin == PICO_VSYS_PIN) {
@@ -81,10 +83,10 @@ float ADCSensor::sample() {
 #endif  // CYW43_USES_VSYS_PIN
 
   if (this->output_raw_) {
-    return raw;
+    return aggr.aggregate();
   }
   float coeff = pin == PICO_VSYS_PIN ? 3.0f : 1.0f;
-  return raw * 3.3f / 4096.0f * coeff;
+  return aggr.aggregate() * 3.3f / 4096.0f * coeff;
 }
 
 }  // namespace adc

--- a/esphome/components/adc/sensor.py
+++ b/esphome/components/adc/sensor.py
@@ -1,11 +1,9 @@
 import logging
 
 import esphome.codegen as cg
-import esphome.config_validation as cv
-import esphome.final_validate as fv
-from esphome.core import CORE
 from esphome.components import sensor, voltage_sampler
 from esphome.components.esp32 import get_esp32_variant
+import esphome.config_validation as cv
 from esphome.const import (
     CONF_ATTENUATION,
     CONF_ID,
@@ -17,10 +15,14 @@ from esphome.const import (
     STATE_CLASS_MEASUREMENT,
     UNIT_VOLT,
 )
+from esphome.core import CORE
+import esphome.final_validate as fv
+
 from . import (
     ATTENUATION_MODES,
     ESP32_VARIANT_ADC1_PIN_TO_CHANNEL,
     ESP32_VARIANT_ADC2_PIN_TO_CHANNEL,
+    SAMPLING_MODES,
     adc_ns,
     validate_adc_pin,
 )
@@ -30,9 +32,11 @@ _LOGGER = logging.getLogger(__name__)
 AUTO_LOAD = ["voltage_sampler"]
 
 CONF_SAMPLES = "samples"
+CONF_SAMPLING_MODE = "sampling_mode"
 
 
 _attenuation = cv.enum(ATTENUATION_MODES, lower=True)
+_sampling_mode = cv.enum(SAMPLING_MODES, lower=True)
 
 
 def validate_config(config):
@@ -88,6 +92,7 @@ CONFIG_SCHEMA = cv.All(
                 cv.only_on_esp32, _attenuation
             ),
             cv.Optional(CONF_SAMPLES, default=1): cv.int_range(min=1, max=255),
+            cv.Optional(CONF_SAMPLING_MODE, default="avg"): _sampling_mode,
         }
     )
     .extend(cv.polling_component_schema("60s")),
@@ -112,6 +117,7 @@ async def to_code(config):
 
     cg.add(var.set_output_raw(config[CONF_RAW]))
     cg.add(var.set_sample_count(config[CONF_SAMPLES]))
+    cg.add(var.set_sampling_mode(config[CONF_SAMPLING_MODE]))
 
     if attenuation := config.get(CONF_ATTENUATION):
         if attenuation == "auto":

--- a/tests/component_tests/sensor/test_sensor.yaml
+++ b/tests/component_tests/sensor/test_sensor.yaml
@@ -10,5 +10,6 @@ sensor:
     pin: A0
     id: s_1
     name: test s1
+    sampling_mode: min
     update_interval: 60s
     device_class: voltage


### PR DESCRIPTION
# What does this implement/fix?

This adds a `sampling_method` option to the ADC sensor. This is useful, for example, when measuring a PWM signal and you need to get min or max of the PWM square wave.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#4601

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example configuration entry
sensor:
  - platform: adc
    pin: GPIOXX
    name: "Living Room Brightness"
    samples: 100
    sampling_method: max
    update_interval: 60s
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
