### PR TITLE
Fix ethernet connection timeout issue caused by incorrect time value during setup

### DIFF
--- a/esphome/core/application.cpp
+++ b/esphome/core/application.cpp
@@ -35,6 +35,8 @@ void Application::setup() {
   for (uint32_t i = 0; i < this->components_.size(); i++) {
     Component *component = this->components_[i];
 
+    // Update loop_component_start_time_ before calling each component during setup
+    this->loop_component_start_time_ = millis();
     component->call();
     this->scheduler.process_to_add();
     this->feed_wdt();
@@ -49,6 +51,8 @@ void Application::setup() {
       this->scheduler.call();
       this->feed_wdt();
       for (uint32_t j = 0; j <= i; j++) {
+        // Update loop_component_start_time_ right before calling each component
+        this->loop_component_start_time_ = millis();
         this->components_[j]->call();
         new_app_state |= this->components_[j]->get_component_state();
         this->app_state_ |= new_app_state;


### PR DESCRIPTION


# What does this implement/fix?

This PR fixes an issue where the ethernet component would fail to establish connections during setup due to `App.get_loop_component_start_time()` returning a stale or zero value. This caused the connection timeout logic to malfunction, leading to an infinite reconnection loop.

## Background
PR #8804 introduced an optimization to reduce calls to `millis()` by caching the current time at the start of each component loop. However, this introduced a regression where components that run during the setup phase (before the main application loop starts) would receive incorrect time values.

## The Problem
The ethernet component's `can_proceed()` method returns `false` until a connection is established. This causes the component to be called repeatedly during the setup phase's waiting loop. During this time:
- `connect_begin_` is set to the current time via `millis()`
- `now` is set to `App.get_loop_component_start_time()` which was either 0 or a stale value
- The timeout calculation `now - connect_begin_` would never trigger correctly

This resulted in the ethernet component being unable to timeout and retry connections properly.

## The Fix
The fix updates `loop_component_start_time_` to the current time before calling each component in the setup waiting loop. This ensures that components receive accurate time values even when running before the main application loop has started.

Additionally, the same update was added before the initial component call during setup to handle edge cases.

## Testing
The fix has been verified to resolve the ethernet connection issue. The component now correctly times out after 15 seconds and retries connections as expected.

## Impact
This fix ensures that any component using `App.get_loop_component_start_time()` during the setup phase will receive accurate time values, preventing similar timeout-related issues in other components.

Fixes: Connection timeout regression introduced in #8804

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
