### PR TITLE
[microphone] Bugfix: protect against starting mic if already started

### DIFF
--- a/esphome/components/microphone/microphone_source.cpp
+++ b/esphome/components/microphone/microphone_source.cpp
@@ -14,12 +14,16 @@ void MicrophoneSource::add_data_callback(std::function<void(const std::vector<ui
 }
 
 void MicrophoneSource::start() {
-  this->enabled_ = true;
-  this->mic_->start();
+  if (!this->enabled_) {
+    this->enabled_ = true;
+    this->mic_->start();
+  }
 }
 void MicrophoneSource::stop() {
-  this->enabled_ = false;
-  this->mic_->stop();
+  if (this->enabled_) {
+    this->enabled_ = false;
+    this->mic_->stop();
+  }
 }
 
 std::vector<uint8_t> MicrophoneSource::process_audio_(const std::vector<uint8_t> &data) {


### PR DESCRIPTION
# What does this implement/fix?

This small PR ensures that an already started MicrophoneSource doesn't start the microphone a second time. This prevents a situation where the MicrophoneSource owns two of the same sempahore in the I2S audio component, which prevents the microphone from actually stopping.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** not applicable

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** not applicable

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
