### PR TITLE
[as3935_i2c] Remove redundant includes

### DIFF
--- a/esphome/components/as3935_i2c/as3935_i2c.h
+++ b/esphome/components/as3935_i2c/as3935_i2c.h
@@ -1,10 +1,7 @@
 #pragma once
 
-#include "esphome/core/component.h"
 #include "esphome/components/as3935/as3935.h"
 #include "esphome/components/i2c/i2c.h"
-#include "esphome/components/sensor/sensor.h"
-#include "esphome/components/binary_sensor/binary_sensor.h"
 
 namespace esphome {
 namespace as3935_i2c {

--- a/tests/components/as3935_i2c/test.esp32-ard.yaml
+++ b/tests/components/as3935_i2c/test.esp32-ard.yaml
@@ -3,4 +3,9 @@ substitutions:
   sda_pin: GPIO17
   irq_pin: GPIO15
 
-<<: !include common.yaml
+packages:
+  as3935: !include common.yaml
+
+# Trigger issue: https://github.com/esphome/issues/issues/6990
+# Compile with no binary sensor results in error
+binary_sensor: !remove


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/issues/issues/6990

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
