### PR TITLE
Add missing ifdefs to api_pb2 files

### DIFF
--- a/esphome/components/api/api_pb2.cpp
+++ b/esphome/components/api/api_pb2.cpp
@@ -1049,6 +1049,7 @@ void SubscribeStatesRequest::calculate_size(uint32_t &total_size) const {}
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void SubscribeStatesRequest::dump_to(std::string &out) const { out.append("SubscribeStatesRequest {}"); }
 #endif
+#ifdef USE_BINARY_SENSOR
 bool ListEntitiesBinarySensorResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 6: {
@@ -1168,6 +1169,8 @@ void ListEntitiesBinarySensorResponse::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
+#endif  // USE_BINARY_SENSOR
+#ifdef USE_BINARY_SENSOR
 bool BinarySensorStateResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 2: {
@@ -1221,6 +1224,8 @@ void BinarySensorStateResponse::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
+#endif  // USE_BINARY_SENSOR
+#ifdef USE_COVER
 bool ListEntitiesCoverResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 5: {
@@ -1370,6 +1375,8 @@ void ListEntitiesCoverResponse::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
+#endif  // USE_COVER
+#ifdef USE_COVER
 bool CoverStateResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 2: {
@@ -1445,6 +1452,8 @@ void CoverStateResponse::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
+#endif  // USE_COVER
+#ifdef USE_COVER
 bool CoverCommandRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 2: {
@@ -1550,6 +1559,8 @@ void CoverCommandRequest::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
+#endif  // USE_COVER
+#ifdef USE_FAN
 bool ListEntitiesFanResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 5: {
@@ -1708,6 +1719,8 @@ void ListEntitiesFanResponse::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
+#endif  // USE_FAN
+#ifdef USE_FAN
 bool FanStateResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 2: {
@@ -1808,6 +1821,8 @@ void FanStateResponse::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
+#endif  // USE_FAN
+#ifdef USE_FAN
 bool FanCommandRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 2: {
@@ -1968,6 +1983,8 @@ void FanCommandRequest::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
+#endif  // USE_FAN
+#ifdef USE_LIGHT
 bool ListEntitiesLightResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 12: {
@@ -2165,6 +2182,8 @@ void ListEntitiesLightResponse::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
+#endif  // USE_LIGHT
+#ifdef USE_LIGHT
 bool LightStateResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 2: {
@@ -2333,6 +2352,8 @@ void LightStateResponse::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
+#endif  // USE_LIGHT
+#ifdef USE_LIGHT
 bool LightCommandRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 2: {
@@ -2643,6 +2664,8 @@ void LightCommandRequest::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
+#endif  // USE_LIGHT
+#ifdef USE_SENSOR
 bool ListEntitiesSensorResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 7: {
@@ -2803,6 +2826,8 @@ void ListEntitiesSensorResponse::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
+#endif  // USE_SENSOR
+#ifdef USE_SENSOR
 bool SensorStateResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 3: {
@@ -2857,6 +2882,8 @@ void SensorStateResponse::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
+#endif  // USE_SENSOR
+#ifdef USE_SWITCH
 bool ListEntitiesSwitchResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 6: {
@@ -2976,6 +3003,8 @@ void ListEntitiesSwitchResponse::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
+#endif  // USE_SWITCH
+#ifdef USE_SWITCH
 bool SwitchStateResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 2: {
@@ -3019,6 +3048,8 @@ void SwitchStateResponse::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
+#endif  // USE_SWITCH
+#ifdef USE_SWITCH
 bool SwitchCommandRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 2: {
@@ -3062,6 +3093,8 @@ void SwitchCommandRequest::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
+#endif  // USE_SWITCH
+#ifdef USE_TEXT_SENSOR
 bool ListEntitiesTextSensorResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 6: {
@@ -3171,6 +3204,8 @@ void ListEntitiesTextSensorResponse::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
+#endif  // USE_TEXT_SENSOR
+#ifdef USE_TEXT_SENSOR
 bool TextSensorStateResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 3: {
@@ -3230,6 +3265,7 @@ void TextSensorStateResponse::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
+#endif  // USE_TEXT_SENSOR
 bool SubscribeLogsRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 1: {
@@ -3318,6 +3354,7 @@ void SubscribeLogsResponse::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
+#ifdef USE_API_NOISE
 bool NoiseEncryptionSetKeyRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 1: {
@@ -3342,6 +3379,8 @@ void NoiseEncryptionSetKeyRequest::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
+#endif  // USE_API_NOISE
+#ifdef USE_API_NOISE
 bool NoiseEncryptionSetKeyResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 1: {
@@ -3366,6 +3405,7 @@ void NoiseEncryptionSetKeyResponse::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
+#endif  // USE_API_NOISE
 void SubscribeHomeassistantServicesRequest::encode(ProtoWriteBuffer buffer) const {}
 void SubscribeHomeassistantServicesRequest::calculate_size(uint32_t &total_size) const {}
 #ifdef HAS_PROTO_MESSAGE_DUMP
@@ -3929,6 +3969,7 @@ void ExecuteServiceRequest::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
+#ifdef USE_ESP32_CAMERA
 bool ListEntitiesCameraResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 5: {
@@ -4028,6 +4069,8 @@ void ListEntitiesCameraResponse::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
+#endif  // USE_ESP32_CAMERA
+#ifdef USE_ESP32_CAMERA
 bool CameraImageResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 3: {
@@ -4087,6 +4130,8 @@ void CameraImageResponse::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
+#endif  // USE_ESP32_CAMERA
+#ifdef USE_ESP32_CAMERA
 bool CameraImageRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 1: {
@@ -4123,6 +4168,8 @@ void CameraImageRequest::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
+#endif  // USE_ESP32_CAMERA
+#ifdef USE_CLIMATE
 bool ListEntitiesClimateResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 5: {
@@ -4456,6 +4503,8 @@ void ListEntitiesClimateResponse::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
+#endif  // USE_CLIMATE
+#ifdef USE_CLIMATE
 bool ClimateStateResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 2: {
@@ -4641,6 +4690,8 @@ void ClimateStateResponse::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
+#endif  // USE_CLIMATE
+#ifdef USE_CLIMATE
 bool ClimateCommandRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 2: {
@@ -4904,6 +4955,8 @@ void ClimateCommandRequest::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
+#endif  // USE_CLIMATE
+#ifdef USE_NUMBER
 bool ListEntitiesNumberResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 9: {
@@ -5066,6 +5119,8 @@ void ListEntitiesNumberResponse::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
+#endif  // USE_NUMBER
+#ifdef USE_NUMBER
 bool NumberStateResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 3: {
@@ -5120,6 +5175,8 @@ void NumberStateResponse::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
+#endif  // USE_NUMBER
+#ifdef USE_NUMBER
 bool NumberCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
   switch (field_id) {
     case 1: {
@@ -5158,6 +5215,8 @@ void NumberCommandRequest::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
+#endif  // USE_NUMBER
+#ifdef USE_SELECT
 bool ListEntitiesSelectResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 7: {
@@ -5275,6 +5334,8 @@ void ListEntitiesSelectResponse::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
+#endif  // USE_SELECT
+#ifdef USE_SELECT
 bool SelectStateResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 3: {
@@ -5334,6 +5395,8 @@ void SelectStateResponse::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
+#endif  // USE_SELECT
+#ifdef USE_SELECT
 bool SelectCommandRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 2: {
@@ -5377,6 +5440,8 @@ void SelectCommandRequest::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
+#endif  // USE_SELECT
+#ifdef USE_LOCK
 bool ListEntitiesLockResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 6: {
@@ -5516,6 +5581,8 @@ void ListEntitiesLockResponse::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
+#endif  // USE_LOCK
+#ifdef USE_LOCK
 bool LockStateResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 2: {
@@ -5559,6 +5626,8 @@ void LockStateResponse::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
+#endif  // USE_LOCK
+#ifdef USE_LOCK
 bool LockCommandRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 2: {
@@ -5628,6 +5697,8 @@ void LockCommandRequest::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
+#endif  // USE_LOCK
+#ifdef USE_BUTTON
 bool ListEntitiesButtonResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 6: {
@@ -5737,6 +5808,8 @@ void ListEntitiesButtonResponse::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
+#endif  // USE_BUTTON
+#ifdef USE_BUTTON
 bool ButtonCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
   switch (field_id) {
     case 1: {
@@ -5762,6 +5835,8 @@ void ButtonCommandRequest::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
+#endif  // USE_BUTTON
+#ifdef USE_MEDIA_PLAYER
 bool MediaPlayerSupportedFormat::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 2: {
@@ -5837,6 +5912,8 @@ void MediaPlayerSupportedFormat::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
+#endif  // USE_MEDIA_PLAYER
+#ifdef USE_MEDIA_PLAYER
 bool ListEntitiesMediaPlayerResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 6: {
@@ -5960,6 +6037,8 @@ void ListEntitiesMediaPlayerResponse::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
+#endif  // USE_MEDIA_PLAYER
+#ifdef USE_MEDIA_PLAYER
 bool MediaPlayerStateResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 2: {
@@ -6024,6 +6103,8 @@ void MediaPlayerStateResponse::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
+#endif  // USE_MEDIA_PLAYER
+#ifdef USE_MEDIA_PLAYER
 bool MediaPlayerCommandRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 2: {
@@ -6144,6 +6225,8 @@ void MediaPlayerCommandRequest::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
+#endif  // USE_MEDIA_PLAYER
+#ifdef USE_BLUETOOTH_PROXY
 bool SubscribeBluetoothLEAdvertisementsRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 1: {
@@ -6171,6 +6254,7 @@ void SubscribeBluetoothLEAdvertisementsRequest::dump_to(std::string &out) const 
   out.append("}");
 }
 #endif
+#endif  // USE_BLUETOOTH_PROXY
 bool BluetoothServiceData::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 2: {
@@ -6232,6 +6316,7 @@ void BluetoothServiceData::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
+#ifdef USE_BLUETOOTH_PROXY
 bool BluetoothLEAdvertisementResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 1: {
@@ -6343,6 +6428,7 @@ void BluetoothLEAdvertisementResponse::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
+#endif  // USE_BLUETOOTH_PROXY
 bool BluetoothLERawAdvertisement::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 1: {
@@ -6408,6 +6494,7 @@ void BluetoothLERawAdvertisement::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
+#ifdef USE_BLUETOOTH_PROXY
 bool BluetoothLERawAdvertisementsResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 1: {
@@ -6438,6 +6525,8 @@ void BluetoothLERawAdvertisementsResponse::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
+#endif  // USE_BLUETOOTH_PROXY
+#ifdef USE_BLUETOOTH_PROXY
 bool BluetoothDeviceRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 1: {
@@ -6496,6 +6585,8 @@ void BluetoothDeviceRequest::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
+#endif  // USE_BLUETOOTH_PROXY
+#ifdef USE_BLUETOOTH_PROXY
 bool BluetoothDeviceConnectionResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 1: {
@@ -6555,6 +6646,8 @@ void BluetoothDeviceConnectionResponse::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
+#endif  // USE_BLUETOOTH_PROXY
+#ifdef USE_BLUETOOTH_PROXY
 bool BluetoothGATTGetServicesRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 1: {
@@ -6580,6 +6673,7 @@ void BluetoothGATTGetServicesRequest::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
+#endif  // USE_BLUETOOTH_PROXY
 bool BluetoothGATTDescriptor::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 1: {
@@ -6769,6 +6863,7 @@ void BluetoothGATTService::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
+#ifdef USE_BLUETOOTH_PROXY
 bool BluetoothGATTGetServicesResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 1: {
@@ -6816,6 +6911,8 @@ void BluetoothGATTGetServicesResponse::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
+#endif  // USE_BLUETOOTH_PROXY
+#ifdef USE_BLUETOOTH_PROXY
 bool BluetoothGATTGetServicesDoneResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 1: {
@@ -6843,6 +6940,8 @@ void BluetoothGATTGetServicesDoneResponse::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
+#endif  // USE_BLUETOOTH_PROXY
+#ifdef USE_BLUETOOTH_PROXY
 bool BluetoothGATTReadRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 1: {
@@ -6881,6 +6980,8 @@ void BluetoothGATTReadRequest::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
+#endif  // USE_BLUETOOTH_PROXY
+#ifdef USE_BLUETOOTH_PROXY
 bool BluetoothGATTReadResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 1: {
@@ -6935,6 +7036,8 @@ void BluetoothGATTReadResponse::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
+#endif  // USE_BLUETOOTH_PROXY
+#ifdef USE_BLUETOOTH_PROXY
 bool BluetoothGATTWriteRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 1: {
@@ -6999,6 +7102,8 @@ void BluetoothGATTWriteRequest::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
+#endif  // USE_BLUETOOTH_PROXY
+#ifdef USE_BLUETOOTH_PROXY
 bool BluetoothGATTReadDescriptorRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 1: {
@@ -7037,6 +7142,8 @@ void BluetoothGATTReadDescriptorRequest::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
+#endif  // USE_BLUETOOTH_PROXY
+#ifdef USE_BLUETOOTH_PROXY
 bool BluetoothGATTWriteDescriptorRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 1: {
@@ -7091,6 +7198,8 @@ void BluetoothGATTWriteDescriptorRequest::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
+#endif  // USE_BLUETOOTH_PROXY
+#ifdef USE_BLUETOOTH_PROXY
 bool BluetoothGATTNotifyRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 1: {
@@ -7139,6 +7248,8 @@ void BluetoothGATTNotifyRequest::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
+#endif  // USE_BLUETOOTH_PROXY
+#ifdef USE_BLUETOOTH_PROXY
 bool BluetoothGATTNotifyDataResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 1: {
@@ -7193,6 +7304,8 @@ void BluetoothGATTNotifyDataResponse::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
+#endif  // USE_BLUETOOTH_PROXY
+#ifdef USE_BLUETOOTH_PROXY
 void SubscribeBluetoothConnectionsFreeRequest::encode(ProtoWriteBuffer buffer) const {}
 void SubscribeBluetoothConnectionsFreeRequest::calculate_size(uint32_t &total_size) const {}
 #ifdef HAS_PROTO_MESSAGE_DUMP
@@ -7200,6 +7313,8 @@ void SubscribeBluetoothConnectionsFreeRequest::dump_to(std::string &out) const {
   out.append("SubscribeBluetoothConnectionsFreeRequest {}");
 }
 #endif
+#endif  // USE_BLUETOOTH_PROXY
+#ifdef USE_BLUETOOTH_PROXY
 bool BluetoothConnectionsFreeResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 1: {
@@ -7257,6 +7372,8 @@ void BluetoothConnectionsFreeResponse::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
+#endif  // USE_BLUETOOTH_PROXY
+#ifdef USE_BLUETOOTH_PROXY
 bool BluetoothGATTErrorResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 1: {
@@ -7306,6 +7423,8 @@ void BluetoothGATTErrorResponse::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
+#endif  // USE_BLUETOOTH_PROXY
+#ifdef USE_BLUETOOTH_PROXY
 bool BluetoothGATTWriteResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 1: {
@@ -7344,6 +7463,8 @@ void BluetoothGATTWriteResponse::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
+#endif  // USE_BLUETOOTH_PROXY
+#ifdef USE_BLUETOOTH_PROXY
 bool BluetoothGATTNotifyResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 1: {
@@ -7382,6 +7503,8 @@ void BluetoothGATTNotifyResponse::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
+#endif  // USE_BLUETOOTH_PROXY
+#ifdef USE_BLUETOOTH_PROXY
 bool BluetoothDevicePairingResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 1: {
@@ -7430,6 +7553,8 @@ void BluetoothDevicePairingResponse::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
+#endif  // USE_BLUETOOTH_PROXY
+#ifdef USE_BLUETOOTH_PROXY
 bool BluetoothDeviceUnpairingResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 1: {
@@ -7478,6 +7603,8 @@ void BluetoothDeviceUnpairingResponse::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
+#endif  // USE_BLUETOOTH_PROXY
+#ifdef USE_BLUETOOTH_PROXY
 void UnsubscribeBluetoothLEAdvertisementsRequest::encode(ProtoWriteBuffer buffer) const {}
 void UnsubscribeBluetoothLEAdvertisementsRequest::calculate_size(uint32_t &total_size) const {}
 #ifdef HAS_PROTO_MESSAGE_DUMP
@@ -7485,6 +7612,8 @@ void UnsubscribeBluetoothLEAdvertisementsRequest::dump_to(std::string &out) cons
   out.append("UnsubscribeBluetoothLEAdvertisementsRequest {}");
 }
 #endif
+#endif  // USE_BLUETOOTH_PROXY
+#ifdef USE_BLUETOOTH_PROXY
 bool BluetoothDeviceClearCacheResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 1: {
@@ -7533,6 +7662,8 @@ void BluetoothDeviceClearCacheResponse::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
+#endif  // USE_BLUETOOTH_PROXY
+#ifdef USE_BLUETOOTH_PROXY
 bool BluetoothScannerStateResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 1: {
@@ -7569,6 +7700,8 @@ void BluetoothScannerStateResponse::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
+#endif  // USE_BLUETOOTH_PROXY
+#ifdef USE_BLUETOOTH_PROXY
 bool BluetoothScannerSetModeRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 1: {
@@ -7595,6 +7728,8 @@ void BluetoothScannerSetModeRequest::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
+#endif  // USE_BLUETOOTH_PROXY
+#ifdef USE_VOICE_ASSISTANT
 bool SubscribeVoiceAssistantRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 1: {
@@ -7632,6 +7767,7 @@ void SubscribeVoiceAssistantRequest::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
+#endif  // USE_VOICE_ASSISTANT
 bool VoiceAssistantAudioSettings::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 1: {
@@ -7687,6 +7823,7 @@ void VoiceAssistantAudioSettings::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
+#ifdef USE_VOICE_ASSISTANT
 bool VoiceAssistantRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 1: {
@@ -7760,6 +7897,8 @@ void VoiceAssistantRequest::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
+#endif  // USE_VOICE_ASSISTANT
+#ifdef USE_VOICE_ASSISTANT
 bool VoiceAssistantResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 1: {
@@ -7797,6 +7936,7 @@ void VoiceAssistantResponse::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
+#endif  // USE_VOICE_ASSISTANT
 bool VoiceAssistantEventData::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 1: {
@@ -7833,6 +7973,7 @@ void VoiceAssistantEventData::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
+#ifdef USE_VOICE_ASSISTANT
 bool VoiceAssistantEventResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 1: {
@@ -7879,6 +8020,8 @@ void VoiceAssistantEventResponse::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
+#endif  // USE_VOICE_ASSISTANT
+#ifdef USE_VOICE_ASSISTANT
 bool VoiceAssistantAudio::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 2: {
@@ -7921,6 +8064,8 @@ void VoiceAssistantAudio::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
+#endif  // USE_VOICE_ASSISTANT
+#ifdef USE_VOICE_ASSISTANT
 bool VoiceAssistantTimerEventResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 1: {
@@ -8005,6 +8150,8 @@ void VoiceAssistantTimerEventResponse::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
+#endif  // USE_VOICE_ASSISTANT
+#ifdef USE_VOICE_ASSISTANT
 bool VoiceAssistantAnnounceRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 4: {
@@ -8067,6 +8214,8 @@ void VoiceAssistantAnnounceRequest::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
+#endif  // USE_VOICE_ASSISTANT
+#ifdef USE_VOICE_ASSISTANT
 bool VoiceAssistantAnnounceFinished::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 1: {
@@ -8091,6 +8240,7 @@ void VoiceAssistantAnnounceFinished::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
+#endif  // USE_VOICE_ASSISTANT
 bool VoiceAssistantWakeWord::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 1: {
@@ -8145,6 +8295,7 @@ void VoiceAssistantWakeWord::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
+#ifdef USE_VOICE_ASSISTANT
 void VoiceAssistantConfigurationRequest::encode(ProtoWriteBuffer buffer) const {}
 void VoiceAssistantConfigurationRequest::calculate_size(uint32_t &total_size) const {}
 #ifdef HAS_PROTO_MESSAGE_DUMP
@@ -8152,6 +8303,8 @@ void VoiceAssistantConfigurationRequest::dump_to(std::string &out) const {
   out.append("VoiceAssistantConfigurationRequest {}");
 }
 #endif
+#endif  // USE_VOICE_ASSISTANT
+#ifdef USE_VOICE_ASSISTANT
 bool VoiceAssistantConfigurationResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 3: {
@@ -8217,6 +8370,8 @@ void VoiceAssistantConfigurationResponse::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
+#endif  // USE_VOICE_ASSISTANT
+#ifdef USE_VOICE_ASSISTANT
 bool VoiceAssistantSetConfiguration::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 1: {
@@ -8251,6 +8406,8 @@ void VoiceAssistantSetConfiguration::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
+#endif  // USE_VOICE_ASSISTANT
+#ifdef USE_ALARM_CONTROL_PANEL
 bool ListEntitiesAlarmControlPanelResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 6: {
@@ -8381,6 +8538,8 @@ void ListEntitiesAlarmControlPanelResponse::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
+#endif  // USE_ALARM_CONTROL_PANEL
+#ifdef USE_ALARM_CONTROL_PANEL
 bool AlarmControlPanelStateResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 2: {
@@ -8424,6 +8583,8 @@ void AlarmControlPanelStateResponse::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
+#endif  // USE_ALARM_CONTROL_PANEL
+#ifdef USE_ALARM_CONTROL_PANEL
 bool AlarmControlPanelCommandRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 2: {
@@ -8483,6 +8644,8 @@ void AlarmControlPanelCommandRequest::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
+#endif  // USE_ALARM_CONTROL_PANEL
+#ifdef USE_TEXT
 bool ListEntitiesTextResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 6: {
@@ -8624,6 +8787,8 @@ void ListEntitiesTextResponse::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
+#endif  // USE_TEXT
+#ifdef USE_TEXT
 bool TextStateResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 3: {
@@ -8683,6 +8848,8 @@ void TextStateResponse::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
+#endif  // USE_TEXT
+#ifdef USE_TEXT
 bool TextCommandRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 2: {
@@ -8726,6 +8893,8 @@ void TextCommandRequest::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
+#endif  // USE_TEXT
+#ifdef USE_DATETIME_DATE
 bool ListEntitiesDateResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 6: {
@@ -8825,6 +8994,8 @@ void ListEntitiesDateResponse::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
+#endif  // USE_DATETIME_DATE
+#ifdef USE_DATETIME_DATE
 bool DateStateResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 2: {
@@ -8901,6 +9072,8 @@ void DateStateResponse::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
+#endif  // USE_DATETIME_DATE
+#ifdef USE_DATETIME_DATE
 bool DateCommandRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 2: {
@@ -8967,6 +9140,8 @@ void DateCommandRequest::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
+#endif  // USE_DATETIME_DATE
+#ifdef USE_DATETIME_TIME
 bool ListEntitiesTimeResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 6: {
@@ -9066,6 +9241,8 @@ void ListEntitiesTimeResponse::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
+#endif  // USE_DATETIME_TIME
+#ifdef USE_DATETIME_TIME
 bool TimeStateResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 2: {
@@ -9142,6 +9319,8 @@ void TimeStateResponse::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
+#endif  // USE_DATETIME_TIME
+#ifdef USE_DATETIME_TIME
 bool TimeCommandRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 2: {
@@ -9208,6 +9387,8 @@ void TimeCommandRequest::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
+#endif  // USE_DATETIME_TIME
+#ifdef USE_EVENT
 bool ListEntitiesEventResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 6: {
@@ -9335,6 +9516,8 @@ void ListEntitiesEventResponse::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
+#endif  // USE_EVENT
+#ifdef USE_EVENT
 bool EventResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 2: {
@@ -9378,6 +9561,8 @@ void EventResponse::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
+#endif  // USE_EVENT
+#ifdef USE_VALVE
 bool ListEntitiesValveResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 6: {
@@ -9517,6 +9702,8 @@ void ListEntitiesValveResponse::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
+#endif  // USE_VALVE
+#ifdef USE_VALVE
 bool ValveStateResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 3: {
@@ -9571,6 +9758,8 @@ void ValveStateResponse::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
+#endif  // USE_VALVE
+#ifdef USE_VALVE
 bool ValveCommandRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 2: {
@@ -9635,6 +9824,8 @@ void ValveCommandRequest::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
+#endif  // USE_VALVE
+#ifdef USE_DATETIME_DATETIME
 bool ListEntitiesDateTimeResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 6: {
@@ -9734,6 +9925,8 @@ void ListEntitiesDateTimeResponse::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
+#endif  // USE_DATETIME_DATETIME
+#ifdef USE_DATETIME_DATETIME
 bool DateTimeStateResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 2: {
@@ -9788,6 +9981,8 @@ void DateTimeStateResponse::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
+#endif  // USE_DATETIME_DATETIME
+#ifdef USE_DATETIME_DATETIME
 bool DateTimeCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
   switch (field_id) {
     case 1: {
@@ -9826,6 +10021,8 @@ void DateTimeCommandRequest::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
+#endif  // USE_DATETIME_DATETIME
+#ifdef USE_UPDATE
 bool ListEntitiesUpdateResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 6: {
@@ -9935,6 +10132,8 @@ void ListEntitiesUpdateResponse::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
+#endif  // USE_UPDATE
+#ifdef USE_UPDATE
 bool UpdateStateResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 2: {
@@ -10065,6 +10264,8 @@ void UpdateStateResponse::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
+#endif  // USE_UPDATE
+#ifdef USE_UPDATE
 bool UpdateCommandRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 2: {
@@ -10108,6 +10309,7 @@ void UpdateCommandRequest::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
+#endif  // USE_UPDATE
 
 }  // namespace api
 }  // namespace esphome

--- a/esphome/components/api/api_pb2.cpp
+++ b/esphome/components/api/api_pb2.cpp
@@ -9,7 +9,6 @@
 namespace esphome {
 namespace api {
 
-#ifdef USE_UPDATE
 #ifdef HAS_PROTO_MESSAGE_DUMP
 template<> const char *proto_enum_to_string<enums::EntityCategory>(enums::EntityCategory value) {
   switch (value) {
@@ -24,7 +23,6 @@ template<> const char *proto_enum_to_string<enums::EntityCategory>(enums::Entity
   }
 }
 #endif
-#endif  // USE_UPDATE
 #ifdef USE_COVER
 #ifdef HAS_PROTO_MESSAGE_DUMP
 template<> const char *proto_enum_to_string<enums::LegacyCoverState>(enums::LegacyCoverState value) {

--- a/esphome/components/api/api_pb2.cpp
+++ b/esphome/components/api/api_pb2.cpp
@@ -9,6 +9,7 @@
 namespace esphome {
 namespace api {
 
+#ifdef USE_UPDATE
 #ifdef HAS_PROTO_MESSAGE_DUMP
 template<> const char *proto_enum_to_string<enums::EntityCategory>(enums::EntityCategory value) {
   switch (value) {
@@ -23,6 +24,8 @@ template<> const char *proto_enum_to_string<enums::EntityCategory>(enums::Entity
   }
 }
 #endif
+#endif  // USE_UPDATE
+#ifdef USE_COVER
 #ifdef HAS_PROTO_MESSAGE_DUMP
 template<> const char *proto_enum_to_string<enums::LegacyCoverState>(enums::LegacyCoverState value) {
   switch (value) {
@@ -35,6 +38,8 @@ template<> const char *proto_enum_to_string<enums::LegacyCoverState>(enums::Lega
   }
 }
 #endif
+#endif  // USE_COVER
+#ifdef USE_COVER
 #ifdef HAS_PROTO_MESSAGE_DUMP
 template<> const char *proto_enum_to_string<enums::CoverOperation>(enums::CoverOperation value) {
   switch (value) {
@@ -49,6 +54,8 @@ template<> const char *proto_enum_to_string<enums::CoverOperation>(enums::CoverO
   }
 }
 #endif
+#endif  // USE_COVER
+#ifdef USE_COVER
 #ifdef HAS_PROTO_MESSAGE_DUMP
 template<> const char *proto_enum_to_string<enums::LegacyCoverCommand>(enums::LegacyCoverCommand value) {
   switch (value) {
@@ -63,6 +70,8 @@ template<> const char *proto_enum_to_string<enums::LegacyCoverCommand>(enums::Le
   }
 }
 #endif
+#endif  // USE_COVER
+#ifdef USE_FAN
 #ifdef HAS_PROTO_MESSAGE_DUMP
 template<> const char *proto_enum_to_string<enums::FanSpeed>(enums::FanSpeed value) {
   switch (value) {
@@ -77,6 +86,8 @@ template<> const char *proto_enum_to_string<enums::FanSpeed>(enums::FanSpeed val
   }
 }
 #endif
+#endif  // USE_FAN
+#ifdef USE_FAN
 #ifdef HAS_PROTO_MESSAGE_DUMP
 template<> const char *proto_enum_to_string<enums::FanDirection>(enums::FanDirection value) {
   switch (value) {
@@ -89,6 +100,8 @@ template<> const char *proto_enum_to_string<enums::FanDirection>(enums::FanDirec
   }
 }
 #endif
+#endif  // USE_FAN
+#ifdef USE_LIGHT
 #ifdef HAS_PROTO_MESSAGE_DUMP
 template<> const char *proto_enum_to_string<enums::ColorMode>(enums::ColorMode value) {
   switch (value) {
@@ -117,6 +130,8 @@ template<> const char *proto_enum_to_string<enums::ColorMode>(enums::ColorMode v
   }
 }
 #endif
+#endif  // USE_LIGHT
+#ifdef USE_SENSOR
 #ifdef HAS_PROTO_MESSAGE_DUMP
 template<> const char *proto_enum_to_string<enums::SensorStateClass>(enums::SensorStateClass value) {
   switch (value) {
@@ -133,6 +148,8 @@ template<> const char *proto_enum_to_string<enums::SensorStateClass>(enums::Sens
   }
 }
 #endif
+#endif  // USE_SENSOR
+#ifdef USE_SENSOR
 #ifdef HAS_PROTO_MESSAGE_DUMP
 template<> const char *proto_enum_to_string<enums::SensorLastResetType>(enums::SensorLastResetType value) {
   switch (value) {
@@ -147,6 +164,7 @@ template<> const char *proto_enum_to_string<enums::SensorLastResetType>(enums::S
   }
 }
 #endif
+#endif  // USE_SENSOR
 #ifdef HAS_PROTO_MESSAGE_DUMP
 template<> const char *proto_enum_to_string<enums::LogLevel>(enums::LogLevel value) {
   switch (value) {
@@ -195,6 +213,7 @@ template<> const char *proto_enum_to_string<enums::ServiceArgType>(enums::Servic
   }
 }
 #endif
+#ifdef USE_CLIMATE
 #ifdef HAS_PROTO_MESSAGE_DUMP
 template<> const char *proto_enum_to_string<enums::ClimateMode>(enums::ClimateMode value) {
   switch (value) {
@@ -217,6 +236,8 @@ template<> const char *proto_enum_to_string<enums::ClimateMode>(enums::ClimateMo
   }
 }
 #endif
+#endif  // USE_CLIMATE
+#ifdef USE_CLIMATE
 #ifdef HAS_PROTO_MESSAGE_DUMP
 template<> const char *proto_enum_to_string<enums::ClimateFanMode>(enums::ClimateFanMode value) {
   switch (value) {
@@ -245,6 +266,8 @@ template<> const char *proto_enum_to_string<enums::ClimateFanMode>(enums::Climat
   }
 }
 #endif
+#endif  // USE_CLIMATE
+#ifdef USE_CLIMATE
 #ifdef HAS_PROTO_MESSAGE_DUMP
 template<> const char *proto_enum_to_string<enums::ClimateSwingMode>(enums::ClimateSwingMode value) {
   switch (value) {
@@ -261,6 +284,8 @@ template<> const char *proto_enum_to_string<enums::ClimateSwingMode>(enums::Clim
   }
 }
 #endif
+#endif  // USE_CLIMATE
+#ifdef USE_CLIMATE
 #ifdef HAS_PROTO_MESSAGE_DUMP
 template<> const char *proto_enum_to_string<enums::ClimateAction>(enums::ClimateAction value) {
   switch (value) {
@@ -281,6 +306,8 @@ template<> const char *proto_enum_to_string<enums::ClimateAction>(enums::Climate
   }
 }
 #endif
+#endif  // USE_CLIMATE
+#ifdef USE_CLIMATE
 #ifdef HAS_PROTO_MESSAGE_DUMP
 template<> const char *proto_enum_to_string<enums::ClimatePreset>(enums::ClimatePreset value) {
   switch (value) {
@@ -305,6 +332,8 @@ template<> const char *proto_enum_to_string<enums::ClimatePreset>(enums::Climate
   }
 }
 #endif
+#endif  // USE_CLIMATE
+#ifdef USE_NUMBER
 #ifdef HAS_PROTO_MESSAGE_DUMP
 template<> const char *proto_enum_to_string<enums::NumberMode>(enums::NumberMode value) {
   switch (value) {
@@ -319,6 +348,8 @@ template<> const char *proto_enum_to_string<enums::NumberMode>(enums::NumberMode
   }
 }
 #endif
+#endif  // USE_NUMBER
+#ifdef USE_LOCK
 #ifdef HAS_PROTO_MESSAGE_DUMP
 template<> const char *proto_enum_to_string<enums::LockState>(enums::LockState value) {
   switch (value) {
@@ -339,6 +370,8 @@ template<> const char *proto_enum_to_string<enums::LockState>(enums::LockState v
   }
 }
 #endif
+#endif  // USE_LOCK
+#ifdef USE_LOCK
 #ifdef HAS_PROTO_MESSAGE_DUMP
 template<> const char *proto_enum_to_string<enums::LockCommand>(enums::LockCommand value) {
   switch (value) {
@@ -353,6 +386,8 @@ template<> const char *proto_enum_to_string<enums::LockCommand>(enums::LockComma
   }
 }
 #endif
+#endif  // USE_LOCK
+#ifdef USE_MEDIA_PLAYER
 #ifdef HAS_PROTO_MESSAGE_DUMP
 template<> const char *proto_enum_to_string<enums::MediaPlayerState>(enums::MediaPlayerState value) {
   switch (value) {
@@ -369,6 +404,8 @@ template<> const char *proto_enum_to_string<enums::MediaPlayerState>(enums::Medi
   }
 }
 #endif
+#endif  // USE_MEDIA_PLAYER
+#ifdef USE_MEDIA_PLAYER
 #ifdef HAS_PROTO_MESSAGE_DUMP
 template<> const char *proto_enum_to_string<enums::MediaPlayerCommand>(enums::MediaPlayerCommand value) {
   switch (value) {
@@ -387,6 +424,8 @@ template<> const char *proto_enum_to_string<enums::MediaPlayerCommand>(enums::Me
   }
 }
 #endif
+#endif  // USE_MEDIA_PLAYER
+#ifdef USE_MEDIA_PLAYER
 #ifdef HAS_PROTO_MESSAGE_DUMP
 template<> const char *proto_enum_to_string<enums::MediaPlayerFormatPurpose>(enums::MediaPlayerFormatPurpose value) {
   switch (value) {
@@ -399,6 +438,8 @@ template<> const char *proto_enum_to_string<enums::MediaPlayerFormatPurpose>(enu
   }
 }
 #endif
+#endif  // USE_MEDIA_PLAYER
+#ifdef USE_BLUETOOTH_PROXY
 #ifdef HAS_PROTO_MESSAGE_DUMP
 template<>
 const char *proto_enum_to_string<enums::BluetoothDeviceRequestType>(enums::BluetoothDeviceRequestType value) {
@@ -422,6 +463,8 @@ const char *proto_enum_to_string<enums::BluetoothDeviceRequestType>(enums::Bluet
   }
 }
 #endif
+#endif  // USE_BLUETOOTH_PROXY
+#ifdef USE_BLUETOOTH_PROXY
 #ifdef HAS_PROTO_MESSAGE_DUMP
 template<> const char *proto_enum_to_string<enums::BluetoothScannerState>(enums::BluetoothScannerState value) {
   switch (value) {
@@ -442,6 +485,8 @@ template<> const char *proto_enum_to_string<enums::BluetoothScannerState>(enums:
   }
 }
 #endif
+#endif  // USE_BLUETOOTH_PROXY
+#ifdef USE_BLUETOOTH_PROXY
 #ifdef HAS_PROTO_MESSAGE_DUMP
 template<> const char *proto_enum_to_string<enums::BluetoothScannerMode>(enums::BluetoothScannerMode value) {
   switch (value) {
@@ -454,6 +499,7 @@ template<> const char *proto_enum_to_string<enums::BluetoothScannerMode>(enums::
   }
 }
 #endif
+#endif  // USE_BLUETOOTH_PROXY
 #ifdef HAS_PROTO_MESSAGE_DUMP
 template<>
 const char *proto_enum_to_string<enums::VoiceAssistantSubscribeFlag>(enums::VoiceAssistantSubscribeFlag value) {
@@ -481,6 +527,7 @@ template<> const char *proto_enum_to_string<enums::VoiceAssistantRequestFlag>(en
   }
 }
 #endif
+#ifdef USE_VOICE_ASSISTANT
 #ifdef HAS_PROTO_MESSAGE_DUMP
 template<> const char *proto_enum_to_string<enums::VoiceAssistantEvent>(enums::VoiceAssistantEvent value) {
   switch (value) {
@@ -519,6 +566,8 @@ template<> const char *proto_enum_to_string<enums::VoiceAssistantEvent>(enums::V
   }
 }
 #endif
+#endif  // USE_VOICE_ASSISTANT
+#ifdef USE_VOICE_ASSISTANT
 #ifdef HAS_PROTO_MESSAGE_DUMP
 template<> const char *proto_enum_to_string<enums::VoiceAssistantTimerEvent>(enums::VoiceAssistantTimerEvent value) {
   switch (value) {
@@ -535,6 +584,8 @@ template<> const char *proto_enum_to_string<enums::VoiceAssistantTimerEvent>(enu
   }
 }
 #endif
+#endif  // USE_VOICE_ASSISTANT
+#ifdef USE_ALARM_CONTROL_PANEL
 #ifdef HAS_PROTO_MESSAGE_DUMP
 template<> const char *proto_enum_to_string<enums::AlarmControlPanelState>(enums::AlarmControlPanelState value) {
   switch (value) {
@@ -563,6 +614,8 @@ template<> const char *proto_enum_to_string<enums::AlarmControlPanelState>(enums
   }
 }
 #endif
+#endif  // USE_ALARM_CONTROL_PANEL
+#ifdef USE_ALARM_CONTROL_PANEL
 #ifdef HAS_PROTO_MESSAGE_DUMP
 template<>
 const char *proto_enum_to_string<enums::AlarmControlPanelStateCommand>(enums::AlarmControlPanelStateCommand value) {
@@ -586,6 +639,8 @@ const char *proto_enum_to_string<enums::AlarmControlPanelStateCommand>(enums::Al
   }
 }
 #endif
+#endif  // USE_ALARM_CONTROL_PANEL
+#ifdef USE_TEXT
 #ifdef HAS_PROTO_MESSAGE_DUMP
 template<> const char *proto_enum_to_string<enums::TextMode>(enums::TextMode value) {
   switch (value) {
@@ -598,6 +653,8 @@ template<> const char *proto_enum_to_string<enums::TextMode>(enums::TextMode val
   }
 }
 #endif
+#endif  // USE_TEXT
+#ifdef USE_VALVE
 #ifdef HAS_PROTO_MESSAGE_DUMP
 template<> const char *proto_enum_to_string<enums::ValveOperation>(enums::ValveOperation value) {
   switch (value) {
@@ -612,6 +669,8 @@ template<> const char *proto_enum_to_string<enums::ValveOperation>(enums::ValveO
   }
 }
 #endif
+#endif  // USE_VALVE
+#ifdef USE_UPDATE
 #ifdef HAS_PROTO_MESSAGE_DUMP
 template<> const char *proto_enum_to_string<enums::UpdateCommand>(enums::UpdateCommand value) {
   switch (value) {
@@ -626,6 +685,7 @@ template<> const char *proto_enum_to_string<enums::UpdateCommand>(enums::UpdateC
   }
 }
 #endif
+#endif  // USE_UPDATE
 bool HelloRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 2: {

--- a/esphome/components/api/api_pb2.h
+++ b/esphome/components/api/api_pb2.h
@@ -418,6 +418,7 @@ class SubscribeStatesRequest : public ProtoMessage {
 
  protected:
 };
+#ifdef USE_BINARY_SENSOR
 class ListEntitiesBinarySensorResponse : public ProtoMessage {
  public:
   std::string object_id{};
@@ -440,6 +441,8 @@ class ListEntitiesBinarySensorResponse : public ProtoMessage {
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
+#endif  // USE_BINARY_SENSOR
+#ifdef USE_BINARY_SENSOR
 class BinarySensorStateResponse : public ProtoMessage {
  public:
   uint32_t key{0};
@@ -455,6 +458,8 @@ class BinarySensorStateResponse : public ProtoMessage {
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
+#endif  // USE_BINARY_SENSOR
+#ifdef USE_COVER
 class ListEntitiesCoverResponse : public ProtoMessage {
  public:
   std::string object_id{};
@@ -480,6 +485,8 @@ class ListEntitiesCoverResponse : public ProtoMessage {
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
+#endif  // USE_COVER
+#ifdef USE_COVER
 class CoverStateResponse : public ProtoMessage {
  public:
   uint32_t key{0};
@@ -497,6 +504,8 @@ class CoverStateResponse : public ProtoMessage {
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
+#endif  // USE_COVER
+#ifdef USE_COVER
 class CoverCommandRequest : public ProtoMessage {
  public:
   uint32_t key{0};
@@ -517,6 +526,8 @@ class CoverCommandRequest : public ProtoMessage {
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
+#endif  // USE_COVER
+#ifdef USE_FAN
 class ListEntitiesFanResponse : public ProtoMessage {
  public:
   std::string object_id{};
@@ -542,6 +553,8 @@ class ListEntitiesFanResponse : public ProtoMessage {
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
+#endif  // USE_FAN
+#ifdef USE_FAN
 class FanStateResponse : public ProtoMessage {
  public:
   uint32_t key{0};
@@ -562,6 +575,8 @@ class FanStateResponse : public ProtoMessage {
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
+#endif  // USE_FAN
+#ifdef USE_FAN
 class FanCommandRequest : public ProtoMessage {
  public:
   uint32_t key{0};
@@ -588,6 +603,8 @@ class FanCommandRequest : public ProtoMessage {
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
+#endif  // USE_FAN
+#ifdef USE_LIGHT
 class ListEntitiesLightResponse : public ProtoMessage {
  public:
   std::string object_id{};
@@ -616,6 +633,8 @@ class ListEntitiesLightResponse : public ProtoMessage {
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
+#endif  // USE_LIGHT
+#ifdef USE_LIGHT
 class LightStateResponse : public ProtoMessage {
  public:
   uint32_t key{0};
@@ -642,6 +661,8 @@ class LightStateResponse : public ProtoMessage {
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
+#endif  // USE_LIGHT
+#ifdef USE_LIGHT
 class LightCommandRequest : public ProtoMessage {
  public:
   uint32_t key{0};
@@ -682,6 +703,8 @@ class LightCommandRequest : public ProtoMessage {
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
+#endif  // USE_LIGHT
+#ifdef USE_SENSOR
 class ListEntitiesSensorResponse : public ProtoMessage {
  public:
   std::string object_id{};
@@ -708,6 +731,8 @@ class ListEntitiesSensorResponse : public ProtoMessage {
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
+#endif  // USE_SENSOR
+#ifdef USE_SENSOR
 class SensorStateResponse : public ProtoMessage {
  public:
   uint32_t key{0};
@@ -723,6 +748,8 @@ class SensorStateResponse : public ProtoMessage {
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
+#endif  // USE_SENSOR
+#ifdef USE_SWITCH
 class ListEntitiesSwitchResponse : public ProtoMessage {
  public:
   std::string object_id{};
@@ -745,6 +772,8 @@ class ListEntitiesSwitchResponse : public ProtoMessage {
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
+#endif  // USE_SWITCH
+#ifdef USE_SWITCH
 class SwitchStateResponse : public ProtoMessage {
  public:
   uint32_t key{0};
@@ -759,6 +788,8 @@ class SwitchStateResponse : public ProtoMessage {
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
+#endif  // USE_SWITCH
+#ifdef USE_SWITCH
 class SwitchCommandRequest : public ProtoMessage {
  public:
   uint32_t key{0};
@@ -773,6 +804,8 @@ class SwitchCommandRequest : public ProtoMessage {
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
+#endif  // USE_SWITCH
+#ifdef USE_TEXT_SENSOR
 class ListEntitiesTextSensorResponse : public ProtoMessage {
  public:
   std::string object_id{};
@@ -794,6 +827,8 @@ class ListEntitiesTextSensorResponse : public ProtoMessage {
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
+#endif  // USE_TEXT_SENSOR
+#ifdef USE_TEXT_SENSOR
 class TextSensorStateResponse : public ProtoMessage {
  public:
   uint32_t key{0};
@@ -810,6 +845,7 @@ class TextSensorStateResponse : public ProtoMessage {
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
+#endif  // USE_TEXT_SENSOR
 class SubscribeLogsRequest : public ProtoMessage {
  public:
   enums::LogLevel level{};
@@ -838,6 +874,7 @@ class SubscribeLogsResponse : public ProtoMessage {
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
+#ifdef USE_API_NOISE
 class NoiseEncryptionSetKeyRequest : public ProtoMessage {
  public:
   std::string key{};
@@ -850,6 +887,8 @@ class NoiseEncryptionSetKeyRequest : public ProtoMessage {
  protected:
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
 };
+#endif  // USE_API_NOISE
+#ifdef USE_API_NOISE
 class NoiseEncryptionSetKeyResponse : public ProtoMessage {
  public:
   bool success{false};
@@ -862,6 +901,7 @@ class NoiseEncryptionSetKeyResponse : public ProtoMessage {
  protected:
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
+#endif  // USE_API_NOISE
 class SubscribeHomeassistantServicesRequest : public ProtoMessage {
  public:
   void encode(ProtoWriteBuffer buffer) const override;
@@ -1028,6 +1068,7 @@ class ExecuteServiceRequest : public ProtoMessage {
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
 };
+#ifdef USE_ESP32_CAMERA
 class ListEntitiesCameraResponse : public ProtoMessage {
  public:
   std::string object_id{};
@@ -1048,6 +1089,8 @@ class ListEntitiesCameraResponse : public ProtoMessage {
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
+#endif  // USE_ESP32_CAMERA
+#ifdef USE_ESP32_CAMERA
 class CameraImageResponse : public ProtoMessage {
  public:
   uint32_t key{0};
@@ -1064,6 +1107,8 @@ class CameraImageResponse : public ProtoMessage {
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
+#endif  // USE_ESP32_CAMERA
+#ifdef USE_ESP32_CAMERA
 class CameraImageRequest : public ProtoMessage {
  public:
   bool single{false};
@@ -1077,6 +1122,8 @@ class CameraImageRequest : public ProtoMessage {
  protected:
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
+#endif  // USE_ESP32_CAMERA
+#ifdef USE_CLIMATE
 class ListEntitiesClimateResponse : public ProtoMessage {
  public:
   std::string object_id{};
@@ -1115,6 +1162,8 @@ class ListEntitiesClimateResponse : public ProtoMessage {
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
+#endif  // USE_CLIMATE
+#ifdef USE_CLIMATE
 class ClimateStateResponse : public ProtoMessage {
  public:
   uint32_t key{0};
@@ -1143,6 +1192,8 @@ class ClimateStateResponse : public ProtoMessage {
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
+#endif  // USE_CLIMATE
+#ifdef USE_CLIMATE
 class ClimateCommandRequest : public ProtoMessage {
  public:
   uint32_t key{0};
@@ -1179,6 +1230,8 @@ class ClimateCommandRequest : public ProtoMessage {
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
+#endif  // USE_CLIMATE
+#ifdef USE_NUMBER
 class ListEntitiesNumberResponse : public ProtoMessage {
  public:
   std::string object_id{};
@@ -1205,6 +1258,8 @@ class ListEntitiesNumberResponse : public ProtoMessage {
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
+#endif  // USE_NUMBER
+#ifdef USE_NUMBER
 class NumberStateResponse : public ProtoMessage {
  public:
   uint32_t key{0};
@@ -1220,6 +1275,8 @@ class NumberStateResponse : public ProtoMessage {
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
+#endif  // USE_NUMBER
+#ifdef USE_NUMBER
 class NumberCommandRequest : public ProtoMessage {
  public:
   uint32_t key{0};
@@ -1233,6 +1290,8 @@ class NumberCommandRequest : public ProtoMessage {
  protected:
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
 };
+#endif  // USE_NUMBER
+#ifdef USE_SELECT
 class ListEntitiesSelectResponse : public ProtoMessage {
  public:
   std::string object_id{};
@@ -1254,6 +1313,8 @@ class ListEntitiesSelectResponse : public ProtoMessage {
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
+#endif  // USE_SELECT
+#ifdef USE_SELECT
 class SelectStateResponse : public ProtoMessage {
  public:
   uint32_t key{0};
@@ -1270,6 +1331,8 @@ class SelectStateResponse : public ProtoMessage {
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
+#endif  // USE_SELECT
+#ifdef USE_SELECT
 class SelectCommandRequest : public ProtoMessage {
  public:
   uint32_t key{0};
@@ -1284,6 +1347,8 @@ class SelectCommandRequest : public ProtoMessage {
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
 };
+#endif  // USE_SELECT
+#ifdef USE_LOCK
 class ListEntitiesLockResponse : public ProtoMessage {
  public:
   std::string object_id{};
@@ -1308,6 +1373,8 @@ class ListEntitiesLockResponse : public ProtoMessage {
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
+#endif  // USE_LOCK
+#ifdef USE_LOCK
 class LockStateResponse : public ProtoMessage {
  public:
   uint32_t key{0};
@@ -1322,6 +1389,8 @@ class LockStateResponse : public ProtoMessage {
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
+#endif  // USE_LOCK
+#ifdef USE_LOCK
 class LockCommandRequest : public ProtoMessage {
  public:
   uint32_t key{0};
@@ -1339,6 +1408,8 @@ class LockCommandRequest : public ProtoMessage {
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
+#endif  // USE_LOCK
+#ifdef USE_BUTTON
 class ListEntitiesButtonResponse : public ProtoMessage {
  public:
   std::string object_id{};
@@ -1360,6 +1431,8 @@ class ListEntitiesButtonResponse : public ProtoMessage {
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
+#endif  // USE_BUTTON
+#ifdef USE_BUTTON
 class ButtonCommandRequest : public ProtoMessage {
  public:
   uint32_t key{0};
@@ -1372,6 +1445,8 @@ class ButtonCommandRequest : public ProtoMessage {
  protected:
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
 };
+#endif  // USE_BUTTON
+#ifdef USE_MEDIA_PLAYER
 class MediaPlayerSupportedFormat : public ProtoMessage {
  public:
   std::string format{};
@@ -1389,6 +1464,8 @@ class MediaPlayerSupportedFormat : public ProtoMessage {
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
+#endif  // USE_MEDIA_PLAYER
+#ifdef USE_MEDIA_PLAYER
 class ListEntitiesMediaPlayerResponse : public ProtoMessage {
  public:
   std::string object_id{};
@@ -1411,6 +1488,8 @@ class ListEntitiesMediaPlayerResponse : public ProtoMessage {
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
+#endif  // USE_MEDIA_PLAYER
+#ifdef USE_MEDIA_PLAYER
 class MediaPlayerStateResponse : public ProtoMessage {
  public:
   uint32_t key{0};
@@ -1427,6 +1506,8 @@ class MediaPlayerStateResponse : public ProtoMessage {
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
+#endif  // USE_MEDIA_PLAYER
+#ifdef USE_MEDIA_PLAYER
 class MediaPlayerCommandRequest : public ProtoMessage {
  public:
   uint32_t key{0};
@@ -1449,6 +1530,8 @@ class MediaPlayerCommandRequest : public ProtoMessage {
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
+#endif  // USE_MEDIA_PLAYER
+#ifdef USE_BLUETOOTH_PROXY
 class SubscribeBluetoothLEAdvertisementsRequest : public ProtoMessage {
  public:
   uint32_t flags{0};
@@ -1461,6 +1544,7 @@ class SubscribeBluetoothLEAdvertisementsRequest : public ProtoMessage {
  protected:
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
+#endif  // USE_BLUETOOTH_PROXY
 class BluetoothServiceData : public ProtoMessage {
  public:
   std::string uuid{};
@@ -1476,6 +1560,7 @@ class BluetoothServiceData : public ProtoMessage {
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
+#ifdef USE_BLUETOOTH_PROXY
 class BluetoothLEAdvertisementResponse : public ProtoMessage {
  public:
   uint64_t address{0};
@@ -1495,6 +1580,7 @@ class BluetoothLEAdvertisementResponse : public ProtoMessage {
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
+#endif  // USE_BLUETOOTH_PROXY
 class BluetoothLERawAdvertisement : public ProtoMessage {
  public:
   uint64_t address{0};
@@ -1511,6 +1597,7 @@ class BluetoothLERawAdvertisement : public ProtoMessage {
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
+#ifdef USE_BLUETOOTH_PROXY
 class BluetoothLERawAdvertisementsResponse : public ProtoMessage {
  public:
   std::vector<BluetoothLERawAdvertisement> advertisements{};
@@ -1523,6 +1610,8 @@ class BluetoothLERawAdvertisementsResponse : public ProtoMessage {
  protected:
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
 };
+#endif  // USE_BLUETOOTH_PROXY
+#ifdef USE_BLUETOOTH_PROXY
 class BluetoothDeviceRequest : public ProtoMessage {
  public:
   uint64_t address{0};
@@ -1538,6 +1627,8 @@ class BluetoothDeviceRequest : public ProtoMessage {
  protected:
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
+#endif  // USE_BLUETOOTH_PROXY
+#ifdef USE_BLUETOOTH_PROXY
 class BluetoothDeviceConnectionResponse : public ProtoMessage {
  public:
   uint64_t address{0};
@@ -1553,6 +1644,8 @@ class BluetoothDeviceConnectionResponse : public ProtoMessage {
  protected:
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
+#endif  // USE_BLUETOOTH_PROXY
+#ifdef USE_BLUETOOTH_PROXY
 class BluetoothGATTGetServicesRequest : public ProtoMessage {
  public:
   uint64_t address{0};
@@ -1565,6 +1658,7 @@ class BluetoothGATTGetServicesRequest : public ProtoMessage {
  protected:
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
+#endif  // USE_BLUETOOTH_PROXY
 class BluetoothGATTDescriptor : public ProtoMessage {
  public:
   std::vector<uint64_t> uuid{};
@@ -1609,6 +1703,7 @@ class BluetoothGATTService : public ProtoMessage {
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
+#ifdef USE_BLUETOOTH_PROXY
 class BluetoothGATTGetServicesResponse : public ProtoMessage {
  public:
   uint64_t address{0};
@@ -1623,6 +1718,8 @@ class BluetoothGATTGetServicesResponse : public ProtoMessage {
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
+#endif  // USE_BLUETOOTH_PROXY
+#ifdef USE_BLUETOOTH_PROXY
 class BluetoothGATTGetServicesDoneResponse : public ProtoMessage {
  public:
   uint64_t address{0};
@@ -1635,6 +1732,8 @@ class BluetoothGATTGetServicesDoneResponse : public ProtoMessage {
  protected:
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
+#endif  // USE_BLUETOOTH_PROXY
+#ifdef USE_BLUETOOTH_PROXY
 class BluetoothGATTReadRequest : public ProtoMessage {
  public:
   uint64_t address{0};
@@ -1648,6 +1747,8 @@ class BluetoothGATTReadRequest : public ProtoMessage {
  protected:
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
+#endif  // USE_BLUETOOTH_PROXY
+#ifdef USE_BLUETOOTH_PROXY
 class BluetoothGATTReadResponse : public ProtoMessage {
  public:
   uint64_t address{0};
@@ -1663,6 +1764,8 @@ class BluetoothGATTReadResponse : public ProtoMessage {
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
+#endif  // USE_BLUETOOTH_PROXY
+#ifdef USE_BLUETOOTH_PROXY
 class BluetoothGATTWriteRequest : public ProtoMessage {
  public:
   uint64_t address{0};
@@ -1679,6 +1782,8 @@ class BluetoothGATTWriteRequest : public ProtoMessage {
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
+#endif  // USE_BLUETOOTH_PROXY
+#ifdef USE_BLUETOOTH_PROXY
 class BluetoothGATTReadDescriptorRequest : public ProtoMessage {
  public:
   uint64_t address{0};
@@ -1692,6 +1797,8 @@ class BluetoothGATTReadDescriptorRequest : public ProtoMessage {
  protected:
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
+#endif  // USE_BLUETOOTH_PROXY
+#ifdef USE_BLUETOOTH_PROXY
 class BluetoothGATTWriteDescriptorRequest : public ProtoMessage {
  public:
   uint64_t address{0};
@@ -1707,6 +1814,8 @@ class BluetoothGATTWriteDescriptorRequest : public ProtoMessage {
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
+#endif  // USE_BLUETOOTH_PROXY
+#ifdef USE_BLUETOOTH_PROXY
 class BluetoothGATTNotifyRequest : public ProtoMessage {
  public:
   uint64_t address{0};
@@ -1721,6 +1830,8 @@ class BluetoothGATTNotifyRequest : public ProtoMessage {
  protected:
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
+#endif  // USE_BLUETOOTH_PROXY
+#ifdef USE_BLUETOOTH_PROXY
 class BluetoothGATTNotifyDataResponse : public ProtoMessage {
  public:
   uint64_t address{0};
@@ -1736,6 +1847,8 @@ class BluetoothGATTNotifyDataResponse : public ProtoMessage {
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
+#endif  // USE_BLUETOOTH_PROXY
+#ifdef USE_BLUETOOTH_PROXY
 class SubscribeBluetoothConnectionsFreeRequest : public ProtoMessage {
  public:
   void encode(ProtoWriteBuffer buffer) const override;
@@ -1746,6 +1859,8 @@ class SubscribeBluetoothConnectionsFreeRequest : public ProtoMessage {
 
  protected:
 };
+#endif  // USE_BLUETOOTH_PROXY
+#ifdef USE_BLUETOOTH_PROXY
 class BluetoothConnectionsFreeResponse : public ProtoMessage {
  public:
   uint32_t free{0};
@@ -1760,6 +1875,8 @@ class BluetoothConnectionsFreeResponse : public ProtoMessage {
  protected:
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
+#endif  // USE_BLUETOOTH_PROXY
+#ifdef USE_BLUETOOTH_PROXY
 class BluetoothGATTErrorResponse : public ProtoMessage {
  public:
   uint64_t address{0};
@@ -1774,6 +1891,8 @@ class BluetoothGATTErrorResponse : public ProtoMessage {
  protected:
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
+#endif  // USE_BLUETOOTH_PROXY
+#ifdef USE_BLUETOOTH_PROXY
 class BluetoothGATTWriteResponse : public ProtoMessage {
  public:
   uint64_t address{0};
@@ -1787,6 +1906,8 @@ class BluetoothGATTWriteResponse : public ProtoMessage {
  protected:
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
+#endif  // USE_BLUETOOTH_PROXY
+#ifdef USE_BLUETOOTH_PROXY
 class BluetoothGATTNotifyResponse : public ProtoMessage {
  public:
   uint64_t address{0};
@@ -1800,6 +1921,8 @@ class BluetoothGATTNotifyResponse : public ProtoMessage {
  protected:
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
+#endif  // USE_BLUETOOTH_PROXY
+#ifdef USE_BLUETOOTH_PROXY
 class BluetoothDevicePairingResponse : public ProtoMessage {
  public:
   uint64_t address{0};
@@ -1814,6 +1937,8 @@ class BluetoothDevicePairingResponse : public ProtoMessage {
  protected:
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
+#endif  // USE_BLUETOOTH_PROXY
+#ifdef USE_BLUETOOTH_PROXY
 class BluetoothDeviceUnpairingResponse : public ProtoMessage {
  public:
   uint64_t address{0};
@@ -1828,6 +1953,8 @@ class BluetoothDeviceUnpairingResponse : public ProtoMessage {
  protected:
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
+#endif  // USE_BLUETOOTH_PROXY
+#ifdef USE_BLUETOOTH_PROXY
 class UnsubscribeBluetoothLEAdvertisementsRequest : public ProtoMessage {
  public:
   void encode(ProtoWriteBuffer buffer) const override;
@@ -1838,6 +1965,8 @@ class UnsubscribeBluetoothLEAdvertisementsRequest : public ProtoMessage {
 
  protected:
 };
+#endif  // USE_BLUETOOTH_PROXY
+#ifdef USE_BLUETOOTH_PROXY
 class BluetoothDeviceClearCacheResponse : public ProtoMessage {
  public:
   uint64_t address{0};
@@ -1852,6 +1981,8 @@ class BluetoothDeviceClearCacheResponse : public ProtoMessage {
  protected:
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
+#endif  // USE_BLUETOOTH_PROXY
+#ifdef USE_BLUETOOTH_PROXY
 class BluetoothScannerStateResponse : public ProtoMessage {
  public:
   enums::BluetoothScannerState state{};
@@ -1865,6 +1996,8 @@ class BluetoothScannerStateResponse : public ProtoMessage {
  protected:
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
+#endif  // USE_BLUETOOTH_PROXY
+#ifdef USE_BLUETOOTH_PROXY
 class BluetoothScannerSetModeRequest : public ProtoMessage {
  public:
   enums::BluetoothScannerMode mode{};
@@ -1877,6 +2010,8 @@ class BluetoothScannerSetModeRequest : public ProtoMessage {
  protected:
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
+#endif  // USE_BLUETOOTH_PROXY
+#ifdef USE_VOICE_ASSISTANT
 class SubscribeVoiceAssistantRequest : public ProtoMessage {
  public:
   bool subscribe{false};
@@ -1890,6 +2025,7 @@ class SubscribeVoiceAssistantRequest : public ProtoMessage {
  protected:
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
+#endif  // USE_VOICE_ASSISTANT
 class VoiceAssistantAudioSettings : public ProtoMessage {
  public:
   uint32_t noise_suppression_level{0};
@@ -1905,6 +2041,7 @@ class VoiceAssistantAudioSettings : public ProtoMessage {
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
+#ifdef USE_VOICE_ASSISTANT
 class VoiceAssistantRequest : public ProtoMessage {
  public:
   bool start{false};
@@ -1922,6 +2059,8 @@ class VoiceAssistantRequest : public ProtoMessage {
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
+#endif  // USE_VOICE_ASSISTANT
+#ifdef USE_VOICE_ASSISTANT
 class VoiceAssistantResponse : public ProtoMessage {
  public:
   uint32_t port{0};
@@ -1935,6 +2074,7 @@ class VoiceAssistantResponse : public ProtoMessage {
  protected:
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
+#endif  // USE_VOICE_ASSISTANT
 class VoiceAssistantEventData : public ProtoMessage {
  public:
   std::string name{};
@@ -1948,6 +2088,7 @@ class VoiceAssistantEventData : public ProtoMessage {
  protected:
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
 };
+#ifdef USE_VOICE_ASSISTANT
 class VoiceAssistantEventResponse : public ProtoMessage {
  public:
   enums::VoiceAssistantEvent event_type{};
@@ -1962,6 +2103,8 @@ class VoiceAssistantEventResponse : public ProtoMessage {
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
+#endif  // USE_VOICE_ASSISTANT
+#ifdef USE_VOICE_ASSISTANT
 class VoiceAssistantAudio : public ProtoMessage {
  public:
   std::string data{};
@@ -1976,6 +2119,8 @@ class VoiceAssistantAudio : public ProtoMessage {
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
+#endif  // USE_VOICE_ASSISTANT
+#ifdef USE_VOICE_ASSISTANT
 class VoiceAssistantTimerEventResponse : public ProtoMessage {
  public:
   enums::VoiceAssistantTimerEvent event_type{};
@@ -1994,6 +2139,8 @@ class VoiceAssistantTimerEventResponse : public ProtoMessage {
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
+#endif  // USE_VOICE_ASSISTANT
+#ifdef USE_VOICE_ASSISTANT
 class VoiceAssistantAnnounceRequest : public ProtoMessage {
  public:
   std::string media_id{};
@@ -2010,6 +2157,8 @@ class VoiceAssistantAnnounceRequest : public ProtoMessage {
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
+#endif  // USE_VOICE_ASSISTANT
+#ifdef USE_VOICE_ASSISTANT
 class VoiceAssistantAnnounceFinished : public ProtoMessage {
  public:
   bool success{false};
@@ -2022,6 +2171,7 @@ class VoiceAssistantAnnounceFinished : public ProtoMessage {
  protected:
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
+#endif  // USE_VOICE_ASSISTANT
 class VoiceAssistantWakeWord : public ProtoMessage {
  public:
   std::string id{};
@@ -2036,6 +2186,7 @@ class VoiceAssistantWakeWord : public ProtoMessage {
  protected:
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
 };
+#ifdef USE_VOICE_ASSISTANT
 class VoiceAssistantConfigurationRequest : public ProtoMessage {
  public:
   void encode(ProtoWriteBuffer buffer) const override;
@@ -2046,6 +2197,8 @@ class VoiceAssistantConfigurationRequest : public ProtoMessage {
 
  protected:
 };
+#endif  // USE_VOICE_ASSISTANT
+#ifdef USE_VOICE_ASSISTANT
 class VoiceAssistantConfigurationResponse : public ProtoMessage {
  public:
   std::vector<VoiceAssistantWakeWord> available_wake_words{};
@@ -2061,6 +2214,8 @@ class VoiceAssistantConfigurationResponse : public ProtoMessage {
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
+#endif  // USE_VOICE_ASSISTANT
+#ifdef USE_VOICE_ASSISTANT
 class VoiceAssistantSetConfiguration : public ProtoMessage {
  public:
   std::vector<std::string> active_wake_words{};
@@ -2073,6 +2228,8 @@ class VoiceAssistantSetConfiguration : public ProtoMessage {
  protected:
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
 };
+#endif  // USE_VOICE_ASSISTANT
+#ifdef USE_ALARM_CONTROL_PANEL
 class ListEntitiesAlarmControlPanelResponse : public ProtoMessage {
  public:
   std::string object_id{};
@@ -2096,6 +2253,8 @@ class ListEntitiesAlarmControlPanelResponse : public ProtoMessage {
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
+#endif  // USE_ALARM_CONTROL_PANEL
+#ifdef USE_ALARM_CONTROL_PANEL
 class AlarmControlPanelStateResponse : public ProtoMessage {
  public:
   uint32_t key{0};
@@ -2110,6 +2269,8 @@ class AlarmControlPanelStateResponse : public ProtoMessage {
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
+#endif  // USE_ALARM_CONTROL_PANEL
+#ifdef USE_ALARM_CONTROL_PANEL
 class AlarmControlPanelCommandRequest : public ProtoMessage {
  public:
   uint32_t key{0};
@@ -2126,6 +2287,8 @@ class AlarmControlPanelCommandRequest : public ProtoMessage {
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
+#endif  // USE_ALARM_CONTROL_PANEL
+#ifdef USE_TEXT
 class ListEntitiesTextResponse : public ProtoMessage {
  public:
   std::string object_id{};
@@ -2150,6 +2313,8 @@ class ListEntitiesTextResponse : public ProtoMessage {
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
+#endif  // USE_TEXT
+#ifdef USE_TEXT
 class TextStateResponse : public ProtoMessage {
  public:
   uint32_t key{0};
@@ -2166,6 +2331,8 @@ class TextStateResponse : public ProtoMessage {
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
+#endif  // USE_TEXT
+#ifdef USE_TEXT
 class TextCommandRequest : public ProtoMessage {
  public:
   uint32_t key{0};
@@ -2180,6 +2347,8 @@ class TextCommandRequest : public ProtoMessage {
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
 };
+#endif  // USE_TEXT
+#ifdef USE_DATETIME_DATE
 class ListEntitiesDateResponse : public ProtoMessage {
  public:
   std::string object_id{};
@@ -2200,6 +2369,8 @@ class ListEntitiesDateResponse : public ProtoMessage {
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
+#endif  // USE_DATETIME_DATE
+#ifdef USE_DATETIME_DATE
 class DateStateResponse : public ProtoMessage {
  public:
   uint32_t key{0};
@@ -2217,6 +2388,8 @@ class DateStateResponse : public ProtoMessage {
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
+#endif  // USE_DATETIME_DATE
+#ifdef USE_DATETIME_DATE
 class DateCommandRequest : public ProtoMessage {
  public:
   uint32_t key{0};
@@ -2233,6 +2406,8 @@ class DateCommandRequest : public ProtoMessage {
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
+#endif  // USE_DATETIME_DATE
+#ifdef USE_DATETIME_TIME
 class ListEntitiesTimeResponse : public ProtoMessage {
  public:
   std::string object_id{};
@@ -2253,6 +2428,8 @@ class ListEntitiesTimeResponse : public ProtoMessage {
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
+#endif  // USE_DATETIME_TIME
+#ifdef USE_DATETIME_TIME
 class TimeStateResponse : public ProtoMessage {
  public:
   uint32_t key{0};
@@ -2270,6 +2447,8 @@ class TimeStateResponse : public ProtoMessage {
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
+#endif  // USE_DATETIME_TIME
+#ifdef USE_DATETIME_TIME
 class TimeCommandRequest : public ProtoMessage {
  public:
   uint32_t key{0};
@@ -2286,6 +2465,8 @@ class TimeCommandRequest : public ProtoMessage {
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
+#endif  // USE_DATETIME_TIME
+#ifdef USE_EVENT
 class ListEntitiesEventResponse : public ProtoMessage {
  public:
   std::string object_id{};
@@ -2308,6 +2489,8 @@ class ListEntitiesEventResponse : public ProtoMessage {
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
+#endif  // USE_EVENT
+#ifdef USE_EVENT
 class EventResponse : public ProtoMessage {
  public:
   uint32_t key{0};
@@ -2322,6 +2505,8 @@ class EventResponse : public ProtoMessage {
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
 };
+#endif  // USE_EVENT
+#ifdef USE_VALVE
 class ListEntitiesValveResponse : public ProtoMessage {
  public:
   std::string object_id{};
@@ -2346,6 +2531,8 @@ class ListEntitiesValveResponse : public ProtoMessage {
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
+#endif  // USE_VALVE
+#ifdef USE_VALVE
 class ValveStateResponse : public ProtoMessage {
  public:
   uint32_t key{0};
@@ -2361,6 +2548,8 @@ class ValveStateResponse : public ProtoMessage {
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
+#endif  // USE_VALVE
+#ifdef USE_VALVE
 class ValveCommandRequest : public ProtoMessage {
  public:
   uint32_t key{0};
@@ -2377,6 +2566,8 @@ class ValveCommandRequest : public ProtoMessage {
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
+#endif  // USE_VALVE
+#ifdef USE_DATETIME_DATETIME
 class ListEntitiesDateTimeResponse : public ProtoMessage {
  public:
   std::string object_id{};
@@ -2397,6 +2588,8 @@ class ListEntitiesDateTimeResponse : public ProtoMessage {
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
+#endif  // USE_DATETIME_DATETIME
+#ifdef USE_DATETIME_DATETIME
 class DateTimeStateResponse : public ProtoMessage {
  public:
   uint32_t key{0};
@@ -2412,6 +2605,8 @@ class DateTimeStateResponse : public ProtoMessage {
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
+#endif  // USE_DATETIME_DATETIME
+#ifdef USE_DATETIME_DATETIME
 class DateTimeCommandRequest : public ProtoMessage {
  public:
   uint32_t key{0};
@@ -2425,6 +2620,8 @@ class DateTimeCommandRequest : public ProtoMessage {
  protected:
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
 };
+#endif  // USE_DATETIME_DATETIME
+#ifdef USE_UPDATE
 class ListEntitiesUpdateResponse : public ProtoMessage {
  public:
   std::string object_id{};
@@ -2446,6 +2643,8 @@ class ListEntitiesUpdateResponse : public ProtoMessage {
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
+#endif  // USE_UPDATE
+#ifdef USE_UPDATE
 class UpdateStateResponse : public ProtoMessage {
  public:
   uint32_t key{0};
@@ -2469,6 +2668,8 @@ class UpdateStateResponse : public ProtoMessage {
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
+#endif  // USE_UPDATE
+#ifdef USE_UPDATE
 class UpdateCommandRequest : public ProtoMessage {
  public:
   uint32_t key{0};
@@ -2483,6 +2684,7 @@ class UpdateCommandRequest : public ProtoMessage {
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
+#endif  // USE_UPDATE
 
 }  // namespace api
 }  // namespace esphome

--- a/esphome/components/api/api_pb2.h
+++ b/esphome/components/api/api_pb2.h
@@ -11,13 +11,11 @@ namespace api {
 
 namespace enums {
 
-#ifdef USE_UPDATE
 enum EntityCategory : uint32_t {
   ENTITY_CATEGORY_NONE = 0,
   ENTITY_CATEGORY_CONFIG = 1,
   ENTITY_CATEGORY_DIAGNOSTIC = 2,
 };
-#endif  // USE_UPDATE
 #ifdef USE_COVER
 enum LegacyCoverState : uint32_t {
   LEGACY_COVER_STATE_OPEN = 0,

--- a/esphome/components/api/api_pb2.h
+++ b/esphome/components/api/api_pb2.h
@@ -10,34 +10,47 @@ namespace api {
 
 namespace enums {
 
+#ifdef USE_UPDATE
 enum EntityCategory : uint32_t {
   ENTITY_CATEGORY_NONE = 0,
   ENTITY_CATEGORY_CONFIG = 1,
   ENTITY_CATEGORY_DIAGNOSTIC = 2,
 };
+#endif  // USE_UPDATE
+#ifdef USE_COVER
 enum LegacyCoverState : uint32_t {
   LEGACY_COVER_STATE_OPEN = 0,
   LEGACY_COVER_STATE_CLOSED = 1,
 };
+#endif  // USE_COVER
+#ifdef USE_COVER
 enum CoverOperation : uint32_t {
   COVER_OPERATION_IDLE = 0,
   COVER_OPERATION_IS_OPENING = 1,
   COVER_OPERATION_IS_CLOSING = 2,
 };
+#endif  // USE_COVER
+#ifdef USE_COVER
 enum LegacyCoverCommand : uint32_t {
   LEGACY_COVER_COMMAND_OPEN = 0,
   LEGACY_COVER_COMMAND_CLOSE = 1,
   LEGACY_COVER_COMMAND_STOP = 2,
 };
+#endif  // USE_COVER
+#ifdef USE_FAN
 enum FanSpeed : uint32_t {
   FAN_SPEED_LOW = 0,
   FAN_SPEED_MEDIUM = 1,
   FAN_SPEED_HIGH = 2,
 };
+#endif  // USE_FAN
+#ifdef USE_FAN
 enum FanDirection : uint32_t {
   FAN_DIRECTION_FORWARD = 0,
   FAN_DIRECTION_REVERSE = 1,
 };
+#endif  // USE_FAN
+#ifdef USE_LIGHT
 enum ColorMode : uint32_t {
   COLOR_MODE_UNKNOWN = 0,
   COLOR_MODE_ON_OFF = 1,
@@ -50,17 +63,22 @@ enum ColorMode : uint32_t {
   COLOR_MODE_RGB_COLOR_TEMPERATURE = 47,
   COLOR_MODE_RGB_COLD_WARM_WHITE = 51,
 };
+#endif  // USE_LIGHT
+#ifdef USE_SENSOR
 enum SensorStateClass : uint32_t {
   STATE_CLASS_NONE = 0,
   STATE_CLASS_MEASUREMENT = 1,
   STATE_CLASS_TOTAL_INCREASING = 2,
   STATE_CLASS_TOTAL = 3,
 };
+#endif  // USE_SENSOR
+#ifdef USE_SENSOR
 enum SensorLastResetType : uint32_t {
   LAST_RESET_NONE = 0,
   LAST_RESET_NEVER = 1,
   LAST_RESET_AUTO = 2,
 };
+#endif  // USE_SENSOR
 enum LogLevel : uint32_t {
   LOG_LEVEL_NONE = 0,
   LOG_LEVEL_ERROR = 1,
@@ -81,6 +99,7 @@ enum ServiceArgType : uint32_t {
   SERVICE_ARG_TYPE_FLOAT_ARRAY = 6,
   SERVICE_ARG_TYPE_STRING_ARRAY = 7,
 };
+#ifdef USE_CLIMATE
 enum ClimateMode : uint32_t {
   CLIMATE_MODE_OFF = 0,
   CLIMATE_MODE_HEAT_COOL = 1,
@@ -90,6 +109,8 @@ enum ClimateMode : uint32_t {
   CLIMATE_MODE_DRY = 5,
   CLIMATE_MODE_AUTO = 6,
 };
+#endif  // USE_CLIMATE
+#ifdef USE_CLIMATE
 enum ClimateFanMode : uint32_t {
   CLIMATE_FAN_ON = 0,
   CLIMATE_FAN_OFF = 1,
@@ -102,12 +123,16 @@ enum ClimateFanMode : uint32_t {
   CLIMATE_FAN_DIFFUSE = 8,
   CLIMATE_FAN_QUIET = 9,
 };
+#endif  // USE_CLIMATE
+#ifdef USE_CLIMATE
 enum ClimateSwingMode : uint32_t {
   CLIMATE_SWING_OFF = 0,
   CLIMATE_SWING_BOTH = 1,
   CLIMATE_SWING_VERTICAL = 2,
   CLIMATE_SWING_HORIZONTAL = 3,
 };
+#endif  // USE_CLIMATE
+#ifdef USE_CLIMATE
 enum ClimateAction : uint32_t {
   CLIMATE_ACTION_OFF = 0,
   CLIMATE_ACTION_COOLING = 2,
@@ -116,6 +141,8 @@ enum ClimateAction : uint32_t {
   CLIMATE_ACTION_DRYING = 5,
   CLIMATE_ACTION_FAN = 6,
 };
+#endif  // USE_CLIMATE
+#ifdef USE_CLIMATE
 enum ClimatePreset : uint32_t {
   CLIMATE_PRESET_NONE = 0,
   CLIMATE_PRESET_HOME = 1,
@@ -126,11 +153,15 @@ enum ClimatePreset : uint32_t {
   CLIMATE_PRESET_SLEEP = 6,
   CLIMATE_PRESET_ACTIVITY = 7,
 };
+#endif  // USE_CLIMATE
+#ifdef USE_NUMBER
 enum NumberMode : uint32_t {
   NUMBER_MODE_AUTO = 0,
   NUMBER_MODE_BOX = 1,
   NUMBER_MODE_SLIDER = 2,
 };
+#endif  // USE_NUMBER
+#ifdef USE_LOCK
 enum LockState : uint32_t {
   LOCK_STATE_NONE = 0,
   LOCK_STATE_LOCKED = 1,
@@ -139,17 +170,23 @@ enum LockState : uint32_t {
   LOCK_STATE_LOCKING = 4,
   LOCK_STATE_UNLOCKING = 5,
 };
+#endif  // USE_LOCK
+#ifdef USE_LOCK
 enum LockCommand : uint32_t {
   LOCK_UNLOCK = 0,
   LOCK_LOCK = 1,
   LOCK_OPEN = 2,
 };
+#endif  // USE_LOCK
+#ifdef USE_MEDIA_PLAYER
 enum MediaPlayerState : uint32_t {
   MEDIA_PLAYER_STATE_NONE = 0,
   MEDIA_PLAYER_STATE_IDLE = 1,
   MEDIA_PLAYER_STATE_PLAYING = 2,
   MEDIA_PLAYER_STATE_PAUSED = 3,
 };
+#endif  // USE_MEDIA_PLAYER
+#ifdef USE_MEDIA_PLAYER
 enum MediaPlayerCommand : uint32_t {
   MEDIA_PLAYER_COMMAND_PLAY = 0,
   MEDIA_PLAYER_COMMAND_PAUSE = 1,
@@ -157,10 +194,14 @@ enum MediaPlayerCommand : uint32_t {
   MEDIA_PLAYER_COMMAND_MUTE = 3,
   MEDIA_PLAYER_COMMAND_UNMUTE = 4,
 };
+#endif  // USE_MEDIA_PLAYER
+#ifdef USE_MEDIA_PLAYER
 enum MediaPlayerFormatPurpose : uint32_t {
   MEDIA_PLAYER_FORMAT_PURPOSE_DEFAULT = 0,
   MEDIA_PLAYER_FORMAT_PURPOSE_ANNOUNCEMENT = 1,
 };
+#endif  // USE_MEDIA_PLAYER
+#ifdef USE_BLUETOOTH_PROXY
 enum BluetoothDeviceRequestType : uint32_t {
   BLUETOOTH_DEVICE_REQUEST_TYPE_CONNECT = 0,
   BLUETOOTH_DEVICE_REQUEST_TYPE_DISCONNECT = 1,
@@ -170,6 +211,8 @@ enum BluetoothDeviceRequestType : uint32_t {
   BLUETOOTH_DEVICE_REQUEST_TYPE_CONNECT_V3_WITHOUT_CACHE = 5,
   BLUETOOTH_DEVICE_REQUEST_TYPE_CLEAR_CACHE = 6,
 };
+#endif  // USE_BLUETOOTH_PROXY
+#ifdef USE_BLUETOOTH_PROXY
 enum BluetoothScannerState : uint32_t {
   BLUETOOTH_SCANNER_STATE_IDLE = 0,
   BLUETOOTH_SCANNER_STATE_STARTING = 1,
@@ -178,10 +221,13 @@ enum BluetoothScannerState : uint32_t {
   BLUETOOTH_SCANNER_STATE_STOPPING = 4,
   BLUETOOTH_SCANNER_STATE_STOPPED = 5,
 };
+#endif  // USE_BLUETOOTH_PROXY
+#ifdef USE_BLUETOOTH_PROXY
 enum BluetoothScannerMode : uint32_t {
   BLUETOOTH_SCANNER_MODE_PASSIVE = 0,
   BLUETOOTH_SCANNER_MODE_ACTIVE = 1,
 };
+#endif  // USE_BLUETOOTH_PROXY
 enum VoiceAssistantSubscribeFlag : uint32_t {
   VOICE_ASSISTANT_SUBSCRIBE_NONE = 0,
   VOICE_ASSISTANT_SUBSCRIBE_API_AUDIO = 1,
@@ -191,6 +237,7 @@ enum VoiceAssistantRequestFlag : uint32_t {
   VOICE_ASSISTANT_REQUEST_USE_VAD = 1,
   VOICE_ASSISTANT_REQUEST_USE_WAKE_WORD = 2,
 };
+#ifdef USE_VOICE_ASSISTANT
 enum VoiceAssistantEvent : uint32_t {
   VOICE_ASSISTANT_ERROR = 0,
   VOICE_ASSISTANT_RUN_START = 1,
@@ -208,12 +255,16 @@ enum VoiceAssistantEvent : uint32_t {
   VOICE_ASSISTANT_TTS_STREAM_START = 98,
   VOICE_ASSISTANT_TTS_STREAM_END = 99,
 };
+#endif  // USE_VOICE_ASSISTANT
+#ifdef USE_VOICE_ASSISTANT
 enum VoiceAssistantTimerEvent : uint32_t {
   VOICE_ASSISTANT_TIMER_STARTED = 0,
   VOICE_ASSISTANT_TIMER_UPDATED = 1,
   VOICE_ASSISTANT_TIMER_CANCELLED = 2,
   VOICE_ASSISTANT_TIMER_FINISHED = 3,
 };
+#endif  // USE_VOICE_ASSISTANT
+#ifdef USE_ALARM_CONTROL_PANEL
 enum AlarmControlPanelState : uint32_t {
   ALARM_STATE_DISARMED = 0,
   ALARM_STATE_ARMED_HOME = 1,
@@ -226,6 +277,8 @@ enum AlarmControlPanelState : uint32_t {
   ALARM_STATE_DISARMING = 8,
   ALARM_STATE_TRIGGERED = 9,
 };
+#endif  // USE_ALARM_CONTROL_PANEL
+#ifdef USE_ALARM_CONTROL_PANEL
 enum AlarmControlPanelStateCommand : uint32_t {
   ALARM_CONTROL_PANEL_DISARM = 0,
   ALARM_CONTROL_PANEL_ARM_AWAY = 1,
@@ -235,20 +288,27 @@ enum AlarmControlPanelStateCommand : uint32_t {
   ALARM_CONTROL_PANEL_ARM_CUSTOM_BYPASS = 5,
   ALARM_CONTROL_PANEL_TRIGGER = 6,
 };
+#endif  // USE_ALARM_CONTROL_PANEL
+#ifdef USE_TEXT
 enum TextMode : uint32_t {
   TEXT_MODE_TEXT = 0,
   TEXT_MODE_PASSWORD = 1,
 };
+#endif  // USE_TEXT
+#ifdef USE_VALVE
 enum ValveOperation : uint32_t {
   VALVE_OPERATION_IDLE = 0,
   VALVE_OPERATION_IS_OPENING = 1,
   VALVE_OPERATION_IS_CLOSING = 2,
 };
+#endif  // USE_VALVE
+#ifdef USE_UPDATE
 enum UpdateCommand : uint32_t {
   UPDATE_COMMAND_NONE = 0,
   UPDATE_COMMAND_UPDATE = 1,
   UPDATE_COMMAND_CHECK = 2,
 };
+#endif  // USE_UPDATE
 
 }  // namespace enums
 

--- a/esphome/components/api/api_pb2.h
+++ b/esphome/components/api/api_pb2.h
@@ -4,6 +4,7 @@
 
 #include "proto.h"
 #include "api_pb2_size.h"
+#include "esphome/core/defines.h"
 
 namespace esphome {
 namespace api {

--- a/script/api_protobuf/api_protobuf.py
+++ b/script/api_protobuf/api_protobuf.py
@@ -755,12 +755,9 @@ def get_opt(
     default: Any = None,
 ) -> Any:
     """Get the option from the descriptor."""
-    try:
-        if not desc.options.HasExtension(opt):
-            return default
-        return desc.options.Extensions[opt]
-    except (AttributeError, KeyError):
+    if not desc.options.HasExtension(opt):
         return default
+    return desc.options.Extensions[opt]
 
 
 # Create a mapping to associate enums with components

--- a/script/api_protobuf/api_protobuf.py
+++ b/script/api_protobuf/api_protobuf.py
@@ -773,6 +773,9 @@ def build_message_type(desc: descriptor.DescriptorProto) -> tuple[str, str]:
     dump: list[str] = []
     size_calc: list[str] = []
 
+    # Check if this message has an ifdef option
+    ifdef = get_opt(desc, pb.ifdef)
+
     for field in desc.field:
         if field.label == 3:
             ti = RepeatedTypeInfo(field)
@@ -795,6 +798,10 @@ def build_message_type(desc: descriptor.DescriptorProto) -> tuple[str, str]:
             dump.append(ti.dump_content)
 
     cpp = ""
+    # Add ifdef at the beginning of the cpp content if needed
+    if ifdef is not None:
+        cpp += f"#ifdef {ifdef}\n"
+
     if decode_varint:
         decode_varint.append("default:\n  return false;")
         o = f"bool {desc.name}::decode_varint(uint32_t field_id, ProtoVarInt value) {{\n"
@@ -893,7 +900,16 @@ def build_message_type(desc: descriptor.DescriptorProto) -> tuple[str, str]:
     prot += "#endif\n"
     public_content.append(prot)
 
-    out = f"class {desc.name} : public ProtoMessage {{\n"
+    # Close the ifdef if needed
+    if ifdef is not None:
+        cpp += f"#endif  // {ifdef}\n"
+
+    out = ""
+    # Add ifdef at the beginning of the header content if needed
+    if ifdef is not None:
+        out += f"#ifdef {ifdef}\n"
+
+    out += f"class {desc.name} : public ProtoMessage {{\n"
     out += " public:\n"
     out += indent("\n".join(public_content)) + "\n"
     out += "\n"
@@ -902,6 +918,11 @@ def build_message_type(desc: descriptor.DescriptorProto) -> tuple[str, str]:
     if len(protected_content) > 0:
         out += "\n"
     out += "};\n"
+
+    # Close the ifdef in the header if needed
+    if ifdef is not None:
+        out += f"#endif  // {ifdef}\n"
+
     return out, cpp
 
 

--- a/script/api_protobuf/api_protobuf.py
+++ b/script/api_protobuf/api_protobuf.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from collections import defaultdict
 from enum import IntEnum
 import os
 from pathlib import Path
@@ -763,7 +764,9 @@ def get_opt(
 
 
 # Create a mapping to associate enums with components
+# Track which components use each enum to identify shared enums
 enum_component_map: dict[str, str] = {}
+enum_usage_set = defaultdict(set)
 
 
 def build_enum_type(desc: descriptor.EnumDescriptorProto) -> tuple[str, str]:
@@ -821,11 +824,13 @@ def build_message_type(desc: descriptor.DescriptorProto) -> tuple[str, str]:
     # Check if this message has an ifdef option
     ifdef = get_opt(desc, pb.ifdef)
 
-    # If it has an ifdef, check all enum fields to map them to the component
+    # If it has an ifdef, check all enum fields to track their usage by component
     if ifdef is not None:
         for field in desc.field:
             if field.type == 14:  # ENUM type
                 enum_name = field.type_name.split(".")[-1]
+                enum_usage_set[enum_name].add(ifdef)
+                # Initially map the enum to its component
                 enum_component_map[enum_name] = ifdef
 
     for field in desc.field:
@@ -1083,7 +1088,13 @@ def main() -> None:
             for field in m.field:
                 if field.type == 14:  # ENUM type
                     enum_name = field.type_name.split(".")[-1]
+                    enum_usage_set[enum_name].add(ifdef)
                     enum_component_map[enum_name] = ifdef
+
+    # Remove ifdefs for enums that are used by multiple different components
+    for enum_name, components in enum_usage_set.items():
+        if len(components) > 1:
+            enum_component_map[enum_name] = None
 
     content += "namespace enums {\n\n"
 

--- a/script/api_protobuf/api_protobuf.py
+++ b/script/api_protobuf/api_protobuf.py
@@ -739,15 +739,57 @@ class RepeatedTypeInfo(TypeInfo):
         return o
 
 
-def build_enum_type(desc) -> tuple[str, str]:
+SOURCE_BOTH = 0
+SOURCE_SERVER = 1
+SOURCE_CLIENT = 2
+
+RECEIVE_CASES: dict[int, str] = {}
+
+ifdefs: dict[str, str] = {}
+
+
+def get_opt(
+    desc: descriptor.DescriptorProto | descriptor.EnumDescriptorProto,
+    opt: descriptor.MessageOptions,
+    default: Any = None,
+) -> Any:
+    """Get the option from the descriptor."""
+    try:
+        if not desc.options.HasExtension(opt):
+            return default
+        return desc.options.Extensions[opt]
+    except (AttributeError, KeyError):
+        return default
+
+
+# Create a mapping to associate enums with components
+enum_component_map: dict[str, str] = {}
+
+
+def build_enum_type(desc: descriptor.EnumDescriptorProto) -> tuple[str, str]:
     """Builds the enum type."""
     name = desc.name
-    out = f"enum {name} : uint32_t {{\n"
+
+    # Get ifdef from the enum_component_map, or default to None
+    ifdef = enum_component_map.get(name, None)
+
+    out = ""
+    if ifdef is not None:
+        out += f"#ifdef {ifdef}\n"
+
+    out += f"enum {name} : uint32_t {{\n"
     for v in desc.value:
         out += f"  {v.name} = {v.number},\n"
     out += "};\n"
 
-    cpp = "#ifdef HAS_PROTO_MESSAGE_DUMP\n"
+    if ifdef is not None:
+        out += f"#endif  // {ifdef}\n"
+
+    cpp = ""
+    if ifdef is not None:
+        cpp += f"#ifdef {ifdef}\n"
+
+    cpp += "#ifdef HAS_PROTO_MESSAGE_DUMP\n"
     cpp += f"template<> const char *proto_enum_to_string<enums::{name}>(enums::{name} value) {{\n"
     cpp += "  switch (value) {\n"
     for v in desc.value:
@@ -758,6 +800,9 @@ def build_enum_type(desc) -> tuple[str, str]:
     cpp += "  }\n"
     cpp += "}\n"
     cpp += "#endif\n"
+
+    if ifdef is not None:
+        cpp += f"#endif  // {ifdef}\n"
 
     return out, cpp
 
@@ -775,6 +820,13 @@ def build_message_type(desc: descriptor.DescriptorProto) -> tuple[str, str]:
 
     # Check if this message has an ifdef option
     ifdef = get_opt(desc, pb.ifdef)
+
+    # If it has an ifdef, check all enum fields to map them to the component
+    if ifdef is not None:
+        for field in desc.field:
+            if field.type == 14:  # ENUM type
+                enum_name = field.type_name.split(".")[-1]
+                enum_component_map[enum_name] = ifdef
 
     for field in desc.field:
         if field.label == 3:
@@ -926,26 +978,6 @@ def build_message_type(desc: descriptor.DescriptorProto) -> tuple[str, str]:
     return out, cpp
 
 
-SOURCE_BOTH = 0
-SOURCE_SERVER = 1
-SOURCE_CLIENT = 2
-
-RECEIVE_CASES: dict[int, str] = {}
-
-ifdefs: dict[str, str] = {}
-
-
-def get_opt(
-    desc: descriptor.DescriptorProto,
-    opt: descriptor.MessageOptions,
-    default: Any = None,
-) -> Any:
-    """Get the option from the descriptor."""
-    if not desc.options.HasExtension(opt):
-        return default
-    return desc.options.Extensions[opt]
-
-
 def build_service_message_type(
     mt: descriptor.DescriptorProto,
 ) -> tuple[str, str] | None:
@@ -1041,6 +1073,16 @@ def main() -> None:
     namespace api {
 
     """
+
+    # The first pass: identify all message types with ifdef guards
+    # and build the enum_component_map
+    for m in file.message_type:
+        ifdef = get_opt(m, pb.ifdef)
+        if ifdef is not None:
+            for field in m.field:
+                if field.type == 14:  # ENUM type
+                    enum_name = field.type_name.split(".")[-1]
+                    enum_component_map[enum_name] = ifdef
 
     content += "namespace enums {\n\n"
 

--- a/script/api_protobuf/api_protobuf.py
+++ b/script/api_protobuf/api_protobuf.py
@@ -1055,6 +1055,7 @@ def main() -> None:
 
     #include "proto.h"
     #include "api_pb2_size.h"
+    #include "esphome/core/defines.h"
 
     namespace esphome {
     namespace api {


### PR DESCRIPTION
# What does this implement/fix?

TODO
- [ ] While it compiles a bit faster it doesn't seem to affect the flash size so it might already be optimized out making this PR pointless... more investigation needed

We had ifdefs in api_service but not in api_pb2 so we would compile in protobuf messages typed that the
device did not use

before
```
-rw-r--r--   1 bdraco  staff  3761924 May  8 03:18 api_pb2.cpp.o
```

after
```
-rw-r--r--   1 bdraco  staff  1982120 May  8 04:18 api_pb2.cpp.o
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
