### PR TITLE
[microphone] Add software mute and fix wrong type for automations

### DIFF
--- a/esphome/components/microphone/__init__.py
+++ b/esphome/components/microphone/__init__.py
@@ -32,6 +32,12 @@ CaptureAction = microphone_ns.class_(
 StopCaptureAction = microphone_ns.class_(
     "StopCaptureAction", automation.Action, cg.Parented.template(Microphone)
 )
+MuteAction = microphone_ns.class_(
+    "MuteAction", automation.Action, cg.Parented.template(Microphone)
+)
+UnmuteAction = microphone_ns.class_(
+    "UnmuteAction", automation.Action, cg.Parented.template(Microphone)
+)
 
 
 DataTrigger = microphone_ns.class_(
@@ -42,6 +48,7 @@ DataTrigger = microphone_ns.class_(
 IsCapturingCondition = microphone_ns.class_(
     "IsCapturingCondition", automation.Condition
 )
+IsMutedCondition = microphone_ns.class_("IsMutedCondition", automation.Condition)
 
 
 async def setup_microphone_core_(var, config):
@@ -186,8 +193,18 @@ automation.register_action(
     "microphone.stop_capture", StopCaptureAction, MICROPHONE_ACTION_SCHEMA
 )(microphone_action)
 
+automation.register_action("microphone.mute", MuteAction, MICROPHONE_ACTION_SCHEMA)(
+    microphone_action
+)
+automation.register_action("microphone.unmute", UnmuteAction, MICROPHONE_ACTION_SCHEMA)(
+    microphone_action
+)
+
 automation.register_condition(
     "microphone.is_capturing", IsCapturingCondition, MICROPHONE_ACTION_SCHEMA
+)(microphone_action)
+automation.register_condition(
+    "microphone.is_muted", IsMutedCondition, MICROPHONE_ACTION_SCHEMA
 )(microphone_action)
 
 

--- a/esphome/components/microphone/__init__.py
+++ b/esphome/components/microphone/__init__.py
@@ -54,10 +54,9 @@ IsMutedCondition = microphone_ns.class_("IsMutedCondition", automation.Condition
 async def setup_microphone_core_(var, config):
     for conf in config.get(CONF_ON_DATA, []):
         trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
-        # Future PR will change the vector type to uint8
         await automation.build_automation(
             trigger,
-            [(cg.std_vector.template(cg.int16).operator("ref").operator("const"), "x")],
+            [(cg.std_vector.template(cg.uint8).operator("ref").operator("const"), "x")],
             conf,
         )
 

--- a/esphome/components/microphone/automation.h
+++ b/esphome/components/microphone/automation.h
@@ -16,6 +16,13 @@ template<typename... Ts> class StopCaptureAction : public Action<Ts...>, public 
   void play(Ts... x) override { this->parent_->stop(); }
 };
 
+template<typename... Ts> class MuteAction : public Action<Ts...>, public Parented<Microphone> {
+  void play(Ts... x) override { this->parent_->set_mute_state(true); }
+};
+template<typename... Ts> class UnmuteAction : public Action<Ts...>, public Parented<Microphone> {
+  void play(Ts... x) override { this->parent_->set_mute_state(false); }
+};
+
 class DataTrigger : public Trigger<const std::vector<uint8_t> &> {
  public:
   explicit DataTrigger(Microphone *mic) {
@@ -26,6 +33,11 @@ class DataTrigger : public Trigger<const std::vector<uint8_t> &> {
 template<typename... Ts> class IsCapturingCondition : public Condition<Ts...>, public Parented<Microphone> {
  public:
   bool check(Ts... x) override { return this->parent_->is_running(); }
+};
+
+template<typename... Ts> class IsMutedCondition : public Condition<Ts...>, public Parented<Microphone> {
+ public:
+  bool check(Ts... x) override { return this->parent_->get_mute_state(); }
 };
 
 }  // namespace microphone

--- a/esphome/components/microphone/microphone.cpp
+++ b/esphome/components/microphone/microphone.cpp
@@ -1,0 +1,21 @@
+#include "microphone.h"
+
+namespace esphome {
+namespace microphone {
+
+void Microphone::add_data_callback(std::function<void(const std::vector<uint8_t> &)> &&data_callback) {
+  std::function<void(const std::vector<uint8_t> &)> mute_handled_callback =
+      [this, data_callback](const std::vector<uint8_t> &data) { data_callback(this->silence_audio_(data)); };
+  this->data_callbacks_.add(std::move(mute_handled_callback));
+}
+
+std::vector<uint8_t> Microphone::silence_audio_(std::vector<uint8_t> data) {
+  if (this->mute_state_) {
+    std::memset((void *) data.data(), 0, data.size());
+  }
+
+  return data;
+}
+
+}  // namespace microphone
+}  // namespace esphome

--- a/esphome/components/microphone/microphone.h
+++ b/esphome/components/microphone/microphone.h
@@ -22,11 +22,7 @@ class Microphone {
  public:
   virtual void start() = 0;
   virtual void stop() = 0;
-  void add_data_callback(std::function<void(const std::vector<uint8_t> &)> &&data_callback) {
-    std::function<void(const std::vector<uint8_t> &)> mute_handled_callback =
-        [this, data_callback](const std::vector<uint8_t> &data) { data_callback(this->silence_audio_(data)); };
-    this->data_callbacks_.add(std::move(mute_handled_callback));
-  }
+  void add_data_callback(std::function<void(const std::vector<uint8_t> &)> &&data_callback);
 
   bool is_running() const { return this->state_ == STATE_RUNNING; }
   bool is_stopped() const { return this->state_ == STATE_STOPPED; }
@@ -37,18 +33,12 @@ class Microphone {
   audio::AudioStreamInfo get_audio_stream_info() { return this->audio_stream_info_; }
 
  protected:
-  std::vector<uint8_t> silence_audio_(std::vector<uint8_t> data) {
-    if (this->mute_state_) {
-      std::memset((void *) data.data(), 0, data.size());
-    }
-
-    return data;
-  }
+  std::vector<uint8_t> silence_audio_(std::vector<uint8_t> data);
 
   State state_{STATE_STOPPED};
+  bool mute_state_{false};
 
   audio::AudioStreamInfo audio_stream_info_;
-  bool mute_state_{false};
 
   CallbackManager<void(const std::vector<uint8_t> &)> data_callbacks_{};
 };

--- a/esphome/components/microphone/microphone.h
+++ b/esphome/components/microphone/microphone.h
@@ -23,18 +23,32 @@ class Microphone {
   virtual void start() = 0;
   virtual void stop() = 0;
   void add_data_callback(std::function<void(const std::vector<uint8_t> &)> &&data_callback) {
-    this->data_callbacks_.add(std::move(data_callback));
+    std::function<void(const std::vector<uint8_t> &)> mute_handled_callback =
+        [this, data_callback](const std::vector<uint8_t> &data) { data_callback(this->silence_audio_(data)); };
+    this->data_callbacks_.add(std::move(mute_handled_callback));
   }
 
   bool is_running() const { return this->state_ == STATE_RUNNING; }
   bool is_stopped() const { return this->state_ == STATE_STOPPED; }
 
+  void set_mute_state(bool is_muted) { this->mute_state_ = is_muted; }
+  bool get_mute_state() { return this->mute_state_; }
+
   audio::AudioStreamInfo get_audio_stream_info() { return this->audio_stream_info_; }
 
  protected:
+  std::vector<uint8_t> silence_audio_(std::vector<uint8_t> data) {
+    if (this->mute_state_) {
+      std::memset((void *) data.data(), 0, data.size());
+    }
+
+    return data;
+  }
+
   State state_{STATE_STOPPED};
 
   audio::AudioStreamInfo audio_stream_info_;
+  bool mute_state_{false};
 
   CallbackManager<void(const std::vector<uint8_t> &)> data_callbacks_{};
 };

--- a/tests/components/microphone/common.yaml
+++ b/tests/components/microphone/common.yaml
@@ -10,3 +10,11 @@ microphone:
     adc_type: external
     pdm: false
     mclk_multiple: 384
+    on_data:
+      - if:
+          condition:
+            - microphone.is_muted:
+          then:
+            - microphone.unmute:
+          else:
+            - microphone.mute:


### PR DESCRIPTION
# What does this implement/fix?

Adds a microphone software mute. When enabled, it zeros all read audio before passing it through via the callback. Adds automation actions and a condition for the software mute state.

Fixes a bug where the data trigger had the wrong type in Python. (I missed changing this in one of my previous microphone PRs).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes esphome/feature-requests/issues/2584

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#4868

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

esphome:
  # silly example showing the automations
  on_boot:
      - if:
          condition:
            - microphone.is_muted:
          then:
            - microphone.unmute:
          else:
            - microphone.mute:

microphone:
  - platform: i2s_audio
    id: i2s_mics
    i2s_din_pin: GPIOXX
    adc_type: external
    pdm: false
    sample_rate: 16000
    bits_per_sample: 32bit
    i2s_mode: secondary
    i2s_audio_id: i2s_input
    channel: stereo

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
