### PR TITLE
[speaker] Bugfix: Fix rapidly adding items to playlist

### DIFF
--- a/esphome/components/speaker/media_player/speaker_media_player.cpp
+++ b/esphome/components/speaker/media_player/speaker_media_player.cpp
@@ -141,72 +141,44 @@ void SpeakerMediaPlayer::watch_media_commands_() {
   esp_err_t err = ESP_OK;
 
   if (xQueueReceive(this->media_control_command_queue_, &media_command, 0) == pdTRUE) {
-    bool new_url = media_command.new_url.has_value() && media_command.new_url.value();
-    bool new_file = media_command.new_file.has_value() && media_command.new_file.value();
+    bool enqueue = media_command.enqueue.has_value() && media_command.enqueue.value();
 
-    if (new_url || new_file) {
-      bool enqueue = media_command.enqueue.has_value() && media_command.enqueue.value();
+    if (media_command.url.has_value() || media_command.file.has_value()) {
+      PlaylistItem playlist_item;
+      if (media_command.url.has_value()) {
+        playlist_item.url = *media_command.url.value();
+        delete media_command.url.value();
+      }
+      if (media_command.file.has_value()) {
+        playlist_item.file = media_command.file.value();
+      }
 
       if (this->single_pipeline_() || (media_command.announce.has_value() && media_command.announce.value())) {
-        // Announcement playlist/pipeline
-
         if (!enqueue) {
-          // Clear the queue and ensure the loaded next item doesn't start playing
+          // Ensure the loaded next item doesn't start playing, clear the queue, start the file, and unpause
           this->cancel_timeout("next_ann");
           this->announcement_playlist_.clear();
-        }
-
-        PlaylistItem playlist_item;
-        if (new_url) {
-          playlist_item.url = this->announcement_url_;
-          if (!enqueue) {
-            // Not adding to the queue, so directly start playback and internally unpause the pipeline
-            this->announcement_pipeline_->start_url(playlist_item.url.value());
-            this->announcement_pipeline_->set_pause_state(false);
-          }
-        } else {
-          playlist_item.file = this->announcement_file_;
-          if (!enqueue) {
-            // Not adding to the queue, so directly start playback and internally unpause the pipeline
+          if (media_command.file.has_value()) {
             this->announcement_pipeline_->start_file(playlist_item.file.value());
-            this->announcement_pipeline_->set_pause_state(false);
+          } else if (media_command.url.has_value()) {
+            this->announcement_pipeline_->start_url(playlist_item.url.value());
           }
+          this->announcement_pipeline_->set_pause_state(false);
         }
         this->announcement_playlist_.push_back(playlist_item);
       } else {
-        // Media playlist/pipeline
-
         if (!enqueue) {
-          // Clear the queue and ensure the loaded next item doesn't start playing
+          // Ensure the loaded next item doesn't start playing, clear the queue, start the file, and unpause
           this->cancel_timeout("next_media");
           this->media_playlist_.clear();
-        }
-
-        this->is_paused_ = false;
-        PlaylistItem playlist_item;
-        if (new_url) {
-          playlist_item.url = this->media_url_;
-          if (!enqueue) {
-            // Not adding to the queue, so directly start playback and internally unpause the pipeline
-            this->media_pipeline_->start_url(playlist_item.url.value());
-            this->media_pipeline_->set_pause_state(false);
-          }
-        } else {
-          playlist_item.file = this->media_file_;
-          if (!enqueue) {
-            // Not adding to the queue, so directly start playback and internally unpause the pipeline
+          if (media_command.file.has_value()) {
             this->media_pipeline_->start_file(playlist_item.file.value());
-            this->media_pipeline_->set_pause_state(false);
+          } else if (media_command.url.has_value()) {
+            this->media_pipeline_->start_url(playlist_item.url.value());
           }
+          this->media_pipeline_->set_pause_state(false);
         }
         this->media_playlist_.push_back(playlist_item);
-      }
-
-      if (err != ESP_OK) {
-        ESP_LOGE(TAG, "Error starting the audio pipeline: %s", esp_err_to_name(err));
-        this->status_set_error();
-      } else {
-        this->status_clear_error();
       }
 
       return;  // Don't process the new file play command further
@@ -429,12 +401,10 @@ void SpeakerMediaPlayer::play_file(audio::AudioFile *media_file, bool announceme
 
   MediaCallCommand media_command;
 
-  media_command.new_file = true;
+  media_command.file = media_file;
   if (this->single_pipeline_() || announcement) {
-    this->announcement_file_ = media_file;
     media_command.announce = true;
   } else {
-    this->media_file_ = media_file;
     media_command.announce = false;
   }
   media_command.enqueue = enqueue;
@@ -456,14 +426,8 @@ void SpeakerMediaPlayer::control(const media_player::MediaPlayerCall &call) {
   }
 
   if (call.get_media_url().has_value()) {
-    std::string new_uri = call.get_media_url().value();
-
-    media_command.new_url = true;
-    if (this->single_pipeline_() || (call.get_announcement().has_value() && call.get_announcement().value())) {
-      this->announcement_url_ = new_uri;
-    } else {
-      this->media_url_ = new_uri;
-    }
+    media_command.url = new std::string(
+        call.get_media_url().value());  // Must be manually deleted after receiving media_command from a queue
 
     if (call.get_command().has_value()) {
       if (call.get_command().value() == media_player::MEDIA_PLAYER_COMMAND_ENQUEUE) {

--- a/esphome/components/speaker/media_player/speaker_media_player.cpp
+++ b/esphome/components/speaker/media_player/speaker_media_player.cpp
@@ -138,7 +138,6 @@ void SpeakerMediaPlayer::watch_media_commands_() {
   }
 
   MediaCallCommand media_command;
-  esp_err_t err = ESP_OK;
 
   if (xQueueReceive(this->media_control_command_queue_, &media_command, 0) == pdTRUE) {
     bool enqueue = media_command.enqueue.has_value() && media_command.enqueue.value();

--- a/esphome/components/speaker/media_player/speaker_media_player.h
+++ b/esphome/components/speaker/media_player/speaker_media_player.h
@@ -24,8 +24,8 @@ struct MediaCallCommand {
   optional<media_player::MediaPlayerCommand> command;
   optional<float> volume;
   optional<bool> announce;
-  optional<bool> new_url;
-  optional<bool> new_file;
+  optional<std::string *> url;  // Must be manually deleted after receiving this struct from a queue
+  optional<audio::AudioFile *> file;
   optional<bool> enqueue;
 };
 
@@ -109,15 +109,11 @@ class SpeakerMediaPlayer : public Component, public media_player::MediaPlayer {
 
   optional<media_player::MediaPlayerSupportedFormat> media_format_;
   AudioPipelineState media_pipeline_state_{AudioPipelineState::STOPPED};
-  std::string media_url_{};         // only modified by control function
-  audio::AudioFile *media_file_{};  // only modified by play_file function
   bool media_repeat_one_{false};
   uint32_t media_playlist_delay_ms_{0};
 
   optional<media_player::MediaPlayerSupportedFormat> announcement_format_;
   AudioPipelineState announcement_pipeline_state_{AudioPipelineState::STOPPED};
-  std::string announcement_url_{};         // only modified by control function
-  audio::AudioFile *announcement_file_{};  // only modified by play_file function
   bool announcement_repeat_one_{false};
   uint32_t announcement_playlist_delay_ms_{0};
 


### PR DESCRIPTION
# What does this implement/fix?

Currently, if you enqueue two items in a row, the second item will play twice. This is because the media player handled adding items to the playlist in the main loop, but the media player control function passed the URL via a member variable. So, the second addition would overwrite the first addition before the main loop could process it. 

This PR refactors how a new playlist item is handled. The FreeRTOS command queue now passes a pointer to a string containing the URL (C++ objects don't play well with being passed by copy in FreeRTOS queues). This does require some manual memory management. The control function creates a new string with the URL, and then the watch_media_commands function deletes it after processing it. This PR makes a similar change to files compiled into the program, but this change doesn't require manual memory management. By passing the URL directly, the logic to start a new file is simplified into less cases.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** not applicable

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** not applicable

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:


Adjust the MEDIA_URL_1_XXX and MEDIA_URL_2_XXX to two different audio file URLs. Without this PR, it will play the second URL twice. With this PR, the first file will play followed by the second one.

```yaml
# Example config.yaml

i2s_audio:
  - id: i2s_output
    i2s_lrclk_pin:
      number: GPIOXX
    i2s_bclk_pin:
      number: GPIOXX

speaker:
  - platform: i2s_audio
    id: i2s_audio_speaker
    sample_rate: 48000
    i2s_dout_pin: GPIOXX
    i2s_audio_id: i2s_output
    dac_type: external
    channel: stereo

media_player:
  - platform: speaker
    id: external_media_player
    name: Media Player
    internal: False
    volume_increment: 0.05
    volume_min: 0.4
    volume_max: 0.85
    announcement_pipeline:
      speaker: i2s_audio_speaker

button:
  - platform: template
    name: Enqueue test
    on_press:
      - lambda: |-
            id(external_media_player)
              ->make_call()
              .set_command(media_player::MediaPlayerCommand::MEDIA_PLAYER_COMMAND_ENQUEUE)
              .set_media_url("MEDIA_URL_1_XXX")
              .perform();
      - lambda: |-
            id(external_media_player)
              ->make_call()
              .set_command(media_player::MediaPlayerCommand::MEDIA_PLAYER_COMMAND_ENQUEUE)
              .set_media_url("MEDIA_URL_2_XXX")
              .perform();

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
