### PR TITLE
fix: Add support for PAS CO2 sensor.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -306,6 +306,7 @@ esphome/components/online_image/* @guillempages
 esphome/components/opentherm/* @olegtarasov
 esphome/components/ota/* @esphome/core
 esphome/components/output/* @esphome/core
+esphome/components/pasco2/* @circuitvalley @ozonejunkieau
 esphome/components/pca6416a/* @Mat931
 esphome/components/pca9554/* @clydebarrow @hwstar
 esphome/components/pcf85063/* @brogon

--- a/esphome/components/pasco2/__init__.py
+++ b/esphome/components/pasco2/__init__.py
@@ -1,0 +1,1 @@
+CODEOWNERS = ["@circuitvalley", "@ozonejunkieau"]

--- a/esphome/components/pasco2/automation.h
+++ b/esphome/components/pasco2/automation.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/core/automation.h"
+#include "pasco2.h"
+
+namespace esphome {
+namespace pasco2 {
+
+template<typename... Ts> class PerformForcedCalibrationAction : public Action<Ts...>, public Parented<PASCO2Component> {
+ public:
+  void play(Ts... x) override {
+    if (this->value_.has_value()) {
+      this->parent_->perform_forced_calibration(this->value_.value(x...));
+    }
+  }
+
+  TEMPLATABLE_VALUE(uint16_t, value)
+};
+
+}  // namespace pasco2
+}  // namespace esphome

--- a/esphome/components/pasco2/pasco2.cpp
+++ b/esphome/components/pasco2/pasco2.cpp
@@ -1,0 +1,432 @@
+#include "pasco2.h"
+#include "esphome/core/hal.h"
+#include "esphome/core/log.h"
+
+namespace esphome {
+namespace pasco2 {
+
+static const char *const TAG = "pasco2";
+
+static const uint8_t XENSIV_PASCO2_REG_PROD_ID = 0x00U;      // REG_PROD
+static const uint8_t XENSIV_PASCO2_REG_SENS_STS = 0x01U;     // SENS_STS
+static const uint8_t XENSIV_PASCO2_REG_MEAS_RATE_H = 0x02U;  // MEAS_RATE_H
+static const uint8_t XENSIV_PASCO2_REG_MEAS_RATE_L = 0x03U;  // MEAS_RATE_L
+static const uint8_t XENSIV_PASCO2_REG_MEAS_CFG = 0x04U;     // MEAS_CFG
+static const uint8_t XENSIV_PASCO2_REG_CO2PPM_H = 0x05U;     // CO2PPM_H
+static const uint8_t XENSIV_PASCO2_REG_CO2PPM_L = 0x06U;     // CO2PPM_L
+static const uint8_t XENSIV_PASCO2_REG_MEAS_STS = 0x07U;     // MEAS_STS
+static const uint8_t XENSIV_PASCO2_REG_INT_CFG = 0x08U;      // INT_CFG:
+static const uint8_t XENSIV_PASCO2_REG_ALARM_TH_H = 0x09U;   // ALARM_TH_H
+static const uint8_t XENSIV_PASCO2_REG_ALARM_TH_L = 0x0AU;   // ALARM_TH_L
+static const uint8_t XENSIV_PASCO2_REG_PRESS_REF_H = 0x0BU;  // PRESS_REF_H
+static const uint8_t XENSIV_PASCO2_REG_PRESS_REF_L = 0x0CU;  // PRESS_REF_L
+static const uint8_t XENSIV_PASCO2_REG_CALIB_REF_H = 0x0DU;  // CALIB_REF_H
+static const uint8_t XENSIV_PASCO2_REG_CALIB_REF_L = 0x0EU;  // CALIB_REF_L
+static const uint8_t XENSIV_PASCO2_REG_SCRATCH_PAD = 0x0FU;  // SCRATCH_PAD
+static const uint8_t XENSIV_PASCO2_REG_SENS_RST = 0x10U;     // SENS_RST
+
+static const uint8_t XENSIV_PASCO2_COMM_DELAY_MS = 5U;
+static const uint8_t XENSIV_PASCO2_COMM_TEST_VAL = 0xA5U;
+static const uint16_t XENSIV_PASCO2_SOFT_RESET_DELAY_MS = 2000U;
+static const uint8_t XENSIV_PASCO2_FCS_MEAS_RATE_S = 10;
+
+static const uint8_t XENSIV_PASCO2_REG_SENS_STS_ICCER_CLR_POS = 0U;  // SENS_STS: ICCER_CLR position
+static const uint8_t XENSIV_PASCO2_REG_SENS_STS_ICCER_CLR_MSK =
+    0x01U << XENSIV_PASCO2_REG_SENS_STS_ICCER_CLR_POS;              // SENS_STS: ICCER_CLR mask
+static const uint8_t XENSIV_PASCO2_REG_SENS_STS_ORVS_CLR_POS = 1U;  // SENS_STS: ORVS_CLR position
+static const uint8_t XENSIV_PASCO2_REG_SENS_STS_ORVS_CLR_MSK =
+    0x01U << XENSIV_PASCO2_REG_SENS_STS_ORVS_CLR_POS;                // SENS_STS: ORVS_CLR mask
+static const uint8_t XENSIV_PASCO2_REG_SENS_STS_ORTMP_CLR_POS = 2U;  // SENS_STS: ORTMP_CLR position
+static const uint8_t XENSIV_PASCO2_REG_SENS_STS_ORTMP_CLR_MSK =
+    0x01U << XENSIV_PASCO2_REG_SENS_STS_ORTMP_CLR_POS;           // SENS_STS: ORTMP_CLR mask
+static const uint8_t XENSIV_PASCO2_REG_SENS_STS_ICCER_POS = 3U;  // SENS_STS: ICCER position
+static const uint8_t XENSIV_PASCO2_REG_SENS_STS_ICCER_MSK =
+    0x01U << XENSIV_PASCO2_REG_SENS_STS_ICCER_POS;              // SENS_STS: ICCER mask
+static const uint8_t XENSIV_PASCO2_REG_SENS_STS_ORVS_POS = 4U;  // SENS_STS: ORVS position
+static const uint8_t XENSIV_PASCO2_REG_SENS_STS_ORVS_MSK =
+    0x01U << XENSIV_PASCO2_REG_SENS_STS_ORVS_POS;                // SENS_STS: ORVS mask
+static const uint8_t XENSIV_PASCO2_REG_SENS_STS_ORTMP_POS = 5U;  // SENS_STS: ORTMP position
+static const uint8_t XENSIV_PASCO2_REG_SENS_STS_ORTMP_MSK =
+    0x01U << XENSIV_PASCO2_REG_SENS_STS_ORTMP_POS;                    // SENS_STS: ORTMP mask
+static const uint8_t XENSIV_PASCO2_REG_SENS_STS_PWM_DIS_ST_POS = 6U;  // SENS_STS: PWM_DIS_ST position
+static const uint8_t XENSIV_PASCO2_REG_SENS_STS_PWM_DIS_ST_MSK =
+    0x01U << XENSIV_PASCO2_REG_SENS_STS_PWM_DIS_ST_POS;            // SENS_STS: PWM_DIS_ST mask
+static const uint8_t XENSIV_PASCO2_REG_SENS_STS_SEN_RDY_POS = 7U;  // SENS_STS: SEN_RDY position
+static const uint8_t XENSIV_PASCO2_REG_SENS_STS_SEN_RDY_MSK =
+    0x01U << XENSIV_PASCO2_REG_SENS_STS_SEN_RDY_POS;  // SENS_STS: SEN_RDY mask
+
+static const uint8_t XENSIV_PASCO2_REG_MEAS_CFG_OP_MODE_POS = 0U;  // MEAS_CFG: OP_MODE position
+static const uint8_t XENSIV_PASCO2_REG_MEAS_CFG_OP_MODE_MSK =
+    0x03U << XENSIV_PASCO2_REG_MEAS_CFG_OP_MODE_POS;  // MEAS_CFG: OP_MODE mask
+static const uint8_t XENSIV_PASCO2_REG_MEAS_CFG_OP_MODE_IDLE =
+    0x00 << XENSIV_PASCO2_REG_MEAS_CFG_OP_MODE_POS;  // MEAS_CFG: OP_MODE_IDLE
+static const uint8_t XENSIV_PASCO2_REG_MEAS_CFG_OP_MODE_SINGLESHOT =
+    0x01 << XENSIV_PASCO2_REG_MEAS_CFG_OP_MODE_POS;  // MEAS_CFG: OP_MODE_SINGLE_SHOT
+static const uint8_t XENSIV_PASCO2_REG_MEAS_CFG_OP_MODE_CONTINOUS =
+    0x02 << XENSIV_PASCO2_REG_MEAS_CFG_OP_MODE_POS;  // MEAS_CFG: OP_MODE_CONTINOUS
+
+static const uint8_t XENSIV_PASCO2_REG_MEAS_CFG_BOC_CFG_POS = 2U;  // MEAS_CFG: BOC_CFG position
+static const uint8_t XENSIV_PASCO2_REG_MEAS_CFG_BOC_CFG_MSK =
+    0x03U << XENSIV_PASCO2_REG_MEAS_CFG_BOC_CFG_POS;  // MEAS_CFG: BOC_CFG mask
+static const uint8_t XENSIV_PASCO2_REG_MEAS_CFG_BOC_CFG_DISABLE =
+    0x0 << XENSIV_PASCO2_REG_MEAS_CFG_BOC_CFG_POS;  // MEAS_CFG: BOC_CFG DISABLE
+static const uint8_t XENSIV_PASCO2_REG_MEAS_CFG_BOC_CFG_ENABLE =
+    0x1 << XENSIV_PASCO2_REG_MEAS_CFG_BOC_CFG_POS;  // MEAS_CFG: BOC_CFG Enable
+static const uint8_t XENSIV_PASCO2_REG_MEAS_CFG_BOC_CFG_FORCE =
+    0x2 << XENSIV_PASCO2_REG_MEAS_CFG_BOC_CFG_POS;  // MEAS_CFG: BOC_CFG Force
+
+static const uint8_t XENSIV_PASCO2_REG_MEAS_CFG_PWM_MODE_POS = 4U;  // MEAS_CFG: PWM_MODE position
+static const uint8_t XENSIV_PASCO2_REG_MEAS_CFG_PWM_MODE_MSK =
+    0x01U << XENSIV_PASCO2_REG_MEAS_CFG_PWM_MODE_POS;  // MEAS_CFG: PWM_MODE mask
+static const uint8_t XENSIV_PASCO2_REG_MEAS_CFG_PWM_MODE_SINGLE =
+    0x00U << XENSIV_PASCO2_REG_MEAS_CFG_PWM_MODE_POS;  // MEAS_CFG: PWM_MODE Single pulse
+static const uint8_t XENSIV_PASCO2_REG_MEAS_CFG_PWM_MODE_TRAIN =
+    0x01U << XENSIV_PASCO2_REG_MEAS_CFG_PWM_MODE_POS;  // MEAS_CFG: PWM_MODE pulse Train
+
+static const uint8_t XENSIV_PASCO2_REG_MEAS_CFG_PWM_OUTEN_POS = 5U;  // MEAS_CFG: PWM_OUTEN position
+static const uint8_t XENSIV_PASCO2_REG_MEAS_CFG_PWM_OUTEN_MSK =
+    0x01U << XENSIV_PASCO2_REG_MEAS_CFG_PWM_OUTEN_POS;  // MEAS_CFG: PWM_OUTEN mask
+static const uint8_t XENSIV_PASCO2_REG_MEAS_CFG_PWM_OUTEN_EN =
+    0x01U << XENSIV_PASCO2_REG_MEAS_CFG_PWM_OUTEN_POS;  // MEAS_CFG: PWM_OUTEN enable
+static const uint8_t XENSIV_PASCO2_REG_MEAS_CFG_PWM_OUTEN_DISABLE =
+    0x00U << XENSIV_PASCO2_REG_MEAS_CFG_PWM_OUTEN_POS;  // MEAS_CFG: PWM_OUTEN enable
+
+static const uint8_t XENSIV_PASCO2_REG_MEAS_STS_ALARM_CLR_POS = 0U;  //  MEAS_STS: ALARM_CLR position
+static const uint8_t XENSIV_PASCO2_REG_MEAS_STS_ALARM_CLR_MSK =
+    0x01U << XENSIV_PASCO2_REG_MEAS_STS_ALARM_CLR_POS;                 // MEAS_STS: ALARM_CLR mask
+static const uint8_t XENSIV_PASCO2_REG_MEAS_STS_INT_STS_CLR_POS = 1U;  // MEAS_STS: INT_STS_CLR position
+static const uint8_t XENSIV_PASCO2_REG_MEAS_STS_INT_STS_CLR_MSK =
+    0x01U << XENSIV_PASCO2_REG_MEAS_STS_INT_STS_CLR_POS;         // MEAS_STS: INT_STS_CLR mask
+static const uint8_t XENSIV_PASCO2_REG_MEAS_STS_ALARM_POS = 2U;  // MEAS_STS: ALARM position
+static const uint8_t XENSIV_PASCO2_REG_MEAS_STS_ALARM_MSK =
+    0x01U << XENSIV_PASCO2_REG_MEAS_STS_ALARM_POS;                 // MEAS_STS: ALARM mask
+static const uint8_t XENSIV_PASCO2_REG_MEAS_STS_INT_STS_POS = 3U;  // MEAS_STS: INT_STS position
+static const uint8_t XENSIV_PASCO2_REG_MEAS_STS_INT_STS_MSK =
+    0x01U << XENSIV_PASCO2_REG_MEAS_STS_INT_STS_POS;            // MEAS_STS: INT_STS mask
+static const uint8_t XENSIV_PASCO2_REG_MEAS_STS_DRDY_POS = 4U;  // MEAS_STS: DRDY position
+static const uint8_t XENSIV_PASCO2_REG_MEAS_STS_DRDY_MSK =
+    0x01U << XENSIV_PASCO2_REG_MEAS_STS_DRDY_POS;  // MEAS_STS: DRDY mask
+
+static const uint8_t XENSIV_PASCO2_CMD_SOFT_RESET = 0xA3U;  //  Soft reset the sensor
+static const uint8_t XENSIV_PASCO2_CMD_RESET_ABOC = 0xBCU;  // Resets the ABOC context
+static const uint8_t XENSIV_PASCO2_CMD_SAVE_FCS_CALIB_OFFSET =
+    0xCFU;  // Saves the force calibration offset into the non volatile memory
+static const uint8_t XENSIV_PASCO2_CMD_RESET_FCS = 0xFCU;  // Resets the forced calibration correction factor
+
+void PASCO2Component::setup() {
+  ESP_LOGCONFIG(TAG, "Setting up pasco2...");
+  // the sensor needs 1000 ms to enter the idle state
+
+  if (this->enable_pin_ != nullptr) {
+    // Set enable pin as OUTPUT and disable the enable pin to force vl53 to HW Standby mode
+    this->enable_pin_->setup();
+    this->enable_pin_->digital_write(true);
+    delayMicroseconds(100);
+  }
+
+  this->initialize_sensor();
+
+}
+
+void PASCO2Component::initialize_sensor() {
+  this->status_clear_error();
+  this->remaining_retries_ = 2;  // Reset retries
+  this->initialization_state_ = InitializationState::WRITE_SCRATCH_PAD;  // Start state machine
+  this->last_action_time_ = millis();  // Initialize timing
+}
+
+void PASCO2Component::loop() {
+  switch (this->initialization_state_) {
+    case InitializationState::IDLE:
+      // No action needed, initialization not yet started.
+      break;
+
+    case InitializationState::WRITE_SCRATCH_PAD:
+      if (millis() - this->last_action_time_ >= 100) {
+        if (!this->write_byte(XENSIV_PASCO2_REG_SCRATCH_PAD, XENSIV_PASCO2_COMM_TEST_VAL, true)) {
+          if (--this->remaining_retries_ == 0) {
+            ESP_LOGE(TAG, "Failed to Write Scratch Pad");
+            this->error_code_ = COMM_FAILED;
+            this->mark_failed();
+            this->initialization_state_ = InitializationState::COMPLETE;  // End state
+          }
+        } else {
+          this->remaining_retries_ = 2;  // Reset retries on success
+          this->initialization_state_ = InitializationState::READ_SCRATCH_PAD;  // Move to next state
+        }
+        this->last_action_time_ = millis();  // Update timing
+      }
+      break;
+
+    case InitializationState::READ_SCRATCH_PAD:
+      if (millis() - this->last_action_time_ >= 100) {
+        uint8_t read_back[2];
+        if (!this->read_bytes(XENSIV_PASCO2_REG_SCRATCH_PAD, &read_back[0], 1)) {
+          ESP_LOGE(TAG, "Failed to read Scratch Pad");
+          this->error_code_ = COMM_FAILED;
+          this->mark_failed();
+          this->initialization_state_ = InitializationState::COMPLETE;  // End state
+        } else if (read_back[0] != XENSIV_PASCO2_COMM_TEST_VAL) {
+          ESP_LOGE(TAG, "Scratch Pad Does not Match");
+          this->error_code_ = COMM_FAILED;
+          this->mark_failed();
+          this->initialization_state_ = InitializationState::COMPLETE;  // End state
+        } else {
+          this->initialization_state_ = InitializationState::SOFT_RESET;  // Move to soft reset state
+        }
+        this->last_action_time_ = millis();  // Update timing
+      }
+      break;
+
+    case InitializationState::SOFT_RESET:
+      if (millis() - this->last_action_time_ >= 100) {
+        if (!this->write_byte(XENSIV_PASCO2_REG_SENS_RST, XENSIV_PASCO2_CMD_SOFT_RESET, true)) {
+          ESP_LOGE(TAG, "Error Sending Soft Reset.");
+          this->error_code_ = SOFT_RESET_FAILED;
+          this->mark_failed();
+          this->initialization_state_ = InitializationState::COMPLETE;  // End state
+        } else {
+          this->last_action_time_ = millis();  // Update timing
+          this->initialization_state_ = InitializationState::READ_STATUS;  // Move to read status state
+        }
+      }
+      break;
+
+    case InitializationState::READ_STATUS:
+      if (millis() - this->last_action_time_ >= 2500) {
+        uint8_t read_back[2];
+        if (!this->read_bytes(XENSIV_PASCO2_REG_SENS_STS, &read_back[0], 1)) {
+          ESP_LOGE(TAG, "Error Reading Status Reg.");
+          this->error_code_ = SOFT_RESET_FAILED;
+          this->mark_failed();
+          this->initialization_state_ = InitializationState::COMPLETE;  // End state
+        } else {
+          // Check status and handle errors
+          handle_status_errors(read_back[0]);
+          if (this->initialization_state_ != InitializationState::COMPLETE) {
+            this->initialized_ = true;  // Mark as initialized
+            this->start_measurement_();  // Start measurements
+            ESP_LOGD(TAG, "Sensor initialized");
+            this->initialization_state_ = InitializationState::COMPLETE;  // End state
+          }
+        }
+        this->last_action_time_ = millis();  // Update timing
+      }
+      break;
+
+    case InitializationState::COMPLETE:
+      // No action needed, initialization complete
+      break;
+  }
+}
+
+void PASCO2Component::handle_status_errors(uint8_t status) {
+  if ((status & XENSIV_PASCO2_REG_SENS_STS_ICCER_MSK) != 0U) {
+    ESP_LOGE(TAG, "Error XENSIV_PASCO2_REG_SENS_STS_ICCER_MSK");
+    this->error_code_ = XENSIV_PASCO2_ICCERR;
+    this->mark_failed();
+  } else if ((status & XENSIV_PASCO2_REG_SENS_STS_ORVS_MSK) != 0U) {
+    ESP_LOGE(TAG, "Error XENSIV_PASCO2_REG_SENS_STS_ORVS_MSK");
+    this->error_code_ = XENSIV_PASCO2_ORVS;
+    this->mark_failed();
+  } else if ((status & XENSIV_PASCO2_REG_SENS_STS_ORTMP_MSK) != 0U) {
+    ESP_LOGE(TAG, "Error XENSIV_PASCO2_REG_SENS_STS_ORTMP_MSK");
+    this->error_code_ = XENSIV_PASCO2_ORTMP;
+    this->mark_failed();
+  } else if ((status & XENSIV_PASCO2_REG_SENS_STS_SEN_RDY_MSK) == 0U) {
+    ESP_LOGE(TAG, "Error XENSIV_PASCO2_REG_SENS_STS_SEN_RDY_MSK");
+    this->error_code_ = XENSIV_PASCO2_ERR_NOT_READY;
+    this->mark_failed();
+  }
+}
+
+void PASCO2Component::dump_config() {
+  ESP_LOGCONFIG(TAG, "pasco2:");
+  LOG_I2C_DEVICE(this);
+  if (this->is_failed()) {
+    switch (this->error_code_) {
+      case COMM_FAILED:
+        ESP_LOGW(TAG, "Communication failed! Is the sensor connected?");
+        break;
+      case SOFT_RESET_FAILED:
+        ESP_LOGW(TAG, "Sensor Reset failed!");
+        break;
+      case XENSIV_PASCO2_ICCERR:
+        ESP_LOGW(TAG, "Sensor ICCERR!");
+        break;
+      case XENSIV_PASCO2_ORVS:
+        ESP_LOGW(TAG, "Sensor ORVS Error!");
+        break;
+      case XENSIV_PASCO2_ORTMP:
+        ESP_LOGW(TAG, "Sensor ORTMP Error!");
+        break;
+      case XENSIV_PASCO2_ERR_NOT_READY:
+        ESP_LOGW(TAG, "Sensor Not Ready Error!");
+        break;
+      default:
+        ESP_LOGW(TAG, "Unknown setup error!");
+        break;
+    }
+  }
+  ESP_LOGCONFIG(TAG, "  Automatic self calibration: %s", ONOFF(this->enable_asc_));
+  if (this->ambient_pressure_source_ != nullptr) {
+    ESP_LOGCONFIG(TAG, "  Dynamic ambient pressure compensation using sensor '%s'",
+                  this->ambient_pressure_source_->get_name().c_str());
+  } else {
+    if (this->ambient_pressure_compensation_) {
+      ESP_LOGCONFIG(TAG, "  Ambient pressure compensation: %dmBar", this->ambient_pressure_);
+    } else {
+      ESP_LOGCONFIG(TAG, "  Ambient pressure compensation disabled");
+    }
+  }
+  switch (this->measurement_mode_) {
+    case PERIODIC:
+      ESP_LOGCONFIG(TAG, "  Measurement mode: periodic (5s)");
+      break;
+    case SINGLE_SHOT:
+      ESP_LOGCONFIG(TAG, "  Measurement mode: single shot");
+      break;
+  }
+  LOG_UPDATE_INTERVAL(this);
+  LOG_SENSOR("  ", "CO2", this->co2_sensor_);
+}
+
+void PASCO2Component::update() {
+  if (!initialized_) {
+    return;
+  }
+
+  if (this->ambient_pressure_source_ != nullptr) {
+    float pressure = this->ambient_pressure_source_->state;
+    if (!std::isnan(pressure)) {
+      set_ambient_pressure_compensation(pressure);
+    }
+  }
+
+  uint32_t wait_time = 0;
+  if (this->measurement_mode_ == SINGLE_SHOT) {
+    start_measurement_();
+    wait_time = 5000;  // Single shot measurement takes 5 secs
+  }
+  this->set_timeout(wait_time, [this]() {
+    // Check if data is ready
+    uint8_t read_back[3];
+    if (!this->read_bytes(XENSIV_PASCO2_REG_MEAS_STS, &read_back[0], 1)) {
+      this->status_set_warning();
+      return;
+    }
+
+    uint16_t co2result;
+    if (read_back[0] & XENSIV_PASCO2_REG_MEAS_STS_DRDY_MSK) {
+      if (!this->read_byte_16(XENSIV_PASCO2_REG_CO2PPM_H, &co2result)) {
+        ESP_LOGW(TAG, "Result Reading Failed!");
+        this->status_set_warning();
+        return;
+      }
+    } else {
+      ESP_LOGW(TAG, "Data not ready yet!");
+      this->status_set_warning();
+      return;
+    }
+
+    if (this->co2_sensor_ != nullptr)
+      this->co2_sensor_->publish_state(co2result);
+
+    ESP_LOGD(TAG, "Read Co2 level %d ppm", co2result);
+
+    this->status_clear_warning();
+  });  // set_timeout
+}
+
+bool PASCO2Component::perform_forced_calibration(uint16_t current_co2_concentration) {
+  if (!this->write_byte(XENSIV_PASCO2_REG_MEAS_CFG,
+                        XENSIV_PASCO2_REG_MEAS_CFG_OP_MODE_IDLE | XENSIV_PASCO2_REG_MEAS_CFG_BOC_CFG_FORCE |
+                            XENSIV_PASCO2_REG_MEAS_CFG_PWM_OUTEN_EN,
+                        true)) {
+    ESP_LOGE(TAG, "Failed to stop measurements");
+    this->status_set_warning();
+  }
+
+  this->set_timeout(500, [this, current_co2_concentration]() {
+    if (this->write_byte_16(XENSIV_PASCO2_REG_CALIB_REF_H, current_co2_concentration)) {
+      ESP_LOGD(TAG, "setting forced calibration Co2 level %d ppm", current_co2_concentration);
+      delay(400);  // NOLINT wait 400 ms for calibration
+      if (!this->start_measurement_()) {
+        return false;
+      } else {
+        ESP_LOGD(TAG, "forced calibration complete");
+      }
+      return true;
+    } else {
+      ESP_LOGE(TAG, "force calibration failed");
+      this->error_code_ = FRC_FAILED;
+      this->status_set_warning();
+      return false;
+    }
+  });
+  return true;
+}
+
+void PASCO2Component::set_ambient_pressure_compensation(float pressure_in_hpa) {
+  ambient_pressure_compensation_ = true;
+  uint16_t new_ambient_pressure = (uint16_t) pressure_in_hpa;
+  if (!initialized_) {
+    ambient_pressure_ = new_ambient_pressure;
+    return;
+  }
+  // Only send pressure value if it has changed since last update
+  if (new_ambient_pressure != ambient_pressure_) {
+    update_ambient_pressure_compensation_(new_ambient_pressure);
+    ambient_pressure_ = new_ambient_pressure;
+  } else {
+    ESP_LOGD(TAG, "ambient pressure compensation skipped - no change required");
+  }
+}
+
+bool PASCO2Component::update_ambient_pressure_compensation_(uint16_t pressure_in_hpa) {
+  if (this->write_byte_16(XENSIV_PASCO2_REG_PRESS_REF_H, pressure_in_hpa)) {
+    ESP_LOGD(TAG, "setting ambient pressure compensation to %d hPa", pressure_in_hpa);
+    return true;
+  } else {
+    ESP_LOGE(TAG, "Error setting ambient pressure compensation.");
+    return false;
+  }
+}
+
+bool PASCO2Component::start_measurement_() {
+  uint8_t measurement_command = XENSIV_PASCO2_REG_MEAS_CFG_OP_MODE_CONTINOUS |
+                                XENSIV_PASCO2_REG_MEAS_CFG_BOC_CFG_ENABLE | XENSIV_PASCO2_REG_MEAS_CFG_PWM_OUTEN_EN;
+  if (this->measurement_mode_ == SINGLE_SHOT) {
+    measurement_command = XENSIV_PASCO2_REG_MEAS_CFG_OP_MODE_SINGLESHOT | XENSIV_PASCO2_REG_MEAS_CFG_BOC_CFG_ENABLE |
+                          XENSIV_PASCO2_REG_MEAS_CFG_PWM_OUTEN_EN;
+  }
+
+  if (!this->write_byte(XENSIV_PASCO2_REG_MEAS_CFG,
+                        XENSIV_PASCO2_REG_MEAS_CFG_OP_MODE_IDLE | XENSIV_PASCO2_REG_MEAS_CFG_BOC_CFG_ENABLE, true)) {
+    ESP_LOGE(TAG, "Failed to stop measurements");
+    this->status_set_warning();
+  }
+
+  if (!this->write_byte_16(XENSIV_PASCO2_REG_MEAS_RATE_H, 5)) {
+    ESP_LOGE(TAG, "Setting Measurement Rate Failed!");
+    return false;
+  }
+
+  static uint8_t remaining_retries = 3;
+  while (remaining_retries) {
+    if (!this->write_byte(XENSIV_PASCO2_REG_MEAS_CFG, measurement_command, true)) {
+      ESP_LOGE(TAG, "Error starting measurements.");
+      this->error_code_ = MEASUREMENT_INIT_FAILED;
+      this->status_set_warning();
+      if (--remaining_retries == 0)
+        return false;
+      delay(50);  // NOLINT wait 50 ms and try again
+    }
+    this->status_clear_warning();
+    return true;
+  }
+  return false;
+}
+
+}  // namespace pasco2
+}  // namespace esphome

--- a/esphome/components/pasco2/pasco2.h
+++ b/esphome/components/pasco2/pasco2.h
@@ -1,0 +1,75 @@
+#pragma once
+#include <vector>
+#include "esphome/core/application.h"
+#include "esphome/core/component.h"
+#include "esphome/components/sensor/sensor.h"
+#include "esphome/components/i2c/i2c.h"
+
+namespace esphome {
+namespace pasco2 {
+
+enum ERRORCODE {
+  COMM_FAILED,
+  SOFT_RESET_FAILED,
+  XENSIV_PASCO2_ICCERR,
+  XENSIV_PASCO2_ORVS,
+  XENSIV_PASCO2_ORTMP,
+  XENSIV_PASCO2_ERR_NOT_READY,
+  MEASUREMENT_INIT_FAILED,
+  FRC_FAILED,
+  UNKNOWN
+};
+enum MeasurementMode { PERIODIC, SINGLE_SHOT };
+
+enum InitializationState {
+    IDLE,
+    WRITE_SCRATCH_PAD,
+    READ_SCRATCH_PAD,
+    SOFT_RESET,
+    READ_STATUS,
+    COMPLETE
+  };
+
+class PASCO2Component : public PollingComponent, public i2c::I2CDevice {
+ public:
+  float get_setup_priority() const override { return setup_priority::DATA; }
+  void setup() override;
+  void dump_config() override;
+  void update() override;
+
+  void initialize_sensor();
+  void loop() override;
+  void handle_status_errors(uint8_t status);
+
+  void set_automatic_self_calibration(bool asc) { enable_asc_ = asc; }
+  void set_ambient_pressure_compensation(float pressure_in_hpa);
+  void set_ambient_pressure_source(sensor::Sensor *pressure) { ambient_pressure_source_ = pressure; }
+
+  void set_co2_sensor(sensor::Sensor *co2) { co2_sensor_ = co2; }
+  void set_measurement_mode(MeasurementMode mode) { measurement_mode_ = mode; }
+  bool perform_forced_calibration(uint16_t current_co2_concentration);
+
+  void set_enable_pin(GPIOPin *enable) { this->enable_pin_ = enable; }
+
+ protected:
+  bool update_ambient_pressure_compensation_(uint16_t pressure_in_hpa);
+  bool start_measurement_();
+  ERRORCODE error_code_;
+
+  InitializationState initialization_state_ = InitializationState::IDLE;
+  unsigned long last_action_time_;
+  uint8_t remaining_retries_;
+  bool initialized_{false};
+
+  bool ambient_pressure_compensation_;
+  uint16_t ambient_pressure_;
+  bool enable_asc_;
+  MeasurementMode measurement_mode_{PERIODIC};
+  sensor::Sensor *co2_sensor_{nullptr};
+  GPIOPin *enable_pin_{nullptr};
+  // used for compensation
+  sensor::Sensor *ambient_pressure_source_{nullptr};
+};
+
+}  // namespace pasco2
+}  // namespace esphome

--- a/esphome/components/pasco2/sensor.py
+++ b/esphome/components/pasco2/sensor.py
@@ -1,0 +1,129 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import i2c, sensor
+from esphome import automation
+from esphome.automation import maybe_simple_id
+from esphome import pins
+
+from esphome.const import (
+    CONF_ID,
+    CONF_CO2,
+    CONF_VALUE,
+    DEVICE_CLASS_CARBON_DIOXIDE,
+    STATE_CLASS_MEASUREMENT,
+    UNIT_PARTS_PER_MILLION,
+    ICON_MOLECULE_CO2,
+    CONF_ENABLE_PIN,
+)
+
+CODEOWNERS = ["@circuitvalley", "@ozonejunkieau"]
+DEPENDENCIES = ["i2c"]
+
+pasco2_ns = cg.esphome_ns.namespace("pasco2")
+PASCO2Component = pasco2_ns.class_(
+    "PASCO2Component", cg.PollingComponent, i2c.I2CDevice
+)
+MeasurementMode = pasco2_ns.enum("MEASUREMENT_MODE")
+MEASUREMENT_MODE_OPTIONS = {
+    "periodic": MeasurementMode.PERIODIC,
+    "single_shot": MeasurementMode.SINGLE_SHOT,
+}
+
+# Actions
+PerformForcedCalibrationAction = pasco2_ns.class_(
+    "PerformForcedCalibrationAction", automation.Action
+)
+FactoryResetAction = pasco2_ns.class_("FactoryResetAction", automation.Action)
+
+CONF_AMBIENT_PRESSURE_COMPENSATION = "ambient_pressure_compensation"
+CONF_AMBIENT_PRESSURE_COMPENSATION_SOURCE = "ambient_pressure_compensation_source"
+CONF_AUTOMATIC_SELF_CALIBRATION = "automatic_self_calibration"
+CONF_MEASUREMENT_MODE = "measurement_mode"
+
+CONFIG_SCHEMA = (
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.declare_id(PASCO2Component),
+            cv.Required(CONF_CO2): sensor.sensor_schema(
+                unit_of_measurement=UNIT_PARTS_PER_MILLION,
+                icon=ICON_MOLECULE_CO2,
+                accuracy_decimals=0,
+                device_class=DEVICE_CLASS_CARBON_DIOXIDE,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ),
+            cv.Optional(CONF_AUTOMATIC_SELF_CALIBRATION, default=True): cv.boolean,
+            cv.Optional(CONF_AMBIENT_PRESSURE_COMPENSATION): cv.pressure,
+            cv.Optional(CONF_ENABLE_PIN): pins.gpio_output_pin_schema,
+            cv.Optional(CONF_AMBIENT_PRESSURE_COMPENSATION_SOURCE): cv.use_id(
+                sensor.Sensor
+            ),
+            cv.Optional(CONF_MEASUREMENT_MODE, default="periodic"): cv.enum(
+                MEASUREMENT_MODE_OPTIONS, lower=True
+            ),
+        }
+    )
+    .extend(cv.polling_component_schema("60s"))
+    .extend(i2c.i2c_device_schema(0x28))
+)
+
+SENSOR_MAP = {
+    CONF_CO2: "set_co2_sensor",
+}
+
+SETTING_MAP = {
+    CONF_AUTOMATIC_SELF_CALIBRATION: "set_automatic_self_calibration",
+    CONF_AMBIENT_PRESSURE_COMPENSATION: "set_ambient_pressure_compensation",
+}
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+    await i2c.register_i2c_device(var, config)
+
+    for key, funcName in SETTING_MAP.items():
+        if key in config:
+            cg.add(getattr(var, funcName)(config[key]))
+
+    for key, funcName in SENSOR_MAP.items():
+        if key in config:
+            sens = await sensor.new_sensor(config[key])
+            cg.add(getattr(var, funcName)(sens))
+
+    if CONF_AMBIENT_PRESSURE_COMPENSATION_SOURCE in config:
+        sens = await cg.get_variable(config[CONF_AMBIENT_PRESSURE_COMPENSATION_SOURCE])
+        cg.add(var.set_ambient_pressure_source(sens))
+
+    if CONF_ENABLE_PIN in config:
+        enable = await cg.gpio_pin_expression(config[CONF_ENABLE_PIN])
+        cg.add(var.set_enable_pin(enable))
+
+    cg.add(var.set_measurement_mode(config[CONF_MEASUREMENT_MODE]))
+
+
+PASCO2_ACTION_SCHEMA = maybe_simple_id(
+    {
+        cv.GenerateID(): cv.use_id(PASCO2Component),
+        cv.Required(CONF_VALUE): cv.templatable(cv.positive_int),
+    }
+)
+
+
+@automation.register_action(
+    "pasco2.perform_forced_calibration",
+    PerformForcedCalibrationAction,
+    PASCO2_ACTION_SCHEMA,
+)
+async def pasco2_frc_to_code(config, action_id, template_arg, args):
+    var = cg.new_Pvariable(action_id, template_arg)
+    await cg.register_parented(var, config[CONF_ID])
+    template_ = await cg.templatable(config[CONF_VALUE], args, cg.uint16)
+    cg.add(var.set_value(template_))
+    return var
+
+
+PASCO2_RESET_ACTION_SCHEMA = maybe_simple_id(
+    {
+        cv.Required(CONF_ID): cv.use_id(PASCO2Component),
+    }
+)

--- a/tests/components/pasco2/test.pasco2.yml
+++ b/tests/components/pasco2/test.pasco2.yml
@@ -1,0 +1,40 @@
+esphome:
+  name: esp32-11
+  friendly_name: esp32-11
+
+esp32:
+  board: esp32-c3-devkitm-1 
+
+# Enable logging
+
+logger:
+
+# Enable Home Assistant API
+
+i2c:
+  sda: GPIO6
+  scl: GPIO7
+  scan: true
+  id: bus_a
+
+external_components:
+  # use all components from a local folder
+  - source:
+      type: local
+      path: components
+
+
+sensor:
+  - platform: pasco2
+    co2:
+      name: tester_co2_name
+    update_interval: 60s
+
+light:
+  - platform: status_led
+    name: sys_status
+    pin:
+      number: GPIO8
+      inverted: True
+    internal: True
+    restore_mode: ALWAYS_OFF

--- a/tests/components/pasco2/test.pasco2.yml
+++ b/tests/components/pasco2/test.pasco2.yml
@@ -3,7 +3,7 @@ esphome:
   friendly_name: esp32-11
 
 esp32:
-  board: esp32-c3-devkitm-1 
+  board: esp32-c3-devkitm-1
 
 # Enable logging
 
@@ -22,7 +22,6 @@ external_components:
   - source:
       type: local
       path: components
-
 
 sensor:
   - platform: pasco2


### PR DESCRIPTION
# What does this implement/fix?

Adds Support for Infineon XENSIV PASCO2 CO2 Sensor.

This is largely based on the existing #5883 code with minor changes to remove any excessive delay calls. If this is not the proper way to contribute these changes please let me know and I'll update. 

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#3427

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
sensor:
  - platform: pasco2
    co2:
      name: co2_name
    update_interval: 60s
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
