### PR TITLE
[graph] Remove ``stream`` dependency

### DIFF
--- a/esphome/components/graph/graph.cpp
+++ b/esphome/components/graph/graph.cpp
@@ -4,9 +4,6 @@
 #include "esphome/core/log.h"
 #include "esphome/core/hal.h"
 #include <algorithm>
-#include <sstream>
-#include <iostream>  // std::cout, std::fixed
-#include <iomanip>
 namespace esphome {
 namespace graph {
 
@@ -231,9 +228,8 @@ void GraphLegend::init(Graph *g) {
     ESP_LOGI(TAGL, "  %s %d %d", txtstr.c_str(), fw, fh);
 
     if (this->values_ != VALUE_POSITION_TYPE_NONE) {
-      std::stringstream ss;
-      ss << std::fixed << std::setprecision(trace->sensor_->get_accuracy_decimals()) << trace->sensor_->get_state();
-      std::string valstr = ss.str();
+      std::string valstr =
+          value_accuracy_to_string(trace->sensor_->get_state(), trace->sensor_->get_accuracy_decimals());
       if (this->units_) {
         valstr += trace->sensor_->get_unit_of_measurement();
       }
@@ -368,9 +364,8 @@ void Graph::draw_legend(display::Display *buff, uint16_t x_offset, uint16_t y_of
     if (legend_->values_ != VALUE_POSITION_TYPE_NONE) {
       int xv = x + legend_->xv_;
       int yv = y + legend_->yv_;
-      std::stringstream ss;
-      ss << std::fixed << std::setprecision(trace->sensor_->get_accuracy_decimals()) << trace->sensor_->get_state();
-      std::string valstr = ss.str();
+      std::string valstr =
+          value_accuracy_to_string(trace->sensor_->get_state(), trace->sensor_->get_accuracy_decimals());
       if (legend_->units_) {
         valstr += trace->sensor_->get_unit_of_measurement();
       }


### PR DESCRIPTION
# What does this implement/fix?

SSIA (reduces binary size by a lot):

## BEFORE
```
Linking .pioenvs/componenttestesp32ard/firmware.elf
RAM:   [=         ]   7.4% (used 24244 bytes from 327680 bytes)
Flash: [===       ]  29.7% (used 545525 bytes from 1835008 bytes)

Linking .pioenvs/componenttestesp32c3ard/firmware.elf
RAM:   [=         ]   5.1% (used 16612 bytes from 327680 bytes)
Flash: [===       ]  27.5% (used 504708 bytes from 1835008 bytes)

Linking .pioenvs/componenttestesp32c3idf/firmware.elf
RAM:   [          ]   4.4% (used 14544 bytes from 327680 bytes)
Flash: [==        ]  24.4% (used 447408 bytes from 1835008 bytes)

Linking .pioenvs/componenttestesp32idf/firmware.elf
RAM:   [=         ]   5.2% (used 17044 bytes from 327680 bytes)
Flash: [===       ]  28.3% (used 518957 bytes from 1835008 bytes)

Linking .pioenvs/componenttestesp8266ard/firmware.elf
RAM:   [=====     ]  51.2% (used 41932 bytes from 81920 bytes)
Flash: [=====     ]  45.4% (used 473811 bytes from 1044464 bytes)

RAM:   [===       ]  29.8% (used 78164 bytes from 262144 bytes)
Flash: [=====     ]  48.0% (used 501548 bytes from 1044480 bytes)
Building .pioenvs/componenttestrp2040ard/firmware.bin
```

## AFTER
```
Linking .pioenvs/componenttestesp32ard/firmware.elf
RAM:   [=         ]   5.2% (used 17180 bytes from 327680 bytes)
Flash: [==        ]  17.1% (used 313209 bytes from 1835008 bytes)

Linking .pioenvs/componenttestesp32c3ard/firmware.elf
RAM:   [          ]   3.2% (used 10540 bytes from 327680 bytes)
Flash: [==        ]  15.8% (used 290810 bytes from 1835008 bytes)

Linking .pioenvs/componenttestesp32c3idf/firmware.elf
RAM:   [          ]   2.6% (used 8392 bytes from 327680 bytes)
Flash: [=         ]  13.6% (used 250150 bytes from 1835008 bytes)

Linking .pioenvs/componenttestesp32idf/firmware.elf
RAM:   [          ]   3.4% (used 11092 bytes from 327680 bytes)
Flash: [=         ]  14.7% (used 269925 bytes from 1835008 bytes)

Linking .pioenvs/componenttestesp8266ard/firmware.elf
RAM:   [====      ]  37.6% (used 30828 bytes from 81920 bytes)
Flash: [===       ]  28.7% (used 299379 bytes from 1044464 bytes)

RAM:   [===       ]  27.5% (used 72132 bytes from 262144 bytes)
Flash: [===       ]  34.1% (used 355888 bytes from 1044480 bytes)
Building .pioenvs/componenttestrp2040ard/firmware.bin
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
