### PR TITLE
[modbus_controller] Update state when ACK received for select, switch

### DIFF
--- a/esphome/components/modbus_controller/select/modbus_select.cpp
+++ b/esphome/components/modbus_controller/select/modbus_select.cpp
@@ -80,6 +80,14 @@ void ModbusSelect::control(const std::string &value) {
         ModbusCommandItem::create_write_multiple_command(this->parent_, write_address, this->register_count, data);
   }
 
+  // publish new value
+  write_cmd.on_data_func = [this, write_cmd, value](ModbusRegisterType register_type, uint16_t start_address,
+                                                    const std::vector<uint8_t> &data) {
+    // gets called when the write command is ack'd from the device
+    this->parent_->on_write_register_response(write_cmd.register_type, start_address, data);
+    this->publish_state(value);
+  };
+
   this->parent_->queue_command(write_cmd);
 
   if (this->optimistic_)

--- a/esphome/components/modbus_controller/switch/modbus_switch.cpp
+++ b/esphome/components/modbus_controller/switch/modbus_switch.cpp
@@ -95,6 +95,13 @@ void ModbusSwitch::write_state(bool state) {
                                                              state ? 0xFFFF & this->bitmask : 0u);
       }
     }
+    // publish new value
+    cmd.on_data_func = [this, cmd, state](ModbusRegisterType register_type, uint16_t start_address,
+                                          const std::vector<uint8_t> &data) {
+      // gets called when the write command is ack'd from the device
+      this->parent_->on_write_register_response(cmd.register_type, start_address, data);
+      this->publish_state(state);
+    };
   }
   this->parent_->queue_command(cmd);
   this->publish_state(state);


### PR DESCRIPTION
# What does this implement/fix?

Immediately update the state once an ACK has been received from the device. This prevents waiting for an update of a component to see if the update actually went through.

In turn this solves Home Assistant from showing new-state, old-state and then new-state again.

Code is inspired by [modbus_number](https://github.com/esphome/esphome/blob/b82666002dc55b60b3e7f3f2549c0bf8a0203f91/esphome/components/modbus_controller/number/modbus_number.cpp#L72), which already does this.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
