### PR TITLE
[i2c] Workaround for i2c on s2

### DIFF
--- a/esphome/components/i2c/i2c_bus_esp_idf.cpp
+++ b/esphome/components/i2c/i2c_bus_esp_idf.cpp
@@ -33,6 +33,17 @@ void IDFI2CBus::setup() {
 
   i2c_config_t conf{};
   memset(&conf, 0, sizeof(conf));
+#ifdef USE_ESP32_VARIANT_ESP32S2
+  // workaround for issue #6718, i2c_param_config doesn't set the clock source in
+  // master mode, timings are programmed for APB but it uses the REF_TICK clock, set
+  // slave mode first to set the clock source then switch to master mode
+  conf.mode = I2C_MODE_SLAVE;
+  conf.sda_io_num = sda_pin_;
+  conf.sda_pullup_en = sda_pullup_enabled_;
+  conf.scl_io_num = scl_pin_;
+  conf.scl_pullup_en = scl_pullup_enabled_;
+  i2c_param_config(port_, &conf);
+#endif
   conf.mode = I2C_MODE_MASTER;
   conf.sda_io_num = sda_pin_;
   conf.sda_pullup_en = sda_pullup_enabled_;

--- a/esphome/components/i2c/i2c_bus_esp_idf.cpp
+++ b/esphome/components/i2c/i2c_bus_esp_idf.cpp
@@ -8,10 +8,6 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-#ifdef USE_ESP32_VARIANT_ESP32S2
-#include <soc/i2c_struct.h>
-#endif
-
 namespace esphome {
 namespace i2c {
 
@@ -43,20 +39,16 @@ void IDFI2CBus::setup() {
   conf.scl_io_num = scl_pin_;
   conf.scl_pullup_en = scl_pullup_enabled_;
   conf.master.clk_speed = frequency_;
+#ifdef USE_ESP32_VARIANT_ESP32S2
+  // workaround for issue #6718, have to use ref clock
+  conf.clk_flags = I2C_SCLK_SRC_FLAG_AWARE_DFS;
+#endif
   esp_err_t err = i2c_param_config(port_, &conf);
   if (err != ESP_OK) {
     ESP_LOGW(TAG, "i2c_param_config failed: %s", esp_err_to_name(err));
     this->mark_failed();
     return;
   }
-#ifdef USE_ESP32_VARIANT_ESP32S2
-  // workaround for issue #6718, i2c_param_config doesn't set the clock source
-  if (port_ == I2C_NUM_0) {
-    I2C0.ctr.ref_always_on = 1;
-  } else {
-    I2C1.ctr.ref_always_on = 1;
-  }
-#endif
   if (timeout_ > 0) {  // if timeout specified in yaml:
     if (timeout_ > 13000) {
       ESP_LOGW(TAG, "i2c timeout of %" PRIu32 "us greater than max of 13ms on esp-idf, setting to max", timeout_);

--- a/esphome/components/i2c/i2c_bus_esp_idf.cpp
+++ b/esphome/components/i2c/i2c_bus_esp_idf.cpp
@@ -35,8 +35,9 @@ void IDFI2CBus::setup() {
   memset(&conf, 0, sizeof(conf));
 #ifdef USE_ESP32_VARIANT_ESP32S2
   // workaround for issue #6718, i2c_param_config doesn't set the clock source in
-  // master mode, timings are programmed for APB but it uses the REF_TICK clock, set
-  // slave mode first to set the clock source then switch to master mode
+  // I2C_MODE_MASTER, timings are programmed for APB but it uses the REF_TICK clock
+  // by default, set I2C_MODE_SLAVE first to set the clock source then switch to
+  // I2C_MODE_MASTER mode
   conf.mode = I2C_MODE_SLAVE;
   conf.sda_io_num = sda_pin_;
   conf.sda_pullup_en = sda_pullup_enabled_;

--- a/esphome/components/i2c/i2c_bus_esp_idf.cpp
+++ b/esphome/components/i2c/i2c_bus_esp_idf.cpp
@@ -8,6 +8,10 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
+#ifdef USE_ESP32_VARIANT_ESP32S2
+#include <soc/i2c_struct.h>
+#endif
+
 namespace esphome {
 namespace i2c {
 
@@ -33,18 +37,6 @@ void IDFI2CBus::setup() {
 
   i2c_config_t conf{};
   memset(&conf, 0, sizeof(conf));
-#ifdef USE_ESP32_VARIANT_ESP32S2
-  // workaround for issue #6718, i2c_param_config doesn't set the clock source in
-  // I2C_MODE_MASTER, timings are programmed for APB but it uses the REF_TICK clock
-  // by default, set I2C_MODE_SLAVE first to set the clock source then switch to
-  // I2C_MODE_MASTER mode
-  conf.mode = I2C_MODE_SLAVE;
-  conf.sda_io_num = sda_pin_;
-  conf.sda_pullup_en = sda_pullup_enabled_;
-  conf.scl_io_num = scl_pin_;
-  conf.scl_pullup_en = scl_pullup_enabled_;
-  i2c_param_config(port_, &conf);
-#endif
   conf.mode = I2C_MODE_MASTER;
   conf.sda_io_num = sda_pin_;
   conf.sda_pullup_en = sda_pullup_enabled_;
@@ -57,6 +49,14 @@ void IDFI2CBus::setup() {
     this->mark_failed();
     return;
   }
+#ifdef USE_ESP32_VARIANT_ESP32S2
+  // workaround for issue #6718, i2c_param_config doesn't set the clock source
+  if (port_ == I2C_NUM_0) {
+    I2C0.ctr.ref_always_on = 1;
+  } else {
+    I2C1.ctr.ref_always_on = 1;
+  }
+#endif
   if (timeout_ > 0) {  // if timeout specified in yaml:
     if (timeout_ > 13000) {
       ESP_LOGW(TAG, "i2c timeout of %" PRIu32 "us greater than max of 13ms on esp-idf, setting to max", timeout_);

--- a/esphome/components/i2c/i2c_bus_esp_idf.cpp
+++ b/esphome/components/i2c/i2c_bus_esp_idf.cpp
@@ -40,7 +40,7 @@ void IDFI2CBus::setup() {
   conf.scl_pullup_en = scl_pullup_enabled_;
   conf.master.clk_speed = frequency_;
 #ifdef USE_ESP32_VARIANT_ESP32S2
-  // workaround for issue #6718, have to use ref clock
+  // workaround for https://github.com/esphome/issues/issues/6718
   conf.clk_flags = I2C_SCLK_SRC_FLAG_AWARE_DFS;
 #endif
   esp_err_t err = i2c_param_config(port_, &conf);


### PR DESCRIPTION
# What does this implement/fix?

Workaround for issue https://github.com/esphome/issues/issues/6718, have to use ref clock, unfortunately the max frequency this will support is 50khz.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/issues/issues/6718

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
