### PR TITLE
Increase zeroconf timeout to 10 seconds

### DIFF
--- a/esphome/zeroconf.py
+++ b/esphome/zeroconf.py
@@ -18,6 +18,8 @@ from esphome.storage_json import StorageJSON, ext_storage_path
 
 _LOGGER = logging.getLogger(__name__)
 
+DEFAULT_TIMEOUT = 10.0
+DEFAULT_TIMEOUT_MS = DEFAULT_TIMEOUT * 1000
 
 _BACKGROUND_TASKS: set[asyncio.Task] = set()
 
@@ -107,7 +109,7 @@ class DashboardImportDiscovery:
         self, zeroconf: Zeroconf, info: AsyncServiceInfo, service_type: str, name: str
     ) -> None:
         """Process a service info."""
-        if await info.async_request(zeroconf, timeout=3000):
+        if await info.async_request(zeroconf, timeout=DEFAULT_TIMEOUT_MS):
             self._process_service_info(name, info)
 
     def _process_service_info(self, name: str, info: ServiceInfo) -> None:
@@ -164,7 +166,9 @@ class DashboardImportDiscovery:
 
 
 class EsphomeZeroconf(Zeroconf):
-    def resolve_host(self, host: str, timeout: float = 3.0) -> list[str] | None:
+    def resolve_host(
+        self, host: str, timeout: float = DEFAULT_TIMEOUT
+    ) -> list[str] | None:
         """Resolve a host name to an IP address."""
         info = AddressResolver(f"{host.partition('.')[0]}.local.")
         if (
@@ -177,7 +181,7 @@ class EsphomeZeroconf(Zeroconf):
 
 class AsyncEsphomeZeroconf(AsyncZeroconf):
     async def async_resolve_host(
-        self, host: str, timeout: float = 3.0
+        self, host: str, timeout: float = DEFAULT_TIMEOUT
     ) -> list[str] | None:
         """Resolve a host name to an IP address."""
         info = AddressResolver(f"{host.partition('.')[0]}.local.")


### PR DESCRIPTION

# What does this implement/fix?

This is effectively the same change as https://github.com/home-assistant/core/pull/143541

Note that aioesphomeapi uses 30s which is likely overkill but 3s was far too low for a low power device to respond in time.


## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
