### PR TITLE
Fix bluetooth race when disconnect called while still connecting

### DIFF
--- a/esphome/components/esp32_ble_client/ble_client_base.cpp
+++ b/esphome/components/esp32_ble_client/ble_client_base.cpp
@@ -201,8 +201,9 @@ bool BLEClientBase::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_
         break;
       }
       if (this->state == espbt::ClientState::DISCONNECTING) {
-        // Disconnect we requested before after connecting started,
-        // but before the connection was established.
+        // Disconnect was requested before after connecting started,
+        // but before the connection was established. Now that we have
+        // this->conn_id_ set, we can disconnect it.
         this->_unconditional_disconnect();
         this->conn_id_ = UNSET_CONN_ID;
         break;
@@ -227,8 +228,9 @@ bool BLEClientBase::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_
         return false;
       this->log_event_("ESP_GATTC_CONNECT_EVT");
       if (this->state == espbt::ClientState::DISCONNECTING) {
-        // Disconnect we requested before after connecting started,
-        // but before the connection was established.
+        // Disconnect was requested before after connecting started,
+        // but before the connection was established. Now that we have
+        // this->conn_id_ set, we can disconnect it.
         this->_unconditional_disconnect();
         this->conn_id_ = UNSET_CONN_ID;
       }

--- a/esphome/components/esp32_ble_client/ble_client_base.cpp
+++ b/esphome/components/esp32_ble_client/ble_client_base.cpp
@@ -143,7 +143,10 @@ void BLEClientBase::unconditional_disconnect() {
   }
   auto err = esp_ble_gattc_close(this->gattc_if_, this->conn_id_);
   if (err != ESP_OK) {
-    ESP_LOGW(TAG, "[%d] [%s] esp_ble_gattc_close error, err=%d", this->connection_index_, this->address_str_.c_str(),
+    // This is a fatal error, we can't do anything about it.
+    // In the future we might consider App.reboot() here since
+    // the BLE stack is in an indeterminate state.
+    ESP_LOGE(TAG, "[%d] [%s] esp_ble_gattc_close error, err=%d", this->connection_index_, this->address_str_.c_str(),
              err);
   }
 

--- a/esphome/components/esp32_ble_client/ble_client_base.cpp
+++ b/esphome/components/esp32_ble_client/ble_client_base.cpp
@@ -249,6 +249,7 @@ bool BLEClientBase::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_
     case ESP_GATTC_CONNECT_EVT: {
       if (!this->check_addr(param->connect.remote_bda))
         return false;
+      this->conn_id_ = param->connect.conn_id;
       this->log_event_("ESP_GATTC_CONNECT_EVT");
       if (this->want_disconnect_) {
         // Disconnect was requested after connecting started,

--- a/esphome/components/esp32_ble_client/ble_client_base.cpp
+++ b/esphome/components/esp32_ble_client/ble_client_base.cpp
@@ -130,10 +130,10 @@ void BLEClientBase::disconnect() {
     this->set_state(espbt::ClientState::DISCONNECTING);
     return;
   }
-  this->unconditional_disconnect();
+  this->_unconditional_disconnect();
 }
 
-void BLEClientBase::unconditional_disconnect() {
+void BLEClientBase::_unconditional_disconnect() {
   // Disconnect without checking the state.
   ESP_LOGI(TAG, "[%d] [%s] Disconnecting.", this->connection_index_, this->address_str_.c_str());
   auto err = esp_ble_gattc_close(this->gattc_if_, this->conn_id_);
@@ -203,7 +203,7 @@ bool BLEClientBase::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_
       if (this->state == espbt::ClientState::DISCONNECTING) {
         // Disconnect we requested before after connecting started,
         // but before the connection was established.
-        this->unconditional_disconnect();
+        this->_unconditional_disconnect();
         break;
       }
       auto ret = esp_ble_gattc_send_mtu_req(this->gattc_if_, param->open.conn_id);
@@ -228,8 +228,7 @@ bool BLEClientBase::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_
       if (this->state == espbt::ClientState::DISCONNECTING) {
         // Disconnect we requested before after connecting started,
         // but before the connection was established.
-        this->unconditional_disconnect();
-        break;
+        this->_unconditional_disconnect();
       }
       break;
     }

--- a/esphome/components/esp32_ble_client/ble_client_base.cpp
+++ b/esphome/components/esp32_ble_client/ble_client_base.cpp
@@ -145,6 +145,7 @@ void BLEClientBase::_unconditional_disconnect() {
   if (this->state_ == espbt::ClientState::SEARCHING || this->state_ == espbt::ClientState::READY_TO_CONNECT ||
       this->state_ == espbt::ClientState::DISCOVERED || this->state_ == espbt::ClientState::DISCONNECTING) {
     this->set_address(0);
+    this->conn_id_ = UNSET_CONN_ID;
     this->set_state(espbt::ClientState::IDLE);
   } else {
     this->set_state(espbt::ClientState::DISCONNECTING);

--- a/esphome/components/esp32_ble_client/ble_client_base.cpp
+++ b/esphome/components/esp32_ble_client/ble_client_base.cpp
@@ -221,6 +221,24 @@ bool BLEClientBase::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_
       this->log_event_("ESP_GATTC_OPEN_EVT");
       this->conn_id_ = param->open.conn_id;
       this->service_count_ = 0;
+      if (this->state_ != espbt::ClientState::CONNECTING) {
+        // This should not happen but lets log it in case it does
+        // because it means we have a bad assumption about how the
+        // ESP BT stack works.
+        if (this->state_ == espbt::ClientState::CONNECTED) {
+          ESP_LOGE(TAG, "[%d] [%s] Got ESP_GATTC_OPEN_EVT while already connected, status=%d", this->connection_index_,
+                   this->address_str_.c_str(), param->open.status);
+        } else if (this->state_ == espbt::ClientState::ESTABLISHED) {
+          ESP_LOGE(TAG, "[%d] [%s] Got ESP_GATTC_OPEN_EVT while already established, status=%d",
+                   this->connection_index_, this->address_str_.c_str(), param->open.status);
+        } else if (this->state_ == espbt::ClientState::DISCONNECTING) {
+          ESP_LOGE(TAG, "[%d] [%s] Got ESP_GATTC_OPEN_EVT while disconnecting, status=%d", this->connection_index_,
+                   this->address_str_.c_str(), param->open.status);
+        } else {
+          ESP_LOGE(TAG, "[%d] [%s] Got ESP_GATTC_OPEN_EVT while not in connecting state, status=%d",
+                   this->connection_index_, this->address_str_.c_str(), param->open.status);
+        }
+      }
       if (param->open.status != ESP_GATT_OK && param->open.status != ESP_GATT_ALREADY_OPEN) {
         ESP_LOGW(TAG, "[%d] [%s] Connection failed, status=%d", this->connection_index_, this->address_str_.c_str(),
                  param->open.status);

--- a/esphome/components/esp32_ble_client/ble_client_base.cpp
+++ b/esphome/components/esp32_ble_client/ble_client_base.cpp
@@ -126,8 +126,9 @@ void BLEClientBase::disconnect() {
   if (this->state_ == espbt::ClientState::IDLE || this->state_ == espbt::ClientState::DISCONNECTING)
     return;
   if (this->state_ == espbt::ClientState::CONNECTING || this->conn_id_ == UNSET_CONN_ID) {
-    ESP_LOGW(TAG, "[%d] [%s] Disconnecting before connected", this->connection_index_, this->address_str_.c_str());
-    this->set_state(espbt::ClientState::DISCONNECTING);
+    ESP_LOGW(TAG, "[%d] [%s] Disconnecting before connected, disconnect scheduled", this->connection_index_,
+             this->address_str_.c_str());
+    this->want_disconnect_ = true;
     return;
   }
   this->unconditional_disconnect();
@@ -137,6 +138,10 @@ void BLEClientBase::unconditional_disconnect() {
   // Disconnect without checking the state.
   ESP_LOGI(TAG, "[%d] [%s] Disconnecting (conn_id: %d).", this->connection_index_, this->address_str_.c_str(),
            this->conn_id_);
+  if (this->state_ == espbt::ClientState::CONNECTING) {
+    ESP_LOGE(TAG, "[%d] [%s] Cannot disconnect while connecting.", this->connection_index_, this->address_str_.c_str());
+    return;
+  }
   if (this->conn_id_ == UNSET_CONN_ID) {
     ESP_LOGE(TAG, "[%d] [%s] No connection ID set, cannot disconnect.", this->connection_index_,
              this->address_str_.c_str());
@@ -213,7 +218,7 @@ bool BLEClientBase::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_
         this->set_state(espbt::ClientState::IDLE);
         break;
       }
-      if (this->state_ == espbt::ClientState::DISCONNECTING) {
+      if (this->want_disconnect_) {
         // Disconnect was requested after connecting started,
         // but before the connection was established. Now that we have
         // this->conn_id_ set, we can disconnect it.
@@ -240,7 +245,7 @@ bool BLEClientBase::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_
       if (!this->check_addr(param->connect.remote_bda))
         return false;
       this->log_event_("ESP_GATTC_CONNECT_EVT");
-      if (this->state_ == espbt::ClientState::DISCONNECTING) {
+      if (this->want_disconnect_) {
         // Disconnect was requested after connecting started,
         // but before the connection was established. Now that we have
         // this->conn_id_ set, we can disconnect it.

--- a/esphome/components/esp32_ble_client/ble_client_base.cpp
+++ b/esphome/components/esp32_ble_client/ble_client_base.cpp
@@ -147,10 +147,6 @@ void BLEClientBase::unconditional_disconnect() {
   // Disconnect without checking the state.
   ESP_LOGI(TAG, "[%d] [%s] Disconnecting (conn_id: %d).", this->connection_index_, this->address_str_.c_str(),
            this->conn_id_);
-  if (this->state_ == espbt::ClientState::CONNECTING) {
-    ESP_LOGE(TAG, "[%d] [%s] Cannot disconnect while connecting.", this->connection_index_, this->address_str_.c_str());
-    return;
-  }
   if (this->state_ == espbt::ClientState::DISCONNECTING) {
     ESP_LOGE(TAG, "[%d] [%s] Tried to disconnect while already disconnecting.", this->connection_index_,
              this->address_str_.c_str());

--- a/esphome/components/esp32_ble_client/ble_client_base.cpp
+++ b/esphome/components/esp32_ble_client/ble_client_base.cpp
@@ -135,7 +135,7 @@ void BLEClientBase::disconnect() {
   }
   ESP_LOGI(TAG, "[%d] [%s] Disconnecting.", this->connection_index_, this->address_str_.c_str());
   if (this->state_ == espbt::ClientState::CONNECTING || this->conn_id_ == UNSET_CONN_ID) {
-    ESP_LOGW(TAG, "[%d] [%s] Disconnecting before connected, disconnect scheduled", this->connection_index_,
+    ESP_LOGW(TAG, "[%d] [%s] Disconnecting before connected, disconnect scheduled.", this->connection_index_,
              this->address_str_.c_str());
     this->want_disconnect_ = true;
     return;

--- a/esphome/components/esp32_ble_client/ble_client_base.cpp
+++ b/esphome/components/esp32_ble_client/ble_client_base.cpp
@@ -142,6 +142,11 @@ void BLEClientBase::unconditional_disconnect() {
     ESP_LOGE(TAG, "[%d] [%s] Cannot disconnect while connecting.", this->connection_index_, this->address_str_.c_str());
     return;
   }
+  if (this->state_ == espbt::ClientState::DISCONNECTING) {
+    ESP_LOGE(TAG, "[%d] [%s] Tried to disconnect while already disconnecting.", this->connection_index_,
+             this->address_str_.c_str());
+    return;
+  }
   if (this->conn_id_ == UNSET_CONN_ID) {
     ESP_LOGE(TAG, "[%d] [%s] No connection ID set, cannot disconnect.", this->connection_index_,
              this->address_str_.c_str());
@@ -161,7 +166,7 @@ void BLEClientBase::unconditional_disconnect() {
   }
 
   if (this->state_ == espbt::ClientState::SEARCHING || this->state_ == espbt::ClientState::READY_TO_CONNECT ||
-      this->state_ == espbt::ClientState::DISCOVERED || this->state_ == espbt::ClientState::DISCONNECTING) {
+      this->state_ == espbt::ClientState::DISCOVERED) {
     this->set_address(0);
     this->set_state(espbt::ClientState::IDLE);
   } else {

--- a/esphome/components/esp32_ble_client/ble_client_base.cpp
+++ b/esphome/components/esp32_ble_client/ble_client_base.cpp
@@ -125,6 +125,7 @@ esp_err_t BLEClientBase::pair() { return esp_ble_set_encryption(this->remote_bda
 void BLEClientBase::disconnect() {
   if (this->state_ == espbt::ClientState::IDLE || this->state_ == espbt::ClientState::DISCONNECTING)
     return;
+  ESP_LOGI(TAG, "[%d] [%s] Disconnecting.", this->connection_index_, this->address_str_.c_str());
   if (this->state_ == espbt::ClientState::CONNECTING || this->conn_id_ == UNSET_CONN_ID) {
     ESP_LOGW(TAG, "[%d] [%s] Disconnecting before connected, disconnect scheduled", this->connection_index_,
              this->address_str_.c_str());

--- a/esphome/components/esp32_ble_client/ble_client_base.cpp
+++ b/esphome/components/esp32_ble_client/ble_client_base.cpp
@@ -135,7 +135,8 @@ void BLEClientBase::disconnect() {
 
 void BLEClientBase::unconditional_disconnect() {
   // Disconnect without checking the state.
-  ESP_LOGI(TAG, "[%d] [%s] Disconnecting.", this->connection_index_, this->address_str_.c_str());
+  ESP_LOGI(TAG, "[%d] [%s] Disconnecting (conn_id: %d).", this->connection_index_, this->address_str_.c_str(),
+           this->conn_id_);
   if (this->conn_id_ == UNSET_CONN_ID) {
     ESP_LOGE(TAG, "[%d] [%s] No connection ID set, cannot disconnect.", this->connection_index_,
              this->address_str_.c_str());

--- a/esphome/components/esp32_ble_client/ble_client_base.cpp
+++ b/esphome/components/esp32_ble_client/ble_client_base.cpp
@@ -205,7 +205,7 @@ bool BLEClientBase::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_
         this->set_state(espbt::ClientState::IDLE);
         break;
       }
-      if (this->state == espbt::ClientState::DISCONNECTING) {
+      if (this->state_ == espbt::ClientState::DISCONNECTING) {
         // Disconnect was requested before after connecting started,
         // but before the connection was established. Now that we have
         // this->conn_id_ set, we can disconnect it.
@@ -232,7 +232,7 @@ bool BLEClientBase::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_
       if (!this->check_addr(param->connect.remote_bda))
         return false;
       this->log_event_("ESP_GATTC_CONNECT_EVT");
-      if (this->state == espbt::ClientState::DISCONNECTING) {
+      if (this->state_ == espbt::ClientState::DISCONNECTING) {
         // Disconnect was requested before after connecting started,
         // but before the connection was established. Now that we have
         // this->conn_id_ set, we can disconnect it.

--- a/esphome/components/esp32_ble_client/ble_client_base.cpp
+++ b/esphome/components/esp32_ble_client/ble_client_base.cpp
@@ -123,8 +123,16 @@ void BLEClientBase::connect() {
 esp_err_t BLEClientBase::pair() { return esp_ble_set_encryption(this->remote_bda_, ESP_BLE_SEC_ENCRYPT); }
 
 void BLEClientBase::disconnect() {
-  if (this->state_ == espbt::ClientState::IDLE || this->state_ == espbt::ClientState::DISCONNECTING)
+  if (this->state_ == espbt::ClientState::IDLE) {
+    ESP_LOGI(TAG, "[%d] [%s] Disconnect requested, but already disconnected.", this->connection_index_,
+             this->address_str_.c_str());
     return;
+  }
+  if (this->state_ == espbt::ClientState::DISCONNECTING) {
+    ESP_LOGI(TAG, "[%d] [%s] Disconnect requested, but already disconnecting.", this->connection_index_,
+             this->address_str_.c_str());
+    return;
+  }
   ESP_LOGI(TAG, "[%d] [%s] Disconnecting.", this->connection_index_, this->address_str_.c_str());
   if (this->state_ == espbt::ClientState::CONNECTING || this->conn_id_ == UNSET_CONN_ID) {
     ESP_LOGW(TAG, "[%d] [%s] Disconnecting before connected, disconnect scheduled", this->connection_index_,

--- a/esphome/components/esp32_ble_client/ble_client_base.cpp
+++ b/esphome/components/esp32_ble_client/ble_client_base.cpp
@@ -206,7 +206,7 @@ bool BLEClientBase::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_
         break;
       }
       if (this->state_ == espbt::ClientState::DISCONNECTING) {
-        // Disconnect was requested before after connecting started,
+        // Disconnect was requested after connecting started,
         // but before the connection was established. Now that we have
         // this->conn_id_ set, we can disconnect it.
         this->_unconditional_disconnect();
@@ -233,7 +233,7 @@ bool BLEClientBase::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_
         return false;
       this->log_event_("ESP_GATTC_CONNECT_EVT");
       if (this->state_ == espbt::ClientState::DISCONNECTING) {
-        // Disconnect was requested before after connecting started,
+        // Disconnect was requested after connecting started,
         // but before the connection was established. Now that we have
         // this->conn_id_ set, we can disconnect it.
         this->_unconditional_disconnect();

--- a/esphome/components/esp32_ble_client/ble_client_base.cpp
+++ b/esphome/components/esp32_ble_client/ble_client_base.cpp
@@ -127,8 +127,14 @@ void BLEClientBase::disconnect() {
     return;
   if (this->state_ == espbt::ClientState::CONNECTING || this->conn_id_ == UNSET_CONN_ID) {
     ESP_LOGW(TAG, "[%d] [%s] Disconnecting before connected", this->connection_index_, this->address_str_.c_str());
+    this->set_state(espbt::ClientState::DISCONNECTING);
     return;
   }
+  this->unconditional_disconnect();
+}
+
+void BLEClientBase::unconditional_disconnect() {
+  // Disconnect without checking the state.
   ESP_LOGI(TAG, "[%d] [%s] Disconnecting.", this->connection_index_, this->address_str_.c_str());
   auto err = esp_ble_gattc_close(this->gattc_if_, this->conn_id_);
   if (err != ESP_OK) {
@@ -137,7 +143,7 @@ void BLEClientBase::disconnect() {
   }
 
   if (this->state_ == espbt::ClientState::SEARCHING || this->state_ == espbt::ClientState::READY_TO_CONNECT ||
-      this->state_ == espbt::ClientState::DISCOVERED) {
+      this->state_ == espbt::ClientState::DISCOVERED || this->state_ == espbt::ClientState::DISCONNECTING) {
     this->set_address(0);
     this->set_state(espbt::ClientState::IDLE);
   } else {
@@ -194,6 +200,12 @@ bool BLEClientBase::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_
         this->set_state(espbt::ClientState::IDLE);
         break;
       }
+      if (this->state == espbt::ClientState::DISCONNECTING) {
+        // Disconnect we requested before after connecting started,
+        // but before the connection was established.
+        this->unconditional_disconnect();
+        break;
+      }
       auto ret = esp_ble_gattc_send_mtu_req(this->gattc_if_, param->open.conn_id);
       if (ret) {
         ESP_LOGW(TAG, "[%d] [%s] esp_ble_gattc_send_mtu_req failed, status=%x", this->connection_index_,
@@ -213,6 +225,12 @@ bool BLEClientBase::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_
       if (!this->check_addr(param->connect.remote_bda))
         return false;
       this->log_event_("ESP_GATTC_CONNECT_EVT");
+      if (this->state == espbt::ClientState::DISCONNECTING) {
+        // Disconnect we requested before after connecting started,
+        // but before the connection was established.
+        this->unconditional_disconnect();
+        break;
+      }
       break;
     }
     case ESP_GATTC_DISCONNECT_EVT: {

--- a/esphome/components/esp32_ble_client/ble_client_base.cpp
+++ b/esphome/components/esp32_ble_client/ble_client_base.cpp
@@ -130,10 +130,10 @@ void BLEClientBase::disconnect() {
     this->set_state(espbt::ClientState::DISCONNECTING);
     return;
   }
-  this->_unconditional_disconnect_();
+  this->unconditional_disconnect();
 }
 
-void BLEClientBase::_unconditional_disconnect_() {
+void BLEClientBase::unconditional_disconnect() {
   // Disconnect without checking the state.
   ESP_LOGI(TAG, "[%d] [%s] Disconnecting.", this->connection_index_, this->address_str_.c_str());
   if (this->conn_id_ == UNSET_CONN_ID) {
@@ -209,7 +209,7 @@ bool BLEClientBase::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_
         // Disconnect was requested after connecting started,
         // but before the connection was established. Now that we have
         // this->conn_id_ set, we can disconnect it.
-        this->_unconditional_disconnect_();
+        this->unconditional_disconnect();
         this->conn_id_ = UNSET_CONN_ID;
         break;
       }
@@ -236,7 +236,7 @@ bool BLEClientBase::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_
         // Disconnect was requested after connecting started,
         // but before the connection was established. Now that we have
         // this->conn_id_ set, we can disconnect it.
-        this->_unconditional_disconnect_();
+        this->unconditional_disconnect();
         this->conn_id_ = UNSET_CONN_ID;
       }
       break;

--- a/esphome/components/esp32_ble_client/ble_client_base.cpp
+++ b/esphome/components/esp32_ble_client/ble_client_base.cpp
@@ -249,15 +249,7 @@ bool BLEClientBase::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_
     case ESP_GATTC_CONNECT_EVT: {
       if (!this->check_addr(param->connect.remote_bda))
         return false;
-      this->conn_id_ = param->connect.conn_id;
       this->log_event_("ESP_GATTC_CONNECT_EVT");
-      if (this->want_disconnect_) {
-        // Disconnect was requested after connecting started,
-        // but before the connection was established. Now that we have
-        // this->conn_id_ set, we can disconnect it.
-        this->unconditional_disconnect();
-        this->conn_id_ = UNSET_CONN_ID;
-      }
       break;
     }
     case ESP_GATTC_DISCONNECT_EVT: {

--- a/esphome/components/esp32_ble_client/ble_client_base.cpp
+++ b/esphome/components/esp32_ble_client/ble_client_base.cpp
@@ -124,7 +124,7 @@ esp_err_t BLEClientBase::pair() { return esp_ble_set_encryption(this->remote_bda
 
 void BLEClientBase::disconnect() {
   if (this->state_ == espbt::ClientState::IDLE) {
-    ESP_LOGI(TAG, "[%d] [%s] Disconnect requested, but already disconnected.", this->connection_index_,
+    ESP_LOGI(TAG, "[%d] [%s] Disconnect requested, but already idle.", this->connection_index_,
              this->address_str_.c_str());
     return;
   }

--- a/esphome/components/esp32_ble_client/ble_client_base.cpp
+++ b/esphome/components/esp32_ble_client/ble_client_base.cpp
@@ -145,7 +145,6 @@ void BLEClientBase::_unconditional_disconnect() {
   if (this->state_ == espbt::ClientState::SEARCHING || this->state_ == espbt::ClientState::READY_TO_CONNECT ||
       this->state_ == espbt::ClientState::DISCOVERED || this->state_ == espbt::ClientState::DISCONNECTING) {
     this->set_address(0);
-    this->conn_id_ = UNSET_CONN_ID;
     this->set_state(espbt::ClientState::IDLE);
   } else {
     this->set_state(espbt::ClientState::DISCONNECTING);
@@ -205,6 +204,7 @@ bool BLEClientBase::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_
         // Disconnect we requested before after connecting started,
         // but before the connection was established.
         this->_unconditional_disconnect();
+        this->conn_id_ = UNSET_CONN_ID;
         break;
       }
       auto ret = esp_ble_gattc_send_mtu_req(this->gattc_if_, param->open.conn_id);
@@ -230,6 +230,7 @@ bool BLEClientBase::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_
         // Disconnect we requested before after connecting started,
         // but before the connection was established.
         this->_unconditional_disconnect();
+        this->conn_id_ = UNSET_CONN_ID;
       }
       break;
     }

--- a/esphome/components/esp32_ble_client/ble_client_base.cpp
+++ b/esphome/components/esp32_ble_client/ble_client_base.cpp
@@ -133,7 +133,6 @@ void BLEClientBase::disconnect() {
              this->address_str_.c_str());
     return;
   }
-  ESP_LOGI(TAG, "[%d] [%s] Disconnecting.", this->connection_index_, this->address_str_.c_str());
   if (this->state_ == espbt::ClientState::CONNECTING || this->conn_id_ == UNSET_CONN_ID) {
     ESP_LOGW(TAG, "[%d] [%s] Disconnecting before connected, disconnect scheduled.", this->connection_index_,
              this->address_str_.c_str());

--- a/esphome/components/esp32_ble_client/ble_client_base.cpp
+++ b/esphome/components/esp32_ble_client/ble_client_base.cpp
@@ -143,9 +143,13 @@ void BLEClientBase::unconditional_disconnect() {
   }
   auto err = esp_ble_gattc_close(this->gattc_if_, this->conn_id_);
   if (err != ESP_OK) {
-    // This is a fatal error, we can't do anything about it.
+    //
+    // This is a fatal error, but we can't do anything about it
+    // and it likely means the BLE stack is in a bad state.
+    //
     // In the future we might consider App.reboot() here since
     // the BLE stack is in an indeterminate state.
+    //
     ESP_LOGE(TAG, "[%d] [%s] esp_ble_gattc_close error, err=%d", this->connection_index_, this->address_str_.c_str(),
              err);
   }

--- a/esphome/components/esp32_ble_client/ble_client_base.cpp
+++ b/esphome/components/esp32_ble_client/ble_client_base.cpp
@@ -136,6 +136,11 @@ void BLEClientBase::disconnect() {
 void BLEClientBase::_unconditional_disconnect() {
   // Disconnect without checking the state.
   ESP_LOGI(TAG, "[%d] [%s] Disconnecting.", this->connection_index_, this->address_str_.c_str());
+  if (this->conn_id_ == UNSET_CONN_ID) {
+    ESP_LOGE(TAG, "[%d] [%s] No connection ID set, cannot disconnect.", this->connection_index_,
+             this->address_str_.c_str());
+    return;
+  }
   auto err = esp_ble_gattc_close(this->gattc_if_, this->conn_id_);
   if (err != ESP_OK) {
     ESP_LOGW(TAG, "[%d] [%s] esp_ble_gattc_close error, err=%d", this->connection_index_, this->address_str_.c_str(),

--- a/esphome/components/esp32_ble_client/ble_client_base.cpp
+++ b/esphome/components/esp32_ble_client/ble_client_base.cpp
@@ -125,7 +125,7 @@ esp_err_t BLEClientBase::pair() { return esp_ble_set_encryption(this->remote_bda
 void BLEClientBase::disconnect() {
   if (this->state_ == espbt::ClientState::IDLE || this->state_ == espbt::ClientState::DISCONNECTING)
     return;
-  if (this->conn_id_ == UNSET_CONN_ID) {
+  if (this->state_ == espbt::ClientState::CONNECTING || this->conn_id_ == UNSET_CONN_ID) {
     ESP_LOGW(TAG, "[%d] [%s] Disconnecting before connected", this->connection_index_, this->address_str_.c_str());
     return;
   }

--- a/esphome/components/esp32_ble_client/ble_client_base.cpp
+++ b/esphome/components/esp32_ble_client/ble_client_base.cpp
@@ -125,6 +125,10 @@ esp_err_t BLEClientBase::pair() { return esp_ble_set_encryption(this->remote_bda
 void BLEClientBase::disconnect() {
   if (this->state_ == espbt::ClientState::IDLE || this->state_ == espbt::ClientState::DISCONNECTING)
     return;
+  if (this->conn_id_ == UNSET_CONN_ID) {
+    ESP_LOGW(TAG, "[%d] [%s] Disconnecting before connected", this->connection_index_, this->address_str_.c_str());
+    return;
+  }
   ESP_LOGI(TAG, "[%d] [%s] Disconnecting.", this->connection_index_, this->address_str_.c_str());
   auto err = esp_ble_gattc_close(this->gattc_if_, this->conn_id_);
   if (err != ESP_OK) {
@@ -241,6 +245,7 @@ bool BLEClientBase::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_
       this->log_event_("ESP_GATTC_CLOSE_EVT");
       this->release_services();
       this->set_state(espbt::ClientState::IDLE);
+      this->conn_id_ = UNSET_CONN_ID;
       break;
     }
     case ESP_GATTC_SEARCH_RES_EVT: {

--- a/esphome/components/esp32_ble_client/ble_client_base.cpp
+++ b/esphome/components/esp32_ble_client/ble_client_base.cpp
@@ -130,10 +130,10 @@ void BLEClientBase::disconnect() {
     this->set_state(espbt::ClientState::DISCONNECTING);
     return;
   }
-  this->_unconditional_disconnect();
+  this->_unconditional_disconnect_();
 }
 
-void BLEClientBase::_unconditional_disconnect() {
+void BLEClientBase::_unconditional_disconnect_() {
   // Disconnect without checking the state.
   ESP_LOGI(TAG, "[%d] [%s] Disconnecting.", this->connection_index_, this->address_str_.c_str());
   if (this->conn_id_ == UNSET_CONN_ID) {
@@ -209,7 +209,7 @@ bool BLEClientBase::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_
         // Disconnect was requested before after connecting started,
         // but before the connection was established. Now that we have
         // this->conn_id_ set, we can disconnect it.
-        this->_unconditional_disconnect();
+        this->_unconditional_disconnect_();
         this->conn_id_ = UNSET_CONN_ID;
         break;
       }
@@ -236,7 +236,7 @@ bool BLEClientBase::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_
         // Disconnect was requested before after connecting started,
         // but before the connection was established. Now that we have
         // this->conn_id_ set, we can disconnect it.
-        this->_unconditional_disconnect();
+        this->_unconditional_disconnect_();
         this->conn_id_ = UNSET_CONN_ID;
       }
       break;

--- a/esphome/components/esp32_ble_client/ble_client_base.h
+++ b/esphome/components/esp32_ble_client/ble_client_base.h
@@ -39,6 +39,7 @@ class BLEClientBase : public espbt::ESPBTClient, public Component {
   void connect() override;
   esp_err_t pair();
   void disconnect() override;
+  void _unconditional_disconnect() override;
   void release_services();
 
   bool connected() { return this->state_ == espbt::ClientState::ESTABLISHED; }

--- a/esphome/components/esp32_ble_client/ble_client_base.h
+++ b/esphome/components/esp32_ble_client/ble_client_base.h
@@ -39,7 +39,7 @@ class BLEClientBase : public espbt::ESPBTClient, public Component {
   void connect() override;
   esp_err_t pair();
   void disconnect() override;
-  void _unconditional_disconnect() override;
+  void _unconditional_disconnect();
   void release_services();
 
   bool connected() { return this->state_ == espbt::ClientState::ESTABLISHED; }

--- a/esphome/components/esp32_ble_client/ble_client_base.h
+++ b/esphome/components/esp32_ble_client/ble_client_base.h
@@ -39,7 +39,7 @@ class BLEClientBase : public espbt::ESPBTClient, public Component {
   void connect() override;
   esp_err_t pair();
   void disconnect() override;
-  void _unconditional_disconnect_();
+  void unconditional_disconnect();
   void release_services();
 
   bool connected() { return this->state_ == espbt::ClientState::ESTABLISHED; }

--- a/esphome/components/esp32_ble_client/ble_client_base.h
+++ b/esphome/components/esp32_ble_client/ble_client_base.h
@@ -21,6 +21,8 @@ namespace esp32_ble_client {
 
 namespace espbt = esphome::esp32_ble_tracker;
 
+static const int UNSET_CONN_ID = 0xFFFF;
+
 class BLEClientBase : public espbt::ESPBTClient, public Component {
  public:
   void setup() override;
@@ -94,7 +96,7 @@ class BLEClientBase : public espbt::ESPBTClient, public Component {
   int gattc_if_;
   esp_bd_addr_t remote_bda_;
   esp_ble_addr_type_t remote_addr_type_{BLE_ADDR_TYPE_PUBLIC};
-  uint16_t conn_id_{0xFFFF};
+  uint16_t conn_id_{UNSET_CONN_ID};
   uint64_t address_{0};
   bool auto_connect_{false};
   std::string address_str_{};

--- a/esphome/components/esp32_ble_client/ble_client_base.h
+++ b/esphome/components/esp32_ble_client/ble_client_base.h
@@ -39,7 +39,7 @@ class BLEClientBase : public espbt::ESPBTClient, public Component {
   void connect() override;
   esp_err_t pair();
   void disconnect() override;
-  void _unconditional_disconnect();
+  void _unconditional_disconnect_();
   void release_services();
 
   bool connected() { return this->state_ == espbt::ClientState::ESTABLISHED; }

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
@@ -187,7 +187,7 @@ class ESPBTClient : public ESPBTDeviceListener {
   // want_disconnect_ is set to true when a disconnect is requested
   // while the client is connecting. This is used to disconnect the
   // client as soon as we get the connection id (conn_id_) from the
-  // ESP_GATTC_OPEN_EVT or ESP_GATTC_CONNECT_EVT event.
+  // ESP_GATTC_OPEN_EVT event.
   bool want_disconnect_{false};
 };
 

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
@@ -173,12 +173,18 @@ class ESPBTClient : public ESPBTDeviceListener {
   virtual void gap_event_handler(esp_gap_ble_cb_event_t event, esp_ble_gap_cb_param_t *param) = 0;
   virtual void connect() = 0;
   virtual void disconnect() = 0;
-  virtual void set_state(ClientState st) { this->state_ = st; }
+  virtual void set_state(ClientState st) {
+    this->state_ = st;
+    if (st == ClientState::IDLE) {
+      this->want_disconnect_ = false;
+    }
+  }
   ClientState state() const { return state_; }
   int app_id;
 
  protected:
   ClientState state_{ClientState::INIT};
+  want_disconnect_{false};
 };
 
 class ESP32BLETracker : public Component,

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
@@ -184,6 +184,10 @@ class ESPBTClient : public ESPBTDeviceListener {
 
  protected:
   ClientState state_{ClientState::INIT};
+  // want_disconnect_ is set to true when a disconnect is requested
+  // while the client is connecting. This is used to disconnect the
+  // client as soon as we get the connection id (conn_id_) from the
+  // ESP_GATTC_OPEN_EVT or ESP_GATTC_CONNECT_EVT event.
   bool want_disconnect_{false};
 };
 

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
@@ -184,7 +184,7 @@ class ESPBTClient : public ESPBTDeviceListener {
 
  protected:
   ClientState state_{ClientState::INIT};
-  want_disconnect_{false};
+  bool want_disconnect_{false};
 };
 
 class ESP32BLETracker : public Component,


### PR DESCRIPTION
# What does this implement/fix?

There is a race where we would try to disconnect before the connection callback which meant the `conn_id_` would be `0xFFFF` so we would try to disconnect the "unset" connection id value of 0xFFFF and proceed to set the state to disconnecting.

Later the callback to set `conn_id_` would get delivered and set the `conn_id_` to the correct value, however this meant the client would be stuck in the disconnecting state forever and the connection left open.

To fix this, when disconnect is requested and we are still in the process of connecting, we set `this->want_disconnect_` to `true`.  When the client gets a `ESP_GATTC_OPEN_EVT` and `this->want_disconnect_` is true, we now call `esp_ble_gattc_close` via `unconditional_disconnect` to disconnect the connection and set the client state to idle. 

Fix can be tested with 
```yaml
external_components:
  - source: github://pr#8297
    components: [ esp32_ble_client, esp32_ble_tracker ]
    refresh: 0s
```

```
[18:40:21][D][sensor:093]: 'Ethernet Uptime': Sending state 105.10000 s with 0 decimals of accuracy
[18:40:22][W][esp32_ble_client:129]: [1] [10:76:36:14:93:76] Disconnecting before connected
[18:40:22][D][esp32_ble_tracker:115]: connecting: 0, discovered: 0, searching: 0, disconnecting: 1
[18:40:24][D][esp32_ble_client:169]: [0] [BC:14:EF:7B:22:2A] ESP_GATTC_NOTIFY_EVT
[18:40:24][D][esp32_ble_client:169]: [0] [BC:14:EF:7B:22:2A] ESP_GATTC_WRITE_CHAR_EVT
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/issues/issues/6701

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
