### PR TITLE
Reduce RAM usage by optimizing Color constant storage

### DIFF
--- a/esphome/core/color.cpp
+++ b/esphome/core/color.cpp
@@ -2,10 +2,8 @@
 
 namespace esphome {
 
-const Color Color::BLACK(0, 0, 0, 0);
-const Color Color::WHITE(255, 255, 255, 255);
-
-const Color COLOR_BLACK(0, 0, 0, 0);
-const Color COLOR_WHITE(255, 255, 255, 255);
+// C++20 constinit ensures compile-time initialization (stored in ROM)
+constinit const Color Color::BLACK(0, 0, 0, 0);
+constinit const Color Color::WHITE(255, 255, 255, 255);
 
 }  // namespace esphome

--- a/esphome/core/color.h
+++ b/esphome/core/color.h
@@ -5,7 +5,9 @@
 
 namespace esphome {
 
-inline static uint8_t esp_scale8(uint8_t i, uint8_t scale) { return (uint16_t(i) * (1 + uint16_t(scale))) / 256; }
+inline static constexpr uint8_t esp_scale8(uint8_t i, uint8_t scale) {
+  return (uint16_t(i) * (1 + uint16_t(scale))) / 256;
+}
 
 struct Color {
   union {
@@ -31,17 +33,20 @@ struct Color {
     uint32_t raw_32;
   };
 
-  inline Color() ESPHOME_ALWAYS_INLINE : r(0), g(0), b(0), w(0) {}  // NOLINT
-  inline Color(uint8_t red, uint8_t green, uint8_t blue) ESPHOME_ALWAYS_INLINE : r(red), g(green), b(blue), w(0) {}
+  inline constexpr Color() ESPHOME_ALWAYS_INLINE : raw_32(0) {}  // NOLINT
+  inline constexpr Color(uint8_t red, uint8_t green, uint8_t blue) ESPHOME_ALWAYS_INLINE : r(red),
+                                                                                           g(green),
+                                                                                           b(blue),
+                                                                                           w(0) {}
 
-  inline Color(uint8_t red, uint8_t green, uint8_t blue, uint8_t white) ESPHOME_ALWAYS_INLINE : r(red),
-                                                                                                g(green),
-                                                                                                b(blue),
-                                                                                                w(white) {}
-  inline explicit Color(uint32_t colorcode) ESPHOME_ALWAYS_INLINE : r((colorcode >> 16) & 0xFF),
-                                                                    g((colorcode >> 8) & 0xFF),
-                                                                    b((colorcode >> 0) & 0xFF),
-                                                                    w((colorcode >> 24) & 0xFF) {}
+  inline constexpr Color(uint8_t red, uint8_t green, uint8_t blue, uint8_t white) ESPHOME_ALWAYS_INLINE : r(red),
+                                                                                                          g(green),
+                                                                                                          b(blue),
+                                                                                                          w(white) {}
+  inline explicit constexpr Color(uint32_t colorcode) ESPHOME_ALWAYS_INLINE : r((colorcode >> 16) & 0xFF),
+                                                                              g((colorcode >> 8) & 0xFF),
+                                                                              b((colorcode >> 0) & 0xFF),
+                                                                              w((colorcode >> 24) & 0xFF) {}
 
   inline bool is_on() ESPHOME_ALWAYS_INLINE { return this->raw_32 != 0; }
 
@@ -168,10 +173,5 @@ struct Color {
   static const Color BLACK;
   static const Color WHITE;
 };
-
-ESPDEPRECATED("Use Color::BLACK instead of COLOR_BLACK", "v1.21")
-extern const Color COLOR_BLACK;
-ESPDEPRECATED("Use Color::WHITE instead of COLOR_WHITE", "v1.21")
-extern const Color COLOR_WHITE;
 
 }  // namespace esphome


### PR DESCRIPTION
# What does this implement/fix?

This PR optimizes memory usage by:
1. **[BREAKING]** Removing deprecated `COLOR_BLACK` and `COLOR_WHITE` constants that have been deprecated since v1.21 (2021)
2. Using C++20's `constinit` to ensure `Color::BLACK` and `Color::WHITE` are stored in ROM instead of RAM
3. Making Color constructors `constexpr` to enable compile-time initialization

**Result:** Saves 16 bytes of RAM by removing deprecated constants and ensures the remaining color constants are stored in ROM (.rodata section) instead of RAM.

## Breaking Changes

- Removed `COLOR_BLACK` and `COLOR_WHITE` global constants
- Users should update to use `Color::BLACK` and `Color::WHITE` instead (as recommended since v1.21)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

<!-- No related issue -->

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

<!-- No documentation changes needed - internal optimization only -->

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# No configuration changes needed - this is an internal optimization
# All existing configurations using displays/lights will automatically benefit

# Example usage remains the same:
light:
  - platform: addressable_light
    # ... configuration ...
    effects:
      - addressable_color_wipe:
          colors:
            - red: 0%
              green: 0%
              blue: 0%
              # Uses Color::BLACK internally
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).