### PR TITLE
[ft63x6] Get correct dimensions from display

### DIFF
--- a/esphome/components/ft63x6/ft63x6.cpp
+++ b/esphome/components/ft63x6/ft63x6.cpp
@@ -42,10 +42,10 @@ void FT63X6Touchscreen::setup() {
 
   // Get touch resolution
   if (this->x_raw_max_ == this->x_raw_min_) {
-    this->x_raw_max_ = 320;
+    this->x_raw_max_ = this->display_->get_native_width();
   }
   if (this->y_raw_max_ == this->y_raw_min_) {
-    this->y_raw_max_ = 480;
+    this->y_raw_max_ = this->display_->get_native_height();
   }
   uint8_t chip_id = this->read_byte_(FT63X6_ADDR_CHIP_ID);
   if (chip_id != 0) {
@@ -71,6 +71,8 @@ void FT63X6Touchscreen::dump_config() {
   LOG_I2C_DEVICE(this);
   LOG_PIN("  Interrupt Pin: ", this->interrupt_pin_);
   LOG_PIN("  Reset Pin: ", this->reset_pin_);
+  ESP_LOGCONFIG(TAG, "  X Calibration: [%d, %d]", this->x_raw_min_, this->x_raw_max_);
+  ESP_LOGCONFIG(TAG, "  Y Calibration: [%d, %d]", this->y_raw_min_, this->y_raw_max_);
   LOG_UPDATE_INTERVAL(this);
 }
 


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://community.home-assistant.io/t/wt32-sc01-plus-esp32-s3-esp-home/659661/45

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
