### PR TITLE
add seeed_energymeter and epaper

### DIFF
--- a/esphome/components/epaper/__init__.py
+++ b/esphome/components/epaper/__init__.py
@@ -1,0 +1,1 @@
+CODEOWNERS = ["@clydebarrow"]

--- a/esphome/components/epaper/__init__.py
+++ b/esphome/components/epaper/__init__.py
@@ -1,1 +1,1 @@
-CODEOWNERS = ["@clydebarrow"]
+CODEOWNERS = ["@ackpeng"]

--- a/esphome/components/epaper/display.py
+++ b/esphome/components/epaper/display.py
@@ -1,0 +1,255 @@
+from esphome import core, pins
+import esphome.codegen as cg
+from esphome.components import display, spi
+import esphome.config_validation as cv
+from esphome.const import (
+    CONF_BUSY_PIN,
+    CONF_DC_PIN,
+    CONF_FULL_UPDATE_EVERY,
+    CONF_ID,
+    CONF_LAMBDA,
+    CONF_MODEL,
+    CONF_PAGES,
+    CONF_RESET_DURATION,
+    CONF_RESET_PIN,
+)
+
+DEPENDENCIES = ["spi"]
+
+_epaper_ns = cg.esphome_ns.namespace("_epaper")
+EPaperBase = _epaper_ns.class_(
+    "EPaperBase", cg.PollingComponent, spi.SPIDevice, display.DisplayBuffer
+)
+EPaper = _epaper_ns.class_("EPaper", EPaperBase)
+EPaperBWR = _epaper_ns.class_(
+    "EPaperBWR", EPaperBase
+)
+EPaper7C = _epaper_ns.class_("EPaper7C", EPaperBase)
+EPaperTypeA = _epaper_ns.class_(
+    "EPaperTypeA", EPaper
+)
+Epaper1P54INBV2 = _epaper_ns.class_(
+    "EPaper1P54InBV2", EPaperBWR
+)
+EPaper2P7In = _epaper_ns.class_(
+    "EPaper2P7In", EPaper
+)
+EPaper2P7InB = _epaper_ns.class_(
+    "EPaper2P7InB", EPaperBWR
+)
+EPaper2P7InBV2 = _epaper_ns.class_(
+    "EPaper2P7InBV2", EPaperBWR
+)
+EPaper2P7InV2 = _epaper_ns.class_(
+    "EPaper2P7InV2", EPaper
+)
+EPaper2P9InB = _epaper_ns.class_(
+    "EPaper2P9InB", EPaper
+)
+EPaper2P9InBV3 = _epaper_ns.class_(
+    "EPaper2P9InBV3", EPaper
+)
+EPaper2P9InV2R2 = _epaper_ns.class_(
+    "EPaper2P9InV2R2", EPaper
+)
+GDEW029T5 = _epaper_ns.class_("GDEW029T5", EPaper)
+GDEY029T94 = _epaper_ns.class_("GDEY029T94", EPaper)
+EPaper2P9InDKE = _epaper_ns.class_(
+    "EPaper2P9InDKE", EPaper
+)
+GDEY042T81 = _epaper_ns.class_("GDEY042T81", EPaper)
+EPaper2P9InD = _epaper_ns.class_(
+    "EPaper2P9InD", EPaper
+)
+EPaper4P2In = _epaper_ns.class_(
+    "EPaper4P2In", EPaper
+)
+EPaper4P2InBV2 = _epaper_ns.class_(
+    "EPaper4P2InBV2", EPaper
+)
+EPaper4P2InBV2BWR = _epaper_ns.class_(
+    "EPaper4P2InBV2BWR", EPaperBWR
+)
+EPaper5P8In = _epaper_ns.class_(
+    "EPaper5P8In", EPaper
+)
+EPaper5P8InV2 = _epaper_ns.class_(
+    "EPaper5P8InV2", EPaper
+)
+EPaper7P3InF = _epaper_ns.class_(
+    "EPaper7P3InF", EPaper7C
+)
+EPaper7P5In = _epaper_ns.class_(
+    "EPaper7P5In", EPaper
+)
+EPaper7P5InBC = _epaper_ns.class_(
+    "EPaper7P5InBC", EPaper
+)
+EPaper7P5InBV2 = _epaper_ns.class_(
+    "EPaper7P5InBV2", EPaper
+)
+EPaper7P5InBV3 = _epaper_ns.class_(
+    "EPaper7P5InBV3", EPaper
+)
+EPaper7P5InBV3BWR = _epaper_ns.class_(
+    "EPaper7P5InBV3BWR", EPaperBWR
+)
+EPaper7P5InV2 = _epaper_ns.class_(
+    "EPaper7P5InV2", EPaper
+)
+EPaper7P5InV2alt = _epaper_ns.class_(
+    "EPaper7P5InV2alt", EPaper
+)
+EPaper7P5InV2P = _epaper_ns.class_(
+    "EPaper7P5InV2P", EPaper
+)
+EPaper7P5InHDB = _epaper_ns.class_(
+    "EPaper7P5InHDB", EPaper
+)
+EPaper2P13InDKE = _epaper_ns.class_(
+    "EPaper2P13InDKE", EPaper
+)
+EPaper2P13InV2 = _epaper_ns.class_(
+    "EPaper2P13InV2", EPaper
+)
+EPaper2P13InV3 = _epaper_ns.class_(
+    "EPaper2P13InV3", EPaper
+)
+EPaper13P3InK = _epaper_ns.class_(
+    "EPaper13P3InK", EPaper
+)
+GDEW0154M09 = _epaper_ns.class_("GDEW0154M09", EPaper)
+
+EPaperTypeAModel = _epaper_ns.enum("EPaperTypeAModel")
+EPaperTypeBModel = _epaper_ns.enum("EPaperTypeBModel")
+
+MODELS = {
+    "1.54in": ("a", EPaperTypeAModel._EPAPER_1_54_IN),
+    "1.54inv2": ("a", EPaperTypeAModel._EPAPER_1_54_IN_V2),
+    "1.54inv2-b": ("b", Epaper1P54INBV2),
+    "2.13in": ("a", EPaperTypeAModel._EPAPER_2_13_IN),
+    "2.13inv2": ("a", EPaperTypeAModel._EPAPER_2_13_IN_V2),
+    "2.13in-ttgo": ("a", EPaperTypeAModel.TTGO_EPAPER_2_13_IN),
+    "2.13in-ttgo-b1": ("a", EPaperTypeAModel.TTGO_EPAPER_2_13_IN_B1),
+    "2.13in-ttgo-b73": ("a", EPaperTypeAModel.TTGO_EPAPER_2_13_IN_B73),
+    "2.13in-ttgo-b74": ("a", EPaperTypeAModel.TTGO_EPAPER_2_13_IN_B74),
+    "2.90in": ("a", EPaperTypeAModel._EPAPER_2_9_IN),
+    "2.90inv2": ("a", EPaperTypeAModel._EPAPER_2_9_IN_V2),
+    "gdew029t5": ("c", GDEW029T5),
+    "2.70in": ("b", EPaper2P7In),
+    "2.70in-b": ("b", EPaper2P7InB),
+    "2.70in-bv2": ("b", EPaper2P7InBV2),
+    "2.70inv2": ("b", EPaper2P7InV2),
+    "2.90in-b": ("b", EPaper2P9InB),
+    "2.90in-bv3": ("b", EPaper2P9InBV3),
+    "gdey029t94": ("c", GDEY029T94),
+    "2.90inv2-r2": ("c", EPaper2P9InV2R2),
+    "2.90in-d": ("b", EPaper2P9InD),
+    "2.90in-dke": ("c", EPaper2P9InDKE),
+    "gdey042t81": ("c", GDEY042T81),
+    "4.20in": ("b", EPaper4P2In),
+    "4.20in-bv2": ("b", EPaper4P2InBV2),
+    "4.20in-bv2-bwr": ("b", EPaper4P2InBV2BWR),
+    "5.83in": ("b", EPaper5P8In),
+    "5.83inv2": ("b", EPaper5P8InV2),
+    "7.30in-f": ("b", EPaper7P3InF),
+    "7.50in": ("b", EPaper7P5In),
+    "7.50in-bv2": ("b", EPaper7P5InBV2),
+    "7.50in-bv3": ("b", EPaper7P5InBV3),
+    "7.50in-bv3-bwr": ("b", EPaper7P5InBV3BWR),
+    "7.50in-bc": ("b", EPaper7P5InBC),
+    "7.50inv2": ("b", EPaper7P5InV2),
+    "7.50inv2alt": ("b", EPaper7P5InV2alt),
+    "7.50inv2p": ("c", EPaper7P5InV2P),
+    "7.50in-hd-b": ("b", EPaper7P5InHDB),
+    "2.13in-ttgo-dke": ("c", EPaper2P13InDKE),
+    "2.13inv3": ("c", EPaper2P13InV3),
+    "1.54in-m5coreink-m09": ("b", GDEW0154M09),
+    "13.3in-k": ("b", EPaper13P3InK),
+}
+
+RESET_PIN_REQUIRED_MODELS = ("2.13inv2", "2.13in-ttgo-b74")
+
+
+def validate_full_update_every_only_types_ac(value):
+    if CONF_FULL_UPDATE_EVERY not in value:
+        return value
+    if MODELS[value[CONF_MODEL]][0] == "b":
+        full_models = []
+        for key, val in sorted(MODELS.items()):
+            if val[0] != "b":
+                full_models.append(key)
+        raise cv.Invalid(
+            "The 'full_update_every' option is only available for models "
+            + ", ".join(full_models)
+        )
+    return value
+
+
+def validate_reset_pin_required(config):
+    if config[CONF_MODEL] in RESET_PIN_REQUIRED_MODELS and CONF_RESET_PIN not in config:
+        raise cv.Invalid(
+            f"'{CONF_RESET_PIN}' is required for model {config[CONF_MODEL]}"
+        )
+    return config
+
+
+CONFIG_SCHEMA = cv.All(
+    display.FULL_DISPLAY_SCHEMA.extend(
+        {
+            cv.GenerateID(): cv.declare_id(EPaperBase),
+            cv.Required(CONF_DC_PIN): pins.gpio_output_pin_schema,
+            cv.Required(CONF_MODEL): cv.one_of(*MODELS, lower=True),
+            cv.Optional(CONF_RESET_PIN): pins.gpio_output_pin_schema,
+            cv.Optional(CONF_BUSY_PIN): pins.gpio_input_pin_schema,
+            cv.Optional(CONF_FULL_UPDATE_EVERY): cv.int_range(min=1, max=4294967295),
+            cv.Optional(CONF_RESET_DURATION): cv.All(
+                cv.positive_time_period_milliseconds,
+                cv.Range(max=core.TimePeriod(milliseconds=500)),
+            ),
+        }
+    )
+    .extend(cv.polling_component_schema("1s"))
+    .extend(spi.spi_device_schema()),
+    validate_full_update_every_only_types_ac,
+    validate_reset_pin_required,
+    cv.has_at_most_one_key(CONF_PAGES, CONF_LAMBDA),
+)
+
+FINAL_VALIDATE_SCHEMA = spi.final_validate_device_schema(
+    "_epaper", require_miso=False, require_mosi=True
+)
+
+
+async def to_code(config):
+    model_type, model = MODELS[config[CONF_MODEL]]
+    if model_type == "a":
+        rhs = EPaperTypeA.new(model)
+        var = cg.Pvariable(config[CONF_ID], rhs, EPaperTypeA)
+    elif model_type in ("b", "c"):
+        rhs = model.new()
+        var = cg.Pvariable(config[CONF_ID], rhs, model)
+    else:
+        raise NotImplementedError()
+
+    await display.register_display(var, config)
+    await spi.register_spi_device(var, config)
+
+    dc = await cg.gpio_pin_expression(config[CONF_DC_PIN])
+    cg.add(var.set_dc_pin(dc))
+
+    if CONF_LAMBDA in config:
+        lambda_ = await cg.process_lambda(
+            config[CONF_LAMBDA], [(display.DisplayRef, "it")], return_type=cg.void
+        )
+        cg.add(var.set_writer(lambda_))
+    if CONF_RESET_PIN in config:
+        reset = await cg.gpio_pin_expression(config[CONF_RESET_PIN])
+        cg.add(var.set_reset_pin(reset))
+    if CONF_BUSY_PIN in config:
+        reset = await cg.gpio_pin_expression(config[CONF_BUSY_PIN])
+        cg.add(var.set_busy_pin(reset))
+    if CONF_FULL_UPDATE_EVERY in config:
+        cg.add(var.set_full_update_every(config[CONF_FULL_UPDATE_EVERY]))
+    if CONF_RESET_DURATION in config:
+        cg.add(var.set_reset_duration(config[CONF_RESET_DURATION]))

