### PR TITLE
[psram] Add version check to fix 5.3.2

### DIFF
--- a/esphome/components/psram/__init__.py
+++ b/esphome/components/psram/__init__.py
@@ -16,6 +16,8 @@ from esphome.const import (
     CONF_ID,
     CONF_MODE,
     CONF_SPEED,
+    KEY_CORE,
+    KEY_FRAMEWORK_VERSION,
     PLATFORM_ESP32,
 )
 from esphome.core import CORE
@@ -110,11 +112,11 @@ async def to_code(config):
         add_idf_sdkconfig_option(f"{SPIRAM_MODES[config[CONF_MODE]]}", True)
         add_idf_sdkconfig_option(f"{SPIRAM_SPEEDS[config[CONF_SPEED]]}", True)
         if config[CONF_MODE] == TYPE_OCTAL and config[CONF_SPEED] == 120e6:
-            add_idf_sdkconfig_option("CONFIG_ESP32S3_DEFAULT_CPU_FREQ_240", True)
-            # This works only on IDF 5.4.x but does no harm on earlier versions
-            add_idf_sdkconfig_option(
-                "CONFIG_SPIRAM_TIMING_TUNING_POINT_VIA_TEMPERATURE_SENSOR", True
-            )
+            add_idf_sdkconfig_option("CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ_240", True)
+            if CORE.data[KEY_CORE][KEY_FRAMEWORK_VERSION] >= cv.Version(5, 4, 0):
+                add_idf_sdkconfig_option(
+                    "CONFIG_SPIRAM_TIMING_TUNING_POINT_VIA_TEMPERATURE_SENSOR", True
+                )
         if config[CONF_ENABLE_ECC]:
             add_idf_sdkconfig_option("CONFIG_SPIRAM_ECC_ENABLE", True)
 


### PR DESCRIPTION
# What does this implement/fix?

- Add version check to fix 5.3.2 because it does actually break earlier versions
- Use newer style CPU_FREQ option

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
