### PR TITLE
tuya low-energy wifi devices support

### DIFF
--- a/esphome/components/tuya/__init__.py
+++ b/esphome/components/tuya/__init__.py
@@ -2,7 +2,7 @@ from esphome import automation, pins
 import esphome.codegen as cg
 from esphome.components import time, uart
 import esphome.config_validation as cv
-from esphome.const import CONF_ID, CONF_SENSOR_DATAPOINT, CONF_TIME_ID, CONF_TRIGGER_ID, CONF_LOW
+from esphome.const import CONF_ID, CONF_SENSOR_DATAPOINT, CONF_TIME_ID, CONF_TRIGGER_ID
 
 DEPENDENCIES = ["uart"]
 
@@ -79,7 +79,7 @@ def assign_declare_id(value):
     )(value[CONF_TRIGGER_ID].id)
     return value
 
-CONF_LOW = "low_energy"
+CONF_LOW_ENERGY = "low_energy"
 CONF_TUYA_ID = "tuya_id"
 CONFIG_SCHEMA = (
     cv.Schema(
@@ -102,7 +102,7 @@ CONFIG_SCHEMA = (
                 },
                 extra_validators=assign_declare_id,
             ),
-            cv.Optional(CONF_LOW, default=False): cv.boolean,
+            cv.Optional(CONF_LOW_ENERGY, default=False): cv.boolean,
         }
     )
     .extend(cv.COMPONENT_SCHEMA)
@@ -114,7 +114,7 @@ async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
     await uart.register_uart_device(var, config)
-    if config[CONF_LOW]:
+    if config[CONF_LOW_ENERGY]:
         cg.add_define("TUYA_LOW_ENERGY")
     if CONF_TIME_ID in config:
         time_ = await cg.get_variable(config[CONF_TIME_ID])

--- a/esphome/components/tuya/__init__.py
+++ b/esphome/components/tuya/__init__.py
@@ -79,6 +79,7 @@ def assign_declare_id(value):
     )(value[CONF_TRIGGER_ID].id)
     return value
 
+
 CONF_LOW_ENERGY = "low_energy"
 CONF_TUYA_ID = "tuya_id"
 CONFIG_SCHEMA = (

--- a/esphome/components/tuya/__init__.py
+++ b/esphome/components/tuya/__init__.py
@@ -2,7 +2,7 @@ from esphome import automation, pins
 import esphome.codegen as cg
 from esphome.components import time, uart
 import esphome.config_validation as cv
-from esphome.const import CONF_ID, CONF_SENSOR_DATAPOINT, CONF_TIME_ID, CONF_TRIGGER_ID
+from esphome.const import CONF_ID, CONF_SENSOR_DATAPOINT, CONF_TIME_ID, CONF_TRIGGER_ID, CONF_LOW
 
 DEPENDENCIES = ["uart"]
 
@@ -79,7 +79,7 @@ def assign_declare_id(value):
     )(value[CONF_TRIGGER_ID].id)
     return value
 
-
+CONF_LOW = "low_energy"
 CONF_TUYA_ID = "tuya_id"
 CONFIG_SCHEMA = (
     cv.Schema(
@@ -102,6 +102,7 @@ CONFIG_SCHEMA = (
                 },
                 extra_validators=assign_declare_id,
             ),
+            cv.Optional(CONF_LOW, default=False): cv.boolean,
         }
     )
     .extend(cv.COMPONENT_SCHEMA)
@@ -113,6 +114,8 @@ async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
     await uart.register_uart_device(var, config)
+    if config[CONF_LOW]:
+        cg.add_define("TUYA_LOW_ENERGY")
     if CONF_TIME_ID in config:
         time_ = await cg.get_variable(config[CONF_TIME_ID])
         cg.add(var.set_time_id(time_))

