### PR TITLE
[i2s_audio] Bugfix: crashes when unlocking i2s bus multiple times

### DIFF
--- a/esphome/components/i2s_audio/microphone/i2s_audio_microphone.cpp
+++ b/esphome/components/i2s_audio/microphone/i2s_audio_microphone.cpp
@@ -482,7 +482,8 @@ void I2SAudioMicrophone::loop() {
       }
 
       if (!this->start_driver_()) {
-        this->status_momentary_error("Driver failed to start; retrying in 1 second", 1000);
+        ESP_LOGE(TAG, "Driver failed to start; retrying in 1 second");
+        this->status_momentary_error("driver_fail", 1000);
         this->stop_driver_();  // Stop/frees whatever possibly started
         break;
       }
@@ -492,7 +493,8 @@ void I2SAudioMicrophone::loop() {
                     &this->task_handle_);
 
         if (this->task_handle_ == nullptr) {
-          this->status_momentary_error("Task failed to start, retrying in 1 second", 1000);
+          ESP_LOGE(TAG, "Task failed to start, retrying in 1 second");
+          this->status_momentary_error("task_fail", 1000);
           this->stop_driver_();  // Stops the driver to return the lock; will be reloaded in next attempt
         }
       }

--- a/esphome/components/i2s_audio/microphone/i2s_audio_microphone.cpp
+++ b/esphome/components/i2s_audio/microphone/i2s_audio_microphone.cpp
@@ -136,6 +136,7 @@ bool I2SAudioMicrophone::start_driver_() {
   if (!this->parent_->try_lock()) {
     return false;  // Waiting for another i2s to return lock
   }
+  this->locked_driver_ = true;
   esp_err_t err;
 
 #ifdef USE_I2S_LEGACY
@@ -340,7 +341,10 @@ void I2SAudioMicrophone::stop_driver_() {
     this->rx_handle_ = nullptr;
   }
 #endif
-  this->parent_->unlock();
+  if (this->locked_driver_) {
+    this->parent_->unlock();
+    this->locked_driver_ = false;
+  }
 }
 
 void I2SAudioMicrophone::mic_task(void *params) {

--- a/esphome/components/i2s_audio/microphone/i2s_audio_microphone.h
+++ b/esphome/components/i2s_audio/microphone/i2s_audio_microphone.h
@@ -81,6 +81,7 @@ class I2SAudioMicrophone : public I2SAudioIn, public microphone::Microphone, pub
   bool pdm_{false};
 
   bool correct_dc_offset_;
+  bool locked_driver_{false};
   int32_t dc_offset_{0};
 };
 


### PR DESCRIPTION
# What does this implement/fix?

#9062 didn't fully fix a crashing issue with the microphone. In certain situations, the I2S driver would attempt to uninstall itself twice. This would cause a crash when it attempted to unlock the I2S bus without having already locked it. This PR adds a boolean to keep track of the lock status to avoid unlocking it more than once. It also explicitly logs two errors, as the string pass to ``status_momonetary_error`` doesn't log that message, but instead uses it to name the timer that removes the error.

As a future note, the whole I2S stack needs a more thorough refactoring. The Mutex lock only locks by task/thread, so the lock is useless if both the speaker and mic start/stop the driver from the main loop (currently only the microphone does this). Long term, the parent I2S audio bus component should handle setting up the rx/tx channel handles, and the microphone/speaker components just retrieve the handles as needed.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** https://github.com/esphome/issues/issues/7098

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** not applicable

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
