### PR TITLE
Pulse Counter Sensor: Changed total pulse count to allow negative numbers

### DIFF
--- a/esphome/components/pulse_counter/automation.h
+++ b/esphome/components/pulse_counter/automation.h
@@ -12,7 +12,7 @@ template<typename... Ts> class SetTotalPulsesAction : public Action<Ts...> {
  public:
   SetTotalPulsesAction(PulseCounterSensor *pulse_counter) : pulse_counter_(pulse_counter) {}
 
-  TEMPLATABLE_VALUE(uint32_t, total_pulses)
+  TEMPLATABLE_VALUE(int32_t, total_pulses)
 
   void play(Ts... x) override { this->pulse_counter_->set_total_pulses(this->total_pulses_.value(x...)); }
 

--- a/esphome/components/pulse_counter/pulse_counter_sensor.cpp
+++ b/esphome/components/pulse_counter/pulse_counter_sensor.cpp
@@ -163,7 +163,7 @@ void PulseCounterSensor::setup() {
   }
 }
 
-void PulseCounterSensor::set_total_pulses(uint32_t pulses) {
+void PulseCounterSensor::set_total_pulses(int32_t pulses) {
   this->current_total_ = pulses;
   this->total_sensor_->publish_state(pulses);
 }

--- a/esphome/components/pulse_counter/pulse_counter_sensor.h
+++ b/esphome/components/pulse_counter/pulse_counter_sensor.h
@@ -44,7 +44,7 @@ struct BasicPulseCounterStorage : public PulseCounterStorageBase {
   pulse_counter_t read_raw_value() override;
 
   volatile pulse_counter_t counter{0};
-  volatile uint32_t last_pulse{0};
+  volatile int32_t last_pulse{0};
 
   ISRInternalGPIOPin isr_pin;
 };
@@ -71,7 +71,7 @@ class PulseCounterSensor : public sensor::Sensor, public PollingComponent {
   void set_filter_us(uint32_t filter) { storage_.filter_us = filter; }
   void set_total_sensor(sensor::Sensor *total_sensor) { total_sensor_ = total_sensor; }
 
-  void set_total_pulses(uint32_t pulses);
+  void set_total_pulses(int32_t pulses);
 
   /// Unit of measurement is "pulses/min".
   void setup() override;
@@ -83,7 +83,7 @@ class PulseCounterSensor : public sensor::Sensor, public PollingComponent {
   InternalGPIOPin *pin_;
   PulseCounterStorageBase &storage_;
   uint32_t last_time_{0};
-  uint32_t current_total_{0};
+  int32_t current_total_{0};
   sensor::Sensor *total_sensor_{nullptr};
 };
 

--- a/esphome/components/pulse_counter/sensor.py
+++ b/esphome/components/pulse_counter/sensor.py
@@ -144,7 +144,7 @@ async def to_code(config):
     cv.Schema(
         {
             cv.Required(CONF_ID): cv.use_id(PulseCounterSensor),
-            cv.Required(CONF_VALUE): cv.templatable(cv.uint32_t),
+            cv.Required(CONF_VALUE): cv.templatable(cv.int_),
         }
     ),
 )


### PR DESCRIPTION
# What does this implement/fix?

A negative total number of pulses was not possible in the pulse counter sensor. This fixes the issue by changing uint32_t to int32_t.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
