### PR TITLE
[bmp3xx] Remove redundant "bmp3xx" from log messages

### DIFF
--- a/esphome/components/bmp3xx_base/bmp3xx_base.cpp
+++ b/esphome/components/bmp3xx_base/bmp3xx_base.cpp
@@ -73,7 +73,7 @@ void BMP3XXComponent::setup() {
   ESP_LOGCONFIG(TAG, "Running setup");
   // Call the Device base class "initialise" function
   if (!reset()) {
-    ESP_LOGE(TAG, "Failed to reset BMP3XX...");
+    ESP_LOGE(TAG, "Failed to reset");
     this->error_code_ = ERROR_SENSOR_RESET;
     this->mark_failed();
   }
@@ -157,16 +157,14 @@ void BMP3XXComponent::dump_config() {
       ESP_LOGE(TAG, ESP_LOG_MSG_COMM_FAIL);
       break;
     case ERROR_WRONG_CHIP_ID:
-      ESP_LOGE(
-          TAG,
-          "BMP3XX has wrong chip ID (reported id: 0x%X) - please check if you are really using a BMP 388 or BMP 390",
-          this->chip_id_.reg);
+      ESP_LOGE(TAG, "Wrong chip ID (reported id: 0x%X) - please check if you are really using a BMP 388 or BMP 390",
+               this->chip_id_.reg);
       break;
     case ERROR_SENSOR_RESET:
-      ESP_LOGE(TAG, "BMP3XX failed to reset");
+      ESP_LOGE(TAG, "Failed to reset");
       break;
     default:
-      ESP_LOGE(TAG, "BMP3XX error code %d", (int) this->error_code_);
+      ESP_LOGE(TAG, "Error code %d", (int) this->error_code_);
       break;
   }
   ESP_LOGCONFIG(TAG, "  IIR Filter: %s", LOG_STR_ARG(iir_filter_to_str(this->iir_filter_)));
@@ -186,7 +184,7 @@ inline uint8_t oversampling_to_time(Oversampling over_sampling) { return (1 << u
 
 void BMP3XXComponent::update() {
   // Enable sensor
-  ESP_LOGV(TAG, "Sending conversion request...");
+  ESP_LOGV(TAG, "Sending conversion request");
   float meas_time = 1.0f;
   // Ref: https://www.bosch-sensortec.com/media/boschsensortec/downloads/datasheets/bst-bmp390-ds002.pdf 3.9.2
   meas_time += 2.02f * oversampling_to_time(this->temperature_oversampling_) + 0.163f;
@@ -296,7 +294,7 @@ bool BMP3XXComponent::get_pressure(float &pressure) {
 bool BMP3XXComponent::get_measurements(float &temperature, float &pressure) {
   // Check if a measurement is ready
   if (!data_ready()) {
-    ESP_LOGD(TAG, "BMP3XX Get measurement - data not ready skipping update");
+    ESP_LOGD(TAG, "Get measurement - data not ready skipping update");
     return false;
   }
 


### PR DESCRIPTION
# What does this implement/fix?

SSIA

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
