### PR TITLE
ina219: powerdown the sensor on shutdown

### DIFF
--- a/esphome/components/ina219/ina219.cpp
+++ b/esphome/components/ina219/ina219.cpp
@@ -129,6 +129,13 @@ void INA219Component::setup() {
   }
 }
 
+void INA219Component::on_powerdown() {
+  // Mode = 0 -> power down
+  if (!this->write_byte_16(INA219_REGISTER_CONFIG, 0)) {
+    ESP_LOGE(TAG, "powerdown error");
+  }
+}
+
 void INA219Component::dump_config() {
   ESP_LOGCONFIG(TAG, "INA219:");
   LOG_I2C_DEVICE(this);

--- a/esphome/components/ina219/ina219.h
+++ b/esphome/components/ina219/ina219.h
@@ -15,6 +15,7 @@ class INA219Component : public PollingComponent, public i2c::I2CDevice {
   void dump_config() override;
   float get_setup_priority() const override;
   void update() override;
+  void on_powerdown() override;
 
   void set_shunt_resistance_ohm(float shunt_resistance_ohm) { shunt_resistance_ohm_ = shunt_resistance_ohm; }
   void set_max_current_a(float max_current_a) { max_current_a_ = max_current_a; }


### PR DESCRIPTION
# What does this implement/fix?

The INA219 has a power-down mode which reduces the power consumption from hundreds of micro-amps to just a few microamps.

Put the sensor into power-down mode when on_shutdown() is executed to save power e.g. when entering deep sleep.

No code is needed to leave power-down since the current code will reset the sensor on setup(), causing it to exit power-down mode.

setup() will be called in any case when waking from shutdown.

Reference: [datasheet](https://www.ti.com/lit/gpn/ina219) section 8.6.2.1

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Checklist:
  - [x] The code change is tested and works locally. 
    - power consumption of the sensor during deep sleep drops from ~310uA to below 1 uA (my measurement equipment is not very accurate at low currents)
    - verified that sensor still yields proper values after waking from deep sleep
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
