### PR TITLE
[voice_assisant] support start/continue conversation and deallocate buffers

### DIFF
--- a/esphome/components/voice_assistant/voice_assistant.h
+++ b/esphome/components/voice_assistant/voice_assistant.h
@@ -41,6 +41,7 @@ enum VoiceAssistantFeature : uint32_t {
   FEATURE_API_AUDIO = 1 << 2,
   FEATURE_TIMERS = 1 << 3,
   FEATURE_ANNOUNCE = 1 << 4,
+  FEATURE_START_CONVERSATION = 1 << 5,
 };
 
 enum class State {
@@ -140,6 +141,7 @@ class VoiceAssistant : public Component {
 #ifdef USE_MEDIA_PLAYER
     if (this->media_player_ != nullptr) {
       flags |= VoiceAssistantFeature::FEATURE_ANNOUNCE;
+      flags |= VoiceAssistantFeature::FEATURE_START_CONVERSATION;
     }
 #endif
 
@@ -267,6 +269,8 @@ class VoiceAssistant : public Component {
 #endif
 #ifdef USE_MEDIA_PLAYER
   media_player::MediaPlayer *media_player_{nullptr};
+  bool media_player_wait_for_announcement_start_{false};
+  bool media_player_wait_for_announcement_end_{false};
 #endif
 
   bool local_output_{false};
@@ -282,7 +286,7 @@ class VoiceAssistant : public Component {
   uint8_t vad_threshold_{5};
   uint8_t vad_counter_{0};
 #endif
-  std::unique_ptr<RingBuffer> ring_buffer_;
+  std::shared_ptr<RingBuffer> ring_buffer_;
 
   bool use_wake_word_;
   uint8_t noise_suppression_level_;
@@ -295,6 +299,8 @@ class VoiceAssistant : public Component {
 
   bool continuous_{false};
   bool silence_detection_;
+
+  bool continue_conversation_{false};
 
   State state_{State::IDLE};
   State desired_state_{State::IDLE};


### PR DESCRIPTION
# What does this implement/fix?

- Adds support for start and continue conversations. 
- Deallocates all buffers after a pipeline is finished to reduce the memory pressure on devices without PSRAM
- Uses a ``shared_ptr`` for the ring buffer in anticipation of upcoming changes to microphone code

You may need to modify your yaml configurations to support the start and continue conversations. In particular:
- Only call ``voice_assistant.stop`` when you want to stop a streaming wake word, especially avoid calling it in the media player's ``on_announcement`` action. The VA component should stop the microphone whenever it sends audio to the media player, it doesn't need to be handled manually.
- Don't assume the pipeline will end when a TTS response finishes playing. Avoid calling things like ``micro_wake_word.start`` until the voice assistant component is no longer running.

I will add links to PRs for the various voice assistant firmware soon to give a full example of yaml actions that work with these new features.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** not applicable

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** not applicable

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
This example is for an ATOM Echo.

```yaml
# Example config.yaml
i2s_audio:
  - id: i2s_audio_bus
    i2s_lrclk_pin: GPIO33
    i2s_bclk_pin: GPIO19

microphone:
  - platform: i2s_audio
    id: echo_microphone
    i2s_din_pin: GPIO23
    adc_type: external
    pdm: true

speaker:
  - platform: i2s_audio
    id: echo_speaker
    i2s_dout_pin: GPIO22
    dac_type: external
    bits_per_sample: 32bit
    channel: right
    buffer_duration: 60ms

media_player:
  - platform: speaker
    name: None
    id: echo_media_player
    announcement_pipeline:
      speaker: echo_speaker
      format: WAV
    codec_support_enabled: false
    buffer_size: 6000

voice_assistant:
  id: va
  microphone: echo_microphone
  media_player: echo_media_player
  noise_suppression_level: 2
  auto_gain: 31dBFS
  volume_multiplier: 2.0

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
