### PR TITLE
Reduce flash usage by making add_message_object non-template

### DIFF
--- a/esphome/components/api/api_pb2_size.h
+++ b/esphome/components/api/api_pb2_size.h
@@ -316,15 +316,13 @@ class ProtoSize {
   /**
    * @brief Calculates and adds the size of a nested message field to the total message size
    *
-   * This templated version directly takes a message object, calculates its size internally,
+   * This version takes a ProtoMessage object, calculates its size internally,
    * and updates the total_size reference. This eliminates the need for a temporary variable
    * at the call site.
    *
-   * @tparam MessageType The type of the nested message (inferred from parameter)
    * @param message The nested message object
    */
-  template<typename MessageType>
-  static inline void add_message_object(uint32_t &total_size, uint32_t field_id_size, const MessageType &message,
+  static inline void add_message_object(uint32_t &total_size, uint32_t field_id_size, const ProtoMessage &message,
                                         bool force = false) {
     uint32_t nested_size = 0;
     message.calculate_size(nested_size);


### PR DESCRIPTION
# What does this implement/fix?

This PR optimizes the Protocol Buffer size calculation code by converting `ProtoSize::add_message_object` from a template function to a non-template function that uses the `ProtoMessage` base class.

## Background

The `add_message_object` function is used throughout the generated API protocol buffer code to calculate the size of nested message fields. Previously, it was implemented as a template, which resulted in a separate instantiation for each message type (DeviceInfo, AreaInfo, etc.). This caused unnecessary code duplication in the binary.

## Changes

- Modified `api_pb2_size.h` to change `add_message_object` from a template function to a regular function that accepts `const ProtoMessage &`
- The function now uses runtime polymorphism via the virtual `calculate_size()` method instead of compile-time templates
- No functional changes - the behavior remains exactly the same

## Benefits

This optimization reduces flash usage by **116 bytes** on ESP32 by eliminating redundant template instantiations. While this is a modest saving, it demonstrates that using runtime polymorphism can be more space-efficient than templates for this use case.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A - Internal optimization only

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - this is an internal optimization
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

## Measurements

Compiled a test configuration before and after the change:

**Before:**
```
RAM:   [=         ]  13.4% (used 43836 bytes from 327680 bytes)
Flash: [======    ]  60.6% (used 1111776 bytes from 1835008 bytes)
```

**After:**
```
RAM:   [=         ]  13.4% (used 43836 bytes from 327680 bytes)
Flash: [======    ]  60.6% (used 1111660 bytes from 1835008 bytes)
```

Flash savings: **116 bytes*