### PR TITLE
Always perform select() when loop duration exceeds interval

### DIFF
--- a/esphome/core/application.cpp
+++ b/esphome/core/application.cpp
@@ -116,12 +116,10 @@ void Application::loop() {
 
   // Use the last component's end time instead of calling millis() again
   auto elapsed = last_op_end_time - this->last_loop_;
-  if (elapsed >= this->loop_interval_) {
+  if (elapsed >= this->loop_interval_ || HighFrequencyLoopRequester::is_high_frequency()) {
     // Even if we overran the loop interval, we still need to select()
     // to know if any sockets have data ready
-    this->delay_with_select_(0);
-  } else if (HighFrequencyLoopRequester::is_high_frequency()) {
-    yield();
+    this->yield_with_select_(0);
   } else {
     uint32_t delay_time = this->loop_interval_ - elapsed;
     uint32_t next_schedule = this->scheduler.next_schedule_in().value_or(delay_time);
@@ -130,7 +128,7 @@ void Application::loop() {
     next_schedule = std::max(next_schedule, delay_time / 2);
     delay_time = std::min(next_schedule, delay_time);
 
-    this->delay_with_select_(delay_time);
+    this->yield_with_select_(delay_time);
   }
   this->last_loop_ = last_op_end_time;
 
@@ -219,7 +217,7 @@ void Application::teardown_components(uint32_t timeout_ms) {
 
     // Give some time for I/O operations if components are still pending
     if (!pending_components.empty()) {
-      this->delay_with_select_(1);
+      this->yield_with_select_(1);
     }
 
     // Update time for next iteration
@@ -297,8 +295,6 @@ bool Application::is_socket_ready(int fd) const {
   // This function is thread-safe for reading the result of select()
   // However, it should only be called after select() has been executed in the main loop
   // The read_fds_ is only modified by select() in the main loop
-  if (HighFrequencyLoopRequester::is_high_frequency())
-    return true;  // fd sets via select are not updated in high frequency looping - so force true fallback behavior
   if (fd < 0 || fd >= FD_SETSIZE)
     return false;
 
@@ -306,7 +302,9 @@ bool Application::is_socket_ready(int fd) const {
 }
 #endif
 
-void Application::delay_with_select_(uint32_t delay_ms) {
+void Application::yield_with_select_(uint32_t delay_ms) {
+  // Delay while monitoring sockets. When delay_ms is 0, always yield() to ensure other tasks run
+  // since select() with 0 timeout only polls without yielding.
 #ifdef USE_SOCKET_SELECT_SUPPORT
   if (!this->socket_fds_.empty()) {
     // Update fd_set if socket list has changed
@@ -343,6 +341,10 @@ void Application::delay_with_select_(uint32_t delay_ms) {
       // Actual error - log and fall back to delay
       ESP_LOGW(TAG, "select() failed with errno %d", errno);
       delay(delay_ms);
+    }
+    // When delay_ms is 0, we need to yield since select(0) doesn't yield
+    if (delay_ms == 0) {
+      yield();
     }
   } else {
     // No sockets registered, use regular delay

--- a/esphome/core/application.cpp
+++ b/esphome/core/application.cpp
@@ -116,7 +116,11 @@ void Application::loop() {
 
   // Use the last component's end time instead of calling millis() again
   auto elapsed = last_op_end_time - this->last_loop_;
-  if (elapsed >= this->loop_interval_ || HighFrequencyLoopRequester::is_high_frequency()) {
+  if (elapsed >= this->loop_interval_) {
+    // Even if we overran the loop interval, we still need to select()
+    // to know if any sockets have data ready
+    this->delay_with_select_(0);
+  } else if (HighFrequencyLoopRequester::is_high_frequency()) {
     yield();
   } else {
     uint32_t delay_time = this->loop_interval_ - elapsed;

--- a/esphome/core/application.h
+++ b/esphome/core/application.h
@@ -575,7 +575,7 @@ class Application {
   void feed_wdt_arch_();
 
   /// Perform a delay while also monitoring socket file descriptors for readiness
-  void delay_with_select_(uint32_t delay_ms);
+  void yield_with_select_(uint32_t delay_ms);
 
   std::vector<Component *> components_{};
   std::vector<Component *> looping_components_{};


### PR DESCRIPTION
# What does this implement/fix?

This PR fixes an issue where network sockets would not be checked for readiness when the main loop execution time exceeded the configured loop interval. Previously, when components took longer than expected to execute, the system would skip the select() call entirely, potentially missing incoming network events during periods of high system load.

The fix ensures that even when the loop overruns its allocated time, a non-blocking select() is performed to check for socket readiness before continuing to the next iteration. Additionally, it fixes a bug where `yield()` was being called even when `select()` wasn't actually executed (when no sockets were registered).

## Changes made:

1. **Renamed `delay_with_select_()` to `yield_with_select_()`** to better reflect its purpose
2. **Fixed yield behavior**: The function now ensures `yield()` is called when `delay_ms` is 0, since `select()` with 0 timeout doesn't yield
3. **Removed workaround**: Reverted commit cdae06e571da27337bab0be1ab6cc781889467fb that forced `is_socket_ready()` to return true during high frequency loops, as it's no longer needed

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes #(issue number if applicable)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#(not required - internal fix)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - this is an internal fix
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs)