### PR TITLE
[logger] Fix bug causing global log level to be overwritten

### DIFF
--- a/esphome/components/logger/__init__.py
+++ b/esphome/components/logger/__init__.py
@@ -247,8 +247,8 @@ async def to_code(config):
         )
     cg.add(log.pre_setup())
 
-    for tag, level in config[CONF_LOGS].items():
-        cg.add(log.set_log_level(tag, LOG_LEVELS[level]))
+    for tag, log_level in config[CONF_LOGS].items():
+        cg.add(log.set_log_level(tag, LOG_LEVELS[log_level]))
 
     cg.add_define("USE_LOGGER")
     this_severity = LOG_LEVEL_SEVERITY.index(level)

--- a/esphome/components/logger/logger.cpp
+++ b/esphome/components/logger/logger.cpp
@@ -102,9 +102,6 @@ void Logger::log_vprintf_(int level, const char *tag, int line, const __FlashStr
 #endif
 
 int HOT Logger::level_for(const char *tag) {
-  // Uses std::vector<> for low memory footprint, though the vector
-  // could be sorted to minimize lookup times. This feature isn't used that
-  // much anyway so it doesn't matter too much.
   if (this->log_levels_.count(tag) != 0)
     return this->log_levels_[tag];
   return this->current_level_;


### PR DESCRIPTION
# What does this implement/fix?

Overriding logging for individual tags accidentally overwrites the global log level:
```
logger:
  level: DEBUG
  logs:
    esp-idf: NONE
```
Fix this and remove an outdated comment. 

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- related https://github.com/esphome/esphome/pull/8222 

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
