### PR TITLE
Streamline setup() logging (a, b)

### DIFF
--- a/esphome/components/a4988/a4988.cpp
+++ b/esphome/components/a4988/a4988.cpp
@@ -7,7 +7,7 @@ namespace a4988 {
 static const char *const TAG = "a4988.stepper";
 
 void A4988::setup() {
-  ESP_LOGCONFIG(TAG, "Setting up A4988...");
+  ESP_LOGCONFIG(TAG, "Running setup");
   if (this->sleep_pin_ != nullptr) {
     this->sleep_pin_->setup();
     this->sleep_pin_->digital_write(false);

--- a/esphome/components/absolute_humidity/absolute_humidity.cpp
+++ b/esphome/components/absolute_humidity/absolute_humidity.cpp
@@ -7,7 +7,7 @@ namespace absolute_humidity {
 static const char *const TAG = "absolute_humidity.sensor";
 
 void AbsoluteHumidityComponent::setup() {
-  ESP_LOGCONFIG(TAG, "Setting up absolute humidity '%s'...", this->get_name().c_str());
+  ESP_LOGCONFIG(TAG, "Running setup for '%s'", this->get_name().c_str());
 
   ESP_LOGD(TAG, "  Added callback for temperature '%s'", this->temperature_sensor_->get_name().c_str());
   this->temperature_sensor_->add_on_state_callback([this](float state) { this->temperature_callback_(state); });

--- a/esphome/components/adc/adc_sensor_esp32.cpp
+++ b/esphome/components/adc/adc_sensor_esp32.cpp
@@ -22,7 +22,7 @@ static const int ADC_MAX = (1 << SOC_ADC_RTC_MAX_BITWIDTH) - 1;
 static const int ADC_HALF = (1 << SOC_ADC_RTC_MAX_BITWIDTH) >> 1;
 
 void ADCSensor::setup() {
-  ESP_LOGCONFIG(TAG, "Setting up ADC '%s'...", this->get_name().c_str());
+  ESP_LOGCONFIG(TAG, "Running setup for '%s'...", this->get_name().c_str());
 
   if (this->channel1_ != ADC1_CHANNEL_MAX) {
     adc1_config_width(ADC_WIDTH_MAX_SOC_BITS);

--- a/esphome/components/adc/adc_sensor_esp8266.cpp
+++ b/esphome/components/adc/adc_sensor_esp8266.cpp
@@ -17,7 +17,7 @@ namespace adc {
 static const char *const TAG = "adc.esp8266";
 
 void ADCSensor::setup() {
-  ESP_LOGCONFIG(TAG, "Setting up ADC '%s'...", this->get_name().c_str());
+  ESP_LOGCONFIG(TAG, "Running setup for '%s'...", this->get_name().c_str());
 #ifndef USE_ADC_SENSOR_VCC
   this->pin_->setup();
 #endif

--- a/esphome/components/adc/adc_sensor_libretiny.cpp
+++ b/esphome/components/adc/adc_sensor_libretiny.cpp
@@ -9,7 +9,7 @@ namespace adc {
 static const char *const TAG = "adc.libretiny";
 
 void ADCSensor::setup() {
-  ESP_LOGCONFIG(TAG, "Setting up ADC '%s'...", this->get_name().c_str());
+  ESP_LOGCONFIG(TAG, "Running setup for '%s'...", this->get_name().c_str());
 #ifndef USE_ADC_SENSOR_VCC
   this->pin_->setup();
 #endif  // !USE_ADC_SENSOR_VCC

--- a/esphome/components/adc/adc_sensor_rp2040.cpp
+++ b/esphome/components/adc/adc_sensor_rp2040.cpp
@@ -14,7 +14,7 @@ namespace adc {
 static const char *const TAG = "adc.rp2040";
 
 void ADCSensor::setup() {
-  ESP_LOGCONFIG(TAG, "Setting up ADC '%s'...", this->get_name().c_str());
+  ESP_LOGCONFIG(TAG, "Running setup for '%s'...", this->get_name().c_str());
   static bool initialized = false;
   if (!initialized) {
     adc_init();

--- a/esphome/components/adc128s102/adc128s102.cpp
+++ b/esphome/components/adc128s102/adc128s102.cpp
@@ -9,7 +9,7 @@ static const char *const TAG = "adc128s102";
 float ADC128S102::get_setup_priority() const { return setup_priority::HARDWARE; }
 
 void ADC128S102::setup() {
-  ESP_LOGCONFIG(TAG, "Setting up adc128s102");
+  ESP_LOGCONFIG(TAG, "Running setup");
   this->spi_setup();
 }
 

--- a/esphome/components/ads1115/ads1115.cpp
+++ b/esphome/components/ads1115/ads1115.cpp
@@ -10,7 +10,7 @@ static const uint8_t ADS1115_REGISTER_CONVERSION = 0x00;
 static const uint8_t ADS1115_REGISTER_CONFIG = 0x01;
 
 void ADS1115Component::setup() {
-  ESP_LOGCONFIG(TAG, "Setting up ADS1115...");
+  ESP_LOGCONFIG(TAG, "Running setup");
   uint16_t value;
   if (!this->read_byte_16(ADS1115_REGISTER_CONVERSION, &value)) {
     this->mark_failed();
@@ -68,7 +68,7 @@ void ADS1115Component::setup() {
   this->prev_config_ = config;
 }
 void ADS1115Component::dump_config() {
-  ESP_LOGCONFIG(TAG, "Setting up ADS1115...");
+  ESP_LOGCONFIG(TAG, "ADS1115:");
   LOG_I2C_DEVICE(this);
   if (this->is_failed()) {
     ESP_LOGE(TAG, "Communication with ADS1115 failed!");

--- a/esphome/components/ads1118/ads1118.cpp
+++ b/esphome/components/ads1118/ads1118.cpp
@@ -8,7 +8,7 @@ static const char *const TAG = "ads1118";
 static const uint8_t ADS1118_DATA_RATE_860_SPS = 0b111;
 
 void ADS1118::setup() {
-  ESP_LOGCONFIG(TAG, "Setting up ads1118");
+  ESP_LOGCONFIG(TAG, "Running setup");
   this->spi_setup();
 
   this->config_ = 0;

--- a/esphome/components/ags10/ags10.cpp
+++ b/esphome/components/ags10/ags10.cpp
@@ -23,7 +23,7 @@ static const uint16_t ZP_CURRENT = 0x0000;
 static const uint16_t ZP_DEFAULT = 0xFFFF;
 
 void AGS10Component::setup() {
-  ESP_LOGCONFIG(TAG, "Setting up ags10...");
+  ESP_LOGCONFIG(TAG, "Running setup");
 
   auto version = this->read_version_();
   if (version) {

--- a/esphome/components/aic3204/aic3204.cpp
+++ b/esphome/components/aic3204/aic3204.cpp
@@ -17,7 +17,7 @@ static const char *const TAG = "aic3204";
   }
 
 void AIC3204::setup() {
-  ESP_LOGCONFIG(TAG, "Setting up AIC3204...");
+  ESP_LOGCONFIG(TAG, "Running setup");
 
   // Set register page to 0
   ERROR_CHECK(this->write_byte(AIC3204_PAGE_CTRL, 0x00), "Set page 0 failed");

--- a/esphome/components/am2315c/am2315c.cpp
+++ b/esphome/components/am2315c/am2315c.cpp
@@ -90,7 +90,7 @@ bool AM2315C::convert_(uint8_t *data, float &humidity, float &temperature) {
 }
 
 void AM2315C::setup() {
-  ESP_LOGCONFIG(TAG, "Setting up AM2315C...");
+  ESP_LOGCONFIG(TAG, "Running setup");
 
   // get status
   uint8_t status = 0;

--- a/esphome/components/am2320/am2320.cpp
+++ b/esphome/components/am2320/am2320.cpp
@@ -34,7 +34,7 @@ void AM2320Component::update() {
   this->status_clear_warning();
 }
 void AM2320Component::setup() {
-  ESP_LOGCONFIG(TAG, "Setting up AM2320...");
+  ESP_LOGCONFIG(TAG, "Running setup");
   uint8_t data[8];
   data[0] = 0;
   data[1] = 4;

--- a/esphome/components/apds9306/apds9306.cpp
+++ b/esphome/components/apds9306/apds9306.cpp
@@ -54,7 +54,7 @@ enum {  // APDS9306 registers
   }
 
 void APDS9306::setup() {
-  ESP_LOGCONFIG(TAG, "Setting up APDS9306...");
+  ESP_LOGCONFIG(TAG, "Running setup");
 
   uint8_t id;
   if (!this->read_byte(APDS9306_PART_ID, &id)) {  // Part ID register

--- a/esphome/components/apds9960/apds9960.cpp
+++ b/esphome/components/apds9960/apds9960.cpp
@@ -15,7 +15,7 @@ static const char *const TAG = "apds9960";
 #define APDS9960_WRITE_BYTE(reg, value) APDS9960_ERROR_CHECK(this->write_byte(reg, value));
 
 void APDS9960::setup() {
-  ESP_LOGCONFIG(TAG, "Setting up APDS9960...");
+  ESP_LOGCONFIG(TAG, "Running setup");
   uint8_t id;
   if (!this->read_byte(0x92, &id)) {  // ID register
     this->error_code_ = COMMUNICATION_FAILED;

--- a/esphome/components/api/api_server.cpp
+++ b/esphome/components/api/api_server.cpp
@@ -27,7 +27,7 @@ APIServer *global_api_server = nullptr;  // NOLINT(cppcoreguidelines-avoid-non-c
 APIServer::APIServer() { global_api_server = this; }
 
 void APIServer::setup() {
-  ESP_LOGCONFIG(TAG, "Setting up Home Assistant API server...");
+  ESP_LOGCONFIG(TAG, "Running setup");
   this->setup_controller();
 
 #ifdef USE_API_NOISE

--- a/esphome/components/as3935/as3935.cpp
+++ b/esphome/components/as3935/as3935.cpp
@@ -7,7 +7,7 @@ namespace as3935 {
 static const char *const TAG = "as3935";
 
 void AS3935Component::setup() {
-  ESP_LOGCONFIG(TAG, "Setting up AS3935...");
+  ESP_LOGCONFIG(TAG, "Running setup");
 
   this->irq_pin_->setup();
   LOG_PIN("  IRQ Pin: ", this->irq_pin_);

--- a/esphome/components/as5600/as5600.cpp
+++ b/esphome/components/as5600/as5600.cpp
@@ -23,7 +23,7 @@ static const uint8_t REGISTER_AGC = 0x1A;        // 8 bytes  / R
 static const uint8_t REGISTER_MAGNITUDE = 0x1B;  // 16 bytes / R
 
 void AS5600Component::setup() {
-  ESP_LOGCONFIG(TAG, "Setting up AS5600...");
+  ESP_LOGCONFIG(TAG, "Running setup");
 
   if (!this->read_byte(REGISTER_STATUS).has_value()) {
     this->mark_failed();

--- a/esphome/components/as7341/as7341.cpp
+++ b/esphome/components/as7341/as7341.cpp
@@ -8,7 +8,7 @@ namespace as7341 {
 static const char *const TAG = "as7341";
 
 void AS7341Component::setup() {
-  ESP_LOGCONFIG(TAG, "Setting up AS7341...");
+  ESP_LOGCONFIG(TAG, "Running setup");
   LOG_I2C_DEVICE(this);
 
   // Verify device ID

--- a/esphome/components/at581x/at581x.cpp
+++ b/esphome/components/at581x/at581x.cpp
@@ -71,7 +71,7 @@ bool AT581XComponent::i2c_read_reg(uint8_t addr, uint8_t &data) {
   return this->read_register(addr, &data, 1) == esphome::i2c::NO_ERROR;
 }
 
-void AT581XComponent::setup() { ESP_LOGCONFIG(TAG, "Setting up AT581X..."); }
+void AT581XComponent::setup() { ESP_LOGCONFIG(TAG, "Running setup"); }
 void AT581XComponent::dump_config() { LOG_I2C_DEVICE(this); }
 #define ARRAY_SIZE(X) (sizeof(X) / sizeof((X)[0]))
 bool AT581XComponent::i2c_write_config() {

--- a/esphome/components/atm90e26/atm90e26.cpp
+++ b/esphome/components/atm90e26/atm90e26.cpp
@@ -41,7 +41,7 @@ void ATM90E26Component::update() {
 }
 
 void ATM90E26Component::setup() {
-  ESP_LOGCONFIG(TAG, "Setting up ATM90E26 Component...");
+  ESP_LOGCONFIG(TAG, "Running setup");
   this->spi_setup();
 
   uint16_t mmode = 0x422;  // default values for everything but L/N line current gains

--- a/esphome/components/atm90e32/atm90e32.cpp
+++ b/esphome/components/atm90e32/atm90e32.cpp
@@ -108,7 +108,7 @@ void ATM90E32Component::update() {
 }
 
 void ATM90E32Component::setup() {
-  ESP_LOGCONFIG(TAG, "Setting up ATM90E32 Component...");
+  ESP_LOGCONFIG(TAG, "Running setup");
   this->spi_setup();
 
   uint16_t mmode0 = 0x87;  // 3P4W 50Hz

--- a/esphome/components/axs15231/touchscreen/axs15231_touchscreen.cpp
+++ b/esphome/components/axs15231/touchscreen/axs15231_touchscreen.cpp
@@ -17,7 +17,7 @@ constexpr static const uint8_t AXS_READ_TOUCHPAD[11] = {0xb5, 0xab, 0xa5, 0x5a, 
   }
 
 void AXS15231Touchscreen::setup() {
-  ESP_LOGCONFIG(TAG, "Setting up AXS15231 Touchscreen...");
+  ESP_LOGCONFIG(TAG, "Running setup");
   if (this->reset_pin_ != nullptr) {
     this->reset_pin_->setup();
     this->reset_pin_->digital_write(false);

--- a/esphome/components/beken_spi_led_strip/led_strip.cpp
+++ b/esphome/components/beken_spi_led_strip/led_strip.cpp
@@ -119,7 +119,7 @@ void spi_dma_tx_finish_callback(unsigned int param) {
 }
 
 void BekenSPILEDStripLightOutput::setup() {
-  ESP_LOGCONFIG(TAG, "Setting up Beken SPI LED Strip...");
+  ESP_LOGCONFIG(TAG, "Running setup");
 
   size_t buffer_size = this->get_buffer_size_();
   size_t dma_buffer_size = (buffer_size * 8) + (2 * 64);

--- a/esphome/components/bh1750/bh1750.cpp
+++ b/esphome/components/bh1750/bh1750.cpp
@@ -38,7 +38,7 @@ MTreg:
 */
 
 void BH1750Sensor::setup() {
-  ESP_LOGCONFIG(TAG, "Setting up BH1750 '%s'...", this->name_.c_str());
+  ESP_LOGCONFIG(TAG, "Running setup for '%s'", this->name_.c_str());
   uint8_t turn_on = BH1750_COMMAND_POWER_ON;
   if (this->write(&turn_on, 1) != i2c::ERROR_OK) {
     this->mark_failed();

--- a/esphome/components/bme280_base/bme280_base.cpp
+++ b/esphome/components/bme280_base/bme280_base.cpp
@@ -88,7 +88,7 @@ const char *oversampling_to_str(BME280Oversampling oversampling) {  // NOLINT
 }
 
 void BME280Component::setup() {
-  ESP_LOGCONFIG(TAG, "Setting up BME280...");
+  ESP_LOGCONFIG(TAG, "Running setup");
   uint8_t chip_id = 0;
 
   // Mark as not failed before initializing. Some devices will turn off sensors to save on batteries

--- a/esphome/components/bme680/bme680.cpp
+++ b/esphome/components/bme680/bme680.cpp
@@ -71,7 +71,7 @@ static const char *iir_filter_to_str(BME680IIRFilter filter) {
 }
 
 void BME680Component::setup() {
-  ESP_LOGCONFIG(TAG, "Setting up BME680...");
+  ESP_LOGCONFIG(TAG, "Running setup");
   uint8_t chip_id;
   if (!this->read_byte(BME680_REGISTER_CHIPID, &chip_id) || chip_id != 0x61) {
     this->mark_failed();

--- a/esphome/components/bme680_bsec/bme680_bsec.cpp
+++ b/esphome/components/bme680_bsec/bme680_bsec.cpp
@@ -15,7 +15,7 @@ std::vector<BME680BSECComponent *>
 uint8_t BME680BSECComponent::work_buffer_[BSEC_MAX_WORKBUFFER_SIZE] = {0};
 
 void BME680BSECComponent::setup() {
-  ESP_LOGCONFIG(TAG, "Setting up BME680(%s) via BSEC...", this->device_id_.c_str());
+  ESP_LOGCONFIG(TAG, "Running setup for '%s'", this->device_id_.c_str());
 
   uint8_t new_idx = BME680BSECComponent::instances.size();
   BME680BSECComponent::instances.push_back(this);

--- a/esphome/components/bme68x_bsec2/bme68x_bsec2.cpp
+++ b/esphome/components/bme68x_bsec2/bme68x_bsec2.cpp
@@ -21,7 +21,7 @@ static const char *const TAG = "bme68x_bsec2.sensor";
 static const std::string IAQ_ACCURACY_STATES[4] = {"Stabilizing", "Uncertain", "Calibrating", "Calibrated"};
 
 void BME68xBSEC2Component::setup() {
-  ESP_LOGCONFIG(TAG, "Setting up BME68X via BSEC2...");
+  ESP_LOGCONFIG(TAG, "Running setup");
 
   this->bsec_status_ = bsec_init_m(&this->bsec_instance_);
   if (this->bsec_status_ != BSEC_OK) {

--- a/esphome/components/bmi160/bmi160.cpp
+++ b/esphome/components/bmi160/bmi160.cpp
@@ -119,7 +119,7 @@ const float GRAVITY_EARTH = 9.80665f;
 void BMI160Component::internal_setup_(int stage) {
   switch (stage) {
     case 0:
-      ESP_LOGCONFIG(TAG, "Setting up BMI160...");
+      ESP_LOGCONFIG(TAG, "Running setup");
       uint8_t chipid;
       if (!this->read_byte(BMI160_REGISTER_CHIPID, &chipid) || (chipid != 0b11010001)) {
         this->mark_failed();

--- a/esphome/components/bmp085/bmp085.cpp
+++ b/esphome/components/bmp085/bmp085.cpp
@@ -20,7 +20,7 @@ void BMP085Component::update() {
   this->set_timeout("temperature", 5, [this]() { this->read_temperature_(); });
 }
 void BMP085Component::setup() {
-  ESP_LOGCONFIG(TAG, "Setting up BMP085...");
+  ESP_LOGCONFIG(TAG, "Running setup");
   uint8_t data[22];
   if (!this->read_bytes(BMP085_REGISTER_AC1_H, data, 22)) {
     this->mark_failed();

--- a/esphome/components/bmp280_base/bmp280_base.cpp
+++ b/esphome/components/bmp280_base/bmp280_base.cpp
@@ -57,7 +57,7 @@ static const char *iir_filter_to_str(BMP280IIRFilter filter) {
 }
 
 void BMP280Component::setup() {
-  ESP_LOGCONFIG(TAG, "Setting up BMP280...");
+  ESP_LOGCONFIG(TAG, "Running setup");
   uint8_t chip_id = 0;
 
   // Read the chip id twice, to work around a bug where the first read is 0.

--- a/esphome/components/bmp3xx_base/bmp3xx_base.cpp
+++ b/esphome/components/bmp3xx_base/bmp3xx_base.cpp
@@ -70,7 +70,7 @@ static const LogString *iir_filter_to_str(IIRFilter filter) {
 
 void BMP3XXComponent::setup() {
   this->error_code_ = NONE;
-  ESP_LOGCONFIG(TAG, "Setting up BMP3XX...");
+  ESP_LOGCONFIG(TAG, "Running setup");
   // Call the Device base class "initialise" function
   if (!reset()) {
     ESP_LOGE(TAG, "Failed to reset BMP3XX...");

--- a/esphome/components/bmp581/bmp581.cpp
+++ b/esphome/components/bmp581/bmp581.cpp
@@ -122,7 +122,7 @@ void BMP581Component::setup() {
    */
 
   this->error_code_ = NONE;
-  ESP_LOGCONFIG(TAG, "Setting up BMP581...");
+  ESP_LOGCONFIG(TAG, "Running setup");
 
   ////////////////////
   // 1) Soft reboot //

--- a/esphome/components/bp1658cj/bp1658cj.cpp
+++ b/esphome/components/bp1658cj/bp1658cj.cpp
@@ -15,7 +15,7 @@ static const uint8_t BP1658CJ_ADDR_START_5CH = 0x30;
 static const uint8_t BP1658CJ_DELAY = 2;
 
 void BP1658CJ::setup() {
-  ESP_LOGCONFIG(TAG, "Setting up BP1658CJ Output Component...");
+  ESP_LOGCONFIG(TAG, "Running setup");
   this->data_pin_->setup();
   this->data_pin_->digital_write(false);
   this->clock_pin_->setup();

--- a/esphome/components/bp5758d/bp5758d.cpp
+++ b/esphome/components/bp5758d/bp5758d.cpp
@@ -20,7 +20,7 @@ static const uint8_t BP5758D_ALL_DATA_CHANNEL_ENABLEMENT = 0b00011111;
 static const uint8_t BP5758D_DELAY = 2;
 
 void BP5758D::setup() {
-  ESP_LOGCONFIG(TAG, "Setting up BP5758D Output Component...");
+  ESP_LOGCONFIG(TAG, "Running setup");
   this->data_pin_->setup();
   this->data_pin_->digital_write(false);
   delayMicroseconds(BP5758D_DELAY);


### PR DESCRIPTION
# What does this implement/fix?

As the size of various internals slowly creeps up, we need to consider ways we can cut back on wasted bytes of flash memory. An easy way to do this is by using fewer unique strings in log messages.

This is the first in a series of PRs I'll do aimed at reducing binary size by way of streamlining log messages. Logging done during `setup()` is an easy win and, when many components are present, this can easily free up hundreds of byes of flash.

When unique strings are used, each must be allocated its own memory; however, the linker will de-duplicate multiple instances of identical strings and combine them down to one. This is easily observed:
1. compile a config with several components as in this PR
2. open `firmware.factory.bin` in your hex editor of choice
3. observe that there is one "Setting up <component/platform>..." string _per component_
4. check out this PR
5. rebuild config
6. open `firmware.factory.bin` in your hex editor of choice
7. observe that there is only a single "Running setup" or "Running setup for %s" string for all components and that binary size is reduced

This is important for devices with 4 MB or less of flash memory, particularly in cases where M4E compliance requires use of BLE (which consumes a significant amount of flash memory itself).

Further, much of the content of the strings replaced in this PR is redundant and unnecessary. For example:

- `ESP_LOGCONFIG(TAG, "Setting up Home Assistant API server...");`
- `ESP_LOGCONFIG(TAG, "Setting up AXS15231 Touchscreen...");`

...produces the following lines in the log:

- `[02:18:41][C][api:030]: Setting up Home Assistant API server...`
- `[02:18:41][C][ax15231.touchscreen:020]: Setting up AXS15231 Touchscreen...`

Given that every component has a `TAG`, the additional text adds no value when troubleshooting or otherwise. The important bits are the `TAG`, the line number and that the message was printed while running `setup()`. Any extra characters are wasted bytes in flash that could otherwise be used for something else and it is simply not necessary that each component has a unique string in this part of the application.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
