### PR TITLE
[nextion] Use safe restart to properly handle globals and restart logging

### DIFF
--- a/esphome/components/nextion/nextion_upload_arduino.cpp
+++ b/esphome/components/nextion/nextion_upload_arduino.cpp
@@ -353,7 +353,7 @@ bool Nextion::upload_end_(bool successful) {
   if (successful) {
     ESP_LOGD(TAG, "Restarting ESPHome");
     delay(1500);  // NOLINT
-    arch_restart();
+    App.safe_reboot();
   } else {
     ESP_LOGE(TAG, "Nextion TFT upload failed");
   }

--- a/esphome/components/nextion/nextion_upload_idf.cpp
+++ b/esphome/components/nextion/nextion_upload_idf.cpp
@@ -353,7 +353,7 @@ bool Nextion::upload_end_(bool successful) {
   if (successful) {
     ESP_LOGD(TAG, "Restarting ESPHome");
     delay(1500);  // NOLINT
-    arch_restart();
+    App.safe_reboot();
   } else {
     ESP_LOGE(TAG, "Nextion TFT upload failed");
   }


### PR DESCRIPTION
# What does this implement/fix?

Replaces direct `arch_restart()` call with `app_safe_reboot()` to ensure proper handling of globals saving to flash and restart reason logging during Nextion TFT upload completion.

### Additional information

- Changes from `arch_restart()` to `app_safe_reboot()` after TFT upload
- Ensures globals are properly saved to flash before restart
- Allows ESPHome to register restart reason as DEBUG instead of unknown/power-on
- Improves system state consistency across restart cycles

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`: N/A

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
