### PR TITLE
[core] Fix ``config_dir`` for dashboard

### DIFF
--- a/esphome/core/__init__.py
+++ b/esphome/core/__init__.py
@@ -582,7 +582,7 @@ class EsphomeCore:
 
     @property
     def config_dir(self):
-        return os.path.dirname(os.path.abspath(self.config_path))
+        return os.path.abspath(os.path.dirname(self.config_path))
 
     @property
     def data_dir(self):


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Fixes a bug introduced in https://github.com/esphome/esphome/pull/8044 where the abspath removed the trailing `/.` and then dirname was removing the actual config directory as it became the last part of the path.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
