### PR TITLE
[speaker] ensure the pipeline returns an error state before returning its stopped

### DIFF
--- a/esphome/components/speaker/media_player/audio_pipeline.cpp
+++ b/esphome/components/speaker/media_player/audio_pipeline.cpp
@@ -174,6 +174,16 @@ AudioPipelineState AudioPipeline::process_state() {
     }
   }
 
+  if ((event_bits & EventGroupBits::READER_MESSAGE_ERROR)) {
+    xEventGroupClearBits(this->event_group_, EventGroupBits::READER_MESSAGE_ERROR);
+    return AudioPipelineState::ERROR_READING;
+  }
+
+  if ((event_bits & EventGroupBits::DECODER_MESSAGE_ERROR)) {
+    xEventGroupClearBits(this->event_group_, EventGroupBits::DECODER_MESSAGE_ERROR);
+    return AudioPipelineState::ERROR_DECODING;
+  }
+
   if ((event_bits & EventGroupBits::READER_MESSAGE_FINISHED) &&
       (!(event_bits & EventGroupBits::READER_MESSAGE_LOADED_MEDIA_TYPE) &&
        (event_bits & EventGroupBits::DECODER_MESSAGE_FINISHED))) {
@@ -201,16 +211,6 @@ AudioPipelineState AudioPipeline::process_state() {
     }
     this->is_playing_ = false;
     return AudioPipelineState::STOPPED;
-  }
-
-  if ((event_bits & EventGroupBits::READER_MESSAGE_ERROR)) {
-    xEventGroupClearBits(this->event_group_, EventGroupBits::READER_MESSAGE_ERROR);
-    return AudioPipelineState::ERROR_READING;
-  }
-
-  if ((event_bits & EventGroupBits::DECODER_MESSAGE_ERROR)) {
-    xEventGroupClearBits(this->event_group_, EventGroupBits::DECODER_MESSAGE_ERROR);
-    return AudioPipelineState::ERROR_DECODING;
   }
 
   if (this->pause_state_) {


### PR DESCRIPTION
# What does this implement/fix?

If the last media player action failed for whatever reason, and then the next attempt works, it would  log an error on the second attempt that was leftover from the original failure. This moves the returning error state to before returning the stop state, so that now the pipeline it gives the error at the appropriate time.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** not applicable

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** not applicable

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

media_player:
  - platform: speaker
    id: external_media_player
    name: Media Player
    internal: False
    volume_increment: 0.05
    volume_min: 0.4
    volume_max: 0.85
    announcement_pipeline:
      speaker: i2s_out_speaker
      format: FLAC     # FLAC is the least processor intensive codec
      num_channels: 1  # Stereo audio is unnecessary for announcements
      sample_rate: 48000

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
