### PR TITLE
[audio, mixer] Memory and CPU performance improvements

### DIFF
--- a/esphome/components/audio/__init__.py
+++ b/esphome/components/audio/__init__.py
@@ -118,4 +118,4 @@ def final_validate_audio_schema(
 
 
 async def to_code(config):
-    cg.add_library("esphome/esp-audio-libs", "1.1.1")
+    cg.add_library("esphome/esp-audio-libs", "1.1.2")

--- a/esphome/components/audio/audio_reader.cpp
+++ b/esphome/components/audio/audio_reader.cpp
@@ -259,14 +259,14 @@ AudioReaderState AudioReader::file_read_() {
 }
 
 AudioReaderState AudioReader::http_read_() {
-  this->output_transfer_buffer_->transfer_data_to_sink(pdMS_TO_TICKS(READ_WRITE_TIMEOUT_MS));
+  this->output_transfer_buffer_->transfer_data_to_sink(pdMS_TO_TICKS(READ_WRITE_TIMEOUT_MS), false);
 
   if (esp_http_client_is_complete_data_received(this->client_)) {
     if (this->output_transfer_buffer_->available() == 0) {
       this->cleanup_connection_();
       return AudioReaderState::FINISHED;
     }
-  } else {
+  } else if (this->output_transfer_buffer_->free() > 0) {
     size_t bytes_to_read = this->output_transfer_buffer_->free();
     int received_len =
         esp_http_client_read(this->client_, (char *) this->output_transfer_buffer_->get_buffer_end(), bytes_to_read);

--- a/esphome/components/audio/audio_resampler.cpp
+++ b/esphome/components/audio/audio_resampler.cpp
@@ -116,6 +116,7 @@ AudioResamplerState AudioResampler::resample(bool stop_gracefully, int32_t *ms_d
 
   if ((this->input_stream_info_.get_sample_rate() != this->output_stream_info_.get_sample_rate()) ||
       (this->input_stream_info_.get_bits_per_sample() != this->output_stream_info_.get_bits_per_sample())) {
+    // Adjust gain by -3 dB to avoid clipping due to the resampling process
     esp_audio_libs::resampler::ResamplerResults results =
         this->resampler_->resample(this->input_transfer_buffer_->get_buffer_start(),
                                    this->output_transfer_buffer_->get_buffer_end(), frames_available, frames_free, -3);

--- a/esphome/components/audio/audio_resampler.cpp
+++ b/esphome/components/audio/audio_resampler.cpp
@@ -93,8 +93,9 @@ AudioResamplerState AudioResampler::resample(bool stop_gracefully, int32_t *ms_d
   }
 
   if (!this->pause_output_) {
-    // Move audio data to the sink
-    this->output_transfer_buffer_->transfer_data_to_sink(pdMS_TO_TICKS(READ_WRITE_TIMEOUT_MS));
+    // Move audio data to the sink without shifting the data in the output transfer buffer to avoid unnecessary, slow
+    // data moves
+    this->output_transfer_buffer_->transfer_data_to_sink(pdMS_TO_TICKS(READ_WRITE_TIMEOUT_MS), false);
   } else {
     // If paused, block to avoid wasting CPU resources
     delay(READ_WRITE_TIMEOUT_MS);

--- a/esphome/components/audio/audio_transfer_buffer.h
+++ b/esphome/components/audio/audio_transfer_buffer.h
@@ -60,6 +60,7 @@ class AudioTransferBuffer {
 
  protected:
   /// @brief Allocates the transfer buffer in external memory, if available.
+  /// @param buffer_size The number of bytes to allocate
   /// @return True is successful, false otherwise.
   bool allocate_buffer_(size_t buffer_size);
 
@@ -89,8 +90,10 @@ class AudioSinkTransferBuffer : public AudioTransferBuffer {
 
   /// @brief Writes any available data in the transfer buffer to the sink.
   /// @param ticks_to_wait FreeRTOS ticks to block while waiting for the sink to have enough space
+  /// @param post_shift If true, all remaining data is moved to the start of the buffer after transferring to the sink.
+  ///                   Defaults to true.
   /// @return Number of bytes written
-  size_t transfer_data_to_sink(TickType_t ticks_to_wait);
+  size_t transfer_data_to_sink(TickType_t ticks_to_wait, bool post_shift = true);
 
   /// @brief Adds a ring buffer as the transfer buffer's sink.
   /// @param ring_buffer weak_ptr to the allocated ring buffer
@@ -125,8 +128,10 @@ class AudioSourceTransferBuffer : public AudioTransferBuffer {
 
   /// @brief Reads any available data from the sink into the transfer buffer.
   /// @param ticks_to_wait FreeRTOS ticks to block while waiting for the source to have enough data
+  /// @param pre_shift If true, any unwritten data is moved to the start of the buffer before transferring from the
+  ///                  source. Defaults to true.
   /// @return Number of bytes read
-  size_t transfer_data_from_source(TickType_t ticks_to_wait);
+  size_t transfer_data_from_source(TickType_t ticks_to_wait, bool pre_shift = true);
 
   /// @brief Adds a ring buffer as the transfer buffer's source.
   /// @param ring_buffer weak_ptr to the allocated ring buffer

--- a/esphome/components/mixer/speaker/mixer_speaker.cpp
+++ b/esphome/components/mixer/speaker/mixer_speaker.cpp
@@ -490,7 +490,8 @@ void MixerSpeaker::audio_mixer_task(void *params) {
       break;
     }
 
-    output_transfer_buffer->transfer_data_to_sink(pdMS_TO_TICKS(TASK_DELAY_MS));
+    // Never shift the data in the output transfer buffer to avoid unnecessary, slow data moves
+    output_transfer_buffer->transfer_data_to_sink(pdMS_TO_TICKS(TASK_DELAY_MS), false);
 
     const uint32_t output_frames_free =
         this_mixer->audio_stream_info_.value().bytes_to_frames(output_transfer_buffer->free());

--- a/platformio.ini
+++ b/platformio.ini
@@ -128,7 +128,7 @@ lib_deps =
     DNSServer                            ; captive_portal (Arduino built-in)
     esphome/ESP32-audioI2S@2.0.7         ; i2s_audio
     droscy/esp_wireguard@0.4.2           ; wireguard
-    esphome/esp-audio-libs@1.1.1         ; audio
+    esphome/esp-audio-libs@1.1.2         ; audio
 
 build_flags =
     ${common:arduino.build_flags}
@@ -149,7 +149,7 @@ lib_deps =
     ${common:idf.lib_deps}
     droscy/esp_wireguard@0.4.2              ; wireguard
     kahrendt/ESPMicroSpeechFeatures@1.1.0   ; micro_wake_word
-    esphome/esp-audio-libs@1.1.1            ; audio
+    esphome/esp-audio-libs@1.1.2            ; audio
 build_flags =
     ${common:idf.build_flags}
     -Wno-nonnull-compare


### PR DESCRIPTION
# What does this implement/fix?

This PR improves the ``AudioTransferBuffer`` class memory handling. Previously, any data not transferred to the sink would be moved to the start of the buffer. This can be useful in certain scenarios, but for the most part, this needlessly wastes CPU cycles. This PR makes this move optional (but defaults to always doing so its not a breaking change). It also updates esp-audio-libs ([GitHub](https://github.com/esphome/esp-audio-libs), [PlatformIO](https://registry.platformio.org/libraries/esphome/esp-audio-libs)) to version 1.1.2, which fixes an issue where the FLAC and MP3 decoders only worked on devices with PSRAM.

---

Here's a couple of task CPU usage measurements on an ESP32-S3 showing the performance benefit:

Playing a stereo 44.1kHz MP3 file resampled to 48 kHz going through a mixer speaker component
- HTTP Read: 5% -> 0%
- Decode: 14% -> 11%
- Resample: 14% -> 13%
- Mixer: 3% -> 2%

Total: 36% -> 26% (a 28% decrease in CPU use!)

Playing a stereo 48 kHz FLAC file without resampling going through a mixer speaker component
- HTTP Read: 4% -> 1%
- Decode: 12% -> 8%
- Mixer: 2% -> 2%

Total: 18% -> 11% (a 39% decrease in CPU use!)

Plain ESP32 chips also greatly benefit from these changes, especially since they typically have slower PSRAM speeds:

Playing a stereo 44.1 kHz MP3 file without resampling going through a mixer speaker component
(The old code is unusable, as the file consistently stutters, hence the mixer CPU usage actually increases with these changes)
- HTTP Read: 17% -> 2%
- Decode: 42% -> 40%
- Mixer: 5% -> 8%

Total: 64% -> 50% (a 22% decrease in CPU use and actually usable!)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** not applicable

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** not applicable

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

speaker:
  - platform: i2s_audio
    id: i2s_audio_speaker
    dac_type: external
    i2s_dout_pin: GPIOXX
    sample_rate: 48000
    bits_per_sample: 16bit
    channel: stereo
    timeout: never
    buffer_duration: 100ms
  - platform: mixer
    id: mixer_speaker_id
    output_speaker: i2s_audio_speaker
    num_channels: 2
    source_speakers:
      - id: announcement_spk_mixer_input
        timeout: never
      - id: media_spk_mixer_input
        timeout: never

media_player:
  - platform: speaker
    id: external_media_player
    name: Media Player
    announcement_pipeline:
      speaker: announcement_spk_mixer_input
      format: FLAC
      num_channels: 1
    media_pipeline:
      speaker: media_spk_mixer_input
      format: FLAC
      num_channels: 2

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
