### PR TITLE
[microphone] simplify mute handling to avoid unnecessary copies

### DIFF
--- a/esphome/components/microphone/microphone.cpp
+++ b/esphome/components/microphone/microphone.cpp
@@ -5,16 +5,14 @@ namespace microphone {
 
 void Microphone::add_data_callback(std::function<void(const std::vector<uint8_t> &)> &&data_callback) {
   std::function<void(const std::vector<uint8_t> &)> mute_handled_callback =
-      [this, data_callback](const std::vector<uint8_t> &data) { data_callback(this->silence_audio_(data)); };
+      [this, data_callback](const std::vector<uint8_t> &data) {
+        if (this->mute_state_) {
+          data_callback(std::vector<uint8_t>(data.size(), 0));
+        } else {
+          data_callback(data);
+        };
+      };
   this->data_callbacks_.add(std::move(mute_handled_callback));
-}
-
-std::vector<uint8_t> Microphone::silence_audio_(std::vector<uint8_t> data) {
-  if (this->mute_state_) {
-    std::memset((void *) data.data(), 0, data.size());
-  }
-
-  return data;
 }
 
 }  // namespace microphone

--- a/esphome/components/microphone/microphone.h
+++ b/esphome/components/microphone/microphone.h
@@ -33,8 +33,6 @@ class Microphone {
   audio::AudioStreamInfo get_audio_stream_info() { return this->audio_stream_info_; }
 
  protected:
-  std::vector<uint8_t> silence_audio_(std::vector<uint8_t> data);
-
   State state_{STATE_STOPPED};
   bool mute_state_{false};
 


### PR DESCRIPTION
# What does this implement/fix?

Currently, the microphone will always copy the data vector before passing it onto the downstream callbacks, even if the microphone isn't muted. This PR simplifies how the mute is applied to avoid unnecessary copies. It reduces the CPU cycles needed for an I2S microphone approximately in half.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** not applicable

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** not applicable

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
