### PR TITLE
New "keep" value to preserve current target temperature when switching presets

### DIFF
--- a/esphome/components/thermostat/climate.py
+++ b/esphome/components/thermostat/climate.py
@@ -74,6 +74,8 @@ CONF_PRESET_CHANGE = "preset_change"
 CONF_DEFAULT_PRESET = "default_preset"
 CONF_ON_BOOT_RESTORE_FROM = "on_boot_restore_from"
 
+TEMPERATURE_VALUE_KEEP = "keep"
+
 CODEOWNERS = ["@kbx81"]
 
 climate_ns = cg.esphome_ns.namespace("climate")
@@ -110,8 +112,14 @@ PRESET_CONFIG_SCHEMA = cv.Schema(
         cv.GenerateID(): cv.declare_id(ThermostatClimateTargetTempConfig),
         cv.Required(CONF_NAME): cv.string_strict,
         cv.Optional(CONF_MODE): validate_climate_mode,
-        cv.Optional(CONF_DEFAULT_TARGET_TEMPERATURE_HIGH): cv.temperature,
-        cv.Optional(CONF_DEFAULT_TARGET_TEMPERATURE_LOW): cv.temperature,
+        cv.Optional(CONF_DEFAULT_TARGET_TEMPERATURE_HIGH): cv.Any(
+            cv.temperature,
+            cv.one_of("keep", lower=True),
+        ),
+        cv.Optional(CONF_DEFAULT_TARGET_TEMPERATURE_LOW): cv.Any(
+            cv.temperature,
+            cv.one_of("keep", lower=True),
+        ),
         cv.Optional(CONF_FAN_MODE): cv.templatable(climate.validate_climate_fan_mode),
         cv.Optional(CONF_SWING_MODE): cv.templatable(
             climate.validate_climate_swing_mode
@@ -378,7 +386,11 @@ def validate_thermostat(config):
                 preset_min_temperature = preset_config[
                     CONF_DEFAULT_TARGET_TEMPERATURE_LOW
                 ]
-                if preset_min_temperature < visual_min_temperature:
+                # due to config validation, the preset_min_temperature can be "keep" or a float value
+                if (
+                    str(preset_min_temperature).lower() != TEMPERATURE_VALUE_KEEP
+                    and preset_min_temperature < visual_min_temperature
+                ):
                     raise cv.Invalid(
                         f"{CONF_DEFAULT_TARGET_TEMPERATURE_LOW} for {preset_config[CONF_NAME]} is set to {preset_min_temperature} which is less than the visual minimum temperature of {visual_min_temperature}"
                     )
@@ -387,9 +399,33 @@ def validate_thermostat(config):
                 preset_max_temperature = preset_config[
                     CONF_DEFAULT_TARGET_TEMPERATURE_HIGH
                 ]
-                if preset_max_temperature > visual_max_temperature:
+                # due to config validation, the preset_max_temperature can be "keep" or a float value
+                if (
+                    str(preset_max_temperature).lower() != TEMPERATURE_VALUE_KEEP
+                    and preset_max_temperature > visual_max_temperature
+                ):
                     raise cv.Invalid(
                         f"{CONF_DEFAULT_TARGET_TEMPERATURE_HIGH} for {preset_config[CONF_NAME]} is set to {preset_max_temperature} which is more than the visual maximum temperature of {visual_max_temperature}"
+                    )
+
+        # Keep temperature validation
+        for preset_config in config[CONF_PRESET]:
+            try:
+                preset_min_temperature = preset_config[
+                    CONF_DEFAULT_TARGET_TEMPERATURE_LOW
+                ]
+                preset_max_temperature = preset_config[
+                    CONF_DEFAULT_TARGET_TEMPERATURE_HIGH
+                ]
+            except KeyError:
+                pass
+            else:
+                if (
+                    str(preset_min_temperature).lower() == TEMPERATURE_VALUE_KEEP
+                    or str(preset_max_temperature).lower() == TEMPERATURE_VALUE_KEEP
+                ):
+                    raise cv.Invalid(
+                        f"with two-point target temperature {CONF_DEFAULT_TARGET_TEMPERATURE_LOW} and {CONF_DEFAULT_TARGET_TEMPERATURE_HIGH} cannot be {TEMPERATURE_VALUE_KEEP} as in preset {preset_config[CONF_NAME]} "
                     )
 
         # Mode validation
@@ -898,13 +934,27 @@ async def to_code(config):
                     preset_config[CONF_DEFAULT_TARGET_TEMPERATURE_HIGH],
                 )
             elif CONF_DEFAULT_TARGET_TEMPERATURE_HIGH in preset_config:
-                preset_target_config = ThermostatClimateTargetTempConfig(
-                    preset_config[CONF_DEFAULT_TARGET_TEMPERATURE_HIGH]
-                )
+                preset_max_temperature = preset_config[
+                    CONF_DEFAULT_TARGET_TEMPERATURE_HIGH
+                ]
+
+                if str(preset_max_temperature).lower() == TEMPERATURE_VALUE_KEEP:
+                    preset_target_config = ThermostatClimateTargetTempConfig()
+                else:
+                    preset_target_config = ThermostatClimateTargetTempConfig(
+                        preset_max_temperature
+                    )
             elif CONF_DEFAULT_TARGET_TEMPERATURE_LOW in preset_config:
-                preset_target_config = ThermostatClimateTargetTempConfig(
-                    preset_config[CONF_DEFAULT_TARGET_TEMPERATURE_LOW]
-                )
+                preset_min_temperature = preset_config[
+                    CONF_DEFAULT_TARGET_TEMPERATURE_LOW
+                ]
+
+                if str(preset_min_temperature).lower() == TEMPERATURE_VALUE_KEEP:
+                    preset_target_config = ThermostatClimateTargetTempConfig()
+                else:
+                    preset_target_config = ThermostatClimateTargetTempConfig(
+                        preset_min_temperature
+                    )
             else:
                 preset_target_config = None
 

--- a/esphome/components/thermostat/climate.py
+++ b/esphome/components/thermostat/climate.py
@@ -408,26 +408,6 @@ def validate_thermostat(config):
                         f"{CONF_DEFAULT_TARGET_TEMPERATURE_HIGH} for {preset_config[CONF_NAME]} is set to {preset_max_temperature} which is more than the visual maximum temperature of {visual_max_temperature}"
                     )
 
