### PR TITLE
[dht] Fix "Falling edge for bit 39 failed!" for Sonoff THS01

### DIFF
--- a/esphome/components/dht/dht.cpp
+++ b/esphome/components/dht/dht.cpp
@@ -10,6 +10,9 @@ static const char *const TAG = "dht";
 void DHT::setup() {
   this->pin_->digital_write(true);
   this->pin_->setup();
+#ifdef USE_ESP32
+  this->pin_->pin_mode(gpio::FLAG_INPUT | gpio::FLAG_OUTPUT | gpio::FLAG_OPEN_DRAIN | gpio::FLAG_PULLUP);
+#endif
   this->pin_->digital_write(true);
 }
 
@@ -72,21 +75,15 @@ bool HOT IRAM_ATTR DHT::read_sensor_(float *temperature, float *humidity, bool r
   int8_t i = 0;
   uint8_t data[5] = {0, 0, 0, 0, 0};
 
-  this->pin_->digital_write(false);
+#ifndef USE_ESP32
   this->pin_->pin_mode(gpio::FLAG_OUTPUT);
+#endif
   this->pin_->digital_write(false);
 
   if (this->model_ == DHT_MODEL_DHT11) {
     delayMicroseconds(18000);
   } else if (this->model_ == DHT_MODEL_SI7021) {
-#ifdef USE_ESP8266
     delayMicroseconds(500);
-    this->pin_->digital_write(true);
-    delayMicroseconds(40);
-#else
-    delayMicroseconds(400);
-    this->pin_->digital_write(true);
-#endif
   } else if (this->model_ == DHT_MODEL_DHT22_TYPE2) {
     delayMicroseconds(2000);
   } else if (this->model_ == DHT_MODEL_AM2120 || this->model_ == DHT_MODEL_AM2302) {
@@ -94,7 +91,11 @@ bool HOT IRAM_ATTR DHT::read_sensor_(float *temperature, float *humidity, bool r
   } else {
     delayMicroseconds(800);
   }
+
+  this->pin_->digital_write(true);
+#ifndef USE_ESP32
   this->pin_->pin_mode(this->pin_->get_flags());
+#endif
 
   {
     InterruptLock lock;

--- a/esphome/components/dht/dht.cpp
+++ b/esphome/components/dht/dht.cpp
@@ -8,20 +8,20 @@ namespace dht {
 static const char *const TAG = "dht";
 
 void DHT::setup() {
-  this->pin_->digital_write(true);
-  this->pin_->setup();
+  this->t_pin_->digital_write(true);
+  this->t_pin_->setup();
 #ifdef USE_ESP32
-  this->pin_->pin_mode(gpio::FLAG_INPUT | gpio::FLAG_OUTPUT | gpio::FLAG_OPEN_DRAIN | gpio::FLAG_PULLUP);
+  this->t_pin_->pin_mode(this->t_pin_->get_flags() | gpio::FLAG_OUTPUT | gpio::FLAG_OPEN_DRAIN);
 #endif
-  this->pin_->digital_write(true);
+  this->t_pin_->digital_write(true);
 }
 
 void DHT::dump_config() {
   ESP_LOGCONFIG(TAG, "DHT:");
-  LOG_PIN("  Pin: ", this->pin_);
+  LOG_PIN("  Pin: ", this->t_pin_);
   ESP_LOGCONFIG(TAG, "  %sModel: %s", this->is_auto_detect_ ? "Auto-detected " : "",
                 this->model_ == DHT_MODEL_DHT11 ? "DHT11" : "DHT22 or equivalent");
-  ESP_LOGCONFIG(TAG, "  Internal pull-up: %s", ONOFF(this->pin_->get_flags() & gpio::FLAG_PULLUP));
+  ESP_LOGCONFIG(TAG, "  Internal pull-up: %s", ONOFF(this->t_pin_->get_flags() & gpio::FLAG_PULLUP));
   LOG_UPDATE_INTERVAL(this);
   LOG_SENSOR("  ", "Temperature", this->temperature_sensor_);
   LOG_SENSOR("  ", "Humidity", this->humidity_sensor_);
@@ -76,9 +76,9 @@ bool HOT IRAM_ATTR DHT::read_sensor_(float *temperature, float *humidity, bool r
   uint8_t data[5] = {0, 0, 0, 0, 0};
 
 #ifndef USE_ESP32
-  this->pin_->pin_mode(gpio::FLAG_OUTPUT);
+  this->pin_.pin_mode(gpio::FLAG_OUTPUT);
 #endif
-  this->pin_->digital_write(false);
+  this->pin_.digital_write(false);
 
   if (this->model_ == DHT_MODEL_DHT11) {
     delayMicroseconds(18000);
@@ -93,9 +93,9 @@ bool HOT IRAM_ATTR DHT::read_sensor_(float *temperature, float *humidity, bool r
   }
 
 #ifdef USE_ESP32
-  this->pin_->digital_write(true);
+  this->pin_.digital_write(true);
 #else
-  this->pin_->pin_mode(this->pin_->get_flags());
+  this->pin_.pin_mode(this->t_pin_->get_flags());
 #endif
 
   {
@@ -112,7 +112,7 @@ bool HOT IRAM_ATTR DHT::read_sensor_(float *temperature, float *humidity, bool r
       uint32_t start_time = micros();
 
       // Wait for rising edge
-      while (!this->pin_->digital_read()) {
+      while (!this->pin_.digital_read()) {
         if (micros() - start_time > 90) {
           if (i < 0) {
             error_code = 1;  // line didn't clear
@@ -129,7 +129,7 @@ bool HOT IRAM_ATTR DHT::read_sensor_(float *temperature, float *humidity, bool r
       uint32_t end_time = start_time;
 
       // Wait for falling edge
-      while (this->pin_->digital_read()) {
+      while (this->pin_.digital_read()) {
         end_time = micros();
         if (end_time - start_time > 90) {
           if (i < 0) {

--- a/esphome/components/dht/dht.cpp
+++ b/esphome/components/dht/dht.cpp
@@ -92,8 +92,9 @@ bool HOT IRAM_ATTR DHT::read_sensor_(float *temperature, float *humidity, bool r
     delayMicroseconds(800);
   }
 
+#ifdef USE_ESP32
   this->pin_->digital_write(true);
-#ifndef USE_ESP32
+#else
   this->pin_->pin_mode(this->pin_->get_flags());
 #endif
 

--- a/esphome/components/dht/dht.h
+++ b/esphome/components/dht/dht.h
@@ -38,7 +38,10 @@ class DHT : public PollingComponent {
    */
   void set_dht_model(DHTModel model);
 
-  void set_pin(InternalGPIOPin *pin) { pin_ = pin; }
+  void set_pin(InternalGPIOPin *pin) {
+    this->t_pin_ = pin;
+    this->pin_ = pin->to_isr();
+  }
   void set_model(DHTModel model) { model_ = model; }
   void set_temperature_sensor(sensor::Sensor *temperature_sensor) { temperature_sensor_ = temperature_sensor; }
   void set_humidity_sensor(sensor::Sensor *humidity_sensor) { humidity_sensor_ = humidity_sensor; }
@@ -54,7 +57,8 @@ class DHT : public PollingComponent {
  protected:
   bool read_sensor_(float *temperature, float *humidity, bool report_errors);
 
-  InternalGPIOPin *pin_;
+  InternalGPIOPin *t_pin_;
+  ISRInternalGPIOPin pin_;
   DHTModel model_{DHT_MODEL_AUTO_DETECT};
   bool is_auto_detect_{false};
   sensor::Sensor *temperature_sensor_{nullptr};


### PR DESCRIPTION
# What does this implement/fix?

Reading sensor dht si7021 often results in error "Falling edge for bit 39 failed!".

I used various log statements and a logic analyser to find the root of the problem.

On esp32 execution time of  `this->pin_->pin_mode()` varies between 50µs and 150µs.
The cause of this are cache misses (Thanks to @swoboda1337).
This delays the first bit read sometimes, which causes it to be missed and thus the last bit (39) fails, because there is no bit anymore.

The solution for esp32 is to don't switch the direction of the pin at all and use pin mode `(gpio::Flags::FLAG_INPUT | gpio::Flags::FLAG_OUTPUT) | gpio::Flags::FLAG_OPEN_DRAIN) | gpio::Flags::FLAG_PULLUP)` instead.
This avoids also the possibility of a short circuit when the output could be high and the sensor pulls low.

Furthermore `ISRInternalGPIOPin` is used to avoid the cache misses also on non esp32 devices.

With this fix, the sensor is read without errors now. The readings are very solid without a single hiccup.

Also tested on esp8266, which sadly doesn't support INPUT | OUTPUT mode.
DHT22 was also tested and is still working.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes "Falling edge for bit 39 failed!"
esphome/issues/issues/2553

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
sensor:
  #  "Sonoff THS01"
  - platform: dht
    id: si7021
    pin: GPIO25
    model: SI7021
    temperature:
      name: "Temperatur"
      id: temperature
    humidity:
      name: "Feuchtigkeit"
      id: humidity
    update_interval: 10s
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

