### PR TITLE
Reserve memory for component and platform vectors

### DIFF
--- a/esphome/components/alarm_control_panel/__init__.py
+++ b/esphome/components/alarm_control_panel/__init__.py
@@ -235,6 +235,7 @@ async def register_alarm_control_panel(var, config):
     if not CORE.has_id(config[CONF_ID]):
         var = cg.Pvariable(config[CONF_ID], var)
     cg.add(cg.App.register_alarm_control_panel(var))
+    CORE.register_platform_component("alarm_control_panel", var)
     await setup_alarm_control_panel_core_(var, config)
 
 

--- a/esphome/components/binary_sensor/__init__.py
+++ b/esphome/components/binary_sensor/__init__.py
@@ -554,6 +554,7 @@ async def register_binary_sensor(var, config):
     if not CORE.has_id(config[CONF_ID]):
         var = cg.Pvariable(config[CONF_ID], var)
     cg.add(cg.App.register_binary_sensor(var))
+    CORE.register_platform_component("binary_sensor", var)
     await setup_binary_sensor_core_(var, config)
 
 

--- a/esphome/components/button/__init__.py
+++ b/esphome/components/button/__init__.py
@@ -108,6 +108,7 @@ async def register_button(var, config):
     if not CORE.has_id(config[CONF_ID]):
         var = cg.Pvariable(config[CONF_ID], var)
     cg.add(cg.App.register_button(var))
+    CORE.register_platform_component("button", var)
     await setup_button_core_(var, config)
 
 

--- a/esphome/components/climate/__init__.py
+++ b/esphome/components/climate/__init__.py
@@ -443,6 +443,7 @@ async def register_climate(var, config):
     if not CORE.has_id(config[CONF_ID]):
         var = cg.Pvariable(config[CONF_ID], var)
     cg.add(cg.App.register_climate(var))
+    CORE.register_platform_component("climate", var)
     await setup_climate_core_(var, config)
 
 

--- a/esphome/components/cover/__init__.py
+++ b/esphome/components/cover/__init__.py
@@ -189,6 +189,7 @@ async def register_cover(var, config):
     if not CORE.has_id(config[CONF_ID]):
         var = cg.Pvariable(config[CONF_ID], var)
     cg.add(cg.App.register_cover(var))
+    CORE.register_platform_component("cover", var)
     await setup_cover_core_(var, config)
 
 

--- a/esphome/components/datetime/__init__.py
+++ b/esphome/components/datetime/__init__.py
@@ -158,7 +158,9 @@ async def setup_datetime_core_(var, config):
 async def register_datetime(var, config):
     if not CORE.has_id(config[CONF_ID]):
         var = cg.Pvariable(config[CONF_ID], var)
-    cg.add(getattr(cg.App, f"register_{config[CONF_TYPE].lower()}")(var))
+    entity_type = config[CONF_TYPE].lower()
+    cg.add(getattr(cg.App, f"register_{entity_type}")(var))
+    CORE.register_platform_component(entity_type, var)
     await setup_datetime_core_(var, config)
     cg.add_define(f"USE_DATETIME_{config[CONF_TYPE]}")
 

--- a/esphome/components/event/__init__.py
+++ b/esphome/components/event/__init__.py
@@ -113,6 +113,7 @@ async def register_event(var, config, *, event_types: list[str]):
     if not CORE.has_id(config[CONF_ID]):
         var = cg.Pvariable(config[CONF_ID], var)
     cg.add(cg.App.register_event(var))
+    CORE.register_platform_component("event", var)
     await setup_event_core_(var, config, event_types=event_types)
 
 

--- a/esphome/components/fan/__init__.py
+++ b/esphome/components/fan/__init__.py
@@ -296,6 +296,7 @@ async def register_fan(var, config):
     if not CORE.has_id(config[CONF_ID]):
         var = cg.Pvariable(config[CONF_ID], var)
     cg.add(cg.App.register_fan(var))
+    CORE.register_platform_component("fan", var)
     await setup_fan_core_(var, config)
 
 

--- a/esphome/components/light/__init__.py
+++ b/esphome/components/light/__init__.py
@@ -37,7 +37,7 @@ from esphome.const import (
     CONF_WEB_SERVER,
     CONF_WHITE,
 )
-from esphome.core import coroutine_with_priority
+from esphome.core import CORE, coroutine_with_priority
 from esphome.cpp_generator import MockObjClass
 from esphome.cpp_helpers import setup_entity
 
@@ -270,6 +270,7 @@ async def setup_light_core_(light_var, output_var, config):
 async def register_light(output_var, config):
     light_var = cg.new_Pvariable(config[CONF_ID], output_var)
     cg.add(cg.App.register_light(light_var))
+    CORE.register_platform_component("light", light_var)
     await cg.register_component(light_var, config)
     await setup_light_core_(light_var, output_var, config)
 

--- a/esphome/components/lock/__init__.py
+++ b/esphome/components/lock/__init__.py
@@ -115,6 +115,7 @@ async def register_lock(var, config):
     if not CORE.has_id(config[CONF_ID]):
         var = cg.Pvariable(config[CONF_ID], var)
     cg.add(cg.App.register_lock(var))
