### PR TITLE
[lvgl] Improve error messages from text validation

### DIFF
--- a/esphome/components/lvgl/schemas.py
+++ b/esphome/components/lvgl/schemas.py
@@ -36,30 +36,35 @@ from .types import (
 # this will be populated later, in __init__.py to avoid circular imports.
 WIDGET_TYPES: dict = {}
 
+TIME_TEXT_SCHEMA = cv.Schema(
+    {
+        cv.Required(CONF_TIME_FORMAT): cv.string,
+        cv.GenerateID(CONF_TIME): cv.templatable(cv.use_id(RealTimeClock)),
+    }
+)
+
+PRINTF_TEXT_SCHEMA = cv.All(
+    cv.Schema(
+        {
+            cv.Required(CONF_FORMAT): cv.string,
+            cv.Optional(CONF_ARGS, default=list): cv.ensure_list(cv.lambda_),
+        },
+    ),
+    validate_printf,
+)
+
 
 def _validate_text(value):
     """
     Do some sanity checking of the format to get better error messages
     than using cv.Any
     """
+    if value is None:
+        raise cv.Invalid("No text specified")
     if isinstance(value, dict):
         if CONF_TIME_FORMAT in value:
-            return cv.Schema(
-                {
-                    cv.Required(CONF_TIME_FORMAT): cv.string,
-                    cv.GenerateID(CONF_TIME): cv.templatable(cv.use_id(RealTimeClock)),
-                }
-            )(value)
-
-        return cv.All(
-            cv.Schema(
-                {
-                    cv.Required(CONF_FORMAT): cv.string,
-                    cv.Optional(CONF_ARGS, default=list): cv.ensure_list(cv.lambda_),
-                },
-            ),
-            validate_printf,
-        )(value)
+            return TIME_TEXT_SCHEMA(value)
+        return PRINTF_TEXT_SCHEMA(value)
 
     return cv.templatable(cv.string)(value)
 

--- a/esphome/components/lvgl/schemas.py
+++ b/esphome/components/lvgl/schemas.py
@@ -36,29 +36,38 @@ from .types import (
 # this will be populated later, in __init__.py to avoid circular imports.
 WIDGET_TYPES: dict = {}
 
-# A schema for text properties
-TEXT_SCHEMA = cv.Schema(
-    {
-        cv.Optional(CONF_TEXT): cv.Any(
-            cv.All(
-                cv.Schema(
-                    {
-                        cv.Required(CONF_FORMAT): cv.string,
-                        cv.Optional(CONF_ARGS, default=list): cv.ensure_list(
-                            cv.lambda_
-                        ),
-                    },
-                ),
-                validate_printf,
-            ),
-            cv.Schema(
+
+def _validate_text(value):
+    """
+    Do some sanity checking of the format to get better error messages
+    than using cv.Any
+    """
+    if isinstance(value, dict):
+        if CONF_TIME_FORMAT in value:
+            return cv.Schema(
                 {
                     cv.Required(CONF_TIME_FORMAT): cv.string,
                     cv.GenerateID(CONF_TIME): cv.templatable(cv.use_id(RealTimeClock)),
                 }
+            )(value)
+
+        return cv.All(
+            cv.Schema(
+                {
+                    cv.Required(CONF_FORMAT): cv.string,
+                    cv.Optional(CONF_ARGS, default=list): cv.ensure_list(cv.lambda_),
+                },
             ),
-            cv.templatable(cv.string),
-        )
+            validate_printf,
+        )(value)
+
+    return cv.templatable(cv.string)(value)
+
+
+# A schema for text properties
+TEXT_SCHEMA = cv.Schema(
+    {
+        cv.Optional(CONF_TEXT): _validate_text,
     }
 )
 


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Using `cv.Any` can result in unhelpful error messages. Use a custom validation function instead to more closely align
the messages with the errror.

Previously this yaml:

```
    on_value:
      then:
        - lvgl.label.update:
            id: lbl_outdoor_temp
            text:
              format: "% °F"
              args: ["id(outside_temp).get_state()"]
```

Would throw these errors:

```
  on_value:
    then:
      - lvgl.label.update:
          id: lbl_outdoor_temp

          'time_format' is a required option for [text].
          text:

            [format] is an invalid option for [text]. Did you mean [time_format]?
            format: % °F

            [args] is an invalid option for [text]. Please check the indentation.
            args:
              - id(outside_temp).get_state()
```

Now it says:

```
  on_value:
    then:
      - lvgl.label.update:
          id: lbl_outdoor_temp

          Found 0 printf-patterns (), but 1 args were given!.
          text:
            format: % °F
            args:
              - id(outside_temp).get_state()
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://discord.com/channels/429907082951524364/1374900765877075969

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
