### PR TITLE
Fix copy/paste errors in smt100 logging sensors.

### DIFF
--- a/esphome/components/smt100/smt100.cpp
+++ b/esphome/components/smt100/smt100.cpp
@@ -49,8 +49,8 @@ float SMT100Component::get_setup_priority() const { return setup_priority::DATA;
 void SMT100Component::dump_config() {
   ESP_LOGCONFIG(TAG, "SMT100:");
 
-  LOG_SENSOR(TAG, "Counts", this->temperature_sensor_);
-  LOG_SENSOR(TAG, "Dielectric Constant", this->temperature_sensor_);
+  LOG_SENSOR(TAG, "Counts", this->counts_sensor_);
+  LOG_SENSOR(TAG, "Dielectric Constant", this->dielectric_constant_sensor_);
   LOG_SENSOR(TAG, "Temperature", this->temperature_sensor_);
   LOG_SENSOR(TAG, "Moisture", this->moisture_sensor_);
   LOG_UPDATE_INTERVAL(this);


### PR DESCRIPTION
# What does this implement/fix?

Fix obvious copy/paste errors in sensor logging.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
