### PR TITLE
[nextion] Reverts back to `arch_restart()` (changed by PR#9010)

### DIFF
--- a/esphome/components/nextion/nextion_upload_arduino.cpp
+++ b/esphome/components/nextion/nextion_upload_arduino.cpp
@@ -350,7 +350,7 @@ bool Nextion::upload_end_(bool successful) {
   if (successful) {
     ESP_LOGD(TAG, "Restart");
     delay(1500);  // NOLINT
-    App.safe_reboot();
+    arch_restart();
   } else {
     ESP_LOGE(TAG, "TFT upload failed");
   }

--- a/esphome/components/nextion/nextion_upload_idf.cpp
+++ b/esphome/components/nextion/nextion_upload_idf.cpp
@@ -350,7 +350,7 @@ bool Nextion::upload_end_(bool successful) {
   if (successful) {
     ESP_LOGD(TAG, "Restart");
     delay(1500);  // NOLINT
-    App.safe_reboot();
+    arch_restart();
   } else {
     ESP_LOGE(TAG, "TFT upload failed");
   }


### PR DESCRIPTION
# What does this implement/fix?

This reverts back the changes introduced by #9010 as that is breaking the TFT upload.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes esphome/issues#7109

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [ ] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
