### PR TITLE
[ld2450] Fix for "unknown" sensor states

### DIFF
--- a/esphome/components/ld2450/ld2450.cpp
+++ b/esphome/components/ld2450/ld2450.cpp
@@ -317,7 +317,7 @@ void LD2450Component::query_zone_info() {
 void LD2450Component::restart_and_read_all_info() {
   this->set_config_mode_(true);
   this->restart_();
-  this->set_timeout(1000, [this]() { this->read_all_info(); });
+  this->set_timeout(1500, [this]() { this->read_all_info(); });
 }
 
 // Send command with values to LD2450

--- a/esphome/components/ld2450/ld2450.cpp
+++ b/esphome/components/ld2450/ld2450.cpp
@@ -113,7 +113,7 @@ void LD2450Component::setup() {
   this->pref_ = global_preferences->make_preference<float>(this->presence_timeout_number_->get_object_id_hash());
   this->set_presence_timeout();
 #endif
-  this->read_all_info();
+  this->restart_and_read_all_info();
 }
 
 void LD2450Component::dump_config() {


### PR DESCRIPTION
# What does this implement/fix?

Fix issue where sensor states are sometimes "unknown". See https://github.com/esphome/esphome/pull/5674#issuecomment-2669281465

Test with:

```yaml
external_components:
  - source: github://pr#8305
    components: [ ld2450 ]
    refresh: 0s
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
