### PR TITLE
[adc] Memory optimizations

### DIFF
--- a/esphome/components/adc/adc_sensor.h
+++ b/esphome/components/adc/adc_sensor.h
@@ -28,19 +28,24 @@ static const adc_atten_t ADC_ATTEN_DB_12_COMPAT = ADC_ATTEN_DB_11;
 #endif
 #endif  // USE_ESP32
 
-enum class SamplingMode : uint8_t { AVG = 0, MIN = 1, MAX = 2 };
+enum class SamplingMode : uint8_t {
+  AVG = 0,
+  MIN = 1,
+  MAX = 2,
+};
+
 const LogString *sampling_mode_to_str(SamplingMode mode);
 
 class Aggregator {
  public:
+  Aggregator(SamplingMode mode);
   void add_sample(uint32_t value);
   uint32_t aggregate();
-  Aggregator(SamplingMode mode);
 
  protected:
-  SamplingMode mode_{SamplingMode::AVG};
   uint32_t aggr_{0};
   uint32_t samples_{0};
+  SamplingMode mode_{SamplingMode::AVG};
 };
 
 class ADCSensor : public sensor::Sensor, public PollingComponent, public voltage_sampler::VoltageSampler {
@@ -81,9 +86,9 @@ class ADCSensor : public sensor::Sensor, public PollingComponent, public voltage
 #endif  // USE_RP2040
 
  protected:
-  InternalGPIOPin *pin_;
-  bool output_raw_{false};
   uint8_t sample_count_{1};
+  bool output_raw_{false};
+  InternalGPIOPin *pin_;
   SamplingMode sampling_mode_{SamplingMode::AVG};
 
 #ifdef USE_RP2040

--- a/esphome/components/adc/adc_sensor_common.cpp
+++ b/esphome/components/adc/adc_sensor_common.cpp
@@ -61,7 +61,7 @@ uint32_t Aggregator::aggregate() {
 
 void ADCSensor::update() {
   float value_v = this->sample();
-  ESP_LOGV(TAG, "'%s': Got voltage=%.4fV", this->get_name().c_str(), value_v);
+  ESP_LOGV(TAG, "'%s': Voltage=%.4fV", this->get_name().c_str(), value_v);
   this->publish_state(value_v);
 }
 

--- a/esphome/components/adc/adc_sensor_esp32.cpp
+++ b/esphome/components/adc/adc_sensor_esp32.cpp
@@ -55,12 +55,12 @@ void ADCSensor::setup() {
 }
 
 void ADCSensor::dump_config() {
-  static const char *const atten_auto_str = "auto";
-  static const char *const atten_0db_str = "0 db";
-  static const char *const atten_2_5db_str = "2.5 db";
-  static const char *const atten_6db_str = "6 db";
-  static const char *const atten_12db_str = "12 db";
-  const char *atten_str = atten_auto_str;
+  static const char *const ATTEN_AUTO_STR = "auto";
+  static const char *const ATTEN_0DB_STR = "0 db";
+  static const char *const ATTEN_2_5DB_STR = "2.5 db";
+  static const char *const ATTEN_6DB_STR = "6 db";
+  static const char *const ATTEN_12DB_STR = "12 db";
+  const char *atten_str = ATTEN_AUTO_STR;
 
   LOG_SENSOR("", "ADC Sensor", this);
   LOG_PIN("  Pin: ", this->pin_);
@@ -68,16 +68,16 @@ void ADCSensor::dump_config() {
   if (!this->autorange_) {
     switch (this->attenuation_) {
       case ADC_ATTEN_DB_0:
-        atten_str = atten_0db_str;
+        atten_str = ATTEN_0DB_STR;
         break;
       case ADC_ATTEN_DB_2_5:
-        atten_str = atten_2_5db_str;
+        atten_str = ATTEN_2_5DB_STR;
         break;
       case ADC_ATTEN_DB_6:
-        atten_str = atten_6db_str;
+        atten_str = ATTEN_6DB_STR;
         break;
       case ADC_ATTEN_DB_12_COMPAT:
-        atten_str = atten_12db_str;
+        atten_str = ATTEN_12DB_STR;
         break;
       default:  // This is to satisfy the unused ADC_ATTEN_MAX
         break;

--- a/esphome/components/adc/adc_sensor_esp32.cpp
+++ b/esphome/components/adc/adc_sensor_esp32.cpp
@@ -55,32 +55,40 @@ void ADCSensor::setup() {
 }
 
 void ADCSensor::dump_config() {
+  static const char *const atten_auto_str = "auto";
+  static const char *const atten_0db_str = "0 db";
+  static const char *const atten_2_5db_str = "2.5 db";
+  static const char *const atten_6db_str = "6 db";
+  static const char *const atten_12db_str = "12 db";
+  const char *atten_str = atten_auto_str;
+
   LOG_SENSOR("", "ADC Sensor", this);
   LOG_PIN("  Pin: ", this->pin_);
-  if (this->autorange_) {
-    ESP_LOGCONFIG(TAG, "  Attenuation: auto");
-  } else {
+
+  if (!this->autorange_) {
     switch (this->attenuation_) {
       case ADC_ATTEN_DB_0:
-        ESP_LOGCONFIG(TAG, "  Attenuation: 0db");
+        atten_str = atten_0db_str;
         break;
       case ADC_ATTEN_DB_2_5:
-        ESP_LOGCONFIG(TAG, "  Attenuation: 2.5db");
+        atten_str = atten_2_5db_str;
         break;
       case ADC_ATTEN_DB_6:
-        ESP_LOGCONFIG(TAG, "  Attenuation: 6db");
+        atten_str = atten_6db_str;
         break;
       case ADC_ATTEN_DB_12_COMPAT:
-        ESP_LOGCONFIG(TAG, "  Attenuation: 12db");
+        atten_str = atten_12db_str;
         break;
       default:  // This is to satisfy the unused ADC_ATTEN_MAX
         break;
     }
   }
+
   ESP_LOGCONFIG(TAG,
+                "  Attenuation: %s\n"
                 "  Samples: %i\n"
                 "  Sampling mode: %s",
-                this->sample_count_, LOG_STR_ARG(sampling_mode_to_str(this->sampling_mode_)));
+                atten_str, this->sample_count_, LOG_STR_ARG(sampling_mode_to_str(this->sampling_mode_)));
   LOG_UPDATE_INTERVAL(this);
 }
 


### PR DESCRIPTION
# What does this implement/fix?

Arranges variables to minimize padding and eliminates redundant/unnecessary text in log messages.

Before (C3):
```
RAM:   [=         ]  14.8% (used 48516 bytes from 327680 bytes)
Flash: [==========]  96.9% (used 1778720 bytes from 1835008 bytes)
```
After (C3):
```
RAM:   [=         ]  14.8% (used 48516 bytes from 327680 bytes)
Flash: [==========]  96.9% (used 1778634 bytes from 1835008 bytes)
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
