### PR TITLE
[speaker, resampler, mixer] Make volume and mute getters virtual

### DIFF
--- a/esphome/components/mixer/speaker/mixer_speaker.cpp
+++ b/esphome/components/mixer/speaker/mixer_speaker.cpp
@@ -177,10 +177,14 @@ void SourceSpeaker::set_mute_state(bool mute_state) {
   this->parent_->get_output_speaker()->set_mute_state(mute_state);
 }
 
+bool SourceSpeaker::get_mute_state() { return this->parent_->get_output_speaker()->get_mute_state(); }
+
 void SourceSpeaker::set_volume(float volume) {
   this->volume_ = volume;
   this->parent_->get_output_speaker()->set_volume(volume);
 }
+
+float SourceSpeaker::get_volume() { return this->parent_->get_output_speaker()->get_volume(); }
 
 size_t SourceSpeaker::process_data_from_source(TickType_t ticks_to_wait) {
   if (!this->transfer_buffer_.use_count()) {

--- a/esphome/components/mixer/speaker/mixer_speaker.h
+++ b/esphome/components/mixer/speaker/mixer_speaker.h
@@ -53,9 +53,11 @@ class SourceSpeaker : public speaker::Speaker, public Component {
 
   /// @brief Mute state changes are passed to the parent's output speaker
   void set_mute_state(bool mute_state) override;
+  bool get_mute_state() override;
 
   /// @brief Volume state changes are passed to the parent's output speaker
   void set_volume(float volume) override;
+  float get_volume() override;
 
   void set_pause_state(bool pause_state) override { this->pause_state_ = pause_state; }
   bool get_pause_state() const override { return this->pause_state_; }

--- a/esphome/components/resampler/speaker/resampler_speaker.h
+++ b/esphome/components/resampler/speaker/resampler_speaker.h
@@ -34,9 +34,11 @@ class ResamplerSpeaker : public Component, public speaker::Speaker {
 
   /// @brief Mute state changes are passed to the parent's output speaker
   void set_mute_state(bool mute_state) override;
+  bool get_mute_state() override { return this->output_speaker_->get_mute_state(); }
 
   /// @brief Volume state changes are passed to the parent's output speaker
   void set_volume(float volume) override;
+  float get_volume() override { return this->output_speaker_->get_volume(); }
 
   void set_output_speaker(speaker::Speaker *speaker) { this->output_speaker_ = speaker; }
   void set_task_stack_in_psram(bool task_stack_in_psram) { this->task_stack_in_psram_ = task_stack_in_psram; }

--- a/esphome/components/speaker/speaker.h
+++ b/esphome/components/speaker/speaker.h
@@ -76,7 +76,7 @@ class Speaker {
     }
 #endif
   };
-  float get_volume() { return this->volume_; }
+  virtual float get_volume() { return this->volume_; }
 
   virtual void set_mute_state(bool mute_state) {
     this->mute_state_ = mute_state;
@@ -90,7 +90,7 @@ class Speaker {
     }
 #endif
   }
-  bool get_mute_state() { return this->mute_state_; }
+  virtual bool get_mute_state() { return this->mute_state_; }
 
 #ifdef USE_AUDIO_DAC
   void set_audio_dac(audio_dac::AudioDac *audio_dac) { this->audio_dac_ = audio_dac; }


### PR DESCRIPTION
# What does this implement/fix?

Makes the mute and volume getters virtual in the ``speaker`` class. Since the resampler and mixer speakers' setters pass all volume and mute commands to their output speakers, the corresponding getters should also get their states from the output speakers instead of returning their non-updated internal values.

These functions are internal and not used in a user facing way.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** not applicable

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** not applicable

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
