### PR TITLE
Fix select() logging flood in very verbose mode

### DIFF
--- a/esphome/core/application.cpp
+++ b/esphome/core/application.cpp
@@ -160,6 +160,10 @@ void Application::loop() {
       int ret = ::select(this->max_fd_ + 1, &this->read_fds_, nullptr, nullptr, &tv);
 #endif
 
+      // Process select() result:
+      // ret < 0: error (except EINTR which is normal)
+      // ret > 0: socket(s) have data ready - normal and expected
+      // ret == 0: timeout occurred - normal and expected
       if (ret < 0) {
         if (errno == EINTR) {
           // Interrupted by signal - this is normal, just continue
@@ -170,11 +174,6 @@ void Application::loop() {
           ESP_LOGW(TAG, "select() failed with errno %d", errno);
           delay(delay_time);
         }
-      } else if (ret > 0) {
-        ESP_LOGVV(TAG, "select() woke early: %d socket(s) ready (saved up to %ums)", ret, delay_time);
-      } else {
-        // ret == 0: timeout occurred (normal)
-        ESP_LOGVV(TAG, "select() timeout after %ums (no sockets ready)", delay_time);
       }
     } else {
       // No sockets registered, use regular delay


### PR DESCRIPTION

# What does this implement/fix?

## Summary
This PR addresses user feedback about excessive logging when using "Very verbose" logging level. The recent socket optimization changes added select() status logging that was flooding the console with messages every 16ms.

## Problem
With very verbose logging enabled, users were seeing walls of repetitive messages:
```
[13:44:25][VV][app:177]: select() timeout after 16ms (no sockets ready)
[13:44:26][VV][app:177]: select() timeout after 16ms (no sockets ready)
[13:44:26][VV][app:177]: select() woke early: 1 socket(s) ready (saved up to 16ms)
[13:44:26][VV][app:177]: select() timeout after 16ms (no sockets ready)
```

These messages occur during normal operation:
- Timeouts happen when no sockets have data (expected behavior)
- "Woke early" happens when sockets receive data (also expected)

## Solution
- Removed the VV logging for both select() timeouts and early wakes
- Cleaned up empty conditional branches that only contained comments
- Added a consolidated comment explaining select() return values
- Kept only the error logging (LOGW) for actual select() failures

## Changes
- `esphome/core/application.cpp`: Removed verbose select() status logging and cleaned up code structure

## Testing
- The select() functionality remains unchanged
- Only the excessive logging has been removed
- Error conditions are still properly logged

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
