### PR TITLE
[spi] Enable >6 devices with ESP-IDF

### DIFF
--- a/esphome/components/mipi_spi/display.py
+++ b/esphome/components/mipi_spi/display.py
@@ -472,3 +472,4 @@ async def to_code(config):
         cg.add(var.set_writer(lambda_))
     await display.register_display(var, config)
     await spi.register_spi_device(var, config)
+    cg.add(var.set_write_only(True))

--- a/esphome/components/spi/spi.cpp
+++ b/esphome/components/spi/spi.cpp
@@ -16,12 +16,13 @@ bool SPIDelegate::is_ready() { return true; }
 GPIOPin *const NullPin::NULL_PIN = new NullPin();  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
 SPIDelegate *SPIComponent::register_device(SPIClient *device, SPIMode mode, SPIBitOrder bit_order, uint32_t data_rate,
-                                           GPIOPin *cs_pin) {
+                                           GPIOPin *cs_pin, bool release_device, bool write_only) {
   if (this->devices_.count(device) != 0) {
     ESP_LOGE(TAG, "Device already registered");
     return this->devices_[device];
   }
-  SPIDelegate *delegate = this->spi_bus_->get_delegate(data_rate, bit_order, mode, cs_pin);  // NOLINT
+  SPIDelegate *delegate =
+      this->spi_bus_->get_delegate(data_rate, bit_order, mode, cs_pin, release_device, write_only);  // NOLINT
   this->devices_[device] = delegate;
   return delegate;
 }

--- a/esphome/components/spi/spi_arduino.cpp
+++ b/esphome/components/spi/spi_arduino.cpp
@@ -43,10 +43,7 @@ class SPIDelegateHw : public SPIDelegate {
       return;
     }
 #ifdef USE_RP2040
-    // avoid overwriting the supplied buffer. Use vector for automatic deallocation
-    auto rxbuf = std::vector<uint8_t>(length);
-    memcpy(rxbuf.data(), ptr, length);
-    this->channel_->transfer((void *) rxbuf.data(), length);
+    this->channel_->transfer(ptr, nullptr, length);
 #elif defined(USE_ESP8266)
     // ESP8266 SPI library requires the pointer to be word aligned, but the data may not be
     // so we need to copy the data to a temporary buffer

--- a/esphome/components/spi/spi_arduino.cpp
+++ b/esphome/components/spi/spi_arduino.cpp
@@ -87,7 +87,7 @@ class SPIBusHw : public SPIBus {
   }
 
   SPIDelegate *get_delegate(uint32_t data_rate, SPIBitOrder bit_order, SPIMode mode, GPIOPin *cs_pin,
-                            bool release_device) override {
+                            bool release_device, bool write_only) override {
     return new SPIDelegateHw(this->channel_, data_rate, bit_order, mode, cs_pin);
   }
 

--- a/esphome/components/spi/spi_arduino.cpp
+++ b/esphome/components/spi/spi_arduino.cpp
@@ -89,7 +89,8 @@ class SPIBusHw : public SPIBus {
 #endif
   }
 
