### PR TITLE
feat: ``wifi.configure`` now emits error after reconnecting to old AP

### DIFF
--- a/esphome/components/wifi/wifi_component.h
+++ b/esphome/components/wifi/wifi_component.h
@@ -484,13 +484,15 @@ template<typename... Ts> class WiFiConfigureAction : public Action<Ts...>, publi
     global_wifi_component->enable();
     // Set timeout for the connection
     this->set_timeout("wifi-connect-timeout", this->connection_timeout_.value(x...), [this]() {
-      this->connecting_ = false;
       // If the timeout is reached, stop connecting and revert to the old AP
       global_wifi_component->disable();
       global_wifi_component->save_wifi_sta(old_sta_.get_ssid(), old_sta_.get_password());
       global_wifi_component->enable();
-      // Callback to notify the user that the connection failed
-      this->error_trigger_->trigger();
+      // Start a timeout for the fallback if the connection to the old AP fails
+      this->set_timeout("wifi-fallback-timeout", 30000, [this]() {
+        this->connecting_ = false;
+        this->error_trigger_->trigger();
+      });
     });
   }
 
@@ -503,6 +505,7 @@ template<typename... Ts> class WiFiConfigureAction : public Action<Ts...>, publi
     if (global_wifi_component->is_connected()) {
       // The WiFi is connected, stop the timeout and reset the connecting flag
       this->cancel_timeout("wifi-connect-timeout");
+      this->cancel_timeout("wifi-fallback-timeout");
       this->connecting_ = false;
       if (global_wifi_component->wifi_ssid() == this->new_sta_.get_ssid()) {
         // Callback to notify the user that the connection was successful

--- a/esphome/components/wifi/wifi_component.h
+++ b/esphome/components/wifi/wifi_component.h
@@ -489,7 +489,7 @@ template<typename... Ts> class WiFiConfigureAction : public Action<Ts...>, publi
       global_wifi_component->save_wifi_sta(old_sta_.get_ssid(), old_sta_.get_password());
       global_wifi_component->enable();
       // Start a timeout for the fallback if the connection to the old AP fails
-      this->set_timeout("wifi-fallback-timeout", 30000, [this]() {
+      this->set_timeout("wifi-fallback-timeout", this->connection_timeout_.value(x...), [this]() {
         this->connecting_ = false;
         this->error_trigger_->trigger();
       });

--- a/esphome/components/wifi/wifi_component.h
+++ b/esphome/components/wifi/wifi_component.h
@@ -483,7 +483,7 @@ template<typename... Ts> class WiFiConfigureAction : public Action<Ts...>, publi
     // Enable WiFi
     global_wifi_component->enable();
     // Set timeout for the connection
-    this->set_timeout("wifi-connect-timeout", this->connection_timeout_.value(x...), [this, x]() {
+    this->set_timeout("wifi-connect-timeout", this->connection_timeout_.value(x...), [this, x...]() {
       // If the timeout is reached, stop connecting and revert to the old AP
       global_wifi_component->disable();
       global_wifi_component->save_wifi_sta(old_sta_.get_ssid(), old_sta_.get_password());

--- a/esphome/components/wifi/wifi_component.h
+++ b/esphome/components/wifi/wifi_component.h
@@ -483,7 +483,7 @@ template<typename... Ts> class WiFiConfigureAction : public Action<Ts...>, publi
     // Enable WiFi
     global_wifi_component->enable();
     // Set timeout for the connection
-    this->set_timeout("wifi-connect-timeout", this->connection_timeout_.value(x...), [this]() {
+    this->set_timeout("wifi-connect-timeout", this->connection_timeout_.value(x...), [this, x]() {
       // If the timeout is reached, stop connecting and revert to the old AP
       global_wifi_component->disable();
       global_wifi_component->save_wifi_sta(old_sta_.get_ssid(), old_sta_.get_password());


### PR DESCRIPTION
# What does this implement/fix?

Before this PR, `wifi.configure` would just call the error callback after the connection timeout, before it had reconnected to the old AP. Now, it waits until the old connection has been reestablished to call the error callback. This facilitates the interaction flow when configuring a new Wi-Fi network.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Checklist:
  - [x] The code change is tested and works locally.
