### PR TITLE
[media_player] Don't reset enqueue command

### DIFF
--- a/esphome/components/media_player/media_player.cpp
+++ b/esphome/components/media_player/media_player.cpp
@@ -56,7 +56,8 @@ const char *media_player_command_to_string(MediaPlayerCommand command) {
 
 void MediaPlayerCall::validate_() {
   if (this->media_url_.has_value()) {
-    if (this->command_.has_value()) {
+    if (this->command_.has_value() && this->command_.value() != MEDIA_PLAYER_COMMAND_ENQUEUE) {
+      // Don't remove an enqueue command
       ESP_LOGW(TAG, "MediaPlayerCall: Setting both command and media_url is not needed.");
       this->command_.reset();
     }


### PR DESCRIPTION
# What does this implement/fix?

The media player component currently always removes the specific command if a media url is passed. This behavior is undesired if we send an enqueue command, as that information is lost to the media player implementation. This PR verifies the command isn't an enqueue command before removing it. 

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** not applicable

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** not applicable

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
Adjust the MEDIA_URL_XXX to a url with a WAV, FLAC, or MP3 file. Without this PR, it will restart the file after 10s. With this PR, the file will completely play twice

# Example config.yaml

i2s_audio:
  - id: i2s_output
    i2s_lrclk_pin:
      number: GPIOXX
    i2s_bclk_pin:
      number: GPIOXX

speaker:
  - platform: i2s_audio
    id: i2s_audio_speaker
    sample_rate: 48000
    i2s_dout_pin: GPIOXX
    i2s_audio_id: i2s_output
    dac_type: external
    channel: stereo

media_player:
  - platform: speaker
    id: external_media_player
    name: Media Player
    internal: False
    volume_increment: 0.05
    volume_min: 0.4
    volume_max: 0.85
    announcement_pipeline:
      speaker: i2s_audio_speaker

button:
  - platform: template
    name: Enqueue test
    on_press:
      - lambda: |-
            id(external_media_player)
              ->make_call()
              .set_command(media_player::MediaPlayerCommand::MEDIA_PLAYER_COMMAND_ENQUEUE)
              .set_media_url("MEDIA_URL_XXX")
              .perform();
      - delay: 10s
      - lambda: |-
            id(external_media_player)
              ->make_call()
              .set_command(media_player::MediaPlayerCommand::MEDIA_PLAYER_COMMAND_ENQUEUE)
              .set_media_url("MEDIA_URL_XXX")
              .perform();


```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
