### PR TITLE
Include MAC address in noise hello

### DIFF
--- a/esphome/components/api/api_frame_helper.cpp
+++ b/esphome/components/api/api_frame_helper.cpp
@@ -311,6 +311,11 @@ APIError APINoiseFrameHelper::state_action_() {
     const std::string &name = App.get_name();
     const uint8_t *name_ptr = reinterpret_cast<const uint8_t *>(name.c_str());
     msg.insert(msg.end(), name_ptr, name_ptr + name.size() + 1);
+    // node mac, terminated by null byte
+    uint8_t mac[6];
+    get_mac_address_raw(mac);
+    const uint8_t *mac_ptr = reinterpret_cast<const uint8_t *>(mac);
+    msg.insert(msg.end(), mac_ptr, mac_ptr + 6 + 1);
 
     aerr = write_frame_(msg.data(), msg.size());
     if (aerr != APIError::OK)

--- a/esphome/components/api/api_frame_helper.cpp
+++ b/esphome/components/api/api_frame_helper.cpp
@@ -312,10 +312,9 @@ APIError APINoiseFrameHelper::state_action_() {
     const uint8_t *name_ptr = reinterpret_cast<const uint8_t *>(name.c_str());
     msg.insert(msg.end(), name_ptr, name_ptr + name.size() + 1);
     // node mac, terminated by null byte
-    uint8_t mac[6];
-    get_mac_address_raw(mac);
-    uint8_t *mac_ptr = reinterpret_cast<uint8_t *>(mac);
-    msg.insert(msg.end(), mac_ptr, mac_ptr + 6 + 1);
+    const std::string &mac = get_mac_address();
+    const uint8_t *mac_ptr = reinterpret_cast<const uint8_t *>(mac.c_str());
+    msg.insert(msg.end(), mac_ptr, mac_ptr + mac.size() + 1);
 
     aerr = write_frame_(msg.data(), msg.size());
     if (aerr != APIError::OK)

--- a/esphome/components/api/api_frame_helper.cpp
+++ b/esphome/components/api/api_frame_helper.cpp
@@ -314,7 +314,7 @@ APIError APINoiseFrameHelper::state_action_() {
     // node mac, terminated by null byte
     uint8_t mac[6];
     get_mac_address_raw(mac);
-    const uint8_t *mac_ptr = reinterpret_cast<const uint8_t *>(mac);
+    uint8_t *mac_ptr = reinterpret_cast<uint8_t *>(mac);
     msg.insert(msg.end(), mac_ptr, mac_ptr + 6 + 1);
 
     aerr = write_frame_(msg.data(), msg.size());


### PR DESCRIPTION
# What does this implement/fix?

Include MAC address in noise hello

Right now we can't tell if its the wrong device now present at the IP Address that Home Assistant last saw it at because we don't get the mac address back, and we only get the name.  When Home Assistant used the name as the unique id, this was fine, but since switching to the mac we have no way to verify we are talking to the correct device if we don't have the key for the device residing at the cached IP (or at least the device claiming to be the correct device)

This means we don't know to retry later if IP has changed, and instead we start reauth, when the device is offline and different one that uses a different key is in its place. See https://github.com/home-assistant/core/issues/133956

https://github.com/esphome/aioesphomeapi/pull/1149
```yaml
external_components:
  - source: github://pr#8551
    components: [api]
    refresh: 0s
```

aioesphomeapi sends
```
00000000  01 00 00 01 00 31 00 0a  2b 7f 41 b7 52 14 2a 4f   .....1.. +.A.R.*O
00000010  85 64 4f 73 f8 25 6e 43  d4 bb 05 1b 4c b2 56 91   .dOs.%nC ....L.V.
00000020  76 9a c6 94 aa 05 23 f9  d2 91 13 96 f6 b9 a9 f6   v.....#. ........
00000030  11 83 bd bb 7b 82 ae                               ....{..
```

device replies
```
00000000  01 00 1f 01 70 6f 6f 6c  68 6f 75 73 65 38 31 70   ....pool house81p
00000010  72 6f 78 79 00 32 34 34  63 61 62 30 36 34 39 39   roxy.244 cab06499
00000020  63 00                                              c.
```
reply as C array
```
0x01, 0x00, 0x1f, 0x01, 0x70, 0x6f, 0x6f, 0x6c, 
0x68, 0x6f, 0x75, 0x73, 0x65, 0x38, 0x31, 0x70, 
0x72, 0x6f, 0x78, 0x79, 0x00, 0x32, 0x34, 0x34, 
0x63, 0x61, 0x62, 0x30, 0x36, 0x34, 0x39, 0x39, 
0x63, 0x00 };
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
