### PR TITLE
Reduce ESP_LOGCONFIG calls

### DIFF
--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -134,6 +134,7 @@ def get_port_type(port):
 
 
 def run_miniterm(config, port, args):
+    from aioesphomeapi import LogParser
     import serial
 
     from esphome import platformio_api
@@ -158,6 +159,7 @@ def run_miniterm(config, port, args):
         ser.dtr = False
         ser.rts = False
 
+    parser = LogParser()
     tries = 0
     while tries < 5:
         try:
@@ -174,8 +176,7 @@ def run_miniterm(config, port, args):
                         .decode("utf8", "backslashreplace")
                     )
                     time_str = datetime.now().time().strftime("[%H:%M:%S]")
-                    message = time_str + line
-                    safe_print(message)
+                    safe_print(parser.parse_line(line, time_str))
 
                     backtrace_state = platformio_api.process_stacktrace(
                         config, line, backtrace_state=backtrace_state

--- a/esphome/components/absolute_humidity/absolute_humidity.cpp
+++ b/esphome/components/absolute_humidity/absolute_humidity.cpp
@@ -40,9 +40,8 @@ void AbsoluteHumidityComponent::dump_config() {
       break;
   }
 
-  ESP_LOGCONFIG(TAG, "Sources");
-  ESP_LOGCONFIG(TAG, "  Temperature: '%s'", this->temperature_sensor_->get_name().c_str());
-  ESP_LOGCONFIG(TAG, "  Relative Humidity: '%s'", this->humidity_sensor_->get_name().c_str());
+  ESP_LOGCONFIG(TAG, "Sources\n  Temperature: '%s'\n  Relative Humidity: '%s'",
+                this->temperature_sensor_->get_name().c_str(), this->humidity_sensor_->get_name().c_str());
 }
 
 float AbsoluteHumidityComponent::get_setup_priority() const { return setup_priority::DATA; }

--- a/esphome/components/absolute_humidity/absolute_humidity.cpp
+++ b/esphome/components/absolute_humidity/absolute_humidity.cpp
@@ -40,7 +40,10 @@ void AbsoluteHumidityComponent::dump_config() {
       break;
   }
 
-  ESP_LOGCONFIG(TAG, "Sources\n  Temperature: '%s'\n  Relative Humidity: '%s'",
+  ESP_LOGCONFIG(TAG,
+                "Sources\n"
+                "  Temperature: '%s'\n"
+                "  Relative Humidity: '%s'",
                 this->temperature_sensor_->get_name().c_str(), this->humidity_sensor_->get_name().c_str());
 }
 

--- a/esphome/components/ac_dimmer/ac_dimmer.cpp
+++ b/esphome/components/ac_dimmer/ac_dimmer.cpp
@@ -214,8 +214,10 @@ void AcDimmer::dump_config() {
   ESP_LOGCONFIG(TAG, "AcDimmer:");
   LOG_PIN("  Output Pin: ", this->gate_pin_);
   LOG_PIN("  Zero-Cross Pin: ", this->zero_cross_pin_);
-  ESP_LOGCONFIG(TAG, "   Min Power: %.1f%%\n   Init with half cycle: %s", this->store_.min_power / 10.0f,
-                YESNO(this->init_with_half_cycle_));
+  ESP_LOGCONFIG(TAG,
+                "   Min Power: %.1f%%\n"
+                "   Init with half cycle: %s",
+                this->store_.min_power / 10.0f, YESNO(this->init_with_half_cycle_));
   if (method_ == DIM_METHOD_LEADING_PULSE) {
     ESP_LOGCONFIG(TAG, "   Method: leading pulse");
   } else if (method_ == DIM_METHOD_LEADING) {

--- a/esphome/components/ac_dimmer/ac_dimmer.cpp
+++ b/esphome/components/ac_dimmer/ac_dimmer.cpp
@@ -214,8 +214,8 @@ void AcDimmer::dump_config() {
   ESP_LOGCONFIG(TAG, "AcDimmer:");
   LOG_PIN("  Output Pin: ", this->gate_pin_);
   LOG_PIN("  Zero-Cross Pin: ", this->zero_cross_pin_);
-  ESP_LOGCONFIG(TAG, "   Min Power: %.1f%%", this->store_.min_power / 10.0f);
-  ESP_LOGCONFIG(TAG, "   Init with half cycle: %s", YESNO(this->init_with_half_cycle_));
+  ESP_LOGCONFIG(TAG, "   Min Power: %.1f%%\n   Init with half cycle: %s", this->store_.min_power / 10.0f,
+                YESNO(this->init_with_half_cycle_));
   if (method_ == DIM_METHOD_LEADING_PULSE) {
     ESP_LOGCONFIG(TAG, "   Method: leading pulse");
   } else if (method_ == DIM_METHOD_LEADING) {

--- a/esphome/components/adc/adc_sensor_esp32.cpp
+++ b/esphome/components/adc/adc_sensor_esp32.cpp
@@ -77,8 +77,8 @@ void ADCSensor::dump_config() {
         break;
     }
   }
-  ESP_LOGCONFIG(TAG, "  Samples: %i", this->sample_count_);
-  ESP_LOGCONFIG(TAG, "  Sampling mode: %s", LOG_STR_ARG(sampling_mode_to_str(this->sampling_mode_)));
+  ESP_LOGCONFIG(TAG, "  Samples: %i\n  Sampling mode: %s", this->sample_count_,
+                LOG_STR_ARG(sampling_mode_to_str(this->sampling_mode_)));
   LOG_UPDATE_INTERVAL(this);
 }
 

--- a/esphome/components/adc/adc_sensor_esp32.cpp
+++ b/esphome/components/adc/adc_sensor_esp32.cpp
@@ -77,8 +77,10 @@ void ADCSensor::dump_config() {
         break;
     }
   }
-  ESP_LOGCONFIG(TAG, "  Samples: %i\n  Sampling mode: %s", this->sample_count_,
-                LOG_STR_ARG(sampling_mode_to_str(this->sampling_mode_)));
+  ESP_LOGCONFIG(TAG,
+                "  Samples: %i\n"
+                "  Sampling mode: %s",
+                this->sample_count_, LOG_STR_ARG(sampling_mode_to_str(this->sampling_mode_)));
   LOG_UPDATE_INTERVAL(this);
 }
 

--- a/esphome/components/adc/adc_sensor_esp8266.cpp
+++ b/esphome/components/adc/adc_sensor_esp8266.cpp
@@ -30,8 +30,10 @@ void ADCSensor::dump_config() {
 #else
   LOG_PIN("  Pin: ", this->pin_);
 #endif  // USE_ADC_SENSOR_VCC
-  ESP_LOGCONFIG(TAG, "  Samples: %i\n  Sampling mode: %s", this->sample_count_,
-                LOG_STR_ARG(sampling_mode_to_str(this->sampling_mode_)));
+  ESP_LOGCONFIG(TAG,
+                "  Samples: %i\n"
+                "  Sampling mode: %s",
+                this->sample_count_, LOG_STR_ARG(sampling_mode_to_str(this->sampling_mode_)));
   LOG_UPDATE_INTERVAL(this);
 }
 

--- a/esphome/components/adc/adc_sensor_esp8266.cpp
+++ b/esphome/components/adc/adc_sensor_esp8266.cpp
@@ -30,8 +30,8 @@ void ADCSensor::dump_config() {
 #else
   LOG_PIN("  Pin: ", this->pin_);
 #endif  // USE_ADC_SENSOR_VCC
-  ESP_LOGCONFIG(TAG, "  Samples: %i", this->sample_count_);
-  ESP_LOGCONFIG(TAG, "  Sampling mode: %s", LOG_STR_ARG(sampling_mode_to_str(this->sampling_mode_)));
+  ESP_LOGCONFIG(TAG, "  Samples: %i\n  Sampling mode: %s", this->sample_count_,
+                LOG_STR_ARG(sampling_mode_to_str(this->sampling_mode_)));
   LOG_UPDATE_INTERVAL(this);
 }
 

--- a/esphome/components/adc/adc_sensor_libretiny.cpp
+++ b/esphome/components/adc/adc_sensor_libretiny.cpp
@@ -22,8 +22,8 @@ void ADCSensor::dump_config() {
 #else   // USE_ADC_SENSOR_VCC
   LOG_PIN("  Pin: ", this->pin_);
 #endif  // USE_ADC_SENSOR_VCC
-  ESP_LOGCONFIG(TAG, "  Samples: %i", this->sample_count_);
-  ESP_LOGCONFIG(TAG, "  Sampling mode: %s", LOG_STR_ARG(sampling_mode_to_str(this->sampling_mode_)));
+  ESP_LOGCONFIG(TAG, "  Samples: %i\n  Sampling mode: %s", this->sample_count_,
+                LOG_STR_ARG(sampling_mode_to_str(this->sampling_mode_)));
   LOG_UPDATE_INTERVAL(this);
 }
 

--- a/esphome/components/adc/adc_sensor_libretiny.cpp
+++ b/esphome/components/adc/adc_sensor_libretiny.cpp
@@ -22,8 +22,10 @@ void ADCSensor::dump_config() {
 #else   // USE_ADC_SENSOR_VCC
   LOG_PIN("  Pin: ", this->pin_);
 #endif  // USE_ADC_SENSOR_VCC
-  ESP_LOGCONFIG(TAG, "  Samples: %i\n  Sampling mode: %s", this->sample_count_,
-                LOG_STR_ARG(sampling_mode_to_str(this->sampling_mode_)));
+  ESP_LOGCONFIG(TAG,
+                "  Samples: %i\n"
+                "  Sampling mode: %s",
+                this->sample_count_, LOG_STR_ARG(sampling_mode_to_str(this->sampling_mode_)));
   LOG_UPDATE_INTERVAL(this);
 }
 

--- a/esphome/components/adc/adc_sensor_rp2040.cpp
+++ b/esphome/components/adc/adc_sensor_rp2040.cpp
@@ -33,8 +33,8 @@ void ADCSensor::dump_config() {
     LOG_PIN("  Pin: ", this->pin_);
 #endif  // USE_ADC_SENSOR_VCC
   }
-  ESP_LOGCONFIG(TAG, "  Samples: %i", this->sample_count_);
-  ESP_LOGCONFIG(TAG, "  Sampling mode: %s", LOG_STR_ARG(sampling_mode_to_str(this->sampling_mode_)));
+  ESP_LOGCONFIG(TAG, "  Samples: %i\n  Sampling mode: %s", this->sample_count_,
+                LOG_STR_ARG(sampling_mode_to_str(this->sampling_mode_)));
   LOG_UPDATE_INTERVAL(this);
 }
 

--- a/esphome/components/adc/adc_sensor_rp2040.cpp
+++ b/esphome/components/adc/adc_sensor_rp2040.cpp
@@ -33,8 +33,10 @@ void ADCSensor::dump_config() {
     LOG_PIN("  Pin: ", this->pin_);
 #endif  // USE_ADC_SENSOR_VCC
   }
-  ESP_LOGCONFIG(TAG, "  Samples: %i\n  Sampling mode: %s", this->sample_count_,
-                LOG_STR_ARG(sampling_mode_to_str(this->sampling_mode_)));
+  ESP_LOGCONFIG(TAG,
+                "  Samples: %i\n"
+                "  Sampling mode: %s",
+                this->sample_count_, LOG_STR_ARG(sampling_mode_to_str(this->sampling_mode_)));
   LOG_UPDATE_INTERVAL(this);
 }
 

--- a/esphome/components/ade7880/ade7880.cpp
+++ b/esphome/components/ade7880/ade7880.cpp
@@ -177,11 +177,14 @@ void ADE7880::dump_config() {
     LOG_SENSOR("    ", "Power Factor", this->channel_a_->power_factor);
     LOG_SENSOR("    ", "Forward Active Energy", this->channel_a_->forward_active_energy);
     LOG_SENSOR("    ", "Reverse Active Energy", this->channel_a_->reverse_active_energy);
-    ESP_LOGCONFIG(TAG, "    Calibration:");
-    ESP_LOGCONFIG(TAG, "     Current: %" PRId32, this->channel_a_->current_gain_calibration);
-    ESP_LOGCONFIG(TAG, "     Voltage: %" PRId32, this->channel_a_->voltage_gain_calibration);
-    ESP_LOGCONFIG(TAG, "     Power: %" PRId32, this->channel_a_->power_gain_calibration);
-    ESP_LOGCONFIG(TAG, "     Phase Angle: %u", this->channel_a_->phase_angle_calibration);
+    ESP_LOGCONFIG(TAG,
+                  "    Calibration:\n"
+                  "     Current: %" PRId32 "\n"
+                  "     Voltage: %" PRId32 "\n"
+                  "     Power: %" PRId32 "\n"
+                  "     Phase Angle: %u",
+                  this->channel_a_->current_gain_calibration, this->channel_a_->voltage_gain_calibration,
+                  this->channel_a_->power_gain_calibration, this->channel_a_->phase_angle_calibration);
   }
 
   if (this->channel_b_ != nullptr) {
@@ -193,11 +196,14 @@ void ADE7880::dump_config() {
     LOG_SENSOR("    ", "Power Factor", this->channel_b_->power_factor);
     LOG_SENSOR("    ", "Forward Active Energy", this->channel_b_->forward_active_energy);
     LOG_SENSOR("    ", "Reverse Active Energy", this->channel_b_->reverse_active_energy);
-    ESP_LOGCONFIG(TAG, "    Calibration:");
-    ESP_LOGCONFIG(TAG, "     Current: %" PRId32, this->channel_b_->current_gain_calibration);
-    ESP_LOGCONFIG(TAG, "     Voltage: %" PRId32, this->channel_b_->voltage_gain_calibration);
-    ESP_LOGCONFIG(TAG, "     Power: %" PRId32, this->channel_b_->power_gain_calibration);
-    ESP_LOGCONFIG(TAG, "     Phase Angle: %u", this->channel_b_->phase_angle_calibration);
+    ESP_LOGCONFIG(TAG,
+                  "    Calibration:\n"
+                  "     Current: %" PRId32 "\n"
+                  "     Voltage: %" PRId32 "\n"
+                  "     Power: %" PRId32 "\n"
+                  "     Phase Angle: %u",
+                  this->channel_b_->current_gain_calibration, this->channel_b_->voltage_gain_calibration,
+                  this->channel_b_->power_gain_calibration, this->channel_b_->phase_angle_calibration);
   }
 
   if (this->channel_c_ != nullptr) {
@@ -209,18 +215,23 @@ void ADE7880::dump_config() {
     LOG_SENSOR("    ", "Power Factor", this->channel_c_->power_factor);
     LOG_SENSOR("    ", "Forward Active Energy", this->channel_c_->forward_active_energy);
     LOG_SENSOR("    ", "Reverse Active Energy", this->channel_c_->reverse_active_energy);
-    ESP_LOGCONFIG(TAG, "    Calibration:");
-    ESP_LOGCONFIG(TAG, "     Current: %" PRId32, this->channel_c_->current_gain_calibration);
-    ESP_LOGCONFIG(TAG, "     Voltage: %" PRId32, this->channel_c_->voltage_gain_calibration);
-    ESP_LOGCONFIG(TAG, "     Power: %" PRId32, this->channel_c_->power_gain_calibration);
-    ESP_LOGCONFIG(TAG, "     Phase Angle: %u", this->channel_c_->phase_angle_calibration);
+    ESP_LOGCONFIG(TAG,
+                  "    Calibration:\n"
+                  "     Current: %" PRId32 "\n"
+                  "     Voltage: %" PRId32 "\n"
+                  "     Power: %" PRId32 "\n"
+                  "     Phase Angle: %u",
+                  this->channel_c_->current_gain_calibration, this->channel_c_->voltage_gain_calibration,
+                  this->channel_c_->power_gain_calibration, this->channel_c_->phase_angle_calibration);
   }
 
   if (this->channel_n_ != nullptr) {
     ESP_LOGCONFIG(TAG, "  Neutral:");
     LOG_SENSOR("    ", "Current", this->channel_n_->current);
-    ESP_LOGCONFIG(TAG, "    Calibration:");
-    ESP_LOGCONFIG(TAG, "     Current: %" PRId32, this->channel_n_->current_gain_calibration);
+    ESP_LOGCONFIG(TAG,
+                  "    Calibration:\n"
+                  "     Current: %" PRId32,
+                  this->channel_n_->current_gain_calibration);
   }
 
   LOG_I2C_DEVICE(this);

--- a/esphome/components/ade7953_base/ade7953_base.cpp
+++ b/esphome/components/ade7953_base/ade7953_base.cpp
@@ -59,8 +59,15 @@ void ADE7953::dump_config() {
   LOG_SENSOR("  ", "Rective Power A Sensor", this->reactive_power_a_sensor_);
   LOG_SENSOR("  ", "Reactive Power B Sensor", this->reactive_power_b_sensor_);
   ESP_LOGCONFIG(TAG,
-                "  USE_ACC_ENERGY_REGS: %d\n  PGA_V_8: 0x%X\n  PGA_IA_8: 0x%X\n  PGA_IB_8: 0x%X\n  VGAIN_32: 0x%08jX\n"
-                "  AIGAIN_32: 0x%08jX\n  BIGAIN_32: 0x%08jX\n  AWGAIN_32: 0x%08jX\n  BWGAIN_32: 0x%08jX",
+                "  USE_ACC_ENERGY_REGS: %d\n"
+                "  PGA_V_8: 0x%X\n"
+                "  PGA_IA_8: 0x%X\n"
+                "  PGA_IB_8: 0x%X\n"
+                "  VGAIN_32: 0x%08jX\n"
+                "  AIGAIN_32: 0x%08jX\n"
+                "  BIGAIN_32: 0x%08jX\n"
+                "  AWGAIN_32: 0x%08jX\n"
+                "  BWGAIN_32: 0x%08jX",
                 this->use_acc_energy_regs_, pga_v_, pga_ia_, pga_ib_, (uintmax_t) vgain_, (uintmax_t) aigain_,
                 (uintmax_t) bigain_, (uintmax_t) awgain_, (uintmax_t) bwgain_);
 }

--- a/esphome/components/ade7953_base/ade7953_base.cpp
+++ b/esphome/components/ade7953_base/ade7953_base.cpp
@@ -58,15 +58,11 @@ void ADE7953::dump_config() {
   LOG_SENSOR("  ", "Active Power B Sensor", this->active_power_b_sensor_);
   LOG_SENSOR("  ", "Rective Power A Sensor", this->reactive_power_a_sensor_);
   LOG_SENSOR("  ", "Reactive Power B Sensor", this->reactive_power_b_sensor_);
-  ESP_LOGCONFIG(TAG, "  USE_ACC_ENERGY_REGS: %d", this->use_acc_energy_regs_);
-  ESP_LOGCONFIG(TAG, "  PGA_V_8: 0x%X", pga_v_);
-  ESP_LOGCONFIG(TAG, "  PGA_IA_8: 0x%X", pga_ia_);
-  ESP_LOGCONFIG(TAG, "  PGA_IB_8: 0x%X", pga_ib_);
-  ESP_LOGCONFIG(TAG, "  VGAIN_32: 0x%08jX", (uintmax_t) vgain_);
-  ESP_LOGCONFIG(TAG, "  AIGAIN_32: 0x%08jX", (uintmax_t) aigain_);
-  ESP_LOGCONFIG(TAG, "  BIGAIN_32: 0x%08jX", (uintmax_t) bigain_);
-  ESP_LOGCONFIG(TAG, "  AWGAIN_32: 0x%08jX", (uintmax_t) awgain_);
-  ESP_LOGCONFIG(TAG, "  BWGAIN_32: 0x%08jX", (uintmax_t) bwgain_);
+  ESP_LOGCONFIG(TAG,
+                "  USE_ACC_ENERGY_REGS: %d\n  PGA_V_8: 0x%X\n  PGA_IA_8: 0x%X\n  PGA_IB_8: 0x%X\n  VGAIN_32: 0x%08jX\n"
+                "  AIGAIN_32: 0x%08jX\n  BIGAIN_32: 0x%08jX\n  AWGAIN_32: 0x%08jX\n  BWGAIN_32: 0x%08jX",
+                this->use_acc_energy_regs_, pga_v_, pga_ia_, pga_ib_, (uintmax_t) vgain_, (uintmax_t) aigain_,
+                (uintmax_t) bigain_, (uintmax_t) awgain_, (uintmax_t) bwgain_);
 }
 
 #define ADE_PUBLISH_(name, val, factor) \

--- a/esphome/components/am43/cover/am43_cover.cpp
+++ b/esphome/components/am43/cover/am43_cover.cpp
@@ -12,8 +12,7 @@ using namespace esphome::cover;
 
 void Am43Component::dump_config() {
   LOG_COVER("", "AM43 Cover", this);
-  ESP_LOGCONFIG(TAG, "  Device Pin: %d", this->pin_);
-  ESP_LOGCONFIG(TAG, "  Invert Position: %d", (int) this->invert_position_);
+  ESP_LOGCONFIG(TAG, "  Device Pin: %d\n  Invert Position: %d", this->pin_, (int) this->invert_position_);
 }
 
 void Am43Component::setup() {

--- a/esphome/components/am43/cover/am43_cover.cpp
+++ b/esphome/components/am43/cover/am43_cover.cpp
@@ -12,7 +12,10 @@ using namespace esphome::cover;
 
 void Am43Component::dump_config() {
   LOG_COVER("", "AM43 Cover", this);
-  ESP_LOGCONFIG(TAG, "  Device Pin: %d\n  Invert Position: %d", this->pin_, (int) this->invert_position_);
+  ESP_LOGCONFIG(TAG,
+                "  Device Pin: %d\n"
+                "  Invert Position: %d",
+                this->pin_, (int) this->invert_position_);
 }
 
 void Am43Component::setup() {

--- a/esphome/components/analog_threshold/analog_threshold_binary_sensor.cpp
+++ b/esphome/components/analog_threshold/analog_threshold_binary_sensor.cpp
@@ -34,8 +34,10 @@ void AnalogThresholdBinarySensor::set_sensor(sensor::Sensor *analog_sensor) {
 void AnalogThresholdBinarySensor::dump_config() {
   LOG_BINARY_SENSOR("", "Analog Threshold Binary Sensor", this);
   LOG_SENSOR("  ", "Sensor", this->sensor_);
-  ESP_LOGCONFIG(TAG, "  Upper threshold: %.11f\n  Lower threshold: %.11f", this->upper_threshold_.value(),
-                this->lower_threshold_.value());
+  ESP_LOGCONFIG(TAG,
+                "  Upper threshold: %.11f\n"
+                "  Lower threshold: %.11f",
+                this->upper_threshold_.value(), this->lower_threshold_.value());
 }
 
 }  // namespace analog_threshold

--- a/esphome/components/analog_threshold/analog_threshold_binary_sensor.cpp
+++ b/esphome/components/analog_threshold/analog_threshold_binary_sensor.cpp
@@ -34,8 +34,8 @@ void AnalogThresholdBinarySensor::set_sensor(sensor::Sensor *analog_sensor) {
 void AnalogThresholdBinarySensor::dump_config() {
   LOG_BINARY_SENSOR("", "Analog Threshold Binary Sensor", this);
   LOG_SENSOR("  ", "Sensor", this->sensor_);
-  ESP_LOGCONFIG(TAG, "  Upper threshold: %.11f", this->upper_threshold_.value());
-  ESP_LOGCONFIG(TAG, "  Lower threshold: %.11f", this->lower_threshold_.value());
+  ESP_LOGCONFIG(TAG, "  Upper threshold: %.11f\n  Lower threshold: %.11f", this->upper_threshold_.value(),
+                this->lower_threshold_.value());
 }
 
 }  // namespace analog_threshold

--- a/esphome/components/apds9306/apds9306.cpp
+++ b/esphome/components/apds9306/apds9306.cpp
@@ -108,7 +108,10 @@ void APDS9306::dump_config() {
     }
   }
 
-  ESP_LOGCONFIG(TAG, "  Gain: %u\n  Measurement rate: %u\n  Measurement Resolution/Bit width: %d",
+  ESP_LOGCONFIG(TAG,
+                "  Gain: %u\n"
+                "  Measurement rate: %u\n"
+                "  Measurement Resolution/Bit width: %d",
                 AMBIENT_LIGHT_GAIN_VALUES[this->gain_], MEASUREMENT_RATE_VALUES[this->measurement_rate_],
                 MEASUREMENT_BIT_WIDTH_VALUES[this->bit_width_]);
 

--- a/esphome/components/apds9306/apds9306.cpp
+++ b/esphome/components/apds9306/apds9306.cpp
@@ -108,9 +108,9 @@ void APDS9306::dump_config() {
     }
   }
 
-  ESP_LOGCONFIG(TAG, "  Gain: %u", AMBIENT_LIGHT_GAIN_VALUES[this->gain_]);
-  ESP_LOGCONFIG(TAG, "  Measurement rate: %u", MEASUREMENT_RATE_VALUES[this->measurement_rate_]);
-  ESP_LOGCONFIG(TAG, "  Measurement Resolution/Bit width: %d", MEASUREMENT_BIT_WIDTH_VALUES[this->bit_width_]);
+  ESP_LOGCONFIG(TAG, "  Gain: %u\n  Measurement rate: %u\n  Measurement Resolution/Bit width: %d",
+                AMBIENT_LIGHT_GAIN_VALUES[this->gain_], MEASUREMENT_RATE_VALUES[this->measurement_rate_],
+                MEASUREMENT_BIT_WIDTH_VALUES[this->bit_width_]);
 
   LOG_UPDATE_INTERVAL(this);
 }

--- a/esphome/components/api/api_server.cpp
+++ b/esphome/components/api/api_server.cpp
@@ -169,7 +169,10 @@ void APIServer::loop() {
 }
 
 void APIServer::dump_config() {
-  ESP_LOGCONFIG(TAG, "API Server:\n  Address: %s:%u", network::get_use_address().c_str(), this->port_);
+  ESP_LOGCONFIG(TAG,
+                "API Server:\n"
+                "  Address: %s:%u",
+                network::get_use_address().c_str(), this->port_);
 #ifdef USE_API_NOISE
   ESP_LOGCONFIG(TAG, "  Using noise encryption: %s", YESNO(this->noise_ctx_->has_psk()));
   if (!this->noise_ctx_->has_psk()) {

--- a/esphome/components/api/api_server.cpp
+++ b/esphome/components/api/api_server.cpp
@@ -169,8 +169,7 @@ void APIServer::loop() {
 }
 
 void APIServer::dump_config() {
-  ESP_LOGCONFIG(TAG, "API Server:");
-  ESP_LOGCONFIG(TAG, "  Address: %s:%u", network::get_use_address().c_str(), this->port_);
+  ESP_LOGCONFIG(TAG, "API Server:\n  Address: %s:%u", network::get_use_address().c_str(), this->port_);
 #ifdef USE_API_NOISE
   ESP_LOGCONFIG(TAG, "  Using noise encryption: %s", YESNO(this->noise_ctx_->has_psk()));
   if (!this->noise_ctx_->has_psk()) {

--- a/esphome/components/api/client.py
+++ b/esphome/components/api/client.py
@@ -5,7 +5,7 @@ from datetime import datetime
 import logging
 from typing import TYPE_CHECKING, Any
 
-from aioesphomeapi import APIClient
+from aioesphomeapi import APIClient, parse_log_message
 from aioesphomeapi.log_runner import async_run
 
 from esphome.const import CONF_KEY, CONF_PASSWORD, CONF_PORT, __version__
@@ -48,7 +48,10 @@ async def async_run_logs(config: dict[str, Any], address: str) -> None:
         text = message.decode("utf8", "backslashreplace")
         if dashboard:
             text = text.replace("\033", "\\033")
-        print(f"[{time_.hour:02}:{time_.minute:02}:{time_.second:02}]{text}")
+        for parsed_msg in parse_log_message(
+            text, f"[{time_.hour:02}:{time_.minute:02}:{time_.second:02}]"
+        ):
+            print(parsed_msg)
 
     stop = await async_run(cli, on_log, name=name)
     try:

--- a/esphome/components/as5600/as5600.cpp
+++ b/esphome/components/as5600/as5600.cpp
@@ -95,11 +95,13 @@ void AS5600Component::dump_config() {
     return;
   }
 
-  ESP_LOGCONFIG(TAG, "  Watchdog: %d", this->watchdog_);
-  ESP_LOGCONFIG(TAG, "  Fast Filter: %d", this->fast_filter_);
-  ESP_LOGCONFIG(TAG, "  Slow Filter: %d", this->slow_filter_);
-  ESP_LOGCONFIG(TAG, "  Hysteresis: %d", this->hysteresis_);
-  ESP_LOGCONFIG(TAG, "  Start Position: %d", this->start_position_);
+  ESP_LOGCONFIG(TAG,
+                "  Watchdog: %d\n"
+                "  Fast Filter: %d\n"
+                "  Slow Filter: %d\n"
+                "  Hysteresis: %d\n"
+                "  Start Position: %d",
+                this->watchdog_, this->fast_filter_, this->slow_filter_, this->hysteresis_, this->start_position_);
   if (this->end_mode_ == END_MODE_POSITION) {
     ESP_LOGCONFIG(TAG, "  End Position: %d", this->end_position_);
   } else {

--- a/esphome/components/as7341/as7341.cpp
+++ b/esphome/components/as7341/as7341.cpp
@@ -41,9 +41,11 @@ void AS7341Component::dump_config() {
     ESP_LOGE(TAG, ESP_LOG_MSG_COMM_FAIL);
   }
   LOG_UPDATE_INTERVAL(this);
-  ESP_LOGCONFIG(TAG, "  Gain: %u", get_gain());
-  ESP_LOGCONFIG(TAG, "  ATIME: %u", get_atime());
-  ESP_LOGCONFIG(TAG, "  ASTEP: %u", get_astep());
+  ESP_LOGCONFIG(TAG,
+                "  Gain: %u\n"
+                "  ATIME: %u\n"
+                "  ASTEP: %u",
+                get_gain(), get_atime(), get_astep());
 
   LOG_SENSOR("  ", "F1", this->f1_);
   LOG_SENSOR("  ", "F2", this->f2_);

--- a/esphome/components/at581x/at581x.cpp
+++ b/esphome/components/at581x/at581x.cpp
@@ -75,15 +75,18 @@ void AT581XComponent::setup() { ESP_LOGCONFIG(TAG, "Running setup"); }
 void AT581XComponent::dump_config() { LOG_I2C_DEVICE(this); }
 #define ARRAY_SIZE(X) (sizeof(X) / sizeof((X)[0]))
 bool AT581XComponent::i2c_write_config() {
-  ESP_LOGCONFIG(TAG, "Writing new config for AT581X");
-  ESP_LOGCONFIG(TAG, "Frequency: %dMHz", this->freq_);
-  ESP_LOGCONFIG(TAG, "Sensing distance: %d", this->delta_);
-  ESP_LOGCONFIG(TAG, "Power: %dµA", this->power_);
-  ESP_LOGCONFIG(TAG, "Gain: %d", this->gain_);
-  ESP_LOGCONFIG(TAG, "Trigger base time: %dms", this->trigger_base_time_ms_);
-  ESP_LOGCONFIG(TAG, "Trigger keep time: %dms", this->trigger_keep_time_ms_);
-  ESP_LOGCONFIG(TAG, "Protect time: %dms", this->protect_time_ms_);
-  ESP_LOGCONFIG(TAG, "Self check time: %dms", this->self_check_time_ms_);
+  ESP_LOGCONFIG(TAG,
+                "Writing new config for AT581X\n"
+                "Frequency: %dMHz\n"
+                "Sensing distance: %d\n"
+                "Power: %dµA\n"
+                "Gain: %d\n"
+                "Trigger base time: %dms\n"
+                "Trigger keep time: %dms\n"
+                "Protect time: %dms\n"
+                "Self check time: %dms",
+                this->freq_, this->delta_, this->power_, this->gain_, this->trigger_base_time_ms_,
+                this->trigger_keep_time_ms_, this->protect_time_ms_, this->self_check_time_ms_);
 
   // Set frequency point
   if (!this->i2c_write_reg(FREQ_ADDR, GAIN61_VALUE)) {

--- a/esphome/components/axs15231/touchscreen/axs15231_touchscreen.cpp
+++ b/esphome/components/axs15231/touchscreen/axs15231_touchscreen.cpp
@@ -60,7 +60,10 @@ void AXS15231Touchscreen::dump_config() {
   LOG_I2C_DEVICE(this);
   LOG_PIN("  Interrupt Pin: ", this->interrupt_pin_);
   LOG_PIN("  Reset Pin: ", this->reset_pin_);
-  ESP_LOGCONFIG(TAG, "  Width: %d\n  Height: %d", this->x_raw_max_, this->y_raw_max_);
+  ESP_LOGCONFIG(TAG,
+                "  Width: %d\n"
+                "  Height: %d",
+                this->x_raw_max_, this->y_raw_max_);
 }
 
 }  // namespace axs15231

--- a/esphome/components/axs15231/touchscreen/axs15231_touchscreen.cpp
+++ b/esphome/components/axs15231/touchscreen/axs15231_touchscreen.cpp
@@ -60,8 +60,7 @@ void AXS15231Touchscreen::dump_config() {
   LOG_I2C_DEVICE(this);
   LOG_PIN("  Interrupt Pin: ", this->interrupt_pin_);
   LOG_PIN("  Reset Pin: ", this->reset_pin_);
-  ESP_LOGCONFIG(TAG, "  Width: %d", this->x_raw_max_);
-  ESP_LOGCONFIG(TAG, "  Height: %d", this->y_raw_max_);
+  ESP_LOGCONFIG(TAG, "  Width: %d\n  Height: %d", this->x_raw_max_, this->y_raw_max_);
 }
 
 }  // namespace axs15231

--- a/esphome/components/bang_bang/bang_bang_climate.cpp
+++ b/esphome/components/bang_bang/bang_bang_climate.cpp
@@ -194,11 +194,14 @@ Trigger<> *BangBangClimate::get_heat_trigger() const { return this->heat_trigger
 void BangBangClimate::set_supports_heat(bool supports_heat) { this->supports_heat_ = supports_heat; }
 void BangBangClimate::dump_config() {
   LOG_CLIMATE("", "Bang Bang Climate", this);
-  ESP_LOGCONFIG(TAG, "  Supports HEAT: %s", YESNO(this->supports_heat_));
-  ESP_LOGCONFIG(TAG, "  Supports COOL: %s", YESNO(this->supports_cool_));
-  ESP_LOGCONFIG(TAG, "  Supports AWAY mode: %s", YESNO(this->supports_away_));
-  ESP_LOGCONFIG(TAG, "  Default Target Temperature Low: %.2f°C", this->normal_config_.default_temperature_low);
-  ESP_LOGCONFIG(TAG, "  Default Target Temperature High: %.2f°C", this->normal_config_.default_temperature_high);
+  ESP_LOGCONFIG(TAG,
+                "  Supports HEAT: %s\n"
+                "  Supports COOL: %s\n"
+                "  Supports AWAY mode: %s\n"
+                "  Default Target Temperature Low: %.2f°C\n"
+                "  Default Target Temperature High: %.2f°C",
+                YESNO(this->supports_heat_), YESNO(this->supports_cool_), YESNO(this->supports_away_),
+                this->normal_config_.default_temperature_low, this->normal_config_.default_temperature_high);
 }
 
 BangBangClimateTargetTempConfig::BangBangClimateTargetTempConfig() = default;

--- a/esphome/components/bedjet/bedjet_hub.cpp
+++ b/esphome/components/bedjet/bedjet_hub.cpp
@@ -484,9 +484,11 @@ void BedJetHub::loop() {}
 void BedJetHub::update() { this->dispatch_status_(); }
 
 void BedJetHub::dump_config() {
-  ESP_LOGCONFIG(TAG, "BedJet Hub '%s'", this->get_name().c_str());
-  ESP_LOGCONFIG(TAG, "  ble_client.app_id: %d", this->parent()->app_id);
-  ESP_LOGCONFIG(TAG, "  ble_client.conn_id: %d", this->parent()->get_conn_id());
+  ESP_LOGCONFIG(TAG,
+                "BedJet Hub '%s'\n"
+                "  ble_client.app_id: %d\n"
+                "  ble_client.conn_id: %d",
+                this->get_name().c_str(), this->parent()->app_id, this->parent()->get_conn_id());
   LOG_UPDATE_INTERVAL(this)
   ESP_LOGCONFIG(TAG, "  Child components (%d):", this->children_.size());
   for (auto *child : this->children_) {

--- a/esphome/components/beken_spi_led_strip/led_strip.cpp
+++ b/esphome/components/beken_spi_led_strip/led_strip.cpp
@@ -345,8 +345,7 @@ light::ESPColorView BekenSPILEDStripLightOutput::get_view_internal(int32_t index
 }
 
 void BekenSPILEDStripLightOutput::dump_config() {
-  ESP_LOGCONFIG(TAG, "Beken SPI LED Strip:");
-  ESP_LOGCONFIG(TAG, "  Pin: %u", this->pin_);
+  ESP_LOGCONFIG(TAG, "Beken SPI LED Strip:\n  Pin: %u", this->pin_);
   const char *rgb_order;
   switch (this->rgb_order_) {
     case ORDER_RGB:
@@ -371,9 +370,11 @@ void BekenSPILEDStripLightOutput::dump_config() {
       rgb_order = "UNKNOWN";
       break;
   }
-  ESP_LOGCONFIG(TAG, "  RGB Order: %s", rgb_order);
-  ESP_LOGCONFIG(TAG, "  Max refresh rate: %" PRIu32, *this->max_refresh_rate_);
-  ESP_LOGCONFIG(TAG, "  Number of LEDs: %u", this->num_leds_);
+  ESP_LOGCONFIG(TAG,
+                "  RGB Order: %s\n"
+                "  Max refresh rate: %" PRIu32 "\n"
+                "  Number of LEDs: %u",
+                rgb_order, *this->max_refresh_rate_, this->num_leds_);
 }
 
 float BekenSPILEDStripLightOutput::get_setup_priority() const { return setup_priority::HARDWARE; }

--- a/esphome/components/beken_spi_led_strip/led_strip.cpp
+++ b/esphome/components/beken_spi_led_strip/led_strip.cpp
@@ -345,7 +345,10 @@ light::ESPColorView BekenSPILEDStripLightOutput::get_view_internal(int32_t index
 }
 
 void BekenSPILEDStripLightOutput::dump_config() {
-  ESP_LOGCONFIG(TAG, "Beken SPI LED Strip:\n  Pin: %u", this->pin_);
+  ESP_LOGCONFIG(TAG,
+                "Beken SPI LED Strip:\n"
+                "  Pin: %u",
+                this->pin_);
   const char *rgb_order;
   switch (this->rgb_order_) {
     case ORDER_RGB:

--- a/esphome/components/bl0942/bl0942.cpp
+++ b/esphome/components/bl0942/bl0942.cpp
@@ -196,14 +196,17 @@ void BL0942::received_package_(DataPacket *data) {
 }
 
 void BL0942::dump_config() {  // NOLINT(readability-function-cognitive-complexity)
-  ESP_LOGCONFIG(TAG, "BL0942:");
-  ESP_LOGCONFIG(TAG, "  Reset: %s", TRUEFALSE(this->reset_));
-  ESP_LOGCONFIG(TAG, "  Address: %d", this->address_);
-  ESP_LOGCONFIG(TAG, "  Nominal line frequency: %d Hz", this->line_freq_);
-  ESP_LOGCONFIG(TAG, "  Current reference: %f", this->current_reference_);
-  ESP_LOGCONFIG(TAG, "  Energy reference: %f", this->energy_reference_);
-  ESP_LOGCONFIG(TAG, "  Power reference: %f", this->power_reference_);
-  ESP_LOGCONFIG(TAG, "  Voltage reference: %f", this->voltage_reference_);
+  ESP_LOGCONFIG(TAG,
+                "BL0942:\n"
+                "  Reset: %s\n"
+                "  Address: %d\n"
+                "  Nominal line frequency: %d Hz\n"
+                "  Current reference: %f\n"
+                "  Energy reference: %f\n"
+                "  Power reference: %f\n"
+                "  Voltage reference: %f",
+                TRUEFALSE(this->reset_), this->address_, this->line_freq_, this->current_reference_,
+                this->energy_reference_, this->power_reference_, this->voltage_reference_);
   LOG_SENSOR("", "Voltage", this->voltage_sensor_);
   LOG_SENSOR("", "Current", this->current_sensor_);
   LOG_SENSOR("", "Power", this->power_sensor_);

--- a/esphome/components/ble_client/output/ble_binary_output.cpp
+++ b/esphome/components/ble_client/output/ble_binary_output.cpp
@@ -10,9 +10,12 @@ static const char *const TAG = "ble_binary_output";
 
 void BLEBinaryOutput::dump_config() {
   ESP_LOGCONFIG(TAG, "BLE Binary Output:");
-  ESP_LOGCONFIG(TAG, "  MAC address        : %s", this->parent_->address_str().c_str());
-  ESP_LOGCONFIG(TAG, "  Service UUID       : %s", this->service_uuid_.to_string().c_str());
-  ESP_LOGCONFIG(TAG, "  Characteristic UUID: %s", this->char_uuid_.to_string().c_str());
+  ESP_LOGCONFIG(TAG,
+                "  MAC address        : %s\n"
+                "  Service UUID       : %s\n"
+                "  Characteristic UUID: %s",
+                this->parent_->address_str().c_str(), this->service_uuid_.to_string().c_str(),
+                this->char_uuid_.to_string().c_str());
   LOG_BINARY_OUTPUT(this);
 }
 

--- a/esphome/components/ble_client/sensor/ble_sensor.cpp
+++ b/esphome/components/ble_client/sensor/ble_sensor.cpp
@@ -15,11 +15,14 @@ void BLESensor::loop() {}
 
 void BLESensor::dump_config() {
   LOG_SENSOR("", "BLE Sensor", this);
-  ESP_LOGCONFIG(TAG, "  MAC address        : %s", this->parent()->address_str().c_str());
-  ESP_LOGCONFIG(TAG, "  Service UUID       : %s", this->service_uuid_.to_string().c_str());
-  ESP_LOGCONFIG(TAG, "  Characteristic UUID: %s", this->char_uuid_.to_string().c_str());
-  ESP_LOGCONFIG(TAG, "  Descriptor UUID    : %s", this->descr_uuid_.to_string().c_str());
-  ESP_LOGCONFIG(TAG, "  Notifications      : %s", YESNO(this->notify_));
+  ESP_LOGCONFIG(TAG,
+                "  MAC address        : %s\n"
+                "  Service UUID       : %s\n"
+                "  Characteristic UUID: %s\n"
+                "  Descriptor UUID    : %s\n"
+                "  Notifications      : %s",
+                this->parent()->address_str().c_str(), this->service_uuid_.to_string().c_str(),
+                this->char_uuid_.to_string().c_str(), this->descr_uuid_.to_string().c_str(), YESNO(this->notify_));
   LOG_UPDATE_INTERVAL(this);
 }
 

--- a/esphome/components/ble_client/text_sensor/ble_text_sensor.cpp
+++ b/esphome/components/ble_client/text_sensor/ble_text_sensor.cpp
@@ -18,11 +18,14 @@ void BLETextSensor::loop() {}
 
 void BLETextSensor::dump_config() {
   LOG_TEXT_SENSOR("", "BLE Text Sensor", this);
-  ESP_LOGCONFIG(TAG, "  MAC address        : %s", this->parent()->address_str().c_str());
-  ESP_LOGCONFIG(TAG, "  Service UUID       : %s", this->service_uuid_.to_string().c_str());
-  ESP_LOGCONFIG(TAG, "  Characteristic UUID: %s", this->char_uuid_.to_string().c_str());
-  ESP_LOGCONFIG(TAG, "  Descriptor UUID    : %s", this->descr_uuid_.to_string().c_str());
-  ESP_LOGCONFIG(TAG, "  Notifications      : %s", YESNO(this->notify_));
+  ESP_LOGCONFIG(TAG,
+                "  MAC address        : %s\n"
+                "  Service UUID       : %s\n"
+                "  Characteristic UUID: %s\n"
+                "  Descriptor UUID    : %s\n"
+                "  Notifications      : %s",
+                this->parent()->address_str().c_str(), this->service_uuid_.to_string().c_str(),
+                this->char_uuid_.to_string().c_str(), this->descr_uuid_.to_string().c_str(), YESNO(this->notify_));
   LOG_UPDATE_INTERVAL(this);
 }
 

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
@@ -146,9 +146,11 @@ void BluetoothProxy::send_api_packet_(const esp32_ble_tracker::ESPBTDevice &devi
 
 void BluetoothProxy::dump_config() {
   ESP_LOGCONFIG(TAG, "Bluetooth Proxy:");
-  ESP_LOGCONFIG(TAG, "  Active: %s", YESNO(this->active_));
-  ESP_LOGCONFIG(TAG, "  Connections: %d", this->connections_.size());
-  ESP_LOGCONFIG(TAG, "  Raw advertisements: %s", YESNO(this->raw_advertisements_));
+  ESP_LOGCONFIG(TAG,
+                "  Active: %s\n"
+                "  Connections: %d\n"
+                "  Raw advertisements: %s",
+                YESNO(this->active_), this->connections_.size(), YESNO(this->raw_advertisements_));
 }
 
 int BluetoothProxy::get_bluetooth_connections_free() {

--- a/esphome/components/bme680_bsec/bme680_bsec.cpp
+++ b/esphome/components/bme680_bsec/bme680_bsec.cpp
@@ -160,8 +160,11 @@ void BME680BSECComponent::dump_config() {
   }
 
   ESP_LOGCONFIG(TAG,
-                "  Temperature Offset: %.2f\n  IAQ Mode: %s\n  Supply Voltage: %sV\n  Sample Rate: %s\n  State Save "
-                "Interval: %ims",
+                "  Temperature Offset: %.2f\n"
+                "  IAQ Mode: %s\n"
+                "  Supply Voltage: %sV\n"
+                "  Sample Rate: %s\n"
+                "  State Save Interval: %ims",
                 this->temperature_offset_, this->iaq_mode_ == IAQ_MODE_STATIC ? "Static" : "Mobile",
                 this->supply_voltage_ == SUPPLY_VOLTAGE_3V3 ? "3.3" : "1.8",
                 BME680_BSEC_SAMPLE_RATE_LOG(this->sample_rate_), this->state_save_interval_ms_);

--- a/esphome/components/bme680_bsec/bme680_bsec.cpp
+++ b/esphome/components/bme680_bsec/bme680_bsec.cpp
@@ -159,11 +159,12 @@ void BME680BSECComponent::dump_config() {
              this->bme680_status_);
   }
 
-  ESP_LOGCONFIG(TAG, "  Temperature Offset: %.2f", this->temperature_offset_);
-  ESP_LOGCONFIG(TAG, "  IAQ Mode: %s", this->iaq_mode_ == IAQ_MODE_STATIC ? "Static" : "Mobile");
-  ESP_LOGCONFIG(TAG, "  Supply Voltage: %sV", this->supply_voltage_ == SUPPLY_VOLTAGE_3V3 ? "3.3" : "1.8");
-  ESP_LOGCONFIG(TAG, "  Sample Rate: %s", BME680_BSEC_SAMPLE_RATE_LOG(this->sample_rate_));
-  ESP_LOGCONFIG(TAG, "  State Save Interval: %ims", this->state_save_interval_ms_);
+  ESP_LOGCONFIG(TAG,
+                "  Temperature Offset: %.2f\n  IAQ Mode: %s\n  Supply Voltage: %sV\n  Sample Rate: %s\n  State Save "
+                "Interval: %ims",
+                this->temperature_offset_, this->iaq_mode_ == IAQ_MODE_STATIC ? "Static" : "Mobile",
+                this->supply_voltage_ == SUPPLY_VOLTAGE_3V3 ? "3.3" : "1.8",
+                BME680_BSEC_SAMPLE_RATE_LOG(this->sample_rate_), this->state_save_interval_ms_);
 
   LOG_SENSOR("  ", "Temperature", this->temperature_sensor_);
   ESP_LOGCONFIG(TAG, "    Sample Rate: %s", BME680_BSEC_SAMPLE_RATE_LOG(this->temperature_sample_rate_));

--- a/esphome/components/bme68x_bsec2/bme68x_bsec2.cpp
+++ b/esphome/components/bme68x_bsec2/bme68x_bsec2.cpp
@@ -58,13 +58,13 @@ void BME68xBSEC2Component::setup() {
 }
 
 void BME68xBSEC2Component::dump_config() {
-  ESP_LOGCONFIG(TAG, "BME68X via BSEC2:");
-
-  ESP_LOGCONFIG(TAG, "  BSEC2 version: %d.%d.%d.%d", this->version_.major, this->version_.minor,
-                this->version_.major_bugfix, this->version_.minor_bugfix);
-
-  ESP_LOGCONFIG(TAG, "  BSEC2 configuration blob:");
-  ESP_LOGCONFIG(TAG, "    Configured: %s", YESNO(this->bsec2_blob_configured_));
+  ESP_LOGCONFIG(TAG,
+                "BME68X via BSEC2:\n"
+                "  BSEC2 version: %d.%d.%d.%d\n"
+                "  BSEC2 configuration blob:\n"
+                "    Configured: %s",
+                this->version_.major, this->version_.minor, this->version_.major_bugfix, this->version_.minor_bugfix,
+                YESNO(this->bsec2_blob_configured_));
   if (this->bsec2_configuration_ != nullptr && this->bsec2_configuration_length_) {
     ESP_LOGCONFIG(TAG, "    Size: %" PRIu32, this->bsec2_configuration_length_);
   }
@@ -77,11 +77,14 @@ void BME68xBSEC2Component::dump_config() {
   if (this->algorithm_output_ != ALGORITHM_OUTPUT_IAQ) {
     ESP_LOGCONFIG(TAG, "  Algorithm output: %s", BME68X_BSEC2_ALGORITHM_OUTPUT_LOG(this->algorithm_output_));
   }
-  ESP_LOGCONFIG(TAG, "  Operating age: %s", BME68X_BSEC2_OPERATING_AGE_LOG(this->operating_age_));
-  ESP_LOGCONFIG(TAG, "  Sample rate: %s", BME68X_BSEC2_SAMPLE_RATE_LOG(this->sample_rate_));
-  ESP_LOGCONFIG(TAG, "  Voltage: %s", BME68X_BSEC2_VOLTAGE_LOG(this->voltage_));
-  ESP_LOGCONFIG(TAG, "  State save interval: %ims", this->state_save_interval_ms_);
-  ESP_LOGCONFIG(TAG, "  Temperature offset: %.2f", this->temperature_offset_);
+  ESP_LOGCONFIG(TAG,
+                "  Operating age: %s\n"
+                "  Sample rate: %s\n"
+                "  Voltage: %s\n"
+                "  State save interval: %ims\n"
+                "  Temperature offset: %.2f",
+                BME68X_BSEC2_OPERATING_AGE_LOG(this->operating_age_), BME68X_BSEC2_SAMPLE_RATE_LOG(this->sample_rate_),
+                BME68X_BSEC2_VOLTAGE_LOG(this->voltage_), this->state_save_interval_ms_, this->temperature_offset_);
 
 #ifdef USE_SENSOR
   LOG_SENSOR("  ", "Temperature", this->temperature_sensor_);

--- a/esphome/components/bmp3xx_base/bmp3xx_base.cpp
+++ b/esphome/components/bmp3xx_base/bmp3xx_base.cpp
@@ -148,8 +148,8 @@ void BMP3XXComponent::setup() {
 }
 
 void BMP3XXComponent::dump_config() {
-  ESP_LOGCONFIG(TAG, "BMP3XX:");
-  ESP_LOGCONFIG(TAG, "  Type: %s (0x%X)", LOG_STR_ARG(chip_type_to_str(this->chip_id_.reg)), this->chip_id_.reg);
+  ESP_LOGCONFIG(TAG, "BMP3XX:\n  Type: %s (0x%X)", LOG_STR_ARG(chip_type_to_str(this->chip_id_.reg)),
+                this->chip_id_.reg);
   switch (this->error_code_) {
     case NONE:
       break;

--- a/esphome/components/bmp3xx_base/bmp3xx_base.cpp
+++ b/esphome/components/bmp3xx_base/bmp3xx_base.cpp
@@ -148,8 +148,10 @@ void BMP3XXComponent::setup() {
 }
 
 void BMP3XXComponent::dump_config() {
-  ESP_LOGCONFIG(TAG, "BMP3XX:\n  Type: %s (0x%X)", LOG_STR_ARG(chip_type_to_str(this->chip_id_.reg)),
-                this->chip_id_.reg);
+  ESP_LOGCONFIG(TAG,
+                "BMP3XX:\n"
+                "  Type: %s (0x%X)",
+                LOG_STR_ARG(chip_type_to_str(this->chip_id_.reg)), this->chip_id_.reg);
   switch (this->error_code_) {
     case NONE:
       break;

--- a/esphome/components/bmp581/bmp581.cpp
+++ b/esphome/components/bmp581/bmp581.cpp
@@ -98,14 +98,20 @@ void BMP581Component::dump_config() {
 
   if (this->temperature_sensor_) {
     LOG_SENSOR("  ", "Temperature", this->temperature_sensor_);
-    ESP_LOGCONFIG(TAG, "    IIR Filter: %s", LOG_STR_ARG(iir_filter_to_str(this->iir_temperature_level_)));
-    ESP_LOGCONFIG(TAG, "    Oversampling: %s", LOG_STR_ARG(oversampling_to_str(this->temperature_oversampling_)));
+    ESP_LOGCONFIG(TAG,
+                  "    IIR Filter: %s\n"
+                  "    Oversampling: %s",
+                  LOG_STR_ARG(iir_filter_to_str(this->iir_temperature_level_)),
+                  LOG_STR_ARG(oversampling_to_str(this->temperature_oversampling_)));
   }
 
   if (this->pressure_sensor_) {
     LOG_SENSOR("  ", "Pressure", this->pressure_sensor_);
-    ESP_LOGCONFIG(TAG, "    IIR Filter: %s", LOG_STR_ARG(iir_filter_to_str(this->iir_pressure_level_)));
-    ESP_LOGCONFIG(TAG, "    Oversampling: %s", LOG_STR_ARG(oversampling_to_str(this->pressure_oversampling_)));
+    ESP_LOGCONFIG(TAG,
+                  "    IIR Filter: %s\n"
+                  "    Oversampling: %s",
+                  LOG_STR_ARG(iir_filter_to_str(this->iir_pressure_level_)),
+                  LOG_STR_ARG(oversampling_to_str(this->pressure_oversampling_)));
   }
 }
 

--- a/esphome/components/bp1658cj/bp1658cj.cpp
+++ b/esphome/components/bp1658cj/bp1658cj.cpp
@@ -26,8 +26,8 @@ void BP1658CJ::dump_config() {
   ESP_LOGCONFIG(TAG, "BP1658CJ:");
   LOG_PIN("  Data Pin: ", this->data_pin_);
   LOG_PIN("  Clock Pin: ", this->clock_pin_);
-  ESP_LOGCONFIG(TAG, "  Color Channels Max Power: %u", this->max_power_color_channels_);
-  ESP_LOGCONFIG(TAG, "  White Channels Max Power: %u", this->max_power_white_channels_);
+  ESP_LOGCONFIG(TAG, "  Color Channels Max Power: %u\n  White Channels Max Power: %u", this->max_power_color_channels_,
+                this->max_power_white_channels_);
 }
 
 void BP1658CJ::loop() {

--- a/esphome/components/bp1658cj/bp1658cj.cpp
+++ b/esphome/components/bp1658cj/bp1658cj.cpp
@@ -26,8 +26,10 @@ void BP1658CJ::dump_config() {
   ESP_LOGCONFIG(TAG, "BP1658CJ:");
   LOG_PIN("  Data Pin: ", this->data_pin_);
   LOG_PIN("  Clock Pin: ", this->clock_pin_);
-  ESP_LOGCONFIG(TAG, "  Color Channels Max Power: %u\n  White Channels Max Power: %u", this->max_power_color_channels_,
-                this->max_power_white_channels_);
+  ESP_LOGCONFIG(TAG,
+                "  Color Channels Max Power: %u\n"
+                "  White Channels Max Power: %u",
+                this->max_power_color_channels_, this->max_power_white_channels_);
 }
 
 void BP1658CJ::loop() {

--- a/esphome/components/cap1188/cap1188.cpp
+++ b/esphome/components/cap1188/cap1188.cpp
@@ -52,9 +52,8 @@ void CAP1188Component::dump_config() {
   ESP_LOGCONFIG(TAG, "CAP1188:");
   LOG_I2C_DEVICE(this);
   LOG_PIN("  Reset Pin: ", this->reset_pin_);
-  ESP_LOGCONFIG(TAG, "  Product ID: 0x%x", this->cap1188_product_id_);
-  ESP_LOGCONFIG(TAG, "  Manufacture ID: 0x%x", this->cap1188_manufacture_id_);
-  ESP_LOGCONFIG(TAG, "  Revision ID: 0x%x", this->cap1188_revision_);
+  ESP_LOGCONFIG(TAG, "  Product ID: 0x%x\n  Manufacture ID: 0x%x\n  Revision ID: 0x%x", this->cap1188_product_id_,
+                this->cap1188_manufacture_id_, this->cap1188_revision_);
 
   switch (this->error_code_) {
     case COMMUNICATION_FAILED:

--- a/esphome/components/cap1188/cap1188.cpp
+++ b/esphome/components/cap1188/cap1188.cpp
@@ -52,8 +52,11 @@ void CAP1188Component::dump_config() {
   ESP_LOGCONFIG(TAG, "CAP1188:");
   LOG_I2C_DEVICE(this);
   LOG_PIN("  Reset Pin: ", this->reset_pin_);
-  ESP_LOGCONFIG(TAG, "  Product ID: 0x%x\n  Manufacture ID: 0x%x\n  Revision ID: 0x%x", this->cap1188_product_id_,
-                this->cap1188_manufacture_id_, this->cap1188_revision_);
+  ESP_LOGCONFIG(TAG,
+                "  Product ID: 0x%x\n"
+                "  Manufacture ID: 0x%x\n"
+                "  Revision ID: 0x%x",
+                this->cap1188_product_id_, this->cap1188_manufacture_id_, this->cap1188_revision_);
 
   switch (this->error_code_) {
     case COMMUNICATION_FAILED:

--- a/esphome/components/chsc6x/chsc6x_touchscreen.cpp
+++ b/esphome/components/chsc6x/chsc6x_touchscreen.cpp
@@ -38,8 +38,11 @@ void CHSC6XTouchscreen::dump_config() {
   ESP_LOGCONFIG(TAG, "CHSC6X Touchscreen:");
   LOG_I2C_DEVICE(this);
   LOG_PIN("  Interrupt Pin: ", this->interrupt_pin_);
-  ESP_LOGCONFIG(TAG, "  Touch timeout: %d\n  x_raw_max_: %d\n  y_raw_max_: %d", this->touch_timeout_, this->x_raw_max_,
-                this->y_raw_max_);
+  ESP_LOGCONFIG(TAG,
+                "  Touch timeout: %d\n"
+                "  x_raw_max_: %d\n"
+                "  y_raw_max_: %d",
+                this->touch_timeout_, this->x_raw_max_, this->y_raw_max_);
 }
 
 }  // namespace chsc6x

--- a/esphome/components/chsc6x/chsc6x_touchscreen.cpp
+++ b/esphome/components/chsc6x/chsc6x_touchscreen.cpp
@@ -38,9 +38,8 @@ void CHSC6XTouchscreen::dump_config() {
   ESP_LOGCONFIG(TAG, "CHSC6X Touchscreen:");
   LOG_I2C_DEVICE(this);
   LOG_PIN("  Interrupt Pin: ", this->interrupt_pin_);
-  ESP_LOGCONFIG(TAG, "  Touch timeout: %d", this->touch_timeout_);
-  ESP_LOGCONFIG(TAG, "  x_raw_max_: %d", this->x_raw_max_);
-  ESP_LOGCONFIG(TAG, "  y_raw_max_: %d", this->y_raw_max_);
+  ESP_LOGCONFIG(TAG, "  Touch timeout: %d\n  x_raw_max_: %d\n  y_raw_max_: %d", this->touch_timeout_, this->x_raw_max_,
+                this->y_raw_max_);
 }
 
 }  // namespace chsc6x

--- a/esphome/components/climate/climate.cpp
+++ b/esphome/components/climate/climate.cpp
@@ -569,17 +569,22 @@ bool Climate::set_custom_preset_(const std::string &preset) {
 void Climate::dump_traits_(const char *tag) {
   auto traits = this->get_traits();
   ESP_LOGCONFIG(tag, "ClimateTraits:");
-  ESP_LOGCONFIG(tag, "  [x] Visual settings:");
-  ESP_LOGCONFIG(tag, "      - Min temperature: %.1f", traits.get_visual_min_temperature());
-  ESP_LOGCONFIG(tag, "      - Max temperature: %.1f", traits.get_visual_max_temperature());
-  ESP_LOGCONFIG(tag, "      - Temperature step:");
-  ESP_LOGCONFIG(tag, "          Target: %.1f", traits.get_visual_target_temperature_step());
+  ESP_LOGCONFIG(tag,
+                "  [x] Visual settings:\n"
+                "      - Min temperature: %.1f\n"
+                "      - Max temperature: %.1f\n"
+                "      - Temperature step:\n"
+                "          Target: %.1f",
+                traits.get_visual_min_temperature(), traits.get_visual_max_temperature(),
+                traits.get_visual_target_temperature_step());
   if (traits.get_supports_current_temperature()) {
     ESP_LOGCONFIG(tag, "          Current: %.1f", traits.get_visual_current_temperature_step());
   }
   if (traits.get_supports_target_humidity() || traits.get_supports_current_humidity()) {
-    ESP_LOGCONFIG(tag, "      - Min humidity: %.0f", traits.get_visual_min_humidity());
-    ESP_LOGCONFIG(tag, "      - Max humidity: %.0f", traits.get_visual_max_humidity());
+    ESP_LOGCONFIG(tag,
+                  "      - Min humidity: %.0f\n"
+                  "      - Max humidity: %.0f",
+                  traits.get_visual_min_humidity(), traits.get_visual_max_humidity());
   }
   if (traits.get_supports_two_point_target_temperature()) {
     ESP_LOGCONFIG(tag, "  [x] Supports two-point target temperature");

--- a/esphome/components/climate_ir/climate_ir.cpp
+++ b/esphome/components/climate_ir/climate_ir.cpp
@@ -75,10 +75,9 @@ void ClimateIR::control(const climate::ClimateCall &call) {
 }
 void ClimateIR::dump_config() {
   LOG_CLIMATE("", "IR Climate", this);
-  ESP_LOGCONFIG(TAG, "  Min. Temperature: %.1f°C", this->minimum_temperature_);
-  ESP_LOGCONFIG(TAG, "  Max. Temperature: %.1f°C", this->maximum_temperature_);
-  ESP_LOGCONFIG(TAG, "  Supports HEAT: %s", YESNO(this->supports_heat_));
-  ESP_LOGCONFIG(TAG, "  Supports COOL: %s", YESNO(this->supports_cool_));
+  ESP_LOGCONFIG(TAG, "  Min. Temperature: %.1f°C\n  Max. Temperature: %.1f°C\n  Supports HEAT: %s\n  Supports COOL: %s",
+                this->minimum_temperature_, this->maximum_temperature_, YESNO(this->supports_heat_),
+                YESNO(this->supports_cool_));
 }
 
 }  // namespace climate_ir

--- a/esphome/components/climate_ir/climate_ir.cpp
+++ b/esphome/components/climate_ir/climate_ir.cpp
@@ -75,7 +75,11 @@ void ClimateIR::control(const climate::ClimateCall &call) {
 }
 void ClimateIR::dump_config() {
   LOG_CLIMATE("", "IR Climate", this);
-  ESP_LOGCONFIG(TAG, "  Min. Temperature: %.1f°C\n  Max. Temperature: %.1f°C\n  Supports HEAT: %s\n  Supports COOL: %s",
+  ESP_LOGCONFIG(TAG,
+                "  Min. Temperature: %.1f°C\n"
+                "  Max. Temperature: %.1f°C\n"
+                "  Supports HEAT: %s\n"
+                "  Supports COOL: %s",
                 this->minimum_temperature_, this->maximum_temperature_, YESNO(this->supports_heat_),
                 YESNO(this->supports_cool_));
 }

--- a/esphome/components/cs5460a/cs5460a.cpp
+++ b/esphome/components/cs5460a/cs5460a.cpp
@@ -319,18 +319,23 @@ bool CS5460AComponent::check_status_() {
 void CS5460AComponent::dump_config() {
   uint32_t state = this->get_component_state();
 
-  ESP_LOGCONFIG(TAG, "CS5460A:");
-  ESP_LOGCONFIG(TAG, "  Init status: %s",
+  ESP_LOGCONFIG(TAG,
+                "CS5460A:\n"
+                "  Init status: %s",
                 state == COMPONENT_STATE_LOOP ? "OK" : (state == COMPONENT_STATE_FAILED ? "failed" : "other"));
   LOG_PIN("  CS Pin: ", cs_);
-  ESP_LOGCONFIG(TAG, "  Samples / cycle: %" PRIu32, samples_);
-  ESP_LOGCONFIG(TAG, "  Phase offset: %i", phase_offset_);
-  ESP_LOGCONFIG(TAG, "  PGA Gain: %s", pga_gain_ == CS5460A_PGA_GAIN_50X ? "50x" : "10x");
-  ESP_LOGCONFIG(TAG, "  Current gain: %.5f", current_gain_);
-  ESP_LOGCONFIG(TAG, "  Voltage gain: %.5f", voltage_gain_);
-  ESP_LOGCONFIG(TAG, "  Current HPF: %s", current_hpf_ ? "enabled" : "disabled");
-  ESP_LOGCONFIG(TAG, "  Voltage HPF: %s", voltage_hpf_ ? "enabled" : "disabled");
-  ESP_LOGCONFIG(TAG, "  Pulse energy: %.2f Wh", pulse_energy_wh_);
+  ESP_LOGCONFIG(TAG,
+                "  Samples / cycle: %" PRIu32 "\n"
+                "  Phase offset: %i\n"
+                "  PGA Gain: %s\n"
+                "  Current gain: %.5f\n"
+                "  Voltage gain: %.5f\n"
+                "  Current HPF: %s\n"
+                "  Voltage HPF: %s\n"
+                "  Pulse energy: %.2f Wh",
+                samples_, phase_offset_, pga_gain_ == CS5460A_PGA_GAIN_50X ? "50x" : "10x", current_gain_,
+                voltage_gain_, current_hpf_ ? "enabled" : "disabled", voltage_hpf_ ? "enabled" : "disabled",
+                pulse_energy_wh_);
   LOG_SENSOR("  ", "Voltage", voltage_sensor_);
   LOG_SENSOR("  ", "Current", current_sensor_);
   LOG_SENSOR("  ", "Power", power_sensor_);

--- a/esphome/components/cst816/touchscreen/cst816_touchscreen.cpp
+++ b/esphome/components/cst816/touchscreen/cst816_touchscreen.cpp
@@ -74,8 +74,10 @@ void CST816Touchscreen::dump_config() {
   LOG_I2C_DEVICE(this);
   LOG_PIN("  Interrupt Pin: ", this->interrupt_pin_);
   LOG_PIN("  Reset Pin: ", this->reset_pin_);
-  ESP_LOGCONFIG(TAG, "  X Raw Min: %d, X Raw Max: %d\n  Y Raw Min: %d, Y Raw Max: %d", this->x_raw_min_,
-                this->x_raw_max_, this->y_raw_min_, this->y_raw_max_);
+  ESP_LOGCONFIG(TAG,
+                "  X Raw Min: %d, X Raw Max: %d\n"
+                "  Y Raw Min: %d, Y Raw Max: %d",
+                this->x_raw_min_, this->x_raw_max_, this->y_raw_min_, this->y_raw_max_);
   const char *name;
   switch (this->chip_id_) {
     case CST820_CHIP_ID:

--- a/esphome/components/cst816/touchscreen/cst816_touchscreen.cpp
+++ b/esphome/components/cst816/touchscreen/cst816_touchscreen.cpp
@@ -74,8 +74,8 @@ void CST816Touchscreen::dump_config() {
   LOG_I2C_DEVICE(this);
   LOG_PIN("  Interrupt Pin: ", this->interrupt_pin_);
   LOG_PIN("  Reset Pin: ", this->reset_pin_);
-  ESP_LOGCONFIG(TAG, "  X Raw Min: %d, X Raw Max: %d", this->x_raw_min_, this->x_raw_max_);
-  ESP_LOGCONFIG(TAG, "  Y Raw Min: %d, Y Raw Max: %d", this->y_raw_min_, this->y_raw_max_);
+  ESP_LOGCONFIG(TAG, "  X Raw Min: %d, X Raw Max: %d\n  Y Raw Min: %d, Y Raw Max: %d", this->x_raw_min_,
+                this->x_raw_max_, this->y_raw_min_, this->y_raw_max_);
   const char *name;
   switch (this->chip_id_) {
     case CST820_CHIP_ID:

--- a/esphome/components/current_based/current_based_cover.cpp
+++ b/esphome/components/current_based/current_based_cover.cpp
@@ -151,8 +151,10 @@ void CurrentBasedCover::dump_config() {
   if (this->max_duration_ != UINT32_MAX) {
     ESP_LOGCONFIG(TAG, "Maximum duration: %.1fs", this->max_duration_ / 1e3f);
   }
-  ESP_LOGCONFIG(TAG, "Start sensing delay: %.1fs\nMalfunction detection: %s", this->start_sensing_delay_ / 1e3f,
-                YESNO(this->malfunction_detection_));
+  ESP_LOGCONFIG(TAG,
+                "Start sensing delay: %.1fs\n"
+                "Malfunction detection: %s",
+                this->start_sensing_delay_ / 1e3f, YESNO(this->malfunction_detection_));
 }
 
 float CurrentBasedCover::get_setup_priority() const { return setup_priority::DATA; }

--- a/esphome/components/current_based/current_based_cover.cpp
+++ b/esphome/components/current_based/current_based_cover.cpp
@@ -151,8 +151,8 @@ void CurrentBasedCover::dump_config() {
   if (this->max_duration_ != UINT32_MAX) {
     ESP_LOGCONFIG(TAG, "Maximum duration: %.1fs", this->max_duration_ / 1e3f);
   }
-  ESP_LOGCONFIG(TAG, "Start sensing delay: %.1fs", this->start_sensing_delay_ / 1e3f);
-  ESP_LOGCONFIG(TAG, "Malfunction detection: %s", YESNO(this->malfunction_detection_));
+  ESP_LOGCONFIG(TAG, "Start sensing delay: %.1fs\nMalfunction detection: %s", this->start_sensing_delay_ / 1e3f,
+                YESNO(this->malfunction_detection_));
 }
 
 float CurrentBasedCover::get_setup_priority() const { return setup_priority::DATA; }

--- a/esphome/components/debug/debug_esp32.cpp
+++ b/esphome/components/debug/debug_esp32.cpp
@@ -107,7 +107,10 @@ std::string DebugComponent::get_wakeup_cause_() {
 }
 
 void DebugComponent::log_partition_info_() {
-  ESP_LOGCONFIG(TAG, "Partition table:\n  %-12s %-4s %-8s %-10s %-10s", "Name", "Type", "Subtype", "Address", "Size");
+  ESP_LOGCONFIG(TAG,
+                "Partition table:\n"
+                "  %-12s %-4s %-8s %-10s %-10s",
+                "Name", "Type", "Subtype", "Address", "Size");
   esp_partition_iterator_t it = esp_partition_find(ESP_PARTITION_TYPE_ANY, ESP_PARTITION_SUBTYPE_ANY, NULL);
   while (it != NULL) {
     const esp_partition_t *partition = esp_partition_get(it);

--- a/esphome/components/debug/debug_esp32.cpp
+++ b/esphome/components/debug/debug_esp32.cpp
@@ -107,8 +107,7 @@ std::string DebugComponent::get_wakeup_cause_() {
 }
 
 void DebugComponent::log_partition_info_() {
-  ESP_LOGCONFIG(TAG, "Partition table:");
-  ESP_LOGCONFIG(TAG, "  %-12s %-4s %-8s %-10s %-10s", "Name", "Type", "Subtype", "Address", "Size");
+  ESP_LOGCONFIG(TAG, "Partition table:\n  %-12s %-4s %-8s %-10s %-10s", "Name", "Type", "Subtype", "Address", "Size");
   esp_partition_iterator_t it = esp_partition_find(ESP_PARTITION_TYPE_ANY, ESP_PARTITION_SUBTYPE_ANY, NULL);
   while (it != NULL) {
     const esp_partition_t *partition = esp_partition_get(it);

--- a/esphome/components/deep_sleep/deep_sleep_esp32.cpp
+++ b/esphome/components/deep_sleep/deep_sleep_esp32.cpp
@@ -46,10 +46,11 @@ void DeepSleepComponent::dump_config_platform_() {
     LOG_PIN("  Wakeup Pin: ", this->wakeup_pin_);
   }
   if (this->wakeup_cause_to_run_duration_.has_value()) {
-    ESP_LOGCONFIG(TAG, "  Default Wakeup Run Duration: %" PRIu32 " ms",
-                  this->wakeup_cause_to_run_duration_->default_cause);
-    ESP_LOGCONFIG(TAG, "  Touch Wakeup Run Duration: %" PRIu32 " ms", this->wakeup_cause_to_run_duration_->touch_cause);
-    ESP_LOGCONFIG(TAG, "  GPIO Wakeup Run Duration: %" PRIu32 " ms", this->wakeup_cause_to_run_duration_->gpio_cause);
+    ESP_LOGCONFIG(TAG,
+                  "  Default Wakeup Run Duration: %" PRIu32 " ms\n  Touch Wakeup Run Duration: %" PRIu32
+                  " ms\n  GPIO Wakeup Run Duration: %" PRIu32 " ms",
+                  this->wakeup_cause_to_run_duration_->default_cause, this->wakeup_cause_to_run_duration_->touch_cause,
+                  this->wakeup_cause_to_run_duration_->gpio_cause);
   }
 }
 

--- a/esphome/components/deep_sleep/deep_sleep_esp32.cpp
+++ b/esphome/components/deep_sleep/deep_sleep_esp32.cpp
@@ -47,8 +47,9 @@ void DeepSleepComponent::dump_config_platform_() {
   }
   if (this->wakeup_cause_to_run_duration_.has_value()) {
     ESP_LOGCONFIG(TAG,
-                  "  Default Wakeup Run Duration: %" PRIu32 " ms\n  Touch Wakeup Run Duration: %" PRIu32
-                  " ms\n  GPIO Wakeup Run Duration: %" PRIu32 " ms",
+                  "  Default Wakeup Run Duration: %" PRIu32 " ms\n"
+                  "  Touch Wakeup Run Duration: %" PRIu32 " ms\n"
+                  "  GPIO Wakeup Run Duration: %" PRIu32 " ms",
                   this->wakeup_cause_to_run_duration_->default_cause, this->wakeup_cause_to_run_duration_->touch_cause,
                   this->wakeup_cause_to_run_duration_->gpio_cause);
   }

--- a/esphome/components/display/display.h
+++ b/esphome/components/display/display.h
@@ -182,8 +182,11 @@ using display_writer_t = std::function<void(Display &)>;
 
 #define LOG_DISPLAY(prefix, type, obj) \
   if ((obj) != nullptr) { \
-    ESP_LOGCONFIG(TAG, prefix type "\n%s  Rotations: %d °\n%s  Dimensions: %dpx x %dpx", prefix, (obj)->rotation_, \
-                  prefix, (obj)->get_width(), (obj)->get_height()); \
+    ESP_LOGCONFIG(TAG, \
+                  prefix type "\n" \
+                              "%s  Rotations: %d °\n" \
+                              "%s  Dimensions: %dpx x %dpx", \
+                  prefix, (obj)->rotation_, prefix, (obj)->get_width(), (obj)->get_height()); \
   }
 
 /// Turn the pixel OFF.

--- a/esphome/components/display/display.h
+++ b/esphome/components/display/display.h
@@ -182,9 +182,8 @@ using display_writer_t = std::function<void(Display &)>;
 
 #define LOG_DISPLAY(prefix, type, obj) \
   if ((obj) != nullptr) { \
-    ESP_LOGCONFIG(TAG, prefix type); \
-    ESP_LOGCONFIG(TAG, "%s  Rotations: %d °", prefix, (obj)->rotation_); \
-    ESP_LOGCONFIG(TAG, "%s  Dimensions: %dpx x %dpx", prefix, (obj)->get_width(), (obj)->get_height()); \
+    ESP_LOGCONFIG(TAG, prefix type "\n%s  Rotations: %d °\n%s  Dimensions: %dpx x %dpx", prefix, (obj)->rotation_, \
+                  prefix, (obj)->get_width(), (obj)->get_height()); \
   }
 
 /// Turn the pixel OFF.

--- a/esphome/components/dps310/dps310.cpp
+++ b/esphome/components/dps310/dps310.cpp
@@ -86,9 +86,11 @@ void DPS310Component::setup() {
 }
 
 void DPS310Component::dump_config() {
-  ESP_LOGCONFIG(TAG, "DPS310:");
-  ESP_LOGCONFIG(TAG, "  Product ID: %u", this->prod_rev_id_ & 0x0F);
-  ESP_LOGCONFIG(TAG, "  Revision ID: %u", (this->prod_rev_id_ >> 4) & 0x0F);
+  ESP_LOGCONFIG(TAG,
+                "DPS310:\n"
+                "  Product ID: %u\n"
+                "  Revision ID: %u",
+                this->prod_rev_id_ & 0x0F, (this->prod_rev_id_ >> 4) & 0x0F);
   LOG_I2C_DEVICE(this);
   if (this->is_failed()) {
     ESP_LOGE(TAG, ESP_LOG_MSG_COMM_FAIL);

--- a/esphome/components/dsmr/dsmr.cpp
+++ b/esphome/components/dsmr/dsmr.cpp
@@ -278,9 +278,8 @@ bool Dsmr::parse_telegram() {
 }
 
 void Dsmr::dump_config() {
-  ESP_LOGCONFIG(TAG, "DSMR:");
-  ESP_LOGCONFIG(TAG, "  Max telegram length: %d", this->max_telegram_len_);
-  ESP_LOGCONFIG(TAG, "  Receive timeout: %.1fs", this->receive_timeout_ / 1e3f);
+  ESP_LOGCONFIG(TAG, "DSMR:\n  Max telegram length: %d\n  Receive timeout: %.1fs", this->max_telegram_len_,
+                this->receive_timeout_ / 1e3f);
   if (this->request_pin_ != nullptr) {
     LOG_PIN("  Request Pin: ", this->request_pin_);
   }

--- a/esphome/components/dsmr/dsmr.cpp
+++ b/esphome/components/dsmr/dsmr.cpp
@@ -278,8 +278,11 @@ bool Dsmr::parse_telegram() {
 }
 
 void Dsmr::dump_config() {
-  ESP_LOGCONFIG(TAG, "DSMR:\n  Max telegram length: %d\n  Receive timeout: %.1fs", this->max_telegram_len_,
-                this->receive_timeout_ / 1e3f);
+  ESP_LOGCONFIG(TAG,
+                "DSMR:\n"
+                "  Max telegram length: %d\n"
+                "  Receive timeout: %.1fs",
+                this->max_telegram_len_, this->receive_timeout_ / 1e3f);
   if (this->request_pin_ != nullptr) {
     LOG_PIN("  Request Pin: ", this->request_pin_);
   }

--- a/esphome/components/duty_time/duty_time_sensor.cpp
+++ b/esphome/components/duty_time/duty_time_sensor.cpp
@@ -94,9 +94,8 @@ void DutyTimeSensor::publish_and_save_(const uint32_t sec, const uint32_t ms) {
 }
 
 void DutyTimeSensor::dump_config() {
-  ESP_LOGCONFIG(TAG, "Duty Time:");
-  ESP_LOGCONFIG(TAG, "  Update Interval: %" PRId32 "ms", this->get_update_interval());
-  ESP_LOGCONFIG(TAG, "  Restore: %s", ONOFF(this->restore_));
+  ESP_LOGCONFIG(TAG, "Duty Time:\n  Update Interval: %" PRId32 "ms\n  Restore: %s", this->get_update_interval(),
+                ONOFF(this->restore_));
   LOG_SENSOR("  ", "Duty Time Sensor:", this);
   LOG_SENSOR("  ", "Last Duty Time Sensor:", this->last_duty_time_sensor_);
 }

--- a/esphome/components/duty_time/duty_time_sensor.cpp
+++ b/esphome/components/duty_time/duty_time_sensor.cpp
@@ -94,8 +94,11 @@ void DutyTimeSensor::publish_and_save_(const uint32_t sec, const uint32_t ms) {
 }
 
 void DutyTimeSensor::dump_config() {
-  ESP_LOGCONFIG(TAG, "Duty Time:\n  Update Interval: %" PRId32 "ms\n  Restore: %s", this->get_update_interval(),
-                ONOFF(this->restore_));
+  ESP_LOGCONFIG(TAG,
+                "Duty Time:\n"
+                "  Update Interval: %" PRId32 "ms\n"
+                "  Restore: %s",
+                this->get_update_interval(), ONOFF(this->restore_));
   LOG_SENSOR("  ", "Duty Time Sensor:", this);
   LOG_SENSOR("  ", "Last Duty Time Sensor:", this->last_duty_time_sensor_);
 }

--- a/esphome/components/emc2101/emc2101.cpp
+++ b/esphome/components/emc2101/emc2101.cpp
@@ -100,8 +100,7 @@ void Emc2101Component::dump_config() {
   if (this->dac_mode_) {
     ESP_LOGCONFIG(TAG, "  DAC Conversion Rate: %X", this->dac_conversion_rate_);
   } else {
-    ESP_LOGCONFIG(TAG, "  PWM Resolution: %02X", this->pwm_resolution_);
-    ESP_LOGCONFIG(TAG, "  PWM Divider: %02X", this->pwm_divider_);
+    ESP_LOGCONFIG(TAG, "  PWM Resolution: %02X\n  PWM Divider: %02X", this->pwm_resolution_, this->pwm_divider_);
   }
   ESP_LOGCONFIG(TAG, "  Inverted: %s", YESNO(this->inverted_));
 }

--- a/esphome/components/emc2101/emc2101.cpp
+++ b/esphome/components/emc2101/emc2101.cpp
@@ -100,7 +100,10 @@ void Emc2101Component::dump_config() {
   if (this->dac_mode_) {
     ESP_LOGCONFIG(TAG, "  DAC Conversion Rate: %X", this->dac_conversion_rate_);
   } else {
-    ESP_LOGCONFIG(TAG, "  PWM Resolution: %02X\n  PWM Divider: %02X", this->pwm_resolution_, this->pwm_divider_);
+    ESP_LOGCONFIG(TAG,
+                  "  PWM Resolution: %02X\n"
+                  "  PWM Divider: %02X",
+                  this->pwm_resolution_, this->pwm_divider_);
   }
   ESP_LOGCONFIG(TAG, "  Inverted: %s", YESNO(this->inverted_));
 }

--- a/esphome/components/es7210/es7210.cpp
+++ b/esphome/components/es7210/es7210.cpp
@@ -25,7 +25,10 @@ static const size_t MCLK_DIV_FRE = 256;
   }
 
 void ES7210::dump_config() {
-  ESP_LOGCONFIG(TAG, "ES7210 audio ADC:\n  Bits Per Sample: %" PRIu8 "\n  Sample Rate: %" PRIu32,
+  ESP_LOGCONFIG(TAG,
+                "ES7210 audio ADC:\n"
+                "  Bits Per Sample: %" PRIu8 "\n"
+                "  Sample Rate: %" PRIu32,
                 this->bits_per_sample_, this->sample_rate_);
 
   if (this->is_failed()) {

--- a/esphome/components/es7210/es7210.cpp
+++ b/esphome/components/es7210/es7210.cpp
@@ -25,9 +25,8 @@ static const size_t MCLK_DIV_FRE = 256;
   }
 
 void ES7210::dump_config() {
-  ESP_LOGCONFIG(TAG, "ES7210 audio ADC:");
-  ESP_LOGCONFIG(TAG, "  Bits Per Sample: %" PRIu8, this->bits_per_sample_);
-  ESP_LOGCONFIG(TAG, "  Sample Rate: %" PRIu32, this->sample_rate_);
+  ESP_LOGCONFIG(TAG, "ES7210 audio ADC:\n  Bits Per Sample: %" PRIu8 "\n  Sample Rate: %" PRIu32,
+                this->bits_per_sample_, this->sample_rate_);
 
   if (this->is_failed()) {
     ESP_LOGE(TAG, "  Failed to initialize");

--- a/esphome/components/es8311/es8311.cpp
+++ b/esphome/components/es8311/es8311.cpp
@@ -53,8 +53,11 @@ void ES8311::setup() {
 
 void ES8311::dump_config() {
   ESP_LOGCONFIG(TAG,
-                "ES8311 Audio Codec:\n  Use MCLK: %s\n  Use Microphone: %s\n  DAC Bits per Sample: %" PRIu8
-                "\n  Sample Rate: %" PRIu32,
+                "ES8311 Audio Codec:\n"
+                "  Use MCLK: %s\n"
+                "  Use Microphone: %s\n"
+                "  DAC Bits per Sample: %" PRIu8 "\n"
+                "  Sample Rate: %" PRIu32,
                 YESNO(this->use_mclk_), YESNO(this->use_mic_), this->resolution_out_, this->sample_frequency_);
 
   if (this->is_failed()) {

--- a/esphome/components/es8311/es8311.cpp
+++ b/esphome/components/es8311/es8311.cpp
@@ -52,11 +52,10 @@ void ES8311::setup() {
 }
 
 void ES8311::dump_config() {
-  ESP_LOGCONFIG(TAG, "ES8311 Audio Codec:");
-  ESP_LOGCONFIG(TAG, "  Use MCLK: %s", YESNO(this->use_mclk_));
-  ESP_LOGCONFIG(TAG, "  Use Microphone: %s", YESNO(this->use_mic_));
-  ESP_LOGCONFIG(TAG, "  DAC Bits per Sample: %" PRIu8, this->resolution_out_);
-  ESP_LOGCONFIG(TAG, "  Sample Rate: %" PRIu32, this->sample_frequency_);
+  ESP_LOGCONFIG(TAG,
+                "ES8311 Audio Codec:\n  Use MCLK: %s\n  Use Microphone: %s\n  DAC Bits per Sample: %" PRIu8
+                "\n  Sample Rate: %" PRIu32,
+                YESNO(this->use_mclk_), YESNO(this->use_mic_), this->resolution_out_, this->sample_frequency_);
 
   if (this->is_failed()) {
     ESP_LOGCONFIG(TAG, "  Failed to initialize!");

--- a/esphome/components/esp32_ble/ble.cpp
+++ b/esphome/components/esp32_ble/ble.cpp
@@ -408,10 +408,12 @@ void ESP32BLE::dump_config() {
         io_capability_s = "invalid";
         break;
     }
-    ESP_LOGCONFIG(TAG, "ESP32 BLE:");
-    ESP_LOGCONFIG(TAG, "  MAC address: %02X:%02X:%02X:%02X:%02X:%02X", mac_address[0], mac_address[1], mac_address[2],
-                  mac_address[3], mac_address[4], mac_address[5]);
-    ESP_LOGCONFIG(TAG, "  IO Capability: %s", io_capability_s);
+    ESP_LOGCONFIG(TAG,
+                  "ESP32 BLE:\n"
+                  "  MAC address: %02X:%02X:%02X:%02X:%02X:%02X\n"
+                  "  IO Capability: %s",
+                  mac_address[0], mac_address[1], mac_address[2], mac_address[3], mac_address[4], mac_address[5],
+                  io_capability_s);
   } else {
     ESP_LOGCONFIG(TAG, "ESP32 BLE: bluetooth stack is not enabled");
   }

--- a/esphome/components/esp32_ble_client/ble_client_base.cpp
+++ b/esphome/components/esp32_ble_client/ble_client_base.cpp
@@ -45,7 +45,10 @@ void BLEClientBase::loop() {
 float BLEClientBase::get_setup_priority() const { return setup_priority::AFTER_BLUETOOTH; }
 
 void BLEClientBase::dump_config() {
-  ESP_LOGCONFIG(TAG, "  Address: %s\n  Auto-Connect: %s", this->address_str().c_str(), TRUEFALSE(this->auto_connect_));
+  ESP_LOGCONFIG(TAG,
+                "  Address: %s\n"
+                "  Auto-Connect: %s",
+                this->address_str().c_str(), TRUEFALSE(this->auto_connect_));
   std::string state_name;
   switch (this->state()) {
     case espbt::ClientState::INIT:

--- a/esphome/components/esp32_ble_client/ble_client_base.cpp
+++ b/esphome/components/esp32_ble_client/ble_client_base.cpp
@@ -45,8 +45,7 @@ void BLEClientBase::loop() {
 float BLEClientBase::get_setup_priority() const { return setup_priority::AFTER_BLUETOOTH; }
 
 void BLEClientBase::dump_config() {
-  ESP_LOGCONFIG(TAG, "  Address: %s", this->address_str().c_str());
-  ESP_LOGCONFIG(TAG, "  Auto-Connect: %s", TRUEFALSE(this->auto_connect_));
+  ESP_LOGCONFIG(TAG, "  Address: %s\n  Auto-Connect: %s", this->address_str().c_str(), TRUEFALSE(this->auto_connect_));
   std::string state_name;
   switch (this->state()) {
     case espbt::ClientState::INIT:

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
@@ -731,11 +731,14 @@ uint64_t ESPBTDevice::address_uint64() const { return esp32_ble::ble_addr_to_uin
 
 void ESP32BLETracker::dump_config() {
   ESP_LOGCONFIG(TAG, "BLE Tracker:");
-  ESP_LOGCONFIG(TAG, "  Scan Duration: %" PRIu32 " s", this->scan_duration_);
-  ESP_LOGCONFIG(TAG, "  Scan Interval: %.1f ms", this->scan_interval_ * 0.625f);
-  ESP_LOGCONFIG(TAG, "  Scan Window: %.1f ms", this->scan_window_ * 0.625f);
-  ESP_LOGCONFIG(TAG, "  Scan Type: %s", this->scan_active_ ? "ACTIVE" : "PASSIVE");
-  ESP_LOGCONFIG(TAG, "  Continuous Scanning: %s", YESNO(this->scan_continuous_));
+  ESP_LOGCONFIG(TAG,
+                "  Scan Duration: %" PRIu32 " s\n"
+                "  Scan Interval: %.1f ms\n"
+                "  Scan Window: %.1f ms\n"
+                "  Scan Type: %s\n"
+                "  Continuous Scanning: %s",
+                this->scan_duration_, this->scan_interval_ * 0.625f, this->scan_window_ * 0.625f,
+                this->scan_active_ ? "ACTIVE" : "PASSIVE", YESNO(this->scan_continuous_));
   switch (this->scanner_state_) {
     case ScannerState::IDLE:
       ESP_LOGCONFIG(TAG, "  Scanner State: IDLE");

--- a/esphome/components/esp32_camera/esp32_camera.cpp
+++ b/esphome/components/esp32_camera/esp32_camera.cpp
@@ -46,17 +46,20 @@ void ESP32Camera::setup() {
 
 void ESP32Camera::dump_config() {
   auto conf = this->config_;
-  ESP_LOGCONFIG(TAG, "ESP32 Camera:");
-  ESP_LOGCONFIG(TAG, "  Name: %s", this->name_.c_str());
-  ESP_LOGCONFIG(TAG, "  Internal: %s", YESNO(this->internal_));
-  ESP_LOGCONFIG(TAG, "  Data Pins: D0:%d D1:%d D2:%d D3:%d D4:%d D5:%d D6:%d D7:%d", conf.pin_d0, conf.pin_d1,
-                conf.pin_d2, conf.pin_d3, conf.pin_d4, conf.pin_d5, conf.pin_d6, conf.pin_d7);
-  ESP_LOGCONFIG(TAG, "  VSYNC Pin: %d", conf.pin_vsync);
-  ESP_LOGCONFIG(TAG, "  HREF Pin: %d", conf.pin_href);
-  ESP_LOGCONFIG(TAG, "  Pixel Clock Pin: %d", conf.pin_pclk);
-  ESP_LOGCONFIG(TAG, "  External Clock: Pin:%d Frequency:%u", conf.pin_xclk, conf.xclk_freq_hz);
-  ESP_LOGCONFIG(TAG, "  I2C Pins: SDA:%d SCL:%d", conf.pin_sccb_sda, conf.pin_sccb_scl);
-  ESP_LOGCONFIG(TAG, "  Reset Pin: %d", conf.pin_reset);
+  ESP_LOGCONFIG(TAG,
+                "ESP32 Camera:\n"
+                "  Name: %s\n"
+                "  Internal: %s\n"
+                "  Data Pins: D0:%d D1:%d D2:%d D3:%d D4:%d D5:%d D6:%d D7:%d\n"
+                "  VSYNC Pin: %d\n"
+                "  HREF Pin: %d\n"
+                "  Pixel Clock Pin: %d\n"
+                "  External Clock: Pin:%d Frequency:%u\n"
+                "  I2C Pins: SDA:%d SCL:%d\n"
+                "  Reset Pin: %d",
+                this->name_.c_str(), YESNO(this->internal_), conf.pin_d0, conf.pin_d1, conf.pin_d2, conf.pin_d3,
+                conf.pin_d4, conf.pin_d5, conf.pin_d6, conf.pin_d7, conf.pin_vsync, conf.pin_href, conf.pin_pclk,
+                conf.pin_xclk, conf.xclk_freq_hz, conf.pin_sccb_sda, conf.pin_sccb_scl, conf.pin_reset);
   switch (this->config_.frame_size) {
     case FRAMESIZE_QQVGA:
       ESP_LOGCONFIG(TAG, "  Resolution: 160x120 (QQVGA)");
@@ -123,24 +126,29 @@ void ESP32Camera::dump_config() {
 
   sensor_t *s = esp_camera_sensor_get();
   auto st = s->status;
-  ESP_LOGCONFIG(TAG, "  JPEG Quality: %u", st.quality);
-  ESP_LOGCONFIG(TAG, "  Framebuffer Count: %u", conf.fb_count);
-  ESP_LOGCONFIG(TAG, "  Contrast: %d", st.contrast);
-  ESP_LOGCONFIG(TAG, "  Brightness: %d", st.brightness);
-  ESP_LOGCONFIG(TAG, "  Saturation: %d", st.saturation);
-  ESP_LOGCONFIG(TAG, "  Vertical Flip: %s", ONOFF(st.vflip));
-  ESP_LOGCONFIG(TAG, "  Horizontal Mirror: %s", ONOFF(st.hmirror));
-  ESP_LOGCONFIG(TAG, "  Special Effect: %u", st.special_effect);
-  ESP_LOGCONFIG(TAG, "  White Balance Mode: %u", st.wb_mode);
+  ESP_LOGCONFIG(TAG,
+                "  JPEG Quality: %u\n"
+                "  Framebuffer Count: %u\n"
+                "  Contrast: %d\n"
+                "  Brightness: %d\n"
+                "  Saturation: %d\n"
+                "  Vertical Flip: %s\n"
+                "  Horizontal Mirror: %s\n"
+                "  Special Effect: %u\n"
+                "  White Balance Mode: %u",
+                st.quality, conf.fb_count, st.contrast, st.brightness, st.saturation, ONOFF(st.vflip),
+                ONOFF(st.hmirror), st.special_effect, st.wb_mode);
   // ESP_LOGCONFIG(TAG, "  Auto White Balance: %u", st.awb);
   // ESP_LOGCONFIG(TAG, "  Auto White Balance Gain: %u", st.awb_gain);
-  ESP_LOGCONFIG(TAG, "  Auto Exposure Control: %u", st.aec);
-  ESP_LOGCONFIG(TAG, "  Auto Exposure Control 2: %u", st.aec2);
-  ESP_LOGCONFIG(TAG, "  Auto Exposure Level: %d", st.ae_level);
-  ESP_LOGCONFIG(TAG, "  Auto Exposure Value: %u", st.aec_value);
-  ESP_LOGCONFIG(TAG, "  AGC: %u", st.agc);
-  ESP_LOGCONFIG(TAG, "  AGC Gain: %u", st.agc_gain);
-  ESP_LOGCONFIG(TAG, "  Gain Ceiling: %u", st.gainceiling);
+  ESP_LOGCONFIG(TAG,
+                "  Auto Exposure Control: %u\n"
+                "  Auto Exposure Control 2: %u\n"
+                "  Auto Exposure Level: %d\n"
+                "  Auto Exposure Value: %u\n"
+                "  AGC: %u\n"
+                "  AGC Gain: %u\n"
+                "  Gain Ceiling: %u",
+                st.aec, st.aec2, st.ae_level, st.aec_value, st.agc, st.agc_gain, st.gainceiling);
   // ESP_LOGCONFIG(TAG, "  BPC: %u", st.bpc);
   // ESP_LOGCONFIG(TAG, "  WPC: %u", st.wpc);
   // ESP_LOGCONFIG(TAG, "  RAW_GMA: %u", st.raw_gma);

--- a/esphome/components/esp32_camera_web_server/camera_web_server.cpp
+++ b/esphome/components/esp32_camera_web_server/camera_web_server.cpp
@@ -85,7 +85,10 @@ void CameraWebServer::on_shutdown() {
 }
 
 void CameraWebServer::dump_config() {
-  ESP_LOGCONFIG(TAG, "ESP32 Camera Web Server:\n  Port: %d", this->port_);
+  ESP_LOGCONFIG(TAG,
+                "ESP32 Camera Web Server:\n"
+                "  Port: %d",
+                this->port_);
   if (this->mode_ == STREAM) {
     ESP_LOGCONFIG(TAG, "  Mode: stream");
   } else {

--- a/esphome/components/esp32_camera_web_server/camera_web_server.cpp
+++ b/esphome/components/esp32_camera_web_server/camera_web_server.cpp
@@ -85,8 +85,7 @@ void CameraWebServer::on_shutdown() {
 }
 
 void CameraWebServer::dump_config() {
-  ESP_LOGCONFIG(TAG, "ESP32 Camera Web Server:");
-  ESP_LOGCONFIG(TAG, "  Port: %d", this->port_);
+  ESP_LOGCONFIG(TAG, "ESP32 Camera Web Server:\n  Port: %d", this->port_);
   if (this->mode_ == STREAM) {
     ESP_LOGCONFIG(TAG, "  Mode: stream");
   } else {

--- a/esphome/components/esp32_rmt_led_strip/led_strip.cpp
+++ b/esphome/components/esp32_rmt_led_strip/led_strip.cpp
@@ -278,9 +278,11 @@ void ESP32RMTLEDStripLightOutput::dump_config() {
       rgb_order = "UNKNOWN";
       break;
   }
-  ESP_LOGCONFIG(TAG, "  RGB Order: %s", rgb_order);
-  ESP_LOGCONFIG(TAG, "  Max refresh rate: %" PRIu32, *this->max_refresh_rate_);
-  ESP_LOGCONFIG(TAG, "  Number of LEDs: %u", this->num_leds_);
+  ESP_LOGCONFIG(TAG,
+                "  RGB Order: %s\n"
+                "  Max refresh rate: %" PRIu32 "\n"
+                "  Number of LEDs: %u",
+                rgb_order, *this->max_refresh_rate_, this->num_leds_);
 }
 
 float ESP32RMTLEDStripLightOutput::get_setup_priority() const { return setup_priority::HARDWARE; }

--- a/esphome/components/esp32_rmt_led_strip/led_strip.cpp
+++ b/esphome/components/esp32_rmt_led_strip/led_strip.cpp
@@ -247,8 +247,7 @@ light::ESPColorView ESP32RMTLEDStripLightOutput::get_view_internal(int32_t index
 }
 
 void ESP32RMTLEDStripLightOutput::dump_config() {
-  ESP_LOGCONFIG(TAG, "ESP32 RMT LED Strip:");
-  ESP_LOGCONFIG(TAG, "  Pin: %u", this->pin_);
+  ESP_LOGCONFIG(TAG, "ESP32 RMT LED Strip:\n  Pin: %u", this->pin_);
 #if ESP_IDF_VERSION_MAJOR >= 5
   ESP_LOGCONFIG(TAG, "  RMT Symbols: %" PRIu32, this->rmt_symbols_);
 #else

--- a/esphome/components/esp32_rmt_led_strip/led_strip.cpp
+++ b/esphome/components/esp32_rmt_led_strip/led_strip.cpp
@@ -247,7 +247,10 @@ light::ESPColorView ESP32RMTLEDStripLightOutput::get_view_internal(int32_t index
 }
 
 void ESP32RMTLEDStripLightOutput::dump_config() {
-  ESP_LOGCONFIG(TAG, "ESP32 RMT LED Strip:\n  Pin: %u", this->pin_);
+  ESP_LOGCONFIG(TAG,
+                "ESP32 RMT LED Strip:\n"
+                "  Pin: %u",
+                this->pin_);
 #if ESP_IDF_VERSION_MAJOR >= 5
   ESP_LOGCONFIG(TAG, "  RMT Symbols: %" PRIu32, this->rmt_symbols_);
 #else

--- a/esphome/components/esp32_touch/esp32_touch.cpp
+++ b/esphome/components/esp32_touch/esp32_touch.cpp
@@ -75,9 +75,11 @@ void ESP32TouchComponent::setup() {
 }
 
 void ESP32TouchComponent::dump_config() {
-  ESP_LOGCONFIG(TAG, "Config for ESP32 Touch Hub:");
-  ESP_LOGCONFIG(TAG, "  Meas cycle: %.2fms", this->meas_cycle_ / (8000000.0f / 1000.0f));
-  ESP_LOGCONFIG(TAG, "  Sleep cycle: %.2fms", this->sleep_cycle_ / (150000.0f / 1000.0f));
+  ESP_LOGCONFIG(TAG,
+                "Config for ESP32 Touch Hub:\n"
+                "  Meas cycle: %.2fms\n"
+                "  Sleep cycle: %.2fms",
+                this->meas_cycle_ / (8000000.0f / 1000.0f), this->sleep_cycle_ / (150000.0f / 1000.0f));
 
   const char *lv_s;
   switch (this->low_voltage_reference_) {
@@ -171,10 +173,12 @@ void ESP32TouchComponent::dump_config() {
         filter_mode_s = "UNKNOWN";
         break;
     }
-    ESP_LOGCONFIG(TAG, "  Filter mode: %s", filter_mode_s);
-    ESP_LOGCONFIG(TAG, "  Debounce count: %" PRIu32, this->debounce_count_);
-    ESP_LOGCONFIG(TAG, "  Noise threshold coefficient: %" PRIu32, this->noise_threshold_);
-    ESP_LOGCONFIG(TAG, "  Jitter filter step size: %" PRIu32, this->jitter_step_);
+    ESP_LOGCONFIG(TAG,
+                  "  Filter mode: %s\n"
+                  "  Debounce count: %" PRIu32 "\n"
+                  "  Noise threshold coefficient: %" PRIu32 "\n"
+                  "  Jitter filter step size: %" PRIu32,
+                  filter_mode_s, this->debounce_count_, this->noise_threshold_, this->jitter_step_);
     const char *smooth_level_s;
     switch (this->smooth_level_) {
       case TOUCH_PAD_SMOOTH_OFF:

--- a/esphome/components/esphome/ota/ota_esphome.cpp
+++ b/esphome/components/esphome/ota/ota_esphome.cpp
@@ -70,9 +70,11 @@ void ESPHomeOTAComponent::setup() {
 }
 
 void ESPHomeOTAComponent::dump_config() {
-  ESP_LOGCONFIG(TAG, "Over-The-Air updates:");
-  ESP_LOGCONFIG(TAG, "  Address: %s:%u", network::get_use_address().c_str(), this->port_);
-  ESP_LOGCONFIG(TAG, "  Version: %d", USE_OTA_VERSION);
+  ESP_LOGCONFIG(TAG,
+                "Over-The-Air updates:\n"
+                "  Address: %s:%u\n"
+                "  Version: %d",
+                network::get_use_address().c_str(), this->port_, USE_OTA_VERSION);
 #ifdef USE_OTA_PASSWORD
   if (!this->password_.empty()) {
     ESP_LOGCONFIG(TAG, "  Password configured");

--- a/esphome/components/ethernet/ethernet_component.cpp
+++ b/esphome/components/ethernet/ethernet_component.cpp
@@ -326,10 +326,12 @@ void EthernetComponent::dump_config() {
   ESP_LOGCONFIG(TAG, "Ethernet:");
   this->dump_connect_params_();
 #ifdef USE_ETHERNET_SPI
-  ESP_LOGCONFIG(TAG, "  CLK Pin: %u", this->clk_pin_);
-  ESP_LOGCONFIG(TAG, "  MISO Pin: %u", this->miso_pin_);
-  ESP_LOGCONFIG(TAG, "  MOSI Pin: %u", this->mosi_pin_);
-  ESP_LOGCONFIG(TAG, "  CS Pin: %u", this->cs_pin_);
+  ESP_LOGCONFIG(TAG,
+                "  CLK Pin: %u\n"
+                "  MISO Pin: %u\n"
+                "  MOSI Pin: %u\n"
+                "  CS Pin: %u",
+                this->clk_pin_, this->miso_pin_, this->mosi_pin_, this->cs_pin_);
 #ifdef USE_ETHERNET_SPI_POLLING_SUPPORT
   if (this->polling_interval_ != 0) {
     ESP_LOGCONFIG(TAG, "  Polling Interval: %lu ms", this->polling_interval_);
@@ -344,9 +346,11 @@ void EthernetComponent::dump_config() {
   if (this->power_pin_ != -1) {
     ESP_LOGCONFIG(TAG, "  Power Pin: %u", this->power_pin_);
   }
-  ESP_LOGCONFIG(TAG, "  MDC Pin: %u", this->mdc_pin_);
-  ESP_LOGCONFIG(TAG, "  MDIO Pin: %u", this->mdio_pin_);
-  ESP_LOGCONFIG(TAG, "  PHY addr: %u", this->phy_addr_);
+  ESP_LOGCONFIG(TAG,
+                "  MDC Pin: %u\n"
+                "  MDIO Pin: %u\n"
+                "  PHY addr: %u",
+                this->mdc_pin_, this->mdio_pin_, this->phy_addr_);
 #endif
   ESP_LOGCONFIG(TAG, "  Type: %s", eth_type);
 }
@@ -512,16 +516,19 @@ bool EthernetComponent::is_connected() { return this->state_ == EthernetComponen
 void EthernetComponent::dump_connect_params_() {
   esp_netif_ip_info_t ip;
   esp_netif_get_ip_info(this->eth_netif_, &ip);
-  ESP_LOGCONFIG(TAG, "  IP Address: %s", network::IPAddress(&ip.ip).str().c_str());
-  ESP_LOGCONFIG(TAG, "  Hostname: '%s'", App.get_name().c_str());
-  ESP_LOGCONFIG(TAG, "  Subnet: %s", network::IPAddress(&ip.netmask).str().c_str());
-  ESP_LOGCONFIG(TAG, "  Gateway: %s", network::IPAddress(&ip.gw).str().c_str());
-
   const ip_addr_t *dns_ip1 = dns_getserver(0);
   const ip_addr_t *dns_ip2 = dns_getserver(1);
 
-  ESP_LOGCONFIG(TAG, "  DNS1: %s", network::IPAddress(dns_ip1).str().c_str());
-  ESP_LOGCONFIG(TAG, "  DNS2: %s", network::IPAddress(dns_ip2).str().c_str());
+  ESP_LOGCONFIG(TAG,
+                "  IP Address: %s\n"
+                "  Hostname: '%s'\n"
+                "  Subnet: %s\n"
+                "  Gateway: %s\n"
+                "  DNS1: %s\n"
+                "  DNS2: %s",
+                network::IPAddress(&ip.ip).str().c_str(), App.get_name().c_str(),
+                network::IPAddress(&ip.netmask).str().c_str(), network::IPAddress(&ip.gw).str().c_str(),
+                network::IPAddress(dns_ip1).str().c_str(), network::IPAddress(dns_ip2).str().c_str());
 
 #if USE_NETWORK_IPV6
   struct esp_ip6_addr if_ip6s[CONFIG_LWIP_IPV6_NUM_ADDRESSES];
@@ -533,9 +540,12 @@ void EthernetComponent::dump_connect_params_() {
   }
 #endif /* USE_NETWORK_IPV6 */
 
-  ESP_LOGCONFIG(TAG, "  MAC Address: %s", this->get_eth_mac_address_pretty().c_str());
-  ESP_LOGCONFIG(TAG, "  Is Full Duplex: %s", YESNO(this->get_duplex_mode() == ETH_DUPLEX_FULL));
-  ESP_LOGCONFIG(TAG, "  Link Speed: %u", this->get_link_speed() == ETH_SPEED_100M ? 100 : 10);
+  ESP_LOGCONFIG(TAG,
+                "  MAC Address: %s\n"
+                "  Is Full Duplex: %s\n"
+                "  Link Speed: %u",
+                this->get_eth_mac_address_pretty().c_str(), YESNO(this->get_duplex_mode() == ETH_DUPLEX_FULL),
+                this->get_link_speed() == ETH_SPEED_100M ? 100 : 10);
 }
 
 #ifdef USE_ETHERNET_SPI

--- a/esphome/components/ethernet/ethernet_component.cpp
+++ b/esphome/components/ethernet/ethernet_component.cpp
@@ -340,7 +340,10 @@ void EthernetComponent::dump_config() {
   {
     ESP_LOGCONFIG(TAG, "  IRQ Pin: %d", this->interrupt_pin_);
   }
-  ESP_LOGCONFIG(TAG, "  Reset Pin: %d\n  Clock Speed: %d MHz", this->reset_pin_, this->clock_speed_ / 1000000);
+  ESP_LOGCONFIG(TAG,
+                "  Reset Pin: %d\n"
+                "  Clock Speed: %d MHz",
+                this->reset_pin_, this->clock_speed_ / 1000000);
 #else
   if (this->power_pin_ != -1) {
     ESP_LOGCONFIG(TAG, "  Power Pin: %u", this->power_pin_);

--- a/esphome/components/ethernet/ethernet_component.cpp
+++ b/esphome/components/ethernet/ethernet_component.cpp
@@ -340,8 +340,7 @@ void EthernetComponent::dump_config() {
   {
     ESP_LOGCONFIG(TAG, "  IRQ Pin: %d", this->interrupt_pin_);
   }
-  ESP_LOGCONFIG(TAG, "  Reset Pin: %d", this->reset_pin_);
-  ESP_LOGCONFIG(TAG, "  Clock Speed: %d MHz", this->clock_speed_ / 1000000);
+  ESP_LOGCONFIG(TAG, "  Reset Pin: %d\n  Clock Speed: %d MHz", this->reset_pin_, this->clock_speed_ / 1000000);
 #else
   if (this->power_pin_ != -1) {
     ESP_LOGCONFIG(TAG, "  Power Pin: %u", this->power_pin_);

--- a/esphome/components/fan/fan.cpp
+++ b/esphome/components/fan/fan.cpp
@@ -189,7 +189,10 @@ void Fan::dump_traits_(const char *tag, const char *prefix) {
   auto traits = this->get_traits();
 
   if (traits.supports_speed()) {
-    ESP_LOGCONFIG(tag, "%s  Speed: YES\n%s  Speed count: %d", prefix, prefix, traits.supported_speed_count());
+    ESP_LOGCONFIG(tag,
+                  "%s  Speed: YES\n"
+                  "%s  Speed count: %d",
+                  prefix, prefix, traits.supported_speed_count());
   }
   if (traits.supports_oscillation()) {
     ESP_LOGCONFIG(tag, "%s  Oscillation: YES", prefix);

--- a/esphome/components/fan/fan.cpp
+++ b/esphome/components/fan/fan.cpp
@@ -189,8 +189,7 @@ void Fan::dump_traits_(const char *tag, const char *prefix) {
   auto traits = this->get_traits();
 
   if (traits.supports_speed()) {
-    ESP_LOGCONFIG(tag, "%s  Speed: YES", prefix);
-    ESP_LOGCONFIG(tag, "%s  Speed count: %d", prefix, traits.supported_speed_count());
+    ESP_LOGCONFIG(tag, "%s  Speed: YES\n%s  Speed count: %d", prefix, prefix, traits.supported_speed_count());
   }
   if (traits.supports_oscillation()) {
     ESP_LOGCONFIG(tag, "%s  Oscillation: YES", prefix);

--- a/esphome/components/fastled_base/fastled_light.cpp
+++ b/esphome/components/fastled_base/fastled_light.cpp
@@ -18,9 +18,11 @@ void FastLEDLightOutput::setup() {
   }
 }
 void FastLEDLightOutput::dump_config() {
-  ESP_LOGCONFIG(TAG, "FastLED light:");
-  ESP_LOGCONFIG(TAG, "  Num LEDs: %u", this->num_leds_);
-  ESP_LOGCONFIG(TAG, "  Max refresh rate: %u", *this->max_refresh_rate_);
+  ESP_LOGCONFIG(TAG,
+                "FastLED light:\n"
+                "  Num LEDs: %u\n"
+                "  Max refresh rate: %u",
+                this->num_leds_, *this->max_refresh_rate_);
 }
 void FastLEDLightOutput::write_state(light::LightState *state) {
   // protect from refreshing too often

--- a/esphome/components/fingerprint_grow/fingerprint_grow.cpp
+++ b/esphome/components/fingerprint_grow/fingerprint_grow.cpp
@@ -534,11 +534,13 @@ void FingerprintGrowComponent::sensor_sleep_() {
 }
 
 void FingerprintGrowComponent::dump_config() {
-  ESP_LOGCONFIG(TAG, "GROW_FINGERPRINT_READER:");
-  ESP_LOGCONFIG(TAG, "  System Identifier Code: 0x%.4X", this->system_identifier_code_);
-  ESP_LOGCONFIG(TAG, "  Touch Sensing Pin: %s",
-                this->has_sensing_pin_ ? this->sensing_pin_->dump_summary().c_str() : "None");
-  ESP_LOGCONFIG(TAG, "  Sensor Power Pin: %s",
+  ESP_LOGCONFIG(TAG,
+                "GROW_FINGERPRINT_READER:\n"
+                "  System Identifier Code: 0x%.4X\n"
+                "  Touch Sensing Pin: %s\n"
+                "  Sensor Power Pin: %s",
+                this->system_identifier_code_,
+                this->has_sensing_pin_ ? this->sensing_pin_->dump_summary().c_str() : "None",
                 this->has_power_pin_ ? this->sensor_power_pin_->dump_summary().c_str() : "None");
   if (this->idle_period_to_sleep_ms_ < UINT32_MAX) {
     ESP_LOGCONFIG(TAG, "  Idle Period to Sleep: %" PRIu32 " ms", this->idle_period_to_sleep_ms_);

--- a/esphome/components/ft5x06/touchscreen/ft5x06_touchscreen.cpp
+++ b/esphome/components/ft5x06/touchscreen/ft5x06_touchscreen.cpp
@@ -81,8 +81,11 @@ void FT5x06Touchscreen::update_touches() {
 }
 
 void FT5x06Touchscreen::dump_config() {
-  ESP_LOGCONFIG(TAG, "FT5x06 Touchscreen:\n  Address: 0x%02X\n  Vendor ID: 0x%X", this->address_,
-                (int) this->vendor_id_);
+  ESP_LOGCONFIG(TAG,
+                "FT5x06 Touchscreen:\n"
+                "  Address: 0x%02X\n"
+                "  Vendor ID: 0x%X",
+                this->address_, (int) this->vendor_id_);
 }
 
 bool FT5x06Touchscreen::err_check_(i2c::ErrorCode err, const char *msg) {

--- a/esphome/components/ft5x06/touchscreen/ft5x06_touchscreen.cpp
+++ b/esphome/components/ft5x06/touchscreen/ft5x06_touchscreen.cpp
@@ -81,9 +81,8 @@ void FT5x06Touchscreen::update_touches() {
 }
 
 void FT5x06Touchscreen::dump_config() {
-  ESP_LOGCONFIG(TAG, "FT5x06 Touchscreen:");
-  ESP_LOGCONFIG(TAG, "  Address: 0x%02X", this->address_);
-  ESP_LOGCONFIG(TAG, "  Vendor ID: 0x%X", (int) this->vendor_id_);
+  ESP_LOGCONFIG(TAG, "FT5x06 Touchscreen:\n  Address: 0x%02X\n  Vendor ID: 0x%X", this->address_,
+                (int) this->vendor_id_);
 }
 
 bool FT5x06Touchscreen::err_check_(i2c::ErrorCode err, const char *msg) {

--- a/esphome/components/ft63x6/ft63x6.cpp
+++ b/esphome/components/ft63x6/ft63x6.cpp
@@ -71,8 +71,10 @@ void FT63X6Touchscreen::dump_config() {
   LOG_I2C_DEVICE(this);
   LOG_PIN("  Interrupt Pin: ", this->interrupt_pin_);
   LOG_PIN("  Reset Pin: ", this->reset_pin_);
-  ESP_LOGCONFIG(TAG, "  X Calibration: [%d, %d]\n  Y Calibration: [%d, %d]", this->x_raw_min_, this->x_raw_max_,
-                this->y_raw_min_, this->y_raw_max_);
+  ESP_LOGCONFIG(TAG,
+                "  X Calibration: [%d, %d]\n"
+                "  Y Calibration: [%d, %d]",
+                this->x_raw_min_, this->x_raw_max_, this->y_raw_min_, this->y_raw_max_);
   LOG_UPDATE_INTERVAL(this);
 }
 

--- a/esphome/components/ft63x6/ft63x6.cpp
+++ b/esphome/components/ft63x6/ft63x6.cpp
@@ -71,8 +71,8 @@ void FT63X6Touchscreen::dump_config() {
   LOG_I2C_DEVICE(this);
   LOG_PIN("  Interrupt Pin: ", this->interrupt_pin_);
   LOG_PIN("  Reset Pin: ", this->reset_pin_);
-  ESP_LOGCONFIG(TAG, "  X Calibration: [%d, %d]", this->x_raw_min_, this->x_raw_max_);
-  ESP_LOGCONFIG(TAG, "  Y Calibration: [%d, %d]", this->y_raw_min_, this->y_raw_max_);
+  ESP_LOGCONFIG(TAG, "  X Calibration: [%d, %d]\n  Y Calibration: [%d, %d]", this->x_raw_min_, this->x_raw_max_,
+                this->y_raw_min_, this->y_raw_max_);
   LOG_UPDATE_INTERVAL(this);
 }
 

--- a/esphome/components/gp2y1010au0f/gp2y1010au0f.cpp
+++ b/esphome/components/gp2y1010au0f/gp2y1010au0f.cpp
@@ -13,8 +13,10 @@ static const float MAX_VOLTAGE = 4.0f;
 
 void GP2Y1010AU0FSensor::dump_config() {
   LOG_SENSOR("", "Sharp GP2Y1010AU0F PM2.5 Sensor", this);
-  ESP_LOGCONFIG(TAG, "  Sampling duration: %" PRId32 " ms\n  ADC voltage multiplier: %.3f", this->sample_duration_,
-                this->voltage_multiplier_);
+  ESP_LOGCONFIG(TAG,
+                "  Sampling duration: %" PRId32 " ms\n"
+                "  ADC voltage multiplier: %.3f",
+                this->sample_duration_, this->voltage_multiplier_);
   LOG_UPDATE_INTERVAL(this);
 }
 

--- a/esphome/components/gp2y1010au0f/gp2y1010au0f.cpp
+++ b/esphome/components/gp2y1010au0f/gp2y1010au0f.cpp
@@ -13,8 +13,8 @@ static const float MAX_VOLTAGE = 4.0f;
 
 void GP2Y1010AU0FSensor::dump_config() {
   LOG_SENSOR("", "Sharp GP2Y1010AU0F PM2.5 Sensor", this);
-  ESP_LOGCONFIG(TAG, "  Sampling duration: %" PRId32 " ms", this->sample_duration_);
-  ESP_LOGCONFIG(TAG, "  ADC voltage multiplier: %.3f", this->voltage_multiplier_);
+  ESP_LOGCONFIG(TAG, "  Sampling duration: %" PRId32 " ms\n  ADC voltage multiplier: %.3f", this->sample_duration_,
+                this->voltage_multiplier_);
   LOG_UPDATE_INTERVAL(this);
 }
 

--- a/esphome/components/gp8403/gp8403.cpp
+++ b/esphome/components/gp8403/gp8403.cpp
@@ -12,7 +12,10 @@ static const uint8_t RANGE_REGISTER = 0x01;
 void GP8403::setup() { this->write_register(RANGE_REGISTER, (uint8_t *) (&this->voltage_), 1); }
 
 void GP8403::dump_config() {
-  ESP_LOGCONFIG(TAG, "GP8403:\n  Voltage: %dV", this->voltage_ == GP8403_VOLTAGE_5V ? 5 : 10);
+  ESP_LOGCONFIG(TAG,
+                "GP8403:\n"
+                "  Voltage: %dV",
+                this->voltage_ == GP8403_VOLTAGE_5V ? 5 : 10);
   LOG_I2C_DEVICE(this);
 }
 

--- a/esphome/components/gp8403/gp8403.cpp
+++ b/esphome/components/gp8403/gp8403.cpp
@@ -12,8 +12,7 @@ static const uint8_t RANGE_REGISTER = 0x01;
 void GP8403::setup() { this->write_register(RANGE_REGISTER, (uint8_t *) (&this->voltage_), 1); }
 
 void GP8403::dump_config() {
-  ESP_LOGCONFIG(TAG, "GP8403:");
-  ESP_LOGCONFIG(TAG, "  Voltage: %dV", this->voltage_ == GP8403_VOLTAGE_5V ? 5 : 10);
+  ESP_LOGCONFIG(TAG, "GP8403:\n  Voltage: %dV", this->voltage_ == GP8403_VOLTAGE_5V ? 5 : 10);
   LOG_I2C_DEVICE(this);
 }
 

--- a/esphome/components/gp8403/output/gp8403_output.cpp
+++ b/esphome/components/gp8403/output/gp8403_output.cpp
@@ -9,7 +9,12 @@ static const char *const TAG = "gp8403.output";
 
 static const uint8_t OUTPUT_REGISTER = 0x02;
 
-void GP8403Output::dump_config() { ESP_LOGCONFIG(TAG, "GP8403 Output:\n  Channel: %u", this->channel_); }
+void GP8403Output::dump_config() {
+  ESP_LOGCONFIG(TAG,
+                "GP8403 Output:\n"
+                "  Channel: %u",
+                this->channel_);
+}
 
 void GP8403Output::write_state(float state) {
   uint16_t value = ((uint16_t) (state * 4095)) << 4;

--- a/esphome/components/gp8403/output/gp8403_output.cpp
+++ b/esphome/components/gp8403/output/gp8403_output.cpp
@@ -9,10 +9,7 @@ static const char *const TAG = "gp8403.output";
 
 static const uint8_t OUTPUT_REGISTER = 0x02;
 
-void GP8403Output::dump_config() {
-  ESP_LOGCONFIG(TAG, "GP8403 Output:");
-  ESP_LOGCONFIG(TAG, "  Channel: %u", this->channel_);
-}
+void GP8403Output::dump_config() { ESP_LOGCONFIG(TAG, "GP8403 Output:\n  Channel: %u", this->channel_); }
 
 void GP8403Output::write_state(float state) {
   uint16_t value = ((uint16_t) (state * 4095)) << 4;

--- a/esphome/components/graphical_display_menu/graphical_display_menu.cpp
+++ b/esphome/components/graphical_display_menu/graphical_display_menu.cpp
@@ -37,8 +37,14 @@ void GraphicalDisplayMenu::setup() {
 
 void GraphicalDisplayMenu::dump_config() {
   ESP_LOGCONFIG(TAG,
-                "Graphical Display Menu\nHas Display: %s\nPopup Mode: %s\nAdvanced Drawing Mode: %s\nHas Font: "
-                "%s\nMode: %s\nActive: %s\nMenu items:",
+                "Graphical Display Menu\n"
+                "Has Display: %s\n"
+                "Popup Mode: %s\n"
+                "Advanced Drawing Mode: %s\n"
+                "Has Font: %s\n"
+                "Mode: %s\n"
+                "Active: %s\n"
+                "Menu items:",
                 YESNO(this->display_ != nullptr), YESNO(this->display_ != nullptr), YESNO(this->display_ == nullptr),
                 YESNO(this->font_ != nullptr),
                 this->mode_ == display_menu_base::MENU_MODE_ROTARY ? "Rotary" : "Joystick", YESNO(this->active_));

--- a/esphome/components/graphical_display_menu/graphical_display_menu.cpp
+++ b/esphome/components/graphical_display_menu/graphical_display_menu.cpp
@@ -36,14 +36,12 @@ void GraphicalDisplayMenu::setup() {
 }
 
 void GraphicalDisplayMenu::dump_config() {
-  ESP_LOGCONFIG(TAG, "Graphical Display Menu");
-  ESP_LOGCONFIG(TAG, "Has Display: %s", YESNO(this->display_ != nullptr));
-  ESP_LOGCONFIG(TAG, "Popup Mode: %s", YESNO(this->display_ != nullptr));
-  ESP_LOGCONFIG(TAG, "Advanced Drawing Mode: %s", YESNO(this->display_ == nullptr));
-  ESP_LOGCONFIG(TAG, "Has Font: %s", YESNO(this->font_ != nullptr));
-  ESP_LOGCONFIG(TAG, "Mode: %s", this->mode_ == display_menu_base::MENU_MODE_ROTARY ? "Rotary" : "Joystick");
-  ESP_LOGCONFIG(TAG, "Active: %s", YESNO(this->active_));
-  ESP_LOGCONFIG(TAG, "Menu items:");
+  ESP_LOGCONFIG(TAG,
+                "Graphical Display Menu\nHas Display: %s\nPopup Mode: %s\nAdvanced Drawing Mode: %s\nHas Font: "
+                "%s\nMode: %s\nActive: %s\nMenu items:",
+                YESNO(this->display_ != nullptr), YESNO(this->display_ != nullptr), YESNO(this->display_ == nullptr),
+                YESNO(this->font_ != nullptr),
+                this->mode_ == display_menu_base::MENU_MODE_ROTARY ? "Rotary" : "Joystick", YESNO(this->active_));
   for (size_t i = 0; i < this->displayed_item_->items_size(); i++) {
     auto *item = this->displayed_item_->get_item(i);
     ESP_LOGCONFIG(TAG, "  %i: %s (Type: %s, Immediate Edit: %s)", i, item->get_text().c_str(),

--- a/esphome/components/growatt_solar/growatt_solar.cpp
+++ b/esphome/components/growatt_solar/growatt_solar.cpp
@@ -133,10 +133,7 @@ void GrowattSolar::on_modbus_data(const std::vector<uint8_t> &data) {
   }
 }
 
-void GrowattSolar::dump_config() {
-  ESP_LOGCONFIG(TAG, "GROWATT Solar:");
-  ESP_LOGCONFIG(TAG, "  Address: 0x%02X", this->address_);
-}
+void GrowattSolar::dump_config() { ESP_LOGCONFIG(TAG, "GROWATT Solar:\n  Address: 0x%02X", this->address_); }
 
 }  // namespace growatt_solar
 }  // namespace esphome

--- a/esphome/components/growatt_solar/growatt_solar.cpp
+++ b/esphome/components/growatt_solar/growatt_solar.cpp
@@ -133,7 +133,12 @@ void GrowattSolar::on_modbus_data(const std::vector<uint8_t> &data) {
   }
 }
 
-void GrowattSolar::dump_config() { ESP_LOGCONFIG(TAG, "GROWATT Solar:\n  Address: 0x%02X", this->address_); }
+void GrowattSolar::dump_config() {
+  ESP_LOGCONFIG(TAG,
+                "GROWATT Solar:\n"
+                "  Address: 0x%02X",
+                this->address_);
+}
 
 }  // namespace growatt_solar
 }  // namespace esphome

--- a/esphome/components/haier/hon_climate.cpp
+++ b/esphome/components/haier/hon_climate.cpp
@@ -345,8 +345,10 @@ void HonClimate::dump_config() {
                 (uint8_t) this->control_method_);
   if (this->hvac_hardware_info_.has_value()) {
     ESP_LOGCONFIG(TAG,
-                  "  Device protocol version: %s\n  Device software version: %s\n  Device hardware version: %s\n  "
-                  "Device name: %s",
+                  "  Device protocol version: %s\n"
+                  "  Device software version: %s\n"
+                  "  Device hardware version: %s\n"
+                  "  Device name: %s",
                   this->hvac_hardware_info_.value().protocol_version_.c_str(),
                   this->hvac_hardware_info_.value().software_version_.c_str(),
                   this->hvac_hardware_info_.value().hardware_version_.c_str(),

--- a/esphome/components/haier/hon_climate.cpp
+++ b/esphome/components/haier/hon_climate.cpp
@@ -339,7 +339,10 @@ void HonClimate::set_handlers() {
 
 void HonClimate::dump_config() {
   HaierClimateBase::dump_config();
-  ESP_LOGCONFIG(TAG, "  Protocol version: hOn\n  Control method: %d", (uint8_t) this->control_method_);
+  ESP_LOGCONFIG(TAG,
+                "  Protocol version: hOn\n"
+                "  Control method: %d",
+                (uint8_t) this->control_method_);
   if (this->hvac_hardware_info_.has_value()) {
     ESP_LOGCONFIG(TAG,
                   "  Device protocol version: %s\n  Device software version: %s\n  Device hardware version: %s\n  "

--- a/esphome/components/haier/hon_climate.cpp
+++ b/esphome/components/haier/hon_climate.cpp
@@ -339,8 +339,7 @@ void HonClimate::set_handlers() {
 
 void HonClimate::dump_config() {
   HaierClimateBase::dump_config();
-  ESP_LOGCONFIG(TAG, "  Protocol version: hOn");
-  ESP_LOGCONFIG(TAG, "  Control method: %d", (uint8_t) this->control_method_);
+  ESP_LOGCONFIG(TAG, "  Protocol version: hOn\n  Control method: %d", (uint8_t) this->control_method_);
   if (this->hvac_hardware_info_.has_value()) {
     ESP_LOGCONFIG(TAG, "  Device protocol version: %s", this->hvac_hardware_info_.value().protocol_version_.c_str());
     ESP_LOGCONFIG(TAG, "  Device software version: %s", this->hvac_hardware_info_.value().software_version_.c_str());

--- a/esphome/components/haier/hon_climate.cpp
+++ b/esphome/components/haier/hon_climate.cpp
@@ -341,10 +341,13 @@ void HonClimate::dump_config() {
   HaierClimateBase::dump_config();
   ESP_LOGCONFIG(TAG, "  Protocol version: hOn\n  Control method: %d", (uint8_t) this->control_method_);
   if (this->hvac_hardware_info_.has_value()) {
-    ESP_LOGCONFIG(TAG, "  Device protocol version: %s", this->hvac_hardware_info_.value().protocol_version_.c_str());
-    ESP_LOGCONFIG(TAG, "  Device software version: %s", this->hvac_hardware_info_.value().software_version_.c_str());
-    ESP_LOGCONFIG(TAG, "  Device hardware version: %s", this->hvac_hardware_info_.value().hardware_version_.c_str());
-    ESP_LOGCONFIG(TAG, "  Device name: %s", this->hvac_hardware_info_.value().device_name_.c_str());
+    ESP_LOGCONFIG(TAG,
+                  "  Device protocol version: %s\n  Device software version: %s\n  Device hardware version: %s\n  "
+                  "Device name: %s",
+                  this->hvac_hardware_info_.value().protocol_version_.c_str(),
+                  this->hvac_hardware_info_.value().software_version_.c_str(),
+                  this->hvac_hardware_info_.value().hardware_version_.c_str(),
+                  this->hvac_hardware_info_.value().device_name_.c_str());
     ESP_LOGCONFIG(TAG, "  Device features:%s%s%s%s%s",
                   (this->hvac_hardware_info_.value().functions_[0] ? " interactive" : ""),
                   (this->hvac_hardware_info_.value().functions_[1] ? " controller-device" : ""),

--- a/esphome/components/havells_solar/havells_solar.cpp
+++ b/esphome/components/havells_solar/havells_solar.cpp
@@ -123,8 +123,7 @@ void HavellsSolar::on_modbus_data(const std::vector<uint8_t> &data) {
 
 void HavellsSolar::update() { this->send(MODBUS_CMD_READ_IN_REGISTERS, 0, MODBUS_REGISTER_COUNT); }
 void HavellsSolar::dump_config() {
-  ESP_LOGCONFIG(TAG, "HAVELLS Solar:");
-  ESP_LOGCONFIG(TAG, "  Address: 0x%02X", this->address_);
+  ESP_LOGCONFIG(TAG, "HAVELLS Solar:\n  Address: 0x%02X", this->address_);
   for (uint8_t i = 0; i < 3; i++) {
     auto phase = this->phases_[i];
     if (!phase.setup)

--- a/esphome/components/havells_solar/havells_solar.cpp
+++ b/esphome/components/havells_solar/havells_solar.cpp
@@ -123,7 +123,10 @@ void HavellsSolar::on_modbus_data(const std::vector<uint8_t> &data) {
 
 void HavellsSolar::update() { this->send(MODBUS_CMD_READ_IN_REGISTERS, 0, MODBUS_REGISTER_COUNT); }
 void HavellsSolar::dump_config() {
-  ESP_LOGCONFIG(TAG, "HAVELLS Solar:\n  Address: 0x%02X", this->address_);
+  ESP_LOGCONFIG(TAG,
+                "HAVELLS Solar:\n"
+                "  Address: 0x%02X",
+                this->address_);
   for (uint8_t i = 0; i < 3; i++) {
     auto phase = this->phases_[i];
     if (!phase.setup)

--- a/esphome/components/he60r/he60r.cpp
+++ b/esphome/components/he60r/he60r.cpp
@@ -40,8 +40,10 @@ CoverTraits HE60rCover::get_traits() {
 void HE60rCover::dump_config() {
   LOG_COVER("", "HE60R Cover", this);
   this->check_uart_settings(1200, 1, uart::UART_CONFIG_PARITY_EVEN, 8);
-  ESP_LOGCONFIG(TAG, "  Open Duration: %.1fs\n  Close Duration: %.1fs", this->open_duration_ / 1e3f,
-                this->close_duration_ / 1e3f);
+  ESP_LOGCONFIG(TAG,
+                "  Open Duration: %.1fs\n"
+                "  Close Duration: %.1fs",
+                this->open_duration_ / 1e3f, this->close_duration_ / 1e3f);
   auto restore = this->restore_state_();
   if (restore.has_value())
     ESP_LOGCONFIG(TAG, "  Saved position %d%%", (int) (restore->position * 100.f));

--- a/esphome/components/he60r/he60r.cpp
+++ b/esphome/components/he60r/he60r.cpp
@@ -40,8 +40,8 @@ CoverTraits HE60rCover::get_traits() {
 void HE60rCover::dump_config() {
   LOG_COVER("", "HE60R Cover", this);
   this->check_uart_settings(1200, 1, uart::UART_CONFIG_PARITY_EVEN, 8);
-  ESP_LOGCONFIG(TAG, "  Open Duration: %.1fs", this->open_duration_ / 1e3f);
-  ESP_LOGCONFIG(TAG, "  Close Duration: %.1fs", this->close_duration_ / 1e3f);
+  ESP_LOGCONFIG(TAG, "  Open Duration: %.1fs\n  Close Duration: %.1fs", this->open_duration_ / 1e3f,
+                this->close_duration_ / 1e3f);
   auto restore = this->restore_state_();
   if (restore.has_value())
     ESP_LOGCONFIG(TAG, "  Saved position %d%%", (int) (restore->position * 100.f));

--- a/esphome/components/hlw8012/hlw8012.cpp
+++ b/esphome/components/hlw8012/hlw8012.cpp
@@ -39,7 +39,9 @@ void HLW8012Component::dump_config() {
   LOG_PIN("  CF Pin: ", this->cf_pin_)
   LOG_PIN("  CF1 Pin: ", this->cf1_pin_)
   ESP_LOGCONFIG(TAG,
-                "  Change measurement mode every %" PRIu32 "\n  Current resistor: %.1f mΩ\n  Voltage Divider: %.1f",
+                "  Change measurement mode every %" PRIu32 "\n"
+                "  Current resistor: %.1f mΩ\n"
+                "  Voltage Divider: %.1f",
                 this->change_mode_every_, this->current_resistor_ * 1000.0f, this->voltage_divider_);
   LOG_UPDATE_INTERVAL(this)
   LOG_SENSOR("  ", "Voltage", this->voltage_sensor_)

--- a/esphome/components/hlw8012/hlw8012.cpp
+++ b/esphome/components/hlw8012/hlw8012.cpp
@@ -38,9 +38,9 @@ void HLW8012Component::dump_config() {
   LOG_PIN("  SEL Pin: ", this->sel_pin_)
   LOG_PIN("  CF Pin: ", this->cf_pin_)
   LOG_PIN("  CF1 Pin: ", this->cf1_pin_)
-  ESP_LOGCONFIG(TAG, "  Change measurement mode every %" PRIu32, this->change_mode_every_);
-  ESP_LOGCONFIG(TAG, "  Current resistor: %.1f mΩ", this->current_resistor_ * 1000.0f);
-  ESP_LOGCONFIG(TAG, "  Voltage Divider: %.1f", this->voltage_divider_);
+  ESP_LOGCONFIG(TAG,
+                "  Change measurement mode every %" PRIu32 "\n  Current resistor: %.1f mΩ\n  Voltage Divider: %.1f",
+                this->change_mode_every_, this->current_resistor_ * 1000.0f, this->voltage_divider_);
   LOG_UPDATE_INTERVAL(this)
   LOG_SENSOR("  ", "Voltage", this->voltage_sensor_)
   LOG_SENSOR("  ", "Current", this->current_sensor_)

--- a/esphome/components/homeassistant/time/homeassistant_time.cpp
+++ b/esphome/components/homeassistant/time/homeassistant_time.cpp
@@ -7,7 +7,10 @@ namespace homeassistant {
 static const char *const TAG = "homeassistant.time";
 
 void HomeassistantTime::dump_config() {
-  ESP_LOGCONFIG(TAG, "Home Assistant Time:\n  Timezone: '%s'", this->timezone_.c_str());
+  ESP_LOGCONFIG(TAG,
+                "Home Assistant Time:\n"
+                "  Timezone: '%s'",
+                this->timezone_.c_str());
 }
 
 float HomeassistantTime::get_setup_priority() const { return setup_priority::DATA; }

--- a/esphome/components/homeassistant/time/homeassistant_time.cpp
+++ b/esphome/components/homeassistant/time/homeassistant_time.cpp
@@ -7,8 +7,7 @@ namespace homeassistant {
 static const char *const TAG = "homeassistant.time";
 
 void HomeassistantTime::dump_config() {
-  ESP_LOGCONFIG(TAG, "Home Assistant Time:");
-  ESP_LOGCONFIG(TAG, "  Timezone: '%s'", this->timezone_.c_str());
+  ESP_LOGCONFIG(TAG, "Home Assistant Time:\n  Timezone: '%s'", this->timezone_.c_str());
 }
 
 float HomeassistantTime::get_setup_priority() const { return setup_priority::DATA; }

--- a/esphome/components/honeywellabp/honeywellabp.cpp
+++ b/esphome/components/honeywellabp/honeywellabp.cpp
@@ -85,8 +85,8 @@ float HONEYWELLABPSensor::get_setup_priority() const { return setup_priority::LA
 void HONEYWELLABPSensor::dump_config() {
   //  LOG_SENSOR("", "HONEYWELLABP", this);
   LOG_PIN("  CS Pin: ", this->cs_);
-  ESP_LOGCONFIG(TAG, "  Min Pressure Range: %0.1f", honeywellabp_min_pressure_);
-  ESP_LOGCONFIG(TAG, "  Max Pressure Range: %0.1f", honeywellabp_max_pressure_);
+  ESP_LOGCONFIG(TAG, "  Min Pressure Range: %0.1f\n  Max Pressure Range: %0.1f", honeywellabp_min_pressure_,
+                honeywellabp_max_pressure_);
   LOG_UPDATE_INTERVAL(this);
 }
 

--- a/esphome/components/honeywellabp/honeywellabp.cpp
+++ b/esphome/components/honeywellabp/honeywellabp.cpp
@@ -85,8 +85,10 @@ float HONEYWELLABPSensor::get_setup_priority() const { return setup_priority::LA
 void HONEYWELLABPSensor::dump_config() {
   //  LOG_SENSOR("", "HONEYWELLABP", this);
   LOG_PIN("  CS Pin: ", this->cs_);
-  ESP_LOGCONFIG(TAG, "  Min Pressure Range: %0.1f\n  Max Pressure Range: %0.1f", honeywellabp_min_pressure_,
-                honeywellabp_max_pressure_);
+  ESP_LOGCONFIG(TAG,
+                "  Min Pressure Range: %0.1f\n"
+                "  Max Pressure Range: %0.1f",
+                honeywellabp_min_pressure_, honeywellabp_max_pressure_);
   LOG_UPDATE_INTERVAL(this);
 }
 

--- a/esphome/components/honeywellabp2_i2c/honeywellabp2.cpp
+++ b/esphome/components/honeywellabp2_i2c/honeywellabp2.cpp
@@ -84,8 +84,8 @@ void HONEYWELLABP2Sensor::update() {
 }
 
 void HONEYWELLABP2Sensor::dump_config() {
-  ESP_LOGCONFIG(TAG, "  Min Pressure Range: %0.1f", this->min_pressure_);
-  ESP_LOGCONFIG(TAG, "  Max Pressure Range: %0.1f", this->max_pressure_);
+  ESP_LOGCONFIG(TAG, "  Min Pressure Range: %0.1f\n  Max Pressure Range: %0.1f", this->min_pressure_,
+                this->max_pressure_);
   if (this->transfer_function_ == ABP2_TRANS_FUNC_A) {
     ESP_LOGCONFIG(TAG, "  Transfer function A");
   } else {

--- a/esphome/components/honeywellabp2_i2c/honeywellabp2.cpp
+++ b/esphome/components/honeywellabp2_i2c/honeywellabp2.cpp
@@ -84,8 +84,10 @@ void HONEYWELLABP2Sensor::update() {
 }
 
 void HONEYWELLABP2Sensor::dump_config() {
-  ESP_LOGCONFIG(TAG, "  Min Pressure Range: %0.1f\n  Max Pressure Range: %0.1f", this->min_pressure_,
-                this->max_pressure_);
+  ESP_LOGCONFIG(TAG,
+                "  Min Pressure Range: %0.1f\n"
+                "  Max Pressure Range: %0.1f",
+                this->min_pressure_, this->max_pressure_);
   if (this->transfer_function_ == ABP2_TRANS_FUNC_A) {
     ESP_LOGCONFIG(TAG, "  Transfer function A");
   } else {

--- a/esphome/components/http_request/http_request.cpp
+++ b/esphome/components/http_request/http_request.cpp
@@ -10,11 +10,8 @@ namespace http_request {
 static const char *const TAG = "http_request";
 
 void HttpRequestComponent::dump_config() {
-  ESP_LOGCONFIG(TAG, "HTTP Request:");
-  ESP_LOGCONFIG(TAG, "  Timeout: %ums", this->timeout_);
-  ESP_LOGCONFIG(TAG, "  User-Agent: %s", this->useragent_);
-  ESP_LOGCONFIG(TAG, "  Follow redirects: %s", YESNO(this->follow_redirects_));
-  ESP_LOGCONFIG(TAG, "  Redirect limit: %d", this->redirect_limit_);
+  ESP_LOGCONFIG(TAG, "HTTP Request:\n  Timeout: %ums\n  User-Agent: %s\n  Follow redirects: %s\n  Redirect limit: %d",
+                this->timeout_, this->useragent_, YESNO(this->follow_redirects_), this->redirect_limit_);
   if (this->watchdog_timeout_ > 0) {
     ESP_LOGCONFIG(TAG, "  Watchdog Timeout: %" PRIu32 "ms", this->watchdog_timeout_);
   }

--- a/esphome/components/http_request/http_request.cpp
+++ b/esphome/components/http_request/http_request.cpp
@@ -10,7 +10,12 @@ namespace http_request {
 static const char *const TAG = "http_request";
 
 void HttpRequestComponent::dump_config() {
-  ESP_LOGCONFIG(TAG, "HTTP Request:\n  Timeout: %ums\n  User-Agent: %s\n  Follow redirects: %s\n  Redirect limit: %d",
+  ESP_LOGCONFIG(TAG,
+                "HTTP Request:\n"
+                "  Timeout: %ums\n"
+                "  User-Agent: %s\n"
+                "  Follow redirects: %s\n"
+                "  Redirect limit: %d",
                 this->timeout_, this->useragent_, YESNO(this->follow_redirects_), this->redirect_limit_);
   if (this->watchdog_timeout_ > 0) {
     ESP_LOGCONFIG(TAG, "  Watchdog Timeout: %" PRIu32 "ms", this->watchdog_timeout_);

--- a/esphome/components/http_request/http_request_idf.cpp
+++ b/esphome/components/http_request/http_request_idf.cpp
@@ -26,8 +26,7 @@ struct UserData {
 
 void HttpRequestIDF::dump_config() {
   HttpRequestComponent::dump_config();
-  ESP_LOGCONFIG(TAG, "  Buffer Size RX: %u", this->buffer_size_rx_);
-  ESP_LOGCONFIG(TAG, "  Buffer Size TX: %u", this->buffer_size_tx_);
+  ESP_LOGCONFIG(TAG, "  Buffer Size RX: %u\n  Buffer Size TX: %u", this->buffer_size_rx_, this->buffer_size_tx_);
 }
 
 esp_err_t HttpRequestIDF::http_event_handler(esp_http_client_event_t *evt) {

--- a/esphome/components/http_request/http_request_idf.cpp
+++ b/esphome/components/http_request/http_request_idf.cpp
@@ -26,7 +26,10 @@ struct UserData {
 
 void HttpRequestIDF::dump_config() {
   HttpRequestComponent::dump_config();
-  ESP_LOGCONFIG(TAG, "  Buffer Size RX: %u\n  Buffer Size TX: %u", this->buffer_size_rx_, this->buffer_size_tx_);
+  ESP_LOGCONFIG(TAG,
+                "  Buffer Size RX: %u\n"
+                "  Buffer Size TX: %u",
+                this->buffer_size_rx_, this->buffer_size_tx_);
 }
 
 esp_err_t HttpRequestIDF::http_event_handler(esp_http_client_event_t *evt) {

--- a/esphome/components/hydreon_rgxx/hydreon_rgxx.cpp
+++ b/esphome/components/hydreon_rgxx/hydreon_rgxx.cpp
@@ -18,7 +18,10 @@ void HydreonRGxxComponent::dump_config() {
     ESP_LOGE(TAG, "Connection with hydreon_rgxx failed!");
   }
   if (model_ == RG9) {
-    ESP_LOGCONFIG(TAG, "  Model: RG9\n  Disable Led: %s", TRUEFALSE(this->disable_led_));
+    ESP_LOGCONFIG(TAG,
+                  "  Model: RG9\n"
+                  "  Disable Led: %s",
+                  TRUEFALSE(this->disable_led_));
   } else {
     ESP_LOGCONFIG(TAG, "  Model: RG15");
     if (this->resolution_ == FORCE_HIGH) {

--- a/esphome/components/hydreon_rgxx/hydreon_rgxx.cpp
+++ b/esphome/components/hydreon_rgxx/hydreon_rgxx.cpp
@@ -18,8 +18,7 @@ void HydreonRGxxComponent::dump_config() {
     ESP_LOGE(TAG, "Connection with hydreon_rgxx failed!");
   }
   if (model_ == RG9) {
-    ESP_LOGCONFIG(TAG, "  Model: RG9");
-    ESP_LOGCONFIG(TAG, "  Disable Led: %s", TRUEFALSE(this->disable_led_));
+    ESP_LOGCONFIG(TAG, "  Model: RG9\n  Disable Led: %s", TRUEFALSE(this->disable_led_));
   } else {
     ESP_LOGCONFIG(TAG, "  Model: RG15");
     if (this->resolution_ == FORCE_HIGH) {

--- a/esphome/components/i2c/i2c_bus_arduino.cpp
+++ b/esphome/components/i2c/i2c_bus_arduino.cpp
@@ -70,9 +70,11 @@ void ArduinoI2CBus::set_pins_and_clock_() {
 
 void ArduinoI2CBus::dump_config() {
   ESP_LOGCONFIG(TAG, "I2C Bus:");
-  ESP_LOGCONFIG(TAG, "  SDA Pin: GPIO%u", this->sda_pin_);
-  ESP_LOGCONFIG(TAG, "  SCL Pin: GPIO%u", this->scl_pin_);
-  ESP_LOGCONFIG(TAG, "  Frequency: %u Hz", this->frequency_);
+  ESP_LOGCONFIG(TAG,
+                "  SDA Pin: GPIO%u\n"
+                "  SCL Pin: GPIO%u\n"
+                "  Frequency: %u Hz",
+                this->sda_pin_, this->scl_pin_, this->frequency_);
   if (timeout_ > 0) {
 #if defined(USE_ESP32)
     ESP_LOGCONFIG(TAG, "  Timeout: %u ms", this->timeout_ / 1000);

--- a/esphome/components/i2c/i2c_bus_esp_idf.cpp
+++ b/esphome/components/i2c/i2c_bus_esp_idf.cpp
@@ -81,9 +81,11 @@ void IDFI2CBus::setup() {
 }
 void IDFI2CBus::dump_config() {
   ESP_LOGCONFIG(TAG, "I2C Bus:");
-  ESP_LOGCONFIG(TAG, "  SDA Pin: GPIO%u", this->sda_pin_);
-  ESP_LOGCONFIG(TAG, "  SCL Pin: GPIO%u", this->scl_pin_);
-  ESP_LOGCONFIG(TAG, "  Frequency: %" PRIu32 " Hz", this->frequency_);
+  ESP_LOGCONFIG(TAG,
+                "  SDA Pin: GPIO%u\n"
+                "  SCL Pin: GPIO%u\n"
+                "  Frequency: %" PRIu32 " Hz",
+                this->sda_pin_, this->scl_pin_, this->frequency_);
   if (timeout_ > 0) {
     ESP_LOGCONFIG(TAG, "  Timeout: %" PRIu32 "us", this->timeout_);
   }

--- a/esphome/components/i2s_audio/media_player/i2s_audio_media_player.cpp
+++ b/esphome/components/i2s_audio/media_player/i2s_audio_media_player.cpp
@@ -244,8 +244,8 @@ void I2SAudioMediaPlayer::dump_config() {
     }
   } else {
 #endif
-    ESP_LOGCONFIG(TAG, "  External DAC channels: %d", this->external_dac_channels_);
-    ESP_LOGCONFIG(TAG, "  I2S DOUT Pin: %d", this->dout_pin_);
+    ESP_LOGCONFIG(TAG, "  External DAC channels: %d\n  I2S DOUT Pin: %d", this->external_dac_channels_,
+                  this->dout_pin_);
     LOG_PIN("  Mute Pin: ", this->mute_pin_);
 #if SOC_I2S_SUPPORTS_DAC
   }

--- a/esphome/components/i2s_audio/media_player/i2s_audio_media_player.cpp
+++ b/esphome/components/i2s_audio/media_player/i2s_audio_media_player.cpp
@@ -244,8 +244,10 @@ void I2SAudioMediaPlayer::dump_config() {
     }
   } else {
 #endif
-    ESP_LOGCONFIG(TAG, "  External DAC channels: %d\n  I2S DOUT Pin: %d", this->external_dac_channels_,
-                  this->dout_pin_);
+    ESP_LOGCONFIG(TAG,
+                  "  External DAC channels: %d\n"
+                  "  I2S DOUT Pin: %d",
+                  this->external_dac_channels_, this->dout_pin_);
     LOG_PIN("  Mute Pin: ", this->mute_pin_);
 #if SOC_I2S_SUPPORTS_DAC
   }

--- a/esphome/components/ili9xxx/ili9xxx_display.cpp
+++ b/esphome/components/ili9xxx/ili9xxx_display.cpp
@@ -89,8 +89,10 @@ void ILI9XXXDisplay::setup_pins_() {
 
 void ILI9XXXDisplay::dump_config() {
   LOG_DISPLAY("", "ili9xxx", this);
-  ESP_LOGCONFIG(TAG, "  Width Offset: %u", this->offset_x_);
-  ESP_LOGCONFIG(TAG, "  Height Offset: %u", this->offset_y_);
+  ESP_LOGCONFIG(TAG,
+                "  Width Offset: %u\n"
+                "  Height Offset: %u",
+                this->offset_x_, this->offset_y_);
   switch (this->buffer_color_mode_) {
     case BITS_8_INDEXED:
       ESP_LOGCONFIG(TAG, "  Color mode: 8bit Indexed");
@@ -111,11 +113,14 @@ void ILI9XXXDisplay::dump_config() {
   LOG_PIN("  CS Pin: ", this->cs_);
   LOG_PIN("  DC Pin: ", this->dc_pin_);
   LOG_PIN("  Busy Pin: ", this->busy_pin_);
-  ESP_LOGCONFIG(TAG, "  Color order: %s", this->color_order_ == display::COLOR_ORDER_BGR ? "BGR" : "RGB");
-  ESP_LOGCONFIG(TAG, "  Swap_xy: %s", YESNO(this->swap_xy_));
-  ESP_LOGCONFIG(TAG, "  Mirror_x: %s", YESNO(this->mirror_x_));
-  ESP_LOGCONFIG(TAG, "  Mirror_y: %s", YESNO(this->mirror_y_));
-  ESP_LOGCONFIG(TAG, "  Invert colors: %s", YESNO(this->pre_invertcolors_));
+  ESP_LOGCONFIG(TAG,
+                "  Color order: %s\n"
+                "  Swap_xy: %s\n"
+                "  Mirror_x: %s\n"
+                "  Mirror_y: %s\n"
+                "  Invert colors: %s",
+                this->color_order_ == display::COLOR_ORDER_BGR ? "BGR" : "RGB", YESNO(this->swap_xy_),
+                YESNO(this->mirror_x_), YESNO(this->mirror_y_), YESNO(this->pre_invertcolors_));
 
   if (this->is_failed()) {
     ESP_LOGCONFIG(TAG, "  => Failed to init Memory: YES!");

--- a/esphome/components/ina226/ina226.cpp
+++ b/esphome/components/ina226/ina226.cpp
@@ -93,9 +93,12 @@ void INA226Component::dump_config() {
   }
   LOG_UPDATE_INTERVAL(this);
 
-  ESP_LOGCONFIG(TAG, "  ADC Conversion Time Bus Voltage: %d", INA226_ADC_TIMES[this->adc_time_voltage_ & 0b111]);
-  ESP_LOGCONFIG(TAG, "  ADC Conversion Time Shunt Voltage: %d", INA226_ADC_TIMES[this->adc_time_current_ & 0b111]);
-  ESP_LOGCONFIG(TAG, "  ADC Averaging Samples: %d", INA226_ADC_AVG_SAMPLES[this->adc_avg_samples_ & 0b111]);
+  ESP_LOGCONFIG(TAG,
+                "  ADC Conversion Time Bus Voltage: %d\n"
+                "  ADC Conversion Time Shunt Voltage: %d\n"
+                "  ADC Averaging Samples: %d",
+                INA226_ADC_TIMES[this->adc_time_voltage_ & 0b111], INA226_ADC_TIMES[this->adc_time_current_ & 0b111],
+                INA226_ADC_AVG_SAMPLES[this->adc_avg_samples_ & 0b111]);
 
   LOG_SENSOR("  ", "Bus Voltage", this->bus_voltage_sensor_);
   LOG_SENSOR("  ", "Shunt Voltage", this->shunt_voltage_sensor_);

--- a/esphome/components/ina2xx_base/ina2xx_base.cpp
+++ b/esphome/components/ina2xx_base/ina2xx_base.cpp
@@ -206,12 +206,16 @@ void INA2XX::dump_config() {
     ESP_LOGE(TAG, ESP_LOG_MSG_COMM_FAIL);
   }
   LOG_UPDATE_INTERVAL(this);
-  ESP_LOGCONFIG(TAG, "  Shunt resistance = %f Ohm", this->shunt_resistance_ohm_);
-  ESP_LOGCONFIG(TAG, "  Max current = %f A", this->max_current_a_);
-  ESP_LOGCONFIG(TAG, "  Shunt temp coeff = %d ppm/°C", this->shunt_tempco_ppm_c_);
-  ESP_LOGCONFIG(TAG, "  ADCRANGE = %d (%s)", (uint8_t) this->adc_range_, this->adc_range_ ? "±40.96 mV" : "±163.84 mV");
-  ESP_LOGCONFIG(TAG, "  CURRENT_LSB = %f", this->current_lsb_);
-  ESP_LOGCONFIG(TAG, "  SHUNT_CAL = %d", this->shunt_cal_);
+  ESP_LOGCONFIG(TAG,
+                "  Shunt resistance = %f Ohm\n"
+                "  Max current = %f A\n"
+                "  Shunt temp coeff = %d ppm/°C\n"
+                "  ADCRANGE = %d (%s)\n"
+                "  CURRENT_LSB = %f\n"
+                "  SHUNT_CAL = %d",
+                this->shunt_resistance_ohm_, this->max_current_a_, this->shunt_tempco_ppm_c_,
+                (uint8_t) this->adc_range_, this->adc_range_ ? "±40.96 mV" : "±163.84 mV", this->current_lsb_,
+                this->shunt_cal_);
 
   ESP_LOGCONFIG(TAG, "  ADC Samples = %d; ADC times: Bus = %d μs, Shunt = %d μs, Temp = %d μs",
                 ADC_SAMPLES[0b111 & (uint8_t) this->adc_avg_samples_],

--- a/esphome/components/inkplate6/inkplate.cpp
+++ b/esphome/components/inkplate6/inkplate.cpp
@@ -186,8 +186,11 @@ void HOT Inkplate6::draw_absolute_pixel_internal(int x, int y, Color color) {
 
 void Inkplate6::dump_config() {
   LOG_DISPLAY("", "Inkplate", this);
-  ESP_LOGCONFIG(TAG, "  Greyscale: %s\n  Partial Updating: %s\n  Full Update Every: %d", YESNO(this->greyscale_),
-                YESNO(this->partial_updating_), this->full_update_every_);
+  ESP_LOGCONFIG(TAG,
+                "  Greyscale: %s\n"
+                "  Partial Updating: %s\n"
+                "  Full Update Every: %d",
+                YESNO(this->greyscale_), YESNO(this->partial_updating_), this->full_update_every_);
   // Log pins
   LOG_PIN("  CKV Pin: ", this->ckv_pin_);
   LOG_PIN("  CL Pin: ", this->cl_pin_);

--- a/esphome/components/inkplate6/inkplate.cpp
+++ b/esphome/components/inkplate6/inkplate.cpp
@@ -186,9 +186,8 @@ void HOT Inkplate6::draw_absolute_pixel_internal(int x, int y, Color color) {
 
 void Inkplate6::dump_config() {
   LOG_DISPLAY("", "Inkplate", this);
-  ESP_LOGCONFIG(TAG, "  Greyscale: %s", YESNO(this->greyscale_));
-  ESP_LOGCONFIG(TAG, "  Partial Updating: %s", YESNO(this->partial_updating_));
-  ESP_LOGCONFIG(TAG, "  Full Update Every: %d", this->full_update_every_);
+  ESP_LOGCONFIG(TAG, "  Greyscale: %s\n  Partial Updating: %s\n  Full Update Every: %d", YESNO(this->greyscale_),
+                YESNO(this->partial_updating_), this->full_update_every_);
   // Log pins
   LOG_PIN("  CKV Pin: ", this->ckv_pin_);
   LOG_PIN("  CL Pin: ", this->cl_pin_);

--- a/esphome/components/key_collector/key_collector.cpp
+++ b/esphome/components/key_collector/key_collector.cpp
@@ -32,8 +32,10 @@ void KeyCollector::dump_config() {
   if (!this->start_keys_.empty())
     ESP_LOGCONFIG(TAG, "  start keys '%s'", this->start_keys_.c_str());
   if (!this->end_keys_.empty()) {
-    ESP_LOGCONFIG(TAG, "  end keys '%s'\n  end key is required: %s", this->end_keys_.c_str(),
-                  ONOFF(this->end_key_required_));
+    ESP_LOGCONFIG(TAG,
+                  "  end keys '%s'\n"
+                  "  end key is required: %s",
+                  this->end_keys_.c_str(), ONOFF(this->end_key_required_));
   }
   if (!this->allowed_keys_.empty())
     ESP_LOGCONFIG(TAG, "  allowed keys '%s'", this->allowed_keys_.c_str());

--- a/esphome/components/key_collector/key_collector.cpp
+++ b/esphome/components/key_collector/key_collector.cpp
@@ -32,8 +32,8 @@ void KeyCollector::dump_config() {
   if (!this->start_keys_.empty())
     ESP_LOGCONFIG(TAG, "  start keys '%s'", this->start_keys_.c_str());
   if (!this->end_keys_.empty()) {
-    ESP_LOGCONFIG(TAG, "  end keys '%s'", this->end_keys_.c_str());
-    ESP_LOGCONFIG(TAG, "  end key is required: %s", ONOFF(this->end_key_required_));
+    ESP_LOGCONFIG(TAG, "  end keys '%s'\n  end key is required: %s", this->end_keys_.c_str(),
+                  ONOFF(this->end_key_required_));
   }
   if (!this->allowed_keys_.empty())
     ESP_LOGCONFIG(TAG, "  allowed keys '%s'", this->allowed_keys_.c_str());

--- a/esphome/components/kuntze/kuntze.cpp
+++ b/esphome/components/kuntze/kuntze.cpp
@@ -77,8 +77,7 @@ void Kuntze::loop() {
 void Kuntze::update() { this->state_ = 1; }
 
 void Kuntze::dump_config() {
-  ESP_LOGCONFIG(TAG, "Kuntze:");
-  ESP_LOGCONFIG(TAG, "  Address: 0x%02X", this->address_);
+  ESP_LOGCONFIG(TAG, "Kuntze:\n  Address: 0x%02X", this->address_);
   LOG_SENSOR("", "pH", this->ph_sensor_);
   LOG_SENSOR("", "temperature", this->temperature_sensor_);
   LOG_SENSOR("", "DIS1", this->dis1_sensor_);

--- a/esphome/components/kuntze/kuntze.cpp
+++ b/esphome/components/kuntze/kuntze.cpp
@@ -77,7 +77,10 @@ void Kuntze::loop() {
 void Kuntze::update() { this->state_ = 1; }
 
 void Kuntze::dump_config() {
-  ESP_LOGCONFIG(TAG, "Kuntze:\n  Address: 0x%02X", this->address_);
+  ESP_LOGCONFIG(TAG,
+                "Kuntze:\n"
+                "  Address: 0x%02X",
+                this->address_);
   LOG_SENSOR("", "pH", this->ph_sensor_);
   LOG_SENSOR("", "temperature", this->temperature_sensor_);
   LOG_SENSOR("", "DIS1", this->dis1_sensor_);

--- a/esphome/components/lc709203f/lc709203f.cpp
+++ b/esphome/components/lc709203f/lc709203f.cpp
@@ -151,8 +151,7 @@ void Lc709203f::dump_config() {
   LOG_I2C_DEVICE(this);
 
   LOG_UPDATE_INTERVAL(this);
-  ESP_LOGCONFIG(TAG, "  Pack Size: %d mAH", this->pack_size_);
-  ESP_LOGCONFIG(TAG, "  Pack APA: 0x%02X", this->apa_);
+  ESP_LOGCONFIG(TAG, "  Pack Size: %d mAH\n  Pack APA: 0x%02X", this->pack_size_, this->apa_);
 
   // This is only true if the pack_voltage_ is either 0x0000 or 0x0001. The config validator
   //  should have already verified this.

--- a/esphome/components/lc709203f/lc709203f.cpp
+++ b/esphome/components/lc709203f/lc709203f.cpp
@@ -151,7 +151,10 @@ void Lc709203f::dump_config() {
   LOG_I2C_DEVICE(this);
 
   LOG_UPDATE_INTERVAL(this);
-  ESP_LOGCONFIG(TAG, "  Pack Size: %d mAH\n  Pack APA: 0x%02X", this->pack_size_, this->apa_);
+  ESP_LOGCONFIG(TAG,
+                "  Pack Size: %d mAH\n"
+                "  Pack APA: 0x%02X",
+                this->pack_size_, this->apa_);
 
   // This is only true if the pack_voltage_ is either 0x0000 or 0x0001. The config validator
   //  should have already verified this.

--- a/esphome/components/lcd_gpio/gpio_lcd_display.cpp
+++ b/esphome/components/lcd_gpio/gpio_lcd_display.cpp
@@ -24,7 +24,10 @@ void GPIOLCDDisplay::setup() {
   LCDDisplay::setup();
 }
 void GPIOLCDDisplay::dump_config() {
-  ESP_LOGCONFIG(TAG, "GPIO LCD Display:\n  Columns: %u, Rows: %u", this->columns_, this->rows_);
+  ESP_LOGCONFIG(TAG,
+                "GPIO LCD Display:\n"
+                "  Columns: %u, Rows: %u",
+                this->columns_, this->rows_);
   LOG_PIN("  RS Pin: ", this->rs_pin_);
   LOG_PIN("  RW Pin: ", this->rw_pin_);
   LOG_PIN("  Enable Pin: ", this->enable_pin_);

--- a/esphome/components/lcd_gpio/gpio_lcd_display.cpp
+++ b/esphome/components/lcd_gpio/gpio_lcd_display.cpp
@@ -24,8 +24,7 @@ void GPIOLCDDisplay::setup() {
   LCDDisplay::setup();
 }
 void GPIOLCDDisplay::dump_config() {
-  ESP_LOGCONFIG(TAG, "GPIO LCD Display:");
-  ESP_LOGCONFIG(TAG, "  Columns: %u, Rows: %u", this->columns_, this->rows_);
+  ESP_LOGCONFIG(TAG, "GPIO LCD Display:\n  Columns: %u, Rows: %u", this->columns_, this->rows_);
   LOG_PIN("  RS Pin: ", this->rs_pin_);
   LOG_PIN("  RW Pin: ", this->rw_pin_);
   LOG_PIN("  Enable Pin: ", this->enable_pin_);

--- a/esphome/components/lcd_menu/lcd_menu.cpp
+++ b/esphome/components/lcd_menu/lcd_menu.cpp
@@ -19,8 +19,12 @@ void LCDCharacterMenuComponent::setup() {
 float LCDCharacterMenuComponent::get_setup_priority() const { return setup_priority::PROCESSOR - 1.0f; }
 
 void LCDCharacterMenuComponent::dump_config() {
-  ESP_LOGCONFIG(TAG, "LCD Menu\n  Columns: %u, Rows: %u\n  Mark characters: %02x, %02x, %02x, %02x", this->columns_,
-                this->rows_, this->mark_selected_, this->mark_editing_, this->mark_submenu_, this->mark_back_);
+  ESP_LOGCONFIG(TAG,
+                "LCD Menu\n"
+                "  Columns: %u, Rows: %u\n"
+                "  Mark characters: %02x, %02x, %02x, %02x",
+                this->columns_, this->rows_, this->mark_selected_, this->mark_editing_, this->mark_submenu_,
+                this->mark_back_);
   if (this->is_failed()) {
     ESP_LOGE(TAG, "The connected display failed, the menu is disabled!");
   }

--- a/esphome/components/lcd_menu/lcd_menu.cpp
+++ b/esphome/components/lcd_menu/lcd_menu.cpp
@@ -19,10 +19,8 @@ void LCDCharacterMenuComponent::setup() {
 float LCDCharacterMenuComponent::get_setup_priority() const { return setup_priority::PROCESSOR - 1.0f; }
 
 void LCDCharacterMenuComponent::dump_config() {
-  ESP_LOGCONFIG(TAG, "LCD Menu");
-  ESP_LOGCONFIG(TAG, "  Columns: %u, Rows: %u", this->columns_, this->rows_);
-  ESP_LOGCONFIG(TAG, "  Mark characters: %02x, %02x, %02x, %02x", this->mark_selected_, this->mark_editing_,
-                this->mark_submenu_, this->mark_back_);
+  ESP_LOGCONFIG(TAG, "LCD Menu\n  Columns: %u, Rows: %u\n  Mark characters: %02x, %02x, %02x, %02x", this->columns_,
+                this->rows_, this->mark_selected_, this->mark_editing_, this->mark_submenu_, this->mark_back_);
   if (this->is_failed()) {
     ESP_LOGE(TAG, "The connected display failed, the menu is disabled!");
   }

--- a/esphome/components/lcd_pcf8574/pcf8574_display.cpp
+++ b/esphome/components/lcd_pcf8574/pcf8574_display.cpp
@@ -21,8 +21,7 @@ void PCF8574LCDDisplay::setup() {
   LCDDisplay::setup();
 }
 void PCF8574LCDDisplay::dump_config() {
-  ESP_LOGCONFIG(TAG, "PCF8574 LCD Display:");
-  ESP_LOGCONFIG(TAG, "  Columns: %u, Rows: %u", this->columns_, this->rows_);
+  ESP_LOGCONFIG(TAG, "PCF8574 LCD Display:\n  Columns: %u, Rows: %u", this->columns_, this->rows_);
   LOG_I2C_DEVICE(this);
   LOG_UPDATE_INTERVAL(this);
   if (this->is_failed()) {

--- a/esphome/components/lcd_pcf8574/pcf8574_display.cpp
+++ b/esphome/components/lcd_pcf8574/pcf8574_display.cpp
@@ -21,7 +21,10 @@ void PCF8574LCDDisplay::setup() {
   LCDDisplay::setup();
 }
 void PCF8574LCDDisplay::dump_config() {
-  ESP_LOGCONFIG(TAG, "PCF8574 LCD Display:\n  Columns: %u, Rows: %u", this->columns_, this->rows_);
+  ESP_LOGCONFIG(TAG,
+                "PCF8574 LCD Display:\n"
+                "  Columns: %u, Rows: %u",
+                this->columns_, this->rows_);
   LOG_I2C_DEVICE(this);
   LOG_UPDATE_INTERVAL(this);
   if (this->is_failed()) {

--- a/esphome/components/ld2410/ld2410.cpp
+++ b/esphome/components/ld2410/ld2410.cpp
@@ -72,9 +72,8 @@ void LD2410Component::dump_config() {
   }
 #endif
   this->read_all_info();
-  ESP_LOGCONFIG(TAG, "  Throttle_ : %ums", this->throttle_);
-  ESP_LOGCONFIG(TAG, "  MAC Address : %s", const_cast<char *>(this->mac_.c_str()));
-  ESP_LOGCONFIG(TAG, "  Firmware Version : %s", const_cast<char *>(this->version_.c_str()));
+  ESP_LOGCONFIG(TAG, "  Throttle_ : %ums\n  MAC Address : %s\n  Firmware Version : %s", this->throttle_,
+                const_cast<char *>(this->mac_.c_str()), const_cast<char *>(this->version_.c_str()));
 }
 
 void LD2410Component::setup() {

--- a/esphome/components/ld2410/ld2410.cpp
+++ b/esphome/components/ld2410/ld2410.cpp
@@ -72,8 +72,11 @@ void LD2410Component::dump_config() {
   }
 #endif
   this->read_all_info();
-  ESP_LOGCONFIG(TAG, "  Throttle_ : %ums\n  MAC Address : %s\n  Firmware Version : %s", this->throttle_,
-                const_cast<char *>(this->mac_.c_str()), const_cast<char *>(this->version_.c_str()));
+  ESP_LOGCONFIG(TAG,
+                "  Throttle_ : %ums\n"
+                "  MAC Address : %s\n"
+                "  Firmware Version : %s",
+                this->throttle_, const_cast<char *>(this->mac_.c_str()), const_cast<char *>(this->version_.c_str()));
 }
 
 void LD2410Component::setup() {

--- a/esphome/components/ld2420/ld2420.cpp
+++ b/esphome/components/ld2420/ld2420.cpp
@@ -65,7 +65,11 @@ static const char *const TAG = "ld2420";
 float LD2420Component::get_setup_priority() const { return setup_priority::BUS; }
 
 void LD2420Component::dump_config() {
-  ESP_LOGCONFIG(TAG, "LD2420:\n  Firmware Version : %7s\nLD2420 Number:", this->ld2420_firmware_ver_);
+  ESP_LOGCONFIG(TAG,
+                "LD2420:\n"
+                "  Firmware Version : %7s\n"
+                "LD2420 Number:",
+                this->ld2420_firmware_ver_);
 #ifdef USE_NUMBER
   LOG_NUMBER(TAG, "  Gate Timeout:", this->gate_timeout_number_);
   LOG_NUMBER(TAG, "  Gate Max Distance:", this->max_gate_distance_number_);

--- a/esphome/components/ld2420/ld2420.cpp
+++ b/esphome/components/ld2420/ld2420.cpp
@@ -65,9 +65,7 @@ static const char *const TAG = "ld2420";
 float LD2420Component::get_setup_priority() const { return setup_priority::BUS; }
 
 void LD2420Component::dump_config() {
-  ESP_LOGCONFIG(TAG, "LD2420:");
-  ESP_LOGCONFIG(TAG, "  Firmware Version : %7s", this->ld2420_firmware_ver_);
-  ESP_LOGCONFIG(TAG, "LD2420 Number:");
+  ESP_LOGCONFIG(TAG, "LD2420:\n  Firmware Version : %7s\nLD2420 Number:", this->ld2420_firmware_ver_);
 #ifdef USE_NUMBER
   LOG_NUMBER(TAG, "  Gate Timeout:", this->gate_timeout_number_);
   LOG_NUMBER(TAG, "  Gate Max Distance:", this->max_gate_distance_number_);

--- a/esphome/components/ld2450/ld2450.cpp
+++ b/esphome/components/ld2450/ld2450.cpp
@@ -188,8 +188,11 @@ void LD2450Component::dump_config() {
 #ifdef USE_NUMBER
   LOG_NUMBER("  ", "PresenceTimeoutNumber", this->presence_timeout_number_);
 #endif
-  ESP_LOGCONFIG(TAG, "  Throttle : %ums\n  MAC Address : %s\n  Firmware version : %s", this->throttle_,
-                const_cast<char *>(this->mac_.c_str()), const_cast<char *>(this->version_.c_str()));
+  ESP_LOGCONFIG(TAG,
+                "  Throttle : %ums\n"
+                "  MAC Address : %s\n"
+                "  Firmware version : %s",
+                this->throttle_, const_cast<char *>(this->mac_.c_str()), const_cast<char *>(this->version_.c_str()));
 }
 
 void LD2450Component::loop() {

--- a/esphome/components/ld2450/ld2450.cpp
+++ b/esphome/components/ld2450/ld2450.cpp
@@ -188,9 +188,8 @@ void LD2450Component::dump_config() {
 #ifdef USE_NUMBER
   LOG_NUMBER("  ", "PresenceTimeoutNumber", this->presence_timeout_number_);
 #endif
-  ESP_LOGCONFIG(TAG, "  Throttle : %ums", this->throttle_);
-  ESP_LOGCONFIG(TAG, "  MAC Address : %s", const_cast<char *>(this->mac_.c_str()));
-  ESP_LOGCONFIG(TAG, "  Firmware version : %s", const_cast<char *>(this->version_.c_str()));
+  ESP_LOGCONFIG(TAG, "  Throttle : %ums\n  MAC Address : %s\n  Firmware version : %s", this->throttle_,
+                const_cast<char *>(this->mac_.c_str()), const_cast<char *>(this->version_.c_str()));
 }
 
 void LD2450Component::loop() {

--- a/esphome/components/ledc/ledc_output.cpp
+++ b/esphome/components/ledc/ledc_output.cpp
@@ -181,10 +181,12 @@ void LEDCOutput::setup() {
 void LEDCOutput::dump_config() {
   ESP_LOGCONFIG(TAG, "Output:");
   LOG_PIN("  Pin ", this->pin_);
-  ESP_LOGCONFIG(TAG, "  Channel: %u", this->channel_);
-  ESP_LOGCONFIG(TAG, "  PWM Frequency: %.1f Hz", this->frequency_);
-  ESP_LOGCONFIG(TAG, "  Phase angle: %.1f°", this->phase_angle_);
-  ESP_LOGCONFIG(TAG, "  Bit depth: %u", this->bit_depth_);
+  ESP_LOGCONFIG(TAG,
+                "  Channel: %u\n"
+                "  PWM Frequency: %.1f Hz\n"
+                "  Phase angle: %.1f°\n"
+                "  Bit depth: %u",
+                this->channel_, this->frequency_, this->phase_angle_, this->bit_depth_);
   ESP_LOGV(TAG, "  Max frequency for bit depth: %f", ledc_max_frequency_for_bit_depth(this->bit_depth_));
   ESP_LOGV(TAG, "  Min frequency for bit depth: %f",
            ledc_min_frequency_for_bit_depth(this->bit_depth_, (this->frequency_ < 100)));

--- a/esphome/components/light/light_state.cpp
+++ b/esphome/components/light/light_state.cpp
@@ -91,12 +91,16 @@ void LightState::setup() {
 void LightState::dump_config() {
   ESP_LOGCONFIG(TAG, "Light '%s'", this->get_name().c_str());
   if (this->get_traits().supports_color_capability(ColorCapability::BRIGHTNESS)) {
-    ESP_LOGCONFIG(TAG, "  Default Transition Length: %.1fs\n  Gamma Correct: %.2f",
+    ESP_LOGCONFIG(TAG,
+                  "  Default Transition Length: %.1fs\n"
+                  "  Gamma Correct: %.2f",
                   this->default_transition_length_ / 1e3f, this->gamma_correct_);
   }
   if (this->get_traits().supports_color_capability(ColorCapability::COLOR_TEMPERATURE)) {
-    ESP_LOGCONFIG(TAG, "  Min Mireds: %.1f\n  Max Mireds: %.1f", this->get_traits().get_min_mireds(),
-                  this->get_traits().get_max_mireds());
+    ESP_LOGCONFIG(TAG,
+                  "  Min Mireds: %.1f\n"
+                  "  Max Mireds: %.1f",
+                  this->get_traits().get_min_mireds(), this->get_traits().get_max_mireds());
   }
 }
 void LightState::loop() {

--- a/esphome/components/light/light_state.cpp
+++ b/esphome/components/light/light_state.cpp
@@ -91,12 +91,12 @@ void LightState::setup() {
 void LightState::dump_config() {
   ESP_LOGCONFIG(TAG, "Light '%s'", this->get_name().c_str());
   if (this->get_traits().supports_color_capability(ColorCapability::BRIGHTNESS)) {
-    ESP_LOGCONFIG(TAG, "  Default Transition Length: %.1fs", this->default_transition_length_ / 1e3f);
-    ESP_LOGCONFIG(TAG, "  Gamma Correct: %.2f", this->gamma_correct_);
+    ESP_LOGCONFIG(TAG, "  Default Transition Length: %.1fs\n  Gamma Correct: %.2f",
+                  this->default_transition_length_ / 1e3f, this->gamma_correct_);
   }
   if (this->get_traits().supports_color_capability(ColorCapability::COLOR_TEMPERATURE)) {
-    ESP_LOGCONFIG(TAG, "  Min Mireds: %.1f", this->get_traits().get_min_mireds());
-    ESP_LOGCONFIG(TAG, "  Max Mireds: %.1f", this->get_traits().get_max_mireds());
+    ESP_LOGCONFIG(TAG, "  Min Mireds: %.1f\n  Max Mireds: %.1f", this->get_traits().get_min_mireds(),
+                  this->get_traits().get_max_mireds());
   }
 }
 void LightState::loop() {

--- a/esphome/components/logger/logger.cpp
+++ b/esphome/components/logger/logger.cpp
@@ -227,7 +227,10 @@ void Logger::dump_config() {
                 "  Initial Level: %s",
                 LOG_LEVELS[ESPHOME_LOG_LEVEL], LOG_LEVELS[this->current_level_]);
 #ifndef USE_HOST
-  ESP_LOGCONFIG(TAG, "  Log Baud Rate: %" PRIu32 "\n  Hardware UART: %s", this->baud_rate_, get_uart_selection_());
+  ESP_LOGCONFIG(TAG,
+                "  Log Baud Rate: %" PRIu32 "\n"
+                "  Hardware UART: %s",
+                this->baud_rate_, get_uart_selection_());
 #endif
 #ifdef USE_ESPHOME_TASK_LOG_BUFFER
   if (this->log_buffer_) {

--- a/esphome/components/logger/logger.cpp
+++ b/esphome/components/logger/logger.cpp
@@ -222,11 +222,10 @@ static const char *const LOG_LEVELS[] = {"NONE", "ERROR", "WARN", "INFO", "CONFI
 
 void Logger::dump_config() {
   ESP_LOGCONFIG(TAG, "Logger:");
-  ESP_LOGCONFIG(TAG, "  Max Level: %s", LOG_LEVELS[ESPHOME_LOG_LEVEL]);
-  ESP_LOGCONFIG(TAG, "  Initial Level: %s", LOG_LEVELS[this->current_level_]);
+  ESP_LOGCONFIG(TAG, "  Max Level: %s\n  Initial Level: %s", LOG_LEVELS[ESPHOME_LOG_LEVEL],
+                LOG_LEVELS[this->current_level_]);
 #ifndef USE_HOST
-  ESP_LOGCONFIG(TAG, "  Log Baud Rate: %" PRIu32, this->baud_rate_);
-  ESP_LOGCONFIG(TAG, "  Hardware UART: %s", get_uart_selection_());
+  ESP_LOGCONFIG(TAG, "  Log Baud Rate: %" PRIu32 "\n  Hardware UART: %s", this->baud_rate_, get_uart_selection_());
 #endif
 #ifdef USE_ESPHOME_TASK_LOG_BUFFER
   if (this->log_buffer_) {

--- a/esphome/components/logger/logger.cpp
+++ b/esphome/components/logger/logger.cpp
@@ -221,8 +221,7 @@ float Logger::get_setup_priority() const { return setup_priority::BUS + 500.0f; 
 static const char *const LOG_LEVELS[] = {"NONE", "ERROR", "WARN", "INFO", "CONFIG", "DEBUG", "VERBOSE", "VERY_VERBOSE"};
 
 void Logger::dump_config() {
-  ESP_LOGCONFIG(TAG, "Logger:");
-  ESP_LOGCONFIG(TAG, "  Max Level: %s\n  Initial Level: %s", LOG_LEVELS[ESPHOME_LOG_LEVEL],
+  ESP_LOGCONFIG(TAG, "Logger:\n  Max Level: %s\n  Initial Level: %s", LOG_LEVELS[ESPHOME_LOG_LEVEL],
                 LOG_LEVELS[this->current_level_]);
 #ifndef USE_HOST
   ESP_LOGCONFIG(TAG, "  Log Baud Rate: %" PRIu32 "\n  Hardware UART: %s", this->baud_rate_, get_uart_selection_());

--- a/esphome/components/logger/logger.cpp
+++ b/esphome/components/logger/logger.cpp
@@ -221,8 +221,11 @@ float Logger::get_setup_priority() const { return setup_priority::BUS + 500.0f; 
 static const char *const LOG_LEVELS[] = {"NONE", "ERROR", "WARN", "INFO", "CONFIG", "DEBUG", "VERBOSE", "VERY_VERBOSE"};
 
 void Logger::dump_config() {
-  ESP_LOGCONFIG(TAG, "Logger:\n  Max Level: %s\n  Initial Level: %s", LOG_LEVELS[ESPHOME_LOG_LEVEL],
-                LOG_LEVELS[this->current_level_]);
+  ESP_LOGCONFIG(TAG,
+                "Logger:\n"
+                "  Max Level: %s\n"
+                "  Initial Level: %s",
+                LOG_LEVELS[ESPHOME_LOG_LEVEL], LOG_LEVELS[this->current_level_]);
 #ifndef USE_HOST
   ESP_LOGCONFIG(TAG, "  Log Baud Rate: %" PRIu32 "\n  Hardware UART: %s", this->baud_rate_, get_uart_selection_());
 #endif

--- a/esphome/components/ltr390/ltr390.cpp
+++ b/esphome/components/ltr390/ltr390.cpp
@@ -187,10 +187,13 @@ void LTR390Component::setup() {
 
 void LTR390Component::dump_config() {
   LOG_I2C_DEVICE(this);
-  ESP_LOGCONFIG(TAG, "  ALS Gain: X%.0f", GAINVALUES[this->gain_als_]);
-  ESP_LOGCONFIG(TAG, "  ALS Resolution: %u-bit", RESOLUTION_BITS[this->res_als_]);
-  ESP_LOGCONFIG(TAG, "  UV Gain: X%.0f", GAINVALUES[this->gain_uv_]);
-  ESP_LOGCONFIG(TAG, "  UV Resolution: %u-bit", RESOLUTION_BITS[this->res_uv_]);
+  ESP_LOGCONFIG(TAG,
+                "  ALS Gain: X%.0f\n"
+                "  ALS Resolution: %u-bit\n"
+                "  UV Gain: X%.0f\n"
+                "  UV Resolution: %u-bit",
+                GAINVALUES[this->gain_als_], RESOLUTION_BITS[this->res_als_], GAINVALUES[this->gain_uv_],
+                RESOLUTION_BITS[this->res_uv_]);
 }
 
 void LTR390Component::update() {

--- a/esphome/components/ltr501/ltr501.cpp
+++ b/esphome/components/ltr501/ltr501.cpp
@@ -94,16 +94,21 @@ void LTRAlsPs501Component::dump_config() {
   };
 
   LOG_I2C_DEVICE(this);
-  ESP_LOGCONFIG(TAG, "  Device type: %s", get_device_type(this->ltr_type_));
-  ESP_LOGCONFIG(TAG, "  Automatic mode: %s", ONOFF(this->automatic_mode_enabled_));
-  ESP_LOGCONFIG(TAG, "  Gain: %.0fx", get_gain_coeff(this->gain_));
-  ESP_LOGCONFIG(TAG, "  Integration time: %d ms", get_itime_ms(this->integration_time_));
-  ESP_LOGCONFIG(TAG, "  Measurement repeat rate: %d ms", get_meas_time_ms(this->repeat_rate_));
-  ESP_LOGCONFIG(TAG, "  Glass attenuation factor: %f", this->glass_attenuation_factor_);
-  ESP_LOGCONFIG(TAG, "  Proximity gain: %.0fx", get_ps_gain_coeff(this->ps_gain_));
-  ESP_LOGCONFIG(TAG, "  Proximity cooldown time: %d s", this->ps_cooldown_time_s_);
-  ESP_LOGCONFIG(TAG, "  Proximity high threshold: %d", this->ps_threshold_high_);
-  ESP_LOGCONFIG(TAG, "  Proximity low threshold: %d", this->ps_threshold_low_);
+  ESP_LOGCONFIG(TAG,
+                "  Device type: %s\n"
+                "  Automatic mode: %s\n"
+                "  Gain: %.0fx\n"
+                "  Integration time: %d ms\n"
+                "  Measurement repeat rate: %d ms\n"
+                "  Glass attenuation factor: %f\n"
+                "  Proximity gain: %.0fx\n"
+                "  Proximity cooldown time: %d s\n"
+                "  Proximity high threshold: %d\n"
+                "  Proximity low threshold: %d",
+                get_device_type(this->ltr_type_), ONOFF(this->automatic_mode_enabled_), get_gain_coeff(this->gain_),
+                get_itime_ms(this->integration_time_), get_meas_time_ms(this->repeat_rate_),
+                this->glass_attenuation_factor_, get_ps_gain_coeff(this->ps_gain_), this->ps_cooldown_time_s_,
+                this->ps_threshold_high_, this->ps_threshold_low_);
 
   LOG_UPDATE_INTERVAL(this);
 

--- a/esphome/components/ltr_als_ps/ltr_als_ps.cpp
+++ b/esphome/components/ltr_als_ps/ltr_als_ps.cpp
@@ -85,21 +85,28 @@ void LTRAlsPsComponent::dump_config() {
   LOG_I2C_DEVICE(this);
   ESP_LOGCONFIG(TAG, "  Device type: %s", get_device_type(this->ltr_type_));
   if (this->is_als_()) {
-    ESP_LOGCONFIG(TAG, "  Automatic mode: %s", ONOFF(this->automatic_mode_enabled_));
-    ESP_LOGCONFIG(TAG, "  Gain: %.0fx", get_gain_coeff(this->gain_));
-    ESP_LOGCONFIG(TAG, "  Integration time: %d ms", get_itime_ms(this->integration_time_));
-    ESP_LOGCONFIG(TAG, "  Measurement repeat rate: %d ms", get_meas_time_ms(this->repeat_rate_));
-    ESP_LOGCONFIG(TAG, "  Glass attenuation factor: %f", this->glass_attenuation_factor_);
+    ESP_LOGCONFIG(TAG,
+                  "  Automatic mode: %s\n"
+                  "  Gain: %.0fx\n"
+                  "  Integration time: %d ms\n"
+                  "  Measurement repeat rate: %d ms\n"
+                  "  Glass attenuation factor: %f",
+                  ONOFF(this->automatic_mode_enabled_), get_gain_coeff(this->gain_),
+                  get_itime_ms(this->integration_time_), get_meas_time_ms(this->repeat_rate_),
+                  this->glass_attenuation_factor_);
     LOG_SENSOR("  ", "ALS calculated lux", this->ambient_light_sensor_);
     LOG_SENSOR("  ", "CH1 Infrared counts", this->infrared_counts_sensor_);
     LOG_SENSOR("  ", "CH0 Visible+IR counts", this->full_spectrum_counts_sensor_);
     LOG_SENSOR("  ", "Actual gain", this->actual_gain_sensor_);
   }
   if (this->is_ps_()) {
-    ESP_LOGCONFIG(TAG, "  Proximity gain: %.0fx", get_ps_gain_coeff(this->ps_gain_));
-    ESP_LOGCONFIG(TAG, "  Proximity cooldown time: %d s", this->ps_cooldown_time_s_);
-    ESP_LOGCONFIG(TAG, "  Proximity high threshold: %d", this->ps_threshold_high_);
-    ESP_LOGCONFIG(TAG, "  Proximity low threshold: %d", this->ps_threshold_low_);
+    ESP_LOGCONFIG(TAG,
+                  "  Proximity gain: %.0fx\n"
+                  "  Proximity cooldown time: %d s\n"
+                  "  Proximity high threshold: %d\n"
+                  "  Proximity low threshold: %d",
+                  get_ps_gain_coeff(this->ps_gain_), this->ps_cooldown_time_s_, this->ps_threshold_high_,
+                  this->ps_threshold_low_);
     LOG_SENSOR("  ", "Proximity counts", this->proximity_counts_sensor_);
   }
   LOG_UPDATE_INTERVAL(this);

--- a/esphome/components/lvgl/lvgl_esphome.cpp
+++ b/esphome/components/lvgl/lvgl_esphome.cpp
@@ -85,11 +85,10 @@ static void rounder_cb(lv_disp_drv_t *disp_drv, lv_area_t *area) {
 lv_event_code_t lv_api_event;     // NOLINT
 lv_event_code_t lv_update_event;  // NOLINT
 void LvglComponent::dump_config() {
-  ESP_LOGCONFIG(TAG, "LVGL:");
-  ESP_LOGCONFIG(TAG, "  Display width/height: %d x %d", this->disp_drv_.hor_res, this->disp_drv_.ver_res);
-  ESP_LOGCONFIG(TAG, "  Buffer size: %zu%%", 100 / this->buffer_frac_);
-  ESP_LOGCONFIG(TAG, "  Rotation: %d", this->rotation);
-  ESP_LOGCONFIG(TAG, "  Draw rounding: %d", (int) this->draw_rounding);
+  ESP_LOGCONFIG(TAG,
+                "LVGL:\n  Display width/height: %d x %d\n  Buffer size: %zu%%\n  Rotation: %d\n  Draw rounding: %d",
+                this->disp_drv_.hor_res, this->disp_drv_.ver_res, 100 / this->buffer_frac_, this->rotation,
+                (int) this->draw_rounding);
 }
 void LvglComponent::set_paused(bool paused, bool show_snow) {
   this->paused_ = paused;

--- a/esphome/components/lvgl/lvgl_esphome.cpp
+++ b/esphome/components/lvgl/lvgl_esphome.cpp
@@ -86,7 +86,11 @@ lv_event_code_t lv_api_event;     // NOLINT
 lv_event_code_t lv_update_event;  // NOLINT
 void LvglComponent::dump_config() {
   ESP_LOGCONFIG(TAG,
-                "LVGL:\n  Display width/height: %d x %d\n  Buffer size: %zu%%\n  Rotation: %d\n  Draw rounding: %d",
+                "LVGL:\n"
+                "  Display width/height: %d x %d\n"
+                "  Buffer size: %zu%%\n"
+                "  Rotation: %d\n"
+                "  Draw rounding: %d",
                 this->disp_drv_.hor_res, this->disp_drv_.ver_res, 100 / this->buffer_frac_, this->rotation,
                 (int) this->draw_rounding);
 }

--- a/esphome/components/matrix_keypad/matrix_keypad.cpp
+++ b/esphome/components/matrix_keypad/matrix_keypad.cpp
@@ -97,8 +97,8 @@ void MatrixKeypad::loop() {
 }
 
 void MatrixKeypad::dump_config() {
-  ESP_LOGCONFIG(TAG, "Matrix Keypad:");
-  ESP_LOGCONFIG(TAG, " Rows:");
+  ESP_LOGCONFIG(TAG, "Matrix Keypad:\n"
+                     " Rows:");
   for (auto &pin : this->rows_) {
     LOG_PIN("  Pin: ", pin);
   }

--- a/esphome/components/matrix_keypad/matrix_keypad.cpp
+++ b/esphome/components/matrix_keypad/matrix_keypad.cpp
@@ -97,8 +97,8 @@ void MatrixKeypad::loop() {
 }
 
 void MatrixKeypad::dump_config() {
-  ESP_LOGCONFIG(TAG, "Matrix Keypad:\n"
-                     " Rows:");
+  ESP_LOGCONFIG(TAG, "Matrix Keypad:");
+  ESP_LOGCONFIG(TAG, " Rows:");
   for (auto &pin : this->rows_) {
     LOG_PIN("  Pin: ", pin);
   }

--- a/esphome/components/matrix_keypad/matrix_keypad.cpp
+++ b/esphome/components/matrix_keypad/matrix_keypad.cpp
@@ -97,7 +97,8 @@ void MatrixKeypad::loop() {
 }
 
 void MatrixKeypad::dump_config() {
-  ESP_LOGCONFIG(TAG, "Matrix Keypad:\n Rows:");
+  ESP_LOGCONFIG(TAG, "Matrix Keypad:\n"
+                     " Rows:");
   for (auto &pin : this->rows_) {
     LOG_PIN("  Pin: ", pin);
   }

--- a/esphome/components/matrix_keypad/matrix_keypad.cpp
+++ b/esphome/components/matrix_keypad/matrix_keypad.cpp
@@ -97,8 +97,7 @@ void MatrixKeypad::loop() {
 }
 
 void MatrixKeypad::dump_config() {
-  ESP_LOGCONFIG(TAG, "Matrix Keypad:");
-  ESP_LOGCONFIG(TAG, " Rows:");
+  ESP_LOGCONFIG(TAG, "Matrix Keypad:\n Rows:");
   for (auto &pin : this->rows_) {
     LOG_PIN("  Pin: ", pin);
   }

--- a/esphome/components/max31865/max31865.cpp
+++ b/esphome/components/max31865/max31865.cpp
@@ -83,8 +83,11 @@ void MAX31865Sensor::dump_config() {
   LOG_SENSOR("", "MAX31865", this);
   LOG_PIN("  CS Pin: ", this->cs_);
   LOG_UPDATE_INTERVAL(this);
-  ESP_LOGCONFIG(TAG, "  Reference Resistance: %.2fΩ\n  RTD: %u-wire %.2fΩ\n  Mains Filter: %s", reference_resistance_,
-                rtd_wires_, rtd_nominal_resistance_,
+  ESP_LOGCONFIG(TAG,
+                "  Reference Resistance: %.2fΩ\n"
+                "  RTD: %u-wire %.2fΩ\n"
+                "  Mains Filter: %s",
+                reference_resistance_, rtd_wires_, rtd_nominal_resistance_,
                 (filter_ == FILTER_60HZ ? "60 Hz" : (filter_ == FILTER_50HZ ? "50 Hz" : "Unknown!")));
 }
 

--- a/esphome/components/max31865/max31865.cpp
+++ b/esphome/components/max31865/max31865.cpp
@@ -83,9 +83,8 @@ void MAX31865Sensor::dump_config() {
   LOG_SENSOR("", "MAX31865", this);
   LOG_PIN("  CS Pin: ", this->cs_);
   LOG_UPDATE_INTERVAL(this);
-  ESP_LOGCONFIG(TAG, "  Reference Resistance: %.2fΩ", reference_resistance_);
-  ESP_LOGCONFIG(TAG, "  RTD: %u-wire %.2fΩ", rtd_wires_, rtd_nominal_resistance_);
-  ESP_LOGCONFIG(TAG, "  Mains Filter: %s",
+  ESP_LOGCONFIG(TAG, "  Reference Resistance: %.2fΩ\n  RTD: %u-wire %.2fΩ\n  Mains Filter: %s", reference_resistance_,
+                rtd_wires_, rtd_nominal_resistance_,
                 (filter_ == FILTER_60HZ ? "60 Hz" : (filter_ == FILTER_50HZ ? "50 Hz" : "Unknown!")));
 }
 

--- a/esphome/components/max6956/max6956.cpp
+++ b/esphome/components/max6956/max6956.cpp
@@ -146,8 +146,7 @@ void MAX6956::dump_config() {
   ESP_LOGCONFIG(TAG, "MAX6956");
 
   if (brightness_mode_ == MAX6956CURRENTMODE::GLOBAL) {
-    ESP_LOGCONFIG(TAG, "current mode: global");
-    ESP_LOGCONFIG(TAG, "global brightness: %u", global_brightness_);
+    ESP_LOGCONFIG(TAG, "current mode: global\nglobal brightness: %u", global_brightness_);
   } else {
     ESP_LOGCONFIG(TAG, "current mode: segment");
   }

--- a/esphome/components/max6956/max6956.cpp
+++ b/esphome/components/max6956/max6956.cpp
@@ -146,7 +146,10 @@ void MAX6956::dump_config() {
   ESP_LOGCONFIG(TAG, "MAX6956");
 
   if (brightness_mode_ == MAX6956CURRENTMODE::GLOBAL) {
-    ESP_LOGCONFIG(TAG, "current mode: global\nglobal brightness: %u", global_brightness_);
+    ESP_LOGCONFIG(TAG,
+                  "current mode: global\n"
+                  "global brightness: %u",
+                  global_brightness_);
   } else {
     ESP_LOGCONFIG(TAG, "current mode: segment");
   }

--- a/esphome/components/max7219/max7219.cpp
+++ b/esphome/components/max7219/max7219.cpp
@@ -133,7 +133,11 @@ void MAX7219Component::setup() {
   this->send_to_all_(MAX7219_REGISTER_SHUTDOWN, 1);
 }
 void MAX7219Component::dump_config() {
-  ESP_LOGCONFIG(TAG, "MAX7219:\n  Number of Chips: %u\n  Intensity: %u", this->num_chips_, this->intensity_);
+  ESP_LOGCONFIG(TAG,
+                "MAX7219:\n"
+                "  Number of Chips: %u\n"
+                "  Intensity: %u",
+                this->num_chips_, this->intensity_);
   LOG_PIN("  CS Pin: ", this->cs_);
   LOG_UPDATE_INTERVAL(this);
 }

--- a/esphome/components/max7219/max7219.cpp
+++ b/esphome/components/max7219/max7219.cpp
@@ -133,9 +133,7 @@ void MAX7219Component::setup() {
   this->send_to_all_(MAX7219_REGISTER_SHUTDOWN, 1);
 }
 void MAX7219Component::dump_config() {
-  ESP_LOGCONFIG(TAG, "MAX7219:");
-  ESP_LOGCONFIG(TAG, "  Number of Chips: %u", this->num_chips_);
-  ESP_LOGCONFIG(TAG, "  Intensity: %u", this->intensity_);
+  ESP_LOGCONFIG(TAG, "MAX7219:\n  Number of Chips: %u\n  Intensity: %u", this->num_chips_, this->intensity_);
   LOG_PIN("  CS Pin: ", this->cs_);
   LOG_UPDATE_INTERVAL(this);
 }

--- a/esphome/components/max7219digit/max7219digit.cpp
+++ b/esphome/components/max7219digit/max7219digit.cpp
@@ -51,14 +51,17 @@ void MAX7219Component::setup() {
 
 void MAX7219Component::dump_config() {
   ESP_LOGCONFIG(TAG, "MAX7219DIGIT:");
-  ESP_LOGCONFIG(TAG, "  Number of Chips: %u", this->num_chips_);
-  ESP_LOGCONFIG(TAG, "  Number of Chips Lines: %u", this->num_chip_lines_);
-  ESP_LOGCONFIG(TAG, "  Chips Lines Style : %u", this->chip_lines_style_);
-  ESP_LOGCONFIG(TAG, "  Intensity: %u", this->intensity_);
-  ESP_LOGCONFIG(TAG, "  Scroll Mode: %u", this->scroll_mode_);
-  ESP_LOGCONFIG(TAG, "  Scroll Speed: %u", this->scroll_speed_);
-  ESP_LOGCONFIG(TAG, "  Scroll Dwell: %u", this->scroll_dwell_);
-  ESP_LOGCONFIG(TAG, "  Scroll Delay: %u", this->scroll_delay_);
+  ESP_LOGCONFIG(TAG,
+                "  Number of Chips: %u\n"
+                "  Number of Chips Lines: %u\n"
+                "  Chips Lines Style : %u\n"
+                "  Intensity: %u\n"
+                "  Scroll Mode: %u\n"
+                "  Scroll Speed: %u\n"
+                "  Scroll Dwell: %u\n"
+                "  Scroll Delay: %u",
+                this->num_chips_, this->num_chip_lines_, this->chip_lines_style_, this->intensity_, this->scroll_mode_,
+                this->scroll_speed_, this->scroll_dwell_, this->scroll_delay_);
   LOG_PIN("  CS Pin: ", this->cs_);
   LOG_UPDATE_INTERVAL(this);
 }

--- a/esphome/components/max9611/max9611.cpp
+++ b/esphome/components/max9611/max9611.cpp
@@ -52,7 +52,10 @@ void MAX9611Component::setup() {
   }
 }
 void MAX9611Component::dump_config() {
-  ESP_LOGCONFIG(TAG, "MAX9611:\n    CSA Gain Register: %x", gain_);
+  ESP_LOGCONFIG(TAG,
+                "MAX9611:\n"
+                "    CSA Gain Register: %x",
+                gain_);
   LOG_I2C_DEVICE(this);
 }
 void MAX9611Component::update() {

--- a/esphome/components/max9611/max9611.cpp
+++ b/esphome/components/max9611/max9611.cpp
@@ -52,8 +52,7 @@ void MAX9611Component::setup() {
   }
 }
 void MAX9611Component::dump_config() {
-  ESP_LOGCONFIG(TAG, "MAX9611:");
-  ESP_LOGCONFIG(TAG, "    CSA Gain Register: %x", gain_);
+  ESP_LOGCONFIG(TAG, "MAX9611:\n    CSA Gain Register: %x", gain_);
   LOG_I2C_DEVICE(this);
 }
 void MAX9611Component::update() {

--- a/esphome/components/mcp3008/sensor/mcp3008_sensor.cpp
+++ b/esphome/components/mcp3008/sensor/mcp3008_sensor.cpp
@@ -10,9 +10,7 @@ static const char *const TAG = "mcp3008.sensor";
 float MCP3008Sensor::get_setup_priority() const { return setup_priority::DATA; }
 
 void MCP3008Sensor::dump_config() {
-  ESP_LOGCONFIG(TAG, "MCP3008Sensor:");
-  ESP_LOGCONFIG(TAG, "  Pin: %u", this->pin_);
-  ESP_LOGCONFIG(TAG, "  Reference Voltage: %.2fV", this->reference_voltage_);
+  ESP_LOGCONFIG(TAG, "MCP3008Sensor:\n  Pin: %u\n  Reference Voltage: %.2fV", this->pin_, this->reference_voltage_);
 }
 
 float MCP3008Sensor::sample() {

--- a/esphome/components/mcp3008/sensor/mcp3008_sensor.cpp
+++ b/esphome/components/mcp3008/sensor/mcp3008_sensor.cpp
@@ -10,7 +10,11 @@ static const char *const TAG = "mcp3008.sensor";
 float MCP3008Sensor::get_setup_priority() const { return setup_priority::DATA; }
 
 void MCP3008Sensor::dump_config() {
-  ESP_LOGCONFIG(TAG, "MCP3008Sensor:\n  Pin: %u\n  Reference Voltage: %.2fV", this->pin_, this->reference_voltage_);
+  ESP_LOGCONFIG(TAG,
+                "MCP3008Sensor:\n"
+                "  Pin: %u\n"
+                "  Reference Voltage: %.2fV",
+                this->pin_, this->reference_voltage_);
 }
 
 float MCP3008Sensor::sample() {

--- a/esphome/components/mdns/mdns_component.cpp
+++ b/esphome/components/mdns/mdns_component.cpp
@@ -117,8 +117,7 @@ void MDNSComponent::compile_records_() {
 }
 
 void MDNSComponent::dump_config() {
-  ESP_LOGCONFIG(TAG, "mDNS:");
-  ESP_LOGCONFIG(TAG, "  Hostname: %s", this->hostname_.c_str());
+  ESP_LOGCONFIG(TAG, "mDNS:\n  Hostname: %s", this->hostname_.c_str());
   ESP_LOGV(TAG, "  Services:");
   for (const auto &service : this->services_) {
     ESP_LOGV(TAG, "  - %s, %s, %d", service.service_type.c_str(), service.proto.c_str(),

--- a/esphome/components/mdns/mdns_component.cpp
+++ b/esphome/components/mdns/mdns_component.cpp
@@ -117,7 +117,10 @@ void MDNSComponent::compile_records_() {
 }
 
 void MDNSComponent::dump_config() {
-  ESP_LOGCONFIG(TAG, "mDNS:\n  Hostname: %s", this->hostname_.c_str());
+  ESP_LOGCONFIG(TAG,
+                "mDNS:\n"
+                "  Hostname: %s",
+                this->hostname_.c_str());
   ESP_LOGV(TAG, "  Services:");
   for (const auto &service : this->services_) {
     ESP_LOGV(TAG, "  - %s, %s, %d", service.service_type.c_str(), service.proto.c_str(),

--- a/esphome/components/micro_wake_word/streaming_model.cpp
+++ b/esphome/components/micro_wake_word/streaming_model.cpp
@@ -11,15 +11,13 @@ namespace esphome {
 namespace micro_wake_word {
 
 void WakeWordModel::log_model_config() {
-  ESP_LOGCONFIG(TAG, "    - Wake Word: %s", this->wake_word_.c_str());
-  ESP_LOGCONFIG(TAG, "      Probability cutoff: %.2f", this->probability_cutoff_ / 255.0f);
-  ESP_LOGCONFIG(TAG, "      Sliding window size: %d", this->sliding_window_size_);
+  ESP_LOGCONFIG(TAG, "    - Wake Word: %s\n      Probability cutoff: %.2f\n      Sliding window size: %d",
+                this->wake_word_.c_str(), this->probability_cutoff_ / 255.0f, this->sliding_window_size_);
 }
 
 void VADModel::log_model_config() {
-  ESP_LOGCONFIG(TAG, "    - VAD Model");
-  ESP_LOGCONFIG(TAG, "      Probability cutoff: %.2f", this->probability_cutoff_ / 255.0f);
-  ESP_LOGCONFIG(TAG, "      Sliding window size: %d", this->sliding_window_size_);
+  ESP_LOGCONFIG(TAG, "    - VAD Model\n      Probability cutoff: %.2f\n      Sliding window size: %d",
+                this->probability_cutoff_ / 255.0f, this->sliding_window_size_);
 }
 
 bool StreamingModel::load_model_() {

--- a/esphome/components/micro_wake_word/streaming_model.cpp
+++ b/esphome/components/micro_wake_word/streaming_model.cpp
@@ -11,12 +11,18 @@ namespace esphome {
 namespace micro_wake_word {
 
 void WakeWordModel::log_model_config() {
-  ESP_LOGCONFIG(TAG, "    - Wake Word: %s\n      Probability cutoff: %.2f\n      Sliding window size: %d",
+  ESP_LOGCONFIG(TAG,
+                "    - Wake Word: %s\n"
+                "      Probability cutoff: %.2f\n"
+                "      Sliding window size: %d",
                 this->wake_word_.c_str(), this->probability_cutoff_ / 255.0f, this->sliding_window_size_);
 }
 
 void VADModel::log_model_config() {
-  ESP_LOGCONFIG(TAG, "    - VAD Model\n      Probability cutoff: %.2f\n      Sliding window size: %d",
+  ESP_LOGCONFIG(TAG,
+                "    - VAD Model\n"
+                "      Probability cutoff: %.2f\n"
+                "      Sliding window size: %d",
                 this->probability_cutoff_ / 255.0f, this->sliding_window_size_);
 }
 

--- a/esphome/components/midea/air_conditioner.cpp
+++ b/esphome/components/midea/air_conditioner.cpp
@@ -104,7 +104,10 @@ ClimateTraits AirConditioner::traits() {
 
 void AirConditioner::dump_config() {
   ESP_LOGCONFIG(Constants::TAG,
-                "MideaDongle:\n  [x] Period: %dms\n  [x] Response timeout: %dms\n  [x] Request attempts: %d",
+                "MideaDongle:\n"
+                "  [x] Period: %dms\n"
+                "  [x] Response timeout: %dms\n"
+                "  [x] Request attempts: %d",
                 this->base_.getPeriod(), this->base_.getTimeout(), this->base_.getNumAttempts());
 #ifdef USE_REMOTE_TRANSMITTER
   ESP_LOGCONFIG(Constants::TAG, "  [x] Using RemoteTransmitter");

--- a/esphome/components/midea/air_conditioner.cpp
+++ b/esphome/components/midea/air_conditioner.cpp
@@ -103,10 +103,9 @@ ClimateTraits AirConditioner::traits() {
 }
 
 void AirConditioner::dump_config() {
-  ESP_LOGCONFIG(Constants::TAG, "MideaDongle:");
-  ESP_LOGCONFIG(Constants::TAG, "  [x] Period: %dms", this->base_.getPeriod());
-  ESP_LOGCONFIG(Constants::TAG, "  [x] Response timeout: %dms", this->base_.getTimeout());
-  ESP_LOGCONFIG(Constants::TAG, "  [x] Request attempts: %d", this->base_.getNumAttempts());
+  ESP_LOGCONFIG(Constants::TAG,
+                "MideaDongle:\n  [x] Period: %dms\n  [x] Response timeout: %dms\n  [x] Request attempts: %d",
+                this->base_.getPeriod(), this->base_.getTimeout(), this->base_.getNumAttempts());
 #ifdef USE_REMOTE_TRANSMITTER
   ESP_LOGCONFIG(Constants::TAG, "  [x] Using RemoteTransmitter");
 #endif

--- a/esphome/components/mipi_spi/mipi_spi.cpp
+++ b/esphome/components/mipi_spi/mipi_spi.cpp
@@ -447,8 +447,8 @@ void MipiSpi::write_command_(uint8_t cmd, const uint8_t *bytes, size_t len) {
 }
 
 void MipiSpi::dump_config() {
-  ESP_LOGCONFIG(TAG, "MIPI_SPI Display");
-  ESP_LOGCONFIG(TAG, "  Model: %s\n  Width: %u\n  Height: %u", this->model_, this->width_, this->height_);
+  ESP_LOGCONFIG(TAG, "MIPI_SPI Display\n  Model: %s\n  Width: %u\n  Height: %u", this->model_, this->width_,
+                this->height_);
   if (this->offset_width_ != 0)
     ESP_LOGCONFIG(TAG, "  Offset width: %u", this->offset_width_);
   if (this->offset_height_ != 0)

--- a/esphome/components/mipi_spi/mipi_spi.cpp
+++ b/esphome/components/mipi_spi/mipi_spi.cpp
@@ -448,20 +448,23 @@ void MipiSpi::write_command_(uint8_t cmd, const uint8_t *bytes, size_t len) {
 
 void MipiSpi::dump_config() {
   ESP_LOGCONFIG(TAG, "MIPI_SPI Display");
-  ESP_LOGCONFIG(TAG, "  Model: %s", this->model_);
-  ESP_LOGCONFIG(TAG, "  Width: %u", this->width_);
-  ESP_LOGCONFIG(TAG, "  Height: %u", this->height_);
+  ESP_LOGCONFIG(TAG, "  Model: %s\n  Width: %u\n  Height: %u", this->model_, this->width_, this->height_);
   if (this->offset_width_ != 0)
     ESP_LOGCONFIG(TAG, "  Offset width: %u", this->offset_width_);
   if (this->offset_height_ != 0)
     ESP_LOGCONFIG(TAG, "  Offset height: %u", this->offset_height_);
-  ESP_LOGCONFIG(TAG, "  Swap X/Y: %s", YESNO(this->madctl_ & MADCTL_MV));
-  ESP_LOGCONFIG(TAG, "  Mirror X: %s", YESNO(this->madctl_ & (MADCTL_MX | MADCTL_XFLIP)));
-  ESP_LOGCONFIG(TAG, "  Mirror Y: %s", YESNO(this->madctl_ & (MADCTL_MY | MADCTL_YFLIP)));
-  ESP_LOGCONFIG(TAG, "  Color depth: %d bits", this->color_depth_ == display::COLOR_BITNESS_565 ? 16 : 8);
-  ESP_LOGCONFIG(TAG, "  Invert colors: %s", YESNO(this->invert_colors_));
-  ESP_LOGCONFIG(TAG, "  Color order: %s", this->madctl_ & MADCTL_BGR ? "BGR" : "RGB");
-  ESP_LOGCONFIG(TAG, "  Pixel mode: %s", this->pixel_mode_ == PIXEL_MODE_18 ? "18bit" : "16bit");
+  ESP_LOGCONFIG(TAG,
+                "  Swap X/Y: %s\n"
+                "  Mirror X: %s\n"
+                "  Mirror Y: %s\n"
+                "  Color depth: %d bits\n"
+                "  Invert colors: %s\n"
+                "  Color order: %s\n"
+                "  Pixel mode: %s",
+                YESNO(this->madctl_ & MADCTL_MV), YESNO(this->madctl_ & (MADCTL_MX | MADCTL_XFLIP)),
+                YESNO(this->madctl_ & (MADCTL_MY | MADCTL_YFLIP)),
+                this->color_depth_ == display::COLOR_BITNESS_565 ? 16 : 8, YESNO(this->invert_colors_),
+                this->madctl_ & MADCTL_BGR ? "BGR" : "RGB", this->pixel_mode_ == PIXEL_MODE_18 ? "18bit" : "16bit");
   if (this->brightness_.has_value())
     ESP_LOGCONFIG(TAG, "  Brightness: %u", this->brightness_.value());
   if (this->spi_16_)

--- a/esphome/components/mipi_spi/mipi_spi.cpp
+++ b/esphome/components/mipi_spi/mipi_spi.cpp
@@ -475,9 +475,8 @@ void MipiSpi::dump_config() {
   LOG_PIN("  CS Pin: ", this->cs_);
   LOG_PIN("  Reset Pin: ", this->reset_pin_);
   LOG_PIN("  DC Pin: ", this->dc_pin_);
-  ESP_LOGCONFIG(TAG, "  SPI Mode: %d", this->mode_);
-  ESP_LOGCONFIG(TAG, "  SPI Data rate: %dMHz", static_cast<unsigned>(this->data_rate_ / 1000000));
-  ESP_LOGCONFIG(TAG, "  SPI Bus width: %d", this->bus_width_);
+  ESP_LOGCONFIG(TAG, "  SPI Mode: %d\n  SPI Data rate: %dMHz\n  SPI Bus width: %d", this->mode_,
+                static_cast<unsigned>(this->data_rate_ / 1000000), this->bus_width_);
 }
 
 }  // namespace mipi_spi

--- a/esphome/components/mipi_spi/mipi_spi.cpp
+++ b/esphome/components/mipi_spi/mipi_spi.cpp
@@ -447,8 +447,12 @@ void MipiSpi::write_command_(uint8_t cmd, const uint8_t *bytes, size_t len) {
 }
 
 void MipiSpi::dump_config() {
-  ESP_LOGCONFIG(TAG, "MIPI_SPI Display\n  Model: %s\n  Width: %u\n  Height: %u", this->model_, this->width_,
-                this->height_);
+  ESP_LOGCONFIG(TAG,
+                "MIPI_SPI Display\n"
+                "  Model: %s\n"
+                "  Width: %u\n"
+                "  Height: %u",
+                this->model_, this->width_, this->height_);
   if (this->offset_width_ != 0)
     ESP_LOGCONFIG(TAG, "  Offset width: %u", this->offset_width_);
   if (this->offset_height_ != 0)
@@ -475,8 +479,11 @@ void MipiSpi::dump_config() {
   LOG_PIN("  CS Pin: ", this->cs_);
   LOG_PIN("  Reset Pin: ", this->reset_pin_);
   LOG_PIN("  DC Pin: ", this->dc_pin_);
-  ESP_LOGCONFIG(TAG, "  SPI Mode: %d\n  SPI Data rate: %dMHz\n  SPI Bus width: %d", this->mode_,
-                static_cast<unsigned>(this->data_rate_ / 1000000), this->bus_width_);
+  ESP_LOGCONFIG(TAG,
+                "  SPI Mode: %d\n"
+                "  SPI Data rate: %dMHz\n"
+                "  SPI Bus width: %d",
+                this->mode_, static_cast<unsigned>(this->data_rate_ / 1000000), this->bus_width_);
 }
 
 }  // namespace mipi_spi

--- a/esphome/components/mixer/speaker/mixer_speaker.cpp
+++ b/esphome/components/mixer/speaker/mixer_speaker.cpp
@@ -43,7 +43,10 @@ enum MixerEventGroupBits : uint32_t {
 };
 
 void SourceSpeaker::dump_config() {
-  ESP_LOGCONFIG(TAG, "Mixer Source Speaker\n  Buffer Duration: %" PRIu32 " ms", this->buffer_duration_ms_);
+  ESP_LOGCONFIG(TAG,
+                "Mixer Source Speaker\n"
+                "  Buffer Duration: %" PRIu32 " ms",
+                this->buffer_duration_ms_);
   if (this->timeout_ms_.has_value()) {
     ESP_LOGCONFIG(TAG, "  Timeout: %" PRIu32 " ms", this->timeout_ms_.value());
   } else {

--- a/esphome/components/mixer/speaker/mixer_speaker.cpp
+++ b/esphome/components/mixer/speaker/mixer_speaker.cpp
@@ -290,7 +290,10 @@ void SourceSpeaker::duck_samples(int16_t *input_buffer, uint32_t input_samples_t
 }
 
 void MixerSpeaker::dump_config() {
-  ESP_LOGCONFIG(TAG, "Speaker Mixer:\n  Number of output channels: %u", this->output_channels_);
+  ESP_LOGCONFIG(TAG,
+                "Speaker Mixer:\n"
+                "  Number of output channels: %u",
+                this->output_channels_);
 }
 
 void MixerSpeaker::setup() {

--- a/esphome/components/mixer/speaker/mixer_speaker.cpp
+++ b/esphome/components/mixer/speaker/mixer_speaker.cpp
@@ -43,8 +43,7 @@ enum MixerEventGroupBits : uint32_t {
 };
 
 void SourceSpeaker::dump_config() {
-  ESP_LOGCONFIG(TAG, "Mixer Source Speaker");
-  ESP_LOGCONFIG(TAG, "  Buffer Duration: %" PRIu32 " ms", this->buffer_duration_ms_);
+  ESP_LOGCONFIG(TAG, "Mixer Source Speaker\n  Buffer Duration: %" PRIu32 " ms", this->buffer_duration_ms_);
   if (this->timeout_ms_.has_value()) {
     ESP_LOGCONFIG(TAG, "  Timeout: %" PRIu32 " ms", this->timeout_ms_.value());
   } else {
@@ -291,8 +290,7 @@ void SourceSpeaker::duck_samples(int16_t *input_buffer, uint32_t input_samples_t
 }
 
 void MixerSpeaker::dump_config() {
-  ESP_LOGCONFIG(TAG, "Speaker Mixer:");
-  ESP_LOGCONFIG(TAG, "  Number of output channels: %u", this->output_channels_);
+  ESP_LOGCONFIG(TAG, "Speaker Mixer:\n  Number of output channels: %u", this->output_channels_);
 }
 
 void MixerSpeaker::setup() {

--- a/esphome/components/modbus/modbus.cpp
+++ b/esphome/components/modbus/modbus.cpp
@@ -165,7 +165,10 @@ bool Modbus::parse_modbus_byte_(uint8_t byte) {
 void Modbus::dump_config() {
   ESP_LOGCONFIG(TAG, "Modbus:");
   LOG_PIN("  Flow Control Pin: ", this->flow_control_pin_);
-  ESP_LOGCONFIG(TAG, "  Send Wait Time: %d ms\n  CRC Disabled: %s", this->send_wait_time_, YESNO(this->disable_crc_));
+  ESP_LOGCONFIG(TAG,
+                "  Send Wait Time: %d ms\n"
+                "  CRC Disabled: %s",
+                this->send_wait_time_, YESNO(this->disable_crc_));
 }
 float Modbus::get_setup_priority() const {
   // After UART bus

--- a/esphome/components/modbus/modbus.cpp
+++ b/esphome/components/modbus/modbus.cpp
@@ -165,8 +165,7 @@ bool Modbus::parse_modbus_byte_(uint8_t byte) {
 void Modbus::dump_config() {
   ESP_LOGCONFIG(TAG, "Modbus:");
   LOG_PIN("  Flow Control Pin: ", this->flow_control_pin_);
-  ESP_LOGCONFIG(TAG, "  Send Wait Time: %d ms", this->send_wait_time_);
-  ESP_LOGCONFIG(TAG, "  CRC Disabled: %s", YESNO(this->disable_crc_));
+  ESP_LOGCONFIG(TAG, "  Send Wait Time: %d ms\n  CRC Disabled: %s", this->send_wait_time_, YESNO(this->disable_crc_));
 }
 float Modbus::get_setup_priority() const {
   // After UART bus

--- a/esphome/components/modbus_controller/modbus_controller.cpp
+++ b/esphome/components/modbus_controller/modbus_controller.cpp
@@ -346,10 +346,12 @@ size_t ModbusController::create_register_ranges_() {
 }
 
 void ModbusController::dump_config() {
-  ESP_LOGCONFIG(TAG, "ModbusController:");
-  ESP_LOGCONFIG(TAG, "  Address: 0x%02X", this->address_);
-  ESP_LOGCONFIG(TAG, "  Max Command Retries: %d", this->max_cmd_retries_);
-  ESP_LOGCONFIG(TAG, "  Offline Skip Updates: %d", this->offline_skip_updates_);
+  ESP_LOGCONFIG(TAG,
+                "ModbusController:\n"
+                "  Address: 0x%02X\n"
+                "  Max Command Retries: %d\n"
+                "  Offline Skip Updates: %d",
+                this->address_, this->max_cmd_retries_, this->offline_skip_updates_);
 #if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERBOSE
   ESP_LOGCONFIG(TAG, "sensormap");
   for (auto &it : this->sensorset_) {

--- a/esphome/components/modbus_controller/output/modbus_output.cpp
+++ b/esphome/components/modbus_controller/output/modbus_output.cpp
@@ -52,8 +52,11 @@ void ModbusFloatOutput::write_state(float value) {
 void ModbusFloatOutput::dump_config() {
   ESP_LOGCONFIG(TAG, "Modbus Float Output:");
   LOG_FLOAT_OUTPUT(this);
-  ESP_LOGCONFIG(TAG, "  Device start address: 0x%X\n  Register count: %d\n  Value type: %d", this->start_address,
-                this->register_count, static_cast<int>(this->sensor_value_type));
+  ESP_LOGCONFIG(TAG,
+                "  Device start address: 0x%X\n"
+                "  Register count: %d\n"
+                "  Value type: %d",
+                this->start_address, this->register_count, static_cast<int>(this->sensor_value_type));
 }
 
 // ModbusBinaryOutput
@@ -101,8 +104,11 @@ void ModbusBinaryOutput::write_state(bool state) {
 void ModbusBinaryOutput::dump_config() {
   ESP_LOGCONFIG(TAG, "Modbus Binary Output:");
   LOG_BINARY_OUTPUT(this);
-  ESP_LOGCONFIG(TAG, "  Device start address: 0x%X\n  Register count: %d\n  Value type: %d", this->start_address,
-                this->register_count, static_cast<int>(this->sensor_value_type));
+  ESP_LOGCONFIG(TAG,
+                "  Device start address: 0x%X\n"
+                "  Register count: %d\n"
+                "  Value type: %d",
+                this->start_address, this->register_count, static_cast<int>(this->sensor_value_type));
 }
 
 }  // namespace modbus_controller

--- a/esphome/components/modbus_controller/output/modbus_output.cpp
+++ b/esphome/components/modbus_controller/output/modbus_output.cpp
@@ -52,9 +52,8 @@ void ModbusFloatOutput::write_state(float value) {
 void ModbusFloatOutput::dump_config() {
   ESP_LOGCONFIG(TAG, "Modbus Float Output:");
   LOG_FLOAT_OUTPUT(this);
-  ESP_LOGCONFIG(TAG, "  Device start address: 0x%X", this->start_address);
-  ESP_LOGCONFIG(TAG, "  Register count: %d", this->register_count);
-  ESP_LOGCONFIG(TAG, "  Value type: %d", static_cast<int>(this->sensor_value_type));
+  ESP_LOGCONFIG(TAG, "  Device start address: 0x%X\n  Register count: %d\n  Value type: %d", this->start_address,
+                this->register_count, static_cast<int>(this->sensor_value_type));
 }
 
 // ModbusBinaryOutput
@@ -102,9 +101,8 @@ void ModbusBinaryOutput::write_state(bool state) {
 void ModbusBinaryOutput::dump_config() {
   ESP_LOGCONFIG(TAG, "Modbus Binary Output:");
   LOG_BINARY_OUTPUT(this);
-  ESP_LOGCONFIG(TAG, "  Device start address: 0x%X", this->start_address);
-  ESP_LOGCONFIG(TAG, "  Register count: %d", this->register_count);
-  ESP_LOGCONFIG(TAG, "  Value type: %d", static_cast<int>(this->sensor_value_type));
+  ESP_LOGCONFIG(TAG, "  Device start address: 0x%X\n  Register count: %d\n  Value type: %d", this->start_address,
+                this->register_count, static_cast<int>(this->sensor_value_type));
 }
 
 }  // namespace modbus_controller

--- a/esphome/components/mqtt/mqtt_alarm_control_panel.cpp
+++ b/esphome/components/mqtt/mqtt_alarm_control_panel.cpp
@@ -45,7 +45,10 @@ void MQTTAlarmControlPanelComponent::setup() {
 void MQTTAlarmControlPanelComponent::dump_config() {
   ESP_LOGCONFIG(TAG, "MQTT alarm_control_panel '%s':", this->alarm_control_panel_->get_name().c_str());
   LOG_MQTT_COMPONENT(true, true)
-  ESP_LOGCONFIG(TAG, "  Supported Features: %" PRIu32 "\n  Requires Code to Disarm: %s\n  Requires Code To Arm: %s",
+  ESP_LOGCONFIG(TAG,
+                "  Supported Features: %" PRIu32 "\n"
+                "  Requires Code to Disarm: %s\n"
+                "  Requires Code To Arm: %s",
                 this->alarm_control_panel_->get_supported_features(),
                 YESNO(this->alarm_control_panel_->get_requires_code()),
                 YESNO(this->alarm_control_panel_->get_requires_code_to_arm()));

--- a/esphome/components/mqtt/mqtt_alarm_control_panel.cpp
+++ b/esphome/components/mqtt/mqtt_alarm_control_panel.cpp
@@ -45,9 +45,10 @@ void MQTTAlarmControlPanelComponent::setup() {
 void MQTTAlarmControlPanelComponent::dump_config() {
   ESP_LOGCONFIG(TAG, "MQTT alarm_control_panel '%s':", this->alarm_control_panel_->get_name().c_str());
   LOG_MQTT_COMPONENT(true, true)
-  ESP_LOGCONFIG(TAG, "  Supported Features: %" PRIu32, this->alarm_control_panel_->get_supported_features());
-  ESP_LOGCONFIG(TAG, "  Requires Code to Disarm: %s", YESNO(this->alarm_control_panel_->get_requires_code()));
-  ESP_LOGCONFIG(TAG, "  Requires Code To Arm: %s", YESNO(this->alarm_control_panel_->get_requires_code_to_arm()));
+  ESP_LOGCONFIG(TAG, "  Supported Features: %" PRIu32 "\n  Requires Code to Disarm: %s\n  Requires Code To Arm: %s",
+                this->alarm_control_panel_->get_supported_features(),
+                YESNO(this->alarm_control_panel_->get_requires_code()),
+                YESNO(this->alarm_control_panel_->get_requires_code_to_arm()));
 }
 
 void MQTTAlarmControlPanelComponent::send_discovery(JsonObject root, mqtt::SendDiscoveryConfig &config) {

--- a/esphome/components/mqtt/mqtt_client.cpp
+++ b/esphome/components/mqtt/mqtt_client.cpp
@@ -149,18 +149,23 @@ void MQTTClientComponent::send_device_info_() {
 }
 
 void MQTTClientComponent::dump_config() {
-  ESP_LOGCONFIG(TAG, "MQTT:");
-  ESP_LOGCONFIG(TAG, "  Server Address: %s:%u (%s)", this->credentials_.address.c_str(), this->credentials_.port,
-                this->ip_.str().c_str());
-  ESP_LOGCONFIG(TAG, "  Username: " LOG_SECRET("'%s'"), this->credentials_.username.c_str());
-  ESP_LOGCONFIG(TAG, "  Client ID: " LOG_SECRET("'%s'"), this->credentials_.client_id.c_str());
-  ESP_LOGCONFIG(TAG, "  Clean Session: %s", YESNO(this->credentials_.clean_session));
+  ESP_LOGCONFIG(TAG,
+                "MQTT:\n"
+                "  Server Address: %s:%u (%s)\n"
+                "  Username: " LOG_SECRET("'%s'") "\n"
+                                                  "  Client ID: " LOG_SECRET("'%s'") "\n"
+                                                                                     "  Clean Session: %s",
+                this->credentials_.address.c_str(), this->credentials_.port, this->ip_.str().c_str(),
+                this->credentials_.username.c_str(), this->credentials_.client_id.c_str(),
+                YESNO(this->credentials_.clean_session));
   if (this->is_discovery_ip_enabled()) {
     ESP_LOGCONFIG(TAG, "  Discovery IP enabled");
   }
   if (!this->discovery_info_.prefix.empty()) {
-    ESP_LOGCONFIG(TAG, "  Discovery prefix: '%s'", this->discovery_info_.prefix.c_str());
-    ESP_LOGCONFIG(TAG, "  Discovery retain: %s", YESNO(this->discovery_info_.retain));
+    ESP_LOGCONFIG(TAG,
+                  "  Discovery prefix: '%s'\n"
+                  "  Discovery retain: %s",
+                  this->discovery_info_.prefix.c_str(), YESNO(this->discovery_info_.retain));
   }
   ESP_LOGCONFIG(TAG, "  Topic Prefix: '%s'", this->topic_prefix_.c_str());
   if (!this->log_message_.topic.empty()) {
@@ -721,9 +726,11 @@ void MQTTMessageTrigger::setup() {
       this->qos_);
 }
 void MQTTMessageTrigger::dump_config() {
-  ESP_LOGCONFIG(TAG, "MQTT Message Trigger:");
-  ESP_LOGCONFIG(TAG, "  Topic: '%s'", this->topic_.c_str());
-  ESP_LOGCONFIG(TAG, "  QoS: %u", this->qos_);
+  ESP_LOGCONFIG(TAG,
+                "MQTT Message Trigger:\n"
+                "  Topic: '%s'\n"
+                "  QoS: %u",
+                this->topic_.c_str(), this->qos_);
 }
 float MQTTMessageTrigger::get_setup_priority() const { return setup_priority::AFTER_CONNECTION; }
 

--- a/esphome/components/mqtt/mqtt_cover.cpp
+++ b/esphome/components/mqtt/mqtt_cover.cpp
@@ -54,12 +54,16 @@ void MQTTCoverComponent::dump_config() {
   bool has_command_topic = traits.get_supports_position() || !traits.get_supports_tilt();
   LOG_MQTT_COMPONENT(true, has_command_topic)
   if (traits.get_supports_position()) {
-    ESP_LOGCONFIG(TAG, "  Position State Topic: '%s'", this->get_position_state_topic().c_str());
-    ESP_LOGCONFIG(TAG, "  Position Command Topic: '%s'", this->get_position_command_topic().c_str());
+    ESP_LOGCONFIG(TAG,
+                  "  Position State Topic: '%s'\n"
+                  "  Position Command Topic: '%s'",
+                  this->get_position_state_topic().c_str(), this->get_position_command_topic().c_str());
   }
   if (traits.get_supports_tilt()) {
-    ESP_LOGCONFIG(TAG, "  Tilt State Topic: '%s'", this->get_tilt_state_topic().c_str());
-    ESP_LOGCONFIG(TAG, "  Tilt Command Topic: '%s'", this->get_tilt_command_topic().c_str());
+    ESP_LOGCONFIG(TAG,
+                  "  Tilt State Topic: '%s'\n"
+                  "  Tilt Command Topic: '%s'",
+                  this->get_tilt_state_topic().c_str(), this->get_tilt_command_topic().c_str());
   }
 }
 void MQTTCoverComponent::send_discovery(JsonObject root, mqtt::SendDiscoveryConfig &config) {

--- a/esphome/components/mqtt/mqtt_fan.cpp
+++ b/esphome/components/mqtt/mqtt_fan.cpp
@@ -121,16 +121,22 @@ void MQTTFanComponent::dump_config() {
   ESP_LOGCONFIG(TAG, "MQTT Fan '%s': ", this->state_->get_name().c_str());
   LOG_MQTT_COMPONENT(true, true);
   if (this->state_->get_traits().supports_direction()) {
-    ESP_LOGCONFIG(TAG, "  Direction State Topic: '%s'", this->get_direction_state_topic().c_str());
-    ESP_LOGCONFIG(TAG, "  Direction Command Topic: '%s'", this->get_direction_command_topic().c_str());
+    ESP_LOGCONFIG(TAG,
+                  "  Direction State Topic: '%s'\n"
+                  "  Direction Command Topic: '%s'",
+                  this->get_direction_state_topic().c_str(), this->get_direction_command_topic().c_str());
   }
   if (this->state_->get_traits().supports_oscillation()) {
-    ESP_LOGCONFIG(TAG, "  Oscillation State Topic: '%s'", this->get_oscillation_state_topic().c_str());
-    ESP_LOGCONFIG(TAG, "  Oscillation Command Topic: '%s'", this->get_oscillation_command_topic().c_str());
+    ESP_LOGCONFIG(TAG,
+                  "  Oscillation State Topic: '%s'\n"
+                  "  Oscillation Command Topic: '%s'",
+                  this->get_oscillation_state_topic().c_str(), this->get_oscillation_command_topic().c_str());
   }
   if (this->state_->get_traits().supports_speed()) {
-    ESP_LOGCONFIG(TAG, "  Speed Level State Topic: '%s'", this->get_speed_level_state_topic().c_str());
-    ESP_LOGCONFIG(TAG, "  Speed Level Command Topic: '%s'", this->get_speed_level_command_topic().c_str());
+    ESP_LOGCONFIG(TAG,
+                  "  Speed Level State Topic: '%s'\n"
+                  "  Speed Level Command Topic: '%s'",
+                  this->get_speed_level_state_topic().c_str(), this->get_speed_level_command_topic().c_str());
   }
 }
 

--- a/esphome/components/mqtt/mqtt_valve.cpp
+++ b/esphome/components/mqtt/mqtt_valve.cpp
@@ -42,8 +42,10 @@ void MQTTValveComponent::dump_config() {
   bool has_command_topic = traits.get_supports_position();
   LOG_MQTT_COMPONENT(true, has_command_topic)
   if (traits.get_supports_position()) {
-    ESP_LOGCONFIG(TAG, "  Position State Topic: '%s'", this->get_position_state_topic().c_str());
-    ESP_LOGCONFIG(TAG, "  Position Command Topic: '%s'", this->get_position_command_topic().c_str());
+    ESP_LOGCONFIG(TAG,
+                  "  Position State Topic: '%s'\n"
+                  "  Position Command Topic: '%s'",
+                  this->get_position_state_topic().c_str(), this->get_position_command_topic().c_str());
   }
 }
 void MQTTValveComponent::send_discovery(JsonObject root, mqtt::SendDiscoveryConfig &config) {

--- a/esphome/components/msa3xx/msa3xx.cpp
+++ b/esphome/components/msa3xx/msa3xx.cpp
@@ -161,13 +161,17 @@ void MSA3xxComponent::dump_config() {
   if (this->is_failed()) {
     ESP_LOGE(TAG, ESP_LOG_MSG_COMM_FAIL);
   }
-  ESP_LOGCONFIG(TAG, "  Model: %s", model_to_string(this->model_));
-  ESP_LOGCONFIG(TAG, "  Power Mode: %s", power_mode_to_string(this->power_mode_));
-  ESP_LOGCONFIG(TAG, "  Bandwidth: %s", bandwidth_to_string(this->bandwidth_));
-  ESP_LOGCONFIG(TAG, "  Range: %s", range_to_string(this->range_));
-  ESP_LOGCONFIG(TAG, "  Resolution: %s", res_to_string(this->resolution_));
-  ESP_LOGCONFIG(TAG, "  Offsets: {%.3f m/s², %.3f m/s², %.3f m/s²}", this->offset_x_, this->offset_y_, this->offset_z_);
-  ESP_LOGCONFIG(TAG, "  Transform: {mirror_x=%s, mirror_y=%s, mirror_z=%s, swap_xy=%s}", YESNO(this->swap_.x_polarity),
+  ESP_LOGCONFIG(TAG,
+                "  Model: %s\n"
+                "  Power Mode: %s\n"
+                "  Bandwidth: %s\n"
+                "  Range: %s\n"
+                "  Resolution: %s\n"
+                "  Offsets: {%.3f m/s², %.3f m/s², %.3f m/s²}\n"
+                "  Transform: {mirror_x=%s, mirror_y=%s, mirror_z=%s, swap_xy=%s}",
+                model_to_string(this->model_), power_mode_to_string(this->power_mode_),
+                bandwidth_to_string(this->bandwidth_), range_to_string(this->range_), res_to_string(this->resolution_),
+                this->offset_x_, this->offset_y_, this->offset_z_, YESNO(this->swap_.x_polarity),
                 YESNO(this->swap_.y_polarity), YESNO(this->swap_.z_polarity), YESNO(this->swap_.x_y_swap));
   LOG_UPDATE_INTERVAL(this);
 

--- a/esphome/components/my9231/my9231.cpp
+++ b/esphome/components/my9231/my9231.cpp
@@ -63,9 +63,11 @@ void MY9231OutputComponent::dump_config() {
   ESP_LOGCONFIG(TAG, "MY9231:");
   LOG_PIN("  DI Pin: ", this->pin_di_);
   LOG_PIN("  DCKI Pin: ", this->pin_dcki_);
-  ESP_LOGCONFIG(TAG, "  Total number of channels: %u", this->num_channels_);
-  ESP_LOGCONFIG(TAG, "  Number of chips: %u", this->num_chips_);
-  ESP_LOGCONFIG(TAG, "  Bit depth: %u", this->bit_depth_);
+  ESP_LOGCONFIG(TAG,
+                "  Total number of channels: %u\n"
+                "  Number of chips: %u\n"
+                "  Bit depth: %u",
+                this->num_channels_, this->num_chips_, this->bit_depth_);
 }
 void MY9231OutputComponent::loop() {
   if (!this->update_)

--- a/esphome/components/nau7802/nau7802.cpp
+++ b/esphome/components/nau7802/nau7802.cpp
@@ -131,8 +131,8 @@ void NAU7802Sensor::dump_config() {
     return;
   }
   // Note these may differ from the values on the device if calbration has been run
-  ESP_LOGCONFIG(TAG, "  Offset Calibration: %s", to_string(this->offset_calibration_).c_str());
-  ESP_LOGCONFIG(TAG, "  Gain Calibration: %f", this->gain_calibration_);
+  ESP_LOGCONFIG(TAG, "  Offset Calibration: %s\n  Gain Calibration: %f", to_string(this->offset_calibration_).c_str(),
+                this->gain_calibration_);
 
   std::string voltage = "unknown";
   switch (this->ldo_) {

--- a/esphome/components/nau7802/nau7802.cpp
+++ b/esphome/components/nau7802/nau7802.cpp
@@ -131,8 +131,10 @@ void NAU7802Sensor::dump_config() {
     return;
   }
   // Note these may differ from the values on the device if calbration has been run
-  ESP_LOGCONFIG(TAG, "  Offset Calibration: %s\n  Gain Calibration: %f", to_string(this->offset_calibration_).c_str(),
-                this->gain_calibration_);
+  ESP_LOGCONFIG(TAG,
+                "  Offset Calibration: %s\n"
+                "  Gain Calibration: %f",
+                to_string(this->offset_calibration_).c_str(), this->gain_calibration_);
 
   std::string voltage = "unknown";
   switch (this->ldo_) {

--- a/esphome/components/nextion/nextion.cpp
+++ b/esphome/components/nextion/nextion.cpp
@@ -150,13 +150,18 @@ void Nextion::dump_config() {
   if (this->skip_connection_handshake_) {
     ESP_LOGCONFIG(TAG, "  Skip handshake:   %s", YESNO(this->skip_connection_handshake_));
   } else {
-    ESP_LOGCONFIG(TAG, "  Device Model:     %s", this->device_model_.c_str());
-    ESP_LOGCONFIG(TAG, "  Firmware Version: %s", this->firmware_version_.c_str());
-    ESP_LOGCONFIG(TAG, "  Serial Number:    %s", this->serial_number_.c_str());
-    ESP_LOGCONFIG(TAG, "  Flash Size:       %s", this->flash_size_.c_str());
+    ESP_LOGCONFIG(TAG,
+                  "  Device Model:     %s\n"
+                  "  Firmware Version: %s\n"
+                  "  Serial Number:    %s\n"
+                  "  Flash Size:       %s",
+                  this->device_model_.c_str(), this->firmware_version_.c_str(), this->serial_number_.c_str(),
+                  this->flash_size_.c_str());
   }
-  ESP_LOGCONFIG(TAG, "  Wake On Touch:    %s", YESNO(this->auto_wake_on_touch_));
-  ESP_LOGCONFIG(TAG, "  Exit reparse:     %s", YESNO(this->exit_reparse_on_start_));
+  ESP_LOGCONFIG(TAG,
+                "  Wake On Touch:    %s\n"
+                "  Exit reparse:     %s",
+                YESNO(this->auto_wake_on_touch_), YESNO(this->exit_reparse_on_start_));
 
   if (this->touch_sleep_timeout_ != 0) {
     ESP_LOGCONFIG(TAG, "  Touch Timeout:    %" PRIu32, this->touch_sleep_timeout_);

--- a/esphome/components/opentherm/hub.cpp
+++ b/esphome/components/opentherm/hub.cpp
@@ -399,13 +399,17 @@ void OpenthermHub::dump_config() {
   ESP_LOGCONFIG(TAG, "OpenTherm:");
   LOG_PIN("  In: ", this->in_pin_);
   LOG_PIN("  Out: ", this->out_pin_);
-  ESP_LOGCONFIG(TAG, "  Sync mode: %s", YESNO(this->sync_mode_));
-  ESP_LOGCONFIG(TAG, "  Sensors: %s", SHOW(OPENTHERM_SENSOR_LIST(ID, )));
-  ESP_LOGCONFIG(TAG, "  Binary sensors: %s", SHOW(OPENTHERM_BINARY_SENSOR_LIST(ID, )));
-  ESP_LOGCONFIG(TAG, "  Switches: %s", SHOW(OPENTHERM_SWITCH_LIST(ID, )));
-  ESP_LOGCONFIG(TAG, "  Input sensors: %s", SHOW(OPENTHERM_INPUT_SENSOR_LIST(ID, )));
-  ESP_LOGCONFIG(TAG, "  Outputs: %s", SHOW(OPENTHERM_OUTPUT_LIST(ID, )));
-  ESP_LOGCONFIG(TAG, "  Numbers: %s", SHOW(OPENTHERM_NUMBER_LIST(ID, )));
+  ESP_LOGCONFIG(TAG,
+                "  Sync mode: %s\n"
+                "  Sensors: %s\n"
+                "  Binary sensors: %s\n"
+                "  Switches: %s\n"
+                "  Input sensors: %s\n"
+                "  Outputs: %s\n"
+                "  Numbers: %s",
+                YESNO(this->sync_mode_), SHOW(OPENTHERM_SENSOR_LIST(ID, )), SHOW(OPENTHERM_BINARY_SENSOR_LIST(ID, )),
+                SHOW(OPENTHERM_SWITCH_LIST(ID, )), SHOW(OPENTHERM_INPUT_SENSOR_LIST(ID, )),
+                SHOW(OPENTHERM_OUTPUT_LIST(ID, )), SHOW(OPENTHERM_NUMBER_LIST(ID, )));
   ESP_LOGCONFIG(TAG, "  Initial requests:");
   for (auto type : initial_messages) {
     ESP_LOGCONFIG(TAG, "  - %d (%s)", type, this->opentherm_->message_id_to_str(type));

--- a/esphome/components/opentherm/number/number.cpp
+++ b/esphome/components/opentherm/number/number.cpp
@@ -31,8 +31,11 @@ void OpenthermNumber::setup() {
 
 void OpenthermNumber::dump_config() {
   LOG_NUMBER("", "OpenTherm Number", this);
-  ESP_LOGCONFIG(TAG, "  Restore value: %d\n  Initial value: %.2f\n  Current value: %.2f", this->restore_value_,
-                this->initial_value_, this->state);
+  ESP_LOGCONFIG(TAG,
+                "  Restore value: %d\n"
+                "  Initial value: %.2f\n"
+                "  Current value: %.2f",
+                this->restore_value_, this->initial_value_, this->state);
 }
 
 }  // namespace opentherm

--- a/esphome/components/opentherm/number/number.cpp
+++ b/esphome/components/opentherm/number/number.cpp
@@ -31,9 +31,8 @@ void OpenthermNumber::setup() {
 
 void OpenthermNumber::dump_config() {
   LOG_NUMBER("", "OpenTherm Number", this);
-  ESP_LOGCONFIG(TAG, "  Restore value: %d", this->restore_value_);
-  ESP_LOGCONFIG(TAG, "  Initial value: %.2f", this->initial_value_);
-  ESP_LOGCONFIG(TAG, "  Current value: %.2f", this->state);
+  ESP_LOGCONFIG(TAG, "  Restore value: %d\n  Initial value: %.2f\n  Current value: %.2f", this->restore_value_,
+                this->initial_value_, this->state);
 }
 
 }  // namespace opentherm

--- a/esphome/components/packet_transport/packet_transport.cpp
+++ b/esphome/components/packet_transport/packet_transport.cpp
@@ -474,10 +474,8 @@ void PacketTransport::process_(const std::vector<uint8_t> &data) {
 }
 
 void PacketTransport::dump_config() {
-  ESP_LOGCONFIG(TAG, "Packet Transport:");
-  ESP_LOGCONFIG(TAG, "  Platform: %s", this->platform_name_);
-  ESP_LOGCONFIG(TAG, "  Encrypted: %s", YESNO(this->is_encrypted_()));
-  ESP_LOGCONFIG(TAG, "  Ping-pong: %s", YESNO(this->ping_pong_enable_));
+  ESP_LOGCONFIG(TAG, "Packet Transport:\n  Platform: %s\n  Encrypted: %s\n  Ping-pong: %s", this->platform_name_,
+                YESNO(this->is_encrypted_()), YESNO(this->ping_pong_enable_));
 #ifdef USE_SENSOR
   for (auto sensor : this->sensors_)
     ESP_LOGCONFIG(TAG, "  Sensor: %s", sensor.id);

--- a/esphome/components/packet_transport/packet_transport.cpp
+++ b/esphome/components/packet_transport/packet_transport.cpp
@@ -474,8 +474,12 @@ void PacketTransport::process_(const std::vector<uint8_t> &data) {
 }
 
 void PacketTransport::dump_config() {
-  ESP_LOGCONFIG(TAG, "Packet Transport:\n  Platform: %s\n  Encrypted: %s\n  Ping-pong: %s", this->platform_name_,
-                YESNO(this->is_encrypted_()), YESNO(this->ping_pong_enable_));
+  ESP_LOGCONFIG(TAG,
+                "Packet Transport:\n"
+                "  Platform: %s\n"
+                "  Encrypted: %s\n"
+                "  Ping-pong: %s",
+                this->platform_name_, YESNO(this->is_encrypted_()), YESNO(this->ping_pong_enable_));
 #ifdef USE_SENSOR
   for (auto sensor : this->sensors_)
     ESP_LOGCONFIG(TAG, "  Sensor: %s", sensor.id);

--- a/esphome/components/pca9554/pca9554.cpp
+++ b/esphome/components/pca9554/pca9554.cpp
@@ -45,8 +45,7 @@ void PCA9554Component::loop() {
 }
 
 void PCA9554Component::dump_config() {
-  ESP_LOGCONFIG(TAG, "PCA9554:");
-  ESP_LOGCONFIG(TAG, "  I/O Pins: %d", this->pin_count_);
+  ESP_LOGCONFIG(TAG, "PCA9554:\n  I/O Pins: %d", this->pin_count_);
   LOG_I2C_DEVICE(this)
   if (this->is_failed()) {
     ESP_LOGE(TAG, ESP_LOG_MSG_COMM_FAIL);

--- a/esphome/components/pca9554/pca9554.cpp
+++ b/esphome/components/pca9554/pca9554.cpp
@@ -45,7 +45,10 @@ void PCA9554Component::loop() {
 }
 
 void PCA9554Component::dump_config() {
-  ESP_LOGCONFIG(TAG, "PCA9554:\n  I/O Pins: %d", this->pin_count_);
+  ESP_LOGCONFIG(TAG,
+                "PCA9554:\n"
+                "  I/O Pins: %d",
+                this->pin_count_);
   LOG_I2C_DEVICE(this)
   if (this->is_failed()) {
     ESP_LOGE(TAG, ESP_LOG_MSG_COMM_FAIL);

--- a/esphome/components/pca9685/pca9685_output.cpp
+++ b/esphome/components/pca9685/pca9685_output.cpp
@@ -83,13 +83,11 @@ void PCA9685Output::setup() {
 }
 
 void PCA9685Output::dump_config() {
-  ESP_LOGCONFIG(TAG, "PCA9685:");
-  ESP_LOGCONFIG(TAG, "  Mode: 0x%02X", this->mode_);
+  ESP_LOGCONFIG(TAG, "PCA9685:\n  Mode: 0x%02X", this->mode_);
   if (this->extclk_) {
     ESP_LOGCONFIG(TAG, "  EXTCLK: enabled");
   } else {
-    ESP_LOGCONFIG(TAG, "  EXTCLK: disabled");
-    ESP_LOGCONFIG(TAG, "  Frequency: %.0f Hz", this->frequency_);
+    ESP_LOGCONFIG(TAG, "  EXTCLK: disabled\n  Frequency: %.0f Hz", this->frequency_);
   }
   if (this->is_failed()) {
     ESP_LOGE(TAG, "Setting up PCA9685 failed!");

--- a/esphome/components/pca9685/pca9685_output.cpp
+++ b/esphome/components/pca9685/pca9685_output.cpp
@@ -83,11 +83,17 @@ void PCA9685Output::setup() {
 }
 
 void PCA9685Output::dump_config() {
-  ESP_LOGCONFIG(TAG, "PCA9685:\n  Mode: 0x%02X", this->mode_);
+  ESP_LOGCONFIG(TAG,
+                "PCA9685:\n"
+                "  Mode: 0x%02X",
+                this->mode_);
   if (this->extclk_) {
     ESP_LOGCONFIG(TAG, "  EXTCLK: enabled");
   } else {
-    ESP_LOGCONFIG(TAG, "  EXTCLK: disabled\n  Frequency: %.0f Hz", this->frequency_);
+    ESP_LOGCONFIG(TAG,
+                  "  EXTCLK: disabled\n"
+                  "  Frequency: %.0f Hz",
+                  this->frequency_);
   }
   if (this->is_failed()) {
     ESP_LOGE(TAG, "Setting up PCA9685 failed!");

--- a/esphome/components/pid/pid_climate.cpp
+++ b/esphome/components/pid/pid_climate.cpp
@@ -82,7 +82,8 @@ void PIDClimate::dump_config() {
     ESP_LOGCONFIG(TAG, "  Deadband disabled.");
   } else {
     ESP_LOGCONFIG(TAG,
-                  "  Deadband Parameters:\n    threshold: %0.5f to %0.5f, multipliers(kp: %.5f, ki: %.5f, kd: %.5f), "
+                  "  Deadband Parameters:\n"
+                  "    threshold: %0.5f to %0.5f, multipliers(kp: %.5f, ki: %.5f, kd: %.5f), "
                   "output samples: %d",
                   controller_.threshold_low_, controller_.threshold_high_, controller_.kp_multiplier_,
                   controller_.ki_multiplier_, controller_.kd_multiplier_, controller_.deadband_output_samples_);

--- a/esphome/components/pid/pid_climate.cpp
+++ b/esphome/components/pid/pid_climate.cpp
@@ -73,15 +73,15 @@ climate::ClimateTraits PIDClimate::traits() {
 }
 void PIDClimate::dump_config() {
   LOG_CLIMATE("", "PID Climate", this);
-  ESP_LOGCONFIG(TAG, "  Control Parameters:");
-  ESP_LOGCONFIG(TAG, "    kp: %.5f, ki: %.5f, kd: %.5f, output samples: %d", controller_.kp_, controller_.ki_,
-                controller_.kd_, controller_.output_samples_);
+  ESP_LOGCONFIG(TAG, "  Control Parameters:\n    kp: %.5f, ki: %.5f, kd: %.5f, output samples: %d", controller_.kp_,
+                controller_.ki_, controller_.kd_, controller_.output_samples_);
 
   if (controller_.threshold_low_ == 0 && controller_.threshold_high_ == 0) {
     ESP_LOGCONFIG(TAG, "  Deadband disabled.");
   } else {
-    ESP_LOGCONFIG(TAG, "  Deadband Parameters:");
-    ESP_LOGCONFIG(TAG, "    threshold: %0.5f to %0.5f, multipliers(kp: %.5f, ki: %.5f, kd: %.5f), output samples: %d",
+    ESP_LOGCONFIG(TAG,
+                  "  Deadband Parameters:\n    threshold: %0.5f to %0.5f, multipliers(kp: %.5f, ki: %.5f, kd: %.5f), "
+                  "output samples: %d",
                   controller_.threshold_low_, controller_.threshold_high_, controller_.kp_multiplier_,
                   controller_.ki_multiplier_, controller_.kd_multiplier_, controller_.deadband_output_samples_);
   }

--- a/esphome/components/pid/pid_climate.cpp
+++ b/esphome/components/pid/pid_climate.cpp
@@ -73,8 +73,10 @@ climate::ClimateTraits PIDClimate::traits() {
 }
 void PIDClimate::dump_config() {
   LOG_CLIMATE("", "PID Climate", this);
-  ESP_LOGCONFIG(TAG, "  Control Parameters:\n    kp: %.5f, ki: %.5f, kd: %.5f, output samples: %d", controller_.kp_,
-                controller_.ki_, controller_.kd_, controller_.output_samples_);
+  ESP_LOGCONFIG(TAG,
+                "  Control Parameters:\n"
+                "    kp: %.5f, ki: %.5f, kd: %.5f, output samples: %d",
+                controller_.kp_, controller_.ki_, controller_.kd_, controller_.output_samples_);
 
   if (controller_.threshold_low_ == 0 && controller_.threshold_high_ == 0) {
     ESP_LOGCONFIG(TAG, "  Deadband disabled.");

--- a/esphome/components/pipsolar/pipsolar.cpp
+++ b/esphome/components/pipsolar/pipsolar.cpp
@@ -861,8 +861,8 @@ void Pipsolar::switch_command(const std::string &command) {
   queue_command_(command.c_str(), command.length());
 }
 void Pipsolar::dump_config() {
-  ESP_LOGCONFIG(TAG, "Pipsolar:");
-  ESP_LOGCONFIG(TAG, "used commands:");
+  ESP_LOGCONFIG(TAG, "Pipsolar:\n"
+                     "used commands:");
   for (auto &used_polling_command : this->used_polling_commands_) {
     if (used_polling_command.length != 0) {
       ESP_LOGCONFIG(TAG, "%s", used_polling_command.command);

--- a/esphome/components/pipsolar/pipsolar.cpp
+++ b/esphome/components/pipsolar/pipsolar.cpp
@@ -861,7 +861,8 @@ void Pipsolar::switch_command(const std::string &command) {
   queue_command_(command.c_str(), command.length());
 }
 void Pipsolar::dump_config() {
-  ESP_LOGCONFIG(TAG, "Pipsolar:\n  used commands:");
+  ESP_LOGCONFIG(TAG, "Pipsolar:\n"
+                     "  used commands:");
   for (auto &used_polling_command : this->used_polling_commands_) {
     if (used_polling_command.length != 0) {
       ESP_LOGCONFIG(TAG, "%s", used_polling_command.command);

--- a/esphome/components/pipsolar/pipsolar.cpp
+++ b/esphome/components/pipsolar/pipsolar.cpp
@@ -861,8 +861,8 @@ void Pipsolar::switch_command(const std::string &command) {
   queue_command_(command.c_str(), command.length());
 }
 void Pipsolar::dump_config() {
-  ESP_LOGCONFIG(TAG, "Pipsolar:\n"
-                     "  used commands:");
+  ESP_LOGCONFIG(TAG, "Pipsolar:");
+  ESP_LOGCONFIG(TAG, "  used commands:");
   for (auto &used_polling_command : this->used_polling_commands_) {
     if (used_polling_command.length != 0) {
       ESP_LOGCONFIG(TAG, "%s", used_polling_command.command);

--- a/esphome/components/pipsolar/pipsolar.cpp
+++ b/esphome/components/pipsolar/pipsolar.cpp
@@ -861,8 +861,7 @@ void Pipsolar::switch_command(const std::string &command) {
   queue_command_(command.c_str(), command.length());
 }
 void Pipsolar::dump_config() {
-  ESP_LOGCONFIG(TAG, "Pipsolar:");
-  ESP_LOGCONFIG(TAG, "used commands:");
+  ESP_LOGCONFIG(TAG, "Pipsolar:\n  used commands:");
   for (auto &used_polling_command : this->used_polling_commands_) {
     if (used_polling_command.length != 0) {
       ESP_LOGCONFIG(TAG, "%s", used_polling_command.command);

--- a/esphome/components/pipsolar/pipsolar.cpp
+++ b/esphome/components/pipsolar/pipsolar.cpp
@@ -862,7 +862,7 @@ void Pipsolar::switch_command(const std::string &command) {
 }
 void Pipsolar::dump_config() {
   ESP_LOGCONFIG(TAG, "Pipsolar:");
-  ESP_LOGCONFIG(TAG, "  used commands:");
+  ESP_LOGCONFIG(TAG, "used commands:");
   for (auto &used_polling_command : this->used_polling_commands_) {
     if (used_polling_command.length != 0) {
       ESP_LOGCONFIG(TAG, "%s", used_polling_command.command);

--- a/esphome/components/pm2005/pm2005.cpp
+++ b/esphome/components/pm2005/pm2005.cpp
@@ -103,8 +103,7 @@ void PM2005Component::update() {
 }
 
 void PM2005Component::dump_config() {
-  ESP_LOGCONFIG(TAG, "PM2005:");
-  ESP_LOGCONFIG(TAG, "  Type: PM2%u05", this->sensor_type_ == PM2105);
+  ESP_LOGCONFIG(TAG, "PM2005:\n  Type: PM2%u05", this->sensor_type_ == PM2105);
 
   LOG_I2C_DEVICE(this);
   if (this->is_failed()) {

--- a/esphome/components/pm2005/pm2005.cpp
+++ b/esphome/components/pm2005/pm2005.cpp
@@ -103,7 +103,10 @@ void PM2005Component::update() {
 }
 
 void PM2005Component::dump_config() {
-  ESP_LOGCONFIG(TAG, "PM2005:\n  Type: PM2%u05", this->sensor_type_ == PM2105);
+  ESP_LOGCONFIG(TAG,
+                "PM2005:\n"
+                "  Type: PM2%u05",
+                this->sensor_type_ == PM2105);
 
   LOG_I2C_DEVICE(this);
   if (this->is_failed()) {

--- a/esphome/components/power_supply/power_supply.cpp
+++ b/esphome/components/power_supply/power_supply.cpp
@@ -17,8 +17,8 @@ void PowerSupply::setup() {
 void PowerSupply::dump_config() {
   ESP_LOGCONFIG(TAG, "Power Supply:");
   LOG_PIN("  Pin: ", this->pin_);
-  ESP_LOGCONFIG(TAG, "  Time to enable: %" PRIu32 " ms", this->enable_time_);
-  ESP_LOGCONFIG(TAG, "  Keep on time: %.1f s", this->keep_on_time_ / 1000.0f);
+  ESP_LOGCONFIG(TAG, "  Time to enable: %" PRIu32 " ms\n  Keep on time: %.1f s", this->enable_time_,
+                this->keep_on_time_ / 1000.0f);
   if (this->enable_on_boot_)
     ESP_LOGCONFIG(TAG, "  Enabled at startup: True");
 }

--- a/esphome/components/power_supply/power_supply.cpp
+++ b/esphome/components/power_supply/power_supply.cpp
@@ -17,8 +17,10 @@ void PowerSupply::setup() {
 void PowerSupply::dump_config() {
   ESP_LOGCONFIG(TAG, "Power Supply:");
   LOG_PIN("  Pin: ", this->pin_);
-  ESP_LOGCONFIG(TAG, "  Time to enable: %" PRIu32 " ms\n  Keep on time: %.1f s", this->enable_time_,
-                this->keep_on_time_ / 1000.0f);
+  ESP_LOGCONFIG(TAG,
+                "  Time to enable: %" PRIu32 " ms\n"
+                "  Keep on time: %.1f s",
+                this->enable_time_, this->keep_on_time_ / 1000.0f);
   if (this->enable_on_boot_)
     ESP_LOGCONFIG(TAG, "  Enabled at startup: True");
 }

--- a/esphome/components/pulse_counter/pulse_counter_sensor.cpp
+++ b/esphome/components/pulse_counter/pulse_counter_sensor.cpp
@@ -171,7 +171,10 @@ void PulseCounterSensor::set_total_pulses(uint32_t pulses) {
 void PulseCounterSensor::dump_config() {
   LOG_SENSOR("", "Pulse Counter", this);
   LOG_PIN("  Pin: ", this->pin_);
-  ESP_LOGCONFIG(TAG, "  Rising Edge: %s\n  Falling Edge: %s\n  Filtering pulses shorter than %" PRIu32 " µs",
+  ESP_LOGCONFIG(TAG,
+                "  Rising Edge: %s\n"
+                "  Falling Edge: %s\n"
+                "  Filtering pulses shorter than %" PRIu32 " µs",
                 EDGE_MODE_TO_STRING[this->storage_.rising_edge_mode],
                 EDGE_MODE_TO_STRING[this->storage_.falling_edge_mode], this->storage_.filter_us);
   LOG_UPDATE_INTERVAL(this);

--- a/esphome/components/pulse_counter/pulse_counter_sensor.cpp
+++ b/esphome/components/pulse_counter/pulse_counter_sensor.cpp
@@ -171,9 +171,9 @@ void PulseCounterSensor::set_total_pulses(uint32_t pulses) {
 void PulseCounterSensor::dump_config() {
   LOG_SENSOR("", "Pulse Counter", this);
   LOG_PIN("  Pin: ", this->pin_);
-  ESP_LOGCONFIG(TAG, "  Rising Edge: %s", EDGE_MODE_TO_STRING[this->storage_.rising_edge_mode]);
-  ESP_LOGCONFIG(TAG, "  Falling Edge: %s", EDGE_MODE_TO_STRING[this->storage_.falling_edge_mode]);
-  ESP_LOGCONFIG(TAG, "  Filtering pulses shorter than %" PRIu32 " µs", this->storage_.filter_us);
+  ESP_LOGCONFIG(TAG, "  Rising Edge: %s\n  Falling Edge: %s\n  Filtering pulses shorter than %" PRIu32 " µs",
+                EDGE_MODE_TO_STRING[this->storage_.rising_edge_mode],
+                EDGE_MODE_TO_STRING[this->storage_.falling_edge_mode], this->storage_.filter_us);
   LOG_UPDATE_INTERVAL(this);
 }
 

--- a/esphome/components/pvvx_mithermometer/display/pvvx_display.cpp
+++ b/esphome/components/pvvx_mithermometer/display/pvvx_display.cpp
@@ -8,11 +8,14 @@ namespace pvvx_mithermometer {
 static const char *const TAG = "display.pvvx_mithermometer";
 
 void PVVXDisplay::dump_config() {
-  ESP_LOGCONFIG(TAG, "PVVX MiThermometer display:");
-  ESP_LOGCONFIG(TAG, "  MAC address           : %s", this->parent_->address_str().c_str());
-  ESP_LOGCONFIG(TAG, "  Service UUID          : %s", this->service_uuid_.to_string().c_str());
-  ESP_LOGCONFIG(TAG, "  Characteristic UUID   : %s", this->char_uuid_.to_string().c_str());
-  ESP_LOGCONFIG(TAG, "  Auto clear            : %s", YESNO(this->auto_clear_enabled_));
+  ESP_LOGCONFIG(TAG,
+                "PVVX MiThermometer display:\n"
+                "  MAC address           : %s\n"
+                "  Service UUID          : %s\n"
+                "  Characteristic UUID   : %s\n"
+                "  Auto clear            : %s",
+                this->parent_->address_str().c_str(), this->service_uuid_.to_string().c_str(),
+                this->char_uuid_.to_string().c_str(), YESNO(this->auto_clear_enabled_));
 #ifdef USE_TIME
   ESP_LOGCONFIG(TAG, "  Set time on connection: %s", YESNO(this->time_ != nullptr));
 #endif

--- a/esphome/components/pylontech/sensor/pylontech_sensor.cpp
+++ b/esphome/components/pylontech/sensor/pylontech_sensor.cpp
@@ -10,8 +10,7 @@ static const char *const TAG = "pylontech.sensor";
 PylontechSensor::PylontechSensor(int8_t bat_num) { this->bat_num_ = bat_num; }
 
 void PylontechSensor::dump_config() {
-  ESP_LOGCONFIG(TAG, "Pylontech Sensor:");
-  ESP_LOGCONFIG(TAG, " Battery %d", this->bat_num_);
+  ESP_LOGCONFIG(TAG, "Pylontech Sensor:\n Battery %d", this->bat_num_);
   LOG_SENSOR("  ", "Voltage", this->voltage_sensor_);
   LOG_SENSOR("  ", "Current", this->current_sensor_);
   LOG_SENSOR("  ", "Temperature", this->temperature_sensor_);

--- a/esphome/components/pylontech/sensor/pylontech_sensor.cpp
+++ b/esphome/components/pylontech/sensor/pylontech_sensor.cpp
@@ -10,7 +10,10 @@ static const char *const TAG = "pylontech.sensor";
 PylontechSensor::PylontechSensor(int8_t bat_num) { this->bat_num_ = bat_num; }
 
 void PylontechSensor::dump_config() {
-  ESP_LOGCONFIG(TAG, "Pylontech Sensor:\n Battery %d", this->bat_num_);
+  ESP_LOGCONFIG(TAG,
+                "Pylontech Sensor:\n"
+                " Battery %d",
+                this->bat_num_);
   LOG_SENSOR("  ", "Voltage", this->voltage_sensor_);
   LOG_SENSOR("  ", "Current", this->current_sensor_);
   LOG_SENSOR("  ", "Temperature", this->temperature_sensor_);

--- a/esphome/components/pylontech/text_sensor/pylontech_text_sensor.cpp
+++ b/esphome/components/pylontech/text_sensor/pylontech_text_sensor.cpp
@@ -10,8 +10,7 @@ static const char *const TAG = "pylontech.textsensor";
 PylontechTextSensor::PylontechTextSensor(int8_t bat_num) { this->bat_num_ = bat_num; }
 
 void PylontechTextSensor::dump_config() {
-  ESP_LOGCONFIG(TAG, "Pylontech Text Sensor:");
-  ESP_LOGCONFIG(TAG, " Battery %d", this->bat_num_);
+  ESP_LOGCONFIG(TAG, "Pylontech Text Sensor:\n Battery %d", this->bat_num_);
   LOG_TEXT_SENSOR("  ", "Base state", this->base_state_text_sensor_);
   LOG_TEXT_SENSOR("  ", "Voltage state", this->voltage_state_text_sensor_);
   LOG_TEXT_SENSOR("  ", "Current state", this->current_state_text_sensor_);

--- a/esphome/components/pylontech/text_sensor/pylontech_text_sensor.cpp
+++ b/esphome/components/pylontech/text_sensor/pylontech_text_sensor.cpp
@@ -10,7 +10,10 @@ static const char *const TAG = "pylontech.textsensor";
 PylontechTextSensor::PylontechTextSensor(int8_t bat_num) { this->bat_num_ = bat_num; }
 
 void PylontechTextSensor::dump_config() {
-  ESP_LOGCONFIG(TAG, "Pylontech Text Sensor:\n Battery %d", this->bat_num_);
+  ESP_LOGCONFIG(TAG,
+                "Pylontech Text Sensor:\n"
+                " Battery %d",
+                this->bat_num_);
   LOG_TEXT_SENSOR("  ", "Base state", this->base_state_text_sensor_);
   LOG_TEXT_SENSOR("  ", "Voltage state", this->voltage_state_text_sensor_);
   LOG_TEXT_SENSOR("  ", "Current state", this->current_state_text_sensor_);

--- a/esphome/components/pzemac/pzemac.cpp
+++ b/esphome/components/pzemac/pzemac.cpp
@@ -64,7 +64,10 @@ void PZEMAC::on_modbus_data(const std::vector<uint8_t> &data) {
 
 void PZEMAC::update() { this->send(PZEM_CMD_READ_IN_REGISTERS, 0, PZEM_REGISTER_COUNT); }
 void PZEMAC::dump_config() {
-  ESP_LOGCONFIG(TAG, "PZEMAC:\n  Address: 0x%02X", this->address_);
+  ESP_LOGCONFIG(TAG,
+                "PZEMAC:\n"
+                "  Address: 0x%02X",
+                this->address_);
   LOG_SENSOR("", "Voltage", this->voltage_sensor_);
   LOG_SENSOR("", "Current", this->current_sensor_);
   LOG_SENSOR("", "Power", this->power_sensor_);

--- a/esphome/components/pzemac/pzemac.cpp
+++ b/esphome/components/pzemac/pzemac.cpp
@@ -64,8 +64,7 @@ void PZEMAC::on_modbus_data(const std::vector<uint8_t> &data) {
 
 void PZEMAC::update() { this->send(PZEM_CMD_READ_IN_REGISTERS, 0, PZEM_REGISTER_COUNT); }
 void PZEMAC::dump_config() {
-  ESP_LOGCONFIG(TAG, "PZEMAC:");
-  ESP_LOGCONFIG(TAG, "  Address: 0x%02X", this->address_);
+  ESP_LOGCONFIG(TAG, "PZEMAC:\n  Address: 0x%02X", this->address_);
   LOG_SENSOR("", "Voltage", this->voltage_sensor_);
   LOG_SENSOR("", "Current", this->current_sensor_);
   LOG_SENSOR("", "Power", this->power_sensor_);

--- a/esphome/components/pzemdc/pzemdc.cpp
+++ b/esphome/components/pzemdc/pzemdc.cpp
@@ -54,8 +54,7 @@ void PZEMDC::on_modbus_data(const std::vector<uint8_t> &data) {
 
 void PZEMDC::update() { this->send(PZEM_CMD_READ_IN_REGISTERS, 0, 8); }
 void PZEMDC::dump_config() {
-  ESP_LOGCONFIG(TAG, "PZEMDC:");
-  ESP_LOGCONFIG(TAG, "  Address: 0x%02X", this->address_);
+  ESP_LOGCONFIG(TAG, "PZEMDC:\n  Address: 0x%02X", this->address_);
   LOG_SENSOR("", "Voltage", this->voltage_sensor_);
   LOG_SENSOR("", "Current", this->current_sensor_);
   LOG_SENSOR("", "Power", this->power_sensor_);

--- a/esphome/components/pzemdc/pzemdc.cpp
+++ b/esphome/components/pzemdc/pzemdc.cpp
@@ -54,7 +54,10 @@ void PZEMDC::on_modbus_data(const std::vector<uint8_t> &data) {
 
 void PZEMDC::update() { this->send(PZEM_CMD_READ_IN_REGISTERS, 0, 8); }
 void PZEMDC::dump_config() {
-  ESP_LOGCONFIG(TAG, "PZEMDC:\n  Address: 0x%02X", this->address_);
+  ESP_LOGCONFIG(TAG,
+                "PZEMDC:\n"
+                "  Address: 0x%02X",
+                this->address_);
   LOG_SENSOR("", "Voltage", this->voltage_sensor_);
   LOG_SENSOR("", "Current", this->current_sensor_);
   LOG_SENSOR("", "Power", this->power_sensor_);

--- a/esphome/components/qr_code/qr_code.cpp
+++ b/esphome/components/qr_code/qr_code.cpp
@@ -8,7 +8,12 @@ namespace qr_code {
 
 static const char *const TAG = "qr_code";
 
-void QrCode::dump_config() { ESP_LOGCONFIG(TAG, "QR code:\n  Value: '%s'", this->value_.c_str()); }
+void QrCode::dump_config() {
+  ESP_LOGCONFIG(TAG,
+                "QR code:\n"
+                "  Value: '%s'",
+                this->value_.c_str());
+}
 
 void QrCode::set_value(const std::string &value) {
   this->value_ = value;

--- a/esphome/components/qr_code/qr_code.cpp
+++ b/esphome/components/qr_code/qr_code.cpp
@@ -8,10 +8,7 @@ namespace qr_code {
 
 static const char *const TAG = "qr_code";
 
-void QrCode::dump_config() {
-  ESP_LOGCONFIG(TAG, "QR code:");
-  ESP_LOGCONFIG(TAG, "  Value: '%s'", this->value_.c_str());
-}
+void QrCode::dump_config() { ESP_LOGCONFIG(TAG, "QR code:\n  Value: '%s'", this->value_.c_str()); }
 
 void QrCode::set_value(const std::string &value) {
   this->value_ = value;

--- a/esphome/components/qwiic_pir/qwiic_pir.cpp
+++ b/esphome/components/qwiic_pir/qwiic_pir.cpp
@@ -99,8 +99,7 @@ void QwiicPIRComponent::dump_config() {
     debounce_mode_str = HYBRID;
   }
 
-  ESP_LOGCONFIG(TAG, "Qwiic PIR:");
-  ESP_LOGCONFIG(TAG, "  Debounce Mode: %s", debounce_mode_str);
+  ESP_LOGCONFIG(TAG, "Qwiic PIR:\n  Debounce Mode: %s", debounce_mode_str);
   if (this->debounce_mode_ == NATIVE_DEBOUNCE_MODE) {
     ESP_LOGCONFIG(TAG, "  Debounce Time: %ums", this->debounce_time_);
   }

--- a/esphome/components/qwiic_pir/qwiic_pir.cpp
+++ b/esphome/components/qwiic_pir/qwiic_pir.cpp
@@ -99,7 +99,10 @@ void QwiicPIRComponent::dump_config() {
     debounce_mode_str = HYBRID;
   }
 
-  ESP_LOGCONFIG(TAG, "Qwiic PIR:\n  Debounce Mode: %s", debounce_mode_str);
+  ESP_LOGCONFIG(TAG,
+                "Qwiic PIR:\n"
+                "  Debounce Mode: %s",
+                debounce_mode_str);
   if (this->debounce_mode_ == NATIVE_DEBOUNCE_MODE) {
     ESP_LOGCONFIG(TAG, "  Debounce Time: %ums", this->debounce_time_);
   }

--- a/esphome/components/remote_receiver/remote_receiver_esp32.cpp
+++ b/esphome/components/remote_receiver/remote_receiver_esp32.cpp
@@ -161,23 +161,33 @@ void RemoteReceiverComponent::dump_config() {
   ESP_LOGCONFIG(TAG, "Remote Receiver:");
   LOG_PIN("  Pin: ", this->pin_);
 #if ESP_IDF_VERSION_MAJOR >= 5
-  ESP_LOGCONFIG(TAG, "  Clock resolution: %" PRIu32 " hz", this->clock_resolution_);
-  ESP_LOGCONFIG(TAG, "  RMT symbols: %" PRIu32, this->rmt_symbols_);
-  ESP_LOGCONFIG(TAG, "  Filter symbols: %" PRIu32, this->filter_symbols_);
-  ESP_LOGCONFIG(TAG, "  Receive symbols: %" PRIu32, this->receive_symbols_);
+  ESP_LOGCONFIG(TAG,
+                "  Clock resolution: %" PRIu32 " hz\n"
+                "  RMT symbols: %" PRIu32 "\n"
+                "  Filter symbols: %" PRIu32 "\n"
+                "  Receive symbols: %" PRIu32 "\n"
+                "  Tolerance: %" PRIu32 "%s\n"
+                "  Filter out pulses shorter than: %" PRIu32 " us\n"
+                "  Signal is done after %" PRIu32 " us of no changes",
+                this->clock_resolution_, this->rmt_symbols_, this->filter_symbols_, this->receive_symbols_,
+                this->tolerance_, (this->tolerance_mode_ == remote_base::TOLERANCE_MODE_TIME) ? " us" : "%",
+                this->filter_us_, this->idle_us_);
 #else
   if (this->pin_->digital_read()) {
     ESP_LOGW(TAG, "Remote Receiver Signal starts with a HIGH value. Usually this means you have to "
                   "invert the signal using 'inverted: True' in the pin schema!");
   }
-  ESP_LOGCONFIG(TAG, "  Channel: %d", this->channel_);
-  ESP_LOGCONFIG(TAG, "  RMT memory blocks: %d", this->mem_block_num_);
-  ESP_LOGCONFIG(TAG, "  Clock divider: %u", this->clock_divider_);
+  ESP_LOGCONFIG(TAG,
+                "  Channel: %d\n"
+                "  RMT memory blocks: %d\n"
+                "  Clock divider: %u\n"
+                "  Tolerance: %" PRIu32 "%s\n"
+                "  Filter out pulses shorter than: %" PRIu32 " us\n"
+                "  Signal is done after %" PRIu32 " us of no changes",
+                this->channel_, this->mem_block_num_, this->clock_divider_, this->tolerance_,
+                (this->tolerance_mode_ == remote_base::TOLERANCE_MODE_TIME) ? " us" : "%", this->filter_us_,
+                this->idle_us_);
 #endif
-  ESP_LOGCONFIG(TAG, "  Tolerance: %" PRIu32 "%s", this->tolerance_,
-                (this->tolerance_mode_ == remote_base::TOLERANCE_MODE_TIME) ? " us" : "%");
-  ESP_LOGCONFIG(TAG, "  Filter out pulses shorter than: %" PRIu32 " us", this->filter_us_);
-  ESP_LOGCONFIG(TAG, "  Signal is done after %" PRIu32 " us of no changes", this->idle_us_);
   if (this->is_failed()) {
     ESP_LOGE(TAG, "Configuring RMT driver failed: %s (%s)", esp_err_to_name(this->error_code_),
              this->error_string_.c_str());

--- a/esphome/components/remote_receiver/remote_receiver_esp8266.cpp
+++ b/esphome/components/remote_receiver/remote_receiver_esp8266.cpp
@@ -63,11 +63,14 @@ void RemoteReceiverComponent::dump_config() {
     ESP_LOGW(TAG, "Remote Receiver Signal starts with a HIGH value. Usually this means you have to "
                   "invert the signal using 'inverted: True' in the pin schema!");
   }
-  ESP_LOGCONFIG(TAG, "  Buffer Size: %u", this->buffer_size_);
-  ESP_LOGCONFIG(TAG, "  Tolerance: %u%s", this->tolerance_,
-                (this->tolerance_mode_ == remote_base::TOLERANCE_MODE_TIME) ? " us" : "%");
-  ESP_LOGCONFIG(TAG, "  Filter out pulses shorter than: %u us", this->filter_us_);
-  ESP_LOGCONFIG(TAG, "  Signal is done after %u us of no changes", this->idle_us_);
+  ESP_LOGCONFIG(TAG,
+                "  Buffer Size: %u\n"
+                "  Tolerance: %u%s\n"
+                "  Filter out pulses shorter than: %u us\n"
+                "  Signal is done after %u us of no changes",
+                this->buffer_size_, this->tolerance_,
+                (this->tolerance_mode_ == remote_base::TOLERANCE_MODE_TIME) ? " us" : "%", this->filter_us_,
+                this->idle_us_);
 }
 
 void RemoteReceiverComponent::loop() {

--- a/esphome/components/remote_receiver/remote_receiver_libretiny.cpp
+++ b/esphome/components/remote_receiver/remote_receiver_libretiny.cpp
@@ -63,11 +63,14 @@ void RemoteReceiverComponent::dump_config() {
     ESP_LOGW(TAG, "Remote Receiver Signal starts with a HIGH value. Usually this means you have to "
                   "invert the signal using 'inverted: True' in the pin schema!");
   }
-  ESP_LOGCONFIG(TAG, "  Buffer Size: %u", this->buffer_size_);
-  ESP_LOGCONFIG(TAG, "  Tolerance: %u%s", this->tolerance_,
-                (this->tolerance_mode_ == remote_base::TOLERANCE_MODE_TIME) ? " us" : "%");
-  ESP_LOGCONFIG(TAG, "  Filter out pulses shorter than: %u us", this->filter_us_);
-  ESP_LOGCONFIG(TAG, "  Signal is done after %u us of no changes", this->idle_us_);
+  ESP_LOGCONFIG(TAG,
+                "  Buffer Size: %u\n"
+                "  Tolerance: %u%s\n"
+                "  Filter out pulses shorter than: %u us\n"
+                "  Signal is done after %u us of no changes",
+                this->buffer_size_, this->tolerance_,
+                (this->tolerance_mode_ == remote_base::TOLERANCE_MODE_TIME) ? " us" : "%", this->filter_us_,
+                this->idle_us_);
 }
 
 void RemoteReceiverComponent::loop() {

--- a/esphome/components/remote_transmitter/remote_transmitter_esp32.cpp
+++ b/esphome/components/remote_transmitter/remote_transmitter_esp32.cpp
@@ -19,8 +19,10 @@ void RemoteTransmitterComponent::setup() {
 void RemoteTransmitterComponent::dump_config() {
   ESP_LOGCONFIG(TAG, "Remote Transmitter:");
 #if ESP_IDF_VERSION_MAJOR >= 5
-  ESP_LOGCONFIG(TAG, "  Clock resolution: %" PRIu32 " hz\n  RMT symbols: %" PRIu32, this->clock_resolution_,
-                this->rmt_symbols_);
+  ESP_LOGCONFIG(TAG,
+                "  Clock resolution: %" PRIu32 " hz\n"
+                "  RMT symbols: %" PRIu32,
+                this->clock_resolution_, this->rmt_symbols_);
 #else
   ESP_LOGCONFIG(TAG,
                 "  Channel: %d\n"

--- a/esphome/components/remote_transmitter/remote_transmitter_esp32.cpp
+++ b/esphome/components/remote_transmitter/remote_transmitter_esp32.cpp
@@ -22,8 +22,11 @@ void RemoteTransmitterComponent::dump_config() {
   ESP_LOGCONFIG(TAG, "  Clock resolution: %" PRIu32 " hz\n  RMT symbols: %" PRIu32, this->clock_resolution_,
                 this->rmt_symbols_);
 #else
-  ESP_LOGCONFIG(TAG, "  Channel: %d\n  RMT memory blocks: %d\n  Clock divider: %u", this->channel_,
-                this->mem_block_num_, this->clock_divider_);
+  ESP_LOGCONFIG(TAG,
+                "  Channel: %d\n"
+                "  RMT memory blocks: %d\n"
+                "  Clock divider: %u",
+                this->channel_, this->mem_block_num_, this->clock_divider_);
 #endif
   LOG_PIN("  Pin: ", this->pin_);
 

--- a/esphome/components/remote_transmitter/remote_transmitter_esp32.cpp
+++ b/esphome/components/remote_transmitter/remote_transmitter_esp32.cpp
@@ -19,12 +19,11 @@ void RemoteTransmitterComponent::setup() {
 void RemoteTransmitterComponent::dump_config() {
   ESP_LOGCONFIG(TAG, "Remote Transmitter:");
 #if ESP_IDF_VERSION_MAJOR >= 5
-  ESP_LOGCONFIG(TAG, "  Clock resolution: %" PRIu32 " hz", this->clock_resolution_);
-  ESP_LOGCONFIG(TAG, "  RMT symbols: %" PRIu32, this->rmt_symbols_);
+  ESP_LOGCONFIG(TAG, "  Clock resolution: %" PRIu32 " hz\n  RMT symbols: %" PRIu32, this->clock_resolution_,
+                this->rmt_symbols_);
 #else
-  ESP_LOGCONFIG(TAG, "  Channel: %d", this->channel_);
-  ESP_LOGCONFIG(TAG, "  RMT memory blocks: %d", this->mem_block_num_);
-  ESP_LOGCONFIG(TAG, "  Clock divider: %u", this->clock_divider_);
+  ESP_LOGCONFIG(TAG, "  Channel: %d\n  RMT memory blocks: %d\n  Clock divider: %u", this->channel_,
+                this->mem_block_num_, this->clock_divider_);
 #endif
   LOG_PIN("  Pin: ", this->pin_);
 

--- a/esphome/components/remote_transmitter/remote_transmitter_esp8266.cpp
+++ b/esphome/components/remote_transmitter/remote_transmitter_esp8266.cpp
@@ -15,7 +15,10 @@ void RemoteTransmitterComponent::setup() {
 }
 
 void RemoteTransmitterComponent::dump_config() {
-  ESP_LOGCONFIG(TAG, "Remote Transmitter:\n  Carrier Duty: %u%%", this->carrier_duty_percent_);
+  ESP_LOGCONFIG(TAG,
+                "Remote Transmitter:\n"
+                "  Carrier Duty: %u%%",
+                this->carrier_duty_percent_);
   LOG_PIN("  Pin: ", this->pin_);
 }
 

--- a/esphome/components/remote_transmitter/remote_transmitter_esp8266.cpp
+++ b/esphome/components/remote_transmitter/remote_transmitter_esp8266.cpp
@@ -15,8 +15,7 @@ void RemoteTransmitterComponent::setup() {
 }
 
 void RemoteTransmitterComponent::dump_config() {
-  ESP_LOGCONFIG(TAG, "Remote Transmitter:");
-  ESP_LOGCONFIG(TAG, "  Carrier Duty: %u%%", this->carrier_duty_percent_);
+  ESP_LOGCONFIG(TAG, "Remote Transmitter:\n  Carrier Duty: %u%%", this->carrier_duty_percent_);
   LOG_PIN("  Pin: ", this->pin_);
 }
 

--- a/esphome/components/remote_transmitter/remote_transmitter_libretiny.cpp
+++ b/esphome/components/remote_transmitter/remote_transmitter_libretiny.cpp
@@ -15,7 +15,10 @@ void RemoteTransmitterComponent::setup() {
 }
 
 void RemoteTransmitterComponent::dump_config() {
-  ESP_LOGCONFIG(TAG, "Remote Transmitter:\n  Carrier Duty: %u%%", this->carrier_duty_percent_);
+  ESP_LOGCONFIG(TAG,
+                "Remote Transmitter:\n"
+                "  Carrier Duty: %u%%",
+                this->carrier_duty_percent_);
   LOG_PIN("  Pin: ", this->pin_);
 }
 

--- a/esphome/components/remote_transmitter/remote_transmitter_libretiny.cpp
+++ b/esphome/components/remote_transmitter/remote_transmitter_libretiny.cpp
@@ -15,8 +15,7 @@ void RemoteTransmitterComponent::setup() {
 }
 
 void RemoteTransmitterComponent::dump_config() {
-  ESP_LOGCONFIG(TAG, "Remote Transmitter:");
-  ESP_LOGCONFIG(TAG, "  Carrier Duty: %u%%", this->carrier_duty_percent_);
+  ESP_LOGCONFIG(TAG, "Remote Transmitter:\n  Carrier Duty: %u%%", this->carrier_duty_percent_);
   LOG_PIN("  Pin: ", this->pin_);
 }
 

--- a/esphome/components/resistance/resistance_sensor.cpp
+++ b/esphome/components/resistance/resistance_sensor.cpp
@@ -8,7 +8,10 @@ static const char *const TAG = "resistance";
 
 void ResistanceSensor::dump_config() {
   LOG_SENSOR("", "Resistance Sensor", this);
-  ESP_LOGCONFIG(TAG, "  Configuration: %s\n  Resistor: %.2fΩ\n  Reference Voltage: %.1fV",
+  ESP_LOGCONFIG(TAG,
+                "  Configuration: %s\n"
+                "  Resistor: %.2fΩ\n"
+                "  Reference Voltage: %.1fV",
                 this->configuration_ == UPSTREAM ? "UPSTREAM" : "DOWNSTREAM", this->resistor_,
                 this->reference_voltage_);
 }

--- a/esphome/components/resistance/resistance_sensor.cpp
+++ b/esphome/components/resistance/resistance_sensor.cpp
@@ -8,9 +8,9 @@ static const char *const TAG = "resistance";
 
 void ResistanceSensor::dump_config() {
   LOG_SENSOR("", "Resistance Sensor", this);
-  ESP_LOGCONFIG(TAG, "  Configuration: %s", this->configuration_ == UPSTREAM ? "UPSTREAM" : "DOWNSTREAM");
-  ESP_LOGCONFIG(TAG, "  Resistor: %.2fΩ", this->resistor_);
-  ESP_LOGCONFIG(TAG, "  Reference Voltage: %.1fV", this->reference_voltage_);
+  ESP_LOGCONFIG(TAG, "  Configuration: %s\n  Resistor: %.2fΩ\n  Reference Voltage: %.1fV",
+                this->configuration_ == UPSTREAM ? "UPSTREAM" : "DOWNSTREAM", this->resistor_,
+                this->reference_voltage_);
 }
 void ResistanceSensor::process_(float value) {
   if (std::isnan(value)) {

--- a/esphome/components/rp2040_pio_led_strip/led_strip.cpp
+++ b/esphome/components/rp2040_pio_led_strip/led_strip.cpp
@@ -199,12 +199,15 @@ light::ESPColorView RP2040PIOLEDStripLightOutput::get_view_internal(int32_t inde
 }
 
 void RP2040PIOLEDStripLightOutput::dump_config() {
-  ESP_LOGCONFIG(TAG, "RP2040 PIO LED Strip Light Output:");
-  ESP_LOGCONFIG(TAG, "  Pin: GPIO%d", this->pin_);
-  ESP_LOGCONFIG(TAG, "  Number of LEDs: %d", this->num_leds_);
-  ESP_LOGCONFIG(TAG, "  RGBW: %s", YESNO(this->is_rgbw_));
-  ESP_LOGCONFIG(TAG, "  RGB Order: %s", rgb_order_to_string(this->rgb_order_));
-  ESP_LOGCONFIG(TAG, "  Max Refresh Rate: %f Hz", this->max_refresh_rate_);
+  ESP_LOGCONFIG(TAG,
+                "RP2040 PIO LED Strip Light Output:\n"
+                "  Pin: GPIO%d\n"
+                "  Number of LEDs: %d\n"
+                "  RGBW: %s\n"
+                "  RGB Order: %s\n"
+                "  Max Refresh Rate: %f Hz",
+                this->pin_, this->num_leds_, YESNO(this->is_rgbw_), rgb_order_to_string(this->rgb_order_),
+                this->max_refresh_rate_);
 }
 
 float RP2040PIOLEDStripLightOutput::get_setup_priority() const { return setup_priority::HARDWARE; }

--- a/esphome/components/rtttl/rtttl.cpp
+++ b/esphome/components/rtttl/rtttl.cpp
@@ -26,7 +26,12 @@ inline double deg2rad(double degrees) {
   return degrees * PI_ON_180;
 }
 
-void Rtttl::dump_config() { ESP_LOGCONFIG(TAG, "Rtttl:\n  Gain: %f", this->gain_); }
+void Rtttl::dump_config() {
+  ESP_LOGCONFIG(TAG,
+                "Rtttl:\n"
+                "  Gain: %f",
+                this->gain_);
+}
 
 void Rtttl::play(std::string rtttl) {
   if (this->state_ != State::STATE_STOPPED && this->state_ != State::STATE_STOPPING) {

--- a/esphome/components/rtttl/rtttl.cpp
+++ b/esphome/components/rtttl/rtttl.cpp
@@ -26,10 +26,7 @@ inline double deg2rad(double degrees) {
   return degrees * PI_ON_180;
 }
 
-void Rtttl::dump_config() {
-  ESP_LOGCONFIG(TAG, "Rtttl:");
-  ESP_LOGCONFIG(TAG, "  Gain: %f", this->gain_);
-}
+void Rtttl::dump_config() { ESP_LOGCONFIG(TAG, "Rtttl:\n  Gain: %f", this->gain_); }
 
 void Rtttl::play(std::string rtttl) {
   if (this->state_ != State::STATE_STOPPED && this->state_ != State::STATE_STOPPING) {

--- a/esphome/components/safe_mode/safe_mode.cpp
+++ b/esphome/components/safe_mode/safe_mode.cpp
@@ -16,10 +16,12 @@ static const char *const TAG = "safe_mode";
 
 void SafeModeComponent::dump_config() {
   ESP_LOGCONFIG(TAG, "Safe Mode:");
-  ESP_LOGCONFIG(TAG, "  Boot considered successful after %" PRIu32 " seconds",
-                this->safe_mode_boot_is_good_after_ / 1000);  // because milliseconds
-  ESP_LOGCONFIG(TAG, "  Invoke after %u boot attempts", this->safe_mode_num_attempts_);
-  ESP_LOGCONFIG(TAG, "  Remain for %" PRIu32 " seconds",
+  ESP_LOGCONFIG(TAG,
+                "  Boot considered successful after %" PRIu32 " seconds\n"
+                "  Invoke after %u boot attempts\n"
+                "  Remain for %" PRIu32 " seconds",
+                this->safe_mode_boot_is_good_after_ / 1000,  // because milliseconds
+                this->safe_mode_num_attempts_,
                 this->safe_mode_enable_time_ / 1000);  // because milliseconds
 
   if (this->safe_mode_rtc_value_ > 1 && this->safe_mode_rtc_value_ != SafeModeComponent::ENTER_SAFE_MODE_MAGIC) {

--- a/esphome/components/scd30/scd30.cpp
+++ b/esphome/components/scd30/scd30.cpp
@@ -140,10 +140,11 @@ void SCD30Component::dump_config() {
   } else {
     ESP_LOGCONFIG(TAG, "  Altitude compensation: %dm", this->altitude_compensation_);
   }
-  ESP_LOGCONFIG(TAG, "  Automatic self calibration: %s", ONOFF(this->enable_asc_));
-  ESP_LOGCONFIG(TAG, "  Ambient pressure compensation: %dmBar", this->ambient_pressure_compensation_);
-  ESP_LOGCONFIG(TAG, "  Temperature offset: %.2f °C", this->temperature_offset_);
-  ESP_LOGCONFIG(TAG, "  Update interval: %ds", this->update_interval_);
+  ESP_LOGCONFIG(TAG,
+                "  Automatic self calibration: %s\n  Ambient pressure compensation: %dmBar\n  Temperature offset: %.2f "
+                "°C\n  Update interval: %ds",
+                ONOFF(this->enable_asc_), this->ambient_pressure_compensation_, this->temperature_offset_,
+                this->update_interval_);
   LOG_SENSOR("  ", "CO2", this->co2_sensor_);
   LOG_SENSOR("  ", "Temperature", this->temperature_sensor_);
   LOG_SENSOR("  ", "Humidity", this->humidity_sensor_);

--- a/esphome/components/scd30/scd30.cpp
+++ b/esphome/components/scd30/scd30.cpp
@@ -141,8 +141,10 @@ void SCD30Component::dump_config() {
     ESP_LOGCONFIG(TAG, "  Altitude compensation: %dm", this->altitude_compensation_);
   }
   ESP_LOGCONFIG(TAG,
-                "  Automatic self calibration: %s\n  Ambient pressure compensation: %dmBar\n  Temperature offset: %.2f "
-                "°C\n  Update interval: %ds",
+                "  Automatic self calibration: %s\n"
+                "  Ambient pressure compensation: %dmBar\n"
+                "  Temperature offset: %.2f °C\n"
+                "  Update interval: %ds",
                 ONOFF(this->enable_asc_), this->ambient_pressure_compensation_, this->temperature_offset_,
                 this->update_interval_);
   LOG_SENSOR("  ", "CO2", this->co2_sensor_);

--- a/esphome/components/scd4x/scd4x.cpp
+++ b/esphome/components/scd4x/scd4x.cpp
@@ -115,11 +115,15 @@ void SCD4XComponent::dump_config() {
                   this->ambient_pressure_source_->get_name().c_str());
   } else {
     if (this->ambient_pressure_compensation_) {
-      ESP_LOGCONFIG(TAG, "  Altitude compensation disabled");
-      ESP_LOGCONFIG(TAG, "  Ambient pressure compensation: %dmBar", this->ambient_pressure_);
+      ESP_LOGCONFIG(TAG,
+                    "  Altitude compensation disabled\n"
+                    "  Ambient pressure compensation: %dmBar",
+                    this->ambient_pressure_);
     } else {
-      ESP_LOGCONFIG(TAG, "  Ambient pressure compensation disabled");
-      ESP_LOGCONFIG(TAG, "  Altitude compensation: %dm", this->altitude_compensation_);
+      ESP_LOGCONFIG(TAG,
+                    "  Ambient pressure compensation disabled\n"
+                    "  Altitude compensation: %dm",
+                    this->altitude_compensation_);
     }
   }
   switch (this->measurement_mode_) {

--- a/esphome/components/sdm_meter/sdm_meter.cpp
+++ b/esphome/components/sdm_meter/sdm_meter.cpp
@@ -84,7 +84,10 @@ void SDMMeter::on_modbus_data(const std::vector<uint8_t> &data) {
 
 void SDMMeter::update() { this->send(MODBUS_CMD_READ_IN_REGISTERS, 0, MODBUS_REGISTER_COUNT); }
 void SDMMeter::dump_config() {
-  ESP_LOGCONFIG(TAG, "SDM Meter:\n  Address: 0x%02X", this->address_);
+  ESP_LOGCONFIG(TAG,
+                "SDM Meter:\n"
+                "  Address: 0x%02X",
+                this->address_);
   for (uint8_t i = 0; i < 3; i++) {
     auto phase = this->phases_[i];
     if (!phase.setup)

--- a/esphome/components/sdm_meter/sdm_meter.cpp
+++ b/esphome/components/sdm_meter/sdm_meter.cpp
@@ -84,8 +84,7 @@ void SDMMeter::on_modbus_data(const std::vector<uint8_t> &data) {
 
 void SDMMeter::update() { this->send(MODBUS_CMD_READ_IN_REGISTERS, 0, MODBUS_REGISTER_COUNT); }
 void SDMMeter::dump_config() {
-  ESP_LOGCONFIG(TAG, "SDM Meter:");
-  ESP_LOGCONFIG(TAG, "  Address: 0x%02X", this->address_);
+  ESP_LOGCONFIG(TAG, "SDM Meter:\n  Address: 0x%02X", this->address_);
   for (uint8_t i = 0; i < 3; i++) {
     auto phase = this->phases_[i];
     if (!phase.setup)

--- a/esphome/components/sds011/sds011.cpp
+++ b/esphome/components/sds011/sds011.cpp
@@ -67,9 +67,8 @@ void SDS011Component::set_working_state(bool working_state) {
 }
 
 void SDS011Component::dump_config() {
-  ESP_LOGCONFIG(TAG, "SDS011:");
-  ESP_LOGCONFIG(TAG, "  Update Interval: %u min", this->update_interval_min_);
-  ESP_LOGCONFIG(TAG, "  RX-only mode: %s", ONOFF(this->rx_mode_only_));
+  ESP_LOGCONFIG(TAG, "SDS011:\n  Update Interval: %u min\n  RX-only mode: %s", this->update_interval_min_,
+                ONOFF(this->rx_mode_only_));
   LOG_SENSOR("  ", "PM2.5", this->pm_2_5_sensor_);
   LOG_SENSOR("  ", "PM10.0", this->pm_10_0_sensor_);
   this->check_uart_settings(9600);

--- a/esphome/components/sds011/sds011.cpp
+++ b/esphome/components/sds011/sds011.cpp
@@ -67,8 +67,11 @@ void SDS011Component::set_working_state(bool working_state) {
 }
 
 void SDS011Component::dump_config() {
-  ESP_LOGCONFIG(TAG, "SDS011:\n  Update Interval: %u min\n  RX-only mode: %s", this->update_interval_min_,
-                ONOFF(this->rx_mode_only_));
+  ESP_LOGCONFIG(TAG,
+                "SDS011:\n"
+                "  Update Interval: %u min\n"
+                "  RX-only mode: %s",
+                this->update_interval_min_, ONOFF(this->rx_mode_only_));
   LOG_SENSOR("  ", "PM2.5", this->pm_2_5_sensor_);
   LOG_SENSOR("  ", "PM10.0", this->pm_10_0_sensor_);
   this->check_uart_settings(9600);

--- a/esphome/components/selec_meter/selec_meter.cpp
+++ b/esphome/components/selec_meter/selec_meter.cpp
@@ -83,7 +83,10 @@ void SelecMeter::on_modbus_data(const std::vector<uint8_t> &data) {
 
 void SelecMeter::update() { this->send(MODBUS_CMD_READ_IN_REGISTERS, 0, MODBUS_REGISTER_COUNT); }
 void SelecMeter::dump_config() {
-  ESP_LOGCONFIG(TAG, "SELEC Meter:\n  Address: 0x%02X", this->address_);
+  ESP_LOGCONFIG(TAG,
+                "SELEC Meter:\n"
+                "  Address: 0x%02X",
+                this->address_);
   LOG_SENSOR("  ", "Total Active Energy", this->total_active_energy_sensor_);
   LOG_SENSOR("  ", "Import Active Energy", this->import_active_energy_sensor_);
   LOG_SENSOR("  ", "Export Active Energy", this->export_active_energy_sensor_);

--- a/esphome/components/selec_meter/selec_meter.cpp
+++ b/esphome/components/selec_meter/selec_meter.cpp
@@ -83,8 +83,7 @@ void SelecMeter::on_modbus_data(const std::vector<uint8_t> &data) {
 
 void SelecMeter::update() { this->send(MODBUS_CMD_READ_IN_REGISTERS, 0, MODBUS_REGISTER_COUNT); }
 void SelecMeter::dump_config() {
-  ESP_LOGCONFIG(TAG, "SELEC Meter:");
-  ESP_LOGCONFIG(TAG, "  Address: 0x%02X", this->address_);
+  ESP_LOGCONFIG(TAG, "SELEC Meter:\n  Address: 0x%02X", this->address_);
   LOG_SENSOR("  ", "Total Active Energy", this->total_active_energy_sensor_);
   LOG_SENSOR("  ", "Import Active Energy", this->import_active_energy_sensor_);
   LOG_SENSOR("  ", "Export Active Energy", this->export_active_energy_sensor_);

--- a/esphome/components/sen5x/sen5x.cpp
+++ b/esphome/components/sen5x/sen5x.cpp
@@ -264,9 +264,9 @@ void SEN5XComponent::dump_config() {
         break;
     }
   }
-  ESP_LOGCONFIG(TAG, "  Productname: %s", this->product_name_.c_str());
-  ESP_LOGCONFIG(TAG, "  Firmware version: %d", this->firmware_version_);
-  ESP_LOGCONFIG(TAG, "  Serial number %02d.%02d.%02d", serial_number_[0], serial_number_[1], serial_number_[2]);
+  ESP_LOGCONFIG(TAG, "  Productname: %s\n  Firmware version: %d\n  Serial number %02d.%02d.%02d",
+                this->product_name_.c_str(), this->firmware_version_, serial_number_[0], serial_number_[1],
+                serial_number_[2]);
   if (this->auto_cleaning_interval_.has_value()) {
     ESP_LOGCONFIG(TAG, "  Auto cleaning interval %" PRId32 " seconds", auto_cleaning_interval_.value());
   }

--- a/esphome/components/sen5x/sen5x.cpp
+++ b/esphome/components/sen5x/sen5x.cpp
@@ -264,7 +264,10 @@ void SEN5XComponent::dump_config() {
         break;
     }
   }
-  ESP_LOGCONFIG(TAG, "  Productname: %s\n  Firmware version: %d\n  Serial number %02d.%02d.%02d",
+  ESP_LOGCONFIG(TAG,
+                "  Productname: %s\n"
+                "  Firmware version: %d\n"
+                "  Serial number %02d.%02d.%02d",
                 this->product_name_.c_str(), this->firmware_version_, serial_number_[0], serial_number_[1],
                 serial_number_[2]);
   if (this->auto_cleaning_interval_.has_value()) {

--- a/esphome/components/sensor/sensor.h
+++ b/esphome/components/sensor/sensor.h
@@ -13,13 +13,17 @@ namespace sensor {
 
 #define LOG_SENSOR(prefix, type, obj) \
   if ((obj) != nullptr) { \
-    ESP_LOGCONFIG(TAG, "%s%s '%s'", prefix, LOG_STR_LITERAL(type), (obj)->get_name().c_str()); \
+    ESP_LOGCONFIG(TAG, \
+                  "%s%s '%s'\n" \
+                  "%s  State Class: '%s'\n" \
+                  "%s  Unit of Measurement: '%s'\n" \
+                  "%s  Accuracy Decimals: %d", \
+                  prefix, LOG_STR_LITERAL(type), (obj)->get_name().c_str(), prefix, \
+                  state_class_to_string((obj)->get_state_class()).c_str(), prefix, \
+                  (obj)->get_unit_of_measurement().c_str(), prefix, (obj)->get_accuracy_decimals()); \
     if (!(obj)->get_device_class().empty()) { \
       ESP_LOGCONFIG(TAG, "%s  Device Class: '%s'", prefix, (obj)->get_device_class().c_str()); \
     } \
-    ESP_LOGCONFIG(TAG, "%s  State Class: '%s'", prefix, state_class_to_string((obj)->get_state_class()).c_str()); \
-    ESP_LOGCONFIG(TAG, "%s  Unit of Measurement: '%s'", prefix, (obj)->get_unit_of_measurement().c_str()); \
-    ESP_LOGCONFIG(TAG, "%s  Accuracy Decimals: %d", prefix, (obj)->get_accuracy_decimals()); \
     if (!(obj)->get_icon().empty()) { \
       ESP_LOGCONFIG(TAG, "%s  Icon: '%s'", prefix, (obj)->get_icon().c_str()); \
     } \

--- a/esphome/components/servo/servo.cpp
+++ b/esphome/components/servo/servo.cpp
@@ -12,11 +12,14 @@ uint32_t global_servo_id = 1911044085ULL;  // NOLINT(cppcoreguidelines-avoid-non
 
 void Servo::dump_config() {
   ESP_LOGCONFIG(TAG, "Servo:");
-  ESP_LOGCONFIG(TAG, "  Idle Level: %.1f%%", this->idle_level_ * 100.0f);
-  ESP_LOGCONFIG(TAG, "  Min Level: %.1f%%", this->min_level_ * 100.0f);
-  ESP_LOGCONFIG(TAG, "  Max Level: %.1f%%", this->max_level_ * 100.0f);
-  ESP_LOGCONFIG(TAG, "  auto detach time: %" PRIu32 " ms", this->auto_detach_time_);
-  ESP_LOGCONFIG(TAG, "  run duration: %" PRIu32 " ms", this->transition_length_);
+  ESP_LOGCONFIG(TAG,
+                "  Idle Level: %.1f%%\n"
+                "  Min Level: %.1f%%\n"
+                "  Max Level: %.1f%%\n"
+                "  auto detach time: %" PRIu32 " ms\n"
+                "  run duration: %" PRIu32 " ms",
+                this->idle_level_ * 100.0f, this->min_level_ * 100.0f, this->max_level_ * 100.0f,
+                this->auto_detach_time_, this->transition_length_);
 }
 
 void Servo::setup() {

--- a/esphome/components/sgp30/sgp30.cpp
+++ b/esphome/components/sgp30/sgp30.cpp
@@ -250,9 +250,11 @@ void SGP30Component::dump_config() {
   } else {
     ESP_LOGCONFIG(TAG, "  Serial number: %" PRIu64, this->serial_number_);
     if (this->eco2_baseline_ != 0x0000 && this->tvoc_baseline_ != 0x0000) {
-      ESP_LOGCONFIG(TAG, "  Baseline:");
-      ESP_LOGCONFIG(TAG, "    eCO2 Baseline: 0x%04X", this->eco2_baseline_);
-      ESP_LOGCONFIG(TAG, "    TVOC Baseline: 0x%04X", this->tvoc_baseline_);
+      ESP_LOGCONFIG(TAG,
+                    "  Baseline:\n"
+                    "    eCO2 Baseline: 0x%04X\n"
+                    "    TVOC Baseline: 0x%04X",
+                    this->eco2_baseline_, this->tvoc_baseline_);
     } else {
       ESP_LOGCONFIG(TAG, "  Baseline: No baseline configured");
     }

--- a/esphome/components/sgp4x/sgp4x.cpp
+++ b/esphome/components/sgp4x/sgp4x.cpp
@@ -289,7 +289,10 @@ void SGP4xComponent::dump_config() {
         break;
     }
   } else {
-    ESP_LOGCONFIG(TAG, "  Type: %s\n  Serial number: %" PRIu64 "\n  Minimum Samples: %f",
+    ESP_LOGCONFIG(TAG,
+                  "  Type: %s\n"
+                  "  Serial number: %" PRIu64 "\n"
+                  "  Minimum Samples: %f",
                   sgp_type_ == SGP41 ? "SGP41" : "SPG40", this->serial_number_, GasIndexAlgorithm_INITIAL_BLACKOUT);
   }
   LOG_UPDATE_INTERVAL(this);

--- a/esphome/components/sgp4x/sgp4x.cpp
+++ b/esphome/components/sgp4x/sgp4x.cpp
@@ -289,9 +289,8 @@ void SGP4xComponent::dump_config() {
         break;
     }
   } else {
-    ESP_LOGCONFIG(TAG, "  Type: %s", sgp_type_ == SGP41 ? "SGP41" : "SPG40");
-    ESP_LOGCONFIG(TAG, "  Serial number: %" PRIu64, this->serial_number_);
-    ESP_LOGCONFIG(TAG, "  Minimum Samples: %f", GasIndexAlgorithm_INITIAL_BLACKOUT);
+    ESP_LOGCONFIG(TAG, "  Type: %s\n  Serial number: %" PRIu64 "\n  Minimum Samples: %f",
+                  sgp_type_ == SGP41 ? "SGP41" : "SPG40", this->serial_number_, GasIndexAlgorithm_INITIAL_BLACKOUT);
   }
   LOG_UPDATE_INTERVAL(this);
 

--- a/esphome/components/shelly_dimmer/shelly_dimmer.cpp
+++ b/esphome/components/shelly_dimmer/shelly_dimmer.cpp
@@ -119,17 +119,21 @@ void ShellyDimmer::dump_config() {
   LOG_PIN("  NRST Pin: ", this->pin_nrst_);
   LOG_PIN("  BOOT0 Pin: ", this->pin_boot0_);
 
-  ESP_LOGCONFIG(TAG, "  Leading Edge: %s", YESNO(this->leading_edge_));
-  ESP_LOGCONFIG(TAG, "  Warmup Brightness: %d", this->warmup_brightness_);
+  ESP_LOGCONFIG(TAG,
+                "  Leading Edge: %s\n"
+                "  Warmup Brightness: %d\n"
+                "  Minimum Brightness: %d\n"
+                "  Maximum Brightness: %d",
+                YESNO(this->leading_edge_), this->warmup_brightness_, this->min_brightness_, this->max_brightness_);
   // ESP_LOGCONFIG(TAG, "  Warmup Time: %d", this->warmup_time_);
   // ESP_LOGCONFIG(TAG, "  Fade Rate: %d", this->fade_rate_);
-  ESP_LOGCONFIG(TAG, "  Minimum Brightness: %d", this->min_brightness_);
-  ESP_LOGCONFIG(TAG, "  Maximum Brightness: %d", this->max_brightness_);
 
   LOG_UPDATE_INTERVAL(this);
 
-  ESP_LOGCONFIG(TAG, "  STM32 current firmware version: %d.%d ", this->version_major_, this->version_minor_);
-  ESP_LOGCONFIG(TAG, "  STM32 required firmware version: %d.%d", USE_SHD_FIRMWARE_MAJOR_VERSION,
+  ESP_LOGCONFIG(TAG,
+                "  STM32 current firmware version: %d.%d \n"
+                "  STM32 required firmware version: %d.%d",
+                this->version_major_, this->version_minor_, USE_SHD_FIRMWARE_MAJOR_VERSION,
                 USE_SHD_FIRMWARE_MINOR_VERSION);
 
   if (this->version_major_ != USE_SHD_FIRMWARE_MAJOR_VERSION ||

--- a/esphome/components/slow_pwm/slow_pwm_output.cpp
+++ b/esphome/components/slow_pwm/slow_pwm_output.cpp
@@ -63,8 +63,10 @@ void SlowPWMOutput::dump_config() {
   if (this->turn_off_trigger_) {
     ESP_LOGCONFIG(TAG, "  Turn off automation configured");
   }
-  ESP_LOGCONFIG(TAG, "  Period: %d ms\n  Restart cycle on state change: %s", this->period_,
-                YESNO(this->restart_cycle_on_state_change_));
+  ESP_LOGCONFIG(TAG,
+                "  Period: %d ms\n"
+                "  Restart cycle on state change: %s",
+                this->period_, YESNO(this->restart_cycle_on_state_change_));
   LOG_FLOAT_OUTPUT(this);
 }
 

--- a/esphome/components/slow_pwm/slow_pwm_output.cpp
+++ b/esphome/components/slow_pwm/slow_pwm_output.cpp
@@ -63,8 +63,8 @@ void SlowPWMOutput::dump_config() {
   if (this->turn_off_trigger_) {
     ESP_LOGCONFIG(TAG, "  Turn off automation configured");
   }
-  ESP_LOGCONFIG(TAG, "  Period: %d ms", this->period_);
-  ESP_LOGCONFIG(TAG, "  Restart cycle on state change: %s", YESNO(this->restart_cycle_on_state_change_));
+  ESP_LOGCONFIG(TAG, "  Period: %d ms\n  Restart cycle on state change: %s", this->period_,
+                YESNO(this->restart_cycle_on_state_change_));
   LOG_FLOAT_OUTPUT(this);
 }
 

--- a/esphome/components/sm2235/sm2235.cpp
+++ b/esphome/components/sm2235/sm2235.cpp
@@ -19,8 +19,10 @@ void SM2235::dump_config() {
   ESP_LOGCONFIG(TAG, "sm2235:");
   LOG_PIN("  Data Pin: ", this->data_pin_);
   LOG_PIN("  Clock Pin: ", this->clock_pin_);
-  ESP_LOGCONFIG(TAG, "  Color Channels Max Power: %u\n  White Channels Max Power: %u", this->max_power_color_channels_,
-                this->max_power_white_channels_);
+  ESP_LOGCONFIG(TAG,
+                "  Color Channels Max Power: %u\n"
+                "  White Channels Max Power: %u",
+                this->max_power_color_channels_, this->max_power_white_channels_);
 }
 
 }  // namespace sm2235

--- a/esphome/components/sm2235/sm2235.cpp
+++ b/esphome/components/sm2235/sm2235.cpp
@@ -19,8 +19,8 @@ void SM2235::dump_config() {
   ESP_LOGCONFIG(TAG, "sm2235:");
   LOG_PIN("  Data Pin: ", this->data_pin_);
   LOG_PIN("  Clock Pin: ", this->clock_pin_);
-  ESP_LOGCONFIG(TAG, "  Color Channels Max Power: %u", this->max_power_color_channels_);
-  ESP_LOGCONFIG(TAG, "  White Channels Max Power: %u", this->max_power_white_channels_);
+  ESP_LOGCONFIG(TAG, "  Color Channels Max Power: %u\n  White Channels Max Power: %u", this->max_power_color_channels_,
+                this->max_power_white_channels_);
 }
 
 }  // namespace sm2235

--- a/esphome/components/sm2335/sm2335.cpp
+++ b/esphome/components/sm2335/sm2335.cpp
@@ -19,8 +19,10 @@ void SM2335::dump_config() {
   ESP_LOGCONFIG(TAG, "sm2335:");
   LOG_PIN("  Data Pin: ", this->data_pin_);
   LOG_PIN("  Clock Pin: ", this->clock_pin_);
-  ESP_LOGCONFIG(TAG, "  Color Channels Max Power: %u\n  White Channels Max Power: %u", this->max_power_color_channels_,
-                this->max_power_white_channels_);
+  ESP_LOGCONFIG(TAG,
+                "  Color Channels Max Power: %u\n"
+                "  White Channels Max Power: %u",
+                this->max_power_color_channels_, this->max_power_white_channels_);
 }
 
 }  // namespace sm2335

--- a/esphome/components/sm2335/sm2335.cpp
+++ b/esphome/components/sm2335/sm2335.cpp
@@ -19,8 +19,8 @@ void SM2335::dump_config() {
   ESP_LOGCONFIG(TAG, "sm2335:");
   LOG_PIN("  Data Pin: ", this->data_pin_);
   LOG_PIN("  Clock Pin: ", this->clock_pin_);
-  ESP_LOGCONFIG(TAG, "  Color Channels Max Power: %u", this->max_power_color_channels_);
-  ESP_LOGCONFIG(TAG, "  White Channels Max Power: %u", this->max_power_white_channels_);
+  ESP_LOGCONFIG(TAG, "  Color Channels Max Power: %u\n  White Channels Max Power: %u", this->max_power_color_channels_,
+                this->max_power_white_channels_);
 }
 
 }  // namespace sm2335

--- a/esphome/components/sonoff_d1/sonoff_d1.cpp
+++ b/esphome/components/sonoff_d1/sonoff_d1.cpp
@@ -287,7 +287,10 @@ void SonoffD1Output::write_state(light::LightState *state) {
 
 void SonoffD1Output::dump_config() {
   ESP_LOGCONFIG(TAG,
-                "Sonoff D1 Dimmer: '%s'\n  Use RM433 Remote: %s\n  Minimal brightness: %d\n  Maximal brightness: %d",
+                "Sonoff D1 Dimmer: '%s'\n"
+                "  Use RM433 Remote: %s\n"
+                "  Minimal brightness: %d\n"
+                "  Maximal brightness: %d",
                 this->light_state_ ? this->light_state_->get_name().c_str() : "", ONOFF(this->use_rm433_remote_),
                 this->min_value_, this->max_value_);
 }

--- a/esphome/components/sonoff_d1/sonoff_d1.cpp
+++ b/esphome/components/sonoff_d1/sonoff_d1.cpp
@@ -286,10 +286,10 @@ void SonoffD1Output::write_state(light::LightState *state) {
 }
 
 void SonoffD1Output::dump_config() {
-  ESP_LOGCONFIG(TAG, "Sonoff D1 Dimmer: '%s'", this->light_state_ ? this->light_state_->get_name().c_str() : "");
-  ESP_LOGCONFIG(TAG, "  Use RM433 Remote: %s", ONOFF(this->use_rm433_remote_));
-  ESP_LOGCONFIG(TAG, "  Minimal brightness: %d", this->min_value_);
-  ESP_LOGCONFIG(TAG, "  Maximal brightness: %d", this->max_value_);
+  ESP_LOGCONFIG(TAG,
+                "Sonoff D1 Dimmer: '%s'\n  Use RM433 Remote: %s\n  Minimal brightness: %d\n  Maximal brightness: %d",
+                this->light_state_ ? this->light_state_->get_name().c_str() : "", ONOFF(this->use_rm433_remote_),
+                this->min_value_, this->max_value_);
 }
 
 void SonoffD1Output::loop() {

--- a/esphome/components/sound_level/sound_level.cpp
+++ b/esphome/components/sound_level/sound_level.cpp
@@ -19,7 +19,10 @@ static const uint32_t RING_BUFFER_DURATION_MS = 120;
 static const double MAX_SAMPLE_SQUARED_DENOMINATOR = INT16_MIN * INT16_MIN;
 
 void SoundLevelComponent::dump_config() {
-  ESP_LOGCONFIG(TAG, "Sound Level Component:\n  Measurement Duration: %" PRIu32 " ms", measurement_duration_ms_);
+  ESP_LOGCONFIG(TAG,
+                "Sound Level Component:\n"
+                "  Measurement Duration: %" PRIu32 " ms",
+                measurement_duration_ms_);
   LOG_SENSOR("  ", "Peak:", this->peak_sensor_);
 
   LOG_SENSOR("  ", "RMS:", this->rms_sensor_);

--- a/esphome/components/sound_level/sound_level.cpp
+++ b/esphome/components/sound_level/sound_level.cpp
@@ -19,8 +19,7 @@ static const uint32_t RING_BUFFER_DURATION_MS = 120;
 static const double MAX_SAMPLE_SQUARED_DENOMINATOR = INT16_MIN * INT16_MIN;
 
 void SoundLevelComponent::dump_config() {
-  ESP_LOGCONFIG(TAG, "Sound Level Component:");
-  ESP_LOGCONFIG(TAG, "  Measurement Duration: %" PRIu32 " ms", measurement_duration_ms_);
+  ESP_LOGCONFIG(TAG, "Sound Level Component:\n  Measurement Duration: %" PRIu32 " ms", measurement_duration_ms_);
   LOG_SENSOR("  ", "Peak:", this->peak_sensor_);
 
   LOG_SENSOR("  ", "RMS:", this->rms_sensor_);

--- a/esphome/components/sprinkler/sprinkler.cpp
+++ b/esphome/components/sprinkler/sprinkler.cpp
@@ -1712,9 +1712,8 @@ void Sprinkler::dump_config() {
     if (this->valve_overlap_) {
       ESP_LOGCONFIG(TAG, "  Valve Overlap: %" PRIu32 " seconds", this->switching_delay_.value_or(0));
     } else {
-      ESP_LOGCONFIG(TAG, "  Valve Open Delay: %" PRIu32 " seconds", this->switching_delay_.value_or(0));
-      ESP_LOGCONFIG(TAG, "  Pump Switch Off During Valve Open Delay: %s",
-                    YESNO(this->pump_switch_off_during_valve_open_delay_));
+      ESP_LOGCONFIG(TAG, "  Valve Open Delay: %" PRIu32 " seconds\n  Pump Switch Off During Valve Open Delay: %s",
+                    this->switching_delay_.value_or(0), YESNO(this->pump_switch_off_during_valve_open_delay_));
     }
   }
   for (size_t valve_number = 0; valve_number < this->number_of_valves(); valve_number++) {

--- a/esphome/components/sprinkler/sprinkler.cpp
+++ b/esphome/components/sprinkler/sprinkler.cpp
@@ -1718,9 +1718,11 @@ void Sprinkler::dump_config() {
     }
   }
   for (size_t valve_number = 0; valve_number < this->number_of_valves(); valve_number++) {
-    ESP_LOGCONFIG(TAG, "  Valve %zu:", valve_number);
-    ESP_LOGCONFIG(TAG, "    Name: %s", this->valve_name(valve_number));
-    ESP_LOGCONFIG(TAG, "    Run Duration: %" PRIu32 " seconds", this->valve_run_duration(valve_number));
+    ESP_LOGCONFIG(TAG,
+                  "  Valve %zu:\n"
+                  "    Name: %s\n"
+                  "    Run Duration: %" PRIu32 " seconds",
+                  valve_number, this->valve_name(valve_number), this->valve_run_duration(valve_number));
     if (this->valve_[valve_number].valve_switch.pulse_duration()) {
       ESP_LOGCONFIG(TAG, "    Pulse Duration: %" PRIu32 " milliseconds",
                     this->valve_[valve_number].valve_switch.pulse_duration());

--- a/esphome/components/sprinkler/sprinkler.cpp
+++ b/esphome/components/sprinkler/sprinkler.cpp
@@ -1712,7 +1712,9 @@ void Sprinkler::dump_config() {
     if (this->valve_overlap_) {
       ESP_LOGCONFIG(TAG, "  Valve Overlap: %" PRIu32 " seconds", this->switching_delay_.value_or(0));
     } else {
-      ESP_LOGCONFIG(TAG, "  Valve Open Delay: %" PRIu32 " seconds\n  Pump Switch Off During Valve Open Delay: %s",
+      ESP_LOGCONFIG(TAG,
+                    "  Valve Open Delay: %" PRIu32 " seconds\n"
+                    "  Pump Switch Off During Valve Open Delay: %s",
                     this->switching_delay_.value_or(0), YESNO(this->pump_switch_off_during_valve_open_delay_));
     }
   }

--- a/esphome/components/sps30/sps30.cpp
+++ b/esphome/components/sps30/sps30.cpp
@@ -96,9 +96,10 @@ void SPS30Component::dump_config() {
     }
   }
   LOG_UPDATE_INTERVAL(this);
-  ESP_LOGCONFIG(TAG, "  Serial Number: '%s'", this->serial_number_);
-  ESP_LOGCONFIG(TAG, "  Firmware version v%0d.%0d", (raw_firmware_version_ >> 8),
-                uint16_t(raw_firmware_version_ & 0xFF));
+  ESP_LOGCONFIG(TAG,
+                "  Serial Number: '%s'\n"
+                "  Firmware version v%0d.%0d",
+                this->serial_number_, (raw_firmware_version_ >> 8), uint16_t(raw_firmware_version_ & 0xFF));
   LOG_SENSOR("  ", "PM1.0 Weight Concentration", this->pm_1_0_sensor_);
   LOG_SENSOR("  ", "PM2.5 Weight Concentration", this->pm_2_5_sensor_);
   LOG_SENSOR("  ", "PM4 Weight Concentration", this->pm_4_0_sensor_);

--- a/esphome/components/ssd1306_i2c/ssd1306_i2c.cpp
+++ b/esphome/components/ssd1306_i2c/ssd1306_i2c.cpp
@@ -24,12 +24,15 @@ void I2CSSD1306::dump_config() {
   LOG_I2C_DEVICE(this);
   ESP_LOGCONFIG(TAG, "  Model: %s", this->model_str_());
   LOG_PIN("  Reset Pin: ", this->reset_pin_);
-  ESP_LOGCONFIG(TAG, "  External VCC: %s", YESNO(this->external_vcc_));
-  ESP_LOGCONFIG(TAG, "  Flip X: %s", YESNO(this->flip_x_));
-  ESP_LOGCONFIG(TAG, "  Flip Y: %s", YESNO(this->flip_y_));
-  ESP_LOGCONFIG(TAG, "  Offset X: %d", this->offset_x_);
-  ESP_LOGCONFIG(TAG, "  Offset Y: %d", this->offset_y_);
-  ESP_LOGCONFIG(TAG, "  Inverted Color: %s", YESNO(this->invert_));
+  ESP_LOGCONFIG(TAG,
+                "  External VCC: %s\n"
+                "  Flip X: %s\n"
+                "  Flip Y: %s\n"
+                "  Offset X: %d\n"
+                "  Offset Y: %d\n"
+                "  Inverted Color: %s",
+                YESNO(this->external_vcc_), YESNO(this->flip_x_), YESNO(this->flip_y_), this->offset_x_,
+                this->offset_y_, YESNO(this->invert_));
   LOG_UPDATE_INTERVAL(this);
 
   if (this->error_code_ == COMMUNICATION_FAILED) {

--- a/esphome/components/ssd1306_spi/ssd1306_spi.cpp
+++ b/esphome/components/ssd1306_spi/ssd1306_spi.cpp
@@ -22,7 +22,12 @@ void SPISSD1306::dump_config() {
   LOG_PIN("  DC Pin: ", this->dc_pin_);
   LOG_PIN("  Reset Pin: ", this->reset_pin_);
   ESP_LOGCONFIG(TAG,
-                "  External VCC: %s\n  Flip X: %s\n  Flip Y: %s\n  Offset X: %d\n  Offset Y: %d\n  Inverted Color: %s",
+                "  External VCC: %s\n"
+                "  Flip X: %s\n"
+                "  Flip Y: %s\n"
+                "  Offset X: %d\n"
+                "  Offset Y: %d\n"
+                "  Inverted Color: %s",
                 YESNO(this->external_vcc_), YESNO(this->flip_x_), YESNO(this->flip_y_), this->offset_x_,
                 this->offset_y_, YESNO(this->invert_));
   LOG_UPDATE_INTERVAL(this);

--- a/esphome/components/ssd1306_spi/ssd1306_spi.cpp
+++ b/esphome/components/ssd1306_spi/ssd1306_spi.cpp
@@ -21,12 +21,10 @@ void SPISSD1306::dump_config() {
   LOG_PIN("  CS Pin: ", this->cs_);
   LOG_PIN("  DC Pin: ", this->dc_pin_);
   LOG_PIN("  Reset Pin: ", this->reset_pin_);
-  ESP_LOGCONFIG(TAG, "  External VCC: %s", YESNO(this->external_vcc_));
-  ESP_LOGCONFIG(TAG, "  Flip X: %s", YESNO(this->flip_x_));
-  ESP_LOGCONFIG(TAG, "  Flip Y: %s", YESNO(this->flip_y_));
-  ESP_LOGCONFIG(TAG, "  Offset X: %d", this->offset_x_);
-  ESP_LOGCONFIG(TAG, "  Offset Y: %d", this->offset_y_);
-  ESP_LOGCONFIG(TAG, "  Inverted Color: %s", YESNO(this->invert_));
+  ESP_LOGCONFIG(TAG,
+                "  External VCC: %s\n  Flip X: %s\n  Flip Y: %s\n  Offset X: %d\n  Offset Y: %d\n  Inverted Color: %s",
+                YESNO(this->external_vcc_), YESNO(this->flip_x_), YESNO(this->flip_y_), this->offset_x_,
+                this->offset_y_, YESNO(this->invert_));
   LOG_UPDATE_INTERVAL(this);
 }
 void SPISSD1306::command(uint8_t value) {

--- a/esphome/components/st7567_i2c/st7567_i2c.cpp
+++ b/esphome/components/st7567_i2c/st7567_i2c.cpp
@@ -24,8 +24,11 @@ void I2CST7567::dump_config() {
   LOG_I2C_DEVICE(this);
   ESP_LOGCONFIG(TAG, "  Model: %s", this->model_str_());
   LOG_PIN("  Reset Pin: ", this->reset_pin_);
-  ESP_LOGCONFIG(TAG, "  Mirror X: %s\n  Mirror Y: %s\n  Invert Colors: %s", YESNO(this->mirror_x_),
-                YESNO(this->mirror_y_), YESNO(this->invert_colors_));
+  ESP_LOGCONFIG(TAG,
+                "  Mirror X: %s\n"
+                "  Mirror Y: %s\n"
+                "  Invert Colors: %s",
+                YESNO(this->mirror_x_), YESNO(this->mirror_y_), YESNO(this->invert_colors_));
   LOG_UPDATE_INTERVAL(this);
 
   if (this->error_code_ == COMMUNICATION_FAILED) {

--- a/esphome/components/st7567_i2c/st7567_i2c.cpp
+++ b/esphome/components/st7567_i2c/st7567_i2c.cpp
@@ -24,9 +24,8 @@ void I2CST7567::dump_config() {
   LOG_I2C_DEVICE(this);
   ESP_LOGCONFIG(TAG, "  Model: %s", this->model_str_());
   LOG_PIN("  Reset Pin: ", this->reset_pin_);
-  ESP_LOGCONFIG(TAG, "  Mirror X: %s", YESNO(this->mirror_x_));
-  ESP_LOGCONFIG(TAG, "  Mirror Y: %s", YESNO(this->mirror_y_));
-  ESP_LOGCONFIG(TAG, "  Invert Colors: %s", YESNO(this->invert_colors_));
+  ESP_LOGCONFIG(TAG, "  Mirror X: %s\n  Mirror Y: %s\n  Invert Colors: %s", YESNO(this->mirror_x_),
+                YESNO(this->mirror_y_), YESNO(this->invert_colors_));
   LOG_UPDATE_INTERVAL(this);
 
   if (this->error_code_ == COMMUNICATION_FAILED) {

--- a/esphome/components/st7701s/st7701s.cpp
+++ b/esphome/components/st7701s/st7701s.cpp
@@ -181,8 +181,7 @@ void ST7701S::write_init_sequence_() {
 
 void ST7701S::dump_config() {
   ESP_LOGCONFIG("", "ST7701S RGB LCD");
-  ESP_LOGCONFIG(TAG, "  Height: %u", this->height_);
-  ESP_LOGCONFIG(TAG, "  Width: %u", this->width_);
+  ESP_LOGCONFIG(TAG, "  Height: %u\n  Width: %u", this->height_, this->width_);
   LOG_PIN("  CS Pin: ", this->cs_);
   LOG_PIN("  DC Pin: ", this->dc_pin_);
   LOG_PIN("  DE Pin: ", this->de_pin_);

--- a/esphome/components/st7701s/st7701s.cpp
+++ b/esphome/components/st7701s/st7701s.cpp
@@ -181,7 +181,10 @@ void ST7701S::write_init_sequence_() {
 
 void ST7701S::dump_config() {
   ESP_LOGCONFIG("", "ST7701S RGB LCD");
-  ESP_LOGCONFIG(TAG, "  Height: %u\n  Width: %u", this->height_, this->width_);
+  ESP_LOGCONFIG(TAG,
+                "  Height: %u\n"
+                "  Width: %u",
+                this->height_, this->width_);
   LOG_PIN("  CS Pin: ", this->cs_);
   LOG_PIN("  DC Pin: ", this->dc_pin_);
   LOG_PIN("  DE Pin: ", this->de_pin_);

--- a/esphome/components/st7789v/st7789v.cpp
+++ b/esphome/components/st7789v/st7789v.cpp
@@ -122,10 +122,15 @@ void ST7789V::setup() {
 
 void ST7789V::dump_config() {
   LOG_DISPLAY("", "SPI ST7789V", this);
-  ESP_LOGCONFIG(
-      TAG, "  Model: %s\n  Height: %u\n  Width: %u\n  Height Offset: %u\n  Width Offset: %u\n  8-bit color mode: %s",
-      this->model_str_, this->height_, this->width_, this->offset_height_, this->offset_width_,
-      YESNO(this->eightbitcolor_));
+  ESP_LOGCONFIG(TAG,
+                "  Model: %s\n"
+                "  Height: %u\n"
+                "  Width: %u\n"
+                "  Height Offset: %u\n"
+                "  Width Offset: %u\n"
+                "  8-bit color mode: %s",
+                this->model_str_, this->height_, this->width_, this->offset_height_, this->offset_width_,
+                YESNO(this->eightbitcolor_));
   LOG_PIN("  CS Pin: ", this->cs_);
   LOG_PIN("  DC Pin: ", this->dc_pin_);
   LOG_PIN("  Reset Pin: ", this->reset_pin_);

--- a/esphome/components/st7789v/st7789v.cpp
+++ b/esphome/components/st7789v/st7789v.cpp
@@ -122,10 +122,10 @@ void ST7789V::setup() {
 
 void ST7789V::dump_config() {
   LOG_DISPLAY("", "SPI ST7789V", this);
-  ESP_LOGCONFIG(TAG, "  Model: %s", this->model_str_);
-  ESP_LOGCONFIG(TAG, "  Height: %u\n  Width: %u\n  Height Offset: %u\n  Width Offset: %u", this->height_, this->width_,
-                this->offset_height_, this->offset_width_);
-  ESP_LOGCONFIG(TAG, "  8-bit color mode: %s", YESNO(this->eightbitcolor_));
+  ESP_LOGCONFIG(
+      TAG, "  Model: %s\n  Height: %u\n  Width: %u\n  Height Offset: %u\n  Width Offset: %u\n  8-bit color mode: %s",
+      this->model_str_, this->height_, this->width_, this->offset_height_, this->offset_width_,
+      YESNO(this->eightbitcolor_));
   LOG_PIN("  CS Pin: ", this->cs_);
   LOG_PIN("  DC Pin: ", this->dc_pin_);
   LOG_PIN("  Reset Pin: ", this->reset_pin_);

--- a/esphome/components/st7789v/st7789v.cpp
+++ b/esphome/components/st7789v/st7789v.cpp
@@ -123,10 +123,8 @@ void ST7789V::setup() {
 void ST7789V::dump_config() {
   LOG_DISPLAY("", "SPI ST7789V", this);
   ESP_LOGCONFIG(TAG, "  Model: %s", this->model_str_);
-  ESP_LOGCONFIG(TAG, "  Height: %u", this->height_);
-  ESP_LOGCONFIG(TAG, "  Width: %u", this->width_);
-  ESP_LOGCONFIG(TAG, "  Height Offset: %u", this->offset_height_);
-  ESP_LOGCONFIG(TAG, "  Width Offset: %u", this->offset_width_);
+  ESP_LOGCONFIG(TAG, "  Height: %u\n  Width: %u\n  Height Offset: %u\n  Width Offset: %u", this->height_, this->width_,
+                this->offset_height_, this->offset_width_);
   ESP_LOGCONFIG(TAG, "  8-bit color mode: %s", YESNO(this->eightbitcolor_));
   LOG_PIN("  CS Pin: ", this->cs_);
   LOG_PIN("  DC Pin: ", this->dc_pin_);

--- a/esphome/components/st7920/st7920.cpp
+++ b/esphome/components/st7920/st7920.cpp
@@ -95,7 +95,10 @@ void ST7920::fill(Color color) { memset(this->buffer_, color.is_on() ? 0xFF : 0x
 void ST7920::dump_config() {
   LOG_DISPLAY("", "ST7920", this);
   LOG_PIN("  CS Pin: ", this->cs_);
-  ESP_LOGCONFIG(TAG, "  Height: %d\n  Width: %d", this->height_, this->width_);
+  ESP_LOGCONFIG(TAG,
+                "  Height: %d\n"
+                "  Width: %d",
+                this->height_, this->width_);
 }
 
 float ST7920::get_setup_priority() const { return setup_priority::PROCESSOR; }

--- a/esphome/components/st7920/st7920.cpp
+++ b/esphome/components/st7920/st7920.cpp
@@ -95,8 +95,7 @@ void ST7920::fill(Color color) { memset(this->buffer_, color.is_on() ? 0xFF : 0x
 void ST7920::dump_config() {
   LOG_DISPLAY("", "ST7920", this);
   LOG_PIN("  CS Pin: ", this->cs_);
-  ESP_LOGCONFIG(TAG, "  Height: %d", this->height_);
-  ESP_LOGCONFIG(TAG, "  Width: %d", this->width_);
+  ESP_LOGCONFIG(TAG, "  Height: %d\n  Width: %d", this->height_, this->width_);
 }
 
 float ST7920::get_setup_priority() const { return setup_priority::PROCESSOR; }

--- a/esphome/components/statsd/statsd.cpp
+++ b/esphome/components/statsd/statsd.cpp
@@ -38,17 +38,14 @@ StatsdComponent::~StatsdComponent() {
 }
 
 void StatsdComponent::dump_config() {
-  ESP_LOGCONFIG(TAG, "statsD:");
-  ESP_LOGCONFIG(TAG, "  host: %s", this->host_);
-  ESP_LOGCONFIG(TAG, "  port: %d", this->port_);
+  ESP_LOGCONFIG(TAG, "statsD:\n  host: %s\n  port: %d", this->host_, this->port_);
   if (this->prefix_) {
     ESP_LOGCONFIG(TAG, "  prefix: %s", this->prefix_);
   }
 
   ESP_LOGCONFIG(TAG, "  metrics:");
   for (sensors_t s : this->sensors_) {
-    ESP_LOGCONFIG(TAG, "    - name: %s", s.name);
-    ESP_LOGCONFIG(TAG, "      type: %d", s.type);
+    ESP_LOGCONFIG(TAG, "    - name: %s\n      type: %d", s.name, s.type);
   }
 }
 

--- a/esphome/components/statsd/statsd.cpp
+++ b/esphome/components/statsd/statsd.cpp
@@ -38,14 +38,21 @@ StatsdComponent::~StatsdComponent() {
 }
 
 void StatsdComponent::dump_config() {
-  ESP_LOGCONFIG(TAG, "statsD:\n  host: %s\n  port: %d", this->host_, this->port_);
+  ESP_LOGCONFIG(TAG,
+                "statsD:\n"
+                "  host: %s\n"
+                "  port: %d",
+                this->host_, this->port_);
   if (this->prefix_) {
     ESP_LOGCONFIG(TAG, "  prefix: %s", this->prefix_);
   }
 
   ESP_LOGCONFIG(TAG, "  metrics:");
   for (sensors_t s : this->sensors_) {
-    ESP_LOGCONFIG(TAG, "    - name: %s\n      type: %d", s.name, s.type);
+    ESP_LOGCONFIG(TAG,
+                  "    - name: %s\n"
+                  "      type: %d",
+                  s.name, s.type);
   }
 }
 

--- a/esphome/components/stepper/stepper.h
+++ b/esphome/components/stepper/stepper.h
@@ -7,7 +7,10 @@ namespace esphome {
 namespace stepper {
 
 #define LOG_STEPPER(this) \
-  ESP_LOGCONFIG(TAG, "  Acceleration: %.0f steps/s^2\n  Deceleration: %.0f steps/s^2\n  Max Speed: %.0f steps/s", \
+  ESP_LOGCONFIG(TAG, \
+                "  Acceleration: %.0f steps/s^2\n" \
+                "  Deceleration: %.0f steps/s^2\n" \
+                "  Max Speed: %.0f steps/s", \
                 this->acceleration_, this->deceleration_, this->max_speed_);
 
 class Stepper {

--- a/esphome/components/stepper/stepper.h
+++ b/esphome/components/stepper/stepper.h
@@ -7,9 +7,8 @@ namespace esphome {
 namespace stepper {
 
 #define LOG_STEPPER(this) \
-  ESP_LOGCONFIG(TAG, "  Acceleration: %.0f steps/s^2", this->acceleration_); \
-  ESP_LOGCONFIG(TAG, "  Deceleration: %.0f steps/s^2", this->deceleration_); \
-  ESP_LOGCONFIG(TAG, "  Max Speed: %.0f steps/s", this->max_speed_);
+  ESP_LOGCONFIG(TAG, "  Acceleration: %.0f steps/s^2\n  Deceleration: %.0f steps/s^2\n  Max Speed: %.0f steps/s", \
+                this->acceleration_, this->deceleration_, this->max_speed_);
 
 class Stepper {
  public:

--- a/esphome/components/switch/switch.cpp
+++ b/esphome/components/switch/switch.cpp
@@ -76,8 +76,11 @@ void log_switch(const char *tag, const char *prefix, const char *type, Switch *o
     }
 
     // Build the base message with mandatory fields
-    ESP_LOGCONFIG(tag, "%s%s '%s'\n%s  Restore Mode: %s%s %s", prefix, type, obj->get_name().c_str(), prefix,
-                  LOG_STR_ARG(inverted), LOG_STR_ARG(restore), LOG_STR_ARG(onoff));
+    ESP_LOGCONFIG(tag,
+                  "%s%s '%s'\n"
+                  "%s  Restore Mode: %s%s %s",
+                  prefix, type, obj->get_name().c_str(), prefix, LOG_STR_ARG(inverted), LOG_STR_ARG(restore),
+                  LOG_STR_ARG(onoff));
 
     // Add optional fields separately
     if (!obj->get_icon().empty()) {

--- a/esphome/components/switch/switch.cpp
+++ b/esphome/components/switch/switch.cpp
@@ -65,7 +65,21 @@ bool Switch::is_inverted() const { return this->inverted_; }
 
 void log_switch(const char *tag, const char *prefix, const char *type, Switch *obj) {
   if (obj != nullptr) {
-    ESP_LOGCONFIG(tag, "%s%s '%s'", prefix, type, obj->get_name().c_str());
+    // Prepare restore mode string
+    const LogString *onoff = LOG_STR(""), *inverted = onoff, *restore;
+    if (obj->restore_mode & RESTORE_MODE_DISABLED_MASK) {
+      restore = LOG_STR("disabled");
+    } else {
+      onoff = obj->restore_mode & RESTORE_MODE_ON_MASK ? LOG_STR("ON") : LOG_STR("OFF");
+      inverted = obj->restore_mode & RESTORE_MODE_INVERTED_MASK ? LOG_STR("inverted ") : LOG_STR("");
+      restore = obj->restore_mode & RESTORE_MODE_PERSISTENT_MASK ? LOG_STR("restore defaults to") : LOG_STR("always");
+    }
+
+    // Build the base message with mandatory fields
+    ESP_LOGCONFIG(tag, "%s%s '%s'\n%s  Restore Mode: %s%s %s", prefix, type, obj->get_name().c_str(), prefix,
+                  LOG_STR_ARG(inverted), LOG_STR_ARG(restore), LOG_STR_ARG(onoff));
+
+    // Add optional fields separately
     if (!obj->get_icon().empty()) {
       ESP_LOGCONFIG(tag, "%s  Icon: '%s'", prefix, obj->get_icon().c_str());
     }
@@ -78,17 +92,6 @@ void log_switch(const char *tag, const char *prefix, const char *type, Switch *o
     if (!obj->get_device_class().empty()) {
       ESP_LOGCONFIG(tag, "%s  Device Class: '%s'", prefix, obj->get_device_class().c_str());
     }
-    const LogString *onoff = LOG_STR(""), *inverted = onoff, *restore;
-    if (obj->restore_mode & RESTORE_MODE_DISABLED_MASK) {
-      restore = LOG_STR("disabled");
-    } else {
-      onoff = obj->restore_mode & RESTORE_MODE_ON_MASK ? LOG_STR("ON") : LOG_STR("OFF");
-      inverted = obj->restore_mode & RESTORE_MODE_INVERTED_MASK ? LOG_STR("inverted ") : LOG_STR("");
-      restore = obj->restore_mode & RESTORE_MODE_PERSISTENT_MASK ? LOG_STR("restore defaults to") : LOG_STR("always");
-    }
-
-    ESP_LOGCONFIG(tag, "%s  Restore Mode: %s%s %s", prefix, LOG_STR_ARG(inverted), LOG_STR_ARG(restore),
-                  LOG_STR_ARG(onoff));
   }
 }
 

--- a/esphome/components/template/alarm_control_panel/template_alarm_control_panel.cpp
+++ b/esphome/components/template/alarm_control_panel/template_alarm_control_panel.cpp
@@ -29,8 +29,10 @@ void TemplateAlarmControlPanel::add_sensor(binary_sensor::BinarySensor *sensor, 
 
 void TemplateAlarmControlPanel::dump_config() {
   ESP_LOGCONFIG(TAG, "TemplateAlarmControlPanel:");
-  ESP_LOGCONFIG(TAG, "  Current State: %s", LOG_STR_ARG(alarm_control_panel_state_to_string(this->current_state_)));
-  ESP_LOGCONFIG(TAG, "  Number of Codes: %u", this->codes_.size());
+  ESP_LOGCONFIG(TAG,
+                "  Current State: %s\n"
+                "  Number of Codes: %u",
+                LOG_STR_ARG(alarm_control_panel_state_to_string(this->current_state_)), this->codes_.size());
   if (!this->codes_.empty())
     ESP_LOGCONFIG(TAG, "  Requires Code To Arm: %s", YESNO(this->requires_code_to_arm_));
   ESP_LOGCONFIG(TAG, "  Arming Away Time: %" PRIu32 "s", (this->arming_away_time_ / 1000));
@@ -38,19 +40,25 @@ void TemplateAlarmControlPanel::dump_config() {
     ESP_LOGCONFIG(TAG, "  Arming Home Time: %" PRIu32 "s", (this->arming_home_time_ / 1000));
   if (this->arming_night_time_ != 0)
     ESP_LOGCONFIG(TAG, "  Arming Night Time: %" PRIu32 "s", (this->arming_night_time_ / 1000));
-  ESP_LOGCONFIG(TAG, "  Pending Time: %" PRIu32 "s", (this->pending_time_ / 1000));
-  ESP_LOGCONFIG(TAG, "  Trigger Time: %" PRIu32 "s", (this->trigger_time_ / 1000));
-  ESP_LOGCONFIG(TAG, "  Supported Features: %" PRIu32, this->get_supported_features());
+  ESP_LOGCONFIG(TAG,
+                "  Pending Time: %" PRIu32 "s\n"
+                "  Trigger Time: %" PRIu32 "s\n"
+                "  Supported Features: %" PRIu32,
+                (this->pending_time_ / 1000), (this->trigger_time_ / 1000), this->get_supported_features());
 #ifdef USE_BINARY_SENSOR
   for (auto sensor_info : this->sensor_map_) {
     ESP_LOGCONFIG(TAG, "  Binary Sensor:");
-    ESP_LOGCONFIG(TAG, "    Name: %s", sensor_info.first->get_name().c_str());
-    ESP_LOGCONFIG(TAG, "    Armed home bypass: %s",
-                  TRUEFALSE(sensor_info.second.flags & BINARY_SENSOR_MODE_BYPASS_ARMED_HOME));
-    ESP_LOGCONFIG(TAG, "    Armed night bypass: %s",
-                  TRUEFALSE(sensor_info.second.flags & BINARY_SENSOR_MODE_BYPASS_ARMED_NIGHT));
-    ESP_LOGCONFIG(TAG, "    Auto bypass: %s", TRUEFALSE(sensor_info.second.flags & BINARY_SENSOR_MODE_BYPASS_AUTO));
-    ESP_LOGCONFIG(TAG, "    Chime mode: %s", TRUEFALSE(sensor_info.second.flags & BINARY_SENSOR_MODE_CHIME));
+    ESP_LOGCONFIG(TAG,
+                  "    Name: %s\n"
+                  "    Armed home bypass: %s\n"
+                  "    Armed night bypass: %s\n"
+                  "    Auto bypass: %s\n"
+                  "    Chime mode: %s",
+                  sensor_info.first->get_name().c_str(),
+                  TRUEFALSE(sensor_info.second.flags & BINARY_SENSOR_MODE_BYPASS_ARMED_HOME),
+                  TRUEFALSE(sensor_info.second.flags & BINARY_SENSOR_MODE_BYPASS_ARMED_NIGHT),
+                  TRUEFALSE(sensor_info.second.flags & BINARY_SENSOR_MODE_BYPASS_AUTO),
+                  TRUEFALSE(sensor_info.second.flags & BINARY_SENSOR_MODE_CHIME));
     const char *sensor_type;
     switch (sensor_info.second.type) {
       case ALARM_SENSOR_TYPE_INSTANT:

--- a/esphome/components/template/select/template_select.cpp
+++ b/esphome/components/template/select/template_select.cpp
@@ -66,9 +66,11 @@ void TemplateSelect::dump_config() {
   LOG_UPDATE_INTERVAL(this);
   if (this->f_.has_value())
     return;
-  ESP_LOGCONFIG(TAG, "  Optimistic: %s", YESNO(this->optimistic_));
-  ESP_LOGCONFIG(TAG, "  Initial Option: %s", this->initial_option_.c_str());
-  ESP_LOGCONFIG(TAG, "  Restore Value: %s", YESNO(this->restore_value_));
+  ESP_LOGCONFIG(TAG,
+                "  Optimistic: %s\n"
+                "  Initial Option: %s\n"
+                "  Restore Value: %s",
+                YESNO(this->optimistic_), this->initial_option_.c_str(), YESNO(this->restore_value_));
 }
 
 }  // namespace template_

--- a/esphome/components/template/valve/template_valve.cpp
+++ b/esphome/components/template/valve/template_valve.cpp
@@ -66,7 +66,10 @@ Trigger<> *TemplateValve::get_toggle_trigger() const { return this->toggle_trigg
 
 void TemplateValve::dump_config() {
   LOG_VALVE("", "Template Valve", this);
-  ESP_LOGCONFIG(TAG, "  Has position: %s\n  Optimistic: %s", YESNO(this->has_position_), YESNO(this->optimistic_));
+  ESP_LOGCONFIG(TAG,
+                "  Has position: %s\n"
+                "  Optimistic: %s",
+                YESNO(this->has_position_), YESNO(this->optimistic_));
 }
 
 void TemplateValve::control(const ValveCall &call) {

--- a/esphome/components/template/valve/template_valve.cpp
+++ b/esphome/components/template/valve/template_valve.cpp
@@ -66,8 +66,7 @@ Trigger<> *TemplateValve::get_toggle_trigger() const { return this->toggle_trigg
 
 void TemplateValve::dump_config() {
   LOG_VALVE("", "Template Valve", this);
-  ESP_LOGCONFIG(TAG, "  Has position: %s", YESNO(this->has_position_));
-  ESP_LOGCONFIG(TAG, "  Optimistic: %s", YESNO(this->optimistic_));
+  ESP_LOGCONFIG(TAG, "  Has position: %s\n  Optimistic: %s", YESNO(this->has_position_), YESNO(this->optimistic_));
 }
 
 void TemplateValve::control(const ValveCall &call) {

--- a/esphome/components/thermostat/thermostat_climate.cpp
+++ b/esphome/components/thermostat/thermostat_climate.cpp
@@ -1300,8 +1300,8 @@ void ThermostatClimate::dump_config() {
   }
   ESP_LOGCONFIG(TAG, "  Start-up Delay Enabled: %s", YESNO(this->use_startup_delay_));
   if (this->supports_cool_) {
-    ESP_LOGCONFIG(TAG, "  Cooling Parameters:");
     ESP_LOGCONFIG(TAG,
+                  "  Cooling Parameters:\n"
                   "    Deadband: %.1f°C\n"
                   "    Overrun: %.1f°C",
                   this->cooling_deadband_, this->cooling_overrun_);

--- a/esphome/components/thermostat/thermostat_climate.cpp
+++ b/esphome/components/thermostat/thermostat_climate.cpp
@@ -1301,36 +1301,47 @@ void ThermostatClimate::dump_config() {
   ESP_LOGCONFIG(TAG, "  Start-up Delay Enabled: %s", YESNO(this->use_startup_delay_));
   if (this->supports_cool_) {
     ESP_LOGCONFIG(TAG, "  Cooling Parameters:");
-    ESP_LOGCONFIG(TAG, "    Deadband: %.1f°C", this->cooling_deadband_);
-    ESP_LOGCONFIG(TAG, "    Overrun: %.1f°C", this->cooling_overrun_);
+    ESP_LOGCONFIG(TAG,
+                  "    Deadband: %.1f°C\n"
+                  "    Overrun: %.1f°C",
+                  this->cooling_deadband_, this->cooling_overrun_);
     if ((this->supplemental_cool_delta_ > 0) || (this->timer_duration_(thermostat::TIMER_COOLING_MAX_RUN_TIME) > 0)) {
-      ESP_LOGCONFIG(TAG, "    Supplemental Delta: %.1f°C", this->supplemental_cool_delta_);
-      ESP_LOGCONFIG(TAG, "    Maximum Run Time: %" PRIu32 "s",
+      ESP_LOGCONFIG(TAG,
+                    "    Supplemental Delta: %.1f°C\n"
+                    "    Maximum Run Time: %" PRIu32 "s",
+                    this->supplemental_cool_delta_,
                     this->timer_duration_(thermostat::TIMER_COOLING_MAX_RUN_TIME) / 1000);
     }
-    ESP_LOGCONFIG(TAG, "    Minimum Off Time: %" PRIu32 "s",
-                  this->timer_duration_(thermostat::TIMER_COOLING_OFF) / 1000);
-    ESP_LOGCONFIG(TAG, "    Minimum Run Time: %" PRIu32 "s",
+    ESP_LOGCONFIG(TAG,
+                  "    Minimum Off Time: %" PRIu32 "s\n"
+                  "    Minimum Run Time: %" PRIu32 "s",
+                  this->timer_duration_(thermostat::TIMER_COOLING_OFF) / 1000,
                   this->timer_duration_(thermostat::TIMER_COOLING_ON) / 1000);
   }
   if (this->supports_heat_) {
     ESP_LOGCONFIG(TAG, "  Heating Parameters:");
-    ESP_LOGCONFIG(TAG, "    Deadband: %.1f°C", this->heating_deadband_);
-    ESP_LOGCONFIG(TAG, "    Overrun: %.1f°C", this->heating_overrun_);
+    ESP_LOGCONFIG(TAG,
+                  "    Deadband: %.1f°C\n"
+                  "    Overrun: %.1f°C",
+                  this->heating_deadband_, this->heating_overrun_);
     if ((this->supplemental_heat_delta_ > 0) || (this->timer_duration_(thermostat::TIMER_HEATING_MAX_RUN_TIME) > 0)) {
-      ESP_LOGCONFIG(TAG, "    Supplemental Delta: %.1f°C", this->supplemental_heat_delta_);
-      ESP_LOGCONFIG(TAG, "    Maximum Run Time: %" PRIu32 "s",
+      ESP_LOGCONFIG(TAG,
+                    "    Supplemental Delta: %.1f°C\n"
+                    "    Maximum Run Time: %" PRIu32 "s",
+                    this->supplemental_heat_delta_,
                     this->timer_duration_(thermostat::TIMER_HEATING_MAX_RUN_TIME) / 1000);
     }
-    ESP_LOGCONFIG(TAG, "    Minimum Off Time: %" PRIu32 "s",
-                  this->timer_duration_(thermostat::TIMER_HEATING_OFF) / 1000);
-    ESP_LOGCONFIG(TAG, "    Minimum Run Time: %" PRIu32 "s",
+    ESP_LOGCONFIG(TAG,
+                  "    Minimum Off Time: %" PRIu32 "s\n"
+                  "    Minimum Run Time: %" PRIu32 "s",
+                  this->timer_duration_(thermostat::TIMER_HEATING_OFF) / 1000,
                   this->timer_duration_(thermostat::TIMER_HEATING_ON) / 1000);
   }
   if (this->supports_fan_only_) {
-    ESP_LOGCONFIG(TAG, "  Fanning Minimum Off Time: %" PRIu32 "s",
-                  this->timer_duration_(thermostat::TIMER_FANNING_OFF) / 1000);
-    ESP_LOGCONFIG(TAG, "  Fanning Minimum Run Time: %" PRIu32 "s",
+    ESP_LOGCONFIG(TAG,
+                  "  Fanning Minimum Off Time: %" PRIu32 "s\n"
+                  "  Fanning Minimum Run Time: %" PRIu32 "s",
+                  this->timer_duration_(thermostat::TIMER_FANNING_OFF) / 1000,
                   this->timer_duration_(thermostat::TIMER_FANNING_ON) / 1000);
   }
   if (this->supports_fan_mode_on_ || this->supports_fan_mode_off_ || this->supports_fan_mode_auto_ ||
@@ -1341,14 +1352,17 @@ void ThermostatClimate::dump_config() {
                   this->timer_duration_(thermostat::TIMER_FAN_MODE) / 1000);
   }
   ESP_LOGCONFIG(TAG, "  Minimum Idle Time: %" PRIu32 "s", this->timer_[thermostat::TIMER_IDLE_ON].time / 1000);
-  ESP_LOGCONFIG(TAG, "  Supports AUTO: %s", YESNO(this->supports_auto_));
-  ESP_LOGCONFIG(TAG, "  Supports HEAT/COOL: %s", YESNO(this->supports_heat_cool_));
-  ESP_LOGCONFIG(TAG, "  Supports COOL: %s", YESNO(this->supports_cool_));
-  ESP_LOGCONFIG(TAG, "  Supports DRY: %s", YESNO(this->supports_dry_));
-  ESP_LOGCONFIG(TAG, "  Supports FAN_ONLY: %s", YESNO(this->supports_fan_only_));
-  ESP_LOGCONFIG(TAG, "  Supports FAN_ONLY_ACTION_USES_FAN_MODE_TIMER: %s",
-                YESNO(this->supports_fan_only_action_uses_fan_mode_timer_));
-  ESP_LOGCONFIG(TAG, "  Supports FAN_ONLY_COOLING: %s", YESNO(this->supports_fan_only_cooling_));
+  ESP_LOGCONFIG(TAG,
+                "  Supports AUTO: %s\n"
+                "  Supports HEAT/COOL: %s\n"
+                "  Supports COOL: %s\n"
+                "  Supports DRY: %s\n"
+                "  Supports FAN_ONLY: %s\n"
+                "  Supports FAN_ONLY_ACTION_USES_FAN_MODE_TIMER: %s\n"
+                "  Supports FAN_ONLY_COOLING: %s",
+                YESNO(this->supports_auto_), YESNO(this->supports_heat_cool_), YESNO(this->supports_cool_),
+                YESNO(this->supports_dry_), YESNO(this->supports_fan_only_),
+                YESNO(this->supports_fan_only_action_uses_fan_mode_timer_), YESNO(this->supports_fan_only_cooling_));
   if (this->supports_cool_) {
     ESP_LOGCONFIG(TAG, "  Supports FAN_WITH_COOLING: %s", YESNO(this->supports_fan_with_cooling_));
   }
@@ -1356,21 +1370,31 @@ void ThermostatClimate::dump_config() {
     ESP_LOGCONFIG(TAG, "  Supports FAN_WITH_HEATING: %s", YESNO(this->supports_fan_with_heating_));
   }
   ESP_LOGCONFIG(TAG, "  Supports HEAT: %s", YESNO(this->supports_heat_));
-  ESP_LOGCONFIG(TAG, "  Supports FAN MODE ON: %s", YESNO(this->supports_fan_mode_on_));
-  ESP_LOGCONFIG(TAG, "  Supports FAN MODE OFF: %s", YESNO(this->supports_fan_mode_off_));
-  ESP_LOGCONFIG(TAG, "  Supports FAN MODE AUTO: %s", YESNO(this->supports_fan_mode_auto_));
-  ESP_LOGCONFIG(TAG, "  Supports FAN MODE LOW: %s", YESNO(this->supports_fan_mode_low_));
-  ESP_LOGCONFIG(TAG, "  Supports FAN MODE MEDIUM: %s", YESNO(this->supports_fan_mode_medium_));
-  ESP_LOGCONFIG(TAG, "  Supports FAN MODE HIGH: %s", YESNO(this->supports_fan_mode_high_));
-  ESP_LOGCONFIG(TAG, "  Supports FAN MODE MIDDLE: %s", YESNO(this->supports_fan_mode_middle_));
-  ESP_LOGCONFIG(TAG, "  Supports FAN MODE FOCUS: %s", YESNO(this->supports_fan_mode_focus_));
-  ESP_LOGCONFIG(TAG, "  Supports FAN MODE DIFFUSE: %s", YESNO(this->supports_fan_mode_diffuse_));
-  ESP_LOGCONFIG(TAG, "  Supports FAN MODE QUIET: %s", YESNO(this->supports_fan_mode_quiet_));
-  ESP_LOGCONFIG(TAG, "  Supports SWING MODE BOTH: %s", YESNO(this->supports_swing_mode_both_));
-  ESP_LOGCONFIG(TAG, "  Supports SWING MODE OFF: %s", YESNO(this->supports_swing_mode_off_));
-  ESP_LOGCONFIG(TAG, "  Supports SWING MODE HORIZONTAL: %s", YESNO(this->supports_swing_mode_horizontal_));
-  ESP_LOGCONFIG(TAG, "  Supports SWING MODE VERTICAL: %s", YESNO(this->supports_swing_mode_vertical_));
-  ESP_LOGCONFIG(TAG, "  Supports TWO SET POINTS: %s", YESNO(this->supports_two_points_));
+  ESP_LOGCONFIG(TAG,
+                "  Supports FAN MODE ON: %s\n"
+                "  Supports FAN MODE OFF: %s\n"
+                "  Supports FAN MODE AUTO: %s\n"
+                "  Supports FAN MODE LOW: %s\n"
+                "  Supports FAN MODE MEDIUM: %s\n"
+                "  Supports FAN MODE HIGH: %s\n"
+                "  Supports FAN MODE MIDDLE: %s\n"
+                "  Supports FAN MODE FOCUS: %s\n"
+                "  Supports FAN MODE DIFFUSE: %s\n"
+                "  Supports FAN MODE QUIET: %s",
+                YESNO(this->supports_fan_mode_on_), YESNO(this->supports_fan_mode_off_),
+                YESNO(this->supports_fan_mode_auto_), YESNO(this->supports_fan_mode_low_),
+                YESNO(this->supports_fan_mode_medium_), YESNO(this->supports_fan_mode_high_),
+                YESNO(this->supports_fan_mode_middle_), YESNO(this->supports_fan_mode_focus_),
+                YESNO(this->supports_fan_mode_diffuse_), YESNO(this->supports_fan_mode_quiet_));
+  ESP_LOGCONFIG(TAG,
+                "  Supports SWING MODE BOTH: %s\n"
+                "  Supports SWING MODE OFF: %s\n"
+                "  Supports SWING MODE HORIZONTAL: %s\n"
+                "  Supports SWING MODE VERTICAL: %s\n"
+                "  Supports TWO SET POINTS: %s",
+                YESNO(this->supports_swing_mode_both_), YESNO(this->supports_swing_mode_off_),
+                YESNO(this->supports_swing_mode_horizontal_), YESNO(this->supports_swing_mode_vertical_),
+                YESNO(this->supports_two_points_));
 
   ESP_LOGCONFIG(TAG, "  Supported PRESETS: ");
   for (auto &it : this->preset_config_) {

--- a/esphome/components/thermostat/thermostat_climate.cpp
+++ b/esphome/components/thermostat/thermostat_climate.cpp
@@ -1319,8 +1319,8 @@ void ThermostatClimate::dump_config() {
                   this->timer_duration_(thermostat::TIMER_COOLING_ON) / 1000);
   }
   if (this->supports_heat_) {
-    ESP_LOGCONFIG(TAG, "  Heating Parameters:");
     ESP_LOGCONFIG(TAG,
+                  "  Heating Parameters:\n"
                   "    Deadband: %.1f°C\n"
                   "    Overrun: %.1f°C",
                   this->heating_deadband_, this->heating_overrun_);

--- a/esphome/components/time_based/time_based_cover.cpp
+++ b/esphome/components/time_based/time_based_cover.cpp
@@ -12,8 +12,10 @@ using namespace esphome::cover;
 
 void TimeBasedCover::dump_config() {
   LOG_COVER("", "Time Based Cover", this);
-  ESP_LOGCONFIG(TAG, "  Open Duration: %.1fs\n  Close Duration: %.1fs", this->open_duration_ / 1e3f,
-                this->close_duration_ / 1e3f);
+  ESP_LOGCONFIG(TAG,
+                "  Open Duration: %.1fs\n"
+                "  Close Duration: %.1fs",
+                this->open_duration_ / 1e3f, this->close_duration_ / 1e3f);
 }
 void TimeBasedCover::setup() {
   auto restore = this->restore_state_();

--- a/esphome/components/time_based/time_based_cover.cpp
+++ b/esphome/components/time_based/time_based_cover.cpp
@@ -12,8 +12,8 @@ using namespace esphome::cover;
 
 void TimeBasedCover::dump_config() {
   LOG_COVER("", "Time Based Cover", this);
-  ESP_LOGCONFIG(TAG, "  Open Duration: %.1fs", this->open_duration_ / 1e3f);
-  ESP_LOGCONFIG(TAG, "  Close Duration: %.1fs", this->close_duration_ / 1e3f);
+  ESP_LOGCONFIG(TAG, "  Open Duration: %.1fs\n  Close Duration: %.1fs", this->open_duration_ / 1e3f,
+                this->close_duration_ / 1e3f);
 }
 void TimeBasedCover::setup() {
   auto restore = this->restore_state_();

--- a/esphome/components/tlc59208f/tlc59208f_output.cpp
+++ b/esphome/components/tlc59208f/tlc59208f_output.cpp
@@ -111,7 +111,10 @@ void TLC59208FOutput::setup() {
 }
 
 void TLC59208FOutput::dump_config() {
-  ESP_LOGCONFIG(TAG, "TLC59208F:\n  Mode: 0x%02X", this->mode_);
+  ESP_LOGCONFIG(TAG,
+                "TLC59208F:\n"
+                "  Mode: 0x%02X",
+                this->mode_);
 
   if (this->is_failed()) {
     ESP_LOGE(TAG, "Setting up TLC59208F failed!");

--- a/esphome/components/tlc59208f/tlc59208f_output.cpp
+++ b/esphome/components/tlc59208f/tlc59208f_output.cpp
@@ -111,8 +111,7 @@ void TLC59208FOutput::setup() {
 }
 
 void TLC59208FOutput::dump_config() {
-  ESP_LOGCONFIG(TAG, "TLC59208F:");
-  ESP_LOGCONFIG(TAG, "  Mode: 0x%02X", this->mode_);
+  ESP_LOGCONFIG(TAG, "TLC59208F:\n  Mode: 0x%02X", this->mode_);
 
   if (this->is_failed()) {
     ESP_LOGE(TAG, "Setting up TLC59208F failed!");

--- a/esphome/components/tm1637/tm1637.cpp
+++ b/esphome/components/tm1637/tm1637.cpp
@@ -135,10 +135,8 @@ void TM1637Display::setup() {
   this->display();
 }
 void TM1637Display::dump_config() {
-  ESP_LOGCONFIG(TAG, "TM1637:");
-  ESP_LOGCONFIG(TAG, "  Intensity: %d", this->intensity_);
-  ESP_LOGCONFIG(TAG, "  Inverted: %d", this->inverted_);
-  ESP_LOGCONFIG(TAG, "  Length: %d", this->length_);
+  ESP_LOGCONFIG(TAG, "TM1637:\n  Intensity: %d\n  Inverted: %d\n  Length: %d", this->intensity_, this->inverted_,
+                this->length_);
   LOG_PIN("  CLK Pin: ", this->clk_pin_);
   LOG_PIN("  DIO Pin: ", this->dio_pin_);
   LOG_UPDATE_INTERVAL(this);

--- a/esphome/components/tm1637/tm1637.cpp
+++ b/esphome/components/tm1637/tm1637.cpp
@@ -135,8 +135,12 @@ void TM1637Display::setup() {
   this->display();
 }
 void TM1637Display::dump_config() {
-  ESP_LOGCONFIG(TAG, "TM1637:\n  Intensity: %d\n  Inverted: %d\n  Length: %d", this->intensity_, this->inverted_,
-                this->length_);
+  ESP_LOGCONFIG(TAG,
+                "TM1637:\n"
+                "  Intensity: %d\n"
+                "  Inverted: %d\n"
+                "  Length: %d",
+                this->intensity_, this->inverted_, this->length_);
   LOG_PIN("  CLK Pin: ", this->clk_pin_);
   LOG_PIN("  DIO Pin: ", this->dio_pin_);
   LOG_UPDATE_INTERVAL(this);

--- a/esphome/components/tm1638/tm1638.cpp
+++ b/esphome/components/tm1638/tm1638.cpp
@@ -43,7 +43,10 @@ void TM1638Component::setup() {
 }
 
 void TM1638Component::dump_config() {
-  ESP_LOGCONFIG(TAG, "TM1638:\n  Intensity: %u", this->intensity_);
+  ESP_LOGCONFIG(TAG,
+                "TM1638:\n"
+                "  Intensity: %u",
+                this->intensity_);
   LOG_PIN("  CLK Pin: ", this->clk_pin_);
   LOG_PIN("  DIO Pin: ", this->dio_pin_);
   LOG_PIN("  STB Pin: ", this->stb_pin_);

--- a/esphome/components/tm1638/tm1638.cpp
+++ b/esphome/components/tm1638/tm1638.cpp
@@ -43,8 +43,7 @@ void TM1638Component::setup() {
 }
 
 void TM1638Component::dump_config() {
-  ESP_LOGCONFIG(TAG, "TM1638:");
-  ESP_LOGCONFIG(TAG, "  Intensity: %u", this->intensity_);
+  ESP_LOGCONFIG(TAG, "TM1638:\n  Intensity: %u", this->intensity_);
   LOG_PIN("  CLK Pin: ", this->clk_pin_);
   LOG_PIN("  DIO Pin: ", this->dio_pin_);
   LOG_PIN("  STB Pin: ", this->stb_pin_);

--- a/esphome/components/tmp1075/tmp1075.cpp
+++ b/esphome/components/tmp1075/tmp1075.cpp
@@ -47,14 +47,11 @@ void TMP1075Sensor::dump_config() {
     ESP_LOGE(TAG, ESP_LOG_MSG_COMM_FAIL);
     return;
   }
-  ESP_LOGCONFIG(TAG, "  limit low  : %.4f °C", alert_limit_low_);
-  ESP_LOGCONFIG(TAG, "  limit high : %.4f °C", alert_limit_high_);
-  ESP_LOGCONFIG(TAG, "  oneshot    : %d", config_.fields.oneshot);
-  ESP_LOGCONFIG(TAG, "  rate       : %d", config_.fields.rate);
-  ESP_LOGCONFIG(TAG, "  fault_count: %d", config_.fields.faults);
-  ESP_LOGCONFIG(TAG, "  polarity   : %d", config_.fields.polarity);
-  ESP_LOGCONFIG(TAG, "  alert_mode : %d", config_.fields.alert_mode);
-  ESP_LOGCONFIG(TAG, "  shutdown   : %d", config_.fields.shutdown);
+  ESP_LOGCONFIG(TAG,
+                "  limit low  : %.4f °C\n  limit high : %.4f °C\n  oneshot    : %d\n  rate       : %d\n"
+                "  fault_count: %d\n  polarity   : %d\n  alert_mode : %d\n  shutdown   : %d",
+                alert_limit_low_, alert_limit_high_, config_.fields.oneshot, config_.fields.rate, config_.fields.faults,
+                config_.fields.polarity, config_.fields.alert_mode, config_.fields.shutdown);
 }
 
 void TMP1075Sensor::set_fault_count(const int faults) {

--- a/esphome/components/tmp1075/tmp1075.cpp
+++ b/esphome/components/tmp1075/tmp1075.cpp
@@ -48,8 +48,14 @@ void TMP1075Sensor::dump_config() {
     return;
   }
   ESP_LOGCONFIG(TAG,
-                "  limit low  : %.4f °C\n  limit high : %.4f °C\n  oneshot    : %d\n  rate       : %d\n"
-                "  fault_count: %d\n  polarity   : %d\n  alert_mode : %d\n  shutdown   : %d",
+                "  limit low  : %.4f °C\n"
+                "  limit high : %.4f °C\n"
+                "  oneshot    : %d\n"
+                "  rate       : %d\n"
+                "  fault_count: %d\n"
+                "  polarity   : %d\n"
+                "  alert_mode : %d\n"
+                "  shutdown   : %d",
                 alert_limit_low_, alert_limit_high_, config_.fields.oneshot, config_.fields.rate, config_.fields.faults,
                 config_.fields.polarity, config_.fields.alert_mode, config_.fields.shutdown);
 }

--- a/esphome/components/tormatic/tormatic_cover.cpp
+++ b/esphome/components/tormatic/tormatic_cover.cpp
@@ -34,8 +34,8 @@ void Tormatic::dump_config() {
   LOG_COVER("", "Tormatic Cover", this);
   this->check_uart_settings(9600, 1, uart::UART_CONFIG_PARITY_NONE, 8);
 
-  ESP_LOGCONFIG(TAG, "  Open Duration: %.1fs", this->open_duration_ / 1e3f);
-  ESP_LOGCONFIG(TAG, "  Close Duration: %.1fs", this->close_duration_ / 1e3f);
+  ESP_LOGCONFIG(TAG, "  Open Duration: %.1fs\n  Close Duration: %.1fs", this->open_duration_ / 1e3f,
+                this->close_duration_ / 1e3f);
 
   auto restore = this->restore_state_();
   if (restore.has_value()) {

--- a/esphome/components/tormatic/tormatic_cover.cpp
+++ b/esphome/components/tormatic/tormatic_cover.cpp
@@ -34,8 +34,10 @@ void Tormatic::dump_config() {
   LOG_COVER("", "Tormatic Cover", this);
   this->check_uart_settings(9600, 1, uart::UART_CONFIG_PARITY_NONE, 8);
 
-  ESP_LOGCONFIG(TAG, "  Open Duration: %.1fs\n  Close Duration: %.1fs", this->open_duration_ / 1e3f,
-                this->close_duration_ / 1e3f);
+  ESP_LOGCONFIG(TAG,
+                "  Open Duration: %.1fs\n"
+                "  Close Duration: %.1fs",
+                this->open_duration_ / 1e3f, this->close_duration_ / 1e3f);
 
   auto restore = this->restore_state_();
   if (restore.has_value()) {

--- a/esphome/components/tsl2561/tsl2561.cpp
+++ b/esphome/components/tsl2561/tsl2561.cpp
@@ -45,7 +45,10 @@ void TSL2561Sensor::dump_config() {
   }
 
   int gain = this->gain_ == TSL2561_GAIN_1X ? 1 : 16;
-  ESP_LOGCONFIG(TAG, "  Gain: %dx\n  Integration Time: %.1f ms", gain, this->get_integration_time_ms_());
+  ESP_LOGCONFIG(TAG,
+                "  Gain: %dx\n"
+                "  Integration Time: %.1f ms",
+                gain, this->get_integration_time_ms_());
 
   LOG_UPDATE_INTERVAL(this);
 }

--- a/esphome/components/tsl2561/tsl2561.cpp
+++ b/esphome/components/tsl2561/tsl2561.cpp
@@ -45,8 +45,7 @@ void TSL2561Sensor::dump_config() {
   }
 
   int gain = this->gain_ == TSL2561_GAIN_1X ? 1 : 16;
-  ESP_LOGCONFIG(TAG, "  Gain: %dx", gain);
-  ESP_LOGCONFIG(TAG, "  Integration Time: %.1f ms", this->get_integration_time_ms_());
+  ESP_LOGCONFIG(TAG, "  Gain: %dx\n  Integration Time: %.1f ms", gain, this->get_integration_time_ms_());
 
   LOG_UPDATE_INTERVAL(this);
 }

--- a/esphome/components/tsl2591/tsl2591.cpp
+++ b/esphome/components/tsl2591/tsl2591.cpp
@@ -123,9 +123,8 @@ void TSL2591Component::dump_config() {
   TSL2591IntegrationTime raw_timing = this->integration_time_;
   int timing_ms = (1 + raw_timing) * 100;
   ESP_LOGCONFIG(TAG, "  Integration Time: %d ms", timing_ms);
-  ESP_LOGCONFIG(TAG, "  Power save mode enabled: %s", ONOFF(this->power_save_mode_enabled_));
-  ESP_LOGCONFIG(TAG, "  Device factor: %f", this->device_factor_);
-  ESP_LOGCONFIG(TAG, "  Glass attenuation factor: %f", this->glass_attenuation_factor_);
+  ESP_LOGCONFIG(TAG, "  Power save mode enabled: %s\n  Device factor: %f\n  Glass attenuation factor: %f",
+                ONOFF(this->power_save_mode_enabled_), this->device_factor_, this->glass_attenuation_factor_);
   LOG_SENSOR("  ", "Full spectrum:", this->full_spectrum_sensor_);
   LOG_SENSOR("  ", "Infrared:", this->infrared_sensor_);
   LOG_SENSOR("  ", "Visible:", this->visible_sensor_);

--- a/esphome/components/tsl2591/tsl2591.cpp
+++ b/esphome/components/tsl2591/tsl2591.cpp
@@ -123,7 +123,10 @@ void TSL2591Component::dump_config() {
   TSL2591IntegrationTime raw_timing = this->integration_time_;
   int timing_ms = (1 + raw_timing) * 100;
   ESP_LOGCONFIG(TAG, "  Integration Time: %d ms", timing_ms);
-  ESP_LOGCONFIG(TAG, "  Power save mode enabled: %s\n  Device factor: %f\n  Glass attenuation factor: %f",
+  ESP_LOGCONFIG(TAG,
+                "  Power save mode enabled: %s\n"
+                "  Device factor: %f\n"
+                "  Glass attenuation factor: %f",
                 ONOFF(this->power_save_mode_enabled_), this->device_factor_, this->glass_attenuation_factor_);
   LOG_SENSOR("  ", "Full spectrum:", this->full_spectrum_sensor_);
   LOG_SENSOR("  ", "Infrared:", this->infrared_sensor_);

--- a/esphome/components/tuya/select/tuya_select.cpp
+++ b/esphome/components/tuya/select/tuya_select.cpp
@@ -44,8 +44,11 @@ void TuyaSelect::control(const std::string &value) {
 
 void TuyaSelect::dump_config() {
   LOG_SELECT("", "Tuya Select", this);
-  ESP_LOGCONFIG(TAG, "  Select has datapoint ID %u\n  Data type: %s\n  Options are:", this->select_id_,
-                this->is_int_ ? "int" : "enum");
+  ESP_LOGCONFIG(TAG,
+                "  Select has datapoint ID %u\n"
+                "  Data type: %s\n"
+                "  Options are:",
+                this->select_id_, this->is_int_ ? "int" : "enum");
   auto options = this->traits.get_options();
   for (auto i = 0; i < this->mappings_.size(); i++) {
     ESP_LOGCONFIG(TAG, "    %i: %s", this->mappings_.at(i), options.at(i).c_str());

--- a/esphome/components/tuya/select/tuya_select.cpp
+++ b/esphome/components/tuya/select/tuya_select.cpp
@@ -44,9 +44,8 @@ void TuyaSelect::control(const std::string &value) {
 
 void TuyaSelect::dump_config() {
   LOG_SELECT("", "Tuya Select", this);
-  ESP_LOGCONFIG(TAG, "  Select has datapoint ID %u", this->select_id_);
-  ESP_LOGCONFIG(TAG, "  Data type: %s", this->is_int_ ? "int" : "enum");
-  ESP_LOGCONFIG(TAG, "  Options are:");
+  ESP_LOGCONFIG(TAG, "  Select has datapoint ID %u\n  Data type: %s\n  Options are:", this->select_id_,
+                this->is_int_ ? "int" : "enum");
   auto options = this->traits.get_options();
   for (auto i = 0; i < this->mappings_.size(); i++) {
     ESP_LOGCONFIG(TAG, "    %i: %s", this->mappings_.at(i), options.at(i).c_str());

--- a/esphome/components/uart/uart_component_esp32_arduino.cpp
+++ b/esphome/components/uart/uart_component_esp32_arduino.cpp
@@ -154,10 +154,8 @@ void ESP32ArduinoUARTComponent::dump_config() {
   if (this->rx_pin_ != nullptr) {
     ESP_LOGCONFIG(TAG, "  RX Buffer Size: %u", this->rx_buffer_size_);
   }
-  ESP_LOGCONFIG(TAG, "  Baud Rate: %u baud", this->baud_rate_);
-  ESP_LOGCONFIG(TAG, "  Data Bits: %u", this->data_bits_);
-  ESP_LOGCONFIG(TAG, "  Parity: %s", LOG_STR_ARG(parity_to_str(this->parity_)));
-  ESP_LOGCONFIG(TAG, "  Stop bits: %u", this->stop_bits_);
+  ESP_LOGCONFIG(TAG, "  Baud Rate: %u baud\n  Data Bits: %u\n  Parity: %s\n  Stop bits: %u", this->baud_rate_,
+                this->data_bits_, LOG_STR_ARG(parity_to_str(this->parity_)), this->stop_bits_);
   this->check_logger_conflict();
 }
 

--- a/esphome/components/uart/uart_component_esp32_arduino.cpp
+++ b/esphome/components/uart/uart_component_esp32_arduino.cpp
@@ -154,8 +154,12 @@ void ESP32ArduinoUARTComponent::dump_config() {
   if (this->rx_pin_ != nullptr) {
     ESP_LOGCONFIG(TAG, "  RX Buffer Size: %u", this->rx_buffer_size_);
   }
-  ESP_LOGCONFIG(TAG, "  Baud Rate: %u baud\n  Data Bits: %u\n  Parity: %s\n  Stop bits: %u", this->baud_rate_,
-                this->data_bits_, LOG_STR_ARG(parity_to_str(this->parity_)), this->stop_bits_);
+  ESP_LOGCONFIG(TAG,
+                "  Baud Rate: %u baud\n"
+                "  Data Bits: %u\n"
+                "  Parity: %s\n"
+                "  Stop bits: %u",
+                this->baud_rate_, this->data_bits_, LOG_STR_ARG(parity_to_str(this->parity_)), this->stop_bits_);
   this->check_logger_conflict();
 }
 

--- a/esphome/components/uart/uart_component_esp8266.cpp
+++ b/esphome/components/uart/uart_component_esp8266.cpp
@@ -121,10 +121,12 @@ void ESP8266UartComponent::dump_config() {
   if (this->rx_pin_ != nullptr) {
     ESP_LOGCONFIG(TAG, "  RX Buffer Size: %u", this->rx_buffer_size_);  // NOLINT
   }
-  ESP_LOGCONFIG(TAG, "  Baud Rate: %u baud", this->baud_rate_);
-  ESP_LOGCONFIG(TAG, "  Data Bits: %u", this->data_bits_);
-  ESP_LOGCONFIG(TAG, "  Parity: %s", LOG_STR_ARG(parity_to_str(this->parity_)));
-  ESP_LOGCONFIG(TAG, "  Stop bits: %u", this->stop_bits_);
+  ESP_LOGCONFIG(TAG,
+                "  Baud Rate: %u baud\n"
+                "  Data Bits: %u\n"
+                "  Parity: %s\n"
+                "  Stop bits: %u",
+                this->baud_rate_, this->data_bits_, LOG_STR_ARG(parity_to_str(this->parity_)), this->stop_bits_);
   if (this->hw_serial_ != nullptr) {
     ESP_LOGCONFIG(TAG, "  Using hardware serial interface.");
   } else {

--- a/esphome/components/uart/uart_component_esp_idf.cpp
+++ b/esphome/components/uart/uart_component_esp_idf.cpp
@@ -162,10 +162,12 @@ void IDFUARTComponent::dump_config() {
   if (this->rx_pin_ != nullptr) {
     ESP_LOGCONFIG(TAG, "  RX Buffer Size: %u", this->rx_buffer_size_);
   }
-  ESP_LOGCONFIG(TAG, "  Baud Rate: %" PRIu32 " baud", this->baud_rate_);
-  ESP_LOGCONFIG(TAG, "  Data Bits: %u", this->data_bits_);
-  ESP_LOGCONFIG(TAG, "  Parity: %s", LOG_STR_ARG(parity_to_str(this->parity_)));
-  ESP_LOGCONFIG(TAG, "  Stop bits: %u", this->stop_bits_);
+  ESP_LOGCONFIG(TAG,
+                "  Baud Rate: %" PRIu32 " baud\n"
+                "  Data Bits: %u\n"
+                "  Parity: %s\n"
+                "  Stop bits: %u",
+                this->baud_rate_, this->data_bits_, LOG_STR_ARG(parity_to_str(this->parity_)), this->stop_bits_);
   this->check_logger_conflict();
 }
 

--- a/esphome/components/uart/uart_component_host.cpp
+++ b/esphome/components/uart/uart_component_host.cpp
@@ -188,14 +188,12 @@ void HostUartComponent::dump_config() {
     }
     return;
   }
-  ESP_LOGCONFIG(TAG, "  Port status: opened");
-  ESP_LOGCONFIG(TAG, "  Baud Rate: %d", this->baud_rate_);
-  ESP_LOGCONFIG(TAG, "  Data Bits: %d", this->data_bits_);
-  ESP_LOGCONFIG(TAG, "  Parity: %s",
+  ESP_LOGCONFIG(TAG, "  Port status: opened\n  Baud Rate: %d\n  Data Bits: %d\n  Parity: %s\n  Stop Bits: %d",
+                this->baud_rate_, this->data_bits_,
                 this->parity_ == UART_CONFIG_PARITY_NONE   ? "None"
                 : this->parity_ == UART_CONFIG_PARITY_EVEN ? "Even"
-                                                           : "Odd");
-  ESP_LOGCONFIG(TAG, "  Stop Bits: %d", this->stop_bits_);
+                                                           : "Odd",
+                this->stop_bits_);
   this->check_logger_conflict();
 }
 

--- a/esphome/components/uart/uart_component_host.cpp
+++ b/esphome/components/uart/uart_component_host.cpp
@@ -188,7 +188,12 @@ void HostUartComponent::dump_config() {
     }
     return;
   }
-  ESP_LOGCONFIG(TAG, "  Port status: opened\n  Baud Rate: %d\n  Data Bits: %d\n  Parity: %s\n  Stop Bits: %d",
+  ESP_LOGCONFIG(TAG,
+                "  Port status: opened\n"
+                "  Baud Rate: %d\n"
+                "  Data Bits: %d\n"
+                "  Parity: %s\n"
+                "  Stop Bits: %d",
                 this->baud_rate_, this->data_bits_,
                 this->parity_ == UART_CONFIG_PARITY_NONE   ? "None"
                 : this->parity_ == UART_CONFIG_PARITY_EVEN ? "Even"

--- a/esphome/components/uart/uart_component_libretiny.cpp
+++ b/esphome/components/uart/uart_component_libretiny.cpp
@@ -108,10 +108,12 @@ void LibreTinyUARTComponent::dump_config() {
   if (this->rx_pin_ != nullptr) {
     ESP_LOGCONFIG(TAG, "  RX Buffer Size: %u", this->rx_buffer_size_);
   }
-  ESP_LOGCONFIG(TAG, "  Baud Rate: %u baud", this->baud_rate_);
-  ESP_LOGCONFIG(TAG, "  Data Bits: %u", this->data_bits_);
-  ESP_LOGCONFIG(TAG, "  Parity: %s", LOG_STR_ARG(parity_to_str(this->parity_)));
-  ESP_LOGCONFIG(TAG, "  Stop bits: %u", this->stop_bits_);
+  ESP_LOGCONFIG(TAG,
+                "  Baud Rate: %u baud\n"
+                "  Data Bits: %u\n"
+                "  Parity: %s\n"
+                "  Stop bits: %u",
+                this->baud_rate_, this->data_bits_, LOG_STR_ARG(parity_to_str(this->parity_)), this->stop_bits_);
   this->check_logger_conflict();
 }
 

--- a/esphome/components/uart/uart_component_rp2040.cpp
+++ b/esphome/components/uart/uart_component_rp2040.cpp
@@ -136,10 +136,12 @@ void RP2040UartComponent::dump_config() {
   if (this->rx_pin_ != nullptr) {
     ESP_LOGCONFIG(TAG, "  RX Buffer Size: %u", this->rx_buffer_size_);
   }
-  ESP_LOGCONFIG(TAG, "  Baud Rate: %u baud", this->baud_rate_);
-  ESP_LOGCONFIG(TAG, "  Data Bits: %u", this->data_bits_);
-  ESP_LOGCONFIG(TAG, "  Parity: %s", LOG_STR_ARG(parity_to_str(this->parity_)));
-  ESP_LOGCONFIG(TAG, "  Stop bits: %u", this->stop_bits_);
+  ESP_LOGCONFIG(TAG,
+                "  Baud Rate: %u baud\n"
+                "  Data Bits: %u\n"
+                "  Parity: %s\n"
+                "  Stop bits: %u",
+                this->baud_rate_, this->data_bits_, LOG_STR_ARG(parity_to_str(this->parity_)), this->stop_bits_);
   if (this->hw_serial_) {
     ESP_LOGCONFIG(TAG, "  Using hardware serial");
   } else {

--- a/esphome/components/udp/udp_component.cpp
+++ b/esphome/components/udp/udp_component.cpp
@@ -122,16 +122,14 @@ void UDPComponent::loop() {
 }
 
 void UDPComponent::dump_config() {
-  ESP_LOGCONFIG(TAG, "UDP:");
-  ESP_LOGCONFIG(TAG, "  Listen Port: %u", this->listen_port_);
-  ESP_LOGCONFIG(TAG, "  Broadcast Port: %u", this->broadcast_port_);
+  ESP_LOGCONFIG(TAG, "UDP:\n  Listen Port: %u\n  Broadcast Port: %u", this->listen_port_, this->broadcast_port_);
   for (const auto &address : this->addresses_)
     ESP_LOGCONFIG(TAG, "  Address: %s", address.c_str());
   if (this->listen_address_.has_value()) {
     ESP_LOGCONFIG(TAG, "  Listen address: %s", this->listen_address_.value().str().c_str());
   }
-  ESP_LOGCONFIG(TAG, "  Broadcasting: %s", YESNO(this->should_broadcast_));
-  ESP_LOGCONFIG(TAG, "  Listening: %s", YESNO(this->should_listen_));
+  ESP_LOGCONFIG(TAG, "  Broadcasting: %s\n  Listening: %s", YESNO(this->should_broadcast_),
+                YESNO(this->should_listen_));
 }
 
 void UDPComponent::send_packet(const uint8_t *data, size_t size) {

--- a/esphome/components/udp/udp_component.cpp
+++ b/esphome/components/udp/udp_component.cpp
@@ -122,14 +122,20 @@ void UDPComponent::loop() {
 }
 
 void UDPComponent::dump_config() {
-  ESP_LOGCONFIG(TAG, "UDP:\n  Listen Port: %u\n  Broadcast Port: %u", this->listen_port_, this->broadcast_port_);
+  ESP_LOGCONFIG(TAG,
+                "UDP:\n"
+                "  Listen Port: %u\n"
+                "  Broadcast Port: %u",
+                this->listen_port_, this->broadcast_port_);
   for (const auto &address : this->addresses_)
     ESP_LOGCONFIG(TAG, "  Address: %s", address.c_str());
   if (this->listen_address_.has_value()) {
     ESP_LOGCONFIG(TAG, "  Listen address: %s", this->listen_address_.value().str().c_str());
   }
-  ESP_LOGCONFIG(TAG, "  Broadcasting: %s\n  Listening: %s", YESNO(this->should_broadcast_),
-                YESNO(this->should_listen_));
+  ESP_LOGCONFIG(TAG,
+                "  Broadcasting: %s\n"
+                "  Listening: %s",
+                YESNO(this->should_broadcast_), YESNO(this->should_listen_));
 }
 
 void UDPComponent::send_packet(const uint8_t *data, size_t size) {

--- a/esphome/components/ufire_ec/ufire_ec.cpp
+++ b/esphome/components/ufire_ec/ufire_ec.cpp
@@ -110,8 +110,10 @@ void UFireECComponent::dump_config() {
   LOG_SENSOR("  ", "EC Sensor", this->ec_sensor_)
   LOG_SENSOR("  ", "Temperature Sensor", this->temperature_sensor_)
   LOG_SENSOR("  ", "Temperature Sensor external", this->temperature_sensor_external_)
-  ESP_LOGCONFIG(TAG, "  Temperature Compensation: %f\n  Temperature Coefficient: %f", this->temperature_compensation_,
-                this->temperature_coefficient_);
+  ESP_LOGCONFIG(TAG,
+                "  Temperature Compensation: %f\n"
+                "  Temperature Coefficient: %f",
+                this->temperature_compensation_, this->temperature_coefficient_);
 }
 
 }  // namespace ufire_ec

--- a/esphome/components/ufire_ec/ufire_ec.cpp
+++ b/esphome/components/ufire_ec/ufire_ec.cpp
@@ -110,8 +110,8 @@ void UFireECComponent::dump_config() {
   LOG_SENSOR("  ", "EC Sensor", this->ec_sensor_)
   LOG_SENSOR("  ", "Temperature Sensor", this->temperature_sensor_)
   LOG_SENSOR("  ", "Temperature Sensor external", this->temperature_sensor_external_)
-  ESP_LOGCONFIG(TAG, "  Temperature Compensation: %f", this->temperature_compensation_);
-  ESP_LOGCONFIG(TAG, "  Temperature Coefficient: %f", this->temperature_coefficient_);
+  ESP_LOGCONFIG(TAG, "  Temperature Compensation: %f\n  Temperature Coefficient: %f", this->temperature_compensation_,
+                this->temperature_coefficient_);
 }
 
 }  // namespace ufire_ec

--- a/esphome/components/ultrasonic/ultrasonic_sensor.cpp
+++ b/esphome/components/ultrasonic/ultrasonic_sensor.cpp
@@ -45,8 +45,10 @@ void UltrasonicSensorComponent::dump_config() {
   LOG_SENSOR("", "Ultrasonic Sensor", this);
   LOG_PIN("  Echo Pin: ", this->echo_pin_);
   LOG_PIN("  Trigger Pin: ", this->trigger_pin_);
-  ESP_LOGCONFIG(TAG, "  Pulse time: %" PRIu32 " µs\n  Timeout: %" PRIu32 " µs", this->pulse_time_us_,
-                this->timeout_us_);
+  ESP_LOGCONFIG(TAG,
+                "  Pulse time: %" PRIu32 " µs\n"
+                "  Timeout: %" PRIu32 " µs",
+                this->pulse_time_us_, this->timeout_us_);
   LOG_UPDATE_INTERVAL(this);
 }
 float UltrasonicSensorComponent::us_to_m(uint32_t us) {

--- a/esphome/components/ultrasonic/ultrasonic_sensor.cpp
+++ b/esphome/components/ultrasonic/ultrasonic_sensor.cpp
@@ -45,8 +45,8 @@ void UltrasonicSensorComponent::dump_config() {
   LOG_SENSOR("", "Ultrasonic Sensor", this);
   LOG_PIN("  Echo Pin: ", this->echo_pin_);
   LOG_PIN("  Trigger Pin: ", this->trigger_pin_);
-  ESP_LOGCONFIG(TAG, "  Pulse time: %" PRIu32 " µs", this->pulse_time_us_);
-  ESP_LOGCONFIG(TAG, "  Timeout: %" PRIu32 " µs", this->timeout_us_);
+  ESP_LOGCONFIG(TAG, "  Pulse time: %" PRIu32 " µs\n  Timeout: %" PRIu32 " µs", this->pulse_time_us_,
+                this->timeout_us_);
   LOG_UPDATE_INTERVAL(this);
 }
 float UltrasonicSensorComponent::us_to_m(uint32_t us) {

--- a/esphome/components/uponor_smatrix/sensor/uponor_smatrix_sensor.cpp
+++ b/esphome/components/uponor_smatrix/sensor/uponor_smatrix_sensor.cpp
@@ -7,8 +7,7 @@ namespace uponor_smatrix {
 static const char *const TAG = "uponor_smatrix.sensor";
 
 void UponorSmatrixSensor::dump_config() {
-  ESP_LOGCONFIG(TAG, "Uponor Smatrix Sensor");
-  ESP_LOGCONFIG(TAG, "  Device address: 0x%04X", this->address_);
+  ESP_LOGCONFIG(TAG, "Uponor Smatrix Sensor\n  Device address: 0x%04X", this->address_);
   LOG_SENSOR("  ", "Temperature", this->temperature_sensor_);
   LOG_SENSOR("  ", "External Temperature", this->external_temperature_sensor_);
   LOG_SENSOR("  ", "Humidity", this->humidity_sensor_);

--- a/esphome/components/uponor_smatrix/sensor/uponor_smatrix_sensor.cpp
+++ b/esphome/components/uponor_smatrix/sensor/uponor_smatrix_sensor.cpp
@@ -7,7 +7,10 @@ namespace uponor_smatrix {
 static const char *const TAG = "uponor_smatrix.sensor";
 
 void UponorSmatrixSensor::dump_config() {
-  ESP_LOGCONFIG(TAG, "Uponor Smatrix Sensor\n  Device address: 0x%04X", this->address_);
+  ESP_LOGCONFIG(TAG,
+                "Uponor Smatrix Sensor\n"
+                "  Device address: 0x%04X",
+                this->address_);
   LOG_SENSOR("  ", "Temperature", this->temperature_sensor_);
   LOG_SENSOR("  ", "External Temperature", this->external_temperature_sensor_);
   LOG_SENSOR("  ", "Humidity", this->humidity_sensor_);

--- a/esphome/components/usb_host/usb_host_client.cpp
+++ b/esphome/components/usb_host/usb_host_client.cpp
@@ -381,9 +381,7 @@ void USBClient::transfer_out(uint8_t ep_address, const transfer_cb_t &callback, 
   }
 }
 void USBClient::dump_config() {
-  ESP_LOGCONFIG(TAG, "USBClient");
-  ESP_LOGCONFIG(TAG, "  Vendor id %04X", this->vid_);
-  ESP_LOGCONFIG(TAG, "  Product id %04X", this->pid_);
+  ESP_LOGCONFIG(TAG, "USBClient\n  Vendor id %04X\n  Product id %04X", this->vid_, this->pid_);
 }
 void USBClient::release_trq(TransferRequest *trq) { this->trq_pool_.push_back(trq); }
 

--- a/esphome/components/usb_host/usb_host_client.cpp
+++ b/esphome/components/usb_host/usb_host_client.cpp
@@ -381,7 +381,11 @@ void USBClient::transfer_out(uint8_t ep_address, const transfer_cb_t &callback, 
   }
 }
 void USBClient::dump_config() {
-  ESP_LOGCONFIG(TAG, "USBClient\n  Vendor id %04X\n  Product id %04X", this->vid_, this->pid_);
+  ESP_LOGCONFIG(TAG,
+                "USBClient\n"
+                "  Vendor id %04X\n"
+                "  Product id %04X",
+                this->vid_, this->pid_);
 }
 void USBClient::release_trq(TransferRequest *trq) { this->trq_pool_.push_back(trq); }
 

--- a/esphome/components/usb_uart/usb_uart.cpp
+++ b/esphome/components/usb_uart/usb_uart.cpp
@@ -178,13 +178,16 @@ void USBUartComponent::loop() { USBClient::loop(); }
 void USBUartComponent::dump_config() {
   USBClient::dump_config();
   for (auto &channel : this->channels_) {
-    ESP_LOGCONFIG(TAG, "  UART Channel %d", channel->index_);
-    ESP_LOGCONFIG(TAG, "    Baud Rate: %" PRIu32 " baud", channel->baud_rate_);
-    ESP_LOGCONFIG(TAG, "    Data Bits: %u", channel->data_bits_);
-    ESP_LOGCONFIG(TAG, "    Parity: %s", PARITY_NAMES[channel->parity_]);
-    ESP_LOGCONFIG(TAG, "    Stop bits: %s", STOP_BITS_NAMES[channel->stop_bits_]);
-    ESP_LOGCONFIG(TAG, "    Debug: %s", YESNO(channel->debug_));
-    ESP_LOGCONFIG(TAG, "    Dummy receiver: %s", YESNO(channel->dummy_receiver_));
+    ESP_LOGCONFIG(TAG,
+                  "  UART Channel %d\n"
+                  "    Baud Rate: %" PRIu32 " baud\n"
+                  "    Data Bits: %u\n"
+                  "    Parity: %s\n"
+                  "    Stop bits: %s\n"
+                  "    Debug: %s\n"
+                  "    Dummy receiver: %s",
+                  channel->index_, channel->baud_rate_, channel->data_bits_, PARITY_NAMES[channel->parity_],
+                  STOP_BITS_NAMES[channel->stop_bits_], YESNO(channel->debug_), YESNO(channel->dummy_receiver_));
   }
 }
 void USBUartComponent::start_input(USBUartChannel *channel) {

--- a/esphome/components/veml3235/veml3235.cpp
+++ b/esphome/components/veml3235/veml3235.cpp
@@ -217,13 +217,12 @@ void VEML3235Sensor::dump_config() {
   LOG_UPDATE_INTERVAL(this);
   ESP_LOGCONFIG(TAG, "  Auto-gain enabled: %s", YESNO(this->auto_gain_));
   if (this->auto_gain_) {
-    ESP_LOGCONFIG(TAG, "  Auto-gain upper threshold: %f%%", this->auto_gain_threshold_high_ * 100.0);
-    ESP_LOGCONFIG(TAG, "  Auto-gain lower threshold: %f%%", this->auto_gain_threshold_low_ * 100.0);
+    ESP_LOGCONFIG(TAG, "  Auto-gain upper threshold: %f%%\n  Auto-gain lower threshold: %f%%",
+                  this->auto_gain_threshold_high_ * 100.0, this->auto_gain_threshold_low_ * 100.0);
     ESP_LOGCONFIG(TAG, "  Values below will be used as initial values only");
   }
-  ESP_LOGCONFIG(TAG, "  Digital gain: %uX", digital_gain);
-  ESP_LOGCONFIG(TAG, "  Gain: %uX", gain);
-  ESP_LOGCONFIG(TAG, "  Integration time: %ums", integration_time);
+  ESP_LOGCONFIG(TAG, "  Digital gain: %uX\n  Gain: %uX\n  Integration time: %ums", digital_gain, gain,
+                integration_time);
 }
 
 }  // namespace veml3235

--- a/esphome/components/veml3235/veml3235.cpp
+++ b/esphome/components/veml3235/veml3235.cpp
@@ -222,8 +222,11 @@ void VEML3235Sensor::dump_config() {
                   "as initial values only",
                   this->auto_gain_threshold_high_ * 100.0, this->auto_gain_threshold_low_ * 100.0);
   }
-  ESP_LOGCONFIG(TAG, "  Digital gain: %uX\n  Gain: %uX\n  Integration time: %ums", digital_gain, gain,
-                integration_time);
+  ESP_LOGCONFIG(TAG,
+                "  Digital gain: %uX\n"
+                "  Gain: %uX\n"
+                "  Integration time: %ums",
+                digital_gain, gain, integration_time);
 }
 
 }  // namespace veml3235

--- a/esphome/components/veml3235/veml3235.cpp
+++ b/esphome/components/veml3235/veml3235.cpp
@@ -217,9 +217,10 @@ void VEML3235Sensor::dump_config() {
   LOG_UPDATE_INTERVAL(this);
   ESP_LOGCONFIG(TAG, "  Auto-gain enabled: %s", YESNO(this->auto_gain_));
   if (this->auto_gain_) {
-    ESP_LOGCONFIG(TAG, "  Auto-gain upper threshold: %f%%\n  Auto-gain lower threshold: %f%%",
+    ESP_LOGCONFIG(TAG,
+                  "  Auto-gain upper threshold: %f%%\n  Auto-gain lower threshold: %f%%\n  Values below will be used "
+                  "as initial values only",
                   this->auto_gain_threshold_high_ * 100.0, this->auto_gain_threshold_low_ * 100.0);
-    ESP_LOGCONFIG(TAG, "  Values below will be used as initial values only");
   }
   ESP_LOGCONFIG(TAG, "  Digital gain: %uX\n  Gain: %uX\n  Integration time: %ums", digital_gain, gain,
                 integration_time);

--- a/esphome/components/veml3235/veml3235.cpp
+++ b/esphome/components/veml3235/veml3235.cpp
@@ -218,8 +218,9 @@ void VEML3235Sensor::dump_config() {
   ESP_LOGCONFIG(TAG, "  Auto-gain enabled: %s", YESNO(this->auto_gain_));
   if (this->auto_gain_) {
     ESP_LOGCONFIG(TAG,
-                  "  Auto-gain upper threshold: %f%%\n  Auto-gain lower threshold: %f%%\n  Values below will be used "
-                  "as initial values only",
+                  "  Auto-gain upper threshold: %f%%\n"
+                  "  Auto-gain lower threshold: %f%%\n"
+                  "  Values below will be used as initial values only",
                   this->auto_gain_threshold_high_ * 100.0, this->auto_gain_threshold_low_ * 100.0);
   }
   ESP_LOGCONFIG(TAG,

--- a/esphome/components/veml7700/veml7700.cpp
+++ b/esphome/components/veml7700/veml7700.cpp
@@ -93,11 +93,11 @@ void VEML7700Component::dump_config() {
   LOG_I2C_DEVICE(this);
   ESP_LOGCONFIG(TAG, "  Automatic gain/time: %s", YESNO(this->automatic_mode_enabled_));
   if (!this->automatic_mode_enabled_) {
-    ESP_LOGCONFIG(TAG, "  Gain: %s", get_gain_str(this->gain_));
-    ESP_LOGCONFIG(TAG, "  Integration time: %d ms", get_itime_ms(this->integration_time_));
+    ESP_LOGCONFIG(TAG, "  Gain: %s\n  Integration time: %d ms", get_gain_str(this->gain_),
+                  get_itime_ms(this->integration_time_));
   }
-  ESP_LOGCONFIG(TAG, "  Lux compensation: %s", YESNO(this->lux_compensation_enabled_));
-  ESP_LOGCONFIG(TAG, "  Glass attenuation factor: %f", this->glass_attenuation_factor_);
+  ESP_LOGCONFIG(TAG, "  Lux compensation: %s\n  Glass attenuation factor: %f", YESNO(this->lux_compensation_enabled_),
+                this->glass_attenuation_factor_);
   LOG_UPDATE_INTERVAL(this);
 
   LOG_SENSOR("  ", "ALS channel lux", this->ambient_light_sensor_);

--- a/esphome/components/veml7700/veml7700.cpp
+++ b/esphome/components/veml7700/veml7700.cpp
@@ -93,11 +93,15 @@ void VEML7700Component::dump_config() {
   LOG_I2C_DEVICE(this);
   ESP_LOGCONFIG(TAG, "  Automatic gain/time: %s", YESNO(this->automatic_mode_enabled_));
   if (!this->automatic_mode_enabled_) {
-    ESP_LOGCONFIG(TAG, "  Gain: %s\n  Integration time: %d ms", get_gain_str(this->gain_),
-                  get_itime_ms(this->integration_time_));
+    ESP_LOGCONFIG(TAG,
+                  "  Gain: %s\n"
+                  "  Integration time: %d ms",
+                  get_gain_str(this->gain_), get_itime_ms(this->integration_time_));
   }
-  ESP_LOGCONFIG(TAG, "  Lux compensation: %s\n  Glass attenuation factor: %f", YESNO(this->lux_compensation_enabled_),
-                this->glass_attenuation_factor_);
+  ESP_LOGCONFIG(TAG,
+                "  Lux compensation: %s\n"
+                "  Glass attenuation factor: %f",
+                YESNO(this->lux_compensation_enabled_), this->glass_attenuation_factor_);
   LOG_UPDATE_INTERVAL(this);
 
   LOG_SENSOR("  ", "ALS channel lux", this->ambient_light_sensor_);

--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -282,8 +282,7 @@ void WebServer::loop() {
   this->events_.loop();
 }
 void WebServer::dump_config() {
-  ESP_LOGCONFIG(TAG, "Web Server:");
-  ESP_LOGCONFIG(TAG, "  Address: %s:%u", network::get_use_address().c_str(), this->base_->get_port());
+  ESP_LOGCONFIG(TAG, "Web Server:\n  Address: %s:%u", network::get_use_address().c_str(), this->base_->get_port());
 }
 float WebServer::get_setup_priority() const { return setup_priority::WIFI - 1.0f; }
 

--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -282,7 +282,10 @@ void WebServer::loop() {
   this->events_.loop();
 }
 void WebServer::dump_config() {
-  ESP_LOGCONFIG(TAG, "Web Server:\n  Address: %s:%u", network::get_use_address().c_str(), this->base_->get_port());
+  ESP_LOGCONFIG(TAG,
+                "Web Server:\n"
+                "  Address: %s:%u",
+                network::get_use_address().c_str(), this->base_->get_port());
 }
 float WebServer::get_setup_priority() const { return setup_priority::WIFI - 1.0f; }
 

--- a/esphome/components/weikai/weikai.cpp
+++ b/esphome/components/weikai/weikai.cpp
@@ -267,11 +267,8 @@ void WeikaiChannel::setup_channel() {
 }
 
 void WeikaiChannel::dump_channel() {
-  ESP_LOGCONFIG(TAG, "  UART %s", this->get_channel_name());
-  ESP_LOGCONFIG(TAG, "    Baud rate: %" PRIu32 " Bd", this->baud_rate_);
-  ESP_LOGCONFIG(TAG, "    Data bits: %u", this->data_bits_);
-  ESP_LOGCONFIG(TAG, "    Stop bits: %u", this->stop_bits_);
-  ESP_LOGCONFIG(TAG, "    Parity: %s", p2s(this->parity_));
+  ESP_LOGCONFIG(TAG, "  UART %s\n    Baud rate: %" PRIu32 " Bd\n    Data bits: %u\n    Stop bits: %u\n    Parity: %s",
+                this->get_channel_name(), this->baud_rate_, this->data_bits_, this->stop_bits_, p2s(this->parity_));
 }
 
 void WeikaiChannel::reset_fifo_() {

--- a/esphome/components/weikai/weikai.cpp
+++ b/esphome/components/weikai/weikai.cpp
@@ -267,7 +267,12 @@ void WeikaiChannel::setup_channel() {
 }
 
 void WeikaiChannel::dump_channel() {
-  ESP_LOGCONFIG(TAG, "  UART %s\n    Baud rate: %" PRIu32 " Bd\n    Data bits: %u\n    Stop bits: %u\n    Parity: %s",
+  ESP_LOGCONFIG(TAG,
+                "  UART %s\n"
+                "    Baud rate: %" PRIu32 " Bd\n"
+                "    Data bits: %u\n"
+                "    Stop bits: %u\n"
+                "    Parity: %s",
                 this->get_channel_name(), this->baud_rate_, this->data_bits_, this->stop_bits_, p2s(this->parity_));
 }
 

--- a/esphome/components/weikai_i2c/weikai_i2c.cpp
+++ b/esphome/components/weikai_i2c/weikai_i2c.cpp
@@ -160,8 +160,10 @@ void WeikaiComponentI2C::setup() {
 }
 
 void WeikaiComponentI2C::dump_config() {
-  ESP_LOGCONFIG(TAG, "Initialization of %s with %d UARTs completed\n  Crystal: %" PRIu32, this->get_name(),
-                this->children_.size(), this->crystal_);
+  ESP_LOGCONFIG(TAG,
+                "Initialization of %s with %d UARTs completed\n"
+                "  Crystal: %" PRIu32,
+                this->get_name(), this->children_.size(), this->crystal_);
   if (test_mode_)
     ESP_LOGCONFIG(TAG,
                   "  Test mode: %d\n"

--- a/esphome/components/weikai_i2c/weikai_i2c.cpp
+++ b/esphome/components/weikai_i2c/weikai_i2c.cpp
@@ -163,7 +163,10 @@ void WeikaiComponentI2C::dump_config() {
   ESP_LOGCONFIG(TAG, "Initialization of %s with %d UARTs completed\n  Crystal: %" PRIu32, this->get_name(),
                 this->children_.size(), this->crystal_);
   if (test_mode_)
-    ESP_LOGCONFIG(TAG, "  Test mode: %d\n  Transfer buffer size: %d", test_mode_, XFER_MAX_SIZE);
+    ESP_LOGCONFIG(TAG,
+                  "  Test mode: %d\n"
+                  "  Transfer buffer size: %d",
+                  test_mode_, XFER_MAX_SIZE);
   this->address_ = this->base_address_;  // we restore the base_address before display (less confusing)
   LOG_I2C_DEVICE(this);
 

--- a/esphome/components/weikai_i2c/weikai_i2c.cpp
+++ b/esphome/components/weikai_i2c/weikai_i2c.cpp
@@ -164,11 +164,12 @@ void WeikaiComponentI2C::dump_config() {
                 "Initialization of %s with %d UARTs completed\n"
                 "  Crystal: %" PRIu32,
                 this->get_name(), this->children_.size(), this->crystal_);
-  if (test_mode_)
+  if (test_mode_) {
     ESP_LOGCONFIG(TAG,
                   "  Test mode: %d\n"
                   "  Transfer buffer size: %d",
                   test_mode_, XFER_MAX_SIZE);
+  }
   this->address_ = this->base_address_;  // we restore the base_address before display (less confusing)
   LOG_I2C_DEVICE(this);
 

--- a/esphome/components/weikai_i2c/weikai_i2c.cpp
+++ b/esphome/components/weikai_i2c/weikai_i2c.cpp
@@ -160,11 +160,10 @@ void WeikaiComponentI2C::setup() {
 }
 
 void WeikaiComponentI2C::dump_config() {
-  ESP_LOGCONFIG(TAG, "Initialization of %s with %d UARTs completed", this->get_name(), this->children_.size());
-  ESP_LOGCONFIG(TAG, "  Crystal: %" PRIu32, this->crystal_);
+  ESP_LOGCONFIG(TAG, "Initialization of %s with %d UARTs completed\n  Crystal: %" PRIu32, this->get_name(),
+                this->children_.size(), this->crystal_);
   if (test_mode_)
-    ESP_LOGCONFIG(TAG, "  Test mode: %d", test_mode_);
-  ESP_LOGCONFIG(TAG, "  Transfer buffer size: %d", XFER_MAX_SIZE);
+    ESP_LOGCONFIG(TAG, "  Test mode: %d\n  Transfer buffer size: %d", test_mode_, XFER_MAX_SIZE);
   this->address_ = this->base_address_;  // we restore the base_address before display (less confusing)
   LOG_I2C_DEVICE(this);
 

--- a/esphome/components/weikai_spi/weikai_spi.cpp
+++ b/esphome/components/weikai_spi/weikai_spi.cpp
@@ -173,8 +173,10 @@ void WeikaiComponentSPI::setup() {
 }
 
 void WeikaiComponentSPI::dump_config() {
-  ESP_LOGCONFIG(TAG, "Initialization of %s with %d UARTs completed\n  Crystal: %" PRIu32 "", this->get_name(),
-                this->children_.size(), this->crystal_);
+  ESP_LOGCONFIG(TAG,
+                "Initialization of %s with %d UARTs completed\n"
+                "  Crystal: %" PRIu32,
+                this->get_name(), this->children_.size(), this->crystal_);
   if (test_mode_)
     ESP_LOGCONFIG(TAG,
                   "  Test mode: %d\n"

--- a/esphome/components/weikai_spi/weikai_spi.cpp
+++ b/esphome/components/weikai_spi/weikai_spi.cpp
@@ -176,7 +176,10 @@ void WeikaiComponentSPI::dump_config() {
   ESP_LOGCONFIG(TAG, "Initialization of %s with %d UARTs completed\n  Crystal: %" PRIu32 "", this->get_name(),
                 this->children_.size(), this->crystal_);
   if (test_mode_)
-    ESP_LOGCONFIG(TAG, "  Test mode: %d\n  Transfer buffer size: %d", test_mode_, XFER_MAX_SIZE);
+    ESP_LOGCONFIG(TAG,
+                  "  Test mode: %d\n"
+                  "  Transfer buffer size: %d",
+                  test_mode_, XFER_MAX_SIZE);
   LOG_PIN("  CS Pin: ", this->cs_);
 
   for (auto *child : this->children_) {

--- a/esphome/components/weikai_spi/weikai_spi.cpp
+++ b/esphome/components/weikai_spi/weikai_spi.cpp
@@ -177,11 +177,12 @@ void WeikaiComponentSPI::dump_config() {
                 "Initialization of %s with %d UARTs completed\n"
                 "  Crystal: %" PRIu32,
                 this->get_name(), this->children_.size(), this->crystal_);
-  if (test_mode_)
+  if (test_mode_) {
     ESP_LOGCONFIG(TAG,
                   "  Test mode: %d\n"
                   "  Transfer buffer size: %d",
                   test_mode_, XFER_MAX_SIZE);
+  }
   LOG_PIN("  CS Pin: ", this->cs_);
 
   for (auto *child : this->children_) {

--- a/esphome/components/weikai_spi/weikai_spi.cpp
+++ b/esphome/components/weikai_spi/weikai_spi.cpp
@@ -173,11 +173,10 @@ void WeikaiComponentSPI::setup() {
 }
 
 void WeikaiComponentSPI::dump_config() {
-  ESP_LOGCONFIG(TAG, "Initialization of %s with %d UARTs completed", this->get_name(), this->children_.size());
-  ESP_LOGCONFIG(TAG, "  Crystal: %" PRIu32 "", this->crystal_);
+  ESP_LOGCONFIG(TAG, "Initialization of %s with %d UARTs completed\n  Crystal: %" PRIu32 "", this->get_name(),
+                this->children_.size(), this->crystal_);
   if (test_mode_)
-    ESP_LOGCONFIG(TAG, "  Test mode: %d", test_mode_);
-  ESP_LOGCONFIG(TAG, "  Transfer buffer size: %d", XFER_MAX_SIZE);
+    ESP_LOGCONFIG(TAG, "  Test mode: %d\n  Transfer buffer size: %d", test_mode_, XFER_MAX_SIZE);
   LOG_PIN("  CS Pin: ", this->cs_);
 
   for (auto *child : this->children_) {

--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -58,7 +58,10 @@ void WiFiComponent::setup() {
 }
 
 void WiFiComponent::start() {
-  ESP_LOGCONFIG(TAG, "Starting\n  Local MAC: %s", get_mac_address_pretty().c_str());
+  ESP_LOGCONFIG(TAG,
+                "Starting\n"
+                "  Local MAC: %s",
+                get_mac_address_pretty().c_str());
   this->last_connected_ = millis();
 
   uint32_t hash = this->has_sta() ? fnv1_hash(App.get_compilation_time()) : 88491487UL;
@@ -261,8 +264,10 @@ void WiFiComponent::setup_ap_config_() {
 
   ESP_LOGCONFIG(TAG, "Setting up AP");
 
-  ESP_LOGCONFIG(TAG, "  AP SSID: '%s'\n  AP Password: '%s'", this->ap_.get_ssid().c_str(),
-                this->ap_.get_password().c_str());
+  ESP_LOGCONFIG(TAG,
+                "  AP SSID: '%s'\n"
+                "  AP Password: '%s'",
+                this->ap_.get_ssid().c_str(), this->ap_.get_password().c_str());
   if (this->ap_.get_manual_ip().has_value()) {
     auto manual = *this->ap_.get_manual_ip();
     ESP_LOGCONFIG(TAG,

--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -58,8 +58,7 @@ void WiFiComponent::setup() {
 }
 
 void WiFiComponent::start() {
-  ESP_LOGCONFIG(TAG, "Starting");
-  ESP_LOGCONFIG(TAG, "  Local MAC: %s", get_mac_address_pretty().c_str());
+  ESP_LOGCONFIG(TAG, "Starting\n  Local MAC: %s", get_mac_address_pretty().c_str());
   this->last_connected_ = millis();
 
   uint32_t hash = this->has_sta() ? fnv1_hash(App.get_compilation_time()) : 88491487UL;
@@ -262,13 +261,15 @@ void WiFiComponent::setup_ap_config_() {
 
   ESP_LOGCONFIG(TAG, "Setting up AP");
 
-  ESP_LOGCONFIG(TAG, "  AP SSID: '%s'", this->ap_.get_ssid().c_str());
-  ESP_LOGCONFIG(TAG, "  AP Password: '%s'", this->ap_.get_password().c_str());
+  ESP_LOGCONFIG(TAG, "  AP SSID: '%s'\n  AP Password: '%s'", this->ap_.get_ssid().c_str(),
+                this->ap_.get_password().c_str());
   if (this->ap_.get_manual_ip().has_value()) {
     auto manual = *this->ap_.get_manual_ip();
-    ESP_LOGCONFIG(TAG, "  AP Static IP: '%s'", manual.static_ip.str().c_str());
-    ESP_LOGCONFIG(TAG, "  AP Gateway: '%s'", manual.gateway.str().c_str());
-    ESP_LOGCONFIG(TAG, "  AP Subnet: '%s'", manual.subnet.str().c_str());
+    ESP_LOGCONFIG(TAG,
+                  "  AP Static IP: '%s'\n"
+                  "  AP Gateway: '%s'\n"
+                  "  AP Subnet: '%s'",
+                  manual.static_ip.str().c_str(), manual.gateway.str().c_str(), manual.subnet.str().c_str());
   }
 
   this->ap_setup_ = this->wifi_start_ap_(this->ap_);
@@ -436,22 +437,29 @@ void WiFiComponent::print_connect_params_() {
       ESP_LOGCONFIG(TAG, "  IP Address: %s", ip.str().c_str());
     }
   }
-  ESP_LOGCONFIG(TAG, "  BSSID: " LOG_SECRET("%02X:%02X:%02X:%02X:%02X:%02X"), bssid[0], bssid[1], bssid[2], bssid[3],
-                bssid[4], bssid[5]);
-  ESP_LOGCONFIG(TAG, "  Hostname: '%s'", App.get_name().c_str());
   int8_t rssi = wifi_rssi();
-  ESP_LOGCONFIG(TAG, "  Signal strength: %d dB %s", rssi, LOG_STR_ARG(get_signal_bars(rssi)));
+  ESP_LOGCONFIG(TAG,
+                "  BSSID: " LOG_SECRET("%02X:%02X:%02X:%02X:%02X:%02X") "\n"
+                                                                        "  Hostname: '%s'\n"
+                                                                        "  Signal strength: %d dB %s",
+                bssid[0], bssid[1], bssid[2], bssid[3], bssid[4], bssid[5], App.get_name().c_str(), rssi,
+                LOG_STR_ARG(get_signal_bars(rssi)));
   if (this->selected_ap_.get_bssid().has_value()) {
     ESP_LOGV(TAG, "  Priority: %.1f", this->get_sta_priority(*this->selected_ap_.get_bssid()));
   }
-  ESP_LOGCONFIG(TAG, "  Channel: %" PRId32, get_wifi_channel());
-  ESP_LOGCONFIG(TAG, "  Subnet: %s", wifi_subnet_mask_().str().c_str());
-  ESP_LOGCONFIG(TAG, "  Gateway: %s", wifi_gateway_ip_().str().c_str());
-  ESP_LOGCONFIG(TAG, "  DNS1: %s", wifi_dns_ip_(0).str().c_str());
-  ESP_LOGCONFIG(TAG, "  DNS2: %s", wifi_dns_ip_(1).str().c_str());
+  ESP_LOGCONFIG(TAG,
+                "  Channel: %" PRId32 "\n"
+                "  Subnet: %s\n"
+                "  Gateway: %s\n"
+                "  DNS1: %s\n"
+                "  DNS2: %s",
+                get_wifi_channel(), wifi_subnet_mask_().str().c_str(), wifi_gateway_ip_().str().c_str(),
+                wifi_dns_ip_(0).str().c_str(), wifi_dns_ip_(1).str().c_str());
 #ifdef USE_WIFI_11KV_SUPPORT
-  ESP_LOGCONFIG(TAG, "  BTM: %s", this->btm_ ? "enabled" : "disabled");
-  ESP_LOGCONFIG(TAG, "  RRM: %s", this->rrm_ ? "enabled" : "disabled");
+  ESP_LOGCONFIG(TAG,
+                "  BTM: %s\n"
+                "  RRM: %s",
+                this->btm_ ? "enabled" : "disabled", this->rrm_ ? "enabled" : "disabled");
 #endif
 }
 

--- a/esphome/components/wireguard/wireguard.cpp
+++ b/esphome/components/wireguard/wireguard.cpp
@@ -130,32 +130,24 @@ void Wireguard::update() {
 
 void Wireguard::dump_config() {
   ESP_LOGCONFIG(TAG, "WireGuard:");
-  ESP_LOGCONFIG(
-      TAG,
-      "  Address: %s\n"
-      "  Netmask: %s\n"
-      "  Private Key: " LOG_SECRET("%s") "\n"
-                                         "  Peer Endpoint: " LOG_SECRET(
-                                             "%s") "\n"
-                                                   "  Peer Port: " LOG_SECRET(
-                                                       "%d") "\n"
-                                                             "  Peer Public Key: " LOG_SECRET(
-                                                                 "%s") "\n"
-                                                                       "  Peer Pre-shared Key: " LOG_SECRET("%s"),
-      this->address_.c_str(), this->netmask_.c_str(), mask_key(this->private_key_).c_str(),
-      this->peer_endpoint_.c_str(), this->peer_port_, this->peer_public_key_.c_str(),
-      (!this->preshared_key_.empty() ? mask_key(this->preshared_key_).c_str() : "NOT IN USE"));
+  ESP_LOGCONFIG(TAG, "  Address: %s", this->address_.c_str());
+  ESP_LOGCONFIG(TAG, "  Netmask: %s", this->netmask_.c_str());
+  ESP_LOGCONFIG(TAG, "  Private Key: " LOG_SECRET("%s"), mask_key(this->private_key_).c_str());
+  ESP_LOGCONFIG(TAG, "  Peer Endpoint: " LOG_SECRET("%s"), this->peer_endpoint_.c_str());
+  ESP_LOGCONFIG(TAG, "  Peer Port: " LOG_SECRET("%d"), this->peer_port_);
+  ESP_LOGCONFIG(TAG, "  Peer Public Key: " LOG_SECRET("%s"), this->peer_public_key_.c_str());
+  ESP_LOGCONFIG(TAG, "  Peer Pre-shared Key: " LOG_SECRET("%s"),
+                (!this->preshared_key_.empty() ? mask_key(this->preshared_key_).c_str() : "NOT IN USE"));
   ESP_LOGCONFIG(TAG, "  Peer Allowed IPs:");
   for (auto &allowed_ip : this->allowed_ips_) {
     ESP_LOGCONFIG(TAG, "    - %s/%s", std::get<0>(allowed_ip).c_str(), std::get<1>(allowed_ip).c_str());
   }
+  ESP_LOGCONFIG(TAG, "  Peer Persistent Keepalive: %d%s", this->keepalive_,
+                (this->keepalive_ > 0 ? "s" : " (DISABLED)"));
+  ESP_LOGCONFIG(TAG, "  Reboot Timeout: %" PRIu32 "%s", (this->reboot_timeout_ / 1000),
+                (this->reboot_timeout_ != 0 ? "s" : " (DISABLED)"));
   // be careful: if proceed_allowed_ is true, require connection is false
-  ESP_LOGCONFIG(TAG,
-                "  Peer Persistent Keepalive: %d%s\n"
-                "  Reboot Timeout: %" PRIu32 "%s\n"
-                "  Require Connection to Proceed: %s",
-                this->keepalive_, (this->keepalive_ > 0 ? "s" : " (DISABLED)"), (this->reboot_timeout_ / 1000),
-                (this->reboot_timeout_ != 0 ? "s" : " (DISABLED)"), (this->proceed_allowed_ ? "NO" : "YES"));
+  ESP_LOGCONFIG(TAG, "  Require Connection to Proceed: %s", (this->proceed_allowed_ ? "NO" : "YES"));
   LOG_UPDATE_INTERVAL(this);
 }
 

--- a/esphome/components/wireguard/wireguard.cpp
+++ b/esphome/components/wireguard/wireguard.cpp
@@ -130,24 +130,32 @@ void Wireguard::update() {
 
 void Wireguard::dump_config() {
   ESP_LOGCONFIG(TAG, "WireGuard:");
-  ESP_LOGCONFIG(TAG, "  Address: %s", this->address_.c_str());
-  ESP_LOGCONFIG(TAG, "  Netmask: %s", this->netmask_.c_str());
-  ESP_LOGCONFIG(TAG, "  Private Key: " LOG_SECRET("%s"), mask_key(this->private_key_).c_str());
-  ESP_LOGCONFIG(TAG, "  Peer Endpoint: " LOG_SECRET("%s"), this->peer_endpoint_.c_str());
-  ESP_LOGCONFIG(TAG, "  Peer Port: " LOG_SECRET("%d"), this->peer_port_);
-  ESP_LOGCONFIG(TAG, "  Peer Public Key: " LOG_SECRET("%s"), this->peer_public_key_.c_str());
-  ESP_LOGCONFIG(TAG, "  Peer Pre-shared Key: " LOG_SECRET("%s"),
-                (!this->preshared_key_.empty() ? mask_key(this->preshared_key_).c_str() : "NOT IN USE"));
+  ESP_LOGCONFIG(
+      TAG,
+      "  Address: %s\n"
+      "  Netmask: %s\n"
+      "  Private Key: " LOG_SECRET("%s") "\n"
+                                         "  Peer Endpoint: " LOG_SECRET(
+                                             "%s") "\n"
+                                                   "  Peer Port: " LOG_SECRET(
+                                                       "%d") "\n"
+                                                             "  Peer Public Key: " LOG_SECRET(
+                                                                 "%s") "\n"
+                                                                       "  Peer Pre-shared Key: " LOG_SECRET("%s"),
+      this->address_.c_str(), this->netmask_.c_str(), mask_key(this->private_key_).c_str(),
+      this->peer_endpoint_.c_str(), this->peer_port_, this->peer_public_key_.c_str(),
+      (!this->preshared_key_.empty() ? mask_key(this->preshared_key_).c_str() : "NOT IN USE"));
   ESP_LOGCONFIG(TAG, "  Peer Allowed IPs:");
   for (auto &allowed_ip : this->allowed_ips_) {
     ESP_LOGCONFIG(TAG, "    - %s/%s", std::get<0>(allowed_ip).c_str(), std::get<1>(allowed_ip).c_str());
   }
-  ESP_LOGCONFIG(TAG, "  Peer Persistent Keepalive: %d%s", this->keepalive_,
-                (this->keepalive_ > 0 ? "s" : " (DISABLED)"));
-  ESP_LOGCONFIG(TAG, "  Reboot Timeout: %" PRIu32 "%s", (this->reboot_timeout_ / 1000),
-                (this->reboot_timeout_ != 0 ? "s" : " (DISABLED)"));
   // be careful: if proceed_allowed_ is true, require connection is false
-  ESP_LOGCONFIG(TAG, "  Require Connection to Proceed: %s", (this->proceed_allowed_ ? "NO" : "YES"));
+  ESP_LOGCONFIG(TAG,
+                "  Peer Persistent Keepalive: %d%s\n"
+                "  Reboot Timeout: %" PRIu32 "%s\n"
+                "  Require Connection to Proceed: %s",
+                this->keepalive_, (this->keepalive_ > 0 ? "s" : " (DISABLED)"), (this->reboot_timeout_ / 1000),
+                (this->reboot_timeout_ != 0 ? "s" : " (DISABLED)"), (this->proceed_allowed_ ? "NO" : "YES"));
   LOG_UPDATE_INTERVAL(this);
 }
 

--- a/esphome/components/x9c/x9c.cpp
+++ b/esphome/components/x9c/x9c.cpp
@@ -68,8 +68,7 @@ void X9cOutput::dump_config() {
   LOG_PIN("  Chip Select Pin: ", this->cs_pin_);
   LOG_PIN("  Increment Pin: ", this->inc_pin_);
   LOG_PIN("  Up/Down Pin: ", this->ud_pin_);
-  ESP_LOGCONFIG(TAG, "  Initial Value: %f", this->initial_value_);
-  ESP_LOGCONFIG(TAG, "  Step Delay: %d", this->step_delay_);
+  ESP_LOGCONFIG(TAG, "  Initial Value: %f\n  Step Delay: %d", this->initial_value_, this->step_delay_);
   LOG_FLOAT_OUTPUT(this);
 }
 

--- a/esphome/components/x9c/x9c.cpp
+++ b/esphome/components/x9c/x9c.cpp
@@ -68,7 +68,10 @@ void X9cOutput::dump_config() {
   LOG_PIN("  Chip Select Pin: ", this->cs_pin_);
   LOG_PIN("  Increment Pin: ", this->inc_pin_);
   LOG_PIN("  Up/Down Pin: ", this->ud_pin_);
-  ESP_LOGCONFIG(TAG, "  Initial Value: %f\n  Step Delay: %d", this->initial_value_, this->step_delay_);
+  ESP_LOGCONFIG(TAG,
+                "  Initial Value: %f\n"
+                "  Step Delay: %d",
+                this->initial_value_, this->step_delay_);
   LOG_FLOAT_OUTPUT(this);
 }
 

--- a/esphome/components/xgzp68xx/xgzp68xx.cpp
+++ b/esphome/components/xgzp68xx/xgzp68xx.cpp
@@ -74,7 +74,10 @@ void XGZP68XXComponent::setup() {
 
   // Display some sample bits to confirm we are talking to the sensor
   this->read_register(SYSCONFIG_ADDRESS, &config, 1);
-  ESP_LOGCONFIG(TAG, "Gain value is %d\nXGZP68xx started!", (config >> 3) & 0b111);
+  ESP_LOGCONFIG(TAG,
+                "Gain value is %d\n"
+                "XGZP68xx started!",
+                (config >> 3) & 0b111);
 }
 
 void XGZP68XXComponent::dump_config() {

--- a/esphome/components/xgzp68xx/xgzp68xx.cpp
+++ b/esphome/components/xgzp68xx/xgzp68xx.cpp
@@ -74,8 +74,7 @@ void XGZP68XXComponent::setup() {
 
   // Display some sample bits to confirm we are talking to the sensor
   this->read_register(SYSCONFIG_ADDRESS, &config, 1);
-  ESP_LOGCONFIG(TAG, "Gain value is %d", (config >> 3) & 0b111);
-  ESP_LOGCONFIG(TAG, "XGZP68xx started!");
+  ESP_LOGCONFIG(TAG, "Gain value is %d\nXGZP68xx started!", (config >> 3) & 0b111);
 }
 
 void XGZP68XXComponent::dump_config() {

--- a/esphome/components/xiaomi_cgd1/xiaomi_cgd1.cpp
+++ b/esphome/components/xiaomi_cgd1/xiaomi_cgd1.cpp
@@ -9,7 +9,10 @@ namespace xiaomi_cgd1 {
 static const char *const TAG = "xiaomi_cgd1";
 
 void XiaomiCGD1::dump_config() {
-  ESP_LOGCONFIG(TAG, "Xiaomi CGD1\n  Bindkey: %s", format_hex_pretty(this->bindkey_, 16).c_str());
+  ESP_LOGCONFIG(TAG,
+                "Xiaomi CGD1\n"
+                "  Bindkey: %s",
+                format_hex_pretty(this->bindkey_, 16).c_str());
   LOG_SENSOR("  ", "Temperature", this->temperature_);
   LOG_SENSOR("  ", "Humidity", this->humidity_);
   LOG_SENSOR("  ", "Battery Level", this->battery_level_);

--- a/esphome/components/xiaomi_cgd1/xiaomi_cgd1.cpp
+++ b/esphome/components/xiaomi_cgd1/xiaomi_cgd1.cpp
@@ -9,8 +9,7 @@ namespace xiaomi_cgd1 {
 static const char *const TAG = "xiaomi_cgd1";
 
 void XiaomiCGD1::dump_config() {
-  ESP_LOGCONFIG(TAG, "Xiaomi CGD1");
-  ESP_LOGCONFIG(TAG, "  Bindkey: %s", format_hex_pretty(this->bindkey_, 16).c_str());
+  ESP_LOGCONFIG(TAG, "Xiaomi CGD1\n  Bindkey: %s", format_hex_pretty(this->bindkey_, 16).c_str());
   LOG_SENSOR("  ", "Temperature", this->temperature_);
   LOG_SENSOR("  ", "Humidity", this->humidity_);
   LOG_SENSOR("  ", "Battery Level", this->battery_level_);

--- a/esphome/components/xiaomi_cgdk2/xiaomi_cgdk2.cpp
+++ b/esphome/components/xiaomi_cgdk2/xiaomi_cgdk2.cpp
@@ -9,8 +9,7 @@ namespace xiaomi_cgdk2 {
 static const char *const TAG = "xiaomi_cgdk2";
 
 void XiaomiCGDK2::dump_config() {
-  ESP_LOGCONFIG(TAG, "Xiaomi CGDK2");
-  ESP_LOGCONFIG(TAG, "  Bindkey: %s", format_hex_pretty(this->bindkey_, 16).c_str());
+  ESP_LOGCONFIG(TAG, "Xiaomi CGDK2\n  Bindkey: %s", format_hex_pretty(this->bindkey_, 16).c_str());
   LOG_SENSOR("  ", "Temperature", this->temperature_);
   LOG_SENSOR("  ", "Humidity", this->humidity_);
   LOG_SENSOR("  ", "Battery Level", this->battery_level_);

--- a/esphome/components/xiaomi_cgdk2/xiaomi_cgdk2.cpp
+++ b/esphome/components/xiaomi_cgdk2/xiaomi_cgdk2.cpp
@@ -9,7 +9,10 @@ namespace xiaomi_cgdk2 {
 static const char *const TAG = "xiaomi_cgdk2";
 
 void XiaomiCGDK2::dump_config() {
-  ESP_LOGCONFIG(TAG, "Xiaomi CGDK2\n  Bindkey: %s", format_hex_pretty(this->bindkey_, 16).c_str());
+  ESP_LOGCONFIG(TAG,
+                "Xiaomi CGDK2\n"
+                "  Bindkey: %s",
+                format_hex_pretty(this->bindkey_, 16).c_str());
   LOG_SENSOR("  ", "Temperature", this->temperature_);
   LOG_SENSOR("  ", "Humidity", this->humidity_);
   LOG_SENSOR("  ", "Battery Level", this->battery_level_);

--- a/esphome/components/xiaomi_cgg1/xiaomi_cgg1.cpp
+++ b/esphome/components/xiaomi_cgg1/xiaomi_cgg1.cpp
@@ -9,8 +9,7 @@ namespace xiaomi_cgg1 {
 static const char *const TAG = "xiaomi_cgg1";
 
 void XiaomiCGG1::dump_config() {
-  ESP_LOGCONFIG(TAG, "Xiaomi CGG1");
-  ESP_LOGCONFIG(TAG, "  Bindkey: %s", format_hex_pretty(this->bindkey_, 16).c_str());
+  ESP_LOGCONFIG(TAG, "Xiaomi CGG1\n  Bindkey: %s", format_hex_pretty(this->bindkey_, 16).c_str());
   LOG_SENSOR("  ", "Temperature", this->temperature_);
   LOG_SENSOR("  ", "Humidity", this->humidity_);
   LOG_SENSOR("  ", "Battery Level", this->battery_level_);

--- a/esphome/components/xiaomi_cgg1/xiaomi_cgg1.cpp
+++ b/esphome/components/xiaomi_cgg1/xiaomi_cgg1.cpp
@@ -9,7 +9,10 @@ namespace xiaomi_cgg1 {
 static const char *const TAG = "xiaomi_cgg1";
 
 void XiaomiCGG1::dump_config() {
-  ESP_LOGCONFIG(TAG, "Xiaomi CGG1\n  Bindkey: %s", format_hex_pretty(this->bindkey_, 16).c_str());
+  ESP_LOGCONFIG(TAG,
+                "Xiaomi CGG1\n"
+                "  Bindkey: %s",
+                format_hex_pretty(this->bindkey_, 16).c_str());
   LOG_SENSOR("  ", "Temperature", this->temperature_);
   LOG_SENSOR("  ", "Humidity", this->humidity_);
   LOG_SENSOR("  ", "Battery Level", this->battery_level_);

--- a/esphome/components/xiaomi_lywsd02mmc/xiaomi_lywsd02mmc.cpp
+++ b/esphome/components/xiaomi_lywsd02mmc/xiaomi_lywsd02mmc.cpp
@@ -9,8 +9,7 @@ namespace xiaomi_lywsd02mmc {
 static const char *const TAG = "xiaomi_lywsd02mmc";
 
 void XiaomiLYWSD02MMC::dump_config() {
-  ESP_LOGCONFIG(TAG, "Xiaomi LYWSD02MMC");
-  ESP_LOGCONFIG(TAG, "  Bindkey: %s", format_hex_pretty(this->bindkey_, 16).c_str());
+  ESP_LOGCONFIG(TAG, "Xiaomi LYWSD02MMC\n  Bindkey: %s", format_hex_pretty(this->bindkey_, 16).c_str());
   LOG_SENSOR("  ", "Temperature", this->temperature_);
   LOG_SENSOR("  ", "Humidity", this->humidity_);
   LOG_SENSOR("  ", "Battery Level", this->battery_level_);

--- a/esphome/components/xiaomi_lywsd02mmc/xiaomi_lywsd02mmc.cpp
+++ b/esphome/components/xiaomi_lywsd02mmc/xiaomi_lywsd02mmc.cpp
@@ -9,7 +9,10 @@ namespace xiaomi_lywsd02mmc {
 static const char *const TAG = "xiaomi_lywsd02mmc";
 
 void XiaomiLYWSD02MMC::dump_config() {
-  ESP_LOGCONFIG(TAG, "Xiaomi LYWSD02MMC\n  Bindkey: %s", format_hex_pretty(this->bindkey_, 16).c_str());
+  ESP_LOGCONFIG(TAG,
+                "Xiaomi LYWSD02MMC\n"
+                "  Bindkey: %s",
+                format_hex_pretty(this->bindkey_, 16).c_str());
   LOG_SENSOR("  ", "Temperature", this->temperature_);
   LOG_SENSOR("  ", "Humidity", this->humidity_);
   LOG_SENSOR("  ", "Battery Level", this->battery_level_);

--- a/esphome/components/xiaomi_lywsd03mmc/xiaomi_lywsd03mmc.cpp
+++ b/esphome/components/xiaomi_lywsd03mmc/xiaomi_lywsd03mmc.cpp
@@ -9,8 +9,7 @@ namespace xiaomi_lywsd03mmc {
 static const char *const TAG = "xiaomi_lywsd03mmc";
 
 void XiaomiLYWSD03MMC::dump_config() {
-  ESP_LOGCONFIG(TAG, "Xiaomi LYWSD03MMC");
-  ESP_LOGCONFIG(TAG, "  Bindkey: %s", format_hex_pretty(this->bindkey_, 16).c_str());
+  ESP_LOGCONFIG(TAG, "Xiaomi LYWSD03MMC\n  Bindkey: %s", format_hex_pretty(this->bindkey_, 16).c_str());
   LOG_SENSOR("  ", "Temperature", this->temperature_);
   LOG_SENSOR("  ", "Humidity", this->humidity_);
   LOG_SENSOR("  ", "Battery Level", this->battery_level_);

--- a/esphome/components/xiaomi_lywsd03mmc/xiaomi_lywsd03mmc.cpp
+++ b/esphome/components/xiaomi_lywsd03mmc/xiaomi_lywsd03mmc.cpp
@@ -9,7 +9,10 @@ namespace xiaomi_lywsd03mmc {
 static const char *const TAG = "xiaomi_lywsd03mmc";
 
 void XiaomiLYWSD03MMC::dump_config() {
-  ESP_LOGCONFIG(TAG, "Xiaomi LYWSD03MMC\n  Bindkey: %s", format_hex_pretty(this->bindkey_, 16).c_str());
+  ESP_LOGCONFIG(TAG,
+                "Xiaomi LYWSD03MMC\n"
+                "  Bindkey: %s",
+                format_hex_pretty(this->bindkey_, 16).c_str());
   LOG_SENSOR("  ", "Temperature", this->temperature_);
   LOG_SENSOR("  ", "Humidity", this->humidity_);
   LOG_SENSOR("  ", "Battery Level", this->battery_level_);

--- a/esphome/components/xiaomi_mhoc401/xiaomi_mhoc401.cpp
+++ b/esphome/components/xiaomi_mhoc401/xiaomi_mhoc401.cpp
@@ -9,8 +9,7 @@ namespace xiaomi_mhoc401 {
 static const char *const TAG = "xiaomi_mhoc401";
 
 void XiaomiMHOC401::dump_config() {
-  ESP_LOGCONFIG(TAG, "Xiaomi MHOC401");
-  ESP_LOGCONFIG(TAG, "  Bindkey: %s", format_hex_pretty(this->bindkey_, 16).c_str());
+  ESP_LOGCONFIG(TAG, "Xiaomi MHOC401\n  Bindkey: %s", format_hex_pretty(this->bindkey_, 16).c_str());
   LOG_SENSOR("  ", "Temperature", this->temperature_);
   LOG_SENSOR("  ", "Humidity", this->humidity_);
   LOG_SENSOR("  ", "Battery Level", this->battery_level_);

--- a/esphome/components/xiaomi_mhoc401/xiaomi_mhoc401.cpp
+++ b/esphome/components/xiaomi_mhoc401/xiaomi_mhoc401.cpp
@@ -9,7 +9,10 @@ namespace xiaomi_mhoc401 {
 static const char *const TAG = "xiaomi_mhoc401";
 
 void XiaomiMHOC401::dump_config() {
-  ESP_LOGCONFIG(TAG, "Xiaomi MHOC401\n  Bindkey: %s", format_hex_pretty(this->bindkey_, 16).c_str());
+  ESP_LOGCONFIG(TAG,
+                "Xiaomi MHOC401\n"
+                "  Bindkey: %s",
+                format_hex_pretty(this->bindkey_, 16).c_str());
   LOG_SENSOR("  ", "Temperature", this->temperature_);
   LOG_SENSOR("  ", "Humidity", this->humidity_);
   LOG_SENSOR("  ", "Battery Level", this->battery_level_);

--- a/esphome/components/xpt2046/touchscreen/xpt2046.cpp
+++ b/esphome/components/xpt2046/touchscreen/xpt2046.cpp
@@ -62,14 +62,11 @@ void XPT2046Component::dump_config() {
   ESP_LOGCONFIG(TAG, "XPT2046:");
 
   LOG_PIN("  IRQ Pin: ", this->irq_pin_);
-  ESP_LOGCONFIG(TAG, "  X min: %d", this->x_raw_min_);
-  ESP_LOGCONFIG(TAG, "  X max: %d", this->x_raw_max_);
-  ESP_LOGCONFIG(TAG, "  Y min: %d", this->y_raw_min_);
-  ESP_LOGCONFIG(TAG, "  Y max: %d", this->y_raw_max_);
+  ESP_LOGCONFIG(TAG, "  X min: %d\n  X max: %d\n  Y min: %d\n  Y max: %d", this->x_raw_min_, this->x_raw_max_,
+                this->y_raw_min_, this->y_raw_max_);
 
-  ESP_LOGCONFIG(TAG, "  Swap X/Y: %s", YESNO(this->swap_x_y_));
-  ESP_LOGCONFIG(TAG, "  Invert X: %s", YESNO(this->invert_x_));
-  ESP_LOGCONFIG(TAG, "  Invert Y: %s", YESNO(this->invert_y_));
+  ESP_LOGCONFIG(TAG, "  Swap X/Y: %s\n  Invert X: %s\n  Invert Y: %s", YESNO(this->swap_x_y_), YESNO(this->invert_x_),
+                YESNO(this->invert_y_));
 
   ESP_LOGCONFIG(TAG, "  threshold: %d", this->threshold_);
 

--- a/esphome/components/xpt2046/touchscreen/xpt2046.cpp
+++ b/esphome/components/xpt2046/touchscreen/xpt2046.cpp
@@ -63,8 +63,14 @@ void XPT2046Component::dump_config() {
 
   LOG_PIN("  IRQ Pin: ", this->irq_pin_);
   ESP_LOGCONFIG(TAG,
-                "  X min: %d\n  X max: %d\n  Y min: %d\n  Y max: %d\n  Swap X/Y: %s\n  Invert X: %s\n  Invert Y: %s\n  "
-                "threshold: %d",
+                "  X min: %d\n"
+                "  X max: %d\n"
+                "  Y min: %d\n"
+                "  Y max: %d\n"
+                "  Swap X/Y: %s\n"
+                "  Invert X: %s\n"
+                "  Invert Y: %s\n"
+                "  threshold: %d",
                 this->x_raw_min_, this->x_raw_max_, this->y_raw_min_, this->y_raw_max_, YESNO(this->swap_x_y_),
                 YESNO(this->invert_x_), YESNO(this->invert_y_), this->threshold_);
 

--- a/esphome/components/xpt2046/touchscreen/xpt2046.cpp
+++ b/esphome/components/xpt2046/touchscreen/xpt2046.cpp
@@ -62,13 +62,11 @@ void XPT2046Component::dump_config() {
   ESP_LOGCONFIG(TAG, "XPT2046:");
 
   LOG_PIN("  IRQ Pin: ", this->irq_pin_);
-  ESP_LOGCONFIG(TAG, "  X min: %d\n  X max: %d\n  Y min: %d\n  Y max: %d", this->x_raw_min_, this->x_raw_max_,
-                this->y_raw_min_, this->y_raw_max_);
-
-  ESP_LOGCONFIG(TAG, "  Swap X/Y: %s\n  Invert X: %s\n  Invert Y: %s", YESNO(this->swap_x_y_), YESNO(this->invert_x_),
-                YESNO(this->invert_y_));
-
-  ESP_LOGCONFIG(TAG, "  threshold: %d", this->threshold_);
+  ESP_LOGCONFIG(TAG,
+                "  X min: %d\n  X max: %d\n  Y min: %d\n  Y max: %d\n  Swap X/Y: %s\n  Invert X: %s\n  Invert Y: %s\n  "
+                "threshold: %d",
+                this->x_raw_min_, this->x_raw_max_, this->y_raw_min_, this->y_raw_max_, YESNO(this->swap_x_y_),
+                YESNO(this->invert_x_), YESNO(this->invert_y_), this->threshold_);
 
   LOG_UPDATE_INTERVAL(this);
 }


### PR DESCRIPTION
This PR optimizes ESPHome's configuration logging system by combining multiple related log lines into single network messages. This dual optimization approach:

1. **Reduces network traffic** during configuration dumps - fewer packets mean faster startup and less network congestion
2. **Reduces flash memory usage** by eliminating redundant format strings and function calls

### Background
- Each ESP_LOGCONFIG call resulted in a separate network packet
- Systems with hundreds of entities generated thousands of network packets during config dumps
- This caused noticeable delays and network congestion
- Multiple ESP_LOGCONFIG calls also consume more flash memory due to duplicated format strings and function call overhead
- **Critical Issue**: If the user has 100+ sensors and they flash the device, when it reconnects it slows the device down so much that it blocks the loop and overloads it, which prevents it from coming back up in Home Assistant in a timely manner or worse hits the timeout for listing entities and then some are missing. This optimization hopes to improve this situation.

### Solution
Combined related configuration log lines using embedded newlines (`\n`) within single ESP_LOGCONFIG calls. This maintains the same visual output while:
- Drastically reducing network overhead (fewer packets)
- Reducing flash memory usage (fewer function calls and format strings)

### Important Note on Log Formatting
- **When using the ESPHome dashboard, Home Assistant, or `esphome logs` command**: The aioesphomeapi library automatically reformats these multi-line messages, so logs appear **exactly as they did before** - each field on its own line with proper indentation. For Web Server https://github.com/esphome/esphome-webserver/pull/142
- **Only when reading serial data with external tools** (e.g., minicom, screen, putty): The messages are still very readable but appear as single multi-line entries rather than separate log entries

### Example Change
```cpp
// Before: Multiple calls (each generates a network packet)
ESP_LOGCONFIG(TAG, "%sSensor '%s'", prefix, obj->get_name().c_str());
ESP_LOGCONFIG(TAG, "%s  State Class: '%s'", prefix, obj->get_state_class());
ESP_LOGCONFIG(TAG, "%s  Unit: '%s'", prefix, obj->get_unit());

// After: Single call (one network packet)
ESP_LOGCONFIG(TAG,
              "%sSensor '%s'\n"
              "%s  State Class: '%s'\n"
              "%s  Unit: '%s'",
              prefix, obj->get_name().c_str(),
              prefix, obj->get_state_class(),
              prefix, obj->get_unit());
```

### Performance Benefits
- **Network Traffic**: ~80-85% reduction in packets for typical sensors (5-6 packets → 1 packet)
- **Flash Memory**: Saved 608 bytes on a test ESP32 build
- **Real-World Impact**: For a system with 200 sensors, reduces ~1000 packets to ~200 packets

### Scope
Optimized 180 components including:
- Core entity types (Sensor, Fan, Switch, Display, etc.)
- Major components (WiFi, Ethernet, MQTT, ESP32 Camera, etc.)
- Hardware components (UART, I2C, SPI, Remote Receiver, etc.)
- Sensors & peripherals (INA226, MAX31865, LTR390, BME68x, TSL2561, TSL2591, VEML7700, VEML3235, Ultrasonic, etc.)
- Display & LED components (ILI9xxx, MAX7219, FastLED, TM1637, Graphical Display Menu, etc.)
- Climate components (Climate IR, PID Climate, Midea Air Conditioner, HLW8012, etc.)
- BLE components (Xiaomi LYWSD03MMC, Xiaomi LYWSD02MMC, etc.)
- Other components (Pipsolar, Sonoff D1, SDS011, Light State, Matrix Keypad, MIPI SPI Display, Mixer Speaker, USB Host Client, X9C, GP8403, ESP32 Camera Web Server, etc.)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- https://github.com/esphome/developers.esphome.io/pull/34

For WebServer

https://github.com/esphome/esphome-webserver/pull/142

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - this is an internal optimization
# All existing configurations work unchanged
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs)