### PR TITLE
[display] Fix Rect::inside

### DIFF
--- a/esphome/components/display/rect.cpp
+++ b/esphome/components/display/rect.cpp
@@ -69,21 +69,16 @@ bool Rect::inside(int16_t test_x, int16_t test_y, bool absolute) const {  // NOL
     return true;
   }
   if (absolute) {
-    return ((test_x >= this->x) && (test_x <= this->x2()) && (test_y >= this->y) && (test_y <= this->y2()));
-  } else {
-    return ((test_x >= 0) && (test_x <= this->w) && (test_y >= 0) && (test_y <= this->h));
+    return test_x >= this->x && test_x < this->x2() && test_y >= this->y && test_y < this->y2();
   }
+  return test_x >= 0 && test_x < this->w && test_y >= 0 && test_y < this->h;
 }
 
-bool Rect::inside(Rect rect, bool absolute) const {
+bool Rect::inside(Rect rect) const {
   if (!this->is_set() || !rect.is_set()) {
     return true;
   }
-  if (absolute) {
-    return ((rect.x <= this->x2()) && (rect.x2() >= this->x) && (rect.y <= this->y2()) && (rect.y2() >= this->y));
-  } else {
-    return ((rect.x <= this->w) && (rect.w >= 0) && (rect.y <= this->h) && (rect.h >= 0));
-  }
+  return this->x2() >= rect.x && this->x <= rect.x2() && this->y2() >= rect.y && this->y <= rect.y2();
 }
 
 void Rect::info(const std::string &prefix) {

--- a/esphome/components/display/rect.h
+++ b/esphome/components/display/rect.h
@@ -26,7 +26,7 @@ class Rect {
   void extend(Rect rect);
   void shrink(Rect rect);
 
-  bool inside(Rect rect, bool absolute = true) const;
+  bool inside(Rect rect) const;
   bool inside(int16_t test_x, int16_t test_y, bool absolute = true) const;
   bool equal(Rect rect) const;
   void info(const std::string &prefix = "rect info:");


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

The function `Rect::inside()` was incorrectly reporting true for a point on the right hand or bottom edge.

Also refactor the version that takes a Rect as argument; it's unclear what "inside" means if the absolute flag is not set, and that is not used in the codebase.

The non-absolute version for a point being inside a rect has been retained even though it's not used, because at at least the semantics there are reasonably clear - the rect origin is ignored.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/issues/issues/6972

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
