### PR TITLE
Pre-reserve looping components vector to reduce memory allocations

### DIFF
--- a/esphome/core/application.cpp
+++ b/esphome/core/application.cpp
@@ -257,6 +257,17 @@ void Application::teardown_components(uint32_t timeout_ms) {
 }
 
 void Application::calculate_looping_components_() {
+  // Count total components that need looping
+  size_t total_looping = 0;
+  for (auto *obj : this->components_) {
+    if (obj->has_overridden_loop()) {
+      total_looping++;
+    }
+  }
+
+  // Pre-reserve vector to avoid reallocations
+  this->looping_components_.reserve(total_looping);
+
   // First add all active components
   for (auto *obj : this->components_) {
     if (obj->has_overridden_loop() &&


### PR DESCRIPTION
# What does this implement/fix?

This PR optimizes memory allocation in the `Application::calculate_looping_components_()` method by pre-reserving the vector capacity before populating it with components.

## Quick description

Currently, `looping_components_` vector is populated using multiple `push_back()` operations without pre-reservation, which can cause multiple memory reallocations as the vector grows. This change:

1. First counts the total number of components that need looping
2. Pre-reserves the exact capacity needed in the vector
3. Then populates the vector with components (active first, then inactive)

This optimization reduces memory fragmentation and improves performance during the setup phase, especially for configurations with many components.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change (this will require users to update their yaml configuration files to achieve the same functionality)
- [x] Code quality improvements
- [ ] Other

## Related issue or feature (if applicable)

N/A

## Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable)

N/A - This is an internal optimization with no user-facing changes.

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml` (if applicable)

N/A - No configuration changes required.

## Checklist

- [x] The code change is tested and works locally.
- [ ] Tests have been added to verify that the new code works (under `tests/` folder).
- [ ] Documentation added/updated as needed.

## Additional Details

The optimization adds a counting pass through `components_` to determine the exact size needed before reserving vector capacity. While this adds one extra iteration, it prevents potentially multiple reallocations during the subsequent `push_back()` operations, resulting in a net performance improvement and reduced memory fragmentation.

The change maintains the existing behavior where active components are added before inactive (LOOP_DONE) components, preserving the partitioned vector design used by the loop management system.