### PR TITLE
[lvgl] Small buffers in internal RAM

### DIFF
--- a/esphome/components/lvgl/lvgl_esphome.cpp
+++ b/esphome/components/lvgl/lvgl_esphome.cpp
@@ -435,7 +435,6 @@ void LvglComponent::setup() {
   auto buf_bytes = buffer_pixels * LV_COLOR_DEPTH / 8;
   void *buffer = nullptr;
   if (this->buffer_frac_ >= 4)
-    // try to allocate in internal memory first if not full screen
     buffer = malloc(buf_bytes);  // NOLINT
   if (buffer == nullptr)
     buffer = lv_custom_mem_alloc(buf_bytes);  // NOLINT

--- a/esphome/components/lvgl/lvgl_esphome.cpp
+++ b/esphome/components/lvgl/lvgl_esphome.cpp
@@ -433,7 +433,12 @@ void LvglComponent::setup() {
   auto height = display->get_height();
   size_t buffer_pixels = width * height / this->buffer_frac_;
   auto buf_bytes = buffer_pixels * LV_COLOR_DEPTH / 8;
-  auto *buffer = lv_custom_mem_alloc(buf_bytes);  // NOLINT
+  void *buffer = nullptr;
+  if (this->buffer_frac_ >= 4)
+    // try to allocate in internal memory first if not full screen
+    buffer = malloc(buf_bytes);  // NOLINT
+  if (buffer == nullptr)
+    buffer = lv_custom_mem_alloc(buf_bytes);  // NOLINT
   if (buffer == nullptr) {
     this->mark_failed();
     this->status_set_error("Memory allocation failure");


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

When the lvgl buffer size is small, try to allocate the draw buffer from internal memory first. This will be faster than using PSRAM. If the allocation fails, PSRAM will still be used if available.


## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://discord.com/channels/429907082951524364/1357721943368925386

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
