### PR TITLE
Ensure components only powerdown after teardown

### DIFF
--- a/esphome/components/deep_sleep/deep_sleep_component.cpp
+++ b/esphome/components/deep_sleep/deep_sleep_component.cpp
@@ -67,6 +67,7 @@ void DeepSleepComponent::begin_sleep(bool manual) {
   // It's critical to teardown components cleanly for deep sleep to ensure
   // Home Assistant sees a clean disconnect instead of marking the device unavailable
   App.teardown_components(TEARDOWN_TIMEOUT_DEEP_SLEEP_MS);
+  App.run_powerdown_hooks();
 
   this->deep_sleep_();
 }

--- a/esphome/components/ethernet/ethernet_component.h
+++ b/esphome/components/ethernet/ethernet_component.h
@@ -56,7 +56,7 @@ class EthernetComponent : public Component {
   void dump_config() override;
   float get_setup_priority() const override;
   bool can_proceed() override;
-  void on_shutdown() override { powerdown(); }
+  void on_powerdown() override { powerdown(); }
   bool is_connected();
 
 #ifdef USE_ETHERNET_SPI

--- a/esphome/components/ili9xxx/ili9xxx_display.h
+++ b/esphome/components/ili9xxx/ili9xxx_display.h
@@ -89,7 +89,7 @@ class ILI9XXXDisplay : public display::DisplayBuffer,
 
   void dump_config() override;
   void setup() override;
-  void on_shutdown() override { this->command(ILI9XXX_SLPIN); }
+  void on_powerdown() override { this->command(ILI9XXX_SLPIN); }
 
   display::DisplayType get_display_type() override { return display::DisplayType::DISPLAY_TYPE_COLOR; }
   void draw_pixels_at(int x_start, int y_start, int w, int h, const uint8_t *ptr, display::ColorOrder order,

--- a/esphome/components/pn532/pn532.h
+++ b/esphome/components/pn532/pn532.h
@@ -38,7 +38,7 @@ class PN532 : public PollingComponent {
   float get_setup_priority() const override;
 
   void loop() override;
-  void on_shutdown() override { powerdown(); }
+  void on_powerdown() override { powerdown(); }
 
   void register_tag(PN532BinarySensor *tag) { this->binary_sensors_.push_back(tag); }
   void register_ontag_trigger(nfc::NfcOnTagTrigger *trig) { this->triggers_ontag_.push_back(trig); }

--- a/esphome/components/power_supply/power_supply.cpp
+++ b/esphome/components/power_supply/power_supply.cpp
@@ -52,7 +52,7 @@ void PowerSupply::unrequest_high_power() {
     });
   }
 }
-void PowerSupply::on_shutdown() {
+void PowerSupply::on_powerdown() {
   this->active_requests_ = 0;
   this->pin_->digital_write(false);
 }

--- a/esphome/components/power_supply/power_supply.h
+++ b/esphome/components/power_supply/power_supply.h
@@ -32,7 +32,7 @@ class PowerSupply : public Component {
   /// Hardware setup priority (+1).
   float get_setup_priority() const override;
 
-  void on_shutdown() override;
+  void on_powerdown() override;
 
  protected:
   GPIOPin *pin_;

--- a/esphome/core/application.cpp
+++ b/esphome/core/application.cpp
@@ -169,6 +169,7 @@ void Application::safe_reboot() {
   ESP_LOGI(TAG, "Rebooting safely");
   run_safe_shutdown_hooks();
   teardown_components(TEARDOWN_TIMEOUT_REBOOT_MS);
+  run_powerdown_hooks();
   arch_restart();
 }
 
@@ -178,6 +179,12 @@ void Application::run_safe_shutdown_hooks() {
   }
   for (auto it = this->components_.rbegin(); it != this->components_.rend(); ++it) {
     (*it)->on_shutdown();
+  }
+}
+
+void Application::run_powerdown_hooks() {
+  for (auto it = this->components_.rbegin(); it != this->components_.rend(); ++it) {
+    (*it)->on_powerdown();
   }
 }
 

--- a/esphome/core/application.h
+++ b/esphome/core/application.h
@@ -257,6 +257,8 @@ class Application {
 
   void run_safe_shutdown_hooks();
 
+  void run_powerdown_hooks();
+
   /** Teardown all components with a timeout.
    *
    * @param timeout_ms Maximum time to wait for teardown in milliseconds

--- a/esphome/core/component.h
+++ b/esphome/core/component.h
@@ -116,6 +116,13 @@ class Component {
    */
   virtual bool teardown() { return true; }
 
+  /** Called after teardown is complete to power down hardware.
+   *
+   * This is called after all components have finished their teardown process,
+   * making it safe to power down hardware like ethernet PHY.
+   */
+  virtual void on_powerdown() {}
+
   uint32_t get_component_state() const;
 
   /** Mark this component as failed. Any future timeouts/intervals/setup/loop will no longer be called.


### PR DESCRIPTION
# What does this implement/fix?

This PR fixes an issue where the Ethernet PHY is powered down before the API server can send disconnect messages to Home Assistant during shutdown/reboot. This causes Home Assistant to mark a deep sleep device as "unavailable" instead of properly disconnected.

The fix introduces a new `on_powerdown()` hook that is called after all components have completed their teardown process. This ensures the network remains available while components clean up their connections.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes #(issue number if applicable)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#(not required - internal API change)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# No configuration changes required
# This is an internal framework improvement

ethernet:
  type: LAN8720
  mdc_pin: GPIO23
  mdio_pin: GPIO18
  # ... other ethernet config
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
https://github.com/esphome/developers.esphome.io/pull/37

## Additional Details

### Problem
The shutdown sequence was:
1. `on_shutdown()` - Ethernet PHY powered down here ❌
2. `teardown()` - API server tries to send disconnect but network is already down
3. Device appears as "unavailable" in Home Assistant

### Solution
New shutdown sequence:
1. `on_shutdown()` - Components prepare for shutdown
2. `teardown()` - API server sends disconnect message (network still up ✓)
3. `on_powerdown()` - Ethernet PHY powers down after all teardowns complete
4. System restarts or enters deep sleep

### Changes Made

1. **Core Framework**:
   - Added `virtual void on_powerdown()` to Component base class
   - Added `run_powerdown_hooks()` to Application class
   - Updated `safe_reboot()` and deep sleep to call powerdown hooks after teardown

2. **Component Updates**:
   - **Ethernet**: Moved `powerdown()` from `on_shutdown()` to `on_powerdown()`
   - Also updated Power Supply, PN532, and ILI9xxx display components that were powering down hardware too early

This ensures clean disconnections and proper device status in Home Assistant.