### PR TITLE
[mdns] Support templatable config options for MDNS extra services

### DIFF
--- a/esphome/components/mdns/__init__.py
+++ b/esphome/components/mdns/__init__.py
@@ -35,7 +35,7 @@ SERVICE_SCHEMA = cv.Schema(
     {
         cv.Required(CONF_SERVICE): cv.string,
         cv.Required(CONF_PROTOCOL): cv.string,
-        cv.Optional(CONF_PORT, default=0): cv.Any(0, cv.port),
+        cv.Optional(CONF_PORT, default=0): cv.templatable(cv.Any(0, cv.port)),
         cv.Optional(CONF_TXT, default={}): {cv.string: cv.templatable(cv.string)},
     }
 )
@@ -112,9 +112,9 @@ async def to_code(config):
                     ("value", template_txt_value_),
                 )
             )
-
+        template_port_value_ = await cg.templatable(service[CONF_PORT], args, cg.uint16)
         exp = mdns_service(
-            service[CONF_SERVICE], service[CONF_PROTOCOL], service[CONF_PORT], txt
+            service[CONF_SERVICE], service[CONF_PROTOCOL], template_port_value_, txt
         )
 
         cg.add(var.add_extra_service(exp))

--- a/esphome/components/mdns/__init__.py
+++ b/esphome/components/mdns/__init__.py
@@ -101,20 +101,19 @@ async def to_code(config):
     await cg.register_component(var, config)
 
     for service in config[CONF_SERVICES]:
-        txt = []
-        args = []
-        for txt_key, txt_value in service[CONF_TXT].items():
-            template_txt_value_ = await cg.templatable(txt_value, args, cg.std_string)
-            txt.append(
-                cg.StructInitializer(
-                    MDNSTXTRecord,
-                    ("key", txt_key),
-                    ("value", template_txt_value_),
-                )
+        txt = [
+            cg.StructInitializer(
+                MDNSTXTRecord,
+                ("key", txt_key),
+                ("value", await cg.templatable(txt_value, [], cg.std_string)),
             )
-        template_port_value_ = await cg.templatable(service[CONF_PORT], args, cg.uint16)
+            for txt_key, txt_value in service[CONF_TXT].items()
+        ]
         exp = mdns_service(
-            service[CONF_SERVICE], service[CONF_PROTOCOL], template_port_value_, txt
+            service[CONF_SERVICE],
+            service[CONF_PROTOCOL],
+            await cg.templatable(service[CONF_PORT], [], cg.uint16),
+            txt,
         )
 
         cg.add(var.add_extra_service(exp))

--- a/esphome/components/mdns/__init__.py
+++ b/esphome/components/mdns/__init__.py
@@ -36,7 +36,7 @@ SERVICE_SCHEMA = cv.Schema(
         cv.Required(CONF_SERVICE): cv.string,
         cv.Required(CONF_PROTOCOL): cv.string,
         cv.Optional(CONF_PORT, default=0): cv.Any(0, cv.port),
-        cv.Optional(CONF_TXT, default={}): {cv.string: cv.string},
+        cv.Optional(CONF_TXT, default={}): {cv.string: cv.templatable(cv.string)},
     }
 )
 
@@ -101,10 +101,17 @@ async def to_code(config):
     await cg.register_component(var, config)
 
     for service in config[CONF_SERVICES]:
