### PR TITLE
Speaker-Media-Player: Fix potential deadlock in audio pipeline

### DIFF
--- a/esphome/components/speaker/media_player/audio_pipeline.cpp
+++ b/esphome/components/speaker/media_player/audio_pipeline.cpp
@@ -443,9 +443,8 @@ void AudioPipeline::decode_task(void *params) {
 
     xEventGroupClearBits(this_pipeline->event_group_,
                          EventGroupBits::DECODER_MESSAGE_FINISHED | EventGroupBits::READER_MESSAGE_LOADED_MEDIA_TYPE);
-    
+
     if (!(event_bits & EventGroupBits::PIPELINE_COMMAND_STOP)) {
-      
       InfoErrorEvent event;
       event.source = InfoErrorSource::DECODER;
 

--- a/esphome/components/speaker/media_player/audio_pipeline.cpp
+++ b/esphome/components/speaker/media_player/audio_pipeline.cpp
@@ -441,9 +441,11 @@ void AudioPipeline::decode_task(void *params) {
                                                  pdFALSE,                                    // Wait for all the bits,
                                                  portMAX_DELAY);  // Block indefinitely until bit is set
 
+    xEventGroupClearBits(this_pipeline->event_group_,
+                         EventGroupBits::DECODER_MESSAGE_FINISHED | EventGroupBits::READER_MESSAGE_LOADED_MEDIA_TYPE);
+    
     if (!(event_bits & EventGroupBits::PIPELINE_COMMAND_STOP)) {
-      xEventGroupClearBits(this_pipeline->event_group_,
-                           EventGroupBits::DECODER_MESSAGE_FINISHED | EventGroupBits::READER_MESSAGE_LOADED_MEDIA_TYPE);
+      
       InfoErrorEvent event;
       event.source = InfoErrorSource::DECODER;
 


### PR DESCRIPTION
# What does this implement/fix?

This PR addresses a potential deadlock in the speaker-media-player component. The deadlock occurs when a new media file is requested (which sets the PIPELINE_COMMAND_STOP flag) after the reader task sets the READER_MESSAGE_LOADED_MEDIA_TYPE flag, but before it is cleared by the decoder thread.

The issue arises due to a circular dependency between two flags:

- The PIPELINE_COMMAND_STOP flag doesn't get cleared until the READER_MESSAGE_LOADED_MEDIA_TYPE flag is cleared.
- However, the READER_MESSAGE_LOADED_MEDIA_TYPE flag is only cleared if PIPELINE_COMMAND_STOP is not set.

This mutual dependency results in both flags blocking each other, causing the pipeline to hang. 

In this fix, I chose to clear the READER_MESSAGE_LOADED_MEDIA_TYPE flag even if the PIPELINE_COMMAND_STOP flag is set, in order to break the deadlock.
Please review whether this is the preferred approach, or if it would be better to instead remove the dependency on READER_MESSAGE_LOADED_MEDIA_TYPE being cleared before allowing PIPELINE_COMMAND_STOP to be cleared.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
