### PR TITLE
[spi] Remove redundant "SPI" from log messages

### DIFF
--- a/esphome/components/spi/spi.cpp
+++ b/esphome/components/spi/spi.cpp
@@ -18,7 +18,7 @@ GPIOPin *const NullPin::NULL_PIN = new NullPin();  // NOLINT(cppcoreguidelines-a
 SPIDelegate *SPIComponent::register_device(SPIClient *device, SPIMode mode, SPIBitOrder bit_order, uint32_t data_rate,
                                            GPIOPin *cs_pin) {
   if (this->devices_.count(device) != 0) {
-    ESP_LOGE(TAG, "SPI device already registered");
+    ESP_LOGE(TAG, "Device already registered");
     return this->devices_[device];
   }
   SPIDelegate *delegate = this->spi_bus_->get_delegate(data_rate, bit_order, mode, cs_pin);  // NOLINT
@@ -28,7 +28,7 @@ SPIDelegate *SPIComponent::register_device(SPIClient *device, SPIMode mode, SPIB
 
 void SPIComponent::unregister_device(SPIClient *device) {
   if (this->devices_.count(device) == 0) {
-    esph_log_e(TAG, "SPI device not registered");
+    esph_log_e(TAG, "Device not registered");
     return;
   }
   delete this->devices_[device];  // NOLINT
@@ -36,14 +36,14 @@ void SPIComponent::unregister_device(SPIClient *device) {
 }
 
 void SPIComponent::setup() {
-  ESP_LOGD(TAG, "Setting up SPI bus...");
+  ESP_LOGCONFIG(TAG, "Running setup");
 
   if (this->sdo_pin_ == nullptr)
     this->sdo_pin_ = NullPin::NULL_PIN;
   if (this->sdi_pin_ == nullptr)
     this->sdi_pin_ = NullPin::NULL_PIN;
   if (this->clk_pin_ == nullptr) {
-    ESP_LOGE(TAG, "No clock pin for SPI");
+    ESP_LOGE(TAG, "No clock pin");
     this->mark_failed();
     return;
   }

--- a/esphome/components/spi_device/spi_device.cpp
+++ b/esphome/components/spi_device/spi_device.cpp
@@ -9,9 +9,8 @@ namespace spi_device {
 static const char *const TAG = "spi_device";
 
 void SPIDeviceComponent::setup() {
-  ESP_LOGD(TAG, "Setting up SPIDevice...");
+  ESP_LOGCONFIG(TAG, "Running setup");
   this->spi_setup();
-  ESP_LOGCONFIG(TAG, "SPIDevice started!");
 }
 
 void SPIDeviceComponent::dump_config() {


### PR DESCRIPTION
# What does this implement/fix?

SSIA

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
