### PR TITLE
made qr_code elements optional

### DIFF
--- a/esphome/components/qr_code/__init__.py
+++ b/esphome/components/qr_code/__init__.py
@@ -21,21 +21,24 @@ ECC = {
     "HIGH": qrcodegen_Ecc.qrcodegen_Ecc_HIGH,
 }
 
-CONFIG_SCHEMA = cv.Schema(
-    {
-        cv.Required(CONF_ID): cv.declare_id(QRCode),
-        cv.Required(CONF_VALUE): cv.string,
-        cv.Optional(CONF_ECC, default="LOW"): cv.enum(ECC, upper=True),
-    }
+CONFIG_SCHEMA = cv.ensure_list(
+    cv.Schema(
+        {
+            cv.Required(CONF_ID): cv.declare_id(QRCode),
+            cv.Required(CONF_VALUE): cv.string,
+            cv.Optional(CONF_ECC, default="LOW"): cv.enum(ECC, upper=True),
+        }
+    )
 )
 
 
 async def to_code(config):
     cg.add_library("wjtje/qr-code-generator-library", "^1.7.0")
 
-    var = cg.new_Pvariable(config[CONF_ID])
-    cg.add(var.set_value(config[CONF_VALUE]))
-    cg.add(var.set_ecc(ECC[config[CONF_ECC]]))
-    await cg.register_component(var, config)
+    for entry in config:
+        var = cg.new_Pvariable(entry[CONF_ID])
+        cg.add(var.set_value(entry[CONF_VALUE]))
+        cg.add(var.set_ecc(ECC[entry[CONF_ECC]]))
+        await cg.register_component(var, entry)
 
     cg.add_define("USE_QR_CODE")


### PR DESCRIPTION
# What does this implement/fix?

I am writing an external component which has the option to use qr codes so I would like to add `qr_code` to my `AUTO_LOAD` list. This was previously not possible as the validator always complained about a missing `id` field unless I added an dummy `qr_code` object to the yaml.
These changes now allow an empty list which fixes my issue.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
Not really applicable I think.
```yaml
# Example config.yaml
qr_code:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
