### PR TITLE
Fix dashboard logging being escaped before parser

### DIFF
--- a/esphome/components/api/client.py
+++ b/esphome/components/api/client.py
@@ -46,12 +46,10 @@ async def async_run_logs(config: dict[str, Any], address: str) -> None:
         time_ = datetime.now()
         message: bytes = msg.message
         text = message.decode("utf8", "backslashreplace")
-        if dashboard:
-            text = text.replace("\033", "\\033")
         for parsed_msg in parse_log_message(
             text, f"[{time_.hour:02}:{time_.minute:02}:{time_.second:02}]"
         ):
-            print(parsed_msg)
+            print(parsed_msg.replace("\033", "\\033") if dashboard else parsed_msg)
 
     stop = await async_run(cli, on_log, name=name)
     try:


### PR DESCRIPTION

# What does this implement/fix?

The parser cannot parse it correctly if we escape it before sending it to the parser

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
