### PR TITLE
[debug] expose RP2040 reset reason

### DIFF
--- a/esphome/components/debug/debug_rp2040.cpp
+++ b/esphome/components/debug/debug_rp2040.cpp
@@ -7,7 +7,27 @@ namespace debug {
 
 static const char *const TAG = "debug";
 
-std::string DebugComponent::get_reset_reason_() { return ""; }
+std::string DebugComponent::get_reset_reason_() {
+  switch (rp2040.getResetReason()) {
+    case RP2040::PWRON_RESET:
+      return "pwron_reset";
+    case RP2040::RUN_PIN_RESET:
+      return "run_pin_reset";
+    case RP2040::SOFT_RESET:
+      return "soft_reset";
+    case RP2040::WDT_RESET:
+      return "wdt_reset";
+    case RP2040::DEBUG_RESET:
+      return "debug_reset";
+    case RP2040::GLITCH_RESET:
+      return "glitch_reset";
+    case RP2040::BROWNOUT_RESET:
+      return "brownout_reset";
+    case RP2040::UNKNOWN_RESET:
+      return "unknown_reason";
+  }
+  return "";
+}
 
 uint32_t DebugComponent::get_free_heap_() { return rp2040.getFreeHeap(); }
 


### PR DESCRIPTION
# What does this implement/fix?

exposes the reset_reason on RP2040 as on other platforms

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

none

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

none

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [x] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

Trimmed from the [debug component docs](https://esphome.io/components/debug.html):

```yaml
# Example configuration entry
debug:
  update_interval: 5s

text_sensor:
  - platform: debug
    reset_reason:
      name: "Reset Reason"

# Logger must be configured
logger:
  level: debug
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