--- a/esphome/components/tuya/tuya.cpp
+++ b/esphome/components/tuya/tuya.cpp
@@ -266,7 +266,7 @@ void Tuya::handle_command_(uint8_t command, uint8_t version, const uint8_t *buff
       this->send_wifi_status_();
       break;
     case TuyaCommandType::WIFI_RESET:
-      cut_cloud_mode = true;
+      cut_cloud_mode_ = true;
       break;
     case TuyaCommandType::DATAPOINT_REPORT:
       this->init_state_ = TuyaInitState::INIT_DONE;
@@ -548,7 +548,7 @@ uint8_t Tuya::get_wifi_status_code_() {
 
     // Protocol version 3 and low energy (0) also supports specifying when connected to "the cloud" - in pair mode, we
     // try to keep the device as long as possible activated (version 0) wi-fi devices
-    if ((this->protocol_version_ >= 0x03 || (!cut_cloud_mode && this->protocol_version_ == 0x00)) &&
+    if ((this->protocol_version_ >= 0x03 || (!cut_cloud_mode_ && this->protocol_version_ == 0x00)) &&
         remote_is_connected()) {
       status = 0x04;
     }

--- a/esphome/components/tuya/tuya.cpp
+++ b/esphome/components/tuya/tuya.cpp
@@ -22,7 +22,23 @@ static const int RECEIVE_TIMEOUT = 300;
 static const int MAX_RETRIES = 5;
 
 void Tuya::setup() {
+#ifndef TUYA_LOW_ENERGY
   this->set_interval("heartbeat", 15000, [this] { this->send_empty_command_(TuyaCommandType::HEARTBEAT); });
+#else
+  this->protocol_version_ = 0;
+  this->write_byte(0x00);
+  this->init_state_ = TuyaInitState::INIT_PRODUCT;
+  this->set_retry(
+      "initquery", 100, 20,
+      [this](const uint8_t remaining_attempts) {
+        if (remaining_attempts > 0) {
+          this->send_empty_command_(TuyaCommandType::PRODUCT_QUERY);
+          return RetryResult::RETRY;
+        }
+        return RetryResult::DONE;
+      },
+      1);
+#endif
   if (this->status_pin_ != nullptr) {
     this->status_pin_->digital_write(false);
   }
@@ -176,11 +192,19 @@ void Tuya::handle_command_(uint8_t command, uint8_t version, const uint8_t *buff
         this->product_ = R"({"p":"INVALID"})";
       }
       if (this->init_state_ == TuyaInitState::INIT_PRODUCT) {
+#ifndef TUYA_LOW_ENERGY
         this->init_state_ = TuyaInitState::INIT_CONF;
         this->send_empty_command_(TuyaCommandType::CONF_QUERY);
+#else
+        this->cancel_retry("initquery");
+        this->init_state_ = TuyaInitState::INIT_DATAPOINT;
+        ESP_LOGV(TAG, "Configured WIFI_STATE periodic send");
+        this->set_interval("wifi", 1000, [this] { this->send_wifi_status_(); });
+#endif
       }
       break;
     }
+#ifndef TUYA_LOW_ENERGY
     case TuyaCommandType::CONF_QUERY: {
       if (len >= 2) {
         this->status_pin_reported_ = buffer[0];
@@ -237,6 +261,22 @@ void Tuya::handle_command_(uint8_t command, uint8_t version, const uint8_t *buff
             TuyaCommand{.cmd = TuyaCommandType::DATAPOINT_REPORT_ACK, .payload = std::vector<uint8_t>{0x01}});
       }
       break;
+#else
+    case TuyaCommandType::WIFI_STATE:
+      this->send_wifi_status_();
+      break;
+    case TuyaCommandType::WIFI_RESET:
+      cut_cloud_mode = true;
+      break;
+    case TuyaCommandType::DATAPOINT_REPORT:
+      this->init_state_ = TuyaInitState::INIT_DONE;
+      this->handle_datapoints_(buffer, len);
+      // report that we received the data after handling them!
+      break;
+    case TuyaCommandType::DP_CACHE:
+      this->send_command_(TuyaCommand{.cmd = TuyaCommandType::DP_CACHE, .payload = std::vector<uint8_t>{0x01}});
+      break;
+#endif
     case TuyaCommandType::DATAPOINT_QUERY:
       break;
     case TuyaCommandType::WIFI_TEST:
@@ -408,6 +448,10 @@ void Tuya::handle_datapoints_(const uint8_t *buffer, size_t len) {
       if (listener.datapoint_id == datapoint.id)
         listener.on_datapoint(datapoint);
     }
+#ifdef TUYA_LOW_ENERGY
+    // after updating everything we report the confirmation of sending them "to the cloud" - the device could stay a little longer, maybe postpone this?
+    this->send_command_(TuyaCommand{.cmd = TuyaCommandType::DATAPOINT_REPORT, .payload = std::vector<uint8_t>{0x00}});
+#endif
   }
 }
 
@@ -424,6 +468,7 @@ void Tuya::send_raw_command_(TuyaCommand command) {
     case TuyaCommandType::PRODUCT_QUERY:
       this->expected_response_ = TuyaCommandType::PRODUCT_QUERY;
       break;
+#ifndef TUYA_LOW_ENERGY
     case TuyaCommandType::CONF_QUERY:
       this->expected_response_ = TuyaCommandType::CONF_QUERY;
       break;
@@ -431,6 +476,7 @@ void Tuya::send_raw_command_(TuyaCommand command) {
     case TuyaCommandType::DATAPOINT_QUERY:
       this->expected_response_ = TuyaCommandType::DATAPOINT_REPORT_ASYNC;
       break;
+#endif
     default:
       break;
   }
@@ -499,8 +545,10 @@ uint8_t Tuya::get_wifi_status_code_() {
   if (network::is_connected()) {
     status = 0x03;
 
-    // Protocol version 3 also supports specifying when connected to "the cloud"
-    if (this->protocol_version_ >= 0x03 && remote_is_connected()) {
+    // Protocol version 3 and low energy (0) also supports specifying when connected to "the cloud" - in pair mode, we try to keep the device as long as possible activated (version 0)
+    // wi-fi devices
+    if ((this->protocol_version_ >= 0x03 || (!cut_cloud_mode && this->protocol_version_ == 0x00)) &&
+        remote_is_connected()) {
       status = 0x04;
     }
   } else {
@@ -691,7 +739,13 @@ void Tuya::send_datapoint_command_(uint8_t datapoint_id, TuyaDatapointType datap
   buffer.push_back(data.size() >> 0);
   buffer.insert(buffer.end(), data.begin(), data.end());
 
-  this->send_command_(TuyaCommand{.cmd = TuyaCommandType::DATAPOINT_DELIVER, .payload = buffer});
+  this->send_command_(TuyaCommand{.cmd =
+#ifndef TUYA_LOW_ENERGY
+                                      TuyaCommandType::DATAPOINT_DELIVER,
+#else
+                                      TuyaCommandType::DATAPOINT_REPORT,
+#endif
+                                  .payload = buffer});
 }
 
 void Tuya::register_listener(uint8_t datapoint_id, const std::function<void(TuyaDatapoint)> &func) {

--- a/esphome/components/tuya/tuya.cpp
+++ b/esphome/components/tuya/tuya.cpp
@@ -449,7 +449,8 @@ void Tuya::handle_datapoints_(const uint8_t *buffer, size_t len) {
         listener.on_datapoint(datapoint);
     }
 #ifdef TUYA_LOW_ENERGY
-    // after updating everything we report the confirmation of sending them "to the cloud" - the device could stay a little longer, maybe postpone this?
+    // after updating everything we report the confirmation of sending them "to the cloud" - the device could stay a
+    // little longer, maybe postpone this?
     this->send_command_(TuyaCommand{.cmd = TuyaCommandType::DATAPOINT_REPORT, .payload = std::vector<uint8_t>{0x00}});
 #endif
   }
@@ -545,8 +546,8 @@ uint8_t Tuya::get_wifi_status_code_() {
   if (network::is_connected()) {
     status = 0x03;
 
-    // Protocol version 3 and low energy (0) also supports specifying when connected to "the cloud" - in pair mode, we try to keep the device as long as possible activated (version 0)
-    // wi-fi devices
+    // Protocol version 3 and low energy (0) also supports specifying when connected to "the cloud" - in pair mode, we
+    // try to keep the device as long as possible activated (version 0) wi-fi devices
     if ((this->protocol_version_ >= 0x03 || (!cut_cloud_mode && this->protocol_version_ == 0x00)) &&
         remote_is_connected()) {
       status = 0x04;

--- a/esphome/components/tuya/tuya.h
+++ b/esphome/components/tuya/tuya.h
@@ -48,18 +48,27 @@ struct TuyaDatapointListener {
 enum class TuyaCommandType : uint8_t {
   HEARTBEAT = 0x00,
   PRODUCT_QUERY = 0x01,
+#ifndef TUYA_LOW_ENERGY
   CONF_QUERY = 0x02,
   WIFI_STATE = 0x03,
   WIFI_RESET = 0x04,
   WIFI_SELECT = 0x05,
   DATAPOINT_DELIVER = 0x06,
+  LOCAL_TIME_QUERY = 0x1C,
+  WIFI_RSSI = 0x24,
+#else
+  WIFI_STATE = 0x02,
+  WIFI_RESET = 0x03,  // pairing mode, will made the device available for at most 2 minutes (maybe less)
+  DATAPOINT_REPORT = 0x05,
+  LOCAL_TIME_QUERY = 0x06,
+  DP_CACHE = 0x10,
+  WIFI_RSSI = 0x0B,
+#endif
   DATAPOINT_REPORT_ASYNC = 0x07,
   DATAPOINT_QUERY = 0x08,
   WIFI_TEST = 0x0E,
-  LOCAL_TIME_QUERY = 0x1C,
   DATAPOINT_REPORT_SYNC = 0x22,
   DATAPOINT_REPORT_ACK = 0x23,
-  WIFI_RSSI = 0x24,
   VACUUM_MAP_UPLOAD = 0x28,
   GET_NETWORK_STATUS = 0x2B,
   EXTENDED_SERVICES = 0x34,
@@ -160,6 +169,7 @@ class Tuya : public Component, public uart::UARTDevice {
   optional<TuyaCommandType> expected_response_{};
   uint8_t wifi_status_ = -1;
   CallbackManager<void()> initialized_callback_{};
+  bool cut_cloud_mode = false;
 };
 
 }  // namespace tuya

--- a/esphome/components/tuya/tuya.h
+++ b/esphome/components/tuya/tuya.h
@@ -169,7 +169,7 @@ class Tuya : public Component, public uart::UARTDevice {
   optional<TuyaCommandType> expected_response_{};
   uint8_t wifi_status_ = -1;
   CallbackManager<void()> initialized_callback_{};
-  bool cut_cloud_mode = false;
+  bool cut_cloud_mode_ = false;
 };
 
 }  // namespace tuya


### PR DESCRIPTION
# What does this implement/fix?

this pull request implements tuya low-energy devices that uses wifi modules combined with an MCU (battery powered - aka version 0)
requirements in configuration for this to work: setup priority is essential,  below an example

## Types of changes

Tuya low energy (battery powered devices) will work with those mods)
Code will need some care for better readability and better look anyway

**Related issue or feature (if applicable):**

no issues, the bool flag, low_energy: true keeps everything in place

## Test Environment

- [x] BK72xx

## Example entry for `config.yaml`:

```yaml
esphome:
  name: heiman-smoke-ws2sa-5
  friendly_name: tuya smoke detector
  name_add_mac_suffix: false

external_components:
  - source: components #let's assume we are using it as an external component, you can put this directory as an EC

bk72xx:
  board: cbu

logger:
  level: WARN #the lower the better for speed sake
  baud_rate: 0

mqtt:
  username: [redacted]
  password: [redacted]
  broker: [redacted]
  #down below we keep the device always available, even in offline, the MCU series exampled updates every 24 hours
  will_message: 
    topic: 
    payload: online
  birth_message: 
    topic: 
    payload: online

ota:
  platform: esphome
  password: !secret ota

wifi:
  ssid: !secret wifi_ssid
  password: !secret wifi_password

binary_sensor:
  - platform: tuya
    sensor_datapoint: 1
    #1 for smoke, 0 for clear, let's invert the logic
    filters: 
      - lambda: return x == 0;
    id: dsmoke
    name: "Smoke Detector"
    retain: True

sensor:
  - platform: tuya
    sensor_datapoint: 9
    name: Autotest
    id: autotest
    retain: True
  
  - platform: tuya
    sensor_datapoint: 14
    #0 low - 1 med - 2 high
    name: Battery Status
    id: battstate
    retain: True
  
  - platform: tuya
    sensor_datapoint: 15
    #from 0 to 100
    name: Battery Level
    id: battlevel
    retain: True

uart:
  - id: tuya_uart
    rx_pin: RX1
    tx_pin: TX1
    baud_rate: 9600
    parity: NONE
    stop_bits: 1
    #this is ABSOLUTELY REQUIRED for it to work, uart and tuya have precedence, in 2 seconds without response the device will deactivate itself
    setup_priority: 790

tuya:
  #required for this kind of devices
  low_energy: true
  #this is ABSOLUTELY REQUIRED for it to work, uart and tuya have precedence, in 2 seconds without response the device will deactivate itself
  setup_priority: 780
```

## Checklist:
  - [ x] The code change is tested and works locally.
  - [ x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ -] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
