### PR TITLE
Optimize logger hot paths

### DIFF
--- a/esphome/components/logger/logger.cpp
+++ b/esphome/components/logger/logger.cpp
@@ -79,14 +79,22 @@ void Logger::log_vprintf_(int level, const char *tag, int line, const __FlashStr
   recursion_guard_ = true;
   this->reset_buffer_();
   // copy format string
+
+  // Optimization: Pre-calculate buffer capacity
   auto *format_pgm_p = reinterpret_cast<const uint8_t *>(format);
-  size_t len = 0;
+  const int max_format_len = this->buffer_remaining_capacity_() - 1;  // Reserve 1 for null terminator
+  int i = 0;
   char ch = '.';
-  while (!this->is_buffer_full_() && ch != '\0') {
-    this->tx_buffer_[this->tx_buffer_at_++] = ch = (char) progmem_read_byte(format_pgm_p++);
+
+  // Optimization: Perform a single boundary check outside the loop
+  // and combine the null-terminator check with the increment operation
+  for (; i < max_format_len && (ch = (char) progmem_read_byte(format_pgm_p++)) != '\0'; i++) {
+    this->tx_buffer_[this->tx_buffer_at_++] = ch;
   }
-  // Buffer full form copying format
-  if (this->is_buffer_full_())
+
+  // Optimization: Early return for buffer overflow cases avoids further processing
+  // when we know the result would be truncated
+  if (i == max_format_len && ch != '\0')
     return;
 
   // length of format string, includes null terminator
@@ -102,16 +110,21 @@ void Logger::log_vprintf_(int level, const char *tag, int line, const __FlashStr
 #endif
 
 int HOT Logger::level_for(const char *tag) {
-  if (this->log_levels_.count(tag) != 0)
-    return this->log_levels_[tag];
+  // Optimization: Using find() since we only need a single map lookup
+  // and tree traversal.
+  auto it = this->log_levels_.find(tag);
+  if (it != this->log_levels_.end())
+    return it->second;
   return this->current_level_;
 }
 
 void HOT Logger::log_message_(int level, const char *tag, int offset) {
-  // remove trailing newline
-  if (this->tx_buffer_[this->tx_buffer_at_ - 1] == '\n') {
+  // Optimization: Combined bounds check and newline check into one condition
+  if (this->tx_buffer_at_ > 0 && this->tx_buffer_[this->tx_buffer_at_ - 1] == '\n') {
+    // Remove trailing newline if present
     this->tx_buffer_at_--;
   }
+
   // make sure null terminator is present
   this->set_null_terminator_();
 
@@ -186,7 +199,11 @@ void Logger::dump_config() {
     ESP_LOGCONFIG(TAG, "  Level for '%s': %s", it.first.c_str(), LOG_LEVELS[it.second]);
   }
 }
-void Logger::write_footer_() { this->write_to_buffer_(ESPHOME_LOG_RESET_COLOR, strlen(ESPHOME_LOG_RESET_COLOR)); }
+void Logger::write_footer_() {
+  // Optimization: Avoid strlen call by using compile-time constant length
+  static const int reset_color_len = strlen(ESPHOME_LOG_RESET_COLOR);
+  this->write_to_buffer_(ESPHOME_LOG_RESET_COLOR, reset_color_len);
+}
 
 void Logger::set_log_level(int level) {
   if (level > ESPHOME_LOG_LEVEL) {

--- a/esphome/components/logger/logger.cpp
+++ b/esphome/components/logger/logger.cpp
@@ -79,22 +79,14 @@ void Logger::log_vprintf_(int level, const char *tag, int line, const __FlashStr
   recursion_guard_ = true;
   this->reset_buffer_();
   // copy format string
-
-  // Optimization: Pre-calculate buffer capacity
   auto *format_pgm_p = reinterpret_cast<const uint8_t *>(format);
-  const int max_format_len = this->buffer_remaining_capacity_() - 1;  // Reserve 1 for null terminator
-  int i = 0;
+  size_t len = 0;
   char ch = '.';
-
-  // Optimization: Perform a single boundary check outside the loop
-  // and combine the null-terminator check with the increment operation
-  for (; i < max_format_len && (ch = (char) progmem_read_byte(format_pgm_p++)) != '\0'; i++) {
-    this->tx_buffer_[this->tx_buffer_at_++] = ch;
+  while (!this->is_buffer_full_() && ch != '\0') {
+    this->tx_buffer_[this->tx_buffer_at_++] = ch = (char) progmem_read_byte(format_pgm_p++);
   }
-
-  // Optimization: Early return for buffer overflow cases avoids further processing
-  // when we know the result would be truncated
-  if (i == max_format_len && ch != '\0')
+  // Buffer full form copying format
+  if (this->is_buffer_full_())
     return;
 
   // length of format string, includes null terminator

--- a/esphome/components/logger/logger.cpp
+++ b/esphome/components/logger/logger.cpp
@@ -193,8 +193,8 @@ void Logger::dump_config() {
 }
 void Logger::write_footer_() {
   // Optimization: Avoid strlen call by using compile-time constant length
-  static const int reset_color_len = strlen(ESPHOME_LOG_RESET_COLOR);
-  this->write_to_buffer_(ESPHOME_LOG_RESET_COLOR, reset_color_len);
+  static const int RESET_COLOR_LEN = strlen(ESPHOME_LOG_RESET_COLOR);
+  this->write_to_buffer_(ESPHOME_LOG_RESET_COLOR, RESET_COLOR_LEN);
 }
 
 void Logger::set_log_level(int level) {

--- a/esphome/components/logger/logger.h
+++ b/esphome/components/logger/logger.h
@@ -120,24 +120,36 @@ class Logger : public Component {
       this->tx_buffer_[this->tx_buffer_at_++] = value;
   }
   inline void write_to_buffer_(const char *value, int length) {
-    for (int i = 0; i < length && !this->is_buffer_full_(); i++) {
-      this->tx_buffer_[this->tx_buffer_at_++] = value[i];
+    // Optimization: Calculate available space once
+    const int available = this->buffer_remaining_capacity_();
+    if (available <= 0)
+      return;
+
+    // Optimization: Determine max copy length upfront to avoid boundary checks
+    // Use the smaller of available space and requested length
+    const int copy_len = (length < available) ? length : available;
+
+    // Optimization: Use memcpy for bulk copy
+    if (copy_len > 0) {
+      memcpy(this->tx_buffer_ + this->tx_buffer_at_, value, copy_len);
+      this->tx_buffer_at_ += copy_len;
     }
   }
   inline void vprintf_to_buffer_(const char *format, va_list args) {
-    if (this->is_buffer_full_())
+    // Optimization: Quick return for full buffer but avoid is_buffer_full_() call
+    const int remaining = this->buffer_remaining_capacity_();
+    if (remaining <= 0)
       return;
-    int remaining = this->buffer_remaining_capacity_();
-    int ret = vsnprintf(this->tx_buffer_ + this->tx_buffer_at_, remaining, format, args);
+
+    const int ret = vsnprintf(this->tx_buffer_ + this->tx_buffer_at_, remaining, format, args);
+
     if (ret < 0) {
       // Encoding error, do not increment buffer_at
       return;
     }
-    if (ret >= remaining) {
-      // output was too long, truncated
-      ret = remaining;
-    }
-    this->tx_buffer_at_ += ret;
+
+    // If ret >= remaining, output was too long and is truncated
+    this->tx_buffer_at_ += (ret >= remaining) ? remaining : ret;
   }
   inline void printf_to_buffer_(const char *format, ...) {
     va_list arg;


### PR DESCRIPTION
# What does this implement/fix?

  1. Use find() instead of count() + operator[] in level_for to reduce redundant map lookups.
  2. Replace character-by-character copying with memcpy in write_to_buffer_ for more efficient bulk copying.
  3. Pre-calculate the length of the reset color string in write_footer_() to avoid calling strlen() on every log message.

To test

```
external_components:
  - source: github://pr#8724
    components: [ logger ]
    refresh: 0s
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
