### PR TITLE
Fix logger stack overflow

### DIFF
--- a/esphome/components/logger/logger.h
+++ b/esphome/components/logger/logger.h
@@ -212,9 +212,9 @@ class Logger : public Component {
   }
 
   // Format string to explicit buffer with varargs
-  inline void printf_to_buffer_(const char *format, char *buffer, int *buffer_at, int buffer_size, ...) {
+  inline void printf_to_buffer_(char *buffer, int *buffer_at, int buffer_size, const char *format, ...) {
     va_list arg;
-    va_start(arg, buffer_size);
+    va_start(arg, format);
     this->format_body_to_buffer_(buffer, buffer_at, buffer_size, format, arg);
     va_end(arg);
   }
@@ -312,13 +312,13 @@ class Logger : public Component {
 #if defined(USE_ESP32) || defined(USE_LIBRETINY)
     if (thread_name != nullptr) {
       // Non-main task with thread name
-      this->printf_to_buffer_("%s[%s][%s:%03u]%s[%s]%s: ", buffer, buffer_at, buffer_size, color, letter, tag, line,
+      this->printf_to_buffer_(buffer, buffer_at, buffer_size, "%s[%s][%s:%03u]%s[%s]%s: ", color, letter, tag, line,
                               ESPHOME_LOG_BOLD(ESPHOME_LOG_COLOR_RED), thread_name, color);
       return;
     }
 #endif
     // Main task or non ESP32/LibreTiny platform
-    this->printf_to_buffer_("%s[%s][%s:%03u]: ", buffer, buffer_at, buffer_size, color, letter, tag, line);
+    this->printf_to_buffer_(buffer, buffer_at, buffer_size, "%s[%s][%s:%03u]: ", color, letter, tag, line);
   }
 
   inline void HOT format_body_to_buffer_(char *buffer, int *buffer_at, int buffer_size, const char *format,


### PR DESCRIPTION
# What does this implement/fix?

## To test
```
external_components:
  - source: github://pr#8988
    components: [ logger ]
    refresh: 0s
```

## Summary
This PR fixes a critical stack overflow issue in the logger component that was introduced in the recent task log buffer feature because of a refactoring error. The issue could case ESP32 devices to crash with a stack overflow when logging from non-main tasks.

## The Problem
The stack overflow occurs due to incorrect parameter ordering in the `printf_to_buffer_` method in `logger.h`. The method signature had the format string as the first parameter, but the variadic arguments initialization with `va_start()` was using `buffer_size` as the reference parameter, which was not the last named parameter before the varargs.

### Stack trace from the issue:
```
[16:50:31]***ERROR*** A stack overflow in task loopTask has been detected.
[16:50:31]
[16:50:31]Backtrace: 0x400838ce:0x3ffbbf60 0x4008a965:0x3ffbbf80 0x4008d1c2:0x3ffbbfa0 0x4008bcd1:0x3ffbc020 0x4008d30c:0x3ffbc050 0x4008d2be:0xa5a5a5a5 |<-CORRUPTED
```

## Root Cause
The `printf_to_buffer_` method had an incorrect parameter order:
```cpp
// Incorrect - format string first, but va_start uses buffer_size
inline void printf_to_buffer_(const char *format, char *buffer, int *buffer_at, int buffer_size, ...) {
    va_list arg;
    va_start(arg, buffer_size);  // Wrong! buffer_size is not the last parameter before varargs
    this->format_body_to_buffer_(buffer, buffer_at, buffer_size, format, arg);
    va_end(arg);
}
```

This caused undefined behavior because `va_start()` must be called with the last named parameter before the variadic arguments, which in the original code should have been `format`, not `buffer_size`.

## The Fix
Reordered the parameters to place the format string as the last named parameter before the varargs:

```cpp
// Correct - format string is now the last named parameter before varargs
inline void printf_to_buffer_(char *buffer, int *buffer_at, int buffer_size, const char *format, ...) {
    va_list arg;
    va_start(arg, format);  // Correct! format is the last parameter before varargs
    this->format_body_to_buffer_(buffer, buffer_at, buffer_size, format, arg);
    va_end(arg);
}
```

Also updated all call sites to match the new parameter order:
```cpp
// Before
this->printf_to_buffer_("%s[%s][%s:%03u]: ", buffer, buffer_at, buffer_size, color, letter, tag, line);

// After  
this->printf_to_buffer_(buffer, buffer_at, buffer_size, "%s[%s][%s:%03u]: ", color, letter, tag, line);
```

## Testing
- The fix ensures proper va_list initialization, preventing stack corruption
- Tested with configurations that use task log buffers and logging from multiple tasks
- No more stack overflow errors when logging from non-main tasks

## Impact
This is a critical fix that prevents crashes on ESP32 devices when using the logger with task log buffers enabled. The issue would manifest when logging from any non-main task (e.g., WiFi tasks, sensor tasks, etc.).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/issues/issues/7049
- fixes https://github.com/esphome/issues/issues/7076
- fixes https://github.com/esphome/issues/issues/7043

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
