### PR TITLE
Remove redundant get_setup_priority() overrides returning default value

### DIFF
--- a/esphome/components/ade7880/ade7880.h
+++ b/esphome/components/ade7880/ade7880.h
@@ -85,8 +85,6 @@ class ADE7880 : public i2c::I2CDevice, public PollingComponent {
 
   void dump_config() override;
 
-  float get_setup_priority() const override { return setup_priority::DATA; }
-
  protected:
   ADE7880Store store_{};
   InternalGPIOPin *irq0_pin_{nullptr};

--- a/esphome/components/ads1115/ads1115.h
+++ b/esphome/components/ads1115/ads1115.h
@@ -49,7 +49,6 @@ class ADS1115Component : public Component, public i2c::I2CDevice {
   void setup() override;
   void dump_config() override;
   /// HARDWARE_LATE setup priority
-  float get_setup_priority() const override { return setup_priority::DATA; }
   void set_continuous_mode(bool continuous_mode) { continuous_mode_ = continuous_mode; }
 
   /// Helper method to request a measurement from a sensor.

--- a/esphome/components/ads1118/ads1118.h
+++ b/esphome/components/ads1118/ads1118.h
@@ -34,7 +34,6 @@ class ADS1118 : public Component,
   ADS1118() = default;
   void setup() override;
   void dump_config() override;
-  float get_setup_priority() const override { return setup_priority::DATA; }
   /// Helper method to request a measurement from a sensor.
   float request_measurement(ADS1118Multiplexer multiplexer, ADS1118Gain gain, bool temperature_mode);
 

--- a/esphome/components/ags10/ags10.h
+++ b/esphome/components/ags10/ags10.h
@@ -31,8 +31,6 @@ class AGS10Component : public PollingComponent, public i2c::I2CDevice {
 
   void dump_config() override;
 
-  float get_setup_priority() const override { return setup_priority::DATA; }
-
   /**
    * Modifies target address of AGS10.
    *

--- a/esphome/components/aic3204/aic3204.h
+++ b/esphome/components/aic3204/aic3204.h
@@ -66,7 +66,6 @@ class AIC3204 : public audio_dac::AudioDac, public Component, public i2c::I2CDev
  public:
   void setup() override;
   void dump_config() override;
-  float get_setup_priority() const override { return setup_priority::DATA; }
 
   bool set_mute_off() override;
   bool set_mute_on() override;

--- a/esphome/components/alpha3/alpha3.h
+++ b/esphome/components/alpha3/alpha3.h
@@ -41,7 +41,6 @@ class Alpha3 : public esphome::ble_client::BLEClientNode, public PollingComponen
   void gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if,
                            esp_ble_gattc_cb_param_t *param) override;
   void dump_config() override;
-  float get_setup_priority() const override { return setup_priority::DATA; }
   void set_flow_sensor(sensor::Sensor *sensor) { this->flow_sensor_ = sensor; }
   void set_head_sensor(sensor::Sensor *sensor) { this->head_sensor_ = sensor; }
   void set_power_sensor(sensor::Sensor *sensor) { this->power_sensor_ = sensor; }

--- a/esphome/components/am43/cover/am43_cover.h
+++ b/esphome/components/am43/cover/am43_cover.h
@@ -22,7 +22,6 @@ class Am43Component : public cover::Cover, public esphome::ble_client::BLEClient
   void gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if,
                            esp_ble_gattc_cb_param_t *param) override;
   void dump_config() override;
-  float get_setup_priority() const override { return setup_priority::DATA; }
   cover::CoverTraits get_traits() override;
   void set_pin(uint16_t pin) { this->pin_ = pin; }
   void set_invert_position(bool invert_position) { this->invert_position_ = invert_position; }

--- a/esphome/components/am43/sensor/am43_sensor.h
+++ b/esphome/components/am43/sensor/am43_sensor.h
@@ -22,7 +22,6 @@ class Am43 : public esphome::ble_client::BLEClientNode, public PollingComponent 
   void gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if,
                            esp_ble_gattc_cb_param_t *param) override;
   void dump_config() override;
-  float get_setup_priority() const override { return setup_priority::DATA; }
   void set_battery(sensor::Sensor *battery) { battery_ = battery; }
   void set_illuminance(sensor::Sensor *illuminance) { illuminance_ = illuminance; }
 

--- a/esphome/components/analog_threshold/analog_threshold_binary_sensor.h
+++ b/esphome/components/analog_threshold/analog_threshold_binary_sensor.h
@@ -12,8 +12,6 @@ class AnalogThresholdBinarySensor : public Component, public binary_sensor::Bina
   void dump_config() override;
   void setup() override;
 
-  float get_setup_priority() const override { return setup_priority::DATA; }
-
   void set_sensor(sensor::Sensor *analog_sensor);
   template<typename T> void set_upper_threshold(T upper_threshold) { this->upper_threshold_ = upper_threshold; }
   template<typename T> void set_lower_threshold(T lower_threshold) { this->lower_threshold_ = lower_threshold; }

--- a/esphome/components/anova/anova.h
+++ b/esphome/components/anova/anova.h
@@ -26,7 +26,6 @@ class Anova : public climate::Climate, public esphome::ble_client::BLEClientNode
   void gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if,
                            esp_ble_gattc_cb_param_t *param) override;
   void dump_config() override;
-  float get_setup_priority() const override { return setup_priority::DATA; }
   climate::ClimateTraits traits() override {
     auto traits = climate::ClimateTraits();
     traits.set_supports_current_temperature(true);

--- a/esphome/components/as5600/as5600.h
+++ b/esphome/components/as5600/as5600.h
@@ -50,7 +50,6 @@ class AS5600Component : public Component, public i2c::I2CDevice {
   void setup() override;
   void dump_config() override;
   /// HARDWARE_LATE setup priority
-  float get_setup_priority() const override { return setup_priority::DATA; }
 
   // configuration setters
   void set_dir_pin(InternalGPIOPin *pin) { this->dir_pin_ = pin; }

--- a/esphome/components/atc_mithermometer/atc_mithermometer.h
+++ b/esphome/components/atc_mithermometer/atc_mithermometer.h
@@ -25,7 +25,6 @@ class ATCMiThermometer : public Component, public esp32_ble_tracker::ESPBTDevice
 
   bool parse_device(const esp32_ble_tracker::ESPBTDevice &device) override;
   void dump_config() override;
-  float get_setup_priority() const override { return setup_priority::DATA; }
   void set_temperature(sensor::Sensor *temperature) { temperature_ = temperature; }
   void set_humidity(sensor::Sensor *humidity) { humidity_ = humidity; }
   void set_battery_level(sensor::Sensor *battery_level) { battery_level_ = battery_level; }

--- a/esphome/components/b_parasite/b_parasite.h
+++ b/esphome/components/b_parasite/b_parasite.h
@@ -16,7 +16,6 @@ class BParasite : public Component, public esp32_ble_tracker::ESPBTDeviceListene
 
   bool parse_device(const esp32_ble_tracker::ESPBTDevice &device) override;
   void dump_config() override;
-  float get_setup_priority() const override { return setup_priority::DATA; }
 
   void set_battery_voltage(sensor::Sensor *battery_voltage) { battery_voltage_ = battery_voltage; }
   void set_temperature(sensor::Sensor *temperature) { temperature_ = temperature; }

--- a/esphome/components/ble_client/output/ble_binary_output.h
+++ b/esphome/components/ble_client/output/ble_binary_output.h
@@ -16,7 +16,6 @@ class BLEBinaryOutput : public output::BinaryOutput, public BLEClientNode, publi
  public:
   void dump_config() override;
   void loop() override {}
-  float get_setup_priority() const override { return setup_priority::DATA; }
   void set_service_uuid16(uint16_t uuid) { this->service_uuid_ = espbt::ESPBTUUID::from_uint16(uuid); }
   void set_service_uuid32(uint32_t uuid) { this->service_uuid_ = espbt::ESPBTUUID::from_uint32(uuid); }
   void set_service_uuid128(uint8_t *uuid) { this->service_uuid_ = espbt::ESPBTUUID::from_raw(uuid); }

--- a/esphome/components/ble_client/sensor/ble_rssi_sensor.h
+++ b/esphome/components/ble_client/sensor/ble_rssi_sensor.h
@@ -18,7 +18,6 @@ class BLEClientRSSISensor : public sensor::Sensor, public PollingComponent, publ
   void loop() override;
   void update() override;
   void dump_config() override;
-  float get_setup_priority() const override { return setup_priority::DATA; }
 
   void gap_event_handler(esp_gap_ble_cb_event_t event, esp_ble_gap_cb_param_t *param) override;
 

--- a/esphome/components/ble_client/sensor/ble_sensor.h
+++ b/esphome/components/ble_client/sensor/ble_sensor.h
@@ -24,7 +24,6 @@ class BLESensor : public sensor::Sensor, public PollingComponent, public BLEClie
   void gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if,
                            esp_ble_gattc_cb_param_t *param) override;
   void dump_config() override;
-  float get_setup_priority() const override { return setup_priority::DATA; }
   void set_service_uuid16(uint16_t uuid) { this->service_uuid_ = espbt::ESPBTUUID::from_uint16(uuid); }
   void set_service_uuid32(uint32_t uuid) { this->service_uuid_ = espbt::ESPBTUUID::from_uint32(uuid); }
   void set_service_uuid128(uint8_t *uuid) { this->service_uuid_ = espbt::ESPBTUUID::from_raw(uuid); }

--- a/esphome/components/ble_client/switch/ble_switch.h
+++ b/esphome/components/ble_client/switch/ble_switch.h
@@ -19,7 +19,6 @@ class BLEClientSwitch : public switch_::Switch, public Component, public BLEClie
   void loop() override {}
   void gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if,
                            esp_ble_gattc_cb_param_t *param) override;
-  float get_setup_priority() const override { return setup_priority::DATA; }
 
  protected:
   void write_state(bool state) override;

--- a/esphome/components/ble_client/text_sensor/ble_text_sensor.h
+++ b/esphome/components/ble_client/text_sensor/ble_text_sensor.h
@@ -20,7 +20,6 @@ class BLETextSensor : public text_sensor::TextSensor, public PollingComponent, p
   void gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if,
                            esp_ble_gattc_cb_param_t *param) override;
   void dump_config() override;
-  float get_setup_priority() const override { return setup_priority::DATA; }
   void set_service_uuid16(uint16_t uuid) { this->service_uuid_ = espbt::ESPBTUUID::from_uint16(uuid); }
   void set_service_uuid32(uint32_t uuid) { this->service_uuid_ = espbt::ESPBTUUID::from_uint32(uuid); }
   void set_service_uuid128(uint8_t *uuid) { this->service_uuid_ = espbt::ESPBTUUID::from_raw(uuid); }

--- a/esphome/components/ble_presence/ble_presence_device.h
+++ b/esphome/components/ble_presence/ble_presence_device.h
@@ -105,7 +105,6 @@ class BLEPresenceDevice : public binary_sensor::BinarySensorInitiallyOff,
       this->set_found_(false);
   }
   void dump_config() override;
-  float get_setup_priority() const override { return setup_priority::DATA; }
 
  protected:
   void set_found_(bool state) {

--- a/esphome/components/ble_rssi/ble_rssi_sensor.h
+++ b/esphome/components/ble_rssi/ble_rssi_sensor.h
@@ -99,7 +99,6 @@ class BLERSSISensor : public sensor::Sensor, public esp32_ble_tracker::ESPBTDevi
     return false;
   }
   void dump_config() override;
-  float get_setup_priority() const override { return setup_priority::DATA; }
 
  protected:
   enum MatchType { MATCH_BY_MAC_ADDRESS, MATCH_BY_IRK, MATCH_BY_SERVICE_UUID, MATCH_BY_IBEACON_UUID };

--- a/esphome/components/ble_scanner/ble_scanner.h
+++ b/esphome/components/ble_scanner/ble_scanner.h
@@ -29,7 +29,6 @@ class BLEScanner : public text_sensor::TextSensor, public esp32_ble_tracker::ESP
     return true;
   }
   void dump_config() override;
-  float get_setup_priority() const override { return setup_priority::DATA; }
 };
 
 }  // namespace ble_scanner

--- a/esphome/components/bmp581/bmp581.h
+++ b/esphome/components/bmp581/bmp581.h
@@ -61,8 +61,6 @@ enum IIRFilter {
 
 class BMP581Component : public PollingComponent, public i2c::I2CDevice {
  public:
-  float get_setup_priority() const override { return setup_priority::DATA; }
-
   void dump_config() override;
 
   void setup() override;

--- a/esphome/components/cap1188/cap1188.h
+++ b/esphome/components/cap1188/cap1188.h
@@ -46,7 +46,6 @@ class CAP1188Component : public Component, public i2c::I2CDevice {
   void set_reset_pin(GPIOPin *reset_pin) { this->reset_pin_ = reset_pin; }
   void setup() override;
   void dump_config() override;
-  float get_setup_priority() const override { return setup_priority::DATA; }
   void loop() override;
 
  protected:

--- a/esphome/components/ccs811/ccs811.h
+++ b/esphome/components/ccs811/ccs811.h
@@ -25,8 +25,6 @@ class CCS811Component : public PollingComponent, public i2c::I2CDevice {
 
   void dump_config() override;
 
-  float get_setup_priority() const override { return setup_priority::DATA; }
-
  protected:
   optional<uint8_t> read_status_() { return this->read_byte(0x00); }
   bool status_has_error_() { return this->read_status_().value_or(1) & 1; }

--- a/esphome/components/copy/binary_sensor/copy_binary_sensor.h
+++ b/esphome/components/copy/binary_sensor/copy_binary_sensor.h
@@ -11,7 +11,6 @@ class CopyBinarySensor : public binary_sensor::BinarySensor, public Component {
   void set_source(binary_sensor::BinarySensor *source) { source_ = source; }
   void setup() override;
   void dump_config() override;
-  float get_setup_priority() const override { return setup_priority::DATA; }
 
  protected:
   binary_sensor::BinarySensor *source_;

--- a/esphome/components/copy/button/copy_button.h
+++ b/esphome/components/copy/button/copy_button.h
@@ -10,7 +10,6 @@ class CopyButton : public button::Button, public Component {
  public:
   void set_source(button::Button *source) { source_ = source; }
   void dump_config() override;
-  float get_setup_priority() const override { return setup_priority::DATA; }
 
  protected:
   void press_action() override;

--- a/esphome/components/copy/cover/copy_cover.h
+++ b/esphome/components/copy/cover/copy_cover.h
@@ -11,7 +11,6 @@ class CopyCover : public cover::Cover, public Component {
   void set_source(cover::Cover *source) { source_ = source; }
   void setup() override;
   void dump_config() override;
-  float get_setup_priority() const override { return setup_priority::DATA; }
 
   cover::CoverTraits get_traits() override;
 

--- a/esphome/components/copy/fan/copy_fan.h
+++ b/esphome/components/copy/fan/copy_fan.h
@@ -11,7 +11,6 @@ class CopyFan : public fan::Fan, public Component {
   void set_source(fan::Fan *source) { source_ = source; }
   void setup() override;
   void dump_config() override;
-  float get_setup_priority() const override { return setup_priority::DATA; }
 
   fan::FanTraits get_traits() override;
 

--- a/esphome/components/copy/lock/copy_lock.h
+++ b/esphome/components/copy/lock/copy_lock.h
@@ -11,7 +11,6 @@ class CopyLock : public lock::Lock, public Component {
   void set_source(lock::Lock *source) { source_ = source; }
   void setup() override;
   void dump_config() override;
-  float get_setup_priority() const override { return setup_priority::DATA; }
 
  protected:
   void control(const lock::LockCall &call) override;

--- a/esphome/components/copy/number/copy_number.h
+++ b/esphome/components/copy/number/copy_number.h
@@ -11,7 +11,6 @@ class CopyNumber : public number::Number, public Component {
   void set_source(number::Number *source) { source_ = source; }
   void setup() override;
   void dump_config() override;
-  float get_setup_priority() const override { return setup_priority::DATA; }
 
  protected:
   void control(float value) override;

--- a/esphome/components/copy/select/copy_select.h
+++ b/esphome/components/copy/select/copy_select.h
@@ -11,7 +11,6 @@ class CopySelect : public select::Select, public Component {
   void set_source(select::Select *source) { source_ = source; }
   void setup() override;
   void dump_config() override;
-  float get_setup_priority() const override { return setup_priority::DATA; }
 
  protected:
   void control(const std::string &value) override;

--- a/esphome/components/copy/sensor/copy_sensor.h
+++ b/esphome/components/copy/sensor/copy_sensor.h
@@ -11,7 +11,6 @@ class CopySensor : public sensor::Sensor, public Component {
   void set_source(sensor::Sensor *source) { source_ = source; }
   void setup() override;
   void dump_config() override;
-  float get_setup_priority() const override { return setup_priority::DATA; }
 
  protected:
   sensor::Sensor *source_;

--- a/esphome/components/copy/switch/copy_switch.h
+++ b/esphome/components/copy/switch/copy_switch.h
@@ -11,7 +11,6 @@ class CopySwitch : public switch_::Switch, public Component {
   void set_source(switch_::Switch *source) { source_ = source; }
   void setup() override;
   void dump_config() override;
-  float get_setup_priority() const override { return setup_priority::DATA; }
 
  protected:
   void write_state(bool state) override;

--- a/esphome/components/copy/text/copy_text.h
+++ b/esphome/components/copy/text/copy_text.h
@@ -11,7 +11,6 @@ class CopyText : public text::Text, public Component {
   void set_source(text::Text *source) { source_ = source; }
   void setup() override;
   void dump_config() override;
-  float get_setup_priority() const override { return setup_priority::DATA; }
 
  protected:
   void control(const std::string &value) override;

--- a/esphome/components/copy/text_sensor/copy_text_sensor.h
+++ b/esphome/components/copy/text_sensor/copy_text_sensor.h
@@ -11,7 +11,6 @@ class CopyTextSensor : public text_sensor::TextSensor, public Component {
   void set_source(text_sensor::TextSensor *source) { source_ = source; }
   void setup() override;
   void dump_config() override;
-  float get_setup_priority() const override { return setup_priority::DATA; }
 
  protected:
   text_sensor::TextSensor *source_;

--- a/esphome/components/cs5460a/cs5460a.h
+++ b/esphome/components/cs5460a/cs5460a.h
@@ -77,7 +77,6 @@ class CS5460AComponent : public Component,
 
   void setup() override;
   void loop() override {}
-  float get_setup_priority() const override { return setup_priority::DATA; }
   void dump_config() override;
 
  protected:

--- a/esphome/components/duty_time/duty_time_sensor.h
+++ b/esphome/components/duty_time/duty_time_sensor.h
@@ -19,7 +19,6 @@ class DutyTimeSensor : public sensor::Sensor, public PollingComponent {
   void update() override;
   void loop() override;
   void dump_config() override;
-  float get_setup_priority() const override { return setup_priority::DATA; }
 
   void start();
   void stop();

--- a/esphome/components/ens160_base/ens160_base.h
+++ b/esphome/components/ens160_base/ens160_base.h
@@ -18,7 +18,6 @@ class ENS160Component : public PollingComponent, public sensor::Sensor {
   void setup() override;
   void update() override;
   void dump_config() override;
-  float get_setup_priority() const override { return setup_priority::DATA; }
 
  protected:
   void send_env_data_();

--- a/esphome/components/es7210/es7210.h
+++ b/esphome/components/es7210/es7210.h
@@ -25,7 +25,6 @@ class ES7210 : public audio_adc::AudioAdc, public Component, public i2c::I2CDevi
    */
  public:
   void setup() override;
-  float get_setup_priority() const override { return setup_priority::DATA; }
   void dump_config() override;
 
   void set_bits_per_sample(ES7210BitsPerSample bits_per_sample) { this->bits_per_sample_ = bits_per_sample; }

--- a/esphome/components/es7243e/es7243e.h
+++ b/esphome/components/es7243e/es7243e.h
@@ -14,7 +14,6 @@ class ES7243E : public audio_adc::AudioAdc, public Component, public i2c::I2CDev
    */
  public:
   void setup() override;
-  float get_setup_priority() const override { return setup_priority::DATA; }
   void dump_config() override;
 
   bool set_mic_gain(float mic_gain) override;

--- a/esphome/components/es8156/es8156.h
+++ b/esphome/components/es8156/es8156.h
@@ -14,7 +14,6 @@ class ES8156 : public audio_dac::AudioDac, public Component, public i2c::I2CDevi
   /////////////////////////
 
   void setup() override;
-  float get_setup_priority() const override { return setup_priority::DATA; }
   void dump_config() override;
 
   ////////////////////////

--- a/esphome/components/es8311/es8311.h
+++ b/esphome/components/es8311/es8311.h
@@ -50,7 +50,6 @@ class ES8311 : public audio_dac::AudioDac, public Component, public i2c::I2CDevi
   /////////////////////////
 
   void setup() override;
-  float get_setup_priority() const override { return setup_priority::DATA; }
   void dump_config() override;
 
   ////////////////////////

--- a/esphome/components/es8388/es8388.h
+++ b/esphome/components/es8388/es8388.h
@@ -38,7 +38,6 @@ class ES8388 : public audio_dac::AudioDac, public Component, public i2c::I2CDevi
   /////////////////////////
 
   void setup() override;
-  float get_setup_priority() const override { return setup_priority::DATA; }
   void dump_config() override;
 
   ////////////////////////

--- a/esphome/components/esp32_touch/esp32_touch.h
+++ b/esphome/components/esp32_touch/esp32_touch.h
@@ -52,7 +52,6 @@ class ESP32TouchComponent : public Component {
   void setup() override;
   void dump_config() override;
   void loop() override;
-  float get_setup_priority() const override { return setup_priority::DATA; }
 
   void on_shutdown() override;
 

--- a/esphome/components/ezo/ezo.h
+++ b/esphome/components/ezo/ezo.h
@@ -38,7 +38,6 @@ class EZOSensor : public sensor::Sensor, public PollingComponent, public i2c::I2
   void loop() override;
   void dump_config() override;
   void update() override;
-  float get_setup_priority() const override { return setup_priority::DATA; };
 
   // I2C
   void set_address(uint8_t address);

--- a/esphome/components/ezo_pmp/ezo_pmp.h
+++ b/esphome/components/ezo_pmp/ezo_pmp.h
@@ -23,7 +23,6 @@ namespace ezo_pmp {
 class EzoPMP : public PollingComponent, public i2c::I2CDevice {
  public:
   void dump_config() override;
-  float get_setup_priority() const override { return setup_priority::DATA; };
 
   void loop() override;
   void update() override;

--- a/esphome/components/feedback/feedback_cover.h
+++ b/esphome/components/feedback/feedback_cover.h
@@ -16,7 +16,6 @@ class FeedbackCover : public cover::Cover, public Component {
   void setup() override;
   void loop() override;
   void dump_config() override;
-  float get_setup_priority() const override { return setup_priority::DATA; };
 
   Trigger<> *get_open_trigger() const { return this->open_trigger_; }
   Trigger<> *get_close_trigger() const { return this->close_trigger_; }

--- a/esphome/components/fs3000/fs3000.h
+++ b/esphome/components/fs3000/fs3000.h
@@ -18,7 +18,6 @@ class FS3000Component : public PollingComponent, public i2c::I2CDevice, public s
   void update() override;
 
   void dump_config() override;
-  float get_setup_priority() const override { return setup_priority::DATA; }
 
   void set_model(FS3000Model model) { this->model_ = model; }
 

--- a/esphome/components/gcja5/gcja5.h
+++ b/esphome/components/gcja5/gcja5.h
@@ -12,7 +12,6 @@ class GCJA5Component : public Component, public uart::UARTDevice {
  public:
   void dump_config() override;
   void loop() override;
-  float get_setup_priority() const override { return setup_priority::DATA; }
 
   void set_pm_1_0_sensor(sensor::Sensor *pm_1_0) { pm_1_0_sensor_ = pm_1_0; }
   void set_pm_2_5_sensor(sensor::Sensor *pm_2_5) { pm_2_5_sensor_ = pm_2_5; }

--- a/esphome/components/gp8403/gp8403.h
+++ b/esphome/components/gp8403/gp8403.h
@@ -15,7 +15,6 @@ class GP8403 : public Component, public i2c::I2CDevice {
  public:
   void setup() override;
   void dump_config() override;
-  float get_setup_priority() const override { return setup_priority::DATA; }
 
   void set_voltage(gp8403::GP8403Voltage voltage) { this->voltage_ = voltage; }
 

--- a/esphome/components/grove_gas_mc_v2/grove_gas_mc_v2.h
+++ b/esphome/components/grove_gas_mc_v2/grove_gas_mc_v2.h
@@ -22,8 +22,6 @@ class GroveGasMultichannelV2Component : public PollingComponent, public i2c::I2C
 
   void dump_config() override;
 
-  float get_setup_priority() const override { return setup_priority::DATA; }
-
  protected:
   enum ErrorCode {
     UNKNOWN,

--- a/esphome/components/he60r/he60r.h
+++ b/esphome/components/he60r/he60r.h
@@ -13,7 +13,6 @@ class HE60rCover : public cover::Cover, public Component, public uart::UARTDevic
   void setup() override;
   void loop() override;
   void dump_config() override;
-  float get_setup_priority() const override { return setup_priority::DATA; };
 
   void set_open_duration(uint32_t duration) { this->open_duration_ = duration; }
   void set_close_duration(uint32_t duration) { this->close_duration_ = duration; }

--- a/esphome/components/honeywellabp2_i2c/honeywellabp2.h
+++ b/esphome/components/honeywellabp2_i2c/honeywellabp2.h
@@ -18,7 +18,6 @@ class HONEYWELLABP2Sensor : public PollingComponent, public i2c::I2CDevice {
   void set_temperature_sensor(sensor::Sensor *temperature_sensor) { this->temperature_sensor_ = temperature_sensor; };
   void loop() override;
   void update() override;
-  float get_setup_priority() const override { return setup_priority::DATA; };
   void dump_config() override;
 
   void read_sensor_data();

--- a/esphome/components/i2c_device/i2c_device.h
+++ b/esphome/components/i2c_device/i2c_device.h
@@ -9,7 +9,6 @@ namespace i2c_device {
 class I2CDeviceComponent : public Component, public i2c::I2CDevice {
  public:
   void dump_config() override;
-  float get_setup_priority() const override { return setup_priority::DATA; }
 
  protected:
 };

--- a/esphome/components/iaqcore/iaqcore.h
+++ b/esphome/components/iaqcore/iaqcore.h
@@ -16,8 +16,6 @@ class IAQCore : public PollingComponent, public i2c::I2CDevice {
   void update() override;
   void dump_config() override;
 
-  float get_setup_priority() const override { return setup_priority::DATA; }
-
  protected:
   sensor::Sensor *co2_{nullptr};
   sensor::Sensor *tvoc_{nullptr};

--- a/esphome/components/ina260/ina260.h
+++ b/esphome/components/ina260/ina260.h
@@ -13,8 +13,6 @@ class INA260Component : public PollingComponent, public i2c::I2CDevice {
   void dump_config() override;
   void update() override;
 
-  float get_setup_priority() const override { return setup_priority::DATA; }
-
   void set_bus_voltage_sensor(sensor::Sensor *bus_voltage_sensor) { this->bus_voltage_sensor_ = bus_voltage_sensor; }
   void set_current_sensor(sensor::Sensor *current_sensor) { this->current_sensor_ = current_sensor; }
   void set_power_sensor(sensor::Sensor *power_sensor) { this->power_sensor_ = power_sensor; }

--- a/esphome/components/inkbird_ibsth1_mini/inkbird_ibsth1_mini.h
+++ b/esphome/components/inkbird_ibsth1_mini/inkbird_ibsth1_mini.h
@@ -16,7 +16,6 @@ class InkbirdIbstH1Mini : public Component, public esp32_ble_tracker::ESPBTDevic
   bool parse_device(const esp32_ble_tracker::ESPBTDevice &device) override;
 
   void dump_config() override;
-  float get_setup_priority() const override { return setup_priority::DATA; }
   void set_temperature(sensor::Sensor *temperature) { temperature_ = temperature; }
   void set_external_temperature(sensor::Sensor *external_temperature) { external_temperature_ = external_temperature; }
   void set_humidity(sensor::Sensor *humidity) { humidity_ = humidity; }

--- a/esphome/components/integration/integration_sensor.h
+++ b/esphome/components/integration/integration_sensor.h
@@ -27,7 +27,6 @@ class IntegrationSensor : public sensor::Sensor, public Component {
  public:
   void setup() override;
   void dump_config() override;
-  float get_setup_priority() const override { return setup_priority::DATA; }
   void set_sensor(Sensor *sensor) { sensor_ = sensor; }
   void set_time(IntegrationSensorTime time) { time_ = time; }
   void set_method(IntegrationMethod method) { method_ = method; }

--- a/esphome/components/interval/interval.h
+++ b/esphome/components/interval/interval.h
@@ -23,8 +23,6 @@ class IntervalTrigger : public Trigger<>, public PollingComponent {
 
   void set_startup_delay(const uint32_t startup_delay) { this->startup_delay_ = startup_delay; }
 
-  float get_setup_priority() const override { return setup_priority::DATA; }
-
  protected:
   uint32_t startup_delay_{0};
   bool started_{false};

--- a/esphome/components/ltr390/ltr390.h
+++ b/esphome/components/ltr390/ltr390.h
@@ -44,7 +44,6 @@ enum LTR390RESOLUTION {
 
 class LTR390Component : public PollingComponent, public i2c::I2CDevice {
  public:
-  float get_setup_priority() const override { return setup_priority::DATA; }
   void setup() override;
   void dump_config() override;
   void update() override;

--- a/esphome/components/ltr501/ltr501.h
+++ b/esphome/components/ltr501/ltr501.h
@@ -25,7 +25,6 @@ class LTRAlsPs501Component : public PollingComponent, public i2c::I2CDevice {
   //
   // EspHome framework functions
   //
-  float get_setup_priority() const override { return setup_priority::DATA; }
   void setup() override;
   void dump_config() override;
   void update() override;

--- a/esphome/components/ltr_als_ps/ltr_als_ps.h
+++ b/esphome/components/ltr_als_ps/ltr_als_ps.h
@@ -25,7 +25,6 @@ class LTRAlsPsComponent : public PollingComponent, public i2c::I2CDevice {
   //
   // EspHome framework functions
   //
-  float get_setup_priority() const override { return setup_priority::DATA; }
   void setup() override;
   void dump_config() override;
   void update() override;

--- a/esphome/components/max9611/max9611.h
+++ b/esphome/components/max9611/max9611.h
@@ -38,7 +38,6 @@ class MAX9611Component : public PollingComponent, public i2c::I2CDevice {
  public:
   void setup() override;
   void dump_config() override;
-  float get_setup_priority() const override { return setup_priority::DATA; }
   void update() override;
   void set_voltage_sensor(sensor::Sensor *vs) { voltage_sensor_ = vs; }
   void set_current_sensor(sensor::Sensor *cs) { current_sensor_ = cs; }

--- a/esphome/components/mcp9600/mcp9600.h
+++ b/esphome/components/mcp9600/mcp9600.h
@@ -24,8 +24,6 @@ class MCP9600Component : public PollingComponent, public i2c::I2CDevice {
   void dump_config() override;
   void update() override;
 
-  float get_setup_priority() const override { return setup_priority::DATA; }
-
   void set_hot_junction(sensor::Sensor *hot_junction) { this->hot_junction_sensor_ = hot_junction; }
   void set_cold_junction(sensor::Sensor *cold_junction) { this->cold_junction_sensor_ = cold_junction; }
   void set_thermocouple_type(MCP9600ThermocoupleType thermocouple_type) {

--- a/esphome/components/mopeka_pro_check/mopeka_pro_check.h
+++ b/esphome/components/mopeka_pro_check/mopeka_pro_check.h
@@ -34,7 +34,6 @@ class MopekaProCheck : public Component, public esp32_ble_tracker::ESPBTDeviceLi
 
   bool parse_device(const esp32_ble_tracker::ESPBTDevice &device) override;
   void dump_config() override;
-  float get_setup_priority() const override { return setup_priority::DATA; }
   void set_min_signal_quality(SensorReadQuality min) { this->min_signal_quality_ = min; };
 
   void set_level(sensor::Sensor *level) { level_ = level; };

--- a/esphome/components/mopeka_std_check/mopeka_std_check.h
+++ b/esphome/components/mopeka_std_check/mopeka_std_check.h
@@ -48,7 +48,6 @@ class MopekaStdCheck : public Component, public esp32_ble_tracker::ESPBTDeviceLi
 
   bool parse_device(const esp32_ble_tracker::ESPBTDevice &device) override;
   void dump_config() override;
-  float get_setup_priority() const override { return setup_priority::DATA; }
 
   void set_level(sensor::Sensor *level) { this->level_ = level; };
   void set_temperature(sensor::Sensor *temperature) { this->temperature_ = temperature; };

--- a/esphome/components/mpl3115a2/mpl3115a2.h
+++ b/esphome/components/mpl3115a2/mpl3115a2.h
@@ -91,8 +91,6 @@ class MPL3115A2Component : public PollingComponent, public i2c::I2CDevice {
   void dump_config() override;
   void update() override;
 
-  float get_setup_priority() const override { return setup_priority::DATA; }
-
  protected:
   sensor::Sensor *temperature_{nullptr};
   sensor::Sensor *altitude_{nullptr};

--- a/esphome/components/ms8607/ms8607.h
+++ b/esphome/components/ms8607/ms8607.h
@@ -37,7 +37,6 @@ class MS8607Component : public PollingComponent, public i2c::I2CDevice {
   void setup() override;
   void update() override;
   void dump_config() override;
-  float get_setup_priority() const override { return setup_priority::DATA; };
 
   void set_temperature_sensor(sensor::Sensor *temperature_sensor) { temperature_sensor_ = temperature_sensor; }
   void set_pressure_sensor(sensor::Sensor *pressure_sensor) { pressure_sensor_ = pressure_sensor; }

--- a/esphome/components/pmsa003i/pmsa003i.h
+++ b/esphome/components/pmsa003i/pmsa003i.h
@@ -32,7 +32,6 @@ class PMSA003IComponent : public PollingComponent, public i2c::I2CDevice {
   void setup() override;
   void dump_config() override;
   void update() override;
-  float get_setup_priority() const override { return setup_priority::DATA; }
 
   void set_standard_units(bool standard_units) { this->standard_units_ = standard_units; }
 

--- a/esphome/components/pmsx003/pmsx003.h
+++ b/esphome/components/pmsx003/pmsx003.h
@@ -31,7 +31,6 @@ enum PMSX003State {
 class PMSX003Component : public uart::UARTDevice, public Component {
  public:
   PMSX003Component() = default;
-  float get_setup_priority() const override { return setup_priority::DATA; }
   void dump_config() override;
   void loop() override;
 

--- a/esphome/components/pn7150/pn7150.h
+++ b/esphome/components/pn7150/pn7150.h
@@ -146,7 +146,6 @@ class PN7150 : public nfc::Nfcc, public Component {
  public:
   void setup() override;
   void dump_config() override;
-  float get_setup_priority() const override { return setup_priority::DATA; }
   void loop() override;
 
   void set_irq_pin(GPIOPin *irq_pin) { this->irq_pin_ = irq_pin; }

--- a/esphome/components/pn7160/pn7160.h
+++ b/esphome/components/pn7160/pn7160.h
@@ -161,7 +161,6 @@ class PN7160 : public nfc::Nfcc, public Component {
  public:
   void setup() override;
   void dump_config() override;
-  float get_setup_priority() const override { return setup_priority::DATA; }
   void loop() override;
 
   void set_dwl_req_pin(GPIOPin *dwl_req_pin) { this->dwl_req_pin_ = dwl_req_pin; }

--- a/esphome/components/pulse_counter/pulse_counter_sensor.h
+++ b/esphome/components/pulse_counter/pulse_counter_sensor.h
@@ -76,7 +76,6 @@ class PulseCounterSensor : public sensor::Sensor, public PollingComponent {
   /// Unit of measurement is "pulses/min".
   void setup() override;
   void update() override;
-  float get_setup_priority() const override { return setup_priority::DATA; }
   void dump_config() override;
 
  protected:

--- a/esphome/components/pulse_width/pulse_width.h
+++ b/esphome/components/pulse_width/pulse_width.h
@@ -32,7 +32,6 @@ class PulseWidthSensor : public sensor::Sensor, public PollingComponent {
   void set_pin(InternalGPIOPin *pin) { pin_ = pin; }
   void setup() override { this->store_.setup(this->pin_); }
   void dump_config() override;
-  float get_setup_priority() const override { return setup_priority::DATA; }
   void update() override;
 
  protected:

--- a/esphome/components/pvvx_mithermometer/display/pvvx_display.h
+++ b/esphome/components/pvvx_mithermometer/display/pvvx_display.h
@@ -39,8 +39,6 @@ class PVVXDisplay : public ble_client::BLEClientNode, public PollingComponent {
 
   void dump_config() override;
 
-  float get_setup_priority() const override { return setup_priority::DATA; }
-
   void update() override;
 
   void gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if,

--- a/esphome/components/pvvx_mithermometer/pvvx_mithermometer.h
+++ b/esphome/components/pvvx_mithermometer/pvvx_mithermometer.h
@@ -25,7 +25,6 @@ class PVVXMiThermometer : public Component, public esp32_ble_tracker::ESPBTDevic
 
   bool parse_device(const esp32_ble_tracker::ESPBTDevice &device) override;
   void dump_config() override;
-  float get_setup_priority() const override { return setup_priority::DATA; }
   void set_temperature(sensor::Sensor *temperature) { temperature_ = temperature; }
   void set_humidity(sensor::Sensor *humidity) { humidity_ = humidity; }
   void set_battery_level(sensor::Sensor *battery_level) { battery_level_ = battery_level; }

--- a/esphome/components/qwiic_pir/qwiic_pir.h
+++ b/esphome/components/qwiic_pir/qwiic_pir.h
@@ -36,7 +36,6 @@ class QwiicPIRComponent : public Component, public i2c::I2CDevice, public binary
   void loop() override;
 
   void dump_config() override;
-  float get_setup_priority() const override { return setup_priority::DATA; }
 
   void set_debounce_time(uint16_t debounce_time) { this->debounce_time_ = debounce_time; }
   void set_debounce_mode(DebounceMode mode) { this->debounce_mode_ = mode; }

--- a/esphome/components/rc522/rc522.h
+++ b/esphome/components/rc522/rc522.h
@@ -19,7 +19,6 @@ class RC522 : public PollingComponent {
   void dump_config() override;
 
   void update() override;
-  float get_setup_priority() const override { return setup_priority::DATA; };
 
   void loop() override;
 

--- a/esphome/components/rdm6300/rdm6300.h
+++ b/esphome/components/rdm6300/rdm6300.h
@@ -21,8 +21,6 @@ class RDM6300Component : public Component, public uart::UARTDevice {
   void register_card(RDM6300BinarySensor *obj) { this->cards_.push_back(obj); }
   void register_trigger(RDM6300Trigger *trig) { this->triggers_.push_back(trig); }
 
-  float get_setup_priority() const override { return setup_priority::DATA; }
-
  protected:
   int8_t read_state_{-1};
   uint8_t buffer_[6]{};

--- a/esphome/components/remote_receiver/remote_receiver.h
+++ b/esphome/components/remote_receiver/remote_receiver.h
@@ -59,7 +59,6 @@ class RemoteReceiverComponent : public remote_base::RemoteReceiverBase,
   void setup() override;
   void dump_config() override;
   void loop() override;
-  float get_setup_priority() const override { return setup_priority::DATA; }
 
 #ifdef USE_ESP32
   void set_filter_symbols(uint32_t filter_symbols) { this->filter_symbols_ = filter_symbols; }

--- a/esphome/components/resistance/resistance_sensor.h
+++ b/esphome/components/resistance/resistance_sensor.h
@@ -24,7 +24,6 @@ class ResistanceSensor : public Component, public sensor::Sensor {
       this->process_(this->sensor_->state);
   }
   void dump_config() override;
-  float get_setup_priority() const override { return setup_priority::DATA; }
 
  protected:
   void process_(float value);

--- a/esphome/components/ruuvitag/ruuvitag.h
+++ b/esphome/components/ruuvitag/ruuvitag.h
@@ -48,7 +48,6 @@ class RuuviTag : public Component, public esp32_ble_tracker::ESPBTDeviceListener
   }
 
   void dump_config() override;
-  float get_setup_priority() const override { return setup_priority::DATA; }
   void set_humidity(sensor::Sensor *humidity) { humidity_ = humidity; }
   void set_temperature(sensor::Sensor *temperature) { temperature_ = temperature; }
   void set_pressure(sensor::Sensor *pressure) { pressure_ = pressure; }

--- a/esphome/components/scd30/scd30.h
+++ b/esphome/components/scd30/scd30.h
@@ -26,7 +26,6 @@ class SCD30Component : public Component, public sensirion_common::SensirionI2CDe
   void setup() override;
   void update();
   void dump_config() override;
-  float get_setup_priority() const override { return setup_priority::DATA; }
 
  protected:
   bool is_data_ready_();

--- a/esphome/components/scd4x/scd4x.h
+++ b/esphome/components/scd4x/scd4x.h
@@ -19,7 +19,6 @@ enum MeasurementMode { PERIODIC, LOW_POWER_PERIODIC, SINGLE_SHOT, SINGLE_SHOT_RH
 
 class SCD4XComponent : public PollingComponent, public sensirion_common::SensirionI2CDevice {
  public:
-  float get_setup_priority() const override { return setup_priority::DATA; }
   void setup() override;
   void dump_config() override;
   void update() override;

--- a/esphome/components/script/script.h
+++ b/esphome/components/script/script.h
@@ -239,8 +239,6 @@ template<class C, typename... Ts> class ScriptWaitAction : public Action<Ts...>,
     this->play_next_tuple_(this->var_);
   }
 
-  float get_setup_priority() const override { return setup_priority::DATA; }
-
   void play(Ts... x) override { /* ignore - see play_complex */
   }
 

--- a/esphome/components/sen5x/sen5x.h
+++ b/esphome/components/sen5x/sen5x.h
@@ -48,7 +48,6 @@ struct TemperatureCompensation {
 
 class SEN5XComponent : public PollingComponent, public sensirion_common::SensirionI2CDevice {
  public:
-  float get_setup_priority() const override { return setup_priority::DATA; }
   void setup() override;
   void dump_config() override;
   void update() override;

--- a/esphome/components/senseair/senseair.h
+++ b/esphome/components/senseair/senseair.h
@@ -10,7 +10,6 @@ namespace senseair {
 
 class SenseAirComponent : public PollingComponent, public uart::UARTDevice {
  public:
-  float get_setup_priority() const override { return setup_priority::DATA; }
   void set_co2_sensor(sensor::Sensor *co2_sensor) { co2_sensor_ = co2_sensor; }
 
   void update() override;

--- a/esphome/components/servo/servo.h
+++ b/esphome/components/servo/servo.h
@@ -20,7 +20,6 @@ class Servo : public Component {
   void detach();
   void setup() override;
   void dump_config() override;
-  float get_setup_priority() const override { return setup_priority::DATA; }
   void set_min_level(float min_level) { min_level_ = min_level; }
   void set_idle_level(float idle_level) { idle_level_ = idle_level; }
   void set_max_level(float max_level) { max_level_ = max_level; }

--- a/esphome/components/sfa30/sfa30.h
+++ b/esphome/components/sfa30/sfa30.h
@@ -11,7 +11,6 @@ class SFA30Component : public PollingComponent, public sensirion_common::Sensiri
   enum ErrorCode { DEVICE_MARKING_READ_FAILED, MEASUREMENT_INIT_FAILED, UNKNOWN };
 
  public:
-  float get_setup_priority() const override { return setup_priority::DATA; }
   void setup() override;
   void dump_config() override;
   void update() override;

--- a/esphome/components/sgp30/sgp30.h
+++ b/esphome/components/sgp30/sgp30.h
@@ -32,7 +32,6 @@ class SGP30Component : public PollingComponent, public sensirion_common::Sensiri
   void setup() override;
   void update() override;
   void dump_config() override;
-  float get_setup_priority() const override { return setup_priority::DATA; }
 
  protected:
   void send_env_data_();

--- a/esphome/components/sgp4x/sgp4x.h
+++ b/esphome/components/sgp4x/sgp4x.h
@@ -75,7 +75,6 @@ class SGP4xComponent : public PollingComponent, public sensor::Sensor, public se
   void update() override;
   void take_sample();
   void dump_config() override;
-  float get_setup_priority() const override { return setup_priority::DATA; }
   void set_store_baseline(bool store_baseline) { store_baseline_ = store_baseline; }
   void set_voc_sensor(sensor::Sensor *voc_sensor) { voc_sensor_ = voc_sensor; }
   void set_nox_sensor(sensor::Sensor *nox_sensor) { nox_sensor_ = nox_sensor; }

--- a/esphome/components/sht4x/sht4x.h
+++ b/esphome/components/sht4x/sht4x.h
@@ -17,7 +17,6 @@ enum SHT4XHEATERTIME : uint16_t { SHT4X_HEATERTIME_LONG = 1100, SHT4X_HEATERTIME
 
 class SHT4XComponent : public PollingComponent, public sensirion_common::SensirionI2CDevice {
  public:
-  float get_setup_priority() const override { return setup_priority::DATA; }
   void setup() override;
   void dump_config() override;
   void update() override;

--- a/esphome/components/sm300d2/sm300d2.h
+++ b/esphome/components/sm300d2/sm300d2.h
@@ -9,8 +9,6 @@ namespace sm300d2 {
 
 class SM300D2Sensor : public PollingComponent, public uart::UARTDevice {
  public:
-  float get_setup_priority() const override { return setup_priority::DATA; }
-
   void set_co2_sensor(sensor::Sensor *co2_sensor) { co2_sensor_ = co2_sensor; }
   void set_formaldehyde_sensor(sensor::Sensor *formaldehyde_sensor) { formaldehyde_sensor_ = formaldehyde_sensor; }
   void set_tvoc_sensor(sensor::Sensor *tvoc_sensor) { tvoc_sensor_ = tvoc_sensor; }

--- a/esphome/components/sps30/sps30.h
+++ b/esphome/components/sps30/sps30.h
@@ -26,7 +26,6 @@ class SPS30Component : public PollingComponent, public sensirion_common::Sensiri
   void setup() override;
   void update() override;
   void dump_config() override;
-  float get_setup_priority() const override { return setup_priority::DATA; }
 
   bool start_fan_cleaning();
 

--- a/esphome/components/status/status_binary_sensor.h
+++ b/esphome/components/status/status_binary_sensor.h
@@ -13,8 +13,6 @@ class StatusBinarySensor : public binary_sensor::BinarySensor, public Component 
   void setup() override;
   void dump_config() override;
 
-  float get_setup_priority() const override { return setup_priority::DATA; }
-
   bool is_status_binary_sensor() const override { return true; }
 };
 

--- a/esphome/components/switch/binary_sensor/switch_binary_sensor.h
+++ b/esphome/components/switch/binary_sensor/switch_binary_sensor.h
@@ -12,7 +12,6 @@ class SwitchBinarySensor : public binary_sensor::BinarySensor, public Component 
   void set_source(Switch *source) { source_ = source; }
   void setup() override;
   void dump_config() override;
-  float get_setup_priority() const override { return setup_priority::DATA; }
 
  protected:
   Switch *source_;

--- a/esphome/components/tmp1075/tmp1075.h
+++ b/esphome/components/tmp1075/tmp1075.h
@@ -58,8 +58,6 @@ class TMP1075Sensor : public PollingComponent, public sensor::Sensor, public i2c
   void setup() override;
   void update() override;
 
-  float get_setup_priority() const override { return setup_priority::DATA; }
-
   void dump_config() override;
 
   // Call write_config() after calling any of these to send the new config to

--- a/esphome/components/tof10120/tof10120_sensor.h
+++ b/esphome/components/tof10120/tof10120_sensor.h
@@ -12,7 +12,6 @@ class TOF10120Sensor : public sensor::Sensor, public PollingComponent, public i2
   void setup() override;
 
   void dump_config() override;
-  float get_setup_priority() const override { return setup_priority::DATA; }
   void update() override;
 };
 }  // namespace tof10120

--- a/esphome/components/tormatic/tormatic_cover.h
+++ b/esphome/components/tormatic/tormatic_cover.h
@@ -16,7 +16,6 @@ class Tormatic : public cover::Cover, public uart::UARTDevice, public PollingCom
   void loop() override;
   void update() override;
   void dump_config() override;
-  float get_setup_priority() const override { return setup_priority::DATA; };
 
   void set_open_duration(uint32_t duration) { this->open_duration_ = duration; }
   void set_close_duration(uint32_t duration) { this->close_duration_ = duration; }

--- a/esphome/components/total_daily_energy/total_daily_energy.h
+++ b/esphome/components/total_daily_energy/total_daily_energy.h
@@ -23,7 +23,6 @@ class TotalDailyEnergy : public sensor::Sensor, public Component {
   void set_method(TotalDailyEnergyMethod method) { method_ = method; }
   void setup() override;
   void dump_config() override;
-  float get_setup_priority() const override { return setup_priority::DATA; }
   void loop() override;
 
   void publish_state_and_save(float state);

--- a/esphome/components/ttp229_bsf/ttp229_bsf.h
+++ b/esphome/components/ttp229_bsf/ttp229_bsf.h
@@ -25,7 +25,6 @@ class TTP229BSFComponent : public Component {
   void register_channel(TTP229BSFChannel *channel) { this->channels_.push_back(channel); }
   void setup() override;
   void dump_config() override;
-  float get_setup_priority() const override { return setup_priority::DATA; }
   void loop() override {
     // check datavalid if sdo is high
     if (!this->sdo_pin_->digital_read()) {

--- a/esphome/components/ttp229_lsf/ttp229_lsf.h
+++ b/esphome/components/ttp229_lsf/ttp229_lsf.h
@@ -23,7 +23,6 @@ class TTP229LSFComponent : public Component, public i2c::I2CDevice {
   void register_channel(TTP229Channel *channel) { this->channels_.push_back(channel); }
   void setup() override;
   void dump_config() override;
-  float get_setup_priority() const override { return setup_priority::DATA; }
   void loop() override;
 
  protected:

--- a/esphome/components/vbus/vbus.h
+++ b/esphome/components/vbus/vbus.h
@@ -30,7 +30,6 @@ class VBus : public uart::UARTDevice, public Component {
  public:
   void dump_config() override;
   void loop() override;
-  float get_setup_priority() const override { return setup_priority::DATA; }
 
   void register_listener(VBusListener *listener) { this->listeners_.push_back(listener); }
 

--- a/esphome/components/veml3235/veml3235.h
+++ b/esphome/components/veml3235/veml3235.h
@@ -65,7 +65,6 @@ class VEML3235Sensor : public sensor::Sensor, public PollingComponent, public i2
   void setup() override;
   void dump_config() override;
   void update() override { this->publish_state(this->read_lx_()); }
-  float get_setup_priority() const override { return setup_priority::DATA; }
 
   // Used by ESPHome framework. Does NOT actually set the value on the device.
   void set_auto_gain(bool auto_gain) { this->auto_gain_ = auto_gain; }

--- a/esphome/components/veml7700/veml7700.h
+++ b/esphome/components/veml7700/veml7700.h
@@ -102,7 +102,6 @@ class VEML7700Component : public PollingComponent, public i2c::I2CDevice {
   //
   // EspHome framework functions
   //
-  float get_setup_priority() const override { return setup_priority::DATA; }
   void setup() override;
   void dump_config() override;
   void update() override;

--- a/esphome/components/vl53l0x/vl53l0x_sensor.h
+++ b/esphome/components/vl53l0x/vl53l0x_sensor.h
@@ -30,7 +30,6 @@ class VL53L0XSensor : public sensor::Sensor, public PollingComponent, public i2c
   void setup() override;
 
   void dump_config() override;
-  float get_setup_priority() const override { return setup_priority::DATA; }
   void update() override;
 
   void loop() override;

--- a/esphome/components/xiaomi_cgd1/xiaomi_cgd1.h
+++ b/esphome/components/xiaomi_cgd1/xiaomi_cgd1.h
@@ -17,7 +17,6 @@ class XiaomiCGD1 : public Component, public esp32_ble_tracker::ESPBTDeviceListen
 
   bool parse_device(const esp32_ble_tracker::ESPBTDevice &device) override;
   void dump_config() override;
-  float get_setup_priority() const override { return setup_priority::DATA; }
   void set_temperature(sensor::Sensor *temperature) { temperature_ = temperature; }
   void set_humidity(sensor::Sensor *humidity) { humidity_ = humidity; }
   void set_battery_level(sensor::Sensor *battery_level) { battery_level_ = battery_level; }

--- a/esphome/components/xiaomi_cgdk2/xiaomi_cgdk2.h
+++ b/esphome/components/xiaomi_cgdk2/xiaomi_cgdk2.h
@@ -17,7 +17,6 @@ class XiaomiCGDK2 : public Component, public esp32_ble_tracker::ESPBTDeviceListe
 
   bool parse_device(const esp32_ble_tracker::ESPBTDevice &device) override;
   void dump_config() override;
-  float get_setup_priority() const override { return setup_priority::DATA; }
   void set_temperature(sensor::Sensor *temperature) { temperature_ = temperature; }
   void set_humidity(sensor::Sensor *humidity) { humidity_ = humidity; }
   void set_battery_level(sensor::Sensor *battery_level) { battery_level_ = battery_level; }

--- a/esphome/components/xiaomi_cgg1/xiaomi_cgg1.h
+++ b/esphome/components/xiaomi_cgg1/xiaomi_cgg1.h
@@ -18,7 +18,6 @@ class XiaomiCGG1 : public Component, public esp32_ble_tracker::ESPBTDeviceListen
   bool parse_device(const esp32_ble_tracker::ESPBTDevice &device) override;
 
   void dump_config() override;
-  float get_setup_priority() const override { return setup_priority::DATA; }
   void set_temperature(sensor::Sensor *temperature) { temperature_ = temperature; }
   void set_humidity(sensor::Sensor *humidity) { humidity_ = humidity; }
   void set_battery_level(sensor::Sensor *battery_level) { battery_level_ = battery_level; }

--- a/esphome/components/xiaomi_cgpr1/xiaomi_cgpr1.h
+++ b/esphome/components/xiaomi_cgpr1/xiaomi_cgpr1.h
@@ -21,7 +21,6 @@ class XiaomiCGPR1 : public Component,
   bool parse_device(const esp32_ble_tracker::ESPBTDevice &device) override;
 
   void dump_config() override;
-  float get_setup_priority() const override { return setup_priority::DATA; }
   void set_battery_level(sensor::Sensor *battery_level) { battery_level_ = battery_level; }
   void set_illuminance(sensor::Sensor *illuminance) { illuminance_ = illuminance; }
   void set_idle_time(sensor::Sensor *idle_time) { idle_time_ = idle_time; }

--- a/esphome/components/xiaomi_gcls002/xiaomi_gcls002.h
+++ b/esphome/components/xiaomi_gcls002/xiaomi_gcls002.h
@@ -17,7 +17,6 @@ class XiaomiGCLS002 : public Component, public esp32_ble_tracker::ESPBTDeviceLis
   bool parse_device(const esp32_ble_tracker::ESPBTDevice &device) override;
 
   void dump_config() override;
-  float get_setup_priority() const override { return setup_priority::DATA; }
   void set_temperature(sensor::Sensor *temperature) { temperature_ = temperature; }
   void set_moisture(sensor::Sensor *moisture) { moisture_ = moisture; }
   void set_conductivity(sensor::Sensor *conductivity) { conductivity_ = conductivity; }

--- a/esphome/components/xiaomi_hhccjcy01/xiaomi_hhccjcy01.h
+++ b/esphome/components/xiaomi_hhccjcy01/xiaomi_hhccjcy01.h
@@ -17,7 +17,6 @@ class XiaomiHHCCJCY01 : public Component, public esp32_ble_tracker::ESPBTDeviceL
   bool parse_device(const esp32_ble_tracker::ESPBTDevice &device) override;
 
   void dump_config() override;
-  float get_setup_priority() const override { return setup_priority::DATA; }
   void set_temperature(sensor::Sensor *temperature) { temperature_ = temperature; }
   void set_moisture(sensor::Sensor *moisture) { moisture_ = moisture; }
   void set_conductivity(sensor::Sensor *conductivity) { conductivity_ = conductivity; }

--- a/esphome/components/xiaomi_hhccjcy10/xiaomi_hhccjcy10.h
+++ b/esphome/components/xiaomi_hhccjcy10/xiaomi_hhccjcy10.h
@@ -16,7 +16,6 @@ class XiaomiHHCCJCY10 : public Component, public esp32_ble_tracker::ESPBTDeviceL
   bool parse_device(const esp32_ble_tracker::ESPBTDevice &device) override;
 
   void dump_config() override;
-  float get_setup_priority() const override { return setup_priority::DATA; }
   void set_temperature(sensor::Sensor *temperature) { this->temperature_ = temperature; }
   void set_moisture(sensor::Sensor *moisture) { this->moisture_ = moisture; }
   void set_conductivity(sensor::Sensor *conductivity) { this->conductivity_ = conductivity; }

--- a/esphome/components/xiaomi_hhccpot002/xiaomi_hhccpot002.h
+++ b/esphome/components/xiaomi_hhccpot002/xiaomi_hhccpot002.h
@@ -17,7 +17,6 @@ class XiaomiHHCCPOT002 : public Component, public esp32_ble_tracker::ESPBTDevice
   bool parse_device(const esp32_ble_tracker::ESPBTDevice &device) override;
 
   void dump_config() override;
-  float get_setup_priority() const override { return setup_priority::DATA; }
   void set_moisture(sensor::Sensor *moisture) { moisture_ = moisture; }
   void set_conductivity(sensor::Sensor *conductivity) { conductivity_ = conductivity; }
 

--- a/esphome/components/xiaomi_jqjcy01ym/xiaomi_jqjcy01ym.h
+++ b/esphome/components/xiaomi_jqjcy01ym/xiaomi_jqjcy01ym.h
@@ -17,7 +17,6 @@ class XiaomiJQJCY01YM : public Component, public esp32_ble_tracker::ESPBTDeviceL
   bool parse_device(const esp32_ble_tracker::ESPBTDevice &device) override;
 
   void dump_config() override;
-  float get_setup_priority() const override { return setup_priority::DATA; }
   void set_temperature(sensor::Sensor *temperature) { temperature_ = temperature; }
   void set_humidity(sensor::Sensor *humidity) { humidity_ = humidity; }
   void set_formaldehyde(sensor::Sensor *formaldehyde) { formaldehyde_ = formaldehyde; }

--- a/esphome/components/xiaomi_lywsd02/xiaomi_lywsd02.h
+++ b/esphome/components/xiaomi_lywsd02/xiaomi_lywsd02.h
@@ -17,7 +17,6 @@ class XiaomiLYWSD02 : public Component, public esp32_ble_tracker::ESPBTDeviceLis
   bool parse_device(const esp32_ble_tracker::ESPBTDevice &device) override;
 
   void dump_config() override;
-  float get_setup_priority() const override { return setup_priority::DATA; }
   void set_temperature(sensor::Sensor *temperature) { temperature_ = temperature; }
   void set_humidity(sensor::Sensor *humidity) { humidity_ = humidity; }
   void set_battery_level(sensor::Sensor *battery_level) { battery_level_ = battery_level; }

--- a/esphome/components/xiaomi_lywsd02mmc/xiaomi_lywsd02mmc.h
+++ b/esphome/components/xiaomi_lywsd02mmc/xiaomi_lywsd02mmc.h
@@ -18,7 +18,6 @@ class XiaomiLYWSD02MMC : public Component, public esp32_ble_tracker::ESPBTDevice
   bool parse_device(const esp32_ble_tracker::ESPBTDevice &device) override;
 
   void dump_config() override;
-  float get_setup_priority() const override { return setup_priority::DATA; }
   void set_temperature(sensor::Sensor *temperature) { this->temperature_ = temperature; }
   void set_humidity(sensor::Sensor *humidity) { this->humidity_ = humidity; }
   void set_battery_level(sensor::Sensor *battery_level) { this->battery_level_ = battery_level; }

--- a/esphome/components/xiaomi_lywsd03mmc/xiaomi_lywsd03mmc.h
+++ b/esphome/components/xiaomi_lywsd03mmc/xiaomi_lywsd03mmc.h
@@ -17,7 +17,6 @@ class XiaomiLYWSD03MMC : public Component, public esp32_ble_tracker::ESPBTDevice
 
   bool parse_device(const esp32_ble_tracker::ESPBTDevice &device) override;
   void dump_config() override;
-  float get_setup_priority() const override { return setup_priority::DATA; }
   void set_temperature(sensor::Sensor *temperature) { temperature_ = temperature; }
   void set_humidity(sensor::Sensor *humidity) { humidity_ = humidity; }
   void set_battery_level(sensor::Sensor *battery_level) { battery_level_ = battery_level; }

--- a/esphome/components/xiaomi_lywsdcgq/xiaomi_lywsdcgq.h
+++ b/esphome/components/xiaomi_lywsdcgq/xiaomi_lywsdcgq.h
@@ -17,7 +17,6 @@ class XiaomiLYWSDCGQ : public Component, public esp32_ble_tracker::ESPBTDeviceLi
   bool parse_device(const esp32_ble_tracker::ESPBTDevice &device) override;
 
   void dump_config() override;
-  float get_setup_priority() const override { return setup_priority::DATA; }
   void set_temperature(sensor::Sensor *temperature) { temperature_ = temperature; }
   void set_humidity(sensor::Sensor *humidity) { humidity_ = humidity; }
   void set_battery_level(sensor::Sensor *battery_level) { battery_level_ = battery_level; }

--- a/esphome/components/xiaomi_mhoc303/xiaomi_mhoc303.h
+++ b/esphome/components/xiaomi_mhoc303/xiaomi_mhoc303.h
@@ -17,7 +17,6 @@ class XiaomiMHOC303 : public Component, public esp32_ble_tracker::ESPBTDeviceLis
   bool parse_device(const esp32_ble_tracker::ESPBTDevice &device) override;
 
   void dump_config() override;
-  float get_setup_priority() const override { return setup_priority::DATA; }
   void set_temperature(sensor::Sensor *temperature) { temperature_ = temperature; }
   void set_humidity(sensor::Sensor *humidity) { humidity_ = humidity; }
   void set_battery_level(sensor::Sensor *battery_level) { battery_level_ = battery_level; }

--- a/esphome/components/xiaomi_mhoc401/xiaomi_mhoc401.h
+++ b/esphome/components/xiaomi_mhoc401/xiaomi_mhoc401.h
@@ -17,7 +17,6 @@ class XiaomiMHOC401 : public Component, public esp32_ble_tracker::ESPBTDeviceLis
 
   bool parse_device(const esp32_ble_tracker::ESPBTDevice &device) override;
   void dump_config() override;
-  float get_setup_priority() const override { return setup_priority::DATA; }
   void set_temperature(sensor::Sensor *temperature) { temperature_ = temperature; }
   void set_humidity(sensor::Sensor *humidity) { humidity_ = humidity; }
   void set_battery_level(sensor::Sensor *battery_level) { battery_level_ = battery_level; }

--- a/esphome/components/xiaomi_miscale/xiaomi_miscale.h
+++ b/esphome/components/xiaomi_miscale/xiaomi_miscale.h
@@ -23,7 +23,6 @@ class XiaomiMiscale : public Component, public esp32_ble_tracker::ESPBTDeviceLis
 
   bool parse_device(const esp32_ble_tracker::ESPBTDevice &device) override;
   void dump_config() override;
-  float get_setup_priority() const override { return setup_priority::DATA; }
   void set_weight(sensor::Sensor *weight) { weight_ = weight; }
   void set_impedance(sensor::Sensor *impedance) { impedance_ = impedance; }
   void set_clear_impedance(bool clear_impedance) { clear_impedance_ = clear_impedance; }

--- a/esphome/components/xiaomi_mjyd02yla/xiaomi_mjyd02yla.h
+++ b/esphome/components/xiaomi_mjyd02yla/xiaomi_mjyd02yla.h
@@ -21,7 +21,6 @@ class XiaomiMJYD02YLA : public Component,
   bool parse_device(const esp32_ble_tracker::ESPBTDevice &device) override;
 
   void dump_config() override;
-  float get_setup_priority() const override { return setup_priority::DATA; }
   void set_idle_time(sensor::Sensor *idle_time) { idle_time_ = idle_time; }
   void set_battery_level(sensor::Sensor *battery_level) { battery_level_ = battery_level; }
   void set_illuminance(sensor::Sensor *illuminance) { illuminance_ = illuminance; }

--- a/esphome/components/xiaomi_mue4094rt/xiaomi_mue4094rt.h
+++ b/esphome/components/xiaomi_mue4094rt/xiaomi_mue4094rt.h
@@ -19,7 +19,6 @@ class XiaomiMUE4094RT : public Component,
   bool parse_device(const esp32_ble_tracker::ESPBTDevice &device) override;
 
   void dump_config() override;
-  float get_setup_priority() const override { return setup_priority::DATA; }
   void set_time(uint16_t timeout) { timeout_ = timeout; }
 
  protected:

--- a/esphome/components/xiaomi_rtcgq02lm/xiaomi_rtcgq02lm.h
+++ b/esphome/components/xiaomi_rtcgq02lm/xiaomi_rtcgq02lm.h
@@ -23,7 +23,6 @@ class XiaomiRTCGQ02LM : public Component, public esp32_ble_tracker::ESPBTDeviceL
 
   bool parse_device(const esp32_ble_tracker::ESPBTDevice &device) override;
   void dump_config() override;
-  float get_setup_priority() const override { return setup_priority::DATA; }
 
 #ifdef USE_BINARY_SENSOR
   void set_motion(binary_sensor::BinarySensor *motion) { this->motion_ = motion; }

--- a/esphome/components/xiaomi_wx08zm/xiaomi_wx08zm.h
+++ b/esphome/components/xiaomi_wx08zm/xiaomi_wx08zm.h
@@ -20,7 +20,6 @@ class XiaomiWX08ZM : public Component,
   bool parse_device(const esp32_ble_tracker::ESPBTDevice &device) override;
 
   void dump_config() override;
-  float get_setup_priority() const override { return setup_priority::DATA; }
   void set_tablet(sensor::Sensor *tablet) { tablet_ = tablet; }
   void set_battery_level(sensor::Sensor *battery_level) { battery_level_ = battery_level; }
 

--- a/esphome/components/xiaomi_xmwsdj04mmc/xiaomi_xmwsdj04mmc.h
+++ b/esphome/components/xiaomi_xmwsdj04mmc/xiaomi_xmwsdj04mmc.h
@@ -18,7 +18,6 @@ class XiaomiXMWSDJ04MMC : public Component, public esp32_ble_tracker::ESPBTDevic
   bool parse_device(const esp32_ble_tracker::ESPBTDevice &device) override;
 
   void dump_config() override;
-  float get_setup_priority() const override { return setup_priority::DATA; }
   void set_temperature(sensor::Sensor *temperature) { this->temperature_ = temperature; }
   void set_humidity(sensor::Sensor *humidity) { this->humidity_ = humidity; }
   void set_battery_level(sensor::Sensor *battery_level) { this->battery_level_ = battery_level; }

--- a/esphome/components/zio_ultrasonic/zio_ultrasonic.h
+++ b/esphome/components/zio_ultrasonic/zio_ultrasonic.h
@@ -11,8 +11,6 @@ namespace zio_ultrasonic {
 
 class ZioUltrasonicComponent : public i2c::I2CDevice, public PollingComponent, public sensor::Sensor {
  public:
-  float get_setup_priority() const override { return setup_priority::DATA; }
-
   void dump_config() override;
 
   void update() override;

--- a/esphome/components/zyaura/zyaura.h
+++ b/esphome/components/zyaura/zyaura.h
@@ -69,7 +69,6 @@ class ZyAuraSensor : public PollingComponent {
   void setup() override { this->store_.setup(this->pin_clock_, this->pin_data_); }
   void dump_config() override;
   void update() override;
-  float get_setup_priority() const override { return setup_priority::DATA; }
 
  protected:
   ZaSensorStore store_;


### PR DESCRIPTION
## What does this implement/fix?

This PR removes 129 redundant `get_setup_priority()` overrides that simply return the default value `setup_priority::DATA`. Since the base `Component` class already returns this value by default, these overrides are unnecessary and add to binary size.

### Summary of changes:
- Removed `get_setup_priority()` methods from 129 component files that were returning the default `setup_priority::DATA` value
- No functional changes - all affected components will continue to use the same priority through the base class implementation
- Reduces code duplication and slightly decreases binary size

### Components affected:
Components in categories including sensors, binary sensors, text sensors, displays, and various integrations had redundant overrides removed.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A (no documentation changes needed)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

*Note: This change affects compile-time code only and doesn't require device-specific testing*

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - this is a code cleanup only
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
    - Existing tests cover component functionality
    - Changes are compile-time only and don't affect runtime behavior

If user exposed functionality or configuration variables are added/changed:
  - N/A - No user-facing changes