### PR TITLE
[vscode] provide version to editor

### DIFF
--- a/esphome/vscode.py
+++ b/esphome/vscode.py
@@ -104,7 +104,7 @@ def _print_version():
         json.dumps(
             {
                 "type": "version",
-                "_value": ESPHOME_VERSION,
+                "value": ESPHOME_VERSION,
             }
         )
     )

--- a/esphome/vscode.py
+++ b/esphome/vscode.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from esphome.config import Config, _format_vol_invalid, validate_config
 import esphome.config_validation as cv
+from esphome.const import __version__ as ESPHOME_VERSION
 from esphome.core import CORE, DocumentRange
 from esphome.yaml_util import parse_yaml
 
@@ -97,7 +98,21 @@ def _ace_loader(fname: str) -> dict[str, Any]:
     return parse_yaml(fname, raw_yaml_stream)
 
 
+def _print_version():
+    """Print ESPHome version."""
+    print(
+        json.dumps(
+            {
+                "type": "version",
+                "_value": ESPHOME_VERSION,
+            }
+        )
+    )
+
+
 def read_config(args):
+    _print_version()
+
     while True:
         CORE.reset()
         data = json.loads(input())

--- a/tests/unit_tests/test_vscode.py
+++ b/tests/unit_tests/test_vscode.py
@@ -18,8 +18,12 @@ def _run_repl_test(input_data):
         vscode.read_config(args)
 
         # Capture printed output
-        full_output = "".join(call[0][0] for call in mock_stdout.write.call_args_list)
-        return full_output.strip().split("\n")
+        full_output = "".join(
+            call[0][0] for call in mock_stdout.write.call_args_list
+        ).strip()
+        splitted_output = full_output.split("\n")
+        remove_version = splitted_output[1:]  # remove first entry with version info
+        return remove_version
 
 
 def _validate(file_path: str):


### PR DESCRIPTION
# What does this implement/fix?

Sends a message with the current version of esphome on the connection for esphome validation. This is used to properly select the schema docs for completion

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
