### PR TITLE
Reduce loop enable/disable log spam by using very verbose level

### DIFF
--- a/esphome/core/application.cpp
+++ b/esphome/core/application.cpp
@@ -376,7 +376,7 @@ void Application::enable_pending_loops_() {
 
     // Clear the pending flag and enable the loop
     component->pending_enable_loop_ = false;
-    ESP_LOGD(TAG, "%s loop enabled from ISR", component->get_component_source());
+    ESP_LOGVV(TAG, "%s loop enabled from ISR", component->get_component_source());
     component->component_state_ &= ~COMPONENT_STATE_MASK;
     component->component_state_ |= COMPONENT_STATE_LOOP;
 

--- a/esphome/core/component.cpp
+++ b/esphome/core/component.cpp
@@ -149,7 +149,7 @@ void Component::mark_failed() {
 }
 void Component::disable_loop() {
   if ((this->component_state_ & COMPONENT_STATE_MASK) != COMPONENT_STATE_LOOP_DONE) {
-    ESP_LOGD(TAG, "%s loop disabled", this->get_component_source());
+    ESP_LOGVV(TAG, "%s loop disabled", this->get_component_source());
     this->component_state_ &= ~COMPONENT_STATE_MASK;
     this->component_state_ |= COMPONENT_STATE_LOOP_DONE;
     App.disable_component_loop_(this);
@@ -157,7 +157,7 @@ void Component::disable_loop() {
 }
 void Component::enable_loop() {
   if ((this->component_state_ & COMPONENT_STATE_MASK) == COMPONENT_STATE_LOOP_DONE) {
-    ESP_LOGD(TAG, "%s loop enabled", this->get_component_source());
+    ESP_LOGVV(TAG, "%s loop enabled", this->get_component_source());
     this->component_state_ &= ~COMPONENT_STATE_MASK;
     this->component_state_ |= COMPONENT_STATE_LOOP;
     App.enable_component_loop_(this);


### PR DESCRIPTION
# What does this implement/fix?

This PR reduces log spam from component loop enable/disable messages by changing their log level from `ESP_LOGD` (debug) to `ESP_LOGVV` (very verbose).

During normal operation, especially during [IDF webserver OTA updates](https://github.com/esphome/esphome/pull/9264), the logs can be flooded with repetitive messages like:
```
[17:34:46][D][component:152]: logger loop disabled
[17:34:46][D][app:379]: logger loop enabled from ISR
```

These messages are useful for deep debugging but create noise during normal debug-level logging. By moving them to very verbose level, they remain available when needed but don't clutter typical debug sessions.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes #(issue number if applicable)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - No documentation changes needed

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# No configuration changes required
# To see these messages, set logger to very_verbose:
logger:
  level: VERY_VERBOSE
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).