### PR TITLE
deep_sleep: Replace polling loop with event-driven state machine

### DIFF
--- a/esphome/components/deep_sleep/deep_sleep_component.cpp
+++ b/esphome/components/deep_sleep/deep_sleep_component.cpp
@@ -36,26 +36,27 @@ void DeepSleepComponent::dump_config() {
   this->dump_config_platform_();
 }
 
-void DeepSleepComponent::loop() {
-  if (this->next_enter_deep_sleep_)
-    this->begin_sleep();
-}
-
-float DeepSleepComponent::get_loop_priority() const {
-  return -100.0f;  // run after everything else is ready
-}
-
 void DeepSleepComponent::set_sleep_duration(uint32_t time_ms) { this->sleep_duration_ = uint64_t(time_ms) * 1000; }
 
 void DeepSleepComponent::set_run_duration(uint32_t time_ms) { this->run_duration_ = time_ms; }
 
 void DeepSleepComponent::begin_sleep(bool manual) {
-  if (this->prevent_ && !manual) {
-    this->next_enter_deep_sleep_ = true;
+  if (this->sleep_state_ == SLEEP_STATE_ENTERING_SLEEP) {
+    // Already entering sleep, avoid re-entrance
     return;
   }
 
+  if (this->prevent_ && !manual) {
+    // Sleep was prevented
+    this->sleep_state_ = SLEEP_STATE_BLOCKED_BY_PREVENT;
+    ESP_LOGD(TAG, "Deep sleep blocked by prevent flag");
+    return;
+  }
+
+  this->sleep_state_ = SLEEP_STATE_ENTERING_SLEEP;
+
   if (!this->prepare_to_sleep_()) {
+    // prepare_to_sleep_ will set appropriate blocked state
     return;
   }
 
@@ -76,7 +77,17 @@ float DeepSleepComponent::get_setup_priority() const { return setup_priority::LA
 
 void DeepSleepComponent::prevent_deep_sleep() { this->prevent_ = true; }
 
-void DeepSleepComponent::allow_deep_sleep() { this->prevent_ = false; }
+void DeepSleepComponent::allow_deep_sleep() {
+  this->prevent_ = false;
+  // If sleep was blocked by prevent flag, try to sleep now
+  if (this->sleep_state_ == SLEEP_STATE_BLOCKED_BY_PREVENT) {
+    ESP_LOGD(TAG, "Deep sleep allowed, executing deferred sleep");
+    this->sleep_state_ = SLEEP_STATE_IDLE;
+    // Schedule sleep for next loop iteration to avoid potential issues
+    // with calling begin_sleep during another component's execution
+    this->defer([this]() { this->begin_sleep(false); });  // false = automatic sleep (respects prevent flag)
+  }
+}
 
 }  // namespace deep_sleep
 }  // namespace esphome

--- a/esphome/components/deep_sleep/deep_sleep_component.cpp
+++ b/esphome/components/deep_sleep/deep_sleep_component.cpp
@@ -48,7 +48,7 @@ void DeepSleepComponent::begin_sleep(bool manual) {
 
   if (this->prevent_ && !manual) {
     // Sleep was prevented
-    this->sleep_state_ = SLEEP_STATE_BLOCKED;
+    this->sleep_state_ = SLEEP_STATE_BLOCKED_BY_PREVENT;
     ESP_LOGD(TAG, "Deep sleep blocked by prevent flag");
     return;
   }
@@ -79,8 +79,8 @@ void DeepSleepComponent::prevent_deep_sleep() { this->prevent_ = true; }
 
 void DeepSleepComponent::allow_deep_sleep() {
   this->prevent_ = false;
-  // If sleep was blocked, try to sleep now
-  if (this->sleep_state_ == SLEEP_STATE_BLOCKED) {
+  // If sleep was blocked by prevent flag, try to sleep now
+  if (this->sleep_state_ == SLEEP_STATE_BLOCKED_BY_PREVENT) {
     ESP_LOGD(TAG, "Deep sleep allowed, executing deferred sleep");
     this->sleep_state_ = SLEEP_STATE_IDLE;
     // Schedule sleep for next loop iteration to avoid potential issues

--- a/esphome/components/deep_sleep/deep_sleep_component.cpp
+++ b/esphome/components/deep_sleep/deep_sleep_component.cpp
@@ -48,7 +48,7 @@ void DeepSleepComponent::begin_sleep(bool manual) {
 
   if (this->prevent_ && !manual) {
     // Sleep was prevented
-    this->sleep_state_ = SLEEP_STATE_BLOCKED_BY_PREVENT;
+    this->sleep_state_ = SLEEP_STATE_BLOCKED;
     ESP_LOGD(TAG, "Deep sleep blocked by prevent flag");
     return;
   }
@@ -79,8 +79,8 @@ void DeepSleepComponent::prevent_deep_sleep() { this->prevent_ = true; }
 
 void DeepSleepComponent::allow_deep_sleep() {
   this->prevent_ = false;
-  // If sleep was blocked by prevent flag, try to sleep now
-  if (this->sleep_state_ == SLEEP_STATE_BLOCKED_BY_PREVENT) {
+  // If sleep was blocked, try to sleep now
+  if (this->sleep_state_ == SLEEP_STATE_BLOCKED) {
     ESP_LOGD(TAG, "Deep sleep allowed, executing deferred sleep");
     this->sleep_state_ = SLEEP_STATE_IDLE;
     // Schedule sleep for next loop iteration to avoid potential issues

--- a/esphome/components/deep_sleep/deep_sleep_component.h
+++ b/esphome/components/deep_sleep/deep_sleep_component.h
@@ -124,8 +124,7 @@ class DeepSleepComponent : public Component {
 #endif
   enum SleepState : uint8_t {
     SLEEP_STATE_IDLE,
-    SLEEP_STATE_BLOCKED_BY_PREVENT,
-    SLEEP_STATE_BLOCKED_BY_WAKEUP_PIN,
+    SLEEP_STATE_BLOCKED,
     SLEEP_STATE_ENTERING_SLEEP,
   };
 

--- a/esphome/components/deep_sleep/deep_sleep_component.h
+++ b/esphome/components/deep_sleep/deep_sleep_component.h
@@ -93,8 +93,6 @@ class DeepSleepComponent : public Component {
 
   void setup() override;
   void dump_config() override;
-  void loop() override;
-  float get_loop_priority() const override;
   float get_setup_priority() const override;
 
   /// Helper to enter deep sleep mode
@@ -124,9 +122,16 @@ class DeepSleepComponent : public Component {
   optional<bool> touch_wakeup_;
   optional<WakeupCauseToRunDuration> wakeup_cause_to_run_duration_;
 #endif
+  enum SleepState : uint8_t {
+    SLEEP_STATE_IDLE,
+    SLEEP_STATE_BLOCKED_BY_PREVENT,
+    SLEEP_STATE_BLOCKED_BY_WAKEUP_PIN,
+    SLEEP_STATE_ENTERING_SLEEP,
+  };
+
   optional<uint32_t> run_duration_;
-  bool next_enter_deep_sleep_{false};
   bool prevent_{false};
+  SleepState sleep_state_{SLEEP_STATE_IDLE};
 };
 
 extern bool global_has_deep_sleep;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)

--- a/esphome/components/deep_sleep/deep_sleep_component.h
+++ b/esphome/components/deep_sleep/deep_sleep_component.h
@@ -124,7 +124,8 @@ class DeepSleepComponent : public Component {
 #endif
   enum SleepState : uint8_t {
     SLEEP_STATE_IDLE,
-    SLEEP_STATE_BLOCKED,
+    SLEEP_STATE_BLOCKED_BY_PREVENT,
+    SLEEP_STATE_BLOCKED_BY_WAKEUP_PIN,
     SLEEP_STATE_ENTERING_SLEEP,
   };
 

--- a/esphome/components/deep_sleep/deep_sleep_esp32.cpp
+++ b/esphome/components/deep_sleep/deep_sleep_esp32.cpp
@@ -59,8 +59,8 @@ bool DeepSleepComponent::prepare_to_sleep_() {
   if (this->wakeup_pin_mode_ == WAKEUP_PIN_MODE_KEEP_AWAKE && this->wakeup_pin_ != nullptr &&
       this->wakeup_pin_->digital_read()) {
     // Defer deep sleep until inactive
-    if (this->sleep_state_ != SLEEP_STATE_BLOCKED) {
-      this->sleep_state_ = SLEEP_STATE_BLOCKED;
+    if (this->sleep_state_ != SLEEP_STATE_BLOCKED_BY_WAKEUP_PIN) {
+      this->sleep_state_ = SLEEP_STATE_BLOCKED_BY_WAKEUP_PIN;
       this->status_set_warning();
       ESP_LOGW(TAG, "Waiting for wakeup pin state change");
       // Set up monitoring - check pin state every 100ms

--- a/esphome/components/deep_sleep/deep_sleep_esp32.cpp
+++ b/esphome/components/deep_sleep/deep_sleep_esp32.cpp
@@ -59,12 +59,26 @@ bool DeepSleepComponent::prepare_to_sleep_() {
   if (this->wakeup_pin_mode_ == WAKEUP_PIN_MODE_KEEP_AWAKE && this->wakeup_pin_ != nullptr &&
       this->wakeup_pin_->digital_read()) {
     // Defer deep sleep until inactive
-    if (!this->next_enter_deep_sleep_) {
+    if (this->sleep_state_ != SLEEP_STATE_BLOCKED_BY_WAKEUP_PIN) {
+      this->sleep_state_ = SLEEP_STATE_BLOCKED_BY_WAKEUP_PIN;
       this->status_set_warning();
       ESP_LOGW(TAG, "Waiting for wakeup pin state change");
+      // Set up monitoring - check pin state every 100ms
+      this->set_interval("wakeup_pin_check", 100, [this]() {
+        if (!this->wakeup_pin_->digital_read()) {
+          ESP_LOGD(TAG, "Wakeup pin inactive, can now enter deep sleep");
+          this->cancel_interval("wakeup_pin_check");
+          this->sleep_state_ = SLEEP_STATE_IDLE;
+          this->begin_sleep(false);  // false = automatic sleep (respects prevent flag)
+        }
+      });
     }
-    this->next_enter_deep_sleep_ = true;
     return false;
+  }
+  // If we were monitoring and now can sleep, clean up
+  if (this->sleep_state_ == SLEEP_STATE_BLOCKED_BY_WAKEUP_PIN) {
+    this->cancel_interval("wakeup_pin_check");
+    this->sleep_state_ = SLEEP_STATE_ENTERING_SLEEP;
   }
   return true;
 }

--- a/esphome/components/deep_sleep/deep_sleep_esp32.cpp
+++ b/esphome/components/deep_sleep/deep_sleep_esp32.cpp
@@ -59,8 +59,8 @@ bool DeepSleepComponent::prepare_to_sleep_() {
   if (this->wakeup_pin_mode_ == WAKEUP_PIN_MODE_KEEP_AWAKE && this->wakeup_pin_ != nullptr &&
       this->wakeup_pin_->digital_read()) {
     // Defer deep sleep until inactive
-    if (this->sleep_state_ != SLEEP_STATE_BLOCKED_BY_WAKEUP_PIN) {
-      this->sleep_state_ = SLEEP_STATE_BLOCKED_BY_WAKEUP_PIN;
+    if (this->sleep_state_ != SLEEP_STATE_BLOCKED) {
+      this->sleep_state_ = SLEEP_STATE_BLOCKED;
       this->status_set_warning();
       ESP_LOGW(TAG, "Waiting for wakeup pin state change");
       // Set up monitoring - check pin state every 100ms

--- a/esphome/components/deep_sleep/deep_sleep_esp32.cpp
+++ b/esphome/components/deep_sleep/deep_sleep_esp32.cpp
@@ -75,11 +75,6 @@ bool DeepSleepComponent::prepare_to_sleep_() {
     }
     return false;
   }
-  // If we were monitoring and now can sleep, clean up
-  if (this->sleep_state_ == SLEEP_STATE_BLOCKED_BY_WAKEUP_PIN) {
-    this->cancel_interval("wakeup_pin_check");
-    this->sleep_state_ = SLEEP_STATE_ENTERING_SLEEP;
-  }
   return true;
 }
 


### PR DESCRIPTION
# What does this implement/fix?

This PR replaces the inefficient polling loop in the `deep_sleep` component with an event-driven state machine approach. The previous implementation had a `loop()` method that was called approximately 7000 times per minute just to check a boolean flag, which wastes CPU cycles and power.

The new implementation uses a state machine with scheduled callbacks (`defer()` and `set_interval()`) to handle sleep transitions only when needed.

## State Machine Diagram

```mermaid
stateDiagram-v2
    [*] --> IDLE: Initial state
    
    IDLE --> BLOCKED_BY_PREVENT: begin_sleep() with prevent=true
    IDLE --> ENTERING_SLEEP: begin_sleep() with prevent=false
    
    BLOCKED_BY_PREVENT --> IDLE: allow_deep_sleep()
    
    ENTERING_SLEEP --> BLOCKED_BY_WAKEUP_PIN: prepare_to_sleep() fails (ESP32 wakeup pin active)
    ENTERING_SLEEP --> [*]: deep_sleep_() executes
    
    BLOCKED_BY_WAKEUP_PIN --> IDLE: Wakeup pin becomes inactive (via interval)
    
    note right of IDLE
        From IDLE, defer() or interval callbacks
        trigger begin_sleep() to retry
    end note
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A (no user-facing changes)

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# No configuration changes - this is an internal optimization
deep_sleep:
  run_duration: 10s
  sleep_duration: 20s
  id: deep_sleep_1

# Test prevent/allow functionality
switch:
  - platform: template
    name: "Prevent Deep Sleep"
    turn_on_action:
      - deep_sleep.prevent: deep_sleep_1
    turn_off_action:
      - deep_sleep.allow: deep_sleep_1
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

## Additional Context

### Implementation Details:
The component now uses a state machine with four states:
- `SLEEP_STATE_IDLE`: Normal operation, ready to sleep
- `SLEEP_STATE_BLOCKED_BY_PREVENT`: Sleep blocked by prevent flag
- `SLEEP_STATE_BLOCKED_BY_WAKEUP_PIN`: Sleep blocked by ESP32 wakeup pin (KEEP_AWAKE mode)  
- `SLEEP_STATE_ENTERING_SLEEP`: Actively entering sleep (prevents re-entrance)

Key changes:
- Removed the polling `loop()` method and `next_enter_deep_sleep_` flag
- Sleep attempts now use event-driven callbacks (`defer()` and `set_interval()`)
- Each blocking condition has its own state with a clear unblocking mechanism
- `allow_deep_sleep()` only affects the prevent-blocked state, not wakeup pin blocking

### Performance Impact:
Real-world runtime statistics showing the improvement:

**Before**: 
```
deep_sleep: count=7000+, avg=0.00ms, max=14ms, total=30ms+
```
The component's loop() was called ~7,000 times per minute (~117 times/second)

**After**:
```
deep_sleep: count=1, avg=1.00ms, max=1ms, total=1ms
```
The component now only runs when actually needed

This represents a **99.99% reduction** in component calls and eliminates continuous CPU time spent polling!

### Why This Matters:
Devices using deep sleep are typically battery-powered (sensors, remote controls, etc.). Every CPU cycle spent in unnecessary polling directly impacts battery life. By eliminating this constant polling (117 times per second), we reduce power consumption during the device's active period, helping to maximize battery life - which is often the primary reason for using deep sleep in the first place.

### Backwards Compatibility:
All existing functionality is preserved. The change is purely internal and does not affect the component's API or configuration.