### PR TITLE
[config] Deprecate more ``*_SCHEMA`` constants

### DIFF
--- a/esphome/components/climate/__init__.py
+++ b/esphome/components/climate/__init__.py
@@ -11,9 +11,11 @@ from esphome.const import (
     CONF_CURRENT_TEMPERATURE_STATE_TOPIC,
     CONF_CUSTOM_FAN_MODE,
     CONF_CUSTOM_PRESET,
+    CONF_ENTITY_CATEGORY,
     CONF_FAN_MODE,
     CONF_FAN_MODE_COMMAND_TOPIC,
     CONF_FAN_MODE_STATE_TOPIC,
+    CONF_ICON,
     CONF_ID,
     CONF_MAX_TEMPERATURE,
     CONF_MIN_TEMPERATURE,
@@ -46,6 +48,7 @@ from esphome.const import (
     CONF_WEB_SERVER,
 )
 from esphome.core import CORE, coroutine_with_priority
+from esphome.cpp_generator import MockObjClass
 from esphome.cpp_helpers import setup_entity
 
 IS_PLATFORM_COMPONENT = True
@@ -151,12 +154,11 @@ ControlTrigger = climate_ns.class_(
     "ControlTrigger", automation.Trigger.template(ClimateCall.operator("ref"))
 )
 
-CLIMATE_SCHEMA = (
+_CLIMATE_SCHEMA = (
     cv.ENTITY_BASE_SCHEMA.extend(web_server.WEBSERVER_SORTING_SCHEMA)
     .extend(cv.MQTT_COMMAND_COMPONENT_SCHEMA)
     .extend(
         {
-            cv.GenerateID(): cv.declare_id(Climate),
             cv.OnlyWith(CONF_MQTT_ID, "mqtt"): cv.declare_id(mqtt.MQTTClimateComponent),
             cv.Optional(CONF_VISUAL, default={}): cv.Schema(
                 {
@@ -243,6 +245,31 @@ CLIMATE_SCHEMA = (
         }
     )
 )
+
+
+def climate_schema(
+    class_: MockObjClass,
+    *,
+    entity_category: str = cv.UNDEFINED,
+    icon: str = cv.UNDEFINED,
+) -> cv.Schema:
+    schema = {
+        cv.GenerateID(): cv.declare_id(Climate),
+    }
+
+    for key, default, validator in [
+        (CONF_ENTITY_CATEGORY, entity_category, cv.entity_category),
+        (CONF_ICON, icon, cv.icon),
+    ]:
+        if default is not cv.UNDEFINED:
+            schema[cv.Optional(key, default=default)] = validator
+
+    return _CLIMATE_SCHEMA.extend(schema)
+
+
+# Remove before 2025.11.0
+CLIMATE_SCHEMA = climate_schema(Climate)
+CLIMATE_SCHEMA.add_extra(cv.deprecated_schema_constant("climate"))
 
 
 async def setup_climate_core_(var, config):
@@ -417,6 +444,12 @@ async def register_climate(var, config):
         var = cg.Pvariable(config[CONF_ID], var)
     cg.add(cg.App.register_climate(var))
     await setup_climate_core_(var, config)
+
+
+async def new_climate(config, *args):
+    var = cg.new_Pvariable(config[CONF_ID], *args)
+    await register_climate(var, config)
+    return var
 
 
 CLIMATE_CONTROL_ACTION_SCHEMA = cv.Schema(

--- a/esphome/components/light/__init__.py
+++ b/esphome/components/light/__init__.py
@@ -180,17 +180,16 @@ def light_schema(
         if default is not cv.UNDEFINED:
             schema[cv.Optional(key, default=default)] = validator
 
-    match type_:
-        case LightType.BINARY:
-            return BINARY_LIGHT_SCHEMA.extend(schema)
-        case LightType.BRIGHTNESS_ONLY:
-            return BRIGHTNESS_ONLY_LIGHT_SCHEMA.extend(schema)
-        case LightType.RGB:
-            return RGB_LIGHT_SCHEMA.extend(schema)
-        case LightType.ADDRESSABLE:
-            return ADDRESSABLE_LIGHT_SCHEMA.extend(schema)
-        case _:
-            raise ValueError(f"Invalid light type: {type_}")
+    if type_ == LightType.BINARY:
+        return BINARY_LIGHT_SCHEMA.extend(schema)
+    if type_ == LightType.BRIGHTNESS_ONLY:
+        return BRIGHTNESS_ONLY_LIGHT_SCHEMA.extend(schema)
+    if type_ == LightType.RGB:
+        return RGB_LIGHT_SCHEMA.extend(schema)
+    if type_ == LightType.ADDRESSABLE:
+        return ADDRESSABLE_LIGHT_SCHEMA.extend(schema)
+
+    raise ValueError(f"Invalid light type: {type_}")
 
 
 def validate_color_temperature_channels(value):

--- a/esphome/components/light/__init__.py
+++ b/esphome/components/light/__init__.py
@@ -1,3 +1,5 @@
+import enum
+
 import esphome.automation as auto
 import esphome.codegen as cg
 from esphome.components import mqtt, power_supply, web_server
@@ -13,15 +15,18 @@ from esphome.const import (
     CONF_COLOR_TEMPERATURE,
     CONF_DEFAULT_TRANSITION_LENGTH,
     CONF_EFFECTS,
+    CONF_ENTITY_CATEGORY,
     CONF_FLASH_TRANSITION_LENGTH,
     CONF_GAMMA_CORRECT,
     CONF_GREEN,
+    CONF_ICON,
     CONF_ID,
     CONF_INITIAL_STATE,
     CONF_MQTT_ID,
     CONF_ON_STATE,
     CONF_ON_TURN_OFF,
     CONF_ON_TURN_ON,
+    CONF_OUTPUT_ID,
     CONF_POWER_SUPPLY,
     CONF_RED,
     CONF_RESTORE_MODE,
@@ -33,6 +38,7 @@ from esphome.const import (
     CONF_WHITE,
 )
 from esphome.core import coroutine_with_priority
+from esphome.cpp_generator import MockObjClass
 from esphome.cpp_helpers import setup_entity
 
 from .automation import LIGHT_STATE_SCHEMA
@@ -141,6 +147,52 @@ ADDRESSABLE_LIGHT_SCHEMA = RGB_LIGHT_SCHEMA.extend(
 )
 
 
+class LightType(enum.IntEnum):
+    """Light type enum."""
+
+    BINARY = 0
+    BRIGHTNESS_ONLY = 1
+    RGB = 2
+    ADDRESSABLE = 3
+
+
+def light_schema(
+    class_: MockObjClass,
+    type_: LightType,
+    *,
+    entity_category: str = cv.UNDEFINED,
+    icon: str = cv.UNDEFINED,
+    default_restore_mode: str = cv.UNDEFINED,
+) -> cv.Schema:
+    schema = {
+        cv.GenerateID(CONF_OUTPUT_ID): cv.declare_id(class_),
+    }
+
+    for key, default, validator in [
+        (CONF_ENTITY_CATEGORY, entity_category, cv.entity_category),
+        (CONF_ICON, icon, cv.icon),
+        (
+            CONF_RESTORE_MODE,
+            default_restore_mode,
+            cv.enum(RESTORE_MODES, upper=True, space="_"),
+        ),
+    ]:
+        if default is not cv.UNDEFINED:
+            schema[cv.Optional(key, default=default)] = validator
+
+    match type_:
+        case LightType.BINARY:
+            return BINARY_LIGHT_SCHEMA.extend(schema)
+        case LightType.BRIGHTNESS_ONLY:
+            return BRIGHTNESS_ONLY_LIGHT_SCHEMA.extend(schema)
+        case LightType.RGB:
+            return RGB_LIGHT_SCHEMA.extend(schema)
+        case LightType.ADDRESSABLE:
+            return ADDRESSABLE_LIGHT_SCHEMA.extend(schema)
+        case _:
+            raise ValueError(f"Invalid light type: {type_}")
+
+
 def validate_color_temperature_channels(value):
     if (
         CONF_COLD_WHITE_COLOR_TEMPERATURE in value
@@ -221,6 +273,12 @@ async def register_light(output_var, config):
     cg.add(cg.App.register_light(light_var))
     await cg.register_component(light_var, config)
     await setup_light_core_(light_var, output_var, config)
+
+
+async def new_light(config, *args):
+    output_var = cg.new_Pvariable(config[CONF_OUTPUT_ID], *args)
+    await register_light(output_var, config)
+    return output_var
 
 
 @coroutine_with_priority(100.0)


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Followup to #8747 and #8748

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
