### PR TITLE
I2c priority

### DIFF
--- a/esphome/components/i2c/__init__.py
+++ b/esphome/components/i2c/__init__.py
@@ -89,7 +89,8 @@ async def to_code(config):
         cg.add(var.set_timeout(int(config[CONF_TIMEOUT].total_microseconds)))
     if CORE.using_arduino:
         cg.add_library("Wire", None)
-    cg.add(var.set_priority(config[CONF_SETUP_PRIORITY]))
+    if CONF_SETUP_PRIORITY in config:
+        cg.add(var.set_priority(config[CONF_SETUP_PRIORITY]))
 
 
 def i2c_device_schema(default_address):

--- a/esphome/components/i2c/__init__.py
+++ b/esphome/components/i2c/__init__.py
@@ -8,6 +8,7 @@ from esphome.const import (
     CONF_ID,
     CONF_INPUT,
     CONF_OUTPUT,
+    CONF_PRIORITY,
     CONF_SCAN,
     CONF_SCL,
     CONF_SDA,
@@ -62,6 +63,7 @@ CONFIG_SCHEMA = cv.All(
             ),
             cv.Optional(CONF_TIMEOUT): cv.positive_time_period,
             cv.Optional(CONF_SCAN, default=True): cv.boolean,
+            cv.Optional(CONF_PRIORITY, default=1000.0): cv.float_,
         }
     ).extend(cv.COMPONENT_SCHEMA),
     cv.only_on([PLATFORM_ESP32, PLATFORM_ESP8266, PLATFORM_RP2040]),
@@ -87,6 +89,7 @@ async def to_code(config):
         cg.add(var.set_timeout(int(config[CONF_TIMEOUT].total_microseconds)))
     if CORE.using_arduino:
         cg.add_library("Wire", None)
+    cg.add(var.set_priority(config[CONF_PRIORITY]))
 
 
 def i2c_device_schema(default_address):

--- a/esphome/components/i2c/__init__.py
+++ b/esphome/components/i2c/__init__.py
@@ -8,10 +8,10 @@ from esphome.const import (
     CONF_ID,
     CONF_INPUT,
     CONF_OUTPUT,
-    CONF_PRIORITY,
     CONF_SCAN,
     CONF_SCL,
     CONF_SDA,
+    CONF_SETUP_PRIORITY,
     CONF_TIMEOUT,
     PLATFORM_ESP32,
     PLATFORM_ESP8266,
@@ -63,7 +63,7 @@ CONFIG_SCHEMA = cv.All(
             ),
             cv.Optional(CONF_TIMEOUT): cv.positive_time_period,
             cv.Optional(CONF_SCAN, default=True): cv.boolean,
-            cv.Optional(CONF_PRIORITY, default=1000.0): cv.float_,
+            cv.Optional(CONF_SETUP_PRIORITY, default=1000.0): cv.float_,
         }
     ).extend(cv.COMPONENT_SCHEMA),
     cv.only_on([PLATFORM_ESP32, PLATFORM_ESP8266, PLATFORM_RP2040]),
@@ -89,7 +89,7 @@ async def to_code(config):
         cg.add(var.set_timeout(int(config[CONF_TIMEOUT].total_microseconds)))
     if CORE.using_arduino:
         cg.add_library("Wire", None)
-    cg.add(var.set_priority(config[CONF_PRIORITY]))
+    cg.add(var.set_priority(config[CONF_SETUP_PRIORITY]))
 
 
 def i2c_device_schema(default_address):

