### PR TITLE
[esp32] Allow pioarduino version 5.4.1

### DIFF
--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -273,6 +273,7 @@ SUPPORTED_PLATFORMIO_ESP_IDF_5X = [
 # pioarduino versions that don't require a release number
 # List based on https://github.com/pioarduino/esp-idf/releases
 SUPPORTED_PIOARDUINO_ESP_IDF_5X = [
+    cv.Version(5, 4, 1),
     cv.Version(5, 4, 0),
     cv.Version(5, 3, 2),
     cv.Version(5, 3, 1),


### PR DESCRIPTION
# What does this implement/fix?

In 5.4.1 espressif added i2c_master_execute_defined_operations to the new i2c driver which would allow us to use the new i2c api without modifying ESPHomes's I2C API and breaking a lot of things. 

Tested:
```
  framework:    
    type: esp-idf
    version: 5.4.1
    platform_version: 54.03.20
```
To use:
```
external_components:    
  - source: github://pr#8480
    components: [ esp32 ]
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
