### PR TITLE
Fix missing BLE GAP events causing RSSI sensor and beacon failures

### DIFF
--- a/esphome/components/esp32_ble/ble_event.h
+++ b/esphome/components/esp32_ble/ble_event.h
@@ -102,6 +102,13 @@ class BLEEvent {
     GATTS,
   };
 
+  // Type definitions for cleaner method signatures
+  struct RSSICompleteData {
+    esp_bt_status_t status;
+    int8_t rssi;
+    esp_bd_addr_t remote_addr;
+  };
+
   // Constructor for GAP events - no external allocations needed
   BLEEvent(esp_gap_ble_cb_event_t e, esp_ble_gap_cb_param_t *p) {
     this->type_ = GAP;
@@ -196,11 +203,7 @@ class BLEEvent {
         } adv_complete;  // 1 byte - for ADV_DATA_SET, SCAN_RSP_DATA_SET, ADV_DATA_RAW_SET, ADV_START, ADV_STOP
         // RSSI complete event
         // Used by: ble_client (ble_rssi_sensor component)
-        struct {
-          esp_bt_status_t status;
-          int8_t rssi;
-          esp_bd_addr_t remote_addr;
-        } read_rssi_complete;  // 8 bytes
+        RSSICompleteData read_rssi_complete;  // 8 bytes
         // Security events - we store the full security union
         // Used by: ble_client (automation), bluetooth_proxy, esp32_ble_client
         esp_ble_sec_t security;  // Variable size, but fits within scan_result size
@@ -232,9 +235,7 @@ class BLEEvent {
   const BLEScanResult &scan_result() const { return event_.gap.scan_result; }
   esp_bt_status_t scan_complete_status() const { return event_.gap.scan_complete.status; }
   esp_bt_status_t adv_complete_status() const { return event_.gap.adv_complete.status; }
-  auto read_rssi_complete() const -> const decltype(event_.gap.read_rssi_complete) & {
-    return event_.gap.read_rssi_complete;
-  }
+  const RSSICompleteData &read_rssi_complete() const { return event_.gap.read_rssi_complete; }
   const esp_ble_sec_t &security() const { return event_.gap.security; }
 
  private:

--- a/esphome/components/esp32_ble/ble_event.h
+++ b/esphome/components/esp32_ble/ble_event.h
@@ -24,14 +24,11 @@ static_assert(sizeof(esp_ble_gap_cb_param_t::ble_scan_stop_cmpl_evt_param) == si
               "ESP-IDF scan_stop_cmpl structure has unexpected size");
 
 // Verify the status field is at offset 0 (first member)
-static_assert(offsetof(esp_ble_gap_cb_param_t, scan_param_cmpl.status) ==
-                  offsetof(esp_ble_gap_cb_param_t, scan_param_cmpl),
+static_assert(offsetof(esp_ble_gap_cb_param_t, scan_param_cmpl.status) == 0,
               "status must be first member of scan_param_cmpl");
-static_assert(offsetof(esp_ble_gap_cb_param_t, scan_start_cmpl.status) ==
-                  offsetof(esp_ble_gap_cb_param_t, scan_start_cmpl),
+static_assert(offsetof(esp_ble_gap_cb_param_t, scan_start_cmpl.status) == 0,
               "status must be first member of scan_start_cmpl");
-static_assert(offsetof(esp_ble_gap_cb_param_t, scan_stop_cmpl.status) ==
-                  offsetof(esp_ble_gap_cb_param_t, scan_stop_cmpl),
+static_assert(offsetof(esp_ble_gap_cb_param_t, scan_stop_cmpl.status) == 0,
               "status must be first member of scan_stop_cmpl");
 
 // Compile-time verification for advertising complete events
@@ -47,18 +44,15 @@ static_assert(sizeof(esp_ble_gap_cb_param_t::ble_adv_stop_cmpl_evt_param) == siz
               "ESP-IDF adv_stop_cmpl structure has unexpected size");
 
 // Verify the status field is at offset 0 for advertising events
-static_assert(offsetof(esp_ble_gap_cb_param_t, adv_data_cmpl.status) == offsetof(esp_ble_gap_cb_param_t, adv_data_cmpl),
+static_assert(offsetof(esp_ble_gap_cb_param_t, adv_data_cmpl.status) == 0,
               "status must be first member of adv_data_cmpl");
-static_assert(offsetof(esp_ble_gap_cb_param_t, scan_rsp_data_cmpl.status) ==
-                  offsetof(esp_ble_gap_cb_param_t, scan_rsp_data_cmpl),
+static_assert(offsetof(esp_ble_gap_cb_param_t, scan_rsp_data_cmpl.status) == 0,
               "status must be first member of scan_rsp_data_cmpl");
-static_assert(offsetof(esp_ble_gap_cb_param_t, adv_data_raw_cmpl.status) ==
-                  offsetof(esp_ble_gap_cb_param_t, adv_data_raw_cmpl),
+static_assert(offsetof(esp_ble_gap_cb_param_t, adv_data_raw_cmpl.status) == 0,
               "status must be first member of adv_data_raw_cmpl");
-static_assert(offsetof(esp_ble_gap_cb_param_t, adv_start_cmpl.status) ==
-                  offsetof(esp_ble_gap_cb_param_t, adv_start_cmpl),
+static_assert(offsetof(esp_ble_gap_cb_param_t, adv_start_cmpl.status) == 0,
               "status must be first member of adv_start_cmpl");
-static_assert(offsetof(esp_ble_gap_cb_param_t, adv_stop_cmpl.status) == offsetof(esp_ble_gap_cb_param_t, adv_stop_cmpl),
+static_assert(offsetof(esp_ble_gap_cb_param_t, adv_stop_cmpl.status) == 0,
               "status must be first member of adv_stop_cmpl");
 
 // Compile-time verification for RSSI complete event structure

--- a/esphome/components/esp32_ble/ble_event.h
+++ b/esphome/components/esp32_ble/ble_event.h
@@ -232,13 +232,7 @@ class BLEEvent {
   const BLEScanResult &scan_result() const { return event_.gap.scan_result; }
   esp_bt_status_t scan_complete_status() const { return event_.gap.scan_complete.status; }
   esp_bt_status_t adv_complete_status() const { return event_.gap.adv_complete.status; }
-  const struct {
-    esp_bt_status_t status;
-    int8_t rssi;
-    esp_bd_addr_t remote_addr;
-  } & read_rssi_complete() const {
-    return event_.gap.read_rssi_complete;
-  }
+  auto &read_rssi_complete() const -> decltype(event_.gap.read_rssi_complete) { return event_.gap.read_rssi_complete; }
   const esp_ble_sec_t &security() const { return event_.gap.security; }
 
  private:
@@ -395,10 +389,8 @@ class BLEEvent {
 };
 
 // Verify the gap_event struct hasn't grown beyond expected size
-// Note: gap_event is a nested struct type, not directly accessible as BLEEvent::gap_event
-// We check the size through the union member instead
-static_assert(offsetof(BLEEvent, event_.gap) + sizeof(((BLEEvent *) 0)->event_.gap) <= 80,
-              "gap_event struct has grown beyond 80 bytes");
+// The gap member in the union should be 80 bytes (including the gap_event enum)
+static_assert(sizeof(decltype(((BLEEvent *) nullptr)->event_.gap)) <= 80, "gap_event struct has grown beyond 80 bytes");
 
 // Verify esp_ble_sec_t fits within our union
 static_assert(sizeof(esp_ble_sec_t) <= 73, "esp_ble_sec_t is larger than BLEScanResult");

--- a/esphome/components/esp32_ble/ble_event.h
+++ b/esphome/components/esp32_ble/ble_event.h
@@ -103,6 +103,10 @@ class BLEEvent {
   };
 
   // Type definitions for cleaner method signatures
+  struct StatusOnlyData {
+    esp_bt_status_t status;
+  };
+
   struct RSSICompleteData {
     esp_bt_status_t status;
     int8_t rssi;
@@ -193,14 +197,11 @@ class BLEEvent {
         // This matches ESP-IDF's scan complete event structures
         // All three (scan_param_cmpl, scan_start_cmpl, scan_stop_cmpl) have identical layout
         // Used by: esp32_ble_tracker
-        struct {
-          esp_bt_status_t status;
-        } scan_complete;  // 1 byte
+        StatusOnlyData scan_complete;  // 1 byte
         // Advertising complete events all have same structure
         // Used by: esp32_ble_beacon, esp32_ble server components
-        struct {
-          esp_bt_status_t status;
-        } adv_complete;  // 1 byte - for ADV_DATA_SET, SCAN_RSP_DATA_SET, ADV_DATA_RAW_SET, ADV_START, ADV_STOP
+        StatusOnlyData
+            adv_complete;  // 1 byte - for ADV_DATA_SET, SCAN_RSP_DATA_SET, ADV_DATA_RAW_SET, ADV_START, ADV_STOP
         // RSSI complete event
         // Used by: ble_client (ble_rssi_sensor component)
         RSSICompleteData read_rssi_complete;  // 8 bytes

--- a/esphome/components/esp32_ble/ble_event.h
+++ b/esphome/components/esp32_ble/ble_event.h
@@ -34,6 +34,41 @@ static_assert(offsetof(esp_ble_gap_cb_param_t, scan_stop_cmpl.status) ==
                   offsetof(esp_ble_gap_cb_param_t, scan_stop_cmpl),
               "status must be first member of scan_stop_cmpl");
 
+// Compile-time verification for advertising complete events
+static_assert(sizeof(esp_ble_gap_cb_param_t::ble_adv_data_cmpl_evt_param) == sizeof(esp_bt_status_t),
+              "ESP-IDF adv_data_cmpl structure has unexpected size");
+static_assert(sizeof(esp_ble_gap_cb_param_t::ble_scan_rsp_data_cmpl_evt_param) == sizeof(esp_bt_status_t),
+              "ESP-IDF scan_rsp_data_cmpl structure has unexpected size");
+static_assert(sizeof(esp_ble_gap_cb_param_t::ble_adv_data_raw_cmpl_evt_param) == sizeof(esp_bt_status_t),
+              "ESP-IDF adv_data_raw_cmpl structure has unexpected size");
+static_assert(sizeof(esp_ble_gap_cb_param_t::ble_adv_start_cmpl_evt_param) == sizeof(esp_bt_status_t),
+              "ESP-IDF adv_start_cmpl structure has unexpected size");
+static_assert(sizeof(esp_ble_gap_cb_param_t::ble_adv_stop_cmpl_evt_param) == sizeof(esp_bt_status_t),
+              "ESP-IDF adv_stop_cmpl structure has unexpected size");
+
+// Verify the status field is at offset 0 for advertising events
+static_assert(offsetof(esp_ble_gap_cb_param_t, adv_data_cmpl.status) == offsetof(esp_ble_gap_cb_param_t, adv_data_cmpl),
+              "status must be first member of adv_data_cmpl");
+static_assert(offsetof(esp_ble_gap_cb_param_t, scan_rsp_data_cmpl.status) ==
+                  offsetof(esp_ble_gap_cb_param_t, scan_rsp_data_cmpl),
+              "status must be first member of scan_rsp_data_cmpl");
+static_assert(offsetof(esp_ble_gap_cb_param_t, adv_data_raw_cmpl.status) ==
+                  offsetof(esp_ble_gap_cb_param_t, adv_data_raw_cmpl),
+              "status must be first member of adv_data_raw_cmpl");
+static_assert(offsetof(esp_ble_gap_cb_param_t, adv_start_cmpl.status) ==
+                  offsetof(esp_ble_gap_cb_param_t, adv_start_cmpl),
+              "status must be first member of adv_start_cmpl");
+static_assert(offsetof(esp_ble_gap_cb_param_t, adv_stop_cmpl.status) == offsetof(esp_ble_gap_cb_param_t, adv_stop_cmpl),
+              "status must be first member of adv_stop_cmpl");
+
+// Compile-time verification for RSSI complete event structure
+static_assert(offsetof(esp_ble_gap_cb_param_t, read_rssi_cmpl.status) == 0,
+              "status must be first member of read_rssi_cmpl");
+static_assert(offsetof(esp_ble_gap_cb_param_t, read_rssi_cmpl.rssi) == sizeof(esp_bt_status_t),
+              "rssi must immediately follow status in read_rssi_cmpl");
+static_assert(offsetof(esp_ble_gap_cb_param_t, read_rssi_cmpl.remote_addr) == sizeof(esp_bt_status_t) + sizeof(int8_t),
+              "remote_addr must follow rssi in read_rssi_cmpl");
+
 // Received GAP, GATTC and GATTS events are only queued, and get processed in the main loop().
 // This class stores each event with minimal memory usage.
 // GAP events (99% of traffic) don't have the vector overhead.
@@ -147,12 +182,28 @@ class BLEEvent {
     struct gap_event {
       esp_gap_ble_cb_event_t gap_event;
       union {
-        BLEScanResult scan_result;  // 73 bytes
+        BLEScanResult scan_result;  // 73 bytes - Used by: esp32_ble_tracker
         // This matches ESP-IDF's scan complete event structures
         // All three (scan_param_cmpl, scan_start_cmpl, scan_stop_cmpl) have identical layout
+        // Used by: esp32_ble_tracker
         struct {
           esp_bt_status_t status;
         } scan_complete;  // 1 byte
+        // Advertising complete events all have same structure
+        // Used by: esp32_ble_beacon, esp32_ble server components
+        struct {
+          esp_bt_status_t status;
+        } adv_complete;  // 1 byte - for ADV_DATA_SET, SCAN_RSP_DATA_SET, ADV_DATA_RAW_SET, ADV_START, ADV_STOP
+        // RSSI complete event
+        // Used by: ble_client (ble_rssi_sensor component)
+        struct {
+          esp_bt_status_t status;
+          int8_t rssi;
+          esp_bd_addr_t remote_addr;
+        } read_rssi_complete;  // 8 bytes
+        // Security events - we store the full security union
+        // Used by: ble_client (automation), bluetooth_proxy, esp32_ble_client
+        esp_ble_sec_t security;  // Variable size, but fits within scan_result size
       };
     } gap;  // 80 bytes total
 
@@ -180,6 +231,11 @@ class BLEEvent {
   esp_gap_ble_cb_event_t gap_event_type() const { return event_.gap.gap_event; }
   const BLEScanResult &scan_result() const { return event_.gap.scan_result; }
   esp_bt_status_t scan_complete_status() const { return event_.gap.scan_complete.status; }
+  esp_bt_status_t adv_complete_status() const { return event_.gap.adv_complete.status; }
+  const esp_ble_gap_cb_param_t::ble_read_rssi_cmpl_evt_param &read_rssi_complete() const {
+    return event_.gap.read_rssi_complete;
+  }
+  const esp_ble_sec_t &security() const { return event_.gap.security; }
 
  private:
   // Initialize GAP event data
@@ -215,8 +271,47 @@ class BLEEvent {
         this->event_.gap.scan_complete.status = p->scan_stop_cmpl.status;
         break;
 
+      // Advertising complete events - all have same structure with just status
+      // Used by: esp32_ble_beacon, esp32_ble server components
+      case ESP_GAP_BLE_ADV_DATA_SET_COMPLETE_EVT:
+        this->event_.gap.adv_complete.status = p->adv_data_cmpl.status;
+        break;
+      case ESP_GAP_BLE_SCAN_RSP_DATA_SET_COMPLETE_EVT:
+        this->event_.gap.adv_complete.status = p->scan_rsp_data_cmpl.status;
+        break;
+      case ESP_GAP_BLE_ADV_DATA_RAW_SET_COMPLETE_EVT:  // Used by: esp32_ble_beacon
+        this->event_.gap.adv_complete.status = p->adv_data_raw_cmpl.status;
+        break;
+      case ESP_GAP_BLE_ADV_START_COMPLETE_EVT:  // Used by: esp32_ble_beacon
+        this->event_.gap.adv_complete.status = p->adv_start_cmpl.status;
+        break;
+      case ESP_GAP_BLE_ADV_STOP_COMPLETE_EVT:  // Used by: esp32_ble_beacon
+        this->event_.gap.adv_complete.status = p->adv_stop_cmpl.status;
+        break;
+
+      // RSSI complete event
+      // Used by: ble_client (ble_rssi_sensor)
+      case ESP_GAP_BLE_READ_RSSI_COMPLETE_EVT:
+        this->event_.gap.read_rssi_complete.status = p->read_rssi_cmpl.status;
+        this->event_.gap.read_rssi_complete.rssi = p->read_rssi_cmpl.rssi;
+        memcpy(this->event_.gap.read_rssi_complete.remote_addr, p->read_rssi_cmpl.remote_addr, sizeof(esp_bd_addr_t));
+        break;
+
+      // Security events - copy the entire security union
+      // Used by: ble_client, bluetooth_proxy, esp32_ble_client
+      case ESP_GAP_BLE_AUTH_CMPL_EVT:      // Used by: bluetooth_proxy, esp32_ble_client
+      case ESP_GAP_BLE_SEC_REQ_EVT:        // Used by: esp32_ble_client
+      case ESP_GAP_BLE_PASSKEY_NOTIF_EVT:  // Used by: ble_client automation
+      case ESP_GAP_BLE_PASSKEY_REQ_EVT:    // Used by: ble_client automation
+      case ESP_GAP_BLE_NC_REQ_EVT:         // Used by: ble_client automation
+        memcpy(&this->event_.gap.security, &p->ble_security, sizeof(esp_ble_sec_t));
+        break;
+
       default:
-        // We only handle 4 GAP event types, others are dropped
+        // We only store data for GAP events that components currently use
+        // Unknown events still get queued and logged in ble.cpp:375 as
+        // "Unhandled GAP event type in loop" - this helps identify new events
+        // that components might need in the future
         break;
     }
   }
@@ -294,6 +389,12 @@ class BLEEvent {
     }
   }
 };
+
+// Verify the gap_event union hasn't grown beyond expected size
+static_assert(sizeof(BLEEvent::gap_event) <= 80, "gap_event union has grown beyond 80 bytes");
+
+// Verify esp_ble_sec_t fits within our union
+static_assert(sizeof(esp_ble_sec_t) <= 73, "esp_ble_sec_t is larger than BLEScanResult");
 
 // BLEEvent total size: 84 bytes (80 byte union + 1 byte type + 3 bytes padding)
 

--- a/esphome/components/esp32_ble/ble_event.h
+++ b/esphome/components/esp32_ble/ble_event.h
@@ -200,8 +200,8 @@ class BLEEvent {
         StatusOnlyData scan_complete;  // 1 byte
         // Advertising complete events all have same structure
         // Used by: esp32_ble_beacon, esp32_ble server components
-        StatusOnlyData
-            adv_complete;  // 1 byte - for ADV_DATA_SET, SCAN_RSP_DATA_SET, ADV_DATA_RAW_SET, ADV_START, ADV_STOP
+        // ADV_DATA_SET, SCAN_RSP_DATA_SET, ADV_DATA_RAW_SET, ADV_START, ADV_STOP
+        StatusOnlyData adv_complete;  // 1 byte
         // RSSI complete event
         // Used by: ble_client (ble_rssi_sensor component)
         RSSICompleteData read_rssi_complete;  // 8 bytes

--- a/esphome/components/esp32_ble/ble_event.h
+++ b/esphome/components/esp32_ble/ble_event.h
@@ -232,7 +232,11 @@ class BLEEvent {
   const BLEScanResult &scan_result() const { return event_.gap.scan_result; }
   esp_bt_status_t scan_complete_status() const { return event_.gap.scan_complete.status; }
   esp_bt_status_t adv_complete_status() const { return event_.gap.adv_complete.status; }
-  const esp_ble_gap_cb_param_t::ble_read_rssi_cmpl_evt_param &read_rssi_complete() const {
+  const struct {
+    esp_bt_status_t status;
+    int8_t rssi;
+    esp_bd_addr_t remote_addr;
+  } & read_rssi_complete() const {
     return event_.gap.read_rssi_complete;
   }
   const esp_ble_sec_t &security() const { return event_.gap.security; }
@@ -390,8 +394,11 @@ class BLEEvent {
   }
 };
 
-// Verify the gap_event union hasn't grown beyond expected size
-static_assert(sizeof(BLEEvent::gap_event) <= 80, "gap_event union has grown beyond 80 bytes");
+// Verify the gap_event struct hasn't grown beyond expected size
+// Note: gap_event is a nested struct type, not directly accessible as BLEEvent::gap_event
+// We check the size through the union member instead
+static_assert(offsetof(BLEEvent, event_.gap) + sizeof(((BLEEvent *) 0)->event_.gap) <= 80,
+              "gap_event struct has grown beyond 80 bytes");
 
 // Verify esp_ble_sec_t fits within our union
 static_assert(sizeof(esp_ble_sec_t) <= 73, "esp_ble_sec_t is larger than BLEScanResult");

--- a/esphome/components/esp32_ble/ble_event.h
+++ b/esphome/components/esp32_ble/ble_event.h
@@ -232,7 +232,9 @@ class BLEEvent {
   const BLEScanResult &scan_result() const { return event_.gap.scan_result; }
   esp_bt_status_t scan_complete_status() const { return event_.gap.scan_complete.status; }
   esp_bt_status_t adv_complete_status() const { return event_.gap.adv_complete.status; }
-  auto &read_rssi_complete() const -> decltype(event_.gap.read_rssi_complete) { return event_.gap.read_rssi_complete; }
+  auto read_rssi_complete() const -> const decltype(event_.gap.read_rssi_complete) & {
+    return event_.gap.read_rssi_complete;
+  }
   const esp_ble_sec_t &security() const { return event_.gap.security; }
 
  private:


### PR DESCRIPTION
## Important Note:
**This PR is based on top of #9101** - That PR will need to be cherry-picked/merged first as this PR depends on the BLE event pool implementation from #9101.

## What does this implement/fix?

This PR fixes a critical issue where many BLE GAP events were being filtered out by the ESP32 BLE implementation, causing:
- BLE RSSI sensors to show as "unavailable" 
- ESP32 BLE beacon components to generate warnings
- Security/pairing events to be dropped

The root cause was that PR #9052 was too conservative in determining which GAP events were actually used by ESPHome components. The GAP event handler in `esp32_ble/ble.cpp` was only allowing 4 scan-related events through, while filtering out all other GAP events with "Ignoring unexpected GAP event type" warnings. This resulted in legitimate events needed by various components being dropped.

### Changes made:

1. **Added 11 missing GAP events to the allowed list** in `ble.cpp` (increasing from 4 to 15 total):
   - **Advertising events** (5 events - used by esp32_ble_beacon and server):
     - `ESP_GAP_BLE_ADV_DATA_SET_COMPLETE_EVT` (event 0)
     - `ESP_GAP_BLE_SCAN_RSP_DATA_SET_COMPLETE_EVT` (event 1)
     - `ESP_GAP_BLE_ADV_DATA_RAW_SET_COMPLETE_EVT` (event 4)
     - `ESP_GAP_BLE_ADV_START_COMPLETE_EVT` (event 6)
     - `ESP_GAP_BLE_ADV_STOP_COMPLETE_EVT` (event 17)
   - **Connection events** (1 event - fixes BLE RSSI sensor):
     - `ESP_GAP_BLE_READ_RSSI_COMPLETE_EVT` (event 26)
   - **Security events** (5 events - used by ble_client and bluetooth_proxy):
     - `ESP_GAP_BLE_AUTH_CMPL_EVT` (event 8)
     - `ESP_GAP_BLE_SEC_REQ_EVT` (event 10)
     - `ESP_GAP_BLE_PASSKEY_NOTIF_EVT` (event 11)
     - `ESP_GAP_BLE_PASSKEY_REQ_EVT` (event 12)
     - `ESP_GAP_BLE_NC_REQ_EVT` (event 16)

2. **Extended BLEEvent storage** in `ble_event.h`:
   - Added `adv_complete` struct (1 byte) for advertising complete events
   - Added `read_rssi_complete` struct (8 bytes) for RSSI data
   - Added `security` union member for authentication events
   - Added comprehensive static_assert checks to ensure memory safety and correct struct layouts
   - Documented which components use each event type

3. **Improved event processing** in `ble.cpp`:
   - Refactored from if-else chain to cleaner nested switch statement
   - Added proper handling for all new event types with appropriate data structures
   - Grouped events by category with clear comments

4. **Code cleanup and optimization**:
   - Added `StatusOnlyData` and `RSSICompleteData` typedefs to avoid anonymous struct issues
   - Consolidated duplicate struct definitions (scan_complete and adv_complete now share `StatusOnlyData`)
   - Simplified `read_rssi_complete()` method signature to use clean type reference

## Safety Analysis

### Why This Implementation is Safe

1. **No Memory Size Increase**:
   - All new event data structures fit within the existing 80-byte union
   - Static assertions verify `esp_ble_sec_t` (largest addition) fits within `BLEScanResult` size
   - Union size remains unchanged at 80 bytes as verified by static_assert

2. **Proper Event Data Handling**:
   - **Status-only events**: Share common `StatusOnlyData` structure (1 byte)
   - **RSSI event**: Dedicated structure with proper field alignment (8 bytes)
   - **Security events**: Reuse ESP-IDF's `esp_ble_sec_t` union directly
   - All data is properly copied in `init_gap_data_()` before callback returns

3. **Backward Compatibility**:
   - Previously queued but unhandled events now have proper data extraction and processing
   - Events without data extraction still get processed but log as "Unhandled GAP event type in loop"
   - No changes to existing event processing logic for scan results

4. **Component Safety**:
   - All events are processed synchronously in the main loop
   - Components that don't handle specific events simply ignore them
   - Reinterpret casts are safe due to compile-time struct verification

5. **Event Lifetime Safety**:
   - Events are returned to the pool immediately after processing in the same loop iteration
   - All gap_event_handlers process events synchronously and don't store pointers
   - Code analysis confirms all components that handle these events:
     - **esp32_ble_beacon**: Reads status field only for advertising events
     - **ble_client**: Reads and stores RSSI value (not pointer) for RSSI events
     - **bluetooth_proxy/esp32_ble_client**: Copy bd_addr and read auth fields for security events
     - **ble_client automation**: Read passkey/bd_addr values for pairing events
   - No component stores pointers to event data - all needed values are read immediately

### Static Safety Checks Added

- Verify all ESP-IDF status-only structures are exactly `sizeof(esp_bt_status_t)`
- Verify status field is at offset 0 in all structures
- Verify RSSI event field offsets match ESP-IDF layout
- Ensure union size hasn't grown beyond 80 bytes

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/issues/issues/7127

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example BLE RSSI sensor that was broken
ble_client:
  - mac_address: XX:XX:XX:XX:XX:XX
    id: my_ble_device

sensor:
  - platform: ble_rssi
    ble_client_id: my_ble_device
    name: "BLE Device RSSI"

# Example beacon that was generating warnings
esp32_ble_beacon:
  type: iBeacon
  uuid: 'c29ce823-e67a-4e71-bff2-abaa32e77a98'
  major: 100
  minor: 1
  tx_power: 4dBm
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).