### PR TITLE
SML runtime optimizations

### DIFF
--- a/esphome/components/sml/sml.cpp
+++ b/esphome/components/sml/sml.cpp
@@ -75,6 +75,7 @@ void Sml::process_sml_file_(const bytes &sml_data) {
 }
 
 void Sml::log_obis_info_(const std::vector<ObisInfo> &obis_info_vec) {
+#ifdef ESPHOME_LOG_HAS_DEBUG
   ESP_LOGD(TAG, "OBIS info:");
   for (auto const &obis_info : obis_info_vec) {
     std::string info;
@@ -83,6 +84,7 @@ void Sml::log_obis_info_(const std::vector<ObisInfo> &obis_info_vec) {
     info += " [0x" + bytes_repr(obis_info.value) + "]";
     ESP_LOGD(TAG, "%s", info.c_str());
   }
+#endif
 }
 
 void Sml::publish_obis_info_(const std::vector<ObisInfo> &obis_info_vec) {

--- a/esphome/components/sml/sml.cpp
+++ b/esphome/components/sml/sml.cpp
@@ -52,9 +52,7 @@ void Sml::loop() {
             break;
 
           // remove start/end sequence
-          this->sml_data_.erase(this->sml_data_.begin(), this->sml_data_.begin() + START_SEQ.size());
-          this->sml_data_.resize(this->sml_data_.size() - 8);
-          this->process_sml_file_(this->sml_data_);
+          this->process_sml_file_(bytes_view(this->sml_data_).subview(START_SEQ.size(), this->sml_data_.size() - START_SEQ.size() - 8));
         }
         break;
       };
@@ -66,8 +64,8 @@ void Sml::add_on_data_callback(std::function<void(std::vector<uint8_t>, bool)> &
   this->data_callbacks_.add(std::move(callback));
 }
 
-void Sml::process_sml_file_(const bytes &sml_data) {
-  SmlFile sml_file = SmlFile(sml_data);
+void Sml::process_sml_file_(const bytes_view &sml_data) {
+  SmlFile sml_file(sml_data);
   std::vector<ObisInfo> obis_info = sml_file.get_obis_info();
   this->publish_obis_info_(obis_info);
 

--- a/esphome/components/sml/sml.cpp
+++ b/esphome/components/sml/sml.cpp
@@ -92,10 +92,11 @@ void Sml::publish_obis_info_(const std::vector<ObisInfo> &obis_info_vec) {
 }
 
 void Sml::publish_value_(const ObisInfo &obis_info) {
+  const auto obis_code = obis_info.code_repr();
   for (auto const &sml_listener : sml_listeners_) {
     if ((!sml_listener->server_id.empty()) && (bytes_repr(obis_info.server_id) != sml_listener->server_id))
       continue;
-    if (obis_info.code_repr() != sml_listener->obis_code)
+    if (obis_code != sml_listener->obis_code)
       continue;
     sml_listener->publish_val(obis_info);
   }

--- a/esphome/components/sml/sml.cpp
+++ b/esphome/components/sml/sml.cpp
@@ -52,7 +52,8 @@ void Sml::loop() {
             break;
 
           // remove start/end sequence
-          this->process_sml_file_(bytes_view(this->sml_data_).subview(START_SEQ.size(), this->sml_data_.size() - START_SEQ.size() - 8));
+          this->process_sml_file_(
+              BytesView(this->sml_data_).subview(START_SEQ.size(), this->sml_data_.size() - START_SEQ.size() - 8));
         }
         break;
       };
@@ -64,7 +65,7 @@ void Sml::add_on_data_callback(std::function<void(std::vector<uint8_t>, bool)> &
   this->data_callbacks_.add(std::move(callback));
 }
 
-void Sml::process_sml_file_(const bytes_view &sml_data) {
+void Sml::process_sml_file_(const BytesView &sml_data) {
   SmlFile sml_file(sml_data);
   std::vector<ObisInfo> obis_info = sml_file.get_obis_info();
   this->publish_obis_info_(obis_info);

--- a/esphome/components/sml/sml.h
+++ b/esphome/components/sml/sml.h
@@ -27,7 +27,7 @@ class Sml : public Component, public uart::UARTDevice {
   void add_on_data_callback(std::function<void(std::vector<uint8_t>, bool)> &&callback);
 
  protected:
-  void process_sml_file_(const bytes &sml_data);
+  void process_sml_file_(const bytes_view &sml_data);
   void log_obis_info_(const std::vector<ObisInfo> &obis_info_vec);
   void publish_obis_info_(const std::vector<ObisInfo> &obis_info_vec);
   char check_start_end_bytes_(uint8_t byte);

--- a/esphome/components/sml/sml.h
+++ b/esphome/components/sml/sml.h
@@ -27,7 +27,7 @@ class Sml : public Component, public uart::UARTDevice {
   void add_on_data_callback(std::function<void(std::vector<uint8_t>, bool)> &&callback);
 
  protected:
-  void process_sml_file_(const bytes_view &sml_data);
+  void process_sml_file_(const BytesView &sml_data);
   void log_obis_info_(const std::vector<ObisInfo> &obis_info_vec);
   void publish_obis_info_(const std::vector<ObisInfo> &obis_info_vec);
   char check_start_end_bytes_(uint8_t byte);

--- a/esphome/components/sml/sml_parser.cpp
+++ b/esphome/components/sml/sml_parser.cpp
@@ -5,17 +5,17 @@
 namespace esphome {
 namespace sml {
 
-SmlFile::SmlFile(bytes buffer) : buffer_(std::move(buffer)) {
+SmlFile::SmlFile(const bytes_view &buffer) : buffer_(buffer) {
   // extract messages
   this->pos_ = 0;
   while (this->pos_ < this->buffer_.size()) {
     if (this->buffer_[this->pos_] == 0x00)
       break;  // EndOfSmlMsg
 
-    SmlNode message = SmlNode();
+    SmlNode message;
     if (!this->setup_node(&message))
       break;
-    this->messages.emplace_back(message);
+    this->messages.emplace_back(std::move(message));
   }
 }
 
@@ -62,22 +62,20 @@ bool SmlFile::setup_node(SmlNode *node) {
     return false;
 
   node->type = type;
-  node->nodes.clear();
-  node->value_bytes.clear();
 
   if (type == SML_LIST) {
     node->nodes.reserve(length);
     for (size_t i = 0; i != length; i++) {
-      SmlNode child_node = SmlNode();
+      SmlNode child_node;
       if (!this->setup_node(&child_node))
         return false;
-      node->nodes.emplace_back(child_node);
+      node->nodes.emplace_back(std::move(child_node));
     }
   } else {
     // Value starts at the current position
     // Value ends "length" bytes later,
     // (since the TL field is counted but already subtracted from length)
-    node->value_bytes = bytes(this->buffer_.begin() + this->pos_, this->buffer_.begin() + this->pos_ + length);
+    node->value_bytes = buffer_.subview(this->pos_, length);
     // Increment the pointer past all consumed bytes
     this->pos_ += length;
   }
@@ -87,14 +85,14 @@ bool SmlFile::setup_node(SmlNode *node) {
 std::vector<ObisInfo> SmlFile::get_obis_info() {
   std::vector<ObisInfo> obis_info;
   for (auto const &message : messages) {
-    SmlNode message_body = message.nodes[3];
+    const auto& message_body = message.nodes[3];
     uint16_t message_type = bytes_to_uint(message_body.nodes[0].value_bytes);
     if (message_type != SML_GET_LIST_RES)
       continue;
 
-    SmlNode get_list_response = message_body.nodes[1];
-    bytes server_id = get_list_response.nodes[1].value_bytes;
-    SmlNode val_list = get_list_response.nodes[4];
+    const auto& get_list_response = message_body.nodes[1];
+    const auto& server_id = get_list_response.nodes[1].value_bytes;
+    const auto& val_list = get_list_response.nodes[4];
 
     for (auto const &val_list_entry : val_list.nodes) {
       obis_info.emplace_back(server_id, val_list_entry);
@@ -103,7 +101,7 @@ std::vector<ObisInfo> SmlFile::get_obis_info() {
   return obis_info;
 }
 
-std::string bytes_repr(const bytes &buffer) {
+std::string bytes_repr(const bytes_view &buffer) {
   std::string repr;
   for (auto const value : buffer) {
     repr += str_sprintf("%02x", value & 0xff);
@@ -111,7 +109,7 @@ std::string bytes_repr(const bytes &buffer) {
   return repr;
 }
 
-uint64_t bytes_to_uint(const bytes &buffer) {
+uint64_t bytes_to_uint(const bytes_view &buffer) {
   uint64_t val = 0;
   for (auto const value : buffer) {
     val = (val << 8) + value;
@@ -119,7 +117,7 @@ uint64_t bytes_to_uint(const bytes &buffer) {
   return val;
 }
 
-int64_t bytes_to_int(const bytes &buffer) {
+int64_t bytes_to_int(const bytes_view &buffer) {
   uint64_t tmp = bytes_to_uint(buffer);
   int64_t val;
 
@@ -135,14 +133,14 @@ int64_t bytes_to_int(const bytes &buffer) {
   return val;
 }
 
-std::string bytes_to_string(const bytes &buffer) { return std::string(buffer.begin(), buffer.end()); }
+std::string bytes_to_string(const bytes_view &buffer) { return std::string(buffer.begin(), buffer.end()); }
 
-ObisInfo::ObisInfo(bytes server_id, SmlNode val_list_entry) : server_id(std::move(server_id)) {
+ObisInfo::ObisInfo(const bytes_view &server_id, const SmlNode &val_list_entry) : server_id(server_id) {
   this->code = val_list_entry.nodes[0].value_bytes;
   this->status = val_list_entry.nodes[1].value_bytes;
   this->unit = bytes_to_uint(val_list_entry.nodes[3].value_bytes);
   this->scaler = bytes_to_int(val_list_entry.nodes[4].value_bytes);
-  SmlNode value_node = val_list_entry.nodes[5];
+  const auto& value_node = val_list_entry.nodes[5];
   this->value = value_node.value_bytes;
   this->value_type = value_node.type;
 }

--- a/esphome/components/sml/sml_parser.cpp
+++ b/esphome/components/sml/sml_parser.cpp
@@ -5,7 +5,7 @@
 namespace esphome {
 namespace sml {
 
-SmlFile::SmlFile(const bytes_view &buffer) : buffer_(buffer) {
+SmlFile::SmlFile(const BytesView &buffer) : buffer_(buffer) {
   // extract messages
   this->pos_ = 0;
   while (this->pos_ < this->buffer_.size()) {
@@ -85,14 +85,14 @@ bool SmlFile::setup_node(SmlNode *node) {
 std::vector<ObisInfo> SmlFile::get_obis_info() {
   std::vector<ObisInfo> obis_info;
   for (auto const &message : messages) {
-    const auto& message_body = message.nodes[3];
+    const auto &message_body = message.nodes[3];
     uint16_t message_type = bytes_to_uint(message_body.nodes[0].value_bytes);
     if (message_type != SML_GET_LIST_RES)
       continue;
 
-    const auto& get_list_response = message_body.nodes[1];
-    const auto& server_id = get_list_response.nodes[1].value_bytes;
-    const auto& val_list = get_list_response.nodes[4];
+    const auto &get_list_response = message_body.nodes[1];
+    const auto &server_id = get_list_response.nodes[1].value_bytes;
+    const auto &val_list = get_list_response.nodes[4];
 
     for (auto const &val_list_entry : val_list.nodes) {
       obis_info.emplace_back(server_id, val_list_entry);
@@ -101,7 +101,7 @@ std::vector<ObisInfo> SmlFile::get_obis_info() {
   return obis_info;
 }
 
-std::string bytes_repr(const bytes_view &buffer) {
+std::string bytes_repr(const BytesView &buffer) {
   std::string repr;
   for (auto const value : buffer) {
     repr += str_sprintf("%02x", value & 0xff);
@@ -109,7 +109,7 @@ std::string bytes_repr(const bytes_view &buffer) {
   return repr;
 }
 
-uint64_t bytes_to_uint(const bytes_view &buffer) {
+uint64_t bytes_to_uint(const BytesView &buffer) {
   uint64_t val = 0;
   for (auto const value : buffer) {
     val = (val << 8) + value;
@@ -117,7 +117,7 @@ uint64_t bytes_to_uint(const bytes_view &buffer) {
   return val;
 }
 
-int64_t bytes_to_int(const bytes_view &buffer) {
+int64_t bytes_to_int(const BytesView &buffer) {
   uint64_t tmp = bytes_to_uint(buffer);
   int64_t val;
 
@@ -133,14 +133,14 @@ int64_t bytes_to_int(const bytes_view &buffer) {
   return val;
 }
 
-std::string bytes_to_string(const bytes_view &buffer) { return std::string(buffer.begin(), buffer.end()); }
+std::string bytes_to_string(const BytesView &buffer) { return std::string(buffer.begin(), buffer.end()); }
 
-ObisInfo::ObisInfo(const bytes_view &server_id, const SmlNode &val_list_entry) : server_id(server_id) {
+ObisInfo::ObisInfo(const BytesView &server_id, const SmlNode &val_list_entry) : server_id(server_id) {
   this->code = val_list_entry.nodes[0].value_bytes;
   this->status = val_list_entry.nodes[1].value_bytes;
   this->unit = bytes_to_uint(val_list_entry.nodes[3].value_bytes);
   this->scaler = bytes_to_int(val_list_entry.nodes[4].value_bytes);
-  const auto& value_node = val_list_entry.nodes[5];
+  const auto &value_node = val_list_entry.nodes[5];
   this->value = value_node.value_bytes;
   this->value_type = value_node.type;
 }

--- a/esphome/components/sml/sml_parser.h
+++ b/esphome/components/sml/sml_parser.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cassert>
 #include <cstdint>
 #include <cstdio>
 #include <string>
@@ -11,44 +12,85 @@ namespace sml {
 
 using bytes = std::vector<uint8_t>;
 
+class bytes_view {
+public:
+    bytes_view() noexcept = default;
+
+    explicit bytes_view(const uint8_t* first, size_t count) noexcept
+        : data_{ first }, count_{ count }
+    {
+    }
+
+    explicit bytes_view(const bytes& bytes) noexcept
+        : data_{ bytes.data() }, count_{ bytes.size() }
+    {
+    }
+
+    size_t size() const noexcept {
+        return count_;
+    }
+
+    uint8_t operator[](size_t index) const noexcept {
+        assert(index < count_);
+        return data_[index];
+    }
+
+    bytes_view subview(size_t offset, size_t count) const noexcept {
+        assert(offset + count <= count_);
+        return bytes_view{ data_ + offset, count };
+    }
+
+    const uint8_t* begin() const noexcept {
+        return data_;
+    }
+
+    const uint8_t* end() const noexcept {
+        return data_ + count_;
+    }
+
+private:
+    const uint8_t* data_ = nullptr;
+    size_t count_ = 0;
+};
+
 class SmlNode {
  public:
   uint8_t type;
-  bytes value_bytes;
+  bytes_view value_bytes;
   std::vector<SmlNode> nodes;
 };
 
 class ObisInfo {
  public:
-  ObisInfo(bytes server_id, SmlNode val_list_entry);
-  bytes server_id;
-  bytes code;
-  bytes status;
+  ObisInfo(const bytes_view &server_id, const SmlNode &val_list_entry);
+  bytes_view server_id;
+  bytes_view code;
+  bytes_view status;
   char unit;
   char scaler;
-  bytes value;
+  bytes_view value;
   uint16_t value_type;
   std::string code_repr() const;
 };
 
 class SmlFile {
  public:
-  SmlFile(bytes buffer);
+  SmlFile(const bytes_view &buffer);
   bool setup_node(SmlNode *node);
   std::vector<SmlNode> messages;
   std::vector<ObisInfo> get_obis_info();
 
  protected:
-  const bytes buffer_;
+  const bytes_view buffer_;
   size_t pos_;
 };
 
-std::string bytes_repr(const bytes &buffer);
+std::string bytes_repr(const bytes_view &buffer);
 
-uint64_t bytes_to_uint(const bytes &buffer);
+uint64_t bytes_to_uint(const bytes_view &buffer);
 
-int64_t bytes_to_int(const bytes &buffer);
+int64_t bytes_to_int(const bytes_view &buffer);
 
-std::string bytes_to_string(const bytes &buffer);
+std::string bytes_to_string(const bytes_view &buffer);
 }  // namespace sml
 }  // namespace esphome

--- a/esphome/components/sml/sml_parser.h
+++ b/esphome/components/sml/sml_parser.h
@@ -12,85 +12,73 @@ namespace sml {
 
 using bytes = std::vector<uint8_t>;
 
-class bytes_view {
-public:
-    bytes_view() noexcept = default;
+class BytesView {
+ public:
+  BytesView() noexcept = default;
 
-    explicit bytes_view(const uint8_t* first, size_t count) noexcept
-        : data_{ first }, count_{ count }
-    {
-    }
+  explicit BytesView(const uint8_t *first, size_t count) noexcept : data_{first}, count_{count} {}
 
-    explicit bytes_view(const bytes& bytes) noexcept
-        : data_{ bytes.data() }, count_{ bytes.size() }
-    {
-    }
+  explicit BytesView(const bytes &bytes) noexcept : data_{bytes.data()}, count_{bytes.size()} {}
 
-    size_t size() const noexcept {
-        return count_;
-    }
+  size_t size() const noexcept { return count_; }
 
-    uint8_t operator[](size_t index) const noexcept {
-        assert(index < count_);
-        return data_[index];
-    }
+  uint8_t operator[](size_t index) const noexcept {
+    assert(index < count_);
+    return data_[index];
+  }
 
-    bytes_view subview(size_t offset, size_t count) const noexcept {
-        assert(offset + count <= count_);
-        return bytes_view{ data_ + offset, count };
-    }
+  BytesView subview(size_t offset, size_t count) const noexcept {
+    assert(offset + count <= count_);
+    return BytesView{data_ + offset, count};
+  }
 
-    const uint8_t* begin() const noexcept {
-        return data_;
-    }
+  const uint8_t *begin() const noexcept { return data_; }
 
-    const uint8_t* end() const noexcept {
-        return data_ + count_;
-    }
+  const uint8_t *end() const noexcept { return data_ + count_; }
 
-private:
-    const uint8_t* data_ = nullptr;
-    size_t count_ = 0;
+ private:
+  const uint8_t *data_ = nullptr;
+  size_t count_ = 0;
 };
 
 class SmlNode {
  public:
   uint8_t type;
-  bytes_view value_bytes;
+  BytesView value_bytes;
   std::vector<SmlNode> nodes;
 };
 
 class ObisInfo {
  public:
-  ObisInfo(const bytes_view &server_id, const SmlNode &val_list_entry);
-  bytes_view server_id;
-  bytes_view code;
-  bytes_view status;
+  ObisInfo(const BytesView &server_id, const SmlNode &val_list_entry);
+  BytesView server_id;
+  BytesView code;
+  BytesView status;
   char unit;
   char scaler;
-  bytes_view value;
+  BytesView value;
   uint16_t value_type;
   std::string code_repr() const;
 };
 
 class SmlFile {
  public:
-  SmlFile(const bytes_view &buffer);
+  SmlFile(const BytesView &buffer);
   bool setup_node(SmlNode *node);
   std::vector<SmlNode> messages;
   std::vector<ObisInfo> get_obis_info();
 
  protected:
-  const bytes_view buffer_;
+  const BytesView buffer_;
   size_t pos_;
 };
 
-std::string bytes_repr(const bytes_view &buffer);
+std::string bytes_repr(const BytesView &buffer);
 
-uint64_t bytes_to_uint(const bytes_view &buffer);
+uint64_t bytes_to_uint(const BytesView &buffer);
 
-int64_t bytes_to_int(const bytes_view &buffer);
+int64_t bytes_to_int(const BytesView &buffer);
 
-std::string bytes_to_string(const bytes_view &buffer);
+std::string bytes_to_string(const BytesView &buffer);
 }  // namespace sml
 }  // namespace esphome


### PR DESCRIPTION
# What does this implement/fix?

This PR includes some optimizations to the SML component.

While using the SML component to decode a number of SML messages from a smart-meter, the warning `Component sml took a long time for an operation (66ms)` appeared. This is with logger level `INFO`, with `DEBUG` the processing time increases to 134ms.

This was tested on an ESP32C3, which does not contain native floating-point support.

By doing a code review, the following issues were identified and fixed:

- Superfluous string formatting of debug messages when debug level is not enabled.
- Superfluous coping of byte vectors where a byte view is appropriate.
- Superfluous string formatting within a for loop.

With these optimizations, SML runtime changes as follows, depending on the logger level:

```code
DEBUG: 134ms -> 97ms
INFO: 66ms -> 25ms
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- none

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- none

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
esphome:
  name: esphome-smart-meter
  friendly_name: "ESPHome Smart Meter"

esp32:
  board: seeed_xiao_esp32c3
  variant: esp32c3
  framework:
    type: arduino

wifi:
  ssid: !secret wifi_ssid
  password: !secret wifi_password

ota:
  - platform: esphome
    password: !secret ota_password

logger:
  level: INFO

api:
  encryption:
    key: !secret api_encryption_key

uart:
  id: uart_bus
  rx_pin: GPIO20 # D7
  baud_rate: 9600

sml:
  id: smart_meter
  uart_id: uart_bus

sensor:
  - platform: uptime
    name: "Uptime"
  - platform: wifi_signal
    name: "WiFi Signal"
  - platform: sml
    id: enery_consumed_total
    name: "Zählerstand Bezug"
    sml_id: smart_meter
    obis_code: "1-0:1.8.0"
    accuracy_decimals: 4
    unit_of_measurement: kWh
    device_class: energy
    state_class: total_increasing
    filters:
      - multiply: 0.0001
      - throttle_average: 30s
  - platform: sml
    id: enery_produced_total
    name: "Zählerstand Einspeisung"
    sml_id: smart_meter
    obis_code: "1-0:2.8.0"
    accuracy_decimals: 4
    unit_of_measurement: kWh
    device_class: energy
    state_class: total_increasing
    filters:
      - multiply: 0.0001
      - throttle_average: 30s
  - platform: sml
    id: power
    name: "Wirkleistung"
    sml_id: smart_meter
    obis_code: "1-0:16.7.0"
    accuracy_decimals: 0
    unit_of_measurement: W
    device_class: power
    state_class: measurement
  - platform: sml
    id: power_l1
    name: "Wirkleistung L1"
    sml_id: smart_meter
    obis_code: "1-0:36.7.0"
    accuracy_decimals: 0
    unit_of_measurement: W
    device_class: power
    state_class: measurement
  - platform: sml
    id: power_l2
    name: "Wirkleistung L2"
    sml_id: smart_meter
    obis_code: "1-0:56.7.0"
    accuracy_decimals: 0
    unit_of_measurement: W
    device_class: power
    state_class: measurement
  - platform: sml
    id: power_l3
    name: "Wirkleistung L3"
    sml_id: smart_meter
    obis_code: "1-0:76.7.0"
    accuracy_decimals: 0
    unit_of_measurement: W
    device_class: power
    state_class: measurement
  - platform: sml
    id: voltage_l1
    name: "Spannung L1"
    sml_id: smart_meter
    obis_code: "1-0:32.7.0"
    accuracy_decimals: 1
    unit_of_measurement: "V"
    device_class: voltage
    state_class: measurement
    filters:
      - multiply: 0.1
  - platform: sml
    id: voltage_l2
    name: "Spannung L2"
    sml_id: smart_meter
    obis_code: "1-0:52.7.0"
    accuracy_decimals: 1
    unit_of_measurement: "V"
    device_class: voltage
    state_class: measurement
    filters:
      - multiply: 0.1
  - platform: sml
    id: voltage_l3
    name: "Spannung L3"
    sml_id: smart_meter
    obis_code: "1-0:72.7.0"
    accuracy_decimals: 1
    unit_of_measurement: "V"
    device_class: voltage
    state_class: measurement
    filters:
      - multiply: 0.1
  - platform: sml
    id: current_l1
    name: "Strom L1"
    sml_id: smart_meter
    obis_code: "1-0:31.7.0"
    accuracy_decimals: 2
    unit_of_measurement: A
    device_class: current
    state_class: measurement
    filters:
      - multiply: 0.01
  - platform: sml
    id: current_l2
    name: "Strom L2"
    sml_id: smart_meter
    obis_code: "1-0:51.7.0"
    accuracy_decimals: 2
    unit_of_measurement: A
    device_class: current
    state_class: measurement
    filters:
      - multiply: 0.01
  - platform: sml
    id: current_l3
    name: "Strom L3"
    sml_id: smart_meter
    obis_code: "1-0:71.7.0"
    accuracy_decimals: 2
    unit_of_measurement: A
    device_class: current
    state_class: measurement
    filters:
      - multiply: 0.01
  - platform: sml
    id: phase_u2_u1
    name: "Phasenwinkel U2 zu U1"
    sml_id: smart_meter
    obis_code: "1-0:81.7.1"
    accuracy_decimals: 0
    unit_of_measurement: °
    device_class: power_factor
    state_class: measurement
  - platform: sml
    id: phase_u3_u1
    name: "Phasenwinkel U3 zu U1"
    sml_id: smart_meter
    obis_code: "1-0:81.7.2"
    accuracy_decimals: 0
    unit_of_measurement: °
    device_class: power_factor
    state_class: measurement
  - platform: sml
    id: phase_i1_u1
    name: "Phasenwinkel I1 zu U1"
    sml_id: smart_meter
    obis_code: "1-0:81.7.4"
    accuracy_decimals: 0
    unit_of_measurement: °
    device_class: power_factor
    state_class: measurement
  - platform: sml
    id: phase_i2_u2
    name: "Phasenwinkel I2 zu U2"
    sml_id: smart_meter
    obis_code: "1-0:81.7.15"
    accuracy_decimals: 0
    unit_of_measurement: °
    device_class: power_factor
    state_class: measurement
  - platform: sml
    id: phase_i3_u3
    name: "Phasenwinkel I3 zu U3"
    sml_id: smart_meter
    obis_code: "1-0:81.7.26"
    accuracy_decimals: 0
    unit_of_measurement: °
    device_class: power_factor
    state_class: measurement
  - platform: sml
    id: grid_frequency
    name: "Netzfrequenz"
    sml_id: smart_meter
    obis_code: "1-0:14.7.0"
    accuracy_decimals: 1
    unit_of_measurement: Hz
    device_class: frequency
    state_class: measurement
    filters:
      - multiply: 0.1
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
