### PR TITLE
[key_collector] enable/disable

### DIFF
--- a/esphome/components/key_collector/__init__.py
+++ b/esphome/components/key_collector/__init__.py
@@ -3,6 +3,7 @@ import esphome.codegen as cg
 from esphome.components import key_provider
 import esphome.config_validation as cv
 from esphome.const import (
+    CONF_ENABLE_ON_BOOT,
     CONF_ID,
     CONF_MAX_LENGTH,
     CONF_MIN_LENGTH,
@@ -28,6 +29,8 @@ CONF_ON_RESULT = "on_result"
 
 key_collector_ns = cg.esphome_ns.namespace("key_collector")
 KeyCollector = key_collector_ns.class_("KeyCollector", cg.Component)
+EnableAction = key_collector_ns.class_("EnableAction", automation.Action)
+DisableAction = key_collector_ns.class_("DisableAction", automation.Action)
 
 CONFIG_SCHEMA = cv.All(
     cv.COMPONENT_SCHEMA.extend(
@@ -46,6 +49,7 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_ON_RESULT): automation.validate_automation(single=True),
             cv.Optional(CONF_ON_TIMEOUT): automation.validate_automation(single=True),
             cv.Optional(CONF_TIMEOUT): cv.positive_time_period_milliseconds,
+            cv.Optional(CONF_ENABLE_ON_BOOT, default=True): cv.boolean,
         }
     ),
     cv.has_at_least_one_key(CONF_END_KEYS, CONF_MAX_LENGTH),
@@ -94,3 +98,34 @@ async def to_code(config):
         )
     if CONF_TIMEOUT in config:
         cg.add(var.set_timeout(config[CONF_TIMEOUT]))
+    cg.add(var.set_enabled(config[CONF_ENABLE_ON_BOOT]))
+
+
+@automation.register_action(
+    "key_collector.enable",
+    EnableAction,
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.use_id(KeyCollector),
+        }
+    ),
+)
+async def enable_to_code(config, action_id, template_arg, args):
+    var = cg.new_Pvariable(action_id, template_arg)
+    await cg.register_parented(var, config[CONF_ID])
+    return var
+
+
+@automation.register_action(
+    "key_collector.disable",
+    DisableAction,
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.use_id(KeyCollector),
+        }
+    ),
+)
+async def disable_to_code(config, action_id, template_arg, args):
+    var = cg.new_Pvariable(action_id, template_arg)
+    await cg.register_parented(var, config[CONF_ID])
+    return var

--- a/esphome/components/key_collector/__init__.py
+++ b/esphome/components/key_collector/__init__.py
@@ -104,7 +104,7 @@ async def to_code(config):
 @automation.register_action(
     "key_collector.enable",
     EnableAction,
-    cv.Schema(
+    automation.maybe_simple_id(
         {
             cv.GenerateID(): cv.use_id(KeyCollector),
         }
@@ -119,7 +119,7 @@ async def enable_to_code(config, action_id, template_arg, args):
 @automation.register_action(
     "key_collector.disable",
     DisableAction,
-    cv.Schema(
+    automation.maybe_simple_id(
         {
             cv.GenerateID(): cv.use_id(KeyCollector),
         }

--- a/esphome/components/key_collector/key_collector.cpp
+++ b/esphome/components/key_collector/key_collector.cpp
@@ -45,6 +45,12 @@ void KeyCollector::set_provider(key_provider::KeyProvider *provider) {
   provider->add_on_key_callback([this](uint8_t key) { this->key_pressed_(key); });
 }
 
+void KeyCollector::set_enabled(bool enabled) {
+  this->enabled_ = enabled;
+  if (!enabled)
+    this->clear(false);
+}
+
 void KeyCollector::clear(bool progress_update) {
   this->result_.clear();
   this->start_key_ = 0;
@@ -55,6 +61,8 @@ void KeyCollector::clear(bool progress_update) {
 void KeyCollector::send_key(uint8_t key) { this->key_pressed_(key); }
 
 void KeyCollector::key_pressed_(uint8_t key) {
+  if (!this->enabled_)
+    return;
   this->last_key_time_ = millis();
   if (!this->start_keys_.empty() && !this->start_key_) {
     if (this->start_keys_.find(key) != std::string::npos) {

--- a/esphome/components/key_collector/key_collector.h
+++ b/esphome/components/key_collector/key_collector.h
@@ -25,6 +25,7 @@ class KeyCollector : public Component {
   Trigger<std::string, uint8_t, uint8_t> *get_result_trigger() const { return this->result_trigger_; };
   Trigger<std::string, uint8_t> *get_timeout_trigger() const { return this->timeout_trigger_; };
   void set_timeout(int timeout) { this->timeout_ = timeout; };
+  void set_enabled(bool enabled);
 
   void clear(bool progress_update = true);
   void send_key(uint8_t key);
@@ -47,6 +48,15 @@ class KeyCollector : public Component {
   Trigger<std::string, uint8_t> *timeout_trigger_;
   uint32_t last_key_time_;
   uint32_t timeout_{0};
+  bool enabled_;
+};
+
+template<typename... Ts> class EnableAction : public Action<Ts...>, public Parented<KeyCollector> {
+  void play(Ts... x) override { this->parent_->set_enabled(true); }
+};
+
+template<typename... Ts> class DisableAction : public Action<Ts...>, public Parented<KeyCollector> {
+  void play(Ts... x) override { this->parent_->set_enabled(false); }
 };
 
 }  // namespace key_collector

--- a/tests/components/key_collector/common.yaml
+++ b/tests/components/key_collector/common.yaml
@@ -26,3 +26,11 @@ key_collector:
       - logger.log:
           format: "input timeout: '%s', started by '%c'"
           args: ['x.c_str()', "(start == 0 ? '~' : start)"]
+    enable_on_boot: false
+
+button:
+  - platform: template
+    id: button0
+    on_press:
+      - key_collector.enable:
+      - key_collector.disable:


### PR DESCRIPTION
# What does this implement/fix?

Enable/disable key collectors which allows different key collectors to be used at different times.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#4895

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
