### PR TITLE
Optimize OTA password storage from std::string to const char

### DIFF
--- a/esphome/components/esphome/ota/ota_esphome.cpp
+++ b/esphome/components/esphome/ota/ota_esphome.cpp
@@ -15,6 +15,7 @@
 
 #include <cerrno>
 #include <cstdio>
+#include <cstring>
 
 namespace esphome {
 
@@ -76,7 +77,7 @@ void ESPHomeOTAComponent::dump_config() {
                 "  Version: %d",
                 network::get_use_address().c_str(), this->port_, USE_OTA_VERSION);
 #ifdef USE_OTA_PASSWORD
-  if (!this->password_.empty()) {
+  if (this->password_ != nullptr) {
     ESP_LOGCONFIG(TAG, "  Password configured");
   }
 #endif
@@ -168,7 +169,7 @@ void ESPHomeOTAComponent::handle_() {
   this->writeall_(buf, 1);
 
 #ifdef USE_OTA_PASSWORD
-  if (!this->password_.empty()) {
+  if (this->password_ != nullptr) {
     buf[0] = ota::OTA_RESPONSE_REQUEST_AUTH;
     this->writeall_(buf, 1);
     md5::MD5Digest md5{};
@@ -187,7 +188,7 @@ void ESPHomeOTAComponent::handle_() {
 
     // prepare challenge
     md5.init();
-    md5.add(this->password_.c_str(), this->password_.length());
+    md5.add(this->password_, strlen(this->password_));
     // add nonce
     md5.add(sbuf, 32);
 

--- a/esphome/components/esphome/ota/ota_esphome.h
+++ b/esphome/components/esphome/ota/ota_esphome.h
@@ -13,7 +13,7 @@ namespace esphome {
 class ESPHomeOTAComponent : public ota::OTAComponent {
  public:
 #ifdef USE_OTA_PASSWORD
-  void set_auth_password(const std::string &password) { password_ = password; }
+  void set_auth_password(const char *password) { password_ = password; }
 #endif  // USE_OTA_PASSWORD
 
   /// Manually set the port OTA should listen on
@@ -32,7 +32,7 @@ class ESPHomeOTAComponent : public ota::OTAComponent {
   bool writeall_(const uint8_t *buf, size_t len);
 
 #ifdef USE_OTA_PASSWORD
-  std::string password_;
+  const char *password_{nullptr};
 #endif  // USE_OTA_PASSWORD
 
   uint16_t port_;


### PR DESCRIPTION
# What does this implement/fix?

This PR optimizes memory usage in the ESPHome OTA component by changing the password storage from `std::string` to `const char*`. Since the OTA password is set once during code generation and never modified at runtime, storing it as a const char pointer eliminates unnecessary dynamic memory allocation.

**Memory savings:** 8 bytes per OTA component instance (12 bytes for std::string minus 4 bytes for const char* on 32-bit platforms).

**Technical changes:**
- Changed `password_` member variable from `std::string` to `const char*`
- Updated `set_auth_password()` to accept `const char*` parameter
- Modified password validation checks from `empty()` to nullptr comparison
- Updated MD5 hash calculation to use `strlen()` instead of `std::string::length()`

This is a safe optimization because:
- The password is only set during code generation via `set_auth_password()`
- The generated C++ code passes string literals which have static storage duration
- No runtime modification of the password occurs

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A (no user-visible changes)

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# No configuration changes - this is an internal optimization
ota:
  - platform: esphome
    password: "my_ota_password"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - N/A - This is an internal optimization with no user-visible changes