### PR TITLE
Add support for deep sleep on ESP32-H2 and add ext1 wakeup reason to make the H2 useable.

### DIFF
--- a/esphome/components/deep_sleep/__init__.py
+++ b/esphome/components/deep_sleep/__init__.py
@@ -157,6 +157,7 @@ CONF_TOUCH_WAKEUP = "touch_wakeup"
 CONF_DEFAULT = "default"
 CONF_GPIO_WAKEUP_REASON = "gpio_wakeup_reason"
 CONF_TOUCH_WAKEUP_REASON = "touch_wakeup_reason"
+CONF_EXT1_WAKEUP_REASON = "ext1_wakeup_reason"
 CONF_UNTIL = "until"
 
 WAKEUP_CAUSES_SCHEMA = cv.Schema(
@@ -164,6 +165,7 @@ WAKEUP_CAUSES_SCHEMA = cv.Schema(
         cv.Required(CONF_DEFAULT): cv.positive_time_period_milliseconds,
         cv.Optional(CONF_TOUCH_WAKEUP_REASON): cv.positive_time_period_milliseconds,
         cv.Optional(CONF_GPIO_WAKEUP_REASON): cv.positive_time_period_milliseconds,
+        cv.Optional(CONF_EXT1_WAKEUP_REASON): cv.positive_time_period_milliseconds,
     }
 )
 
@@ -232,6 +234,12 @@ async def to_code(config):
                     "gpio_cause",
                     run_duration_config.get(
                         CONF_GPIO_WAKEUP_REASON, default_run_duration
+                    ),
+                ),
+                (
+                    "ext1_cause",
+                    run_duration_config.get(
+                        CONF_EXT1_WAKEUP_REASON, default_run_duration
                     ),
                 ),
             )

--- a/esphome/components/deep_sleep/deep_sleep_component.h
+++ b/esphome/components/deep_sleep/deep_sleep_component.h
@@ -48,7 +48,7 @@ struct WakeupCauseToRunDuration {
   uint32_t touch_cause;
   // Run duration if woken up by GPIO pins.
   uint32_t gpio_cause;
-  // Run duration if woken up by ext1 pins.
+  // Run duration if woken up by EXT1 pins.
   uint32_t ext1_cause;
 };
 

--- a/esphome/components/deep_sleep/deep_sleep_component.h
+++ b/esphome/components/deep_sleep/deep_sleep_component.h
@@ -48,6 +48,8 @@ struct WakeupCauseToRunDuration {
   uint32_t touch_cause;
   // Run duration if woken up by GPIO pins.
   uint32_t gpio_cause;
+  // Run duration if woken up by ext1 pins.
+  uint32_t ext1_cause;
 };
 
 #endif

