### PR TITLE
2025.4.1

### DIFF
--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
@@ -265,6 +265,12 @@ void BluetoothProxy::bluetooth_device_request(const api::BluetoothDeviceRequest 
                  connection->get_connection_index(), connection->address_str().c_str());
         return;
       } else if (connection->state() == espbt::ClientState::CONNECTING) {
+        if (connection->disconnect_pending()) {
+          ESP_LOGW(TAG, "[%d] [%s] Connection request while pending disconnect, cancelling pending disconnect",
+                   connection->get_connection_index(), connection->address_str().c_str());
+          connection->cancel_pending_disconnect();
+          return;
+        }
         ESP_LOGW(TAG, "[%d] [%s] Connection request ignored, already connecting", connection->get_connection_index(),
                  connection->address_str().c_str());
         return;

--- a/esphome/components/ens160_base/ens160_base.cpp
+++ b/esphome/components/ens160_base/ens160_base.cpp
@@ -187,7 +187,7 @@ void ENS160Component::update() {
       }
       return;
     case INVALID_OUTPUT:
-      ESP_LOGE(TAG, "ENS160 Invalid Status - No Invalid Output");
+      ESP_LOGE(TAG, "ENS160 Invalid Status - No valid output");
       this->status_set_warning();
       return;
   }

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
@@ -173,6 +173,8 @@ class ESPBTClient : public ESPBTDeviceListener {
   virtual void gap_event_handler(esp_gap_ble_cb_event_t event, esp_ble_gap_cb_param_t *param) = 0;
   virtual void connect() = 0;
   virtual void disconnect() = 0;
+  bool disconnect_pending() const { return this->want_disconnect_; }
+  void cancel_pending_disconnect() { this->want_disconnect_ = false; }
   virtual void set_state(ClientState st) {
     this->state_ = st;
     if (st == ClientState::IDLE) {

--- a/esphome/components/lvgl/lvgl_esphome.cpp
+++ b/esphome/components/lvgl/lvgl_esphome.cpp
@@ -120,6 +120,7 @@ void LvglComponent::add_event_cb(lv_obj_t *obj, event_callback_t callback, lv_ev
 void LvglComponent::add_page(LvPageType *page) {
   this->pages_.push_back(page);
   page->set_parent(this);
+  lv_disp_set_default(this->disp_);
   page->setup(this->pages_.size() - 1);
 }
 void LvglComponent::show_page(size_t index, lv_scr_load_anim_t anim, uint32_t time) {

--- a/esphome/components/online_image/online_image.cpp
+++ b/esphome/components/online_image/online_image.cpp
@@ -111,7 +111,7 @@ void OnlineImage::update() {
     case ImageFormat::BMP:
       accept_mime_type = "image/bmp";
       break;
-#endif  // ONLINE_IMAGE_BMP_SUPPORT
+#endif  // USE_ONLINE_IMAGE_BMP_SUPPORT
 #ifdef USE_ONLINE_IMAGE_JPEG_SUPPORT
     case ImageFormat::JPEG:
       accept_mime_type = "image/jpeg";
@@ -121,7 +121,7 @@ void OnlineImage::update() {
     case ImageFormat::PNG:
       accept_mime_type = "image/png";
       break;
-#endif  // ONLINE_IMAGE_PNG_SUPPORT
+#endif  // USE_ONLINE_IMAGE_PNG_SUPPORT
     default:
       accept_mime_type = "image/*";
   }
@@ -159,7 +159,7 @@ void OnlineImage::update() {
     ESP_LOGD(TAG, "Allocating BMP decoder");
     this->decoder_ = make_unique<BmpDecoder>(this);
   }
-#endif  // ONLINE_IMAGE_BMP_SUPPORT
+#endif  // USE_ONLINE_IMAGE_BMP_SUPPORT
 #ifdef USE_ONLINE_IMAGE_JPEG_SUPPORT
   if (this->format_ == ImageFormat::JPEG) {
     ESP_LOGD(TAG, "Allocating JPEG decoder");
@@ -171,7 +171,7 @@ void OnlineImage::update() {
     ESP_LOGD(TAG, "Allocating PNG decoder");
     this->decoder_ = make_unique<PngDecoder>(this);
   }
-#endif  // ONLINE_IMAGE_PNG_SUPPORT
+#endif  // USE_ONLINE_IMAGE_PNG_SUPPORT
 
   if (!this->decoder_) {
     ESP_LOGE(TAG, "Could not instantiate decoder. Image format unsupported: %d", this->format_);
@@ -185,7 +185,7 @@ void OnlineImage::update() {
     this->download_error_callback_.call();
     return;
   }
-  ESP_LOGI(TAG, "Downloading image (Size: %d)", total_size);
+  ESP_LOGI(TAG, "Downloading image (Size: %zu)", total_size);
   this->start_time_ = ::time(nullptr);
 }
 

--- a/esphome/components/psram/psram.cpp
+++ b/esphome/components/psram/psram.cpp
@@ -1,7 +1,8 @@
 
 #ifdef USE_ESP32
 #include "psram.h"
-#ifdef USE_ESP_IDF
+#include <esp_idf_version.h>
+#if defined(USE_ESP_IDF) && ESP_IDF_VERSION_MAJOR >= 5
 #include <esp_psram.h>
 #endif  // USE_ESP_IDF
 
@@ -15,7 +16,7 @@ static const char *const TAG = "psram";
 
 void PsramComponent::dump_config() {
   ESP_LOGCONFIG(TAG, "PSRAM:");
-#ifdef USE_ESP_IDF
+#if defined(USE_ESP_IDF) && ESP_IDF_VERSION_MAJOR >= 5
   bool available = esp_psram_is_initialized();
 
   ESP_LOGCONFIG(TAG, "  Available: %s", YESNO(available));

--- a/esphome/components/watchdog/watchdog.cpp
+++ b/esphome/components/watchdog/watchdog.cpp
@@ -6,6 +6,7 @@
 #include <cinttypes>
 #include <cstdint>
 #ifdef USE_ESP32
+#include <soc/soc_caps.h>
 #include "esp_idf_version.h"
 #include "esp_task_wdt.h"
 #endif
@@ -40,7 +41,7 @@ void WatchdogManager::set_timeout_(uint32_t timeout_ms) {
 #if ESP_IDF_VERSION_MAJOR >= 5
   esp_task_wdt_config_t wdt_config = {
       .timeout_ms = timeout_ms,
-      .idle_core_mask = 0x03,
+      .idle_core_mask = (1 << SOC_CPU_CORES_NUM) - 1,
       .trigger_panic = true,
   };
   esp_task_wdt_reconfigure(&wdt_config);

--- a/esphome/const.py
+++ b/esphome/const.py
@@ -1,6 +1,6 @@
 """Constants used by esphome."""
 
-__version__ = "2025.4.0"
+__version__ = "2025.4.1"
 
 ALLOWED_NAME_CHARS = "abcdefghijklmnopqrstuvwxyz0123456789-_"
 VALID_SUBSTITUTIONS_CHARACTERS = (

--- a/esphome/log.py
+++ b/esphome/log.py
@@ -74,12 +74,13 @@ def setup_log(
 
     colorama.init()
 
-    if log_level == logging.DEBUG:
-        CORE.verbose = True
-    elif log_level == logging.CRITICAL:
-        CORE.quiet = True
-
+    # Setup logging - will map log level from string to constant
     logging.basicConfig(level=log_level)
+
+    if logging.root.level == logging.DEBUG:
+        CORE.verbose = True
+    elif logging.root.level == logging.CRITICAL:
+        CORE.quiet = True
 
     logging.getLogger("urllib3").setLevel(logging.WARNING)
 


### PR DESCRIPTION
**Do not merge, release script will automatically merge**
- Fix psram below idf 5 [esphome#8584](https://github.com/esphome/esphome/pull/8584)
- [lvgl] Ensure pages are created on the correct display [esphome#8596](https://github.com/esphome/esphome/pull/8596)
- Fix BLE connection loop caused by timeout and pending disconnect race [esphome#8597](https://github.com/esphome/esphome/pull/8597)
- [online_image] Fix printf format; comment fixes [esphome#8607](https://github.com/esphome/esphome/pull/8607)
- [watchdog] Fix for variants with single core [esphome#8602](https://github.com/esphome/esphome/pull/8602)
- [core] Fix setting of log level/verbose [esphome#8600](https://github.com/esphome/esphome/pull/8600)
- Update ens160_base.cpp – fix wrong double negative [esphome#8639](https://github.com/esphome/esphome/pull/8639)

<details>
<summary>Metadata</summary>

@coderabbitai ignore
</details>
