### PR TITLE
Sort resolved IP addresses for dashboard

### DIFF
--- a/esphome/dashboard/web_server.py
+++ b/esphome/dashboard/web_server.py
@@ -38,7 +38,7 @@ import yaml
 from yaml.nodes import Node
 
 from esphome import const, platformio_api, yaml_util
-from esphome.helpers import get_bool_env, mkdir_p
+from esphome.helpers import get_bool_env, mkdir_p, sort_ip_addresses
 from esphome.storage_json import (
     StorageJSON,
     archive_storage_path,
@@ -336,7 +336,7 @@ class EsphomePortCommandWebSocket(EsphomeCommandWebSocket):
                 # Use the IP address if available but only
                 # if the API is loaded and the device is online
                 # since MQTT logging will not work otherwise
-                port = address_list[0]
+                port = sort_ip_addresses(address_list)[0]
             elif (
                 entry.address
                 and (
@@ -347,7 +347,7 @@ class EsphomePortCommandWebSocket(EsphomeCommandWebSocket):
                 and not isinstance(address_list, Exception)
             ):
                 # If mdns is not available, try to use the DNS cache
-                port = address_list[0]
+                port = sort_ip_addresses(address_list)[0]
 
         return [
             *DASHBOARD_COMMAND,

--- a/esphome/helpers.py
+++ b/esphome/helpers.py
@@ -200,12 +200,20 @@ def resolve_ip_address(host, port):
     return res
 
 
-def sort_ip_addresses(address_list):
+def sort_ip_addresses(address_list: list[str]) -> list[str]:
+    """Takes a list of IP addresses in string form, e.g. from mDNS or MQTT,
+    and sorts them into the best order to actually try connecting to them.
+
+    This is roughly based on RFC6724 but a lot simpler: First we choose
+    IPv6 addresses, then Legacy IP addresses, and lowest priority is
+    link-local IPv6 addresses that don't have a link specified (which
+    are useless, but mDNS does provide them in that form.)
+    """
     import socket
 
     # First "resolve" all the IP addresses to get getaddrinfo() tuples
     # which indicate the type of address, scope, etc.
-    res = []
+    res: list[str] = []
     for addr in address_list:
         # This should always work as these are supposed to be IP addresses
         try:
@@ -220,7 +228,7 @@ def sort_ip_addresses(address_list):
     res.sort(key=addr_preference_)
 
     # Finally, turn the getaddrinfo() tuples back into plain hostnames.
-    sorted_address_list = []
+    sorted_address_list: list[str] = []
     for r in res:
         sorted_address_list.append(socket.getnameinfo(r[4], socket.NI_NUMERICHOST)[0])
 

--- a/esphome/helpers.py
+++ b/esphome/helpers.py
@@ -226,10 +226,9 @@ def sort_ip_addresses(address_list: list[str]) -> list[str]:
     for addr in address_list:
         # This should always work as these are supposed to be IP addresses
         try:
-            r = socket.getaddrinfo(
+            res += socket.getaddrinfo(
                 addr, 0, proto=socket.IPPROTO_TCP, flags=socket.AI_NUMERICHOST
             )
-            res += r
         except OSError:
             _LOGGER.info("Failed to parse IP address '%s'", addr)
 

--- a/esphome/helpers.py
+++ b/esphome/helpers.py
@@ -207,7 +207,8 @@ def sort_ip_addresses(address_list: list[str]) -> list[str]:
     This is roughly based on RFC6724 but a lot simpler: First we choose
     IPv6 addresses, then Legacy IP addresses, and lowest priority is
     link-local IPv6 addresses that don't have a link specified (which
-    are useless, but mDNS does provide them in that form.)
+    are useless, but mDNS does provide them in that form). Addresses
+    which cannot be parsed are silently dropped.
     """
     import socket
 

--- a/esphome/helpers.py
+++ b/esphome/helpers.py
@@ -200,6 +200,33 @@ def resolve_ip_address(host, port):
     return res
 
 
+def sort_ip_addresses(address_list):
+    import socket
+
+    # First "resolve" all the IP addresses to get getaddrinfo() tuples
+    # which indicate the type of address, scope, etc.
+    res = []
+    for addr in address_list:
+        # This should always work as these are supposed to be IP addresses
+        try:
+            r = socket.getaddrinfo(
+                addr, 0, proto=socket.IPPROTO_TCP, flags=socket.AI_NUMERICHOST
+            )
+            res = res + r
+        except OSError:
+            _LOGGER.info("Failed to parse IP address '%s'", addr)
+
+    # Now use that information to sort them.
+    res.sort(key=addr_preference_)
+
+    # Finally, turn the getaddrinfo() tuples back into plain hostnames.
+    sorted_address_list = []
+    for r in res:
+        sorted_address_list.append(socket.getnameinfo(r[4], socket.NI_NUMERICHOST)[0])
+
+    return sorted_address_list
+
+
 def get_bool_env(var, default=False):
     value = os.getenv(var, default)
     if isinstance(value, str):

--- a/esphome/helpers.py
+++ b/esphome/helpers.py
@@ -229,7 +229,7 @@ def sort_ip_addresses(address_list: list[str]) -> list[str]:
             r = socket.getaddrinfo(
                 addr, 0, proto=socket.IPPROTO_TCP, flags=socket.AI_NUMERICHOST
             )
-            res = res + r
+            res += r
         except OSError:
             _LOGGER.info("Failed to parse IP address '%s'", addr)
 

--- a/esphome/helpers.py
+++ b/esphome/helpers.py
@@ -228,11 +228,7 @@ def sort_ip_addresses(address_list: list[str]) -> list[str]:
     res.sort(key=addr_preference_)
 
     # Finally, turn the getaddrinfo() tuples back into plain hostnames.
-    sorted_address_list: list[str] = []
-    for r in res:
-        sorted_address_list.append(socket.getnameinfo(r[4], socket.NI_NUMERICHOST)[0])
-
-    return sorted_address_list
+    return [socket.getnameinfo(r[4], socket.NI_NUMERICHOST)[0] for r in res]
 
 
 def get_bool_env(var, default=False):

--- a/esphome/helpers.py
+++ b/esphome/helpers.py
@@ -211,9 +211,17 @@ def sort_ip_addresses(address_list: list[str]) -> list[str]:
     """
     import socket
 
-    # First "resolve" all the IP addresses to get getaddrinfo() tuples
-    # which indicate the type of address, scope, etc.
-    res: list[str] = []
+    # First "resolve" all the IP addresses to getaddrinfo() tuples of the form
+    # (family, type, proto, canonname, sockaddr)
+    res: list[
+        tuple[
+            int,
+            int,
+            int,
+            Union[str, None],
+            Union[tuple[str, int], tuple[str, int, int, int]],
+        ]
+    ] = []
     for addr in address_list:
         # This should always work as these are supposed to be IP addresses
         try:

--- a/tests/unit_tests/test_helpers.py
+++ b/tests/unit_tests/test_helpers.py
@@ -267,3 +267,13 @@ def test_sanitize(text, expected):
     actual = helpers.sanitize(text)
 
     assert actual == expected
+
+
+@pytest.mark.parametrize(
+    "text, expected",
+    ((["127.0.0.1", "fe80::1", "2001::2"], ["2001::2", "127.0.0.1", "fe80::1"]),),
+)
+def test_sort_ip_addresses(text, expected):
+    actual = helpers.sort_ip_addresses(text)
+
+    assert actual == expected

--- a/tests/unit_tests/test_helpers.py
+++ b/tests/unit_tests/test_helpers.py
@@ -273,7 +273,7 @@ def test_sanitize(text, expected):
     "text, expected",
     ((["127.0.0.1", "fe80::1", "2001::2"], ["2001::2", "127.0.0.1", "fe80::1"]),),
 )
-def test_sort_ip_addresses(text, expected):
+def test_sort_ip_addresses(text: list[str], expected: list[str]) -> None:
     actual = helpers.sort_ip_addresses(text)
 
     assert actual == expected


### PR DESCRIPTION
In https://github.com/esphome/esphome/pull/7414 I fixed the name resolution in helpers.resolve_ip_address() to return a *list* of addresses sorted in an approximation of RFC6724 preference.

I missed the fact that the dashboard code calls directly into the underlying zeroconf resolve_host() functions. As those return a list, we get a TypeError("expected string or bytes-like object, got 'list'")>) raised when trying to use the result of the lookup.

