### PR TITLE
Fix BYPASS_AUTO feature to work with or without an arming delay

### DIFF
--- a/esphome/components/template/alarm_control_panel/template_alarm_control_panel.h
+++ b/esphome/components/template/alarm_control_panel/template_alarm_control_panel.h
@@ -60,6 +60,7 @@ class TemplateAlarmControlPanel : public alarm_control_panel::AlarmControlPanel,
   bool get_requires_code_to_arm() const override { return this->requires_code_to_arm_; }
   bool get_all_sensors_ready() { return this->sensors_ready_; };
   void set_restore_mode(TemplateAlarmControlPanelRestoreMode restore_mode) { this->restore_mode_ = restore_mode; }
+  void bypass_before_arming();
 
 #ifdef USE_BINARY_SENSOR
   /** Add a binary_sensor to the alarm_panel.


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to #8795 that fixes the BYPASS_AUTO logic when used without an arming delay.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other


## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
alarm_control_panel:
  platform: template
  id: acp1
  restore_mode: RESTORE_DEFAULT_DISARMED
  name: Konnected Alarm
  binary_sensors:
    - input: zone1
      bypass_auto: True
    - input: zone2
      bypass_auto: True
    - input: zone3
  on_triggered:
    then:
    - switch.turn_on: alarm1
  on_cleared:
    then:
    - switch.turn_off: alarm1

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

