### PR TITLE
[lvgl] Try to allocate smaller buffer on failure

### DIFF
--- a/esphome/components/lvgl/__init__.py
+++ b/esphome/components/lvgl/__init__.py
@@ -321,7 +321,7 @@ async def to_code(configs):
             frac = 2
         elif frac > 0.19:
             frac = 4
-        else:
+        elif frac != 0:
             frac = 8
         displays = [
             await cg.get_variable(display) for display in config[df.CONF_DISPLAYS]
@@ -422,7 +422,7 @@ LVGL_SCHEMA = cv.All(
                 ): lvalid.lv_font,
                 cv.Optional(df.CONF_FULL_REFRESH, default=False): cv.boolean,
                 cv.Optional(CONF_DRAW_ROUNDING, default=2): cv.positive_int,
-                cv.Optional(CONF_BUFFER_SIZE, default="100%"): cv.percentage,
+                cv.Optional(CONF_BUFFER_SIZE, default=0): cv.percentage,
                 cv.Optional(df.CONF_LOG_LEVEL, default="WARN"): cv.one_of(
                     *df.LV_LOG_LEVELS, upper=True
                 ),

--- a/esphome/components/lvgl/lvgl_esphome.cpp
+++ b/esphome/components/lvgl/lvgl_esphome.cpp
@@ -435,7 +435,7 @@ void LvglComponent::setup() {
   auto *display = this->displays_[0];
   auto width = display->get_width();
   auto height = display->get_height();
-  auto frac = buffer_frac_;
+  auto frac = this->buffer_frac_;
   if (frac == 0)
     frac = 1;
   size_t buffer_pixels = width * height / frac;

--- a/esphome/components/lvgl/lvgl_esphome.cpp
+++ b/esphome/components/lvgl/lvgl_esphome.cpp
@@ -11,6 +11,8 @@ namespace esphome {
 namespace lvgl {
 static const char *const TAG = "lvgl";
 
+static const size_t MIN_BUFFER_FRAC = 8;
+
 static const char *const EVENT_NAMES[] = {
     "NONE",
     "PRESSED",
@@ -439,15 +441,15 @@ void LvglComponent::setup() {
   size_t buffer_pixels = width * height / frac;
   auto buf_bytes = buffer_pixels * LV_COLOR_DEPTH / 8;
   void *buffer = nullptr;
-  if (this->buffer_frac_ >= 4)
+  if (this->buffer_frac_ >= MIN_BUFFER_FRAC / 2)
     buffer = malloc(buf_bytes);  // NOLINT
   if (buffer == nullptr)
     buffer = lv_custom_mem_alloc(buf_bytes);  // NOLINT
   // if specific buffer size not set and can't get 100%, try for a smaller one
   if (buffer == nullptr && this->buffer_frac_ == 0) {
-    frac = 8;
-    buffer_pixels /= 8;
-    buffer = lv_custom_mem_alloc(buf_bytes / 8);  // NOLINT
+    frac = MIN_BUFFER_FRAC;
+    buffer_pixels /= MIN_BUFFER_FRAC;
+    buffer = lv_custom_mem_alloc(buf_bytes / MIN_BUFFER_FRAC);  // NOLINT
   }
   if (buffer == nullptr) {
     this->mark_failed();

--- a/esphome/components/lvgl/lvgl_esphome.cpp
+++ b/esphome/components/lvgl/lvgl_esphome.cpp
@@ -452,8 +452,8 @@ void LvglComponent::setup() {
     buffer = lv_custom_mem_alloc(buf_bytes / MIN_BUFFER_FRAC);  // NOLINT
   }
   if (buffer == nullptr) {
-    this->mark_failed();
     this->status_set_error("Memory allocation failure");
+    this->mark_failed();
     return;
   }
   this->buffer_frac_ = frac;
@@ -466,8 +466,8 @@ void LvglComponent::setup() {
   if (this->rotation != display::DISPLAY_ROTATION_0_DEGREES) {
     this->rotate_buf_ = static_cast<lv_color_t *>(lv_custom_mem_alloc(buf_bytes));  // NOLINT
     if (this->rotate_buf_ == nullptr) {
-      this->mark_failed();
       this->status_set_error("Memory allocation failure");
+      this->mark_failed();
       return;
     }
   }

--- a/esphome/components/lvgl/lvgl_esphome.cpp
+++ b/esphome/components/lvgl/lvgl_esphome.cpp
@@ -85,6 +85,7 @@ lv_event_code_t lv_update_event;  // NOLINT
 void LvglComponent::dump_config() {
   ESP_LOGCONFIG(TAG, "LVGL:");
   ESP_LOGCONFIG(TAG, "  Display width/height: %d x %d", this->disp_drv_.hor_res, this->disp_drv_.ver_res);
+  ESP_LOGCONFIG(TAG, "  Buffer size: %d%%", 100 / this->buffer_frac_);
   ESP_LOGCONFIG(TAG, "  Rotation: %d", this->rotation);
   ESP_LOGCONFIG(TAG, "  Draw rounding: %d", (int) this->draw_rounding);
 }
@@ -432,18 +433,28 @@ void LvglComponent::setup() {
   auto *display = this->displays_[0];
   auto width = display->get_width();
   auto height = display->get_height();
-  size_t buffer_pixels = width * height / this->buffer_frac_;
+  auto frac = buffer_frac_;
+  if (frac == 0)
+    frac = 1;
+  size_t buffer_pixels = width * height / frac;
   auto buf_bytes = buffer_pixels * LV_COLOR_DEPTH / 8;
   void *buffer = nullptr;
   if (this->buffer_frac_ >= 4)
     buffer = malloc(buf_bytes);  // NOLINT
   if (buffer == nullptr)
     buffer = lv_custom_mem_alloc(buf_bytes);  // NOLINT
+  // if specific buffer size not set and can't get 100%, try for a smaller one
+  if (buffer == nullptr && this->buffer_frac_ == 0) {
+    frac = 8;
+    buffer_pixels /= 8;
+    buffer = lv_custom_mem_alloc(buf_bytes / 8);  // NOLINT
+  }
   if (buffer == nullptr) {
     this->mark_failed();
     this->status_set_error("Memory allocation failure");
     return;
   }
+  this->buffer_frac_ = frac;
   lv_disp_draw_buf_init(&this->draw_buf_, buffer, nullptr, buffer_pixels);
   this->disp_drv_.hor_res = width;
   this->disp_drv_.ver_res = height;

--- a/esphome/components/lvgl/lvgl_esphome.cpp
+++ b/esphome/components/lvgl/lvgl_esphome.cpp
@@ -87,7 +87,7 @@ lv_event_code_t lv_update_event;  // NOLINT
 void LvglComponent::dump_config() {
   ESP_LOGCONFIG(TAG, "LVGL:");
   ESP_LOGCONFIG(TAG, "  Display width/height: %d x %d", this->disp_drv_.hor_res, this->disp_drv_.ver_res);
-  ESP_LOGCONFIG(TAG, "  Buffer size: %d%%", 100 / this->buffer_frac_);
+  ESP_LOGCONFIG(TAG, "  Buffer size: %zu%%", 100 / this->buffer_frac_);
   ESP_LOGCONFIG(TAG, "  Rotation: %d", this->rotation);
   ESP_LOGCONFIG(TAG, "  Draw rounding: %d", (int) this->draw_rounding);
 }

--- a/script/helpers.py
+++ b/script/helpers.py
@@ -5,7 +5,6 @@ import re
 import subprocess
 
 import colorama
-import helpers_zephyr
 
 root_path = os.path.abspath(os.path.normpath(os.path.join(__file__, "..", "..")))
 basepath = os.path.join(root_path, "esphome")
@@ -149,7 +148,9 @@ def load_idedata(environment):
     Path(temp_folder).mkdir(exist_ok=True)
 
     if "nrf" in environment:
-        data = helpers_zephyr.load_idedata(environment, temp_folder, platformio_ini)
+        from helpers_zephyr import load_idedata as zephyr_load_idedata
+
+        data = zephyr_load_idedata(environment, temp_folder, platformio_ini)
     else:
         stdout = subprocess.check_output(
             ["pio", "run", "-t", "idedata", "-e", environment]


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

* If no specific buffer size has been configured, and allocation of a 100% buffer fails, attempt allocation of a 1/8 size buffer.

This will make for more seamless operation on boards without PSRAM, obviating the need for a manual buffer size configuration.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#4914

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
