### PR TITLE
Fix missing protobuf message dump for batched messages with very verbose logging

### DIFF
--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -284,6 +284,11 @@ uint16_t APIConnection::encode_message_to_buffer(ProtoMessage &msg, uint16_t mes
   // Encode directly into buffer
   msg.encode(buffer);
 
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  // Log the message for VV debugging
+  conn->log_send_message_(msg.message_name(), msg.dump());
+#endif
+
   // Calculate actual encoded size (not including header that was already added)
   size_t actual_payload_size = shared_buf.size() - size_before_encode;
 

--- a/esphome/components/api/api_pb2.h
+++ b/esphome/components/api/api_pb2.h
@@ -281,7 +281,7 @@ class HelloRequest : public ProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 1;
   static constexpr uint16_t ESTIMATED_SIZE = 17;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "hello_request"; }
+  const char *message_name() const override { return "hello_request"; }
 #endif
   std::string client_info{};
   uint32_t api_version_major{0};
@@ -301,7 +301,7 @@ class HelloResponse : public ProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 2;
   static constexpr uint16_t ESTIMATED_SIZE = 26;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "hello_response"; }
+  const char *message_name() const override { return "hello_response"; }
 #endif
   uint32_t api_version_major{0};
   uint32_t api_version_minor{0};
@@ -322,7 +322,7 @@ class ConnectRequest : public ProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 3;
   static constexpr uint16_t ESTIMATED_SIZE = 9;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "connect_request"; }
+  const char *message_name() const override { return "connect_request"; }
 #endif
   std::string password{};
   void encode(ProtoWriteBuffer buffer) const override;
@@ -339,7 +339,7 @@ class ConnectResponse : public ProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 4;
   static constexpr uint16_t ESTIMATED_SIZE = 2;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "connect_response"; }
+  const char *message_name() const override { return "connect_response"; }
 #endif
   bool invalid_password{false};
   void encode(ProtoWriteBuffer buffer) const override;
@@ -356,7 +356,7 @@ class DisconnectRequest : public ProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 5;
   static constexpr uint16_t ESTIMATED_SIZE = 0;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "disconnect_request"; }
+  const char *message_name() const override { return "disconnect_request"; }
 #endif
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
@@ -369,7 +369,7 @@ class DisconnectResponse : public ProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 6;
   static constexpr uint16_t ESTIMATED_SIZE = 0;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "disconnect_response"; }
+  const char *message_name() const override { return "disconnect_response"; }
 #endif
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
@@ -382,7 +382,7 @@ class PingRequest : public ProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 7;
   static constexpr uint16_t ESTIMATED_SIZE = 0;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "ping_request"; }
+  const char *message_name() const override { return "ping_request"; }
 #endif
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
@@ -395,7 +395,7 @@ class PingResponse : public ProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 8;
   static constexpr uint16_t ESTIMATED_SIZE = 0;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "ping_response"; }
+  const char *message_name() const override { return "ping_response"; }
 #endif
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
@@ -408,7 +408,7 @@ class DeviceInfoRequest : public ProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 9;
   static constexpr uint16_t ESTIMATED_SIZE = 0;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "device_info_request"; }
+  const char *message_name() const override { return "device_info_request"; }
 #endif
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
@@ -450,7 +450,7 @@ class DeviceInfoResponse : public ProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 10;
   static constexpr uint16_t ESTIMATED_SIZE = 219;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "device_info_response"; }
+  const char *message_name() const override { return "device_info_response"; }
 #endif
   bool uses_password{false};
   std::string name{};
@@ -489,7 +489,7 @@ class ListEntitiesRequest : public ProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 11;
   static constexpr uint16_t ESTIMATED_SIZE = 0;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "list_entities_request"; }
+  const char *message_name() const override { return "list_entities_request"; }
 #endif
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
@@ -502,7 +502,7 @@ class ListEntitiesDoneResponse : public ProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 19;
   static constexpr uint16_t ESTIMATED_SIZE = 0;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "list_entities_done_response"; }
+  const char *message_name() const override { return "list_entities_done_response"; }
 #endif
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
@@ -515,7 +515,7 @@ class SubscribeStatesRequest : public ProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 20;
   static constexpr uint16_t ESTIMATED_SIZE = 0;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "subscribe_states_request"; }
+  const char *message_name() const override { return "subscribe_states_request"; }
 #endif
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
@@ -528,7 +528,7 @@ class ListEntitiesBinarySensorResponse : public InfoResponseProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 12;
   static constexpr uint16_t ESTIMATED_SIZE = 60;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "list_entities_binary_sensor_response"; }
+  const char *message_name() const override { return "list_entities_binary_sensor_response"; }
 #endif
   std::string device_class{};
   bool is_status_binary_sensor{false};
@@ -548,7 +548,7 @@ class BinarySensorStateResponse : public StateResponseProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 21;
   static constexpr uint16_t ESTIMATED_SIZE = 9;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "binary_sensor_state_response"; }
+  const char *message_name() const override { return "binary_sensor_state_response"; }
 #endif
   bool state{false};
   bool missing_state{false};
@@ -567,7 +567,7 @@ class ListEntitiesCoverResponse : public InfoResponseProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 13;
   static constexpr uint16_t ESTIMATED_SIZE = 66;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "list_entities_cover_response"; }
+  const char *message_name() const override { return "list_entities_cover_response"; }
 #endif
   bool assumed_state{false};
   bool supports_position{false};
@@ -590,7 +590,7 @@ class CoverStateResponse : public StateResponseProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 22;
   static constexpr uint16_t ESTIMATED_SIZE = 19;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "cover_state_response"; }
+  const char *message_name() const override { return "cover_state_response"; }
 #endif
   enums::LegacyCoverState legacy_state{};
   float position{0.0f};
@@ -611,7 +611,7 @@ class CoverCommandRequest : public ProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 30;
   static constexpr uint16_t ESTIMATED_SIZE = 25;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "cover_command_request"; }
