### PR TITLE
2025.6.1

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -48,7 +48,7 @@ PROJECT_NAME           = ESPHome
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 2025.6.0
+PROJECT_NUMBER         = 2025.6.1
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/esphome/components/esp32_ble/ble.h
+++ b/esphome/components/esp32_ble/ble.h
@@ -12,6 +12,7 @@
 #include "esphome/core/helpers.h"
 
 #include "ble_event.h"
+#include "ble_event_pool.h"
 #include "queue.h"
 
 #ifdef USE_ESP32
@@ -148,6 +149,7 @@ class ESP32BLE : public Component {
   BLEComponentState state_{BLE_COMPONENT_STATE_OFF};
 
   LockFreeQueue<BLEEvent, MAX_BLE_QUEUE_SIZE> ble_events_;
+  BLEEventPool<MAX_BLE_QUEUE_SIZE> ble_event_pool_;
   BLEAdvertising *advertising_{};
   esp_ble_io_cap_t io_cap_{ESP_IO_CAP_NONE};
   uint32_t advertising_cycle_time_{};

--- a/esphome/components/esp32_ble/ble_event_pool.h
+++ b/esphome/components/esp32_ble/ble_event_pool.h
@@ -1,0 +1,72 @@
+#pragma once
+
+#ifdef USE_ESP32
+
+#include <atomic>
+#include <cstddef>
+#include "ble_event.h"
+#include "queue.h"
+#include "esphome/core/helpers.h"
+
+namespace esphome {
+namespace esp32_ble {
+
+// BLE Event Pool - On-demand pool of BLEEvent objects to avoid heap fragmentation
+// Events are allocated on first use and reused thereafter, growing to peak usage
+template<uint8_t SIZE> class BLEEventPool {
+ public:
+  BLEEventPool() : total_created_(0) {}
+
+  ~BLEEventPool() {
+    // Clean up any remaining events in the free list
+    BLEEvent *event;
+    while ((event = this->free_list_.pop()) != nullptr) {
+      delete event;
+    }
+  }
+
+  // Allocate an event from the pool
+  // Returns nullptr if pool is full
+  BLEEvent *allocate() {
+    // Try to get from free list first
+    BLEEvent *event = this->free_list_.pop();
+    if (event != nullptr)
+      return event;
+
+    // Need to create a new event
+    if (this->total_created_ >= SIZE) {
+      // Pool is at capacity
+      return nullptr;
+    }
+
+    // Use internal RAM for better performance
+    RAMAllocator<BLEEvent> allocator(RAMAllocator<BLEEvent>::ALLOC_INTERNAL);
+    event = allocator.allocate(1);
+
+    if (event == nullptr) {
+      // Memory allocation failed
+      return nullptr;
+    }
+
+    // Placement new to construct the object
+    new (event) BLEEvent();
+    this->total_created_++;
+    return event;
+  }
+
+  // Return an event to the pool for reuse
+  void release(BLEEvent *event) {
+    if (event != nullptr) {
+      this->free_list_.push(event);
+    }
+  }
+
+ private:
+  LockFreeQueue<BLEEvent, SIZE> free_list_;  // Free events ready for reuse
+  uint8_t total_created_;                    // Total events created (high water mark)
+};
+
+}  // namespace esp32_ble
+}  // namespace esphome
+
+#endif

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
@@ -522,6 +522,7 @@ optional<ESPBLEiBeacon> ESPBLEiBeacon::from_manufacturer_data(const ServiceData 
 }
 
 void ESPBTDevice::parse_scan_rst(const BLEScanResult &scan_result) {
+  this->scan_result_ = &scan_result;
   for (uint8_t i = 0; i < ESP_BD_ADDR_LEN; i++)
     this->address_[i] = scan_result.bda[i];
   this->address_type_ = static_cast<esp_ble_addr_type_t>(scan_result.ble_addr_type);

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
@@ -85,6 +85,9 @@ class ESPBTDevice {
 
   const std::vector<ServiceData> &get_service_datas() const { return service_datas_; }
 
+  // Exposed through a function for use in lambdas
+  const BLEScanResult &get_scan_result() const { return *scan_result_; }
+
   bool resolve_irk(const uint8_t *irk) const;
 
   optional<ESPBLEiBeacon> get_ibeacon() const {
@@ -111,6 +114,7 @@ class ESPBTDevice {
   std::vector<ESPBTUUID> service_uuids_{};
   std::vector<ServiceData> manufacturer_datas_{};
   std::vector<ServiceData> service_datas_{};
+  const BLEScanResult *scan_result_{nullptr};
 };
 
 class ESP32BLETracker;

--- a/esphome/components/openthread/__init__.py
+++ b/esphome/components/openthread/__init__.py
@@ -46,7 +46,7 @@ def set_sdkconfig_options(config):
     add_idf_sdkconfig_option("CONFIG_OPENTHREAD_NETWORK_PANID", config[CONF_PAN_ID])
     add_idf_sdkconfig_option("CONFIG_OPENTHREAD_NETWORK_CHANNEL", config[CONF_CHANNEL])
     add_idf_sdkconfig_option(
-        "CONFIG_OPENTHREAD_NETWORK_MASTERKEY", f"{config[CONF_NETWORK_KEY]:X}"
+        "CONFIG_OPENTHREAD_NETWORK_MASTERKEY", f"{config[CONF_NETWORK_KEY]:X}".lower()
     )
 
     if network_name := config.get(CONF_NETWORK_NAME):
@@ -54,14 +54,14 @@ def set_sdkconfig_options(config):
 
     if (ext_pan_id := config.get(CONF_EXT_PAN_ID)) is not None:
         add_idf_sdkconfig_option(
-            "CONFIG_OPENTHREAD_NETWORK_EXTPANID", f"{ext_pan_id:X}"
+            "CONFIG_OPENTHREAD_NETWORK_EXTPANID", f"{ext_pan_id:X}".lower()
         )
     if (mesh_local_prefix := config.get(CONF_MESH_LOCAL_PREFIX)) is not None:
         add_idf_sdkconfig_option(
-            "CONFIG_OPENTHREAD_MESH_LOCAL_PREFIX", f"{mesh_local_prefix:X}"
+            "CONFIG_OPENTHREAD_MESH_LOCAL_PREFIX", f"{mesh_local_prefix}".lower()
         )
     if (pskc := config.get(CONF_PSKC)) is not None:
-        add_idf_sdkconfig_option("CONFIG_OPENTHREAD_NETWORK_PSKC", f"{pskc:X}")
+        add_idf_sdkconfig_option("CONFIG_OPENTHREAD_NETWORK_PSKC", f"{pskc:X}".lower())
 
     if CONF_FORCE_DATASET in config:
         if config[CONF_FORCE_DATASET]:
@@ -98,7 +98,7 @@ _CONNECTION_SCHEMA = cv.Schema(
         cv.Optional(CONF_EXT_PAN_ID): cv.hex_int,
         cv.Optional(CONF_NETWORK_NAME): cv.string_strict,
         cv.Optional(CONF_PSKC): cv.hex_int,
-        cv.Optional(CONF_MESH_LOCAL_PREFIX): cv.hex_int,
+        cv.Optional(CONF_MESH_LOCAL_PREFIX): cv.ipv6network,
     }
 )
 

--- a/esphome/components/openthread/openthread.cpp
+++ b/esphome/components/openthread/openthread.cpp
@@ -137,7 +137,7 @@ void OpenThreadSrpComponent::setup() {
   // Copy the mdns services to our local instance so that the c_str pointers remain valid for the lifetime of this
   // component
   this->mdns_services_ = this->mdns_->get_services();
-  ESP_LOGW(TAG, "Setting up SRP services. count = %d\n", this->mdns_services_.size());
+  ESP_LOGD(TAG, "Setting up SRP services. count = %d\n", this->mdns_services_.size());
   for (const auto &service : this->mdns_services_) {
     otSrpClientBuffersServiceEntry *entry = otSrpClientBuffersAllocateService(instance);
     if (!entry) {
@@ -185,11 +185,11 @@ void OpenThreadSrpComponent::setup() {
     if (error != OT_ERROR_NONE) {
       ESP_LOGW(TAG, "Failed to add service: %s", otThreadErrorToString(error));
     }
-    ESP_LOGW(TAG, "Added service: %s", full_service.c_str());
+    ESP_LOGD(TAG, "Added service: %s", full_service.c_str());
   }
 
   otSrpClientEnableAutoStartMode(instance, srp_start_callback, nullptr);
-  ESP_LOGW(TAG, "Finished SRP setup");
+  ESP_LOGD(TAG, "Finished SRP setup");
 }
 
 void *OpenThreadSrpComponent::pool_alloc_(size_t size) {

--- a/esphome/components/openthread/tlv.py
+++ b/esphome/components/openthread/tlv.py
@@ -1,5 +1,6 @@
 # Sourced from https://gist.github.com/agners/0338576e0003318b63ec1ea75adc90f9
 import binascii
+import ipaddress
 
 from esphome.const import CONF_CHANNEL
 
@@ -37,6 +38,12 @@ def parse_tlv(tlv) -> dict:
         if tag in TLV_TYPES:
             if tag == 3:
                 output[TLV_TYPES[tag]] = val.decode("utf-8")
+            elif tag == 7:
+                mesh_local_prefix = binascii.hexlify(val).decode("utf-8")
+                mesh_local_prefix_str = f"{mesh_local_prefix}0000000000000000"
+                ipv6_bytes = bytes.fromhex(mesh_local_prefix_str)
+                ipv6_address = ipaddress.IPv6Address(ipv6_bytes)
+                output[TLV_TYPES[tag]] = f"{ipv6_address}/64"
             else:
                 output[TLV_TYPES[tag]] = int.from_bytes(val)
     return output

--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -3,7 +3,15 @@
 from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime
-from ipaddress import AddressValueError, IPv4Address, ip_address
+from ipaddress import (
+    AddressValueError,
+    IPv4Address,
+    IPv4Network,
+    IPv6Address,
+    IPv6Network,
+    ip_address,
+    ip_network,
+)
 import logging
 import os
 import re
@@ -1176,6 +1184,14 @@ def ipv4address(value):
     return address
 
 
+def ipv6address(value):
+    try:
+        address = IPv6Address(value)
+    except AddressValueError as exc:
+        raise Invalid(f"{value} is not a valid IPv6 address") from exc
+    return address
+
+
 def ipv4address_multi_broadcast(value):
     address = ipv4address(value)
     if not (address.is_multicast or (address == IPv4Address("255.255.255.255"))):
@@ -1191,6 +1207,33 @@ def ipaddress(value):
     except ValueError as exc:
         raise Invalid(f"{value} is not a valid IP address") from exc
     return address
+
+
+def ipv4network(value):
+    """Validate that the value is a valid IPv4 network."""
+    try:
+        network = IPv4Network(value, strict=False)
+    except ValueError as exc:
+        raise Invalid(f"{value} is not a valid IPv4 network") from exc
+    return network
+
+
+def ipv6network(value):
+    """Validate that the value is a valid IPv6 network."""
+    try:
+        network = IPv6Network(value, strict=False)
+    except ValueError as exc:
+        raise Invalid(f"{value} is not a valid IPv6 network") from exc
+    return network
+
+
+def ipnetwork(value):
+    """Validate that the value is a valid IP network."""
+    try:
+        network = ip_network(value, strict=False)
+    except ValueError as exc:
+        raise Invalid(f"{value} is not a valid IP network") from exc
+    return network
 
 
 def _valid_topic(value):

--- a/esphome/const.py
+++ b/esphome/const.py
@@ -1,6 +1,6 @@
 """Constants used by esphome."""
 
-__version__ = "2025.6.0"
+__version__ = "2025.6.1"
 
 ALLOWED_NAME_CHARS = "abcdefghijklmnopqrstuvwxyz0123456789-_"
 VALID_SUBSTITUTIONS_CHARACTERS = (

--- a/esphome/yaml_util.py
+++ b/esphome/yaml_util.py
@@ -5,7 +5,7 @@ import fnmatch
 import functools
 import inspect
 from io import BytesIO, TextIOBase, TextIOWrapper
-from ipaddress import _BaseAddress
+from ipaddress import _BaseAddress, _BaseNetwork
 import logging
 import math
 import os
@@ -621,6 +621,7 @@ ESPHomeDumper.add_multi_representer(str, ESPHomeDumper.represent_stringify)
 ESPHomeDumper.add_multi_representer(int, ESPHomeDumper.represent_int)
 ESPHomeDumper.add_multi_representer(float, ESPHomeDumper.represent_float)
 ESPHomeDumper.add_multi_representer(_BaseAddress, ESPHomeDumper.represent_stringify)
+ESPHomeDumper.add_multi_representer(_BaseNetwork, ESPHomeDumper.represent_stringify)
 ESPHomeDumper.add_multi_representer(MACAddress, ESPHomeDumper.represent_stringify)
 ESPHomeDumper.add_multi_representer(TimePeriod, ESPHomeDumper.represent_stringify)
 ESPHomeDumper.add_multi_representer(Lambda, ESPHomeDumper.represent_lambda)

--- a/tests/components/openthread/test.esp32-c6-idf.yaml
+++ b/tests/components/openthread/test.esp32-c6-idf.yaml
@@ -8,4 +8,6 @@ openthread:
   pan_id: 0x8f28
   ext_pan_id: 0xd63e8e3e495ebbc3
   pskc: 0xc23a76e98f1a6483639b1ac1271e2e27
+  mesh_local_prefix: fd53:145f:ed22:ad81::/64
   force_dataset: true
+


### PR DESCRIPTION
**Do not merge, release script will automatically merge**
<details>
<summary>Show</summary>

- Eliminate memory fragmentation with BLE event pool [esphome#9101](https://github.com/esphome/esphome/pull/9101)
- [nextion] Fix command spacing double timing and response blocking issues [esphome#9134](https://github.com/esphome/esphome/pull/9134)
- Fix missing BLE GAP events causing RSSI sensor and beacon failures [esphome#9138](https://github.com/esphome/esphome/pull/9138)
- [config validation] Add more ip address / network validators [esphome#9181](https://github.com/esphome/esphome/pull/9181)
- Fixes for setup of OpenThread either using TLV or entering Credentials directly [esphome#9157](https://github.com/esphome/esphome/pull/9157)
- Restore access to BLEScanResult as get_scan_result [esphome#9148](https://github.com/esphome/esphome/pull/9148)
</details>

<details>
<summary>Metadata</summary>

@coderabbitai ignore
</details>
