### PR TITLE
[core, qspi_dbi] Clang tidy fixes for 5.3.2

### DIFF
--- a/esphome/components/qspi_dbi/qspi_dbi.cpp
+++ b/esphome/components/qspi_dbi/qspi_dbi.cpp
@@ -1,4 +1,4 @@
-#ifdef USE_ESP_IDF
+#if defined(USE_ESP_IDF) && defined(USE_ESP32_VARIANT_ESP32S3)
 #include "qspi_dbi.h"
 #include "esphome/core/log.h"
 

--- a/esphome/components/qspi_dbi/qspi_dbi.h
+++ b/esphome/components/qspi_dbi/qspi_dbi.h
@@ -3,7 +3,7 @@
 //
 #pragma once
 
-#ifdef USE_ESP_IDF
+#if defined(USE_ESP_IDF) && defined(USE_ESP32_VARIANT_ESP32S3)
 #include "esphome/components/spi/spi.h"
 #include "esphome/components/display/display.h"
 #include "esphome/components/display/display_buffer.h"

--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -45,9 +45,6 @@
 #endif
 #ifdef USE_ESP32
 #include "rom/crc.h"
-#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 3, 2)
-#include "esp_mac.h"
-#endif
 #include "esp_efuse.h"
 #include "esp_efuse_table.h"
 #endif


### PR DESCRIPTION
# What does this implement/fix?

Fixes for clang tidy needed for 5.3.2:
- Remove duplicate esp_mac.h include from helpers.cpp
- Add S3 ifdef to qspi_dbi as esp_lcd_panel_rgb.h is now only available on S3 as it is only supported on S3

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- related https://github.com/esphome/esphome/pull/8464

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
