### PR TITLE
[micro_wake_word] avoid attempting to load models or allocate memory if already running

### DIFF
--- a/esphome/components/micro_wake_word/micro_wake_word.cpp
+++ b/esphome/components/micro_wake_word/micro_wake_word.cpp
@@ -157,6 +157,11 @@ void MicroWakeWord::start() {
     return;
   }
 
+  if (this->state_ != State::IDLE) {
+    ESP_LOGW(TAG, "Wake word is already running");
+    return;
+  }
+
   if (!this->load_models_() || !this->allocate_buffers_()) {
     ESP_LOGE(TAG, "Failed to load the wake word model(s) or allocate buffers");
     this->status_set_error();
@@ -166,11 +171,6 @@ void MicroWakeWord::start() {
 
   if (this->status_has_error()) {
     ESP_LOGW(TAG, "Wake word component has an error. Please check logs");
-    return;
-  }
-
-  if (this->state_ != State::IDLE) {
-    ESP_LOGW(TAG, "Wake word is already running");
     return;
   }
 


### PR DESCRIPTION
# What does this implement/fix?

Avoids allocating memory or attempting to load models if mWW is already running. This avoids a potential memory leak where the FrontendState struct is allocated multiple times after calling the start function while already running.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** not applicable

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** not applicable

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

...
  on_*:
    - micro_wake_word.start:
    - delay: 1000 ms
    - micro_wake_word.start:

micro_wake_word:
  on_wake_word_detected:
    - voice_assistant.start:
        wake_word: !lambda return wake_word;
  vad:
  models:
    - model: okay_nabu

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
