### PR TITLE
Fix crash when event last_event_type is null in web_server

### DIFF
--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -1683,15 +1683,15 @@ void WebServer::handle_event_request(AsyncWebServerRequest *request, const UrlMa
   request->send(404);
 }
 
+static std::string get_event_type(event::Event *event) { return event->last_event_type ? *event->last_event_type : ""; }
+
 std::string WebServer::event_state_json_generator(WebServer *web_server, void *source) {
-  event::Event *event = (event::Event *) source;
-  const std::string event_type = event->last_event_type ? *event->last_event_type : "";
-  return web_server->event_json(event, event_type, DETAIL_STATE);
+  auto *event = static_cast<event::Event *>(source);
+  return web_server->event_json(event, get_event_type(event), DETAIL_STATE);
 }
 std::string WebServer::event_all_json_generator(WebServer *web_server, void *source) {
-  event::Event *event = (event::Event *) source;
-  const std::string event_type = event->last_event_type ? *event->last_event_type : "";
-  return web_server->event_json(event, event_type, DETAIL_ALL);
+  auto *event = static_cast<event::Event *>(source);
+  return web_server->event_json(event, get_event_type(event), DETAIL_ALL);
 }
 std::string WebServer::event_json(event::Event *obj, const std::string &event_type, JsonDetail start_config) {
   return json::build_json([this, obj, event_type, start_config](JsonObject root) {

--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -1684,11 +1684,14 @@ void WebServer::handle_event_request(AsyncWebServerRequest *request, const UrlMa
 }
 
 std::string WebServer::event_state_json_generator(WebServer *web_server, void *source) {
-  return web_server->event_json((event::Event *) (source), *(((event::Event *) (source))->last_event_type),
-                                DETAIL_STATE);
+  event::Event *event = (event::Event *) source;
+  const std::string event_type = event->last_event_type ? *event->last_event_type : "";
+  return web_server->event_json(event, event_type, DETAIL_STATE);
 }
 std::string WebServer::event_all_json_generator(WebServer *web_server, void *source) {
-  return web_server->event_json((event::Event *) (source), *(((event::Event *) (source))->last_event_type), DETAIL_ALL);
+  event::Event *event = (event::Event *) source;
+  const std::string event_type = event->last_event_type ? *event->last_event_type : "";
+  return web_server->event_json(event, event_type, DETAIL_ALL);
 }
 std::string WebServer::event_json(event::Event *obj, const std::string &event_type, JsonDetail start_config) {
   return json::build_json([this, obj, event_type, start_config](JsonObject root) {


### PR DESCRIPTION
# What does this implement/fix?

This PR fixes a crash in the web_server component that occurs when generating JSON for events that have a null `last_event_type` pointer. The crash manifests as a LoadProhibited exception when the code attempts to dereference the null pointer.

The fix adds null checks in `event_state_json_generator` and `event_all_json_generator` functions before dereferencing `last_event_type`, using an empty string as the default when the pointer is null.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

<!-- No existing issue for this crash -->

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

<!-- No documentation changes needed for this bugfix -->

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# This crash can occur with any configuration that has events and web_server
web_server:
  port: 80

event:
  - platform: template
    name: "Test Event"
    id: test_event
    event_types:
      - "test_event_type"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

## Additional Context

Stack trace from the crash:
```
Guru Meditation Error: Core  0 panic'ed (LoadProhibited). Exception was unhandled.

Core  0 register dump:
PC      : 0x400d4939  PS      : 0x00060130  A0      : 0x800f9636  A1      : 0x3ffcc8b0  
WARNING Decoded 0x400d4939: std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_data() const at /Users/bdraco/.platformio/packages/toolchain-xtensa-esp-elf/xtensa-esp-elf/include/c++/13.2.0/bits/basic_string.h:223
 (inlined by) std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::basic_string(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) at /Users/bdraco/.platformio/packages/toolchain-xtensa-esp-elf/xtensa-esp-elf/include/c++/13.2.0/bits/basic_string.h:541
A2      : 0x3ffcc8e8  A3      : 0x00000000  A4      : 0x00000000  A5      : 0x00000000  
A6      : 0x3ffcce1c  A7      : 0x3ffe835c  A8      : 0x3ffcc8f0  A9      : 0x3ffcca00  
A10     : 0x3ffe8444  A11     : 0x00000000  A12     : 0x00000000  A13     : 0x00060923  
A14     : 0x00000001  A15     : 0x3ffccdd0  SAR     : 0x0000000a  EXCCAUSE: 0x0000001c  
EXCVADDR: 0x00000000  LBEG    : 0x400012e5  LEND    : 0x40001309  LCOUNT  : 0x80100efd  


Backtrace: 0x400d4936:0x3ffcc8b0 0x400f9633:0x3ffcc8e0 0x400f96ad:0x3ffcc940 0x40100f3b:0x3ffcc960 0x40100f85:0x3ffcc9a0 0x400f75b9:0x3ffcc9c0 0x40103349:0x3ffcc9e0 0x40100e9a:0x3ffcca00 0x40100eb0:0x3ffcca20 0x400fbc17:0x3ffcca40 0x400fbc4a:0x3ffcca90 0x4019ff21:0x3ffccab0 0x4019ffd5:0x3ffccad0 0x401019a2:0x3ffccaf0 0x40105cda:0x3ffccb20 0x400e790a:0x3ffccb40
WARNING Found stack trace! Trying to decode it
WARNING Decoded 0x400d4936: std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_Alloc_hider::_Alloc_hider(char*, std::allocator<char>&&) at /Users/bdraco/.platformio/packages/toolchain-xtensa-esp-elf/xtensa-esp-elf/include/c++/13.2.0/bits/basic_string.h:193 (discriminator 1)
 (inlined by) std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_Alloc_hider::_Alloc_hider(char*, std::allocator<char>&&) at /Users/bdraco/.platformio/packages/toolchain-xtensa-esp-elf/xtensa-esp-elf/include/c++/13.2.0/bits/basic_string.h:193 (discriminator 1)
 (inlined by) std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::basic_string(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) at /Users/bdraco/.platformio/packages/toolchain-xtensa-esp-elf/xtensa-esp-elf/include/c++/13.2.0/bits/basic_string.h:538 (discriminator 1)
WARNING Decoded 0x400f9633: esphome::web_server::WebServer::event_json(esphome::event::Event*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, esphome::web_server::JsonDetail) at /Users/bdraco/esphome/.esphome/build/ol/src/esphome/components/web_server/web_server.cpp:1694
WARNING Decoded 0x400f96ad: esphome::web_server::WebServer::event_all_json_generator[abi:cxx11](esphome::web_server::WebServer*, void*) at /Users/bdraco/esphome/.esphome/build/ol/src/esphome/components/web_server/web_server.cpp:1691
WARNING Decoded 0x40100f3b: esphome::web_server_idf::AsyncEventSourceResponse::deferrable_send_state(void*, char const*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > (*)(esphome::web_server::WebServer*, void*)) at /Users/bdraco/esphome/.esphome/build/ol/src/esphome/components/web_server_idf/web_server_idf.cpp:627
 (inlined by) esphome::web_server_idf::AsyncEventSourceResponse::deferrable_send_state(void*, char const*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > (*)(esphome::web_server::WebServer*, void*)) at /Users/bdraco/esphome/.esphome/build/ol/src/esphome/components/web_server_idf/web_server_idf.cpp:601
WARNING Decoded 0x40100f85: esphome::web_server_idf::AsyncEventSource::deferrable_send_state(void*, char const*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > (*)(esphome::web_server::WebServer*, void*)) at /Users/bdraco/esphome/.esphome/build/ol/src/esphome/components/web_server_idf/web_server_idf.cpp:425
WARNING Decoded 0x400f75b9: esphome::web_server::ListEntitiesIterator::on_event(esphome::event::Event*) at /Users/bdraco/esphome/.esphome/build/ol/src/esphome/components/web_server/list_entities.cpp:180
WARNING Decoded 0x40103349: esphome::ComponentIterator::advance() at /Users/bdraco/esphome/.esphome/build/ol/src/esphome/core/component_iterator.cpp:335
WARNING Decoded 0x40100e9a: esphome::web_server_idf::AsyncEventSourceResponse::loop() at /Users/bdraco/esphome/.esphome/build/ol/src/esphome/components/web_server_idf/web_server_idf.cpp:537 (discriminator 1)
WARNING Decoded 0x40100eb0: esphome::web_server_idf::AsyncEventSource::loop() at /Users/bdraco/esphome/.esphome/build/ol/src/esphome/components/web_server_idf/web_server_idf.cpp:412
WARNING Decoded 0x400fbc17: esphome::web_server::WebServer::loop() at /Users/bdraco/esphome/.esphome/build/ol/src/esphome/components/web_server/web_server.cpp:282
WARNING Decoded 0x400fbc4a: non-virtual thunk to esphome::web_server::WebServer::loop() at /Users/bdraco/esphome/.esphome/build/ol/src/esphome/components/web_server/web_server.h:210
WARNING Decoded 0x4019ff21: esphome::Component::call_loop() at /Users/bdraco/esphome/.esphome/build/ol/src/esphome/core/component.cpp:84
WARNING Decoded 0x4019ffd5: esphome::Component::call() at /Users/bdraco/esphome/.esphome/build/ol/src/esphome/core/component.cpp:112
WARNING Decoded 0x401019a2: esphome::Application::loop() at /Users/bdraco/esphome/.esphome/build/ol/src/esphome/core/application.cpp:128
WARNING Decoded 0x40105cda: loop() at /Users/bdraco/esphome/.esphome/build/ol/ol.yaml:1345
WARNING Decoded 0x400e790a: esphome::loop_task(void*) at /Users/bdraco/esphome/.esphome/build/ol/src/esphome/components/esp32/core.cpp:86 (discriminator 1)
```

The crash occurs when an event object's `last_event_type` pointer is null and the code tries to dereference it to create a string copy in line 1691 of web_server.cpp:
```cpp
return web_server->event_json((event::Event *) (source), *(((event::Event *) (source))->last_event_type), DETAIL_ALL);
```