### PR TITLE
[display] Properly handle case of auto_clear_enabled: false

### DIFF
--- a/esphome/components/display/__init__.py
+++ b/esphome/components/display/__init__.py
@@ -101,7 +101,7 @@ async def setup_display_core_(var, config):
     if CONF_ROTATION in config:
         cg.add(var.set_rotation(DISPLAY_ROTATIONS[config[CONF_ROTATION]]))
 
-    if auto_clear := config.get(CONF_AUTO_CLEAR_ENABLED):
+    if (auto_clear := config.get(CONF_AUTO_CLEAR_ENABLED)) is not None:
         # Default to true if pages or lambda is specified. Ideally this would be done during validation, but
         # the possible schemas are too complex to do this easily.
         if auto_clear == CONF_UNSPECIFIED:


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Previous PR changing default handling of `auto_clear_enabled` breaks when it's explicitly set to `false`.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
