### PR TITLE
real_time_clock: Apply timezone immediately in set_timezone()

### DIFF
--- a/esphome/components/time/real_time_clock.cpp
+++ b/esphome/components/time/real_time_clock.cpp
@@ -21,10 +21,7 @@ namespace time {
 static const char *const TAG = "time";
 
 RealTimeClock::RealTimeClock() = default;
-void RealTimeClock::call_setup() {
-  this->apply_timezone_();
-  PollingComponent::call_setup();
-}
+void RealTimeClock::call_setup() { PollingComponent::call_setup(); }
 void RealTimeClock::synchronize_epoch_(uint32_t epoch) {
   // Update UTC epoch time.
   struct timeval timev {

--- a/esphome/components/time/real_time_clock.cpp
+++ b/esphome/components/time/real_time_clock.cpp
@@ -21,7 +21,6 @@ namespace time {
 static const char *const TAG = "time";
 
 RealTimeClock::RealTimeClock() = default;
-void RealTimeClock::call_setup() { PollingComponent::call_setup(); }
 void RealTimeClock::synchronize_epoch_(uint32_t epoch) {
   // Update UTC epoch time.
   struct timeval timev {

--- a/esphome/components/time/real_time_clock.h
+++ b/esphome/components/time/real_time_clock.h
@@ -21,7 +21,10 @@ class RealTimeClock : public PollingComponent {
   explicit RealTimeClock();
 
   /// Set the time zone.
-  void set_timezone(const std::string &tz) { this->timezone_ = tz; }
+  void set_timezone(const std::string &tz) {
+    this->timezone_ = tz;
+    this->apply_timezone_();
+  }
 
   /// Get the time zone currently in use.
   std::string get_timezone() { return this->timezone_; }

--- a/esphome/components/time/real_time_clock.h
+++ b/esphome/components/time/real_time_clock.h
@@ -38,8 +38,6 @@ class RealTimeClock : public PollingComponent {
   /// Get the current time as the UTC epoch since January 1st 1970.
   time_t timestamp_now() { return ::time(nullptr); }
 
-  void call_setup() override;
-
   void add_on_time_sync_callback(std::function<void()> callback) {
     this->time_sync_callback_.add(std::move(callback));
   };


### PR DESCRIPTION
The timezone is handled by the C library, when ESPHome sets the $TZ environment variable and then calls tzset().

That's done from the ->apply_timezone() method which is currently invoked only from ->call_setup(). For the SNTP component, setup is actually quite late in boot (setup_priority::BEFORE_CONNECTION).

So everything which runs *before* that will get incorrect times in GMT instead of localtime, because the timezone hasn't been set up yet. That includes on_boot methods at the default priority as well as a lot of other setup.

Fix that by telling the C library about the timezone as early as possible, directly in the ->set_timezone() method.

Closes https://github.com/esphome/issues/issues/6840


## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/issues/issues/6840

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [N/A] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
