### PR TITLE
Require reserve_size in create_buffer to reduce realloc overhead

### DIFF
--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -212,8 +212,7 @@ void APIConnection::loop() {
     msg_size += 1 + ProtoSize::varint(to_send) + to_send;
     ProtoSize::add_bool_field(msg_size, 1, done);
 
-    auto buffer = this->create_buffer();
-    buffer.get_buffer()->reserve(msg_size);
+    auto buffer = this->create_buffer(msg_size);
     // fixed32 key = 1;
     buffer.encode_fixed32(1, esp32_camera::global_esp32_camera->get_object_id_hash());
     // bytes data = 2;
@@ -1807,8 +1806,7 @@ bool APIConnection::try_send_log_message(int level, const char *tag, const char 
   msg_size += 1 + api::ProtoSize::varint(static_cast<uint32_t>(line_length)) + line_length;
 
   // Create a pre-sized buffer
-  auto buffer = this->create_buffer();
-  buffer.get_buffer()->reserve(msg_size);
+  auto buffer = this->create_buffer(msg_size);
 
   // Encode the message (SubscribeLogsResponse)
   buffer.encode_uint32(1, static_cast<uint32_t>(level));  // LogLevel level = 1

--- a/esphome/components/api/api_connection.h
+++ b/esphome/components/api/api_connection.h
@@ -312,9 +312,10 @@ class APIConnection : public APIServerConnection {
   void on_fatal_error() override;
   void on_unauthenticated_access() override;
   void on_no_setup_connection() override;
-  ProtoWriteBuffer create_buffer() override {
+  ProtoWriteBuffer create_buffer(uint32_t reserve_size) override {
     // FIXME: ensure no recursive writes can happen
     this->proto_write_buffer_.clear();
+    this->proto_write_buffer_.reserve(reserve_size);
     return {&this->proto_write_buffer_};
   }
   bool send_buffer(ProtoWriteBuffer buffer, uint32_t message_type) override;

--- a/esphome/components/api/proto.h
+++ b/esphome/components/api/proto.h
@@ -311,6 +311,13 @@ class ProtoService {
   virtual void on_fatal_error() = 0;
   virtual void on_unauthenticated_access() = 0;
   virtual void on_no_setup_connection() = 0;
+  /**
+   * Create a buffer with a reserved size.
+   * @param reserve_size The number of bytes to pre-allocate in the buffer. This is a hint
+   *                     to optimize memory usage and avoid reallocations during encoding.
+   *                     Implementations should aim to allocate at least this size.
+   * @return A ProtoWriteBuffer object with the reserved size.
+   */
   virtual ProtoWriteBuffer create_buffer(uint32_t reserve_size) = 0;
   virtual bool send_buffer(ProtoWriteBuffer buffer, uint32_t message_type) = 0;
   virtual bool read_message(uint32_t msg_size, uint32_t msg_type, uint8_t *msg_data) = 0;

--- a/esphome/components/api/proto.h
+++ b/esphome/components/api/proto.h
@@ -311,7 +311,7 @@ class ProtoService {
   virtual void on_fatal_error() = 0;
   virtual void on_unauthenticated_access() = 0;
   virtual void on_no_setup_connection() = 0;
-  virtual ProtoWriteBuffer create_buffer() = 0;
+  virtual ProtoWriteBuffer create_buffer(uint32_t reserve_size) = 0;
   virtual bool send_buffer(ProtoWriteBuffer buffer, uint32_t message_type) = 0;
   virtual bool read_message(uint32_t msg_size, uint32_t msg_type, uint8_t *msg_data) = 0;
 
@@ -321,8 +321,7 @@ class ProtoService {
     msg.calculate_size(msg_size);
 
     // Create a pre-sized buffer
-    auto buffer = this->create_buffer();
-    buffer.get_buffer()->reserve(msg_size);
+    auto buffer = this->create_buffer(msg_size);
 
     // Encode message into the buffer
     msg.encode(buffer);


### PR DESCRIPTION

# What does this implement/fix?

This change modifies the `create_buffer` function in the API component to require an explicit `reserve_size`.  
By enforcing this parameter, all new usages of `create_buffer` must now consider memory preallocation,  
helping prevent inefficient memory growth and unnecessary `realloc` calls during runtime.

Closes https://github.com/esphome/issues/issues/7002

testing
```
external_components:
  - source: github://pr#8715
    components: [ api ]
    refresh: 0s
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
