### PR TITLE
[ethernet] Reduce memory usage by 8 bytes

### DIFF
--- a/esphome/components/ethernet/ethernet_component.h
+++ b/esphome/components/ethernet/ethernet_component.h
@@ -15,7 +15,7 @@
 namespace esphome {
 namespace ethernet {
 
-enum EthernetType {
+enum EthernetType : uint8_t {
   ETHERNET_TYPE_UNKNOWN = 0,
   ETHERNET_TYPE_LAN8720,
   ETHERNET_TYPE_RTL8201,
@@ -42,7 +42,7 @@ struct PHYRegister {
   uint32_t page;
 };
 
-enum class EthernetComponentState {
+enum class EthernetComponentState : uint8_t {
   STOPPED,
   CONNECTING,
   CONNECTED,
@@ -119,25 +119,31 @@ class EthernetComponent : public Component {
   uint32_t polling_interval_{0};
 #endif
 #else
-  uint8_t phy_addr_{0};
+  // Group all 32-bit members first
   int power_pin_{-1};
-  uint8_t mdc_pin_{23};
-  uint8_t mdio_pin_{18};
   emac_rmii_clock_mode_t clk_mode_{EMAC_CLK_EXT_IN};
   emac_rmii_clock_gpio_t clk_gpio_{EMAC_CLK_IN_GPIO};
   std::vector<PHYRegister> phy_registers_{};
-#endif
-  EthernetType type_{ETHERNET_TYPE_UNKNOWN};
-  optional<ManualIP> manual_ip_{};
 
+  // Group all 8-bit members together
+  uint8_t phy_addr_{0};
+  uint8_t mdc_pin_{23};
+  uint8_t mdio_pin_{18};
+#endif
+  optional<ManualIP> manual_ip_{};
+  uint32_t connect_begin_;
+
+  // Group all uint8_t types together (enums and bools)
+  EthernetType type_{ETHERNET_TYPE_UNKNOWN};
+  EthernetComponentState state_{EthernetComponentState::STOPPED};
   bool started_{false};
   bool connected_{false};
   bool got_ipv4_address_{false};
 #if LWIP_IPV6
   uint8_t ipv6_count_{0};
 #endif /* LWIP_IPV6 */
-  EthernetComponentState state_{EthernetComponentState::STOPPED};
-  uint32_t connect_begin_;
+
+  // Pointers at the end (naturally aligned)
   esp_netif_t *eth_netif_{nullptr};
   esp_eth_handle_t eth_handle_;
   esp_eth_phy_t *phy_{nullptr};


### PR DESCRIPTION
## What does this implement/fix?

This PR optimizes the memory layout of the `EthernetComponent` class to reduce padding waste on 32-bit systems. By reordering member variables and using appropriately sized enum types, we achieve an 8-byte reduction in the structure size (from 136 to 128 bytes).

### Changes made:
1. Changed `EthernetType` enum to use `uint8_t` as the underlying type (was using default 4 bytes)
2. Changed `EthernetComponentState` enum class to use `uint8_t` as the underlying type (was using default 4 bytes)
3. Reordered member variables to minimize padding by grouping same-sized members together

This optimization is particularly beneficial for ESP32 devices where memory is constrained and every byte counts.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A (no user-facing changes)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - this is an internal optimization
ethernet:
  type: LAN8720
  mdc_pin: GPIO23
  mdio_pin: GPIO18
  clk_mode: GPIO17_OUT
  phy_addr: 0
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - N/A - No user-exposed functionality changes