### PR TITLE
[voice_assistant] Support streaming TTS responses and fixes crash for long responses

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -491,7 +491,7 @@ esphome/components/vbus/* @ssieb
 esphome/components/veml3235/* @kbx81
 esphome/components/veml7700/* @latonita
 esphome/components/version/* @esphome/core
-esphome/components/voice_assistant/* @jesserockz
+esphome/components/voice_assistant/* @jesserockz @kahrendt
 esphome/components/wake_on_lan/* @clydebarrow @willwill2will54
 esphome/components/watchdog/* @oarcher
 esphome/components/waveshare_epaper/* @clydebarrow

--- a/esphome/components/voice_assistant/__init__.py
+++ b/esphome/components/voice_assistant/__init__.py
@@ -21,6 +21,7 @@ CODEOWNERS = ["@jesserockz"]
 
 CONF_ON_END = "on_end"
 CONF_ON_INTENT_END = "on_intent_end"
+CONF_ON_INTENT_PROGRESS = "on_intent_progress"
 CONF_ON_INTENT_START = "on_intent_start"
 CONF_ON_LISTENING = "on_listening"
 CONF_ON_START = "on_start"
@@ -134,6 +135,9 @@ CONFIG_SCHEMA = cv.All(
                 single=True
             ),
             cv.Optional(CONF_ON_INTENT_START): automation.validate_automation(
+                single=True
+            ),
+            cv.Optional(CONF_ON_INTENT_PROGRESS): automation.validate_automation(
                 single=True
             ),
             cv.Optional(CONF_ON_INTENT_END): automation.validate_automation(
@@ -280,6 +284,13 @@ async def to_code(config):
             var.get_intent_start_trigger(),
             [],
             config[CONF_ON_INTENT_START],
+        )
+
+    if CONF_ON_INTENT_PROGRESS in config:
+        await automation.build_automation(
+            var.get_intent_progress_trigger(),
+            [(cg.std_string, "x")],
+            config[CONF_ON_INTENT_PROGRESS],
         )
 
     if CONF_ON_INTENT_END in config:

--- a/esphome/components/voice_assistant/__init__.py
+++ b/esphome/components/voice_assistant/__init__.py
@@ -17,7 +17,7 @@ from esphome.const import (
 AUTO_LOAD = ["socket"]
 DEPENDENCIES = ["api", "microphone"]
 
-CODEOWNERS = ["@jesserockz"]
+CODEOWNERS = ["@jesserockz", "@kahrendt"]
 
 CONF_ON_END = "on_end"
 CONF_ON_INTENT_END = "on_intent_end"

--- a/esphome/components/voice_assistant/voice_assistant.cpp
+++ b/esphome/components/voice_assistant/voice_assistant.cpp
@@ -647,12 +647,9 @@ void VoiceAssistant::on_event(const api::VoiceAssistantEventResponse &msg) {
       std::string tts_url_for_trigger = "";
 #ifdef USE_MEDIA_PLAYER
       if (this->media_player_ != nullptr) {
-        for (auto arg : msg.data) {
+        for (const auto &arg : msg.data) {
           if ((arg.name == "tts_start_streaming") && (arg.value == "1") && !this->tts_response_url_.empty()) {
-            this->media_player_->make_call()
-                .set_media_url(std::move(this->tts_response_url_))
-                .set_announcement(true)
-                .perform();
+            this->media_player_->make_call().set_media_url(this->tts_response_url_).set_announcement(true).perform();
 
             this->media_player_wait_for_announcement_start_ = true;
             this->media_player_wait_for_announcement_end_ = false;

--- a/esphome/components/voice_assistant/voice_assistant.cpp
+++ b/esphome/components/voice_assistant/voice_assistant.cpp
@@ -555,7 +555,7 @@ void VoiceAssistant::request_stop() {
       break;
     case State::AWAITING_RESPONSE:
       this->signal_stop_();
-      break;
+      // Fallthrough intended to stop a streaming TTS announcement that has potentially started
     case State::STREAMING_RESPONSE:
 #ifdef USE_MEDIA_PLAYER
       // Stop any ongoing media player announcement
@@ -599,6 +599,15 @@ void VoiceAssistant::on_event(const api::VoiceAssistantEventResponse &msg) {
   switch (msg.event_type) {
     case api::enums::VOICE_ASSISTANT_RUN_START:
       ESP_LOGD(TAG, "Assist Pipeline running");
+#ifdef USE_MEDIA_PLAYER
+      this->started_streaming_tts_ = false;
+      for (auto arg : msg.data) {
+        if (arg.name == "url") {
+          this->tts_response_url_ = std::move(arg.value);
+        }
+      }
+#endif
+      break;
       this->defer([this]() { this->start_trigger_->trigger(); });
       break;
     case api::enums::VOICE_ASSISTANT_WAKE_WORD_START:
@@ -633,6 +642,30 @@ void VoiceAssistant::on_event(const api::VoiceAssistantEventResponse &msg) {
       ESP_LOGD(TAG, "Intent started");
       this->defer([this]() { this->intent_start_trigger_->trigger(); });
       break;
+    case api::enums::VOICE_ASSISTANT_INTENT_PROGRESS: {
+      ESP_LOGD(TAG, "Intent progress");
+      std::string tts_url_for_trigger = "";
+#ifdef USE_MEDIA_PLAYER
+      if (this->media_player_ != nullptr) {
+        for (auto arg : msg.data) {
+          if ((arg.name == "tts_start_streaming") && (arg.value == "1") && !this->tts_response_url_.empty()) {
+            this->media_player_->make_call()
+                .set_media_url(std::move(this->tts_response_url_))
+                .set_announcement(true)
+                .perform();
+
+            this->media_player_wait_for_announcement_start_ = true;
+            this->media_player_wait_for_announcement_end_ = false;
+            this->started_streaming_tts_ = true;
+            tts_url_for_trigger = this->tts_response_url_;
+            this->tts_response_url_.clear();  // Reset streaming URL
+          }
+        }
+      }
+#endif
+      this->defer([this, tts_url_for_trigger]() { this->intent_progress_trigger_->trigger(tts_url_for_trigger); });
+      break;
+    }
     case api::enums::VOICE_ASSISTANT_INTENT_END: {
       for (auto arg : msg.data) {
         if (arg.name == "conversation_id") {
@@ -683,7 +716,7 @@ void VoiceAssistant::on_event(const api::VoiceAssistantEventResponse &msg) {
       ESP_LOGD(TAG, "Response URL: \"%s\"", url.c_str());
       this->defer([this, url]() {
 #ifdef USE_MEDIA_PLAYER
-        if (this->media_player_ != nullptr) {
+        if ((this->media_player_ != nullptr) && (!this->started_streaming_tts_)) {
           this->media_player_->make_call().set_media_url(url).set_announcement(true).perform();
 
           this->media_player_wait_for_announcement_start_ = true;

--- a/esphome/components/voice_assistant/voice_assistant.cpp
+++ b/esphome/components/voice_assistant/voice_assistant.cpp
@@ -622,6 +622,8 @@ void VoiceAssistant::on_event(const api::VoiceAssistantEventResponse &msg) {
       if (text.empty()) {
         ESP_LOGW(TAG, "No text in STT_END event");
         return;
+      } else if (text.length() > 500) {
+        text = text.substr(0, 497) + "...";
       }
       ESP_LOGD(TAG, "Speech recognised as: \"%s\"", text.c_str());
       this->defer([this, text]() { this->stt_end_trigger_->trigger(text); });
@@ -652,6 +654,9 @@ void VoiceAssistant::on_event(const api::VoiceAssistantEventResponse &msg) {
       if (text.empty()) {
         ESP_LOGW(TAG, "No text in TTS_START event");
         return;
+      }
+      if (text.length() > 500) {
+        text = text.substr(0, 497) + "...";
       }
       ESP_LOGD(TAG, "Response: \"%s\"", text.c_str());
       this->defer([this, text]() {

--- a/esphome/components/voice_assistant/voice_assistant.cpp
+++ b/esphome/components/voice_assistant/voice_assistant.cpp
@@ -607,7 +607,6 @@ void VoiceAssistant::on_event(const api::VoiceAssistantEventResponse &msg) {
         }
       }
 #endif
-      break;
       this->defer([this]() { this->start_trigger_->trigger(); });
       break;
     case api::enums::VOICE_ASSISTANT_WAKE_WORD_START:

--- a/esphome/components/voice_assistant/voice_assistant.h
+++ b/esphome/components/voice_assistant/voice_assistant.h
@@ -177,6 +177,7 @@ class VoiceAssistant : public Component {
 
   Trigger<> *get_intent_end_trigger() const { return this->intent_end_trigger_; }
   Trigger<> *get_intent_start_trigger() const { return this->intent_start_trigger_; }
+  Trigger<std::string> *get_intent_progress_trigger() const { return this->intent_progress_trigger_; }
   Trigger<> *get_listening_trigger() const { return this->listening_trigger_; }
   Trigger<> *get_end_trigger() const { return this->end_trigger_; }
   Trigger<> *get_start_trigger() const { return this->start_trigger_; }
@@ -233,6 +234,7 @@ class VoiceAssistant : public Component {
   Trigger<> *tts_stream_start_trigger_ = new Trigger<>();
   Trigger<> *tts_stream_end_trigger_ = new Trigger<>();
 #endif
+  Trigger<std::string> *intent_progress_trigger_ = new Trigger<std::string>();
   Trigger<> *wake_word_detected_trigger_ = new Trigger<>();
   Trigger<std::string> *stt_end_trigger_ = new Trigger<std::string>();
   Trigger<std::string> *tts_end_trigger_ = new Trigger<std::string>();
@@ -268,6 +270,8 @@ class VoiceAssistant : public Component {
 #endif
 #ifdef USE_MEDIA_PLAYER
   media_player::MediaPlayer *media_player_{nullptr};
+  std::string tts_response_url_{""};
+  bool started_streaming_tts_{false};
   bool media_player_wait_for_announcement_start_{false};
   bool media_player_wait_for_announcement_end_{false};
 #endif


### PR DESCRIPTION
# What does this implement/fix?

- Sends a streaming TTS response URL to the media player once the intent progress event fires
  - Adds a new ``on_intent_progress`` trigger that has a variable with the streaming TTS URL available (the string is empty if no TTS url is available)
  
- Fixes a crash when either the STT or TTS text is too long by truncating the strings to 500 characters. Previously, a long text would cause the following callback to stack overflow.
- Adds myself as codeowner
 
They aren't strictly required, but #9221 and #9222 are very helpful to avoid inconsistent failures. The TTS provider in HA must support streaming for this to work (currently only the latest wyoming-piper addon supports this with the latest HA 2025.7.0 beta).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- closes https://github.com/OHF-Voice/backlog-issues/issues/28

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#5037

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).