### PR TITLE
[tuya_select] - Fix datapoint config error.

### DIFF
--- a/esphome/components/tuya/select/__init__.py
+++ b/esphome/components/tuya/select/__init__.py
@@ -54,8 +54,8 @@ async def to_code(config):
     cg.add(var.set_select_mappings(list(options_map.keys())))
     parent = await cg.get_variable(config[CONF_TUYA_ID])
     cg.add(var.set_tuya_parent(parent))
-    if enum_datapoint := config.get(CONF_ENUM_DATAPOINT, None) is not None:
+    if (enum_datapoint := config.get(CONF_ENUM_DATAPOINT, None)) is not None:
         cg.add(var.set_select_id(enum_datapoint, False))
-    if int_datapoint := config.get(CONF_INT_DATAPOINT, None) is not None:
+    if (int_datapoint := config.get(CONF_INT_DATAPOINT, None)) is not None:
         cg.add(var.set_select_id(int_datapoint, True))
     cg.add(var.set_optimistic(config[CONF_OPTIMISTIC]))


### PR DESCRIPTION
# What does this implement/fix?

Fix `tuya_select` datapoint bug erroneously being cast to a boolean, introduced in 2025.5.0

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/issues/issues/7037

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [X] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
select:
  - platform: "tuya"
    name: "Indicator Configuration"
    entity_category: config
    enum_datapoint: 101
    optimistic: true
    options:
      0: "Inverted"
      1: "Normal"
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
