### PR TITLE
[speaker] Bugfix: Media player always unpauses when receiving a stop command

### DIFF
--- a/esphome/components/speaker/media_player/speaker_media_player.cpp
+++ b/esphome/components/speaker/media_player/speaker_media_player.cpp
@@ -203,19 +203,38 @@ void SpeakerMediaPlayer::watch_media_commands_() {
           this->is_paused_ = true;
           break;
         case media_player::MEDIA_PLAYER_COMMAND_STOP:
+          // Pipelines do not stop immediately after calling the stop command, so we wait until it is confirmed topped
+          // before unpausing it. This avoids a short stretch of audio playing immediately after receiving the stop
+          // command when the pipeline was originally paused
           if (this->single_pipeline_() || (media_command.announce.has_value() && media_command.announce.value())) {
             if (this->announcement_pipeline_ != nullptr) {
               this->cancel_timeout("next_ann");
               this->announcement_playlist_.clear();
               this->announcement_pipeline_->stop();
+              this->set_retry("unpause_ann", 50, 3, [this](const uint8_t remaining_attempts) {
+                if (this->announcement_pipeline_state_ == AudioPipelineState::STOPPED) {
+                  this->announcement_pipeline_->set_pause_state(false);
+                  return RetryResult::DONE;
+                }
+                return RetryResult::RETRY;
+              });
             }
           } else {
             if (this->media_pipeline_ != nullptr) {
               this->cancel_timeout("next_media");
               this->media_playlist_.clear();
               this->media_pipeline_->stop();
+              this->set_retry("unpause_med", 50, 3, [this](const uint8_t remaining_attempts) {
+                if (this->media_pipeline_state_ == AudioPipelineState::STOPPED) {
+                  this->media_pipeline_->set_pause_state(false);
+                  this->is_paused_ = false;
+                  return RetryResult::DONE;
+                }
+                return RetryResult::RETRY;
+              });
             }
           }
+
           break;
         case media_player::MEDIA_PLAYER_COMMAND_TOGGLE:
           if (this->media_pipeline_ != nullptr) {

--- a/esphome/components/speaker/media_player/speaker_media_player.cpp
+++ b/esphome/components/speaker/media_player/speaker_media_player.cpp
@@ -203,9 +203,8 @@ void SpeakerMediaPlayer::watch_media_commands_() {
           this->is_paused_ = true;
           break;
         case media_player::MEDIA_PLAYER_COMMAND_STOP:
-          // Pipelines do not stop immediately after calling the stop command, so we wait until it is confirmed topped
-          // before unpausing it. This avoids a short stretch of audio playing immediately after receiving the stop
-          // command when the pipeline was originally paused
+          // Pipelines do not stop immediately after calling the stop command, so confirm its stopped before unpausing.
+          // This avoids an audible short segment playing after receiving the stop command in a paused state.
           if (this->single_pipeline_() || (media_command.announce.has_value() && media_command.announce.value())) {
             if (this->announcement_pipeline_ != nullptr) {
               this->cancel_timeout("next_ann");


### PR DESCRIPTION
# What does this implement/fix?

If the media player is paused and then receives a stop command, it currently still reports the paused state. Music Assistant always pauses then stops after 30 seconds, and so when a user tries to resume the stream in MA, it requires pressing play twice.

This PR always removes the pause state when receiving a stop command. Using ``set_retry``, it waits to confirm the pipeline is stopped before unpausing to avoid playing a short segment of audio.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes music-assistant/support/issues/3775

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** not applicable

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

Play a song in Music Assistant targetting this player. Pause it and wait over 30 seconds then press play again. Without this PR, you need to press twice before it resumes. With this PR it will resume on the first press

```yaml
# Example config.yaml


speaker:
  - platform: i2s_audio
    id: i2s_audio_speaker
    dac_type: external
    i2s_dout_pin: GPIOXX
    sample_rate: 48000
    bits_per_sample: 16bit
    channel: stereo
    timeout: never
    buffer_duration: 100ms
  - platform: mixer
    id: mixer_speaker_id
    output_speaker: i2s_audio_speaker
    num_channels: 2
    source_speakers:
      - id: announcement_spk_mixer_input
        timeout: never
      - id: media_spk_mixer_input
        timeout: never

media_player:
  - platform: speaker
    id: external_media_player
    name: Media Player
    announcement_pipeline:
      speaker: announcement_spk_mixer_input
      format: FLAC
      num_channels: 1
    media_pipeline:
      speaker: media_spk_mixer_input
      format: FLAC
      num_channels: 2

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
