### PR TITLE
Reduce core RAM usage by 40 bytes with static initialization optimizations

### DIFF
--- a/esphome/core/component.cpp
+++ b/esphome/core/component.cpp
@@ -31,18 +31,12 @@ static const char *const TAG = "component";
 // This is safe because ESPHome is single-threaded during initialization
 namespace {
 // Error messages for failed components
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 std::unique_ptr<std::vector<std::pair<const Component *, const char *>>> component_error_messages;
 // Setup priority overrides - freed after setup completes
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 std::unique_ptr<std::vector<std::pair<const Component *, float>>> setup_priority_overrides;
 }  // namespace
-
-static std::unique_ptr<std::vector<std::pair<const Component *, const char *>>> &get_component_error_messages() {
-  return component_error_messages;
-}
-
-static std::unique_ptr<std::vector<std::pair<const Component *, float>>> &get_setup_priority_overrides() {
-  return setup_priority_overrides;
-}
 
 namespace setup_priority {
 
@@ -136,8 +130,8 @@ void Component::call_dump_config() {
   if (this->is_failed()) {
     // Look up error message from global vector
     const char *error_msg = "unspecified";
-    if (get_component_error_messages()) {
-      for (const auto &pair : *get_component_error_messages()) {
+    if (component_error_messages) {
+      for (const auto &pair : *component_error_messages) {
         if (pair.first == this) {
           error_msg = pair.second;
           break;
@@ -291,18 +285,18 @@ void Component::status_set_error(const char *message) {
   ESP_LOGE(TAG, "Component %s set Error flag: %s", this->get_component_source(), message);
   if (strcmp(message, "unspecified") != 0) {
     // Lazy allocate the error messages vector if needed
-    if (!get_component_error_messages()) {
-      get_component_error_messages() = std::make_unique<std::vector<std::pair<const Component *, const char *>>>();
+    if (!component_error_messages) {
+      component_error_messages = std::make_unique<std::vector<std::pair<const Component *, const char *>>>();
     }
     // Check if this component already has an error message
-    for (auto &pair : *get_component_error_messages()) {
+    for (auto &pair : *component_error_messages) {
       if (pair.first == this) {
         pair.second = message;
         return;
       }
     }
     // Add new error message
-    get_component_error_messages()->emplace_back(this, message);
+    component_error_messages->emplace_back(this, message);
   }
 }
 void Component::status_clear_warning() {
@@ -328,9 +322,9 @@ void Component::status_momentary_error(const std::string &name, uint32_t length)
 void Component::dump_config() {}
 float Component::get_actual_setup_priority() const {
   // Check if there's an override in the global vector
-  if (get_setup_priority_overrides()) {
+  if (setup_priority_overrides) {
     // Linear search is fine for small n (typically < 5 overrides)
-    for (const auto &pair : *get_setup_priority_overrides()) {
+    for (const auto &pair : *setup_priority_overrides) {
       if (pair.first == this) {
         return pair.second;
       }
@@ -340,14 +334,14 @@ float Component::get_actual_setup_priority() const {
 }
 void Component::set_setup_priority(float priority) {
   // Lazy allocate the vector if needed
-  if (!get_setup_priority_overrides()) {
-    get_setup_priority_overrides() = std::make_unique<std::vector<std::pair<const Component *, float>>>();
+  if (!setup_priority_overrides) {
+    setup_priority_overrides = std::make_unique<std::vector<std::pair<const Component *, float>>>();
     // Reserve some space to avoid reallocations (most configs have < 10 overrides)
-    get_setup_priority_overrides()->reserve(10);
+    setup_priority_overrides->reserve(10);
   }
 
   // Check if this component already has an override
-  for (auto &pair : *get_setup_priority_overrides()) {
+  for (auto &pair : *setup_priority_overrides) {
     if (pair.first == this) {
       pair.second = priority;
       return;
@@ -355,7 +349,7 @@ void Component::set_setup_priority(float priority) {
   }
 
   // Add new override
-  get_setup_priority_overrides()->emplace_back(this, priority);
+  setup_priority_overrides->emplace_back(this, priority);
 }
 
 bool Component::has_overridden_loop() const {
@@ -420,7 +414,7 @@ WarnIfComponentBlockingGuard::~WarnIfComponentBlockingGuard() {}
 
 void clear_setup_priority_overrides() {
   // Free the setup priority map completely
-  get_setup_priority_overrides().reset();
+  setup_priority_overrides.reset();
 }
 
 }  // namespace esphome

--- a/esphome/core/component.cpp
+++ b/esphome/core/component.cpp
@@ -26,16 +26,22 @@ static const char *const TAG = "component";
 // 1. Components are never destroyed in ESPHome
 // 2. Failed components remain failed (no recovery mechanism)
 // 3. Memory usage is minimal (only failures with custom messages are stored)
+
+// Using namespace-scope static to avoid guard variables (saves 16 bytes total)
+// This is safe because ESPHome is single-threaded during initialization
+namespace {
+// Error messages for failed components
+std::unique_ptr<std::vector<std::pair<const Component *, const char *>>> component_error_messages;
+// Setup priority overrides - freed after setup completes
+std::unique_ptr<std::vector<std::pair<const Component *, float>>> setup_priority_overrides;
+}  // namespace
+
 static std::unique_ptr<std::vector<std::pair<const Component *, const char *>>> &get_component_error_messages() {
-  static std::unique_ptr<std::vector<std::pair<const Component *, const char *>>> instance;
-  return instance;
+  return component_error_messages;
 }
 
-// Setup priority overrides - freed after setup completes
-// Typically < 5 entries, lazy allocated
 static std::unique_ptr<std::vector<std::pair<const Component *, float>>> &get_setup_priority_overrides() {
-  static std::unique_ptr<std::vector<std::pair<const Component *, float>>> instance;
-  return instance;
+  return setup_priority_overrides;
 }
 
 namespace setup_priority {

--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -465,6 +465,13 @@ static constexpr const char *BASE64_CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
                                             "abcdefghijklmnopqrstuvwxyz"
                                             "0123456789+/";
 
+// Helper function to find the index of a base64 character in the lookup table.
+// Returns the character's position (0-63) if found, or 0 if not found.
+// NOTE: This returns 0 for both 'A' (valid base64 char at index 0) and invalid characters.
+// This is safe because is_base64() is ALWAYS checked before calling this function,
+// preventing invalid characters from ever reaching here. The base64_decode function
+// stops processing at the first invalid character due to the is_base64() check in its
+// while loop condition, making this edge case harmless in practice.
 static inline uint8_t base64_find_char(char c) {
   const char *pos = strchr(BASE64_CHARS, c);
   return pos ? (pos - BASE64_CHARS) : 0;
@@ -532,6 +539,9 @@ std::vector<uint8_t> base64_decode(const std::string &encoded_string) {
   uint8_t char_array_4[4], char_array_3[3];
   std::vector<uint8_t> ret;
 
+  // SAFETY: The loop condition checks is_base64() before processing each character.
+  // This ensures base64_find_char() is only called on valid base64 characters,
+  // preventing the edge case where invalid chars would return 0 (same as 'A').
   while (in_len-- && (encoded_string[in] != '=') && is_base64(encoded_string[in])) {
     char_array_4[i++] = encoded_string[in];
     in++;

--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -490,7 +490,7 @@ std::string base64_encode(const uint8_t *buf, size_t buf_len) {
       char_array_4[3] = char_array_3[2] & 0x3f;
 
       for (i = 0; (i < 4); i++)
-        ret += BASE64_CHARS[char_array_4[i]];
+        ret += BASE64_CHARS[static_cast<uint8_t>(char_array_4[i])];
       i = 0;
     }
   }
@@ -505,7 +505,7 @@ std::string base64_encode(const uint8_t *buf, size_t buf_len) {
     char_array_4[3] = char_array_3[2] & 0x3f;
 
     for (j = 0; (j < i + 1); j++)
-      ret += BASE64_CHARS[char_array_4[j]];
+      ret += BASE64_CHARS[static_cast<uint8_t>(char_array_4[j])];
 
     while ((i++ < 3))
       ret += '=';

--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -460,9 +460,15 @@ int8_t step_to_accuracy_decimals(float step) {
   return str.length() - dot_pos - 1;
 }
 
-static const std::string BASE64_CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-                                        "abcdefghijklmnopqrstuvwxyz"
-                                        "0123456789+/";
+// Use C-style string constant to store in ROM instead of RAM (saves 24 bytes)
+static constexpr const char *BASE64_CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+                                            "abcdefghijklmnopqrstuvwxyz"
+                                            "0123456789+/";
+
+static inline uint8_t base64_find_char(char c) {
+  const char *pos = strchr(BASE64_CHARS, c);
+  return pos ? (pos - BASE64_CHARS) : 0;
+}
 
 static inline bool is_base64(char c) { return (isalnum(c) || (c == '+') || (c == '/')); }
 
@@ -531,7 +537,7 @@ std::vector<uint8_t> base64_decode(const std::string &encoded_string) {
     in++;
     if (i == 4) {
       for (i = 0; i < 4; i++)
-        char_array_4[i] = BASE64_CHARS.find(char_array_4[i]);
+        char_array_4[i] = base64_find_char(char_array_4[i]);
 
       char_array_3[0] = (char_array_4[0] << 2) + ((char_array_4[1] & 0x30) >> 4);
       char_array_3[1] = ((char_array_4[1] & 0xf) << 4) + ((char_array_4[2] & 0x3c) >> 2);
@@ -548,7 +554,7 @@ std::vector<uint8_t> base64_decode(const std::string &encoded_string) {
       char_array_4[j] = 0;
 
     for (j = 0; j < 4; j++)
-      char_array_4[j] = BASE64_CHARS.find(char_array_4[j]);
+      char_array_4[j] = base64_find_char(char_array_4[j]);
 
     char_array_3[0] = (char_array_4[0] << 2) + ((char_array_4[1] & 0x30) >> 4);
     char_array_3[1] = ((char_array_4[1] & 0xf) << 4) + ((char_array_4[2] & 0x3c) >> 2);


### PR DESCRIPTION
# What does this implement/fix?

This PR reduces RAM usage by optimizing how static variables are initialized in core components:

1. **Eliminates guard variables** (16 bytes saved): Moved static local variables to namespace scope in `component.cpp` to avoid C++ guard variables for thread-safe initialization, which aren't needed since ESPHome is single-threaded during startup. Also removed unnecessary wrapper functions to directly access the variables.

2. **Moves BASE64_CHARS to ROM** (24 bytes saved): Changed from `std::string` to `constexpr const char*` in `helpers.cpp` so the Base64 character table is stored in flash ROM instead of RAM. Fixed array subscript warnings by adding proper type casts.

**Result:** Saves 40 bytes of RAM

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

<!-- No related issue -->

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

<!-- No documentation changes needed - internal optimization only -->

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# No configuration changes needed - this is an internal optimization
# All ESPHome configurations automatically benefit from reduced RAM usage
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

## Additional Notes:

### Memory optimization details:

1. **Guard variable elimination**: 
   - Static local variables in functions require guard variables for thread-safe initialization (8 bytes each)
   - Moved to anonymous namespace scope since ESPHome initialization is single-threaded
   - Removed wrapper functions `get_component_error_messages()` and `get_setup_priority_overrides()` for direct access
   - Added NOLINT comments to suppress linter warnings about non-const global variables

2. **BASE64_CHARS optimization**:
   - Changed from `std::string` (24 bytes in RAM) to `constexpr const char*` (stored in ROM)
   - Added `base64_find_char()` helper to replace `std::string::find()` functionality
   - Fixed clang-tidy char subscript warnings by casting to `uint8_t`
   - Maintains exact same behavior with strchr()

3. **Testing**:
   - Verified compilation on ESP32 with Arduino framework
   - Confirmed 40-byte RAM reduction using memory analysis
   - All Base64 encoding/decoding functionality tested and working

