### PR TITLE
Sanyo aircon

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -96,6 +96,7 @@ esphome/components/ch422g/* @clydebarrow @jesterret
 esphome/components/chsc6x/* @kkosik20
 esphome/components/climate/* @esphome/core
 esphome/components/climate_ir/* @glmnet
+esphome/components/climate_ir_sanyo/* @deece
 esphome/components/color_temperature/* @jesserockz
 esphome/components/combination/* @Cat-Ion @kahrendt
 esphome/components/const/* @esphome/core

--- a/esphome/components/climate_ir_sanyo/__init__.py
+++ b/esphome/components/climate_ir_sanyo/__init__.py
@@ -1,0 +1,1 @@
+CODEOWNERS = ["@deece"]

--- a/esphome/components/climate_ir_sanyo/climate.py
+++ b/esphome/components/climate_ir_sanyo/climate.py
@@ -1,0 +1,20 @@
+import esphome.codegen as cg
+from esphome.components import climate_ir
+import esphome.config_validation as cv
+from esphome.const import CONF_ID
+
+AUTO_LOAD = ["climate_ir"]
+
+climate_ir_sanyo_ns = cg.esphome_ns.namespace("climate_ir_sanyo")
+SanyoIrClimate = climate_ir_sanyo_ns.class_("SanyoIrClimate", climate_ir.ClimateIR)
+
+CONFIG_SCHEMA = climate_ir.CLIMATE_IR_WITH_RECEIVER_SCHEMA.extend(
+    {
+        cv.GenerateID(): cv.declare_id(SanyoIrClimate),
+    }
+)
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await climate_ir.register_climate_ir(var, config)

--- a/esphome/components/climate_ir_sanyo/climate_ir_sanyo.cpp
+++ b/esphome/components/climate_ir_sanyo/climate_ir_sanyo.cpp
@@ -1,0 +1,360 @@
+// climate_ir_sanyo.cpp
+
+#include "climate_ir_sanyo.h"
+#include "esphome/core/log.h"
+#include <cstring>
+
+namespace esphome {
+namespace climate_ir_sanyo {
+
+const char *const TAG = "climate.climate_ir_sanyo";
+const uint8_t TEMP_MIN = 18;
+const uint8_t TEMP_MAX = 28;
+
+Frame::Frame() { this->clear(); }
+
+#if VERIFY_GENERATION
+void Frame::compare(const Frame &other) {
+  char buf[256];
+
+  ESP_LOGD(TAG, "Nibble   :     0     1     2     3     4     5     6     7     8     9    10    11");
+
+  // First line: Hex Nibbles - "Ours"
+  ESP_LOGD(TAG, "Expected :     %X     %X     %X     %X     %X     %X     %X     %X     %X     %X     %X     %X",
+           nibbles[0], nibbles[1], nibbles[2], nibbles[3], nibbles[4], nibbles[5], nibbles[6], nibbles[7], nibbles[8],
+           nibbles[9], nibbles[10], nibbles[11]);
+
+  // Second line: Hex Nibbles - "Theirs"
+  ESP_LOGD(TAG, "Generated:     %X     %X     %X     %X     %X     %X     %X     %X     %X     %X     %X     %X",
+           other.nibbles[0], other.nibbles[1], other.nibbles[2], other.nibbles[3], other.nibbles[4], other.nibbles[5],
+           other.nibbles[6], other.nibbles[7], other.nibbles[8], other.nibbles[9], other.nibbles[10],
+           other.nibbles[11]);
+
+  // Fourth line: Binary with mismatches shown as *
+  snprintf(buf, sizeof(buf), "Binary   : ");
+  for (int i = 0; i < 12; ++i) {
+    uint8_t a = nibbles[i];
+    uint8_t b = other.nibbles[i];
+
+    char bin[32] = "";
+    for (int bit = 3; bit >= 0; --bit) {
+      int a_bit = (a >> bit) & 1;
+      int b_bit = (b >> bit) & 1;
+
+      if (a_bit == b_bit)
+        snprintf(bin + strlen(bin), sizeof(bin) - strlen(bin), "%d", a_bit);
+      else
+        strncat(bin, "*", sizeof(bin) - strlen(bin) - 1);
+    }
+    char tmp[8];
+    snprintf(tmp, sizeof(tmp), " %s ", bin);
+    strncat(buf, tmp, sizeof(buf) - strlen(buf) - 1);
+  }
+
+  ESP_LOGD(TAG, "%s", buf);
+}
+#endif
+
+void Frame::clear() {
+  std::memset(this->nibbles, 0, sizeof(this->nibbles));
+  nibbles[0] = 0xA;
+  nibbles[1] = 0x6;
+}
+
+#define TEMPERATURE_BITS (BIT1 | BIT0)
+
+void Frame::set_target_temperature(float temp) {
+  int value = int(temp) + 28;
+  nibbles[2] = value & 0x0F;
+  nibbles[3] = BIT2 | (value >> 4) & TEMPERATURE_BITS;
+}
+
+float Frame::get_target_temperature() {
+  int8_t temperature = nibbles[2] & 0x0F;
+  temperature |= (nibbles[3] & TEMPERATURE_BITS) << 4;
+  return float(temperature - 28);
+}
+
+void Frame::set_room_temperature(float temp) {
+  int value = int(temp) + 28;
+  nibbles[4] = value & 0x0F;
+  nibbles[5] = BIT2 | (value >> 4) & TEMPERATURE_BITS;
+}
+
+float Frame::get_room_temperature() {
+  int8_t temperature = nibbles[4] & 0x0F;
+  temperature |= (nibbles[5] & TEMPERATURE_BITS) << 4;
+  return float(temperature - 28);
+}
+
+#define NIGHT_SETBACK_BIT (BIT1)
+
+// Night Setback has the AC gradually increase/reduce the target temperature over a few hours to minimise power
+void Frame::set_night_setback(bool on) {
+  if (on)
+    nibbles[10] |= NIGHT_SETBACK_BIT;
+  else
+    nibbles[10] &= ~NIGHT_SETBACK_BIT;
+}
+
+bool Frame::get_night_setback() { return (nibbles[10] & NIGHT_SETBACK_BIT) != 0; }
+
+#define POWER_BITS_10 (BIT2 | BIT3)
+#define POWER_BIT_10 (BIT3)
+#define POWER_OFF_BIT_10 (BIT2)
+
+void Frame::set_power(bool on) {
+  nibbles[10] &= ~POWER_BITS_10;
+
+  if (on) {
+    nibbles[10] |= POWER_BIT_10;
+  } else {
+    // Weird outlier where this bit of the temperature is cleared when turned off
+    nibbles[3] &= ~BIT0;
+
+    nibbles[6] = 0x00;
+    nibbles[7] = 0x00;
+    nibbles[10] |= POWER_OFF_BIT_10;
+
+    set_target_temperature(4);
+  }
+}
+
+bool Frame::get_power() { return (nibbles[10] & POWER_BIT_10) != 0; }
+
+#define CLIMATE_MODE_BITS_9 (BIT0 | BIT1)
+
+void Frame::set_mode(climate::ClimateMode mode) {
+  nibbles[9] &= ~CLIMATE_MODE_BITS_9;
+  nibbles[10] &= ~POWER_BITS_10;
+
+  switch (mode) {
+    case climate::CLIMATE_MODE_FAN_ONLY:
+      set_power(true);
+      nibbles[9] |= 0x0;
+      nibbles[10] |= BIT3;
+      break;
+    case climate::CLIMATE_MODE_COOL:
+      set_power(true);
+      nibbles[9] |= BIT0;
+      nibbles[10] |= BIT3;
+      break;
+    case climate::CLIMATE_MODE_HEAT:
+      set_power(true);
+      nibbles[9] |= BIT0 | BIT1;
+      nibbles[10] |= BIT3;
+      break;
+    case climate::CLIMATE_MODE_HEAT_COOL:
+    case climate::CLIMATE_MODE_AUTO:
+    default:
+      set_power(true);
+      nibbles[9] |= BIT1;
+      nibbles[10] |= BIT3;
+      break;
+  }
+}
+
+climate::ClimateMode Frame::get_mode() {
+  uint8_t mode = nibbles[9] & CLIMATE_MODE_BITS_9;
+  switch (mode) {
+    case 0x0:
+      return climate::CLIMATE_MODE_FAN_ONLY;
+      break;
+    case 0x1:
+      return climate::CLIMATE_MODE_COOL;
+      break;
+    case 0x2:
+      return climate::CLIMATE_MODE_HEAT_COOL;
+      break;
+    case 0x3:
+      return climate::CLIMATE_MODE_HEAT;
+      break;
+    default:
+      ESP_LOGW(TAG, "Unknown mode = %u", mode);
+      return climate::CLIMATE_MODE_HEAT_COOL;
+      break;
+  }
+}
+
+#define FAN_MODE_BITS (BIT0 | BIT1)
+
+void Frame::set_fan_mode(climate::ClimateFanMode fan) {
+  switch (fan) {
+    case climate::CLIMATE_FAN_AUTO:
+      nibbles[8] = (nibbles[8] & ~FAN_MODE_BITS) | 0x00;
+      break;
+    case climate::CLIMATE_FAN_HIGH:
+      nibbles[8] = (nibbles[8] & ~FAN_MODE_BITS) | BIT0;
+      break;
+    case climate::CLIMATE_FAN_LOW:
+      nibbles[8] = (nibbles[8] & ~FAN_MODE_BITS) | BIT1;
+      break;
+    case climate::CLIMATE_FAN_MEDIUM:
+      nibbles[8] = (nibbles[8] & ~FAN_MODE_BITS) | BIT0 | BIT1;
+      break;
+  }
+}
+
+climate::ClimateFanMode Frame::get_fan_mode() {
+  switch (nibbles[8] & FAN_MODE_BITS) {
+    case 0x0:
+      return climate::CLIMATE_FAN_AUTO;
+    case 0x1:
+      return climate::CLIMATE_FAN_HIGH;
+    case 0x2:
+      return climate::CLIMATE_FAN_LOW;
+    case 0x3:
+      return climate::CLIMATE_FAN_MEDIUM;
+  }
+}
+
+#define SWING_MODE_BITS (BIT0)
+
+void Frame::set_swing_mode(climate::ClimateSwingMode swing) {
+  switch (swing) {
+    case climate::CLIMATE_SWING_VERTICAL:
+      nibbles[10] |= SWING_MODE_BITS;
+      break;
+    default:
+      nibbles[10] &= ~SWING_MODE_BITS;
+  }
+}
+
+climate::ClimateSwingMode Frame::get_swing_mode() {
+  return (nibbles[10] & SWING_MODE_BITS) ? climate::CLIMATE_SWING_VERTICAL : climate::CLIMATE_SWING_OFF;
+}
+
+#define ROOM_SENSING_BIT (BIT2)
+
+void Frame::set_room_sensing(bool on) {
+  if (on)
+    nibbles[9] |= ROOM_SENSING_BIT;
+  else
+    nibbles[9] &= ~ROOM_SENSING_BIT;
+}
+bool Frame::get_room_sensing() { return (nibbles[9] & ROOM_SENSING_BIT) != 0; }
+
+remote_base::NECLikeData Frame::to_bits() {
+  this->update_checksum();
+
+  remote_base::NECLikeData data;
+  data.bits_.reserve(12 * 4);
+  for (int i = 0; i < 12; ++i)
+    for (int bit = 0; bit < 4; ++bit)
+      data.bits_.push_back((nibbles[i] & (1u << bit)) != 0);
+  return data;
+}
+
+bool Frame::from_bits(const remote_base::NECLikeData &data_bits) {
+  for (int i = 0; i < 12; ++i) {
+    nibbles[i] = 0;
+    for (int j = 0; j < 4; ++j)
+      nibbles[i] = (nibbles[i] >> 1) | (data_bits.bits_[i * 4 + j] ? (1 << 3) : 0);
+  }
+
+  uint8_t checksum = calculate_checksum();
+  if (checksum == nibbles[11])
+    return true;
+
+  ESP_LOGW(TAG, "Invalid checksum: Got %1X, expected %1X", checksum, nibbles[11]);
+}
+
+uint8_t Frame::calculate_checksum() {
+  uint8_t sum = 0;
+  for (int i = 2; i < 11; ++i)
+    sum += nibbles[i] & 0x0F;
+  return sum & 0x0F;
+}
+
+void Frame::update_checksum() { nibbles[11] = calculate_checksum(); }
+
+// SanyoIrClimate implementation
+SanyoIrClimate::SanyoIrClimate()
+    : climate_ir::ClimateIR(
+          TEMP_MIN, TEMP_MAX, 1.0f, false, true,
+          {climate::CLIMATE_FAN_AUTO, climate::CLIMATE_FAN_LOW, climate::CLIMATE_FAN_MEDIUM, climate::CLIMATE_FAN_HIGH},
+          {climate::CLIMATE_SWING_OFF, climate::CLIMATE_SWING_VERTICAL}) {}
+
+void SanyoIrClimate::set_room_sensing(bool on) { frame.set_room_sensing(on); }
+
+bool SanyoIrClimate::get_room_sensing() { return frame.get_room_sensing(); }
+
+void SanyoIrClimate::set_night_setback(bool on) { frame.set_night_setback(on); }
+
+bool SanyoIrClimate::get_night_setback() { return frame.get_night_setback(); }
+
+void SanyoIrClimate::transmit_state() {
+  // Remove this clear after testing
+  frame.clear();
+  frame.set_target_temperature(this->target_temperature);
+  frame.set_room_temperature(this->current_temperature);
+
+  bool on = this->mode != climate::CLIMATE_MODE_OFF;
+  if (on) {
+    // Don't clobber the previous mode when we turn off
+    frame.set_mode(this->mode);
+  }
+  frame.set_power(on);
+  frame.set_fan_mode(this->fan_mode.value());
+  frame.set_swing_mode(this->swing_mode);
+  auto data = frame.to_bits();
+  remote_base::NECLikeProtocol protocol;
+  auto tx = this->transmitter_->transmit();
+  protocol.encode(tx.get_data(), data);
+  tx.perform();
+}
+
+bool SanyoIrClimate::on_receive(remote_base::RemoteReceiveData src) {
+  auto opt = remote_base::NECLikeProtocol().decode(src);
+  if (!opt.has_value())
+    return false;
+  if (!frame.from_bits(*opt)) {
+    return false;
+  }
+
+  if (frame.get_power() && frame.get_mode() != climate::CLIMATE_MODE_FAN_ONLY) {
+    this->target_temperature = frame.get_target_temperature();
+  }
+  this->current_temperature = frame.get_room_temperature();
+
+  // Mode and power are tracked independantly
+  this->mode = frame.get_mode();
+  if (!frame.get_power()) {
+    this->mode = climate::CLIMATE_MODE_OFF;
+  }
+
+  this->fan_mode = frame.get_fan_mode();
+  this->swing_mode = frame.get_swing_mode();
+  this->set_room_sensing(frame.get_room_sensing());
+  this->publish_state();
+  this->dump_state_();
+
+#if VERIFY_GENERATION
+  {
+    Frame test_frame;
+    test_frame.clear();
+    test_frame.set_target_temperature(frame.get_target_temperature());
+    test_frame.set_room_temperature(frame.get_room_temperature());
+    test_frame.set_mode(frame.get_mode());
+    test_frame.set_power(frame.get_power());
+    test_frame.set_fan_mode(frame.get_fan_mode());
+    test_frame.set_swing_mode(frame.get_swing_mode());
+    test_frame.set_room_sensing(frame.get_room_sensing());
+    test_frame.set_night_setback(frame.get_night_setback());
+    test_frame.to_bits();
+    frame.compare(test_frame);
+  }
+#endif
+
+  return true;
+}
+
+void SanyoIrClimate::dump_state_() {
+  ESP_LOGD(TAG, "Sanyo state: target=%.1f°C, room=%.1f°C, mode=%u, fan=%u, swing=%u, room_sensing=%s night_setback=%s",
+           this->target_temperature, this->current_temperature, static_cast<uint32_t>(this->mode),
+           static_cast<uint32_t>(this->fan_mode.value()), static_cast<uint32_t>(this->swing_mode),
+           this->get_room_sensing() ? "true" : "false", this->get_night_setback() ? "true" : "false");
+}
+
+}  // namespace climate_ir_sanyo
+}  // namespace esphome

--- a/esphome/components/climate_ir_sanyo/climate_ir_sanyo.h
+++ b/esphome/components/climate_ir_sanyo/climate_ir_sanyo.h
@@ -1,0 +1,75 @@
+// climate_ir_sanyo.h
+#pragma once
+
+#include "esphome/components/climate_ir/climate_ir.h"
+#include "esphome/components/remote_base/nec_like_protocol.h"
+
+/* Set to 1 to mimic simulating sending codes based on the current configuration.
+ * Used to verify that we will generate the same IR code that the remote does.
+ */
+#define VERIFY_GENERATION 0
+
+namespace esphome {
+namespace climate_ir_sanyo {
+
+class Frame {
+ public:
+  Frame();
+  void clear();
+
+#if VERIFY_GENERATION
+  void compare(const Frame &other);
+#endif
+
+  void set_target_temperature(float temp);
+  float get_target_temperature();
+
+  void set_room_temperature(float temp);
+  float get_room_temperature();
+
+  void set_mode(climate::ClimateMode mode);
+  climate::ClimateMode get_mode();
+
+  void set_fan_mode(climate::ClimateFanMode fan);
+  climate::ClimateFanMode get_fan_mode();
+
+  void set_swing_mode(climate::ClimateSwingMode swing);
+  climate::ClimateSwingMode get_swing_mode();
+
+  void set_room_sensing(bool on);
+  bool get_room_sensing();
+
+  void set_power(bool on);
+  bool get_power();
+
+  void set_night_setback(bool on);
+  bool get_night_setback();
+
+  remote_base::NECLikeData to_bits();
+  bool from_bits(const remote_base::NECLikeData &data_bits);
+
+ private:
+  uint8_t nibbles[12];
+  uint8_t calculate_checksum();
+  void update_checksum();
+};
+
+class SanyoIrClimate : public climate_ir::ClimateIR {
+ public:
+  SanyoIrClimate();
+  void set_room_sensing(bool on);
+  bool get_room_sensing();
+  void set_night_setback(bool on);
+  bool get_night_setback();
+
+ protected:
+  void transmit_state() override;
+  bool on_receive(remote_base::RemoteReceiveData src) override;
+  void dump_state_();
+
+ private:
+  Frame frame;
+};
+
+}  // namespace climate_ir_sanyo
+}  // namespace esphome

