### PR TITLE
Optimize Bluetooth proxy batching and increase scan buffer capacity

### DIFF
--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
@@ -52,6 +52,11 @@ bool BluetoothProxy::parse_device(const esp32_ble_tracker::ESPBTDevice &device) 
   return true;
 }
 
+// Batch size for BLE advertisements to maximize WiFi efficiency
+// Each advertisement is up to 80 bytes when packaged (including protocol overhead)
+// Most advertisements are 20-30 bytes, allowing even more to fit per packet
+// 16 advertisements × 80 bytes (worst case) = 1280 bytes out of ~1320 bytes usable payload
+// This achieves ~97% WiFi MTU utilization while staying under the limit
 static constexpr size_t FLUSH_BATCH_SIZE = 16;
 static std::vector<api::BluetoothLERawAdvertisement> &get_batch_buffer() {
   static std::vector<api::BluetoothLERawAdvertisement> batch_buffer;

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
@@ -52,7 +52,7 @@ bool BluetoothProxy::parse_device(const esp32_ble_tracker::ESPBTDevice &device) 
   return true;
 }
 
-static constexpr size_t FLUSH_BATCH_SIZE = 8;
+static constexpr size_t FLUSH_BATCH_SIZE = 16;
 static std::vector<api::BluetoothLERawAdvertisement> &get_batch_buffer() {
   static std::vector<api::BluetoothLERawAdvertisement> batch_buffer;
   return batch_buffer;

--- a/esphome/components/esp32_ble/ble.h
+++ b/esphome/components/esp32_ble/ble.h
@@ -26,9 +26,9 @@ namespace esp32_ble {
 
 // Maximum number of BLE scan results to buffer
 #ifdef USE_PSRAM
-static constexpr uint8_t SCAN_RESULT_BUFFER_SIZE = 32;
+static constexpr uint8_t SCAN_RESULT_BUFFER_SIZE = 36;
 #else
-static constexpr uint8_t SCAN_RESULT_BUFFER_SIZE = 20;
+static constexpr uint8_t SCAN_RESULT_BUFFER_SIZE = 24;
 #endif
 
 // Maximum size of the BLE event queue - must be power of 2 for lock-free queue

--- a/esphome/components/esp32_ble/ble.h
+++ b/esphome/components/esp32_ble/ble.h
@@ -25,6 +25,11 @@ namespace esphome {
 namespace esp32_ble {
 
 // Maximum number of BLE scan results to buffer
+// Sized to handle bursts of advertisements while allowing for processing delays
+// With 16 advertisements per batch and some safety margin:
+// - Without PSRAM: 24 entries (1.5× batch size)
+// - With PSRAM: 36 entries (2.25× batch size)
+// The reduced structure size (~80 bytes vs ~400 bytes) allows for larger buffers
 #ifdef USE_PSRAM
 static constexpr uint8_t SCAN_RESULT_BUFFER_SIZE = 36;
 #else


### PR DESCRIPTION
# What does this implement/fix?

This PR improves Bluetooth proxy efficiency by increasing the advertisement batch size and scan result buffer capacity.

Previously, we used very conservative settings due to concerns about blocking the event loop. Now that we've switched to lock-free queues for BLE scan results, we can safely increase these values for better performance.

**Changes:**
1. Increase advertisement batch size from 8 to 16
2. Increase scan result buffer size by 4 (20→24 without PSRAM, 32→36 with PSRAM)

**Benefits:**
- Doubles the number of advertisements sent per packet (8 → 16)
- Improves WiFi MTU utilization from 48.5% to 97% (640 → 1280 bytes)
- Reduces WiFi frames sent by 50%
- Improved airtime efficiency and reduced radio contention
- Additional buffer capacity provides safety margin against any loop delays
- Still maintains <100ms forwarding latency with the existing time-based flush

**Technical details:**
- BLE advertisements are typically ~20 bytes raw data (max 62 bytes for adv+scan response)
- When packaged with protocol overhead: ~80 bytes per advertisement (vs ~400 bytes previously for the queued objects)
- WiFi MTU allows ~1320 bytes of usable payload
- 16 advertisements × 80 bytes = 1280 bytes (97% utilization)
- The smaller structure size allows us to safely increase buffer capacity

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Related to https://github.com/esphome/backlog/issues/21

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - No user-facing changes

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# No configuration changes needed - this is an internal optimization
bluetooth_proxy:
  active: true
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).