+  const char *message_name() const override { return "cover_command_request"; }
 #endif
   uint32_t key{0};
   bool has_legacy_command{false};
@@ -636,7 +636,7 @@ class ListEntitiesFanResponse : public InfoResponseProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 14;
   static constexpr uint16_t ESTIMATED_SIZE = 77;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "list_entities_fan_response"; }
+  const char *message_name() const override { return "list_entities_fan_response"; }
 #endif
   bool supports_oscillation{false};
   bool supports_speed{false};
@@ -659,7 +659,7 @@ class FanStateResponse : public StateResponseProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 23;
   static constexpr uint16_t ESTIMATED_SIZE = 26;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "fan_state_response"; }
+  const char *message_name() const override { return "fan_state_response"; }
 #endif
   bool state{false};
   bool oscillating{false};
@@ -683,7 +683,7 @@ class FanCommandRequest : public ProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 31;
   static constexpr uint16_t ESTIMATED_SIZE = 38;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "fan_command_request"; }
+  const char *message_name() const override { return "fan_command_request"; }
 #endif
   uint32_t key{0};
   bool has_state{false};
@@ -714,7 +714,7 @@ class ListEntitiesLightResponse : public InfoResponseProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 15;
   static constexpr uint16_t ESTIMATED_SIZE = 90;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "list_entities_light_response"; }
+  const char *message_name() const override { return "list_entities_light_response"; }
 #endif
   std::vector<enums::ColorMode> supported_color_modes{};
   bool legacy_supports_brightness{false};
@@ -740,7 +740,7 @@ class LightStateResponse : public StateResponseProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 24;
   static constexpr uint16_t ESTIMATED_SIZE = 63;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "light_state_response"; }
+  const char *message_name() const override { return "light_state_response"; }
 #endif
   bool state{false};
   float brightness{0.0f};
@@ -770,7 +770,7 @@ class LightCommandRequest : public ProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 32;
   static constexpr uint16_t ESTIMATED_SIZE = 107;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "light_command_request"; }
+  const char *message_name() const override { return "light_command_request"; }
 #endif
   uint32_t key{0};
   bool has_state{false};
@@ -815,7 +815,7 @@ class ListEntitiesSensorResponse : public InfoResponseProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 16;
   static constexpr uint16_t ESTIMATED_SIZE = 77;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "list_entities_sensor_response"; }
+  const char *message_name() const override { return "list_entities_sensor_response"; }
 #endif
   std::string unit_of_measurement{};
   int32_t accuracy_decimals{0};
@@ -839,7 +839,7 @@ class SensorStateResponse : public StateResponseProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 25;
   static constexpr uint16_t ESTIMATED_SIZE = 12;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "sensor_state_response"; }
+  const char *message_name() const override { return "sensor_state_response"; }
 #endif
   float state{0.0f};
   bool missing_state{false};
@@ -858,7 +858,7 @@ class ListEntitiesSwitchResponse : public InfoResponseProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 17;
   static constexpr uint16_t ESTIMATED_SIZE = 60;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "list_entities_switch_response"; }
+  const char *message_name() const override { return "list_entities_switch_response"; }
 #endif
   bool assumed_state{false};
   std::string device_class{};
@@ -878,7 +878,7 @@ class SwitchStateResponse : public StateResponseProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 26;
   static constexpr uint16_t ESTIMATED_SIZE = 7;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "switch_state_response"; }
+  const char *message_name() const override { return "switch_state_response"; }
 #endif
   bool state{false};
   void encode(ProtoWriteBuffer buffer) const override;
@@ -896,7 +896,7 @@ class SwitchCommandRequest : public ProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 33;
   static constexpr uint16_t ESTIMATED_SIZE = 7;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "switch_command_request"; }
+  const char *message_name() const override { return "switch_command_request"; }
 #endif
   uint32_t key{0};
   bool state{false};
@@ -915,7 +915,7 @@ class ListEntitiesTextSensorResponse : public InfoResponseProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 18;
   static constexpr uint16_t ESTIMATED_SIZE = 58;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "list_entities_text_sensor_response"; }
+  const char *message_name() const override { return "list_entities_text_sensor_response"; }
 #endif
   std::string device_class{};
   void encode(ProtoWriteBuffer buffer) const override;
@@ -934,7 +934,7 @@ class TextSensorStateResponse : public StateResponseProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 27;
   static constexpr uint16_t ESTIMATED_SIZE = 16;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "text_sensor_state_response"; }
+  const char *message_name() const override { return "text_sensor_state_response"; }
 #endif
   std::string state{};
   bool missing_state{false};
@@ -954,7 +954,7 @@ class SubscribeLogsRequest : public ProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 28;
   static constexpr uint16_t ESTIMATED_SIZE = 4;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "subscribe_logs_request"; }
+  const char *message_name() const override { return "subscribe_logs_request"; }
 #endif
   enums::LogLevel level{};
   bool dump_config{false};
@@ -972,7 +972,7 @@ class SubscribeLogsResponse : public ProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 29;
   static constexpr uint16_t ESTIMATED_SIZE = 13;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "subscribe_logs_response"; }
+  const char *message_name() const override { return "subscribe_logs_response"; }
 #endif
   enums::LogLevel level{};
   std::string message{};
@@ -992,7 +992,7 @@ class NoiseEncryptionSetKeyRequest : public ProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 124;
   static constexpr uint16_t ESTIMATED_SIZE = 9;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "noise_encryption_set_key_request"; }
+  const char *message_name() const override { return "noise_encryption_set_key_request"; }
 #endif
   std::string key{};
   void encode(ProtoWriteBuffer buffer) const override;
@@ -1009,7 +1009,7 @@ class NoiseEncryptionSetKeyResponse : public ProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 125;
   static constexpr uint16_t ESTIMATED_SIZE = 2;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "noise_encryption_set_key_response"; }
+  const char *message_name() const override { return "noise_encryption_set_key_response"; }
 #endif
   bool success{false};
   void encode(ProtoWriteBuffer buffer) const override;
