### PR TITLE
[micro_wake_word] Experimental cutoff adjustments and uses mic sample rate

### DIFF
--- a/esphome/components/micro_wake_word/micro_wake_word.cpp
+++ b/esphome/components/micro_wake_word/micro_wake_word.cpp
@@ -179,7 +179,7 @@ void MicroWakeWord::inference_task(void *params) {
 
         // Generate new spectrogram features
         uint32_t processed_samples = this_mww->generate_features_(
-            (int16_t *) audio_buffer->get_buffer_start(), new_bytes_to_process / sizeof(int16_t), features_buffer);
+            (int16_t *) audio_buffer->get_buffer_start(), audio_buffer->available() / sizeof(int16_t), features_buffer);
         audio_buffer->decrease_buffer_length(processed_samples * sizeof(int16_t));
 
         // Run inference using the new spectorgram features

--- a/esphome/components/micro_wake_word/micro_wake_word.cpp
+++ b/esphome/components/micro_wake_word/micro_wake_word.cpp
@@ -22,8 +22,6 @@ static const ssize_t DETECTION_QUEUE_LENGTH = 5;
 static const size_t DATA_TIMEOUT_MS = 50;
 
 static const uint32_t RING_BUFFER_DURATION_MS = 120;
-static const uint32_t RING_BUFFER_SAMPLES = RING_BUFFER_DURATION_MS * (AUDIO_SAMPLE_FREQUENCY / 1000);
-static const size_t RING_BUFFER_SIZE = RING_BUFFER_SAMPLES * sizeof(int16_t);
 
 static const uint32_t INFERENCE_TASK_STACK_SIZE = 3072;
 static const UBaseType_t INFERENCE_TASK_PRIORITY = 3;
@@ -141,13 +139,15 @@ void MicroWakeWord::inference_task(void *params) {
   xEventGroupSetBits(this_mww->event_group_, EventGroupBits::TASK_STARTING);
 
   {  // Ensures any C++ objects fall out of scope to deallocate before deleting the task
-    const size_t new_samples_to_read = this_mww->features_step_size_ * (AUDIO_SAMPLE_FREQUENCY / 1000);
+
+    const size_t new_bytes_to_process =
+        this_mww->microphone_source_->get_audio_stream_info().ms_to_bytes(this_mww->features_step_size_);
     std::unique_ptr<audio::AudioSourceTransferBuffer> audio_buffer;
     int8_t features_buffer[PREPROCESSOR_FEATURE_SIZE];
 
     if (!(xEventGroupGetBits(this_mww->event_group_) & ERROR_BITS)) {
       // Allocate audio transfer buffer
-      audio_buffer = audio::AudioSourceTransferBuffer::create(new_samples_to_read * sizeof(int16_t));
+      audio_buffer = audio::AudioSourceTransferBuffer::create(new_bytes_to_process);
 
       if (audio_buffer == nullptr) {
         xEventGroupSetBits(this_mww->event_group_, EventGroupBits::ERROR_MEMORY);
@@ -156,7 +156,8 @@ void MicroWakeWord::inference_task(void *params) {
 
     if (!(xEventGroupGetBits(this_mww->event_group_) & ERROR_BITS)) {
       // Allocate ring buffer
-      std::shared_ptr<RingBuffer> temp_ring_buffer = RingBuffer::create(RING_BUFFER_SIZE);
+      std::shared_ptr<RingBuffer> temp_ring_buffer = RingBuffer::create(
+          this_mww->microphone_source_->get_audio_stream_info().ms_to_bytes(RING_BUFFER_DURATION_MS));
       if (temp_ring_buffer.use_count() == 0) {
         xEventGroupSetBits(this_mww->event_group_, EventGroupBits::ERROR_MEMORY);
       }
@@ -171,14 +172,14 @@ void MicroWakeWord::inference_task(void *params) {
       while (!(xEventGroupGetBits(this_mww->event_group_) & COMMAND_STOP)) {
         audio_buffer->transfer_data_from_source(pdMS_TO_TICKS(DATA_TIMEOUT_MS));
 
-        if (audio_buffer->available() < new_samples_to_read * sizeof(int16_t)) {
+        if (audio_buffer->available() < new_bytes_to_process) {
           // Insufficient data to generate new spectrogram features, read more next iteration
           continue;
         }
 
         // Generate new spectrogram features
-        size_t processed_samples = this_mww->generate_features_(
-            (int16_t *) audio_buffer->get_buffer_start(), audio_buffer->available() / sizeof(int16_t), features_buffer);
+        uint32_t processed_samples = this_mww->generate_features_((int16_t *) audio_buffer->get_buffer_start(),
+                                                                  new_bytes_to_process, features_buffer);
         audio_buffer->decrease_buffer_length(processed_samples * sizeof(int16_t));
 
         // Run inference using the new spectorgram features
@@ -297,7 +298,8 @@ void MicroWakeWord::loop() {
       if ((this->inference_task_handle_ == nullptr) && !this->status_has_error()) {
         // Setup preprocesor feature generator. If done in the task, it would lock the task to its initial core, as it
         // uses floating point operations.
-        if (!FrontendPopulateState(&this->frontend_config_, &this->frontend_state_, AUDIO_SAMPLE_FREQUENCY)) {
+        if (!FrontendPopulateState(&this->frontend_config_, &this->frontend_state_,
+                                   this->microphone_source_->get_audio_stream_info().get_sample_rate())) {
           this->status_momentary_error(
               "Failed to allocate buffers for spectrogram feature processor, attempting again in 1 second", 1000);
           return;

--- a/esphome/components/micro_wake_word/micro_wake_word.cpp
+++ b/esphome/components/micro_wake_word/micro_wake_word.cpp
@@ -178,8 +178,8 @@ void MicroWakeWord::inference_task(void *params) {
         }
 
         // Generate new spectrogram features
-        uint32_t processed_samples = this_mww->generate_features_((int16_t *) audio_buffer->get_buffer_start(),
-                                                                  new_bytes_to_process, features_buffer);
+        uint32_t processed_samples = this_mww->generate_features_(
+            (int16_t *) audio_buffer->get_buffer_start(), new_bytes_to_process / sizeof(int16_t), features_buffer);
         audio_buffer->decrease_buffer_length(processed_samples * sizeof(int16_t));
 
         // Run inference using the new spectorgram features

--- a/esphome/components/micro_wake_word/micro_wake_word.h
+++ b/esphome/components/micro_wake_word/micro_wake_word.h
@@ -121,8 +121,6 @@ class MicroWakeWord : public Component {
   /// @param audio_features (int8_t *) Buffer containing new spectrogram features
   /// @return True if successful, false if any errors were encountered
   bool update_model_probabilities_(const int8_t audio_features[PREPROCESSOR_FEATURE_SIZE]);
-
-  inline uint16_t new_samples_to_get_() { return (this->features_step_size_ * (AUDIO_SAMPLE_FREQUENCY / 1000)); }
 };
 
 }  // namespace micro_wake_word

--- a/esphome/components/micro_wake_word/preprocessor_settings.h
+++ b/esphome/components/micro_wake_word/preprocessor_settings.h
@@ -15,8 +15,6 @@ namespace micro_wake_word {
 static const uint8_t PREPROCESSOR_FEATURE_SIZE = 40;
 // Duration of each slice used as input into the preprocessor
 static const uint8_t FEATURE_DURATION_MS = 30;
-// Audio sample frequency in hertz
-static const uint16_t AUDIO_SAMPLE_FREQUENCY = 16000;
 
 static const float FILTERBANK_LOWER_BAND_LIMIT = 125.0;
 static const float FILTERBANK_UPPER_BAND_LIMIT = 7500.0;

--- a/esphome/components/micro_wake_word/streaming_model.cpp
+++ b/esphome/components/micro_wake_word/streaming_model.cpp
@@ -159,12 +159,13 @@ void StreamingModel::reset_probabilities() {
   this->ignore_windows_ = -MIN_SLICES_BEFORE_DETECTION;
 }
 
-WakeWordModel::WakeWordModel(const std::string &id, const uint8_t *model_start, uint8_t probability_cutoff,
+WakeWordModel::WakeWordModel(const std::string &id, const uint8_t *model_start, uint8_t default_probability_cutoff,
                              size_t sliding_window_average_size, const std::string &wake_word, size_t tensor_arena_size,
                              bool default_enabled, bool internal_only) {
   this->id_ = id;
   this->model_start_ = model_start;
-  this->probability_cutoff_ = probability_cutoff;
+  this->default_probability_cutoff_ = default_probability_cutoff;
+  this->probability_cutoff_ = default_probability_cutoff;
   this->sliding_window_size_ = sliding_window_average_size;
   this->recent_streaming_probabilities_.resize(sliding_window_average_size, 0);
   this->wake_word_ = wake_word;
@@ -222,10 +223,11 @@ DetectionEvent WakeWordModel::determine_detected() {
   return detection_event;
 }
 
-VADModel::VADModel(const uint8_t *model_start, uint8_t probability_cutoff, size_t sliding_window_size,
+VADModel::VADModel(const uint8_t *model_start, uint8_t default_probability_cutoff, size_t sliding_window_size,
                    size_t tensor_arena_size) {
   this->model_start_ = model_start;
-  this->probability_cutoff_ = probability_cutoff;
+  this->default_probability_cutoff_ = default_probability_cutoff;
+  this->probability_cutoff_ = default_probability_cutoff;
   this->sliding_window_size_ = sliding_window_size;
   this->recent_streaming_probabilities_.resize(sliding_window_size, 0);
   this->tensor_arena_size_ = tensor_arena_size;

--- a/esphome/components/micro_wake_word/streaming_model.h
+++ b/esphome/components/micro_wake_word/streaming_model.h
@@ -56,6 +56,7 @@ class StreamingModel {
 
   // Quantized probability cutoffs mapping 0.0 - 1.0 to 0 - 255
   uint8_t get_default_probability_cutoff() const { return this->default_probability_cutoff_; }
+  uint8_t get_probability_cutoff() const { return this->probability_cutoff_; }
   void set_probability_cutoff(uint8_t probability_cutoff) { this->probability_cutoff_ = probability_cutoff; }
 
  protected:

--- a/esphome/components/micro_wake_word/streaming_model.h
+++ b/esphome/components/micro_wake_word/streaming_model.h
@@ -54,6 +54,9 @@ class StreamingModel {
 
   bool get_unprocessed_probability_status() { return this->unprocessed_probability_status_; }
 
+  void set_probability_cutoff(uint8_t probability_cutoff) { this->probability_cutoff_ = probability_cutoff; }
+  uint8_t get_probability_cutoff() { return this->probability_cutoff_; }
+
  protected:
   /// @brief Allocates tensor and variable arenas and sets up the model interpreter
   /// @return True if successful, false otherwise

--- a/esphome/components/micro_wake_word/streaming_model.h
+++ b/esphome/components/micro_wake_word/streaming_model.h
@@ -50,12 +50,13 @@ class StreamingModel {
   virtual void disable() { this->enabled_ = false; }
 
   /// @brief Return true if the model is enabled.
-  bool is_enabled() { return this->enabled_; }
+  bool is_enabled() const { return this->enabled_; }
 
-  bool get_unprocessed_probability_status() { return this->unprocessed_probability_status_; }
+  bool get_unprocessed_probability_status() const { return this->unprocessed_probability_status_; }
 
+  // Quantized probability cutoffs mapping 0.0 - 1.0 to 0 - 255
+  uint8_t get_default_probability_cutoff() const { return this->default_probability_cutoff_; }
   void set_probability_cutoff(uint8_t probability_cutoff) { this->probability_cutoff_ = probability_cutoff; }
-  uint8_t get_probability_cutoff() { return this->probability_cutoff_; }
 
  protected:
   /// @brief Allocates tensor and variable arenas and sets up the model interpreter
@@ -72,8 +73,10 @@ class StreamingModel {
   uint8_t current_stride_step_{0};
   int16_t ignore_windows_{-MIN_SLICES_BEFORE_DETECTION};
 
-  uint8_t probability_cutoff_;  // Quantized probability cutoff mapping 0.0 - 1.0 to 0 - 255
+  uint8_t default_probability_cutoff_;
+  uint8_t probability_cutoff_;
   size_t sliding_window_size_;
+
   size_t last_n_index_{0};
   size_t tensor_arena_size_;
   std::vector<uint8_t> recent_streaming_probabilities_;
@@ -91,14 +94,14 @@ class WakeWordModel final : public StreamingModel {
   /// @brief Constructs a wake word model object
   /// @param id (std::string) identifier for this model
   /// @param model_start (const uint8_t *) pointer to the start of the model's TFLite FlatBuffer
-  /// @param probability_cutoff (uint8_t) probability cutoff for acceping the wake word has been said
+  /// @param default_probability_cutoff (uint8_t) probability cutoff for acceping the wake word has been said
   /// @param sliding_window_average_size (size_t) the length of the sliding window computing the mean rolling
   ///                                    probability
   /// @param wake_word (std::string) Friendly name of the wake word
   /// @param tensor_arena_size (size_t) Size in bytes for allocating the tensor arena
   /// @param default_enabled (bool) If true, it will be enabled by default on first boot
   /// @param internal_only (bool) If true, the model will not be exposed to HomeAssistant as an available model
-  WakeWordModel(const std::string &id, const uint8_t *model_start, uint8_t probability_cutoff,
+  WakeWordModel(const std::string &id, const uint8_t *model_start, uint8_t default_probability_cutoff,
                 size_t sliding_window_average_size, const std::string &wake_word, size_t tensor_arena_size,
                 bool default_enabled, bool internal_only);
 
@@ -135,7 +138,7 @@ class WakeWordModel final : public StreamingModel {
 
 class VADModel final : public StreamingModel {
  public:
-  VADModel(const uint8_t *model_start, uint8_t probability_cutoff, size_t sliding_window_size,
+  VADModel(const uint8_t *model_start, uint8_t default_probability_cutoff, size_t sliding_window_size,
            size_t tensor_arena_size);
 
   void log_model_config() override;


### PR DESCRIPTION
# What does this implement/fix?

- Adds setter/getter for the wake word probability cutoff to enable easier testing adjustments via lambda actions
  - This will help us expose some default thresholds for the VPE for different wake word sensitivity levels
- Cleans up the the spectrogram feature preprocessor configuration. In particular, the sample rate is pulled from the microphone source - technically mWW can function at higher sample rates, but I am leaving the Python validation requiring 16 kHz as this requires a lot more testing.

There are no using-facing changes with this PR.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** not applicable

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** not applicable

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

micro_wake_word:
  models:
    - model: https://github.com/kahrendt/microWakeWord/releases/download/okay_nabu_20241226.3/okay_nabu.json
      id: okay_nabu

number:
  - platform: template
    name: "Okay Nabu Cutoff"
    min_value: 0.0
    max_value: 1.0
    step: 0.01
    initial_value: 0.85
    restore_value: true
    set_action:
      - lambda: id(okay_nabu).set_probability_cutoff(static_cast<uint8_t>(x*255.0));

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
