### PR TITLE
2025.5.0b3

### DIFF
--- a/.github/actions/build-image/action.yaml
+++ b/.github/actions/build-image/action.yaml
@@ -47,7 +47,7 @@ runs:
 
     - name: Build and push to ghcr by digest
       id: build-ghcr
-      uses: docker/build-push-action@v6.16.0
+      uses: docker/build-push-action@v6.17.0
       env:
         DOCKER_BUILD_SUMMARY: false
         DOCKER_BUILD_RECORD_UPLOAD: false
@@ -73,7 +73,7 @@ runs:
 
     - name: Build and push to dockerhub by digest
       id: build-dockerhub
-      uses: docker/build-push-action@v6.16.0
+      uses: docker/build-push-action@v6.17.0
       env:
         DOCKER_BUILD_SUMMARY: false
         DOCKER_BUILD_RECORD_UPLOAD: false

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -169,7 +169,7 @@ esphome/components/gp2y1010au0f/* @zry98
 esphome/components/gp8403/* @jesserockz
 esphome/components/gpio/* @esphome/core
 esphome/components/gpio/one_wire/* @ssieb
-esphome/components/gps/* @coogle
+esphome/components/gps/* @coogle @ximex
 esphome/components/graph/* @synco
 esphome/components/graphical_display_menu/* @MrMDavidson
 esphome/components/gree/* @orestismers

--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -43,7 +43,7 @@ from esphome.const import (
 )
 from esphome.core import CORE, EsphomeError, coroutine
 from esphome.helpers import get_bool_env, indent, is_ip_address
-from esphome.log import Fore, color, setup_log
+from esphome.log import AnsiFore, color, setup_log
 from esphome.util import (
     get_serial_ports,
     list_yaml_files,
@@ -83,7 +83,7 @@ def choose_prompt(options, purpose: str = None):
                 raise ValueError
             break
         except ValueError:
-            safe_print(color(Fore.RED, f"Invalid option: '{opt}'"))
+            safe_print(color(AnsiFore.RED, f"Invalid option: '{opt}'"))
     return options[opt - 1][1]
 
 
@@ -596,30 +596,30 @@ def command_update_all(args):
         click.echo(f"{half_line}{middle_text}{half_line}")
 
     for f in files:
-        print(f"Updating {color(Fore.CYAN, f)}")
+        print(f"Updating {color(AnsiFore.CYAN, f)}")
         print("-" * twidth)
         print()
         rc = run_external_process(
             "esphome", "--dashboard", "run", f, "--no-logs", "--device", "OTA"
         )
         if rc == 0:
-            print_bar(f"[{color(Fore.BOLD_GREEN, 'SUCCESS')}] {f}")
+            print_bar(f"[{color(AnsiFore.BOLD_GREEN, 'SUCCESS')}] {f}")
             success[f] = True
         else:
-            print_bar(f"[{color(Fore.BOLD_RED, 'ERROR')}] {f}")
+            print_bar(f"[{color(AnsiFore.BOLD_RED, 'ERROR')}] {f}")
             success[f] = False
 
         print()
         print()
         print()
 
-    print_bar(f"[{color(Fore.BOLD_WHITE, 'SUMMARY')}]")
+    print_bar(f"[{color(AnsiFore.BOLD_WHITE, 'SUMMARY')}]")
     failed = 0
     for f in files:
         if success[f]:
-            print(f"  - {f}: {color(Fore.GREEN, 'SUCCESS')}")
+            print(f"  - {f}: {color(AnsiFore.GREEN, 'SUCCESS')}")
         else:
-            print(f"  - {f}: {color(Fore.BOLD_RED, 'FAILED')}")
+            print(f"  - {f}: {color(AnsiFore.BOLD_RED, 'FAILED')}")
             failed += 1
     return failed
 
@@ -645,7 +645,7 @@ def command_rename(args, config):
         if c not in ALLOWED_NAME_CHARS:
             print(
                 color(
-                    Fore.BOLD_RED,
+                    AnsiFore.BOLD_RED,
                     f"'{c}' is an invalid character for names. Valid characters are: "
                     f"{ALLOWED_NAME_CHARS} (lowercase, no spaces)",
                 )
@@ -658,7 +658,9 @@ def command_rename(args, config):
     yaml = yaml_util.load_yaml(CORE.config_path)
     if CONF_ESPHOME not in yaml or CONF_NAME not in yaml[CONF_ESPHOME]:
         print(
-            color(Fore.BOLD_RED, "Complex YAML files cannot be automatically renamed.")
+            color(
+                AnsiFore.BOLD_RED, "Complex YAML files cannot be automatically renamed."
+            )
         )
         return 1
     old_name = yaml[CONF_ESPHOME][CONF_NAME]
@@ -681,7 +683,7 @@ def command_rename(args, config):
             )
             > 1
         ):
-            print(color(Fore.BOLD_RED, "Too many matches in YAML to safely rename"))
+            print(color(AnsiFore.BOLD_RED, "Too many matches in YAML to safely rename"))
             return 1
 
         new_raw = re.sub(
@@ -693,7 +695,7 @@ def command_rename(args, config):
 
     new_path = os.path.join(CORE.config_dir, args.name + ".yaml")
     print(
-        f"Updating {color(Fore.CYAN, CORE.config_path)} to {color(Fore.CYAN, new_path)}"
+        f"Updating {color(AnsiFore.CYAN, CORE.config_path)} to {color(AnsiFore.CYAN, new_path)}"
     )
     print()
 
@@ -702,7 +704,7 @@ def command_rename(args, config):
 
     rc = run_external_process("esphome", "config", new_path)
     if rc != 0:
-        print(color(Fore.BOLD_RED, "Rename failed. Reverting changes."))
+        print(color(AnsiFore.BOLD_RED, "Rename failed. Reverting changes."))
         os.remove(new_path)
         return 1
 
@@ -728,7 +730,7 @@ def command_rename(args, config):
     if CORE.config_path != new_path:
         os.remove(CORE.config_path)
 
-    print(color(Fore.BOLD_GREEN, "SUCCESS"))
+    print(color(AnsiFore.BOLD_GREEN, "SUCCESS"))
     print()
     return 0
 

--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -8,6 +8,7 @@
 #include "esphome/core/hal.h"
 #include "esphome/core/log.h"
 #include "esphome/core/version.h"
+#include "esphome/core/application.h"
 
 #ifdef USE_DEEP_SLEEP
 #include "esphome/components/deep_sleep/deep_sleep_component.h"
@@ -146,7 +147,7 @@ void APIConnection::loop() {
     }
     return;
   } else {
-    this->last_traffic_ = millis();
+    this->last_traffic_ = App.get_loop_component_start_time();
     // read a packet
     this->read_message(buffer.data_len, buffer.type, &buffer.container[buffer.data_offset]);
     if (this->remove_)
@@ -163,7 +164,7 @@ void APIConnection::loop() {
   static uint32_t keepalive = 60000;
   static uint8_t max_ping_retries = 60;
   static uint16_t ping_retry_interval = 1000;
-  const uint32_t now = millis();
+  const uint32_t now = App.get_loop_component_start_time();
   if (this->sent_ping_) {
     // Disconnect if not responded within 2.5*keepalive
     if (now - this->last_traffic_ > (keepalive * 5) / 2) {

--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -1962,7 +1962,7 @@ bool APIConnection::send_buffer(ProtoWriteBuffer buffer, uint32_t message_type) 
     }
   }
 
-  APIError err = this->helper_->write_packet(message_type, buffer.get_buffer()->data(), buffer.get_buffer()->size());
+  APIError err = this->helper_->write_protobuf_packet(message_type, buffer);
   if (err == APIError::WOULD_BLOCK)
     return false;
   if (err != APIError::OK) {

--- a/esphome/components/api/api_frame_helper.h
+++ b/esphome/components/api/api_frame_helper.h
@@ -16,6 +16,8 @@
 namespace esphome {
 namespace api {
 
+class ProtoWriteBuffer;
+
 struct ReadPacketBuffer {
   std::vector<uint8_t> container;
   uint16_t type;
@@ -65,32 +67,46 @@ class APIFrameHelper {
   virtual APIError loop() = 0;
   virtual APIError read_packet(ReadPacketBuffer *buffer) = 0;
   virtual bool can_write_without_blocking() = 0;
-  virtual APIError write_packet(uint16_t type, const uint8_t *data, size_t len) = 0;
+  virtual APIError write_protobuf_packet(uint16_t type, ProtoWriteBuffer buffer) = 0;
   virtual std::string getpeername() = 0;
   virtual int getpeername(struct sockaddr *addr, socklen_t *addrlen) = 0;
   virtual APIError close() = 0;
   virtual APIError shutdown(int how) = 0;
   // Give this helper a name for logging
   virtual void set_log_info(std::string info) = 0;
+  // Get the frame header padding required by this protocol
+  virtual uint8_t frame_header_padding() = 0;
+  // Get the frame footer size required by this protocol
+  virtual uint8_t frame_footer_size() = 0;
 
  protected:
   // Common implementation for writing raw data to socket
   template<typename StateEnum>
   APIError write_raw_(const struct iovec *iov, int iovcnt, socket::Socket *socket, std::vector<uint8_t> &tx_buf,
                       const std::string &info, StateEnum &state, StateEnum failed_state);
+
+  uint8_t frame_header_padding_{0};
+  uint8_t frame_footer_size_{0};
 };
 
 #ifdef USE_API_NOISE
 class APINoiseFrameHelper : public APIFrameHelper {
  public:
   APINoiseFrameHelper(std::unique_ptr<socket::Socket> socket, std::shared_ptr<APINoiseContext> ctx)
-      : socket_(std::move(socket)), ctx_(std::move(std::move(ctx))) {}
+      : socket_(std::move(socket)), ctx_(std::move(ctx)) {
+    // Noise header structure:
+    // Pos 0: indicator (0x01)
+    // Pos 1-2: encrypted payload size (16-bit big-endian)
+    // Pos 3-6: encrypted type (16-bit) + data_len (16-bit)
+    // Pos 7+: actual payload data
+    frame_header_padding_ = 7;
+  }
   ~APINoiseFrameHelper() override;
   APIError init() override;
   APIError loop() override;
   APIError read_packet(ReadPacketBuffer *buffer) override;
   bool can_write_without_blocking() override;
-  APIError write_packet(uint16_t type, const uint8_t *payload, size_t len) override;
+  APIError write_protobuf_packet(uint16_t type, ProtoWriteBuffer buffer) override;
   std::string getpeername() override { return this->socket_->getpeername(); }
   int getpeername(struct sockaddr *addr, socklen_t *addrlen) override {
     return this->socket_->getpeername(addr, addrlen);
@@ -99,6 +115,10 @@ class APINoiseFrameHelper : public APIFrameHelper {
   APIError shutdown(int how) override;
   // Give this helper a name for logging
   void set_log_info(std::string info) override { info_ = std::move(info); }
+  // Get the frame header padding required by this protocol
+  uint8_t frame_header_padding() override { return frame_header_padding_; }
+  // Get the frame footer size required by this protocol
+  uint8_t frame_footer_size() override { return frame_footer_size_; }
 
  protected:
   struct ParsedFrame {
@@ -152,13 +172,20 @@ class APINoiseFrameHelper : public APIFrameHelper {
 #ifdef USE_API_PLAINTEXT
 class APIPlaintextFrameHelper : public APIFrameHelper {
  public:
-  APIPlaintextFrameHelper(std::unique_ptr<socket::Socket> socket) : socket_(std::move(socket)) {}
+  APIPlaintextFrameHelper(std::unique_ptr<socket::Socket> socket) : socket_(std::move(socket)) {
+    // Plaintext header structure (worst case):
+    // Pos 0: indicator (0x00)
+    // Pos 1-3: payload size varint (up to 3 bytes)
+    // Pos 4-5: message type varint (up to 2 bytes)
+    // Pos 6+: actual payload data
+    frame_header_padding_ = 6;
+  }
   ~APIPlaintextFrameHelper() override = default;
   APIError init() override;
   APIError loop() override;
   APIError read_packet(ReadPacketBuffer *buffer) override;
   bool can_write_without_blocking() override;
-  APIError write_packet(uint16_t type, const uint8_t *payload, size_t len) override;
+  APIError write_protobuf_packet(uint16_t type, ProtoWriteBuffer buffer) override;
   std::string getpeername() override { return this->socket_->getpeername(); }
   int getpeername(struct sockaddr *addr, socklen_t *addrlen) override {
     return this->socket_->getpeername(addr, addrlen);
@@ -167,6 +194,10 @@ class APIPlaintextFrameHelper : public APIFrameHelper {
   APIError shutdown(int how) override;
   // Give this helper a name for logging
   void set_log_info(std::string info) override { info_ = std::move(info); }
+  // Get the frame header padding required by this protocol
+  uint8_t frame_header_padding() override { return frame_header_padding_; }
+  // Get the frame footer size required by this protocol
+  uint8_t frame_footer_size() override { return frame_footer_size_; }
 
  protected:
   struct ParsedFrame {

--- a/esphome/components/api/proto.h
+++ b/esphome/components/api/proto.h
@@ -83,6 +83,34 @@ class ProtoVarInt {
       return static_cast<int64_t>(this->value_ >> 1);
     }
   }
+  /**
+   * Encode the varint value to a pre-allocated buffer without bounds checking.
+   *
+   * @param buffer The pre-allocated buffer to write the encoded varint to
+   * @param len The size of the buffer in bytes
+   *
+   * @note The caller is responsible for ensuring the buffer is large enough
+   *       to hold the encoded value. Use ProtoSize::varint() to calculate
+   *       the exact size needed before calling this method.
+   * @note No bounds checking is performed for performance reasons.
+   */
+  void encode_to_buffer_unchecked(uint8_t *buffer, size_t len) {
+    uint64_t val = this->value_;
+    if (val <= 0x7F) {
+      buffer[0] = val;
+      return;
+    }
+    size_t i = 0;
+    while (val && i < len) {
+      uint8_t temp = val & 0x7F;
+      val >>= 7;
+      if (val) {
+        buffer[i++] = temp | 0x80;
+      } else {
+        buffer[i++] = temp;
+      }
+    }
+  }
   void encode(std::vector<uint8_t> &out) {
     uint64_t val = this->value_;
     if (val <= 0x7F) {

--- a/esphome/components/ballu/climate.py
+++ b/esphome/components/ballu/climate.py
@@ -7,7 +7,7 @@ CODEOWNERS = ["@bazuchan"]
 ballu_ns = cg.esphome_ns.namespace("ballu")
 BalluClimate = ballu_ns.class_("BalluClimate", climate_ir.ClimateIR)
 
-CONFIG_SCHEMA = climate_ir.climare_ir_with_receiver_schema(BalluClimate)
+CONFIG_SCHEMA = climate_ir.climate_ir_with_receiver_schema(BalluClimate)
 
 
 async def to_code(config):

--- a/esphome/components/bedjet/bedjet_hub.cpp
+++ b/esphome/components/bedjet/bedjet_hub.cpp
@@ -3,6 +3,7 @@
 #include "bedjet_hub.h"
 #include "bedjet_child.h"
 #include "bedjet_const.h"
+#include "esphome/core/application.h"
 #include <cinttypes>
 
 namespace esphome {

--- a/esphome/components/binary_sensor/binary_sensor.cpp
+++ b/esphome/components/binary_sensor/binary_sensor.cpp
@@ -15,17 +15,21 @@ void BinarySensor::publish_state(bool state) {
   if (!this->publish_dedup_.next(state))
     return;
   if (this->filter_list_ == nullptr) {
-    this->send_state_internal(state);
+    this->send_state_internal(state, false);
   } else {
-    this->filter_list_->input(state);
+    this->filter_list_->input(state, false);
   }
 }
 void BinarySensor::publish_initial_state(bool state) {
-  this->has_state_ = false;
-  this->publish_state(state);
+  if (!this->publish_dedup_.next(state))
+    return;
+  if (this->filter_list_ == nullptr) {
+    this->send_state_internal(state, true);
+  } else {
+    this->filter_list_->input(state, true);
+  }
 }
-void BinarySensor::send_state_internal(bool state) {
-  bool is_initial = !this->has_state_;
+void BinarySensor::send_state_internal(bool state, bool is_initial) {
   if (is_initial) {
     ESP_LOGD(TAG, "'%s': Sending initial state %s", this->get_name().c_str(), ONOFF(state));
   } else {

--- a/esphome/components/binary_sensor/binary_sensor.h
+++ b/esphome/components/binary_sensor/binary_sensor.h
@@ -67,7 +67,7 @@ class BinarySensor : public EntityBase, public EntityBase_DeviceClass {
 
   // ========== INTERNAL METHODS ==========
   // (In most use cases you won't need these)
-  void send_state_internal(bool state);
+  void send_state_internal(bool state, bool is_initial);
 
   /// Return whether this binary sensor has outputted a state.
   virtual bool has_state() const;

--- a/esphome/components/binary_sensor/filter.h
+++ b/esphome/components/binary_sensor/filter.h
@@ -14,11 +14,11 @@ class BinarySensor;
 
 class Filter {
  public:
-  virtual optional<bool> new_value(bool value) = 0;
+  virtual optional<bool> new_value(bool value, bool is_initial) = 0;
 
-  void input(bool value);
+  void input(bool value, bool is_initial);
 
-  void output(bool value);
+  void output(bool value, bool is_initial);
 
  protected:
   friend BinarySensor;
@@ -30,7 +30,7 @@ class Filter {
 
 class DelayedOnOffFilter : public Filter, public Component {
  public:
-  optional<bool> new_value(bool value) override;
+  optional<bool> new_value(bool value, bool is_initial) override;
 
   float get_setup_priority() const override;
 
@@ -44,7 +44,7 @@ class DelayedOnOffFilter : public Filter, public Component {
 
 class DelayedOnFilter : public Filter, public Component {
  public:
-  optional<bool> new_value(bool value) override;
+  optional<bool> new_value(bool value, bool is_initial) override;
 
   float get_setup_priority() const override;
 
@@ -56,7 +56,7 @@ class DelayedOnFilter : public Filter, public Component {
 
 class DelayedOffFilter : public Filter, public Component {
  public:
-  optional<bool> new_value(bool value) override;
+  optional<bool> new_value(bool value, bool is_initial) override;
 
   float get_setup_priority() const override;
 
@@ -68,7 +68,7 @@ class DelayedOffFilter : public Filter, public Component {
 
 class InvertFilter : public Filter {
  public:
-  optional<bool> new_value(bool value) override;
+  optional<bool> new_value(bool value, bool is_initial) override;
 };
 
 struct AutorepeatFilterTiming {
@@ -86,7 +86,7 @@ class AutorepeatFilter : public Filter, public Component {
  public:
   explicit AutorepeatFilter(std::vector<AutorepeatFilterTiming> timings);
 
-  optional<bool> new_value(bool value) override;
+  optional<bool> new_value(bool value, bool is_initial) override;
 
   float get_setup_priority() const override;
 
@@ -102,7 +102,7 @@ class LambdaFilter : public Filter {
  public:
   explicit LambdaFilter(std::function<optional<bool>(bool)> f);
 
-  optional<bool> new_value(bool value) override;
+  optional<bool> new_value(bool value, bool is_initial) override;
 
  protected:
   std::function<optional<bool>(bool)> f_;
@@ -110,7 +110,7 @@ class LambdaFilter : public Filter {
 
 class SettleFilter : public Filter, public Component {
  public:
-  optional<bool> new_value(bool value) override;
+  optional<bool> new_value(bool value, bool is_initial) override;
 
   float get_setup_priority() const override;
 

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
@@ -2,6 +2,7 @@
 
 #include "esphome/core/log.h"
 #include "esphome/core/macros.h"
+#include "esphome/core/application.h"
 
 #ifdef USE_ESP32
 
@@ -177,7 +178,7 @@ void BluetoothProxy::loop() {
   // Flush any pending BLE advertisements that have been accumulated but not yet sent
   if (this->raw_advertisements_) {
     static uint32_t last_flush_time = 0;
-    uint32_t now = millis();
+    uint32_t now = App.get_loop_component_start_time();
 
     // Flush accumulated advertisements every 100ms
     if (now - last_flush_time >= 100) {

--- a/esphome/components/ccs811/sensor.py
+++ b/esphome/components/ccs811/sensor.py
@@ -32,14 +32,14 @@ CONFIG_SCHEMA = (
     cv.Schema(
         {
             cv.GenerateID(): cv.declare_id(CCS811Component),
-            cv.Required(CONF_ECO2): sensor.sensor_schema(
+            cv.Optional(CONF_ECO2): sensor.sensor_schema(
                 unit_of_measurement=UNIT_PARTS_PER_MILLION,
                 icon=ICON_MOLECULE_CO2,
                 accuracy_decimals=0,
                 device_class=DEVICE_CLASS_CARBON_DIOXIDE,
                 state_class=STATE_CLASS_MEASUREMENT,
             ),
-            cv.Required(CONF_TVOC): sensor.sensor_schema(
+            cv.Optional(CONF_TVOC): sensor.sensor_schema(
                 unit_of_measurement=UNIT_PARTS_PER_BILLION,
                 icon=ICON_RADIATOR,
                 accuracy_decimals=0,
@@ -64,10 +64,13 @@ async def to_code(config):
     await cg.register_component(var, config)
     await i2c.register_i2c_device(var, config)
 
-    sens = await sensor.new_sensor(config[CONF_ECO2])
-    cg.add(var.set_co2(sens))
-    sens = await sensor.new_sensor(config[CONF_TVOC])
-    cg.add(var.set_tvoc(sens))
+    if eco2_config := config.get(CONF_ECO2):
+        sens = await sensor.new_sensor(eco2_config)
+        cg.add(var.set_co2(sens))
+
+    if tvoc_config := config.get(CONF_TVOC):
+        sens = await sensor.new_sensor(tvoc_config)
+        cg.add(var.set_tvoc(sens))
 
     if version_config := config.get(CONF_VERSION):
         sens = await text_sensor.new_text_sensor(version_config)

--- a/esphome/components/climate_ir/__init__.py
+++ b/esphome/components/climate_ir/__init__.py
@@ -40,7 +40,7 @@ def climate_ir_schema(
     )
 
 
-def climare_ir_with_receiver_schema(
+def climate_ir_with_receiver_schema(
     class_: MockObjClass,
 ) -> cv.Schema:
     return climate_ir_schema(class_).extend(
@@ -59,7 +59,7 @@ def deprecated_schema_constant(config):
         type = str(id.type).split("::", maxsplit=1)[0]
     _LOGGER.warning(
         "Using `climate_ir.CLIMATE_IR_WITH_RECEIVER_SCHEMA` is deprecated and will be removed in ESPHome 2025.11.0. "
-        "Please use `climate_ir.climare_ir_with_receiver_schema(...)` instead. "
+        "Please use `climate_ir.climate_ir_with_receiver_schema(...)` instead. "
         "If you are seeing this, report an issue to the external_component author and ask them to update it. "
         "https://developers.esphome.io/blog/2025/05/14/_schema-deprecations/. "
         "Component using this schema: %s",
@@ -68,7 +68,7 @@ def deprecated_schema_constant(config):
     return config
 
 
-CLIMATE_IR_WITH_RECEIVER_SCHEMA = climare_ir_with_receiver_schema(ClimateIR)
+CLIMATE_IR_WITH_RECEIVER_SCHEMA = climate_ir_with_receiver_schema(ClimateIR)
 CLIMATE_IR_WITH_RECEIVER_SCHEMA.add_extra(deprecated_schema_constant)
 
 

--- a/esphome/components/climate_ir_lg/climate.py
+++ b/esphome/components/climate_ir_lg/climate.py
@@ -13,7 +13,7 @@ CONF_BIT_HIGH = "bit_high"
 CONF_BIT_ONE_LOW = "bit_one_low"
 CONF_BIT_ZERO_LOW = "bit_zero_low"
 
-CONFIG_SCHEMA = climate_ir.climare_ir_with_receiver_schema(LgIrClimate).extend(
+CONFIG_SCHEMA = climate_ir.climate_ir_with_receiver_schema(LgIrClimate).extend(
     {
         cv.Optional(
             CONF_HEADER_HIGH, default="8000us"

--- a/esphome/components/coolix/climate.py
+++ b/esphome/components/coolix/climate.py
@@ -7,7 +7,7 @@ CODEOWNERS = ["@glmnet"]
 coolix_ns = cg.esphome_ns.namespace("coolix")
 CoolixClimate = coolix_ns.class_("CoolixClimate", climate_ir.ClimateIR)
 
-CONFIG_SCHEMA = climate_ir.climare_ir_with_receiver_schema(CoolixClimate)
+CONFIG_SCHEMA = climate_ir.climate_ir_with_receiver_schema(CoolixClimate)
 
 
 async def to_code(config):

--- a/esphome/components/cse7766/cse7766.cpp
+++ b/esphome/components/cse7766/cse7766.cpp
@@ -1,5 +1,6 @@
 #include "cse7766.h"
 #include "esphome/core/log.h"
+#include "esphome/core/application.h"
 
 namespace esphome {
 namespace cse7766 {
@@ -7,7 +8,7 @@ namespace cse7766 {
 static const char *const TAG = "cse7766";
 
 void CSE7766Component::loop() {
-  const uint32_t now = millis();
+  const uint32_t now = App.get_loop_component_start_time();
   if (now - this->last_transmission_ >= 500) {
     // last transmission too long ago. Reset RX index.
     this->raw_data_index_ = 0;

--- a/esphome/components/current_based/current_based_cover.cpp
+++ b/esphome/components/current_based/current_based_cover.cpp
@@ -1,6 +1,7 @@
 #include "current_based_cover.h"
 #include "esphome/core/hal.h"
 #include "esphome/core/log.h"
+#include "esphome/core/application.h"
 #include <cfloat>
 
 namespace esphome {
@@ -60,7 +61,7 @@ void CurrentBasedCover::loop() {
   if (this->current_operation == COVER_OPERATION_IDLE)
     return;
 
-  const uint32_t now = millis();
+  const uint32_t now = App.get_loop_component_start_time();
 
   if (this->current_operation == COVER_OPERATION_OPENING) {
     if (this->malfunction_detection_ && this->is_closing_()) {  // Malfunction

--- a/esphome/components/daikin/climate.py
+++ b/esphome/components/daikin/climate.py
@@ -6,7 +6,7 @@ AUTO_LOAD = ["climate_ir"]
 daikin_ns = cg.esphome_ns.namespace("daikin")
 DaikinClimate = daikin_ns.class_("DaikinClimate", climate_ir.ClimateIR)
 
-CONFIG_SCHEMA = climate_ir.climare_ir_with_receiver_schema(DaikinClimate)
+CONFIG_SCHEMA = climate_ir.climate_ir_with_receiver_schema(DaikinClimate)
 
 
 async def to_code(config):

--- a/esphome/components/daikin_arc/climate.py
+++ b/esphome/components/daikin_arc/climate.py
@@ -6,7 +6,7 @@ AUTO_LOAD = ["climate_ir"]
 daikin_arc_ns = cg.esphome_ns.namespace("daikin_arc")
 DaikinArcClimate = daikin_arc_ns.class_("DaikinArcClimate", climate_ir.ClimateIR)
 
-CONFIG_SCHEMA = climate_ir.climare_ir_with_receiver_schema(DaikinArcClimate)
+CONFIG_SCHEMA = climate_ir.climate_ir_with_receiver_schema(DaikinArcClimate)
 
 
 async def to_code(config):

--- a/esphome/components/daikin_brc/climate.py
+++ b/esphome/components/daikin_brc/climate.py
@@ -9,7 +9,7 @@ daikin_brc_ns = cg.esphome_ns.namespace("daikin_brc")
 DaikinBrcClimate = daikin_brc_ns.class_("DaikinBrcClimate", climate_ir.ClimateIR)
 
 
-CONFIG_SCHEMA = climate_ir.climare_ir_with_receiver_schema(DaikinBrcClimate).extend(
+CONFIG_SCHEMA = climate_ir.climate_ir_with_receiver_schema(DaikinBrcClimate).extend(
     {
         cv.Optional(CONF_USE_FAHRENHEIT, default=False): cv.boolean,
     }

--- a/esphome/components/daly_bms/daly_bms.cpp
+++ b/esphome/components/daly_bms/daly_bms.cpp
@@ -1,6 +1,7 @@
 #include "daly_bms.h"
 #include <vector>
 #include "esphome/core/log.h"
+#include "esphome/core/application.h"
 
 namespace esphome {
 namespace daly_bms {
@@ -32,7 +33,7 @@ void DalyBmsComponent::update() {
 }
 
 void DalyBmsComponent::loop() {
-  const uint32_t now = millis();
+  const uint32_t now = App.get_loop_component_start_time();
   if (this->receiving_ && (now - this->last_transmission_ >= 200)) {
     // last transmission too long ago. Reset RX index.
     ESP_LOGW(TAG, "Last transmission too long ago. Reset RX index.");

--- a/esphome/components/debug/debug_component.cpp
+++ b/esphome/components/debug/debug_component.cpp
@@ -70,7 +70,7 @@ void DebugComponent::loop() {
 #ifdef USE_SENSOR
   // calculate loop time - from last call to this one
   if (this->loop_time_sensor_ != nullptr) {
-    uint32_t now = millis();
+    uint32_t now = App.get_loop_component_start_time();
     uint32_t loop_time = now - this->last_loop_timetag_;
     this->max_loop_time_ = std::max(this->max_loop_time_, loop_time);
     this->last_loop_timetag_ = now;

--- a/esphome/components/delonghi/climate.py
+++ b/esphome/components/delonghi/climate.py
@@ -6,7 +6,7 @@ AUTO_LOAD = ["climate_ir"]
 delonghi_ns = cg.esphome_ns.namespace("delonghi")
 DelonghiClimate = delonghi_ns.class_("DelonghiClimate", climate_ir.ClimateIR)
 
-CONFIG_SCHEMA = climate_ir.climare_ir_with_receiver_schema(DelonghiClimate)
+CONFIG_SCHEMA = climate_ir.climate_ir_with_receiver_schema(DelonghiClimate)
 
 
 async def to_code(config):

--- a/esphome/components/dps310/sensor.py
+++ b/esphome/components/dps310/sensor.py
@@ -27,14 +27,14 @@ CONFIG_SCHEMA = (
     cv.Schema(
         {
             cv.GenerateID(): cv.declare_id(DPS310Component),
-            cv.Required(CONF_TEMPERATURE): sensor.sensor_schema(
+            cv.Optional(CONF_TEMPERATURE): sensor.sensor_schema(
                 unit_of_measurement=UNIT_CELSIUS,
                 icon=ICON_THERMOMETER,
                 accuracy_decimals=1,
                 device_class=DEVICE_CLASS_TEMPERATURE,
                 state_class=STATE_CLASS_MEASUREMENT,
             ),
-            cv.Required(CONF_PRESSURE): sensor.sensor_schema(
+            cv.Optional(CONF_PRESSURE): sensor.sensor_schema(
                 unit_of_measurement=UNIT_HECTOPASCAL,
                 icon=ICON_GAUGE,
                 accuracy_decimals=1,
@@ -53,10 +53,10 @@ async def to_code(config):
     await cg.register_component(var, config)
     await i2c.register_i2c_device(var, config)
 
-    if CONF_TEMPERATURE in config:
-        sens = await sensor.new_sensor(config[CONF_TEMPERATURE])
+    if temperature := config.get(CONF_TEMPERATURE):
+        sens = await sensor.new_sensor(temperature)
         cg.add(var.set_temperature_sensor(sens))
 
-    if CONF_PRESSURE in config:
-        sens = await sensor.new_sensor(config[CONF_PRESSURE])
+    if pressure := config.get(CONF_PRESSURE):
+        sens = await sensor.new_sensor(pressure)
         cg.add(var.set_pressure_sensor(sens))

--- a/esphome/components/ee895/sensor.py
+++ b/esphome/components/ee895/sensor.py
@@ -26,19 +26,19 @@ CONFIG_SCHEMA = (
     cv.Schema(
         {
             cv.GenerateID(): cv.declare_id(EE895Component),
-            cv.Required(CONF_TEMPERATURE): sensor.sensor_schema(
+            cv.Optional(CONF_TEMPERATURE): sensor.sensor_schema(
                 unit_of_measurement=UNIT_CELSIUS,
                 accuracy_decimals=1,
                 device_class=DEVICE_CLASS_TEMPERATURE,
                 state_class=STATE_CLASS_MEASUREMENT,
             ),
-            cv.Required(CONF_CO2): sensor.sensor_schema(
+            cv.Optional(CONF_CO2): sensor.sensor_schema(
                 unit_of_measurement=UNIT_PARTS_PER_MILLION,
                 icon=ICON_MOLECULE_CO2,
                 accuracy_decimals=0,
                 state_class=STATE_CLASS_MEASUREMENT,
             ),
-            cv.Required(CONF_PRESSURE): sensor.sensor_schema(
+            cv.Optional(CONF_PRESSURE): sensor.sensor_schema(
                 unit_of_measurement=UNIT_HECTOPASCAL,
                 accuracy_decimals=1,
                 device_class=DEVICE_CLASS_PRESSURE,
@@ -56,14 +56,14 @@ async def to_code(config):
     await cg.register_component(var, config)
     await i2c.register_i2c_device(var, config)
 
-    if CONF_TEMPERATURE in config:
-        sens = await sensor.new_sensor(config[CONF_TEMPERATURE])
+    if temperature := config.get(CONF_TEMPERATURE):
+        sens = await sensor.new_sensor(temperature)
         cg.add(var.set_temperature_sensor(sens))
 
-    if CONF_CO2 in config:
-        sens = await sensor.new_sensor(config[CONF_CO2])
+    if co2 := config.get(CONF_CO2):
+        sens = await sensor.new_sensor(co2)
         cg.add(var.set_co2_sensor(sens))
 
-    if CONF_PRESSURE in config:
-        sens = await sensor.new_sensor(config[CONF_PRESSURE])
+    if pressure := config.get(CONF_PRESSURE):
+        sens = await sensor.new_sensor(pressure)
         cg.add(var.set_pressure_sensor(sens))

--- a/esphome/components/emmeti/climate.py
+++ b/esphome/components/emmeti/climate.py
@@ -7,7 +7,7 @@ AUTO_LOAD = ["climate_ir"]
 emmeti_ns = cg.esphome_ns.namespace("emmeti")
 EmmetiClimate = emmeti_ns.class_("EmmetiClimate", climate_ir.ClimateIR)
 
-CONFIG_SCHEMA = climate_ir.climare_ir_with_receiver_schema(EmmetiClimate)
+CONFIG_SCHEMA = climate_ir.climate_ir_with_receiver_schema(EmmetiClimate)
 
 
 async def to_code(config):

--- a/esphome/components/endstop/endstop_cover.cpp
+++ b/esphome/components/endstop/endstop_cover.cpp
@@ -1,6 +1,7 @@
 #include "endstop_cover.h"
 #include "esphome/core/log.h"
 #include "esphome/core/hal.h"
+#include "esphome/core/application.h"
 
 namespace esphome {
 namespace endstop {
@@ -65,7 +66,7 @@ void EndstopCover::loop() {
   if (this->current_operation == COVER_OPERATION_IDLE)
     return;
 
-  const uint32_t now = millis();
+  const uint32_t now = App.get_loop_component_start_time();
 
   if (this->current_operation == COVER_OPERATION_OPENING && this->is_open_()) {
     float dur = (now - this->start_dir_time_) / 1e3f;

--- a/esphome/components/ens160_base/__init__.py
+++ b/esphome/components/ens160_base/__init__.py
@@ -28,21 +28,21 @@ UNIT_INDEX = "index"
 
 CONFIG_SCHEMA_BASE = cv.Schema(
     {
-        cv.Required(CONF_ECO2): sensor.sensor_schema(
+        cv.Optional(CONF_ECO2): sensor.sensor_schema(
             unit_of_measurement=UNIT_PARTS_PER_MILLION,
             icon=ICON_MOLECULE_CO2,
             accuracy_decimals=0,
             device_class=DEVICE_CLASS_CARBON_DIOXIDE,
             state_class=STATE_CLASS_MEASUREMENT,
         ),
-        cv.Required(CONF_TVOC): sensor.sensor_schema(
+        cv.Optional(CONF_TVOC): sensor.sensor_schema(
             unit_of_measurement=UNIT_PARTS_PER_BILLION,
             icon=ICON_RADIATOR,
             accuracy_decimals=0,
             device_class=DEVICE_CLASS_VOLATILE_ORGANIC_COMPOUNDS_PARTS,
             state_class=STATE_CLASS_MEASUREMENT,
         ),
-        cv.Required(CONF_AQI): sensor.sensor_schema(
+        cv.Optional(CONF_AQI): sensor.sensor_schema(
             icon=ICON_CHEMICAL_WEAPON,
             accuracy_decimals=0,
             device_class=DEVICE_CLASS_AQI,
@@ -62,12 +62,15 @@ async def to_code_base(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
 
-    sens = await sensor.new_sensor(config[CONF_ECO2])
-    cg.add(var.set_co2(sens))
-    sens = await sensor.new_sensor(config[CONF_TVOC])
-    cg.add(var.set_tvoc(sens))
-    sens = await sensor.new_sensor(config[CONF_AQI])
-    cg.add(var.set_aqi(sens))
+    if eco2_config := config.get(CONF_ECO2):
+        sens = await sensor.new_sensor(eco2_config)
+        cg.add(var.set_co2(sens))
+    if tvoc_config := config.get(CONF_TVOC):
+        sens = await sensor.new_sensor(tvoc_config)
+        cg.add(var.set_tvoc(sens))
+    if aqi_config := config.get(CONF_AQI):
+        sens = await sensor.new_sensor(aqi_config)
+        cg.add(var.set_aqi(sens))
 
     if compensation_config := config.get(CONF_COMPENSATION):
         sens = await cg.get_variable(compensation_config[CONF_TEMPERATURE])

--- a/esphome/components/esp32_ble/ble_advertising.cpp
+++ b/esphome/components/esp32_ble/ble_advertising.cpp
@@ -6,6 +6,7 @@
 #include <cstring>
 #include "ble_uuid.h"
 #include "esphome/core/log.h"
+#include "esphome/core/application.h"
 
 namespace esphome {
 namespace esp32_ble {
@@ -143,7 +144,7 @@ void BLEAdvertising::loop() {
   if (this->raw_advertisements_callbacks_.empty()) {
     return;
   }
-  const uint32_t now = millis();
+  const uint32_t now = App.get_loop_component_start_time();
   if (now - this->last_advertisement_time_ > this->advertising_cycle_time_) {
     this->stop();
     this->current_adv_index_ += 1;

--- a/esphome/components/esp32_camera/esp32_camera.cpp
+++ b/esphome/components/esp32_camera/esp32_camera.cpp
@@ -3,6 +3,7 @@
 #include "esp32_camera.h"
 #include "esphome/core/log.h"
 #include "esphome/core/hal.h"
+#include "esphome/core/application.h"
 
 #include <freertos/task.h>
 
@@ -162,7 +163,7 @@ void ESP32Camera::loop() {
   }
 
   // request idle image every idle_update_interval
-  const uint32_t now = millis();
+  const uint32_t now = App.get_loop_component_start_time();
   if (this->idle_update_interval_ != 0 && now - this->last_idle_request_ > this->idle_update_interval_) {
     this->last_idle_request_ = now;
     this->request_image(IDLE);

--- a/esphome/components/esp32_camera/esp32_camera.h
+++ b/esphome/components/esp32_camera/esp32_camera.h
@@ -106,7 +106,7 @@ class CameraImageReader {
 };
 
 /* ---------------- ESP32Camera class ---------------- */
-class ESP32Camera : public Component, public EntityBase {
+class ESP32Camera : public EntityBase, public Component {
  public:
   ESP32Camera();
 

--- a/esphome/components/esp32_improv/esp32_improv_component.cpp
+++ b/esphome/components/esp32_improv/esp32_improv_component.cpp
@@ -92,7 +92,7 @@ void ESP32ImprovComponent::loop() {
 
   if (!this->incoming_data_.empty())
     this->process_incoming_data_();
-  uint32_t now = millis();
+  uint32_t now = App.get_loop_component_start_time();
 
   switch (this->state_) {
     case improv::STATE_STOPPED:

--- a/esphome/components/esp32_touch/esp32_touch.cpp
+++ b/esphome/components/esp32_touch/esp32_touch.cpp
@@ -288,7 +288,7 @@ uint32_t ESP32TouchComponent::component_touch_pad_read(touch_pad_t tp) {
 }
 
 void ESP32TouchComponent::loop() {
-  const uint32_t now = millis();
+  const uint32_t now = App.get_loop_component_start_time();
   bool should_print = this->setup_mode_ && now - this->setup_mode_last_log_print_ > 250;
   for (auto *child : this->children_) {
     child->value_ = this->component_touch_pad_read(child->get_touch_pad());

--- a/esphome/components/ethernet/ethernet_component.cpp
+++ b/esphome/components/ethernet/ethernet_component.cpp
@@ -240,7 +240,7 @@ void EthernetComponent::setup() {
 }
 
 void EthernetComponent::loop() {
-  const uint32_t now = millis();
+  const uint32_t now = App.get_loop_component_start_time();
 
   switch (this->state_) {
     case EthernetComponentState::STOPPED:

--- a/esphome/components/feedback/feedback_cover.cpp
+++ b/esphome/components/feedback/feedback_cover.cpp
@@ -1,6 +1,7 @@
 #include "feedback_cover.h"
 #include "esphome/core/hal.h"
 #include "esphome/core/log.h"
+#include "esphome/core/application.h"
 
 namespace esphome {
 namespace feedback {
@@ -220,7 +221,7 @@ void FeedbackCover::set_open_obstacle_sensor(binary_sensor::BinarySensor *open_o
 void FeedbackCover::loop() {
   if (this->current_operation == COVER_OPERATION_IDLE)
     return;
-  const uint32_t now = millis();
+  const uint32_t now = App.get_loop_component_start_time();
 
   // Recompute position every loop cycle
   this->recompute_position_();

--- a/esphome/components/fujitsu_general/climate.py
+++ b/esphome/components/fujitsu_general/climate.py
@@ -8,7 +8,7 @@ FujitsuGeneralClimate = fujitsu_general_ns.class_(
     "FujitsuGeneralClimate", climate_ir.ClimateIR
 )
 
-CONFIG_SCHEMA = climate_ir.climare_ir_with_receiver_schema(FujitsuGeneralClimate)
+CONFIG_SCHEMA = climate_ir.climate_ir_with_receiver_schema(FujitsuGeneralClimate)
 
 
 async def to_code(config):

--- a/esphome/components/gcja5/gcja5.cpp
+++ b/esphome/components/gcja5/gcja5.cpp
@@ -6,6 +6,7 @@
  */
 #include "gcja5.h"
 #include "esphome/core/log.h"
+#include "esphome/core/application.h"
 #include <cstring>
 
 namespace esphome {
@@ -16,7 +17,7 @@ static const char *const TAG = "gcja5";
 void GCJA5Component::setup() { ESP_LOGCONFIG(TAG, "Setting up gcja5..."); }
 
 void GCJA5Component::loop() {
-  const uint32_t now = millis();
+  const uint32_t now = App.get_loop_component_start_time();
   if (now - this->last_transmission_ >= 500) {
     // last transmission too long ago. Reset RX index.
     this->rx_message_.clear();

--- a/esphome/components/gps/__init__.py
+++ b/esphome/components/gps/__init__.py
@@ -9,23 +9,32 @@ from esphome.const import (
     CONF_LONGITUDE,
     CONF_SATELLITES,
     CONF_SPEED,
+    DEVICE_CLASS_SPEED,
     STATE_CLASS_MEASUREMENT,
     UNIT_DEGREES,
     UNIT_KILOMETER_PER_HOUR,
     UNIT_METER,
 )
 
+CONF_GPS_ID = "gps_id"
+CONF_HDOP = "hdop"
+
+ICON_ALTIMETER = "mdi:altimeter"
+ICON_COMPASS = "mdi:compass"
+ICON_LATITUDE = "mdi:latitude"
+ICON_LONGITUDE = "mdi:longitude"
+ICON_SATELLITE = "mdi:satellite-variant"
+ICON_SPEEDOMETER = "mdi:speedometer"
+
 DEPENDENCIES = ["uart"]
 AUTO_LOAD = ["sensor"]
 
-CODEOWNERS = ["@coogle"]
+CODEOWNERS = ["@coogle", "@ximex"]
 
 gps_ns = cg.esphome_ns.namespace("gps")
 GPS = gps_ns.class_("GPS", cg.Component, uart.UARTDevice)
 GPSListener = gps_ns.class_("GPSListener")
 
-CONF_GPS_ID = "gps_id"
-CONF_HDOP = "hdop"
 MULTI_CONF = True
 CONFIG_SCHEMA = cv.All(
     cv.Schema(
@@ -33,25 +42,37 @@ CONFIG_SCHEMA = cv.All(
             cv.GenerateID(): cv.declare_id(GPS),
             cv.Optional(CONF_LATITUDE): sensor.sensor_schema(
                 unit_of_measurement=UNIT_DEGREES,
+                icon=ICON_LATITUDE,
                 accuracy_decimals=6,
+                state_class=STATE_CLASS_MEASUREMENT,
             ),
             cv.Optional(CONF_LONGITUDE): sensor.sensor_schema(
                 unit_of_measurement=UNIT_DEGREES,
+                icon=ICON_LONGITUDE,
                 accuracy_decimals=6,
+                state_class=STATE_CLASS_MEASUREMENT,
             ),
             cv.Optional(CONF_SPEED): sensor.sensor_schema(
                 unit_of_measurement=UNIT_KILOMETER_PER_HOUR,
+                icon=ICON_SPEEDOMETER,
                 accuracy_decimals=3,
+                device_class=DEVICE_CLASS_SPEED,
+                state_class=STATE_CLASS_MEASUREMENT,
             ),
             cv.Optional(CONF_COURSE): sensor.sensor_schema(
                 unit_of_measurement=UNIT_DEGREES,
+                icon=ICON_COMPASS,
                 accuracy_decimals=2,
+                state_class=STATE_CLASS_MEASUREMENT,
             ),
             cv.Optional(CONF_ALTITUDE): sensor.sensor_schema(
                 unit_of_measurement=UNIT_METER,
+                icon=ICON_ALTIMETER,
                 accuracy_decimals=2,
+                state_class=STATE_CLASS_MEASUREMENT,
             ),
             cv.Optional(CONF_SATELLITES): sensor.sensor_schema(
+                icon=ICON_SATELLITE,
                 accuracy_decimals=0,
                 state_class=STATE_CLASS_MEASUREMENT,
             ),
@@ -73,28 +94,28 @@ async def to_code(config):
     await cg.register_component(var, config)
     await uart.register_uart_device(var, config)
 
-    if CONF_LATITUDE in config:
-        sens = await sensor.new_sensor(config[CONF_LATITUDE])
+    if latitude_config := config.get(CONF_LATITUDE):
+        sens = await sensor.new_sensor(latitude_config)
         cg.add(var.set_latitude_sensor(sens))
 
-    if CONF_LONGITUDE in config:
-        sens = await sensor.new_sensor(config[CONF_LONGITUDE])
+    if longitude_config := config.get(CONF_LONGITUDE):
+        sens = await sensor.new_sensor(longitude_config)
         cg.add(var.set_longitude_sensor(sens))
 
-    if CONF_SPEED in config:
-        sens = await sensor.new_sensor(config[CONF_SPEED])
+    if speed_config := config.get(CONF_SPEED):
+        sens = await sensor.new_sensor(speed_config)
         cg.add(var.set_speed_sensor(sens))
 
-    if CONF_COURSE in config:
-        sens = await sensor.new_sensor(config[CONF_COURSE])
+    if course_config := config.get(CONF_COURSE):
+        sens = await sensor.new_sensor(course_config)
         cg.add(var.set_course_sensor(sens))
 
-    if CONF_ALTITUDE in config:
-        sens = await sensor.new_sensor(config[CONF_ALTITUDE])
+    if altitude_config := config.get(CONF_ALTITUDE):
+        sens = await sensor.new_sensor(altitude_config)
         cg.add(var.set_altitude_sensor(sens))
 
-    if CONF_SATELLITES in config:
-        sens = await sensor.new_sensor(config[CONF_SATELLITES])
+    if satellites_config := config.get(CONF_SATELLITES):
+        sens = await sensor.new_sensor(satellites_config)
         cg.add(var.set_satellites_sensor(sens))
 
     if hdop_config := config.get(CONF_HDOP):
@@ -102,4 +123,4 @@ async def to_code(config):
         cg.add(var.set_hdop_sensor(sens))
 
     # https://platformio.org/lib/show/1655/TinyGPSPlus
-    cg.add_library("mikalhart/TinyGPSPlus", "1.0.2")
+    cg.add_library("mikalhart/TinyGPSPlus", "1.1.0")

--- a/esphome/components/gps/gps.cpp
+++ b/esphome/components/gps/gps.cpp
@@ -10,6 +10,17 @@ static const char *const TAG = "gps";
 
 TinyGPSPlus &GPSListener::get_tiny_gps() { return this->parent_->get_tiny_gps(); }
 
+void GPS::dump_config() {
+  ESP_LOGCONFIG(TAG, "GPS:");
+  LOG_SENSOR("  ", "Latitude", this->latitude_sensor_);
+  LOG_SENSOR("  ", "Longitude", this->longitude_sensor_);
+  LOG_SENSOR("  ", "Speed", this->speed_sensor_);
+  LOG_SENSOR("  ", "Course", this->course_sensor_);
+  LOG_SENSOR("  ", "Altitude", this->altitude_sensor_);
+  LOG_SENSOR("  ", "Satellites", this->satellites_sensor_);
+  LOG_SENSOR("  ", "HDOP", this->hdop_sensor_);
+}
+
 void GPS::update() {
   if (this->latitude_sensor_ != nullptr)
     this->latitude_sensor_->publish_state(this->latitude_);
@@ -34,40 +45,45 @@ void GPS::update() {
 }
 
 void GPS::loop() {
-  while (this->available() && !this->has_time_) {
+  while (this->available() > 0 && !this->has_time_) {
     if (this->tiny_gps_.encode(this->read())) {
-      if (tiny_gps_.location.isUpdated()) {
-        this->latitude_ = tiny_gps_.location.lat();
-        this->longitude_ = tiny_gps_.location.lng();
+      if (this->tiny_gps_.location.isUpdated()) {
+        this->latitude_ = this->tiny_gps_.location.lat();
+        this->longitude_ = this->tiny_gps_.location.lng();
 
         ESP_LOGD(TAG, "Location:");
-        ESP_LOGD(TAG, "  Lat: %f", this->latitude_);
-        ESP_LOGD(TAG, "  Lon: %f", this->longitude_);
+        ESP_LOGD(TAG, "  Lat: %.6f °", this->latitude_);
+        ESP_LOGD(TAG, "  Lon: %.6f °", this->longitude_);
       }
 
-      if (tiny_gps_.speed.isUpdated()) {
-        this->speed_ = tiny_gps_.speed.kmph();
+      if (this->tiny_gps_.speed.isUpdated()) {
+        this->speed_ = this->tiny_gps_.speed.kmph();
         ESP_LOGD(TAG, "Speed: %.3f km/h", this->speed_);
       }
-      if (tiny_gps_.course.isUpdated()) {
-        this->course_ = tiny_gps_.course.deg();
+
+      if (this->tiny_gps_.course.isUpdated()) {
+        this->course_ = this->tiny_gps_.course.deg();
         ESP_LOGD(TAG, "Course: %.2f °", this->course_);
       }
-      if (tiny_gps_.altitude.isUpdated()) {
-        this->altitude_ = tiny_gps_.altitude.meters();
+
+      if (this->tiny_gps_.altitude.isUpdated()) {
+        this->altitude_ = this->tiny_gps_.altitude.meters();
         ESP_LOGD(TAG, "Altitude: %.2f m", this->altitude_);
       }
-      if (tiny_gps_.satellites.isUpdated()) {
-        this->satellites_ = tiny_gps_.satellites.value();
+
+      if (this->tiny_gps_.satellites.isUpdated()) {
+        this->satellites_ = this->tiny_gps_.satellites.value();
         ESP_LOGD(TAG, "Satellites: %d", this->satellites_);
       }
-      if (tiny_gps_.hdop.isUpdated()) {
-        this->hdop_ = tiny_gps_.hdop.hdop();
+
+      if (this->tiny_gps_.hdop.isUpdated()) {
+        this->hdop_ = this->tiny_gps_.hdop.hdop();
         ESP_LOGD(TAG, "HDOP: %.3f", this->hdop_);
       }
 
-      for (auto *listener : this->listeners_)
+      for (auto *listener : this->listeners_) {
         listener->on_update(this->tiny_gps_);
+      }
     }
   }
 }

--- a/esphome/components/gps/gps.h
+++ b/esphome/components/gps/gps.h
@@ -5,7 +5,7 @@
 #include "esphome/core/component.h"
 #include "esphome/components/uart/uart.h"
 #include "esphome/components/sensor/sensor.h"
-#include <TinyGPS++.h>
+#include <TinyGPSPlus.h>
 
 #include <vector>
 
@@ -27,13 +27,13 @@ class GPSListener {
 
 class GPS : public PollingComponent, public uart::UARTDevice {
  public:
-  void set_latitude_sensor(sensor::Sensor *latitude_sensor) { latitude_sensor_ = latitude_sensor; }
-  void set_longitude_sensor(sensor::Sensor *longitude_sensor) { longitude_sensor_ = longitude_sensor; }
-  void set_speed_sensor(sensor::Sensor *speed_sensor) { speed_sensor_ = speed_sensor; }
-  void set_course_sensor(sensor::Sensor *course_sensor) { course_sensor_ = course_sensor; }
-  void set_altitude_sensor(sensor::Sensor *altitude_sensor) { altitude_sensor_ = altitude_sensor; }
-  void set_satellites_sensor(sensor::Sensor *satellites_sensor) { satellites_sensor_ = satellites_sensor; }
-  void set_hdop_sensor(sensor::Sensor *hdop_sensor) { hdop_sensor_ = hdop_sensor; }
+  void set_latitude_sensor(sensor::Sensor *latitude_sensor) { this->latitude_sensor_ = latitude_sensor; }
+  void set_longitude_sensor(sensor::Sensor *longitude_sensor) { this->longitude_sensor_ = longitude_sensor; }
+  void set_speed_sensor(sensor::Sensor *speed_sensor) { this->speed_sensor_ = speed_sensor; }
+  void set_course_sensor(sensor::Sensor *course_sensor) { this->course_sensor_ = course_sensor; }
+  void set_altitude_sensor(sensor::Sensor *altitude_sensor) { this->altitude_sensor_ = altitude_sensor; }
+  void set_satellites_sensor(sensor::Sensor *satellites_sensor) { this->satellites_sensor_ = satellites_sensor; }
+  void set_hdop_sensor(sensor::Sensor *hdop_sensor) { this->hdop_sensor_ = hdop_sensor; }
 
   void register_listener(GPSListener *listener) {
     listener->parent_ = this;
@@ -41,19 +41,20 @@ class GPS : public PollingComponent, public uart::UARTDevice {
   }
   float get_setup_priority() const override { return setup_priority::HARDWARE; }
 
+  void dump_config() override;
   void loop() override;
   void update() override;
 
   TinyGPSPlus &get_tiny_gps() { return this->tiny_gps_; }
 
  protected:
-  float latitude_ = NAN;
-  float longitude_ = NAN;
-  float speed_ = NAN;
-  float course_ = NAN;
-  float altitude_ = NAN;
-  int satellites_ = 0;
-  double hdop_ = NAN;
+  float latitude_{NAN};
+  float longitude_{NAN};
+  float speed_{NAN};
+  float course_{NAN};
+  float altitude_{NAN};
+  uint16_t satellites_{0};
+  float hdop_{NAN};
 
   sensor::Sensor *latitude_sensor_{nullptr};
   sensor::Sensor *longitude_sensor_{nullptr};

--- a/esphome/components/gree/climate.py
+++ b/esphome/components/gree/climate.py
@@ -21,7 +21,7 @@ MODELS = {
     "yag": Model.GREE_YAG,
 }
 
-CONFIG_SCHEMA = climate_ir.climare_ir_with_receiver_schema(GreeClimate).extend(
+CONFIG_SCHEMA = climate_ir.climate_ir_with_receiver_schema(GreeClimate).extend(
     {
         cv.Required(CONF_MODEL): cv.enum(MODELS),
     }

--- a/esphome/components/growatt_solar/growatt_solar.cpp
+++ b/esphome/components/growatt_solar/growatt_solar.cpp
@@ -1,5 +1,6 @@
 #include "growatt_solar.h"
 #include "esphome/core/log.h"
+#include "esphome/core/application.h"
 
 namespace esphome {
 namespace growatt_solar {
@@ -18,7 +19,7 @@ void GrowattSolar::loop() {
 
 void GrowattSolar::update() {
   // If our last send has had no reply yet, and it wasn't that long ago, do nothing.
-  uint32_t now = millis();
+  const uint32_t now = App.get_loop_component_start_time();
   if (now - this->last_send_ < this->get_update_interval() / 2) {
     return;
   }

--- a/esphome/components/heatpumpir/climate.py
+++ b/esphome/components/heatpumpir/climate.py
@@ -97,7 +97,7 @@ VERTICAL_DIRECTIONS = {
 }
 
 CONFIG_SCHEMA = cv.All(
-    climate_ir.climare_ir_with_receiver_schema(HeatpumpIRClimate).extend(
+    climate_ir.climate_ir_with_receiver_schema(HeatpumpIRClimate).extend(
         {
             cv.Required(CONF_PROTOCOL): cv.enum(PROTOCOLS),
             cv.Required(CONF_HORIZONTAL_DEFAULT): cv.enum(HORIZONTAL_DIRECTIONS),

--- a/esphome/components/hitachi_ac344/climate.py
+++ b/esphome/components/hitachi_ac344/climate.py
@@ -6,7 +6,7 @@ AUTO_LOAD = ["climate_ir"]
 hitachi_ac344_ns = cg.esphome_ns.namespace("hitachi_ac344")
 HitachiClimate = hitachi_ac344_ns.class_("HitachiClimate", climate_ir.ClimateIR)
 
-CONFIG_SCHEMA = climate_ir.climare_ir_with_receiver_schema(HitachiClimate)
+CONFIG_SCHEMA = climate_ir.climate_ir_with_receiver_schema(HitachiClimate)
 
 
 async def to_code(config):

--- a/esphome/components/hitachi_ac424/climate.py
+++ b/esphome/components/hitachi_ac424/climate.py
@@ -6,7 +6,7 @@ AUTO_LOAD = ["climate_ir"]
 hitachi_ac424_ns = cg.esphome_ns.namespace("hitachi_ac424")
 HitachiClimate = hitachi_ac424_ns.class_("HitachiClimate", climate_ir.ClimateIR)
 
-CONFIG_SCHEMA = climate_ir.climare_ir_with_receiver_schema(HitachiClimate)
+CONFIG_SCHEMA = climate_ir.climate_ir_with_receiver_schema(HitachiClimate)
 
 
 async def to_code(config):

--- a/esphome/components/hte501/sensor.py
+++ b/esphome/components/hte501/sensor.py
@@ -25,13 +25,13 @@ CONFIG_SCHEMA = (
     cv.Schema(
         {
             cv.GenerateID(): cv.declare_id(HTE501Component),
-            cv.Required(CONF_TEMPERATURE): sensor.sensor_schema(
+            cv.Optional(CONF_TEMPERATURE): sensor.sensor_schema(
                 unit_of_measurement=UNIT_CELSIUS,
                 accuracy_decimals=1,
                 device_class=DEVICE_CLASS_TEMPERATURE,
                 state_class=STATE_CLASS_MEASUREMENT,
             ),
-            cv.Required(CONF_HUMIDITY): sensor.sensor_schema(
+            cv.Optional(CONF_HUMIDITY): sensor.sensor_schema(
                 unit_of_measurement=UNIT_PERCENT,
                 accuracy_decimals=1,
                 device_class=DEVICE_CLASS_HUMIDITY,
@@ -49,10 +49,10 @@ async def to_code(config):
     await cg.register_component(var, config)
     await i2c.register_i2c_device(var, config)
 
-    if CONF_TEMPERATURE in config:
-        sens = await sensor.new_sensor(config[CONF_TEMPERATURE])
+    if temperature := config.get(CONF_TEMPERATURE):
+        sens = await sensor.new_sensor(temperature)
         cg.add(var.set_temperature_sensor(sens))
 
-    if CONF_HUMIDITY in config:
-        sens = await sensor.new_sensor(config[CONF_HUMIDITY])
+    if humidity := config.get(CONF_HUMIDITY):
+        sens = await sensor.new_sensor(humidity)
         cg.add(var.set_humidity_sensor(sens))

--- a/esphome/components/hyt271/sensor.py
+++ b/esphome/components/hyt271/sensor.py
@@ -23,13 +23,13 @@ CONFIG_SCHEMA = (
     cv.Schema(
         {
             cv.GenerateID(): cv.declare_id(HYT271Component),
-            cv.Required(CONF_TEMPERATURE): sensor.sensor_schema(
+            cv.Optional(CONF_TEMPERATURE): sensor.sensor_schema(
                 unit_of_measurement=UNIT_CELSIUS,
                 accuracy_decimals=1,
                 device_class=DEVICE_CLASS_TEMPERATURE,
                 state_class=STATE_CLASS_MEASUREMENT,
             ),
-            cv.Required(CONF_HUMIDITY): sensor.sensor_schema(
+            cv.Optional(CONF_HUMIDITY): sensor.sensor_schema(
                 unit_of_measurement=UNIT_PERCENT,
                 accuracy_decimals=1,
                 device_class=DEVICE_CLASS_HUMIDITY,
@@ -47,10 +47,10 @@ async def to_code(config):
     await cg.register_component(var, config)
     await i2c.register_i2c_device(var, config)
 
-    if CONF_TEMPERATURE in config:
-        sens = await sensor.new_sensor(config[CONF_TEMPERATURE])
+    if temperature := config.get(CONF_TEMPERATURE):
+        sens = await sensor.new_sensor(temperature)
         cg.add(var.set_temperature(sens))
 
-    if CONF_HUMIDITY in config:
-        sens = await sensor.new_sensor(config[CONF_HUMIDITY])
+    if humidity := config.get(CONF_HUMIDITY):
+        sens = await sensor.new_sensor(humidity)
         cg.add(var.set_humidity(sens))

--- a/esphome/components/kuntze/kuntze.cpp
+++ b/esphome/components/kuntze/kuntze.cpp
@@ -1,5 +1,6 @@
 #include "kuntze.h"
 #include "esphome/core/log.h"
+#include "esphome/core/application.h"
 
 namespace esphome {
 namespace kuntze {
@@ -60,7 +61,7 @@ void Kuntze::on_modbus_data(const std::vector<uint8_t> &data) {
 }
 
 void Kuntze::loop() {
-  uint32_t now = millis();
+  uint32_t now = App.get_loop_component_start_time();
   // timeout after 15 seconds
   if (this->waiting_ && (now - this->last_send_ > 15000)) {
     ESP_LOGW(TAG, "timed out waiting for response");

--- a/esphome/components/logger/__init__.py
+++ b/esphome/components/logger/__init__.py
@@ -254,6 +254,7 @@ async def to_code(config):
         config[CONF_TX_BUFFER_SIZE],
     )
     if CORE.is_esp32:
+        cg.add(log.create_pthread_key())
         task_log_buffer_size = config[CONF_TASK_LOG_BUFFER_SIZE]
         if task_log_buffer_size > 0:
             cg.add_define("USE_ESPHOME_TASK_LOG_BUFFER")

--- a/esphome/components/matrix_keypad/matrix_keypad.cpp
+++ b/esphome/components/matrix_keypad/matrix_keypad.cpp
@@ -1,5 +1,6 @@
 #include "matrix_keypad.h"
 #include "esphome/core/log.h"
+#include "esphome/core/application.h"
 
 namespace esphome {
 namespace matrix_keypad {
@@ -28,7 +29,7 @@ void MatrixKeypad::setup() {
 void MatrixKeypad::loop() {
   static uint32_t active_start = 0;
   static int active_key = -1;
-  uint32_t now = millis();
+  uint32_t now = App.get_loop_component_start_time();
   int key = -1;
   bool error = false;
   int pos = 0, row, col;

--- a/esphome/components/max7219digit/max7219digit.cpp
+++ b/esphome/components/max7219digit/max7219digit.cpp
@@ -2,6 +2,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/helpers.h"
 #include "esphome/core/hal.h"
+#include "esphome/core/application.h"
 #include "max7219font.h"
 
 #include <algorithm>
@@ -63,7 +64,7 @@ void MAX7219Component::dump_config() {
 }
 
 void MAX7219Component::loop() {
-  const uint32_t now = millis();
+  const uint32_t now = App.get_loop_component_start_time();
   const uint32_t millis_since_last_scroll = now - this->last_scroll_;
   const size_t first_line_size = this->max_displaybuffer_[0].size();
   // check if the buffer has shrunk past the current position since last update

--- a/esphome/components/mhz19/sensor.py
+++ b/esphome/components/mhz19/sensor.py
@@ -32,7 +32,7 @@ CONFIG_SCHEMA = (
     cv.Schema(
         {
             cv.GenerateID(): cv.declare_id(MHZ19Component),
-            cv.Required(CONF_CO2): sensor.sensor_schema(
+            cv.Optional(CONF_CO2): sensor.sensor_schema(
                 unit_of_measurement=UNIT_PARTS_PER_MILLION,
                 icon=ICON_MOLECULE_CO2,
                 accuracy_decimals=0,
@@ -61,16 +61,20 @@ async def to_code(config):
     await cg.register_component(var, config)
     await uart.register_uart_device(var, config)
 
-    if CONF_CO2 in config:
-        sens = await sensor.new_sensor(config[CONF_CO2])
+    if co2 := config.get(CONF_CO2):
+        sens = await sensor.new_sensor(co2)
         cg.add(var.set_co2_sensor(sens))
 
-    if CONF_TEMPERATURE in config:
-        sens = await sensor.new_sensor(config[CONF_TEMPERATURE])
+    if temperature := config.get(CONF_TEMPERATURE):
+        sens = await sensor.new_sensor(temperature)
         cg.add(var.set_temperature_sensor(sens))
 
-    if CONF_AUTOMATIC_BASELINE_CALIBRATION in config:
-        cg.add(var.set_abc_enabled(config[CONF_AUTOMATIC_BASELINE_CALIBRATION]))
+    if (
+        automatic_baseline_calibration := config.get(
+            CONF_AUTOMATIC_BASELINE_CALIBRATION
+        )
+    ) is not None:
+        cg.add(var.set_abc_enabled(automatic_baseline_calibration))
 
     cg.add(var.set_warmup_seconds(config[CONF_WARMUP_TIME]))
 

--- a/esphome/components/midea_ir/climate.py
+++ b/esphome/components/midea_ir/climate.py
@@ -10,7 +10,7 @@ midea_ir_ns = cg.esphome_ns.namespace("midea_ir")
 MideaIR = midea_ir_ns.class_("MideaIR", climate_ir.ClimateIR)
 
 
-CONFIG_SCHEMA = climate_ir.climare_ir_with_receiver_schema(MideaIR).extend(
+CONFIG_SCHEMA = climate_ir.climate_ir_with_receiver_schema(MideaIR).extend(
     {
         cv.Optional(CONF_USE_FAHRENHEIT, default=False): cv.boolean,
     }

--- a/esphome/components/mitsubishi/climate.py
+++ b/esphome/components/mitsubishi/climate.py
@@ -43,7 +43,7 @@ VERTICAL_DIRECTIONS = {
 }
 
 
-CONFIG_SCHEMA = climate_ir.climare_ir_with_receiver_schema(MitsubishiClimate).extend(
+CONFIG_SCHEMA = climate_ir.climate_ir_with_receiver_schema(MitsubishiClimate).extend(
     {
         cv.Optional(CONF_SET_FAN_MODE, default="3levels"): cv.enum(SETFANMODE),
         cv.Optional(CONF_SUPPORTS_DRY, default=False): cv.boolean,

--- a/esphome/components/modbus/modbus.cpp
+++ b/esphome/components/modbus/modbus.cpp
@@ -1,6 +1,7 @@
 #include "modbus.h"
 #include "esphome/core/log.h"
 #include "esphome/core/helpers.h"
+#include "esphome/core/application.h"
 
 namespace esphome {
 namespace modbus {
@@ -13,7 +14,7 @@ void Modbus::setup() {
   }
 }
 void Modbus::loop() {
-  const uint32_t now = millis();
+  const uint32_t now = App.get_loop_component_start_time();
 
   while (this->available()) {
     uint8_t byte;

--- a/esphome/components/mqtt/mqtt_client.cpp
+++ b/esphome/components/mqtt/mqtt_client.cpp
@@ -345,7 +345,7 @@ void MQTTClientComponent::loop() {
     this->disconnect_reason_.reset();
   }
 
-  const uint32_t now = millis();
+  const uint32_t now = App.get_loop_component_start_time();
 
   switch (this->state_) {
     case MQTT_CLIENT_DISABLED:

--- a/esphome/components/ms5611/sensor.py
+++ b/esphome/components/ms5611/sensor.py
@@ -24,13 +24,13 @@ CONFIG_SCHEMA = (
     cv.Schema(
         {
             cv.GenerateID(): cv.declare_id(MS5611Component),
-            cv.Required(CONF_TEMPERATURE): sensor.sensor_schema(
+            cv.Optional(CONF_TEMPERATURE): sensor.sensor_schema(
                 unit_of_measurement=UNIT_CELSIUS,
                 accuracy_decimals=1,
                 device_class=DEVICE_CLASS_TEMPERATURE,
                 state_class=STATE_CLASS_MEASUREMENT,
             ),
-            cv.Required(CONF_PRESSURE): sensor.sensor_schema(
+            cv.Optional(CONF_PRESSURE): sensor.sensor_schema(
                 unit_of_measurement=UNIT_HECTOPASCAL,
                 icon=ICON_GAUGE,
                 accuracy_decimals=1,
@@ -49,10 +49,10 @@ async def to_code(config):
     await cg.register_component(var, config)
     await i2c.register_i2c_device(var, config)
 
-    if CONF_TEMPERATURE in config:
-        sens = await sensor.new_sensor(config[CONF_TEMPERATURE])
+    if temperature := config.get(CONF_TEMPERATURE):
+        sens = await sensor.new_sensor(temperature)
         cg.add(var.set_temperature_sensor(sens))
 
-    if CONF_PRESSURE in config:
-        sens = await sensor.new_sensor(config[CONF_PRESSURE])
+    if pressure := config.get(CONF_PRESSURE):
+        sens = await sensor.new_sensor(pressure)
         cg.add(var.set_pressure_sensor(sens))

--- a/esphome/components/ms8607/sensor.py
+++ b/esphome/components/ms8607/sensor.py
@@ -29,19 +29,19 @@ CONFIG_SCHEMA = (
     cv.Schema(
         {
             cv.GenerateID(): cv.declare_id(MS8607Component),
-            cv.Required(CONF_TEMPERATURE): sensor.sensor_schema(
+            cv.Optional(CONF_TEMPERATURE): sensor.sensor_schema(
                 unit_of_measurement=UNIT_CELSIUS,
                 accuracy_decimals=2,  # Resolution: 0.01
                 device_class=DEVICE_CLASS_TEMPERATURE,
                 state_class=STATE_CLASS_MEASUREMENT,
             ),
-            cv.Required(CONF_PRESSURE): sensor.sensor_schema(
+            cv.Optional(CONF_PRESSURE): sensor.sensor_schema(
                 unit_of_measurement=UNIT_HECTOPASCAL,
                 accuracy_decimals=2,  # Resolution: 0.016
                 device_class=DEVICE_CLASS_PRESSURE,
                 state_class=STATE_CLASS_MEASUREMENT,
             ),
-            cv.Required(CONF_HUMIDITY): sensor.sensor_schema(
+            cv.Optional(CONF_HUMIDITY): sensor.sensor_schema(
                 unit_of_measurement=UNIT_PERCENT,
                 accuracy_decimals=2,  # Resolution: 0.04
                 device_class=DEVICE_CLASS_HUMIDITY,

--- a/esphome/components/noblex/climate.py
+++ b/esphome/components/noblex/climate.py
@@ -6,7 +6,7 @@ AUTO_LOAD = ["climate_ir"]
 noblex_ns = cg.esphome_ns.namespace("noblex")
 NoblexClimate = noblex_ns.class_("NoblexClimate", climate_ir.ClimateIR)
 
-CONFIG_SCHEMA = climate_ir.climare_ir_with_receiver_schema(NoblexClimate)
+CONFIG_SCHEMA = climate_ir.climate_ir_with_receiver_schema(NoblexClimate)
 
 
 async def to_code(config):

--- a/esphome/components/pmsx003/pmsx003.cpp
+++ b/esphome/components/pmsx003/pmsx003.cpp
@@ -1,5 +1,6 @@
 #include "pmsx003.h"
 #include "esphome/core/log.h"
+#include "esphome/core/application.h"
 
 namespace esphome {
 namespace pmsx003 {
@@ -42,7 +43,7 @@ void PMSX003Component::dump_config() {
 }
 
 void PMSX003Component::loop() {
-  const uint32_t now = millis();
+  const uint32_t now = App.get_loop_component_start_time();
 
   // If we update less often than it takes the device to stabilise, spin the fan down
   // rather than running it constantly. It does take some time to stabilise, so we

--- a/esphome/components/pzem004t/pzem004t.cpp
+++ b/esphome/components/pzem004t/pzem004t.cpp
@@ -1,5 +1,6 @@
 #include "pzem004t.h"
 #include "esphome/core/log.h"
+#include "esphome/core/application.h"
 #include <cinttypes>
 
 namespace esphome {
@@ -16,7 +17,7 @@ void PZEM004T::setup() {
 }
 
 void PZEM004T::loop() {
-  const uint32_t now = millis();
+  const uint32_t now = App.get_loop_component_start_time();
   if (now - this->last_read_ > 500 && this->available() < 7) {
     while (this->available())
       this->read();

--- a/esphome/components/rf_bridge/rf_bridge.cpp
+++ b/esphome/components/rf_bridge/rf_bridge.cpp
@@ -1,5 +1,6 @@
 #include "rf_bridge.h"
 #include "esphome/core/log.h"
+#include "esphome/core/application.h"
 #include <cinttypes>
 #include <cstring>
 
@@ -128,7 +129,7 @@ void RFBridgeComponent::write_byte_str_(const std::string &codes) {
 }
 
 void RFBridgeComponent::loop() {
-  const uint32_t now = millis();
+  const uint32_t now = App.get_loop_component_start_time();
   if (now - this->last_bridge_byte_ > 50) {
     this->rx_buffer_.clear();
     this->last_bridge_byte_ = now;

--- a/esphome/components/sds011/sds011.cpp
+++ b/esphome/components/sds011/sds011.cpp
@@ -1,5 +1,6 @@
 #include "sds011.h"
 #include "esphome/core/log.h"
+#include "esphome/core/application.h"
 
 namespace esphome {
 namespace sds011 {
@@ -75,7 +76,7 @@ void SDS011Component::dump_config() {
 }
 
 void SDS011Component::loop() {
-  const uint32_t now = millis();
+  const uint32_t now = App.get_loop_component_start_time();
   if ((now - this->last_transmission_ >= 500) && this->data_index_) {
     // last transmission too long ago. Reset RX index.
     ESP_LOGV(TAG, "Last transmission too long ago. Reset RX index.");

--- a/esphome/components/senseair/sensor.py
+++ b/esphome/components/senseair/sensor.py
@@ -38,7 +38,7 @@ CONFIG_SCHEMA = (
     cv.Schema(
         {
             cv.GenerateID(): cv.declare_id(SenseAirComponent),
-            cv.Required(CONF_CO2): sensor.sensor_schema(
+            cv.Optional(CONF_CO2): sensor.sensor_schema(
                 unit_of_measurement=UNIT_PARTS_PER_MILLION,
                 icon=ICON_MOLECULE_CO2,
                 accuracy_decimals=0,
@@ -57,8 +57,8 @@ async def to_code(config):
     await cg.register_component(var, config)
     await uart.register_uart_device(var, config)
 
-    if CONF_CO2 in config:
-        sens = await sensor.new_sensor(config[CONF_CO2])
+    if co2 := config.get(CONF_CO2):
+        sens = await sensor.new_sensor(co2)
         cg.add(var.set_co2_sensor(sens))
 
 

--- a/esphome/components/sgp30/sensor.py
+++ b/esphome/components/sgp30/sensor.py
@@ -37,14 +37,14 @@ CONFIG_SCHEMA = (
     cv.Schema(
         {
             cv.GenerateID(): cv.declare_id(SGP30Component),
-            cv.Required(CONF_ECO2): sensor.sensor_schema(
+            cv.Optional(CONF_ECO2): sensor.sensor_schema(
                 unit_of_measurement=UNIT_PARTS_PER_MILLION,
                 icon=ICON_MOLECULE_CO2,
                 accuracy_decimals=0,
                 device_class=DEVICE_CLASS_CARBON_DIOXIDE,
                 state_class=STATE_CLASS_MEASUREMENT,
             ),
-            cv.Required(CONF_TVOC): sensor.sensor_schema(
+            cv.Optional(CONF_TVOC): sensor.sensor_schema(
                 unit_of_measurement=UNIT_PARTS_PER_BILLION,
                 icon=ICON_RADIATOR,
                 accuracy_decimals=0,
@@ -86,32 +86,30 @@ async def to_code(config):
     await cg.register_component(var, config)
     await i2c.register_i2c_device(var, config)
 
-    if CONF_ECO2 in config:
-        sens = await sensor.new_sensor(config[CONF_ECO2])
+    if eco2_config := config.get(CONF_ECO2):
+        sens = await sensor.new_sensor(eco2_config)
         cg.add(var.set_eco2_sensor(sens))
 
-    if CONF_TVOC in config:
-        sens = await sensor.new_sensor(config[CONF_TVOC])
+    if tvoc_config := config.get(CONF_TVOC):
+        sens = await sensor.new_sensor(tvoc_config)
         cg.add(var.set_tvoc_sensor(sens))
 
-    if CONF_ECO2_BASELINE in config:
-        sens = await sensor.new_sensor(config[CONF_ECO2_BASELINE])
+    if eco2_baseline_config := config.get(CONF_ECO2_BASELINE):
+        sens = await sensor.new_sensor(eco2_baseline_config)
         cg.add(var.set_eco2_baseline_sensor(sens))
 
-    if CONF_TVOC_BASELINE in config:
-        sens = await sensor.new_sensor(config[CONF_TVOC_BASELINE])
+    if tvoc_baseline_config := config.get(CONF_TVOC_BASELINE):
+        sens = await sensor.new_sensor(tvoc_baseline_config)
         cg.add(var.set_tvoc_baseline_sensor(sens))
 
-    if CONF_STORE_BASELINE in config:
-        cg.add(var.set_store_baseline(config[CONF_STORE_BASELINE]))
+    if (store_baseline := config.get(CONF_STORE_BASELINE)) is not None:
+        cg.add(var.set_store_baseline(store_baseline))
 
-    if CONF_BASELINE in config:
-        baseline_config = config[CONF_BASELINE]
+    if baseline_config := config.get(CONF_BASELINE):
         cg.add(var.set_eco2_baseline(baseline_config[CONF_ECO2_BASELINE]))
         cg.add(var.set_tvoc_baseline(baseline_config[CONF_TVOC_BASELINE]))
 
-    if CONF_COMPENSATION in config:
-        compensation_config = config[CONF_COMPENSATION]
+    if compensation_config := config.get(CONF_COMPENSATION):
         sens = await cg.get_variable(compensation_config[CONF_HUMIDITY_SOURCE])
         cg.add(var.set_humidity_sensor(sens))
         sens = await cg.get_variable(compensation_config[CONF_TEMPERATURE_SOURCE])

--- a/esphome/components/shtcx/sensor.py
+++ b/esphome/components/shtcx/sensor.py
@@ -26,13 +26,13 @@ CONFIG_SCHEMA = (
     cv.Schema(
         {
             cv.GenerateID(): cv.declare_id(SHTCXComponent),
-            cv.Required(CONF_TEMPERATURE): sensor.sensor_schema(
+            cv.Optional(CONF_TEMPERATURE): sensor.sensor_schema(
                 unit_of_measurement=UNIT_CELSIUS,
                 accuracy_decimals=1,
                 device_class=DEVICE_CLASS_TEMPERATURE,
                 state_class=STATE_CLASS_MEASUREMENT,
             ),
-            cv.Required(CONF_HUMIDITY): sensor.sensor_schema(
+            cv.Optional(CONF_HUMIDITY): sensor.sensor_schema(
                 unit_of_measurement=UNIT_PERCENT,
                 accuracy_decimals=1,
                 device_class=DEVICE_CLASS_HUMIDITY,
@@ -50,10 +50,10 @@ async def to_code(config):
     await cg.register_component(var, config)
     await i2c.register_i2c_device(var, config)
 
-    if CONF_TEMPERATURE in config:
-        sens = await sensor.new_sensor(config[CONF_TEMPERATURE])
+    if temperature := config.get(CONF_TEMPERATURE):
+        sens = await sensor.new_sensor(temperature)
         cg.add(var.set_temperature_sensor(sens))
 
-    if CONF_HUMIDITY in config:
-        sens = await sensor.new_sensor(config[CONF_HUMIDITY])
+    if humidity := config.get(CONF_HUMIDITY):
+        sens = await sensor.new_sensor(humidity)
         cg.add(var.set_humidity_sensor(sens))

--- a/esphome/components/slow_pwm/slow_pwm_output.cpp
+++ b/esphome/components/slow_pwm/slow_pwm_output.cpp
@@ -1,5 +1,6 @@
 #include "slow_pwm_output.h"
 #include "esphome/core/log.h"
+#include "esphome/core/application.h"
 
 namespace esphome {
 namespace slow_pwm {
@@ -39,7 +40,7 @@ void SlowPWMOutput::set_output_state_(bool new_state) {
 }
 
 void SlowPWMOutput::loop() {
-  uint32_t now = millis();
+  uint32_t now = App.get_loop_component_start_time();
   float scaled_state = this->state_ * this->period_;
 
   if (now - this->period_start_time_ >= this->period_) {

--- a/esphome/components/sprinkler/sprinkler.cpp
+++ b/esphome/components/sprinkler/sprinkler.cpp
@@ -20,7 +20,7 @@ SprinklerSwitch::SprinklerSwitch(switch_::Switch *off_switch, switch_::Switch *o
 bool SprinklerSwitch::is_latching_valve() { return (this->off_switch_ != nullptr) && (this->on_switch_ != nullptr); }
 
 void SprinklerSwitch::loop() {
-  if ((this->pinned_millis_) && (millis() > this->pinned_millis_ + this->pulse_duration_)) {
+  if ((this->pinned_millis_) && (App.get_loop_component_start_time() > this->pinned_millis_ + this->pulse_duration_)) {
     this->pinned_millis_ = 0;  // reset tracker
     if (this->off_switch_->state) {
       this->off_switch_->turn_off();
@@ -148,22 +148,23 @@ SprinklerValveOperator::SprinklerValveOperator(SprinklerValve *valve, Sprinkler 
     : controller_(controller), valve_(valve) {}
 
 void SprinklerValveOperator::loop() {
-  if (millis() >= this->start_millis_) {  // dummy check
+  uint32_t now = App.get_loop_component_start_time();
+  if (now >= this->start_millis_) {  // dummy check
     switch (this->state_) {
       case STARTING:
-        if (millis() > (this->start_millis_ + this->start_delay_)) {
+        if (now > (this->start_millis_ + this->start_delay_)) {
           this->run_();  // start_delay_ has been exceeded, so ensure both valves are on and update the state
         }
         break;
 
       case ACTIVE:
-        if (millis() > (this->start_millis_ + this->start_delay_ + this->run_duration_)) {
+        if (now > (this->start_millis_ + this->start_delay_ + this->run_duration_)) {
           this->stop();  // start_delay_ + run_duration_ has been exceeded, start shutting down
         }
         break;
 
       case STOPPING:
-        if (millis() > (this->stop_millis_ + this->stop_delay_)) {
+        if (now > (this->stop_millis_ + this->stop_delay_)) {
           this->kill_();  // stop_delay_has been exceeded, ensure all valves are off
         }
         break;

--- a/esphome/components/t6615/sensor.py
+++ b/esphome/components/t6615/sensor.py
@@ -19,7 +19,7 @@ CONFIG_SCHEMA = (
     cv.Schema(
         {
             cv.GenerateID(): cv.declare_id(T6615Component),
-            cv.Required(CONF_CO2): sensor.sensor_schema(
+            cv.Optional(CONF_CO2): sensor.sensor_schema(
                 unit_of_measurement=UNIT_PARTS_PER_MILLION,
                 accuracy_decimals=0,
                 device_class=DEVICE_CLASS_CARBON_DIOXIDE,
@@ -41,6 +41,6 @@ async def to_code(config):
     await cg.register_component(var, config)
     await uart.register_uart_device(var, config)
 
-    if CONF_CO2 in config:
-        sens = await sensor.new_sensor(config[CONF_CO2])
+    if co2 := config.get(CONF_CO2):
+        sens = await sensor.new_sensor(co2)
         cg.add(var.set_co2_sensor(sens))

--- a/esphome/components/t6615/t6615.cpp
+++ b/esphome/components/t6615/t6615.cpp
@@ -63,7 +63,8 @@ void T6615Component::loop() {
     case T6615Command::GET_PPM: {
       const uint16_t ppm = encode_uint16(response_buffer[3], response_buffer[4]);
       ESP_LOGD(TAG, "T6615 Received CO₂=%uppm", ppm);
-      this->co2_sensor_->publish_state(ppm);
+      if (this->co2_sensor_ != nullptr)
+        this->co2_sensor_->publish_state(ppm);
       break;
     }
     default:

--- a/esphome/components/tcl112/climate.py
+++ b/esphome/components/tcl112/climate.py
@@ -7,7 +7,7 @@ CODEOWNERS = ["@glmnet"]
 tcl112_ns = cg.esphome_ns.namespace("tcl112")
 Tcl112Climate = tcl112_ns.class_("Tcl112Climate", climate_ir.ClimateIR)
 
-CONFIG_SCHEMA = climate_ir.climare_ir_with_receiver_schema(Tcl112Climate)
+CONFIG_SCHEMA = climate_ir.climate_ir_with_receiver_schema(Tcl112Climate)
 
 
 async def to_code(config):

--- a/esphome/components/time_based/time_based_cover.cpp
+++ b/esphome/components/time_based/time_based_cover.cpp
@@ -1,6 +1,7 @@
 #include "time_based_cover.h"
 #include "esphome/core/log.h"
 #include "esphome/core/hal.h"
+#include "esphome/core/application.h"
 
 namespace esphome {
 namespace time_based {
@@ -26,7 +27,7 @@ void TimeBasedCover::loop() {
   if (this->current_operation == COVER_OPERATION_IDLE)
     return;
 
-  const uint32_t now = millis();
+  const uint32_t now = App.get_loop_component_start_time();
 
   // Recompute position every loop cycle
   this->recompute_position_();

--- a/esphome/components/toshiba/climate.py
+++ b/esphome/components/toshiba/climate.py
@@ -16,7 +16,7 @@ MODELS = {
     "RAC-PT1411HWRU-F": Model.MODEL_RAC_PT1411HWRU_F,
 }
 
-CONFIG_SCHEMA = climate_ir.climare_ir_with_receiver_schema(ToshibaClimate).extend(
+CONFIG_SCHEMA = climate_ir.climate_ir_with_receiver_schema(ToshibaClimate).extend(
     {
         cv.Optional(CONF_MODEL, default="generic"): cv.enum(MODELS, upper=True),
     }

--- a/esphome/components/uart/switch/uart_switch.cpp
+++ b/esphome/components/uart/switch/uart_switch.cpp
@@ -1,5 +1,6 @@
 #include "uart_switch.h"
 #include "esphome/core/log.h"
+#include "esphome/core/application.h"
 
 namespace esphome {
 namespace uart {
@@ -8,7 +9,7 @@ static const char *const TAG = "uart.switch";
 
 void UARTSwitch::loop() {
   if (this->send_every_) {
-    const uint32_t now = millis();
+    const uint32_t now = App.get_loop_component_start_time();
     if (now - this->last_transmission_ > this->send_every_) {
       this->write_command_(this->state);
       this->last_transmission_ = now;

--- a/esphome/components/uponor_smatrix/climate/uponor_smatrix_climate.cpp
+++ b/esphome/components/uponor_smatrix/climate/uponor_smatrix_climate.cpp
@@ -1,6 +1,7 @@
 #include "uponor_smatrix_climate.h"
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
+#include "esphome/core/application.h"
 
 namespace esphome {
 namespace uponor_smatrix {
@@ -13,7 +14,7 @@ void UponorSmatrixClimate::dump_config() {
 }
 
 void UponorSmatrixClimate::loop() {
-  const uint32_t now = millis();
+  const uint32_t now = App.get_loop_component_start_time();
 
   // Publish state after all update packets are processed
   if (this->last_data_ != 0 && (now - this->last_data_ > 100) && this->target_temperature_raw_ != 0) {

--- a/esphome/components/uponor_smatrix/uponor_smatrix.cpp
+++ b/esphome/components/uponor_smatrix/uponor_smatrix.cpp
@@ -1,5 +1,6 @@
 #include "uponor_smatrix.h"
 #include "esphome/core/log.h"
+#include "esphome/core/application.h"
 
 namespace esphome {
 namespace uponor_smatrix {
@@ -35,7 +36,7 @@ void UponorSmatrixComponent::dump_config() {
 }
 
 void UponorSmatrixComponent::loop() {
-  const uint32_t now = millis();
+  const uint32_t now = App.get_loop_component_start_time();
 
   // Discard stale data
   if (!this->rx_buffer_.empty() && (now - this->last_rx_ > 50)) {

--- a/esphome/components/whirlpool/climate.py
+++ b/esphome/components/whirlpool/climate.py
@@ -15,7 +15,7 @@ MODELS = {
     "DG11J1-91": Model.MODEL_DG11J1_91,
 }
 
-CONFIG_SCHEMA = climate_ir.climare_ir_with_receiver_schema(WhirlpoolClimate).extend(
+CONFIG_SCHEMA = climate_ir.climate_ir_with_receiver_schema(WhirlpoolClimate).extend(
     {
         cv.Optional(CONF_MODEL, default="DG11J1-3A"): cv.enum(MODELS, upper=True),
     }

--- a/esphome/components/whynter/climate.py
+++ b/esphome/components/whynter/climate.py
@@ -9,7 +9,7 @@ whynter_ns = cg.esphome_ns.namespace("whynter")
 Whynter = whynter_ns.class_("Whynter", climate_ir.ClimateIR)
 
 
-CONFIG_SCHEMA = climate_ir.climare_ir_with_receiver_schema(Whynter).extend(
+CONFIG_SCHEMA = climate_ir.climate_ir_with_receiver_schema(Whynter).extend(
     {
         cv.Optional(CONF_USE_FAHRENHEIT, default=False): cv.boolean,
     }

--- a/esphome/components/zhlt01/climate.py
+++ b/esphome/components/zhlt01/climate.py
@@ -7,7 +7,7 @@ CODEOWNERS = ["@cfeenstra1024"]
 zhlt01_ns = cg.esphome_ns.namespace("zhlt01")
 ZHLT01Climate = zhlt01_ns.class_("ZHLT01Climate", climate_ir.ClimateIR)
 
-CONFIG_SCHEMA = climate_ir.climare_ir_with_receiver_schema(ZHLT01Climate)
+CONFIG_SCHEMA = climate_ir.climate_ir_with_receiver_schema(ZHLT01Climate)
 
 
 async def to_code(config):

--- a/esphome/config.py
+++ b/esphome/config.py
@@ -28,7 +28,7 @@ import esphome.core.config as core_config
 import esphome.final_validate as fv
 from esphome.helpers import indent
 from esphome.loader import ComponentManifest, get_component, get_platform
-from esphome.log import Fore, color
+from esphome.log import AnsiFore, color
 from esphome.types import ConfigFragmentType, ConfigType
 from esphome.util import OrderedDict, safe_print
 from esphome.voluptuous_schema import ExtraKeysInvalid
@@ -959,7 +959,7 @@ def line_info(config, path, highlight=True):
     if obj:
         mark = obj.start_mark
         source = f"[source {mark.document}:{mark.line + 1}]"
-        return color(Fore.CYAN, source)
+        return color(AnsiFore.CYAN, source)
     return "None"
 
 
@@ -983,7 +983,7 @@ def dump_dict(
     if at_root:
         error = config.get_error_for_path(path)
         if error is not None:
-            ret += f"\n{color(Fore.BOLD_RED, _format_vol_invalid(error, config))}\n"
+            ret += f"\n{color(AnsiFore.BOLD_RED, _format_vol_invalid(error, config))}\n"
 
     if isinstance(conf, (list, tuple)):
         multiline = True
@@ -995,11 +995,11 @@ def dump_dict(
             path_ = path + [i]
             error = config.get_error_for_path(path_)
             if error is not None:
-                ret += f"\n{color(Fore.BOLD_RED, _format_vol_invalid(error, config))}\n"
+                ret += f"\n{color(AnsiFore.BOLD_RED, _format_vol_invalid(error, config))}\n"
 
             sep = "- "
             if config.is_in_error_path(path_):
-                sep = color(Fore.RED, sep)
+                sep = color(AnsiFore.RED, sep)
             msg, _ = dump_dict(config, path_, at_root=False)
             msg = indent(msg)
             inf = line_info(config, path_, highlight=config.is_in_error_path(path_))
@@ -1018,11 +1018,11 @@ def dump_dict(
             path_ = path + [k]
             error = config.get_error_for_path(path_)
             if error is not None:
-                ret += f"\n{color(Fore.BOLD_RED, _format_vol_invalid(error, config))}\n"
+                ret += f"\n{color(AnsiFore.BOLD_RED, _format_vol_invalid(error, config))}\n"
 
             st = f"{k}: "
             if config.is_in_error_path(path_):
-                st = color(Fore.RED, st)
+                st = color(AnsiFore.RED, st)
             msg, m = dump_dict(config, path_, at_root=False)
 
             inf = line_info(config, path_, highlight=config.is_in_error_path(path_))
@@ -1044,7 +1044,7 @@ def dump_dict(
         if len(conf) > 80:
             conf = f"|-\n{indent(conf)}"
         error = config.get_error_for_path(path)
-        col = Fore.BOLD_RED if error else Fore.KEEP
+        col = AnsiFore.BOLD_RED if error else AnsiFore.KEEP
         ret += color(col, str(conf))
     elif isinstance(conf, core.Lambda):
         if is_secret(conf):
@@ -1052,13 +1052,13 @@ def dump_dict(
 
         conf = f"!lambda |-\n{indent(str(conf.value))}"
         error = config.get_error_for_path(path)
-        col = Fore.BOLD_RED if error else Fore.KEEP
+        col = AnsiFore.BOLD_RED if error else AnsiFore.KEEP
         ret += color(col, conf)
     elif conf is None:
         pass
     else:
         error = config.get_error_for_path(path)
-        col = Fore.BOLD_RED if error else Fore.KEEP
+        col = AnsiFore.BOLD_RED if error else AnsiFore.KEEP
         ret += color(col, str(conf))
         multiline = "\n" in ret
 
@@ -1100,13 +1100,13 @@ def read_config(command_line_substitutions):
         if not CORE.verbose:
             res = strip_default_ids(res)
 
-        safe_print(color(Fore.BOLD_RED, "Failed config"))
+        safe_print(color(AnsiFore.BOLD_RED, "Failed config"))
         safe_print("")
         for path, domain in res.output_paths:
             if not res.is_in_error_path(path):
                 continue
 
-            errstr = color(Fore.BOLD_RED, f"{domain}:")
+            errstr = color(AnsiFore.BOLD_RED, f"{domain}:")
             errline = line_info(res, path)
             if errline:
                 errstr += f" {errline}"
@@ -1121,7 +1121,7 @@ def read_config(command_line_substitutions):
             safe_print(indent("\n".join(split_dump[:i])))
 
         for err in res.errors:
-            safe_print(color(Fore.BOLD_RED, err.msg))
+            safe_print(color(AnsiFore.BOLD_RED, err.msg))
             safe_print("")
 
         return None

--- a/esphome/const.py
+++ b/esphome/const.py
@@ -1,6 +1,6 @@
 """Constants used by esphome."""
 
-__version__ = "2025.5.0b2"
+__version__ = "2025.5.0b3"
 
 ALLOWED_NAME_CHARS = "abcdefghijklmnopqrstuvwxyz0123456789-_"
 VALID_SUBSTITUTIONS_CHARACTERS = (

--- a/esphome/core/application.cpp
+++ b/esphome/core/application.cpp
@@ -67,22 +67,32 @@ void Application::loop() {
   uint32_t new_app_state = 0;
 
   this->scheduler.call();
-  this->feed_wdt();
+
+  // Get the initial loop time at the start
+  uint32_t last_op_end_time = millis();
+
+  // Feed WDT with time
+  this->feed_wdt(last_op_end_time);
+
   for (Component *component : this->looping_components_) {
+    // Update the cached time before each component runs
+    this->loop_component_start_time_ = last_op_end_time;
+
     {
       this->set_current_component(component);
-      WarnIfComponentBlockingGuard guard{component};
+      WarnIfComponentBlockingGuard guard{component, last_op_end_time};
       component->call();
+      // Use the finish method to get the current time as the end time
+      last_op_end_time = guard.finish();
     }
     new_app_state |= component->get_component_state();
     this->app_state_ |= new_app_state;
-    this->feed_wdt();
+    this->feed_wdt(last_op_end_time);
   }
   this->app_state_ = new_app_state;
 
-  const uint32_t now = millis();
-
-  auto elapsed = now - this->last_loop_;
+  // Use the last component's end time instead of calling millis() again
+  auto elapsed = last_op_end_time - this->last_loop_;
   if (elapsed >= this->loop_interval_ || HighFrequencyLoopRequester::is_high_frequency()) {
     yield();
   } else {
@@ -94,7 +104,7 @@ void Application::loop() {
     delay_time = std::min(next_schedule, delay_time);
     delay(delay_time);
   }
-  this->last_loop_ = now;
+  this->last_loop_ = last_op_end_time;
 
   if (this->dump_config_at_ < this->components_.size()) {
     if (this->dump_config_at_ == 0) {
@@ -109,10 +119,12 @@ void Application::loop() {
   }
 }
 
-void IRAM_ATTR HOT Application::feed_wdt() {
+void IRAM_ATTR HOT Application::feed_wdt(uint32_t time) {
   static uint32_t last_feed = 0;
-  uint32_t now = micros();
-  if (now - last_feed > 3000) {
+  // Use provided time if available, otherwise get current time
+  uint32_t now = time ? time : millis();
+  // Compare in milliseconds (3ms threshold)
+  if (now - last_feed > 3) {
     arch_feed_wdt();
     last_feed = now;
 #ifdef USE_STATUS_LED

--- a/esphome/core/application.h
+++ b/esphome/core/application.h
@@ -217,6 +217,9 @@ class Application {
 
   std::string get_compilation_time() const { return this->compilation_time_; }
 
+  /// Get the cached time in milliseconds from when the current component started its loop execution
+  inline uint32_t IRAM_ATTR HOT get_loop_component_start_time() const { return this->loop_component_start_time_; }
+
   /** Set the target interval with which to run the loop() calls.
    * If the loop() method takes longer than the target interval, ESPHome won't
    * sleep in loop(), but if the time spent in loop() is small than the target, ESPHome
@@ -236,7 +239,7 @@ class Application {
 
   void schedule_dump_config() { this->dump_config_at_ = 0; }
 
-  void feed_wdt();
+  void feed_wdt(uint32_t time = 0);
 
   void reboot();
 
@@ -551,6 +554,7 @@ class Application {
   size_t dump_config_at_{SIZE_MAX};
   uint32_t app_state_{0};
   Component *current_component_{nullptr};
+  uint32_t loop_component_start_time_{0};
 };
 
 /// Global storage of Application pointer - only one Application can exist.

--- a/esphome/core/component.h
+++ b/esphome/core/component.h
@@ -339,7 +339,11 @@ class PollingComponent : public Component {
 
 class WarnIfComponentBlockingGuard {
  public:
-  WarnIfComponentBlockingGuard(Component *component);
+  WarnIfComponentBlockingGuard(Component *component, uint32_t start_time);
+
+  // Finish the timing operation and return the current time
+  uint32_t finish();
+
   ~WarnIfComponentBlockingGuard();
 
  protected:

--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -229,8 +229,11 @@ void HOT Scheduler::call() {
       //  - timeouts/intervals get added, potentially invalidating vector pointers
       //  - timeouts/intervals get cancelled
       {
-        WarnIfComponentBlockingGuard guard{item->component};
+        uint32_t now_ms = millis();
+        WarnIfComponentBlockingGuard guard{item->component, now_ms};
         item->callback();
+        // Call finish to ensure blocking time is properly calculated and reported
+        guard.finish();
       }
     }
 

--- a/esphome/log.py
+++ b/esphome/log.py
@@ -1,9 +1,10 @@
+from enum import Enum
 import logging
 
 from esphome.core import CORE
 
 
-class AnsiFore:
+class AnsiFore(Enum):
     KEEP = ""
     BLACK = "\033[30m"
     RED = "\033[31m"
@@ -26,7 +27,7 @@ class AnsiFore:
     BOLD_RESET = "\033[1;39m"
 
 
-class AnsiStyle:
+class AnsiStyle(Enum):
     BRIGHT = "\033[1m"
     BOLD = "\033[1m"
     DIM = "\033[2m"
@@ -35,16 +36,10 @@ class AnsiStyle:
     RESET_ALL = "\033[0m"
 
 
-Fore = AnsiFore()
-Style = AnsiStyle()
-
-
-def color(col: str, msg: str, reset: bool = True) -> bool:
-    if col and not col.startswith("\033["):
-        raise ValueError("Color must be value from esphome.log.Fore")
-    s = str(col) + msg
+def color(col: AnsiFore, msg: str, reset: bool = True) -> str:
+    s = col.value + msg
     if reset and col:
-        s += str(Style.RESET_ALL)
+        s += AnsiStyle.RESET_ALL.value
     return s
 
 
@@ -54,20 +49,21 @@ class ESPHomeLogFormatter(logging.Formatter):
         fmt += "%(levelname)s %(message)s"
         super().__init__(fmt=fmt, style="%")
 
-    def format(self, record):
+    # @override
+    def format(self, record: logging.LogRecord) -> str:
         formatted = super().format(record)
         prefix = {
-            "DEBUG": Fore.CYAN,
-            "INFO": Fore.GREEN,
-            "WARNING": Fore.YELLOW,
-            "ERROR": Fore.RED,
-            "CRITICAL": Fore.RED,
+            "DEBUG": AnsiFore.CYAN.value,
+            "INFO": AnsiFore.GREEN.value,
+            "WARNING": AnsiFore.YELLOW.value,
+            "ERROR": AnsiFore.RED.value,
+            "CRITICAL": AnsiFore.RED.value,
         }.get(record.levelname, "")
-        return f"{prefix}{formatted}{Style.RESET_ALL}"
+        return f"{prefix}{formatted}{AnsiStyle.RESET_ALL.value}"
 
 
 def setup_log(
-    log_level=logging.INFO,
+    log_level: int = logging.INFO,
     include_timestamp: bool = False,
 ) -> None:
     import colorama

--- a/esphome/mqtt.py
+++ b/esphome/mqtt.py
@@ -28,7 +28,7 @@ from esphome.const import (
 )
 from esphome.core import CORE, EsphomeError
 from esphome.helpers import get_int_env, get_str_env
-from esphome.log import Fore, color
+from esphome.log import AnsiFore, color
 from esphome.util import safe_print
 
 _LOGGER = logging.getLogger(__name__)
@@ -291,7 +291,7 @@ def get_fingerprint(config):
 
     sha1 = hashlib.sha1(cert_der).hexdigest()
 
-    safe_print(f"SHA1 Fingerprint: {color(Fore.CYAN, sha1)}")
+    safe_print(f"SHA1 Fingerprint: {color(AnsiFore.CYAN, sha1)}")
     safe_print(
         f"Copy the string above into mqtt.ssl_fingerprints section of {CORE.config_path}"
     )

--- a/esphome/voluptuous_schema.py
+++ b/esphome/voluptuous_schema.py
@@ -15,7 +15,9 @@ class ExtraKeysInvalid(vol.Invalid):
 def ensure_multiple_invalid(err):
     if isinstance(err, vol.MultipleInvalid):
         return err
-    return vol.MultipleInvalid(err)
+    if isinstance(err, list):
+        return vol.MultipleInvalid(err)
+    return vol.MultipleInvalid([err])
 
 
 # pylint: disable=protected-access, unidiomatic-typecheck

--- a/esphome/wizard.py
+++ b/esphome/wizard.py
@@ -9,7 +9,7 @@ import esphome.config_validation as cv
 from esphome.const import ALLOWED_NAME_CHARS, ENV_QUICKWIZARD
 from esphome.core import CORE
 from esphome.helpers import get_bool_env, write_file
-from esphome.log import Fore, color
+from esphome.log import AnsiFore, color
 from esphome.storage_json import StorageJSON, ext_storage_path
 from esphome.util import safe_input, safe_print
 
@@ -219,7 +219,7 @@ def wizard_write(path, **kwargs):
         elif board in rtl87xx_boards.BOARDS:
             platform = "RTL87XX"
         else:
-            safe_print(color(Fore.RED, f'The board "{board}" is unknown.'))
+            safe_print(color(AnsiFore.RED, f'The board "{board}" is unknown.'))
             return False
         kwargs["platform"] = platform
     hardware = kwargs["platform"]
@@ -274,12 +274,12 @@ def wizard(path):
 
     if not path.endswith(".yaml") and not path.endswith(".yml"):
         safe_print(
-            f"Please make your configuration file {color(Fore.CYAN, path)} have the extension .yaml or .yml"
+            f"Please make your configuration file {color(AnsiFore.CYAN, path)} have the extension .yaml or .yml"
         )
         return 1
     if os.path.exists(path):
         safe_print(
-            f"Uh oh, it seems like {color(Fore.CYAN, path)} already exists, please delete that file first or chose another configuration file."
+            f"Uh oh, it seems like {color(AnsiFore.CYAN, path)} already exists, please delete that file first or chose another configuration file."
         )
         return 2
 
@@ -298,17 +298,19 @@ def wizard(path):
     sleep(3.0)
     safe_print()
     safe_print_step(1, CORE_BIG)
-    safe_print(f"First up, please choose a {color(Fore.GREEN, 'name')} for your node.")
+    safe_print(
+        f"First up, please choose a {color(AnsiFore.GREEN, 'name')} for your node."
+    )
     safe_print(
         "It should be a unique name that can be used to identify the device later."
     )
     sleep(1)
     safe_print(
-        f"For example, I like calling the node in my living room {color(Fore.BOLD_WHITE, 'livingroom')}."
+        f"For example, I like calling the node in my living room {color(AnsiFore.BOLD_WHITE, 'livingroom')}."
     )
     safe_print()
     sleep(1)
-    name = safe_input(color(Fore.BOLD_WHITE, "(name): "))
+    name = safe_input(color(AnsiFore.BOLD_WHITE, "(name): "))
 
     while True:
         try:
@@ -317,7 +319,7 @@ def wizard(path):
         except vol.Invalid:
             safe_print(
                 color(
-                    Fore.RED,
+                    AnsiFore.RED,
                     f'Oh noes, "{name}" isn\'t a valid name. Names can only '
                     f"include numbers, lower-case letters and hyphens. ",
                 )
@@ -325,11 +327,13 @@ def wizard(path):
             name = strip_accents(name).lower().replace(" ", "-")
             name = strip_accents(name).lower().replace("_", "-")
             name = "".join(c for c in name if c in ALLOWED_NAME_CHARS)
-            safe_print(f'Shall I use "{color(Fore.CYAN, name)}" as the name instead?')
+            safe_print(
+                f'Shall I use "{color(AnsiFore.CYAN, name)}" as the name instead?'
+            )
             sleep(0.5)
             name = default_input("(name [{}]): ", name)
 
-    safe_print(f'Great! Your node is now called "{color(Fore.CYAN, name)}".')
+    safe_print(f'Great! Your node is now called "{color(AnsiFore.CYAN, name)}".')
     sleep(1)
     safe_print_step(2, ESP_BIG)
     safe_print(
@@ -346,7 +350,7 @@ def wizard(path):
         sleep(0.5)
         safe_print()
         platform = safe_input(
-            color(Fore.BOLD_WHITE, f"({'/'.join(wizard_platforms)}): ")
+            color(AnsiFore.BOLD_WHITE, f"({'/'.join(wizard_platforms)}): ")
         )
         try:
             platform = vol.All(vol.Upper, vol.Any(*wizard_platforms))(platform.upper())
@@ -355,7 +359,9 @@ def wizard(path):
             safe_print(
                 f'Unfortunately, I can\'t find an espressif microcontroller called "{platform}". Please try again.'
             )
-    safe_print(f"Thanks! You've chosen {color(Fore.CYAN, platform)} as your platform.")
+    safe_print(
+        f"Thanks! You've chosen {color(AnsiFore.CYAN, platform)} as your platform."
+    )
     safe_print()
     sleep(1)
 
@@ -376,27 +382,29 @@ def wizard(path):
     else:
         raise NotImplementedError("Unknown platform!")
 
-    safe_print(f"Next, I need to know what {color(Fore.GREEN, 'board')} you're using.")
+    safe_print(
+        f"Next, I need to know what {color(AnsiFore.GREEN, 'board')} you're using."
+    )
     sleep(0.5)
-    safe_print(f"Please go to {color(Fore.GREEN, board_link)} and choose a board.")
+    safe_print(f"Please go to {color(AnsiFore.GREEN, board_link)} and choose a board.")
     if platform == "ESP32":
-        safe_print(f"(Type {color(Fore.GREEN, 'esp01_1m')} for Sonoff devices)")
+        safe_print(f"(Type {color(AnsiFore.GREEN, 'esp01_1m')} for Sonoff devices)")
     safe_print()
     # Don't sleep because user needs to copy link
     if platform == "ESP32":
-        safe_print(f'For example "{color(Fore.BOLD_WHITE, "nodemcu-32s")}".')
+        safe_print(f'For example "{color(AnsiFore.BOLD_WHITE, "nodemcu-32s")}".')
         boards_list = esp32_boards.BOARDS.items()
     elif platform == "ESP8266":
-        safe_print(f'For example "{color(Fore.BOLD_WHITE, "nodemcuv2")}".')
+        safe_print(f'For example "{color(AnsiFore.BOLD_WHITE, "nodemcuv2")}".')
         boards_list = esp8266_boards.BOARDS.items()
     elif platform == "BK72XX":
-        safe_print(f'For example "{color(Fore.BOLD_WHITE, "cb2s")}".')
+        safe_print(f'For example "{color(AnsiFore.BOLD_WHITE, "cb2s")}".')
         boards_list = bk72xx_boards.BOARDS.items()
     elif platform == "RTL87XX":
-        safe_print(f'For example "{color(Fore.BOLD_WHITE, "wr3")}".')
+        safe_print(f'For example "{color(AnsiFore.BOLD_WHITE, "wr3")}".')
         boards_list = rtl87xx_boards.BOARDS.items()
     elif platform == "RP2040":
-        safe_print(f'For example "{color(Fore.BOLD_WHITE, "rpipicow")}".')
+        safe_print(f'For example "{color(AnsiFore.BOLD_WHITE, "rpipicow")}".')
         boards_list = rp2040_boards.BOARDS.items()
 
     else:
@@ -409,19 +417,21 @@ def wizard(path):
         boards.append(board_id)
 
     while True:
-        board = safe_input(color(Fore.BOLD_WHITE, "(board): "))
+        board = safe_input(color(AnsiFore.BOLD_WHITE, "(board): "))
         try:
             board = vol.All(vol.Lower, vol.Any(*boards))(board)
             break
         except vol.Invalid:
             safe_print(
-                color(Fore.RED, f'Sorry, I don\'t think the board "{board}" exists.')
+                color(
+                    AnsiFore.RED, f'Sorry, I don\'t think the board "{board}" exists.'
+                )
             )
             safe_print()
             sleep(0.25)
             safe_print()
 
-    safe_print(f"Way to go! You've chosen {color(Fore.CYAN, board)} as your board.")
+    safe_print(f"Way to go! You've chosen {color(AnsiFore.CYAN, board)} as your board.")
     safe_print()
     sleep(1)
 
@@ -432,19 +442,19 @@ def wizard(path):
         safe_print()
         sleep(1)
         safe_print(
-            f"First, what's the {color(Fore.GREEN, 'SSID')} (the name) of the WiFi network {name} should connect to?"
+            f"First, what's the {color(AnsiFore.GREEN, 'SSID')} (the name) of the WiFi network {name} should connect to?"
         )
         sleep(1.5)
-        safe_print(f'For example "{color(Fore.BOLD_WHITE, "Abraham Linksys")}".')
+        safe_print(f'For example "{color(AnsiFore.BOLD_WHITE, "Abraham Linksys")}".')
         while True:
-            ssid = safe_input(color(Fore.BOLD_WHITE, "(ssid): "))
+            ssid = safe_input(color(AnsiFore.BOLD_WHITE, "(ssid): "))
             try:
                 ssid = cv.ssid(ssid)
                 break
             except vol.Invalid:
                 safe_print(
                     color(
-                        Fore.RED,
+                        AnsiFore.RED,
                         f'Unfortunately, "{ssid}" doesn\'t seem to be a valid SSID. Please try again.',
                     )
                 )
@@ -452,18 +462,18 @@ def wizard(path):
                 sleep(1)
 
         safe_print(
-            f'Thank you very much! You\'ve just chosen "{color(Fore.CYAN, ssid)}" as your SSID.'
+            f'Thank you very much! You\'ve just chosen "{color(AnsiFore.CYAN, ssid)}" as your SSID.'
         )
         safe_print()
         sleep(0.75)
 
         safe_print(
-            f"Now please state the {color(Fore.GREEN, 'password')} of the WiFi network so that I can connect to it (Leave empty for no password)"
+            f"Now please state the {color(AnsiFore.GREEN, 'password')} of the WiFi network so that I can connect to it (Leave empty for no password)"
         )
         safe_print()
-        safe_print(f'For example "{color(Fore.BOLD_WHITE, "PASSWORD42")}"')
+        safe_print(f'For example "{color(AnsiFore.BOLD_WHITE, "PASSWORD42")}"')
         sleep(0.5)
-        psk = safe_input(color(Fore.BOLD_WHITE, "(PSK): "))
+        psk = safe_input(color(AnsiFore.BOLD_WHITE, "(PSK): "))
         safe_print(
             "Perfect! WiFi is now set up (you can create static IPs and so on later)."
         )
@@ -475,12 +485,12 @@ def wizard(path):
             "(over the air) and integrates into Home Assistant with a native API."
         )
         safe_print(
-            f"This can be insecure if you do not trust the WiFi network. Do you want to set a {color(Fore.GREEN, 'password')} for connecting to this ESP?"
+            f"This can be insecure if you do not trust the WiFi network. Do you want to set a {color(AnsiFore.GREEN, 'password')} for connecting to this ESP?"
         )
         safe_print()
         sleep(0.25)
         safe_print("Press ENTER for no password")
-        password = safe_input(color(Fore.BOLD_WHITE, "(password): "))
+        password = safe_input(color(AnsiFore.BOLD_WHITE, "(password): "))
     else:
         ssid, password, psk = "", "", ""
 
@@ -497,8 +507,8 @@ def wizard(path):
 
     safe_print()
     safe_print(
-        color(Fore.CYAN, "DONE! I've now written a new configuration file to ")
-        + color(Fore.BOLD_CYAN, path)
+        color(AnsiFore.CYAN, "DONE! I've now written a new configuration file to ")
+        + color(AnsiFore.BOLD_CYAN, path)
     )
     safe_print()
     safe_print("Next steps:")

--- a/platformio.ini
+++ b/platformio.ini
@@ -64,7 +64,7 @@ lib_deps =
     heman/AsyncMqttClient-esphome@1.0.0                   ; mqtt
     esphome/ESPAsyncWebServer-esphome@3.3.0               ; web_server_base
     fastled/FastLED@3.9.16                                ; fastled_base
-    mikalhart/TinyGPSPlus@1.0.2                           ; gps
+    mikalhart/TinyGPSPlus@1.1.0                           ; gps
     freekode/TM1651@1.0.1                                 ; tm1651
     glmnet/Dsmr@0.7                                       ; dsmr
     rweather/Crypto@0.4.0                                 ; dsmr

--- a/tests/components/gps/common.yaml
+++ b/tests/components/gps/common.yaml
@@ -6,6 +6,20 @@ uart:
     parity: EVEN
 
 gps:
+  latitude:
+    name: "Latitude"
+  longitude:
+    name: "Longitude"
+  altitude:
+    name: "Altitude"
+  speed:
+    name: "Speed"
+  course:
+    name: "Course"
+  satellites:
+    name: "Satellites"
+  hdop:
+    name: "HDOP"
 
 time:
   - platform: gps


### PR DESCRIPTION
**Do not merge, release script will automatically merge**
## Full list of changes

### All changes

<details>
<summary>Show</summary>

- Update some sensor schemas to be Optional [esphome#8803](https://github.com/esphome/esphome/pull/8803)
- Use fixed buffer for plaintext protocol like noise protocol [esphome#8800](https://github.com/esphome/esphome/pull/8800)
- Optimize protobuf varint decoder for ESPHome use case [esphome#8791](https://github.com/esphome/esphome/pull/8791)
- Logger Recursion Guard per Task on ESP32 [esphome#8765](https://github.com/esphome/esphome/pull/8765)
- [log] improve/refactor ``log`` [esphome#8708](https://github.com/esphome/esphome/pull/8708)
- [gps] update lib, improve code/tests/config [esphome#8768](https://github.com/esphome/esphome/pull/8768)
- Fix ESP32 Camera class inheritance [esphome#8811](https://github.com/esphome/esphome/pull/8811)
- [sen5x] Fix validation for values read from hardware [esphome#8769](https://github.com/esphome/esphome/pull/8769)
- Fix the case of single error [esphome#8824](https://github.com/esphome/esphome/pull/8824)
- Revert "[binary_sensor] initial state refactor" [esphome#8828](https://github.com/esphome/esphome/pull/8828)
- Fix misspelling of climate in climate_ir.climate_ir_with_receiver_schema [esphome#8829](https://github.com/esphome/esphome/pull/8829)
- Fix ESP32 console logging corruption and message loss in multi-task [esphome#8806](https://github.com/esphome/esphome/pull/8806)
- Reduce number of calls to fetch time in the main loop [esphome#8804](https://github.com/esphome/esphome/pull/8804)
- Refactor API frame helpers to enable buffer reuse [esphome#8825](https://github.com/esphome/esphome/pull/8825)
</details>

### Dependency Changes

<details>
<summary>Show</summary>

- Bump docker/build-push-action from 6.16.0 to 6.17.0 in /.github/actions/build-image [esphome#8810](https://github.com/esphome/esphome/pull/8810)
</details>
<details>
<summary>Metadata</summary>

@coderabbitai ignore
</details>
