### PR TITLE
[inkplate] Remove arduino dependency

### DIFF
--- a/esphome/components/inkplate6/display.py
+++ b/esphome/components/inkplate6/display.py
@@ -117,7 +117,6 @@ CONFIG_SCHEMA = cv.All(
     .extend(cv.polling_component_schema("5s"))
     .extend(i2c.i2c_device_schema(0x48)),
     cv.has_at_most_one_key(CONF_PAGES, CONF_LAMBDA),
-    cv.only_with_arduino,
 )
 
 

--- a/esphome/components/inkplate6/inkplate.cpp
+++ b/esphome/components/inkplate6/inkplate.cpp
@@ -3,9 +3,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-#ifdef USE_ESP32_FRAMEWORK_ARDUINO
-
-#include <esp32-hal-gpio.h>
+#include <hal/gpio_hal.h>
 
 namespace esphome {
 namespace inkplate6 {
@@ -721,5 +719,3 @@ void Inkplate6::pins_as_outputs_() {
 
 }  // namespace inkplate6
 }  // namespace esphome
-
-#endif  // USE_ESP32_FRAMEWORK_ARDUINO

--- a/esphome/components/inkplate6/inkplate.h
+++ b/esphome/components/inkplate6/inkplate.h
@@ -5,8 +5,6 @@
 #include "esphome/core/component.h"
 #include "esphome/core/hal.h"
 
-#ifdef USE_ESP32_FRAMEWORK_ARDUINO
-
 namespace esphome {
 namespace inkplate6 {
 
@@ -254,5 +252,3 @@ class Inkplate6 : public display::DisplayBuffer, public i2c::I2CDevice {
 
 }  // namespace inkplate6
 }  // namespace esphome
-
-#endif  // USE_ESP32_FRAMEWORK_ARDUINO

--- a/tests/components/inkplate6/test.esp32-idf.yaml
+++ b/tests/components/inkplate6/test.esp32-idf.yaml
@@ -1,0 +1,1 @@
+<<: !include common.yaml


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Untested on hardware, but compile test added for idf.

Originally when working on this component, I thought the `GPIO` object was an Arduino API, but it seems it is from idf and so simply removing the arduino include and replacing with the direct idf one allows this to compile for idf.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