-        # Keep temperature validation
-        for preset_config in config[CONF_PRESET]:
-            try:
-                preset_min_temperature = preset_config[
-                    CONF_DEFAULT_TARGET_TEMPERATURE_LOW
-                ]
-                preset_max_temperature = preset_config[
-                    CONF_DEFAULT_TARGET_TEMPERATURE_HIGH
-                ]
-            except KeyError:
-                pass
-            else:
-                if (
-                    str(preset_min_temperature).lower() == TEMPERATURE_VALUE_KEEP
-                    or str(preset_max_temperature).lower() == TEMPERATURE_VALUE_KEEP
-                ):
-                    raise cv.Invalid(
-                        f"with two-point target temperature {CONF_DEFAULT_TARGET_TEMPERATURE_LOW} and {CONF_DEFAULT_TARGET_TEMPERATURE_HIGH} cannot be {TEMPERATURE_VALUE_KEEP} as in preset {preset_config[CONF_NAME]} "
-                    )
-
         # Mode validation
         for preset_config in config[CONF_PRESET]:
             if CONF_MODE not in preset_config:
@@ -929,32 +909,42 @@ async def to_code(config):
                 standard_preset = climate.CLIMATE_PRESETS[name.upper()]
 
             if two_points_available:
+                preset_min_temperature = preset_config[
+                    CONF_DEFAULT_TARGET_TEMPERATURE_LOW
+                ]
+                preset_max_temperature = preset_config[
+                    CONF_DEFAULT_TARGET_TEMPERATURE_HIGH
+                ]
                 preset_target_config = ThermostatClimateTargetTempConfig(
-                    preset_config[CONF_DEFAULT_TARGET_TEMPERATURE_LOW],
-                    preset_config[CONF_DEFAULT_TARGET_TEMPERATURE_HIGH],
+                    preset_min_temperature
+                    if preset_min_temperature != TEMPERATURE_VALUE_KEEP
+                    else float("nan"),
+                    preset_max_temperature
+                    if preset_max_temperature != TEMPERATURE_VALUE_KEEP
+                    else float("nan"),
                 )
             elif CONF_DEFAULT_TARGET_TEMPERATURE_HIGH in preset_config:
                 preset_max_temperature = preset_config[
                     CONF_DEFAULT_TARGET_TEMPERATURE_HIGH
                 ]
