### PR TITLE
[am2315c] Use warning not fail during update

### DIFF
--- a/esphome/components/am2315c/am2315c.cpp
+++ b/esphome/components/am2315c/am2315c.cpp
@@ -128,7 +128,7 @@ void AM2315C::update() {
   data[2] = 0x00;
   if (this->write(data, 3) != i2c::ERROR_OK) {
     ESP_LOGE(TAG, "Write failed!");
-    this->mark_failed();
+    this->status_set_warning();
     return;
   }
 
@@ -138,12 +138,12 @@ void AM2315C::update() {
     uint8_t status = 0;
     if (this->read(&status, 1) != i2c::ERROR_OK) {
       ESP_LOGE(TAG, "Read failed!");
-      this->mark_failed();
+      this->status_set_warning();
       return;
     }
     if ((status & 0x80) == 0x80) {
       ESP_LOGE(TAG, "HW still busy!");
-      this->mark_failed();
+      this->status_set_warning();
       return;
     }
 
@@ -151,7 +151,7 @@ void AM2315C::update() {
     uint8_t data[7];
     if (this->read(data, 7) != i2c::ERROR_OK) {
       ESP_LOGE(TAG, "Read failed!");
-      this->mark_failed();
+      this->status_set_warning();
       return;
     }
 


### PR DESCRIPTION
# What does this implement/fix?

No reason to mark as failed after one failed read/write

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
