### PR TITLE
Fix misspelling of climate in climate_ir.climate_ir_with_receiver_schema

### DIFF
--- a/esphome/components/ballu/climate.py
+++ b/esphome/components/ballu/climate.py
@@ -7,7 +7,7 @@ CODEOWNERS = ["@bazuchan"]
 ballu_ns = cg.esphome_ns.namespace("ballu")
 BalluClimate = ballu_ns.class_("BalluClimate", climate_ir.ClimateIR)
 
-CONFIG_SCHEMA = climate_ir.climare_ir_with_receiver_schema(BalluClimate)
+CONFIG_SCHEMA = climate_ir.climate_ir_with_receiver_schema(BalluClimate)
 
 
 async def to_code(config):

--- a/esphome/components/climate_ir/__init__.py
+++ b/esphome/components/climate_ir/__init__.py
@@ -40,7 +40,7 @@ def climate_ir_schema(
     )
 
 
-def climare_ir_with_receiver_schema(
+def climate_ir_with_receiver_schema(
     class_: MockObjClass,
 ) -> cv.Schema:
     return climate_ir_schema(class_).extend(
@@ -59,7 +59,7 @@ def deprecated_schema_constant(config):
         type = str(id.type).split("::", maxsplit=1)[0]
     _LOGGER.warning(
         "Using `climate_ir.CLIMATE_IR_WITH_RECEIVER_SCHEMA` is deprecated and will be removed in ESPHome 2025.11.0. "
-        "Please use `climate_ir.climare_ir_with_receiver_schema(...)` instead. "
+        "Please use `climate_ir.climate_ir_with_receiver_schema(...)` instead. "
         "If you are seeing this, report an issue to the external_component author and ask them to update it. "
         "https://developers.esphome.io/blog/2025/05/14/_schema-deprecations/. "
         "Component using this schema: %s",
@@ -68,7 +68,7 @@ def deprecated_schema_constant(config):
     return config
 
 
-CLIMATE_IR_WITH_RECEIVER_SCHEMA = climare_ir_with_receiver_schema(ClimateIR)
+CLIMATE_IR_WITH_RECEIVER_SCHEMA = climate_ir_with_receiver_schema(ClimateIR)
 CLIMATE_IR_WITH_RECEIVER_SCHEMA.add_extra(deprecated_schema_constant)
 
 

--- a/esphome/components/climate_ir_lg/climate.py
+++ b/esphome/components/climate_ir_lg/climate.py
@@ -13,7 +13,7 @@ CONF_BIT_HIGH = "bit_high"
 CONF_BIT_ONE_LOW = "bit_one_low"
 CONF_BIT_ZERO_LOW = "bit_zero_low"
 
-CONFIG_SCHEMA = climate_ir.climare_ir_with_receiver_schema(LgIrClimate).extend(
+CONFIG_SCHEMA = climate_ir.climate_ir_with_receiver_schema(LgIrClimate).extend(
     {
         cv.Optional(
             CONF_HEADER_HIGH, default="8000us"

--- a/esphome/components/coolix/climate.py
+++ b/esphome/components/coolix/climate.py
@@ -7,7 +7,7 @@ CODEOWNERS = ["@glmnet"]
 coolix_ns = cg.esphome_ns.namespace("coolix")
 CoolixClimate = coolix_ns.class_("CoolixClimate", climate_ir.ClimateIR)
 
-CONFIG_SCHEMA = climate_ir.climare_ir_with_receiver_schema(CoolixClimate)
+CONFIG_SCHEMA = climate_ir.climate_ir_with_receiver_schema(CoolixClimate)
 
 
 async def to_code(config):

--- a/esphome/components/daikin/climate.py
+++ b/esphome/components/daikin/climate.py
@@ -6,7 +6,7 @@ AUTO_LOAD = ["climate_ir"]
 daikin_ns = cg.esphome_ns.namespace("daikin")
 DaikinClimate = daikin_ns.class_("DaikinClimate", climate_ir.ClimateIR)
 
-CONFIG_SCHEMA = climate_ir.climare_ir_with_receiver_schema(DaikinClimate)
+CONFIG_SCHEMA = climate_ir.climate_ir_with_receiver_schema(DaikinClimate)
 
 
 async def to_code(config):

--- a/esphome/components/daikin_arc/climate.py
+++ b/esphome/components/daikin_arc/climate.py
@@ -6,7 +6,7 @@ AUTO_LOAD = ["climate_ir"]
 daikin_arc_ns = cg.esphome_ns.namespace("daikin_arc")
 DaikinArcClimate = daikin_arc_ns.class_("DaikinArcClimate", climate_ir.ClimateIR)
 
-CONFIG_SCHEMA = climate_ir.climare_ir_with_receiver_schema(DaikinArcClimate)
+CONFIG_SCHEMA = climate_ir.climate_ir_with_receiver_schema(DaikinArcClimate)
 
 
 async def to_code(config):

--- a/esphome/components/daikin_brc/climate.py
+++ b/esphome/components/daikin_brc/climate.py
@@ -9,7 +9,7 @@ daikin_brc_ns = cg.esphome_ns.namespace("daikin_brc")
 DaikinBrcClimate = daikin_brc_ns.class_("DaikinBrcClimate", climate_ir.ClimateIR)
 
 
-CONFIG_SCHEMA = climate_ir.climare_ir_with_receiver_schema(DaikinBrcClimate).extend(
+CONFIG_SCHEMA = climate_ir.climate_ir_with_receiver_schema(DaikinBrcClimate).extend(
     {
         cv.Optional(CONF_USE_FAHRENHEIT, default=False): cv.boolean,
     }

--- a/esphome/components/delonghi/climate.py
+++ b/esphome/components/delonghi/climate.py
@@ -6,7 +6,7 @@ AUTO_LOAD = ["climate_ir"]
 delonghi_ns = cg.esphome_ns.namespace("delonghi")
 DelonghiClimate = delonghi_ns.class_("DelonghiClimate", climate_ir.ClimateIR)
 
-CONFIG_SCHEMA = climate_ir.climare_ir_with_receiver_schema(DelonghiClimate)
+CONFIG_SCHEMA = climate_ir.climate_ir_with_receiver_schema(DelonghiClimate)
 
 
 async def to_code(config):

--- a/esphome/components/emmeti/climate.py
+++ b/esphome/components/emmeti/climate.py
@@ -7,7 +7,7 @@ AUTO_LOAD = ["climate_ir"]
 emmeti_ns = cg.esphome_ns.namespace("emmeti")
 EmmetiClimate = emmeti_ns.class_("EmmetiClimate", climate_ir.ClimateIR)
 
-CONFIG_SCHEMA = climate_ir.climare_ir_with_receiver_schema(EmmetiClimate)
+CONFIG_SCHEMA = climate_ir.climate_ir_with_receiver_schema(EmmetiClimate)
 
 
 async def to_code(config):

--- a/esphome/components/fujitsu_general/climate.py
+++ b/esphome/components/fujitsu_general/climate.py
@@ -8,7 +8,7 @@ FujitsuGeneralClimate = fujitsu_general_ns.class_(
     "FujitsuGeneralClimate", climate_ir.ClimateIR
 )
 
-CONFIG_SCHEMA = climate_ir.climare_ir_with_receiver_schema(FujitsuGeneralClimate)
+CONFIG_SCHEMA = climate_ir.climate_ir_with_receiver_schema(FujitsuGeneralClimate)
 
 
 async def to_code(config):

--- a/esphome/components/gree/climate.py
+++ b/esphome/components/gree/climate.py
@@ -21,7 +21,7 @@ MODELS = {
     "yag": Model.GREE_YAG,
 }
 
-CONFIG_SCHEMA = climate_ir.climare_ir_with_receiver_schema(GreeClimate).extend(
+CONFIG_SCHEMA = climate_ir.climate_ir_with_receiver_schema(GreeClimate).extend(
     {
         cv.Required(CONF_MODEL): cv.enum(MODELS),
     }

--- a/esphome/components/heatpumpir/climate.py
+++ b/esphome/components/heatpumpir/climate.py
@@ -97,7 +97,7 @@ VERTICAL_DIRECTIONS = {
 }
 
 CONFIG_SCHEMA = cv.All(
-    climate_ir.climare_ir_with_receiver_schema(HeatpumpIRClimate).extend(
+    climate_ir.climate_ir_with_receiver_schema(HeatpumpIRClimate).extend(
         {
             cv.Required(CONF_PROTOCOL): cv.enum(PROTOCOLS),
             cv.Required(CONF_HORIZONTAL_DEFAULT): cv.enum(HORIZONTAL_DIRECTIONS),

--- a/esphome/components/hitachi_ac344/climate.py
+++ b/esphome/components/hitachi_ac344/climate.py
@@ -6,7 +6,7 @@ AUTO_LOAD = ["climate_ir"]
 hitachi_ac344_ns = cg.esphome_ns.namespace("hitachi_ac344")
 HitachiClimate = hitachi_ac344_ns.class_("HitachiClimate", climate_ir.ClimateIR)
 
-CONFIG_SCHEMA = climate_ir.climare_ir_with_receiver_schema(HitachiClimate)
+CONFIG_SCHEMA = climate_ir.climate_ir_with_receiver_schema(HitachiClimate)
 
 
 async def to_code(config):

--- a/esphome/components/hitachi_ac424/climate.py
+++ b/esphome/components/hitachi_ac424/climate.py
@@ -6,7 +6,7 @@ AUTO_LOAD = ["climate_ir"]
 hitachi_ac424_ns = cg.esphome_ns.namespace("hitachi_ac424")
 HitachiClimate = hitachi_ac424_ns.class_("HitachiClimate", climate_ir.ClimateIR)
 
-CONFIG_SCHEMA = climate_ir.climare_ir_with_receiver_schema(HitachiClimate)
+CONFIG_SCHEMA = climate_ir.climate_ir_with_receiver_schema(HitachiClimate)
 
 
 async def to_code(config):

--- a/esphome/components/midea_ir/climate.py
+++ b/esphome/components/midea_ir/climate.py
@@ -10,7 +10,7 @@ midea_ir_ns = cg.esphome_ns.namespace("midea_ir")
 MideaIR = midea_ir_ns.class_("MideaIR", climate_ir.ClimateIR)
 
 
-CONFIG_SCHEMA = climate_ir.climare_ir_with_receiver_schema(MideaIR).extend(
+CONFIG_SCHEMA = climate_ir.climate_ir_with_receiver_schema(MideaIR).extend(
     {
         cv.Optional(CONF_USE_FAHRENHEIT, default=False): cv.boolean,
     }

--- a/esphome/components/mitsubishi/climate.py
+++ b/esphome/components/mitsubishi/climate.py
@@ -43,7 +43,7 @@ VERTICAL_DIRECTIONS = {
 }
 
 
-CONFIG_SCHEMA = climate_ir.climare_ir_with_receiver_schema(MitsubishiClimate).extend(
+CONFIG_SCHEMA = climate_ir.climate_ir_with_receiver_schema(MitsubishiClimate).extend(
     {
         cv.Optional(CONF_SET_FAN_MODE, default="3levels"): cv.enum(SETFANMODE),
         cv.Optional(CONF_SUPPORTS_DRY, default=False): cv.boolean,

--- a/esphome/components/noblex/climate.py
+++ b/esphome/components/noblex/climate.py
@@ -6,7 +6,7 @@ AUTO_LOAD = ["climate_ir"]
 noblex_ns = cg.esphome_ns.namespace("noblex")
 NoblexClimate = noblex_ns.class_("NoblexClimate", climate_ir.ClimateIR)
 
-CONFIG_SCHEMA = climate_ir.climare_ir_with_receiver_schema(NoblexClimate)
+CONFIG_SCHEMA = climate_ir.climate_ir_with_receiver_schema(NoblexClimate)
 
 
 async def to_code(config):

--- a/esphome/components/tcl112/climate.py
+++ b/esphome/components/tcl112/climate.py
@@ -7,7 +7,7 @@ CODEOWNERS = ["@glmnet"]
 tcl112_ns = cg.esphome_ns.namespace("tcl112")
 Tcl112Climate = tcl112_ns.class_("Tcl112Climate", climate_ir.ClimateIR)
 
-CONFIG_SCHEMA = climate_ir.climare_ir_with_receiver_schema(Tcl112Climate)
+CONFIG_SCHEMA = climate_ir.climate_ir_with_receiver_schema(Tcl112Climate)
 
 
 async def to_code(config):

--- a/esphome/components/toshiba/climate.py
+++ b/esphome/components/toshiba/climate.py
@@ -16,7 +16,7 @@ MODELS = {
     "RAC-PT1411HWRU-F": Model.MODEL_RAC_PT1411HWRU_F,
 }
 
-CONFIG_SCHEMA = climate_ir.climare_ir_with_receiver_schema(ToshibaClimate).extend(
+CONFIG_SCHEMA = climate_ir.climate_ir_with_receiver_schema(ToshibaClimate).extend(
     {
         cv.Optional(CONF_MODEL, default="generic"): cv.enum(MODELS, upper=True),
     }

--- a/esphome/components/whirlpool/climate.py
+++ b/esphome/components/whirlpool/climate.py
@@ -15,7 +15,7 @@ MODELS = {
     "DG11J1-91": Model.MODEL_DG11J1_91,
 }
 
-CONFIG_SCHEMA = climate_ir.climare_ir_with_receiver_schema(WhirlpoolClimate).extend(
+CONFIG_SCHEMA = climate_ir.climate_ir_with_receiver_schema(WhirlpoolClimate).extend(
     {
         cv.Optional(CONF_MODEL, default="DG11J1-3A"): cv.enum(MODELS, upper=True),
     }

--- a/esphome/components/whynter/climate.py
+++ b/esphome/components/whynter/climate.py
@@ -9,7 +9,7 @@ whynter_ns = cg.esphome_ns.namespace("whynter")
 Whynter = whynter_ns.class_("Whynter", climate_ir.ClimateIR)
 
 
-CONFIG_SCHEMA = climate_ir.climare_ir_with_receiver_schema(Whynter).extend(
+CONFIG_SCHEMA = climate_ir.climate_ir_with_receiver_schema(Whynter).extend(
     {
         cv.Optional(CONF_USE_FAHRENHEIT, default=False): cv.boolean,
     }

--- a/esphome/components/zhlt01/climate.py
+++ b/esphome/components/zhlt01/climate.py
@@ -7,7 +7,7 @@ CODEOWNERS = ["@cfeenstra1024"]
 zhlt01_ns = cg.esphome_ns.namespace("zhlt01")
 ZHLT01Climate = zhlt01_ns.class_("ZHLT01Climate", climate_ir.ClimateIR)
 
-CONFIG_SCHEMA = climate_ir.climare_ir_with_receiver_schema(ZHLT01Climate)
+CONFIG_SCHEMA = climate_ir.climate_ir_with_receiver_schema(ZHLT01Climate)
 
 
 async def to_code(config):


### PR DESCRIPTION
# What does this implement/fix?

Climate is misspelled as "climare"in the definition of `climate_ir.climate_ir_with_receiver_schema` in [de27ce79dc4ced](https://github.com/esphome/esphome/commit/de27ce79dc4ced31dd787c787c6e91dc164abb17).  While it does make the name more unique, that was probably not intended.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
