### PR TITLE
[logger] Fix options in select

### DIFF
--- a/esphome/components/logger/__init__.py
+++ b/esphome/components/logger/__init__.py
@@ -25,6 +25,7 @@ from esphome.const import (
     CONF_HARDWARE_UART,
     CONF_ID,
     CONF_LEVEL,
+    CONF_LOGGER,
     CONF_LOGS,
     CONF_ON_MESSAGE,
     CONF_TAG,
@@ -250,6 +251,7 @@ CONFIG_SCHEMA = cv.All(
 async def to_code(config):
     baud_rate = config[CONF_BAUD_RATE]
     level = config[CONF_LEVEL]
+    CORE.data.setdefault(CONF_LOGGER, {})[CONF_LEVEL] = level
     initial_level = LOG_LEVELS[config.get(CONF_INITIAL_LEVEL, level)]
     log = cg.new_Pvariable(
         config[CONF_ID],

--- a/esphome/components/logger/select/__init__.py
+++ b/esphome/components/logger/select/__init__.py
@@ -5,7 +5,7 @@ from esphome.const import CONF_LEVEL, CONF_LOGGER, ENTITY_CATEGORY_CONFIG, ICON_
 from esphome.core import CORE
 from esphome.cpp_helpers import register_component, register_parented
 
-from .. import CONF_LOGGER_ID, LOG_LEVEL_SEVERITY, Logger, logger_ns
+from .. import CONF_LOGGER_ID, LOG_LEVELS, Logger, logger_ns
 
 CODEOWNERS = ["@clydebarrow"]
 
@@ -21,8 +21,8 @@ CONFIG_SCHEMA = select.select_schema(
 
 
 async def to_code(config):
-    levels = LOG_LEVEL_SEVERITY
-    index = levels.index(CORE.config[CONF_LOGGER][CONF_LEVEL])
+    levels = LOG_LEVELS.keys()
+    index = levels.index(CORE.data[CONF_LOGGER][CONF_LEVEL])
     levels = levels[: index + 1]
     var = await select.new_select(config, options=levels)
     await register_parented(var, config[CONF_LOGGER_ID])

--- a/esphome/components/logger/select/__init__.py
+++ b/esphome/components/logger/select/__init__.py
@@ -21,7 +21,7 @@ CONFIG_SCHEMA = select.select_schema(
 
 
 async def to_code(config):
-    levels = LOG_LEVELS.keys()
+    levels = list(LOG_LEVELS)
     index = levels.index(CORE.data[CONF_LOGGER][CONF_LEVEL])
     levels = levels[: index + 1]
     var = await select.new_select(config, options=levels)

--- a/esphome/components/logger/select/__init__.py
+++ b/esphome/components/logger/select/__init__.py
@@ -21,9 +21,10 @@ CONFIG_SCHEMA = select.select_schema(
 
 
 async def to_code(config):
+    parent = await cg.get_variable(config[CONF_LOGGER_ID])
     levels = list(LOG_LEVELS)
     index = levels.index(CORE.data[CONF_LOGGER][CONF_LEVEL])
     levels = levels[: index + 1]
     var = await select.new_select(config, options=levels)
-    await register_parented(var, config[CONF_LOGGER_ID])
+    await register_parented(var, parent)
     await register_component(var, config)


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

The select was showing `CONFIG` as an option which is not valid to choose from.

Also store global log level in `CORE.data` instead of accessing `CORE.config` directly

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/issues/issues/7028

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
