### PR TITLE
[tmp1075] fix component for TMP1075N

### DIFF
--- a/esphome/components/tmp1075/tmp1075.h
+++ b/esphome/components/tmp1075/tmp1075.h
@@ -36,9 +36,8 @@ struct TMP1075Config {
       uint8_t shutdown : 1;  // Sets the device in shutdown mode to conserve power.
                              // 0: Device is in continuous conversion
                              // 1: Device is in shutdown mode
-      uint8_t unused : 8;
     } fields;
-    uint16_t regvalue;
+    uint8_t regvalue;
   };
 };
 


### PR DESCRIPTION
# What does this implement/fix?

The component tries to read and compare a register that doesn't exist on the TMP1075**N**.  It also should only be doing byte operations on the config register.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/issues/issues/5387

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
