### PR TITLE
[core] Handle mis-typed platform name more cleanly

### DIFF
--- a/esphome/core/config.py
+++ b/esphome/core/config.py
@@ -189,9 +189,10 @@ def _is_target_platform(name):
     from esphome.loader import get_component
 
     try:
-        if get_component(name, True).is_target_platform:
-            return True
+        return get_component(name, True).is_target_platform
     except KeyError:
+        pass
+    except ImportError:
         pass
     return False
 


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

A mis-typed platform name throws an exception. This should be handled more gracefully

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

esphome:
  name: loader

esp33:

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
