### PR TITLE
[ld2450] Use ``App.get_loop_component_start_time()``, shorten log messages

### DIFF
--- a/esphome/components/ld2450/ld2450.cpp
+++ b/esphome/components/ld2450/ld2450.cpp
@@ -190,9 +190,9 @@ void LD2450Component::dump_config() {
   LOG_NUMBER("  ", "PresenceTimeoutNumber", this->presence_timeout_number_);
 #endif
   ESP_LOGCONFIG(TAG,
-                "  Throttle : %ums\n"
-                "  MAC Address : %s\n"
-                "  Firmware version : %s",
+                "  Throttle: %ums\n"
+                "  MAC Address: %s\n"
+                "  Firmware version: %s",
                 this->throttle_, const_cast<char *>(this->mac_.c_str()), const_cast<char *>(this->version_.c_str()));
 }
 

--- a/esphome/components/ld2450/ld2450.cpp
+++ b/esphome/components/ld2450/ld2450.cpp
@@ -121,7 +121,7 @@ void LD2450Component::setup() {
 }
 
 void LD2450Component::dump_config() {
-  ESP_LOGCONFIG(TAG, "Human motion tracking radar:");
+  ESP_LOGCONFIG(TAG, "LD2450:");
 #ifdef USE_BINARY_SENSOR
   LOG_BINARY_SENSOR("  ", "TargetBinarySensor", this->target_binary_sensor_);
   LOG_BINARY_SENSOR("  ", "MovingTargetBinarySensor", this->moving_target_binary_sensor_);

--- a/esphome/components/ld2450/ld2450.cpp
+++ b/esphome/components/ld2450/ld2450.cpp
@@ -6,6 +6,7 @@
 #ifdef USE_SENSOR
 #include "esphome/components/sensor/sensor.h"
 #endif
+#include "esphome/core/application.h"
 #include "esphome/core/component.h"
 
 #define highbyte(val) (uint8_t)((val) >> 8)
@@ -120,7 +121,7 @@ void LD2450Component::setup() {
 }
 
 void LD2450Component::dump_config() {
-  ESP_LOGCONFIG(TAG, "HLK-LD2450 Human motion tracking radar module:");
+  ESP_LOGCONFIG(TAG, "Human motion tracking radar:");
 #ifdef USE_BINARY_SENSOR
   LOG_BINARY_SENSOR("  ", "TargetBinarySensor", this->target_binary_sensor_);
   LOG_BINARY_SENSOR("  ", "MovingTargetBinarySensor", this->moving_target_binary_sensor_);
@@ -266,8 +267,7 @@ bool LD2450Component::get_timeout_status_(uint32_t check_millis) {
   if (this->timeout_ == 0) {
     this->timeout_ = ld2450::convert_seconds_to_ms(DEFAULT_PRESENCE_TIMEOUT);
   }
-  auto current_millis = millis();
-  return current_millis - check_millis >= this->timeout_;
+  return App.get_loop_component_start_time() - check_millis >= this->timeout_;
 }
 
 // Extract, store and publish zone details LD2450 buffer
@@ -354,25 +354,24 @@ void LD2450Component::send_command_(uint8_t command, const uint8_t *command_valu
 //   Header       Target 1                  Target 2                  Target 3                  End
 void LD2450Component::handle_periodic_data_(uint8_t *buffer, uint8_t len) {
   if (len < 29) {  // header (4 bytes) + 8 x 3 target data + footer (2 bytes)
-    ESP_LOGE(TAG, "Periodic data: invalid message length");
+    ESP_LOGE(TAG, "Invalid message length");
     return;
   }
   if (buffer[0] != 0xAA || buffer[1] != 0xFF || buffer[2] != 0x03 || buffer[3] != 0x00) {  // header
-    ESP_LOGE(TAG, "Periodic data: invalid message header");
+    ESP_LOGE(TAG, "Invalid message header");
     return;
   }
   if (buffer[len - 2] != 0x55 || buffer[len - 1] != 0xCC) {  // footer
-    ESP_LOGE(TAG, "Periodic data: invalid message footer");
+    ESP_LOGE(TAG, "Invalid message footer");
     return;
   }
 
-  auto current_millis = millis();
-  if (current_millis - this->last_periodic_millis_ < this->throttle_) {
+  if (App.get_loop_component_start_time() - this->last_periodic_millis_ < this->throttle_) {
     ESP_LOGV(TAG, "Throttling: %d", this->throttle_);
     return;
   }
 
-  this->last_periodic_millis_ = current_millis;
+  this->last_periodic_millis_ = App.get_loop_component_start_time();
 
   int16_t target_count = 0;
   int16_t still_target_count = 0;
@@ -555,13 +554,13 @@ void LD2450Component::handle_periodic_data_(uint8_t *buffer, uint8_t len) {
 #ifdef USE_SENSOR
   // For presence timeout check
   if (target_count > 0) {
-    this->presence_millis_ = millis();
+    this->presence_millis_ = App.get_loop_component_start_time();
   }
   if (moving_target_count > 0) {
-    this->moving_presence_millis_ = millis();
+    this->moving_presence_millis_ = App.get_loop_component_start_time();
   }
   if (still_target_count > 0) {
-    this->still_presence_millis_ = millis();
+    this->still_presence_millis_ = App.get_loop_component_start_time();
   }
 #endif
 }
@@ -569,31 +568,31 @@ void LD2450Component::handle_periodic_data_(uint8_t *buffer, uint8_t len) {
 bool LD2450Component::handle_ack_data_(uint8_t *buffer, uint8_t len) {
   ESP_LOGV(TAG, "Handling ack data for command %02X", buffer[COMMAND]);
   if (len < 10) {
-    ESP_LOGE(TAG, "Ack data: invalid length");
+    ESP_LOGE(TAG, "Invalid ack length");
     return true;
   }
   if (buffer[0] != 0xFD || buffer[1] != 0xFC || buffer[2] != 0xFB || buffer[3] != 0xFA) {  // frame header
-    ESP_LOGE(TAG, "Ack data: invalid header (command %02X)", buffer[COMMAND]);
+    ESP_LOGE(TAG, "Invalid ack header (command %02X)", buffer[COMMAND]);
     return true;
   }
   if (buffer[COMMAND_STATUS] != 0x01) {
-    ESP_LOGE(TAG, "Ack data: invalid status");
+    ESP_LOGE(TAG, "Invalid ack status");
     return true;
   }
   if (buffer[8] || buffer[9]) {
-    ESP_LOGE(TAG, "Ack data: last buffer was %u, %u", buffer[8], buffer[9]);
+    ESP_LOGE(TAG, "Last buffer was %u, %u", buffer[8], buffer[9]);
     return true;
   }
 
   switch (buffer[COMMAND]) {
     case lowbyte(CMD_ENABLE_CONF):
-      ESP_LOGV(TAG, "Got enable conf command");
+      ESP_LOGV(TAG, "Enable conf command");
       break;
     case lowbyte(CMD_DISABLE_CONF):
-      ESP_LOGV(TAG, "Got disable conf command");
+      ESP_LOGV(TAG, "Disable conf command");
       break;
     case lowbyte(CMD_SET_BAUD_RATE):
-      ESP_LOGV(TAG, "Got baud rate change command");
+      ESP_LOGV(TAG, "Baud rate change command");
 #ifdef USE_SELECT
       if (this->baud_rate_select_ != nullptr) {
         ESP_LOGV(TAG, "Change baud rate to %s", this->baud_rate_select_->state.c_str());
@@ -627,10 +626,10 @@ bool LD2450Component::handle_ack_data_(uint8_t *buffer, uint8_t len) {
 #endif
       break;
     case lowbyte(CMD_BLUETOOTH):
-      ESP_LOGV(TAG, "Got Bluetooth command");
+      ESP_LOGV(TAG, "Bluetooth command");
       break;
     case lowbyte(CMD_SINGLE_TARGET_MODE):
-      ESP_LOGV(TAG, "Got single target conf command");
+      ESP_LOGV(TAG, "Single target conf command");
 #ifdef USE_SWITCH
       if (this->multi_target_switch_ != nullptr) {
         this->multi_target_switch_->publish_state(false);
@@ -638,7 +637,7 @@ bool LD2450Component::handle_ack_data_(uint8_t *buffer, uint8_t len) {
 #endif
       break;
     case lowbyte(CMD_MULTI_TARGET_MODE):
-      ESP_LOGV(TAG, "Got multi target conf command");
+      ESP_LOGV(TAG, "Multi target conf command");
 #ifdef USE_SWITCH
       if (this->multi_target_switch_ != nullptr) {
         this->multi_target_switch_->publish_state(true);
@@ -646,7 +645,7 @@ bool LD2450Component::handle_ack_data_(uint8_t *buffer, uint8_t len) {
 #endif
       break;
     case lowbyte(CMD_QUERY_TARGET_MODE):
-      ESP_LOGV(TAG, "Got query target tracking mode command");
+      ESP_LOGV(TAG, "Query target tracking mode command");
 #ifdef USE_SWITCH
       if (this->multi_target_switch_ != nullptr) {
         this->multi_target_switch_->publish_state(buffer[10] == 0x02);
@@ -654,7 +653,7 @@ bool LD2450Component::handle_ack_data_(uint8_t *buffer, uint8_t len) {
 #endif
       break;
     case lowbyte(CMD_QUERY_ZONE):
-      ESP_LOGV(TAG, "Got query zone conf command");
+      ESP_LOGV(TAG, "Query zone conf command");
       this->zone_type_ = std::stoi(std::to_string(buffer[10]), nullptr, 16);
       this->publish_zone_type();
 #ifdef USE_SELECT
@@ -674,7 +673,7 @@ bool LD2450Component::handle_ack_data_(uint8_t *buffer, uint8_t len) {
       this->process_zone_(buffer);
       break;
     case lowbyte(CMD_SET_ZONE):
-      ESP_LOGV(TAG, "Got set zone conf command");
+      ESP_LOGV(TAG, "Set zone conf command");
       this->query_zone_info();
       break;
     default:


### PR DESCRIPTION
# What does this implement/fix?

SSIA

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
