### PR TITLE
Fix '--device MQTT' for devices with static IP

### DIFF
--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -375,10 +375,12 @@ def upload_program(config, args, host):
     password = ota_conf.get(CONF_PASSWORD, "")
 
     if (
-        not is_ip_address(CORE.address)  # pylint: disable=too-many-boolean-expressions
-        and (get_port_type(host) == "MQTT" or config[CONF_MDNS][CONF_DISABLED])
-        and CONF_MQTT in config
+        CONF_MQTT in config  # pylint: disable=too-many-boolean-expressions
         and (not args.device or args.device in ("MQTT", "OTA"))
+        and (
+            ((config[CONF_MDNS][CONF_DISABLED]) and not is_ip_address(CORE.address))
+            or get_port_type(host) == "MQTT"
+        )
     ):
         from esphome import mqtt
 


### PR DESCRIPTION
An earlier commit disabled the MQTT IP lookup if the device has a static IP address in CORE.address. That made sense for the automatic fallback to MQTT when mDNS is disabled, but not if the user explicitly asked for MQTT.

Rework the condition to apply that check only to the !mDNS case, and clean it up to be a little more understandable.

Fixes: ac0549578197 ("Dont do mqtt ip lookup if `use_address` has ip address (#5096)")

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A
## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [N/A] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
