### PR TITLE
[CI] Clang tidy fixes for 5.3.2

### DIFF
--- a/script/clang-tidy
+++ b/script/clang-tidy
@@ -36,6 +36,7 @@ def clang_options(idedata):
         # clang doesn't support Xtensa (yet?), so compile in 32-bit mode and pretend we're the Xtensa compiler
         cmd.append("-m32")
         cmd.append("-D__XTENSA__")
+        cmd.append("-D_LIBC")
     else:
         cmd.append(f"--target={triplet}")
 
@@ -79,6 +80,7 @@ def clang_options(idedata):
             "-fstrict-volatile-bitfields",
             "-mlongcalls",
             "-mtext-section-literals",
+            "-mdisable-hardware-atomics",
             "-mfix-esp32-psram-cache-issue",
             "-mfix-esp32-psram-cache-strategy=memw",
             "-fno-tree-switch-conversion",


### PR DESCRIPTION
# What does this implement/fix?

Fixes for clang tidy needed for 5.3.2:
- Add _LIBC define as Xtensa header now has #if defined(_LIBC) || defined(_LIBM) || defined(_LIBGLOSS)
- Remove -mdisable-hardware-atomics from flags

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- related https://github.com/esphome/esphome/pull/8464

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
