### PR TITLE
DHT platform now supports modules with inbuilt external resistor

### DIFF
--- a/esphome/components/dht/dht.cpp
+++ b/esphome/components/dht/dht.cpp
@@ -103,7 +103,9 @@ bool HOT IRAM_ATTR DHT::read_sensor_(float *temperature, float *humidity, bool r
   }
 
   gpio::Flags flags = gpio::FLAG_INPUT;
-  if (this->pin_->get_flags() & gpio::FLAG_PULLUP) {
+  if (this->pin_->get_flags() & gpio::FLAG_PULLDOWN) {
+    flags = flags | gpio::FLAG_PULLDOWN;
+  } else {
     flags = flags | gpio::FLAG_PULLUP;
   }
   this->pin_->pin_mode(flags);

--- a/esphome/components/dht/dht.cpp
+++ b/esphome/components/dht/dht.cpp
@@ -23,7 +23,6 @@ void DHT::dump_config() {
   } else {
     ESP_LOGCONFIG(TAG, "  Model: DHT22 (or equivalent)");
   }
-  ESP_LOGCONFIG(TAG, "  Internal Pull-up: %s", this->use_pullup_ ? "ENABLED" : "DISABLED");
 
   LOG_UPDATE_INTERVAL(this);
 
@@ -104,10 +103,8 @@ bool HOT IRAM_ATTR DHT::read_sensor_(float *temperature, float *humidity, bool r
   }
 
   gpio::Flags flags = gpio::FLAG_INPUT;
-  if (this->use_pullup_) {
+  if (this->pin_->get_flags() & gpio::FLAG_PULLUP) {
     flags = flags | gpio::FLAG_PULLUP;
-  } else {
-    flags = flags | gpio::FLAG_PULLDOWN;
   }
   this->pin_->pin_mode(flags);
 

--- a/esphome/components/dht/dht.cpp
+++ b/esphome/components/dht/dht.cpp
@@ -101,7 +101,6 @@ bool HOT IRAM_ATTR DHT::read_sensor_(float *temperature, float *humidity, bool r
   } else {
     delayMicroseconds(800);
   }
-
   this->pin_->pin_mode(this->pin_->get_flags());
 
   {

--- a/esphome/components/dht/dht.cpp
+++ b/esphome/components/dht/dht.cpp
@@ -23,6 +23,7 @@ void DHT::dump_config() {
   } else {
     ESP_LOGCONFIG(TAG, "  Model: DHT22 (or equivalent)");
   }
+  ESP_LOGCONFIG(TAG, "  Internal Pull-up: %s", ONOFF(this->pin_->get_flags() & gpio::FLAG_PULLUP));
 
   LOG_UPDATE_INTERVAL(this);
 

--- a/esphome/components/dht/dht.cpp
+++ b/esphome/components/dht/dht.cpp
@@ -105,7 +105,9 @@ bool HOT IRAM_ATTR DHT::read_sensor_(float *temperature, float *humidity, bool r
 
   gpio::Flags flags = gpio::FLAG_INPUT;
   if (this->use_pullup_) {
-      flags = flags | gpio::FLAG_PULLUP;
+    flags = flags | gpio::FLAG_PULLUP;
+  } else {
+    flags = flags | gpio::FLAG_PULLDOWN;
   }
   this->pin_->pin_mode(flags);
 

--- a/esphome/components/dht/dht.cpp
+++ b/esphome/components/dht/dht.cpp
@@ -103,7 +103,7 @@ bool HOT IRAM_ATTR DHT::read_sensor_(float *temperature, float *humidity, bool r
     delayMicroseconds(800);
   }
 
-  gpio::Flags flags = gpio::FLAG_INPUT | gpio::FLAG_PULLDOWN;
+  gpio::Flags flags = gpio::FLAG_INPUT;
   if (this->use_pullup_) {
       flags = flags | gpio::FLAG_PULLUP;
   }

--- a/esphome/components/dht/dht.cpp
+++ b/esphome/components/dht/dht.cpp
@@ -102,7 +102,7 @@ bool HOT IRAM_ATTR DHT::read_sensor_(float *temperature, float *humidity, bool r
     delayMicroseconds(800);
   }
 
-  // this->pin_->pin_mode(this->pin_->get_flags());
+  this->pin_->pin_mode(this->pin_->get_flags());
 
   {
     InterruptLock lock;

--- a/esphome/components/dht/dht.cpp
+++ b/esphome/components/dht/dht.cpp
@@ -103,7 +103,7 @@ bool HOT IRAM_ATTR DHT::read_sensor_(float *temperature, float *humidity, bool r
     delayMicroseconds(800);
   }
 
-  gpio::Flags flags = gpio::FLAG_INPUT;
+  gpio::Flags flags = gpio::FLAG_INPUT | gpio::FLAG_PULLDOWN;
   if (this->use_pullup_) {
       flags = flags | gpio::FLAG_PULLUP;
   }

--- a/esphome/components/dht/dht.cpp
+++ b/esphome/components/dht/dht.cpp
@@ -23,6 +23,7 @@ void DHT::dump_config() {
   } else {
     ESP_LOGCONFIG(TAG, "  Model: DHT22 (or equivalent)");
   }
+  ESP_LOGCONFIG(TAG, "  Internal Pull-up: %s", this.use_pullup_ ? "ENABLED" : "DISABLED");
 
   LOG_UPDATE_INTERVAL(this);
 

--- a/esphome/components/dht/dht.cpp
+++ b/esphome/components/dht/dht.cpp
@@ -101,7 +101,12 @@ bool HOT IRAM_ATTR DHT::read_sensor_(float *temperature, float *humidity, bool r
   } else {
     delayMicroseconds(800);
   }
-  this->pin_->pin_mode(gpio::FLAG_INPUT | gpio::FLAG_PULLUP);
+
+  gpio::Flags flags = gpio::FLAG_INPUT;
+  if (this->use_pullup_) {
+      flags = flags | gpio::FLAG_PULLUP;
+  }
+  this->pin_->pin_mode(flags);
 
   {
     InterruptLock lock;

--- a/esphome/components/dht/dht.cpp
+++ b/esphome/components/dht/dht.cpp
@@ -102,13 +102,7 @@ bool HOT IRAM_ATTR DHT::read_sensor_(float *temperature, float *humidity, bool r
     delayMicroseconds(800);
   }
 
-  gpio::Flags flags = gpio::FLAG_INPUT;
-  if (this->pin_->get_flags() & gpio::FLAG_PULLDOWN) {
-    flags = flags | gpio::FLAG_PULLDOWN;
-  } else {
-    flags = flags | gpio::FLAG_PULLUP;
-  }
-  this->pin_->pin_mode(flags);
+  // this->pin_->pin_mode(this->pin_->get_flags());
 
   {
     InterruptLock lock;

--- a/esphome/components/dht/dht.cpp
+++ b/esphome/components/dht/dht.cpp
@@ -23,7 +23,7 @@ void DHT::dump_config() {
   } else {
     ESP_LOGCONFIG(TAG, "  Model: DHT22 (or equivalent)");
   }
-  ESP_LOGCONFIG(TAG, "  Internal Pull-up: %s", this.use_pullup_ ? "ENABLED" : "DISABLED");
+  ESP_LOGCONFIG(TAG, "  Internal Pull-up: %s", this->use_pullup_ ? "ENABLED" : "DISABLED");
 
   LOG_UPDATE_INTERVAL(this);
 

--- a/esphome/components/dht/dht.h
+++ b/esphome/components/dht/dht.h
@@ -40,7 +40,6 @@ class DHT : public PollingComponent {
 
   void set_pin(InternalGPIOPin *pin) { pin_ = pin; }
   void set_model(DHTModel model) { model_ = model; }
-  void set_pullup(bool pullup) { this->use_pullup_ = pullup; }
   void set_temperature_sensor(sensor::Sensor *temperature_sensor) { temperature_sensor_ = temperature_sensor; }
   void set_humidity_sensor(sensor::Sensor *humidity_sensor) { humidity_sensor_ = humidity_sensor; }
 
@@ -58,7 +57,6 @@ class DHT : public PollingComponent {
   InternalGPIOPin *pin_;
   DHTModel model_{DHT_MODEL_AUTO_DETECT};
   bool is_auto_detect_{false};
-  bool use_pullup_{true};
   sensor::Sensor *temperature_sensor_{nullptr};
   sensor::Sensor *humidity_sensor_{nullptr};
 };

--- a/esphome/components/dht/dht.h
+++ b/esphome/components/dht/dht.h
@@ -40,6 +40,7 @@ class DHT : public PollingComponent {
 
   void set_pin(InternalGPIOPin *pin) { pin_ = pin; }
   void set_model(DHTModel model) { model_ = model; }
+  void set_pullup(bool pullup) { this->use_pullup_ = pullup; }
   void set_temperature_sensor(sensor::Sensor *temperature_sensor) { temperature_sensor_ = temperature_sensor; }
   void set_humidity_sensor(sensor::Sensor *humidity_sensor) { humidity_sensor_ = humidity_sensor; }
 
@@ -57,6 +58,7 @@ class DHT : public PollingComponent {
   InternalGPIOPin *pin_;
   DHTModel model_{DHT_MODEL_AUTO_DETECT};
   bool is_auto_detect_{false};
+  bool use_pullup_{true};
   sensor::Sensor *temperature_sensor_{nullptr};
   sensor::Sensor *humidity_sensor_{nullptr};
 };

--- a/esphome/components/dht/sensor.py
+++ b/esphome/components/dht/sensor.py
@@ -34,7 +34,7 @@ DHT = dht_ns.class_("DHT", cg.PollingComponent)
 CONFIG_SCHEMA = cv.Schema(
     {
         cv.GenerateID(): cv.declare_id(DHT),
-        cv.Required(CONF_PIN): pins.internal_gpio_input_pin_schema,
+        cv.Required(CONF_PIN): pins.internal_gpio_input_pullup_pin_schema,
         cv.Optional(CONF_TEMPERATURE): sensor.sensor_schema(
             unit_of_measurement=UNIT_CELSIUS,
             accuracy_decimals=1,

--- a/esphome/components/dht/sensor.py
+++ b/esphome/components/dht/sensor.py
@@ -1,9 +1,7 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome import pins
-import esphome.codegen as cg
 from esphome.components import sensor
-import esphome.config_validation as cv
 from esphome.const import (
     CONF_HUMIDITY,
     CONF_ID,
@@ -13,8 +11,8 @@ from esphome.const import (
     STATE_CLASS_MEASUREMENT,
     UNIT_CELSIUS,
     UNIT_PERCENT,
-    DEVICE_CLASS_HUMIDITY,
     DEVICE_CLASS_TEMPERATURE,
+    DEVICE_CLASS_HUMIDITY,
 )
 from esphome.cpp_helpers import gpio_pin_expression
 

--- a/esphome/components/dht/sensor.py
+++ b/esphome/components/dht/sensor.py
@@ -1,21 +1,19 @@
-import esphome.codegen as cg
-import esphome.config_validation as cv
 from esphome import pins
+import esphome.codegen as cg
 from esphome.components import sensor
+import esphome.config_validation as cv
 from esphome.const import (
     CONF_HUMIDITY,
     CONF_ID,
     CONF_MODEL,
     CONF_PIN,
-    CONF_PULLUP,
     CONF_TEMPERATURE,
+    DEVICE_CLASS_HUMIDITY,
+    DEVICE_CLASS_TEMPERATURE,
     STATE_CLASS_MEASUREMENT,
     UNIT_CELSIUS,
     UNIT_PERCENT,
-    DEVICE_CLASS_TEMPERATURE,
-    DEVICE_CLASS_HUMIDITY,
 )
-
 from esphome.cpp_helpers import gpio_pin_expression
 
 dht_ns = cg.esphome_ns.namespace("dht")
@@ -51,7 +49,6 @@ CONFIG_SCHEMA = cv.Schema(
         cv.Optional(CONF_MODEL, default="auto detect"): cv.enum(
             DHT_MODELS, upper=True, space="_"
         ),
-        cv.Optional(CONF_PULLUP, default=True): cv.boolean
     }
 ).extend(cv.polling_component_schema("60s"))
 
@@ -62,7 +59,6 @@ async def to_code(config):
 
     pin = await gpio_pin_expression(config[CONF_PIN])
     cg.add(var.set_pin(pin))
-    cg.add(var.set_pullup(config[CONF_PULLUP]))
 
     if CONF_TEMPERATURE in config:
         sens = await sensor.new_sensor(config[CONF_TEMPERATURE])

--- a/esphome/components/dht/sensor.py
+++ b/esphome/components/dht/sensor.py
@@ -14,6 +14,7 @@ from esphome.const import (
     DEVICE_CLASS_TEMPERATURE,
     DEVICE_CLASS_HUMIDITY,
 )
+
 from esphome.cpp_helpers import gpio_pin_expression
 
 dht_ns = cg.esphome_ns.namespace("dht")

--- a/esphome/components/dht/sensor.py
+++ b/esphome/components/dht/sensor.py
@@ -1,3 +1,5 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
 from esphome import pins
 import esphome.codegen as cg
 from esphome.components import sensor
@@ -8,11 +10,11 @@ from esphome.const import (
     CONF_MODEL,
     CONF_PIN,
     CONF_TEMPERATURE,
-    DEVICE_CLASS_HUMIDITY,
-    DEVICE_CLASS_TEMPERATURE,
     STATE_CLASS_MEASUREMENT,
     UNIT_CELSIUS,
     UNIT_PERCENT,
+    DEVICE_CLASS_HUMIDITY,
+    DEVICE_CLASS_TEMPERATURE,
 )
 from esphome.cpp_helpers import gpio_pin_expression
 

--- a/esphome/components/dht/sensor.py
+++ b/esphome/components/dht/sensor.py
@@ -7,6 +7,7 @@ from esphome.const import (
     CONF_ID,
     CONF_MODEL,
     CONF_PIN,
+    CONF_PULLUP,
     CONF_TEMPERATURE,
     STATE_CLASS_MEASUREMENT,
     UNIT_CELSIUS,
@@ -50,6 +51,7 @@ CONFIG_SCHEMA = cv.Schema(
         cv.Optional(CONF_MODEL, default="auto detect"): cv.enum(
             DHT_MODELS, upper=True, space="_"
         ),
+        cv.Optional(CONF_PULLUP, default=True): cv.boolean
     }
 ).extend(cv.polling_component_schema("60s"))
 
@@ -60,6 +62,7 @@ async def to_code(config):
 
     pin = await gpio_pin_expression(config[CONF_PIN])
     cg.add(var.set_pin(pin))
+    cg.add(var.set_pullup(config[CONF_PULLUP]))
 
     if CONF_TEMPERATURE in config:
         sens = await sensor.new_sensor(config[CONF_TEMPERATURE])


### PR DESCRIPTION
# What does this implement/fix?
The DHT11 and DHT22 modules that already have an external resistor were not returning any readings with the Raspberry Pi pico w ( RP2040 ) board. The root cause was the configuration of the internal pull-up resistor, which once disabled, the module worked properly and returned proper values.

The following DHT modules were used. They contain SMD 103 on-board resistor - 10K-Ohm.
DHT22 - https://quartzcomponents.com/products/dht22-temprature-and-humidity-sensor-module
DHT11 - https://quartzcomponents.com/products/dht11-temperature-humidity-sensor-module

<!-- Quick description and explanation of changes -->

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/issues/issues/4615 

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#4673

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [x] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
  - platform: dht
    model: DHT22
    pin:
      number: GPIO19
      mode:
        input: true
        pullup: false
    temperature:
      name: "Room Temperature"
    humidity:
      name: "Room Humidity"
    update_interval: 5s

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
