### PR TITLE
Use python3 in place of python, as some systems don't emulate the former

### DIFF
--- a/script/test_build_components
+++ b/script/test_build_components
@@ -53,7 +53,7 @@ start_esphome() {
   echo "> [$target_component] [$test_name] [$target_platform_with_version]"
   set -x
   # TODO: Validate escape of Command line substitution value
-  python -m esphome -s component_name $target_component -s component_dir ../../components/$target_component -s test_name $test_name -s target_platform $target_platform $esphome_command $component_test_file
+  python3 -m esphome -s component_name $target_component -s component_dir ../../components/$target_component -s test_name $test_name -s target_platform $target_platform $esphome_command $component_test_file
   { set +x; } 2>/dev/null
 }
 


### PR DESCRIPTION
# What does this implement/fix?

Call python3 instead of python in a build script

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

Some systems (including mine) don't make python a symlink to python3, so ensure that the correct program is being called

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
