### PR TITLE
don't crash on null pages

### DIFF
--- a/esphome/components/display/display.cpp
+++ b/esphome/components/display/display.cpp
@@ -815,8 +815,20 @@ void Display::test_card() {
 
 DisplayPage::DisplayPage(display_writer_t writer) : writer_(std::move(writer)) {}
 void DisplayPage::show() { this->parent_->show_page(this); }
-void DisplayPage::show_next() { this->next_->show(); }
-void DisplayPage::show_prev() { this->prev_->show(); }
+void DisplayPage::show_next() {
+  if (this->next_ == nullptr) {
+    ESP_LOGE(TAG, "no next page");
+    return;
+  }
+  this->next_->show();
+}
+void DisplayPage::show_prev() {
+  if (this->prev_ == nullptr) {
+    ESP_LOGE(TAG, "no previous page");
+    return;
+  }
+  this->prev_->show();
+}
 void DisplayPage::set_parent(Display *parent) { this->parent_ = parent; }
 void DisplayPage::set_prev(DisplayPage *prev) { this->prev_ = prev; }
 void DisplayPage::set_next(DisplayPage *next) { this->next_ = next; }


### PR DESCRIPTION
# What does this implement/fix?

When the graphical display menu creates a page for itself, it doesn't have any next or previous pages.  If you try to change pages, it will crash.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
