### PR TITLE
[api] Dump bytes fields as hex instead of unreadable string

### DIFF
--- a/esphome/components/api/api_pb2.cpp
+++ b/esphome/components/api/api_pb2.cpp
@@ -3,6 +3,7 @@
 #include "api_pb2.h"
 #include "api_pb2_size.h"
 #include "esphome/core/log.h"
+#include "esphome/core/helpers.h"
 
 #include <cinttypes>
 
@@ -3510,7 +3511,7 @@ void SubscribeLogsResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  message: ");
-  out.append("'").append(this->message).append("'");
+  out.append(format_hex_pretty(this->message));
   out.append("\n");
 
   out.append("  send_failed: ");
@@ -3538,7 +3539,7 @@ void NoiseEncryptionSetKeyRequest::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("NoiseEncryptionSetKeyRequest {\n");
   out.append("  key: ");
-  out.append("'").append(this->key).append("'");
+  out.append(format_hex_pretty(this->key));
   out.append("\n");
   out.append("}");
 }
@@ -4284,7 +4285,7 @@ void CameraImageResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  data: ");
-  out.append("'").append(this->data).append("'");
+  out.append(format_hex_pretty(this->data));
   out.append("\n");
 
   out.append("  done: ");
@@ -6811,7 +6812,7 @@ void BluetoothServiceData::dump_to(std::string &out) const {
   }
 
   out.append("  data: ");
-  out.append("'").append(this->data).append("'");
+  out.append(format_hex_pretty(this->data));
   out.append("\n");
   out.append("}");
 }
@@ -6894,7 +6895,7 @@ void BluetoothLEAdvertisementResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  name: ");
-  out.append("'").append(this->name).append("'");
+  out.append(format_hex_pretty(this->name));
   out.append("\n");
 
   out.append("  rssi: ");
@@ -6987,7 +6988,7 @@ void BluetoothLERawAdvertisement::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  data: ");
-  out.append("'").append(this->data).append("'");
+  out.append(format_hex_pretty(this->data));
   out.append("\n");
   out.append("}");
 }
@@ -7514,7 +7515,7 @@ void BluetoothGATTReadResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  data: ");
-  out.append("'").append(this->data).append("'");
+  out.append(format_hex_pretty(this->data));
   out.append("\n");
   out.append("}");
 }
@@ -7578,7 +7579,7 @@ void BluetoothGATTWriteRequest::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  data: ");
-  out.append("'").append(this->data).append("'");
+  out.append(format_hex_pretty(this->data));
   out.append("\n");
   out.append("}");
 }
@@ -7670,7 +7671,7 @@ void BluetoothGATTWriteDescriptorRequest::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  data: ");
-  out.append("'").append(this->data).append("'");
+  out.append(format_hex_pretty(this->data));
   out.append("\n");
   out.append("}");
 }
@@ -7772,7 +7773,7 @@ void BluetoothGATTNotifyDataResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  data: ");
-  out.append("'").append(this->data).append("'");
+  out.append(format_hex_pretty(this->data));
   out.append("\n");
   out.append("}");
 }
@@ -8492,7 +8493,7 @@ void VoiceAssistantAudio::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("VoiceAssistantAudio {\n");
   out.append("  data: ");
-  out.append("'").append(this->data).append("'");
+  out.append(format_hex_pretty(this->data));
   out.append("\n");
 
   out.append("  end: ");

--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -4,13 +4,13 @@
 #include "esphome/core/hal.h"
 #include "esphome/core/log.h"
 
+#include <strings.h>
 #include <algorithm>
 #include <cctype>
 #include <cmath>
 #include <cstdarg>
 #include <cstdio>
 #include <cstring>
-#include <strings.h>
 
 #ifdef USE_HOST
 #ifndef _WIN32
@@ -43,10 +43,10 @@
 #include <random>
 #endif
 #ifdef USE_ESP32
-#include "rom/crc.h"
-#include "esp_mac.h"
 #include "esp_efuse.h"
 #include "esp_efuse_table.h"
+#include "esp_mac.h"
+#include "rom/crc.h"
 #endif
 
 #ifdef USE_LIBRETINY
