### PR TITLE
[udp] fix clang tidy

### DIFF
--- a/esphome/components/udp/udp_component.h
+++ b/esphome/components/udp/udp_component.h
@@ -70,7 +70,9 @@ class UDPComponent : public PollingComponent {
   }
 #endif
   void add_address(const char *addr) { this->addresses_.emplace_back(addr); }
+#ifdef USE_NETWORK
   void set_listen_address(const char *listen_addr) { this->listen_address_ = network::IPAddress(listen_addr); }
+#endif
   void set_port(uint16_t port) { this->port_ = port; }
   float get_setup_priority() const override { return setup_priority::AFTER_WIFI; }
 
@@ -144,8 +146,9 @@ class UDPComponent : public PollingComponent {
   std::vector<BinarySensor> binary_sensors_{};
   std::map<std::string, std::map<std::string, binary_sensor::BinarySensor *>> remote_binary_sensors_{};
 #endif
-
+#ifdef USE_NETWORK
   optional<network::IPAddress> listen_address_{};
+#endif
   std::map<std::string, Provider> providers_{};
   std::vector<uint8_t> ping_header_{};
   std::vector<uint8_t> header_{};


### PR DESCRIPTION
# What does this implement/fix?

Part of https://github.com/esphome/esphome/pull/7049. Fix following error
```
/home/bh/git/github/esphome/esphome/components/udp/udp_component.h:73:78: error: use of undeclared identifier 'network' [clang-diagnostic-error]
   73 |   void set_listen_address(const char *listen_addr) { this->listen_address_ = network::IPAddress(listen_addr); }
      |                                                                              ^
/home/bh/git/github/esphome/esphome/components/udp/udp_component.h:148:12: error: use of undeclared identifier 'network' [clang-diagnostic-error]
  148 |   optional<network::IPAddress> listen_address_{};
      |            ^
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
