### PR TITLE
[axs15231] Don't overwrite manual dimensions

### DIFF
--- a/esphome/components/axs15231/touchscreen/axs15231_touchscreen.cpp
+++ b/esphome/components/axs15231/touchscreen/axs15231_touchscreen.cpp
@@ -30,8 +30,12 @@ void AXS15231Touchscreen::setup() {
     this->interrupt_pin_->setup();
     this->attach_interrupt_(this->interrupt_pin_, gpio::INTERRUPT_FALLING_EDGE);
   }
-  this->x_raw_max_ = this->display_->get_native_width();
-  this->y_raw_max_ = this->display_->get_native_height();
+  if (this->x_raw_max_ == 0) {
+    this->x_raw_max_ = this->display_->get_native_width();
+  }
+  if (this->y_raw_max_ == 0) {
+    this->y_raw_max_ = this->display_->get_native_height();
+  }
   ESP_LOGCONFIG(TAG, "AXS15231 Touchscreen setup complete");
 }
 
@@ -44,7 +48,7 @@ void AXS15231Touchscreen::update_touches() {
   err = this->read(data, sizeof(data));
   ERROR_CHECK(err);
   this->status_clear_warning();
-  if (data[0] != 0)  // no touches
+  if (data[0] != 0 || data[1] == 0)  // no touches
     return;
   uint16_t x = encode_uint16(data[2] & 0xF, data[3]);
   uint16_t y = encode_uint16(data[4] & 0xF, data[5]);


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

AXS15231 touchscreen driver was not respecting manually specified dimensions.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://discord.com/channels/429907082951524364/1360462685535207604

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

display:
  - platform: qspi_dbi
    model: axs15231
    data_rate: 40MHz
    dimensions:
      height: 480
      width: 320
    cs_pin:
      number: 45
      ignore_strapping_warning: true
    rotation: 90

touchscreen:
  platform: axs15231
  interrupt_pin: GPIO3
  transform:
    swap_xy: true
    mirror_x: false
    mirror_y: true
  calibration:
    x_min: 0
    x_max: 480
    y_min: 0
    y_max: 320
  on_touch:
  - lambda: |-
        ESP_LOGI("cal", "x=%d, y=%d, x_raw=%d, y_raw=%0d",
            touch.x,
            touch.y,
            touch.x_raw,
            touch.y_raw
            );

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
