### PR TITLE
Fix API connection sending ping too early after connection establishment

### DIFF
--- a/esphome/components/api/api_connection.h
+++ b/esphome/components/api/api_connection.h
@@ -15,6 +15,9 @@
 namespace esphome {
 namespace api {
 
+// Keepalive timeout in milliseconds
+static constexpr uint32_t KEEPALIVE_TIMEOUT_MS = 60000;
+
 using send_message_t = bool (APIConnection::*)(void *);
 
 /*


### PR DESCRIPTION
# What does this implement/fix?

Commit 574aabdedec80ca20dec5a54439a9ad649bf8cb4 introduced a regression where ESPHome sends a PingRequest to Home Assistant immediately upon connection establishment, causing Home Assistant to disconnect with:
```
[22:00:24][W][api.connection:174]: Home Assistant 2025.6.0.dev0 (192.168.148.95) didn't respond to ping request in time. Disconnecting...
```
because `aioesphomeapi` installs the ping listener too late as well so HA never responds. This is fixed in https://github.com/esphome/aioesphomeapi/pull/1195 but not in a public HA release.

The commit changed time calls from `millis()` to `App.get_loop_component_start_time()` for performance optimization. However, this created a timing issue:
- `APIConnection::start()` set `last_traffic_` using `millis()`
- `APIConnection::loop()` used cached time from `App.get_loop_component_start_time()`
- When connections were established after >60s uptime, the keepalive check triggered immediately

1. **Initialize `next_ping_retry_` in `start()`** to delay the first ping by the keepalive period
2. **Use consistent time source** - changed `start()` to use `App.get_loop_component_start_time()`
3. **Create shared constant** `KEEPALIVE_TIMEOUT_MS` to avoid hardcoding the timeout value

- Added `KEEPALIVE_TIMEOUT_MS` constant (60000ms) in `api_connection.h`
- Modified `APIConnection::start()` to:
  - Use `App.get_loop_component_start_time()` for consistency
  - Set `next_ping_retry_ = last_traffic_ + KEEPALIVE_TIMEOUT_MS`
- Updated `APIConnection::loop()` to use the new constant

- First ping is sent 60 seconds after connection establishment
- No immediate ping on connection that causes Home Assistant to disconnect
- Maintains the performance optimization from the original commit

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
