### PR TITLE
Use UINT16_MAX instead of hard coded 65535 in api

### DIFF
--- a/esphome/components/api/api_frame_helper.cpp
+++ b/esphome/components/api/api_frame_helper.cpp
@@ -8,7 +8,6 @@
 #include "api_pb2_size.h"
 #include <cstring>
 #include <cinttypes>
-#include <limits>
 
 namespace esphome {
 namespace api {

--- a/esphome/components/api/api_frame_helper.cpp
+++ b/esphome/components/api/api_frame_helper.cpp
@@ -8,6 +8,7 @@
 #include "api_pb2_size.h"
 #include <cstring>
 #include <cinttypes>
+#include <limits>
 
 namespace esphome {
 namespace api {
@@ -887,7 +888,7 @@ APIError APIPlaintextFrameHelper::try_read_frame_(ParsedFrame *frame) {
     //   - At least 2 bytes in the buffer for the varints
     // Buffer layout:
     //   First 1-3 bytes: Message size varint (variable length)
-    //     - 2 bytes would only allow up to 16383, which is less than noise's 65535
+    //     - 2 bytes would only allow up to 16383, which is less than noise's UINT16_MAX (65535)
     //     - 3 bytes allows up to 2097151, ensuring we support at least as much as noise
     //   Remaining 1-2 bytes: Message type varint (variable length)
     // We now attempt to parse both varints. If either is incomplete,
@@ -900,9 +901,9 @@ APIError APIPlaintextFrameHelper::try_read_frame_(ParsedFrame *frame) {
       continue;
     }
 
-    if (msg_size_varint->as_uint32() > 65535) {
+    if (msg_size_varint->as_uint32() > UINT16_MAX) {
       state_ = State::FAILED;
-      HELPER_LOG("Bad packet: message size %" PRIu32 " exceeds maximum 65535", msg_size_varint->as_uint32());
+      HELPER_LOG("Bad packet: message size %" PRIu32 " exceeds maximum %u", msg_size_varint->as_uint32(), UINT16_MAX);
       return APIError::BAD_DATA_PACKET;
     }
     rx_header_parsed_len_ = msg_size_varint->as_uint16();
@@ -912,9 +913,9 @@ APIError APIPlaintextFrameHelper::try_read_frame_(ParsedFrame *frame) {
       // not enough data there yet
       continue;
     }
-    if (msg_type_varint->as_uint32() > 65535) {
+    if (msg_type_varint->as_uint32() > UINT16_MAX) {
       state_ = State::FAILED;
-      HELPER_LOG("Bad packet: message type %" PRIu32 " exceeds maximum 65535", msg_type_varint->as_uint32());
+      HELPER_LOG("Bad packet: message type %" PRIu32 " exceeds maximum %u", msg_type_varint->as_uint32(), UINT16_MAX);
       return APIError::BAD_DATA_PACKET;
     }
     rx_header_parsed_type_ = msg_type_varint->as_uint16();

--- a/esphome/components/api/api_frame_helper.cpp
+++ b/esphome/components/api/api_frame_helper.cpp
@@ -901,9 +901,10 @@ APIError APIPlaintextFrameHelper::try_read_frame_(ParsedFrame *frame) {
       continue;
     }
 
-    if (msg_size_varint->as_uint32() > UINT16_MAX) {
+    if (msg_size_varint->as_uint32() > std::numeric_limits<uint16_t>::max()) {
       state_ = State::FAILED;
-      HELPER_LOG("Bad packet: message size %" PRIu32 " exceeds maximum %u", msg_size_varint->as_uint32(), UINT16_MAX);
+      HELPER_LOG("Bad packet: message size %" PRIu32 " exceeds maximum %u", msg_size_varint->as_uint32(),
+                 std::numeric_limits<uint16_t>::max());
       return APIError::BAD_DATA_PACKET;
     }
     rx_header_parsed_len_ = msg_size_varint->as_uint16();
@@ -913,9 +914,10 @@ APIError APIPlaintextFrameHelper::try_read_frame_(ParsedFrame *frame) {
       // not enough data there yet
       continue;
     }
-    if (msg_type_varint->as_uint32() > UINT16_MAX) {
+    if (msg_type_varint->as_uint32() > std::numeric_limits<uint16_t>::max()) {
       state_ = State::FAILED;
-      HELPER_LOG("Bad packet: message type %" PRIu32 " exceeds maximum %u", msg_type_varint->as_uint32(), UINT16_MAX);
+      HELPER_LOG("Bad packet: message type %" PRIu32 " exceeds maximum %u", msg_type_varint->as_uint32(),
+                 std::numeric_limits<uint16_t>::max());
       return APIError::BAD_DATA_PACKET;
     }
     rx_header_parsed_type_ = msg_type_varint->as_uint16();

--- a/esphome/components/api/api_frame_helper.h
+++ b/esphome/components/api/api_frame_helper.h
@@ -101,7 +101,7 @@ class APIFrameHelper {
     std::vector<uint8_t> data;
     uint16_t offset{0};  // Current offset within the buffer (uint16_t to reduce memory usage)
 
-    // Using uint16_t reduces memory usage since ESPHome API messages are limited to 64KB max
+    // Using uint16_t reduces memory usage since ESPHome API messages are limited to UINT16_MAX (65535) bytes
     uint16_t remaining() const { return static_cast<uint16_t>(data.size()) - offset; }
     const uint8_t *current_data() const { return data.data() + offset; }
   };
@@ -192,7 +192,7 @@ class APINoiseFrameHelper : public APIFrameHelper {
   void send_explicit_handshake_reject_(const std::string &reason);
   // Fixed-size header buffer for noise protocol:
   // 1 byte for indicator + 2 bytes for message size (16-bit value, not varint)
-  // Note: Maximum message size is 65535, with a limit of 128 bytes during handshake phase
+  // Note: Maximum message size is UINT16_MAX (65535), with a limit of 128 bytes during handshake phase
   uint8_t rx_header_buf_[3];
   uint8_t rx_header_buf_len_ = 0;
 
@@ -230,7 +230,7 @@ class APIPlaintextFrameHelper : public APIFrameHelper {
   APIError try_read_frame_(ParsedFrame *frame);
   // Fixed-size header buffer for plaintext protocol:
   // We only need space for the two varints since we validate the indicator byte separately.
-  // To match noise protocol's maximum message size (65535), we need:
+  // To match noise protocol's maximum message size (UINT16_MAX = 65535), we need:
   // 3 bytes for message size varint (supports up to 2097151) + 2 bytes for message type varint
   //
   // While varints could theoretically be up to 10 bytes each for 64-bit values,

--- a/esphome/components/api/api_frame_helper.h
+++ b/esphome/components/api/api_frame_helper.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <cstdint>
 #include <deque>
+#include <limits>
 #include <utility>
 #include <vector>
 


### PR DESCRIPTION
# What does this implement/fix?

Use `std::numeric_limits<uint16_t>::max()` instead of hard coded 65535 in api
https://github.com/esphome/esphome/pull/8805#discussion_r2103255012

```
external_components:
  - source: github://pr#8884
    components: [ api ]
    refresh: 0s
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
