### PR TITLE
[binary_sensor] Add timeout filter

### DIFF
--- a/esphome/components/binary_sensor/__init__.py
+++ b/esphome/components/binary_sensor/__init__.py
@@ -148,6 +148,7 @@ BinarySensorCondition = binary_sensor_ns.class_("BinarySensorCondition", Conditi
 
 # Filters
 Filter = binary_sensor_ns.class_("Filter")
+TimeoutFilter = binary_sensor_ns.class_("TimeoutFilter", Filter, cg.Component)
 DelayedOnOffFilter = binary_sensor_ns.class_("DelayedOnOffFilter", Filter, cg.Component)
 DelayedOnFilter = binary_sensor_ns.class_("DelayedOnFilter", Filter, cg.Component)
 DelayedOffFilter = binary_sensor_ns.class_("DelayedOffFilter", Filter, cg.Component)
@@ -169,6 +170,19 @@ def register_filter(name, filter_type, schema):
 @register_filter("invert", InvertFilter, {})
 async def invert_filter_to_code(config, filter_id):
     return cg.new_Pvariable(filter_id)
+
+
+@register_filter(
+    "timeout",
+    TimeoutFilter,
+    cv.templatable(cv.positive_time_period_milliseconds),
+)
+async def timeout_filter_to_code(config, filter_id):
+    var = cg.new_Pvariable(filter_id)
+    await cg.register_component(var, {})
+    template_ = await cg.templatable(config, [], cg.uint32)
+    cg.add(var.set_timeout_value(template_))
+    return var
 
 
 @register_filter(

--- a/esphome/components/binary_sensor/filter.cpp
+++ b/esphome/components/binary_sensor/filter.cpp
@@ -25,6 +25,12 @@ void Filter::input(bool value) {
   }
 }
 
+void TimeoutFilter::input(bool value) {
+  this->set_timeout("timeout", this->timeout_delay_.value(), [this]() { this->parent_->invalidate_state(); });
+  // we do not de-dup here otherwise changes from invalid to valid state will not be output
+  this->output(value);
+}
+
 optional<bool> DelayedOnOffFilter::new_value(bool value) {
   if (value) {
     this->set_timeout("ON_OFF", this->on_delay_.value(), [this]() { this->output(true); });

--- a/esphome/components/binary_sensor/filter.h
+++ b/esphome/components/binary_sensor/filter.h
@@ -30,7 +30,7 @@ class Filter {
 
 class TimeoutFilter : public Filter, public Component {
  public:
-  optional<bool> new_value(bool value) override { return value == true; }
+  optional<bool> new_value(bool value) override { return value; }
   void input(bool value) override;
   template<typename T> void set_timeout_value(T timeout) { this->timeout_delay_ = timeout; }
 

--- a/esphome/components/binary_sensor/filter.h
+++ b/esphome/components/binary_sensor/filter.h
@@ -16,7 +16,7 @@ class Filter {
  public:
   virtual optional<bool> new_value(bool value) = 0;
 
-  void input(bool value);
+  virtual void input(bool value);
 
   void output(bool value);
 
@@ -26,6 +26,16 @@ class Filter {
   Filter *next_{nullptr};
   BinarySensor *parent_{nullptr};
   Deduplicator<bool> dedup_;
+};
+
+class TimeoutFilter : public Filter, public Component {
+ public:
+  optional<bool> new_value(bool value) override { return value == true; }
+  void input(bool value) override;
+  template<typename T> void set_timeout_value(T timeout) { this->timeout_delay_ = timeout; }
+
+ protected:
+  TemplatableValue<uint32_t> timeout_delay_{};
 };
 
 class DelayedOnOffFilter : public Filter, public Component {

--- a/tests/components/binary_sensor/common.yaml
+++ b/tests/components/binary_sensor/common.yaml
@@ -4,6 +4,31 @@ binary_sensor:
     id: some_binary_sensor
     name: "Random binary"
     lambda: return (random_uint32() & 1) == 0;
+    filters:
+      - invert:
+      - delayed_on: 100ms
+      - delayed_off: 100ms
+      # Templated, delays for 1s (1000ms) only if a reed switch is active
+      - delayed_on_off: !lambda "return 1000;"
+      - delayed_on_off:
+          time_on: 10s
+          time_off: !lambda "return 1000;"
+      - autorepeat:
+          - delay: 1s
+            time_off: 100ms
+            time_on: 900ms
+          - delay: 5s
+            time_off: 100ms
+            time_on: 400ms
+      - lambda: |-
+          if (id(some_binary_sensor).state) {
+            return x;
+          } else {
+            return {};
+          }
+      - settle: 100ms
+      - timeout: 10s
+
     on_state_change:
       then:
         - logger.log:


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Add a `timeout` filter for binary sensors that will invalidate the state if no state has been published for a specified period of time.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#5034

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [x] host

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
binary_sensor:
  - platform: template
    id: bst
    filters:
      - timeout: 2s
    on_state_change:
      - logger.log:
          format: "%s"
          args: [ONOFFMAYBE(x)]

interval:
  - interval: 3s
    then:
      - binary_sensor.template.publish:
          id: bst
          state: true
      - logger.log: published state
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
