### PR TITLE
Feature/cover feedback calibration

### DIFF
--- a/esphome/components/feedback/cover.py
+++ b/esphome/components/feedback/cover.py
@@ -20,6 +20,7 @@ CONF_CLOSE_SENSOR = "close_sensor"
 CONF_OPEN_OBSTACLE_SENSOR = "open_obstacle_sensor"
 CONF_CLOSE_OBSTACLE_SENSOR = "close_obstacle_sensor"
 CONF_HAS_BUILT_IN_ENDSTOP = "has_built_in_endstop"
+CONF_ENABLE_DURATION_AUTOCALIBRATION = "enable_duration_autocalibration"
 CONF_INFER_ENDSTOP_FROM_MOVEMENT = "infer_endstop_from_movement"
 CONF_DIRECTION_CHANGE_WAIT_TIME = "direction_change_wait_time"
 CONF_ACCELERATION_WAIT_TIME = "acceleration_wait_time"
@@ -70,6 +71,7 @@ CONFIG_FEEDBACK_COVER_BASE_SCHEMA = (
             ),
             cv.Optional(CONF_MAX_DURATION): cv.positive_time_period_milliseconds,
             cv.Optional(CONF_HAS_BUILT_IN_ENDSTOP, default=False): cv.boolean,
+            cv.Optional(CONF_ENABLE_DURATION_AUTOCALIBRATION, default=False): cv.boolean,
             cv.Optional(CONF_ASSUMED_STATE): cv.boolean,
             cv.Optional(
                 CONF_UPDATE_INTERVAL, "1000ms"
@@ -139,6 +141,7 @@ async def to_code(config):
         cg.add(var.set_max_duration(config[CONF_MAX_DURATION]))
 
     cg.add(var.set_has_built_in_endstop(config[CONF_HAS_BUILT_IN_ENDSTOP]))
+    cg.add(var.set_enable_duration_autocalibration(config[CONF_ENABLE_DURATION_AUTOCALIBRATION]))
 
     if CONF_ASSUMED_STATE in config:
         cg.add(var.set_assumed_state(config[CONF_ASSUMED_STATE]))

--- a/esphome/components/feedback/feedback_cover.cpp
+++ b/esphome/components/feedback/feedback_cover.cpp
@@ -30,10 +30,12 @@ void FeedbackCover::setup() {
   }
 
   // if available, get moving state from sensors
-  if (this->open_feedback_ != nullptr && this->open_feedback_->state) {
-    this->current_operation = COVER_OPERATION_OPENING;
-  } else if (this->close_feedback_ != nullptr && this->close_feedback_->state) {
-    this->current_operation = COVER_OPERATION_CLOSING;
+  if(this->open_feedback_ != this->close_feedback_) {	//If the sensor is the same, we can not define the current operation
+	  if (this->open_feedback_ != nullptr && this->open_feedback_->state) {
+		this->current_operation = COVER_OPERATION_OPENING;
+	  } else if (this->close_feedback_ != nullptr && this->close_feedback_->state) {
+		this->current_operation = COVER_OPERATION_CLOSING;
+	  }
   }
 #endif
 
@@ -93,11 +95,12 @@ void FeedbackCover::set_open_sensor(binary_sensor::BinarySensor *open_feedback) 
   // setup callbacks to react to sensor changes
   open_feedback->add_on_state_callback([this](bool state) {
     ESP_LOGD(TAG, "'%s' - Open feedback '%s'.", this->name_.c_str(), state ? "STARTED" : "ENDED");
-    this->recompute_position_();
+	
+	this->recompute_position_();
     if (!state && this->infer_endstop_ && this->current_trigger_operation_ == COVER_OPERATION_OPENING) {
       this->endstop_reached_(true);
     }
-    this->set_current_operation_(state ? COVER_OPERATION_OPENING : COVER_OPERATION_IDLE, false);
+	if(this->current_trigger_operation_ != COVER_OPERATION_CLOSING) this->set_current_operation_(state ? COVER_OPERATION_OPENING : COVER_OPERATION_IDLE, false);
   });
 }
 
@@ -105,13 +108,12 @@ void FeedbackCover::set_close_sensor(binary_sensor::BinarySensor *close_feedback
   this->close_feedback_ = close_feedback;
 
   close_feedback->add_on_state_callback([this](bool state) {
-    ESP_LOGD(TAG, "'%s' - Close feedback '%s'.", this->name_.c_str(), state ? "STARTED" : "ENDED");
-    this->recompute_position_();
-    if (!state && this->infer_endstop_ && this->current_trigger_operation_ == COVER_OPERATION_CLOSING) {
-      this->endstop_reached_(false);
-    }
-
-    this->set_current_operation_(state ? COVER_OPERATION_CLOSING : COVER_OPERATION_IDLE, false);
+	ESP_LOGD(TAG, "'%s' - Close feedback '%s'.", this->name_.c_str(), state ? "STARTED" : "ENDED");
+	this->recompute_position_();
+	if (!state && this->infer_endstop_ && this->current_trigger_operation_ == COVER_OPERATION_CLOSING) {
+	  this->endstop_reached_(false);
+	}
+	if(this->current_trigger_operation_ != COVER_OPERATION_OPENING) this->set_current_operation_(state ? COVER_OPERATION_CLOSING : COVER_OPERATION_IDLE, false);
   });
 }
 

--- a/esphome/components/feedback/feedback_cover.cpp
+++ b/esphome/components/feedback/feedback_cover.cpp
@@ -94,13 +94,29 @@ void FeedbackCover::set_open_sensor(binary_sensor::BinarySensor *open_feedback) 
 
   // setup callbacks to react to sensor changes
   open_feedback->add_on_state_callback([this](bool state) {
-    ESP_LOGD(TAG, "'%s' - Open feedback '%s'.", this->name_.c_str(), state ? "STARTED" : "ENDED");
-	
-	this->recompute_position_();
-    if (!state && this->infer_endstop_ && this->current_trigger_operation_ == COVER_OPERATION_OPENING) {
-      this->endstop_reached_(true);
-    }
-	if(this->current_trigger_operation_ != COVER_OPERATION_CLOSING) this->set_current_operation_(state ? COVER_OPERATION_OPENING : COVER_OPERATION_IDLE, false);
+	if(this->open_feedback_ == this->close_feedback_) {
+		ESP_LOGD(TAG, "'%s' - Open/Close feedback '%s'.", this->name_.c_str(), state ? "STARTED" : "ENDED");
+		this->recompute_position_();
+		
+		if (!state && this->infer_endstop_ && this->current_trigger_operation_ == COVER_OPERATION_OPENING) {
+		  this->endstop_reached_(true);
+		}
+		else if (!state && this->infer_endstop_ && this->current_trigger_operation_ == COVER_OPERATION_CLOSING) {
+		  this->endstop_reached_(false);
+		}
+		
+		if(this->current_trigger_operation_ != COVER_OPERATION_CLOSING) this->set_current_operation_(state ? COVER_OPERATION_OPENING : COVER_OPERATION_IDLE, false);
+		else if(this->current_trigger_operation_ != COVER_OPERATION_OPENING) this->set_current_operation_(state ? COVER_OPERATION_CLOSING : COVER_OPERATION_IDLE, false);
+	}
+	else {
+		ESP_LOGD(TAG, "'%s' - Open feedback '%s'.", this->name_.c_str(), state ? "STARTED" : "ENDED");
+		
+		this->recompute_position_();
+		if (!state && this->infer_endstop_ && this->current_trigger_operation_ == COVER_OPERATION_OPENING) {
+		  this->endstop_reached_(true);
+		}
+		this->set_current_operation_(state ? COVER_OPERATION_OPENING : COVER_OPERATION_IDLE, false);
+	}
   });
 }
 
