### PR TITLE
Use a ``define`` for log message constants

### DIFF
--- a/esphome/core/log_const_en.h
+++ b/esphome/core/log_const_en.h
@@ -1,11 +1,4 @@
 #pragma once
 
-#include "defines.h"
-
-#ifdef USE_ESP8266
 #define ESP_LOG_MSG_COMM_FAIL "Communication failed"
 #define ESP_LOG_MSG_COMM_FAIL_FOR "Communication failed for '%s'"
-#else
-constexpr const char *const ESP_LOG_MSG_COMM_FAIL = "Communication failed";
-constexpr const char *const ESP_LOG_MSG_COMM_FAIL_FOR = "Communication failed for '%s'";
-#endif


### PR DESCRIPTION
# What does this implement/fix?

Since constexpr makes 8266 builds unhappy, simplify and just use a `#define` for these messages.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
