### PR TITLE
[waveshare_epaper] Add support for Waveshare 3.7inch (G) display

### DIFF
--- a/esphome/components/waveshare_epaper/display.py
+++ b/esphome/components/waveshare_epaper/display.py
@@ -24,6 +24,7 @@ WaveshareEPaper = waveshare_epaper_ns.class_("WaveshareEPaper", WaveshareEPaperB
 WaveshareEPaperBWR = waveshare_epaper_ns.class_(
     "WaveshareEPaperBWR", WaveshareEPaperBase
 )
+WaveshareEPaper4C = waveshare_epaper_ns.class_("WaveshareEPaper4C", WaveshareEPaperBase)
 WaveshareEPaper7C = waveshare_epaper_ns.class_("WaveshareEPaper7C", WaveshareEPaperBase)
 WaveshareEPaperTypeA = waveshare_epaper_ns.class_(
     "WaveshareEPaperTypeA", WaveshareEPaper

--- a/esphome/components/waveshare_epaper/display.py
+++ b/esphome/components/waveshare_epaper/display.py
@@ -53,6 +53,9 @@ WaveshareEPaper2P9InBV3 = waveshare_epaper_ns.class_(
 WaveshareEPaper2P9InV2R2 = waveshare_epaper_ns.class_(
     "WaveshareEPaper2P9InV2R2", WaveshareEPaper
 )
+WaveshareEPaper3P7InG = waveshare_epaper_ns.class_(
+    "WaveshareEPaper3P7InG", WaveshareEPaper4C
+)
 GDEW029T5 = waveshare_epaper_ns.class_("GDEW029T5", WaveshareEPaper)
 GDEY029T94 = waveshare_epaper_ns.class_("GDEY029T94", WaveshareEPaper)
 WaveshareEPaper2P9InDKE = waveshare_epaper_ns.class_(
@@ -151,6 +154,7 @@ MODELS = {
     "2.90inv2-r2": ("c", WaveshareEPaper2P9InV2R2),
     "2.90in-d": ("b", WaveshareEPaper2P9InD),
     "2.90in-dke": ("c", WaveshareEPaper2P9InDKE),
+    "3.70in-g": ("b", WaveshareEPaper3P7InG),
     "gdey042t81": ("c", GDEY042T81),
     "4.20in": ("b", WaveshareEPaper4P2In),
     "4.20in-bv2": ("b", WaveshareEPaper4P2InBV2),

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -352,7 +352,10 @@ void HOT WaveshareEPaperBWR::draw_absolute_pixel_internal(int x, int y, Color co
   }
 }
 void WaveshareEPaper4C::fill(Color color) {
-  this->filled_rectangle(0, 0, this->get_width(), this->get_height(), color);
+  const uint8_t pixel_bits = this->color_to_hex(color);
+  const uint8_t fill_pattern = (pixel_bits << 6) | (pixel_bits << 4) | (pixel_bits << 2) | (pixel_bits);
+
+  memset(this->buffer_, fill_pattern, this->get_buffer_length_());
 }
 void HOT WaveshareEPaper4C::draw_absolute_pixel_internal(int x, int y, Color color) {
   if (x >= this->get_width_internal() || y >= this->get_height_internal() || x < 0 || y < 0)

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -362,8 +362,9 @@ void HOT WaveshareEPaper4C::draw_absolute_pixel_internal(int x, int y, Color col
   const uint8_t subpos = x & 0x03;
   const uint8_t pixel_bits = this->color_to_hex(color);
 
-  this->buffer_[pos] &= ~(0xC0 >> (subpos * 2));
-  this->buffer_[pos] |= pixel_bits >> (subpos * 2);
+  const uint8_t offset_bits = (3 - subpos) * 2;
+  this->buffer_[pos] &= ~(0b11 << offset_bits);
+  this->buffer_[pos] |= pixel_bits << offset_bits;
 }
 
 uint8_t WaveshareEPaper4C::color_to_hex(Color color) {
@@ -371,15 +372,15 @@ uint8_t WaveshareEPaper4C::color_to_hex(Color color) {
   if (color.red > 127) {
     if (color.green > 170) {
       if (color.blue > 127) {
-        hex_code = 0b01 << 6;  // White
+        hex_code = 0b01;  // White
       } else {
-        hex_code = 0b10 << 6;  // Yellow
+        hex_code = 0b10;  // Yellow
       }
     } else {
-      hex_code = 0b11 << 6;  // Red
+      hex_code = 0b11;  // Red
     }
   } else {
-    hex_code = 0b00 << 6;  // Black
+    hex_code = 0b00;  // Black
   }
 
   return hex_code;

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -319,6 +319,9 @@ uint32_t WaveshareEPaper::get_buffer_length_() {
 uint32_t WaveshareEPaperBWR::get_buffer_length_() {
   return this->get_width_controller() * this->get_height_internal() / 4u;
 }  // black and red buffer
+uint32_t WaveshareEPaper4C::get_buffer_length_() {
+  return this->get_width_controller() * this->get_height_internal() / 4u;
+}  // 4 colors buffer, 1 pixel = 2 bits, we will store 4 pixels in every byte
 uint32_t WaveshareEPaper7C::get_buffer_length_() {
   return this->get_width_controller() * this->get_height_internal() / 8u * 3u;
 }  // 7 colors buffer, 1 pixel = 3 bits, we will store 8 pixels in 24 bits = 3 bytes
@@ -348,6 +351,40 @@ void HOT WaveshareEPaperBWR::draw_absolute_pixel_internal(int x, int y, Color co
     this->buffer_[pos + buf_half_len] &= ~(0x80 >> subpos);
   }
 }
+void WaveshareEPaper4C::fill(Color color) {
+  this->filled_rectangle(0, 0, this->get_width(), this->get_height(), color);
+}
+void HOT WaveshareEPaper4C::draw_absolute_pixel_internal(int x, int y, Color color) {
+  if (x >= this->get_width_internal() || y >= this->get_height_internal() || x < 0 || y < 0)
+    return;
+
+  const uint32_t pos = (x + y * this->get_width_internal()) / 4u;
+  const uint8_t subpos = x & 0x03;
+  const uint8_t pixel_bits = this->color_to_hex(color);
+
+  this->buffer_[pos] &= ~(0xC0 >> (subpos * 2));
+  this->buffer_[pos] |= pixel_bits >> (subpos * 2);
+}
+
+uint8_t WaveshareEPaper4C::color_to_hex(Color color) {
+  uint8_t hex_code;
+  if (color.red > 127) {
+    if (color.green > 170) {
+      if (color.blue > 127) {
+        hex_code = 0b01 << 6;  // White
+      } else {
+        hex_code = 0b10 << 6;  // Yellow
+      }
+    } else {
+      hex_code = 0b11 << 6;  // Red
+    }
+  } else {
+    hex_code = 0b00 << 6;  // Black
+  }
+
+  return hex_code;
+}
+
 void HOT WaveshareEPaper7C::draw_absolute_pixel_internal(int x, int y, Color color) {
   if (x >= this->get_width_internal() || y >= this->get_height_internal() || x < 0 || y < 0)
     return;

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -2086,8 +2086,8 @@ void WaveshareEPaper3P7InG::dump_config() {
 int WaveshareEPaper3P7InG::get_width_internal() { return 240; }
 int WaveshareEPaper3P7InG::get_height_internal() { return 416; }
 
-// Refresh time is usually 20s, so we use 35s to be save.
-uint32_t WaveshareEPaper3P7InG::idle_timeout_() { return 35000; }
+// Refresh time is usually 12s, so we use 20s to be save.
+uint32_t WaveshareEPaper3P7InG::idle_timeout_() { return 20000; }
 
 // ========================================================
 //     Good Display 2.9in black/white

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -1869,6 +1869,222 @@ int WaveshareEPaper2P9InV2R2::get_width_controller() { return this->get_width_in
 void WaveshareEPaper2P9InV2R2::set_full_update_every(uint32_t full_update_every) {
   this->full_update_every_ = full_update_every;
 }
+
+// ========================================================
+//               3.70in (G)
+// based on SDK and examples in ZIP file from:
+// https://files.waveshare.com/wiki/3.7inch_e-Paper_HAT%2B_G/3in7_e-Paper_G.zip
+// ========================================================
+void WaveshareEPaper3P7InG::initialize() {
+  this->init_display_();
+  ESP_LOGD(TAG, "Initialized WaveshareEPaper3P7");
+  this->deep_sleep();
+}
+
+void WaveshareEPaper3P7InG::init_display_() {
+  this->reset_();
+  this->wait_until_idle_();
+
+  // Panel settings
+  this->command(0x00);
+  this->data(0x0F);
+  this->data(0x29);
+
+  // Power settings
+  this->command(0x01);
+  this->data(0x07);
+  this->data(0x00);
+  this->data(0x22);
+  this->data(0x78);
+  this->data(0x0A);
+  this->data(0x22);
+
+  this->command(0x03);
+  this->data(0x10);
+  this->data(0x54);
+  this->data(0x44);
+
+  this->command(0x06);
+  this->data(0xC0);
+  this->data(0xC0);
+  this->data(0xC0);
+
+  // PLL Control
+  this->command(0x30);
+  this->data(0x08);
+
+  // Temperature sensor enable
+  this->command(0x41);
+  this->data(0x00);
+
+  this->command(0x50);
+  this->data(0x37);
+
+  // TCON setting
+  this->command(0x60);
+  this->data(0x02);
+  this->data(0x02);
+
+  // Resolution setting
+  this->command(0x61);
+  this->data(this->get_width_internal() / 256);
+  this->data(this->get_width_internal() % 256);
+  this->data(this->get_height_internal() / 256);
+  this->data(this->get_height_internal() % 256);
+
+  // Gate/source start setting
+  this->command(0x65);
+  this->data(0x00);
+  this->data(0x00);
+  this->data(0x00);
+  this->data(0x00);
+
+  this->command(0xE7);
+  this->data(0x1C);
+
+  this->command(0xE3);
+  this->data(0x22);
+
+  this->command(0xFF);
+  this->data(0xA5);
+
+  this->command(0xEF);
+  this->data(0x01);
+  this->data(0x1E);
+  this->data(0x0A);
+  this->data(0x1B);
+  this->data(0x0B);
+  this->data(0x17);
+
+  this->command(0xC3);
+  this->data(0xFD);
+  this->command(0xDC);
+  this->data(0x01);
+  this->command(0xDD);
+  this->data(0x08);
+  this->command(0xDE);
+  this->data(0x41);
+
+  this->command(0xFD);
+  this->data(0x01);
+  this->command(0xE8);
+  this->data(0x03);
+
+  this->command(0xDA);
+  this->data(0x07);
+
+  this->command(0xC9);
+  this->data(0x00);
+
+  this->command(0xA8);
+  this->data(0x0F);
+
+  this->command(0xFF);
+  this->data(0xE3);
+
+  this->command(0xE9);
+  this->data(0x01);
+
+  this->command(0x04);
+  this->wait_until_idle_();
+
+  this->command(0xFF);
+  this->data(0xA5);
+
+  this->command(0xEF);
+  this->data(0x03);
+  this->data(0x1E);
+  this->data(0x0A);
+  this->data(0x1B);
+  this->data(0x0E);
+  this->data(0x15);
+
+  this->command(0xDC);
+  this->data(0x01);
+
+  this->command(0xDD);
+  this->data(0x08);
+
+  this->command(0xDE);
+  this->data(0x41);
+
+  this->command(0xFF);
+  this->data(0xE3);
+
+  /* Enable fast refresh
+   * Reduces refresh time from 20s to 12s.
+   */
+  this->command(0xE0);
+  this->data(0x02);
+
+  this->command(0xE6);
+  this->data(0x5B);
+
+  this->command(0xA5);
+  this->data(0x00);
+  this->wait_until_idle_();
+}
+
+void WaveshareEPaper3P7InG::reset_() {
+  // vendor library uses a delay of 200ms, but 20ms seems to work fine
+  if (this->reset_pin_ != nullptr) {
+    this->reset_pin_->digital_write(true);
+    delay(20);
+    this->reset_pin_->digital_write(false);
+    delay(2);
+    this->reset_pin_->digital_write(true);
+    delay(20);
+  }
+}
+
+void HOT WaveshareEPaper3P7InG::display() {
+  this->init_display_();
+
+  this->command(0x10);
+  this->start_data_();
+  this->write_array(this->buffer_, this->get_buffer_length_());
+  this->end_data_();
+
+  this->command(0x12);
+  this->data(0x00);
+  this->wait_until_idle_();
+
+  this->deep_sleep();
+}
+
+// busy pin is inverted compared to most panels!
+bool WaveshareEPaper3P7InG::wait_until_idle_() {
+  if (this->busy_pin_ == nullptr || this->busy_pin_->digital_read()) {
+    return true;
+  }
+
+  const uint32_t start = millis();
+  while (!this->busy_pin_->digital_read()) {
+    if (millis() - start > this->idle_timeout_()) {
+      ESP_LOGE(TAG, "Timeout while displaying image!");
+      return false;
+    }
+    App.feed_wdt();
+    delay(5);
+  }
+  return true;
+}
+
+void WaveshareEPaper3P7InG::dump_config() {
+  LOG_DISPLAY("", "Waveshare E-Paper", this);
+  ESP_LOGCONFIG(TAG, "  Model: 3.7inG");
+  LOG_PIN("  Reset Pin: ", this->reset_pin_);
+  LOG_PIN("  DC Pin: ", this->dc_pin_);
+  LOG_PIN("  Busy Pin: ", this->busy_pin_);
+  LOG_UPDATE_INTERVAL(this);
+}
+
+int WaveshareEPaper3P7InG::get_width_internal() { return 240; }
+int WaveshareEPaper3P7InG::get_height_internal() { return 416; }
+
+// Refresh time is usually 20s, so we use 35s to be save.
+uint32_t WaveshareEPaper3P7InG::idle_timeout_() { return 35000; }
+
 // ========================================================
 //     Good Display 2.9in black/white
 // Datasheet:

--- a/esphome/components/waveshare_epaper/waveshare_epaper.h
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.h
@@ -496,6 +496,36 @@ class WaveshareEPaper2P9InD : public WaveshareEPaper {
   int get_height_internal() override;
 };
 
+class WaveshareEPaper3P7InG : public WaveshareEPaper4C {
+ public:
+  void initialize() override;
+
+  void display() override;
+
+  void dump_config() override;
+
+  void deep_sleep() override {
+    this->command(0x02);
+    this->data(0x00);
+    this->wait_until_idle_();
+    this->command(0x07);
+    this->data(0xA5);
+  }
+
+ protected:
+  int get_width_internal() override;
+
+  int get_height_internal() override;
+
+  uint32_t idle_timeout_() override;
+
+  bool wait_until_idle_();
+
+ private:
+  void init_display_();
+  void reset_();
+};
+
 class GDEY042T81 : public WaveshareEPaper {
  public:
   GDEY042T81();

--- a/esphome/components/waveshare_epaper/waveshare_epaper.h
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.h
@@ -83,6 +83,18 @@ class WaveshareEPaperBWR : public WaveshareEPaperBase {
   uint32_t get_buffer_length_() override;
 };
 
+class WaveshareEPaper4C : public WaveshareEPaperBase {
+ public:
+  uint8_t color_to_hex(Color color);
+  void fill(Color color) override;
+
+  display::DisplayType get_display_type() override { return display::DisplayType::DISPLAY_TYPE_COLOR; }
+
+ protected:
+  void draw_absolute_pixel_internal(int x, int y, Color color) override;
+  uint32_t get_buffer_length_() override;
+};
+
 class WaveshareEPaper7C : public WaveshareEPaperBase {
  public:
   uint8_t color_to_hex(Color color);

--- a/tests/components/waveshare_epaper/common.yaml
+++ b/tests/components/waveshare_epaper/common.yaml
@@ -454,6 +454,26 @@ display:
     lambda: |-
       it.rectangle(0, 0, it.get_width(), it.get_height());
 
+  # 3.7 inch displays
+  - platform: waveshare_epaper
+    id: epd_3_70g
+    model: 3.70in-g
+    spi_id: spi_waveshare_epaper
+    cs_pin:
+      allow_other_uses: true
+      number: ${cs_pin}
+    dc_pin:
+      allow_other_uses: true
+      number: ${dc_pin}
+    busy_pin:
+      allow_other_uses: true
+      number: ${busy_pin}
+    reset_pin:
+      allow_other_uses: true
+      number: ${reset_pin}
+    lambda: |-
+      it.rectangle(0, 0, it.get_width(), it.get_height());
+
   # 4.2 inch displays
   - platform: waveshare_epaper
     id: epd_4_20


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->
This PR adds support for the [Waveshare 3.7inch (G) display](https://www.waveshare.com/wiki/3.7inch_e-Paper_HAT+_(G)_Manual).
As this is the first 4 color (Black/White/Red/Yellow) display to be supported in esphome it also lays some groundwork to simplify adding support for other 4 color displays.

Fast refresh mode is always enabled, which brings the refresh time from ~20 seconds to ~12 seconds. I couldn't see any difference in picture quality between the modes.

Deep sleep is also supported and enabled after every update, as the documentation advises against leaving the screen on for a long time to prevent permanent damage.

![PXL_20250704_112305517](https://github.com/user-attachments/assets/dd53ece2-7c74-48c8-9004-2f6b922b5640)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other


**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#5063

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
esp32:
  board: esp32dev
  framework:
    type: esp-idf

font:
  - file: gfonts://Roboto
    id: roboto
    size: 64

spi:
  - clk_pin: 13
    mosi_pin: 14

display:
  - platform: waveshare_epaper
    cs_pin: 15
    dc_pin: 27
    busy_pin: 25
    reset_pin: 26
    model: 3.70in-g
    update_interval: 24h
    rotation: 90°
    lambda: |
      auto black = Color(0, 0, 0);
      auto red = Color(255, 0, 0);
      auto yellow = Color(255, 255, 0);
      auto white = Color(255, 255, 255);
      it.fill(white);
      it.filled_circle(20, 32, 15, red);
      it.filled_circle(40, 32, 15, yellow);
      it.filled_circle(60, 32, 15, black);
      it.print(0, 50, id(roboto), black, "E-Paper");
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
