### PR TITLE
Reduce API memory footprint through bitfield consolidation and type sizing

### DIFF
--- a/esphome/components/api/__init__.py
+++ b/esphome/components/api/__init__.py
@@ -110,9 +110,10 @@ CONFIG_SCHEMA = cv.All(
             ): ACTIONS_SCHEMA,
             cv.Exclusive(CONF_ACTIONS, group_of_exclusion=CONF_ACTIONS): ACTIONS_SCHEMA,
             cv.Optional(CONF_ENCRYPTION): _encryption_schema,
-            cv.Optional(
-                CONF_BATCH_DELAY, default="100ms"
-            ): cv.positive_time_period_milliseconds,
+            cv.Optional(CONF_BATCH_DELAY, default="100ms"): cv.All(
+                cv.positive_time_period_milliseconds,
+                cv.Range(max=cv.TimePeriod(milliseconds=65535)),
+            ),
             cv.Optional(CONF_ON_CLIENT_CONNECTED): automation.validate_automation(
                 single=True
             ),

--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -93,21 +93,21 @@ APIConnection::~APIConnection() {
 #ifdef HAS_PROTO_MESSAGE_DUMP
 void APIConnection::log_batch_item_(const DeferredBatch::BatchItem &item) {
   // Set log-only mode
-  this->log_only_mode_ = true;
+  this->flags_.log_only_mode = true;
 
   // Call the creator - it will create the message and log it via encode_message_to_buffer
   item.creator(item.entity, this, std::numeric_limits<uint16_t>::max(), true, item.message_type);
 
   // Clear log-only mode
-  this->log_only_mode_ = false;
+  this->flags_.log_only_mode = false;
 }
 #endif
 
 void APIConnection::loop() {
-  if (this->next_close_) {
+  if (this->flags_.next_close) {
     // requested a disconnect
     this->helper_->close();
-    this->remove_ = true;
+    this->flags_.remove = true;
     return;
   }
 
@@ -148,15 +148,14 @@ void APIConnection::loop() {
         } else {
           this->read_message(0, buffer.type, nullptr);
         }
-        if (this->remove_)
+        if (this->flags_.remove)
           return;
       }
     }
   }
 
   // Process deferred batch if scheduled
