### PR TITLE
Add support for GL-R01 I2C - Time of Flight sensor

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -162,6 +162,7 @@ esphome/components/ft5x06/* @clydebarrow
 esphome/components/ft63x6/* @gpambrozio
 esphome/components/gcja5/* @gcormier
 esphome/components/gdk101/* @Szewcson
+esphome/components/gl_r01_i2c/* @pkejval
 esphome/components/globals/* @esphome/core
 esphome/components/gp2y1010au0f/* @zry98
 esphome/components/gp8403/* @jesserockz

--- a/esphome/components/gl_r01_i2c/__init__.py
+++ b/esphome/components/gl_r01_i2c/__init__.py
@@ -1,3 +1,0 @@
-CODEOWNERS = ["@pkejval"]
-DEPENDENCIES = ["i2c"]
-AUTO_LOAD = ["sensor"]

--- a/esphome/components/gl_r01_i2c/__init__.py
+++ b/esphome/components/gl_r01_i2c/__init__.py
@@ -1,0 +1,3 @@
+CODEOWNERS = ["@pkejval"]
+DEPENDENCIES = ["i2c"]
+AUTO_LOAD = ["sensor"]

--- a/esphome/components/gl_r01_i2c/gl_r01_i2c.cpp
+++ b/esphome/components/gl_r01_i2c/gl_r01_i2c.cpp
@@ -1,0 +1,116 @@
+#include "esphome/core/log.h"
+#include "esphome/core/hal.h"
+#include "gl_r01_i2c.h"
+
+namespace esphome {
+namespace gl_r01_i2c {
+
+static const char *const TAG = "gl_r01_i2c";
+
+// Register definitions from datasheet
+static const uint8_t REG_VERSION = 0x00;
+static const uint8_t REG_DISTANCE = 0x02;
+static const uint8_t REG_TRIGGER = 0x10;
+static const uint8_t CMD_TRIGGER = 0xB0;
+static const uint8_t RESTART_CMD1 = 0x5A;
+static const uint8_t RESTART_CMD2 = 0xA5;
+
+void GLR01I2CComponent::set_min_read_interval(uint32_t min_read_interval) {
+  this->min_read_interval_ = min_read_interval;
+}
+
+void GLR01I2CComponent::setup() {
+  ESP_LOGCONFIG(TAG, "Setting up GL-R01 I2C...");
+  // Verify sensor presence
+  if (!this->read_byte_16(REG_VERSION, &this->version_)) {
+    ESP_LOGE(TAG, "Failed to communicate with GL-R01 I2C sensor!");
+    this->mark_failed();
+    return;
+  }
+  ESP_LOGD(TAG, "Found GL-R01 I2C with version 0x%04X", this->version_);
+}
+
+void GLR01I2CComponent::dump_config() {
+  ESP_LOGCONFIG(TAG, "GL-R01 I2C:");
+  ESP_LOGCONFIG(TAG, " Firmware Version: 0x%04X", this->version_);
+  ESP_LOGCONFIG(TAG, " Minimum read interval: %u ms", this->min_read_interval_);
+  LOG_I2C_DEVICE(this);
+  LOG_SENSOR(" ", "Distance", this);
+}
+
+void GLR01I2CComponent::update() {
+  if (this->is_failed())
+    return;
+  if (state_ != GLR01I2CState::IDLE) {
+    ESP_LOGVV(TAG, "Previous measurement still in progress");
+    return;
+  }
+
+  // Trigger a new measurement
+  if (!this->write_byte(REG_TRIGGER, CMD_TRIGGER)) {
+    ESP_LOGE(TAG, "Failed to trigger measurement!");
+    this->status_set_warning();
+    return;
+  }
+
+  state_ = GLR01I2CState::TRIGGERED;
+  trigger_time_ = millis();
+}
+
+void GLR01I2CComponent::loop() {
+  if (this->is_failed())
+    return;
+  // Wait for result after measurement was triggered
+  if (state_ == GLR01I2CState::TRIGGERED) {
+    if (millis() - trigger_time_ >= min_read_interval_) {
+      state_ = GLR01I2CState::READY;
+    }
+  }
+
+  if (state_ == GLR01I2CState::READY) {
+    uint16_t distance = 0;
+    if (!this->read_byte_16(REG_DISTANCE, &distance)) {
+      ESP_LOGE(TAG, "Failed to read distance value!");
+      this->status_set_warning();
+      state_ = GLR01I2CState::IDLE;
+      return;
+    }
+
+    if (distance == 0xFFFF) {
+      ESP_LOGW(TAG,
+               "Invalid measurement received! Check connection or consider increasing min_read_interval from %u ms!",
+               this->min_read_interval_);
+      this->status_set_warning();
+    } else {
+      ESP_LOGV(TAG, "Distance: %umm", distance);
+      this->publish_state(distance);
+      this->status_clear_warning();
+    }
+
+    state_ = GLR01I2CState::IDLE;
+  }
+}
+
+bool GLR01I2CComponent::restart_sensor() {
+  if (!this->write_byte(REG_TRIGGER, RESTART_CMD1)) {
+    ESP_LOGE(TAG, "Failed to send restart command part 1!");
+    return false;
+  }
+
+  if (!this->write_byte(REG_TRIGGER, RESTART_CMD2)) {
+    ESP_LOGE(TAG, "Failed to send restart command part 2!");
+    return false;
+  }
+
+  ESP_LOGI(TAG, "Restart command issued successfully");
+  return true;
+}
+
+void RestartSensorAction::play() {
+  if (!this->parent_->restart_sensor()) {
+    ESP_LOGE(TAG, "Failed to restart sensor!");
+  }
+}
+
+}  // namespace gl_r01_i2c
+}  // namespace esphome

--- a/esphome/components/gl_r01_i2c/gl_r01_i2c.cpp
+++ b/esphome/components/gl_r01_i2c/gl_r01_i2c.cpp
@@ -46,7 +46,7 @@ void GLR01I2CComponent::update() {
     return;
   }
 
-  // Schedule reading the result after the minimum read interval
+  // Schedule reading the result after the read delay 
   this->set_timeout(READ_DELAY, [this]() { this->read_distance_(); });
 }
 

--- a/esphome/components/gl_r01_i2c/gl_r01_i2c.cpp
+++ b/esphome/components/gl_r01_i2c/gl_r01_i2c.cpp
@@ -91,26 +91,5 @@ void GLR01I2CComponent::loop() {
   }
 }
 
-bool GLR01I2CComponent::restart_sensor() {
-  if (!this->write_byte(REG_TRIGGER, RESTART_CMD1)) {
-    ESP_LOGE(TAG, "Failed to send restart command part 1!");
-    return false;
-  }
-
-  if (!this->write_byte(REG_TRIGGER, RESTART_CMD2)) {
-    ESP_LOGE(TAG, "Failed to send restart command part 2!");
-    return false;
-  }
-
-  ESP_LOGI(TAG, "Restart command issued successfully");
-  return true;
-}
-
-void RestartSensorAction::play() {
-  if (!this->parent_->restart_sensor()) {
-    ESP_LOGE(TAG, "Failed to restart sensor!");
-  }
-}
-
 }  // namespace gl_r01_i2c
 }  // namespace esphome

--- a/esphome/components/gl_r01_i2c/gl_r01_i2c.cpp
+++ b/esphome/components/gl_r01_i2c/gl_r01_i2c.cpp
@@ -1,6 +1,5 @@
 #include "esphome/core/log.h"
 #include "esphome/core/hal.h"
-#include "esphome/core/application.h"
 #include "gl_r01_i2c.h"
 
 namespace esphome {
@@ -46,7 +45,7 @@ void GLR01I2CComponent::update() {
     return;
   }
 
-  // Schedule reading the result after the read delay 
+  // Schedule reading the result after the read delay
   this->set_timeout(READ_DELAY, [this]() { this->read_distance_(); });
 }
 

--- a/esphome/components/gl_r01_i2c/gl_r01_i2c.cpp
+++ b/esphome/components/gl_r01_i2c/gl_r01_i2c.cpp
@@ -30,7 +30,6 @@ void GLR01I2CComponent::setup() {
 void GLR01I2CComponent::dump_config() {
   ESP_LOGCONFIG(TAG, "GL-R01 I2C:");
   ESP_LOGCONFIG(TAG, " Firmware Version: 0x%04X", this->version_);
-  ESP_LOGCONFIG(TAG, " Minimum read interval: %u ms", this->min_read_interval_);
   LOG_I2C_DEVICE(this);
   LOG_SENSOR(" ", "Distance", this);
 }

--- a/esphome/components/gl_r01_i2c/gl_r01_i2c.cpp
+++ b/esphome/components/gl_r01_i2c/gl_r01_i2c.cpp
@@ -15,6 +15,7 @@ static const uint8_t REG_TRIGGER = 0x10;
 static const uint8_t CMD_TRIGGER = 0xB0;
 static const uint8_t RESTART_CMD1 = 0x5A;
 static const uint8_t RESTART_CMD2 = 0xA5;
+static const uint8_t READ_DELAY = 40;  // minimum milliseconds from datasheet to safely read measurement result
 
 void GLR01I2CComponent::setup() {
   ESP_LOGCONFIG(TAG, "Setting up GL-R01 I2C...");
@@ -46,7 +47,7 @@ void GLR01I2CComponent::update() {
   }
 
   // Schedule reading the result after the minimum read interval
-  this->set_timeout(this->min_read_interval_, [this]() { this->read_distance_(); });
+  this->set_timeout(READ_DELAY, [this]() { this->read_distance_(); });
 }
 
 void GLR01I2CComponent::read_distance_() {

--- a/esphome/components/gl_r01_i2c/gl_r01_i2c.cpp
+++ b/esphome/components/gl_r01_i2c/gl_r01_i2c.cpp
@@ -1,5 +1,6 @@
 #include "esphome/core/log.h"
 #include "esphome/core/hal.h"
+#include "esphome/core/application.h"
 #include "gl_r01_i2c.h"
 
 namespace esphome {
@@ -37,10 +38,6 @@ void GLR01I2CComponent::dump_config() {
 void GLR01I2CComponent::update() {
   if (this->is_failed())
     return;
-  if (this->state_ != GLR01I2CState::IDLE) {
-    ESP_LOGVV(TAG, "Previous measurement still in progress");
-    return;
-  }
 
   // Trigger a new measurement
   if (!this->write_byte(REG_TRIGGER, CMD_TRIGGER)) {
@@ -49,39 +46,28 @@ void GLR01I2CComponent::update() {
     return;
   }
 
-  this->state_ = GLR01I2CState::TRIGGERED;
-  this->trigger_time_ = millis();
+  // Schedule reading the result after the minimum read interval
+  App.scheduler.set_timeout(this, "read_distance", this->min_read_interval_, [this]() { this->read_distance_(); });
 }
 
-void GLR01I2CComponent::loop() {
+void GLR01I2CComponent::read_distance_() {
   if (this->is_failed())
     return;
-  // Wait for result after measurement was triggered
-  if (this->state_ == GLR01I2CState::TRIGGERED) {
-    if (millis() - this->trigger_time_ >= this->min_read_interval_) {
-      this->state_ = GLR01I2CState::READY;
-    }
+
+  uint16_t distance = 0;
+  if (!this->read_byte_16(REG_DISTANCE, &distance)) {
+    ESP_LOGE(TAG, "Failed to read distance value!");
+    this->status_set_warning();
+    return;
   }
 
-  if (this->state_ == GLR01I2CState::READY) {
-    uint16_t distance = 0;
-    if (!this->read_byte_16(REG_DISTANCE, &distance)) {
-      ESP_LOGE(TAG, "Failed to read distance value!");
-      this->status_set_warning();
-      this->state_ = GLR01I2CState::IDLE;
-      return;
-    }
-
-    if (distance == 0xFFFF) {
-      ESP_LOGW(TAG, "Invalid measurement received!");
-      this->status_set_warning();
-    } else {
-      ESP_LOGV(TAG, "Distance: %umm", distance);
-      this->publish_state(distance);
-      this->status_clear_warning();
-    }
-
-    this->state_ = GLR01I2CState::IDLE;
+  if (distance == 0xFFFF) {
+    ESP_LOGW(TAG, "Invalid measurement received!");
+    this->status_set_warning();
+  } else {
+    ESP_LOGV(TAG, "Distance: %umm", distance);
+    this->publish_state(distance);
+    this->status_clear_warning();
   }
 }
 

--- a/esphome/components/gl_r01_i2c/gl_r01_i2c.cpp
+++ b/esphome/components/gl_r01_i2c/gl_r01_i2c.cpp
@@ -47,7 +47,7 @@ void GLR01I2CComponent::update() {
   }
 
   // Schedule reading the result after the minimum read interval
-  App.scheduler.set_timeout(this, "read_distance", this->min_read_interval_, [this]() { this->read_distance_(); });
+  this->set_timeout(this->min_read_interval_, [this]() { this->read_distance_(); });
 }
 
 void GLR01I2CComponent::read_distance_() {

--- a/esphome/components/gl_r01_i2c/gl_r01_i2c.cpp
+++ b/esphome/components/gl_r01_i2c/gl_r01_i2c.cpp
@@ -15,10 +15,6 @@ static const uint8_t CMD_TRIGGER = 0xB0;
 static const uint8_t RESTART_CMD1 = 0x5A;
 static const uint8_t RESTART_CMD2 = 0xA5;
 
-void GLR01I2CComponent::set_min_read_interval(uint32_t min_read_interval) {
-  this->min_read_interval_ = min_read_interval;
-}
-
 void GLR01I2CComponent::setup() {
   ESP_LOGCONFIG(TAG, "Setting up GL-R01 I2C...");
   // Verify sensor presence
@@ -77,9 +73,7 @@ void GLR01I2CComponent::loop() {
     }
 
     if (distance == 0xFFFF) {
-      ESP_LOGW(TAG,
-               "Invalid measurement received! Check connection or consider increasing min_read_interval from %u ms!",
-               this->min_read_interval_);
+      ESP_LOGW(TAG, "Invalid measurement received!");
       this->status_set_warning();
     } else {
       ESP_LOGV(TAG, "Distance: %umm", distance);

--- a/esphome/components/gl_r01_i2c/gl_r01_i2c.cpp
+++ b/esphome/components/gl_r01_i2c/gl_r01_i2c.cpp
@@ -41,7 +41,7 @@ void GLR01I2CComponent::dump_config() {
 void GLR01I2CComponent::update() {
   if (this->is_failed())
     return;
-  if (state_ != GLR01I2CState::IDLE) {
+  if (this->state_ != GLR01I2CState::IDLE) {
     ESP_LOGVV(TAG, "Previous measurement still in progress");
     return;
   }
@@ -53,26 +53,26 @@ void GLR01I2CComponent::update() {
     return;
   }
 
-  state_ = GLR01I2CState::TRIGGERED;
-  trigger_time_ = millis();
+  this->state_ = GLR01I2CState::TRIGGERED;
+  this->trigger_time_ = millis();
 }
 
 void GLR01I2CComponent::loop() {
   if (this->is_failed())
     return;
   // Wait for result after measurement was triggered
-  if (state_ == GLR01I2CState::TRIGGERED) {
-    if (millis() - trigger_time_ >= min_read_interval_) {
-      state_ = GLR01I2CState::READY;
+  if (this->state_ == GLR01I2CState::TRIGGERED) {
+    if (millis() - this->trigger_time_ >= this->min_read_interval_) {
+      this->state_ = GLR01I2CState::READY;
     }
   }
 
-  if (state_ == GLR01I2CState::READY) {
+  if (this->state_ == GLR01I2CState::READY) {
     uint16_t distance = 0;
     if (!this->read_byte_16(REG_DISTANCE, &distance)) {
       ESP_LOGE(TAG, "Failed to read distance value!");
       this->status_set_warning();
-      state_ = GLR01I2CState::IDLE;
+      this->state_ = GLR01I2CState::IDLE;
       return;
     }
 
@@ -87,7 +87,7 @@ void GLR01I2CComponent::loop() {
       this->status_clear_warning();
     }
 
-    state_ = GLR01I2CState::IDLE;
+    this->state_ = GLR01I2CState::IDLE;
   }
 }
 

--- a/esphome/components/gl_r01_i2c/gl_r01_i2c.cpp
+++ b/esphome/components/gl_r01_i2c/gl_r01_i2c.cpp
@@ -35,9 +35,6 @@ void GLR01I2CComponent::dump_config() {
 }
 
 void GLR01I2CComponent::update() {
-  if (this->is_failed())
-    return;
-
   // Trigger a new measurement
   if (!this->write_byte(REG_TRIGGER, CMD_TRIGGER)) {
     ESP_LOGE(TAG, "Failed to trigger measurement!");
@@ -50,9 +47,6 @@ void GLR01I2CComponent::update() {
 }
 
 void GLR01I2CComponent::read_distance_() {
-  if (this->is_failed())
-    return;
-
   uint16_t distance = 0;
   if (!this->read_byte_16(REG_DISTANCE, &distance)) {
     ESP_LOGE(TAG, "Failed to read distance value!");

--- a/esphome/components/gl_r01_i2c/gl_r01_i2c.h
+++ b/esphome/components/gl_r01_i2c/gl_r01_i2c.h
@@ -16,7 +16,6 @@ class GLR01I2CComponent : public sensor::Sensor, public i2c::I2CDevice, public P
   void update() override;
   void loop() override;
   float get_setup_priority() const override { return setup_priority::DATA; }
-  bool restart_sensor();
 
   void set_min_read_interval(uint32_t min_read_interval);
 
@@ -25,15 +24,6 @@ class GLR01I2CComponent : public sensor::Sensor, public i2c::I2CDevice, public P
   uint32_t trigger_time_{0};
   uint32_t min_read_interval_{40};  // minimum milliseconds from datasheet
   uint16_t version_{0};
-};
-
-class RestartSensorAction : public Action<> {
- public:
-  explicit RestartSensorAction(GLR01I2CComponent *parent) : parent_(parent) {}
-  void play() override;
-
- protected:
-  GLR01I2CComponent *parent_;
 };
 
 }  // namespace gl_r01_i2c

--- a/esphome/components/gl_r01_i2c/gl_r01_i2c.h
+++ b/esphome/components/gl_r01_i2c/gl_r01_i2c.h
@@ -16,7 +16,6 @@ class GLR01I2CComponent : public sensor::Sensor, public i2c::I2CDevice, public P
 
  protected:
   void read_distance_();
-  uint32_t min_read_interval_{40};  // minimum milliseconds from datasheet
   uint16_t version_{0};
 };
 

--- a/esphome/components/gl_r01_i2c/gl_r01_i2c.h
+++ b/esphome/components/gl_r01_i2c/gl_r01_i2c.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/components/sensor/sensor.h"
+#include "esphome/components/i2c/i2c.h"
+
+namespace esphome {
+namespace gl_r01_i2c {
+
+enum class GLR01I2CState { IDLE, TRIGGERED, READY };
+
+class GLR01I2CComponent : public sensor::Sensor, public i2c::I2CDevice, public PollingComponent {
+ public:
+  void setup() override;
+  void dump_config() override;
+  void update() override;
+  void loop() override;
+  float get_setup_priority() const override { return setup_priority::DATA; }
+  bool restart_sensor();
+
+  void set_min_read_interval(uint32_t min_read_interval);
+
+ protected:
+  GLR01I2CState state_{GLR01I2CState::IDLE};
+  uint32_t trigger_time_{0};
+  uint32_t min_read_interval_{40};  // minimum milliseconds from datasheet
+  uint16_t version_{0};
+};
+
+class RestartSensorAction : public Action<> {
+ public:
+  explicit RestartSensorAction(GLR01I2CComponent *parent) : parent_(parent) {}
+  void play() override;
+
+ protected:
+  GLR01I2CComponent *parent_;
+};
+
+}  // namespace gl_r01_i2c
+}  // namespace esphome

--- a/esphome/components/gl_r01_i2c/gl_r01_i2c.h
+++ b/esphome/components/gl_r01_i2c/gl_r01_i2c.h
@@ -7,19 +7,15 @@
 namespace esphome {
 namespace gl_r01_i2c {
 
-enum class GLR01I2CState { IDLE, TRIGGERED, READY };
-
 class GLR01I2CComponent : public sensor::Sensor, public i2c::I2CDevice, public PollingComponent {
  public:
   void setup() override;
   void dump_config() override;
   void update() override;
-  void loop() override;
   float get_setup_priority() const override { return setup_priority::DATA; }
 
  protected:
-  GLR01I2CState state_{GLR01I2CState::IDLE};
-  uint32_t trigger_time_{0};
+  void read_distance_();
   uint32_t min_read_interval_{40};  // minimum milliseconds from datasheet
   uint16_t version_{0};
 };

--- a/esphome/components/gl_r01_i2c/gl_r01_i2c.h
+++ b/esphome/components/gl_r01_i2c/gl_r01_i2c.h
@@ -17,8 +17,6 @@ class GLR01I2CComponent : public sensor::Sensor, public i2c::I2CDevice, public P
   void loop() override;
   float get_setup_priority() const override { return setup_priority::DATA; }
 
-  void set_min_read_interval(uint32_t min_read_interval);
-
  protected:
   GLR01I2CState state_{GLR01I2CState::IDLE};
   uint32_t trigger_time_{0};

--- a/esphome/components/gl_r01_i2c/gl_r01_i2c.h
+++ b/esphome/components/gl_r01_i2c/gl_r01_i2c.h
@@ -12,7 +12,6 @@ class GLR01I2CComponent : public sensor::Sensor, public i2c::I2CDevice, public P
   void setup() override;
   void dump_config() override;
   void update() override;
-  float get_setup_priority() const override { return setup_priority::DATA; }
 
  protected:
   void read_distance_();

--- a/esphome/components/gl_r01_i2c/sensor.py
+++ b/esphome/components/gl_r01_i2c/sensor.py
@@ -15,7 +15,6 @@ gl_r01_i2c_ns = cg.esphome_ns.namespace("gl_r01_i2c")
 GLR01I2CComponent = gl_r01_i2c_ns.class_(
     "GLR01I2CComponent", i2c.I2CDevice, cg.PollingComponent
 )
-RestartSensorAction = gl_r01_i2c_ns.class_("RestartSensorAction", automation.Action)
 
 
 # Ensure min_read_interval is at least 40ms as stated in datasheet
@@ -44,21 +43,6 @@ CONFIG_SCHEMA = (
         }
     )
 )
-
-
-@automation.register_action(
-    "gl_r01_i2c.restart",
-    RestartSensorAction,
-    cv.Schema(
-        {
-            cv.Required(CONF_ID): cv.use_id(GLR01I2CComponent),
-        }
-    ),
-)
-async def gl_r01_i2c_restart_to_code(config, action_id, template_arg, args):
-    parent = await cg.get_variable(config[CONF_ID])
-    var = cg.new_Pvariable(action_id, template_arg, parent)
-    return var
 
 
 async def to_code(config):

--- a/esphome/components/gl_r01_i2c/sensor.py
+++ b/esphome/components/gl_r01_i2c/sensor.py
@@ -1,0 +1,72 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+import esphome.automation as automation
+from esphome.components import i2c, sensor
+from esphome.const import (
+    CONF_ID,
+    DEVICE_CLASS_DISTANCE,
+    STATE_CLASS_MEASUREMENT,
+    UNIT_MILLIMETER,
+)
+
+CONF_MIN_READ_INTERVAL = "min_read_interval"
+
+gl_r01_i2c_ns = cg.esphome_ns.namespace("gl_r01_i2c")
+GLR01I2CComponent = gl_r01_i2c_ns.class_(
+    "GLR01I2CComponent", i2c.I2CDevice, cg.PollingComponent
+)
+RestartSensorAction = gl_r01_i2c_ns.class_("RestartSensorAction", automation.Action)
+
+
+# Ensure min_read_interval is at least 40ms as stated in datasheet
+def validate_min_read_interval(value):
+    value = cv.positive_time_period_milliseconds(value)
+    if value.total_milliseconds < 40:
+        raise cv.Invalid(f"min_read_interval must be at least 40ms (got {value})")
+    return value
+
+
+CONFIG_SCHEMA = (
+    sensor.sensor_schema(
+        GLR01I2CComponent,
+        unit_of_measurement=UNIT_MILLIMETER,
+        accuracy_decimals=0,
+        device_class=DEVICE_CLASS_DISTANCE,
+        state_class=STATE_CLASS_MEASUREMENT,
+    )
+    .extend(cv.polling_component_schema("1s"))
+    .extend(i2c.i2c_device_schema(0x74))
+    .extend(
+        {
+            cv.Optional(
+                CONF_MIN_READ_INTERVAL, default="40ms"
+            ): cv.positive_time_period_milliseconds,
+        }
+    )
+)
+
+
+@automation.register_action(
+    "gl_r01_i2c.restart",
+    RestartSensorAction,
+    cv.Schema(
+        {
+            cv.Required(CONF_ID): cv.use_id(GLR01I2CComponent),
+        }
+    ),
+)
+async def gl_r01_i2c_restart_to_code(config, action_id, template_arg, args):
+    parent = await cg.get_variable(config[CONF_ID])
+    var = cg.new_Pvariable(action_id, template_arg, parent)
+    return var
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+    await sensor.register_sensor(var, config)
+    await i2c.register_i2c_device(var, config)
+
+    # Set the min_read_interval if provided in config
+    if CONF_MIN_READ_INTERVAL in config:
+        cg.add(var.set_min_read_interval(config[CONF_MIN_READ_INTERVAL]))

--- a/esphome/components/gl_r01_i2c/sensor.py
+++ b/esphome/components/gl_r01_i2c/sensor.py
@@ -8,6 +8,9 @@ from esphome.const import (
     UNIT_MILLIMETER,
 )
 
+CODEOWNERS = ["@pkejval"]
+DEPENDENCIES = ["i2c"]
+
 CONF_MIN_READ_INTERVAL = "min_read_interval"
 
 gl_r01_i2c_ns = cg.esphome_ns.namespace("gl_r01_i2c")

--- a/esphome/components/gl_r01_i2c/sensor.py
+++ b/esphome/components/gl_r01_i2c/sensor.py
@@ -1,6 +1,5 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
-import esphome.automation as automation
 from esphome.components import i2c, sensor
 from esphome.const import (
     CONF_ID,

--- a/esphome/components/gl_r01_i2c/sensor.py
+++ b/esphome/components/gl_r01_i2c/sensor.py
@@ -11,21 +11,10 @@ from esphome.const import (
 CODEOWNERS = ["@pkejval"]
 DEPENDENCIES = ["i2c"]
 
-CONF_MIN_READ_INTERVAL = "min_read_interval"
-
 gl_r01_i2c_ns = cg.esphome_ns.namespace("gl_r01_i2c")
 GLR01I2CComponent = gl_r01_i2c_ns.class_(
     "GLR01I2CComponent", i2c.I2CDevice, cg.PollingComponent
 )
-
-
-# Ensure min_read_interval is at least 40ms as stated in datasheet
-def validate_min_read_interval(value):
-    value = cv.positive_time_period_milliseconds(value)
-    if value.total_milliseconds < 40:
-        raise cv.Invalid(f"min_read_interval must be at least 40ms (got {value})")
-    return value
-
 
 CONFIG_SCHEMA = (
     sensor.sensor_schema(
@@ -37,13 +26,6 @@ CONFIG_SCHEMA = (
     )
     .extend(cv.polling_component_schema("1s"))
     .extend(i2c.i2c_device_schema(0x74))
-    .extend(
-        {
-            cv.Optional(
-                CONF_MIN_READ_INTERVAL, default="40ms"
-            ): cv.positive_time_period_milliseconds,
-        }
-    )
 )
 
 
@@ -52,7 +34,3 @@ async def to_code(config):
     await cg.register_component(var, config)
     await sensor.register_sensor(var, config)
     await i2c.register_i2c_device(var, config)
-
-    # Set the min_read_interval if provided in config
-    if CONF_MIN_READ_INTERVAL in config:
-        cg.add(var.set_min_read_interval(config[CONF_MIN_READ_INTERVAL]))

--- a/esphome/components/gl_r01_i2c/sensor.py
+++ b/esphome/components/gl_r01_i2c/sensor.py
@@ -24,7 +24,7 @@ CONFIG_SCHEMA = (
         device_class=DEVICE_CLASS_DISTANCE,
         state_class=STATE_CLASS_MEASUREMENT,
     )
-    .extend(cv.polling_component_schema("1s"))
+    .extend(cv.polling_component_schema("60s"))
     .extend(i2c.i2c_device_schema(0x74))
 )
 

--- a/tests/components/gl_r01_i2c/common.yaml
+++ b/tests/components/gl_r01_i2c/common.yaml
@@ -5,6 +5,8 @@ i2c:
 
 sensor:
   - platform: gl_r01_i2c
+    id: tof
+    name: "ToF sensor"
     i2c_id: i2c_gl_r01_i2c
     address: 0x74
     update_interval: 15s

--- a/tests/components/gl_r01_i2c/common.yaml
+++ b/tests/components/gl_r01_i2c/common.yaml
@@ -1,0 +1,10 @@
+i2c:
+  - id: i2c_gl_r01_i2c
+    scl: ${scl_pin}
+    sda: ${sda_pin}
+
+sensor:
+  - platform: gl_r01_i2c
+    i2c_id: i2c_gl_r01_i2c
+    address: 0x74
+    update_interval: 15s

--- a/tests/components/gl_r01_i2c/test.esp32-ard.yaml
+++ b/tests/components/gl_r01_i2c/test.esp32-ard.yaml
@@ -1,0 +1,5 @@
+substitutions:
+  scl_pin: GPIO16
+  sda_pin: GPIO17
+
+<<: !include common.yaml

--- a/tests/components/gl_r01_i2c/test.esp32-c3-ard.yaml
+++ b/tests/components/gl_r01_i2c/test.esp32-c3-ard.yaml
@@ -1,0 +1,5 @@
+substitutions:
+  scl_pin: GPIO5
+  sda_pin: GPIO4
+
+<<: !include common.yaml

--- a/tests/components/gl_r01_i2c/test.esp32-c3-idf.yaml
+++ b/tests/components/gl_r01_i2c/test.esp32-c3-idf.yaml
@@ -1,0 +1,5 @@
+substitutions:
+  scl_pin: GPIO5
+  sda_pin: GPIO4
+
+<<: !include common.yaml

--- a/tests/components/gl_r01_i2c/test.esp32-idf.yaml
+++ b/tests/components/gl_r01_i2c/test.esp32-idf.yaml
@@ -1,0 +1,5 @@
+substitutions:
+  scl_pin: GPIO16
+  sda_pin: GPIO17
+
+<<: !include common.yaml

--- a/tests/components/gl_r01_i2c/test.esp8266-ard.yaml
+++ b/tests/components/gl_r01_i2c/test.esp8266-ard.yaml
@@ -1,0 +1,5 @@
+substitutions:
+  scl_pin: GPIO5
+  sda_pin: GPIO4
+
+<<: !include common.yaml

--- a/tests/components/gl_r01_i2c/test.rp2040-ard.yaml
+++ b/tests/components/gl_r01_i2c/test.rp2040-ard.yaml
@@ -1,0 +1,5 @@
+substitutions:
+  scl_pin: GPIO5
+  sda_pin: GPIO4
+
+<<: !include common.yaml


### PR DESCRIPTION
# What does this implement/fix?

Add support for Time of Flight sensor GL-R01 I2C variant as can be bought from https://www.aliexpress.com/item/1005005968519496.html


## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#4721

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
i2c:
  sda: GPIO25
  scl: GPIO22

sensor:
  - platform: gl_r01_i2c
    id: tof
    name: "ToF"

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
