### PR TITLE
[xiaomi_miscale] Add support for S400

### DIFF
--- a/esphome/components/xiaomi_ble/xiaomi_ble.cpp
+++ b/esphome/components/xiaomi_ble/xiaomi_ble.cpp
@@ -287,8 +287,12 @@ bool decrypt_xiaomi_payload(std::vector<uint8_t> &raw, const uint8_t *bindkey, c
                          .tagsize = 4,
                          .ivsize = 12};
 
-  vector.datasize = (raw.size() == 19) ? raw.size() - 12 : raw.size() - 18;
-  int cipher_pos = (raw.size() == 19) ? 5 : 11;
+  vector.datasize = raw.size() - 12;
+  int cipher_pos = 5;
+  if (raw.size() != 19 && raw.size() != 24) {
+    vector.datasize = raw.size() - 18;
+    cipher_pos = 11;
+  }
 
   const uint8_t *v = raw.data();
 

--- a/esphome/components/xiaomi_miscale/sensor.py
+++ b/esphome/components/xiaomi_miscale/sensor.py
@@ -2,35 +2,57 @@ import esphome.codegen as cg
 from esphome.components import esp32_ble_tracker, sensor
 import esphome.config_validation as cv
 from esphome.const import (
+    CONF_BINDKEY,
     CONF_CLEAR_IMPEDANCE,
     CONF_ID,
     CONF_IMPEDANCE,
     CONF_MAC_ADDRESS,
     CONF_WEIGHT,
+    DEVICE_CLASS_TIMESTAMP,
+    DEVICE_CLASS_WEIGHT,
+    ICON_HEART_PULSE,
     ICON_OMEGA,
     ICON_SCALE_BATHROOM,
     STATE_CLASS_MEASUREMENT,
+    UNIT_BEATS_PER_MINUTE,
     UNIT_KILOGRAM,
     UNIT_OHM,
 )
 
 DEPENDENCIES = ["esp32_ble_tracker"]
+AUTO_LOAD = ["xiaomi_ble"]
+
+CONF_HEART_RATE = "heart_rate"
+CONF_IMPEDANCE_HIGH = "impedance_high"
+CONF_IMPEDANCE_LOW = "impedance_low"
+CONF_PROFILE_ID = "profile_id"
+CONF_TIMESTAMP = "timestamp"
+CONF_ALLOWED_PROFILE_IDS = "allowed_profile_ids"
 
 xiaomi_miscale_ns = cg.esphome_ns.namespace("xiaomi_miscale")
 XiaomiMiscale = xiaomi_miscale_ns.class_(
     "XiaomiMiscale", esp32_ble_tracker.ESPBTDeviceListener, cg.Component
 )
 
