### PR TITLE
Initialise h-bridge switch to requested initial state

### DIFF
--- a/esphome/components/hbridge/switch/hbridge_switch.cpp
+++ b/esphome/components/hbridge/switch/hbridge_switch.cpp
@@ -12,7 +12,7 @@ float HBridgeSwitch::get_setup_priority() const { return setup_priority::HARDWAR
 void HBridgeSwitch::setup() {
   ESP_LOGCONFIG(TAG, "Setting up H-Bridge Switch '%s'...", this->name_.c_str());
 
-  optional<bool> initial_state = this->get_initial_state_with_restore_mode().value_or(false);
+  optional<bool> initial_state = this->get_initial_state_with_restore_mode();
 
   // Like GPIOSwitch does, set the pin state both before and after pin setup()
   this->on_pin_->digital_write(false);
@@ -24,7 +24,7 @@ void HBridgeSwitch::setup() {
   this->off_pin_->digital_write(false);
 
   if (initial_state.has_value())
-    this->write_state(initial_state);
+    this->write_state(initial_state.value());
 }
 
 void HBridgeSwitch::dump_config() {


### PR DESCRIPTION
# What does this implement/fix?

Fixes https://github.com/esphome/issues/issues/6833
fixes https://github.com/esphome/issues/issues/6608

The `value_or(false)` call converted the `optional<bool>` to a plain `bool` and `write_state(initial_state)` was writing whether or not there was initial state (which there always would be because of the `value_or` call). This meant that regardless of the requested `restore_mode` in the config, the switch would always be turned on at boot.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes [<link to issue>](https://github.com/esphome/issues/issues/6833)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
esphome:
  name: name_was_here
  friendly_name: FRIENDLY_NAME_WAS_HERE

esp32:
  board: esp32dev
  framework:
    type: arduino

# Enable logging
logger:

# Enable Home Assistant API
api:
  encryption:
    key: KEY_WAS_HERE

ota:
  - platform: esphome
    password: PASSWORD_WAS_HERE

wifi:
  <<: !include network-common.yaml

captive_portal:

switch:
  - platform: hbridge
    id: ir_cut
    name: "IR Filter"
    # I'm aware 12 is a strapping pin, but I've tried 14, which isn't, and the issue still occurs
    on_pin: GPIO12
    off_pin: GPIO13
    pulse_length: 50ms
    wait_time: 50ms
    restore_mode: ALWAYS_OFF
```

## Checklist:
  - [x] The code change is tested and works locally. *Caveat: I bodged it locally by copying the source from my `.esphome` directory and feeding it to Platform IO on another machine as I don't know the proper procedure.*
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