--- a/esphome/components/remote_base/__init__.py
+++ b/esphome/components/remote_base/__init__.py
@@ -837,6 +837,39 @@ async def nec_action(var, config, args):
     cg.add(var.set_command_repeats(template_))
 
 
+# NEC-like Air Conditioner, uses NEC encoding for arbitrary length codes
+NECLikeData, NECLikeBinarySensor, NECLikeTrigger, NECLikeAction, NECLikeDumper = (
+    declare_protocol("NECLike")
+)
+
+NEC_LIKE_SCHEMA = cv.Schema(
+    {
+        cv.Required(CONF_DATA): cv.string,
+    }
+)
+
+
+@register_binary_sensor("nec_like", NECLikeBinarySensor, NEC_LIKE_SCHEMA)
+def nec_like_binary_sensor(var, config):
+    cg.add(var.set_data(config[CONF_DATA]))
+
+
+@register_trigger("nec_like", NECLikeTrigger, NECLikeData)
+def nec_like_trigger(var, config):
+    pass
+
+
+@register_dumper("nec_like", NECLikeDumper)
+def nec_like_dumper(var, config):
+    pass
+
+
+@register_action("nec_like", NECLikeAction, NEC_LIKE_SCHEMA)
+async def nec_like_action(var, config, args):
+    bits = await cg.templatable(config[CONF_DATA], args, cg.std_string)
+    cg.add(var.set_bits(bits))
+
+
 # Pioneer
 (
     PioneerData,

--- a/esphome/components/remote_base/nec_like_protocol.cpp
+++ b/esphome/components/remote_base/nec_like_protocol.cpp
@@ -1,0 +1,91 @@
+#include "nec_like_protocol.h"
+#include "esphome/core/log.h"
+
+namespace esphome {
+namespace remote_base {
+
+static const char *const TAG = "remote.nec_like";
+
+// NEC timing constants (µs)
+static const uint32_t HEADER_HIGH_US = 9000;
+static const uint32_t HEADER_LOW_US = 4500;
+static const uint32_t BIT_HIGH_US = 560;
+static const uint32_t BIT_ONE_LOW_US = 1680;
+static const uint32_t BIT_ZERO_LOW_US = 600;
+
+void NECLikeProtocol::encode(RemoteTransmitData *dst, const NECLikeData &data) {
+  ESP_LOGD(TAG, "Sending NEC_Like raw bits, length=%u", data.bits_.size());
+  dst->reserve(2 + data.bits_.size() * 2 + 1);
+  dst->set_carrier_frequency(38000);
+
+  // Header
+  dst->item(HEADER_HIGH_US, HEADER_LOW_US);
+  // Bits
+  for (size_t i = 0; i < data.bits_.size(); ++i) {
+    dst->mark(BIT_HIGH_US);
+    if (data.bits_[i]) {
+      dst->space(BIT_ONE_LOW_US);
+    } else {
+      dst->space(BIT_ZERO_LOW_US);
+    }
+  }
+  // Final mark
+  dst->mark(BIT_HIGH_US);
+}
+
+optional<NECLikeData> NECLikeProtocol::decode(RemoteReceiveData src) {
+  NECLikeData data;
+  data.bits_.clear();
+
+  // Expect header
+  if (!src.expect_item(HEADER_HIGH_US, HEADER_LOW_US))
+    return {};
+
+  // Decode bits
+  while (true) {
+    if (src.expect_item(BIT_HIGH_US, BIT_ONE_LOW_US)) {
+      data.bits_.push_back(true);
+    } else if (src.expect_item(BIT_HIGH_US, BIT_ZERO_LOW_US)) {
+      data.bits_.push_back(false);
+    } else {
+      break;
+    }
+  }
+  // Optional trailing mark
+  src.expect_mark(BIT_HIGH_US);
+
+  return data;
+}
+
+void NECLikeProtocol::dump(const NECLikeData &data) {
+  // Convert bits to hex for logging
+  std::string hex_str;
+  for (size_t i = 0; i + 8 <= data.bits_.size(); i += 8) {
+    uint8_t byte = 0;
+    for (size_t j = 0; j < 8; ++j)
+      byte = (byte << 1) | (data.bits_[i + j]);
+    char buf[4];
+    snprintf(buf, sizeof(buf), "%02X", byte);
+    if (!hex_str.empty())
+      hex_str += ' ';
+    hex_str += buf;
+  }
+  ESP_LOGI(TAG, "Received NEC_Like (%u bits): %s", data.bits_.size(), hex_str.c_str());
+}
+
+void NECLikeProtocol::swap_nibbles(NECLikeData &data) {
+  size_t n = data.bits_.size();
+  size_t full_bytes = n / 8;
+  // copy original bitstream
+  std::vector<bool> orig = data.bits_;
+  // For each full byte, swap high and low nibble in-place
+  for (size_t i = 0; i < full_bytes; ++i) {
+    for (size_t bit = 0; bit < 8; ++bit) {
+      size_t src_bit = i * 8 + ((bit + 4) % 8);
+      data.bits_[i * 8 + bit] = orig[src_bit];
+    }
+  }
+}
+
+}  // namespace remote_base
+}  // namespace esphome

--- a/esphome/components/remote_base/nec_like_protocol.h
+++ b/esphome/components/remote_base/nec_like_protocol.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include "remote_base.h"
+
+namespace esphome {
+namespace remote_base {
+
+/**
+ * Raw NEC‐style IR protocol (NEC_Like) that captures low‐level bits.
+ */
+struct NECLikeData {
+  std::vector<bool> bits_;
+
+  bool operator==(const NECLikeData &rhs) const { return bits_ == rhs.bits_; }
+};
+
+class NECLikeProtocol : public RemoteProtocol<NECLikeData> {
+ public:
+  void encode(RemoteTransmitData *dst, const NECLikeData &data) override;
+  optional<NECLikeData> decode(RemoteReceiveData src) override;
+  void dump(const NECLikeData &data) override;
+  void swap_nibbles(NECLikeData &data);
+};
+
+DECLARE_REMOTE_PROTOCOL(NECLike)
+
+/**
+ * Action to send raw NEC_Like bitstrings.
+ */
+template<typename... Ts> class NECLikeAction : public RemoteTransmitterActionBase<Ts...> {
+ public:
+  TEMPLATABLE_VALUE(std::string, bits)
+
+  void encode(RemoteTransmitData *dst, Ts... x) override {
+    NECLikeData data;
+    data.bits_ = this->bits_.value(x...);
+    NECLikeProtocol().encode(dst, data);
+  }
+};
+
+}  // namespace remote_base
+}  // namespace esphome


### PR DESCRIPTION
# What does this implement/fix?

Support for Sanyo IR air conditioners

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#4917

## Test Environment

- [ ] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
remote_receiver:
  id: irrx
  pin:
    number: GPIO18
    inverted: true
    mode:
      input:
        true
        #      pullup: true
  # high 55% tolerance is recommended for some remote control units
  tolerance: 55%
  # dump: nec_like

climate:
  - platform: climate_ir_sanyo
    name: "AC"
    receiver_id: irrx
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
