### PR TITLE
[audio] Determine http timeout based on duration since last successful read

### DIFF
--- a/esphome/components/audio/audio_reader.h
+++ b/esphome/components/audio/audio_reader.h
@@ -71,7 +71,7 @@ class AudioReader {
   void cleanup_connection_();
 
   size_t buffer_size_;
-  uint32_t no_data_read_count_;
+  uint32_t last_data_read_ms_;
 
   esp_http_client_handle_t client_{nullptr};
 


### PR DESCRIPTION
# What does this implement/fix?

If the http client in the audio reader successfully receives the header, but then the data is slow to be available, the reader would fail after 100 tries (with 20 ms delays in between) with no bytes read. This affects certain media services in MusicAssistant that can be slow to send the initial data like Tidal and Apple Music.

This PR changes the logic to consider the last time data was last read instead of an absolute count, and sets the timeout cutoff to 5000 ms.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** not applicable

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** not applicable
## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

Use Music Assistant to open a file from Tidal or Apple Music.

```yaml
# Example config.yaml

media_player:
  - platform: speaker
    id: external_media_player
    name: Media Player
    internal: False
    volume_increment: 0.05
    volume_min: 0.4
    volume_max: 0.85
    announcement_pipeline:
      speaker: announcement_resampling_speaker
      format: FLAC 
      sample_rate: 48000

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
