### PR TITLE
[i2s_audio] Bugfix: Speaker incorrectly delays when sending data

### DIFF
--- a/esphome/components/i2s_audio/speaker/i2s_audio_speaker.cpp
+++ b/esphome/components/i2s_audio/speaker/i2s_audio_speaker.cpp
@@ -203,7 +203,7 @@ size_t I2SAudioSpeaker::play(const uint8_t *data, size_t length, TickType_t tick
     this->start();
   }
 
-  if ((this->state_ != speaker::STATE_RUNNING) || (this->audio_ring_buffer_.use_count() == 1)) {
+  if ((this->state_ != speaker::STATE_RUNNING) || (this->audio_ring_buffer_.use_count() != 1)) {
     // Unable to write data to a running speaker, so delay the max amount of time so it can get ready
     vTaskDelay(ticks_to_wait);
     ticks_to_wait = 0;


### PR DESCRIPTION
# What does this implement/fix?

Fixes a wrong negation for determining if the ``i2s_audio`` speaker isn't ready to receive data. This caused skipping audio for certain codec and speaker stack combinations.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** not applicable

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** not applicable

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

This config would cause constant skipping on a regular ESP32 before applying the fix

```yaml
# Example config.yaml

speaker:
  - platform: i2s_audio
    id: i2s_spk
    dac_type: external
    i2s_dout_pin: GPIOXX
    sample_rate: 48000
    bits_per_sample: 16bit
    channel: stereo

media_player:
  - platform: speaker
    id: external_media_player
    name: Media Player
    announcement_pipeline:
      speaker: i2s_spk
      format: MP3
      num_channels: 2

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
