### PR TITLE
[lock] Tidy up template publish action and lockstate locations

### DIFF
--- a/esphome/components/lock/__init__.py
+++ b/esphome/components/lock/__init__.py
@@ -31,6 +31,18 @@ LockCondition = lock_ns.class_("LockCondition", Condition)
 LockLockTrigger = lock_ns.class_("LockLockTrigger", automation.Trigger.template())
 LockUnlockTrigger = lock_ns.class_("LockUnlockTrigger", automation.Trigger.template())
 
+LockState = lock_ns.enum("LockState")
+
+LOCK_STATES = {
+    "LOCKED": LockState.LOCK_STATE_LOCKED,
+    "UNLOCKED": LockState.LOCK_STATE_UNLOCKED,
+    "JAMMED": LockState.LOCK_STATE_JAMMED,
+    "LOCKING": LockState.LOCK_STATE_LOCKING,
+    "UNLOCKING": LockState.LOCK_STATE_UNLOCKING,
+}
+
+validate_lock_state = cv.enum(LOCK_STATES, upper=True)
+
 LOCK_SCHEMA = (
     cv.ENTITY_BASE_SCHEMA.extend(web_server.WEBSERVER_SORTING_SCHEMA)
     .extend(cv.MQTT_COMMAND_COMPONENT_SCHEMA)
@@ -79,7 +91,7 @@ async def register_lock(var, config):
 
 LOCK_ACTION_SCHEMA = maybe_simple_id(
     {
-        cv.Required(CONF_ID): cv.use_id(Lock),
+        cv.GenerateID(CONF_ID): cv.use_id(Lock),
     }
 )
 

--- a/esphome/components/lock/automation.h
+++ b/esphome/components/lock/automation.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include "esphome/core/component.h"
-#include "esphome/core/automation.h"
 #include "esphome/components/lock/lock.h"
+#include "esphome/core/automation.h"
+#include "esphome/core/component.h"
 
 namespace esphome {
 namespace lock {
@@ -70,17 +70,6 @@ class LockUnlockTrigger : public Trigger<> {
       }
     });
   }
-};
-
-template<typename... Ts> class LockPublishAction : public Action<Ts...> {
- public:
-  LockPublishAction(Lock *a_lock) : lock_(a_lock) {}
-  TEMPLATABLE_VALUE(LockState, state)
-
-  void play(Ts... x) override { this->lock_->publish_state(this->state_.value(x...)); }
-
- protected:
-  Lock *lock_;
 };
 
 }  // namespace lock

--- a/esphome/components/template/lock/automation.h
+++ b/esphome/components/template/lock/automation.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "template_lock.h"
+
+#include "esphome/core/automation.h"
+
+namespace esphome {
+namespace template_ {
+
+template<typename... Ts> class TemplateLockPublishAction : public Action<Ts...>, public Parented<TemplateLock> {
+ public:
+  TEMPLATABLE_VALUE(lock::LockState, state)
+
+  void play(Ts... x) override { this->parent_->publish_state(this->state_.value(x...)); }
+};
+
+}  // namespace template_
+}  // namespace esphome

--- a/tests/components/lock/common.yaml
+++ b/tests/components/lock/common.yaml
@@ -27,9 +27,7 @@ lock:
           id: test_lock1
           state: !lambda "return LOCK_STATE_UNLOCKED;"
     on_lock:
-      - lock.template.publish:
-          id: test_lock1
-          state: !lambda "return LOCK_STATE_LOCKED;"
+      - lock.template.publish: LOCKED
   - platform: output
     name: Generic Output Lock
     id: test_lock2


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

- `LockState` was declared in the incorrect component
- The LockPublishAction should only exist inside the Template Lock component files.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
