### PR TITLE
[psram] 120MHz does not work in octal mode

### DIFF
--- a/esphome/components/psram/__init__.py
+++ b/esphome/components/psram/__init__.py
@@ -9,9 +9,12 @@ CODEOWNERS = ["@esphome/core"]
 psram_ns = cg.esphome_ns.namespace("psram")
 PsramComponent = psram_ns.class_("PsramComponent", cg.Component)
 
+TYPE_QUAD = "quad"
+TYPE_OCTAL = "octal"
+
 SPIRAM_MODES = {
-    "quad": "CONFIG_SPIRAM_MODE_QUAD",
-    "octal": "CONFIG_SPIRAM_MODE_OCT",
+    TYPE_QUAD: "CONFIG_SPIRAM_MODE_QUAD",
+    TYPE_OCTAL: "CONFIG_SPIRAM_MODE_OCT",
 }
 
 SPIRAM_SPEEDS = {
@@ -22,7 +25,7 @@ SPIRAM_SPEEDS = {
 
 
 def validate_psram_mode(config):
-    if config[CONF_MODE] == "octal" and config[CONF_SPEED] == 120e6:
+    if config[CONF_MODE] == TYPE_OCTAL and config[CONF_SPEED] == 120e6:
         raise cv.Invalid("PSRAM 120MHz is not supported in octal mode")
     return config
 
@@ -31,8 +34,12 @@ CONFIG_SCHEMA = cv.All(
     cv.Schema(
         {
             cv.GenerateID(): cv.declare_id(PsramComponent),
-            cv.Optional(CONF_MODE): cv.enum(SPIRAM_MODES, lower=True),
-            cv.Optional(CONF_SPEED): cv.All(cv.frequency, cv.one_of(*SPIRAM_SPEEDS)),
+            cv.Optional(CONF_MODE, default=TYPE_QUAD): cv.enum(
+                SPIRAM_MODES, lower=True
+            ),
+            cv.Optional(CONF_SPEED, default=40e6): cv.All(
+                cv.frequency, cv.one_of(*SPIRAM_SPEEDS)
+            ),
         }
     ),
     cv.only_on_esp32,
@@ -53,10 +60,8 @@ async def to_code(config):
         add_idf_sdkconfig_option("CONFIG_SPIRAM_USE_CAPS_ALLOC", True)
         add_idf_sdkconfig_option("CONFIG_SPIRAM_IGNORE_NOTFOUND", True)
 
-        if CONF_MODE in config:
-            add_idf_sdkconfig_option(f"{SPIRAM_MODES[config[CONF_MODE]]}", True)
-        if CONF_SPEED in config:
-            add_idf_sdkconfig_option(f"{SPIRAM_SPEEDS[config[CONF_SPEED]]}", True)
+        add_idf_sdkconfig_option(f"{SPIRAM_MODES[config[CONF_MODE]]}", True)
+        add_idf_sdkconfig_option(f"{SPIRAM_SPEEDS[config[CONF_SPEED]]}", True)
 
     cg.add_define("USE_PSRAM")
 

--- a/esphome/components/psram/__init__.py
+++ b/esphome/components/psram/__init__.py
@@ -20,6 +20,13 @@ SPIRAM_SPEEDS = {
     120e6: "CONFIG_SPIRAM_SPEED_120M",
 }
 
+
+def validate_psram_mode(config):
+    if config[CONF_MODE] == "octal" and config[CONF_SPEED] == 120e6:
+        raise cv.Invalid("PSRAM 120MHz is not supported in octal mode")
+    return config
+
+
 CONFIG_SCHEMA = cv.All(
     cv.Schema(
         {
@@ -29,6 +36,7 @@ CONFIG_SCHEMA = cv.All(
         }
     ),
     cv.only_on_esp32,
+    validate_psram_mode,
 )
 
 


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#4776

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
