### PR TITLE
Ensure plaintext responds with bad indicator byte before dropping the connection

### DIFF
--- a/esphome/components/api/api_frame_helper.cpp
+++ b/esphome/components/api/api_frame_helper.cpp
@@ -897,7 +897,7 @@ APIError APIPlaintextFrameHelper::read_packet(ReadPacketBuffer *buffer) {
     if (aerr == APIError::BAD_INDICATOR) {
       HELPER_LOG("Responding with bad indicator byte %u", frame.msg[0]);
       struct iovec iov[1];
-      const uint8_t *msg = "Bad indicator byte";
+      const char *msg = "Bad indicator byte";
       iov[0].iov_base = (void *) msg;
       iov[0].iov_len = 19;
       write_raw_(iov, 1);

--- a/esphome/components/api/api_frame_helper.cpp
+++ b/esphome/components/api/api_frame_helper.cpp
@@ -907,7 +907,7 @@ APIError APIPlaintextFrameHelper::read_packet(ReadPacketBuffer *buffer) {
       // We must send at least 3 bytes to be read, so we add
       // a message after the indicator byte to ensures its long
       // enough and can aid in debugging.
-      const char msg[] = "\x00Bad indicator byte";
+      const char msg[] = "\x00" "Bad indicator byte";
       iov[0].iov_base = (void *) msg;
       iov[0].iov_len = 19;
       write_raw_(iov, 1);

--- a/esphome/components/api/api_frame_helper.cpp
+++ b/esphome/components/api/api_frame_helper.cpp
@@ -899,6 +899,11 @@ APIError APIPlaintextFrameHelper::read_packet(ReadPacketBuffer *buffer) {
       // understand the indicator byte so it knows
       // we do not support it.
       struct iovec iov[1];
+      // The \x00 first byte is the marker, the rest is the message
+      // that will be sent to the remote. The remote likely does not
+      // understand the message, but it will know that we do not
+      // understand the indicator byte, and we need to send
+      // at least 3 bytes to be valid.
       const char msg[] = {'\x00', 'B', 'a', 'd', ' ', 'i', 'n', 'd', 'i', 'c',
                           'a',    't', 'o', 'r', ' ', 'b', 'y', 't', 'e'};
       iov[0].iov_base = (void *) msg;

--- a/esphome/components/api/api_frame_helper.cpp
+++ b/esphome/components/api/api_frame_helper.cpp
@@ -895,6 +895,7 @@ APIError APIPlaintextFrameHelper::read_packet(ReadPacketBuffer *buffer) {
   aerr = try_read_frame_(&frame);
   if (aerr != APIError::OK) {
     if (aerr == APIError::BAD_INDICATOR) {
+      HELPER_LOG("Responding with bad indicator byte %u", frame.msg[0]);
       struct iovec iov[1];
       const uint8_t *msg = "Bad indicator byte";
       iov[0].iov_base = (void *) msg;

--- a/esphome/components/api/api_frame_helper.cpp
+++ b/esphome/components/api/api_frame_helper.cpp
@@ -899,11 +899,12 @@ APIError APIPlaintextFrameHelper::read_packet(ReadPacketBuffer *buffer) {
       // understand the indicator byte so it knows
       // we do not support it.
       struct iovec iov[1];
-      // The \x00 first byte is the marker, the rest is the message
-      // that will be sent to the remote. The remote likely does not
-      // understand the message, but it will know that we do not
-      // understand the indicator byte, and we need to send
-      // at least 3 bytes to be valid.
+      // The \x00 first byte is the marker, the remote will
+      // know how to handle the indicator byte, but it likely
+      // won't understand the rest of the message. We must
+      // send at least 3 bytes to be valid so we add a message
+      // after the indicator byte to ensures its long enough
+      // and can aid in debugging.
       const char msg[] = {'\x00', 'B', 'a', 'd', ' ', 'i', 'n', 'd', 'i', 'c',
                           'a',    't', 'o', 'r', ' ', 'b', 'y', 't', 'e'};
       iov[0].iov_base = (void *) msg;

--- a/esphome/components/api/api_frame_helper.cpp
+++ b/esphome/components/api/api_frame_helper.cpp
@@ -899,9 +899,10 @@ APIError APIPlaintextFrameHelper::read_packet(ReadPacketBuffer *buffer) {
       // understand the indicator byte so it knows
       // we do not support it.
       struct iovec iov[1];
-      const char *msg = "Bad indicator byte";
+      const char msg[] = {'\x00', 'B', 'a', 'd', ' ', 'i', 'n', 'd', 'i', 'c',
+                          'a',    't', 'o', 'r', ' ', 'b', 'y', 't', 'e'};
       iov[0].iov_base = (void *) msg;
-      iov[0].iov_len = 18;
+      iov[0].iov_len = 19;
       write_raw_(iov, 1);
     }
     return aerr;

--- a/esphome/components/api/api_frame_helper.cpp
+++ b/esphome/components/api/api_frame_helper.cpp
@@ -897,7 +897,7 @@ APIError APIPlaintextFrameHelper::read_packet(ReadPacketBuffer *buffer) {
     if (aerr == APIError::BAD_INDICATOR) {
       struct iovec iov[1];
       const uint8_t *msg = "Bad indicator byte";
-      iov[0].iov_base = const_cast<uint8_t *>(msg);
+      iov[0].iov_base = (void *) msg;
       iov[0].iov_len = 19;
       write_raw_(iov, 1);
     }

--- a/esphome/components/api/api_frame_helper.cpp
+++ b/esphome/components/api/api_frame_helper.cpp
@@ -907,7 +907,8 @@ APIError APIPlaintextFrameHelper::read_packet(ReadPacketBuffer *buffer) {
       // We must send at least 3 bytes to be read, so we add
       // a message after the indicator byte to ensures its long
       // enough and can aid in debugging.
-      const char msg[] = "\x00" "Bad indicator byte";
+      const char msg[] = "\x00"
+                         "Bad indicator byte";
       iov[0].iov_base = (void *) msg;
       iov[0].iov_len = 19;
       write_raw_(iov, 1);

--- a/esphome/components/api/api_frame_helper.cpp
+++ b/esphome/components/api/api_frame_helper.cpp
@@ -895,11 +895,13 @@ APIError APIPlaintextFrameHelper::read_packet(ReadPacketBuffer *buffer) {
   aerr = try_read_frame_(&frame);
   if (aerr != APIError::OK) {
     if (aerr == APIError::BAD_INDICATOR) {
-      HELPER_LOG("Responding with bad indicator byte %u", frame.msg[0]);
+      // Make sure to tell the remote that we don't
+      // understand the indicator byte so it knows
+      // we do not support it.
       struct iovec iov[1];
       const char *msg = "Bad indicator byte";
       iov[0].iov_base = (void *) msg;
-      iov[0].iov_len = 19;
+      iov[0].iov_len = 18;
       write_raw_(iov, 1);
     }
     return aerr;

--- a/esphome/components/api/api_frame_helper.cpp
+++ b/esphome/components/api/api_frame_helper.cpp
@@ -893,8 +893,16 @@ APIError APIPlaintextFrameHelper::read_packet(ReadPacketBuffer *buffer) {
 
   ParsedFrame frame;
   aerr = try_read_frame_(&frame);
-  if (aerr != APIError::OK)
+  if (aerr != APIError::OK) {
+    if (aerr == APIError::BAD_INDICATOR) {
+      struct iovec iov[1];
+      const uint8_t *msg = "Bad indicator byte";
+      iov[0].iov_base = const_cast<uint8_t *>(msg);
+      iov[0].iov_len = 19;
+      write_raw_(iov, 1);
+    }
     return aerr;
+  }
 
   buffer->container = std::move(frame.msg);
   buffer->data_offset = 0;

--- a/esphome/components/api/api_frame_helper.cpp
+++ b/esphome/components/api/api_frame_helper.cpp
@@ -907,8 +907,7 @@ APIError APIPlaintextFrameHelper::read_packet(ReadPacketBuffer *buffer) {
       // We must send at least 3 bytes to be read, so we add
       // a message after the indicator byte to ensures its long
       // enough and can aid in debugging.
-      const char msg[] = {'\x00', 'B', 'a', 'd', ' ', 'i', 'n', 'd', 'i', 'c',
-                          'a',    't', 'o', 'r', ' ', 'b', 'y', 't', 'e'};
+      const char msg[] = "\x00Bad indicator byte";
       iov[0].iov_base = (void *) msg;
       iov[0].iov_len = 19;
       write_raw_(iov, 1);

--- a/esphome/components/api/api_frame_helper.cpp
+++ b/esphome/components/api/api_frame_helper.cpp
@@ -899,12 +899,14 @@ APIError APIPlaintextFrameHelper::read_packet(ReadPacketBuffer *buffer) {
       // understand the indicator byte so it knows
       // we do not support it.
       struct iovec iov[1];
-      // The \x00 first byte is the marker, the remote will
-      // know how to handle the indicator byte, but it likely
-      // won't understand the rest of the message. We must
-      // send at least 3 bytes to be valid so we add a message
-      // after the indicator byte to ensures its long enough
-      // and can aid in debugging.
+      // The \x00 first byte is the marker for plaintext.
+      //
+      // The remote will know how to handle the indicator byte,
+      // but it likely won't understand the rest of the message.
+      //
+      // We must send at least 3 bytes to be read, so we add
+      // a message after the indicator byte to ensures its long
+      // enough and can aid in debugging.
       const char msg[] = {'\x00', 'B', 'a', 'd', ' ', 'i', 'n', 'd', 'i', 'c',
                           'a',    't', 'o', 'r', ' ', 'b', 'y', 't', 'e'};
       iov[0].iov_base = (void *) msg;


### PR DESCRIPTION
# What does this implement/fix?

Ensure plaintext responds with `\x00Bad indicator byte` before dropping the connection when the indicator byte is wrong.

We need to send back a response that starts with the plaintext marker (`\x00`) to ensure `aioesphomeapi` knows we are speaking plaintext when it tries to speak noise to an ESP that is using plaintext.

Currently we simply drop the connection with no indication to the remote running `aioesphomeapi` what is wrong. This lead to some false positives in https://github.com/home-assistant/core/issues/142381 because we didn't have a way decisively tell what was wrong.  This is a better solution for https://github.com/home-assistant/core/issues/121442

aioesphomeapi Send
```
00000000  01 00 00 01 00 31 00 fc  ee 4c 2e b7 38 b9 64 ea   .....1.. .L..8.d.
00000010  33 9c 1f 45 0b 07 8f 7d  44 39 e7 b2 cb a8 97 fa   3..E...} D9......
00000020  54 95 bb f8 12 cf 61 ce  83 20 37 06 08 78 dc 00   T.....a. . 7..x..
00000030  b2 47 53 5e b8 41 44                               .GS^.AD
```

Device responds with
```
00000000  00 42 61 64 20 69 6e 64  69 63 61 74 6f 72 20 62   .Bad ind icator b
00000010  79 74 65                                           yte
```

```yaml
external_components:
  - source: github://pr#8521
    components: [api]
    refresh: 0s
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** https://github.com/home-assistant/core/issues/142381

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
