### PR TITLE
[remote_base] Fix dumper base class and enable schema extension

### DIFF
--- a/esphome/components/remote_base/__init__.py
+++ b/esphome/components/remote_base/__init__.py
@@ -126,7 +126,9 @@ def register_trigger(name, type, data_type):
     return decorator
 
 
-def register_dumper(name, type, schema={}):
+def register_dumper(name, type, schema=None):
+    if schema is None:
+        schema = {}
     registerer = DUMPER_REGISTRY.register(name, type, schema)
 
     def decorator(func):

--- a/esphome/components/remote_base/__init__.py
+++ b/esphome/components/remote_base/__init__.py
@@ -57,7 +57,7 @@ RemoteReceiverBinarySensorBase = ns.class_(
 RemoteReceiverTrigger = ns.class_(
     "RemoteReceiverTrigger", automation.Trigger, RemoteReceiverListener
 )
-RemoteTransmitterDumper = ns.class_("RemoteTransmitterDumper")
+RemoteReceiverDumperBase = ns.class_("RemoteReceiverDumperBase")
 RemoteTransmittable = ns.class_("RemoteTransmittable")
 RemoteTransmitterActionBase = ns.class_(
     "RemoteTransmitterActionBase", RemoteTransmittable, automation.Action
@@ -126,8 +126,8 @@ def register_trigger(name, type, data_type):
     return decorator
 
 
-def register_dumper(name, type):
-    registerer = DUMPER_REGISTRY.register(name, type, {})
+def register_dumper(name, type, schema={}):
+    registerer = DUMPER_REGISTRY.register(name, type, schema)
 
     def decorator(func):
         async def new_func(config, dumper_id):
@@ -189,7 +189,7 @@ def declare_protocol(name):
     binary_sensor_ = ns.class_(f"{name}BinarySensor", RemoteReceiverBinarySensorBase)
     trigger = ns.class_(f"{name}Trigger", RemoteReceiverTrigger)
     action = ns.class_(f"{name}Action", RemoteTransmitterActionBase)
-    dumper = ns.class_(f"{name}Dumper", RemoteTransmitterDumper)
+    dumper = ns.class_(f"{name}Dumper", RemoteReceiverDumperBase)
     return data, binary_sensor_, trigger, action, dumper
 
 
@@ -1405,7 +1405,7 @@ rc_switch_protocols = ns.RC_SWITCH_PROTOCOLS
 RCSwitchData = ns.struct("RCSwitchData")
 RCSwitchBase = ns.class_("RCSwitchBase")
 RCSwitchTrigger = ns.class_("RCSwitchTrigger", RemoteReceiverTrigger)
-RCSwitchDumper = ns.class_("RCSwitchDumper", RemoteTransmitterDumper)
+RCSwitchDumper = ns.class_("RCSwitchDumper", RemoteReceiverDumperBase)
 RCSwitchRawAction = ns.class_("RCSwitchRawAction", RemoteTransmitterActionBase)
 RCSwitchTypeAAction = ns.class_("RCSwitchTypeAAction", RemoteTransmitterActionBase)
 RCSwitchTypeBAction = ns.class_("RCSwitchTypeBAction", RemoteTransmitterActionBase)

--- a/esphome/components/remote_base/remote_base.cpp
+++ b/esphome/components/remote_base/remote_base.cpp
@@ -19,6 +19,22 @@ bool RemoteReceiveData::peek_mark(uint32_t length, uint32_t offset) const {
   return value >= 0 && lo <= value && value <= hi;
 }
 
+bool RemoteReceiveData::peek_mark_at_least(uint32_t length, uint32_t offset) const {
+  if (!this->is_valid(offset))
+    return false;
+  const int32_t value = this->peek(offset);
+  const int32_t lo = this->lower_bound_(length);
+  return value >= 0 && lo <= value;
+}
+
+bool RemoteReceiveData::peek_mark_at_most(uint32_t length, uint32_t offset) const {
+  if (!this->is_valid(offset))
+    return false;
+  const int32_t value = this->peek(offset);
+  const int32_t hi = this->upper_bound_(length);
+  return value >= 0 && value <= hi;
+}
+
 bool RemoteReceiveData::peek_space(uint32_t length, uint32_t offset) const {
   if (!this->is_valid(offset))
     return false;
@@ -34,6 +50,14 @@ bool RemoteReceiveData::peek_space_at_least(uint32_t length, uint32_t offset) co
   const int32_t value = this->peek(offset);
   const int32_t lo = this->lower_bound_(length);
   return value <= 0 && lo <= -value;
+}
+
+bool RemoteReceiveData::peek_space_at_most(uint32_t length, uint32_t offset) const {
+  if (!this->is_valid(offset))
+    return false;
+  const int32_t value = this->peek(offset);
+  const int32_t hi = this->upper_bound_(length);
+  return value <= 0 && -value <= hi;
 }
 
 bool RemoteReceiveData::expect_mark(uint32_t length) {

--- a/esphome/components/remote_base/remote_base.h
+++ b/esphome/components/remote_base/remote_base.h
@@ -54,7 +54,7 @@ class RemoteReceiveData {
   int32_t peek(uint32_t offset = 0) const { return this->data_[this->index_ + offset]; }
   bool peek_mark(uint32_t length, uint32_t offset = 0) const;
   bool peek_mark_at_least(uint32_t length, uint32_t offset = 0) const;
-  bool peek_mark_at_most(uint32_t length, uint32_t offset = 0) const;  
+  bool peek_mark_at_most(uint32_t length, uint32_t offset = 0) const;
   bool peek_space(uint32_t length, uint32_t offset = 0) const;
   bool peek_space_at_least(uint32_t length, uint32_t offset = 0) const;
   bool peek_space_at_most(uint32_t length, uint32_t offset = 0) const;

--- a/esphome/components/remote_base/remote_base.h
+++ b/esphome/components/remote_base/remote_base.h
@@ -53,8 +53,11 @@ class RemoteReceiveData {
   bool is_valid(uint32_t offset = 0) const { return this->index_ + offset < this->data_.size(); }
   int32_t peek(uint32_t offset = 0) const { return this->data_[this->index_ + offset]; }
   bool peek_mark(uint32_t length, uint32_t offset = 0) const;
+  bool peek_mark_at_least(uint32_t length, uint32_t offset = 0) const;
+  bool peek_mark_at_most(uint32_t length, uint32_t offset = 0) const;  
   bool peek_space(uint32_t length, uint32_t offset = 0) const;
   bool peek_space_at_least(uint32_t length, uint32_t offset = 0) const;
+  bool peek_space_at_most(uint32_t length, uint32_t offset = 0) const;
   bool peek_item(uint32_t mark, uint32_t space, uint32_t offset = 0) const {
     return this->peek_space(space, offset + 1) && this->peek_mark(mark, offset);
   }


### PR DESCRIPTION

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Dumper base class in yaml was wrongly named, not that it matters, just a small correction.

Implemented the missing `peek_*_at_*` functions.

New third argument (schema) for dumper registration, similar to binary_sensor. There was no way to customize it. https://github.com/esphome/esphome/pull/6300/#issuecomment-3002044284 
Example: 

```
def register_dumper(name, type, schema=None):
    if schema is None:
        schema = {}
    registerer = DUMPER_REGISTRY.register(name, type, schema)
```
```
@register_dumper(
    "rc_switch_but_better",
    RCSwitchButBetterDumper,
    RC_SWITCH_BUT_BETTER_PROTOCOL_SCHEMA,
)
def rc_switch_but_better_dumper(var, config):
    cg.add(var.set_protocol(build_rc_switch_but_better_protocol(config)))
```
```
remote_receiver:
  dump:
    - rc_switch_but_better:
        pulse_length: 200
        sync: [26,1]
        zero: [1,3]
        one: [3,1]
        nbits: 65
        nbits_min: 8
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
