### PR TITLE
[adc] sort variants and add links to reference implementations

### DIFF
--- a/esphome/components/adc/__init__.py
+++ b/esphome/components/adc/__init__.py
@@ -47,9 +47,10 @@ SAMPLING_MODES = {
 adc1_channel_t = cg.global_ns.enum("adc1_channel_t")
 adc2_channel_t = cg.global_ns.enum("adc2_channel_t")
 
-# From https://github.com/espressif/esp-idf/blob/master/components/driver/include/driver/adc_common.h
 # pin to adc1 channel mapping
+# https://github.com/espressif/esp-idf/blob/v4.4.8/components/driver/include/driver/adc.h
 ESP32_VARIANT_ADC1_PIN_TO_CHANNEL = {
+    # https://github.com/espressif/esp-idf/blob/master/components/soc/esp32/include/soc/adc_channel.h
     VARIANT_ESP32: {
         36: adc1_channel_t.ADC1_CHANNEL_0,
         37: adc1_channel_t.ADC1_CHANNEL_1,
@@ -60,6 +61,41 @@ ESP32_VARIANT_ADC1_PIN_TO_CHANNEL = {
         34: adc1_channel_t.ADC1_CHANNEL_6,
         35: adc1_channel_t.ADC1_CHANNEL_7,
     },
+    # https://github.com/espressif/esp-idf/blob/master/components/soc/esp32c2/include/soc/adc_channel.h
+    VARIANT_ESP32C2: {
+        0: adc1_channel_t.ADC1_CHANNEL_0,
+        1: adc1_channel_t.ADC1_CHANNEL_1,
+        2: adc1_channel_t.ADC1_CHANNEL_2,
+        3: adc1_channel_t.ADC1_CHANNEL_3,
+        4: adc1_channel_t.ADC1_CHANNEL_4,
+    },
+    # https://github.com/espressif/esp-idf/blob/master/components/soc/esp32c3/include/soc/adc_channel.h
+    VARIANT_ESP32C3: {
+        0: adc1_channel_t.ADC1_CHANNEL_0,
+        1: adc1_channel_t.ADC1_CHANNEL_1,
+        2: adc1_channel_t.ADC1_CHANNEL_2,
+        3: adc1_channel_t.ADC1_CHANNEL_3,
+        4: adc1_channel_t.ADC1_CHANNEL_4,
+    },
+    # https://github.com/espressif/esp-idf/blob/master/components/soc/esp32c6/include/soc/adc_channel.h
+    VARIANT_ESP32C6: {
+        0: adc1_channel_t.ADC1_CHANNEL_0,
+        1: adc1_channel_t.ADC1_CHANNEL_1,
+        2: adc1_channel_t.ADC1_CHANNEL_2,
+        3: adc1_channel_t.ADC1_CHANNEL_3,
+        4: adc1_channel_t.ADC1_CHANNEL_4,
+        5: adc1_channel_t.ADC1_CHANNEL_5,
+        6: adc1_channel_t.ADC1_CHANNEL_6,
+    },
+    # https://github.com/espressif/esp-idf/blob/master/components/soc/esp32h2/include/soc/adc_channel.h
+    VARIANT_ESP32H2: {
+        1: adc1_channel_t.ADC1_CHANNEL_0,
+        2: adc1_channel_t.ADC1_CHANNEL_1,
+        3: adc1_channel_t.ADC1_CHANNEL_2,
+        4: adc1_channel_t.ADC1_CHANNEL_3,
+        5: adc1_channel_t.ADC1_CHANNEL_4,
+    },
+    # https://github.com/espressif/esp-idf/blob/master/components/soc/esp32s2/include/soc/adc_channel.h
     VARIANT_ESP32S2: {
         1: adc1_channel_t.ADC1_CHANNEL_0,
         2: adc1_channel_t.ADC1_CHANNEL_1,
@@ -72,6 +108,7 @@ ESP32_VARIANT_ADC1_PIN_TO_CHANNEL = {
         9: adc1_channel_t.ADC1_CHANNEL_8,
         10: adc1_channel_t.ADC1_CHANNEL_9,
     },
+    # https://github.com/espressif/esp-idf/blob/master/components/soc/esp32s3/include/soc/adc_channel.h
     VARIANT_ESP32S3: {
         1: adc1_channel_t.ADC1_CHANNEL_0,
         2: adc1_channel_t.ADC1_CHANNEL_1,
@@ -84,40 +121,12 @@ ESP32_VARIANT_ADC1_PIN_TO_CHANNEL = {
         9: adc1_channel_t.ADC1_CHANNEL_8,
         10: adc1_channel_t.ADC1_CHANNEL_9,
     },
-    VARIANT_ESP32C3: {
-        0: adc1_channel_t.ADC1_CHANNEL_0,
-        1: adc1_channel_t.ADC1_CHANNEL_1,
-        2: adc1_channel_t.ADC1_CHANNEL_2,
-        3: adc1_channel_t.ADC1_CHANNEL_3,
-        4: adc1_channel_t.ADC1_CHANNEL_4,
-    },
-    VARIANT_ESP32C2: {
-        0: adc1_channel_t.ADC1_CHANNEL_0,
-        1: adc1_channel_t.ADC1_CHANNEL_1,
-        2: adc1_channel_t.ADC1_CHANNEL_2,
-        3: adc1_channel_t.ADC1_CHANNEL_3,
-        4: adc1_channel_t.ADC1_CHANNEL_4,
-    },
-    VARIANT_ESP32C6: {
-        0: adc1_channel_t.ADC1_CHANNEL_0,
-        1: adc1_channel_t.ADC1_CHANNEL_1,
-        2: adc1_channel_t.ADC1_CHANNEL_2,
-        3: adc1_channel_t.ADC1_CHANNEL_3,
-        4: adc1_channel_t.ADC1_CHANNEL_4,
-        5: adc1_channel_t.ADC1_CHANNEL_5,
-        6: adc1_channel_t.ADC1_CHANNEL_6,
-    },
-    VARIANT_ESP32H2: {
-        1: adc1_channel_t.ADC1_CHANNEL_0,
-        2: adc1_channel_t.ADC1_CHANNEL_1,
-        3: adc1_channel_t.ADC1_CHANNEL_2,
-        4: adc1_channel_t.ADC1_CHANNEL_3,
-        5: adc1_channel_t.ADC1_CHANNEL_4,
-    },
 }
 
+# pin to adc2 channel mapping
+# https://github.com/espressif/esp-idf/blob/v4.4.8/components/driver/include/driver/adc.h
 ESP32_VARIANT_ADC2_PIN_TO_CHANNEL = {
-    # TODO: add other variants
+    # https://github.com/espressif/esp-idf/blob/master/components/soc/esp32/include/soc/adc_channel.h
     VARIANT_ESP32: {
         4: adc2_channel_t.ADC2_CHANNEL_0,
         0: adc2_channel_t.ADC2_CHANNEL_1,
@@ -130,6 +139,19 @@ ESP32_VARIANT_ADC2_PIN_TO_CHANNEL = {
         25: adc2_channel_t.ADC2_CHANNEL_8,
         26: adc2_channel_t.ADC2_CHANNEL_9,
     },
+    # https://github.com/espressif/esp-idf/blob/master/components/soc/esp32c2/include/soc/adc_channel.h
+    VARIANT_ESP32C2: {
+        5: adc2_channel_t.ADC2_CHANNEL_0,
+    },
+    # https://github.com/espressif/esp-idf/blob/master/components/soc/esp32c3/include/soc/adc_channel.h
+    VARIANT_ESP32C3: {
+        5: adc2_channel_t.ADC2_CHANNEL_0,
+    },
+    # https://github.com/espressif/esp-idf/blob/master/components/soc/esp32c6/include/soc/adc_channel.h
+    VARIANT_ESP32C6: {},  # no ADC2
+    # https://github.com/espressif/esp-idf/blob/master/components/soc/esp32h2/include/soc/adc_channel.h
+    VARIANT_ESP32H2: {},  # no ADC2
+    # https://github.com/espressif/esp-idf/blob/master/components/soc/esp32s2/include/soc/adc_channel.h
     VARIANT_ESP32S2: {
         11: adc2_channel_t.ADC2_CHANNEL_0,
         12: adc2_channel_t.ADC2_CHANNEL_1,
@@ -142,6 +164,7 @@ ESP32_VARIANT_ADC2_PIN_TO_CHANNEL = {
         19: adc2_channel_t.ADC2_CHANNEL_8,
         20: adc2_channel_t.ADC2_CHANNEL_9,
     },
+    # https://github.com/espressif/esp-idf/blob/master/components/soc/esp32s3/include/soc/adc_channel.h
     VARIANT_ESP32S3: {
         11: adc2_channel_t.ADC2_CHANNEL_0,
         12: adc2_channel_t.ADC2_CHANNEL_1,
@@ -154,12 +177,6 @@ ESP32_VARIANT_ADC2_PIN_TO_CHANNEL = {
         19: adc2_channel_t.ADC2_CHANNEL_8,
         20: adc2_channel_t.ADC2_CHANNEL_9,
     },
-    VARIANT_ESP32C3: {
-        5: adc2_channel_t.ADC2_CHANNEL_0,
-    },
-    VARIANT_ESP32C2: {},
-    VARIANT_ESP32C6: {},
-    VARIANT_ESP32H2: {},
 }
 
 


### PR DESCRIPTION
# What does this implement/fix?

Mostly improvements of comments. Added missing pin for `ESP32-C2`

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#4715

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