+    CORE.register_platform_component("lock", var)
     await _setup_lock_core(var, config)
 
 

--- a/esphome/components/media_player/__init__.py
+++ b/esphome/components/media_player/__init__.py
@@ -103,6 +103,7 @@ async def register_media_player(var, config):
     if not CORE.has_id(config[CONF_ID]):
         var = cg.Pvariable(config[CONF_ID], var)
     cg.add(cg.App.register_media_player(var))
+    CORE.register_platform_component("media_player", var)
     await setup_media_player_core_(var, config)
 
 

--- a/esphome/components/number/__init__.py
+++ b/esphome/components/number/__init__.py
@@ -277,6 +277,7 @@ async def register_number(
     if not CORE.has_id(config[CONF_ID]):
         var = cg.Pvariable(config[CONF_ID], var)
     cg.add(cg.App.register_number(var))
+    CORE.register_platform_component("number", var)
     await setup_number_core_(
         var, config, min_value=min_value, max_value=max_value, step=step
     )

--- a/esphome/components/select/__init__.py
+++ b/esphome/components/select/__init__.py
@@ -111,6 +111,7 @@ async def register_select(var, config, *, options: list[str]):
     if not CORE.has_id(config[CONF_ID]):
         var = cg.Pvariable(config[CONF_ID], var)
     cg.add(cg.App.register_select(var))
+    CORE.register_platform_component("select", var)
     await setup_select_core_(var, config, options=options)
 
 

--- a/esphome/components/sensor/__init__.py
+++ b/esphome/components/sensor/__init__.py
@@ -167,7 +167,6 @@ DEVICE_CLASSES = [
 ]
 
 _LOGGER = logging.getLogger(__name__)
-
 sensor_ns = cg.esphome_ns.namespace("sensor")
 StateClasses = sensor_ns.enum("StateClass")
 STATE_CLASSES = {
@@ -840,6 +839,7 @@ async def register_sensor(var, config):
     if not CORE.has_id(config[CONF_ID]):
         var = cg.Pvariable(config[CONF_ID], var)
     cg.add(cg.App.register_sensor(var))
+    CORE.register_platform_component("sensor", var)
     await setup_sensor_core_(var, config)
 
 

--- a/esphome/components/switch/__init__.py
+++ b/esphome/components/switch/__init__.py
@@ -159,6 +159,7 @@ async def register_switch(var, config):
     if not CORE.has_id(config[CONF_ID]):
         var = cg.Pvariable(config[CONF_ID], var)
     cg.add(cg.App.register_switch(var))
+    CORE.register_platform_component("switch", var)
     await setup_switch_core_(var, config)
 
 

--- a/esphome/components/text/__init__.py
+++ b/esphome/components/text/__init__.py
@@ -126,6 +126,7 @@ async def register_text(
     if not CORE.has_id(config[CONF_ID]):
         var = cg.Pvariable(config[CONF_ID], var)
     cg.add(cg.App.register_text(var))
+    CORE.register_platform_component("text", var)
     await setup_text_core_(
         var, config, min_length=min_length, max_length=max_length, pattern=pattern
     )

--- a/esphome/components/text_sensor/__init__.py
+++ b/esphome/components/text_sensor/__init__.py
@@ -215,6 +215,7 @@ async def register_text_sensor(var, config):
     if not CORE.has_id(config[CONF_ID]):
         var = cg.Pvariable(config[CONF_ID], var)
     cg.add(cg.App.register_text_sensor(var))
+    CORE.register_platform_component("text_sensor", var)
     await setup_text_sensor_core_(var, config)
 
 

--- a/esphome/components/update/__init__.py
+++ b/esphome/components/update/__init__.py
@@ -111,6 +111,7 @@ async def register_update(var, config):
     if not CORE.has_id(config[CONF_ID]):
         var = cg.Pvariable(config[CONF_ID], var)
     cg.add(cg.App.register_update(var))
+    CORE.register_platform_component("update", var)
     await setup_update_core_(var, config)
 
 

--- a/esphome/components/valve/__init__.py
+++ b/esphome/components/valve/__init__.py
@@ -163,6 +163,7 @@ async def register_valve(var, config):
     if not CORE.has_id(config[CONF_ID]):
         var = cg.Pvariable(config[CONF_ID], var)
     cg.add(cg.App.register_valve(var))
+    CORE.register_platform_component("valve", var)
     await _setup_valve_core(var, config)
 
 

--- a/esphome/core/application.h
+++ b/esphome/core/application.h
@@ -198,6 +198,73 @@ class Application {
   void register_update(update::UpdateEntity *update) { this->updates_.push_back(update); }
 #endif
 
+  /// Reserve space for components to avoid memory fragmentation
+  void reserve_components(size_t count) { this->components_.reserve(count); }
+
+#ifdef USE_BINARY_SENSOR
+  void reserve_binary_sensor(size_t count) { this->binary_sensors_.reserve(count); }
+#endif
+#ifdef USE_SWITCH
+  void reserve_switch(size_t count) { this->switches_.reserve(count); }
+#endif
+#ifdef USE_BUTTON
+  void reserve_button(size_t count) { this->buttons_.reserve(count); }
+#endif
+#ifdef USE_SENSOR
+  void reserve_sensor(size_t count) { this->sensors_.reserve(count); }
+#endif
+#ifdef USE_TEXT_SENSOR
+  void reserve_text_sensor(size_t count) { this->text_sensors_.reserve(count); }
+#endif
+#ifdef USE_FAN
+  void reserve_fan(size_t count) { this->fans_.reserve(count); }
+#endif
+#ifdef USE_COVER
+  void reserve_cover(size_t count) { this->covers_.reserve(count); }
+#endif
+#ifdef USE_CLIMATE
+  void reserve_climate(size_t count) { this->climates_.reserve(count); }
+#endif
+#ifdef USE_LIGHT
+  void reserve_light(size_t count) { this->lights_.reserve(count); }
+#endif
+#ifdef USE_NUMBER
+  void reserve_number(size_t count) { this->numbers_.reserve(count); }
+#endif
+#ifdef USE_DATETIME_DATE
+  void reserve_date(size_t count) { this->dates_.reserve(count); }
+#endif
+#ifdef USE_DATETIME_TIME
+  void reserve_time(size_t count) { this->times_.reserve(count); }
+#endif
+#ifdef USE_DATETIME_DATETIME
+  void reserve_datetime(size_t count) { this->datetimes_.reserve(count); }
+#endif
+#ifdef USE_SELECT
+  void reserve_select(size_t count) { this->selects_.reserve(count); }
+#endif
+#ifdef USE_TEXT
+  void reserve_text(size_t count) { this->texts_.reserve(count); }
+#endif
+#ifdef USE_LOCK
+  void reserve_lock(size_t count) { this->locks_.reserve(count); }
+#endif
+#ifdef USE_VALVE
+  void reserve_valve(size_t count) { this->valves_.reserve(count); }
+#endif
+#ifdef USE_MEDIA_PLAYER
+  void reserve_media_player(size_t count) { this->media_players_.reserve(count); }
+#endif
+#ifdef USE_ALARM_CONTROL_PANEL
+  void reserve_alarm_control_panel(size_t count) { this->alarm_control_panels_.reserve(count); }
+#endif
+#ifdef USE_EVENT
+  void reserve_event(size_t count) { this->events_.reserve(count); }
+#endif
+#ifdef USE_UPDATE
+  void reserve_update(size_t count) { this->updates_.reserve(count); }
+#endif
+
   /// Register the component in this Application instance.
   template<class C> C *register_component(C *c) {
     static_assert(std::is_base_of<Component, C>::value, "Only Component subclasses can be registered");

--- a/esphome/cpp_generator.py
+++ b/esphome/cpp_generator.py
@@ -579,13 +579,13 @@ def new_Pvariable(id_: ID, *args: SafeExpType) -> Pvariable:
     return Pvariable(id_, rhs)
 
 
-def add(expression: Expression | Statement):
+def add(expression: Expression | Statement, prepend: bool = False):
     """Add an expression to the codegen section.
 
     After this is called, the given given expression will
     show up in the setup() function after this has been called.
     """
-    CORE.add(expression)
+    CORE.add(expression, prepend)
 
 
 def add_global(expression: SafeExpType | Statement, prepend: bool = False):


### PR DESCRIPTION
# What does this implement/fix?

This PR adds memory pre-allocation for component and platform vectors to reduce memory fragmentation and improve startup performance in ESPHome.

During initialization, ESPHome dynamically registers components and platform entities (sensors, binary sensors, switches, etc.), causing multiple vector reallocations as they grow. This leads to memory fragmentation, increased memory usage, and slower startup times due to repeated allocations and copies.

The implementation tracks the count of each platform type during config generation and reserves the exact amount of space needed in each vector before component registration begins. This results in a single allocation per vector instead of multiple reallocations.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A - This is an internal optimization that doesn't require documentation

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - this is a transparent optimization
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

## Additional Details

### Implementation Overview

1. **Component tracking**: During config validation, track the count of each platform type being registered via `CORE.register_platform_component()`
2. **Pre-allocation**: Before component registration begins, reserve the exact amount of space needed in each vector
3. **Early reservation**: Add reserve statements at the beginning of `setup()` to allocate memory before any components are created

### Example Generated Code
```cpp
void setup() {
  App.reserve_components(25);
  App.reserve_sensor(10);
  App.reserve_binary_sensor(5);
  // ... other reservations
  
  // ... rest of setup
}
```

### Benefits
- **Reduced memory fragmentation**: Single allocation per vector instead of multiple reallocations
- **Lower memory usage**: Avoids temporary memory spikes during vector growth
- **Faster startup**: Eliminates repeated copying of vector contents during reallocation
- **No runtime overhead**: All work is done during code generation