-                # due to config validation, the preset_max_temperature can be TEMPERATURE_VALUE_KEEP or a float value
-                if preset_max_temperature == TEMPERATURE_VALUE_KEEP:
-                    preset_target_config = ThermostatClimateTargetTempConfig()
-                else:
-                    preset_target_config = ThermostatClimateTargetTempConfig(
-                        preset_max_temperature
-                    )
+                preset_target_config = ThermostatClimateTargetTempConfig(
+                    # Due to config validation, the preset_max_temperature can be
+                    # a float value or TEMPERATURE_VALUE_KEEP, no other values.
+                    preset_max_temperature
+                    if preset_max_temperature != TEMPERATURE_VALUE_KEEP
+                    else float("nan")
+                )
             elif CONF_DEFAULT_TARGET_TEMPERATURE_LOW in preset_config:
                 preset_min_temperature = preset_config[
                     CONF_DEFAULT_TARGET_TEMPERATURE_LOW
                 ]
-                # due to config validation, the preset_min_temperature can be TEMPERATURE_VALUE_KEEP or a float value
-                if preset_min_temperature == TEMPERATURE_VALUE_KEEP:
-                    preset_target_config = ThermostatClimateTargetTempConfig()
-                else:
-                    preset_target_config = ThermostatClimateTargetTempConfig(
-                        preset_min_temperature
-                    )
+                preset_target_config = ThermostatClimateTargetTempConfig(
+                    # Due to config validation, the preset_min_temperature can be
+                    # a float value or TEMPERATURE_VALUE_KEEP, no other values.
+                    preset_min_temperature
+                    if preset_min_temperature != TEMPERATURE_VALUE_KEEP
+                    else float("nan")
+                )
             else:
                 preset_target_config = None
 

--- a/esphome/components/thermostat/climate.py
+++ b/esphome/components/thermostat/climate.py
@@ -386,9 +386,9 @@ def validate_thermostat(config):
                 preset_min_temperature = preset_config[
                     CONF_DEFAULT_TARGET_TEMPERATURE_LOW
                 ]
