### PR TITLE
Optimize API connection memory usage by removing client_peername_

### DIFF
--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -77,7 +77,6 @@ void APIConnection::start() {
     return;
   }
   this->client_info_ = helper_->getpeername();
-  this->client_peername_ = this->client_info_;
   this->helper_->set_log_info(this->client_info_);
 }
 
@@ -1550,12 +1549,11 @@ bool APIConnection::try_send_log_message(int level, const char *tag, const char 
 
 HelloResponse APIConnection::hello(const HelloRequest &msg) {
   this->client_info_ = msg.client_info;
-  this->client_peername_ = this->helper_->getpeername();
   this->helper_->set_log_info(this->get_client_combined_info());
   this->client_api_version_major_ = msg.api_version_major;
   this->client_api_version_minor_ = msg.api_version_minor;
   ESP_LOGV(TAG, "Hello from client: '%s' | %s | API Version %" PRIu32 ".%" PRIu32, this->client_info_.c_str(),
-           this->client_peername_.c_str(), this->client_api_version_major_, this->client_api_version_minor_);
+           this->helper_->getpeername().c_str(), this->client_api_version_major_, this->client_api_version_minor_);
 
   HelloResponse resp;
   resp.api_version_major = 1;
@@ -1575,7 +1573,7 @@ ConnectResponse APIConnection::connect(const ConnectRequest &msg) {
   if (correct) {
     ESP_LOGD(TAG, "%s connected", this->get_client_combined_info().c_str());
     this->connection_state_ = ConnectionState::AUTHENTICATED;
-    this->parent_->get_client_connected_trigger()->trigger(this->client_info_, this->client_peername_);
+    this->parent_->get_client_connected_trigger()->trigger(this->client_info_, this->helper_->getpeername());
 #ifdef USE_HOMEASSISTANT_TIME
     if (homeassistant::global_homeassistant_time != nullptr) {
       this->send_time_request();

--- a/esphome/components/api/api_connection.h
+++ b/esphome/components/api/api_connection.h
@@ -276,11 +276,12 @@ class APIConnection : public APIServerConnection {
   bool send_buffer(ProtoWriteBuffer buffer, uint16_t message_type) override;
 
   std::string get_client_combined_info() const {
-    if (this->client_info_ == this->client_peername_) {
+    std::string peername = this->helper_->getpeername();
+    if (this->client_info_ == peername) {
       // Before Hello message, both are the same (just IP:port)
       return this->client_info_;
     }
-    return this->client_info_ + " (" + this->client_peername_ + ")";
+    return this->client_info_ + " (" + peername + ")";
   }
 
   // Buffer allocator methods for batch processing
@@ -452,7 +453,6 @@ class APIConnection : public APIServerConnection {
 
   // Strings (12 bytes each on 32-bit)
   std::string client_info_;
-  std::string client_peername_;
 
   // 2-byte aligned types
   uint16_t client_api_version_major_{0};

--- a/esphome/components/api/api_server.cpp
+++ b/esphome/components/api/api_server.cpp
@@ -184,7 +184,7 @@ void APIServer::loop() {
     }
 
     // Rare case: handle disconnection
-    this->client_disconnected_trigger_->trigger(client->client_info_, client->client_peername_);
+    this->client_disconnected_trigger_->trigger(client->client_info_, client->helper_->getpeername());
     ESP_LOGV(TAG, "Remove connection %s", client->client_info_.c_str());
 
     // Swap with the last element and pop (avoids expensive vector shifts)


### PR DESCRIPTION
# What does this implement/fix?

This PR removes the redundant `client_peername_` field from the API connection class, saving 12 bytes of memory per connection on 32-bit systems.

The `client_peername_` field was storing the socket peer name (IP:port) which was only used during:
- Error logging 
- Connection state changes (connected/disconnected events)
- The `get_client_combined_info()` method for displaying client info

Since these are all rare events during normal operation, we can call `helper_->getpeername()` dynamically when needed instead of storing it. This trades a small performance hit (system call) during these rare events for memory savings.

This optimization becomes even more beneficial when combined with #9207, which reduces the frequency of logging during connection issues by replacing the ping retry timer with a batch queue fallback system.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# No configuration changes needed - this is an internal optimization
api:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).