### PR TITLE
Avoid Reallocation When Sending Logging Messages

### DIFF
--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -1794,9 +1794,6 @@ bool APIConnection::try_send_log_message(int level, const char *tag, const char 
   buffer.encode_uint32(1, static_cast<uint32_t>(level));  // LogLevel level = 1
   buffer.encode_string(3, line, line_length);             // string message = 3
 
-  ESP_LOGW(TAG, "Sending log message, expected size: %" PRIu32 ", actual size: %" PRIu32, msg_size,
-           static_cast<uint32_t>(buffer.get_buffer()->size()));
-
   // SubscribeLogsResponse - 29
   return this->send_buffer(buffer, 29);
 }

--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -1780,11 +1780,11 @@ bool APIConnection::try_send_log_message(int level, const char *tag, const char 
 
   // Add size for level field (field ID 1, varint type)
   // 1 byte for field tag + size of the level varint
-  msg_size += 1 + ProtoSize::varint(static_cast<uint32_t>(level));
+  msg_size += 1 + api::ProtoSize::varint(static_cast<uint32_t>(level));
 
   // Add size for string field (field ID 3, string type)
   // 1 byte for field tag + size of length varint + string length
-  msg_size += 1 + ProtoSize::varint(line_length) + line_length;
+  msg_size += 1 + api::ProtoSize::varint(static_cast<uint32_t>(line_length)) + line_length;
 
   // Create a pre-sized buffer
   auto buffer = this->create_buffer();

--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -1774,12 +1774,26 @@ bool APIConnection::try_send_log_message(int level, const char *tag, const char 
   if (this->log_subscription_ < level)
     return false;
 
-  // Send raw so that we don't copy too much
+  // Pre-calculate message size to avoid reallocations
+  const size_t line_length = strlen(line);
+  uint32_t msg_size = 0;
+
+  // Add size for level field (field ID 1, varint type)
+  // 1 byte for field tag + size of the level varint
+  msg_size += 1 + ProtoSize::varint(static_cast<uint32_t>(level));
+
+  // Add size for string field (field ID 3, string type)
+  // 1 byte for field tag + size of length varint + string length
+  msg_size += 1 + ProtoSize::varint(line_length) + line_length;
+
+  // Create a pre-sized buffer
   auto buffer = this->create_buffer();
-  // LogLevel level = 1;
-  buffer.encode_uint32(1, static_cast<uint32_t>(level));
-  // string message = 3;
-  buffer.encode_string(3, line, strlen(line));
+  buffer.get_buffer()->reserve(msg_size);
+
+  // Encode the message (SubscribeLogsResponse)
+  buffer.encode_uint32(1, static_cast<uint32_t>(level));  // LogLevel level = 1
+  buffer.encode_string(3, line, line_length);             // string message = 3
+
   // SubscribeLogsResponse - 29
   return this->send_buffer(buffer, 29);
 }

--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -1794,6 +1794,9 @@ bool APIConnection::try_send_log_message(int level, const char *tag, const char 
   buffer.encode_uint32(1, static_cast<uint32_t>(level));  // LogLevel level = 1
   buffer.encode_string(3, line, line_length);             // string message = 3
 
+  ESP_LOGW(TAG, "Sending log message, expected size: %" PRIu32 ", actual size: %" PRIu32, msg_size,
+           static_cast<uint32_t>(buffer.get_buffer()->size()));
+
   // SubscribeLogsResponse - 29
   return this->send_buffer(buffer, 29);
 }


### PR DESCRIPTION
# What does this implement/fix?

This PR ensures that logging messages are sent without triggering buffer reallocations, addressing a specific case not covered by https://github.com/esphome/esphome/pull/8707.

It extends the preallocation improvements introduced in that PR to the logging subsystem, which also uses the API encoder.
```
external_components:
  - source: github://pr#8714
    components: [ api ]
    refresh: 0s
```
## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
