### PR TITLE
Reserve space in the frame helper when we know in advance how much we need

### DIFF
--- a/esphome/components/api/api_frame_helper.cpp
+++ b/esphome/components/api/api_frame_helper.cpp
@@ -5,6 +5,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/application.h"
 #include "proto.h"
+#include "api_pb2_size.h"
 #include <cstring>
 
 namespace esphome {
@@ -574,6 +575,8 @@ APIError APINoiseFrameHelper::write_raw_(const struct iovec *iov, int iovcnt) {
 
   if (!tx_buf_.empty()) {
     // tx buf not empty, can't write now because then stream would be inconsistent
+    // Reserve space upfront to avoid multiple reallocations
+    tx_buf_.reserve(tx_buf_.size() + total_write_len);
     for (int i = 0; i < iovcnt; i++) {
       tx_buf_.insert(tx_buf_.end(), reinterpret_cast<uint8_t *>(iov[i].iov_base),
                      reinterpret_cast<uint8_t *>(iov[i].iov_base) + iov[i].iov_len);
@@ -584,6 +587,8 @@ APIError APINoiseFrameHelper::write_raw_(const struct iovec *iov, int iovcnt) {
   ssize_t sent = socket_->writev(iov, iovcnt);
   if (is_would_block(sent)) {
     // operation would block, add buffer to tx_buf
+    // Reserve space upfront to avoid multiple reallocations
+    tx_buf_.reserve(tx_buf_.size() + total_write_len);
     for (int i = 0; i < iovcnt; i++) {
       tx_buf_.insert(tx_buf_.end(), reinterpret_cast<uint8_t *>(iov[i].iov_base),
                      reinterpret_cast<uint8_t *>(iov[i].iov_base) + iov[i].iov_len);
@@ -596,6 +601,10 @@ APIError APINoiseFrameHelper::write_raw_(const struct iovec *iov, int iovcnt) {
     return APIError::SOCKET_WRITE_FAILED;
   } else if ((size_t) sent != total_write_len) {
     // partially sent, add end to tx_buf
+    size_t remaining = total_write_len - sent;
+    // Reserve space upfront to avoid multiple reallocations
+    tx_buf_.reserve(tx_buf_.size() + remaining);
+
     size_t to_consume = sent;
     for (int i = 0; i < iovcnt; i++) {
       if (to_consume >= iov[i].iov_len) {
@@ -933,6 +942,7 @@ APIError APIPlaintextFrameHelper::write_packet(uint16_t type, const uint8_t *pay
   }
 
   std::vector<uint8_t> header;
+  header.reserve(1 + api::ProtoSize::varint(payload_len) + api::ProtoSize::varint(type));
   header.push_back(0x00);
   ProtoVarInt(payload_len).encode(header);
   ProtoVarInt(type).encode(header);
@@ -994,6 +1004,8 @@ APIError APIPlaintextFrameHelper::write_raw_(const struct iovec *iov, int iovcnt
 
   if (!tx_buf_.empty()) {
     // tx buf not empty, can't write now because then stream would be inconsistent
+    // Reserve space upfront to avoid multiple reallocations
+    tx_buf_.reserve(tx_buf_.size() + total_write_len);
     for (int i = 0; i < iovcnt; i++) {
       tx_buf_.insert(tx_buf_.end(), reinterpret_cast<uint8_t *>(iov[i].iov_base),
                      reinterpret_cast<uint8_t *>(iov[i].iov_base) + iov[i].iov_len);
@@ -1004,6 +1016,8 @@ APIError APIPlaintextFrameHelper::write_raw_(const struct iovec *iov, int iovcnt
   ssize_t sent = socket_->writev(iov, iovcnt);
   if (is_would_block(sent)) {
     // operation would block, add buffer to tx_buf
+    // Reserve space upfront to avoid multiple reallocations
+    tx_buf_.reserve(tx_buf_.size() + total_write_len);
     for (int i = 0; i < iovcnt; i++) {
       tx_buf_.insert(tx_buf_.end(), reinterpret_cast<uint8_t *>(iov[i].iov_base),
                      reinterpret_cast<uint8_t *>(iov[i].iov_base) + iov[i].iov_len);
@@ -1016,6 +1030,10 @@ APIError APIPlaintextFrameHelper::write_raw_(const struct iovec *iov, int iovcnt
     return APIError::SOCKET_WRITE_FAILED;
   } else if ((size_t) sent != total_write_len) {
     // partially sent, add end to tx_buf
+    size_t remaining = total_write_len - sent;
+    // Reserve space upfront to avoid multiple reallocations
+    tx_buf_.reserve(tx_buf_.size() + remaining);
+
     size_t to_consume = sent;
     for (int i = 0; i < iovcnt; i++) {
       if (to_consume >= iov[i].iov_len) {

--- a/esphome/components/api/api_frame_helper.cpp
+++ b/esphome/components/api/api_frame_helper.cpp
@@ -942,7 +942,8 @@ APIError APIPlaintextFrameHelper::write_packet(uint16_t type, const uint8_t *pay
   }
 
   std::vector<uint8_t> header;
-  header.reserve(1 + api::ProtoSize::varint(payload_len) + api::ProtoSize::varint(type));
+  header.reserve(1 + api::ProtoSize::varint(static_cast<uint32_t>(payload_len)) +
+                 api::ProtoSize::varint(static_cast<uint32_t>(type)));
   header.push_back(0x00);
   ProtoVarInt(payload_len).encode(header);
   ProtoVarInt(type).encode(header);


### PR DESCRIPTION


# What does this implement/fix?

This PR builds on PR #8707 by reserving buffer space ahead of time in `APINoiseFrameHelper` and `APIPlaintextFrameHelper` when the required size is known in advance. This reduces reallocations and improves efficiency when constructing API frames.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
