### PR TITLE
[packet_transport] Make some arguments const

### DIFF
--- a/esphome/components/packet_transport/packet_transport.cpp
+++ b/esphome/components/packet_transport/packet_transport.cpp
@@ -353,7 +353,7 @@ static bool process_rolling_code(Provider &provider, PacketDecoder &decoder) {
 /**
  * Process a received packet
  */
-void PacketTransport::process_(std::vector<uint8_t> &data) {
+void PacketTransport::process_(const std::vector<uint8_t> &data) {
   auto ping_key_seen = !this->ping_pong_enable_;
   PacketDecoder decoder((data.data()), data.size());
   char namebuf[256]{};

--- a/esphome/components/packet_transport/packet_transport.h
+++ b/esphome/components/packet_transport/packet_transport.h
@@ -101,12 +101,12 @@ class PacketTransport : public PollingComponent {
 
  protected:
   // child classes must implement this
-  virtual void send_packet(std::vector<uint8_t> &buf) const = 0;
+  virtual void send_packet(const std::vector<uint8_t> &buf) const = 0;
   virtual size_t get_max_packet_size() = 0;
   virtual bool should_send() { return true; }
 
   // to be called by child classes when a data packet is received.
-  void process_(std::vector<uint8_t> &data);
+  void process_(const std::vector<uint8_t> &data);
   void send_data_(bool all);
   void flush_();
   void add_data_(uint8_t key, const char *id, float data);
@@ -146,7 +146,6 @@ class PacketTransport : public PollingComponent {
   const char *platform_name_{""};
   void add_key_(const char *name, uint32_t key);
   void send_ping_pong_request_();
-  void process_ping_request_(const char *name, uint8_t *ptr, size_t len);
 
   inline bool is_encrypted_() { return !this->encryption_key_.empty(); }
 };

--- a/esphome/components/uart/packet_transport/uart_transport.cpp
+++ b/esphome/components/uart/packet_transport/uart_transport.cpp
@@ -74,7 +74,7 @@ void UARTTransport::write_byte_(uint8_t byte) const {
   this->parent_->write_byte(byte);
 }
 
-void UARTTransport::send_packet(std::vector<uint8_t> &buf) const {
+void UARTTransport::send_packet(const std::vector<uint8_t> &buf) const {
   this->parent_->write_byte(FLAG_BYTE);
   for (uint8_t byte : buf) {
     this->write_byte_(byte);

--- a/esphome/components/uart/packet_transport/uart_transport.h
+++ b/esphome/components/uart/packet_transport/uart_transport.h
@@ -29,7 +29,7 @@ class UARTTransport : public packet_transport::PacketTransport, public UARTDevic
 
  protected:
   void write_byte_(uint8_t byte) const;
-  void send_packet(std::vector<uint8_t> &buf) const override;
+  void send_packet(const std::vector<uint8_t> &buf) const override;
   bool should_send() override { return true; };
   size_t get_max_packet_size() override { return MAX_PACKET_SIZE; }
   std::vector<uint8_t> receive_buffer_{};

--- a/esphome/components/udp/packet_transport/udp_transport.cpp
+++ b/esphome/components/udp/packet_transport/udp_transport.cpp
@@ -31,6 +31,6 @@ void UDPTransport::update() {
   this->resend_data_ = this->should_broadcast_;
 }
 
-void UDPTransport::send_packet(std::vector<uint8_t> &buf) const { this->parent_->send_packet(buf); }
+void UDPTransport::send_packet(const std::vector<uint8_t> &buf) const { this->parent_->send_packet(buf); }
 }  // namespace udp
 }  // namespace esphome

--- a/esphome/components/udp/packet_transport/udp_transport.h
+++ b/esphome/components/udp/packet_transport/udp_transport.h
@@ -16,7 +16,7 @@ class UDPTransport : public packet_transport::PacketTransport, public Parented<U
   float get_setup_priority() const override { return setup_priority::AFTER_WIFI; }
 
  protected:
-  void send_packet(std::vector<uint8_t> &buf) const override;
+  void send_packet(const std::vector<uint8_t> &buf) const override;
   bool should_send() override;
   bool should_broadcast_{false};
   size_t get_max_packet_size() override { return MAX_PACKET_SIZE; }

--- a/esphome/components/udp/udp_component.h
+++ b/esphome/components/udp/udp_component.h
@@ -30,7 +30,7 @@ class UDPComponent : public Component {
   void loop() override;
   void dump_config() override;
   void send_packet(const uint8_t *data, size_t size);
-  void send_packet(std::vector<uint8_t> &buf) { this->send_packet(buf.data(), buf.size()); }
+  void send_packet(const std::vector<uint8_t> &buf) { this->send_packet(buf.data(), buf.size()); }
   float get_setup_priority() const override { return setup_priority::AFTER_WIFI; };
 
  protected:


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Change some function signatures to have const arguments since they aren't modified.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://discord.com/channels/429907082951524364/1369065842972561499/1369066980555882578

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
