### PR TITLE
Optimize memory usage by lazy-allocating raw callbacks in sensors

### DIFF
--- a/esphome/components/sensor/sensor.cpp
+++ b/esphome/components/sensor/sensor.cpp
@@ -21,6 +21,7 @@ std::string state_class_to_string(StateClass state_class) {
 }
 
 Sensor::Sensor() : state(NAN), raw_state(NAN) {}
+Sensor::~Sensor() { delete this->raw_callback_; }
 
 int8_t Sensor::get_accuracy_decimals() {
   if (this->accuracy_decimals_.has_value())
@@ -38,7 +39,9 @@ StateClass Sensor::get_state_class() {
 
 void Sensor::publish_state(float state) {
   this->raw_state = state;
-  this->raw_callback_.call(state);
+  if (this->raw_callback_ != nullptr) {
+    this->raw_callback_->call(state);
+  }
 
   ESP_LOGV(TAG, "'%s': Received new state %f", this->name_.c_str(), state);
 
@@ -51,7 +54,10 @@ void Sensor::publish_state(float state) {
 
 void Sensor::add_on_state_callback(std::function<void(float)> &&callback) { this->callback_.add(std::move(callback)); }
 void Sensor::add_on_raw_state_callback(std::function<void(float)> &&callback) {
-  this->raw_callback_.add(std::move(callback));
+  if (this->raw_callback_ == nullptr) {
+    this->raw_callback_ = new CallbackManager<void(float)>();  // NOLINT
+  }
+  this->raw_callback_->add(std::move(callback));
 }
 
 void Sensor::add_filter(Filter *filter) {

--- a/esphome/components/sensor/sensor.cpp
+++ b/esphome/components/sensor/sensor.cpp
@@ -21,7 +21,6 @@ std::string state_class_to_string(StateClass state_class) {
 }
 
 Sensor::Sensor() : state(NAN), raw_state(NAN) {}
-Sensor::~Sensor() { delete this->raw_callback_; }
 
 int8_t Sensor::get_accuracy_decimals() {
   if (this->accuracy_decimals_.has_value())
@@ -39,7 +38,7 @@ StateClass Sensor::get_state_class() {
 
 void Sensor::publish_state(float state) {
   this->raw_state = state;
-  if (this->raw_callback_ != nullptr) {
+  if (this->raw_callback_) {
     this->raw_callback_->call(state);
   }
 
@@ -54,8 +53,8 @@ void Sensor::publish_state(float state) {
 
 void Sensor::add_on_state_callback(std::function<void(float)> &&callback) { this->callback_.add(std::move(callback)); }
 void Sensor::add_on_raw_state_callback(std::function<void(float)> &&callback) {
-  if (this->raw_callback_ == nullptr) {
-    this->raw_callback_ = new CallbackManager<void(float)>();  // NOLINT
+  if (!this->raw_callback_) {
+    this->raw_callback_ = std::make_unique<CallbackManager<void(float)>>();
   }
   this->raw_callback_->add(std::move(callback));
 }

--- a/esphome/components/sensor/sensor.h
+++ b/esphome/components/sensor/sensor.h
@@ -7,6 +7,7 @@
 #include "esphome/components/sensor/filter.h"
 
 #include <vector>
+#include <memory>
 
 namespace esphome {
 namespace sensor {
@@ -61,7 +62,6 @@ std::string state_class_to_string(StateClass state_class);
 class Sensor : public EntityBase, public EntityBase_DeviceClass, public EntityBase_UnitOfMeasurement {
  public:
   explicit Sensor();
-  ~Sensor();
 
   /// Get the accuracy in decimals, using the manual override if set.
   int8_t get_accuracy_decimals();
@@ -153,8 +153,8 @@ class Sensor : public EntityBase, public EntityBase_DeviceClass, public EntityBa
   void internal_send_state_to_frontend(float state);
 
  protected:
-  CallbackManager<void(float)> *raw_callback_{nullptr};  ///< Storage for raw state callbacks (lazy allocated).
-  CallbackManager<void(float)> callback_;                ///< Storage for filtered state callbacks.
+  std::unique_ptr<CallbackManager<void(float)>> raw_callback_;  ///< Storage for raw state callbacks (lazy allocated).
+  CallbackManager<void(float)> callback_;                       ///< Storage for filtered state callbacks.
 
   Filter *filter_list_{nullptr};  ///< Store all active filters.
 

--- a/esphome/components/sensor/sensor.h
+++ b/esphome/components/sensor/sensor.h
@@ -61,6 +61,7 @@ std::string state_class_to_string(StateClass state_class);
 class Sensor : public EntityBase, public EntityBase_DeviceClass, public EntityBase_UnitOfMeasurement {
  public:
   explicit Sensor();
+  ~Sensor();
 
   /// Get the accuracy in decimals, using the manual override if set.
   int8_t get_accuracy_decimals();
@@ -152,8 +153,8 @@ class Sensor : public EntityBase, public EntityBase_DeviceClass, public EntityBa
   void internal_send_state_to_frontend(float state);
 
  protected:
-  CallbackManager<void(float)> raw_callback_;  ///< Storage for raw state callbacks.
-  CallbackManager<void(float)> callback_;      ///< Storage for filtered state callbacks.
+  CallbackManager<void(float)> *raw_callback_{nullptr};  ///< Storage for raw state callbacks (lazy allocated).
+  CallbackManager<void(float)> callback_;                ///< Storage for filtered state callbacks.
 
   Filter *filter_list_{nullptr};  ///< Store all active filters.
 

--- a/esphome/components/text_sensor/text_sensor.cpp
+++ b/esphome/components/text_sensor/text_sensor.cpp
@@ -6,11 +6,9 @@ namespace text_sensor {
 
 static const char *const TAG = "text_sensor";
 
-TextSensor::~TextSensor() { delete this->raw_callback_; }
-
 void TextSensor::publish_state(const std::string &state) {
   this->raw_state = state;
-  if (this->raw_callback_ != nullptr) {
+  if (this->raw_callback_) {
     this->raw_callback_->call(state);
   }
 
@@ -57,8 +55,8 @@ void TextSensor::add_on_state_callback(std::function<void(std::string)> callback
   this->callback_.add(std::move(callback));
 }
 void TextSensor::add_on_raw_state_callback(std::function<void(std::string)> callback) {
-  if (this->raw_callback_ == nullptr) {
-    this->raw_callback_ = new CallbackManager<void(std::string)>();  // NOLINT
+  if (!this->raw_callback_) {
+    this->raw_callback_ = std::make_unique<CallbackManager<void(std::string)>>();
   }
   this->raw_callback_->add(std::move(callback));
 }

--- a/esphome/components/text_sensor/text_sensor.cpp
+++ b/esphome/components/text_sensor/text_sensor.cpp
@@ -6,9 +6,13 @@ namespace text_sensor {
 
 static const char *const TAG = "text_sensor";
 
+TextSensor::~TextSensor() { delete this->raw_callback_; }
+
 void TextSensor::publish_state(const std::string &state) {
   this->raw_state = state;
-  this->raw_callback_.call(state);
+  if (this->raw_callback_ != nullptr) {
+    this->raw_callback_->call(state);
+  }
 
   ESP_LOGV(TAG, "'%s': Received new state %s", this->name_.c_str(), state.c_str());
 
@@ -53,7 +57,10 @@ void TextSensor::add_on_state_callback(std::function<void(std::string)> callback
   this->callback_.add(std::move(callback));
 }
 void TextSensor::add_on_raw_state_callback(std::function<void(std::string)> callback) {
-  this->raw_callback_.add(std::move(callback));
+  if (this->raw_callback_ == nullptr) {
+    this->raw_callback_ = new CallbackManager<void(std::string)>();  // NOLINT
+  }
+  this->raw_callback_->add(std::move(callback));
 }
 
 std::string TextSensor::get_state() const { return this->state; }

--- a/esphome/components/text_sensor/text_sensor.h
+++ b/esphome/components/text_sensor/text_sensor.h
@@ -6,6 +6,7 @@
 #include "esphome/components/text_sensor/filter.h"
 
 #include <vector>
+#include <memory>
 
 namespace esphome {
 namespace text_sensor {
@@ -34,7 +35,6 @@ namespace text_sensor {
 class TextSensor : public EntityBase, public EntityBase_DeviceClass {
  public:
   TextSensor() = default;
-  ~TextSensor();
 
   /// Getter-syntax for .state.
   std::string get_state() const;
@@ -75,8 +75,9 @@ class TextSensor : public EntityBase, public EntityBase_DeviceClass {
   void internal_send_state_to_frontend(const std::string &state);
 
  protected:
-  CallbackManager<void(std::string)> *raw_callback_{nullptr};  ///< Storage for raw state callbacks (lazy allocated).
-  CallbackManager<void(std::string)> callback_;                ///< Storage for filtered state callbacks.
+  std::unique_ptr<CallbackManager<void(std::string)>>
+      raw_callback_;                             ///< Storage for raw state callbacks (lazy allocated).
+  CallbackManager<void(std::string)> callback_;  ///< Storage for filtered state callbacks.
 
   Filter *filter_list_{nullptr};  ///< Store all active filters.
 

--- a/esphome/components/text_sensor/text_sensor.h
+++ b/esphome/components/text_sensor/text_sensor.h
@@ -33,6 +33,9 @@ namespace text_sensor {
 
 class TextSensor : public EntityBase, public EntityBase_DeviceClass {
  public:
+  TextSensor() = default;
+  ~TextSensor();
+
   /// Getter-syntax for .state.
   std::string get_state() const;
   /// Getter-syntax for .raw_state
@@ -72,8 +75,8 @@ class TextSensor : public EntityBase, public EntityBase_DeviceClass {
   void internal_send_state_to_frontend(const std::string &state);
 
  protected:
-  CallbackManager<void(std::string)> raw_callback_;  ///< Storage for raw state callbacks.
-  CallbackManager<void(std::string)> callback_;      ///< Storage for filtered state callbacks.
+  CallbackManager<void(std::string)> *raw_callback_{nullptr};  ///< Storage for raw state callbacks (lazy allocated).
+  CallbackManager<void(std::string)> callback_;                ///< Storage for filtered state callbacks.
 
   Filter *filter_list_{nullptr};  ///< Store all active filters.
 


### PR DESCRIPTION
# What does this implement/fix?

This PR optimizes memory usage by making raw callbacks in sensors and text sensors lazily allocated. Raw callbacks are rarely used - they're only needed when using the `on_raw_value` automation trigger, which processes sensor values before any filters are applied.

In testing with 200+ sensors, we found that 100% of sensors had 0 raw callbacks. By changing `raw_callback_` from a member object to a lazily-allocated pointer using `std::unique_ptr`, we save the overhead of an empty `std::vector` for each sensor that doesn't use raw callbacks (which is the vast majority).

**Memory savings:**
- 12 bytes saved per sensor without raw callbacks (empty vector overhead)
- 12 bytes saved per text_sensor without raw callbacks
- For a typical configuration with 200 sensors: ~2.4KB RAM saved
- Real-world testing showed free memory increased from 102,004 to 104,324 bytes (2.3KB saved)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Related to memory optimization efforts for ESP8266 and other memory-constrained devices

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - No user-facing changes

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# No configuration changes needed - this is an internal optimization
# The following still works exactly as before:

sensor:
  - platform: template
    name: "My Sensor"
    lambda: return 42.0;
    # Raw callbacks only allocated if this automation is used:
    on_raw_value:
      - logger.log: "Raw value received"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - N/A - Internal optimization only, no user-facing changes