@@ -1026,7 +1026,7 @@ class SubscribeHomeassistantServicesRequest : public ProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 34;
   static constexpr uint16_t ESTIMATED_SIZE = 0;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "subscribe_homeassistant_services_request"; }
+  const char *message_name() const override { return "subscribe_homeassistant_services_request"; }
 #endif
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
@@ -1052,7 +1052,7 @@ class HomeassistantServiceResponse : public ProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 35;
   static constexpr uint16_t ESTIMATED_SIZE = 113;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "homeassistant_service_response"; }
+  const char *message_name() const override { return "homeassistant_service_response"; }
 #endif
   std::string service{};
   std::vector<HomeassistantServiceMap> data{};
@@ -1074,7 +1074,7 @@ class SubscribeHomeAssistantStatesRequest : public ProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 38;
   static constexpr uint16_t ESTIMATED_SIZE = 0;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "subscribe_home_assistant_states_request"; }
+  const char *message_name() const override { return "subscribe_home_assistant_states_request"; }
 #endif
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
@@ -1087,7 +1087,7 @@ class SubscribeHomeAssistantStateResponse : public ProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 39;
   static constexpr uint16_t ESTIMATED_SIZE = 20;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "subscribe_home_assistant_state_response"; }
+  const char *message_name() const override { return "subscribe_home_assistant_state_response"; }
 #endif
   std::string entity_id{};
   std::string attribute{};
@@ -1107,7 +1107,7 @@ class HomeAssistantStateResponse : public ProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 40;
   static constexpr uint16_t ESTIMATED_SIZE = 27;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "home_assistant_state_response"; }
+  const char *message_name() const override { return "home_assistant_state_response"; }
 #endif
   std::string entity_id{};
   std::string state{};
@@ -1126,7 +1126,7 @@ class GetTimeRequest : public ProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 36;
   static constexpr uint16_t ESTIMATED_SIZE = 0;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "get_time_request"; }
+  const char *message_name() const override { return "get_time_request"; }
 #endif
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
@@ -1139,7 +1139,7 @@ class GetTimeResponse : public ProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 37;
   static constexpr uint16_t ESTIMATED_SIZE = 5;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "get_time_response"; }
+  const char *message_name() const override { return "get_time_response"; }
 #endif
   uint32_t epoch_seconds{0};
   void encode(ProtoWriteBuffer buffer) const override;
@@ -1170,7 +1170,7 @@ class ListEntitiesServicesResponse : public ProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 41;
   static constexpr uint16_t ESTIMATED_SIZE = 48;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "list_entities_services_response"; }
+  const char *message_name() const override { return "list_entities_services_response"; }
 #endif
   std::string name{};
   uint32_t key{0};
@@ -1212,7 +1212,7 @@ class ExecuteServiceRequest : public ProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 42;
   static constexpr uint16_t ESTIMATED_SIZE = 39;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "execute_service_request"; }
+  const char *message_name() const override { return "execute_service_request"; }
 #endif
   uint32_t key{0};
   std::vector<ExecuteServiceArgument> args{};
@@ -1231,7 +1231,7 @@ class ListEntitiesCameraResponse : public InfoResponseProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 43;
   static constexpr uint16_t ESTIMATED_SIZE = 49;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "list_entities_camera_response"; }
+  const char *message_name() const override { return "list_entities_camera_response"; }
 #endif
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(uint32_t &total_size) const override;
@@ -1249,7 +1249,7 @@ class CameraImageResponse : public ProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 44;
   static constexpr uint16_t ESTIMATED_SIZE = 16;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "camera_image_response"; }
+  const char *message_name() const override { return "camera_image_response"; }
 #endif
   uint32_t key{0};
   std::string data{};
@@ -1270,7 +1270,7 @@ class CameraImageRequest : public ProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 45;
   static constexpr uint16_t ESTIMATED_SIZE = 4;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "camera_image_request"; }
+  const char *message_name() const override { return "camera_image_request"; }
 #endif
   bool single{false};
   bool stream{false};
@@ -1288,7 +1288,7 @@ class ListEntitiesClimateResponse : public InfoResponseProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 46;
   static constexpr uint16_t ESTIMATED_SIZE = 156;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "list_entities_climate_response"; }
+  const char *message_name() const override { return "list_entities_climate_response"; }
 #endif
   bool supports_current_temperature{false};
   bool supports_two_point_target_temperature{false};
@@ -1324,7 +1324,7 @@ class ClimateStateResponse : public StateResponseProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 47;
   static constexpr uint16_t ESTIMATED_SIZE = 65;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "climate_state_response"; }
+  const char *message_name() const override { return "climate_state_response"; }
 #endif
   enums::ClimateMode mode{};
   float current_temperature{0.0f};
@@ -1356,7 +1356,7 @@ class ClimateCommandRequest : public ProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 48;
   static constexpr uint16_t ESTIMATED_SIZE = 83;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "climate_command_request"; }
+  const char *message_name() const override { return "climate_command_request"; }
 #endif
   uint32_t key{0};
   bool has_mode{false};
@@ -1397,7 +1397,7 @@ class ListEntitiesNumberResponse : public InfoResponseProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 49;
   static constexpr uint16_t ESTIMATED_SIZE = 84;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "list_entities_number_response"; }
+  const char *message_name() const override { return "list_entities_number_response"; }
 #endif
   float min_value{0.0f};
   float max_value{0.0f};
@@ -1421,7 +1421,7 @@ class NumberStateResponse : public StateResponseProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 50;
   static constexpr uint16_t ESTIMATED_SIZE = 12;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "number_state_response"; }
+  const char *message_name() const override { return "number_state_response"; }
 #endif
   float state{0.0f};
   bool missing_state{false};
@@ -1440,7 +1440,7 @@ class NumberCommandRequest : public ProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 51;
   static constexpr uint16_t ESTIMATED_SIZE = 10;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "number_command_request"; }
