### PR TITLE
[gt911][cst226][ektf2232] Swap x and y calibration values 

### DIFF
--- a/esphome/components/cst226/touchscreen/cst226_touchscreen.cpp
+++ b/esphome/components/cst226/touchscreen/cst226_touchscreen.cpp
@@ -72,6 +72,8 @@ void CST226Touchscreen::continue_setup_() {
     if (this->read16_(0xD1F8, buffer, 4)) {
       this->x_raw_max_ = buffer[0] + (buffer[1] << 8);
       this->y_raw_max_ = buffer[2] + (buffer[3] << 8);
+      if (this->swap_x_y_)
+        std::swap(this->x_raw_max_, this->y_raw_max_);
     } else {
       this->x_raw_max_ = this->display_->get_native_width();
       this->y_raw_max_ = this->display_->get_native_height();

--- a/esphome/components/ektf2232/touchscreen/ektf2232.cpp
+++ b/esphome/components/ektf2232/touchscreen/ektf2232.cpp
@@ -34,26 +34,29 @@ void EKTF2232Touchscreen::setup() {
 
   // Get touch resolution
   uint8_t received[4];
-  if (this->x_raw_max_ == this->x_raw_min_) {
-    this->write(GET_X_RES, 4);
-    if (this->read(received, 4)) {
-      ESP_LOGE(TAG, "Failed to read X resolution!");
+  if (this->x_raw_max_ == 0 || this->y_raw_max_ == 0) {
+    auto err = this->write(GET_X_RES, 4);
+    if (err == i2c::ERROR_OK) {
+      err = this->read(received, 4);
+      if (err == i2c::ERROR_OK) {
+        this->x_raw_max_ = ((received[2])) | ((received[3] & 0xf0) << 4);
+        err = this->write(GET_Y_RES, 4);
+        if (err == i2c::ERROR_OK) {
+          err = this->read(received, 4);
+          if (err == i2c::ERROR_OK) {
+            this->y_raw_max_ = ((received[2])) | ((received[3] & 0xf0) << 4);
+          }
+        }
+      }
+    }
+    if (err != i2c::ERROR_OK) {
+      ESP_LOGE(TAG, "Failed to read calibration values!");
       this->interrupt_pin_->detach_interrupt();
       this->mark_failed();
       return;
     }
-    this->x_raw_max_ = ((received[2])) | ((received[3] & 0xf0) << 4);
-  }
-
-  if (this->y_raw_max_ == this->y_raw_min_) {
-    this->write(GET_Y_RES, 4);
-    if (this->read(received, 4)) {
-      ESP_LOGE(TAG, "Failed to read Y resolution!");
-      this->interrupt_pin_->detach_interrupt();
-      this->mark_failed();
-      return;
-    }
-    this->y_raw_max_ = ((received[2])) | ((received[3] & 0xf0) << 4);
+    if (this->swap_x_y_)
+      std::swap(this->x_raw_max_, this->y_raw_max_);
   }
   this->set_power_state(true);
 }

--- a/esphome/components/gt911/touchscreen/gt911_touchscreen.cpp
+++ b/esphome/components/gt911/touchscreen/gt911_touchscreen.cpp
@@ -60,23 +60,24 @@ void GT911Touchscreen::setup() {
       }
     }
   }
-  if (err == i2c::ERROR_OK) {
-    err = this->write(GET_MAX_VALUES, 2);
+  if (this->x_raw_max_ == 0 || this->y_raw_max_ == 0) {
+    // no calibration? Attempt to read the max values from the touchscreen.
     if (err == i2c::ERROR_OK) {
-      err = this->read(data, sizeof(data));
+      err = this->write(GET_MAX_VALUES, 2);
       if (err == i2c::ERROR_OK) {
-        auto max_x = encode_uint16(data[1], data[0]);
-        auto max_y = encode_uint16(data[3], data[2]);
-        if (this->swap_x_y_)
-          std::swap(max_x, max_y);
-        if (this->x_raw_max_ == this->x_raw_min_) {
-          this->x_raw_max_ = max_x;
+        err = this->read(data, sizeof(data));
+        if (err == i2c::ERROR_OK) {
+          this->x_raw_max_ = encode_uint16(data[1], data[0]);
+          this->y_raw_max_ = encode_uint16(data[3], data[2]);
+          if (this->swap_x_y_)
+            std::swap(this->x_raw_max_, this->y_raw_max_);
         }
-        if (this->y_raw_max_ == this->y_raw_min_) {
-          this->y_raw_max_ = max_y;
-        }
-        esph_log_d(TAG, "calibration max_x/max_y %d/%d", this->x_raw_max_, this->y_raw_max_);
       }
+    }
+    if (err != i2c::ERROR_OK) {
+      ESP_LOGE(TAG, "Failed to read calibration values from touchscreen!");
+      this->mark_failed();
+      return;
     }
   }
   if (err != i2c::ERROR_OK) {

--- a/esphome/components/gt911/touchscreen/gt911_touchscreen.cpp
+++ b/esphome/components/gt911/touchscreen/gt911_touchscreen.cpp
@@ -65,11 +65,15 @@ void GT911Touchscreen::setup() {
     if (err == i2c::ERROR_OK) {
       err = this->read(data, sizeof(data));
       if (err == i2c::ERROR_OK) {
+        auto max_x = encode_uint16(data[1], data[0]);
+        auto max_y = encode_uint16(data[3], data[2]);
+        if (this->swap_x_y_)
+          std::swap(max_x, max_y);
         if (this->x_raw_max_ == this->x_raw_min_) {
-          this->x_raw_max_ = encode_uint16(data[1], data[0]);
+          this->x_raw_max_ = max_x;
         }
         if (this->y_raw_max_ == this->y_raw_min_) {
-          this->y_raw_max_ = encode_uint16(data[3], data[2]);
+          this->y_raw_max_ = max_y;
         }
         esph_log_d(TAG, "calibration max_x/max_y %d/%d", this->x_raw_max_, this->y_raw_max_);
       }


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Some touchscreen drivers read the max-x and max-y values from the chip, these should be swapped when the touch coordinates are being reported with swapped axes.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/pull/8442#issuecomment-2745965434

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
