### PR TITLE
[i2s_audio] Correct a microphone with a DC offset signal

### DIFF
--- a/esphome/components/i2s_audio/microphone/__init__.py
+++ b/esphome/components/i2s_audio/microphone/__init__.py
@@ -30,6 +30,7 @@ DEPENDENCIES = ["i2s_audio"]
 
 CONF_ADC_PIN = "adc_pin"
 CONF_ADC_TYPE = "adc_type"
+CONF_CORRECT_DC_OFFSET = "correct_dc_offset"
 CONF_PDM = "pdm"
 
 I2SAudioMicrophone = i2s_audio_ns.class_(
@@ -88,9 +89,12 @@ BASE_SCHEMA = microphone.MICROPHONE_SCHEMA.extend(
         default_sample_rate=16000,
         default_channel=CONF_RIGHT,
         default_bits_per_sample="32bit",
+    ).extend(
+        {
+            cv.Optional(CONF_CORRECT_DC_OFFSET, default=False): cv.boolean,
+        }
     )
 ).extend(cv.COMPONENT_SCHEMA)
-
 
 CONFIG_SCHEMA = cv.All(
     cv.typed_schema(
@@ -140,3 +144,5 @@ async def to_code(config):
     else:
         cg.add(var.set_din_pin(config[CONF_I2S_DIN_PIN]))
         cg.add(var.set_pdm(config[CONF_PDM]))
+
+    cg.add(var.set_correct_dc_offset(config[CONF_CORRECT_DC_OFFSET]))

--- a/esphome/components/i2s_audio/microphone/i2s_audio_microphone.cpp
+++ b/esphome/components/i2s_audio/microphone/i2s_audio_microphone.cpp
@@ -396,6 +396,10 @@ void I2SAudioMicrophone::fix_dc_offset_(std::vector<uint8_t> &data) {
   const size_t bytes_per_sample = this->audio_stream_info_.samples_to_bytes(1);
   const uint32_t total_samples = this->audio_stream_info_.bytes_to_samples(data.size());
 
+  if (total_samples == 0) {
+    return;
+  }
+
   int64_t offset_accumulator = 0;
   for (uint32_t sample_index = 0; sample_index < total_samples; ++sample_index) {
     const uint32_t byte_index = sample_index * bytes_per_sample;

--- a/esphome/components/i2s_audio/microphone/i2s_audio_microphone.cpp
+++ b/esphome/components/i2s_audio/microphone/i2s_audio_microphone.cpp
@@ -24,8 +24,8 @@ static const uint32_t READ_DURATION_MS = 16;
 static const size_t TASK_STACK_SIZE = 4096;
 static const ssize_t TASK_PRIORITY = 23;
 
-// Use an exponential moving average to correct a DC offset with weight factor 1/10
-static const int32_t DC_OFFSET_MOVING_AVERAGE_COEFFICIENT_DENOMINATOR = 10;
+// Use an exponential moving average to correct a DC offset with weight factor 1/1000
+static const int32_t DC_OFFSET_MOVING_AVERAGE_COEFFICIENT_DENOMINATOR = 1000;
 
 static const char *const TAG = "i2s_audio.microphone";
 
@@ -410,8 +410,6 @@ void I2SAudioMicrophone::fix_dc_offset_(std::vector<uint8_t> &data) {
   }
 
   const int32_t new_offset = offset_accumulator / total_samples;
-
-  // Apply an exponential moving average with factor 0.1
   this->dc_offset_ = new_offset / DC_OFFSET_MOVING_AVERAGE_COEFFICIENT_DENOMINATOR +
                      (DC_OFFSET_MOVING_AVERAGE_COEFFICIENT_DENOMINATOR - 1) * this->dc_offset_ /
                          DC_OFFSET_MOVING_AVERAGE_COEFFICIENT_DENOMINATOR;

--- a/esphome/components/i2s_audio/microphone/i2s_audio_microphone.cpp
+++ b/esphome/components/i2s_audio/microphone/i2s_audio_microphone.cpp
@@ -369,7 +369,7 @@ void I2SAudioMicrophone::mic_task(void *params) {
         }
         this_microphone->data_callbacks_.call(samples);
       } else {
-        delay(READ_DURATION_MS);
+        vTaskDelay(pdMS_TO_TICKS(READ_DURATION_MS));
       }
     }
   }
@@ -380,7 +380,7 @@ void I2SAudioMicrophone::mic_task(void *params) {
   xEventGroupSetBits(this_microphone->event_group_, MicrophoneEventGroupBits::TASK_STOPPED);
   while (true) {
     // Continuously delay until the loop method deletes the task
-    delay(10);
+    vTaskDelay(pdMS_TO_TICKS(10));
   }
 }
 

--- a/esphome/components/i2s_audio/microphone/i2s_audio_microphone.cpp
+++ b/esphome/components/i2s_audio/microphone/i2s_audio_microphone.cpp
@@ -22,6 +22,9 @@ static const uint32_t READ_DURATION_MS = 16;
 static const size_t TASK_STACK_SIZE = 4096;
 static const ssize_t TASK_PRIORITY = 23;
 
+// Use an exponential moving average to correct a DC offset with weight factor 1/10
+static const int32_t DC_OFFSET_MOVING_AVERAGE_COEFFICIENT_DENOMINATOR = 10;
+
 static const char *const TAG = "i2s_audio.microphone";
 
 enum MicrophoneEventGroupBits : uint32_t {
@@ -361,6 +364,9 @@ void I2SAudioMicrophone::mic_task(void *params) {
         samples.resize(bytes_to_read);
         size_t bytes_read = this_microphone->read_(samples.data(), bytes_to_read, 2 * pdMS_TO_TICKS(READ_DURATION_MS));
         samples.resize(bytes_read);
+        if (this_microphone->correct_dc_offset_) {
+          this_microphone->fix_dc_offset_(samples);
+        }
         this_microphone->data_callbacks_.call(samples);
       } else {
         delay(READ_DURATION_MS);
@@ -373,9 +379,30 @@ void I2SAudioMicrophone::mic_task(void *params) {
 
   xEventGroupSetBits(this_microphone->event_group_, MicrophoneEventGroupBits::TASK_STOPPED);
   while (true) {
-    // Continuously delay until the loop method delete the task
+    // Continuously delay until the loop method deletes the task
     delay(10);
   }
+}
+
+void I2SAudioMicrophone::fix_dc_offset_(std::vector<uint8_t> &data) {
+  const size_t bytes_per_sample = this->audio_stream_info_.samples_to_bytes(1);
+  const uint32_t total_samples = this->audio_stream_info_.bytes_to_samples(data.size());
+
+  int64_t offset_accumulator = 0;
+  for (uint32_t sample_index = 0; sample_index < total_samples; ++sample_index) {
+    const uint32_t byte_index = sample_index * bytes_per_sample;
+    int32_t sample = audio::unpack_audio_sample_to_q31(&data[byte_index], bytes_per_sample);
+    offset_accumulator += sample;
+    sample -= this->dc_offset_;
+    audio::pack_q31_as_audio_sample(sample, &data[byte_index], bytes_per_sample);
+  }
+
+  const int32_t new_offset = offset_accumulator / total_samples;
+
+  // Apply an exponential moving average with factor 0.1
+  this->dc_offset_ = new_offset / DC_OFFSET_MOVING_AVERAGE_COEFFICIENT_DENOMINATOR +
+                     (DC_OFFSET_MOVING_AVERAGE_COEFFICIENT_DENOMINATOR - 1) * this->dc_offset_ /
+                         DC_OFFSET_MOVING_AVERAGE_COEFFICIENT_DENOMINATOR;
 }
 
 size_t I2SAudioMicrophone::read_(uint8_t *buf, size_t len, TickType_t ticks_to_wait) {

--- a/esphome/components/i2s_audio/microphone/i2s_audio_microphone.cpp
+++ b/esphome/components/i2s_audio/microphone/i2s_audio_microphone.cpp
@@ -12,6 +12,8 @@
 #include "esphome/core/hal.h"
 #include "esphome/core/log.h"
 
+#include "esphome/components/audio/audio.h"
+
 namespace esphome {
 namespace i2s_audio {
 
@@ -73,21 +75,11 @@ void I2SAudioMicrophone::setup() {
     this->mark_failed();
     return;
   }
+
+  this->configure_stream_settings_();
 }
 
-void I2SAudioMicrophone::start() {
-  if (this->is_failed())
-    return;
-
-  xSemaphoreTake(this->active_listeners_semaphore_, 0);
-}
-
-bool I2SAudioMicrophone::start_driver_() {
-  if (!this->parent_->try_lock()) {
-    return false;  // Waiting for another i2s to return lock
-  }
-  esp_err_t err;
-
+void I2SAudioMicrophone::configure_stream_settings_() {
   uint8_t channel_count = 1;
 #ifdef USE_I2S_LEGACY
   uint8_t bits_per_sample = this->bits_per_sample_;
@@ -96,10 +88,10 @@ bool I2SAudioMicrophone::start_driver_() {
     channel_count = 2;
   }
 #else
-  if (this->slot_bit_width_ == I2S_SLOT_BIT_WIDTH_AUTO) {
-    this->slot_bit_width_ = I2S_SLOT_BIT_WIDTH_16BIT;
+  uint8_t bits_per_sample = 16;
+  if (this->slot_bit_width_ != I2S_SLOT_BIT_WIDTH_AUTO) {
+    bits_per_sample = this->slot_bit_width_;
   }
-  uint8_t bits_per_sample = this->slot_bit_width_;
 
   if (this->slot_mode_ == I2S_SLOT_MODE_STEREO) {
     channel_count = 2;
@@ -116,6 +108,26 @@ bool I2SAudioMicrophone::start_driver_() {
     bits_per_sample = 32;
   }
 #endif
+
+  if (this->pdm_) {
+    bits_per_sample = 16;  // PDM mics are always 16 bits per sample
+  }
+
+  this->audio_stream_info_ = audio::AudioStreamInfo(bits_per_sample, channel_count, this->sample_rate_);
+}
+
+void I2SAudioMicrophone::start() {
+  if (this->is_failed())
+    return;
+
+  xSemaphoreTake(this->active_listeners_semaphore_, 0);
+}
+
+bool I2SAudioMicrophone::start_driver_() {
+  if (!this->parent_->try_lock()) {
+    return false;  // Waiting for another i2s to return lock
+  }
+  esp_err_t err;
 
 #ifdef USE_I2S_LEGACY
   i2s_driver_config_t config = {
@@ -205,8 +217,6 @@ bool I2SAudioMicrophone::start_driver_() {
   i2s_std_gpio_config_t pin_config = this->parent_->get_pin_config();
 #if SOC_I2S_SUPPORTS_PDM_RX
   if (this->pdm_) {
-    bits_per_sample = 16;  // PDM mics are always 16 bits per sample with the IDF 5 driver
-
     i2s_pdm_rx_clk_config_t clk_cfg = {
         .sample_rate_hz = this->sample_rate_,
         .clk_src = clk_src,
@@ -280,10 +290,8 @@ bool I2SAudioMicrophone::start_driver_() {
   }
 #endif
 
-  this->audio_stream_info_ = audio::AudioStreamInfo(bits_per_sample, channel_count, this->sample_rate_);
-
   this->status_clear_error();
-
+  this->configure_stream_settings_();  // redetermine the settings in case some settings were changed after compilation
   return true;
 }
 

--- a/esphome/components/i2s_audio/microphone/i2s_audio_microphone.h
+++ b/esphome/components/i2s_audio/microphone/i2s_audio_microphone.h
@@ -53,6 +53,9 @@ class I2SAudioMicrophone : public I2SAudioIn, public microphone::Microphone, pub
 
   size_t read_(uint8_t *buf, size_t len, TickType_t ticks_to_wait);
 
+  /// @brief Sets the Microphone ``audio_stream_info_`` member variable to the configured I2S settings.
+  void configure_stream_settings_();
+
   static void mic_task(void *params);
 
   SemaphoreHandle_t active_listeners_semaphore_{nullptr};

--- a/esphome/components/i2s_audio/microphone/i2s_audio_microphone.h
+++ b/esphome/components/i2s_audio/microphone/i2s_audio_microphone.h
@@ -7,8 +7,10 @@
 #include "esphome/components/microphone/microphone.h"
 #include "esphome/core/component.h"
 
+#include <freertos/FreeRTOS.h>
 #include <freertos/event_groups.h>
 #include <freertos/semphr.h>
+#include <freertos/task.h>
 
 namespace esphome {
 namespace i2s_audio {

--- a/esphome/components/i2s_audio/microphone/i2s_audio_microphone.h
+++ b/esphome/components/i2s_audio/microphone/i2s_audio_microphone.h
@@ -20,6 +20,9 @@ class I2SAudioMicrophone : public I2SAudioIn, public microphone::Microphone, pub
   void stop() override;
 
   void loop() override;
+
+  void set_correct_dc_offset(bool correct_dc_offset) { this->correct_dc_offset_ = correct_dc_offset; }
+
 #ifdef USE_I2S_LEGACY
   void set_din_pin(int8_t pin) { this->din_pin_ = pin; }
 #else
@@ -41,6 +44,11 @@ class I2SAudioMicrophone : public I2SAudioIn, public microphone::Microphone, pub
   bool start_driver_();
   void stop_driver_();
 
+  /// @brief Attempts to correct a microphone DC offset; e.g., a microphones silent level is offset from 0. Applies a
+  /// correction offset that is updated using an exponential moving average for all samples away from 0.
+  /// @param data
+  void fix_dc_offset_(std::vector<uint8_t> &data);
+
   size_t read_(uint8_t *buf, size_t len, TickType_t ticks_to_wait);
 
   static void mic_task(void *params);
@@ -61,6 +69,9 @@ class I2SAudioMicrophone : public I2SAudioIn, public microphone::Microphone, pub
   i2s_chan_handle_t rx_handle_;
 #endif
   bool pdm_{false};
+
+  bool correct_dc_offset_;
+  int32_t dc_offset_{0};
 };
 
 }  // namespace i2s_audio

--- a/tests/components/microphone/common.yaml
+++ b/tests/components/microphone/common.yaml
@@ -10,6 +10,7 @@ microphone:
     adc_type: external
     pdm: false
     mclk_multiple: 384
+    correct_dc_offset: true
     on_data:
       - if:
           condition:


### PR DESCRIPTION
# What does this implement/fix?

- Fixes not including the proper FreeRTOS task header
- Moves the calculation for the audio stream info into its own function and calls it during setup. This way downstream MicrophoneSources knows the correct sample rate, even if the microphone hasn't started yet.
- Adds a new parameter for correcting a DC offset in the microphone signal. When enabled, it computes an exponential moving average for the mic signal, and subtracts the average from the actual signal to correct for it.

ATOM Echo example without correction:
<img width="300" alt="atom-echo-dc-offset-original" src="https://github.com/user-attachments/assets/f627f3bd-0b17-4c64-8db2-355cd1017b2b" />

ATOM Echo example with correction:
<img width="300" alt="atom-echo-dc-offset-corrected" src="https://github.com/user-attachments/assets/66f7ebc5-e3ac-4411-8a1f-a52e78b38899" />
On this Echo, the noise floor before the fix was -30 dB. After the fix, it is around -60 dB. Listening to the audio recordings, there is less of a background hum with the corrected audio, and it seems the voice activity detector in Home Assistant performs better.

The fact this can happen may be due to a hardware design issue with PDM microphones: see a [comment on the esp-idf issue tracker](https://github.com/espressif/esp-idf/issues/11105#issuecomment-2558334515).




## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** not applicable

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#4902

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
This is a configuration for an ATOM Echo with the correction enabled.
```yaml
# Example config.yaml

i2s_audio:
  - id: i2s_audio_bus
    i2s_lrclk_pin: GPIO33
    i2s_bclk_pin: GPIO19

microphone:
  - platform: i2s_audio
    id: echo_microphone
    i2s_din_pin: GPIO23
    adc_type: external
    pdm: true
    sample_rate: 16000
    correct_dc_offset: true

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