+  const char *message_name() const override { return "number_command_request"; }
 #endif
   uint32_t key{0};
   float state{0.0f};
@@ -1458,7 +1458,7 @@ class ListEntitiesSelectResponse : public InfoResponseProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 52;
   static constexpr uint16_t ESTIMATED_SIZE = 67;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "list_entities_select_response"; }
+  const char *message_name() const override { return "list_entities_select_response"; }
 #endif
   std::vector<std::string> options{};
   void encode(ProtoWriteBuffer buffer) const override;
@@ -1477,7 +1477,7 @@ class SelectStateResponse : public StateResponseProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 53;
   static constexpr uint16_t ESTIMATED_SIZE = 16;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "select_state_response"; }
+  const char *message_name() const override { return "select_state_response"; }
 #endif
   std::string state{};
   bool missing_state{false};
@@ -1497,7 +1497,7 @@ class SelectCommandRequest : public ProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 54;
   static constexpr uint16_t ESTIMATED_SIZE = 14;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "select_command_request"; }
+  const char *message_name() const override { return "select_command_request"; }
 #endif
   uint32_t key{0};
   std::string state{};
@@ -1516,7 +1516,7 @@ class ListEntitiesSirenResponse : public InfoResponseProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 55;
   static constexpr uint16_t ESTIMATED_SIZE = 71;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "list_entities_siren_response"; }
+  const char *message_name() const override { return "list_entities_siren_response"; }
 #endif
   std::vector<std::string> tones{};
   bool supports_duration{false};
@@ -1537,7 +1537,7 @@ class SirenStateResponse : public StateResponseProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 56;
   static constexpr uint16_t ESTIMATED_SIZE = 7;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "siren_state_response"; }
+  const char *message_name() const override { return "siren_state_response"; }
 #endif
   bool state{false};
   void encode(ProtoWriteBuffer buffer) const override;
@@ -1555,7 +1555,7 @@ class SirenCommandRequest : public ProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 57;
   static constexpr uint16_t ESTIMATED_SIZE = 33;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "siren_command_request"; }
+  const char *message_name() const override { return "siren_command_request"; }
 #endif
   uint32_t key{0};
   bool has_state{false};
@@ -1582,7 +1582,7 @@ class ListEntitiesLockResponse : public InfoResponseProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 58;
   static constexpr uint16_t ESTIMATED_SIZE = 64;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "list_entities_lock_response"; }
+  const char *message_name() const override { return "list_entities_lock_response"; }
 #endif
   bool assumed_state{false};
   bool supports_open{false};
@@ -1604,7 +1604,7 @@ class LockStateResponse : public StateResponseProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 59;
   static constexpr uint16_t ESTIMATED_SIZE = 7;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "lock_state_response"; }
+  const char *message_name() const override { return "lock_state_response"; }
 #endif
   enums::LockState state{};
   void encode(ProtoWriteBuffer buffer) const override;
@@ -1622,7 +1622,7 @@ class LockCommandRequest : public ProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 60;
   static constexpr uint16_t ESTIMATED_SIZE = 18;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "lock_command_request"; }
+  const char *message_name() const override { return "lock_command_request"; }
 #endif
   uint32_t key{0};
   enums::LockCommand command{};
@@ -1644,7 +1644,7 @@ class ListEntitiesButtonResponse : public InfoResponseProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 61;
   static constexpr uint16_t ESTIMATED_SIZE = 58;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "list_entities_button_response"; }
+  const char *message_name() const override { return "list_entities_button_response"; }
 #endif
   std::string device_class{};
   void encode(ProtoWriteBuffer buffer) const override;
@@ -1663,7 +1663,7 @@ class ButtonCommandRequest : public ProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 62;
   static constexpr uint16_t ESTIMATED_SIZE = 5;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "button_command_request"; }
+  const char *message_name() const override { return "button_command_request"; }
 #endif
   uint32_t key{0};
   void encode(ProtoWriteBuffer buffer) const override;
@@ -1697,7 +1697,7 @@ class ListEntitiesMediaPlayerResponse : public InfoResponseProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 63;
   static constexpr uint16_t ESTIMATED_SIZE = 85;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "list_entities_media_player_response"; }
+  const char *message_name() const override { return "list_entities_media_player_response"; }
 #endif
   bool supports_pause{false};
   std::vector<MediaPlayerSupportedFormat> supported_formats{};
@@ -1717,7 +1717,7 @@ class MediaPlayerStateResponse : public StateResponseProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 64;
   static constexpr uint16_t ESTIMATED_SIZE = 14;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "media_player_state_response"; }
+  const char *message_name() const override { return "media_player_state_response"; }
 #endif
   enums::MediaPlayerState state{};
   float volume{0.0f};
@@ -1737,7 +1737,7 @@ class MediaPlayerCommandRequest : public ProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 65;
   static constexpr uint16_t ESTIMATED_SIZE = 31;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "media_player_command_request"; }
+  const char *message_name() const override { return "media_player_command_request"; }
 #endif
   uint32_t key{0};
   bool has_command{false};
@@ -1764,7 +1764,7 @@ class SubscribeBluetoothLEAdvertisementsRequest : public ProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 66;
   static constexpr uint16_t ESTIMATED_SIZE = 4;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "subscribe_bluetooth_le_advertisements_request"; }
+  const char *message_name() const override { return "subscribe_bluetooth_le_advertisements_request"; }
 #endif
   uint32_t flags{0};
   void encode(ProtoWriteBuffer buffer) const override;
@@ -1796,7 +1796,7 @@ class BluetoothLEAdvertisementResponse : public ProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 67;
   static constexpr uint16_t ESTIMATED_SIZE = 107;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "bluetooth_le_advertisement_response"; }
+  const char *message_name() const override { return "bluetooth_le_advertisement_response"; }
 #endif
   uint64_t address{0};
   std::string name{};
