### PR TITLE
Eliminate API component guard variable to save 8 bytes RAM

### DIFF
--- a/esphome/components/api/api_server.cpp
+++ b/esphome/components/api/api_server.cpp
@@ -24,6 +24,14 @@ static const char *const TAG = "api";
 // APIServer
 APIServer *global_api_server = nullptr;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
+#ifndef USE_API_YAML_SERVICES
+// Global empty vector to avoid guard variables (saves 8 bytes)
+// This is initialized at program startup before any threads
+static const std::vector<UserServiceDescriptor *> empty_user_services{};
+
+const std::vector<UserServiceDescriptor *> &get_empty_user_services_instance() { return empty_user_services; }
+#endif
+
 APIServer::APIServer() {
   global_api_server = this;
   // Pre-allocate shared write buffer

--- a/esphome/components/api/api_server.h
+++ b/esphome/components/api/api_server.h
@@ -25,6 +25,11 @@ struct SavedNoisePsk {
 } PACKED;  // NOLINT
 #endif
 
+#ifndef USE_API_YAML_SERVICES
+// Forward declaration of helper function
+const std::vector<UserServiceDescriptor *> &get_empty_user_services_instance();
+#endif
+
 class APIServer : public Component, public Controller {
  public:
   APIServer();
@@ -151,8 +156,11 @@ class APIServer : public Component, public Controller {
 #ifdef USE_API_YAML_SERVICES
     return this->user_services_;
 #else
-    static const std::vector<UserServiceDescriptor *> EMPTY;
-    return this->user_services_ ? *this->user_services_ : EMPTY;
+    if (this->user_services_) {
+      return *this->user_services_;
+    }
+    // Return reference to global empty instance (no guard needed)
+    return get_empty_user_services_instance();
 #endif
   }
 


### PR DESCRIPTION
# What does this implement/fix?

This PR eliminates an 8-byte C++ guard variable in the API component by refactoring how the empty user services vector is handled when `USE_API_YAML_SERVICES` is not defined.

The guard variable was being created for thread-safe initialization of a static local vector. By moving this to a global static initialized at program startup, we avoid the need for runtime synchronization.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# No configuration changes needed - this is an internal optimization
api:
```

## Technical Details

When `USE_API_YAML_SERVICES` is not defined, `APIServer::get_user_services()` needs to return an empty vector reference. Previously, this used a function-local static vector which required a guard variable for thread-safe initialization:

```cpp
// Old code - requires 8-byte guard variable
static const std::vector<UserServiceDescriptor *> EMPTY;
```

The refactoring moves this to a global static that's initialized before `main()`:

```cpp
// New code - no guard variable needed
static const std::vector<UserServiceDescriptor *> empty_user_services{};
```

### Memory Impact
- Eliminates 8-byte guard variable
- Keeps necessary 12-byte empty vector
- Net savings: 8 bytes RAM

The 12-byte vector itself cannot be eliminated as we need a valid object to return a reference to, maintaining API compatibility.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).