### PR TITLE
Adding support for chsc6x touch controller

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -93,6 +93,7 @@ esphome/components/captive_portal/* @OttoWinter
 esphome/components/ccs811/* @habbie
 esphome/components/cd74hc4067/* @asoehlke
 esphome/components/ch422g/* @clydebarrow @jesterret
+esphome/components/chsc6x/* @kkosik20
 esphome/components/climate/* @esphome/core
 esphome/components/climate_ir/* @glmnet
 esphome/components/color_temperature/* @jesserockz

--- a/esphome/components/chsc6x/__init__.py
+++ b/esphome/components/chsc6x/__init__.py
@@ -1,0 +1,2 @@
+CODEOWNERS = ["@kkosik20"]
+DEPENDENCIES = ["i2c"]

--- a/esphome/components/chsc6x/chsc6x_touchscreen.cpp
+++ b/esphome/components/chsc6x/chsc6x_touchscreen.cpp
@@ -1,0 +1,47 @@
+#include "chsc6x_touchscreen.h"
+
+namespace esphome {
+namespace chsc6x {
+
+void CHSC6XTouchscreen::setup() {
+  ESP_LOGCONFIG(TAG, "Setting up CHSC6X Touchscreen...");
+  if (this->interrupt_pin_ != nullptr) {
+    this->interrupt_pin_->setup();
+    this->attach_interrupt_(this->interrupt_pin_, gpio::INTERRUPT_FALLING_EDGE);
+  }
+  if (this->x_raw_max_ == this->x_raw_min_) {
+    this->x_raw_max_ = this->display_->get_native_width();
+  }
+  if (this->y_raw_max_ == this->y_raw_min_) {
+    this->y_raw_max_ = this->display_->get_native_height();
+  }
+
+  ESP_LOGCONFIG(TAG, "CHSC6X Touchscreen setup complete");
+}
+
+void CHSC6XTouchscreen::update_touches() {
+  uint8_t data[CHSC6X_REG_STATUS_LEN];
+  if (!this->read_bytes(CHSC6X_REG_STATUS, data, sizeof(data))) {
+    return;
+  }
+
+  uint8_t num_of_touches = data[CHSC6X_REG_STATUS_TOUCH];
+
+  if (num_of_touches == 1) {
+    uint16_t x = data[CHSC6X_REG_STATUS_X_COR];
+    uint16_t y = data[CHSC6X_REG_STATUS_Y_COR];
+    this->add_raw_touch_position_(0, x, y);
+  }
+}
+
+void CHSC6XTouchscreen::dump_config() {
+  ESP_LOGCONFIG(TAG, "CHSC6X Touchscreen:");
+  LOG_I2C_DEVICE(this);
+  LOG_PIN("  Interrupt Pin: ", this->interrupt_pin_);
+  ESP_LOGCONFIG(TAG, "  Touch timeout: %d", this->touch_timeout_);
+  ESP_LOGCONFIG(TAG, "  x_raw_max_: %d", this->x_raw_max_);
+  ESP_LOGCONFIG(TAG, "  y_raw_max_: %d", this->y_raw_max_);
+}
+
+}  // namespace chsc6x
+}  // namespace esphome

--- a/esphome/components/chsc6x/chsc6x_touchscreen.h
+++ b/esphome/components/chsc6x/chsc6x_touchscreen.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "esphome/components/i2c/i2c.h"
+#include "esphome/components/touchscreen/touchscreen.h"
+#include "esphome/core/component.h"
+#include "esphome/core/hal.h"
+#include "esphome/core/log.h"
+
+namespace esphome {
+namespace chsc6x {
+
+static const char *const TAG = "chsc6x.touchscreen";
+
+static const uint8_t CHSC6X_REG_STATUS = 0x00;
+static const uint8_t CHSC6X_REG_STATUS_TOUCH = 0x00;
+static const uint8_t CHSC6X_REG_STATUS_X_COR = 0x02;
+static const uint8_t CHSC6X_REG_STATUS_Y_COR = 0x04;
+static const uint8_t CHSC6X_REG_STATUS_LEN = 0x05;
+static const uint8_t CHSC6X_CHIP_ID = 0x2e;
+
+class CHSC6XTouchscreen : public touchscreen::Touchscreen, public i2c::I2CDevice {
+ public:
+  void setup() override;
+  void update_touches() override;
+  void dump_config() override;
+
+  void set_interrupt_pin(InternalGPIOPin *pin) { this->interrupt_pin_ = pin; }
+
+ protected:
+  InternalGPIOPin *interrupt_pin_{};
+};
+
+}  // namespace chsc6x
+}  // namespace esphome

--- a/esphome/components/chsc6x/touchscreen.py
+++ b/esphome/components/chsc6x/touchscreen.py
@@ -1,0 +1,33 @@
+from esphome import pins
+import esphome.codegen as cg
+from esphome.components import i2c, touchscreen
+import esphome.config_validation as cv
+from esphome.const import CONF_ID, CONF_INTERRUPT_PIN
+
+chsc6x_ns = cg.esphome_ns.namespace("chsc6x")
+
+CHSC6XTouchscreen = chsc6x_ns.class_(
+    "CHSC6XTouchscreen",
+    touchscreen.Touchscreen,
+    i2c.I2CDevice,
+)
+
+CONFIG_SCHEMA = (
+    touchscreen.touchscreen_schema("100ms")
+    .extend(
+        {
+            cv.GenerateID(): cv.declare_id(CHSC6XTouchscreen),
+            cv.Optional(CONF_INTERRUPT_PIN): pins.internal_gpio_input_pin_schema,
+        }
+    )
+    .extend(i2c.i2c_device_schema(0x2E))
+)
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await touchscreen.register_touchscreen(var, config)
+    await i2c.register_i2c_device(var, config)
+
+    if interrupt_pin := config.get(CONF_INTERRUPT_PIN):
+        cg.add(var.set_interrupt_pin(await cg.gpio_pin_expression(interrupt_pin)))

--- a/tests/components/chsc6x/test.esp32-ard.yaml
+++ b/tests/components/chsc6x/test.esp32-ard.yaml
@@ -1,0 +1,25 @@
+i2c:
+  - id: i2c_chsc6x
+    scl: 3
+    sda: 21
+
+spi:
+  clk_pin: 16
+  mosi_pin: 17
+
+display:
+  - platform: ili9xxx
+    id: ili9xxx_display
+    model: GC9A01A
+    invert_colors: True
+    cs_pin: 18
+    dc_pin: 19
+    pages:
+      - id: page1
+        lambda: |-
+          it.rectangle(0, 0, it.get_width(), it.get_height());
+
+touchscreen:
+  - platform: chsc6x
+    display: ili9xxx_display
+    interrupt_pin: 20

--- a/tests/components/chsc6x/test.esp32-c3-ard.yaml
+++ b/tests/components/chsc6x/test.esp32-c3-ard.yaml
@@ -1,0 +1,25 @@
+i2c:
+  - id: i2c_chsc6x
+    scl: 3
+    sda: 9
+
+spi:
+  clk_pin: 5
+  mosi_pin: 4
+
+display:
+  - platform: ili9xxx
+    id: ili9xxx_display
+    model: GC9A01A
+    invert_colors: True
+    cs_pin: 18
+    dc_pin: 19
+    pages:
+      - id: page1
+        lambda: |-
+          it.rectangle(0, 0, it.get_width(), it.get_height());
+
+touchscreen:
+  - platform: chsc6x
+    display: ili9xxx_display
+    interrupt_pin: 20

--- a/tests/components/chsc6x/test.esp32-c3-idf.yaml
+++ b/tests/components/chsc6x/test.esp32-c3-idf.yaml
@@ -1,0 +1,25 @@
+i2c:
+  - id: i2c_chsc6x
+    scl: 3
+    sda: 9
+
+spi:
+  clk_pin: 5
+  mosi_pin: 4
+
+display:
+  - platform: ili9xxx
+    id: ili9xxx_display
+    model: GC9A01A
+    invert_colors: True
+    cs_pin: 18
+    dc_pin: 19
+    pages:
+      - id: page1
+        lambda: |-
+          it.rectangle(0, 0, it.get_width(), it.get_height());
+
+touchscreen:
+  - platform: chsc6x
+    display: ili9xxx_display
+    interrupt_pin: 20

--- a/tests/components/chsc6x/test.esp32-idf.yaml
+++ b/tests/components/chsc6x/test.esp32-idf.yaml
@@ -1,0 +1,25 @@
+i2c:
+  - id: i2c_chsc6x
+    scl: 3
+    sda: 21
+
+spi:
+  clk_pin: 16
+  mosi_pin: 17
+
+display:
+  - platform: ili9xxx
+    id: ili9xxx_display
+    model: GC9A01A
+    invert_colors: True
+    cs_pin: 18
+    dc_pin: 19
+    pages:
+      - id: page1
+        lambda: |-
+          it.rectangle(0, 0, it.get_width(), it.get_height());
+
+touchscreen:
+  - platform: chsc6x
+    display: ili9xxx_display
+    interrupt_pin: 20

--- a/tests/components/chsc6x/test.rp2040-ard.yaml
+++ b/tests/components/chsc6x/test.rp2040-ard.yaml
@@ -1,0 +1,25 @@
+i2c:
+  - id: i2c_chsc6x
+    scl: 1
+    sda: 0
+
+spi:
+  clk_pin: 2
+  mosi_pin: 3
+
+display:
+  - platform: ili9xxx
+    id: ili9xxx_display
+    model: GC9A01A
+    invert_colors: True
+    cs_pin: 18
+    dc_pin: 19
+    pages:
+      - id: page1
+        lambda: |-
+          it.rectangle(0, 0, it.get_width(), it.get_height());
+
+touchscreen:
+  - platform: chsc6x
+    display: ili9xxx_display
+    interrupt_pin: 20


### PR DESCRIPTION
# What does this implement/fix?

Adding support for touchscreen chsc6x, used for example in "Studio Round Display for XIAO"

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#4700

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
display:
  - platform: ili9xxx
    model: GC9A01A
    auto_clear_enabled: True
    invert_colors: True
    id: watchface
    cs_pin: GPIO2
    dc_pin: GPIO4
    pages:
      - id: left
        lambda: |-
          it.printf(40, 80, id(my_font), id(my_red), "Left!");
      - id: right
        lambda: |-
          it.printf(40, 80, id(my_font), id(my_red), "Right!");

touchscreen:
  platform: chsc6x
  id: my_touchscreen
  display: watchface
  interrupt_pin: GPIO44
  touch_timeout: 100ms

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

https://github.com/esphome/esphome-docs/pull/4700
