### PR TITLE
[ltr390] Move calculation to allow dynamic setting of gain and resolution

### DIFF
--- a/esphome/components/ltr390/ltr390.h
+++ b/esphome/components/ltr390/ltr390.h
@@ -77,7 +77,6 @@ class LTR390Component : public PollingComponent, public i2c::I2CDevice {
   LTR390GAIN gain_uv_;
   LTR390RESOLUTION res_als_;
   LTR390RESOLUTION res_uv_;
-  float sensitivity_uv_;
   float wfac_;
 
   sensor::Sensor *light_sensor_{nullptr};


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

This allows the gain and resolution to be set at runtime. There are no other restrictions on these as they are each sent to the sensor right before every read.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
