### PR TITLE
[packages] Allow list instead of dict for packages

### DIFF
--- a/esphome/components/packages/__init__.py
+++ b/esphome/components/packages/__init__.py
@@ -25,21 +25,9 @@ DOMAIN = CONF_PACKAGES
 
 def validate_git_package(config: dict):
     new_config = config
-    for key, conf in config.items():
-        if CONF_URL in conf:
-            try:
-                conf = BASE_SCHEMA(conf)
-                if CONF_FILE in conf:
-                    new_config[key][CONF_FILES] = [conf[CONF_FILE]]
-                    del new_config[key][CONF_FILE]
-            except cv.MultipleInvalid as e:
-                with cv.prepend_path([key]):
-                    raise e
-            except cv.Invalid as e:
-                raise cv.Invalid(
-                    "Extra keys not allowed in git based package",
-                    path=[key] + e.path,
-                ) from e
+    if CONF_FILE in config:
+        new_config[CONF_FILES] = [config[CONF_FILE]]
+        del new_config[CONF_FILE]
     return new_config
 
 
@@ -74,8 +62,8 @@ BASE_SCHEMA = cv.All(
             cv.Required(CONF_URL): cv.url,
             cv.Optional(CONF_USERNAME): cv.string,
             cv.Optional(CONF_PASSWORD): cv.string,
-            cv.Exclusive(CONF_FILE, "files"): validate_yaml_filename,
-            cv.Exclusive(CONF_FILES, "files"): cv.All(
+            cv.Exclusive(CONF_FILE, CONF_FILES): validate_yaml_filename,
+            cv.Exclusive(CONF_FILES, CONF_FILES): cv.All(
                 cv.ensure_list(
                     cv.Any(
                         validate_yaml_filename,
@@ -98,16 +86,18 @@ BASE_SCHEMA = cv.All(
         }
     ),
     cv.has_at_least_one_key(CONF_FILE, CONF_FILES),
+    validate_git_package,
 )
 
+PACKAGE_SCHEMA = cv.Any(validate_source_shorthand, BASE_SCHEMA, dict)
 
-CONFIG_SCHEMA = cv.All(
+CONFIG_SCHEMA = cv.Any(
     cv.Schema(
         {
-            str: cv.Any(validate_source_shorthand, BASE_SCHEMA, dict),
+            str: PACKAGE_SCHEMA,
         }
     ),
-    validate_git_package,
+    cv.ensure_list(PACKAGE_SCHEMA),
 )
 
 
@@ -189,19 +179,27 @@ def do_packages_pass(config: dict):
     packages = config[CONF_PACKAGES]
     with cv.prepend_path(CONF_PACKAGES):
         packages = CONFIG_SCHEMA(packages)
-        if not isinstance(packages, dict):
-            raise cv.Invalid(
-                f"Packages must be a key to value mapping, got {type(packages)} instead"
-            )
-
-        for package_name, package_config in reversed(packages.items()):
-            with cv.prepend_path(package_name):
+        if isinstance(packages, dict):
+            for package_name, package_config in reversed(packages.items()):
+                with cv.prepend_path(package_name):
+                    recursive_package = package_config
+                    if CONF_URL in package_config:
+                        package_config = _process_base_package(package_config)
+                    if isinstance(package_config, dict):
+                        recursive_package = do_packages_pass(package_config)
+                    config = merge_config(recursive_package, config)
+        elif isinstance(packages, list):
+            for package_config in reversed(packages):
                 recursive_package = package_config
                 if CONF_URL in package_config:
                     package_config = _process_base_package(package_config)
                 if isinstance(package_config, dict):
                     recursive_package = do_packages_pass(package_config)
                 config = merge_config(recursive_package, config)
+        else:
+            raise cv.Invalid(
+                f"Packages must be a key to value mapping or list, got {type(packages)} instead"
+            )
 
         del config[CONF_PACKAGES]
     return config

--- a/esphome/components/packages/__init__.py
+++ b/esphome/components/packages/__init__.py
@@ -24,6 +24,9 @@ DOMAIN = CONF_PACKAGES
 
 
 def validate_git_package(config: dict):
+    if CONF_URL not in config:
+        return config
+    config = BASE_SCHEMA(config)
     new_config = config
     if CONF_FILE in config:
         new_config[CONF_FILES] = [config[CONF_FILE]]
@@ -86,10 +89,11 @@ BASE_SCHEMA = cv.All(
         }
     ),
     cv.has_at_least_one_key(CONF_FILE, CONF_FILES),
-    validate_git_package,
 )
 
-PACKAGE_SCHEMA = cv.Any(validate_source_shorthand, BASE_SCHEMA, dict)
+PACKAGE_SCHEMA = cv.All(
+    cv.Any(validate_source_shorthand, BASE_SCHEMA, dict), validate_git_package
+)
 
 CONFIG_SCHEMA = cv.Any(
     cv.Schema(
@@ -173,6 +177,16 @@ def _process_base_package(config: dict) -> dict:
     return {"packages": packages}
 
 
+def _process_package(package_config, config):
+    recursive_package = package_config
+    if CONF_URL in package_config:
+        package_config = _process_base_package(package_config)
+    if isinstance(package_config, dict):
+        recursive_package = do_packages_pass(package_config)
+    config = merge_config(recursive_package, config)
+    return config
+
+
 def do_packages_pass(config: dict):
     if CONF_PACKAGES not in config:
         return config
@@ -182,20 +196,10 @@ def do_packages_pass(config: dict):
         if isinstance(packages, dict):
             for package_name, package_config in reversed(packages.items()):
                 with cv.prepend_path(package_name):
-                    recursive_package = package_config
-                    if CONF_URL in package_config:
-                        package_config = _process_base_package(package_config)
-                    if isinstance(package_config, dict):
-                        recursive_package = do_packages_pass(package_config)
-                    config = merge_config(recursive_package, config)
+                    config = _process_package(package_config, config)
         elif isinstance(packages, list):
             for package_config in reversed(packages):
-                recursive_package = package_config
-                if CONF_URL in package_config:
-                    package_config = _process_base_package(package_config)
-                if isinstance(package_config, dict):
-                    recursive_package = do_packages_pass(package_config)
-                config = merge_config(recursive_package, config)
+                config = _process_package(package_config, config)
         else:
             raise cv.Invalid(
                 f"Packages must be a key to value mapping or list, got {type(packages)} instead"

--- a/tests/component_tests/packages/test_packages.py
+++ b/tests/component_tests/packages/test_packages.py
@@ -7,7 +7,6 @@ import pytest
 
 from esphome.components.packages import do_packages_pass
 from esphome.config_helpers import Extend, Remove
-import esphome.config_validation as cv
 from esphome.const import (
     CONF_DEFAULTS,
     CONF_DOMAIN,
@@ -72,17 +71,6 @@ def test_package_unused(basic_esphome, basic_wifi):
 
     actual = do_packages_pass(config)
     assert actual == config
-
-
-def test_package_invalid_dict(basic_esphome, basic_wifi):
-    """
-    Ensures an error is raised if packages is not valid.
-
-    """
-    config = {CONF_ESPHOME: basic_esphome, CONF_PACKAGES: basic_wifi}
-
-    with pytest.raises(cv.Invalid):
-        do_packages_pass(config)
 
 
 def test_package_include(basic_wifi, basic_esphome):

--- a/tests/component_tests/packages/test_packages.py
+++ b/tests/component_tests/packages/test_packages.py
@@ -7,6 +7,7 @@ import pytest
 
 from esphome.components.packages import do_packages_pass
 from esphome.config_helpers import Extend, Remove
+import esphome.config_validation as cv
 from esphome.const import (
     CONF_DEFAULTS,
     CONF_DOMAIN,
@@ -71,6 +72,18 @@ def test_package_unused(basic_esphome, basic_wifi):
 
     actual = do_packages_pass(config)
     assert actual == config
+
+
+def test_package_invalid_dict(basic_esphome, basic_wifi):
+    """
+    If a url: key is present, it's expected to be well-formed remote package spec. Ensure an error is raised if not.
+    Any other simple dict passed as a package will be merged as usual but may fail later validation.
+
+    """
+    config = {CONF_ESPHOME: basic_esphome, CONF_PACKAGES: basic_wifi | {CONF_URL: ""}}
+
+    with pytest.raises(cv.Invalid):
+        do_packages_pass(config)
 
 
 def test_package_include(basic_wifi, basic_esphome):

--- a/tests/components/packages/package.yaml
+++ b/tests/components/packages/package.yaml
@@ -1,0 +1,3 @@
+sensor:
+  - platform: template
+    id: package_sensor

--- a/tests/components/packages/test.esp32-ard.yaml
+++ b/tests/components/packages/test.esp32-ard.yaml
@@ -1,0 +1,11 @@
+packages:
+  - sensor:
+      - platform: template
+        id: inline_sensor
+  - !include package.yaml
+  - github://esphome/esphome/tests/components/template/common.yaml@dev
+  - url: https://github.com/esphome/esphome
+    file: tests/components/binary_sensor_map/common.yaml
+    ref: dev
+    refresh: 1d
+

--- a/tests/components/packages/test.esp32-idf.yaml
+++ b/tests/components/packages/test.esp32-idf.yaml
@@ -1,0 +1,13 @@
+packages:
+  sensor:
+    sensor:
+      - platform: template
+        id: inline_sensor
+  local: !include package.yaml
+  shorthand: github://esphome/esphome/tests/components/template/common.yaml@dev
+  github:
+    url: https://github.com/esphome/esphome
+    file: tests/components/binary_sensor_map/common.yaml
+    ref: dev
+    refresh: 1d
+


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

The current implementation of `packages:` requires a mapping for the list of packages, but the keys in the mapping
aren't actually used for anything.

As an alternative simply allow a list.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#4883
## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [x] host

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

packages:
  - github://clydebarrow/sample-configs/lvgl-package.yaml@main
  - !include common.yaml
  - url: https://github.com/clydebarrow/sample-configs
    file: lvgl-package.yaml
    ref: main  # optional
    refresh: 1d  # optional

# or a simple case:

packages: !include common.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
