### PR TITLE
Mmc5603 fix for devices that don't retrieve chip_id

### DIFF
--- a/esphome/components/mmc5603/mmc5603.cpp
+++ b/esphome/components/mmc5603/mmc5603.cpp
@@ -39,7 +39,7 @@ void MMC5603Component::setup() {
     return;
   }
 
-  if (id != MMC56X3_CHIP_ID) {
+  if (id != 0 && id != MMC56X3_CHIP_ID) {
     ESP_LOGCONFIG(TAG, "Chip Wrong");
     this->error_code_ = ID_REGISTERS;
     this->mark_failed();

--- a/esphome/components/mmc5603/mmc5603.cpp
+++ b/esphome/components/mmc5603/mmc5603.cpp
@@ -39,7 +39,7 @@ void MMC5603Component::setup() {
     return;
   }
 
-  if (id != 0 && id != MMC56X3_CHIP_ID) {
+  if (id != 0 && id != MMC56X3_CHIP_ID) {  // ID is not reported correctly by all chips
     ESP_LOGCONFIG(TAG, "Chip Wrong");
     this->error_code_ = ID_REGISTERS;
     this->mark_failed();

--- a/esphome/components/mmc5603/mmc5603.cpp
+++ b/esphome/components/mmc5603/mmc5603.cpp
@@ -39,7 +39,7 @@ void MMC5603Component::setup() {
     return;
   }
 
-  if (id != 0 && id != MMC56X3_CHIP_ID) {  // ID is not reported correctly by all chips
+  if (id != 0 && id != MMC56X3_CHIP_ID) {  // ID is not reported correctly by all chips, 0 on some chips
     ESP_LOGCONFIG(TAG, "Chip Wrong");
     this->error_code_ = ID_REGISTERS;
     this->mark_failed();

--- a/tests/components/mmc5603/test.esp32-s3-ard.yaml
+++ b/tests/components/mmc5603/test.esp32-s3-ard.yaml
@@ -1,5 +1,0 @@
-substitutions:
-  scl_pin: GPIO41
-  sda_pin: GPIO40
-
-<<: !include common.yaml

--- a/tests/components/mmc5603/test.esp32-s3-ard.yaml
+++ b/tests/components/mmc5603/test.esp32-s3-ard.yaml
@@ -1,0 +1,5 @@
+substitutions:
+  scl_pin: GPIO41
+  sda_pin: GPIO40
+
+<<: !include common.yaml


### PR DESCRIPTION



# What does this implement/fix?

Added a check for id of 0 for boards that don't read the chipID correctly, namely the esp32 s3 py qt and esp32 feather v2 report the chipID as 0.

## Types of changes

- [X ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [X ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [X ] The code change is tested and works locally.
  - [X] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
