### PR TITLE
Add from_values function to ESPTime struct

### DIFF
--- a/esphome/core/time.cpp
+++ b/esphome/core/time.cpp
@@ -18,19 +18,8 @@ size_t ESPTime::strftime(char *buffer, size_t buffer_len, const char *format) {
 }
 
 ESPTime ESPTime::from_values(uint16_t year, uint8_t month, uint8_t day, uint8_t hour, uint8_t minute, uint8_t second) {
-  ESPTime res{};
   std::tm c_tm = {0, 0, 0, day, (month -1), (year - 1900)};
-  res.second = uint8_t(c_tm->tm_sec);
-  res.minute = uint8_t(c_tm->tm_min);
-  res.hour = uint8_t(c_tm->tm_hour);
-  res.day_of_week = uint8_t(c_tm->tm_wday + 1);
-  res.day_of_month = uint8_t(c_tm->tm_mday);
-  res.day_of_year = uint16_t(c_tm->tm_yday + 1);
-  res.month = uint8_t(c_tm->tm_mon + 1);
-  res.year = uint16_t(c_tm->tm_year + 1900);
-  res.is_dst = bool(c_tm->tm_isdst);
-  res.timestamp = c_time;
-  return res;
+  return this->from_c_tm(c_tm);
 }
 
 ESPTime ESPTime::from_c_tm(struct tm *c_tm, time_t c_time) {

--- a/esphome/core/time.cpp
+++ b/esphome/core/time.cpp
@@ -17,6 +17,23 @@ size_t ESPTime::strftime(char *buffer, size_t buffer_len, const char *format) {
   return ::strftime(buffer, buffer_len, format, &c_tm);
 }
 
+ESPTime ESPTime::from_values(uint16_t year, uint8_t month, uint8_t day,
+                             uint8_t hour, uint8_t minute, uint8_t second) {
+  ESPTime res{};
+  std::tm tm = { 0, 0, 0, day, (month -1), (year - 1900) };
+  res.second = uint8_t(c_tm->tm_sec);
+  res.minute = uint8_t(c_tm->tm_min);
+  res.hour = uint8_t(c_tm->tm_hour);
+  res.day_of_week = uint8_t(c_tm->tm_wday + 1);
+  res.day_of_month = uint8_t(c_tm->tm_mday);
+  res.day_of_year = uint16_t(c_tm->tm_yday + 1);
+  res.month = uint8_t(c_tm->tm_mon + 1);
+  res.year = uint16_t(c_tm->tm_year + 1900);
+  res.is_dst = bool(c_tm->tm_isdst);
+  res.timestamp = c_time;
+  return res;
+}
+
 ESPTime ESPTime::from_c_tm(struct tm *c_tm, time_t c_time) {
   ESPTime res{};
   res.second = uint8_t(c_tm->tm_sec);

--- a/esphome/core/time.cpp
+++ b/esphome/core/time.cpp
@@ -19,7 +19,7 @@ size_t ESPTime::strftime(char *buffer, size_t buffer_len, const char *format) {
 
 ESPTime ESPTime::from_values(uint16_t year, uint8_t month, uint8_t day, uint8_t hour, uint8_t minute, uint8_t second) {
   ESPTime res{};
-  std::tm tm = {0, 0, 0, day, (month -1), (year - 1900)};
+  std::tm c_tm = {0, 0, 0, day, (month -1), (year - 1900)};
   res.second = uint8_t(c_tm->tm_sec);
   res.minute = uint8_t(c_tm->tm_min);
   res.hour = uint8_t(c_tm->tm_hour);

--- a/esphome/core/time.cpp
+++ b/esphome/core/time.cpp
@@ -19,7 +19,7 @@ size_t ESPTime::strftime(char *buffer, size_t buffer_len, const char *format) {
 
 ESPTime ESPTime::from_values(uint16_t year, uint8_t month, uint8_t day, uint8_t hour, uint8_t minute, uint8_t second) {
   ESPTime res{};
-  std::tm tm = { 0, 0, 0, day, (month -1), (year - 1900)};
+  std::tm tm = {0, 0, 0, day, (month -1), (year - 1900)};
   res.second = uint8_t(c_tm->tm_sec);
   res.minute = uint8_t(c_tm->tm_min);
   res.hour = uint8_t(c_tm->tm_hour);

--- a/esphome/core/time.cpp
+++ b/esphome/core/time.cpp
@@ -17,10 +17,9 @@ size_t ESPTime::strftime(char *buffer, size_t buffer_len, const char *format) {
   return ::strftime(buffer, buffer_len, format, &c_tm);
 }
 
-ESPTime ESPTime::from_values(uint16_t year, uint8_t month, uint8_t day,
-                             uint8_t hour, uint8_t minute, uint8_t second) {
+ESPTime ESPTime::from_values(uint16_t year, uint8_t month, uint8_t day, uint8_t hour, uint8_t minute, uint8_t second) {
   ESPTime res{};
-  std::tm tm = { 0, 0, 0, day, (month -1), (year - 1900) };
+  std::tm tm = { 0, 0, 0, day, (month -1), (year - 1900)};
   res.second = uint8_t(c_tm->tm_sec);
   res.minute = uint8_t(c_tm->tm_min);
   res.hour = uint8_t(c_tm->tm_hour);

--- a/esphome/core/time.cpp
+++ b/esphome/core/time.cpp
@@ -19,7 +19,7 @@ size_t ESPTime::strftime(char *buffer, size_t buffer_len, const char *format) {
 
 ESPTime ESPTime::from_values(uint16_t year, uint8_t month, uint8_t day, uint8_t hour, uint8_t minute, uint8_t second) {
   std::tm c_tm = {0, 0, 0, day, (month -1), (year - 1900)};
-  return this->from_c_tm(c_tm);
+  return this->from_c_tm(&c_tm);
 }
 
 ESPTime ESPTime::from_c_tm(struct tm *c_tm, time_t c_time) {

--- a/esphome/core/time.cpp
+++ b/esphome/core/time.cpp
@@ -117,7 +117,7 @@ bool ESPTime::strptime(const std::string &time_to_parse, ESPTime &esp_time) {
 
 
 static bool from_local_values(uint16_t year, uint8_t month, uint8_t day, uint8_t hour, uint8_t minute, uint8_t second, ESPTime &esp_time) {
-  return this->strptime(sprintf("%04hu-%02hhu-%02hhu %02hhu:%02hhu:%02hhu"), year, month, day, hour, minute, second, esp_time);
+  return this->strptime(sprintf("%04hu-%02hhu-%02hhu %02hhu:%02hhu:%02hhu", year, month, day, hour, minute, second), esp_time);
 }
 
 void ESPTime::increment_second() {

--- a/esphome/core/time.cpp
+++ b/esphome/core/time.cpp
@@ -17,11 +17,6 @@ size_t ESPTime::strftime(char *buffer, size_t buffer_len, const char *format) {
   return ::strftime(buffer, buffer_len, format, &c_tm);
 }
 
-ESPTime ESPTime::from_values(uint16_t year, uint8_t month, uint8_t day, uint8_t hour, uint8_t minute, uint8_t second) {
-  std::tm c_tm = {0, 0, 0, day, (month -1), (year - 1900)};
-  return this->from_c_tm(&c_tm);
-}
-
 ESPTime ESPTime::from_c_tm(struct tm *c_tm, time_t c_time) {
   ESPTime res{};
   res.second = uint8_t(c_tm->tm_sec);

--- a/esphome/core/time.cpp
+++ b/esphome/core/time.cpp
@@ -115,6 +115,11 @@ bool ESPTime::strptime(const std::string &time_to_parse, ESPTime &esp_time) {
   return true;
 }
 
+
+static bool from_local_values(uint16_t year, uint8_t month, uint8_t day, uint8_t hour, uint8_t minute, uint8_t second, ESPTime &esp_time) {
+  return this->strptime(sprintf("%04hu-%02hhu-%02hhu %02hhu:%02hhu:%02hhu"), year, month, day, hour, minute, second, esp_time);
+}
+
 void ESPTime::increment_second() {
   this->timestamp++;
   if (!increment_time_value(this->second, 0, 60))

--- a/esphome/core/time.h
+++ b/esphome/core/time.h
@@ -72,6 +72,11 @@ struct ESPTime {
    */
   static bool strptime(const std::string &time_to_parse, ESPTime &esp_time);
 
+  /** Initialize new ESPTime struct using given values
+   *  required, to mimic c_tm initialization without day of week required
+   */
+  static bool from_local_values(uint16_t year, uint8_t month, uint8_t day, uint8_t hour, uint8_t minute, uint8_t second, ESPTime & esp_time);
+
   /// Convert a C tm struct instance with a C unix epoch timestamp to an ESPTime instance.
   static ESPTime from_c_tm(struct tm *c_tm, time_t c_time);
 
@@ -84,11 +89,6 @@ struct ESPTime {
     struct tm *c_tm = ::localtime(&epoch);
     return ESPTime::from_c_tm(c_tm, epoch);
   }
-
-  /** Initialize new ESPTime struct using given values
-   *  required, to mimic c_tm initialization without day of week required
-   */
-  static ESPTime from_values(uint16_t year, uint8_t month, uint8_t day, uint8_t hour, uint8_t minute, uint8_t second);
 
   /** Convert an UTC epoch timestamp to a UTC time ESPTime instance.
    *

--- a/esphome/core/time.h
+++ b/esphome/core/time.h
@@ -90,7 +90,7 @@ struct ESPTime {
    */
   static ESPTime from_values(uint16_t year, uint8_t month, uint8_t day,
                              uint8_t hour, uint8_t minute, uint8_t second);
-  
+
   /** Convert an UTC epoch timestamp to a UTC time ESPTime instance.
    *
    * @param epoch Seconds since 1st January 1970. In UTC.

--- a/esphome/core/time.h
+++ b/esphome/core/time.h
@@ -84,6 +84,13 @@ struct ESPTime {
     struct tm *c_tm = ::localtime(&epoch);
     return ESPTime::from_c_tm(c_tm, epoch);
   }
+
+  /** Initialize new ESPTime struct using given values
+   *  required, to mimic c_tm initialization without day of week required
+   */
+  static ESPTime from_values(uint16_t year, uint8_t month, uint8_t day,
+                             uint8_t hour, uint8_t minute, uint8_t second);
+  
   /** Convert an UTC epoch timestamp to a UTC time ESPTime instance.
    *
    * @param epoch Seconds since 1st January 1970. In UTC.

--- a/esphome/core/time.h
+++ b/esphome/core/time.h
@@ -88,8 +88,7 @@ struct ESPTime {
   /** Initialize new ESPTime struct using given values
    *  required, to mimic c_tm initialization without day of week required
    */
-  static ESPTime from_values(uint16_t year, uint8_t month, uint8_t day,
-                             uint8_t hour, uint8_t minute, uint8_t second);
+  static ESPTime from_values(uint16_t year, uint8_t month, uint8_t day, uint8_t hour, uint8_t minute, uint8_t second);
 
   /** Convert an UTC epoch timestamp to a UTC time ESPTime instance.
    *


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Currently, there is no easy way to initialize an ESPTime directly from int values without knowing the correct day of the week, if you actually need that data (day of the week) afterwards, as it does not get re-calculated internally.
So, e.g. in the situation where you have a date/time represented by multiple ints, you will need to create a string or a c_tm to then initialize an ESPTime instance afterwards.
This adds function "from_local_values", allowing direct intuitive one-liner ESPTime-initialisation from int values.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
