### PR TITLE
Update esp32-camera library version

### DIFF
--- a/esphome/components/esp32_camera/__init__.py
+++ b/esphome/components/esp32_camera/__init__.py
@@ -296,7 +296,7 @@ async def to_code(config):
         add_idf_component(
             name="esp32-camera",
             repo="https://github.com/espressif/esp32-camera.git",
-            ref="v2.0.9",
+            ref="v2.0.15",
         )
 
     for conf in config.get(CONF_ON_STREAM_START, []):

--- a/esphome/components/esp32_camera/esp32_camera.cpp
+++ b/esphome/components/esp32_camera/esp32_camera.cpp
@@ -54,11 +54,7 @@ void ESP32Camera::dump_config() {
   ESP_LOGCONFIG(TAG, "  HREF Pin: %d", conf.pin_href);
   ESP_LOGCONFIG(TAG, "  Pixel Clock Pin: %d", conf.pin_pclk);
   ESP_LOGCONFIG(TAG, "  External Clock: Pin:%d Frequency:%u", conf.pin_xclk, conf.xclk_freq_hz);
-#ifdef USE_ESP_IDF  // Temporary until the espressif/esp32-camera library is updated
-  ESP_LOGCONFIG(TAG, "  I2C Pins: SDA:%d SCL:%d", conf.pin_sscb_sda, conf.pin_sscb_scl);
-#else
   ESP_LOGCONFIG(TAG, "  I2C Pins: SDA:%d SCL:%d", conf.pin_sccb_sda, conf.pin_sccb_scl);
-#endif
   ESP_LOGCONFIG(TAG, "  Reset Pin: %d", conf.pin_reset);
   switch (this->config_.frame_size) {
     case FRAMESIZE_QQVGA:
@@ -238,13 +234,8 @@ void ESP32Camera::set_external_clock(uint8_t pin, uint32_t frequency) {
   this->config_.xclk_freq_hz = frequency;
 }
 void ESP32Camera::set_i2c_pins(uint8_t sda, uint8_t scl) {
-#ifdef USE_ESP_IDF  // Temporary until the espressif/esp32-camera library is updated
-  this->config_.pin_sscb_sda = sda;
-  this->config_.pin_sscb_scl = scl;
-#else
   this->config_.pin_sccb_sda = sda;
   this->config_.pin_sccb_scl = scl;
-#endif
 }
 void ESP32Camera::set_reset_pin(uint8_t pin) { this->config_.pin_reset = pin; }
 void ESP32Camera::set_power_down_pin(uint8_t pin) { this->config_.pin_pwdn = pin; }

--- a/esphome/idf_component.yml
+++ b/esphome/idf_component.yml
@@ -4,7 +4,7 @@ dependencies:
     version: v1.3.1
   esp32_camera:
     git: https://github.com/espressif/esp32-camera.git
-    version: v2.0.9
+    version: v2.0.15
   mdns:
     git: https://github.com/espressif/esp-protocols.git
     version: mdns-v1.8.2


### PR DESCRIPTION
# What does this implement/fix?

This update will use a newer version of the esp32-camera library.

In my case it will support the new "mega ccm" camera module used by the M5Stack CamS3 5MP (PY260).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