-  SPIDelegate *get_delegate(uint32_t data_rate, SPIBitOrder bit_order, SPIMode mode, GPIOPin *cs_pin) override {
+  SPIDelegate *get_delegate(uint32_t data_rate, SPIBitOrder bit_order, SPIMode mode, GPIOPin *cs_pin,
+                            bool release_device) override {
     return new SPIDelegateHw(this->channel_, data_rate, bit_order, mode, cs_pin);
   }
 

--- a/esphome/components/spi/spi_esp_idf.cpp
+++ b/esphome/components/spi/spi_esp_idf.cpp
@@ -10,6 +10,16 @@ static const size_t MAX_TRANSFER_SIZE = 4092;  // dictated by ESP-IDF API.
 
 class SPIDelegateHw : public SPIDelegate {
  public:
+  SPIDelegateHw(SPIInterface channel, uint32_t data_rate, SPIBitOrder bit_order, SPIMode mode, GPIOPin *cs_pin,
+                bool release_device, bool write_only)
+      : SPIDelegate(data_rate, bit_order, mode, cs_pin),
+        channel_(channel),
+        release_device_(release_device),
+        write_only_(write_only) {
+    if (!this->release_device_)
+      add_device_();
+  }
+
   bool add_device_() {
     spi_device_interface_config_t config = {};
     config.mode = static_cast<uint8_t>(this->mode_);
@@ -29,15 +39,6 @@ class SPIDelegateHw : public SPIDelegate {
       return false;
     }
     return true;
-  }
-  SPIDelegateHw(SPIInterface channel, uint32_t data_rate, SPIBitOrder bit_order, SPIMode mode, GPIOPin *cs_pin,
-                bool write_only, bool release_device)
-      : SPIDelegate(data_rate, bit_order, mode, cs_pin),
-        channel_(channel),
-        write_only_(write_only),
-        release_device_(release_device) {
-    if (!this->release_device_)
-      add_device_();
   }
 
   bool is_ready() override { return this->handle_ != nullptr; }
@@ -250,8 +251,8 @@ class SPIBusHw : public SPIBus {
 
   SPIDelegate *get_delegate(uint32_t data_rate, SPIBitOrder bit_order, SPIMode mode, GPIOPin *cs_pin,
                             bool release_device, bool write_only) override {
-    return new SPIDelegateHw(this->channel_, data_rate, bit_order, mode, cs_pin,
-                             write_only || Utility::get_pin_no(this->sdi_pin_) == -1, release_device);
+    return new SPIDelegateHw(this->channel_, data_rate, bit_order, mode, cs_pin, release_device,
+                             write_only || Utility::get_pin_no(this->sdi_pin_) == -1);
   }
 
  protected:

--- a/esphome/components/spi/spi_esp_idf.cpp
+++ b/esphome/components/spi/spi_esp_idf.cpp
@@ -20,27 +20,6 @@ class SPIDelegateHw : public SPIDelegate {
       add_device_();
   }
 
-  bool add_device_() {
-    spi_device_interface_config_t config = {};
-    config.mode = static_cast<uint8_t>(this->mode_);
-    config.clock_speed_hz = static_cast<int>(this->data_rate_);
-    config.spics_io_num = -1;
-    config.flags = 0;
-    config.queue_size = 1;
-    config.pre_cb = nullptr;
-    config.post_cb = nullptr;
-    if (this->bit_order_ == BIT_ORDER_LSB_FIRST)
-      config.flags |= SPI_DEVICE_BIT_LSBFIRST;
-    if (this->write_only_)
-      config.flags |= SPI_DEVICE_HALFDUPLEX | SPI_DEVICE_NO_DUMMY;
-    esp_err_t const err = spi_bus_add_device(this->channel_, &config, &this->handle_);
-    if (err != ESP_OK) {
-      ESP_LOGE(TAG, "Add device failed - err %X", err);
-      return false;
-    }
-    return true;
-  }
-
   bool is_ready() override { return this->handle_ != nullptr; }
 
   void begin_transaction() override {
@@ -206,10 +185,31 @@ class SPIDelegateHw : public SPIDelegate {
   void read_array(uint8_t *ptr, size_t length) override { this->transfer(nullptr, ptr, length); }
 
  protected:
+  bool add_device_() {
+    spi_device_interface_config_t config = {};
+    config.mode = static_cast<uint8_t>(this->mode_);
+    config.clock_speed_hz = static_cast<int>(this->data_rate_);
+    config.spics_io_num = -1;
+    config.flags = 0;
+    config.queue_size = 1;
+    config.pre_cb = nullptr;
+    config.post_cb = nullptr;
+    if (this->bit_order_ == BIT_ORDER_LSB_FIRST)
+      config.flags |= SPI_DEVICE_BIT_LSBFIRST;
+    if (this->write_only_)
+      config.flags |= SPI_DEVICE_HALFDUPLEX | SPI_DEVICE_NO_DUMMY;
+    esp_err_t const err = spi_bus_add_device(this->channel_, &config, &this->handle_);
+    if (err != ESP_OK) {
+      ESP_LOGE(TAG, "Add device failed - err %X", err);
+      return false;
+    }
+    return true;
+  }
+
   SPIInterface channel_{};
   spi_device_handle_t handle_{};
-  bool write_only_{false};
   bool release_device_{false};
+  bool write_only_{false};
 };
 
 class SPIBusHw : public SPIBus {

--- a/esphome/components/spi/spi_esp_idf.cpp
+++ b/esphome/components/spi/spi_esp_idf.cpp
@@ -10,35 +10,47 @@ static const size_t MAX_TRANSFER_SIZE = 4092;  // dictated by ESP-IDF API.
 
 class SPIDelegateHw : public SPIDelegate {
  public:
-  SPIDelegateHw(SPIInterface channel, uint32_t data_rate, SPIBitOrder bit_order, SPIMode mode, GPIOPin *cs_pin,
-                bool write_only)
-      : SPIDelegate(data_rate, bit_order, mode, cs_pin), channel_(channel), write_only_(write_only) {
+  bool add_device_() {
     spi_device_interface_config_t config = {};
-    config.mode = static_cast<uint8_t>(mode);
-    config.clock_speed_hz = static_cast<int>(data_rate);
+    config.mode = static_cast<uint8_t>(this->mode_);
+    config.clock_speed_hz = static_cast<int>(this->data_rate_);
     config.spics_io_num = -1;
     config.flags = 0;
     config.queue_size = 1;
     config.pre_cb = nullptr;
     config.post_cb = nullptr;
-    if (bit_order == BIT_ORDER_LSB_FIRST)
+    if (this->bit_order_ == BIT_ORDER_LSB_FIRST)
       config.flags |= SPI_DEVICE_BIT_LSBFIRST;
-    if (write_only)
+    if (this->write_only_)
       config.flags |= SPI_DEVICE_HALFDUPLEX | SPI_DEVICE_NO_DUMMY;
-    esp_err_t const err = spi_bus_add_device(channel, &config, &this->handle_);
-    if (err != ESP_OK)
+    esp_err_t const err = spi_bus_add_device(this->channel_, &config, &this->handle_);
+    if (err != ESP_OK) {
       ESP_LOGE(TAG, "Add device failed - err %X", err);
+      return false;
+    }
+    return true;
+  }
+  SPIDelegateHw(SPIInterface channel, uint32_t data_rate, SPIBitOrder bit_order, SPIMode mode, GPIOPin *cs_pin,
+                bool write_only, bool release_device)
+      : SPIDelegate(data_rate, bit_order, mode, cs_pin),
+        channel_(channel),
+        write_only_(write_only),
+        release_device_(release_device) {
+    if (!this->release_device_)
+      add_device_();
   }
 
   bool is_ready() override { return this->handle_ != nullptr; }
 
   void begin_transaction() override {
+    if (this->release_device_)
+      this->add_device_();
     if (this->is_ready()) {
       if (spi_device_acquire_bus(this->handle_, portMAX_DELAY) != ESP_OK)
         ESP_LOGE(TAG, "Failed to acquire SPI bus");
       SPIDelegate::begin_transaction();
     } else {
-      ESP_LOGW(TAG, "spi_setup called before initialisation");
+      ESP_LOGW(TAG, "SPI device not ready, cannot begin transaction");
     }
   }
 
@@ -46,6 +58,10 @@ class SPIDelegateHw : public SPIDelegate {
     if (this->is_ready()) {
       SPIDelegate::end_transaction();
       spi_device_release_bus(this->handle_);
+      if (this->release_device_) {
+        spi_bus_remove_device(this->handle_);
+        this->handle_ = nullptr;  // reset handle to indicate no device is registered
+      }
     }
   }
 
@@ -192,6 +208,7 @@ class SPIDelegateHw : public SPIDelegate {
   SPIInterface channel_{};
   spi_device_handle_t handle_{};
   bool write_only_{false};
+  bool release_device_{false};
 };
 
 class SPIBusHw : public SPIBus {
@@ -231,9 +248,10 @@ class SPIBusHw : public SPIBus {
       ESP_LOGE(TAG, "Bus init failed - err %X", err);
   }
 
-  SPIDelegate *get_delegate(uint32_t data_rate, SPIBitOrder bit_order, SPIMode mode, GPIOPin *cs_pin) override {
+  SPIDelegate *get_delegate(uint32_t data_rate, SPIBitOrder bit_order, SPIMode mode, GPIOPin *cs_pin,
+                            bool release_device, bool write_only) override {
     return new SPIDelegateHw(this->channel_, data_rate, bit_order, mode, cs_pin,
-                             Utility::get_pin_no(this->sdi_pin_) == -1);
+                             write_only || Utility::get_pin_no(this->sdi_pin_) == -1, release_device);
   }
 
  protected:

--- a/tests/components/spi_device/common.yaml
+++ b/tests/components/spi_device/common.yaml
@@ -5,7 +5,7 @@ spi:
     miso_pin: ${miso_pin}
 
 spi_device:
-  id: spi_device_test
-  data_rate: 2MHz
-  spi_mode: 3
-  bit_order: lsb_first
+  - id: spi_device_test
+    data_rate: 2MHz
+    spi_mode: 3
+    bit_order: lsb_first

--- a/tests/components/spi_device/test.esp32-idf.yaml
+++ b/tests/components/spi_device/test.esp32-idf.yaml
@@ -4,3 +4,8 @@ substitutions:
   miso_pin: GPIO15
 
 <<: !include common.yaml
+spi_device:
+  - id: spi_device_test
+    release_device: true
+    data_rate: 1MHz
+    spi_mode: 0


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

* Provide a work-around for the ESP-IDF library limit of 6 configured SPI devices. This is achieved by allowing an SPI device to be configured `release_device: true` which causes the ESP-IDF device to be released between transactions.
* Allow an SPI device to be designated as write-only even when a MISO pin is configured (useful for displays where a touchscreen is on the same bus.) This enables higher data rates.
* For RP2040, remove an unnecessary copy of data on write.
* Make use of the `write_only` option for `mipi_spi`


## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://discordapp.com/channels/429907082951524364/1379838458952028230

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#5007

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [x] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
spi_device:
    - id: spidev_0
      data_rate: 2MHz
      spi_mode: 3
      release_device: true
    - id: spidev_1
      data_rate: 2MHz
      spi_mode: 0
      release_device: true
    - id: spidev_2
      data_rate: 2MHz
      spi_mode: 0
      release_device: true
    - id: spidev_3
      data_rate: 2MHz
      spi_mode: 0
      release_device: true
    - id: spidev_4
      data_rate: 2MHz
      spi_mode: 0
      release_device: true
    - id: spidev_5
      data_rate: 2MHz
      spi_mode: 0
      release_device: true
    - id: spidev_6
      data_rate: 2MHz
      spi_mode: 0
    - id: spidev_7
      data_rate: 2MHz
      spi_mode: 0

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
