### PR TITLE
[Fix] webserver esp-idf v5.5

### DIFF
--- a/esphome/components/web_server_idf/web_server_idf.cpp
+++ b/esphome/components/web_server_idf/web_server_idf.cpp
@@ -81,8 +81,11 @@ esp_err_t AsyncWebServer::request_post_handler(httpd_req_t *r) {
     httpd_resp_send_err(r, HTTPD_411_LENGTH_REQUIRED, nullptr);
     return ESP_OK;
   }
-
+#if (ESP_IDF_VERSION_MAJOR <= 5) && (ESP_IDF_VERSION_MINOR <= 5)
+  if (r->content_len > CONFIG_HTTPD_MAX_REQ_HDR_LEN) {
+#else
   if (r->content_len > HTTPD_MAX_REQ_HDR_LEN) {
+#endif
     ESP_LOGW(TAG, "Request size is to big: %zu", r->content_len);
     httpd_resp_send_err(r, HTTPD_400_BAD_REQUEST, nullptr);
     return ESP_FAIL;

--- a/tests/components/web_server/test.esp32-c5-idf.yaml
+++ b/tests/components/web_server/test.esp32-c5-idf.yaml
@@ -1,0 +1,1 @@
+<<: !include common_v2.yaml


### PR DESCRIPTION
# What does this implement/fix?

allowing Webserver on ESP32-C5  (ESP-IDF v5.5)


## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
esp32:
  board: esp32-c5-devkitc-1
  framework:
    type: esp-idf
    version: 5.5.0
    release: "20250510"
    platform_version: 55.03.30-alpha1

web_server:
  port: 80    
  version: 3
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
