### PR TITLE
[spi] Restrict octal spi to S3/S2/P4

### DIFF
--- a/esphome/components/spi/__init__.py
+++ b/esphome/components/spi/__init__.py
@@ -9,6 +9,7 @@ from esphome.components.esp32.const import (
     VARIANT_ESP32C3,
     VARIANT_ESP32C6,
     VARIANT_ESP32H2,
+    VARIANT_ESP32P4,
     VARIANT_ESP32S2,
     VARIANT_ESP32S3,
 )
@@ -290,7 +291,11 @@ def spi_mode_schema(mode):
     pin_count = 4 if mode == TYPE_QUAD else 8
     onlys = [cv.only_on([PLATFORM_ESP32]), cv.only_with_esp_idf]
     if pin_count == 8:
-        onlys.append(only_on_variant(supported=[VARIANT_ESP32S3]))
+        onlys.append(
+            only_on_variant(
+                supported=[VARIANT_ESP32S3, VARIANT_ESP32S2, VARIANT_ESP32P4]
+            )
+        )
     return cv.All(
         *onlys,
         cv.Schema(

--- a/esphome/components/spi/__init__.py
+++ b/esphome/components/spi/__init__.py
@@ -2,6 +2,7 @@ import re
 
 from esphome import pins
 import esphome.codegen as cg
+from esphome.components.esp32 import only_on_variant
 from esphome.components.esp32.const import (
     KEY_ESP32,
     VARIANT_ESP32C2,
@@ -287,7 +288,11 @@ def spi_mode_schema(mode):
     if mode == TYPE_SINGLE:
         return SPI_SINGLE_SCHEMA
     pin_count = 4 if mode == TYPE_QUAD else 8
+    onlys = [cv.only_on([PLATFORM_ESP32]), cv.only_with_esp_idf]
+    if pin_count == 8:
+        onlys.append(only_on_variant(supported=[VARIANT_ESP32S3]))
     return cv.All(
+        *onlys,
         cv.Schema(
             {
                 cv.GenerateID(): cv.declare_id(TYPE_CLASS[mode]),
@@ -308,8 +313,6 @@ def spi_mode_schema(mode):
                 ),
             }
         ),
-        cv.only_on([PLATFORM_ESP32]),
-        cv.only_with_esp_idf,
     )
 
 

--- a/tests/components/spi/test.esp32-p4-idf.yaml
+++ b/tests/components/spi/test.esp32-p4-idf.yaml
@@ -1,0 +1,38 @@
+spi:
+  - id: quad_spi
+    type: quad
+    interface: spi3
+    clk_pin:
+      number: 47
+    data_pins:
+      - allow_other_uses: true
+        number: 40
+      - allow_other_uses: true
+        number: 41
+      - allow_other_uses: true
+        number: 42
+      - allow_other_uses: true
+        number: 43
+  - id: octal_spi
+    type: octal
+    interface: hardware
+    clk_pin:
+      number: 0
+    data_pins:
+      - 36
+      - 37
+      - 38
+      - 39
+      - allow_other_uses: true
+        number: 40
+      - allow_other_uses: true
+        number: 41
+      - allow_other_uses: true
+        number: 42
+      - allow_other_uses: true
+        number: 43
+  - id: spi_id_3
+    interface: any
+    clk_pin: 8
+    mosi_pin: 9
+


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

The new octal spi support doesn't work on ESP32 other than the S3/S2/P4 variants, so add a config time check.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#4989

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
