### PR TITLE
2025.3.0b2

### DIFF
--- a/esphome/components/api/api.proto
+++ b/esphome/components/api/api.proto
@@ -1567,6 +1567,8 @@ message VoiceAssistantAnnounceRequest {
 
   string media_id = 1;
   string text = 2;
+  string preannounce_media_id = 3;
+  bool start_conversation = 4;
 }
 
 message VoiceAssistantAnnounceFinished {

--- a/esphome/components/api/api_pb2.cpp
+++ b/esphome/components/api/api_pb2.cpp
@@ -7094,6 +7094,16 @@ void VoiceAssistantTimerEventResponse::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
+bool VoiceAssistantAnnounceRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 4: {
+      this->start_conversation = value.as_bool();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
 bool VoiceAssistantAnnounceRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 1: {
@@ -7104,6 +7114,10 @@ bool VoiceAssistantAnnounceRequest::decode_length(uint32_t field_id, ProtoLength
       this->text = value.as_string();
       return true;
     }
+    case 3: {
+      this->preannounce_media_id = value.as_string();
+      return true;
+    }
     default:
       return false;
   }
@@ -7111,6 +7125,8 @@ bool VoiceAssistantAnnounceRequest::decode_length(uint32_t field_id, ProtoLength
 void VoiceAssistantAnnounceRequest::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_string(1, this->media_id);
   buffer.encode_string(2, this->text);
+  buffer.encode_string(3, this->preannounce_media_id);
+  buffer.encode_bool(4, this->start_conversation);
 }
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void VoiceAssistantAnnounceRequest::dump_to(std::string &out) const {
@@ -7122,6 +7138,14 @@ void VoiceAssistantAnnounceRequest::dump_to(std::string &out) const {
 
   out.append("  text: ");
   out.append("'").append(this->text).append("'");
+  out.append("\n");
+
+  out.append("  preannounce_media_id: ");
+  out.append("'").append(this->preannounce_media_id).append("'");
+  out.append("\n");
+
+  out.append("  start_conversation: ");
+  out.append(YESNO(this->start_conversation));
   out.append("\n");
   out.append("}");
 }

--- a/esphome/components/api/api_pb2.h
+++ b/esphome/components/api/api_pb2.h
@@ -1832,6 +1832,8 @@ class VoiceAssistantAnnounceRequest : public ProtoMessage {
  public:
   std::string media_id{};
   std::string text{};
+  std::string preannounce_media_id{};
+  bool start_conversation{false};
   void encode(ProtoWriteBuffer buffer) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
@@ -1839,6 +1841,7 @@ class VoiceAssistantAnnounceRequest : public ProtoMessage {
 
  protected:
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
 class VoiceAssistantAnnounceFinished : public ProtoMessage {
  public:

--- a/esphome/components/audio/__init__.py
+++ b/esphome/components/audio/__init__.py
@@ -118,4 +118,4 @@ def final_validate_audio_schema(
 
 
 async def to_code(config):
-    cg.add_library("esphome/esp-audio-libs", "1.1.1")
+    cg.add_library("esphome/esp-audio-libs", "1.1.2")

--- a/esphome/components/audio/audio_reader.cpp
+++ b/esphome/components/audio/audio_reader.cpp
@@ -259,14 +259,14 @@ AudioReaderState AudioReader::file_read_() {
 }
 
 AudioReaderState AudioReader::http_read_() {
-  this->output_transfer_buffer_->transfer_data_to_sink(pdMS_TO_TICKS(READ_WRITE_TIMEOUT_MS));
+  this->output_transfer_buffer_->transfer_data_to_sink(pdMS_TO_TICKS(READ_WRITE_TIMEOUT_MS), false);
 
   if (esp_http_client_is_complete_data_received(this->client_)) {
     if (this->output_transfer_buffer_->available() == 0) {
       this->cleanup_connection_();
       return AudioReaderState::FINISHED;
     }
-  } else {
+  } else if (this->output_transfer_buffer_->free() > 0) {
     size_t bytes_to_read = this->output_transfer_buffer_->free();
     int received_len =
         esp_http_client_read(this->client_, (char *) this->output_transfer_buffer_->get_buffer_end(), bytes_to_read);

--- a/esphome/components/audio/audio_transfer_buffer.h
+++ b/esphome/components/audio/audio_transfer_buffer.h
@@ -60,6 +60,7 @@ class AudioTransferBuffer {
 
  protected:
   /// @brief Allocates the transfer buffer in external memory, if available.
+  /// @param buffer_size The number of bytes to allocate
   /// @return True is successful, false otherwise.
   bool allocate_buffer_(size_t buffer_size);
 
@@ -89,8 +90,10 @@ class AudioSinkTransferBuffer : public AudioTransferBuffer {
 
   /// @brief Writes any available data in the transfer buffer to the sink.
   /// @param ticks_to_wait FreeRTOS ticks to block while waiting for the sink to have enough space
+  /// @param post_shift If true, all remaining data is moved to the start of the buffer after transferring to the sink.
+  ///                   Defaults to true.
   /// @return Number of bytes written
-  size_t transfer_data_to_sink(TickType_t ticks_to_wait);
+  size_t transfer_data_to_sink(TickType_t ticks_to_wait, bool post_shift = true);
 
   /// @brief Adds a ring buffer as the transfer buffer's sink.
   /// @param ring_buffer weak_ptr to the allocated ring buffer
@@ -125,8 +128,10 @@ class AudioSourceTransferBuffer : public AudioTransferBuffer {
 
   /// @brief Reads any available data from the sink into the transfer buffer.
   /// @param ticks_to_wait FreeRTOS ticks to block while waiting for the source to have enough data
+  /// @param pre_shift If true, any unwritten data is moved to the start of the buffer before transferring from the
+  ///                  source. Defaults to true.
   /// @return Number of bytes read
-  size_t transfer_data_from_source(TickType_t ticks_to_wait);
+  size_t transfer_data_from_source(TickType_t ticks_to_wait, bool pre_shift = true);
 
   /// @brief Adds a ring buffer as the transfer buffer's source.
   /// @param ring_buffer weak_ptr to the allocated ring buffer

--- a/esphome/components/mdns/__init__.py
+++ b/esphome/components/mdns/__init__.py
@@ -91,7 +91,7 @@ async def to_code(config):
         add_idf_component(
             name="mdns",
             repo="https://github.com/espressif/esp-protocols.git",
-            ref="mdns-v1.5.1",
+            ref="mdns-v1.8.0",
             path="components/mdns",
         )
 

--- a/esphome/components/mixer/speaker/mixer_speaker.cpp
+++ b/esphome/components/mixer/speaker/mixer_speaker.cpp
@@ -490,7 +490,8 @@ void MixerSpeaker::audio_mixer_task(void *params) {
       break;
     }
 
-    output_transfer_buffer->transfer_data_to_sink(pdMS_TO_TICKS(TASK_DELAY_MS));
+    // Never shift the data in the output transfer buffer to avoid unnecessary, slow data moves
+    output_transfer_buffer->transfer_data_to_sink(pdMS_TO_TICKS(TASK_DELAY_MS), false);
 
     const uint32_t output_frames_free =
         this_mixer->audio_stream_info_.value().bytes_to_frames(output_transfer_buffer->free());

--- a/esphome/components/mixer/speaker/mixer_speaker.cpp
+++ b/esphome/components/mixer/speaker/mixer_speaker.cpp
@@ -177,10 +177,14 @@ void SourceSpeaker::set_mute_state(bool mute_state) {
   this->parent_->get_output_speaker()->set_mute_state(mute_state);
 }
 
+bool SourceSpeaker::get_mute_state() { return this->parent_->get_output_speaker()->get_mute_state(); }
+
 void SourceSpeaker::set_volume(float volume) {
   this->volume_ = volume;
   this->parent_->get_output_speaker()->set_volume(volume);
 }
+
+float SourceSpeaker::get_volume() { return this->parent_->get_output_speaker()->get_volume(); }
 
 size_t SourceSpeaker::process_data_from_source(TickType_t ticks_to_wait) {
   if (!this->transfer_buffer_.use_count()) {

--- a/esphome/components/mixer/speaker/mixer_speaker.h
+++ b/esphome/components/mixer/speaker/mixer_speaker.h
@@ -53,9 +53,11 @@ class SourceSpeaker : public speaker::Speaker, public Component {
 
   /// @brief Mute state changes are passed to the parent's output speaker
   void set_mute_state(bool mute_state) override;
+  bool get_mute_state() override;
 
   /// @brief Volume state changes are passed to the parent's output speaker
   void set_volume(float volume) override;
+  float get_volume() override;
 
   void set_pause_state(bool pause_state) override { this->pause_state_ = pause_state; }
   bool get_pause_state() const override { return this->pause_state_; }

--- a/esphome/components/resampler/speaker/resampler_speaker.h
+++ b/esphome/components/resampler/speaker/resampler_speaker.h
@@ -34,9 +34,11 @@ class ResamplerSpeaker : public Component, public speaker::Speaker {
 
   /// @brief Mute state changes are passed to the parent's output speaker
   void set_mute_state(bool mute_state) override;
+  bool get_mute_state() override { return this->output_speaker_->get_mute_state(); }
 
   /// @brief Volume state changes are passed to the parent's output speaker
   void set_volume(float volume) override;
+  float get_volume() override { return this->output_speaker_->get_volume(); }
 
   void set_output_speaker(speaker::Speaker *speaker) { this->output_speaker_ = speaker; }
   void set_task_stack_in_psram(bool task_stack_in_psram) { this->task_stack_in_psram_ = task_stack_in_psram; }

--- a/esphome/components/speaker/speaker.h
+++ b/esphome/components/speaker/speaker.h
@@ -76,7 +76,7 @@ class Speaker {
     }
 #endif
   };
-  float get_volume() { return this->volume_; }
+  virtual float get_volume() { return this->volume_; }
 
   virtual void set_mute_state(bool mute_state) {
     this->mute_state_ = mute_state;
@@ -90,7 +90,7 @@ class Speaker {
     }
 #endif
   }
-  bool get_mute_state() { return this->mute_state_; }
+  virtual bool get_mute_state() { return this->mute_state_; }
 
 #ifdef USE_AUDIO_DAC
   void set_audio_dac(audio_dac::AudioDac *audio_dac) { this->audio_dac_ = audio_dac; }

--- a/esphome/const.py
+++ b/esphome/const.py
@@ -1,6 +1,6 @@
 """Constants used by esphome."""
 
-__version__ = "2025.3.0b1"
+__version__ = "2025.3.0b2"
 
 ALLOWED_NAME_CHARS = "abcdefghijklmnopqrstuvwxyz0123456789-_"
 VALID_SUBSTITUTIONS_CHARACTERS = (

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -719,6 +719,25 @@ template<class T> class RAMAllocator {
     return ptr;
   }
 
+  T *reallocate(T *p, size_t n) { return this->reallocate(p, n, sizeof(T)); }
+
+  T *reallocate(T *p, size_t n, size_t manual_size) {
+    size_t size = n * sizeof(T);
+    T *ptr = nullptr;
+#ifdef USE_ESP32
+    if (this->flags_ & Flags::ALLOC_EXTERNAL) {
+      ptr = static_cast<T *>(heap_caps_realloc(p, size, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT));
+    }
+    if (ptr == nullptr && this->flags_ & Flags::ALLOC_INTERNAL) {
+      ptr = static_cast<T *>(heap_caps_realloc(p, size, MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT));
+    }
+#else
+    // Ignore ALLOC_EXTERNAL/ALLOC_INTERNAL flags if external allocation is not supported
+    ptr = static_cast<T *>(realloc(p, size));  // NOLINT(cppcoreguidelines-owning-memory,cppcoreguidelines-no-malloc)
+#endif
+    return ptr;
+  }
+
   void deallocate(T *p, size_t n) {
     free(p);  // NOLINT(cppcoreguidelines-owning-memory,cppcoreguidelines-no-malloc)
   }

--- a/esphome/idf_component.yml
+++ b/esphome/idf_component.yml
@@ -7,7 +7,7 @@ dependencies:
     version: v2.0.9
   mdns:
     git: https://github.com/espressif/esp-protocols.git
-    version: mdns-v1.5.1
+    version: mdns-v1.8.0
     path: components/mdns
     rules:
       - if: "idf_version >=5.0"

--- a/platformio.ini
+++ b/platformio.ini
@@ -128,7 +128,7 @@ lib_deps =
     DNSServer                            ; captive_portal (Arduino built-in)
     esphome/ESP32-audioI2S@2.0.7         ; i2s_audio
     droscy/esp_wireguard@0.4.2           ; wireguard
-    esphome/esp-audio-libs@1.1.1         ; audio
+    esphome/esp-audio-libs@1.1.2         ; audio
 
 build_flags =
     ${common:arduino.build_flags}
@@ -149,7 +149,7 @@ lib_deps =
     ${common:idf.lib_deps}
     droscy/esp_wireguard@0.4.2              ; wireguard
     kahrendt/ESPMicroSpeechFeatures@1.1.0   ; micro_wake_word
-    esphome/esp-audio-libs@1.1.1            ; audio
+    esphome/esp-audio-libs@1.1.2            ; audio
 build_flags =
     ${common:idf.build_flags}
     -Wno-nonnull-compare

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,10 +43,12 @@ include-package-data = true
 
 [tool.setuptools.dynamic]
 dependencies = {file = ["requirements.txt"]}
-optional-dependencies.dev = { file = ["requirements_dev.txt"] }
-optional-dependencies.test = { file = ["requirements_test.txt"] }
-optional-dependencies.displays = { file = ["requirements_optional.txt"] }
 version = {attr = "esphome.const.__version__"}
+
+[tool.setuptools.dynamic.optional-dependencies]
+dev = { file = ["requirements_dev.txt"] }
+test = { file = ["requirements_test.txt"] }
+displays = { file = ["requirements_optional.txt"] }
 
 [tool.setuptools.packages.find]
 include = ["esphome*"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ PyYAML==6.0.2
 paho-mqtt==1.6.1
 colorama==0.4.6
 icmplib==3.0.4
-tornado==6.4
+tornado==6.4.2
 tzlocal==5.2    # from time
 tzdata>=2021.1  # from time
 pyserial==3.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ platformio==6.1.16  # When updating platformio, also update Dockerfile
 esptool==4.8.1
 click==8.1.7
 esphome-dashboard==20250212.0
-aioesphomeapi==29.5.1
+aioesphomeapi==29.6.0
 zeroconf==0.146.1
 puremagic==1.27
 ruamel.yaml==0.18.6 # dashboard_import

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 async_timeout==4.0.3; python_version <= "3.10"
-cryptography==43.0.0
+cryptography==44.0.2
 voluptuous==0.14.2
 PyYAML==6.0.2
 paho-mqtt==1.6.1


### PR DESCRIPTION
**Do not merge, release script will automatically merge**
## Full list of changes

### All changes

- Bump mdns library to 1.8.0 [esphome#8378](https://github.com/esphome/esphome/pull/8378)
- [audio, mixer] Memory and CPU performance improvements [esphome#8387](https://github.com/esphome/esphome/pull/8387)
- [speaker, resampler, mixer] Make volume and mute getters virtual [esphome#8391](https://github.com/esphome/esphome/pull/8391)
- [core] add reallocation support to RAMAllocator [esphome#8390](https://github.com/esphome/esphome/pull/8390)
- [api] add voice assistant announce to the api [esphome#8395](https://github.com/esphome/esphome/pull/8395)
- Bump aioesphomeapi to 29.6.0 [esphome#8396](https://github.com/esphome/esphome/pull/8396)
- Rework pyproject.toml to make it parseable by dependabot [esphome#8397](https://github.com/esphome/esphome/pull/8397)
- Bump cryptography to 44.0.2 [esphome#8399](https://github.com/esphome/esphome/pull/8399)
- Bump tornado from 6.4 to 6.4.2 [esphome#8398](https://github.com/esphome/esphome/pull/8398)

<details>
<summary>Metadata</summary>

@coderabbitai ignore
</details>
