### PR TITLE
BWR mode support for Waveshare 7.50in-bwr

### DIFF
--- a/esphome/components/waveshare_epaper/display.py
+++ b/esphome/components/waveshare_epaper/display.py
@@ -82,6 +82,9 @@ WaveshareEPaper7P3InF = waveshare_epaper_ns.class_(
 WaveshareEPaper7P5In = waveshare_epaper_ns.class_(
     "WaveshareEPaper7P5In", WaveshareEPaper
 )
+WaveshareEPaper7P5InBWR = waveshare_epaper_ns.class_(
+    "WaveshareEPaper7P5InBWR", WaveshareEPaperBWR
+)
 WaveshareEPaper7P5InBC = waveshare_epaper_ns.class_(
     "WaveshareEPaper7P5InBC", WaveshareEPaper
 )
@@ -154,6 +157,7 @@ MODELS = {
     "5.83inv2": ("b", WaveshareEPaper5P8InV2),
     "7.30in-f": ("b", WaveshareEPaper7P3InF),
     "7.50in": ("b", WaveshareEPaper7P5In),
+    "7.50in-bwr": ("b", WaveshareEPaper7P5InBWR),
     "7.50in-bv2": ("b", WaveshareEPaper7P5InBV2),
     "7.50in-bv3": ("b", WaveshareEPaper7P5InBV3),
     "7.50in-bv3-bwr": ("b", WaveshareEPaper7P5InBV3BWR),

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -3307,6 +3307,102 @@ void WaveshareEPaper7P5In::dump_config() {
   LOG_PIN("  Busy Pin: ", this->busy_pin_);
   LOG_UPDATE_INTERVAL(this);
 }
+
+void WaveshareEPaper7P5InBWR::initialize() {
+  // COMMAND POWER SETTING
+  this->command(0x01);
+  this->data(0x37);
+  this->data(0x00);
+  // COMMAND PANEL SETTING
+  this->command(0x00);
+  this->data(0xCF);
+  this->data(0x0B);
+  // COMMAND BOOSTER SOFT START
+  this->command(0x06);
+  this->data(0xC7);
+  this->data(0xCC);
+  this->data(0x28);
+  // COMMAND POWER ON
+  this->command(0x04);
+  this->wait_until_idle_();
+  delay(10);
+  // COMMAND PLL CONTROL
+  this->command(0x30);
+  this->data(0x3C);
+  // COMMAND TEMPERATURE SENSOR CALIBRATION
+  this->command(0x41);
+  this->data(0x00);
+  // COMMAND VCOM AND DATA INTERVAL SETTING
+  this->command(0x50);
+  this->data(0x77);
+  // COMMAND TCON SETTING
+  this->command(0x60);
+  this->data(0x22);
+  // COMMAND RESOLUTION SETTING
+  this->command(0x61);
+  this->data(0x02);
+  this->data(0x80);
+  this->data(0x01);
+  this->data(0x80);
+  // COMMAND VCM DC SETTING REGISTER
+  this->command(0x82);
+  this->data(0x1E);
+  this->command(0xE5);
+  this->data(0x03);
+}
+
+void HOT WaveshareEPaper7P5InBWR::display() {
+  const uint32_t buf_len = this->get_buffer_length_() / 2u;
+
+  // COMMAND DATA START TRANSMISSION 1 (B/W data)
+  // COMMAND DATA START TRANSMISSION 1
+  this->command(0x10);
+  this->start_data_();
+  for (size_t i = 0; i < buf_len; i++) {
+    uint8_t temp1 = this->buffer_[i];
+    uint8_t temp1red = this->buffer_[i + buf_len];
+    for (uint8_t j = 0; j < 8; j++) {
+      uint8_t temp2;
+      if (temp1red & 0x80) {
+        temp2 = 0x04; // red
+      } else if (temp1 & 0x80) {
+        temp2 = 0x03; // black
+      } else {
+        temp2 = 0x00; // white
+      }
+      temp2 <<= 4;
+      temp1 <<= 1;
+      temp1red <<= 1;
+      j++;
+      if (temp1red & 0x80) {
+        temp2 |= 0x04;  // red
+      } else if (temp1 & 0x80) {
+        temp2 |= 0x03; // black
+      } else {
+        temp2 |= 0x00;  // white
+      }
+      temp1 <<= 1;
+      temp1red <<= 1;
+      this->write_byte(temp2);
+    }
+    App.feed_wdt();
+  }
+  this->end_data_();
+
+  // COMMAND DISPLAY REFRESH
+  this->command(0x12);
+}
+int WaveshareEPaper7P5InBWR::get_width_internal() { return 640; }
+int WaveshareEPaper7P5InBWR::get_height_internal() { return 384; }
+void WaveshareEPaper7P5InBWR::dump_config() {
+  LOG_DISPLAY("", "Waveshare E-Paper", this);
+  ESP_LOGCONFIG(TAG, "  Model: 7.5in BWR-Mode");
+  LOG_PIN("  Reset Pin: ", this->reset_pin_);
+  LOG_PIN("  DC Pin: ", this->dc_pin_);
+  LOG_PIN("  Busy Pin: ", this->busy_pin_);
+  LOG_UPDATE_INTERVAL(this);
+}
+
 void WaveshareEPaper7P3InF::initialize() {
   if (this->buffers_[0] == nullptr) {
     ESP_LOGE(TAG, "Buffer unavailable!");

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -3364,11 +3364,11 @@ void HOT WaveshareEPaper7P5InBWR::display() {
     for (uint8_t j = 0; j < 8; j++) {
       uint8_t temp2;
       if (temp1red & 0x80) {
-        temp2 = 0x04; // red
+        temp2 = 0x04;  // red
       } else if (temp1 & 0x80) {
-        temp2 = 0x03; // black
+        temp2 = 0x03;  // black
       } else {
-        temp2 = 0x00; // white
+        temp2 = 0x00;  // white
       }
       temp2 <<= 4;
       temp1 <<= 1;
@@ -3377,7 +3377,7 @@ void HOT WaveshareEPaper7P5InBWR::display() {
       if (temp1red & 0x80) {
         temp2 |= 0x04;  // red
       } else if (temp1 & 0x80) {
-        temp2 |= 0x03; // black
+        temp2 |= 0x03;  // black
       } else {
         temp2 |= 0x00;  // white
       }

--- a/esphome/components/waveshare_epaper/waveshare_epaper.h
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.h
@@ -739,6 +739,29 @@ class WaveshareEPaper7P5In : public WaveshareEPaper {
   int get_height_internal() override;
 };
 
+class WaveshareEPaper7P5InBWR : public WaveshareEPaperBWR {
+ public:
+  void initialize() override;
+
+  void display() override;
+
+  void dump_config() override;
+
+  void deep_sleep() override {
+    // COMMAND POWER OFF
+    this->command(0x02);
+    this->wait_until_idle_();
+    // COMMAND DEEP SLEEP
+    this->command(0x07);
+    this->data(0xA5);  // check byte
+  }
+
+ protected:
+  int get_width_internal() override;
+
+  int get_height_internal() override;
+};
+
 class WaveshareEPaper7P5InBV2 : public WaveshareEPaper {
  public:
   void initialize() override;


### PR DESCRIPTION
# What does this implement/fix?

Adds support for the 640x384 black red and while e-paper display [Waveshare 7.5inch (B)](https://www.waveshare.com/wiki/7.5inch_e-Paper_HAT_(C)), that's the BWR version of the already supported 7.50in.
See here: https://camo.githubusercontent.com/07515a9609a4d5a1b08fa1f0f07a101a89d6ba593f984a0dbb694d91b161df2a/687474703a2f2f7777772e7761766573686172652e636f6d2f696d672f6465766b69742f67656e6572616c2f652d50617065722d4d6f64756c65732d434d502e6a7067

Datasheet: https://files.waveshare.com/upload/2/29/7.5inch_e-paper-b-Specification.pdf

Also works on clones like HINK-E075A01.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

None

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#4818

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
esphome:
  name: test-waveshared

esp32:
  board: esp32dev
  framework:
    type: arduino

logger:

spi:
  clk_pin: GPIO13
  mosi_pin: GPIO14

display:
  - platform: waveshare_epaper
    id: eink_display
    cs_pin: GPIO15
    dc_pin: GPIO27
    busy_pin: GPIO25
    reset_pin: GPIO26
    model: 7.50in-bwr
    #show_test_card: true
    update_interval: 2min
    lambda: |-
      const auto BLACK   = Color(0,   0,   0,   0);
      const auto RED     = Color(255, 0,   0,   0);
      const auto WHITE   = Color(255, 255, 255, 0);
      it.filled_circle(20, 32, 15, WHITE);
      it.filled_circle(40, 32, 15, BLACK);
      it.filled_circle(60, 32, 15, RED);
```
This test produces the following image (note the red color is displayed):
https://ichibi.eu/index.php/s/gSzPKdqLaszFqX3

Uncomment `show_test_card: true` to produce the following image:
https://ichibi.eu/index.php/s/6qcnYMcf5PJJqNX

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
