### PR TITLE
[text] Move to use ``text_schema(..)`` instead of ``TEXT_SCHEMA``

### DIFF
--- a/esphome/components/copy/text/__init__.py
+++ b/esphome/components/copy/text/__init__.py
@@ -9,12 +9,15 @@ from .. import copy_ns
 CopyText = copy_ns.class_("CopyText", text.Text, cg.Component)
 
 
-CONFIG_SCHEMA = text.TEXT_SCHEMA.extend(
-    {
-        cv.GenerateID(): cv.declare_id(CopyText),
-        cv.Required(CONF_SOURCE_ID): cv.use_id(text.Text),
-    }
-).extend(cv.COMPONENT_SCHEMA)
+CONFIG_SCHEMA = (
+    text.text_schema(CopyText)
+    .extend(
+        {
+            cv.Required(CONF_SOURCE_ID): cv.use_id(text.Text),
+        }
+    )
+    .extend(cv.COMPONENT_SCHEMA)
+)
 
 FINAL_VALIDATE_SCHEMA = cv.All(
     inherit_property_from(CONF_ICON, CONF_SOURCE_ID),

--- a/esphome/components/lvgl/text/__init__.py
+++ b/esphome/components/lvgl/text/__init__.py
@@ -19,9 +19,8 @@ from ..widgets import get_widgets, wait_for_widgets
 
 LVGLText = lvgl_ns.class_("LVGLText", text.Text)
 
-CONFIG_SCHEMA = text.TEXT_SCHEMA.extend(
+CONFIG_SCHEMA = text.text_schema(LVGLText).extend(
     {
-        cv.GenerateID(): cv.declare_id(LVGLText),
         cv.Required(CONF_WIDGET): cv.use_id(LvText),
     }
 )

--- a/esphome/components/template/text/__init__.py
+++ b/esphome/components/template/text/__init__.py
@@ -46,9 +46,9 @@ def validate(config):
 
 
 CONFIG_SCHEMA = cv.All(
-    text.TEXT_SCHEMA.extend(
+    text.text_schema(TemplateText)
+    .extend(
         {
-            cv.GenerateID(): cv.declare_id(TemplateText),
             cv.Optional(CONF_MIN_LENGTH, default=0): cv.int_range(min=0, max=255),
             cv.Optional(CONF_MAX_LENGTH, default=255): cv.int_range(min=0, max=255),
             cv.Optional(CONF_PATTERN): cv.string,
@@ -58,7 +58,8 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_INITIAL_VALUE): cv.string_strict,
             cv.Optional(CONF_RESTORE_VALUE, default=False): cv.boolean,
         }
-    ).extend(cv.polling_component_schema("60s")),
+    )
+    .extend(cv.polling_component_schema("60s")),
     validate,
 )
 

--- a/esphome/components/text/__init__.py
+++ b/esphome/components/text/__init__.py
@@ -5,6 +5,8 @@ import esphome.codegen as cg
 from esphome.components import mqtt, web_server
 import esphome.config_validation as cv
 from esphome.const import (
+    CONF_ENTITY_CATEGORY,
+    CONF_ICON,
     CONF_ID,
     CONF_MODE,
     CONF_MQTT_ID,
@@ -14,6 +16,7 @@ from esphome.const import (
     CONF_WEB_SERVER,
 )
 from esphome.core import CORE, coroutine_with_priority
+from esphome.cpp_generator import MockObjClass
 from esphome.cpp_helpers import setup_entity
 
 CODEOWNERS = ["@mauritskorse"]
@@ -39,7 +42,7 @@ TEXT_MODES = {
     "PASSWORD": TextMode.TEXT_MODE_PASSWORD,  # to be implemented for keys, passwords, etc.
 }
 
-TEXT_SCHEMA = (
+_TEXT_SCHEMA = (
     cv.ENTITY_BASE_SCHEMA.extend(web_server.WEBSERVER_SORTING_SCHEMA)
     .extend(cv.MQTT_COMPONENT_SCHEMA)
     .extend(
@@ -55,6 +58,29 @@ TEXT_SCHEMA = (
         }
     )
 )
+
+
+def text_schema(
+    class_: MockObjClass = cv.UNDEFINED,
+    *,
+    icon: str = cv.UNDEFINED,
+    entity_category: str = cv.UNDEFINED,
+    mode: str = cv.UNDEFINED,
+) -> cv.Schema:
+    schema = {}
+
+    if class_ is not cv.UNDEFINED:
+        schema[cv.GenerateID()] = cv.declare_id(class_)
+
+    for key, default, validator in [
+        (CONF_ICON, icon, cv.icon),
+        (CONF_ENTITY_CATEGORY, entity_category, cv.entity_category),
+        (CONF_MODE, mode, cv.enum(TEXT_MODES, upper=True)),
+    ]:
+        if default is not cv.UNDEFINED:
+            schema[cv.Optional(key, default=default)] = validator
+
+    return _TEXT_SCHEMA.extend(schema)
 
 
 async def setup_text_core_(


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Trying to bring all EntityBase types in line with each other

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