@@ -393,6 +393,21 @@ std::string format_hex_pretty(const uint16_t *data, size_t length) {
   return ret;
 }
 std::string format_hex_pretty(const std::vector<uint16_t> &data) { return format_hex_pretty(data.data(), data.size()); }
+std::string format_hex_pretty(const std::string &data) {
+  if (data.empty())
+    return "";
+  std::string ret;
+  ret.resize(3 * data.length() - 1);
+  for (size_t i = 0; i < data.length(); i++) {
+    ret[3 * i] = format_hex_pretty_char((data[i] & 0xF0) >> 4);
+    ret[3 * i + 1] = format_hex_pretty_char(data[i] & 0x0F);
+    if (i != data.length() - 1)
+      ret[3 * i + 2] = '.';
+  }
+  if (data.length() > 4)
+    return ret + " (" + to_string(data.length()) + ")";
+  return ret;
+}
 
 std::string format_bin(const uint8_t *data, size_t length) {
   std::string result;

--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -405,7 +405,7 @@ std::string format_hex_pretty(const std::string &data) {
       ret[3 * i + 2] = '.';
   }
   if (data.length() > 4)
-    return ret + " (" + to_string(data.length()) + ")";
+    return ret + " (" + std::to_string(data.length()) + ")";
   return ret;
 }
 

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -348,6 +348,8 @@ std::string format_hex_pretty(const uint16_t *data, size_t length);
 std::string format_hex_pretty(const std::vector<uint8_t> &data);
 /// Format the vector \p data in pretty-printed, human-readable hex.
 std::string format_hex_pretty(const std::vector<uint16_t> &data);
+/// Format the string \p data in pretty-printed, human-readable hex.
+std::string format_hex_pretty(const std::string &data);
 /// Format an unsigned integer in pretty-printed, human-readable hex, starting with the most significant byte.
 template<typename T, enable_if_t<std::is_unsigned<T>::value, int> = 0> std::string format_hex_pretty(T val) {
   val = convert_big_endian(val);

--- a/script/api_protobuf/api_protobuf.py
+++ b/script/api_protobuf/api_protobuf.py
@@ -530,7 +530,7 @@ class BytesType(TypeInfo):
     wire_type = WireType.LENGTH_DELIMITED  # Uses wire type 2
 
     def dump(self, name: str) -> str:
-        o = f'out.append("\'").append({name}).append("\'");'
+        o = f"out.append(format_hex_pretty({name}));"
         return o
 
     def get_size_calculation(self, name: str, force: bool = False) -> str:
@@ -1255,6 +1255,7 @@ def main() -> None:
     #include "api_pb2.h"
     #include "api_pb2_size.h"
     #include "esphome/core/log.h"
+    #include "esphome/core/helpers.h"
 
     #include <cinttypes>
 


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

While looking at https://github.com/esphome/issues/issues/7182 I realised it is not easy to understand the logged data, and it doesnt make sense to try log it as a regualar string


```
[08:39:42][VV][api.service:013]: send_message bluetooth_le_raw_advertisements_response: BluetoothLERawAdvertisementsResponse {
[08:39:42][VV][api.service:013]:   advertisements: BluetoothLERawAdvertisement {
[08:39:42][VV][api.service:013]:   address: 146221725868918
[08:39:42][VV][api.service:013]:   rssi: -56
[08:39:42][VV][api.service:013]:   address_type: 0
[08:39:42][VV][api.service:013]:   data: 02.01.06.09.16.77.46.00.00.00.00.00.00 (13)
[08:39:42]}
[08:39:43][VV][api.service:013]: send_message bluetooth_le_raw_advertisements_response: BluetoothLERawAdvertisementsResponse {
[08:39:43][VV][api.service:013]:   advertisements: BluetoothLERawAdvertisement {
[08:39:43][VV][api.service:013]:   address: 224908687744318
[08:39:43][VV][api.service:013]:   rssi: -90
[08:39:43][VV][api.service:013]:   address_type: 0
[08:39:43][VV][api.service:013]:   data: 02.01.06
[08:39:43]}
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
