### PR TITLE
[display] Don't assume glyph x_offset is zero.

### DIFF
--- a/esphome/components/display/display.cpp
+++ b/esphome/components/display/display.cpp
@@ -555,10 +555,10 @@ void Display::get_text_bounds(int x, int y, const char *text, BaseFont *font, Te
 
   switch (x_align) {
     case TextAlign::RIGHT:
-      *x1 = x - *width;
+      *x1 = x - *width - x_offset;
       break;
     case TextAlign::CENTER_HORIZONTAL:
-      *x1 = x - (*width) / 2;
+      *x1 = x - (*width + x_offset) / 2;
       break;
     case TextAlign::LEFT:
     default:


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

The display text measuring code did not take into account the x offset of a character glyph. This offset was always zero in the past, but with the new font changes that is no longer the case.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/issues/issues/6903

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [x] host

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
