### PR TITLE
Remove empty generated protobuf methods

### DIFF
--- a/esphome/components/api/api_pb2.cpp
+++ b/esphome/components/api/api_pb2.cpp
@@ -795,28 +795,18 @@ void ConnectResponse::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
-void DisconnectRequest::encode(ProtoWriteBuffer buffer) const {}
-void DisconnectRequest::calculate_size(uint32_t &total_size) const {}
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void DisconnectRequest::dump_to(std::string &out) const { out.append("DisconnectRequest {}"); }
 #endif
-void DisconnectResponse::encode(ProtoWriteBuffer buffer) const {}
-void DisconnectResponse::calculate_size(uint32_t &total_size) const {}
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void DisconnectResponse::dump_to(std::string &out) const { out.append("DisconnectResponse {}"); }
 #endif
-void PingRequest::encode(ProtoWriteBuffer buffer) const {}
-void PingRequest::calculate_size(uint32_t &total_size) const {}
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void PingRequest::dump_to(std::string &out) const { out.append("PingRequest {}"); }
 #endif
-void PingResponse::encode(ProtoWriteBuffer buffer) const {}
-void PingResponse::calculate_size(uint32_t &total_size) const {}
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void PingResponse::dump_to(std::string &out) const { out.append("PingResponse {}"); }
 #endif
-void DeviceInfoRequest::encode(ProtoWriteBuffer buffer) const {}
-void DeviceInfoRequest::calculate_size(uint32_t &total_size) const {}
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void DeviceInfoRequest::dump_to(std::string &out) const { out.append("DeviceInfoRequest {}"); }
 #endif
@@ -1037,18 +1027,12 @@ void DeviceInfoResponse::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
-void ListEntitiesRequest::encode(ProtoWriteBuffer buffer) const {}
-void ListEntitiesRequest::calculate_size(uint32_t &total_size) const {}
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void ListEntitiesRequest::dump_to(std::string &out) const { out.append("ListEntitiesRequest {}"); }
 #endif
-void ListEntitiesDoneResponse::encode(ProtoWriteBuffer buffer) const {}
-void ListEntitiesDoneResponse::calculate_size(uint32_t &total_size) const {}
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void ListEntitiesDoneResponse::dump_to(std::string &out) const { out.append("ListEntitiesDoneResponse {}"); }
 #endif
-void SubscribeStatesRequest::encode(ProtoWriteBuffer buffer) const {}
-void SubscribeStatesRequest::calculate_size(uint32_t &total_size) const {}
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void SubscribeStatesRequest::dump_to(std::string &out) const { out.append("SubscribeStatesRequest {}"); }
 #endif
