### PR TITLE
Use smaller atomic types for ESP32 BLE Tracker ring buffer indices

### DIFF
--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
@@ -122,10 +122,10 @@ void ESP32BLETracker::loop() {
   // Consumer side: This runs in the main loop thread
   if (this->scanner_state_ == ScannerState::RUNNING) {
     // Load our own index with relaxed ordering (we're the only writer)
-    size_t read_idx = this->ring_read_index_.load(std::memory_order_relaxed);
+    uint8_t read_idx = this->ring_read_index_.load(std::memory_order_relaxed);
 
     // Load producer's index with acquire to see their latest writes
-    size_t write_idx = this->ring_write_index_.load(std::memory_order_acquire);
+    uint8_t write_idx = this->ring_write_index_.load(std::memory_order_acquire);
 
     while (read_idx != write_idx) {
       // Process one result at a time directly from ring buffer
@@ -409,11 +409,11 @@ void ESP32BLETracker::gap_scan_event_handler(const BLEScanResult &scan_result) {
     // IMPORTANT: Only this thread writes to ring_write_index_
 
     // Load our own index with relaxed ordering (we're the only writer)
-    size_t write_idx = this->ring_write_index_.load(std::memory_order_relaxed);
-    size_t next_write_idx = (write_idx + 1) % SCAN_RESULT_BUFFER_SIZE;
+    uint8_t write_idx = this->ring_write_index_.load(std::memory_order_relaxed);
+    uint8_t next_write_idx = (write_idx + 1) % SCAN_RESULT_BUFFER_SIZE;
 
     // Load consumer's index with acquire to see their latest updates
-    size_t read_idx = this->ring_read_index_.load(std::memory_order_acquire);
+    uint8_t read_idx = this->ring_read_index_.load(std::memory_order_acquire);
 
     // Check if buffer is full
     if (next_write_idx != read_idx) {

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
@@ -289,9 +289,9 @@ class ESP32BLETracker : public Component,
   // Consumer: ESPHome main loop (loop() method)
   // This design ensures zero blocking in the BT callback and prevents scan result loss
   BLEScanResult *scan_ring_buffer_;
-  std::atomic<size_t> ring_write_index_{0};      // Written only by BT callback (producer)
-  std::atomic<size_t> ring_read_index_{0};       // Written only by main loop (consumer)
-  std::atomic<size_t> scan_results_dropped_{0};  // Tracks buffer overflow events
+  std::atomic<uint8_t> ring_write_index_{0};       // Written only by BT callback (producer)
+  std::atomic<uint8_t> ring_read_index_{0};        // Written only by main loop (consumer)
+  std::atomic<uint16_t> scan_results_dropped_{0};  // Tracks buffer overflow events
 
   esp_bt_status_t scan_start_failed_{ESP_BT_STATUS_SUCCESS};
   esp_bt_status_t scan_set_param_failed_{ESP_BT_STATUS_SUCCESS};


### PR DESCRIPTION
# What does this implement/fix?

This PR optimizes the memory usage of the ESP32 BLE Tracker component by using appropriately sized atomic types for ring buffer indices. After verifying that all atomic operations used in ESPHome are lock-free on ESP32, we can safely reduce the index sizes from `size_t` (4 bytes) to `uint8_t` (1 byte) for buffer indices, saving 8 bytes per BLE tracker instance without any performance penalty.

### Changes Made
- Changed `ring_write_index_` and `ring_read_index_` from `std::atomic<size_t>` to `std::atomic<uint8_t>` (saves 6 bytes)
- Changed `scan_results_dropped_` from `std::atomic<size_t>` to `std::atomic<uint16_t>` (saves 2 bytes)
- Total: **8 bytes saved per ESP32 BLE Tracker instance**

### Why This Is Safe
- `SCAN_RESULT_BUFFER_SIZE` is only 32 (with PSRAM) or 20 (without PSRAM)
- `uint8_t` can represent 0-255, more than sufficient for buffer indices
- `uint16_t` allows counting up to 65,535 dropped events
- All operations remain lock-free with smaller atomic types

### Testing Performed
1. Verified all atomic types remain lock-free on ESP32:
   - `ATOMIC_CHAR_LOCK_FREE: 2` (always lock-free for uint8_t)
   - `ATOMIC_SHORT_LOCK_FREE: 2` (always lock-free for uint16_t)

2. Performance benchmarking shows identical performance:
   - Atomic ring buffer: 0.76 µs per push+pop operation
   - No regression in BLE scanning performance
   - Lock-free ring buffer maintains its 8.89x performance advantage over FreeRTOS alternatives

Every byte counts on ESP32, especially when running complex configurations with Bluetooth proxy functionality. This simple optimization provides a free memory reduction without any performance penalty.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A (internal implementation detail, no user-facing changes)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# No configuration changes needed - this is an internal optimization
esp32_ble_tracker:
  scan_parameters:
    active: true

bluetooth_proxy:
  active: true
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).