### PR TITLE
[touchscreen] Clear interrupt flag before reading touch data.

### DIFF
--- a/esphome/components/touchscreen/touchscreen.cpp
+++ b/esphome/components/touchscreen/touchscreen.cpp
@@ -50,13 +50,15 @@ void Touchscreen::loop() {
       tp.second.x_prev = tp.second.x;
       tp.second.y_prev = tp.second.y;
     }
+    // The interrupt flag must be reset BEFORE calling update_touches, otherwise we might miss an interrupt that was
+    // triggered while we were reading touch data.
+    this->store_.touched = false;
     this->update_touches();
     if (this->skip_update_) {
       for (auto &tp : this->touches_) {
         tp.second.state &= ~STATE_RELEASING;
       }
     } else {
-      this->store_.touched = false;
       this->defer([this]() { this->send_touches_(); });
       if (this->touch_timeout_ > 0) {
         // Simulate a touch after <this->touch_timeout_> ms. This will reset any existing timeout operation.


### PR DESCRIPTION
# What does this implement/fix?

Currently, the `store_.touched` flag (normally set by an interrupt handler) is cleared *after* reading touch data.  Some touchscreens (e.g. the tt21xxx) generate data quickly enough to trigger a new interrupt before update_touches() completes.

When this tt21xxx's buffer is full, it won't generate another interrupt until data is read, so the situation above causes the touchscreen to stop responding due to the interrupt flag being set to false while the tt21xxx's buffer is full.

This change fully resolves esphome/issues#5274 for me.  I do not believe it should negatively impact any other touchscreen drivers, but I don't have examples of those to test with.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes esphome/issues#5274

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
touchscreen:
  platform: tt21100
  id: espbox_touch
  interrupt_pin:
    number: GPIO3
    ignore_strapping_warning: True
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
