### PR TITLE
Reduce code duplication in auto-generated API protocol code

### DIFF
--- a/esphome/components/api/api_pb2_service.cpp
+++ b/esphome/components/api/api_pb2_service.cpp
@@ -620,342 +620,300 @@ void APIServerConnection::on_ping_request(const PingRequest &msg) {
   }
 }
 void APIServerConnection::on_device_info_request(const DeviceInfoRequest &msg) {
-  if (!this->check_connection_setup_()) {
-    return;
-  }
-  DeviceInfoResponse ret = this->device_info(msg);
-  if (!this->send_message(ret)) {
-    this->on_fatal_error();
+  if (this->check_connection_setup_()) {
+    DeviceInfoResponse ret = this->device_info(msg);
+    if (!this->send_message(ret)) {
+      this->on_fatal_error();
+    }
   }
 }
 void APIServerConnection::on_list_entities_request(const ListEntitiesRequest &msg) {
-  if (!this->check_authenticated_()) {
-    return;
+  if (this->check_authenticated_()) {
+    this->list_entities(msg);
   }
-  this->list_entities(msg);
 }
 void APIServerConnection::on_subscribe_states_request(const SubscribeStatesRequest &msg) {
-  if (!this->check_authenticated_()) {
-    return;
+  if (this->check_authenticated_()) {
+    this->subscribe_states(msg);
   }
-  this->subscribe_states(msg);
 }
 void APIServerConnection::on_subscribe_logs_request(const SubscribeLogsRequest &msg) {
-  if (!this->check_authenticated_()) {
-    return;
+  if (this->check_authenticated_()) {
+    this->subscribe_logs(msg);
   }
-  this->subscribe_logs(msg);
 }
 void APIServerConnection::on_subscribe_homeassistant_services_request(
     const SubscribeHomeassistantServicesRequest &msg) {
-  if (!this->check_authenticated_()) {
-    return;
+  if (this->check_authenticated_()) {
+    this->subscribe_homeassistant_services(msg);
   }
-  this->subscribe_homeassistant_services(msg);
 }
 void APIServerConnection::on_subscribe_home_assistant_states_request(const SubscribeHomeAssistantStatesRequest &msg) {
-  if (!this->check_authenticated_()) {
-    return;
+  if (this->check_authenticated_()) {
+    this->subscribe_home_assistant_states(msg);
   }
-  this->subscribe_home_assistant_states(msg);
 }
 void APIServerConnection::on_get_time_request(const GetTimeRequest &msg) {
-  if (!this->check_connection_setup_()) {
-    return;
-  }
-  GetTimeResponse ret = this->get_time(msg);
-  if (!this->send_message(ret)) {
-    this->on_fatal_error();
+  if (this->check_connection_setup_()) {
+    GetTimeResponse ret = this->get_time(msg);
+    if (!this->send_message(ret)) {
+      this->on_fatal_error();
+    }
   }
 }
 void APIServerConnection::on_execute_service_request(const ExecuteServiceRequest &msg) {
-  if (!this->check_authenticated_()) {
-    return;
+  if (this->check_authenticated_()) {
+    this->execute_service(msg);
   }
-  this->execute_service(msg);
 }
 #ifdef USE_API_NOISE
 void APIServerConnection::on_noise_encryption_set_key_request(const NoiseEncryptionSetKeyRequest &msg) {
-  if (!this->check_authenticated_()) {
-    return;
-  }
-  NoiseEncryptionSetKeyResponse ret = this->noise_encryption_set_key(msg);
-  if (!this->send_message(ret)) {
-    this->on_fatal_error();
+  if (this->check_authenticated_()) {
+    NoiseEncryptionSetKeyResponse ret = this->noise_encryption_set_key(msg);
+    if (!this->send_message(ret)) {
+      this->on_fatal_error();
+    }
   }
 }
 #endif
 #ifdef USE_BUTTON
 void APIServerConnection::on_button_command_request(const ButtonCommandRequest &msg) {
-  if (!this->check_authenticated_()) {
-    return;
+  if (this->check_authenticated_()) {
+    this->button_command(msg);
   }
-  this->button_command(msg);
 }
 #endif
 #ifdef USE_ESP32_CAMERA
 void APIServerConnection::on_camera_image_request(const CameraImageRequest &msg) {
-  if (!this->check_authenticated_()) {
-    return;
+  if (this->check_authenticated_()) {
+    this->camera_image(msg);
   }
-  this->camera_image(msg);
 }
 #endif
 #ifdef USE_CLIMATE
 void APIServerConnection::on_climate_command_request(const ClimateCommandRequest &msg) {
-  if (!this->check_authenticated_()) {
-    return;
+  if (this->check_authenticated_()) {
+    this->climate_command(msg);
   }
-  this->climate_command(msg);
 }
 #endif
 #ifdef USE_COVER
 void APIServerConnection::on_cover_command_request(const CoverCommandRequest &msg) {
-  if (!this->check_authenticated_()) {
-    return;
+  if (this->check_authenticated_()) {
+    this->cover_command(msg);
   }
-  this->cover_command(msg);
 }
 #endif
 #ifdef USE_DATETIME_DATE
 void APIServerConnection::on_date_command_request(const DateCommandRequest &msg) {
-  if (!this->check_authenticated_()) {
-    return;
+  if (this->check_authenticated_()) {
+    this->date_command(msg);
   }
-  this->date_command(msg);
 }
 #endif
 #ifdef USE_DATETIME_DATETIME
 void APIServerConnection::on_date_time_command_request(const DateTimeCommandRequest &msg) {
-  if (!this->check_authenticated_()) {
-    return;
+  if (this->check_authenticated_()) {
+    this->datetime_command(msg);
   }
-  this->datetime_command(msg);
 }
 #endif
 #ifdef USE_FAN
 void APIServerConnection::on_fan_command_request(const FanCommandRequest &msg) {
-  if (!this->check_authenticated_()) {
-    return;
+  if (this->check_authenticated_()) {
+    this->fan_command(msg);
   }
-  this->fan_command(msg);
 }
 #endif
 #ifdef USE_LIGHT
 void APIServerConnection::on_light_command_request(const LightCommandRequest &msg) {
-  if (!this->check_authenticated_()) {
-    return;
+  if (this->check_authenticated_()) {
+    this->light_command(msg);
   }
-  this->light_command(msg);
 }
 #endif
 #ifdef USE_LOCK
 void APIServerConnection::on_lock_command_request(const LockCommandRequest &msg) {
-  if (!this->check_authenticated_()) {
-    return;
+  if (this->check_authenticated_()) {
+    this->lock_command(msg);
   }
-  this->lock_command(msg);
 }
 #endif
 #ifdef USE_MEDIA_PLAYER
 void APIServerConnection::on_media_player_command_request(const MediaPlayerCommandRequest &msg) {
-  if (!this->check_authenticated_()) {
-    return;
+  if (this->check_authenticated_()) {
+    this->media_player_command(msg);
   }
-  this->media_player_command(msg);
 }
 #endif
 #ifdef USE_NUMBER
 void APIServerConnection::on_number_command_request(const NumberCommandRequest &msg) {
-  if (!this->check_authenticated_()) {
-    return;
+  if (this->check_authenticated_()) {
+    this->number_command(msg);
   }
-  this->number_command(msg);
 }
 #endif
 #ifdef USE_SELECT
 void APIServerConnection::on_select_command_request(const SelectCommandRequest &msg) {
-  if (!this->check_authenticated_()) {
-    return;
+  if (this->check_authenticated_()) {
+    this->select_command(msg);
   }
-  this->select_command(msg);
 }
 #endif
 #ifdef USE_SIREN
 void APIServerConnection::on_siren_command_request(const SirenCommandRequest &msg) {
-  if (!this->check_authenticated_()) {
-    return;
+  if (this->check_authenticated_()) {
+    this->siren_command(msg);
   }
-  this->siren_command(msg);
 }
 #endif
 #ifdef USE_SWITCH
 void APIServerConnection::on_switch_command_request(const SwitchCommandRequest &msg) {
-  if (!this->check_authenticated_()) {
-    return;
+  if (this->check_authenticated_()) {
+    this->switch_command(msg);
   }
-  this->switch_command(msg);
 }
 #endif
 #ifdef USE_TEXT
 void APIServerConnection::on_text_command_request(const TextCommandRequest &msg) {
-  if (!this->check_authenticated_()) {
-    return;
+  if (this->check_authenticated_()) {
+    this->text_command(msg);
   }
-  this->text_command(msg);
 }
 #endif
 #ifdef USE_DATETIME_TIME
 void APIServerConnection::on_time_command_request(const TimeCommandRequest &msg) {
-  if (!this->check_authenticated_()) {
-    return;
+  if (this->check_authenticated_()) {
+    this->time_command(msg);
   }
-  this->time_command(msg);
 }
 #endif
 #ifdef USE_UPDATE
 void APIServerConnection::on_update_command_request(const UpdateCommandRequest &msg) {
-  if (!this->check_authenticated_()) {
-    return;
+  if (this->check_authenticated_()) {
+    this->update_command(msg);
   }
-  this->update_command(msg);
 }
 #endif
 #ifdef USE_VALVE
 void APIServerConnection::on_valve_command_request(const ValveCommandRequest &msg) {
-  if (!this->check_authenticated_()) {
-    return;
+  if (this->check_authenticated_()) {
+    this->valve_command(msg);
   }
-  this->valve_command(msg);
 }
 #endif
 #ifdef USE_BLUETOOTH_PROXY
 void APIServerConnection::on_subscribe_bluetooth_le_advertisements_request(
     const SubscribeBluetoothLEAdvertisementsRequest &msg) {
-  if (!this->check_authenticated_()) {
-    return;
+  if (this->check_authenticated_()) {
+    this->subscribe_bluetooth_le_advertisements(msg);
   }
-  this->subscribe_bluetooth_le_advertisements(msg);
 }
 #endif
 #ifdef USE_BLUETOOTH_PROXY
 void APIServerConnection::on_bluetooth_device_request(const BluetoothDeviceRequest &msg) {
-  if (!this->check_authenticated_()) {
-    return;
+  if (this->check_authenticated_()) {
+    this->bluetooth_device_request(msg);
   }
-  this->bluetooth_device_request(msg);
 }
 #endif
 #ifdef USE_BLUETOOTH_PROXY
 void APIServerConnection::on_bluetooth_gatt_get_services_request(const BluetoothGATTGetServicesRequest &msg) {
-  if (!this->check_authenticated_()) {
-    return;
+  if (this->check_authenticated_()) {
+    this->bluetooth_gatt_get_services(msg);
   }
-  this->bluetooth_gatt_get_services(msg);
 }
 #endif
 #ifdef USE_BLUETOOTH_PROXY
 void APIServerConnection::on_bluetooth_gatt_read_request(const BluetoothGATTReadRequest &msg) {
-  if (!this->check_authenticated_()) {
-    return;
+  if (this->check_authenticated_()) {
+    this->bluetooth_gatt_read(msg);
   }
-  this->bluetooth_gatt_read(msg);
 }
 #endif
 #ifdef USE_BLUETOOTH_PROXY
 void APIServerConnection::on_bluetooth_gatt_write_request(const BluetoothGATTWriteRequest &msg) {
-  if (!this->check_authenticated_()) {
-    return;
+  if (this->check_authenticated_()) {
+    this->bluetooth_gatt_write(msg);
   }
-  this->bluetooth_gatt_write(msg);
 }
 #endif
 #ifdef USE_BLUETOOTH_PROXY
 void APIServerConnection::on_bluetooth_gatt_read_descriptor_request(const BluetoothGATTReadDescriptorRequest &msg) {
-  if (!this->check_authenticated_()) {
-    return;
+  if (this->check_authenticated_()) {
+    this->bluetooth_gatt_read_descriptor(msg);
   }
-  this->bluetooth_gatt_read_descriptor(msg);
 }
 #endif
 #ifdef USE_BLUETOOTH_PROXY
 void APIServerConnection::on_bluetooth_gatt_write_descriptor_request(const BluetoothGATTWriteDescriptorRequest &msg) {
-  if (!this->check_authenticated_()) {
-    return;
+  if (this->check_authenticated_()) {
+    this->bluetooth_gatt_write_descriptor(msg);
   }
-  this->bluetooth_gatt_write_descriptor(msg);
 }
 #endif
 #ifdef USE_BLUETOOTH_PROXY
 void APIServerConnection::on_bluetooth_gatt_notify_request(const BluetoothGATTNotifyRequest &msg) {
-  if (!this->check_authenticated_()) {
-    return;
+  if (this->check_authenticated_()) {
+    this->bluetooth_gatt_notify(msg);
   }
-  this->bluetooth_gatt_notify(msg);
 }
 #endif
 #ifdef USE_BLUETOOTH_PROXY
 void APIServerConnection::on_subscribe_bluetooth_connections_free_request(
     const SubscribeBluetoothConnectionsFreeRequest &msg) {
-  if (!this->check_authenticated_()) {
-    return;
-  }
-  BluetoothConnectionsFreeResponse ret = this->subscribe_bluetooth_connections_free(msg);
-  if (!this->send_message(ret)) {
-    this->on_fatal_error();
+  if (this->check_authenticated_()) {
+    BluetoothConnectionsFreeResponse ret = this->subscribe_bluetooth_connections_free(msg);
+    if (!this->send_message(ret)) {
+      this->on_fatal_error();
+    }
   }
 }
 #endif
 #ifdef USE_BLUETOOTH_PROXY
 void APIServerConnection::on_unsubscribe_bluetooth_le_advertisements_request(
     const UnsubscribeBluetoothLEAdvertisementsRequest &msg) {
-  if (!this->check_authenticated_()) {
-    return;
+  if (this->check_authenticated_()) {
+    this->unsubscribe_bluetooth_le_advertisements(msg);
   }
-  this->unsubscribe_bluetooth_le_advertisements(msg);
 }
 #endif
 #ifdef USE_BLUETOOTH_PROXY
 void APIServerConnection::on_bluetooth_scanner_set_mode_request(const BluetoothScannerSetModeRequest &msg) {
-  if (!this->check_authenticated_()) {
-    return;
+  if (this->check_authenticated_()) {
+    this->bluetooth_scanner_set_mode(msg);
   }
-  this->bluetooth_scanner_set_mode(msg);
 }
 #endif
 #ifdef USE_VOICE_ASSISTANT
 void APIServerConnection::on_subscribe_voice_assistant_request(const SubscribeVoiceAssistantRequest &msg) {
-  if (!this->check_authenticated_()) {
-    return;
+  if (this->check_authenticated_()) {
+    this->subscribe_voice_assistant(msg);
   }
-  this->subscribe_voice_assistant(msg);
 }
 #endif
 #ifdef USE_VOICE_ASSISTANT
 void APIServerConnection::on_voice_assistant_configuration_request(const VoiceAssistantConfigurationRequest &msg) {
-  if (!this->check_authenticated_()) {
-    return;
-  }
-  VoiceAssistantConfigurationResponse ret = this->voice_assistant_get_configuration(msg);
-  if (!this->send_message(ret)) {
-    this->on_fatal_error();
+  if (this->check_authenticated_()) {
+    VoiceAssistantConfigurationResponse ret = this->voice_assistant_get_configuration(msg);
+    if (!this->send_message(ret)) {
+      this->on_fatal_error();
+    }
   }
 }
 #endif
 #ifdef USE_VOICE_ASSISTANT
 void APIServerConnection::on_voice_assistant_set_configuration(const VoiceAssistantSetConfiguration &msg) {
-  if (!this->check_authenticated_()) {
-    return;
+  if (this->check_authenticated_()) {
+    this->voice_assistant_set_configuration(msg);
   }
-  this->voice_assistant_set_configuration(msg);
 }
 #endif
 #ifdef USE_ALARM_CONTROL_PANEL
 void APIServerConnection::on_alarm_control_panel_command_request(const AlarmControlPanelCommandRequest &msg) {
-  if (!this->check_authenticated_()) {
-    return;
+  if (this->check_authenticated_()) {
+    this->alarm_control_panel_command(msg);
   }
-  this->alarm_control_panel_command(msg);
 }
 #endif
 

--- a/esphome/components/api/api_pb2_service.cpp
+++ b/esphome/components/api/api_pb2_service.cpp
@@ -620,8 +620,7 @@ void APIServerConnection::on_ping_request(const PingRequest &msg) {
   }
 }
 void APIServerConnection::on_device_info_request(const DeviceInfoRequest &msg) {
-  if (!this->is_connection_setup()) {
-    this->on_no_setup_connection();
+  if (!this->check_connection_setup_()) {
     return;
   }
   DeviceInfoResponse ret = this->device_info(msg);
@@ -630,64 +629,38 @@ void APIServerConnection::on_device_info_request(const DeviceInfoRequest &msg) {
   }
 }
 void APIServerConnection::on_list_entities_request(const ListEntitiesRequest &msg) {
-  if (!this->is_connection_setup()) {
-    this->on_no_setup_connection();
-    return;
-  }
-  if (!this->is_authenticated()) {
-    this->on_unauthenticated_access();
+  if (!this->check_authenticated_()) {
     return;
   }
   this->list_entities(msg);
 }
 void APIServerConnection::on_subscribe_states_request(const SubscribeStatesRequest &msg) {
-  if (!this->is_connection_setup()) {
-    this->on_no_setup_connection();
-    return;
-  }
-  if (!this->is_authenticated()) {
-    this->on_unauthenticated_access();
+  if (!this->check_authenticated_()) {
     return;
   }
   this->subscribe_states(msg);
 }
 void APIServerConnection::on_subscribe_logs_request(const SubscribeLogsRequest &msg) {
-  if (!this->is_connection_setup()) {
-    this->on_no_setup_connection();
-    return;
-  }
-  if (!this->is_authenticated()) {
-    this->on_unauthenticated_access();
+  if (!this->check_authenticated_()) {
     return;
   }
   this->subscribe_logs(msg);
 }
 void APIServerConnection::on_subscribe_homeassistant_services_request(
     const SubscribeHomeassistantServicesRequest &msg) {
-  if (!this->is_connection_setup()) {
-    this->on_no_setup_connection();
-    return;
-  }
-  if (!this->is_authenticated()) {
-    this->on_unauthenticated_access();
+  if (!this->check_authenticated_()) {
     return;
   }
   this->subscribe_homeassistant_services(msg);
 }
 void APIServerConnection::on_subscribe_home_assistant_states_request(const SubscribeHomeAssistantStatesRequest &msg) {
-  if (!this->is_connection_setup()) {
-    this->on_no_setup_connection();
-    return;
-  }
-  if (!this->is_authenticated()) {
-    this->on_unauthenticated_access();
+  if (!this->check_authenticated_()) {
     return;
   }
   this->subscribe_home_assistant_states(msg);
 }
 void APIServerConnection::on_get_time_request(const GetTimeRequest &msg) {
-  if (!this->is_connection_setup()) {
-    this->on_no_setup_connection();
+  if (!this->check_connection_setup_()) {
     return;
   }
   GetTimeResponse ret = this->get_time(msg);
@@ -696,24 +669,14 @@ void APIServerConnection::on_get_time_request(const GetTimeRequest &msg) {
   }
 }
 void APIServerConnection::on_execute_service_request(const ExecuteServiceRequest &msg) {
-  if (!this->is_connection_setup()) {
-    this->on_no_setup_connection();
-    return;
-  }
-  if (!this->is_authenticated()) {
-    this->on_unauthenticated_access();
+  if (!this->check_authenticated_()) {
     return;
   }
   this->execute_service(msg);
 }
 #ifdef USE_API_NOISE
 void APIServerConnection::on_noise_encryption_set_key_request(const NoiseEncryptionSetKeyRequest &msg) {
-  if (!this->is_connection_setup()) {
-    this->on_no_setup_connection();
-    return;
-  }
-  if (!this->is_authenticated()) {
-    this->on_unauthenticated_access();
+  if (!this->check_authenticated_()) {
     return;
   }
   NoiseEncryptionSetKeyResponse ret = this->noise_encryption_set_key(msg);
@@ -724,12 +687,7 @@ void APIServerConnection::on_noise_encryption_set_key_request(const NoiseEncrypt
 #endif
 #ifdef USE_BUTTON
 void APIServerConnection::on_button_command_request(const ButtonCommandRequest &msg) {
-  if (!this->is_connection_setup()) {
-    this->on_no_setup_connection();
-    return;
-  }
-  if (!this->is_authenticated()) {
-    this->on_unauthenticated_access();
+  if (!this->check_authenticated_()) {
     return;
   }
   this->button_command(msg);
@@ -737,12 +695,7 @@ void APIServerConnection::on_button_command_request(const ButtonCommandRequest &
 #endif
 #ifdef USE_ESP32_CAMERA
 void APIServerConnection::on_camera_image_request(const CameraImageRequest &msg) {
-  if (!this->is_connection_setup()) {
-    this->on_no_setup_connection();
-    return;
-  }
-  if (!this->is_authenticated()) {
-    this->on_unauthenticated_access();
+  if (!this->check_authenticated_()) {
     return;
   }
   this->camera_image(msg);
@@ -750,12 +703,7 @@ void APIServerConnection::on_camera_image_request(const CameraImageRequest &msg)
 #endif
 #ifdef USE_CLIMATE
 void APIServerConnection::on_climate_command_request(const ClimateCommandRequest &msg) {
-  if (!this->is_connection_setup()) {
-    this->on_no_setup_connection();
-    return;
-  }
-  if (!this->is_authenticated()) {
-    this->on_unauthenticated_access();
+  if (!this->check_authenticated_()) {
     return;
   }
   this->climate_command(msg);
@@ -763,12 +711,7 @@ void APIServerConnection::on_climate_command_request(const ClimateCommandRequest
 #endif
 #ifdef USE_COVER
 void APIServerConnection::on_cover_command_request(const CoverCommandRequest &msg) {
-  if (!this->is_connection_setup()) {
-    this->on_no_setup_connection();
-    return;
-  }
-  if (!this->is_authenticated()) {
-    this->on_unauthenticated_access();
+  if (!this->check_authenticated_()) {
     return;
   }
   this->cover_command(msg);
@@ -776,12 +719,7 @@ void APIServerConnection::on_cover_command_request(const CoverCommandRequest &ms
 #endif
 #ifdef USE_DATETIME_DATE
 void APIServerConnection::on_date_command_request(const DateCommandRequest &msg) {
-  if (!this->is_connection_setup()) {
-    this->on_no_setup_connection();
-    return;
-  }
-  if (!this->is_authenticated()) {
-    this->on_unauthenticated_access();
+  if (!this->check_authenticated_()) {
     return;
   }
   this->date_command(msg);
@@ -789,12 +727,7 @@ void APIServerConnection::on_date_command_request(const DateCommandRequest &msg)
 #endif
 #ifdef USE_DATETIME_DATETIME
 void APIServerConnection::on_date_time_command_request(const DateTimeCommandRequest &msg) {
-  if (!this->is_connection_setup()) {
-    this->on_no_setup_connection();
-    return;
-  }
-  if (!this->is_authenticated()) {
-    this->on_unauthenticated_access();
+  if (!this->check_authenticated_()) {
     return;
   }
   this->datetime_command(msg);
@@ -802,12 +735,7 @@ void APIServerConnection::on_date_time_command_request(const DateTimeCommandRequ
 #endif
 #ifdef USE_FAN
 void APIServerConnection::on_fan_command_request(const FanCommandRequest &msg) {
-  if (!this->is_connection_setup()) {
-    this->on_no_setup_connection();
-    return;
-  }
-  if (!this->is_authenticated()) {
-    this->on_unauthenticated_access();
+  if (!this->check_authenticated_()) {
     return;
   }
   this->fan_command(msg);
@@ -815,12 +743,7 @@ void APIServerConnection::on_fan_command_request(const FanCommandRequest &msg) {
 #endif
 #ifdef USE_LIGHT
 void APIServerConnection::on_light_command_request(const LightCommandRequest &msg) {
-  if (!this->is_connection_setup()) {
-    this->on_no_setup_connection();
-    return;
-  }
-  if (!this->is_authenticated()) {
-    this->on_unauthenticated_access();
+  if (!this->check_authenticated_()) {
     return;
   }
   this->light_command(msg);
@@ -828,12 +751,7 @@ void APIServerConnection::on_light_command_request(const LightCommandRequest &ms
 #endif
 #ifdef USE_LOCK
 void APIServerConnection::on_lock_command_request(const LockCommandRequest &msg) {
-  if (!this->is_connection_setup()) {
-    this->on_no_setup_connection();
-    return;
-  }
-  if (!this->is_authenticated()) {
-    this->on_unauthenticated_access();
+  if (!this->check_authenticated_()) {
     return;
   }
   this->lock_command(msg);
@@ -841,12 +759,7 @@ void APIServerConnection::on_lock_command_request(const LockCommandRequest &msg)
 #endif
 #ifdef USE_MEDIA_PLAYER
 void APIServerConnection::on_media_player_command_request(const MediaPlayerCommandRequest &msg) {
-  if (!this->is_connection_setup()) {
-    this->on_no_setup_connection();
-    return;
-  }
-  if (!this->is_authenticated()) {
-    this->on_unauthenticated_access();
+  if (!this->check_authenticated_()) {
     return;
   }
   this->media_player_command(msg);
@@ -854,12 +767,7 @@ void APIServerConnection::on_media_player_command_request(const MediaPlayerComma
 #endif
 #ifdef USE_NUMBER
 void APIServerConnection::on_number_command_request(const NumberCommandRequest &msg) {
-  if (!this->is_connection_setup()) {
-    this->on_no_setup_connection();
-    return;
-  }
-  if (!this->is_authenticated()) {
-    this->on_unauthenticated_access();
+  if (!this->check_authenticated_()) {
     return;
   }
   this->number_command(msg);
@@ -867,12 +775,7 @@ void APIServerConnection::on_number_command_request(const NumberCommandRequest &
 #endif
 #ifdef USE_SELECT
 void APIServerConnection::on_select_command_request(const SelectCommandRequest &msg) {
-  if (!this->is_connection_setup()) {
-    this->on_no_setup_connection();
-    return;
-  }
-  if (!this->is_authenticated()) {
-    this->on_unauthenticated_access();
+  if (!this->check_authenticated_()) {
     return;
   }
   this->select_command(msg);
@@ -880,12 +783,7 @@ void APIServerConnection::on_select_command_request(const SelectCommandRequest &
 #endif
 #ifdef USE_SIREN
 void APIServerConnection::on_siren_command_request(const SirenCommandRequest &msg) {
-  if (!this->is_connection_setup()) {
-    this->on_no_setup_connection();
-    return;
-  }
-  if (!this->is_authenticated()) {
-    this->on_unauthenticated_access();
+  if (!this->check_authenticated_()) {
     return;
   }
   this->siren_command(msg);
@@ -893,12 +791,7 @@ void APIServerConnection::on_siren_command_request(const SirenCommandRequest &ms
 #endif
 #ifdef USE_SWITCH
 void APIServerConnection::on_switch_command_request(const SwitchCommandRequest &msg) {
-  if (!this->is_connection_setup()) {
-    this->on_no_setup_connection();
-    return;
-  }
-  if (!this->is_authenticated()) {
-    this->on_unauthenticated_access();
+  if (!this->check_authenticated_()) {
     return;
   }
   this->switch_command(msg);
@@ -906,12 +799,7 @@ void APIServerConnection::on_switch_command_request(const SwitchCommandRequest &
 #endif
 #ifdef USE_TEXT
 void APIServerConnection::on_text_command_request(const TextCommandRequest &msg) {
-  if (!this->is_connection_setup()) {
-    this->on_no_setup_connection();
-    return;
-  }
-  if (!this->is_authenticated()) {
-    this->on_unauthenticated_access();
+  if (!this->check_authenticated_()) {
     return;
   }
   this->text_command(msg);
@@ -919,12 +807,7 @@ void APIServerConnection::on_text_command_request(const TextCommandRequest &msg)
 #endif
 #ifdef USE_DATETIME_TIME
 void APIServerConnection::on_time_command_request(const TimeCommandRequest &msg) {
-  if (!this->is_connection_setup()) {
-    this->on_no_setup_connection();
-    return;
-  }
-  if (!this->is_authenticated()) {
-    this->on_unauthenticated_access();
+  if (!this->check_authenticated_()) {
     return;
   }
   this->time_command(msg);
@@ -932,12 +815,7 @@ void APIServerConnection::on_time_command_request(const TimeCommandRequest &msg)
 #endif
 #ifdef USE_UPDATE
 void APIServerConnection::on_update_command_request(const UpdateCommandRequest &msg) {
-  if (!this->is_connection_setup()) {
-    this->on_no_setup_connection();
-    return;
-  }
-  if (!this->is_authenticated()) {
-    this->on_unauthenticated_access();
+  if (!this->check_authenticated_()) {
     return;
   }
   this->update_command(msg);
@@ -945,12 +823,7 @@ void APIServerConnection::on_update_command_request(const UpdateCommandRequest &
 #endif
 #ifdef USE_VALVE
 void APIServerConnection::on_valve_command_request(const ValveCommandRequest &msg) {
-  if (!this->is_connection_setup()) {
-    this->on_no_setup_connection();
-    return;
-  }
-  if (!this->is_authenticated()) {
-    this->on_unauthenticated_access();
+  if (!this->check_authenticated_()) {
     return;
   }
   this->valve_command(msg);
@@ -959,12 +832,7 @@ void APIServerConnection::on_valve_command_request(const ValveCommandRequest &ms
 #ifdef USE_BLUETOOTH_PROXY
 void APIServerConnection::on_subscribe_bluetooth_le_advertisements_request(
     const SubscribeBluetoothLEAdvertisementsRequest &msg) {
-  if (!this->is_connection_setup()) {
-    this->on_no_setup_connection();
-    return;
-  }
-  if (!this->is_authenticated()) {
-    this->on_unauthenticated_access();
+  if (!this->check_authenticated_()) {
     return;
   }
   this->subscribe_bluetooth_le_advertisements(msg);
@@ -972,12 +840,7 @@ void APIServerConnection::on_subscribe_bluetooth_le_advertisements_request(
 #endif
 #ifdef USE_BLUETOOTH_PROXY
 void APIServerConnection::on_bluetooth_device_request(const BluetoothDeviceRequest &msg) {
-  if (!this->is_connection_setup()) {
-    this->on_no_setup_connection();
-    return;
-  }
-  if (!this->is_authenticated()) {
-    this->on_unauthenticated_access();
+  if (!this->check_authenticated_()) {
     return;
   }
   this->bluetooth_device_request(msg);
@@ -985,12 +848,7 @@ void APIServerConnection::on_bluetooth_device_request(const BluetoothDeviceReque
 #endif
 #ifdef USE_BLUETOOTH_PROXY
 void APIServerConnection::on_bluetooth_gatt_get_services_request(const BluetoothGATTGetServicesRequest &msg) {
-  if (!this->is_connection_setup()) {
-    this->on_no_setup_connection();
-    return;
-  }
-  if (!this->is_authenticated()) {
-    this->on_unauthenticated_access();
+  if (!this->check_authenticated_()) {
     return;
   }
   this->bluetooth_gatt_get_services(msg);
@@ -998,12 +856,7 @@ void APIServerConnection::on_bluetooth_gatt_get_services_request(const Bluetooth
 #endif
 #ifdef USE_BLUETOOTH_PROXY
 void APIServerConnection::on_bluetooth_gatt_read_request(const BluetoothGATTReadRequest &msg) {
-  if (!this->is_connection_setup()) {
-    this->on_no_setup_connection();
-    return;
-  }
-  if (!this->is_authenticated()) {
-    this->on_unauthenticated_access();
+  if (!this->check_authenticated_()) {
     return;
   }
   this->bluetooth_gatt_read(msg);
@@ -1011,12 +864,7 @@ void APIServerConnection::on_bluetooth_gatt_read_request(const BluetoothGATTRead
 #endif
 #ifdef USE_BLUETOOTH_PROXY
 void APIServerConnection::on_bluetooth_gatt_write_request(const BluetoothGATTWriteRequest &msg) {
-  if (!this->is_connection_setup()) {
-    this->on_no_setup_connection();
-    return;
-  }
-  if (!this->is_authenticated()) {
-    this->on_unauthenticated_access();
+  if (!this->check_authenticated_()) {
     return;
   }
   this->bluetooth_gatt_write(msg);
@@ -1024,12 +872,7 @@ void APIServerConnection::on_bluetooth_gatt_write_request(const BluetoothGATTWri
 #endif
 #ifdef USE_BLUETOOTH_PROXY
 void APIServerConnection::on_bluetooth_gatt_read_descriptor_request(const BluetoothGATTReadDescriptorRequest &msg) {
-  if (!this->is_connection_setup()) {
-    this->on_no_setup_connection();
-    return;
-  }
-  if (!this->is_authenticated()) {
-    this->on_unauthenticated_access();
+  if (!this->check_authenticated_()) {
     return;
   }
   this->bluetooth_gatt_read_descriptor(msg);
@@ -1037,12 +880,7 @@ void APIServerConnection::on_bluetooth_gatt_read_descriptor_request(const Blueto
 #endif
 #ifdef USE_BLUETOOTH_PROXY
 void APIServerConnection::on_bluetooth_gatt_write_descriptor_request(const BluetoothGATTWriteDescriptorRequest &msg) {
-  if (!this->is_connection_setup()) {
-    this->on_no_setup_connection();
-    return;
-  }
-  if (!this->is_authenticated()) {
-    this->on_unauthenticated_access();
+  if (!this->check_authenticated_()) {
     return;
   }
   this->bluetooth_gatt_write_descriptor(msg);
@@ -1050,12 +888,7 @@ void APIServerConnection::on_bluetooth_gatt_write_descriptor_request(const Bluet
 #endif
 #ifdef USE_BLUETOOTH_PROXY
 void APIServerConnection::on_bluetooth_gatt_notify_request(const BluetoothGATTNotifyRequest &msg) {
-  if (!this->is_connection_setup()) {
-    this->on_no_setup_connection();
-    return;
-  }
-  if (!this->is_authenticated()) {
-    this->on_unauthenticated_access();
+  if (!this->check_authenticated_()) {
     return;
   }
   this->bluetooth_gatt_notify(msg);
@@ -1064,12 +897,7 @@ void APIServerConnection::on_bluetooth_gatt_notify_request(const BluetoothGATTNo
 #ifdef USE_BLUETOOTH_PROXY
 void APIServerConnection::on_subscribe_bluetooth_connections_free_request(
     const SubscribeBluetoothConnectionsFreeRequest &msg) {
-  if (!this->is_connection_setup()) {
-    this->on_no_setup_connection();
-    return;
-  }
-  if (!this->is_authenticated()) {
-    this->on_unauthenticated_access();
+  if (!this->check_authenticated_()) {
     return;
   }
   BluetoothConnectionsFreeResponse ret = this->subscribe_bluetooth_connections_free(msg);
@@ -1081,12 +909,7 @@ void APIServerConnection::on_subscribe_bluetooth_connections_free_request(
 #ifdef USE_BLUETOOTH_PROXY
 void APIServerConnection::on_unsubscribe_bluetooth_le_advertisements_request(
     const UnsubscribeBluetoothLEAdvertisementsRequest &msg) {
-  if (!this->is_connection_setup()) {
-    this->on_no_setup_connection();
-    return;
-  }
-  if (!this->is_authenticated()) {
-    this->on_unauthenticated_access();
+  if (!this->check_authenticated_()) {
     return;
   }
   this->unsubscribe_bluetooth_le_advertisements(msg);
@@ -1094,12 +917,7 @@ void APIServerConnection::on_unsubscribe_bluetooth_le_advertisements_request(
 #endif
 #ifdef USE_BLUETOOTH_PROXY
 void APIServerConnection::on_bluetooth_scanner_set_mode_request(const BluetoothScannerSetModeRequest &msg) {
-  if (!this->is_connection_setup()) {
-    this->on_no_setup_connection();
-    return;
-  }
-  if (!this->is_authenticated()) {
-    this->on_unauthenticated_access();
+  if (!this->check_authenticated_()) {
     return;
   }
   this->bluetooth_scanner_set_mode(msg);
@@ -1107,12 +925,7 @@ void APIServerConnection::on_bluetooth_scanner_set_mode_request(const BluetoothS
 #endif
 #ifdef USE_VOICE_ASSISTANT
 void APIServerConnection::on_subscribe_voice_assistant_request(const SubscribeVoiceAssistantRequest &msg) {
-  if (!this->is_connection_setup()) {
-    this->on_no_setup_connection();
-    return;
-  }
-  if (!this->is_authenticated()) {
-    this->on_unauthenticated_access();
+  if (!this->check_authenticated_()) {
     return;
   }
   this->subscribe_voice_assistant(msg);
@@ -1120,12 +933,7 @@ void APIServerConnection::on_subscribe_voice_assistant_request(const SubscribeVo
 #endif
 #ifdef USE_VOICE_ASSISTANT
 void APIServerConnection::on_voice_assistant_configuration_request(const VoiceAssistantConfigurationRequest &msg) {
-  if (!this->is_connection_setup()) {
-    this->on_no_setup_connection();
-    return;
-  }
-  if (!this->is_authenticated()) {
-    this->on_unauthenticated_access();
+  if (!this->check_authenticated_()) {
     return;
   }
   VoiceAssistantConfigurationResponse ret = this->voice_assistant_get_configuration(msg);
@@ -1136,12 +944,7 @@ void APIServerConnection::on_voice_assistant_configuration_request(const VoiceAs
 #endif
 #ifdef USE_VOICE_ASSISTANT
 void APIServerConnection::on_voice_assistant_set_configuration(const VoiceAssistantSetConfiguration &msg) {
-  if (!this->is_connection_setup()) {
-    this->on_no_setup_connection();
-    return;
-  }
-  if (!this->is_authenticated()) {
-    this->on_unauthenticated_access();
+  if (!this->check_authenticated_()) {
     return;
   }
   this->voice_assistant_set_configuration(msg);
@@ -1149,12 +952,7 @@ void APIServerConnection::on_voice_assistant_set_configuration(const VoiceAssist
 #endif
 #ifdef USE_ALARM_CONTROL_PANEL
 void APIServerConnection::on_alarm_control_panel_command_request(const AlarmControlPanelCommandRequest &msg) {
-  if (!this->is_connection_setup()) {
-    this->on_no_setup_connection();
-    return;
-  }
-  if (!this->is_authenticated()) {
-    this->on_unauthenticated_access();
+  if (!this->check_authenticated_()) {
     return;
   }
   this->alarm_control_panel_command(msg);

--- a/esphome/components/api/api_pb2_service.h
+++ b/esphome/components/api/api_pb2_service.h
@@ -17,25 +17,6 @@ class APIServerConnectionBase : public ProtoService {
  public:
 #endif
 
- protected:
-  bool check_connection_setup_() {
-    if (!this->is_connection_setup()) {
-      this->on_no_setup_connection();
-      return false;
-    }
-    return true;
-  }
-  bool check_authenticated_() {
-    if (!this->check_connection_setup_()) {
-      return false;
-    }
-    if (!this->is_authenticated()) {
-      this->on_unauthenticated_access();
-      return false;
-    }
-    return true;
-  }
-
  public:
   template<typename T> bool send_message(const T &msg) {
 #ifdef HAS_PROTO_MESSAGE_DUMP

--- a/esphome/components/api/api_pb2_service.h
+++ b/esphome/components/api/api_pb2_service.h
@@ -17,6 +17,26 @@ class APIServerConnectionBase : public ProtoService {
  public:
 #endif
 
+ protected:
+  bool check_connection_setup_() {
+    if (!this->is_connection_setup()) {
+      this->on_no_setup_connection();
+      return false;
+    }
+    return true;
+  }
+  bool check_authenticated_() {
+    if (!this->check_connection_setup_()) {
+      return false;
+    }
+    if (!this->is_authenticated()) {
+      this->on_unauthenticated_access();
+      return false;
+    }
+    return true;
+  }
+
+ public:
   template<typename T> bool send_message(const T &msg) {
 #ifdef HAS_PROTO_MESSAGE_DUMP
     this->log_send_message_(T::message_name(), msg.dump());

--- a/esphome/components/api/api_pb2_service.h
+++ b/esphome/components/api/api_pb2_service.h
@@ -17,7 +17,6 @@ class APIServerConnectionBase : public ProtoService {
  public:
 #endif
 
- public:
   template<typename T> bool send_message(const T &msg) {
 #ifdef HAS_PROTO_MESSAGE_DUMP
     this->log_send_message_(T::message_name(), msg.dump());

--- a/esphome/components/api/proto.h
+++ b/esphome/components/api/proto.h
@@ -377,6 +377,26 @@ class ProtoService {
     // Send the buffer
     return this->send_buffer(buffer, message_type);
   }
+
+  // Authentication helper methods
+  bool check_connection_setup_() {
+    if (!this->is_connection_setup()) {
+      this->on_no_setup_connection();
+      return false;
+    }
+    return true;
+  }
+
+  bool check_authenticated_() {
+    if (!this->check_connection_setup_()) {
+      return false;
+    }
+    if (!this->is_authenticated()) {
+      this->on_unauthenticated_access();
+      return false;
+    }
+    return true;
+  }
 };
 
 }  // namespace api

--- a/script/api_protobuf/api_protobuf.py
+++ b/script/api_protobuf/api_protobuf.py
@@ -1353,8 +1353,6 @@ def main() -> None:
     hpp += " public:\n"
     hpp += "#endif\n\n"
 
-    hpp += " public:\n"
-
     # Add generic send_message method
     hpp += "  template<typename T>\n"
     hpp += "  bool send_message(const T &msg) {\n"

--- a/script/api_protobuf/api_protobuf.py
+++ b/script/api_protobuf/api_protobuf.py
@@ -1353,6 +1353,27 @@ def main() -> None:
     hpp += " public:\n"
     hpp += "#endif\n\n"
 
+    # Add authentication check helper methods
+    hpp += " protected:\n"
+    hpp += "  bool check_connection_setup_() {\n"
+    hpp += "    if (!this->is_connection_setup()) {\n"
+    hpp += "      this->on_no_setup_connection();\n"
+    hpp += "      return false;\n"
+    hpp += "    }\n"
+    hpp += "    return true;\n"
+    hpp += "  }\n"
+    hpp += "  bool check_authenticated_() {\n"
+    hpp += "    if (!this->check_connection_setup_()) {\n"
+    hpp += "      return false;\n"
+    hpp += "    }\n"
+    hpp += "    if (!this->is_authenticated()) {\n"
+    hpp += "      this->on_unauthenticated_access();\n"
+    hpp += "      return false;\n"
+    hpp += "    }\n"
+    hpp += "    return true;\n"
+    hpp += "  }\n"
+    hpp += " public:\n\n"
+
     # Add generic send_message method
     hpp += "  template<typename T>\n"
     hpp += "  bool send_message(const T &msg) {\n"
@@ -1426,14 +1447,12 @@ def main() -> None:
         hpp += f"  virtual {ret} {func}(const {inp} &msg) = 0;\n"
         cpp += f"void {class_name}::{on_func}(const {inp} &msg) {{\n"
         body = ""
-        if needs_conn:
-            body += "if (!this->is_connection_setup()) {\n"
-            body += "  this->on_no_setup_connection();\n"
+        if needs_auth:
+            body += "if (!this->check_authenticated_()) {\n"
             body += "  return;\n"
             body += "}\n"
-        if needs_auth:
-            body += "if (!this->is_authenticated()) {\n"
-            body += "  this->on_unauthenticated_access();\n"
+        elif needs_conn:
+            body += "if (!this->check_connection_setup_()) {\n"
             body += "  return;\n"
             body += "}\n"
 

--- a/script/api_protobuf/api_protobuf.py
+++ b/script/api_protobuf/api_protobuf.py
@@ -1446,23 +1446,40 @@ def main() -> None:
         hpp_protected += f"  void {on_func}(const {inp} &msg) override;\n"
         hpp += f"  virtual {ret} {func}(const {inp} &msg) = 0;\n"
         cpp += f"void {class_name}::{on_func}(const {inp} &msg) {{\n"
-        body = ""
-        if needs_auth:
-            body += "if (!this->check_authenticated_()) {\n"
-            body += "  return;\n"
-            body += "}\n"
-        elif needs_conn:
-            body += "if (!this->check_connection_setup_()) {\n"
-            body += "  return;\n"
-            body += "}\n"
 
-        if is_void:
-            body += f"this->{func}(msg);\n"
-        else:
-            body += f"{ret} ret = this->{func}(msg);\n"
-            body += "if (!this->send_message(ret)) {\n"
-            body += "  this->on_fatal_error();\n"
+        # Start with authentication/connection check if needed
+        if needs_auth or needs_conn:
+            # Determine which check to use
+            if needs_auth:
+                check_func = "this->check_authenticated_()"
+            else:
+                check_func = "this->check_connection_setup_()"
+
+            body = f"if ({check_func}) {{\n"
+
+            # Add the actual handler code, indented
+            handler_body = ""
+            if is_void:
+                handler_body = f"this->{func}(msg);\n"
+            else:
+                handler_body = f"{ret} ret = this->{func}(msg);\n"
+                handler_body += "if (!this->send_message(ret)) {\n"
+                handler_body += "  this->on_fatal_error();\n"
+                handler_body += "}\n"
+
+            body += indent(handler_body) + "\n"
             body += "}\n"
+        else:
+            # No auth check needed, just call the handler
+            body = ""
+            if is_void:
+                body += f"this->{func}(msg);\n"
+            else:
+                body += f"{ret} ret = this->{func}(msg);\n"
+                body += "if (!this->send_message(ret)) {\n"
+                body += "  this->on_fatal_error();\n"
+                body += "}\n"
+
         cpp += indent(body) + "\n" + "}\n"
 
         if ifdef is not None:

--- a/script/api_protobuf/api_protobuf.py
+++ b/script/api_protobuf/api_protobuf.py
@@ -1353,26 +1353,7 @@ def main() -> None:
     hpp += " public:\n"
     hpp += "#endif\n\n"
 
-    # Add authentication check helper methods
-    hpp += " protected:\n"
-    hpp += "  bool check_connection_setup_() {\n"
-    hpp += "    if (!this->is_connection_setup()) {\n"
-    hpp += "      this->on_no_setup_connection();\n"
-    hpp += "      return false;\n"
-    hpp += "    }\n"
-    hpp += "    return true;\n"
-    hpp += "  }\n"
-    hpp += "  bool check_authenticated_() {\n"
-    hpp += "    if (!this->check_connection_setup_()) {\n"
-    hpp += "      return false;\n"
-    hpp += "    }\n"
-    hpp += "    if (!this->is_authenticated()) {\n"
-    hpp += "      this->on_unauthenticated_access();\n"
-    hpp += "      return false;\n"
-    hpp += "    }\n"
-    hpp += "    return true;\n"
-    hpp += "  }\n"
-    hpp += " public:\n\n"
+    hpp += " public:\n"
 
     # Add generic send_message method
     hpp += "  template<typename T>\n"


### PR DESCRIPTION
# What does this implement/fix?

This PR reduces code duplication in the auto-generated API protocol code by introducing helper methods for authentication checks. Previously, every API command handler repeated the same authentication check pattern:

```cpp
if (!this->is_connection_setup()) {
  this->on_no_setup_connection();
  return;
}
if (!this->is_authenticated()) {
  this->on_unauthenticated_access();
  return;
}
```

This pattern was duplicated across 40+ command handlers, resulting in ~200 lines of repetitive code.

The changes modify the code generator (`script/api_protobuf/api_protobuf.py`) to:
1. Generate two helper methods: `check_connection_setup_()` and `check_authenticated_()`
2. Replace all repetitive authentication checks with calls to these helpers
3. Use positive condition checks to reduce nesting and improve readability

**Example transformation:**

Before:
```cpp
void APIServerConnection::on_climate_command_request(const ClimateCommandRequest &msg) {
  if (!this->is_connection_setup()) {
    this->on_no_setup_connection();
    return;
  }
  if (!this->is_authenticated()) {
    this->on_unauthenticated_access();
    return;
  }
  this->climate_command(msg);
}
```

After:
```cpp
void APIServerConnection::on_climate_command_request(const ClimateCommandRequest &msg) {
  if (this->check_authenticated_()) {
    this->climate_command(msg);
  }
}
```

**Results:**
- **Lines removed:** 245
- **Lines added:** 43
- **Net reduction:** 202 lines (~20% reduction in api_pb2_service.cpp)
- **File size:** Reduced from 1165 lines to 921 lines
- **Flash memory saved:** 1084 bytes (from 1106528 to 1105444 bytes)
- **RAM usage:** No change (43844 bytes)
- **Improved maintainability:** Authentication logic is now centralized in one place
- **Better readability:** Positive conditions eliminate early returns and reduce nesting

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A - This is an internal code generation improvement with no user-facing changes.

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - this is an internal code generation improvement
api:
  password: "example"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

Note: This change only affects the code generator script. The generated code maintains identical functionality while reducing duplication. No new tests are required as existing API tests cover this functionality.