-  if (this->deferred_batch_.batch_scheduled &&
-      now - this->deferred_batch_.batch_start_time >= this->get_batch_delay_ms_()) {
+  if (this->flags_.batch_scheduled && now - this->deferred_batch_.batch_start_time >= this->get_batch_delay_ms_()) {
     this->process_batch_();
   }
 
@@ -166,7 +165,7 @@ void APIConnection::loop() {
     this->initial_state_iterator_.advance();
   }
 
-  if (this->sent_ping_) {
+  if (this->flags_.sent_ping) {
     // Disconnect if not responded within 2.5*keepalive
     if (now - this->last_traffic_ > KEEPALIVE_DISCONNECT_TIMEOUT) {
       on_fatal_error();
@@ -174,13 +173,13 @@ void APIConnection::loop() {
     }
   } else if (now - this->last_traffic_ > KEEPALIVE_TIMEOUT_MS) {
     ESP_LOGVV(TAG, "Sending keepalive PING");
-    this->sent_ping_ = this->send_message(PingRequest());
-    if (!this->sent_ping_) {
+    this->flags_.sent_ping = this->send_message(PingRequest());
+    if (!this->flags_.sent_ping) {
       // If we can't send the ping request directly (tx_buffer full),
       // schedule it at the front of the batch so it will be sent with priority
       ESP_LOGW(TAG, "Buffer full, ping queued");
       this->schedule_message_front_(nullptr, &APIConnection::try_send_ping_request, PingRequest::MESSAGE_TYPE);
-      this->sent_ping_ = true;  // Mark as sent to avoid scheduling multiple pings
+      this->flags_.sent_ping = true;  // Mark as sent to avoid scheduling multiple pings
     }
   }
 
@@ -240,13 +239,13 @@ DisconnectResponse APIConnection::disconnect(const DisconnectRequest &msg) {
   // don't close yet, we still need to send the disconnect response
   // close will happen on next loop
   ESP_LOGD(TAG, "%s disconnected", this->get_client_combined_info().c_str());
-  this->next_close_ = true;
+  this->flags_.next_close = true;
   DisconnectResponse resp;
   return resp;
 }
 void APIConnection::on_disconnect_response(const DisconnectResponse &value) {
   this->helper_->close();
-  this->remove_ = true;
+  this->flags_.remove = true;
 }
 
 // Encodes a message to the buffer and returns the total number of bytes used,
@@ -255,7 +254,7 @@ uint16_t APIConnection::encode_message_to_buffer(ProtoMessage &msg, uint16_t mes
                                                  uint32_t remaining_size, bool is_single) {
 #ifdef HAS_PROTO_MESSAGE_DUMP
   // If in log-only mode, just log and return
-  if (conn->log_only_mode_) {
+  if (conn->flags_.log_only_mode) {
     conn->log_send_message_(msg.message_name(), msg.dump());
     return 1;  // Return non-zero to indicate "success" for logging
   }
@@ -1175,7 +1174,7 @@ void APIConnection::media_player_command(const MediaPlayerCommandRequest &msg) {
 
 #ifdef USE_ESP32_CAMERA
 void APIConnection::set_camera_state(std::shared_ptr<esp32_camera::CameraImage> image) {
-  if (!this->state_subscription_)
+  if (!this->flags_.state_subscription)
     return;
   if (this->image_reader_.available())
     return;
@@ -1529,7 +1528,7 @@ void APIConnection::update_command(const UpdateCommandRequest &msg) {
 #endif
 
 bool APIConnection::try_send_log_message(int level, const char *tag, const char *line) {
-  if (this->log_subscription_ < level)
+  if (this->flags_.log_subscription < level)
     return false;
 
   // Pre-calculate message size to avoid reallocations
@@ -1570,7 +1569,7 @@ HelloResponse APIConnection::hello(const HelloRequest &msg) {
   resp.server_info = App.get_name() + " (esphome v" ESPHOME_VERSION ")";
   resp.name = App.get_name();
 
-  this->connection_state_ = ConnectionState::CONNECTED;
+  this->flags_.connection_state = static_cast<uint8_t>(ConnectionState::CONNECTED);
   return resp;
 }
 ConnectResponse APIConnection::connect(const ConnectRequest &msg) {
@@ -1581,7 +1580,7 @@ ConnectResponse APIConnection::connect(const ConnectRequest &msg) {
   resp.invalid_password = !correct;
   if (correct) {
     ESP_LOGD(TAG, "%s connected", this->get_client_combined_info().c_str());
-    this->connection_state_ = ConnectionState::AUTHENTICATED;
+    this->flags_.connection_state = static_cast<uint8_t>(ConnectionState::AUTHENTICATED);
     this->parent_->get_client_connected_trigger()->trigger(this->client_info_, this->client_peername_);
 #ifdef USE_HOMEASSISTANT_TIME
     if (homeassistant::global_homeassistant_time != nullptr) {
@@ -1695,7 +1694,7 @@ void APIConnection::subscribe_home_assistant_states(const SubscribeHomeAssistant
   state_subs_at_ = 0;
 }
 bool APIConnection::try_to_clear_buffer(bool log_out_of_space) {
-  if (this->remove_)
+  if (this->flags_.remove)
     return false;
   if (this->helper_->can_write_without_blocking())
     return true;
@@ -1745,7 +1744,7 @@ void APIConnection::on_no_setup_connection() {
 }
 void APIConnection::on_fatal_error() {
   this->helper_->close();
-  this->remove_ = true;
+  this->flags_.remove = true;
 }
 
 void APIConnection::DeferredBatch::add_item(EntityBase *entity, MessageCreator creator, uint16_t message_type) {
@@ -1770,8 +1769,8 @@ void APIConnection::DeferredBatch::add_item_front(EntityBase *entity, MessageCre
 }
 
 bool APIConnection::schedule_batch_() {
-  if (!this->deferred_batch_.batch_scheduled) {
-    this->deferred_batch_.batch_scheduled = true;
+  if (!this->flags_.batch_scheduled) {
+    this->flags_.batch_scheduled = true;
     this->deferred_batch_.batch_start_time = App.get_loop_component_start_time();
   }
   return true;
@@ -1780,14 +1779,14 @@ bool APIConnection::schedule_batch_() {
 ProtoWriteBuffer APIConnection::allocate_single_message_buffer(uint16_t size) { return this->create_buffer(size); }
 
 ProtoWriteBuffer APIConnection::allocate_batch_message_buffer(uint16_t size) {
-  ProtoWriteBuffer result = this->prepare_message_buffer(size, this->batch_first_message_);
-  this->batch_first_message_ = false;
+  ProtoWriteBuffer result = this->prepare_message_buffer(size, this->flags_.batch_first_message);
+  this->flags_.batch_first_message = false;
   return result;
 }
 
 void APIConnection::process_batch_() {
   if (this->deferred_batch_.empty()) {
-    this->deferred_batch_.batch_scheduled = false;
+    this->flags_.batch_scheduled = false;
     return;
   }
 
@@ -1840,7 +1839,7 @@ void APIConnection::process_batch_() {
 
   // Reserve based on estimated size (much more accurate than 24-byte worst-case)
   this->parent_->get_shared_buffer_ref().reserve(total_estimated_size + total_overhead);
-  this->batch_first_message_ = true;
+  this->flags_.batch_first_message = true;
 
   size_t items_processed = 0;
   uint16_t remaining_size = std::numeric_limits<uint16_t>::max();

--- a/esphome/components/api/api_connection.h
+++ b/esphome/components/api/api_connection.h
@@ -125,7 +125,7 @@ class APIConnection : public APIServerConnection {
 #endif
   bool try_send_log_message(int level, const char *tag, const char *line);
   void send_homeassistant_service_call(const HomeassistantServiceResponse &call) {
-    if (!this->service_call_subscription_)
+    if (!this->flags_.service_call_subscription)
       return;
     this->send_message(call);
   }
@@ -185,7 +185,7 @@ class APIConnection : public APIServerConnection {
   void on_disconnect_response(const DisconnectResponse &value) override;
   void on_ping_response(const PingResponse &value) override {
     // we initiated ping
-    this->sent_ping_ = false;
+    this->flags_.sent_ping = false;
   }
   void on_home_assistant_state_response(const HomeAssistantStateResponse &msg) override;
 #ifdef USE_HOMEASSISTANT_TIME
@@ -198,16 +198,16 @@ class APIConnection : public APIServerConnection {
   DeviceInfoResponse device_info(const DeviceInfoRequest &msg) override;
   void list_entities(const ListEntitiesRequest &msg) override { this->list_entities_iterator_.begin(); }
   void subscribe_states(const SubscribeStatesRequest &msg) override {
-    this->state_subscription_ = true;
+    this->flags_.state_subscription = true;
     this->initial_state_iterator_.begin();
   }
   void subscribe_logs(const SubscribeLogsRequest &msg) override {
-    this->log_subscription_ = msg.level;
+    this->flags_.log_subscription = msg.level;
     if (msg.dump_config)
       App.schedule_dump_config();
   }
   void subscribe_homeassistant_services(const SubscribeHomeassistantServicesRequest &msg) override {
-    this->service_call_subscription_ = true;
+    this->flags_.service_call_subscription = true;
   }
   void subscribe_home_assistant_states(const SubscribeHomeAssistantStatesRequest &msg) override;
   GetTimeResponse get_time(const GetTimeRequest &msg) override {
@@ -219,9 +219,12 @@ class APIConnection : public APIServerConnection {
   NoiseEncryptionSetKeyResponse noise_encryption_set_key(const NoiseEncryptionSetKeyRequest &msg) override;
 #endif
 
-  bool is_authenticated() override { return this->connection_state_ == ConnectionState::AUTHENTICATED; }
+  bool is_authenticated() override {
+    return static_cast<ConnectionState>(this->flags_.connection_state) == ConnectionState::AUTHENTICATED;
+  }
   bool is_connection_setup() override {
-    return this->connection_state_ == ConnectionState ::CONNECTED || this->is_authenticated();
+    return static_cast<ConnectionState>(this->flags_.connection_state) == ConnectionState::CONNECTED ||
+           this->is_authenticated();
   }
   void on_fatal_error() override;
   void on_unauthenticated_access() override;
@@ -444,48 +447,27 @@ class APIConnection : public APIServerConnection {
   static uint16_t try_send_ping_request(EntityBase *entity, APIConnection *conn, uint32_t remaining_size,
                                         bool is_single);
 
-  // Pointers first (4 bytes each, naturally aligned)
+  // === Optimal member ordering for 32-bit systems ===
+
+  // Group 1: Pointers (4 bytes each on 32-bit)
   std::unique_ptr<APIFrameHelper> helper_;
   APIServer *parent_;
 
-  // 4-byte aligned types
-  uint32_t last_traffic_;
-  int state_subs_at_ = -1;
-
-  // Strings (12 bytes each on 32-bit)
-  std::string client_info_;
-  std::string client_peername_;
-
-  // 2-byte aligned types
-  uint16_t client_api_version_major_{0};
-  uint16_t client_api_version_minor_{0};
-
-  // Group all 1-byte types together to minimize padding
-  enum class ConnectionState : uint8_t {
-    WAITING_FOR_HELLO,
-    CONNECTED,
-    AUTHENTICATED,
-  } connection_state_{ConnectionState::WAITING_FOR_HELLO};
-  uint8_t log_subscription_{ESPHOME_LOG_LEVEL_NONE};
-  bool remove_{false};
-  bool state_subscription_{false};
-  bool sent_ping_{false};
-  bool service_call_subscription_{false};
-  bool next_close_ = false;
-  // 7 bytes used, 1 byte padding
-#ifdef HAS_PROTO_MESSAGE_DUMP
-  // When true, encode_message_to_buffer will only log, not encode
-  bool log_only_mode_{false};
-#endif
-  uint8_t ping_retries_{0};
-  // 8 bytes used, no padding needed
-
-  // Larger objects at the end
+  // Group 2: Larger objects (must be 4-byte aligned)
+  // These contain vectors/pointers internally, so putting them early ensures good alignment
   InitialStateIterator initial_state_iterator_;
   ListEntitiesIterator list_entities_iterator_;
 #ifdef USE_ESP32_CAMERA
   esp32_camera::CameraImageReader image_reader_;
 #endif
+
+  // Group 3: Strings (12 bytes each on 32-bit, 4-byte aligned)
+  std::string client_info_;
+  std::string client_peername_;
+
+  // Group 4: 4-byte types
+  uint32_t last_traffic_;
+  int state_subs_at_ = -1;
 
   // Function pointer type for message encoding
   using MessageCreatorPtr = uint16_t (*)(EntityBase *, APIConnection *, uint32_t remaining_size, bool is_single);
@@ -596,7 +578,6 @@ class APIConnection : public APIServerConnection {
 
     std::vector<BatchItem> items;
     uint32_t batch_start_time{0};
-    bool batch_scheduled{false};
 
     DeferredBatch() {
       // Pre-allocate capacity for typical batch sizes to avoid reallocation
@@ -609,13 +590,47 @@ class APIConnection : public APIServerConnection {
     void add_item_front(EntityBase *entity, MessageCreator creator, uint16_t message_type);
     void clear() {
       items.clear();
-      batch_scheduled = false;
       batch_start_time = 0;
     }
     bool empty() const { return items.empty(); }
   };
 
+  // DeferredBatch here (16 bytes, 4-byte aligned)
   DeferredBatch deferred_batch_;
+
+  // ConnectionState enum for type safety
+  enum class ConnectionState : uint8_t {
+    WAITING_FOR_HELLO = 0,
+    CONNECTED = 1,
+    AUTHENTICATED = 2,
+  };
+
+  // Group 5: Pack all small members together to minimize padding
+  // This group starts at a 4-byte boundary after DeferredBatch
+  struct APIFlags {
+    // Connection state only needs 2 bits (3 states)
+    uint8_t connection_state : 2;
+    // Log subscription needs 3 bits (log levels 0-7)
+    uint8_t log_subscription : 3;
+    // Boolean flags (1 bit each)
+    uint8_t remove : 1;
+    uint8_t state_subscription : 1;
+    uint8_t sent_ping : 1;
+
+    uint8_t service_call_subscription : 1;
+    uint8_t next_close : 1;
+    uint8_t batch_scheduled : 1;
+    uint8_t batch_first_message : 1;  // For batch buffer allocation
+#ifdef HAS_PROTO_MESSAGE_DUMP
+    uint8_t log_only_mode : 1;
+#endif
+  } flags_{};  // 2 bytes total
+
+  // 2-byte types immediately after flags_ (no padding between them)
+  uint16_t client_api_version_major_{0};
+  uint16_t client_api_version_minor_{0};
+  // Total: 2 (flags) + 2 + 2 = 6 bytes, then 2 bytes padding to next 4-byte boundary
+
   uint32_t get_batch_delay_ms_() const;
   // Message will use 8 more bytes than the minimum size, and typical
   // MTU is 1500. Sometimes users will see as low as 1460 MTU.
@@ -632,9 +647,6 @@ class APIConnection : public APIServerConnection {
 
   bool schedule_batch_();
   void process_batch_();
-
-  // State for batch buffer allocation
-  bool batch_first_message_{false};
 
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void log_batch_item_(const DeferredBatch::BatchItem &item);

--- a/esphome/components/api/api_server.cpp
+++ b/esphome/components/api/api_server.cpp
@@ -431,7 +431,7 @@ void APIServer::set_port(uint16_t port) { this->port_ = port; }
 
 void APIServer::set_password(const std::string &password) { this->password_ = password; }
 
-void APIServer::set_batch_delay(uint32_t batch_delay) { this->batch_delay_ = batch_delay; }
+void APIServer::set_batch_delay(uint16_t batch_delay) { this->batch_delay_ = batch_delay; }
 
 void APIServer::send_homeassistant_service_call(const HomeassistantServiceResponse &call) {
   for (auto &client : this->clients_) {

--- a/esphome/components/api/api_server.cpp
+++ b/esphome/components/api/api_server.cpp
@@ -104,7 +104,7 @@ void APIServer::setup() {
         return;
       }
       for (auto &c : this->clients_) {
-        if (!c->remove_)
+        if (!c->flags_.remove)
           c->try_send_log_message(level, tag, message);
       }
     });
@@ -116,7 +116,7 @@ void APIServer::setup() {
     esp32_camera::global_esp32_camera->add_image_callback(
         [this](const std::shared_ptr<esp32_camera::CameraImage> &image) {
           for (auto &c : this->clients_) {
-            if (!c->remove_)
+            if (!c->flags_.remove)
               c->set_camera_state(image);
           }
         });
@@ -176,7 +176,7 @@ void APIServer::loop() {
   while (client_index < this->clients_.size()) {
     auto &client = this->clients_[client_index];
 
-    if (!client->remove_) {
+    if (!client->flags_.remove) {
       // Common case: process active client
       client->loop();
       client_index++;
@@ -502,7 +502,7 @@ bool APIServer::save_noise_psk(psk_t psk, bool make_active) {
 #ifdef USE_HOMEASSISTANT_TIME
 void APIServer::request_time() {
   for (auto &client : this->clients_) {
-    if (!client->remove_ && client->is_authenticated())
+    if (!client->flags_.remove && client->is_authenticated())
       client->send_time_request();
   }
 }

--- a/esphome/components/api/api_server.h
+++ b/esphome/components/api/api_server.h
@@ -40,8 +40,8 @@ class APIServer : public Component, public Controller {
   void set_port(uint16_t port);
   void set_password(const std::string &password);
   void set_reboot_timeout(uint32_t reboot_timeout);
-  void set_batch_delay(uint32_t batch_delay);
-  uint32_t get_batch_delay() const { return batch_delay_; }
+  void set_batch_delay(uint16_t batch_delay);
+  uint16_t get_batch_delay() const { return batch_delay_; }
 
   // Get reference to shared buffer for API connections
   std::vector<uint8_t> &get_shared_buffer_ref() { return shared_write_buffer_; }
@@ -150,7 +150,6 @@ class APIServer : public Component, public Controller {
 
   // 4-byte aligned types
   uint32_t reboot_timeout_{300000};
-  uint32_t batch_delay_{100};
 
   // Vectors and strings (12 bytes each on 32-bit)
   std::vector<std::unique_ptr<APIConnection>> clients_;
@@ -161,8 +160,9 @@ class APIServer : public Component, public Controller {
 
   // Group smaller types together
   uint16_t port_{6053};
+  uint16_t batch_delay_{100};
   bool shutting_down_ = false;
-  // 3 bytes used, 1 byte padding
+  // 5 bytes used, 3 bytes padding
 
 #ifdef USE_API_NOISE
   std::shared_ptr<APINoiseContext> noise_ctx_ = std::make_shared<APINoiseContext>();


### PR DESCRIPTION
# What does this implement/fix?

This PR reduces the memory footprint of the API component through optimizations to both `APIConnection` and `APIServer`:

## 1. APIConnection Bitfield Packing (16+ bytes saved per connection)
- **Bitfield packing**: Consolidates all boolean flags and small enum values into a single 2-byte `APIFlags` struct instead of using individual bytes for each flag
- **Member reordering**: Reorganizes class members to minimize padding on 32-bit systems

### APIConnection changes:
- Created `APIFlags` bitfield struct that packs:
  - `connection_state` (2 bits - only needs 3 states)
  - `log_subscription` (3 bits - log levels 0-7)
  - 7 boolean flags (1 bit each)
  - Optional `log_only_mode` (1 bit when HAS_PROTO_MESSAGE_DUMP is defined)
- Moved `batch_scheduled` flag from `DeferredBatch` to `APIFlags`
- Added `batch_first_message` to bitfield instead of standalone bool
- Removed unused `ping_retries` member
- Reordered all class members for optimal alignment on 32-bit systems

## 2. APIServer Batch Delay Optimization (2 bytes saved)
- Changed `batch_delay_` from `uint32_t` to `uint16_t`
- Supports delays up to 65.535 seconds (more than sufficient for typical use)
- Added Python validation to enforce maximum value of 65535ms

### Total memory savings:
- APIConnection bitfield consolidation: ~6 bytes (8+ individual bytes → 2 bytes)
- APIConnection DeferredBatch optimization: 4 bytes (removed bool + padding)
- APIConnection batch_first_message optimization: 4 bytes (bool + padding)
- APIConnection member reordering: ~2-4 bytes reduced padding
- APIServer batch_delay size reduction: 2 bytes
- **Total: ~18-20 bytes saved (16-18 per APIConnection + 2 per APIServer)**

This is particularly beneficial for devices with multiple simultaneous API connections.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Note:** While we added an upper limit of 65535ms to `batch_delay`, we did not mark this as a breaking change since any value beyond a few seconds is nonsensical for this use case.

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#5043

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# No configuration changes needed - this is an internal memory optimization
api:
  password: "example"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - N/A - This is an internal optimization with no user-exposed changes