In https://github.com/esphome/esphome/pull/7747 the traceback was fixed by just using the *first* element of that list, but the list still wasn't *sorted*, so we're essentially using a *randomly* selected address which happened to be the first one to respond to mDNS.

Fix it properly by providing a helpers.sort_ip_addresses() function which performs the same sort as we do for the OTA connection.

This involves calling gethostinfo() so we can see the address type and scope for each address, then applying the same ordering criteria, then getnameinfo() to turn it back into a string again for the output.

(In the original resolve_ip_address() we *wanted* the getaddrinfo() tuples, so we didn't perform the final getnameinfo() and it all seemed a little more natural).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

## Test Environment

Only unit tested locally with the following hack:
```
--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -42,7 +42,7 @@ from esphome.const import (
     SECRETS_FILES,
 )
 from esphome.core import CORE, EsphomeError, coroutine
-from esphome.helpers import get_bool_env, indent, is_ip_address
+from esphome.helpers import get_bool_env, indent, is_ip_address, sort_ip_addresses
 from esphome.log import Fore, color, setup_log
 from esphome.util import (
     get_serial_ports,
@@ -374,6 +374,12 @@ def upload_program(config, args, host):
     remote_port = int(ota_conf[CONF_PORT])
     password = ota_conf.get(CONF_PASSWORD, "")
 
+
+    addrlist = [ '10.0.0.1', '2001::6', 'fe80::2', 'fe80::1%lo' ]
+    slist = sort_ip_addresses(addrlist)
+    for l in slist:
+        _LOGGER.info(l);
+
     if (
         CONF_MQTT in config  # pylint: disable=too-many-boolean-expressions
         and (not args.device or args.device in ("MQTT", "OTA"))

```
```
INFO 2001::6
INFO fe80::1%lo
INFO 10.0.0.1
INFO fe80::2
```