### PR TITLE
2025.4.0b2

### DIFF
--- a/esphome/components/api/api_frame_helper.cpp
+++ b/esphome/components/api/api_frame_helper.cpp
@@ -311,6 +311,10 @@ APIError APINoiseFrameHelper::state_action_() {
     const std::string &name = App.get_name();
     const uint8_t *name_ptr = reinterpret_cast<const uint8_t *>(name.c_str());
     msg.insert(msg.end(), name_ptr, name_ptr + name.size() + 1);
+    // node mac, terminated by null byte
+    const std::string &mac = get_mac_address();
+    const uint8_t *mac_ptr = reinterpret_cast<const uint8_t *>(mac.c_str());
+    msg.insert(msg.end(), mac_ptr, mac_ptr + mac.size() + 1);
 
     aerr = write_frame_(msg.data(), msg.size());
     if (aerr != APIError::OK)

--- a/esphome/components/axs15231/touchscreen/axs15231_touchscreen.cpp
+++ b/esphome/components/axs15231/touchscreen/axs15231_touchscreen.cpp
@@ -30,8 +30,12 @@ void AXS15231Touchscreen::setup() {
     this->interrupt_pin_->setup();
     this->attach_interrupt_(this->interrupt_pin_, gpio::INTERRUPT_FALLING_EDGE);
   }
-  this->x_raw_max_ = this->display_->get_native_width();
-  this->y_raw_max_ = this->display_->get_native_height();
+  if (this->x_raw_max_ == 0) {
+    this->x_raw_max_ = this->display_->get_native_width();
+  }
+  if (this->y_raw_max_ == 0) {
+    this->y_raw_max_ = this->display_->get_native_height();
+  }
   ESP_LOGCONFIG(TAG, "AXS15231 Touchscreen setup complete");
 }
 
