### PR TITLE
Fix web_server URL parsing lifetime issue

### DIFF
--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -62,10 +62,7 @@ static UrlMatch parse_url(const char *url_ptr, size_t url_len, bool only_domain)
   // Find domain (everything up to next '/' or end)
   const char *domain_end = (const char *) memchr(start, '/', end - start);
   if (!domain_end) {
-    // No more slashes, entire remaining string is domain
-    match.domain = start;
-    match.domain_len = end - start;
-    match.valid = true;
+    // No second slash found - original behavior returns invalid
     return match;
   }
 

--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -48,93 +48,68 @@ static const char *const HEADER_CORS_ALLOW_PNA = "Access-Control-Allow-Private-N
 
 // Helper function to handle the actual URL parsing logic
 static UrlMatch parse_url(const char *url_ptr, size_t url_len, bool only_domain) {
-  UrlMatch match;
-  match.valid = false;
-  match.domain = nullptr;
-  match.id = nullptr;
-  match.method = nullptr;
-  match.domain_len = 0;
-  match.id_len = 0;
-  match.method_len = 0;
+  UrlMatch match{};
 
   // URL must start with '/'
   if (url_len < 2 || url_ptr[0] != '/') {
     return match;
   }
 
-  // Find domain
-  size_t domain_start = 1;
-  size_t domain_end = domain_start;
+  // Skip leading '/'
+  const char *start = url_ptr + 1;
+  const char *end = url_ptr + url_len;
 
-  // Find the next '/' after domain
-  while (domain_end < url_len && url_ptr[domain_end] != '/') {
-    domain_end++;
-  }
-
-  if (domain_end == url_len) {
-    // URL is just "/domain"
-    match.domain = url_ptr + domain_start;
-    match.domain_len = url_len - domain_start;
+  // Find domain (everything up to next '/' or end)
+  const char *domain_end = (const char *) memchr(start, '/', end - start);
+  if (!domain_end) {
+    // No more slashes, entire remaining string is domain
+    match.domain = start;
+    match.domain_len = end - start;
     match.valid = true;
     return match;
   }
 
   // Set domain
-  match.domain = url_ptr + domain_start;
-  match.domain_len = domain_end - domain_start;
-
-  if (only_domain) {
-    match.valid = true;
-    return match;
-  }
-
-  // Check if there's anything after domain
-  if (url_len == domain_end + 1)
-    return match;
-
-  // Find ID
-  size_t id_begin = domain_end + 1;
-  size_t id_end = id_begin;
-
-  // Find the next '/' after id
-  while (id_end < url_len && url_ptr[id_end] != '/') {
-    id_end++;
-  }
-
+  match.domain = start;
+  match.domain_len = domain_end - start;
   match.valid = true;
 
-  if (id_end == url_len) {
-    // URL is "/domain/id" with no method
-    match.id = url_ptr + id_begin;
-    match.id_len = url_len - id_begin;
+  if (only_domain) {
+    return match;
+  }
+
+  // Parse ID if present
+  if (domain_end + 1 >= end) {
+    return match;  // Nothing after domain slash
+  }
+
+  const char *id_start = domain_end + 1;
+  const char *id_end = (const char *) memchr(id_start, '/', end - id_start);
+
+  if (!id_end) {
+    // No more slashes, entire remaining string is ID
+    match.id = id_start;
+    match.id_len = end - id_start;
     return match;
   }
 
   // Set ID
-  match.id = url_ptr + id_begin;
-  match.id_len = id_end - id_begin;
+  match.id = id_start;
+  match.id_len = id_end - id_start;
 
-  // Set method if present
-  size_t method_begin = id_end + 1;
-  if (method_begin < url_len) {
-    match.method = url_ptr + method_begin;
-    match.method_len = url_len - method_begin;
+  // Parse method if present
+  if (id_end + 1 < end) {
+    match.method = id_end + 1;
+    match.method_len = end - (id_end + 1);
   }
 
   return match;
 }
 
-// Overload for std::string - stores the string to ensure pointers remain valid
-UrlMatch match_url(const std::string &url, bool only_domain = false) {
-  return parse_url(url.c_str(), url.length(), only_domain);
+// Single match_url function that works with any string type
+inline UrlMatch match_url(const char *url, size_t len, bool only_domain = false) {
+  return parse_url(url, len, only_domain);
 }
-
-#ifdef USE_ARDUINO
-// Overload for Arduino String - stores the string to ensure pointers remain valid
-UrlMatch match_url(const String &url, bool only_domain = false) {
-  return parse_url(url.c_str(), url.length(), only_domain);
-}
-#endif
 
 #ifdef USE_ARDUINO
 // helper for allowing only unique entries in the queue
@@ -1785,7 +1760,7 @@ bool WebServer::canHandle(AsyncWebServerRequest *request) const {
   // If we pass it directly to match_url(), it could create a temporary std::string from Arduino String
   // UrlMatch stores pointers to the string's data, so we must ensure the string outlives match_url()
   const auto &url = request->url();
-  UrlMatch match = match_url(url, true);  // NOLINT
+  UrlMatch match = match_url(url.c_str(), url.length(), true);
   if (!match.valid)
     return false;
 #ifdef USE_SENSOR
@@ -1926,7 +1901,7 @@ void WebServer::handleRequest(AsyncWebServerRequest *request) {
 
   // See comment in canHandle() for why we store the URL reference
   const auto &url = request->url();
-  UrlMatch match = match_url(url);  // NOLINT
+  UrlMatch match = match_url(url.c_str(), url.length());
 
 #ifdef USE_SENSOR
   if (match.domain_equals("sensor")) {

--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -46,7 +46,8 @@ static const char *const HEADER_CORS_REQ_PNA = "Access-Control-Request-Private-N
 static const char *const HEADER_CORS_ALLOW_PNA = "Access-Control-Allow-Private-Network";
 #endif
 
-UrlMatch match_url(const std::string &url, bool only_domain = false) {
+// Helper function to handle the actual URL parsing logic
+static UrlMatch parse_url(const char *url_ptr, size_t url_len, bool only_domain) {
   UrlMatch match;
   match.valid = false;
   match.domain = nullptr;
@@ -56,18 +57,21 @@ UrlMatch match_url(const std::string &url, bool only_domain = false) {
   match.id_len = 0;
   match.method_len = 0;
 
-  const char *url_ptr = url.c_str();
-  size_t url_len = url.length();
-
   // URL must start with '/'
-  if (url_len < 2 || url_ptr[0] != '/')
+  if (url_len < 2 || url_ptr[0] != '/') {
     return match;
+  }
 
   // Find domain
   size_t domain_start = 1;
-  size_t domain_end = url.find('/', domain_start);
+  size_t domain_end = domain_start;
 
-  if (domain_end == std::string::npos) {
+  // Find the next '/' after domain
+  while (domain_end < url_len && url_ptr[domain_end] != '/') {
+    domain_end++;
+  }
+
+  if (domain_end == url_len) {
     // URL is just "/domain"
     match.domain = url_ptr + domain_start;
     match.domain_len = url_len - domain_start;
@@ -90,11 +94,16 @@ UrlMatch match_url(const std::string &url, bool only_domain = false) {
 
   // Find ID
   size_t id_begin = domain_end + 1;
-  size_t id_end = url.find('/', id_begin);
+  size_t id_end = id_begin;
+
+  // Find the next '/' after id
+  while (id_end < url_len && url_ptr[id_end] != '/') {
+    id_end++;
+  }
 
   match.valid = true;
 
-  if (id_end == std::string::npos) {
+  if (id_end == url_len) {
     // URL is "/domain/id" with no method
     match.id = url_ptr + id_begin;
     match.id_len = url_len - id_begin;
@@ -114,6 +123,18 @@ UrlMatch match_url(const std::string &url, bool only_domain = false) {
 
   return match;
 }
+
+// Overload for std::string - stores the string to ensure pointers remain valid
+UrlMatch match_url(const std::string &url, bool only_domain = false) {
+  return parse_url(url.c_str(), url.length(), only_domain);
+}
+
+#ifdef USE_ARDUINO
+// Overload for Arduino String - stores the string to ensure pointers remain valid
+UrlMatch match_url(const String &url, bool only_domain = false) {
+  return parse_url(url.c_str(), url.length(), only_domain);
+}
+#endif
 
 #ifdef USE_ARDUINO
 // helper for allowing only unique entries in the queue
@@ -1759,7 +1780,12 @@ bool WebServer::canHandle(AsyncWebServerRequest *request) const {
   }
 #endif
 
-  UrlMatch match = match_url(request->url().c_str(), true);  // NOLINT
+  // Store the URL to prevent temporary string destruction
+  // request->url() returns a reference to a String (on Arduino) or std::string (on ESP-IDF)
+  // If we pass it directly to match_url(), it could create a temporary std::string from Arduino String
+  // UrlMatch stores pointers to the string's data, so we must ensure the string outlives match_url()
+  const auto &url = request->url();
+  UrlMatch match = match_url(url, true);  // NOLINT
   if (!match.valid)
     return false;
 #ifdef USE_SENSOR
@@ -1898,7 +1924,10 @@ void WebServer::handleRequest(AsyncWebServerRequest *request) {
   }
 #endif
 
-  UrlMatch match = match_url(request->url().c_str());  // NOLINT
+  // See comment in canHandle() for why we store the URL reference
+  const auto &url = request->url();
+  UrlMatch match = match_url(url);  // NOLINT
+
 #ifdef USE_SENSOR
   if (match.domain_equals("sensor")) {
     this->handle_sensor_request(request, match);

--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -46,8 +46,8 @@ static const char *const HEADER_CORS_REQ_PNA = "Access-Control-Request-Private-N
 static const char *const HEADER_CORS_ALLOW_PNA = "Access-Control-Allow-Private-Network";
 #endif
 
-// Helper function to handle the actual URL parsing logic
-static UrlMatch parse_url(const char *url_ptr, size_t url_len, bool only_domain) {
+// Parse URL and return match info
+static UrlMatch match_url(const char *url_ptr, size_t url_len, bool only_domain) {
   UrlMatch match{};
 
   // URL must start with '/'
@@ -1749,9 +1749,9 @@ bool WebServer::canHandle(AsyncWebServerRequest *request) const {
 
   // Store the URL to prevent temporary string destruction
   // request->url() returns a reference to a String (on Arduino) or std::string (on ESP-IDF)
-  // UrlMatch stores pointers to the string's data, so we must ensure the string outlives parse_url()
+  // UrlMatch stores pointers to the string's data, so we must ensure the string outlives match_url()
   const auto &url = request->url();
-  UrlMatch match = parse_url(url.c_str(), url.length(), true);
+  UrlMatch match = match_url(url.c_str(), url.length(), true);
   if (!match.valid)
     return false;
 #ifdef USE_SENSOR
@@ -1892,7 +1892,7 @@ void WebServer::handleRequest(AsyncWebServerRequest *request) {
 
   // See comment in canHandle() for why we store the URL reference
   const auto &url = request->url();
-  UrlMatch match = parse_url(url.c_str(), url.length(), false);
+  UrlMatch match = match_url(url.c_str(), url.length(), false);
 
 #ifdef USE_SENSOR
   if (match.domain_equals("sensor")) {

--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -106,11 +106,6 @@ static UrlMatch parse_url(const char *url_ptr, size_t url_len, bool only_domain)
   return match;
 }
 
-// Single match_url function that works with any string type
-inline UrlMatch match_url(const char *url, size_t len, bool only_domain = false) {
-  return parse_url(url, len, only_domain);
-}
-
 #ifdef USE_ARDUINO
 // helper for allowing only unique entries in the queue
 void DeferredUpdateEventSource::deq_push_back_with_dedup_(void *source, message_generator_t *message_generator) {
@@ -1757,10 +1752,9 @@ bool WebServer::canHandle(AsyncWebServerRequest *request) const {
 
   // Store the URL to prevent temporary string destruction
   // request->url() returns a reference to a String (on Arduino) or std::string (on ESP-IDF)
-  // If we pass it directly to match_url(), it could create a temporary std::string from Arduino String
-  // UrlMatch stores pointers to the string's data, so we must ensure the string outlives match_url()
+  // UrlMatch stores pointers to the string's data, so we must ensure the string outlives parse_url()
   const auto &url = request->url();
-  UrlMatch match = match_url(url.c_str(), url.length(), true);
+  UrlMatch match = parse_url(url.c_str(), url.length(), true);
   if (!match.valid)
     return false;
 #ifdef USE_SENSOR
@@ -1901,7 +1895,7 @@ void WebServer::handleRequest(AsyncWebServerRequest *request) {
 
   // See comment in canHandle() for why we store the URL reference
   const auto &url = request->url();
-  UrlMatch match = match_url(url.c_str(), url.length());
+  UrlMatch match = parse_url(url.c_str(), url.length(), false);
 
 #ifdef USE_SENSOR
   if (match.domain_equals("sensor")) {


### PR DESCRIPTION
# What does this implement/fix?

This fixes a regression in the web_server component introduced by #9263 where URL parsing would fail with "httpd_uri: uri handler execution failed" errors on ESP-IDF.

The issue was caused by storing pointers to temporary string data in the `UrlMatch` struct. When `request->url().c_str()` was passed to `match_url()`, it could create a temporary `std::string` (when converting from Arduino `String`), and the pointers stored in `UrlMatch` would point to memory that was freed when the temporary was destroyed.

**This issue only affected the dev branch and never made it to any stable release. The problem only manifests on ESP-IDF builds, not Arduino framework builds.** The original PR was tested primarily on Arduino framework where it worked correctly, with only basic load testing on ESP-IDF, which is why this issue was not caught initially.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Regression from #9263

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - No documentation changes needed

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# No config changes - this fixes existing web_server functionality
web_server:
  port: 80
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

## Additional Details

The fix ensures proper string lifetime by:
1. Storing `request->url()` in a local reference before passing to `parse_url()`
2. Calling `parse_url()` directly with `const char*` and `size_t` parameters
3. Simplifying the parsing logic using `memchr()` for cleaner and more efficient code

Key improvements in this implementation:
- Replaced manual character-by-character loops with `memchr()` for finding delimiters
- Removed template overloads and the `match_url()` wrapper function - now calls `parse_url()` directly
- Reduced code size by ~30% while maintaining the same functionality
- Cleaner pointer arithmetic using start/end pointers instead of indices
- Eliminated unnecessary function indirection

This maintains the memory optimization benefits of #9263 while fixing the lifetime issue and further simplifying the implementation.