### PR TITLE
Split out daikin IR protocol and Daikin climate component

### DIFF
--- a/esphome/components/daikin/daikin.cpp
+++ b/esphome/components/daikin/daikin.cpp
@@ -1,5 +1,5 @@
 #include "daikin.h"
-#include "esphome/components/remote_base/remote_base.h"
+#include "esphome/components/remote_base/daikin_protocol.h"
 
 namespace esphome {
 namespace daikin {
@@ -7,62 +7,21 @@ namespace daikin {
 static const char *const TAG = "daikin.climate";
 
 void DaikinClimate::transmit_state() {
-  uint8_t remote_state[35] = {0x11, 0xDA, 0x27, 0x00, 0xC5, 0x00, 0x00, 0xD7, 0x11, 0xDA, 0x27, 0x00,
-                              0x42, 0x49, 0x05, 0xA2, 0x11, 0xDA, 0x27, 0x00, 0x00, 0x00, 0x00, 0x00,
-                              0x00, 0x00, 0x00, 0x06, 0x60, 0x00, 0x00, 0xC0, 0x00, 0x00, 0x00};
+  const remote_base::DaikinData frame_1{.data = {0xC5, 0x00, 0x00}};
+  const remote_base::DaikinData frame_2{.data = {0x42, 0x49, 0x05}};
 
-  remote_state[21] = this->operation_mode_();
-  remote_state[22] = this->temperature_();
+  remote_base::DaikinData frame_3{
+      .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x06, 0x60, 0x00, 0x00, 0xC0, 0x00, 0x00}};
+
+  frame_3.data[1] = this->operation_mode_();
+  frame_3.data[2] = this->temperature_();
   uint16_t fan_speed = this->fan_speed_();
-  remote_state[24] = fan_speed >> 8;
-  remote_state[25] = fan_speed & 0xff;
+  frame_3.data[4] = fan_speed >> 8;
+  frame_3.data[5] = fan_speed & 0xff;
 
-  // Calculate checksum
-  for (int i = 16; i < 34; i++) {
-    remote_state[34] += remote_state[i];
-  }
-
-  auto transmit = this->transmitter_->transmit();
-  auto *data = transmit.get_data();
-  data->set_carrier_frequency(DAIKIN_IR_FREQUENCY);
-
-  data->mark(DAIKIN_HEADER_MARK);
-  data->space(DAIKIN_HEADER_SPACE);
-  for (int i = 0; i < 8; i++) {
-    for (uint8_t mask = 1; mask > 0; mask <<= 1) {  // iterate through bit mask
-      data->mark(DAIKIN_BIT_MARK);
-      bool bit = remote_state[i] & mask;
-      data->space(bit ? DAIKIN_ONE_SPACE : DAIKIN_ZERO_SPACE);
-    }
-  }
-  data->mark(DAIKIN_BIT_MARK);
-  data->space(DAIKIN_MESSAGE_SPACE);
-  data->mark(DAIKIN_HEADER_MARK);
-  data->space(DAIKIN_HEADER_SPACE);
-
-  for (int i = 8; i < 16; i++) {
-    for (uint8_t mask = 1; mask > 0; mask <<= 1) {  // iterate through bit mask
-      data->mark(DAIKIN_BIT_MARK);
-      bool bit = remote_state[i] & mask;
-      data->space(bit ? DAIKIN_ONE_SPACE : DAIKIN_ZERO_SPACE);
-    }
-  }
-  data->mark(DAIKIN_BIT_MARK);
-  data->space(DAIKIN_MESSAGE_SPACE);
-  data->mark(DAIKIN_HEADER_MARK);
-  data->space(DAIKIN_HEADER_SPACE);
-
-  for (int i = 16; i < 35; i++) {
-    for (uint8_t mask = 1; mask > 0; mask <<= 1) {  // iterate through bit mask
-      data->mark(DAIKIN_BIT_MARK);
-      bool bit = remote_state[i] & mask;
-      data->space(bit ? DAIKIN_ONE_SPACE : DAIKIN_ZERO_SPACE);
-    }
-  }
-  data->mark(DAIKIN_BIT_MARK);
-  data->space(0);
-
-  transmit.perform();
+  this->transmit_<remote_base::DaikinProtocol>(frame_1);
+  this->transmit_<remote_base::DaikinProtocol>(frame_2);
+  this->transmit_<remote_base::DaikinProtocol>(frame_3);
 }
 
 uint8_t DaikinClimate::operation_mode_() {
@@ -140,14 +99,16 @@ uint8_t DaikinClimate::temperature_() {
   }
 }
 
-bool DaikinClimate::parse_state_frame_(const uint8_t frame[]) {
-  uint8_t checksum = 0;
-  for (int i = 0; i < (DAIKIN_STATE_FRAME_SIZE - 1); i++) {
-    checksum += frame[i];
-  }
-  if (frame[DAIKIN_STATE_FRAME_SIZE - 1] != checksum)
+bool DaikinClimate::on_receive(remote_base::RemoteReceiveData data) {
+  auto decoded = remote_base::DaikinProtocol().decode(data);
+  if (!decoded.has_value())
     return false;
-  uint8_t mode = frame[5];
+
+  const remote_base::DaikinData &state = decoded.value();
+  if (state.data.size() != 14 || state.data[0] != 0)  // Frame type
+    return false;
+
+  uint8_t mode = state.data[1];
   if (mode & DAIKIN_MODE_ON) {
     switch (mode & 0xF0) {
       case DAIKIN_MODE_COOL:
@@ -169,12 +130,14 @@ bool DaikinClimate::parse_state_frame_(const uint8_t frame[]) {
   } else {
     this->mode = climate::CLIMATE_MODE_OFF;
   }
-  uint8_t temperature = frame[6];
+
+  uint8_t temperature = state.data[2];
   if (!(temperature & 0xC0)) {
     this->target_temperature = temperature >> 1;
   }
-  uint8_t fan_mode = frame[8];
-  uint8_t swing_mode = frame[9];
+
+  uint8_t fan_mode = state.data[4];
+  uint8_t swing_mode = state.data[5];
   if (fan_mode & 0xF && swing_mode & 0xF) {
     this->swing_mode = climate::CLIMATE_SWING_BOTH;
   } else if (fan_mode & 0xF) {
@@ -203,46 +166,6 @@ bool DaikinClimate::parse_state_frame_(const uint8_t frame[]) {
   }
   this->publish_state();
   return true;
-}
-
-bool DaikinClimate::on_receive(remote_base::RemoteReceiveData data) {
-  uint8_t state_frame[DAIKIN_STATE_FRAME_SIZE] = {};
-  if (!data.expect_item(DAIKIN_HEADER_MARK, DAIKIN_HEADER_SPACE)) {
-    return false;
-  }
-  for (uint8_t pos = 0; pos < DAIKIN_STATE_FRAME_SIZE; pos++) {
-    uint8_t byte = 0;
-    for (int8_t bit = 0; bit < 8; bit++) {
-      if (data.expect_item(DAIKIN_BIT_MARK, DAIKIN_ONE_SPACE)) {
-        byte |= 1 << bit;
-      } else if (!data.expect_item(DAIKIN_BIT_MARK, DAIKIN_ZERO_SPACE)) {
-        return false;
-      }
-    }
-    state_frame[pos] = byte;
-    if (pos == 0) {
-      // frame header
-      if (byte != 0x11)
-        return false;
-    } else if (pos == 1) {
-      // frame header
-      if (byte != 0xDA)
-        return false;
-    } else if (pos == 2) {
-      // frame header
-      if (byte != 0x27)
-        return false;
-    } else if (pos == 3) {  // NOLINT(bugprone-branch-clone)
-      // frame header
-      if (byte != 0x00)
-        return false;
-    } else if (pos == 4) {
-      // frame type
-      if (byte != 0x00)
-        return false;
-    }
-  }
-  return this->parse_state_frame_(state_frame);
 }
 
 }  // namespace daikin

--- a/esphome/components/daikin/daikin.h
+++ b/esphome/components/daikin/daikin.h
@@ -28,15 +28,6 @@ const uint8_t DAIKIN_FAN_3 = 0x50;
 const uint8_t DAIKIN_FAN_4 = 0x60;
 const uint8_t DAIKIN_FAN_5 = 0x70;
 
-// IR Transmission
-const uint32_t DAIKIN_IR_FREQUENCY = 38000;
-const uint32_t DAIKIN_HEADER_MARK = 3360;
-const uint32_t DAIKIN_HEADER_SPACE = 1760;
-const uint32_t DAIKIN_BIT_MARK = 520;
-const uint32_t DAIKIN_ONE_SPACE = 1370;
-const uint32_t DAIKIN_ZERO_SPACE = 360;
-const uint32_t DAIKIN_MESSAGE_SPACE = 32300;
-
 // State Frame size
 const uint8_t DAIKIN_STATE_FRAME_SIZE = 19;
 
@@ -57,7 +48,6 @@ class DaikinClimate : public climate_ir::ClimateIR {
   uint8_t temperature_();
   // Handle received IR Buffer
   bool on_receive(remote_base::RemoteReceiveData data) override;
-  bool parse_state_frame_(const uint8_t frame[]);
 };
 
 }  // namespace daikin

--- a/esphome/components/remote_base/__init__.py
+++ b/esphome/components/remote_base/__init__.py
@@ -472,6 +472,36 @@ def coolix_dumper(var, config):
     pass
 
 
+# Daikin
+DaikinData, DaikinBinarySensor, DaikinTrigger, DaikinAction, DaikinDumper = (
+    declare_protocol("Daikin")
+)
+
+DAIKIN_SCHEMA = cv.Schema({cv.Required(CONF_DATA): [cv.hex_uint8_t]})
+
+
+@register_binary_sensor("daikin", DaikinBinarySensor, DAIKIN_SCHEMA)
+def daikin_binary_sensor(var, config):
+    cg.add(var.set_code(config[CONF_DATA]))
+
+
+@register_action("daikin", DaikinAction, DAIKIN_SCHEMA)
+async def daikin_action(var, config, args):
+    vec_ = cg.std_vector.template(cg.uint8)
+    template_ = await cg.templatable(config[CONF_DATA], args, vec_, vec_)
+    cg.add(var.set_data(template_))
+
+
+@register_trigger("daikin", DaikinTrigger, DaikinData)
+def daikin_trigger(var, config):
+    pass
+
+
+@register_dumper("daikin", DaikinDumper)
+def daikin_dumper(var, config):
+    pass
+
+
 # Dish
 DishData, DishBinarySensor, DishTrigger, DishAction, DishDumper = declare_protocol(
     "Dish"

--- a/esphome/components/remote_base/daikin_protocol.cpp
+++ b/esphome/components/remote_base/daikin_protocol.cpp
@@ -1,0 +1,110 @@
+#include "daikin_protocol.h"
+#include "esphome/core/log.h"
+
+namespace esphome {
+namespace remote_base {
+
+static const char *const TAG = "remote.daikin";
+
+// IR Transmission
+static const uint32_t IR_FREQUENCY = 38000;
+static const uint32_t HEADER_MARK = 3360;
+static const uint32_t HEADER_SPACE = 1760;
+static const uint32_t BIT_MARK = 520;
+static const uint32_t ONE_SPACE = 1370;
+static const uint32_t ZERO_SPACE = 360;
+static const uint32_t MESSAGE_SPACE = 32300;
+
+static const uint8_t HEADER[] = {0x11, 0xda, 0x27, 0x00};
+
+void DaikinProtocol::encode(RemoteTransmitData *dst, const DaikinData &data) {
+  dst->set_carrier_frequency(IR_FREQUENCY);
+
+  dst->mark(HEADER_MARK);
+  dst->space(HEADER_SPACE);
+
+  uint8_t checksum = 0;
+
+  for (size_t i = 0; i < sizeof(HEADER); i++) {
+    DaikinProtocol::encode_byte(dst, HEADER[i]);
+    checksum += HEADER[i];
+  }
+
+  for (uint8_t byte : data.data) {
+    DaikinProtocol::encode_byte(dst, byte);
+    checksum += byte;
+  }
+
+  DaikinProtocol::encode_byte(dst, checksum);
+
+  dst->mark(BIT_MARK);
+  dst->space(MESSAGE_SPACE);
+}
+
+optional<DaikinData> DaikinProtocol::decode(RemoteReceiveData src) {
+  if (!src.expect_item(HEADER_MARK, HEADER_SPACE)) {
+    return {};
+  }
+
+  DaikinData out;
+  bool end_message = false;
+
+  while (src.is_valid() && !end_message) {
+    // Fetch each byte
+    uint8_t byte = 0;
+    for (int8_t bit = 0; bit < 8; bit++) {
+      if (src.expect_item(BIT_MARK, ONE_SPACE)) {
+        byte |= 1 << bit;
+      } else if (!src.expect_item(BIT_MARK, ZERO_SPACE)) {
+        end_message = true;
+        break;
+      }
+    }
+
+    if (!end_message)
+      out.data.push_back(byte);
+  }
+
+  if (out.data.size() <= 4)
+    return {};
+
+  // Calculate checksum and check header
+  uint8_t checksum = 0, i = 0;
+  for (auto it = out.data.begin(); it != std::prev(out.data.end()); i++) {
+    checksum += *it;
+
+    if (i < sizeof(HEADER)) {
+      if (*it != HEADER[i]) {
+        ESP_LOGD(TAG, "Invalid header byte (%hhu): received %02X, expected %02X", i, *it, HEADER[i]);
+        return {};
+      }
+
+      it = out.data.erase(it);
+    } else {
+      ++it;
+    }
+  }
+
+  if (checksum != out.data.back()) {
+    ESP_LOGD(TAG, "Invalid checksum: received %02X, expected %02X", out.data.back(), checksum);
+    return {};
+  }
+
+  out.data.pop_back();
+  return out;
+}
+
+void DaikinProtocol::dump(const DaikinData &data) {
+  ESP_LOGI(TAG, "Received Daikin: %s", format_hex_pretty(data.data).c_str());
+}
+
+void DaikinProtocol::encode_byte(RemoteTransmitData *dst, uint8_t byte) {
+  for (uint8_t mask = 1; mask > 0; mask <<= 1) {
+    dst->mark(BIT_MARK);
+    const bool bit = byte & mask;
+    dst->space(bit ? ONE_SPACE : ZERO_SPACE);
+  }
+}
+
+}  // namespace remote_base
+}  // namespace esphome

--- a/esphome/components/remote_base/daikin_protocol.cpp
+++ b/esphome/components/remote_base/daikin_protocol.cpp
@@ -1,6 +1,8 @@
 #include "daikin_protocol.h"
 #include "esphome/core/log.h"
 
+#include <cinttypes>
+
 namespace esphome {
 namespace remote_base {
 
@@ -18,10 +20,10 @@ static const uint32_t MESSAGE_SPACE = 32300;
 static const uint8_t HEADER[] = {0x11, 0xda, 0x27, 0x00};
 
 void DaikinProtocol::encode(RemoteTransmitData *dst, const DaikinData &data) {
+  dst->reserve(4 + (sizeof(HEADER) + data.data.size() + 1) * 16);
   dst->set_carrier_frequency(IR_FREQUENCY);
 
-  dst->mark(HEADER_MARK);
-  dst->space(HEADER_SPACE);
+  dst->item(HEADER_MARK, HEADER_SPACE);
 
   uint8_t checksum = 0;
 
@@ -37,8 +39,7 @@ void DaikinProtocol::encode(RemoteTransmitData *dst, const DaikinData &data) {
 
   DaikinProtocol::encode_byte(dst, checksum);
 
-  dst->mark(BIT_MARK);
-  dst->space(MESSAGE_SPACE);
+  dst->item(BIT_MARK, MESSAGE_SPACE);
 }
 
 optional<DaikinData> DaikinProtocol::decode(RemoteReceiveData src) {
@@ -75,7 +76,7 @@ optional<DaikinData> DaikinProtocol::decode(RemoteReceiveData src) {
 
     if (i < sizeof(HEADER)) {
       if (*it != HEADER[i]) {
-        ESP_LOGD(TAG, "Invalid header byte (%hhu): received %02X, expected %02X", i, *it, HEADER[i]);
+        ESP_LOGD(TAG, "Invalid header byte (%" PRIu8 "): received %02" PRIX8 ", expected %02" PRIX8, i, *it, HEADER[i]);
         return {};
       }
 
@@ -86,7 +87,7 @@ optional<DaikinData> DaikinProtocol::decode(RemoteReceiveData src) {
   }
 
   if (checksum != out.data.back()) {
-    ESP_LOGD(TAG, "Invalid checksum: received %02X, expected %02X", out.data.back(), checksum);
+    ESP_LOGD(TAG, "Invalid checksum: received %02" PRIX8 ", expected %02" PRIX8, out.data.back(), checksum);
     return {};
   }
 
@@ -100,9 +101,8 @@ void DaikinProtocol::dump(const DaikinData &data) {
 
 void DaikinProtocol::encode_byte(RemoteTransmitData *dst, uint8_t byte) {
   for (uint8_t mask = 1; mask > 0; mask <<= 1) {
-    dst->mark(BIT_MARK);
     const bool bit = byte & mask;
-    dst->space(bit ? ONE_SPACE : ZERO_SPACE);
+    dst->item(BIT_MARK, bit ? ONE_SPACE : ZERO_SPACE);
   }
 }
 

--- a/esphome/components/remote_base/daikin_protocol.cpp
+++ b/esphome/components/remote_base/daikin_protocol.cpp
@@ -25,9 +25,9 @@ void DaikinProtocol::encode(RemoteTransmitData *dst, const DaikinData &data) {
 
   uint8_t checksum = 0;
 
-  for (size_t i = 0; i < sizeof(HEADER); i++) {
-    DaikinProtocol::encode_byte(dst, HEADER[i]);
-    checksum += HEADER[i];
+  for (uint8_t byte : HEADER) {
+    DaikinProtocol::encode_byte(dst, byte);
+    checksum += byte;
   }
 
   for (uint8_t byte : data.data) {

--- a/esphome/components/remote_base/daikin_protocol.h
+++ b/esphome/components/remote_base/daikin_protocol.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "remote_base.h"
+
+#include <vector>
+
+namespace esphome {
+namespace remote_base {
+
+struct DaikinData {
+  std::vector<uint8_t> data;
+
+  bool operator==(const DaikinData &rhs) const { return data == rhs.data; }
+};
+
+class DaikinProtocol : public RemoteProtocol<DaikinData> {
+ public:
+  void encode(RemoteTransmitData *dst, const DaikinData &data) override;
+  optional<DaikinData> decode(RemoteReceiveData src) override;
+  void dump(const DaikinData &data) override;
+
+ protected:
+  static void encode_byte(RemoteTransmitData *dst, uint8_t byte);
+};
+
+DECLARE_REMOTE_PROTOCOL(Daikin);
+
+template<typename... Ts> class DaikinAction : public RemoteTransmitterActionBase<Ts...> {
+ public:
+  TEMPLATABLE_VALUE(std::vector<uint8_t>, data);
+
+  void set_data(const std::vector<uint8_t> &data) { data_ = data; }
+  void encode(RemoteTransmitData *dst, Ts... x) override {
+    DaikinData data{};
+    data.data = this->data_.value(x...);
+    DaikinProtocol().encode(dst, data);
+  }
+};
+
+}  // namespace remote_base
+}  // namespace esphome

--- a/esphome/components/remote_base/daikin_protocol.h
+++ b/esphome/components/remote_base/daikin_protocol.h
@@ -30,7 +30,7 @@ template<typename... Ts> class DaikinAction : public RemoteTransmitterActionBase
  public:
   TEMPLATABLE_VALUE(std::vector<uint8_t>, data);
 
-  void set_data(const std::vector<uint8_t> &data) { data_ = data; }
+  void set_data(const std::vector<uint8_t> &data) { this->data_ = data; }
   void encode(RemoteTransmitData *dst, Ts... x) override {
     DaikinData data{};
     data.data = this->data_.value(x...);

--- a/tests/components/remote_receiver/common-actions.yaml
+++ b/tests/components/remote_receiver/common-actions.yaml
@@ -147,3 +147,7 @@ on_toto:
     - logger.log:
         format: "on_toto: %u %u %u"
         args: ["x.rc_code_1", "x.rc_code_2", "x.command"]
+on_daikin:
+  then:
+    - lambda: |-
+        ESP_LOGD("daikin", "Daikin data: %s", format_hex(x.data).c_str());

--- a/tests/components/remote_transmitter/common-buttons.yaml
+++ b/tests/components/remote_transmitter/common-buttons.yaml
@@ -197,3 +197,25 @@ button:
           command: 0xEC
           rc_code_1: 0x0D
           rc_code_2: 0x0D
+  - platform: template
+    name: Daikin
+    on_press:
+      - remote_transmitter.transmit_daikin:
+          data:
+            [
+              0x00,
+              0x61,
+              0x32,
+              0x00,
+              0xB0,
+              0x00,
+              0x00,
+              0x00,
+              0x00,
+              0x00,
+              0x00,
+              0xC5,
+              0x00,
+              0x08,
+            ]
+


### PR DESCRIPTION
# What does this implement/fix?

This MR moved the raw Daikin IR data to usable bytes to class under the `remote_base`, this has the following advantages:
- Able to send custom data using actions
- Able to see what data is received using `remote_receiver` dump
- Remove responsibilities from the Daikin ir climate component

<!-- Quick description and explanation of changes -->
## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#4659

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
remote_receiver:
  - id: ir_receiver
    pin:
      number: GPIO4
      inverted: True
    dump:
      - daikin

remote_transmitter:
  - id: ir_transmitter
    pin:
      number: GPIO15
    carrier_duty_percent: 50%

climate:
  - platform: daikin
    name: "Daikin AC"
    receiver_id: ir_receiver
    transmitter_id: ir_transmitter
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
