### PR TITLE
[I2S] Minor speedups: 

### DIFF
--- a/esphome/components/i2s_audio/microphone/i2s_audio_microphone.cpp
+++ b/esphome/components/i2s_audio/microphone/i2s_audio_microphone.cpp
@@ -171,7 +171,7 @@ size_t I2SAudioMicrophone::read(int16_t *buf, size_t len) {
     return 0;
   }
   if (bytes_read == 0) {
-    this->status_set_warning();
+    this->status_set_warning("No data read from microphone");
     return 0;
   }
   this->status_clear_warning();

--- a/esphome/components/i2s_audio/microphone/i2s_audio_microphone.cpp
+++ b/esphome/components/i2s_audio/microphone/i2s_audio_microphone.cpp
@@ -191,9 +191,8 @@ size_t I2SAudioMicrophone::read(int16_t *buf, size_t len) {
 }
 
 void I2SAudioMicrophone::read_() {
-  std::vector<int16_t> samples;
   samples.resize(BUFFER_SIZE);
-  size_t bytes_read = this->read(samples.data(), BUFFER_SIZE / sizeof(int16_t));
+  size_t bytes_read = this->read(samples.data(), BUFFER_SIZE * sizeof(int16_t));
   samples.resize(bytes_read / sizeof(int16_t));
   this->data_callbacks_.call(samples);
 }

--- a/esphome/components/i2s_audio/microphone/i2s_audio_microphone.cpp
+++ b/esphome/components/i2s_audio/microphone/i2s_audio_microphone.cpp
@@ -112,7 +112,7 @@ void I2SAudioMicrophone::start_() {
     }
   }
 
-  this->samples.reserve(BUFFER_SIZE);
+  this->samples_.reserve(BUFFER_SIZE);
 
   this->state_ = microphone::STATE_RUNNING;
   this->high_freq_.start();
@@ -154,8 +154,8 @@ void I2SAudioMicrophone::stop_() {
     return;
   }
 
-  this->samples.clear();
-  this->samples.shrink_to_fit();
+  this->samples_.clear();
+  this->samples_.shrink_to_fit();
   this->parent_->unlock();
   this->state_ = microphone::STATE_STOPPED;
   this->high_freq_.stop();
@@ -197,10 +197,10 @@ size_t I2SAudioMicrophone::read(int16_t *buf, size_t len) {
 }
 
 void I2SAudioMicrophone::read_() {
-  samples.resize(BUFFER_SIZE);
-  size_t bytes_read = this->read(samples.data(), BUFFER_SIZE * sizeof(int16_t));
-  samples.resize(bytes_read / sizeof(int16_t));
-  this->data_callbacks_.call(samples);
+  samples_.resize(BUFFER_SIZE);
+  size_t bytes_read = this->read(samples_.data(), BUFFER_SIZE * sizeof(int16_t));
+  samples_.resize(bytes_read / sizeof(int16_t));
+  this->data_callbacks_.call(samples_);
 }
 
 void I2SAudioMicrophone::loop() {

--- a/esphome/components/i2s_audio/microphone/i2s_audio_microphone.cpp
+++ b/esphome/components/i2s_audio/microphone/i2s_audio_microphone.cpp
@@ -111,6 +111,9 @@ void I2SAudioMicrophone::start_() {
       return;
     }
   }
+
+  this->samples.reserve(BUFFER_SIZE);
+
   this->state_ = microphone::STATE_RUNNING;
   this->high_freq_.start();
   this->status_clear_error();
@@ -150,6 +153,9 @@ void I2SAudioMicrophone::stop_() {
     this->status_set_error();
     return;
   }
+
+  this->samples.clear();
+  this->samples.shrink_to_fit();
   this->parent_->unlock();
   this->state_ = microphone::STATE_STOPPED;
   this->high_freq_.stop();

--- a/esphome/components/i2s_audio/microphone/i2s_audio_microphone.h
+++ b/esphome/components/i2s_audio/microphone/i2s_audio_microphone.h
@@ -21,6 +21,12 @@ class I2SAudioMicrophone : public I2SAudioIn, public microphone::Microphone, pub
   void set_din_pin(int8_t pin) { this->din_pin_ = pin; }
   void set_pdm(bool pdm) { this->pdm_ = pdm; }
 
+  /** Reads audio data into a buffer
+   *
+   * @param buf A preallocated buffer to read data into
+   * @param len The length (in bytes) of the buffer
+   * @return The number of bytes actually read
+   */
   size_t read(int16_t *buf, size_t len) override;
 
 #if SOC_I2S_SUPPORTS_ADC

--- a/esphome/components/i2s_audio/microphone/i2s_audio_microphone.h
+++ b/esphome/components/i2s_audio/microphone/i2s_audio_microphone.h
@@ -43,6 +43,7 @@ class I2SAudioMicrophone : public I2SAudioIn, public microphone::Microphone, pub
   bool pdm_{false};
 
   HighFrequencyLoopRequester high_freq_;
+  std::vector<int16_t> samples;
 };
 
 }  // namespace i2s_audio

--- a/esphome/components/i2s_audio/microphone/i2s_audio_microphone.h
+++ b/esphome/components/i2s_audio/microphone/i2s_audio_microphone.h
@@ -43,7 +43,7 @@ class I2SAudioMicrophone : public I2SAudioIn, public microphone::Microphone, pub
   bool pdm_{false};
 
   HighFrequencyLoopRequester high_freq_;
-  std::vector<int16_t> samples;
+  std::vector<int16_t> samples_;
 };
 
 }  // namespace i2s_audio

--- a/esphome/components/microphone/microphone.h
+++ b/esphome/components/microphone/microphone.h
@@ -23,6 +23,13 @@ class Microphone {
   void add_data_callback(std::function<void(const std::vector<int16_t> &)> &&data_callback) {
     this->data_callbacks_.add(std::move(data_callback));
   }
+
+  /** Reads audio data into a buffer
+   *
+   * @param buf A preallocated buffer to read data into
+   * @param len the length (in BYTES) of the buffer
+   * @return The number of BYTES actually read
+   */
   virtual size_t read(int16_t *buf, size_t len) = 0;
 
   bool is_running() const { return this->state_ == STATE_RUNNING; }


### PR DESCRIPTION
# What does this implement/fix?

- Don't create a new vector on every loop, retain it between iterations.  Allocate the memory on start(), and release it on stop().
- Fix a bug where only half the buffer would be read (dividing the number of elements by their size, instead of multiplying)

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A (probably)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
