### PR TITLE
[modbus] Modbus server role: write holding registers

### DIFF
--- a/esphome/components/modbus/modbus.h
+++ b/esphome/components/modbus/modbus.h
@@ -59,6 +59,7 @@ class ModbusDevice {
   virtual void on_modbus_data(const std::vector<uint8_t> &data) = 0;
   virtual void on_modbus_error(uint8_t function_code, uint8_t exception_code) {}
   virtual void on_modbus_read_registers(uint8_t function_code, uint16_t start_address, uint16_t number_of_registers){};
+  virtual void on_modbus_write_registers(uint8_t function_code, const std::vector<uint8_t> &data){};
   void send(uint8_t function, uint16_t start_address, uint16_t number_of_entities, uint8_t payload_len = 0,
             const uint8_t *payload = nullptr) {
     this->parent_->send(this->address_, function, start_address, number_of_entities, payload_len, payload);

--- a/esphome/components/modbus_controller/__init__.py
+++ b/esphome/components/modbus_controller/__init__.py
@@ -39,6 +39,7 @@ CODEOWNERS = ["@martgras"]
 AUTO_LOAD = ["modbus"]
 
 CONF_READ_LAMBDA = "read_lambda"
+CONF_WRITE_LAMBDA = "write_lambda"
 CONF_SERVER_REGISTERS = "server_registers"
 MULTI_CONF = True
 
@@ -148,6 +149,7 @@ ModbusServerRegisterSchema = cv.Schema(
         cv.Required(CONF_ADDRESS): cv.positive_int,
         cv.Optional(CONF_VALUE_TYPE, default="U_WORD"): cv.enum(SENSOR_VALUE_TYPE),
         cv.Required(CONF_READ_LAMBDA): cv.returning_lambda,
+        cv.Optional(CONF_WRITE_LAMBDA): cv.returning_lambda,
     }
 )
 
@@ -318,6 +320,18 @@ async def to_code(config):
                     ),
                 )
             )
+            if CONF_WRITE_LAMBDA in server_register:
+                cpp_type = CPP_TYPE_REGISTER_MAP[server_register[CONF_VALUE_TYPE]]
+                cg.add(
+                    server_register_var.set_write_lambda(
+                        cg.TemplateArguments(cpp_type),
+                        await cg.process_lambda(
+                            server_register[CONF_WRITE_LAMBDA],
+                            parameters=[(cg.uint16, "address"), (cpp_type, "x")],
+                            return_type=cg.bool_,
+                        ),
+                    )
+                )
             cg.add(var.add_server_register(server_register_var))
     await register_modbus_device(var, config)
     for conf in config.get(CONF_ON_COMMAND_SENT, []):

--- a/esphome/components/modbus_controller/__init__.py
+++ b/esphome/components/modbus_controller/__init__.py
@@ -321,7 +321,6 @@ async def to_code(config):
                 )
             )
             if CONF_WRITE_LAMBDA in server_register:
