### PR TITLE
[core] add reallocation support to RAMAllocator

### DIFF
--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -719,6 +719,25 @@ template<class T> class RAMAllocator {
     return ptr;
   }
 
+  T *reallocate(T *p, size_t n) { return this->reallocate(p, n, sizeof(T)); }
+
+  T *reallocate(T *p, size_t n, size_t manual_size) {
+    size_t size = n * sizeof(T);
+    T *ptr = nullptr;
+#ifdef USE_ESP32
+    if (this->flags_ & Flags::ALLOC_EXTERNAL) {
+      ptr = static_cast<T *>(heap_caps_realloc(p, size, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT));
+    }
+    if (ptr == nullptr && this->flags_ & Flags::ALLOC_INTERNAL) {
+      ptr = static_cast<T *>(heap_caps_realloc(p, size, MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT));
+    }
+#else
+    // Ignore ALLOC_EXTERNAL/ALLOC_INTERNAL flags if external allocation is not supported
+    ptr = static_cast<T *>(realloc(p, size));  // NOLINT(cppcoreguidelines-owning-memory,cppcoreguidelines-no-malloc)
+#endif
+    return ptr;
+  }
+
   void deallocate(T *p, size_t n) {
     free(p);  // NOLINT(cppcoreguidelines-owning-memory,cppcoreguidelines-no-malloc)
   }


### PR DESCRIPTION
# What does this implement/fix?

Adds a ``reallocate`` function to the ``RAMAllocator`` helper class, based on the ESP32 function ``heap_caps_realloc``. On non-ESP32 platforms, it falls back to the standard C ``realloc``.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** not applicable

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** not applicable

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

Not applicable

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
