### PR TITLE
Add enable_loop_soon_any_context() for thread and ISR-safe loop enabling

### DIFF
--- a/esphome/core/application.h
+++ b/esphome/core/application.h
@@ -577,6 +577,8 @@ class Application {
   // to ensure component state is properly updated along with the loop partition
   void disable_component_loop_(Component *component);
   void enable_component_loop_(Component *component);
+  void enable_pending_loops_();
+  void activate_looping_component_(uint16_t index);
 
   void feed_wdt_arch_();
 
@@ -682,6 +684,7 @@ class Application {
   uint32_t loop_interval_{16};
   size_t dump_config_at_{SIZE_MAX};
   uint8_t app_state_{0};
+  volatile bool has_pending_enable_loop_requests_{false};
   Component *current_component_{nullptr};
   uint32_t loop_component_start_time_{0};
 

--- a/esphome/core/component.cpp
+++ b/esphome/core/component.cpp
@@ -163,15 +163,15 @@ void Component::enable_loop() {
     App.enable_component_loop_(this);
   }
 }
-void IRAM_ATTR HOT Component::enable_loop_soon_from_isr() {
-  // This method is ISR-safe because:
+void IRAM_ATTR HOT Component::enable_loop_soon_any_context() {
+  // This method is thread and ISR-safe because:
   // 1. Only performs simple assignments to volatile variables (atomic on all platforms)
   // 2. No read-modify-write operations that could be interrupted
   // 3. No memory allocation, object construction, or function calls
   // 4. IRAM_ATTR ensures code is in IRAM, not flash (required for ISR execution)
   // 5. Components are never destroyed, so no use-after-free concerns
   // 6. App is guaranteed to be initialized before any ISR could fire
-  // 7. Multiple ISR calls are safe - just sets the same flags to true
+  // 7. Multiple ISR/thread calls are safe - just sets the same flags to true
   // 8. Race condition with main loop is handled by clearing flag before processing
   this->pending_enable_loop_ = true;
   App.has_pending_enable_loop_requests_ = true;

--- a/esphome/core/component.cpp
+++ b/esphome/core/component.cpp
@@ -148,10 +148,12 @@ void Component::mark_failed() {
   App.disable_component_loop_(this);
 }
 void Component::disable_loop() {
-  ESP_LOGD(TAG, "%s loop disabled", this->get_component_source());
-  this->component_state_ &= ~COMPONENT_STATE_MASK;
-  this->component_state_ |= COMPONENT_STATE_LOOP_DONE;
-  App.disable_component_loop_(this);
+  if ((this->component_state_ & COMPONENT_STATE_MASK) != COMPONENT_STATE_LOOP_DONE) {
+    ESP_LOGD(TAG, "%s loop disabled", this->get_component_source());
+    this->component_state_ &= ~COMPONENT_STATE_MASK;
+    this->component_state_ |= COMPONENT_STATE_LOOP_DONE;
+    App.disable_component_loop_(this);
+  }
 }
 void Component::enable_loop() {
   if ((this->component_state_ & COMPONENT_STATE_MASK) == COMPONENT_STATE_LOOP_DONE) {
@@ -160,6 +162,19 @@ void Component::enable_loop() {
     this->component_state_ |= COMPONENT_STATE_LOOP;
     App.enable_component_loop_(this);
   }
+}
+void IRAM_ATTR HOT Component::enable_loop_soon_from_isr() {
+  // This method is ISR-safe because:
+  // 1. Only performs simple assignments to volatile variables (atomic on all platforms)
+  // 2. No read-modify-write operations that could be interrupted
+  // 3. No memory allocation, object construction, or function calls
+  // 4. IRAM_ATTR ensures code is in IRAM, not flash (required for ISR execution)
+  // 5. Components are never destroyed, so no use-after-free concerns
+  // 6. App is guaranteed to be initialized before any ISR could fire
+  // 7. Multiple ISR calls are safe - just sets the same flags to true
+  // 8. Race condition with main loop is handled by clearing flag before processing
+  this->pending_enable_loop_ = true;
+  App.has_pending_enable_loop_requests_ = true;
 }
 void Component::reset_to_construction_state() {
   if ((this->component_state_ & COMPONENT_STATE_MASK) == COMPONENT_STATE_FAILED) {

--- a/esphome/core/component.h
+++ b/esphome/core/component.h
@@ -171,15 +171,15 @@ class Component {
    */
   void enable_loop();
 
-  /** ISR-safe version of enable_loop() that can be called from interrupt context.
+  /** Thread and ISR-safe version of enable_loop() that can be called from any context.
    *
    * This method defers the actual enable via enable_pending_loops_ to the main loop,
-   * making it safe to call from ISR handlers, timer callbacks, or other
-   * interrupt contexts.
+   * making it safe to call from ISR handlers, timer callbacks, other threads,
+   * or any interrupt context.
    *
    * @note The actual loop enabling will happen on the next main loop iteration.
    * @note Only one pending enable request is tracked per component.
-   * @note There is no disable_loop_soon_from_isr() on purpose - it would race
+   * @note There is no disable_loop_soon_any_context() on purpose - it would race
    *       against enable calls and synchronization would get too complex
    *       to provide a safe version that would work for each component.
    *
@@ -190,7 +190,7 @@ class Component {
    *       disable_loop() in its next ::loop() iteration. Implementations
    *       will need to carefully consider all possible race conditions.
    */
-  void enable_loop_soon_from_isr();
+  void enable_loop_soon_any_context();
 
   bool is_failed() const;
 
@@ -363,7 +363,7 @@ class Component {
   /// Bit 3: STATUS_LED_ERROR
   /// Bits 4-7: Unused - reserved for future expansion (50% of the bits are free)
   uint8_t component_state_{0x00};
-  volatile bool pending_enable_loop_{false};  ///< ISR-safe flag for enable_loop_soon_from_isr
+  volatile bool pending_enable_loop_{false};  ///< ISR-safe flag for enable_loop_soon_any_context
 };
 
 /** This class simplifies creating components that periodically check a state.

--- a/esphome/core/component.h
+++ b/esphome/core/component.h
@@ -171,6 +171,27 @@ class Component {
    */
   void enable_loop();
 
+  /** ISR-safe version of enable_loop() that can be called from interrupt context.
+   *
+   * This method defers the actual enable via enable_pending_loops_ to the main loop,
+   * making it safe to call from ISR handlers, timer callbacks, or other
+   * interrupt contexts.
+   *
+   * @note The actual loop enabling will happen on the next main loop iteration.
+   * @note Only one pending enable request is tracked per component.
+   * @note There is no disable_loop_soon_from_isr() on purpose - it would race
+   *       against enable calls and synchronization would get too complex
+   *       to provide a safe version that would work for each component.
+   *
+   *       Use disable_loop() from the main thread only.
+   *
+   *       If you need to disable the loop from ISR, carefully implement
+   *       it in the component itself, with an ISR safe approach, and call
+   *       disable_loop() in its next ::loop() iteration. Implementations
+   *       will need to carefully consider all possible race conditions.
+   */
+  void enable_loop_soon_from_isr();
+
   bool is_failed() const;
 
   bool is_ready() const;
@@ -331,16 +352,18 @@ class Component {
   /// Cancel a defer callback using the specified name, name must not be empty.
   bool cancel_defer(const std::string &name);  // NOLINT
 
+  // Ordered for optimal packing on 32-bit systems
+  float setup_priority_override_{NAN};
+  const char *component_source_{nullptr};
+  const char *error_message_{nullptr};
+  uint16_t warn_if_blocking_over_{WARN_IF_BLOCKING_OVER_MS};  ///< Warn if blocked for this many ms (max 65.5s)
   /// State of this component - each bit has a purpose:
   /// Bits 0-1: Component state (0x00=CONSTRUCTION, 0x01=SETUP, 0x02=LOOP, 0x03=FAILED)
   /// Bit 2: STATUS_LED_WARNING
   /// Bit 3: STATUS_LED_ERROR
   /// Bits 4-7: Unused - reserved for future expansion (50% of the bits are free)
   uint8_t component_state_{0x00};
-  float setup_priority_override_{NAN};
-  const char *component_source_{nullptr};
-  uint16_t warn_if_blocking_over_{WARN_IF_BLOCKING_OVER_MS};  ///< Warn if blocked for this many ms (max 65.5s)
-  const char *error_message_{nullptr};
+  volatile bool pending_enable_loop_{false};  ///< ISR-safe flag for enable_loop_soon_from_isr
 };
 
 /** This class simplifies creating components that periodically check a state.

--- a/tests/integration/fixtures/external_components/loop_test_component/__init__.py
+++ b/tests/integration/fixtures/external_components/loop_test_component/__init__.py
@@ -7,9 +7,13 @@ CODEOWNERS = ["@esphome/tests"]
 
 loop_test_component_ns = cg.esphome_ns.namespace("loop_test_component")
 LoopTestComponent = loop_test_component_ns.class_("LoopTestComponent", cg.Component)
+LoopTestISRComponent = loop_test_component_ns.class_(
+    "LoopTestISRComponent", cg.Component
+)
 
 CONF_DISABLE_AFTER = "disable_after"
 CONF_TEST_REDUNDANT_OPERATIONS = "test_redundant_operations"
+CONF_ISR_COMPONENTS = "isr_components"
 
 COMPONENT_CONFIG_SCHEMA = cv.Schema(
     {
@@ -20,10 +24,18 @@ COMPONENT_CONFIG_SCHEMA = cv.Schema(
     }
 )
 
+ISR_COMPONENT_CONFIG_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(): cv.declare_id(LoopTestISRComponent),
+        cv.Required(CONF_NAME): cv.string,
+    }
+)
+
 CONFIG_SCHEMA = cv.Schema(
     {
         cv.GenerateID(): cv.declare_id(LoopTestComponent),
         cv.Required(CONF_COMPONENTS): cv.ensure_list(COMPONENT_CONFIG_SCHEMA),
+        cv.Optional(CONF_ISR_COMPONENTS): cv.ensure_list(ISR_COMPONENT_CONFIG_SCHEMA),
     }
 ).extend(cv.COMPONENT_SCHEMA)
 
@@ -76,3 +88,9 @@ async def to_code(config):
                 comp_config[CONF_TEST_REDUNDANT_OPERATIONS]
             )
         )
+
+    # Create ISR test components
+    for isr_config in config.get(CONF_ISR_COMPONENTS, []):
+        var = cg.new_Pvariable(isr_config[CONF_ID])
+        await cg.register_component(var, isr_config)
+        cg.add(var.set_name(isr_config[CONF_NAME]))

--- a/tests/integration/fixtures/external_components/loop_test_component/loop_test_isr_component.cpp
+++ b/tests/integration/fixtures/external_components/loop_test_component/loop_test_isr_component.cpp
@@ -1,0 +1,80 @@
+#include "loop_test_isr_component.h"
+#include "esphome/core/hal.h"
+#include "esphome/core/application.h"
+
+namespace esphome {
+namespace loop_test_component {
+
+static const char *const ISR_TAG = "loop_test_isr_component";
+
+void LoopTestISRComponent::setup() {
+  ESP_LOGI(ISR_TAG, "[%s] ISR component setup called", this->name_.c_str());
+  this->last_check_time_ = millis();
+}
+
+void LoopTestISRComponent::loop() {
+  this->loop_count_++;
+  ESP_LOGI(ISR_TAG, "[%s] ISR component loop count: %d", this->name_.c_str(), this->loop_count_);
+
+  // Disable after 5 loops
+  if (this->loop_count_ == 5) {
+    ESP_LOGI(ISR_TAG, "[%s] Disabling after 5 loops", this->name_.c_str());
+    this->disable_loop();
+    this->last_disable_time_ = millis();
+    // Simulate ISR after disabling
+    this->set_timeout("simulate_isr_1", 50, [this]() {
+      ESP_LOGI(ISR_TAG, "[%s] Simulating ISR enable", this->name_.c_str());
+      this->simulate_isr_enable();
+      // Test reentrancy - call enable_loop() directly after ISR
+      // This simulates another thread calling enable_loop while processing ISR enables
+      this->set_timeout("test_reentrant", 10, [this]() {
+        ESP_LOGI(ISR_TAG, "[%s] Testing reentrancy - calling enable_loop() directly", this->name_.c_str());
+        this->enable_loop();
+      });
+    });
+  }
+
+  // If we get here after being disabled, it means ISR re-enabled us
+  if (this->loop_count_ > 5 && this->loop_count_ < 10) {
+    ESP_LOGI(ISR_TAG, "[%s] Running after ISR re-enable! ISR was called %d times", this->name_.c_str(),
+             this->isr_call_count_);
+  }
+
+  // Disable again after 10 loops to test multiple ISR enables
+  if (this->loop_count_ == 10) {
+    ESP_LOGI(ISR_TAG, "[%s] Disabling again after 10 loops", this->name_.c_str());
+    this->disable_loop();
+    this->last_disable_time_ = millis();
+
+    // Test pure ISR enable without any main loop enable
+    this->set_timeout("simulate_isr_2", 50, [this]() {
+      ESP_LOGI(ISR_TAG, "[%s] Testing pure ISR enable (no main loop enable)", this->name_.c_str());
+      this->simulate_isr_enable();
+      // DO NOT call enable_loop() - test that ISR alone works
+    });
+  }
+
+  // Log when we're running after second ISR enable
+  if (this->loop_count_ > 10) {
+    ESP_LOGI(ISR_TAG, "[%s] Running after pure ISR re-enable! ISR was called %d times total", this->name_.c_str(),
+             this->isr_call_count_);
+  }
+}
+
+void IRAM_ATTR LoopTestISRComponent::simulate_isr_enable() {
+  // This simulates what would happen in a real ISR
+  // In a real scenario, this would be called from an actual interrupt handler
+
+  this->isr_call_count_++;
+
+  // Call enable_loop_soon_from_isr multiple times to test that it's safe
+  this->enable_loop_soon_from_isr();
+  this->enable_loop_soon_from_isr();  // Test multiple calls
+  this->enable_loop_soon_from_isr();  // Should be idempotent
+
+  // Note: In a real ISR, we cannot use ESP_LOG* macros as they're not ISR-safe
+  // For testing, we'll track the call count and log it from the main loop
+}
+
+}  // namespace loop_test_component
+}  // namespace esphome

--- a/tests/integration/fixtures/external_components/loop_test_component/loop_test_isr_component.cpp
+++ b/tests/integration/fixtures/external_components/loop_test_component/loop_test_isr_component.cpp
@@ -67,10 +67,10 @@ void IRAM_ATTR LoopTestISRComponent::simulate_isr_enable() {
 
   this->isr_call_count_++;
 
-  // Call enable_loop_soon_from_isr multiple times to test that it's safe
-  this->enable_loop_soon_from_isr();
-  this->enable_loop_soon_from_isr();  // Test multiple calls
-  this->enable_loop_soon_from_isr();  // Should be idempotent
+  // Call enable_loop_soon_any_context multiple times to test that it's safe
+  this->enable_loop_soon_any_context();
+  this->enable_loop_soon_any_context();  // Test multiple calls
+  this->enable_loop_soon_any_context();  // Should be idempotent
 
   // Note: In a real ISR, we cannot use ESP_LOG* macros as they're not ISR-safe
   // For testing, we'll track the call count and log it from the main loop

--- a/tests/integration/fixtures/external_components/loop_test_component/loop_test_isr_component.h
+++ b/tests/integration/fixtures/external_components/loop_test_component/loop_test_isr_component.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/core/log.h"
+#include "esphome/core/hal.h"
+
+namespace esphome {
+namespace loop_test_component {
+
+class LoopTestISRComponent : public Component {
+ public:
+  void set_name(const std::string &name) { this->name_ = name; }
+
+  void setup() override;
+  void loop() override;
+
+  // Simulates an ISR calling enable_loop_soon_from_isr
+  void simulate_isr_enable();
+
+  float get_setup_priority() const override { return setup_priority::DATA; }
+
+ protected:
+  std::string name_;
+  int loop_count_{0};
+  uint32_t last_disable_time_{0};
+  uint32_t last_check_time_{0};
+  bool isr_enable_pending_{false};
+  int isr_call_count_{0};
+};
+
+}  // namespace loop_test_component
+}  // namespace esphome

--- a/tests/integration/fixtures/external_components/loop_test_component/loop_test_isr_component.h
+++ b/tests/integration/fixtures/external_components/loop_test_component/loop_test_isr_component.h
@@ -14,7 +14,7 @@ class LoopTestISRComponent : public Component {
   void setup() override;
   void loop() override;
 
-  // Simulates an ISR calling enable_loop_soon_from_isr
+  // Simulates an ISR calling enable_loop_soon_any_context
   void simulate_isr_enable();
 
   float get_setup_priority() const override { return setup_priority::DATA; }

--- a/tests/integration/fixtures/loop_disable_enable.yaml
+++ b/tests/integration/fixtures/loop_disable_enable.yaml
@@ -35,7 +35,7 @@ loop_test_component:
       test_redundant_operations: true
       disable_after: 10
 
-  # ISR test component that uses enable_loop_soon_from_isr
+  # ISR test component that uses enable_loop_soon_any_context
   isr_components:
     - id: isr_test
       name: "isr_test"

--- a/tests/integration/fixtures/loop_disable_enable.yaml
+++ b/tests/integration/fixtures/loop_disable_enable.yaml
@@ -35,6 +35,11 @@ loop_test_component:
       test_redundant_operations: true
       disable_after: 10
 
+  # ISR test component that uses enable_loop_soon_from_isr
+  isr_components:
+    - id: isr_test
+      name: "isr_test"
+
 # Interval to re-enable the self_disable_10 component after some time
 interval:
   - interval: 0.5s


### PR DESCRIPTION
# What does this implement/fix?

This PR adds a new `enable_loop_soon_any_context()` method to the `Component` class, allowing components to safely request their `loop()` method to be re-enabled from interrupt service routines (ISRs), other threads, or any execution context.

## Motivation

Currently, components can disable their `loop()` method to save CPU cycles when inactive using `disable_loop()`. However, there was no safe way to re-enable the loop from an ISR context (e.g., GPIO interrupts, timer callbacks). Calling `enable_loop()` directly from an ISR is unsafe because it:
- Performs read-modify-write operations on component state
- Calls into Application methods that manipulate data structures
- Could cause race conditions or crashes

## Implementation

The solution introduces:

1. **`Component::enable_loop_soon_any_context()`** - A thread and ISR-safe method that defers the actual `enable_loop()` call to the main thread
2. **Volatile flags** - Uses simple volatile variable assignments that are atomic on all platforms
3. **Efficient processing** - A global flag (`has_pending_enable_loop_requests_`) avoids unnecessary iteration when no components have pending requests
4. **Race condition handling** - The global flag is cleared before processing to ensure no requests are lost
5. **Memory optimization** - Component member variables reordered to eliminate padding on 32-bit systems (saves 8 bytes per component)

### ISR Safety

The method is ISR-safe because it:
- Only performs simple assignments to volatile variables (atomic on all platforms)
- Contains no read-modify-write operations that could be interrupted
- Does no memory allocation, object construction, or function calls
- Is marked with `IRAM_ATTR` to ensure code is in IRAM for ISR execution
- Takes advantage of components never being destroyed in ESPHome

### Design Decisions

- **No `disable_loop_soon_any_context()`** - This is intentional. Disable operations would race against enable calls and synchronization would become too complex. Disabling should only be done from the main thread.
- **"soon" in the name** - Clearly indicates the operation is deferred, not immediate
- **Volatile over std::atomic** - Ensures compatibility across all platforms (ESP8266, ESP32, LibreTiny, RP2040)

### Example Usage

```cpp
class ExampleISRComponent : public Component {
 protected:
  void IRAM_ATTR HOT gpio_interrupt_handler() {
    // Request loop to be enabled on next main loop iteration
    this->enable_loop_soon_any_context();
    // The actual enable_loop() will happen safely in the main thread
  }
};
```

### Use Cases

This addresses the need for components that:
- Monitor hardware interrupts but don't need continuous loop() execution
- Want to save power by disabling loop() when idle
- Need to respond quickly to external events

Examples include interrupt-driven sensors, event-based communication protocols, and power-sensitive battery-operated devices.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Related issue or feature (if applicable): fixes <link to issue>

N/A

## Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable): esphome/esphome-docs#<number>

N/A - This is primarily an internal API for component developers. The method is documented inline with comprehensive docstrings.

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Not applicable - this is an internal API change
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).
  - [ ] Documentation added/updated as needed.
  - [x] I have read the [contributing guide](https://github.com/esphome/esphome/blob/dev/CONTRIBUTING.md).