### PR TITLE
Fix API message encoding to return actual size instead of calculated size

### DIFF
--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -256,7 +256,7 @@ uint16_t APIConnection::encode_message_to_buffer(ProtoMessage &msg, uint16_t mes
   const uint8_t footer_size = conn->helper_->frame_footer_size();
 
   // Calculate total size with padding for buffer allocation
-  uint16_t total_calculated_size = static_cast<uint16_t>(calculated_size) + header_padding + footer_size;
+  size_t total_calculated_size = calculated_size + header_padding + footer_size;
 
   // Check if it fits
   if (total_calculated_size > remaining_size) {
@@ -278,11 +278,11 @@ uint16_t APIConnection::encode_message_to_buffer(ProtoMessage &msg, uint16_t mes
   size_t actual_payload_size = shared_buf.size() - size_before_encode;
 
   // Return actual total size (header + actual payload + footer)
-  uint16_t actual_total_size = header_padding + static_cast<uint16_t>(actual_payload_size) + footer_size;
+  size_t actual_total_size = header_padding + actual_payload_size + footer_size;
 
   // Verify that calculate_size() returned the correct value
   assert(calculated_size == actual_payload_size);
-  return actual_total_size;
+  return static_cast<uint16_t>(actual_total_size);
 }
 
 #ifdef USE_BINARY_SENSOR

--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -248,25 +248,41 @@ void APIConnection::on_disconnect_response(const DisconnectResponse &value) {
 uint16_t APIConnection::encode_message_to_buffer(ProtoMessage &msg, uint16_t message_type, APIConnection *conn,
                                                  uint32_t remaining_size, bool is_single) {
   // Calculate size
-  uint32_t size = 0;
-  msg.calculate_size(size);
+  uint32_t calculated_size = 0;
+  msg.calculate_size(calculated_size);
+
+  // Cache frame sizes to avoid repeated virtual calls
+  const uint8_t header_padding = conn->helper_->frame_header_padding();
+  const uint8_t footer_size = conn->helper_->frame_footer_size();
 
   // Calculate total size with padding for buffer allocation
-  uint16_t total_size =
-      static_cast<uint16_t>(size) + conn->helper_->frame_header_padding() + conn->helper_->frame_footer_size();
+  uint16_t total_calculated_size = static_cast<uint16_t>(calculated_size) + header_padding + footer_size;
 
   // Check if it fits
-  if (total_size > remaining_size) {
+  if (total_calculated_size > remaining_size) {
     return 0;  // Doesn't fit
   }
 
   // Allocate buffer space - pass payload size, allocation functions add header/footer space
-  ProtoWriteBuffer buffer =
-      is_single ? conn->allocate_single_message_buffer(size) : conn->allocate_batch_message_buffer(size);
+  ProtoWriteBuffer buffer = is_single ? conn->allocate_single_message_buffer(calculated_size)
+                                      : conn->allocate_batch_message_buffer(calculated_size);
+
+  // Get buffer size after allocation (which includes header padding)
+  std::vector<uint8_t> &shared_buf = conn->parent_->get_shared_buffer_ref();
+  size_t size_before_encode = shared_buf.size();
 
   // Encode directly into buffer
   msg.encode(buffer);
-  return total_size;
+
+  // Calculate actual encoded size (not including header that was already added)
+  size_t actual_payload_size = shared_buf.size() - size_before_encode;
+
+  // Return actual total size (header + actual payload + footer)
+  uint16_t actual_total_size = header_padding + static_cast<uint16_t>(actual_payload_size) + footer_size;
+
+  // Verify that calculate_size() returned the correct value
+  assert(calculated_size == actual_payload_size);
+  return actual_total_size;
 }
 
 #ifdef USE_BINARY_SENSOR

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -119,6 +119,21 @@ async def yaml_config(request: pytest.FixtureRequest, unused_tcp_port: int) -> s
         # Add port configuration after api:
         content = content.replace("api:", f"api:\n  port: {unused_tcp_port}")
 
+    # Add debug build flags for integration tests to enable assertions
+    if "esphome:" in content:
+        # Check if platformio_options already exists
+        if "platformio_options:" not in content:
+            # Add platformio_options with debug flags after esphome:
+            content = content.replace(
+                "esphome:",
+                "esphome:\n"
+                "  # Enable assertions for integration tests\n"
+                "  platformio_options:\n"
+                "    build_flags:\n"
+                '      - "-DDEBUG"  # Enable assert() statements\n'
+                '      - "-g"       # Add debug symbols',
+            )
+
     return content
 
 


### PR DESCRIPTION
## Description

This PR fixes a bug in `APIConnection::encode_message_to_buffer` where the function was returning the pre-calculated message size instead of the actual encoded size. This could lead to corruption in batch message processing if the `calculate_size()` method returned an incorrect value.

The fix ensures that batch message offset calculations are always correct by tracking the actual bytes written to the buffer during encoding.

### What it does?

- Tracks the actual number of bytes written during protobuf encoding
- Returns the real size (header + actual payload + footer) instead of the calculated size
- Adds an assertion to catch any mismatches between calculated and actual sizes during development

### Why is it needed?

If a protobuf message's `calculate_size()` method returns an incorrect value (due to a bug in the auto-generated code or manual implementation), the batch processing logic would use wrong offsets for subsequent messages, potentially corrupting the message stream and causing decoding errors on the Home Assistant side.

## Types of Changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

## Related information

This issue was discovered while investigating potential protobuf message size calculation issues in the auto-generated `api_pb2.cpp` file.

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

Tested on host platform only.

## Example configuration

```yaml
# Any configuration with API and entities will test this code path
esphome:
  name: test-device

host:

logger:

api:

select:
  - platform: template
    name: "Test Select"
    options:
      - "Option 1"
      - "Option 2" 
      - "Option 3"
    optimistic: true

sensor:
  - platform: template
    name: "Test Sensor"
    lambda: return 42.0;
```

## Checklist

- [x] The code change is tested and works locally.
- [ ] Tests have been added to verify that the new code works (help needed).
- [ ] This is a bug fix and doesn't need documentation updates.

## Additional Notes

The performance impact is negligible (2-3 arithmetic operations per message). In fact, this could improve performance in cases where `calculate_size()` overestimates, allowing more messages to fit in each batch.

The assert will help catch any `calculate_size()` implementation bugs during development but won't affect release builds.