### PR TITLE
[mcp23xxx_base] fix pin interrupts

### DIFF
--- a/esphome/components/mcp23xxx_base/__init__.py
+++ b/esphome/components/mcp23xxx_base/__init__.py
@@ -60,7 +60,6 @@ MCP23XXX_PIN_SCHEMA = pins.gpio_base_schema(
     cv.int_range(min=0, max=15),
     modes=[CONF_INPUT, CONF_OUTPUT, CONF_PULLUP],
     mode_validator=validate_mode,
-    invertible=True,
 ).extend(
     {
         cv.Required(CONF_MCP23XXX): cv.use_id(MCP23XXXBase),

--- a/esphome/components/mcp23xxx_base/__init__.py
+++ b/esphome/components/mcp23xxx_base/__init__.py
@@ -60,6 +60,7 @@ MCP23XXX_PIN_SCHEMA = pins.gpio_base_schema(
     cv.int_range(min=0, max=15),
     modes=[CONF_INPUT, CONF_OUTPUT, CONF_PULLUP],
     mode_validator=validate_mode,
+    invertible=True,
 ).extend(
     {
         cv.Required(CONF_MCP23XXX): cv.use_id(MCP23XXXBase),

--- a/esphome/components/mcp23xxx_base/mcp23xxx_base.cpp
+++ b/esphome/components/mcp23xxx_base/mcp23xxx_base.cpp
@@ -6,7 +6,11 @@ namespace mcp23xxx_base {
 
 float MCP23XXXBase::get_setup_priority() const { return setup_priority::IO; }
 
-void MCP23XXXGPIOPin::setup() { pin_mode(flags_); }
+void MCP23XXXGPIOPin::setup() {
+  pin_mode(flags_);
+  this->parent_->pin_interrupt_mode(this->pin_, this->interrupt_mode_);
+}
+
 void MCP23XXXGPIOPin::pin_mode(gpio::Flags flags) { this->parent_->pin_mode(this->pin_, flags); }
 bool MCP23XXXGPIOPin::digital_read() { return this->parent_->digital_read(this->pin_) != this->inverted_; }
 void MCP23XXXGPIOPin::digital_write(bool value) { this->parent_->digital_write(this->pin_, value != this->inverted_); }


### PR DESCRIPTION
# What does this implement/fix?

pins wouldn't actually trigger the interrupt pin if configured

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
