### PR TITLE
Fix ``end_of_scan_`` not being called while disconnecting

### DIFF
--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
@@ -176,9 +176,9 @@ void ESP32BLETracker::loop() {
       https://github.com/espressif/esp-idf/issues/6688
 
     */
-    if (!connecting && !disconnecting && xSemaphoreTake(this->scan_end_lock_, 0L)) {
+    if (!connecting && xSemaphoreTake(this->scan_end_lock_, 0L)) {
       if (this->scan_continuous_) {
-        if (!promote_to_connecting && !this->scan_start_failed_ && !this->scan_set_param_failed_) {
+        if (!disconnecting && !promote_to_connecting && !this->scan_start_failed_ && !this->scan_set_param_failed_) {
           this->start_scan_(false);
         } else {
           // We didn't start the scan, so we need to release the lock


### PR DESCRIPTION
# What does this implement/fix?

If at least one client is in disconnecting state, we will not take the lock to figure out if the scanner needs to be started or end of scan needs to be declared.  Since we do not stop the scanner for disconnecting (we only avoid starting but do not stop it), and only connecting, we should only avoid taking the lock if we are connecting.

Fix can be tested with 2025.2.1+
```yaml
external_components:
  - source: github://pr#8297
    components: [ esp32_ble_tracker ]
    refresh: 0s
```

potential fix for https://github.com/esphome/issues/issues/5119

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
