### PR TITLE
Fix compiler warning in tsl2591 component

### DIFF
--- a/esphome/components/tsl2591/tsl2591.cpp
+++ b/esphome/components/tsl2591/tsl2591.cpp
@@ -232,7 +232,7 @@ void TSL2591Component::set_integration_time_and_gain(TSL2591IntegrationTime inte
   this->integration_time_ = integration_time;
   this->gain_ = gain;
   if (!this->write_byte(TSL2591_COMMAND_BIT | TSL2591_REGISTER_CONTROL,
-                        this->integration_time_ | this->gain_)) {  // NOLINT
+                        static_cast<uint8_t>(this->integration_time_) | static_cast<uint8_t>(this->gain_))) {
     ESP_LOGE(TAG, "I2C write failed");
   }
   // The ADC values can be confused if gain or integration time are changed in the middle of a cycle.


### PR DESCRIPTION
# What does this implement/fix?

The tsl2591 component produces an easy to fix deprecated warning that has been around for a while. Yes it's a single warning.

``` sh
src/esphome/components/tsl2591/tsl2591.cpp: In member function 'void esphome::tsl2591::TSL2591Component::set_integration_time_and_gain(esphome::tsl2591::TSL2591IntegrationTime, esphome::tsl2591::TSL2591Gain)':
src/esphome/components/tsl2591/tsl2591.cpp:235:49: warning: bitwise operation between different enumeration types 'esphome::tsl2591::TSL2591IntegrationTime' and 'esphome::tsl2591::TSL2591Gain' is deprecated [-Wdeprecated-enum-enum-conversion]
  235 |                         this->integration_time_ | this->gain_)) {  // NOLINT
      |                         ~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~
```
<!-- Quick description and explanation of changes -->

I added two static_cast's.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
sensor:
  - platform: tsl2591
    id: tsl2591_sensor
    update_interval: 1s
    gain: low
    device_factor: 53
    integration_time: 500ms
    calculated_lux:
      name: "Lux"

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
