### PR TITLE
Fix second scrolling run ussue

### DIFF
--- a/esphome/components/max7219digit/max7219digit.cpp
+++ b/esphome/components/max7219digit/max7219digit.cpp
@@ -64,40 +64,40 @@ void MAX7219Component::dump_config() {
 
 void MAX7219Component::loop() {
   const uint32_t now = millis();
-  const uint32_t sinceLastScroll = now - this->last_scroll_;
-  const size_t lineSize = this->max_displaybuffer_[0].size();
+  const uint32_t millis_since_last_scroll = now - this->last_scroll_;
+  const size_t first_line_size = this->max_displaybuffer_[0].size();
   // check if the buffer has shrunk past the current position since last update
-  if ((lineSize >= this->old_buffer_size_ + 3) || (lineSize <= this->old_buffer_size_ - 3)) {
-    ESP_LOGV(TAG, "Buffer size changed %d to %d", this->old_buffer_size_, lineSize);
+  if ((first_line_size >= this->old_buffer_size_ + 3) || (first_line_size <= this->old_buffer_size_ - 3)) {
+    ESP_LOGV(TAG, "Buffer size changed %d to %d", this->old_buffer_size_, first_line_size);
     this->stepsleft_ = 0;
     this->display();
-    this->old_buffer_size_ = lineSize;
+    this->old_buffer_size_ = first_line_size;
   }
 
-  if (!this->scroll_ || (lineSize <= (size_t) get_width_internal())) {
+  if (!this->scroll_ || (first_line_size <= (size_t) get_width_internal())) {
     ESP_LOGVV(TAG, "Return if there is no need to scroll or scroll is off.");
     this->display();
     return;
   }
 
-  if ((this->stepsleft_ == 0) && (sinceLastScroll < this->scroll_delay_)) {
+  if ((this->stepsleft_ == 0) && (millis_since_last_scroll < this->scroll_delay_)) {
     ESP_LOGVV(TAG, "At first step. Waiting for scroll delay");
     this->display();
     return;
   }
 
   if (this->scroll_mode_ == ScrollMode::STOP) {
-    if (this->stepsleft_ + get_width_internal() == lineSize + 1) {
-      if (sinceLastScroll < this->scroll_dwell_) {
+    if (this->stepsleft_ + get_width_internal() == first_line_size + 1) {
+      if (millis_since_last_scroll < this->scroll_dwell_) {
         ESP_LOGVV(TAG, "Dwell time at end of string in case of stop at end. Step %d, since last scroll %d, dwell %d.",
-                  this->stepsleft_, sinceLastScroll, this->scroll_dwell_);
+                  this->stepsleft_, millis_since_last_scroll, this->scroll_dwell_);
         return;
       }
       ESP_LOGV(TAG, "Dwell time passed. Continue scrolling.");
     }
   }
 
-  if (sinceLastScroll >= this->scroll_speed_) {
+  if (millis_since_last_scroll >= this->scroll_speed_) {
     ESP_LOGVV(TAG, "Call to scroll left action");
     this->last_scroll_ = now;
     this->scroll_left();

--- a/esphome/components/max7219digit/max7219digit.cpp
+++ b/esphome/components/max7219digit/max7219digit.cpp
@@ -4,6 +4,8 @@
 #include "esphome/core/hal.h"
 #include "max7219font.h"
 
+#include <algorithm>
+
 namespace esphome {
 namespace max7219digit {
 
@@ -61,45 +63,42 @@ void MAX7219Component::dump_config() {
 }
 
 void MAX7219Component::loop() {
-  uint32_t now = millis();
-
+  const uint32_t now = millis();
+  const uint32_t sinceLastScroll = now - this->last_scroll_;
+  const size_t lineSize = this->max_displaybuffer_[0].size();
   // check if the buffer has shrunk past the current position since last update
-  if ((this->max_displaybuffer_[0].size() >= this->old_buffer_size_ + 3) ||
-      (this->max_displaybuffer_[0].size() <= this->old_buffer_size_ - 3)) {
+  if ((lineSize >= this->old_buffer_size_ + 3) || (lineSize <= this->old_buffer_size_ - 3)) {
+    ESP_LOGV(TAG, "Buffer size changed %d to %d", this->old_buffer_size_, lineSize);
     this->stepsleft_ = 0;
     this->display();
-    this->old_buffer_size_ = this->max_displaybuffer_[0].size();
+    this->old_buffer_size_ = lineSize;
   }
 
-  // Reset the counter back to 0 when full string has been displayed.
-  if (this->stepsleft_ > this->max_displaybuffer_[0].size())
-    this->stepsleft_ = 0;
-
-  // Return if there is no need to scroll or scroll is off
-  if (!this->scroll_ || (this->max_displaybuffer_[0].size() <= (size_t) get_width_internal())) {
+  if (!this->scroll_ || (lineSize <= (size_t) get_width_internal())) {
+    ESP_LOGVV(TAG, "Return if there is no need to scroll or scroll is off.");
     this->display();
     return;
   }
 
-  if ((this->stepsleft_ == 0) && (now - this->last_scroll_ < this->scroll_delay_)) {
+  if ((this->stepsleft_ == 0) && (sinceLastScroll < this->scroll_delay_)) {
+    ESP_LOGVV(TAG, "At first step. Waiting for scroll delay");
     this->display();
     return;
   }
 
-  // Dwell time at end of string in case of stop at end
   if (this->scroll_mode_ == ScrollMode::STOP) {
-    if (this->stepsleft_ >= this->max_displaybuffer_[0].size() - (size_t) get_width_internal() + 1) {
-      if (now - this->last_scroll_ >= this->scroll_dwell_) {
-        this->stepsleft_ = 0;
-        this->last_scroll_ = now;
-        this->display();
+    if (this->stepsleft_ + get_width_internal() == lineSize + 1) {
+      if (sinceLastScroll < this->scroll_dwell_) {
+        ESP_LOGVV(TAG, "Dwell time at end of string in case of stop at end. Step %d, since last scroll %d, dwell %d.",
+                  this->stepsleft_, sinceLastScroll, this->scroll_dwell_);
+        return;
       }
-      return;
+      ESP_LOGV(TAG, "Dwell time passed. Continue scrolling.");
     }
   }
 
-  // Actual call to scroll left action
-  if (now - this->last_scroll_ >= this->scroll_speed_) {
+  if (sinceLastScroll >= this->scroll_speed_) {
+    ESP_LOGVV(TAG, "Call to scroll left action");
     this->last_scroll_ = now;
     this->scroll_left();
     this->display();
@@ -227,19 +226,20 @@ void MAX7219Component::scroll(bool on_off) { this->set_scroll(on_off); }
 
 void MAX7219Component::scroll_left() {
   for (int chip_line = 0; chip_line < this->num_chip_lines_; chip_line++) {
+    auto scroll = [&](std::vector<uint8_t> &line, uint16_t steps) {
+      std::rotate(line.begin(), std::next(line.begin(), steps), line.end());
+    };
     if (this->update_) {
       this->max_displaybuffer_[chip_line].push_back(this->bckgrnd_);
-      for (uint16_t i = 0; i < this->stepsleft_; i++) {
-        this->max_displaybuffer_[chip_line].push_back(this->max_displaybuffer_[chip_line].front());
-        this->max_displaybuffer_[chip_line].erase(this->max_displaybuffer_[chip_line].begin());
-      }
+      scroll(this->max_displaybuffer_[chip_line],
+             (this->stepsleft_ + 1) % (this->max_displaybuffer_[chip_line].size()));
     } else {
-      this->max_displaybuffer_[chip_line].push_back(this->max_displaybuffer_[chip_line].front());
-      this->max_displaybuffer_[chip_line].erase(this->max_displaybuffer_[chip_line].begin());
+      scroll(this->max_displaybuffer_[chip_line], 1);
     }
   }
   this->update_ = false;
   this->stepsleft_++;
+  this->stepsleft_ %= this->max_displaybuffer_[0].size();
 }
 
 void MAX7219Component::send_char(uint8_t chip, uint8_t data) {


### PR DESCRIPTION
# What does this implement/fix?

- Fixes the issue with text scrolling with `scroll_mode: STOP` after first run
- use `std::rotate` to get rig of extra allocations
- comments are moved to `ESP_LOGVV` for debugging

Behavior: 
- first chars of text are shown
- waits `scroll_delay`
- starts scrolling to the end
- last chars of text are shown correctly
- waits `scroll_dwell`
- continues scrolling second run
- stops few chars before the end of text (BUG: should scroll to last char)
- waits `scroll_dwell`

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
display:
  - platform: max7219digit
    id: screen
    cs_pin: 18
    num_chips: 4
    intensity: 8
    scroll_mode: STOP
    scroll_speed: 25ms
    scroll_delay: 2s
    scroll_dwell: 5s
    lambda: |
        it.print(3, 7, id(digit_font), TextAlign::BASELINE, longString);
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
