### PR TITLE
Disable dynamic log level control for ESP32 ESP-IDF builds

### DIFF
--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -758,6 +758,9 @@ async def to_code(config):
         add_idf_sdkconfig_option("CONFIG_ESP_TASK_WDT_CHECK_IDLE_TASK_CPU0", False)
         add_idf_sdkconfig_option("CONFIG_ESP_TASK_WDT_CHECK_IDLE_TASK_CPU1", False)
 
+        # Disable dynamic log level control to save memory
+        add_idf_sdkconfig_option("CONFIG_LOG_DYNAMIC_LEVEL_CONTROL", False)
+
         # Set default CPU frequency
         add_idf_sdkconfig_option(f"CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ_{freq}", True)
 


### PR DESCRIPTION
# What does this implement/fix?

This PR disables dynamic log level control in ESP-IDF builds for ESP32 devices by setting `CONFIG_LOG_DYNAMIC_LEVEL_CONTROL=n`. This optimization reduces memory usage as ESPHome doesn't utilize the dynamic logging feature at runtime.

Dynamic log level control allows changing log levels at runtime, but ESPHome's logging system sets levels at compile time. By disabling this unused feature, we can save memory on ESP32 devices.

## Memory Savings Analysis

Based on analysis of the ESP-IDF source code, disabling `CONFIG_LOG_DYNAMIC_LEVEL_CONTROL` saves:

### Static RAM savings (32-bit ESP32):
- **Tag cache array**: 248 bytes (31 entries × 8 bytes each)
- **Cache management variables**: 8-12 bytes
- **Global log level variable**: 4 bytes  
- **Linked list head**: 4 bytes
- **Total static RAM**: ~264-268 bytes

### Additional savings:
- Prevents dynamic memory allocations for per-tag logging
- Code size reduction from eliminating dynamic level checking paths
- **Total estimated savings**: 300-500 bytes

ESPHome only sets the global log level once at initialization (`esp_log_level_set("*", ESP_LOG_VERBOSE)`) and doesn't use per-tag logging, making the dynamic control feature unnecessary overhead.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Memory optimization for ESP32 devices using ESP-IDF framework

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- Not applicable (internal optimization, no user-facing changes)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# No configuration changes needed - this is an internal optimization
esp32:
  board: esp32dev
  framework:
    type: esp-idf
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).