### PR TITLE
[rp2040_esphost] Support ESPHost library for Wi-Fi on Pi Pico

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -360,6 +360,7 @@ esphome/components/restart/* @esphome/core
 esphome/components/rf_bridge/* @jesserockz
 esphome/components/rgbct/* @jesserockz
 esphome/components/rp2040/* @jesserockz
+esphome/components/rp2040_esphost/* @kuba2k2
 esphome/components/rp2040_pio_led_strip/* @Papa-DMan
 esphome/components/rp2040_pwm/* @jesserockz
 esphome/components/rpi_dpi_rgb/* @clydebarrow

--- a/esphome/components/rp2040_esphost/__init__.py
+++ b/esphome/components/rp2040_esphost/__init__.py
@@ -1,0 +1,60 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome import pins
+from esphome.components.spi import (
+    CONF_INTERFACE_INDEX,
+    SPIComponent,
+    SPIDataRate,
+)
+from esphome.const import CONF_CS_PIN, CONF_DATA_RATE, CONF_RESET_PIN, CONF_SPI_ID
+from esphome.core import CORE
+
+DEPENDENCIES = ["spi"]
+CODEOWNERS = ["@kuba2k2"]
+
+CONF_HANDSHAKE_PIN = "handshake_pin"
+CONF_DATA_READY_PIN = "data_ready_pin"
+
+
+ESPHOST_DATA_RATE_OPTIONS = {
+    10e6: SPIDataRate.DATA_RATE_10MHZ,
+    8e6: SPIDataRate.DATA_RATE_8MHZ,
+    5e6: SPIDataRate.DATA_RATE_5MHZ,
+    4e6: SPIDataRate.DATA_RATE_4MHZ,
+    2e6: SPIDataRate.DATA_RATE_2MHZ,
+    1e6: SPIDataRate.DATA_RATE_1MHZ,
+}
+
+CONFIG_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(CONF_SPI_ID): cv.use_id(SPIComponent),
+        cv.Required(CONF_CS_PIN): pins.gpio_output_pin_schema,
+        cv.Required(CONF_HANDSHAKE_PIN): pins.gpio_input_pin_schema,
+        cv.Required(CONF_DATA_READY_PIN): pins.gpio_input_pin_schema,
+        cv.Required(CONF_RESET_PIN): pins.gpio_output_pin_schema,
+        cv.Optional(CONF_DATA_RATE, default="1MHz"): cv.All(
+            cv.frequency, cv.enum(ESPHOST_DATA_RATE_OPTIONS)
+        ),
+    }
+)
+
+
+async def to_code(config):
+    parent = config[CONF_SPI_ID]
+    parent_path = CORE.config.get_path_for_id(parent)
+    spi_config = CORE.config.get_config_for_path(parent_path[:-1])
+
+    spi_interface = spi_config[CONF_INTERFACE_INDEX]
+    cs_pin = config[CONF_CS_PIN]["number"]
+    handshake_pin = config[CONF_HANDSHAKE_PIN]["number"]
+    data_ready_pin = config[CONF_DATA_READY_PIN]["number"]
+    reset_pin = config[CONF_RESET_PIN]["number"]
+    data_rate_mhz = int(config[CONF_DATA_RATE] / 1e6)
+
+    cg.add_define("USE_RP2040_ESPHOST")
+    cg.add_build_flag(f"-DESPHOSTSPI=SPI{spi_interface}")
+    cg.add_build_flag(f"-DESPHOST_CS={cs_pin}")
+    cg.add_build_flag(f"-DESPHOST_HANDSHAKE={handshake_pin}")
+    cg.add_build_flag(f"-DESPHOST_DATA_READY={data_ready_pin}")
+    cg.add_build_flag(f"-DESPHOST_RESET={reset_pin}")
+    cg.add_build_flag(f"-DESPHOSTSPI_MHZ={data_rate_mhz}")

--- a/esphome/components/wifi/wifi_component.h
+++ b/esphome/components/wifi/wifi_component.h
@@ -40,11 +40,13 @@ extern "C" {
 #endif
 
 #ifdef USE_RP2040
+#ifndef USE_RP2040_ESPHOST
 extern "C" {
 #include "cyw43.h"
 #include "cyw43_country.h"
 #include "pico/cyw43_arch.h"
 }
+#endif
 
 #include <WiFi.h>
 #endif
@@ -372,7 +374,7 @@ class WiFiComponent : public Component {
   void wifi_process_event_(IDFWiFiEvent *data);
 #endif
 
-#ifdef USE_RP2040
+#if defined(USE_RP2040) && !defined(USE_RP2040_ESPHOST)
   static int s_wifi_scan_result(void *env, const cyw43_ev_scan_result_t *result);
   void wifi_scan_result(void *env, const cyw43_ev_scan_result_t *result);
 #endif

--- a/esphome/components/wifi/wifi_component.h
+++ b/esphome/components/wifi/wifi_component.h
@@ -40,6 +40,9 @@ extern "C" {
 #endif
 
 #ifdef USE_RP2040
+#ifdef ARDUINO_RASPBERRY_PI_PICO_W
+#undef USE_RP2040_ESPHOST
+#endif
 #ifndef USE_RP2040_ESPHOST
 extern "C" {
 #include "cyw43.h"

--- a/esphome/components/wifi/wifi_component_pico_w.cpp
+++ b/esphome/components/wifi/wifi_component_pico_w.cpp
@@ -20,7 +20,12 @@ namespace wifi {
 
 static const char *const TAG = "wifi_pico_w";
 
+#ifdef USE_RP2040_ESPHOST
+static bool s_sta_connecting = false;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+#endif
+
 bool WiFiComponent::wifi_mode_(optional<bool> sta, optional<bool> ap) {
+#ifndef USE_RP2040_ESPHOST
   if (sta.has_value()) {
     if (sta.value()) {
       cyw43_wifi_set_up(&cyw43_state, CYW43_ITF_STA, true, CYW43_COUNTRY_WORLDWIDE);
@@ -32,9 +37,27 @@ bool WiFiComponent::wifi_mode_(optional<bool> sta, optional<bool> ap) {
     }
   }
   return true;
+#else
+  uint8_t current_mode = WiFi.getMode();
+  bool current_sta = current_mode & WIFI_STA;
+  bool current_ap = current_mode & WIFI_AP;
+  bool enable_sta = sta.value_or(current_sta);
+  bool enable_ap = ap.value_or(current_ap);
+  if (current_sta == enable_sta && current_ap == enable_ap)
+    return true;
+
+  uint8_t mode = 0;
+  if (enable_sta)
+    mode |= WIFI_STA;
+  if (enable_ap)
+    mode |= WIFI_AP;
+  WiFi.mode(static_cast<WiFiMode_t>(mode));
+  return true;
+#endif
 }
 
 bool WiFiComponent::wifi_apply_power_save_() {
+#ifndef USE_RP2040_ESPHOST
   uint32_t pm;
   switch (this->power_save_) {
     case WIFI_POWER_SAVE_NONE:
@@ -49,6 +72,9 @@ bool WiFiComponent::wifi_apply_power_save_() {
   }
   int ret = cyw43_wifi_pm(&cyw43_state, pm);
   return ret == 0;
+#else
+  return false;
+#endif
 }
 
 // TODO: The driver doesnt seem to have an API for this
@@ -96,6 +122,7 @@ const char *get_disconnect_reason_str(uint8_t reason) {
 }
 
 WiFiSTAConnectStatus WiFiComponent::wifi_sta_connect_status_() {
+#ifndef USE_RP2040_ESPHOST
   int status = cyw43_tcpip_link_status(&cyw43_state, CYW43_ITF_STA);
   switch (status) {
     case CYW43_LINK_JOIN:
@@ -110,8 +137,22 @@ WiFiSTAConnectStatus WiFiComponent::wifi_sta_connect_status_() {
       return WiFiSTAConnectStatus::ERROR_NETWORK_NOT_FOUND;
   }
   return WiFiSTAConnectStatus::IDLE;
+#else
+  auto status = WiFi.status();
+  if (status == WL_CONNECTED) {
+    return WiFiSTAConnectStatus::CONNECTED;
+  } else if (status == WL_CONNECT_FAILED || status == WL_CONNECTION_LOST) {
+    return WiFiSTAConnectStatus::ERROR_CONNECT_FAILED;
+  } else if (status == WL_NO_SSID_AVAIL) {
+    return WiFiSTAConnectStatus::ERROR_NETWORK_NOT_FOUND;
+  } else if (s_sta_connecting) {
+    return WiFiSTAConnectStatus::CONNECTING;
+  }
+  return WiFiSTAConnectStatus::IDLE;
+#endif
 }
 
+#ifndef USE_RP2040_ESPHOST
 int WiFiComponent::s_wifi_scan_result(void *env, const cyw43_ev_scan_result_t *result) {
   global_wifi_component->wifi_scan_result(env, result);
   return 0;
@@ -139,6 +180,32 @@ bool WiFiComponent::wifi_scan_start_(bool passive) {
   return err == 0;
   return true;
 }
+#else
+bool WiFiComponent::wifi_scan_start_(bool passive) {
+  this->scan_result_.clear();
+
+  int16_t num = WiFi.scanNetworks(false);
+  if (num < 0)
+    return false;
+
+  this->scan_result_.reserve(static_cast<unsigned int>(num));
+  for (int i = 0; i < num; i++) {
+    String ssid = WiFi.SSID(i);
+    uint8_t authmode = WiFi.encryptionType(i);
+    int32_t rssi = WiFi.RSSI(i);
+    uint8_t bssid[6];
+    WiFi.BSSID(i, bssid);
+    int32_t channel = WiFi.channel(i);
+
+    WiFiScanResult scan({bssid[0], bssid[1], bssid[2], bssid[3], bssid[4], bssid[5]}, std::string(ssid.c_str()),
+                        channel, rssi, authmode != WIFI_AUTH_OPEN, ssid.length() == 0);
+    this->scan_result_.push_back(scan);
+  }
+  WiFi.scanDelete();
+  this->scan_done_ = true;
+  return true;
+}
+#endif
 
 #ifdef USE_WIFI_AP
 bool WiFiComponent::wifi_ap_ip_config_(optional<ManualIP> manual_ip) {
@@ -175,8 +242,12 @@ network::IPAddress WiFiComponent::wifi_soft_ap_ip() { return {(const ip_addr_t *
 #endif  // USE_WIFI_AP
 
 bool WiFiComponent::wifi_disconnect_() {
+#ifndef USE_RP2040_ESPHOST
   int err = cyw43_wifi_leave(&cyw43_state, CYW43_ITF_STA);
   return err == 0;
+#else
+  return WiFi.disconnect() == WL_DISCONNECTED;
+#endif
 }
 
 bssid_t WiFiComponent::wifi_bssid() {
@@ -207,10 +278,12 @@ network::IPAddress WiFiComponent::wifi_dns_ip_(int num) {
 }
 
 void WiFiComponent::wifi_loop_() {
+#ifndef USE_RP2040_ESPHOST
   if (this->state_ == WIFI_COMPONENT_STATE_STA_SCANNING && !cyw43_wifi_scan_active(&cyw43_state)) {
     this->scan_done_ = true;
     ESP_LOGV(TAG, "Scan done!");
   }
+#endif
 }
 
 void WiFiComponent::wifi_pre_setup_() {}

--- a/esphome/components/wifi/wifi_component_pico_w.cpp
+++ b/esphome/components/wifi/wifi_component_pico_w.cpp
@@ -296,7 +296,11 @@ void WiFiComponent::wifi_pre_setup_() {
   watchdog_disable();
   // communicate with esp-hosted and get the MAC address
   WiFi.macAddress(mac_addr);
-  watchdog_enable(0x7fffff, false);
+#if USE_RP2040_WATCHDOG_TIMEOUT > 0
+  watchdog_enable(USE_RP2040_WATCHDOG_TIMEOUT, false);
+#else
+  watchdog_disable();
+#endif
   // if it's unchanged, an error occurred
   if (memcmp(mac_addr, mac_invalid, 6) == 0) {
     ESP_LOGE(TAG, "Couldn't initialize ESPHost, check the connections");

--- a/esphome/components/wifi/wifi_component_pico_w.cpp
+++ b/esphome/components/wifi/wifi_component_pico_w.cpp
@@ -286,7 +286,24 @@ void WiFiComponent::wifi_loop_() {
 #endif
 }
 
-void WiFiComponent::wifi_pre_setup_() {}
+void WiFiComponent::wifi_pre_setup_() {
+#ifdef USE_RP2040_ESPHOST
+  // check if initHW() returns false by verifying the esp-hosted MAC address
+  uint8_t mac_addr[6], mac_invalid[6];
+  memset(mac_addr, 0xAA, 6);
+  memset(mac_invalid, 0xAA, 6);
+  // disable the watchdog temporarily (the connection check takes time)
+  watchdog_disable();
+  // communicate with esp-hosted and get the MAC address
+  WiFi.macAddress(mac_addr);
+  watchdog_enable(0x7fffff, false);
+  // if it's unchanged, an error occurred
+  if (memcmp(mac_addr, mac_invalid, 6) == 0) {
+    ESP_LOGE(TAG, "Couldn't initialize ESPHost, check the connections");
+    this->mark_failed("ESPHost init failed");
+  }
+#endif
+}
 
 }  // namespace wifi
 }  // namespace esphome

--- a/esphome/components/wifi/wifi_component_rp2040.cpp
+++ b/esphome/components/wifi/wifi_component_rp2040.cpp
@@ -18,7 +18,7 @@
 namespace esphome {
 namespace wifi {
 
-static const char *const TAG = "wifi_pico_w";
+static const char *const TAG = "wifi_rp2040";
 
 #ifdef USE_RP2040_ESPHOST
 static bool s_sta_connecting = false;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)


### PR DESCRIPTION
# What does this implement/fix?

This component supports the `ESPHost` library, present in the Arduino-Pico framework. It allows an RP2040 (Pi Pico) without the Wi-Fi module to connect to the Internet using an external, SPI-connected, ESP32 module.

More info in the documentation PR, and on [esp-hosted](https://github.com/espressif/esp-hosted) main page.

**Note:** this PR requires #8868 to function correctly. It has a `watchdog_timeout` property support.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** N/A
**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#4929

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [x] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
rp2040:
  board: rpipico
  watchdog_timeout: 0s

spi:
  clk_pin: GPIO10
  mosi_pin: GPIO11
  miso_pin: GPIO12
  interface: hardware

rp2040_esphost:
  cs_pin: GPIO13
  handshake_pin: GPIO14
  data_ready_pin: GPIO15
  reset_pin: GPIO16
  data_rate: 10MHz
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