@@ -1836,7 +1836,7 @@ class BluetoothLERawAdvertisementsResponse : public ProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 93;
   static constexpr uint16_t ESTIMATED_SIZE = 34;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "bluetooth_le_raw_advertisements_response"; }
+  const char *message_name() const override { return "bluetooth_le_raw_advertisements_response"; }
 #endif
   std::vector<BluetoothLERawAdvertisement> advertisements{};
   void encode(ProtoWriteBuffer buffer) const override;
@@ -1853,7 +1853,7 @@ class BluetoothDeviceRequest : public ProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 68;
   static constexpr uint16_t ESTIMATED_SIZE = 12;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "bluetooth_device_request"; }
+  const char *message_name() const override { return "bluetooth_device_request"; }
 #endif
   uint64_t address{0};
   enums::BluetoothDeviceRequestType request_type{};
@@ -1873,7 +1873,7 @@ class BluetoothDeviceConnectionResponse : public ProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 69;
   static constexpr uint16_t ESTIMATED_SIZE = 14;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "bluetooth_device_connection_response"; }
+  const char *message_name() const override { return "bluetooth_device_connection_response"; }
 #endif
   uint64_t address{0};
   bool connected{false};
@@ -1893,7 +1893,7 @@ class BluetoothGATTGetServicesRequest : public ProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 70;
   static constexpr uint16_t ESTIMATED_SIZE = 4;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "bluetooth_gatt_get_services_request"; }
+  const char *message_name() const override { return "bluetooth_gatt_get_services_request"; }
 #endif
   uint64_t address{0};
   void encode(ProtoWriteBuffer buffer) const override;
@@ -1954,7 +1954,7 @@ class BluetoothGATTGetServicesResponse : public ProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 71;
   static constexpr uint16_t ESTIMATED_SIZE = 38;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "bluetooth_gatt_get_services_response"; }
+  const char *message_name() const override { return "bluetooth_gatt_get_services_response"; }
 #endif
   uint64_t address{0};
   std::vector<BluetoothGATTService> services{};
@@ -1973,7 +1973,7 @@ class BluetoothGATTGetServicesDoneResponse : public ProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 72;
   static constexpr uint16_t ESTIMATED_SIZE = 4;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "bluetooth_gatt_get_services_done_response"; }
+  const char *message_name() const override { return "bluetooth_gatt_get_services_done_response"; }
 #endif
   uint64_t address{0};
   void encode(ProtoWriteBuffer buffer) const override;
@@ -1990,7 +1990,7 @@ class BluetoothGATTReadRequest : public ProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 73;
   static constexpr uint16_t ESTIMATED_SIZE = 8;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "bluetooth_gatt_read_request"; }
+  const char *message_name() const override { return "bluetooth_gatt_read_request"; }
 #endif
   uint64_t address{0};
   uint32_t handle{0};
@@ -2008,7 +2008,7 @@ class BluetoothGATTReadResponse : public ProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 74;
   static constexpr uint16_t ESTIMATED_SIZE = 17;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "bluetooth_gatt_read_response"; }
+  const char *message_name() const override { return "bluetooth_gatt_read_response"; }
 #endif
   uint64_t address{0};
   uint32_t handle{0};
@@ -2028,7 +2028,7 @@ class BluetoothGATTWriteRequest : public ProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 75;
   static constexpr uint16_t ESTIMATED_SIZE = 19;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "bluetooth_gatt_write_request"; }
+  const char *message_name() const override { return "bluetooth_gatt_write_request"; }
 #endif
   uint64_t address{0};
   uint32_t handle{0};
@@ -2049,7 +2049,7 @@ class BluetoothGATTReadDescriptorRequest : public ProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 76;
   static constexpr uint16_t ESTIMATED_SIZE = 8;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "bluetooth_gatt_read_descriptor_request"; }
+  const char *message_name() const override { return "bluetooth_gatt_read_descriptor_request"; }
 #endif
   uint64_t address{0};
   uint32_t handle{0};
@@ -2067,7 +2067,7 @@ class BluetoothGATTWriteDescriptorRequest : public ProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 77;
   static constexpr uint16_t ESTIMATED_SIZE = 17;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "bluetooth_gatt_write_descriptor_request"; }
+  const char *message_name() const override { return "bluetooth_gatt_write_descriptor_request"; }
 #endif
   uint64_t address{0};
   uint32_t handle{0};
@@ -2087,7 +2087,7 @@ class BluetoothGATTNotifyRequest : public ProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 78;
   static constexpr uint16_t ESTIMATED_SIZE = 10;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "bluetooth_gatt_notify_request"; }
+  const char *message_name() const override { return "bluetooth_gatt_notify_request"; }
 #endif
   uint64_t address{0};
   uint32_t handle{0};
@@ -2106,7 +2106,7 @@ class BluetoothGATTNotifyDataResponse : public ProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 79;
   static constexpr uint16_t ESTIMATED_SIZE = 17;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "bluetooth_gatt_notify_data_response"; }
+  const char *message_name() const override { return "bluetooth_gatt_notify_data_response"; }
 #endif
   uint64_t address{0};
   uint32_t handle{0};
@@ -2126,7 +2126,7 @@ class SubscribeBluetoothConnectionsFreeRequest : public ProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 80;
   static constexpr uint16_t ESTIMATED_SIZE = 0;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "subscribe_bluetooth_connections_free_request"; }
+  const char *message_name() const override { return "subscribe_bluetooth_connections_free_request"; }
 #endif
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
@@ -2139,7 +2139,7 @@ class BluetoothConnectionsFreeResponse : public ProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 81;
   static constexpr uint16_t ESTIMATED_SIZE = 16;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "bluetooth_connections_free_response"; }
+  const char *message_name() const override { return "bluetooth_connections_free_response"; }
 #endif
   uint32_t free{0};
   uint32_t limit{0};
@@ -2158,7 +2158,7 @@ class BluetoothGATTErrorResponse : public ProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 82;
   static constexpr uint16_t ESTIMATED_SIZE = 12;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "bluetooth_gatt_error_response"; }
