### PR TITLE
[voice_assistant] Bugfix: Properly detect states where mic is running

### DIFF
--- a/esphome/components/voice_assistant/voice_assistant.cpp
+++ b/esphome/components/voice_assistant/voice_assistant.cpp
@@ -695,12 +695,12 @@ void VoiceAssistant::on_event(const api::VoiceAssistantEventResponse &msg) {
     }
     case api::enums::VOICE_ASSISTANT_RUN_END: {
       ESP_LOGD(TAG, "Assist Pipeline ended");
-      if ((this->state_ == State::STARTING_PIPELINE) || (this->state_ == State::AWAITING_RESPONSE)) {
-        // Pipeline ended before starting microphone
-        // Or there wasn't a TTS start event ("nevermind")
-        this->set_state_(State::IDLE, State::IDLE);
-      } else if (this->state_ == State::STREAMING_MICROPHONE) {
-        this->ring_buffer_->reset();
+      if ((this->state_ == State::START_PIPELINE) || (this->state_ == State::STARTING_PIPELINE) ||
+          (this->state_ == State::STREAMING_MICROPHONE)) {
+        // Microphone is running, stop it
+        this->set_state_(State::STOP_MICROPHONE, State::IDLE);
+      } else if (this->state_ == State::AWAITING_RESPONSE) {
+        // No TTS start event ("nevermind")
         this->set_state_(State::IDLE, State::IDLE);
       }
       this->defer([this]() { this->end_trigger_->trigger(); });


### PR DESCRIPTION
# What does this implement/fix?

If the VA component is in the ``START_PIPELINE``, ``STARTING_PIPELINE``, or ``STREAMING_MICROPHONE`` states, then the microphone is running. This PR ensures the VA stops the microphone when it is in these states after receiving a run end message. This fixes a bug where the microphone wouldn't stop when testing different TTS voices with the voice wizard, which made any device without duplex audio get in a stuck state.

Note, resetting the ring buffer is no longer necessary since #8610 automatically deallocates the ring buffer in the idle state.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** not applicable

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** not applicable

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
