### PR TITLE
[speaker] bugfix: continue to block tasks if stop flag is set

### DIFF
--- a/esphome/components/speaker/media_player/audio_pipeline.cpp
+++ b/esphome/components/speaker/media_player/audio_pipeline.cpp
@@ -343,13 +343,12 @@ void AudioPipeline::read_task(void *params) {
     xEventGroupSetBits(this_pipeline->event_group_, EventGroupBits::READER_MESSAGE_FINISHED);
 
     // Wait until the pipeline notifies us the source of the media file
-    EventBits_t event_bits =
-        xEventGroupWaitBits(this_pipeline->event_group_,
-                            EventGroupBits::READER_COMMAND_INIT_FILE | EventGroupBits::READER_COMMAND_INIT_HTTP |
-                                EventGroupBits::PIPELINE_COMMAND_STOP,  // Bit message to read
-                            pdFALSE,                                    // Clear the bit on exit
-                            pdFALSE,                                    // Wait for all the bits,
-                            portMAX_DELAY);                             // Block indefinitely until bit is set
+    EventBits_t event_bits = xEventGroupWaitBits(
+        this_pipeline->event_group_,
+        EventGroupBits::READER_COMMAND_INIT_FILE | EventGroupBits::READER_COMMAND_INIT_HTTP,  // Bit message to read
+        pdFALSE,                                                                              // Clear the bit on exit
+        pdFALSE,                                                                              // Wait for all the bits,
+        portMAX_DELAY);  // Block indefinitely until bit is set
 
     if (!(event_bits & EventGroupBits::PIPELINE_COMMAND_STOP)) {
       xEventGroupClearBits(this_pipeline->event_group_, EventGroupBits::READER_MESSAGE_FINISHED |
@@ -434,12 +433,12 @@ void AudioPipeline::decode_task(void *params) {
     xEventGroupSetBits(this_pipeline->event_group_, EventGroupBits::DECODER_MESSAGE_FINISHED);
 
     // Wait until the reader notifies us that the media type is available
-    EventBits_t event_bits = xEventGroupWaitBits(this_pipeline->event_group_,
-                                                 EventGroupBits::READER_MESSAGE_LOADED_MEDIA_TYPE |
-                                                     EventGroupBits::PIPELINE_COMMAND_STOP,  // Bit message to read
-                                                 pdFALSE,                                    // Clear the bit on exit
-                                                 pdFALSE,                                    // Wait for all the bits,
-                                                 portMAX_DELAY);  // Block indefinitely until bit is set
+    EventBits_t event_bits =
+        xEventGroupWaitBits(this_pipeline->event_group_,
+                            EventGroupBits::READER_MESSAGE_LOADED_MEDIA_TYPE,  // Bit message to read
+                            pdFALSE,                                           // Clear the bit on exit
+                            pdFALSE,                                           // Wait for all the bits,
+                            portMAX_DELAY);                                    // Block indefinitely until bit is set
 
     xEventGroupClearBits(this_pipeline->event_group_,
                          EventGroupBits::DECODER_MESSAGE_FINISHED | EventGroupBits::READER_MESSAGE_LOADED_MEDIA_TYPE);


### PR DESCRIPTION
# What does this implement/fix?

If the stop flag is set, then the tasks will continuously loop, hogging the CPU, until deleted. This PR makes the ``xEventGroupWaitBits`` functions continue to block if the ``PIPELINE_COMMAND_STOP`` bit is set. This fixes a rare case where the task to run a second time with the previous run's data due to a race condition issue.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** not applicable

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** not applicable

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
