### PR TITLE
[i2s_audio, mixer, resampler, speaker] Simplify duration played callback

### DIFF
--- a/esphome/components/i2s_audio/speaker/i2s_audio_speaker.cpp
+++ b/esphome/components/i2s_audio/speaker/i2s_audio_speaker.cpp
@@ -14,6 +14,8 @@
 #include "esphome/core/hal.h"
 #include "esphome/core/log.h"
 
+#include "esp_timer.h"
+
 namespace esphome {
 namespace i2s_audio {
 
@@ -366,7 +368,7 @@ void I2SAudioSpeaker::speaker_task(void *params) {
                             bytes_to_write, &bytes_written, pdMS_TO_TICKS(DMA_BUFFER_DURATION_MS * 5));
 #endif
 
-          uint32_t write_timestamp = micros();
+          int64_t now = esp_timer_get_time();
 
           if (bytes_written != bytes_to_write) {
             xEventGroupSetBits(this_speaker->event_group_, SpeakerEventGroupBits::ERR_ESP_INVALID_SIZE);
@@ -374,17 +376,9 @@ void I2SAudioSpeaker::speaker_task(void *params) {
 
           bytes_read -= bytes_written;
 
-          this_speaker->accumulated_frames_written_ += audio_stream_info.bytes_to_frames(bytes_written);
-          const uint32_t new_playback_ms =
-              audio_stream_info.frames_to_milliseconds_with_remainder(&this_speaker->accumulated_frames_written_);
-          const uint32_t remainder_us =
-              audio_stream_info.frames_to_microseconds(this_speaker->accumulated_frames_written_);
-
-          uint32_t pending_frames =
-              audio_stream_info.bytes_to_frames(bytes_read + this_speaker->audio_ring_buffer_->available());
-          const uint32_t pending_ms = audio_stream_info.frames_to_milliseconds_with_remainder(&pending_frames);
-
-          this_speaker->audio_output_callback_(new_playback_ms, remainder_us, pending_ms, write_timestamp);
+          last_data_received_time = millis();
+          this_speaker->audio_output_callback_(audio_stream_info.bytes_to_frames(bytes_written),
+                                               now + dma_buffers_duration_ms * 1000);
 
           tx_dma_underflow = false;
           last_data_received_time = millis();

--- a/esphome/components/i2s_audio/speaker/i2s_audio_speaker.cpp
+++ b/esphome/components/i2s_audio/speaker/i2s_audio_speaker.cpp
@@ -373,10 +373,8 @@ void I2SAudioSpeaker::speaker_task(void *params) {
           if (bytes_written != bytes_to_write) {
             xEventGroupSetBits(this_speaker->event_group_, SpeakerEventGroupBits::ERR_ESP_INVALID_SIZE);
           }
-
           bytes_read -= bytes_written;
 
-          last_data_received_time = millis();
           this_speaker->audio_output_callback_(audio_stream_info.bytes_to_frames(bytes_written),
                                                now + dma_buffers_duration_ms * 1000);
 

--- a/esphome/components/mixer/speaker/mixer_speaker.h
+++ b/esphome/components/mixer/speaker/mixer_speaker.h
@@ -114,9 +114,7 @@ class SourceSpeaker : public speaker::Speaker, public Component {
   uint32_t ducking_transition_samples_remaining_{0};
   uint32_t samples_per_ducking_step_{0};
 
-  uint32_t accumulated_frames_read_{0};
-
-  uint32_t pending_playback_ms_{0};
+  uint32_t pending_playback_frames_{0};
 };
 
 class MixerSpeaker : public Component {

--- a/esphome/components/resampler/speaker/resampler_speaker.h
+++ b/esphome/components/resampler/speaker/resampler_speaker.h
@@ -100,7 +100,7 @@ class ResamplerSpeaker : public Component, public speaker::Speaker {
 
   uint32_t buffer_duration_ms_;
 
-  int32_t playback_differential_ms_{0};
+  uint64_t callback_remainder_{0};
 };
 
 }  // namespace resampler

--- a/esphome/components/speaker/media_player/speaker_media_player.h
+++ b/esphome/components/speaker/media_player/speaker_media_player.h
@@ -73,10 +73,6 @@ class SpeakerMediaPlayer : public Component, public media_player::MediaPlayer {
 
   void play_file(audio::AudioFile *media_file, bool announcement, bool enqueue);
 
-  uint32_t get_playback_ms() const { return this->playback_ms_; }
-  uint32_t get_playback_us() const { return this->playback_us_; }
-  uint32_t get_decoded_playback_ms() const { return this->decoded_playback_ms_; }
-
   void set_playlist_delay_ms(AudioPipelineType pipeline_type, uint32_t delay_ms);
 
  protected:

--- a/esphome/components/speaker/media_player/speaker_media_player.h
+++ b/esphome/components/speaker/media_player/speaker_media_player.h
@@ -141,13 +141,6 @@ class SpeakerMediaPlayer : public Component, public media_player::MediaPlayer {
   Trigger<> *mute_trigger_ = new Trigger<>();
   Trigger<> *unmute_trigger_ = new Trigger<>();
   Trigger<float> *volume_trigger_ = new Trigger<float>();
-
-  uint32_t decoded_playback_ms_{0};
-  uint32_t playback_us_{0};
-  uint32_t playback_ms_{0};
-  uint32_t remainder_us_{0};
-  uint32_t pending_ms_{0};
-  uint32_t last_audio_write_timestamp_{0};
 };
 
 }  // namespace speaker

--- a/esphome/components/speaker/speaker.h
+++ b/esphome/components/speaker/speaker.h
@@ -104,12 +104,9 @@ class Speaker {
 
   /// Callback function for sending the duration of the audio written to the speaker since the last callback.
   /// Parameters:
-  ///   - Duration in milliseconds. Never rounded and should always be less than or equal to the actual duration.
-  ///   - Remainder duration in microseconds. Rounded duration after subtracting the previous parameter from the actual
-  ///     duration.
-  ///   - Duration of remaining, unwritten audio buffered in the speaker in milliseconds.
-  ///   - System time in microseconds when the last write was completed.
-  void add_audio_output_callback(std::function<void(uint32_t, uint32_t, uint32_t, uint32_t)> &&callback) {
+  ///   - Frames played
+  ///   - System time in microseconds when the frames were written to the DAC
+  void add_audio_output_callback(std::function<void(uint32_t, int64_t)> &&callback) {
     this->audio_output_callback_.add(std::move(callback));
   }
 
@@ -123,7 +120,7 @@ class Speaker {
   audio_dac::AudioDac *audio_dac_{nullptr};
 #endif
 
-  CallbackManager<void(uint32_t, uint32_t, uint32_t, uint32_t)> audio_output_callback_{};
+  CallbackManager<void(uint32_t, int64_t)> audio_output_callback_{};
 };
 
 }  // namespace speaker


### PR DESCRIPTION
# What does this implement/fix?

- Simplifies the duration played callback for speakers to only pass the number of frames played and the system time in microseconds. This is a much simpler approach instead of carefully handling the duration remainder due to integer division truncation. 
- Changes the system time to an int64 instead of only using 32 bits - the system time in microseconds would rollover after ~72 minutes, which is very problematic for syncing audio.
- Removes a duplicated pending playback calculation in the mixer speaker.
- Removes the old callback and associated values from the media player - they were never used.

I've marked it as a breaking change since the parent speaker class has changed, but there are no user-facing changes. The callback's information was never exposed.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** not applicable

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** not applicable

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
