### PR TITLE
[script] Use local import for zephyr

### DIFF
--- a/script/helpers.py
+++ b/script/helpers.py
@@ -5,7 +5,6 @@ import re
 import subprocess
 
 import colorama
-import helpers_zephyr
 
 root_path = os.path.abspath(os.path.normpath(os.path.join(__file__, "..", "..")))
 basepath = os.path.join(root_path, "esphome")
@@ -149,7 +148,9 @@ def load_idedata(environment):
     Path(temp_folder).mkdir(exist_ok=True)
 
     if "nrf" in environment:
-        data = helpers_zephyr.load_idedata(environment, temp_folder, platformio_ini)
+        from helpers_zephyr import load_idedata as zephyr_load_idedata
+
+        data = zephyr_load_idedata(environment, temp_folder, platformio_ini)
     else:
         stdout = subprocess.check_output(
             ["pio", "run", "-t", "idedata", "-e", environment]


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Recent change to `script/helpers.py` throws this error on git operations:

```
  File "/Users/clyde/dev/opensourceprojects/esp/esphome/script/helpers.py", line 8, in <module>
    import helpers_zephyr
ModuleNotFoundError: No module named 'helpers_zephyr'
```

Change import to local to avoid this.


## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