+  const char *message_name() const override { return "bluetooth_gatt_error_response"; }
 #endif
   uint64_t address{0};
   uint32_t handle{0};
@@ -2177,7 +2177,7 @@ class BluetoothGATTWriteResponse : public ProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 83;
   static constexpr uint16_t ESTIMATED_SIZE = 8;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "bluetooth_gatt_write_response"; }
+  const char *message_name() const override { return "bluetooth_gatt_write_response"; }
 #endif
   uint64_t address{0};
   uint32_t handle{0};
@@ -2195,7 +2195,7 @@ class BluetoothGATTNotifyResponse : public ProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 84;
   static constexpr uint16_t ESTIMATED_SIZE = 8;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "bluetooth_gatt_notify_response"; }
+  const char *message_name() const override { return "bluetooth_gatt_notify_response"; }
 #endif
   uint64_t address{0};
   uint32_t handle{0};
@@ -2213,7 +2213,7 @@ class BluetoothDevicePairingResponse : public ProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 85;
   static constexpr uint16_t ESTIMATED_SIZE = 10;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "bluetooth_device_pairing_response"; }
+  const char *message_name() const override { return "bluetooth_device_pairing_response"; }
 #endif
   uint64_t address{0};
   bool paired{false};
@@ -2232,7 +2232,7 @@ class BluetoothDeviceUnpairingResponse : public ProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 86;
   static constexpr uint16_t ESTIMATED_SIZE = 10;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "bluetooth_device_unpairing_response"; }
+  const char *message_name() const override { return "bluetooth_device_unpairing_response"; }
 #endif
   uint64_t address{0};
   bool success{false};
@@ -2251,7 +2251,7 @@ class UnsubscribeBluetoothLEAdvertisementsRequest : public ProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 87;
   static constexpr uint16_t ESTIMATED_SIZE = 0;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "unsubscribe_bluetooth_le_advertisements_request"; }
+  const char *message_name() const override { return "unsubscribe_bluetooth_le_advertisements_request"; }
 #endif
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
@@ -2264,7 +2264,7 @@ class BluetoothDeviceClearCacheResponse : public ProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 88;
   static constexpr uint16_t ESTIMATED_SIZE = 10;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "bluetooth_device_clear_cache_response"; }
+  const char *message_name() const override { return "bluetooth_device_clear_cache_response"; }
 #endif
   uint64_t address{0};
   bool success{false};
@@ -2283,7 +2283,7 @@ class BluetoothScannerStateResponse : public ProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 126;
   static constexpr uint16_t ESTIMATED_SIZE = 4;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "bluetooth_scanner_state_response"; }
+  const char *message_name() const override { return "bluetooth_scanner_state_response"; }
 #endif
   enums::BluetoothScannerState state{};
   enums::BluetoothScannerMode mode{};
@@ -2301,7 +2301,7 @@ class BluetoothScannerSetModeRequest : public ProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 127;
   static constexpr uint16_t ESTIMATED_SIZE = 2;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "bluetooth_scanner_set_mode_request"; }
+  const char *message_name() const override { return "bluetooth_scanner_set_mode_request"; }
 #endif
   enums::BluetoothScannerMode mode{};
   void encode(ProtoWriteBuffer buffer) const override;
@@ -2318,7 +2318,7 @@ class SubscribeVoiceAssistantRequest : public ProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 89;
   static constexpr uint16_t ESTIMATED_SIZE = 6;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "subscribe_voice_assistant_request"; }
+  const char *message_name() const override { return "subscribe_voice_assistant_request"; }
 #endif
   bool subscribe{false};
   uint32_t flags{0};
@@ -2351,7 +2351,7 @@ class VoiceAssistantRequest : public ProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 90;
   static constexpr uint16_t ESTIMATED_SIZE = 41;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "voice_assistant_request"; }
+  const char *message_name() const override { return "voice_assistant_request"; }
 #endif
   bool start{false};
   std::string conversation_id{};
@@ -2373,7 +2373,7 @@ class VoiceAssistantResponse : public ProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 91;
   static constexpr uint16_t ESTIMATED_SIZE = 6;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "voice_assistant_response"; }
+  const char *message_name() const override { return "voice_assistant_response"; }
 #endif
   uint32_t port{0};
   bool error{false};
@@ -2404,7 +2404,7 @@ class VoiceAssistantEventResponse : public ProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 92;
   static constexpr uint16_t ESTIMATED_SIZE = 36;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "voice_assistant_event_response"; }
+  const char *message_name() const override { return "voice_assistant_event_response"; }
 #endif
   enums::VoiceAssistantEvent event_type{};
   std::vector<VoiceAssistantEventData> data{};
@@ -2423,7 +2423,7 @@ class VoiceAssistantAudio : public ProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 106;
   static constexpr uint16_t ESTIMATED_SIZE = 11;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "voice_assistant_audio"; }
+  const char *message_name() const override { return "voice_assistant_audio"; }
 #endif
   std::string data{};
   bool end{false};
@@ -2442,7 +2442,7 @@ class VoiceAssistantTimerEventResponse : public ProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 115;
   static constexpr uint16_t ESTIMATED_SIZE = 30;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "voice_assistant_timer_event_response"; }
+  const char *message_name() const override { return "voice_assistant_timer_event_response"; }
 #endif
   enums::VoiceAssistantTimerEvent event_type{};
   std::string timer_id{};
@@ -2465,7 +2465,7 @@ class VoiceAssistantAnnounceRequest : public ProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 119;
   static constexpr uint16_t ESTIMATED_SIZE = 29;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "voice_assistant_announce_request"; }
+  const char *message_name() const override { return "voice_assistant_announce_request"; }
 #endif
   std::string media_id{};
   std::string text{};
@@ -2486,7 +2486,7 @@ class VoiceAssistantAnnounceFinished : public ProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 120;
   static constexpr uint16_t ESTIMATED_SIZE = 2;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "voice_assistant_announce_finished"; }
