### PR TITLE
Ethernet add duplex and link speed option

### DIFF
--- a/esphome/components/ethernet/__init__.py
+++ b/esphome/components/ethernet/__init__.py
@@ -27,6 +27,7 @@ from esphome.const import (
     CONF_PAGE_ID,
     CONF_POLLING_INTERVAL,
     CONF_RESET_PIN,
+    CONF_SPEED,
     CONF_SPI,
     CONF_STATIC_IP,
     CONF_SUBNET,
@@ -45,6 +46,7 @@ AUTO_LOAD = ["network"]
 LOGGER = logging.getLogger(__name__)
 
 ethernet_ns = cg.esphome_ns.namespace("ethernet")
+
 PHYRegister = ethernet_ns.struct("PHYRegister")
 CONF_PHY_ADDR = "phy_addr"
 CONF_MDC_PIN = "mdc_pin"
@@ -90,6 +92,19 @@ CLK_MODES = {
         emac_rmii_clock_mode_t.EMAC_CLK_OUT,
         emac_rmii_clock_gpio_t.EMAC_CLK_OUT_180_GPIO,
     ),
+}
+
+eth_speed_t = cg.global_ns.enum("eth_speed_t")
+SPEED_MODES = {
+    "SPEED_10M": eth_speed_t.ETH_SPEED_10M,
+    "SPEED_100M": eth_speed_t.ETH_SPEED_100M,
+}
+
+CONF_DUPLEX = "duplex"
+eth_duplex_t = cg.global_ns.enum("eth_duplex_t")
+DUPLEX_MODES = {
+    "DUPLEX_HALF": eth_duplex_t.ETH_DUPLEX_HALF,
+    "DUPLEX_FULL": eth_duplex_t.ETH_DUPLEX_FULL,
 }
 
 
@@ -166,6 +181,8 @@ BASE_SCHEMA = cv.Schema(
             "This option has been removed. Please use the [disabled] option under the "
             "new mdns component instead."
         ),
+        cv.Optional(CONF_SPEED): cv.enum(SPEED_MODES, upper=True, space="_"),
+        cv.Optional(CONF_DUPLEX): cv.enum(DUPLEX_MODES, upper=True, space="_"),
     }
 ).extend(cv.COMPONENT_SCHEMA)
 
@@ -317,6 +334,12 @@ async def to_code(config):
 
     cg.add(var.set_type(ETHERNET_TYPES[config[CONF_TYPE]]))
     cg.add(var.set_use_address(config[CONF_USE_ADDRESS]))
+
+    if link_speed := config.get(CONF_SPEED):
+        cg.add(var.set_link_speed(link_speed))
+
+    if duplex_mode := config.get(CONF_DUPLEX):
+        cg.add(var.set_duplex_mode(duplex_mode))
 
     if CONF_MANUAL_IP in config:
         cg.add(var.set_manual_ip(manual_ip(config[CONF_MANUAL_IP])))

--- a/esphome/components/ethernet/ethernet_component.cpp
+++ b/esphome/components/ethernet/ethernet_component.cpp
@@ -234,6 +234,22 @@ void EthernetComponent::setup() {
   ESPHL_ERROR_CHECK(err, "GOT IPv6 event handler register error");
 #endif /* USE_NETWORK_IPV6 */
 
+  if (this->duplex_mode_.has_value() || this->link_speed_.has_value()) {
+    bool auto_nego_en = false;
+    err = esp_eth_ioctl(this->eth_handle_, ETH_CMD_S_AUTONEGO, &auto_nego_en);
+    ESPHL_ERROR_CHECK(err, "ETH_CMD_S_AUTONEGO error");
+
+    if (this->duplex_mode_.has_value()) {
+      esp_eth_ioctl(this->eth_handle_, ETH_CMD_S_DUPLEX_MODE, &this->duplex_mode_);
+      ESPHL_ERROR_CHECK(err, "ETH_CMD_S_DUPLEX_MODE error");
+    }
+
+    if (this->link_speed_.has_value()) {
+      esp_eth_ioctl(this->eth_handle_, ETH_CMD_S_SPEED, &this->link_speed_);
+      ESPHL_ERROR_CHECK(err, "ETH_CMD_S_SPEED error");
+    }
+  }
+
   /* start Ethernet driver state machine */
   err = esp_eth_start(this->eth_handle_);
   ESPHL_ERROR_CHECK(err, "ETH start error");
@@ -592,6 +608,8 @@ eth_duplex_t EthernetComponent::get_duplex_mode() {
   return duplex_mode;
 }
 
+void EthernetComponent::set_duplex_mode(eth_duplex_t duplex_mode) { this->duplex_mode_ = duplex_mode; }
+
 eth_speed_t EthernetComponent::get_link_speed() {
   esp_err_t err;
   eth_speed_t speed;
@@ -599,6 +617,8 @@ eth_speed_t EthernetComponent::get_link_speed() {
   ESPHL_ERROR_CHECK_RET(err, "ETH_CMD_G_SPEED error", ETH_SPEED_10M);
   return speed;
 }
+
+void EthernetComponent::set_link_speed(eth_speed_t speed) { this->link_speed_ = speed; }
 
 bool EthernetComponent::powerdown() {
   ESP_LOGI(TAG, "Powering down ethernet PHY");

--- a/esphome/components/ethernet/ethernet_component.h
+++ b/esphome/components/ethernet/ethernet_component.h
@@ -88,7 +88,9 @@ class EthernetComponent : public Component {
   void get_eth_mac_address_raw(uint8_t *mac);
   std::string get_eth_mac_address_pretty();
   eth_duplex_t get_duplex_mode();
+  void set_duplex_mode(eth_duplex_t duplex_mode);
   eth_speed_t get_link_speed();
+  void set_link_speed(eth_speed_t speed);
   bool powerdown();
 
  protected:
@@ -129,6 +131,8 @@ class EthernetComponent : public Component {
 #endif
   EthernetType type_{ETHERNET_TYPE_UNKNOWN};
   optional<ManualIP> manual_ip_{};
+  optional<eth_duplex_t> duplex_mode_{};
+  optional<eth_speed_t> link_speed_{};
 
   bool started_{false};
   bool connected_{false};


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/issues/issues/5100

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#4973

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
ethernet:
  type: RTL8201
  mdc_pin: 23
  mdio_pin: 18
  clk_mode: GPIO0_IN
  phy_addr: 0
  speed: SPEED_10M
  duplex: DUPLEX_HALF
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
