### PR TITLE
Image byte order

### DIFF
--- a/esphome/components/image/__init__.py
+++ b/esphome/components/image/__init__.py
@@ -5,6 +5,7 @@ import io
 import logging
 from pathlib import Path
 import re
+import struct
 
 from PIL import Image, UnidentifiedImageError
 
@@ -597,7 +598,15 @@ async def write_image(config, all_frames=False):
                 encoder.encode(pixels[row * width + col])
             encoder.end_row()
 
-    rhs = [HexInt(x) for x in encoder.data]
+    byte_order = config[CONF_BYTE_ORDER]
+    if byte_order == "big_endian":
+        image_data = encoder.data
+    else:
+        bytebuffer = [x[0] for x in struct.iter_unpack("<H", bytes(encoder.data))]
+        image_data = struct.pack(f">{len(bytebuffer) * 'H'}", *bytebuffer)
+
+    rhs = [HexInt(x) for x in image_data]
+
     prog_arr = cg.progmem_array(config[CONF_RAW_DATA_ID], rhs)
     image_type = get_image_type_enum(type)
     trans_value = get_transparency_enum(encoder.transparency)

--- a/esphome/components/image/__init__.py
+++ b/esphome/components/image/__init__.py
@@ -38,6 +38,7 @@ CONF_OPAQUE = "opaque"
 CONF_CHROMA_KEY = "chroma_key"
 CONF_ALPHA_CHANNEL = "alpha_channel"
 CONF_INVERT_ALPHA = "invert_alpha"
+CONF_BYTE_ORDER = "byte_order"
 
 TRANSPARENCY_TYPES = (
     CONF_OPAQUE,
@@ -469,6 +470,9 @@ BASE_SCHEMA = cv.Schema(
             "NONE", "FLOYDSTEINBERG", upper=True
         ),
         cv.Optional(CONF_INVERT_ALPHA, default=False): cv.boolean,
+        cv.Optional(CONF_BYTE_ORDER, default="big_endian"): cv.one_of(
+            "big_endian", "little_endian"
+        ),
         cv.GenerateID(CONF_RAW_DATA_ID): cv.declare_id(cg.uint8),
     }
 ).add_extra(validate_settings)


### PR DESCRIPTION
# What does this implement/fix?

Add option to output little endian byte order for image buffers.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
image:
  - file: 'source/images/back72.png'
    id: back
    type: RGB565
    byte_order: little_endian 
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
