### PR TITLE
[speaker] Bugfixes: two pause state issues

### DIFF
--- a/esphome/components/speaker/media_player/speaker_media_player.cpp
+++ b/esphome/components/speaker/media_player/speaker_media_player.cpp
@@ -170,12 +170,28 @@ void SpeakerMediaPlayer::watch_media_commands_() {
           // Ensure the loaded next item doesn't start playing, clear the queue, start the file, and unpause
           this->cancel_timeout("next_media");
           this->media_playlist_.clear();
-          if (media_command.file.has_value()) {
-            this->media_pipeline_->start_file(playlist_item.file.value());
-          } else if (media_command.url.has_value()) {
-            this->media_pipeline_->start_url(playlist_item.url.value());
+          if (this->is_paused_) {
+            // If paused, stop the media pipeline and unpause it after confirming its stopped. This avoids playing a
+            // short segment of the paused file before starting the new one.
+            this->media_pipeline_->stop();
+            this->set_retry("unpause_med", 50, 3, [this](const uint8_t remaining_attempts) {
+              if (this->media_pipeline_state_ == AudioPipelineState::STOPPED) {
+                this->media_pipeline_->set_pause_state(false);
+                this->is_paused_ = false;
+                return RetryResult::DONE;
+              }
+              return RetryResult::RETRY;
+            });
+          } else {
+            // Not paused, just directly start the file
+            if (media_command.file.has_value()) {
+              this->media_pipeline_->start_file(playlist_item.file.value());
+            } else if (media_command.url.has_value()) {
+              this->media_pipeline_->start_url(playlist_item.url.value());
+            }
+            this->media_pipeline_->set_pause_state(false);
+            this->is_paused_ = false;
           }
-          this->media_pipeline_->set_pause_state(false);
         }
         this->media_playlist_.push_back(playlist_item);
       }
@@ -350,7 +366,7 @@ void SpeakerMediaPlayer::loop() {
         }
 
         if (timeout_ms > 0) {
-          // Pause pipeline internally to facilitiate delay between items
+          // Pause pipeline internally to facilitate the delay between items
           this->announcement_pipeline_->set_pause_state(true);
           // Internally unpause the pipeline after the delay between playlist items. Announcements do not follow the
           // media player's pause state.
@@ -390,7 +406,7 @@ void SpeakerMediaPlayer::loop() {
             }
 
             if (timeout_ms > 0) {
-              // Pause pipeline internally to facilitiate delay between items
+              // Pause pipeline internally to facilitate the delay between items
               this->media_pipeline_->set_pause_state(true);
               // Internally unpause the pipeline after the delay between playlist items, if the media player state is
               // not paused.

--- a/esphome/components/speaker/media_player/speaker_media_player.cpp
+++ b/esphome/components/speaker/media_player/speaker_media_player.cpp
@@ -100,7 +100,7 @@ void SpeakerMediaPlayer::setup() {
 
   if (!this->single_pipeline_()) {
     this->media_pipeline_ = make_unique<AudioPipeline>(this->media_speaker_, this->buffer_size_,
-                                                       this->task_stack_in_psram_, "ann", MEDIA_PIPELINE_TASK_PRIORITY);
+                                                       this->task_stack_in_psram_, "med", MEDIA_PIPELINE_TASK_PRIORITY);
 
     if (this->media_pipeline_ == nullptr) {
       ESP_LOGE(TAG, "Failed to create media pipeline");

--- a/esphome/components/speaker/media_player/speaker_media_player.cpp
+++ b/esphome/components/speaker/media_player/speaker_media_player.cpp
@@ -352,9 +352,9 @@ void SpeakerMediaPlayer::loop() {
         if (timeout_ms > 0) {
           // Pause pipeline internally to facilitiate delay between items
           this->announcement_pipeline_->set_pause_state(true);
-          // Internally unpause the pipeline after the delay between playlist items
-          this->set_timeout("next_ann", timeout_ms,
-                            [this]() { this->announcement_pipeline_->set_pause_state(this->is_paused_); });
+          // Internally unpause the pipeline after the delay between playlist items. Announcements do not follow the
+          // media player's pause state.
+          this->set_timeout("next_ann", timeout_ms, [this]() { this->announcement_pipeline_->set_pause_state(false); });
         }
       }
     } else {
@@ -392,7 +392,8 @@ void SpeakerMediaPlayer::loop() {
             if (timeout_ms > 0) {
               // Pause pipeline internally to facilitiate delay between items
               this->media_pipeline_->set_pause_state(true);
-              // Internally unpause the pipeline after the delay between playlist items
+              // Internally unpause the pipeline after the delay between playlist items, if the media player state is
+              // not paused.
               this->set_timeout("next_media", timeout_ms,
                                 [this]() { this->media_pipeline_->set_pause_state(this->is_paused_); });
             }


### PR DESCRIPTION
# What does this implement/fix?

This PR fixes two bugs related to the media player's pause state:
 - The announcement pipeline playlist would not move on to the next item if the media player was paused. The announcement pipeline is intended not to follow the media player's pause state, so it should still move onto the next item. On the VPE, if you had media paused and a timer started to ring, it would only ring once due to this bug.
 - When starting a new file while paused, the media player would still report the pause state despite starting to play the new flie. This PR first sends a stop command to the pipeline if its in the paused state. Once the pipeline has stopped, it sets the pause state to false allowing the new file to start playing.


## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes esphome/home-assistant-voice-pe#357 (announcement playlist not moving onto the next item when media player is paused)
- fixes esphome/home-assistant-voice-pe#370 (incorrect state when starting a new file while paused)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** not applicable

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

Start playing a file with the media player. Pause it. Then start playing a new file. Without this PR, it would still report as paused despite the new file playing. With this PR, it properly shows that it is playing.

```yaml
# Example config.yaml

speaker:
  - platform: i2s_audio
    id: i2s_audio_speaker
    dac_type: external
    i2s_dout_pin: GPIOXX
    sample_rate: 48000
    bits_per_sample: 16bit
    channel: stereo
    timeout: never
    buffer_duration: 100ms
  - platform: mixer
    id: mixer_speaker_id
    output_speaker: i2s_audio_speaker
    num_channels: 2
    source_speakers:
      - id: announcement_spk_mixer_input
        timeout: never
      - id: media_spk_mixer_input
        timeout: never

media_player:
  - platform: speaker
    id: external_media_player
    name: Media Player
    announcement_pipeline:
      speaker: announcement_spk_mixer_input
      format: FLAC
      num_channels: 1
    media_pipeline:
      speaker: media_spk_mixer_input
      format: FLAC
      num_channels: 2
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
