### PR TITLE
[analog_threshold] Make thresholds templatable

### DIFF
--- a/esphome/components/analog_threshold/analog_threshold_binary_sensor.cpp
+++ b/esphome/components/analog_threshold/analog_threshold_binary_sensor.cpp
@@ -14,7 +14,8 @@ void AnalogThresholdBinarySensor::setup() {
   if (std::isnan(sensor_value)) {
     this->publish_initial_state(false);
   } else {
-    this->publish_initial_state(sensor_value >= (this->lower_threshold_ + this->upper_threshold_) / 2.0f);
+    this->publish_initial_state(sensor_value >=
+                                (this->lower_threshold_.value() + this->upper_threshold_.value()) / 2.0f);
   }
 }
 
@@ -24,7 +25,8 @@ void AnalogThresholdBinarySensor::set_sensor(sensor::Sensor *analog_sensor) {
   this->sensor_->add_on_state_callback([this](float sensor_value) {
     // if there is an invalid sensor reading, ignore the change and keep the current state
     if (!std::isnan(sensor_value)) {
-      this->publish_state(sensor_value >= (this->state ? this->lower_threshold_ : this->upper_threshold_));
+      this->publish_state(sensor_value >=
+                          (this->state ? this->lower_threshold_.value() : this->upper_threshold_.value()));
     }
   });
 }
@@ -32,8 +34,8 @@ void AnalogThresholdBinarySensor::set_sensor(sensor::Sensor *analog_sensor) {
 void AnalogThresholdBinarySensor::dump_config() {
   LOG_BINARY_SENSOR("", "Analog Threshold Binary Sensor", this);
   LOG_SENSOR("  ", "Sensor", this->sensor_);
-  ESP_LOGCONFIG(TAG, "  Upper threshold: %.11f", this->upper_threshold_);
-  ESP_LOGCONFIG(TAG, "  Lower threshold: %.11f", this->lower_threshold_);
+  ESP_LOGCONFIG(TAG, "  Upper threshold: %.11f", this->upper_threshold_.value());
+  ESP_LOGCONFIG(TAG, "  Lower threshold: %.11f", this->lower_threshold_.value());
 }
 
 }  // namespace analog_threshold

--- a/esphome/components/analog_threshold/analog_threshold_binary_sensor.h
+++ b/esphome/components/analog_threshold/analog_threshold_binary_sensor.h
@@ -15,14 +15,13 @@ class AnalogThresholdBinarySensor : public Component, public binary_sensor::Bina
   float get_setup_priority() const override { return setup_priority::DATA; }
 
   void set_sensor(sensor::Sensor *analog_sensor);
-  void set_upper_threshold(float threshold) { this->upper_threshold_ = threshold; }
-  void set_lower_threshold(float threshold) { this->lower_threshold_ = threshold; }
+  template<typename T> void set_upper_threshold(T upper_threshold) { this->upper_threshold_ = upper_threshold; }
+  template<typename T> void set_lower_threshold(T lower_threshold) { this->lower_threshold_ = lower_threshold; }
 
  protected:
   sensor::Sensor *sensor_{nullptr};
-
-  float upper_threshold_;
-  float lower_threshold_;
+  TemplatableValue<float> upper_threshold_{};
+  TemplatableValue<float> lower_threshold_{};
 };
 
 }  // namespace analog_threshold

--- a/tests/components/analog_threshold/common.yaml
+++ b/tests/components/analog_threshold/common.yaml
@@ -26,3 +26,17 @@ binary_sensor:
     threshold: 100
     filters:
       - invert:
+  - platform: analog_threshold
+    name: Analog Threshold 3
+    sensor_id: template_sensor
+    threshold: !lambda return 100;
+    filters:
+      - invert:
+  - platform: analog_threshold
+    name: Analog Threshold 4
+    sensor_id: template_sensor
+    threshold:
+      upper: !lambda return 110;
+      lower: !lambda return 90;
+    filters:
+      - invert:


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#4768

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

binary_sensor:
  - platform: analog_threshold
    id: is_charging
    name: "Is charging"
    sensor_id: power_sensor
    threshold: !lambda return id(power_threshold).state;
    filters:
      - delayed_off: 1h
    on_release:
      switch.turn_off: relay

number:
  - platform: template
    name: Power threshold
    id: power_threshold
    optimistic: true
    restore_value: true
    initial_value: 10
    min_value: 0
    max_value: 100
    step: 2

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
