### PR TITLE
Bump aioesphomeapi to 29.5.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ platformio==6.1.16  # When updating platformio, also update Dockerfile
 esptool==4.7.0
 click==8.1.7
 esphome-dashboard==20250212.0
-aioesphomeapi==29.3.2
+aioesphomeapi==29.4.0
 zeroconf==0.145.1
 puremagic==1.27
 ruamel.yaml==0.18.6 # dashboard_import

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ platformio==6.1.16  # When updating platformio, also update Dockerfile
 esptool==4.7.0
 click==8.1.7
 esphome-dashboard==20250212.0
-aioesphomeapi==29.4.0
+aioesphomeapi==29.4.1
 zeroconf==0.145.1
 puremagic==1.27
 ruamel.yaml==0.18.6 # dashboard_import

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ platformio==6.1.16  # When updating platformio, also update Dockerfile
 esptool==4.7.0
 click==8.1.7
 esphome-dashboard==20250212.0
-aioesphomeapi==29.4.1
+aioesphomeapi==29.5.1
 zeroconf==0.145.1
 puremagic==1.27
 ruamel.yaml==0.18.6 # dashboard_import


### PR DESCRIPTION
# What does this implement/fix?

changelog: https://github.com/esphome/aioesphomeapi/compare/v29.3.2...v29.5.1

`aioesphomeapi-discover` now has `--verbose` flag to help tracking down https://github.com/esphome/issues/issues/6311


## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
