### PR TITLE
fix: Implemented internal method

### DIFF
--- a/esphome/components/ch422g/ch422g.cpp
+++ b/esphome/components/ch422g/ch422g.cpp
@@ -4,7 +4,7 @@
 namespace esphome {
 namespace ch422g {
 
-static const uint8_t CH422G_REG_MODE = 0x24;
+static const uint8_t CH422G_REG_MODE = 0x22;
 static const uint8_t CH422G_MODE_OUTPUT = 0x01;      // enables output mode on 0-7
 static const uint8_t CH422G_MODE_OPEN_DRAIN = 0x04;  // enables open drain mode on 8-11
 static const uint8_t CH422G_REG_IN = 0x26;           // read reg for input bits

--- a/esphome/components/ch422g/ch422g.cpp
+++ b/esphome/components/ch422g/ch422g.cpp
@@ -4,7 +4,7 @@
 namespace esphome {
 namespace ch422g {
 
-static const uint8_t CH422G_REG_MODE = 0x22;
+static const uint8_t CH422G_REG_MODE = 0x24;
 static const uint8_t CH422G_MODE_OUTPUT = 0x01;      // enables output mode on 0-7
 static const uint8_t CH422G_MODE_OPEN_DRAIN = 0x04;  // enables open drain mode on 8-11
 static const uint8_t CH422G_REG_IN = 0x26;           // read reg for input bits

--- a/esphome/components/ch422g/ch422g.h
+++ b/esphome/components/ch422g/ch422g.h
@@ -46,7 +46,7 @@ class CH422GComponent : public Component, public i2c::I2CDevice {
 /// Helper class to expose a CH422G pin as a GPIO pin.
 class CH422GGPIOPin : public GPIOPin {
  public:
-  void setup() override{};
+  void setup() override {};
   void pin_mode(gpio::Flags flags) override;
   bool digital_read() override;
   void digital_write(bool value) override;
@@ -58,6 +58,8 @@ class CH422GGPIOPin : public GPIOPin {
   void set_flags(gpio::Flags flags);
 
   gpio::Flags get_flags() const override { return this->flags_; }
+
+  bool is_internal() override { return false; }
 
  protected:
   CH422GComponent *parent_{};


### PR DESCRIPTION
# What does this implement/fix?
The CH422GGPIOPin class implements GPIOPin, which has the `is_internal()` method missing, and I get an error when instantiating it. This PR is adding the missing method.

```src/main.cpp: In function 'void setup()':
src/main.cpp:735:57: error: invalid new-expression of abstract class type 'esphome::ch422g::CH422GGPIOPin'
  735 |   ch422g_ch422ggpiopin_id_2 = new ch422g::CH422GGPIOPin();
      |                                                         ^
In file included from src/esphome.h:15,
                 from src/main.cpp:3:
src/esphome/components/ch422g/ch422g.h:49:7: note:   because the following virtual functions are pure within 'esphome::ch422g::CH422GGPIOPin':
   49 | class CH422GGPIOPin : public GPIOPin {
      |       ^~~~~~~~~~~~~
In file included from src/esphome/core/hal.h:4,
                 from src/esphome/core/application.h:7,
                 from src/esphome/components/api/api_connection.h:9,
                 from src/esphome.h:3:
src/esphome/core/gpio.h:61:23: note:     'virtual esphome::gpio::Flags esphome::GPIOPin::get_flags() const'
   61 |   virtual gpio::Flags get_flags() const = 0;
      |                       ^~~~~~~~~
src/main.cpp:741:55: error: invalid new-expression of abstract class type 'esphome::ch422g::CH422GGPIOPin'
  741 |   ch422g_ch422ggpiopin_id = new ch422g::CH422GGPIOPin();
      |                                                       ^
Compiling .pioenvs/waveshare-4-3-ch422g/driver/i2s/i2s_common.c.o
Compiling .pioenvs/waveshare-4-3-ch422g/driver/i2s/i2s_std.c.o
Compiling .pioenvs/waveshare-4-3-ch422g/driver/deprecated/i2s_legacy.c.o
Compiling .pioenvs/waveshare-4-3-ch422g/driver/i2s/i2s_pdm.c.o
Compiling .pioenvs/waveshare-4-3-ch422g/driver/i2s/i2s_tdm.c.o
./../esphome/display.yaml:276:57: error: invalid new-expression of abstract class type 'esphome::ch422g::CH422GGPIOPin'
Compiling .pioenvs/waveshare-4-3-ch422g/driver/ledc/ledc.c.o
Compiling .pioenvs/waveshare-4-3-ch422g/driver/mcpwm/mcpwm_cap.c.o
Compiling .pioenvs/waveshare-4-3-ch422g/driver/mcpwm/mcpwm_cmpr.c.o
Compiling .pioenvs/waveshare-4-3-ch422g/driver/mcpwm/mcpwm_com.c.o
Compiling .pioenvs/waveshare-4-3-ch422g/driver/mcpwm/mcpwm_fault.c.o
Compiling .pioenvs/waveshare-4-3-ch422g/driver/mcpwm/mcpwm_gen.c.o
Compiling .pioenvs/waveshare-4-3-ch422g/driver/mcpwm/mcpwm_oper.c.o
Compiling .pioenvs/waveshare-4-3-ch422g/driver/mcpwm/mcpwm_sync.c.o
Compiling .pioenvs/waveshare-4-3-ch422g/driver/mcpwm/mcpwm_timer.c.o
Compiling .pioenvs/waveshare-4-3-ch422g/driver/deprecated/mcpwm_legacy.c.o
*** [.pioenvs/waveshare-4-3-ch422g/src/main.cpp.o] Error 1
========================= [FAILED] Took 23.75 seconds =========================```

<!-- Quick description and explanation of changes -->

## Types of changes

- [ x ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
