### PR TITLE
[log.h]: Add more macros for boolean expressions

### DIFF
--- a/esphome/core/log.h
+++ b/esphome/core/log.h
@@ -158,9 +158,24 @@ int esp_idf_log_vprintf_(const char *format, va_list args);  // NOLINT
 #define BYTE_TO_BINARY(byte) \
   ((byte) &0x80 ? '1' : '0'), ((byte) &0x40 ? '1' : '0'), ((byte) &0x20 ? '1' : '0'), ((byte) &0x10 ? '1' : '0'), \
       ((byte) &0x08 ? '1' : '0'), ((byte) &0x04 ? '1' : '0'), ((byte) &0x02 ? '1' : '0'), ((byte) &0x01 ? '1' : '0')
-#define YESNO(b) ((b) ? "YES" : "NO")
 #define ONOFF(b) ((b) ? "ON" : "OFF")
+#define YESNO(b) ((b) ? "YES" : "NO")
+#define UPDOWN(b) ((b) ? "UP" : "DOWN")
+#define PASSFAIL(b) ((b) ? "PASS" : "FAIL")
+#define HIGHLOW(b) ((b) ? "HIGH" : "LOW")
+#define OPENSHUT(b) ((b) ? "OPEN" : "SHUT")
 #define TRUEFALSE(b) ((b) ? "TRUE" : "FALSE")
+#define STARTSTOP(b) ((b) ? "START" : "STOP")
+#define VALIDINVALID(b) ((b) ? "VALID" : "INVALID")
+#define ACTIVEINACTIVE(b) ((b) ? "ACTIVE" : "INACTIVE")
+#define ENABLEDISABLE(b) ((b) ? "ENABLE" : "DISABLE")
+#define PRESENTABSENT(b) ((b) ? "PRESENT" : "ABSENT")
+#define SUCCESSFAILURE(b) ((b) ? "SUCCESS" : "FAILURE")
+#define READYNOTREADY(b) ((b) ? "READY" : "NOT READY")
+#define VISIBLEHIDDEN(b) ((b) ? "VISIBLE" : "HIDDEN")
+#define GRANTEDDENIED(b) ((b) ? "GRANTED" : "DENIED")
+#define ENABLEDDISABLED(b) ((b) ? "ENABLED" : "DISABLED")
+#define CONNECTEDDISCONNECTED(b) ((b) ? "CONNECTED" : "DISCONNECTED")
 
 // Helper class that identifies strings that may be stored in flash storage (similar to Arduino's __FlashStringHelper)
 struct LogString;


### PR DESCRIPTION
# What does this implement/fix?

These changes aim to improve code readability and maintainability by providing intuitive, descriptive macros for common boolean expressions.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
