### PR TITLE
Fix pref conflict of WiFi creds and fast_connect

### DIFF
--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -66,7 +66,7 @@ void WiFiComponent::start() {
 
   this->pref_ = global_preferences->make_preference<wifi::SavedWifiSettings>(hash, true);
   if (this->fast_connect_) {
-    this->fast_connect_pref_ = global_preferences->make_preference<wifi::SavedWifiFastConnectSettings>(hash, false);
+    this->fast_connect_pref_ = global_preferences->make_preference<wifi::SavedWifiFastConnectSettings>(hash + 1, false);
   }
 
   SavedWifiSettings save{};


### PR DESCRIPTION
Caching `fast_connect` state in a persistent preference, added in PR #5931 (e2f2fea), reused the same preference key as the saved basic WiFi creds.

Suppose the basic WiFi creds have been earlier stored, e.g., by previously used `captive_portal`.  Upon enabling `fast_connect` later the saved basic WiFi creds get interpreted as the cached `fast_connect` state, resulting in bogus BSSID and channel number.  Connecting repeatedly fails and may require non-trivial debricking.

Using separate persistent preferences for separate purposes resolves the problem cleanly.  The two sets of settings can be safely used separately or even together (e.g., via `set_fast_connect(true)` in `esphome.on_boot`).

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes N/A (no issue created ATM)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [X] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

N/A

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] N/A