### PR TITLE
Silence protobuf compatibility warnings when importing aioesphomeapi

### DIFF
--- a/esphome/components/api/client.py
+++ b/esphome/components/api/client.py
@@ -4,9 +4,15 @@ import asyncio
 from datetime import datetime
 import logging
 from typing import TYPE_CHECKING, Any
+import warnings
 
-from aioesphomeapi import APIClient, parse_log_message
-from aioesphomeapi.log_runner import async_run
+# Suppress protobuf version warnings
+with warnings.catch_warnings():
+    warnings.filterwarnings(
+        "ignore", category=UserWarning, message=".*Protobuf gencode version.*"
+    )
+    from aioesphomeapi import APIClient, parse_log_message
+    from aioesphomeapi.log_runner import async_run
 
 from esphome.const import CONF_KEY, CONF_PASSWORD, CONF_PORT, __version__
 from esphome.core import CORE


### PR DESCRIPTION
# What does this implement/fix?

This PR suppresses protobuf version mismatch warnings that appear when viewing logs via the ESPHome API. 

The `aioesphomeapi` library currently supports both protobuf 5 and 6, which generates warnings about gencode version being older than the runtime version:
```
Protobuf gencode version 5.29.5 is exactly one major version older than the runtime version 6.31.1 at api.proto. Please update the gencode to avoid compatibility violations in the next runtime release.
```

These warnings are spurious and not a problem for ESPHome since both protobuf versions are intentionally supported. The warnings clutter the log output and are not actionable by ESPHome users, so they are suppressed during import to provide a cleaner log viewing experience.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

None

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A - No documentation changes needed

## Test Environment

N/A - This change affects log output only and is platform-independent

## Example entry for `config.yaml`:

```yaml
# No configuration changes required
# This fix applies to all configurations using the API component
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).