### PR TITLE
Fix HLW8012 sensor not returning values if change_mode_every is set to never

### DIFF
--- a/esphome/components/hlw8012/hlw8012.cpp
+++ b/esphome/components/hlw8012/hlw8012.cpp
@@ -69,7 +69,7 @@ void HLW8012Component::update() {
 
   float power = cf_hz * this->power_multiplier_;
 
-  if (this->change_mode_at_ != 0) {
+  if (this->change_mode_at_ != 0 || this->change_mode_every_ == 0) {
     // Only read cf1 after one cycle. Apparently it's quite unstable after being changed.
     if (this->current_mode_) {
       float current = cf1_hz * this->current_multiplier_;


### PR DESCRIPTION
# What does this implement/fix?

This small change fixes the issue that the `hlw8012` sensor component does not output any values if `change_mode_every` is set to `never`

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/issues/issues/5619

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
sensor:
  - platform: hlw8012
    sel_pin: GPIOXX
    cf_pin: GPIOXX
    cf1_pin: GPIOXX
    voltage:
      name: "HLW8012 Voltage"
    initial_mode: VOLTAGE
    change_mode_every: never
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
