### PR TITLE
[io_bus] Initial implementation

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -225,6 +225,7 @@ esphome/components/inkplate6/* @jesserockz
 esphome/components/integration/* @OttoWinter
 esphome/components/internal_temperature/* @Mat931
 esphome/components/interval/* @esphome/core
+esphome/components/io_bus/* @clydebarrow
 esphome/components/jsn_sr04t/* @Mafus1
 esphome/components/json/* @OttoWinter
 esphome/components/kamstrup_kmp/* @cfeenstra1024

--- a/esphome/components/io_bus/__init__.py
+++ b/esphome/components/io_bus/__init__.py
@@ -1,0 +1,4 @@
+import esphome.codegen as cg
+
+io_bus_ns = cg.esphome_ns.namespace("io_bus")
+IOBus = io_bus_ns.class_("IOBus")

--- a/esphome/components/io_bus/__init__.py
+++ b/esphome/components/io_bus/__init__.py
@@ -2,3 +2,7 @@ import esphome.codegen as cg
 
 io_bus_ns = cg.esphome_ns.namespace("io_bus")
 IOBus = io_bus_ns.class_("IOBus")
+
+CODEOWNERS = ["@clydebarrow"]
+# Allow configuration in yaml, for testing
+CONFIG_SCHEMA = {}

--- a/esphome/components/io_bus/io_bus.h
+++ b/esphome/components/io_bus/io_bus.h
@@ -1,0 +1,71 @@
+#pragma once
+
+#include "esphome/core/log.h"
+#include "esphome/core/gpio.h"
+
+namespace esphome {
+namespace io_bus {
+
+/**
+ * A pin to replace those that don't exist.
+ */
+class NullPin : public GPIOPin {
+ public:
+  void setup() override {}
+
+  void pin_mode(gpio::Flags _) override {}
+
+  bool digital_read() override { return false; }
+
+  void digital_write(bool _) override {}
+
+  std::string dump_summary() const override { return {"Not used"}; }
+};
+
+// https://bugs.llvm.org/show_bug.cgi?id=48040
+static GPIOPin *const NULL_PIN = new NullPin();  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+
+/**
+ * A class that can write a byte-oriented bus interface with CS and DC controls, typically used for
+ * LCD display controller interfacing.
+ */
+class IOBus {
+ public:
+  virtual void bus_setup() = 0;
+
+  virtual void bus_teardown() = 0;
+
+  /**
+   * Write a data array. Will not control dc or cs pins.
+   * @param data
+   * @param length
+   */
+  virtual void write_array(const uint8_t *data, size_t length) = 0;
+
+  /**
+   * Write a command followed by data. CS and DC will be controlled automatically.
+   * On return, the DC pin will be in DATA mode.
+   * @param cmd An 8 bit command. Passing -1 will suppress the command phase
+   * @param data The data to write. May be null if length==0
+   * @param length The number of data bytes to write (excludes the command byte)
+   */
+  virtual void write_cmd_data(int cmd, const uint8_t *data, size_t length) = 0;
+
+  /**
+   * Convenience function for parameterless commands.
+   * @param cmd The 8 bit command.
+   */
+  void write_cmd(uint8_t cmd) { this->write_cmd_data(cmd, nullptr, 0); }
+
+  virtual void dump_config(){};
+
+  virtual void begin_transaction() = 0;
+  virtual void end_transaction() = 0;
+
+  void set_dc_pin(GPIOPin *dc_pin) { this->dc_pin_ = dc_pin; }
+
+ protected:
+  GPIOPin *dc_pin_{io_bus::NULL_PIN};
+};
+}  // namespace io_bus
+}  // namespace esphome

--- a/esphome/components/io_bus/io_bus.h
+++ b/esphome/components/io_bus/io_bus.h
@@ -20,6 +20,8 @@ class NullPin : public GPIOPin {
   void digital_write(bool _) override {}
 
   std::string dump_summary() const override { return {"Not used"}; }
+
+  gpio::Flags get_flags() const override { return gpio::Flags{}; }
 };
 
 // https://bugs.llvm.org/show_bug.cgi?id=48040

--- a/tests/components/io_bus/common.yaml
+++ b/tests/components/io_bus/common.yaml
@@ -1,0 +1,7 @@
+io_bus:
+
+esphome:
+  on_boot:
+    lambda: |-
+      #include "esphome/components/io_bus/io_bus.h"
+

--- a/tests/components/io_bus/test.esp32-ard.yaml
+++ b/tests/components/io_bus/test.esp32-ard.yaml
@@ -1,0 +1,1 @@
+!include common.yaml

--- a/tests/components/io_bus/test.esp32-c3-ard.yaml
+++ b/tests/components/io_bus/test.esp32-c3-ard.yaml
@@ -1,0 +1,1 @@
+!include common.yaml

--- a/tests/components/io_bus/test.esp32-c3-idf.yaml
+++ b/tests/components/io_bus/test.esp32-c3-idf.yaml
@@ -1,0 +1,1 @@
+!include common.yaml

--- a/tests/components/io_bus/test.esp32-idf.yaml
+++ b/tests/components/io_bus/test.esp32-idf.yaml
@@ -1,0 +1,1 @@
+!include common.yaml

--- a/tests/components/io_bus/test.esp8266-ard.yaml
+++ b/tests/components/io_bus/test.esp8266-ard.yaml
@@ -1,0 +1,1 @@
+!include common.yaml

--- a/tests/components/io_bus/test.host.yaml
+++ b/tests/components/io_bus/test.host.yaml
@@ -1,0 +1,1 @@
+!include common.yaml

--- a/tests/components/io_bus/test.rp2040-ard.yaml
+++ b/tests/components/io_bus/test.rp2040-ard.yaml
@@ -1,0 +1,1 @@
+!include common.yaml


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

In preparation for adding a new bus parallel type - `i80` - used for interfacing  LCD display controllers. This is used in a similar way to the `spi` component, and will be utilised by the `ili9xxx` display driver, enabling support for the Seeed [W32-SC01-Plus](https://www.seeedstudio.com/WT32-3-5-Inch-Display-p-5542.html) and the [LilyGo T-Display S3](https://www.lilygo.cc/products/t-display-s3?variant=42589373268149).


This PR contains only the `io_bus`  components. Further PRs will add the `i80` bus component and functionality to the SPI and ili9xxx components.

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes 
- https://github.com/esphome/feature-requests/issues/2387
- https://github.com/esphome/feature-requests/issues/901
- 

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#3761

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [x] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml
i80:
  dc_pin: 7
  wr_pin: 8
  rd_pin: 9
  data_pins:
    - 39
    - 40
    - 41
    - 42
    -
      ignore_strapping_warning: true
      number: 45
    -
      ignore_strapping_warning: true
      number: 46
    - 47
    - 48
    
display:
  - platform: ili9xxx
    bus_type: i80
    cs_pin: 6
    reset_pin: 5
    model: st7789v
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
