### PR TITLE
[gpio] Reduce ESP32 memory usage by optimizing struct padding

### DIFF
--- a/esphome/components/esp32/gpio.h
+++ b/esphome/components/esp32/gpio.h
@@ -29,9 +29,9 @@ class ESP32InternalGPIOPin : public InternalGPIOPin {
   void attach_interrupt(void (*func)(void *), void *arg, gpio::InterruptType type) const override;
 
   gpio_num_t pin_;
-  bool inverted_;
   gpio_drive_cap_t drive_strength_;
   gpio::Flags flags_;
+  bool inverted_;
   // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
   static bool isr_service_installed;
 };


### PR DESCRIPTION
# What does this implement/fix?

This PR optimizes memory usage in the ESP32 GPIO implementation by reordering class members to reduce padding waste. The `ESP32InternalGPIOPin` class had suboptimal member ordering that caused unnecessary padding between members.

By reordering the members to group same-sized types together, we reduce the structure size from 20 bytes to 16 bytes, saving 4 bytes per GPIO pin instance. This is particularly beneficial for projects using many GPIO pins.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - this is an internal optimization
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).