### PR TITLE
[ethernet] Remove redundant "ethernet" from log messages

### DIFF
--- a/esphome/components/ethernet/ethernet_component.cpp
+++ b/esphome/components/ethernet/ethernet_component.cpp
@@ -245,33 +245,33 @@ void EthernetComponent::loop() {
   switch (this->state_) {
     case EthernetComponentState::STOPPED:
       if (this->started_) {
-        ESP_LOGI(TAG, "Starting ethernet connection");
+        ESP_LOGI(TAG, "Starting connection");
         this->state_ = EthernetComponentState::CONNECTING;
         this->start_connect_();
       }
       break;
     case EthernetComponentState::CONNECTING:
       if (!this->started_) {
-        ESP_LOGI(TAG, "Stopped ethernet connection");
+        ESP_LOGI(TAG, "Stopped connection");
         this->state_ = EthernetComponentState::STOPPED;
       } else if (this->connected_) {
         // connection established
-        ESP_LOGI(TAG, "Connected via Ethernet!");
+        ESP_LOGI(TAG, "Connected");
         this->state_ = EthernetComponentState::CONNECTED;
 
         this->dump_connect_params_();
         this->status_clear_warning();
       } else if (now - this->connect_begin_ > 15000) {
-        ESP_LOGW(TAG, "Connecting via ethernet failed! Re-connecting...");
+        ESP_LOGW(TAG, "Connecting failed; reconnecting");
         this->start_connect_();
       }
       break;
     case EthernetComponentState::CONNECTED:
       if (!this->started_) {
-        ESP_LOGI(TAG, "Stopped ethernet connection");
+        ESP_LOGI(TAG, "Stopped connection");
         this->state_ = EthernetComponentState::STOPPED;
       } else if (!this->connected_) {
-        ESP_LOGW(TAG, "Connection via Ethernet lost! Re-connecting...");
+        ESP_LOGW(TAG, "Connection lost; reconnecting");
         this->state_ = EthernetComponentState::CONNECTING;
         this->start_connect_();
       }


### PR DESCRIPTION
# What does this implement/fix?

SSIA

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
