### PR TITLE
Bump aioesphomeapi to 29.6.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ platformio==6.1.16  # When updating platformio, also update Dockerfile
 esptool==4.8.1
 click==8.1.7
 esphome-dashboard==20250212.0
-aioesphomeapi==29.5.1
+aioesphomeapi==29.6.0
 zeroconf==0.146.1
 puremagic==1.27
 ruamel.yaml==0.18.6 # dashboard_import


### PR DESCRIPTION


changelog: https://github.com/esphome/aioesphomeapi/compare/v29.5.1...v29.6.0

