### PR TITLE
Replace glyphsets with esphome_glyphsets

### DIFF
--- a/esphome/components/font/__init__.py
+++ b/esphome/components/font/__init__.py
@@ -5,8 +5,8 @@ import os
 from pathlib import Path
 import re
 
+import esphome_glyphsets as glyphsets
 import freetype
-import glyphsets
 import requests
 
 from esphome import core, external_files

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ aioesphomeapi==24.6.2
 zeroconf==0.144.3
 puremagic==1.27
 ruamel.yaml==0.18.6 # dashboard_import
-glyphsets==1.0.0
+esphome-glyphsets==0.1.0
 pillow==10.4.0
 freetype-py==2.5.1
 


### PR DESCRIPTION

# What does this implement/fix?

We only need two functions from glyphsets and it brings in many deps, including ones that pin to an old EOL protobuf which conflicts with this project.
```
(venv) bdraco@MacBook-Pro-37 esphome % time python -c "import glyphsets"
python -c "import glyphsets"  0.24s user 0.06s system 61% cpu 0.486 total
(venv) bdraco@MacBook-Pro-37 esphome % time python -c "import esphome_glyphsets"
python -c "import esphome_glyphsets"  0.02s user 0.01s system 84% cpu 0.028 total
```

Replace it with a lightweight version that re-implements these simple functions
https://github.com/esphome/esphome-glyphsets

unblocks https://github.com/esphome/esphome/pull/8105

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
