### PR TITLE
Bump openssh-client to 1:9.2p1-2+deb12u4 to fix docker builds

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -35,7 +35,7 @@ RUN \
         iputils-ping=3:20221126-1+deb12u1 \
         git=1:2.39.5-0+deb12u1 \
         curl=7.88.1-10+deb12u8 \
-        openssh-client=1:9.2p1-2+deb12u3 \
+        openssh-client=1:9.2p1-2+deb12u4 \
         python3-cffi=1.15.1-5 \
         libcairo2=1.16.0-7 \
         libmagic1=1:5.44-3 \


### PR DESCRIPTION
# What does this implement/fix?

Bump openssh-client to 1:9.2p1-2+deb12u4 to fix docker builds
## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