@@ -108,12 +124,17 @@ void FeedbackCover::set_close_sensor(binary_sensor::BinarySensor *close_feedback
   this->close_feedback_ = close_feedback;
 
   close_feedback->add_on_state_callback([this](bool state) {
-	ESP_LOGD(TAG, "'%s' - Close feedback '%s'.", this->name_.c_str(), state ? "STARTED" : "ENDED");
-	this->recompute_position_();
-	if (!state && this->infer_endstop_ && this->current_trigger_operation_ == COVER_OPERATION_CLOSING) {
-	  this->endstop_reached_(false);
+	if(this->open_feedback_ == this->close_feedback_) {
+		//To nothing because it's done by open_feedback callback
 	}
-	if(this->current_trigger_operation_ != COVER_OPERATION_OPENING) this->set_current_operation_(state ? COVER_OPERATION_CLOSING : COVER_OPERATION_IDLE, false);
+	else {
+		ESP_LOGD(TAG, "'%s' - Close feedback '%s'.", this->name_.c_str(), state ? "STARTED" : "ENDED");
+		this->recompute_position_();
+		if (!state && this->infer_endstop_ && this->current_trigger_operation_ == COVER_OPERATION_CLOSING) {
+		  this->endstop_reached_(false);
+		}
+		this->set_current_operation_(state ? COVER_OPERATION_CLOSING : COVER_OPERATION_IDLE, false);
+	}
   });
 }
 

--- a/esphome/components/feedback/feedback_cover.cpp
+++ b/esphome/components/feedback/feedback_cover.cpp
@@ -21,6 +21,9 @@ void FeedbackCover::setup() {
   }
   this->current_operation = COVER_OPERATION_IDLE;
 
+  this->last_stop_at_fully_open_state = false;
+  this->last_stop_at_fully_close_state = false;
+  
 #ifdef USE_BINARY_SENSOR
   // if available, get position from endstop sensors
   if (this->open_endstop_ != nullptr && this->open_endstop_->state) {
@@ -40,6 +43,7 @@ void FeedbackCover::setup() {
 	  }
   }
 #endif
+
 
   this->last_recompute_time_ = this->start_dir_time_ = millis();
 }
