### PR TITLE
[modbus_controller] Add assumed_state to switch

### DIFF
--- a/esphome/components/modbus_controller/switch/__init__.py
+++ b/esphome/components/modbus_controller/switch/__init__.py
@@ -63,8 +63,9 @@ async def to_code(config):
     paren = await cg.get_variable(config[CONF_MODBUS_CONTROLLER_ID])
     cg.add(var.set_parent(paren))
     cg.add(var.set_use_write_mutiple(config[CONF_USE_WRITE_MULTIPLE]))
-    cg.add(var.set_assumed_state(config[CONF_ASSUMED_STATE]))
-    if config[CONF_ASSUMED_STATE] is False:
+    assumed_state = config[CONF_ASSUMED_STATE]
+    cg.add(var.set_assumed_state(assumed_state))
+    if not assumed_state:
         cg.add(paren.add_sensor_item(var))
     if CONF_WRITE_LAMBDA in config:
         template_ = await cg.process_lambda(

--- a/esphome/components/modbus_controller/switch/__init__.py
+++ b/esphome/components/modbus_controller/switch/__init__.py
@@ -1,7 +1,7 @@
 import esphome.codegen as cg
 from esphome.components import switch
 import esphome.config_validation as cv
-from esphome.const import CONF_ADDRESS, CONF_ID
+from esphome.const import CONF_ADDRESS, CONF_ASSUMED_STATE, CONF_ID
 
 from .. import (
     MODBUS_REGISTER_TYPE,
@@ -36,6 +36,7 @@ CONFIG_SCHEMA = cv.All(
     .extend(ModbusItemBaseSchema)
     .extend(
         {
+            cv.Optional(CONF_ASSUMED_STATE, default=False): cv.boolean,
             cv.Optional(CONF_REGISTER_TYPE): cv.enum(MODBUS_REGISTER_TYPE),
             cv.Optional(CONF_USE_WRITE_MULTIPLE, default=False): cv.boolean,
             cv.Optional(CONF_WRITE_LAMBDA): cv.returning_lambda,
@@ -62,7 +63,9 @@ async def to_code(config):
     paren = await cg.get_variable(config[CONF_MODBUS_CONTROLLER_ID])
     cg.add(var.set_parent(paren))
     cg.add(var.set_use_write_mutiple(config[CONF_USE_WRITE_MULTIPLE]))
-    cg.add(paren.add_sensor_item(var))
+    cg.add(var.set_assumed_state(config[CONF_ASSUMED_STATE]))
+    if config[CONF_ASSUMED_STATE] is False:
+        cg.add(paren.add_sensor_item(var))
     if CONF_WRITE_LAMBDA in config:
         template_ = await cg.process_lambda(
             config[CONF_WRITE_LAMBDA],

--- a/esphome/components/modbus_controller/switch/modbus_switch.cpp
+++ b/esphome/components/modbus_controller/switch/modbus_switch.cpp
@@ -19,6 +19,10 @@ void ModbusSwitch::setup() {
 }
 void ModbusSwitch::dump_config() { LOG_SWITCH(TAG, "Modbus Controller Switch", this); }
 
+void ModbusSwitch::set_assumed_state(bool assumed_state) { this->assumed_state_ = assumed_state; }
+
+bool ModbusSwitch::assumed_state() { return this->assumed_state_; }
+
 void ModbusSwitch::parse_and_publish(const std::vector<uint8_t> &data) {
   bool value = false;
   switch (this->register_type) {

--- a/esphome/components/modbus_controller/switch/modbus_switch.h
+++ b/esphome/components/modbus_controller/switch/modbus_switch.h
@@ -29,6 +29,7 @@ class ModbusSwitch : public Component, public switch_::Switch, public SensorItem
   void setup() override;
   void write_state(bool state) override;
   void dump_config() override;
+  void set_assumed_state(bool assumed_state);
   void set_state(bool state) { this->state = state; }
   void parse_and_publish(const std::vector<uint8_t> &data) override;
   void set_parent(ModbusController *parent) { this->parent_ = parent; }
@@ -40,10 +41,12 @@ class ModbusSwitch : public Component, public switch_::Switch, public SensorItem
   void set_use_write_mutiple(bool use_write_multiple) { this->use_write_multiple_ = use_write_multiple; }
 
  protected:
+  bool assumed_state() override;
   ModbusController *parent_{nullptr};
   bool use_write_multiple_{false};
   optional<transform_func_t> publish_transform_func_{nullopt};
   optional<write_transform_func_t> write_transform_func_{nullopt};
+  bool assumed_state_{false};
 };
 
 }  // namespace modbus_controller


### PR DESCRIPTION
# What does this implement/fix?
Fix for https://github.com/esphome/feature-requests/issues/3159
<!-- Quick description and explanation of changes -->
* Adds option `assumed_state` to switch configuration which disables read updates for the switch

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/feature-requests/issues/3159


**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#4933

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
switch:
  - platform: modbus_controller
    modbus_controller_id: modbus1
    id: switch1
    register_type: coil
    address: 0x0002
    assumed_state: true
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
