### PR TITLE
[gcja5] Remove unused ``setup()`` method

### DIFF
--- a/esphome/components/gcja5/gcja5.cpp
+++ b/esphome/components/gcja5/gcja5.cpp
@@ -14,8 +14,6 @@ namespace gcja5 {
 
 static const char *const TAG = "gcja5";
 
-void GCJA5Component::setup() { ESP_LOGCONFIG(TAG, "Running setup"); }
-
 void GCJA5Component::loop() {
   const uint32_t now = App.get_loop_component_start_time();
   if (now - this->last_transmission_ >= 500) {

--- a/esphome/components/gcja5/gcja5.h
+++ b/esphome/components/gcja5/gcja5.h
@@ -9,7 +9,6 @@ namespace gcja5 {
 
 class GCJA5Component : public Component, public uart::UARTDevice {
  public:
-  void setup() override;
   void dump_config() override;
   void loop() override;
   float get_setup_priority() const override { return setup_priority::DATA; }


### PR DESCRIPTION
# What does this implement/fix?

SSIA

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
