### PR TITLE
Eliminate web_server_idf guard variable to save 8 bytes RAM

### DIFF
--- a/esphome/components/web_server_idf/web_server_idf.cpp
+++ b/esphome/components/web_server_idf/web_server_idf.cpp
@@ -39,6 +39,7 @@ static const char *const TAG = "web_server_idf";
 
 // Global instance to avoid guard variable (saves 8 bytes)
 // This is initialized at program startup before any threads
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 static DefaultHeaders default_headers_instance;
 
 DefaultHeaders &DefaultHeaders::Instance() { return default_headers_instance; }

--- a/esphome/components/web_server_idf/web_server_idf.cpp
+++ b/esphome/components/web_server_idf/web_server_idf.cpp
@@ -37,6 +37,12 @@ namespace web_server_idf {
 
 static const char *const TAG = "web_server_idf";
 
+// Global instance to avoid guard variable (saves 8 bytes)
+// This is initialized at program startup before any threads
+static DefaultHeaders default_headers_instance;
+
+DefaultHeaders &DefaultHeaders::Instance() { return default_headers_instance; }
+
 void AsyncWebServer::end() {
   if (this->server_) {
     httpd_stop(this->server_);

--- a/esphome/components/web_server_idf/web_server_idf.cpp
+++ b/esphome/components/web_server_idf/web_server_idf.cpp
@@ -39,8 +39,10 @@ static const char *const TAG = "web_server_idf";
 
 // Global instance to avoid guard variable (saves 8 bytes)
 // This is initialized at program startup before any threads
+namespace {
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
-static DefaultHeaders default_headers_instance;
+DefaultHeaders default_headers_instance;
+}  // namespace
 
 DefaultHeaders &DefaultHeaders::Instance() { return default_headers_instance; }
 

--- a/esphome/components/web_server_idf/web_server_idf.h
+++ b/esphome/components/web_server_idf/web_server_idf.h
@@ -328,10 +328,7 @@ class DefaultHeaders {
   void addHeader(const char *name, const char *value) { this->headers_.emplace_back(name, value); }
 
   // NOLINTNEXTLINE(readability-identifier-naming)
-  static DefaultHeaders &Instance() {
-    static DefaultHeaders instance;
-    return instance;
-  }
+  static DefaultHeaders &Instance();
 
  protected:
   std::vector<std::pair<std::string, std::string>> headers_;


### PR DESCRIPTION
## What does this implement/fix?

This PR eliminates an 8-byte guard variable used for thread-safe initialization of the `DefaultHeaders` singleton in the web_server_idf component. The guard variable was being created by the compiler for the static local variable inside the `Instance()` method.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
```yaml
# No configuration changes needed
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

## Description

This optimization moves the `DefaultHeaders` singleton instance to file scope, eliminating the need for a guard variable that was consuming 8 bytes of RAM.

### Before:
- Static local variable in `Instance()` method required an 8-byte guard variable for thread-safe initialization
- Total RAM usage: 20 bytes (12 bytes for the instance + 8 bytes for the guard)

### After:
- Global static instance initialized at program startup
- Total RAM usage: 12 bytes (just the instance)

### Technical details:
The C++ compiler generates guard variables for static local variables to ensure thread-safe initialization. Since ESP32 applications are single-threaded during initialization and the `DefaultHeaders` instance is only accessed after startup, we can safely move it to file scope where it's initialized before `main()` runs.

### RAM savings:
- 8 bytes saved per device using web_server with ESP-IDF framework

## Verification

Tested on ESP32 with web server enabled:
```
WEB_SERVER_IDF COMPONENT (12 bytes):  # Was 20 bytes before
--------------------------------------------------------------------------------

By File:

  web_server_idf.cpp.o (12 bytes):
        12 bytes  bss   unknown
                  Address: 0x3ffc26bc  Section: .dram0.bss
```

The guard variable `_ZGVZN7esphome14web_server_idf14DefaultHeaders8InstanceEvE8instance` is no longer present in the memory map.