### PR TITLE
Have ESPHome's YAML dumper comply with its own yamllint rules

### DIFF
--- a/esphome/yaml_util.py
+++ b/esphome/yaml_util.py
@@ -606,7 +606,7 @@ class ESPHomeDumper(yaml.SafeDumper):
 
     # The below override configures this dumper to indent output YAML properly:
     def increase_indent(self, flow=False, indentless=False):
-        return super(ESPHomeDumper, self).increase_indent(flow, False)
+        return super().increase_indent(flow, False)
 
 
 ESPHomeDumper.add_multi_representer(

--- a/esphome/yaml_util.py
+++ b/esphome/yaml_util.py
@@ -604,6 +604,10 @@ class ESPHomeDumper(yaml.SafeDumper):
             return self.represent_secret(value.id)
         return self.represent_stringify(value.id)
 
+    # The below override configures this dumper to indent output YAML properly:
+    def increase_indent(self, flow=False, indentless=False):
+        return super(ESPHomeDumper, self).increase_indent(flow, False)
+
 
 ESPHomeDumper.add_multi_representer(
     dict, lambda dumper, value: dumper.represent_mapping("tag:yaml.org,2002:map", value)


### PR DESCRIPTION
# What does this implement/fix?

When ESPHome dumps a YAML configuration and you want to use that resulting YAML as an example in some test, etc, the generated YAML does not comply with ESPHome's own yaml lint (`yamllint`) rules regarding indentation. This PR fixes this.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

## Example entry for `config.yaml`:

current output:
```yaml
binary_sensor:
- platform: gpio
# ...
```
with this PR:
```yaml
binary_sensor:
  - platform: gpio
# ...
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
