### PR TITLE
[touchscreen] Axis swap bugfix

### DIFF
--- a/esphome/components/touchscreen/touchscreen.cpp
+++ b/esphome/components/touchscreen/touchscreen.cpp
@@ -74,6 +74,9 @@ void Touchscreen::loop() {
 void Touchscreen::add_raw_touch_position_(uint8_t id, int16_t x_raw, int16_t y_raw, int16_t z_raw) {
   TouchPoint tp;
   uint16_t x, y;
+  if (this->swap_x_y_) {
+    std::swap(x_raw, y_raw);
+  }
   if (this->touches_.count(id) == 0) {
     tp.state = STATE_PRESSED;
     tp.id = id;
@@ -89,10 +92,6 @@ void Touchscreen::add_raw_touch_position_(uint8_t id, int16_t x_raw, int16_t y_r
   if (this->x_raw_max_ != this->x_raw_min_ and this->y_raw_max_ != this->y_raw_min_) {
     x = this->normalize_(x_raw, this->x_raw_min_, this->x_raw_max_, this->invert_x_);
     y = this->normalize_(y_raw, this->y_raw_min_, this->y_raw_max_, this->invert_y_);
-
-    if (this->swap_x_y_) {
-      std::swap(x, y);
-    }
 
     tp.x = (uint16_t) ((int) x * this->display_width_ / 0x1000);
     tp.y = (uint16_t) ((int) y * this->display_height_ / 0x1000);


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

When using `transform` to swap the axes of a touchscreen, the swapping is done *after* the scaling via the calibration values. Since calibration values are set automatically from display dimensions this results in the range of values being calculated from the wrong axis unless calibration has been set manually. Instead the swapping is done at the raw level.

This is _potentially_ a breaking change since to work-around this problem some users may have set calibration values that are now wrong.


## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
