### PR TITLE
2025.2.0b5

### DIFF
--- a/esphome/components/api/client.py
+++ b/esphome/components/api/client.py
@@ -1,18 +1,23 @@
 from __future__ import annotations
 
 import asyncio
-import logging
 from datetime import datetime
-from typing import Any
+import logging
+from typing import TYPE_CHECKING, Any
 
 from aioesphomeapi import APIClient
-from aioesphomeapi.api_pb2 import SubscribeLogsResponse
 from aioesphomeapi.log_runner import async_run
 
 from esphome.const import CONF_KEY, CONF_PASSWORD, CONF_PORT, __version__
 from esphome.core import CORE
 
 from . import CONF_ENCRYPTION
+
+if TYPE_CHECKING:
+    from aioesphomeapi.api_pb2 import (
+        SubscribeLogsResponse,  # pylint: disable=no-name-in-module
+    )
+
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/esphome/components/font/__init__.py
+++ b/esphome/components/font/__init__.py
@@ -5,8 +5,8 @@ import os
 from pathlib import Path
 import re
 
+import esphome_glyphsets as glyphsets
 import freetype
-import glyphsets
 import requests
 
 from esphome import core, external_files

--- a/esphome/const.py
+++ b/esphome/const.py
@@ -1,6 +1,6 @@
 """Constants used by esphome."""
 
-__version__ = "2025.2.0b4"
+__version__ = "2025.2.0b5"
 
 ALLOWED_NAME_CHARS = "abcdefghijklmnopqrstuvwxyz0123456789-_"
 VALID_SUBSTITUTIONS_CHARACTERS = (

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ platformio==6.1.16  # When updating platformio, also update Dockerfile
 esptool==4.7.0
 click==8.1.7
 esphome-dashboard==20250212.0
-aioesphomeapi==24.6.2
+aioesphomeapi==29.1.0
 zeroconf==0.144.3
 puremagic==1.27
 ruamel.yaml==0.18.6 # dashboard_import

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ aioesphomeapi==24.6.2
 zeroconf==0.144.3
 puremagic==1.27
 ruamel.yaml==0.18.6 # dashboard_import
-glyphsets==1.0.0
+esphome-glyphsets==0.1.0
 pillow==10.4.0
 freetype-py==2.5.1
 


### PR DESCRIPTION
**Do not merge, release script will automatically merge**
## Full list of changes

### All changes

- Replace glyphsets with esphome_glyphsets [esphome#8261](https://github.com/esphome/esphome/pull/8261)
- Bump aioesphomeapi to 29.1.0 [esphome#8105](https://github.com/esphome/esphome/pull/8105)

<details>
<summary>Metadata</summary>

@coderabbitai ignore
</details>
