### PR TITLE
[http_request.update] Fix ``size_t`` printing

### DIFF
--- a/esphome/components/http_request/update/http_request_update.cpp
+++ b/esphome/components/http_request/update/http_request_update.cpp
@@ -57,7 +57,7 @@ void HttpRequestUpdate::update_task(void *params) {
   ExternalRAMAllocator<uint8_t> allocator(ExternalRAMAllocator<uint8_t>::ALLOW_FAILURE);
   uint8_t *data = allocator.allocate(container->content_length);
   if (data == nullptr) {
-    std::string msg = str_sprintf("Failed to allocate %d bytes for manifest", container->content_length);
+    std::string msg = str_sprintf("Failed to allocate %zu bytes for manifest", container->content_length);
     this_update->status_set_error(msg.c_str());
     container->end();
     UPDATE_RETURN;


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

https://github.com/esphome/esphome/pull/9143#discussion_r2155889309

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
