### PR TITLE
[web_server] Fix download list where external_components has a substitution value

### DIFF
--- a/esphome/dashboard/web_server.py
+++ b/esphome/dashboard/web_server.py
@@ -602,7 +602,7 @@ class DownloadListRequestHandler(BaseHandler):
         try:
             downloads_json = await loop.run_in_executor(None, self._get, configuration)
         except vol.Invalid as exc:
-            _LOGGER.error(exc)
+            _LOGGER.exception("Error while fetching downloads", exc_info=exc)
             self.send_error(404)
             return
         if downloads_json is None:

--- a/esphome/dashboard/web_server.py
+++ b/esphome/dashboard/web_server.py
@@ -601,10 +601,12 @@ class DownloadListRequestHandler(BaseHandler):
         loop = asyncio.get_running_loop()
         try:
             downloads_json = await loop.run_in_executor(None, self._get, configuration)
-        except vol.Invalid:
+        except vol.Invalid as exc:
+            _LOGGER.error(exc)
             self.send_error(404)
             return
         if downloads_json is None:
+            _LOGGER.error("Configuration %s not found", configuration)
             self.send_error(404)
             return
         self.set_status(200)
@@ -618,14 +620,17 @@ class DownloadListRequestHandler(BaseHandler):
         if storage_json is None:
             return None
 
-        config = yaml_util.load_yaml(settings.rel_path(configuration))
+        try:
+            config = yaml_util.load_yaml(settings.rel_path(configuration))
 
-        if const.CONF_EXTERNAL_COMPONENTS in config:
-            from esphome.components.external_components import (
-                do_external_components_pass,
-            )
+            if const.CONF_EXTERNAL_COMPONENTS in config:
+                from esphome.components.external_components import (
+                    do_external_components_pass,
+                )
 
-            do_external_components_pass(config)
+                do_external_components_pass(config)
+        except vol.Invalid:
+            _LOGGER.info("Could not parse `external_components`, skipping")
 
         from esphome.components.esp32 import VARIANTS as ESP32_VARIANTS
 


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

#8139 tries to parse `external_components` in order to see if the platform is located as one (for #7049)

Unfortunately as it does not use the entire yaml parser in ESPHome, it fails if there are substitutions in the external components (and possibly in other places too)

For now, wrap that code and skip if it goes wrong as it is not important to all merged code in ESPHome.

```
2025-05-27 07:51:58,895 ERROR Invalid external components configuration: Source is not a file system path, in expected github://username/name[@branch-or-tag] or github://pr#1234 format! for dictionary value @ data['external_components'][0]['source']
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
