### PR TITLE
Reduce WiFi stack memory usage when using Ethernet with ESP-IDF

### DIFF
--- a/esphome/components/ethernet/__init__.py
+++ b/esphome/components/ethernet/__init__.py
@@ -342,5 +342,16 @@ async def to_code(config):
 
     cg.add_define("USE_ETHERNET")
 
+    # Disable WiFi when using Ethernet with ESP-IDF
+    # Since ethernet and wifi components are mutually exclusive,
+    # we can save flash space by not compiling WiFi support
+    if CORE.using_esp_idf:
+        add_idf_sdkconfig_option("CONFIG_ESP_WIFI_ENABLED", False)
+        # Also disable WiFi NVS flash to save more space
+        add_idf_sdkconfig_option("CONFIG_ESP_WIFI_NVS_ENABLED", False)
+        # Disable WiFi/BT coexistence since we're not using WiFi
+        # This prevents the coexistence feature from re-enabling WiFi
+        add_idf_sdkconfig_option("CONFIG_ESP_COEX_SW_COEXIST_ENABLE", False)
+
     if CORE.using_arduino:
         cg.add_library("WiFi", None)


### PR DESCRIPTION
# What does this implement/fix?

This PR reduces WiFi stack memory usage on ESP32 devices that use Ethernet instead of WiFi by disabling unnecessary WiFi-related features in ESP-IDF builds.

When using Ethernet with ESP-IDF, we can save approximately 2.4KB of flash memory by disabling:
- `CONFIG_ESP_WIFI_NVS_ENABLED` - WiFi NVS flash storage
- `CONFIG_ESP_COEX_SW_COEXIST_ENABLE` - Software coexistence between WiFi and Bluetooth

Note: The WiFi stack cannot be completely disabled when Bluetooth is enabled due to ESP-IDF internal dependencies (shared PHY layer and hardware coexistence), but this change eliminates unnecessary WiFi features that consume flash memory on Ethernet-only devices.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/issues/issues/7184

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A (no user-facing changes)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# No configuration changes needed - this is an internal optimization
# Example config using Ethernet with Bluetooth on ESP32
esphome:
  name: ethernet-device

esp32:
  board: esp32-poe-iso
  framework:
    type: esp-idf

ethernet:
  type: LAN8720
  mdc_pin: GPIO23
  mdio_pin: GPIO18
  clk_mode: GPIO17_OUT
  phy_addr: 0

# Bluetooth components work normally
esp32_ble_tracker:
bluetooth_proxy:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

## Testing performed:
- Compiled `ol.yaml` (ESP32 with Ethernet + Bluetooth) with memory analysis
- Verified flash savings of ~2.4KB
- Confirmed device compiles successfully with the changes
- Verified `CONFIG_ESP_WIFI_NVS_ENABLED=n` and `CONFIG_ESP_COEX_SW_COEXIST_ENABLE=n` in generated sdkconfig