### PR TITLE
[helpers] Allow RAMAllocator to be told the size of the object manually

### DIFF
--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -3,11 +3,11 @@
 #include <cmath>
 #include <cstring>
 #include <functional>
+#include <limits>
 #include <memory>
 #include <string>
 #include <type_traits>
 #include <vector>
-#include <limits>
 
 #include "esphome/core/optional.h"
 
@@ -700,8 +700,10 @@ template<class T> class RAMAllocator {
   }
   template<class U> constexpr RAMAllocator(const RAMAllocator<U> &other) : flags_{other.flags_} {}
 
-  T *allocate(size_t n) {
-    size_t size = n * sizeof(T);
+  T *allocate(size_t n) { return this->allocate(n, sizeof(T)); }
+
+  T *allocate(size_t n, size_t manual_size) {
+    size_t size = n * manual_size;
     T *ptr = nullptr;
 #ifdef USE_ESP32
     if (this->flags_ & Flags::ALLOC_EXTERNAL) {


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

This is a requirement for #8354 as we cannot access the size of the struct.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
