### PR TITLE
[script, external_components] support external components in list-components.py

### DIFF
--- a/script/list-components.py
+++ b/script/list-components.py
@@ -1,11 +1,16 @@
 #!/usr/bin/env python3
 import argparse
+import io
 from pathlib import Path
 import sys
 
+import voluptuous as vol
+
+sys.path.append(str(Path(__file__).parents[1]))
 from helpers import changed_files, git_ls_files
 
 from esphome.const import (
+    CONF_EXTERNAL_COMPONENTS,
     KEY_CORE,
     KEY_TARGET_FRAMEWORK,
     KEY_TARGET_PLATFORM,
@@ -14,6 +19,7 @@ from esphome.const import (
 )
 from esphome.core import CORE
 from esphome.loader import get_component, get_platform
+from esphome.yaml_util import parse_yaml
 
 
 def filter_component_files(str):
@@ -39,7 +45,7 @@ def add_item_to_components_graph(components_graph, parent, child):
             components_graph[parent].append(child)
 
 
-def create_components_graph():
+def create_components_graph(changed_configs: list[str]):
     # The root directory of the repo
     root = Path(__file__).parent.parent
     components_dir = root / "esphome" / "components"
@@ -56,6 +62,9 @@ def create_components_graph():
     CORE.data[KEY_CORE] = TARGET_CONFIGURATIONS[0]
 
     components_graph = {}
+
+    if changed_configs:
+        load_external_components(changed_configs)
 
     for path in components_dir.iterdir():
         if not path.is_dir():
@@ -121,11 +130,13 @@ def find_children_of_component(components_graph, component_name, depth=0):
     return list(set(children))
 
 
-def get_components(files: list[str], get_dependencies: bool = False):
+def get_components(
+    files: list[str], get_dependencies: bool = False, changed_configs: list[str] = []
+):
     components = extract_component_names_array_from_files_array(files)
 
     if get_dependencies:
-        components_graph = create_components_graph()
+        components_graph = create_components_graph(changed_configs)
 
         all_components = components.copy()
         for c in components:
@@ -136,6 +147,43 @@ def get_components(files: list[str], get_dependencies: bool = False):
         return sorted(all_changed_components)
 
     return sorted(components)
+
+
+def load_external_components_from_file(file):
+    inside_external_components = False
+    config = {}
+    buffer = ""
+    with open(file) as f:
+        for line in f:
+            if line.startswith(f"{CONF_EXTERNAL_COMPONENTS}:"):
+                inside_external_components = True
+            if inside_external_components:
+                buffer += line
+                temp_config = parse_yaml("", io.StringIO(buffer))
+                if len(temp_config) > 1:
+                    return config
+                config = temp_config
+    return config
+
+
+def load_external_components(changed_configs):
+    merged_config = None
+    for file in changed_configs:
+        config = load_external_components_from_file(file)
+        if CONF_EXTERNAL_COMPONENTS in config:
+            if merged_config is None:
+                merged_config = config
+            else:
+                merged_config[CONF_EXTERNAL_COMPONENTS] += config[
+                    CONF_EXTERNAL_COMPONENTS
+                ]
+    if CONF_EXTERNAL_COMPONENTS in merged_config:
+        from esphome.components.external_components import do_external_components_pass
+
+        try:
+            do_external_components_pass(merged_config)
+        except vol.Invalid:
+            pass
 
 
 def main():
@@ -157,6 +205,8 @@ def main():
     files = git_ls_files()
     files = filter(filter_component_files, files)
 
+    changed_configs = []
+
     if args.changed:
         if args.branch:
             changed = changed_files(args.branch)
@@ -165,8 +215,12 @@ def main():
         # If any base test file(s) changed, there's no need to filter out components
         if not any("tests/test_build_components" in file for file in changed):
             files = [f for f in files if f in changed]
+        else:
+            for f in changed:
+                if "tests/test_build_components" in f or "tests/components" in f:
+                    changed_configs += [f]
 
-    for c in get_components(files, args.changed):
+    for c in get_components(files, args.changed, changed_configs):
         print(c)
 
 


### PR DESCRIPTION
# What does this implement/fix?

It allows to reference another PR in CI. It allows to break big PR e.g. https://github.com/esphome/esphome/pull/6075 on smaller one. Example of usage https://github.com/esphome/esphome/blob/ec1ccdadfd514c14e84cb0505e5ba38bd1c391de/tests/test_build_components/build_components_base.esp32-ard.yaml#L1-L4

It works in following way:
1. Gather all changed yaml files in "tests/test_build_components" and "tests/components"
2. Select files which have `external_components`
3. Merged external_components from all files
4. load external_components based on merged config

It will help keeping big changes up to date. Even though it is not perfect. It allows to make PR smaller and still use CI.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
