### PR TITLE
[time] fix recalc_timestamp_local

### DIFF
--- a/esphome/core/time.cpp
+++ b/esphome/core/time.cpp
@@ -197,6 +197,7 @@ void ESPTime::recalc_timestamp_local() {
   tm.tm_hour = this->hour;
   tm.tm_min = this->minute;
   tm.tm_sec = this->second;
+  tm.tm_isdst = -1;
 
   this->timestamp = mktime(&tm);
 }


### PR DESCRIPTION
`ESPTime::recalc_timestamp_local()` can sometimes wrongly use an invalid summer time depending on the current timezone. This fixes the problem by telling `mktime()` to always look for the correct value in the current TZ data.

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/issues/issues/6742

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Sync time using HA
time:
  - platform: homeassistant
    id: ha_time
    timezone: Europe/Paris # no problem using UTC here

datetime:
  - platform: template
    type: datetime
    name: Test Datetime
    optimistic: true
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).