### PR TITLE
[alarm_control_panel] BYPASS_AUTO option for Template Alarm Control Panel sensors left open when armed

### DIFF
--- a/esphome/components/template/alarm_control_panel/__init__.py
+++ b/esphome/components/template/alarm_control_panel/__init__.py
@@ -10,6 +10,7 @@ CODEOWNERS = ["@grahambrown11", "@hwstar"]
 CONF_CODES = "codes"
 CONF_BYPASS_ARMED_HOME = "bypass_armed_home"
 CONF_BYPASS_ARMED_NIGHT = "bypass_armed_night"
+CONF_BYPASS_AUTO = "bypass_auto"
 CONF_CHIME = "chime"
 CONF_TRIGGER_MODE = "trigger_mode"
 CONF_REQUIRES_CODE_TO_ARM = "requires_code_to_arm"
@@ -23,6 +24,7 @@ CONF_TRIGGER_TIME = "trigger_time"
 FLAG_NORMAL = "normal"
 FLAG_BYPASS_ARMED_HOME = "bypass_armed_home"
 FLAG_BYPASS_ARMED_NIGHT = "bypass_armed_night"
+FLAG_BYPASS_AUTO = "bypass_auto"
 FLAG_CHIME = "chime"
 
 BinarySensorFlags = {
@@ -30,6 +32,7 @@ BinarySensorFlags = {
     FLAG_BYPASS_ARMED_HOME: 1 << 1,
     FLAG_BYPASS_ARMED_NIGHT: 1 << 2,
     FLAG_CHIME: 1 << 3,
+    FLAG_BYPASS_AUTO: 1 << 4,
 }
 
 
@@ -68,6 +71,7 @@ TEMPLATE_ALARM_CONTROL_PANEL_BINARY_SENSOR_SCHEMA = cv.maybe_simple_value(
         cv.Required(CONF_INPUT): cv.use_id(binary_sensor.BinarySensor),
         cv.Optional(CONF_BYPASS_ARMED_HOME, default=False): cv.boolean,
         cv.Optional(CONF_BYPASS_ARMED_NIGHT, default=False): cv.boolean,
+        cv.Optional(CONF_BYPASS_AUTO, default=False): cv.boolean,
         cv.Optional(CONF_CHIME, default=False): cv.boolean,
         cv.Optional(CONF_TRIGGER_MODE, default="DELAYED"): cv.enum(
             ALARM_SENSOR_TYPES, upper=True, space="_"
@@ -143,6 +147,8 @@ async def to_code(config):
         if sensor[CONF_BYPASS_ARMED_NIGHT]:
             flags |= BinarySensorFlags[FLAG_BYPASS_ARMED_NIGHT]
             supports_arm_night = True
+        if sensor[CONF_BYPASS_AUTO]:
+            flags |= BinarySensorFlags[FLAG_BYPASS_AUTO]
         if sensor[CONF_CHIME]:
             flags |= BinarySensorFlags[FLAG_CHIME]
         cg.add(var.add_sensor(bs, flags, sensor[CONF_TRIGGER_MODE]))

--- a/esphome/components/template/alarm_control_panel/template_alarm_control_panel.h
+++ b/esphome/components/template/alarm_control_panel/template_alarm_control_panel.h
@@ -22,6 +22,7 @@ enum BinarySensorFlags : uint16_t {
   BINARY_SENSOR_MODE_BYPASS_ARMED_HOME = 1 << 1,
   BINARY_SENSOR_MODE_BYPASS_ARMED_NIGHT = 1 << 2,
   BINARY_SENSOR_MODE_CHIME = 1 << 3,
+  BINARY_SENSOR_MODE_BYPASS_AUTO = 1 << 4,
 };
 
 enum AlarmSensorType : uint16_t {
@@ -121,7 +122,8 @@ class TemplateAlarmControlPanel : public alarm_control_panel::AlarmControlPanel,
 #ifdef USE_BINARY_SENSOR
   // This maps a binary sensor to its type and attribute bits
   std::map<binary_sensor::BinarySensor *, SensorInfo> sensor_map_;
-
+  // a list of automatically bypassed sensors
+  std::vector<uint8_t> bypassed_sensor_indicies_;
 #endif
   TemplateAlarmControlPanelRestoreMode restore_mode_{};
 

--- a/tests/components/alarm_control_panel/common.yaml
+++ b/tests/components/alarm_control_panel/common.yaml
@@ -19,6 +19,7 @@ alarm_control_panel:
       - input: bin1
         bypass_armed_home: true
         bypass_armed_night: true
+        bypass_auto: true
     on_state:
       then:
         - lambda: !lambda |-
@@ -38,6 +39,7 @@ alarm_control_panel:
       - input: bin1
         bypass_armed_home: true
         bypass_armed_night: true
+        bypass_auto: true
     on_disarmed:
       then:
         - logger.log: "### DISARMED ###"


### PR DESCRIPTION
# What does this implement/fix?

This adds a `bypass_auto` option to the `binary_sensors` schema used in the template Alarm Control Panel. Inspired by the _Bypass automatically_ option in [Alarmo](https://github.com/nielsfaber/alarmo), this feature causes sensors to be automatically bypassed if they are left on/active/open at the time of arming the alarm. The bypassed sensor will remain bypassed until the alarm is disarmed.

The typical use case for this is a window or door that is accidentally left open when leaving the house or at night when arming the alarm. Previous behavior, without this feature, the alarm would immediately be triggered as soon as it became armed, and this would prevent the user from arming the other sensors to detect a real intrusion.

Real-world example (happened to me many times) -- One of the kids leaves their bedroom window open a crack and leaves for school. Automations automatically arm the alarm system when the house is empty, and previously this would cause the alarm to be immediately triggered. I would have to disarm the alarm, and leave it disarmed until someone can come home to physically close the window. Now, with the `bypass_auto` flag enabled for that sensor, the open window is excluded from triggering the alarm, but only for the duration of that armed session, so that the house can remain secured via all the other sensors in the alarm system.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#4911

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
alarm_control_panel:
  platform: template
  id: acp1
  restore_mode: RESTORE_DEFAULT_DISARMED
  name: Konnected Alarm
  binary_sensors:
    - input: zone1
      bypass_auto: True
    - input: zone2
      bypass_auto: True
    - input: zone3
  arming_away_time: 90s
  arming_home_time: 30s
  arming_night_time: 30s
  pending_time: 30s
  on_triggered:
    then:
    - script.execute: trigger_alarm1
  on_cleared:
    then:
    - switch.turn_off: alarm1
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
