### PR TITLE
Fix psram below idf 5

### DIFF
--- a/esphome/components/psram/psram.cpp
+++ b/esphome/components/psram/psram.cpp
@@ -1,7 +1,8 @@
 
 #ifdef USE_ESP32
 #include "psram.h"
-#ifdef USE_ESP_IDF
+#include <esp_idf_version.h>
+#if defined(USE_ESP_IDF) && ESP_IDF_VERSION_MAJOR >= 5
 #include <esp_psram.h>
 #endif  // USE_ESP_IDF
 
@@ -15,7 +16,7 @@ static const char *const TAG = "psram";
 
 void PsramComponent::dump_config() {
   ESP_LOGCONFIG(TAG, "PSRAM:");
-#ifdef USE_ESP_IDF
+#if defined(USE_ESP_IDF) && ESP_IDF_VERSION_MAJOR >= 5
   bool available = esp_psram_is_initialized();
 
   ESP_LOGCONFIG(TAG, "  Available: %s", YESNO(available));


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
