### PR TITLE
[bmp085] Fix error in read of pressure

### DIFF
--- a/esphome/components/bmp085/bmp085.cpp
+++ b/esphome/components/bmp085/bmp085.cpp
@@ -95,7 +95,7 @@ void BMP085Component::read_pressure_() {
     return;
   }
 
-  uint32_t value = (uint32_t(buffer[0]) << 16) | (uint32_t(buffer[1]) << 8) | uint32_t(buffer[0]);
+  uint32_t value = (uint32_t(buffer[0]) << 16) | (uint32_t(buffer[1]) << 8) | uint32_t(buffer[2]);
   if ((value >> 5) == 0) {
     ESP_LOGW(TAG, "Invalid pressure!");
     this->status_set_warning();


### PR DESCRIPTION
# What does this implement/fix?

At the moment of constricting the raw value of pressure the buffer was adding two times buffer[0] And not taking into account the third part of that buffer

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
