### PR TITLE
dashboard: Implement automatic ping fallback

### DIFF
--- a/docker/ha-addon-rootfs/etc/s6-overlay/s6-rc.d/esphome/run
+++ b/docker/ha-addon-rootfs/etc/s6-overlay/s6-rc.d/esphome/run
@@ -23,10 +23,6 @@ if bashio::config.true 'streamer_mode'; then
     export ESPHOME_STREAMER_MODE=true
 fi
 
-if bashio::config.true 'status_use_ping'; then
-    export ESPHOME_DASHBOARD_USE_PING=true
-fi
-
 if bashio::config.has_value 'relative_url'; then
     export ESPHOME_DASHBOARD_RELATIVE_URL=$(bashio::config 'relative_url')
 fi

--- a/esphome/dashboard/core.py
+++ b/esphome/dashboard/core.py
@@ -24,7 +24,7 @@ _LOGGER = logging.getLogger(__name__)
 
 IGNORED_DEVICES_STORAGE_PATH = "ignored-devices.json"
 
-MDNS_BOOTSTRAP_TIME = 10
+MDNS_BOOTSTRAP_TIME = 7.5
 
 
 @dataclass

--- a/esphome/dashboard/core.py
+++ b/esphome/dashboard/core.py
@@ -24,6 +24,8 @@ _LOGGER = logging.getLogger(__name__)
 
 IGNORED_DEVICES_STORAGE_PATH = "ignored-devices.json"
 
+MDNS_BOOTSTRAP_TIME = 10
+
 
 @dataclass
 class Event:
@@ -137,10 +139,10 @@ class ESPHomeDashboard:
         self.mdns_status = mdns_status
         if mdns_status.async_setup():
             mdns_task = asyncio.create_task(mdns_status.async_run())
-            # Start ping 10 seconds after startup to ensure
+            # Start ping MDNS_BOOTSTRAP_TIME seconds after startup to ensure
             # MDNS has had a chance to resolve the devices
             start_ping_timer = self.loop.call_later(
-                10, self._async_start_ping_status, ping_status
+                MDNS_BOOTSTRAP_TIME, self._async_start_ping_status, ping_status
             )
         else:
             # If mDNS is not available, start the ping status immediately

--- a/esphome/dashboard/core.py
+++ b/esphome/dashboard/core.py
@@ -150,9 +150,8 @@ class ESPHomeDashboard:
             status_thread_mqtt = MqttStatusThread()
             status_thread_mqtt.start()
 
-        shutdown_event = asyncio.Event()
         try:
-            await shutdown_event.wait()
+            await asyncio.Event().wait()
         finally:
             _LOGGER.info("Shutting down...")
             self.stop_event.set()

--- a/esphome/dashboard/core.py
+++ b/esphome/dashboard/core.py
@@ -137,10 +137,10 @@ class ESPHomeDashboard:
         self.mdns_status = mdns_status
         if mdns_status.async_setup():
             mdns_task = asyncio.create_task(mdns_status.async_run())
-            # Start ping 5 seconds after startup to ensure
+            # Start ping 10 seconds after startup to ensure
             # MDNS has had a chance to resolve the devices
             start_ping_timer = self.loop.call_later(
-                5, self._async_start_ping_status, ping_status
+                10, self._async_start_ping_status, ping_status
             )
         else:
             # If mDNS is not available, start the ping status immediately

--- a/esphome/dashboard/core.py
+++ b/esphome/dashboard/core.py
@@ -121,6 +121,9 @@ class ESPHomeDashboard:
                 {"ignored_devices": sorted(self.ignored_devices)}, indent=2, fp=f_handle
             )
 
+    def _async_start_ping_status(self, ping_status: PingStatus) -> None:
+        self._ping_status_task = asyncio.create_task(ping_status.async_run())
+
     async def async_run(self) -> None:
         """Run the dashboard."""
         settings = self.settings
@@ -131,18 +134,17 @@ class ESPHomeDashboard:
         ping_status = PingStatus()
         start_ping_timer: asyncio.TimerHandle | None = None
 
-        def _start_ping_status():
-            self._ping_status_task = asyncio.create_task(ping_status.async_run())
-
         self.mdns_status = mdns_status
         if mdns_status.async_setup():
             mdns_task = asyncio.create_task(mdns_status.async_run())
             # Start ping 5 seconds after startup to ensure
             # MDNS has had a chance to resolve the devices
-            start_ping_timer = self.loop.call_later(5, _start_ping_status)
+            start_ping_timer = self.loop.call_later(
+                5, self._async_start_ping_status, ping_status
+            )
         else:
             # If mDNS is not available, start the ping status immediately
-            _start_ping_status()
+            self._async_start_ping_status(ping_status)
 
         if settings.status_use_mqtt:
             from .status.mqtt import MqttStatusThread

--- a/esphome/dashboard/core.py
+++ b/esphome/dashboard/core.py
@@ -136,7 +136,7 @@ class ESPHomeDashboard:
 
         self.mdns_status = mdns_status
         if mdns_status.async_setup():
-            mdns_task = asyncio.create_task(mdns_status.async_run())
+            mdns_task = asyncio.create_task(mdns_status.async_run(self))
             # Start ping 5 seconds after startup to ensure
             # MDNS has had a chance to resolve the devices
             start_ping_timer = self.loop.call_later(
@@ -149,7 +149,7 @@ class ESPHomeDashboard:
         if settings.status_use_mqtt:
             from .status.mqtt import MqttStatusThread
 
-            status_thread_mqtt = MqttStatusThread()
+            status_thread_mqtt = MqttStatusThread(self)
             status_thread_mqtt.start()
 
         try:

--- a/esphome/dashboard/core.py
+++ b/esphome/dashboard/core.py
@@ -9,7 +9,7 @@ import json
 import logging
 from pathlib import Path
 import threading
-from typing import TYPE_CHECKING, Any, Callable
+from typing import Any, Callable
 
 from esphome.storage_json import ignored_devices_storage_path
 
@@ -17,10 +17,8 @@ from ..zeroconf import DiscoveredImport
 from .dns import DNSCache
 from .entries import DashboardEntries
 from .settings import DashboardSettings
-
-if TYPE_CHECKING:
-    from .status.mdns import MDNSStatus
-
+from .status.mdns import MDNSStatus
+from .status.ping import PingStatus
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -81,6 +79,7 @@ class ESPHomeDashboard:
         "dns_cache",
         "_background_tasks",
         "ignored_devices",
+        "_ping_status_task",
     )
 
     def __init__(self) -> None:
@@ -97,6 +96,7 @@ class ESPHomeDashboard:
         self.dns_cache = DNSCache()
         self._background_tasks: set[asyncio.Task] = set()
         self.ignored_devices: set[str] = set()
+        self._ping_status_task: asyncio.Task | None = None
 
     async def async_setup(self) -> None:
         """Setup the dashboard."""
@@ -125,21 +125,24 @@ class ESPHomeDashboard:
         """Run the dashboard."""
         settings = self.settings
         mdns_task: asyncio.Task | None = None
-        ping_status_task: asyncio.Task | None = None
         await self.entries.async_update_entries()
 
-        if settings.status_use_ping:
-            from .status.ping import PingStatus
+        mdns_status = MDNSStatus()
+        ping_status = PingStatus()
+        start_ping_timer: asyncio.TimerHandle | None = None
 
-            ping_status = PingStatus()
-            ping_status_task = asyncio.create_task(ping_status.async_run())
-        else:
-            from .status.mdns import MDNSStatus
+        def _start_ping_status():
+            self._ping_status_task = asyncio.create_task(ping_status.async_run())
 
-            mdns_status = MDNSStatus()
-            await mdns_status.async_refresh_hosts()
-            self.mdns_status = mdns_status
+        self.mdns_status = mdns_status
+        if mdns_status.async_setup():
             mdns_task = asyncio.create_task(mdns_status.async_run())
+            # Start ping 5 seconds after startup to ensure
+            # MDNS has had a chance to resolve the devices
+            start_ping_timer = self.loop.call_later(5, _start_ping_status)
+        else:
+            # If mDNS is not available, start the ping status immediately
+            _start_ping_status()
 
         if settings.status_use_mqtt:
             from .status.mqtt import MqttStatusThread
@@ -154,8 +157,11 @@ class ESPHomeDashboard:
             _LOGGER.info("Shutting down...")
             self.stop_event.set()
             self.ping_request.set()
-            if ping_status_task:
-                ping_status_task.cancel()
+            if start_ping_timer:
+                start_ping_timer.cancel()
+            if self._ping_status_task:
+                self._ping_status_task.cancel()
+                self._ping_status_task = None
             if mdns_task:
                 mdns_task.cancel()
             if settings.status_use_mqtt:

--- a/esphome/dashboard/core.py
+++ b/esphome/dashboard/core.py
@@ -130,13 +130,13 @@ class ESPHomeDashboard:
         mdns_task: asyncio.Task | None = None
         await self.entries.async_update_entries()
 
-        mdns_status = MDNSStatus()
-        ping_status = PingStatus()
+        mdns_status = MDNSStatus(self)
+        ping_status = PingStatus(self)
         start_ping_timer: asyncio.TimerHandle | None = None
 
         self.mdns_status = mdns_status
         if mdns_status.async_setup():