@@ -107,8 +111,23 @@ void FeedbackCover::set_open_sensor(binary_sensor::BinarySensor *open_feedback) 
 		  this->endstop_reached_(false);
 		}
 		
+		cover::CoverOperation operation_when_sensor_detected{this->current_trigger_operation_};
+
 		if(this->current_trigger_operation_ != COVER_OPERATION_CLOSING) this->set_current_operation_(state ? COVER_OPERATION_OPENING : COVER_OPERATION_IDLE, false);
 		else if(this->current_trigger_operation_ != COVER_OPERATION_OPENING) this->set_current_operation_(state ? COVER_OPERATION_CLOSING : COVER_OPERATION_IDLE, false);
+		
+		
+		//Set bool for next move
+		if(!state) {
+			if(operation_when_sensor_detected == COVER_OPERATION_OPENING) {
+				this->last_stop_at_fully_open_state = true;
+				this->last_stop_at_fully_close_state = false;
+			}
+			else if(operation_when_sensor_detected == COVER_OPERATION_CLOSING) {
+				this->last_stop_at_fully_open_state = false;
+				this->last_stop_at_fully_close_state = true;
+			}
+		}
 	}
 	else {
 		ESP_LOGD(TAG, "'%s' - Open feedback '%s'.", this->name_.c_str(), state ? "STARTED" : "ENDED");
@@ -117,7 +136,16 @@ void FeedbackCover::set_open_sensor(binary_sensor::BinarySensor *open_feedback) 
 		if (!state && this->infer_endstop_ && this->current_trigger_operation_ == COVER_OPERATION_OPENING) {
 		  this->endstop_reached_(true);
 		}
+		cover::CoverOperation operation_when_sensor_detected{this->current_trigger_operation_};
 		this->set_current_operation_(state ? COVER_OPERATION_OPENING : COVER_OPERATION_IDLE, false);
+		
+		//Set bool for next move
+		if(!state) {
+			if(operation_when_sensor_detected == COVER_OPERATION_OPENING) {
+				this->last_stop_at_fully_open_state = true;
+				this->last_stop_at_fully_close_state = false;
+			}
+		}
 	}
   });
 }
