### PR TITLE
Optimize protobuf varint decoder for ESPHome use case

### DIFF
--- a/esphome/components/api/proto.h
+++ b/esphome/components/api/proto.h
@@ -34,10 +34,12 @@ class ProtoVarInt {
     }
 
     // General case for multi-byte varints
-    uint64_t result = 0;
-    uint8_t bitpos = 0;
+    // Since we know buffer[0]'s high bit is set, initialize with its value
+    uint64_t result = buffer[0] & 0x7F;
+    uint8_t bitpos = 7;
 
-    for (uint32_t i = 0; i < len; i++) {
+    // Start from the second byte since we've already processed the first
+    for (uint32_t i = 1; i < len; i++) {
       uint8_t val = buffer[i];
       result |= uint64_t(val & 0x7F) << uint64_t(bitpos);
       bitpos += 7;

--- a/esphome/components/api/proto.h
+++ b/esphome/components/api/proto.h
@@ -20,12 +20,20 @@ class ProtoVarInt {
   explicit ProtoVarInt(uint64_t value) : value_(value) {}
 
   static optional<ProtoVarInt> parse(const uint8_t *buffer, uint32_t len, uint32_t *consumed) {
-    if (consumed != nullptr)
-      *consumed = 0;
-
-    if (len == 0)
+    if (len == 0) {
+      if (consumed != nullptr)
+        *consumed = 0;
       return {};
+    }
 
+    // Most common case: single-byte varint (values 0-127)
+    if ((buffer[0] & 0x80) == 0) {
+      if (consumed != nullptr)
+        *consumed = 1;
+      return ProtoVarInt(buffer[0]);
+    }
+
+    // General case for multi-byte varints
     uint64_t result = 0;
     uint8_t bitpos = 0;
 
@@ -40,7 +48,9 @@ class ProtoVarInt {
       }
     }
 
-    return {};
+    if (consumed != nullptr)
+      *consumed = 0;
+    return {};  // Incomplete or invalid varint
   }
 
   uint32_t as_uint32() const { return this->value_; }


### PR DESCRIPTION
# What does this implement/fix?

This PR optimizes the `ProtoVarInt::parse` method in the Protocol Buffer implementation to significantly improve parsing performance. The optimization provides up to 30% faster varint parsing in benchmarks, which is a critical operation in ESPHome's API communications.

## Testing
```
external_components:
  - source: github://pr#8791
    components: [ api ]
    refresh: 0s
```
## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).


## Benchmarks
A standalone benchmark was created to measure the performance improvement:

```cpp
#include <chrono>
#include <cstdint>
#include <iostream>
#include <random>
#include <vector>
#include <optional>

// Original implementation
class OriginalProtoVarInt {
 public:
  OriginalProtoVarInt() : value_(0) {}
  explicit OriginalProtoVarInt(uint64_t value) : value_(value) {}

  static std::optional<OriginalProtoVarInt> parse(const uint8_t *buffer, uint32_t len, uint32_t *consumed) {
    if (consumed != nullptr)
      *consumed = 0;

    if (len == 0)
      return {};

    uint64_t result = 0;
    uint8_t bitpos = 0;

    for (uint32_t i = 0; i < len; i++) {
      uint8_t val = buffer[i];
      result |= uint64_t(val & 0x7F) << uint64_t(bitpos);
      bitpos += 7;
      if ((val & 0x80) == 0) {
        if (consumed != nullptr)
          *consumed = i + 1;
        return OriginalProtoVarInt(result);
      }
    }

    return {};
  }

  uint64_t value() const { return value_; }
  
 protected:
  uint64_t value_;
};

// Optimized implementation
class OptimizedProtoVarInt {
 public:
  OptimizedProtoVarInt() : value_(0) {}
  explicit OptimizedProtoVarInt(uint64_t value) : value_(value) {}

  static std::optional<OptimizedProtoVarInt> parse(const uint8_t *buffer, uint32_t len, uint32_t *consumed) {
    if (len == 0) {
      if (consumed != nullptr)
        *consumed = 0;    
      return {};
    }

    // Most common case: single-byte varint (values 0-127)
    if ((buffer[0] & 0x80) == 0) {
      if (consumed != nullptr)
        *consumed = 1;
      return OptimizedProtoVarInt(buffer[0]);
    }

    // General case for multi-byte varints
    // Since we know buffer[0]'s high bit is set, initialize with its value
    uint64_t result = buffer[0] & 0x7F;
    uint8_t bitpos = 7;

    // Start from the second byte since we've already processed the first
    for (uint32_t i = 1; i < len; i++) {
      uint8_t val = buffer[i];
      result |= uint64_t(val & 0x7F) << uint64_t(bitpos);
      bitpos += 7;
      if ((val & 0x80) == 0) {
        if (consumed != nullptr)
          *consumed = i + 1;
        return OptimizedProtoVarInt(result);
      }
    }

    if (consumed != nullptr)
      *consumed = 0;  
    return {};  // Incomplete or invalid varint
  }

  uint64_t value() const { return value_; }
  
 protected:
  uint64_t value_;
};

// Function to encode a value as a varint
std::vector<uint8_t> encode_varint(uint64_t value) {
  std::vector<uint8_t> result;
  if (value <= 0x7F) {
    result.push_back(static_cast<uint8_t>(value));
    return result;
  }
  
  while (value) {
    uint8_t byte = value & 0x7F;
    value >>= 7;
    if (value) {
      byte |= 0x80;
    }
    result.push_back(byte);
  }
  
  return result;
}

// Generate test data with realistic distribution of varint lengths
std::vector<std::vector<uint8_t>> generate_test_data(int count_per_size) {
  std::vector<std::vector<uint8_t>> test_data;
  std::random_device rd;
  std::mt19937 gen(rd());
  
  // In most protobuf messages, the vast majority are 1-byte varints (0-127)
  // with some 2-byte and very few larger ones
  
  // 80% 1-byte varints (0-127) - most common in real protobuf data
  // Protocol buffer messages often use a lot of small integers, enum values, and boolean flags
  std::uniform_int_distribution<uint64_t> dist1(0, 127);
  for (int i = 0; i < count_per_size * 8; i++) {
    test_data.push_back(encode_varint(dist1(gen)));
  }
  
  // 15% 2-byte varints (128-16383) - somewhat common
  std::uniform_int_distribution<uint64_t> dist2(128, 16383);
  for (int i = 0; i < count_per_size * 1.5; i++) {
    test_data.push_back(encode_varint(dist2(gen)));
  }
  
  // 4% 3-byte varints (16384-2097151) - less common
  std::uniform_int_distribution<uint64_t> dist3(16384, 2097151);
  for (int i = 0; i < count_per_size * 0.4; i++) {
    test_data.push_back(encode_varint(dist3(gen)));
  }
  
  // 1% 4-byte and larger varints - rare but important to handle correctly
  std::vector<uint64_t> larger_values = {
    2097152, 268435456, 1000000000, 
    UINT32_MAX, UINT32_MAX + 1ULL, 
    (1ULL << 35) - 1, (1ULL << 42) - 1,
    (1ULL << 49) - 1, (1ULL << 56) - 1,
    (1ULL << 63) - 1, UINT64_MAX
  };
  
  for (auto value : larger_values) {
    test_data.push_back(encode_varint(value));
  }
  
  // Shuffle the test data to ensure random access patterns
  std::shuffle(test_data.begin(), test_data.end(), gen);
  
  return test_data;
}

int main() {
  const int ITERATIONS = 10000000;
  const int SAMPLES_PER_SIZE = 10;
  
  auto test_data = generate_test_data(SAMPLES_PER_SIZE);
  std::cout << "Generated " << test_data.size() << " test varints" << std::endl;
  
  // Verify both implementations produce the same results
  for (const auto& data : test_data) {
    uint32_t consumed_orig = 0;
    uint32_t consumed_opt = 0;
    
    auto orig_result = OriginalProtoVarInt::parse(data.data(), data.size(), &consumed_orig);
    auto opt_result = OptimizedProtoVarInt::parse(data.data(), data.size(), &consumed_opt);
    
    if (!orig_result.has_value() || !opt_result.has_value() || 
        orig_result->value() != opt_result->value() || 
        consumed_orig != consumed_opt) {
      std::cout << "ERROR: Results don't match!" << std::endl;
      return 1;
    }
  }
  
  std::cout << "Verification passed. Both implementations produce identical results." << std::endl;
  
  // Benchmark original implementation
  auto start_orig = std::chrono::high_resolution_clock::now();
  
  for (int i = 0; i < ITERATIONS; i++) {
    const auto& data = test_data[i % test_data.size()];
    uint32_t consumed = 0;
    auto result = OriginalProtoVarInt::parse(data.data(), data.size(), &consumed);
    if (!result.has_value()) {
      std::cout << "Error parsing test data" << std::endl;
      return 1;
    }
  }
  
  auto end_orig = std::chrono::high_resolution_clock::now();
  auto duration_orig = std::chrono::duration_cast<std::chrono::microseconds>(end_orig - start_orig);
  
  // Benchmark optimized implementation
  auto start_opt = std::chrono::high_resolution_clock::now();
  
  for (int i = 0; i < ITERATIONS; i++) {
    const auto& data = test_data[i % test_data.size()];
    uint32_t consumed = 0;
    auto result = OptimizedProtoVarInt::parse(data.data(), data.size(), &consumed);
    if (!result.has_value()) {
      std::cout << "Error parsing test data" << std::endl;
      return 1;
    }
  }
  
  auto end_opt = std::chrono::high_resolution_clock::now();
  auto duration_opt = std::chrono::duration_cast<std::chrono::microseconds>(end_opt - start_opt);
  
  // Report results
  std::cout << "Original implementation: " << duration_orig.count() << " microseconds" << std::endl;
  std::cout << "Optimized implementation: " << duration_opt.count() << " microseconds" << std::endl;
  
  double improvement = 100.0 * (1.0 - static_cast<double>(duration_opt.count()) / duration_orig.count());
  std::cout << "Improvement: " << improvement << "%" << std::endl;
  
  return 0;
}
```

Running this benchmark shows the following results:
```
Generated 110 test varints
Verification passed. Both implementations produce identical results.
Original implementation: 13075 microseconds
Optimized implementation: 9161 microseconds
Improvement: 29.935%
```

The optimized implementation is approximately 30% faster than the original