### PR TITLE
Add cv.deprecated and cv.removed to config validation

### DIFF
--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -2266,8 +2266,8 @@ def rename_key(old_key, new_key):
 
 def _deprecated_or_removed(
     key: str,
-    replacement_key: str | None,
-    default: Any | None,
+    replacement_key: Optional[str],
+    default: Optional[Any],
     raise_if_present: bool,
     option_removed: bool,
 ) -> Callable[[dict], dict]:
@@ -2337,9 +2337,9 @@ def _deprecated_or_removed(
 
 def deprecated(
     key: str,
-    replacement_key: str | None = None,
-    default: Any | None = None,
-    raise_if_present: bool | None = False,
+    replacement_key: Optional[str] = None,
+    default: Optional[Any] = None,
+    raise_if_present: Optional[bool] = False,
 ) -> Callable[[dict], dict]:
     """Log key as deprecated and provide a replacement (if exists).
 
@@ -2363,8 +2363,8 @@ def deprecated(
 
 def removed(
     key: str,
-    default: Any | None = None,
-    raise_if_present: bool | None = True,
+    default: Optional[Any] = None,
+    raise_if_present: Optional[bool] = True,
 ) -> Callable[[dict], dict]:
     """Log key as deprecated and fail the config validation.
 

--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -1,5 +1,7 @@
 """Helpers for config validation using voluptuous."""
 
+from __future__ import annotations
+
 from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime
@@ -2040,7 +2042,7 @@ class Version:
         return f"{self.major}.{self.minor}.{self.patch}"
 
     @classmethod
-    def parse(cls, value: str) -> "Version":
+    def parse(cls, value: str) -> Version:
         match = re.match(r"^(\d+).(\d+).(\d+)-?\w*$", value)
         if match is None:
             raise ValueError(f"Not a valid version number {value}")

--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -8,6 +8,7 @@ import logging
 import os
 import re
 from string import ascii_letters, digits
+from typing import Callable
 import uuid as uuid_
 
 import voluptuous as vol
@@ -87,6 +88,8 @@ from esphome.schema_extractors import (
 from esphome.util import parse_esphome_version
 from esphome.voluptuous_schema import _Schema
 from esphome.yaml_util import make_data_base
+
+from .frame import get_component_logger
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -2259,3 +2262,120 @@ def rename_key(old_key, new_key):
         return config
 
     return validator
+
+
+def _deprecated_or_removed(
+    key: str,
+    replacement_key: str | None,
+    default: Any | None,
+    raise_if_present: bool,
+    option_removed: bool,
+) -> Callable[[dict], dict]:
+    """Log key as deprecated and provide a replacement (if exists) or fail.
+
+    Expected behavior:
+        - Outputs or throws the appropriate deprecation warning if key is detected
+        - Outputs or throws the appropriate error if key is detected
+          and removed from support
+        - Processes schema moving the value from key to replacement_key
+        - Processes schema changing nothing if only replacement_key provided
+        - No warning if only replacement_key provided
+        - No warning if neither key nor replacement_key are provided
+            - Adds replacement_key with default value in this case
+    """
+
+    def validator(config: dict) -> dict:
+        """Check if key is in config and log warning or error."""
+        if key in config:
+            if option_removed:
+                level = logging.ERROR
+                option_status = "has been removed"
+            else:
+                level = logging.WARNING
+                option_status = "is deprecated"
+
+            try:
+                # near = (
+                #    f"near {config.__config_file__}"  # type: ignore[attr-defined]
+                #    f":{config.__line__} "  # type: ignore[attr-defined]
+                # )
+                near = ""  # TODO: fix this
+            except AttributeError:
+                near = ""
+            arguments: tuple[str, ...]
+            if replacement_key:
+                warning = "The '%s' option %s%s, please replace it with '%s'"
+                arguments = (key, near, option_status, replacement_key)
+            else:
+                warning = (
+                    "The '%s' option %s%s, please remove it from your configuration"
+                )
+                arguments = (key, near, option_status)
+
+            if raise_if_present:
+                raise vol.Invalid(warning % arguments)
+
+            get_component_logger(__name__).log(level, warning, *arguments)
+            value = config[key]
+            if replacement_key or option_removed:
+                config.pop(key)
+        else:
+            value = default
+
+        keys = [key]
+        if replacement_key:
+            keys.append(replacement_key)
+            if value is not None and (
+                replacement_key not in config or default == config.get(replacement_key)
+            ):
+                config[replacement_key] = value
+
+        return has_at_most_one_key(*keys)(config)
+
+    return validator
+
+
+def deprecated(
+    key: str,
+    replacement_key: str | None = None,
+    default: Any | None = None,
+    raise_if_present: bool | None = False,
+) -> Callable[[dict], dict]:
+    """Log key as deprecated and provide a replacement (if exists).
+
+    Expected behavior:
+        - Outputs the appropriate deprecation warning if key is detected
+          or raises an exception
+        - Processes schema moving the value from key to replacement_key
+        - Processes schema changing nothing if only replacement_key provided
+        - No warning if only replacement_key provided
+        - No warning if neither key nor replacement_key are provided
+            - Adds replacement_key with default value in this case
+    """
+    return _deprecated_or_removed(
+        key,
+        replacement_key=replacement_key,
+        default=default,
+        raise_if_present=raise_if_present or False,
+        option_removed=False,
+    )
+
+
+def removed(
+    key: str,
+    default: Any | None = None,
+    raise_if_present: bool | None = True,
+) -> Callable[[dict], dict]:
+    """Log key as deprecated and fail the config validation.
+
+    Expected behavior:
+        - Outputs the appropriate error if key is detected and removed from
+          support or raises an exception.
+    """
+    return _deprecated_or_removed(
+        key,
+        replacement_key=None,
+        default=default,
+        raise_if_present=raise_if_present or False,
+        option_removed=True,
+    )

--- a/esphome/frame.py
+++ b/esphome/frame.py
@@ -8,7 +8,7 @@ import sys
 from types import FrameType
 
 
-@dataclass(kw_only=True)
+@dataclass()
 class ComponentFrame:
     """Component frame container."""
 
@@ -37,7 +37,7 @@ class ComponentFrame:
 def get_current_frame(depth: int = 0) -> FrameType:
     """Return the current frame."""
     # Add one to depth since get_current_frame is included
-    return sys._getframe(depth + 1)  # noqa: SLF001
+    return sys._getframe(depth + 1)  # pylint: disable=protected-access
 
 
 class MissingComponentFrame(Exception):

--- a/esphome/frame.py
+++ b/esphome/frame.py
@@ -97,7 +97,6 @@ def get_component_logger(fallback_name: str) -> logging.Logger:
 
     If Python is unable to access the sources files, the call stack frame
     will be missing information, so let's guard by requiring a fallback name.
-    https://github.com/home-assistant/core/issues/24982
     """
     try:
         component_frame = get_component_frame()

--- a/esphome/frame.py
+++ b/esphome/frame.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from functools import cached_property
+import linecache
+import logging
+import sys
+from types import FrameType
+
+
+@dataclass(kw_only=True)
+class ComponentFrame:
+    """Component frame container."""
+
+    custom_component: bool
+    component: str
+    module: str | None
+    relative_filename: str
+    frame: FrameType
+
+    @cached_property
+    def line_number(self) -> int:
+        """Return the line number of the frame."""
+        return self.frame.f_lineno
+
+    @cached_property
+    def filename(self) -> str:
+        """Return the filename of the frame."""
+        return self.frame.f_code.co_filename
+
+    @cached_property
+    def line(self) -> str:
+        """Return the line of the frame."""
+        return (linecache.getline(self.filename, self.line_number) or "?").strip()
+
+
+def get_current_frame(depth: int = 0) -> FrameType:
+    """Return the current frame."""
+    # Add one to depth since get_current_frame is included
+    return sys._getframe(depth + 1)  # noqa: SLF001
+
+
+class MissingComponentFrame(Exception):
+    """Raised when no component is found in the frame."""
+
+
+def get_component_frame(exclude_components: set | None = None) -> ComponentFrame:
+    """Return the frame, component and component path of the current stack frame."""
+    found_frame = None
+    if not exclude_components:
+        exclude_components = set()
+
+    frame: FrameType | None = get_current_frame()
+    while frame is not None:
+        filename = frame.f_code.co_filename
+
+        for path in ("custom_components/", "esphome/components/"):
+            try:
+                index = filename.index(path)
+                start = index + len(path)
+                end = filename.index("/", start)
+                component = filename[start:end]
+                if component not in exclude_components:
+                    found_frame = frame
+
+                break
+            except ValueError:
+                continue
+
+        if found_frame is not None:
+            break
+
+        frame = frame.f_back
+
+    if found_frame is None:
+        raise MissingComponentFrame
+
+    found_module: str | None = None
+    for module, module_obj in dict(sys.modules).items():
+        if not hasattr(module_obj, "__file__"):
+            continue
+        if module_obj.__file__ == found_frame.f_code.co_filename:
+            found_module = module
+            break
+
+    return ComponentFrame(
+        custom_component=path == "custom_components/",
+        component=component,
+        module=found_module,
+        relative_filename=found_frame.f_code.co_filename[index:],
+        frame=found_frame,
+    )
+
+
+def get_component_logger(fallback_name: str) -> logging.Logger:
+    """Return a logger by checking the current component frame.
+
+    If Python is unable to access the sources files, the call stack frame
+    will be missing information, so let's guard by requiring a fallback name.
+    https://github.com/home-assistant/core/issues/24982
+    """
+    try:
+        component_frame = get_component_frame()
+    except MissingComponentFrame:
+        return logging.getLogger(fallback_name)
+
+    if component_frame.custom_component:
+        logger_name = f"custom_components.{component_frame.component}"
+    else:
+        logger_name = f"esphome.components.{component_frame.component}"
+
+    return logging.getLogger(logger_name)


### PR DESCRIPTION

# What does this implement/fix?

These are adapted from HA core

Currently we remove keys from YAML which breaks user configurations without any notice.

In HA we mark these as deprecated or removed which gives users time to adapt.

Example anyone using `esp32_rmt` got a surprise in 2025.2.x that `CONF_RMT_CHANNEL` removed so their YAML no longer validates. It could have been marked as `cv.removed` since its no longer needed if we had `cv.removed` at the time.

https://github.com/esphome/esphome/pull/7770/files#diff-8d5bfacdc6c7d62624eeb1029bdcec74878e95cf16fc5e421c2fb2c87b879680L75

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
