### PR TITLE
[core] Fix setting of log level/verbose

### DIFF
--- a/esphome/log.py
+++ b/esphome/log.py
@@ -74,12 +74,13 @@ def setup_log(
 
     colorama.init()
 
-    if log_level == logging.DEBUG:
-        CORE.verbose = True
-    elif log_level == logging.CRITICAL:
-        CORE.quiet = True
-
+    # Setup logging - will map log level from string to constant
     logging.basicConfig(level=log_level)
+
+    if logging.root.level == logging.DEBUG:
+        CORE.verbose = True
+    elif logging.root.level == logging.CRITICAL:
+        CORE.quiet = True
 
     logging.getLogger("urllib3").setLevel(logging.WARNING)
 


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

The command line argument to set the log level yields a string; this was being compared to an integer log level value, which always tested false, consequently `CORE.verbose` was never set.

Use the logging internal mapping of level names to numbers to avoid this.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [x] host

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
