### PR TITLE
Add flip X and Y on inkplate6 component 

### DIFF
--- a/esphome/components/inkplate6/display.py
+++ b/esphome/components/inkplate6/display.py
@@ -10,6 +10,9 @@ from esphome.const import (
     CONF_OE_PIN,
     CONF_PAGES,
     CONF_WAKEUP_PIN,
+    CONF_TRANSFORM,
+    CONF_MIRROR_X,
+    CONF_MIRROR_Y
 )
 
 DEPENDENCIES = ["i2c", "esp32"]
@@ -35,8 +38,6 @@ CONF_POWERUP_PIN = "powerup_pin"
 CONF_SPH_PIN = "sph_pin"
 CONF_SPV_PIN = "spv_pin"
 CONF_VCOM_PIN = "vcom_pin"
-CONF_FLIP_Y = "flip_y"
-CONF_FLIP_X = "flip_x"
 
 inkplate6_ns = cg.esphome_ns.namespace("inkplate6")
 Inkplate6 = inkplate6_ns.class_(
@@ -63,8 +64,12 @@ CONFIG_SCHEMA = cv.All(
         {
             cv.GenerateID(): cv.declare_id(Inkplate6),
             cv.Optional(CONF_GREYSCALE, default=False): cv.boolean,
-            cv.Optional(CONF_FLIP_Y, default=False): cv.boolean,
-            cv.Optional(CONF_FLIP_X, default=False): cv.boolean,
+            cv.Optional(CONF_TRANSFORM): cv.Schema(
+                    {
+                        cv.Optional(CONF_MIRROR_X, default=False): cv.boolean,
+                        cv.Optional(CONF_MIRROR_Y, default=False): cv.boolean,
+                    }
+                ),
             cv.Optional(CONF_PARTIAL_UPDATING, default=True): cv.boolean,
             cv.Optional(CONF_FULL_UPDATE_EVERY, default=10): cv.uint32_t,
             cv.Optional(CONF_MODEL, default="inkplate_6"): cv.enum(
@@ -129,8 +134,9 @@ async def to_code(config):
         cg.add(var.set_writer(lambda_))
 
     cg.add(var.set_greyscale(config[CONF_GREYSCALE]))
-    cg.add(var.set_flip_y(config[CONF_FLIP_Y]))
-    cg.add(var.set_flip_x(config[CONF_FLIP_X]))
+    if transform := config.get(CONF_TRANSFORM):
+        cg.add(var.set_mirror_x(transform[CONF_MIRROR_X]))
+        cg.add(var.set_mirror_y(transform[CONF_MIRROR_Y]))
     cg.add(var.set_partial_updating(config[CONF_PARTIAL_UPDATING]))
     cg.add(var.set_full_update_every(config[CONF_FULL_UPDATE_EVERY]))
 

--- a/esphome/components/inkplate6/display.py
+++ b/esphome/components/inkplate6/display.py
@@ -35,7 +35,7 @@ CONF_POWERUP_PIN = "powerup_pin"
 CONF_SPH_PIN = "sph_pin"
 CONF_SPV_PIN = "spv_pin"
 CONF_VCOM_PIN = "vcom_pin"
-
+CONF_FLIP_Y = "flip_y"
 
 inkplate6_ns = cg.esphome_ns.namespace("inkplate6")
 Inkplate6 = inkplate6_ns.class_(
@@ -62,6 +62,7 @@ CONFIG_SCHEMA = cv.All(
         {
             cv.GenerateID(): cv.declare_id(Inkplate6),
             cv.Optional(CONF_GREYSCALE, default=False): cv.boolean,
+            cv.Optional(CONF_FLIP_Y, default=False): cv.boolean,
             cv.Optional(CONF_PARTIAL_UPDATING, default=True): cv.boolean,
             cv.Optional(CONF_FULL_UPDATE_EVERY, default=10): cv.uint32_t,
             cv.Optional(CONF_MODEL, default="inkplate_6"): cv.enum(
@@ -126,6 +127,7 @@ async def to_code(config):
         cg.add(var.set_writer(lambda_))
 
     cg.add(var.set_greyscale(config[CONF_GREYSCALE]))
+    cg.add(var.set_flip_y(config[CONF_FLIP_Y]))
     cg.add(var.set_partial_updating(config[CONF_PARTIAL_UPDATING]))
     cg.add(var.set_full_update_every(config[CONF_FULL_UPDATE_EVERY]))
 

--- a/esphome/components/inkplate6/display.py
+++ b/esphome/components/inkplate6/display.py
@@ -36,6 +36,7 @@ CONF_SPH_PIN = "sph_pin"
 CONF_SPV_PIN = "spv_pin"
 CONF_VCOM_PIN = "vcom_pin"
 CONF_FLIP_Y = "flip_y"
+CONF_FLIP_X = "flip_x"
 
 inkplate6_ns = cg.esphome_ns.namespace("inkplate6")
 Inkplate6 = inkplate6_ns.class_(
@@ -63,6 +64,7 @@ CONFIG_SCHEMA = cv.All(
             cv.GenerateID(): cv.declare_id(Inkplate6),
             cv.Optional(CONF_GREYSCALE, default=False): cv.boolean,
             cv.Optional(CONF_FLIP_Y, default=False): cv.boolean,
+            cv.Optional(CONF_FLIP_X, default=False): cv.boolean,
             cv.Optional(CONF_PARTIAL_UPDATING, default=True): cv.boolean,
             cv.Optional(CONF_FULL_UPDATE_EVERY, default=10): cv.uint32_t,
             cv.Optional(CONF_MODEL, default="inkplate_6"): cv.enum(
@@ -128,6 +130,7 @@ async def to_code(config):
 
     cg.add(var.set_greyscale(config[CONF_GREYSCALE]))
     cg.add(var.set_flip_y(config[CONF_FLIP_Y]))
+    cg.add(var.set_flip_x(config[CONF_FLIP_X]))
     cg.add(var.set_partial_updating(config[CONF_PARTIAL_UPDATING]))
     cg.add(var.set_full_update_every(config[CONF_FULL_UPDATE_EVERY]))
 

--- a/esphome/components/inkplate6/display.py
+++ b/esphome/components/inkplate6/display.py
@@ -12,7 +12,7 @@ from esphome.const import (
     CONF_WAKEUP_PIN,
     CONF_TRANSFORM,
     CONF_MIRROR_X,
-    CONF_MIRROR_Y
+    CONF_MIRROR_Y,
 )
 
 DEPENDENCIES = ["i2c", "esp32"]
@@ -65,11 +65,11 @@ CONFIG_SCHEMA = cv.All(
             cv.GenerateID(): cv.declare_id(Inkplate6),
             cv.Optional(CONF_GREYSCALE, default=False): cv.boolean,
             cv.Optional(CONF_TRANSFORM): cv.Schema(
-                    {
-                        cv.Optional(CONF_MIRROR_X, default=False): cv.boolean,
-                        cv.Optional(CONF_MIRROR_Y, default=False): cv.boolean,
-                    }
-                ),
+                {
+                    cv.Optional(CONF_MIRROR_X, default=False): cv.boolean,
+                    cv.Optional(CONF_MIRROR_Y, default=False): cv.boolean,
+                }
+            ),
             cv.Optional(CONF_PARTIAL_UPDATING, default=True): cv.boolean,
             cv.Optional(CONF_FULL_UPDATE_EVERY, default=10): cv.uint32_t,
             cv.Optional(CONF_MODEL, default="inkplate_6"): cv.enum(

--- a/esphome/components/inkplate6/inkplate.cpp
+++ b/esphome/components/inkplate6/inkplate.cpp
@@ -156,10 +156,10 @@ void HOT Inkplate6::draw_absolute_pixel_internal(int x, int y, Color color) {
   if (x >= this->get_width_internal() || y >= this->get_height_internal() || x < 0 || y < 0)
     return;
 
-  if (this->flip_y_)
+  if (this->mirror_y_)
     y = this->get_height_internal() - y - 1;
 
-  if (this->flip_x_)
+  if (this->mirror_x_)
     x = this->get_width_internal() - x - 1;
 
   if (this->greyscale_) {

--- a/esphome/components/inkplate6/inkplate.cpp
+++ b/esphome/components/inkplate6/inkplate.cpp
@@ -156,6 +156,9 @@ void HOT Inkplate6::draw_absolute_pixel_internal(int x, int y, Color color) {
   if (x >= this->get_width_internal() || y >= this->get_height_internal() || x < 0 || y < 0)
     return;
 
+  if (this->flip_y_)
+    y = this->get_height_internal() - y - 1;
+
   if (this->greyscale_) {
     int x1 = x / 2;
     int x_sub = x % 2;

--- a/esphome/components/inkplate6/inkplate.cpp
+++ b/esphome/components/inkplate6/inkplate.cpp
@@ -159,6 +159,9 @@ void HOT Inkplate6::draw_absolute_pixel_internal(int x, int y, Color color) {
   if (this->flip_y_)
     y = this->get_height_internal() - y - 1;
 
+  if (this->flip_x_)
+    x = this->get_width_internal() - x - 1;
+
   if (this->greyscale_) {
     int x1 = x / 2;
     int x_sub = x % 2;

--- a/esphome/components/inkplate6/inkplate.h
+++ b/esphome/components/inkplate6/inkplate.h
@@ -92,6 +92,8 @@ class Inkplate6 : public display::DisplayBuffer, public i2c::I2CDevice {
     if (this->is_ready())
       this->initialize_();
   }
+  void set_flip_y(bool flip_y) { this->flip_y_ = flip_y; }
+
   void set_partial_updating(bool partial_updating) { this->partial_updating_ = partial_updating; }
   void set_full_update_every(uint32_t full_update_every) { this->full_update_every_ = full_update_every; }
 
@@ -221,6 +223,7 @@ class Inkplate6 : public display::DisplayBuffer, public i2c::I2CDevice {
 
   bool block_partial_{true};
   bool greyscale_;
+  bool flip_y_;
   bool partial_updating_;
 
   InkplateModel model_;

--- a/esphome/components/inkplate6/inkplate.h
+++ b/esphome/components/inkplate6/inkplate.h
@@ -92,8 +92,8 @@ class Inkplate6 : public display::DisplayBuffer, public i2c::I2CDevice {
     if (this->is_ready())
       this->initialize_();
   }
-  void set_flip_y(bool flip_y) { this->flip_y_ = flip_y; }
-  void set_flip_x(bool flip_x) { this->flip_x_ = flip_x; }
+  void set_mirror_y(bool mirror_y) { this->mirror_y_ = mirror_y; }
+  void set_mirror_x(bool mirror_x) { this->mirror_x_ = mirror_x; }
 
   void set_partial_updating(bool partial_updating) { this->partial_updating_ = partial_updating; }
   void set_full_update_every(uint32_t full_update_every) { this->full_update_every_ = full_update_every; }
@@ -224,8 +224,8 @@ class Inkplate6 : public display::DisplayBuffer, public i2c::I2CDevice {
 
   bool block_partial_{true};
   bool greyscale_;
-  bool flip_y_;
-  bool flip_x_;
+  bool mirror_y_;
+  bool mirror_x_;
   bool partial_updating_;
 
   InkplateModel model_;

--- a/esphome/components/inkplate6/inkplate.h
+++ b/esphome/components/inkplate6/inkplate.h
@@ -93,6 +93,7 @@ class Inkplate6 : public display::DisplayBuffer, public i2c::I2CDevice {
       this->initialize_();
   }
   void set_flip_y(bool flip_y) { this->flip_y_ = flip_y; }
+  void set_flip_x(bool flip_x) { this->flip_x_ = flip_x; }
 
   void set_partial_updating(bool partial_updating) { this->partial_updating_ = partial_updating; }
   void set_full_update_every(uint32_t full_update_every) { this->full_update_every_ = full_update_every; }
@@ -224,6 +225,7 @@ class Inkplate6 : public display::DisplayBuffer, public i2c::I2CDevice {
   bool block_partial_{true};
   bool greyscale_;
   bool flip_y_;
+  bool flip_x_;
   bool partial_updating_;
 
   InkplateModel model_;

--- a/esphome/components/inkplate6/inkplate.h
+++ b/esphome/components/inkplate6/inkplate.h
@@ -224,7 +224,7 @@ class Inkplate6 : public display::DisplayBuffer, public i2c::I2CDevice {
 
   bool block_partial_{true};
   bool greyscale_;
-  bool mirror_y_;
+  bool mirror_y_{false};
   bool mirror_x_;
   bool partial_updating_;
 

--- a/esphome/components/inkplate6/inkplate.h
+++ b/esphome/components/inkplate6/inkplate.h
@@ -225,7 +225,7 @@ class Inkplate6 : public display::DisplayBuffer, public i2c::I2CDevice {
   bool block_partial_{true};
   bool greyscale_;
   bool mirror_y_{false};
-  bool mirror_x_;
+  bool mirror_x_{false};
   bool partial_updating_;
 
   InkplateModel model_;


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Fix the issue in https://github.com/esphome/issues/issues/6507 by implementing a way to flip the screen on both x and y axis, on top of the previous rotations.

They might be a cleaner way to fix it for the specific Inkplate 5gen2 but this approach seems more scalable.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

-  fixes https://github.com/esphome/issues/issues/6507
- follow up on https://github.com/esphome/esphome/pull/7904

Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):

https://github.com/esphome/esphome-docs/pull/4488

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx


## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
