### PR TITLE
mcp2515: Add missing CFG1 assignment to be able to use 50kbps with a 16MHz crystal.

### DIFF
--- a/esphome/components/mcp2515/mcp2515.cpp
+++ b/esphome/components/mcp2515/mcp2515.cpp
@@ -550,6 +550,7 @@ canbus::Error MCP2515::set_bitrate_(canbus::CanSpeed can_speed, CanClock can_clo
           cfg3 = MCP_16MHZ_40KBPS_CFG3;
           break;
         case (canbus::CAN_50KBPS):  //  50Kbps
+          cfg1 = MCP_16MHZ_50KBPS_CFG1;
           cfg2 = MCP_16MHZ_50KBPS_CFG2;
           cfg3 = MCP_16MHZ_50KBPS_CFG3;
           break;


### PR DESCRIPTION
# What does this implement/fix?

Add missing CFG1 assignment to be able to use 50kbps with a 16MHz crystal using an MCP2515.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
