### PR TITLE
Fix bluetooth proxy busy loop when disconnecting pending BLE connections

### DIFF
--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
@@ -170,7 +170,7 @@ int BluetoothProxy::get_bluetooth_connections_free() {
 void BluetoothProxy::loop() {
   if (!api::global_api_server->is_connected() || this->api_connection_ == nullptr) {
     for (auto *connection : this->connections_) {
-      if (connection->get_address() != 0) {
+      if (connection->get_address() != 0 && !connection->disconnect_pending()) {
         connection->disconnect();
       }
     }


### PR DESCRIPTION
# What does this implement/fix?

This PR fixes a busy loop that occurs when the API connection is lost while BLE clients are in the process of connecting. The bluetooth proxy was repeatedly attempting to disconnect the same BLE connections hundreds of times per second, causing excessive CPU usage and log spam.

The issue occurs because when a BLE client is in the CONNECTING state and `disconnect()` is called, it only sets a `want_disconnect_` flag but doesn't actually disconnect. The bluetooth proxy's `loop()` method was not checking this flag, so it kept calling `disconnect()` on every loop iteration.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes #(issue number if one exists)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no documentation changes needed)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# No configuration changes required
# This affects existing bluetooth_proxy configurations:

bluetooth_proxy:
  active: true

# The fix prevents busy loops when API disconnects while BLE devices are connecting
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

## Additional Notes

The fix is a one-line change that adds a check for `disconnect_pending()` before attempting to disconnect a BLE connection. This prevents the repeated disconnect attempts that were causing the busy loop.

Before fix:
```
[07:31:47][W][esp32_ble_client:154]: [0] [2B:80:03:ED:CE:5D] Disconnecting before connected, disconnect scheduled.
```
(repeated hundreds of times per second)

After fix:
- The disconnect is only attempted once per connection
- CPU usage returns to normal when API disconnects
- Log spam is eliminated