### PR TITLE
Optimize Application ``area_`` from ``std::string`` to ``const char*``

### DIFF
--- a/esphome/components/mqtt/mqtt_component.cpp
+++ b/esphome/components/mqtt/mqtt_component.cpp
@@ -153,7 +153,7 @@ bool MQTTComponent::send_discovery_() {
         if (node_friendly_name.empty()) {
           node_friendly_name = node_name;
         }
-        const std::string &node_area = App.get_area();
+        std::string node_area = App.get_area();
 
         JsonObject device_info = root.createNestedObject(MQTT_DEVICE);
         const auto mac = get_mac_address();

--- a/esphome/core/application.h
+++ b/esphome/core/application.h
@@ -87,8 +87,8 @@ static const uint32_t TEARDOWN_TIMEOUT_REBOOT_MS = 1000;  // 1 second for quick 
 
 class Application {
  public:
-  void pre_setup(const std::string &name, const std::string &friendly_name, const std::string &area,
-                 const char *comment, const char *compilation_time, bool name_add_mac_suffix) {
+  void pre_setup(const std::string &name, const std::string &friendly_name, const char *area, const char *comment,
+                 const char *compilation_time, bool name_add_mac_suffix) {
     arch_init();
     this->name_add_mac_suffix_ = name_add_mac_suffix;
     if (name_add_mac_suffix) {
@@ -285,7 +285,7 @@ class Application {
   const std::string &get_friendly_name() const { return this->friendly_name_; }
 
   /// Get the area of this Application set by pre_setup().
-  const std::string &get_area() const { return this->area_; }
+  std::string get_area() const { return this->area_ == nullptr ? "" : this->area_; }
 
   /// Get the comment of this Application set by pre_setup().
   std::string get_comment() const { return this->comment_; }
@@ -646,7 +646,7 @@ class Application {
 
   std::string name_;
   std::string friendly_name_;
-  std::string area_;
+  const char *area_{nullptr};
   const char *comment_{nullptr};
   const char *compilation_time_{nullptr};
   bool name_add_mac_suffix_;


### PR DESCRIPTION
# What does this implement/fix?

This PR optimizes memory usage by changing the `area_` member in the Application class from `std::string` to `const char*`. This saves 20 bytes of RAM.

## Details

### Memory Savings
- **Before**: `std::string area_` - 24 bytes (on ESP32/ESP8266)
- **After**: `const char* area_` - 4 bytes
- **Savings**: 20 bytes per Application instance

### Changes
1. Changed `Application::area_` from `std::string` to `const char*`
2. Updated `pre_setup()` to accept `const char* area` instead of `const std::string& area`
3. Modified `get_area()` to return `std::string` by value instead of `const std::string&` by reference

### Why is this safe?
- The area value is set once during initialization from Python code generation
- It's never modified during runtime
- The string literal passed from Python has a lifetime that extends for the entire program

### Breaking Change
This is a **breaking change** for external components that may be storing the result of `get_area()` as a reference:
- **Before**: `get_area()` returned `const std::string&` (reference)
- **After**: `get_area()` returns `std::string` (by value)

Code that stores the result as `const std::string& area = App.get_area()` will now be storing a reference to a temporary, which is undefined behavior. The MQTT component was updated to handle this change.

### Migration Guide
External components should update their code from:
```cpp
const std::string& area = App.get_area();
```
to:
```cpp
std::string area = App.get_area();
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# No configuration changes needed - this is an internal optimization
esphome:
  name: my-device
  friendly_name: "My Device"
  area: "Living Room"  # This field is optimized
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).