### PR TITLE
Change RP2040 PIO SK6812 timings

### DIFF
--- a/esphome/components/rp2040_pio_led_strip/light.py
+++ b/esphome/components/rp2040_pio_led_strip/light.py
@@ -173,7 +173,7 @@ RGB_ORDERS = {
 CHIPSET_TIMINGS = {
     "WS2812": LEDStripTimings(20, 40, 46, 34),
     "WS2812B": LEDStripTimings(23, 49, 46, 26),
-    "SK6812": LEDStripTimings(17, 52, 34, 34),
+    "SK6812": LEDStripTimings(20, 54, 38, 38),
     "SM16703": LEDStripTimings(17, 52, 52, 17),
 }
 


### PR DESCRIPTION
Updates the LEDStripTimings() parameters to working timings for the SK6812 using RP2040 PIO controller

# What does this implement/fix?

SK6812 led strips on RP2040 PIO do not work with the current timings of (17, 52, 34, 34). The timings are changed to working timings of (20, 54, 38, 38).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/issues/issues/5991

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [x] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
light:
  - platform: rp2040_pio_led_strip
    name: sk6812
    id: sk6812
    pin: GPIO0
    num_leds: 8
    pio: 0
    rgb_order: GRB
    is_rgbw: true
    chipset: SK6812

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
