### PR TITLE
Bump cryptography to 45.0.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 async_timeout==5.0.1; python_version <= "3.10"
-cryptography==44.0.2
+cryptography==45.0.1
 voluptuous==0.15.2
 PyYAML==6.0.2
 paho-mqtt==1.6.1


### PR DESCRIPTION
This is nearly a 50% speed up for most use cases

details in https://github.com/pyca/cryptography/pull/12857

needs to be bump together

cryptography changelog: https://github.com/pyca/cryptography/compare/44.0.2...45.0.1


## [CodSpeed Performance Report](https://codspeed.io/esphome/aioesphomeapi/branches/crypto_test)

### Merging will **improve `aioesphomeapi` performances by 64.01%**

<sub>Comparing <code>crypto_test</code> (c23fb69) with <code>main</code> (8652e10)</sub>



### Summary

`⚡ 5` improvements  
`✅ 5` untouched benchmarks  



### Benchmarks breakdown

|     | Benchmark | `BASE` | `HEAD` | Change |
| --- | --------- | ----------------------- | ------------------- | ------ |
| ⚡ | `` test_noise_messages[0] `` | 2.1 ms | 1.3 ms | +64.01% |
| ⚡ | `` test_noise_messages[1024] `` | 2.7 ms | 1.9 ms | +46.15% |
| ⚡ | `` test_noise_messages[128] `` | 2.3 ms | 1.5 ms | +54.85% |
| ⚡ | `` test_noise_messages[16384] `` | 15.9 ms | 15 ms | +5.69% |
| ⚡ | `` test_noise_messages[64] `` | 2.2 ms | 1.4 ms | +58.54% |
