### PR TITLE
[online_image]Pin specific version of JPEG library

### DIFF
--- a/esphome/components/online_image/__init__.py
+++ b/esphome/components/online_image/__init__.py
@@ -66,7 +66,7 @@ class JPEGFormat(Format):
 
     def actions(self):
         cg.add_define("USE_ONLINE_IMAGE_JPEG_SUPPORT")
-        cg.add_library("JPEGDEC", "1.6.2", "https://github.com/bitbank2/JPEGDEC")
+        cg.add_library("JPEGDEC", None, "https://github.com/bitbank2/JPEGDEC#ca1e0f2")
 
 
 class PNGFormat(Format):

--- a/platformio.ini
+++ b/platformio.ini
@@ -42,7 +42,7 @@ lib_deps =
     pavlodn/HaierProtocol@0.9.31           ; haier
     kikuchan98/pngle@1.0.2                 ; online_image
     ; Using the repository directly, otherwise ESP-IDF can't use the library
-    https://github.com/bitbank2/JPEGDEC.git#1.6.2            ; online_image
+    https://github.com/bitbank2/JPEGDEC.git#ca1e0f2    ; online_image
     ; This is using the repository until a new release is published to PlatformIO
     https://github.com/Sensirion/arduino-gas-index-algorithm.git#3.2.1 ; Sensirion Gas Index Algorithm Arduino Library
     lvgl/lvgl@8.4.0                                       ; lvgl


### PR DESCRIPTION
# What does this implement/fix?

There was an update in the used JPEG library that broke compilation for ESP32-S3 devices. Pin a specific commit in the repository to avoid such regressions in the future.

<!-- Quick description and explanation of changes -->

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