-                # due to config validation, the preset_min_temperature can be "keep" or a float value
+                # due to config validation, the preset_min_temperature can be TEMPERATURE_VALUE_KEEP or a float value
                 if (
-                    str(preset_min_temperature).lower() != TEMPERATURE_VALUE_KEEP
+                    preset_min_temperature != TEMPERATURE_VALUE_KEEP
                     and preset_min_temperature < visual_min_temperature
                 ):
                     raise cv.Invalid(
@@ -399,9 +399,9 @@ def validate_thermostat(config):
                 preset_max_temperature = preset_config[
                     CONF_DEFAULT_TARGET_TEMPERATURE_HIGH
                 ]
-                # due to config validation, the preset_max_temperature can be "keep" or a float value
+                # due to config validation, the preset_max_temperature can be TEMPERATURE_VALUE_KEEP or a float value
                 if (
-                    str(preset_max_temperature).lower() != TEMPERATURE_VALUE_KEEP
+                    preset_max_temperature != TEMPERATURE_VALUE_KEEP
                     and preset_max_temperature > visual_max_temperature
                 ):
                     raise cv.Invalid(
@@ -937,8 +937,8 @@ async def to_code(config):
                 preset_max_temperature = preset_config[
                     CONF_DEFAULT_TARGET_TEMPERATURE_HIGH
                 ]
-
-                if str(preset_max_temperature).lower() == TEMPERATURE_VALUE_KEEP:
+                # due to config validation, the preset_max_temperature can be TEMPERATURE_VALUE_KEEP or a float value
+                if preset_max_temperature == TEMPERATURE_VALUE_KEEP:
                     preset_target_config = ThermostatClimateTargetTempConfig()
                 else:
                     preset_target_config = ThermostatClimateTargetTempConfig(
@@ -948,8 +948,8 @@ async def to_code(config):
                 preset_min_temperature = preset_config[
                     CONF_DEFAULT_TARGET_TEMPERATURE_LOW
                 ]
-
-                if str(preset_min_temperature).lower() == TEMPERATURE_VALUE_KEEP:
+                # due to config validation, the preset_min_temperature can be TEMPERATURE_VALUE_KEEP or a float value
+                if preset_min_temperature == TEMPERATURE_VALUE_KEEP:
                     preset_target_config = ThermostatClimateTargetTempConfig()
                 else:
                     preset_target_config = ThermostatClimateTargetTempConfig(

--- a/esphome/components/thermostat/thermostat_climate.cpp
+++ b/esphome/components/thermostat/thermostat_climate.cpp
@@ -1058,7 +1058,7 @@ bool ThermostatClimate::change_preset_internal_(const ThermostatClimateTargetTem
       something_changed = true;
     }
   } else {
-    if (this->target_temperature != config.default_temperature) {
+    if (std::isfinite(config.default_temperature) && (this->target_temperature != config.default_temperature)) {
       this->target_temperature = config.default_temperature;
       something_changed = true;
     }

--- a/esphome/components/thermostat/thermostat_climate.cpp
+++ b/esphome/components/thermostat/thermostat_climate.cpp
@@ -1049,16 +1049,25 @@ bool ThermostatClimate::change_preset_internal_(const ThermostatClimateTargetTem
   bool something_changed = false;
 
   if (this->supports_two_points_) {
-    if (this->target_temperature_low != config.default_temperature_low) {
+    if (std::isnan(config.default_temperature_low)) {
+      ESP_LOGV(TAG, "Preset's default_temperature_low is NaN, not changing current target value %.2f",
+               this->target_temperature_low);
+    } else if (this->target_temperature_low != config.default_temperature_low) {
       this->target_temperature_low = config.default_temperature_low;
       something_changed = true;
     }
-    if (this->target_temperature_high != config.default_temperature_high) {
+    if (std::isnan(config.default_temperature_high)) {
+      ESP_LOGV(TAG, "Preset's default_temperature_high is NaN, not changing current target value %.2f",
+               this->target_temperature_high);
+    } else if (this->target_temperature_high != config.default_temperature_high) {
       this->target_temperature_high = config.default_temperature_high;
       something_changed = true;
     }
   } else {
-    if (std::isfinite(config.default_temperature) && (this->target_temperature != config.default_temperature)) {
+    if (std::isnan(config.default_temperature)) {
+      ESP_LOGV(TAG, "Preset's default_temperature is NaN, not changing current target value %.2f",
+               this->target_temperature);
+    } else if (this->target_temperature != config.default_temperature) {
       this->target_temperature = config.default_temperature;
       something_changed = true;
     }


### PR DESCRIPTION
# What does this implement/fix?

This PR introduces the value `keep` to be set in `default_target_temperature_[low|high]` of thermostat's presets when the user does not want to change the target temperature activating that preset.

My use case of `none` preset is like "disable any manual override leaving anything untouched" as described in [FR 2521](https://github.com/esphome/feature-requests/issues/2521).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- addresses https://github.com/esphome/feature-requests/issues/2521
- partially related to https://github.com/esphome/feature-requests/issues/1787

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** none at the moment, I'll update the doc if my solution is acceptable

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
climate:                                                                                                                                                                                                                                      
  - platform: thermostat                                                                                                                                                                                                                      
    name: 'Central Heating'
    [...]
    preset:                                                                                                                                                                                                                                   
      - name: none                                                                                                                                                                                                                                                                                                                                                                                          
        default_target_temperature_low: keep                                                                                                                                                                                                  
        default_target_temperature_high: keep
      - name: eco                                                                                                                                                                                                                             
        mode: heat                                                                                                                                                                                                                            
        default_target_temperature_low: 17                                                                                                                                                                                                    
        default_target_temperature_high: keep
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
