### PR TITLE
[http_request] allow retrieval of more than just the first header

### DIFF
--- a/esphome/components/http_request/http_request_arduino.cpp
+++ b/esphome/components/http_request/http_request_arduino.cpp
@@ -133,7 +133,6 @@ std::shared_ptr<HttpContainer> HttpRequestArduino::perform(std::string url, std:
       std::string header_value = container->client_.header(i).c_str();
       ESP_LOGD(TAG, "Received response header, name: %s, value: %s", header_name.c_str(), header_value.c_str());
       container->response_headers_[header_name].push_back(header_value);
-      break;
     }
   }
 

--- a/esphome/components/http_request/http_request_idf.cpp
+++ b/esphome/components/http_request/http_request_idf.cpp
@@ -42,7 +42,6 @@ esp_err_t HttpRequestIDF::http_event_handler(esp_http_client_event_t *evt) {
         const std::string header_value = evt->header_value;
         ESP_LOGD(TAG, "Received response header, name: %s, value: %s", header_name.c_str(), header_value.c_str());
         user_data->response_headers[header_name].push_back(header_value);
-        break;
       }
       break;
     }


### PR DESCRIPTION
# What does this implement/fix?

Currently, only the first header is retrieved.

This bug was introduced by accident when addressing the PR review feedback at https://github.com/esphome/esphome/pull/8224#discussion_r2019812316 in commit https://github.com/esphome/esphome/pull/8224/commits/2e6bbea7748621bb8e92a564c4fd701723242c89

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/issues/issues/7083

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

n/a

## Test Environment

- [X] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
external_components:
  - source: github://pr#9242
    components: [ http_request ]
    refresh: 0s

http_request:
  verify_ssl: false

time:
  - platform: homeassistant
    id: homeassistant_time
    timezone: America/New_York
    on_time: 
      - seconds: '*'
        then:
          - logger.log: "About to perform request"
          - http_request.get:
              url: https://www.integralblue.com/logo.png
              collect_headers:
                - etag
                - last-modified
              on_response:
                then:
                  - logger.log:
                      format: 'Response status: %d, Duration: %u ms, etag: %s, last-modified: %s'
                      args:
                        - response->status_code
                        - response->duration_ms
                        - response->get_response_header("etag").c_str()
                        - response->get_response_header("last-modified").c_str()
              on_error:
                  then:
                  - logger.log:
                      format: 'Error!'
          - logger.log: "Request completed"
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
