### PR TITLE
Force socket ready when high frequency looping

### DIFF
--- a/esphome/core/application.cpp
+++ b/esphome/core/application.cpp
@@ -297,6 +297,8 @@ bool Application::is_socket_ready(int fd) const {
   // This function is thread-safe for reading the result of select()
   // However, it should only be called after select() has been executed in the main loop
   // The read_fds_ is only modified by select() in the main loop
+  if (HighFrequencyLoopRequester::is_high_frequency())
+    return true;  // fd sets via select are not updated in high frequency looping - so force true fallback behavior
   if (fd < 0 || fd >= FD_SETSIZE)
     return false;
 


### PR DESCRIPTION
# What does this implement/fix?

Hi - this is related to #8918.  I believe that if a component is being used that requests high frequency looping, then the API and OTA will now be broken (it is for me at least).  I *think* this is all that is required to unbreak it in those situations.  It is working for my test case with a high speed loop (personal fork re-enabling software remote receiver on esp32: [esp32_soft_rmt](https://github.com/juanboro/esphome/tree/esp32_soft_rmt)). 

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**
#8918 

- fixes
Just implements the fallback behavior of if select isn't available if high speed looping is happening. 

## Test Environment

- [ ] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

N/A

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
     - N/A

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
