### PR TITLE
[voice_assistant] Add announce support

### DIFF
--- a/esphome/components/voice_assistant/voice_assistant.cpp
+++ b/esphome/components/voice_assistant/voice_assistant.cpp
@@ -1,4 +1,5 @@
 #include "voice_assistant.h"
+#include "esphome/core/defines.h"
 
 #ifdef USE_VOICE_ASSISTANT
 
@@ -733,8 +734,9 @@ void VoiceAssistant::on_event(const api::VoiceAssistantEventResponse &msg) {
     }
     case api::enums::VOICE_ASSISTANT_RUN_END: {
       ESP_LOGD(TAG, "Assist Pipeline ended");
-      if (this->state_ == State::STARTING_PIPELINE) {
+      if ((this->state_ == State::STARTING_PIPELINE) || (this->state_ == State::AWAITING_RESPONSE)) {
         // Pipeline ended before starting microphone
+        // Or there wasn't a TTS start event ("nevermind")
         this->set_state_(State::IDLE, State::IDLE);
       } else if (this->state_ == State::STREAMING_MICROPHONE) {
         this->ring_buffer_->reset();
@@ -747,9 +749,6 @@ void VoiceAssistant::on_event(const api::VoiceAssistantEventResponse &msg) {
         {
           this->set_state_(State::IDLE, State::IDLE);
         }
-      } else if (this->state_ == State::AWAITING_RESPONSE) {
-        // No TTS start event ("nevermind")
-        this->set_state_(State::IDLE, State::IDLE);
       }
       this->defer([this]() { this->end_trigger_->trigger(); });
       break;

--- a/esphome/components/voice_assistant/voice_assistant.cpp
+++ b/esphome/components/voice_assistant/voice_assistant.cpp
@@ -127,7 +127,7 @@ void VoiceAssistant::clear_buffers_() {
   }
 
 #ifdef USE_SPEAKER
-  if (this->speaker_buffer_ != nullptr) {
+  if ((this->speaker_ != nullptr) && (this->speaker_buffer_ != nullptr)) {
     memset(this->speaker_buffer_, 0, SPEAKER_BUFFER_SIZE);
 
     this->speaker_buffer_size_ = 0;
@@ -159,7 +159,7 @@ void VoiceAssistant::deallocate_buffers_() {
   this->input_buffer_ = nullptr;
 
 #ifdef USE_SPEAKER
-  if (this->speaker_buffer_ != nullptr) {
+  if ((this->speaker_ != nullptr) && (this->speaker_buffer_ != nullptr)) {
     ExternalRAMAllocator<uint8_t> speaker_deallocator(ExternalRAMAllocator<uint8_t>::ALLOW_FAILURE);
     speaker_deallocator.deallocate(this->speaker_buffer_, SPEAKER_BUFFER_SIZE);
     this->speaker_buffer_ = nullptr;
@@ -389,7 +389,7 @@ void VoiceAssistant::loop() {
       }
 #endif
       if (playing) {
-        this->set_timeout("playing", 2000, [this]() {
+        this->set_timeout("playing", 50, [this]() {
           this->cancel_timeout("speaker-timeout");
           this->set_state_(State::IDLE, State::IDLE);
 
@@ -614,6 +614,8 @@ void VoiceAssistant::request_stop() {
       this->desired_state_ = State::IDLE;
       break;
     case State::AWAITING_RESPONSE:
+      this->signal_stop_();
+      break;
     case State::STREAMING_RESPONSE:
     case State::RESPONSE_FINISHED:
       break;  // Let the incoming audio stream finish then it will go to idle.
@@ -725,7 +727,10 @@ void VoiceAssistant::on_event(const api::VoiceAssistantEventResponse &msg) {
     }
     case api::enums::VOICE_ASSISTANT_RUN_END: {
       ESP_LOGD(TAG, "Assist Pipeline ended");
-      if (this->state_ == State::STREAMING_MICROPHONE) {
+      if (this->state_ == State::STARTING_PIPELINE) {
+        // Pipeline ended before starting microphone
+        this->set_state_(State::IDLE, State::IDLE);
+      } else if (this->state_ == State::STREAMING_MICROPHONE) {
         this->ring_buffer_->reset();
 #ifdef USE_ESP_ADF
         if (this->use_wake_word_) {

--- a/esphome/components/voice_assistant/voice_assistant.cpp
+++ b/esphome/components/voice_assistant/voice_assistant.cpp
@@ -389,14 +389,7 @@ void VoiceAssistant::loop() {
       }
 #endif
       if (playing) {
-        this->set_timeout("playing", 50, [this]() {
-          this->cancel_timeout("speaker-timeout");
-          this->set_state_(State::IDLE, State::IDLE);
-
-          api::VoiceAssistantAnnounceFinished msg;
-          msg.success = true;
-          this->api_client_->send_voice_assistant_announce_finished(msg);
-        });
+        this->start_playback_timeout_();
       }
       break;
     }
@@ -633,6 +626,17 @@ void VoiceAssistant::signal_stop_() {
   this->api_client_->send_voice_assistant_request(msg);
 }
 
+void VoiceAssistant::start_playback_timeout_() {
+  this->set_timeout("playing", 100, [this]() {
+    this->cancel_timeout("speaker-timeout");
+    this->set_state_(State::IDLE, State::IDLE);
+
+    api::VoiceAssistantAnnounceFinished msg;
+    msg.success = true;
+    this->api_client_->send_voice_assistant_announce_finished(msg);
+  });
+}
+
 void VoiceAssistant::on_event(const api::VoiceAssistantEventResponse &msg) {
   ESP_LOGD(TAG, "Event Type: %" PRId32, msg.event_type);
   switch (msg.event_type) {
@@ -717,6 +721,8 @@ void VoiceAssistant::on_event(const api::VoiceAssistantEventResponse &msg) {
 #ifdef USE_MEDIA_PLAYER
         if (this->media_player_ != nullptr) {
           this->media_player_->make_call().set_media_url(url).set_announcement(true).perform();
+          // Start the playback timeout, as the media player state isn't immediately updated
+          this->start_playback_timeout_();
         }
 #endif
         this->tts_end_trigger_->trigger(url);

--- a/esphome/components/voice_assistant/voice_assistant.h
+++ b/esphome/components/voice_assistant/voice_assistant.h
@@ -40,6 +40,7 @@ enum VoiceAssistantFeature : uint32_t {
   FEATURE_SPEAKER = 1 << 1,
   FEATURE_API_AUDIO = 1 << 2,
   FEATURE_TIMERS = 1 << 3,
+  FEATURE_ANNOUNCE = 1 << 4,
 };
 
 enum class State {
@@ -135,6 +136,12 @@ class VoiceAssistant : public Component {
     if (this->has_timers_) {
       flags |= VoiceAssistantFeature::FEATURE_TIMERS;
     }
+
+#ifdef USE_MEDIA_PLAYER
+    if (this->media_player_ != nullptr) {
+      flags |= VoiceAssistantFeature::FEATURE_ANNOUNCE;
+    }
+#endif
 
     return flags;
   }

--- a/esphome/components/voice_assistant/voice_assistant.h
+++ b/esphome/components/voice_assistant/voice_assistant.h
@@ -216,6 +216,7 @@ class VoiceAssistant : public Component {
   void set_state_(State state);
   void set_state_(State state, State desired_state);
   void signal_stop_();
+  void start_playback_timeout_();
 
   std::unique_ptr<socket::Socket> socket_ = nullptr;
   struct sockaddr_storage dest_addr_;

--- a/esphome/core/defines.h
+++ b/esphome/core/defines.h
@@ -35,6 +35,7 @@
 #define USE_DEEP_SLEEP
 #define USE_DISPLAY
 #define USE_ESP32_IMPROV_STATE_CALLBACK
+#define USE_ESP_ADF
 #define USE_EVENT
 #define USE_FAN
 #define USE_GRAPH

--- a/esphome/core/defines.h
+++ b/esphome/core/defines.h
@@ -35,7 +35,6 @@
 #define USE_DEEP_SLEEP
 #define USE_DISPLAY
 #define USE_ESP32_IMPROV_STATE_CALLBACK
-#define USE_ESP_ADF
 #define USE_EVENT
 #define USE_FAN
 #define USE_GRAPH


### PR DESCRIPTION
# What does this implement/fix?

Adds support for sending announcements with HA's ``assist_satellite.announce`` action. Requires using a media player component for audio output. Since the media player's state isn't immediately updated when it receives the url, this PR starts the playback timeout right away so that the VA doesn't instantly report its finished.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** not applicable

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** not applicable

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

Example is for M5Stack's ATOM Echo.

```yaml
# Example config.yaml

i2s_audio:
  - id: i2s_audio_bus
    i2s_lrclk_pin: GPIO33
    i2s_bclk_pin: GPIO19

microphone:
  - platform: i2s_audio
    id: echo_microphone
    i2s_din_pin: GPIO23
    adc_type: external
    pdm: true

speaker:
  - platform: i2s_audio
    id: echo_speaker
    i2s_dout_pin: GPIO22
    dac_type: external
    bits_per_sample: 32bit
    channel: right
    buffer_duration: 500ms

media_player:
  - platform: speaker
    name: "Speaker Media Player"
    id: echo_media_player
    announcement_pipeline:
      speaker: echo_speaker
      format: WAV
    codec_support_enabled: false
    buffer_size: 6000

voice_assistant:
  id: va
  microphone: echo_microphone
  media_player: echo_media_player
  noise_suppression_level: 2
  auto_gain: 31dBFS
  volume_multiplier: 2.0

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
