### PR TITLE
[i2s_audio] Fix: Slot bit-width for ESP32 variant

### DIFF
--- a/esphome/components/i2s_audio/speaker/i2s_audio_speaker.cpp
+++ b/esphome/components/i2s_audio/speaker/i2s_audio_speaker.cpp
@@ -629,7 +629,16 @@ esp_err_t I2SAudioSpeaker::start_i2s_driver_(audio::AudioStreamInfo &audio_strea
     std_slot_cfg =
         I2S_STD_MSB_SLOT_DEFAULT_CONFIG((i2s_data_bit_width_t) audio_stream_info.get_bits_per_sample(), slot_mode);
   }
+#ifdef USE_ESP32_VARIANT_ESP32
+  // There seems to be a bug on the ESP32 (non-variant) platform where setting the slot bit width higher then the bits
+  // per sample causes the audio to play too fast. Setting the ws_width to the configured slot bit width seems to
+  // make it play at the correct speed while sending more bits per slot.
+  if (this->slot_bit_width_ != I2S_SLOT_BIT_WIDTH_AUTO) {
+    std_slot_cfg.ws_width = static_cast<uint32_t>(this->slot_bit_width_);
+  }
+#else
   std_slot_cfg.slot_bit_width = this->slot_bit_width_;
+#endif
   std_slot_cfg.slot_mask = slot_mask;
 
   pin_config.dout = this->dout_pin_;


### PR DESCRIPTION
# What does this implement/fix?

Fixes an upstream bug for configuring the ESP32 (non-variant) I2S speaker with the IDF5 driver. It seems like there is a problem only on ESP32s where configuring the slot bit width to higher values makes the audio play at the wrong speed (an S3, for example, doesn't have this issue). This PR instead adjusts the word select width parameter.

This fixes the audio quality on an ATOM Echo speaker, as configuring it for 16 bits per sample sounds horrible (even considering the quality of the built-in speaker!) and previously setting it to 32 bits per sample led the audio to play at double speed.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** not applicable

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** not applicable

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

Example configuration for the ATOM Echo with good quality sound played at the correct speed.

```yaml
# Example config.yaml

i2s_audio:
  - id: i2s_audio_bus
    i2s_lrclk_pin: GPIO33
    i2s_bclk_pin: GPIO19

speaker:
  - platform: i2s_audio
    id: echo_speaker
    i2s_dout_pin: GPIO22
    dac_type: external
    bits_per_sample: 32bit
    sample_rate: 16000
    channel: right
    buffer_duration: 60ms

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
