### PR TITLE
[globals] Prevent redundant oversized string checks in loop

### DIFF
--- a/esphome/components/globals/globals_component.h
+++ b/esphome/components/globals/globals_component.h
@@ -112,7 +112,11 @@ template<typename T, uint8_t SZ> class RestoringGlobalStringComponent : public C
         temp[0] = ((unsigned char) size);
         this->rtc_.save(&temp);
       }
-      this->prev_value_.assign(this->value_);  // To avoid this routine repeating on every loop
+      // Always update prev_value_ to match current value, even for oversized strings.
+      // This prevents redundant size checks on every loop iteration when a string 
+      // remains oversized. Without this, the diff != 0 check would pass repeatedly
+      // for the same oversized string, wasting CPU cycles on size comparisons.
+      this->prev_value_.assign(this->value_);
     }
   }
 

--- a/esphome/components/globals/globals_component.h
+++ b/esphome/components/globals/globals_component.h
@@ -104,7 +104,6 @@ template<typename T, uint8_t SZ> class RestoringGlobalStringComponent : public C
       unsigned char temp[SZ];
 
       // If string is bigger than the allocation, do not save it.
-      // We don't need to waste ram setting prev_value either.
       int size = this->value_.size();
       // Less than, not less than or equal, SZ includes the length byte.
       if (size < SZ) {
@@ -112,8 +111,8 @@ template<typename T, uint8_t SZ> class RestoringGlobalStringComponent : public C
         // SZ should be pre checked at the schema level, it can't go past the char range.
         temp[0] = ((unsigned char) size);
         this->rtc_.save(&temp);
-        this->prev_value_.assign(this->value_);
       }
+      this->prev_value_.assign(this->value_);  // To avoid this routine repeating on every loop
     }
   }
 

--- a/esphome/components/globals/globals_component.h
+++ b/esphome/components/globals/globals_component.h
@@ -39,7 +39,7 @@ template<typename T> class RestoringGlobalsComponent : public Component {
   void setup() override {
     this->rtc_ = global_preferences->make_preference<T>(1944399030U ^ this->name_hash_);
     this->rtc_.load(&this->value_);
-    memcpy(&this->prev_value_, &this->value_, sizeof(T));
+    memcpy(&this->last_checked_value_, &this->value_, sizeof(T));
   }
 
   float get_setup_priority() const override { return setup_priority::HARDWARE; }
@@ -52,15 +52,15 @@ template<typename T> class RestoringGlobalsComponent : public Component {
 
  protected:
   void store_value_() {
-    int diff = memcmp(&this->value_, &this->prev_value_, sizeof(T));
+    int diff = memcmp(&this->value_, &this->last_checked_value_, sizeof(T));
     if (diff != 0) {
       this->rtc_.save(&this->value_);
-      memcpy(&this->prev_value_, &this->value_, sizeof(T));
+      memcpy(&this->last_checked_value_, &this->value_, sizeof(T));
     }
   }
 
   T value_{};
-  T prev_value_{};
+  T last_checked_value_{};
   uint32_t name_hash_{};
   ESPPreferenceObject rtc_;
 };
@@ -85,7 +85,7 @@ template<typename T, uint8_t SZ> class RestoringGlobalStringComponent : public C
     if (hasdata) {
       this->value_.assign(temp + 1, temp[0]);
     }
-    this->prev_value_.assign(this->value_);
+    this->last_checked_value_.assign(this->value_);
   }
 
   float get_setup_priority() const override { return setup_priority::HARDWARE; }
@@ -98,7 +98,7 @@ template<typename T, uint8_t SZ> class RestoringGlobalStringComponent : public C
 
  protected:
   void store_value_() {
-    int diff = this->value_.compare(this->prev_value_);
+    int diff = this->value_.compare(this->last_checked_value_);
     if (diff != 0) {
       // Make it into a length prefixed thing
       unsigned char temp[SZ];
@@ -112,16 +112,16 @@ template<typename T, uint8_t SZ> class RestoringGlobalStringComponent : public C
         temp[0] = ((unsigned char) size);
         this->rtc_.save(&temp);
       }
-      // Always update prev_value_ to match current value, even for oversized strings.
-      // This prevents redundant size checks on every loop iteration when a string 
-      // remains oversized. Without this, the diff != 0 check would pass repeatedly
-      // for the same oversized string, wasting CPU cycles on size comparisons.
-      this->prev_value_.assign(this->value_);
+      // Always update last_checked_value_ to match current value, even for oversized strings.
+      // This prevents redundant size checks on every loop iteration when a string remains oversized.
+      // Without this, the diff != 0 check would pass repeatedly for the same oversized string,
+      // wasting CPU cycles on size comparisons.
+      this->last_checked_value_.assign(this->value_);
     }
   }
 
   T value_{};
-  T prev_value_{};
+  T last_checked_value_{};
   uint32_t name_hash_{};
   ESPPreferenceObject rtc_;
 };


### PR DESCRIPTION
# What does this implement/fix?

Optimizes the performance of `RestoringGlobalStringComponent` by preventing repeated oversized string checks on every loop cycle.

### Changes made:
- Added `last_checked_value_` assignment when string is too large to store
- Prevents the component from repeatedly checking if the same oversized string can be saved
- Added explanatory comment about avoiding routine repetition
- Renamed `_prev_value` to `last_checked_value_` due to the change in semantics

### Why this change?
Previously, when a string exceeded the maximum storage size (`SZ`), the component would:
1. Detect the string is oversized (correct behavior)
2. Skip saving the string (correct behavior)
3. Leave `_prev_value` unchanged
4. **Re-check the same oversized string on every subsequent loop cycle** (inefficient)

Now it updates `last_checked_value_` to match the current value, so the size check only happens once when the string first becomes oversized.

### Impact:
- **Performance**: Reduces CPU cycles spent on repeated size comparisons for oversized strings
- **Trade-off**: Uses slightly more RAM to store the longer `last_checked_value_` string
- **Behavior**: No functional changes - oversized strings still aren't saved (as intended)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- It may help with an issue reported here (another repo): https://github.com/Blackymas/NSPanel_HA_Blueprint/issues/2543#issuecomment-2927608439

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [ ] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`: N/A

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
