### PR TITLE
Reduce web_server loop overhead on ESP32 by avoiding unnecessary semaphore operations

### DIFF
--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -311,7 +311,8 @@ void WebServer::setup() {
 }
 void WebServer::loop() {
 #ifdef USE_ESP32
-  if (xSemaphoreTake(this->to_schedule_lock_, 0L)) {
+  // Check atomic flag first to avoid taking semaphore when queue is empty
+  if (this->to_schedule_has_items_.load(std::memory_order_relaxed) && xSemaphoreTake(this->to_schedule_lock_, 0L)) {
     std::function<void()> fn;
     if (!to_schedule_.empty()) {
       // scheduler execute things out of order which may lead to incorrect state
@@ -319,6 +320,9 @@ void WebServer::loop() {
       // let's execute it directly from the loop
       fn = std::move(to_schedule_.front());
       to_schedule_.pop_front();
+      if (to_schedule_.empty()) {
+        this->to_schedule_has_items_.store(false, std::memory_order_relaxed);
+      }
     }
     xSemaphoreGive(this->to_schedule_lock_);
     if (fn) {
@@ -2066,6 +2070,7 @@ void WebServer::schedule_(std::function<void()> &&f) {
 #ifdef USE_ESP32
   xSemaphoreTake(this->to_schedule_lock_, portMAX_DELAY);
   to_schedule_.push_back(std::move(f));
+  this->to_schedule_has_items_.store(true, std::memory_order_relaxed);
   xSemaphoreGive(this->to_schedule_lock_);
 #else
   this->defer(std::move(f));

--- a/esphome/components/web_server/web_server.h
+++ b/esphome/components/web_server/web_server.h
@@ -18,6 +18,7 @@
 #include <freertos/FreeRTOS.h>
 #include <freertos/semphr.h>
 #include <deque>
+#include <atomic>
 #endif
 
 #if USE_WEBSERVER_VERSION >= 2
@@ -524,6 +525,7 @@ class WebServer : public Controller, public Component, public AsyncWebHandler {
 #ifdef USE_ESP32
   std::deque<std::function<void()>> to_schedule_;
   SemaphoreHandle_t to_schedule_lock_;
+  std::atomic<bool> to_schedule_has_items_{false};
 #endif
 };
 


### PR DESCRIPTION
# What does this implement/fix?

This PR optimizes the web_server component loop on ESP32 by reducing unnecessary semaphore operations. Previously, the loop would take a semaphore lock on every iteration to check if there was work to do, even when the queue was empty most of the time. This caused measurable overhead in runtime statistics.

The fix adds an atomic flag to track whether the deferred work queue has items, allowing the loop to skip the expensive semaphore operation when the queue is empty. 

**Performance improvement measured:**
- Before: web_server used 620ms of CPU time over 60 seconds (avg 0.09ms per call)
- After: web_server uses only 1ms of CPU time over 60 seconds (avg 0.00ms per call)
- **Result: 99.8% reduction in CPU time spent in web_server loop**

This optimization eliminates the constant semaphore checking overhead while maintaining full functionality when there's actual work to process.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A - No documentation changes needed

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# No configuration changes required
web_server:
  port: 80
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).