### PR TITLE
Resolve esphome::optional vs std::optional ambiguity in code generation

### DIFF
--- a/esphome/cpp_types.py
+++ b/esphome/cpp_types.py
@@ -29,7 +29,9 @@ Component = esphome_ns.class_("Component")
 ComponentPtr = Component.operator("ptr")
 PollingComponent = esphome_ns.class_("PollingComponent", Component)
 Application = esphome_ns.class_("Application")
-optional = esphome_ns.class_("optional")
+# Create optional with explicit namespace to avoid ambiguity with std::optional
+# The generated code will use esphome::optional instead of just optional
+optional = global_ns.namespace("esphome").class_("optional")
 arduino_json_ns = global_ns.namespace("ArduinoJson")
 JsonObject = arduino_json_ns.class_("JsonObject")
 JsonObjectConst = arduino_json_ns.class_("JsonObjectConst")

--- a/tests/component_tests/text/test_text.py
+++ b/tests/component_tests/text/test_text.py
@@ -66,5 +66,5 @@ def test_text_config_lamda_is_set(generate_main):
     main_cpp = generate_main("tests/component_tests/text/test_text.yaml")
 
     # Then
-    assert "it_4->set_template([=]() -> optional<std::string> {" in main_cpp
+    assert "it_4->set_template([=]() -> esphome::optional<std::string> {" in main_cpp
     assert 'return std::string{"Hello"};' in main_cpp


### PR DESCRIPTION
# What does this implement/fix?

This PR fixes a compilation error that occurs when building components with Arduino framework on ESP32 platforms. The error was caused by ambiguity between `std::optional` (available in C++17) and `esphome::optional` in generated lambda return types.

The issue was introduced after #8867 added C++17 support. With C++17, `std::optional` becomes available, creating ambiguity with ESPHome's own `esphome::optional` implementation. The compiler couldn't resolve which `optional` type to use in lambda expressions:

```
error: reference to 'optional' is ambiguous
note: candidates are: 'template<class T> class esphome::optional'
note:                 'template<class _Tp> class std::optional'
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes compilation errors introduced after #8867

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Any component using template lambdas that return optional values
# Example: prometheus component with template sensors

sensor:
  - platform: template
    id: my_sensor
    lambda: |-
      if (millis() > 10000) {
        return 42.0;
      } else {
        return 0.0;
      }

prometheus:
  include_internal: true
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).