### PR TITLE
Update ens160_base.cpp – fix wrong double negative

### DIFF
--- a/esphome/components/ens160_base/ens160_base.cpp
+++ b/esphome/components/ens160_base/ens160_base.cpp
@@ -187,7 +187,7 @@ void ENS160Component::update() {
       }
       return;
     case INVALID_OUTPUT:
-      ESP_LOGE(TAG, "ENS160 Invalid Status - No Invalid Output");
+      ESP_LOGE(TAG, "ENS160 Invalid Status - No valid output");
       this->status_set_warning();
       return;
   }


### PR DESCRIPTION
The Validity Flag means „no valid output“

# What does this implement/fix?

just a typo in the Validity Flag

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ X ] Other