-                cpp_type = CPP_TYPE_REGISTER_MAP[server_register[CONF_VALUE_TYPE]]
                 cg.add(
                     server_register_var.set_write_lambda(
                         cg.TemplateArguments(cpp_type),

--- a/esphome/components/modbus_controller/modbus_controller.cpp
+++ b/esphome/components/modbus_controller/modbus_controller.cpp
@@ -152,6 +152,95 @@ void ModbusController::on_modbus_read_registers(uint8_t function_code, uint16_t 
   this->send(function_code, start_address, number_of_registers, response.size(), response.data());
 }
 
+void ModbusController::on_modbus_write_registers(uint8_t function_code, const std::vector<uint8_t> &data) {
+  uint16_t number_of_registers;
+  uint16_t payload_size;
+  uint16_t payload_offset;
+
+  if (function_code == 0x10) {
+    number_of_registers = uint16_t(data[3]) | (uint16_t(data[2]) << 8);
+    if (number_of_registers == 0 || number_of_registers > 0x7B) {
+      ESP_LOGW(TAG, "Invalid number of registers %d. Sending exception response.", number_of_registers);
+      send_error(function_code, 3);
+      return;
+    }
+    payload_size = data[4];
+    if (payload_size != number_of_registers * 2) {
+      ESP_LOGW(TAG, "Payload size of %d bytes is not 2 times the number of registers (%d). Sending exception response.",
+               payload_size, number_of_registers);
+      send_error(function_code, 3);
+      return;
+    }
+    payload_offset = 5;
+  } else if (function_code == 0x06) {
+    number_of_registers = 1;
+    payload_size = 2;
+    payload_offset = 2;
+  } else {
+    ESP_LOGW(TAG, "Invalid function code 0x%X. Sending exception response.", function_code);
+    send_error(function_code, 1);
+    return;
+  }
+
+  uint16_t start_address = uint16_t(data[1]) | (uint16_t(data[0]) << 8);
+  ESP_LOGD(TAG,
+           "Received write holding registers for device 0x%X. FC: 0x%X. Start address: 0x%X. Number of registers: "
+           "0x%X.",
+           this->address_, function_code, start_address, number_of_registers);
+
+  auto for_each_register = [this, start_address, number_of_registers, payload_offset](
+                               const std::function<bool(ServerRegister *, uint16_t offset)> &callback) -> bool {
+    uint16_t offset = payload_offset;
+    for (uint16_t current_address = start_address; current_address < start_address + number_of_registers;) {
+      bool ok = false;
+      for (auto *server_register : this->server_registers_) {
+        if (server_register->address == current_address) {
+          ok = callback(server_register, offset);
+          current_address += server_register->register_count;
+          offset += server_register->register_count * sizeof(uint16_t);
+          break;
+        }
+      }
+
+      if (!ok) {
+        return false;
+      }
+    }
+    return true;
+  };
+
+  // check all registers are writable before writing to any of them:
+  if (!for_each_register([](ServerRegister *server_register, uint16_t offset) -> bool {
+        return server_register->write_lambda != nullptr;
+      })) {
+    send_error(function_code, 1);
+    return;
+  }
+
+  // Actually write to the registers:
+  if (!for_each_register([&data](ServerRegister *server_register, uint16_t offset) {
+        int64_t number = payload_to_number(data, server_register->value_type, offset, 0xFFFFFFFF);
+
+        if (value_type_is_float(server_register->value_type)) {
+          float float_value = bit_cast<float>(static_cast<uint32_t>(number));
+          return server_register->write_lambda(&float_value, sizeof(float));
+        } else {
+          size_t size = value_type_size_in_words(server_register->value_type) * 2;
+          return server_register->write_lambda(&number, size);
+        }
+      })) {
+    send_error(function_code, 4);
+    return;
+  }
+
+  std::vector<uint8_t> response;
+  response.reserve(6);
+  response.push_back(this->address_);
+  response.push_back(function_code);
+  response.insert(response.end(), data.begin(), data.begin() + 4);
+  this->send_raw(response);
+}
+
 SensorSet ModbusController::find_sensors_(ModbusRegisterType register_type, uint16_t start_address) const {
   auto reg_it = std::find_if(
       std::begin(this->register_ranges_), std::end(this->register_ranges_),

--- a/esphome/components/modbus_controller/modbus_controller.cpp
+++ b/esphome/components/modbus_controller/modbus_controller.cpp
@@ -154,7 +154,6 @@ void ModbusController::on_modbus_read_registers(uint8_t function_code, uint16_t 
 
 void ModbusController::on_modbus_write_registers(uint8_t function_code, const std::vector<uint8_t> &data) {
   uint16_t number_of_registers;
-  uint16_t payload_size;
   uint16_t payload_offset;
 
   if (function_code == 0x10) {
@@ -164,7 +163,7 @@ void ModbusController::on_modbus_write_registers(uint8_t function_code, const st
       send_error(function_code, 3);
       return;
     }
-    payload_size = data[4];
+    uint16_t payload_size = data[4];
     if (payload_size != number_of_registers * 2) {
       ESP_LOGW(TAG, "Payload size of %d bytes is not 2 times the number of registers (%d). Sending exception response.",
                payload_size, number_of_registers);
@@ -174,7 +173,6 @@ void ModbusController::on_modbus_write_registers(uint8_t function_code, const st
     payload_offset = 5;
   } else if (function_code == 0x06) {
     number_of_registers = 1;
-    payload_size = 2;
     payload_offset = 2;
   } else {
     ESP_LOGW(TAG, "Invalid function code 0x%X. Sending exception response.", function_code);
@@ -220,14 +218,7 @@ void ModbusController::on_modbus_write_registers(uint8_t function_code, const st
   // Actually write to the registers:
   if (!for_each_register([&data](ServerRegister *server_register, uint16_t offset) {
         int64_t number = payload_to_number(data, server_register->value_type, offset, 0xFFFFFFFF);
-
-        if (value_type_is_float(server_register->value_type)) {
-          float float_value = bit_cast<float>(static_cast<uint32_t>(number));
-          return server_register->write_lambda(&float_value, sizeof(float));
-        } else {
-          size_t size = value_type_size_in_words(server_register->value_type) * 2;
-          return server_register->write_lambda(&number, size);
-        }
+        return server_register->write_lambda(number);
       })) {
     send_error(function_code, 4);
     return;

--- a/esphome/components/modbus_controller/modbus_controller.h
+++ b/esphome/components/modbus_controller/modbus_controller.h
@@ -67,30 +67,6 @@ inline bool value_type_is_float(SensorValueType v) {
   return v == SensorValueType::FP32 || v == SensorValueType::FP32_R;
 }
 
-inline uint8_t value_type_size_in_words(SensorValueType v) {
-  switch (v) {
-    case SensorValueType::RAW:
-    case SensorValueType::U_WORD:
-    case SensorValueType::S_WORD:
-    case SensorValueType::BIT:
-      return 1;
-    case SensorValueType::U_DWORD:
-    case SensorValueType::S_DWORD:
-    case SensorValueType::U_DWORD_R:
-    case SensorValueType::S_DWORD_R:
-    case SensorValueType::FP32:
-    case SensorValueType::FP32_R:
-      return 2;
-    case SensorValueType::U_QWORD:
-    case SensorValueType::S_QWORD:
-    case SensorValueType::U_QWORD_R:
-    case SensorValueType::S_QWORD_R:
-      return 4;
-    default:
-      return 0;  // unknown type
-  }
-}
-
 inline ModbusFunctionCode modbus_register_read_function(ModbusRegisterType reg_type) {
   switch (reg_type) {
     case ModbusRegisterType::COIL:
@@ -282,7 +258,7 @@ class SensorItem {
 
 class ServerRegister {
   using ReadLambda = std::function<int64_t()>;
-  using WriteLambda = std::function<bool(const void *, size_t)>;
+  using WriteLambda = std::function<bool(int64_t value)>;
 
  public:
   ServerRegister(uint16_t address, SensorValueType value_type, uint8_t register_count) {
@@ -299,6 +275,17 @@ class ServerRegister {
       } else {
         return static_cast<int64_t>(user_value);
       }
+    };
+  }
+
+  template<typename T>
+  void set_write_lambda(const std::function<bool(uint16_t address, const T v)> &&user_write_lambda) {
+    this->write_lambda = [this, user_write_lambda](int64_t number) {
+      if constexpr (std::is_same_v<T, float>) {
+        float float_value = bit_cast<float>(static_cast<uint32_t>(number));
+        return user_write_lambda(this->address, float_value);
+      }
+      return user_write_lambda(this->address, static_cast<T>(number));
     };
   }
 
@@ -330,16 +317,6 @@ class ServerRegister {
   uint8_t register_count{0};
   ReadLambda read_lambda;
   WriteLambda write_lambda;
-
-  template<typename T>
-  void set_write_lambda(const std::function<bool(uint16_t address, const T v)> &&user_write_lambda) {
-    this->write_lambda = [this, user_write_lambda](const void *value, size_t size) {
-      if (size != sizeof(T)) {
-        return false;
-      }
-      return user_write_lambda(this->address, *static_cast<const T *>(value));
-    };
-  }
 };
 
 // ModbusController::create_register_ranges_ tries to optimize register range

--- a/esphome/components/modbus_controller/modbus_controller.h
+++ b/esphome/components/modbus_controller/modbus_controller.h
@@ -67,6 +67,30 @@ inline bool value_type_is_float(SensorValueType v) {
   return v == SensorValueType::FP32 || v == SensorValueType::FP32_R;
 }
 
+inline uint8_t value_type_size_in_words(SensorValueType v) {
+  switch (v) {
+    case SensorValueType::RAW:
+    case SensorValueType::U_WORD:
+    case SensorValueType::S_WORD:
+    case SensorValueType::BIT:
+      return 1;
+    case SensorValueType::U_DWORD:
+    case SensorValueType::S_DWORD:
+    case SensorValueType::U_DWORD_R:
+    case SensorValueType::S_DWORD_R:
+    case SensorValueType::FP32:
+    case SensorValueType::FP32_R:
+      return 2;
+    case SensorValueType::U_QWORD:
+    case SensorValueType::S_QWORD:
+    case SensorValueType::U_QWORD_R:
+    case SensorValueType::S_QWORD_R:
+      return 4;
+    default:
+      return 0;  // unknown type
+  }
+}
+
 inline ModbusFunctionCode modbus_register_read_function(ModbusRegisterType reg_type) {
   switch (reg_type) {
     case ModbusRegisterType::COIL:
@@ -258,6 +282,7 @@ class SensorItem {
 
 class ServerRegister {
   using ReadLambda = std::function<int64_t()>;
+  using WriteLambda = std::function<bool(const void *, size_t)>;
 
  public:
   ServerRegister(uint16_t address, SensorValueType value_type, uint8_t register_count) {
@@ -304,6 +329,17 @@ class ServerRegister {
   SensorValueType value_type{SensorValueType::RAW};
   uint8_t register_count{0};
   ReadLambda read_lambda;
+  WriteLambda write_lambda;
+
+  template<typename T>
+  void set_write_lambda(const std::function<bool(uint16_t address, const T v)> &&user_write_lambda) {
+    this->write_lambda = [this, user_write_lambda](const void *value, size_t size) {
+      if (size != sizeof(T)) {
+        return false;
+      }
+      return user_write_lambda(this->address, *static_cast<const T *>(value));
+    };
+  }
 };
 
 // ModbusController::create_register_ranges_ tries to optimize register range
@@ -485,6 +521,8 @@ class ModbusController : public PollingComponent, public modbus::ModbusDevice {
   void on_modbus_error(uint8_t function_code, uint8_t exception_code) override;
   /// called when a modbus request (function code 0x03 or 0x04) was parsed without errors
   void on_modbus_read_registers(uint8_t function_code, uint16_t start_address, uint16_t number_of_registers) final;
+  /// called when a modbus request (function code 0x06 or 0x10) was parsed without errors
+  void on_modbus_write_registers(uint8_t function_code, const std::vector<uint8_t> &data) final;
   /// default delegate called by process_modbus_data when a response has retrieved from the incoming queue
   void on_register_data(ModbusRegisterType register_type, uint16_t start_address, const std::vector<uint8_t> &data);
   /// default delegate called by process_modbus_data when a response for a write response has retrieved from the

--- a/tests/components/modbus_controller/common.yaml
+++ b/tests/components/modbus_controller/common.yaml
@@ -33,7 +33,18 @@ modbus_controller:
         read_lambda: |-
           return 42.3;
     max_cmd_retries: 0
-
+  - id: modbus_controller3
+    address: 0x3
+    modbus_id: mod_bus2
+    server_registers:
+      - address: 0x0009
+        value_type: S_DWORD
+        read_lambda: |-
+          return 31;
+        write_lambda: |-
+          printf("address=%d, value=%d", x);
+          return true;
+    max_cmd_retries: 0
 binary_sensor:
   - platform: modbus_controller
     modbus_controller_id: modbus_controller1


### PR DESCRIPTION
# What does this implement/fix?

This PR extends the Modbus server role interface to support writing to holding registers with operations FC=`0x06` (Write single holding register) and FC=`0x10` (Write multiple holding registers)

A new property, `write_lambda` is added that exposes two variables: `address` (the address of the register to be written) and `x`, a variable with the value sent by the client.

`x` will be of the appropriate type as configured by the user in the `value_type` property, i.e., `S_DWORD` will make `x` to be of type `int32_t`, etc, avoiding loss of precision.

All datatypes are supported.

The user can return `true` if the operation was successful, `false` otherwise, in which case a modbus exception code `4` will be sent to the client according to the standard.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#5017

## Test Environment

- [x] ESP32
- [x] Host
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
modbus_controller:
  - id: modbus_controller3
    address: 0x3
    modbus_id: mod_bus2
    server_registers:
      - address: 0x0009
        value_type: S_DWORD
        read_lambda: |-
          return 31;
        write_lambda: |-
          printf("address=%d, value=%d, sizeof(x) == %d\n", address, x, sizeof(x));
          return true; // success
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
