### PR TITLE
Optimize entity icon memory usage with USE_ENTITY_ICON flag

### DIFF
--- a/esphome/core/defines.h
+++ b/esphome/core/defines.h
@@ -32,6 +32,7 @@
 #define USE_DEEP_SLEEP
 #define USE_DEVICES
 #define USE_DISPLAY
+#define USE_ENTITY_ICON
 #define USE_ESP32_IMPROV_STATE_CALLBACK
 #define USE_EVENT
 #define USE_FAN

--- a/esphome/core/entity_base.cpp
+++ b/esphome/core/entity_base.cpp
@@ -27,12 +27,22 @@ void EntityBase::set_name(const char *name) {
 
 // Entity Icon
 std::string EntityBase::get_icon() const {
+#ifdef USE_ENTITY_ICON
   if (this->icon_c_str_ == nullptr) {
     return "";
   }
   return this->icon_c_str_;
+#else
+  return "";
+#endif
 }
-void EntityBase::set_icon(const char *icon) { this->icon_c_str_ = icon; }
+void EntityBase::set_icon(const char *icon) {
+#ifdef USE_ENTITY_ICON
+  this->icon_c_str_ = icon;
+#else
+  // No-op when USE_ENTITY_ICON is not defined
+#endif
+}
 
 // Entity Object ID
 std::string EntityBase::get_object_id() const {

--- a/esphome/core/entity_base.h
+++ b/esphome/core/entity_base.h
@@ -80,7 +80,9 @@ class EntityBase {
 
   StringRef name_;
   const char *object_id_c_str_{nullptr};
+#ifdef USE_ENTITY_ICON
   const char *icon_c_str_{nullptr};
+#endif
   uint32_t object_id_hash_{};
 #ifdef USE_DEVICES
   Device *device_{};

--- a/esphome/core/entity_helpers.py
+++ b/esphome/core/entity_helpers.py
@@ -1,6 +1,7 @@
 from collections.abc import Callable
 import logging
 
+import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.const import (
     CONF_DEVICE_ID,
@@ -108,6 +109,8 @@ async def setup_entity(var: MockObj, config: ConfigType, platform: str) -> None:
     if CONF_INTERNAL in config:
         add(var.set_internal(config[CONF_INTERNAL]))
     if CONF_ICON in config:
+        # Add USE_ENTITY_ICON define when icons are used
+        cg.add_define("USE_ENTITY_ICON")
         add(var.set_icon(config[CONF_ICON]))
     if CONF_ENTITY_CATEGORY in config:
         add(var.set_entity_category(config[CONF_ENTITY_CATEGORY]))

--- a/tests/integration/fixtures/entity_icon.yaml
+++ b/tests/integration/fixtures/entity_icon.yaml
@@ -1,0 +1,78 @@
+esphome:
+  name: icon-test
+
+host:
+
+api:
+
+logger:
+
+# Test entities with custom icons
+sensor:
+  - platform: template
+    name: "Sensor With Icon"
+    icon: "mdi:temperature-celsius"
+    unit_of_measurement: "°C"
+    update_interval: 1s
+    lambda: |-
+      return 25.5;
+
+  - platform: template
+    name: "Sensor Without Icon"
+    unit_of_measurement: "%"
+    update_interval: 1s
+    lambda: |-
+      return 50.0;
+
+binary_sensor:
+  - platform: template
+    name: "Binary Sensor With Icon"
+    icon: "mdi:motion-sensor"
+    lambda: |-
+      return true;
+
+  - platform: template
+    name: "Binary Sensor Without Icon"
+    lambda: |-
+      return false;
+
+text_sensor:
+  - platform: template
+    name: "Text Sensor With Icon"
+    icon: "mdi:text-box"
+    lambda: |-
+      return {"Hello Icons"};
+
+switch:
+  - platform: template
+    name: "Switch With Icon"
+    icon: "mdi:toggle-switch"
+    optimistic: true
+
+button:
+  - platform: template
+    name: "Button With Icon"
+    icon: "mdi:gesture-tap-button"
+    on_press:
+      - logger.log: "Button with icon pressed"
+
+number:
+  - platform: template
+    name: "Number With Icon"
+    icon: "mdi:numeric"
+    initial_value: 42
+    min_value: 0
+    max_value: 100
+    step: 1
+    optimistic: true
+
+select:
+  - platform: template
+    name: "Select With Icon"
+    icon: "mdi:format-list-bulleted"
+    options:
+      - "Option A"
+      - "Option B"
+      - "Option C"
+    initial_option: "Option A"
+    optimistic: true

--- a/tests/integration/test_entity_icon.py
+++ b/tests/integration/test_entity_icon.py
@@ -1,0 +1,97 @@
+"""Integration test for entity icons with USE_ENTITY_ICON feature."""
+
+from __future__ import annotations
+
+import asyncio
+
+from aioesphomeapi import EntityState
+import pytest
+
+from .types import APIClientConnectedFactory, RunCompiledFunction
+
+
+@pytest.mark.asyncio
+async def test_entity_icon(
+    yaml_config: str,
+    run_compiled: RunCompiledFunction,
+    api_client_connected: APIClientConnectedFactory,
+) -> None:
+    """Test that entities with custom icons work correctly with USE_ENTITY_ICON."""
+    # Write, compile and run the ESPHome device, then connect to API
+    async with run_compiled(yaml_config), api_client_connected() as client:
+        # Get all entities
+        entities = await client.list_entities_services()
+
+        # Create a map of entity names to entity info
+        entity_map = {entity.name: entity for entity in entities[0]}
+
+        # Test entities with icons
+        icon_test_cases = [
+            # (entity_name, expected_icon)
+            ("Sensor With Icon", "mdi:temperature-celsius"),
+            ("Binary Sensor With Icon", "mdi:motion-sensor"),
+            ("Text Sensor With Icon", "mdi:text-box"),
+            ("Switch With Icon", "mdi:toggle-switch"),
+            ("Button With Icon", "mdi:gesture-tap-button"),
+            ("Number With Icon", "mdi:numeric"),
+            ("Select With Icon", "mdi:format-list-bulleted"),
+        ]
+
+        # Test entities without icons (should have empty string)
+        no_icon_test_cases = [
+            "Sensor Without Icon",
+            "Binary Sensor Without Icon",
+        ]
+
+        # Verify entities with icons
+        for entity_name, expected_icon in icon_test_cases:
+            assert entity_name in entity_map, (
+                f"Entity '{entity_name}' not found in API response"
+            )
+            entity = entity_map[entity_name]
+
+            # Check icon field
+            assert hasattr(entity, "icon"), (
+                f"{entity_name}: Entity should have icon attribute"
+            )
+            assert entity.icon == expected_icon, (
+                f"{entity_name}: icon mismatch - "
+                f"expected '{expected_icon}', got '{entity.icon}'"
+            )
+
+        # Verify entities without icons
+        for entity_name in no_icon_test_cases:
+            assert entity_name in entity_map, (
+                f"Entity '{entity_name}' not found in API response"
+            )
+            entity = entity_map[entity_name]
+
+            # Check icon field is empty
+            assert hasattr(entity, "icon"), (
+                f"{entity_name}: Entity should have icon attribute"
+            )
+            assert entity.icon == "", (
+                f"{entity_name}: icon should be empty string for entities without icons, "
+                f"got '{entity.icon}'"
+            )
+
+        # Subscribe to states to ensure everything works normally
+        states: dict[int, EntityState] = {}
+        state_received = asyncio.Event()
+
+        def on_state(state: EntityState) -> None:
+            states[state.key] = state
+            state_received.set()
+
+        client.subscribe_states(on_state)
+
+        # Wait for states
+        try:
+            await asyncio.wait_for(state_received.wait(), timeout=5.0)
+        except asyncio.TimeoutError:
+            pytest.fail("No states received within 5 seconds")
+
+        # Verify we received states
+        assert len(states) > 0, (
+            "No states received - entities may not be working correctly"
+        )


### PR DESCRIPTION
## What does this implement/fix?

This PR implements a memory optimization for entity icons in ESPHome. The optimization saves 4 bytes per entity on 32-bit systems by conditionally compiling icon storage only when icons are actually used.

### Background
- Each entity in ESPHome stores an icon pointer that uses 4 bytes on 32-bit systems
- Home Assistant has shifted to device class icons and UI-configurable icons, reducing the need for hardcoded icons
- Many configurations don't use icons at all, wasting memory on embedded devices where every byte counts

### Implementation
- Adds `USE_ENTITY_ICON` preprocessor flag that is automatically set when any entity uses an icon
- Icon storage (`icon_c_str_`) is conditionally compiled based on this flag
- When icons aren't used, `get_icon()` returns an empty string and `set_icon()` becomes a no-op
- **This is fully backward compatible** - existing configurations work unchanged
- **Icon support is NOT being removed or deprecated** - this is purely an optimization

### Key Features
- **Pay-as-you-go model**: Icon storage is only allocated when icons are actually used
- **Automatic detection**: The build system automatically detects icon usage and sets the flag
- **Zero user impact**: No configuration changes required
- **Full API compatibility**: All existing code continues to work

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A (No user-visible changes)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [x] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# No configuration changes needed!
# Icons work exactly as before:

sensor:
  - platform: template
    name: "Temperature"
    icon: "mdi:thermometer"  # When icons are used, USE_ENTITY_ICON is automatically set
    lambda: return 25.0;

binary_sensor:
  - platform: template
    name: "Door"
    # No icon - saves 4 bytes of memory per entity
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

## Additional Notes

- Integration tests added to verify entities with and without icons work correctly
- Tested memory savings by compiling configurations with and without icons
- Verified `USE_ENTITY_ICON` is correctly added to defines.h when icons are present
- All existing entity types continue to support icons when configured
