### PR TITLE
[online_image] Last-Modified-Date and ETag response caching

### DIFF
--- a/esphome/components/online_image/__init__.py
+++ b/esphome/components/online_image/__init__.py
@@ -213,7 +213,7 @@ async def to_code(config):
 
     for conf in config.get(CONF_ON_DOWNLOAD_FINISHED, []):
         trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
-        await automation.build_automation(trigger, [], conf)
+        await automation.build_automation(trigger, [(bool, "cached")], conf)
 
     for conf in config.get(CONF_ON_ERROR, []):
         trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)

--- a/esphome/components/online_image/online_image.cpp
+++ b/esphome/components/online_image/online_image.cpp
@@ -3,10 +3,10 @@
 #include "esphome/core/log.h"
 
 static const char *const TAG = "online_image";
-static const std::string ETAG_HEADER_NAME = "etag";
-static const std::string IF_NONE_MATCH_HEADER_NAME = "if-none-match";
-static const std::string LAST_MODIFIED_HEADER_NAME = "last-modified";
-static const std::string IF_MODIFIED_SINCE_HEADER_NAME = "if-modified-since";
+static const char *const ETAG_HEADER_NAME = "etag";
+static const char *const IF_NONE_MATCH_HEADER_NAME = "if-none-match";
+static const char *const LAST_MODIFIED_HEADER_NAME = "last-modified";
+static const char *const IF_MODIFIED_SINCE_HEADER_NAME = "if-modified-since";
 
 #include "image_decoder.h"
 

--- a/esphome/components/online_image/online_image.cpp
+++ b/esphome/components/online_image/online_image.cpp
@@ -217,10 +217,10 @@ void OnlineImage::loop() {
     ESP_LOGD(TAG, "Image fully downloaded, read %zu bytes, width/height = %d/%d", this->downloader_->get_bytes_read(),
              this->width_, this->height_);
     ESP_LOGD(TAG, "Total time: %lds", ::time(nullptr) - this->start_time_);
-    this->end_connection_();
     this->etag_ = this->downloader_->get_response_header(ETAG_HEADER_NAME);
     this->last_modified_ = this->downloader_->get_response_header(LAST_MODIFIED_HEADER_NAME);
     this->download_finished_callback_.call(false);
+    this->end_connection_();
     return;
   }
   if (this->downloader_ == nullptr) {

--- a/esphome/components/online_image/online_image.cpp
+++ b/esphome/components/online_image/online_image.cpp
@@ -3,6 +3,10 @@
 #include "esphome/core/log.h"
 
 static const char *const TAG = "online_image";
+static const std::string ETAG_HEADER_NAME = "etag";
+static const std::string IF_NONE_MATCH_HEADER_NAME = "if-none-match";
+static const std::string LAST_MODIFIED_HEADER_NAME = "last-modified";
+static const std::string IF_MODIFIED_SINCE_HEADER_NAME = "if-modified-since";
 
 #include "image_decoder.h"
 
@@ -60,6 +64,8 @@ void OnlineImage::release() {
     this->height_ = 0;
     this->buffer_width_ = 0;
     this->buffer_height_ = 0;
+    this->last_modified_ = "";
+    this->etag_ = "";
     this->end_connection_();
   }
 }
@@ -127,9 +133,17 @@ void OnlineImage::update() {
   }
   accept_header.value = accept_mime_type + ",*/*;q=0.8";
 
+  if (!this->etag_.empty()) {
+    headers.push_back(http_request::Header{IF_NONE_MATCH_HEADER_NAME, this->etag_});
+  }
+
+  if (!this->last_modified_.empty()) {
+    headers.push_back(http_request::Header{IF_MODIFIED_SINCE_HEADER_NAME, this->last_modified_});
+  }
+
   headers.push_back(accept_header);
 
