### PR TITLE
[shtcx] Shorten log messages

### DIFF
--- a/esphome/components/shtcx/shtcx.cpp
+++ b/esphome/components/shtcx/shtcx.cpp
@@ -20,7 +20,7 @@ inline const char *to_string(SHTCXType type) {
     case SHTCX_TYPE_SHTC1:
       return "SHTC1";
     default:
-      return "[Unknown model]";
+      return "UNKNOWN";
   }
 }
 
@@ -29,15 +29,9 @@ void SHTCXComponent::setup() {
   this->wake_up();
   this->soft_reset();
 
-  if (!this->write_command(SHTCX_COMMAND_READ_ID_REGISTER)) {
-    ESP_LOGE(TAG, "Error requesting Device ID");
-    this->mark_failed();
-    return;
-  }
-
   uint16_t device_id_register;
-  if (!this->read_data(&device_id_register, 1)) {
-    ESP_LOGE(TAG, "Error reading Device ID");
+  if (!this->write_command(SHTCX_COMMAND_READ_ID_REGISTER) || !this->read_data(&device_id_register, 1)) {
+    ESP_LOGE(TAG, ESP_LOG_MSG_COMM_FAIL);
     this->mark_failed();
     return;
   }
@@ -53,8 +47,8 @@ void SHTCXComponent::setup() {
   } else {
     this->type_ = SHTCX_TYPE_UNKNOWN;
   }
-  ESP_LOGCONFIG(TAG, "  Device identified: %s (%04x)", to_string(this->type_), device_id_register);
 }
+
 void SHTCXComponent::dump_config() {
   ESP_LOGCONFIG(TAG, "SHTCx:");
   ESP_LOGCONFIG(TAG, "  Model: %s (%04x)", to_string(this->type_), this->sensor_id_);
@@ -67,17 +61,19 @@ void SHTCXComponent::dump_config() {
   LOG_SENSOR("  ", "Temperature", this->temperature_sensor_);
   LOG_SENSOR("  ", "Humidity", this->humidity_sensor_);
 }
+
 float SHTCXComponent::get_setup_priority() const { return setup_priority::DATA; }
+
 void SHTCXComponent::update() {
   if (this->status_has_warning()) {
-    ESP_LOGW(TAG, "Retrying to reconnect the sensor.");
+    ESP_LOGW(TAG, "Retrying communication");
     this->soft_reset();
   }
   if (this->type_ != SHTCX_TYPE_SHTC1) {
     this->wake_up();
   }
   if (!this->write_command(SHTCX_COMMAND_POLLING_H)) {
-    ESP_LOGE(TAG, "sensor polling failed");
+    ESP_LOGE(TAG, "Polling failed");
     if (this->temperature_sensor_ != nullptr)
       this->temperature_sensor_->publish_state(NAN);
     if (this->humidity_sensor_ != nullptr)
@@ -91,13 +87,13 @@ void SHTCXComponent::update() {
     float humidity = NAN;
     uint16_t raw_data[2];
     if (!this->read_data(raw_data, 2)) {
-      ESP_LOGE(TAG, "sensor read failed");
+      ESP_LOGE(TAG, ESP_LOG_MSG_COMM_FAIL);
       this->status_set_warning();
     } else {
       temperature = 175.0f * float(raw_data[0]) / 65536.0f - 45.0f;
       humidity = 100.0f * float(raw_data[1]) / 65536.0f;
 
-      ESP_LOGD(TAG, "Got temperature=%.2f°C humidity=%.2f%%", temperature, humidity);
+      ESP_LOGD(TAG, "Temperature=%.2f°C Humidity=%.2f%%", temperature, humidity);
     }
     if (this->temperature_sensor_ != nullptr)
       this->temperature_sensor_->publish_state(temperature);
@@ -114,6 +110,7 @@ void SHTCXComponent::soft_reset() {
   this->write_command(SHTCX_COMMAND_SOFT_RESET);
   delayMicroseconds(200);
 }
+
 void SHTCXComponent::sleep() { this->write_command(SHTCX_COMMAND_SLEEP); }
 
 void SHTCXComponent::wake_up() {


### PR DESCRIPTION
# What does this implement/fix?

Before: `Flash: [======    ]  57.6% (used 1057818 bytes from 1835008 bytes)`

After: `Flash: [======    ]  57.6% (used 1057582 bytes from 1835008 bytes)`


## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
