### PR TITLE
Add option to enable support for USB Hubs

### DIFF
--- a/esphome/components/usb_host/__init__.py
+++ b/esphome/components/usb_host/__init__.py
@@ -19,6 +19,7 @@ USBClient = usb_host_ns.class_("USBClient", Component)
 CONF_DEVICES = "devices"
 CONF_VID = "vid"
 CONF_PID = "pid"
+CONF_ENABLE_HUBS = "enable_hubs"
 
 
 def usb_device_schema(cls=USBClient, vid: int = None, pid: [int] = None) -> cv.Schema:
@@ -42,6 +43,7 @@ CONFIG_SCHEMA = cv.All(
     cv.COMPONENT_SCHEMA.extend(
         {
             cv.GenerateID(): cv.declare_id(USBHost),
+            cv.Optional(CONF_ENABLE_HUBS, default=False): cv.boolean,
             cv.Optional(CONF_DEVICES): cv.ensure_list(usb_device_schema()),
         }
     ),
@@ -58,6 +60,8 @@ async def register_usb_client(config):
 
 async def to_code(config):
     add_idf_sdkconfig_option("CONFIG_USB_HOST_CONTROL_TRANSFER_MAX_SIZE", 1024)
+    if config.get(CONF_ENABLE_HUBS):
+        add_idf_sdkconfig_option("CONFIG_USB_HOST_HUBS_SUPPORTED", True)
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
     for device in config.get(CONF_DEVICES) or ():


### PR DESCRIPTION
# What does this implement/fix?

esp_idf supports USB Hubs now. Provide an option to enable support for this.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**
#8334 

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#5016

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
usb_host:
  enable_hubs: true

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
