### PR TITLE
Improve logging in integration tests when port does not open

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -378,6 +378,9 @@ async def run_binary_and_wait_for_port(
                 ),
             ]
 
+        # Small yield to ensure the process has a chance to start
+        await asyncio.sleep(0)
+
         while loop.time() - start_time < timeout:
             try:
                 # Try to connect to the port

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -6,8 +6,10 @@ import asyncio
 from collections.abc import AsyncGenerator, Generator
 from contextlib import AbstractAsyncContextManager, asynccontextmanager
 import logging
+import os
 from pathlib import Path
 import platform
+import pty
 import signal
 import socket
 import sys
@@ -346,14 +348,30 @@ async def run_binary_and_wait_for_port(
     timeout: float = PORT_WAIT_TIMEOUT,
 ) -> AsyncGenerator[None]:
     """Run a binary, wait for it to open a port, and clean up on exit."""
-    # Run the compiled binary directly with output capture
+    # Create a pseudo-terminal to make the binary think it's running interactively
+    # This is needed because the ESPHome host logger checks isatty()
+    master_fd, slave_fd = pty.openpty()
+
+    # Run the compiled binary with PTY
     process = await asyncio.create_subprocess_exec(
         str(binary_path),
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE,
+        stdout=slave_fd,
+        stderr=slave_fd,
         stdin=asyncio.subprocess.DEVNULL,
         # Start in a new process group to isolate signal handling
         start_new_session=True,
+        pass_fds=(slave_fd,),
+    )
+
+    # Close the slave end in the parent process
+    os.close(slave_fd)
+
+    # Convert master_fd to async streams for reading
+    loop = asyncio.get_running_loop()
+    master_reader = asyncio.StreamReader()
+    master_protocol = asyncio.StreamReaderProtocol(master_reader)
+    master_transport, _ = await loop.connect_read_pipe(
+        lambda: master_protocol, os.fdopen(master_fd, "rb", 0)
     )
 
     assert process.returncode is None, "Process died immediately"
@@ -364,19 +382,15 @@ async def run_binary_and_wait_for_port(
 
     # Start collecting output
     stdout_lines: list[str] = []
-    stderr_lines: list[str] = []
     output_tasks: list[asyncio.Task] = []
 
     try:
-        if process.stdout and process.stderr:
-            output_tasks = [
-                asyncio.create_task(
-                    _read_stream_lines(process.stdout, stdout_lines, sys.stdout)
-                ),
-                asyncio.create_task(
-                    _read_stream_lines(process.stderr, stderr_lines, sys.stderr)
-                ),
-            ]
+        # Read from the PTY master (combines stdout and stderr)
+        output_tasks = [
+            asyncio.create_task(
+                _read_stream_lines(master_reader, stdout_lines, sys.stdout)
+            )
+        ]
 
         # Small yield to ensure the process has a chance to start
         await asyncio.sleep(0)
@@ -404,16 +418,9 @@ async def run_binary_and_wait_for_port(
             error_msg += f"\nProcess exited with code: {process.returncode}"
 
         # Include any output collected so far
-        if stdout_lines or stderr_lines:
-            error_msg += "\n\n--- Process Output ---"
-            if stdout_lines:
-                error_msg += "\nSTDOUT:\n" + "\n".join(
-                    stdout_lines[-100:]
-                )  # Last 100 lines
-            if stderr_lines:
-                error_msg += "\n\nSTDERR:\n" + "\n".join(
-                    stderr_lines[-100:]
-                )  # Last 100 lines
+        if stdout_lines:
+            error_msg += "\n\n--- Process Output ---\n"
+            error_msg += "\n".join(stdout_lines[-100:])  # Last 100 lines
 
         raise TimeoutError(error_msg)
 
@@ -428,9 +435,12 @@ async def run_binary_and_wait_for_port(
                 result, asyncio.CancelledError
             ):
                 print(
-                    f"Error reading from {'stdout' if i == 0 else 'stderr'}: {result}",
+                    f"Error reading from PTY: {result}",
                     file=sys.stderr,
                 )
+
+        # Close the PTY transport
+        master_transport.close()
 
         # Cleanup: terminate the process gracefully
         if process.returncode is None:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -20,6 +20,10 @@ from aioesphomeapi import APIClient, APIConnectionError, ReconnectLogic
 import pytest
 import pytest_asyncio
 
+import esphome.config
+from esphome.core import CORE
+from esphome.platformio_api import get_idedata
+
 # Skip all integration tests on Windows
 if platform.system() == "Windows":
     pytest.skip(
@@ -142,9 +146,6 @@ async def compile_esphome(
     integration_test_dir: Path,
 ) -> AsyncGenerator[CompileFunction]:
     """Compile an ESPHome configuration and return the binary path."""
-    import esphome.config
-    from esphome.core import CORE
-    from esphome.platformio_api import get_idedata
 
     async def _compile(config_path: Path) -> Path:
         # Compile using subprocess, inheriting stdout/stderr to show progress

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -392,7 +392,11 @@ async def run_binary_and_wait_for_port(
     )
     output_reader = controller_reader
 
-    assert process.returncode is None, "Process died immediately"
+    if process.returncode is not None:
+        raise RuntimeError(
+            f"Process died immediately with return code {process.returncode}. "
+            "Ensure the binary is valid and can run successfully."
+        )
 
     # Wait for the API server to start listening
     loop = asyncio.get_running_loop()

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -378,9 +378,6 @@ async def run_binary_and_wait_for_port(
                 ),
             ]
 
-        # Small yield to ensure the process has a chance to start
-        await asyncio.sleep(0)
-
         while loop.time() - start_time < timeout:
             try:
                 # Try to connect to the port

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -11,7 +11,6 @@ from pathlib import Path
 import platform
 import signal
 import socket
-import subprocess
 import sys
 import tempfile
 from typing import TextIO
@@ -41,21 +40,13 @@ from .types import (
     RunCompiledFunction,
 )
 
-# Platform detection
-IS_WINDOWS = platform.system() == "Windows"
-
-# pty is Unix-only, import conditionally
-if not IS_WINDOWS:
-    import pty
-else:
-    pty = None
-
-
 # Skip all integration tests on Windows
 if platform.system() == "Windows":
     pytest.skip(
         "Integration tests are not supported on Windows", allow_module_level=True
     )
+
+import pty  # not available on Windows
 
 
 @pytest.fixture(scope="module", autouse=True)
@@ -374,47 +365,32 @@ async def run_binary_and_wait_for_port(
     timeout: float = PORT_WAIT_TIMEOUT,
 ) -> AsyncGenerator[None]:
     """Run a binary, wait for it to open a port, and clean up on exit."""
-    if IS_WINDOWS:
-        # On Windows, we can't use PTY, so just use pipes
-        process = await asyncio.create_subprocess_exec(
-            str(binary_path),
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.STDOUT,
-            stdin=asyncio.subprocess.DEVNULL,
-            # creationflags for Windows to create new process group
-            creationflags=subprocess.CREATE_NEW_PROCESS_GROUP,
-        )
+    # Create a pseudo-terminal to make the binary think it's running interactively
+    # This is needed because the ESPHome host logger checks isatty()
+    controller_fd, device_fd = pty.openpty()
 
-        # Set up output reader
-        output_reader = process.stdout
-        controller_transport = None
-    else:
-        # Create a pseudo-terminal to make the binary think it's running interactively
-        # This is needed because the ESPHome host logger checks isatty()
-        controller_fd, device_fd = pty.openpty()
+    # Run the compiled binary with PTY
+    process = await asyncio.create_subprocess_exec(
+        str(binary_path),
+        stdout=device_fd,
+        stderr=device_fd,
+        stdin=asyncio.subprocess.DEVNULL,
+        # Start in a new process group to isolate signal handling
+        start_new_session=True,
+        pass_fds=(device_fd,),
+    )
 
-        # Run the compiled binary with PTY
-        process = await asyncio.create_subprocess_exec(
-            str(binary_path),
-            stdout=device_fd,
-            stderr=device_fd,
-            stdin=asyncio.subprocess.DEVNULL,
-            # Start in a new process group to isolate signal handling
-            start_new_session=True,
-            pass_fds=(device_fd,),
-        )
+    # Close the device end in the parent process
+    os.close(device_fd)
 
-        # Close the device end in the parent process
-        os.close(device_fd)
-
-        # Convert controller_fd to async streams for reading
-        loop = asyncio.get_running_loop()
-        controller_reader = asyncio.StreamReader()
-        controller_protocol = asyncio.StreamReaderProtocol(controller_reader)
-        controller_transport, _ = await loop.connect_read_pipe(
-            lambda: controller_protocol, os.fdopen(controller_fd, "rb", 0)
-        )
-        output_reader = controller_reader
+    # Convert controller_fd to async streams for reading
+    loop = asyncio.get_running_loop()
+    controller_reader = asyncio.StreamReader()
+    controller_protocol = asyncio.StreamReaderProtocol(controller_reader)
+    controller_transport, _ = await loop.connect_read_pipe(
+        lambda: controller_protocol, os.fdopen(controller_fd, "rb", 0)
+    )
+    output_reader = controller_reader
 
     assert process.returncode is None, "Process died immediately"
 
@@ -487,29 +463,19 @@ async def run_binary_and_wait_for_port(
 
         # Cleanup: terminate the process gracefully
         if process.returncode is None:
-            if IS_WINDOWS:
-                # On Windows, just terminate the process
+            # Send SIGINT (Ctrl+C) for graceful shutdown
+            process.send_signal(signal.SIGINT)
+            try:
+                await asyncio.wait_for(process.wait(), timeout=SIGINT_TIMEOUT)
+            except asyncio.TimeoutError:
+                # If SIGINT didn't work, try SIGTERM
                 process.terminate()
                 try:
                     await asyncio.wait_for(process.wait(), timeout=SIGTERM_TIMEOUT)
                 except asyncio.TimeoutError:
-                    # Force kill if needed
+                    # Last resort: SIGKILL
                     process.kill()
                     await process.wait()
-            else:
-                # Send SIGINT (Ctrl+C) for graceful shutdown
-                process.send_signal(signal.SIGINT)
-                try:
-                    await asyncio.wait_for(process.wait(), timeout=SIGINT_TIMEOUT)
-                except asyncio.TimeoutError:
-                    # If SIGINT didn't work, try SIGTERM
-                    process.terminate()
-                    try:
-                        await asyncio.wait_for(process.wait(), timeout=SIGTERM_TIMEOUT)
-                    except asyncio.TimeoutError:
-                        # Last resort: SIGKILL
-                        process.kill()
-                        await process.wait()
 
 
 @asynccontextmanager

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -9,9 +9,9 @@ import logging
 import os
 from pathlib import Path
 import platform
-import pty
 import signal
 import socket
+import subprocess
 import sys
 import tempfile
 from typing import TextIO
@@ -23,12 +23,6 @@ import pytest_asyncio
 import esphome.config
 from esphome.core import CORE
 from esphome.platformio_api import get_idedata
-
-# Skip all integration tests on Windows
-if platform.system() == "Windows":
-    pytest.skip(
-        "Integration tests are not supported on Windows", allow_module_level=True
-    )
 
 from .const import (
     API_CONNECTION_TIMEOUT,
@@ -46,6 +40,22 @@ from .types import (
     ConfigWriter,
     RunCompiledFunction,
 )
+
+# Platform detection
+IS_WINDOWS = platform.system() == "Windows"
+
+# pty is Unix-only, import conditionally
+if not IS_WINDOWS:
+    import pty
+else:
+    pty = None
+
+
+# Skip all integration tests on Windows
+if platform.system() == "Windows":
+    pytest.skip(
+        "Integration tests are not supported on Windows", allow_module_level=True
+    )
 
 
 @pytest.fixture(scope="module", autouse=True)
@@ -364,31 +374,47 @@ async def run_binary_and_wait_for_port(
     timeout: float = PORT_WAIT_TIMEOUT,
 ) -> AsyncGenerator[None]:
     """Run a binary, wait for it to open a port, and clean up on exit."""
-    # Create a pseudo-terminal to make the binary think it's running interactively
-    # This is needed because the ESPHome host logger checks isatty()
-    controller_fd, device_fd = pty.openpty()
+    if IS_WINDOWS:
+        # On Windows, we can't use PTY, so just use pipes
+        process = await asyncio.create_subprocess_exec(
+            str(binary_path),
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.STDOUT,
+            stdin=asyncio.subprocess.DEVNULL,
+            # creationflags for Windows to create new process group
+            creationflags=subprocess.CREATE_NEW_PROCESS_GROUP,
+        )
 
-    # Run the compiled binary with PTY
-    process = await asyncio.create_subprocess_exec(
-        str(binary_path),
-        stdout=device_fd,
-        stderr=device_fd,
-        stdin=asyncio.subprocess.DEVNULL,
-        # Start in a new process group to isolate signal handling
-        start_new_session=True,
-        pass_fds=(device_fd,),
-    )
+        # Set up output reader
+        output_reader = process.stdout
+        controller_transport = None
+    else:
+        # Create a pseudo-terminal to make the binary think it's running interactively
+        # This is needed because the ESPHome host logger checks isatty()
+        controller_fd, device_fd = pty.openpty()
 
-    # Close the device end in the parent process
-    os.close(device_fd)
+        # Run the compiled binary with PTY
+        process = await asyncio.create_subprocess_exec(
+            str(binary_path),
+            stdout=device_fd,
+            stderr=device_fd,
+            stdin=asyncio.subprocess.DEVNULL,
+            # Start in a new process group to isolate signal handling
+            start_new_session=True,
+            pass_fds=(device_fd,),
+        )
 
-    # Convert controller_fd to async streams for reading
-    loop = asyncio.get_running_loop()
-    controller_reader = asyncio.StreamReader()
-    controller_protocol = asyncio.StreamReaderProtocol(controller_reader)
-    controller_transport, _ = await loop.connect_read_pipe(
-        lambda: controller_protocol, os.fdopen(controller_fd, "rb", 0)
-    )
+        # Close the device end in the parent process
+        os.close(device_fd)
+
+        # Convert controller_fd to async streams for reading
+        loop = asyncio.get_running_loop()
+        controller_reader = asyncio.StreamReader()
+        controller_protocol = asyncio.StreamReaderProtocol(controller_reader)
+        controller_transport, _ = await loop.connect_read_pipe(
+            lambda: controller_protocol, os.fdopen(controller_fd, "rb", 0)
+        )
+        output_reader = controller_reader
 
     assert process.returncode is None, "Process died immediately"
 
@@ -401,10 +427,10 @@ async def run_binary_and_wait_for_port(
     output_tasks: list[asyncio.Task] = []
 
     try:
-        # Read from the PTY controller (combines stdout and stderr)
+        # Read from output stream
         output_tasks = [
             asyncio.create_task(
-                _read_stream_lines(controller_reader, stdout_lines, sys.stdout)
+                _read_stream_lines(output_reader, stdout_lines, sys.stdout)
             )
         ]
 
@@ -455,24 +481,35 @@ async def run_binary_and_wait_for_port(
                     file=sys.stderr,
                 )
 
-        # Close the PTY transport
-        controller_transport.close()
+        # Close the PTY transport (Unix only)
+        if controller_transport is not None:
+            controller_transport.close()
 
         # Cleanup: terminate the process gracefully
         if process.returncode is None:
-            # Send SIGINT (Ctrl+C) for graceful shutdown
-            process.send_signal(signal.SIGINT)
-            try:
-                await asyncio.wait_for(process.wait(), timeout=SIGINT_TIMEOUT)
-            except asyncio.TimeoutError:
-                # If SIGINT didn't work, try SIGTERM
+            if IS_WINDOWS:
+                # On Windows, just terminate the process
                 process.terminate()
                 try:
                     await asyncio.wait_for(process.wait(), timeout=SIGTERM_TIMEOUT)
                 except asyncio.TimeoutError:
-                    # Last resort: SIGKILL
+                    # Force kill if needed
                     process.kill()
                     await process.wait()
+            else:
+                # Send SIGINT (Ctrl+C) for graceful shutdown
+                process.send_signal(signal.SIGINT)
+                try:
+                    await asyncio.wait_for(process.wait(), timeout=SIGINT_TIMEOUT)
+                except asyncio.TimeoutError:
+                    # If SIGINT didn't work, try SIGTERM
+                    process.terminate()
+                    try:
+                        await asyncio.wait_for(process.wait(), timeout=SIGTERM_TIMEOUT)
+                    except asyncio.TimeoutError:
+                        # Last resort: SIGKILL
+                        process.kill()
+                        await process.wait()
 
 
 @asynccontextmanager

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -10,7 +10,9 @@ from pathlib import Path
 import platform
 import signal
 import socket
+import sys
 import tempfile
+from typing import TextIO
 
 from aioesphomeapi import APIClient, APIConnectionError, ReconnectLogic
 import pytest
@@ -37,7 +39,6 @@ from .types import (
     CompileFunction,
     ConfigWriter,
     RunCompiledFunction,
-    RunFunction,
 )
 
 
@@ -134,33 +135,28 @@ async def write_yaml_config(
     yield _write_config
 
 
-async def _run_esphome_command(
-    command: str,
-    config_path: Path,
-    cwd: Path,
-) -> asyncio.subprocess.Process:
-    """Run an ESPHome command with the given arguments."""
-    return await asyncio.create_subprocess_exec(
-        "esphome",
-        command,
-        str(config_path),
-        cwd=cwd,
-        stdout=None,  # Inherit stdout
-        stderr=None,  # Inherit stderr
-        stdin=asyncio.subprocess.DEVNULL,
-        # Start in a new process group to isolate signal handling
-        start_new_session=True,
-    )
-
-
 @pytest_asyncio.fixture
 async def compile_esphome(
     integration_test_dir: Path,
 ) -> AsyncGenerator[CompileFunction]:
-    """Compile an ESPHome configuration."""
+    """Compile an ESPHome configuration and return the binary path."""
+    import esphome.config
+    from esphome.core import CORE
+    from esphome.platformio_api import get_idedata
 
-    async def _compile(config_path: Path) -> None:
-        proc = await _run_esphome_command("compile", config_path, integration_test_dir)
+    async def _compile(config_path: Path) -> Path:
+        # Compile using subprocess, inheriting stdout/stderr to show progress
+        proc = await asyncio.create_subprocess_exec(
+            "esphome",
+            "compile",
+            str(config_path),
+            cwd=integration_test_dir,
+            stdout=None,  # Inherit stdout
+            stderr=None,  # Inherit stderr
+            stdin=asyncio.subprocess.DEVNULL,
+            # Start in a new process group to isolate signal handling
+            start_new_session=True,
+        )
         await proc.wait()
         if proc.returncode != 0:
             raise RuntimeError(
@@ -168,39 +164,29 @@ async def compile_esphome(
                 f"Run with 'pytest -s' to see compilation output."
             )
 
+        # Load the config to get idedata (blocking call, must use executor)
+        loop = asyncio.get_running_loop()
+
+        def _read_config_and_get_binary():
+            CORE.config_path = str(config_path)
+            config = esphome.config.read_config(
+                {"command": "compile", "config": str(config_path)}
+            )
+            if config is None:
+                raise RuntimeError(f"Failed to read config from {config_path}")
+
+            # Get the compiled binary path
+            idedata = get_idedata(config)
+            return Path(idedata.firmware_elf_path)
+
+        binary_path = await loop.run_in_executor(None, _read_config_and_get_binary)
+
+        if not binary_path.exists():
+            raise RuntimeError(f"Compiled binary not found at {binary_path}")
+
+        return binary_path
+
     yield _compile
-
-
-@pytest_asyncio.fixture
-async def run_esphome_process(
-    integration_test_dir: Path,
-) -> AsyncGenerator[RunFunction]:
-    """Run an ESPHome process and manage its lifecycle."""
-    processes: list[asyncio.subprocess.Process] = []
-
-    async def _run(config_path: Path) -> asyncio.subprocess.Process:
-        process = await _run_esphome_command("run", config_path, integration_test_dir)
-        processes.append(process)
-        return process
-
-    yield _run
-
-    # Cleanup: terminate all "run" processes gracefully
-    for process in processes:
-        if process.returncode is None:
-            # Send SIGINT (Ctrl+C) for graceful shutdown of the running ESPHome instance
-            process.send_signal(signal.SIGINT)
-            try:
-                await asyncio.wait_for(process.wait(), timeout=SIGINT_TIMEOUT)
-            except asyncio.TimeoutError:
-                # If SIGINT didn't work, try SIGTERM
-                process.terminate()
-                try:
-                    await asyncio.wait_for(process.wait(), timeout=SIGTERM_TIMEOUT)
-                except asyncio.TimeoutError:
-                    # Last resort: SIGKILL
-                    process.kill()
-                    await process.wait()
 
 
 @asynccontextmanager
@@ -341,28 +327,126 @@ async def api_client_connected(
     yield _connect_client
 
 
-async def wait_for_port_open(
-    host: str, port: int, timeout: float = PORT_WAIT_TIMEOUT
+async def _read_stream_lines(
+    stream: asyncio.StreamReader, lines: list[str], output_stream: TextIO
 ) -> None:
-    """Wait for a TCP port to be open and accepting connections."""
+    """Read lines from a stream, append to list, and echo to output stream."""
+    while line := await stream.readline():
+        decoded_line = line.decode("utf-8", errors="replace")
+        lines.append(decoded_line.rstrip())
+        # Echo to stdout/stderr in real-time
+        print(decoded_line.rstrip(), file=output_stream, flush=True)
+
+
+@asynccontextmanager
+async def run_binary_and_wait_for_port(
+    binary_path: Path,
+    host: str,
+    port: int,
+    timeout: float = PORT_WAIT_TIMEOUT,
+) -> AsyncGenerator[None]:
+    """Run a binary, wait for it to open a port, and clean up on exit."""
+    # Run the compiled binary directly with output capture
+    process = await asyncio.create_subprocess_exec(
+        str(binary_path),
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+        stdin=asyncio.subprocess.DEVNULL,
+        # Start in a new process group to isolate signal handling
+        start_new_session=True,
+    )
+
+    assert process.returncode is None, "Process died immediately"
+
+    # Wait for the API server to start listening
     loop = asyncio.get_running_loop()
     start_time = loop.time()
 
-    # Small yield to ensure the process has a chance to start
-    await asyncio.sleep(0)
+    # Start collecting output
+    stdout_lines: list[str] = []
+    stderr_lines: list[str] = []
+    output_tasks: list[asyncio.Task] = []
 
-    while loop.time() - start_time < timeout:
-        try:
-            # Try to connect to the port
-            _, writer = await asyncio.open_connection(host, port)
-            writer.close()
-            await writer.wait_closed()
-            return  # Port is open
-        except (ConnectionRefusedError, OSError):
-            # Port not open yet, wait a bit and try again
-            await asyncio.sleep(PORT_POLL_INTERVAL)
+    try:
+        if process.stdout and process.stderr:
+            output_tasks = [
+                asyncio.create_task(
+                    _read_stream_lines(process.stdout, stdout_lines, sys.stdout)
+                ),
+                asyncio.create_task(
+                    _read_stream_lines(process.stderr, stderr_lines, sys.stderr)
+                ),
+            ]
 
-    raise TimeoutError(f"Port {port} on {host} did not open within {timeout} seconds")
+        # Small yield to ensure the process has a chance to start
+        await asyncio.sleep(0)
+
+        while loop.time() - start_time < timeout:
+            try:
+                # Try to connect to the port
+                _, writer = await asyncio.open_connection(host, port)
+                writer.close()
+                await writer.wait_closed()
+                # Port is open, yield control
+                yield
+                return
+            except (ConnectionRefusedError, OSError):
+                # Check if process died
+                if process.returncode is not None:
+                    break
+                # Port not open yet, wait a bit and try again
+                await asyncio.sleep(PORT_POLL_INTERVAL)
+
+        # Timeout or process died - build error message
+        error_msg = f"Port {port} on {host} did not open within {timeout} seconds"
+
+        if process.returncode is not None:
+            error_msg += f"\nProcess exited with code: {process.returncode}"
+
+        # Include any output collected so far
+        if stdout_lines or stderr_lines:
+            error_msg += "\n\n--- Process Output ---"
+            if stdout_lines:
+                error_msg += "\nSTDOUT:\n" + "\n".join(
+                    stdout_lines[-100:]
+                )  # Last 100 lines
+            if stderr_lines:
+                error_msg += "\n\nSTDERR:\n" + "\n".join(
+                    stderr_lines[-100:]
+                )  # Last 100 lines
+
+        raise TimeoutError(error_msg)
+
+    finally:
+        # Cancel output collection tasks
+        for task in output_tasks:
+            task.cancel()
+        # Wait for tasks to complete and check for exceptions
+        results = await asyncio.gather(*output_tasks, return_exceptions=True)
+        for i, result in enumerate(results):
+            if isinstance(result, Exception) and not isinstance(
+                result, asyncio.CancelledError
+            ):
+                print(
+                    f"Error reading from {'stdout' if i == 0 else 'stderr'}: {result}",
+                    file=sys.stderr,
+                )
+
+        # Cleanup: terminate the process gracefully
+        if process.returncode is None:
+            # Send SIGINT (Ctrl+C) for graceful shutdown
+            process.send_signal(signal.SIGINT)
+            try:
+                await asyncio.wait_for(process.wait(), timeout=SIGINT_TIMEOUT)
+            except asyncio.TimeoutError:
+                # If SIGINT didn't work, try SIGTERM
+                process.terminate()
+                try:
+                    await asyncio.wait_for(process.wait(), timeout=SIGTERM_TIMEOUT)
+                except asyncio.TimeoutError:
+                    # Last resort: SIGKILL
+                    process.kill()
+                    await process.wait()
 
 
 @asynccontextmanager
@@ -371,40 +455,29 @@ async def run_compiled_context(
     filename: str | None,
     write_yaml_config: ConfigWriter,
     compile_esphome: CompileFunction,
-    run_esphome_process: RunFunction,
     port: int,
     port_socket: socket.socket | None = None,
-) -> AsyncGenerator[asyncio.subprocess.Process]:
+) -> AsyncGenerator[None]:
     """Context manager to write, compile and run an ESPHome configuration."""
     # Write the YAML config
     config_path = await write_yaml_config(yaml_content, filename)
 
-    # Compile the configuration
-    await compile_esphome(config_path)
+    # Compile the configuration and get binary path
+    binary_path = await compile_esphome(config_path)
 
     # Close the port socket right before running to release the port
     if port_socket is not None:
         port_socket.close()
 
-    # Run the ESPHome device
-    process = await run_esphome_process(config_path)
-    assert process.returncode is None, "Process died immediately"
-
-    # Wait for the API server to start listening
-    await wait_for_port_open(LOCALHOST, port, timeout=PORT_WAIT_TIMEOUT)
-
-    try:
-        yield process
-    finally:
-        # Process cleanup is handled by run_esphome_process fixture
-        pass
+    # Run the binary and wait for the API server to start
+    async with run_binary_and_wait_for_port(binary_path, LOCALHOST, port):
+        yield
 
 
 @pytest_asyncio.fixture
 async def run_compiled(
     write_yaml_config: ConfigWriter,
     compile_esphome: CompileFunction,
-    run_esphome_process: RunFunction,
     reserved_tcp_port: tuple[int, socket.socket],
 ) -> AsyncGenerator[RunCompiledFunction]:
     """Write, compile and run an ESPHome configuration."""
@@ -418,7 +491,6 @@ async def run_compiled(
             filename,
             write_yaml_config,
             compile_esphome,
-            run_esphome_process,
             port,
             port_socket,
         )

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -148,24 +148,39 @@ async def compile_esphome(
     """Compile an ESPHome configuration and return the binary path."""
 
     async def _compile(config_path: Path) -> Path:
-        # Compile using subprocess, inheriting stdout/stderr to show progress
-        proc = await asyncio.create_subprocess_exec(
-            "esphome",
-            "compile",
-            str(config_path),
-            cwd=integration_test_dir,
-            stdout=None,  # Inherit stdout
-            stderr=None,  # Inherit stderr
-            stdin=asyncio.subprocess.DEVNULL,
-            # Start in a new process group to isolate signal handling
-            start_new_session=True,
-        )
-        await proc.wait()
-        if proc.returncode != 0:
-            raise RuntimeError(
-                f"Failed to compile {config_path}, return code: {proc.returncode}. "
-                f"Run with 'pytest -s' to see compilation output."
+        # Retry compilation up to 3 times if we get a segfault
+        max_retries = 3
+        for attempt in range(max_retries):
+            # Compile using subprocess, inheriting stdout/stderr to show progress
+            proc = await asyncio.create_subprocess_exec(
+                "esphome",
+                "compile",
+                str(config_path),
+                cwd=integration_test_dir,
+                stdout=None,  # Inherit stdout
+                stderr=None,  # Inherit stderr
+                stdin=asyncio.subprocess.DEVNULL,
+                # Start in a new process group to isolate signal handling
+                start_new_session=True,
             )
+            await proc.wait()
+
+            if proc.returncode == 0:
+                # Success!
+                break
+            elif proc.returncode == -11 and attempt < max_retries - 1:
+                # Segfault (-11 = SIGSEGV), retry
+                print(
+                    f"Compilation segfaulted (attempt {attempt + 1}/{max_retries}), retrying..."
+                )
+                await asyncio.sleep(1)  # Brief pause before retry
+                continue
+            else:
+                # Other error or final retry
+                raise RuntimeError(
+                    f"Failed to compile {config_path}, return code: {proc.returncode}. "
+                    f"Run with 'pytest -s' to see compilation output."
+                )
 
         # Load the config to get idedata (blocking call, must use executor)
         loop = asyncio.get_running_loop()

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -350,28 +350,28 @@ async def run_binary_and_wait_for_port(
     """Run a binary, wait for it to open a port, and clean up on exit."""
     # Create a pseudo-terminal to make the binary think it's running interactively
     # This is needed because the ESPHome host logger checks isatty()
-    master_fd, slave_fd = pty.openpty()
+    controller_fd, device_fd = pty.openpty()
 
     # Run the compiled binary with PTY
     process = await asyncio.create_subprocess_exec(
         str(binary_path),
-        stdout=slave_fd,
-        stderr=slave_fd,
+        stdout=device_fd,
+        stderr=device_fd,
         stdin=asyncio.subprocess.DEVNULL,
         # Start in a new process group to isolate signal handling
         start_new_session=True,
-        pass_fds=(slave_fd,),
+        pass_fds=(device_fd,),
     )
 
-    # Close the slave end in the parent process
-    os.close(slave_fd)
+    # Close the device end in the parent process
+    os.close(device_fd)
 
-    # Convert master_fd to async streams for reading
+    # Convert controller_fd to async streams for reading
     loop = asyncio.get_running_loop()
-    master_reader = asyncio.StreamReader()
-    master_protocol = asyncio.StreamReaderProtocol(master_reader)
-    master_transport, _ = await loop.connect_read_pipe(
-        lambda: master_protocol, os.fdopen(master_fd, "rb", 0)
+    controller_reader = asyncio.StreamReader()
+    controller_protocol = asyncio.StreamReaderProtocol(controller_reader)
+    controller_transport, _ = await loop.connect_read_pipe(
+        lambda: controller_protocol, os.fdopen(controller_fd, "rb", 0)
     )
 
     assert process.returncode is None, "Process died immediately"
@@ -385,10 +385,10 @@ async def run_binary_and_wait_for_port(
     output_tasks: list[asyncio.Task] = []
 
     try:
-        # Read from the PTY master (combines stdout and stderr)
+        # Read from the PTY controller (combines stdout and stderr)
         output_tasks = [
             asyncio.create_task(
-                _read_stream_lines(master_reader, stdout_lines, sys.stdout)
+                _read_stream_lines(controller_reader, stdout_lines, sys.stdout)
             )
         ]
 
@@ -440,7 +440,7 @@ async def run_binary_and_wait_for_port(
                 )
 
         # Close the PTY transport
-        master_transport.close()
+        controller_transport.close()
 
         # Cleanup: terminate the process gracefully
         if process.returncode is None:

--- a/tests/integration/types.py
+++ b/tests/integration/types.py
@@ -11,11 +11,9 @@ from typing import Protocol
 from aioesphomeapi import APIClient
 
 ConfigWriter = Callable[[str, str | None], Awaitable[Path]]
-CompileFunction = Callable[[Path], Awaitable[None]]
+CompileFunction = Callable[[Path], Awaitable[Path]]
 RunFunction = Callable[[Path], Awaitable[asyncio.subprocess.Process]]
-RunCompiledFunction = Callable[
-    [str, str | None], AbstractAsyncContextManager[asyncio.subprocess.Process]
-]
+RunCompiledFunction = Callable[[str, str | None], AbstractAsyncContextManager[None]]
 WaitFunction = Callable[[APIClient, float], Awaitable[bool]]
 
 


### PR DESCRIPTION
# What does this implement/fix?


## Summary

This PR improves error diagnostics when integration tests fail with port timeout errors. Previously, when the ESPHome API port failed to open, tests would fail with a generic timeout message without any information about what went wrong. This made debugging CI failures difficult.

## Problem

Integration tests would fail with:
```
TimeoutError: Port 6053 on 127.0.0.1 did not open within 30.0 seconds
```

Without any indication of why the port didn't open - was it a compilation error, a crash, or something else?

## Solution

### 1. Capture process output for error reporting
- Modified `wait_for_port_open` to capture stdout/stderr while waiting
- On timeout, include the last 100 lines of output in the error message
- Output is still displayed in real-time when running with `pytest -s`

### 2. Fix missing output from ESPHome binary
- ESPHome's host logger checks `isatty()` and suppresses output when not connected to a terminal
- Allocated a pseudo-terminal (PTY) to make the binary output logs normally
- This ensures we capture actual diagnostic information

### 3. Optimize test execution
- Switch from `esphome run` to `esphome compile` + direct binary execution
- Eliminates redundant compilation
- Gives better control over process output capture

### 4. Code improvements
- Consolidated process management into `run_binary_and_wait_for_port` context manager
- Removed unused fixtures and helper functions
- Better separation of concerns

## Result

Now when a timeout occurs, you see:
```
TimeoutError: Port 6053 on 127.0.0.1 did not open within 30.0 seconds
Process exited with code: 1

--- Process Output ---
[12:34:56][C][logger:123]: Log level: DEBUG
[12:34:56][E][api:456]: Failed to bind to port 6053: Address already in use
[12:34:56][E][component:789]: Component api failed to start
```

This makes it immediately clear why the test failed, greatly improving the debugging experience for both local development and CI failures.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
