### PR TITLE
[valve] Tidy up template publish action location

### DIFF
--- a/esphome/components/template/valve/__init__.py
+++ b/esphome/components/template/valve/__init__.py
@@ -21,6 +21,10 @@ from .. import template_ns
 
 TemplateValve = template_ns.class_("TemplateValve", valve.Valve, cg.Component)
 
+TemplateValvePublishAction = template_ns.class_(
+    "TemplateValvePublishAction", automation.Action, cg.Parented.template(TemplateValve)
+)
+
 TemplateValveRestoreMode = template_ns.enum("TemplateValveRestoreMode")
 RESTORE_MODES = {
     "NO_RESTORE": TemplateValveRestoreMode.VALVE_NO_RESTORE,
@@ -90,10 +94,10 @@ async def to_code(config):
 
 @automation.register_action(
     "valve.template.publish",
-    valve.ValvePublishAction,
+    TemplateValvePublishAction,
     cv.Schema(
         {
-            cv.Required(CONF_ID): cv.use_id(valve.Valve),
+            cv.GenerateID(): cv.use_id(TemplateValve),
             cv.Exclusive(CONF_STATE, "pos"): cv.templatable(valve.validate_valve_state),
             cv.Exclusive(CONF_POSITION, "pos"): cv.templatable(cv.percentage),
             cv.Optional(CONF_CURRENT_OPERATION): cv.templatable(
@@ -103,8 +107,8 @@ async def to_code(config):
     ),
 )
 async def valve_template_publish_to_code(config, action_id, template_arg, args):
-    paren = await cg.get_variable(config[CONF_ID])
-    var = cg.new_Pvariable(action_id, template_arg, paren)
+    var = cg.new_Pvariable(action_id, template_arg)
+    await cg.register_parented(var, config[CONF_ID])
     if state_config := config.get(CONF_STATE):
         template_ = await cg.templatable(state_config, args, float)
         cg.add(var.set_position(template_))

--- a/esphome/components/template/valve/automation.h
+++ b/esphome/components/template/valve/automation.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "template_valve.h"
+
+#include "esphome/core/automation.h"
+
+namespace esphome {
+namespace template_ {
+
+template<typename... Ts> class TemplateValvePublishAction : public Action<Ts...>, public Parented<TemplateValve> {
+  TEMPLATABLE_VALUE(float, position)
+  TEMPLATABLE_VALUE(valve::ValveOperation, current_operation)
+
+  void play(Ts... x) override {
+    if (this->position_.has_value())
+      this->parent_->position = this->position_.value(x...);
+    if (this->current_operation_.has_value())
+      this->parent_->current_operation = this->current_operation_.value(x...);
+    this->parent_->publish_state();
+  }
+};
+
+}  // namespace template_
+}  // namespace esphome

--- a/esphome/components/valve/automation.h
+++ b/esphome/components/valve/automation.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "esphome/core/component.h"
 #include "esphome/core/automation.h"
+#include "esphome/core/component.h"
 #include "valve.h"
 
 namespace esphome {
@@ -61,24 +61,6 @@ template<typename... Ts> class ControlAction : public Action<Ts...> {
     if (this->position_.has_value())
       call.set_position(this->position_.value(x...));
     call.perform();
-  }
-
- protected:
-  Valve *valve_;
-};
-
-template<typename... Ts> class ValvePublishAction : public Action<Ts...> {
- public:
-  ValvePublishAction(Valve *valve) : valve_(valve) {}
-  TEMPLATABLE_VALUE(float, position)
-  TEMPLATABLE_VALUE(ValveOperation, current_operation)
-
-  void play(Ts... x) override {
-    if (this->position_.has_value())
-      this->valve_->position = this->position_.value(x...);
-    if (this->current_operation_.has_value())
-      this->valve_->current_operation = this->current_operation_.value(x...);
-    this->valve_->publish_state();
   }
 
  protected:

--- a/tests/components/template/common.yaml
+++ b/tests/components/template/common.yaml
@@ -174,6 +174,8 @@ valve:
       - logger.log: open_action
     close_action:
       - logger.log: close_action
+      - valve.template.publish:
+          state: CLOSED
     stop_action:
       - logger.log: stop_action
     optimistic: true


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

- The (Template)ValvePublishAction should only exist inside the Template Valve component files

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
