### PR TITLE
[esp32] Change ``enable_lwip_mdns_queries`` default to ``True``

### DIFF
--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -606,7 +606,7 @@ ESP_IDF_FRAMEWORK_SCHEMA = cv.All(
                         CONF_ENABLE_LWIP_DHCP_SERVER, "wifi", default=False
                     ): cv.boolean,
                     cv.Optional(
-                        CONF_ENABLE_LWIP_MDNS_QUERIES, default=False
+                        CONF_ENABLE_LWIP_MDNS_QUERIES, default=True
                     ): cv.boolean,
                     cv.Optional(
                         CONF_ENABLE_LWIP_BRIDGE_INTERFACE, default=False
@@ -762,7 +762,7 @@ async def to_code(config):
             and not advanced[CONF_ENABLE_LWIP_DHCP_SERVER]
         ):
             add_idf_sdkconfig_option("CONFIG_LWIP_DHCPS", False)
-        if not advanced.get(CONF_ENABLE_LWIP_MDNS_QUERIES, False):
+        if not advanced.get(CONF_ENABLE_LWIP_MDNS_QUERIES, True):
             add_idf_sdkconfig_option("CONFIG_LWIP_DNS_SUPPORT_MDNS_QUERIES", False)
         if not advanced.get(CONF_ENABLE_LWIP_BRIDGE_INTERFACE, False):
             add_idf_sdkconfig_option("CONFIG_LWIP_BRIDGEIF_MAX_PORTS", 0)


### PR DESCRIPTION
# What does this implement/fix?

This changes default of `enable_lwip_mdns_queries` to true as to not disable mDNS resolver by default.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/issues/issues/7130

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs/pull/5027

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
