### PR TITLE
[canbus] Add callback for use by other components

### DIFF
--- a/esphome/components/canbus/canbus.cpp
+++ b/esphome/components/canbus/canbus.cpp
@@ -86,6 +86,9 @@ void Canbus::loop() {
       data.push_back(can_message.data[i]);
     }
 
+    this->callback_manager_(can_message.can_id, can_message.use_extended_id, can_message.remote_transmission_request,
+                            data);
+
     // fire all triggers
     for (auto *trigger : this->triggers_) {
       if ((trigger->can_id_ == (can_message.can_id & trigger->can_id_mask_)) &&

--- a/esphome/components/canbus/canbus.h
+++ b/esphome/components/canbus/canbus.h
@@ -82,7 +82,7 @@ class Canbus : public Component {
 
   void add_trigger(CanbusTrigger *trigger);
   void add_callback(
-      std::function<void(uint32_t can_id, bool extended_id, bool rtr, std::vector<uint8_t> data)> callback) {
+      std::function<void(uint32_t can_id, bool extended_id, bool rtr, std::vector<uint8_t> &data)> callback) {
     this->callback_manager_.add(std::move(callback));
   }
 
@@ -92,7 +92,7 @@ class Canbus : public Component {
   uint32_t can_id_;
   bool use_extended_id_;
   CanSpeed bit_rate_;
-  CallbackManager<void(uint32_t can_id, bool extended_id, bool rtr, std::vector<uint8_t> data)> callback_manager_{};
+  CallbackManager<void(uint32_t can_id, bool extended_id, bool rtr, std::vector<uint8_t> &data)> callback_manager_{};
 
   virtual bool setup_internal();
   virtual Error send_message(struct CanFrame *frame);

--- a/esphome/components/canbus/canbus.h
+++ b/esphome/components/canbus/canbus.h
@@ -81,6 +81,10 @@ class Canbus : public Component {
   void set_bitrate(CanSpeed bit_rate) { this->bit_rate_ = bit_rate; }
 
   void add_trigger(CanbusTrigger *trigger);
+  void add_callback(
+      std::function<void(uint32_t can_id, bool extended_id, bool rtr, std::vector<uint8_t> data)> callback) {
+    this->callback_manager_.add(std::move(callback));
+  }
 
  protected:
   template<typename... Ts> friend class CanbusSendAction;
@@ -88,6 +92,7 @@ class Canbus : public Component {
   uint32_t can_id_;
   bool use_extended_id_;
   CanSpeed bit_rate_;
+  CallbackManager<void(uint32_t can_id, bool extended_id, bool rtr, std::vector<uint8_t> data)> callback_manager_{};
 
   virtual bool setup_internal();
   virtual Error send_message(struct CanFrame *frame);

--- a/esphome/components/canbus/canbus.h
+++ b/esphome/components/canbus/canbus.h
@@ -81,8 +81,18 @@ class Canbus : public Component {
   void set_bitrate(CanSpeed bit_rate) { this->bit_rate_ = bit_rate; }
 
   void add_trigger(CanbusTrigger *trigger);
+  /**
+   * Add a callback to be called when a CAN message is received. All received messages
+   * are passed to the callback without filtering.
+   *
+   * The callback function receives:
+   * - can_id of the received data
+   * - extended_id True if the can_id is an extended id
+   * - rtr If this is a remote transmission request
+   * - data The message data
+   */
   void add_callback(
-      std::function<void(uint32_t can_id, bool extended_id, bool rtr, std::vector<uint8_t> &data)> callback) {
+      std::function<void(uint32_t can_id, bool extended_id, bool rtr, const std::vector<uint8_t> &data)> callback) {
     this->callback_manager_.add(std::move(callback));
   }
 
@@ -92,7 +102,8 @@ class Canbus : public Component {
   uint32_t can_id_;
   bool use_extended_id_;
   CanSpeed bit_rate_;
-  CallbackManager<void(uint32_t can_id, bool extended_id, bool rtr, std::vector<uint8_t> &data)> callback_manager_{};
+  CallbackManager<void(uint32_t can_id, bool extended_id, bool rtr, const std::vector<uint8_t> &data)>
+      callback_manager_{};
 
   virtual bool setup_internal();
   virtual Error send_message(struct CanFrame *frame);


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Canbus component had triggers for running automations, but no simple callback for other components to use.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
