### PR TITLE
[esp32] Use IDF 5.3.1 as default for IDF builds

### DIFF
--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -250,11 +250,11 @@ ARDUINO_PLATFORM_VERSION = cv.Version(5, 4, 0)
 # The default/recommended esp-idf framework version
 #  - https://github.com/espressif/esp-idf/releases
 #  - https://api.registry.platformio.org/v3/packages/platformio/tool/framework-espidf
-RECOMMENDED_ESP_IDF_FRAMEWORK_VERSION = cv.Version(5, 1, 5)
+RECOMMENDED_ESP_IDF_FRAMEWORK_VERSION = cv.Version(5, 3, 1)
 # The platformio/espressif32 version to use for esp-idf frameworks
 #  - https://github.com/platformio/platform-espressif32/releases
 #  - https://api.registry.platformio.org/v3/packages/platformio/platform/espressif32
-ESP_IDF_PLATFORM_VERSION = cv.Version(51, 3, 7)
+ESP_IDF_PLATFORM_VERSION = cv.Version(53, 3, 10)
 
 # List based on https://registry.platformio.org/tools/platformio/framework-espidf/versions
 SUPPORTED_PLATFORMIO_ESP_IDF_5X = [
@@ -317,8 +317,8 @@ def _arduino_check_versions(value):
 def _esp_idf_check_versions(value):
     value = value.copy()
     lookups = {
-        "dev": (cv.Version(5, 1, 5), "https://github.com/espressif/esp-idf.git"),
-        "latest": (cv.Version(5, 1, 5), None),
+        "dev": (cv.Version(5, 3, 1), "https://github.com/espressif/esp-idf.git"),
+        "latest": (cv.Version(5, 3, 1), None),
         "recommended": (RECOMMENDED_ESP_IDF_FRAMEWORK_VERSION, None),
     }
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -140,9 +140,9 @@ extra_scripts = post:esphome/components/esp32/post_build.py.script
 ; This are common settings for the ESP32 (all variants) using IDF.
 [common:esp32-idf]
 extends = common:idf
-platform = https://github.com/pioarduino/platform-espressif32/releases/download/51.03.06/platform-espressif32.zip
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/53.03.10/platform-espressif32.zip
 platform_packages =
-    pioarduino/framework-espidf@https://github.com/pioarduino/esp-idf/releases/download/v5.1.5/esp-idf-v5.1.5.zip
+    pioarduino/framework-espidf@https://github.com/pioarduino/esp-idf/releases/download/v5.3.1/esp-idf-v5.3.1.zip
 
 framework = espidf
 lib_deps =

--- a/script/clang-tidy
+++ b/script/clang-tidy
@@ -36,6 +36,7 @@ def clang_options(idedata):
         # clang doesn't support Xtensa (yet?), so compile in 32-bit mode and pretend we're the Xtensa compiler
         cmd.append("-m32")
         cmd.append("-D__XTENSA__")
+        cmd.append("-D_LIBC")
     else:
         cmd.append(f"--target={triplet}")
 
@@ -77,6 +78,7 @@ def clang_options(idedata):
             "-free",
             "-fipa-pta",
             "-fstrict-volatile-bitfields",
+            "-mdisable-hardware-atomics",
             "-mlongcalls",
             "-mtext-section-literals",
             "-mfix-esp32-psram-cache-issue",
@@ -110,7 +112,6 @@ def clang_options(idedata):
 
     # add the esphome include directory using -I
     cmd.extend(["-I", root_path])
-
     return cmd
 
 

--- a/script/clang-tidy
+++ b/script/clang-tidy
@@ -112,6 +112,7 @@ def clang_options(idedata):
 
     # add the esphome include directory using -I
     cmd.extend(["-I", root_path])
+
     return cmd
 
 


### PR DESCRIPTION
# What does this implement/fix?

Use IDF 5.3.1 as default for IDF builds

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
