### PR TITLE
[esp32] Regenerate boards from recommended platform version

### DIFF
--- a/esphome/components/esp32/boards.py
+++ b/esphome/components/esp32/boards.py
@@ -1339,17 +1339,7 @@ ESP32_BOARD_PINS = {
 }
 
 """
-BOARDS generated with:
-
-git clone https://github.com/platformio/platform-espressif32
-for x in platform-espressif32/boards/*.json; do
-  mcu=$(jq -r .build.mcu <"$x");
-  name=$(jq -r .name <"$x");
-  fname=$(basename "$x")
-  board="${fname%.*}"
-  variant=$(echo "$mcu" | tr '[:lower:]' '[:upper:]')
-  echo "    \"$board\": {\"name\": \"$name\", \"variant\": VARIANT_${variant},},"
-done | sort
+BOARDS generated with script/generate-esp32-boards.py
 """
 
 BOARDS = {
@@ -1360,6 +1350,10 @@ BOARDS = {
     "adafruit_camera_esp32s3": {
         "name": "Adafruit pyCamera S3",
         "variant": VARIANT_ESP32S3,
+    },
+    "adafruit_feather_esp32_v2": {
+        "name": "Adafruit Feather ESP32 V2",
+        "variant": VARIANT_ESP32,
     },
     "adafruit_feather_esp32c6": {
         "name": "Adafruit Feather ESP32-C6",
@@ -1393,10 +1387,6 @@ BOARDS = {
         "name": "Adafruit Feather ESP32-S3 TFT",
         "variant": VARIANT_ESP32S3,
     },
-    "adafruit_feather_esp32_v2": {
-        "name": "Adafruit Feather ESP32 V2",
-        "variant": VARIANT_ESP32,
-    },
     "adafruit_funhouse_esp32s2": {
         "name": "Adafruit FunHouse",
         "variant": VARIANT_ESP32S2,
@@ -1421,13 +1411,13 @@ BOARDS = {
         "name": "Adafruit Metro ESP32-S3",
         "variant": VARIANT_ESP32S3,
     },
-    "adafruit_qtpy_esp32c3": {
-        "name": "Adafruit QT Py ESP32-C3",
-        "variant": VARIANT_ESP32C3,
-    },
     "adafruit_qtpy_esp32": {
         "name": "Adafruit QT Py ESP32",
         "variant": VARIANT_ESP32,
+    },
+    "adafruit_qtpy_esp32c3": {
+        "name": "Adafruit QT Py ESP32-C3",
+        "variant": VARIANT_ESP32C3,
     },
     "adafruit_qtpy_esp32s2": {
         "name": "Adafruit QT Py ESP32-S2",
@@ -1477,13 +1467,13 @@ BOARDS = {
         "name": "Smart Bee Data Logger",
         "variant": VARIANT_ESP32S3,
     },
-    "bee_motion_mini": {
-        "name": "Smart Bee Motion Mini",
-        "variant": VARIANT_ESP32C3,
-    },
     "bee_motion": {
         "name": "Smart Bee Motion",
         "variant": VARIANT_ESP32S2,
+    },
+    "bee_motion_mini": {
+        "name": "Smart Bee Motion Mini",
+        "variant": VARIANT_ESP32C3,
     },
     "bee_motion_s3": {
         "name": "Smart Bee Motion S3",
@@ -1517,6 +1507,10 @@ BOARDS = {
         "name": "D-duino-32",
         "variant": VARIANT_ESP32,
     },
+    "deneyapkart": {
+        "name": "Deneyap Kart",
+        "variant": VARIANT_ESP32,
+    },
     "deneyapkart1A": {
         "name": "Deneyap Kart 1A",
         "variant": VARIANT_ESP32,
@@ -1528,10 +1522,6 @@ BOARDS = {
     "deneyapkartg": {
         "name": "Deneyap Kart G",
         "variant": VARIANT_ESP32C3,
-    },
-    "deneyapkart": {
-        "name": "Deneyap Kart",
-        "variant": VARIANT_ESP32,
     },
     "deneyapmini": {
         "name": "Deneyap Mini",
@@ -1573,8 +1563,8 @@ BOARDS = {
         "name": "Seeed Studio Edgebox-ESP-100",
         "variant": VARIANT_ESP32S3,
     },
-    "esp320": {
-        "name": "Electronic SweetPeas ESP320",
+    "esp-wrover-kit": {
+        "name": "Espressif ESP-WROVER-KIT",
         "variant": VARIANT_ESP32,
     },
     "esp32-c2-devkitm-1": {
@@ -1601,24 +1591,8 @@ BOARDS = {
         "name": "Espressif ESP32-C6-DevKitM-1",
         "variant": VARIANT_ESP32C6,
     },
-    "esp32cam": {
-        "name": "AI Thinker ESP32-CAM",
-        "variant": VARIANT_ESP32,
-    },
     "esp32-devkitlipo": {
         "name": "OLIMEX ESP32-DevKit-LiPo",
-        "variant": VARIANT_ESP32,
-    },
-    "esp32dev": {
-        "name": "Espressif ESP32 Dev Module",
-        "variant": VARIANT_ESP32,
-    },
-    "esp32doit-devkit-v1": {
-        "name": "DOIT ESP32 DEVKIT V1",
-        "variant": VARIANT_ESP32,
-    },
-    "esp32doit-espduino": {
-        "name": "DOIT ESPduino32",
         "variant": VARIANT_ESP32,
     },
     "esp32-evb": {
@@ -1633,24 +1607,24 @@ BOARDS = {
         "name": "Espressif ESP32-H2-DevKit",
         "variant": VARIANT_ESP32H2,
     },
-    "esp32-p4-evboard": {
-        "name": "Espressif ESP32-P4 Function EV Board",
-        "variant": VARIANT_ESP32P4,
-    },
     "esp32-p4": {
         "name": "Espressif ESP32-P4 generic",
+        "variant": VARIANT_ESP32P4,
+    },
+    "esp32-p4-evboard": {
+        "name": "Espressif ESP32-P4 Function EV Board",
         "variant": VARIANT_ESP32P4,
     },
     "esp32-pico-devkitm-2": {
         "name": "Espressif ESP32-PICO-DevKitM-2",
         "variant": VARIANT_ESP32,
     },
-    "esp32-poe-iso": {
-        "name": "OLIMEX ESP32-PoE-ISO",
-        "variant": VARIANT_ESP32,
-    },
     "esp32-poe": {
         "name": "OLIMEX ESP32-PoE",
+        "variant": VARIANT_ESP32,
+    },
+    "esp32-poe-iso": {
+        "name": "OLIMEX ESP32-PoE-ISO",
         "variant": VARIANT_ESP32,
     },
     "esp32-pro": {
@@ -1669,8 +1643,44 @@ BOARDS = {
         "name": "Espressif ESP32-S2-Saola-1",
         "variant": VARIANT_ESP32S2,
     },
+    "esp32-s3-devkitc-1": {
+        "name": "Espressif ESP32-S3-DevKitC-1-N8 (8 MB QD, No PSRAM)",
+        "variant": VARIANT_ESP32S3,
+    },
+    "esp32-s3-devkitm-1": {
+        "name": "Espressif ESP32-S3-DevKitM-1",
+        "variant": VARIANT_ESP32S3,
+    },
+    "esp32-solo1": {
+        "name": "Espressif Generic ESP32-solo1 4M Flash",
+        "variant": VARIANT_ESP32,
+    },
+    "esp320": {
+        "name": "Electronic SweetPeas ESP320",
+        "variant": VARIANT_ESP32,
+    },
+    "esp32cam": {
+        "name": "AI Thinker ESP32-CAM",
+        "variant": VARIANT_ESP32,
+    },
+    "esp32dev": {
+        "name": "Espressif ESP32 Dev Module",
+        "variant": VARIANT_ESP32,
+    },
+    "esp32doit-devkit-v1": {
+        "name": "DOIT ESP32 DEVKIT V1",
+        "variant": VARIANT_ESP32,
+    },
+    "esp32doit-espduino": {
+        "name": "DOIT ESPduino32",
+        "variant": VARIANT_ESP32,
+    },
     "esp32s3_120_16_8-qio_opi": {
         "name": "ESP32-S3 16MB QIO, 8MB OPI PSRAM",
+        "variant": VARIANT_ESP32S3,
+    },
+    "esp32s3_powerfeather": {
+        "name": "ESP32-S3 PowerFeather",
         "variant": VARIANT_ESP32S3,
     },
     "esp32s3box": {
@@ -1681,25 +1691,9 @@ BOARDS = {
         "name": "ESP32S3 CAM LCD",
         "variant": VARIANT_ESP32S3,
     },
-    "esp32-s3-devkitc-1": {
-        "name": "Espressif ESP32-S3-DevKitC-1-N8 (8 MB QD, No PSRAM)",
-        "variant": VARIANT_ESP32S3,
-    },
-    "esp32-s3-devkitm-1": {
-        "name": "Espressif ESP32-S3-DevKitM-1",
-        "variant": VARIANT_ESP32S3,
-    },
-    "esp32s3_powerfeather": {
-        "name": "ESP32-S3 PowerFeather",
-        "variant": VARIANT_ESP32S3,
-    },
     "esp32s3usbotg": {
         "name": "Espressif ESP32-S3-USB-OTG",
         "variant": VARIANT_ESP32S3,
-    },
-    "esp32-solo1": {
-        "name": "Espressif Generic ESP32-solo1 4M Flash",
-        "variant": VARIANT_ESP32,
     },
     "esp32thing": {
         "name": "SparkFun ESP32 Thing",
@@ -1723,10 +1717,6 @@ BOARDS = {
     },
     "espino32": {
         "name": "ESPino32",
-        "variant": VARIANT_ESP32,
-    },
-    "esp-wrover-kit": {
-        "name": "Espressif ESP-WROVER-KIT",
         "variant": VARIANT_ESP32,
     },
     "etboard": {
@@ -1777,13 +1767,13 @@ BOARDS = {
         "name": "Heltec WiFi Kit 32",
         "variant": VARIANT_ESP32,
     },
-    "heltec_wifi_kit_32_v2": {
-        "name": "Heltec WiFi Kit 32 (V2)",
-        "variant": VARIANT_ESP32,
-    },
     "heltec_wifi_kit_32_V3": {
         "name": "Heltec WiFi Kit 32 (V3)",
         "variant": VARIANT_ESP32S3,
+    },
+    "heltec_wifi_kit_32_v2": {
+        "name": "Heltec WiFi Kit 32 (V2)",
+        "variant": VARIANT_ESP32,
     },
     "heltec_wifi_lora_32": {
         "name": "Heltec WiFi LoRa 32",
@@ -1797,12 +1787,12 @@ BOARDS = {
         "name": "Heltec WiFi LoRa 32 (V3)",
         "variant": VARIANT_ESP32S3,
     },
-    "heltec_wireless_stick_lite": {
-        "name": "Heltec Wireless Stick Lite",
-        "variant": VARIANT_ESP32,
-    },
     "heltec_wireless_stick": {
         "name": "Heltec Wireless Stick",
+        "variant": VARIANT_ESP32,
+    },
+    "heltec_wireless_stick_lite": {
+        "name": "Heltec Wireless Stick Lite",
         "variant": VARIANT_ESP32,
     },
     "honeylemon": {
@@ -1877,16 +1867,16 @@ BOARDS = {
         "name": "Lilka v2",
         "variant": VARIANT_ESP32S3,
     },
-    "lilygo-t3-s3": {
-        "name": "LilyGo T3-S3",
-        "variant": VARIANT_ESP32S3,
-    },
     "lilygo-t-display": {
         "name": "LilyGo T-Display",
         "variant": VARIANT_ESP32,
     },
     "lilygo-t-display-s3": {
         "name": "LilyGo T-Display-S3",
+        "variant": VARIANT_ESP32S3,
+    },
+    "lilygo-t3-s3": {
+        "name": "LilyGo T3-S3",
         "variant": VARIANT_ESP32S3,
     },
     "lionbit": {
@@ -1897,12 +1887,12 @@ BOARDS = {
         "name": "Lion:Bit S3 STEM Dev Board",
         "variant": VARIANT_ESP32S3,
     },
-    "lolin32_lite": {
-        "name": "WEMOS LOLIN32 Lite",
-        "variant": VARIANT_ESP32,
-    },
     "lolin32": {
         "name": "WEMOS LOLIN32",
+        "variant": VARIANT_ESP32,
+    },
+    "lolin32_lite": {
+        "name": "WEMOS LOLIN32 Lite",
         "variant": VARIANT_ESP32,
     },
     "lolin_c3_mini": {
@@ -1925,6 +1915,10 @@ BOARDS = {
         "name": "WEMOS LOLIN S2 PICO",
         "variant": VARIANT_ESP32S2,
     },
+    "lolin_s3": {
+        "name": "WEMOS LOLIN S3",
+        "variant": VARIANT_ESP32S3,
+    },
     "lolin_s3_mini": {
         "name": "WEMOS LOLIN S3 Mini",
         "variant": VARIANT_ESP32S3,
@@ -1933,20 +1927,16 @@ BOARDS = {
         "name": "WEMOS LOLIN S3 Mini Pro",
         "variant": VARIANT_ESP32S3,
     },
-    "lolin_s3": {
-        "name": "WEMOS LOLIN S3",
-        "variant": VARIANT_ESP32S3,
-    },
     "lolin_s3_pro": {
         "name": "WEMOS LOLIN S3 PRO",
         "variant": VARIANT_ESP32S3,
     },
-    "lopy4": {
-        "name": "Pycom LoPy4",
-        "variant": VARIANT_ESP32,
-    },
     "lopy": {
         "name": "Pycom LoPy",
+        "variant": VARIANT_ESP32,
+    },
+    "lopy4": {
+        "name": "Pycom LoPy4",
         "variant": VARIANT_ESP32,
     },
     "m5stack-atom": {
@@ -1957,16 +1947,16 @@ BOARDS = {
         "name": "M5Stack AtomS3",
         "variant": VARIANT_ESP32S3,
     },
-    "m5stack-core2": {
-        "name": "M5Stack Core2",
+    "m5stack-core-esp32": {
+        "name": "M5Stack Core ESP32",
         "variant": VARIANT_ESP32,
     },
     "m5stack-core-esp32-16M": {
         "name": "M5Stack Core ESP32 16M",
         "variant": VARIANT_ESP32,
     },
-    "m5stack-core-esp32": {
-        "name": "M5Stack Core ESP32",
+    "m5stack-core2": {
+        "name": "M5Stack Core2",
         "variant": VARIANT_ESP32,
     },
     "m5stack-coreink": {
@@ -1985,10 +1975,6 @@ BOARDS = {
         "name": "M5Stack GREY ESP32",
         "variant": VARIANT_ESP32,
     },
-    "m5stack_paper": {
-        "name": "M5Stack Paper",
-        "variant": VARIANT_ESP32,
-    },
     "m5stack-stamps3": {
         "name": "M5Stack StampS3",
         "variant": VARIANT_ESP32S3,
@@ -1999,6 +1985,10 @@ BOARDS = {
     },
     "m5stack-timer-cam": {
         "name": "M5Stack Timer CAM",
+        "variant": VARIANT_ESP32,
+    },
+    "m5stack_paper": {
+        "name": "M5Stack Paper",
         "variant": VARIANT_ESP32,
     },
     "m5stamp-pico": {
@@ -2069,13 +2059,13 @@ BOARDS = {
         "name": "Node32s",
         "variant": VARIANT_ESP32,
     },
-    "nodemcu-32s2": {
-        "name": "Ai-Thinker NodeMCU-32S2 (ESP-12K)",
-        "variant": VARIANT_ESP32S2,
-    },
     "nodemcu-32s": {
         "name": "NodeMCU-32S",
         "variant": VARIANT_ESP32,
+    },
+    "nodemcu-32s2": {
+        "name": "Ai-Thinker NodeMCU-32S2 (ESP-12K)",
+        "variant": VARIANT_ESP32S2,
     },
     "nscreen-32": {
         "name": "YeaCreate NSCREEN-32",
@@ -2129,6 +2119,10 @@ BOARDS = {
         "name": "RYMCU ESP32-S3-DevKitC-1-N8R2 (8 MB QD, 2 MB PSRAM)",
         "variant": VARIANT_ESP32S3,
     },
+    "s_odi_ultra": {
+        "name": "S.ODI Ultra v1",
+        "variant": VARIANT_ESP32,
+    },
     "seeed_xiao_esp32c3": {
         "name": "Seeed Studio XIAO ESP32C3",
         "variant": VARIANT_ESP32C3,
@@ -2153,29 +2147,25 @@ BOARDS = {
         "name": "SG-O AirMon",
         "variant": VARIANT_ESP32,
     },
-    "s_odi_ultra": {
-        "name": "S.ODI Ultra v1",
+    "sparkfun_esp32_iot_redboard": {
+        "name": "SparkFun ESP32 IoT RedBoard",
         "variant": VARIANT_ESP32,
     },
     "sparkfun_esp32c6_thing_plus": {
         "name": "Sparkfun ESP32-C6 Thing Plus",
         "variant": VARIANT_ESP32C6,
     },
-    "sparkfun_esp32_iot_redboard": {
-        "name": "SparkFun ESP32 IoT RedBoard",
-        "variant": VARIANT_ESP32,
-    },
     "sparkfun_esp32micromod": {
         "name": "SparkFun ESP32 MicroMod",
-        "variant": VARIANT_ESP32,
-    },
-    "sparkfun_esp32s2_thing_plus_c": {
-        "name": "SparkFun ESP32 Thing Plus C",
         "variant": VARIANT_ESP32,
     },
     "sparkfun_esp32s2_thing_plus": {
         "name": "SparkFun ESP32-S2 Thing Plus",
         "variant": VARIANT_ESP32S2,
+    },
+    "sparkfun_esp32s2_thing_plus_c": {
+        "name": "SparkFun ESP32 Thing Plus C",
+        "variant": VARIANT_ESP32,
     },
     "sparkfun_esp32s3_thing_plus": {
         "name": "SPARKFUN_ESP32S3_THING_PLUS",
@@ -2197,6 +2187,10 @@ BOARDS = {
         "name": "Unexpected Maker TinyPICO",
         "variant": VARIANT_ESP32,
     },
+    "trueverit-iot-driver": {
+        "name": "Trueverit ESP32 Universal IoT Driver",
+        "variant": VARIANT_ESP32,
+    },
     "trueverit-iot-driver-mk2": {
         "name": "Trueverit ESP32 Universal IoT Driver MK II",
         "variant": VARIANT_ESP32,
@@ -2205,32 +2199,16 @@ BOARDS = {
         "name": "Trueverit ESP32 Universal IoT Driver MK III",
         "variant": VARIANT_ESP32,
     },
-    "trueverit-iot-driver": {
-        "name": "Trueverit ESP32 Universal IoT Driver",
-        "variant": VARIANT_ESP32,
-    },
     "ttgo-lora32-v1": {
         "name": "TTGO LoRa32-OLED V1",
-        "variant": VARIANT_ESP32,
-    },
-    "ttgo-lora32-v21": {
-        "name": "TTGO LoRa32-OLED v2.1.6",
         "variant": VARIANT_ESP32,
     },
     "ttgo-lora32-v2": {
         "name": "TTGO LoRa32-OLED V2",
         "variant": VARIANT_ESP32,
     },
-    "ttgo-t1": {
-        "name": "TTGO T1",
-        "variant": VARIANT_ESP32,
-    },
-    "ttgo-t7-v13-mini32": {
-        "name": "TTGO T7 V1.3 Mini32",
-        "variant": VARIANT_ESP32,
-    },
-    "ttgo-t7-v14-mini32": {
-        "name": "TTGO T7 V1.4 Mini32",
+    "ttgo-lora32-v21": {
+        "name": "TTGO LoRa32-OLED v2.1.6",
         "variant": VARIANT_ESP32,
     },
     "ttgo-t-beam": {
@@ -2243,6 +2221,18 @@ BOARDS = {
     },
     "ttgo-t-watch": {
         "name": "TTGO T-Watch",
+        "variant": VARIANT_ESP32,
+    },
+    "ttgo-t1": {
+        "name": "TTGO T1",
+        "variant": VARIANT_ESP32,
+    },
+    "ttgo-t7-v13-mini32": {
+        "name": "TTGO T7 V1.3 Mini32",
+        "variant": VARIANT_ESP32,
+    },
+    "ttgo-t7-v14-mini32": {
+        "name": "TTGO T7 V1.4 Mini32",
         "variant": VARIANT_ESP32,
     },
     "turta_iot_node": {
@@ -2317,21 +2307,17 @@ BOARDS = {
         "name": "SQFMI Watchy v2.0",
         "variant": VARIANT_ESP32,
     },
-    "waveshare_esp32s3_touch_lcd_128": {
-        "name": "Waveshare ESP32-S3-Touch-LCD-1.28 (16 MB QD, 2MB PSRAM)",
-        "variant": VARIANT_ESP32S3,
-    },
     "waveshare_esp32_s3_zero": {
         "name": "Waveshare ESP32-S3-Zero",
+        "variant": VARIANT_ESP32S3,
+    },
+    "waveshare_esp32s3_touch_lcd_128": {
+        "name": "Waveshare ESP32-S3-Touch-LCD-1.28 (16 MB QD, 2MB PSRAM)",
         "variant": VARIANT_ESP32S3,
     },
     "weactstudio_esp32c3coreboard": {
         "name": "WeAct Studio ESP32C3CoreBoard",
         "variant": VARIANT_ESP32C3,
-    },
-    "wemosbat": {
-        "name": "WeMos WiFi and Bluetooth Battery",
-        "variant": VARIANT_ESP32,
     },
     "wemos_d1_mini32": {
         "name": "WEMOS D1 MINI ESP32",
@@ -2339,6 +2325,10 @@ BOARDS = {
     },
     "wemos_d1_uno32": {
         "name": "WEMOS D1 R32",
+        "variant": VARIANT_ESP32,
+    },
+    "wemosbat": {
+        "name": "WeMos WiFi and Bluetooth Battery",
         "variant": VARIANT_ESP32,
     },
     "wesp32": {
@@ -2349,13 +2339,13 @@ BOARDS = {
         "name": "Widora AIR",
         "variant": VARIANT_ESP32,
     },
-    "wifiduino32c3": {
-        "name": "Blinker WiFiduinoV2 (ESP32-C3)",
-        "variant": VARIANT_ESP32C3,
-    },
     "wifiduino32": {
         "name": "Blinker WiFiduino32",
         "variant": VARIANT_ESP32,
+    },
+    "wifiduino32c3": {
+        "name": "Blinker WiFiduinoV2 (ESP32-C3)",
+        "variant": VARIANT_ESP32C3,
     },
     "wifiduino32s3": {
         "name": "Blinker WiFiduino32S3",

--- a/esphome/components/esp32/boards.py
+++ b/esphome/components/esp32/boards.py
@@ -2,7 +2,6 @@ from .const import (
     VARIANT_ESP32,
     VARIANT_ESP32C2,
     VARIANT_ESP32C3,
-    VARIANT_ESP32C5,
     VARIANT_ESP32C6,
     VARIANT_ESP32H2,
     VARIANT_ESP32P4,
@@ -1594,10 +1593,6 @@ BOARDS = {
         "name": "Ai-Thinker ESP-C3-M1-I-Kit",
         "variant": VARIANT_ESP32C3,
     },
-    "esp32-c5-devkitc-1": {
-        "name": "Espressif ESP32-C5-DevKitC-1",
-        "variant": VARIANT_ESP32C5,
-    },
     "esp32-c6-devkitc-1": {
         "name": "Espressif ESP32-C6-DevKitC-1",
         "variant": VARIANT_ESP32C6,
@@ -1638,12 +1633,12 @@ BOARDS = {
         "name": "Espressif ESP32-H2-DevKit",
         "variant": VARIANT_ESP32H2,
     },
-    "esp32-p4": {
-        "name": "Espressif ESP32-P4 generic",
-        "variant": VARIANT_ESP32P4,
-    },
     "esp32-p4-evboard": {
         "name": "Espressif ESP32-P4 Function EV Board",
+        "variant": VARIANT_ESP32P4,
+    },
+    "esp32-p4": {
+        "name": "Espressif ESP32-P4 generic",
         "variant": VARIANT_ESP32P4,
     },
     "esp32-pico-devkitm-2": {
@@ -1673,6 +1668,10 @@ BOARDS = {
     "esp32-s2-saola-1": {
         "name": "Espressif ESP32-S2-Saola-1",
         "variant": VARIANT_ESP32S2,
+    },
+    "esp32s3_120_16_8-qio_opi": {
+        "name": "ESP32-S3 16MB QIO, 8MB OPI PSRAM",
+        "variant": VARIANT_ESP32S3,
     },
     "esp32s3box": {
         "name": "Espressif ESP32-S3-Box",
@@ -1758,6 +1757,14 @@ BOARDS = {
         "name": "Franzininho WiFi MSC",
         "variant": VARIANT_ESP32S2,
     },
+    "freenove_esp32_s3_wroom": {
+        "name": "Freenove ESP32-S3 WROOM N8R8 (8MB Flash / 8MB PSRAM)",
+        "variant": VARIANT_ESP32S3,
+    },
+    "freenove_esp32_wrover": {
+        "name": "Freenove ESP32-Wrover",
+        "variant": VARIANT_ESP32,
+    },
     "frogboard": {
         "name": "Frog Board ESP32",
         "variant": VARIANT_ESP32,
@@ -1768,6 +1775,10 @@ BOARDS = {
     },
     "heltec_wifi_kit_32": {
         "name": "Heltec WiFi Kit 32",
+        "variant": VARIANT_ESP32,
+    },
+    "heltec_wifi_kit_32_v2": {
+        "name": "Heltec WiFi Kit 32 (V2)",
         "variant": VARIANT_ESP32,
     },
     "heltec_wifi_kit_32_V3": {
@@ -1806,6 +1817,14 @@ BOARDS = {
         "name": "Hornbill ESP32 Minima",
         "variant": VARIANT_ESP32,
     },
+    "huidu_hd_wf2": {
+        "name": "Huidu HD-WF2",
+        "variant": VARIANT_ESP32S3,
+    },
+    "huidu_hd_wf4": {
+        "name": "Huidu HD-WF4",
+        "variant": VARIANT_ESP32S3,
+    },
     "imbrios-logsens-v1p1": {
         "name": "Imbrios LogSens V1P1",
         "variant": VARIANT_ESP32,
@@ -1838,6 +1857,10 @@ BOARDS = {
         "name": "ArtronShop IOXESP32PS",
         "variant": VARIANT_ESP32,
     },
+    "jczn_2432s028r": {
+        "name": "ESP32-2432S028R CYD",
+        "variant": VARIANT_ESP32,
+    },
     "kb32-ft": {
         "name": "MakerAsia KB32-FT",
         "variant": VARIANT_ESP32,
@@ -1852,6 +1875,10 @@ BOARDS = {
     },
     "lilka_v2": {
         "name": "Lilka v2",
+        "variant": VARIANT_ESP32S3,
+    },
+    "lilygo-t3-s3": {
+        "name": "LilyGo T3-S3",
         "variant": VARIANT_ESP32S3,
     },
     "lilygo-t-display": {
@@ -1900,6 +1927,10 @@ BOARDS = {
     },
     "lolin_s3_mini": {
         "name": "WEMOS LOLIN S3 Mini",
+        "variant": VARIANT_ESP32S3,
+    },
+    "lolin_s3_mini_pro": {
+        "name": "WEMOS LOLIN S3 Mini Pro",
         "variant": VARIANT_ESP32S3,
     },
     "lolin_s3": {
@@ -2094,9 +2125,17 @@ BOARDS = {
         "name": "RoboHeart Hercules",
         "variant": VARIANT_ESP32,
     },
+    "rymcu-esp32-s3-devkitc-1": {
+        "name": "RYMCU ESP32-S3-DevKitC-1-N8R2 (8 MB QD, 2 MB PSRAM)",
+        "variant": VARIANT_ESP32S3,
+    },
     "seeed_xiao_esp32c3": {
         "name": "Seeed Studio XIAO ESP32C3",
         "variant": VARIANT_ESP32C3,
+    },
+    "seeed_xiao_esp32c6": {
+        "name": "Seeed Studio XIAO ESP32C6",
+        "variant": VARIANT_ESP32C6,
     },
     "seeed_xiao_esp32s3": {
         "name": "Seeed Studio XIAO ESP32S3",
@@ -2138,9 +2177,17 @@ BOARDS = {
         "name": "SparkFun ESP32-S2 Thing Plus",
         "variant": VARIANT_ESP32S2,
     },
+    "sparkfun_esp32s3_thing_plus": {
+        "name": "SPARKFUN_ESP32S3_THING_PLUS",
+        "variant": VARIANT_ESP32S3,
+    },
     "sparkfun_lora_gateway_1-channel": {
         "name": "SparkFun LoRa Gateway 1-Channel",
         "variant": VARIANT_ESP32,
+    },
+    "sparkfun_qwiic_pocket_esp32c6": {
+        "name": "SparkFun ESP32-C6 Qwiic Pocket",
+        "variant": VARIANT_ESP32C6,
     },
     "tamc_termod_s3": {
         "name": "TAMC Termod S3",
@@ -2270,6 +2317,18 @@ BOARDS = {
         "name": "SQFMI Watchy v2.0",
         "variant": VARIANT_ESP32,
     },
+    "waveshare_esp32s3_touch_lcd_128": {
+        "name": "Waveshare ESP32-S3-Touch-LCD-1.28 (16 MB QD, 2MB PSRAM)",
+        "variant": VARIANT_ESP32S3,
+    },
+    "waveshare_esp32_s3_zero": {
+        "name": "Waveshare ESP32-S3-Zero",
+        "variant": VARIANT_ESP32S3,
+    },
+    "weactstudio_esp32c3coreboard": {
+        "name": "WeAct Studio ESP32C3CoreBoard",
+        "variant": VARIANT_ESP32C3,
+    },
     "wemosbat": {
         "name": "WeMos WiFi and Bluetooth Battery",
         "variant": VARIANT_ESP32,
@@ -2306,12 +2365,32 @@ BOARDS = {
         "name": "Pycom WiPy3",
         "variant": VARIANT_ESP32,
     },
+    "ws_esp32_s3_matrix": {
+        "name": "Waveshare ESP32-S3-Matrix",
+        "variant": VARIANT_ESP32S3,
+    },
     "wt32-eth01": {
         "name": "Wireless-Tag WT32-ETH01 Ethernet Module",
         "variant": VARIANT_ESP32,
     },
+    "wt32-sc01-plus": {
+        "name": "wt32-sc01-plus",
+        "variant": VARIANT_ESP32S3,
+    },
     "xinabox_cw02": {
         "name": "XinaBox CW02",
         "variant": VARIANT_ESP32,
+    },
+    "yb_esp32s3_amp_v2": {
+        "name": "YelloByte YB-ESP32-S3-AMP (Rev.2)",
+        "variant": VARIANT_ESP32S3,
+    },
+    "yb_esp32s3_amp_v3": {
+        "name": "YelloByte YB-ESP32-S3-AMP (Rev.3)",
+        "variant": VARIANT_ESP32S3,
+    },
+    "yb_esp32s3_eth": {
+        "name": "YelloByte YB-ESP32-S3-ETH",
+        "variant": VARIANT_ESP32S3,
     },
 }

--- a/script/generate-esp32-boards.py
+++ b/script/generate-esp32-boards.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+
+import json
+import os
+import subprocess
+import tempfile
+
+from esphome.components.esp32 import ESP_IDF_PLATFORM_VERSION as ver
+
+version_str = f"{ver.major}.{ver.minor:02d}.{ver.patch:02d}"
+print(f"ESP32 Platform Version: {version_str}")
+
+
+def get_boards():
+    with tempfile.TemporaryDirectory() as tempdir:
+        subprocess.run(
+            [
+                "git",
+                "clone",
+                "--depth",
+                "1",
+                "--branch",
+                f"{ver.major}.{ver.minor:02d}.{ver.patch:02d}",
+                "https://github.com/pioarduino/platform-espressif32",
+                tempdir,
+            ],
+            check=True,
+        )
+        boards_file = os.path.join(tempdir, "boards")
+        boards = {}
+        for fname in os.listdir(boards_file):
+            if not fname.endswith(".json"):
+                continue
+            with open(os.path.join(boards_file, fname), encoding="utf-8") as f:
+                board_info = json.load(f)
+                mcu = board_info["build"]["mcu"]
+                name = board_info["name"]
+                board = fname[:-5]
+                variant = mcu.upper()
+                boards[board] = {
+                    "name": name,
+                    "variant": f"VARIANT_{variant}",
+                }
+        return boards
+
+
+TEMPLATE = """    "%s": {
+        "name": "%s",
+        "variant": %s,
+    },
+"""
+
+
+def main():
+    boards = get_boards()
+    # open boards.py, delete existing BOARDS variable and write the new boards dict
+    boards_file_path = os.path.join(
+        os.path.dirname(__file__), "..", "esphome", "components", "esp32", "boards.py"
+    )
+    with open(boards_file_path, encoding="UTF-8") as f:
+        lines = f.readlines()
+
+    with open(boards_file_path, "w", encoding="UTF-8") as f:
+        for line in lines:
+            if line.startswith("BOARDS = {"):
+                f.write("BOARDS = {\n")
+                for board, info in sorted(boards.items()):
+                    f.write(TEMPLATE % (board, info["name"], info["variant"]))
+                f.write("}\n")
+                break
+
+            f.write(line)
+
+
+if __name__ == "__main__":
+    main()
+    print("ESP32 boards updated successfully.")


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

This list of boards is not kept up to date properly with the platform version.

There were instructions in the code file itself, but they were not the easiest to use.

Instead you can now run `script/generate-esp32-boards.py` and it will do it automatically.

The order of them has changed due to python `sorted` ordering things differently from `... | sort` on the shell

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