-            mdns_task = asyncio.create_task(mdns_status.async_run(self))
+            mdns_task = asyncio.create_task(mdns_status.async_run())
             # Start ping 5 seconds after startup to ensure
             # MDNS has had a chance to resolve the devices
             start_ping_timer = self.loop.call_later(

--- a/esphome/dashboard/dns.py
+++ b/esphome/dashboard/dns.py
@@ -18,7 +18,7 @@ RESOLVE_TIMEOUT = 2.5
 async def _async_resolve_wrapper(hostname: str) -> list[str] | Exception:
     """Wrap the icmplib async_resolve function."""
     with suppress(ValueError):
-        return ip_address(hostname)
+        return [ip_address(hostname)]
     try:
         async with async_timeout(RESOLVE_TIMEOUT):
             return await async_resolve(hostname)

--- a/esphome/dashboard/dns.py
+++ b/esphome/dashboard/dns.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import asyncio
+from contextlib import suppress
+from ipaddress import ip_address
 import sys
 
 from icmplib import NameLookupError, async_resolve
@@ -10,11 +12,15 @@ if sys.version_info >= (3, 11):
 else:
     from async_timeout import timeout as async_timeout
 
+RESOLVE_TIMEOUT = 2.5
+
 
 async def _async_resolve_wrapper(hostname: str) -> list[str] | Exception:
     """Wrap the icmplib async_resolve function."""
+    with suppress(ValueError):
+        return ip_address(hostname)
     try:
-        async with async_timeout(2):
+        async with async_timeout(RESOLVE_TIMEOUT):
             return await async_resolve(hostname)
     except (asyncio.TimeoutError, NameLookupError, UnicodeError) as ex:
         return ex

--- a/esphome/dashboard/dns.py
+++ b/esphome/dashboard/dns.py
@@ -12,7 +12,7 @@ if sys.version_info >= (3, 11):
 else:
     from async_timeout import timeout as async_timeout
 
-RESOLVE_TIMEOUT = 2.5
+RESOLVE_TIMEOUT = 3.0
 
 
 async def _async_resolve_wrapper(hostname: str) -> list[str] | Exception:

--- a/esphome/dashboard/dns.py
+++ b/esphome/dashboard/dns.py
@@ -18,7 +18,7 @@ RESOLVE_TIMEOUT = 2.5
 async def _async_resolve_wrapper(hostname: str) -> list[str] | Exception:
     """Wrap the icmplib async_resolve function."""
     with suppress(ValueError):
-        return [ip_address(hostname)]
+        return [str(ip_address(hostname))]
     try:
         async with async_timeout(RESOLVE_TIMEOUT):
             return await async_resolve(hostname)

--- a/esphome/dashboard/entries.py
+++ b/esphome/dashboard/entries.py
@@ -39,6 +39,7 @@ class EntryStateSource(StrEnum):
     MDNS = "mdns"
     PING = "ping"
     MQTT = "mqtt"
+    UNKNOWN = "unknown"
 
 
 class ReachableState(StrEnum):
@@ -278,7 +279,7 @@ class DashboardEntry:
         self._storage_path = ext_storage_path(self.filename)
         self.cache_key = cache_key
         self.storage: StorageJSON | None = None
-        self.state = EntryState.UNKNOWN
+        self.state = EntryState(ReachableState.UNKNOWN, EntryStateSource.UNKNOWN)
         self._to_dict: dict[str, Any] | None = None
 
     def __repr__(self) -> str:

--- a/esphome/dashboard/entries.py
+++ b/esphome/dashboard/entries.py
@@ -68,7 +68,7 @@ UNKNOWN_STATE = EntryState(ReachableState.UNKNOWN, EntryStateSource.UNKNOWN)
 
 
 @lru_cache  # creating frozen dataclass instances is expensive, so we cache them
-def bool_to_entry_state(value: bool, source: EntryStateSource) -> EntryState:
+def bool_to_entry_state(value: bool | None, source: EntryStateSource) -> EntryState:
     """Convert a bool to an entry state."""
     return EntryState(_BOOL_TO_REACHABLE_STATE[value], source)
 

--- a/esphome/dashboard/entries.py
+++ b/esphome/dashboard/entries.py
@@ -47,6 +47,7 @@ class EntryStateSource(StrEnum):
 class ReachableState(StrEnum):
     ONLINE = "online"
     OFFLINE = "offline"
+    DNS_FAILURE = "dns_failure"
     UNKNOWN = "unknown"
 
 
@@ -58,6 +59,7 @@ _BOOL_TO_REACHABLE_STATE = {
 _REACHABLE_STATE_TO_BOOL = {
     ReachableState.ONLINE: True,
     ReachableState.OFFLINE: False,
+    ReachableState.DNS_FAILURE: False,
     ReachableState.UNKNOWN: None,
 }
 

--- a/esphome/dashboard/entries.py
+++ b/esphome/dashboard/entries.py
@@ -67,7 +67,7 @@ _REACHABLE_STATE_TO_BOOL = {
 UNKNOWN_STATE = EntryState(ReachableState.UNKNOWN, EntryStateSource.UNKNOWN)
 
 
-@lru_cache
+@lru_cache  # creating frozen dataclass instances is expensive, so we cache them
 def bool_to_entry_state(value: bool, source: EntryStateSource) -> EntryState:
     """Convert a bool to an entry state."""
     return EntryState(_BOOL_TO_REACHABLE_STATE[value], source)

--- a/esphome/dashboard/entries.py
+++ b/esphome/dashboard/entries.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 from collections import defaultdict
 from dataclasses import dataclass
+from functools import lru_cache
 import logging
 import os
 from typing import TYPE_CHECKING, Any
@@ -29,7 +30,7 @@ _LOGGER = logging.getLogger(__name__)
 DashboardCacheKeyType = tuple[int, int, float, int]
 
 
-@dataclass
+@dataclass(frozen=True)
 class EntryState:
     """Represents the state of an entry."""
 
@@ -66,6 +67,7 @@ _REACHABLE_STATE_TO_BOOL = {
 UNKNOWN_STATE = EntryState(ReachableState.UNKNOWN, EntryStateSource.UNKNOWN)
 
 
+@lru_cache
 def bool_to_entry_state(value: bool, source: EntryStateSource) -> EntryState:
     """Convert a bool to an entry state."""
     return EntryState(_BOOL_TO_REACHABLE_STATE[value], source)

--- a/esphome/dashboard/entries.py
+++ b/esphome/dashboard/entries.py
@@ -31,6 +31,8 @@ DashboardCacheKeyType = tuple[int, int, float, int]
 
 @dataclass
 class EntryState:
+    """Represents the state of an entry."""
+
     reachable: ReachableState
     source: EntryStateSource
 
@@ -58,6 +60,8 @@ _REACHABLE_STATE_TO_BOOL = {
     ReachableState.OFFLINE: False,
     ReachableState.UNKNOWN: None,
 }
+
+UNKNOWN_STATE = EntryState(ReachableState.UNKNOWN, EntryStateSource.UNKNOWN)
 
 
 def bool_to_entry_state(value: bool, source: EntryStateSource) -> EntryState:
@@ -279,7 +283,7 @@ class DashboardEntry:
         self._storage_path = ext_storage_path(self.filename)
         self.cache_key = cache_key
         self.storage: StorageJSON | None = None
-        self.state = EntryState(ReachableState.UNKNOWN, EntryStateSource.UNKNOWN)
+        self.state = UNKNOWN_STATE
         self._to_dict: dict[str, Any] | None = None
 
     def __repr__(self) -> str:

--- a/esphome/dashboard/entries.py
+++ b/esphome/dashboard/entries.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from collections import defaultdict
+from dataclasses import dataclass
 import logging
 import os
 from typing import TYPE_CHECKING, Any
@@ -27,37 +28,45 @@ _LOGGER = logging.getLogger(__name__)
 
 DashboardCacheKeyType = tuple[int, int, float, int]
 
-# Currently EntryState is a simple
-# online/offline/unknown enum, but in the future
-# it may be expanded to include more states
+
+@dataclass
+class EntryState:
+    reachable: ReachableState
+    source: EntryStateSource
 
 
-class EntryState(StrEnum):
+class EntryStateSource(StrEnum):
+    MDNS = "mdns"
+    PING = "ping"
+    MQTT = "mqtt"
+
+
+class ReachableState(StrEnum):
     ONLINE = "online"
     OFFLINE = "offline"
     UNKNOWN = "unknown"
 
 
-_BOOL_TO_ENTRY_STATE = {
-    True: EntryState.ONLINE,
-    False: EntryState.OFFLINE,
-    None: EntryState.UNKNOWN,
+_BOOL_TO_REACHABLE_STATE = {
+    True: ReachableState.ONLINE,
+    False: ReachableState.OFFLINE,
+    None: ReachableState.UNKNOWN,
 }
-_ENTRY_STATE_TO_BOOL = {
-    EntryState.ONLINE: True,
-    EntryState.OFFLINE: False,
-    EntryState.UNKNOWN: None,
+_REACHABLE_STATE_TO_BOOL = {
+    ReachableState.ONLINE: True,
+    ReachableState.OFFLINE: False,
+    ReachableState.UNKNOWN: None,
 }
 
 
-def bool_to_entry_state(value: bool) -> EntryState:
+def bool_to_entry_state(value: bool, source: EntryStateSource) -> EntryState:
     """Convert a bool to an entry state."""
-    return _BOOL_TO_ENTRY_STATE[value]
+    return EntryState(_BOOL_TO_REACHABLE_STATE[value], source)
 
 
 def entry_state_to_bool(value: EntryState) -> bool | None:
     """Convert an entry state to a bool."""
-    return _ENTRY_STATE_TO_BOOL[value]
+    return _REACHABLE_STATE_TO_BOOL[value.reachable]
 
 
 class DashboardEntries:

--- a/esphome/dashboard/entries.py
+++ b/esphome/dashboard/entries.py
@@ -137,6 +137,55 @@ class DashboardEntries:
         """Set the state for an entry."""
         self.async_set_state(entry, state)
 
+    def set_state_if_online_or_source(
+        self, entry: DashboardEntry, state: EntryState
+    ) -> None:
+        """Set the state for an entry if its online or provided by the source or unknown."""
+        asyncio.run_coroutine_threadsafe(
+            self._async_set_state_if_online_or_source(entry, state), self._loop
+        ).result()
+
+    async def _async_set_state_if_online_or_source(
+        self, entry: DashboardEntry, state: EntryState
+    ) -> None:
+        """Set the state for an entry if its online or provided by the source or unknown."""
+        self.async_set_state_if_online_or_source(entry, state)
+
+    def async_set_state_if_online_or_source(
+        self, entry: DashboardEntry, state: EntryState
+    ) -> None:
+        """Set the state for an entry if its online or provided by the source or unknown."""
+        if (
+            state.reachable is ReachableState.ONLINE
+            and entry.state.reachable is not ReachableState.ONLINE
+        ) or entry.state.source in (
+            EntryStateSource.UNKNOWN,
+            state.source,
+        ):
+            self.async_set_state(entry, state)
+
+    def set_state_if_source(self, entry: DashboardEntry, state: EntryState) -> None:
+        """Set the state for an entry if provided by the source or unknown."""
+        asyncio.run_coroutine_threadsafe(
+            self._async_set_state_if_source(entry, state), self._loop
+        ).result()
+
+    async def _async_set_state_if_source(
+        self, entry: DashboardEntry, state: EntryState
+    ) -> None:
+        """Set the state for an entry if rovided by the source or unknown."""
+        self.async_set_state_if_source(entry, state)
+
+    def async_set_state_if_source(
+        self, entry: DashboardEntry, state: EntryState
+    ) -> None:
+        """Set the state for an entry if provided by the source or unknown."""
+        if entry.state.source in (
+            EntryStateSource.UNKNOWN,
+            state.source,
+        ):
+            self.async_set_state(entry, state)
+
     def async_set_state(self, entry: DashboardEntry, state: EntryState) -> None:
         """Set the state for an entry."""
         if entry.state == state:

--- a/esphome/dashboard/settings.py
+++ b/esphome/dashboard/settings.py
@@ -55,10 +55,6 @@ class DashboardSettings:
         return os.getenv("ESPHOME_DASHBOARD_RELATIVE_URL") or "/"
 
     @property
-    def status_use_ping(self):
-        return get_bool_env("ESPHOME_DASHBOARD_USE_PING")
-
-    @property
     def status_use_mqtt(self) -> bool:
         return get_bool_env("ESPHOME_DASHBOARD_USE_MQTT")
 

--- a/esphome/dashboard/status/mdns.py
+++ b/esphome/dashboard/status/mdns.py
@@ -65,9 +65,7 @@ class MDNSStatus:
                 # the device won't respond to a request to ._esphomelib._tcp.local.
                 poll_names.setdefault(entry.name, set()).add(entry)
             elif (online := host_mdns_state.get(entry.name, SENTINEL)) != SENTINEL:
-                entries.async_set_state(
-                    entry, bool_to_entry_state(online, EntryStateSource.MDNS)
-                )
+                self._async_set_state(entry, online)
         if poll_names and self.aiozc:
             results = await asyncio.gather(
                 *(self.aiozc.async_resolve_host(name) for name in poll_names)
@@ -76,15 +74,19 @@ class MDNSStatus:
                 result = bool(address_list)
                 host_mdns_state[name] = result
                 for entry in poll_names[name]:
-                    # If we can reach it via mDNS, we always set it
-                    # online, however if we can't reach it via mDNS
-                    # we only set it to offline if the state is unknown
-                    # or from mDNS
-                    state = bool_to_entry_state(result, EntryStateSource.MDNS)
-                    if result:
-                        entries.async_set_state(entry, state)
-                    else:
-                        entries.async_set_state_if_source(entry, state)
+                    self._async_set_state(entry, result)
+
+    def _async_set_state(self, entry: DashboardEntry, result: bool | None) -> None:
+        """Set the state of an entry."""
+        # If we can reach it via mDNS, we always set it
+        # online, however if we can't reach it via mDNS
+        # we only set it to offline if the state is unknown
+        # or from mDNS
+        state = bool_to_entry_state(result, EntryStateSource.MDNS)
+        if result:
+            self.dashboard.entries.async_set_state(entry, state)
+        else:
+            self.dashboard.entries.async_set_state_if_source(entry, state)
 
     async def async_run(self) -> None:
         """Run the mdns status."""
@@ -98,14 +100,7 @@ class MDNSStatus:
                 host_mdns_state[name] = result
                 if matching_entries := entries.get_by_name(name):
                     for entry in matching_entries:
-                        # If its reachable via mDNS, we always set it
-                        # to online even if no_mdns is set since we can
-                        # reach it via mDNS
-                        if result or not entry.no_mdns:
-                            entries.async_set_state(
-                                entry,
-                                bool_to_entry_state(result, EntryStateSource.MDNS),
-                            )
+                        self._async_set_state(entry, result)
 
         stat = DashboardStatus(on_update)
         imports = DashboardImportDiscovery()

--- a/esphome/dashboard/status/mdns.py
+++ b/esphome/dashboard/status/mdns.py
@@ -13,7 +13,12 @@ from esphome.zeroconf import (
 )
 
 from ..const import SENTINEL
-from ..entries import DashboardEntry, EntryStateSource, bool_to_entry_state
+from ..entries import (
+    DashboardEntry,
+    EntryStateSource,
+    ReachableState,
+    bool_to_entry_state,
+)
 
 if typing.TYPE_CHECKING:
     from ..core import ESPHomeDashboard
@@ -77,7 +82,8 @@ class MDNSStatus:
                 host_mdns_state[name] = result
                 for entry in poll_names[name]:
                     if (
-                        entry.state.source is EntryStateSource.UNKNOWN
+                        (result and entry.state.reachable is not ReachableState.ONLINE)
+                        or entry.state.source is EntryStateSource.UNKNOWN
                         or entry.state.source is EntryStateSource.MDNS
                     ):
                         entries.async_set_state(

--- a/esphome/dashboard/status/mdns.py
+++ b/esphome/dashboard/status/mdns.py
@@ -81,10 +81,12 @@ class MDNSStatus:
                 result = bool(address_list)
                 host_mdns_state[name] = result
                 for entry in poll_names[name]:
+                    state = entry.state
                     if (
-                        (result and entry.state.reachable is not ReachableState.ONLINE)
-                        or entry.state.source is EntryStateSource.UNKNOWN
-                        or entry.state.source is EntryStateSource.MDNS
+                        result and state.reachable is not ReachableState.ONLINE
+                    ) or state.source in (
+                        EntryStateSource.UNKNOWN,
+                        EntryStateSource.MDNS,
                     ):
                         entries.async_set_state(
                             entry, bool_to_entry_state(result, EntryStateSource.MDNS)

--- a/esphome/dashboard/status/mdns.py
+++ b/esphome/dashboard/status/mdns.py
@@ -102,11 +102,10 @@ class MDNSStatus:
                 host_mdns_state[name] = result
                 if matching_entries := entries.get_by_name(name):
                     for entry in matching_entries:
-                        if not entry.no_mdns:
-                            entries.async_set_state(
-                                entry,
-                                bool_to_entry_state(result, EntryStateSource.MDNS),
-                            )
+                        entries.async_set_state(
+                            entry,
+                            bool_to_entry_state(result, EntryStateSource.MDNS),
+                        )
 
         stat = DashboardStatus(on_update)
         imports = DashboardImportDiscovery()

--- a/esphome/dashboard/status/mdns.py
+++ b/esphome/dashboard/status/mdns.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import typing
 
 from esphome.zeroconf import (
     ESPHOME_SERVICE_TYPE,
@@ -12,8 +13,10 @@ from esphome.zeroconf import (
 )
 
 from ..const import SENTINEL
-from ..core import DASHBOARD
 from ..entries import DashboardEntry, EntryStateSource, bool_to_entry_state
+
+if typing.TYPE_CHECKING:
+    from ..core import ESPHomeDashboard
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -21,13 +24,14 @@ _LOGGER = logging.getLogger(__name__)
 class MDNSStatus:
     """Class that updates the mdns status."""
 
-    def __init__(self) -> None:
+    def __init__(self, dashboard: ESPHomeDashboard) -> None:
         """Initialize the MDNSStatus class."""
         super().__init__()
         self.aiozc: AsyncEsphomeZeroconf | None = None
         # This is the current mdns state for each host (True, False, None)
         self.host_mdns_state: dict[str, bool | None] = {}
         self._loop = asyncio.get_running_loop()
+        self.dashboard = dashboard
 
     def async_setup(self) -> bool:
         """Set up the MDNSStatus class."""
@@ -44,9 +48,9 @@ class MDNSStatus:
             return await aiozc.async_resolve_host(host_name)
         return None
 
-    async def async_refresh_hosts(self):
+    async def async_refresh_hosts(self) -> None:
         """Refresh the hosts to track."""
-        dashboard = DASHBOARD
+        dashboard = self.dashboard
         host_mdns_state = self.host_mdns_state
         entries = dashboard.entries
         poll_names: dict[str, set[DashboardEntry]] = {}
@@ -77,7 +81,8 @@ class MDNSStatus:
                     )
 
     async def async_run(self) -> None:
-        dashboard = DASHBOARD
+        """Run the mdns status."""
+        dashboard = self.dashboard
         entries = dashboard.entries
         host_mdns_state = self.host_mdns_state
 
@@ -105,7 +110,7 @@ class MDNSStatus:
 
         ping_request = dashboard.ping_request
         while not dashboard.stop_event.is_set():
-            await self.async_refresh_hosts()
+            await self.async_refresh_hosts(dashboard)
             await ping_request.wait()
             ping_request.clear()
 

--- a/esphome/dashboard/status/mdns.py
+++ b/esphome/dashboard/status/mdns.py
@@ -78,14 +78,16 @@ class MDNSStatus:
 
     def _async_set_state(self, entry: DashboardEntry, result: bool | None) -> None:
         """Set the state of an entry."""
-        # If we can reach it via mDNS, we always set it
-        # online, however if we can't reach it via mDNS
-        # we only set it to offline if the state is unknown
-        # or from mDNS
+
         state = bool_to_entry_state(result, EntryStateSource.MDNS)
         if result:
+            # If we can reach it via mDNS, we always set it online
+            # since its the fastest source if its working
             self.dashboard.entries.async_set_state(entry, state)
         else:
+            # However if we can't reach it via mDNS
+            # we only set it to offline if the state is unknown
+            # or from mDNS
             self.dashboard.entries.async_set_state_if_source(entry, state)
 
     async def async_run(self) -> None:

--- a/esphome/dashboard/status/mdns.py
+++ b/esphome/dashboard/status/mdns.py
@@ -38,7 +38,9 @@ class MDNSStatus:
         try:
             self.aiozc = AsyncEsphomeZeroconf()
         except OSError as e:
-            _LOGGER.error("Error initializing zeroconf: %s", e)
+            _LOGGER.warning(
+                "Failed to initialize zeroconf, will fallback to ping: %s", e
+            )
             return False
         return True
 

--- a/esphome/dashboard/status/mdns.py
+++ b/esphome/dashboard/status/mdns.py
@@ -78,7 +78,6 @@ class MDNSStatus:
 
     def _async_set_state(self, entry: DashboardEntry, result: bool | None) -> None:
         """Set the state of an entry."""
-
         state = bool_to_entry_state(result, EntryStateSource.MDNS)
         if result:
             # If we can reach it via mDNS, we always set it online

--- a/esphome/dashboard/status/mdns.py
+++ b/esphome/dashboard/status/mdns.py
@@ -82,6 +82,10 @@ class MDNSStatus:
                 host_mdns_state[name] = result
                 for entry in poll_names[name]:
                     state = entry.state
+                    # If we can reach it via mDNS, we always set it
+                    # online, however if we can't reach it via mDNS
+                    # we only set it to offline if the state is unknown
+                    # or from mDNS
                     if (
                         result and state.reachable is not ReachableState.ONLINE
                     ) or state.source in (
@@ -104,6 +108,9 @@ class MDNSStatus:
                 host_mdns_state[name] = result
                 if matching_entries := entries.get_by_name(name):
                     for entry in matching_entries:
+                        # If its reachable via mDNS, we always set it
+                        # to online even if no_mdns is set since we can
+                        # reach it via mDNS
                         if result or not entry.no_mdns:
                             entries.async_set_state(
                                 entry,

--- a/esphome/dashboard/status/mdns.py
+++ b/esphome/dashboard/status/mdns.py
@@ -37,7 +37,7 @@ class MDNSStatus:
         """Set up the MDNSStatus class."""
         try:
             self.aiozc = AsyncEsphomeZeroconf()
-        except Exception as e:
+        except OSError as e:
             _LOGGER.error("Error initializing zeroconf: %s", e)
             return False
         return True

--- a/esphome/dashboard/status/mdns.py
+++ b/esphome/dashboard/status/mdns.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 
 from esphome.zeroconf import (
     ESPHOME_SERVICE_TYPE,
@@ -14,6 +15,8 @@ from ..const import SENTINEL
 from ..core import DASHBOARD
 from ..entries import DashboardEntry, EntryStateSource, bool_to_entry_state
 
+_LOGGER = logging.getLogger(__name__)
+
 
 class MDNSStatus:
     """Class that updates the mdns status."""
@@ -25,6 +28,15 @@ class MDNSStatus:
         # This is the current mdns state for each host (True, False, None)
         self.host_mdns_state: dict[str, bool | None] = {}
         self._loop = asyncio.get_running_loop()
+
+    def async_setup(self) -> bool:
+        """Set up the MDNSStatus class."""
+        try:
+            self.aiozc = AsyncEsphomeZeroconf()
+        except Exception as e:
+            _LOGGER.error("Error initializing zeroconf: %s", e)
+            return False
+        return True
 
     async def async_resolve_host(self, host_name: str) -> list[str] | None:
         """Resolve a host name to an address in a thread-safe manner."""
@@ -67,8 +79,6 @@ class MDNSStatus:
     async def async_run(self) -> None:
         dashboard = DASHBOARD
         entries = dashboard.entries
-        aiozc = AsyncEsphomeZeroconf()
-        self.aiozc = aiozc
         host_mdns_state = self.host_mdns_state
 
         def on_update(dat: dict[str, bool | None]) -> None:
@@ -88,7 +98,7 @@ class MDNSStatus:
         dashboard.import_result = imports.import_state
 
         browser = DashboardBrowser(
-            aiozc.zeroconf,
+            self.aiozc.zeroconf,
             ESPHOME_SERVICE_TYPE,
             [stat.browser_callback, imports.browser_callback],
         )
@@ -100,5 +110,5 @@ class MDNSStatus:
             ping_request.clear()
 
         await browser.async_cancel()
-        await aiozc.async_close()
+        await self.aiozc.async_close()
         self.aiozc = None

--- a/esphome/dashboard/status/mdns.py
+++ b/esphome/dashboard/status/mdns.py
@@ -76,9 +76,13 @@ class MDNSStatus:
                 result = bool(address_list)
                 host_mdns_state[name] = result
                 for entry in poll_names[name]:
-                    entries.async_set_state(
-                        entry, bool_to_entry_state(result, EntryStateSource.MDNS)
-                    )
+                    if (
+                        entry.state.source is EntryStateSource.UNKNOWN
+                        or entry.state.source is EntryStateSource.MDNS
+                    ):
+                        entries.async_set_state(
+                            entry, bool_to_entry_state(result, EntryStateSource.MDNS)
+                        )
 
     async def async_run(self) -> None:
         """Run the mdns status."""

--- a/esphome/dashboard/status/mdns.py
+++ b/esphome/dashboard/status/mdns.py
@@ -102,10 +102,11 @@ class MDNSStatus:
                 host_mdns_state[name] = result
                 if matching_entries := entries.get_by_name(name):
                     for entry in matching_entries:
-                        entries.async_set_state(
-                            entry,
-                            bool_to_entry_state(result, EntryStateSource.MDNS),
-                        )
+                        if result or not entry.no_mdns:
+                            entries.async_set_state(
+                                entry,
+                                bool_to_entry_state(result, EntryStateSource.MDNS),
+                            )
 
         stat = DashboardStatus(on_update)
         imports = DashboardImportDiscovery()

--- a/esphome/dashboard/status/mdns.py
+++ b/esphome/dashboard/status/mdns.py
@@ -13,12 +13,7 @@ from esphome.zeroconf import (
 )
 
 from ..const import SENTINEL
-from ..entries import (
-    DashboardEntry,
-    EntryStateSource,
-    ReachableState,
-    bool_to_entry_state,
-)
+from ..entries import DashboardEntry, EntryStateSource, bool_to_entry_state
 
 if typing.TYPE_CHECKING:
     from ..core import ESPHomeDashboard
@@ -81,20 +76,13 @@ class MDNSStatus:
                 result = bool(address_list)
                 host_mdns_state[name] = result
                 for entry in poll_names[name]:
-                    state = entry.state
                     # If we can reach it via mDNS, we always set it
                     # online, however if we can't reach it via mDNS
                     # we only set it to offline if the state is unknown
                     # or from mDNS
-                    if (
-                        result and state.reachable is not ReachableState.ONLINE
-                    ) or state.source in (
-                        EntryStateSource.UNKNOWN,
-                        EntryStateSource.MDNS,
-                    ):
-                        entries.async_set_state(
-                            entry, bool_to_entry_state(result, EntryStateSource.MDNS)
-                        )
+                    entries.async_set_state_if_online_or_source(
+                        entry, bool_to_entry_state(result, EntryStateSource.MDNS)
+                    )
 
     async def async_run(self) -> None:
         """Run the mdns status."""

--- a/esphome/dashboard/status/mdns.py
+++ b/esphome/dashboard/status/mdns.py
@@ -80,9 +80,11 @@ class MDNSStatus:
                     # online, however if we can't reach it via mDNS
                     # we only set it to offline if the state is unknown
                     # or from mDNS
-                    entries.async_set_state_if_online_or_source(
-                        entry, bool_to_entry_state(result, EntryStateSource.MDNS)
-                    )
+                    state = bool_to_entry_state(result, EntryStateSource.MDNS)
+                    if result:
+                        entries.async_set_state(entry, state)
+                    else:
+                        entries.async_set_state_if_source(entry, state)
 
     async def async_run(self) -> None:
         """Run the mdns status."""

--- a/esphome/dashboard/status/mdns.py
+++ b/esphome/dashboard/status/mdns.py
@@ -12,7 +12,7 @@ from esphome.zeroconf import (
 
 from ..const import SENTINEL
 from ..core import DASHBOARD
-from ..entries import DashboardEntry, bool_to_entry_state
+from ..entries import DashboardEntry, EntryStateSource, bool_to_entry_state
 
 
 class MDNSStatus:
@@ -49,7 +49,9 @@ class MDNSStatus:
                 # the device won't respond to a request to ._esphomelib._tcp.local.
                 poll_names.setdefault(entry.name, set()).add(entry)
             elif (online := host_mdns_state.get(entry.name, SENTINEL)) != SENTINEL:
-                entries.async_set_state(entry, bool_to_entry_state(online))
+                entries.async_set_state(
+                    entry, bool_to_entry_state(online, EntryStateSource.MDNS)
+                )
         if poll_names and self.aiozc:
             results = await asyncio.gather(
                 *(self.aiozc.async_resolve_host(name) for name in poll_names)
@@ -58,7 +60,9 @@ class MDNSStatus:
                 result = bool(address_list)
                 host_mdns_state[name] = result
                 for entry in poll_names[name]:
-                    entries.async_set_state(entry, bool_to_entry_state(result))
+                    entries.async_set_state(
+                        entry, bool_to_entry_state(result, EntryStateSource.MDNS)
+                    )
 
     async def async_run(self) -> None:
         dashboard = DASHBOARD
@@ -74,7 +78,10 @@ class MDNSStatus:
                 if matching_entries := entries.get_by_name(name):
                     for entry in matching_entries:
                         if not entry.no_mdns:
-                            entries.async_set_state(entry, bool_to_entry_state(result))
+                            entries.async_set_state(
+                                entry,
+                                bool_to_entry_state(result, EntryStateSource.MDNS),
+                            )
 
         stat = DashboardStatus(on_update)
         imports = DashboardImportDiscovery()

--- a/esphome/dashboard/status/mdns.py
+++ b/esphome/dashboard/status/mdns.py
@@ -110,7 +110,7 @@ class MDNSStatus:
 
         ping_request = dashboard.ping_request
         while not dashboard.stop_event.is_set():
-            await self.async_refresh_hosts(dashboard)
+            await self.async_refresh_hosts()
             await ping_request.wait()
             ping_request.clear()
 

--- a/esphome/dashboard/status/mqtt.py
+++ b/esphome/dashboard/status/mqtt.py
@@ -41,10 +41,11 @@ class MqttStatusThread(threading.Thread):
                     return
                 if matching_entries := entries.get_by_name(data["name"]):
                     for entry in matching_entries:
+                        state = entry.state
                         if (
-                            entry.state.reachable is not ReachableState.ONLINE
-                            or entry.state.source is EntryStateSource.UNKNOWN
-                            or entry.state.source is EntryStateSource.MQTT
+                            state.reachable is not ReachableState.ONLINE
+                            or state.source
+                            in (EntryStateSource.UNKNOWN, EntryStateSource.MQTT)
                         ):
                             entries.set_state(
                                 entry,
@@ -73,10 +74,8 @@ class MqttStatusThread(threading.Thread):
             current_entries = entries.all()
             # will be set to true on on_message
             for entry in current_entries:
-                if (
-                    entry.state.source is EntryStateSource.UNKNOWN
-                    or entry.state.source is EntryStateSource.MQTT
-                ):
+                state = entry.state
+                if state.source in (EntryStateSource.UNKNOWN, EntryStateSource.MQTT):
                     entries.set_state(
                         entry, EntryState(ReachableState.OFFLINE, EntryStateSource.MQTT)
                     )

--- a/esphome/dashboard/status/mqtt.py
+++ b/esphome/dashboard/status/mqtt.py
@@ -42,6 +42,8 @@ class MqttStatusThread(threading.Thread):
                 if matching_entries := entries.get_by_name(data["name"]):
                     for entry in matching_entries:
                         state = entry.state
+                        # Only override state if we don't have a state from another source
+                        # or we have a state from MQTT and the device is reachable
                         if (
                             state.reachable is not ReachableState.ONLINE
                             or state.source
@@ -72,6 +74,7 @@ class MqttStatusThread(threading.Thread):
             # will be set to true on on_message
             for entry in current_entries:
                 state = entry.state
+                # Only override state if we don't have a state from another source
                 if state.source in (EntryStateSource.UNKNOWN, EntryStateSource.MQTT):
                     entries.set_state(
                         entry, bool_to_entry_state(False, EntryStateSource.MQTT)

--- a/esphome/dashboard/status/mqtt.py
+++ b/esphome/dashboard/status/mqtt.py
@@ -39,13 +39,19 @@ class MqttStatusThread(threading.Thread):
                 data = json.loads(payload)
                 if "name" not in data:
                     return
-                for entry in current_entries:
-                    if entry.name == data["name"]:
-                        entries.set_state(
-                            entry,
-                            EntryState(ReachableState.ONLINE, EntryStateSource.MQTT),
-                        )
-                        return
+                if matching_entries := entries.get_by_name(data["name"]):
+                    for entry in matching_entries:
+                        if (
+                            entry.state.reachable is not ReachableState.ONLINE
+                            or entry.state.source is EntryStateSource.UNKNOWN
+                            or entry.state.source is EntryStateSource.MQTT
+                        ):
+                            entries.set_state(
+                                entry,
+                                EntryState(
+                                    ReachableState.ONLINE, EntryStateSource.MQTT
+                                ),
+                            )
 
         def on_connect(client, userdata, flags, return_code):
             client.publish("esphome/discover", None, retain=False)
@@ -67,7 +73,10 @@ class MqttStatusThread(threading.Thread):
             current_entries = entries.all()
             # will be set to true on on_message
             for entry in current_entries:
-                if entry.no_mdns:
+                if (
+                    entry.state.source is EntryStateSource.UNKNOWN
+                    or entry.state.source is EntryStateSource.MQTT
+                ):
                     entries.set_state(
                         entry, EntryState(ReachableState.OFFLINE, EntryStateSource.MQTT)
                     )

--- a/esphome/dashboard/status/mqtt.py
+++ b/esphome/dashboard/status/mqtt.py
@@ -4,19 +4,27 @@ import binascii
 import json
 import os
 import threading
+import typing
 
 from esphome import mqtt
 
-from ..core import DASHBOARD
 from ..entries import EntryState, EntryStateSource, ReachableState
+
+if typing.TYPE_CHECKING:
+    from ..core import ESPHomeDashboard
 
 
 class MqttStatusThread(threading.Thread):
     """Status thread to get the status of the devices via MQTT."""
 
+    def __init__(self, dashboard: ESPHomeDashboard) -> None:
+        """Initialize the status thread."""
+        super().__init__()
+        self.dashboard = dashboard
+
     def run(self) -> None:
         """Run the status thread."""
-        dashboard = DASHBOARD
+        dashboard = self.dashboard
         entries = dashboard.entries
         current_entries = entries.all()
 

--- a/esphome/dashboard/status/mqtt.py
+++ b/esphome/dashboard/status/mqtt.py
@@ -8,7 +8,7 @@ import typing
 
 from esphome import mqtt
 
-from ..entries import EntryState, EntryStateSource, ReachableState
+from ..entries import EntryStateSource, ReachableState, bool_to_entry_state
 
 if typing.TYPE_CHECKING:
     from ..core import ESPHomeDashboard
@@ -48,10 +48,7 @@ class MqttStatusThread(threading.Thread):
                             in (EntryStateSource.UNKNOWN, EntryStateSource.MQTT)
                         ):
                             entries.set_state(
-                                entry,
-                                EntryState(
-                                    ReachableState.ONLINE, EntryStateSource.MQTT
-                                ),
+                                entry, bool_to_entry_state(True, EntryStateSource.MQTT)
                             )
 
         def on_connect(client, userdata, flags, return_code):
@@ -77,7 +74,7 @@ class MqttStatusThread(threading.Thread):
                 state = entry.state
                 if state.source in (EntryStateSource.UNKNOWN, EntryStateSource.MQTT):
                     entries.set_state(
-                        entry, EntryState(ReachableState.OFFLINE, EntryStateSource.MQTT)
+                        entry, bool_to_entry_state(False, EntryStateSource.MQTT)
                     )
 
             client.publish("esphome/discover", None, retain=False)

--- a/esphome/dashboard/status/mqtt.py
+++ b/esphome/dashboard/status/mqtt.py
@@ -8,7 +8,7 @@ import threading
 from esphome import mqtt
 
 from ..core import DASHBOARD
-from ..entries import EntryState
+from ..entries import EntryState, EntryStateSource, ReachableState
 
 
 class MqttStatusThread(threading.Thread):
@@ -33,7 +33,10 @@ class MqttStatusThread(threading.Thread):
                     return
                 for entry in current_entries:
                     if entry.name == data["name"]:
-                        entries.set_state(entry, EntryState.ONLINE)
+                        entries.set_state(
+                            entry,
+                            EntryState(ReachableState.ONLINE, EntryStateSource.MQTT),
+                        )
                         return
 
         def on_connect(client, userdata, flags, return_code):
@@ -57,7 +60,9 @@ class MqttStatusThread(threading.Thread):
             # will be set to true on on_message
             for entry in current_entries:
                 if entry.no_mdns:
-                    entries.set_state(entry, EntryState.OFFLINE)
+                    entries.set_state(
+                        entry, EntryState(ReachableState.OFFLINE, EntryStateSource.MQTT)
+                    )
 
             client.publish("esphome/discover", None, retain=False)
             dashboard.mqtt_ping_request.wait()

--- a/esphome/dashboard/status/mqtt.py
+++ b/esphome/dashboard/status/mqtt.py
@@ -8,7 +8,7 @@ import typing
 
 from esphome import mqtt
 
-from ..entries import EntryStateSource, ReachableState, bool_to_entry_state
+from ..entries import EntryStateSource, bool_to_entry_state
 
 if typing.TYPE_CHECKING:
     from ..core import ESPHomeDashboard
@@ -41,17 +41,11 @@ class MqttStatusThread(threading.Thread):
                     return
                 if matching_entries := entries.get_by_name(data["name"]):
                     for entry in matching_entries:
-                        state = entry.state
                         # Only override state if we don't have a state from another source
                         # or we have a state from MQTT and the device is reachable
-                        if (
-                            state.reachable is not ReachableState.ONLINE
-                            or state.source
-                            in (EntryStateSource.UNKNOWN, EntryStateSource.MQTT)
-                        ):
-                            entries.set_state(
-                                entry, bool_to_entry_state(True, EntryStateSource.MQTT)
-                            )
+                        entries.set_state_if_online_or_source(
+                            entry, bool_to_entry_state(True, EntryStateSource.MQTT)
+                        )
 
         def on_connect(client, userdata, flags, return_code):
             client.publish("esphome/discover", None, retain=False)
@@ -73,12 +67,10 @@ class MqttStatusThread(threading.Thread):
             current_entries = entries.all()
             # will be set to true on on_message
             for entry in current_entries:
-                state = entry.state
                 # Only override state if we don't have a state from another source
-                if state.source in (EntryStateSource.UNKNOWN, EntryStateSource.MQTT):
-                    entries.set_state(
-                        entry, bool_to_entry_state(False, EntryStateSource.MQTT)
-                    )
+                entries.set_state_if_source(
+                    entry, bool_to_entry_state(False, EntryStateSource.MQTT)
+                )
 
             client.publish("esphome/discover", None, retain=False)
             dashboard.mqtt_ping_request.wait()

--- a/esphome/dashboard/status/ping.py
+++ b/esphome/dashboard/status/ping.py
@@ -28,6 +28,8 @@ GROUP_SIZE = int(MAX_EXECUTOR_WORKERS / 2)
 
 DNS_FAILURE_STATE = EntryState(ReachableState.DNS_FAILURE, EntryStateSource.PING)
 
+MIN_PING_INTERVAL = 5  # ensure we don't ping too often
+
 
 class PingStatus:
     def __init__(self, dashboard: ESPHomeDashboard) -> None:
@@ -49,6 +51,7 @@ class PingStatus:
             # Only ping if the dashboard is open
             await dashboard.ping_request.wait()
             dashboard.ping_request.clear()
+            iteration_start = time.monotonic()
             current_entries = dashboard.entries.async_all()
             to_ping: list[DashboardEntry] = []
 
@@ -120,6 +123,11 @@ class PingStatus:
                         entry,
                         bool_to_entry_state(ping_result, EntryStateSource.PING),
                     )
+
+            if not dashboard.stop_event.is_set():
+                iteration_duration = time.monotonic() - iteration_start
+                if iteration_duration < MIN_PING_INTERVAL:
+                    await asyncio.sleep(MIN_PING_INTERVAL - iteration_duration)
 
 
 async def _can_use_icmp_lib_with_privilege() -> None | bool:

--- a/esphome/dashboard/status/ping.py
+++ b/esphome/dashboard/status/ping.py
@@ -58,6 +58,7 @@ class PingStatus:
                     EntryStateSource.PING,
                 ):
                     # No address or we already have a state from another source
+                    # so no need to ping
                     continue
                 to_ping.append(entry)
 
@@ -76,6 +77,9 @@ class PingStatus:
 
                 for entry, result in zip(ping_group, dns_results):
                     if isinstance(result, Exception):
+                        # Only update state if its unknown or from ping
+                        # so we don't mark it as offline if we have a state
+                        # from mDNS or MQTT
                         if entry.state.source in (
                             EntryStateSource.UNKNOWN,
                             EntryStateSource.PING,
@@ -108,6 +112,10 @@ class PingStatus:
                         ping_result = host.is_alive
                     entry = cast(DashboardEntry, entry_addresses[0])
                     state = entry.state
+                    # If we can reach it via ping, we always set it
+                    # online, however if we can't reach it via ping
+                    # we only set it to offline if the state is unknown
+                    # or from ping
                     if (
                         ping_result and state.reachable is not ReachableState.ONLINE
                     ) or state.source in (

--- a/esphome/dashboard/status/ping.py
+++ b/esphome/dashboard/status/ping.py
@@ -100,7 +100,7 @@ class PingStatus:
 
                 results = await asyncio.gather(
                     *(
-                        async_ping(addresses[0], privileged=privileged)
+                        async_ping(addresses[0], count=2, privileged=privileged)
                         for _, addresses in entry_addresses
                     ),
                     return_exceptions=True,

--- a/esphome/dashboard/status/ping.py
+++ b/esphome/dashboard/status/ping.py
@@ -112,7 +112,7 @@ class PingStatus:
                     else:
                         host: Host = result
                         ping_result = host.is_alive
-                    entry, _ = entry_addresses
+                    entry = cast(DashboardEntry, entry_addresses[0])
                     if (
                         (
                             ping_result

--- a/esphome/dashboard/status/ping.py
+++ b/esphome/dashboard/status/ping.py
@@ -51,14 +51,11 @@ class PingStatus:
             to_ping: list[DashboardEntry] = []
 
             for entry in current_entries:
-                if entry.address is None:
-                    # No address we can't ping it
-                    continue
-                if (
-                    entry.state.source is not EntryStateSource.UNKNOWN
-                    and entry.state.source is not EntryStateSource.PING
+                if entry.address is None or entry.state.source not in (
+                    EntryStateSource.UNKNOWN,
+                    EntryStateSource.PING,
                 ):
-                    # We already have a state from another source
+                    # No address or we already have a state from another source
                     continue
                 to_ping.append(entry)
 
@@ -77,9 +74,9 @@ class PingStatus:
 
                 for entry, result in zip(ping_group, dns_results):
                     if isinstance(result, Exception):
-                        if (
-                            entry.state.source is EntryStateSource.UNKNOWN
-                            or entry.state.source is EntryStateSource.PING
+                        if entry.state.source in (
+                            EntryStateSource.UNKNOWN,
+                            EntryStateSource.PING,
                         ):
                             entries.async_set_state(
                                 entry,
@@ -113,13 +110,12 @@ class PingStatus:
                         host: Host = result
                         ping_result = host.is_alive
                     entry = cast(DashboardEntry, entry_addresses[0])
+                    state = entry.state
                     if (
-                        (
-                            ping_result
-                            and entry.state.reachable is not ReachableState.ONLINE
-                        )
-                        or entry.state.source is EntryStateSource.UNKNOWN
-                        or entry.state.source is EntryStateSource.PING
+                        ping_result and state.reachable is not ReachableState.ONLINE
+                    ) or state.source in (
+                        EntryStateSource.UNKNOWN,
+                        EntryStateSource.PING,
                     ):
                         entries.async_set_state(
                             entry,

--- a/esphome/dashboard/status/ping.py
+++ b/esphome/dashboard/status/ping.py
@@ -3,12 +3,12 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
+import typing
 from typing import cast
 
 from icmplib import Host, SocketPermissionError, async_ping
 
 from ..const import MAX_EXECUTOR_WORKERS
-from ..core import DASHBOARD
 from ..entries import (
     DashboardEntry,
     EntryState,
@@ -18,20 +18,25 @@ from ..entries import (
 )
 from ..util.itertools import chunked
 
+if typing.TYPE_CHECKING:
+    from ..core import ESPHomeDashboard
+
+
 _LOGGER = logging.getLogger(__name__)
 
 GROUP_SIZE = int(MAX_EXECUTOR_WORKERS / 2)
 
 
 class PingStatus:
-    def __init__(self) -> None:
+    def __init__(self, dashboard: ESPHomeDashboard) -> None:
         """Initialize the PingStatus class."""
         super().__init__()
         self._loop = asyncio.get_running_loop()
+        self.dashboard = dashboard
 
     async def async_run(self) -> None:
         """Run the ping status."""
-        dashboard = DASHBOARD
+        dashboard = self.dashboard
         entries = dashboard.entries
         privileged = await _can_use_icmp_lib_with_privilege()
         if privileged is None:

--- a/esphome/dashboard/status/ping.py
+++ b/esphome/dashboard/status/ping.py
@@ -9,7 +9,13 @@ from icmplib import Host, SocketPermissionError, async_ping
 
 from ..const import MAX_EXECUTOR_WORKERS
 from ..core import DASHBOARD
-from ..entries import DashboardEntry, EntryState, EntryStateSource, bool_to_entry_state
+from ..entries import (
+    DashboardEntry,
+    EntryState,
+    EntryStateSource,
+    ReachableState,
+    bool_to_entry_state,
+)
 from ..util.itertools import chunked
 
 _LOGGER = logging.getLogger(__name__)
@@ -38,7 +44,9 @@ class PingStatus:
             dashboard.ping_request.clear()
             current_entries = dashboard.entries.async_all()
             to_ping: list[DashboardEntry] = [
-                entry for entry in current_entries if entry.address is not None
+                entry
+                for entry in current_entries
+                if entry.address is not None and entry.state
             ]
 
             # Resolve DNS for all entries
@@ -56,7 +64,10 @@ class PingStatus:
 
                 for entry, result in zip(ping_group, dns_results):
                     if isinstance(result, Exception):
-                        entries.async_set_state(entry, EntryState.UNKNOWN)
+                        entries.async_set_state(
+                            entry,
+                            EntryState(ReachableState.UNKNOWN, EntryStateSource.PING),
+                        )
                         continue
                     if isinstance(result, BaseException):
                         raise result

--- a/esphome/dashboard/status/ping.py
+++ b/esphome/dashboard/status/ping.py
@@ -26,6 +26,8 @@ _LOGGER = logging.getLogger(__name__)
 
 GROUP_SIZE = int(MAX_EXECUTOR_WORKERS / 2)
 
+DNS_FAILURE_STATE = EntryState(ReachableState.DNS_FAILURE, EntryStateSource.PING)
+
 
 class PingStatus:
     def __init__(self, dashboard: ESPHomeDashboard) -> None:
@@ -78,12 +80,7 @@ class PingStatus:
                             EntryStateSource.UNKNOWN,
                             EntryStateSource.PING,
                         ):
-                            entries.async_set_state(
-                                entry,
-                                EntryState(
-                                    ReachableState.DNS_FAILURE, EntryStateSource.PING
-                                ),
-                            )
+                            entries.async_set_state(entry, DNS_FAILURE_STATE)
                         continue
                     if isinstance(result, BaseException):
                         raise result

--- a/esphome/dashboard/status/ping.py
+++ b/esphome/dashboard/status/ping.py
@@ -100,7 +100,7 @@ class PingStatus:
 
                 results = await asyncio.gather(
                     *(
-                        async_ping(addresses[0], count=2, privileged=privileged)
+                        async_ping(addresses[0], privileged=privileged)
                         for _, addresses in entry_addresses
                     ),
                     return_exceptions=True,

--- a/esphome/dashboard/status/ping.py
+++ b/esphome/dashboard/status/ping.py
@@ -43,11 +43,15 @@ class PingStatus:
             await dashboard.ping_request.wait()
             dashboard.ping_request.clear()
             current_entries = dashboard.entries.async_all()
-            to_ping: list[DashboardEntry] = [
-                entry
-                for entry in current_entries
-                if entry.address is not None and entry.state
-            ]
+            to_ping: list[DashboardEntry] = []
+
+            for entry in current_entries:
+                if entry.address is None or (
+                    entry.state.reachable == ReachableState.ONLINE
+                    and entry.state.source == EntryStateSource.MDNS
+                ):
+                    continue
+                to_ping.append(entry)
 
             # Resolve DNS for all entries
             entries_with_addresses: dict[DashboardEntry, list[str]] = {}

--- a/esphome/dashboard/status/ping.py
+++ b/esphome/dashboard/status/ping.py
@@ -53,12 +53,17 @@ class PingStatus:
             to_ping: list[DashboardEntry] = []
 
             for entry in current_entries:
-                if entry.address is None or entry.state.source not in (
-                    EntryStateSource.UNKNOWN,
-                    EntryStateSource.PING,
-                ):
+                if entry.address is None:
                     # No address or we already have a state from another source
                     # so no need to ping
+                    continue
+                if (
+                    entry.state.reachable is ReachableState.ONLINE
+                    and entry.state.source
+                    not in (EntryStateSource.PING, EntryStateSource.UNKNOWN)
+                ):
+                    # If we already have a state from another source and
+                    # it's online, we don't need to ping
                     continue
                 to_ping.append(entry)
 

--- a/esphome/dashboard/status/ping.py
+++ b/esphome/dashboard/status/ping.py
@@ -55,8 +55,8 @@ class PingStatus:
                     entry.address is None
                     or entry.no_mdns
                     or (
-                        entry.state.reachable == ReachableState.ONLINE
-                        and entry.state.source == EntryStateSource.MDNS
+                        entry.state.reachable is ReachableState.ONLINE
+                        and entry.state.source is EntryStateSource.MDNS
                     )
                 ):
                     continue
@@ -79,7 +79,9 @@ class PingStatus:
                     if isinstance(result, Exception):
                         entries.async_set_state(
                             entry,
-                            EntryState(ReachableState.UNKNOWN, EntryStateSource.PING),
+                            EntryState(
+                                ReachableState.DNS_FAILURE, EntryStateSource.PING
+                            ),
                         )
                         continue
                     if isinstance(result, BaseException):

--- a/esphome/dashboard/status/ping.py
+++ b/esphome/dashboard/status/ping.py
@@ -46,9 +46,13 @@ class PingStatus:
             to_ping: list[DashboardEntry] = []
 
             for entry in current_entries:
-                if entry.address is None or (
-                    entry.state.reachable == ReachableState.ONLINE
-                    and entry.state.source == EntryStateSource.MDNS
+                if (
+                    entry.address is None
+                    or entry.no_mdns
+                    or (
+                        entry.state.reachable == ReachableState.ONLINE
+                        and entry.state.source == EntryStateSource.MDNS
+                    )
                 ):
                     continue
                 to_ping.append(entry)

--- a/esphome/dashboard/status/ping.py
+++ b/esphome/dashboard/status/ping.py
@@ -77,12 +77,16 @@ class PingStatus:
 
                 for entry, result in zip(ping_group, dns_results):
                     if isinstance(result, Exception):
-                        entries.async_set_state(
-                            entry,
-                            EntryState(
-                                ReachableState.DNS_FAILURE, EntryStateSource.PING
-                            ),
-                        )
+                        if (
+                            entry.state.source is EntryStateSource.UNKNOWN
+                            or entry.state.source is EntryStateSource.PING
+                        ):
+                            entries.async_set_state(
+                                entry,
+                                EntryState(
+                                    ReachableState.DNS_FAILURE, EntryStateSource.PING
+                                ),
+                            )
                         continue
                     if isinstance(result, BaseException):
                         raise result
@@ -109,9 +113,18 @@ class PingStatus:
                         host: Host = result
                         ping_result = host.is_alive
                     entry, _ = entry_addresses
-                    entries.async_set_state(
-                        entry, bool_to_entry_state(ping_result, EntryStateSource.PING)
-                    )
+                    if (
+                        (
+                            ping_result
+                            and entry.state.reachable is not ReachableState.ONLINE
+                        )
+                        or entry.state.source is EntryStateSource.UNKNOWN
+                        or entry.state.source is EntryStateSource.PING
+                    ):
+                        entries.async_set_state(
+                            entry,
+                            bool_to_entry_state(ping_result, EntryStateSource.PING),
+                        )
 
 
 async def _can_use_icmp_lib_with_privilege() -> None | bool:

--- a/esphome/dashboard/status/ping.py
+++ b/esphome/dashboard/status/ping.py
@@ -51,14 +51,14 @@ class PingStatus:
             to_ping: list[DashboardEntry] = []
 
             for entry in current_entries:
+                if entry.address is None:
+                    # No address we can't ping it
+                    continue
                 if (
-                    entry.address is None
-                    or entry.no_mdns
-                    or (
-                        entry.state.reachable is ReachableState.ONLINE
-                        and entry.state.source is EntryStateSource.MDNS
-                    )
+                    entry.state.source is not EntryStateSource.UNKNOWN
+                    and entry.state.source is not EntryStateSource.PING
                 ):
+                    # We already have a state from another source
                     continue
                 to_ping.append(entry)
 

--- a/esphome/dashboard/status/ping.py
+++ b/esphome/dashboard/status/ping.py
@@ -9,7 +9,7 @@ from icmplib import Host, SocketPermissionError, async_ping
 
 from ..const import MAX_EXECUTOR_WORKERS
 from ..core import DASHBOARD
-from ..entries import DashboardEntry, EntryState, bool_to_entry_state
+from ..entries import DashboardEntry, EntryState, EntryStateSource, bool_to_entry_state
 from ..util.itertools import chunked
 
 _LOGGER = logging.getLogger(__name__)
@@ -83,7 +83,9 @@ class PingStatus:
                         host: Host = result
                         ping_result = host.is_alive
                     entry, _ = entry_addresses
-                    entries.async_set_state(entry, bool_to_entry_state(ping_result))
+                    entries.async_set_state(
+                        entry, bool_to_entry_state(ping_result, EntryStateSource.PING)
+                    )
 
 
 async def _can_use_icmp_lib_with_privilege() -> None | bool:

--- a/esphome/dashboard/status/ping.py
+++ b/esphome/dashboard/status/ping.py
@@ -80,11 +80,7 @@ class PingStatus:
                         # Only update state if its unknown or from ping
                         # so we don't mark it as offline if we have a state
                         # from mDNS or MQTT
-                        if entry.state.source in (
-                            EntryStateSource.UNKNOWN,
-                            EntryStateSource.PING,
-                        ):
-                            entries.async_set_state(entry, DNS_FAILURE_STATE)
+                        entries.async_set_state_if_source(entry, DNS_FAILURE_STATE)
                         continue
                     if isinstance(result, BaseException):
                         raise result
@@ -111,21 +107,14 @@ class PingStatus:
                         host: Host = result
                         ping_result = host.is_alive
                     entry = cast(DashboardEntry, entry_addresses[0])
-                    state = entry.state
                     # If we can reach it via ping, we always set it
                     # online, however if we can't reach it via ping
                     # we only set it to offline if the state is unknown
                     # or from ping
-                    if (
-                        ping_result and state.reachable is not ReachableState.ONLINE
-                    ) or state.source in (
-                        EntryStateSource.UNKNOWN,
-                        EntryStateSource.PING,
-                    ):
-                        entries.async_set_state(
-                            entry,
-                            bool_to_entry_state(ping_result, EntryStateSource.PING),
-                        )
+                    entries.async_set_state_if_online_or_source(
+                        entry,
+                        bool_to_entry_state(ping_result, EntryStateSource.PING),
+                    )
 
 
 async def _can_use_icmp_lib_with_privilege() -> None | bool:

--- a/esphome/dashboard/status/ping.py
+++ b/esphome/dashboard/status/ping.py
@@ -114,7 +114,7 @@ class PingStatus:
                     else:
                         host: Host = result
                         ping_result = host.is_alive
-                    entry = cast(DashboardEntry, entry_addresses[0])
+                    entry: DashboardEntry = entry_addresses[0]
                     # If we can reach it via ping, we always set it
                     # online, however if we can't reach it via ping
                     # we only set it to offline if the state is unknown

--- a/esphome/dashboard/web_server.py
+++ b/esphome/dashboard/web_server.py
@@ -44,7 +44,7 @@ from esphome.yaml_util import FastestAvailableSafeLoader
 
 from .const import DASHBOARD_COMMAND
 from .core import DASHBOARD
-from .entries import EntryState, entry_state_to_bool
+from .entries import UNKNOWN_STATE, entry_state_to_bool
 from .util.file import write_file
 from .util.subprocess import async_run_system_command
 from .util.text import friendly_name_slugify
@@ -381,7 +381,7 @@ class EsphomeRenameHandler(EsphomeCommandWebSocket):
         # Remove the old ping result from the cache
         entries = DASHBOARD.entries
         if entry := entries.get(self.old_name):
-            entries.async_set_state(entry, EntryState.UNKNOWN)
+            entries.async_set_state(entry, UNKNOWN_STATE)
 
 
 class EsphomeUploadHandler(EsphomePortCommandWebSocket):

--- a/esphome/zeroconf.py
+++ b/esphome/zeroconf.py
@@ -174,7 +174,8 @@ class DashboardImportDiscovery:
 
 def _make_host_resolver(host: str) -> HostResolver:
     """Create a new HostResolver for the given host name."""
-    return AddressResolver(f"{host.partition(".")[0]}.local.")
+    short_host = host.partition(".")[0]
+    return AddressResolver(f"{short_host}.local.")
 
 
 class EsphomeZeroconf(Zeroconf):

--- a/esphome/zeroconf.py
+++ b/esphome/zeroconf.py
@@ -5,7 +5,13 @@ from dataclasses import dataclass
 import logging
 from typing import Callable
 
-from zeroconf import IPVersion, ServiceInfo, ServiceStateChange, Zeroconf
+from zeroconf import (
+    AddressResolver,
+    IPVersion,
+    ServiceInfo,
+    ServiceStateChange,
+    Zeroconf,
+)
 from zeroconf.asyncio import AsyncServiceBrowser, AsyncServiceInfo, AsyncZeroconf
 
 from esphome.storage_json import StorageJSON, ext_storage_path
@@ -168,11 +174,7 @@ class DashboardImportDiscovery:
 
 def _make_host_resolver(host: str) -> HostResolver:
     """Create a new HostResolver for the given host name."""
-    name = host.partition(".")[0]
-    info = HostResolver(
-        ESPHOME_SERVICE_TYPE, f"{name}.{ESPHOME_SERVICE_TYPE}", server=f"{name}.local."
-    )
-    return info
+    return AddressResolver(f"{host.partition(".")[0]}.local.")
 
 
 class EsphomeZeroconf(Zeroconf):

--- a/esphome/zeroconf.py
+++ b/esphome/zeroconf.py
@@ -22,15 +22,6 @@ _LOGGER = logging.getLogger(__name__)
 _BACKGROUND_TASKS: set[asyncio.Task] = set()
 
 
-class HostResolver(ServiceInfo):
-    """Resolve a host name to an IP address."""
-
-    @property
-    def _is_complete(self) -> bool:
-        """The ServiceInfo has all expected properties."""
-        return bool(self._ipv4_addresses)
-
-
 class DashboardStatus:
     def __init__(self, on_update: Callable[[dict[str, bool | None], []]]) -> None:
         """Initialize the dashboard status."""
@@ -172,7 +163,7 @@ class DashboardImportDiscovery:
                 )
 
 
-def _make_host_resolver(host: str) -> HostResolver:
+def _make_resolver(host: str) -> AddressResolver:
     """Create a new HostResolver for the given host name."""
     short_host = host.partition(".")[0]
     return AddressResolver(f"{short_host}.local.")
@@ -181,7 +172,7 @@ def _make_host_resolver(host: str) -> HostResolver:
 class EsphomeZeroconf(Zeroconf):
     def resolve_host(self, host: str, timeout: float = 3.0) -> list[str] | None:
         """Resolve a host name to an IP address."""
-        info = _make_host_resolver(host)
+        info = _make_resolver(host)
         if (
             info.load_from_cache(self)
             or (timeout and info.request(self, timeout * 1000))
@@ -195,7 +186,7 @@ class AsyncEsphomeZeroconf(AsyncZeroconf):
         self, host: str, timeout: float = 3.0
     ) -> list[str] | None:
         """Resolve a host name to an IP address."""
-        info = _make_host_resolver(host)
+        info = _make_resolver(host)
         if (
             info.load_from_cache(self.zeroconf)
             or (timeout and await info.async_request(self.zeroconf, timeout * 1000))

--- a/esphome/zeroconf.py
+++ b/esphome/zeroconf.py
@@ -163,16 +163,10 @@ class DashboardImportDiscovery:
                 )
 
 
-def _make_resolver(host: str) -> AddressResolver:
-    """Create a new HostResolver for the given host name."""
-    short_host = host.partition(".")[0]
-    return AddressResolver(f"{short_host}.local.")
-
-
 class EsphomeZeroconf(Zeroconf):
     def resolve_host(self, host: str, timeout: float = 3.0) -> list[str] | None:
         """Resolve a host name to an IP address."""
-        info = _make_resolver(host)
+        info = AddressResolver(f'{host.partition(".")[0]}.local.')
         if (
             info.load_from_cache(self)
             or (timeout and info.request(self, timeout * 1000))
@@ -186,7 +180,7 @@ class AsyncEsphomeZeroconf(AsyncZeroconf):
         self, host: str, timeout: float = 3.0
     ) -> list[str] | None:
         """Resolve a host name to an IP address."""
-        info = _make_resolver(host)
+        info = AddressResolver(f'{host.partition(".")[0]}.local.')
         if (
             info.load_from_cache(self.zeroconf)
             or (timeout and await info.async_request(self.zeroconf, timeout * 1000))


### PR DESCRIPTION
# What does this implement/fix?

Automatically fallback to ping when mDNS is broken or the device has mdns disabled instead of having the user have to manually configure this.  As before, ping only happens when the dashboard is open so mDNS is still preferred since we are always browsing for devices when the dashboard is running.

This change also improves the situation for the mixed use case where some devices are reachable different methods:

- mDNS
- Ping
- MQTT

Previously users would have to give up mDNS to enable ping since it was one or the other.

Once we see a device as reachable via a specific method we will keep using that method to check device until it becomes unreachable by that method, at which point we will accept state from any method that can reach it.

# Breaking change

It is no longer necessary to configure `status_use_ping` as fallback to ping will automatically happen when mDNS is not available or disabled for a device.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
