### PR TITLE
Optimize Component and Application state storage from uint32_t to uint8_t

### DIFF
--- a/esphome/components/bme280_base/bme280_base.cpp
+++ b/esphome/components/bme280_base/bme280_base.cpp
@@ -93,9 +93,8 @@ void BME280Component::setup() {
 
   // Mark as not failed before initializing. Some devices will turn off sensors to save on batteries
   // and when they come back on, the COMPONENT_STATE_FAILED bit must be unset on the component.
-  if ((this->component_state_ & COMPONENT_STATE_MASK) == COMPONENT_STATE_FAILED) {
-    this->component_state_ &= ~COMPONENT_STATE_MASK;
-    this->component_state_ |= COMPONENT_STATE_CONSTRUCTION;
+  if (this->is_failed()) {
+    this->reset_to_construction_state();
   }
 
   if (!this->read_byte(BME280_REGISTER_CHIPID, &chip_id)) {

--- a/esphome/components/kmeteriso/kmeteriso.cpp
+++ b/esphome/components/kmeteriso/kmeteriso.cpp
@@ -19,9 +19,8 @@ void KMeterISOComponent::setup() {
 
   // Mark as not failed before initializing. Some devices will turn off sensors to save on batteries
   // and when they come back on, the COMPONENT_STATE_FAILED bit must be unset on the component.
-  if ((this->component_state_ & COMPONENT_STATE_MASK) == COMPONENT_STATE_FAILED) {
-    this->component_state_ &= ~COMPONENT_STATE_MASK;
-    this->component_state_ |= COMPONENT_STATE_CONSTRUCTION;
+  if (this->is_failed()) {
+    this->reset_to_construction_state();
   }
 
   auto err = this->bus_->writev(this->address_, nullptr, 0);

--- a/esphome/components/status_led/light/status_led_light.cpp
+++ b/esphome/components/status_led/light/status_led_light.cpp
@@ -9,10 +9,10 @@ namespace status_led {
 static const char *const TAG = "status_led";
 
 void StatusLEDLightOutput::loop() {
-  uint32_t new_state = App.get_app_state() & STATUS_LED_MASK;
+  uint8_t new_state = App.get_app_state() & STATUS_LED_MASK;
 
   if (new_state != this->last_app_state_) {
-    ESP_LOGV(TAG, "New app state 0x%08" PRIX32, new_state);
+    ESP_LOGV(TAG, "New app state 0x%02X", new_state);
   }
 
   if ((new_state & STATUS_LED_ERROR) != 0u) {

--- a/esphome/components/status_led/light/status_led_light.h
+++ b/esphome/components/status_led/light/status_led_light.h
@@ -36,7 +36,7 @@ class StatusLEDLightOutput : public light::LightOutput, public Component {
   GPIOPin *pin_{nullptr};
   output::BinaryOutput *output_{nullptr};
   light::LightState *lightstate_{};
-  uint32_t last_app_state_{0xFFFF};
+  uint8_t last_app_state_{0xFF};
   void output_state_(bool state);
 };
 

--- a/esphome/components/weikai/weikai.cpp
+++ b/esphome/components/weikai/weikai.cpp
@@ -102,7 +102,7 @@ WeikaiRegister &WeikaiRegister::operator|=(uint8_t value) {
 // The WeikaiComponent methods
 ///////////////////////////////////////////////////////////////////////////////
 void WeikaiComponent::loop() {
-  if ((this->component_state_ & COMPONENT_STATE_MASK) != COMPONENT_STATE_LOOP)
+  if (!this->is_in_loop_state())
     return;
 
   // If there are some bytes in the receive FIFO we transfers them to the ring buffers

--- a/esphome/core/application.cpp
+++ b/esphome/core/application.cpp
@@ -66,7 +66,7 @@ void Application::setup() {
                      [](Component *a, Component *b) { return a->get_loop_priority() > b->get_loop_priority(); });
 
     do {
-      uint32_t new_app_state = STATUS_LED_WARNING;
+      uint8_t new_app_state = STATUS_LED_WARNING;
       this->scheduler.call();
       this->feed_wdt();
       for (uint32_t j = 0; j <= i; j++) {
@@ -87,7 +87,7 @@ void Application::setup() {
   this->calculate_looping_components_();
 }
 void Application::loop() {
-  uint32_t new_app_state = 0;
+  uint8_t new_app_state = 0;
 
   this->scheduler.call();
 

--- a/esphome/core/application.h
+++ b/esphome/core/application.h
@@ -332,7 +332,7 @@ class Application {
    */
   void teardown_components(uint32_t timeout_ms);
 
-  uint32_t get_app_state() const { return this->app_state_; }
+  uint8_t get_app_state() const { return this->app_state_; }
 
 #ifdef USE_BINARY_SENSOR
   const std::vector<binary_sensor::BinarySensor *> &get_binary_sensors() { return this->binary_sensors_; }
@@ -653,7 +653,7 @@ class Application {
   uint32_t last_loop_{0};
   uint32_t loop_interval_{16};
   size_t dump_config_at_{SIZE_MAX};
-  uint32_t app_state_{0};
+  uint8_t app_state_{0};
   Component *current_component_{nullptr};
   uint32_t loop_component_start_time_{0};
 


### PR DESCRIPTION
# What does this implement/fix?

This PR optimizes memory usage by reducing `component_state_` and `app_state_` from uint32_t to uint8_t. The state tracking was using only 4 bits out of 32, wasting 28 bits (3.5 bytes) per component. This optimization saves 3 bytes per component plus 3 bytes for the application state.

**Memory Savings:**
- **3 bytes per component** (component_state_: uint32_t → uint8_t)
- **3 bytes for app state** (app_state_: uint32_t → uint8_t)
- Typical configuration (30 components): **93 bytes saved**
- Large configuration (100 components): **303 bytes saved**
- Complex configuration (250 components): **753 bytes saved**

The new bit layout is more efficient:
- Bits 0-1: Component state (CONSTRUCTION, SETUP, LOOP, FAILED)
- Bit 2: STATUS_LED_WARNING flag
- Bit 3: STATUS_LED_ERROR flag
- Bits 4-7: Reserved for future use (50% headroom)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Part of ongoing memory optimization efforts for resource-constrained devices

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- Not applicable (internal implementation)

## Breaking Changes for External Components

⚠️ **This is a breaking change for external components that directly access `component_state_`**

### Migration Guide for External Components:

Instead of directly accessing `component_state_`, use the new public methods:

**OLD (Direct Access - No Longer Supported):**
```cpp
// DON'T DO THIS ANYMORE:
if ((this->component_state_ & COMPONENT_STATE_MASK) == COMPONENT_STATE_FAILED) {
    this->component_state_ &= ~COMPONENT_STATE_MASK;
    this->component_state_ |= COMPONENT_STATE_CONSTRUCTION;
}
```

**NEW (Use Public Methods):**
```cpp
// DO THIS INSTEAD:
if (this->is_failed()) {
    this->reset_to_construction_state();
}
```

### New Public Methods Added:

1. **`reset_to_construction_state()`** - Reset a failed component back to construction state
2. **`is_in_loop_state()`** - Check if component has completed setup and is in loop state

### Affected Components (already updated in this PR):
- `bme280_base` - Updated to use `is_failed()` and `reset_to_construction_state()`
- `weikai` - Updated to use `is_in_loop_state()`
- `kmeteriso` - Updated to use `is_failed()` and `reset_to_construction_state()`

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Implementation Details

### Changes Made:
1. **component.h**:
   - Changed `component_state_` from uint32_t to uint8_t
   - Updated all state constants to uint8_t with new bit layout
   - Added public methods for state manipulation
   - Changed `get_component_state()` return type to uint8_t

2. **component.cpp**:
   - Updated constant values for compact bit layout
   - Implemented new public methods
   - Updated all state manipulations

3. **application.h/cpp**:
   - Changed `app_state_` from uint32_t to uint8_t
   - Updated `get_app_state()` return type

4. **External components**:
   - Updated to use public methods instead of direct access

### Technical Details:
- Component states (4 values) now use only 2 bits instead of 8
- Status LED flags use 2 individual bits
- 50% of the byte remains available for future expansion
- All state transitions and checks work identically

## Example entry for `config.yaml`:

```yaml
# No configuration changes needed - this is an internal optimization
# that automatically reduces memory usage for all components
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

