### PR TITLE
[micro_wake_word] avoid duplicated detections from same event

### DIFF
--- a/esphome/components/micro_wake_word/streaming_model.cpp
+++ b/esphome/components/micro_wake_word/streaming_model.cpp
@@ -147,7 +147,11 @@ bool StreamingModel::perform_streaming_inference(const int8_t features[PREPROCES
       this->recent_streaming_probabilities_[this->last_n_index_] = output->data.uint8[0];  // probability;
       this->unprocessed_probability_status_ = true;
     }
-    this->ignore_windows_ = std::min(this->ignore_windows_ + 1, 0);
+    if (this->recent_streaming_probabilities_[this->last_n_index_] < this->probability_cutoff_) {
+      // Only increment ignore windows if less than the probability cutoff; this forces the model to "cool-off" from a
+      // previous detection and calling ``reset_probabilities`` so it avoids duplicate detections
+      this->ignore_windows_ = std::min(this->ignore_windows_ + 1, 0);
+    }
   }
   return true;
 }


### PR DESCRIPTION
# What does this implement/fix?

Some wake word models ("Hey Mycroft") can keep reporting high probabilities long after the initial detection. This PR fixes it so that it will only increment the ignore window counter if the most recent probability is below the cutoff threshold, which avoids duplicate activations when ``stop_after_detection`` is false.

Fixes an issue on the VPE where the Mycroft model would activate twice cancelling the ongoing VA pipeline.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** not applicable

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** not applicable

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

micro_wake_word:
  id: mww
  stop_after_detection: false
  models:
    - model: hey_mycroft
      id: hey_mycroft

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