--- a/esphome/components/deep_sleep/deep_sleep_esp32.cpp
+++ b/esphome/components/deep_sleep/deep_sleep_esp32.cpp
@@ -69,7 +69,7 @@ bool DeepSleepComponent::prepare_to_sleep_() {
 }
 
 void DeepSleepComponent::deep_sleep_() {
-#if !defined(USE_ESP32_VARIANT_ESP32C3) && !defined(USE_ESP32_VARIANT_ESP32C6) && !defined(USE_ESP32_VARIANT_ESP32H2) 
+#if !defined(USE_ESP32_VARIANT_ESP32C3) && !defined(USE_ESP32_VARIANT_ESP32C6) && !defined(USE_ESP32_VARIANT_ESP32H2)
   if (this->sleep_duration_.has_value())
     esp_sleep_enable_timer_wakeup(*this->sleep_duration_);
   if (this->wakeup_pin_ != nullptr) {
@@ -88,7 +88,7 @@ void DeepSleepComponent::deep_sleep_() {
     esp_sleep_pd_config(ESP_PD_DOMAIN_RTC_PERIPH, ESP_PD_OPTION_ON);
   }
 #endif
-#if defined(USE_ESP32_VARIANT_ESP32H2) 
+#if defined(USE_ESP32_VARIANT_ESP32H2)
   if (this->sleep_duration_.has_value())
     esp_sleep_enable_timer_wakeup(*this->sleep_duration_);
 

--- a/esphome/components/deep_sleep/deep_sleep_esp32.cpp
+++ b/esphome/components/deep_sleep/deep_sleep_esp32.cpp
@@ -13,6 +13,7 @@ optional<uint32_t> DeepSleepComponent::get_run_duration_() const {
     switch (wakeup_cause) {
       case ESP_SLEEP_WAKEUP_EXT0:
       case ESP_SLEEP_WAKEUP_EXT1:
+        return this->wakeup_cause_to_run_duration_->ext1_cause;
       case ESP_SLEEP_WAKEUP_GPIO:
         return this->wakeup_cause_to_run_duration_->gpio_cause;
       case ESP_SLEEP_WAKEUP_TOUCHPAD:
@@ -30,7 +31,9 @@ void DeepSleepComponent::set_wakeup_pin_mode(WakeupPinMode wakeup_pin_mode) {
 
 #if !defined(USE_ESP32_VARIANT_ESP32C3) && !defined(USE_ESP32_VARIANT_ESP32C6)
 void DeepSleepComponent::set_ext1_wakeup(Ext1Wakeup ext1_wakeup) { this->ext1_wakeup_ = ext1_wakeup; }
+#endif
 
+#if !defined(USE_ESP32_VARIANT_ESP32C3) && !defined(USE_ESP32_VARIANT_ESP32C6) && !defined(USE_ESP32_VARIANT_ESP32H2)
 void DeepSleepComponent::set_touch_wakeup(bool touch_wakeup) { this->touch_wakeup_ = touch_wakeup; }
 #endif
 
@@ -47,6 +50,7 @@ void DeepSleepComponent::dump_config_platform_() {
                   this->wakeup_cause_to_run_duration_->default_cause);
     ESP_LOGCONFIG(TAG, "  Touch Wakeup Run Duration: %" PRIu32 " ms", this->wakeup_cause_to_run_duration_->touch_cause);
     ESP_LOGCONFIG(TAG, "  GPIO Wakeup Run Duration: %" PRIu32 " ms", this->wakeup_cause_to_run_duration_->gpio_cause);
+    ESP_LOGCONFIG(TAG, "  EXT1 Wakeup Run Duration: %" PRIu32 " ms", this->wakeup_cause_to_run_duration_->ext1_cause);
   }
 }
 
@@ -65,7 +69,7 @@ bool DeepSleepComponent::prepare_to_sleep_() {
 }
 
 void DeepSleepComponent::deep_sleep_() {
-#if !defined(USE_ESP32_VARIANT_ESP32C3) && !defined(USE_ESP32_VARIANT_ESP32C6)
+#if !defined(USE_ESP32_VARIANT_ESP32C3) && !defined(USE_ESP32_VARIANT_ESP32C6) && !defined(USE_ESP32_VARIANT_ESP32H2) 
   if (this->sleep_duration_.has_value())
     esp_sleep_enable_timer_wakeup(*this->sleep_duration_);
   if (this->wakeup_pin_ != nullptr) {
@@ -82,6 +86,14 @@ void DeepSleepComponent::deep_sleep_() {
   if (this->touch_wakeup_.has_value() && *(this->touch_wakeup_)) {
     esp_sleep_enable_touchpad_wakeup();
     esp_sleep_pd_config(ESP_PD_DOMAIN_RTC_PERIPH, ESP_PD_OPTION_ON);
+  }
+#endif
+#if defined(USE_ESP32_VARIANT_ESP32H2) 
+  if (this->sleep_duration_.has_value())
+    esp_sleep_enable_timer_wakeup(*this->sleep_duration_);
+
+  if (this->ext1_wakeup_.has_value()) {
+    esp_sleep_enable_ext1_wakeup(this->ext1_wakeup_->mask, this->ext1_wakeup_->wakeup_mode);
   }
 #endif
 #if defined(USE_ESP32_VARIANT_ESP32C3) || defined(USE_ESP32_VARIANT_ESP32C6)

--- a/tests/component_tests/deep_sleep/test_deep_sleep.py
+++ b/tests/component_tests/deep_sleep/test_deep_sleep.py
@@ -40,5 +40,6 @@ def test_deep_sleep_run_duration_dictionary(generate_main):
         "    .default_cause = 10000,\n"
         "    .touch_cause = 10000,\n"
         "    .gpio_cause = 30000,\n"
+        "    .ext1_cause = 10000,\n"
         "});"
     ) in main_cpp


### PR DESCRIPTION
# What does this implement/fix?

Add support for deep sleep on the ESP32-H2. Since the H2 variant does not support GPIO wakeup but only EXT1, EXT1 wakeup reason is added as well so that the user can implement an IO triggered wakeup.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/issues/issues/6752

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#4686

## Test Environment

- [X] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
