### PR TITLE
[watchdog] Fix for variants with single core

### DIFF
--- a/esphome/components/watchdog/watchdog.cpp
+++ b/esphome/components/watchdog/watchdog.cpp
@@ -6,6 +6,7 @@
 #include <cinttypes>
 #include <cstdint>
 #ifdef USE_ESP32
+#include <soc/soc_caps.h>
 #include "esp_idf_version.h"
 #include "esp_task_wdt.h"
 #endif
@@ -40,7 +41,7 @@ void WatchdogManager::set_timeout_(uint32_t timeout_ms) {
 #if ESP_IDF_VERSION_MAJOR >= 5
   esp_task_wdt_config_t wdt_config = {
       .timeout_ms = timeout_ms,
-      .idle_core_mask = 0x03,
+      .idle_core_mask = (1 << SOC_CPU_CORES_NUM) - 1,
       .trigger_panic = true,
   };
   esp_task_wdt_reconfigure(&wdt_config);


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

The existing code was indiscriminately setting the core mask to `0x03` / `0b11` which was indicating core 0 and core 1. Core 1 does not exist on single core variants and the config function was returning an error and not doing what was expected.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
