### PR TITLE
unify lowercase `x` in hexadecimal values

### DIFF
--- a/esphome/components/as7341/as7341.h
+++ b/esphome/components/as7341/as7341.h
@@ -7,7 +7,7 @@
 namespace esphome {
 namespace as7341 {
 
-static const uint8_t AS7341_CHIP_ID = 0X09;
+static const uint8_t AS7341_CHIP_ID = 0x09;
 
 static const uint8_t AS7341_CONFIG = 0x70;
 static const uint8_t AS7341_LED = 0x74;

--- a/esphome/components/bl0906/constants.h
+++ b/esphome/components/bl0906/constants.h
@@ -45,7 +45,7 @@ static const uint8_t BL0906_WRITE_COMMAND = 0xCA;
 static const uint8_t BL0906_V_RMS = 0x16;
 
 // Total power
-static const uint8_t BL0906_WATT_SUM = 0X2C;
+static const uint8_t BL0906_WATT_SUM = 0x2C;
 
 // Current1~6
 static const uint8_t BL0906_I_1_RMS = 0x0D;  // current_1
@@ -56,29 +56,29 @@ static const uint8_t BL0906_I_5_RMS = 0x13;
 static const uint8_t BL0906_I_6_RMS = 0x14;  // current_6
 
 // Power1~6
-static const uint8_t BL0906_WATT_1 = 0X23;  // power_1
-static const uint8_t BL0906_WATT_2 = 0X24;
-static const uint8_t BL0906_WATT_3 = 0X25;
-static const uint8_t BL0906_WATT_4 = 0X26;
-static const uint8_t BL0906_WATT_5 = 0X29;
-static const uint8_t BL0906_WATT_6 = 0X2A;  // power_6
+static const uint8_t BL0906_WATT_1 = 0x23;  // power_1
+static const uint8_t BL0906_WATT_2 = 0x24;
+static const uint8_t BL0906_WATT_3 = 0x25;
+static const uint8_t BL0906_WATT_4 = 0x26;
+static const uint8_t BL0906_WATT_5 = 0x29;
+static const uint8_t BL0906_WATT_6 = 0x2A;  // power_6
 
 // Active pulse count, unsigned
-static const uint8_t BL0906_CF_1_CNT = 0X30;  // Channel_1
-static const uint8_t BL0906_CF_2_CNT = 0X31;
-static const uint8_t BL0906_CF_3_CNT = 0X32;
-static const uint8_t BL0906_CF_4_CNT = 0X33;
-static const uint8_t BL0906_CF_5_CNT = 0X36;
-static const uint8_t BL0906_CF_6_CNT = 0X37;  // Channel_6
+static const uint8_t BL0906_CF_1_CNT = 0x30;  // Channel_1
+static const uint8_t BL0906_CF_2_CNT = 0x31;
+static const uint8_t BL0906_CF_3_CNT = 0x32;
+static const uint8_t BL0906_CF_4_CNT = 0x33;
+static const uint8_t BL0906_CF_5_CNT = 0x36;
+static const uint8_t BL0906_CF_6_CNT = 0x37;  // Channel_6
 
 // Total active pulse count, unsigned
-static const uint8_t BL0906_CF_SUM_CNT = 0X39;
+static const uint8_t BL0906_CF_SUM_CNT = 0x39;
 
 // Voltage frequency cycle
-static const uint8_t BL0906_FREQUENCY = 0X4E;
+static const uint8_t BL0906_FREQUENCY = 0x4E;
 
 // Internal temperature
-static const uint8_t BL0906_TEMPERATURE = 0X5E;
+static const uint8_t BL0906_TEMPERATURE = 0x5E;
 
 // Calibration register
 // RMS gain adjustment register

--- a/esphome/components/climate_ir_lg/climate_ir_lg.cpp
+++ b/esphome/components/climate_ir_lg/climate_ir_lg.cpp
@@ -32,7 +32,7 @@ const uint32_t FAN_MAX = 0x40;
 
 // Temperature
 const uint8_t TEMP_RANGE = TEMP_MAX - TEMP_MIN + 1;
-const uint32_t TEMP_MASK = 0XF00;
+const uint32_t TEMP_MASK = 0xF00;
 const uint32_t TEMP_SHIFT = 8;
 
 const uint16_t BITS = 28;

--- a/esphome/components/hm3301/hm3301.h
+++ b/esphome/components/hm3301/hm3301.h
@@ -8,7 +8,7 @@
 namespace esphome {
 namespace hm3301 {
 
-static const uint8_t SELECT_COMM_CMD = 0X88;
+static const uint8_t SELECT_COMM_CMD = 0x88;
 
 class HM3301Component : public PollingComponent, public i2c::I2CDevice {
  public:

--- a/esphome/components/ili9xxx/ili9xxx_init.h
+++ b/esphome/components/ili9xxx/ili9xxx_init.h
@@ -388,7 +388,7 @@ static const uint8_t PROGMEM INITCMD_GC9D01N[] = {
   0x8D, 1, 0xFF,
   0x8E, 1, 0xFF,
   0x8F, 1, 0xFF,
-  0X3A, 1, 0x05,    // COLMOD: Pixel Format Set (3Ah) MCU interface, 16 bits / pixel
+  0x3A, 1, 0x05,    // COLMOD: Pixel Format Set (3Ah) MCU interface, 16 bits / pixel
   0xEC, 1, 0x01,    // Inversion (ECh) DINV=1+2H1V column for Dual Gate (BFh=0)
                     // According to datasheet Inversion (ECh) value 0x01 isn't valid, but Lilygo uses it everywhere
   0x74, 7, 0x02, 0x0E, 0x00, 0x00, 0x00, 0x00, 0x00,

--- a/esphome/components/ld2410/ld2410.h
+++ b/esphome/components/ld2410/ld2410.h
@@ -129,7 +129,7 @@ enum PeriodicDataStructure : uint8_t {
   LIGHT_SENSOR = 37,
   OUT_PIN_SENSOR = 38,
 };
-enum PeriodicDataValue : uint8_t { HEAD = 0XAA, END = 0x55, CHECK = 0x00 };
+enum PeriodicDataValue : uint8_t { HEAD = 0xAA, END = 0x55, CHECK = 0x00 };
 
 enum AckDataStructure : uint8_t { COMMAND = 6, COMMAND_STATUS = 7 };
 

--- a/esphome/components/ld2450/ld2450.h
+++ b/esphome/components/ld2450/ld2450.h
@@ -105,7 +105,7 @@ enum PeriodicDataStructure : uint8_t {
   TARGET_RESOLUTION = 10,
 };
 
-enum PeriodicDataValue : uint8_t { HEAD = 0XAA, END = 0x55, CHECK = 0x00 };
+enum PeriodicDataValue : uint8_t { HEAD = 0xAA, END = 0x55, CHECK = 0x00 };
 
 enum AckDataStructure : uint8_t { COMMAND = 6, COMMAND_STATUS = 7 };
 

--- a/esphome/components/mitsubishi/mitsubishi.cpp
+++ b/esphome/components/mitsubishi/mitsubishi.cpp
@@ -25,8 +25,8 @@ const uint8_t MITSUBISHI_FAN_AUTO = 0x00;
 
 const uint8_t MITSUBISHI_VERTICAL_VANE_SWING = 0x38;
 
-// const uint8_t MITSUBISHI_AUTO = 0X80;
-const uint8_t MITSUBISHI_OTHERWISE = 0X40;
+// const uint8_t MITSUBISHI_AUTO = 0x80;
+const uint8_t MITSUBISHI_OTHERWISE = 0x40;
 const uint8_t MITSUBISHI_POWERFUL = 0x08;
 
 // Optional presets used to enable some model features
@@ -42,13 +42,13 @@ const uint16_t MITSUBISHI_HEADER_SPACE = 1700;
 const uint16_t MITSUBISHI_MIN_GAP = 17500;
 
 // Marker bytes
-const uint8_t MITSUBISHI_BYTE00 = 0X23;
-const uint8_t MITSUBISHI_BYTE01 = 0XCB;
-const uint8_t MITSUBISHI_BYTE02 = 0X26;
-const uint8_t MITSUBISHI_BYTE03 = 0X01;
-const uint8_t MITSUBISHI_BYTE04 = 0X00;
-const uint8_t MITSUBISHI_BYTE13 = 0X00;
-const uint8_t MITSUBISHI_BYTE16 = 0X00;
+const uint8_t MITSUBISHI_BYTE00 = 0x23;
+const uint8_t MITSUBISHI_BYTE01 = 0xCB;
+const uint8_t MITSUBISHI_BYTE02 = 0x26;
+const uint8_t MITSUBISHI_BYTE03 = 0x01;
+const uint8_t MITSUBISHI_BYTE04 = 0x00;
+const uint8_t MITSUBISHI_BYTE13 = 0x00;
+const uint8_t MITSUBISHI_BYTE16 = 0x00;
 
 climate::ClimateTraits MitsubishiClimate::traits() {
   auto traits = climate::ClimateTraits();

--- a/esphome/components/pn7150/pn7150.h
+++ b/esphome/components/pn7150/pn7150.h
@@ -123,8 +123,8 @@ enum class NCIState : uint8_t {
   RFST_POLL_ACTIVE,
   EP_DEACTIVATING,
   EP_SELECTING,
-  TEST = 0XFE,
-  FAILED = 0XFF,
+  TEST = 0xFE,
+  FAILED = 0xFF,
 };
 
 enum class TestMode : uint8_t {

--- a/esphome/components/pn7160/pn7160.h
+++ b/esphome/components/pn7160/pn7160.h
@@ -138,8 +138,8 @@ enum class NCIState : uint8_t {
   RFST_POLL_ACTIVE,
   EP_DEACTIVATING,
   EP_SELECTING,
-  TEST = 0XFE,
-  FAILED = 0XFF,
+  TEST = 0xFE,
+  FAILED = 0xFF,
 };
 
 enum class TestMode : uint8_t {

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -1004,7 +1004,7 @@ void WaveshareEPaper1P54InBV2::initialize() {
 
   this->command(0x4E);  // set RAM x address count to 0;
   this->data(0x00);
-  this->command(0x4F);  // set RAM y address count to 0X199;
+  this->command(0x4F);  // set RAM y address count to 0x199;
   this->data(0xC7);
   this->data(0x00);
 
@@ -1878,7 +1878,7 @@ void GDEY029T94::initialize() {
 
   this->command(0x4E);  // set RAM x address count to 0;
   this->data(0x00);
-  this->command(0x4F);  // set RAM y address count to 0X199;
+  this->command(0x4F);  // set RAM y address count to 0x199;
   this->command(0x00);
   this->command(0x00);
   this->wait_until_idle_();
@@ -2070,7 +2070,7 @@ void GDEW029T5::init_full_() {
   this->init_display_();
   this->command(0x82);  // vcom_DC setting
   this->data(0x08);
-  this->command(0X50);  // VCOM AND DATA INTERVAL SETTING
+  this->command(0x50);  // VCOM AND DATA INTERVAL SETTING
   this->data(0x97);     // WBmode:VBDF 17|D7 VBDW 97 VBDB 57   WBRmode:VBDF F7 VBDW 77 VBDB 37  VBDR B7
   this->command(0x20);
   this->write_lut_(LUT_20_VCOMDC_29_5, sizeof(LUT_20_VCOMDC_29_5));
@@ -2090,7 +2090,7 @@ void GDEW029T5::init_partial_() {
   this->init_display_();
   this->command(0x82);  // vcom_DC setting
   this->data(0x08);
-  this->command(0X50);  // VCOM AND DATA INTERVAL SETTING
+  this->command(0x50);  // VCOM AND DATA INTERVAL SETTING
   this->data(0x17);     // WBmode:VBDF 17|D7 VBDW 97 VBDB 57   WBRmode:VBDF F7 VBDW 77 VBDB 37  VBDR B7
   this->command(0x20);
   this->write_lut_(LUT_20_VCOMDC_PARTIAL_29_5, sizeof(LUT_20_VCOMDC_PARTIAL_29_5));
@@ -4481,10 +4481,10 @@ void WaveshareEPaper7P5InHDB::initialize() {
   this->data(0x01);     // LUT1, for white
 
   this->command(0x18);
-  this->data(0X80);
+  this->data(0x80);
 
   this->command(0x22);
-  this->data(0XB1);  // Load Temperature and waveform setting.
+  this->data(0xB1);  // Load Temperature and waveform setting.
 
   this->command(0x20);
 

--- a/esphome/components/xpt2046/touchscreen/xpt2046.cpp
+++ b/esphome/components/xpt2046/touchscreen/xpt2046.cpp
@@ -32,7 +32,7 @@ void XPT2046Component::update_touches() {
 
   int16_t touch_pressure_1 = this->read_adc_(0xB1 /* touch_pressure_1 */);
   int16_t touch_pressure_2 = this->read_adc_(0xC1 /* touch_pressure_2 */);
-  z_raw = touch_pressure_1 + 0Xfff - touch_pressure_2;
+  z_raw = touch_pressure_1 + 0xfff - touch_pressure_2;
   ESP_LOGVV(TAG, "Touchscreen Update z = %d", z_raw);
   touch = (z_raw >= this->threshold_);
   if (touch) {


### PR DESCRIPTION
# What does this implement/fix?

unify lowercase `x` in hexadecimal values

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
