### PR TITLE
[modbus_controller] Remove `stream` dependency

### DIFF
--- a/esphome/components/modbus_controller/text_sensor/modbus_textsensor.cpp
+++ b/esphome/components/modbus_controller/text_sensor/modbus_textsensor.cpp
@@ -13,7 +13,6 @@ void ModbusTextSensor::parse_and_publish(const std::vector<uint8_t> &data) {
   std::string output_str{};
   uint8_t items_left = this->response_bytes;
   uint8_t index = this->offset;
-  char buffer[5];
   while ((items_left > 0) && index < data.size()) {
     uint8_t b = data[index];
     switch (this->encode_) {

--- a/esphome/components/modbus_controller/text_sensor/modbus_textsensor.cpp
+++ b/esphome/components/modbus_controller/text_sensor/modbus_textsensor.cpp
@@ -1,8 +1,6 @@
 
 #include "modbus_textsensor.h"
 #include "esphome/core/log.h"
-#include <iomanip>
-#include <sstream>
 
 namespace esphome {
 namespace modbus_controller {
@@ -12,7 +10,7 @@ static const char *const TAG = "modbus_controller.text_sensor";
 void ModbusTextSensor::dump_config() { LOG_TEXT_SENSOR("", "Modbus Controller Text Sensor", this); }
 
 void ModbusTextSensor::parse_and_publish(const std::vector<uint8_t> &data) {
-  std::ostringstream output;
+  std::string output_str{};
   uint8_t items_left = this->response_bytes;
   uint8_t index = this->offset;
   char buffer[5];
@@ -20,12 +18,10 @@ void ModbusTextSensor::parse_and_publish(const std::vector<uint8_t> &data) {
     uint8_t b = data[index];
     switch (this->encode_) {
       case RawEncoding::HEXBYTES:
-        sprintf(buffer, "%02x", b);
-        output << buffer;
+        output_str += str_snprintf("%02x", 2, b);
         break;
       case RawEncoding::COMMA:
-        sprintf(buffer, index != this->offset ? ",%d" : "%d", b);
-        output << buffer;
+        output_str += str_sprintf(index != this->offset ? ",%d" : "%d", b);
         break;
       case RawEncoding::ANSI:
         if (b < 0x20)
@@ -33,25 +29,24 @@ void ModbusTextSensor::parse_and_publish(const std::vector<uint8_t> &data) {
       // FALLTHROUGH
       // Anything else no encoding
       default:
-        output << (char) b;
+        output_str += (char) b;
         break;
     }
     items_left--;
     index++;
   }
 
-  auto result = output.str();
   // Is there a lambda registered
   // call it with the pre converted value and the raw data array
   if (this->transform_func_.has_value()) {
     // the lambda can parse the response itself
-    auto val = (*this->transform_func_)(this, result, data);
+    auto val = (*this->transform_func_)(this, output_str, data);
     if (val.has_value()) {
       ESP_LOGV(TAG, "Value overwritten by lambda");
-      result = val.value();
+      output_str = val.value();
     }
   }
-  this->publish_state(result);
+  this->publish_state(output_str);
 }
 
 }  // namespace modbus_controller


### PR DESCRIPTION
# What does this implement/fix?

SSIA -- reduces binary size by a lot:

## BEFORE
```
Linking .pioenvs/componenttestesp32ard/firmware.elf
RAM:   [=         ]   6.9% (used 22624 bytes from 327680 bytes)
Flash: [===       ]  29.5% (used 541793 bytes from 1835008 bytes)

Linking .pioenvs/componenttestesp32c3ard/firmware.elf
RAM:   [          ]   4.6% (used 15108 bytes from 327680 bytes)
Flash: [===       ]  27.8% (used 510426 bytes from 1835008 bytes)

Linking .pioenvs/componenttestesp32c3idf/firmware.elf
RAM:   [          ]   4.0% (used 13224 bytes from 327680 bytes)
Flash: [===       ]  25.4% (used 466126 bytes from 1835008 bytes)

Linking .pioenvs/componenttestesp32idf/firmware.elf
RAM:   [          ]   4.8% (used 15716 bytes from 327680 bytes)
Flash: [===       ]  28.7% (used 526601 bytes from 1835008 bytes)

RAM:   [=====     ]  49.7% (used 40732 bytes from 81920 bytes)
Flash: [=====     ]  46.9% (used 489831 bytes from 1044464 bytes)

RAM:   [===       ]  30.6% (used 80124 bytes from 262144 bytes)
Flash: [=====     ]  50.6% (used 528312 bytes from 1044480 bytes)
Building .pioenvs/componenttestrp2040ard/firmware.bin
```

## AFTER
```
Linking .pioenvs/componenttestesp32ard/firmware.elf
RAM:   [=         ]   5.2% (used 16940 bytes from 327680 bytes)
Flash: [==        ]  17.3% (used 317237 bytes from 1835008 bytes)

Linking .pioenvs/componenttestesp32c3ard/firmware.elf
RAM:   [          ]   3.2% (used 10412 bytes from 327680 bytes)
Flash: [==        ]  16.3% (used 298866 bytes from 1835008 bytes)

Linking .pioenvs/componenttestesp32c3idf/firmware.elf
RAM:   [          ]   2.6% (used 8464 bytes from 327680 bytes)
Flash: [=         ]  14.8% (used 270748 bytes from 1835008 bytes)

Linking .pioenvs/componenttestesp32idf/firmware.elf
RAM:   [          ]   3.4% (used 11140 bytes from 327680 bytes)
Flash: [==        ]  15.6% (used 285657 bytes from 1835008 bytes)

Linking .pioenvs/componenttestesp8266ard/firmware.elf
RAM:   [====      ]  37.8% (used 30988 bytes from 81920 bytes)
Flash: [===       ]  30.9% (used 322235 bytes from 1044464 bytes)

RAM:   [===       ]  27.5% (used 72056 bytes from 262144 bytes)
Flash: [====      ]  36.3% (used 378912 bytes from 1044480 bytes)
Building .pioenvs/componenttestrp2040ard/firmware.bin
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
