### PR TITLE
2025.2.0b4

### DIFF
--- a/esphome/components/dht/dht.cpp
+++ b/esphome/components/dht/dht.cpp
@@ -23,6 +23,7 @@ void DHT::dump_config() {
   } else {
     ESP_LOGCONFIG(TAG, "  Model: DHT22 (or equivalent)");
   }
+  ESP_LOGCONFIG(TAG, "  Internal Pull-up: %s", ONOFF(this->pin_->get_flags() & gpio::FLAG_PULLUP));
 
   LOG_UPDATE_INTERVAL(this);
 
@@ -101,7 +102,7 @@ bool HOT IRAM_ATTR DHT::read_sensor_(float *temperature, float *humidity, bool r
   } else {
     delayMicroseconds(800);
   }
-  this->pin_->pin_mode(gpio::FLAG_INPUT | gpio::FLAG_PULLUP);
+  this->pin_->pin_mode(this->pin_->get_flags());
 
   {
     InterruptLock lock;

--- a/esphome/components/dht/sensor.py
+++ b/esphome/components/dht/sensor.py
@@ -34,7 +34,7 @@ DHT = dht_ns.class_("DHT", cg.PollingComponent)
 CONFIG_SCHEMA = cv.Schema(
     {
         cv.GenerateID(): cv.declare_id(DHT),
-        cv.Required(CONF_PIN): pins.internal_gpio_input_pin_schema,
+        cv.Required(CONF_PIN): pins.internal_gpio_input_pullup_pin_schema,
         cv.Optional(CONF_TEMPERATURE): sensor.sensor_schema(
             unit_of_measurement=UNIT_CELSIUS,
             accuracy_decimals=1,

--- a/esphome/components/display/display.cpp
+++ b/esphome/components/display/display.cpp
@@ -815,8 +815,20 @@ void Display::test_card() {
 
 DisplayPage::DisplayPage(display_writer_t writer) : writer_(std::move(writer)) {}
 void DisplayPage::show() { this->parent_->show_page(this); }
-void DisplayPage::show_next() { this->next_->show(); }
-void DisplayPage::show_prev() { this->prev_->show(); }
+void DisplayPage::show_next() {
+  if (this->next_ == nullptr) {
+    ESP_LOGE(TAG, "no next page");
+    return;
+  }
+  this->next_->show();
+}
+void DisplayPage::show_prev() {
+  if (this->prev_ == nullptr) {
+    ESP_LOGE(TAG, "no previous page");
+    return;
+  }
+  this->prev_->show();
+}
 void DisplayPage::set_parent(Display *parent) { this->parent_ = parent; }
 void DisplayPage::set_prev(DisplayPage *prev) { this->prev_ = prev; }
 void DisplayPage::set_next(DisplayPage *next) { this->next_ = next; }

--- a/esphome/components/scd30/sensor.py
+++ b/esphome/components/scd30/sensor.py
@@ -75,7 +75,7 @@ CONFIG_SCHEMA = (
             cv.Optional(CONF_UPDATE_INTERVAL, default="60s"): cv.All(
                 cv.positive_time_period_seconds,
                 cv.Range(
-                    min=core.TimePeriod(seconds=1), max=core.TimePeriod(seconds=1800)
+                    min=core.TimePeriod(seconds=2), max=core.TimePeriod(seconds=1800)
                 ),
             ),
         }

--- a/esphome/const.py
+++ b/esphome/const.py
@@ -1,6 +1,6 @@
 """Constants used by esphome."""
 
-__version__ = "2025.2.0b3"
+__version__ = "2025.2.0b4"
 
 ALLOWED_NAME_CHARS = "abcdefghijklmnopqrstuvwxyz0123456789-_"
 VALID_SUBSTITUTIONS_CHARACTERS = (

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ esptool==4.7.0
 click==8.1.7
 esphome-dashboard==20250212.0
 aioesphomeapi==24.6.2
-zeroconf==0.144.1
+zeroconf==0.144.3
 puremagic==1.27
 ruamel.yaml==0.18.6 # dashboard_import
 glyphsets==1.0.0


### PR DESCRIPTION
**Do not merge, release script will automatically merge**
## Full list of changes

### Breaking Changes

- [scd30] Increase minimal CONF_UPDATE_INTERVAL from 1 to 2 seconds [esphome#8256](https://github.com/esphome/esphome/pull/8256) (breaking-change)

### All changes

- don't crash on null pages [esphome#8254](https://github.com/esphome/esphome/pull/8254)
- [scd30] Increase minimal CONF_UPDATE_INTERVAL from 1 to 2 seconds [esphome#8256](https://github.com/esphome/esphome/pull/8256) (breaking-change)
- Bump zeroconf to 0.144.3 [esphome#8253](https://github.com/esphome/esphome/pull/8253)
- DHT platform now supports modules with inbuilt external resistor [esphome#8257](https://github.com/esphome/esphome/pull/8257)

<details>
<summary>Metadata</summary>

@coderabbitai ignore
</details>
