### PR TITLE
my uart parser

### DIFF
--- a/esphome/components/uart_parser/__init__.py
+++ b/esphome/components/uart_parser/__init__.py
@@ -1,0 +1,17 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.const import CONF_ID
+
+uart_parser_ns = cg.esphome_ns.namespace("uart_parser")
+UartParser = uart_parser_ns.class_("EmptyComponent", cg.Component)
+
+CONFIG_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(): cv.declare_id(UartParser),
+    }
+).extend(cv.COMPONENT_SCHEMA)
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)

--- a/esphome/components/uart_parser/uart_parser.cpp
+++ b/esphome/components/uart_parser/uart_parser.cpp
@@ -1,0 +1,26 @@
+#include "esphome/core/log.h"
+#include "uart_parser.h"
+
+namespace esphome {
+namespace empty_component {
+
+static const char *TAG = "empty_component.component";
+
+uart::UARTComponent *uart_component = new uart::UARTComponent(115200, 0, GPIO25);
+
+void UartParser::setup() {
+    ESP_LOGI("custom_component", "My Custom Component Initialized");
+}
+
+void UartParser::loop() {
+    ESP_LOGI("custom_component", "Component is running");
+    
+}
+
+void UartParser::dump_config(){
+    ESP_LOGCONFIG(TAG, "Empty component");
+}
+
+
+}  // namespace empty_component
+}  // namespace esphome

--- a/esphome/components/uart_parser/uart_parser.cpp
+++ b/esphome/components/uart_parser/uart_parser.cpp
@@ -8,19 +8,11 @@ static const char *TAG = "empty_component.component";
 
 uart::UARTComponent *uart_component = new uart::UARTComponent(115200, 0, GPIO25);
 
-void UartParser::setup() {
-    ESP_LOGI("custom_component", "My Custom Component Initialized");
-}
+void UartParser::setup() { ESP_LOGI("custom_component", "My Custom Component Initialized"); }
 
-void UartParser::loop() {
-    ESP_LOGI("custom_component", "Component is running");
-    
-}
+void UartParser::loop() { ESP_LOGI("custom_component", "Component is running"); }
 
-void UartParser::dump_config(){
-    ESP_LOGCONFIG(TAG, "Empty component");
-}
-
+void UartParser::dump_config() { ESP_LOGCONFIG(TAG, "Empty component"); }
 
 }  // namespace empty_component
 }  // namespace esphome

--- a/esphome/components/uart_parser/uart_parser.h
+++ b/esphome/components/uart_parser/uart_parser.h
@@ -12,6 +12,5 @@ class UartParser : public Component {
   void dump_config() override;
 };
 
-
-}  // namespace empty_component
+}  // namespace uart_parser
 }  // namespace esphome

--- a/esphome/components/uart_parser/uart_parser.h
+++ b/esphome/components/uart_parser/uart_parser.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "esphome/core/component.h"
+
+namespace esphome {
+namespace uart_parser {
+
+class UartParser : public Component {
+ public:
+  void setup() override;
+  void loop() override;
+  void dump_config() override;
+};
+
+
+}  // namespace empty_component
+}  // namespace esphome


### PR DESCRIPTION
# What does this implement/fix?

This implements some custom logic for a Project. It parses uart data into multiple values which are then send over MQTT to other devices.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
esphome:
  name: "couch-mqtt-client"
  friendly_name: Couch MQTT Client

esp32:
  board: esp32dev
  framework:
    type: arduino

# Enable logging
logger:

# Enable Home Assistant API
api:
  encryption:
    key: "IT4G8xQglYvJe+C2zMVM0KEjb/JaaRFhwqRbL7HYZ/k="

ota:
  - platform: esphome
    password: "f2c9b612251e6550d53d2321d23ee354"

mqtt:
  broker: 192.168.178.57
  username: mosquittobroker
  password: !secret mqtt_password

uart:
  rx_pin: GPIO25
  baud_rate: 115200
  debug:
    direction: RX
    dummy_receiver: false

external_components:
  - source: components

empty_component:
  id: empty_component_1

wifi:
  ssid: !secret wifi_ssid
  password: !secret wifi_password

  # Enable fallback hotspot (captive portal) in case wifi connection fails
  ap:
    ssid: "Couche-Mqtt-Client"
    password: "9qPj5fjpN8tu"

captive_portal:
    

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
