### PR TITLE
Fix bugs in ac_dimmer and add new features for dimmers with less zero crossings

### DIFF
--- a/esphome/components/ac_dimmer/ac_dimmer.cpp
+++ b/esphome/components/ac_dimmer/ac_dimmer.cpp
@@ -37,16 +37,43 @@ uint32_t IRAM_ATTR HOT AcDimmerDataStore::timer_intr(uint32_t now) {
     return 0;
 
   uint32_t time_since_zc = now - this->crossed_zero_at;
-  if (this->value == 65535 || this->value == 0) {
+  if (this->value == 65535) {
+    // the light has gone to 100%, immediately turn on the output to prevent flicker
+    this->gate_pin.digital_write(true);
+    return 0;
+  } else if (this->value == 0) {
     return 0;
   }
 
   if (this->enable_time_us != 0 && time_since_zc >= this->enable_time_us) {
-    this->enable_time_us = 0;
+
+    // If we're doing a double time pulse, see if we've done the second one yet
+    if (this->method == DIM_METHOD_LEADING_PULSE_DOUBLE) {
+      if (!this->first_cycle_done) {
+        // Mark that we've done the first cycle
+        this->first_cycle_done = true;
+
+        // Increase the enable time by half of the cycle time, to trigger it again for the 2nd cycle
+        this->enable_time_us += this->cycle_time_us * 0.5;
+      } else {
+        this->enable_time_us = 0;
+      }
+      // Set the disable time to 1 -- it will be reset at the end of this loop to GATE_ENABLE_TIME plus time_since.
+      this->disable_time_us = 1;
+
+    } else {
+      // Normal case.  Turn off the Enable time.
+      this->enable_time_us = 0;
+    }
+
+    // Actually sent an output to the gate to enable power
     this->gate_pin.digital_write(true);
+
     // Prevent too short pulses
     this->disable_time_us = std::max(this->disable_time_us, time_since_zc + GATE_ENABLE_TIME);
   }
+
+  // If it is time to disable the gate pin, do that now.
   if (this->disable_time_us != 0 && time_since_zc >= this->disable_time_us) {
     this->disable_time_us = 0;
     this->gate_pin.digital_write(false);
@@ -105,28 +132,57 @@ void IRAM_ATTR HOT AcDimmerDataStore::gpio_intr() {
   if (this->value == 65535) {
     // fully on, enable output immediately
     this->gate_pin.digital_write(true);
+
   } else if (this->init_cycle) {
     // send a full cycle
     this->init_cycle = false;
     this->enable_time_us = 0;
     this->disable_time_us = cycle_time_us;
+
   } else if (this->value == 0) {
     // fully off, disable output immediately
     this->gate_pin.digital_write(false);
+
   } else {
     if (this->method == DIM_METHOD_TRAILING) {
       this->enable_time_us = 1;  // cannot be 0
       this->disable_time_us = std::max((uint32_t) 10, this->value * this->cycle_time_us / 65535);
+
     } else {
       // calculate time until enable in µs: (1.0-value)*cycle_time, but with integer arithmetic
       // also take into account min_power
-      auto min_us = this->cycle_time_us * this->min_power / 1000;
+      auto min_us = this->cycle_time_us * this->min_power / 1000; // this will be a minimum cycle length
       this->enable_time_us = std::max((uint32_t) 1, ((65535 - this->value) * (this->cycle_time_us - min_us)) / 65535);
+
+      // Some dimmers don't work correctly when the
+      if (this->max_dimmer > 0) {
+        auto max_us = (this->cycle_time_us * (1000 - this->max_dimmer)) / 1000; // this will be a minimum cycle length
+        // if we are in LEADING_PULSE_DOUBLE mode, double the calculated number
+        if (this->method == DIM_METHOD_LEADING_PULSE_DOUBLE) {
+          max_us *= 2;
+        }
+        // calculate the max we can dim -- for example, some dimmers and LED bulbs get weird when the dimmer is
+        // at less than 100% but more than 90%
+        this->enable_time_us = std::max(max_us, this->enable_time_us);
+      }
+
 
       if (this->method == DIM_METHOD_LEADING_PULSE) {
         // Minimum pulse time should be enough for the triac to trigger when it is close to the ZC zone
         // this is for brightness near 99%
         this->disable_time_us = std::max(this->enable_time_us + GATE_ENABLE_TIME, (uint32_t) cycle_time_us / 10);
+
+      } else if (this->method == DIM_METHOD_LEADING_PULSE_DOUBLE) {
+        // Cut the enable time in half, since each half is done per half cycle
+        this->enable_time_us *= 0.5;
+
+        // For a double pulse (once for each zero crossing, simply set the Disable Time to the min gate time
+        // It will be reset in the timer function above.
+        this->disable_time_us = this->enable_time_us + GATE_ENABLE_TIME;
+
+        // Also mark that we haven't yet seen the first pulse.
+        this->first_cycle_done = false;
+
       } else {
         this->gate_pin.digital_write(false);
         this->disable_time_us = this->cycle_time_us;
@@ -177,6 +233,7 @@ void AcDimmer::setup() {
   this->store_.zero_cross_pin_number = this->zero_cross_pin_->get_pin();
   this->store_.min_power = static_cast<uint16_t>(this->min_power_ * 1000);
   this->min_power_ = 0;
+  this->store_.max_dimmer = static_cast<uint16_t>(this->max_dim_ * 1000);
   this->store_.method = this->method_;
 
   if (setup_zero_cross_pin) {
@@ -214,9 +271,12 @@ void AcDimmer::dump_config() {
   LOG_PIN("  Output Pin: ", this->gate_pin_);
   LOG_PIN("  Zero-Cross Pin: ", this->zero_cross_pin_);
   ESP_LOGCONFIG(TAG, "   Min Power: %.1f%%", this->store_.min_power / 10.0f);
+  ESP_LOGCONFIG(TAG, "   Max Dim: %.1f%%", this->max_dim_ / 10.0f);
   ESP_LOGCONFIG(TAG, "   Init with half cycle: %s", YESNO(this->init_with_half_cycle_));
   if (method_ == DIM_METHOD_LEADING_PULSE) {
     ESP_LOGCONFIG(TAG, "   Method: leading pulse");
+  } else if (method_ == DIM_METHOD_LEADING_PULSE_DOUBLE) {
+    ESP_LOGCONFIG(TAG, "   Method: leading pulse double");
   } else if (method_ == DIM_METHOD_LEADING) {
     ESP_LOGCONFIG(TAG, "   Method: leading");
   } else {

--- a/esphome/components/ac_dimmer/ac_dimmer.cpp
+++ b/esphome/components/ac_dimmer/ac_dimmer.cpp
@@ -46,7 +46,6 @@ uint32_t IRAM_ATTR HOT AcDimmerDataStore::timer_intr(uint32_t now) {
   }
 
   if (this->enable_time_us != 0 && time_since_zc >= this->enable_time_us) {
-
     // If we're doing a double time pulse, see if we've done the second one yet
     if (this->method == DIM_METHOD_LEADING_PULSE_DOUBLE) {
       if (!this->first_cycle_done) {
@@ -151,12 +150,13 @@ void IRAM_ATTR HOT AcDimmerDataStore::gpio_intr() {
     } else {
       // calculate time until enable in µs: (1.0-value)*cycle_time, but with integer arithmetic
       // also take into account min_power
-      auto min_us = this->cycle_time_us * this->min_power / 1000; // this will be a minimum cycle length
+      auto min_us = this->cycle_time_us * this->min_power / 1000;  // this will be a minimum cycle length
       this->enable_time_us = std::max((uint32_t) 1, ((65535 - this->value) * (this->cycle_time_us - min_us)) / 65535);
 
-      // Some dimmers don't work correctly when the
+      // Some dimmers don't work correctly when the dimming value is between, say, 90 and 100 -- for example,
+      // the Etekcity dimmer flickers oddly at these levels when used with LED bulbs.
       if (this->max_dimmer > 0) {
-        auto max_us = (this->cycle_time_us * (1000 - this->max_dimmer)) / 1000; // this will be a minimum cycle length
+        auto max_us = (this->cycle_time_us * (1000 - this->max_dimmer)) / 1000;  // this will be a minimum cycle length
         // if we are in LEADING_PULSE_DOUBLE mode, double the calculated number
         if (this->method == DIM_METHOD_LEADING_PULSE_DOUBLE) {
           max_us *= 2;
@@ -165,7 +165,6 @@ void IRAM_ATTR HOT AcDimmerDataStore::gpio_intr() {
         // at less than 100% but more than 90%
         this->enable_time_us = std::max(max_us, this->enable_time_us);
       }
-
 
       if (this->method == DIM_METHOD_LEADING_PULSE) {
         // Minimum pulse time should be enough for the triac to trigger when it is close to the ZC zone

--- a/esphome/components/ac_dimmer/ac_dimmer.h
+++ b/esphome/components/ac_dimmer/ac_dimmer.h
@@ -9,7 +9,7 @@
 namespace esphome {
 namespace ac_dimmer {
 
-enum DimMethod { DIM_METHOD_LEADING_PULSE = 0, DIM_METHOD_LEADING, DIM_METHOD_TRAILING };
+enum DimMethod { DIM_METHOD_LEADING_PULSE = 0, DIM_METHOD_LEADING_PULSE_DOUBLE, DIM_METHOD_LEADING, DIM_METHOD_TRAILING };
 
 struct AcDimmerDataStore {
   /// Zero-cross pin
@@ -22,7 +22,9 @@ struct AcDimmerDataStore {
   uint16_t value;
   /// Minimum power for activation
   uint16_t min_power;
-  /// Time between the last two ZC pulses
+  /// Once dimming below 100%, don't dim more than this (some dimmers don't work right between 90 and 99%)
+  uint16_t max_dimmer;
+   /// Maximum power allowed while dimming
   uint32_t cycle_time_us;
   /// Time (in micros()) of last ZC signal
   uint32_t crossed_zero_at;
@@ -34,6 +36,9 @@ struct AcDimmerDataStore {
   bool init_cycle;
   /// Dimmer method
   DimMethod method;
+  // Second half of cycle, for dimmers that only give a single zero crossing pulse
+  // Set to false on the crossing, and then true after it has passed
+  bool first_cycle_done;
 
   uint32_t timer_intr(uint32_t now);
 
@@ -52,6 +57,7 @@ class AcDimmer : public output::FloatOutput, public Component {
   void set_gate_pin(InternalGPIOPin *gate_pin) { gate_pin_ = gate_pin; }
   void set_zero_cross_pin(InternalGPIOPin *zero_cross_pin) { zero_cross_pin_ = zero_cross_pin; }
   void set_init_with_half_cycle(bool init_with_half_cycle) { init_with_half_cycle_ = init_with_half_cycle; }
+  void set_max_dim(float max_dim) { max_dim_ = max_dim; }
   void set_method(DimMethod method) { method_ = method; }
 
  protected:
@@ -61,6 +67,7 @@ class AcDimmer : public output::FloatOutput, public Component {
   InternalGPIOPin *zero_cross_pin_;
   AcDimmerDataStore store_;
   bool init_with_half_cycle_;
+  float max_dim_;
   DimMethod method_;
 };
 

--- a/esphome/components/ac_dimmer/ac_dimmer.h
+++ b/esphome/components/ac_dimmer/ac_dimmer.h
@@ -9,7 +9,12 @@
 namespace esphome {
 namespace ac_dimmer {
 
-enum DimMethod { DIM_METHOD_LEADING_PULSE = 0, DIM_METHOD_LEADING_PULSE_DOUBLE, DIM_METHOD_LEADING, DIM_METHOD_TRAILING };
+enum DimMethod {
+  DIM_METHOD_LEADING_PULSE = 0,
+  DIM_METHOD_LEADING_PULSE_DOUBLE,
+  DIM_METHOD_LEADING,
+  DIM_METHOD_TRAILING
+};
 
 struct AcDimmerDataStore {
   /// Zero-cross pin
@@ -24,7 +29,7 @@ struct AcDimmerDataStore {
   uint16_t min_power;
   /// Once dimming below 100%, don't dim more than this (some dimmers don't work right between 90 and 99%)
   uint16_t max_dimmer;
-   /// Maximum power allowed while dimming
+  /// Time between the last two ZC pulses
   uint32_t cycle_time_us;
   /// Time (in micros()) of last ZC signal
   uint32_t crossed_zero_at;

--- a/esphome/components/ac_dimmer/output.py
+++ b/esphome/components/ac_dimmer/output.py
@@ -12,6 +12,7 @@ AcDimmer = ac_dimmer_ns.class_("AcDimmer", output.FloatOutput, cg.Component)
 DimMethod = ac_dimmer_ns.enum("DimMethod")
 DIM_METHODS = {
     "LEADING_PULSE": DimMethod.DIM_METHOD_LEADING_PULSE,
+    "LEADING_PULSE_DOUBLE": DimMethod.DIM_METHOD_LEADING_PULSE_DOUBLE,
     "LEADING": DimMethod.DIM_METHOD_LEADING,
     "TRAILING": DimMethod.DIM_METHOD_TRAILING,
 }
@@ -19,6 +20,7 @@ DIM_METHODS = {
 CONF_GATE_PIN = "gate_pin"
 CONF_ZERO_CROSS_PIN = "zero_cross_pin"
 CONF_INIT_WITH_HALF_CYCLE = "init_with_half_cycle"
+CONF_MAX_DIM = "max_dimmer" # don't allow dimming more than this amount
 CONFIG_SCHEMA = cv.All(
     output.FLOAT_OUTPUT_SCHEMA.extend(
         {
@@ -26,6 +28,7 @@ CONFIG_SCHEMA = cv.All(
             cv.Required(CONF_GATE_PIN): pins.internal_gpio_output_pin_schema,
             cv.Required(CONF_ZERO_CROSS_PIN): pins.internal_gpio_input_pin_schema,
             cv.Optional(CONF_INIT_WITH_HALF_CYCLE, default=True): cv.boolean,
+            cv.Optional(CONF_MAX_DIM, default=0): cv.float_range(min=0, max=1),
             cv.Optional(CONF_METHOD, default="leading pulse"): cv.enum(
                 DIM_METHODS, upper=True, space="_"
             ),
@@ -49,4 +52,5 @@ async def to_code(config):
     pin = await cg.gpio_pin_expression(config[CONF_ZERO_CROSS_PIN])
     cg.add(var.set_zero_cross_pin(pin))
     cg.add(var.set_init_with_half_cycle(config[CONF_INIT_WITH_HALF_CYCLE]))
+    cg.add(var.set_max_dim(config[CONF_MAX_DIM]))
     cg.add(var.set_method(config[CONF_METHOD]))

--- a/esphome/components/ac_dimmer/output.py
+++ b/esphome/components/ac_dimmer/output.py
@@ -20,7 +20,7 @@ DIM_METHODS = {
 CONF_GATE_PIN = "gate_pin"
 CONF_ZERO_CROSS_PIN = "zero_cross_pin"
 CONF_INIT_WITH_HALF_CYCLE = "init_with_half_cycle"
-CONF_MAX_DIM = "max_dimmer" # don't allow dimming more than this amount
+CONF_MAX_DIM = "max_dimmer"  # don't allow dimming more than this amount
 CONFIG_SCHEMA = cv.All(
     output.FLOAT_OUTPUT_SCHEMA.extend(
         {


### PR DESCRIPTION
# What is changing in this PR?
- Adding a new dimming method, `LEADING_PULSE_DOUBLE`
- Adding a new property, `max_dimmer`

# What is the reason for this change?
Certain dimmers, such as the Etekcity ESWD16-R4P, implement a zero crossing detector that only triggers on the rising crossing, and not the falling crossing.  This makes the `LEADING_PULSE` and `LEADING` dimmer algorithms not work, since they expect to get a pulse every half wavelength.

This PR implements a new method, `LEADING_PULSE_DOUBLE`, which uses the known cycle time, divided in two, to perform the correct dimming at the zero crossings on both the rising and falling zero crossings.

Video example:
https://github.com/user-attachments/assets/d9c81f84-5cce-4e69-a6d7-42b00282c5c4

Next, as some dimmers such as the Etekcity ESWD16 do not perform well between dimmer values of 99% and 90%, especially with LED bulbs, the new setting `max_dimmer` has been added, allowing you to specify a max dim value.  When you attempt to dim at values above this value, the dim is clamped to the max, until the light reaches 100% and the triac can be enabled with 100% duty cycle.

![20250124_223020_preview](https://github.com/user-attachments/assets/0a12c838-5186-4642-930d-dda82bf06af6)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#4616

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
output:
  - platform: ac_dimmer
    id: main_dimmer
    gate_pin: 15
    init_with_half_cycle: true # Makes the startup work better for LED bulbs, apparently.
    method: LEADING_PULSE_DOUBLE
    min_power: 10%
    max_dimmer: 0.9 # don't allow dimming more than this (but less than 100%)
    zero_cross_pin:
      number: 13
      mode:
        input: true
        pullup: true
      inverted: yes # seems the output actually is inverted here.

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
