### PR TITLE
Add mcp4461 component for MCP4461 quad i2c digipot/rheostat

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -263,6 +263,7 @@ esphome/components/mcp23x17_base/* @jesserockz
 esphome/components/mcp23xxx_base/* @jesserockz
 esphome/components/mcp2515/* @danielschramm @mvturnho
 esphome/components/mcp3204/* @rsumner
+esphome/components/mcp4461/* @p1ngb4ck
 esphome/components/mcp4728/* @berfenger
 esphome/components/mcp47a1/* @jesserockz
 esphome/components/mcp9600/* @mreditor97

--- a/esphome/components/mcp4461/__init__.py
+++ b/esphome/components/mcp4461/__init__.py
@@ -1,0 +1,42 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import i2c
+from esphome.const import CONF_ID
+
+CODEOWNERS = ["@p1ngb4ck"]
+DEPENDENCIES = ["i2c"]
+MULTI_CONF = True
+CONF_DISABLE_WIPER_0 = "disable_wiper_0"
+CONF_DISABLE_WIPER_1 = "disable_wiper_1"
+CONF_DISABLE_WIPER_2 = "disable_wiper_2"
+CONF_DISABLE_WIPER_3 = "disable_wiper_3"
+
+mcp4461_ns = cg.esphome_ns.namespace("Mcp4461")
+Mcp4461Component = mcp4461_ns.class_("Mcp4461Component", cg.Component, i2c.I2CDevice)
+CONF_MCP4461_ID = "mcp4461_id"
+
+CONFIG_SCHEMA = (
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.declare_id(Mcp4461Component),
+            cv.Optional(CONF_DISABLE_WIPER_0, default=False): cv.boolean,
+            cv.Optional(CONF_DISABLE_WIPER_1, default=False): cv.boolean,
+            cv.Optional(CONF_DISABLE_WIPER_2, default=False): cv.boolean,
+            cv.Optional(CONF_DISABLE_WIPER_3, default=False): cv.boolean,
+        }
+    )
+    .extend(cv.COMPONENT_SCHEMA)
+    .extend(i2c.i2c_device_schema(0x2C))
+)
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(
+        config[CONF_ID],
+        config[CONF_DISABLE_WIPER_0],
+        config[CONF_DISABLE_WIPER_1],
+        config[CONF_DISABLE_WIPER_2],
+        config[CONF_DISABLE_WIPER_3],
+    )
+    await cg.register_component(var, config)
+    await i2c.register_i2c_device(var, config)

--- a/esphome/components/mcp4461/__init__.py
+++ b/esphome/components/mcp4461/__init__.py
@@ -11,7 +11,7 @@ CONF_DISABLE_WIPER_1 = "disable_wiper_1"
 CONF_DISABLE_WIPER_2 = "disable_wiper_2"
 CONF_DISABLE_WIPER_3 = "disable_wiper_3"
 
-mcp4461_ns = cg.esphome_ns.namespace("Mcp4461")
+mcp4461_ns = cg.esphome_ns.namespace("MCP4461")
 Mcp4461Component = mcp4461_ns.class_("Mcp4461Component", cg.Component, i2c.I2CDevice)
 CONF_MCP4461_ID = "mcp4461_id"
 

--- a/esphome/components/mcp4461/__init__.py
+++ b/esphome/components/mcp4461/__init__.py
@@ -11,7 +11,7 @@ CONF_DISABLE_WIPER_1 = "disable_wiper_1"
 CONF_DISABLE_WIPER_2 = "disable_wiper_2"
 CONF_DISABLE_WIPER_3 = "disable_wiper_3"
 
-mcp4461_ns = cg.esphome_ns.namespace("MCP4461")
+mcp4461_ns = cg.esphome_ns.namespace("mcp4461")
 Mcp4461Component = mcp4461_ns.class_("Mcp4461Component", cg.Component, i2c.I2CDevice)
 CONF_MCP4461_ID = "mcp4461_id"
 

--- a/esphome/components/mcp4461/mcp4461.cpp
+++ b/esphome/components/mcp4461/mcp4461.cpp
@@ -77,6 +77,113 @@ uint16_t Mcp4461Component::get_status_register_() {
 
 bool Mcp4461Component::is_writing_() { return (bool) ((this->get_status_register_() >> 4) & 0x01); }
 
+uint8_t Mcp4461Component::get_wiper_address_(uint8_t wiper) {
+  uint8_t addr;
+  bool nonvolatile = false;
+  if (wiper > 3) {
+    nonvolatile = true;
+    wiper = wiper - 4;
+  }
+  switch (wiper) {
+    case 0:
+      addr = (uint8_t) Mcp4461Addresses::MCP4461_VW0;
+      break;
+    case 1:
+      addr = (uint8_t) Mcp4461Addresses::MCP4461_VW1;
+      break;
+    case 2:
+      addr = (uint8_t) Mcp4461Addresses::MCP4461_VW2;
+      break;
+    case 3:
+      addr = (uint8_t) Mcp4461Addresses::MCP4461_VW3;
+      break;
+    default:
+      ESP_LOGE(TAG, "unknown wiper specified");
+      return 0;
+  }
+  if (nonvolatile) {
+    addr = addr + 0x20;
+  }
+  return addr;
+}
+
+uint16_t Mcp4461Component::get_wiper_level_(uint8_t wiper) {
+  uint8_t reg = 0;
+  uint16_t buf = 0;
+  reg |= this->get_wiper_address_(wiper);
+  reg |= (uint8_t) Mcp4461Commands::READ;
+  if (wiper > 3) {
+    while (this->is_writing_()) {
+      ESP_LOGV(TAG, "delaying during eeprom write");
+    }
+  }
+  if (!this->read_byte_16(reg, &buf)) {
+    this->status_set_warning();
+    if (wiper > 3) {
+      this->status_set_warning();
+      ESP_LOGW(TAG, "Error fetching nonvolatile wiper %d value", wiper);
+    } else {
+      this->status_set_warning();
+      ESP_LOGW(TAG, "Error fetching wiper %d value", wiper);
+    }
+    return 0;
+  }
+  return buf;
+}
+
+void Mcp4461Component::update_wiper_level_(uint8_t wiper) {
+  uint16_t data;
+  data = this->get_wiper_level_(wiper);
+  ESP_LOGV(TAG, "Got value %d from wiper %d", data, wiper);
+  this->reg_[wiper].state = data;
+}
+
+void Mcp4461Component::set_wiper_level_(uint8_t wiper, uint16_t value) {
+  ESP_LOGV(TAG, "Setting MCP4461 wiper %d to %d!", wiper, value);
+  this->reg_[wiper].state = value;
+  this->update_ = true;
+}
+
+void Mcp4461Component::write_wiper_level_(uint8_t wiper, uint16_t value) {
+  if (wiper > 3) {
+    while (this->is_writing_()) {
+      ESP_LOGV(TAG, "delaying during eeprom write");
+    }
+  }
+  this->mcp4461_write_(this->get_wiper_address_(wiper), value);
+}
+
+void Mcp4461Component::enable_wiper_(uint8_t wiper) {
+  ESP_LOGV(TAG, "Enabling wiper %d", wiper);
+  this->reg_[wiper].terminal_hw = true;
+  this->update_ = true;
+}
+
+void Mcp4461Component::disable_wiper_(uint8_t wiper) {
+  ESP_LOGV(TAG, "Disabling wiper %d", wiper);
+  this->reg_[wiper].terminal_hw = false;
+  this->update_ = true;
+}
+
+void Mcp4461Component::increase_wiper_(uint8_t wiper) {
+  ESP_LOGV(TAG, "Increasing wiper %d", wiper);
+  uint8_t reg = 0;
+  uint8_t addr;
+  addr = this->get_wiper_address_(wiper);
+  reg |= addr;
+  reg |= (uint8_t) Mcp4461Commands::INCREMENT;
+  this->write(&this->address_, reg, sizeof(reg));
+}
+
+void Mcp4461Component::decrease_wiper_(uint8_t wiper) {
+  ESP_LOGV(TAG, "Decreasing wiper %d", wiper);
+  uint8_t reg = 0;
+  uint8_t addr;
+  addr = this->get_wiper_address_(wiper);
+  reg |= addr;
+  reg |= (uint8_t) Mcp4461Commands::DECREMENT;
+  this->write(&this->address_, reg, sizeof(reg));
+}
 
 uint8_t Mcp4461Component::calc_terminal_connector_byte_(Mcp4461TerminalIdx terminal_connector) {
   uint8_t i;
@@ -202,114 +309,6 @@ void Mcp4461Component::disable_terminal_(uint8_t wiper, char terminal) {
       return;
   }
   this->update_ = true;
-}
-
-uint8_t Mcp4461Component::get_wiper_address_(uint8_t wiper) {
-  uint8_t addr;
-  bool nonvolatile = false;
-  if (wiper > 3) {
-    nonvolatile = true;
-    wiper = wiper - 4;
-  }
-  switch (wiper) {
-    case 0:
-      addr = (uint8_t) Mcp4461Addresses::MCP4461_VW0;
-      break;
-    case 1:
-      addr = (uint8_t) Mcp4461Addresses::MCP4461_VW1;
-      break;
-    case 2:
-      addr = (uint8_t) Mcp4461Addresses::MCP4461_VW2;
-      break;
-    case 3:
-      addr = (uint8_t) Mcp4461Addresses::MCP4461_VW3;
-      break;
-    default:
-      ESP_LOGE(TAG, "unknown wiper specified");
-      return 0;
-  }
-  if (nonvolatile) {
-    addr = addr + 0x20;
-  }
-  return addr;
-}
-
-uint16_t Mcp4461Component::get_wiper_level_(uint8_t wiper) {
-  uint8_t reg = 0;
-  uint16_t buf = 0;
-  reg |= this->get_wiper_address_(wiper);
-  reg |= (uint8_t) Mcp4461Commands::READ;
-  if (wiper > 3) {
-    while (this->is_writing_()) {
-      ESP_LOGV(TAG, "delaying during eeprom write");
-    }
-  }
-  if (!this->read_byte_16(reg, &buf)) {
-    this->status_set_warning();
-    if (wiper > 3) {
-      this->status_set_warning();
-      ESP_LOGW(TAG, "Error fetching nonvolatile wiper %d value", wiper);
-    } else {
-      this->status_set_warning();
-      ESP_LOGW(TAG, "Error fetching wiper %d value", wiper);
-    }
-    return 0;
-  }
-  return buf;
-}
-
-void Mcp4461Component::update_wiper_state_(uint8_t wiper) {
-  uint16_t data;
-  data = this->get_wiper_level_(wiper);
-  ESP_LOGV(TAG, "Got value %d from wiper %d", data, wiper);
-  this->reg_[wiper].state = data;
-}
-
-void Mcp4461Component::set_wiper_level_(uint8_t wiper, uint16_t value) {
-  ESP_LOGV(TAG, "Setting MCP4461 wiper %d to %d!", wiper, value);
-  this->reg_[wiper].state = value;
-  this->update_ = true;
-}
-
-void Mcp4461Component::write_wiper_level_(uint8_t wiper, uint16_t value) {
-  if (wiper > 3) {
-    while (this->is_writing_()) {
-      ESP_LOGV(TAG, "delaying during eeprom write");
-    }
-  }
-  this->mcp4461_write_(this->get_wiper_address_(wiper), value);
-}
-
-void Mcp4461Component::enable_wiper_(uint8_t wiper) {
-  ESP_LOGV(TAG, "Enabling wiper %d", wiper);
-  this->reg_[wiper].terminal_hw = true;
-  this->update_ = true;
-}
-
-void Mcp4461Component::disable_wiper_(uint8_t wiper) {
-  ESP_LOGV(TAG, "Disabling wiper %d", wiper);
-  this->reg_[wiper].terminal_hw = false;
-  this->update_ = true;
-}
-
-void Mcp4461Component::increase_wiper_(uint8_t wiper) {
-  ESP_LOGV(TAG, "Increasing wiper %d", wiper);
-  uint8_t reg = 0;
-  uint8_t addr;
-  addr = this->get_wiper_address_(wiper);
-  reg |= addr;
-  reg |= (uint8_t) Mcp4461Commands::INCREMENT;
-  this->write(&this->address_, reg, sizeof(reg));
-}
-
-void Mcp4461Component::decrease_wiper_(uint8_t wiper) {
-  ESP_LOGV(TAG, "Decreasing wiper %d", wiper);
-  uint8_t reg = 0;
-  uint8_t addr;
-  addr = this->get_wiper_address_(wiper);
-  reg |= addr;
-  reg |= (uint8_t) Mcp4461Commands::DECREMENT;
-  this->write(&this->address_, reg, sizeof(reg));
 }
 
 uint16_t Mcp4461Component::get_eeprom_value(MCP4461EEPRomLocation location) {

--- a/esphome/components/mcp4461/mcp4461.cpp
+++ b/esphome/components/mcp4461/mcp4461.cpp
@@ -62,7 +62,7 @@ void Mcp4461Component::loop() {
   }
 }
 
-uint16_t Mcp4461Component::get_status_register_() {
+uint16_t Mcp4461Component::get_status_register() {
   uint8_t reg = 0;
   reg |= (uint8_t) Mcp4461Addresses::MCP4461_STATUS;
   reg |= (uint8_t) Mcp4461Commands::READ;
@@ -107,7 +107,7 @@ uint8_t Mcp4461Component::get_wiper_address_(uint8_t wiper) {
   return addr;
 }
 
-uint16_t Mcp4461Component::get_wiper_level_(uint8_t wiper) {
+uint16_t Mcp4461Component::get_wiper_level(uint8_t wiper) {
   uint8_t reg = 0;
   uint16_t buf = 0;
   reg |= this->get_wiper_address_(wiper);
@@ -131,14 +131,14 @@ uint16_t Mcp4461Component::get_wiper_level_(uint8_t wiper) {
   return buf;
 }
 
-void Mcp4461Component::update_wiper_level_(uint8_t wiper) {
+void Mcp4461Component::update_wiper_level(uint8_t wiper) {
   uint16_t data;
   data = this->get_wiper_level_(wiper);
   ESP_LOGV(TAG, "Got value %d from wiper %d", data, wiper);
   this->reg_[wiper].state = data;
 }
 
-void Mcp4461Component::set_wiper_level_(uint8_t wiper, uint16_t value) {
+void Mcp4461Component::set_wiper_level(uint8_t wiper, uint16_t value) {
   ESP_LOGV(TAG, "Setting MCP4461 wiper %d to %d!", wiper, value);
   this->reg_[wiper].state = value;
   this->update_ = true;
@@ -153,19 +153,19 @@ void Mcp4461Component::write_wiper_level_(uint8_t wiper, uint16_t value) {
   this->mcp4461_write_(this->get_wiper_address_(wiper), value);
 }
 
-void Mcp4461Component::enable_wiper_(uint8_t wiper) {
+void Mcp4461Component::enable_wiper(uint8_t wiper) {
   ESP_LOGV(TAG, "Enabling wiper %d", wiper);
   this->reg_[wiper].terminal_hw = true;
   this->update_ = true;
 }
 
-void Mcp4461Component::disable_wiper_(uint8_t wiper) {
+void Mcp4461Component::disable_wiper(uint8_t wiper) {
   ESP_LOGV(TAG, "Disabling wiper %d", wiper);
   this->reg_[wiper].terminal_hw = false;
   this->update_ = true;
 }
 
-void Mcp4461Component::increase_wiper_(uint8_t wiper) {
+void Mcp4461Component::increase_wiper(uint8_t wiper) {
   ESP_LOGV(TAG, "Increasing wiper %d", wiper);
   uint8_t reg = 0;
   uint8_t addr;
@@ -175,7 +175,7 @@ void Mcp4461Component::increase_wiper_(uint8_t wiper) {
   this->write(&this->address_, reg, sizeof(reg));
 }
 
-void Mcp4461Component::decrease_wiper_(uint8_t wiper) {
+void Mcp4461Component::decrease_wiper(uint8_t wiper) {
   ESP_LOGV(TAG, "Decreasing wiper %d", wiper);
   uint8_t reg = 0;
   uint8_t addr;
@@ -209,7 +209,7 @@ uint8_t Mcp4461Component::calc_terminal_connector_byte_(Mcp4461TerminalIdx termi
   return (uint8_t) new_value_byte;
 }
 
-uint8_t Mcp4461Component::get_terminal_register_(Mcp4461TerminalIdx terminal_connector) {
+uint8_t Mcp4461Component::get_terminal_register(Mcp4461TerminalIdx terminal_connector) {
   uint8_t reg = 0;
   if ((uint8_t) terminal_connector == 0) {
     reg |= (uint8_t) Mcp4461Addresses::MCP4461_TCON0;
@@ -226,7 +226,7 @@ uint8_t Mcp4461Component::get_terminal_register_(Mcp4461TerminalIdx terminal_con
   return (uint8_t) (buf & 0x00ff);
 }
 
-void Mcp4461Component::update_terminal_register_(Mcp4461TerminalIdx terminal_connector) {
+void Mcp4461Component::update_terminal_register(Mcp4461TerminalIdx terminal_connector) {
   if (((uint8_t) terminal_connector != 0 && (uint8_t) terminal_connector != 1)) {
     return;
   }
@@ -247,7 +247,7 @@ void Mcp4461Component::update_terminal_register_(Mcp4461TerminalIdx terminal_con
   this->reg_[(wiper_index + 1)].terminal_hw = ((terminal_data >> 7) & 0x01);
 }
 
-void Mcp4461Component::set_terminal_register_(Mcp4461TerminalIdx terminal_connector, uint8_t data) {
+void Mcp4461Component::set_terminal_register(Mcp4461TerminalIdx terminal_connector, uint8_t data) {
   uint8_t addr;
   if ((uint8_t) terminal_connector == 0) {
     addr = (uint8_t) Mcp4461Addresses::MCP4461_TCON0;
@@ -259,7 +259,7 @@ void Mcp4461Component::set_terminal_register_(Mcp4461TerminalIdx terminal_connec
   this->mcp4461_write_(addr, data);
 }
 
-void Mcp4461Component::enable_terminal_(uint8_t wiper, char terminal) {
+void Mcp4461Component::enable_terminal(uint8_t wiper, char terminal) {
   if (wiper > 3) {
     return;
   }
@@ -285,7 +285,7 @@ void Mcp4461Component::enable_terminal_(uint8_t wiper, char terminal) {
   this->update_ = true;
 }
 
-void Mcp4461Component::disable_terminal_(uint8_t wiper, char terminal) {
+void Mcp4461Component::disable_terminal(uint8_t wiper, char terminal) {
   if (wiper > 3) {
     return;
   }

--- a/esphome/components/mcp4461/mcp4461.cpp
+++ b/esphome/components/mcp4461/mcp4461.cpp
@@ -1,0 +1,359 @@
+#include "mcp4461.h"
+
+#include "esphome/core/helpers.h"
+#include "esphome/core/log.h"
+
+namespace esphome {
+namespace mcp4461 {
+
+static const char *const TAG = "mcp4461";
+
+void Mcp4461Component::setup() {
+  ESP_LOGCONFIG(TAG, "Setting up mcp4461 (0x%02X)...", this->address_);
+  auto err = this->write(nullptr, 0);
+  if (err != i2c::ERROR_OK) {
+    this->mark_failed();
+    return;
+  }
+  this->begin_();
+}
+
+void Mcp4461Component::begin_() {
+  for (uint8_t i = 0; i < 8; i++) {
+    if (this->reg_[i].enabled) {
+      this->reg_[i].state = this->get_wiper_level_(i);
+    }
+  }
+}
+
+void Mcp4461Component::dump_config() {
+  ESP_LOGCONFIG(TAG, "mcp4461:");
+  LOG_I2C_DEVICE(this);
+  if (this->is_failed()) {
+    ESP_LOGE(TAG, "Communication with mcp4461 failed!");
+  }
+}
+
+void Mcp4461Component::loop() {
+  if (this->update_) {
+    uint8_t i;
+    for (i = 0; i < 8; i++) {
+      // set wiper i state if changed
+      if (this->reg_[i].state != this->get_wiper_level_(i)) {
+        this->write_wiper_level_(i, this->reg_[i].state);
+      }
+      // terminal register changes only applicable to wipers 0-3 !
+      if (i < 4) {
+        // set terminal register changes
+        if (i == 0 || i == 2) {
+          Mcp4461TerminalIdx terminal_connector = Mcp4461TerminalIdx::MCP4461_TERMINAL_0;
+          if (i > 0) {
+            terminal_connector = Mcp4461TerminalIdx::MCP4461_TERMINAL_1;
+          }
+          uint8_t new_terminal_value = this->calc_terminal_connector_byte_(terminal_connector);
+          if (new_terminal_value != this->get_terminal_register_(terminal_connector)) {
+            ESP_LOGV(TAG, "updating terminal %d to new value %d", (uint8_t) terminal_connector, new_terminal_value);
+            this->set_terminal_register_(terminal_connector, new_terminal_value);
+          }
+        }
+      }
+    }
+    this->update_ = false;
+  }
+}
+
+uint8_t Mcp4461Component::calc_terminal_connector_byte_(Mcp4461TerminalIdx terminal_connector) {
+  uint8_t i;
+  if (((uint8_t) terminal_connector == 0 || (uint8_t) terminal_connector == 1)) {
+    i = 0;
+  } else {
+    i = 2;
+  }
+  uint8_t new_value_byte_array[8];
+  new_value_byte_array[0] = (uint8_t) this->reg_[i].terminal_b;
+  new_value_byte_array[1] = (uint8_t) this->reg_[i].terminal_w;
+  new_value_byte_array[2] = (uint8_t) this->reg_[i].terminal_a;
+  new_value_byte_array[3] = (uint8_t) this->reg_[i].terminal_hw;
+  new_value_byte_array[4] = (uint8_t) this->reg_[(i + 1)].terminal_b;
+  new_value_byte_array[5] = (uint8_t) this->reg_[(i + 1)].terminal_w;
+  new_value_byte_array[6] = (uint8_t) this->reg_[(i + 1)].terminal_a;
+  new_value_byte_array[7] = (uint8_t) this->reg_[(i + 1)].terminal_hw;
+  unsigned char new_value_byte = 0;
+  uint8_t b;
+  for (b = 0; b < 8; b++) {
+    new_value_byte += (new_value_byte_array[b] << (7 - b));
+  }
+  return (uint8_t) new_value_byte;
+}
+
+void Mcp4461Component::update_terminal_register_(Mcp4461TerminalIdx terminal_connector) {
+  if (((uint8_t) terminal_connector != 0 && (uint8_t) terminal_connector != 1)) {
+    return;
+  }
+  uint8_t terminal_data;
+  terminal_data = this->get_terminal_register_(terminal_connector);
+  ESP_LOGV(TAG, "Got terminal register %d data %0xh", (uint8_t) terminal_connector, terminal_data);
+  uint8_t wiper_index = 0;
+  if ((uint8_t) terminal_connector == 1) {
+    wiper_index = 2;
+  }
+  this->reg_[wiper_index].terminal_b = ((terminal_data >> 0) & 0x01);
+  this->reg_[wiper_index].terminal_w = ((terminal_data >> 1) & 0x01);
+  this->reg_[wiper_index].terminal_a = ((terminal_data >> 2) & 0x01);
+  this->reg_[wiper_index].terminal_hw = ((terminal_data >> 3) & 0x01);
+  this->reg_[(wiper_index + 1)].terminal_b = ((terminal_data >> 4) & 0x01);
+  this->reg_[(wiper_index + 1)].terminal_w = ((terminal_data >> 5) & 0x01);
+  this->reg_[(wiper_index + 1)].terminal_a = ((terminal_data >> 6) & 0x01);
+  this->reg_[(wiper_index + 1)].terminal_hw = ((terminal_data >> 7) & 0x01);
+}
+
+uint16_t Mcp4461Component::get_status_register_() {
+  uint8_t reg = 0;
+  reg |= (uint8_t) Mcp4461Addresses::MCP4461_STATUS;
+  reg |= (uint8_t) Mcp4461Commands::READ;
+  uint16_t buf;
+  if (!this->read_byte_16(reg, &buf)) {
+    this->status_set_warning();
+    ESP_LOGW(TAG, "Error fetching status register value");
+    return 0;
+  }
+  return buf;
+}
+
+bool Mcp4461Component::is_writing_() { return (bool) ((this->get_status_register_() >> 4) & 0x01); }
+
+uint8_t Mcp4461Component::get_terminal_register_(Mcp4461TerminalIdx terminal_connector) {
+  uint8_t reg = 0;
+  if ((uint8_t) terminal_connector == 0) {
+    reg |= (uint8_t) Mcp4461Addresses::MCP4461_TCON0;
+  } else {
+    reg |= (uint8_t) Mcp4461Addresses::MCP4461_TCON1;
+  }
+  reg |= (uint8_t) Mcp4461Commands::READ;
+  uint16_t buf;
+  if (!this->read_byte_16(reg, &buf)) {
+    this->status_set_warning();
+    ESP_LOGW(TAG, "Error fetching terminal register value");
+    return 0;
+  }
+  return (uint8_t) (buf & 0x00ff);
+}
+
+void Mcp4461Component::set_terminal_register_(Mcp4461TerminalIdx terminal_connector, uint8_t data) {
+  uint8_t addr;
+  if ((uint8_t) terminal_connector == 0) {
+    addr = (uint8_t) Mcp4461Addresses::MCP4461_TCON0;
+  } else if ((uint8_t) terminal_connector == 1) {
+    addr = (uint8_t) Mcp4461Addresses::MCP4461_TCON1;
+  } else {
+    return;
+  }
+  this->mcp4461_write_(addr, data);
+}
+
+void Mcp4461Component::enable_terminal_(uint8_t wiper, char terminal) {
+  if (wiper > 3) {
+    return;
+  }
+  ESP_LOGV(TAG, "Enabling terminal %c of wiper %d", terminal, wiper);
+  switch (terminal) {
+    case 'h':
+      this->reg_[wiper].terminal_hw = true;
+      break;
+    case 'a':
+      this->reg_[wiper].terminal_a = true;
+      break;
+    case 'b':
+      this->reg_[wiper].terminal_b = true;
+      break;
+    case 'w':
+      this->reg_[wiper].terminal_w = true;
+      break;
+    default:
+      this->status_set_warning();
+      ESP_LOGW(TAG, "Unknown terminal %c specified", terminal);
+      return;
+  }
+  this->update_ = true;
+}
+
+void Mcp4461Component::disable_terminal_(uint8_t wiper, char terminal) {
+  if (wiper > 3) {
+    return;
+  }
+  ESP_LOGV(TAG, "Disabling terminal %c of wiper %d", terminal, wiper);
+  switch (terminal) {
+    case 'h':
+      this->reg_[wiper].terminal_hw = false;
+      break;
+    case 'a':
+      this->reg_[wiper].terminal_a = false;
+      break;
+    case 'b':
+      this->reg_[wiper].terminal_b = false;
+      break;
+    case 'w':
+      this->reg_[wiper].terminal_w = false;
+      break;
+    default:
+      this->status_set_warning();
+      ESP_LOGW(TAG, "Unknown terminal %c specified", terminal);
+      return;
+  }
+  this->update_ = true;
+}
+
+uint8_t Mcp4461Component::get_wiper_address_(uint8_t wiper) {
+  uint8_t addr;
+  bool nonvolatile = false;
+  if (wiper > 3) {
+    nonvolatile = true;
+    wiper = wiper - 4;
+  }
+  switch (wiper) {
+    case 0:
+      addr = (uint8_t) Mcp4461Addresses::MCP4461_VW0;
+      break;
+    case 1:
+      addr = (uint8_t) Mcp4461Addresses::MCP4461_VW1;
+      break;
+    case 2:
+      addr = (uint8_t) Mcp4461Addresses::MCP4461_VW2;
+      break;
+    case 3:
+      addr = (uint8_t) Mcp4461Addresses::MCP4461_VW3;
+      break;
+    default:
+      ESP_LOGE(TAG, "unknown wiper specified");
+      return 0;
+  }
+  if (nonvolatile) {
+    addr = addr + 0x20;
+  }
+  return addr;
+}
+
+uint16_t Mcp4461Component::get_wiper_level_(uint8_t wiper) {
+  uint8_t reg = 0;
+  uint16_t buf = 0;
+  reg |= this->get_wiper_address_(wiper);
+  reg |= (uint8_t) Mcp4461Commands::READ;
+  if (wiper > 3) {
+    while (this->is_writing_()) {
+      ESP_LOGV(TAG, "delaying during eeprom write");
+    }
+  }
+  if (!this->read_byte_16(reg, &buf)) {
+    this->status_set_warning();
+    if (wiper > 3) {
+      this->status_set_warning();
+      ESP_LOGW(TAG, "Error fetching nonvolatile wiper %d value", wiper);
+    } else {
+      this->status_set_warning();
+      ESP_LOGW(TAG, "Error fetching wiper %d value", wiper);
+    }
+    return 0;
+  }
+  return buf;
+}
+
+void Mcp4461Component::update_wiper_state_(uint8_t wiper) {
+  uint16_t data;
+  data = this->get_wiper_level_(wiper);
+  ESP_LOGV(TAG, "Got value %d from wiper %d", data, wiper);
+  this->reg_[wiper].state = data;
+}
+
+void Mcp4461Component::set_wiper_level_(uint8_t wiper, uint16_t value) {
+  ESP_LOGV(TAG, "Setting MCP4461 wiper %d to %d!", wiper, value);
+  this->reg_[wiper].state = value;
+  this->update_ = true;
+}
+
+void Mcp4461Component::write_wiper_level_(uint8_t wiper, uint16_t value) {
+  if (wiper > 3) {
+    while (this->is_writing_()) {
+      ESP_LOGV(TAG, "delaying during eeprom write");
+    }
+  }
+  this->mcp4461_write_(this->get_wiper_address_(wiper), value);
+}
+
+void Mcp4461Component::enable_wiper_(uint8_t wiper) {
+  ESP_LOGV(TAG, "Enabling wiper %d", wiper);
+  this->reg_[wiper].terminal_hw = true;
+  this->update_ = true;
+}
+
+void Mcp4461Component::disable_wiper_(uint8_t wiper) {
+  ESP_LOGV(TAG, "Disabling wiper %d", wiper);
+  this->reg_[wiper].terminal_hw = false;
+  this->update_ = true;
+}
+
+void Mcp4461Component::increase_wiper_(uint8_t wiper) {
+  ESP_LOGV(TAG, "Increasing wiper %d", wiper);
+  uint8_t reg = 0;
+  uint8_t addr;
+  addr = this->get_wiper_address_(wiper);
+  reg |= addr;
+  reg |= (uint8_t) Mcp4461Commands::INCREMENT;
+  this->write(&this->address_, reg, sizeof(reg));
+}
+
+void Mcp4461Component::decrease_wiper_(uint8_t wiper) {
+  ESP_LOGV(TAG, "Decreasing wiper %d", wiper);
+  uint8_t reg = 0;
+  uint8_t addr;
+  addr = this->get_wiper_address_(wiper);
+  reg |= addr;
+  reg |= (uint8_t) Mcp4461Commands::DECREMENT;
+  this->write(&this->address_, reg, sizeof(reg));
+}
+
+uint16_t Mcp4461Component::get_eeprom_value(MCP4461EEPRomLocation location) {
+  uint8_t reg = 0;
+  reg |= (uint8_t) (MCP4461_EEPROM_1 + ((uint8_t) location * 0x10));
+  reg |= (uint8_t) Mcp4461Commands::READ;
+  uint16_t buf;
+  if (!this->read_byte_16(reg, &buf)) {
+    this->status_set_warning();
+    ESP_LOGW(TAG, "Error fetching EEPRom location value");
+    return 0;
+  }
+  return buf;
+}
+
+void Mcp4461Component::set_eeprom_value(MCP4461EEPRomLocation location, uint16_t value) {
+  uint8_t addr = 0;
+  if (value > 256) {
+    return;
+  } else if (value == 256) {
+    addr = 1;
+  }
+  uint8_t data;
+  addr |= (uint8_t) (MCP4461_EEPROM_1 + ((uint8_t) location * 0x10));
+  data = (uint8_t) (value & 0x00ff);
+  while (this->is_writing_()) {
+    ESP_LOGV(TAG, "delaying during eeprom write");
+  }
+  this->write_byte(addr, data);
+}
+
+void Mcp4461Component::mcp4461_write_(uint8_t addr, uint16_t data) {
+  uint8_t reg = 0;
+  if (data > 0x100) {
+    return;
+  }
+  if (data > 0xFF) {
+    reg = 1;
+  }
+  uint8_t value_byte;
+  value_byte = (uint8_t) (data & 0x00ff);
+  ESP_LOGV(TAG, "Writing value %d", data);
+  reg |= addr;
+  reg |= (uint8_t) Mcp4461Commands::WRITE;
+  this->write_byte(reg, value_byte);
+}
+}  // namespace mcp4461
+}  // namespace esphome

--- a/esphome/components/mcp4461/mcp4461.cpp
+++ b/esphome/components/mcp4461/mcp4461.cpp
@@ -39,7 +39,7 @@ void Mcp4461Component::loop() {
     uint8_t i;
     for (i = 0; i < 8; i++) {
       // set wiper i state if changed
-      if (this->reg_[i].state != this->get_wiper_level_(i)) {
+      if (this->reg_[i].state != this->get_wiper_level(i)) {
         this->write_wiper_level_(i, this->reg_[i].state);
       }
       // terminal register changes only applicable to wipers 0-3 !
@@ -51,9 +51,9 @@ void Mcp4461Component::loop() {
             terminal_connector = Mcp4461TerminalIdx::MCP4461_TERMINAL_1;
           }
           uint8_t new_terminal_value = this->calc_terminal_connector_byte_(terminal_connector);
-          if (new_terminal_value != this->get_terminal_register_(terminal_connector)) {
+          if (new_terminal_value != this->get_terminal_register(terminal_connector)) {
             ESP_LOGV(TAG, "updating terminal %d to new value %d", (uint8_t) terminal_connector, new_terminal_value);
-            this->set_terminal_register_(terminal_connector, new_terminal_value);
+            this->set_terminal_register(terminal_connector, new_terminal_value);
           }
         }
       }
@@ -75,7 +75,7 @@ uint16_t Mcp4461Component::get_status_register() {
   return buf;
 }
 
-bool Mcp4461Component::is_writing_() { return (bool) ((this->get_status_register_() >> 4) & 0x01); }
+bool Mcp4461Component::is_writing_() { return (bool) ((this->get_status_register() >> 4) & 0x01); }
 
 uint8_t Mcp4461Component::get_wiper_address_(uint8_t wiper) {
   uint8_t addr;
@@ -133,7 +133,7 @@ uint16_t Mcp4461Component::get_wiper_level(uint8_t wiper) {
 
 void Mcp4461Component::update_wiper_level(uint8_t wiper) {
   uint16_t data;
-  data = this->get_wiper_level_(wiper);
+  data = this->get_wiper_level(wiper);
   ESP_LOGV(TAG, "Got value %d from wiper %d", data, wiper);
   this->reg_[wiper].state = data;
 }
@@ -231,7 +231,7 @@ void Mcp4461Component::update_terminal_register(Mcp4461TerminalIdx terminal_conn
     return;
   }
   uint8_t terminal_data;
-  terminal_data = this->get_terminal_register_(terminal_connector);
+  terminal_data = this->get_terminal_register(terminal_connector);
   ESP_LOGV(TAG, "Got terminal register %d data %0xh", (uint8_t) terminal_connector, terminal_data);
   uint8_t wiper_index = 0;
   if ((uint8_t) terminal_connector == 1) {

--- a/esphome/components/mcp4461/mcp4461.cpp
+++ b/esphome/components/mcp4461/mcp4461.cpp
@@ -21,7 +21,7 @@ void Mcp4461Component::setup() {
 void Mcp4461Component::begin_() {
   for (uint8_t i = 0; i < 8; i++) {
     if (this->reg_[i].enabled) {
-      this->reg_[i].state = this->get_wiper_level_(i);
+      this->reg_[i].state = this->get_wiper_level(i);
     }
   }
 }

--- a/esphome/components/mcp4461/mcp4461.cpp
+++ b/esphome/components/mcp4461/mcp4461.cpp
@@ -62,6 +62,22 @@ void Mcp4461Component::loop() {
   }
 }
 
+uint16_t Mcp4461Component::get_status_register_() {
+  uint8_t reg = 0;
+  reg |= (uint8_t) Mcp4461Addresses::MCP4461_STATUS;
+  reg |= (uint8_t) Mcp4461Commands::READ;
+  uint16_t buf;
+  if (!this->read_byte_16(reg, &buf)) {
+    this->status_set_warning();
+    ESP_LOGW(TAG, "Error fetching status register value");
+    return 0;
+  }
+  return buf;
+}
+
+bool Mcp4461Component::is_writing_() { return (bool) ((this->get_status_register_() >> 4) & 0x01); }
+
+
 uint8_t Mcp4461Component::calc_terminal_connector_byte_(Mcp4461TerminalIdx terminal_connector) {
   uint8_t i;
   if (((uint8_t) terminal_connector == 0 || (uint8_t) terminal_connector == 1)) {
@@ -86,6 +102,23 @@ uint8_t Mcp4461Component::calc_terminal_connector_byte_(Mcp4461TerminalIdx termi
   return (uint8_t) new_value_byte;
 }
 
+uint8_t Mcp4461Component::get_terminal_register_(Mcp4461TerminalIdx terminal_connector) {
+  uint8_t reg = 0;
+  if ((uint8_t) terminal_connector == 0) {
+    reg |= (uint8_t) Mcp4461Addresses::MCP4461_TCON0;
+  } else {
+    reg |= (uint8_t) Mcp4461Addresses::MCP4461_TCON1;
+  }
+  reg |= (uint8_t) Mcp4461Commands::READ;
+  uint16_t buf;
+  if (!this->read_byte_16(reg, &buf)) {
+    this->status_set_warning();
+    ESP_LOGW(TAG, "Error fetching terminal register value");
+    return 0;
+  }
+  return (uint8_t) (buf & 0x00ff);
+}
+
 void Mcp4461Component::update_terminal_register_(Mcp4461TerminalIdx terminal_connector) {
   if (((uint8_t) terminal_connector != 0 && (uint8_t) terminal_connector != 1)) {
     return;
@@ -105,38 +138,6 @@ void Mcp4461Component::update_terminal_register_(Mcp4461TerminalIdx terminal_con
   this->reg_[(wiper_index + 1)].terminal_w = ((terminal_data >> 5) & 0x01);
   this->reg_[(wiper_index + 1)].terminal_a = ((terminal_data >> 6) & 0x01);
   this->reg_[(wiper_index + 1)].terminal_hw = ((terminal_data >> 7) & 0x01);
-}
-
-uint16_t Mcp4461Component::get_status_register_() {
-  uint8_t reg = 0;
-  reg |= (uint8_t) Mcp4461Addresses::MCP4461_STATUS;
-  reg |= (uint8_t) Mcp4461Commands::READ;
-  uint16_t buf;
-  if (!this->read_byte_16(reg, &buf)) {
-    this->status_set_warning();
-    ESP_LOGW(TAG, "Error fetching status register value");
-    return 0;
-  }
-  return buf;
-}
-
-bool Mcp4461Component::is_writing_() { return (bool) ((this->get_status_register_() >> 4) & 0x01); }
-
-uint8_t Mcp4461Component::get_terminal_register_(Mcp4461TerminalIdx terminal_connector) {
-  uint8_t reg = 0;
-  if ((uint8_t) terminal_connector == 0) {
-    reg |= (uint8_t) Mcp4461Addresses::MCP4461_TCON0;
-  } else {
-    reg |= (uint8_t) Mcp4461Addresses::MCP4461_TCON1;
-  }
-  reg |= (uint8_t) Mcp4461Commands::READ;
-  uint16_t buf;
-  if (!this->read_byte_16(reg, &buf)) {
-    this->status_set_warning();
-    ESP_LOGW(TAG, "Error fetching terminal register value");
-    return 0;
-  }
-  return (uint8_t) (buf & 0x00ff);
 }
 
 void Mcp4461Component::set_terminal_register_(Mcp4461TerminalIdx terminal_connector, uint8_t data) {

--- a/esphome/components/mcp4461/mcp4461.h
+++ b/esphome/components/mcp4461/mcp4461.h
@@ -67,19 +67,19 @@ class Mcp4461Component : public Component, public i2c::I2CDevice {
   void dump_config() override;
   float get_setup_priority() const override { return setup_priority::HARDWARE; }
   void loop() override;
-  uint16_t get_status_register_();
-  uint16_t get_wiper_level_(uint8_t wiper);
-  void set_wiper_level_(uint8_t wiper, uint16_t value);
-  void update_wiper_level_(uint8_t wiper);
-  void enable_wiper_(uint8_t wiper);
-  void disable_wiper_(uint8_t wiper);
-  void increase_wiper_(uint8_t wiper);
-  void decrease_wiper_(uint8_t wiper);
-  void enable_terminal_(uint8_t wiper, char terminal);
-  void disable_terminal_(uint8_t wiper, char terminal);
-  void update_terminal_register_(Mcp4461TerminalIdx terminal_connector);
-  uint8_t get_terminal_register_(Mcp4461TerminalIdx terminal_connector);
-  void set_terminal_register_(Mcp4461TerminalIdx terminal_connector, uint8_t data);
+  uint16_t get_status_register();
+  uint16_t get_wiper_level(uint8_t wiper);
+  void set_wiper_level(uint8_t wiper, uint16_t value);
+  void update_wiper_level(uint8_t wiper);
+  void enable_wiper(uint8_t wiper);
+  void disable_wiper(uint8_t wiper);
+  void increase_wiper(uint8_t wiper);
+  void decrease_wiper(uint8_t wiper);
+  void enable_terminal(uint8_t wiper, char terminal);
+  void disable_terminal(uint8_t wiper, char terminal);
+  void update_terminal_register(Mcp4461TerminalIdx terminal_connector);
+  uint8_t get_terminal_register(Mcp4461TerminalIdx terminal_connector);
+  void set_terminal_register(Mcp4461TerminalIdx terminal_connector, uint8_t data);
   uint16_t get_eeprom_value(MCP4461EEPRomLocation location);
   void set_eeprom_value(MCP4461EEPRomLocation location, uint16_t value);
 

--- a/esphome/components/mcp4461/mcp4461.h
+++ b/esphome/components/mcp4461/mcp4461.h
@@ -52,8 +52,8 @@ enum class Mcp4461TerminalIdx { MCP4461_TERMINAL_0 = 0, MCP4461_TERMINAL_1 = 1 }
 
 class Mcp4461Wiper;
 
-/// Mcp4461 Component
-class Mcp4461 : public Component, public i2c::I2CDevice {
+// Mcp4461Component
+class Mcp4461Component : public Component, public i2c::I2CDevice {
  public:
   Mcp4461Component(bool disable_wiper_0, bool disable_wiper_1, bool disable_wiper_2, bool disable_wiper_3)
       : wiper_0_enabled_(false), wiper_1_enabled_(false), wiper_2_enabled_(false), wiper_3_enabled_(false) {

--- a/esphome/components/mcp4461/mcp4461.h
+++ b/esphome/components/mcp4461/mcp4461.h
@@ -1,0 +1,104 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/components/i2c/i2c.h"
+
+namespace esphome {
+namespace mcp4461 {
+
+struct WiperState {
+  bool terminal_a = true;
+  bool terminal_b = true;
+  bool terminal_w = true;
+  bool terminal_hw = true;
+  uint16_t state;
+  bool enabled = true;
+};
+
+enum class Mcp4461Defaults { WIPER_VALUE = 0x80 };
+enum class Mcp4461Commands { WRITE = 0x0, INCREMENT = 0x4, DECREMENT = 0x8, READ = 0xC };
+
+enum class Mcp4461Addresses {
+  MCP4461_VW0 = 0x00,
+  MCP4461_VW1 = 0x10,
+  MCP4461_VW2 = 0x60,
+  MCP4461_VW3 = 0x70,
+  MCP4461_STATUS = 0x50,
+  MCP4461_TCON0 = 0x40,
+  MCP4461_TCON1 = 0xA0,
+  MCP4461_EEPROM_1 = 0xB0
+};
+
+enum MCP4461WiperIdx {
+  MCP4461_WIPER_0 = 0,
+  MCP4461_WIPER_1 = 1,
+  MCP4461_WIPER_2 = 2,
+  MCP4461_WIPER_3 = 3,
+  MCP4461_WIPER_4 = 4,
+  MCP4461_WIPER_5 = 5,
+  MCP4461_WIPER_6 = 6,
+  MCP4461_WIPER_7 = 7
+};
+
+enum MCP4461EEPRomLocation {
+  MCP4461_EEPROM_0 = 0,
+  MCP4461_EEPROM_1 = 1,
+  MCP4461_EEPROM_2 = 2,
+  MCP4461_EEPROM_3 = 3,
+  MCP4461_EEPROM_4 = 4
+};
+
+enum class Mcp4461TerminalIdx { MCP4461_TERMINAL_0 = 0, MCP4461_TERMINAL_1 = 1 };
+
+class Mcp4461Wiper;
+
+/// Mcp4461 Component
+class Mcp4461Component : public Component, public i2c::I2CDevice {
+ public:
+  Mcp4461Component(bool disable_wiper_0, bool disable_wiper_1, bool disable_wiper_2, bool disable_wiper_3)
+      : wiper_0_enabled_(false), wiper_1_enabled_(false), wiper_2_enabled_(false), wiper_3_enabled_(false) {
+    this->reg_[0].enabled = this->wiper_0_enabled_;
+    this->reg_[1].enabled = this->wiper_1_enabled_;
+    this->reg_[2].enabled = this->wiper_2_enabled_;
+    this->reg_[3].enabled = this->wiper_3_enabled_;
+  }
+
+  void setup() override;
+  void dump_config() override;
+  float get_setup_priority() const override { return setup_priority::HARDWARE; }
+  void loop() override;
+  uint16_t get_eeprom_value(MCP4461EEPRomLocation location);
+  void set_eeprom_value(MCP4461EEPRomLocation location, uint16_t value);
+
+ protected:
+  friend Mcp4461Wiper;
+  uint8_t get_wiper_address_(uint8_t wiper);
+  void update_wiper_state_(uint8_t wiper);
+  void write_wiper_level_(uint8_t wiper, uint16_t value);
+  void enable_wiper_(uint8_t wiper);
+  void disable_wiper_(uint8_t wiper);
+  void increase_wiper_(uint8_t wiper);
+  void decrease_wiper_(uint8_t wiper);
+  void mcp4461_write_(uint8_t addr, uint16_t data);
+  uint8_t calc_terminal_connector_byte_(Mcp4461TerminalIdx terminal_connector);
+  void update_terminal_register_(Mcp4461TerminalIdx terminal_connector);
+  void enable_terminal_(uint8_t wiper, char terminal);
+  void disable_terminal_(uint8_t wiper, char terminal);
+  uint8_t get_terminal_register_(Mcp4461TerminalIdx terminal_connector);
+  void set_terminal_register_(Mcp4461TerminalIdx terminal_connector, uint8_t data);
+  uint16_t get_status_register_();
+  uint16_t get_wiper_level_(uint8_t wiper);
+  void set_wiper_level_(uint8_t wiper, uint16_t value);
+  bool is_writing_();
+
+ private:
+  WiperState reg_[8];
+  void begin_();
+  bool update_ = false;
+  bool wiper_0_enabled_ = true;
+  bool wiper_1_enabled_ = true;
+  bool wiper_2_enabled_ = true;
+  bool wiper_3_enabled_ = true;
+};
+}  // namespace mcp4461
+}  // namespace esphome

--- a/esphome/components/mcp4461/mcp4461.h
+++ b/esphome/components/mcp4461/mcp4461.h
@@ -67,29 +67,29 @@ class Mcp4461Component : public Component, public i2c::I2CDevice {
   void dump_config() override;
   float get_setup_priority() const override { return setup_priority::HARDWARE; }
   void loop() override;
+  uint16_t get_status_register_();
+  uint16_t get_wiper_level_(uint8_t wiper);
+  void set_wiper_level_(uint8_t wiper, uint16_t value);
+  void update_wiper_level_(uint8_t wiper);
+  void enable_wiper_(uint8_t wiper);
+  void disable_wiper_(uint8_t wiper);
+  void increase_wiper_(uint8_t wiper);
+  void decrease_wiper_(uint8_t wiper);
+  void enable_terminal_(uint8_t wiper, char terminal);
+  void disable_terminal_(uint8_t wiper, char terminal);
+  void update_terminal_register_(Mcp4461TerminalIdx terminal_connector);
+  uint8_t get_terminal_register_(Mcp4461TerminalIdx terminal_connector);
+  void set_terminal_register_(Mcp4461TerminalIdx terminal_connector, uint8_t data);
   uint16_t get_eeprom_value(MCP4461EEPRomLocation location);
   void set_eeprom_value(MCP4461EEPRomLocation location, uint16_t value);
 
  protected:
   friend Mcp4461Wiper;
+  bool is_writing_();
   uint8_t get_wiper_address_(uint8_t wiper);
-  void update_wiper_state_(uint8_t wiper);
   void write_wiper_level_(uint8_t wiper, uint16_t value);
-  void enable_wiper_(uint8_t wiper);
-  void disable_wiper_(uint8_t wiper);
-  void increase_wiper_(uint8_t wiper);
-  void decrease_wiper_(uint8_t wiper);
   void mcp4461_write_(uint8_t addr, uint16_t data);
   uint8_t calc_terminal_connector_byte_(Mcp4461TerminalIdx terminal_connector);
-  void update_terminal_register_(Mcp4461TerminalIdx terminal_connector);
-  void enable_terminal_(uint8_t wiper, char terminal);
-  void disable_terminal_(uint8_t wiper, char terminal);
-  uint8_t get_terminal_register_(Mcp4461TerminalIdx terminal_connector);
-  void set_terminal_register_(Mcp4461TerminalIdx terminal_connector, uint8_t data);
-  uint16_t get_status_register_();
-  uint16_t get_wiper_level_(uint8_t wiper);
-  void set_wiper_level_(uint8_t wiper, uint16_t value);
-  bool is_writing_();
 
  private:
   WiperState reg_[8];

--- a/esphome/components/mcp4461/mcp4461.h
+++ b/esphome/components/mcp4461/mcp4461.h
@@ -53,7 +53,7 @@ enum class Mcp4461TerminalIdx { MCP4461_TERMINAL_0 = 0, MCP4461_TERMINAL_1 = 1 }
 class Mcp4461Wiper;
 
 /// Mcp4461 Component
-class Mcp4461Component : public Component, public i2c::I2CDevice {
+class Mcp4461 : public Component, public i2c::I2CDevice {
  public:
   Mcp4461Component(bool disable_wiper_0, bool disable_wiper_1, bool disable_wiper_2, bool disable_wiper_3)
       : wiper_0_enabled_(false), wiper_1_enabled_(false), wiper_2_enabled_(false), wiper_3_enabled_(false) {

--- a/esphome/components/mcp4461/output/__init__.py
+++ b/esphome/components/mcp4461/output/__init__.py
@@ -31,7 +31,7 @@ CONFIG_SCHEMA = output.FLOAT_OUTPUT_SCHEMA.extend(
         cv.GenerateID(CONF_MCP4461_ID): cv.use_id(Mcp4461Component),
         cv.Required(CONF_CHANNEL): cv.enum(CHANNEL_OPTIONS, upper=True),
         cv.Optional(CONF_ENABLE, default=True): cv.boolean,
-        cv.Optional(CONF_INITIAL_VALUE): cv.float_range(min=0.000, max=0.256),
+        cv.Optional(CONF_INITIAL_VALUE): cv.float_range(min=0.000, max=1.0),
         cv.Optional(CONF_TERMINAL_A, default=True): cv.boolean,
         cv.Optional(CONF_TERMINAL_B, default=True): cv.boolean,
         cv.Optional(CONF_TERMINAL_W, default=True): cv.boolean,

--- a/esphome/components/mcp4461/output/__init__.py
+++ b/esphome/components/mcp4461/output/__init__.py
@@ -45,7 +45,6 @@ async def to_code(config):
         parent,
         config[CONF_CHANNEL],
         config[CONF_ENABLE],
-        config[CONF_INITIAL_VALUE],
         config[CONF_TERMINAL_A],
         config[CONF_TERMINAL_B],
         config[CONF_TERMINAL_W],

--- a/esphome/components/mcp4461/output/__init__.py
+++ b/esphome/components/mcp4461/output/__init__.py
@@ -32,7 +32,7 @@ CONFIG_SCHEMA = output.FLOAT_OUTPUT_SCHEMA.extend(
         cv.Required(CONF_CHANNEL): cv.enum(CHANNEL_OPTIONS, upper=True),
         cv.Optional(CONF_ENABLE, default=True): cv.boolean,
         cv.Optional(CONF_INITIAL_VALUE, default=1.0): cv.float_range(
-            min=0.001, max=0.256
+            min=0.000, max=0.256
         ),
         cv.Optional(CONF_TERMINAL_A, default=True): cv.boolean,
         cv.Optional(CONF_TERMINAL_B, default=True): cv.boolean,

--- a/esphome/components/mcp4461/output/__init__.py
+++ b/esphome/components/mcp4461/output/__init__.py
@@ -31,9 +31,7 @@ CONFIG_SCHEMA = output.FLOAT_OUTPUT_SCHEMA.extend(
         cv.GenerateID(CONF_MCP4461_ID): cv.use_id(Mcp4461Component),
         cv.Required(CONF_CHANNEL): cv.enum(CHANNEL_OPTIONS, upper=True),
         cv.Optional(CONF_ENABLE, default=True): cv.boolean,
-        cv.Optional(CONF_INITIAL_VALUE): cv.float_range(
-            min=0.000, max=0.256
-        ),
+        cv.Optional(CONF_INITIAL_VALUE): cv.float_range(min=0.000, max=0.256),
         cv.Optional(CONF_TERMINAL_A, default=True): cv.boolean,
         cv.Optional(CONF_TERMINAL_B, default=True): cv.boolean,
         cv.Optional(CONF_TERMINAL_W, default=True): cv.boolean,

--- a/esphome/components/mcp4461/output/__init__.py
+++ b/esphome/components/mcp4461/output/__init__.py
@@ -1,7 +1,7 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import output
-from esphome.const import CONF_CHANNEL, CONF_ID, CONF_INITIAL_VALUE
+from esphome.const import CONF_CHANNEL, CONF_ID
 from .. import Mcp4461Component, CONF_MCP4461_ID, mcp4461_ns
 
 DEPENDENCIES = ["mcp4461"]
@@ -31,7 +31,6 @@ CONFIG_SCHEMA = output.FLOAT_OUTPUT_SCHEMA.extend(
         cv.GenerateID(CONF_MCP4461_ID): cv.use_id(Mcp4461Component),
         cv.Required(CONF_CHANNEL): cv.enum(CHANNEL_OPTIONS, upper=True),
         cv.Optional(CONF_ENABLE, default=True): cv.boolean,
-        cv.Optional(CONF_INITIAL_VALUE): cv.float_range(min=0.000, max=1.0),
         cv.Optional(CONF_TERMINAL_A, default=True): cv.boolean,
         cv.Optional(CONF_TERMINAL_B, default=True): cv.boolean,
         cv.Optional(CONF_TERMINAL_W, default=True): cv.boolean,
@@ -52,5 +51,3 @@ async def to_code(config):
         config[CONF_TERMINAL_W],
     )
     await output.register_output(var, config)
-    initial_value = await cg.get_variable(config[CONF_INITIAL_VALUE])
-    cg.add(var.set_initial_value(initial_value))

--- a/esphome/components/mcp4461/output/__init__.py
+++ b/esphome/components/mcp4461/output/__init__.py
@@ -1,0 +1,58 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import output
+from esphome.const import CONF_CHANNEL, CONF_ID, CONF_INITIAL_VALUE
+from .. import Mcp4461Component, CONF_MCP4461_ID, mcp4461_ns
+
+DEPENDENCIES = ["mcp4461"]
+
+Mcp4461Wiper = mcp4461_ns.class_("Mcp4461Wiper", output.FloatOutput)
+
+MCP4461WiperIdx = mcp4461_ns.enum("MCP4461WiperIdx")
+CHANNEL_OPTIONS = {
+    "A": MCP4461WiperIdx.MCP4461_WIPER_0,
+    "B": MCP4461WiperIdx.MCP4461_WIPER_1,
+    "C": MCP4461WiperIdx.MCP4461_WIPER_2,
+    "D": MCP4461WiperIdx.MCP4461_WIPER_3,
+    "E": MCP4461WiperIdx.MCP4461_WIPER_4,
+    "F": MCP4461WiperIdx.MCP4461_WIPER_5,
+    "G": MCP4461WiperIdx.MCP4461_WIPER_6,
+    "H": MCP4461WiperIdx.MCP4461_WIPER_7,
+}
+
+CONF_ENABLE = "enable"
+CONF_AUTOSAVE = "autosave"
+CONF_TERMINAL_A = "terminal_a"
+CONF_TERMINAL_B = "terminal_b"
+CONF_TERMINAL_W = "terminal_w"
+
+CONFIG_SCHEMA = output.FLOAT_OUTPUT_SCHEMA.extend(
+    {
+        cv.Required(CONF_ID): cv.declare_id(Mcp4461Wiper),
+        cv.GenerateID(CONF_MCP4461_ID): cv.use_id(Mcp4461Component),
+        cv.Required(CONF_CHANNEL): cv.enum(CHANNEL_OPTIONS, upper=True),
+        cv.Optional(CONF_ENABLE, default=True): cv.boolean,
+        cv.Optional(CONF_INITIAL_VALUE, default=1.0): cv.float_range(
+            min=0.001, max=0.256
+        ),
+        cv.Optional(CONF_TERMINAL_A, default=True): cv.boolean,
+        cv.Optional(CONF_TERMINAL_B, default=True): cv.boolean,
+        cv.Optional(CONF_TERMINAL_W, default=True): cv.boolean,
+    }
+)
+
+
+async def to_code(config):
+    parent = await cg.get_variable(config[CONF_MCP4461_ID])
+    var = cg.new_Pvariable(
+        config[CONF_ID],
+        parent,
+        config[CONF_CHANNEL],
+        config[CONF_ENABLE],
+        config[CONF_TERMINAL_A],
+        config[CONF_TERMINAL_B],
+        config[CONF_TERMINAL_W],
+    )
+    await output.register_output(var, config)
+
+    cg.add(var.set_initial_value(config[CONF_INITIAL_VALUE]))

--- a/esphome/components/mcp4461/output/__init__.py
+++ b/esphome/components/mcp4461/output/__init__.py
@@ -21,7 +21,6 @@ CHANNEL_OPTIONS = {
 }
 
 CONF_ENABLE = "enable"
-CONF_AUTOSAVE = "autosave"
 CONF_TERMINAL_A = "terminal_a"
 CONF_TERMINAL_B = "terminal_b"
 CONF_TERMINAL_W = "terminal_w"

--- a/esphome/components/mcp4461/output/__init__.py
+++ b/esphome/components/mcp4461/output/__init__.py
@@ -46,6 +46,7 @@ async def to_code(config):
         parent,
         config[CONF_CHANNEL],
         config[CONF_ENABLE],
+        config[CONF_INITIAL_VALUE],
         config[CONF_TERMINAL_A],
         config[CONF_TERMINAL_B],
         config[CONF_TERMINAL_W],

--- a/esphome/components/mcp4461/output/__init__.py
+++ b/esphome/components/mcp4461/output/__init__.py
@@ -52,5 +52,5 @@ async def to_code(config):
         config[CONF_TERMINAL_W],
     )
     await output.register_output(var, config)
-
-    cg.add(var.set_initial_value(config[CONF_INITIAL_VALUE]))
+    initial_value = await cg.get_variable(config[CONF_INITIAL_VALUE])
+    cg.add(var.set_initial_value(initial_value))

--- a/esphome/components/mcp4461/output/__init__.py
+++ b/esphome/components/mcp4461/output/__init__.py
@@ -31,7 +31,7 @@ CONFIG_SCHEMA = output.FLOAT_OUTPUT_SCHEMA.extend(
         cv.GenerateID(CONF_MCP4461_ID): cv.use_id(Mcp4461Component),
         cv.Required(CONF_CHANNEL): cv.enum(CHANNEL_OPTIONS, upper=True),
         cv.Optional(CONF_ENABLE, default=True): cv.boolean,
-        cv.Optional(CONF_INITIAL_VALUE, default=1.0): cv.float_range(
+        cv.Optional(CONF_INITIAL_VALUE): cv.float_range(
             min=0.000, max=0.256
         ),
         cv.Optional(CONF_TERMINAL_A, default=True): cv.boolean,

--- a/esphome/components/mcp4461/output/mcp4461_output.cpp
+++ b/esphome/components/mcp4461/output/mcp4461_output.cpp
@@ -21,18 +21,18 @@ void Mcp4461Wiper::write_state(float state) {
   taps = static_cast<uint16_t>(state);
   ESP_LOGV(TAG, "Setting wiper %d to value %d", this->wiper_, taps);
   this->state_ = state;
-  this->parent_->set_wiper_level_(this->wiper_, taps);
+  this->parent_->set_wiper_level(this->wiper_, taps);
 }
 
-uint16_t Mcp4461Wiper::get_wiper_level() { return this->parent_->get_wiper_level_(this->wiper_); }
+uint16_t Mcp4461Wiper::get_wiper_level() { return this->parent_->get_wiper_level(this->wiper_); }
 
 void Mcp4461Wiper::save_level() {
   if (this->wiper_ > 3) {
     ESP_LOGW(TAG, "Cannot save level for nonvolatile wiper %d !", this->wiper_);
     return;
   }
-  uint8_t volatile_wiper = this->wiper_ + 4;
-  this->parent_->set_wiper_level_(volatile_wiper, this->state_);
+  uint8_t nonvolatile_wiper = this->wiper_ + 4;
+  this->parent_->set_wiper_level(nonvolatile_wiper, this->state_);
 }
 
 void Mcp4461Wiper::enable_wiper() {
@@ -40,7 +40,7 @@ void Mcp4461Wiper::enable_wiper() {
     ESP_LOGW(TAG, "Cannot enable nonvolatile wiper %d !", this->wiper_);
     return;
   }
-  this->parent_->enable_wiper_(this->wiper_);
+  this->parent_->enable_wiper(this->wiper_);
 }
 
 void Mcp4461Wiper::disable_wiper() {
@@ -48,7 +48,7 @@ void Mcp4461Wiper::disable_wiper() {
     ESP_LOGW(TAG, "Cannot disable nonvolatile wiper %d !", this->wiper_);
     return;
   }
-  this->parent_->disable_wiper_(this->wiper_);
+  this->parent_->disable_wiper(this->wiper_);
 }
 
 void Mcp4461Wiper::increase_wiper() {
@@ -56,7 +56,7 @@ void Mcp4461Wiper::increase_wiper() {
     ESP_LOGW(TAG, "Cannot increase nonvolatile wiper %d !", this->wiper_);
     return;
   }
-  this->parent_->increase_wiper_(this->wiper_);
+  this->parent_->increase_wiper(this->wiper_);
 }
 
 void Mcp4461Wiper::decrease_wiper() {
@@ -64,7 +64,7 @@ void Mcp4461Wiper::decrease_wiper() {
     ESP_LOGW(TAG, "Cannot decrease nonvolatile wiper %d !", this->wiper_);
     return;
   }
-  this->parent_->decrease_wiper_(this->wiper_);
+  this->parent_->decrease_wiper(this->wiper_);
 }
 
 void Mcp4461Wiper::enable_terminal(char terminal) {
@@ -72,7 +72,7 @@ void Mcp4461Wiper::enable_terminal(char terminal) {
     ESP_LOGW(TAG, "Cannot get/set terminals nonvolatile wiper %d !", this->wiper_);
     return;
   }
-  this->parent_->enable_terminal_(this->wiper_, terminal);
+  this->parent_->enable_terminal(this->wiper_, terminal);
 }
 
 void Mcp4461Wiper::disable_terminal(char terminal) {
@@ -80,7 +80,7 @@ void Mcp4461Wiper::disable_terminal(char terminal) {
     ESP_LOGW(TAG, "Cannot get/set terminals for nonvolatile wiper %d !", this->wiper_);
     return;
   }
-  this->parent_->disable_terminal_(this->wiper_, terminal);
+  this->parent_->disable_terminal(this->wiper_, terminal);
 }
 
 }  // namespace mcp4461

--- a/esphome/components/mcp4461/output/mcp4461_output.cpp
+++ b/esphome/components/mcp4461/output/mcp4461_output.cpp
@@ -15,7 +15,6 @@ void Mcp4461Wiper::write_state(float state) {
   state = state * 1000.0;
   if (state > max_taps) {
     ESP_LOGW(TAG, "Cannot set taps > 0.256 for wiper %d, clamping to 0.256!", this->wiper_);
-    return;
     state = 256.0;
   }
   uint16_t taps;

--- a/esphome/components/mcp4461/output/mcp4461_output.cpp
+++ b/esphome/components/mcp4461/output/mcp4461_output.cpp
@@ -1,0 +1,86 @@
+#include "mcp4461_output.h"
+#include <cmath>
+
+#include "esphome/core/helpers.h"
+#include "esphome/core/log.h"
+
+namespace esphome {
+namespace mcp4461 {
+
+static const char *const TAG = "mcp4461";
+
+void Mcp4461Wiper::write_state(float state) {
+  ESP_LOGV(TAG, "Got value %02f from frontend", state);
+  const float max_taps = 256.0;
+  state = state * 1000.0;
+  if (state > max_taps) {
+    state = 256.0;
+  }
+  uint16_t taps;
+  taps = static_cast<uint16_t>(state);
+  ESP_LOGV(TAG, "Setting wiper %d to value %d", this->wiper_, taps);
+  this->state_ = state;
+  this->parent_->set_wiper_level_(this->wiper_, taps);
+}
+
+uint16_t Mcp4461Wiper::get_wiper_level() { return this->parent_->get_wiper_level_(this->wiper_); }
+
+void Mcp4461Wiper::save_level() {
+  if (this->wiper_ > 3) {
+    ESP_LOGW(TAG, "Cannot save level for nonvolatile wiper %d !", this->wiper_);
+    return;
+  }
+  uint8_t volatile_wiper = this->wiper_ + 4;
+  this->parent_->set_wiper_level_(volatile_wiper, this->state_);
+}
+
+void Mcp4461Wiper::enable_wiper() {
+  if (this->wiper_ > 3) {
+    ESP_LOGW(TAG, "Cannot enable nonvolatile wiper %d !", this->wiper_);
+    return;
+  }
+  this->parent_->enable_wiper_(this->wiper_);
+}
+
+void Mcp4461Wiper::disable_wiper() {
+  if (this->wiper_ > 3) {
+    ESP_LOGW(TAG, "Cannot disable nonvolatile wiper %d !", this->wiper_);
+    return;
+  }
+  this->parent_->disable_wiper_(this->wiper_);
+}
+
+void Mcp4461Wiper::increase_wiper() {
+  if (this->wiper_ > 3) {
+    ESP_LOGW(TAG, "Cannot increase nonvolatile wiper %d !", this->wiper_);
+    return;
+  }
+  this->parent_->increase_wiper_(this->wiper_);
+}
+
+void Mcp4461Wiper::decrease_wiper() {
+  if (this->wiper_ > 3) {
+    ESP_LOGW(TAG, "Cannot decrease nonvolatile wiper %d !", this->wiper_);
+    return;
+  }
+  this->parent_->decrease_wiper_(this->wiper_);
+}
+
+void Mcp4461Wiper::enable_terminal(char terminal) {
+  if (this->wiper_ > 3) {
+    ESP_LOGW(TAG, "Cannot get/set terminals nonvolatile wiper %d !", this->wiper_);
+    return;
+  }
+  this->parent_->enable_terminal_(this->wiper_, terminal);
+}
+
+void Mcp4461Wiper::disable_terminal(char terminal) {
+  if (this->wiper_ > 3) {
+    ESP_LOGW(TAG, "Cannot get/set terminals for nonvolatile wiper %d !", this->wiper_);
+    return;
+  }
+  this->parent_->disable_terminal_(this->wiper_, terminal);
+}
+
+}  // namespace mcp4461
+}  // namespace esphome

--- a/esphome/components/mcp4461/output/mcp4461_output.cpp
+++ b/esphome/components/mcp4461/output/mcp4461_output.cpp
@@ -14,6 +14,8 @@ void Mcp4461Wiper::write_state(float state) {
   const float max_taps = 256.0;
   state = state * 1000.0;
   if (state > max_taps) {
+    ESP_LOGW(TAG, "Cannot set taps > 0.256 for wiper %d, clamping to 0.256!", this->wiper_);
+    return;
     state = 256.0;
   }
   uint16_t taps;

--- a/esphome/components/mcp4461/output/mcp4461_output.h
+++ b/esphome/components/mcp4461/output/mcp4461_output.h
@@ -44,7 +44,6 @@ class Mcp4461Wiper : public output::FloatOutput {
   Mcp4461Component *parent_;
   MCP4461WiperIdx wiper_;
   bool enable_;
-  uint16_t initial_state_;
   uint16_t state_;
   bool terminal_a_;
   bool terminal_b_;

--- a/esphome/components/mcp4461/output/mcp4461_output.h
+++ b/esphome/components/mcp4461/output/mcp4461_output.h
@@ -1,0 +1,55 @@
+#pragma once
+
+#include "../mcp4461.h"
+#include "esphome/core/component.h"
+#include "esphome/components/output/float_output.h"
+#include "esphome/components/i2c/i2c.h"
+
+namespace esphome {
+namespace mcp4461 {
+
+class Mcp4461Wiper : public output::FloatOutput {
+ public:
+  Mcp4461Wiper(Mcp4461Component *parent, MCP4461WiperIdx wiper, bool enable, bool terminal_a, bool terminal_b,
+               bool terminal_w)
+      : parent_(parent),
+        wiper_(wiper),
+        enable_(enable),
+        terminal_a_(terminal_a),
+        terminal_b_(terminal_b),
+        terminal_w_(terminal_w) {
+    // update wiper connection state
+    if (!enable && wiper < 4) {
+      parent->reg_[wiper].enabled = false;
+      parent->disable_terminal_(wiper, 'h');
+    }
+    if (!terminal_a && wiper < 4)
+      parent->disable_terminal_(wiper, 'a');
+    if (!terminal_b && wiper < 4)
+      parent->disable_terminal_(wiper, 'b');
+    if (!terminal_w && wiper < 4)
+      parent->disable_terminal_(wiper, 'w');
+  }
+  uint16_t get_wiper_level();
+  void save_level();
+  void enable_wiper();
+  void disable_wiper();
+  void increase_wiper();
+  void decrease_wiper();
+  void enable_terminal(char terminal);
+  void disable_terminal(char terminal);
+
+ protected:
+  void write_state(float state) override;
+  Mcp4461Component *parent_;
+  MCP4461WiperIdx wiper_;
+  bool enable_;
+  uint16_t initial_state_;
+  uint16_t state_;
+  bool terminal_a_;
+  bool terminal_b_;
+  bool terminal_w_;
+};
+
+}  // namespace mcp4461
+}  // namespace esphome

--- a/esphome/components/mcp4461/output/mcp4461_output.h
+++ b/esphome/components/mcp4461/output/mcp4461_output.h
@@ -21,14 +21,14 @@ class Mcp4461Wiper : public output::FloatOutput {
     // update wiper connection state
     if (!enable && wiper < 4) {
       parent->reg_[wiper].enabled = false;
-      parent->disable_terminal_(wiper, 'h');
+      parent->disable_terminal(wiper, 'h');
     }
     if (!terminal_a && wiper < 4)
-      parent->disable_terminal_(wiper, 'a');
+      parent->disable_terminal(wiper, 'a');
     if (!terminal_b && wiper < 4)
-      parent->disable_terminal_(wiper, 'b');
+      parent->disable_terminal(wiper, 'b');
     if (!terminal_w && wiper < 4)
-      parent->disable_terminal_(wiper, 'w');
+      parent->disable_terminal(wiper, 'w');
   }
   uint16_t get_wiper_level();
   void save_level();

--- a/tests/components/mcp4461/test.esp32-ard.yaml
+++ b/tests/components/mcp4461/test.esp32-ard.yaml
@@ -5,23 +5,23 @@ i2c:
 
 mcp4461:
   - id: mcp4461_digipot_01
-    
+
 output:
   - platform: mcp4461
     id: digipot_wiper_1
     mcp4461_id: mcp4461_digipot_01
     channel: A
-  
+
   - platform: mcp4461
     id: digipot_wiper_2
     mcp4461_id: mcp4461_digipot_01
     channel: B
-    
+
   - platform: mcp4461
     id: digipot_wiper_3
     mcp4461_id: mcp4461_digipot_01
     channel: C
-    
+
   - platform: mcp4461
     id: digipot_wiper_4
     mcp4461_id: mcp4461_digipot_01

--- a/tests/components/mcp4461/test.esp32-ard.yaml
+++ b/tests/components/mcp4461/test.esp32-ard.yaml
@@ -1,0 +1,28 @@
+i2c:
+  - id: i2c_mcp4461
+    sda: 16
+    scl: 17
+
+mcp4461:
+  - id: mcp4461_digipot_01
+    
+output:
+  - platform: mcp4461
+    id: digipot_wiper_1
+    mcp4461_id: mcp4461_digipot_01
+    channel: A
+  
+  - platform: mcp4461
+    id: digipot_wiper_2
+    mcp4461_id: mcp4461_digipot_01
+    channel: B
+    
+  - platform: mcp4461
+    id: digipot_wiper_3
+    mcp4461_id: mcp4461_digipot_01
+    channel: C
+    
+  - platform: mcp4461
+    id: digipot_wiper_4
+    mcp4461_id: mcp4461_digipot_01
+    channel: D

--- a/tests/components/mcp4461/test.esp32-c3-ard.yaml
+++ b/tests/components/mcp4461/test.esp32-c3-ard.yaml
@@ -1,0 +1,28 @@
+i2c:
+  - id: i2c_mcp4461
+    sda: 4
+    scl: 5
+
+mcp4461:
+  - id: mcp4461_digipot_01
+    
+output:
+  - platform: mcp4461
+    id: digipot_wiper_1
+    mcp4461_id: mcp4461_digipot_01
+    channel: A
+  
+  - platform: mcp4461
+    id: digipot_wiper_2
+    mcp4461_id: mcp4461_digipot_01
+    channel: B
+    
+  - platform: mcp4461
+    id: digipot_wiper_3
+    mcp4461_id: mcp4461_digipot_01
+    channel: C
+    
+  - platform: mcp4461
+    id: digipot_wiper_4
+    mcp4461_id: mcp4461_digipot_01
+    channel: D

--- a/tests/components/mcp4461/test.esp32-c3-ard.yaml
+++ b/tests/components/mcp4461/test.esp32-c3-ard.yaml
@@ -5,23 +5,23 @@ i2c:
 
 mcp4461:
   - id: mcp4461_digipot_01
-    
+
 output:
   - platform: mcp4461
     id: digipot_wiper_1
     mcp4461_id: mcp4461_digipot_01
     channel: A
-  
+
   - platform: mcp4461
     id: digipot_wiper_2
     mcp4461_id: mcp4461_digipot_01
     channel: B
-    
+
   - platform: mcp4461
     id: digipot_wiper_3
     mcp4461_id: mcp4461_digipot_01
     channel: C
-    
+
   - platform: mcp4461
     id: digipot_wiper_4
     mcp4461_id: mcp4461_digipot_01

--- a/tests/components/mcp4461/test.esp32-c3-idf.yaml
+++ b/tests/components/mcp4461/test.esp32-c3-idf.yaml
@@ -1,0 +1,28 @@
+i2c:
+  - id: i2c_mcp4461
+    sda: 4
+    scl: 5
+
+mcp4461:
+  - id: mcp4461_digipot_01
+    
+output:
+  - platform: mcp4461
+    id: digipot_wiper_1
+    mcp4461_id: mcp4461_digipot_01
+    channel: A
+  
+  - platform: mcp4461
+    id: digipot_wiper_2
+    mcp4461_id: mcp4461_digipot_01
+    channel: B
+    
+  - platform: mcp4461
+    id: digipot_wiper_3
+    mcp4461_id: mcp4461_digipot_01
+    channel: C
+    
+  - platform: mcp4461
+    id: digipot_wiper_4
+    mcp4461_id: mcp4461_digipot_01
+    channel: D

--- a/tests/components/mcp4461/test.esp32-c3-idf.yaml
+++ b/tests/components/mcp4461/test.esp32-c3-idf.yaml
@@ -5,7 +5,7 @@ i2c:
 
 mcp4461:
   - id: mcp4461_digipot_01
-    
+
 output:
   - platform: mcp4461
     id: digipot_wiper_1
@@ -16,12 +16,12 @@ output:
     id: digipot_wiper_2
     mcp4461_id: mcp4461_digipot_01
     channel: B
-    
+
   - platform: mcp4461
     id: digipot_wiper_3
     mcp4461_id: mcp4461_digipot_01
     channel: C
-    
+
   - platform: mcp4461
     id: digipot_wiper_4
     mcp4461_id: mcp4461_digipot_01

--- a/tests/components/mcp4461/test.esp32-c3-idf.yaml
+++ b/tests/components/mcp4461/test.esp32-c3-idf.yaml
@@ -11,7 +11,7 @@ output:
     id: digipot_wiper_1
     mcp4461_id: mcp4461_digipot_01
     channel: A
-  
+
   - platform: mcp4461
     id: digipot_wiper_2
     mcp4461_id: mcp4461_digipot_01

--- a/tests/components/mcp4461/test.esp32-idf.yaml
+++ b/tests/components/mcp4461/test.esp32-idf.yaml
@@ -5,23 +5,23 @@ i2c:
 
 mcp4461:
   - id: mcp4461_digipot_01
-    
+
 output:
   - platform: mcp4461
     id: digipot_wiper_1
     mcp4461_id: mcp4461_digipot_01
     channel: A
-  
+
   - platform: mcp4461
     id: digipot_wiper_2
     mcp4461_id: mcp4461_digipot_01
     channel: B
-    
+
   - platform: mcp4461
     id: digipot_wiper_3
     mcp4461_id: mcp4461_digipot_01
     channel: C
-    
+
   - platform: mcp4461
     id: digipot_wiper_4
     mcp4461_id: mcp4461_digipot_01

--- a/tests/components/mcp4461/test.esp32-idf.yaml
+++ b/tests/components/mcp4461/test.esp32-idf.yaml
@@ -1,0 +1,28 @@
+i2c:
+  - id: i2c_mcp4461
+    sda: 16
+    scl: 17
+
+mcp4461:
+  - id: mcp4461_digipot_01
+    
+output:
+  - platform: mcp4461
+    id: digipot_wiper_1
+    mcp4461_id: mcp4461_digipot_01
+    channel: A
+  
+  - platform: mcp4461
+    id: digipot_wiper_2
+    mcp4461_id: mcp4461_digipot_01
+    channel: B
+    
+  - platform: mcp4461
+    id: digipot_wiper_3
+    mcp4461_id: mcp4461_digipot_01
+    channel: C
+    
+  - platform: mcp4461
+    id: digipot_wiper_4
+    mcp4461_id: mcp4461_digipot_01
+    channel: D

--- a/tests/components/mcp4461/test.esp8266-ard.yaml
+++ b/tests/components/mcp4461/test.esp8266-ard.yaml
@@ -1,0 +1,28 @@
+i2c:
+  - id: i2c_mcp4461
+    sda: 4
+    scl: 5
+
+mcp4461:
+  - id: mcp4461_digipot_01
+    
+output:
+  - platform: mcp4461
+    id: digipot_wiper_1
+    mcp4461_id: mcp4461_digipot_01
+    channel: A
+  
+  - platform: mcp4461
+    id: digipot_wiper_2
+    mcp4461_id: mcp4461_digipot_01
+    channel: B
+    
+  - platform: mcp4461
+    id: digipot_wiper_3
+    mcp4461_id: mcp4461_digipot_01
+    channel: C
+    
+  - platform: mcp4461
+    id: digipot_wiper_4
+    mcp4461_id: mcp4461_digipot_01
+    channel: D

--- a/tests/components/mcp4461/test.esp8266-ard.yaml
+++ b/tests/components/mcp4461/test.esp8266-ard.yaml
@@ -5,23 +5,23 @@ i2c:
 
 mcp4461:
   - id: mcp4461_digipot_01
-    
+
 output:
   - platform: mcp4461
     id: digipot_wiper_1
     mcp4461_id: mcp4461_digipot_01
     channel: A
-  
+
   - platform: mcp4461
     id: digipot_wiper_2
     mcp4461_id: mcp4461_digipot_01
     channel: B
-    
+
   - platform: mcp4461
     id: digipot_wiper_3
     mcp4461_id: mcp4461_digipot_01
     channel: C
-    
+
   - platform: mcp4461
     id: digipot_wiper_4
     mcp4461_id: mcp4461_digipot_01


### PR DESCRIPTION
# What does this implement/fix?

Support for MCP4461 Quad I2C Digipot/Rheostat with EEPRom

https://ww1.microchip.com/downloads/aemDocuments/documents/OTH/ProductDocuments/DataSheets/22265a.pdf
Supports 100kHz, 400khZ, 1.7MHz & 3.4MHz frequencies & has two address pins (up to four devices on single bus)

Tested with 4 devices on single bus @400kHz on Wemos D1 Mini & NodeMCU-S32s (ESP32/ESP-IDF) so far

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**


**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#4632

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
esphome:
  on_boot:
    priority: 100
    then:
      - number.set:
          id: digipot_volatile_0
          value: !lambda |-
            return id(digipot_wiper_0).get_wiper_level();
       - number.set:
          id: digipot_nonvolatile_0
          value: !lambda |-
            return id(digipot_nonvolatile_wiper_0).get_wiper_level();

  mcp4461:
  - id: mcp4461_output_01
    address: 0x2C
    
 output:
  - platform: mcp4461
    id: digipot_wiper_0
    mcp4461_id: mcp4461_output_01
    channel: A
  
  - platform: mcp4461
    id: digipot_nonvolatile_wiper_0
    mcp4461_id: mcp4461_output_01
    channel: E

number:
  - platform: template
    name: "Digipot 1 Volatile"
    id: digipot_volatile_0
    optimistic: True
    min_value: 0
    max_value: 256
    step: 1
    set_action: 
      then:
        - output.set_level: 
            id: digipot_wiper_0
            level: !lambda return static_cast<float>(x / 1000);

  - platform: template
    name: "Digipot 1 Nonvolatile"
    id: digipot_nonvolatile_0
    optimistic: True
    min_value: 0
    max_value: 256
    step: 1
    set_action: 
      then:
        - output.set_level: 
            id: digipot_nonvolatile_wiper_0
            level: !lambda return static_cast<float>(x / 1000);

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
