### PR TITLE
[lvgl] Implement switch restore

### DIFF
--- a/esphome/components/lvgl/switch/lvgl_switch.h
+++ b/esphome/components/lvgl/switch/lvgl_switch.h
@@ -10,26 +10,15 @@
 namespace esphome {
 namespace lvgl {
 
-class LVGLSwitch : public switch_::Switch {
+class LVGLSwitch : public switch_::Switch, public Component {
  public:
-  void set_control_lambda(std::function<void(bool)> state_lambda) {
-    this->state_lambda_ = std::move(state_lambda);
-    if (this->initial_state_.has_value()) {
-      this->state_lambda_(this->initial_state_.value());
-      this->initial_state_.reset();
-    }
-  }
+  LVGLSwitch(std::function<void(bool)> state_lambda) : state_lambda_(std::move(state_lambda)) {}
+
+  void setup() override { this->write_state(this->get_initial_state_with_restore_mode().value_or(false)); }
 
  protected:
-  void write_state(bool value) override {
-    if (this->state_lambda_ != nullptr) {
-      this->state_lambda_(value);
-    } else {
-      this->initial_state_ = value;
-    }
-  }
+  void write_state(bool value) override { this->state_lambda_(value); }
   std::function<void(bool)> state_lambda_{};
-  optional<bool> initial_state_{};
 };
 
 }  // namespace lvgl


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

* LVGL switch did not honor restore settings;
* Earlier LVGL setup sequence required some sleight-of-hand to avoid null pointers - this is no longer the case so the relevant code has been removed.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://discord.com/channels/429907082951524364/1355279632676683776

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [x] host

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
