### PR TITLE
[remote_base] Add default value for offset in is_valid

### DIFF
--- a/esphome/components/remote_base/remote_base.h
+++ b/esphome/components/remote_base/remote_base.h
@@ -54,7 +54,7 @@ class RemoteReceiveData {
   uint32_t get_index() const { return index_; }
   int32_t operator[](uint32_t index) const { return this->data_[index]; }
   int32_t size() const { return this->data_.size(); }
-  bool is_valid(uint32_t offset) const { return this->index_ + offset < this->data_.size(); }
+  bool is_valid(uint32_t offset = 0) const { return this->index_ + offset < this->data_.size(); }
   int32_t peek(uint32_t offset = 0) const { return this->data_[this->index_ + offset]; }
   bool peek_mark(uint32_t length, uint32_t offset = 0) const;
   bool peek_space(uint32_t length, uint32_t offset = 0) const;


### PR DESCRIPTION
# What does this implement/fix?

Add default value for offset in is_valid 

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
