### PR TITLE
[nextion] Optimize log messages to reduce memory usage

### DIFF
--- a/esphome/components/nextion/binary_sensor/nextion_binarysensor.cpp
+++ b/esphome/components/nextion/binary_sensor/nextion_binarysensor.cpp
@@ -16,7 +16,7 @@ void NextionBinarySensor::process_bool(const std::string &variable_name, bool st
 
   if (this->variable_name_ == variable_name) {
     this->publish_state(state);
-    ESP_LOGD(TAG, "Processed binarysensor \"%s\" state %s", variable_name.c_str(), state ? "ON" : "OFF");
+    ESP_LOGD(TAG, "Binary sensor: %s=%s", variable_name.c_str(), ONOFF(state));
   }
 }
 
@@ -61,8 +61,7 @@ void NextionBinarySensor::set_state(bool state, bool publish, bool send_to_nexti
 
   this->update_component_settings();
 
-  ESP_LOGN(TAG, "Wrote state for sensor \"%s\" state %s", this->variable_name_.c_str(),
-           ONOFF(this->variable_name_.c_str()));
+  ESP_LOGN(TAG, "Write: %s=%s", this->variable_name_.c_str(), ONOFF(this->state));
 }
 
 }  // namespace nextion

--- a/esphome/components/nextion/nextion.cpp
+++ b/esphome/components/nextion/nextion.cpp
@@ -37,7 +37,7 @@ bool Nextion::send_command_(const std::string &command) {
   }
 #endif  // USE_NEXTION_COMMAND_SPACING
 
-  ESP_LOGN(TAG, "send_command %s", command.c_str());
+  ESP_LOGN(TAG, "cmd: %s", command.c_str());
 
   this->write_str(command.c_str());
   const uint8_t to_send[3] = {0xFF, 0xFF, 0xFF};
