### PR TITLE
Restore access to BLEScanResult as get_scan_result

### DIFF
--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
@@ -522,6 +522,7 @@ optional<ESPBLEiBeacon> ESPBLEiBeacon::from_manufacturer_data(const ServiceData 
 }
 
 void ESPBTDevice::parse_scan_rst(const BLEScanResult &scan_result) {
+  this->scan_result_ = &scan_result;
   for (uint8_t i = 0; i < ESP_BD_ADDR_LEN; i++)
     this->address_[i] = scan_result.bda[i];
   this->address_type_ = static_cast<esp_ble_addr_type_t>(scan_result.ble_addr_type);

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
@@ -85,6 +85,7 @@ class ESPBTDevice {
 
   const std::vector<ServiceData> &get_service_datas() const { return service_datas_; }
 
+  // Exposed through a function for use in lambdas
   const BLEScanResult &get_scan_result() const { return *scan_result_; }
 
   bool resolve_irk(const uint8_t *irk) const;

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
@@ -85,6 +85,8 @@ class ESPBTDevice {
 
   const std::vector<ServiceData> &get_service_datas() const { return service_datas_; }
 
+  const BLEScanResult &get_scan_result() const { return *scan_result_; }
+
   bool resolve_irk(const uint8_t *irk) const;
 
   optional<ESPBLEiBeacon> get_ibeacon() const {
@@ -111,6 +113,7 @@ class ESPBTDevice {
   std::vector<ESPBTUUID> service_uuids_{};
   std::vector<ServiceData> manufacturer_datas_{};
   std::vector<ServiceData> service_datas_{};
+  const BLEScanResult *scan_result_{nullptr};
 };
 
 class ESP32BLETracker;


### PR DESCRIPTION
# What does this implement/fix?

This will allow to create ESPBTDeviceListener's which will have full access to scan result and allow to parse RAW data or reconstruct BLE Advertising packet and forward it to external processing like this done in [BLE Gateway](https://github.com/myhomeiot/esphome-components#ble-gateway) component.

Originally it's was added by [PR#2854](https://github.com/esphome/esphome/pull/2854), in the last version of ESPHome 2025.6.0 this was removed due to heavy optimization. Please consider to add it back.

Thanks in advance!

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

The using of parse_devices for RAW extraction doesn't help in complex cases where this data required directly in lambda like in these example:
```yaml
esp32_ble_tracker:
  on_ble_advertise:
    then:
      - if:
          condition:
            - lambda: |-
                #if ESPHOME_VERSION_CODE < VERSION_CODE(2024, 6, 0)
                #error "Requires ESPHome 2024.6.0 or higher"
                #endif
                #define IRK(s) \
                  ({ \
                    std::vector<uint8_t> irk(16); \
                    if (sscanf((s), \
                      "%02hhx%02hhx%02hhx%02hhx%02hhx%02hhx%02hhx%02hhx%02hhx%02hhx%02hhx%02hhx%02hhx%02hhx%02hhx%02hhx", \
                      &irk[0], &irk[1], &irk[2], &irk[3], &irk[4], &irk[5], &irk[6], &irk[7], \
                      &irk[8], &irk[9], &irk[10], &irk[11], &irk[12], &irk[13], &irk[14], &irk[15]) != 16) \
                      ESP_LOGE("on_ble_advertise", "IRK format error: (%s)", (s)); \
                    irk; \
                  })

                static const std::vector<std::vector<uint8_t>> irks = {
                  IRK("${irk_test_phone}")
                };

                for (auto irk : irks)
                  if (x.resolve_irk(irk.data()))
                    return true;
                return false;
          then:
            - homeassistant.event:
                event: esphome.on_ble_advertise
                data:
                  packet: !lambda return ble_gateway::BLEGateway::scan_result_to_hci_packet_hex(x.get_scan_result());
                  gateway_id: ${device_id}
                  proxy: !lambda return true;
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
