### PR TITLE
[lvgl] Add refresh action to re-evaluate initial widget properties

### DIFF
--- a/esphome/components/lvgl/__init__.py
+++ b/esphome/components/lvgl/__init__.py
@@ -243,8 +243,7 @@ def final_validation(configs):
         for w in refreshed_widgets:
             path = global_config.get_path_for_id(w)
             widget_conf = global_config.get_config_for_path(path[:-1])
-            config = {k: v for k, v in widget_conf.items() if isinstance(v, Lambda)}
-            if not config:
+            if not any(isinstance(v, Lambda) for v in widget_conf.values()):
                 raise cv.Invalid(
                     f"Widget '{w}'does not have any templated properties to refresh",
                 )

--- a/esphome/components/lvgl/__init__.py
+++ b/esphome/components/lvgl/__init__.py
@@ -18,13 +18,13 @@ from esphome.const import (
     CONF_TRIGGER_ID,
     CONF_TYPE,
 )
-from esphome.core import CORE, ID
+from esphome.core import CORE, ID, Lambda
 from esphome.cpp_generator import MockObj
 from esphome.final_validate import full_config
 from esphome.helpers import write_file_if_changed
 
 from . import defines as df, helpers, lv_validation as lvalid
-from .automation import disp_update, focused_widgets, update_to_code
+from .automation import disp_update, focused_widgets, refreshed_widgets, update_to_code
 from .defines import add_define
 from .encoders import (
     ENCODERS_CONFIG,
@@ -239,6 +239,14 @@ def final_validation(configs):
                 raise cv.Invalid(
                     "A non adjustable arc may not be focused",
                     path,
+                )
+        for w in refreshed_widgets:
+            path = global_config.get_path_for_id(w)
+            widget_conf = global_config.get_config_for_path(path[:-1])
+            config = {k: v for k, v in widget_conf.items() if isinstance(v, Lambda)}
+            if not config:
+                raise cv.Invalid(
+                    f"Widget '{w}'does not have any templated properties to refresh",
                 )
 
 

--- a/esphome/components/lvgl/__init__.py
+++ b/esphome/components/lvgl/__init__.py
@@ -245,7 +245,7 @@ def final_validation(configs):
             widget_conf = global_config.get_config_for_path(path[:-1])
             if not any(isinstance(v, Lambda) for v in widget_conf.values()):
                 raise cv.Invalid(
-                    f"Widget '{w}'does not have any templated properties to refresh",
+                    f"Widget '{w}' does not have any templated properties to refresh",
                 )
 
 

--- a/esphome/components/lvgl/automation.py
+++ b/esphome/components/lvgl/automation.py
@@ -36,11 +36,11 @@ from .lvcode import (
     lvgl_comp,
 )
 from .schemas import (
+    ALL_STYLES,
     DISP_BG_SCHEMA,
     LIST_ACTION_SCHEMA,
     LVGL_SCHEMA,
     base_update_schema,
-    id_list_schema,
 )
 from .types import (
     LV_STATE,
@@ -371,7 +371,7 @@ async def obj_update_to_code(config, action_id, template_arg, args):
 
 
 def validate_refresh_config(config):
-    for w in config[CONF_ID]:
+    for w in config:
         refreshed_widgets.add(w[CONF_ID])
     return config
 
@@ -379,16 +379,31 @@ def validate_refresh_config(config):
 @automation.register_action(
     "lvgl.widget.refresh",
     ObjUpdateAction,
-    cv.All(id_list_schema(lv_obj_t), validate_refresh_config),
+    cv.All(
+        cv.ensure_list(
+            cv.maybe_simple_value(
+                {
+                    cv.Required(CONF_ID): cv.use_id(lv_obj_t),
+                },
+                key=CONF_ID,
+            )
+        ),
+        validate_refresh_config,
+    ),
 )
 async def obj_refresh_to_code(config, action_id, template_arg, args):
-    widget = await get_widgets(config[CONF_ID])
+    widget = await get_widgets(config)
 
     async def do_refresh(widget: Widget):
-        # only update things that might have changed, i.e. are templated
+        # only update style properties that might have changed, i.e. are templated
         config = {k: v for k, v in widget.config.items() if isinstance(v, Lambda)}
         await set_obj_properties(widget, config)
-        await widget.type.to_code(widget, config)
+        # must pass full widget config here as some may be required, even if not templated.
+        # so first check if any non-style properties are templated, if not we can skip the update
+        config = {k: v for k, v in widget.config.items() if k not in ALL_STYLES}
+        if any(isinstance(v, Lambda) for v in config.values()):
+            await set_obj_properties(widget, config)
+        await widget.type.to_code(widget, widget.config)
         if (
             widget.type.w_type.value_property is not None
             and widget.type.w_type.value_property in config

--- a/esphome/components/lvgl/automation.py
+++ b/esphome/components/lvgl/automation.py
@@ -402,12 +402,11 @@ async def obj_refresh_to_code(config, action_id, template_arg, args):
         # so first check if any non-style properties are templated, if not we can skip the update
         config = {k: v for k, v in widget.config.items() if k not in ALL_STYLES}
         if any(isinstance(v, Lambda) for v in config.values()):
-            await set_obj_properties(widget, config)
-        await widget.type.to_code(widget, widget.config)
-        if (
-            widget.type.w_type.value_property is not None
-            and widget.type.w_type.value_property in config
-        ):
-            lv.event_send(widget.obj, UPDATE_EVENT, nullptr)
+            await widget.type.to_code(widget, widget.config)
+            if (
+                widget.type.w_type.value_property is not None
+                and widget.type.w_type.value_property in config
+            ):
+                lv.event_send(widget.obj, UPDATE_EVENT, nullptr)
 
     return await action_to_code(widget, do_refresh, action_id, template_arg, args)

--- a/esphome/components/lvgl/automation.py
+++ b/esphome/components/lvgl/automation.py
@@ -398,11 +398,11 @@ async def obj_refresh_to_code(config, action_id, template_arg, args):
         # only update style properties that might have changed, i.e. are templated
         config = {k: v for k, v in widget.config.items() if isinstance(v, Lambda)}
         await set_obj_properties(widget, config)
-        # must pass full widget config here as some may be required, even if not templated.
-        # so first check if any non-style properties are templated, if not we can skip the update
+        # must pass all widget-specific options here, even if not templated, but only do so if at least one is
+        # templated. First filter out common style properties.
         config = {k: v for k, v in widget.config.items() if k not in ALL_STYLES}
         if any(isinstance(v, Lambda) for v in config.values()):
-            await widget.type.to_code(widget, widget.config)
+            await widget.type.to_code(widget, config)
             if (
                 widget.type.w_type.value_property is not None
                 and widget.type.w_type.value_property in config

--- a/esphome/components/lvgl/automation.py
+++ b/esphome/components/lvgl/automation.py
@@ -35,7 +35,13 @@ from .lvcode import (
     lv_obj,
     lvgl_comp,
 )
-from .schemas import DISP_BG_SCHEMA, LIST_ACTION_SCHEMA, LVGL_SCHEMA, base_update_schema
+from .schemas import (
+    DISP_BG_SCHEMA,
+    LIST_ACTION_SCHEMA,
+    LVGL_SCHEMA,
+    base_update_schema,
+    id_list_schema,
+)
 from .types import (
     LV_STATE,
     LvglAction,
@@ -57,6 +63,7 @@ from .widgets import (
 
 # Record widgets that are used in a focused action here
 focused_widgets = set()
+refreshed_widgets = set()
 
 
 async def action_to_code(
@@ -361,3 +368,31 @@ async def obj_update_to_code(config, action_id, template_arg, args):
     return await action_to_code(
         widgets, do_update, action_id, template_arg, args, config
     )
+
+
+def validate_refresh_config(config):
+    for w in config[CONF_ID]:
+        refreshed_widgets.add(w[CONF_ID])
+    return config
+
+
+@automation.register_action(
+    "lvgl.widget.refresh",
+    ObjUpdateAction,
+    cv.All(id_list_schema(lv_obj_t), validate_refresh_config),
+)
+async def obj_refresh_to_code(config, action_id, template_arg, args):
+    widget = await get_widgets(config[CONF_ID])
+
+    async def do_refresh(widget: Widget):
+        # only update things that might have changed, i.e. are templated
+        config = {k: v for k, v in widget.config.items() if isinstance(v, Lambda)}
+        await set_obj_properties(widget, config)
+        await widget.type.to_code(widget, config)
+        if (
+            widget.type.w_type.value_property is not None
+            and widget.type.w_type.value_property in config
+        ):
+            lv.event_send(widget.obj, UPDATE_EVENT, nullptr)
+
+    return await action_to_code(widget, do_refresh, action_id, template_arg, args)

--- a/esphome/components/lvgl/schemas.py
+++ b/esphome/components/lvgl/schemas.py
@@ -281,21 +281,6 @@ def automation_schema(typ: LvType):
     )
 
 
-def id_list_schema(widget_type):
-    return cv.Schema(
-        {
-            cv.Optional(CONF_ID): cv.ensure_list(
-                cv.maybe_simple_value(
-                    {
-                        cv.Required(CONF_ID): cv.use_id(widget_type),
-                    },
-                    key=CONF_ID,
-                )
-            )
-        }
-    )
-
-
 def base_update_schema(widget_type, parts):
     """
     Create a schema for updating a widgets style properties, states and flags
@@ -303,7 +288,23 @@ def base_update_schema(widget_type, parts):
     :param parts:  The allowable parts to specify
     :return:
     """
-    return part_schema(parts).extend(id_list_schema(widget_type)).extend(FLAG_SCHEMA)
+    return (
+        part_schema(parts)
+        .extend(
+            {
+                cv.Required(CONF_ID): cv.ensure_list(
+                    cv.maybe_simple_value(
+                        {
+                            cv.Required(CONF_ID): cv.use_id(widget_type),
+                        },
+                        key=CONF_ID,
+                    )
+                ),
+                cv.Optional(CONF_STATE): SET_STATE_SCHEMA,
+            }
+        )
+        .extend(FLAG_SCHEMA)
+    )
 
 
 def create_modify_schema(widget_type):

--- a/esphome/components/lvgl/schemas.py
+++ b/esphome/components/lvgl/schemas.py
@@ -281,6 +281,21 @@ def automation_schema(typ: LvType):
     )
 
 
+def id_list_schema(widget_type):
+    return cv.Schema(
+        {
+            cv.Optional(CONF_ID): cv.ensure_list(
+                cv.maybe_simple_value(
+                    {
+                        cv.Required(CONF_ID): cv.use_id(widget_type),
+                    },
+                    key=CONF_ID,
+                )
+            )
+        }
+    )
+
+
 def base_update_schema(widget_type, parts):
     """
     Create a schema for updating a widgets style properties, states and flags
@@ -288,23 +303,7 @@ def base_update_schema(widget_type, parts):
     :param parts:  The allowable parts to specify
     :return:
     """
-    return (
-        part_schema(parts)
-        .extend(
-            {
-                cv.Required(CONF_ID): cv.ensure_list(
-                    cv.maybe_simple_value(
-                        {
-                            cv.Required(CONF_ID): cv.use_id(widget_type),
-                        },
-                        key=CONF_ID,
-                    )
-                ),
-                cv.Optional(CONF_STATE): SET_STATE_SCHEMA,
-            }
-        )
-        .extend(FLAG_SCHEMA)
-    )
+    return part_schema(parts).extend(id_list_schema(widget_type)).extend(FLAG_SCHEMA)
 
 
 def create_modify_schema(widget_type):

--- a/tests/components/lvgl/lvgl-package.yaml
+++ b/tests/components/lvgl/lvgl-package.yaml
@@ -203,7 +203,7 @@ lvgl:
         - animimg:
             height: 60
             id: anim_img
-            src: [cat_image, dog_image]
+            src: !lambda "return {dog_image, cat_image};"
             repeat_count: 10
             duration: 1s
             auto_start: true
@@ -215,6 +215,7 @@ lvgl:
                   id: anim_img
                   src: !lambda "return {dog_image, cat_image};"
                   duration: 2s
+              - lvgl.widget.refresh: anim_img
         - label:
             on_boot:
               lvgl.label.update:


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Allows a widget to be updated using templated properties specified in the widget definition, as an alternative to the
`lvgl.widget.update` action.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/feature-requests/issues/2489#issuecomment-2847178424

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#4876

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [x] host

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
