### PR TITLE
[update] Move to use ``update_schema(..)`` instead of ``UPDATE_SCHEMA``

### DIFF
--- a/esphome/components/http_request/update/__init__.py
+++ b/esphome/components/http_request/update/__init__.py
@@ -16,14 +16,17 @@ HttpRequestUpdate = http_request_ns.class_(
 
 CONF_OTA_ID = "ota_id"
 
-CONFIG_SCHEMA = update.UPDATE_SCHEMA.extend(
-    {
-        cv.GenerateID(): cv.declare_id(HttpRequestUpdate),
-        cv.GenerateID(CONF_OTA_ID): cv.use_id(OtaHttpRequestComponent),
-        cv.GenerateID(CONF_HTTP_REQUEST_ID): cv.use_id(HttpRequestComponent),
-        cv.Required(CONF_SOURCE): cv.url,
-    }
-).extend(cv.polling_component_schema("6h"))
+CONFIG_SCHEMA = (
+    update.update_schema(HttpRequestUpdate)
+    .extend(
+        {
+            cv.GenerateID(CONF_OTA_ID): cv.use_id(OtaHttpRequestComponent),
+            cv.GenerateID(CONF_HTTP_REQUEST_ID): cv.use_id(HttpRequestComponent),
+            cv.Required(CONF_SOURCE): cv.url,
+        }
+    )
+    .extend(cv.polling_component_schema("6h"))
+)
 
 
 async def to_code(config):

--- a/esphome/components/update/__init__.py
+++ b/esphome/components/update/__init__.py
@@ -6,6 +6,7 @@ from esphome.const import (
     CONF_DEVICE_CLASS,
     CONF_ENTITY_CATEGORY,
     CONF_FORCE_UPDATE,
+    CONF_ICON,
     CONF_ID,
     CONF_MQTT_ID,
     CONF_WEB_SERVER,
@@ -14,6 +15,7 @@ from esphome.const import (
     ENTITY_CATEGORY_CONFIG,
 )
 from esphome.core import CORE, coroutine_with_priority
+from esphome.cpp_generator import MockObjClass
 from esphome.cpp_helpers import setup_entity
 
 CODEOWNERS = ["@jesserockz"]
@@ -38,7 +40,7 @@ DEVICE_CLASSES = [
 
 CONF_ON_UPDATE_AVAILABLE = "on_update_available"
 
-UPDATE_SCHEMA = (
+_UPDATE_SCHEMA = (
     cv.ENTITY_BASE_SCHEMA.extend(web_server.WEBSERVER_SORTING_SCHEMA)
     .extend(cv.MQTT_COMMAND_COMPONENT_SCHEMA)
     .extend(
@@ -54,6 +56,29 @@ UPDATE_SCHEMA = (
         }
     )
 )
+
+
+def update_schema(
+    class_: MockObjClass = cv.UNDEFINED,
+    *,
+    icon: str = cv.UNDEFINED,
+    device_class: str = cv.UNDEFINED,
+    entity_category: str = cv.UNDEFINED,
+) -> cv.Schema:
+    schema = {}
+
+    if class_ is not cv.UNDEFINED:
+        schema[cv.GenerateID()] = cv.declare_id(class_)
+
+    for key, default, validator in [
+        (CONF_ICON, icon, cv.icon),
+        (CONF_DEVICE_CLASS, device_class, cv.one_of(*DEVICE_CLASSES, lower=True)),
+        (CONF_ENTITY_CATEGORY, entity_category, cv.entity_category),
+    ]:
+        if default is not cv.UNDEFINED:
+            schema[cv.Optional(key, default=default)] = validator
+
+    return _UPDATE_SCHEMA.extend(schema)
 
 
 async def setup_update_core_(var, config):


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Trying to bring all EntityBase types in line with each other

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
