### PR TITLE
 Fix Max7219display reverse_enable function

### DIFF
--- a/esphome/components/max7219digit/max7219digit.cpp
+++ b/esphome/components/max7219digit/max7219digit.cpp
@@ -112,21 +112,19 @@ void MAX7219Component::display() {
   // Run this routine for the rows of every chip 8x row 0 top to 7 bottom
   // Fill the pixel parameter with display data
   // Send the data to the chip
-  for (uint8_t chip = 0; chip < this->num_chips_ / this->num_chip_lines_; chip++) {
-    for (uint8_t chip_line = 0; chip_line < this->num_chip_lines_; chip_line++) {
+  for (uint8_t chip_line = 0; chip_line < this->num_chip_lines_; chip_line++) {
+    bool reverse =
+        chip_line % 2 != 0 && this->chip_lines_style_ == ChipLinesStyle::SNAKE ? !this->reverse_ : this->reverse_;
+    for (uint8_t chip_idx = 0; chip_idx < this->num_chips_ / this->num_chip_lines_; chip_idx++) {
+      uint8_t chip = reverse
+                         ? (this->num_chips_ / this->num_chip_lines_ - 1 - chip_idx)
+                         : chip_idx;
       for (uint8_t j = 0; j < 8; j++) {
-        bool reverse =
-            chip_line % 2 != 0 && this->chip_lines_style_ == ChipLinesStyle::SNAKE ? !this->reverse_ : this->reverse_;
-        if (reverse) {
-          pixels[j] =
-              this->max_displaybuffer_[chip_line][(this->num_chips_ / this->num_chip_lines_ - chip - 1) * 8 + j];
-        } else {
-          pixels[j] = this->max_displaybuffer_[chip_line][chip * 8 + j];
-        }
+        pixels[j] = this->max_displaybuffer_[chip_line][chip * 8 + j];
       }
       if (chip_line % 2 != 0 && this->chip_lines_style_ == ChipLinesStyle::SNAKE)
         this->orientation_ = orientation_180_();
-      this->send64pixels(chip_line * this->num_chips_ / this->num_chip_lines_ + chip, pixels);
+      this->send64pixels(chip_line * (this->num_chips_ / this->num_chip_lines_) + chip, pixels);
       if (chip_line % 2 != 0 && this->chip_lines_style_ == ChipLinesStyle::SNAKE)
         this->orientation_ = orientation_180_();
     }

--- a/esphome/components/max7219digit/max7219digit.cpp
+++ b/esphome/components/max7219digit/max7219digit.cpp
@@ -113,7 +113,8 @@ void MAX7219Component::display() {
   // Fill the pixel parameter with display data
   // Send the data to the chip
   for (uint8_t chip_line = 0; chip_line < this->num_chip_lines_; chip_line++) {
-    bool reverse = (chip_line % 2 != 0 && this->chip_lines_style_ == ChipLinesStyle::SNAKE) ? !this->reverse_ : this->reverse_;
+    bool reverse =
+        (chip_line % 2 != 0 && this->chip_lines_style_ == ChipLinesStyle::SNAKE) ? !this->reverse_ : this->reverse_;
     for (uint8_t chip_idx = 0; chip_idx < this->num_chips_ / this->num_chip_lines_; chip_idx++) {
       uint8_t chip = reverse ? (this->num_chips_ / this->num_chip_lines_ - 1 - chip_idx) : chip_idx;
       for (uint8_t j = 0; j < 8; j++) {
@@ -288,7 +289,7 @@ void MAX7219Component::send64pixels(uint8_t chip, const uint8_t pixels[8]) {
     for (int i = 0; i < this->num_chips_ - chip - 1; i++)  // end with enough NOPs so later chips don't update
       this->send_byte_(MAX7219_REGISTER_NOOP, MAX7219_REGISTER_NOOP);
     this->disable();  // all done disable SPI
-  }                   // end of for each column
+  }  // end of for each column
 }  // end of send64pixels
 
 uint8_t MAX7219Component::printdigit(const char *str) { return this->printdigit(0, str); }

--- a/esphome/components/max7219digit/max7219digit.cpp
+++ b/esphome/components/max7219digit/max7219digit.cpp
@@ -113,19 +113,16 @@ void MAX7219Component::display() {
   // Fill the pixel parameter with display data
   // Send the data to the chip
   for (uint8_t chip_line = 0; chip_line < this->num_chip_lines_; chip_line++) {
-    bool reverse =
-        (chip_line % 2 != 0 && this->chip_lines_style_ == ChipLinesStyle::SNAKE) ? !this->reverse_ : this->reverse_;
+    bool reverse = (chip_line % 2 != 0 && this->chip_lines_style_ == ChipLinesStyle::SNAKE) ? !this->reverse_ : this->reverse_;
     for (uint8_t chip_idx = 0; chip_idx < this->num_chips_ / this->num_chip_lines_; chip_idx++) {
-      uint8_t chip =
-          reverse ? (this->num_chips_ / this->num_chip_lines_ - 1 - chip_idx) : chip_idx;
+      uint8_t chip = reverse ? (this->num_chips_ / this->num_chip_lines_ - 1 - chip_idx) : chip_idx;
       for (uint8_t j = 0; j < 8; j++) {
         pixels[j] = this->max_displaybuffer_[chip_line][chip * 8 + j];
       }
       if (chip_line % 2 != 0 && this->chip_lines_style_ == ChipLinesStyle::SNAKE) {
         this->orientation_ = orientation_180_();
       }
-      this->send64pixels(
-          chip_line * (this->num_chips_ / this->num_chip_lines_) + chip, pixels);
+      this->send64pixels(chip_line * (this->num_chips_ / this->num_chip_lines_) + chip, pixels);
       if (chip_line % 2 != 0 && this->chip_lines_style_ == ChipLinesStyle::SNAKE) {
         this->orientation_ = orientation_180_();
       }

--- a/esphome/components/max7219digit/max7219digit.cpp
+++ b/esphome/components/max7219digit/max7219digit.cpp
@@ -289,7 +289,7 @@ void MAX7219Component::send64pixels(uint8_t chip, const uint8_t pixels[8]) {
     for (int i = 0; i < this->num_chips_ - chip - 1; i++)  // end with enough NOPs so later chips don't update
       this->send_byte_(MAX7219_REGISTER_NOOP, MAX7219_REGISTER_NOOP);
     this->disable();  // all done disable SPI
-  }  // end of for each column
+  }                   // end of for each column
 }  // end of send64pixels
 
 uint8_t MAX7219Component::printdigit(const char *str) { return this->printdigit(0, str); }

--- a/esphome/components/max7219digit/max7219digit.cpp
+++ b/esphome/components/max7219digit/max7219digit.cpp
@@ -114,19 +114,21 @@ void MAX7219Component::display() {
   // Send the data to the chip
   for (uint8_t chip_line = 0; chip_line < this->num_chip_lines_; chip_line++) {
     bool reverse =
-        chip_line % 2 != 0 && this->chip_lines_style_ == ChipLinesStyle::SNAKE ? !this->reverse_ : this->reverse_;
+        (chip_line % 2 != 0 && this->chip_lines_style_ == ChipLinesStyle::SNAKE) ? !this->reverse_ : this->reverse_;
     for (uint8_t chip_idx = 0; chip_idx < this->num_chips_ / this->num_chip_lines_; chip_idx++) {
-      uint8_t chip = reverse
-                         ? (this->num_chips_ / this->num_chip_lines_ - 1 - chip_idx)
-                         : chip_idx;
+      uint8_t chip =
+          reverse ? (this->num_chips_ / this->num_chip_lines_ - 1 - chip_idx) : chip_idx;
       for (uint8_t j = 0; j < 8; j++) {
         pixels[j] = this->max_displaybuffer_[chip_line][chip * 8 + j];
       }
-      if (chip_line % 2 != 0 && this->chip_lines_style_ == ChipLinesStyle::SNAKE)
+      if (chip_line % 2 != 0 && this->chip_lines_style_ == ChipLinesStyle::SNAKE) {
         this->orientation_ = orientation_180_();
-      this->send64pixels(chip_line * (this->num_chips_ / this->num_chip_lines_) + chip, pixels);
-      if (chip_line % 2 != 0 && this->chip_lines_style_ == ChipLinesStyle::SNAKE)
+      }
+      this->send64pixels(
+          chip_line * (this->num_chips_ / this->num_chip_lines_) + chip, pixels);
+      if (chip_line % 2 != 0 && this->chip_lines_style_ == ChipLinesStyle::SNAKE) {
         this->orientation_ = orientation_180_();
+      }
     }
   }
 }


### PR DESCRIPTION
# What does this implement/fix?

This fixes the reverse_enable function for the Max7219display component.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

**Related issue or feature (if applicable):**
- fixes https://github.com/esphome/issues/issues/6869

## Test Environment
- [x] ESP8266

## Checklist:
  - [x] The code change is tested and works locally.

