### PR TITLE
Optimize Application class memory layout and reduce loop_interval size

### DIFF
--- a/esphome/core/application.h
+++ b/esphome/core/application.h
@@ -337,6 +337,9 @@ class Application {
    * Each component can request a high frequency loop execution by using the HighFrequencyLoopRequester
    * helper in helpers.h
    *
+   * Note: This method is not called by ESPHome core code. It is only used by lambda functions
+   * in YAML configurations or by external components.
+   *
    * @param loop_interval The interval in milliseconds to run the core loop at. Defaults to 16 milliseconds.
    */
   void set_loop_interval(uint32_t loop_interval) {

--- a/esphome/core/application.h
+++ b/esphome/core/application.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <algorithm>
+#include <limits>
 #include <string>
 #include <vector>
 #include "esphome/core/component.h"
@@ -337,9 +339,11 @@ class Application {
    *
    * @param loop_interval The interval in milliseconds to run the core loop at. Defaults to 16 milliseconds.
    */
-  void set_loop_interval(uint32_t loop_interval) { this->loop_interval_ = loop_interval; }
+  void set_loop_interval(uint32_t loop_interval) {
+    this->loop_interval_ = std::min(loop_interval, static_cast<uint32_t>(std::numeric_limits<uint16_t>::max()));
+  }
 
-  uint32_t get_loop_interval() const { return this->loop_interval_; }
+  uint32_t get_loop_interval() const { return static_cast<uint32_t>(this->loop_interval_); }
 
   void schedule_dump_config() { this->dump_config_at_ = 0; }
 
@@ -618,6 +622,17 @@ class Application {
   /// Perform a delay while also monitoring socket file descriptors for readiness
   void yield_with_select_(uint32_t delay_ms);
 
+  // === Member variables ordered by size to minimize padding ===
+
+  // Pointer-sized members first
+  Component *current_component_{nullptr};
+  const char *comment_{nullptr};
+  const char *compilation_time_{nullptr};
+
+  // size_t members
+  size_t dump_config_at_{SIZE_MAX};
+
+  // Vectors (largest members)
   std::vector<Component *> components_{};
 
   // Partitioned vector design for looping components
@@ -637,11 +652,6 @@ class Application {
   //   and active_end_ is incremented
   // - This eliminates branch mispredictions from flag checking in the hot loop
   std::vector<Component *> looping_components_{};
-  uint16_t looping_components_active_end_{0};
-
-  // For safe reentrant modifications during iteration
-  uint16_t current_loop_index_{0};
-  bool in_loop_{false};
 
 #ifdef USE_DEVICES
   std::vector<Device *> devices_{};
@@ -713,26 +723,39 @@ class Application {
   std::vector<update::UpdateEntity *> updates_{};
 #endif
 
+#ifdef USE_SOCKET_SELECT_SUPPORT
+  std::vector<int> socket_fds_;  // Vector of all monitored socket file descriptors
+#endif
+
+  // String members
   std::string name_;
   std::string friendly_name_;
-  const char *comment_{nullptr};
-  const char *compilation_time_{nullptr};
-  bool name_add_mac_suffix_;
+
+  // 4-byte members
   uint32_t last_loop_{0};
-  uint32_t loop_interval_{16};
-  size_t dump_config_at_{SIZE_MAX};
-  uint8_t app_state_{0};
-  volatile bool has_pending_enable_loop_requests_{false};
-  Component *current_component_{nullptr};
   uint32_t loop_component_start_time_{0};
 
 #ifdef USE_SOCKET_SELECT_SUPPORT
-  // Socket select management
-  std::vector<int> socket_fds_;     // Vector of all monitored socket file descriptors
+  int max_fd_{-1};  // Highest file descriptor number for select()
+#endif
+
+  // 2-byte members (grouped together for alignment)
+  uint16_t loop_interval_{16};  // Loop interval in ms (max 65535ms = 65.5 seconds)
+  uint16_t looping_components_active_end_{0};
+  uint16_t current_loop_index_{0};  // For safe reentrant modifications during iteration
+
+  // 1-byte members (grouped together to minimize padding)
+  uint8_t app_state_{0};
+  bool name_add_mac_suffix_;
+  bool in_loop_{false};
+  volatile bool has_pending_enable_loop_requests_{false};
+
+#ifdef USE_SOCKET_SELECT_SUPPORT
   bool socket_fds_changed_{false};  // Flag to rebuild base_read_fds_ when socket_fds_ changes
-  int max_fd_{-1};                  // Highest file descriptor number for select()
-  fd_set base_read_fds_{};          // Cached fd_set rebuilt only when socket_fds_ changes
-  fd_set read_fds_{};               // Working fd_set for select(), copied from base_read_fds_
+
+  // Variable-sized members at end
+  fd_set base_read_fds_{};  // Cached fd_set rebuilt only when socket_fds_ changes
+  fd_set read_fds_{};       // Working fd_set for select(), copied from base_read_fds_
 #endif
 };
 


### PR DESCRIPTION
replaces https://github.com/esphome/esphome/pull/9086 since I closed that because there were conflicts

# What does this implement/fix?

This PR optimizes the memory layout of the Application class to reduce padding on 32-bit systems and reduces memory usage by right-sizing the `loop_interval_` member.

The changes:
1. Reorder class members by size (pointers → size_t → vectors → strings → 4-byte → 2-byte → 1-byte) to eliminate alignment padding
2. Change `loop_interval_` from `uint32_t` to `uint16_t` since loop intervals above 65.5 seconds are not practical
3. Add clamping to ensure values above 65535ms are limited to the maximum

This saves approximately 12-15 bytes per Application instance on 32-bit systems through better alignment and type sizing.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Memory optimization for ESP8266 and other memory-constrained devices

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- Not required - internal optimization only

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# No configuration changes required
# Note: loop_interval can still be set via lambdas but is now limited to 65535ms maximum

esphome:
  on_boot:
    - lambda: |-
        // This still works as before
        App.set_loop_interval(100);  // 100ms
        
        // Values above 65535 are now clamped
        App.set_loop_interval(100000);  // Will be set to 65535ms
```

## Breaking Change Notes

The maximum `loop_interval` is now limited to 65535ms (65.5 seconds) instead of ~4.3 billion milliseconds. This is unlikely to affect any real-world usage as:
- The default is 16ms
- Users typically decrease this value for faster loops, not increase it
- A 65-second loop interval would make the device essentially unresponsive
- The change only affects lambdas that call `App.set_loop_interval()` with values > 65535

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).