### PR TITLE
Bail quickly if there is no data to read

### DIFF
--- a/esphome/components/api/api_frame_helper.cpp
+++ b/esphome/components/api/api_frame_helper.cpp
@@ -268,15 +268,8 @@ APIError APINoiseFrameHelper::try_read_frame_(ParsedFrame *frame) {
   }
 
   // Only check for available data when starting a new frame read
-  if (rx_header_buf_len_ == 0) {
-    ssize_t available = socket_->available();
-    if (available == 0) {
-      return APIError::WOULD_BLOCK;
-    } else if (available == -1) {
-      state_ = State::FAILED;
-      HELPER_LOG("Socket available failed with errno %d", errno);
-      return APIError::SOCKET_READ_FAILED;
-    }
+  if (rx_header_buf_len_ == 0 && socket_->available() == 0) {
+    return APIError::WOULD_BLOCK;
   }
 
   // read header
@@ -840,15 +833,8 @@ APIError APIPlaintextFrameHelper::try_read_frame_(ParsedFrame *frame) {
   }
 
   // Only check for available data when starting a new frame read
-  if (rx_header_buf_pos_ == 0) {
-    ssize_t available = socket_->available();
-    if (available == 0) {
-      return APIError::WOULD_BLOCK;
-    } else if (available == -1) {
-      state_ = State::FAILED;
-      HELPER_LOG("Socket read_available failed with errno %d", errno);
-      return APIError::SOCKET_READ_FAILED;
-    }
+  if (rx_header_buf_pos_ == 0 && socket_->available() == 0) {
+    return APIError::WOULD_BLOCK;
   }
 
   // read header

--- a/esphome/components/api/api_frame_helper.cpp
+++ b/esphome/components/api/api_frame_helper.cpp
@@ -267,6 +267,18 @@ APIError APINoiseFrameHelper::try_read_frame_(ParsedFrame *frame) {
     return APIError::BAD_ARG;
   }
 
+  // Only check for available data when starting a new frame read
+  if (rx_header_buf_len_ == 0) {
+    ssize_t available = socket_->available();
+    if (available == 0) {
+      return APIError::WOULD_BLOCK;
+    } else if (available == -1) {
+      state_ = State::FAILED;
+      HELPER_LOG("Socket available failed with errno %d", errno);
+      return APIError::SOCKET_READ_FAILED;
+    }
+  }
+
   // read header
   if (rx_header_buf_len_ < 3) {
     // no header information yet
@@ -827,64 +839,84 @@ APIError APIPlaintextFrameHelper::try_read_frame_(ParsedFrame *frame) {
     return APIError::BAD_ARG;
   }
 
+  // Only check for available data when starting a new frame read
+  if (rx_header_buf_pos_ == 0) {
+    ssize_t available = socket_->available();
+    if (available == 0) {
+      return APIError::WOULD_BLOCK;
+    } else if (available == -1) {
+      state_ = State::FAILED;
+      HELPER_LOG("Socket read_available failed with errno %d", errno);
+      return APIError::SOCKET_READ_FAILED;
+    }
+  }
+
   // read header
   while (!rx_header_parsed_) {
-    uint8_t data;
-    // Reading one byte at a time is fastest in practice for ESP32 when
-    // there is no data on the wire (which is the common case).
-    // This results in faster failure detection compared to
-    // attempting to read multiple bytes at once.
-    ssize_t received = socket_->read(&data, 1);
-    if (received == -1) {
-      if (errno == EWOULDBLOCK || errno == EAGAIN) {
-        return APIError::WOULD_BLOCK;
-      }
-      state_ = State::FAILED;
-      HELPER_LOG("Socket read failed with errno %d", errno);
-      return APIError::SOCKET_READ_FAILED;
-    } else if (received == 0) {
-      state_ = State::FAILED;
-      HELPER_LOG("Connection closed");
-      return APIError::CONNECTION_CLOSED;
-    }
-
-    // Successfully read a byte
-
-    // Process byte according to current buffer position
-    if (rx_header_buf_pos_ == 0) {  // Case 1: First byte (indicator byte)
-      if (data != 0x00) {
+    if (rx_header_buf_pos_ == 0) {
+      // Try to read the first 3 bytes at once (indicator + 2 initial bytes)
+      // We can safely read 3 bytes because the minimum header is indicator + 2 varint bytes
+      ssize_t received = socket_->read(rx_header_buf_, 3);
+      if (received == -1) {
+        if (errno == EWOULDBLOCK || errno == EAGAIN) {
+          return APIError::WOULD_BLOCK;
+        }
         state_ = State::FAILED;
-        HELPER_LOG("Bad indicator byte %u", data);
+        HELPER_LOG("Socket read failed with errno %d", errno);
+        return APIError::SOCKET_READ_FAILED;
+      } else if (received == 0) {
+        state_ = State::FAILED;
+        HELPER_LOG("Connection closed");
+        return APIError::CONNECTION_CLOSED;
+      }
+
+      // Validate indicator byte
+      if (rx_header_buf_[0] != 0x00) {
+        state_ = State::FAILED;
+        HELPER_LOG("Bad indicator byte %u", rx_header_buf_[0]);
         return APIError::BAD_INDICATOR;
       }
-      // We don't store the indicator byte, just increment position
-      rx_header_buf_pos_ = 1;  // Set to 1 directly
-      continue;                // Need more bytes before we can parse
-    }
 
-    // Check buffer overflow before storing
-    if (rx_header_buf_pos_ == 5) {  // Case 2: Buffer would overflow (5 bytes is max allowed)
-      state_ = State::FAILED;
-      HELPER_LOG("Header buffer overflow");
-      return APIError::BAD_DATA_PACKET;
-    }
+      // Update our position based on how many bytes we got
+      rx_header_buf_pos_ = received;
 
-    // Store byte in buffer (adjust index to account for skipped indicator byte)
-    rx_header_buf_[rx_header_buf_pos_ - 1] = data;
+      // If we didn't get all 3 bytes, need more
+      if (rx_header_buf_pos_ < 3)
+        continue;
+    } else {
+      // For additional bytes (beyond the first 3), read one at a time
+      // Check buffer overflow before reading
+      if (rx_header_buf_pos_ >= 6) {  // 6 bytes is max allowed (indicator + 5 varint bytes)
+        state_ = State::FAILED;
+        HELPER_LOG("Header buffer overflow");
+        return APIError::BAD_DATA_PACKET;
+      }
 
-    // Increment position after storing
-    rx_header_buf_pos_++;
+      // Read one byte at a time to avoid reading into message body
+      ssize_t received = socket_->read(&rx_header_buf_[rx_header_buf_pos_], 1);
+      if (received == -1) {
+        if (errno == EWOULDBLOCK || errno == EAGAIN) {
+          return APIError::WOULD_BLOCK;
+        }
+        state_ = State::FAILED;
+        HELPER_LOG("Socket read failed with errno %d", errno);
+        return APIError::SOCKET_READ_FAILED;
+      } else if (received == 0) {
+        state_ = State::FAILED;
+        HELPER_LOG("Connection closed");
+        return APIError::CONNECTION_CLOSED;
+      }
 
-    // Case 3: If we only have one varint byte, we need more
-    if (rx_header_buf_pos_ == 2) {  // Have read indicator + 1 byte
-      continue;                     // Need more bytes before we can parse
+      // Increment position
+      rx_header_buf_pos_++;
     }
 
     // At this point, we have at least 3 bytes total:
-    //   - Validated indicator byte (0x00) but not stored
+    //   - Validated indicator byte (0x00) in the first position
     //   - At least 2 bytes in the buffer for the varints
     // Buffer layout:
-    //   First 1-3 bytes: Message size varint (variable length)
+    //   Byte 0: Indicator byte (0x00)
+    //   Bytes 1-3: Message size varint (variable length)
     //     - 2 bytes would only allow up to 16383, which is less than noise's 65535
     //     - 3 bytes allows up to 2097151, ensuring we support at least as much as noise
     //   Remaining 1-2 bytes: Message type varint (variable length)
@@ -892,7 +924,7 @@ APIError APIPlaintextFrameHelper::try_read_frame_(ParsedFrame *frame) {
     // we'll continue reading more bytes.
 
     uint32_t consumed = 0;
-    auto msg_size_varint = ProtoVarInt::parse(&rx_header_buf_[0], rx_header_buf_pos_ - 1, &consumed);
+    auto msg_size_varint = ProtoVarInt::parse(&rx_header_buf_[1], rx_header_buf_pos_ - 1, &consumed);
     if (!msg_size_varint.has_value()) {
       // not enough data there yet
       continue;
@@ -900,7 +932,8 @@ APIError APIPlaintextFrameHelper::try_read_frame_(ParsedFrame *frame) {
 
     rx_header_parsed_len_ = msg_size_varint->as_uint32();
 
-    auto msg_type_varint = ProtoVarInt::parse(&rx_header_buf_[consumed], rx_header_buf_pos_ - 1 - consumed, &consumed);
+    auto msg_type_varint =
+        ProtoVarInt::parse(&rx_header_buf_[1 + consumed], rx_header_buf_pos_ - 1 - consumed, &consumed);
     if (!msg_type_varint.has_value()) {
       // not enough data there yet
       continue;

--- a/esphome/components/api/api_frame_helper.h
+++ b/esphome/components/api/api_frame_helper.h
@@ -183,14 +183,14 @@ class APIPlaintextFrameHelper : public APIFrameHelper {
 
   std::string info_;
   // Fixed-size header buffer for plaintext protocol:
-  // We only need space for the two varints since we validate the indicator byte separately.
+  // We need space for the indicator byte and the two varints.
   // To match noise protocol's maximum message size (65535), we need:
-  // 3 bytes for message size varint (supports up to 2097151) + 2 bytes for message type varint
+  // 1 byte for indicator + 3 bytes for message size varint (supports up to 2097151) + 2 bytes for message type varint
   //
   // While varints could theoretically be up to 10 bytes each for 64-bit values,
   // attempting to process messages with headers that large would likely crash the
   // ESP32 due to memory constraints.
-  uint8_t rx_header_buf_[5];  // 5 bytes for varints (3 for size + 2 for type)
+  uint8_t rx_header_buf_[6];  // 1 byte for indicator + 5 bytes for varints (3 for size + 2 for type)
   uint8_t rx_header_buf_pos_ = 0;
   bool rx_header_parsed_ = false;
   uint32_t rx_header_parsed_type_ = 0;

--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -681,6 +681,10 @@ async def to_code(config):
         add_idf_sdkconfig_option("CONFIG_ESP_TASK_WDT_CHECK_IDLE_TASK_CPU0", False)
         add_idf_sdkconfig_option("CONFIG_ESP_TASK_WDT_CHECK_IDLE_TASK_CPU1", False)
 
+        # Enable socket receive buffer option for FIONREAD support
+        # Already enabled on Arduino framework by default
+        add_idf_sdkconfig_option("CONFIG_LWIP_SO_RCVBUF", True)
+
         # Set default CPU frequency
         add_idf_sdkconfig_option(f"CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ_{freq}", True)
 

--- a/esphome/components/socket/bsd_sockets_impl.cpp
+++ b/esphome/components/socket/bsd_sockets_impl.cpp
@@ -101,6 +101,13 @@ class BSDSocketImpl : public Socket {
     return ::readv(fd_, iov, iovcnt);
 #endif
   }
+  ssize_t available() override {
+    int bytes_available = 0;
+    int ret = ::ioctl(fd_, FIONREAD, &bytes_available);
+    if (ret == -1)
+      return -1;
+    return bytes_available;
+  }
   ssize_t write(const void *buf, size_t len) override { return ::write(fd_, buf, len); }
   ssize_t send(void *buf, size_t len, int flags) { return ::send(fd_, buf, len, flags); }
   ssize_t writev(const struct iovec *iov, int iovcnt) override {

--- a/esphome/components/socket/lwip_raw_tcp_impl.cpp
+++ b/esphome/components/socket/lwip_raw_tcp_impl.cpp
@@ -380,6 +380,22 @@ class LWIPRawImpl : public Socket {
     }
     return ret;
   }
+  ssize_t available() override {
+    if (pcb_ == nullptr) {
+      errno = ECONNRESET;
+      return -1;
+    }
+
+    // Check if we have data in the receive buffer
+    if (rx_buf_ != nullptr) {
+      size_t pb_len = rx_buf_->len;
+      size_t pb_left = pb_len - rx_buf_offset_;
+      return pb_left;
+    }
+
+    // No data in buffer
+    return 0;
+  }
   ssize_t internal_write(const void *buf, size_t len) {
     if (pcb_ == nullptr) {
       errno = ECONNRESET;

--- a/esphome/components/socket/lwip_raw_tcp_impl.cpp
+++ b/esphome/components/socket/lwip_raw_tcp_impl.cpp
@@ -388,9 +388,7 @@ class LWIPRawImpl : public Socket {
 
     // Check if we have data in the receive buffer
     if (rx_buf_ != nullptr) {
-      size_t pb_len = rx_buf_->len;
-      size_t pb_left = pb_len - rx_buf_offset_;
-      return pb_left;
+      return rx_buf_->len - rx_buf_offset_;
     }
 
     // No data in buffer

--- a/esphome/components/socket/lwip_sockets_impl.cpp
+++ b/esphome/components/socket/lwip_sockets_impl.cpp
@@ -81,6 +81,13 @@ class LwIPSocketImpl : public Socket {
   int listen(int backlog) override { return lwip_listen(fd_, backlog); }
   ssize_t read(void *buf, size_t len) override { return lwip_read(fd_, buf, len); }
   ssize_t readv(const struct iovec *iov, int iovcnt) override { return lwip_readv(fd_, iov, iovcnt); }
+  ssize_t available() override {
+    int bytes_available = 0;
+    int ret = lwip_ioctl(fd_, FIONREAD, &bytes_available);
+    if (ret == -1)
+      return -1;
+    return bytes_available;
+  }
   ssize_t write(const void *buf, size_t len) override { return lwip_write(fd_, buf, len); }
   ssize_t send(void *buf, size_t len, int flags) { return lwip_send(fd_, buf, len, flags); }
   ssize_t writev(const struct iovec *iov, int iovcnt) override { return lwip_writev(fd_, iov, iovcnt); }

--- a/esphome/components/socket/socket.h
+++ b/esphome/components/socket/socket.h
@@ -38,6 +38,7 @@ class Socket {
   virtual ssize_t recvfrom(void *buf, size_t len, sockaddr *addr, socklen_t *addr_len) = 0;
 #endif
   virtual ssize_t readv(const struct iovec *iov, int iovcnt) = 0;
+  virtual ssize_t available() = 0;  // Returns number of bytes available to read without blocking, or -1 on error
   virtual ssize_t write(const void *buf, size_t len) = 0;
   virtual ssize_t writev(const struct iovec *iov, int iovcnt) = 0;
   virtual ssize_t sendto(const void *buf, size_t len, int flags, const struct sockaddr *to, socklen_t tolen) = 0;


### PR DESCRIPTION
# What does this implement/fix?

Bail quickly if there is no data to read

Most of the api stats are time spent trying to read when there is no data available. I'm trying to figure out a faster way to bail quickly when there is nothing to read
```
[12:30:46][I][api.stats:373]: Record count for key sections: helper_loop=6751, read_packet=6751, total_loop=6751
[12:30:46][I][api.stats:102]: API Connection Section Runtime Statistics
[12:30:46][I][api.stats:103]: Period stats (last 60000ms):
[12:30:46][I][api.stats:130]:   total_loop: count=6751, avg=0.42ms, max=204ms, total=2807ms
[12:30:46][I][api.stats:130]:   send_buffer_total: count=731, avg=1.67ms, max=3ms, total=1221ms
[12:30:46][I][api.stats:130]:   write_packet: count=731, avg=1.40ms, max=2ms, total=1024ms
[12:30:46][I][api.stats:130]:   read_packet: count=6751, avg=0.15ms, max=1ms, total=1016ms
[12:30:46][I][api.stats:130]:   process_queue: count=6751, avg=0.01ms, max=1ms, total=87ms
[12:30:46][I][api.stats:130]:   iterator_advance: count=6751, avg=0.01ms, max=1ms, total=78ms
[12:30:46][I][api.stats:130]:   helper_loop: count=6751, avg=0.00ms, max=1ms, total=25ms
[12:30:46][I][api.stats:130]:   try_to_clear_buffer: count=731, avg=0.03ms, max=1ms, total=19ms
[12:30:46][I][api.stats:130]:   keepalive: count=6751, avg=0.00ms, max=1ms, total=9ms
[12:30:46][I][api.stats:130]:   state_subs: count=6751, avg=0.00ms, max=1ms, total=2ms
[12:30:46][I][api.stats:130]:   process_message: count=4, avg=0.25ms, max=1ms, total=1ms
[12:30:46][I][api.stats:136]: Total stats (since boot):
[12:30:46][I][api.stats:146]:   total_loop: count=568147, avg=0.44ms, max=215ms, total=252110ms
[12:30:46][I][api.stats:146]:   read_packet: count=568148, avg=0.17ms, max=2ms, total=93760ms
[12:30:46][I][api.stats:146]:   send_buffer_total: count=55968, avg=1.67ms, max=3ms, total=93527ms
[12:30:46][I][api.stats:146]:   write_packet: count=55968, avg=1.37ms, max=3ms, total=76653ms
[12:30:46][I][api.stats:146]:   iterator_advance: count=568148, avg=0.02ms, max=3ms, total=10509ms
[12:30:46][I][api.stats:146]:   process_queue: count=568148, avg=0.01ms, max=2ms, total=8098ms
[12:30:46][I][api.stats:146]:   helper_loop: count=568148, avg=0.00ms, max=2ms, total=2312ms
[12:30:46][I][api.stats:146]:   try_to_clear_buffer: count=55968, avg=0.02ms, max=1ms, total=1280ms
[12:30:46][I][api.stats:146]:   keepalive: count=568148, avg=0.00ms, max=1ms, total=645ms
[12:30:46][I][api.stats:146]:   process_message: count=660, avg=0.70ms, max=4ms, total=462ms
[12:30:46][I][api.stats:146]:   state_subs: count=568148, avg=0.00ms, max=1ms, total=317ms
[12:30:46][D][api.stats:153]: Resetting API section stats, sections count: 11
[12:30:46][I][api.stats:381]: Next API section stats log scheduled for 5120485

```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
