### PR TITLE
2025.2.0b3

### DIFF
--- a/esphome/components/esp32_dac/esp32_dac.h
+++ b/esphome/components/esp32_dac/esp32_dac.h
@@ -7,6 +7,10 @@
 
 #ifdef USE_ESP32
 
+#ifdef USE_ESP_IDF
+#include <driver/dac_oneshot.h>
+#endif
+
 namespace esphome {
 namespace esp32_dac {
 
@@ -16,6 +20,7 @@ class ESP32DAC : public output::FloatOutput, public Component {
 
   /// Initialize pin
   void setup() override;
+  void on_safe_shutdown() override;
   void dump_config() override;
   /// HARDWARE setup_priority
   float get_setup_priority() const override { return setup_priority::HARDWARE; }
@@ -24,6 +29,9 @@ class ESP32DAC : public output::FloatOutput, public Component {
   void write_state(float state) override;
 
   InternalGPIOPin *pin_;
+#ifdef USE_ESP_IDF
+  dac_oneshot_handle_t dac_handle_;
+#endif
 };
 
 }  // namespace esp32_dac

--- a/esphome/components/esp32_dac/output.py
+++ b/esphome/components/esp32_dac/output.py
@@ -1,15 +1,27 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
 from esphome import pins
 from esphome.components import output
-import esphome.config_validation as cv
-import esphome.codegen as cg
+from esphome.components.esp32 import get_esp32_variant
+from esphome.components.esp32.const import VARIANT_ESP32, VARIANT_ESP32S2
 from esphome.const import CONF_ID, CONF_NUMBER, CONF_PIN
 
 DEPENDENCIES = ["esp32"]
 
+DAC_PINS = {
+    VARIANT_ESP32: (25, 26),
+    VARIANT_ESP32S2: (17, 18),
+}
+
 
 def valid_dac_pin(value):
-    num = value[CONF_NUMBER]
-    cv.one_of(25, 26)(num)
+    variant = get_esp32_variant()
+    try:
+        valid_pins = DAC_PINS[variant]
+    except KeyError as ex:
+        raise cv.Invalid(f"DAC is not supported on {variant}") from ex
+    given_pin = value[CONF_NUMBER]
+    cv.one_of(*valid_pins)(given_pin)
     return value
 
 

--- a/esphome/components/logger/__init__.py
+++ b/esphome/components/logger/__init__.py
@@ -247,8 +247,8 @@ async def to_code(config):
         )
     cg.add(log.pre_setup())
 
-    for tag, level in config[CONF_LOGS].items():
-        cg.add(log.set_log_level(tag, LOG_LEVELS[level]))
+    for tag, log_level in config[CONF_LOGS].items():
+        cg.add(log.set_log_level(tag, LOG_LEVELS[log_level]))
 
     cg.add_define("USE_LOGGER")
     this_severity = LOG_LEVEL_SEVERITY.index(level)

--- a/esphome/components/logger/logger.cpp
+++ b/esphome/components/logger/logger.cpp
@@ -102,9 +102,6 @@ void Logger::log_vprintf_(int level, const char *tag, int line, const __FlashStr
 #endif
 
 int HOT Logger::level_for(const char *tag) {
-  // Uses std::vector<> for low memory footprint, though the vector
-  // could be sorted to minimize lookup times. This feature isn't used that
-  // much anyway so it doesn't matter too much.
   if (this->log_levels_.count(tag) != 0)
     return this->log_levels_[tag];
   return this->current_level_;

--- a/esphome/components/online_image/jpeg_image.cpp
+++ b/esphome/components/online_image/jpeg_image.cpp
@@ -58,7 +58,7 @@ int HOT JpegDecoder::decode(uint8_t *buffer, size_t size) {
   }
 
   if (!this->jpeg_.openRAM(buffer, size, draw_callback)) {
-    ESP_LOGE(TAG, "Could not open image for decoding.");
+    ESP_LOGE(TAG, "Could not open image for decoding: %d", this->jpeg_.getLastError());
     return DECODE_ERROR_INVALID_TYPE;
   }
   auto jpeg_type = this->jpeg_.getJPEGType();
@@ -73,7 +73,9 @@ int HOT JpegDecoder::decode(uint8_t *buffer, size_t size) {
 
   this->jpeg_.setUserPointer(this);
   this->jpeg_.setPixelType(RGB8888);
-  this->set_size(this->jpeg_.getWidth(), this->jpeg_.getHeight());
+  if (!this->set_size(this->jpeg_.getWidth(), this->jpeg_.getHeight())) {
+    return DECODE_ERROR_OUT_OF_MEMORY;
+  }
   if (!this->jpeg_.decode(0, 0, 0)) {
     ESP_LOGE(TAG, "Error while decoding.");
     this->jpeg_.close();

--- a/esphome/components/online_image/online_image.cpp
+++ b/esphome/components/online_image/online_image.cpp
@@ -64,33 +64,34 @@ void OnlineImage::release() {
   }
 }
 
-bool OnlineImage::resize_(int width_in, int height_in) {
+size_t OnlineImage::resize_(int width_in, int height_in) {
   int width = this->fixed_width_;
   int height = this->fixed_height_;
-  if (this->auto_resize_()) {
+  if (this->is_auto_resize_()) {
     width = width_in;
     height = height_in;
     if (this->width_ != width && this->height_ != height) {
       this->release();
     }
   }
-  if (this->buffer_) {
-    return false;
-  }
   size_t new_size = this->get_buffer_size_(width, height);
+  if (this->buffer_) {
+    // Buffer already allocated => no need to resize
+    return new_size;
+  }
   ESP_LOGD(TAG, "Allocating new buffer of %zu bytes", new_size);
   this->buffer_ = this->allocator_.allocate(new_size);
   if (this->buffer_ == nullptr) {
     ESP_LOGE(TAG, "allocation of %zu bytes failed. Biggest block in heap: %zu Bytes", new_size,
              this->allocator_.get_max_free_block_size());
     this->end_connection_();
-    return false;
+    return 0;
   }
   this->buffer_width_ = width;
   this->buffer_height_ = height;
   this->width_ = width;
   ESP_LOGV(TAG, "New size: (%d, %d)", width, height);
-  return true;
+  return new_size;
 }
 
 void OnlineImage::update() {

--- a/esphome/components/online_image/online_image.h
+++ b/esphome/components/online_image/online_image.h
@@ -99,9 +99,22 @@ class OnlineImage : public PollingComponent,
 
   int get_position_(int x, int y) const { return (x + y * this->buffer_width_) * this->get_bpp() / 8; }
 
-  ESPHOME_ALWAYS_INLINE bool auto_resize_() const { return this->fixed_width_ == 0 || this->fixed_height_ == 0; }
+  ESPHOME_ALWAYS_INLINE bool is_auto_resize_() const { return this->fixed_width_ == 0 || this->fixed_height_ == 0; }
 
-  bool resize_(int width, int height);
+  /**
+   * @brief Resize the image buffer to the requested dimensions.
+   *
+   * The buffer will be allocated if not existing.
+   * If the dimensions have been fixed in the yaml config, the buffer will be created
+   * with those dimensions and not resized, even on request.
+   * Otherwise, the old buffer will be deallocated and a new buffer with the requested
+   * allocated
+   *
+   * @param width
+   * @param height
+   * @return 0 if no memory could be allocated, the size of the new buffer otherwise.
+   */
+  size_t resize_(int width, int height);
 
   /**
    * @brief Draw a pixel into the buffer.

--- a/esphome/const.py
+++ b/esphome/const.py
@@ -1,6 +1,6 @@
 """Constants used by esphome."""
 
-__version__ = "2025.2.0b2"
+__version__ = "2025.2.0b3"
 
 ALLOWED_NAME_CHARS = "abcdefghijklmnopqrstuvwxyz0123456789-_"
 VALID_SUBSTITUTIONS_CHARACTERS = (

--- a/esphome/dashboard/web_server.py
+++ b/esphome/dashboard/web_server.py
@@ -853,7 +853,7 @@ class InfoRequestHandler(BaseHandler):
         dashboard = DASHBOARD
         entry = dashboard.entries.get(yaml_path)
 
-        if not entry:
+        if not entry or entry.storage is None:
             self.set_status(404)
             return
 


### PR DESCRIPTION
**Do not merge, release script will automatically merge**
## Full list of changes

### All changes

- [online_image]Fix reset if buffer not allocated [esphome#8236](https://github.com/esphome/esphome/pull/8236)
- [logger] Fix bug causing global log level to be overwritten [esphome#8248](https://github.com/esphome/esphome/pull/8248)
- Add support for the DAC on the S2 [esphome#8030](https://github.com/esphome/esphome/pull/8030)
- Fix crash when storage file doesnt exist yet [esphome#8249](https://github.com/esphome/esphome/pull/8249)

<details>
<summary>Metadata</summary>

@coderabbitai ignore
</details>
