### PR TITLE
2025.3.1

### DIFF
--- a/esphome/components/ft63x6/ft63x6.cpp
+++ b/esphome/components/ft63x6/ft63x6.cpp
@@ -42,10 +42,10 @@ void FT63X6Touchscreen::setup() {
 
   // Get touch resolution
   if (this->x_raw_max_ == this->x_raw_min_) {
-    this->x_raw_max_ = 320;
+    this->x_raw_max_ = this->display_->get_native_width();
   }
   if (this->y_raw_max_ == this->y_raw_min_) {
-    this->y_raw_max_ = 480;
+    this->y_raw_max_ = this->display_->get_native_height();
   }
   uint8_t chip_id = this->read_byte_(FT63X6_ADDR_CHIP_ID);
   if (chip_id != 0) {
@@ -71,6 +71,8 @@ void FT63X6Touchscreen::dump_config() {
   LOG_I2C_DEVICE(this);
   LOG_PIN("  Interrupt Pin: ", this->interrupt_pin_);
   LOG_PIN("  Reset Pin: ", this->reset_pin_);
+  ESP_LOGCONFIG(TAG, "  X Calibration: [%d, %d]", this->x_raw_min_, this->x_raw_max_);
+  ESP_LOGCONFIG(TAG, "  Y Calibration: [%d, %d]", this->y_raw_min_, this->y_raw_max_);
   LOG_UPDATE_INTERVAL(this);
 }
 

--- a/esphome/components/lvgl/lvgl_esphome.cpp
+++ b/esphome/components/lvgl/lvgl_esphome.cpp
@@ -423,8 +423,6 @@ LvglComponent::LvglComponent(std::vector<display::Display *> displays, float buf
   this->disp_drv_.full_refresh = this->full_refresh_;
   this->disp_drv_.flush_cb = static_flush_cb;
   this->disp_drv_.rounder_cb = rounder_cb;
-  this->disp_drv_.hor_res = 0;
-  this->disp_drv_.ver_res = 0;
   this->disp_ = lv_disp_drv_register(&this->disp_drv_);
 }
 
@@ -448,7 +446,7 @@ void LvglComponent::setup() {
   lv_disp_drv_update(this->disp_, &this->disp_drv_);
   this->rotation = display->get_rotation();
   if (this->rotation != display::DISPLAY_ROTATION_0_DEGREES) {
-    this->rotate_buf_ = static_cast<lv_color_t *>(lv_custom_mem_alloc(this->draw_buf_.size));  // NOLINT
+    this->rotate_buf_ = static_cast<lv_color_t *>(lv_custom_mem_alloc(buf_bytes));  // NOLINT
     if (this->rotate_buf_ == nullptr) {
       this->mark_failed();
       this->status_set_error("Memory allocation failure");

--- a/esphome/components/lvgl/lvgl_esphome.cpp
+++ b/esphome/components/lvgl/lvgl_esphome.cpp
@@ -441,7 +441,7 @@ void LvglComponent::setup() {
     this->status_set_error("Memory allocation failure");
     return;
   }
-  lv_disp_draw_buf_init(&this->draw_buf_, buffer, nullptr, buf_bytes);
+  lv_disp_draw_buf_init(&this->draw_buf_, buffer, nullptr, buffer_pixels);
   this->disp_drv_.hor_res = width;
   this->disp_drv_.ver_res = height;
   // this->setup_driver_(display->get_width(), display->get_height());

--- a/esphome/const.py
+++ b/esphome/const.py
@@ -1,6 +1,6 @@
 """Constants used by esphome."""
 
-__version__ = "2025.3.0"
+__version__ = "2025.3.1"
 
 ALLOWED_NAME_CHARS = "abcdefghijklmnopqrstuvwxyz0123456789-_"
 VALID_SUBSTITUTIONS_CHARACTERS = (


### PR DESCRIPTION
**Do not merge, release script will automatically merge**
- [ft63x6] Get correct dimensions from display [esphome#8417](https://github.com/esphome/esphome/pull/8417)
- [lvgl] Set correct buffer size [esphome#8442](https://github.com/esphome/esphome/pull/8442)
- [lvgl] Ensure non-zero screen dimensions during init [esphome#8444](https://github.com/esphome/esphome/pull/8444)

<details>
<summary>Metadata</summary>

@coderabbitai ignore
</details>
