### PR TITLE
[esp32_ble_server] Add appearance advertising field

### DIFF
--- a/esphome/components/esp32_ble/ble.cpp
+++ b/esphome/components/esp32_ble/ble.cpp
@@ -110,6 +110,7 @@ void ESP32BLE::advertising_init_() {
 
   this->advertising_->set_scan_response(true);
   this->advertising_->set_min_preferred_interval(0x06);
+  this->advertising_->set_appearance(this->appearance_);
 }
 
 bool ESP32BLE::ble_setup_() {

--- a/esphome/components/esp32_ble/ble.h
+++ b/esphome/components/esp32_ble/ble.h
@@ -95,6 +95,7 @@ class ESP32BLE : public Component {
   void advertising_start();
   void advertising_set_service_data(const std::vector<uint8_t> &data);
   void advertising_set_manufacturer_data(const std::vector<uint8_t> &data);
+  void advertising_set_appearance(uint16_t appearance) { this->appearance_ = appearance; }
   void advertising_add_service_uuid(ESPBTUUID uuid);
   void advertising_remove_service_uuid(ESPBTUUID uuid);
   void advertising_register_raw_advertisement_callback(std::function<void(bool)> &&callback);
@@ -128,11 +129,12 @@ class ESP32BLE : public Component {
   BLEComponentState state_{BLE_COMPONENT_STATE_OFF};
 
   Queue<BLEEvent> ble_events_;
-  BLEAdvertising *advertising_;
+  BLEAdvertising *advertising_{};
   esp_ble_io_cap_t io_cap_{ESP_IO_CAP_NONE};
-  uint32_t advertising_cycle_time_;
-  bool enable_on_boot_;
+  uint32_t advertising_cycle_time_{};
+  bool enable_on_boot_{};
   optional<std::string> name_;
+  uint16_t appearance_{0};
 };
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)

--- a/esphome/components/esp32_ble/ble_advertising.h
+++ b/esphome/components/esp32_ble/ble_advertising.h
@@ -32,6 +32,7 @@ class BLEAdvertising {
   void set_scan_response(bool scan_response) { this->scan_response_ = scan_response; }
   void set_min_preferred_interval(uint16_t interval) { this->advertising_data_.min_interval = interval; }
   void set_manufacturer_data(const std::vector<uint8_t> &data);
+  void set_appearance(uint16_t appearance) { this->advertising_data_.appearance = appearance; }
   void set_service_data(const std::vector<uint8_t> &data);
   void register_raw_advertisement_callback(std::function<void(bool)> &&callback);
 

--- a/esphome/components/esp32_ble_server/__init__.py
+++ b/esphome/components/esp32_ble_server/__init__.py
@@ -32,6 +32,7 @@ DEPENDENCIES = ["esp32"]
 DOMAIN = "esp32_ble_server"
 
 CONF_ADVERTISE = "advertise"
+CONF_APPEARANCE = "appearance"
 CONF_BROADCAST = "broadcast"
 CONF_CHARACTERISTICS = "characteristics"
 CONF_DESCRIPTION = "description"
@@ -421,6 +422,7 @@ CONFIG_SCHEMA = cv.Schema(
         cv.GenerateID(): cv.declare_id(BLEServer),
         cv.GenerateID(esp32_ble.CONF_BLE_ID): cv.use_id(esp32_ble.ESP32BLE),
         cv.Optional(CONF_MANUFACTURER): value_schema("string", templatable=False),
+        cv.Optional(CONF_APPEARANCE, default=0): cv.uint16_t,
         cv.Optional(CONF_MODEL): value_schema("string", templatable=False),
         cv.Optional(CONF_FIRMWARE_VERSION): value_schema("string", templatable=False),
         cv.Optional(CONF_MANUFACTURER_DATA): cv.Schema([cv.uint8_t]),
@@ -531,6 +533,7 @@ async def to_code(config):
     cg.add(parent.register_gatts_event_handler(var))
     cg.add(parent.register_ble_status_event_handler(var))
     cg.add(var.set_parent(parent))
+    cg.add(parent.advertising_set_appearance(config[CONF_APPEARANCE]))
     if CONF_MANUFACTURER_DATA in config:
         cg.add(var.set_manufacturer_data(config[CONF_MANUFACTURER_DATA]))
     for service_config in config[CONF_SERVICES]:

--- a/tests/components/esp32_ble_server/common.yaml
+++ b/tests/components/esp32_ble_server/common.yaml
@@ -2,6 +2,7 @@ esp32_ble_server:
   id: ble_server
   manufacturer_data: [0x72, 0x4, 0x00, 0x23]
   manufacturer: ESPHome
+  appearance: 0x1
   model: Test
   on_connect:
     - lambda: |-


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Allows configuration of the `appearance` advertising field.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/feature-requests/issues/3136

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#4871

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
esp32_ble_server:
  id: ble
  manufacturer_data: [0x72, 0x4, 0x00, 0x23]
  firmware_version: "1.1"
  appearance: 0xC0
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
