### PR TITLE
[prometheus] Adding valve entity metrics

### DIFF
--- a/esphome/components/prometheus/prometheus_handler.cpp
+++ b/esphome/components/prometheus/prometheus_handler.cpp
@@ -83,6 +83,12 @@ void PrometheusHandler::handleRequest(AsyncWebServerRequest *req) {
     this->update_entity_row_(stream, obj, area, node, friendly_name);
 #endif
 
+#ifdef USE_VALVE
+  this->valve_type_(stream);
+  for (auto *obj : App.get_valves())
+    this->valve_row_(stream, obj, area, node, friendly_name);
+#endif
+
   req->send(stream);
 }
 
@@ -766,6 +772,54 @@ void PrometheusHandler::update_entity_row_(AsyncResponseStream *stream, update::
     stream->print(F("\",name=\""));
     stream->print(relabel_name_(obj).c_str());
     stream->print(F("\"} 1\n"));
+  }
+}
+#endif
+
+#ifdef USE_VALVE
+void PrometheusHandler::valve_type_(AsyncResponseStream *stream) {
+  stream->print(F("#TYPE esphome_valve_operation gauge\n"));
+  stream->print(F("#TYPE esphome_valve_failed gauge\n"));
+  stream->print(F("#TYPE esphome_valve_position gauge\n"));
+}
+
+void PrometheusHandler::valve_row_(AsyncResponseStream *stream, valve::Valve *obj, std::string &area, std::string &node,
+                                   std::string &friendly_name) {
+  if (obj->is_internal() && !this->include_internal_)
+    return;
+  stream->print(F("esphome_valve_failed{id=\""));
+  stream->print(relabel_id_(obj).c_str());
+  add_area_label_(stream, area);
+  add_node_label_(stream, node);
+  add_friendly_name_label_(stream, friendly_name);
+  stream->print(F("\",name=\""));
+  stream->print(relabel_name_(obj).c_str());
+  stream->print(F("\"} 0\n"));
+  // Data itself
+  stream->print(F("esphome_valve_operation{id=\""));
+  stream->print(relabel_id_(obj).c_str());
+  add_area_label_(stream, area);
+  add_node_label_(stream, node);
+  add_friendly_name_label_(stream, friendly_name);
+  stream->print(F("\",name=\""));
+  stream->print(relabel_name_(obj).c_str());
+  stream->print(F("\",operation=\""));
+  stream->print(valve::valve_operation_to_str(obj->current_operation).c_str());
+  stream->print(F("\"} "));
+  stream->print(F("1.0"));
+  stream->print(F("\n"));
+  // Now see if position is supported
+  if (obj->get_traits().get_supports_position()) {
+    stream->print(F("esphome_valve_position{id=\""));
+    stream->print(relabel_id_(obj).c_str());
+    add_area_label_(stream, area);
+    add_node_label_(stream, node);
+    add_friendly_name_label_(stream, friendly_name);
+    stream->print(F("\",name=\""));
+    stream->print(relabel_name_(obj).c_str());
+    stream->print(F("\"} "));
+    stream->print(obj->position);
+    stream->print(F("\n"));
   }
 }
 #endif

--- a/esphome/components/prometheus/prometheus_handler.cpp
+++ b/esphome/components/prometheus/prometheus_handler.cpp
@@ -804,7 +804,7 @@ void PrometheusHandler::valve_row_(AsyncResponseStream *stream, valve::Valve *ob
   stream->print(F("\",name=\""));
   stream->print(relabel_name_(obj).c_str());
   stream->print(F("\",operation=\""));
-  stream->print(valve::valve_operation_to_str(obj->current_operation).c_str());
+  stream->print(valve::valve_operation_to_str(obj->current_operation));
   stream->print(F("\"} "));
   stream->print(F("1.0"));
   stream->print(F("\n"));

--- a/esphome/components/prometheus/prometheus_handler.h
+++ b/esphome/components/prometheus/prometheus_handler.h
@@ -161,6 +161,14 @@ class PrometheusHandler : public AsyncWebHandler, public Component {
   void handle_update_state_(AsyncResponseStream *stream, update::UpdateState state);
 #endif
 
+#ifdef USE_VALVE
+  /// Return the type for prometheus
+  void valve_type_(AsyncResponseStream *stream);
+  /// Return the valve state as prometheus data point
+  void valve_row_(AsyncResponseStream *stream, valve::Valve *obj, std::string &area, std::string &node,
+                  std::string &friendly_name);
+#endif
+
   web_server_base::WebServerBase *base_;
   bool include_internal_{false};
   std::map<EntityBase *, std::string> relabel_map_id_;

--- a/tests/components/prometheus/common.yaml
+++ b/tests/components/prometheus/common.yaml
@@ -121,6 +121,23 @@ number:
     max_value: 100
     step: 1
 
+valve:
+  - platform: template
+    name: "Template Valve"
+    lambda: |-
+      if (id(top_end_stop).state) {
+        return VALVE_OPEN;
+      } else {
+        return VALVE_CLOSED;
+      }
+    open_action:
+      - switch.turn_on: open_valve_switch
+    close_action:
+      - switch.turn_on: close_valve_switch
+    stop_action:
+      - switch.turn_on: stop_valve_switch
+    optimistic: true
+
 prometheus:
   include_internal: true
   relabel:

--- a/tests/components/prometheus/common.yaml
+++ b/tests/components/prometheus/common.yaml
@@ -125,18 +125,9 @@ valve:
   - platform: template
     name: "Template Valve"
     lambda: |-
-      if (id(top_end_stop).state) {
-        return VALVE_OPEN;
-      } else {
-        return VALVE_CLOSED;
-      }
-    open_action:
-      - switch.turn_on: open_valve_switch
-    close_action:
-      - switch.turn_on: close_valve_switch
-    stop_action:
-      - switch.turn_on: stop_valve_switch
+      return VALVE_OPEN;
     optimistic: true
+    has_position: true
 
 prometheus:
   include_internal: true


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

I wanted to add `valve` entity metrics like below:

```
#TYPE esphome_valve_operation gauge
#TYPE esphome_valve_failed gauge
#TYPE esphome_valve_position gauge
esphome_valve_failed{id="template_valve",area="Dev",node="devtestprometheus",name="Template Valve"} 0
esphome_valve_operation{id="template_valve",area="Dev",node="devtestprometheus",name="Template Valve",operation="IDLE"} 1.0
esphome_valve_position{id="template_valve",area="Dev",node="devtestprometheus",name="Template Valve"} 1.00
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
valve:
  - platform: template
    name: "Template Valve"
    lambda: |-
      return VALVE_OPEN;
    optimistic: true
    has_position: true

prometheus:
  include_internal: true
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
