### PR TITLE
Optimize API server performance by using cached loop time

### DIFF
--- a/esphome/components/api/api_server.cpp
+++ b/esphome/components/api/api_server.cpp
@@ -106,7 +106,7 @@ void APIServer::setup() {
   }
 #endif
 
-  this->last_connected_ = millis();
+  this->last_connected_ = App.get_loop_component_start_time();
 
 #ifdef USE_ESP32_CAMERA
   if (esp32_camera::global_esp32_camera != nullptr && !esp32_camera::global_esp32_camera->is_internal()) {
@@ -164,7 +164,7 @@ void APIServer::loop() {
   }
 
   if (this->reboot_timeout_ != 0) {
-    const uint32_t now = millis();
+    const uint32_t now = App.get_loop_component_start_time();
     if (!this->is_connected()) {
       if (now - this->last_connected_ > this->reboot_timeout_) {
         ESP_LOGE(TAG, "No client connected; rebooting");


### PR DESCRIPTION
# What does this implement/fix?

This PR optimizes the API server component by replacing `millis()` calls with `App.get_loop_component_start_time()` to reduce redundant time calculations and improve performance.

**Changes:**
- Replace 2 `millis()` calls in `api_server.cpp` with `App.get_loop_component_start_time()`
  - In `setup()`: Initialize `last_connected_` with loop component start time
  - In `loop()`: Use cached loop time for reboot timeout tracking

**Performance Impact:**
Based on runtime statistics showing API component with high loop counts (229,880 over the measurement period), this optimization eliminates redundant system calls for time retrieval. The framework already captures the loop start time once per iteration, so reusing this value reduces overhead.

**Safety Analysis:**
The changes are safe because:
1. Consistent timing: Both the timeout check and update use the same time reference within each loop iteration
2. Proper initialization: During setup, `loop_component_start_time_` is set to current `millis()` before API server setup runs
3. No precision loss: The reboot timeout (default 5 minutes) is orders of magnitude larger than any timing differences
4. Preserved behavior: The reboot-on-disconnect functionality remains unchanged

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# No configuration changes required
# This is an internal optimization

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).