### PR TITLE
Fix the case of single error

### DIFF
--- a/esphome/voluptuous_schema.py
+++ b/esphome/voluptuous_schema.py
@@ -16,7 +16,7 @@ def ensure_multiple_invalid(err):
     if isinstance(err, vol.MultipleInvalid):
         return err
     if isinstance(err, list):
-        return vol.MultipleInvalid(err)    
+        return vol.MultipleInvalid(err)
     return vol.MultipleInvalid([err])
 
 

--- a/esphome/voluptuous_schema.py
+++ b/esphome/voluptuous_schema.py
@@ -15,7 +15,7 @@ class ExtraKeysInvalid(vol.Invalid):
 def ensure_multiple_invalid(err):
     if isinstance(err, vol.MultipleInvalid):
         return err
-    if isinstance(err, list)
+    if isinstance(err, list):
         return vol.MultipleInvalid(err)    
     return vol.MultipleInvalid([err])
 

--- a/esphome/voluptuous_schema.py
+++ b/esphome/voluptuous_schema.py
@@ -15,7 +15,9 @@ class ExtraKeysInvalid(vol.Invalid):
 def ensure_multiple_invalid(err):
     if isinstance(err, vol.MultipleInvalid):
         return err
-    return vol.MultipleInvalid(err)
+    if isinstance(err, list)
+        return vol.MultipleInvalid(err)    
+    return vol.MultipleInvalid([err])
 
 
 # pylint: disable=protected-access, unidiomatic-typecheck


### PR DESCRIPTION
`MultipleInvalid` initializer expects error list, not a single error

# What does this implement/fix?

I had an error rasing error from validator

```
Traceback (most recent call last):
  File ".venv/bin/esphome", line 8, in <module>
    sys.exit(main())
  File ".venv/lib/python3.10/site-packages/esphome/__main__.py", line 1081, in main
    return run_esphome(sys.argv)
  File ".venv/lib/python3.10/site-packages/esphome/__main__.py", line 1059, in run_esphome
    config = read_config(dict(args.substitution) if args.substitution else {})
  File ".venv/lib/python3.10/site-packages/esphome/config.py", line 1095, in read_config
    res = load_config(command_line_substitutions)
  File ".venv/lib/python3.10/site-packages/esphome/config.py", line 949, in load_config
    return _load_config(command_line_substitutions)
  File ".venv/lib/python3.10/site-packages/esphome/config.py", line 939, in _load_config
    return validate_config(config, command_line_substitutions)
  File ".venv/lib/python3.10/site-packages/esphome/config.py", line 863, in validate_config
    result.run_validation_steps()
  File ".venv/lib/python3.10/site-packages/esphome/config.py", line 142, in run_validation_steps
    task.step.run(self)
  File ".venv/lib/python3.10/site-packages/esphome/config.py", line 562, in run
    validated = schema(self.conf)
  File ".venv/lib/python3.10/site-packages/esphome/voluptuous_schema.py", line 35, in __call__
    res = super().__call__(data)
  File ".venv/lib/python3.10/site-packages/voluptuous/schema_builder.py", line 205, in __call__
    return self._compiled([], data)
  File ".venv/lib/python3.10/site-packages/voluptuous/validators.py", line 256, in _run
    return self._exec(self._compiled, value, path)
  File ".venv/lib/python3.10/site-packages/voluptuous/validators.py", line 384, in _exec
    v = func(path, v)
  File ".venv/lib/python3.10/site-packages/voluptuous/schema_builder.py", line 779, in validate_callable
    return schema(data)
  File ".venv/lib/python3.10/site-packages/esphome/config_validation.py", line 1588, in validator
    value = Schema(schemas[key_v])(value)
  File ".venv/lib/python3.10/site-packages/esphome/voluptuous_schema.py", line 35, in __call__
    res = super().__call__(data)
  File ".venv/lib/python3.10/site-packages/voluptuous/schema_builder.py", line 205, in __call__
    return self._compiled([], data)
  File ".venv/lib/python3.10/site-packages/voluptuous/schema_builder.py", line 779, in validate_callable
    return schema(data)
  File ".venv/lib/python3.10/site-packages/esphome/voluptuous_schema.py", line 41, in __call__
    raise ensure_multiple_invalid(err)
  File ".venv/lib/python3.10/site-packages/esphome/voluptuous_schema.py", line 18, in ensure_multiple_invalid
    return vol.MultipleInvalid(err)
  File ".venv/lib/python3.10/site-packages/voluptuous/error.py", line 62, in __init__
    self.errors = errors[:] if errors else []
TypeError: 'Invalid' object is not subscriptable
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
