### PR TITLE
[max9611] Remove redundant "max9611" from log messages

### DIFF
--- a/esphome/components/max9611/max9611.cpp
+++ b/esphome/components/max9611/max9611.cpp
@@ -42,17 +42,17 @@ void MAX9611Component::setup() {
   const uint8_t fast_mode_dat[] = {CONTROL_REGISTER_1_ADRR, MAX9611Multiplexer::MAX9611_MULTIPLEXER_FAST_MODE};
 
   if (this->write(reinterpret_cast<const uint8_t *>(&setup_dat), sizeof(setup_dat)) != ErrorCode::ERROR_OK) {
-    ESP_LOGE(TAG, "Failed to setup Max9611 during GAIN SET");
+    ESP_LOGE(TAG, "GAIN SET failed");
     return;
   }
   delay(SETUP_DELAY);
   if (this->write(reinterpret_cast<const uint8_t *>(&fast_mode_dat), sizeof(fast_mode_dat)) != ErrorCode::ERROR_OK) {
-    ESP_LOGE(TAG, "Failed to setup Max9611 during FAST MODE SET");
+    ESP_LOGE(TAG, "FAST MODE SET failed");
     return;
   }
 }
 void MAX9611Component::dump_config() {
-  ESP_LOGCONFIG(TAG, "Dump Config max9611...");
+  ESP_LOGCONFIG(TAG, "MAX9611:");
   ESP_LOGCONFIG(TAG, "    CSA Gain Register: %x", gain_);
   LOG_I2C_DEVICE(this);
 }
@@ -63,7 +63,7 @@ void MAX9611Component::update() {
   // Just read the entire register map in a bulk read, faster than individually querying register.
   const ErrorCode read_result = this->read(register_map_, sizeof(register_map_));
   if (write_result != ErrorCode::ERROR_OK || read_result != ErrorCode::ERROR_OK) {
-    ESP_LOGW(TAG, "MAX9611 Update FAILED!");
+    ESP_LOGW(TAG, "Update failed");
     return;
   }
   uint16_t csa_register = ((register_map_[CSA_DATA_BYTE_MSB_ADRR] << 8) | (register_map_[CSA_DATA_BYTE_LSB_ADRR])) >> 4;


### PR DESCRIPTION
# What does this implement/fix?

SSIA

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
