### PR TITLE
Fix typo preventing tt21100 from autosetting the touchscreen res.

### DIFF
--- a/esphome/components/tt21100/touchscreen/tt21100.cpp
+++ b/esphome/components/tt21100/touchscreen/tt21100.cpp
@@ -68,7 +68,7 @@ void TT21100Touchscreen::setup() {
       this->x_raw_max_ = this->display_->get_native_width();
     }
     if (this->y_raw_max_ == this->y_raw_min_) {
-      this->x_raw_max_ = this->display_->get_native_height();
+      this->y_raw_max_ = this->display_->get_native_height();
     }
   }
 


### PR DESCRIPTION
# What does this implement/fix?

There is a typo in the tt21100 driver setting `x_raw_max_` to the display height instead of `y_raw_max_`.  This prevents touches from being passed on (they all get the CALIBRATE flag set) unless you manually specify touchscreen max coordinates via `calibration`.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
touchscreen:
  platform: tt21100
  id: touch_tt21100
  display: display_ili9xxx
  transform:
    mirror_x: True
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
