### PR TITLE
Rework pyproject.toml to make it parseable by dependabot

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,10 +43,12 @@ include-package-data = true
 
 [tool.setuptools.dynamic]
 dependencies = {file = ["requirements.txt"]}
-optional-dependencies.dev = { file = ["requirements_dev.txt"] }
-optional-dependencies.test = { file = ["requirements_test.txt"] }
-optional-dependencies.displays = { file = ["requirements_optional.txt"] }
 version = {attr = "esphome.const.__version__"}
+
+[tool.setuptools.dynamic.optional-dependencies]
+dev = { file = ["requirements_dev.txt"] }
+test = { file = ["requirements_test.txt"] }
+displays = { file = ["requirements_optional.txt"] }
 
 [tool.setuptools.packages.find]
 include = ["esphome*"]


### PR DESCRIPTION

# What does this implement/fix?

Dependabot updates have been failing because the ruby toml parser used by dependabot fails to parse `pyproject.toml`

Test script: `toml_test.rb`:
```ruby
require 'toml-rb'
TomlRB.load_file(File.join(File.dirname(__FILE__), 'pyproject.toml'))
```

Before
```
toml-rb/keyvalue.rb:21:in 'block in TomlRB::Keyvalue#assign': Key "optional-dependencies" is defined more than once (TomlRB::ValueOverwriteError)
```

After - no error


## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
