### PR TITLE
[globals] Improve handling of oversized string values

### DIFF
--- a/esphome/components/globals/globals_component.h
+++ b/esphome/components/globals/globals_component.h
@@ -98,22 +98,24 @@ template<typename T, uint8_t SZ> class RestoringGlobalStringComponent : public C
 
  protected:
   void store_value_() {
-    int diff = this->value_.compare(this->prev_value_);
+    const int diff = this->value_.compare(this->prev_value_);
     if (diff != 0) {
-      // Make it into a length prefixed thing
-      unsigned char temp[SZ];
+      const uint8_t size = static_cast<uint8_t>(this->value_.size());
 
       // If string is bigger than the allocation, do not save it.
-      // We don't need to waste ram setting prev_value either.
-      int size = this->value_.size();
-      // Less than, not less than or equal, SZ includes the length byte.
-      if (size < SZ) {
-        memcpy(temp + 1, this->value_.c_str(), size);
-        // SZ should be pre checked at the schema level, it can't go past the char range.
-        temp[0] = ((unsigned char) size);
-        this->rtc_.save(&temp);
-        this->prev_value_.assign(this->value_);
+      if (size >= SZ) {
+        ESP_LOGW("globals", "Skipped saving oversized string (%d >= %d)", size, SZ);
+        this->prev_value_.assign(this->value_);  // Prevent repeated attempts
+        return;
       }
+
+      // Make it into a length prefixed thing
+      unsigned char temp[SZ];
+      memcpy(temp + 1, this->value_.c_str(), size);
+      // SZ should be pre checked at the schema level, it can't go past the char range.
+      temp[0] = static_cast<unsigned char>(size);
+      this->rtc_.save(&temp);
+      this->prev_value_.assign(this->value_);
     }
   }
 


### PR DESCRIPTION
# What does this implement/fix?

This improves the behavior of `RestoringGlobalStringComponent` when handling oversized string values:

- Skips saving the value if its length exceeds the allocated RTC buffer (`SZ`), as intended.
- Logs a warning when an oversized value is skipped to improve observability and ease debugging.
- Prevents repeated attempts to store the same oversized value by updating `prev_value_`, avoiding unnecessary processing during each loop cycle.

These changes enhance the runtime stability of the component, especially in scenarios where input values might grow unexpectedly due to dynamic sources.

No change in behavior for valid-sized strings.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [ ] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`: N/A

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
