### PR TITLE
Reduce LightCall memory usage by 50 bytes per call

### DIFF
--- a/esphome/components/light/addressable_light.h
+++ b/esphome/components/light/addressable_light.h
@@ -97,12 +97,12 @@ class AddressableLight : public LightOutput, public Component {
   }
   virtual ESPColorView get_view_internal(int32_t index) const = 0;
 
-  bool effect_active_{false};
   ESPColorCorrection correction_{};
+  LightState *state_parent_{nullptr};
 #ifdef USE_POWER_SUPPLY
   power_supply::PowerSupplyRequester power_;
 #endif
-  LightState *state_parent_{nullptr};
+  bool effect_active_{false};
 };
 
 class AddressableLightTransformer : public LightTransitionTransformer {
@@ -114,9 +114,9 @@ class AddressableLightTransformer : public LightTransitionTransformer {
 
  protected:
   AddressableLight &light_;
-  Color target_color_{};
   float last_transition_progress_{0.0f};
   float accumulated_alpha_{0.0f};
+  Color target_color_{};
 };
 
 }  // namespace light

--- a/esphome/components/light/esp_color_correction.h
+++ b/esphome/components/light/esp_color_correction.h
@@ -69,8 +69,8 @@ class ESPColorCorrection {
  protected:
   uint8_t gamma_table_[256];
   uint8_t gamma_reverse_table_[256];
-  uint8_t local_brightness_{255};
   Color max_brightness_;
+  uint8_t local_brightness_{255};
 };
 
 }  // namespace light

--- a/esphome/components/light/light_call.cpp
+++ b/esphome/components/light/light_call.cpp
@@ -2,11 +2,27 @@
 #include "light_call.h"
 #include "light_state.h"
 #include "esphome/core/log.h"
