### PR TITLE
[uart] fix: missing uart_config_t struct initialisation

### DIFF
--- a/esphome/components/uart/uart_component_esp_idf.cpp
+++ b/esphome/components/uart/uart_component_esp_idf.cpp
@@ -42,7 +42,7 @@ uart_config_t IDFUARTComponent::get_config_() {
       break;
   }
 
-  uart_config_t uart_config;
+  uart_config_t uart_config = {0};
   uart_config.baud_rate = this->baud_rate_;
   uart_config.data_bits = data_bits;
   uart_config.parity = parity;

--- a/esphome/components/uart/uart_component_esp_idf.cpp
+++ b/esphome/components/uart/uart_component_esp_idf.cpp
@@ -42,7 +42,7 @@ uart_config_t IDFUARTComponent::get_config_() {
       break;
   }
 
-  uart_config_t uart_config = {0};
+  uart_config_t uart_config{};
   uart_config.baud_rate = this->baud_rate_;
   uart_config.data_bits = data_bits;
   uart_config.parity = parity;


### PR DESCRIPTION
# What does this implement/fix?

[esp-idf](https://github.com/espressif/esp-idf/blob/v5.3.2/components/esp_driver_uart/src/uart.c#L846) added a check in its `uart_param_config` function to check if `uart_config->flags.backup_before_sleep == 0` when `SOC_UART_SUPPORT_SLEEP_RETENTION` is not supported and implemented a new [flags](https://github.com/espressif/esp-idf/blob/v5.3.2/components/esp_driver_uart/include/driver/uart.h#L49) property of the `uart_config_t` struct

this [struct](https://github.com/espressif/esp-idf/blob/v5.3.2/components/esp_driver_uart/include/driver/uart.h#L54) is not correctly initialized with 0 in esphomes [IDFUARTComponent::get_config_](https://github.com/esphome/esphome/blob/dev/esphome/components/uart/uart_component_esp_idf.cpp#L45) function.

This leads to flaky behavior, because it holds random uninitialized memory as value.


## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/14yannick/hoermann_door/issues/9  
- fixes https://github.com/esphome/issues/issues/7167
- fixes https://github.com/esphome/issues/issues/7163

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
esphome:
  name: "hcp01"
  friendly_name: "HCP01"

external_components:
    - source: github://14yannick/hoermann_door
      refresh: 0s

esp32:
  board: esp32dev
  framework:
    type: esp-idf

logger:
  level: DEBUG
  baud_rate: 0 # Disable Serial logging to avoid conflict with uart bus on UART0

ota:
  - platform: esphome

uart:
  id: uart_bus
  baud_rate: 19200
  rx_pin: 18
  tx_pin: 17

uapbridge_esp:
  id: garage_door_comp
  uart_id: uart_bus
  auto_correction: true

cover:
  - platform: uapbridge
    id: cover01
    name: cover01
    device_class: garage

api:

wifi:
  ssid: !secret wifi_ssid
  password: !secret wifi_password

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
