### PR TITLE
[ld2450] Move consts to cpp file, optimize memory use

### DIFF
--- a/esphome/components/ld2450/ld2450.cpp
+++ b/esphome/components/ld2450/ld2450.cpp
@@ -21,20 +21,44 @@ static const char *const NO_MAC = "08:05:04:03:02:01";
 static const char *const UNKNOWN_MAC = "unknown";
 static const char *const VERSION_FMT = "%u.%02X.%02X%02X%02X%02X";
 
+// Convert baud rate enum to int
+static const std::map<std::string, uint8_t> BAUD_RATE_ENUM_TO_INT{
+    {"9600", BAUD_RATE_9600},     {"19200", BAUD_RATE_19200},   {"38400", BAUD_RATE_38400},
+    {"57600", BAUD_RATE_57600},   {"115200", BAUD_RATE_115200}, {"230400", BAUD_RATE_230400},
+    {"256000", BAUD_RATE_256000}, {"460800", BAUD_RATE_460800},
+};
+
+// Convert zone type int to enum
+static const std::map<ZoneTypeStructure, std::string> ZONE_TYPE_INT_TO_ENUM{
+    {ZONE_DISABLED, "Disabled"},
+    {ZONE_DETECTION, "Detection"},
+    {ZONE_FILTER, "Filter"},
+};
+
+// Convert zone type enum to int
+static const std::map<std::string, uint8_t> ZONE_TYPE_ENUM_TO_INT{
+    {"Disabled", ZONE_DISABLED},
+    {"Detection", ZONE_DETECTION},
+    {"Filter", ZONE_FILTER},
+};
+
+// LD2450 serial command header & footer
+static const uint8_t CMD_FRAME_HEADER[4] = {0xFD, 0xFC, 0xFB, 0xFA};
+static const uint8_t CMD_FRAME_END[4] = {0x04, 0x03, 0x02, 0x01};
 // LD2450 UART Serial Commands
-static const uint8_t CMD_ENABLE_CONF = 0x00FF;
-static const uint8_t CMD_DISABLE_CONF = 0x00FE;
-static const uint8_t CMD_VERSION = 0x00A0;
-static const uint8_t CMD_MAC = 0x00A5;
-static const uint8_t CMD_RESET = 0x00A2;
-static const uint8_t CMD_RESTART = 0x00A3;
-static const uint8_t CMD_BLUETOOTH = 0x00A4;
-static const uint8_t CMD_SINGLE_TARGET_MODE = 0x0080;
-static const uint8_t CMD_MULTI_TARGET_MODE = 0x0090;
-static const uint8_t CMD_QUERY_TARGET_MODE = 0x0091;
-static const uint8_t CMD_SET_BAUD_RATE = 0x00A1;
-static const uint8_t CMD_QUERY_ZONE = 0x00C1;
-static const uint8_t CMD_SET_ZONE = 0x00C2;
+static const uint8_t CMD_ENABLE_CONF = 0xFF;
+static const uint8_t CMD_DISABLE_CONF = 0xFE;
+static const uint8_t CMD_VERSION = 0xA0;
+static const uint8_t CMD_MAC = 0xA5;
+static const uint8_t CMD_RESET = 0xA2;
+static const uint8_t CMD_RESTART = 0xA3;
+static const uint8_t CMD_BLUETOOTH = 0xA4;
+static const uint8_t CMD_SINGLE_TARGET_MODE = 0x80;
+static const uint8_t CMD_MULTI_TARGET_MODE = 0x90;
+static const uint8_t CMD_QUERY_TARGET_MODE = 0x91;
+static const uint8_t CMD_SET_BAUD_RATE = 0xA1;
+static const uint8_t CMD_QUERY_ZONE = 0xC1;
+static const uint8_t CMD_SET_ZONE = 0xC2;
 
 static inline uint16_t convert_seconds_to_ms(uint16_t value) { return value * 1000; };
 

--- a/esphome/components/ld2450/ld2450.cpp
+++ b/esphome/components/ld2450/ld2450.cpp
@@ -21,26 +21,87 @@ static const char *const NO_MAC = "08:05:04:03:02:01";
 static const char *const UNKNOWN_MAC = "unknown";
 static const char *const VERSION_FMT = "%u.%02X.%02X%02X%02X%02X";
 
