### PR TITLE
[esp32_touch] Only read one touch sensor per loop

### DIFF
--- a/esphome/components/esp32_touch/esp32_touch.cpp
+++ b/esphome/components/esp32_touch/esp32_touch.cpp
@@ -2,8 +2,8 @@
 
 #include "esp32_touch.h"
 #include "esphome/core/application.h"
-#include "esphome/core/log.h"
 #include "esphome/core/hal.h"
+#include "esphome/core/log.h"
 
 #include <cinttypes>
 
@@ -294,26 +294,28 @@ uint32_t ESP32TouchComponent::component_touch_pad_read(touch_pad_t tp) {
 void ESP32TouchComponent::loop() {
   const uint32_t now = App.get_loop_component_start_time();
   bool should_print = this->setup_mode_ && now - this->setup_mode_last_log_print_ > 250;
-  for (auto *child : this->children_) {
-    child->value_ = this->component_touch_pad_read(child->get_touch_pad());
-#if !(defined(USE_ESP32_VARIANT_ESP32S2) || defined(USE_ESP32_VARIANT_ESP32S3))
-    child->publish_state(child->value_ < child->get_threshold());
-#else
-    child->publish_state(child->value_ > child->get_threshold());
-#endif
-
-    if (should_print) {
-      ESP_LOGD(TAG, "Touch Pad '%s' (T%" PRIu32 "): %" PRIu32, child->get_name().c_str(),
-               (uint32_t) child->get_touch_pad(), child->value_);
-    }
-
-    App.feed_wdt();
-  }
-
   if (should_print) {
     // Avoid spamming logs
     this->setup_mode_last_log_print_ = now;
   }
+  if (this->children_.empty()) {
+    return;
+  }
+
+  auto *child = this->children_[this->current_child_];
+  child->value_ = this->component_touch_pad_read(child->get_touch_pad());
+#if !(defined(USE_ESP32_VARIANT_ESP32S2) || defined(USE_ESP32_VARIANT_ESP32S3))
+  child->publish_state(child->value_ < child->get_threshold());
+#else
+  child->publish_state(child->value_ > child->get_threshold());
+#endif
+
+  if (should_print) {
+    ESP_LOGD(TAG, "Touch Pad '%s' (T%" PRIu32 "): %" PRIu32, child->get_name().c_str(),
+             (uint32_t) child->get_touch_pad(), child->value_);
+  }
+
+  this->current_child_ = (this->current_child_ + 1) % this->children_.size();
 }
 
 void ESP32TouchComponent::on_shutdown() {

--- a/esphome/components/esp32_touch/esp32_touch.cpp
+++ b/esphome/components/esp32_touch/esp32_touch.cpp
@@ -293,10 +293,8 @@ uint32_t ESP32TouchComponent::component_touch_pad_read(touch_pad_t tp) {
 
 void ESP32TouchComponent::loop() {
   const uint32_t now = App.get_loop_component_start_time();
-  bool should_print = this->setup_mode_ && now - this->setup_mode_last_log_print_ > 250;
-  if (should_print && this->current_child_ == this->children_.size() - 1) {
-    // Avoid spamming logs
-    this->setup_mode_last_log_print_ = now;
+  if (this->current_child_ == 0) {
+    this->should_print_ = this->setup_mode_ && now - this->setup_mode_last_log_print_ > 250;
   }
   if (this->children_.empty()) {
     return;
@@ -310,9 +308,15 @@ void ESP32TouchComponent::loop() {
   child->publish_state(child->value_ > child->get_threshold());
 #endif
 
-  if (should_print) {
+  if (this->should_print_) {
     ESP_LOGD(TAG, "Touch Pad '%s' (T%" PRIu32 "): %" PRIu32, child->get_name().c_str(),
              (uint32_t) child->get_touch_pad(), child->value_);
+  }
+
+  if (this->should_print_ && this->current_child_ == this->children_.size() - 1) {
+    // Avoid spamming logs
+    this->setup_mode_last_log_print_ = now;
+    this->should_print_ = false;
   }
 
   this->current_child_ = (this->current_child_ + 1) % this->children_.size();

--- a/esphome/components/esp32_touch/esp32_touch.cpp
+++ b/esphome/components/esp32_touch/esp32_touch.cpp
@@ -294,7 +294,7 @@ uint32_t ESP32TouchComponent::component_touch_pad_read(touch_pad_t tp) {
 void ESP32TouchComponent::loop() {
   const uint32_t now = App.get_loop_component_start_time();
   bool should_print = this->setup_mode_ && now - this->setup_mode_last_log_print_ > 250;
-  if (should_print) {
+  if (should_print && this->current_child_ == this->children_.size() - 1) {
     // Avoid spamming logs
     this->setup_mode_last_log_print_ = now;
   }

--- a/esphome/components/esp32_touch/esp32_touch.h
+++ b/esphome/components/esp32_touch/esp32_touch.h
@@ -75,6 +75,7 @@ class ESP32TouchComponent : public Component {
   std::vector<ESP32TouchBinarySensor *> children_;
   uint8_t current_child_{0};
   bool setup_mode_{false};
+  bool should_print_{false};
   uint32_t setup_mode_last_log_print_{0};
   // common parameters
   uint16_t sleep_cycle_{4095};

--- a/esphome/components/esp32_touch/esp32_touch.h
+++ b/esphome/components/esp32_touch/esp32_touch.h
@@ -2,9 +2,9 @@
 
 #ifdef USE_ESP32
 
-#include "esphome/core/component.h"
-#include "esphome/components/binary_sensor/binary_sensor.h"
 #include <esp_idf_version.h>
+#include "esphome/components/binary_sensor/binary_sensor.h"
+#include "esphome/core/component.h"
 
 #include <vector>
 
@@ -73,6 +73,7 @@ class ESP32TouchComponent : public Component {
 #endif
 
   std::vector<ESP32TouchBinarySensor *> children_;
+  uint8_t current_child_{0};
   bool setup_mode_{false};
   uint32_t setup_mode_last_log_print_{0};
   // common parameters


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

The esp32_touch component takes up to 8ms per each configured binary sensor per loop to read.
2 pins/sensors == 16ms etc...

After #8918, because the esp32_touch loop was always taking longer than 16ms, the `select` was never called, meaning sockets were never being ready.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