@@ -57,7 +57,7 @@ bool Nextion::check_connect_() {
   // Check if the handshake should be skipped for the Nextion connection
   if (this->skip_connection_handshake_) {
     // Log the connection status without handshake
-    ESP_LOGW(TAG, "Nextion display set as connected without performing handshake");
+    ESP_LOGW(TAG, "Connected (no handshake)");
     // Set the connection status to true
     this->is_connected_ = true;
     // Return true indicating the connection is set
@@ -88,27 +88,27 @@ bool Nextion::check_connect_() {
   this->recv_ret_string_(response, 0, false);
   if (!response.empty() && response[0] == 0x1A) {
     // Swallow invalid variable name responses that may be caused by the above commands
-    ESP_LOGD(TAG, "0x1A error ignored during setup");
+    ESP_LOGD(TAG, "0x1A error ignored (setup)");
     return false;
   }
   if (response.empty() || response.find("comok") == std::string::npos) {
 #ifdef NEXTION_PROTOCOL_LOG
-    ESP_LOGN(TAG, "Bad connect request %s", response.c_str());
+    ESP_LOGN(TAG, "Bad connect: %s", response.c_str());
     for (size_t i = 0; i < response.length(); i++) {
-      ESP_LOGN(TAG, "response %s %d %d %c", response.c_str(), i, response[i], response[i]);
+      ESP_LOGN(TAG, "resp: %s %d %d %c", response.c_str(), i, response[i], response[i]);
     }
 #endif
 
-    ESP_LOGW(TAG, "Nextion is not connected! ");
+    ESP_LOGW(TAG, "Not connected");
     comok_sent_ = 0;
     return false;
   }
 
   this->ignore_is_setup_ = true;
-  ESP_LOGI(TAG, "Nextion is connected");
+  ESP_LOGI(TAG, "Connected");
   this->is_connected_ = true;
 
-  ESP_LOGN(TAG, "connect request %s", response.c_str());
+  ESP_LOGN(TAG, "connect: %s", response.c_str());
 
   size_t start;
   size_t end = 0;
@@ -120,14 +120,14 @@ bool Nextion::check_connect_() {
 
   this->is_detected_ = (connect_info.size() == 7);
   if (this->is_detected_) {
-    ESP_LOGN(TAG, "Received connect_info %zu", connect_info.size());
+    ESP_LOGN(TAG, "Connect info: %zu", connect_info.size());
 
     this->device_model_ = connect_info[2];
     this->firmware_version_ = connect_info[3];
     this->serial_number_ = connect_info[5];
     this->flash_size_ = connect_info[6];
   } else {
-    ESP_LOGE(TAG, "Nextion returned bad connect value \"%s\"", response.c_str());
+    ESP_LOGE(TAG, "Bad connect value: '%s'", response.c_str());
   }
 
   this->ignore_is_setup_ = false;
@@ -148,35 +148,35 @@ void Nextion::reset_(bool reset_nextion) {
 void Nextion::dump_config() {
   ESP_LOGCONFIG(TAG, "Nextion:");
   if (this->skip_connection_handshake_) {
-    ESP_LOGCONFIG(TAG, "  Skip handshake:   %s", YESNO(this->skip_connection_handshake_));
+    ESP_LOGCONFIG(TAG, "  Skip handshake: %s", YESNO(this->skip_connection_handshake_));
   } else {
     ESP_LOGCONFIG(TAG,
-                  "  Device Model:     %s\n"
-                  "  Firmware Version: %s\n"
-                  "  Serial Number:    %s\n"
-                  "  Flash Size:       %s",
+                  "  Device Model:   %s\n"
+                  "  FW Version:     %s\n"
+                  "  Serial Number:  %s\n"
+                  "  Flash Size:     %s",
                   this->device_model_.c_str(), this->firmware_version_.c_str(), this->serial_number_.c_str(),
                   this->flash_size_.c_str());
   }
   ESP_LOGCONFIG(TAG,
-                "  Wake On Touch:    %s\n"
-                "  Exit reparse:     %s",
+                "  Wake On Touch:  %s\n"
+                "  Exit reparse:   %s",
                 YESNO(this->auto_wake_on_touch_), YESNO(this->exit_reparse_on_start_));
 
   if (this->touch_sleep_timeout_ != 0) {
-    ESP_LOGCONFIG(TAG, "  Touch Timeout:    %" PRIu32, this->touch_sleep_timeout_);
+    ESP_LOGCONFIG(TAG, "  Touch Timeout:  %" PRIu32, this->touch_sleep_timeout_);
   }
 
   if (this->wake_up_page_ != -1) {
-    ESP_LOGCONFIG(TAG, "  Wake Up Page:     %" PRId16, this->wake_up_page_);
+    ESP_LOGCONFIG(TAG, "  Wake Up Page:   %" PRId16, this->wake_up_page_);
   }
 
   if (this->start_up_page_ != -1) {
-    ESP_LOGCONFIG(TAG, "  Start Up Page:    %" PRId16, this->start_up_page_);
+    ESP_LOGCONFIG(TAG, "  Start Up Page:  %" PRId16, this->start_up_page_);
   }
 
 #ifdef USE_NEXTION_COMMAND_SPACING
-  ESP_LOGCONFIG(TAG, "  Command spacing:  %" PRIu8 "ms", this->command_pacer_.get_spacing());
+  ESP_LOGCONFIG(TAG, "  Cmd spacing:      %" PRIu8 "ms", this->command_pacer_.get_spacing());
 #endif  // USE_NEXTION_COMMAND_SPACING
 
 #ifdef USE_NEXTION_MAX_QUEUE_SIZE
@@ -257,7 +257,7 @@ bool Nextion::send_command_printf(const char *format, ...) {
   int ret = vsnprintf(buffer, sizeof(buffer), format, arg);
   va_end(arg);
   if (ret <= 0) {
-    ESP_LOGW(TAG, "Building command for format '%s' failed!", format);
+    ESP_LOGW(TAG, "Bad cmd format: '%s'", format);
     return false;
   }
 
@@ -278,9 +278,9 @@ void Nextion::print_queue_members_() {
       break;
 
     if (i == nullptr) {
-      ESP_LOGN(TAG, "Nextion queue is null");
+      ESP_LOGN(TAG, "Queue null");
     } else {
-      ESP_LOGN(TAG, "Nextion queue type: %d:%s , name: %s", i->component->get_queue_type(),
+      ESP_LOGN(TAG, "Queue type: %d:%s, name: %s", i->component->get_queue_type(),
                i->component->get_queue_type_string().c_str(), i->component->get_variable_name().c_str());
     }
   }
@@ -321,7 +321,7 @@ void Nextion::loop() {
       this->started_ms_ = millis();
 
     if (this->started_ms_ + this->startup_override_ms_ < millis()) {
-      ESP_LOGD(TAG, "Manually set nextion report ready");
+      ESP_LOGD(TAG, "Manual ready set");
       this->nextion_reports_is_setup_ = true;
     }
   }
@@ -330,20 +330,20 @@ void Nextion::loop() {
 bool Nextion::remove_from_q_(bool report_empty) {
   if (this->nextion_queue_.empty()) {
     if (report_empty) {
-      ESP_LOGE(TAG, "Nextion queue is empty!");
+      ESP_LOGE(TAG, "Queue empty");
     }
     return false;
   }
 
   NextionQueue *nb = this->nextion_queue_.front();
   if (!nb || !nb->component) {
-    ESP_LOGE(TAG, "Invalid queue entry!");
+    ESP_LOGE(TAG, "Invalid queue");
     this->nextion_queue_.pop_front();
     return false;
   }
   NextionComponentBase *component = nb->component;
 
-  ESP_LOGN(TAG, "Removing %s from the queue", component->get_variable_name().c_str());
+  ESP_LOGN(TAG, "Removed: %s", component->get_variable_name().c_str());
 
   if (component->get_queue_type() == NextionQueueType::NO_RESULT) {
     if (component->get_variable_name() == "sleep_wake") {
@@ -379,16 +379,16 @@ void Nextion::process_nextion_commands_() {
   size_t to_process_length = 0;
   std::string to_process;
 
-  ESP_LOGN(TAG, "this->command_data_ %s length %d", this->command_data_.c_str(), this->command_data_.length());
+  ESP_LOGN(TAG, "command_data_ %s len %d", this->command_data_.c_str(), this->command_data_.length());
 #ifdef NEXTION_PROTOCOL_LOG
   this->print_queue_members_();
 #endif
   while ((to_process_length = this->command_data_.find(COMMAND_DELIMITER)) != std::string::npos) {
-    ESP_LOGN(TAG, "print_queue_members_ size %zu", this->nextion_queue_.size());
+    ESP_LOGN(TAG, "queue size: %zu", this->nextion_queue_.size());
     while (to_process_length + COMMAND_DELIMITER.length() < this->command_data_.length() &&
            static_cast<uint8_t>(this->command_data_[to_process_length + COMMAND_DELIMITER.length()]) == 0xFF) {
       ++to_process_length;
-      ESP_LOGN(TAG, "Add extra 0xFF to process");
+      ESP_LOGN(TAG, "Add 0xFF");
     }
 
     this->nextion_event_ = this->command_data_[0];
@@ -398,19 +398,19 @@ void Nextion::process_nextion_commands_() {
 
     switch (this->nextion_event_) {
       case 0x00:  // instruction sent by user has failed
-        ESP_LOGW(TAG, "Nextion reported invalid instruction!");
+        ESP_LOGW(TAG, "Invalid instruction");
         this->remove_from_q_();
 
         break;
       case 0x01:  // instruction sent by user was successful
 
-        ESP_LOGVV(TAG, "instruction sent by user was successful");
+        ESP_LOGVV(TAG, "Cmd OK");
         ESP_LOGN(TAG, "this->nextion_queue_.empty() %s", this->nextion_queue_.empty() ? "True" : "False");
 
         this->remove_from_q_();
         if (!this->is_setup_) {
           if (this->nextion_queue_.empty()) {
-            ESP_LOGD(TAG, "Nextion is setup");
+            ESP_LOGD(TAG, "Setup complete");
             this->is_setup_ = true;
             this->setup_callback_.call();
           }
@@ -420,42 +420,42 @@ void Nextion::process_nextion_commands_() {
 #endif
         break;
       case 0x02:  // invalid Component ID or name was used
-        ESP_LOGW(TAG, "Nextion reported component ID or name invalid!");
+        ESP_LOGW(TAG, "Invalid component ID/name");
         this->remove_from_q_();
         break;
       case 0x03:  // invalid Page ID or name was used
-        ESP_LOGW(TAG, "Nextion reported page ID invalid!");
+        ESP_LOGW(TAG, "Invalid page ID");
         this->remove_from_q_();
         break;
       case 0x04:  // invalid Picture ID was used
-        ESP_LOGW(TAG, "Nextion reported picture ID invalid!");
+        ESP_LOGW(TAG, "Invalid picture ID");
         this->remove_from_q_();
         break;
       case 0x05:  // invalid Font ID was used
-        ESP_LOGW(TAG, "Nextion reported font ID invalid!");
+        ESP_LOGW(TAG, "Invalid font ID");
         this->remove_from_q_();
         break;
       case 0x06:  // File operation fails
-        ESP_LOGW(TAG, "Nextion File operation fail!");
+        ESP_LOGW(TAG, "File operation failed");
         break;
       case 0x09:  // Instructions with CRC validation fails their CRC check
-        ESP_LOGW(TAG, "Nextion Instructions with CRC validation fails their CRC check!");
+        ESP_LOGW(TAG, "CRC validation failed");
         break;
       case 0x11:  // invalid Baud rate was used
-        ESP_LOGW(TAG, "Nextion reported baud rate invalid!");
+        ESP_LOGW(TAG, "Invalid baud rate");
         break;
       case 0x12:  // invalid Waveform ID or Channel # was used
         if (this->waveform_queue_.empty()) {
           ESP_LOGW(TAG,
-                   "Nextion reported invalid Waveform ID or Channel # was used but no waveform sensor in queue found!");
+                   "Invalid waveform ID %d/ch %d");
         } else {
           auto &nb = this->waveform_queue_.front();
           NextionComponentBase *component = nb->component;
 
-          ESP_LOGW(TAG, "Nextion reported invalid Waveform ID %d or Channel # %d was used!",
+          ESP_LOGW(TAG, "Invalid waveform ID %d/ch %d",
                    component->get_component_id(), component->get_wave_channel_id());
 
-          ESP_LOGN(TAG, "Removing waveform from queue with component id %d and waveform id %d",
+          ESP_LOGN(TAG, "Remove waveform ID %d/ch %d",
                    component->get_component_id(), component->get_wave_channel_id());
 
           delete nb;  // NOLINT(cppcoreguidelines-owning-memory)
@@ -463,53 +463,50 @@ void Nextion::process_nextion_commands_() {
         }
         break;
       case 0x1A:  // variable name invalid
-        ESP_LOGW(TAG, "Nextion reported variable name invalid!");
+        ESP_LOGW(TAG, "Invalid variable name");
         this->remove_from_q_();
         break;
       case 0x1B:  // variable operation invalid
-        ESP_LOGW(TAG, "Nextion reported variable operation invalid!");
+        ESP_LOGW(TAG, "Invalid variable operation");
         this->remove_from_q_();
         break;
       case 0x1C:  // failed to assign
-        ESP_LOGW(TAG, "Nextion reported failed to assign variable!");
+        ESP_LOGW(TAG, "Variable assign failed");
         this->remove_from_q_();
         break;
       case 0x1D:  // operate EEPROM failed
-        ESP_LOGW(TAG, "Nextion reported operating EEPROM failed!");
+        ESP_LOGW(TAG, "EEPROM operation failed");
         break;
       case 0x1E:  // parameter quantity invalid
-        ESP_LOGW(TAG, "Nextion reported parameter quantity invalid!");
+        ESP_LOGW(TAG, "Invalid parameter count");
         this->remove_from_q_();
         break;
       case 0x1F:  // IO operation failed
-        ESP_LOGW(TAG, "Nextion reported component I/O operation invalid!");
+        ESP_LOGW(TAG, "Invalid component I/O");
         break;
       case 0x20:  // undefined escape characters
-        ESP_LOGW(TAG, "Nextion reported undefined escape characters!");
+        ESP_LOGW(TAG, "Undefined escape chars");
         this->remove_from_q_();
         break;
       case 0x23:  // too long variable name
-        ESP_LOGW(TAG, "Nextion reported too long variable name!");
+        ESP_LOGW(TAG, "Variable name too long");
         this->remove_from_q_();
         break;
       case 0x24:  //  Serial Buffer overflow occurs
         // Buffer will continue to receive the current instruction, all previous instructions are lost.
-        ESP_LOGE(TAG, "Nextion reported Serial Buffer overflow!");
+        ESP_LOGE(TAG, "Serial buffer overflow");
         this->buffer_overflow_callback_.call();
         break;
       case 0x65: {  // touch event return data
         if (to_process_length != 3) {
-          ESP_LOGW(TAG, "Touch event data is expecting 3, received %zu", to_process_length);
+          ESP_LOGW(TAG, "Incorrect touch len: %zu (need 3)", to_process_length);
           break;
         }
 
         uint8_t page_id = to_process[0];
         uint8_t component_id = to_process[1];
         uint8_t touch_event = to_process[2];  // 0 -> release, 1 -> press
-        ESP_LOGD(TAG, "Got touch event:");
-        ESP_LOGD(TAG, "  page_id:      %u", page_id);
-        ESP_LOGD(TAG, "  component_id: %u", component_id);
-        ESP_LOGD(TAG, "  event type:   %s", touch_event ? "PRESS" : "RELEASE");
+        ESP_LOGD(TAG, "Touch %s: page %u comp %u", touch_event ? "PRESS" : "RELEASE", page_id, component_id);
         for (auto *touch : this->touch_) {
           touch->process_touch(page_id, component_id, touch_event != 0);
         }
@@ -519,12 +516,12 @@ void Nextion::process_nextion_commands_() {
       case 0x66: {  // Nextion initiated new page event return data.
                     // Also is used for sendme command which we never explicitly initiate
         if (to_process_length != 1) {
-          ESP_LOGW(TAG, "New page event data is expecting 1, received %zu", to_process_length);
+          ESP_LOGW(TAG, "Page event: expect 1, got %zu", to_process_length);
           break;
         }
 
         uint8_t page_id = to_process[0];
-        ESP_LOGD(TAG, "Got new page: %u", page_id);
+        ESP_LOGD(TAG, "New page: %u", page_id);
         this->page_callback_.call(page_id);
         break;
       }
@@ -534,7 +531,7 @@ void Nextion::process_nextion_commands_() {
       case 0x68: {  // touch coordinate data (sleep)
 
         if (to_process_length != 5) {
-          ESP_LOGW(TAG, "Touch coordinate data is expecting 5, received %zu", to_process_length);
+          ESP_LOGW(TAG, "Touch coordinate: expect 5, got %zu", to_process_length);
           ESP_LOGW(TAG, "%s", to_process.c_str());
           break;
         }
@@ -542,10 +539,7 @@ void Nextion::process_nextion_commands_() {
         uint16_t x = (uint16_t(to_process[0]) << 8) | to_process[1];
         uint16_t y = (uint16_t(to_process[2]) << 8) | to_process[3];
         uint8_t touch_event = to_process[4];  // 0 -> release, 1 -> press
-        ESP_LOGD(TAG, "Got touch event:");
-        ESP_LOGD(TAG, "  x:    %u", x);
-        ESP_LOGD(TAG, "  y:    %u", y);
-        ESP_LOGD(TAG, "  type: %s", touch_event ? "PRESS" : "RELEASE");
+        ESP_LOGD(TAG, "Touch %s at %u,%u", touch_event ? "PRESS" : "RELEASE", x, y);
         break;
       }
 
@@ -556,23 +550,23 @@ void Nextion::process_nextion_commands_() {
       case 0x70:  // string variable data return
       {
         if (this->nextion_queue_.empty()) {
-          ESP_LOGW(TAG, "ERROR: Received string return but the queue is empty");
+          ESP_LOGW(TAG, "String return but queue is empty");
           break;
         }
 
         NextionQueue *nb = this->nextion_queue_.front();
         if (!nb || !nb->component) {
-          ESP_LOGE(TAG, "Invalid queue entry!");
+          ESP_LOGE(TAG, "Invalid queue entry");
           this->nextion_queue_.pop_front();
           return;
         }
         NextionComponentBase *component = nb->component;
 
         if (component->get_queue_type() != NextionQueueType::TEXT_SENSOR) {
-          ESP_LOGE(TAG, "ERROR: Received string return but next in queue \"%s\" is not a text sensor",
+          ESP_LOGE(TAG, "String return but '%s' not text sensor",
                    component->get_variable_name().c_str());
         } else {
-          ESP_LOGN(TAG, "Received get_string response: \"%s\" for component id: %s, type: %s", to_process.c_str(),
+          ESP_LOGN(TAG, "String resp: '%s' id: %s type: %s", to_process.c_str(),
                    component->get_variable_name().c_str(), component->get_queue_type_string().c_str());
           component->set_state_from_string(to_process, true, false);
         }
@@ -590,12 +584,12 @@ void Nextion::process_nextion_commands_() {
       case 0x71:  // numeric variable data return
       {
         if (this->nextion_queue_.empty()) {
-          ESP_LOGE(TAG, "ERROR: Received numeric return but the queue is empty");
+          ESP_LOGE(TAG, "Numeric return but queue empty");
           break;
         }
 
         if (to_process_length == 0) {
-          ESP_LOGE(TAG, "ERROR: Received numeric return but no data!");
+          ESP_LOGE(TAG, "Numeric return but no data");
           break;
         }
 
@@ -607,7 +601,7 @@ void Nextion::process_nextion_commands_() {
 
         NextionQueue *nb = this->nextion_queue_.front();
         if (!nb || !nb->component) {
-          ESP_LOGE(TAG, "Invalid queue entry!");
+          ESP_LOGE(TAG, "Invalid queue");
           this->nextion_queue_.pop_front();
           return;
         }
@@ -616,10 +610,10 @@ void Nextion::process_nextion_commands_() {
         if (component->get_queue_type() != NextionQueueType::SENSOR &&
             component->get_queue_type() != NextionQueueType::BINARY_SENSOR &&
             component->get_queue_type() != NextionQueueType::SWITCH) {
-          ESP_LOGE(TAG, "ERROR: Received numeric return but next in queue \"%s\" is not a valid sensor type %d",
+          ESP_LOGE(TAG, "Numeric return but '%s' invalid type %d",
                    component->get_variable_name().c_str(), component->get_queue_type());
         } else {
-          ESP_LOGN(TAG, "Received numeric return for variable %s, queue type %d:%s, value %d",
+          ESP_LOGN(TAG, "Numeric: %s type %d:%s val %d",
                    component->get_variable_name().c_str(), component->get_queue_type(),
                    component->get_queue_type_string().c_str(), value);
           component->set_state_from_int(value, true, false);
@@ -632,14 +626,14 @@ void Nextion::process_nextion_commands_() {
       }
 
       case 0x86: {  // device automatically enters into sleep mode
-        ESP_LOGVV(TAG, "Received Nextion entering sleep automatically");
+        ESP_LOGVV(TAG, "Auto sleep");
         this->is_sleeping_ = true;
         this->sleep_callback_.call();
         break;
       }
       case 0x87:  // device automatically wakes up
       {
-        ESP_LOGVV(TAG, "Received Nextion leaves sleep automatically");
+        ESP_LOGVV(TAG, "Auto wake");
         this->is_sleeping_ = false;
         this->wake_callback_.call();
         this->all_components_send_state_(false);
@@ -647,7 +641,7 @@ void Nextion::process_nextion_commands_() {
       }
       case 0x88:  // system successful start up
       {
-        ESP_LOGD(TAG, "system successful start up %zu", to_process_length);
+        ESP_LOGD(TAG, "System start: %zu", to_process_length);
         this->nextion_reports_is_setup_ = true;
         break;
       }
@@ -666,17 +660,15 @@ void Nextion::process_nextion_commands_() {
         // Get variable name
         auto index = to_process.find('\0');
         if (index == std::string::npos || (to_process_length - index - 1) < 1) {
-          ESP_LOGE(TAG, "Bad switch component data received for 0x90 event!");
-          ESP_LOGN(TAG, "to_process %s %zu %d", to_process.c_str(), to_process_length, index);
+          ESP_LOGE(TAG, "Bad switch data (0x90)");
+          ESP_LOGN(TAG, "proc: %s %zu %d", to_process.c_str(), to_process_length, index);
           break;
         }
 
         variable_name = to_process.substr(0, index);
         ++index;
 
-        ESP_LOGN(TAG, "Got Switch:");
-        ESP_LOGN(TAG, "  variable_name: %s", variable_name.c_str());
-        ESP_LOGN(TAG, "  value:         %d", to_process[0] != 0);
+        ESP_LOGN(TAG, "Switch %s: %s", ONOFF(to_process[index] != 0), variable_name.c_str());
 
         for (auto *switchtype : this->switchtype_) {
           switchtype->process_bool(variable_name, to_process[index] != 0);
@@ -694,8 +686,8 @@ void Nextion::process_nextion_commands_() {
 
         auto index = to_process.find('\0');
         if (index == std::string::npos || (to_process_length - index - 1) != 4) {
-          ESP_LOGE(TAG, "Bad sensor component data received for 0x91 event!");
-          ESP_LOGN(TAG, "to_process %s %zu %d", to_process.c_str(), to_process_length, index);
+          ESP_LOGE(TAG, "Bad sensor data (0x91)");
+          ESP_LOGN(TAG, "proc: %s %zu %d", to_process.c_str(), to_process_length, index);
           break;
         }
 
@@ -707,9 +699,7 @@ void Nextion::process_nextion_commands_() {
           value += to_process[i + index + 1] << (8 * i);
         }
 
-        ESP_LOGN(TAG, "Got sensor:");
-        ESP_LOGN(TAG, "  variable_name: %s", variable_name.c_str());
-        ESP_LOGN(TAG, "  value:         %d", value);
+        ESP_LOGN(TAG, "Sensor: %s=%d", variable_name.c_str(), value);
 
         for (auto *sensor : this->sensortype_) {
           sensor->process_sensor(variable_name, value);
@@ -731,8 +721,8 @@ void Nextion::process_nextion_commands_() {
         // Get variable name
         auto index = to_process.find('\0');
         if (index == std::string::npos || (to_process_length - index - 1) < 1) {
-          ESP_LOGE(TAG, "Bad text sensor component data received for 0x92 event!");
-          ESP_LOGN(TAG, "to_process %s %zu %d", to_process.c_str(), to_process_length, index);
+          ESP_LOGE(TAG, "Bad text data (0x92)");
+          ESP_LOGN(TAG, "proc: %s %zu %d", to_process.c_str(), to_process_length, index);
           break;
         }
 
@@ -741,9 +731,7 @@ void Nextion::process_nextion_commands_() {
 
         text_value = to_process.substr(index);
 
-        ESP_LOGN(TAG, "Got Text Sensor:");
-        ESP_LOGN(TAG, "  variable_name: %s", variable_name.c_str());
-        ESP_LOGN(TAG, "  value:         %s", text_value.c_str());
+        ESP_LOGN(TAG, "Text sensor: %s='%s'", variable_name.c_str(), text_value.c_str());
 
         // NextionTextSensorResponseQueue *nq = new NextionTextSensorResponseQueue;
         // nq->variable_name = variable_name;
@@ -766,17 +754,15 @@ void Nextion::process_nextion_commands_() {
         // Get variable name
         auto index = to_process.find('\0');
         if (index == std::string::npos || (to_process_length - index - 1) < 1) {
-          ESP_LOGE(TAG, "Bad binary sensor component data received for 0x92 event!");
-          ESP_LOGN(TAG, "to_process %s %zu %d", to_process.c_str(), to_process_length, index);
+          ESP_LOGE(TAG, "Bad binary data (0x92)");
+          ESP_LOGN(TAG, "proc: %s %zu %d", to_process.c_str(), to_process_length, index);
           break;
         }
 
         variable_name = to_process.substr(0, index);
         ++index;
 
-        ESP_LOGN(TAG, "Got Binary Sensor:");
-        ESP_LOGN(TAG, "  variable_name: %s", variable_name.c_str());
-        ESP_LOGN(TAG, "  value:         %d", to_process[index] != 0);
+        ESP_LOGN(TAG, "Binary sensor: %s=%s", variable_name.c_str(), ONOFF(to_process[index] != 0));
 
         for (auto *binarysensortype : this->binarysensortype_) {
           binarysensortype->process_bool(&variable_name[0], to_process[index] != 0);
@@ -784,14 +770,14 @@ void Nextion::process_nextion_commands_() {
         break;
       }
       case 0xFD: {  // data transparent transmit finished
-        ESP_LOGVV(TAG, "Nextion reported data transmit finished!");
+        ESP_LOGVV(TAG, "Data transmit done");
         this->check_pending_waveform_();
         break;
       }
       case 0xFE: {  // data transparent transmit ready
-        ESP_LOGVV(TAG, "Nextion reported ready for transmit!");
+        ESP_LOGVV(TAG, "Ready for transmit");
         if (this->waveform_queue_.empty()) {
-          ESP_LOGE(TAG, "No waveforms in queue to send data!");
+          ESP_LOGE(TAG, "No waveforms queued");
           break;
         }
 
@@ -802,7 +788,7 @@ void Nextion::process_nextion_commands_() {
 
         this->write_array(component->get_wave_buffer().data(), static_cast<int>(buffer_to_send));
 
-        ESP_LOGN(TAG, "Nextion sending waveform data for component id %d and waveform id %d, size %zu",
+        ESP_LOGN(TAG, "Send waveform: component id %d, waveform id %d, size %zu",
                  component->get_component_id(), component->get_wave_channel_id(), buffer_to_send);
 
         component->clear_wave_buffer(buffer_to_send);
@@ -811,7 +797,7 @@ void Nextion::process_nextion_commands_() {
         break;
       }
       default:
-        ESP_LOGW(TAG, "Received unknown event from nextion: 0x%02X", this->nextion_event_);
+        ESP_LOGW(TAG, "Unknown event: 0x%02X", this->nextion_event_);
         break;
     }
 
@@ -828,7 +814,7 @@ void Nextion::process_nextion_commands_() {
       NextionComponentBase *component = this->nextion_queue_[i]->component;
       if (this->nextion_queue_[i]->queue_time + this->max_q_age_ms_ < ms) {
         if (this->nextion_queue_[i]->queue_time == 0) {
-          ESP_LOGD(TAG, "Removing old queue type \"%s\" name \"%s\" queue_time 0",
+          ESP_LOGD(TAG, "Remove old queue '%s':'%s' (t=0)",
                    component->get_queue_type_string().c_str(), component->get_variable_name().c_str());
         }
 
@@ -836,7 +822,7 @@ void Nextion::process_nextion_commands_() {
           this->is_sleeping_ = false;
         }
 
-        ESP_LOGD(TAG, "Removing old queue type \"%s\" name \"%s\"", component->get_queue_type_string().c_str(),
+        ESP_LOGD(TAG, "Remove old queue '%s':'%s'", component->get_queue_type_string().c_str(),
                  component->get_variable_name().c_str());
 
         if (component->get_queue_type() == NextionQueueType::NO_RESULT) {
@@ -856,7 +842,7 @@ void Nextion::process_nextion_commands_() {
       }
     }
   }
-  ESP_LOGN(TAG, "Loop End");
+  ESP_LOGN(TAG, "Loop end");
   // App.feed_wdt(); Remove before master merge
   this->process_serial_();
 }  // namespace nextion
@@ -866,10 +852,7 @@ void Nextion::set_nextion_sensor_state(int queue_type, const std::string &name, 
 }
 
 void Nextion::set_nextion_sensor_state(NextionQueueType queue_type, const std::string &name, float state) {
-  ESP_LOGN(TAG, "Received state:");
-  ESP_LOGN(TAG, "  variable:   %s", name.c_str());
-  ESP_LOGN(TAG, "  state:      %lf", state);
-  ESP_LOGN(TAG, "  queue type: %d", queue_type);
+  ESP_LOGN(TAG, "State: %s=%lf (type %d)", name.c_str(), state, queue_type);
 
   switch (queue_type) {
     case NextionQueueType::SENSOR: {
@@ -900,15 +883,13 @@ void Nextion::set_nextion_sensor_state(NextionQueueType queue_type, const std::s
       break;
     }
     default: {
-      ESP_LOGW(TAG, "set_nextion_sensor_state does not support a queue type %d", queue_type);
+      ESP_LOGW(TAG, "set_sensor_state: bad type %d", queue_type);
     }
   }
 }
 
 void Nextion::set_nextion_text_state(const std::string &name, const std::string &state) {
-  ESP_LOGD(TAG, "Received state:");
-  ESP_LOGD(TAG, "  variable: %s", name.c_str());
-  ESP_LOGD(TAG, "  state:    %s", state.c_str());
+  ESP_LOGD(TAG, "State: %s='%s'", name.c_str(), state.c_str());
 
   for (auto *sensor : this->textsensortype_) {
     if (name == sensor->get_variable_name()) {
@@ -919,7 +900,7 @@ void Nextion::set_nextion_text_state(const std::string &name, const std::string 
 }
 
 void Nextion::all_components_send_state_(bool force_update) {
-  ESP_LOGD(TAG, "all_components_send_state_ ");
+  ESP_LOGD(TAG, "Send states");
   for (auto *binarysensortype : this->binarysensortype_) {
     if (force_update || binarysensortype->get_needs_to_send_update())
       binarysensortype->send_state_to_nextion();
@@ -1019,7 +1000,7 @@ uint16_t Nextion::recv_ret_string_(std::string &response, uint32_t timeout, bool
 void Nextion::add_no_result_to_queue_(const std::string &variable_name) {
 #ifdef USE_NEXTION_MAX_QUEUE_SIZE
   if (this->max_queue_size_ > 0 && this->nextion_queue_.size() >= this->max_queue_size_) {
-    ESP_LOGW(TAG, "Nextion queue full (%zu entries), dropping NORESULT command: %s", this->nextion_queue_.size(),
+    ESP_LOGW(TAG, "Queue full (%zu), drop: %s", this->nextion_queue_.size(),
              variable_name.c_str());
     return;
   }
@@ -1028,7 +1009,7 @@ void Nextion::add_no_result_to_queue_(const std::string &variable_name) {
   ExternalRAMAllocator<nextion::NextionQueue> allocator(ExternalRAMAllocator<nextion::NextionQueue>::ALLOW_FAILURE);
   nextion::NextionQueue *nextion_queue = allocator.allocate(1);
   if (nextion_queue == nullptr) {
-    ESP_LOGW(TAG, "Failed to allocate NextionQueue");
+    ESP_LOGW(TAG, "Queue alloc failed");
     return;
   }
   new (nextion_queue) nextion::NextionQueue();
@@ -1041,7 +1022,7 @@ void Nextion::add_no_result_to_queue_(const std::string &variable_name) {
 
   this->nextion_queue_.push_back(nextion_queue);
 
-  ESP_LOGN(TAG, "Add to queue type: NORESULT component %s", nextion_queue->component->get_variable_name().c_str());
+  ESP_LOGN(TAG, "Queue NORESULT: %s", nextion_queue->component->get_variable_name().c_str());
 }
 
 /**
@@ -1070,7 +1051,7 @@ bool Nextion::add_no_result_to_queue_with_ignore_sleep_printf_(const std::string
   int ret = vsnprintf(buffer, sizeof(buffer), format, arg);
   va_end(arg);
   if (ret <= 0) {
-    ESP_LOGW(TAG, "Building command for format '%s' failed!", format);
+    ESP_LOGW(TAG, "Bad cmd format: '%s'", format);
     return false;
   }
 
@@ -1095,7 +1076,7 @@ bool Nextion::add_no_result_to_queue_with_printf_(const std::string &variable_na
   int ret = vsnprintf(buffer, sizeof(buffer), format, arg);
   va_end(arg);
   if (ret <= 0) {
-    ESP_LOGW(TAG, "Building command for format '%s' failed!", format);
+    ESP_LOGW(TAG, "Bad cmd format: '%s'", format);
     return false;
   }
 
@@ -1175,7 +1156,7 @@ void Nextion::add_to_get_queue(NextionComponentBase *component) {
 
 #ifdef USE_NEXTION_MAX_QUEUE_SIZE
   if (this->max_queue_size_ > 0 && this->nextion_queue_.size() >= this->max_queue_size_) {
-    ESP_LOGW(TAG, "Nextion queue full (%zu entries), dropping GET for \"%s\"", this->nextion_queue_.size(),
+    ESP_LOGW(TAG, "Queue full (%zu), drop GET: %s", this->nextion_queue_.size(),
              component->get_variable_name().c_str());
     return;
   }
@@ -1184,7 +1165,7 @@ void Nextion::add_to_get_queue(NextionComponentBase *component) {
   ExternalRAMAllocator<nextion::NextionQueue> allocator(ExternalRAMAllocator<nextion::NextionQueue>::ALLOW_FAILURE);
   nextion::NextionQueue *nextion_queue = allocator.allocate(1);
   if (nextion_queue == nullptr) {
-    ESP_LOGW(TAG, "Failed to allocate NextionQueue");
+    ESP_LOGW(TAG, "Queue alloc failed");
     return;
   }
   new (nextion_queue) nextion::NextionQueue();
@@ -1192,7 +1173,7 @@ void Nextion::add_to_get_queue(NextionComponentBase *component) {
   nextion_queue->component = component;
   nextion_queue->queue_time = millis();
 
-  ESP_LOGN(TAG, "Add to queue type: %s component %s", component->get_queue_type_string().c_str(),
+  ESP_LOGN(TAG, "Queue %s: %s", component->get_queue_type_string().c_str(),
            component->get_variable_name().c_str());
 
   std::string command = "get " + component->get_variable_name_to_send();
@@ -1217,7 +1198,7 @@ void Nextion::add_addt_command_to_queue(NextionComponentBase *component) {
   ExternalRAMAllocator<nextion::NextionQueue> allocator(ExternalRAMAllocator<nextion::NextionQueue>::ALLOW_FAILURE);
   nextion::NextionQueue *nextion_queue = allocator.allocate(1);
   if (nextion_queue == nullptr) {
-    ESP_LOGW(TAG, "Failed to allocate NextionQueue");
+    ESP_LOGW(TAG, "Queue alloc failed");
     return;
   }
   new (nextion_queue) nextion::NextionQueue();
@@ -1249,8 +1230,8 @@ void Nextion::check_pending_waveform_() {
 
 void Nextion::set_writer(const nextion_writer_t &writer) { this->writer_ = writer; }
 
-ESPDEPRECATED("set_wait_for_ack(bool) is deprecated and has no effect", "v1.20")
-void Nextion::set_wait_for_ack(bool wait_for_ack) { ESP_LOGE(TAG, "This command is deprecated"); }
+ESPDEPRECATED("set_wait_for_ack(bool) deprecated, no effect", "v1.20")
+void Nextion::set_wait_for_ack(bool wait_for_ack) { ESP_LOGE(TAG, "Deprecated"); }
 
 bool Nextion::is_updating() { return this->is_updating_; }
 

--- a/esphome/components/nextion/nextion.cpp
+++ b/esphome/components/nextion/nextion.cpp
@@ -446,17 +446,15 @@ void Nextion::process_nextion_commands_() {
         break;
       case 0x12:  // invalid Waveform ID or Channel # was used
         if (this->waveform_queue_.empty()) {
-          ESP_LOGW(TAG,
-                   "Invalid waveform ID %d/ch %d");
+          ESP_LOGW(TAG, "Invalid waveform ID %d/ch %d");
         } else {
           auto &nb = this->waveform_queue_.front();
           NextionComponentBase *component = nb->component;
 
-          ESP_LOGW(TAG, "Invalid waveform ID %d/ch %d",
-                   component->get_component_id(), component->get_wave_channel_id());
+          ESP_LOGW(TAG, "Invalid waveform ID %d/ch %d", component->get_component_id(),
+                   component->get_wave_channel_id());
 
-          ESP_LOGN(TAG, "Remove waveform ID %d/ch %d",
-                   component->get_component_id(), component->get_wave_channel_id());
+          ESP_LOGN(TAG, "Remove waveform ID %d/ch %d", component->get_component_id(), component->get_wave_channel_id());
 
           delete nb;  // NOLINT(cppcoreguidelines-owning-memory)
           this->waveform_queue_.pop_front();
@@ -563,12 +561,10 @@ void Nextion::process_nextion_commands_() {
         NextionComponentBase *component = nb->component;
 
         if (component->get_queue_type() != NextionQueueType::TEXT_SENSOR) {
-          ESP_LOGE(TAG, "String return but '%s' not text sensor",
-                   component->get_variable_name().c_str());
+          ESP_LOGE(TAG, "String return but '%s' not text sensor", component->get_variable_name().c_str());
         } else {
-          ESP_LOGN(TAG, "String resp: '%s' id: %s type: %s", to_process.c_str(),
-                   component->get_variable_name().c_str(), component->get_queue_type_string().c_str());
-          component->set_state_from_string(to_process, true, false);
+          ESP_LOGN(TAG, "String resp: '%s' id: %s type: %s", to_process.c_str(), component->get_variable_name().c_str(),
+                   component->get_queue_type_string().c_str());
         }
 
         delete nb;  // NOLINT(cppcoreguidelines-owning-memory)
@@ -610,12 +606,11 @@ void Nextion::process_nextion_commands_() {
         if (component->get_queue_type() != NextionQueueType::SENSOR &&
             component->get_queue_type() != NextionQueueType::BINARY_SENSOR &&
             component->get_queue_type() != NextionQueueType::SWITCH) {
-          ESP_LOGE(TAG, "Numeric return but '%s' invalid type %d",
-                   component->get_variable_name().c_str(), component->get_queue_type());
+          ESP_LOGE(TAG, "Numeric return but '%s' invalid type %d", component->get_variable_name().c_str(),
+                   component->get_queue_type());
         } else {
-          ESP_LOGN(TAG, "Numeric: %s type %d:%s val %d",
-                   component->get_variable_name().c_str(), component->get_queue_type(),
-                   component->get_queue_type_string().c_str(), value);
+          ESP_LOGN(TAG, "Numeric: %s type %d:%s val %d", component->get_variable_name().c_str(),
+                   component->get_queue_type(), component->get_queue_type_string().c_str(), value);
           component->set_state_from_int(value, true, false);
         }
 
@@ -788,8 +783,8 @@ void Nextion::process_nextion_commands_() {
 
         this->write_array(component->get_wave_buffer().data(), static_cast<int>(buffer_to_send));
 
-        ESP_LOGN(TAG, "Send waveform: component id %d, waveform id %d, size %zu",
-                 component->get_component_id(), component->get_wave_channel_id(), buffer_to_send);
+        ESP_LOGN(TAG, "Send waveform: component id %d, waveform id %d, size %zu", component->get_component_id(),
+                 component->get_wave_channel_id(), buffer_to_send);
 
         component->clear_wave_buffer(buffer_to_send);
         delete nb;  // NOLINT(cppcoreguidelines-owning-memory)
@@ -814,8 +809,8 @@ void Nextion::process_nextion_commands_() {
       NextionComponentBase *component = this->nextion_queue_[i]->component;
       if (this->nextion_queue_[i]->queue_time + this->max_q_age_ms_ < ms) {
         if (this->nextion_queue_[i]->queue_time == 0) {
-          ESP_LOGD(TAG, "Remove old queue '%s':'%s' (t=0)",
-                   component->get_queue_type_string().c_str(), component->get_variable_name().c_str());
+          ESP_LOGD(TAG, "Remove old queue '%s':'%s' (t=0)", component->get_queue_type_string().c_str(),
+                   component->get_variable_name().c_str());
         }
 
         if (component->get_variable_name() == "sleep_wake") {
@@ -1000,8 +995,7 @@ uint16_t Nextion::recv_ret_string_(std::string &response, uint32_t timeout, bool
 void Nextion::add_no_result_to_queue_(const std::string &variable_name) {
 #ifdef USE_NEXTION_MAX_QUEUE_SIZE
   if (this->max_queue_size_ > 0 && this->nextion_queue_.size() >= this->max_queue_size_) {
-    ESP_LOGW(TAG, "Queue full (%zu), drop: %s", this->nextion_queue_.size(),
-             variable_name.c_str());
+    ESP_LOGW(TAG, "Queue full (%zu), drop: %s", this->nextion_queue_.size(), variable_name.c_str());
     return;
   }
 #endif
@@ -1173,8 +1167,7 @@ void Nextion::add_to_get_queue(NextionComponentBase *component) {
   nextion_queue->component = component;
   nextion_queue->queue_time = millis();
 
-  ESP_LOGN(TAG, "Queue %s: %s", component->get_queue_type_string().c_str(),
-           component->get_variable_name().c_str());
+  ESP_LOGN(TAG, "Queue %s: %s", component->get_queue_type_string().c_str(), component->get_variable_name().c_str());
 
   std::string command = "get " + component->get_variable_name_to_send();
 

--- a/esphome/components/nextion/nextion.cpp
+++ b/esphome/components/nextion/nextion.cpp
@@ -446,7 +446,7 @@ void Nextion::process_nextion_commands_() {
         break;
       case 0x12:  // invalid Waveform ID or Channel # was used
         if (this->waveform_queue_.empty()) {
-          ESP_LOGW(TAG, "Invalid waveform ID %d/ch %d");
+          ESP_LOGW(TAG, "Waveform ID/ch used but no sensor queued");
         } else {
           auto &nb = this->waveform_queue_.front();
           NextionComponentBase *component = nb->component;

--- a/esphome/components/nextion/nextion_commands.cpp
+++ b/esphome/components/nextion/nextion_commands.cpp
@@ -17,7 +17,7 @@ void Nextion::set_wake_up_page(uint8_t wake_up_page) {
 
 void Nextion::set_touch_sleep_timeout(uint32_t touch_sleep_timeout) {
   if (touch_sleep_timeout < 3) {
-    ESP_LOGD(TAG, "Sleep timeout out of bounds, range 3-65535");
+    ESP_LOGD(TAG, "Sleep timeout out of bounds (3-65535)");
     return;
   }
 
@@ -37,7 +37,7 @@ void Nextion::sleep(bool sleep) {
 
 // Protocol reparse mode
 bool Nextion::set_protocol_reparse_mode(bool active_mode) {
-  ESP_LOGV(TAG, "Set Nextion protocol reparse mode: %s", YESNO(active_mode));
+  ESP_LOGV(TAG, "Reparse mode: %s", YESNO(active_mode));
   this->ignore_is_setup_ = true;  // if not in reparse mode setup will fail, so it should be ignored
   bool all_commands_sent = true;
   if (active_mode) {  // Sets active protocol reparse mode
@@ -184,7 +184,7 @@ void Nextion::goto_page(uint8_t page) { this->add_no_result_to_queue_with_printf
 
 void Nextion::set_backlight_brightness(float brightness) {
   if (brightness < 0 || brightness > 1.0) {
-    ESP_LOGD(TAG, "Brightness out of bounds, percentage range 0-1.0");
+    ESP_LOGD(TAG, "Brightness out of bounds (0-1.0)");
     return;
   }
   this->add_no_result_to_queue_with_printf_("backlight_brightness", "dim=%d", static_cast<int>(brightness * 100));

--- a/esphome/components/nextion/nextion_upload_arduino.cpp
+++ b/esphome/components/nextion/nextion_upload_arduino.cpp
@@ -31,7 +31,7 @@ inline uint32_t Nextion::get_free_heap_() {
 
 int Nextion::upload_by_chunks_(HTTPClient &http_client, uint32_t &range_start) {
   uint32_t range_size = this->tft_size_ - range_start;
-  ESP_LOGV(TAG, "Free heap: %" PRIu32, this->get_free_heap_());
+  ESP_LOGV(TAG, "Heap: %" PRIu32, this->get_free_heap_());
   uint32_t range_end = ((upload_first_chunk_sent_ or this->tft_size_ < 4096) ? this->tft_size_ : 4096) - 1;
   ESP_LOGD(TAG, "Range start: %" PRIu32, range_start);
   if (range_size <= 0 or range_end <= range_start) {
@@ -43,11 +43,11 @@ int Nextion::upload_by_chunks_(HTTPClient &http_client, uint32_t &range_start) {
 
   char range_header[32];
   sprintf(range_header, "bytes=%" PRIu32 "-%" PRIu32, range_start, range_end);
-  ESP_LOGV(TAG, "Requesting range: %s", range_header);
+  ESP_LOGV(TAG, "Range: %s", range_header);
   http_client.addHeader("Range", range_header);
   int code = http_client.GET();
   if (code != HTTP_CODE_OK and code != HTTP_CODE_PARTIAL_CONTENT) {
-    ESP_LOGW(TAG, "HTTP Request failed; Error: %s", HTTPClient::errorToString(code).c_str());
+    ESP_LOGW(TAG, "HTTP failed: %s", HTTPClient::errorToString(code).c_str());
     return -1;
   }
 
@@ -55,7 +55,7 @@ int Nextion::upload_by_chunks_(HTTPClient &http_client, uint32_t &range_start) {
   ExternalRAMAllocator<uint8_t> allocator(ExternalRAMAllocator<uint8_t>::ALLOW_FAILURE);
   uint8_t *buffer = allocator.allocate(4096);
   if (!buffer) {
-    ESP_LOGE(TAG, "Failed to allocate upload buffer");
+    ESP_LOGE(TAG, "Buffer alloc failed");
     return -1;
   }
 
@@ -64,7 +64,7 @@ int Nextion::upload_by_chunks_(HTTPClient &http_client, uint32_t &range_start) {
     App.feed_wdt();
     const uint16_t buffer_size =
         this->content_length_ < 4096 ? this->content_length_ : 4096;  // Limits buffer to the remaining data
-    ESP_LOGV(TAG, "Fetching %" PRIu16 " bytes from HTTP", buffer_size);
+    ESP_LOGV(TAG, "Fetch %" PRIu16 " bytes", buffer_size);
     uint16_t read_len = 0;
     int partial_read_len = 0;
     const uint32_t start_time = millis();
@@ -81,14 +81,13 @@ int Nextion::upload_by_chunks_(HTTPClient &http_client, uint32_t &range_start) {
     }
     if (read_len != buffer_size) {
       // Did not receive the full package within the timeout period
-      ESP_LOGE(TAG, "Failed to read full package, received only %" PRIu16 " of %" PRIu16 " bytes", read_len,
-               buffer_size);
+      ESP_LOGE(TAG, "Read failed: %" PRIu16 "/%" PRIu16 " bytes", read_len, buffer_size);
       // Deallocate buffer
       allocator.deallocate(buffer, 4096);
       buffer = nullptr;
       return -1;
     }
-    ESP_LOGV(TAG, "%d bytes fetched, writing it to UART", read_len);
+    ESP_LOGV(TAG, "Fetched %d bytes", read_len);
     if (read_len > 0) {
       recv_string.clear();
       this->write_array(buffer, buffer_size);
@@ -99,23 +98,23 @@ int Nextion::upload_by_chunks_(HTTPClient &http_client, uint32_t &range_start) {
 #if defined(USE_ESP32) && defined(USE_PSRAM)
       ESP_LOGD(
           TAG,
-          "Uploaded %0.2f%%, remaining %" PRIu32 " bytes, free heap: %" PRIu32 " (DRAM) + %" PRIu32 " (PSRAM) bytes",
+          "Upload: %0.2f%% (%" PRIu32 " left, heap: %" PRIu32 "+%" PRIu32 ")",
           upload_percentage, this->content_length_, static_cast<uint32_t>(heap_caps_get_free_size(MALLOC_CAP_INTERNAL)),
           static_cast<uint32_t>(heap_caps_get_free_size(MALLOC_CAP_SPIRAM)));
 #else
-      ESP_LOGD(TAG, "Uploaded %0.2f%%, remaining %" PRIu32 " bytes, free heap: %" PRIu32 " bytes", upload_percentage,
-               this->content_length_, this->get_free_heap_());
+      ESP_LOGD(TAG, "Upload: %0.2f%% (%" PRIu32 " left, heap: %" PRIu32 ")", upload_percentage, this->content_length_,
+               this->get_free_heap_());
 #endif
       upload_first_chunk_sent_ = true;
       if (recv_string[0] == 0x08 && recv_string.size() == 5) {  // handle partial upload request
-        ESP_LOGD(TAG, "recv_string [%s]",
-                 format_hex_pretty(reinterpret_cast<const uint8_t *>(recv_string.data()), recv_string.size()).c_str());
+        ESP_LOGD(TAG, "Recv: [%s]", format_hex_pretty(reinterpret_cast<const uint8_t *>(recv_string.data()),
+                 recv_string.size()).c_str());
         uint32_t result = 0;
         for (int j = 0; j < 4; ++j) {
           result += static_cast<uint8_t>(recv_string[j + 1]) << (8 * j);
         }
         if (result > 0) {
-          ESP_LOGI(TAG, "Nextion reported new range %" PRIu32, result);
+          ESP_LOGI(TAG, "New range: %" PRIu32, result);
           this->content_length_ = this->tft_size_ - result;
           range_start = result;
         } else {
@@ -126,8 +125,8 @@ int Nextion::upload_by_chunks_(HTTPClient &http_client, uint32_t &range_start) {
         buffer = nullptr;
         return range_end + 1;
       } else if (recv_string[0] != 0x05 and recv_string[0] != 0x08) {  // 0x05 == "ok"
-        ESP_LOGE(TAG, "Invalid response from Nextion: [%s]",
-                 format_hex_pretty(reinterpret_cast<const uint8_t *>(recv_string.data()), recv_string.size()).c_str());
+        ESP_LOGE(TAG, "Invalid response: [%s]", format_hex_pretty(reinterpret_cast<const uint8_t *>(recv_string.data()),
+                 recv_string.size()).c_str());
         // Deallocate buffer
         allocator.deallocate(buffer, 4096);
         buffer = nullptr;
@@ -136,10 +135,10 @@ int Nextion::upload_by_chunks_(HTTPClient &http_client, uint32_t &range_start) {
 
       recv_string.clear();
     } else if (read_len == 0) {
-      ESP_LOGV(TAG, "End of HTTP response reached");
+      ESP_LOGV(TAG, "HTTP end");
       break;  // Exit the loop if there is no more data to read
     } else {
-      ESP_LOGE(TAG, "Failed to read from HTTP client, error code: %d", read_len);
+      ESP_LOGE(TAG, "HTTP read failed: %d", read_len);
       break;  // Exit the loop on error
     }
   }
@@ -151,26 +150,26 @@ int Nextion::upload_by_chunks_(HTTPClient &http_client, uint32_t &range_start) {
 }
 
 bool Nextion::upload_tft(uint32_t baud_rate, bool exit_reparse) {
-  ESP_LOGD(TAG, "Nextion TFT upload requested");
+  ESP_LOGD(TAG, "TFT upload requested");
   ESP_LOGD(TAG, "Exit reparse: %s", YESNO(exit_reparse));
   ESP_LOGD(TAG, "URL: %s", this->tft_url_.c_str());
 
   if (this->is_updating_) {
-    ESP_LOGW(TAG, "Currently uploading");
+    ESP_LOGW(TAG, "Upload in progress");
     return false;
   }
 
   if (!network::is_connected()) {
-    ESP_LOGE(TAG, "Network is not connected");
+    ESP_LOGE(TAG, "No network");
     return false;
   }
 
   this->is_updating_ = true;
 
   if (exit_reparse) {
-    ESP_LOGD(TAG, "Exiting Nextion reparse mode");
+    ESP_LOGD(TAG, "Exit reparse mode");
     if (!this->set_protocol_reparse_mode(false)) {
-      ESP_LOGW(TAG, "Failed to request Nextion to exit reparse mode");
+      ESP_LOGW(TAG, "Exit reparse failed");
       return false;
     }
   }
@@ -185,8 +184,8 @@ bool Nextion::upload_tft(uint32_t baud_rate, bool exit_reparse) {
   ESP_LOGD(TAG, "Baud rate: %" PRIu32, baud_rate);
 
   // Define the configuration for the HTTP client
-  ESP_LOGV(TAG, "Initializing HTTP client");
-  ESP_LOGV(TAG, "Free heap: %" PRIu32, this->get_free_heap_());
+  ESP_LOGV(TAG, "Init HTTP client");
+  ESP_LOGV(TAG, "Heap: %" PRIu32, this->get_free_heap_());
   HTTPClient http_client;
   http_client.setTimeout(15000);  // Yes 15 seconds.... Helps 8266s along
 
@@ -215,7 +214,7 @@ bool Nextion::upload_tft(uint32_t baud_rate, bool exit_reparse) {
   http_client.addHeader("Range", "bytes=0-255");
   const char *header_names[] = {"Content-Range"};
   http_client.collectHeaders(header_names, 1);
-  ESP_LOGD(TAG, "Requesting URL: %s", this->tft_url_.c_str());
+  ESP_LOGD(TAG, "URL: %s", this->tft_url_.c_str());
   http_client.setReuse(true);
   // try up to 5 times. DNS sometimes needs a second try or so
   int tries = 1;
@@ -224,7 +223,7 @@ bool Nextion::upload_tft(uint32_t baud_rate, bool exit_reparse) {
 
   App.feed_wdt();
   while (code != 200 && code != 206 && tries <= 5) {
-    ESP_LOGW(TAG, "HTTP Request failed; URL: %s; Error: %s, retrying (%d/5)", this->tft_url_.c_str(),
+    ESP_LOGW(TAG, "HTTP fail: URL: %s; Error: %s, retry %d/5", this->tft_url_.c_str(),
              HTTPClient::errorToString(code).c_str(), tries);
 
     delay(250);  // NOLINT
@@ -241,27 +240,27 @@ bool Nextion::upload_tft(uint32_t baud_rate, bool exit_reparse) {
   content_range_string.remove(0, 12);
   this->tft_size_ = content_range_string.toInt();
 
-  ESP_LOGD(TAG, "TFT file size: %zu bytes", this->tft_size_);
+  ESP_LOGD(TAG, "TFT size: %zu bytes", this->tft_size_);
   if (this->tft_size_ < 4096) {
-    ESP_LOGE(TAG, "File size check failed.");
-    ESP_LOGD(TAG, "Close HTTP connection");
+    ESP_LOGE(TAG, "Size check failed");
+    ESP_LOGD(TAG, "Close HTTP");
     http_client.end();
     ESP_LOGV(TAG, "Connection closed");
     return this->upload_end_(false);
   } else {
-    ESP_LOGV(TAG, "File size check passed. Proceeding");
+    ESP_LOGV(TAG, "Size check OK");
   }
   this->content_length_ = this->tft_size_;
 
-  ESP_LOGD(TAG, "Uploading Nextion");
+  ESP_LOGD(TAG, "Uploading");
 
   // The Nextion will ignore the upload command if it is sleeping
-  ESP_LOGV(TAG, "Wake-up Nextion");
+  ESP_LOGV(TAG, "Wake-up");
   this->ignore_is_setup_ = true;
   this->send_command_("sleep=0");
   this->send_command_("dim=100");
   delay(250);  // NOLINT
-  ESP_LOGV(TAG, "Free heap: %" PRIu32, this->get_free_heap_());
+  ESP_LOGV(TAG, "Heap: %" PRIu32, this->get_free_heap_());
 
   App.feed_wdt();
   char command[128];
@@ -271,16 +270,16 @@ bool Nextion::upload_tft(uint32_t baud_rate, bool exit_reparse) {
   sprintf(command, "whmi-wris %d,%d,1", this->content_length_, baud_rate);
 
   // Clear serial receive buffer
-  ESP_LOGV(TAG, "Clear serial receive buffer");
+  ESP_LOGV(TAG, "Clear RX buffer");
   this->reset_(false);
   delay(250);  // NOLINT
-  ESP_LOGV(TAG, "Free heap: %" PRIu32, this->get_free_heap_());
+  ESP_LOGV(TAG, "Heap: %" PRIu32, this->get_free_heap_());
 
-  ESP_LOGV(TAG, "Send upload instruction: %s", command);
+  ESP_LOGV(TAG, "Upload cmd: %s", command);
   this->send_command_(command);
 
   if (baud_rate != this->original_baud_rate_) {
-    ESP_LOGD(TAG, "Changing baud rate from %" PRIu32 " to %" PRIu32 " bps", this->original_baud_rate_, baud_rate);
+    ESP_LOGD(TAG, "Baud: %" PRIu32 "->%" PRIu32, this->original_baud_rate_, baud_rate);
     this->parent_->set_baud_rate(baud_rate);
     this->parent_->load_settings();
   }
@@ -288,74 +287,74 @@ bool Nextion::upload_tft(uint32_t baud_rate, bool exit_reparse) {
   App.feed_wdt();
 
   std::string response;
-  ESP_LOGV(TAG, "Waiting for upgrade response");
+  ESP_LOGV(TAG, "Wait upload resp");
   this->recv_ret_string_(response, 5000, true);  // This can take some time to return
 
   // The Nextion display will, if it's ready to accept data, send a 0x05 byte.
-  ESP_LOGD(TAG, "Upgrade response is [%s] - %zu byte(s)",
+  ESP_LOGD(TAG, "Upload resp: [%s] %zu B",
            format_hex_pretty(reinterpret_cast<const uint8_t *>(response.data()), response.size()).c_str(),
            response.length());
-  ESP_LOGV(TAG, "Free heap: %" PRIu32, this->get_free_heap_());
+  ESP_LOGV(TAG, "Heap: %" PRIu32, this->get_free_heap_());
 
   if (response.find(0x05) != std::string::npos) {
-    ESP_LOGV(TAG, "Preparation for TFT upload done");
+    ESP_LOGV(TAG, "Upload prep done");
   } else {
-    ESP_LOGE(TAG, "Preparation for TFT upload failed %d \"%s\"", response[0], response.c_str());
-    ESP_LOGD(TAG, "Close HTTP connection");
+    ESP_LOGE(TAG, "Prep failed %d '%s'", response[0], response.c_str());
+    ESP_LOGD(TAG, "Close HTTP");
     http_client.end();
     ESP_LOGV(TAG, "Connection closed");
     return this->upload_end_(false);
   }
 
-  ESP_LOGD(TAG, "Uploading TFT to Nextion:");
-  ESP_LOGD(TAG, "  URL: %s", this->tft_url_.c_str());
-  ESP_LOGD(TAG, "  File size: %d bytes", this->content_length_);
-  ESP_LOGD(TAG, "  Free heap: %" PRIu32, this->get_free_heap_());
+  ESP_LOGD(TAG, "Upload TFT:");
+  ESP_LOGD(TAG, "  URL:  %s", this->tft_url_.c_str());
+  ESP_LOGD(TAG, "  Size: %d bytes", this->content_length_);
+  ESP_LOGD(TAG, "  Heap: %" PRIu32, this->get_free_heap_());
 
   // Proceed with the content download as before
 
-  ESP_LOGV(TAG, "Starting transfer by chunks loop");
+  ESP_LOGV(TAG, "Start chunk transfer");
 
   uint32_t position = 0;
   while (this->content_length_ > 0) {
     int upload_result = upload_by_chunks_(http_client, position);
     if (upload_result < 0) {
-      ESP_LOGE(TAG, "Error uploading TFT to Nextion!");
-      ESP_LOGD(TAG, "Close HTTP connection");
+      ESP_LOGE(TAG, "Upload error");
+      ESP_LOGD(TAG, "Close HTTP");
       http_client.end();
       ESP_LOGV(TAG, "Connection closed");
       return this->upload_end_(false);
     }
     App.feed_wdt();
-    ESP_LOGV(TAG, "Free heap: %" PRIu32 ", Bytes left: %" PRIu32, this->get_free_heap_(), this->content_length_);
+    ESP_LOGV(TAG, "Heap: %" PRIu32 " left: %" PRIu32, this->get_free_heap_(), this->content_length_);
   }
 
-  ESP_LOGD(TAG, "Successfully uploaded TFT to Nextion!");
+  ESP_LOGD(TAG, "Upload complete");
 
-  ESP_LOGD(TAG, "Close HTTP connection");
+  ESP_LOGV(TAG, "Close HTTP");
   http_client.end();
   ESP_LOGV(TAG, "Connection closed");
   return upload_end_(true);
 }
 
 bool Nextion::upload_end_(bool successful) {
-  ESP_LOGD(TAG, "Nextion TFT upload finished: %s", YESNO(successful));
+  ESP_LOGD(TAG, "TFT upload done: %s", YESNO(successful));
   this->is_updating_ = false;
   this->ignore_is_setup_ = false;
 
   uint32_t baud_rate = this->parent_->get_baud_rate();
   if (baud_rate != this->original_baud_rate_) {
-    ESP_LOGD(TAG, "Changing baud rate back from %" PRIu32 " to %" PRIu32 " bps", baud_rate, this->original_baud_rate_);
+    ESP_LOGD(TAG, "Baud back: %" PRIu32 "->%" PRIu32, baud_rate, this->original_baud_rate_);
     this->parent_->set_baud_rate(this->original_baud_rate_);
     this->parent_->load_settings();
   }
 
   if (successful) {
-    ESP_LOGD(TAG, "Restarting ESPHome");
+    ESP_LOGD(TAG, "Restart");
     delay(1500);  // NOLINT
     App.safe_reboot();
   } else {
-    ESP_LOGE(TAG, "Nextion TFT upload failed");
+    ESP_LOGE(TAG, "TFT upload failed");
   }
   return successful;
 }

--- a/esphome/components/nextion/nextion_upload_arduino.cpp
+++ b/esphome/components/nextion/nextion_upload_arduino.cpp
@@ -96,19 +96,17 @@ int Nextion::upload_by_chunks_(HTTPClient &http_client, uint32_t &range_start) {
       this->content_length_ -= read_len;
       const float upload_percentage = 100.0f * (this->tft_size_ - this->content_length_) / this->tft_size_;
 #if defined(USE_ESP32) && defined(USE_PSRAM)
-      ESP_LOGD(
-          TAG,
-          "Upload: %0.2f%% (%" PRIu32 " left, heap: %" PRIu32 "+%" PRIu32 ")",
-          upload_percentage, this->content_length_, static_cast<uint32_t>(heap_caps_get_free_size(MALLOC_CAP_INTERNAL)),
-          static_cast<uint32_t>(heap_caps_get_free_size(MALLOC_CAP_SPIRAM)));
+      ESP_LOGD(TAG, "Upload: %0.2f%% (%" PRIu32 " left, heap: %" PRIu32 "+%" PRIu32 ")", upload_percentage,
+               this->content_length_, static_cast<uint32_t>(heap_caps_get_free_size(MALLOC_CAP_INTERNAL)),
+               static_cast<uint32_t>(heap_caps_get_free_size(MALLOC_CAP_SPIRAM)));
 #else
       ESP_LOGD(TAG, "Upload: %0.2f%% (%" PRIu32 " left, heap: %" PRIu32 ")", upload_percentage, this->content_length_,
                this->get_free_heap_());
 #endif
       upload_first_chunk_sent_ = true;
       if (recv_string[0] == 0x08 && recv_string.size() == 5) {  // handle partial upload request
-        ESP_LOGD(TAG, "Recv: [%s]", format_hex_pretty(reinterpret_cast<const uint8_t *>(recv_string.data()),
-                 recv_string.size()).c_str());
+        ESP_LOGD(TAG, "Recv: [%s]",
+                 format_hex_pretty(reinterpret_cast<const uint8_t *>(recv_string.data()), recv_string.size()).c_str());
         uint32_t result = 0;
         for (int j = 0; j < 4; ++j) {
           result += static_cast<uint8_t>(recv_string[j + 1]) << (8 * j);
@@ -125,8 +123,8 @@ int Nextion::upload_by_chunks_(HTTPClient &http_client, uint32_t &range_start) {
         buffer = nullptr;
         return range_end + 1;
       } else if (recv_string[0] != 0x05 and recv_string[0] != 0x08) {  // 0x05 == "ok"
-        ESP_LOGE(TAG, "Invalid response: [%s]", format_hex_pretty(reinterpret_cast<const uint8_t *>(recv_string.data()),
-                 recv_string.size()).c_str());
+        ESP_LOGE(TAG, "Invalid response: [%s]",
+                 format_hex_pretty(reinterpret_cast<const uint8_t *>(recv_string.data()), recv_string.size()).c_str());
         // Deallocate buffer
         allocator.deallocate(buffer, 4096);
         buffer = nullptr;

--- a/esphome/components/nextion/nextion_upload_idf.cpp
+++ b/esphome/components/nextion/nextion_upload_idf.cpp
@@ -99,14 +99,12 @@ int Nextion::upload_by_chunks_(esp_http_client_handle_t http_client, uint32_t &r
       this->content_length_ -= read_len;
       const float upload_percentage = 100.0f * (this->tft_size_ - this->content_length_) / this->tft_size_;
 #ifdef USE_PSRAM
-      ESP_LOGD(
-          TAG,
-          "Upload: %0.2f%% (%" PRIu32 " left, heap: %" PRIu32 "+%" PRIu32 ")", upload_percentage, this->content_length_,
-          static_cast<uint32_t>(heap_caps_get_free_size(MALLOC_CAP_INTERNAL)),
-          static_cast<uint32_t>(heap_caps_get_free_size(MALLOC_CAP_SPIRAM)));
+      ESP_LOGD(TAG, "Upload: %0.2f%% (%" PRIu32 " left, heap: %" PRIu32 "+%" PRIu32 ")", upload_percentage,
+               this->content_length_, static_cast<uint32_t>(heap_caps_get_free_size(MALLOC_CAP_INTERNAL)),
+               static_cast<uint32_t>(heap_caps_get_free_size(MALLOC_CAP_SPIRAM)));
 #else
-      ESP_LOGD(TAG, "Upload: %0.2f%% (%" PRIu32 " left, heap: %" PRIu32 ")", upload_percentage,
-               this->content_length_, static_cast<uint32_t>(esp_get_free_heap_size()));
+      ESP_LOGD(TAG, "Upload: %0.2f%% (%" PRIu32 " left, heap: %" PRIu32 ")", upload_percentage, this->content_length_,
+               static_cast<uint32_t>(esp_get_free_heap_size()));
 #endif
       upload_first_chunk_sent_ = true;
       if (recv_string[0] == 0x08 && recv_string.size() == 5) {  // handle partial upload request
@@ -128,8 +126,8 @@ int Nextion::upload_by_chunks_(esp_http_client_handle_t http_client, uint32_t &r
         buffer = nullptr;
         return range_end + 1;
       } else if (recv_string[0] != 0x05 and recv_string[0] != 0x08) {  // 0x05 == "ok"
-        ESP_LOGE(TAG, "Invalid response: [%s]", format_hex_pretty(reinterpret_cast<const uint8_t *>(recv_string.data()),
-                 recv_string.size()).c_str());
+        ESP_LOGE(TAG, "Invalid response: [%s]",
+                 format_hex_pretty(reinterpret_cast<const uint8_t *>(recv_string.data()), recv_string.size()).c_str());
         // Deallocate buffer
         allocator.deallocate(buffer, 4096);
         buffer = nullptr;
@@ -281,8 +279,8 @@ bool Nextion::upload_tft(uint32_t baud_rate, bool exit_reparse) {
   this->recv_ret_string_(response, 5000, true);  // This can take some time to return
 
   // The Nextion display will, if it's ready to accept data, send a 0x05 byte.
-  ESP_LOGD(TAG, "Upload resp: [%s] %zu B", format_hex_pretty(reinterpret_cast<const uint8_t *>(response.data()),
-           response.size()).c_str(),
+  ESP_LOGD(TAG, "Upload resp: [%s] %zu B",
+           format_hex_pretty(reinterpret_cast<const uint8_t *>(response.data()), response.size()).c_str(),
            response.length());
   ESP_LOGV(TAG, "Heap: %" PRIu32, esp_get_free_heap_size());
 

--- a/esphome/components/nextion/nextion_upload_idf.cpp
+++ b/esphome/components/nextion/nextion_upload_idf.cpp
@@ -21,7 +21,7 @@ static const char *const TAG = "nextion.upload.idf";
 
 int Nextion::upload_by_chunks_(esp_http_client_handle_t http_client, uint32_t &range_start) {
   uint32_t range_size = this->tft_size_ - range_start;
-  ESP_LOGV(TAG, "Free heap: %" PRIu32, esp_get_free_heap_size());
+  ESP_LOGV(TAG, "Heap: %" PRIu32, esp_get_free_heap_size());
   uint32_t range_end = ((upload_first_chunk_sent_ or this->tft_size_ < 4096) ? this->tft_size_ : 4096) - 1;
   ESP_LOGD(TAG, "Range start: %" PRIu32, range_start);
   if (range_size <= 0 or range_end <= range_start) {
@@ -33,20 +33,20 @@ int Nextion::upload_by_chunks_(esp_http_client_handle_t http_client, uint32_t &r
 
   char range_header[32];
   sprintf(range_header, "bytes=%" PRIu32 "-%" PRIu32, range_start, range_end);
-  ESP_LOGV(TAG, "Requesting range: %s", range_header);
+  ESP_LOGV(TAG, "Range: %s", range_header);
   esp_http_client_set_header(http_client, "Range", range_header);
-  ESP_LOGV(TAG, "Opening HTTP connetion");
+  ESP_LOGV(TAG, "Open HTTP");
   esp_err_t err = esp_http_client_open(http_client, 0);
   if (err != ESP_OK) {
-    ESP_LOGE(TAG, "Failed to open HTTP connection: %s", esp_err_to_name(err));
+    ESP_LOGE(TAG, "HTTP open failed: %s", esp_err_to_name(err));
     return -1;
   }
 
-  ESP_LOGV(TAG, "Fetch content length");
+  ESP_LOGV(TAG, "Fetch length");
   const int chunk_size = esp_http_client_fetch_headers(http_client);
-  ESP_LOGV(TAG, "content_length = %d", chunk_size);
+  ESP_LOGV(TAG, "Length: %d", chunk_size);
   if (chunk_size <= 0) {
-    ESP_LOGE(TAG, "Failed to get chunk's content length: %d", chunk_size);
+    ESP_LOGE(TAG, "Get length failed: %d", chunk_size);
     return -1;
   }
 
@@ -54,7 +54,7 @@ int Nextion::upload_by_chunks_(esp_http_client_handle_t http_client, uint32_t &r
   ExternalRAMAllocator<uint8_t> allocator(ExternalRAMAllocator<uint8_t>::ALLOW_FAILURE);
   uint8_t *buffer = allocator.allocate(4096);
   if (!buffer) {
-    ESP_LOGE(TAG, "Failed to allocate upload buffer");
+    ESP_LOGE(TAG, "Buffer alloc failed");
     return -1;
   }
 
@@ -63,7 +63,7 @@ int Nextion::upload_by_chunks_(esp_http_client_handle_t http_client, uint32_t &r
     App.feed_wdt();
     const uint16_t buffer_size =
         this->content_length_ < 4096 ? this->content_length_ : 4096;  // Limits buffer to the remaining data
-    ESP_LOGV(TAG, "Fetching %" PRIu16 " bytes from HTTP", buffer_size);
+    ESP_LOGV(TAG, "Fetch %" PRIu16 " bytes", buffer_size);
     uint16_t read_len = 0;
     int partial_read_len = 0;
     uint8_t retries = 0;
@@ -84,14 +84,13 @@ int Nextion::upload_by_chunks_(esp_http_client_handle_t http_client, uint32_t &r
     }
     if (read_len != buffer_size) {
       // Did not receive the full package within the timeout period
-      ESP_LOGE(TAG, "Failed to read full package, received only %" PRIu16 " of %" PRIu16 " bytes", read_len,
-               buffer_size);
+      ESP_LOGE(TAG, "Read failed: %" PRIu16 "/%" PRIu16 " bytes", read_len, buffer_size);
       // Deallocate buffer
       allocator.deallocate(buffer, 4096);
       buffer = nullptr;
       return -1;
     }
-    ESP_LOGV(TAG, "%d bytes fetched, writing it to UART", read_len);
+    ESP_LOGV(TAG, "Fetched %d bytes", read_len);
     if (read_len > 0) {
       recv_string.clear();
       this->write_array(buffer, buffer_size);
@@ -102,23 +101,23 @@ int Nextion::upload_by_chunks_(esp_http_client_handle_t http_client, uint32_t &r
 #ifdef USE_PSRAM
       ESP_LOGD(
           TAG,
-          "Uploaded %0.2f%%, remaining %" PRIu32 " bytes, free heap: %" PRIu32 " (DRAM) + %" PRIu32 " (PSRAM) bytes",
-          upload_percentage, this->content_length_, static_cast<uint32_t>(heap_caps_get_free_size(MALLOC_CAP_INTERNAL)),
+          "Upload: %0.2f%% (%" PRIu32 " left, heap: %" PRIu32 "+%" PRIu32 ")", upload_percentage, this->content_length_,
+          static_cast<uint32_t>(heap_caps_get_free_size(MALLOC_CAP_INTERNAL)),
           static_cast<uint32_t>(heap_caps_get_free_size(MALLOC_CAP_SPIRAM)));
 #else
-      ESP_LOGD(TAG, "Uploaded %0.2f%%, remaining %" PRIu32 " bytes, free heap: %" PRIu32 " bytes", upload_percentage,
+      ESP_LOGD(TAG, "Upload: %0.2f%% (%" PRIu32 " left, heap: %" PRIu32 ")", upload_percentage,
                this->content_length_, static_cast<uint32_t>(esp_get_free_heap_size()));
 #endif
       upload_first_chunk_sent_ = true;
       if (recv_string[0] == 0x08 && recv_string.size() == 5) {  // handle partial upload request
-        ESP_LOGD(TAG, "recv_string [%s]",
+        ESP_LOGD(TAG, "Recv: [%s]",
                  format_hex_pretty(reinterpret_cast<const uint8_t *>(recv_string.data()), recv_string.size()).c_str());
         uint32_t result = 0;
         for (int j = 0; j < 4; ++j) {
           result += static_cast<uint8_t>(recv_string[j + 1]) << (8 * j);
         }
         if (result > 0) {
-          ESP_LOGI(TAG, "Nextion reported new range %" PRIu32, result);
+          ESP_LOGI(TAG, "New range: %" PRIu32, result);
           this->content_length_ = this->tft_size_ - result;
           range_start = result;
         } else {
@@ -129,8 +128,8 @@ int Nextion::upload_by_chunks_(esp_http_client_handle_t http_client, uint32_t &r
         buffer = nullptr;
         return range_end + 1;
       } else if (recv_string[0] != 0x05 and recv_string[0] != 0x08) {  // 0x05 == "ok"
-        ESP_LOGE(TAG, "Invalid response from Nextion: [%s]",
-                 format_hex_pretty(reinterpret_cast<const uint8_t *>(recv_string.data()), recv_string.size()).c_str());
+        ESP_LOGE(TAG, "Invalid response: [%s]", format_hex_pretty(reinterpret_cast<const uint8_t *>(recv_string.data()),
+                 recv_string.size()).c_str());
         // Deallocate buffer
         allocator.deallocate(buffer, 4096);
         buffer = nullptr;
@@ -139,10 +138,10 @@ int Nextion::upload_by_chunks_(esp_http_client_handle_t http_client, uint32_t &r
 
       recv_string.clear();
     } else if (read_len == 0) {
-      ESP_LOGV(TAG, "End of HTTP response reached");
+      ESP_LOGV(TAG, "HTTP end");
       break;  // Exit the loop if there is no more data to read
     } else {
-      ESP_LOGE(TAG, "Failed to read from HTTP client, error code: %" PRIu16, read_len);
+      ESP_LOGE(TAG, "HTTP read failed: %" PRIu16, read_len);
       break;  // Exit the loop on error
     }
   }
@@ -154,26 +153,26 @@ int Nextion::upload_by_chunks_(esp_http_client_handle_t http_client, uint32_t &r
 }
 
 bool Nextion::upload_tft(uint32_t baud_rate, bool exit_reparse) {
-  ESP_LOGD(TAG, "Nextion TFT upload requested");
+  ESP_LOGD(TAG, "TFT upload requested");
   ESP_LOGD(TAG, "Exit reparse: %s", YESNO(exit_reparse));
   ESP_LOGD(TAG, "URL: %s", this->tft_url_.c_str());
 
   if (this->is_updating_) {
-    ESP_LOGW(TAG, "Currently uploading");
+    ESP_LOGW(TAG, "Upload in progress");
     return false;
   }
 
   if (!network::is_connected()) {
-    ESP_LOGE(TAG, "Network is not connected");
+    ESP_LOGE(TAG, "No network");
     return false;
   }
 
   this->is_updating_ = true;
 
   if (exit_reparse) {
-    ESP_LOGD(TAG, "Exiting Nextion reparse mode");
+    ESP_LOGD(TAG, "Exit reparse mode");
     if (!this->set_protocol_reparse_mode(false)) {
-      ESP_LOGW(TAG, "Failed to request Nextion to exit reparse mode");
+      ESP_LOGW(TAG, "Exit reparse failed");
       return false;
     }
   }
@@ -188,8 +187,8 @@ bool Nextion::upload_tft(uint32_t baud_rate, bool exit_reparse) {
   ESP_LOGD(TAG, "Baud rate: %" PRIu32, baud_rate);
 
   // Define the configuration for the HTTP client
-  ESP_LOGV(TAG, "Initializing HTTP client");
-  ESP_LOGV(TAG, "Free heap: %" PRIu32, esp_get_free_heap_size());
+  ESP_LOGV(TAG, "Init HTTP client");
+  ESP_LOGV(TAG, "Heap: %" PRIu32, esp_get_free_heap_size());
   esp_http_client_config_t config = {
       .url = this->tft_url_.c_str(),
       .cert_pem = nullptr,
@@ -201,30 +200,30 @@ bool Nextion::upload_tft(uint32_t baud_rate, bool exit_reparse) {
   // Initialize the HTTP client with the configuration
   esp_http_client_handle_t http_client = esp_http_client_init(&config);
   if (!http_client) {
-    ESP_LOGE(TAG, "Failed to initialize HTTP client.");
+    ESP_LOGE(TAG, "HTTP init failed");
     return this->upload_end_(false);
   }
 
   esp_err_t err = esp_http_client_set_header(http_client, "Connection", "keep-alive");
   if (err != ESP_OK) {
-    ESP_LOGE(TAG, "HTTP set header failed: %s", esp_err_to_name(err));
+    ESP_LOGE(TAG, "Set header failed: %s", esp_err_to_name(err));
     esp_http_client_cleanup(http_client);
     return this->upload_end_(false);
   }
 
   // Perform the HTTP request
-  ESP_LOGV(TAG, "Check if the client could connect");
-  ESP_LOGV(TAG, "Free heap: %" PRIu32, esp_get_free_heap_size());
+  ESP_LOGV(TAG, "Check connection");
+  ESP_LOGV(TAG, "Heap: %" PRIu32, esp_get_free_heap_size());
   err = esp_http_client_perform(http_client);
   if (err != ESP_OK) {
-    ESP_LOGE(TAG, "HTTP request failed: %s", esp_err_to_name(err));
+    ESP_LOGE(TAG, "HTTP failed: %s", esp_err_to_name(err));
     esp_http_client_cleanup(http_client);
     return this->upload_end_(false);
   }
 
   // Check the HTTP Status Code
-  ESP_LOGV(TAG, "Check the HTTP Status Code");
-  ESP_LOGV(TAG, "Free heap: %" PRIu32, esp_get_free_heap_size());
+  ESP_LOGV(TAG, "Check status");
+  ESP_LOGV(TAG, "Heap: %" PRIu32, esp_get_free_heap_size());
   int status_code = esp_http_client_get_status_code(http_client);
   if (status_code != 200 && status_code != 206) {
     return this->upload_end_(false);
@@ -232,28 +231,28 @@ bool Nextion::upload_tft(uint32_t baud_rate, bool exit_reparse) {
 
   this->tft_size_ = esp_http_client_get_content_length(http_client);
 
-  ESP_LOGD(TAG, "TFT file size: %zu bytes", this->tft_size_);
+  ESP_LOGD(TAG, "TFT size: %zu bytes", this->tft_size_);
   if (this->tft_size_ < 4096 || this->tft_size_ > 134217728) {
-    ESP_LOGE(TAG, "File size check failed.");
-    ESP_LOGD(TAG, "Close HTTP connection");
+    ESP_LOGE(TAG, "Size check failed");
+    ESP_LOGD(TAG, "Close HTTP");
     esp_http_client_close(http_client);
     esp_http_client_cleanup(http_client);
     ESP_LOGV(TAG, "Connection closed");
     return this->upload_end_(false);
   } else {
-    ESP_LOGV(TAG, "File size check passed. Proceeding");
+    ESP_LOGV(TAG, "Size check OK");
   }
   this->content_length_ = this->tft_size_;
 
-  ESP_LOGD(TAG, "Uploading Nextion");
+  ESP_LOGD(TAG, "Uploading");
 
   // The Nextion will ignore the upload command if it is sleeping
-  ESP_LOGV(TAG, "Wake-up Nextion");
+  ESP_LOGV(TAG, "Wake-up");
   this->ignore_is_setup_ = true;
   this->send_command_("sleep=0");
   this->send_command_("dim=100");
   vTaskDelay(pdMS_TO_TICKS(250));  // NOLINT
-  ESP_LOGV(TAG, "Free heap: %" PRIu32, esp_get_free_heap_size());
+  ESP_LOGV(TAG, "Heap: %" PRIu32, esp_get_free_heap_size());
 
   App.feed_wdt();
   char command[128];
@@ -263,75 +262,75 @@ bool Nextion::upload_tft(uint32_t baud_rate, bool exit_reparse) {
   sprintf(command, "whmi-wris %" PRIu32 ",%" PRIu32 ",1", this->content_length_, baud_rate);
 
   // Clear serial receive buffer
-  ESP_LOGV(TAG, "Clear serial receive buffer");
+  ESP_LOGV(TAG, "Clear RX buffer");
   this->reset_(false);
   vTaskDelay(pdMS_TO_TICKS(250));  // NOLINT
-  ESP_LOGV(TAG, "Free heap: %" PRIu32, esp_get_free_heap_size());
+  ESP_LOGV(TAG, "Heap: %" PRIu32, esp_get_free_heap_size());
 
-  ESP_LOGV(TAG, "Send upload instruction: %s", command);
+  ESP_LOGV(TAG, "Upload cmd: %s", command);
   this->send_command_(command);
 
   if (baud_rate != this->original_baud_rate_) {
-    ESP_LOGD(TAG, "Changing baud rate from %" PRIu32 " to %" PRIu32 " bps", this->original_baud_rate_, baud_rate);
+    ESP_LOGD(TAG, "Baud: %" PRIu32 "->%" PRIu32, this->original_baud_rate_, baud_rate);
     this->parent_->set_baud_rate(baud_rate);
     this->parent_->load_settings();
   }
 
   std::string response;
-  ESP_LOGV(TAG, "Waiting for upgrade response");
+  ESP_LOGV(TAG, "Wait upload resp");
   this->recv_ret_string_(response, 5000, true);  // This can take some time to return
 
   // The Nextion display will, if it's ready to accept data, send a 0x05 byte.
-  ESP_LOGD(TAG, "Upgrade response is [%s] - %zu byte(s)",
-           format_hex_pretty(reinterpret_cast<const uint8_t *>(response.data()), response.size()).c_str(),
+  ESP_LOGD(TAG, "Upload resp: [%s] %zu B", format_hex_pretty(reinterpret_cast<const uint8_t *>(response.data()),
+           response.size()).c_str(),
            response.length());
-  ESP_LOGV(TAG, "Free heap: %" PRIu32, esp_get_free_heap_size());
+  ESP_LOGV(TAG, "Heap: %" PRIu32, esp_get_free_heap_size());
 
   if (response.find(0x05) != std::string::npos) {
-    ESP_LOGV(TAG, "Preparation for TFT upload done");
+    ESP_LOGV(TAG, "Upload prep done");
   } else {
-    ESP_LOGE(TAG, "Preparation for TFT upload failed %d \"%s\"", response[0], response.c_str());
-    ESP_LOGD(TAG, "Close HTTP connection");
+    ESP_LOGE(TAG, "Upload prep failed %d '%s'", response[0], response.c_str());
+    ESP_LOGD(TAG, "Close HTTP");
     esp_http_client_close(http_client);
     esp_http_client_cleanup(http_client);
     ESP_LOGV(TAG, "Connection closed");
     return this->upload_end_(false);
   }
 
-  ESP_LOGV(TAG, "Change the method to GET before starting the download");
+  ESP_LOGV(TAG, "Set method to GET");
   esp_err_t set_method_result = esp_http_client_set_method(http_client, HTTP_METHOD_GET);
   if (set_method_result != ESP_OK) {
-    ESP_LOGE(TAG, "Failed to set HTTP method to GET: %s", esp_err_to_name(set_method_result));
+    ESP_LOGE(TAG, "Set GET failed: %s", esp_err_to_name(set_method_result));
     return this->upload_end_(false);
   }
 
-  ESP_LOGD(TAG, "Uploading TFT to Nextion:");
-  ESP_LOGD(TAG, "  URL: %s", this->tft_url_.c_str());
-  ESP_LOGD(TAG, "  File size: %" PRIu32 " bytes", this->content_length_);
-  ESP_LOGD(TAG, "  Free heap: %" PRIu32, esp_get_free_heap_size());
+  ESP_LOGD(TAG, "Uploading TFT:");
+  ESP_LOGD(TAG, "  URL:  %s", this->tft_url_.c_str());
+  ESP_LOGD(TAG, "  Size: %" PRIu32 " bytes", this->content_length_);
+  ESP_LOGD(TAG, "  Heap: %" PRIu32, esp_get_free_heap_size());
 
   // Proceed with the content download as before
 
-  ESP_LOGV(TAG, "Starting transfer by chunks loop");
+  ESP_LOGV(TAG, "Start chunk transfer");
 
   uint32_t position = 0;
   while (this->content_length_ > 0) {
     int upload_result = upload_by_chunks_(http_client, position);
     if (upload_result < 0) {
-      ESP_LOGE(TAG, "Error uploading TFT to Nextion!");
-      ESP_LOGD(TAG, "Close HTTP connection");
+      ESP_LOGE(TAG, "TFT upload error");
+      ESP_LOGD(TAG, "Close HTTP");
       esp_http_client_close(http_client);
       esp_http_client_cleanup(http_client);
       ESP_LOGV(TAG, "Connection closed");
       return this->upload_end_(false);
     }
     App.feed_wdt();
-    ESP_LOGV(TAG, "Free heap: %" PRIu32 ", Bytes left: %" PRIu32, esp_get_free_heap_size(), this->content_length_);
+    ESP_LOGV(TAG, "Heap: %" PRIu32 " left: %" PRIu32, esp_get_free_heap_size(), this->content_length_);
   }
 
-  ESP_LOGD(TAG, "Successfully uploaded TFT to Nextion!");
+  ESP_LOGD(TAG, "TFT upload complete");
 
-  ESP_LOGD(TAG, "Close HTTP connection");
+  ESP_LOGD(TAG, "Close HTTP");
   esp_http_client_close(http_client);
   esp_http_client_cleanup(http_client);
   ESP_LOGV(TAG, "Connection closed");
@@ -339,23 +338,23 @@ bool Nextion::upload_tft(uint32_t baud_rate, bool exit_reparse) {
 }
 
 bool Nextion::upload_end_(bool successful) {
-  ESP_LOGD(TAG, "Nextion TFT upload finished: %s", YESNO(successful));
+  ESP_LOGD(TAG, "TFT upload done: %s", YESNO(successful));
   this->is_updating_ = false;
   this->ignore_is_setup_ = false;
 
   uint32_t baud_rate = this->parent_->get_baud_rate();
   if (baud_rate != this->original_baud_rate_) {
-    ESP_LOGD(TAG, "Changing baud rate back from %" PRIu32 " to %" PRIu32 " bps", baud_rate, this->original_baud_rate_);
+    ESP_LOGD(TAG, "Baud back: %" PRIu32 "->%" PRIu32, baud_rate, this->original_baud_rate_);
     this->parent_->set_baud_rate(this->original_baud_rate_);
     this->parent_->load_settings();
   }
 
   if (successful) {
-    ESP_LOGD(TAG, "Restarting ESPHome");
+    ESP_LOGD(TAG, "Restart");
     delay(1500);  // NOLINT
     App.safe_reboot();
   } else {
-    ESP_LOGE(TAG, "Nextion TFT upload failed");
+    ESP_LOGE(TAG, "TFT upload failed");
   }
   return successful;
 }

--- a/esphome/components/nextion/sensor/nextion_sensor.cpp
+++ b/esphome/components/nextion/sensor/nextion_sensor.cpp
@@ -13,7 +13,7 @@ void NextionSensor::process_sensor(const std::string &variable_name, int state) 
 
   if (this->wave_chan_id_ == UINT8_MAX && this->variable_name_ == variable_name) {
     this->publish_state(state);
-    ESP_LOGD(TAG, "Processed sensor \"%s\" state %d", variable_name.c_str(), state);
+    ESP_LOGD(TAG, "Sensor: %s=%d", variable_name.c_str(), state);
   }
 }
 
@@ -93,7 +93,7 @@ void NextionSensor::set_state(float state, bool publish, bool send_to_nextion) {
   }
   this->update_component_settings();
 
-  ESP_LOGN(TAG, "Wrote state for sensor \"%s\" state %lf", this->variable_name_.c_str(), published_state);
+  ESP_LOGN(TAG, "Write: %s=%lf", this->variable_name_.c_str(), published_state);
 }
 
 void NextionSensor::wave_update_() {
@@ -105,8 +105,8 @@ void NextionSensor::wave_update_() {
   size_t buffer_to_send =
       this->wave_buffer_.size() < 255 ? this->wave_buffer_.size() : 255;  // ADDT command can only send 255
 
-  ESP_LOGN(TAG, "wave_update send %zu of %zu value(s) to wave nextion component id %d and wave channel id %d",
-           buffer_to_send, this->wave_buffer_.size(), this->component_id_, this->wave_chan_id_);
+  ESP_LOGN(TAG, "Wave update: %zu/%zu vals to comp %d ch %d", buffer_to_send, this->wave_buffer_.size(),
+           this->component_id_, this->wave_chan_id_);
 #endif
 
   this->nextion_->add_addt_command_to_queue(this);

--- a/esphome/components/nextion/switch/nextion_switch.cpp
+++ b/esphome/components/nextion/switch/nextion_switch.cpp
@@ -13,7 +13,7 @@ void NextionSwitch::process_bool(const std::string &variable_name, bool on) {
   if (this->variable_name_ == variable_name) {
     this->publish_state(on);
 
-    ESP_LOGD(TAG, "Processed switch \"%s\" state %s", variable_name.c_str(), state ? "ON" : "OFF");
+    ESP_LOGD(TAG, "Switch: %s=%s", variable_name.c_str(), ONOFF(on));
   }
 }
 
@@ -43,7 +43,7 @@ void NextionSwitch::set_state(bool state, bool publish, bool send_to_nextion) {
 
   this->update_component_settings();
 
-  ESP_LOGN(TAG, "Updated switch \"%s\" state %s", this->variable_name_.c_str(), ONOFF(state));
+  ESP_LOGN(TAG, "Write: %s=%s", this->variable_name_.c_str(), ONOFF(state));
 }
 
 void NextionSwitch::write_state(bool state) { this->set_state(state); }

--- a/esphome/components/nextion/text_sensor/nextion_textsensor.cpp
+++ b/esphome/components/nextion/text_sensor/nextion_textsensor.cpp
@@ -11,7 +11,7 @@ void NextionTextSensor::process_text(const std::string &variable_name, const std
     return;
   if (this->variable_name_ == variable_name) {
     this->publish_state(text_value);
-    ESP_LOGD(TAG, "Processed text_sensor \"%s\" state \"%s\"", variable_name.c_str(), text_value.c_str());
+    ESP_LOGD(TAG, "Text sensor: %s='%s'", variable_name.c_str(), text_value.c_str());
   }
 }
 
@@ -42,7 +42,7 @@ void NextionTextSensor::set_state(const std::string &state, bool publish, bool s
 
   this->update_component_settings();
 
-  ESP_LOGN(TAG, "Wrote state for text_sensor \"%s\" state \"%s\"", this->variable_name_.c_str(), state.c_str());
+  ESP_LOGN(TAG, "Write: %s='%s'", this->variable_name_.c_str(), state.c_str());
 }
 
 }  // namespace nextion


### PR DESCRIPTION
# What does this implement/fix?

Optimizes log messages across the Nextion component to reduce flash memory usage while maintaining full debugging capability.

### Problem
The Nextion component contained numerous verbose log messages that consumed significant flash memory, particularly on resource-constrained devices. Many messages contained redundant prefixes, excessive spacing, and verbose descriptions that could be made more concise without losing essential information.

### Solution
- **Removed redundant "Nextion" prefixes** from error messages (context is clear from log tag)
- **Shortened verbose descriptions** while preserving all essential debugging information
- **Standardized component logging patterns** for consistency across sensor types
- **Consolidated multi-line logs** into single-line formats for better readability
- **Used standard abbreviations** (RX, resp, etc.)
- **Applied consistent formatting** for similar message types

### Key Changes
- **nextion.cpp**: Optimized protocol error messages, queue logging, and component state messages
- **nextion_commands.cpp**: Shortened validation error messages
- **nextion_upload_*.cpp**: Streamlined upload progress and error messages
- **Component files**: Standardized sensor/switch/text sensor logging patterns

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`: N/A

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
