### PR TITLE
[esp32_touch] Fix variants, add tests for variants

### DIFF
--- a/esphome/components/esp32_touch/esp32_touch.cpp
+++ b/esphome/components/esp32_touch/esp32_touch.cpp
@@ -52,7 +52,7 @@ void ESP32TouchComponent::setup() {
   }
 #endif
 
-#if ESP_IDF_VERSION_MAJOR >= 5
+#if ESP_IDF_VERSION_MAJOR >= 5 && defined(USE_ESP32_VARIANT_ESP32)
   touch_pad_set_measurement_clock_cycles(this->meas_cycle_);
   touch_pad_set_measurement_interval(this->sleep_cycle_);
 #else

--- a/tests/components/esp32_touch/common-variants.yaml
+++ b/tests/components/esp32_touch/common-variants.yaml
@@ -1,6 +1,5 @@
 esp32_touch:
   setup_mode: false
-  iir_filter: 10ms
   sleep_duration: 27ms
   measurement_duration: 8ms
   low_voltage_reference: 0.5V

--- a/tests/components/esp32_touch/test.esp32-ard.yaml
+++ b/tests/components/esp32_touch/test.esp32-ard.yaml
@@ -1,1 +1,4 @@
+substitutions:
+  pin: GPIO27
+
 <<: !include common.yaml

--- a/tests/components/esp32_touch/test.esp32-idf.yaml
+++ b/tests/components/esp32_touch/test.esp32-idf.yaml
@@ -1,1 +1,4 @@
+substitutions:
+  pin: GPIO27
+
 <<: !include common.yaml

--- a/tests/components/esp32_touch/test.esp32-s2-ard.yaml
+++ b/tests/components/esp32_touch/test.esp32-s2-ard.yaml
@@ -1,0 +1,4 @@
+substitutions:
+  pin: GPIO12
+
+<<: !include common-variants.yaml

--- a/tests/components/esp32_touch/test.esp32-s2-idf.yaml
+++ b/tests/components/esp32_touch/test.esp32-s2-idf.yaml
@@ -1,0 +1,4 @@
+substitutions:
+  pin: GPIO12
+
+<<: !include common-variants.yaml

--- a/tests/components/esp32_touch/test.esp32-s3-ard.yaml
+++ b/tests/components/esp32_touch/test.esp32-s3-ard.yaml
@@ -1,0 +1,4 @@
+substitutions:
+  pin: GPIO12
+
+<<: !include common-variants.yaml

--- a/tests/components/esp32_touch/test.esp32-s3-idf.yaml
+++ b/tests/components/esp32_touch/test.esp32-s3-idf.yaml
@@ -1,0 +1,4 @@
+substitutions:
+  pin: GPIO12
+
+<<: !include common-variants.yaml


### PR DESCRIPTION
# What does this implement/fix?

#8092 broke compilation for variants (S2 + S3). This fixes the issue and adds tests to avoid this in the future.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
