### PR TITLE
[display] Virtualise methods to allow subclasses to optimise

### DIFF
--- a/esphome/components/display/display.cpp
+++ b/esphome/components/display/display.cpp
@@ -764,7 +764,6 @@ const uint8_t TESTCARD_FONT[3][8] PROGMEM = {{0x41, 0x7F, 0x7F, 0x09, 0x19, 0x7F
 void Display::test_card() {
   int w = get_width(), h = get_height(), image_w, image_h;
   this->clear();
-  this->show_test_card_ = false;
   if (this->get_display_type() == DISPLAY_TYPE_COLOR) {
     Color r(255, 0, 0), g(0, 255, 0), b(0, 0, 255);
     image_w = std::min(w - 20, 310);

--- a/esphome/components/display/display.h
+++ b/esphome/components/display/display.h
@@ -258,20 +258,27 @@ class Display : public PollingComponent {
   }
 
   /// Draw a straight line from the point [x1,y1] to [x2,y2] with the given color.
-  virtual void line(int x1, int y1, int x2, int y2, Color color = COLOR_ON);
+  virtual void line(int x1, int y1, int x2, int y2, Color color);
+  void line(int x1, int y1, int x2, int y2) { this->line(x1, y1, x2, y2, COLOR_ON); }
 
   /// Draw a straight line at the given angle based on the origin [x, y] for a specified length with the given color.
-  virtual void line_at_angle(int x, int y, int angle, int length, Color color = COLOR_ON);
+  virtual void line_at_angle(int x, int y, int angle, int length, Color color);
+  void line_at_angle(int x, int y, int angle, int length) { this->line_at_angle(x, y, angle, length, COLOR_ON); }
 
   /// Draw a straight line at the given angle based on the origin [x, y] from a specified start and stop radius with the
   /// given color.
+  void line_at_angle(int x, int y, int angle, int start_radius, int stop_radius) {
+    this->line_at_angle(x, y, angle, start_radius, stop_radius, COLOR_ON);
+  }
   virtual void line_at_angle(int x, int y, int angle, int start_radius, int stop_radius, Color color = COLOR_ON);
 
   /// Draw a horizontal line from the point [x,y] to [x+width,y] with the given color.
-  virtual void horizontal_line(int x, int y, int width, Color color = COLOR_ON);
+  virtual void horizontal_line(int x, int y, int width, Color color);
+  void horizontal_line(int x, int y, int width) { this->horizontal_line(x, y, width, COLOR_ON); }
 
   /// Draw a vertical line from the point [x,y] to [x,y+width] with the given color.
-  virtual void vertical_line(int x, int y, int height, Color color = COLOR_ON);
+  virtual void vertical_line(int x, int y, int height, Color color);
+  void vertical_line(int x, int y, int height) { this->vertical_line(x, y, height, COLOR_ON); }
 
   /// Draw the outline of a rectangle with the top left point at [x1,y1] and the bottom right point at
   /// [x1+width,y1+height].
@@ -290,7 +297,7 @@ class Display : public PollingComponent {
   /// color.
   void filled_ring(int center_x, int center_y, int radius1, int radius2, Color color = COLOR_ON);
   /// Fill a half-ring "gauge" centered around [center_x,center_y] between two circles with the radius1 and radius2
-  /// with he given color and filled up to 'progress' percent
+  /// with the given color and filled up to 'progress' percent
   void filled_gauge(int center_x, int center_y, int radius1, int radius2, int progress, Color color = COLOR_ON);
 
   /// Draw the outline of a triangle contained between the points [x1,y1], [x2,y2] and [x3,y3] with the given color.

--- a/esphome/components/display/display.h
+++ b/esphome/components/display/display.h
@@ -267,10 +267,10 @@ class Display : public PollingComponent {
 
   /// Draw a straight line at the given angle based on the origin [x, y] from a specified start and stop radius with the
   /// given color.
+  virtual void line_at_angle(int x, int y, int angle, int start_radius, int stop_radius, Color color);
   void line_at_angle(int x, int y, int angle, int start_radius, int stop_radius) {
     this->line_at_angle(x, y, angle, start_radius, stop_radius, COLOR_ON);
   }
-  virtual void line_at_angle(int x, int y, int angle, int start_radius, int stop_radius, Color color = COLOR_ON);
 
   /// Draw a horizontal line from the point [x,y] to [x+width,y] with the given color.
   virtual void horizontal_line(int x, int y, int width, Color color);
@@ -280,6 +280,9 @@ class Display : public PollingComponent {
   virtual void vertical_line(int x, int y, int height, Color color);
   void vertical_line(int x, int y, int height) { this->vertical_line(x, y, height, COLOR_ON); }
 
+  // Methods below are not virtual, since they are implemented using the above methods and are thus not
+  // prime candidates for overriding in derived classes.
+
   /// Draw the outline of a rectangle with the top left point at [x1,y1] and the bottom right point at
   /// [x1+width,y1+height].
   void rectangle(int x1, int y1, int width, int height, Color color = COLOR_ON);
@@ -287,17 +290,16 @@ class Display : public PollingComponent {
   /// Fill a rectangle with the top left point at [x1,y1] and the bottom right point at [x1+width,y1+height].
   void filled_rectangle(int x1, int y1, int width, int height, Color color = COLOR_ON);
 
-  /// Draw the outline of a circle centered around [center_x,center_y] with the radius radius with the given color.
+  /// Draw the outline of a circle centered around [center_x,center_y] with the specified radius and color.
   void circle(int center_x, int center_xy, int radius, Color color = COLOR_ON);
 
-  /// Fill a circle centered around [center_x,center_y] with the radius radius with the given color.
+  /// Fill a circle centered around [center_x,center_y] with the specified radius and color.
   void filled_circle(int center_x, int center_y, int radius, Color color = COLOR_ON);
 
-  /// Fill a ring centered around [center_x,center_y] between two circles with the radius1 and radius2 with the given
-  /// color.
+  /// Fill a ring centered around [center_x,center_y] between two circles given two radii and a color
   void filled_ring(int center_x, int center_y, int radius1, int radius2, Color color = COLOR_ON);
-  /// Fill a half-ring "gauge" centered around [center_x,center_y] between two circles with the radius1 and radius2
-  /// with the given color and filled up to 'progress' percent
+  /// Fill a half-ring "gauge" centered around [center_x,center_y] between two circles given two radii and a color,
+  /// filled to 'progress' percent
   void filled_gauge(int center_x, int center_y, int radius1, int radius2, int progress, Color color = COLOR_ON);
 
   /// Draw the outline of a triangle contained between the points [x1,y1], [x2,y2] and [x3,y3] with the given color.

--- a/esphome/components/display/display.h
+++ b/esphome/components/display/display.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <cstdarg>
 #include <vector>
 
 #include "rect.h"
@@ -259,20 +258,20 @@ class Display : public PollingComponent {
   }
 
   /// Draw a straight line from the point [x1,y1] to [x2,y2] with the given color.
-  void line(int x1, int y1, int x2, int y2, Color color = COLOR_ON);
+  virtual void line(int x1, int y1, int x2, int y2, Color color = COLOR_ON);
 
   /// Draw a straight line at the given angle based on the origin [x, y] for a specified length with the given color.
-  void line_at_angle(int x, int y, int angle, int length, Color color = COLOR_ON);
+  virtual void line_at_angle(int x, int y, int angle, int length, Color color = COLOR_ON);
 
   /// Draw a straight line at the given angle based on the origin [x, y] from a specified start and stop radius with the
   /// given color.
-  void line_at_angle(int x, int y, int angle, int start_radius, int stop_radius, Color color = COLOR_ON);
+  virtual void line_at_angle(int x, int y, int angle, int start_radius, int stop_radius, Color color = COLOR_ON);
 
   /// Draw a horizontal line from the point [x,y] to [x+width,y] with the given color.
-  void horizontal_line(int x, int y, int width, Color color = COLOR_ON);
+  virtual void horizontal_line(int x, int y, int width, Color color = COLOR_ON);
 
   /// Draw a vertical line from the point [x,y] to [x,y+width] with the given color.
-  void vertical_line(int x, int y, int height, Color color = COLOR_ON);
+  virtual void vertical_line(int x, int y, int height, Color color = COLOR_ON);
 
   /// Draw the outline of a rectangle with the top left point at [x1,y1] and the bottom right point at
   /// [x1+width,y1+height].

--- a/esphome/components/display/display.h
+++ b/esphome/components/display/display.h
@@ -354,8 +354,11 @@ class Display : public PollingComponent {
    * @param text The text to draw.
    * @param background When using multi-bit (anti-aliased) fonts, blend this background color into pixels
    */
-  void print(int x, int y, BaseFont *font, Color color, TextAlign align, const char *text,
-             Color background = COLOR_OFF);
+  virtual void print(int x, int y, BaseFont *font, Color color, TextAlign align, const char *text, Color background);
+  // default color overload
+  void print(int x, int y, BaseFont *font, Color color, TextAlign align, const char *text) {
+    this->print(x, y, font, color, align, text, COLOR_OFF);
+  }
 
   /** Print `text` with the top left at [x,y] with `font`.
    *
@@ -527,7 +530,10 @@ class Display : public PollingComponent {
    * @param color_on The color to replace in binary images for the on bits.
    * @param color_off The color to replace in binary images for the off bits.
    */
-  void image(int x, int y, BaseImage *image, ImageAlign align, Color color_on = COLOR_ON, Color color_off = COLOR_OFF);
+  virtual void image(int x, int y, BaseImage *image, ImageAlign align, Color color_on, Color color_off);
+  void image(int x, int y, BaseImage *image, ImageAlign align, Color color_on = COLOR_ON) {
+    this->image(x, y, image, align, color_on, COLOR_OFF);
+  }
 
 #ifdef USE_GRAPH
   /** Draw the `graph` with the top-left corner at [x,y] to the screen.

--- a/esphome/components/display/display_buffer.cpp
+++ b/esphome/components/display/display_buffer.cpp
@@ -44,10 +44,7 @@ int DisplayBuffer::get_height() {
   }
 }
 
-void HOT DisplayBuffer::draw_pixel_at(int x, int y, Color color) {
-  if (!this->get_clipping().inside(x, y))
-    return;  // NOLINT
-
+void HOT DisplayBuffer::rotate_point_(int &x, int &y) {
   switch (this->rotation_) {
     case DISPLAY_ROTATION_0_DEGREES:
       break;
@@ -64,6 +61,12 @@ void HOT DisplayBuffer::draw_pixel_at(int x, int y, Color color) {
       y = this->get_height_internal() - y - 1;
       break;
   }
+}
+
+void HOT DisplayBuffer::draw_pixel_at(int x, int y, Color color) {
+  if (!this->get_clipping().inside(x, y))
+    return;  // NOLINT
+  this->rotate_point_(x, y);
   this->draw_absolute_pixel_internal(x, y, color);
   App.feed_wdt();
 }

--- a/esphome/components/display/display_buffer.h
+++ b/esphome/components/display/display_buffer.h
@@ -18,12 +18,12 @@ class DisplayBuffer : public Display {
   int get_width() override;
   /// Get the height of the image in pixels with rotation applied.
   int get_height() override;
-  void rotate_point_(int &x, int &y);
 
   /// Set a single pixel at the specified coordinates to the given color.
   void draw_pixel_at(int x, int y, Color color) override;
 
  protected:
+  void rotate_point_(int &x, int &y);
   virtual void draw_absolute_pixel_internal(int x, int y, Color color) = 0;
 
   void init_internal_(uint32_t buffer_length);

--- a/esphome/components/display/display_buffer.h
+++ b/esphome/components/display/display_buffer.h
@@ -18,6 +18,7 @@ class DisplayBuffer : public Display {
   int get_width() override;
   /// Get the height of the image in pixels with rotation applied.
   int get_height() override;
+  void rotate_point_(int &x, int &y);
 
   /// Set a single pixel at the specified coordinates to the given color.
   void draw_pixel_at(int x, int y, Color color) override;


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

The drawing primitives in `display` are generic but naive, and could be optimised by overriding them in concrete subclasses.

Update several signatures by adding `virtual` thus allowing subclasses to override.

Further PR to take advantage of this is coming.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
