### PR TITLE
Add 24s support for daly_bms

### DIFF
--- a/esphome/components/daly_bms/daly_bms.cpp
+++ b/esphome/components/daly_bms/daly_bms.cpp
@@ -305,6 +305,27 @@ void DalyBmsComponent::decode_data_(std::vector<uint8_t> data) {
                   this->cell_18_voltage_sensor_->publish_state((float) encode_uint16(it[9], it[10]) / 1000);
                 }
                 break;
+              case 7:
+                if (this->cell_19_voltage_sensor_) {
+                  this->cell_19_voltage_sensor_->publish_state((float) encode_uint16(it[5], it[6]) / 1000);
+                }
+                if (this->cell_20_voltage_sensor_) {
+                  this->cell_20_voltage_sensor_->publish_state((float) encode_uint16(it[7], it[8]) / 1000);
+                }
+                if (this->cell_21_voltage_sensor_) {
+                  this->cell_21_voltage_sensor_->publish_state((float) encode_uint16(it[9], it[10]) / 1000);
+                }
+              case 8:
+                if (this->cell_22_voltage_sensor_) {
+                  this->cell_22_voltage_sensor_->publish_state((float) encode_uint16(it[5], it[6]) / 1000);
+                }
+                if (this->cell_23_voltage_sensor_) {
+                  this->cell_23_voltage_sensor_->publish_state((float) encode_uint16(it[7], it[8]) / 1000);
+                }
+                if (this->cell_24_voltage_sensor_) {
+                  this->cell_24_voltage_sensor_->publish_state((float) encode_uint16(it[9], it[10]) / 1000);
+                }
+                break;
             }
             break;
 #endif

--- a/esphome/components/daly_bms/daly_bms.h
+++ b/esphome/components/daly_bms/daly_bms.h
@@ -56,6 +56,12 @@ class DalyBmsComponent : public PollingComponent, public uart::UARTDevice {
   SUB_SENSOR(cell_16_voltage)
   SUB_SENSOR(cell_17_voltage)
   SUB_SENSOR(cell_18_voltage)
+  SUB_SENSOR(cell_19_voltage)
+  SUB_SENSOR(cell_20_voltage)
+  SUB_SENSOR(cell_21_voltage)
+  SUB_SENSOR(cell_22_voltage)
+  SUB_SENSOR(cell_23_voltage)
+  SUB_SENSOR(cell_24_voltage)
 #endif
 
 #ifdef USE_TEXT_SENSOR

--- a/esphome/components/daly_bms/sensor.py
+++ b/esphome/components/daly_bms/sensor.py
@@ -55,6 +55,12 @@ CONF_CELL_15_VOLTAGE = "cell_15_voltage"
 CONF_CELL_16_VOLTAGE = "cell_16_voltage"
 CONF_CELL_17_VOLTAGE = "cell_17_voltage"
 CONF_CELL_18_VOLTAGE = "cell_18_voltage"
+CONF_CELL_19_VOLTAGE = "cell_19_voltage"
+CONF_CELL_20_VOLTAGE = "cell_20_voltage"
+CONF_CELL_21_VOLTAGE = "cell_21_voltage"
+CONF_CELL_22_VOLTAGE = "cell_22_voltage"
+CONF_CELL_23_VOLTAGE = "cell_23_voltage"
+CONF_CELL_24_VOLTAGE = "cell_24_voltage"
 ICON_CURRENT_DC = "mdi:current-dc"
 ICON_BATTERY_OUTLINE = "mdi:battery-outline"
 ICON_THERMOMETER_CHEVRON_UP = "mdi:thermometer-chevron-up"
@@ -97,6 +103,12 @@ TYPES = [
     CONF_CELL_16_VOLTAGE,
     CONF_CELL_17_VOLTAGE,
     CONF_CELL_18_VOLTAGE,
+    CONF_CELL_19_VOLTAGE,
+    CONF_CELL_20_VOLTAGE,
+    CONF_CELL_21_VOLTAGE,
+    CONF_CELL_22_VOLTAGE,
+    CONF_CELL_23_VOLTAGE,
+    CONF_CELL_24_VOLTAGE,
 ]
 
 CELL_VOLTAGE_SCHEMA = sensor.sensor_schema(
@@ -219,6 +231,12 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_CELL_16_VOLTAGE): CELL_VOLTAGE_SCHEMA,
             cv.Optional(CONF_CELL_17_VOLTAGE): CELL_VOLTAGE_SCHEMA,
             cv.Optional(CONF_CELL_18_VOLTAGE): CELL_VOLTAGE_SCHEMA,
+            cv.Optional(CONF_CELL_19_VOLTAGE): CELL_VOLTAGE_SCHEMA,
+            cv.Optional(CONF_CELL_20_VOLTAGE): CELL_VOLTAGE_SCHEMA,
+            cv.Optional(CONF_CELL_21_VOLTAGE): CELL_VOLTAGE_SCHEMA,
+            cv.Optional(CONF_CELL_22_VOLTAGE): CELL_VOLTAGE_SCHEMA,
+            cv.Optional(CONF_CELL_23_VOLTAGE): CELL_VOLTAGE_SCHEMA,
+            cv.Optional(CONF_CELL_24_VOLTAGE): CELL_VOLTAGE_SCHEMA,
         }
     ).extend(cv.COMPONENT_SCHEMA)
 )


### PR DESCRIPTION
# What does this implement/fix?

Daly bms component previously supported only up to 18 cells. Now all 24 cells can be accessed.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

Has been tested with a 24 cell battery and ESP32-WROOM module

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
daly_bms:
  update_interval: 20s
  uart_id: ${uart_id}
  address: 0x40

sensor:
  - platform: daly_bms
    cell_19_voltage:
      name: "Cell 19 Voltage"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