+  const char *message_name() const override { return "voice_assistant_announce_finished"; }
 #endif
   bool success{false};
   void encode(ProtoWriteBuffer buffer) const override;
@@ -2517,7 +2517,7 @@ class VoiceAssistantConfigurationRequest : public ProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 121;
   static constexpr uint16_t ESTIMATED_SIZE = 0;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "voice_assistant_configuration_request"; }
+  const char *message_name() const override { return "voice_assistant_configuration_request"; }
 #endif
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
@@ -2530,7 +2530,7 @@ class VoiceAssistantConfigurationResponse : public ProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 122;
   static constexpr uint16_t ESTIMATED_SIZE = 56;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "voice_assistant_configuration_response"; }
+  const char *message_name() const override { return "voice_assistant_configuration_response"; }
 #endif
   std::vector<VoiceAssistantWakeWord> available_wake_words{};
   std::vector<std::string> active_wake_words{};
@@ -2550,7 +2550,7 @@ class VoiceAssistantSetConfiguration : public ProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 123;
   static constexpr uint16_t ESTIMATED_SIZE = 18;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "voice_assistant_set_configuration"; }
+  const char *message_name() const override { return "voice_assistant_set_configuration"; }
 #endif
   std::vector<std::string> active_wake_words{};
   void encode(ProtoWriteBuffer buffer) const override;
@@ -2567,7 +2567,7 @@ class ListEntitiesAlarmControlPanelResponse : public InfoResponseProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 94;
   static constexpr uint16_t ESTIMATED_SIZE = 57;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "list_entities_alarm_control_panel_response"; }
+  const char *message_name() const override { return "list_entities_alarm_control_panel_response"; }
 #endif
   uint32_t supported_features{0};
   bool requires_code{false};
@@ -2588,7 +2588,7 @@ class AlarmControlPanelStateResponse : public StateResponseProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 95;
   static constexpr uint16_t ESTIMATED_SIZE = 7;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "alarm_control_panel_state_response"; }
+  const char *message_name() const override { return "alarm_control_panel_state_response"; }
 #endif
   enums::AlarmControlPanelState state{};
   void encode(ProtoWriteBuffer buffer) const override;
@@ -2606,7 +2606,7 @@ class AlarmControlPanelCommandRequest : public ProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 96;
   static constexpr uint16_t ESTIMATED_SIZE = 16;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "alarm_control_panel_command_request"; }
+  const char *message_name() const override { return "alarm_control_panel_command_request"; }
 #endif
   uint32_t key{0};
   enums::AlarmControlPanelStateCommand command{};
@@ -2627,7 +2627,7 @@ class ListEntitiesTextResponse : public InfoResponseProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 97;
   static constexpr uint16_t ESTIMATED_SIZE = 68;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "list_entities_text_response"; }
+  const char *message_name() const override { return "list_entities_text_response"; }
 #endif
   uint32_t min_length{0};
   uint32_t max_length{0};
@@ -2649,7 +2649,7 @@ class TextStateResponse : public StateResponseProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 98;
   static constexpr uint16_t ESTIMATED_SIZE = 16;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "text_state_response"; }
+  const char *message_name() const override { return "text_state_response"; }
 #endif
   std::string state{};
   bool missing_state{false};
@@ -2669,7 +2669,7 @@ class TextCommandRequest : public ProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 99;
   static constexpr uint16_t ESTIMATED_SIZE = 14;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "text_command_request"; }
+  const char *message_name() const override { return "text_command_request"; }
 #endif
   uint32_t key{0};
   std::string state{};
@@ -2688,7 +2688,7 @@ class ListEntitiesDateResponse : public InfoResponseProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 100;
   static constexpr uint16_t ESTIMATED_SIZE = 49;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "list_entities_date_response"; }
+  const char *message_name() const override { return "list_entities_date_response"; }
 #endif
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(uint32_t &total_size) const override;
@@ -2706,7 +2706,7 @@ class DateStateResponse : public StateResponseProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 101;
   static constexpr uint16_t ESTIMATED_SIZE = 19;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "date_state_response"; }
+  const char *message_name() const override { return "date_state_response"; }
 #endif
   bool missing_state{false};
   uint32_t year{0};
@@ -2727,7 +2727,7 @@ class DateCommandRequest : public ProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 102;
   static constexpr uint16_t ESTIMATED_SIZE = 17;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "date_command_request"; }
+  const char *message_name() const override { return "date_command_request"; }
 #endif
   uint32_t key{0};
   uint32_t year{0};
@@ -2748,7 +2748,7 @@ class ListEntitiesTimeResponse : public InfoResponseProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 103;
   static constexpr uint16_t ESTIMATED_SIZE = 49;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "list_entities_time_response"; }
+  const char *message_name() const override { return "list_entities_time_response"; }
 #endif
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(uint32_t &total_size) const override;
@@ -2766,7 +2766,7 @@ class TimeStateResponse : public StateResponseProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 104;
   static constexpr uint16_t ESTIMATED_SIZE = 19;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "time_state_response"; }
+  const char *message_name() const override { return "time_state_response"; }
 #endif
   bool missing_state{false};
   uint32_t hour{0};
@@ -2787,7 +2787,7 @@ class TimeCommandRequest : public ProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 105;
   static constexpr uint16_t ESTIMATED_SIZE = 17;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "time_command_request"; }
+  const char *message_name() const override { return "time_command_request"; }
 #endif
   uint32_t key{0};
   uint32_t hour{0};
@@ -2808,7 +2808,7 @@ class ListEntitiesEventResponse : public InfoResponseProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 107;
   static constexpr uint16_t ESTIMATED_SIZE = 76;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "list_entities_event_response"; }
+  const char *message_name() const override { return "list_entities_event_response"; }
 #endif
   std::string device_class{};
   std::vector<std::string> event_types{};
@@ -2828,7 +2828,7 @@ class EventResponse : public StateResponseProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 108;
   static constexpr uint16_t ESTIMATED_SIZE = 14;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "event_response"; }
