### PR TITLE
Increase default repeat delay for Toto remote transmitter protocol

### DIFF
--- a/esphome/components/remote_base/toto_protocol.h
+++ b/esphome/components/remote_base/toto_protocol.h
@@ -36,7 +36,7 @@ template<typename... Ts> class TotoAction : public RemoteTransmitterActionBase<T
     data.rc_code_2 = this->rc_code_2_.value(x...);
     data.command = this->command_.value(x...);
     this->set_send_times(this->send_times_.value_or(x..., 3));
-    this->set_send_wait(this->send_wait_.value_or(x..., 32000));
+    this->set_send_wait(this->send_wait_.value_or(x..., 36000));
     TotoProtocol().encode(dst, data);
   }
 };


### PR DESCRIPTION
# What does this implement/fix?

Increases the default frame repeat delay for Toto from 32000us to 36000us. This delay more closely follows how an actual Toto remote behaves and is more reliable for multi-frame commands.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#4683

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
remote_receiver:
  pin: 
    number: GPIO34
    inverted: True
  on_toto:
    then:
      - logger.log:
          format: "Received Toto data - command:0x%02X rc_code_1:0x%01X rc_code_2:0x%01X"
          args: ["x.command", "x.rc_code_1", "x.rc_code_2"]

remote_transmitter:
  pin:
    number: GPIO14
  carrier_duty_percent: 50%

button:
  - platform: template
    name: Toggle Power
    on_press:
      - remote_transmitter.transmit_toto:
          command: 0xA3 # On/Off

  - platform: template
    name: Power Save
    on_press:
      - remote_transmitter.transmit_toto:
          command: 0xEC   # Set Water/Seat Temp
          rc_code_1: 0x00 # Water Temp
          rc_code_2: 0x00 # Seat Temp

  - platform: template
    name: Hot and Ready
    on_press:
      - remote_transmitter.transmit_toto:
          command: 0xEC   # Set Water/Seat Temp
          rc_code_1: 0x0D # Water Temp
          rc_code_2: 0x0D # Seat Temp

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
