### PR TITLE
Mark ESPTime comparison operators as const

### DIFF
--- a/esphome/core/time.cpp
+++ b/esphome/core/time.cpp
@@ -226,11 +226,11 @@ int32_t ESPTime::timezone_offset() {
   return offset;
 }
 
-bool ESPTime::operator<(ESPTime other) const { return this->timestamp < other.timestamp; }
-bool ESPTime::operator<=(ESPTime other) const { return this->timestamp <= other.timestamp; }
-bool ESPTime::operator==(ESPTime other) const { return this->timestamp == other.timestamp; }
-bool ESPTime::operator>=(ESPTime other) const { return this->timestamp >= other.timestamp; }
-bool ESPTime::operator>(ESPTime other) const { return this->timestamp > other.timestamp; }
+bool ESPTime::operator<(const ESPTime &other) const { return this->timestamp < other.timestamp; }
+bool ESPTime::operator<=(const ESPTime &other) const { return this->timestamp <= other.timestamp; }
+bool ESPTime::operator==(const ESPTime &other) const { return this->timestamp == other.timestamp; }
+bool ESPTime::operator>=(const ESPTime &other) const { return this->timestamp >= other.timestamp; }
+bool ESPTime::operator>(const ESPTime &other) const { return this->timestamp > other.timestamp; }
 
 template<typename T> bool increment_time_value(T &current, uint16_t begin, uint16_t end) {
   current++;

--- a/esphome/core/time.cpp
+++ b/esphome/core/time.cpp
@@ -226,11 +226,11 @@ int32_t ESPTime::timezone_offset() {
   return offset;
 }
 
-bool ESPTime::operator<(ESPTime other) { return this->timestamp < other.timestamp; }
-bool ESPTime::operator<=(ESPTime other) { return this->timestamp <= other.timestamp; }
-bool ESPTime::operator==(ESPTime other) { return this->timestamp == other.timestamp; }
-bool ESPTime::operator>=(ESPTime other) { return this->timestamp >= other.timestamp; }
-bool ESPTime::operator>(ESPTime other) { return this->timestamp > other.timestamp; }
+bool ESPTime::operator<(ESPTime other) const { return this->timestamp < other.timestamp; }
+bool ESPTime::operator<=(ESPTime other) const { return this->timestamp <= other.timestamp; }
+bool ESPTime::operator==(ESPTime other) const { return this->timestamp == other.timestamp; }
+bool ESPTime::operator>=(ESPTime other) const { return this->timestamp >= other.timestamp; }
+bool ESPTime::operator>(ESPTime other) const { return this->timestamp > other.timestamp; }
 
 template<typename T> bool increment_time_value(T &current, uint16_t begin, uint16_t end) {
   current++;

--- a/esphome/core/time.h
+++ b/esphome/core/time.h
@@ -109,10 +109,10 @@ struct ESPTime {
   void increment_second();
   /// Increment this clock instance by one day.
   void increment_day();
-  bool operator<(ESPTime other);
-  bool operator<=(ESPTime other);
-  bool operator==(ESPTime other);
-  bool operator>=(ESPTime other);
-  bool operator>(ESPTime other);
+  bool operator<(ESPTime other) const;
+  bool operator<=(ESPTime other) const;
+  bool operator==(ESPTime other) const;
+  bool operator>=(ESPTime other) const;
+  bool operator>(ESPTime other) const;
 };
 }  // namespace esphome

--- a/esphome/core/time.h
+++ b/esphome/core/time.h
@@ -109,10 +109,10 @@ struct ESPTime {
   void increment_second();
   /// Increment this clock instance by one day.
   void increment_day();
-  bool operator<(ESPTime other) const;
-  bool operator<=(ESPTime other) const;
-  bool operator==(ESPTime other) const;
-  bool operator>=(ESPTime other) const;
-  bool operator>(ESPTime other) const;
+  bool operator<(const ESPTime &other) const;
+  bool operator<=(const ESPTime &other) const;
+  bool operator==(const ESPTime &other) const;
+  bool operator>=(const ESPTime &other) const;
+  bool operator>(const ESPTime &other) const;
 };
 }  // namespace esphome


### PR DESCRIPTION
# What does this implement/fix?

This PR marks all comparison operators on the ESPTime type as `const`. This allows comparing `const ESPTime` objects.

This is also needed to compare two `std::vector<ESPTime>` objects using `==`, as `std::vector::operator==` only takes `const` arguments. 

<!-- Quick description and explanation of changes -->

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other


## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx


## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
