### PR TITLE
Add support for M3200 pressure sensors.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -242,6 +242,7 @@ esphome/components/ltr390/* @latonita @sjtrny
 esphome/components/ltr501/* @latonita
 esphome/components/ltr_als_ps/* @latonita
 esphome/components/lvgl/* @clydebarrow
+esphome/components/m3200/* @ilikecake
 esphome/components/m5stack_8angle/* @rnauber
 esphome/components/matrix_keypad/* @ssieb
 esphome/components/max17043/* @blacknell

--- a/esphome/components/m3200/__init__.py
+++ b/esphome/components/m3200/__init__.py
@@ -1,0 +1,1 @@
+CODEOWNERS = ["@ilikecake"]

--- a/esphome/components/m3200/m3200.cpp
+++ b/esphome/components/m3200/m3200.cpp
@@ -78,9 +78,11 @@ void M3200::update() {
   
   // If we get here, the device tried to get data 10 times and got stale data or an invalid status
   // every time. I have only seen it fail once from stale data, so 10 failures probably indicates a
-  // i2c bus problem.
+  // i2c bus problem. If this happens, we log an error but continue. I considered marking the device
+  // failed if this happens, but it is possible to recover from a bus failure, so I don't want to 
+  // mark the device failed unnessecarially.
   ESP_LOGE(TAG, "Ten read failures in a row. Device is probably failed.");
-  this->mark_failed();
+  //this->mark_failed();
 }
 
 void M3200::dump_config() {

--- a/esphome/components/m3200/m3200.cpp
+++ b/esphome/components/m3200/m3200.cpp
@@ -1,0 +1,99 @@
+#include "esphome/core/log.h"
+#include "m3200.h"
+
+namespace esphome {
+namespace m3200 {
+
+static const char *const TAG = "m3200.sensor";
+
+// Device I2C address. This address is fixed.
+static const uint8_t M3200_I2C_ADDR_DEFAULT = 0x28;   //TODO: Is this settable? Should I allow the user to define it?
+
+//Status byte definitions
+static const uint8_t M3200_STATUS_OK = 0x00;
+static const uint8_t M3200_STATUS_STALE = 0x80;
+static const uint8_t M3200_STATUS_FAULT = 0xC0;
+
+// The number of times to retry an I2C transaction before giving up. I have only seen 1
+// failure before a successful read.
+static const uint8_t M3200_I2C_RETRY_COUNT = 10;
+
+void M3200::setup() {
+  //Precalculate the slope of the calibration curve so that we don't need to do it every time.
+  this->slope_ = (float(this->fs_pressure_)-(this->min_pressure_))/(15000. - 1000.);
+}
+
+void M3200::update() {
+  uint8_t i = 0;
+  i2c::ErrorCode return_code;
+  uint8_t read_buffer[4];
+  uint16_t raw_pressure = 0;
+  uint16_t raw_temperature = 0;
+  
+  float pressure;
+  float temperature;
+  
+  for (i=0; i<M3200_I2C_RETRY_COUNT; i++) {
+    //Read data from the device
+    return_code = this->read(read_buffer, 4);
+    
+    if ((read_buffer[0] & 0xC0) == M3200_STATUS_OK) {
+      //Device indicates the data is good.
+      raw_pressure = ((read_buffer[0]&0x3F) << 8) | read_buffer[1];
+      raw_temperature = (read_buffer[2] << 3) | ((read_buffer[3] & 0xE0)>>5);
+      //ESP_LOGD(TAG, "pressure: %d", raw_pressure);
+      //ESP_LOGD(TAG, "temperature: %d", raw_temperature);
+      
+      pressure = (this->slope_)*(float(raw_pressure)-1000.) + (this->min_pressure_);
+      temperature = ((200.)/(2048.))*float(raw_temperature) - 50.;
+      
+      if (this->pressure_sensor_ != nullptr) {
+        this->pressure_sensor_->publish_state(pressure);
+      }
+      
+      if (this->temperature_sensor_ != nullptr) {
+        this->temperature_sensor_->publish_state(temperature);
+      }
+
+      return;
+    } 
+    else if ((read_buffer[0] & 0xC0) == M3200_STATUS_STALE) {
+      // The device indicates that the data is stale. This means we already read this data. 
+      // If this happens, we retry to try to get a good reading.
+      //ESP_LOGD(TAG, "Stale Data");
+    }
+    else if ((read_buffer[0] & 0xC0) == M3200_STATUS_FAULT) {
+      // Device indicates a sensor fault. Not sure what this means exactly, but it is probably bad.
+      // A power cycle might fix the device in this state.
+      ESP_LOGE(TAG, "Sensor Fault");
+      this->mark_failed();
+      return;
+    }
+    else {
+      // We should never get here. This means that the status bits were invalid (0b01) This probably
+      // indicates a fault on the i2c bus. We will retry here and see if it gets better.
+      ESP_LOGW(TAG, "Undefined sensor status");
+    }
+  }
+  
+  // If we get here, the device tried to get data 10 times and got stale data or an invalid status
+  // every time. I have only seen it fail once from stale data, so 10 failures probably indicates a
+  // i2c bus problem.
+  ESP_LOGE(TAG, "Ten read failures in a row. Device is probably failed.");
+  this->mark_failed();
+}
+
+void M3200::dump_config() {
+  ESP_LOGCONFIG(TAG, "M3200:");
+  LOG_I2C_DEVICE(this);
+  if (this->is_failed()) {
+    // TODO: The sensor might get failed here.
+    ESP_LOGCONFIG(TAG, "  M3200 is indicating a failure. Power cycle might fix it.");
+  }
+  LOG_UPDATE_INTERVAL(this);
+  ESP_LOGCONFIG(TAG, "  Full Scale Pressure: %d psi", this->fs_pressure_);
+  ESP_LOGCONFIG(TAG, "  Minimum Pressure: %d psi", this->min_pressure_);
+}
+
+}  // namespace m3200
+}  // namespace esphome

--- a/esphome/components/m3200/m3200.h
+++ b/esphome/components/m3200/m3200.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/components/sensor/sensor.h"
+#include "esphome/components/i2c/i2c.h"
+
+namespace esphome {
+namespace m3200 {
+
+
+class M3200 : public sensor::Sensor, public PollingComponent, public i2c::I2CDevice {
+ public:
+  void setup() override;
+  void update() override;
+  void dump_config() override;
+
+  void set_fs_pressure(uint16_t fs_pressure) { fs_pressure_ = fs_pressure; };
+  void set_min_pressure_(uint16_t min_pressure) { min_pressure_ = min_pressure; };
+  void set_temperature_sensor(sensor::Sensor *temperature_sensor) { temperature_sensor_ = temperature_sensor; }
+  void set_pressure_sensor(sensor::Sensor *pressure_sensor) { pressure_sensor_ = pressure_sensor; }
+
+ //private:
+  //uint8_t get_register_(uint8_t register_to_read, uint16_t *register_value);
+  //uint8_t set_register_(uint8_t register_to_set, uint16_t value_to_set);
+  //uint8_t crc8_(uint8_t *byte_buffer, uint8_t length_of_crc);
+
+ protected:
+  sensor::Sensor *temperature_sensor_{nullptr};
+  sensor::Sensor *pressure_sensor_{nullptr};
+  uint16_t fs_pressure_;
+  float min_pressure_;
+  float slope_;
+  //float intercept_;
+
+};
+
+}  // namespace m3200
+}  // namespace esphome

--- a/esphome/components/m3200/sensor.py
+++ b/esphome/components/m3200/sensor.py
@@ -36,7 +36,7 @@ CONFIG_SCHEMA = (
     cv.Schema(
         {
             cv.GenerateID(): cv.declare_id(m3200),
-            cv.Required(CONF_FULL_SCALE_PRESSURE): cv.int_range(min=100, max=5000),
+            cv.Required(CONF_FULL_SCALE_PRESSURE): cv.int_range(min=10, max=6000),
             cv.Required(CONF_PRESSURE_TYPE): cv.enum(PRESSURE_GAGE_TYPE, upper=True),
             
             cv.Optional(CONF_TEMPERATURE): sensor.sensor_schema(

--- a/esphome/components/m3200/sensor.py
+++ b/esphome/components/m3200/sensor.py
@@ -1,0 +1,76 @@
+import esphome.codegen as cg
+from esphome.components import i2c, sensor
+import esphome.config_validation as cv
+from esphome.const import (
+    CONF_ID,
+    CONF_PRESSURE,
+    CONF_TEMPERATURE,
+    DEVICE_CLASS_PRESSURE,
+    DEVICE_CLASS_TEMPERATURE,
+    STATE_CLASS_MEASUREMENT,
+    UNIT_CELSIUS,
+    UNIT_PASCAL,
+    ICON_THERMOMETER,
+    ICON_GAUGE,
+)
+
+DEPENDENCIES = ["i2c"]
+
+m3200_ns = cg.esphome_ns.namespace("m3200")
+
+CONF_PRESSURE_TYPE = "pressure_type"
+CONF_FULL_SCALE_PRESSURE = "full_scale_pressure"
+UNIT_PSI = "psi"
+
+PRESSURE_GAGE_TYPE = {
+    "GAGE": 0,
+    "GAUGE": 0,
+    "COMPOUND": -14.7,
+}
+
+
+
+m3200 = m3200_ns.class_("M3200", cg.PollingComponent, i2c.I2CDevice)
+
+CONFIG_SCHEMA = (
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.declare_id(m3200),
+            cv.Required(CONF_FULL_SCALE_PRESSURE): cv.int_range(min=100, max=5000),
+            cv.Required(CONF_PRESSURE_TYPE): cv.enum(PRESSURE_GAGE_TYPE, upper=True),
+            
+            cv.Optional(CONF_TEMPERATURE): sensor.sensor_schema(
+                unit_of_measurement=UNIT_CELSIUS,
+                icon=ICON_THERMOMETER,
+                accuracy_decimals=2,
+                device_class=DEVICE_CLASS_TEMPERATURE,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ),
+            cv.Optional(CONF_PRESSURE): sensor.sensor_schema(
+                unit_of_measurement=UNIT_PSI,
+                icon=ICON_GAUGE,
+                accuracy_decimals=2,
+                device_class=DEVICE_CLASS_PRESSURE,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ),
+        }
+    )
+    .extend(cv.polling_component_schema("10s"))
+    .extend(i2c.i2c_device_schema(0x28))
+)
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+    await i2c.register_i2c_device(var, config)
+    cg.add(var.set_fs_pressure(config.get(CONF_FULL_SCALE_PRESSURE)))
+    cg.add(var.set_min_pressure_(PRESSURE_GAGE_TYPE[config.get(CONF_PRESSURE_TYPE)]))
+
+    if CONF_TEMPERATURE in config:
+        sens = await sensor.new_sensor(config[CONF_TEMPERATURE])
+        cg.add(var.set_temperature_sensor(sens))
+
+    if CONF_PRESSURE in config:
+        sens = await sensor.new_sensor(config[CONF_PRESSURE])
+        cg.add(var.set_pressure_sensor(sens))


### PR DESCRIPTION
# What does this implement/fix?

Adds support for the M3200 series pressure and temperature sensor from TE. [Website](https://www.te.com/en/product-CAT-PTT0068.html)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#4802

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
sensor:
  - platform: m3200
      full_scale_pressure: 100
      pressure_type: GAGE
      temperature:
        name: "M3200 Temperature"
      pressure:
        name: "M3200 Pressure"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
