### PR TITLE
Fix api log client crashing when api encryption is dynamic

### DIFF
--- a/esphome/components/api/client.py
+++ b/esphome/components/api/client.py
@@ -29,8 +29,8 @@ async def async_run_logs(config: dict[str, Any], address: str) -> None:
     port: int = int(conf[CONF_PORT])
     password: str = conf[CONF_PASSWORD]
     noise_psk: str | None = None
-    if CONF_ENCRYPTION in conf:
-        noise_psk = conf[CONF_ENCRYPTION][CONF_KEY]
+    if (encryption := conf.get(CONF_ENCRYPTION)) and (key := encryption.get(CONF_KEY)):
+        noise_psk = key
     _LOGGER.info("Starting log output from %s using esphome API", address)
     cli = APIClient(
         address,


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

https://github.com/esphome/backlog/issues/1#issuecomment-3012688771

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
