### PR TITLE
[nextion] Revert to `millis()` on `recv_ret_string_`

### DIFF
--- a/esphome/components/nextion/nextion.cpp
+++ b/esphome/components/nextion/nextion.cpp
@@ -967,9 +967,9 @@ uint16_t Nextion::recv_ret_string_(std::string &response, uint32_t timeout, bool
   bool exit_flag = false;
   bool ff_flag = false;
 
-  start = App.get_loop_component_start_time();
+  start = millis();
 
-  while ((timeout == 0 && this->available()) || App.get_loop_component_start_time() - start <= timeout) {
+  while ((timeout == 0 && this->available()) || millis() - start <= timeout) {
     if (!this->available()) {
       App.feed_wdt();
       delay(1);
@@ -1038,7 +1038,7 @@ void Nextion::add_no_result_to_queue_(const std::string &variable_name) {
   nextion_queue->component = new nextion::NextionComponentBase;
   nextion_queue->component->set_variable_name(variable_name);
 
-  nextion_queue->queue_time = App.get_loop_component_start_time();
+  nextion_queue->queue_time = millis();
 
   this->nextion_queue_.push_back(nextion_queue);
 

--- a/esphome/components/nextion/nextion.cpp
+++ b/esphome/components/nextion/nextion.cpp
@@ -963,11 +963,10 @@ uint16_t Nextion::recv_ret_string_(std::string &response, uint32_t timeout, bool
   uint16_t ret = 0;
   uint8_t c = 0;
   uint8_t nr_of_ff_bytes = 0;
-  uint64_t start;
   bool exit_flag = false;
   bool ff_flag = false;
 
-  start = millis();
+  const uint32_t start = millis();
 
   while ((timeout == 0 && this->available()) || millis() - start <= timeout) {
     if (!this->available()) {


### PR DESCRIPTION
# What does this implement/fix?

This partially reverts change from #9150 where calls to `millis()` have been replaced by `App.get_loop_component_start_time()`.

The implementation based on `App.get_loop_component_start_time()` on the `recv_ret_string_` was driving to an infinite loop during the TFT upload process and breaking the upload.

The other instances or `App.get_loop_component_start_time()` introduced by #9150 are kept.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [ ] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`: N/A

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
