### PR TITLE
[dashboard] Rename trash/delete to archive

### DIFF
--- a/esphome/storage_json.py
+++ b/esphome/storage_json.py
@@ -36,6 +36,10 @@ def trash_storage_path() -> str:
     return CORE.relative_config_path("trash")
 
 
+def archive_storage_path() -> str:
+    return CORE.relative_config_path("archive")
+
+
 class StorageJSON:
     def __init__(
         self,


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Since we dont actually delete the yaml files, it doesnt make sense to call this delete.

We will rename the frontend to be Archive, and potentially add a frontend way to list the archived files and restore them.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
