### PR TITLE
[online_image] Set Accept header

### DIFF
--- a/esphome/components/online_image/online_image.cpp
+++ b/esphome/components/online_image/online_image.cpp
@@ -100,7 +100,27 @@ void OnlineImage::update() {
   }
   ESP_LOGI(TAG, "Updating image %s", this->url_.c_str());
 
-  this->downloader_ = this->parent_->get(this->url_);
+  std::list<http_request::Header> headers = {};
+
+  http_request::Header accept_header;
+  accept_header.name = "Accept";
+  switch (this->format_) {
+    case ImageFormat::BMP:
+      accept_header.value = "image/bmp;q=0.9,*/*;q=0.8";
+      break;
+    case ImageFormat::JPEG:
+      accept_header.value = "image/jpeg;q=0.9,*/*;q=0.8";
+      break;
+    case ImageFormat::PNG:
+      accept_header.value = "image/png;q=0.9,*/*;q=0.8";
+      break;
+    default:
+      accept_header.value = "*/*";
+  }
+
+  headers.push_back(accept_header);
+
+  this->downloader_ = this->parent_->get(this->url_, headers);
 
   if (this->downloader_ == nullptr) {
     ESP_LOGE(TAG, "Download failed.");

--- a/esphome/components/online_image/online_image.cpp
+++ b/esphome/components/online_image/online_image.cpp
@@ -105,15 +105,21 @@ void OnlineImage::update() {
   http_request::Header accept_header;
   accept_header.name = "Accept";
   switch (this->format_) {
+#ifdef USE_ONLINE_IMAGE_BMP_SUPPORT
     case ImageFormat::BMP:
       accept_header.value = "image/bmp;q=0.9,*/*;q=0.8";
       break;
+#endif  // ONLINE_IMAGE_BMP_SUPPORT
+#ifdef USE_ONLINE_IMAGE_JPEG_SUPPORT
     case ImageFormat::JPEG:
       accept_header.value = "image/jpeg;q=0.9,*/*;q=0.8";
       break;
+#endif  // USE_ONLINE_IMAGE_JPEG_SUPPORT
+#ifdef USE_ONLINE_IMAGE_PNG_SUPPORT
     case ImageFormat::PNG:
       accept_header.value = "image/png;q=0.9,*/*;q=0.8";
       break;
+#endif  // ONLINE_IMAGE_PNG_SUPPORT
     default:
       accept_header.value = "*/*";
   }

--- a/esphome/components/online_image/online_image.cpp
+++ b/esphome/components/online_image/online_image.cpp
@@ -104,25 +104,27 @@ void OnlineImage::update() {
 
   http_request::Header accept_header;
   accept_header.name = "Accept";
+  std::string accept_mime_type;
   switch (this->format_) {
 #ifdef USE_ONLINE_IMAGE_BMP_SUPPORT
     case ImageFormat::BMP:
-      accept_header.value = "image/bmp;q=0.9,*/*;q=0.8";
+      accept_mime_type = "image/bmp";
       break;
 #endif  // ONLINE_IMAGE_BMP_SUPPORT
 #ifdef USE_ONLINE_IMAGE_JPEG_SUPPORT
     case ImageFormat::JPEG:
-      accept_header.value = "image/jpeg;q=0.9,*/*;q=0.8";
+      accept_mime_type = "image/jpeg";
       break;
 #endif  // USE_ONLINE_IMAGE_JPEG_SUPPORT
 #ifdef USE_ONLINE_IMAGE_PNG_SUPPORT
     case ImageFormat::PNG:
-      accept_header.value = "image/png;q=0.9,*/*;q=0.8";
+      accept_mime_type = "image/png";
       break;
 #endif  // ONLINE_IMAGE_PNG_SUPPORT
     default:
-      accept_header.value = "*/*";
+      accept_mime_type = "image/*";
   }
+  accept_header.value = (accept_mime_type + ",*/*;q=0.8").c_str();
 
   headers.push_back(accept_header);
 


### PR DESCRIPTION
# What does this implement/fix?

The HTTP Accept request header indicates which content types, expressed as MIME types, the sender is able to understand. In requests, the server uses content negotiation to select one of the proposals.

See: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept


## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

n/a

## Test Environment

- [ ] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

Any example would work, such as the one shown in https://esphome.io/components/online_image.html

```yaml
online_image:
  - url: "https://example.com/example.png"
    format: png
    id: my_online_image
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
