### PR TITLE
[micro_wake_word] Clarify spectrogram features calculation

### DIFF
--- a/esphome/components/micro_wake_word/micro_wake_word.cpp
+++ b/esphome/components/micro_wake_word/micro_wake_word.cpp
@@ -404,8 +404,8 @@ size_t MicroWakeWord::generate_features_(int16_t *audio_buffer, size_t samples_a
     constexpr int32_t value_div = 666;  // 666 = 25.6 * 26.0 after rounding
     int32_t value = ((frontend_output.values[i] * value_scale) + (value_div / 2)) / value_div;
 
-    value -= INT8_MIN;
-    features_buffer[i] = clamp<int8_t>(value, INT8_MIN, INT8_MAX);
+    value += INT8_MIN;  // Adds a -128; i.e., subtracts 128
+    features_buffer[i] = static_cast<int8_t>(clamp<int32_t>(value, INT8_MIN, INT8_MAX));
   }
 
   return processed_samples;


### PR DESCRIPTION
# What does this implement/fix?

The current code to convert the raw spectrogram feature to a scaled int8 value produces the correct value, but it does not match the description in the code comments. See <https://github.com/esphome/home-assistant-voice-pe/issues/393#issuecomment-2845131310> for details.

This PR modifies the code to follow the description in the code comment for clarity.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- closes esphome/home-assistant-voice-pe/issues/393

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** not applicable

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