+#include "esphome/core/optional.h"
 
 namespace esphome {
 namespace light {
 
 static const char *const TAG = "light";
+
+// Macro to reduce repetitive setter code
+#define IMPLEMENT_LIGHT_CALL_SETTER(name, type, flag) \
+  LightCall &LightCall::set_##name(optional<type> name) { \
+    if (name.has_value()) { \
+      this->name##_ = name.value(); \
+    } \
+    this->set_flag_(flag, name.has_value()); \
+    return *this; \
+  } \
+  LightCall &LightCall::set_##name(type name) { \
+    this->name##_ = name; \
+    this->set_flag_(flag, true); \
+    return *this; \
+  }
 
 static const LogString *color_mode_to_human(ColorMode color_mode) {
   if (color_mode == ColorMode::UNKNOWN)
@@ -32,41 +48,43 @@ void LightCall::perform() {
   const char *name = this->parent_->get_name().c_str();
   LightColorValues v = this->validate_();
 
-  if (this->publish_) {
+  if (this->get_publish_()) {
     ESP_LOGD(TAG, "'%s' Setting:", name);
 
     // Only print color mode when it's being changed
     ColorMode current_color_mode = this->parent_->remote_values.get_color_mode();
-    if (this->color_mode_.value_or(current_color_mode) != current_color_mode) {
+    ColorMode target_color_mode = this->has_color_mode() ? this->color_mode_ : current_color_mode;
+    if (target_color_mode != current_color_mode) {
       ESP_LOGD(TAG, "  Color mode: %s", LOG_STR_ARG(color_mode_to_human(v.get_color_mode())));
     }
 
     // Only print state when it's being changed
     bool current_state = this->parent_->remote_values.is_on();
-    if (this->state_.value_or(current_state) != current_state) {
+    bool target_state = this->has_state() ? this->state_ : current_state;
+    if (target_state != current_state) {
       ESP_LOGD(TAG, "  State: %s", ONOFF(v.is_on()));
     }
 
-    if (this->brightness_.has_value()) {
+    if (this->has_brightness()) {
       ESP_LOGD(TAG, "  Brightness: %.0f%%", v.get_brightness() * 100.0f);
     }
 
-    if (this->color_brightness_.has_value()) {
+    if (this->has_color_brightness()) {
       ESP_LOGD(TAG, "  Color brightness: %.0f%%", v.get_color_brightness() * 100.0f);
     }
-    if (this->red_.has_value() || this->green_.has_value() || this->blue_.has_value()) {
+    if (this->has_red() || this->has_green() || this->has_blue()) {
       ESP_LOGD(TAG, "  Red: %.0f%%, Green: %.0f%%, Blue: %.0f%%", v.get_red() * 100.0f, v.get_green() * 100.0f,
                v.get_blue() * 100.0f);
     }
 
-    if (this->white_.has_value()) {
+    if (this->has_white()) {
       ESP_LOGD(TAG, "  White: %.0f%%", v.get_white() * 100.0f);
     }
-    if (this->color_temperature_.has_value()) {
+    if (this->has_color_temperature()) {
       ESP_LOGD(TAG, "  Color temperature: %.1f mireds", v.get_color_temperature());
     }
 
-    if (this->cold_white_.has_value() || this->warm_white_.has_value()) {
+    if (this->has_cold_white() || this->has_warm_white()) {
       ESP_LOGD(TAG, "  Cold white: %.0f%%, warm white: %.0f%%", v.get_cold_white() * 100.0f,
                v.get_warm_white() * 100.0f);
     }
@@ -74,58 +92,57 @@ void LightCall::perform() {
 
   if (this->has_flash_()) {
     // FLASH
-    if (this->publish_) {
-      ESP_LOGD(TAG, "  Flash length: %.1fs", *this->flash_length_ / 1e3f);
+    if (this->get_publish_()) {
+      ESP_LOGD(TAG, "  Flash length: %.1fs", this->flash_length_ / 1e3f);
     }
 
-    this->parent_->start_flash_(v, *this->flash_length_, this->publish_);
+    this->parent_->start_flash_(v, this->flash_length_, this->get_publish_());
   } else if (this->has_transition_()) {
     // TRANSITION
-    if (this->publish_) {
-      ESP_LOGD(TAG, "  Transition length: %.1fs", *this->transition_length_ / 1e3f);
+    if (this->get_publish_()) {
+      ESP_LOGD(TAG, "  Transition length: %.1fs", this->transition_length_ / 1e3f);
     }
 
     // Special case: Transition and effect can be set when turning off
     if (this->has_effect_()) {
-      if (this->publish_) {
+      if (this->get_publish_()) {
         ESP_LOGD(TAG, "  Effect: 'None'");
       }
       this->parent_->stop_effect_();
     }
 
-    this->parent_->start_transition_(v, *this->transition_length_, this->publish_);
+    this->parent_->start_transition_(v, this->transition_length_, this->get_publish_());
 
   } else if (this->has_effect_()) {
     // EFFECT
-    auto effect = this->effect_;
     const char *effect_s;
-    if (effect == 0u) {
+    if (this->effect_ == 0u) {
       effect_s = "None";
     } else {
-      effect_s = this->parent_->effects_[*this->effect_ - 1]->get_name().c_str();
+      effect_s = this->parent_->effects_[this->effect_ - 1]->get_name().c_str();
     }
 
-    if (this->publish_) {
+    if (this->get_publish_()) {
       ESP_LOGD(TAG, "  Effect: '%s'", effect_s);
     }
 
-    this->parent_->start_effect_(*this->effect_);
+    this->parent_->start_effect_(this->effect_);
 
     // Also set light color values when starting an effect
     // For example to turn off the light
     this->parent_->set_immediately_(v, true);
   } else {
     // INSTANT CHANGE
-    this->parent_->set_immediately_(v, this->publish_);
+    this->parent_->set_immediately_(v, this->get_publish_());
   }
 
   if (!this->has_transition_()) {
     this->parent_->target_state_reached_callback_.call();
   }
-  if (this->publish_) {
+  if (this->get_publish_()) {
     this->parent_->publish_state();
   }
-  if (this->save_) {
+  if (this->get_save_()) {
     this->parent_->save_remote_values_();
   }
 }
@@ -135,82 +152,80 @@ LightColorValues LightCall::validate_() {
   auto traits = this->parent_->get_traits();
 
   // Color mode check
-  if (this->color_mode_.has_value() && !traits.supports_color_mode(this->color_mode_.value())) {
-    ESP_LOGW(TAG, "'%s' does not support color mode %s", name,
-             LOG_STR_ARG(color_mode_to_human(this->color_mode_.value())));
-    this->color_mode_.reset();
+  if (this->has_color_mode() && !traits.supports_color_mode(this->color_mode_)) {
+    ESP_LOGW(TAG, "'%s' does not support color mode %s", name, LOG_STR_ARG(color_mode_to_human(this->color_mode_)));
+    this->set_flag_(FLAG_HAS_COLOR_MODE, false);
   }
 
   // Ensure there is always a color mode set
-  if (!this->color_mode_.has_value()) {
+  if (!this->has_color_mode()) {
     this->color_mode_ = this->compute_color_mode_();
+    this->set_flag_(FLAG_HAS_COLOR_MODE, true);
   }
-  auto color_mode = *this->color_mode_;
+  auto color_mode = this->color_mode_;
 
   // Transform calls that use non-native parameters for the current mode.
   this->transform_parameters_();
 
   // Brightness exists check
-  if (this->brightness_.has_value() && *this->brightness_ > 0.0f && !(color_mode & ColorCapability::BRIGHTNESS)) {
+  if (this->has_brightness() && this->brightness_ > 0.0f && !(color_mode & ColorCapability::BRIGHTNESS)) {
     ESP_LOGW(TAG, "'%s': setting brightness not supported", name);
-    this->brightness_.reset();
+    this->set_flag_(FLAG_HAS_BRIGHTNESS, false);
   }
 
   // Transition length possible check
-  if (this->transition_length_.has_value() && *this->transition_length_ != 0 &&
-      !(color_mode & ColorCapability::BRIGHTNESS)) {
+  if (this->has_transition_() && this->transition_length_ != 0 && !(color_mode & ColorCapability::BRIGHTNESS)) {
     ESP_LOGW(TAG, "'%s': transitions not supported", name);
-    this->transition_length_.reset();
+    this->set_flag_(FLAG_HAS_TRANSITION, false);
   }
 
   // Color brightness exists check
-  if (this->color_brightness_.has_value() && *this->color_brightness_ > 0.0f && !(color_mode & ColorCapability::RGB)) {
+  if (this->has_color_brightness() && this->color_brightness_ > 0.0f && !(color_mode & ColorCapability::RGB)) {
     ESP_LOGW(TAG, "'%s': color mode does not support setting RGB brightness", name);
-    this->color_brightness_.reset();
+    this->set_flag_(FLAG_HAS_COLOR_BRIGHTNESS, false);
   }
 
   // RGB exists check
-  if ((this->red_.has_value() && *this->red_ > 0.0f) || (this->green_.has_value() && *this->green_ > 0.0f) ||
-      (this->blue_.has_value() && *this->blue_ > 0.0f)) {
+  if ((this->has_red() && this->red_ > 0.0f) || (this->has_green() && this->green_ > 0.0f) ||
+      (this->has_blue() && this->blue_ > 0.0f)) {
     if (!(color_mode & ColorCapability::RGB)) {
       ESP_LOGW(TAG, "'%s': color mode does not support setting RGB color", name);
-      this->red_.reset();
-      this->green_.reset();
-      this->blue_.reset();
+      this->set_flag_(FLAG_HAS_RED, false);
+      this->set_flag_(FLAG_HAS_GREEN, false);
+      this->set_flag_(FLAG_HAS_BLUE, false);
     }
   }
 
   // White value exists check
-  if (this->white_.has_value() && *this->white_ > 0.0f &&
+  if (this->has_white() && this->white_ > 0.0f &&
       !(color_mode & ColorCapability::WHITE || color_mode & ColorCapability::COLD_WARM_WHITE)) {
     ESP_LOGW(TAG, "'%s': color mode does not support setting white value", name);
-    this->white_.reset();
+    this->set_flag_(FLAG_HAS_WHITE, false);
   }
 
   // Color temperature exists check
-  if (this->color_temperature_.has_value() &&
+  if (this->has_color_temperature() &&
       !(color_mode & ColorCapability::COLOR_TEMPERATURE || color_mode & ColorCapability::COLD_WARM_WHITE)) {
     ESP_LOGW(TAG, "'%s': color mode does not support setting color temperature", name);
-    this->color_temperature_.reset();
+    this->set_flag_(FLAG_HAS_COLOR_TEMPERATURE, false);
   }
 
   // Cold/warm white value exists check
-  if ((this->cold_white_.has_value() && *this->cold_white_ > 0.0f) ||
-      (this->warm_white_.has_value() && *this->warm_white_ > 0.0f)) {
+  if ((this->has_cold_white() && this->cold_white_ > 0.0f) || (this->has_warm_white() && this->warm_white_ > 0.0f)) {
     if (!(color_mode & ColorCapability::COLD_WARM_WHITE)) {
       ESP_LOGW(TAG, "'%s': color mode does not support setting cold/warm white value", name);
-      this->cold_white_.reset();
-      this->warm_white_.reset();
+      this->set_flag_(FLAG_HAS_COLD_WHITE, false);
+      this->set_flag_(FLAG_HAS_WARM_WHITE, false);
     }
   }
 
 #define VALIDATE_RANGE_(name_, upper_name, min, max) \
-  if (name_##_.has_value()) { \
-    auto val = *name_##_; \
+  if (this->has_##name_()) { \
+    auto val = this->name_##_; \
     if (val < (min) || val > (max)) { \
       ESP_LOGW(TAG, "'%s': %s value %.2f is out of range [%.1f - %.1f]", name, LOG_STR_LITERAL(upper_name), val, \
                (min), (max)); \
-      name_##_ = clamp(val, (min), (max)); \
+      this->name_##_ = clamp(val, (min), (max)); \
     } \
   }
 #define VALIDATE_RANGE(name, upper_name) VALIDATE_RANGE_(name, upper_name, 0.0f, 1.0f)
@@ -227,110 +242,116 @@ LightColorValues LightCall::validate_() {
   VALIDATE_RANGE_(color_temperature, "Color temperature", traits.get_min_mireds(), traits.get_max_mireds())
 
   // Flag whether an explicit turn off was requested, in which case we'll also stop the effect.
-  bool explicit_turn_off_request = this->state_.has_value() && !*this->state_;
+  bool explicit_turn_off_request = this->has_state() && !this->state_;
 
   // Turn off when brightness is set to zero, and reset brightness (so that it has nonzero brightness when turned on).
-  if (this->brightness_.has_value() && *this->brightness_ == 0.0f) {
-    this->state_ = optional<float>(false);
-    this->brightness_ = optional<float>(1.0f);
+  if (this->has_brightness() && this->brightness_ == 0.0f) {
+    this->state_ = false;
+    this->set_flag_(FLAG_HAS_STATE, true);
+    this->brightness_ = 1.0f;
   }
 
   // Set color brightness to 100% if currently zero and a color is set.
-  if (this->red_.has_value() || this->green_.has_value() || this->blue_.has_value()) {
-    if (!this->color_brightness_.has_value() && this->parent_->remote_values.get_color_brightness() == 0.0f)
-      this->color_brightness_ = optional<float>(1.0f);
+  if (this->has_red() || this->has_green() || this->has_blue()) {
+    if (!this->has_color_brightness() && this->parent_->remote_values.get_color_brightness() == 0.0f) {
+      this->color_brightness_ = 1.0f;
+      this->set_flag_(FLAG_HAS_COLOR_BRIGHTNESS, true);
+    }
   }
 
   // Create color values for the light with this call applied.
   auto v = this->parent_->remote_values;
-  if (this->color_mode_.has_value())
-    v.set_color_mode(*this->color_mode_);
-  if (this->state_.has_value())
-    v.set_state(*this->state_);
-  if (this->brightness_.has_value())
-    v.set_brightness(*this->brightness_);
-  if (this->color_brightness_.has_value())
-    v.set_color_brightness(*this->color_brightness_);
-  if (this->red_.has_value())
-    v.set_red(*this->red_);
-  if (this->green_.has_value())
-    v.set_green(*this->green_);
-  if (this->blue_.has_value())
-    v.set_blue(*this->blue_);
-  if (this->white_.has_value())
-    v.set_white(*this->white_);
-  if (this->color_temperature_.has_value())
-    v.set_color_temperature(*this->color_temperature_);
-  if (this->cold_white_.has_value())
-    v.set_cold_white(*this->cold_white_);
-  if (this->warm_white_.has_value())
-    v.set_warm_white(*this->warm_white_);
+  if (this->has_color_mode())
+    v.set_color_mode(this->color_mode_);
+  if (this->has_state())
+    v.set_state(this->state_);
+  if (this->has_brightness())
+    v.set_brightness(this->brightness_);
+  if (this->has_color_brightness())
+    v.set_color_brightness(this->color_brightness_);
+  if (this->has_red())
+    v.set_red(this->red_);
+  if (this->has_green())
+    v.set_green(this->green_);
+  if (this->has_blue())
+    v.set_blue(this->blue_);
+  if (this->has_white())
+    v.set_white(this->white_);
+  if (this->has_color_temperature())
+    v.set_color_temperature(this->color_temperature_);
+  if (this->has_cold_white())
+    v.set_cold_white(this->cold_white_);
+  if (this->has_warm_white())
+    v.set_warm_white(this->warm_white_);
 
   v.normalize_color();
 
   // Flash length check
-  if (this->has_flash_() && *this->flash_length_ == 0) {
+  if (this->has_flash_() && this->flash_length_ == 0) {
     ESP_LOGW(TAG, "'%s': flash length must be greater than zero", name);
-    this->flash_length_.reset();
+    this->set_flag_(FLAG_HAS_FLASH, false);
   }
 
   // validate transition length/flash length/effect not used at the same time
   bool supports_transition = color_mode & ColorCapability::BRIGHTNESS;
 
   // If effect is already active, remove effect start
-  if (this->has_effect_() && *this->effect_ == this->parent_->active_effect_index_) {
-    this->effect_.reset();
+  if (this->has_effect_() && this->effect_ == this->parent_->active_effect_index_) {
+    this->set_flag_(FLAG_HAS_EFFECT, false);
   }
 
   // validate effect index
-  if (this->has_effect_() && *this->effect_ > this->parent_->effects_.size()) {
-    ESP_LOGW(TAG, "'%s': invalid effect index %" PRIu32, name, *this->effect_);
-    this->effect_.reset();
+  if (this->has_effect_() && this->effect_ > this->parent_->effects_.size()) {
+    ESP_LOGW(TAG, "'%s': invalid effect index %" PRIu32, name, this->effect_);
+    this->set_flag_(FLAG_HAS_EFFECT, false);
   }
 
   if (this->has_effect_() && (this->has_transition_() || this->has_flash_())) {
     ESP_LOGW(TAG, "'%s': effect cannot be used with transition/flash", name);
-    this->transition_length_.reset();
-    this->flash_length_.reset();
+    this->set_flag_(FLAG_HAS_TRANSITION, false);
+    this->set_flag_(FLAG_HAS_FLASH, false);
   }
 
   if (this->has_flash_() && this->has_transition_()) {
     ESP_LOGW(TAG, "'%s': flash cannot be used with transition", name);
-    this->transition_length_.reset();
+    this->set_flag_(FLAG_HAS_TRANSITION, false);
   }
 
-  if (!this->has_transition_() && !this->has_flash_() && (!this->has_effect_() || *this->effect_ == 0) &&
+  if (!this->has_transition_() && !this->has_flash_() && (!this->has_effect_() || this->effect_ == 0) &&
       supports_transition) {
     // nothing specified and light supports transitions, set default transition length
     this->transition_length_ = this->parent_->default_transition_length_;
+    this->set_flag_(FLAG_HAS_TRANSITION, true);
   }
 
-  if (this->transition_length_.value_or(0) == 0) {
+  if (this->has_transition_() && this->transition_length_ == 0) {
     // 0 transition is interpreted as no transition (instant change)
-    this->transition_length_.reset();
+    this->set_flag_(FLAG_HAS_TRANSITION, false);
   }
 
   if (this->has_transition_() && !supports_transition) {
     ESP_LOGW(TAG, "'%s': transitions not supported", name);
-    this->transition_length_.reset();
+    this->set_flag_(FLAG_HAS_TRANSITION, false);
   }
 
   // If not a flash and turning the light off, then disable the light
   // Do not use light color values directly, so that effects can set 0% brightness
   // Reason: When user turns off the light in frontend, the effect should also stop
-  if (!this->has_flash_() && !this->state_.value_or(v.is_on())) {
+  bool target_state = this->has_state() ? this->state_ : v.is_on();
+  if (!this->has_flash_() && !target_state) {
     if (this->has_effect_()) {
       ESP_LOGW(TAG, "'%s': cannot start effect when turning off", name);
-      this->effect_.reset();
+      this->set_flag_(FLAG_HAS_EFFECT, false);
     } else if (this->parent_->active_effect_index_ != 0 && explicit_turn_off_request) {
       // Auto turn off effect
       this->effect_ = 0;
+      this->set_flag_(FLAG_HAS_EFFECT, true);
     }
   }
 
   // Disable saving for flashes
   if (this->has_flash_())
-    this->save_ = false;
+    this->set_flag_(FLAG_SAVE, false);
 
   return v;
 }
@@ -343,24 +364,27 @@ void LightCall::transform_parameters_() {
   // - RGBWW lights with color_interlock=true, which also sets "brightness" and
   //   "color_temperature" (without color_interlock, CW/WW are set directly)
   // - Legacy Home Assistant (pre-colormode), which sets "white" and "color_temperature"
-  if (((this->white_.has_value() && *this->white_ > 0.0f) || this->color_temperature_.has_value()) &&  //
-      (*this->color_mode_ & ColorCapability::COLD_WARM_WHITE) &&                                       //
-      !(*this->color_mode_ & ColorCapability::WHITE) &&                                                //
-      !(*this->color_mode_ & ColorCapability::COLOR_TEMPERATURE) &&                                    //
+  if (((this->has_white() && this->white_ > 0.0f) || this->has_color_temperature()) &&  //
+      (this->color_mode_ & ColorCapability::COLD_WARM_WHITE) &&                         //
+      !(this->color_mode_ & ColorCapability::WHITE) &&                                  //
+      !(this->color_mode_ & ColorCapability::COLOR_TEMPERATURE) &&                      //
       traits.get_min_mireds() > 0.0f && traits.get_max_mireds() > 0.0f) {
     ESP_LOGD(TAG, "'%s': setting cold/warm white channels using white/color temperature values",
              this->parent_->get_name().c_str());
-    if (this->color_temperature_.has_value()) {
-      const float color_temp = clamp(*this->color_temperature_, traits.get_min_mireds(), traits.get_max_mireds());
+    if (this->has_color_temperature()) {
+      const float color_temp = clamp(this->color_temperature_, traits.get_min_mireds(), traits.get_max_mireds());
       const float ww_fraction =
           (color_temp - traits.get_min_mireds()) / (traits.get_max_mireds() - traits.get_min_mireds());
       const float cw_fraction = 1.0f - ww_fraction;
       const float max_cw_ww = std::max(ww_fraction, cw_fraction);
       this->cold_white_ = gamma_uncorrect(cw_fraction / max_cw_ww, this->parent_->get_gamma_correct());
       this->warm_white_ = gamma_uncorrect(ww_fraction / max_cw_ww, this->parent_->get_gamma_correct());
+      this->set_flag_(FLAG_HAS_COLD_WHITE, true);
+      this->set_flag_(FLAG_HAS_WARM_WHITE, true);
     }
-    if (this->white_.has_value()) {
-      this->brightness_ = *this->white_;
+    if (this->has_white()) {
+      this->brightness_ = this->white_;
+      this->set_flag_(FLAG_HAS_BRIGHTNESS, true);
     }
   }
 }
@@ -378,7 +402,7 @@ ColorMode LightCall::compute_color_mode_() {
 
   // Don't change if the light is being turned off.
   ColorMode current_mode = this->parent_->remote_values.get_color_mode();
-  if (this->state_.has_value() && !*this->state_)
+  if (this->has_state() && !this->state_)
     return current_mode;
 
   // If no color mode is specified, we try to guess the color mode. This is needed for backward compatibility to
@@ -411,12 +435,12 @@ ColorMode LightCall::compute_color_mode_() {
   return color_mode;
 }
 std::set<ColorMode> LightCall::get_suitable_color_modes_() {
-  bool has_white = this->white_.has_value() && *this->white_ > 0.0f;
-  bool has_ct = this->color_temperature_.has_value();
-  bool has_cwww = (this->cold_white_.has_value() && *this->cold_white_ > 0.0f) ||
-                  (this->warm_white_.has_value() && *this->warm_white_ > 0.0f);
-  bool has_rgb = (this->color_brightness_.has_value() && *this->color_brightness_ > 0.0f) ||
-                 (this->red_.has_value() || this->green_.has_value() || this->blue_.has_value());
+  bool has_white = this->has_white() && this->white_ > 0.0f;
+  bool has_ct = this->has_color_temperature();
+  bool has_cwww =
+      (this->has_cold_white() && this->cold_white_ > 0.0f) || (this->has_warm_white() && this->warm_white_ > 0.0f);
+  bool has_rgb = (this->has_color_brightness() && this->color_brightness_ > 0.0f) ||
+                 (this->has_red() || this->has_green() || this->has_blue());
 
 #define KEY(white, ct, cwww, rgb) ((white) << 0 | (ct) << 1 | (cwww) << 2 | (rgb) << 3)
 #define ENTRY(white, ct, cwww, rgb, ...) \
@@ -549,110 +573,19 @@ LightCall &LightCall::set_warm_white_if_supported(float warm_white) {
     this->set_warm_white(warm_white);
   return *this;
 }
-LightCall &LightCall::set_state(optional<bool> state) {
-  this->state_ = state;
-  return *this;
-}
-LightCall &LightCall::set_state(bool state) {
-  this->state_ = state;
-  return *this;
-}
-LightCall &LightCall::set_transition_length(optional<uint32_t> transition_length) {
-  this->transition_length_ = transition_length;
-  return *this;
-}
-LightCall &LightCall::set_transition_length(uint32_t transition_length) {
-  this->transition_length_ = transition_length;
-  return *this;
-}
-LightCall &LightCall::set_flash_length(optional<uint32_t> flash_length) {
-  this->flash_length_ = flash_length;
-  return *this;
-}
-LightCall &LightCall::set_flash_length(uint32_t flash_length) {
-  this->flash_length_ = flash_length;
-  return *this;
-}
-LightCall &LightCall::set_brightness(optional<float> brightness) {
-  this->brightness_ = brightness;
-  return *this;
-}
-LightCall &LightCall::set_brightness(float brightness) {
-  this->brightness_ = brightness;
-  return *this;
-}
-LightCall &LightCall::set_color_mode(optional<ColorMode> color_mode) {
-  this->color_mode_ = color_mode;
-  return *this;
-}
-LightCall &LightCall::set_color_mode(ColorMode color_mode) {
-  this->color_mode_ = color_mode;
-  return *this;
-}
-LightCall &LightCall::set_color_brightness(optional<float> brightness) {
-  this->color_brightness_ = brightness;
-  return *this;
-}
-LightCall &LightCall::set_color_brightness(float brightness) {
-  this->color_brightness_ = brightness;
-  return *this;
-}
-LightCall &LightCall::set_red(optional<float> red) {
-  this->red_ = red;
-  return *this;
-}
-LightCall &LightCall::set_red(float red) {
-  this->red_ = red;
-  return *this;
-}
-LightCall &LightCall::set_green(optional<float> green) {
-  this->green_ = green;
-  return *this;
-}
-LightCall &LightCall::set_green(float green) {
-  this->green_ = green;
-  return *this;
-}
-LightCall &LightCall::set_blue(optional<float> blue) {
-  this->blue_ = blue;
-  return *this;
-}
-LightCall &LightCall::set_blue(float blue) {
-  this->blue_ = blue;
-  return *this;
-}
-LightCall &LightCall::set_white(optional<float> white) {
-  this->white_ = white;
-  return *this;
-}
-LightCall &LightCall::set_white(float white) {
-  this->white_ = white;
-  return *this;
-}
-LightCall &LightCall::set_color_temperature(optional<float> color_temperature) {
-  this->color_temperature_ = color_temperature;
-  return *this;
-}
-LightCall &LightCall::set_color_temperature(float color_temperature) {
-  this->color_temperature_ = color_temperature;
-  return *this;
-}
-LightCall &LightCall::set_cold_white(optional<float> cold_white) {
-  this->cold_white_ = cold_white;
-  return *this;
-}
-LightCall &LightCall::set_cold_white(float cold_white) {
-  this->cold_white_ = cold_white;
-  return *this;
-}
-LightCall &LightCall::set_warm_white(optional<float> warm_white) {
-  this->warm_white_ = warm_white;
-  return *this;
-}
-LightCall &LightCall::set_warm_white(float warm_white) {
-  this->warm_white_ = warm_white;
-  return *this;
-}
+IMPLEMENT_LIGHT_CALL_SETTER(state, bool, FLAG_HAS_STATE)
+IMPLEMENT_LIGHT_CALL_SETTER(transition_length, uint32_t, FLAG_HAS_TRANSITION)
+IMPLEMENT_LIGHT_CALL_SETTER(flash_length, uint32_t, FLAG_HAS_FLASH)
+IMPLEMENT_LIGHT_CALL_SETTER(brightness, float, FLAG_HAS_BRIGHTNESS)
+IMPLEMENT_LIGHT_CALL_SETTER(color_mode, ColorMode, FLAG_HAS_COLOR_MODE)
+IMPLEMENT_LIGHT_CALL_SETTER(color_brightness, float, FLAG_HAS_COLOR_BRIGHTNESS)
+IMPLEMENT_LIGHT_CALL_SETTER(red, float, FLAG_HAS_RED)
+IMPLEMENT_LIGHT_CALL_SETTER(green, float, FLAG_HAS_GREEN)
+IMPLEMENT_LIGHT_CALL_SETTER(blue, float, FLAG_HAS_BLUE)
+IMPLEMENT_LIGHT_CALL_SETTER(white, float, FLAG_HAS_WHITE)
+IMPLEMENT_LIGHT_CALL_SETTER(color_temperature, float, FLAG_HAS_COLOR_TEMPERATURE)
+IMPLEMENT_LIGHT_CALL_SETTER(cold_white, float, FLAG_HAS_COLD_WHITE)
+IMPLEMENT_LIGHT_CALL_SETTER(warm_white, float, FLAG_HAS_WARM_WHITE)
 LightCall &LightCall::set_effect(optional<std::string> effect) {
   if (effect.has_value())
     this->set_effect(*effect);
@@ -660,18 +593,22 @@ LightCall &LightCall::set_effect(optional<std::string> effect) {
 }
 LightCall &LightCall::set_effect(uint32_t effect_number) {
   this->effect_ = effect_number;
+  this->set_flag_(FLAG_HAS_EFFECT, true);
   return *this;
 }
 LightCall &LightCall::set_effect(optional<uint32_t> effect_number) {
-  this->effect_ = effect_number;
+  if (effect_number.has_value()) {
+    this->effect_ = effect_number.value();
+  }
+  this->set_flag_(FLAG_HAS_EFFECT, effect_number.has_value());
   return *this;
 }
 LightCall &LightCall::set_publish(bool publish) {
-  this->publish_ = publish;
+  this->set_flag_(FLAG_PUBLISH, publish);
   return *this;
 }
 LightCall &LightCall::set_save(bool save) {
-  this->save_ = save;
+  this->set_flag_(FLAG_SAVE, save);
   return *this;
 }
 LightCall &LightCall::set_rgb(float red, float green, float blue) {

--- a/esphome/components/light/light_call.cpp
+++ b/esphome/components/light/light_call.cpp
@@ -515,7 +515,7 @@ LightCall &LightCall::from_light_color_values(const LightColorValues &values) {
   return *this;
 }
 ColorMode LightCall::get_active_color_mode_() {
-  return this->color_mode_.value_or(this->parent_->remote_values.get_color_mode());
+  return this->has_color_mode() ? this->color_mode_ : this->parent_->remote_values.get_color_mode();
 }
 LightCall &LightCall::set_transition_length_if_supported(uint32_t transition_length) {
   if (this->get_active_color_mode_() & ColorCapability::BRIGHTNESS)
@@ -529,7 +529,7 @@ LightCall &LightCall::set_brightness_if_supported(float brightness) {
 }
 LightCall &LightCall::set_color_mode_if_supported(ColorMode color_mode) {
   if (this->parent_->get_traits().supports_color_mode(color_mode))
-    this->color_mode_ = color_mode;
+    this->set_color_mode(color_mode);
   return *this;
 }
 LightCall &LightCall::set_color_brightness_if_supported(float brightness) {

--- a/esphome/components/light/light_call.cpp
+++ b/esphome/components/light/light_call.cpp
@@ -11,11 +11,11 @@ static const char *const TAG = "light";
 
 // Macro to reduce repetitive setter code
 #define IMPLEMENT_LIGHT_CALL_SETTER(name, type, flag) \
-  LightCall &LightCall::set_##name(optional<type> name) { \
-    if (name.has_value()) { \
-      this->name##_ = name.value(); \
+  LightCall &LightCall::set_##name(optional<type>(name)) { \
+    if ((name).has_value()) { \
+      this->name##_ = (name).value(); \
     } \
-    this->set_flag_(flag, name.has_value()); \
+    this->set_flag_(flag, (name).has_value()); \
     return *this; \
   } \
   LightCall &LightCall::set_##name(type name) { \

--- a/esphome/components/light/light_call.h
+++ b/esphome/components/light/light_call.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "esphome/core/optional.h"
 #include "light_color_values.h"
 #include <set>
 
@@ -131,6 +130,19 @@ class LightCall {
   /// Set whether this light call should trigger a save state to recover them at startup..
   LightCall &set_save(bool save);
 
+  // Getter methods to check if values are set
+  bool has_state() const { return (flags_ & FLAG_HAS_STATE) != 0; }
+  bool has_brightness() const { return (flags_ & FLAG_HAS_BRIGHTNESS) != 0; }
+  bool has_color_brightness() const { return (flags_ & FLAG_HAS_COLOR_BRIGHTNESS) != 0; }
+  bool has_red() const { return (flags_ & FLAG_HAS_RED) != 0; }
+  bool has_green() const { return (flags_ & FLAG_HAS_GREEN) != 0; }
+  bool has_blue() const { return (flags_ & FLAG_HAS_BLUE) != 0; }
+  bool has_white() const { return (flags_ & FLAG_HAS_WHITE) != 0; }
+  bool has_color_temperature() const { return (flags_ & FLAG_HAS_COLOR_TEMPERATURE) != 0; }
+  bool has_cold_white() const { return (flags_ & FLAG_HAS_COLD_WHITE) != 0; }
+  bool has_warm_white() const { return (flags_ & FLAG_HAS_WARM_WHITE) != 0; }
+  bool has_color_mode() const { return (flags_ & FLAG_HAS_COLOR_MODE) != 0; }
+
   /** Set the RGB color of the light by RGB values.
    *
    * Please note that this only changes the color of the light, not the brightness.
@@ -170,27 +182,57 @@ class LightCall {
   /// Some color modes also can be set using non-native parameters, transform those calls.
   void transform_parameters_();
 
-  bool has_transition_() { return this->transition_length_.has_value(); }
-  bool has_flash_() { return this->flash_length_.has_value(); }
-  bool has_effect_() { return this->effect_.has_value(); }
+  enum FieldFlags : uint16_t {
+    FLAG_HAS_STATE = 1 << 0,
+    FLAG_HAS_TRANSITION = 1 << 1,
+    FLAG_HAS_FLASH = 1 << 2,
+    FLAG_HAS_EFFECT = 1 << 3,
+    FLAG_HAS_BRIGHTNESS = 1 << 4,
+    FLAG_HAS_COLOR_BRIGHTNESS = 1 << 5,
+    FLAG_HAS_RED = 1 << 6,
+    FLAG_HAS_GREEN = 1 << 7,
+    FLAG_HAS_BLUE = 1 << 8,
+    FLAG_HAS_WHITE = 1 << 9,
+    FLAG_HAS_COLOR_TEMPERATURE = 1 << 10,
+    FLAG_HAS_COLD_WHITE = 1 << 11,
+    FLAG_HAS_WARM_WHITE = 1 << 12,
+    FLAG_HAS_COLOR_MODE = 1 << 13,
+    FLAG_PUBLISH = 1 << 14,
+    FLAG_SAVE = 1 << 15,
+  };
+
+  bool has_transition_() { return (this->flags_ & FLAG_HAS_TRANSITION) != 0; }
+  bool has_flash_() { return (this->flags_ & FLAG_HAS_FLASH) != 0; }
+  bool has_effect_() { return (this->flags_ & FLAG_HAS_EFFECT) != 0; }
+  bool get_publish_() { return (this->flags_ & FLAG_PUBLISH) != 0; }
+  bool get_save_() { return (this->flags_ & FLAG_SAVE) != 0; }
+
+  // Helper to set flag
+  void set_flag_(FieldFlags flag, bool value) {
+    if (value)
+      this->flags_ |= flag;
+    else
+      this->flags_ &= ~flag;
+  }
 
   LightState *parent_;
-  optional<bool> state_;
-  optional<uint32_t> transition_length_;
-  optional<uint32_t> flash_length_;
-  optional<ColorMode> color_mode_;
-  optional<float> brightness_;
-  optional<float> color_brightness_;
-  optional<float> red_;
-  optional<float> green_;
-  optional<float> blue_;
-  optional<float> white_;
-  optional<float> color_temperature_;
-  optional<float> cold_white_;
-  optional<float> warm_white_;
-  optional<uint32_t> effect_;
-  bool publish_{true};
-  bool save_{true};
+  // Group 4-byte aligned members first
+  uint32_t transition_length_;
+  uint32_t flash_length_;
+  uint32_t effect_;
+  float brightness_;
+  float color_brightness_;
+  float red_;
+  float green_;
+  float blue_;
+  float white_;
+  float color_temperature_;
+  float cold_white_;
+  float warm_white_;
+  // Group smaller members at the end for better packing
+  uint16_t flags_{FLAG_PUBLISH | FLAG_SAVE};  // Default publish and save to true
+  ColorMode color_mode_;
+  bool state_;
 };
 
 }  // namespace light

--- a/esphome/components/light/light_call.h
+++ b/esphome/components/light/light_call.h
@@ -215,10 +215,11 @@ class LightCall {
 
   // Helper to set flag
   void set_flag_(FieldFlags flag, bool value) {
-    if (value)
+    if (value) {
       this->flags_ |= flag;
-    else
+    } else {
       this->flags_ &= ~flag;
+    }
   }
 
   LightState *parent_;

--- a/esphome/components/light/light_call.h
+++ b/esphome/components/light/light_call.h
@@ -9,6 +9,11 @@ namespace light {
 class LightState;
 
 /** This class represents a requested change in a light state.
+ *
+ * Light state changes are tracked using a bitfield flags_ to minimize memory usage.
+ * Each possible light property has a flag indicating whether it has been set.
+ * This design keeps LightCall at ~56 bytes to minimize heap fragmentation on
+ * ESP8266 and other memory-constrained devices.
  */
 class LightCall {
  public:
@@ -182,6 +187,7 @@ class LightCall {
   /// Some color modes also can be set using non-native parameters, transform those calls.
   void transform_parameters_();
 
+  // Bitfield flags - each flag indicates whether a corresponding value has been set.
   enum FieldFlags : uint16_t {
     FLAG_HAS_STATE = 1 << 0,
     FLAG_HAS_TRANSITION = 1 << 1,
@@ -216,6 +222,8 @@ class LightCall {
   }
 
   LightState *parent_;
+
+  // Light state values - use flags_ to check if a value has been set.
   // Group 4-byte aligned members first
   uint32_t transition_length_;
   uint32_t flash_length_;
@@ -229,8 +237,9 @@ class LightCall {
   float color_temperature_;
   float cold_white_;
   float warm_white_;
-  // Group smaller members at the end for better packing
-  uint16_t flags_{FLAG_PUBLISH | FLAG_SAVE};  // Default publish and save to true
+
+  // Smaller members at the end for better packing
+  uint16_t flags_{FLAG_PUBLISH | FLAG_SAVE};  // Tracks which values are set
   ColorMode color_mode_;
   bool state_;
 };

--- a/esphome/components/light/light_color_values.h
+++ b/esphome/components/light/light_color_values.h
@@ -46,8 +46,7 @@ class LightColorValues {
  public:
   /// Construct the LightColorValues with all attributes enabled, but state set to off.
   LightColorValues()
-      : color_mode_(ColorMode::UNKNOWN),
-        state_(0.0f),
+      : state_(0.0f),
         brightness_(1.0f),
         color_brightness_(1.0f),
         red_(1.0f),
@@ -56,7 +55,8 @@ class LightColorValues {
         white_(1.0f),
         color_temperature_{0.0f},
         cold_white_{1.0f},
-        warm_white_{1.0f} {}
+        warm_white_{1.0f},
+        color_mode_(ColorMode::UNKNOWN) {}
 
   LightColorValues(ColorMode color_mode, float state, float brightness, float color_brightness, float red, float green,
                    float blue, float white, float color_temperature, float cold_white, float warm_white) {

--- a/esphome/components/light/light_color_values.h
+++ b/esphome/components/light/light_color_values.h
@@ -292,7 +292,6 @@ class LightColorValues {
   void set_warm_white(float warm_white) { this->warm_white_ = clamp(warm_white, 0.0f, 1.0f); }
 
  protected:
-  ColorMode color_mode_;
   float state_;  ///< ON / OFF, float for transition
   float brightness_;
   float color_brightness_;
@@ -303,6 +302,7 @@ class LightColorValues {
   float color_temperature_;  ///< Color Temperature in Mired
   float cold_white_;
   float warm_white_;
+  ColorMode color_mode_;
 };
 
 }  // namespace light

--- a/esphome/components/light/light_state.h
+++ b/esphome/components/light/light_state.h
@@ -31,9 +31,7 @@ enum LightRestoreMode : uint8_t {
 struct LightStateRTCState {
   LightStateRTCState(ColorMode color_mode, bool state, float brightness, float color_brightness, float red, float green,
                      float blue, float white, float color_temp, float cold_white, float warm_white)
-      : color_mode(color_mode),
-        state(state),
-        brightness(brightness),
+      : brightness(brightness),
         color_brightness(color_brightness),
         red(red),
         green(green),
@@ -41,10 +39,12 @@ struct LightStateRTCState {
         white(white),
         color_temp(color_temp),
         cold_white(cold_white),
-        warm_white(warm_white) {}
+        warm_white(warm_white),
+        effect(0),
+        color_mode(color_mode),
+        state(state) {}
   LightStateRTCState() = default;
-  ColorMode color_mode{ColorMode::UNKNOWN};
-  bool state{false};
+  // Group 4-byte aligned members first
   float brightness{1.0f};
   float color_brightness{1.0f};
   float red{1.0f};
@@ -55,6 +55,9 @@ struct LightStateRTCState {
   float cold_white{1.0f};
   float warm_white{1.0f};
   uint32_t effect{0};
+  // Group smaller members at the end
+  ColorMode color_mode{ColorMode::UNKNOWN};
+  bool state{false};
 };
 
 /** This class represents the communication layer between the front-end MQTT layer and the
@@ -216,6 +219,8 @@ class LightState : public EntityBase, public Component {
   std::unique_ptr<LightTransformer> transformer_{nullptr};
   /// List of effects for this light.
   std::vector<LightEffect *> effects_;
+  /// Object used to store the persisted values of the light.
+  ESPPreferenceObject rtc_;
   /// Value for storing the index of the currently active effect. 0 if no effect is active
   uint32_t active_effect_index_{};
   /// Default transition length for all transitions in ms.
@@ -224,14 +229,10 @@ class LightState : public EntityBase, public Component {
   uint32_t flash_transition_length_{};
   /// Gamma correction factor for the light.
   float gamma_correct_{};
-
   /// Whether the light value should be written in the next cycle.
   bool next_write_{true};
   // for effects, true if a transformer (transition) is active.
   bool is_transformer_active_ = false;
-
-  /// Object used to store the persisted values of the light.
-  ESPPreferenceObject rtc_;
 
   /** Callback to call when new values for the frontend are available.
    *

--- a/esphome/components/light/transformers.h
+++ b/esphome/components/light/transformers.h
@@ -59,9 +59,9 @@ class LightTransitionTransformer : public LightTransformer {
   // transition from 0 to 1 on x = [0, 1]
   static float smoothed_progress(float x) { return x * x * x * (x * (x * 6.0f - 15.0f) + 10.0f); }
 
-  bool changing_color_mode_{false};
   LightColorValues end_values_{};
   LightColorValues intermediate_values_{};
+  bool changing_color_mode_{false};
 };
 
 class LightFlashTransformer : public LightTransformer {
@@ -117,8 +117,8 @@ class LightFlashTransformer : public LightTransformer {
 
  protected:
   LightState &state_;
-  uint32_t transition_length_;
   std::unique_ptr<LightTransformer> transformer_{nullptr};
+  uint32_t transition_length_;
   bool begun_lightstate_restore_;
 };
 

--- a/tests/integration/fixtures/light_calls.yaml
+++ b/tests/integration/fixtures/light_calls.yaml
@@ -1,0 +1,80 @@
+esphome:
+  name: light-calls-test
+host:
+api:  # Port will be automatically injected
+logger:
+  level: DEBUG
+
+# Test outputs for RGBCW light
+output:
+  - platform: template
+    id: test_red
+    type: float
+    write_action:
+      - logger.log:
+          format: "Red output: %.2f"
+          args: [state]
+  - platform: template
+    id: test_green
+    type: float
+    write_action:
+      - logger.log:
+          format: "Green output: %.2f"
+          args: [state]
+  - platform: template
+    id: test_blue
+    type: float
+    write_action:
+      - logger.log:
+          format: "Blue output: %.2f"
+          args: [state]
+  - platform: template
+    id: test_cold_white
+    type: float
+    write_action:
+      - logger.log:
+          format: "Cold white output: %.2f"
+          args: [state]
+  - platform: template
+    id: test_warm_white
+    type: float
+    write_action:
+      - logger.log:
+          format: "Warm white output: %.2f"
+          args: [state]
+
+light:
+  - platform: rgbww
+    name: "Test RGBCW Light"
+    id: test_light
+    red: test_red
+    green: test_green
+    blue: test_blue
+    cold_white: test_cold_white
+    warm_white: test_warm_white
+    cold_white_color_temperature: 6536 K
+    warm_white_color_temperature: 2000 K
+    constant_brightness: true
+    effects:
+      - random:
+          name: "Random Effect"
+          transition_length: 100ms
+          update_interval: 200ms
+      - strobe:
+          name: "Strobe Effect"
+      - pulse:
+          name: "Pulse Effect"
+          transition_length: 100ms
+
+  # Additional lights to test memory with multiple instances
+  - platform: rgb
+    name: "Test RGB Light"
+    id: test_rgb_light
+    red: test_red
+    green: test_green
+    blue: test_blue
+
+  - platform: binary
+    name: "Test Binary Light"
+    id: test_binary_light
+    output: test_red

--- a/tests/integration/test_light_calls.py
+++ b/tests/integration/test_light_calls.py
@@ -1,0 +1,189 @@
+"""Integration test for all light call combinations.
+
+Tests that LightCall handles all possible light operations correctly
+including RGB, color temperature, effects, transitions, and flash.
+"""
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from .types import APIClientConnectedFactory, RunCompiledFunction
+
+
+@pytest.mark.asyncio
+async def test_light_calls(
+    yaml_config: str,
+    run_compiled: RunCompiledFunction,
+    api_client_connected: APIClientConnectedFactory,
+) -> None:
+    """Test all possible LightCall operations and combinations."""
+    async with run_compiled(yaml_config), api_client_connected() as client:
+        # Track state changes with futures
+        state_futures: dict[int, asyncio.Future[Any]] = {}
+        states: dict[int, Any] = {}
+
+        def on_state(state):
+            states[state.key] = state
+            if state.key in state_futures and not state_futures[state.key].done():
+                state_futures[state.key].set_result(state)
+
+        client.subscribe_states(on_state)
+
+        # Get the light entities
+        entities = await client.list_entities_services()
+        lights = [e for e in entities[0] if e.object_id.startswith("test_")]
+        assert len(lights) >= 2  # Should have RGBCW and RGB lights
+
+        rgbcw_light = next(light for light in lights if "RGBCW" in light.name)
+        rgb_light = next(light for light in lights if "RGB Light" in light.name)
+
+        async def wait_for_state_change(key, timeout=1.0):
+            """Wait for a state change for the given entity key."""
+            loop = asyncio.get_event_loop()
+            state_futures[key] = loop.create_future()
+            try:
+                return await asyncio.wait_for(state_futures[key], timeout)
+            finally:
+                state_futures.pop(key, None)
+
+        # Test all individual parameters first
+
+        # Test 1: state only
+        client.light_command(key=rgbcw_light.key, state=True)
+        state = await wait_for_state_change(rgbcw_light.key)
+        assert state.state is True
+
+        # Test 2: brightness only
+        client.light_command(key=rgbcw_light.key, brightness=0.5)
+        state = await wait_for_state_change(rgbcw_light.key)
+        assert state.brightness == pytest.approx(0.5)
+
+        # Test 3: color_brightness only
+        client.light_command(key=rgbcw_light.key, color_brightness=0.8)
+        state = await wait_for_state_change(rgbcw_light.key)
+        assert state.color_brightness == pytest.approx(0.8)
+
+        # Test 4-7: RGB values must be set together via rgb parameter
+        client.light_command(key=rgbcw_light.key, rgb=(0.7, 0.3, 0.9))
+        state = await wait_for_state_change(rgbcw_light.key)
+        assert state.red == pytest.approx(0.7, abs=0.1)
+        assert state.green == pytest.approx(0.3, abs=0.1)
+        assert state.blue == pytest.approx(0.9, abs=0.1)
+
+        # Test 7: white value
+        client.light_command(key=rgbcw_light.key, white=0.6)
+        state = await wait_for_state_change(rgbcw_light.key)
+        # White might need more tolerance or might not be directly settable
+        if hasattr(state, "white"):
+            assert state.white == pytest.approx(0.6, abs=0.1)
+
+        # Test 8: color_temperature only
+        client.light_command(key=rgbcw_light.key, color_temperature=300)
+        state = await wait_for_state_change(rgbcw_light.key)
+        assert state.color_temperature == pytest.approx(300)
+
+        # Test 9: cold_white only
+        client.light_command(key=rgbcw_light.key, cold_white=0.8)
+        state = await wait_for_state_change(rgbcw_light.key)
+        assert state.cold_white == pytest.approx(0.8)
+
+        # Test 10: warm_white only
+        client.light_command(key=rgbcw_light.key, warm_white=0.2)
+        state = await wait_for_state_change(rgbcw_light.key)
+        assert state.warm_white == pytest.approx(0.2)
+
+        # Test 11: transition_length with state change
+        client.light_command(key=rgbcw_light.key, state=False, transition_length=0.1)
+        state = await wait_for_state_change(rgbcw_light.key)
+        assert state.state is False
+
+        # Test 12: flash_length
+        client.light_command(key=rgbcw_light.key, state=True, flash_length=0.2)
+        state = await wait_for_state_change(rgbcw_light.key)
+        # Flash starts
+        assert state.state is True
+        # Wait for flash to end
+        state = await wait_for_state_change(rgbcw_light.key)
+
+        # Test 13: effect only
+        # First ensure light is on
+        client.light_command(key=rgbcw_light.key, state=True)
+        state = await wait_for_state_change(rgbcw_light.key)
+        # Now set effect
+        client.light_command(key=rgbcw_light.key, effect="Random Effect")
+        state = await wait_for_state_change(rgbcw_light.key)
+        assert state.effect == "Random Effect"
+
+        # Test 14: stop effect
+        client.light_command(key=rgbcw_light.key, effect="None")
+        state = await wait_for_state_change(rgbcw_light.key)
+        assert state.effect == "None"
+
+        # Test 15: color_mode parameter
+        client.light_command(
+            key=rgbcw_light.key, state=True, color_mode=5
+        )  # COLD_WARM_WHITE
+        state = await wait_for_state_change(rgbcw_light.key)
+        assert state.state is True
+
+        # Now test common combinations
+
+        # Test 16: RGB combination (set_rgb) - RGB values get normalized
+        client.light_command(key=rgbcw_light.key, rgb=(1.0, 0.0, 0.5))
+        state = await wait_for_state_change(rgbcw_light.key)
+        # RGB values get normalized - in this case red is already 1.0
+        assert state.red == pytest.approx(1.0, abs=0.1)
+        assert state.green == pytest.approx(0.0, abs=0.1)
+        assert state.blue == pytest.approx(0.5, abs=0.1)
+
+        # Test 17: Multiple RGB changes to test transitions
+        client.light_command(key=rgbcw_light.key, rgb=(0.2, 0.8, 0.4))
+        state = await wait_for_state_change(rgbcw_light.key)
+        # RGB values get normalized so green (highest) becomes 1.0
+        # Expected: (0.2/0.8, 0.8/0.8, 0.4/0.8) = (0.25, 1.0, 0.5)
+        assert state.red == pytest.approx(0.25, abs=0.01)
+        assert state.green == pytest.approx(1.0, abs=0.01)
+        assert state.blue == pytest.approx(0.5, abs=0.01)
+
+        # Test 18: State + brightness + transition
+        client.light_command(
+            key=rgbcw_light.key, state=True, brightness=0.7, transition_length=0.1
+        )
+        state = await wait_for_state_change(rgbcw_light.key)
+        assert state.state is True
+        assert state.brightness == pytest.approx(0.7)
+
+        # Test 19: RGB + brightness + color_brightness
+        client.light_command(
+            key=rgb_light.key,
+            state=True,
+            brightness=0.8,
+            color_brightness=0.9,
+            rgb=(0.2, 0.4, 0.6),
+        )
+        state = await wait_for_state_change(rgb_light.key)
+        assert state.state is True
+        assert state.brightness == pytest.approx(0.8)
+
+        # Test 20: Color temp + cold/warm white
+        client.light_command(
+            key=rgbcw_light.key, color_temperature=250, cold_white=0.7, warm_white=0.3
+        )
+        state = await wait_for_state_change(rgbcw_light.key)
+        assert state.color_temperature == pytest.approx(250)
+
+        # Test 21: Turn RGB light off
+        client.light_command(key=rgb_light.key, state=False)
+        state = await wait_for_state_change(rgb_light.key)
+        assert state.state is False
+
+        # Final cleanup - turn all lights off
+        for light in lights:
+            client.light_command(
+                key=light.key,
+                state=False,
+            )
+            state = await wait_for_state_change(light.key)
+            assert state.state is False

--- a/tests/integration/test_light_calls.py
+++ b/tests/integration/test_light_calls.py
@@ -24,7 +24,7 @@ async def test_light_calls(
         state_futures: dict[int, asyncio.Future[Any]] = {}
         states: dict[int, Any] = {}
 
-        def on_state(state):
+        def on_state(state: Any) -> None:
             states[state.key] = state
             if state.key in state_futures and not state_futures[state.key].done():
                 state_futures[state.key].set_result(state)
@@ -39,7 +39,7 @@ async def test_light_calls(
         rgbcw_light = next(light for light in lights if "RGBCW" in light.name)
         rgb_light = next(light for light in lights if "RGB Light" in light.name)
 
-        async def wait_for_state_change(key, timeout=1.0):
+        async def wait_for_state_change(key: int, timeout: float = 1.0) -> Any:
             """Wait for a state change for the given entity key."""
             loop = asyncio.get_event_loop()
             state_futures[key] = loop.create_future()


### PR DESCRIPTION
# What does this implement/fix?

This PR reduces heap fragmentation and memory pressure during light operations by optimizing the `LightCall` class. Each light state change (from automations, API calls, or effects) creates a temporary `LightCall` object on the heap. By reducing each allocation from ~106 bytes to ~56 bytes, we significantly reduce heap churn.

This optimization is critical for ESP8266 with its limited 80KB RAM, where heap fragmentation from frequent allocations can lead to out-of-memory errors even when total free memory appears sufficient.

### Key improvements:
- **LightCall**: Reduced from ~106 bytes to ~56 bytes per allocation (47% reduction)
  - Replaced 14 `optional<>` members with raw values + 16-bit bitfield
  - Eliminated per-member overhead: each `optional<float>` used 8 bytes vs 4 bytes for raw float
- **Reduced heap fragmentation**: Smaller allocations are easier to fit in fragmented heap
- **Lower memory pressure**: Less likely to trigger garbage collection or OOM during light effects

### Impact:

- **Reduced heap fragmentation** - smaller allocations fit better in fragmented memory
- **Lower allocation pressure** - 50 fewer bytes per light operation
- **Better reliability** - less chance of OOM errors during complex light animations or when multiple lights change simultaneously


## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A (internal optimization, no user-facing changes)

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - this is an internal optimization
# All existing light configurations work unchanged

light:
  - platform: rgb
    name: "Test RGB Light"
    red: output_red
    green: output_green
    blue: output_blue
    effects:
      - random:
      - strobe:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

## Additional Notes:


### Classes Modified:
1. **LightCall** - Complete refactor to use bitfields instead of optional<>
2. **LightStateRTCState** - Reordered members for better alignment
3. **LightState** - Grouped larger members together, bools at end
4. **LightColorValues** - Moved ColorMode enum to end
5. **AddressableLight** - Optimized member ordering
6. **ESPColorCorrection** - Better alignment
7. **LightTransitionTransformer** - Moved bool to end
8. **LightFlashTransformer** - Optimized ordering
9. **AddressableLightTransformer** - Reordered float members

### Implementation Details:
- Added `FieldFlags` enum with 16 bit flags for tracking set values
- Implemented helper methods `has_*()` for checking if values are set
- Used macro `IMPLEMENT_LIGHT_CALL_SETTER` to reduce code duplication
- All validate/transform logic updated to use new flag-based approach