### PR TITLE
[gps] Add hdop sensor

### DIFF
--- a/esphome/components/gps/__init__.py
+++ b/esphome/components/gps/__init__.py
@@ -25,6 +25,7 @@ GPS = gps_ns.class_("GPS", cg.Component, uart.UARTDevice)
 GPSListener = gps_ns.class_("GPSListener")
 
 CONF_GPS_ID = "gps_id"
+CONF_HDOP = "hdop"
 MULTI_CONF = True
 CONFIG_SCHEMA = cv.All(
     cv.Schema(
@@ -40,7 +41,7 @@ CONFIG_SCHEMA = cv.All(
             ),
             cv.Optional(CONF_SPEED): sensor.sensor_schema(
                 unit_of_measurement=UNIT_KILOMETER_PER_HOUR,
-                accuracy_decimals=6,
+                accuracy_decimals=3,
             ),
             cv.Optional(CONF_COURSE): sensor.sensor_schema(
                 unit_of_measurement=UNIT_DEGREES,
@@ -48,10 +49,14 @@ CONFIG_SCHEMA = cv.All(
             ),
             cv.Optional(CONF_ALTITUDE): sensor.sensor_schema(
                 unit_of_measurement=UNIT_METER,
-                accuracy_decimals=1,
+                accuracy_decimals=2,
             ),
             cv.Optional(CONF_SATELLITES): sensor.sensor_schema(
                 accuracy_decimals=0,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ),
+            cv.Optional(CONF_HDOP): sensor.sensor_schema(
+                accuracy_decimals=3,
                 state_class=STATE_CLASS_MEASUREMENT,
             ),
         }
@@ -91,6 +96,10 @@ async def to_code(config):
     if CONF_SATELLITES in config:
         sens = await sensor.new_sensor(config[CONF_SATELLITES])
         cg.add(var.set_satellites_sensor(sens))
+
+    if CONF_HDOP in config:
+        sens = await sensor.new_sensor(config[CONF_HDOP])
+        cg.add(var.set_hdop_sensor(sens))
 
     # https://platformio.org/lib/show/1655/TinyGPSPlus
     cg.add_library("mikalhart/TinyGPSPlus", "1.0.2")

--- a/esphome/components/gps/__init__.py
+++ b/esphome/components/gps/__init__.py
@@ -25,6 +25,7 @@ GPS = gps_ns.class_("GPS", cg.Component, uart.UARTDevice)
 GPSListener = gps_ns.class_("GPSListener")
 
 CONF_GPS_ID = "gps_id"
+CONF_HDOP = "hdop"
 MULTI_CONF = True
 CONFIG_SCHEMA = cv.All(
     cv.Schema(
@@ -40,7 +41,7 @@ CONFIG_SCHEMA = cv.All(
             ),
             cv.Optional(CONF_SPEED): sensor.sensor_schema(
                 unit_of_measurement=UNIT_KILOMETER_PER_HOUR,
-                accuracy_decimals=6,
+                accuracy_decimals=2,
             ),
             cv.Optional(CONF_COURSE): sensor.sensor_schema(
                 unit_of_measurement=UNIT_DEGREES,
@@ -48,10 +49,14 @@ CONFIG_SCHEMA = cv.All(
             ),
             cv.Optional(CONF_ALTITUDE): sensor.sensor_schema(
                 unit_of_measurement=UNIT_METER,
-                accuracy_decimals=1,
+                accuracy_decimals=2,
             ),
             cv.Optional(CONF_SATELLITES): sensor.sensor_schema(
                 accuracy_decimals=0,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ),
+            cv.Optional(CONF_HDOP): sensor.sensor_schema(
+                accuracy_decimals=3,
                 state_class=STATE_CLASS_MEASUREMENT,
             ),
         }
@@ -91,6 +96,10 @@ async def to_code(config):
     if CONF_SATELLITES in config:
         sens = await sensor.new_sensor(config[CONF_SATELLITES])
         cg.add(var.set_satellites_sensor(sens))
+
+    if CONF_HDOP in config:
+        sens = await sensor.new_sensor(config[CONF_HDOP])
+        cg.add(var.set_hdop_sensor(sens))
 
     # https://platformio.org/lib/show/1655/TinyGPSPlus
     cg.add_library("mikalhart/TinyGPSPlus", "1.0.2")

--- a/esphome/components/gps/__init__.py
+++ b/esphome/components/gps/__init__.py
@@ -97,8 +97,8 @@ async def to_code(config):
         sens = await sensor.new_sensor(config[CONF_SATELLITES])
         cg.add(var.set_satellites_sensor(sens))
 
-    if CONF_HDOP in config:
-        sens = await sensor.new_sensor(config[CONF_HDOP])
+    if hdop_config := config.get(CONF_HDOP):
+        sens = await sensor.new_sensor(hdop_config)
         cg.add(var.set_hdop_sensor(sens))
 
     # https://platformio.org/lib/show/1655/TinyGPSPlus

--- a/esphome/components/gps/gps.cpp
+++ b/esphome/components/gps/gps.cpp
@@ -28,6 +28,9 @@ void GPS::update() {
 
   if (this->satellites_sensor_ != nullptr)
     this->satellites_sensor_->publish_state(this->satellites_);
+
+  if (this->hdop_sensor_ != nullptr)
+    this->hdop_sensor_->publish_state(this->hdop_);
 }
 
 void GPS::loop() {
@@ -44,23 +47,23 @@ void GPS::loop() {
 
       if (tiny_gps_.speed.isUpdated()) {
         this->speed_ = tiny_gps_.speed.kmph();
-        ESP_LOGD(TAG, "Speed:");
-        ESP_LOGD(TAG, "  %f km/h", this->speed_);
+        ESP_LOGD(TAG, "Speed: %.3f km/h", this->speed_);
       }
       if (tiny_gps_.course.isUpdated()) {
         this->course_ = tiny_gps_.course.deg();
-        ESP_LOGD(TAG, "Course:");
-        ESP_LOGD(TAG, "  %f °", this->course_);
+        ESP_LOGD(TAG, "Course: %.2f °", this->course_);
       }
       if (tiny_gps_.altitude.isUpdated()) {
         this->altitude_ = tiny_gps_.altitude.meters();
-        ESP_LOGD(TAG, "Altitude:");
-        ESP_LOGD(TAG, "  %f m", this->altitude_);
+        ESP_LOGD(TAG, "Altitude: %.2f m", this->altitude_);
       }
       if (tiny_gps_.satellites.isUpdated()) {
         this->satellites_ = tiny_gps_.satellites.value();
-        ESP_LOGD(TAG, "Satellites:");
-        ESP_LOGD(TAG, "  %d", this->satellites_);
+        ESP_LOGD(TAG, "Satellites: %d", this->satellites_);
+      }
+      if (tiny_gps_.hdop.isUpdated()) {
+        this->hdop_ = tiny_gps_.hdop.hdop();
+        ESP_LOGD(TAG, "HDOP: %.3f", this->hdop_);
       }
 
       for (auto *listener : this->listeners_)

--- a/esphome/components/gps/gps.cpp
+++ b/esphome/components/gps/gps.cpp
@@ -28,6 +28,9 @@ void GPS::update() {
 
   if (this->satellites_sensor_ != nullptr)
     this->satellites_sensor_->publish_state(this->satellites_);
+
+  if (this->hdop_sensor_ != nullptr)
+    this->hdop_sensor_->publish_state(this->hdop_);
 }
 
 void GPS::loop() {
@@ -37,30 +40,29 @@ void GPS::loop() {
         this->latitude_ = tiny_gps_.location.lat();
         this->longitude_ = tiny_gps_.location.lng();
 
-        ESP_LOGD(TAG, "Location:");
-        ESP_LOGD(TAG, "  Lat: %f", this->latitude_);
-        ESP_LOGD(TAG, "  Lon: %f", this->longitude_);
+        ESP_LOGD(TAG, "Lat: %f", this->latitude_);
+        ESP_LOGD(TAG, "Lon: %f", this->longitude_);
       }
 
       if (tiny_gps_.speed.isUpdated()) {
         this->speed_ = tiny_gps_.speed.kmph();
-        ESP_LOGD(TAG, "Speed:");
-        ESP_LOGD(TAG, "  %f km/h", this->speed_);
+        ESP_LOGD(TAG, "Speed: %.2f km/h", this->speed_);
       }
       if (tiny_gps_.course.isUpdated()) {
         this->course_ = tiny_gps_.course.deg();
-        ESP_LOGD(TAG, "Course:");
-        ESP_LOGD(TAG, "  %f °", this->course_);
+        ESP_LOGD(TAG, "Course: %.2f °", this->course_);
       }
       if (tiny_gps_.altitude.isUpdated()) {
         this->altitude_ = tiny_gps_.altitude.meters();
-        ESP_LOGD(TAG, "Altitude:");
-        ESP_LOGD(TAG, "  %f m", this->altitude_);
+        ESP_LOGD(TAG, "Altitude: %.2f m", this->altitude_);
       }
       if (tiny_gps_.satellites.isUpdated()) {
         this->satellites_ = tiny_gps_.satellites.value();
-        ESP_LOGD(TAG, "Satellites:");
-        ESP_LOGD(TAG, "  %d", this->satellites_);
+        ESP_LOGD(TAG, "Satellites: %d", this->satellites_);
+      }
+      if (tiny_gps_.hdop.isUpdated()) {
+        this->hdop_ = tiny_gps_.hdop.hdop();
+        ESP_LOGD(TAG, "HDOP: %.3f", this->hdop_);
       }
 
       for (auto *listener : this->listeners_)

--- a/esphome/components/gps/gps.h
+++ b/esphome/components/gps/gps.h
@@ -33,6 +33,7 @@ class GPS : public PollingComponent, public uart::UARTDevice {
   void set_course_sensor(sensor::Sensor *course_sensor) { course_sensor_ = course_sensor; }
   void set_altitude_sensor(sensor::Sensor *altitude_sensor) { altitude_sensor_ = altitude_sensor; }
   void set_satellites_sensor(sensor::Sensor *satellites_sensor) { satellites_sensor_ = satellites_sensor; }
+  void set_hdop_sensor(sensor::Sensor *hdop_sensor) { hdop_sensor_ = hdop_sensor; }
 
   void register_listener(GPSListener *listener) {
     listener->parent_ = this;
@@ -46,12 +47,13 @@ class GPS : public PollingComponent, public uart::UARTDevice {
   TinyGPSPlus &get_tiny_gps() { return this->tiny_gps_; }
 
  protected:
-  float latitude_ = -1;
-  float longitude_ = -1;
-  float speed_ = -1;
-  float course_ = -1;
-  float altitude_ = -1;
-  int satellites_ = -1;
+  float latitude_ = NAN;
+  float longitude_ = NAN;
+  float speed_ = NAN;
+  float course_ = NAN;
+  float altitude_ = NAN;
+  int satellites_ = 0;
+  double hdop_ = NAN;
 
   sensor::Sensor *latitude_sensor_{nullptr};
   sensor::Sensor *longitude_sensor_{nullptr};
@@ -59,6 +61,7 @@ class GPS : public PollingComponent, public uart::UARTDevice {
   sensor::Sensor *course_sensor_{nullptr};
   sensor::Sensor *altitude_sensor_{nullptr};
   sensor::Sensor *satellites_sensor_{nullptr};
+  sensor::Sensor *hdop_sensor_{nullptr};
 
   bool has_time_{false};
   TinyGPSPlus tiny_gps_;


### PR DESCRIPTION
# What does this implement/fix?
TinyGPSPlus in currently used version 1.0.2 supports reading HDOP (Horizontal Dilution Of Precision).
However the current `gps` component does not define a sensor for it.
This add `hdop` as an additional sensor for `gps`.
Additional changes
- Change debug logs to 1 line per value instead of 2
- Change defaults from -1 to NAN, satellites defaults to 0

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/feature-requests/issues/3140

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#4882

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
  hdop:
    name: "HDOP"
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in https://github.com/esphome/esphome-docs/pull/4879

## Tested with
1. Heltec HTIT Tracker (https://heltec.org/project/wireless-tracker) and its onboard UC6580 GNSS chipset
2. Same Heltec, but with external u-blox NEO-F10N (https://www.sparkfun.com/sparkfun-gnss-l1-l5-breakout-neo-f10n-sma.html)