### PR TITLE
[audio] Bugfix: fix flac decoding glitches by using esp-audio-libs v1.1.3

### DIFF
--- a/esphome/components/audio/__init__.py
+++ b/esphome/components/audio/__init__.py
@@ -118,4 +118,4 @@ def final_validate_audio_schema(
 
 
 async def to_code(config):
-    cg.add_library("esphome/esp-audio-libs", "1.1.2")
+    cg.add_library("esphome/esp-audio-libs", "1.1.3")

--- a/platformio.ini
+++ b/platformio.ini
@@ -128,7 +128,7 @@ lib_deps =
     DNSServer                            ; captive_portal (Arduino built-in)
     esphome/ESP32-audioI2S@2.0.7         ; i2s_audio
     droscy/esp_wireguard@0.4.2           ; wireguard
-    esphome/esp-audio-libs@1.1.2         ; audio
+    esphome/esp-audio-libs@1.1.3         ; audio
 
 build_flags =
     ${common:arduino.build_flags}
@@ -149,7 +149,7 @@ lib_deps =
     ${common:idf.lib_deps}
     droscy/esp_wireguard@0.4.2              ; wireguard
     kahrendt/ESPMicroSpeechFeatures@1.1.0   ; micro_wake_word
-    esphome/esp-audio-libs@1.1.2            ; audio
+    esphome/esp-audio-libs@1.1.3            ; audio
 build_flags =
     ${common:idf.build_flags}
     -Wno-nonnull-compare


### PR DESCRIPTION
# What does this implement/fix?

Certain FLAC files would have audio glitches when decoded due to a bug. This PR bumps ``esp-audio-libs`` to v1.1.3 which fixes the issue.

[esp-audio-libs on GitHub](https://github.com/esphome/esp-audio-libs)
[esp-audio-libs on PlatformIO](https://registry.platformio.org/libraries/esphome/esp-audio-libs)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** not applicable

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** not applicable

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

speaker:
  - platform: i2s_audio
    id: i2s_audio_speaker
    dac_type: external
    i2s_dout_pin: GPIOXX
    sample_rate: 48000
    bits_per_sample: 16bit
    channel: stereo
    timeout: never
    buffer_duration: 100ms
  - platform: mixer
    id: mixer_speaker_id
    output_speaker: i2s_audio_speaker
    num_channels: 2
    source_speakers:
      - id: announcement_spk_mixer_input
        timeout: never
      - id: media_spk_mixer_input
        timeout: never

media_player:
  - platform: speaker
    id: external_media_player
    name: Media Player
    announcement_pipeline:
      speaker: announcement_spk_mixer_input
      format: FLAC
      num_channels: 1
    media_pipeline:
      speaker: media_spk_mixer_input
      format: FLAC
      num_channels: 2

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
