### PR TITLE
[valve] Move to use ``valve_schema(..)`` instead of ``VALVE_SCHEMA``

### DIFF
--- a/esphome/components/template/valve/__init__.py
+++ b/esphome/components/template/valve/__init__.py
@@ -31,23 +31,30 @@ RESTORE_MODES = {
 CONF_HAS_POSITION = "has_position"
 CONF_TOGGLE_ACTION = "toggle_action"
 
-CONFIG_SCHEMA = valve.VALVE_SCHEMA.extend(
-    {
-        cv.GenerateID(): cv.declare_id(TemplateValve),
-        cv.Optional(CONF_LAMBDA): cv.returning_lambda,
-        cv.Optional(CONF_OPTIMISTIC, default=False): cv.boolean,
-        cv.Optional(CONF_ASSUMED_STATE, default=False): cv.boolean,
-        cv.Optional(CONF_HAS_POSITION, default=False): cv.boolean,
-        cv.Optional(CONF_OPEN_ACTION): automation.validate_automation(single=True),
-        cv.Optional(CONF_CLOSE_ACTION): automation.validate_automation(single=True),
-        cv.Optional(CONF_STOP_ACTION): automation.validate_automation(single=True),
-        cv.Optional(CONF_TOGGLE_ACTION): automation.validate_automation(single=True),
-        cv.Optional(CONF_POSITION_ACTION): automation.validate_automation(single=True),
-        cv.Optional(CONF_RESTORE_MODE, default="NO_RESTORE"): cv.enum(
-            RESTORE_MODES, upper=True
-        ),
-    }
-).extend(cv.COMPONENT_SCHEMA)
+CONFIG_SCHEMA = (
+    valve.valve_schema(TemplateValve)
+    .extend(
+        {
+            cv.Optional(CONF_LAMBDA): cv.returning_lambda,
+            cv.Optional(CONF_OPTIMISTIC, default=False): cv.boolean,
+            cv.Optional(CONF_ASSUMED_STATE, default=False): cv.boolean,
+            cv.Optional(CONF_HAS_POSITION, default=False): cv.boolean,
+            cv.Optional(CONF_OPEN_ACTION): automation.validate_automation(single=True),
+            cv.Optional(CONF_CLOSE_ACTION): automation.validate_automation(single=True),
+            cv.Optional(CONF_STOP_ACTION): automation.validate_automation(single=True),
+            cv.Optional(CONF_TOGGLE_ACTION): automation.validate_automation(
+                single=True
+            ),
+            cv.Optional(CONF_POSITION_ACTION): automation.validate_automation(
+                single=True
+            ),
+            cv.Optional(CONF_RESTORE_MODE, default="NO_RESTORE"): cv.enum(
+                RESTORE_MODES, upper=True
+            ),
+        }
+    )
+    .extend(cv.COMPONENT_SCHEMA)
+)
 
 
 async def to_code(config):

--- a/esphome/components/valve/__init__.py
+++ b/esphome/components/valve/__init__.py
@@ -5,6 +5,8 @@ from esphome.components import mqtt, web_server
 import esphome.config_validation as cv
 from esphome.const import (
     CONF_DEVICE_CLASS,
+    CONF_ENTITY_CATEGORY,
+    CONF_ICON,
     CONF_ID,
     CONF_MQTT_ID,
     CONF_ON_OPEN,
@@ -20,6 +22,7 @@ from esphome.const import (
     DEVICE_CLASS_WATER,
 )
 from esphome.core import CORE, coroutine_with_priority
+from esphome.cpp_generator import MockObjClass
 from esphome.cpp_helpers import setup_entity
 
 IS_PLATFORM_COMPONENT = True
@@ -71,7 +74,7 @@ ValveClosedTrigger = valve_ns.class_(
 
 CONF_ON_CLOSED = "on_closed"
 
-VALVE_SCHEMA = (
+_VALVE_SCHEMA = (
     cv.ENTITY_BASE_SCHEMA.extend(web_server.WEBSERVER_SORTING_SCHEMA)
     .extend(cv.MQTT_COMMAND_COMPONENT_SCHEMA)
     .extend(
@@ -100,7 +103,30 @@ VALVE_SCHEMA = (
 )
 
 
-async def setup_valve_core_(var, config):
+def valve_schema(
+    class_: MockObjClass = cv.UNDEFINED,
+    *,
+    device_class: str = cv.UNDEFINED,
+    entity_category: str = cv.UNDEFINED,
+    icon: str = cv.UNDEFINED,
+) -> cv.Schema:
+    schema = {}
+
+    if class_ is not cv.UNDEFINED:
+        schema[cv.GenerateID()] = cv.declare_id(class_)
+
+    for key, default, validator in [
+        (CONF_DEVICE_CLASS, device_class, cv.one_of(*DEVICE_CLASSES, lower=True)),
+        (CONF_ENTITY_CATEGORY, entity_category, cv.entity_category),
+        (CONF_ICON, icon, cv.icon),
+    ]:
+        if default is not cv.UNDEFINED:
+            schema[cv.Optional(key, default=default)] = validator
+
+    return _VALVE_SCHEMA.extend(schema)
+
+
+async def _setup_valve_core(var, config):
     await setup_entity(var, config)
 
     if device_class_config := config.get(CONF_DEVICE_CLASS):
@@ -132,7 +158,7 @@ async def register_valve(var, config):
     if not CORE.has_id(config[CONF_ID]):
         var = cg.Pvariable(config[CONF_ID], var)
     cg.add(cg.App.register_valve(var))
-    await setup_valve_core_(var, config)
+    await _setup_valve_core(var, config)
 
 
 async def new_valve(config, *args):


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Trying to bring all EntityBase types in line with each other

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
