### PR TITLE
[micro_wake_word] Use microphone callback and avoid unnecessary allocation attempts

### DIFF
--- a/esphome/components/micro_wake_word/micro_wake_word.cpp
+++ b/esphome/components/micro_wake_word/micro_wake_word.cpp
@@ -157,6 +157,11 @@ void MicroWakeWord::start() {
     return;
   }
 
+  if (this->state_ != State::IDLE) {
+    ESP_LOGW(TAG, "Wake word is already running");
+    return;
+  }
+
   if (!this->load_models_() || !this->allocate_buffers_()) {
     ESP_LOGE(TAG, "Failed to load the wake word model(s) or allocate buffers");
     this->status_set_error();
@@ -166,11 +171,6 @@ void MicroWakeWord::start() {
 
   if (this->status_has_error()) {
     ESP_LOGW(TAG, "Wake word component has an error. Please check logs");
-    return;
-  }
-
-  if (this->state_ != State::IDLE) {
-    ESP_LOGW(TAG, "Wake word is already running");
     return;
   }
 

--- a/esphome/components/micro_wake_word/micro_wake_word.cpp
+++ b/esphome/components/micro_wake_word/micro_wake_word.cpp
@@ -61,6 +61,29 @@ void MicroWakeWord::dump_config() {
 void MicroWakeWord::setup() {
   ESP_LOGCONFIG(TAG, "Setting up microWakeWord...");
 
+  this->microphone_->add_data_callback([this](const std::vector<int16_t> &data) {
+    if (this->state_ != State::DETECTING_WAKE_WORD) {
+      return;
+    }
+    std::shared_ptr<RingBuffer> temp_ring_buffer = this->ring_buffer_;
+    if (this->ring_buffer_.use_count() == 2) {
+      // mWW still owns the ring buffer and temp_ring_buffer does as well, proceed to copy audio into ring buffer
+
+      size_t bytes_free = temp_ring_buffer->free();
+
+      if (bytes_free < data.size() * sizeof(int16_t)) {
+        ESP_LOGW(
+            TAG,
+            "Not enough free bytes in ring buffer to store incoming audio data (free bytes=%d, incoming bytes=%d). "
+            "Resetting the ring buffer. Wake word detection accuracy will be reduced.",
+            bytes_free, data.size());
+
+        temp_ring_buffer->reset();
+      }
+      temp_ring_buffer->write((void *) data.data(), data.size() * sizeof(int16_t));
+    }
+  });
+
   if (!this->register_streaming_ops_(this->streaming_op_resolver_)) {
     this->mark_failed();
     return;
@@ -107,7 +130,6 @@ void MicroWakeWord::loop() {
       ESP_LOGD(TAG, "Starting Microphone");
       this->microphone_->start();
       this->set_state_(State::STARTING_MICROPHONE);
-      this->high_freq_.start();
       break;
     case State::STARTING_MICROPHONE:
       if (this->microphone_->is_running()) {
@@ -115,21 +137,19 @@ void MicroWakeWord::loop() {
       }
       break;
     case State::DETECTING_WAKE_WORD:
-      while (!this->has_enough_samples_()) {
-        this->read_microphone_();
-      }
-      this->update_model_probabilities_();
-      if (this->detect_wake_words_()) {
-        ESP_LOGD(TAG, "Wake Word '%s' Detected", (this->detected_wake_word_).c_str());
-        this->detected_ = true;
-        this->set_state_(State::STOP_MICROPHONE);
+      while (this->has_enough_samples_()) {
+        this->update_model_probabilities_();
+        if (this->detect_wake_words_()) {
+          ESP_LOGD(TAG, "Wake Word '%s' Detected", (this->detected_wake_word_).c_str());
+          this->detected_ = true;
+          this->set_state_(State::STOP_MICROPHONE);
+        }
       }
       break;
     case State::STOP_MICROPHONE:
       ESP_LOGD(TAG, "Stopping Microphone");
       this->microphone_->stop();
       this->set_state_(State::STOPPING_MICROPHONE);
-      this->high_freq_.stop();
       this->unload_models_();
       this->deallocate_buffers_();
       break;
@@ -196,26 +216,6 @@ void MicroWakeWord::set_state_(State state) {
   this->state_ = state;
 }
 
-size_t MicroWakeWord::read_microphone_() {
-  size_t bytes_read = this->microphone_->read(this->input_buffer_, INPUT_BUFFER_SIZE * sizeof(int16_t));
-  if (bytes_read == 0) {
-    return 0;
-  }
-
-  size_t bytes_free = this->ring_buffer_->free();
-
-  if (bytes_free < bytes_read) {
-    ESP_LOGW(TAG,
-             "Not enough free bytes in ring buffer to store incoming audio data (free bytes=%d, incoming bytes=%d). "
-             "Resetting the ring buffer. Wake word detection accuracy will be reduced.",
-             bytes_free, bytes_read);
-
-    this->ring_buffer_->reset();
-  }
-
-  return this->ring_buffer_->write((void *) this->input_buffer_, bytes_read);
-}
-
 bool MicroWakeWord::allocate_buffers_() {
   ExternalRAMAllocator<int16_t> audio_samples_allocator(ExternalRAMAllocator<int16_t>::ALLOW_FAILURE);
 
@@ -235,9 +235,9 @@ bool MicroWakeWord::allocate_buffers_() {
     }
   }
 
-  if (this->ring_buffer_ == nullptr) {
+  if (this->ring_buffer_.use_count() == 0) {
     this->ring_buffer_ = RingBuffer::create(BUFFER_SIZE * sizeof(int16_t));
-    if (this->ring_buffer_ == nullptr) {
+    if (this->ring_buffer_.use_count() == 0) {
       ESP_LOGE(TAG, "Could not allocate ring buffer");
       return false;
     }
@@ -248,10 +248,17 @@ bool MicroWakeWord::allocate_buffers_() {
 
 void MicroWakeWord::deallocate_buffers_() {
   ExternalRAMAllocator<int16_t> audio_samples_allocator(ExternalRAMAllocator<int16_t>::ALLOW_FAILURE);
-  audio_samples_allocator.deallocate(this->input_buffer_, INPUT_BUFFER_SIZE * sizeof(int16_t));
-  this->input_buffer_ = nullptr;
-  audio_samples_allocator.deallocate(this->preprocessor_audio_buffer_, this->new_samples_to_get_());
-  this->preprocessor_audio_buffer_ = nullptr;
+  if (this->input_buffer_ != nullptr) {
+    audio_samples_allocator.deallocate(this->input_buffer_, INPUT_BUFFER_SIZE * sizeof(int16_t));
+    this->input_buffer_ = nullptr;
+  }
+
+  if (this->preprocessor_audio_buffer_ != nullptr) {
+    audio_samples_allocator.deallocate(this->preprocessor_audio_buffer_, this->new_samples_to_get_());
+    this->preprocessor_audio_buffer_ = nullptr;
+  }
+
+  this->ring_buffer_.reset();
 }
 
 bool MicroWakeWord::load_models_() {

--- a/esphome/components/micro_wake_word/micro_wake_word.h
+++ b/esphome/components/micro_wake_word/micro_wake_word.h
@@ -62,9 +62,8 @@ class MicroWakeWord : public Component {
   microphone::Microphone *microphone_{nullptr};
   Trigger<std::string> *wake_word_detected_trigger_ = new Trigger<std::string>();
   State state_{State::IDLE};
-  HighFrequencyLoopRequester high_freq_;
 
-  std::unique_ptr<RingBuffer> ring_buffer_;
+  std::shared_ptr<RingBuffer> ring_buffer_;
 
   std::vector<WakeWordModel> wake_word_models_;
 
@@ -97,15 +96,6 @@ class MicroWakeWord : public Component {
   /// @brief Tests if there are enough samples in the ring buffer to generate new features.
   /// @return True if enough samples, false otherwise.
   bool has_enough_samples_();
-
-  /** Reads audio from microphone into the ring buffer
-   *
-   * Audio data (16000 kHz with int16 samples) is read into the input_buffer_.
-   * Verifies the ring buffer has enough space for all audio data. If not, it logs
-   * a warning and resets the ring buffer entirely.
-   * @return Number of bytes written to the ring buffer
-   */
-  size_t read_microphone_();
 
   /// @brief Allocates memory for input_buffer_, preprocessor_audio_buffer_, and ring_buffer_
   /// @return True if successful, false otherwise


### PR DESCRIPTION
# What does this implement/fix?

Switches to using a callback for receiving microphone data instead of directly reading from the microphone. This will solve issues where multiple components can't access the same microphone at the same time. It uses a ``shared_ptr`` for the ring buffer to avoid deallocation issues once I move the microphone reading into a separate task.

Should merge #8625 first (it works without it, but some audio samples are lost and the wake word detection accuracy suffers). 

Includes the fix (and closes #8611) to avoid allocating memory or loading models if it is already running. This fixes a potential memory leak with the ``FrontendState struct`` if one tries to start mWW while its already running.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** not applicable

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** not applicable

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

i2s_audio:
  - id: i2s_audio_bus
    i2s_lrclk_pin: GPIO33
    i2s_bclk_pin: GPIO19

microphone:
  - platform: i2s_audio
    id: echo_microphone
    i2s_din_pin: GPIO23
    adc_type: external
    pdm: true

micro_wake_word:
  on_wake_word_detected:
    - voice_assistant.start:
        wake_word: !lambda return wake_word;
  vad:
  models:
    - model: okay_nabu

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