@@ -44,7 +48,7 @@ void AXS15231Touchscreen::update_touches() {
   err = this->read(data, sizeof(data));
   ERROR_CHECK(err);
   this->status_clear_warning();
-  if (data[0] != 0)  // no touches
+  if (data[0] != 0 || data[1] == 0)  // no touches
     return;
   uint16_t x = encode_uint16(data[2] & 0xF, data[3]);
   uint16_t y = encode_uint16(data[4] & 0xF, data[5]);

--- a/esphome/components/lvgl/automation.py
+++ b/esphome/components/lvgl/automation.py
@@ -4,6 +4,7 @@ from esphome import automation
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.const import CONF_ACTION, CONF_GROUP, CONF_ID, CONF_TIMEOUT
+from esphome.core import Lambda
 from esphome.cpp_generator import TemplateArguments, get_variable
 from esphome.cpp_types import nullptr
 
@@ -64,7 +65,14 @@ async def action_to_code(
     action_id,
     template_arg,
     args,
+    config=None,
 ):
+    # Ensure all required ids have been processed, so our LambdaContext doesn't get context-switched.
+    if config:
+        for lamb in config.values():
+            if isinstance(lamb, Lambda):
+                for id_ in lamb.requires_ids:
+                    await get_variable(id_)
     await wait_for_widgets()
     async with LambdaContext(parameters=args, where=action_id) as context:
         for widget in widgets:
@@ -84,7 +92,9 @@ async def update_to_code(config, action_id, template_arg, args):
             lv.event_send(widget.obj, UPDATE_EVENT, nullptr)
 
     widgets = await get_widgets(config[CONF_ID])
-    return await action_to_code(widgets, do_update, action_id, template_arg, args)
+    return await action_to_code(
+        widgets, do_update, action_id, template_arg, args, config
+    )
 
 
 @automation.register_condition(
@@ -348,4 +358,6 @@ async def obj_update_to_code(config, action_id, template_arg, args):
         await set_obj_properties(widget, config)
 
     widgets = await get_widgets(config[CONF_ID])
-    return await action_to_code(widgets, do_update, action_id, template_arg, args)
+    return await action_to_code(
+        widgets, do_update, action_id, template_arg, args, config
+    )

--- a/esphome/components/lvgl/encoders.py
+++ b/esphome/components/lvgl/encoders.py
@@ -18,6 +18,7 @@ from .helpers import lvgl_components_required, requires_component
 from .lvcode import lv, lv_add, lv_assign, lv_expr, lv_Pvariable
 from .schemas import ENCODER_SCHEMA
 from .types import lv_group_t, lv_indev_type_t, lv_key_t
+from .widgets import get_widgets
 
 ENCODERS_CONFIG = cv.ensure_list(
     ENCODER_SCHEMA.extend(
@@ -76,5 +77,5 @@ async def encoders_to_code(var, config, default_group):
 async def initial_focus_to_code(config):
     for enc_conf in config[CONF_ENCODERS]:
         if default_focus := enc_conf.get(CONF_INITIAL_FOCUS):
-            obj = await cg.get_variable(default_focus)
-            lv.group_focus_obj(obj)
+            widget = await get_widgets(default_focus)
+            lv.group_focus_obj(widget[0].obj)

--- a/esphome/components/lvgl/lvcode.py
+++ b/esphome/components/lvgl/lvcode.py
@@ -173,7 +173,8 @@ class LambdaContext(CodeContext):
 
 class LvContext(LambdaContext):
     """
-    Code generation into the LVGL initialisation code (called in `setup()`)
+    Code generation into the LVGL initialisation code, called before setup() and loop()
+    Basically just does cg.add, so now fairly redundant.
     """
 
     added_lambda_count = 0

--- a/esphome/components/lvgl/lvgl_esphome.h
+++ b/esphome/components/lvgl/lvgl_esphome.h
@@ -63,10 +63,12 @@ inline void lv_disp_set_bg_image(lv_disp_t *disp, esphome::image::Image *image) 
 inline void lv_obj_set_style_bg_img_src(lv_obj_t *obj, esphome::image::Image *image, lv_style_selector_t selector) {
   lv_obj_set_style_bg_img_src(obj, image->get_lv_img_dsc(), selector);
 }
+#ifdef USE_LVGL_CANVAS
 inline void lv_canvas_draw_img(lv_obj_t *canvas, lv_coord_t x, lv_coord_t y, image::Image *image,
                                lv_draw_img_dsc_t *dsc) {
   lv_canvas_draw_img(canvas, x, y, image->get_lv_img_dsc(), dsc);
 }
+#endif
 
 #ifdef USE_LVGL_METER
 inline lv_meter_indicator_t *lv_meter_add_needle_img(lv_obj_t *obj, lv_meter_scale_t *scale, esphome::image::Image *src,

--- a/esphome/components/lvgl/number/__init__.py
+++ b/esphome/components/lvgl/number/__init__.py
@@ -1,6 +1,7 @@
 import esphome.codegen as cg
 from esphome.components import number
 import esphome.config_validation as cv
+from esphome.const import CONF_RESTORE_VALUE
 from esphome.cpp_generator import MockObj
 
 from ..defines import CONF_ANIMATED, CONF_UPDATE_ON_RELEASE, CONF_WIDGET
@@ -10,21 +11,21 @@ from ..lvcode import (
     EVENT_ARG,
     UPDATE_EVENT,
     LambdaContext,
-    LvContext,
+    ReturnStatement,
     lv,
-    lv_add,
     lvgl_static,
 )
 from ..types import LV_EVENT, LvNumber, lvgl_ns
 from ..widgets import get_widgets, wait_for_widgets
 
-LVGLNumber = lvgl_ns.class_("LVGLNumber", number.Number)
+LVGLNumber = lvgl_ns.class_("LVGLNumber", number.Number, cg.Component)
 
 CONFIG_SCHEMA = number.number_schema(LVGLNumber).extend(
     {
         cv.Required(CONF_WIDGET): cv.use_id(LvNumber),
         cv.Optional(CONF_ANIMATED, default=True): animated,
         cv.Optional(CONF_UPDATE_ON_RELEASE, default=False): cv.boolean,
+        cv.Optional(CONF_RESTORE_VALUE, default=False): cv.boolean,
     }
 )
 
@@ -32,32 +33,34 @@ CONFIG_SCHEMA = number.number_schema(LVGLNumber).extend(
 async def to_code(config):
     widget = await get_widgets(config, CONF_WIDGET)
     widget = widget[0]
-    var = await number.new_number(
-        config,
-        max_value=widget.get_max(),
-        min_value=widget.get_min(),
-        step=widget.get_step(),
-    )
-
     await wait_for_widgets()
+    async with LambdaContext([], return_type=cg.float_) as value:
+        value.add(ReturnStatement(widget.get_value()))
     async with LambdaContext([(cg.float_, "v")]) as control:
         await widget.set_property(
             "value", MockObj("v") * MockObj(widget.get_scale()), config[CONF_ANIMATED]
         )
         lv.event_send(widget.obj, API_EVENT, cg.nullptr)
-        control.add(var.publish_state(widget.get_value()))
-    async with LambdaContext(EVENT_ARG) as event:
-        event.add(var.publish_state(widget.get_value()))
     event_code = (
         LV_EVENT.VALUE_CHANGED
         if not config[CONF_UPDATE_ON_RELEASE]
         else LV_EVENT.RELEASED
     )
-    async with LvContext():
-        lv_add(var.set_control_lambda(await control.get_lambda()))
-        lv_add(
-            lvgl_static.add_event_cb(
-                widget.obj, await event.get_lambda(), UPDATE_EVENT, event_code
-            )
+    var = await number.new_number(
+        config,
+        await control.get_lambda(),
+        await value.get_lambda(),
+        event_code,
+        config[CONF_RESTORE_VALUE],
+        max_value=widget.get_max(),
+        min_value=widget.get_min(),
+        step=widget.get_step(),
+    )
+    async with LambdaContext(EVENT_ARG) as event:
+        event.add(var.on_value())
+    await cg.register_component(var, config)
+    cg.add(
+        lvgl_static.add_event_cb(
+            widget.obj, await event.get_lambda(), UPDATE_EVENT, event_code
         )
-        lv_add(var.publish_state(widget.get_value()))
+    )

--- a/esphome/components/lvgl/number/lvgl_number.h
+++ b/esphome/components/lvgl/number/lvgl_number.h
@@ -3,33 +3,46 @@
 #include <utility>
 
 #include "esphome/components/number/number.h"
-#include "esphome/core/automation.h"
 #include "esphome/core/component.h"
 #include "esphome/core/preferences.h"
 
 namespace esphome {
 namespace lvgl {
 
-class LVGLNumber : public number::Number {
+class LVGLNumber : public number::Number, public Component {
  public:
-  void set_control_lambda(std::function<void(float)> control_lambda) {
-    this->control_lambda_ = std::move(control_lambda);
-    if (this->initial_state_.has_value()) {
-      this->control_lambda_(this->initial_state_.value());
-      this->initial_state_.reset();
+  LVGLNumber(std::function<void(float)> control_lambda, std::function<float()> value_lambda, lv_event_code_t event,
+             bool restore)
+      : control_lambda_(std::move(control_lambda)),
+        value_lambda_(std::move(value_lambda)),
+        event_(event),
+        restore_(restore) {}
+
+  void setup() override {
+    float value = this->value_lambda_();
+    if (this->restore_) {
+      this->pref_ = global_preferences->make_preference<float>(this->get_object_id_hash());
+      if (this->pref_.load(&value)) {
+        this->control_lambda_(value);
+      }
     }
+    this->publish_state(value);
   }
+
+  void on_value() { this->publish_state(this->value_lambda_()); }
 
  protected:
   void control(float value) override {
-    if (this->control_lambda_ != nullptr) {
-      this->control_lambda_(value);
-    } else {
-      this->initial_state_ = value;
-    }
+    this->control_lambda_(value);
+    this->publish_state(value);
+    if (this->restore_)
+      this->pref_.save(&value);
   }
-  std::function<void(float)> control_lambda_{};
-  optional<float> initial_state_{};
+  std::function<void(float)> control_lambda_;
+  std::function<float()> value_lambda_;
+  lv_event_code_t event_;
+  bool restore_;
+  ESPPreferenceObject pref_{};
 };
 
 }  // namespace lvgl

--- a/esphome/components/lvgl/schemas.py
+++ b/esphome/components/lvgl/schemas.py
@@ -81,7 +81,9 @@ ENCODER_SCHEMA = cv.Schema(
             cv.declare_id(LVEncoderListener), requires_component("binary_sensor")
         ),
         cv.Optional(CONF_GROUP): cv.declare_id(lv_group_t),
-        cv.Optional(df.CONF_INITIAL_FOCUS): cv.use_id(lv_obj_t),
+        cv.Optional(df.CONF_INITIAL_FOCUS): cv.All(
+            LIST_ACTION_SCHEMA, cv.Length(min=1, max=1)
+        ),
         cv.Optional(df.CONF_LONG_PRESS_TIME, default="400ms"): PRESS_TIME,
         cv.Optional(df.CONF_LONG_PRESS_REPEAT_TIME, default="100ms"): PRESS_TIME,
     }

--- a/esphome/components/lvgl/select/__init__.py
+++ b/esphome/components/lvgl/select/__init__.py
@@ -1,18 +1,19 @@
+import esphome.codegen as cg
 from esphome.components import select
 import esphome.config_validation as cv
-from esphome.const import CONF_OPTIONS
+from esphome.const import CONF_ID, CONF_OPTIONS, CONF_RESTORE_VALUE
 
 from ..defines import CONF_ANIMATED, CONF_WIDGET, literal
-from ..lvcode import LvContext
 from ..types import LvSelect, lvgl_ns
-from ..widgets import get_widgets, wait_for_widgets
+from ..widgets import get_widgets
 
-LVGLSelect = lvgl_ns.class_("LVGLSelect", select.Select)
+LVGLSelect = lvgl_ns.class_("LVGLSelect", select.Select, cg.Component)
 
 CONFIG_SCHEMA = select.select_schema(LVGLSelect).extend(
     {
         cv.Required(CONF_WIDGET): cv.use_id(LvSelect),
         cv.Optional(CONF_ANIMATED, default=False): cv.boolean,
+        cv.Optional(CONF_RESTORE_VALUE, default=False): cv.boolean,
     }
 )
 
@@ -21,12 +22,9 @@ async def to_code(config):
     widget = await get_widgets(config, CONF_WIDGET)
     widget = widget[0]
     options = widget.config.get(CONF_OPTIONS, [])
-    selector = await select.new_select(config, options=options)
-    await wait_for_widgets()
-    async with LvContext() as ctx:
-        ctx.add(
-            selector.set_widget(
-                widget.var,
-                literal("LV_ANIM_ON" if config[CONF_ANIMATED] else "LV_ANIM_OFF"),
-            )
-        )
+    animated = literal("LV_ANIM_ON" if config[CONF_ANIMATED] else "LV_ANIM_OFF")
+    selector = cg.new_Pvariable(
+        config[CONF_ID], widget.var, animated, config[CONF_RESTORE_VALUE]
+    )
+    await select.register_select(selector, config, options=options)
+    await cg.register_component(selector, config)

--- a/esphome/components/lvgl/widgets/buttonmatrix.py
+++ b/esphome/components/lvgl/widgets/buttonmatrix.py
@@ -250,7 +250,7 @@ async def button_update_to_code(config, action_id, template_arg, args):
     widgets = await get_widgets(config[CONF_ID])
     assert all(isinstance(w, MatrixButton) for w in widgets)
 
-    async def do_button_update(w: MatrixButton):
+    async def do_button_update(w):
         if (width := config.get(CONF_WIDTH)) is not None:
             lv.btnmatrix_set_btn_width(w.obj, w.index, width)
         if config.get(CONF_SELECTED):
@@ -275,5 +275,5 @@ async def button_update_to_code(config, action_id, template_arg, args):
                 )
 
     return await action_to_code(
-        widgets, do_button_update, action_id, template_arg, args
+        widgets, do_button_update, action_id, template_arg, args, config
     )

--- a/esphome/components/lvgl/widgets/canvas.py
+++ b/esphome/components/lvgl/widgets/canvas.py
@@ -97,7 +97,7 @@ async def canvas_fill(config, action_id, template_arg, args):
     async def do_fill(w: Widget):
         lv.canvas_fill_bg(w.obj, color, opa)
 
-    return await action_to_code(widget, do_fill, action_id, template_arg, args)
+    return await action_to_code(widget, do_fill, action_id, template_arg, args, config)
 
 
 @automation.register_action(
@@ -145,7 +145,9 @@ async def canvas_set_pixel(config, action_id, template_arg, args):
                         x, y = point
                         lv.canvas_set_px_opa(w.obj, x, y, opa_var)
 
-    return await action_to_code(widget, do_set_pixels, action_id, template_arg, args)
+    return await action_to_code(
+        widget, do_set_pixels, action_id, template_arg, args, config
+    )
 
 
 DRAW_SCHEMA = cv.Schema(
@@ -181,7 +183,9 @@ async def draw_to_code(config, dsc_type, props, do_draw, action_id, template_arg
                     lv_assign(getattr(dsc, mapped_prop), value)
             await do_draw(w, x, y, dsc_addr)
 
-    return await action_to_code(widget, action_func, action_id, template_arg, args)
+    return await action_to_code(
+        widget, action_func, action_id, template_arg, args, config
+    )
 
 
 RECT_PROPS = {

--- a/esphome/components/lvgl/widgets/meter.py
+++ b/esphome/components/lvgl/widgets/meter.py
@@ -297,7 +297,9 @@ async def indicator_update_to_code(config, action_id, template_arg, args):
     async def set_value(w: Widget):
         await set_indicator_values(w.var, w.obj, config)
 
-    return await action_to_code(widget, set_value, action_id, template_arg, args)
+    return await action_to_code(
+        widget, set_value, action_id, template_arg, args, config
+    )
 
 
 async def set_indicator_values(meter, indicator, config):

--- a/esphome/components/speaker/media_player/audio_pipeline.cpp
+++ b/esphome/components/speaker/media_player/audio_pipeline.cpp
@@ -441,9 +441,10 @@ void AudioPipeline::decode_task(void *params) {
                                                  pdFALSE,                                    // Wait for all the bits,
                                                  portMAX_DELAY);  // Block indefinitely until bit is set
 
+    xEventGroupClearBits(this_pipeline->event_group_,
+                         EventGroupBits::DECODER_MESSAGE_FINISHED | EventGroupBits::READER_MESSAGE_LOADED_MEDIA_TYPE);
+
     if (!(event_bits & EventGroupBits::PIPELINE_COMMAND_STOP)) {
-      xEventGroupClearBits(this_pipeline->event_group_,
-                           EventGroupBits::DECODER_MESSAGE_FINISHED | EventGroupBits::READER_MESSAGE_LOADED_MEDIA_TYPE);
       InfoErrorEvent event;
       event.source = InfoErrorSource::DECODER;
 

--- a/esphome/const.py
+++ b/esphome/const.py
@@ -1,6 +1,6 @@
 """Constants used by esphome."""
 
-__version__ = "2025.4.0b1"
+__version__ = "2025.4.0b2"
 
 ALLOWED_NAME_CHARS = "abcdefghijklmnopqrstuvwxyz0123456789-_"
 VALID_SUBSTITUTIONS_CHARACTERS = (

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ platformio==6.1.18  # When updating platformio, also update /docker/Dockerfile
 esptool==4.8.1
 click==8.1.7
 esphome-dashboard==20250212.0
-aioesphomeapi==29.9.0
+aioesphomeapi==29.10.0
 zeroconf==0.146.3
 puremagic==1.28
 ruamel.yaml==0.18.10 # dashboard_import

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ esptool==4.8.1
 click==8.1.7
 esphome-dashboard==20250212.0
 aioesphomeapi==29.10.0
-zeroconf==0.146.3
+zeroconf==0.146.4
 puremagic==1.28
 ruamel.yaml==0.18.10 # dashboard_import
 esphome-glyphsets==0.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ pyserial==3.5
 platformio==6.1.18  # When updating platformio, also update /docker/Dockerfile
 esptool==4.8.1
 click==8.1.7
-esphome-dashboard==20250212.0
+esphome-dashboard==20250415.0
 aioesphomeapi==29.10.0
 zeroconf==0.146.4
 puremagic==1.28

--- a/tests/components/lvgl/common.yaml
+++ b/tests/components/lvgl/common.yaml
@@ -38,6 +38,7 @@ number:
     widget: slider_id
     name: LVGL Slider
     update_on_release: true
+    restore_value: true
   - platform: lvgl
     widget: lv_arc
     id: lvgl_arc_number

--- a/tests/components/lvgl/lvgl-package.yaml
+++ b/tests/components/lvgl/lvgl-package.yaml
@@ -990,3 +990,13 @@ color:
     green_int: 123
     blue_int: 64
     white_int: 255
+
+select:
+  - platform: lvgl
+    id: lv_roller_select
+    widget: lv_roller
+    restore_value: true
+  - platform: lvgl
+    id: lv_dropdown_select
+    widget: lv_dropdown
+    restore_value: false

--- a/tests/components/lvgl/test.esp32-idf.yaml
+++ b/tests/components/lvgl/test.esp32-idf.yaml
@@ -71,5 +71,6 @@ lvgl:
     sensor: encoder
     enter_button: pushbutton
     group: general
+    initial_focus: lv_roller
 
 <<: !include common.yaml


### PR DESCRIPTION
**Do not merge, release script will automatically merge**
## Full list of changes

### All changes

- [lvgl] Fix use of image without canvas (Bugfix) [esphome#8540](https://github.com/esphome/esphome/pull/8540)
- Include MAC address in noise hello [esphome#8551](https://github.com/esphome/esphome/pull/8551)
- [axs15231] Don't overwrite manual dimensions [esphome#8553](https://github.com/esphome/esphome/pull/8553)
- [lvgl] Fix initial focus on roller [esphome#8547](https://github.com/esphome/esphome/pull/8547)
- [lvgl] Add restore_value to select and number [esphome#8494](https://github.com/esphome/esphome/pull/8494)
- Speaker-Media-Player: Fix potential deadlock in audio pipeline [esphome#8548](https://github.com/esphome/esphome/pull/8548)
- [lvgl] Ensure captured lambdas are in correct order [esphome#8560](https://github.com/esphome/esphome/pull/8560)
- Bump aioesphomeapi from 29.9.0 to 29.10.0 [esphome#8562](https://github.com/esphome/esphome/pull/8562)
- Bump zeroconf from 0.146.3 to 0.146.4 [esphome#8563](https://github.com/esphome/esphome/pull/8563)
- Bump esphome-dashboard to 20250415.0 [esphome#8565](https://github.com/esphome/esphome/pull/8565)

<details>
<summary>Metadata</summary>

@coderabbitai ignore
</details>
