### PR TITLE
[ld2420] only use select if available

### DIFF
--- a/esphome/components/ld2420/ld2420.cpp
+++ b/esphome/components/ld2420/ld2420.cpp
@@ -140,14 +140,16 @@ void LD2420Component::setup() {
   if (get_firmware_int_(ld2420_firmware_ver_) < CALIBRATE_VERSION_MIN) {
     this->set_operating_mode(OP_SIMPLE_MODE_STRING);
 #ifdef USE_SELECT
-    this->operating_selector_->publish_state(OP_SIMPLE_MODE_STRING);
+    if (this->operating_selector_ != nullptr)
+      this->operating_selector_->publish_state(OP_SIMPLE_MODE_STRING);
 #endif
     this->set_mode_(CMD_SYSTEM_MODE_SIMPLE);
     ESP_LOGW(TAG, "LD2420 Frimware Version %s and older are only supported in Simple Mode", ld2420_firmware_ver_);
   } else {
     this->set_mode_(CMD_SYSTEM_MODE_ENERGY);
 #ifdef USE_SELECT    
-    this->operating_selector_->publish_state(OP_NORMAL_MODE_STRING);
+    if (this->operating_selector_ != nullptr)
+      this->operating_selector_->publish_state(OP_NORMAL_MODE_STRING);
 #endif
   }
 #ifdef USE_NUMBER
@@ -300,7 +302,8 @@ void LD2420Component::set_operating_mode(const std::string &state) {
     this->current_operating_mode = OP_MODE_TO_UINT.at(state);
     // Entering Auto Calibrate we need to clear the privoiuos data collection
 #ifdef USE_SELECT
-    this->operating_selector_->publish_state(state);
+    if (this->operating_selector_ != nullptr)
+      this->operating_selector_->publish_state(state);
 #endif
     if (current_operating_mode == OP_CALIBRATE_MODE) {
       this->set_calibration_(true);
@@ -321,7 +324,8 @@ void LD2420Component::set_operating_mode(const std::string &state) {
   } else {
     this->current_operating_mode = OP_SIMPLE_MODE;
 #ifdef USE_SELECT
-    this->operating_selector_->publish_state(OP_SIMPLE_MODE_STRING);
+    if (this->operating_selector_ != nullptr)
+      this->operating_selector_->publish_state(OP_SIMPLE_MODE_STRING);
 #endif
   }
 }

--- a/esphome/components/ld2420/ld2420.cpp
+++ b/esphome/components/ld2420/ld2420.cpp
@@ -147,7 +147,7 @@ void LD2420Component::setup() {
     ESP_LOGW(TAG, "LD2420 Frimware Version %s and older are only supported in Simple Mode", ld2420_firmware_ver_);
   } else {
     this->set_mode_(CMD_SYSTEM_MODE_ENERGY);
-#ifdef USE_SELECT    
+#ifdef USE_SELECT
     if (this->operating_selector_ != nullptr)
       this->operating_selector_->publish_state(OP_NORMAL_MODE_STRING);
 #endif

--- a/esphome/components/ld2420/ld2420.cpp
+++ b/esphome/components/ld2420/ld2420.cpp
@@ -67,8 +67,8 @@ float LD2420Component::get_setup_priority() const { return setup_priority::BUS; 
 void LD2420Component::dump_config() {
   ESP_LOGCONFIG(TAG, "LD2420:");
   ESP_LOGCONFIG(TAG, "  Firmware Version : %7s", this->ld2420_firmware_ver_);
-  ESP_LOGCONFIG(TAG, "LD2420 Number:");
 #ifdef USE_NUMBER
+  ESP_LOGCONFIG(TAG, "LD2420 Number:");
   LOG_NUMBER(TAG, "  Gate Timeout:", this->gate_timeout_number_);
   LOG_NUMBER(TAG, "  Gate Max Distance:", this->max_gate_distance_number_);
   LOG_NUMBER(TAG, "  Gate Min Distance:", this->min_gate_distance_number_);
@@ -84,8 +84,10 @@ void LD2420Component::dump_config() {
   LOG_BUTTON(TAG, "  Factory Reset:", this->factory_reset_button_);
   LOG_BUTTON(TAG, "  Restart Module:", this->restart_module_button_);
 #endif
+#ifdef USE_SELECT
   ESP_LOGCONFIG(TAG, "LD2420 Select:");
   LOG_SELECT(TAG, "  Operating Mode", this->operating_selector_);
+#endif
   if (this->get_firmware_int_(ld2420_firmware_ver_) < CALIBRATE_VERSION_MIN) {
     ESP_LOGW(TAG, "LD2420 Firmware Version %s and older are only supported in Simple Mode", ld2420_firmware_ver_);
   }
@@ -137,12 +139,16 @@ void LD2420Component::setup() {
   memcpy(&this->new_config, &this->current_config, sizeof(this->current_config));
   if (get_firmware_int_(ld2420_firmware_ver_) < CALIBRATE_VERSION_MIN) {
     this->set_operating_mode(OP_SIMPLE_MODE_STRING);
+#ifdef USE_SELECT
     this->operating_selector_->publish_state(OP_SIMPLE_MODE_STRING);
+#endif
     this->set_mode_(CMD_SYSTEM_MODE_SIMPLE);
     ESP_LOGW(TAG, "LD2420 Frimware Version %s and older are only supported in Simple Mode", ld2420_firmware_ver_);
   } else {
     this->set_mode_(CMD_SYSTEM_MODE_ENERGY);
+#ifdef USE_SELECT    
     this->operating_selector_->publish_state(OP_NORMAL_MODE_STRING);
+#endif
   }
 #ifdef USE_NUMBER
   this->init_gate_config_numbers();
@@ -293,7 +299,9 @@ void LD2420Component::set_operating_mode(const std::string &state) {
   if (get_firmware_int_(ld2420_firmware_ver_) >= CALIBRATE_VERSION_MIN) {
     this->current_operating_mode = OP_MODE_TO_UINT.at(state);
     // Entering Auto Calibrate we need to clear the privoiuos data collection
+#ifdef USE_SELECT
     this->operating_selector_->publish_state(state);
+#endif
     if (current_operating_mode == OP_CALIBRATE_MODE) {
       this->set_calibration_(true);
       for (uint8_t gate = 0; gate < LD2420_TOTAL_GATES; gate++) {
@@ -312,7 +320,9 @@ void LD2420Component::set_operating_mode(const std::string &state) {
     }
   } else {
     this->current_operating_mode = OP_SIMPLE_MODE;
+#ifdef USE_SELECT
     this->operating_selector_->publish_state(OP_SIMPLE_MODE_STRING);
+#endif
   }
 }
 


### PR DESCRIPTION
# What does this implement/fix?

Compiling fails if there are no selects in the config.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/issues/issues/6928

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
