### PR TITLE
[heatpumpir] Bump HeatpumpIR to 1.0.35

### DIFF
--- a/esphome/components/heatpumpir/climate.py
+++ b/esphome/components/heatpumpir/climate.py
@@ -125,6 +125,6 @@ async def to_code(config):
     cg.add(var.set_max_temperature(config[CONF_MAX_TEMPERATURE]))
     cg.add(var.set_min_temperature(config[CONF_MIN_TEMPERATURE]))
 
-    cg.add_library("tonia/HeatpumpIR", "1.0.32")
+    cg.add_library("tonia/HeatpumpIR", "1.0.35")
     if CORE.is_libretiny:
         CORE.add_platformio_option("lib_ignore", "IRremoteESP8266")

--- a/platformio.ini
+++ b/platformio.ini
@@ -72,7 +72,7 @@ lib_deps =
     glmnet/Dsmr@0.7                                       ; dsmr
     rweather/Crypto@0.4.0                                 ; dsmr
     dudanov/MideaUART@1.1.9                               ; midea
-    tonia/HeatpumpIR@1.0.32                               ; heatpumpir
+    tonia/HeatpumpIR@1.0.35                               ; heatpumpir
 build_flags =
     ${common.build_flags}
     -DUSE_ARDUINO


### PR DESCRIPTION
# What does this implement/fix?

Bump HeatpumpIR to 1.0.35 to support Arduino 3

https://github.com/ToniA/arduino-heatpumpir/commits/1.0.35

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