-  this->downloader_ = this->parent_->get(this->url_, headers);
+  this->downloader_ = this->parent_->get(this->url_, headers, {ETAG_HEADER_NAME, LAST_MODIFIED_HEADER_NAME});
 
   if (this->downloader_ == nullptr) {
     ESP_LOGE(TAG, "Download failed.");
@@ -141,7 +155,9 @@ void OnlineImage::update() {
   int http_code = this->downloader_->status_code;
   if (http_code == HTTP_CODE_NOT_MODIFIED) {
     // Image hasn't changed on server. Skip download.
+    ESP_LOGI(TAG, "Server returned HTTP 304 (Not Modified). Download skipped.");
     this->end_connection_();
+    this->download_finished_callback_.call(true);
     return;
   }
   if (http_code != HTTP_CODE_OK) {
@@ -202,7 +218,9 @@ void OnlineImage::loop() {
              this->width_, this->height_);
     ESP_LOGD(TAG, "Total time: %lds", ::time(nullptr) - this->start_time_);
     this->end_connection_();
-    this->download_finished_callback_.call();
+    this->etag_ = this->downloader_->get_response_header(ETAG_HEADER_NAME);
+    this->last_modified_ = this->downloader_->get_response_header(LAST_MODIFIED_HEADER_NAME);
+    this->download_finished_callback_.call(false);
     return;
   }
   if (this->downloader_ == nullptr) {
@@ -325,7 +343,7 @@ bool OnlineImage::validate_url_(const std::string &url) {
   return true;
 }
 
-void OnlineImage::add_on_finished_callback(std::function<void()> &&callback) {
+void OnlineImage::add_on_finished_callback(std::function<void(bool)> &&callback) {
   this->download_finished_callback_.add(std::move(callback));
 }
 

--- a/esphome/components/online_image/online_image.h
+++ b/esphome/components/online_image/online_image.h
@@ -63,6 +63,8 @@ class OnlineImage : public PollingComponent,
     if (this->validate_url_(url)) {
       this->url_ = url;
     }
+    this->etag_ = "";
+    this->last_modified_ = "";
   }
 
   /**

--- a/esphome/components/online_image/online_image.h
+++ b/esphome/components/online_image/online_image.h
@@ -86,7 +86,7 @@ class OnlineImage : public PollingComponent,
    */
   size_t resize_download_buffer(size_t size) { return this->download_buffer_.resize(size); }
 
-  void add_on_finished_callback(std::function<void()> &&callback);
+  void add_on_finished_callback(std::function<void(bool)> &&callback);
   void add_on_error_callback(std::function<void()> &&callback);
 
  protected:
@@ -131,7 +131,7 @@ class OnlineImage : public PollingComponent,
 
   void end_connection_();
 
-  CallbackManager<void()> download_finished_callback_{};
+  CallbackManager<void(bool)> download_finished_callback_{};
   CallbackManager<void()> download_error_callback_{};
 
   std::shared_ptr<http_request::HttpContainer> downloader_{nullptr};
@@ -173,6 +173,14 @@ class OnlineImage : public PollingComponent,
    * decoded images).
    */
   int buffer_height_;
+  /**
+   * The value of the ETag HTTP header provided in the last response.
+   */
+  std::string etag_ = "";
+  /**
+   * The value of the Last-Modified HTTP header provided in the last response.
+   */
+  std::string last_modified_ = "";
 
   time_t start_time_;
 
@@ -202,10 +210,10 @@ template<typename... Ts> class OnlineImageReleaseAction : public Action<Ts...> {
   OnlineImage *parent_;
 };
 
-class DownloadFinishedTrigger : public Trigger<> {
+class DownloadFinishedTrigger : public Trigger<bool> {
  public:
   explicit DownloadFinishedTrigger(OnlineImage *parent) {
-    parent->add_on_finished_callback([this]() { this->trigger(); });
+    parent->add_on_finished_callback([this](bool cached) { this->trigger(cached); });
   }
 };
 

--- a/tests/components/online_image/common.yaml
+++ b/tests/components/online_image/common.yaml
@@ -11,6 +11,13 @@ online_image:
     format: PNG
     type: BINARY
     resize: 50x50
+    on_download_finished:
+      lambda: |-
+        if (cached) {
+          ESP_LOGD("online_image", "Cache hit: using cached image");
+        } else {
+          ESP_LOGD("online_image", "Cache miss: fresh download");
+        }
   - id: online_binary_transparent_image
     url: http://www.libpng.org/pub/png/img_png/pnglogo-blk-tiny.png
     type: BINARY


### PR DESCRIPTION
# What does this implement/fix?

Use the Last-Modified-Date and ETag response headers (if present) when making subsequent requests to implement conditional response caching. If the data on the server is not modified, then a 304 Not Modified response results and the online_image component will reuse the previously received data instead of downloading and processing it again.

See: https://developer.mozilla.org/en-US/docs/Web/HTTP/Caching

The `on_download_finished` callback now has a boolean argument provided that is `true` when a new image is downloaded (cache miss); it's `false` when there is a cache hit.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- https://github.com/esphome/esphome-docs/pull/4906

## Test Environment

- [X] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
