### PR TITLE
Add const char overload for Component::defer()

### DIFF
--- a/esphome/core/component.cpp
+++ b/esphome/core/component.cpp
@@ -248,6 +248,9 @@ bool Component::cancel_defer(const std::string &name) {  // NOLINT
 void Component::defer(const std::string &name, std::function<void()> &&f) {  // NOLINT
   App.scheduler.set_timeout(this, name, 0, std::move(f));
 }
+void Component::defer(const char *name, std::function<void()> &&f) {  // NOLINT
+  App.scheduler.set_timeout(this, name, 0, std::move(f));
+}
 void Component::set_timeout(uint32_t timeout, std::function<void()> &&f) {  // NOLINT
   App.scheduler.set_timeout(this, "", timeout, std::move(f));
 }

--- a/esphome/core/component.h
+++ b/esphome/core/component.h
@@ -380,6 +380,21 @@ class Component {
    */
   void defer(const std::string &name, std::function<void()> &&f);  // NOLINT
 
+  /** Defer a callback to the next loop() call with a const char* name.
+   *
+   * IMPORTANT: The provided name pointer must remain valid for the lifetime of the deferred task.
+   * This means the name should be:
+   *   - A string literal (e.g., "update")
+   *   - A static const char* variable
+   *   - A pointer with lifetime >= the deferred execution
+   *
+   * For dynamic strings, use the std::string overload instead.
+   *
+   * @param name The name of the defer function (must have static lifetime)
+   * @param f The callback
+   */
+  void defer(const char *name, std::function<void()> &&f);  // NOLINT
+
   /// Defer a callback to the next loop() call.
   void defer(std::function<void()> &&f);  // NOLINT
 

--- a/tests/integration/fixtures/scheduler_string_test.yaml
+++ b/tests/integration/fixtures/scheduler_string_test.yaml
@@ -75,20 +75,42 @@ script:
           App.scheduler.cancel_timeout(component1, "cancel_static_timeout");
           ESP_LOGI("test", "Cancelled static timeout using const char*");
 
+          // Test 6 & 7: Test defer with const char* overload using a test component
+          class TestDeferComponent : public Component {
+          public:
+            void test_static_defer() {
+              // Test 6: Static string literal with defer (const char* overload)
+              this->defer("static_defer_1", []() {
+                ESP_LOGI("test", "Static defer 1 fired");
+                id(timeout_counter) += 1;
+              });
+
+              // Test 7: Static const char* with defer
+              static const char* DEFER_NAME = "static_defer_2";
+              this->defer(DEFER_NAME, []() {
+                ESP_LOGI("test", "Static defer 2 fired");
+                id(timeout_counter) += 1;
+              });
+            }
+          };
+
+          static TestDeferComponent test_defer_component;
+          test_defer_component.test_static_defer();
+
   - id: test_dynamic_strings
     then:
       - logger.log: "Testing dynamic string timeouts and intervals"
       - lambda: |-
           auto *component2 = id(test_sensor2);
 
-          // Test 6: Dynamic string with set_timeout (std::string)
+          // Test 8: Dynamic string with set_timeout (std::string)
           std::string dynamic_name = "dynamic_timeout_" + std::to_string(id(dynamic_counter)++);
           App.scheduler.set_timeout(component2, dynamic_name, 100, []() {
             ESP_LOGI("test", "Dynamic timeout fired");
             id(timeout_counter) += 1;
           });
 
-          // Test 7: Dynamic string with set_interval
+          // Test 9: Dynamic string with set_interval
           std::string interval_name = "dynamic_interval_" + std::to_string(id(dynamic_counter)++);
           App.scheduler.set_interval(component2, interval_name, 250, [interval_name]() {
             ESP_LOGI("test", "Dynamic interval fired: %s", interval_name.c_str());
@@ -99,7 +121,7 @@ script:
             }
           });
 
-          // Test 8: Cancel with different string object but same content
+          // Test 10: Cancel with different string object but same content
           std::string cancel_name = "cancel_test";
           App.scheduler.set_timeout(component2, cancel_name, 2000, []() {
             ESP_LOGI("test", "This should be cancelled");
@@ -109,6 +131,21 @@ script:
           std::string cancel_name_2 = "cancel_test";
           App.scheduler.cancel_timeout(component2, cancel_name_2);
           ESP_LOGI("test", "Cancelled timeout using different string object");
+
+          // Test 11: Dynamic string with defer (using std::string overload)
+          class TestDynamicDeferComponent : public Component {
+          public:
+            void test_dynamic_defer() {
+              std::string defer_name = "dynamic_defer_" + std::to_string(id(dynamic_counter)++);
+              this->defer(defer_name, [defer_name]() {
+                ESP_LOGI("test", "Dynamic defer fired: %s", defer_name.c_str());
+                id(timeout_counter) += 1;
+              });
+            }
+          };
+
+          static TestDynamicDeferComponent test_dynamic_defer_component;
+          test_dynamic_defer_component.test_dynamic_defer();
 
   - id: report_results
     then:


### PR DESCRIPTION
## What does this implement/fix?

This PR is a follow-up to #9251, adding the missing const char* overload for `Component::defer()` that was overlooked in the original optimization.

PR #9251 added const char* overloads for `set_interval()`, `set_timeout()`, `cancel_interval()`, and `cancel_timeout()` to eliminate unnecessary heap allocations when called with string literals. However, `defer()` was missed, which follows the same pattern and would benefit from the same optimization.

This is particularly beneficial for `mqtt` (5 times) and external components like `ratgdo` which uses named defer calls extensively (24+ times), all with string literals.

Note: A const char* overload for `cancel_defer()` was not added because it is never used in the entire codebase (neither internally nor in any known external components).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Follow-up to #9251

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - Internal optimization only

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - this is an internal optimization
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).