+  const char *message_name() const override { return "event_response"; }
 #endif
   std::string event_type{};
   void encode(ProtoWriteBuffer buffer) const override;
@@ -2846,7 +2846,7 @@ class ListEntitiesValveResponse : public InfoResponseProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 109;
   static constexpr uint16_t ESTIMATED_SIZE = 64;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "list_entities_valve_response"; }
+  const char *message_name() const override { return "list_entities_valve_response"; }
 #endif
   std::string device_class{};
   bool assumed_state{false};
@@ -2868,7 +2868,7 @@ class ValveStateResponse : public StateResponseProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 110;
   static constexpr uint16_t ESTIMATED_SIZE = 12;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "valve_state_response"; }
+  const char *message_name() const override { return "valve_state_response"; }
 #endif
   float position{0.0f};
   enums::ValveOperation current_operation{};
@@ -2887,7 +2887,7 @@ class ValveCommandRequest : public ProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 111;
   static constexpr uint16_t ESTIMATED_SIZE = 14;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "valve_command_request"; }
+  const char *message_name() const override { return "valve_command_request"; }
 #endif
   uint32_t key{0};
   bool has_position{false};
@@ -2908,7 +2908,7 @@ class ListEntitiesDateTimeResponse : public InfoResponseProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 112;
   static constexpr uint16_t ESTIMATED_SIZE = 49;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "list_entities_date_time_response"; }
+  const char *message_name() const override { return "list_entities_date_time_response"; }
 #endif
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(uint32_t &total_size) const override;
@@ -2926,7 +2926,7 @@ class DateTimeStateResponse : public StateResponseProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 113;
   static constexpr uint16_t ESTIMATED_SIZE = 12;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "date_time_state_response"; }
+  const char *message_name() const override { return "date_time_state_response"; }
 #endif
   bool missing_state{false};
   uint32_t epoch_seconds{0};
@@ -2945,7 +2945,7 @@ class DateTimeCommandRequest : public ProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 114;
   static constexpr uint16_t ESTIMATED_SIZE = 10;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "date_time_command_request"; }
+  const char *message_name() const override { return "date_time_command_request"; }
 #endif
   uint32_t key{0};
   uint32_t epoch_seconds{0};
@@ -2963,7 +2963,7 @@ class ListEntitiesUpdateResponse : public InfoResponseProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 116;
   static constexpr uint16_t ESTIMATED_SIZE = 58;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "list_entities_update_response"; }
+  const char *message_name() const override { return "list_entities_update_response"; }
 #endif
   std::string device_class{};
   void encode(ProtoWriteBuffer buffer) const override;
@@ -2982,7 +2982,7 @@ class UpdateStateResponse : public StateResponseProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 117;
   static constexpr uint16_t ESTIMATED_SIZE = 61;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "update_state_response"; }
+  const char *message_name() const override { return "update_state_response"; }
 #endif
   bool missing_state{false};
   bool in_progress{false};
@@ -3009,7 +3009,7 @@ class UpdateCommandRequest : public ProtoMessage {
   static constexpr uint16_t MESSAGE_TYPE = 118;
   static constexpr uint16_t ESTIMATED_SIZE = 7;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  static constexpr const char *message_name() { return "update_command_request"; }
+  const char *message_name() const override { return "update_command_request"; }
 #endif
   uint32_t key{0};
   enums::UpdateCommand command{};

--- a/esphome/components/api/api_pb2_service.h
+++ b/esphome/components/api/api_pb2_service.h
@@ -19,7 +19,7 @@ class APIServerConnectionBase : public ProtoService {
 
   template<typename T> bool send_message(const T &msg) {
 #ifdef HAS_PROTO_MESSAGE_DUMP
-    this->log_send_message_(T::message_name(), msg.dump());
+    this->log_send_message_(msg.message_name(), msg.dump());
 #endif
     return this->send_message_(msg, T::MESSAGE_TYPE);
   }

--- a/esphome/components/api/proto.h
+++ b/esphome/components/api/proto.h
@@ -335,7 +335,7 @@ class ProtoMessage {
 #ifdef HAS_PROTO_MESSAGE_DUMP
   std::string dump() const;
   virtual void dump_to(std::string &out) const = 0;
-  virtual const char *message_name() const = 0;
+  virtual const char *message_name() const { return "unknown"; }
 #endif
 
  protected:

--- a/esphome/components/api/proto.h
+++ b/esphome/components/api/proto.h
@@ -335,6 +335,7 @@ class ProtoMessage {
 #ifdef HAS_PROTO_MESSAGE_DUMP
   std::string dump() const;
   virtual void dump_to(std::string &out) const = 0;
+  virtual const char *message_name() const = 0;
 #endif
 
  protected:

--- a/script/api_protobuf/api_protobuf.py
+++ b/script/api_protobuf/api_protobuf.py
@@ -886,7 +886,7 @@ def build_message_type(
         public_content.append("#ifdef HAS_PROTO_MESSAGE_DUMP")
         snake_name = camel_to_snake(desc.name)
         public_content.append(
-            f'static constexpr const char *message_name() {{ return "{snake_name}"; }}'
+            f'const char *message_name() const override {{ return "{snake_name}"; }}'
         )
         public_content.append("#endif")
 
@@ -1356,7 +1356,7 @@ def main() -> None:
     hpp += "  template<typename T>\n"
     hpp += "  bool send_message(const T &msg) {\n"
     hpp += "#ifdef HAS_PROTO_MESSAGE_DUMP\n"
-    hpp += "    this->log_send_message_(T::message_name(), msg.dump());\n"
+    hpp += "    this->log_send_message_(msg.message_name(), msg.dump());\n"
     hpp += "#endif\n"
     hpp += "    return this->send_message_(msg, T::MESSAGE_TYPE);\n"
     hpp += "  }\n\n"


### PR DESCRIPTION

# What does this implement/fix?

Fix missing protobuf message dump for batched messages with very verbose logging

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