-// Convert baud rate enum to int
-static const std::map<std::string, uint8_t> BAUD_RATE_ENUM_TO_INT{
+enum BaudRateStructure : uint8_t {
+  BAUD_RATE_9600 = 1,
+  BAUD_RATE_19200 = 2,
+  BAUD_RATE_38400 = 3,
+  BAUD_RATE_57600 = 4,
+  BAUD_RATE_115200 = 5,
+  BAUD_RATE_230400 = 6,
+  BAUD_RATE_256000 = 7,
+  BAUD_RATE_460800 = 8
+};
+
+// Zone type struct
+enum ZoneTypeStructure : uint8_t {
+  ZONE_DISABLED = 0,
+  ZONE_DETECTION = 1,
+  ZONE_FILTER = 2,
+};
+
+enum PeriodicDataStructure : uint8_t {
+  TARGET_X = 4,
+  TARGET_Y = 6,
+  TARGET_SPEED = 8,
+  TARGET_RESOLUTION = 10,
+};
+
+enum PeriodicDataValue : uint8_t {
+  HEAD = 0xAA,
+  END = 0x55,
+  CHECK = 0x00,
+};
+
+enum AckDataStructure : uint8_t {
+  COMMAND = 6,
+  COMMAND_STATUS = 7,
+};
+
+// Memory-efficient lookup tables
+struct StringToUint8 {
+  const char *str;
+  uint8_t value;
+};
+
+struct Uint8ToString {
+  uint8_t value;
+  const char *str;
+};
+
+constexpr StringToUint8 BAUD_RATES_BY_STR[] = {
     {"9600", BAUD_RATE_9600},     {"19200", BAUD_RATE_19200},   {"38400", BAUD_RATE_38400},
     {"57600", BAUD_RATE_57600},   {"115200", BAUD_RATE_115200}, {"230400", BAUD_RATE_230400},
     {"256000", BAUD_RATE_256000}, {"460800", BAUD_RATE_460800},
 };
 
-// Convert zone type int to enum
-static const std::map<ZoneTypeStructure, std::string> ZONE_TYPE_INT_TO_ENUM{
+constexpr Uint8ToString ZONE_TYPE_BY_UINT[] = {
     {ZONE_DISABLED, "Disabled"},
     {ZONE_DETECTION, "Detection"},
     {ZONE_FILTER, "Filter"},
 };
 
-// Convert zone type enum to int
-static const std::map<std::string, uint8_t> ZONE_TYPE_ENUM_TO_INT{
+constexpr StringToUint8 ZONE_TYPE_BY_STR[] = {
     {"Disabled", ZONE_DISABLED},
     {"Detection", ZONE_DETECTION},
     {"Filter", ZONE_FILTER},
 };
+
+// Helper functions for lookups
+template<size_t N> uint8_t find_uint8(const StringToUint8 (&arr)[N], const std::string &str) {
+  for (const auto &entry : arr) {
+    if (str == entry.str)
+      return entry.value;
+  }
+  return 0xFF;  // Not found
+}
+
+template<size_t N> const char *find_str(const Uint8ToString (&arr)[N], uint8_t value) {
+  for (const auto &entry : arr) {
+    if (value == entry.value)
+      return entry.str;
+  }
+  return "";  // Not found
+}
 
 // LD2450 serial command header & footer
 static const uint8_t CMD_FRAME_HEADER[4] = {0xFD, 0xFC, 0xFB, 0xFA};
@@ -744,7 +805,7 @@ void LD2450Component::set_bluetooth(bool enable) {
 // Set Baud rate
 void LD2450Component::set_baud_rate(const std::string &state) {
   this->set_config_mode_(true);
-  uint8_t cmd_value[2] = {BAUD_RATE_ENUM_TO_INT.at(state), 0x00};
+  uint8_t cmd_value[2] = {find_uint8(BAUD_RATES_BY_STR, state), 0x00};
   this->send_command_(CMD_SET_BAUD_RATE, cmd_value, 2);
   this->set_timeout(200, [this]() { this->restart_(); });
 }
@@ -752,7 +813,7 @@ void LD2450Component::set_baud_rate(const std::string &state) {
 // Set Zone Type - one of: Disabled, Detection, Filter
 void LD2450Component::set_zone_type(const std::string &state) {
   ESP_LOGV(TAG, "Set zone type: %s", state.c_str());
-  uint8_t zone_type = ZONE_TYPE_ENUM_TO_INT.at(state);
+  uint8_t zone_type = find_uint8(ZONE_TYPE_BY_STR, state);
   this->zone_type_ = zone_type;
   this->send_set_zone_command_();
 }
@@ -760,7 +821,7 @@ void LD2450Component::set_zone_type(const std::string &state) {
 // Publish Zone Type to Select component
 void LD2450Component::publish_zone_type() {
 #ifdef USE_SELECT
-  std::string zone_type = ZONE_TYPE_INT_TO_ENUM.at(static_cast<ZoneTypeStructure>(this->zone_type_));
+  std::string zone_type = find_str(ZONE_TYPE_BY_UINT, this->zone_type_);
   if (this->zone_type_select_ != nullptr) {
     this->zone_type_select_->publish_state(zone_type);
   }

--- a/esphome/components/ld2450/ld2450.h
+++ b/esphome/components/ld2450/ld2450.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <iomanip>
-#include <map>
 #include "esphome/components/uart/uart.h"
 #include "esphome/core/component.h"
 #include "esphome/core/defines.h"
@@ -65,35 +63,6 @@ struct ZoneOfNumbers {
   number::Number *y2 = nullptr;
 };
 #endif
-
-enum BaudRateStructure : uint8_t {
-  BAUD_RATE_9600 = 1,
-  BAUD_RATE_19200 = 2,
-  BAUD_RATE_38400 = 3,
-  BAUD_RATE_57600 = 4,
-  BAUD_RATE_115200 = 5,
-  BAUD_RATE_230400 = 6,
-  BAUD_RATE_256000 = 7,
-  BAUD_RATE_460800 = 8
-};
-
-// Zone type struct
-enum ZoneTypeStructure : uint8_t {
-  ZONE_DISABLED = 0,
-  ZONE_DETECTION = 1,
-  ZONE_FILTER = 2,
-};
-
-enum PeriodicDataStructure : uint8_t {
-  TARGET_X = 4,
-  TARGET_Y = 6,
-  TARGET_SPEED = 8,
-  TARGET_RESOLUTION = 10,
-};
-
-enum PeriodicDataValue : uint8_t { HEAD = 0xAA, END = 0x55, CHECK = 0x00 };
-
-enum AckDataStructure : uint8_t { COMMAND = 6, COMMAND_STATUS = 7 };
 
 class LD2450Component : public Component, public uart::UARTDevice {
 #ifdef USE_SENSOR

--- a/esphome/components/ld2450/ld2450.h
+++ b/esphome/components/ld2450/ld2450.h
@@ -77,26 +77,12 @@ enum BaudRateStructure : uint8_t {
   BAUD_RATE_460800 = 8
 };
 
-// Convert baud rate enum to int
-static const std::map<std::string, uint8_t> BAUD_RATE_ENUM_TO_INT{
-    {"9600", BAUD_RATE_9600},     {"19200", BAUD_RATE_19200},   {"38400", BAUD_RATE_38400},
-    {"57600", BAUD_RATE_57600},   {"115200", BAUD_RATE_115200}, {"230400", BAUD_RATE_230400},
-    {"256000", BAUD_RATE_256000}, {"460800", BAUD_RATE_460800}};
-
 // Zone type struct
-enum ZoneTypeStructure : uint8_t { ZONE_DISABLED = 0, ZONE_DETECTION = 1, ZONE_FILTER = 2 };
-
-// Convert zone type int to enum
-static const std::map<ZoneTypeStructure, std::string> ZONE_TYPE_INT_TO_ENUM{
-    {ZONE_DISABLED, "Disabled"}, {ZONE_DETECTION, "Detection"}, {ZONE_FILTER, "Filter"}};
-
-// Convert zone type enum to int
-static const std::map<std::string, uint8_t> ZONE_TYPE_ENUM_TO_INT{
-    {"Disabled", ZONE_DISABLED}, {"Detection", ZONE_DETECTION}, {"Filter", ZONE_FILTER}};
-
-// LD2450 serial command header & footer
-static const uint8_t CMD_FRAME_HEADER[4] = {0xFD, 0xFC, 0xFB, 0xFA};
-static const uint8_t CMD_FRAME_END[4] = {0x04, 0x03, 0x02, 0x01};
+enum ZoneTypeStructure : uint8_t {
+  ZONE_DISABLED = 0,
+  ZONE_DETECTION = 1,
+  ZONE_FILTER = 2,
+};
 
 enum PeriodicDataStructure : uint8_t {
   TARGET_X = 4,


### PR DESCRIPTION
# What does this implement/fix?

Before:
```
RAM:   [=         ]  15.0% (used 49064 bytes from 327680 bytes)
Flash: [========= ]  89.6% (used 1644048 bytes from 1835008 bytes)
```
After:
```
RAM:   [=         ]  14.8% (used 48552 bytes from 327680 bytes)
Flash: [========= ]  89.3% (used 1639238 bytes from 1835008 bytes)
```

EDIT:

With changes from #9209 to eliminate `map`, we have:

```
RAM:   [=         ]  14.8% (used 48488 bytes from 327680 bytes)
Flash: [========= ]  89.3% (used 1637858 bytes from 1835008 bytes)
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
