### PR TITLE
[nextion] Allocate NextionQueue in PSRAM (if available)

### DIFF
--- a/esphome/components/nextion/nextion.cpp
+++ b/esphome/components/nextion/nextion.cpp
@@ -1003,8 +1003,13 @@ uint16_t Nextion::recv_ret_string_(std::string &response, uint32_t timeout, bool
  * @param variable_name Name for the queue
  */
 void Nextion::add_no_result_to_queue_(const std::string &variable_name) {
-  // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
-  nextion::NextionQueue *nextion_queue = new nextion::NextionQueue;
+  ExternalRAMAllocator<nextion::NextionQueue> allocator(ExternalRAMAllocator<nextion::NextionQueue>::ALLOW_FAILURE);
+  nextion::NextionQueue *nextion_queue = allocator.allocate(1);
+  if (nextion_queue == nullptr) {
+    ESP_LOGW(TAG, "Failed to allocate NextionQueue");
+    return;
+  }
+  new (nextion_queue) nextion::NextionQueue();
 
   // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
   nextion_queue->component = new nextion::NextionComponentBase;
@@ -1137,8 +1142,13 @@ void Nextion::add_to_get_queue(NextionComponentBase *component) {
   if ((!this->is_setup() && !this->ignore_is_setup_))
     return;
 
-  // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
-  nextion::NextionQueue *nextion_queue = new nextion::NextionQueue;
+  ExternalRAMAllocator<nextion::NextionQueue> allocator(ExternalRAMAllocator<nextion::NextionQueue>::ALLOW_FAILURE);
+  nextion::NextionQueue *nextion_queue = allocator.allocate(1);
+  if (nextion_queue == nullptr) {
+    ESP_LOGW(TAG, "Failed to allocate NextionQueue");
+    return;
+  }
+  new (nextion_queue) nextion::NextionQueue();
 
   nextion_queue->component = component;
   nextion_queue->queue_time = millis();
@@ -1165,8 +1175,13 @@ void Nextion::add_addt_command_to_queue(NextionComponentBase *component) {
   if ((!this->is_setup() && !this->ignore_is_setup_) || this->is_sleeping())
     return;
 
-  // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
-  nextion::NextionQueue *nextion_queue = new nextion::NextionQueue;
+  ExternalRAMAllocator<nextion::NextionQueue> allocator(ExternalRAMAllocator<nextion::NextionQueue>::ALLOW_FAILURE);
+  nextion::NextionQueue *nextion_queue = allocator.allocate(1);
+  if (nextion_queue == nullptr) {
+    ESP_LOGW(TAG, "Failed to allocate NextionQueue");
+    return;
+  }
+  new (nextion_queue) nextion::NextionQueue();
 
   nextion_queue->component = component;
   nextion_queue->queue_time = millis();


### PR DESCRIPTION
# What does this implement/fix?

This change updates the `NextionQueue` allocation to use PSRAM when available, via ESPHome's built-in `ExternalRAMAllocator`. This reduces DRAM usage.

### Details

- Allocation uses `ExternalRAMAllocator<T>::ALLOW_FAILURE`, which safely returns `nullptr` if PSRAM is not present or exhausted.
- Fallback or recovery is handled gracefully by skipping queue insertion in such cases.
- No changes to YAML or configuration are needed — this is an internal optimization only.

### Note

- This commit only applies the PSRAM optimization to `NextionQueue` (also affecting waveform queues).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [ ] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`: N/A

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
