### PR TITLE
Bump zeroconf to 0.144.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ esptool==4.7.0
 click==8.1.7
 esphome-dashboard==20250212.0
 aioesphomeapi==24.6.2
-zeroconf==0.144.2
+zeroconf==0.144.3
 puremagic==1.27
 ruamel.yaml==0.18.6 # dashboard_import
 glyphsets==1.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ esptool==4.7.0
 click==8.1.7
 esphome-dashboard==20250212.0
 aioesphomeapi==24.6.2
-zeroconf==0.144.1
+zeroconf==0.144.2
 puremagic==1.27
 ruamel.yaml==0.18.6 # dashboard_import
 glyphsets==1.0.0


### PR DESCRIPTION


# What does this implement/fix?

Improves error message when port 5353 is in use and is blocked by another stack

changelog: https://github.com/python-zeroconf/python-zeroconf/compare/0.144.1...0.144.3

thread: https://ptb.discord.com/channels/429907082951524364/1339781064285229089

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
