### PR TITLE
[config] Deprecate other ``*_SCHEMA`` constants

### DIFF
--- a/esphome/components/binary_sensor/__init__.py
+++ b/esphome/components/binary_sensor/__init__.py
@@ -386,7 +386,7 @@ def validate_click_timing(value):
     return value
 
 
-BINARY_SENSOR_SCHEMA = (
+_BINARY_SENSOR_SCHEMA = (
     cv.ENTITY_BASE_SCHEMA.extend(web_server.WEBSERVER_SORTING_SCHEMA)
     .extend(cv.MQTT_COMPONENT_SCHEMA)
     .extend(
@@ -480,7 +480,12 @@ def binary_sensor_schema(
         if default is not cv.UNDEFINED:
             schema[cv.Optional(key, default=default)] = validator
 
-    return BINARY_SENSOR_SCHEMA.extend(schema)
+    return _BINARY_SENSOR_SCHEMA.extend(schema)
+
+
+# Remove before 2025.11.0
+BINARY_SENSOR_SCHEMA = binary_sensor_schema()
+BINARY_SENSOR_SCHEMA.add_extra(cv.deprecated_schema_constant("binary_sensor"))
 
 
 async def setup_binary_sensor_core_(var, config):

--- a/esphome/components/button/__init__.py
+++ b/esphome/components/button/__init__.py
@@ -82,7 +82,7 @@ def button_schema(
 
 
 # Remove before 2025.11.0
-BUTTON_SCHEMA = button_schema(cv.UNDEFINED)
+BUTTON_SCHEMA = button_schema(Button)
 BUTTON_SCHEMA.add_extra(cv.deprecated_schema_constant("button"))
 
 

--- a/esphome/components/button/__init__.py
+++ b/esphome/components/button/__init__.py
@@ -44,7 +44,7 @@ ButtonPressTrigger = button_ns.class_(
 validate_device_class = cv.one_of(*DEVICE_CLASSES, lower=True, space="_")
 
 
-BUTTON_SCHEMA = (
+_BUTTON_SCHEMA = (
     cv.ENTITY_BASE_SCHEMA.extend(web_server.WEBSERVER_SORTING_SCHEMA)
     .extend(cv.MQTT_COMMAND_COMPONENT_SCHEMA)
     .extend(
@@ -78,7 +78,12 @@ def button_schema(
         if default is not cv.UNDEFINED:
             schema[cv.Optional(key, default=default)] = validator
 
-    return BUTTON_SCHEMA.extend(schema)
+    return _BUTTON_SCHEMA.extend(schema)
+
+
+# Remove before 2025.11.0
+BUTTON_SCHEMA = button_schema(cv.UNDEFINED)
+BUTTON_SCHEMA.add_extra(cv.deprecated_schema_constant("button"))
 
 
 async def setup_button_core_(var, config):

--- a/esphome/components/event/__init__.py
+++ b/esphome/components/event/__init__.py
@@ -41,7 +41,7 @@ EventTrigger = event_ns.class_("EventTrigger", automation.Trigger.template())
 
 validate_device_class = cv.one_of(*DEVICE_CLASSES, lower=True, space="_")
 
-EVENT_SCHEMA = (
+_EVENT_SCHEMA = (
     cv.ENTITY_BASE_SCHEMA.extend(web_server.WEBSERVER_SORTING_SCHEMA)
     .extend(cv.MQTT_COMPONENT_SCHEMA)
     .extend(
@@ -79,7 +79,12 @@ def event_schema(
         if default is not cv.UNDEFINED:
             schema[cv.Optional(key, default=default)] = validator
 
-    return EVENT_SCHEMA.extend(schema)
+    return _EVENT_SCHEMA.extend(schema)
+
+
+# Remove before 2025.11.0
+EVENT_SCHEMA = event_schema()
+EVENT_SCHEMA.add_extra(cv.deprecated_schema_constant("event"))
 
 
 async def setup_event_core_(var, config, *, event_types: list[str]):

--- a/esphome/components/number/__init__.py
+++ b/esphome/components/number/__init__.py
@@ -170,7 +170,7 @@ NUMBER_OPERATION_OPTIONS = {
 validate_device_class = cv.one_of(*DEVICE_CLASSES, lower=True, space="_")
 validate_unit_of_measurement = cv.string_strict
 
-NUMBER_SCHEMA = (
+_NUMBER_SCHEMA = (
     cv.ENTITY_BASE_SCHEMA.extend(web_server.WEBSERVER_SORTING_SCHEMA)
     .extend(cv.MQTT_COMMAND_COMPONENT_SCHEMA)
     .extend(
@@ -216,7 +216,12 @@ def number_schema(
         if default is not cv.UNDEFINED:
             schema[cv.Optional(key, default=default)] = validator
 
-    return NUMBER_SCHEMA.extend(schema)
+    return _NUMBER_SCHEMA.extend(schema)
+
+
+# Remove before 2025.11.0
+NUMBER_SCHEMA = number_schema(cv.UNDEFINED)
+NUMBER_SCHEMA.add_extra(cv.deprecated_schema_constant("number"))
 
 
 async def setup_number_core_(

--- a/esphome/components/number/__init__.py
+++ b/esphome/components/number/__init__.py
@@ -220,7 +220,7 @@ def number_schema(
 
 
 # Remove before 2025.11.0
-NUMBER_SCHEMA = number_schema(cv.UNDEFINED)
+NUMBER_SCHEMA = number_schema(Number)
 NUMBER_SCHEMA.add_extra(cv.deprecated_schema_constant("number"))
 
 

--- a/esphome/components/select/__init__.py
+++ b/esphome/components/select/__init__.py
@@ -48,7 +48,7 @@ SELECT_OPERATION_OPTIONS = {
 }
 
 
-SELECT_SCHEMA = (
+_SELECT_SCHEMA = (
     cv.ENTITY_BASE_SCHEMA.extend(web_server.WEBSERVER_SORTING_SCHEMA)
     .extend(cv.MQTT_COMMAND_COMPONENT_SCHEMA)
     .extend(
@@ -84,7 +84,12 @@ def select_schema(
         )
     if icon is not cv.UNDEFINED:
         schema = schema.extend({cv.Optional(CONF_ICON, default=icon): cv.icon})
-    return SELECT_SCHEMA.extend(schema)
+    return _SELECT_SCHEMA.extend(schema)
+
+
+# Remove before 2025.11.0
+SELECT_SCHEMA = select_schema()
+SELECT_SCHEMA.add_extra(cv.deprecated_schema_constant("select"))
 
 
 async def setup_select_core_(var, config, *, options: list[str]):

--- a/esphome/components/sensor/__init__.py
+++ b/esphome/components/sensor/__init__.py
@@ -264,7 +264,7 @@ validate_accuracy_decimals = cv.int_
 validate_icon = cv.icon
 validate_device_class = cv.one_of(*DEVICE_CLASSES, lower=True, space="_")
 
-SENSOR_SCHEMA = (
+_SENSOR_SCHEMA = (
     cv.ENTITY_BASE_SCHEMA.extend(web_server.WEBSERVER_SORTING_SCHEMA)
     .extend(cv.MQTT_COMPONENT_SCHEMA)
     .extend(
@@ -337,7 +337,12 @@ def sensor_schema(
         if default is not cv.UNDEFINED:
             schema[cv.Optional(key, default=default)] = validator
 
-    return SENSOR_SCHEMA.extend(schema)
+    return _SENSOR_SCHEMA.extend(schema)
+
+
+# Remove before 2025.11.0
+SENSOR_SCHEMA = sensor_schema()
+SENSOR_SCHEMA.add_extra(cv.deprecated_schema_constant("sensor"))
 
 
 @FILTER_REGISTRY.register("offset", OffsetFilter, cv.templatable(cv.float_))

--- a/esphome/components/switch/__init__.py
+++ b/esphome/components/switch/__init__.py
@@ -135,7 +135,9 @@ def switch_schema(
     return schema
 
 
-SWITCH_SCHEMA = switch_schema()  # for compatibility
+# Remove before 2025.11.0
+SWITCH_SCHEMA = switch_schema()
+SWITCH_SCHEMA.add_extra(cv.deprecated_schema_constant("switch"))
 
 
 async def setup_switch_core_(var, config):

--- a/esphome/components/text_sensor/__init__.py
+++ b/esphome/components/text_sensor/__init__.py
@@ -125,7 +125,7 @@ async def map_filter_to_code(config, filter_id):
 
 validate_device_class = cv.one_of(*DEVICE_CLASSES, lower=True, space="_")
 
-TEXT_SENSOR_SCHEMA = (
+_TEXT_SENSOR_SCHEMA = (
     cv.ENTITY_BASE_SCHEMA.extend(web_server.WEBSERVER_SORTING_SCHEMA)
     .extend(cv.MQTT_COMPONENT_SCHEMA)
     .extend(
@@ -160,7 +160,7 @@ def text_sensor_schema(
     entity_category: str = cv.UNDEFINED,
     device_class: str = cv.UNDEFINED,
 ) -> cv.Schema:
-    schema = TEXT_SENSOR_SCHEMA
+    schema = _TEXT_SENSOR_SCHEMA
     if class_ is not cv.UNDEFINED:
         schema = schema.extend({cv.GenerateID(): cv.declare_id(class_)})
     if icon is not cv.UNDEFINED:
@@ -182,6 +182,11 @@ def text_sensor_schema(
             }
         )
     return schema
+
+
+# Remove before 2025.11.0
+TEXT_SENSOR_SCHEMA = text_sensor_schema()
+TEXT_SENSOR_SCHEMA.add_extra(cv.deprecated_schema_constant("text_sensor"))
 
 
 async def build_filters(config):


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Follow up to https://github.com/esphome/esphome/pull/8747 aligning all entity types

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