@@ -3369,8 +3353,6 @@ void NoiseEncryptionSetKeyResponse::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
-void SubscribeHomeassistantServicesRequest::encode(ProtoWriteBuffer buffer) const {}
-void SubscribeHomeassistantServicesRequest::calculate_size(uint32_t &total_size) const {}
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void SubscribeHomeassistantServicesRequest::dump_to(std::string &out) const {
   out.append("SubscribeHomeassistantServicesRequest {}");
@@ -3496,8 +3478,6 @@ void HomeassistantServiceResponse::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
-void SubscribeHomeAssistantStatesRequest::encode(ProtoWriteBuffer buffer) const {}
-void SubscribeHomeAssistantStatesRequest::calculate_size(uint32_t &total_size) const {}
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void SubscribeHomeAssistantStatesRequest::dump_to(std::string &out) const {
   out.append("SubscribeHomeAssistantStatesRequest {}");
@@ -3601,8 +3581,6 @@ void HomeAssistantStateResponse::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
-void GetTimeRequest::encode(ProtoWriteBuffer buffer) const {}
-void GetTimeRequest::calculate_size(uint32_t &total_size) const {}
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void GetTimeRequest::dump_to(std::string &out) const { out.append("GetTimeRequest {}"); }
 #endif
@@ -7497,8 +7475,6 @@ void BluetoothGATTNotifyDataResponse::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
-void SubscribeBluetoothConnectionsFreeRequest::encode(ProtoWriteBuffer buffer) const {}
-void SubscribeBluetoothConnectionsFreeRequest::calculate_size(uint32_t &total_size) const {}
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void SubscribeBluetoothConnectionsFreeRequest::dump_to(std::string &out) const {
   out.append("SubscribeBluetoothConnectionsFreeRequest {}");
@@ -7782,8 +7758,6 @@ void BluetoothDeviceUnpairingResponse::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
-void UnsubscribeBluetoothLEAdvertisementsRequest::encode(ProtoWriteBuffer buffer) const {}
-void UnsubscribeBluetoothLEAdvertisementsRequest::calculate_size(uint32_t &total_size) const {}
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void UnsubscribeBluetoothLEAdvertisementsRequest::dump_to(std::string &out) const {
   out.append("UnsubscribeBluetoothLEAdvertisementsRequest {}");
@@ -8449,8 +8423,6 @@ void VoiceAssistantWakeWord::dump_to(std::string &out) const {
   out.append("}");
 }
 #endif
-void VoiceAssistantConfigurationRequest::encode(ProtoWriteBuffer buffer) const {}
-void VoiceAssistantConfigurationRequest::calculate_size(uint32_t &total_size) const {}
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void VoiceAssistantConfigurationRequest::dump_to(std::string &out) const {
   out.append("VoiceAssistantConfigurationRequest {}");

--- a/esphome/components/api/api_pb2.h
+++ b/esphome/components/api/api_pb2.h
@@ -356,8 +356,6 @@ class DisconnectRequest : public ProtoMessage {
 #ifdef HAS_PROTO_MESSAGE_DUMP
   static constexpr const char *message_name() { return "disconnect_request"; }
 #endif
-  void encode(ProtoWriteBuffer buffer) const override;
-  void calculate_size(uint32_t &total_size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
 #endif
@@ -371,8 +369,6 @@ class DisconnectResponse : public ProtoMessage {
 #ifdef HAS_PROTO_MESSAGE_DUMP
   static constexpr const char *message_name() { return "disconnect_response"; }
 #endif
-  void encode(ProtoWriteBuffer buffer) const override;
-  void calculate_size(uint32_t &total_size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
 #endif
@@ -386,8 +382,6 @@ class PingRequest : public ProtoMessage {
 #ifdef HAS_PROTO_MESSAGE_DUMP
   static constexpr const char *message_name() { return "ping_request"; }
 #endif
-  void encode(ProtoWriteBuffer buffer) const override;
-  void calculate_size(uint32_t &total_size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
 #endif
@@ -401,8 +395,6 @@ class PingResponse : public ProtoMessage {
 #ifdef HAS_PROTO_MESSAGE_DUMP
   static constexpr const char *message_name() { return "ping_response"; }
 #endif
-  void encode(ProtoWriteBuffer buffer) const override;
-  void calculate_size(uint32_t &total_size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
 #endif
@@ -416,8 +408,6 @@ class DeviceInfoRequest : public ProtoMessage {
 #ifdef HAS_PROTO_MESSAGE_DUMP
   static constexpr const char *message_name() { return "device_info_request"; }
 #endif
-  void encode(ProtoWriteBuffer buffer) const override;
-  void calculate_size(uint32_t &total_size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
 #endif
@@ -467,8 +457,6 @@ class ListEntitiesRequest : public ProtoMessage {
 #ifdef HAS_PROTO_MESSAGE_DUMP
   static constexpr const char *message_name() { return "list_entities_request"; }
 #endif
-  void encode(ProtoWriteBuffer buffer) const override;
-  void calculate_size(uint32_t &total_size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
 #endif
@@ -482,8 +470,6 @@ class ListEntitiesDoneResponse : public ProtoMessage {
 #ifdef HAS_PROTO_MESSAGE_DUMP
   static constexpr const char *message_name() { return "list_entities_done_response"; }
 #endif
-  void encode(ProtoWriteBuffer buffer) const override;
-  void calculate_size(uint32_t &total_size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
 #endif
@@ -497,8 +483,6 @@ class SubscribeStatesRequest : public ProtoMessage {
 #ifdef HAS_PROTO_MESSAGE_DUMP
   static constexpr const char *message_name() { return "subscribe_states_request"; }
 #endif
-  void encode(ProtoWriteBuffer buffer) const override;
-  void calculate_size(uint32_t &total_size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
 #endif
@@ -1010,8 +994,6 @@ class SubscribeHomeassistantServicesRequest : public ProtoMessage {
 #ifdef HAS_PROTO_MESSAGE_DUMP
   static constexpr const char *message_name() { return "subscribe_homeassistant_services_request"; }
 #endif
-  void encode(ProtoWriteBuffer buffer) const override;
-  void calculate_size(uint32_t &total_size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
 #endif
@@ -1060,8 +1042,6 @@ class SubscribeHomeAssistantStatesRequest : public ProtoMessage {
 #ifdef HAS_PROTO_MESSAGE_DUMP
   static constexpr const char *message_name() { return "subscribe_home_assistant_states_request"; }
 #endif
-  void encode(ProtoWriteBuffer buffer) const override;
-  void calculate_size(uint32_t &total_size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
 #endif
@@ -1114,8 +1094,6 @@ class GetTimeRequest : public ProtoMessage {
 #ifdef HAS_PROTO_MESSAGE_DUMP
   static constexpr const char *message_name() { return "get_time_request"; }
 #endif
-  void encode(ProtoWriteBuffer buffer) const override;
-  void calculate_size(uint32_t &total_size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
 #endif
@@ -2116,8 +2094,6 @@ class SubscribeBluetoothConnectionsFreeRequest : public ProtoMessage {
 #ifdef HAS_PROTO_MESSAGE_DUMP
   static constexpr const char *message_name() { return "subscribe_bluetooth_connections_free_request"; }
 #endif
-  void encode(ProtoWriteBuffer buffer) const override;
-  void calculate_size(uint32_t &total_size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
 #endif
@@ -2243,8 +2219,6 @@ class UnsubscribeBluetoothLEAdvertisementsRequest : public ProtoMessage {
 #ifdef HAS_PROTO_MESSAGE_DUMP
   static constexpr const char *message_name() { return "unsubscribe_bluetooth_le_advertisements_request"; }
 #endif
-  void encode(ProtoWriteBuffer buffer) const override;
-  void calculate_size(uint32_t &total_size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
 #endif
@@ -2511,8 +2485,6 @@ class VoiceAssistantConfigurationRequest : public ProtoMessage {
 #ifdef HAS_PROTO_MESSAGE_DUMP
   static constexpr const char *message_name() { return "voice_assistant_configuration_request"; }
 #endif
-  void encode(ProtoWriteBuffer buffer) const override;
-  void calculate_size(uint32_t &total_size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
 #endif

--- a/esphome/components/api/proto.h
+++ b/esphome/components/api/proto.h
@@ -327,9 +327,11 @@ class ProtoWriteBuffer {
 class ProtoMessage {
  public:
   virtual ~ProtoMessage() = default;
-  virtual void encode(ProtoWriteBuffer buffer) const = 0;
+  // Default implementation for messages with no fields
+  virtual void encode(ProtoWriteBuffer buffer) const {}
   void decode(const uint8_t *buffer, size_t length);
-  virtual void calculate_size(uint32_t &total_size) const = 0;
+  // Default implementation for messages with no fields
+  virtual void calculate_size(uint32_t &total_size) const {}
 #ifdef HAS_PROTO_MESSAGE_DUMP
   std::string dump() const;
   virtual void dump_to(std::string &out) const = 0;

--- a/script/api_protobuf/api_protobuf.py
+++ b/script/api_protobuf/api_protobuf.py
@@ -959,36 +959,35 @@ def build_message_type(
         prot = "bool decode_64bit(uint32_t field_id, Proto64Bit value) override;"
         protected_content.insert(0, prot)
 
-    o = f"void {desc.name}::encode(ProtoWriteBuffer buffer) const {{"
+    # Only generate encode method if there are fields to encode
     if encode:
+        o = f"void {desc.name}::encode(ProtoWriteBuffer buffer) const {{"
         if len(encode) == 1 and len(encode[0]) + len(o) + 3 < 120:
             o += f" {encode[0]} "
         else:
             o += "\n"
             o += indent("\n".join(encode)) + "\n"
-    o += "}\n"
-    cpp += o
-    prot = "void encode(ProtoWriteBuffer buffer) const override;"
-    public_content.append(prot)
+        o += "}\n"
+        cpp += o
+        prot = "void encode(ProtoWriteBuffer buffer) const override;"
+        public_content.append(prot)
+    # If no fields to encode, the default implementation in ProtoMessage will be used
 
-    # Add calculate_size method
-    o = f"void {desc.name}::calculate_size(uint32_t &total_size) const {{"
-
-    # Add a check for empty/default objects to short-circuit the calculation
-    # Only add this optimization if we have fields to check
+    # Add calculate_size method only if there are fields
     if size_calc:
+        o = f"void {desc.name}::calculate_size(uint32_t &total_size) const {{"
         # For a single field, just inline it for simplicity
         if len(size_calc) == 1 and len(size_calc[0]) + len(o) + 3 < 120:
             o += f" {size_calc[0]} "
         else:
-            # For multiple fields, add a short-circuit check
+            # For multiple fields
             o += "\n"
-            # Performance optimization: add all the size calculations
             o += indent("\n".join(size_calc)) + "\n"
-    o += "}\n"
-    cpp += o
-    prot = "void calculate_size(uint32_t &total_size) const override;"
-    public_content.append(prot)
+        o += "}\n"
+        cpp += o
+        prot = "void calculate_size(uint32_t &total_size) const override;"
+        public_content.append(prot)
+    # If no fields to calculate size for, the default implementation in ProtoMessage will be used
 
     o = f"void {desc.name}::dump_to(std::string &out) const {{"
     if dump:


### PR DESCRIPTION
# What does this implement/fix?

This PR optimizes the ESPHome API protocol buffer implementation by eliminating redundant empty method implementations. Messages with no fields now use default implementations from the `ProtoMessage` base class instead of generating empty methods for each message type.

## The Problem

Currently, every proto message class generates its own `encode()` and `calculate_size()` methods, even when they're empty:

```cpp
void DisconnectRequest::encode(ProtoWriteBuffer buffer) const {}
void DisconnectRequest::calculate_size(uint32_t &total_size) const {}
void PingRequest::encode(ProtoWriteBuffer buffer) const {}
void PingRequest::calculate_size(uint32_t &total_size) const {}
// ... 24 more empty implementations
```

This creates unnecessary code duplication for the 14 message types that have no fields.

## The Solution

1. **Modified `esphome/components/api/proto.h`**:
   - Changed `encode()` and `calculate_size()` from pure virtual to virtual with empty default implementations
   
2. **Modified `script/api_protobuf/api_protobuf.py`**:
   - Updated the code generator to skip generating empty methods
   - Only generates these methods when the message has actual fields

## Impact

- **Code Reduction**: Removes 28 empty method implementations
- **Flash Memory**: No significant change -- compiler optimizes these away anyways
- **No Functional Changes**: Protocol behavior remains identical

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Part of ongoing API code reduction efforts

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - Internal code generation optimization

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# No configuration changes - this is an internal optimization
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).