### PR TITLE
Include Bluetooth connection slot allocations in connections free message

### DIFF
--- a/esphome/components/api/api.proto
+++ b/esphome/components/api/api.proto
@@ -1381,6 +1381,7 @@ message BluetoothConnectionsFreeResponse {
 
   uint32 free = 1;
   uint32 limit = 2;
+  repeated uint64 allocated = 3;
 }
 
 message BluetoothGATTErrorResponse {

--- a/esphome/components/api/api_pb2.cpp
+++ b/esphome/components/api/api_pb2.cpp
@@ -6430,6 +6430,10 @@ bool BluetoothConnectionsFreeResponse::decode_varint(uint32_t field_id, ProtoVar
       this->limit = value.as_uint32();
       return true;
     }
+    case 3: {
+      this->allocated.push_back(value.as_uint64());
+      return true;
+    }
     default:
       return false;
   }
@@ -6437,6 +6441,9 @@ bool BluetoothConnectionsFreeResponse::decode_varint(uint32_t field_id, ProtoVar
 void BluetoothConnectionsFreeResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint32(1, this->free);
   buffer.encode_uint32(2, this->limit);
+  for (auto &it : this->allocated) {
+    buffer.encode_uint64(3, it, true);
+  }
 }
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void BluetoothConnectionsFreeResponse::dump_to(std::string &out) const {
@@ -6451,6 +6458,13 @@ void BluetoothConnectionsFreeResponse::dump_to(std::string &out) const {
   sprintf(buffer, "%" PRIu32, this->limit);
   out.append(buffer);
   out.append("\n");
+
+  for (const auto &it : this->allocated) {
+    out.append("  allocated: ");
+    sprintf(buffer, "%llu", it);
+    out.append(buffer);
+    out.append("\n");
+  }
   out.append("}");
 }
 #endif

--- a/esphome/components/api/api_pb2.h
+++ b/esphome/components/api/api_pb2.h
@@ -1624,6 +1624,7 @@ class BluetoothConnectionsFreeResponse : public ProtoMessage {
  public:
   uint32_t free{0};
   uint32_t limit{0};
+  std::vector<uint64_t> allocated{};
   void encode(ProtoWriteBuffer buffer) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
@@ -475,6 +475,11 @@ void BluetoothProxy::send_connections_free() {
   api::BluetoothConnectionsFreeResponse call;
   call.free = this->get_bluetooth_connections_free();
   call.limit = this->get_bluetooth_connections_limit();
+  for (auto *connection : this->connections_) {
+    if (connection->address_ != 0) {
+      call.allocations.push_back(connection->address_);
+    }
+  }
   this->api_connection_->send_bluetooth_connections_free_response(call);
 }
 

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
@@ -477,7 +477,7 @@ void BluetoothProxy::send_connections_free() {
   call.limit = this->get_bluetooth_connections_limit();
   for (auto *connection : this->connections_) {
     if (connection->address_ != 0) {
-      call.allocations.push_back(connection->address_);
+      call.allocated.push_back(connection->address_);
     }
   }
   this->api_connection_->send_bluetooth_connections_free_response(call);


### PR DESCRIPTION
~~TODO:~~ done

- [x] build test device
- [x] flash test device
- [x] test in HA

ESPHome https://github.com/esphome/esphome/pull/8148
bleak-esphome https://github.com/Bluetooth-Devices/bleak-esphome/pull/74
aioesphomeapi https://github.com/esphome/aioesphomeapi/pull/1038

# What does this implement/fix?

For local adapters we already track the remote addresses that the adapter is connecting/connected to. We want to be able to show the same data for ESPHome.

The Bluetooth stack has support keeping track of these but since we don't send them, `bleak-esphome` currently sends an empty list https://github.com/Bluetooth-Devices/bleak-esphome/pull/74

Can be tested with
```
external_components:
  - source: github://pr#8148
    components: [ api, bluetooth_proxy ]
    refresh: 0s
    
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
