### PR TITLE
[ld2420] Move consts to cpp file, optimize memory use

### DIFF
--- a/esphome/components/ld2420/ld2420.cpp
+++ b/esphome/components/ld2420/ld2420.cpp
@@ -63,20 +63,137 @@ namespace ld2420 {
 
 static const char *const TAG = "ld2420";
 
+// Local const's
+static const uint16_t REFRESH_RATE_MS = 1000;
+
+// Command sets
+static const uint16_t CMD_DISABLE_CONF = 0x00FE;
+static const uint16_t CMD_ENABLE_CONF = 0x00FF;
+static const uint16_t CMD_PARM_HIGH_TRESH = 0x0012;
+static const uint16_t CMD_PARM_LOW_TRESH = 0x0021;
+static const uint16_t CMD_PROTOCOL_VER = 0x0002;
+static const uint16_t CMD_READ_ABD_PARAM = 0x0008;
+static const uint16_t CMD_READ_REG_ADDR = 0x0020;
+static const uint16_t CMD_READ_REGISTER = 0x0002;
+static const uint16_t CMD_READ_SERIAL_NUM = 0x0011;
+static const uint16_t CMD_READ_SYS_PARAM = 0x0013;
+static const uint16_t CMD_READ_VERSION = 0x0000;
+static const uint16_t CMD_RESTART = 0x0068;
+static const uint16_t CMD_SYSTEM_MODE = 0x0000;
+static const uint16_t CMD_SYSTEM_MODE_GR = 0x0003;
+static const uint16_t CMD_SYSTEM_MODE_MTT = 0x0001;
+static const uint16_t CMD_SYSTEM_MODE_SIMPLE = 0x0064;
+static const uint16_t CMD_SYSTEM_MODE_DEBUG = 0x0000;
+static const uint16_t CMD_SYSTEM_MODE_ENERGY = 0x0004;
+static const uint16_t CMD_SYSTEM_MODE_VS = 0x0002;
+static const uint16_t CMD_WRITE_ABD_PARAM = 0x0007;
+static const uint16_t CMD_WRITE_REGISTER = 0x0001;
+static const uint16_t CMD_WRITE_SYS_PARAM = 0x0012;
+
+static const uint8_t CMD_ABD_DATA_REPLY_SIZE = 0x04;
+static const uint8_t CMD_ABD_DATA_REPLY_START = 0x0A;
+static const uint8_t CMD_MAX_BYTES = 0x64;
+static const uint8_t CMD_REG_DATA_REPLY_SIZE = 0x02;
+
+static const uint8_t LD2420_ERROR_NONE = 0x00;
+static const uint8_t LD2420_ERROR_TIMEOUT = 0x02;
+static const uint8_t LD2420_ERROR_UNKNOWN = 0x01;
+
+// Register address values
+static const uint16_t CMD_MIN_GATE_REG = 0x0000;
+static const uint16_t CMD_MAX_GATE_REG = 0x0001;
+static const uint16_t CMD_TIMEOUT_REG = 0x0004;
+static const uint16_t CMD_GATE_MOVE_THRESH[TOTAL_GATES] = {0x0010, 0x0011, 0x0012, 0x0013, 0x0014, 0x0015,
+                                                           0x0016, 0x0017, 0x0018, 0x0019, 0x001A, 0x001B,
+                                                           0x001C, 0x001D, 0x001E, 0x001F};
+static const uint16_t CMD_GATE_STILL_THRESH[TOTAL_GATES] = {0x0020, 0x0021, 0x0022, 0x0023, 0x0024, 0x0025,
+                                                            0x0026, 0x0027, 0x0028, 0x0029, 0x002A, 0x002B,
+                                                            0x002C, 0x002D, 0x002E, 0x002F};
+static const uint32_t FACTORY_MOVE_THRESH[TOTAL_GATES] = {60000, 30000, 400, 250, 250, 250, 250, 250,
+                                                          250,   250,   250, 250, 250, 250, 250, 250};
+static const uint32_t FACTORY_STILL_THRESH[TOTAL_GATES] = {40000, 20000, 200, 200, 200, 200, 200, 150,
+                                                           150,   100,   100, 100, 100, 100, 100, 100};
+static const uint16_t FACTORY_TIMEOUT = 120;
+static const uint16_t FACTORY_MIN_GATE = 1;
+static const uint16_t FACTORY_MAX_GATE = 12;
+
+// COMMAND_BYTE Header & Footer
+static const uint32_t CMD_FRAME_FOOTER = 0x01020304;
+static const uint32_t CMD_FRAME_HEADER = 0xFAFBFCFD;
+static const uint32_t DEBUG_FRAME_FOOTER = 0xFAFBFCFD;
+static const uint32_t DEBUG_FRAME_HEADER = 0x1410BFAA;
+static const uint32_t ENERGY_FRAME_FOOTER = 0xF5F6F7F8;
+static const uint32_t ENERGY_FRAME_HEADER = 0xF1F2F3F4;
+static const int CALIBRATE_VERSION_MIN = 154;
+static const uint8_t CMD_FRAME_COMMAND = 6;
+static const uint8_t CMD_FRAME_DATA_LENGTH = 4;
+static const uint8_t CMD_FRAME_STATUS = 7;
+static const uint8_t CMD_ERROR_WORD = 8;
+static const uint8_t ENERGY_SENSOR_START = 9;
+static const uint8_t CALIBRATE_REPORT_INTERVAL = 4;
+static const std::string OP_NORMAL_MODE_STRING = "Normal";
+static const std::string OP_SIMPLE_MODE_STRING = "Simple";
+
+// Memory-efficient lookup tables
+struct StringToUint8 {
+  const char *str;
+  uint8_t value;
+};
+
+static constexpr StringToUint8 OP_MODE_BY_STR[] = {
+    {"Normal", OP_NORMAL_MODE},
+    {"Calibrate", OP_CALIBRATE_MODE},
+    {"Simple", OP_SIMPLE_MODE},
+};
+
+static constexpr const char *ERR_MESSAGE[] = {
+    "None",
+    "Unknown",
+    "Timeout",
+};
+
+// Helper function for lookups
+template<size_t N> uint8_t find_uint8(const StringToUint8 (&arr)[N], const std::string &str) {
+  for (const auto &entry : arr) {
+    if (str == entry.str)
+      return entry.value;
+  }
+  return 0xFF;  // Not found
+}
+
+static uint8_t calc_checksum(void *data, size_t size) {
+  uint8_t checksum = 0;
+  uint8_t *data_bytes = (uint8_t *) data;
+  for (size_t i = 0; i < size; i++) {
+    checksum ^= data_bytes[i];  // XOR operation
+  }
+  return checksum;
+}
+
+static int get_firmware_int(const char *version_string) {
+  std::string version_str = version_string;
+  if (version_str[0] == 'v') {
+    version_str = version_str.substr(1);
+  }
+  version_str.erase(remove(version_str.begin(), version_str.end(), '.'), version_str.end());
+  int version_integer = stoi(version_str);
+  return version_integer;
+}
+
 float LD2420Component::get_setup_priority() const { return setup_priority::BUS; }
 
 void LD2420Component::dump_config() {
   ESP_LOGCONFIG(TAG,
                 "LD2420:\n"
                 "  Firmware version: %7s",
-                this->ld2420_firmware_ver_);
+                this->firmware_ver_);
 #ifdef USE_NUMBER
   ESP_LOGCONFIG(TAG, "Number:");
   LOG_NUMBER(TAG, "  Gate Timeout:", this->gate_timeout_number_);
   LOG_NUMBER(TAG, "  Gate Max Distance:", this->max_gate_distance_number_);
   LOG_NUMBER(TAG, "  Gate Min Distance:", this->min_gate_distance_number_);
   LOG_NUMBER(TAG, "  Gate Select:", this->gate_select_number_);
-  for (uint8_t gate = 0; gate < LD2420_TOTAL_GATES; gate++) {
+  for (uint8_t gate = 0; gate < TOTAL_GATES; gate++) {
     LOG_NUMBER(TAG, "  Gate Move Threshold:", this->gate_move_threshold_numbers_[gate]);
     LOG_NUMBER(TAG, "  Gate Still Threshold::", this->gate_still_threshold_numbers_[gate]);
   }
@@ -89,28 +206,9 @@ void LD2420Component::dump_config() {
 #endif
   ESP_LOGCONFIG(TAG, "Select:");
   LOG_SELECT(TAG, "  Operating Mode", this->operating_selector_);
-  if (LD2420Component::get_firmware_int(this->ld2420_firmware_ver_) < CALIBRATE_VERSION_MIN) {
-    ESP_LOGW(TAG, "Firmware version %s and older supports Simple Mode only", this->ld2420_firmware_ver_);
+  if (ld2420::get_firmware_int(this->firmware_ver_) < CALIBRATE_VERSION_MIN) {
+    ESP_LOGW(TAG, "Firmware version %s and older supports Simple Mode only", this->firmware_ver_);
   }
-}
-
-uint8_t LD2420Component::calc_checksum(void *data, size_t size) {
-  uint8_t checksum = 0;
-  uint8_t *data_bytes = (uint8_t *) data;
-  for (size_t i = 0; i < size; i++) {
-    checksum ^= data_bytes[i];  // XOR operation
-  }
-  return checksum;
-}
-
-int LD2420Component::get_firmware_int(const char *version_string) {
-  std::string version_str = version_string;
-  if (version_str[0] == 'v') {
-    version_str = version_str.substr(1);
-  }
-  version_str.erase(remove(version_str.begin(), version_str.end(), '.'), version_str.end());
-  int version_integer = stoi(version_str);
-  return version_integer;
 }
 
 void LD2420Component::setup() {
@@ -125,24 +223,24 @@ void LD2420Component::setup() {
   this->init_gate_config_numbers();
 #endif
   this->get_firmware_version_();
-  const char *pfw = this->ld2420_firmware_ver_;
+  const char *pfw = this->firmware_ver_;
   std::string fw_str(pfw);
 
   for (auto &listener : this->listeners_) {
     listener->on_fw_version(fw_str);
   }
 
-  for (uint8_t gate = 0; gate < LD2420_TOTAL_GATES; gate++) {
+  for (uint8_t gate = 0; gate < TOTAL_GATES; gate++) {
     delay_microseconds_safe(125);
     this->get_gate_threshold_(gate);
   }
 
   memcpy(&this->new_config, &this->current_config, sizeof(this->current_config));
-  if (LD2420Component::get_firmware_int(this->ld2420_firmware_ver_) < CALIBRATE_VERSION_MIN) {
+  if (ld2420::get_firmware_int(this->firmware_ver_) < CALIBRATE_VERSION_MIN) {
     this->set_operating_mode(OP_SIMPLE_MODE_STRING);
     this->operating_selector_->publish_state(OP_SIMPLE_MODE_STRING);
     this->set_mode_(CMD_SYSTEM_MODE_SIMPLE);
-    ESP_LOGW(TAG, "Firmware version %s and older supports Simple Mode only", this->ld2420_firmware_ver_);
+    ESP_LOGW(TAG, "Firmware version %s and older supports Simple Mode only", this->firmware_ver_);
   } else {
     this->set_mode_(CMD_SYSTEM_MODE_ENERGY);
     this->operating_selector_->publish_state(OP_NORMAL_MODE_STRING);
@@ -167,7 +265,7 @@ void LD2420Component::apply_config_action() {
     return;
   }
   this->set_min_max_distances_timeout(this->new_config.max_gate, this->new_config.min_gate, this->new_config.timeout);
-  for (uint8_t gate = 0; gate < LD2420_TOTAL_GATES; gate++) {
+  for (uint8_t gate = 0; gate < TOTAL_GATES; gate++) {
     delay_microseconds_safe(125);
     this->set_gate_threshold(gate);
   }
@@ -193,7 +291,7 @@ void LD2420Component::factory_reset_action() {
   this->min_gate_distance_number_->state = FACTORY_MIN_GATE;
   this->max_gate_distance_number_->state = FACTORY_MAX_GATE;
 #endif
-  for (uint8_t gate = 0; gate < LD2420_TOTAL_GATES; gate++) {
+  for (uint8_t gate = 0; gate < TOTAL_GATES; gate++) {
     this->new_config.move_thresh[gate] = FACTORY_MOVE_THRESH[gate];
     this->new_config.still_thresh[gate] = FACTORY_STILL_THRESH[gate];
     delay_microseconds_safe(125);
@@ -241,7 +339,7 @@ void LD2420Component::loop() {
 }
 
 void LD2420Component::update_radar_data(uint16_t const *gate_energy, uint8_t sample_number) {
-  for (uint8_t gate = 0; gate < LD2420_TOTAL_GATES; ++gate) {
+  for (uint8_t gate = 0; gate < TOTAL_GATES; ++gate) {
     this->radar_data[gate][sample_number] = gate_energy[gate];
   }
   this->total_sample_number_counter++;
@@ -251,7 +349,7 @@ void LD2420Component::auto_calibrate_sensitivity() {
   // Calculate average and peak values for each gate
   const float move_factor = gate_move_sensitivity_factor + 1;
   const float still_factor = (gate_still_sensitivity_factor / 2) + 1;
-  for (uint8_t gate = 0; gate < LD2420_TOTAL_GATES; ++gate) {
+  for (uint8_t gate = 0; gate < TOTAL_GATES; ++gate) {
     uint32_t sum = 0;
     uint16_t peak = 0;
 
@@ -280,7 +378,7 @@ void LD2420Component::auto_calibrate_sensitivity() {
 }
 
 void LD2420Component::report_gate_data() {
-  for (uint8_t gate = 0; gate < LD2420_TOTAL_GATES; ++gate) {
+  for (uint8_t gate = 0; gate < TOTAL_GATES; ++gate) {
     // Output results
     ESP_LOGI(TAG, "Gate: %2d Avg: %5d Peak: %5d", gate, this->gate_avg[gate], this->gate_peak[gate]);
   }
@@ -289,13 +387,13 @@ void LD2420Component::report_gate_data() {
 
 void LD2420Component::set_operating_mode(const std::string &state) {
   // If unsupported firmware ignore mode select
-  if (LD2420Component::get_firmware_int(ld2420_firmware_ver_) >= CALIBRATE_VERSION_MIN) {
-    this->current_operating_mode = OP_MODE_TO_UINT.at(state);
+  if (ld2420::get_firmware_int(firmware_ver_) >= CALIBRATE_VERSION_MIN) {
+    this->current_operating_mode = find_uint8(OP_MODE_BY_STR, state);
     // Entering Auto Calibrate we need to clear the privoiuos data collection
     this->operating_selector_->publish_state(state);
     if (current_operating_mode == OP_CALIBRATE_MODE) {
       this->set_calibration_(true);
-      for (uint8_t gate = 0; gate < LD2420_TOTAL_GATES; gate++) {
+      for (uint8_t gate = 0; gate < TOTAL_GATES; gate++) {
         this->gate_avg[gate] = 0;
         this->gate_peak[gate] = 0;
         for (uint8_t i = 0; i < CALIBRATE_SAMPLES; i++) {
@@ -330,11 +428,12 @@ void LD2420Component::readline_(int rx_data, uint8_t *buffer, int len) {
         this->set_cmd_active_(false);  // Set command state to inactive after responce.
         this->handle_ack_data_(buffer, pos);
         pos = 0;
-      } else if ((buffer[pos - 2] == 0x0D && buffer[pos - 1] == 0x0A) && (get_mode_() == CMD_SYSTEM_MODE_SIMPLE)) {
+      } else if ((buffer[pos - 2] == 0x0D && buffer[pos - 1] == 0x0A) &&
+                 (this->get_mode_() == CMD_SYSTEM_MODE_SIMPLE)) {
         this->handle_simple_mode_(buffer, pos);
         pos = 0;
       } else if ((memcmp(&buffer[pos - 4], &ENERGY_FRAME_FOOTER, sizeof(ENERGY_FRAME_FOOTER)) == 0) &&
-                 (get_mode_() == CMD_SYSTEM_MODE_ENERGY)) {
+                 (this->get_mode_() == CMD_SYSTEM_MODE_ENERGY)) {
         this->handle_energy_mode_(buffer, pos);
         pos = 0;
       }
@@ -483,8 +582,8 @@ void LD2420Component::handle_ack_data_(uint8_t *buffer, int len) {
       ESP_LOGV(TAG, "Set system parameter(s): %2X %s", CMD_WRITE_SYS_PARAM, result);
       break;
     case (CMD_READ_VERSION):
-      memcpy(this->ld2420_firmware_ver_, &buffer[12], buffer[10]);
-      ESP_LOGV(TAG, "Firmware version: %7s %s", this->ld2420_firmware_ver_, result);
+      memcpy(this->firmware_ver_, &buffer[12], buffer[10]);
+      ESP_LOGV(TAG, "Firmware version: %7s %s", this->firmware_ver_, result);
       break;
     default:
       break;
@@ -753,7 +852,7 @@ void LD2420Component::init_gate_config_numbers() {
     this->gate_move_sensitivity_factor_number_->publish_state(this->gate_move_sensitivity_factor);
   if (this->gate_still_sensitivity_factor_number_ != nullptr)
     this->gate_still_sensitivity_factor_number_->publish_state(this->gate_still_sensitivity_factor);
-  for (uint8_t gate = 0; gate < LD2420_TOTAL_GATES; gate++) {
+  for (uint8_t gate = 0; gate < TOTAL_GATES; gate++) {
     if (this->gate_still_threshold_numbers_[gate] != nullptr) {
       this->gate_still_threshold_numbers_[gate]->publish_state(
           static_cast<uint16_t>(this->current_config.still_thresh[gate]));

--- a/esphome/components/ld2420/ld2420.cpp
+++ b/esphome/components/ld2420/ld2420.cpp
@@ -189,23 +189,23 @@ void LD2420Component::dump_config() {
                 this->firmware_ver_);
 #ifdef USE_NUMBER
   ESP_LOGCONFIG(TAG, "Number:");
-  LOG_NUMBER(TAG, "  Gate Timeout:", this->gate_timeout_number_);
-  LOG_NUMBER(TAG, "  Gate Max Distance:", this->max_gate_distance_number_);
-  LOG_NUMBER(TAG, "  Gate Min Distance:", this->min_gate_distance_number_);
-  LOG_NUMBER(TAG, "  Gate Select:", this->gate_select_number_);
+  LOG_NUMBER("  ", "Gate Timeout:", this->gate_timeout_number_);
+  LOG_NUMBER("  ", "Gate Max Distance:", this->max_gate_distance_number_);
+  LOG_NUMBER("  ", "Gate Min Distance:", this->min_gate_distance_number_);
+  LOG_NUMBER("  ", "Gate Select:", this->gate_select_number_);
   for (uint8_t gate = 0; gate < TOTAL_GATES; gate++) {
-    LOG_NUMBER(TAG, "  Gate Move Threshold:", this->gate_move_threshold_numbers_[gate]);
-    LOG_NUMBER(TAG, "  Gate Still Threshold::", this->gate_still_threshold_numbers_[gate]);
+    LOG_NUMBER("  ", "Gate Move Threshold:", this->gate_move_threshold_numbers_[gate]);
+    LOG_NUMBER("  ", "Gate Still Threshold::", this->gate_still_threshold_numbers_[gate]);
   }
 #endif
 #ifdef USE_BUTTON
-  LOG_BUTTON(TAG, "  Apply Config:", this->apply_config_button_);
-  LOG_BUTTON(TAG, "  Revert Edits:", this->revert_config_button_);
-  LOG_BUTTON(TAG, "  Factory Reset:", this->factory_reset_button_);
-  LOG_BUTTON(TAG, "  Restart Module:", this->restart_module_button_);
+  LOG_BUTTON("  ", "Apply Config:", this->apply_config_button_);
+  LOG_BUTTON("  ", "Revert Edits:", this->revert_config_button_);
+  LOG_BUTTON("  ", "Factory Reset:", this->factory_reset_button_);
+  LOG_BUTTON("  ", "Restart Module:", this->restart_module_button_);
 #endif
   ESP_LOGCONFIG(TAG, "Select:");
-  LOG_SELECT(TAG, "  Operating Mode", this->operating_selector_);
+  LOG_SELECT("  ", "Operating Mode", this->operating_selector_);
   if (ld2420::get_firmware_int(this->firmware_ver_) < CALIBRATE_VERSION_MIN) {
     ESP_LOGW(TAG, "Firmware version %s and older supports Simple Mode only", this->firmware_ver_);
   }

--- a/esphome/components/ld2420/ld2420.h
+++ b/esphome/components/ld2420/ld2420.h
@@ -16,88 +16,18 @@
 #ifdef USE_BUTTON
 #include "esphome/components/button/button.h"
 #endif
-#include <map>
-#include <functional>
 
 namespace esphome {
 namespace ld2420 {
 
-// Local const's
-static const uint16_t REFRESH_RATE_MS = 1000;
-
-// Command sets
-static const uint8_t CMD_ABD_DATA_REPLY_SIZE = 0x04;
-static const uint8_t CMD_ABD_DATA_REPLY_START = 0x0A;
-static const uint16_t CMD_DISABLE_CONF = 0x00FE;
-static const uint16_t CMD_ENABLE_CONF = 0x00FF;
-static const uint8_t CMD_MAX_BYTES = 0x64;
-static const uint16_t CMD_PARM_HIGH_TRESH = 0x0012;
-static const uint16_t CMD_PARM_LOW_TRESH = 0x0021;
-static const uint16_t CMD_PROTOCOL_VER = 0x0002;
-static const uint16_t CMD_READ_ABD_PARAM = 0x0008;
-static const uint16_t CMD_READ_REG_ADDR = 0x0020;
-static const uint16_t CMD_READ_REGISTER = 0x0002;
-static const uint16_t CMD_READ_SERIAL_NUM = 0x0011;
-static const uint16_t CMD_READ_SYS_PARAM = 0x0013;
-static const uint16_t CMD_READ_VERSION = 0x0000;
-static const uint8_t CMD_REG_DATA_REPLY_SIZE = 0x02;
-static const uint16_t CMD_RESTART = 0x0068;
-static const uint16_t CMD_SYSTEM_MODE = 0x0000;
-static const uint16_t CMD_SYSTEM_MODE_GR = 0x0003;
-static const uint16_t CMD_SYSTEM_MODE_MTT = 0x0001;
-static const uint16_t CMD_SYSTEM_MODE_SIMPLE = 0x0064;
-static const uint16_t CMD_SYSTEM_MODE_DEBUG = 0x0000;
-static const uint16_t CMD_SYSTEM_MODE_ENERGY = 0x0004;
-static const uint16_t CMD_SYSTEM_MODE_VS = 0x0002;
-static const uint16_t CMD_WRITE_ABD_PARAM = 0x0007;
-static const uint16_t CMD_WRITE_REGISTER = 0x0001;
-static const uint16_t CMD_WRITE_SYS_PARAM = 0x0012;
-
-static const uint8_t LD2420_ERROR_NONE = 0x00;
-static const uint8_t LD2420_ERROR_TIMEOUT = 0x02;
-static const uint8_t LD2420_ERROR_UNKNOWN = 0x01;
-static const uint8_t LD2420_TOTAL_GATES = 16;
+static const uint8_t TOTAL_GATES = 16;
 static const uint8_t CALIBRATE_SAMPLES = 64;
 
-// Register address values
-static const uint16_t CMD_MIN_GATE_REG = 0x0000;
-static const uint16_t CMD_MAX_GATE_REG = 0x0001;
-static const uint16_t CMD_TIMEOUT_REG = 0x0004;
-static const uint16_t CMD_GATE_MOVE_THRESH[LD2420_TOTAL_GATES] = {0x0010, 0x0011, 0x0012, 0x0013, 0x0014, 0x0015,
-                                                                  0x0016, 0x0017, 0x0018, 0x0019, 0x001A, 0x001B,
-                                                                  0x001C, 0x001D, 0x001E, 0x001F};
-static const uint16_t CMD_GATE_STILL_THRESH[LD2420_TOTAL_GATES] = {0x0020, 0x0021, 0x0022, 0x0023, 0x0024, 0x0025,
-                                                                   0x0026, 0x0027, 0x0028, 0x0029, 0x002A, 0x002B,
-                                                                   0x002C, 0x002D, 0x002E, 0x002F};
-static const uint32_t FACTORY_MOVE_THRESH[LD2420_TOTAL_GATES] = {60000, 30000, 400, 250, 250, 250, 250, 250,
-                                                                 250,   250,   250, 250, 250, 250, 250, 250};
-static const uint32_t FACTORY_STILL_THRESH[LD2420_TOTAL_GATES] = {40000, 20000, 200, 200, 200, 200, 200, 150,
-                                                                  150,   100,   100, 100, 100, 100, 100, 100};
-static const uint16_t FACTORY_TIMEOUT = 120;
-static const uint16_t FACTORY_MIN_GATE = 1;
-static const uint16_t FACTORY_MAX_GATE = 12;
-
-// COMMAND_BYTE Header & Footer
-static const uint8_t CMD_FRAME_COMMAND = 6;
-static const uint8_t CMD_FRAME_DATA_LENGTH = 4;
-static const uint32_t CMD_FRAME_FOOTER = 0x01020304;
-static const uint32_t CMD_FRAME_HEADER = 0xFAFBFCFD;
-static const uint32_t DEBUG_FRAME_FOOTER = 0xFAFBFCFD;
-static const uint32_t DEBUG_FRAME_HEADER = 0x1410BFAA;
-static const uint32_t ENERGY_FRAME_FOOTER = 0xF5F6F7F8;
-static const uint32_t ENERGY_FRAME_HEADER = 0xF1F2F3F4;
-static const uint8_t CMD_FRAME_STATUS = 7;
-static const uint8_t CMD_ERROR_WORD = 8;
-static const uint8_t ENERGY_SENSOR_START = 9;
-static const uint8_t CALIBRATE_REPORT_INTERVAL = 4;
-static const int CALIBRATE_VERSION_MIN = 154;
-static const std::string OP_NORMAL_MODE_STRING = "Normal";
-static const std::string OP_SIMPLE_MODE_STRING = "Simple";
-
-enum OpModeStruct : uint8_t { OP_NORMAL_MODE = 1, OP_CALIBRATE_MODE = 2, OP_SIMPLE_MODE = 3 };
-static const std::map<std::string, uint8_t> OP_MODE_TO_UINT{
-    {"Normal", OP_NORMAL_MODE}, {"Calibrate", OP_CALIBRATE_MODE}, {"Simple", OP_SIMPLE_MODE}};
-static constexpr const char *ERR_MESSAGE[] = {"None", "Unknown", "Timeout"};
+enum OpMode : uint8_t {
+  OP_NORMAL_MODE = 1,
+  OP_CALIBRATE_MODE = 2,
+  OP_SIMPLE_MODE = 3,
+};
 
 class LD2420Listener {
  public:
@@ -109,6 +39,23 @@ class LD2420Listener {
 
 class LD2420Component : public Component, public uart::UARTDevice {
  public:
+  struct CmdFrameT {
+    uint32_t header{0};
+    uint32_t footer{0};
+    uint16_t length{0};
+    uint16_t command{0};
+    uint16_t data_length{0};
+    uint8_t data[18];
+  };
+
+  struct RegConfigT {
+    uint32_t move_thresh[TOTAL_GATES];
+    uint32_t still_thresh[TOTAL_GATES];
+    uint16_t min_gate{0};
+    uint16_t max_gate{0};
+    uint16_t timeout{0};
+  };
+
   void setup() override;
   void dump_config() override;
   void loop() override;
@@ -150,23 +97,6 @@ class LD2420Component : public Component, public uart::UARTDevice {
 #endif
   void register_listener(LD2420Listener *listener) { this->listeners_.push_back(listener); }
 
-  struct CmdFrameT {
-    uint32_t header{0};
-    uint16_t length{0};
-    uint16_t command{0};
-    uint8_t data[18];
-    uint16_t data_length{0};
-    uint32_t footer{0};
-  };
-
-  struct RegConfigT {
-    uint16_t min_gate{0};
-    uint16_t max_gate{0};
-    uint16_t timeout{0};
-    uint32_t move_thresh[LD2420_TOTAL_GATES];
-    uint32_t still_thresh[LD2420_TOTAL_GATES];
-  };
-
   void send_module_restart();
   void restart_module_action();
   void apply_config_action();
@@ -179,23 +109,28 @@ class LD2420Component : public Component, public uart::UARTDevice {
   void set_operating_mode(const std::string &state);
   void auto_calibrate_sensitivity();
   void update_radar_data(uint16_t const *gate_energy, uint8_t sample_number);
-  static uint8_t calc_checksum(void *data, size_t size);
+  uint8_t set_config_mode(bool enable);
+  void set_min_max_distances_timeout(uint32_t max_gate_distance, uint32_t min_gate_distance, uint32_t timeout);
+  void set_gate_threshold(uint8_t gate);
+  void set_reg_value(uint16_t reg, uint16_t value);
+  void set_system_mode(uint16_t mode);
+  void ld2420_restart();
 
-  RegConfigT current_config;
-  RegConfigT new_config;
+  float gate_move_sensitivity_factor{0.5};
+  float gate_still_sensitivity_factor{0.5};
   int32_t last_periodic_millis = millis();
   int32_t report_periodic_millis = millis();
   int32_t monitor_periodic_millis = millis();
   int32_t last_normal_periodic_millis = millis();
-  bool output_energy_state{false};
-  uint8_t current_operating_mode{OP_NORMAL_MODE};
-  uint16_t radar_data[LD2420_TOTAL_GATES][CALIBRATE_SAMPLES];
-  uint16_t gate_avg[LD2420_TOTAL_GATES];
-  uint16_t gate_peak[LD2420_TOTAL_GATES];
-  uint8_t sample_number_counter{0};
+  uint16_t radar_data[TOTAL_GATES][CALIBRATE_SAMPLES];
+  uint16_t gate_avg[TOTAL_GATES];
+  uint16_t gate_peak[TOTAL_GATES];
   uint16_t total_sample_number_counter{0};
-  float gate_move_sensitivity_factor{0.5};
-  float gate_still_sensitivity_factor{0.5};
+  uint8_t current_operating_mode{OP_NORMAL_MODE};
+  uint8_t sample_number_counter{0};
+  bool output_energy_state{false};
+  RegConfigT current_config;
+  RegConfigT new_config;
 #ifdef USE_SELECT
   select::Select *operating_selector_{nullptr};
 #endif
@@ -205,24 +140,17 @@ class LD2420Component : public Component, public uart::UARTDevice {
   button::Button *restart_module_button_{nullptr};
   button::Button *factory_reset_button_{nullptr};
 #endif
-  void set_min_max_distances_timeout(uint32_t max_gate_distance, uint32_t min_gate_distance, uint32_t timeout);
-  void set_gate_threshold(uint8_t gate);
-  void set_reg_value(uint16_t reg, uint16_t value);
-  uint8_t set_config_mode(bool enable);
-  void set_system_mode(uint16_t mode);
-  void ld2420_restart();
 
  protected:
   struct CmdReplyT {
+    uint32_t data[4];
+    uint16_t error;
     uint8_t command;
     uint8_t status;
-    uint32_t data[4];
     uint8_t length;
-    uint16_t error;
     volatile bool ack;
   };
 
-  static int get_firmware_int(const char *version_string);
   void get_firmware_version_();
   int get_gate_threshold_(uint8_t gate);
   void get_reg_value_(uint16_t reg);
@@ -253,17 +181,17 @@ class LD2420Component : public Component, public uart::UARTDevice {
   std::vector<number::Number *> gate_move_threshold_numbers_ = std::vector<number::Number *>(16);
 #endif
 
-  uint16_t gate_energy_[LD2420_TOTAL_GATES];
-  CmdReplyT cmd_reply_;
   uint32_t max_distance_gate_;
   uint32_t min_distance_gate_;
-  uint16_t system_mode_{CMD_SYSTEM_MODE_ENERGY};
-  bool cmd_active_{false};
-  char ld2420_firmware_ver_[8]{"v0.0.0"};
-  bool presence_{false};
-  bool calibration_{false};
+  uint16_t system_mode_;
+  uint16_t gate_energy_[TOTAL_GATES];
   uint16_t distance_{0};
   uint8_t config_checksum_{0};
+  char firmware_ver_[8]{"v0.0.0"};
+  bool cmd_active_{false};
+  bool presence_{false};
+  bool calibration_{false};
+  CmdReplyT cmd_reply_;
   std::vector<LD2420Listener *> listeners_{};
 };
 

--- a/esphome/components/ld2420/sensor/ld2420_sensor.h
+++ b/esphome/components/ld2420/sensor/ld2420_sensor.h
@@ -27,7 +27,7 @@ class LD2420Sensor : public LD2420Listener, public Component, sensor::Sensor {
 
  protected:
   sensor::Sensor *distance_sensor_{nullptr};
-  std::vector<sensor::Sensor *> energy_sensors_ = std::vector<sensor::Sensor *>(LD2420_TOTAL_GATES);
+  std::vector<sensor::Sensor *> energy_sensors_ = std::vector<sensor::Sensor *>(TOTAL_GATES);
 };
 
 }  // namespace ld2420


### PR DESCRIPTION
# What does this implement/fix?

Before:
```
RAM:   [          ]   4.4% (used 14420 bytes from 327680 bytes)
Flash: [=         ]  14.8% (used 271852 bytes from 1835008 bytes)
```
After:
```
RAM:   [          ]   4.2% (used 13892 bytes from 327680 bytes)
Flash: [=         ]  14.7% (used 270060 bytes from 1835008 bytes)
```

**Note:** Keeping as draft until I can test on real hardware.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
