### PR TITLE
Switch to native arm runners for docker CI

### DIFF
--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -33,11 +33,11 @@ concurrency:
 jobs:
   check-docker:
     name: Build docker containers
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        arch: [amd64, aarch64]
+        os: ["ubuntu-latest", "ubuntu-24.04-arm"]
         build_type: ["ha-addon", "docker", "lint"]
     steps:
       - uses: actions/checkout@v4.1.7
@@ -47,8 +47,6 @@ jobs:
           python-version: "3.9"
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3.9.0
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3.4.0
 
       - name: Set TAG
         run: |
@@ -58,6 +56,6 @@ jobs:
         run: |
           docker/build.py \
             --tag "${TAG}" \
-            --arch "${{ matrix.arch }}" \
+            --arch "${{ matrix.os == 'ubuntu-24.04-arm' && 'aarch64' || 'amd64' }}" \
             --build-type "${{ matrix.build_type }}" \
             build


### PR DESCRIPTION
# What does this implement/fix?

Speed up the aarch64 CI builds by quite a bit by using native arm runners.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
