### PR TITLE
Optimize API component memory usage by reordering class members to reduce padding

### DIFF
--- a/esphome/components/api/api_server.h
+++ b/esphome/components/api/api_server.h
@@ -142,19 +142,27 @@ class APIServer : public Component, public Controller {
   }
 
  protected:
-  bool shutting_down_ = false;
+  // Pointers and pointer-like types first (4 bytes each)
   std::unique_ptr<socket::Socket> socket_ = nullptr;
-  uint16_t port_{6053};
+  Trigger<std::string, std::string> *client_connected_trigger_ = new Trigger<std::string, std::string>();
+  Trigger<std::string, std::string> *client_disconnected_trigger_ = new Trigger<std::string, std::string>();
+
+  // 4-byte aligned types
   uint32_t reboot_timeout_{300000};
   uint32_t batch_delay_{100};
   uint32_t last_connected_{0};
+
+  // Vectors and strings (12 bytes each on 32-bit)
   std::vector<std::unique_ptr<APIConnection>> clients_;
   std::string password_;
   std::vector<uint8_t> shared_write_buffer_;  // Shared proto write buffer for all connections
   std::vector<HomeAssistantStateSubscription> state_subs_;
   std::vector<UserServiceDescriptor *> user_services_;
-  Trigger<std::string, std::string> *client_connected_trigger_ = new Trigger<std::string, std::string>();
-  Trigger<std::string, std::string> *client_disconnected_trigger_ = new Trigger<std::string, std::string>();
+
+  // Group smaller types together
+  uint16_t port_{6053};
+  bool shutting_down_ = false;
+  // 3 bytes used, 1 byte padding
 
 #ifdef USE_API_NOISE
   std::shared_ptr<APINoiseContext> noise_ctx_ = std::make_shared<APINoiseContext>();


### PR DESCRIPTION
## What does this implement/fix?

This PR optimizes memory usage in the API component by reordering class member variables to minimize padding on 32-bit systems (ESP32). The changes reduce memory consumption by approximately 32 bytes per API connection through:

1. **Reordering class members** to group variables by alignment requirements, reducing padding waste
2. **Optimizing data types** where appropriate:
   - Changed `ConnectionState` enum to `uint8_t` (was using default int size)
   - Changed `log_subscription_` from `int` to `uint8_t` (log levels only range 0-7)
   - Changed `client_api_version_major_` and `client_api_version_minor_` from `uint32_t` to `uint16_t`
   - Changed `State` enum in APIFrameHelper to `uint8_t`
3. **Removing redundant data** by eliminating `client_combined_info_` string and generating it on-demand

### Memory savings per connection:
- **APIConnection**: ~9 bytes padding eliminated + 12 bytes from removed string
- **APIServer**: ~4 bytes padding eliminated
- **APIFrameHelper**: ~1 byte padding eliminated
- **APINoiseFrameHelper**: ~4 bytes padding eliminated
- **APIPlaintextFrameHelper**: ~2 bytes padding eliminated

Total: **~32 bytes saved per API connection**

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A (no user-facing changes)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - this is an internal optimization
api:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

**Note:** This is a memory optimization that doesn't change any functionality. All existing API functionality remains exactly the same, just using less memory.