### PR TITLE
Fix ``captive_portal`` loading entire ``web_server``

### DIFF
--- a/esphome/components/web_server_idf/__init__.py
+++ b/esphome/components/web_server_idf/__init__.py
@@ -8,8 +8,6 @@ CONFIG_SCHEMA = cv.All(
     cv.only_with_esp_idf,
 )
 
-AUTO_LOAD = ["web_server"]
-
 
 async def to_code(config):
     # Increase the maximum supported size of headers section in HTTP request packet to be processed by the server

--- a/esphome/components/web_server_idf/web_server_idf.cpp
+++ b/esphome/components/web_server_idf/web_server_idf.cpp
@@ -14,7 +14,7 @@
 #ifdef USE_WEBSERVER
 #include "esphome/components/web_server/web_server.h"
 #include "esphome/components/web_server/list_entities.h"
-#endif // USE_WEBSERVER
+#endif  // USE_WEBSERVER
 
 namespace esphome {
 namespace web_server_idf {

--- a/esphome/components/web_server_idf/web_server_idf.cpp
+++ b/esphome/components/web_server_idf/web_server_idf.cpp
@@ -14,7 +14,7 @@
 #ifdef USE_WEBSERVER
 #include "esphome/components/web_server/web_server.h"
 #include "esphome/components/web_server/list_entities.h"
-#endif
+#endif // USE_WEBSERVER
 
 namespace esphome {
 namespace web_server_idf {

--- a/esphome/components/web_server_idf/web_server_idf.cpp
+++ b/esphome/components/web_server_idf/web_server_idf.cpp
@@ -2,7 +2,6 @@
 
 #include <cstdarg>
 
-#include "esphome/core/defines.h"
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
@@ -10,12 +9,12 @@
 
 #include "utils.h"
 
+#include "web_server_idf.h"
+
 #ifdef USE_WEBSERVER
 #include "esphome/components/web_server/web_server.h"
 #include "esphome/components/web_server/list_entities.h"
 #endif
-
-#include "web_server_idf.h"
 
 namespace esphome {
 namespace web_server_idf {

--- a/esphome/components/web_server_idf/web_server_idf.cpp
+++ b/esphome/components/web_server_idf/web_server_idf.cpp
@@ -9,8 +9,10 @@
 
 #include "utils.h"
 
+#ifdef USE_WEBSERVER
 #include "esphome/components/web_server/web_server.h"
 #include "esphome/components/web_server/list_entities.h"
+#endif
 
 #include "web_server_idf.h"
 
@@ -273,6 +275,7 @@ void AsyncResponseStream::printf(const char *fmt, ...) {
   this->print(str);
 }
 
+#ifdef USE_WEBSERVER
 AsyncEventSource::~AsyncEventSource() {
   for (auto *ses : this->sessions_) {
     delete ses;  // NOLINT(cppcoreguidelines-owning-memory)
@@ -511,6 +514,7 @@ void AsyncEventSourceResponse::deferrable_send_state(void *source, const char *e
     }
   }
 }
+#endif
 
 }  // namespace web_server_idf
 }  // namespace esphome

--- a/esphome/components/web_server_idf/web_server_idf.cpp
+++ b/esphome/components/web_server_idf/web_server_idf.cpp
@@ -2,6 +2,7 @@
 
 #include <cstdarg>
 
+#include "esphome/core/defines.h"
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 

--- a/esphome/components/web_server_idf/web_server_idf.h
+++ b/esphome/components/web_server_idf/web_server_idf.h
@@ -1,6 +1,7 @@
 #pragma once
 #ifdef USE_ESP_IDF
 
+#include "esphome/core/defines.h"
 #include <esp_http_server.h>
 
 #include <functional>

--- a/esphome/components/web_server_idf/web_server_idf.h
+++ b/esphome/components/web_server_idf/web_server_idf.h
@@ -311,7 +311,7 @@ class AsyncEventSource : public AsyncWebHandler {
   connect_handler_t on_connect_{};
   esphome::web_server::WebServer *web_server_;
 };
-#endif
+#endif  // USE_WEBSERVER
 
 class DefaultHeaders {
   friend class AsyncWebServerRequest;

--- a/esphome/components/web_server_idf/web_server_idf.h
+++ b/esphome/components/web_server_idf/web_server_idf.h
@@ -12,10 +12,12 @@
 #include <vector>
 
 namespace esphome {
+#ifdef USE_WEBSERVER
 namespace web_server {
 class WebServer;
 class ListEntitiesIterator;
 };  // namespace web_server
+#endif
 namespace web_server_idf {
 
 #define F(string_literal) (string_literal)
@@ -220,6 +222,7 @@ class AsyncWebHandler {
   virtual bool isRequestHandlerTrivial() { return true; }
 };
 
+#ifdef USE_WEBSERVER
 class AsyncEventSource;
 class AsyncEventSourceResponse;
 
@@ -307,10 +310,13 @@ class AsyncEventSource : public AsyncWebHandler {
   connect_handler_t on_connect_{};
   esphome::web_server::WebServer *web_server_;
 };
+#endif
 
 class DefaultHeaders {
   friend class AsyncWebServerRequest;
+#ifdef USE_WEBSERVER
   friend class AsyncEventSourceResponse;
+#endif
 
  public:
   // NOLINTNEXTLINE(readability-identifier-naming)


### PR DESCRIPTION
# What does this implement/fix?

## Quick description
This PR fixes an issue where the `captive_portal` component automatically includes the full `web_server` component when using the ESP-IDF framework, causing unnecessary binary size increase.

This PR fixes a regression introduced in PR #7538 where the `web_server_idf` component was set to automatically load the full `web_server` component. This caused the `captive_portal` component to inadvertently include the web server functionality when using ESP-IDF framework, significantly increasing binary size.

### Root Cause
The `captive_portal` component depends on `web_server_base`, which conditionally loads `web_server_idf` when using ESP-IDF. The `web_server_idf` component had `AUTO_LOAD = ["web_server"]`, creating an unwanted dependency chain:
```
captive_portal → web_server_base → web_server_idf → web_server
```

### Solution
1. Removed the `AUTO_LOAD = ["web_server"]` directive from `web_server_idf/__init__.py`
2. Added conditional compilation guards (`#ifdef USE_WEBSERVER`) around web_server-specific code in `web_server_idf` to ensure it compiles correctly both with and without the web_server component

### Changes Made
- **esphome/components/web_server_idf/__init__.py**: Removed `AUTO_LOAD = ["web_server"]`
- **esphome/components/web_server_idf/web_server_idf.h**: Added `#ifdef USE_WEBSERVER` guards around:
  - Forward declarations for `web_server::WebServer` and `web_server::ListEntitiesIterator`
  - `AsyncEventSource` and `AsyncEventSourceResponse` class declarations
  - `DeferredEvent` struct and `message_generator_t` type definition
  - Friend declaration in `DefaultHeaders` class
- **esphome/components/web_server_idf/web_server_idf.cpp**: Added `#ifdef USE_WEBSERVER` guards around:
  - Include statements for web_server headers
  - All `AsyncEventSource` and `AsyncEventSourceResponse` method implementations

### Testing
- Verified that `captive_portal` alone no longer includes `web_server` component
- Verified that explicitly including `web_server` still works correctly
- Confirmed `USE_WEBSERVER` is only defined when `web_server` component is explicitly included
- Both configurations compile successfully on ESP-IDF framework

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes https://github.com/esphome/issues/issues/6883 fixes https://github.com/esphome/issues/issues/7112

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Test configuration showing captive_portal no longer pulls in web_server
esphome:
  name: captive-portal-test

esp32:
  board: esp32doit-devkit-v1
  framework:
    type: esp-idf

wifi:
  ssid: "test_network"
  password: "test1234"

# This should NOT automatically include web_server component
captive_portal:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs)