### PR TITLE
Fix web_server busy loop with ungracefully disconnected clients

### DIFF
--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -137,15 +137,15 @@ void DeferredUpdateEventSource::process_deferred_queue_() {
     if (this->send(message.c_str(), "state") != DISCARDED) {
       // O(n) but memory efficiency is more important than speed here which is why std::vector was chosen
       deferred_queue_.erase(deferred_queue_.begin());
-      consecutive_send_failures_ = 0;  // Reset failure count on successful send
+      this->consecutive_send_failures_ = 0;  // Reset failure count on successful send
     } else {
-      consecutive_send_failures_++;
-      if (consecutive_send_failures_ >= MAX_CONSECUTIVE_SEND_FAILURES) {
+      this->consecutive_send_failures_++;
+      if (this->consecutive_send_failures_ >= MAX_CONSECUTIVE_SEND_FAILURES) {
         // Too many failures, connection is likely dead
         ESP_LOGW(TAG, "Closing stuck EventSource connection after %" PRIu16 " failed sends",
-                 consecutive_send_failures_);
+                 this->consecutive_send_failures_);
         this->close();
-        deferred_queue_.clear();
+        this->deferred_queue_.clear();
       }
       break;
     }
@@ -186,7 +186,7 @@ void DeferredUpdateEventSource::deferrable_send_state(void *source, const char *
     if (this->send(message.c_str(), "state") == DISCARDED) {
       deq_push_back_with_dedup_(source, message_generator);
     } else {
-      consecutive_send_failures_ = 0;  // Reset failure count on successful send
+      this->consecutive_send_failures_ = 0;  // Reset failure count on successful send
     }
   }
 }

--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -137,7 +137,16 @@ void DeferredUpdateEventSource::process_deferred_queue_() {
     if (this->send(message.c_str(), "state") != DISCARDED) {
       // O(n) but memory efficiency is more important than speed here which is why std::vector was chosen
       deferred_queue_.erase(deferred_queue_.begin());
+      consecutive_send_failures_ = 0;  // Reset failure count on successful send
     } else {
+      consecutive_send_failures_++;
+      if (consecutive_send_failures_ >= MAX_CONSECUTIVE_SEND_FAILURES) {
+        // Too many failures, connection is likely dead
+        ESP_LOGW(TAG, "Closing stuck EventSource connection after %" PRIu16 " failed sends",
+                 consecutive_send_failures_);
+        this->close();
+        deferred_queue_.clear();
+      }
       break;
     }
   }
@@ -176,6 +185,8 @@ void DeferredUpdateEventSource::deferrable_send_state(void *source, const char *
     std::string message = message_generator(web_server_, source);
     if (this->send(message.c_str(), "state") == DISCARDED) {
       deq_push_back_with_dedup_(source, message_generator);
+    } else {
+      consecutive_send_failures_ = 0;  // Reset failure count on successful send
     }
   }
 }

--- a/esphome/components/web_server/web_server.h
+++ b/esphome/components/web_server/web_server.h
@@ -126,6 +126,8 @@ class DeferredUpdateEventSource : public AsyncEventSource {
   // footprint is more important than speed here)
   std::vector<DeferredEvent> deferred_queue_;
   WebServer *web_server_;
+  uint16_t consecutive_send_failures_{0};
+  static constexpr uint16_t MAX_CONSECUTIVE_SEND_FAILURES = 2500;  // ~20 seconds at 125Hz loop rate
 
   // helper for allowing only unique entries in the queue
   void deq_push_back_with_dedup_(void *source, message_generator_t *message_generator);


### PR DESCRIPTION
# What does this implement/fix?

This PR fixes a web server busy loop issue that occurs when browser clients disconnect ungracefully (e.g., force closing the browser window, network disconnection). The web server would continue trying to send events to dead connections, consuming significant CPU time. **This issue only affects Arduino framework builds, not ESP-IDF.**

**The issue (Arduino framework only):**
- When a browser window is closed without properly closing the EventSource connection, the TCP connection may remain in a half-open state
- The web server's event loop continues trying to send updates to this dead connection
- Each send attempt fails and returns `DISCARDED`, but the connection isn't removed
- This creates a busy loop consuming ~8-9% of CPU time indefinitely
- ESP-IDF builds use a different implementation that doesn't have this issue

**The fix:**
- Add tracking of consecutive send failures for each EventSource connection (Arduino only)
- After 2500 consecutive failures (~20 seconds at typical loop rate), close the stuck connection
- This gives legitimate clients with temporary congestion plenty of time to recover
- Prevents the web server from wasting CPU cycles on dead connections forever

**Performance improvement (Arduino framework):**
- Before: web_server consumed 5-9% of CPU time with stuck connections trying to clear the queue
- After: web_server returns to near-zero CPU usage after dead connections are cleaned up

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A - No documentation changes needed

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# No configuration changes required
web_server:
  port: 80
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).