### PR TITLE
[preferences] Better handling of flash_write_interval

### DIFF
--- a/esphome/components/preferences/__init__.py
+++ b/esphome/components/preferences/__init__.py
@@ -1,6 +1,7 @@
-from esphome.const import CONF_ID
 import esphome.codegen as cg
 import esphome.config_validation as cv
+from esphome.const import CONF_ID
+from esphome.core import TimePeriod
 
 CODEOWNERS = ["@esphome/core"]
 
@@ -11,9 +12,9 @@ CONF_FLASH_WRITE_INTERVAL = "flash_write_interval"
 CONFIG_SCHEMA = cv.Schema(
     {
         cv.GenerateID(): cv.declare_id(IntervalSyncer),
-        cv.Optional(
-            CONF_FLASH_WRITE_INTERVAL, default="60s"
-        ): cv.positive_time_period_milliseconds,
+        cv.Optional(CONF_FLASH_WRITE_INTERVAL, default="60s"): cv.All(
+            cv.update_interval, cv.Range(min=TimePeriod(milliseconds=1000))
+        ),
     }
 ).extend(cv.COMPONENT_SCHEMA)
 

--- a/esphome/components/preferences/__init__.py
+++ b/esphome/components/preferences/__init__.py
@@ -1,7 +1,6 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.const import CONF_ID
-from esphome.core import TimePeriod
 
 CODEOWNERS = ["@esphome/core"]
 
@@ -12,9 +11,7 @@ CONF_FLASH_WRITE_INTERVAL = "flash_write_interval"
 CONFIG_SCHEMA = cv.Schema(
     {
         cv.GenerateID(): cv.declare_id(IntervalSyncer),
-        cv.Optional(CONF_FLASH_WRITE_INTERVAL, default="60s"): cv.All(
-            cv.update_interval, cv.Range(min=TimePeriod(milliseconds=1000))
-        ),
+        cv.Optional(CONF_FLASH_WRITE_INTERVAL, default="60s"): cv.update_interval,
     }
 ).extend(cv.COMPONENT_SCHEMA)
 

--- a/esphome/components/preferences/syncer.h
+++ b/esphome/components/preferences/syncer.h
@@ -8,15 +8,22 @@ namespace preferences {
 
 class IntervalSyncer : public Component {
  public:
-  void set_write_interval(uint32_t write_interval) { write_interval_ = write_interval; }
+  void set_write_interval(uint32_t write_interval) { this->write_interval_ = write_interval; }
   void setup() override {
-    set_interval(write_interval_, []() { global_preferences->sync(); });
+    if (this->write_interval_ != 0) {
+      set_interval(this->write_interval_, []() { global_preferences->sync(); });
+    }
+  }
+  void loop() override {
+    if (this->write_interval_ == 0) {
+      global_preferences->sync();
+    }
   }
   void on_shutdown() override { global_preferences->sync(); }
   float get_setup_priority() const override { return setup_priority::BUS; }
 
  protected:
-  uint32_t write_interval_;
+  uint32_t write_interval_{60000};
 };
 
 }  // namespace preferences

--- a/tests/components/preferences/test.esp32-idf.yaml
+++ b/tests/components/preferences/test.esp32-idf.yaml
@@ -1,0 +1,2 @@
+preferences:
+  flash_write_interval: 20s


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Setting `flash_write_interval` to 0 to cause immediate flash writes results in an `interval` call with a period of 0 which will be continually called. Instead, when set to 0, just sync in the `loop()` call.

Also allow `never` as a valid option.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#4642

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
