### PR TITLE
Add GDEY0583T81 support

### DIFF
--- a/esphome/components/waveshare_epaper/display.py
+++ b/esphome/components/waveshare_epaper/display.py
@@ -79,6 +79,7 @@ WaveshareEPaper5P8In = waveshare_epaper_ns.class_(
 WaveshareEPaper5P8InV2 = waveshare_epaper_ns.class_(
     "WaveshareEPaper5P8InV2", WaveshareEPaper
 )
+GDEY0583T81 = waveshare_epaper_ns.class_("GDEY0583T81", WaveshareEPaper)
 WaveshareEPaper7P3InF = waveshare_epaper_ns.class_(
     "WaveshareEPaper7P3InF", WaveshareEPaper7C
 )
@@ -156,6 +157,7 @@ MODELS = {
     "5.65in-f": ("b", WaveshareEPaper5P65InF),
     "5.83in": ("b", WaveshareEPaper5P8In),
     "5.83inv2": ("b", WaveshareEPaper5P8InV2),
+    "gdey0583t81": ("c", GDEY0583T81),
     "7.30in-f": ("b", WaveshareEPaper7P3InF),
     "7.50in": ("b", WaveshareEPaper7P5In),
     "7.50in-bv2": ("b", WaveshareEPaper7P5InBV2),

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -2938,6 +2938,223 @@ void WaveshareEPaper5P8InV2::dump_config() {
   LOG_UPDATE_INTERVAL(this);
 }
 
+// ========================================================
+//     Good Display 5.83in black/white GDEY0583T81
+// Product page:
+//  - https://www.good-display.com/product/440.html
+//  - https://www.seeedstudio.com/5-83-Monochrome-ePaper-Display-with-648x480-Pixels-p-5785.html
+// Datasheet:
+//  - https://www.good-display.com/public/html/pdfjs/viewer/viewernew.html?file=https://v4.cecdn.yun300.cn/100001_1909185148/GDEY0583T81-new.pdf
+//  - https://v4.cecdn.yun300.cn/100001_1909185148/GDEY0583T81-new.pdf
+// Reference code from GoodDisplay:
+//  - https://www.good-display.com/companyfile/903.html
+// ========================================================
+
+void GDEY0583T81::initialize() {
+  // Allocate buffer for old data for partial updates
+  ExternalRAMAllocator<uint8_t> allocator(ExternalRAMAllocator<uint8_t>::ALLOW_FAILURE);
+  this->old_buffer_ = allocator.allocate(this->get_buffer_length_());
+  if (this->old_buffer_ == nullptr) {
+    ESP_LOGE(TAG, "Could not allocate old buffer for display!");
+    return;
+  }
+  for (size_t i = 0; i < this->get_buffer_length_(); i++) {
+    this->old_buffer_[i] = 0xFF;
+  }
+
+  this->init_full_();
+
+  this->wait_until_idle_();
+
+  this->deep_sleep();
+}
+
+void GDEY0583T81::power_on_() {
+  if (!this->power_is_on_) {
+    this->command(0x04);
+    this->wait_until_idle_();
+  }
+  this->power_is_on_ = true;
+  this->is_deep_sleep_ = false;
+}
+
+void GDEY0583T81::power_off_() {
+  this->command(0x02);
+  this->wait_until_idle_();
+  this->power_is_on_ = false;
+}
+
+void GDEY0583T81::deep_sleep() {
+  if (this->is_deep_sleep_) {
+    return;
+  }
+
+  // VCOM and data interval setting (CDI)
+  this->command(0x50);
+  this->data(0xf7);
+
+  this->power_off_();
+  delay(10);
+
+  // Deep sleep (DSLP)
+  this->command(0x07);
+  this->data(0xA5);
+  this->is_deep_sleep_ = true;
+}
+
+void GDEY0583T81::reset_() {
+  if (this->reset_pin_ != nullptr) {
+    this->reset_pin_->digital_write(false);
+    delay(10);
+    this->reset_pin_->digital_write(true);
+    delay(10);
+  }
+}
+
+// Initialize for full screen update in fast mode
+void GDEY0583T81::init_full_() {
+  this->init_display_();
+
+  // Based on the GD sample code
+  // VCOM and data interval setting (CDI)
+  this->command(0x50);
+  this->data(0x29);
+  this->data(0x07);
+
+  // Cascade Setting (CCSET)
+  this->command(0xE0);
+  this->data(0x02);
+
+  // Force Temperature (TSSET)
+  this->command(0xE5);
+  this->data(0x5A);
+}
+
+// Initialize for a partial update of the full screen
+void GDEY0583T81::init_partial_() {
+  this->init_display_();
+
+  // Cascade Setting (CCSET)
+  this->command(0xE0);
+  this->data(0x02);
+
+  // Force Temperature (TSSET)
+  this->command(0xE5);
+  this->data(0x6E);
+}
+
+void GDEY0583T81::init_display_() {
+  this->reset_();
+
+  // Panel Setting (PSR)
+  this->command(0x00);
+  // Sets: REG=0, LUT from OTP (set by CDI)
+  // KW/R=1, Sets KW mode (Black/White)
+  //         as opposed to the default KWR mode (Black/White/Red)
+  // UD=1, Gate Scan Direction, 1 = up (default)
+  // SHL=1, Source Shift Direction, 1 = right (default)
+  // SHD_N=1, Booster Switch, 1 = ON (default)
+  // RST_N=1, Soft reset, 1 = No effect (default)
+  this->data(0x1F);
+
+  // Resolution setting (TRES)
+  this->command(0x61);
+
+  // Horizontal display resolution (HRES)
+  this->data(get_width_internal() / 256);
+  this->data(get_width_internal() % 256);
+
+  // Vertical display resolution (VRES)
+  this->data(get_height_internal() / 256);
+  this->data(get_height_internal() % 256);
+
+  this->power_on_();
+}
+
+void HOT GDEY0583T81::display() {
+  bool full_update = this->at_update_ == 0;
+  if (full_update) {
+    this->init_full_();
+  } else {
+    this->init_partial_();
+
+    // VCOM and data interval setting (CDI)
+    this->command(0x50);
+    this->data(0xA9);
+    this->data(0x07);
+
+    // Partial In (PTIN), makes the display enter partial mode
+    this->command(0x91);
+
+    // Partial Window (PTL)
+    //  We use the full screen as the window
+    this->command(0x90);
+
+    // Horizontal start/end channel bank (HRST/HRED)
+    this->data(0);
+    this->data(0);
+    this->data((get_width_internal() - 1) / 256);
+    this->data((get_width_internal() - 1) % 256);
+
+    // Vertical start/end line (VRST/VRED)
+    this->data(0);
+    this->data(0);
+    this->data((get_height_internal() - 1) / 256);
+    this->data((get_height_internal() - 1) % 256);
+
+    this->data(0x01);
+
+    // Display Start Transmission 1 (DTM1)
+    //  in KW mode this writes "OLD" data to SRAM
+    this->command(0x10);
+    this->start_data_();
+    this->write_array(this->old_buffer_, this->get_buffer_length_());
+    this->end_data_();
+  }
+
+  // Display Start Transmission 2 (DTM2)
+  //  in KW mode this writes "NEW" data to SRAM
+  this->command(0x13);
+  this->start_data_();
+  this->write_array(this->buffer_, this->get_buffer_length_());
+  this->end_data_();
+
+  for (size_t i = 0; i < this->get_buffer_length_(); i++) {
+    this->old_buffer_[i] = this->buffer_[i];
+  }
+
+  // Display Refresh (DRF)
+  this->command(0x12);
+  delay(10);
+  this->wait_until_idle_();
+
+  if (full_update) {
+    ESP_LOGD(TAG, "Full update done");
+  } else {
+    // Partial out (PTOUT), makes the display exit partial mode
+    this->command(0x92);
+    ESP_LOGD(TAG, "Partial update done, next full update after %d cycles", this->full_update_every_ - this->at_update_ - 1);
+  }
+
+  this->at_update_ = (this->at_update_ + 1) % this->full_update_every_;
+
+  this->deep_sleep();
+}
+
+void GDEY0583T81::set_full_update_every(uint32_t full_update_every) { this->full_update_every_ = full_update_every; }
+int GDEY0583T81::get_width_internal() { return 648; }
+int GDEY0583T81::get_height_internal() { return 480; }
+uint32_t GDEY0583T81::idle_timeout_() { return 5000; }
+void GDEY0583T81::dump_config() {
+  LOG_DISPLAY("", "GoodDisplay E-Paper", this);
+  ESP_LOGCONFIG(TAG, "  Model: 5.83in B/W GDEY0583T81");
+  ESP_LOGCONFIG(TAG, "  Full Update Every: %" PRIu32, this->full_update_every_);
+  LOG_PIN("  Reset Pin: ", this->reset_pin_);
+  LOG_PIN("  DC Pin: ", this->dc_pin_);
+  LOG_PIN("  Busy Pin: ", this->busy_pin_);
+  LOG_UPDATE_INTERVAL(this);
+}
+
 void WaveshareEPaper7P5InBV2::initialize() {
   // COMMAND POWER SETTING
   this->command(0x01);

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -2953,7 +2953,7 @@ void WaveshareEPaper5P8InV2::dump_config() {
 
 void GDEY0583T81::initialize() {
   // Allocate buffer for old data for partial updates
-  RAMAllocator<uint8_t> allocator();
+  RAMAllocator<uint8_t> allocator{};
   this->old_buffer_ = allocator.allocate(this->get_buffer_length_());
   if (this->old_buffer_ == nullptr) {
     ESP_LOGE(TAG, "Could not allocate old buffer for display!");

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -2944,7 +2944,8 @@ void WaveshareEPaper5P8InV2::dump_config() {
 //  - https://www.good-display.com/product/440.html
 //  - https://www.seeedstudio.com/5-83-Monochrome-ePaper-Display-with-648x480-Pixels-p-5785.html
 // Datasheet:
-//  - https://www.good-display.com/public/html/pdfjs/viewer/viewernew.html?file=https://v4.cecdn.yun300.cn/100001_1909185148/GDEY0583T81-new.pdf
+//  -
+//  https://www.good-display.com/public/html/pdfjs/viewer/viewernew.html?file=https://v4.cecdn.yun300.cn/100001_1909185148/GDEY0583T81-new.pdf
 //  - https://v4.cecdn.yun300.cn/100001_1909185148/GDEY0583T81-new.pdf
 // Reference code from GoodDisplay:
 //  - https://www.good-display.com/companyfile/903.html
@@ -3133,7 +3134,8 @@ void HOT GDEY0583T81::display() {
   } else {
     // Partial out (PTOUT), makes the display exit partial mode
     this->command(0x92);
-    ESP_LOGD(TAG, "Partial update done, next full update after %d cycles", this->full_update_every_ - this->at_update_ - 1);
+    ESP_LOGD(TAG, "Partial update done, next full update after %d cycles",
+             this->full_update_every_ - this->at_update_ - 1);
   }
 
   this->at_update_ = (this->at_update_ + 1) % this->full_update_every_;

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -2953,15 +2953,13 @@ void WaveshareEPaper5P8InV2::dump_config() {
 
 void GDEY0583T81::initialize() {
   // Allocate buffer for old data for partial updates
-  ExternalRAMAllocator<uint8_t> allocator(ExternalRAMAllocator<uint8_t>::ALLOW_FAILURE);
+  RAMAllocator<uint8_t> allocator();
   this->old_buffer_ = allocator.allocate(this->get_buffer_length_());
   if (this->old_buffer_ == nullptr) {
     ESP_LOGE(TAG, "Could not allocate old buffer for display!");
     return;
   }
-  for (size_t i = 0; i < this->get_buffer_length_(); i++) {
-    this->old_buffer_[i] = 0xFF;
-  }
+  memset(this->old_buffer_, 0xFF, this->get_buffer_length_());
 
   this->init_full_();
 

--- a/esphome/components/waveshare_epaper/waveshare_epaper.h
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.h
@@ -686,6 +686,40 @@ class WaveshareEPaper5P8InV2 : public WaveshareEPaper {
   int get_height_internal() override;
 };
 
+class GDEY0583T81 : public WaveshareEPaper {
+ public:
+  void initialize() override;
+
+  void display() override;
+
+  void dump_config() override;
+
+  void deep_sleep() override;
+
+  void set_full_update_every(uint32_t full_update_every);
+
+ protected:
+  int get_width_internal() override;
+  int get_height_internal() override;
+  uint32_t idle_timeout_() override;
+
+ private:
+  void power_on_();
+  void power_off_();
+  void reset_();
+  void update_full_();
+  void update_part_();
+  void init_full_();
+  void init_partial_();
+  void init_display_();
+
+  uint32_t full_update_every_{30};
+  uint32_t at_update_{0};
+  bool power_is_on_{false};
+  bool is_deep_sleep_{false};
+  uint8_t *old_buffer_{nullptr};
+};
+
 class WaveshareEPaper5P65InF : public WaveshareEPaper7C {
  public:
   void initialize() override;


### PR DESCRIPTION
# What does this implement/fix?

Adds support for the 5.83" Good Display GDEY0583T81 E-paper variant

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- none

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#4869

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
display:
  - platform: waveshare_epaper
    id: "disp"
    cs_pin: GPIO3
    dc_pin: GPIO5
    busy_pin:
      number: GPIO4
      inverted: true
    reset_pin: GPIO2
    model: gdey0583t81
    full_update_every: 10
    update_interval: 10s
    auto_clear_enabled: true
    lambda: |-
      // Drawing random lines to test the partial update and ghosting effects with short update interval
      int x1 = rand() % 648;
      int y1 = rand() % 480;
      int x2,y2;

      for (int i = 0; i < 20; i++) {
        x2 = rand() % 648;
        y2 = rand() % 480;

        it.line(x1, y1, x2, y2);
        x1 = x2;
        y1 = y2;
      }
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
