### PR TITLE
Fix flakey tests

### DIFF
--- a/tests/dashboard/test_web_server.py
+++ b/tests/dashboard/test_web_server.py
@@ -53,6 +53,8 @@ async def dashboard() -> DashboardTestHelper:
     assert DASHBOARD.settings.on_ha_addon is True
     assert DASHBOARD.settings.using_auth is False
     task = asyncio.create_task(DASHBOARD.async_run())
+    # Wait for initial device loading to complete
+    await DASHBOARD.entries.async_request_update_entries()
     client = AsyncHTTPClient()
     io_loop = IOLoop(make_current=False)
     yield DashboardTestHelper(io_loop, client, port)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 from collections.abc import AsyncGenerator, Generator
 from contextlib import AbstractAsyncContextManager, asynccontextmanager
+import logging
 from pathlib import Path
 import platform
 import signal
@@ -38,6 +39,29 @@ from .types import (
     RunCompiledFunction,
     RunFunction,
 )
+
+
+@pytest.fixture(scope="module", autouse=True)
+def enable_aioesphomeapi_debug_logging():
+    """Enable debug logging for aioesphomeapi to help diagnose connection issues."""
+    # Get the aioesphomeapi logger
+    logger = logging.getLogger("aioesphomeapi")
+    # Save the original level
+    original_level = logger.level
+    # Set to DEBUG level
+    logger.setLevel(logging.DEBUG)
+    # Also ensure we have a handler that outputs to console
+    if not logger.handlers:
+        handler = logging.StreamHandler()
+        handler.setLevel(logging.DEBUG)
+        formatter = logging.Formatter(
+            "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+        )
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+    yield
+    # Restore original level
+    logger.setLevel(original_level)
 
 
 @pytest.fixture

--- a/tests/integration/const.py
+++ b/tests/integration/const.py
@@ -2,7 +2,7 @@
 
 # Network constants
 DEFAULT_API_PORT = 6053
-LOCALHOST = "localhost"
+LOCALHOST = "127.0.0.1"
 
 # Timeout constants
 API_CONNECTION_TIMEOUT = 30.0  # seconds


### PR DESCRIPTION
# What does this implement/fix?

- Make sure the integrations test log the aioesphomeapi output
- Connect to 127.0.0.1 instead of localhost as the api would try to lookup localhost via mDNS which sometimes fails in the CI
- There was a race between when the dashboard finished starting up and the test would execute looking for entries


## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
