### PR TITLE
[lvgl] Fix templated argument to ``lvgl.is_idle``

### DIFF
--- a/esphome/components/lvgl/automation.py
+++ b/esphome/components/lvgl/automation.py
@@ -21,7 +21,7 @@ from .defines import (
     literal,
     static_cast,
 )
-from .lv_validation import lv_bool, lv_color, lv_image, opacity
+from .lv_validation import lv_bool, lv_color, lv_image, lv_milliseconds, opacity
 from .lvcode import (
     LVGL_COMP_ARG,
     UPDATE_EVENT,
@@ -129,14 +129,14 @@ async def lvgl_is_paused(config, condition_id, template_arg, args):
     LVGL_SCHEMA.extend(
         {
             cv.Required(CONF_TIMEOUT): cv.templatable(
-                cv.positive_time_period_milliseconds
+                lv_milliseconds,
             )
         }
     ),
 )
 async def lvgl_is_idle(config, condition_id, template_arg, args):
     lvgl = config[CONF_LVGL_ID]
-    timeout = await cg.templatable(config[CONF_TIMEOUT], [], cg.uint32)
+    timeout = await lv_milliseconds.process(config[CONF_TIMEOUT])
     async with LambdaContext(LVGL_COMP_ARG, return_type=cg.bool_) as context:
         lv_add(ReturnStatement(lvgl_comp.is_idle(timeout)))
     var = cg.new_Pvariable(

--- a/tests/components/lvgl/lvgl-package.yaml
+++ b/tests/components/lvgl/lvgl-package.yaml
@@ -170,6 +170,12 @@ lvgl:
               lvgl.page.is_showing: page1
             then:
               logger.log: "Yes, page1 showing"
+        - if:
+            condition:
+              lvgl.is_idle:
+                timeout: !lambda return 5000;
+            then:
+              logger.log: LVGL is idle
       on_unload:
         - logger.log: page unloaded
         - lvgl.widget.focus: mark


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Templated arguments to `timeout:` in `lvgl.is_idle` were not being evaluated.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://discord.com/channels/429907082951524364/1380317498997477436

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [x] host

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
        - if:
            condition:
              lvgl.is_idle:
                timeout: !lambda return 5000;
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
