### PR TITLE
[esp32] Dynamically set default framework based on variant

### DIFF
--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -630,6 +630,21 @@ ESP_IDF_FRAMEWORK_SCHEMA = cv.All(
 )
 
 
+def _set_default_framework(config):
+    if CONF_FRAMEWORK not in config:
+        config = config.copy()
+
+        variant = config[CONF_VARIANT]
+        if variant in ARDUINO_ALLOWED_VARIANTS:
+            config[CONF_FRAMEWORK] = ARDUINO_FRAMEWORK_SCHEMA({})
+            config[CONF_FRAMEWORK][CONF_TYPE] = FRAMEWORK_ARDUINO
+        else:
+            config[CONF_FRAMEWORK] = ESP_IDF_FRAMEWORK_SCHEMA({})
+            config[CONF_FRAMEWORK][CONF_TYPE] = FRAMEWORK_ESP_IDF
+
+    return config
+
+
 FRAMEWORK_ESP_IDF = "esp-idf"
 FRAMEWORK_ARDUINO = "arduino"
 FRAMEWORK_SCHEMA = cv.typed_schema(
@@ -639,7 +654,6 @@ FRAMEWORK_SCHEMA = cv.typed_schema(
     },
     lower=True,
     space="-",
-    default_type=FRAMEWORK_ARDUINO,
 )
 
 
@@ -666,10 +680,11 @@ CONFIG_SCHEMA = cv.All(
             ),
             cv.Optional(CONF_PARTITIONS): cv.file_,
             cv.Optional(CONF_VARIANT): cv.one_of(*VARIANTS, upper=True),
-            cv.Optional(CONF_FRAMEWORK, default={}): FRAMEWORK_SCHEMA,
+            cv.Optional(CONF_FRAMEWORK): FRAMEWORK_SCHEMA,
         }
     ),
     _detect_variant,
+    _set_default_framework,
     set_core_data,
 )
 

--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -94,6 +94,13 @@ COMPILER_OPTIMIZATIONS = {
     "SIZE": "CONFIG_COMPILER_OPTIMIZATION_SIZE",
 }
 
+ARDUINO_ALLOWED_VARIANTS = [
+    VARIANT_ESP32,
+    VARIANT_ESP32C3,
+    VARIANT_ESP32S2,
+    VARIANT_ESP32S3,
+]
+
 
 def get_cpu_frequencies(*frequencies):
     return [str(x) + "MHZ" for x in frequencies]
@@ -143,12 +150,17 @@ def set_core_data(config):
         CORE.data[KEY_ESP32][KEY_COMPONENTS] = {}
     elif conf[CONF_TYPE] == FRAMEWORK_ARDUINO:
         CORE.data[KEY_CORE][KEY_TARGET_FRAMEWORK] = "arduino"
+        if variant not in ARDUINO_ALLOWED_VARIANTS:
+            raise cv.Invalid(
+                f"ESPHome does not support using the Arduino framework for the {variant}. Please use the ESP-IDF framework instead.",
+                path=[CONF_FRAMEWORK, CONF_TYPE],
+            )
     CORE.data[KEY_CORE][KEY_FRAMEWORK_VERSION] = cv.Version.parse(
         config[CONF_FRAMEWORK][CONF_VERSION]
     )
 
     CORE.data[KEY_ESP32][KEY_BOARD] = config[CONF_BOARD]
-    CORE.data[KEY_ESP32][KEY_VARIANT] = config[CONF_VARIANT]
+    CORE.data[KEY_ESP32][KEY_VARIANT] = variant
     CORE.data[KEY_ESP32][KEY_EXTRA_BUILD_FILES] = {}
 
     return config

--- a/esphome/wizard.py
+++ b/esphome/wizard.py
@@ -70,20 +70,6 @@ ESP32_CONFIG = """
 esp32:
   board: {board}
   framework:
-    type: arduino
-"""
-
-ESP32S2_CONFIG = """
-esp32:
-  board: {board}
-  framework:
-    type: esp-idf
-"""
-
-ESP32C3_CONFIG = """
-esp32:
-  board: {board}
-  framework:
     type: esp-idf
 """
 
@@ -105,8 +91,6 @@ rtl87xx:
 HARDWARE_BASE_CONFIGS = {
     "ESP8266": ESP8266_CONFIG,
     "ESP32": ESP32_CONFIG,
-    "ESP32S2": ESP32S2_CONFIG,
-    "ESP32C3": ESP32C3_CONFIG,
     "RP2040": RP2040_CONFIG,
     "BK72XX": BK72XX_CONFIG,
     "RTL87XX": RTL87XX_CONFIG,


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

- Set default framework based on the variant this config is for
  - Arduino:
    - ESP32
    - ESP32-C3
    - ESP32-S2
    - ESP32-S3
  - ESP-IDF
    - ESP32-C2
    - ESP32-C5
    - ESP32-C6
    - ESP32-H2
    - ESP32-P4
- Only allow specific variants to use Arduino as a framework
  - ESP32
  - ESP32-C3
  - ESP32-S2
  - ESP32-S3

These variants require Arduino 3 which is not ready yet for ESPHome.
I believe even once ESPHOme has bumped the Arduino version to 3+, we still should only allow ESP-IDF for any variant not in this list and any new ones added.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
