### PR TITLE
Optimize SafeModeComponent memory layout to reduce padding

### DIFF
--- a/esphome/components/safe_mode/safe_mode.h
+++ b/esphome/components/safe_mode/safe_mode.h
@@ -33,12 +33,15 @@ class SafeModeComponent : public Component {
   void write_rtc_(uint32_t val);
   uint32_t read_rtc_();
 
-  bool boot_successful_{false};                   ///< set to true after boot is considered successful
+  // Group all 4-byte aligned members together to avoid padding
   uint32_t safe_mode_boot_is_good_after_{60000};  ///< The amount of time after which the boot is considered successful
   uint32_t safe_mode_enable_time_{60000};         ///< The time safe mode should remain active for
   uint32_t safe_mode_rtc_value_{0};
   uint32_t safe_mode_start_time_{0};  ///< stores when safe mode was enabled
+  // Group 1-byte members together to minimize padding
+  bool boot_successful_{false};  ///< set to true after boot is considered successful
   uint8_t safe_mode_num_attempts_{0};
+  // Larger objects at the end
   ESPPreferenceObject rtc_;
   CallbackManager<void()> safe_mode_callback_{};
 


### PR DESCRIPTION
## What does this implement/fix?

This PR optimizes the memory layout of the `SafeModeComponent` class by reordering member variables to minimize padding waste on 32-bit architectures. The original layout had mixed-size members (bool, uint8_t, and uint32_t) that caused the compiler to insert padding bytes for proper alignment.

Original layout caused padding issues:
- `bool boot_successful_` (1 byte) + 3 bytes padding before next uint32_t
- `uint8_t safe_mode_num_attempts_` (1 byte) + 3 bytes padding before next member
- Total: 6 bytes of wasted memory per instance

The optimization groups members by alignment requirements:
- All 4-byte aligned `uint32_t` members are placed together first
- 1-byte members (`bool` and `uint8_t`) are grouped consecutively
- Larger complex objects are placed at the end

This reduces the component's memory footprint by eliminating unnecessary padding between members.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# No configuration changes required
# This is an internal memory optimization

safe_mode:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

## Additional details

Memory savings per SafeModeComponent instance on 32-bit architectures:
- Before: 6 bytes of padding waste (3 bytes after `boot_successful_` and 3 bytes after `safe_mode_num_attempts_`)
- After: 2 bytes of padding (only after the two consecutive 1-byte members at the end of the struct)
- Net savings: 4 bytes per instance

This is part of ongoing efforts to reduce memory usage in ESPHome components, particularly important for memory-constrained devices like ESP8266.