### PR TITLE
Split LockFreeQueue into base and notifying variants to reduce memory usage

### DIFF
--- a/esphome/components/mqtt/mqtt_backend_esp32.h
+++ b/esphome/components/mqtt/mqtt_backend_esp32.h
@@ -252,7 +252,7 @@ class MQTTBackendESP32 final : public MQTTBackend {
 #if defined(USE_MQTT_IDF_ENQUEUE)
   static void esphome_mqtt_task(void *params);
   EventPool<struct QueueElement, MQTT_QUEUE_LENGTH> mqtt_event_pool_;
-  LockFreeQueue<struct QueueElement, MQTT_QUEUE_LENGTH> mqtt_queue_;
+  NotifyingLockFreeQueue<struct QueueElement, MQTT_QUEUE_LENGTH> mqtt_queue_;
   TaskHandle_t task_handle_{nullptr};
   bool enqueue_(MqttQueueTypeT type, const char *topic, int qos = 0, bool retain = false, const char *payload = NULL,
                 size_t len = 0);

--- a/esphome/core/lock_free_queue.h
+++ b/esphome/core/lock_free_queue.h
@@ -126,18 +126,14 @@ template<class T, uint8_t SIZE> class NotifyingLockFreeQueue : public LockFreeQu
       if (was_empty) {
         // Queue was empty - consumer might be going to sleep, must notify
         xTaskNotifyGive(task_to_notify_);
-      } else {
-        // Queue wasn't empty - check if consumer has caught up to previous tail
-        uint8_t head_after = this->head_.load(std::memory_order_acquire);
-        if (head_after == old_tail) {
-          // Consumer just caught up to where tail was - might go to sleep, must notify
-          // Note: There's a benign race here - between reading head_after and calling
-          // xTaskNotifyGive(), the consumer could advance further. This would result
-          // in an unnecessary wake-up, but is harmless and extremely rare in practice.
-          xTaskNotifyGive(task_to_notify_);
-        }
-        // Otherwise: consumer is still behind, no need to notify
+      } else if (this->head_.load(std::memory_order_acquire) == old_tail) {
+        // Consumer just caught up to where tail was - might go to sleep, must notify
+        // Note: There's a benign race here - between reading head and calling
+        // xTaskNotifyGive(), the consumer could advance further. This would result
+        // in an unnecessary wake-up, but is harmless and extremely rare in practice.
+        xTaskNotifyGive(task_to_notify_);
       }
+      // Otherwise: consumer is still behind, no need to notify
     }
 
     return result;

