### PR TITLE
[udp] differentiate publishing the initial state for binary sensors

### DIFF
--- a/esphome/components/udp/udp_component.cpp
+++ b/esphome/components/udp/udp_component.cpp
@@ -522,8 +522,14 @@ void UDPComponent::process_(uint8_t *buf, const size_t len) {
       sensors[namebuf]->publish_state(rdata.f32);
 #endif
 #ifdef USE_BINARY_SENSOR
-    if (byte == BINARY_SENSOR_KEY && binary_sensors.count(namebuf) != 0)
-      binary_sensors[namebuf]->publish_state(rdata.u32 != 0);
+    if (byte == BINARY_SENSOR_KEY && binary_sensors.count(namebuf) != 0) {
+      auto state = rdata.u32 != 0;
+      if (binary_sensors[namebuf]->has_state()) {
+        binary_sensors[namebuf]->publish_state(state);
+      } else {
+        binary_sensors[namebuf]->publish_initial_state(state);
+      }
+    }
 #endif
   }
 }


### PR DESCRIPTION
# What does this implement/fix?

The udp binary sensor is updated to differentiate when publishing the initial state. This avoids spurious state changes when booting.

To preserve the existing behavior set `publish_initial_state: true` for the binary sensor.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
binary_sensor:
  - platform: udp
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
