### PR TITLE
[i2s_audio] Add ``dump_config`` methods, shorten log messages

### DIFF
--- a/esphome/components/i2s_audio/i2s_audio.cpp
+++ b/esphome/components/i2s_audio/i2s_audio.cpp
@@ -18,7 +18,7 @@ void I2SAudioComponent::setup() {
 
   static i2s_port_t next_port_num = I2S_NUM_0;
   if (next_port_num >= I2S_NUM_MAX) {
-    ESP_LOGE(TAG, "Too many I2S Audio components");
+    ESP_LOGE(TAG, "Too many components");
     this->mark_failed();
     return;
   }

--- a/esphome/components/i2s_audio/microphone/i2s_audio_microphone.cpp
+++ b/esphome/components/i2s_audio/microphone/i2s_audio_microphone.cpp
@@ -45,7 +45,7 @@ void I2SAudioMicrophone::setup() {
 #if SOC_I2S_SUPPORTS_ADC
   if (this->adc_) {
     if (this->parent_->get_port() != I2S_NUM_0) {
-      ESP_LOGE(TAG, "Internal ADC only works on I2S0!");
+      ESP_LOGE(TAG, "Internal ADC only works on I2S0");
       this->mark_failed();
       return;
     }
@@ -55,7 +55,7 @@ void I2SAudioMicrophone::setup() {
   {
     if (this->pdm_) {
       if (this->parent_->get_port() != I2S_NUM_0) {
-        ESP_LOGE(TAG, "PDM only works on I2S0!");
+        ESP_LOGE(TAG, "PDM only works on I2S0");
         this->mark_failed();
         return;
       }
@@ -64,19 +64,28 @@ void I2SAudioMicrophone::setup() {
 
   this->active_listeners_semaphore_ = xSemaphoreCreateCounting(MAX_LISTENERS, MAX_LISTENERS);
   if (this->active_listeners_semaphore_ == nullptr) {
-    ESP_LOGE(TAG, "Failed to create semaphore");
+    ESP_LOGE(TAG, "Creating semaphore failed");
     this->mark_failed();
     return;
   }
 
   this->event_group_ = xEventGroupCreate();
   if (this->event_group_ == nullptr) {
-    ESP_LOGE(TAG, "Failed to create event group");
+    ESP_LOGE(TAG, "Creating event group failed");
     this->mark_failed();
     return;
   }
 
   this->configure_stream_settings_();
+}
+
+void I2SAudioMicrophone::dump_config() {
+  ESP_LOGCONFIG(TAG,
+                "Microphone:\n"
+                "  Pin: %d\n"
+                "  PDM: %s\n"
+                "  DC offset correction: %s",
+                static_cast<int8_t>(this->din_pin_), YESNO(this->pdm_), YESNO(this->correct_dc_offset_));
 }
 
 void I2SAudioMicrophone::configure_stream_settings_() {
@@ -151,7 +160,7 @@ bool I2SAudioMicrophone::start_driver_() {
     config.mode = (i2s_mode_t) (config.mode | I2S_MODE_ADC_BUILT_IN);
     err = i2s_driver_install(this->parent_->get_port(), &config, 0, nullptr);
     if (err != ESP_OK) {
-      ESP_LOGE(TAG, "Error installing I2S driver: %s", esp_err_to_name(err));
+      ESP_LOGE(TAG, "Error installing driver: %s", esp_err_to_name(err));
       return false;
     }
 
@@ -174,7 +183,7 @@ bool I2SAudioMicrophone::start_driver_() {
 
     err = i2s_driver_install(this->parent_->get_port(), &config, 0, nullptr);
     if (err != ESP_OK) {
-      ESP_LOGE(TAG, "Error installing I2S driver: %s", esp_err_to_name(err));
+      ESP_LOGE(TAG, "Error installing driver: %s", esp_err_to_name(err));
       return false;
     }
 
@@ -183,7 +192,7 @@ bool I2SAudioMicrophone::start_driver_() {
 
     err = i2s_set_pin(this->parent_->get_port(), &pin_config);
     if (err != ESP_OK) {
-      ESP_LOGE(TAG, "Error setting I2S pin: %s", esp_err_to_name(err));
+      ESP_LOGE(TAG, "Error setting pin: %s", esp_err_to_name(err));
       return false;
     }
   }
@@ -198,7 +207,7 @@ bool I2SAudioMicrophone::start_driver_() {
   /* Allocate a new RX channel and get the handle of this channel */
   err = i2s_new_channel(&chan_cfg, NULL, &this->rx_handle_);
   if (err != ESP_OK) {
-    ESP_LOGE(TAG, "Error creating new I2S channel: %s", esp_err_to_name(err));
+    ESP_LOGE(TAG, "Error creating channel: %s", esp_err_to_name(err));
     return false;
   }
 
@@ -270,14 +279,14 @@ bool I2SAudioMicrophone::start_driver_() {
     err = i2s_channel_init_std_mode(this->rx_handle_, &std_cfg);
   }
   if (err != ESP_OK) {
-    ESP_LOGE(TAG, "Error initializing I2S channel: %s", esp_err_to_name(err));
+    ESP_LOGE(TAG, "Error initializing channel: %s", esp_err_to_name(err));
     return false;
   }
 
   /* Before reading data, start the RX channel first */
   i2s_channel_enable(this->rx_handle_);
   if (err != ESP_OK) {
-    ESP_LOGE(TAG, "Error enabling I2S Microphone: %s", esp_err_to_name(err));
+    ESP_LOGE(TAG, "Enabling failed: %s", esp_err_to_name(err));
     return false;
   }
 #endif
@@ -304,29 +313,29 @@ void I2SAudioMicrophone::stop_driver_() {
   if (this->adc_) {
     err = i2s_adc_disable(this->parent_->get_port());
     if (err != ESP_OK) {
-      ESP_LOGW(TAG, "Error disabling ADC - it may not have started: %s", esp_err_to_name(err));
+      ESP_LOGW(TAG, "Error disabling ADC: %s", esp_err_to_name(err));
     }
   }
 #endif
   err = i2s_stop(this->parent_->get_port());
   if (err != ESP_OK) {
-    ESP_LOGW(TAG, "Error stopping I2S microphone - it may not have started: %s", esp_err_to_name(err));
+    ESP_LOGW(TAG, "Error stopping: %s", esp_err_to_name(err));
   }
   err = i2s_driver_uninstall(this->parent_->get_port());
   if (err != ESP_OK) {
-    ESP_LOGW(TAG, "Error uninstalling I2S driver - it may not have started: %s", esp_err_to_name(err));
+    ESP_LOGW(TAG, "Error uninstalling driver: %s", esp_err_to_name(err));
   }
 #else
   if (this->rx_handle_ != nullptr) {
     /* Have to stop the channel before deleting it */
     err = i2s_channel_disable(this->rx_handle_);
     if (err != ESP_OK) {
-      ESP_LOGW(TAG, "Error stopping I2S microphone - it may not have started: %s", esp_err_to_name(err));
+      ESP_LOGW(TAG, "Error stopping: %s", esp_err_to_name(err));
     }
     /* If the handle is not needed any more, delete it to release the channel resources */
     err = i2s_del_channel(this->rx_handle_);
     if (err != ESP_OK) {
-      ESP_LOGW(TAG, "Error deleting I2S channel - it may not have started: %s", esp_err_to_name(err));
+      ESP_LOGW(TAG, "Error deleting channel: %s", esp_err_to_name(err));
     }
     this->rx_handle_ = nullptr;
   }
@@ -403,7 +412,7 @@ size_t I2SAudioMicrophone::read_(uint8_t *buf, size_t len, TickType_t ticks_to_w
     // Ignore ESP_ERR_TIMEOUT if ticks_to_wait = 0, as it will read the data on the next call
     if (!this->status_has_warning()) {
       // Avoid spamming the logs with the error message if its repeated
-      ESP_LOGW(TAG, "Error reading from I2S microphone: %s", esp_err_to_name(err));
+      ESP_LOGW(TAG, "Read error: %s", esp_err_to_name(err));
     }
     this->status_set_warning();
     return 0;
@@ -431,19 +440,19 @@ void I2SAudioMicrophone::loop() {
   uint32_t event_group_bits = xEventGroupGetBits(this->event_group_);
 
   if (event_group_bits & MicrophoneEventGroupBits::TASK_STARTING) {
-    ESP_LOGD(TAG, "Task started, attempting to allocate buffer");
+    ESP_LOGV(TAG, "Task started, attempting to allocate buffer");
     xEventGroupClearBits(this->event_group_, MicrophoneEventGroupBits::TASK_STARTING);
   }
 
   if (event_group_bits & MicrophoneEventGroupBits::TASK_RUNNING) {
-    ESP_LOGD(TAG, "Task is running and reading data");
+    ESP_LOGV(TAG, "Task is running and reading data");
 
     xEventGroupClearBits(this->event_group_, MicrophoneEventGroupBits::TASK_RUNNING);
     this->state_ = microphone::STATE_RUNNING;
   }
 
   if ((event_group_bits & MicrophoneEventGroupBits::TASK_STOPPED)) {
-    ESP_LOGD(TAG, "Task finished, freeing resources and uninstalling I2S driver");
+    ESP_LOGV(TAG, "Task finished, freeing resources and uninstalling driver");
 
     vTaskDelete(this->task_handle_);
     this->task_handle_ = nullptr;
@@ -473,7 +482,7 @@ void I2SAudioMicrophone::loop() {
       }
 
       if (!this->start_driver_()) {
-        this->status_momentary_error("I2S driver failed to start, unloading it and attempting again in 1 second", 1000);
+        this->status_momentary_error("Driver failed to start; retrying in 1 second", 1000);
         this->stop_driver_();  // Stop/frees whatever possibly started
         break;
       }
@@ -483,7 +492,7 @@ void I2SAudioMicrophone::loop() {
                     &this->task_handle_);
 
         if (this->task_handle_ == nullptr) {
-          this->status_momentary_error("Task failed to start, attempting again in 1 second", 1000);
+          this->status_momentary_error("Task failed to start, retrying in 1 second", 1000);
           this->stop_driver_();  // Stops the driver to return the lock; will be reloaded in next attempt
         }
       }

--- a/esphome/components/i2s_audio/microphone/i2s_audio_microphone.h
+++ b/esphome/components/i2s_audio/microphone/i2s_audio_microphone.h
@@ -18,6 +18,7 @@ namespace i2s_audio {
 class I2SAudioMicrophone : public I2SAudioIn, public microphone::Microphone, public Component {
  public:
   void setup() override;
+  void dump_config() override;
   void start() override;
   void stop() override;
 

--- a/esphome/components/i2s_audio/speaker/i2s_audio_speaker.h
+++ b/esphome/components/i2s_audio/speaker/i2s_audio_speaker.h
@@ -24,6 +24,7 @@ class I2SAudioSpeaker : public I2SAudioOut, public speaker::Speaker, public Comp
   float get_setup_priority() const override { return esphome::setup_priority::PROCESSOR; }
 
   void setup() override;
+  void dump_config() override;
   void loop() override;
 
   void set_buffer_duration(uint32_t buffer_duration_ms) { this->buffer_duration_ms_ = buffer_duration_ms; }


### PR DESCRIPTION
# What does this implement/fix?

See https://discord.com/channels/429907082951524364/1378454169039540345

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