--- a/esphome/core/lock_free_queue.h
+++ b/esphome/core/lock_free_queue.h
@@ -31,11 +31,19 @@
 
 namespace esphome {
 
+// Base lock-free queue without task notification
 template<class T, uint8_t SIZE> class LockFreeQueue {
  public:
-  LockFreeQueue() : head_(0), tail_(0), dropped_count_(0), task_to_notify_(nullptr) {}
+  LockFreeQueue() : head_(0), tail_(0), dropped_count_(0) {}
 
   bool push(T *element) {
+    bool was_empty;
+    return push_internal_(element, was_empty);
+  }
+
+ protected:
+  // Internal push that reports if queue was empty - for use by derived classes
+  bool push_internal_(T *element, bool &was_empty) {
     if (element == nullptr)
       return false;
 
@@ -51,34 +59,15 @@ template<class T, uint8_t SIZE> class LockFreeQueue {
       return false;
     }
 
-    // Check if queue was empty before push
-    bool was_empty = (current_tail == head_before);
+    was_empty = (current_tail == head_before);
 
     buffer_[current_tail] = element;
     tail_.store(next_tail, std::memory_order_release);
 
-    // Notify optimization: only notify if we need to
-    if (task_to_notify_ != nullptr) {
-      if (was_empty) {
-        // Queue was empty - consumer might be going to sleep, must notify
-        xTaskNotifyGive(task_to_notify_);
-      } else {
-        // Queue wasn't empty - check if consumer has caught up to previous tail
-        uint8_t head_after = head_.load(std::memory_order_acquire);
-        if (head_after == current_tail) {
-          // Consumer just caught up to where tail was - might go to sleep, must notify
-          // Note: There's a benign race here - between reading head_after and calling
-          // xTaskNotifyGive(), the consumer could advance further. This would result
-          // in an unnecessary wake-up, but is harmless and extremely rare in practice.
-          xTaskNotifyGive(task_to_notify_);
-        }
-        // Otherwise: consumer is still behind, no need to notify
-      }
-    }
-
     return true;
   }
 
+ public:
   T *pop() {
     uint8_t current_head = head_.load(std::memory_order_relaxed);
 
@@ -108,11 +97,6 @@ template<class T, uint8_t SIZE> class LockFreeQueue {
     return next_tail == head_.load(std::memory_order_acquire);
   }
 
-  // Set the FreeRTOS task handle to notify when items are pushed to the queue
-  // This enables efficient wake-up of a consumer task that's waiting for data
-  // @param task The FreeRTOS task handle to notify, or nullptr to disable notifications
-  void set_task_to_notify(TaskHandle_t task) { task_to_notify_ = task; }
-
  protected:
   T *buffer_[SIZE];
   // Atomic: written by producer (push/increment), read+reset by consumer (get_and_reset)
@@ -123,7 +107,31 @@ template<class T, uint8_t SIZE> class LockFreeQueue {
   std::atomic<uint8_t> head_;
   // Atomic: written by producer (push), read by consumer (pop) to check if empty
   std::atomic<uint8_t> tail_;
-  // Task handle for notification (optional)
+};
+
+// Extended queue with task notification support
+template<class T, uint8_t SIZE> class NotifyingLockFreeQueue : public LockFreeQueue<T, SIZE> {
+ public:
+  NotifyingLockFreeQueue() : LockFreeQueue<T, SIZE>(), task_to_notify_(nullptr) {}
+
+  bool push(T *element) {
+    bool was_empty;
+    bool result = this->push_internal_(element, was_empty);
+
+    // Notify if push succeeded and queue was empty
+    if (result && task_to_notify_ != nullptr && was_empty) {
+      xTaskNotifyGive(task_to_notify_);
+    }
+
+    return result;
+  }
+
+  // Set the FreeRTOS task handle to notify when items are pushed to the queue
+  // This enables efficient wake-up of a consumer task that's waiting for data
+  // @param task The FreeRTOS task handle to notify, or nullptr to disable notifications
+  void set_task_to_notify(TaskHandle_t task) { task_to_notify_ = task; }
+
+ private:
   TaskHandle_t task_to_notify_;
 };
 

--- a/esphome/core/lock_free_queue.h
+++ b/esphome/core/lock_free_queue.h
@@ -118,9 +118,26 @@ template<class T, uint8_t SIZE> class NotifyingLockFreeQueue : public LockFreeQu
     bool was_empty;
     bool result = this->push_internal_(element, was_empty);
 
-    // Notify if push succeeded and queue was empty
-    if (result && task_to_notify_ != nullptr && was_empty) {
-      xTaskNotifyGive(task_to_notify_);
+    // Notify optimization: only notify if we need to
+    if (result && task_to_notify_ != nullptr) {
+      if (was_empty) {
+        // Queue was empty - consumer might be going to sleep, must notify
+        xTaskNotifyGive(task_to_notify_);
+      } else {
+        // Queue wasn't empty - check if consumer has caught up to previous tail
+        uint8_t current_tail = this->tail_.load(std::memory_order_relaxed);
+        uint8_t head_after = this->head_.load(std::memory_order_acquire);
+        // We just pushed, so go back one position to get the old tail
+        uint8_t previous_tail = (current_tail + SIZE - 1) % SIZE;
+        if (head_after == previous_tail) {
+          // Consumer just caught up to where tail was - might go to sleep, must notify
+          // Note: There's a benign race here - between reading head_after and calling
+          // xTaskNotifyGive(), the consumer could advance further. This would result
+          // in an unnecessary wake-up, but is harmless and extremely rare in practice.
+          xTaskNotifyGive(task_to_notify_);
+        }
+        // Otherwise: consumer is still behind, no need to notify
+      }
     }
 
     return result;

--- a/esphome/core/lock_free_queue.h
+++ b/esphome/core/lock_free_queue.h
@@ -122,19 +122,17 @@ template<class T, uint8_t SIZE> class NotifyingLockFreeQueue : public LockFreeQu
     bool result = this->push_internal_(element, was_empty, old_tail);
 
     // Notify optimization: only notify if we need to
-    if (result && task_to_notify_ != nullptr) {
-      if (was_empty) {
-        // Queue was empty - consumer might be going to sleep, must notify
-        xTaskNotifyGive(task_to_notify_);
-      } else if (this->head_.load(std::memory_order_acquire) == old_tail) {
-        // Consumer just caught up to where tail was - might go to sleep, must notify
-        // Note: There's a benign race here - between reading head and calling
-        // xTaskNotifyGive(), the consumer could advance further. This would result
-        // in an unnecessary wake-up, but is harmless and extremely rare in practice.
-        xTaskNotifyGive(task_to_notify_);
-      }
-      // Otherwise: consumer is still behind, no need to notify
+    if (result && task_to_notify_ != nullptr &&
+        (was_empty || this->head_.load(std::memory_order_acquire) == old_tail)) {
+      // Notify in two cases:
+      // 1. Queue was empty - consumer might be going to sleep
+      // 2. Consumer just caught up to where tail was - might go to sleep
+      // Note: There's a benign race in case 2 - between reading head and calling
+      // xTaskNotifyGive(), the consumer could advance further. This would result
+      // in an unnecessary wake-up, but is harmless and extremely rare in practice.
+      xTaskNotifyGive(task_to_notify_);
     }
+    // Otherwise: consumer is still behind, no need to notify
 
     return result;
   }

--- a/esphome/core/lock_free_queue.h
+++ b/esphome/core/lock_free_queue.h
@@ -38,12 +38,13 @@ template<class T, uint8_t SIZE> class LockFreeQueue {
 
   bool push(T *element) {
     bool was_empty;
-    return push_internal_(element, was_empty);
+    uint8_t old_tail;
+    return push_internal_(element, was_empty, old_tail);
   }
 
  protected:
-  // Internal push that reports if queue was empty - for use by derived classes
-  bool push_internal_(T *element, bool &was_empty) {
+  // Internal push that reports queue state - for use by derived classes
+  bool push_internal_(T *element, bool &was_empty, uint8_t &old_tail) {
     if (element == nullptr)
       return false;
 
@@ -60,6 +61,7 @@ template<class T, uint8_t SIZE> class LockFreeQueue {
     }
 
     was_empty = (current_tail == head_before);
+    old_tail = current_tail;
 
     buffer_[current_tail] = element;
     tail_.store(next_tail, std::memory_order_release);
@@ -116,7 +118,8 @@ template<class T, uint8_t SIZE> class NotifyingLockFreeQueue : public LockFreeQu
 
   bool push(T *element) {
     bool was_empty;
-    bool result = this->push_internal_(element, was_empty);
+    uint8_t old_tail;
+    bool result = this->push_internal_(element, was_empty, old_tail);
 
     // Notify optimization: only notify if we need to
     if (result && task_to_notify_ != nullptr) {
@@ -125,11 +128,8 @@ template<class T, uint8_t SIZE> class NotifyingLockFreeQueue : public LockFreeQu
         xTaskNotifyGive(task_to_notify_);
       } else {
         // Queue wasn't empty - check if consumer has caught up to previous tail
-        uint8_t current_tail = this->tail_.load(std::memory_order_relaxed);
         uint8_t head_after = this->head_.load(std::memory_order_acquire);
-        // We just pushed, so go back one position to get the old tail
-        uint8_t previous_tail = (current_tail + SIZE - 1) % SIZE;
-        if (head_after == previous_tail) {
+        if (head_after == old_tail) {
           // Consumer just caught up to where tail was - might go to sleep, must notify
           // Note: There's a benign race here - between reading head_after and calling
           // xTaskNotifyGive(), the consumer could advance further. This would result


### PR DESCRIPTION
# What does this implement/fix?

This PR refactors the `LockFreeQueue` class to split it into a base class without task notification and a derived `NotifyingLockFreeQueue` class that adds notification support. This optimization reduces memory usage for components that don't need task notification, particularly benefiting ESP32 BLE which uses two queues.

**Key motivation**: Making this change now before more components start using `LockFreeQueue` is critical, as it will become much harder to refactor once there are multiple consumers of the API.

### Changes:
1. **Base `LockFreeQueue`**: Removed `task_to_notify_` member and notification logic
2. **New `NotifyingLockFreeQueue`**: Derived class that adds task notification support
3. **BLE component**: Uses base `LockFreeQueue` (doesn't need notifications)
4. **MQTT component**: Uses `NotifyingLockFreeQueue` (needs notifications)

### Memory savings on 32-bit ESP32:
- 4 bytes saved per queue instance that doesn't need notifications (pointer size on 32-bit)
- ESP32 BLE saves 8 bytes total (2 queues: `ble_events_` and `ble_event_pool_`)
- No performance impact or behavioral changes

### Technical details:
- Maintains SPSC (Single Producer Single Consumer) thread safety
- No virtual methods, so no vtable overhead
- Code duplication avoided through protected `push_internal_()` method
- Follows ESPHome coding conventions

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal implementation detail)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - this is an internal optimization
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - N/A - Internal implementation change only