### PR TITLE
[socket] add connect method

### DIFF
--- a/esphome/components/socket/bsd_sockets_impl.cpp
+++ b/esphome/components/socket/bsd_sockets_impl.cpp
@@ -46,6 +46,7 @@ class BSDSocketImpl : public Socket {
       close();  // NOLINT(clang-analyzer-optin.cplusplus.VirtualCall)
     }
   }
+  int connect(const struct sockaddr *addr, socklen_t addrlen) override { return ::connect(fd_, addr, addrlen); }
   std::unique_ptr<Socket> accept(struct sockaddr *addr, socklen_t *addrlen) override {
     int fd = ::accept(fd_, addr, addrlen);
     if (fd == -1)

--- a/esphome/components/socket/lwip_sockets_impl.cpp
+++ b/esphome/components/socket/lwip_sockets_impl.cpp
@@ -39,6 +39,7 @@ class LwIPSocketImpl : public Socket {
       close();  // NOLINT(clang-analyzer-optin.cplusplus.VirtualCall)
     }
   }
+  int connect(const struct sockaddr *addr, socklen_t addrlen) override { return lwip_connect(fd_, addr, addrlen); }
   std::unique_ptr<Socket> accept(struct sockaddr *addr, socklen_t *addrlen) override {
     int fd = lwip_accept(fd_, addr, addrlen);
     if (fd == -1)

--- a/esphome/components/socket/socket.h
+++ b/esphome/components/socket/socket.h
@@ -21,7 +21,9 @@ class Socket {
   virtual int close() = 0;
   // not supported yet:
   // virtual int connect(const std::string &address) = 0;
-  // virtual int connect(const struct sockaddr *addr, socklen_t addrlen) = 0;
+#if defined(USE_SOCKET_IMPL_LWIP_SOCKETS) || defined(USE_SOCKET_IMPL_BSD_SOCKETS)
+  virtual int connect(const struct sockaddr *addr, socklen_t addrlen) = 0;
+#endif
   virtual int shutdown(int how) = 0;
 
   virtual int getpeername(struct sockaddr *addr, socklen_t *addrlen) = 0;


### PR DESCRIPTION
# What does this implement/fix?

Adds the connect function to the socket component's BSD and LWIP implementations. I used an ``#if`` to exclude the raw implementation, as I'm not sure exactly how it should be implemented in that case.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** not applicable

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** not applicable

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