--- a/esphome/components/i2c/i2c_bus_arduino.h
+++ b/esphome/components/i2c/i2c_bus_arduino.h
@@ -21,13 +21,14 @@ class ArduinoI2CBus : public I2CBus, public Component {
   void dump_config() override;
   ErrorCode readv(uint8_t address, ReadBuffer *buffers, size_t cnt) override;
   ErrorCode writev(uint8_t address, WriteBuffer *buffers, size_t cnt, bool stop) override;
-  float get_setup_priority() const override { return setup_priority::BUS; }
+  float get_setup_priority() const override { return setup_priority_; }
 
   void set_scan(bool scan) { scan_ = scan; }
   void set_sda_pin(uint8_t sda_pin) { sda_pin_ = sda_pin; }
   void set_scl_pin(uint8_t scl_pin) { scl_pin_ = scl_pin; }
   void set_frequency(uint32_t frequency) { frequency_ = frequency; }
   void set_timeout(uint32_t timeout) { timeout_ = timeout; }
+  void set_priority(float priority) { setup_priority_ = priority; }
 
  private:
   void recover_();
@@ -41,6 +42,7 @@ class ArduinoI2CBus : public I2CBus, public Component {
   uint32_t frequency_;
   uint32_t timeout_ = 0;
   bool initialized_ = false;
+  float setup_priority_ = 1000.0f;
 };
 
 }  // namespace i2c

--- a/esphome/components/i2c/i2c_bus_esp_idf.h
+++ b/esphome/components/i2c/i2c_bus_esp_idf.h
@@ -21,7 +21,7 @@ class IDFI2CBus : public I2CBus, public Component {
   void dump_config() override;
   ErrorCode readv(uint8_t address, ReadBuffer *buffers, size_t cnt) override;
   ErrorCode writev(uint8_t address, WriteBuffer *buffers, size_t cnt, bool stop) override;
-  float get_setup_priority() const override { return setup_priority::BUS; }
+  float get_setup_priority() const override { return setup_priority_; }
 
   void set_scan(bool scan) { scan_ = scan; }
   void set_sda_pin(uint8_t sda_pin) { sda_pin_ = sda_pin; }
@@ -30,6 +30,7 @@ class IDFI2CBus : public I2CBus, public Component {
   void set_scl_pullup_enabled(bool scl_pullup_enabled) { scl_pullup_enabled_ = scl_pullup_enabled; }
   void set_frequency(uint32_t frequency) { frequency_ = frequency; }
   void set_timeout(uint32_t timeout) { timeout_ = timeout; }
+  void set_priority(float priority) { setup_priority_ = priority; }
 
  private:
   void recover_();
@@ -44,6 +45,7 @@ class IDFI2CBus : public I2CBus, public Component {
   uint32_t frequency_;
   uint32_t timeout_ = 0;
   bool initialized_ = false;
+  float setup_priority_ = 1000.0f;
 };
 
 }  // namespace i2c

--- a/tests/components/i2c/common.yaml
+++ b/tests/components/i2c/common.yaml
@@ -2,4 +2,4 @@ i2c:
   - id: i2c_i2c
     scl: ${scl_pin}
     sda: ${sda_pin}
-    priority: 600
+    setup_priority: 600

--- a/tests/components/i2c/common.yaml
+++ b/tests/components/i2c/common.yaml
@@ -2,3 +2,4 @@ i2c:
   - id: i2c_i2c
     scl: ${scl_pin}
     sda: ${sda_pin}
+    priority: 600


### PR DESCRIPTION
# What does this implement/fix?

Adds the setup_priority field to the i2c components. This allows for users to delay the setup of the i2c bus in scenarios where they may have turned off devices attached to the i2c bus (low power/solar). 

Currently this behavior would results in the "SCL held low" error on the bus as the connected i2c devices are not powered. This is caused by the i2c component starting with priority 1000, vs the hardware/GPIO setup task at priority 800. 

This change allows users to set the i2c to setup after the hardware pins that may be controlled by a switch component to power the i2c devices. This prevents the errors caused by devices attached to the bus not being powered when the i2c component is initialized.

Default i2c test (tests/components/i2c/common.yaml) modified to add the new parameter.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes esphome/feature-requests#3069

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#4727

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
i2c:
  sda: GPIO5
  scl: GPIO6
  setup_priority: 601
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
