### PR TITLE
[speaker] Bugfix: Ensure all audio is played after completely decoding a file

### DIFF
--- a/esphome/components/speaker/media_player/audio_pipeline.h
+++ b/esphome/components/speaker/media_player/audio_pipeline.h
@@ -112,6 +112,7 @@ class AudioPipeline {
 
   uint32_t playback_ms_{0};
 
+  bool hard_stop_{false};
   bool is_playing_{false};
   bool pause_state_{false};
   bool task_stack_in_psram_;


### PR DESCRIPTION
# What does this implement/fix?

Fixes a bug where the end of the audio clip was cutoff in the output speaker had a long buffer. When an audio file is completely decoded, it now uses the speaker's finish function to ensure all audio is played. If a stop command is sent in the middle of a file, then it will still use the speaker's stop function.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** not applicable

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** not applicable

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

Example config is for an M5Stack ATOM Echo

```yaml
# Example config.yaml

speaker:
  - platform: i2s_audio
    id: echo_speaker
    i2s_dout_pin: GPIO22
    dac_type: external
    bits_per_sample: 32bit
    channel: right
    buffer_duration: 500ms

media_player:
  - platform: speaker
    name: "Speaker Media Player"
    id: echo_media_player
    announcement_pipeline:
      speaker: echo_speaker
      format: WAV
    codec_support_enabled: false
    buffer_size: 6000

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
