### PR TITLE
[i2s_audio] Bump esphome/ESP32-audioI2S to 2.3.0

### DIFF
--- a/esphome/components/i2s_audio/media_player/__init__.py
+++ b/esphome/components/i2s_audio/media_player/__init__.py
@@ -116,5 +116,5 @@ async def to_code(config):
 
     cg.add_library("WiFiClientSecure", None)
     cg.add_library("HTTPClient", None)
-    cg.add_library("esphome/ESP32-audioI2S", "2.2.0")
+    cg.add_library("esphome/ESP32-audioI2S", "2.3.0")
     cg.add_build_flag("-DAUDIO_NO_SD_FS")

--- a/platformio.ini
+++ b/platformio.ini
@@ -135,7 +135,7 @@ lib_deps =
     HTTPClient                           ; http_request,nextion (Arduino built-in)
     ESPmDNS                              ; mdns (Arduino built-in)
     DNSServer                            ; captive_portal (Arduino built-in)
-    esphome/ESP32-audioI2S@2.2.0         ; i2s_audio
+    esphome/ESP32-audioI2S@2.3.0         ; i2s_audio
     droscy/esp_wireguard@0.4.2           ; wireguard
     esphome/esp-audio-libs@1.1.4         ; audio
 


### PR DESCRIPTION
# What does this implement/fix?

Bump esphome/ESP32-audioI2S to 2.3.0 to support Arduino 3

https://github.com/esphome/ESP32-audioI2S/compare/2.2.0...2.3.0

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