--- a/esphome/components/epaper/epaper.cpp
+++ b/esphome/components/epaper/epaper.cpp
@@ -1,0 +1,4352 @@
+#include "epaper.h"
+#include "esphome/core/log.h"
+#include "esphome/core/application.h"
+#include "esphome/core/helpers.h"
+#include <cinttypes>
+#include <bitset>
+
+namespace esphome {
+namespace _epaper {
+
+static const char *const TAG = "_epaper";
+
+static const uint8_t LUT_SIZE_ = 30;
+
+static const uint8_t FULL_UPDATE_LUT[LUT_SIZE_] = {0x02, 0x02, 0x01, 0x11, 0x12, 0x12, 0x22, 0x22, 0x66, 0x69,
+                                                            0x69, 0x59, 0x58, 0x99, 0x99, 0x88, 0x00, 0x00, 0x00, 0x00,
+                                                            0xF8, 0xB4, 0x13, 0x51, 0x35, 0x51, 0x51, 0x19, 0x01, 0x00};
+
+static const uint8_t PARTIAL_UPDATE_LUT[LUT_SIZE_] = {
+    0x10, 0x18, 0x18, 0x08, 0x18, 0x18, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x13, 0x14, 0x44, 0x12, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+
+static const uint8_t LUT_SIZE_TTGO = 70;
+
+static const uint8_t FULL_UPDATE_LUT_TTGO[LUT_SIZE_TTGO] = {
+    0x80, 0x60, 0x40, 0x00, 0x00, 0x00, 0x00,  // LUT0: BB:     VS 0 ~7
+    0x10, 0x60, 0x20, 0x00, 0x00, 0x00, 0x00,  // LUT1: BW:     VS 0 ~7
+    0x80, 0x60, 0x40, 0x00, 0x00, 0x00, 0x00,  // LUT2: WB:     VS 0 ~7
+    0x10, 0x60, 0x20, 0x00, 0x00, 0x00, 0x00,  // LUT3: WW:     VS 0 ~7
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,  // LUT4: VCOM:   VS 0 ~7
+    0x03, 0x03, 0x00, 0x00, 0x02,              // TP0 A~D RP0
+    0x09, 0x09, 0x00, 0x00, 0x02,              // TP1 A~D RP1
+    0x03, 0x03, 0x00, 0x00, 0x02,              // TP2 A~D RP2
+    0x00, 0x00, 0x00, 0x00, 0x00,              // TP3 A~D RP3
+    0x00, 0x00, 0x00, 0x00, 0x00,              // TP4 A~D RP4
+    0x00, 0x00, 0x00, 0x00, 0x00,              // TP5 A~D RP5
+    0x00, 0x00, 0x00, 0x00, 0x00,              // TP6 A~D RP6
+};
+
+static const uint8_t PARTIAL_UPDATE_LUT_TTGO[LUT_SIZE_TTGO] = {
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,  // LUT0: BB:     VS 0 ~7
+    0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,  // LUT1: BW:     VS 0 ~7
+    0x40, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,  // LUT2: WB:     VS 0 ~7
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,  // LUT3: WW:     VS 0 ~7
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,  // LUT4: VCOM:   VS 0 ~7
+    0x0A, 0x00, 0x00, 0x00, 0x00,              // TP0 A~D RP0
+    0x00, 0x00, 0x00, 0x00, 0x00,              // TP1 A~D RP1
+    0x00, 0x00, 0x00, 0x00, 0x00,              // TP2 A~D RP2
+    0x00, 0x00, 0x00, 0x00, 0x00,              // TP3 A~D RP3
+    0x00, 0x00, 0x00, 0x00, 0x00,              // TP4 A~D RP4
+    0x00, 0x00, 0x00, 0x00, 0x00,              // TP5 A~D RP5
+    0x00, 0x00, 0x00, 0x00, 0x00,              // TP6 A~D RP6
+};
+
+static const uint8_t LUT_SIZE_TTGO_B73 = 100;
+
+static const uint8_t FULL_UPDATE_LUT_TTGO_B73[LUT_SIZE_TTGO_B73] = {
+    0xA0, 0x90, 0x50, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x50, 0x90, 0xA0, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0xA0, 0x90, 0x50, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x50, 0x90, 0xA0, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+
+    0x0F, 0x0F, 0x00, 0x00, 0x00, 0x0F, 0x0F, 0x00, 0x00, 0x03, 0x0F, 0x0F, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+};
+
+static const uint8_t PARTIAL_UPDATE_LUT_TTGO_B73[LUT_SIZE_TTGO_B73] = {
+    0x40, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x40, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+
+    0x0A, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+};
+
+static const uint8_t LUT_SIZE_TTGO_B1 = 29;
+
+static const uint8_t FULL_UPDATE_LUT_TTGO_B1[LUT_SIZE_TTGO_B1] = {
+    0x22, 0x55, 0xAA, 0x55, 0xAA, 0x55, 0xAA, 0x11, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x1E, 0x1E, 0x1E, 0x1E, 0x1E, 0x1E, 0x1E, 0x1E, 0x01, 0x00, 0x00, 0x00, 0x00};
+
+static const uint8_t PARTIAL_UPDATE_LUT_TTGO_B1[LUT_SIZE_TTGO_B1] = {
+    0x18, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x0F, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+
+// clang-format off
+// Disable formatting to preserve the same look as in  examples
+static const uint8_t PARTIAL_UPD_2IN9_LUT_SIZE = 159;
+static const uint8_t PARTIAL_UPD_2IN9_LUT[PARTIAL_UPD_2IN9_LUT_SIZE] =
+{
+    0x00, 0x40, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x80, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x40, 0x40, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x0A, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,
+    0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x00, 0x00, 0x00,
+    0x22, 0x17, 0x41, 0xB0, 0x32, 0x36,
+};
+// clang-format on
+
+void EPaperBase::setup() {
+  this->init_internal_(this->get_buffer_length_());
+  this->setup_pins_();
+  this->spi_setup();
+  this->reset_();
+  this->initialize();
+}
+void EPaperBase::setup_pins_() {
+  this->dc_pin_->setup();  // OUTPUT
+  this->dc_pin_->digital_write(false);
+  if (this->reset_pin_ != nullptr) {
+    this->reset_pin_->setup();  // OUTPUT
+    this->reset_pin_->digital_write(true);
+  }
+  if (this->busy_pin_ != nullptr) {
+    this->busy_pin_->setup();  // INPUT
+  }
+}
+float EPaperBase::get_setup_priority() const { return setup_priority::PROCESSOR; }
+void EPaperBase::command(uint8_t value) {
+  this->start_command_();
+  this->write_byte(value);
+  this->end_command_();
+}
+void EPaperBase::data(uint8_t value) {
+  this->start_data_();
+  this->write_byte(value);
+  this->end_data_();
+}
+
+// write a command followed by one or more bytes of data.
+// The command is the first byte, length is the total including cmd.
+void EPaperBase::cmd_data(const uint8_t *c_data, size_t length) {
+  this->dc_pin_->digital_write(false);
+  this->enable();
+  this->write_byte(c_data[0]);
+  this->dc_pin_->digital_write(true);
+  this->write_array(c_data + 1, length - 1);
+  this->disable();
+}
+
+bool EPaperBase::wait_until_idle_() {
+  if (this->busy_pin_ == nullptr || !this->busy_pin_->digital_read()) {
+    return true;
+  }
+
+  const uint32_t start = millis();
+  while (this->busy_pin_->digital_read()) {
+    if (millis() - start > this->idle_timeout_()) {
+      ESP_LOGE(TAG, "Timeout while displaying image!");
+      return false;
+    }
+    delay(1);
+  }
+  return true;
+}
+void EPaperBase::update() {
+  this->do_update_();
+  this->display();
+}
+void EPaper::fill(Color color) {
+  // flip logic
+  const uint8_t fill = color.is_on() ? 0x00 : 0xFF;
+  for (uint32_t i = 0; i < this->get_buffer_length_(); i++)
+    this->buffer_[i] = fill;
+}
+void EPaper7C::setup() {
+  this->init_internal_7c_(this->get_buffer_length_());
+  this->setup_pins_();
+  this->spi_setup();
+  this->reset_();
+  this->initialize();
+}
+void EPaper7C::init_internal_7c_(uint32_t buffer_length) {
+  ExternalRAMAllocator<uint8_t> allocator(ExternalRAMAllocator<uint8_t>::ALLOW_FAILURE);
+  uint32_t small_buffer_length = buffer_length / NUM_BUFFERS;
+
+  for (int i = 0; i < NUM_BUFFERS; i++) {
+    this->buffers_[i] = allocator.allocate(small_buffer_length);
+    if (this->buffers_[i] == nullptr) {
+      ESP_LOGE(TAG, "Could not allocate buffer %d for display!", i);
+      for (auto &buffer : this->buffers_) {
+        allocator.deallocate(buffer, small_buffer_length);
+        buffer = nullptr;
+      }
+      return;
+    }
+  }
+  this->clear();
+}
+uint8_t EPaper7C::color_to_hex(Color color) {
+  uint8_t hex_code;
+  if (color.red > 127) {
+    if (color.green > 170) {
+      if (color.blue > 127) {
+        hex_code = 0x1;  // White
+      } else {
+        hex_code = 0x5;  // Yellow
+      }
+    } else if (color.green > 85) {
+      hex_code = 0x6;  // Orange
+    } else {
+      hex_code = 0x4;  // Red (or Magenta)
+    }
+  } else {
+    if (color.green > 127) {
+      if (color.blue > 127) {
+        hex_code = 0x3;  // Cyan -> Blue
+      } else {
+        hex_code = 0x2;  // Green
+      }
+    } else {
+      if (color.blue > 127) {
+        hex_code = 0x3;  // Blue
+      } else {
+        hex_code = 0x0;  // Black
+      }
+    }
+  }
+
+  return hex_code;
+}
+void EPaper7C::fill(Color color) {
+  uint8_t pixel_color;
+  if (color.is_on()) {
+    pixel_color = this->color_to_hex(color);
+  } else {
+    pixel_color = 0x1;
+  }
+
+  if (this->buffers_[0] == nullptr) {
+    ESP_LOGE(TAG, "Buffer unavailable!");
+  } else {
+    uint32_t small_buffer_length = this->get_buffer_length_() / NUM_BUFFERS;
+    for (auto &buffer : this->buffers_) {
+      for (uint32_t buffer_pos = 0; buffer_pos < small_buffer_length; buffer_pos += 3) {
+        // We store 8 bitset<3> in 3 bytes
+        // | byte 1 | byte 2 | byte 3 |
+        // |aaabbbaa|abbbaaab|bbaaabbb|
+        buffer[buffer_pos + 0] = pixel_color << 5 | pixel_color << 2 | pixel_color >> 1;
+        buffer[buffer_pos + 1] = pixel_color << 7 | pixel_color << 4 | pixel_color << 1 | pixel_color >> 2;
+        buffer[buffer_pos + 2] = pixel_color << 6 | pixel_color << 3 | pixel_color << 0;
+      }
+      App.feed_wdt();
+    }
+  }
+}
+void HOT EPaper::draw_absolute_pixel_internal(int x, int y, Color color) {
+  if (x >= this->get_width_internal() || y >= this->get_height_internal() || x < 0 || y < 0)
+    return;
+
+  const uint32_t pos = (x + y * this->get_width_controller()) / 8u;
+  const uint8_t subpos = x & 0x07;
+  // flip logic
+  if (!color.is_on()) {
+    this->buffer_[pos] |= 0x80 >> subpos;
+  } else {
+    this->buffer_[pos] &= ~(0x80 >> subpos);
+  }
+}
+
+uint32_t EPaper::get_buffer_length_() {
+  return this->get_width_controller() * this->get_height_internal() / 8u;
+}  // just a black buffer
+uint32_t EPaperBWR::get_buffer_length_() {
+  return this->get_width_controller() * this->get_height_internal() / 4u;
+}  // black and red buffer
+uint32_t EPaper7C::get_buffer_length_() {
+  return this->get_width_controller() * this->get_height_internal() / 8u * 3u;
+}  // 7 colors buffer, 1 pixel = 3 bits, we will store 8 pixels in 24 bits = 3 bytes
+
+void EPaperBWR::fill(Color color) {
+  this->filled_rectangle(0, 0, this->get_width(), this->get_height(), color);
+}
+void HOT EPaperBWR::draw_absolute_pixel_internal(int x, int y, Color color) {
+  if (x >= this->get_width_internal() || y >= this->get_height_internal() || x < 0 || y < 0)
+    return;
+
+  const uint32_t buf_half_len = this->get_buffer_length_() / 2u;
+
+  const uint32_t pos = (x + y * this->get_width_internal()) / 8u;
+  const uint8_t subpos = x & 0x07;
+  // flip logic
+  if (color.is_on()) {
+    this->buffer_[pos] |= 0x80 >> subpos;
+  } else {
+    this->buffer_[pos] &= ~(0x80 >> subpos);
+  }
+
+  // draw red pixels only, if the color contains red only
+  if (((color.red > 0) && (color.green == 0) && (color.blue == 0))) {
+    this->buffer_[pos + buf_half_len] |= 0x80 >> subpos;
+  } else {
+    this->buffer_[pos + buf_half_len] &= ~(0x80 >> subpos);
+  }
+}
+void HOT EPaper7C::draw_absolute_pixel_internal(int x, int y, Color color) {
+  if (x >= this->get_width_internal() || y >= this->get_height_internal() || x < 0 || y < 0)
+    return;
+
+  uint8_t pixel_bits = this->color_to_hex(color);
+  uint32_t small_buffer_length = this->get_buffer_length_() / NUM_BUFFERS;
+  uint32_t pixel_position = x + y * this->get_width_controller();
+  uint32_t first_bit_position = pixel_position * 3;
+  uint32_t byte_position = first_bit_position / 8u;
+  uint32_t byte_subposition = first_bit_position % 8u;
+  uint32_t buffer_position = byte_position / small_buffer_length;
+  uint32_t buffer_subposition = byte_position % small_buffer_length;
+
+  if (byte_subposition <= 5) {
+    this->buffers_[buffer_position][buffer_subposition] =
+        (this->buffers_[buffer_position][buffer_subposition] & (0xFF ^ (0b111 << (5 - byte_subposition)))) |
+        (pixel_bits << (5 - byte_subposition));
+  } else {
+    this->buffers_[buffer_position][buffer_subposition + 0] =
+        (this->buffers_[buffer_position][buffer_subposition + 0] & (0xFF ^ (0b111 >> (byte_subposition - 5)))) |
+        (pixel_bits >> (byte_subposition - 5));
+
+    this->buffers_[buffer_position][buffer_subposition + 1] = (this->buffers_[buffer_position][buffer_subposition + 1] &
+                                                               (0xFF ^ (0xFF & (0b111 << (13 - byte_subposition))))) |
+                                                              (pixel_bits << (13 - byte_subposition));
+  }
+}
+void EPaperBase::start_command_() {
+  this->dc_pin_->digital_write(false);
+  this->enable();
+}
+void EPaperBase::end_command_() { this->disable(); }
+void EPaperBase::start_data_() {
+  this->dc_pin_->digital_write(true);
+  this->enable();
+}
+void EPaperBase::end_data_() { this->disable(); }
+void EPaperBase::on_safe_shutdown() { this->deep_sleep(); }
+
+// ========================================================
+//                          Type A
+// ========================================================
+
+void EPaperTypeA::initialize() {
+  // Achieve display intialization
+  this->init_display_();
+  // If a reset pin is configured, eligible displays can be set to deep sleep
+  // between updates, as recommended by the hardware provider
+  if (this->reset_pin_ != nullptr) {
+    switch (this->model_) {
+      // More models can be added here to enable deep sleep if eligible
+      case _EPAPER_1_54_IN:
+      case _EPAPER_1_54_IN_V2:
+        this->deep_sleep_between_updates_ = true;
+        ESP_LOGI(TAG, "Set the display to deep sleep");
+        this->deep_sleep();
+        break;
+      default:
+        break;
+    }
+  }
+}
+void EPaperTypeA::init_display_() {
+  if (this->model_ == TTGO_EPAPER_2_13_IN_B74 || this->model_ == _EPAPER_2_13_IN_V2) {
+    if (this->reset_pin_ != nullptr) {
+      this->reset_pin_->digital_write(false);
+      delay(10);
+      this->reset_pin_->digital_write(true);
+      delay(10);
+      this->wait_until_idle_();
+    }
+
+    this->command(0x12);  // SWRESET
+    this->wait_until_idle_();
+  }
+
+  // COMMAND DRIVER OUTPUT CONTROL
+  this->command(0x01);
+  this->data(this->get_height_internal() - 1);
+  this->data((this->get_height_internal() - 1) >> 8);
+  this->data(0x00);  // ? GD = 0, SM = 0, TB = 0
+
+  // COMMAND BOOSTER SOFT START CONTROL
+  this->command(0x0C);
+  this->data(0xD7);
+  this->data(0xD6);
+  this->data(0x9D);
+
+  // COMMAND WRITE VCOM REGISTER
+  this->command(0x2C);
+  this->data(0xA8);
+
+  // COMMAND SET DUMMY LINE PERIOD
+  this->command(0x3A);
+  this->data(0x1A);
+
+  // COMMAND SET GATE TIME
+  this->command(0x3B);
+  this->data(0x08);  // 2µs per row
+
+  // COMMAND DATA ENTRY MODE SETTING
+  this->command(0x11);
+  switch (this->model_) {
+    case TTGO_EPAPER_2_13_IN_B1:
+      this->data(0x01);  // x increase, y decrease : as in demo code
+      break;
+    case TTGO_EPAPER_2_13_IN_B74:
+    case _EPAPER_2_9_IN_V2:
+      this->data(0x03);  // from top left to bottom right
+      // RAM content option for Display Update
+      this->command(0x21);
+      this->data(0x00);
+      this->data(0x80);
+      break;
+    default:
+      this->data(0x03);  // from top left to bottom right
+  }
+}
+void EPaperTypeA::dump_config() {
+  LOG_DISPLAY("", " E-Paper", this);
+  switch (this->model_) {
+    case _EPAPER_1_54_IN:
+      ESP_LOGCONFIG(TAG, "  Model: 1.54in");
+      break;
+    case _EPAPER_1_54_IN_V2:
+      ESP_LOGCONFIG(TAG, "  Model: 1.54inV2");
+      break;
+    case _EPAPER_2_13_IN:
+      ESP_LOGCONFIG(TAG, "  Model: 2.13in");
+      break;
+    case _EPAPER_2_13_IN_V2:
+      ESP_LOGCONFIG(TAG, "  Model: 2.13inV2");
+      break;
+    case TTGO_EPAPER_2_13_IN:
+      ESP_LOGCONFIG(TAG, "  Model: 2.13in (TTGO)");
+      break;
+    case TTGO_EPAPER_2_13_IN_B73:
+      ESP_LOGCONFIG(TAG, "  Model: 2.13in (TTGO B73)");
+      break;
+    case TTGO_EPAPER_2_13_IN_B74:
+      ESP_LOGCONFIG(TAG, "  Model: 2.13in (TTGO B74)");
+      break;
+    case TTGO_EPAPER_2_13_IN_B1:
+      ESP_LOGCONFIG(TAG, "  Model: 2.13in (TTGO B1)");
+      break;
+    case _EPAPER_2_9_IN:
+      ESP_LOGCONFIG(TAG, "  Model: 2.9in");
+      break;
+    case _EPAPER_2_9_IN_V2:
+      ESP_LOGCONFIG(TAG, "  Model: 2.9inV2");
+      break;
+  }
+  ESP_LOGCONFIG(TAG, "  Full Update Every: %" PRIu32, this->full_update_every_);
+  LOG_PIN("  Reset Pin: ", this->reset_pin_);
+  LOG_PIN("  DC Pin: ", this->dc_pin_);
+  LOG_PIN("  Busy Pin: ", this->busy_pin_);
+  LOG_UPDATE_INTERVAL(this);
+}
+void HOT EPaperTypeA::display() {
+  bool full_update = this->at_update_ == 0;
+  bool prev_full_update = this->at_update_ == 1;
+
+  if (this->deep_sleep_between_updates_) {
+    ESP_LOGI(TAG, "Wake up the display");
+    this->reset_();
+    this->wait_until_idle_();
+    this->init_display_();
+  }
+
+  if (!this->wait_until_idle_()) {
+    this->status_set_warning();
+    return;
+  }
+
+  if (this->full_update_every_ >= 1) {
+    if (full_update != prev_full_update) {
+      switch (this->model_) {
+        case TTGO_EPAPER_2_13_IN:
+        case _EPAPER_2_13_IN_V2:
+          //  2.13" V2 uses the same LUTs as TTGO
+          this->write_lut_(full_update ? FULL_UPDATE_LUT_TTGO : PARTIAL_UPDATE_LUT_TTGO, LUT_SIZE_TTGO);
+          break;
+        case TTGO_EPAPER_2_13_IN_B73:
+          this->write_lut_(full_update ? FULL_UPDATE_LUT_TTGO_B73 : PARTIAL_UPDATE_LUT_TTGO_B73, LUT_SIZE_TTGO_B73);
+          break;
+        case TTGO_EPAPER_2_13_IN_B74:
+          // there is no LUT
+          break;
+        case TTGO_EPAPER_2_13_IN_B1:
+          this->write_lut_(full_update ? FULL_UPDATE_LUT_TTGO_B1 : PARTIAL_UPDATE_LUT_TTGO_B1, LUT_SIZE_TTGO_B1);
+          break;
+        default:
+          this->write_lut_(full_update ? FULL_UPDATE_LUT : PARTIAL_UPDATE_LUT, LUT_SIZE_);
+      }
+    }
+    this->at_update_ = (this->at_update_ + 1) % this->full_update_every_;
+  }
+
+  if (this->model_ == _EPAPER_2_13_IN_V2) {
+    // Set VCOM for full or partial update
+    this->command(0x2C);
+    this->data(full_update ? 0x55 : 0x26);
+
+    if (!full_update) {
+      // Enable "ping-pong"
+      this->command(0x37);
+      this->data(0x00);
+      this->data(0x00);
+      this->data(0x00);
+      this->data(0x00);
+      this->data(0x40);
+      this->data(0x00);
+      this->data(0x00);
+      this->command(0x22);
+      this->data(0xc0);
+      this->command(0x20);
+    }
+  }
+
+  // Border waveform
+  switch (this->model_) {
+    case TTGO_EPAPER_2_13_IN_B74:
+      this->command(0x3C);
+      this->data(full_update ? 0x05 : 0x80);
+      break;
+    case _EPAPER_2_13_IN_V2:
+      this->command(0x3C);
+      this->data(full_update ? 0x03 : 0x01);
+      break;
+    default:
+      break;
+  }
+
+  // Set x & y regions we want to write to (full)
+  switch (this->model_) {
+    case TTGO_EPAPER_2_13_IN_B1:
+      // COMMAND SET RAM X ADDRESS START END POSITION
+      this->command(0x44);
+      this->data(0x00);
+      this->data((this->get_width_controller() - 1) >> 3);
+      // COMMAND SET RAM Y ADDRESS START END POSITION
+      this->command(0x45);
+      this->data(this->get_height_internal() - 1);
+      this->data((this->get_height_internal() - 1) >> 8);
+      this->data(0x00);
+      this->data(0x00);
+
+      // COMMAND SET RAM X ADDRESS COUNTER
+      this->command(0x4E);
+      this->data(0x00);
+      // COMMAND SET RAM Y ADDRESS COUNTER
+      this->command(0x4F);
+      this->data(this->get_height_internal() - 1);
+      this->data((this->get_height_internal() - 1) >> 8);
+
+      break;
+    default:
+      // COMMAND SET RAM X ADDRESS START END POSITION
+      this->command(0x44);
+      this->data(0x00);
+      this->data((this->get_width_internal() - 1) >> 3);
+      // COMMAND SET RAM Y ADDRESS START END POSITION
+      this->command(0x45);
+      this->data(0x00);
+      this->data(0x00);
+      this->data(this->get_height_internal() - 1);
+      this->data((this->get_height_internal() - 1) >> 8);
+
+      // COMMAND SET RAM X ADDRESS COUNTER
+      this->command(0x4E);
+      this->data(0x00);
+      // COMMAND SET RAM Y ADDRESS COUNTER
+      this->command(0x4F);
+      this->data(0x00);
+      this->data(0x00);
+  }
+
+  if (!this->wait_until_idle_()) {
+    this->status_set_warning();
+    return;
+  }
+
+  // COMMAND WRITE RAM
+  this->command(0x24);
+  this->start_data_();
+  switch (this->model_) {
+    case TTGO_EPAPER_2_13_IN_B1: {  // block needed because of variable initializations
+      int16_t wb = ((this->get_width_controller()) >> 3);
+      for (int i = 0; i < this->get_height_internal(); i++) {
+        for (int j = 0; j < wb; j++) {
+          int idx = j + (this->get_height_internal() - 1 - i) * wb;
+          this->write_byte(this->buffer_[idx]);
+        }
+      }
+      break;
+    }
+    default:
+      this->write_array(this->buffer_, this->get_buffer_length_());
+  }
+  this->end_data_();
+
+  if (this->model_ == _EPAPER_2_13_IN_V2 && full_update) {
+    // Write base image again on full refresh
+    this->command(0x26);
+    this->start_data_();
+    this->write_array(this->buffer_, this->get_buffer_length_());
+    this->end_data_();
+  }
+
+  // COMMAND DISPLAY UPDATE CONTROL 2
+  this->command(0x22);
+  switch (this->model_) {
+    case _EPAPER_2_9_IN_V2:
+    case _EPAPER_1_54_IN_V2:
+    case TTGO_EPAPER_2_13_IN_B74:
+      this->data(full_update ? 0xF7 : 0xFF);
+      break;
+    case TTGO_EPAPER_2_13_IN_B73:
+      this->data(0xC7);
+      break;
+    case _EPAPER_2_13_IN_V2:
+      this->data(full_update ? 0xC7 : 0x0C);
+      break;
+    default:
+      this->data(0xC4);
+      break;
+  }
+
+  // COMMAND MASTER ACTIVATION
+  this->command(0x20);
+  // COMMAND TERMINATE FRAME READ WRITE
+  this->command(0xFF);
+
+  this->status_clear_warning();
+
+  if (this->deep_sleep_between_updates_) {
+    ESP_LOGI(TAG, "Set the display back to deep sleep");
+    this->deep_sleep();
+  }
+}
+int EPaperTypeA::get_width_internal() {
+  switch (this->model_) {
+    case _EPAPER_1_54_IN:
+    case _EPAPER_1_54_IN_V2:
+      return 200;
+    case _EPAPER_2_13_IN:
+    case _EPAPER_2_13_IN_V2:
+    case TTGO_EPAPER_2_13_IN:
+    case TTGO_EPAPER_2_13_IN_B73:
+    case TTGO_EPAPER_2_13_IN_B74:
+    case TTGO_EPAPER_2_13_IN_B1:
+      return 122;
+    case _EPAPER_2_9_IN:
+    case _EPAPER_2_9_IN_V2:
+      return 128;
+  }
+  return 0;
+}
+// The controller of the 2.13" displays has a buffer larger than screen size
+int EPaperTypeA::get_width_controller() {
+  switch (this->model_) {
+    case _EPAPER_2_13_IN:
+    case _EPAPER_2_13_IN_V2:
+    case TTGO_EPAPER_2_13_IN:
+    case TTGO_EPAPER_2_13_IN_B73:
+    case TTGO_EPAPER_2_13_IN_B74:
+    case TTGO_EPAPER_2_13_IN_B1:
+      return 128;
+    default:
+      return this->get_width_internal();
+  }
+}
+int EPaperTypeA::get_height_internal() {
+  switch (this->model_) {
+    case _EPAPER_1_54_IN:
+    case _EPAPER_1_54_IN_V2:
+      return 200;
+    case _EPAPER_2_13_IN:
+    case _EPAPER_2_13_IN_V2:
+    case TTGO_EPAPER_2_13_IN:
+    case TTGO_EPAPER_2_13_IN_B73:
+    case TTGO_EPAPER_2_13_IN_B74:
+    case TTGO_EPAPER_2_13_IN_B1:
+      return 250;
+    case _EPAPER_2_9_IN:
+    case _EPAPER_2_9_IN_V2:
+      return 296;
+  }
+  return 0;
+}
+void EPaperTypeA::write_lut_(const uint8_t *lut, const uint8_t size) {
+  // COMMAND WRITE LUT REGISTER
+  this->command(0x32);
+  for (uint8_t i = 0; i < size; i++)
+    this->data(lut[i]);
+}
+EPaperTypeA::EPaperTypeA(EPaperTypeAModel model) : model_(model) {}
+void EPaperTypeA::set_full_update_every(uint32_t full_update_every) {
+  this->full_update_every_ = full_update_every;
+}
+
+uint32_t EPaperTypeA::idle_timeout_() {
+  switch (this->model_) {
+    case _EPAPER_1_54_IN:
+    case _EPAPER_1_54_IN_V2:
+    case _EPAPER_2_13_IN_V2:
+    case TTGO_EPAPER_2_13_IN_B1:
+      return 2500;
+    default:
+      return EPaperBase::idle_timeout_();
+  }
+}
+
+// ========================================================
+//                          Type B
+// ========================================================
+// Datasheet:
+//  - https://www..com/w/upload/7/7f/4.2inch-e-paper-b-specification.pdf
+//  - https://github.com/soonuse/epd-library-arduino/blob/master/4.2inch_e-paper/epd4in2/
+
+static const uint8_t LUT_VCOM_DC_2_7[44] = {
+    0x00, 0x00, 0x00, 0x0F, 0x0F, 0x00, 0x00, 0x05, 0x00, 0x32, 0x32, 0x00, 0x00, 0x02, 0x00,
+    0x0F, 0x0F, 0x00, 0x00, 0x05, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+};
+
+static const uint8_t LUT_WHITE_TO_WHITE_2_7[42] = {
+    0x50, 0x0F, 0x0F, 0x00, 0x00, 0x05, 0x60, 0x32, 0x32, 0x00, 0x00, 0x02, 0xA0, 0x0F,
+    0x0F, 0x00, 0x00, 0x05, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+};
+
+static const uint8_t LUT_BLACK_TO_WHITE_2_7[42] = {
+    0x50, 0x0F, 0x0F, 0x00, 0x00, 0x05, 0x60, 0x32, 0x32, 0x00, 0x00, 0x02, 0xA0, 0x0F,
+    0x0F, 0x00, 0x00, 0x05, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+};
+
+static const uint8_t LUT_WHITE_TO_BLACK_2_7[] = {
+    0xA0, 0x0F, 0x0F, 0x00, 0x00, 0x05, 0x60, 0x32, 0x32, 0x00, 0x00, 0x02, 0x50, 0x0F,
+    0x0F, 0x00, 0x00, 0x05, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+};
+
+static const uint8_t LUT_BLACK_TO_BLACK_2_7[42] = {
+    0xA0, 0x0F, 0x0F, 0x00, 0x00, 0x05, 0x60, 0x32, 0x32, 0x00, 0x00, 0x02, 0x50, 0x0F,
+    0x0F, 0x00, 0x00, 0x05, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+};
+
+void EPaper2P7In::initialize() {
+  // command power setting
+  this->command(0x01);
+  this->data(0x03);  // VDS_EN, VDG_EN
+  this->data(0x00);  // VCOM_HV, VGHL_LV[1], VGHL_LV[0]
+  this->data(0x2B);  // VDH
+  this->data(0x2B);  // VDL
+  this->data(0x09);  // VDHR
+
+  // command booster soft start
+  this->command(0x06);
+  this->data(0x07);
+  this->data(0x07);
+  this->data(0x17);
+
+  // Power optimization - ???
+  this->command(0xF8);
+  this->data(0x60);
+  this->data(0xA5);
+  this->command(0xF8);
+  this->data(0x89);
+  this->data(0xA5);
+  this->command(0xF8);
+  this->data(0x90);
+  this->data(0x00);
+  this->command(0xF8);
+  this->data(0x93);
+  this->data(0x2A);
+  this->command(0xF8);
+  this->data(0xA0);
+  this->data(0xA5);
+  this->command(0xF8);
+  this->data(0xA1);
+  this->data(0x00);
+  this->command(0xF8);
+  this->data(0x73);
+  this->data(0x41);
+
+  // command partial display refresh
+  this->command(0x16);
+  this->data(0x00);
+
+  // command power on
+  this->command(0x04);
+  this->wait_until_idle_();
+  delay(10);
+
+  // Command panel setting
+  this->command(0x00);
+  this->data(0xAF);  // KW-BF   KWR-AF    BWROTP 0f
+  // command pll control
+  this->command(0x30);
+  this->data(0x3A);  // 3A 100HZ   29 150Hz 39 200HZ    31 171HZ
+  // COMMAND VCM DC SETTING
+  this->command(0x82);
+  this->data(0x12);
+
+  delay(2);
+  // COMMAND LUT FOR VCOM
+  this->command(0x20);
+  for (uint8_t i : LUT_VCOM_DC_2_7)
+    this->data(i);
+
+  // COMMAND LUT WHITE TO WHITE
+  this->command(0x21);
+  for (uint8_t i : LUT_WHITE_TO_WHITE_2_7)
+    this->data(i);
+  // COMMAND LUT BLACK TO WHITE
+  this->command(0x22);
+  for (uint8_t i : LUT_BLACK_TO_WHITE_2_7)
+    this->data(i);
+  // COMMAND LUT WHITE TO BLACK
+  this->command(0x23);
+  for (uint8_t i : LUT_WHITE_TO_BLACK_2_7)
+    this->data(i);
+  // COMMAND LUT BLACK TO BLACK
+  this->command(0x24);
+  for (uint8_t i : LUT_BLACK_TO_BLACK_2_7)
+    this->data(i);
+}
+void HOT EPaper2P7In::display() {
+  uint32_t buf_len = this->get_buffer_length_();
+
+  // COMMAND DATA START TRANSMISSION 1
+  this->command(0x10);
+  delay(2);
+  for (uint32_t i = 0; i < buf_len; i++) {
+    this->data(this->buffer_[i]);
+  }
+  delay(2);
+
+  // COMMAND DATA START TRANSMISSION 2
+  this->command(0x13);
+  delay(2);
+  for (uint32_t i = 0; i < buf_len; i++) {
+    this->data(this->buffer_[i]);
+  }
+
+  // COMMAND DISPLAY REFRESH
+  this->command(0x12);
+}
+int EPaper2P7In::get_width_internal() { return 176; }
+int EPaper2P7In::get_height_internal() { return 264; }
+void EPaper2P7In::dump_config() {
+  LOG_DISPLAY("", " E-Paper", this);
+  ESP_LOGCONFIG(TAG, "  Model: 2.7in");
+  LOG_PIN("  Reset Pin: ", this->reset_pin_);
+  LOG_PIN("  DC Pin: ", this->dc_pin_);
+  LOG_PIN("  Busy Pin: ", this->busy_pin_);
+  LOG_UPDATE_INTERVAL(this);
+}
+
+void EPaper2P7InV2::initialize() {
+  this->reset_();
+  this->wait_until_idle_();
+
+  this->command(0x12);  // SWRESET
+  this->wait_until_idle_();
+
+  // SET WINDOWS
+  // XRAM_START_AND_END_POSITION
+  this->command(0x44);
+  this->data(0x00);
+  this->data(((this->get_width_controller() - 1) >> 3) & 0xFF);
+  // YRAM_START_AND_END_POSITION
+  this->command(0x45);
+  this->data(0x00);
+  this->data(0x00);
+  this->data((get_height_internal() - 1) & 0xFF);
+  this->data(((get_height_internal() - 1) >> 8) & 0xFF);
+
+  // SET CURSOR
+  // XRAM_ADDRESS
+  this->command(0x4E);
+  this->data(0x00);
+  // YRAM_ADDRESS
+  this->command(0x4F);
+  this->data(0x00);
+  this->data(0x00);
+
+  this->command(0x11);  // data entry mode
+  this->data(0x03);
+}
+void HOT EPaper2P7InV2::display() {
+  this->command(0x24);
+  this->start_data_();
+  this->write_array(this->buffer_, this->get_buffer_length_());
+  this->end_data_();
+
+  // COMMAND DISPLAY REFRESH
+  this->command(0x22);
+  this->data(0xF7);
+  this->command(0x20);
+}
+int EPaper2P7InV2::get_width_internal() { return 176; }
+int EPaper2P7InV2::get_height_internal() { return 264; }
+void EPaper2P7InV2::dump_config() {
+  LOG_DISPLAY("", " E-Paper", this);
+  ESP_LOGCONFIG(TAG, "  Model: 2.7in V2");
+  LOG_PIN("  Reset Pin: ", this->reset_pin_);
+  LOG_PIN("  DC Pin: ", this->dc_pin_);
+  LOG_PIN("  Busy Pin: ", this->busy_pin_);
+  LOG_UPDATE_INTERVAL(this);
+}
+
+// ========================================================
+//                          1.54inch_v2_e-paper_b
+// ========================================================
+// Datasheet:
+//  - https://files..com/upload/9/9e/1.54inch-e-paper-b-v2-specification.pdf
+//  - https://www..com/wiki/1.54inch_e-Paper_Module_(B)_Manual
+
+void EPaper1P54InBV2::initialize() {
+  this->reset_();
+
+  this->wait_until_idle_();
+
+  this->command(0x12);
+  this->wait_until_idle_();
+
+  this->command(0x01);
+  this->data(0xC7);
+  this->data(0x00);
+  this->data(0x01);
+
+  this->command(0x11);  // data entry mode
+  this->data(0x01);
+
+  this->command(0x44);  // set Ram-X address start/end position
+  this->data(0x00);
+  this->data(0x18);  // 0x18-->(24+1)*8=200
+
+  this->command(0x45);  // set Ram-Y address start/end position
+  this->data(0xC7);     // 0xC7-->(199+1)=200
+  this->data(0x00);
+  this->data(0x00);
+  this->data(0x00);
+
+  this->command(0x3C);  // BorderWavefrom
+  this->data(0x05);
+
+  this->command(0x18);  // Read built-in temperature sensor
+  this->data(0x80);
+
+  this->command(0x4E);  // set RAM x address count to 0;
+  this->data(0x00);
+  this->command(0x4F);  // set RAM y address count to 0X199;
+  this->data(0xC7);
+  this->data(0x00);
+
+  this->wait_until_idle_();
+}
+
+void HOT EPaper1P54InBV2::display() {
+  uint32_t buf_len_half = this->get_buffer_length_() >> 1;
+  this->initialize();
+
+  // COMMAND DATA START TRANSMISSION 1 (BLACK)
+  this->command(0x24);
+  delay(2);
+  for (uint32_t i = 0; i < buf_len_half; i++) {
+    this->data(~this->buffer_[i]);
+  }
+  delay(2);
+
+  // COMMAND DATA START TRANSMISSION 2  (RED)
+  this->command(0x26);
+  delay(2);
+  for (uint32_t i = buf_len_half; i < buf_len_half * 2u; i++) {
+    this->data(this->buffer_[i]);
+  }
+  this->command(0x22);
+  this->data(0xf7);
+  this->command(0x20);
+  this->wait_until_idle_();
+
+  this->deep_sleep();
+}
+int EPaper1P54InBV2::get_height_internal() { return 200; }
+int EPaper1P54InBV2::get_width_internal() { return 200; }
+void EPaper1P54InBV2::dump_config() {
+  LOG_DISPLAY("", " E-Paper", this);
+  ESP_LOGCONFIG(TAG, "  Model: 1.54in V2 B");
+  LOG_PIN("  Reset Pin: ", this->reset_pin_);
+  LOG_PIN("  DC Pin: ", this->dc_pin_);
+  LOG_PIN("  Busy Pin: ", this->busy_pin_);
+  LOG_UPDATE_INTERVAL(this);
+}
+
+// ========================================================
+//                          2.7inch_e-paper_b
+// ========================================================
+// Datasheet:
+//  - https://www..com/w/upload/d/d8/2.7inch-e-paper-b-specification.pdf
+//  - https://github.com//e-Paper/blob/master/RaspberryPi_JetsonNano/c/lib/e-Paper/EPD_2in7b.c
+
+static const uint8_t LUT_VCOM_DC_2_7B[44] = {0x00, 0x00, 0x00, 0x1A, 0x1A, 0x00, 0x00, 0x01, 0x00, 0x0A, 0x0A,
+                                             0x00, 0x00, 0x08, 0x00, 0x0E, 0x01, 0x0E, 0x01, 0x10, 0x00, 0x0A,
+                                             0x0A, 0x00, 0x00, 0x08, 0x00, 0x04, 0x10, 0x00, 0x00, 0x05, 0x00,
+                                             0x03, 0x0E, 0x00, 0x00, 0x0A, 0x00, 0x23, 0x00, 0x00, 0x00, 0x01};
+
+static const uint8_t LUT_WHITE_TO_WHITE_2_7B[42] = {0x90, 0x1A, 0x1A, 0x00, 0x00, 0x01, 0x40, 0x0A, 0x0A, 0x00, 0x00,
+                                                    0x08, 0x84, 0x0E, 0x01, 0x0E, 0x01, 0x10, 0x80, 0x0A, 0x0A, 0x00,
+                                                    0x00, 0x08, 0x00, 0x04, 0x10, 0x00, 0x00, 0x05, 0x00, 0x03, 0x0E,
+                                                    0x00, 0x00, 0x0A, 0x00, 0x23, 0x00, 0x00, 0x00, 0x01};
+
+static const uint8_t LUT_BLACK_TO_WHITE_2_7B[42] = {0xA0, 0x1A, 0x1A, 0x00, 0x00, 0x01, 0x00, 0x0A, 0x0A, 0x00, 0x00,
+                                                    0x08, 0x84, 0x0E, 0x01, 0x0E, 0x01, 0x10, 0x90, 0x0A, 0x0A, 0x00,
+                                                    0x00, 0x08, 0xB0, 0x04, 0x10, 0x00, 0x00, 0x05, 0xB0, 0x03, 0x0E,
+                                                    0x00, 0x00, 0x0A, 0xC0, 0x23, 0x00, 0x00, 0x00, 0x01};
+
+static const uint8_t LUT_WHITE_TO_BLACK_2_7B[] = {0x90, 0x1A, 0x1A, 0x00, 0x00, 0x01, 0x20, 0x0A, 0x0A, 0x00, 0x00,
+                                                  0x08, 0x84, 0x0E, 0x01, 0x0E, 0x01, 0x10, 0x10, 0x0A, 0x0A, 0x00,
+                                                  0x00, 0x08, 0x00, 0x04, 0x10, 0x00, 0x00, 0x05, 0x00, 0x03, 0x0E,
+                                                  0x00, 0x00, 0x0A, 0x00, 0x23, 0x00, 0x00, 0x00, 0x01};
+
+static const uint8_t LUT_BLACK_TO_BLACK_2_7B[42] = {0x90, 0x1A, 0x1A, 0x00, 0x00, 0x01, 0x40, 0x0A, 0x0A, 0x00, 0x00,
+                                                    0x08, 0x84, 0x0E, 0x01, 0x0E, 0x01, 0x10, 0x80, 0x0A, 0x0A, 0x00,
+                                                    0x00, 0x08, 0x00, 0x04, 0x10, 0x00, 0x00, 0x05, 0x00, 0x03, 0x0E,
+                                                    0x00, 0x00, 0x0A, 0x00, 0x23, 0x00, 0x00, 0x00, 0x01};
+
+void EPaper2P7InB::initialize() {
+  this->reset_();
+
+  // command power on
+  this->command(0x04);
+  this->wait_until_idle_();
+  delay(10);
+
+  // Command panel setting
+  this->command(0x00);
+  this->data(0xAF);  // KW-BF   KWR-AF    BWROTP 0f
+  // command pll control
+  this->command(0x30);
+  this->data(0x3A);  // 3A 100HZ   29 150Hz 39 200HZ    31 171HZ
+
+  // command power setting
+  this->command(0x01);
+  this->data(0x03);  // VDS_EN, VDG_EN
+  this->data(0x00);  // VCOM_HV, VGHL_LV[1], VGHL_LV[0]
+  this->data(0x2B);  // VDH
+  this->data(0x2B);  // VDL
+  this->data(0x09);  // VDHR
+
+  // command booster soft start
+  this->command(0x06);
+  this->data(0x07);
+  this->data(0x07);
+  this->data(0x17);
+
+  // Power optimization - ???
+  this->command(0xF8);
+  this->data(0x60);
+  this->data(0xA5);
+  this->command(0xF8);
+  this->data(0x89);
+  this->data(0xA5);
+  this->command(0xF8);
+  this->data(0x90);
+  this->data(0x00);
+  this->command(0xF8);
+  this->data(0x93);
+  this->data(0x2A);
+  this->command(0xF8);
+  this->data(0x73);
+  this->data(0x41);
+
+  // COMMAND VCM DC SETTING
+  this->command(0x82);
+  this->data(0x12);
+
+  // VCOM_AND_DATA_INTERVAL_SETTING
+  this->command(0x50);
+  this->data(0x87);  // define by OTP
+
+  delay(2);
+  // COMMAND LUT FOR VCOM
+  this->command(0x20);
+  for (uint8_t i : LUT_VCOM_DC_2_7B)
+    this->data(i);
+  // COMMAND LUT WHITE TO WHITE
+  this->command(0x21);
+  for (uint8_t i : LUT_WHITE_TO_WHITE_2_7B)
+    this->data(i);
+  // COMMAND LUT BLACK TO WHITE
+  this->command(0x22);
+  for (uint8_t i : LUT_BLACK_TO_WHITE_2_7B)
+    this->data(i);
+  // COMMAND LUT WHITE TO BLACK
+  this->command(0x23);
+  for (uint8_t i : LUT_WHITE_TO_BLACK_2_7B) {
+    this->data(i);
+  }
+  // COMMAND LUT BLACK TO BLACK
+  this->command(0x24);
+
+  for (uint8_t i : LUT_BLACK_TO_BLACK_2_7B) {
+    this->data(i);
+  }
+
+  delay(2);
+}
+
+void HOT EPaper2P7InB::display() {
+  uint32_t buf_len_half = this->get_buffer_length_() >> 1;
+  this->initialize();
+
+  // TCON_RESOLUTION
+  this->command(0x61);
+  this->data(this->get_width_controller() >> 8);
+  this->data(this->get_width_controller() & 0xff);  // 176
+  this->data(this->get_height_internal() >> 8);
+  this->data(this->get_height_internal() & 0xff);  // 264
+
+  // COMMAND DATA START TRANSMISSION 1 (BLACK)
+  this->command(0x10);
+  delay(2);
+  for (uint32_t i = 0; i < buf_len_half; i++) {
+    this->data(this->buffer_[i]);
+  }
+  this->command(0x11);
+  delay(2);
+
+  // COMMAND DATA START TRANSMISSION 2  (RED)
+  this->command(0x13);
+  delay(2);
+  for (uint32_t i = buf_len_half; i < buf_len_half * 2u; i++) {
+    this->data(this->buffer_[i]);
+  }
+  this->command(0x11);
+
+  delay(2);
+
+  // COMMAND DISPLAY REFRESH
+  this->command(0x12);
+  this->wait_until_idle_();
+
+  this->deep_sleep();
+}
+int EPaper2P7InB::get_width_internal() { return 176; }
+int EPaper2P7InB::get_height_internal() { return 264; }
+void EPaper2P7InB::dump_config() {
+  LOG_DISPLAY("", " E-Paper", this);
+  ESP_LOGCONFIG(TAG, "  Model: 2.7in B");
+  LOG_PIN("  Reset Pin: ", this->reset_pin_);
+  LOG_PIN("  DC Pin: ", this->dc_pin_);
+  LOG_PIN("  Busy Pin: ", this->busy_pin_);
+  LOG_UPDATE_INTERVAL(this);
+}
+
+// ========================================================
+//                          2.7inch_e-paper_b_v2
+// ========================================================
+// Datasheet:
+//  - https://www..com/w/upload/7/7b/2.7inch-e-paper-b-v2-specification.pdf
+//  - https://github.com//e-Paper/blob/master/RaspberryPi_JetsonNano/c/lib/e-Paper/EPD_2in7b_V2.c
+
+void EPaper2P7InBV2::initialize() {
+  this->reset_();
+
+  this->wait_until_idle_();
+  this->command(0x12);
+  this->wait_until_idle_();
+
+  this->command(0x00);
+  this->data(0x27);
+  this->data(0x01);
+  this->data(0x00);
+
+  this->command(0x11);
+  this->data(0x03);
+
+  // self.SetWindows(0, 0, self.width-1, self.height-1)
+  // SetWindows(self, Xstart, Ystart, Xend, Yend):
+
+  uint32_t xend = this->get_width_controller() - 1;
+  uint32_t yend = this->get_height_internal() - 1;
+  this->command(0x44);
+  this->data(0x00);
+  this->data((xend >> 3) & 0xff);
+
+  this->command(0x45);
+  this->data(0x00);
+  this->data(0x00);
+  this->data(yend & 0xff);
+  this->data((yend >> 8) & 0xff);
+
+  // SetCursor(self, Xstart, Ystart):
+  this->command(0x4E);
+  this->data(0x00);
+  this->command(0x4F);
+  this->data(0x00);
+  this->data(0x00);
+}
+
+void HOT EPaper2P7InBV2::display() {
+  uint32_t buf_len = this->get_buffer_length_();
+  // COMMAND DATA START TRANSMISSION 1 (BLACK)
+  this->command(0x24);
+  delay(2);
+  for (uint32_t i = 0; i < buf_len; i++) {
+    this->data(this->buffer_[i]);
+  }
+  delay(2);
+
+  // COMMAND DATA START TRANSMISSION 2  (RED)
+  this->command(0x26);
+  delay(2);
+  for (uint32_t i = 0; i < buf_len; i++) {
+    this->data(this->buffer_[i]);
+  }
+
+  delay(2);
+
+  this->command(0x20);
+
+  this->wait_until_idle_();
+}
+int EPaper2P7InBV2::get_width_internal() { return 176; }
+int EPaper2P7InBV2::get_height_internal() { return 264; }
+void EPaper2P7InBV2::dump_config() {
+  LOG_DISPLAY("", " E-Paper", this);
+  ESP_LOGCONFIG(TAG, "  Model: 2.7in B V2");
+  LOG_PIN("  Reset Pin: ", this->reset_pin_);
+  LOG_PIN("  DC Pin: ", this->dc_pin_);
+  LOG_PIN("  Busy Pin: ", this->busy_pin_);
+  LOG_UPDATE_INTERVAL(this);
+}
+
+// ========================================================
+//               2.90in Type B (LUT from OTP)
+// Datasheet:
+//  - https://www..com/w/upload/b/bb/2.9inch-e-paper-b-specification.pdf
+//  - https://github.com/soonuse/epd-library-arduino/blob/master/2.9inch_e-paper_b/epd2in9b/epd2in9b.cpp
+// ========================================================
+
+void EPaper2P9InB::initialize() {
+  // from https://www..com/w/upload/b/bb/2.9inch-e-paper-b-specification.pdf, page 37
+  // EPD hardware init start
+  this->reset_();
+
+  // COMMAND BOOSTER SOFT START
+  this->command(0x06);
+  this->data(0x17);
+  this->data(0x17);
+  this->data(0x17);
+
+  // COMMAND POWER ON
+  this->command(0x04);
+  this->wait_until_idle_();
+
+  // COMMAND PANEL SETTING
+  this->command(0x00);
+  // 128x296 resolution:        10
+  // LUT from OTP:              0
+  // B/W mode (doesn't work):   1
+  // scan-up:                   1
+  // shift-right:               1
+  // booster ON:                1
+  // no soft reset:             1
+  this->data(0x9F);
+
+  // COMMAND RESOLUTION SETTING
+  // set to 128x296 by COMMAND PANEL SETTING
+
+  // COMMAND VCOM AND DATA INTERVAL SETTING
+  // use defaults for white border and ESPHome image polarity
+
+  // EPD hardware init end
+}
+void HOT EPaper2P9InB::display() {
+  // COMMAND DATA START TRANSMISSION 1 (B/W data)
+  this->command(0x10);
+  delay(2);
+  this->start_data_();
+  this->write_array(this->buffer_, this->get_buffer_length_());
+  this->end_data_();
+  delay(2);
+
+  // COMMAND DATA START TRANSMISSION 2 (RED data)
+  this->command(0x13);
+  delay(2);
+  this->start_data_();
+  for (size_t i = 0; i < this->get_buffer_length_(); i++)
+    this->write_byte(0x00);
+  this->end_data_();
+  delay(2);
+
+  // COMMAND DISPLAY REFRESH
+  this->command(0x12);
+  delay(2);
+  this->wait_until_idle_();
+
+  // COMMAND POWER OFF
+  // NOTE: power off < deep sleep
+  this->command(0x02);
+}
+int EPaper2P9InB::get_width_internal() { return 128; }
+int EPaper2P9InB::get_height_internal() { return 296; }
+void EPaper2P9InB::dump_config() {
+  LOG_DISPLAY("", " E-Paper", this);
+  ESP_LOGCONFIG(TAG, "  Model: 2.9in (B)");
+  LOG_PIN("  Reset Pin: ", this->reset_pin_);
+  LOG_PIN("  DC Pin: ", this->dc_pin_);
+  LOG_PIN("  Busy Pin: ", this->busy_pin_);
+  LOG_UPDATE_INTERVAL(this);
+}
+
+// ========================================================
+//   2.9-inch E-Paper (Type D)
+//   WIKI: https://www..com/wiki/Pico-ePaper-2.9-D
+//  Datasheet: https://www..com/w/upload/b/b5/2.9inch_e-Paper_(D)_Specification.pdf
+// ========================================================
+
+void EPaper2P9InD::initialize() {
+  // EPD hardware init start
+  this->reset_();
+
+  // Booster Soft Start
+  this->command(0x06);  // Command: BTST
+  this->data(0x17);     // Soft start configuration Phase A
+  this->data(0x17);     // Soft start configuration Phase B
+  this->data(0x17);     // Soft start configuration Phase C
+
+  // Power Setting
+  this->command(0x01);  // Command: PWR
+  this->data(0x03);     // Intern DC/DC for VDH/VDL and VGH/VGL
+  this->data(0x00);     // Default configuration VCOM_HV and VGHL_LV
+  this->data(0x2b);     // VDH = 10.8 V
+  this->data(0x2b);     // VDL = -10.8 V
+
+  // Power ON
+  this->command(0x04);  // Command: PON
+  this->wait_until_idle_();
+
+  // Panel settings
+  this->command(0x00);  // Command: PSR
+  this->data(0x1F);     // LUT from OTP, black and white mode, default scan
+
+  // PLL Control
+  this->command(0x30);  // Command: PLL
+  this->data(0x3A);     // Default PLL frequency
+
+  // Resolution settings
+  this->command(0x61);  // Command: TRES
+  this->data(0x80);     // Width: 128
+  this->data(0x01);     // Height MSB: 296
+  this->data(0x28);     // Height LSB: 296
+
+  // VCOM and data interval settings
+  this->command(0x50);  // Command: CDI
+  this->data(0x77);
+
+  // VCOM_DC settings
+  this->command(0x82);  // Command: VDCS
+  this->data(0x12);     // Dafault VCOM_DC
+}
+
+void EPaper2P9InD::display() {
+  // Start transmitting old data (clearing buffer)
+  this->command(0x10);  // Command: DTM1 (OLD frame data)
+  this->start_data_();
+  this->write_array(this->buffer_, this->get_buffer_length_());
+  this->end_data_();
+
+  // Start transmitting new data (updated content)
+  this->command(0x13);  // Command: DTM2 (NEW frame data)
+  this->start_data_();
+  this->write_array(this->buffer_, this->get_buffer_length_());
+  this->end_data_();
+
+  // Refresh Display
+  this->command(0x12);  // Command: DRF
+  this->wait_until_idle_();
+
+  // Enter Power Off
+  this->command(0x02);  // Command: POF
+  this->wait_until_idle_();
+
+  // Enter Deep Sleep
+  this->command(0x07);  // Command: DSLP
+  this->data(0xA5);
+}
+
+int EPaper2P9InD::get_width_internal() { return 128; }
+int EPaper2P9InD::get_height_internal() { return 296; }
+void EPaper2P9InD::dump_config() {
+  LOG_DISPLAY("", " E-Paper", this);
+  ESP_LOGCONFIG(TAG, "  Model: 2.9in (D)");
+  LOG_PIN("  Reset Pin: ", this->reset_pin_);
+  LOG_PIN("  DC Pin: ", this->dc_pin_);
+  LOG_PIN("  Busy Pin: ", this->busy_pin_);
+  LOG_UPDATE_INTERVAL(this);
+}
+
+// DKE 2.9
+// https://www.badge.team/docs/badges/sha2017/hardware/#e-ink-display-the-dke-group-depg0290b1
+// https://www.badge.team/docs/badges/sha2017/hardware/DEPG0290B01V3.0.pdf
+static const uint8_t LUT_SIZE_DKE = 70;
+static const uint8_t UPDATE_LUT_DKE[LUT_SIZE_DKE] = {
+    0xA0, 0x90, 0x50, 0x0,  0x0,  0x0,  0x0, 0x50, 0x90, 0xA0, 0x0,  0x0,  0x0,  0x0, 0xA0, 0x90, 0x50, 0x0,
+    0x0,  0x0,  0x0,  0x50, 0x90, 0xA0, 0x0, 0x0,  0x0,  0x0,  0x00, 0x00, 0x00, 0x0, 0x0,  0x0,  0x0,  0xF,
+    0xF,  0x0,  0x0,  0x0,  0xF,  0xF,  0x0, 0x0,  0x02, 0xF,  0xF,  0x0,  0x0,  0x0, 0x0,  0x0,  0x0,  0x0,
+    0x0,  0x0,  0x0,  0x0,  0x0,  0x0,  0x0, 0x0,  0x0,  0x0,  0x0,  0x0,  0x0,  0x0, 0x0,  0x0,
+};
+static const uint8_t PART_UPDATE_LUT_DKE[LUT_SIZE_DKE] = {
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x20, 0xa0, 0x80, 0x00, 0x00, 0x00, 0x00, 0x50, 0x10, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03,
+    0x05, 0x00, 0x00, 0x00, 0x01, 0x08, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+static const uint8_t FULL_UPDATE_LUT_DKE[LUT_SIZE_DKE] = {
+    0x90, 0x50, 0xa0, 0x50, 0x50, 0x00, 0x00, 0x00, 0x00, 0x10, 0xa0, 0xa0, 0x80, 0x00, 0x90, 0x50, 0xa0, 0x50,
+    0x50, 0x00, 0x00, 0x00, 0x00, 0x10, 0xa0, 0xa0, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x17,
+    0x04, 0x00, 0x00, 0x00, 0x0b, 0x04, 0x00, 0x00, 0x00, 0x06, 0x05, 0x00, 0x00, 0x00, 0x04, 0x05, 0x00, 0x00,
+    0x00, 0x01, 0x0e, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+
+void EPaper2P9InDKE::initialize() {
+  // Hardware reset
+  delay(10);
+  this->reset_pin_->digital_write(false);
+  delayMicroseconds(200);
+  this->reset_pin_->digital_write(true);
+  delayMicroseconds(200);
+  // Wait for busy low
+  this->wait_until_idle_();
+  // Software reset
+  this->command(0x12);
+  // Wait for busy low
+  this->wait_until_idle_();
+  // Set Analog Block Control
+  this->command(0x74);
+  this->data(0x54);
+  // Set Digital Block Control
+  this->command(0x7E);
+  this->data(0x3B);
+  // Set display size and driver output control
+  this->command(0x01);
+  // this->data(0x27);
+  // this->data(0x01);
+  // this->data(0x00);
+  this->data(this->get_height_internal() - 1);
+  this->data((this->get_height_internal() - 1) >> 8);
+  this->data(0x00);  // ? GD = 0, SM = 0, TB = 0
+  // Ram data entry mode
+  this->command(0x11);
+  this->data(0x03);
+  // Set Ram X address
+  this->command(0x44);
+  this->data(0x00);
+  this->data(0x0F);
+  // Set Ram Y address
+  this->command(0x45);
+  this->data(0x00);
+  this->data(0x00);
+  this->data(0x27);
+  this->data(0x01);
+  // Set border
+  this->command(0x3C);
+  // this->data(0x80);
+  this->data(0x01);
+  // Set VCOM value
+  this->command(0x2C);
+  this->data(0x26);
+  // Gate voltage setting
+  this->command(0x03);
+  this->data(0x17);
+  // Source voltage setting
+  this->command(0x04);
+  this->data(0x41);
+  this->data(0x00);
+  this->data(0x32);
+  // Frame setting 50hz
+  this->command(0x3A);
+  this->data(0x30);
+  this->command(0x3B);
+  this->data(0x0A);
+  // Load LUT
+  this->command(0x32);
+  for (uint8_t v : FULL_UPDATE_LUT_DKE)
+    this->data(v);
+}
+
+void HOT EPaper2P9InDKE::display() {
+  ESP_LOGI(TAG, "Performing e-paper update.");
+  // Set Ram X address counter
+  this->command(0x4e);
+  this->data(0);
+  // Set Ram Y address counter
+  this->command(0x4f);
+  this->data(0);
+  this->data(0);
+  // Load image (128/8*296)
+  this->command(0x24);
+  this->start_data_();
+  this->write_array(this->buffer_, this->get_buffer_length_());
+  this->end_data_();
+  // Image update
+  this->command(0x22);
+  this->data(0xC7);
+  this->command(0x20);
+  // Wait for busy low
+  this->wait_until_idle_();
+  // Enter deep sleep mode
+  this->command(0x10);
+  this->data(0x01);
+}
+int EPaper2P9InDKE::get_width_internal() { return 128; }
+int EPaper2P9InDKE::get_height_internal() { return 296; }
+void EPaper2P9InDKE::dump_config() {
+  LOG_DISPLAY("", " E-Paper", this);
+  ESP_LOGCONFIG(TAG, "  Model: 2.9in DKE");
+  LOG_PIN("  Reset Pin: ", this->reset_pin_);
+  LOG_PIN("  DC Pin: ", this->dc_pin_);
+  LOG_PIN("  Busy Pin: ", this->busy_pin_);
+  LOG_UPDATE_INTERVAL(this);
+}
+void EPaper2P9InDKE::set_full_update_every(uint32_t full_update_every) {
+  this->full_update_every_ = full_update_every;
+}
+
+// ========================================================
+//               2.90in Type B (LUT from OTP)
+// Datasheet:
+//  - https://files..com/upload/a/af/2.9inch-e-paper-b-v3-specification.pdf
+// ========================================================
+
+void EPaper2P9InBV3::initialize() {
+  // from https://github.com/team/e-Paper/blob/master/Arduino/epd2in9b_V3/epd2in9b_V3.cpp
+  this->reset_();
+
+  // COMMAND POWER ON
+  this->command(0x04);
+  this->wait_until_idle_();
+
+  // COMMAND PANEL SETTING
+  this->command(0x00);
+  this->data(0x0F);
+  this->data(0x89);
+
+  // COMMAND RESOLUTION SETTING
+  this->command(0x61);
+  this->data(0x80);
+  this->data(0x01);
+  this->data(0x28);
+
+  // COMMAND VCOM AND DATA INTERVAL SETTING
+  this->command(0x50);
+  this->data(0x77);
+}
+void HOT EPaper2P9InBV3::display() {
+  // COMMAND DATA START TRANSMISSION 1 (B/W data)
+  this->command(0x10);
+  delay(2);
+  this->start_data_();
+  this->write_array(this->buffer_, this->get_buffer_length_());
+  this->end_data_();
+  this->command(0x92);
+  delay(2);
+
+  // COMMAND DATA START TRANSMISSION 2 (RED data)
+  this->command(0x13);
+  delay(2);
+  this->start_data_();
+  for (size_t i = 0; i < this->get_buffer_length_(); i++)
+    this->write_byte(0xFF);
+  this->end_data_();
+  this->command(0x92);
+  delay(2);
+
+  // COMMAND DISPLAY REFRESH
+  this->command(0x12);
+  delay(2);
+  this->wait_until_idle_();
+
+  // COMMAND POWER OFF
+  // NOTE: power off < deep sleep
+  this->command(0x02);
+}
+int EPaper2P9InBV3::get_width_internal() { return 128; }
+int EPaper2P9InBV3::get_height_internal() { return 296; }
+void EPaper2P9InBV3::dump_config() {
+  LOG_DISPLAY("", " E-Paper", this);
+  ESP_LOGCONFIG(TAG, "  Model: 2.9in (B) V3");
+  LOG_PIN("  Reset Pin: ", this->reset_pin_);
+  LOG_PIN("  DC Pin: ", this->dc_pin_);
+  LOG_PIN("  Busy Pin: ", this->busy_pin_);
+  LOG_UPDATE_INTERVAL(this);
+}
+
+// ========================================================
+//               2.90in v2 rev2
+// based on SDK and examples in ZIP file from:
+// https://www..com/pico-epaper-2.9.htm
+// ========================================================
+
+void EPaper2P9InV2R2::initialize() {
+  this->reset_();
+  this->wait_until_idle_();
+
+  this->command(0x12);  // SWRESET
+  this->wait_until_idle_();
+
+  this->command(0x01);
+  this->data(0x27);
+  this->data(0x01);
+  this->data(0x00);
+
+  this->command(0x11);
+  this->data(0x03);
+
+  // SetWindows(0, 0, w, h)
+  this->command(0x44);
+  this->data(0x00);
+  this->data(((this->get_width_controller() - 1) >> 3) & 0xFF);
+
+  this->command(0x45);
+  this->data(0x00);
+  this->data(0x00);
+  this->data((this->get_height_internal() - 1) & 0xFF);
+  this->data(((this->get_height_internal() - 1) >> 8) & 0xFF);
+
+  this->command(0x21);
+  this->data(0x00);
+  this->data(0x80);
+
+  // SetCursor(0, 0)
+  this->command(0x4E);
+  this->data(0x00);
+  this->command(0x4f);
+  this->data(0x00);
+  this->data(0x00);
+
+  this->wait_until_idle_();
+}
+
+EPaper2P9InV2R2::EPaper2P9InV2R2() { this->reset_duration_ = 10; }
+
+void EPaper2P9InV2R2::reset_() {
+  if (this->reset_pin_ != nullptr) {
+    this->reset_pin_->digital_write(false);
+    delay(reset_duration_);  // NOLINT
+    this->reset_pin_->digital_write(true);
+    delay(reset_duration_);  // NOLINT
+  }
+}
+
+void EPaper2P9InV2R2::display() {
+  if (!this->wait_until_idle_()) {
+    this->status_set_warning();
+    ESP_LOGE(TAG, "fail idle 1");
+    return;
+  }
+
+  if (this->full_update_every_ == 1) {
+    // do single full update
+    this->command(0x24);
+    this->start_data_();
+    this->write_array(this->buffer_, this->get_buffer_length_());
+    this->end_data_();
+
+    // TurnOnDisplay
+    this->command(0x22);
+    this->data(0xF7);
+    this->command(0x20);
+    return;
+  }
+
+  // if (this->full_update_every_ == 1 ||
+  if (this->at_update_ == 0) {
+    // do base update
+    this->command(0x24);
+    this->start_data_();
+    this->write_array(this->buffer_, this->get_buffer_length_());
+    this->end_data_();
+
+    this->command(0x26);
+    this->start_data_();
+    this->write_array(this->buffer_, this->get_buffer_length_());
+    this->end_data_();
+
+    // TurnOnDisplay
+    this->command(0x22);
+    this->data(0xF7);
+    this->command(0x20);
+  } else {
+    // do partial update
+    this->reset_();
+
+    this->write_lut_(PARTIAL_UPD_2IN9_LUT, PARTIAL_UPD_2IN9_LUT_SIZE);
+
+    this->command(0x37);
+    this->data(0x00);
+    this->data(0x00);
+    this->data(0x00);
+    this->data(0x00);
+    this->data(0x00);
+    this->data(0x40);
+    this->data(0x00);
+    this->data(0x00);
+    this->data(0x00);
+    this->data(0x00);
+
+    this->command(0x3C);
+    this->data(0x80);
+
+    this->command(0x22);
+    this->data(0xC0);
+    this->command(0x20);
+
+    if (!this->wait_until_idle_()) {
+      ESP_LOGE(TAG, "fail idle 2");
+    }
+
+    // SetWindows(0, 0, w, h)
+    this->command(0x44);
+    this->data(0x00);
+    this->data(((this->get_width_controller() - 1) >> 3) & 0xFF);
+
+    this->command(0x45);
+    this->data(0x00);
+    this->data(0x00);
+    this->data((this->get_height_internal() - 1) & 0xFF);
+    this->data(((this->get_height_internal() - 1) >> 8) & 0xFF);
+
+    // SetCursor(0, 0)
+    this->command(0x4E);
+    this->data(0x00);
+    this->command(0x4f);
+    this->data(0x00);
+    this->data(0x00);
+
+    // write b/w
+    this->command(0x24);
+    this->start_data_();
+    this->write_array(this->buffer_, this->get_buffer_length_());
+    this->end_data_();
+
+    // TurnOnDisplayPartial
+    this->command(0x22);
+    this->data(0x0F);
+    this->command(0x20);
+  }
+
+  this->at_update_ = (this->at_update_ + 1) % this->full_update_every_;
+}
+
+void EPaper2P9InV2R2::write_lut_(const uint8_t *lut, const uint8_t size) {
+  // COMMAND WRITE LUT REGISTER
+  this->command(0x32);
+  for (uint8_t i = 0; i < size; i++)
+    this->data(lut[i]);
+}
+
+void EPaper2P9InV2R2::dump_config() {
+  LOG_DISPLAY("", " E-Paper", this);
+  ESP_LOGCONFIG(TAG, "  Model: 2.9inV2R2");
+  ESP_LOGCONFIG(TAG, "  Full Update Every: %" PRIu32, this->full_update_every_);
+  LOG_PIN("  Reset Pin: ", this->reset_pin_);
+  LOG_PIN("  DC Pin: ", this->dc_pin_);
+  LOG_PIN("  Busy Pin: ", this->busy_pin_);
+  LOG_UPDATE_INTERVAL(this);
+}
+
+void EPaper2P9InV2R2::deep_sleep() {
+  this->command(0x10);
+  this->data(0x01);
+}
+
+int EPaper2P9InV2R2::get_width_internal() { return 128; }
+int EPaper2P9InV2R2::get_height_internal() { return 296; }
+int EPaper2P9InV2R2::get_width_controller() { return this->get_width_internal(); }
+void EPaper2P9InV2R2::set_full_update_every(uint32_t full_update_every) {
+  this->full_update_every_ = full_update_every;
+}
+// ========================================================
+//     Good Display 2.9in black/white
+// Datasheet:
+//  - https://files.studio.com/wiki/Other_Display/29-epaper/GDEY029T94.pdf
+//  -
+//  https://github.com/Allen-Kuang/e-ink_Demo/blob/main/2.9%20inch%20E-paper%20-%20monocolor%20128x296/example/Display_EPD_W21.cpp
+// ========================================================
+
+void GDEY029T94::initialize() {
+  // EPD hardware init start
+  this->reset_();
+
+  this->wait_until_idle_();
+  this->command(0x12);  // SWRESET
+  this->wait_until_idle_();
+
+  this->command(0x01);  // Driver output control
+  this->data((this->get_height_internal() - 1) % 256);
+  this->data((this->get_height_internal() - 1) / 256);
+  this->data(0x00);
+
+  this->command(0x11);  // data entry mode
+  this->data(0x03);
+
+  this->command(0x44);  // set Ram-X address start/end position
+  this->data(0x00);
+  this->data(this->get_width_internal() / 8 - 1);
+
+  this->command(0x45);  // set Ram-Y address start/end position
+  this->data(0x00);
+  this->data(0x00);
+  this->data((this->get_height_internal() - 1) % 256);
+  this->data((this->get_height_internal() - 1) / 256);
+
+  this->command(0x3C);  // BorderWavefrom
+  this->data(0x05);
+
+  this->command(0x21);  //  Display update control
+  this->data(0x00);
+  this->data(0x80);
+
+  this->command(0x18);  // Read built-in temperature sensor
+  this->data(0x80);
+
+  this->command(0x4E);  // set RAM x address count to 0;
+  this->data(0x00);
+  this->command(0x4F);  // set RAM y address count to 0X199;
+  this->command(0x00);
+  this->command(0x00);
+  this->wait_until_idle_();
+}
+void HOT GDEY029T94::display() {
+  this->command(0x24);  // write RAM for black(0)/white (1)
+  this->start_data_();
+  for (uint32_t i = 0; i < this->get_buffer_length_(); i++) {
+    this->write_byte(this->buffer_[i]);
+  }
+  this->end_data_();
+  this->command(0x22);  // Display Update Control
+  this->data(0xF7);
+  this->command(0x20);  // Activate Display Update Sequence
+  this->wait_until_idle_();
+}
+int GDEY029T94::get_width_internal() { return 128; }
+int GDEY029T94::get_height_internal() { return 296; }
+void GDEY029T94::dump_config() {
+  LOG_DISPLAY("", "E-Paper (Good Display)", this);
+  ESP_LOGCONFIG(TAG, "  Model: 2.9in GDEY029T94");
+  LOG_PIN("  Reset Pin: ", this->reset_pin_);
+  LOG_PIN("  DC Pin: ", this->dc_pin_);
+  LOG_PIN("  Busy Pin: ", this->busy_pin_);
+  LOG_UPDATE_INTERVAL(this);
+}
+
+// ========================================================
+//     Good Display 2.9in black/white
+// Datasheet:
+//  - https://v4.cecdn.yun300.cn/100001_1909185148/SSD1680.pdf
+//  - https://github.com/adafruit/Adafruit_EPD/blob/master/src/panels/ThinkInk_290_Grayscale4_T5.h
+//  - https://github.com/ZinggJM/GxEPD2/blob/master/src/epd/GxEPD2_290_T5.cpp
+//  - http://www.e-paper-display.com/GDEW029T5%20V3.1%20Specification5c22.pdf?
+// ========================================================
+
+// full screen update LUT
+static const uint8_t LUT_20_VCOMDC_29_5[] = {
+    0x00, 0x08, 0x00, 0x00, 0x00, 0x02, 0x60, 0x28, 0x28, 0x00, 0x00, 0x01, 0x00, 0x14, 0x00,
+    0x00, 0x00, 0x01, 0x00, 0x12, 0x12, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+};
+
+static const uint8_t LUT_21_WW_29_5[] = {
+    0x40, 0x08, 0x00, 0x00, 0x00, 0x02, 0x90, 0x28, 0x28, 0x00, 0x00, 0x01, 0x40, 0x14,
+    0x00, 0x00, 0x00, 0x01, 0xA0, 0x12, 0x12, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+};
+
+static const uint8_t LUT_22_BW_29_5[] = {
+    0x40, 0x08, 0x00, 0x00, 0x00, 0x02, 0x90, 0x28, 0x28, 0x00, 0x00, 0x01, 0x40, 0x14,
+    0x00, 0x00, 0x00, 0x01, 0xA0, 0x12, 0x12, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+};
+
+static const uint8_t LUT_23_WB_29_5[] = {
+    0x80, 0x08, 0x00, 0x00, 0x00, 0x02, 0x90, 0x28, 0x28, 0x00, 0x00, 0x01, 0x80, 0x14,
+    0x00, 0x00, 0x00, 0x01, 0x50, 0x12, 0x12, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+};
+
+static const uint8_t LUT_24_BB_29_5[] = {
+    0x80, 0x08, 0x00, 0x00, 0x00, 0x02, 0x90, 0x28, 0x28, 0x00, 0x00, 0x01, 0x80, 0x14,
+    0x00, 0x00, 0x00, 0x01, 0x50, 0x12, 0x12, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+};
+
+// partial screen update LUT
+static const uint8_t LUT_20_VCOMDC_PARTIAL_29_5[] = {
+    0x00, 0x20, 0x01, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+};
+
+static const uint8_t LUT_21_WW_PARTIAL_29_5[] = {
+    0x00, 0x20, 0x01, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+};
+
+static const uint8_t LUT_22_BW_PARTIAL_29_5[] = {
+    0x80, 0x20, 0x01, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+};
+
+static const uint8_t LUT_23_WB_PARTIAL_29_5[] = {
+    0x40, 0x20, 0x01, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+};
+
+static const uint8_t LUT_24_BB_PARTIAL_29_5[] = {
+    0x00, 0x20, 0x01, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+};
+
+void GDEW029T5::power_on_() {
+  if (!this->power_is_on_) {
+    this->command(0x04);
+    this->wait_until_idle_();
+  }
+  this->power_is_on_ = true;
+}
+
+void GDEW029T5::power_off_() {
+  this->command(0x02);
+  this->wait_until_idle_();
+  this->power_is_on_ = false;
+}
+
+void GDEW029T5::deep_sleep() {
+  this->power_off_();
+  if (this->deep_sleep_between_updates_) {
+    this->command(0x07);  // deep sleep
+    this->data(0xA5);     // check code
+    ESP_LOGD(TAG, "go to deep sleep");
+    this->is_deep_sleep_ = true;
+  }
+}
+
+void GDEW029T5::init_display_() {
+  // from https://github.com/ZinggJM/GxEPD2/blob/master/src/epd/GxEPD2_290_T5.cpp
+
+  // Hardware Initialization
+  if (this->deep_sleep_between_updates_ && this->is_deep_sleep_) {
+    ESP_LOGI(TAG, "wake up from deep sleep");
+    this->reset_();
+    this->is_deep_sleep_ = false;
+  }
+
+  // COMMAND POWER SETTINGS
+  this->command(0x01);
+  this->data(0x03);
+  this->data(0x00);
+  this->data(0x2b);
+  this->data(0x2b);
+  this->data(0x03); /* for b/w */
+
+  // COMMAND BOOSTER SOFT START
+  this->command(0x06);
+  this->data(0x17);
+  this->data(0x17);
+  this->data(0x17);
+
+  this->power_on_();
+
+  // COMMAND PANEL SETTING
+  this->command(0x00);
+  // 128x296 resolution:        10
+  // LUT from register:         1
+  // B/W mode (doesn't work):   1
+  // scan-up:                   1
+  // shift-right:               1
+  // booster ON:                1
+  // no soft reset:             1
+  this->data(0b10111111);
+  this->data(0x0d);     // VCOM to 0V fast
+  this->command(0x30);  // PLL setting
+  this->data(0x3a);     // 3a 100HZ   29 150Hz 39 200HZ 31 171HZ
+  this->command(0x61);  // resolution setting
+  this->data(this->get_width_internal());
+  this->data(this->get_height_internal() >> 8);
+  this->data(this->get_height_internal() & 0xFF);
+
+  ESP_LOGD(TAG, "panel setting done");
+}
+
+void GDEW029T5::initialize() {
+  // from https://www..com/w/upload/b/bb/2.9inch-e-paper-b-specification.pdf, page 37
+  if (this->reset_pin_ != nullptr)
+    this->deep_sleep_between_updates_ = true;
+
+  // old buffer for partial update
+  ExternalRAMAllocator<uint8_t> allocator(ExternalRAMAllocator<uint8_t>::ALLOW_FAILURE);
+  this->old_buffer_ = allocator.allocate(this->get_buffer_length_());
+  if (this->old_buffer_ == nullptr) {
+    ESP_LOGE(TAG, "Could not allocate old buffer for display!");
+    return;
+  }
+  for (size_t i = 0; i < this->get_buffer_length_(); i++) {
+    this->old_buffer_[i] = 0xFF;
+  }
+}
+
+// initialize for full(normal) update
+void GDEW029T5::init_full_() {
+  this->init_display_();
+  this->command(0x82);  // vcom_DC setting
+  this->data(0x08);
+  this->command(0X50);  // VCOM AND DATA INTERVAL SETTING
+  this->data(0x97);     // WBmode:VBDF 17|D7 VBDW 97 VBDB 57   WBRmode:VBDF F7 VBDW 77 VBDB 37  VBDR B7
+  this->command(0x20);
+  this->write_lut_(LUT_20_VCOMDC_29_5, sizeof(LUT_20_VCOMDC_29_5));
+  this->command(0x21);
+  this->write_lut_(LUT_21_WW_29_5, sizeof(LUT_21_WW_29_5));
+  this->command(0x22);
+  this->write_lut_(LUT_22_BW_29_5, sizeof(LUT_22_BW_29_5));
+  this->command(0x23);
+  this->write_lut_(LUT_23_WB_29_5, sizeof(LUT_23_WB_29_5));
+  this->command(0x24);
+  this->write_lut_(LUT_24_BB_29_5, sizeof(LUT_24_BB_29_5));
+  ESP_LOGD(TAG, "initialized full update");
+}
+
+// initialzie for partial update
+void GDEW029T5::init_partial_() {
+  this->init_display_();
+  this->command(0x82);  // vcom_DC setting
+  this->data(0x08);
+  this->command(0X50);  // VCOM AND DATA INTERVAL SETTING
+  this->data(0x17);     // WBmode:VBDF 17|D7 VBDW 97 VBDB 57   WBRmode:VBDF F7 VBDW 77 VBDB 37  VBDR B7
+  this->command(0x20);
+  this->write_lut_(LUT_20_VCOMDC_PARTIAL_29_5, sizeof(LUT_20_VCOMDC_PARTIAL_29_5));
+  this->command(0x21);
+  this->write_lut_(LUT_21_WW_PARTIAL_29_5, sizeof(LUT_21_WW_PARTIAL_29_5));
+  this->command(0x22);
+  this->write_lut_(LUT_22_BW_PARTIAL_29_5, sizeof(LUT_22_BW_PARTIAL_29_5));
+  this->command(0x23);
+  this->write_lut_(LUT_23_WB_PARTIAL_29_5, sizeof(LUT_23_WB_PARTIAL_29_5));
+  this->command(0x24);
+  this->write_lut_(LUT_24_BB_PARTIAL_29_5, sizeof(LUT_24_BB_PARTIAL_29_5));
+  ESP_LOGD(TAG, "initialized partial update");
+}
+
+void HOT GDEW029T5::display() {
+  bool full_update = this->at_update_ == 0;
+  if (full_update) {
+    this->init_full_();
+  } else {
+    this->init_partial_();
+    this->command(0x91);  // partial in
+    // set partial window
+    this->command(0x90);
+    // this->data(0);
+    this->data(0);
+    // this->data(0);
+    this->data((this->get_width_internal() - 1) % 256);
+    this->data(0);
+    this->data(0);
+    this->data(((this->get_height_internal() - 1)) / 256);
+    this->data(((this->get_height_internal() - 1)) % 256);
+    this->data(0x01);
+  }
+  // input old buffer data
+  this->command(0x10);
+  delay(2);
+  this->start_data_();
+  for (size_t i = 0; i < this->get_buffer_length_(); i++) {
+    this->write_byte(this->old_buffer_[i]);
+  }
+  this->end_data_();
+  delay(2);
+
+  // COMMAND DATA START TRANSMISSION 2 (B/W only)
+  this->command(0x13);
+  delay(2);
+  this->start_data_();
+  for (size_t i = 0; i < this->get_buffer_length_(); i++) {
+    this->write_byte(this->buffer_[i]);
+    this->old_buffer_[i] = this->buffer_[i];
+  }
+  this->end_data_();
+  delay(2);
+
+  // COMMAND DISPLAY REFRESH
+  this->command(0x12);
+  delay(2);
+  this->wait_until_idle_();
+
+  if (full_update) {
+    ESP_LOGD(TAG, "full update done");
+  } else {
+    this->command(0x92);  // partial out
+    ESP_LOGD(TAG, "partial update done");
+  }
+
+  this->at_update_ = (this->at_update_ + 1) % this->full_update_every_;
+  // COMMAND deep sleep
+  this->deep_sleep();
+}
+
+void GDEW029T5::write_lut_(const uint8_t *lut, const uint8_t size) {
+  // COMMAND WRITE LUT REGISTER
+  this->start_data_();
+  for (uint8_t i = 0; i < size; i++)
+    this->write_byte(lut[i]);
+  this->end_data_();
+}
+
+void GDEW029T5::set_full_update_every(uint32_t full_update_every) { this->full_update_every_ = full_update_every; }
+
+int GDEW029T5::get_width_internal() { return 128; }
+int GDEW029T5::get_height_internal() { return 296; }
+void GDEW029T5::dump_config() {
+  LOG_DISPLAY("", " E-Paper (Good Display)", this);
+  ESP_LOGCONFIG(TAG, "  Model: 2.9in Greyscale GDEW029T5");
+  LOG_PIN("  Reset Pin: ", this->reset_pin_);
+  LOG_PIN("  DC Pin: ", this->dc_pin_);
+  LOG_PIN("  Busy Pin: ", this->busy_pin_);
+  ESP_LOGCONFIG(TAG, "  Full Update Every: %" PRIu32, this->full_update_every_);
+  LOG_UPDATE_INTERVAL(this);
+}
+
+// ========================================================
+//     Good Display 1.54in black/white/grey GDEW0154M09
+// As used in M5Stack Core Ink
+// Datasheet:
+//  - https://v4.cecdn.yun300.cn/100001_1909185148/GDEW0154M09-200709.pdf
+//  - https://github.com/m5stack/M5Core-Ink
+// Reference code from GoodDisplay:
+//  - https://github.com/GoodDisplay/E-paper-Display-Library-of-GoodDisplay/
+//  -> /Monochrome_E-paper-Display/1.54inch_JD79653_GDEW0154M09_200x200/ESP32-Arduino%20IDE/GDEW0154M09_Arduino.ino
+// M5Stack Core Ink spec:
+//  - https://docs.m5stack.com/en/core/coreink
+// ========================================================
+
+void GDEW0154M09::initialize() {
+  this->init_internal_();
+  ExternalRAMAllocator<uint8_t> allocator(ExternalRAMAllocator<uint8_t>::ALLOW_FAILURE);
+  this->lastbuff_ = allocator.allocate(this->get_buffer_length_());
+  if (this->lastbuff_ != nullptr) {
+    memset(this->lastbuff_, 0xff, sizeof(uint8_t) * this->get_buffer_length_());
+  }
+  this->clear_();
+}
+
+void GDEW0154M09::reset_() {
+  // RST is inverse from other einks in this project
+  if (this->reset_pin_ != nullptr) {
+    this->reset_pin_->digital_write(false);
+    delay(10);
+    this->reset_pin_->digital_write(true);
+    delay(10);
+  }
+}
+
+void GDEW0154M09::init_internal_() {
+  this->reset_();
+
+  // clang-format off
+  // 200x200 resolution:        11
+  // LUT from OTP:              0
+  // B/W mode (doesn't work):   1
+  // scan-up:                   1
+  // shift-right:               1
+  // booster ON:                1
+  // no soft reset:             1
+  const uint8_t panel_setting_1 = 0b11011111;
+
+  // VCOM status off            0
+  // Temp sensing default       1
+  // VGL Power Off Floating     1
+  // NORG expect refresh        1
+  // VCOM Off on displ off      0
+  const uint8_t panel_setting_2 = 0b01110;
+
+  const uint8_t wf_t0154_cz_b3_list[] = {
+      11, //  11 commands in list
+      CMD_PSR_PANEL_SETTING, 2, panel_setting_1, panel_setting_2,
+      CMD_UNDOCUMENTED_0x4D, 1, 0x55,
+      CMD_UNDOCUMENTED_0xAA, 1, 0x0f,
+      CMD_UNDOCUMENTED_0xE9, 1, 0x02,
+      CMD_UNDOCUMENTED_0xB6, 1, 0x11,
+      CMD_UNDOCUMENTED_0xF3, 1, 0x0a,
+      CMD_TRES_RESOLUTION_SETTING, 3, 0xc8, 0x00, 0xc8,
+      CMD_TCON_TCONSETTING, 1, 0x00,
+      CMD_CDI_VCOM_DATA_INTERVAL, 1, 0xd7,
+      CMD_PWS_POWER_SAVING, 1, 0x00,
+      CMD_PON_POWER_ON, 0
+  };
+  // clang-format on
+
+  this->write_init_list_(wf_t0154_cz_b3_list);
+  delay(100);  // NOLINT
+  this->wait_until_idle_();
+}
+
+void GDEW0154M09::write_init_list_(const uint8_t *list) {
+  uint8_t list_limit = list[0];
+  uint8_t *start_ptr = ((uint8_t *) list + 1);
+  for (uint8_t i = 0; i < list_limit; i++) {
+    this->command(*(start_ptr + 0));
+    for (uint8_t dnum = 0; dnum < *(start_ptr + 1); dnum++) {
+      this->data(*(start_ptr + 2 + dnum));
+    }
+    start_ptr += (*(start_ptr + 1) + 2);
+  }
+}
+
+void GDEW0154M09::clear_() {
+  uint32_t pixsize = this->get_buffer_length_();
+  for (uint8_t j = 0; j < 2; j++) {
+    this->command(CMD_DTM1_DATA_START_TRANS);
+    for (int count = 0; count < pixsize; count++) {
+      this->data(0x00);
+    }
+    this->command(CMD_DTM2_DATA_START_TRANS2);
+    for (int count = 0; count < pixsize; count++) {
+      this->data(0xff);
+    }
+    this->command(CMD_DISPLAY_REFRESH);
+    delay(10);
+    this->wait_until_idle_();
+  }
+}
+
+void HOT GDEW0154M09::display() {
+  this->init_internal_();
+  // "Mode 0 display" for now
+  this->command(CMD_DTM1_DATA_START_TRANS);
+  for (int i = 0; i < this->get_buffer_length_(); i++) {
+    this->data(0xff);
+  }
+  this->command(CMD_DTM2_DATA_START_TRANS2);  // write 'new' data to SRAM
+  for (int i = 0; i < this->get_buffer_length_(); i++) {
+    this->data(this->buffer_[i]);
+  }
+  this->command(CMD_DISPLAY_REFRESH);
+  delay(10);
+  this->wait_until_idle_();
+  this->deep_sleep();
+}
+
+void GDEW0154M09::deep_sleep() {
+  // COMMAND DEEP SLEEP
+  this->command(CMD_POF_POWER_OFF);
+  this->wait_until_idle_();
+  delay(1000);  // NOLINT
+  this->command(CMD_DSLP_DEEP_SLEEP);
+  this->data(DATA_DSLP_DEEP_SLEEP);
+}
+
+int GDEW0154M09::get_width_internal() { return 200; }
+int GDEW0154M09::get_height_internal() { return 200; }
+void GDEW0154M09::dump_config() {
+  LOG_DISPLAY("", "M5Stack CoreInk E-Paper (Good Display)", this);
+  ESP_LOGCONFIG(TAG, "  Model: 1.54in Greyscale GDEW0154M09");
+  LOG_PIN("  Reset Pin: ", this->reset_pin_);
+  LOG_PIN("  DC Pin: ", this->dc_pin_);
+  LOG_PIN("  Busy Pin: ", this->busy_pin_);
+  LOG_UPDATE_INTERVAL(this);
+}
+
+// ========================================================
+//     Good Display 4.2in black/white GDEY042T81 (SSD1683)
+// Product page:
+//  - https://www.good-display.com/product/386.html
+// Datasheet:
+//  - https://v4.cecdn.yun300.cn/100001_1909185148/GDEY042T81.pdf
+//  - https://v4.cecdn.yun300.cn/100001_1909185148/SSD1683.PDF
+// Reference code from GoodDisplay:
+//  - https://www.good-display.com/companyfile/1572.html (2024-08-01 15:40:41)
+// Other reference code:
+//  - https://github.com/ZinggJM/GxEPD2/blob/03d8e7a533c1493f762e392ead12f1bcb7fab8f9/src/gdey/GxEPD2_420_GDEY042T81.cpp
+// ========================================================
+
+void GDEY042T81::initialize() {
+  this->init_display_();
+  ESP_LOGD(TAG, "Initialization complete, set the display to deep sleep");
+  this->deep_sleep();
+}
+
+// conflicting documentation / examples regarding reset timings
+//   https://v4.cecdn.yun300.cn/100001_1909185148/SSD1683.PDF -> 10ms
+//   GD sample code (Display_EPD_W21.cpp, see above) -> 10 ms
+//   https://v4.cecdn.yun300.cn/100001_1909185148/GDEY042T81.pdf (section 14.2) -> 0.2ms (200us)
+//   https://github.com/ZinggJM/GxEPD2/blob/03d8e7a533c1493f762e392ead12f1bcb7fab8f9/src/gdey/GxEPD2_420_GDEY042T81.cpp#L351
+//   -> 10ms
+//  10 ms seems to work, so we use this
+GDEY042T81::GDEY042T81() { this->reset_duration_ = 10; }
+
+void GDEY042T81::reset_() {
+  if (this->reset_pin_ != nullptr) {
+    this->reset_pin_->digital_write(false);
+    delay(reset_duration_);  // NOLINT
+    this->reset_pin_->digital_write(true);
+    delay(reset_duration_);  // NOLINT
+  }
+}
+
+void GDEY042T81::init_display_() {
+  this->reset_();
+
+  this->wait_until_idle_();
+  this->command(0x12);  // SWRESET
+  this->wait_until_idle_();
+
+  // Specify number of lines for the driver: 300 (MUX 300)
+  // https://v4.cecdn.yun300.cn/100001_1909185148/SSD1683.PDF (section 8.1)
+  // https://github.com/ZinggJM/GxEPD2/blob/03d8e7a533c1493f762e392ead12f1bcb7fab8f9/src/gdey/GxEPD2_420_GDEY042T81.cpp#L354
+  this->command(0x01);  //  driver output control
+  this->data(0x2B);     // (height - 1) % 256
+  this->data(0x01);     // (height - 1) / 256
+  this->data(0x00);
+
+  // https://github.com/ZinggJM/GxEPD2/blob/03d8e7a533c1493f762e392ead12f1bcb7fab8f9/src/gdey/GxEPD2_420_GDEY042T81.cpp#L360
+  this->command(0x3C);  // BorderWaveform
+  this->data(0x01);
+  this->command(0x18);  // Read built-in temperature sensor
+  this->data(0x80);
+
+  // GD sample code (Display_EPD_W21.cpp@90ff)
+  this->command(0x11);  // data entry mode
+  this->data(0x03);
+  // set windows (0,0,400,300)
+  this->command(0x44);  // set Ram-X address start/end position
+  this->data(0);
+  this->data(0x31);  // (width / 8 -1)
+
+  this->command(0x45);  //  set Ram-y address start/end position
+  this->data(0);
+  this->data(0);
+  this->data(0x2B);  // (height - 1) % 256
+  this->data(0x01);  // (height - 1) / 256
+
+  // set cursor (0,0)
+  this->command(0x4E);  // set RAM x address count to 0;
+  this->data(0);
+  this->command(0x4F);  // set RAM y address count to 0;
+  this->data(0);
+  this->data(0);
+
+  this->wait_until_idle_();
+}
+
+// https://github.com/ZinggJM/GxEPD2/blob/03d8e7a533c1493f762e392ead12f1bcb7fab8f9/src/gdey/GxEPD2_420_GDEY042T81.cpp#L366
+void GDEY042T81::update_full_() {
+  this->command(0x21);  // display update control
+  this->data(0x40);     // bypass RED as 0
+  this->data(0x00);     // single chip application
+
+  // only ever do a fast update because slow updates are only relevant
+  // for lower operating temperatures
+  // see
+  // https://github.com/ZinggJM/GxEPD2/blob/03d8e7a533c1493f762e392ead12f1bcb7fab8f9/src/gdey/GxEPD2_290_GDEY029T94.h#L30
+  //
+  // Should slow/fast updates be made configurable similar to how GxEPD2 does it? No idea if anyone would need it...
+  this->command(0x1A);  // Write to temperature register
+  this->data(0x6E);
+  this->command(0x22);
+  this->data(0xd7);
+
+  this->command(0x20);
+  this->wait_until_idle_();
+}
+
+// https://github.com/ZinggJM/GxEPD2/blob/03d8e7a533c1493f762e392ead12f1bcb7fab8f9/src/gdey/GxEPD2_420_GDEY042T81.cpp#L389
+void GDEY042T81::update_part_() {
+  this->command(0x21);  // display update control
+  this->data(0x00);     // RED normal
+  this->data(0x00);     // single chip application
+
+  this->command(0x22);
+  this->data(0xfc);
+
+  this->command(0x20);
+  this->wait_until_idle_();
+}
+
+void HOT GDEY042T81::display() {
+  ESP_LOGD(TAG, "Wake up the display");
+  this->init_display_();
+
+  if (!this->wait_until_idle_()) {
+    this->status_set_warning();
+    ESP_LOGE(TAG, "Failed to perform update, display is busy");
+    return;
+  }
+
+  // basic code structure copied from EPaper2P9InV2R2
+  if (this->full_update_every_ == 1) {
+    ESP_LOGD(TAG, "Full update");
+    // do single full update
+    this->command(0x24);
+    this->start_data_();
+    this->write_array(this->buffer_, this->get_buffer_length_());
+    this->end_data_();
+
+    // TurnOnDisplay
+    this->update_full_();
+    return;
+  }
+
+  // if (this->full_update_every_ == 1 ||
+  if (this->at_update_ == 0) {
+    ESP_LOGD(TAG, "Update");
+    // do base update
+    this->command(0x24);
+    this->start_data_();
+    this->write_array(this->buffer_, this->get_buffer_length_());
+    this->end_data_();
+
+    this->command(0x26);
+    this->start_data_();
+    this->write_array(this->buffer_, this->get_buffer_length_());
+    this->end_data_();
+
+    // TurnOnDisplay;
+    this->update_full_();
+  } else {
+    // do partial update (full screen)
+    // no need to load a LUT for GoodDisplays as they seem to have the LUT onboard
+    // GD example code (Display_EPD_W21.cpp@283ff)
+    //
+    // not setting the BorderWaveform here again (contrary to the GD example) because according to
+    // https://github.com/ZinggJM/GxEPD2/blob/03d8e7a533c1493f762e392ead12f1bcb7fab8f9/src/gdey/GxEPD2_420_GDEY042T81.cpp#L358
+    // it seems to be enough to set it during display initialization
+    ESP_LOGD(TAG, "Partial update");
+    this->reset_();
+    if (!this->wait_until_idle_()) {
+      this->status_set_warning();
+      ESP_LOGE(TAG, "Failed to perform partial update, display is busy");
+      return;
+    }
+
+    this->command(0x24);
+    this->start_data_();
+    this->write_array(this->buffer_, this->get_buffer_length_());
+    this->end_data_();
+
+    // TurnOnDisplay
+    this->update_part_();
+  }
+
+  this->at_update_ = (this->at_update_ + 1) % this->full_update_every_;
+  this->wait_until_idle_();
+  ESP_LOGD(TAG, "Set the display back to deep sleep");
+  this->deep_sleep();
+}
+void GDEY042T81::set_full_update_every(uint32_t full_update_every) { this->full_update_every_ = full_update_every; }
+int GDEY042T81::get_width_internal() { return 400; }
+int GDEY042T81::get_height_internal() { return 300; }
+uint32_t GDEY042T81::idle_timeout_() { return 5000; }
+void GDEY042T81::dump_config() {
+  LOG_DISPLAY("", "GoodDisplay E-Paper", this);
+  ESP_LOGCONFIG(TAG, "  Model: 4.2in B/W GDEY042T81");
+  ESP_LOGCONFIG(TAG, "  Full Update Every: %" PRIu32, this->full_update_every_);
+  LOG_PIN("  Reset Pin: ", this->reset_pin_);
+  LOG_PIN("  DC Pin: ", this->dc_pin_);
+  LOG_PIN("  Busy Pin: ", this->busy_pin_);
+  LOG_UPDATE_INTERVAL(this);
+}
+
+static const uint8_t LUT_VCOM_DC_4_2[] = {
+    0x00, 0x17, 0x00, 0x00, 0x00, 0x02, 0x00, 0x17, 0x17, 0x00, 0x00, 0x02, 0x00, 0x0A, 0x01,
+    0x00, 0x00, 0x01, 0x00, 0x0E, 0x0E, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+};
+static const uint8_t LUT_WHITE_TO_WHITE_4_2[] = {
+    0x40, 0x17, 0x00, 0x00, 0x00, 0x02, 0x90, 0x17, 0x17, 0x00, 0x00, 0x02, 0x40, 0x0A,
+    0x01, 0x00, 0x00, 0x01, 0xA0, 0x0E, 0x0E, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+};
+static const uint8_t LUT_BLACK_TO_WHITE_4_2[] = {
+    0x40, 0x17, 0x00, 0x00, 0x00, 0x02, 0x90, 0x17, 0x17, 0x00, 0x00, 0x02, 0x40, 0x0A,
+    0x01, 0x00, 0x00, 0x01, 0xA0, 0x0E, 0x0E, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+};
+
+static const uint8_t LUT_BLACK_TO_BLACK_4_2[] = {
+    0x80, 0x17, 0x00, 0x00, 0x00, 0x02, 0x90, 0x17, 0x17, 0x00, 0x00, 0x02, 0x80, 0x0A,
+    0x01, 0x00, 0x00, 0x01, 0x50, 0x0E, 0x0E, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+};
+
+static const uint8_t LUT_WHITE_TO_BLACK_4_2[] = {
+    0x80, 0x17, 0x00, 0x00, 0x00, 0x02, 0x90, 0x17, 0x17, 0x00, 0x00, 0x02, 0x80, 0x0A,
+    0x01, 0x00, 0x00, 0x01, 0x50, 0x0E, 0x0E, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+};
+
+void EPaper4P2In::initialize() {
+  // https://www..com/w/upload/7/7f/4.2inch-e-paper-b-specification.pdf - page 8
+
+  // COMMAND POWER SETTING
+  this->command(0x01);
+  this->data(0x03);  // VDS_EN, VDG_EN
+  this->data(0x00);  // VCOM_HV, VGHL_LV[1], VGHL_LV[0]
+  this->data(0x2B);  // VDH
+  this->data(0x2B);  // VDL
+  this->data(0xFF);  // VDHR
+
+  // COMMAND BOOSTER SOFT START
+  this->command(0x06);
+  this->data(0x17);  // PHA
+  this->data(0x17);  // PHB
+  this->data(0x17);  // PHC
+
+  // COMMAND POWER ON
+  this->command(0x04);
+  this->wait_until_idle_();
+  delay(10);
+  // COMMAND PANEL SETTING
+  this->command(0x00);
+  this->data(0xBF);  // KW-BF   KWR-AF  BWROTP 0f
+  this->data(0x0B);
+  // COMMAND PLL CONTROL
+  this->command(0x30);
+  this->data(0x3C);  // 3A 100HZ   29 150Hz 39 200HZ  31 171HZ
+
+  delay(2);
+  // COMMAND LUT FOR VCOM
+  this->command(0x20);
+  for (uint8_t i : LUT_VCOM_DC_4_2)
+    this->data(i);
+  // COMMAND LUT WHITE TO WHITE
+  this->command(0x21);
+  for (uint8_t i : LUT_WHITE_TO_WHITE_4_2)
+    this->data(i);
+  // COMMAND LUT BLACK TO WHITE
+  this->command(0x22);
+  for (uint8_t i : LUT_BLACK_TO_WHITE_4_2)
+    this->data(i);
+  // COMMAND LUT WHITE TO BLACK
+  this->command(0x23);
+  for (uint8_t i : LUT_WHITE_TO_BLACK_4_2)
+    this->data(i);
+  // COMMAND LUT BLACK TO BLACK
+  this->command(0x24);
+  for (uint8_t i : LUT_BLACK_TO_BLACK_4_2)
+    this->data(i);
+}
+void HOT EPaper4P2In::display() {
+  // COMMAND RESOLUTION SETTING
+  this->command(0x61);
+  this->data(0x01);
+  this->data(0x90);
+  this->data(0x01);
+  this->data(0x2C);
+
+  // COMMAND VCM DC SETTING REGISTER
+  this->command(0x82);
+  this->data(0x12);
+
+  // COMMAND VCOM AND DATA INTERVAL SETTING
+  this->command(0x50);
+  this->data(0x97);
+
+  // COMMAND DATA START TRANSMISSION 1
+  this->command(0x10);
+  delay(2);
+  this->start_data_();
+  this->write_array(this->buffer_, this->get_buffer_length_());
+  this->end_data_();
+  delay(2);
+  // COMMAND DATA START TRANSMISSION 2
+  this->command(0x13);
+  delay(2);
+  this->start_data_();
+  this->write_array(this->buffer_, this->get_buffer_length_());
+  this->end_data_();
+  // COMMAND DISPLAY REFRESH
+  this->command(0x12);
+}
+int EPaper4P2In::get_width_internal() { return 400; }
+int EPaper4P2In::get_height_internal() { return 300; }
+void EPaper4P2In::dump_config() {
+  LOG_DISPLAY("", " E-Paper", this);
+  ESP_LOGCONFIG(TAG, "  Model: 4.2in");
+  LOG_PIN("  Reset Pin: ", this->reset_pin_);
+  LOG_PIN("  DC Pin: ", this->dc_pin_);
+  LOG_PIN("  Busy Pin: ", this->busy_pin_);
+  LOG_UPDATE_INTERVAL(this);
+}
+
+// ========================================================
+//               4.20in Type B (LUT from OTP)
+// Datasheet:
+//  - https://www..com/w/upload/2/20/4.2inch-e-paper-module-user-manual-en.pdf
+//  - https://github.com//e-Paper/blob/master/RaspberryPi_JetsonNano/c/lib/e-Paper/EPD_4in2b_V2.c
+// ========================================================
+void EPaper4P2InBV2::initialize() {
+  // these exact timings are required for a proper reset/init
+  this->reset_pin_->digital_write(false);
+  delay(2);
+  this->reset_pin_->digital_write(true);
+  delay(200);  // NOLINT
+
+  // COMMAND POWER ON
+  this->command(0x04);
+  this->wait_until_idle_();
+
+  // COMMAND PANEL SETTING
+  this->command(0x00);
+  this->data(0x0f);  // LUT from OTP
+}
+
+void HOT EPaper4P2InBV2::display() {
+  // COMMAND DATA START TRANSMISSION 1 (B/W data)
+  this->command(0x10);
+  this->start_data_();
+  this->write_array(this->buffer_, this->get_buffer_length_());
+  this->end_data_();
+
+  // COMMAND DATA START TRANSMISSION 2 (RED data)
+  this->command(0x13);
+  this->start_data_();
+  for (size_t i = 0; i < this->get_buffer_length_(); i++)
+    this->write_byte(0xFF);
+  this->end_data_();
+  delay(2);
+
+  // COMMAND DISPLAY REFRESH
+  this->command(0x12);
+  this->wait_until_idle_();
+
+  // COMMAND POWER OFF
+  // NOTE: power off < deep sleep
+  this->command(0x02);
+}
+int EPaper4P2InBV2::get_width_internal() { return 400; }
+int EPaper4P2InBV2::get_height_internal() { return 300; }
+void EPaper4P2InBV2::dump_config() {
+  LOG_DISPLAY("", " E-Paper", this);
+  ESP_LOGCONFIG(TAG, "  Model: 4.2in (B V2)");
+  LOG_PIN("  Reset Pin: ", this->reset_pin_);
+  LOG_PIN("  DC Pin: ", this->dc_pin_);
+  LOG_PIN("  Busy Pin: ", this->busy_pin_);
+  LOG_UPDATE_INTERVAL(this);
+}
+
+// ========================================================
+//    4.20in Type B With Red colour support (LUT from OTP)
+// Datasheet:
+//  - https://www..com/w/upload/2/20/4.2inch-e-paper-module-user-manual-en.pdf
+//  - https://github.com//e-Paper/blob/master/RaspberryPi_JetsonNano/c/lib/e-Paper/EPD_4in2b_V2.c
+// The implementation is an adaptation of EPaper4P2InBV2 class
+// ========================================================
+void EPaper4P2InBV2BWR::initialize() {
+  // these exact timings are required for a proper reset/init
+  this->reset_pin_->digital_write(false);
+  delay(2);
+  this->reset_pin_->digital_write(true);
+  delay(200);  // NOLINT
+
+  // COMMAND POWER ON
+  this->command(0x04);
+  this->wait_until_idle_();
+
+  // COMMAND PANEL SETTING
+  this->command(0x00);
+  this->data(0x0f);  // LUT from OTP
+}
+
+void HOT EPaper4P2InBV2BWR::display() {
+  const uint32_t buf_len = this->get_buffer_length_() / 2u;
+
+  this->command(0x10);  // Send BW data Transmission
+  delay(2);             // Delay to prevent Watchdog error
+  for (uint32_t i = 0; i < buf_len; ++i) {
+    this->data(this->buffer_[i]);
+  }
+
+  this->command(0x13);  // Send red data Transmission
+  delay(2);             // Delay to prevent Watchdog error
+  for (uint32_t i = 0; i < buf_len; ++i) {
+    // Red color need to flip bit from the buffer. Otherwise, red will conqure the screen!
+    this->data(~this->buffer_[buf_len + i]);
+  }
+
+  // COMMAND DISPLAY REFRESH
+  this->command(0x12);
+  this->wait_until_idle_();
+
+  // COMMAND POWER OFF
+  // NOTE: power off < deep sleep
+  this->command(0x02);
+}
+int EPaper4P2InBV2BWR::get_width_internal() { return 400; }
+int EPaper4P2InBV2BWR::get_height_internal() { return 300; }
+void EPaper4P2InBV2BWR::dump_config() {
+  LOG_DISPLAY("", " E-Paper", this);
+  ESP_LOGCONFIG(TAG, "  Model: 4.2in (B V2) BWR-Mode");
+  LOG_PIN("  Reset Pin: ", this->reset_pin_);
+  LOG_PIN("  DC Pin: ", this->dc_pin_);
+  LOG_PIN("  Busy Pin: ", this->busy_pin_);
+  LOG_UPDATE_INTERVAL(this);
+}
+
+void EPaper5P8In::initialize() {
+  // COMMAND POWER SETTING
+  this->command(0x01);
+  this->data(0x37);
+  this->data(0x00);
+
+  // COMMAND PANEL SETTING
+  this->command(0x00);
+  this->data(0xCF);
+  this->data(0x0B);
+
+  // COMMAND BOOSTER SOFT START
+  this->command(0x06);
+  this->data(0xC7);
+  this->data(0xCC);
+  this->data(0x28);
+
+  // COMMAND POWER ON
+  this->command(0x04);
+  this->wait_until_idle_();
+  delay(10);
+
+  // COMMAND PLL CONTROL
+  this->command(0x30);
+  this->data(0x3C);
+
+  // COMMAND TEMPERATURE SENSOR CALIBRATION
+  this->command(0x41);
+  this->data(0x00);
+
+  // COMMAND VCOM AND DATA INTERVAL SETTING
+  this->command(0x50);
+  this->data(0x77);
+
+  // COMMAND TCON SETTING
+  this->command(0x60);
+  this->data(0x22);
+
+  // COMMAND RESOLUTION SETTING
+  this->command(0x61);
+  this->data(0x02);
+  this->data(0x58);
+  this->data(0x01);
+  this->data(0xC0);
+
+  // COMMAND VCM DC SETTING REGISTER
+  this->command(0x82);
+  this->data(0x1E);
+
+  this->command(0xE5);
+  this->data(0x03);
+}
+void HOT EPaper5P8In::display() {
+  // COMMAND DATA START TRANSMISSION 1
+  this->command(0x10);
+
+  this->start_data_();
+  for (size_t i = 0; i < this->get_buffer_length_(); i++) {
+    uint8_t temp1 = this->buffer_[i];
+    for (uint8_t j = 0; j < 8; j++) {
+      uint8_t temp2;
+      if (temp1 & 0x80) {
+        temp2 = 0x03;
+      } else {
+        temp2 = 0x00;
+      }
+
+      temp2 <<= 4;
+      temp1 <<= 1;
+      j++;
+      if (temp1 & 0x80) {
+        temp2 |= 0x03;
+      } else {
+        temp2 |= 0x00;
+      }
+      temp1 <<= 1;
+      this->write_byte(temp2);
+    }
+
+    App.feed_wdt();
+  }
+  this->end_data_();
+
+  // COMMAND DISPLAY REFRESH
+  this->command(0x12);
+}
+int EPaper5P8In::get_width_internal() { return 600; }
+int EPaper5P8In::get_height_internal() { return 448; }
+void EPaper5P8In::dump_config() {
+  LOG_DISPLAY("", " E-Paper", this);
+  ESP_LOGCONFIG(TAG, "  Model: 5.83in");
+  LOG_PIN("  Reset Pin: ", this->reset_pin_);
+  LOG_PIN("  DC Pin: ", this->dc_pin_);
+  LOG_PIN("  Busy Pin: ", this->busy_pin_);
+  LOG_UPDATE_INTERVAL(this);
+}
+
+// ========================================================
+//               5.83in V2
+// Datasheet/Specification/Reference:
+//  - https://www..com/w/upload/3/37/5.83inch_e-Paper_V2_Specification.pdf
+//  - https://github.com//e-Paper/blob/master/Arduino/epd5in83_V2/epd5in83_V2.cpp
+// ========================================================
+void EPaper5P8InV2::initialize() {
+  // COMMAND POWER SETTING
+  this->command(0x01);
+  this->data(0x07);
+  this->data(0x07);
+  this->data(0x3f);
+  this->data(0x3f);
+
+  // COMMAND POWER ON
+  this->command(0x04);
+  delay(10);
+  this->wait_until_idle_();
+
+  // PANNEL SETTING
+  this->command(0x00);
+  this->data(0x1F);
+
+  // COMMAND RESOLUTION SETTING
+  this->command(0x61);
+  this->data(0x02);
+  this->data(0x88);
+  this->data(0x01);
+  this->data(0xE0);
+
+  this->command(0x15);
+  this->data(0x00);
+
+  // COMMAND TCON SETTING
+  this->command(0x60);
+  this->data(0x22);
+
+  // Do we need this?
+  // COMMAND PLL CONTROL
+  this->command(0x30);
+  this->data(0x3C);  // 3A 100HZ   29 150Hz 39 200HZ  31 171HZ
+}
+void HOT EPaper5P8InV2::display() {
+  // Reuse the code from EPaper4P2In::display()
+  // COMMAND VCM DC SETTING REGISTER
+  this->command(0x82);
+  this->data(0x12);
+
+  // COMMAND VCOM AND DATA INTERVAL SETTING
+  this->command(0x50);
+  this->data(0x97);
+
+  // COMMAND DATA START TRANSMISSION 1
+  this->command(0x10);
+  delay(2);
+  this->start_data_();
+  this->write_array(this->buffer_, this->get_buffer_length_());
+  this->end_data_();
+  delay(2);
+
+  // COMMAND DATA START TRANSMISSION 2
+  this->command(0x13);
+  delay(2);
+  this->start_data_();
+  this->write_array(this->buffer_, this->get_buffer_length_());
+  this->end_data_();
+
+  // COMMAND DISPLAY REFRESH
+  this->command(0x12);
+}
+int EPaper5P8InV2::get_width_internal() { return 648; }
+int EPaper5P8InV2::get_height_internal() { return 480; }
+void EPaper5P8InV2::dump_config() {
+  LOG_DISPLAY("", " E-Paper", this);
+  ESP_LOGCONFIG(TAG, "  Model: 5.83inv2");
+  LOG_PIN("  Reset Pin: ", this->reset_pin_);
+  LOG_PIN("  DC Pin: ", this->dc_pin_);
+  LOG_PIN("  Busy Pin: ", this->busy_pin_);
+  LOG_UPDATE_INTERVAL(this);
+}
+
+void EPaper7P5InBV2::initialize() {
+  // COMMAND POWER SETTING
+  this->command(0x01);
+  this->data(0x07);
+  this->data(0x07);  // VGH=20V,VGL=-20V
+  this->data(0x3f);  // VDH=15V
+  this->data(0x3f);  // VDL=-15V
+  // COMMAND POWER ON
+  this->command(0x04);
+  delay(100);  // NOLINT
+  this->wait_until_idle_();
+  // COMMAND PANEL SETTING
+  this->command(0x00);
+  this->data(0x0F);     // KW3f, KWR-2F, BWROTP 0f, BWOTP 1f
+  this->command(0x61);  // tres
+  this->data(0x03);     // 800px
+  this->data(0x20);
+  this->data(0x01);  // 400px
+  this->data(0xE0);
+  this->command(0x15);
+  this->data(0x00);
+  // COMMAND VCOM AND DATA INTERVAL SETTING
+  this->command(0x50);
+  this->data(0x11);
+  this->data(0x07);
+  // COMMAND TCON SETTING
+  this->command(0x60);
+  this->data(0x22);
+
+  this->command(0x82);
+  this->data(0x08);
+  this->command(0x30);
+  this->data(0x06);
+
+  // COMMAND RESOLUTION SETTING
+  this->command(0x65);
+  this->data(0x00);
+  this->data(0x00);  // 800*480
+  this->data(0x00);
+  this->data(0x00);
+}
+void HOT EPaper7P5InBV2::display() {
+  // COMMAND DATA START TRANSMISSION 1 (B/W data)
+  this->command(0x10);
+  delay(2);
+  this->start_data_();
+  this->write_array(this->buffer_, this->get_buffer_length_());
+  this->end_data_();
+  delay(2);
+
+  // COMMAND DATA START TRANSMISSION 2 (RED data)
+  this->command(0x13);
+  delay(2);
+  this->start_data_();
+  for (size_t i = 0; i < this->get_buffer_length_(); i++)
+    this->write_byte(0x00);
+  this->end_data_();
+  delay(2);
+
+  // COMMAND DISPLAY REFRESH
+  this->command(0x12);
+  delay(100);  // NOLINT
+  this->wait_until_idle_();
+  this->deep_sleep();
+}
+int EPaper7P5InBV2::get_width_internal() { return 800; }
+int EPaper7P5InBV2::get_height_internal() { return 480; }
+void EPaper7P5InBV2::dump_config() {
+  LOG_DISPLAY("", " E-Paper", this);
+  ESP_LOGCONFIG(TAG, "  Model: 7.5in-bv2");
+  LOG_PIN("  Reset Pin: ", this->reset_pin_);
+  LOG_PIN("  DC Pin: ", this->dc_pin_);
+  LOG_PIN("  Busy Pin: ", this->busy_pin_);
+  LOG_UPDATE_INTERVAL(this);
+}
+
+void EPaper7P5InBV3::initialize() { this->init_display_(); }
+bool EPaper7P5InBV3::wait_until_idle_() {
+  if (this->busy_pin_ == nullptr) {
+    return true;
+  }
+
+  const uint32_t start = millis();
+  while (this->busy_pin_->digital_read()) {
+    this->command(0x71);
+    if (millis() - start > this->idle_timeout_()) {
+      ESP_LOGI(TAG, "Timeout while displaying image!");
+      return false;
+    }
+    App.feed_wdt();
+    delay(10);
+  }
+  delay(200);  // NOLINT
+  return true;
+};
+void EPaper7P5InBV3::init_display_() {
+  this->reset_();
+
+  // COMMAND POWER SETTING
+  this->command(0x01);
+
+  // 1-0=11: internal power
+  this->data(0x07);
+  this->data(0x17);  // VGH&VGL
+  this->data(0x3F);  // VSH
+  this->data(0x26);  // VSL
+  this->data(0x11);  // VSHR
+
+  // VCOM DC Setting
+  this->command(0x82);
+  this->data(0x24);  // VCOM
+
+  // Booster Setting
+  this->command(0x06);
+  this->data(0x27);
+  this->data(0x27);
+  this->data(0x2F);
+  this->data(0x17);
+
+  // POWER ON
+  this->command(0x04);
+
+  delay(100);  // NOLINT
+  this->wait_until_idle_();
+  // COMMAND PANEL SETTING
+  this->command(0x00);
+  this->data(0x3F);  // KW-3f   KWR-2F BWROTP 0f BWOTP 1f
+
+  // COMMAND RESOLUTION SETTING
+  this->command(0x61);
+  this->data(0x03);  // source 800
+  this->data(0x20);
+  this->data(0x01);  // gate 480
+  this->data(0xE0);
+  // COMMAND ...?
+  this->command(0x15);
+  this->data(0x00);
+  // COMMAND VCOM AND DATA INTERVAL SETTING
+  this->command(0x50);
+  this->data(0x10);
+  this->data(0x00);
+  // COMMAND TCON SETTING
+  this->command(0x60);
+  this->data(0x22);
+  // Resolution setting
+  this->command(0x65);
+  this->data(0x00);
+  this->data(0x00);  // 800*480
+  this->data(0x00);
+  this->data(0x00);
+
+  uint8_t lut_vcom_7_i_n5_v2[] = {
+      0x0, 0xF, 0xF, 0x0, 0x0, 0x1, 0x0, 0xF, 0x1, 0xF, 0x1, 0x2, 0x0, 0xF, 0xF, 0x0, 0x0, 0x1, 0x0, 0x0, 0x0,
+      0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+  };
+
+  uint8_t lut_ww_7_i_n5_v2[] = {
+      0x10, 0xF, 0xF, 0x0, 0x0, 0x1, 0x84, 0xF, 0x1, 0xF, 0x1, 0x2, 0x20, 0xF, 0xF, 0x0, 0x0, 0x1, 0x0, 0x0, 0x0,
+      0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+  };
+
+  uint8_t lut_bw_7_i_n5_v2[] = {
+      0x10, 0xF, 0xF, 0x0, 0x0, 0x1, 0x84, 0xF, 0x1, 0xF, 0x1, 0x2, 0x20, 0xF, 0xF, 0x0, 0x0, 0x1, 0x0, 0x0, 0x0,
+      0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+  };
+
+  uint8_t lut_wb_7_i_n5_v2[] = {
+      0x80, 0xF, 0xF, 0x0, 0x0, 0x3, 0x84, 0xF, 0x1, 0xF, 0x1, 0x4, 0x40, 0xF, 0xF, 0x0, 0x0, 0x3, 0x0, 0x0, 0x0,
+      0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+  };
+
+  uint8_t lut_bb_7_i_n5_v2[] = {
+      0x80, 0xF, 0xF, 0x0, 0x0, 0x1, 0x84, 0xF, 0x1, 0xF, 0x1, 0x2, 0x40, 0xF, 0xF, 0x0, 0x0, 0x1, 0x0, 0x0, 0x0,
+      0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+  };
+
+  uint8_t count;
+  this->command(0x20);  // VCOM
+  for (count = 0; count < 42; count++)
+    this->data(lut_vcom_7_i_n5_v2[count]);
+
+  this->command(0x21);  // LUTBW
+  for (count = 0; count < 42; count++)
+    this->data(lut_ww_7_i_n5_v2[count]);
+
+  this->command(0x22);  // LUTBW
+  for (count = 0; count < 42; count++)
+    this->data(lut_bw_7_i_n5_v2[count]);
+
+  this->command(0x23);  // LUTWB
+  for (count = 0; count < 42; count++)
+    this->data(lut_wb_7_i_n5_v2[count]);
+
+  this->command(0x24);  // LUTBB
+  for (count = 0; count < 42; count++)
+    this->data(lut_bb_7_i_n5_v2[count]);
+};
+void HOT EPaper7P5InBV3::display() {
+  this->init_display_();
+  uint32_t buf_len = this->get_buffer_length_();
+
+  this->command(0x10);
+  for (uint32_t i = 0; i < buf_len; i++) {
+    this->data(0xFF);
+  }
+
+  this->command(0x13);  // Start Transmission
+  delay(2);
+  for (uint32_t i = 0; i < buf_len; i++) {
+    this->data(~this->buffer_[i]);
+  }
+
+  this->command(0x12);  // Display Refresh
+  delay(100);           // NOLINT
+  this->wait_until_idle_();
+  this->deep_sleep();
+}
+int EPaper7P5InBV3::get_width_internal() { return 800; }
+int EPaper7P5InBV3::get_height_internal() { return 480; }
+void EPaper7P5InBV3::dump_config() {
+  LOG_DISPLAY("", " E-Paper", this);
+  ESP_LOGCONFIG(TAG, "  Model: 7.5in-bv3");
+  LOG_PIN("  Reset Pin: ", this->reset_pin_);
+  LOG_PIN("  DC Pin: ", this->dc_pin_);
+  LOG_PIN("  Busy Pin: ", this->busy_pin_);
+  LOG_UPDATE_INTERVAL(this);
+}
+
+void EPaper7P5InBV3BWR::initialize() { this->init_display_(); }
+bool EPaper7P5InBV3BWR::wait_until_idle_() {
+  if (this->busy_pin_ == nullptr) {
+    return true;
+  }
+
+  const uint32_t start = millis();
+  while (this->busy_pin_->digital_read()) {
+    this->command(0x71);
+    if (millis() - start > this->idle_timeout_()) {
+      ESP_LOGI(TAG, "Timeout while displaying image!");
+      return false;
+    }
+    App.feed_wdt();
+    delay(10);
+  }
+  delay(200);  // NOLINT
+  return true;
+};
+void EPaper7P5InBV3BWR::init_display_() {
+  this->reset_();
+
+  // COMMAND POWER SETTING
+  this->command(0x01);
+
+  // 1-0=11: internal power
+  this->data(0x07);  // VRS_EN=1, VS_EN=1, VG_EN=1
+  this->data(0x17);  // VGH&VGL ??? VCOM_SLEW=1 but this is fixed, VG_LVL[2:0]=111 => VGH=20V VGL=-20V, it could be 0x07
+  this->data(0x3F);  // VSH=15V?
+  this->data(0x26);  // VSL=-9.4V?
+  this->data(0x11);  // VSHR=5.8V?
+
+  // VCOM DC Setting
+  this->command(0x82);
+  this->data(0x24);  // VCOM=-1.9V
+
+  // POWER ON
+  this->command(0x04);
+  delay(100);  // NOLINT
+  this->wait_until_idle_();
+
+  // COMMAND PANEL SETTING
+  this->command(0x00);
+  this->data(0x0F);  // KW-3f   KWR-2F BWROTP 0f BWOTP 1f
+
+  // COMMAND RESOLUTION SETTING
+  this->command(0x61);
+  this->data(0x03);  // source 800
+  this->data(0x20);
+  this->data(0x01);  // gate 480
+  this->data(0xE0);
+
+  // COMMAND VCOM AND DATA INTERVAL SETTING
+  this->command(0x50);
+  this->data(0x20);
+  this->data(0x00);
+
+  // COMMAND TCON SETTING
+  this->command(0x60);
+  this->data(0x22);
+
+  // Resolution setting
+  this->command(0x65);
+  this->data(0x00);
+  this->data(0x00);  // 800*480
+  this->data(0x00);
+  this->data(0x00);
+};
+void HOT EPaper7P5InBV3BWR::display() {
+  this->init_display_();
+  const uint32_t buf_len = this->get_buffer_length_() / 2u;
+
+  this->command(0x10);  // Send BW data Transmission
+  delay(2);
+  for (uint32_t i = 0; i < buf_len; i++) {
+    this->data(this->buffer_[i]);
+  }
+
+  this->command(0x13);  // Send red data Transmission
+  delay(2);
+  for (uint32_t i = 0; i < buf_len; i++) {
+    this->data(this->buffer_[i + buf_len]);
+  }
+
+  this->command(0x12);  // Display Refresh
+  delay(100);           // NOLINT
+  this->wait_until_idle_();
+  this->deep_sleep();
+}
+int EPaper7P5InBV3BWR::get_width_internal() { return 800; }
+int EPaper7P5InBV3BWR::get_height_internal() { return 480; }
+void EPaper7P5InBV3BWR::dump_config() {
+  LOG_DISPLAY("", " E-Paper", this);
+  ESP_LOGCONFIG(TAG, "  Model: 7.5in-bv3 BWR-Mode");
+  LOG_PIN("  Reset Pin: ", this->reset_pin_);
+  LOG_PIN("  DC Pin: ", this->dc_pin_);
+  LOG_PIN("  Busy Pin: ", this->busy_pin_);
+  LOG_UPDATE_INTERVAL(this);
+}
+
+void EPaper7P5In::initialize() {
+  // COMMAND POWER SETTING
+  this->command(0x01);
+  this->data(0x37);
+  this->data(0x00);
+  // COMMAND PANEL SETTING
+  this->command(0x00);
+  this->data(0xCF);
+  this->data(0x0B);
+  // COMMAND BOOSTER SOFT START
+  this->command(0x06);
+  this->data(0xC7);
+  this->data(0xCC);
+  this->data(0x28);
+  // COMMAND POWER ON
+  this->command(0x04);
+  this->wait_until_idle_();
+  delay(10);
+  // COMMAND PLL CONTROL
+  this->command(0x30);
+  this->data(0x3C);
+  // COMMAND TEMPERATURE SENSOR CALIBRATION
+  this->command(0x41);
+  this->data(0x00);
+  // COMMAND VCOM AND DATA INTERVAL SETTING
+  this->command(0x50);
+  this->data(0x77);
+  // COMMAND TCON SETTING
+  this->command(0x60);
+  this->data(0x22);
+  // COMMAND RESOLUTION SETTING
+  this->command(0x61);
+  this->data(0x02);
+  this->data(0x80);
+  this->data(0x01);
+  this->data(0x80);
+  // COMMAND VCM DC SETTING REGISTER
+  this->command(0x82);
+  this->data(0x1E);
+  this->command(0xE5);
+  this->data(0x03);
+}
+void HOT EPaper7P5In::display() {
+  // COMMAND DATA START TRANSMISSION 1
+  this->command(0x10);
+  this->start_data_();
+  for (size_t i = 0; i < this->get_buffer_length_(); i++) {
+    uint8_t temp1 = this->buffer_[i];
+    for (uint8_t j = 0; j < 8; j++) {
+      uint8_t temp2;
+      if (temp1 & 0x80) {
+        temp2 = 0x03;
+      } else {
+        temp2 = 0x00;
+      }
+      temp2 <<= 4;
+      temp1 <<= 1;
+      j++;
+      if (temp1 & 0x80) {
+        temp2 |= 0x03;
+      } else {
+        temp2 |= 0x00;
+      }
+      temp1 <<= 1;
+      this->write_byte(temp2);
+    }
+    App.feed_wdt();
+  }
+  this->end_data_();
+  // COMMAND DISPLAY REFRESH
+  this->command(0x12);
+}
+int EPaper7P5In::get_width_internal() { return 640; }
+int EPaper7P5In::get_height_internal() { return 384; }
+void EPaper7P5In::dump_config() {
+  LOG_DISPLAY("", " E-Paper", this);
+  ESP_LOGCONFIG(TAG, "  Model: 7.5in");
+  LOG_PIN("  Reset Pin: ", this->reset_pin_);
+  LOG_PIN("  DC Pin: ", this->dc_pin_);
+  LOG_PIN("  Busy Pin: ", this->busy_pin_);
+  LOG_UPDATE_INTERVAL(this);
+}
+void EPaper7P3InF::initialize() {
+  if (this->buffers_[0] == nullptr) {
+    ESP_LOGE(TAG, "Buffer unavailable!");
+    return;
+  }
+
+  this->reset_();
+  delay(20);
+  this->wait_until_idle_();
+
+  // COMMAND CMDH
+  this->command(0xAA);
+  this->data(0x49);
+  this->data(0x55);
+  this->data(0x20);
+  this->data(0x08);
+  this->data(0x09);
+  this->data(0x18);
+
+  this->command(0x01);
+  this->data(0x3F);
+  this->data(0x00);
+  this->data(0x32);
+  this->data(0x2A);
+  this->data(0x0E);
+  this->data(0x2A);
+
+  this->command(0x00);
+  this->data(0x5F);
+  this->data(0x69);
+
+  this->command(0x03);
+  this->data(0x00);
+  this->data(0x54);
+  this->data(0x00);
+  this->data(0x44);
+
+  this->command(0x05);
+  this->data(0x40);
+  this->data(0x1F);
+  this->data(0x1F);
+  this->data(0x2C);
+
+  this->command(0x06);
+  this->data(0x6F);
+  this->data(0x1F);
+  this->data(0x1F);
+  this->data(0x22);
+
+  this->command(0x08);
+  this->data(0x6F);
+  this->data(0x1F);
+  this->data(0x1F);
+  this->data(0x22);
+
+  // COMMAND IPC
+  this->command(0x13);
+  this->data(0x00);
+  this->data(0x04);
+
+  this->command(0x30);
+  this->data(0x3C);
+
+  // COMMAND TSE
+  this->command(0x41);
+  this->data(0x00);
+
+  this->command(0x50);
+  this->data(0x3F);
+
+  this->command(0x60);
+  this->data(0x02);
+  this->data(0x00);
+
+  this->command(0x61);
+  this->data(0x03);
+  this->data(0x20);
+  this->data(0x01);
+  this->data(0xE0);
+
+  this->command(0x82);
+  this->data(0x1E);
+
+  this->command(0x84);
+  this->data(0x00);
+
+  // COMMAND AGID
+  this->command(0x86);
+  this->data(0x00);
+
+  this->command(0xE3);
+  this->data(0x2F);
+
+  // COMMAND CCSET
+  this->command(0xE0);
+  this->data(0x00);
+
+  // COMMAND TSSET
+  this->command(0xE6);
+  this->data(0x00);
+
+  ESP_LOGI(TAG, "Display initialized successfully");
+}
+void HOT EPaper7P3InF::display() {
+  if (this->buffers_[0] == nullptr) {
+    ESP_LOGE(TAG, "Buffer unavailable!");
+    return;
+  }
+
+  // INITIALIZATION
+  ESP_LOGI(TAG, "Initialise the display");
+  this->initialize();
+
+  // COMMAND DATA START TRANSMISSION
+  ESP_LOGI(TAG, "Sending data to the display");
+  this->command(0x10);
+  uint32_t small_buffer_length = this->get_buffer_length_() / NUM_BUFFERS;
+  uint8_t byte_to_send;
+  for (auto &buffer : this->buffers_) {
+    for (uint32_t buffer_pos = 0; buffer_pos < small_buffer_length; buffer_pos += 3) {
+      std::bitset<24> triplet =
+          buffer[buffer_pos + 0] << 16 | buffer[buffer_pos + 1] << 8 | buffer[buffer_pos + 2] << 0;
+      // 8 bitset<3> are stored in 3 bytes
+      // |aaabbbaa|abbbaaab|bbaaabbb|
+      // | byte 1 | byte 2 | byte 3 |
+      byte_to_send = ((triplet >> 17).to_ulong() & 0b01110000) | ((triplet >> 18).to_ulong() & 0b00000111);
+      this->data(byte_to_send);
+
+      byte_to_send = ((triplet >> 11).to_ulong() & 0b01110000) | ((triplet >> 12).to_ulong() & 0b00000111);
+      this->data(byte_to_send);
+
+      byte_to_send = ((triplet >> 5).to_ulong() & 0b01110000) | ((triplet >> 6).to_ulong() & 0b00000111);
+      this->data(byte_to_send);
+
+      byte_to_send = ((triplet << 1).to_ulong() & 0b01110000) | ((triplet << 0).to_ulong() & 0b00000111);
+      this->data(byte_to_send);
+    }
+    App.feed_wdt();
+  }
+
+  // COMMAND POWER ON
+  ESP_LOGI(TAG, "Power on the display");
+  this->command(0x04);
+  this->wait_until_idle_();
+
+  // COMMAND REFRESH SCREEN
+  ESP_LOGI(TAG, "Refresh the display");
+  this->command(0x12);
+  this->data(0x00);
+  this->wait_until_idle_();
+
+  // COMMAND POWER OFF
+  ESP_LOGI(TAG, "Power off the display");
+  this->command(0x02);
+  this->data(0x00);
+  this->wait_until_idle_();
+
+  ESP_LOGI(TAG, "Set the display to deep sleep");
+  this->command(0x07);
+  this->data(0xA5);
+}
+int EPaper7P3InF::get_width_internal() { return 800; }
+int EPaper7P3InF::get_height_internal() { return 480; }
+uint32_t EPaper7P3InF::idle_timeout_() { return 35000; }
+void EPaper7P3InF::dump_config() {
+  LOG_DISPLAY("", " E-Paper", this);
+  ESP_LOGCONFIG(TAG, "  Model: 7.3in-F");
+  LOG_PIN("  Reset Pin: ", this->reset_pin_);
+  LOG_PIN("  DC Pin: ", this->dc_pin_);
+  LOG_PIN("  Busy Pin: ", this->busy_pin_);
+  LOG_UPDATE_INTERVAL(this);
+}
+
+bool EPaper7P3InF::wait_until_idle_() {
+  if (this->busy_pin_ == nullptr) {
+    return true;
+  }
+  const uint32_t start = millis();
+  while (this->busy_pin_->digital_read()) {
+    if (millis() - start > this->idle_timeout_()) {
+      ESP_LOGE(TAG, "Timeout while displaying image!");
+      return false;
+    }
+    App.feed_wdt();
+    delay(10);
+  }
+  delay(200);  // NOLINT
+  return true;
+}
+bool EPaper7P5InV2::wait_until_idle_() {
+  if (this->busy_pin_ == nullptr) {
+    return true;
+  }
+
+  const uint32_t start = millis();
+  while (this->busy_pin_->digital_read()) {
+    this->command(0x71);
+    if (millis() - start > this->idle_timeout_()) {
+      ESP_LOGE(TAG, "Timeout while displaying image!");
+      return false;
+    }
+    App.feed_wdt();
+    delay(10);
+  }
+  return true;
+}
+void EPaper7P5InV2::initialize() {
+  // COMMAND POWER SETTING
+  this->command(0x01);
+  this->data(0x07);
+  this->data(0x07);
+  this->data(0x3f);
+  this->data(0x3f);
+
+  // We don't want the display to be powered at this point
+
+  delay(100);  // NOLINT
+  this->wait_until_idle_();
+
+  // COMMAND VCOM AND DATA INTERVAL SETTING
+  this->command(0x50);
+  this->data(0x10);
+  this->data(0x07);
+
+  // COMMAND TCON SETTING
+  this->command(0x60);
+  this->data(0x22);
+
+  // COMMAND PANEL SETTING
+  this->command(0x00);
+  this->data(0x1F);
+
+  // COMMAND RESOLUTION SETTING
+  this->command(0x61);
+  this->data(0x03);
+  this->data(0x20);
+  this->data(0x01);
+  this->data(0xE0);
+
+  // COMMAND DUAL SPI MM_EN, DUSPI_EN
+  this->command(0x15);
+  this->data(0x00);
+
+  // COMMAND POWER DRIVER HAT DOWN
+  // This command will turn off booster, controller, source driver, gate driver, VCOM, and
+  // temperature sensor, but register data will be kept until VDD turned OFF or Deep Sleep Mode.
+  // Source/Gate/Border/VCOM will be released to floating.
+  this->command(0x02);
+}
+void HOT EPaper7P5InV2::display() {
+  uint32_t buf_len = this->get_buffer_length_();
+
+  // COMMAND POWER ON
+  ESP_LOGI(TAG, "Power on the display and hat");
+
+  // This command will turn on booster, controller, regulators, and temperature sensor will be
+  // activated for one-time sensing before enabling booster. When all voltages are ready, the
+  // BUSY_N signal will return to high.
+  this->command(0x04);
+  delay(200);  // NOLINT
+  this->wait_until_idle_();
+
+  // COMMAND DATA START TRANSMISSION NEW DATA
+  this->command(0x13);
+  delay(2);
+  for (uint32_t i = 0; i < buf_len; i++) {
+    this->data(~(this->buffer_[i]));
+  }
+
+  delay(100);  // NOLINT
+  this->wait_until_idle_();
+
+  // COMMAND DISPLAY REFRESH
+  this->command(0x12);
+  delay(100);  // NOLINT
+  this->wait_until_idle_();
+
+  ESP_LOGV(TAG, "Before command(0x02) (>> power off)");
+  this->command(0x02);
+  this->wait_until_idle_();
+  ESP_LOGV(TAG, "After command(0x02) (>> power off)");
+}
+
+int EPaper7P5InV2::get_width_internal() { return 800; }
+int EPaper7P5InV2::get_height_internal() { return 480; }
+uint32_t EPaper7P5InV2::idle_timeout_() { return 10000; }
+void EPaper7P5InV2::dump_config() {
+  LOG_DISPLAY("", " E-Paper", this);
+  ESP_LOGCONFIG(TAG, "  Model: 7.5inV2rev2");
+  LOG_PIN("  Reset Pin: ", this->reset_pin_);
+  LOG_PIN("  DC Pin: ", this->dc_pin_);
+  LOG_PIN("  Busy Pin: ", this->busy_pin_);
+  LOG_UPDATE_INTERVAL(this);
+}
+
+/* 7.50inV2alt */
+bool EPaper7P5InV2alt::wait_until_idle_() {
+  if (this->busy_pin_ == nullptr) {
+    return true;
+  }
+
+  const uint32_t start = millis();
+  while (this->busy_pin_->digital_read()) {
+    this->command(0x71);
+    if (millis() - start > this->idle_timeout_()) {
+      ESP_LOGI(TAG, "Timeout while displaying image!");
+      return false;
+    }
+    delay(10);
+  }
+  return true;
+}
+
+void EPaper7P5InV2alt::initialize() {
+  this->reset_();
+
+  // COMMAND POWER SETTING
+  this->command(0x01);
+
+  // 1-0=11: internal power
+  this->data(0x07);
+  this->data(0x17);  // VGH&VGL
+  this->data(0x3F);  // VSH
+  this->data(0x26);  // VSL
+  this->data(0x11);  // VSHR
+
+  // VCOM DC Setting
+  this->command(0x82);
+  this->data(0x24);  // VCOM
+
+  // Booster Setting
+  this->command(0x06);
+  this->data(0x27);
+  this->data(0x27);
+  this->data(0x2F);
+  this->data(0x17);
+
+  // POWER ON
+  this->command(0x04);
+
+  delay(100);  // NOLINT
+  this->wait_until_idle_();
+  // COMMAND PANEL SETTING
+  this->command(0x00);
+  this->data(0x3F);  // KW-3f   KWR-2F BWROTP 0f BWOTP 1f
+
+  // COMMAND RESOLUTION SETTING
+  this->command(0x61);
+  this->data(0x03);  // source 800
+  this->data(0x20);
+  this->data(0x01);  // gate 480
+  this->data(0xE0);
+  // COMMAND ...?
+  this->command(0x15);
+  this->data(0x00);
+  // COMMAND VCOM AND DATA INTERVAL SETTING
+  this->command(0x50);
+  this->data(0x10);
+  this->data(0x00);
+  // COMMAND TCON SETTING
+  this->command(0x60);
+  this->data(0x22);
+  // Resolution setting
+  this->command(0x65);
+  this->data(0x00);
+  this->data(0x00);  // 800*480
+  this->data(0x00);
+  this->data(0x00);
+
+  this->wait_until_idle_();
+
+  uint8_t lut_vcom_7_i_n5_v2[] = {
+      0x0, 0xF, 0xF, 0x0, 0x0, 0x1, 0x0, 0xF, 0x1, 0xF, 0x1, 0x2, 0x0, 0xF, 0xF, 0x0, 0x0, 0x1, 0x0, 0x0, 0x0,
+      0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+  };
+
+  uint8_t lut_ww_7_i_n5_v2[] = {
+      0x10, 0xF, 0xF, 0x0, 0x0, 0x1, 0x84, 0xF, 0x1, 0xF, 0x1, 0x2, 0x20, 0xF, 0xF, 0x0, 0x0, 0x1, 0x0, 0x0, 0x0,
+      0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+  };
+
+  uint8_t lut_bw_7_i_n5_v2[] = {
+      0x10, 0xF, 0xF, 0x0, 0x0, 0x1, 0x84, 0xF, 0x1, 0xF, 0x1, 0x2, 0x20, 0xF, 0xF, 0x0, 0x0, 0x1, 0x0, 0x0, 0x0,
+      0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+  };
+
+  uint8_t lut_wb_7_i_n5_v2[] = {
+      0x80, 0xF, 0xF, 0x0, 0x0, 0x3, 0x84, 0xF, 0x1, 0xF, 0x1, 0x4, 0x40, 0xF, 0xF, 0x0, 0x0, 0x3, 0x0, 0x0, 0x0,
+      0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+  };
+
+  uint8_t lut_bb_7_i_n5_v2[] = {
+      0x80, 0xF, 0xF, 0x0, 0x0, 0x1, 0x84, 0xF, 0x1, 0xF, 0x1, 0x2, 0x40, 0xF, 0xF, 0x0, 0x0, 0x1, 0x0, 0x0, 0x0,
+      0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+  };
+
+  uint8_t count;
+  this->command(0x20);  // VCOM
+  for (count = 0; count < 42; count++)
+    this->data(lut_vcom_7_i_n5_v2[count]);
+
+  this->command(0x21);  // LUTBW
+  for (count = 0; count < 42; count++)
+    this->data(lut_ww_7_i_n5_v2[count]);
+
+  this->command(0x22);  // LUTBW
+  for (count = 0; count < 42; count++)
+    this->data(lut_bw_7_i_n5_v2[count]);
+
+  this->command(0x23);  // LUTWB
+  for (count = 0; count < 42; count++)
+    this->data(lut_wb_7_i_n5_v2[count]);
+
+  this->command(0x24);  // LUTBB
+  for (count = 0; count < 42; count++)
+    this->data(lut_bb_7_i_n5_v2[count]);
+}
+
+void EPaper7P5InV2alt::dump_config() {
+  LOG_DISPLAY("", " E-Paper", this);
+  ESP_LOGCONFIG(TAG, "  Model: 7.5inV2");
+  LOG_PIN("  Reset Pin: ", this->reset_pin_);
+  LOG_PIN("  DC Pin: ", this->dc_pin_);
+  LOG_PIN("  Busy Pin: ", this->busy_pin_);
+  LOG_UPDATE_INTERVAL(this);
+}
+
+/* 7.50inV2 with partial and fast refresh */
+bool EPaper7P5InV2P::wait_until_idle_() {
+  if (this->busy_pin_ == nullptr) {
+    return true;
+  }
+
+  const uint32_t start = millis();
+  while (this->busy_pin_->digital_read()) {
+    this->command(0x71);
+    if (millis() - start > this->idle_timeout_()) {
+      ESP_LOGE(TAG, "Timeout while displaying image!");
+      return false;
+    }
+    App.feed_wdt();
+    delay(10);
+  }
+  return true;
+}
+
+void EPaper7P5InV2P::reset_() {
+  if (this->reset_pin_ != nullptr) {
+    this->reset_pin_->digital_write(true);
+    delay(20);
+    this->reset_pin_->digital_write(false);
+    delay(2);
+    this->reset_pin_->digital_write(true);
+    delay(20);
+  }
+}
+
+void EPaper7P5InV2P::turn_on_display_() {
+  this->command(0x12);
+  delay(100);  // NOLINT
+  this->wait_until_idle_();
+}
+
+void EPaper7P5InV2P::initialize() {
+  this->reset_();
+
+  // COMMAND POWER SETTING
+  this->command(0x01);
+  this->data(0x07);
+  this->data(0x07);
+  this->data(0x3f);
+  this->data(0x3f);
+
+  // COMMAND BOOSTER SOFT START
+  this->command(0x06);
+  this->data(0x17);
+  this->data(0x17);
+  this->data(0x28);
+  this->data(0x17);
+
+  // COMMAND POWER DRIVER HAT UP
+  this->command(0x04);
+  delay(100);  // NOLINT
+  this->wait_until_idle_();
+
+  // COMMAND PANEL SETTING
+  this->command(0x00);
+  this->data(0x1F);
+
+  // COMMAND RESOLUTION SETTING
+  this->command(0x61);
+  this->data(0x03);
+  this->data(0x20);
+  this->data(0x01);
+  this->data(0xE0);
+
+  // COMMAND DUAL SPI MM_EN, DUSPI_EN
+  this->command(0x15);
+  this->data(0x00);
+
+  // COMMAND VCOM AND DATA INTERVAL SETTING
+  this->command(0x50);
+  this->data(0x10);
+  this->data(0x07);
+
+  // COMMAND TCON SETTING
+  this->command(0x60);
+  this->data(0x22);
+
+  // COMMAND ENABLE FAST UPDATE
+  this->command(0xE0);
+  this->data(0x02);
+  this->command(0xE5);
+  this->data(0x5A);
+
+  // COMMAND POWER DRIVER HAT DOWN
+  this->command(0x02);
+}
+
+void HOT EPaper7P5InV2P::display() {
+  uint32_t buf_len = this->get_buffer_length_();
+
+  // COMMAND POWER ON
+  ESP_LOGI(TAG, "Power on the display and hat");
+
+  this->command(0x04);
+  delay(200);  // NOLINT
+  this->wait_until_idle_();
+
+  if (this->full_update_every_ == 1) {
+    this->command(0x13);
+    for (uint32_t i = 0; i < buf_len; i++) {
+      this->data(~(this->buffer_[i]));
+    }
+
+    this->turn_on_display_();
+
+    this->command(0x02);
+    this->wait_until_idle_();
+    return;
+  }
+
+  this->command(0x50);
+  this->data(0xA9);
+  this->data(0x07);
+
+  if (this->at_update_ == 0) {
+    // Enable fast refresh
+    this->command(0xE5);
+    this->data(0x5A);
+
+    this->command(0x92);
+
+    this->command(0x10);
+    delay(2);
+    for (uint32_t i = 0; i < buf_len; i++) {
+      this->data(~(this->buffer_[i]));
+    }
+
+    delay(100);  // NOLINT
+    this->wait_until_idle_();
+
+    this->command(0x13);
+    delay(2);
+    for (uint32_t i = 0; i < buf_len; i++) {
+      this->data(this->buffer_[i]);
+    }
+
+    delay(100);  // NOLINT
+    this->wait_until_idle_();
+
+    this->turn_on_display_();
+
+  } else {
+    // Enable partial refresh
+    this->command(0xE5);
+    this->data(0x6E);
+
+    // Activate partial refresh and set window bounds
+    this->command(0x91);
+    this->command(0x90);
+
+    this->data(0x00);
+    this->data(0x00);
+    this->data((get_width_internal() - 1) >> 8 & 0xFF);
+    this->data((get_width_internal() - 1) & 0xFF);
+
+    this->data(0x00);
+    this->data(0x00);
+    this->data((get_height_internal() - 1) >> 8 & 0xFF);
+    this->data((get_height_internal() - 1) & 0xFF);
+
+    this->data(0x01);
+
+    this->command(0x13);
+    delay(2);
+    for (uint32_t i = 0; i < buf_len; i++) {
+      this->data(this->buffer_[i]);
+    }
+
+    delay(100);  // NOLINT
+    this->wait_until_idle_();
+
+    this->turn_on_display_();
+  }
+
+  ESP_LOGV(TAG, "Before command(0x02) (>> power off)");
+  this->command(0x02);
+  this->wait_until_idle_();
+  ESP_LOGV(TAG, "After command(0x02) (>> power off)");
+
+  this->at_update_ = (this->at_update_ + 1) % this->full_update_every_;
+}
+
+int EPaper7P5InV2P::get_width_internal() { return 800; }
+int EPaper7P5InV2P::get_height_internal() { return 480; }
+uint32_t EPaper7P5InV2P::idle_timeout_() { return 10000; }
+void EPaper7P5InV2P::dump_config() {
+  LOG_DISPLAY("", " E-Paper", this);
+  ESP_LOGCONFIG(TAG, "  Model: 7.50inv2p");
+  ESP_LOGCONFIG(TAG, "  Full Update Every: %" PRIu32, this->full_update_every_);
+  LOG_PIN("  Reset Pin: ", this->reset_pin_);
+  LOG_PIN("  DC Pin: ", this->dc_pin_);
+  LOG_PIN("  Busy Pin: ", this->busy_pin_);
+  LOG_UPDATE_INTERVAL(this);
+}
+void EPaper7P5InV2P::set_full_update_every(uint32_t full_update_every) {
+  this->full_update_every_ = full_update_every;
+}
+
+/* 7.50in-bc */
+void EPaper7P5InBC::initialize() {
+  /* The command sequence is similar to the 7P5In display but differs in subtle ways
+  to allow for faster updates. */
+  // COMMAND POWER SETTING
+  this->command(0x01);
+  this->data(0x37);
+  this->data(0x00);
+
+  // COMMAND PANEL SETTING
+  this->command(0x00);
+  this->data(0xCF);
+  this->data(0x08);
+
+  // COMMAND PLL CONTROL
+  this->command(0x30);
+  this->data(0x3A);
+
+  // COMMAND VCM_DC_SETTING: all temperature range
+  this->command(0x82);
+  this->data(0x28);
+
+  // COMMAND BOOSTER SOFT START
+  this->command(0x06);
+  this->data(0xC7);
+  this->data(0xCC);
+  this->data(0x15);
+
+  // COMMAND VCOM AND DATA INTERVAL SETTING
+  this->command(0x50);
+  this->data(0x77);
+
+  // COMMAND TCON SETTING
+  this->command(0x60);
+  this->data(0x22);
+
+  // COMMAND FLASH CONTROL
+  this->command(0x65);
+  this->data(0x00);
+
+  // COMMAND RESOLUTION SETTING
+  this->command(0x61);
+  this->data(0x02);  // 640 >> 8
+  this->data(0x80);
+  this->data(0x01);  // 384 >> 8
+  this->data(0x80);
+
+  // COMMAND FLASH MODE
+  this->command(0xE5);
+  this->data(0x03);
+}
+
+void HOT EPaper7P5InBC::display() {
+  // COMMAND DATA START TRANSMISSION 1
+  this->command(0x10);
+  this->start_data_();
+
+  for (size_t i = 0; i < this->get_buffer_length_(); i++) {
+    // A line of eight source pixels (each a bit in this byte)
+    uint8_t eight_pixels = this->buffer_[i];
+
+    for (uint8_t j = 0; j < 8; j += 2) {
+      /* For bichromatic displays, each byte represents two pixels. Each nibble encodes a pixel: 0=white, 3=black,
+      4=color. Therefore, e.g. 0x44 = two adjacent color pixels, 0x33 is two adjacent black pixels, etc. If you want
+      to draw using the color pixels, change '0x30' with '0x40' and '0x03' with '0x04' below. */
+      uint8_t left_nibble = (eight_pixels & 0x80) ? 0x30 : 0x00;
+      eight_pixels <<= 1;
+      uint8_t right_nibble = (eight_pixels & 0x80) ? 0x03 : 0x00;
+      eight_pixels <<= 1;
+      this->write_byte(left_nibble | right_nibble);
+    }
+    App.feed_wdt();
+  }
+  this->end_data_();
+
+  // Unlike the 7P5In display, we send the "power on" command here rather than during initialization
+  // COMMAND POWER ON
+  this->command(0x04);
+
+  // COMMAND DISPLAY REFRESH
+  this->command(0x12);
+}
+
+int EPaper7P5InBC::get_width_internal() { return 640; }
+
+int EPaper7P5InBC::get_height_internal() { return 384; }
+
+void EPaper7P5InBC::dump_config() {
+  LOG_DISPLAY("", " E-Paper", this);
+  ESP_LOGCONFIG(TAG, "  Model: 7.5in-bc");
+  LOG_PIN("  Reset Pin: ", this->reset_pin_);
+  LOG_PIN("  DC Pin: ", this->dc_pin_);
+  LOG_PIN("  Busy Pin: ", this->busy_pin_);
+  LOG_UPDATE_INTERVAL(this);
+}
+
+void EPaper7P5InHDB::initialize() {
+  this->command(0x12);  // SWRESET
+
+  this->wait_until_idle_();  // waiting for the electronic paper IC to release the idle signal
+
+  this->command(0x46);  // Auto Write RAM
+  this->data(0xF7);
+
+  this->wait_until_idle_();  // waiting for the electronic paper IC to release the idle signal
+
+  this->command(0x47);  // Auto Write RAM
+  this->data(0xF7);
+
+  this->wait_until_idle_();  // waiting for the electronic paper IC to release the idle signal
+
+  this->command(0x0C);  // Soft start setting
+  this->data(0xAE);
+  this->data(0xC7);
+  this->data(0xC3);
+  this->data(0xC0);
+  this->data(0x40);
+
+  this->command(0x01);  // Set MUX as 527
+  this->data(0xAF);
+  this->data(0x02);
+  this->data(0x01);
+
+  this->command(0x11);  // Data entry mode
+  this->data(0x01);
+
+  this->command(0x44);
+  this->data(0x00);  // RAM x address start at 0
+  this->data(0x00);
+  this->data(0x6F);  // RAM x address end at 36Fh -> 879
+  this->data(0x03);
+
+  this->command(0x45);
+  this->data(0xAF);  // RAM y address start at 20Fh;
+  this->data(0x02);
+  this->data(0x00);  // RAM y address end at 00h;
+  this->data(0x00);
+
+  this->command(0x3C);  // VBD
+  this->data(0x01);     // LUT1, for white
+
+  this->command(0x18);
+  this->data(0X80);
+
+  this->command(0x22);
+  this->data(0XB1);  // Load Temperature and waveform setting.
+
+  this->command(0x20);
+
+  this->wait_until_idle_();  // waiting for the electronic paper IC to release the idle signal
+
+  this->command(0x4E);
+  this->data(0x00);
+  this->data(0x00);
+
+  this->command(0x4F);
+  this->data(0xAF);
+  this->data(0x02);
+}
+
+void HOT EPaper7P5InHDB::display() {
+  this->command(0x4F);
+  this->data(0xAf);
+  this->data(0x02);
+
+  // BLACK
+  this->command(0x24);
+  this->start_data_();
+  this->write_array(this->buffer_, this->get_buffer_length_());
+  this->end_data_();
+
+  // RED
+  this->command(0x26);
+  this->start_data_();
+  for (size_t i = 0; i < this->get_buffer_length_(); i++)
+    this->write_byte(0x00);
+  this->end_data_();
+
+  this->command(0x22);
+  this->data(0xC7);
+  this->command(0x20);
+  delay(100);  // NOLINT
+}
+
+int EPaper7P5InHDB::get_width_internal() { return 880; }
+
+int EPaper7P5InHDB::get_height_internal() { return 528; }
+
+void EPaper7P5InHDB::dump_config() {
+  LOG_DISPLAY("", " E-Paper", this);
+  ESP_LOGCONFIG(TAG, "  Model: 7.5in-HD-b");
+  LOG_PIN("  Reset Pin: ", this->reset_pin_);
+  LOG_PIN("  DC Pin: ", this->dc_pin_);
+  LOG_PIN("  Busy Pin: ", this->busy_pin_);
+  LOG_UPDATE_INTERVAL(this);
+}
+
+static const uint8_t LUT_SIZE_TTGO_DKE_PART = 153;
+
+static const uint8_t PART_UPDATE_LUT_TTGO_DKE[LUT_SIZE_TTGO_DKE_PART] = {
+    0x0, 0x40, 0x0, 0x0, 0x0,  0x0,  0x0,  0x0,  0x0,  0x0,  0x0, 0x0, 0x80, 0x80, 0x0, 0x0, 0x0, 0x0,  0x0, 0x0,
+    0x0, 0x0,  0x0, 0x0, 0x40, 0x40, 0x0,  0x0,  0x0,  0x0,  0x0, 0x0, 0x0,  0x0,  0x0, 0x0, 0x0, 0x80, 0x0, 0x0,
+    0x0, 0x0,  0x0, 0x0, 0x0,  0x0,  0x0,  0x0,  0x0,  0x0,  0x0, 0x0, 0x0,  0x0,  0x0, 0x0, 0x0, 0x0,  0x0, 0x0,
+    0xF, 0x0,  0x0, 0x0, 0x0,  0x0,  0x0,  0x4,  0x0,  0x0,  0x0, 0x0, 0x0,  0x0,  0x0, 0x0, 0x0, 0x0,  0x0, 0x0,
+    0x0, 0x0,  0x0, 0x0, 0x0,  0x0,  0x0,  0x0,  0x0,  0x0,  0x0, 0x0, 0x0,  0x0,  0x0, 0x0, 0x0, 0x0,  0x0, 0x0,
+    0x0, 0x0,  0x0, 0x0, 0x0,  0x0,  0x0,  0x0,  0x0,  0x0,  0x0, 0x0, 0x0,  0x0,  0x0, 0x0, 0x0, 0x0,  0x0, 0x0,
+    0x0, 0x0,  0x1, 0x0, 0x0,  0x0,  0x0,  0x0,  0x0,  0x1,  0x0, 0x0, 0x0,  0x0,  0x0, 0x0, 0x0, 0x0,  0x0, 0x0,
+    0x0, 0x0,  0x0, 0x0, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x0, 0x0, 0x0,
+    // 0x22,   0x17,   0x41,   0x0,    0x32,   0x32
+};
+
+void EPaper2P13InDKE::initialize() {}
+void HOT EPaper2P13InDKE::display() {
+  bool partial = this->at_update_ != 0;
+  this->at_update_ = (this->at_update_ + 1) % this->full_update_every_;
+
+  if (partial) {
+    ESP_LOGI(TAG, "Performing partial e-paper update.");
+  } else {
+    ESP_LOGI(TAG, "Performing full e-paper update.");
+  }
+
+  // start and set up data format
+  this->command(0x12);
+  this->wait_until_idle_();
+
+  this->command(0x11);
+  this->data(0x03);
+  this->command(0x44);
+  this->data(1);
+  this->data(this->get_width_internal() / 8);
+  this->command(0x45);
+  this->data(0);
+  this->data(0);
+  this->data(this->get_height_internal());
+  this->data(0);
+  this->command(0x4e);
+  this->data(1);
+  this->command(0x4f);
+  this->data(0);
+  this->data(0);
+
+  if (!partial) {
+    // send data
+    this->command(0x24);
+    this->start_data_();
+    this->write_array(this->buffer_, this->get_buffer_length_());
+    this->end_data_();
+
+    // commit
+    this->command(0x20);
+    this->wait_until_idle_();
+  } else {
+    // set up partial update
+    this->command(0x32);
+    this->start_data_();
+    this->write_array(PART_UPDATE_LUT_TTGO_DKE, sizeof(PART_UPDATE_LUT_TTGO_DKE));
+    this->end_data_();
+    this->command(0x3F);
+    this->data(0x22);
+
+    this->command(0x03);
+    this->data(0x17);
+    this->command(0x04);
+    this->data(0x41);
+    this->data(0x00);
+    this->data(0x32);
+    this->command(0x2C);
+    this->data(0x32);
+
+    this->command(0x37);
+    this->data(0x00);
+    this->data(0x00);
+    this->data(0x00);
+    this->data(0x00);
+    this->data(0x00);
+    this->data(0x40);
+    this->data(0x00);
+    this->data(0x00);
+    this->data(0x00);
+    this->data(0x00);
+
+    this->command(0x3C);
+    this->data(0x80);
+    this->command(0x22);
+    this->data(0xC0);
+    this->command(0x20);
+    this->wait_until_idle_();
+
+    // send data
+    this->command(0x24);
+    this->start_data_();
+    this->write_array(this->buffer_, this->get_buffer_length_());
+    this->end_data_();
+
+    // commit as partial
+    this->command(0x22);
+    this->data(0xCF);
+    this->command(0x20);
+    this->wait_until_idle_();
+
+    // data must be sent again on partial update
+    this->command(0x24);
+    this->start_data_();
+    this->write_array(this->buffer_, this->get_buffer_length_());
+    this->end_data_();
+  }
+
+  ESP_LOGI(TAG, "Completed e-paper update.");
+}
+
+int EPaper2P13InDKE::get_width_internal() { return 128; }
+int EPaper2P13InDKE::get_height_internal() { return 250; }
+uint32_t EPaper2P13InDKE::idle_timeout_() { return 5000; }
+void EPaper2P13InDKE::dump_config() {
+  LOG_DISPLAY("", " E-Paper", this);
+  ESP_LOGCONFIG(TAG, "  Model: 2.13inDKE");
+  LOG_PIN("  CS Pin: ", this->cs_);
+  LOG_PIN("  Reset Pin: ", this->reset_pin_);
+  LOG_PIN("  DC Pin: ", this->dc_pin_);
+  LOG_PIN("  Busy Pin: ", this->busy_pin_);
+  LOG_UPDATE_INTERVAL(this);
+}
+
+void EPaper2P13InDKE::set_full_update_every(uint32_t full_update_every) {
+  this->full_update_every_ = full_update_every;
+}
+
+// ========================================================
+//               13.3in (K version)
+// Datasheet/Specification/Reference:
+//  - https://files..com/wiki/13.3inch-e-Paper-HAT-(K)/13.3-inch-e-Paper-(K)-user-manual.pdf
+//  - https://github.com/team/e-Paper/tree/master/Arduino/epd13in3k
+// ========================================================
+
+// using default wait_until_idle_() function
+void EPaper13P3InK::initialize() {
+  this->wait_until_idle_();
+  this->command(0x12);  // SWRESET
+  this->wait_until_idle_();
+
+  this->command(0x0c);  // set soft start
+  this->data(0xae);
+  this->data(0xc7);
+  this->data(0xc3);
+  this->data(0xc0);
+  this->data(0x80);
+
+  this->command(0x01);                            // driver output control
+  this->data((get_height_internal() - 1) % 256);  // Y
+  this->data((get_height_internal() - 1) / 256);  // Y
+  this->data(0x00);
+
+  this->command(0x11);  // data entry mode
+  this->data(0x03);
+
+  // SET WINDOWS
+  // XRAM_START_AND_END_POSITION
+  this->command(0x44);
+  this->data(0 & 0xFF);
+  this->data((0 >> 8) & 0x03);
+  this->data((get_width_internal() - 1) & 0xFF);
+  this->data(((get_width_internal() - 1) >> 8) & 0x03);
+  // YRAM_START_AND_END_POSITION
+  this->command(0x45);
+  this->data(0 & 0xFF);
+  this->data((0 >> 8) & 0x03);
+  this->data((get_height_internal() - 1) & 0xFF);
+  this->data(((get_height_internal() - 1) >> 8) & 0x03);
+
+  this->command(0x3C);  // Border setting
+  this->data(0x01);
+
+  this->command(0x18);  // use the internal temperature sensor
+  this->data(0x80);
+
+  // SET CURSOR
+  // XRAM_ADDRESS
+  this->command(0x4E);
+  this->data(0 & 0xFF);
+  this->data((0 >> 8) & 0x03);
+  // YRAM_ADDRESS
+  this->command(0x4F);
+  this->data(0 & 0xFF);
+  this->data((0 >> 8) & 0x03);
+}
+void HOT EPaper13P3InK::display() {
+  // do single full update
+  this->command(0x24);
+  this->start_data_();
+  this->write_array(this->buffer_, this->get_buffer_length_());
+  this->end_data_();
+
+  // COMMAND DISPLAY REFRESH
+  this->command(0x22);
+  this->data(0xF7);
+  this->command(0x20);
+}
+
+int EPaper13P3InK::get_width_internal() { return 960; }
+int EPaper13P3InK::get_height_internal() { return 680; }
+uint32_t EPaper13P3InK::idle_timeout_() { return 10000; }
+void EPaper13P3InK::dump_config() {
+  LOG_DISPLAY("", " E-Paper", this);
+  ESP_LOGCONFIG(TAG, "  Model: 13.3inK");
+  LOG_PIN("  Reset Pin: ", this->reset_pin_);
+  LOG_PIN("  DC Pin: ", this->dc_pin_);
+  LOG_PIN("  Busy Pin: ", this->busy_pin_);
+  LOG_UPDATE_INTERVAL(this);
+}
+
+}  // namespace _epaper
+}  // namespace esphome

--- a/esphome/components/epaper/epaper.h
+++ b/esphome/components/epaper/epaper.h
@@ -1,0 +1,1054 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/components/spi/spi.h"
+#include "esphome/components/display/display_buffer.h"
+
+namespace esphome {
+namespace _epaper {
+
+class EPaperBase : public display::DisplayBuffer,
+                            public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARITY_LOW,
+                                                  spi::CLOCK_PHASE_LEADING, spi::DATA_RATE_2MHZ> {
+ public:
+  void set_dc_pin(GPIOPin *dc_pin) { dc_pin_ = dc_pin; }
+  float get_setup_priority() const override;
+  void set_reset_pin(GPIOPin *reset) { this->reset_pin_ = reset; }
+  void set_busy_pin(GPIOPin *busy) { this->busy_pin_ = busy; }
+  void set_reset_duration(uint32_t reset_duration) { this->reset_duration_ = reset_duration; }
+
+  void command(uint8_t value);
+  void data(uint8_t value);
+  void cmd_data(const uint8_t *data, size_t length);
+
+  virtual void display() = 0;
+  virtual void initialize() = 0;
+  virtual void deep_sleep() = 0;
+
+  void update() override;
+
+  void setup() override;
+
+  void on_safe_shutdown() override;
+
+ protected:
+  bool wait_until_idle_();
+
+  void setup_pins_();
+
+  void reset_() {
+    if (this->reset_pin_ != nullptr) {
+      this->reset_pin_->digital_write(false);
+      delay(reset_duration_);  // NOLINT
+      this->reset_pin_->digital_write(true);
+      delay(20);
+    }
+  }
+
+  virtual int get_width_controller() { return this->get_width_internal(); };
+
+  virtual uint32_t get_buffer_length_() = 0;  // NOLINT(readability-identifier-naming)
+  uint32_t reset_duration_{200};
+
+  void start_command_();
+  void end_command_();
+  void start_data_();
+  void end_data_();
+
+  GPIOPin *reset_pin_{nullptr};
+  GPIOPin *dc_pin_;
+  GPIOPin *busy_pin_{nullptr};
+  virtual uint32_t idle_timeout_() { return 1000u; }  // NOLINT(readability-identifier-naming)
+};
+
+class EPaper : public EPaperBase {
+ public:
+  void fill(Color color) override;
+
+  display::DisplayType get_display_type() override { return display::DisplayType::DISPLAY_TYPE_BINARY; }
+
+ protected:
+  void draw_absolute_pixel_internal(int x, int y, Color color) override;
+  uint32_t get_buffer_length_() override;
+};
+
+class EPaperBWR : public EPaperBase {
+ public:
+  void fill(Color color) override;
+
+  display::DisplayType get_display_type() override { return display::DisplayType::DISPLAY_TYPE_COLOR; }
+
+ protected:
+  void draw_absolute_pixel_internal(int x, int y, Color color) override;
+  uint32_t get_buffer_length_() override;
+};
+
+class EPaper7C : public EPaperBase {
+ public:
+  uint8_t color_to_hex(Color color);
+  void fill(Color color) override;
+
+  display::DisplayType get_display_type() override { return display::DisplayType::DISPLAY_TYPE_COLOR; }
+
+ protected:
+  void draw_absolute_pixel_internal(int x, int y, Color color) override;
+  uint32_t get_buffer_length_() override;
+  void setup() override;
+  void init_internal_7c_(uint32_t buffer_length);
+
+  static const int NUM_BUFFERS = 10;
+  uint8_t *buffers_[NUM_BUFFERS];
+};
+
+enum EPaperTypeAModel {
+  _EPAPER_1_54_IN = 0,
+  _EPAPER_1_54_IN_V2,
+  _EPAPER_2_13_IN,
+  _EPAPER_2_13_IN_V2,
+  _EPAPER_2_9_IN,
+  _EPAPER_2_9_IN_V2,
+  TTGO_EPAPER_2_13_IN,
+  TTGO_EPAPER_2_13_IN_B73,
+  TTGO_EPAPER_2_13_IN_B1,
+  TTGO_EPAPER_2_13_IN_B74,
+};
+
+class EPaperTypeA : public EPaper {
+ public:
+  EPaperTypeA(EPaperTypeAModel model);
+
+  void initialize() override;
+
+  void dump_config() override;
+
+  void display() override;
+
+  void deep_sleep() override {
+    switch (this->model_) {
+      // Models with specific deep sleep command and data
+      case _EPAPER_1_54_IN:
+      case _EPAPER_1_54_IN_V2:
+      case _EPAPER_2_9_IN_V2:
+      case _EPAPER_2_13_IN_V2:
+        // COMMAND DEEP SLEEP MODE
+        this->command(0x10);
+        this->data(0x01);
+        break;
+      // Other models default to simple deep sleep command
+      default:
+        // COMMAND DEEP SLEEP
+        this->command(0x10);
+        break;
+    }
+    if (this->model_ != _EPAPER_2_13_IN_V2) {
+      // From panel specification:
+      // "After this command initiated, the chip will enter Deep Sleep Mode, BUSY pad will keep output high."
+      this->wait_until_idle_();
+    }
+  }
+
+  void set_full_update_every(uint32_t full_update_every);
+
+ protected:
+  void write_lut_(const uint8_t *lut, uint8_t size);
+
+  void init_display_();
+
+  int get_width_internal() override;
+
+  int get_height_internal() override;
+
+  int get_width_controller() override;
+
+  uint32_t full_update_every_{30};
+  uint32_t at_update_{0};
+  EPaperTypeAModel model_;
+  uint32_t idle_timeout_() override;
+
+  bool deep_sleep_between_updates_{false};
+};
+
+enum EPaperTypeBModel {
+  _EPAPER_2_7_IN = 0,
+  _EPAPER_2_7_IN_B,
+  _EPAPER_2_7_IN_B_V2,
+  _EPAPER_4_2_IN,
+  _EPAPER_4_2_IN_B_V2,
+  _EPAPER_7_3_IN_F,
+  _EPAPER_7_5_IN,
+  _EPAPER_7_5_INV2,
+  _EPAPER_7_5_IN_B_V2,
+  _EPAPER_13_3_IN_K,
+};
+
+class EPaper1P54InBV2 : public EPaperBWR {
+ public:
+  void initialize() override;
+
+  void display() override;
+
+  void dump_config() override;
+
+  void deep_sleep() override {
+    this->command(0x10);
+    this->data(0x01);
+  }
+
+ protected:
+  int get_width_internal() override;
+  int get_height_internal() override;
+};
+
+class EPaper2P7In : public EPaper {
+ public:
+  void initialize() override;
+
+  void display() override;
+
+  void dump_config() override;
+
+  void deep_sleep() override {
+    // COMMAND DEEP SLEEP
+    this->command(0x07);
+    this->data(0xA5);  // check byte
+  }
+
+ protected:
+  int get_width_internal() override;
+  int get_height_internal() override;
+};
+
+class EPaper2P7InB : public EPaperBWR {
+ public:
+  void initialize() override;
+
+  void display() override;
+
+  void dump_config() override;
+
+  void deep_sleep() override {
+    // COMMAND VCOM_AND_DATA_INTERVAL_SETTING
+    this->command(0x50);
+    // COMMAND POWER OFF
+    this->command(0x02);
+    this->wait_until_idle_();
+    // COMMAND DEEP SLEEP
+    this->command(0x07);  // deep sleep
+    this->data(0xA5);     // check byte
+  }
+
+ protected:
+  int get_width_internal() override;
+  int get_height_internal() override;
+};
+
+class EPaper2P7InBV2 : public EPaperBWR {
+ public:
+  void initialize() override;
+
+  void display() override;
+
+  void dump_config() override;
+
+  void deep_sleep() override {
+    // COMMAND DEEP SLEEP
+    this->command(0x10);
+    this->data(0x01);
+  }
+
+ protected:
+  int get_width_internal() override;
+  int get_height_internal() override;
+};
+
+class GDEW029T5 : public EPaper {
+ public:
+  void initialize() override;
+
+  void display() override;
+
+  void dump_config() override;
+
+  void deep_sleep() override;
+  void set_full_update_every(uint32_t full_update_every);
+
+ protected:
+  void init_display_();
+  void init_full_();
+  void init_partial_();
+  void write_lut_(const uint8_t *lut, uint8_t size);
+  void power_off_();
+  void power_on_();
+  int get_width_internal() override;
+
+  int get_height_internal() override;
+
+ private:
+  uint32_t full_update_every_{30};
+  uint32_t at_update_{0};
+  bool deep_sleep_between_updates_{false};
+  bool power_is_on_{false};
+  bool is_deep_sleep_{false};
+  uint8_t *old_buffer_{nullptr};
+};
+
+class GDEY029T94 : public EPaper {
+ public:
+  void initialize() override;
+
+  void display() override;
+
+  void dump_config() override;
+
+  void deep_sleep() override {
+    this->command(0x10);  // Enter deep sleep
+    this->data(0x01);
+  }
+
+ protected:
+  int get_width_internal() override;
+
+  int get_height_internal() override;
+};
+
+class EPaper2P7InV2 : public EPaper {
+ public:
+  void initialize() override;
+
+  void display() override;
+
+  void dump_config() override;
+
+  void deep_sleep() override { ; }
+
+ protected:
+  int get_width_internal() override;
+
+  int get_height_internal() override;
+};
+
+class GDEW0154M09 : public EPaper {
+ public:
+  void initialize() override;
+  void display() override;
+  void dump_config() override;
+  void deep_sleep() override;
+
+ protected:
+  int get_width_internal() override;
+  int get_height_internal() override;
+
+ private:
+  static const uint8_t CMD_DTM1_DATA_START_TRANS = 0x10;
+  static const uint8_t CMD_DTM2_DATA_START_TRANS2 = 0x13;
+  static const uint8_t CMD_DISPLAY_REFRESH = 0x12;
+  static const uint8_t CMD_AUTO_SEQ = 0x17;
+  static const uint8_t DATA_AUTO_PON_DSR_POF_DSLP = 0xA7;
+  static const uint8_t CMD_PSR_PANEL_SETTING = 0x00;
+  static const uint8_t CMD_UNDOCUMENTED_0x4D = 0x4D;  //  NOLINT
+  static const uint8_t CMD_UNDOCUMENTED_0xAA = 0xaa;  //  NOLINT
+  static const uint8_t CMD_UNDOCUMENTED_0xE9 = 0xe9;  //  NOLINT
+  static const uint8_t CMD_UNDOCUMENTED_0xB6 = 0xb6;  //  NOLINT
+  static const uint8_t CMD_UNDOCUMENTED_0xF3 = 0xf3;  //  NOLINT
+  static const uint8_t CMD_TRES_RESOLUTION_SETTING = 0x61;
+  static const uint8_t CMD_TCON_TCONSETTING = 0x60;
+  static const uint8_t CMD_CDI_VCOM_DATA_INTERVAL = 0x50;
+  static const uint8_t CMD_POF_POWER_OFF = 0x02;
+  static const uint8_t CMD_DSLP_DEEP_SLEEP = 0x07;
+  static const uint8_t DATA_DSLP_DEEP_SLEEP = 0xA5;
+  static const uint8_t CMD_PWS_POWER_SAVING = 0xe3;
+  static const uint8_t CMD_PON_POWER_ON = 0x04;
+  static const uint8_t CMD_PTL_PARTIAL_WINDOW = 0x90;
+
+  uint8_t *lastbuff_ = nullptr;
+  void reset_();
+  void clear_();
+  void write_init_list_(const uint8_t *list);
+  void init_internal_();
+};
+
+class EPaper2P9InB : public EPaper {
+ public:
+  void initialize() override;
+
+  void display() override;
+
+  void dump_config() override;
+
+  void deep_sleep() override {
+    // COMMAND DEEP SLEEP
+    this->command(0x07);
+    this->data(0xA5);  // check byte
+  }
+
+ protected:
+  int get_width_internal() override;
+
+  int get_height_internal() override;
+};
+
+class EPaper2P9InBV3 : public EPaper {
+ public:
+  void initialize() override;
+
+  void display() override;
+
+  void dump_config() override;
+
+  void deep_sleep() override {
+    // COMMAND DEEP SLEEP
+    this->command(0x07);
+    this->data(0xA5);  // check byte
+  }
+
+ protected:
+  int get_width_internal() override;
+
+  int get_height_internal() override;
+};
+
+class EPaper2P9InV2R2 : public EPaper {
+ public:
+  EPaper2P9InV2R2();
+
+  void initialize() override;
+
+  void display() override;
+
+  void dump_config() override;
+
+  void deep_sleep() override;
+
+  void set_full_update_every(uint32_t full_update_every);
+
+ protected:
+  void write_lut_(const uint8_t *lut, uint8_t size);
+
+  int get_width_internal() override;
+
+  int get_height_internal() override;
+
+  int get_width_controller() override;
+
+  uint32_t full_update_every_{30};
+  uint32_t at_update_{0};
+
+ private:
+  void reset_();
+};
+
+class EPaper2P9InDKE : public EPaper {
+ public:
+  void initialize() override;
+
+  void display() override;
+
+  void dump_config() override;
+
+  void deep_sleep() override {
+    // COMMAND DEEP SLEEP
+    this->command(0x10);
+    this->data(0x01);
+  }
+
+  void set_full_update_every(uint32_t full_update_every);
+
+ protected:
+  uint32_t full_update_every_{30};
+  uint32_t at_update_{0};
+  int get_width_internal() override;
+
+  int get_height_internal() override;
+};
+
+class EPaper2P9InD : public EPaper {
+ public:
+  void initialize() override;
+
+  void display() override;
+
+  void dump_config() override;
+
+  void deep_sleep() override {
+    // COMMAND DEEP SLEEP
+    this->command(0x07);
+    this->data(0xA5);
+  }
+
+ protected:
+  int get_width_internal() override;
+
+  int get_height_internal() override;
+};
+
+class GDEY042T81 : public EPaper {
+ public:
+  GDEY042T81();
+
+  void initialize() override;
+
+  void display() override;
+
+  void dump_config() override;
+
+  void deep_sleep() override {
+    // COMMAND POWER OFF
+    this->command(0x22);
+    this->data(0x83);
+    this->command(0x20);
+    // COMMAND DEEP SLEEP
+    this->command(0x10);
+    this->data(0x01);
+  }
+
+  void set_full_update_every(uint32_t full_update_every);
+
+ protected:
+  uint32_t full_update_every_{30};
+  uint32_t at_update_{0};
+
+  int get_width_internal() override;
+  int get_height_internal() override;
+  uint32_t idle_timeout_() override;
+
+ private:
+  void reset_();
+  void update_full_();
+  void update_part_();
+  void init_display_();
+};
+
+class EPaper4P2In : public EPaper {
+ public:
+  void initialize() override;
+
+  void display() override;
+
+  void dump_config() override;
+
+  void deep_sleep() override {
+    // COMMAND VCOM AND DATA INTERVAL SETTING
+    this->command(0x50);
+    this->data(0x17);  // border floating
+
+    // COMMAND VCM DC SETTING
+    this->command(0x82);
+    // COMMAND PANEL SETTING
+    this->command(0x00);
+
+    delay(100);  // NOLINT
+
+    // COMMAND POWER SETTING
+    this->command(0x01);
+    this->data(0x00);
+    this->data(0x00);
+    this->data(0x00);
+    this->data(0x00);
+    this->data(0x00);
+    delay(100);  // NOLINT
+
+    // COMMAND POWER OFF
+    this->command(0x02);
+    this->wait_until_idle_();
+    // COMMAND DEEP SLEEP
+    this->command(0x07);
+    this->data(0xA5);  // check byte
+  }
+
+ protected:
+  int get_width_internal() override;
+
+  int get_height_internal() override;
+};
+
+class EPaper4P2InBV2 : public EPaper {
+ public:
+  void initialize() override;
+
+  void display() override;
+
+  void dump_config() override;
+
+  void deep_sleep() override {
+    // COMMAND VCOM AND DATA INTERVAL SETTING
+    this->command(0x50);
+    this->data(0xF7);  // border floating
+
+    // COMMAND POWER OFF
+    this->command(0x02);
+    this->wait_until_idle_();
+
+    // COMMAND DEEP SLEEP
+    this->command(0x07);
+    this->data(0xA5);  // check code
+  }
+
+ protected:
+  int get_width_internal() override;
+
+  int get_height_internal() override;
+};
+
+class EPaper4P2InBV2BWR : public EPaperBWR {
+ public:
+  void initialize() override;
+
+  void display() override;
+
+  void dump_config() override;
+
+  void deep_sleep() override {
+    // COMMAND VCOM AND DATA INTERVAL SETTING
+    this->command(0x50);
+    this->data(0xF7);  // border floating
+
+    // COMMAND POWER OFF
+    this->command(0x02);
+    this->wait_until_idle_();
+
+    // COMMAND DEEP SLEEP
+    this->command(0x07);
+    this->data(0xA5);  // check code
+  }
+
+ protected:
+  int get_width_internal() override;
+
+  int get_height_internal() override;
+};
+
+class EPaper5P8In : public EPaper {
+ public:
+  void initialize() override;
+
+  void display() override;
+
+  void dump_config() override;
+
+  void deep_sleep() override {
+    // COMMAND POWER OFF
+    this->command(0x02);
+    this->wait_until_idle_();
+    // COMMAND DEEP SLEEP
+    this->command(0x07);
+    this->data(0xA5);  // check byte
+  }
+
+ protected:
+  int get_width_internal() override;
+
+  int get_height_internal() override;
+};
+
+class EPaper5P8InV2 : public EPaper {
+ public:
+  void initialize() override;
+
+  void display() override;
+
+  void dump_config() override;
+
+  void deep_sleep() override {
+    // COMMAND VCOM AND DATA INTERVAL SETTING
+    this->command(0x50);
+    this->data(0x17);  // border floating
+
+    // COMMAND VCM DC SETTING
+    this->command(0x82);
+    // COMMAND PANEL SETTING
+    this->command(0x00);
+
+    delay(100);  // NOLINT
+
+    // COMMAND POWER SETTING
+    this->command(0x01);
+    this->data(0x00);
+    this->data(0x00);
+    this->data(0x00);
+    this->data(0x00);
+    this->data(0x00);
+    delay(100);  // NOLINT
+
+    // COMMAND POWER OFF
+    this->command(0x02);
+    this->wait_until_idle_();
+    // COMMAND DEEP SLEEP
+    this->command(0x07);
+    this->data(0xA5);  // check byte
+  }
+
+ protected:
+  int get_width_internal() override;
+
+  int get_height_internal() override;
+};
+
+class EPaper7P3InF : public EPaper7C {
+ public:
+  void initialize() override;
+
+  void display() override;
+
+  void dump_config() override;
+
+ protected:
+  int get_width_internal() override;
+
+  int get_height_internal() override;
+
+  uint32_t idle_timeout_() override;
+
+  void deep_sleep() override { ; }
+
+  bool wait_until_idle_();
+
+  bool deep_sleep_between_updates_{true};
+
+  void reset_() {
+    if (this->reset_pin_ != nullptr) {
+      this->reset_pin_->digital_write(true);
+      delay(20);
+      this->reset_pin_->digital_write(false);
+      delay(1);
+      this->reset_pin_->digital_write(true);
+      delay(20);
+    }
+  };
+};
+
+class EPaper7P5In : public EPaper {
+ public:
+  void initialize() override;
+
+  void display() override;
+
+  void dump_config() override;
+
+  void deep_sleep() override {
+    // COMMAND POWER OFF
+    this->command(0x02);
+    this->wait_until_idle_();
+    // COMMAND DEEP SLEEP
+    this->command(0x07);
+    this->data(0xA5);  // check byte
+  }
+
+ protected:
+  int get_width_internal() override;
+
+  int get_height_internal() override;
+};
+
+class EPaper7P5InBV2 : public EPaper {
+ public:
+  void initialize() override;
+
+  void display() override;
+
+  void dump_config() override;
+
+  void deep_sleep() override {
+    // COMMAND POWER OFF
+    this->command(0x02);
+    this->wait_until_idle_();
+    // COMMAND DEEP SLEEP
+    this->command(0x07);  // deep sleep
+    this->data(0xA5);     // check byte
+  }
+
+ protected:
+  int get_width_internal() override;
+
+  int get_height_internal() override;
+};
+
+class EPaper7P5InBV3 : public EPaper {
+ public:
+  bool wait_until_idle_();
+
+  void initialize() override;
+
+  void display() override;
+
+  void dump_config() override;
+
+  void deep_sleep() override {
+    this->command(0x02);  // Power off
+    this->wait_until_idle_();
+    this->command(0x07);  // Deep sleep
+    this->data(0xA5);
+  }
+
+  void clear_screen();
+
+ protected:
+  int get_width_internal() override;
+
+  int get_height_internal() override;
+
+  void reset_() {
+    if (this->reset_pin_ != nullptr) {
+      this->reset_pin_->digital_write(true);
+      delay(200);  // NOLINT
+      this->reset_pin_->digital_write(false);
+      delay(5);
+      this->reset_pin_->digital_write(true);
+      delay(200);  // NOLINT
+    }
+  };
+
+  void init_display_();
+};
+
+class EPaper7P5InBV3BWR : public EPaperBWR {
+ public:
+  bool wait_until_idle_();
+
+  void initialize() override;
+
+  void display() override;
+
+  void dump_config() override;
+
+  void deep_sleep() override {
+    this->command(0x02);  // Power off
+    this->wait_until_idle_();
+    this->command(0x07);  // Deep sleep
+    this->data(0xA5);
+  }
+
+  void clear_screen();
+
+ protected:
+  int get_width_internal() override;
+
+  int get_height_internal() override;
+
+  void reset_() {
+    if (this->reset_pin_ != nullptr) {
+      this->reset_pin_->digital_write(true);
+      delay(200);  // NOLINT
+      this->reset_pin_->digital_write(false);
+      delay(5);
+      this->reset_pin_->digital_write(true);
+      delay(200);  // NOLINT
+    }
+  };
+
+  void init_display_();
+};
+
+class EPaper7P5InBC : public EPaper {
+ public:
+  void initialize() override;
+
+  void display() override;
+
+  void dump_config() override;
+
+  void deep_sleep() override {
+    // COMMAND POWER OFF
+    this->command(0x02);
+    this->wait_until_idle_();
+    // COMMAND DEEP SLEEP
+    this->command(0x07);
+    this->data(0xA5);  // check byte
+  }
+
+ protected:
+  int get_width_internal() override;
+
+  int get_height_internal() override;
+};
+
+class EPaper7P5InV2 : public EPaper {
+ public:
+  bool wait_until_idle_();
+
+  void initialize() override;
+
+  void display() override;
+
+  void dump_config() override;
+
+  void deep_sleep() override {
+    // COMMAND POWER OFF
+    this->command(0x02);
+    this->wait_until_idle_();
+    // COMMAND DEEP SLEEP
+    this->command(0x07);
+    this->data(0xA5);  // check byte
+  }
+
+ protected:
+  int get_width_internal() override;
+
+  int get_height_internal() override;
+
+  uint32_t idle_timeout_() override;
+};
+
+class EPaper7P5InV2alt : public EPaper7P5InV2 {
+ public:
+  bool wait_until_idle_();
+  void initialize() override;
+  void dump_config() override;
+
+ protected:
+  void reset_() {
+    if (this->reset_pin_ != nullptr) {
+      this->reset_pin_->digital_write(true);
+      delay(200);  // NOLINT
+      this->reset_pin_->digital_write(false);
+      delay(2);
+      this->reset_pin_->digital_write(true);
+      delay(20);
+    }
+  };
+};
+
+class EPaper7P5InV2P : public EPaper {
+ public:
+  bool wait_until_idle_();
+
+  void initialize() override;
+
+  void display() override;
+
+  void dump_config() override;
+
+  void deep_sleep() override {
+    // COMMAND POWER OFF
+    this->command(0x02);
+    this->wait_until_idle_();
+    // COMMAND DEEP SLEEP
+    this->command(0x07);
+    this->data(0xA5);  // check byte
+  }
+
+  void set_full_update_every(uint32_t full_update_every);
+
+ protected:
+  int get_width_internal() override;
+
+  int get_height_internal() override;
+
+  uint32_t idle_timeout_() override;
+
+  uint32_t full_update_every_{30};
+  uint32_t at_update_{0};
+
+ private:
+  void reset_();
+
+  void turn_on_display_();
+};
+
+class EPaper7P5InHDB : public EPaper {
+ public:
+  void initialize() override;
+
+  void display() override;
+
+  void dump_config() override;
+
+  void deep_sleep() override {
+    // deep sleep
+    this->command(0x10);
+    this->data(0x01);
+  }
+
+ protected:
+  int get_width_internal() override;
+
+  int get_height_internal() override;
+};
+
+class EPaper2P13InDKE : public EPaper {
+ public:
+  void initialize() override;
+
+  void display() override;
+
+  void dump_config() override;
+
+  void deep_sleep() override {
+    // COMMAND POWER DOWN
+    this->command(0x10);
+    this->data(0x01);
+    // cannot wait until idle here, the device no longer responds
+  }
+
+  void set_full_update_every(uint32_t full_update_every);
+
+ protected:
+  int get_width_internal() override;
+
+  int get_height_internal() override;
+
+  uint32_t idle_timeout_() override;
+
+  uint32_t full_update_every_{30};
+  uint32_t at_update_{0};
+};
+
+class EPaper2P13InV3 : public EPaper {
+ public:
+  void display() override;
+
+  void dump_config() override;
+
+  void deep_sleep() override {
+    // COMMAND POWER DOWN
+    this->command(0x10);
+    this->data(0x01);
+    // cannot wait until idle here, the device no longer responds
+  }
+
+  void set_full_update_every(uint32_t full_update_every);
+
+  void setup() override;
+  void initialize() override;
+
+ protected:
+  int get_width_controller() override;
+  int get_width_internal() override;
+  int get_height_internal() override;
+  uint32_t idle_timeout_() override;
+
+  void write_buffer_(uint8_t cmd, int top, int bottom);
+  void set_window_(int t, int b);
+  void send_reset_();
+  void partial_update_();
+  void full_update_();
+
+  uint32_t full_update_every_{30};
+  uint32_t at_update_{0};
+  bool is_busy_{false};
+  void write_lut_(const uint8_t *lut);
+};
+
+class EPaper13P3InK : public EPaper {
+ public:
+  void initialize() override;
+
+  void display() override;
+
+  void dump_config() override;
+
+  void deep_sleep() override {
+    // COMMAND DEEP SLEEP
+    this->command(0x10);
+    this->data(0x01);
+  }
+
+ protected:
+  int get_width_internal() override;
+
+  int get_height_internal() override;
+
+  uint32_t idle_timeout_() override;
+};
+
+}  // namespace _epaper
+}  // namespace esphome

--- a/esphome/components/seeed_energymeter/__init__.py
+++ b/esphome/components/seeed_energymeter/__init__.py
@@ -1,0 +1,1 @@
+CODEOWNERS = ["@ziceva"]

--- a/esphome/components/seeed_energymeter/__init__.py
+++ b/esphome/components/seeed_energymeter/__init__.py
@@ -1,1 +1,1 @@
-CODEOWNERS = ["@ziceva"]
+CODEOWNERS = ["@ackpeng"]

--- a/esphome/components/seeed_energymeter/seeedenergymeter.cpp
+++ b/esphome/components/seeed_energymeter/seeedenergymeter.cpp
@@ -1,0 +1,151 @@
+#include "seeedenergymeter.h"
+#include "esphome/core/log.h"
+#include <cinttypes>
+
+namespace esphome {
+namespace SeeedEnergyMeter {
+
+static const char *const TAG = "SeeedEnergyMeter";
+
+// https://www.belling.com.cn/media/file_object/bel_product/BL0939/datasheet/BL0939_V1.2_cn.pdf
+// (unfortunately chinese, but the protocol can be understood with some translation tool)
+static const uint8_t BL0939_READ_COMMAND = 0x55;  // 0x5{A4,A3,A2,A1}
+static const uint8_t BL0939_FULL_PACKET = 0xAA;
+static const uint8_t BL0939_PACKET_HEADER = 0x55;
+
+static const uint8_t BL0939_WRITE_COMMAND = 0xA5;  // 0xA{A4,A3,A2,A1}
+static const uint8_t BL0939_REG_IA_FAST_RMS_CTRL = 0x10;
+static const uint8_t BL0939_REG_IB_FAST_RMS_CTRL = 0x1E;
+static const uint8_t BL0939_REG_MODE = 0x18;
+static const uint8_t BL0939_REG_SOFT_RESET = 0x19;
+static const uint8_t BL0939_REG_USR_WRPROT = 0x1A;
+static const uint8_t BL0939_REG_TPS_CTRL = 0x1B;
+
+const uint8_t BL0939_INIT[6][6] = {
+    // Reset to default
+    {BL0939_WRITE_COMMAND, BL0939_REG_SOFT_RESET, 0x5A, 0x5A, 0x5A, 0x33},
+    // Enable User Operation Write
+    {BL0939_WRITE_COMMAND, BL0939_REG_USR_WRPROT, 0x55, 0x00, 0x00, 0xEB},
+    // 0x0100 = CF_UNABLE energy pulse, AC_FREQ_SEL 50Hz, RMS_UPDATE_SEL 800mS
+    {BL0939_WRITE_COMMAND, BL0939_REG_MODE, 0x00, 0x10, 0x00, 0x32},
+    // 0x47FF = Over-current and leakage alarm on, Automatic temperature measurement, Interval 100mS
+    {BL0939_WRITE_COMMAND, BL0939_REG_TPS_CTRL, 0xFF, 0x47, 0x00, 0xF9},
+    // 0x181C = Half cycle, Fast RMS threshold 6172
+    {BL0939_WRITE_COMMAND, BL0939_REG_IA_FAST_RMS_CTRL, 0x1C, 0x18, 0x00, 0x16},
+    // 0x181C = Half cycle, Fast RMS threshold 6172
+    {BL0939_WRITE_COMMAND, BL0939_REG_IB_FAST_RMS_CTRL, 0x1C, 0x18, 0x00, 0x08}};
+
+void SeeedEnergyMeter::loop() {
+
+  update();
+  DataPacket buffer;
+  if (!this->available()) {
+    ESP_LOGI(TAG, "No data available");
+    return;
+  }
+
+  if (read_array((uint8_t *) &buffer, sizeof(buffer))) {
+    if (validate_checksum(&buffer)) {
+      received_package_(&buffer);
+    }
+  } else {
+    ESP_LOGI(TAG, "Junk on wire. Throwing away partial message");
+    while (read() >= 0)
+      ;
+  }
+}
+
+bool SeeedEnergyMeter::validate_checksum(const DataPacket *data) {
+  uint8_t checksum = BL0939_READ_COMMAND;
+  // Whole package but checksum
+  for (uint32_t i = 0; i < sizeof(data->raw) - 1; i++) {
+    checksum += data->raw[i];
+  }
+  checksum ^= 0xFF;
+  if (checksum != data->checksum) {
+    ESP_LOGI(TAG, "SeeedEnergyMeter invalid checksum! 0x%02X != 0x%02X", checksum, data->checksum);
+  }
+  return checksum == data->checksum;
+}
+
+void SeeedEnergyMeter::update() {
+  this->flush();
+  this->write_byte(BL0939_READ_COMMAND);
+  this->write_byte(BL0939_FULL_PACKET);
+}
+
+void SeeedEnergyMeter::setup() {
+  ESP_LOGI(TAG, "SeeedEnergyMeter: Setup");
+  for (auto *i : BL0939_INIT) {
+    this->write_array(i, 6);
+    delay(1);
+  }
+  this->flush();
+}
+
+void SeeedEnergyMeter::received_package_(const DataPacket *data) const {
+  // Bad header
+  if (data->frame_header != BL0939_PACKET_HEADER) {
+    ESP_LOGW(TAG, "Invalid data. Header mismatch: %d", data->frame_header);
+    return;
+  }
+
+  float v_rms = (float) to_uint32_t(data->v_rms) / voltage_reference_;
+  float ia_rms = (float) to_uint32_t(data->ia_rms) / current_reference_;
+  float ib_rms = (float) to_uint32_t(data->ib_rms) / current_reference_;
+  float a_watt = (float) to_int32_t(data->a_watt) / power_reference_;
+  float b_watt = (float) to_int32_t(data->b_watt) / power_reference_;
+  int32_t cfa_cnt = to_int32_t(data->cfa_cnt);
+  int32_t cfb_cnt = to_int32_t(data->cfb_cnt);
+  float a_energy_consumption = (float) cfa_cnt / energy_reference_;
+  float b_energy_consumption = (float) cfb_cnt / energy_reference_;
+  float total_energy_consumption = a_energy_consumption + b_energy_consumption;
+
+  if (voltage_sensor_ != nullptr) {
+    voltage_sensor_->publish_state(v_rms);
+  }
+  if (current_sensor_1_ != nullptr) {
+    current_sensor_1_->publish_state(ia_rms);
+  }
+  if (current_sensor_2_ != nullptr) {
+    current_sensor_2_->publish_state(ib_rms);
+  }
+  if (power_sensor_1_ != nullptr) {
+    power_sensor_1_->publish_state(a_watt);
+  }
+  if (power_sensor_2_ != nullptr) {
+    power_sensor_2_->publish_state(b_watt);
+  }
+  if (energy_sensor_1_ != nullptr) {
+    energy_sensor_1_->publish_state(a_energy_consumption);
+  }
+  if (energy_sensor_2_ != nullptr) {
+    energy_sensor_2_->publish_state(b_energy_consumption);
+  }
+  if (energy_sensor_sum_ != nullptr) {
+    energy_sensor_sum_->publish_state(total_energy_consumption);
+  }
+
+  ESP_LOGV(TAG,
+           "BL0939: U %fV, I1 %fA, I2 %fA, P1 %fW, P2 %fW, CntA %" PRId32 ", CntB %" PRId32 ", ∫P1 %fkWh, ∫P2 %fkWh",
+           v_rms, ia_rms, ib_rms, a_watt, b_watt, cfa_cnt, cfb_cnt, a_energy_consumption, b_energy_consumption);
+}
+
+void SeeedEnergyMeter::dump_config() {  // NOLINT(readability-function-cognitive-complexity)
+  ESP_LOGCONFIG(TAG, "BL0939:");
+  LOG_SENSOR("", "Voltage", this->voltage_sensor_);
+  LOG_SENSOR("", "Current 1", this->current_sensor_1_);
+  LOG_SENSOR("", "Current 2", this->current_sensor_2_);
+  LOG_SENSOR("", "Power 1", this->power_sensor_1_);
+  LOG_SENSOR("", "Power 2", this->power_sensor_2_);
+  LOG_SENSOR("", "Energy 1", this->energy_sensor_1_);
+  LOG_SENSOR("", "Energy 2", this->energy_sensor_2_);
+  LOG_SENSOR("", "Energy sum", this->energy_sensor_sum_);
+}
+
+uint32_t SeeedEnergyMeter::to_uint32_t(ube24_t input) { return input.h << 16 | input.m << 8 | input.l; }
+
+int32_t SeeedEnergyMeter::to_int32_t(sbe24_t input) { return input.h << 16 | input.m << 8 | input.l; }
+
+}  // namespace SeeedEnergyMeter
+}  // namespace esphome

--- a/esphome/components/seeed_energymeter/seeedenergymeter.cpp
+++ b/esphome/components/seeed_energymeter/seeedenergymeter.cpp
@@ -8,7 +8,6 @@ namespace SeeedEnergyMeter {
 static const char *const TAG = "SeeedEnergyMeter";
 
 // https://www.belling.com.cn/media/file_object/bel_product/BL0939/datasheet/BL0939_V1.2_cn.pdf
-// (unfortunately chinese, but the protocol can be understood with some translation tool)
 static const uint8_t BL0939_READ_COMMAND = 0x55;  // 0x5{A4,A3,A2,A1}
 static const uint8_t BL0939_FULL_PACKET = 0xAA;
 static const uint8_t BL0939_PACKET_HEADER = 0x55;

--- a/esphome/components/seeed_energymeter/seeedenergymeter.h
+++ b/esphome/components/seeed_energymeter/seeedenergymeter.h
@@ -1,0 +1,113 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/components/uart/uart.h"
+#include "esphome/components/sensor/sensor.h"
+
+#define Vref 1.218
+#define R1  24.9
+#define R2  5 * 22000
+#define RL  0.25    // 0.5 * 1000 / 2000
+
+namespace esphome {
+namespace SeeedEnergyMeter {
+
+// https://datasheet.lcsc.com/lcsc/2108071830_BL-Shanghai-Belling-BL0939_C2841044.pdf
+// (unfortunately chinese, but the formulas can be easily understood)
+// Sonoff Dual R3 V2 has the exact same resistor values for the current shunts (RL=1miliOhm)
+// and for the voltage divider (R1=0.51kOhm, R2=5*390kOhm)
+// as in the manufacturer's reference circuit, so the same formulas were used here (Vref=1.218V)
+
+static const float BL0939_IREF =  324004 * RL / Vref;
+static const float BL0939_UREF = 79931 * R1 * 1000 / (Vref * R2);
+static const float BL0939_PREF = 4046 * RL * R1 * 1000 / (Vref * Vref * R2);
+static const float BL0939_EREF = 3.6e6 * 4046 * RL * R1 * 1000 / (1638.4 * 256 * Vref * Vref * R2);
+
+struct ube24_t {  // NOLINT(readability-identifier-naming,altera-struct-pack-align)
+  uint8_t l;
+  uint8_t m;
+  uint8_t h;
+} __attribute__((packed));
+
+struct ube16_t {  // NOLINT(readability-identifier-naming,altera-struct-pack-align)
+  uint8_t l;
+  uint8_t h;
+} __attribute__((packed));
+
+struct sbe24_t {  // NOLINT(readability-identifier-naming,altera-struct-pack-align)
+  uint8_t l;
+  uint8_t m;
+  int8_t h;
+} __attribute__((packed));
+
+// Caveat: All these values are big endian (low - middle - high)
+
+union DataPacket {  // NOLINT(altera-struct-pack-align)
+  uint8_t raw[35];
+  struct {
+    uint8_t frame_header;  // 0x55 according to docs
+    ube24_t ia_fast_rms;
+    ube24_t ia_rms;
+    ube24_t ib_rms;
+    ube24_t v_rms;
+    ube24_t ib_fast_rms;
+    sbe24_t a_watt;
+    sbe24_t b_watt;
+    sbe24_t cfa_cnt;
+    sbe24_t cfb_cnt;
+    ube16_t tps1;
+    uint8_t RESERVED1;  // value of 0x00
+    ube16_t tps2;
+    uint8_t RESERVED2;  // value of 0x00
+    uint8_t checksum;   // checksum
+  };
+} __attribute__((packed));
+
+class SeeedEnergyMeter : public PollingComponent, public uart::UARTDevice {
+ public:
+  void set_voltage_sensor(sensor::Sensor *voltage_sensor) { voltage_sensor_ = voltage_sensor; }
+  void set_current_sensor_1(sensor::Sensor *current_sensor_1) { current_sensor_1_ = current_sensor_1; }
+  void set_current_sensor_2(sensor::Sensor *current_sensor_2) { current_sensor_2_ = current_sensor_2; }
+  void set_power_sensor_1(sensor::Sensor *power_sensor_1) { power_sensor_1_ = power_sensor_1; }
+  void set_power_sensor_2(sensor::Sensor *power_sensor_2) { power_sensor_2_ = power_sensor_2; }
+  void set_energy_sensor_1(sensor::Sensor *energy_sensor_1) { energy_sensor_1_ = energy_sensor_1; }
+  void set_energy_sensor_2(sensor::Sensor *energy_sensor_2) { energy_sensor_2_ = energy_sensor_2; }
+  void set_energy_sensor_sum(sensor::Sensor *energy_sensor_sum) { energy_sensor_sum_ = energy_sensor_sum; }
+
+  void loop() override;
+
+  void update() override;
+  void setup() override;
+  void dump_config() override;
+
+ protected:
+  sensor::Sensor *voltage_sensor_{nullptr};
+  sensor::Sensor *current_sensor_1_{nullptr};
+  sensor::Sensor *current_sensor_2_{nullptr};
+  // NB This may be negative as the circuits is seemingly able to measure
+  // power in both directions
+  sensor::Sensor *power_sensor_1_{nullptr};
+  sensor::Sensor *power_sensor_2_{nullptr};
+  sensor::Sensor *energy_sensor_1_{nullptr};
+  sensor::Sensor *energy_sensor_2_{nullptr};
+  sensor::Sensor *energy_sensor_sum_{nullptr};
+
+  // Divide by this to turn into Watt
+  float power_reference_ = BL0939_PREF;
+  // Divide by this to turn into Volt
+  float voltage_reference_ = BL0939_UREF;
+  // Divide by this to turn into Ampere
+  float current_reference_ = BL0939_IREF;
+  // Divide by this to turn into kWh
+  float energy_reference_ = BL0939_EREF;
+
+  static uint32_t to_uint32_t(ube24_t input);
+
+  static int32_t to_int32_t(sbe24_t input);
+
+  static bool validate_checksum(const DataPacket *data);
+
+  void received_package_(const DataPacket *data) const;
+};
+}  // namespace SeeedEnergyMeter
+}  // namespace esphome

--- a/esphome/components/seeed_energymeter/seeedenergymeter.h
+++ b/esphome/components/seeed_energymeter/seeedenergymeter.h
@@ -13,9 +13,6 @@ namespace esphome {
 namespace SeeedEnergyMeter {
 
 // https://datasheet.lcsc.com/lcsc/2108071830_BL-Shanghai-Belling-BL0939_C2841044.pdf
-// (unfortunately chinese, but the formulas can be easily understood)
-// Sonoff Dual R3 V2 has the exact same resistor values for the current shunts (RL=1miliOhm)
-// and for the voltage divider (R1=0.51kOhm, R2=5*390kOhm)
 // as in the manufacturer's reference circuit, so the same formulas were used here (Vref=1.218V)
 
 static const float BL0939_IREF =  324004 * RL / Vref;

--- a/esphome/components/seeed_energymeter/seeedenergymeter.h
+++ b/esphome/components/seeed_energymeter/seeedenergymeter.h
@@ -7,7 +7,7 @@
 #define Vref 1.218
 #define R1  24.9
 #define R2  5 * 22000
-#define RL  0.25    // 0.5 * 1000 / 2000
+#define RL  0.3    // 0.6 * 1000 / 2000
 
 namespace esphome {
 namespace SeeedEnergyMeter {

--- a/esphome/components/seeed_energymeter/sensor.py
+++ b/esphome/components/seeed_energymeter/sensor.py
@@ -1,0 +1,119 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import sensor, uart
+from esphome.const import (
+    CONF_ID,
+    CONF_VOLTAGE,
+    DEVICE_CLASS_CURRENT,
+    DEVICE_CLASS_ENERGY,
+    DEVICE_CLASS_POWER,
+    DEVICE_CLASS_VOLTAGE,
+    STATE_CLASS_MEASUREMENT,
+    STATE_CLASS_TOTAL_INCREASING,
+    UNIT_AMPERE,
+    UNIT_KILOWATT_HOURS,
+    UNIT_VOLT,
+    UNIT_WATT,
+)
+
+DEPENDENCIES = ["uart"]
+
+CONF_CURRENT_1 = "current_1"
+CONF_CURRENT_2 = "current_2"
+CONF_ACTIVE_POWER_1 = "active_power_1"
+CONF_ACTIVE_POWER_2 = "active_power_2"
+CONF_ENERGY_1 = "energy_1"
+CONF_ENERGY_2 = "energy_2"
+CONF_ENERGY_TOTAL = "energy_total"
+
+SeeedEnergyMeter_ns = cg.esphome_ns.namespace("SeeedEnergyMeter")
+SeeedEnergyMeter = SeeedEnergyMeter_ns.class_("SeeedEnergyMeter", cg.PollingComponent, uart.UARTDevice)
+
+CONFIG_SCHEMA = (
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.declare_id(SeeedEnergyMeter),
+            cv.Optional(CONF_VOLTAGE): sensor.sensor_schema(
+                unit_of_measurement=UNIT_VOLT,
+                accuracy_decimals=1,
+                device_class=DEVICE_CLASS_VOLTAGE,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ),
+            cv.Optional(CONF_CURRENT_1): sensor.sensor_schema(
+                unit_of_measurement=UNIT_AMPERE,
+                accuracy_decimals=2,
+                device_class=DEVICE_CLASS_CURRENT,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ),
+            cv.Optional(CONF_CURRENT_2): sensor.sensor_schema(
+                unit_of_measurement=UNIT_AMPERE,
+                accuracy_decimals=2,
+                device_class=DEVICE_CLASS_CURRENT,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ),
+            cv.Optional(CONF_ACTIVE_POWER_1): sensor.sensor_schema(
+                unit_of_measurement=UNIT_WATT,
+                accuracy_decimals=0,
+                device_class=DEVICE_CLASS_POWER,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ),
+            cv.Optional(CONF_ACTIVE_POWER_2): sensor.sensor_schema(
+                unit_of_measurement=UNIT_WATT,
+                accuracy_decimals=0,
+                device_class=DEVICE_CLASS_POWER,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ),
+            cv.Optional(CONF_ENERGY_1): sensor.sensor_schema(
+                unit_of_measurement=UNIT_KILOWATT_HOURS,
+                accuracy_decimals=3,
+                device_class=DEVICE_CLASS_ENERGY,
+                state_class=STATE_CLASS_TOTAL_INCREASING,
+            ),
+            cv.Optional(CONF_ENERGY_2): sensor.sensor_schema(
+                unit_of_measurement=UNIT_KILOWATT_HOURS,
+                accuracy_decimals=3,
+                device_class=DEVICE_CLASS_ENERGY,
+                state_class=STATE_CLASS_TOTAL_INCREASING,
+            ),
+            cv.Optional(CONF_ENERGY_TOTAL): sensor.sensor_schema(
+                unit_of_measurement=UNIT_KILOWATT_HOURS,
+                accuracy_decimals=3,
+                device_class=DEVICE_CLASS_ENERGY,
+                state_class=STATE_CLASS_TOTAL_INCREASING,
+            ),
+        }
+    )
+    .extend(cv.polling_component_schema("60s"))
+    .extend(uart.UART_DEVICE_SCHEMA)
+)
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+    await uart.register_uart_device(var, config)
+
+    if voltage_config := config.get(CONF_VOLTAGE):
+        sens = await sensor.new_sensor(voltage_config)
+        cg.add(var.set_voltage_sensor(sens))
+    if current_1_config := config.get(CONF_CURRENT_1):
+        sens = await sensor.new_sensor(current_1_config)
+        cg.add(var.set_current_sensor_1(sens))
+    if current_2_config := config.get(CONF_CURRENT_2):
+        sens = await sensor.new_sensor(current_2_config)
+        cg.add(var.set_current_sensor_2(sens))
+    if active_power_1_config := config.get(CONF_ACTIVE_POWER_1):
+        sens = await sensor.new_sensor(active_power_1_config)
+        cg.add(var.set_power_sensor_1(sens))
+    if active_power_2_config := config.get(CONF_ACTIVE_POWER_2):
+        sens = await sensor.new_sensor(active_power_2_config)
+        cg.add(var.set_power_sensor_2(sens))
+    if energy_1_config := config.get(CONF_ENERGY_1):
+        sens = await sensor.new_sensor(energy_1_config)
+        cg.add(var.set_energy_sensor_1(sens))
+    if energy_2_config := config.get(CONF_ENERGY_2):
+        sens = await sensor.new_sensor(energy_2_config)
+        cg.add(var.set_energy_sensor_2(sens))
+    if energy_total_config := config.get(CONF_ENERGY_TOTAL):
+        sens = await sensor.new_sensor(energy_total_config)
+        cg.add(var.set_energy_sensor_sum(sens))


### PR DESCRIPTION
# What does this implement/fix?

- Added seeed_energymeter sensor, which is based on the current transformer solution of bl0939 and can provide higher power measurement accuracy.
- add epaper,it is an ink screen driver
## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other


## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml for seeed_energymeter sensor
uart:
  tx_pin: GPIO16
  rx_pin: GPIO17
  baud_rate: 4800

sensor:
  - platform: seeed_energymeter
    voltage:
      name: 'Voltage'
    current_1:
      name: 'Current 1'
    current_2:
      name: 'Current 2'
    active_power_1:
      name: 'Active Power 1'
    active_power_2:
      name: 'Active Power 2'
    energy_1:
      name: 'Energy 1'
    energy_2:
      name: 'Energy 2'
    energy_total:
      name: 'Energy Total'
    update_interval: 2s
```

```yaml
# Example config.yaml for epaper
captive_portal:

font:
  - file: "gfonts://Inter@700"
    id: font1
    size: 24

spi:
  clk_pin: GPIO8
  mosi_pin: GPIO10

display:
  - platform: epaper
    cs_pin: GPIO3
    dc_pin: GPIO5
    busy_pin: GPIO4
    reset_pin: GPIO2
    model: 7.50inv2    
    update_interval: 30s
    lambda: |-
      it.print(0, 0, id(font1), "Hello World!");
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
