### PR TITLE
added deep sleep check for partial updates to inkplate6

### DIFF
--- a/esphome/components/inkplate6/inkplate.cpp
+++ b/esphome/components/inkplate6/inkplate.cpp
@@ -65,6 +65,13 @@ void Inkplate6::initialize_() {
   if (buffer_size == 0)
     return;
 
+  // check if we came out of deep sleep
+  int resetInfo = esp_sleep_get_wakeup_cause();
+  if (resetInfo >= 1) {
+    ESP_LOGD(TAG, "Woke up from deep sleep, disabling full refresh by turning off partial update blocking by default");
+    this->block_partial_ = false;
+  }
+
   if (this->partial_buffer_ != nullptr)
     allocator.deallocate(this->partial_buffer_, buffer_size);
   if (this->partial_buffer_2_ != nullptr)


### PR DESCRIPTION
partial updates now work by overriding the block if we are waking up from a deep sleep.

this simple check will identify when wakeup is from a deep sleep, and using the block_partial bool, allow the display to resume where it left off. 

Albeit, the user will have to configure the default page to be no updates, and force an update with the desired page after all objects are synced from sources and trigger a page update.

Note all the counters an all state will still reset on wakeup, so the user will have to manage at a lower level to force a full refresh when desired, perhaps using home assistant to decide when this should occur.

no direct issue opened, but similar to the feature request https://github.com/esphome/feature-requests/issues/1555

# What does this implement/fix?
allow deep sleep wakeup to avoid full display refresh, if configured for partial updates

<!-- Quick description and explanation of changes -->

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

https://github.com/esphome/feature-requests/issues/3043

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

deep_sleep:
  run_duration: 1min
  id: deep_sleep_1
  sleep_duration: 10s

display:
  - platform: inkplate6
    id: inkplate_display
    model: inkplate_10
    greyscale: False
    partial_updating: True
    auto_clear_enabled: False
    update_interval: never
    #update_interval: 1min
    # must manually trigger full updates
    full_update_every: 0
    #full_update_every: 480

    ckv_pin: 32
    sph_pin: 33
    gmod_pin:
      pca6416a: pca6416a_hub
      number: 1
    gpio0_enable_pin:
      pca6416a: pca6416a_hub
      number: 8
    oe_pin:
      pca6416a: pca6416a_hub
      number: 0
    spv_pin:
      pca6416a: pca6416a_hub
      number: 2
    powerup_pin:
      pca6416a: pca6416a_hub
      number: 4
    wakeup_pin:
      pca6416a: pca6416a_hub
      number: 3
    vcom_pin:
      pca6416a: pca6416a_hub
      number: 5
    pages:
      - id: page1
        lambda: |-
        // your code here
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
