### PR TITLE
[audio] Bump esp-audio-libs to version 1.1.4 for speed optimizations

### DIFF
--- a/esphome/components/audio/__init__.py
+++ b/esphome/components/audio/__init__.py
@@ -165,4 +165,4 @@ def final_validate_audio_schema(
 
 
 async def to_code(config):
-    cg.add_library("esphome/esp-audio-libs", "1.1.3")
+    cg.add_library("esphome/esp-audio-libs", "1.1.4")

--- a/platformio.ini
+++ b/platformio.ini
@@ -128,7 +128,7 @@ lib_deps =
     DNSServer                            ; captive_portal (Arduino built-in)
     esphome/ESP32-audioI2S@2.0.7         ; i2s_audio
     droscy/esp_wireguard@0.4.2           ; wireguard
-    esphome/esp-audio-libs@1.1.3         ; audio
+    esphome/esp-audio-libs@1.1.4         ; audio
 
 build_flags =
     ${common:arduino.build_flags}
@@ -149,7 +149,7 @@ lib_deps =
     ${common:idf.lib_deps}
     droscy/esp_wireguard@0.4.2              ; wireguard
     kahrendt/ESPMicroSpeechFeatures@1.1.0   ; micro_wake_word
-    esphome/esp-audio-libs@1.1.3            ; audio
+    esphome/esp-audio-libs@1.1.4            ; audio
 build_flags =
     ${common:idf.build_flags}
     -Wno-nonnull-compare


### PR DESCRIPTION
# What does this implement/fix?

Bumps the esp-audio-libs library to version 1.1.4 ([GitHub](https://github.com/esphome/esp-audio-libs), [PlatformIO](https://registry.platformio.org/libraries/esphome/esp-audio-libs)). This gives a nice speed bump on an ESP32-S3 at the cost of increasing the firmware size by ~4kB:

- Decoding stereo FLAC at 48kHz is 20% faster
- Resampling stereo 44.1kHz audio to 48 kHz is 7% faster

MP3 decoding only sped up by about 1%, which isn't particularly significant, but it isn't worse at least!

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** not applicable

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** not applicable

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
