### PR TITLE
[config] Clean build on ESP-IDF when component/platform combos change

### DIFF
--- a/esphome/config.py
+++ b/esphome/config.py
@@ -389,6 +389,7 @@ class LoadValidationStep(ConfigValidationStep):
                 result.add_str_error(f"Platform not found: '{p_domain}'", path)
                 continue
             CORE.loaded_integrations.add(p_name)
+            CORE.loaded_platforms.add(f"{self.domain}/{p_name}")
 
             # Process AUTO_LOAD
             for load in platform.auto_load:
@@ -964,7 +965,7 @@ def line_info(config, path, highlight=True):
 
 
 def _print_on_next_line(obj):
-    if isinstance(obj, (list, tuple, dict)):
+    if isinstance(obj, list | tuple | dict):
         return True
     if isinstance(obj, str):
         return len(obj) > 80
@@ -985,7 +986,7 @@ def dump_dict(
         if error is not None:
             ret += f"\n{color(AnsiFore.BOLD_RED, _format_vol_invalid(error, config))}\n"
 
-    if isinstance(conf, (list, tuple)):
+    if isinstance(conf, list | tuple):
         multiline = True
         if not conf:
             ret += "[]"

--- a/esphome/config.py
+++ b/esphome/config.py
@@ -965,7 +965,7 @@ def line_info(config, path, highlight=True):
 
 
 def _print_on_next_line(obj):
-    if isinstance(obj, list | tuple | dict):
+    if isinstance(obj, (list, tuple, dict)):
         return True
     if isinstance(obj, str):
         return len(obj) > 80

--- a/esphome/config.py
+++ b/esphome/config.py
@@ -986,7 +986,7 @@ def dump_dict(
         if error is not None:
             ret += f"\n{color(AnsiFore.BOLD_RED, _format_vol_invalid(error, config))}\n"
 
-    if isinstance(conf, list | tuple):
+    if isinstance(conf, (list, tuple)):
         multiline = True
         if not conf:
             ret += "[]"

--- a/esphome/core/__init__.py
+++ b/esphome/core/__init__.py
@@ -512,6 +512,8 @@ class EsphomeCore:
         self.platformio_options: dict[str, str | list[str]] = {}
         # A set of strings of names of loaded integrations, used to find namespace ID conflicts
         self.loaded_integrations = set()
+        # A set of strings for platform/integration combos
+        self.loaded_platforms = set()
         # A set of component IDs to track what Component subclasses are declared
         self.component_ids = set()
         # Whether ESPHome was started in verbose mode

--- a/esphome/core/__init__.py
+++ b/esphome/core/__init__.py
@@ -513,7 +513,7 @@ class EsphomeCore:
         # A set of strings of names of loaded integrations, used to find namespace ID conflicts
         self.loaded_integrations = set()
         # A set of strings for platform/integration combos
-        self.loaded_platforms = set()
+        self.loaded_platforms: set[str] = set()
         # A set of component IDs to track what Component subclasses are declared
         self.component_ids = set()
         # Whether ESPHome was started in verbose mode

--- a/esphome/storage_json.py
+++ b/esphome/storage_json.py
@@ -46,15 +46,16 @@ class StorageJSON:
         storage_version: int,
         name: str,
         friendly_name: str,
-        comment: str,
-        esphome_version: str,
+        comment: str | None,
+        esphome_version: str | None,
         src_version: int | None,
         address: str,
         web_port: int | None,
         target_platform: str,
-        build_path: str,
-        firmware_bin_path: str,
+        build_path: str | None,
+        firmware_bin_path: str | None,
         loaded_integrations: set[str],
+        loaded_platforms: set[str],
         no_mdns: bool,
         framework: str | None = None,
         core_platform: str | None = None,
@@ -86,6 +87,8 @@ class StorageJSON:
         self.firmware_bin_path = firmware_bin_path
         # A set of strings of names of loaded integrations
         self.loaded_integrations = loaded_integrations
+        # A set of strings for platform/integration combos
+        self.loaded_platforms = loaded_platforms
         # Is mDNS disabled
         self.no_mdns = no_mdns
         # The framework used to compile the firmware
@@ -107,6 +110,7 @@ class StorageJSON:
             "build_path": self.build_path,
             "firmware_bin_path": self.firmware_bin_path,
             "loaded_integrations": sorted(self.loaded_integrations),
+            "loaded_platforms": sorted(self.loaded_platforms),
             "no_mdns": self.no_mdns,
             "framework": self.framework,
             "core_platform": self.core_platform,
@@ -138,6 +142,7 @@ class StorageJSON:
             build_path=esph.build_path,
             firmware_bin_path=esph.firmware_bin,
             loaded_integrations=esph.loaded_integrations,
+            loaded_platforms=esph.loaded_platforms,
             no_mdns=(
                 CONF_MDNS in esph.config
                 and CONF_DISABLED in esph.config[CONF_MDNS]
@@ -164,6 +169,7 @@ class StorageJSON:
             build_path=None,
             firmware_bin_path=None,
             loaded_integrations=set(),
+            loaded_platforms=set(),
             no_mdns=False,
             framework=None,
             core_platform=platform.lower(),
@@ -187,6 +193,7 @@ class StorageJSON:
         build_path = storage.get("build_path")
         firmware_bin_path = storage.get("firmware_bin_path")
         loaded_integrations = set(storage.get("loaded_integrations", []))
+        loaded_platforms = set(storage.get("loaded_platforms", []))
         no_mdns = storage.get("no_mdns", False)
         framework = storage.get("framework")
         core_platform = storage.get("core_platform")
@@ -203,6 +210,7 @@ class StorageJSON:
             build_path,
             firmware_bin_path,
             loaded_integrations,
+            loaded_platforms,
             no_mdns,
             framework,
             core_platform,
@@ -252,7 +260,7 @@ class EsphomeStorageJSON:
     def last_update_check(self, new: datetime) -> None:
         self.last_update_check_str = new.strftime("%Y-%m-%dT%H:%M:%S")
 
-    def to_json(self) -> dict:
+    def to_json(self) -> str:
         return f"{json.dumps(self.as_dict(), indent=2)}\n"
 
     def save(self, path: str) -> None:

--- a/esphome/writer.py
+++ b/esphome/writer.py
@@ -107,7 +107,10 @@ def storage_should_clean(old: StorageJSON, new: StorageJSON) -> bool:
         return True
     if old.build_path != new.build_path:
         return True
-    if old.loaded_integrations != new.loaded_integrations:
+    if (
+        old.loaded_integrations != new.loaded_integrations
+        or old.loaded_platforms != new.loaded_platforms
+    ):
         if new.core_platform == PLATFORM_ESP32:
             from esphome.components.esp32 import FRAMEWORK_ESP_IDF
 


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

ESP-IDF doesn't always handle source changes properly; this was fixed for addition/deletion of components, but an issue remained where link-time failures occurred when a new platform for an existing integration was added or removed.

This PR now also compiles a set of integration/platform combinations and stores this in the json file. Any change in this will trigger a build clean on ESP-IDF just as for a change in the set of integrations.


## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://discord.com/channels/429907082951524364/1381338889666695281/1381342987753230438
- https://github.com/esphome/issues/issues/6178
- https://github.com/esphome/issues/issues/6050
- 

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

binary_sensor:
- platform: template
  name: Template Binary
  entity_category: diagnostic
  lambda: return true;

# Addition or removal of this entity will cause link error on rebuild
- platform: gpio
  id: gpio_binary
  pin: 0

switch:
  - platform: template
    id: switch_t
    name: "Output switch"
    optimistic: true
  - platform: gpio
    id: switch_gpio
    pin: GPIO32
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
