### PR TITLE
[mqtt] Don't wait for connection unless configured to

### DIFF
--- a/esphome/components/mqtt/__init__.py
+++ b/esphome/components/mqtt/__init__.py
@@ -68,6 +68,7 @@ def AUTO_LOAD():
 
 CONF_DISCOVER_IP = "discover_ip"
 CONF_IDF_SEND_ASYNC = "idf_send_async"
+CONF_WAIT_FOR_CONNECTION = "wait_for_connection"
 
 
 def validate_message_just_topic(value):
@@ -298,6 +299,7 @@ CONFIG_SCHEMA = cv.All(
                 }
             ),
             cv.Optional(CONF_PUBLISH_NAN_AS_NONE, default=False): cv.boolean,
+            cv.Optional(CONF_WAIT_FOR_CONNECTION, default=False): cv.boolean,
         }
     ),
     validate_config,
@@ -452,6 +454,8 @@ async def to_code(config):
         await automation.build_automation(trigger, [], conf)
 
     cg.add(var.set_publish_nan_as_none(config[CONF_PUBLISH_NAN_AS_NONE]))
+
+    cg.add(var.set_wait_for_connection(config[CONF_WAIT_FOR_CONNECTION]))
 
 
 MQTT_PUBLISH_ACTION_SCHEMA = cv.Schema(

--- a/esphome/components/mqtt/mqtt_client.cpp
+++ b/esphome/components/mqtt/mqtt_client.cpp
@@ -171,7 +171,8 @@ void MQTTClientComponent::dump_config() {
   }
 }
 bool MQTTClientComponent::can_proceed() {
-  return network::is_disabled() || this->state_ == MQTT_CLIENT_DISABLED || this->is_connected();
+  return network::is_disabled() || this->state_ == MQTT_CLIENT_DISABLED || this->is_connected() ||
+         !this->wait_for_connection_;
 }
 
 void MQTTClientComponent::start_dnslookup_() {

--- a/esphome/components/mqtt/mqtt_client.h
+++ b/esphome/components/mqtt/mqtt_client.h
@@ -4,11 +4,11 @@
 
 #ifdef USE_MQTT
 
-#include "esphome/core/component.h"
-#include "esphome/core/automation.h"
-#include "esphome/core/log.h"
 #include "esphome/components/json/json_util.h"
 #include "esphome/components/network/ip_address.h"
+#include "esphome/core/automation.h"
+#include "esphome/core/component.h"
+#include "esphome/core/log.h"
 #if defined(USE_ESP32)
 #include "mqtt_backend_esp32.h"
 #elif defined(USE_ESP8266)
@@ -267,6 +267,8 @@ class MQTTClientComponent : public Component {
   void set_publish_nan_as_none(bool publish_nan_as_none);
   bool is_publish_nan_as_none() const;
 
+  void set_wait_for_connection(bool wait_for_connection) { this->wait_for_connection_ = wait_for_connection; }
+
  protected:
   void send_device_info_();
 
@@ -334,6 +336,7 @@ class MQTTClientComponent : public Component {
   optional<MQTTClientDisconnectReason> disconnect_reason_{};
 
   bool publish_nan_as_none_{false};
+  bool wait_for_connection_{false};
 };
 
 extern MQTTClientComponent *global_mqtt_client;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

To align with the way the api works, by default we should not wait for the connection before allowing other components to proceed.

Im not sure whether to set this as default to false (don't wait / breaking change) or true (do wait / current behaviour). Seeking feedback. 

Related:

- https://github.com/esphome/esphome-docs/pull/4838

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#5029

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
