### PR TITLE
Fix unexpected widget update behavior

### DIFF
--- a/esphome/components/lvgl/widgets/animimg.py
+++ b/esphome/components/lvgl/widgets/animimg.py
@@ -23,12 +23,12 @@ def lv_repeat_count(value):
 
 ANIMIMG_BASE_SCHEMA = cv.Schema(
     {
-        cv.Optional(CONF_REPEAT_COUNT, default="forever"): lv_repeat_count,
         cv.Optional(CONF_AUTO_START, default=True): cv.boolean,
     }
 )
 ANIMIMG_SCHEMA = ANIMIMG_BASE_SCHEMA.extend(
     {
+        cv.Optional(CONF_REPEAT_COUNT, default="forever"): lv_repeat_count,
         cv.Required(CONF_DURATION): lv_milliseconds,
         cv.Required(CONF_SRC): lv_image_list,
     }
@@ -36,6 +36,7 @@ ANIMIMG_SCHEMA = ANIMIMG_BASE_SCHEMA.extend(
 
 ANIMIMG_MODIFY_SCHEMA = ANIMIMG_BASE_SCHEMA.extend(
     {
+        cv.Optional(CONF_REPEAT_COUNT): lv_repeat_count,
         cv.Optional(CONF_DURATION): lv_milliseconds,
         cv.Optional(CONF_SRC): lv_image_list,
     }

--- a/esphome/components/lvgl/widgets/animimg.py
+++ b/esphome/components/lvgl/widgets/animimg.py
@@ -23,12 +23,12 @@ def lv_repeat_count(value):
 
 ANIMIMG_BASE_SCHEMA = cv.Schema(
     {
+        cv.Optional(CONF_REPEAT_COUNT, default="forever"): lv_repeat_count,
         cv.Optional(CONF_AUTO_START, default=True): cv.boolean,
     }
 )
 ANIMIMG_SCHEMA = ANIMIMG_BASE_SCHEMA.extend(
     {
-        cv.Optional(CONF_REPEAT_COUNT, default="forever"): lv_repeat_count,
         cv.Required(CONF_DURATION): lv_milliseconds,
         cv.Required(CONF_SRC): lv_image_list,
     }
@@ -36,7 +36,6 @@ ANIMIMG_SCHEMA = ANIMIMG_BASE_SCHEMA.extend(
 
 ANIMIMG_MODIFY_SCHEMA = ANIMIMG_BASE_SCHEMA.extend(
     {
-        cv.Optional(CONF_REPEAT_COUNT): lv_repeat_count,
         cv.Optional(CONF_DURATION): lv_milliseconds,
         cv.Optional(CONF_SRC): lv_image_list,
     }

--- a/esphome/components/lvgl/widgets/arc.py
+++ b/esphome/components/lvgl/widgets/arc.py
@@ -67,10 +67,11 @@ class ArcType(NumberType):
             lv.arc_set_mode(w.obj, literal(config[CONF_MODE]))
             lv.arc_set_change_rate(w.obj, config[CONF_CHANGE_RATE])
 
-        if config.get(CONF_ADJUSTABLE) is False:
+        adjustable = config.get(CONF_ADJUSTABLE)
+        if adjustable is False:
             lv_obj.remove_style(w.obj, nullptr, literal("LV_PART_KNOB"))
             w.clear_flag("LV_OBJ_FLAG_CLICKABLE")
-        elif CONF_GROUP not in config:
+        elif adjustable is True and CONF_GROUP not in config:
             # For some reason arc does not get automatically added to the default group
             lv.group_add_obj(lv_expr.group_get_default(), w.obj)
 

--- a/esphome/components/lvgl/widgets/arc.py
+++ b/esphome/components/lvgl/widgets/arc.py
@@ -67,13 +67,13 @@ class ArcType(NumberType):
             lv.arc_set_mode(w.obj, literal(config[CONF_MODE]))
             lv.arc_set_change_rate(w.obj, config[CONF_CHANGE_RATE])
 
-        adjustable = config.get(CONF_ADJUSTABLE)
-        if adjustable is False:
-            lv_obj.remove_style(w.obj, nullptr, literal("LV_PART_KNOB"))
-            w.clear_flag("LV_OBJ_FLAG_CLICKABLE")
-        elif adjustable is True and CONF_GROUP not in config:
-            # For some reason arc does not get automatically added to the default group
-            lv.group_add_obj(lv_expr.group_get_default(), w.obj)
+        if CONF_ADJUSTABLE in config:
+            if not config[CONF_ADJUSTABLE]:
+                lv_obj.remove_style(w.obj, nullptr, literal("LV_PART_KNOB"))
+                w.clear_flag("LV_OBJ_FLAG_CLICKABLE")
+            elif CONF_GROUP not in config:
+                # For some reason arc does not get automatically added to the default group
+                lv.group_add_obj(lv_expr.group_get_default(), w.obj)
 
         value = await get_start_value(config)
         if value is not None:

--- a/esphome/components/lvgl/widgets/dropdown.py
+++ b/esphome/components/lvgl/widgets/dropdown.py
@@ -36,7 +36,6 @@ DROPDOWN_BASE_SCHEMA = cv.Schema(
         cv.Optional(CONF_SYMBOL): lv_text,
         cv.Exclusive(CONF_SELECTED_INDEX, CONF_SELECTED_TEXT): lv_int,
         cv.Exclusive(CONF_SELECTED_TEXT, CONF_SELECTED_TEXT): lv_text,
-        cv.Optional(CONF_DIR, default="BOTTOM"): DIRECTIONS.one_of,
         cv.Optional(CONF_DROPDOWN_LIST): part_schema(dropdown_list_spec.parts),
     }
 )
@@ -44,12 +43,14 @@ DROPDOWN_BASE_SCHEMA = cv.Schema(
 DROPDOWN_SCHEMA = DROPDOWN_BASE_SCHEMA.extend(
     {
         cv.Required(CONF_OPTIONS): cv.ensure_list(option_string),
+        cv.Optional(CONF_DIR, default="BOTTOM"): DIRECTIONS.one_of,
     }
 )
 
 DROPDOWN_UPDATE_SCHEMA = DROPDOWN_BASE_SCHEMA.extend(
     {
         cv.Optional(CONF_OPTIONS): cv.ensure_list(option_string),
+        cv.Optional(CONF_DIR): DIRECTIONS.one_of,
     }
 )
 

--- a/esphome/components/lvgl/widgets/img.py
+++ b/esphome/components/lvgl/widgets/img.py
@@ -22,8 +22,8 @@ CONF_IMAGE = "image"
 
 BASE_IMG_SCHEMA = cv.Schema(
     {
-        cv.Optional(CONF_PIVOT_X, default="50%"): size,
-        cv.Optional(CONF_PIVOT_Y, default="50%"): size,
+        cv.Optional(CONF_PIVOT_X): size,
+        cv.Optional(CONF_PIVOT_Y): size,
         cv.Optional(CONF_ANGLE): angle,
         cv.Optional(CONF_ZOOM): zoom,
         cv.Optional(CONF_OFFSET_X): size,
@@ -65,10 +65,11 @@ class ImgType(WidgetType):
     async def to_code(self, w: Widget, config):
         if src := config.get(CONF_SRC):
             lv.img_set_src(w.obj, await lv_image.process(src))
-        if (cf_angle := config.get(CONF_ANGLE)) is not None:
-            pivot_x = config[CONF_PIVOT_X]
-            pivot_y = config[CONF_PIVOT_Y]
+        if (pivot_x := config.get(CONF_PIVOT_X)) and (
+            pivot_y := config.get(CONF_PIVOT_Y)
+        ):
             lv.img_set_pivot(w.obj, pivot_x, pivot_y)
+        if (cf_angle := config.get(CONF_ANGLE)) is not None:
             lv.img_set_angle(w.obj, cf_angle)
         if (img_zoom := config.get(CONF_ZOOM)) is not None:
             lv.img_set_zoom(w.obj, img_zoom)


### PR DESCRIPTION
# What does this implement/fix?

- animimg would have an unintended default `repeat_count` of `forever` when updated.
- arc would be added to whatever the current default LVGL input group is when updated.
- dropdown would have an unintended default `direction` of `BOTTOM` when updated.
- image had invalid default values for `pivot_x/y`, which would also be unintended when updating.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)

**Related issue or feature (if applicable):**

- fixes esphome/issues/issues/6759

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs/pull/4677

## Test Environment

- [X] Host

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