@@ -135,7 +163,15 @@ void FeedbackCover::set_close_sensor(binary_sensor::BinarySensor *close_feedback
 		if (!state && this->infer_endstop_ && this->current_trigger_operation_ == COVER_OPERATION_CLOSING) {
 		  this->endstop_reached_(false);
 		}
+		cover::CoverOperation operation_when_sensor_detected{this->current_trigger_operation_};
 		this->set_current_operation_(state ? COVER_OPERATION_CLOSING : COVER_OPERATION_IDLE, false);
+		
+		if(!state) {
+			if(operation_when_sensor_detected == COVER_OPERATION_CLOSING) {
+				this->last_stop_at_fully_open_state = false;
+				this->last_stop_at_fully_close_state = true;
+			}
+		}
 	}
   });
 }
@@ -168,11 +204,19 @@ void FeedbackCover::endstop_reached_(bool open_endstop) {
   // from a position slightly past the endpoint
   if (this->current_trigger_operation_ == (open_endstop ? COVER_OPERATION_OPENING : COVER_OPERATION_CLOSING)) {
     float dur = (now - this->start_dir_time_) / 1e3f;
+	float durMs = now - this->start_dir_time_;
     ESP_LOGD(TAG, "'%s' - %s endstop reached. Took %.1fs.", this->name_.c_str(), open_endstop ? "Open" : "Close", dur);
 	
-	
-	ESP_LOGD(TAG, "'%s' - Endstop reached : %s %s", this->name_.c_str(), this->last_stop_at_fully_open_state ? "open true" : "open false", this->last_stop_at_fully_close_state ? "close true" : "close false");
-	
+	if(this->enable_duration_autocalibration_) {
+		if(this->last_stop_at_fully_open_state) {
+			ESP_LOGI(TAG, "'%s' - Close duration autocalibration : %.1fs.", this->name_.c_str(), dur);
+			this->close_duration_ = durMs;
+		}
+		else if(this->last_stop_at_fully_close_state) {
+			ESP_LOGI(TAG, "'%s' - Open duration autocalibration : %.1fs.", this->name_.c_str(), dur);
+			this->open_duration_ = durMs;
+		}
+	}
 	
     // if there is no external mechanism, stop the cover
     if (!this->has_built_in_endstop_) {
@@ -182,8 +226,6 @@ void FeedbackCover::endstop_reached_(bool open_endstop) {
     }
 	
 	//Set bool for next move
-	ESP_LOGD(TAG, "'%s' - Set last_stop_at_fully !!", this->name_.c_str());
-	
 	if(open_endstop) {
 		this->last_stop_at_fully_open_state = true;
 		this->last_stop_at_fully_close_state = false;
@@ -220,14 +262,6 @@ void FeedbackCover::set_current_operation_(cover::CoverOperation operation, bool
     this->start_dir_time_ = this->last_recompute_time_ = now;
     this->publish_state();
     this->last_publish_time_ = now;
-	
-	if(operation == COVER_OPERATION_IDLE) {
-		this->last_stop_at_fully_open_state = false;
-		this->last_stop_at_fully_close_state = false;
-		
-		ESP_LOGD(TAG, "'%s' - Set last_stop_at_fully false !!", this->name_.c_str());
-	
-	}
   }
 }
 
@@ -434,6 +468,12 @@ void FeedbackCover::start_direction_(CoverOperation dir) {
              : dir == COVER_OPERATION_CLOSING ? "CLOSE"
                                               : "STOP");
     trig->trigger();
+  }
+  
+  //If the stop is ask, we cannot known if it's because of endstop
+  if(dir == COVER_OPERATION_IDLE) {
+	this->last_stop_at_fully_open_state = false;
+	this->last_stop_at_fully_close_state = false;
   }
 }
 

--- a/esphome/components/feedback/feedback_cover.cpp
+++ b/esphome/components/feedback/feedback_cover.cpp
@@ -25,8 +25,10 @@ void FeedbackCover::setup() {
   // if available, get position from endstop sensors
   if (this->open_endstop_ != nullptr && this->open_endstop_->state) {
     this->position = COVER_OPEN;
+	last_stop_at_fully_open_state = true;
   } else if (this->close_endstop_ != nullptr && this->close_endstop_->state) {
     this->position = COVER_CLOSED;
+	last_stop_at_fully_close_state = true;
   }
 
   // if available, get moving state from sensors
@@ -144,13 +146,29 @@ void FeedbackCover::endstop_reached_(bool open_endstop) {
   if (this->current_trigger_operation_ == (open_endstop ? COVER_OPERATION_OPENING : COVER_OPERATION_CLOSING)) {
     float dur = (now - this->start_dir_time_) / 1e3f;
     ESP_LOGD(TAG, "'%s' - %s endstop reached. Took %.1fs.", this->name_.c_str(), open_endstop ? "Open" : "Close", dur);
-
+	
+	
+	ESP_LOGD(TAG, "'%s' - Endstop reached : %s %s", this->name_.c_str(), this->last_stop_at_fully_open_state ? "open true" : "open false", this->last_stop_at_fully_close_state ? "close true" : "close false");
+	
+	
     // if there is no external mechanism, stop the cover
     if (!this->has_built_in_endstop_) {
       this->start_direction_(COVER_OPERATION_IDLE);
     } else {
       this->set_current_operation_(COVER_OPERATION_IDLE, true);
     }
+	
+	//Set bool for next move
+	ESP_LOGD(TAG, "'%s' - Set last_stop_at_fully !!", this->name_.c_str());
+	
+	if(open_endstop) {
+		this->last_stop_at_fully_open_state = true;
+		this->last_stop_at_fully_close_state = false;
+	}
+	else {
+		this->last_stop_at_fully_open_state = false;
+		this->last_stop_at_fully_close_state = true;
+	}
   }
 
   // always sync position and publish
@@ -179,6 +197,14 @@ void FeedbackCover::set_current_operation_(cover::CoverOperation operation, bool
     this->start_dir_time_ = this->last_recompute_time_ = now;
     this->publish_state();
     this->last_publish_time_ = now;
+	
+	if(operation == COVER_OPERATION_IDLE) {
+		this->last_stop_at_fully_open_state = false;
+		this->last_stop_at_fully_close_state = false;
+		
+		ESP_LOGD(TAG, "'%s' - Set last_stop_at_fully false !!", this->name_.c_str());
+	
+	}
   }
 }
 

--- a/esphome/components/feedback/feedback_cover.h
+++ b/esphome/components/feedback/feedback_cover.h
@@ -75,6 +75,9 @@ class FeedbackCover : public cover::Cover, public Component {
   bool assumed_state_{false};
   bool infer_endstop_{false};
   float obstacle_rollback_{0};
+  
+  bool last_stop_at_fully_open_state = false;
+  bool last_stop_at_fully_close_state = false;
 
   cover::CoverOperation last_operation_{cover::COVER_OPERATION_OPENING};
   cover::CoverOperation current_trigger_operation_{cover::COVER_OPERATION_IDLE};

--- a/esphome/components/feedback/feedback_cover.h
+++ b/esphome/components/feedback/feedback_cover.h
@@ -40,6 +40,7 @@ class FeedbackCover : public cover::Cover, public Component {
   void set_infer_endstop(bool infer_endstop) { this->infer_endstop_ = infer_endstop; }
   void set_direction_change_waittime(uint32_t waittime) { this->direction_change_waittime_ = waittime; }
   void set_acceleration_wait_time(uint32_t waittime) { this->acceleration_wait_time_ = waittime; }
+  void set_enable_duration_autocalibration(bool value) { this->enable_duration_autocalibration_ = value; }
 
   cover::CoverTraits get_traits() override;
 
@@ -72,6 +73,7 @@ class FeedbackCover : public cover::Cover, public Component {
   optional<uint32_t> direction_change_waittime_{};
   uint32_t acceleration_wait_time_{0};
   bool has_built_in_endstop_{false};
+  bool enable_duration_autocalibration_{false};
   bool assumed_state_{false};
   bool infer_endstop_{false};
   float obstacle_rollback_{0};


### PR DESCRIPTION
# What does this implement/fix?

The opening and closing time is automatically calibrated when the cover makes a complete movement. The endstop must be informed (directly or via moving sensor).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#4972

## Test Environment

- [X ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
cover:
  - platform: feedback
...
    enable_duration_autocalibration: true
```

## Checklist:
  - [X ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [X ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
