### PR TITLE
[api] Allow setting custom MAC address for HA

### DIFF
--- a/esphome/components/api/__init__.py
+++ b/esphome/components/api/__init__.py
@@ -12,6 +12,7 @@ from esphome.const import (
     CONF_EVENT,
     CONF_ID,
     CONF_KEY,
+    CONF_MAC_ADDRESS,
     CONF_ON_CLIENT_CONNECTED,
     CONF_ON_CLIENT_DISCONNECTED,
     CONF_PASSWORD,
@@ -86,6 +87,7 @@ CONFIG_SCHEMA = cv.All(
     cv.Schema(
         {
             cv.GenerateID(): cv.declare_id(APIServer),
+            cv.Optional(CONF_MAC_ADDRESS): cv.mac_address,
             cv.Optional(CONF_PORT, default=6053): cv.port,
             cv.Optional(CONF_PASSWORD, default=""): cv.string_strict,
             cv.Optional(
@@ -117,6 +119,8 @@ async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
 
+    if mac_address := config.get(CONF_MAC_ADDRESS):
+        cg.add(var.set_mac_address(str(mac_address)))
     cg.add(var.set_port(config[CONF_PORT]))
     cg.add(var.set_password(config[CONF_PASSWORD]))
     cg.add(var.set_reboot_timeout(config[CONF_REBOOT_TIMEOUT]))

--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -1815,7 +1815,7 @@ DeviceInfoResponse APIConnection::device_info(const DeviceInfoRequest &msg) {
   resp.name = App.get_name();
   resp.friendly_name = App.get_friendly_name();
   resp.suggested_area = App.get_area();
-  resp.mac_address = get_mac_address_pretty();
+  resp.mac_address = parent_->get_mac_address();
   resp.esphome_version = ESPHOME_VERSION;
   resp.compilation_time = App.get_compilation_time();
 #if defined(USE_ESP8266) || defined(USE_ESP32)

--- a/esphome/components/api/api_server.cpp
+++ b/esphome/components/api/api_server.cpp
@@ -25,6 +25,9 @@ static const char *const TAG = "api";
 void APIServer::setup() {
   ESP_LOGCONFIG(TAG, "Setting up Home Assistant API server...");
   this->setup_controller();
+  if (this->mac_address.empty()) {
+    this->mac_address = std::move(get_mac_address_pretty());
+  }
   socket_ = socket::socket_ip(SOCK_STREAM, 0);
   if (socket_ == nullptr) {
     ESP_LOGW(TAG, "Could not create socket.");
@@ -139,6 +142,7 @@ void APIServer::loop() {
 void APIServer::dump_config() {
   ESP_LOGCONFIG(TAG, "API Server:");
   ESP_LOGCONFIG(TAG, "  Address: %s:%u", network::get_use_address().c_str(), this->port_);
+  ESP_LOGCONFIG(TAG, "  MAC address: %s", this->mac_address.c_str());
 #ifdef USE_API_NOISE
   ESP_LOGCONFIG(TAG, "  Using noise encryption: YES");
 #else
@@ -376,6 +380,8 @@ const std::vector<APIServer::HomeAssistantStateSubscription> &APIServer::get_sta
   return this->state_subs_;
 }
 uint16_t APIServer::get_port() const { return this->port_; }
+std::string APIServer::get_mac_address() const { return this->mac_address; }
+void APIServer::set_mac_address(std::string mac_address) { this->mac_address = std::move(mac_address); }
 void APIServer::set_reboot_timeout(uint32_t reboot_timeout) { this->reboot_timeout_ = reboot_timeout; }
 #ifdef USE_HOMEASSISTANT_TIME
 void APIServer::request_time() {

--- a/esphome/components/api/api_server.cpp
+++ b/esphome/components/api/api_server.cpp
@@ -25,8 +25,8 @@ static const char *const TAG = "api";
 void APIServer::setup() {
   ESP_LOGCONFIG(TAG, "Setting up Home Assistant API server...");
   this->setup_controller();
-  if (this->mac_address.empty()) {
-    this->mac_address = std::move(get_mac_address_pretty());
+  if (this->mac_address_.empty()) {
+    this->mac_address_ = std::move(get_mac_address_pretty());
   }
   socket_ = socket::socket_ip(SOCK_STREAM, 0);
   if (socket_ == nullptr) {
@@ -142,7 +142,7 @@ void APIServer::loop() {
 void APIServer::dump_config() {
   ESP_LOGCONFIG(TAG, "API Server:");
   ESP_LOGCONFIG(TAG, "  Address: %s:%u", network::get_use_address().c_str(), this->port_);
-  ESP_LOGCONFIG(TAG, "  MAC address: %s", this->mac_address.c_str());
+  ESP_LOGCONFIG(TAG, "  MAC address: %s", this->mac_address_.c_str());
 #ifdef USE_API_NOISE
   ESP_LOGCONFIG(TAG, "  Using noise encryption: YES");
 #else
@@ -380,8 +380,8 @@ const std::vector<APIServer::HomeAssistantStateSubscription> &APIServer::get_sta
   return this->state_subs_;
 }
 uint16_t APIServer::get_port() const { return this->port_; }
-std::string APIServer::get_mac_address() const { return this->mac_address; }
-void APIServer::set_mac_address(std::string mac_address) { this->mac_address = std::move(mac_address); }
+std::string APIServer::get_mac_address() const { return this->mac_address_; }
+void APIServer::set_mac_address(std::string mac_address) { this->mac_address_ = std::move(mac_address); }
 void APIServer::set_reboot_timeout(uint32_t reboot_timeout) { this->reboot_timeout_ = reboot_timeout; }
 #ifdef USE_HOMEASSISTANT_TIME
 void APIServer::request_time() {

--- a/esphome/components/api/api_server.cpp
+++ b/esphome/components/api/api_server.cpp
@@ -26,7 +26,7 @@ void APIServer::setup() {
   ESP_LOGCONFIG(TAG, "Setting up Home Assistant API server...");
   this->setup_controller();
   if (this->mac_address_.empty()) {
-    this->mac_address_ = std::move(get_mac_address_pretty());
+    this->mac_address_ = get_mac_address_pretty();
   }
   socket_ = socket::socket_ip(SOCK_STREAM, 0);
   if (socket_ == nullptr) {

--- a/esphome/components/api/api_server.h
+++ b/esphome/components/api/api_server.h
@@ -24,6 +24,8 @@ class APIServer : public Component, public Controller {
   APIServer();
   void setup() override;
   uint16_t get_port() const;
+  std::string get_mac_address() const;
+  void set_mac_address(std::string mac_address);
   float get_setup_priority() const override;
   void loop() override;
   void dump_config() override;
@@ -131,6 +133,7 @@ class APIServer : public Component, public Controller {
  protected:
   std::unique_ptr<socket::Socket> socket_ = nullptr;
   uint16_t port_{6053};
+  std::string mac_address{};
   uint32_t reboot_timeout_{300000};
   uint32_t last_connected_{0};
   std::vector<std::unique_ptr<APIConnection>> clients_;

--- a/esphome/components/api/api_server.h
+++ b/esphome/components/api/api_server.h
@@ -133,7 +133,7 @@ class APIServer : public Component, public Controller {
  protected:
   std::unique_ptr<socket::Socket> socket_ = nullptr;
   uint16_t port_{6053};
-  std::string mac_address{};
+  std::string mac_address_{};
   uint32_t reboot_timeout_{300000};
   uint32_t last_connected_{0};
   std::vector<std::unique_ptr<APIConnection>> clients_;

--- a/tests/components/api/common.yaml
+++ b/tests/components/api/common.yaml
@@ -14,6 +14,7 @@ esphome:
 api:
   port: 8000
   password: pwd
+  mac_address: "62:23:45:AF:B3:DD"
   reboot_timeout: 0min
   encryption:
     key: bOFFzzvfpg5DB94DuBGLXD/hMnhpDKgP9UQyBulwWVU=


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

ESPHome sends its MAC address to HA, not for any networking use, but evidently to act as a unique identifier for the device. This causes problems if a hardware device fails and needs to be replaced with something identical - except that it will have a different MAC address. This results in HA refusing to believe that the device with the same name is the same device, and the only way to fix that is to remove the original device and re-add the "new" one. 

This PR provides a way to circumvent that problem, by allowing the previous MAC address to be reassigned to the new piece of hardware. This does not affect networking since the actual MAC address will still be used by the network components.

It's also helpful if a device needs to be temporarily replaced while some work on it is being done.

Other uses include assigning a locally-administered MAC address rather than relying on the pre-programmed one.


 
## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#4792
## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
api:
  mac_address: 84:F7:03:E8:04:14
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
