### PR TITLE
2025.2.0b6

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -35,7 +35,7 @@ RUN \
         iputils-ping=3:20221126-1+deb12u1 \
         git=1:2.39.5-0+deb12u1 \
         curl=7.88.1-10+deb12u8 \
-        openssh-client=1:9.2p1-2+deb12u3 \
+        openssh-client=1:9.2p1-2+deb12u4 \
         python3-cffi=1.15.1-5 \
         libcairo2=1.16.0-7 \
         libmagic1=1:5.44-3 \

--- a/esphome/components/remote_base/toto_protocol.h
+++ b/esphome/components/remote_base/toto_protocol.h
@@ -36,7 +36,7 @@ template<typename... Ts> class TotoAction : public RemoteTransmitterActionBase<T
     data.rc_code_2 = this->rc_code_2_.value(x...);
     data.command = this->command_.value(x...);
     this->set_send_times(this->send_times_.value_or(x..., 3));
-    this->set_send_wait(this->send_wait_.value_or(x..., 32000));
+    this->set_send_wait(this->send_wait_.value_or(x..., 36000));
     TotoProtocol().encode(dst, data);
   }
 };

--- a/esphome/const.py
+++ b/esphome/const.py
@@ -1,6 +1,6 @@
 """Constants used by esphome."""
 
-__version__ = "2025.2.0b5"
+__version__ = "2025.2.0b6"
 
 ALLOWED_NAME_CHARS = "abcdefghijklmnopqrstuvwxyz0123456789-_"
 VALID_SUBSTITUTIONS_CHARACTERS = (

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ esptool==4.7.0
 click==8.1.7
 esphome-dashboard==20250212.0
 aioesphomeapi==29.1.0
-zeroconf==0.144.3
+zeroconf==0.145.1
 puremagic==1.27
 ruamel.yaml==0.18.6 # dashboard_import
 esphome-glyphsets==0.1.0


### PR DESCRIPTION
**Do not merge, release script will automatically merge**
## Full list of changes

### All changes

- Bump openssh-client to 1:9.2p1-2+deb12u4 to fix docker builds [esphome#8269](https://github.com/esphome/esphome/pull/8269)
- Increase default repeat delay for Toto remote transmitter protocol [esphome#8265](https://github.com/esphome/esphome/pull/8265)
- Bump zeroconf to 0.145.1 [esphome#8267](https://github.com/esphome/esphome/pull/8267)

<details>
<summary>Metadata</summary>

@coderabbitai ignore
</details>