+
+def _validate_profile_ids(value):
+    if isinstance(value, str) and value.lower() == "any":
+        return value
+    return cv.uint8_t(value)
+
+
 CONFIG_SCHEMA = (
     cv.Schema(
         {
             cv.GenerateID(): cv.declare_id(XiaomiMiscale),
             cv.Required(CONF_MAC_ADDRESS): cv.mac_address,
+            cv.Optional(CONF_BINDKEY): cv.bind_key,
             cv.Optional(CONF_CLEAR_IMPEDANCE, default=False): cv.boolean,
             cv.Optional(CONF_WEIGHT): sensor.sensor_schema(
                 unit_of_measurement=UNIT_KILOGRAM,
                 icon=ICON_SCALE_BATHROOM,
                 accuracy_decimals=2,
+                device_class=DEVICE_CLASS_WEIGHT,
                 state_class=STATE_CLASS_MEASUREMENT,
             ),
             cv.Optional(CONF_IMPEDANCE): sensor.sensor_schema(
@@ -38,6 +60,37 @@ CONFIG_SCHEMA = (
                 icon=ICON_OMEGA,
                 accuracy_decimals=0,
                 state_class=STATE_CLASS_MEASUREMENT,
+            ),
+            cv.Optional(CONF_IMPEDANCE_HIGH): sensor.sensor_schema(
+                unit_of_measurement=UNIT_OHM,
+                icon=ICON_OMEGA,
+                accuracy_decimals=1,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ),
+            cv.Optional(CONF_IMPEDANCE_LOW): sensor.sensor_schema(
+                unit_of_measurement=UNIT_OHM,
+                icon=ICON_OMEGA,
+                accuracy_decimals=1,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ),
+            cv.Optional(CONF_HEART_RATE): sensor.sensor_schema(
+                unit_of_measurement=UNIT_BEATS_PER_MINUTE,
+                icon=ICON_HEART_PULSE,
+                accuracy_decimals=0,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ),
+            cv.Optional(CONF_TIMESTAMP): sensor.sensor_schema(
+                icon="mdi:calendar-clock",
+                device_class=DEVICE_CLASS_TIMESTAMP,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ),
+            cv.Optional(CONF_PROFILE_ID): sensor.sensor_schema(
+                icon="mdi:identifier",
+                accuracy_decimals=0,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ),
+            cv.Optional(CONF_ALLOWED_PROFILE_IDS, default=["any"]): cv.ensure_list(
+                _validate_profile_ids
             ),
         }
     )
@@ -54,9 +107,29 @@ async def to_code(config):
     cg.add(var.set_address(config[CONF_MAC_ADDRESS].as_hex))
     cg.add(var.set_clear_impedance(config[CONF_CLEAR_IMPEDANCE]))
 
-    if CONF_WEIGHT in config:
-        sens = await sensor.new_sensor(config[CONF_WEIGHT])
+    if bindkey := config.get(CONF_BINDKEY):
+        cg.add(var.set_bindkey(bindkey))
+    if weight_config := config.get(CONF_WEIGHT):
+        sens = await sensor.new_sensor(weight_config)
         cg.add(var.set_weight(sens))
-    if CONF_IMPEDANCE in config:
-        sens = await sensor.new_sensor(config[CONF_IMPEDANCE])
+    if impedance_config := config.get(CONF_IMPEDANCE):
+        sens = await sensor.new_sensor(impedance_config)
         cg.add(var.set_impedance(sens))
+    if impedance_low_config := config.get(CONF_IMPEDANCE_LOW):
+        sens = await sensor.new_sensor(impedance_low_config)
+        cg.add(var.set_impedance_low(sens))
+    if heart_rate_config := config.get(CONF_HEART_RATE):
+        sens = await sensor.new_sensor(heart_rate_config)
+        cg.add(var.set_heart_rate(sens))
+    if timestamp_config := config.get(CONF_TIMESTAMP):
+        sens = await sensor.new_sensor(timestamp_config)
+        cg.add(var.set_timestamp(sens))
+    if profile_id_config := config.get(CONF_PROFILE_ID):
+        sens = await sensor.new_sensor(profile_id_config)
+        cg.add(var.set_profile_id(sens))
+    if (
+        allowed_profile_ids := config.get(CONF_ALLOWED_PROFILE_IDS)
+    ) and "any" not in allowed_profile_ids:
+        cg.add(var.set_allow_any_profile_id(False))
+        for allowed_id in allowed_profile_ids:
+            cg.add(var.add_allowed_profile_id(allowed_id))

--- a/esphome/components/xiaomi_miscale/xiaomi_miscale.cpp
+++ b/esphome/components/xiaomi_miscale/xiaomi_miscale.cpp
@@ -10,8 +10,25 @@ static const char *const TAG = "xiaomi_miscale";
 
 void XiaomiMiscale::dump_config() {
   ESP_LOGCONFIG(TAG, "Xiaomi Miscale");
+  ESP_LOGCONFIG(TAG, "  Bindkey: %s", format_hex_pretty(this->bindkey_, 16).c_str());
   LOG_SENSOR("  ", "Weight", this->weight_);
   LOG_SENSOR("  ", "Impedance", this->impedance_);
+  LOG_SENSOR("  ", "Impedance Low", this->impedance_low_);
+  LOG_SENSOR("  ", "Heart Rate", this->heart_rate_);
+  LOG_SENSOR("  ", "Timestamp", this->timestamp_);
+  LOG_SENSOR("  ", "Profile ID", this->profile_id_);
+}
+
+void XiaomiMiscale::set_bindkey(const std::string &bindkey) {
+  memset(bindkey_, 0, 16);
+  if (bindkey.size() != 32) {
+    return;
+  }
+  char temp[3] = {0};
+  for (int i = 0; i < 16; i++) {
+    strncpy(temp, &(bindkey.c_str()[i * 2]), 2);
+    bindkey_[i] = std::strtoul(temp, nullptr, 16);
+  }
 }
 
 bool XiaomiMiscale::parse_device(const esp32_ble_tracker::ESPBTDevice &device) {
@@ -33,21 +50,55 @@ bool XiaomiMiscale::parse_device(const esp32_ble_tracker::ESPBTDevice &device) {
     if (!report_results_(res, device.address_str()))
       continue;
 
+    if (res->model == Model::MODEL_S400 &&
+        (!res->profile_id.has_value() ||
+         (!this->allow_any_profile_id_ && !this->allowed_profile_ids_.count(*res->profile_id)))) {
+      continue;
+    }
+
     if (res->weight.has_value() && this->weight_ != nullptr)
       this->weight_->publish_state(*res->weight);
-
     if (this->impedance_ != nullptr) {
-      if (res->version == 1) {
-        ESP_LOGW(TAG, "Impedance is only supported on version 2. Your scale was identified as version 1.");
+      if (res->model == Model::MODEL_V1) {
+        ESP_LOGW(TAG, "Impedance is only supported on version 2 and S400. Your scale was identified as version 1.");
       } else {
         if (res->impedance.has_value()) {
           this->impedance_->publish_state(*res->impedance);
         } else {
-          if (clear_impedance_)
+          if (this->clear_impedance_)
             this->impedance_->publish_state(NAN);
         }
       }
     }
+    if (this->impedance_low_ != nullptr) {
+      if (res->model == Model::MODEL_V1 || res->model == Model::MODEL_V2) {
+        ESP_LOGW(TAG, "Impedance is only supported on S400. Your scale was identified as version %d.", res->model);
+      } else if (res->impedance_low.has_value()) {
+        this->impedance_low_->publish_state(*res->impedance_low);
+      }
+    }
+    if (this->heart_rate_ != nullptr) {
+      if (res->model == Model::MODEL_V1 || res->model == Model::MODEL_V2) {
+        ESP_LOGW(TAG, "Heart rate is only supported on S400. Your scale was identified as version %d.", res->model);
+      } else if (res->heart_rate.has_value()) {
+        this->heart_rate_->publish_state(*res->heart_rate);
+      }
+    }
+    if (this->timestamp_ != nullptr) {
+      if (res->model == Model::MODEL_V1 || res->model == Model::MODEL_V2) {
+        ESP_LOGW(TAG, "Timestamp is only supported on S400. Your scale was identified as version %d.", res->model);
+      } else if (res->timestamp.has_value()) {
+        this->timestamp_->publish_state(*res->timestamp);
+      }
+    }
+    if (this->profile_id_ != nullptr) {
+      if (res->model == Model::MODEL_V1 || res->model == Model::MODEL_V2) {
+        ESP_LOGW(TAG, "Timestamp is only supported on S400. Your scale was identified as version %d.", res->model);
+      } else if (res->profile_id.has_value()) {
+        this->profile_id_->publish_state(*res->profile_id);
+      }
+    }
+
     success = true;
   }
 
@@ -57,9 +108,11 @@ bool XiaomiMiscale::parse_device(const esp32_ble_tracker::ESPBTDevice &device) {
 optional<ParseResult> XiaomiMiscale::parse_header_(const esp32_ble_tracker::ServiceData &service_data) {
   ParseResult result;
   if (service_data.uuid == esp32_ble_tracker::ESPBTUUID::from_uint16(0x181D) && service_data.data.size() == 10) {
-    result.version = 1;
+    result.model = Model::MODEL_V1;
   } else if (service_data.uuid == esp32_ble_tracker::ESPBTUUID::from_uint16(0x181B) && service_data.data.size() == 13) {
-    result.version = 2;
+    result.model = Model::MODEL_V2;
+  } else if (service_data.uuid == esp32_ble_tracker::ESPBTUUID::from_uint16(0xFE95) && service_data.data.size() == 24) {
+    result.model = Model::MODEL_S400;
   } else {
     ESP_LOGVV(TAG,
               "parse_header(): Couldn't identify scale version or data size was not correct. UUID: %s, data_size: %d",
@@ -71,10 +124,15 @@ optional<ParseResult> XiaomiMiscale::parse_header_(const esp32_ble_tracker::Serv
 }
 
 bool XiaomiMiscale::parse_message_(const std::vector<uint8_t> &message, ParseResult &result) {
-  if (result.version == 1) {
+  if (result.model == Model::MODEL_V1) {
     return parse_message_v1_(message, result);
-  } else {
+  } else if (result.model == Model::MODEL_V2) {
     return parse_message_v2_(message, result);
+  } else if (result.model == Model::MODEL_S400) {
+    return parse_message_s400_(message, result);
+  } else {
+    ESP_LOGVV(TAG, "parse_message(): unsupported model: %s", get_model_name_(result.model).c_str());
+    return false;
   }
 }
 
@@ -145,19 +203,126 @@ bool XiaomiMiscale::parse_message_v2_(const std::vector<uint8_t> &message, Parse
   return true;
 }
 
+bool XiaomiMiscale::parse_message_s400_(const std::vector<uint8_t> &message, ParseResult &result) {
+  const uint8_t *raw = message.data();
+
+  const bool has_data = raw[0] & 0x40;
+  if (!has_data) {
+    ESP_LOGVV(TAG, "parse_message_s400(): service data has no DATA flag.");
+    return false;
+  }
+
+  const uint16_t device_id = encode_uint16(raw[3], raw[2]);
+  if (device_id != 0x3BD5) {
+    ESP_LOGVV(TAG, "parse_message_s400(): unknown device ID (%X).", device_id);
+    return false;
+  }
+
+  static uint8_t last_frame_count = 0;
+  if (last_frame_count == raw[4]) {
+    ESP_LOGVV(TAG, "parse_message_s400(): duplicate data packet received (%d).", static_cast<int>(last_frame_count));
+    return false;
+  }
+  last_frame_count = raw[4];
+
+  const bool has_encryption = raw[0] & 0x08;
+  if (has_encryption && this->bindkey_[0] == 0) {  // unset
+    ESP_LOGW(TAG, "parse_message_s400(): received encrypted packet but bindkey is not set.");
+    return false;
+  } else if (has_encryption && (!(xiaomi_ble::decrypt_xiaomi_payload(const_cast<std::vector<uint8_t> &>(message),
+                                                                     this->bindkey_, this->address_)))) {
+    ESP_LOGW(TAG, "parse_message_s400(): decryption failed, bindkey might be wrong.");
+    return false;
+  }
+
+  uint8_t raw_offset = 5;
+  const uint16_t value_type = encode_uint16(raw[raw_offset + 1], raw[raw_offset + 0]);
+  if (value_type != 0x6E16) {
+    ESP_LOGVV(TAG, "parse_message_s400(): unknown value type (%X).", value_type);
+    return false;
+  }
+  const uint8_t value_length = raw[raw_offset + 2];
+  if (value_length != 9) {
+    ESP_LOGVV(TAG, "parse_message_s400(): value has wrong size (%d)!", value_length);
+    return false;
+  }
+
+  const uint8_t *data = raw + raw_offset + 3;
+  // 0 profile ID (S400 FE95)
+  // 1-4 metrics (int(impedance * 10) << 18) + ((heart_rate - 50) << 11) + int(weight * 10)
+  //     bits 0-10 weight
+  //     bits 11-17 heart rate
+  //     bits 18-31 impedance high if weight == 0 and heart rate == 0, otherwise impedance low
+  // 5-8 UNIX epoch timestamp
+  // ref: https://github.com/AlexxIT/XiaomiGateway3/issues/1388#issuecomment-2444669822
+
+  // timestamp, 4 bytes, 32-bit unsigned integer, UNIX epoch
+  result.timestamp = encode_uint32(data[8], data[7], data[6], data[5]);
+  // compressed metrics, 4 bytes
+  const uint32_t data_int = encode_uint32(data[4], data[3], data[2], data[1]);
+  // weight, 11-bit unsigned integer, 10x float, 0.1 kg
+  const uint16_t weight = data_int & 0x7FF;
+  if (weight != 0) {
+    result.weight = weight / 10.0f;
+  }
+  // heart rate, 7-bit unsigned integer, -50 offset, 1 bpm
+  const uint8_t heart_rate = (data_int >> 11) & 0x7F;
+  if (heart_rate > 0 && heart_rate < 127) {
+    result.heart_rate = heart_rate + 50;
+  }
+  // impedance high or low, 14-bit unsigned integer, 10x float, 0.1 Ohm
+  const uint16_t impedance = data_int >> 18;
+  if (impedance != 0) {
+    if (weight == 0 && heart_rate == 0) {  // second packet with only impedance low metric
+      result.impedance_low = impedance / 10.0f;
+    } else {
+      result.impedance = impedance / 10.0f;
+    }
+  }
+  // profile ID, 1 byte, 8-bit unsigned integer, 1
+  result.profile_id = data[0];
+
+  return true;
+}
+
+std::string XiaomiMiscale::get_model_name_(const Model model) {
+  switch (model) {
+    case Model::MODEL_V1:
+      return "V1";
+    case Model::MODEL_V2:
+      return "V2";
+    case Model::MODEL_S400:
+      return "S400";
+    default:
+      return "UNKNOWN";
+  }
+}
+
 bool XiaomiMiscale::report_results_(const optional<ParseResult> &result, const std::string &address) {
   if (!result.has_value()) {
     ESP_LOGVV(TAG, "report_results(): no results available.");
     return false;
   }
 
-  ESP_LOGD(TAG, "Got Xiaomi Miscale v%d (%s):", result->version, address.c_str());
+  ESP_LOGI(TAG, "Got Xiaomi Miscale %s (%s):", get_model_name_(result->model).c_str(), address.c_str());
 
   if (result->weight.has_value()) {
-    ESP_LOGD(TAG, "  Weight: %.2fkg", *result->weight);
+    ESP_LOGI(TAG, "  Weight: %.2fkg", *result->weight);
   }
   if (result->impedance.has_value()) {
-    ESP_LOGD(TAG, "  Impedance: %.0fohm", *result->impedance);
+    ESP_LOGI(TAG, "  Impedance: %.1fohm", *result->impedance);
+  }
+  if (result->impedance_low.has_value()) {
+    ESP_LOGI(TAG, "  Impedance Low: %.1fohm", *result->impedance_low);
+  }
+  if (result->heart_rate.has_value()) {
+    ESP_LOGI(TAG, "  Heart Rate: %ubpm", *result->heart_rate);
+  }
+  if (result->timestamp.has_value()) {
+    ESP_LOGI(TAG, "  Timestamp: %u", *result->timestamp);
+  }
+  if (result->profile_id.has_value()) {
+    ESP_LOGI(TAG, "  Profile ID: %u", *result->profile_id);
   }
 
   return true;

--- a/esphome/components/xiaomi_miscale/xiaomi_miscale.h
+++ b/esphome/components/xiaomi_miscale/xiaomi_miscale.h
@@ -3,7 +3,9 @@
 #include "esphome/core/component.h"
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/esp32_ble_tracker/esp32_ble_tracker.h"
+#include "esphome/components/xiaomi_ble/xiaomi_ble.h"
 
+#include <set>
 #include <vector>
 
 #ifdef USE_ESP32
@@ -11,32 +13,59 @@
 namespace esphome {
 namespace xiaomi_miscale {
 
+enum Model {
+  MODEL_V1,
+  MODEL_V2,
+  MODEL_S400,
+};
+
 struct ParseResult {
-  int version;
+  enum Model model;
   optional<float> weight;
   optional<float> impedance;
+  optional<float> impedance_low;
+  optional<uint8_t> heart_rate;
+  optional<uint8_t> profile_id;
+  optional<uint32_t> timestamp;
 };
 
 class XiaomiMiscale : public Component, public esp32_ble_tracker::ESPBTDeviceListener {
  public:
   void set_address(uint64_t address) { address_ = address; };
+  void set_bindkey(const std::string &bindkey);
 
   bool parse_device(const esp32_ble_tracker::ESPBTDevice &device) override;
   void dump_config() override;
   void set_weight(sensor::Sensor *weight) { weight_ = weight; }
   void set_impedance(sensor::Sensor *impedance) { impedance_ = impedance; }
+  void set_impedance_low(sensor::Sensor *impedance_low) { impedance_low_ = impedance_low; }
+  void set_heart_rate(sensor::Sensor *heart_rate) { heart_rate_ = heart_rate; }
+  void set_timestamp(sensor::Sensor *timestamp) { timestamp_ = timestamp; }
+  void set_profile_id(sensor::Sensor *profile_id) { profile_id_ = profile_id; }
   void set_clear_impedance(bool clear_impedance) { clear_impedance_ = clear_impedance; }
+  void set_allow_any_profile_id(bool allowed) { allow_any_profile_id_ = allowed; }
+  void add_allowed_profile_id(uint8_t allowed_id) { allowed_profile_ids_.insert(allowed_id); }
 
  protected:
   uint64_t address_;
+  uint8_t bindkey_[16];
+
   sensor::Sensor *weight_{nullptr};
   sensor::Sensor *impedance_{nullptr};
+  sensor::Sensor *heart_rate_{nullptr};
+  sensor::Sensor *impedance_low_{nullptr};
+  sensor::Sensor *timestamp_{nullptr};
+  sensor::Sensor *profile_id_{nullptr};
+  bool allow_any_profile_id_ = true;
+  std::set<uint8_t> allowed_profile_ids_;
   bool clear_impedance_{false};
 
   optional<ParseResult> parse_header_(const esp32_ble_tracker::ServiceData &service_data);
   bool parse_message_(const std::vector<uint8_t> &message, ParseResult &result);
   bool parse_message_v1_(const std::vector<uint8_t> &message, ParseResult &result);
   bool parse_message_v2_(const std::vector<uint8_t> &message, ParseResult &result);
+  bool parse_message_s400_(const std::vector<uint8_t> &message, ParseResult &result);
+  std::string get_model_name_(Model model);
   bool report_results_(const optional<ParseResult> &result, const std::string &address);
 };
 

--- a/tests/components/xiaomi_miscale_s400/common.yaml
+++ b/tests/components/xiaomi_miscale_s400/common.yaml
@@ -1,0 +1,21 @@
+esp32_ble_tracker:
+
+sensor:
+  - platform: xiaomi_miscale
+    mac_address: '5C:CA:D3:70:D4:A2'
+    bindkey: '0728974d657a4b60964c1b1677f35f7c'
+    weight:
+      name: "Xiaomi Mi Scale Weight"
+    impedance:
+      name: "Xiaomi Mi Scale Impedance"
+    impedance_low:
+      name: "Xiaomi Mi Scale Impedance Low"
+    heart_rate:
+      name: "Xiaomi Mi Scale Heart Rate"
+    timestamp:
+      name: "Xiaomi Mi Scale Timestamp"
+    profile_id:
+      name: "Xiaomi Mi Scale Profile ID"
+    allowed_profile_ids:
+      - 1
+      - any

--- a/tests/components/xiaomi_miscale_s400/test.esp32-idf.yaml
+++ b/tests/components/xiaomi_miscale_s400/test.esp32-idf.yaml
@@ -1,0 +1,4 @@
+packages:
+  ble: !include ../../test_build_components/common/ble/esp32-idf.yaml
+
+<<: !include common.yaml


### PR DESCRIPTION
# What does this implement/fix?

Add support for [Xiaomi Body Composition Scale S400](https://www.mi.com/global/product/xiaomi-body-composition-scale-s400/specs/) (MJTZC01YM) to the component [`xiaomi_miscale`](https://esphome.io/components/sensor/xiaomi_miscale).

Also fixes cipher text offset in [`xiaomi_ble`](https://github.com/esphome/esphome/blob/f3b1b11ebaf4af7a3cd7c2072e2da3f51fcc83e2/esphome/components/xiaomi_ble/xiaomi_ble.cpp#L278-L279), but I'm not sure if there are any device sending 24-byte packets with an offset of 11.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#4801

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
sensor:
  # Xiaomi Body Composition Scale S400
  - platform: xiaomi_miscale
    mac_address: 'DE:AD:BE:EF:13:37'
    bindkey: '0728974d657a4b60964c1b1677f35f7c'
    weight:
      name: 'Body Scale Weight'
      accuracy_decimals: 1
    heart_rate:
      name: 'Body Scale Heart Rate'
    impedance:
      name: 'Body Scale Impedance High'
    impedance_low:
      name: 'Body Scale Impedance Low'
    timestamp:
      name: 'Body Scale Timestamp'
    profile_id:
      name: 'Body Scale Profile ID'
    allowed_profile_ids:
      - 1
      - 2
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
