### PR TITLE
[rp2040] use low-level control for ISR gpio and add IRAM_ATTR

### DIFF
--- a/esphome/core/hal.h
+++ b/esphome/core/hal.h
@@ -24,6 +24,11 @@
 #define PROGMEM ICACHE_RODATA_ATTR
 #endif
 
+#elif defined(USE_RP2040)
+
+#define IRAM_ATTR __attribute__((noinline, long_call, section(".time_critical")))
+#define PROGMEM
+
 #else
 
 #define IRAM_ATTR


### PR DESCRIPTION
# What does this implement/fix?

Use low-level pin access to avoid flash delays.
Add IRAM_ATTR support for rp2040

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [X] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
