### PR TITLE
2025.6.0b3

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -48,7 +48,7 @@ PROJECT_NAME           = ESPHome
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 2025.6.0b2
+PROJECT_NUMBER         = 2025.6.0b3
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/esphome/components/i2s_audio/i2s_audio.cpp
+++ b/esphome/components/i2s_audio/i2s_audio.cpp
@@ -18,7 +18,7 @@ void I2SAudioComponent::setup() {
 
   static i2s_port_t next_port_num = I2S_NUM_0;
   if (next_port_num >= I2S_NUM_MAX) {
-    ESP_LOGE(TAG, "Too many I2S Audio components");
+    ESP_LOGE(TAG, "Too many components");
     this->mark_failed();
     return;
   }

--- a/esphome/components/i2s_audio/microphone/i2s_audio_microphone.cpp
+++ b/esphome/components/i2s_audio/microphone/i2s_audio_microphone.cpp
@@ -45,7 +45,7 @@ void I2SAudioMicrophone::setup() {
 #if SOC_I2S_SUPPORTS_ADC
   if (this->adc_) {
     if (this->parent_->get_port() != I2S_NUM_0) {
-      ESP_LOGE(TAG, "Internal ADC only works on I2S0!");
+      ESP_LOGE(TAG, "Internal ADC only works on I2S0");
       this->mark_failed();
       return;
     }
@@ -55,7 +55,7 @@ void I2SAudioMicrophone::setup() {
   {
     if (this->pdm_) {
       if (this->parent_->get_port() != I2S_NUM_0) {
-        ESP_LOGE(TAG, "PDM only works on I2S0!");
+        ESP_LOGE(TAG, "PDM only works on I2S0");
         this->mark_failed();
         return;
       }
@@ -64,19 +64,28 @@ void I2SAudioMicrophone::setup() {
 
   this->active_listeners_semaphore_ = xSemaphoreCreateCounting(MAX_LISTENERS, MAX_LISTENERS);
   if (this->active_listeners_semaphore_ == nullptr) {
-    ESP_LOGE(TAG, "Failed to create semaphore");
+    ESP_LOGE(TAG, "Creating semaphore failed");
     this->mark_failed();
     return;
   }
 
   this->event_group_ = xEventGroupCreate();
   if (this->event_group_ == nullptr) {
-    ESP_LOGE(TAG, "Failed to create event group");
+    ESP_LOGE(TAG, "Creating event group failed");
     this->mark_failed();
     return;
   }
 
   this->configure_stream_settings_();
+}
+
+void I2SAudioMicrophone::dump_config() {
+  ESP_LOGCONFIG(TAG,
+                "Microphone:\n"
+                "  Pin: %d\n"
+                "  PDM: %s\n"
+                "  DC offset correction: %s",
+                static_cast<int8_t>(this->din_pin_), YESNO(this->pdm_), YESNO(this->correct_dc_offset_));
 }
 
 void I2SAudioMicrophone::configure_stream_settings_() {
@@ -151,7 +160,7 @@ bool I2SAudioMicrophone::start_driver_() {
     config.mode = (i2s_mode_t) (config.mode | I2S_MODE_ADC_BUILT_IN);
     err = i2s_driver_install(this->parent_->get_port(), &config, 0, nullptr);
     if (err != ESP_OK) {
-      ESP_LOGE(TAG, "Error installing I2S driver: %s", esp_err_to_name(err));
+      ESP_LOGE(TAG, "Error installing driver: %s", esp_err_to_name(err));
       return false;
     }
 
@@ -174,7 +183,7 @@ bool I2SAudioMicrophone::start_driver_() {
 
     err = i2s_driver_install(this->parent_->get_port(), &config, 0, nullptr);
     if (err != ESP_OK) {
-      ESP_LOGE(TAG, "Error installing I2S driver: %s", esp_err_to_name(err));
+      ESP_LOGE(TAG, "Error installing driver: %s", esp_err_to_name(err));
       return false;
     }
 
@@ -183,7 +192,7 @@ bool I2SAudioMicrophone::start_driver_() {
 
     err = i2s_set_pin(this->parent_->get_port(), &pin_config);
     if (err != ESP_OK) {
-      ESP_LOGE(TAG, "Error setting I2S pin: %s", esp_err_to_name(err));
+      ESP_LOGE(TAG, "Error setting pin: %s", esp_err_to_name(err));
       return false;
     }
   }
@@ -198,7 +207,7 @@ bool I2SAudioMicrophone::start_driver_() {
   /* Allocate a new RX channel and get the handle of this channel */
   err = i2s_new_channel(&chan_cfg, NULL, &this->rx_handle_);
   if (err != ESP_OK) {
-    ESP_LOGE(TAG, "Error creating new I2S channel: %s", esp_err_to_name(err));
+    ESP_LOGE(TAG, "Error creating channel: %s", esp_err_to_name(err));
     return false;
   }
 
@@ -270,14 +279,14 @@ bool I2SAudioMicrophone::start_driver_() {
     err = i2s_channel_init_std_mode(this->rx_handle_, &std_cfg);
   }
   if (err != ESP_OK) {
-    ESP_LOGE(TAG, "Error initializing I2S channel: %s", esp_err_to_name(err));
+    ESP_LOGE(TAG, "Error initializing channel: %s", esp_err_to_name(err));
     return false;
   }
 
   /* Before reading data, start the RX channel first */
   i2s_channel_enable(this->rx_handle_);
   if (err != ESP_OK) {
-    ESP_LOGE(TAG, "Error enabling I2S Microphone: %s", esp_err_to_name(err));
+    ESP_LOGE(TAG, "Enabling failed: %s", esp_err_to_name(err));
     return false;
   }
 #endif
@@ -304,29 +313,29 @@ void I2SAudioMicrophone::stop_driver_() {
   if (this->adc_) {
     err = i2s_adc_disable(this->parent_->get_port());
     if (err != ESP_OK) {
-      ESP_LOGW(TAG, "Error disabling ADC - it may not have started: %s", esp_err_to_name(err));
+      ESP_LOGW(TAG, "Error disabling ADC: %s", esp_err_to_name(err));
     }
   }
 #endif
   err = i2s_stop(this->parent_->get_port());
   if (err != ESP_OK) {
-    ESP_LOGW(TAG, "Error stopping I2S microphone - it may not have started: %s", esp_err_to_name(err));
+    ESP_LOGW(TAG, "Error stopping: %s", esp_err_to_name(err));
   }
   err = i2s_driver_uninstall(this->parent_->get_port());
   if (err != ESP_OK) {
-    ESP_LOGW(TAG, "Error uninstalling I2S driver - it may not have started: %s", esp_err_to_name(err));
+    ESP_LOGW(TAG, "Error uninstalling driver: %s", esp_err_to_name(err));
   }
 #else
   if (this->rx_handle_ != nullptr) {
     /* Have to stop the channel before deleting it */
     err = i2s_channel_disable(this->rx_handle_);
     if (err != ESP_OK) {
-      ESP_LOGW(TAG, "Error stopping I2S microphone - it may not have started: %s", esp_err_to_name(err));
+      ESP_LOGW(TAG, "Error stopping: %s", esp_err_to_name(err));
     }
     /* If the handle is not needed any more, delete it to release the channel resources */
     err = i2s_del_channel(this->rx_handle_);
     if (err != ESP_OK) {
-      ESP_LOGW(TAG, "Error deleting I2S channel - it may not have started: %s", esp_err_to_name(err));
+      ESP_LOGW(TAG, "Error deleting channel: %s", esp_err_to_name(err));
     }
     this->rx_handle_ = nullptr;
   }
@@ -403,7 +412,7 @@ size_t I2SAudioMicrophone::read_(uint8_t *buf, size_t len, TickType_t ticks_to_w
     // Ignore ESP_ERR_TIMEOUT if ticks_to_wait = 0, as it will read the data on the next call
     if (!this->status_has_warning()) {
       // Avoid spamming the logs with the error message if its repeated
-      ESP_LOGW(TAG, "Error reading from I2S microphone: %s", esp_err_to_name(err));
+      ESP_LOGW(TAG, "Read error: %s", esp_err_to_name(err));
     }
     this->status_set_warning();
     return 0;
@@ -431,19 +440,19 @@ void I2SAudioMicrophone::loop() {
   uint32_t event_group_bits = xEventGroupGetBits(this->event_group_);
 
   if (event_group_bits & MicrophoneEventGroupBits::TASK_STARTING) {
-    ESP_LOGD(TAG, "Task started, attempting to allocate buffer");
+    ESP_LOGV(TAG, "Task started, attempting to allocate buffer");
     xEventGroupClearBits(this->event_group_, MicrophoneEventGroupBits::TASK_STARTING);
   }
 
   if (event_group_bits & MicrophoneEventGroupBits::TASK_RUNNING) {
-    ESP_LOGD(TAG, "Task is running and reading data");
+    ESP_LOGV(TAG, "Task is running and reading data");
 
     xEventGroupClearBits(this->event_group_, MicrophoneEventGroupBits::TASK_RUNNING);
     this->state_ = microphone::STATE_RUNNING;
   }
 
   if ((event_group_bits & MicrophoneEventGroupBits::TASK_STOPPED)) {
-    ESP_LOGD(TAG, "Task finished, freeing resources and uninstalling I2S driver");
+    ESP_LOGV(TAG, "Task finished, freeing resources and uninstalling driver");
 
     vTaskDelete(this->task_handle_);
     this->task_handle_ = nullptr;
@@ -473,7 +482,7 @@ void I2SAudioMicrophone::loop() {
       }
 
       if (!this->start_driver_()) {
-        this->status_momentary_error("I2S driver failed to start, unloading it and attempting again in 1 second", 1000);
+        this->status_momentary_error("Driver failed to start; retrying in 1 second", 1000);
         this->stop_driver_();  // Stop/frees whatever possibly started
         break;
       }
@@ -483,7 +492,7 @@ void I2SAudioMicrophone::loop() {
                     &this->task_handle_);
 
         if (this->task_handle_ == nullptr) {
-          this->status_momentary_error("Task failed to start, attempting again in 1 second", 1000);
+          this->status_momentary_error("Task failed to start, retrying in 1 second", 1000);
           this->stop_driver_();  // Stops the driver to return the lock; will be reloaded in next attempt
         }
       }

--- a/esphome/components/i2s_audio/microphone/i2s_audio_microphone.h
+++ b/esphome/components/i2s_audio/microphone/i2s_audio_microphone.h
@@ -81,6 +81,7 @@ class I2SAudioMicrophone : public I2SAudioIn, public microphone::Microphone, pub
   bool pdm_{false};
 
   bool correct_dc_offset_;
+  bool locked_driver_{false};
   int32_t dc_offset_{0};
 };
 

--- a/esphome/components/i2s_audio/microphone/i2s_audio_microphone.h
+++ b/esphome/components/i2s_audio/microphone/i2s_audio_microphone.h
@@ -18,6 +18,7 @@ namespace i2s_audio {
 class I2SAudioMicrophone : public I2SAudioIn, public microphone::Microphone, public Component {
  public:
   void setup() override;
+  void dump_config() override;
   void start() override;
   void stop() override;
 

--- a/esphome/components/i2s_audio/speaker/i2s_audio_speaker.h
+++ b/esphome/components/i2s_audio/speaker/i2s_audio_speaker.h
@@ -24,6 +24,7 @@ class I2SAudioSpeaker : public I2SAudioOut, public speaker::Speaker, public Comp
   float get_setup_priority() const override { return esphome::setup_priority::PROCESSOR; }
 
   void setup() override;
+  void dump_config() override;
   void loop() override;
 
   void set_buffer_duration(uint32_t buffer_duration_ms) { this->buffer_duration_ms_ = buffer_duration_ms; }

--- a/esphome/components/light/light_state.h
+++ b/esphome/components/light/light_state.h
@@ -17,7 +17,7 @@ namespace light {
 
 class LightOutput;
 
-enum LightRestoreMode {
+enum LightRestoreMode : uint8_t {
   LIGHT_RESTORE_DEFAULT_OFF,
   LIGHT_RESTORE_DEFAULT_ON,
   LIGHT_ALWAYS_OFF,
@@ -212,12 +212,18 @@ class LightState : public EntityBase, public Component {
 
   /// Store the output to allow effects to have more access.
   LightOutput *output_;
-  /// Value for storing the index of the currently active effect. 0 if no effect is active
-  uint32_t active_effect_index_{};
   /// The currently active transformer for this light (transition/flash).
   std::unique_ptr<LightTransformer> transformer_{nullptr};
-  /// Whether the light value should be written in the next cycle.
-  bool next_write_{true};
+  /// List of effects for this light.
+  std::vector<LightEffect *> effects_;
+  /// Value for storing the index of the currently active effect. 0 if no effect is active
+  uint32_t active_effect_index_{};
+  /// Default transition length for all transitions in ms.
+  uint32_t default_transition_length_{};
+  /// Transition length to use for flash transitions.
+  uint32_t flash_transition_length_{};
+  /// Gamma correction factor for the light.
+  float gamma_correct_{};
 
   /// Object used to store the persisted values of the light.
   ESPPreferenceObject rtc_;
@@ -236,19 +242,13 @@ class LightState : public EntityBase, public Component {
    */
   CallbackManager<void()> target_state_reached_callback_{};
 
-  /// Default transition length for all transitions in ms.
-  uint32_t default_transition_length_{};
-  /// Transition length to use for flash transitions.
-  uint32_t flash_transition_length_{};
-  /// Gamma correction factor for the light.
-  float gamma_correct_{};
-  /// Restore mode of the light.
-  LightRestoreMode restore_mode_;
   /// Initial state of the light.
   optional<LightStateRTCState> initial_state_{};
-  /// List of effects for this light.
-  std::vector<LightEffect *> effects_;
 
+  /// Restore mode of the light.
+  LightRestoreMode restore_mode_;
+  /// Whether the light value should be written in the next cycle.
+  bool next_write_{true};
   // for effects, true if a transformer (transition) is active.
   bool is_transformer_active_ = false;
 };

--- a/esphome/components/switch/switch.h
+++ b/esphome/components/switch/switch.h
@@ -21,7 +21,7 @@ const int RESTORE_MODE_PERSISTENT_MASK = 0x02;
 const int RESTORE_MODE_INVERTED_MASK = 0x04;
 const int RESTORE_MODE_DISABLED_MASK = 0x08;
 
-enum SwitchRestoreMode {
+enum SwitchRestoreMode : uint8_t {
   SWITCH_ALWAYS_OFF = !RESTORE_MODE_ON_MASK,
   SWITCH_ALWAYS_ON = RESTORE_MODE_ON_MASK,
   SWITCH_RESTORE_DEFAULT_OFF = RESTORE_MODE_PERSISTENT_MASK,
@@ -49,11 +49,11 @@ class Switch : public EntityBase, public EntityBase_DeviceClass {
    */
   void publish_state(bool state);
 
-  /// The current reported state of the binary sensor.
-  bool state;
-
   /// Indicates whether or not state is to be retrieved from flash and how
   SwitchRestoreMode restore_mode{SWITCH_RESTORE_DEFAULT_OFF};
+
+  /// The current reported state of the binary sensor.
+  bool state;
 
   /** Turn this switch on. This is called by the front-end.
    *
@@ -123,10 +123,16 @@ class Switch : public EntityBase, public EntityBase_DeviceClass {
    */
   virtual void write_state(bool state) = 0;
 
-  CallbackManager<void(bool)> state_callback_{};
-  bool inverted_{false};
-  Deduplicator<bool> publish_dedup_;
+  // Pointer first (4 bytes)
   ESPPreferenceObject rtc_;
+
+  // CallbackManager (12 bytes on 32-bit - contains vector)
+  CallbackManager<void(bool)> state_callback_{};
+
+  // Small types grouped together
+  Deduplicator<bool> publish_dedup_;  // 2 bytes (bool has_value_ + bool last_value_)
+  bool inverted_{false};              // 1 byte
+  // Total: 3 bytes, 1 byte padding
 };
 
 #define LOG_SWITCH(prefix, type, obj) log_switch((TAG), (prefix), LOG_STR_LITERAL(type), (obj))

--- a/esphome/const.py
+++ b/esphome/const.py
@@ -1,6 +1,6 @@
 """Constants used by esphome."""
 
-__version__ = "2025.6.0b2"
+__version__ = "2025.6.0b3"
 
 ALLOWED_NAME_CHARS = "abcdefghijklmnopqrstuvwxyz0123456789-_"
 VALID_SUBSTITUTIONS_CHARACTERS = (


### PR DESCRIPTION
**Do not merge, release script will automatically merge**
## Full list of changes

### All changes

<details>
<summary>Show</summary>

- [i2s_audio] Add ``dump_config`` methods, shorten log messages [esphome#9099](https://github.com/esphome/esphome/pull/9099)
- [i2s_audio] Bugfix: crashes when unlocking i2s bus multiple times [esphome#9100](https://github.com/esphome/esphome/pull/9100)
- [spi] Cater for non-word-aligned buffers on esp8266 [esphome#9108](https://github.com/esphome/esphome/pull/9108)
- Optimize LightState memory layout [esphome#9113](https://github.com/esphome/esphome/pull/9113)
- Reduce Switch component memory usage by 8 bytes per instance [esphome#9112](https://github.com/esphome/esphome/pull/9112)
</details>

<details>
<summary>Metadata</summary>

@coderabbitai ignore
</details>
