### PR TITLE
2025.2.2

### DIFF
--- a/esphome/components/audio/audio_reader.h
+++ b/esphome/components/audio/audio_reader.h
@@ -71,7 +71,7 @@ class AudioReader {
   void cleanup_connection_();
 
   size_t buffer_size_;
-  uint32_t no_data_read_count_;
+  uint32_t last_data_read_ms_;
 
   esp_http_client_handle_t client_{nullptr};
 

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
@@ -176,9 +176,9 @@ void ESP32BLETracker::loop() {
       https://github.com/espressif/esp-idf/issues/6688
 
     */
-    if (!connecting && !disconnecting && xSemaphoreTake(this->scan_end_lock_, 0L)) {
+    if (!connecting && xSemaphoreTake(this->scan_end_lock_, 0L)) {
       if (this->scan_continuous_) {
-        if (!promote_to_connecting && !this->scan_start_failed_ && !this->scan_set_param_failed_) {
+        if (!disconnecting && !promote_to_connecting && !this->scan_start_failed_ && !this->scan_set_param_failed_) {
           this->start_scan_(false);
         } else {
           // We didn't start the scan, so we need to release the lock

--- a/esphome/components/ltr390/ltr390.h
+++ b/esphome/components/ltr390/ltr390.h
@@ -77,7 +77,6 @@ class LTR390Component : public PollingComponent, public i2c::I2CDevice {
   LTR390GAIN gain_uv_;
   LTR390RESOLUTION res_als_;
   LTR390RESOLUTION res_uv_;
-  float sensitivity_uv_;
   float wfac_;
 
   sensor::Sensor *light_sensor_{nullptr};

--- a/esphome/const.py
+++ b/esphome/const.py
@@ -1,6 +1,6 @@
 """Constants used by esphome."""
 
-__version__ = "2025.2.1"
+__version__ = "2025.2.2"
 
 ALLOWED_NAME_CHARS = "abcdefghijklmnopqrstuvwxyz0123456789-_"
 VALID_SUBSTITUTIONS_CHARACTERS = (

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ platformio==6.1.16  # When updating platformio, also update Dockerfile
 esptool==4.7.0
 click==8.1.7
 esphome-dashboard==20250212.0
-aioesphomeapi==29.1.1
+aioesphomeapi==29.3.2
 zeroconf==0.145.1
 puremagic==1.27
 ruamel.yaml==0.18.6 # dashboard_import


### PR DESCRIPTION
**Do not merge, release script will automatically merge**
- Fix end_of_scan_ not being called while disconnecting [esphome#8328](https://github.com/esphome/esphome/pull/8328)
- [audio] Determine http timeout based on duration since last successful read [esphome#8341](https://github.com/esphome/esphome/pull/8341)
- Bump aioesphomeapi to 29.3.2 [esphome#8353](https://github.com/esphome/esphome/pull/8353)
- [ltr390] Move calculation to allow dynamic setting of gain and resolution [esphome#8343](https://github.com/esphome/esphome/pull/8343)

<details>
<summary>Metadata</summary>

@coderabbitai ignore
</details>