-        txt = [
-            mdns_txt_record(txt_key, txt_value)
-            for txt_key, txt_value in service[CONF_TXT].items()
-        ]
+        txt = []
+        args = []
+        for txt_key, txt_value in service[CONF_TXT].items():
+            template_txt_value_ = await cg.templatable(txt_value, args, cg.std_string)
+            txt.append(
+                cg.StructInitializer(
+                    MDNSTXTRecord,
+                    ("key", txt_key),
+                    ("value", template_txt_value_),
+                )
+            )
 
         exp = mdns_service(
             service[CONF_SERVICE], service[CONF_PROTOCOL], service[CONF_PORT], txt

--- a/esphome/components/mdns/mdns_component.cpp
+++ b/esphome/components/mdns/mdns_component.cpp
@@ -121,7 +121,8 @@ void MDNSComponent::dump_config() {
   ESP_LOGCONFIG(TAG, "  Hostname: %s", this->hostname_.c_str());
   ESP_LOGV(TAG, "  Services:");
   for (const auto &service : this->services_) {
-    ESP_LOGV(TAG, "  - %s, %s, %d", service.service_type.c_str(), service.proto.c_str(), service.port);
+    ESP_LOGV(TAG, "  - %s, %s, %d", service.service_type.c_str(), service.proto.c_str(),
+             const_cast<TemplatableValue<uint16_t> &>(service.port).value());
     for (const auto &record : service.txt_records) {
       ESP_LOGV(TAG, "    TXT: %s = %s", record.key.c_str(),
                const_cast<TemplatableValue<std::string> &>(record.value).value().c_str());

--- a/esphome/components/mdns/mdns_component.cpp
+++ b/esphome/components/mdns/mdns_component.cpp
@@ -123,7 +123,8 @@ void MDNSComponent::dump_config() {
   for (const auto &service : this->services_) {
     ESP_LOGV(TAG, "  - %s, %s, %d", service.service_type.c_str(), service.proto.c_str(), service.port);
     for (const auto &record : service.txt_records) {
-      ESP_LOGV(TAG, "    TXT: %s = %s", record.key.c_str(), record.value.c_str());
+      ESP_LOGV(TAG, "    TXT: %s = %s", record.key.c_str(),
+               const_cast<TemplatableValue<std::string> &>(record.value).value().c_str());
     }
   }
 }

--- a/esphome/components/mdns/mdns_component.h
+++ b/esphome/components/mdns/mdns_component.h
@@ -21,7 +21,7 @@ struct MDNSService {
   // second label indicating protocol _including_ underscore character prefix
   // as defined in RFC6763 Section 7, like "_tcp" or "_udp"
   std::string proto;
-  uint16_t port;
+  TemplatableValue<uint16_t> port;
   std::vector<MDNSTXTRecord> txt_records;
 };
 

--- a/esphome/components/mdns/mdns_component.h
+++ b/esphome/components/mdns/mdns_component.h
@@ -3,6 +3,7 @@
 #ifdef USE_MDNS
 #include <string>
 #include <vector>
+#include "esphome/core/automation.h"
 #include "esphome/core/component.h"
 
 namespace esphome {
@@ -10,7 +11,7 @@ namespace mdns {
 
 struct MDNSTXTRecord {
   std::string key;
-  std::string value;
+  TemplatableValue<std::string> value;
 };
 
 struct MDNSService {

--- a/esphome/components/mdns/mdns_esp32.cpp
+++ b/esphome/components/mdns/mdns_esp32.cpp
@@ -34,8 +34,8 @@ void MDNSComponent::setup() {
       it.value = strdup(const_cast<TemplatableValue<std::string> &>(record.value).value().c_str());
       txt_records.push_back(it);
     }
-    uint16_t port_ = const_cast<TemplatableValue<uint16_t> &>(service.port).value();
-    err = mdns_service_add(nullptr, service.service_type.c_str(), service.proto.c_str(), port_, txt_records.data(),
+    uint16_t port = const_cast<TemplatableValue<uint16_t> &>(service.port).value();
+    err = mdns_service_add(nullptr, service.service_type.c_str(), service.proto.c_str(), port, txt_records.data(),
                            txt_records.size());
 
     // free records

--- a/esphome/components/mdns/mdns_esp32.cpp
+++ b/esphome/components/mdns/mdns_esp32.cpp
@@ -34,8 +34,9 @@ void MDNSComponent::setup() {
       it.value = strdup(const_cast<TemplatableValue<std::string> &>(record.value).value().c_str());
       txt_records.push_back(it);
     }
-    err = mdns_service_add(nullptr, service.service_type.c_str(), service.proto.c_str(), service.port,
-                           txt_records.data(), txt_records.size());
+    uint16_t port_ = const_cast<TemplatableValue<uint16_t> &>(service.port).value();
+    err = mdns_service_add(nullptr, service.service_type.c_str(), service.proto.c_str(), port_, txt_records.data(),
+                           txt_records.size());
 
     // free records
     for (const auto &it : txt_records) {

--- a/esphome/components/mdns/mdns_esp32.cpp
+++ b/esphome/components/mdns/mdns_esp32.cpp
@@ -31,7 +31,7 @@ void MDNSComponent::setup() {
       mdns_txt_item_t it{};
       // dup strings to ensure the pointer is valid even after the record loop
       it.key = strdup(record.key.c_str());
-      it.value = strdup(record.value.c_str());
+      it.value = strdup(const_cast<TemplatableValue<std::string> &>(record.value).value().c_str());
       txt_records.push_back(it);
     }
     err = mdns_service_add(nullptr, service.service_type.c_str(), service.proto.c_str(), service.port,

--- a/esphome/components/mdns/mdns_esp8266.cpp
+++ b/esphome/components/mdns/mdns_esp8266.cpp
@@ -29,8 +29,8 @@ void MDNSComponent::setup() {
     while (*service_type == '_') {
       service_type++;
     }
-    uint16_t port_ = const_cast<TemplatableValue<uint16_t> &>(service.port).value();
-    MDNS.addService(service_type, proto, port_);
+    uint16_t port = const_cast<TemplatableValue<uint16_t> &>(service.port).value();
+    MDNS.addService(service_type, proto, port);
     for (const auto &record : service.txt_records) {
       MDNS.addServiceTxt(service_type, proto, record.key.c_str(),
                          const_cast<TemplatableValue<std::string> &>(record.value).value().c_str());

--- a/esphome/components/mdns/mdns_esp8266.cpp
+++ b/esphome/components/mdns/mdns_esp8266.cpp
@@ -29,7 +29,8 @@ void MDNSComponent::setup() {
     while (*service_type == '_') {
       service_type++;
     }
-    MDNS.addService(service_type, proto, service.port);
+    uint16_t port_ = const_cast<TemplatableValue<uint16_t> &>(service.port).value();
+    MDNS.addService(service_type, proto, port_);
     for (const auto &record : service.txt_records) {
       MDNS.addServiceTxt(service_type, proto, record.key.c_str(),
                          const_cast<TemplatableValue<std::string> &>(record.value).value().c_str());

--- a/esphome/components/mdns/mdns_esp8266.cpp
+++ b/esphome/components/mdns/mdns_esp8266.cpp
@@ -31,7 +31,8 @@ void MDNSComponent::setup() {
     }
     MDNS.addService(service_type, proto, service.port);
     for (const auto &record : service.txt_records) {
-      MDNS.addServiceTxt(service_type, proto, record.key.c_str(), record.value.c_str());
+      MDNS.addServiceTxt(service_type, proto, record.key.c_str(),
+                         const_cast<TemplatableValue<std::string> &>(record.value).value().c_str());
     }
   }
 }

--- a/esphome/components/mdns/mdns_libretiny.cpp
+++ b/esphome/components/mdns/mdns_libretiny.cpp
@@ -29,7 +29,8 @@ void MDNSComponent::setup() {
     while (*service_type == '_') {
       service_type++;
     }
-    MDNS.addService(service_type, proto, service.port);
+    uint16_t port_ = const_cast<TemplatableValue<uint16_t> &>(service.port).value();
+    MDNS.addService(service_type, proto, port_);
     for (const auto &record : service.txt_records) {
       MDNS.addServiceTxt(service_type, proto, record.key.c_str(),
                          const_cast<TemplatableValue<std::string> &>(record.value).value().c_str());

--- a/esphome/components/mdns/mdns_libretiny.cpp
+++ b/esphome/components/mdns/mdns_libretiny.cpp
@@ -31,7 +31,8 @@ void MDNSComponent::setup() {
     }
     MDNS.addService(service_type, proto, service.port);
     for (const auto &record : service.txt_records) {
-      MDNS.addServiceTxt(service_type, proto, record.key.c_str(), record.value.c_str());
+      MDNS.addServiceTxt(service_type, proto, record.key.c_str(),
+                         const_cast<TemplatableValue<std::string> &>(record.value).value().c_str());
     }
   }
 }

--- a/esphome/components/mdns/mdns_rp2040.cpp
+++ b/esphome/components/mdns/mdns_rp2040.cpp
@@ -29,8 +29,8 @@ void MDNSComponent::setup() {
     while (*service_type == '_') {
       service_type++;
     }
-    uint16_t port_ = const_cast<TemplatableValue<uint16_t> &>(service.port).value();
-    MDNS.addService(service_type, proto, port_);
+    uint16_t port = const_cast<TemplatableValue<uint16_t> &>(service.port).value();
+    MDNS.addService(service_type, proto, port);
     for (const auto &record : service.txt_records) {
       MDNS.addServiceTxt(service_type, proto, record.key.c_str(),
                          const_cast<TemplatableValue<std::string> &>(record.value).value().c_str());

--- a/esphome/components/mdns/mdns_rp2040.cpp
+++ b/esphome/components/mdns/mdns_rp2040.cpp
@@ -29,7 +29,8 @@ void MDNSComponent::setup() {
     while (*service_type == '_') {
       service_type++;
     }
-    MDNS.addService(service_type, proto, service.port);
+    uint16_t port_ = const_cast<TemplatableValue<uint16_t> &>(service.port).value();
+    MDNS.addService(service_type, proto, port_);
     for (const auto &record : service.txt_records) {
       MDNS.addServiceTxt(service_type, proto, record.key.c_str(),
                          const_cast<TemplatableValue<std::string> &>(record.value).value().c_str());

--- a/esphome/components/mdns/mdns_rp2040.cpp
+++ b/esphome/components/mdns/mdns_rp2040.cpp
@@ -31,7 +31,8 @@ void MDNSComponent::setup() {
     }
     MDNS.addService(service_type, proto, service.port);
     for (const auto &record : service.txt_records) {
-      MDNS.addServiceTxt(service_type, proto, record.key.c_str(), record.value.c_str());
+      MDNS.addServiceTxt(service_type, proto, record.key.c_str(),
+                         const_cast<TemplatableValue<std::string> &>(record.value).value().c_str());
     }
   }
 }

--- a/esphome/core/automation.h
+++ b/esphome/core/automation.h
@@ -1,10 +1,11 @@
 #pragma once
 
-#include <vector>
 #include "esphome/core/component.h"
-#include "esphome/core/helpers.h"
 #include "esphome/core/defines.h"
+#include "esphome/core/helpers.h"
 #include "esphome/core/preferences.h"
+#include <utility>
+#include <vector>
 
 namespace esphome {
 
@@ -27,7 +28,7 @@ template<typename T, typename... X> class TemplatableValue {
   TemplatableValue() : type_(NONE) {}
 
   template<typename F, enable_if_t<!is_invocable<F, X...>::value, int> = 0>
-  TemplatableValue(F value) : type_(VALUE), value_(value) {}
+  TemplatableValue(F value) : type_(VALUE), value_(std::move(value)) {}
 
   template<typename F, enable_if_t<is_invocable<F, X...>::value, int> = 0>
   TemplatableValue(F f) : type_(LAMBDA), f_(f) {}

--- a/tests/components/mdns/common-enabled.yaml
+++ b/tests/components/mdns/common-enabled.yaml
@@ -4,3 +4,10 @@ wifi:
 
 mdns:
   disabled: false
+  services:
+    - service: _test_service
+      protocol: _tcp
+      port: 8888
+      txt:
+        static_string: Anything
+        templated_string: !lambda return "Something else";


### PR DESCRIPTION
# What does this implement/fix?

Adds support for MDNS service configurations with templatable configuration options for _port_ and _txt_ entries. This allows for device makers to publish custom MDNS entries with values that are unique per device or build.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#4836

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
mdns:
  services:
    - service: _konnected
      protocol: _tcp
      port: !lambda return USE_WEBSERVER_PORT;
      txt:
        friendly_name: !lambda return App.get_friendly_name();
        project_name: !lambda return ESPHOME_PROJECT_NAME;
        project_version: !lambda return ESPHOME_PROJECT_VERSION;
        mac: !lambda return get_mac_address();
        esphome_version: !lambda return ESPHOME_VERSION;
        platform: !lambda |-
          return
          #if defined(USE_ESP8266)
            "ESP8266"
          #elif defined(USE_ESP32)
            "ESP32"
          #endif
          ;
        network: !lambda |-
          return
          #if defined(USE_WIFI)
          "wifi"
          #elif defined(USE_ETHERNET)
          "ethernet"
          #endif
          ;

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
