### PR TITLE
[nextion] Remove upload flags reset from success path to prevent TFT corruption

### DIFF
--- a/esphome/components/nextion/nextion_upload_arduino.cpp
+++ b/esphome/components/nextion/nextion_upload_arduino.cpp
@@ -337,23 +337,26 @@ bool Nextion::upload_tft(uint32_t baud_rate, bool exit_reparse) {
 
 bool Nextion::upload_end_(bool successful) {
   ESP_LOGD(TAG, "TFT upload done: %s", YESNO(successful));
-  this->is_updating_ = false;
-  this->ignore_is_setup_ = false;
-
-  uint32_t baud_rate = this->parent_->get_baud_rate();
-  if (baud_rate != this->original_baud_rate_) {
-    ESP_LOGD(TAG, "Baud back: %" PRIu32 "->%" PRIu32, baud_rate, this->original_baud_rate_);
-    this->parent_->set_baud_rate(this->original_baud_rate_);
-    this->parent_->load_settings();
-  }
 
   if (successful) {
     ESP_LOGD(TAG, "Restart");
     delay(1500);  // NOLINT
     App.safe_reboot();
+    delay(1500);  // NOLINT
   } else {
     ESP_LOGE(TAG, "TFT upload failed");
+
+    this->is_updating_ = false;
+    this->ignore_is_setup_ = false;
+
+    uint32_t baud_rate = this->parent_->get_baud_rate();
+    if (baud_rate != this->original_baud_rate_) {
+      ESP_LOGD(TAG, "Baud back: %" PRIu32 "->%" PRIu32, baud_rate, this->original_baud_rate_);
+      this->parent_->set_baud_rate(this->original_baud_rate_);
+      this->parent_->load_settings();
+    }
   }
+
   return successful;
 }
 

--- a/esphome/components/nextion/nextion_upload_idf.cpp
+++ b/esphome/components/nextion/nextion_upload_idf.cpp
@@ -337,15 +337,6 @@ bool Nextion::upload_tft(uint32_t baud_rate, bool exit_reparse) {
 
 bool Nextion::upload_end_(bool successful) {
   ESP_LOGD(TAG, "TFT upload done: %s", YESNO(successful));
-  this->is_updating_ = false;
-  this->ignore_is_setup_ = false;
-
-  uint32_t baud_rate = this->parent_->get_baud_rate();
-  if (baud_rate != this->original_baud_rate_) {
-    ESP_LOGD(TAG, "Baud back: %" PRIu32 "->%" PRIu32, baud_rate, this->original_baud_rate_);
-    this->parent_->set_baud_rate(this->original_baud_rate_);
-    this->parent_->load_settings();
-  }
 
   if (successful) {
     ESP_LOGD(TAG, "Restart");
@@ -353,7 +344,18 @@ bool Nextion::upload_end_(bool successful) {
     App.safe_reboot();
   } else {
     ESP_LOGE(TAG, "TFT upload failed");
+
+    this->is_updating_ = false;
+    this->ignore_is_setup_ = false;
+
+    uint32_t baud_rate = this->parent_->get_baud_rate();
+    if (baud_rate != this->original_baud_rate_) {
+      ESP_LOGD(TAG, "Baud back: %" PRIu32 "->%" PRIu32, baud_rate, this->original_baud_rate_);
+      this->parent_->set_baud_rate(this->original_baud_rate_);
+      this->parent_->load_settings();
+    }
   }
+
   return successful;
 }
 


### PR DESCRIPTION
# What does this implement/fix?

Moves the `App.safe_reboot()` call before setting upload completion flags (`is_updating_` and `ignore_is_setup_`) to prevent potential TFT corruption during the restart window.

### Summary
Removes upload flags reset from the success path on TFT uploads to prevent potential display corruption during the restart window.

### Problem
The previous implementation reset upload flags (`is_updating_`, `ignore_is_setup_`) before calling `App.safe_reboot()`, creating a brief window where other system components could send commands to the display during the graceful restart process. Any data sent during this window would be interpreted by the Nextion display as part of the TFT file, causing a "System DATA error!" and requiring a new transfer.

### Solution
Removes upload flags reset from the success path entirely:
- Success path: Restart immediately without resetting upload flags (flags will be reset by reboot, no timing window)
- Failure path: Proper cleanup of upload flags and baud rate restoration (system continues running)

This prevents the corruption issue by ensuring no system components can detect upload completion and send display commands before the restart occurs.

For more details, please look at this thread on Discord: https://discord.com/channels/429907082951524364/1382496793442648176

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes esphome/issues#7109

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [ ] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`: N/A

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
