### PR TITLE
Add SSL certificate option for dashboard/web server

### DIFF
--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -949,7 +949,7 @@ def parse_args(argv):
     )
     parser_dashboard.add_argument(
         "--port",
-        help="The HTTP port to open connections on. Defaults to 6052.",
+        help="The HTTP(S) port to open connections on. Defaults to 6052.",
         type=int,
         default=6052,
     )
@@ -958,6 +958,24 @@ def parse_args(argv):
         help="The address to bind to.",
         type=str,
         default="0.0.0.0",
+    )
+    parser_dashboard.add_argument(
+        "--cert-crt",
+        help="The optional SSL certificate file name for the web server. This option requires the option `--cert-key` This option will enable HTTPS on the web server.",
+        type=str,
+        default="",
+    )
+    parser_dashboard.add_argument(
+        "--cert-key",
+        help="The optional SSL key file name for the web server. This option requires the option `--cert-crt`.",
+        type=str,
+        default="",
+    )
+    parser_dashboard.add_argument(
+        "--cert-pass",
+        help="The optional SSL key file password for the web server. This option requires the option `--cert-crt`",
+        type=str,
+        default="",
     )
     parser_dashboard.add_argument(
         "--username",

--- a/esphome/dashboard/dashboard.py
+++ b/esphome/dashboard/dashboard.py
@@ -139,7 +139,16 @@ async def async_start(args) -> None:
     address: str | None = args.address
     port: int | None = args.port
 
-    start_web_server(make_app(args.verbose), sock, address, port, settings.config_dir)
+    start_web_server(
+        make_app(args.verbose),
+        sock,
+        address,
+        port,
+        settings.config_dir,
+        args.cert_crt,
+        args.cert_key,
+        args.cert_pass,
+    )
 
     if args.open_ui:
         import webbrowser

--- a/esphome/dashboard/web_server.py
+++ b/esphome/dashboard/web_server.py
@@ -14,6 +14,7 @@ import os
 from pathlib import Path
 import secrets
 import shutil
+import ssl
 import subprocess
 import threading
 import time
@@ -1234,6 +1235,9 @@ def start_web_server(
     address: str | None,
     port: int | None,
     config_dir: str,
+    cert_crt: str | None,
+    cert_key: str | None,
+    cert_pass: str | None,
 ) -> None:
     """Start the web server listener."""
 
@@ -1243,14 +1247,21 @@ def start_web_server(
         archive_path = archive_storage_path()
         shutil.move(trash_path, archive_path)
 
+    ssl_context: ssl.SSLContext = None
+    if cert_crt is not None and len(cert_crt) > 0 and os.path.exists(cert_crt):
+        if cert_key is not None and len(cert_key) > 0 and os.path.exists(cert_key):
+            ssl_context = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
+            ssl_context.load_cert_chain(cert_crt, cert_key, cert_pass)
+
     if socket is None:
         _LOGGER.info(
-            "Starting dashboard web server on http://%s:%s and configuration dir %s...",
+            "Starting dashboard web server on http%s://%s:%s and configuration dir %s...",
+            ("" if ssl_context is None else "s"),
             address,
             port,
             config_dir,
         )
-        app.listen(port, address)
+        app.listen(port, address, ssl_options=ssl_context)
         return
 
     _LOGGER.info(
@@ -1258,6 +1269,6 @@ def start_web_server(
         socket,
         config_dir,
     )
-    server = tornado.httpserver.HTTPServer(app)
+    server = tornado.httpserver.HTTPServer(app, ssl_options=ssl_context)
     socket = tornado.netutil.bind_unix_socket(socket, mode=0o666)
     server.add_socket(socket)


### PR DESCRIPTION
# What does this implement/fix?

This feature adds three command line options to run the webserver with HTTP**S**:
 - `--cert-crt <file>` sets the certificate file.
 - `--cert-key <file>` sets the corrosponding key file.
 - `--cert-pass <passphrase>` optionally sets the passphrase of the certificate.
The SSL code is source from  https://www.tornadoweb.org/en/stable/httpserver.html#http-server

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

_none_

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

_none_

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
