### PR TITLE
Use std::span to eliminate heap allocation for single-packet API transmissions

### DIFF
--- a/esphome/components/api/api_frame_helper.h
+++ b/esphome/components/api/api_frame_helper.h
@@ -2,6 +2,7 @@
 #include <cstdint>
 #include <deque>
 #include <limits>
+#include <span>
 #include <utility>
 #include <vector>
 
@@ -101,7 +102,7 @@ class APIFrameHelper {
   // Write multiple protobuf packets in a single operation
   // packets contains (message_type, offset, length) for each message in the buffer
   // The buffer contains all messages with appropriate padding before each
-  virtual APIError write_protobuf_packets(ProtoWriteBuffer buffer, const std::vector<PacketInfo> &packets) = 0;
+  virtual APIError write_protobuf_packets(ProtoWriteBuffer buffer, std::span<const PacketInfo> packets) = 0;
   // Get the frame header padding required by this protocol
   virtual uint8_t frame_header_padding() = 0;
   // Get the frame footer size required by this protocol
@@ -194,7 +195,7 @@ class APINoiseFrameHelper : public APIFrameHelper {
   APIError loop() override;
   APIError read_packet(ReadPacketBuffer *buffer) override;
   APIError write_protobuf_packet(uint16_t type, ProtoWriteBuffer buffer) override;
-  APIError write_protobuf_packets(ProtoWriteBuffer buffer, const std::vector<PacketInfo> &packets) override;
+  APIError write_protobuf_packets(ProtoWriteBuffer buffer, std::span<const PacketInfo> packets) override;
   // Get the frame header padding required by this protocol
   uint8_t frame_header_padding() override { return frame_header_padding_; }
   // Get the frame footer size required by this protocol
@@ -248,7 +249,7 @@ class APIPlaintextFrameHelper : public APIFrameHelper {
   APIError loop() override;
   APIError read_packet(ReadPacketBuffer *buffer) override;
   APIError write_protobuf_packet(uint16_t type, ProtoWriteBuffer buffer) override;
-  APIError write_protobuf_packets(ProtoWriteBuffer buffer, const std::vector<PacketInfo> &packets) override;
+  APIError write_protobuf_packets(ProtoWriteBuffer buffer, std::span<const PacketInfo> packets) override;
   uint8_t frame_header_padding() override { return frame_header_padding_; }
   // Get the frame footer size required by this protocol
   uint8_t frame_footer_size() override { return frame_footer_size_; }


### PR DESCRIPTION
# What does this implement/fix?

This PR optimizes the API frame helper's packet writing path by replacing `std::vector<PacketInfo>` with `std::span<const PacketInfo>` for the `write_protobuf_packets` method. This change leverages C++20 features to eliminate heap allocations for single-packet transmissions.

Single-packet transmissions represent the vast majority of API traffic, including:
- **Bluetooth proxy data** - Each BLE advertisement, scan result, and GATT operation is sent as an individual packet
- **State updates** - Each sensor reading, switch state change, or other entity update is transmitted separately
- **Log messages** - Each debug, info, warning, or error log entry is sent as a single packet
- **Real-time events** - Button presses, motion detection, and other immediate notifications

The optimization provides:
- **Zero heap allocation** for these common single-packet cases by using `std::span` with stack-allocated `PacketInfo`
- **Improved Bluetooth proxy performance** - Critical for handling high-frequency BLE advertisements without memory churn
- **Lower latency for state updates** - Sensor values and switch states are transmitted with less overhead
- **Reduced log streaming overhead** - Important for debugging and monitoring without impacting performance
- **Backward compatibility** with existing code that passes `std::vector<PacketInfo>` (implicit conversion to span)

Additional optimizations included:
- Cache buffer pointer outside loops to avoid repeated dereferencing
- Remove redundant local variables in packet processing
- Use direct byte operations with static_casts

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - this is an internal optimization
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

---

## Memory Impact

**Before:**
```
RAM:   [          ]   4.8% (used 15788 bytes from 327680 bytes)
Flash: [===       ]  29.4% (used 539668 bytes from 1835008 bytes)
```

**After:**
```
RAM:   [          ]   4.8% (used 15788 bytes from 327680 bytes)
Flash: [===       ]  29.4% (used 539584 bytes from 1835008 bytes)
```

**Result:** 84 bytes reduction in flash usage with no increase in RAM usage.
