### PR TITLE
[scd4x] Optimize logging + minor code clean-up

### DIFF
--- a/esphome/components/scd4x/scd4x.h
+++ b/esphome/components/scd4x/scd4x.h
@@ -8,14 +8,20 @@
 namespace esphome {
 namespace scd4x {
 
-enum ERRORCODE {
+enum ErrorCode : uint8_t {
   COMMUNICATION_FAILED,
   SERIAL_NUMBER_IDENTIFICATION_FAILED,
   MEASUREMENT_INIT_FAILED,
   FRC_FAILED,
-  UNKNOWN
+  UNKNOWN,
 };
-enum MeasurementMode { PERIODIC, LOW_POWER_PERIODIC, SINGLE_SHOT, SINGLE_SHOT_RHT_ONLY };
+
+enum MeasurementMode : uint8_t {
+  PERIODIC,
+  LOW_POWER_PERIODIC,
+  SINGLE_SHOT,
+  SINGLE_SHOT_RHT_ONLY,
+};
 
 class SCD4XComponent : public PollingComponent, public sensirion_common::SensirionI2CDevice {
  public:
@@ -39,15 +45,14 @@ class SCD4XComponent : public PollingComponent, public sensirion_common::Sensiri
  protected:
   bool update_ambient_pressure_compensation_(uint16_t pressure_in_hpa);
   bool start_measurement_();
-  ERRORCODE error_code_;
 
-  bool initialized_{false};
-
-  float temperature_offset_;
   uint16_t altitude_compensation_;
-  bool ambient_pressure_compensation_;
   uint16_t ambient_pressure_;
+  bool initialized_{false};
+  bool ambient_pressure_compensation_;
   bool enable_asc_;
+  float temperature_offset_;
+  ErrorCode error_code_;
   MeasurementMode measurement_mode_{PERIODIC};
   sensor::Sensor *co2_sensor_{nullptr};
   sensor::Sensor *temperature_sensor_{nullptr};


### PR DESCRIPTION
# What does this implement/fix?

Reworks some logging to reduce flash usage by about 160 bytes.
Also includes some minor code clean-up/readability improvements.
Before:
```
RAM:   [=         ]  14.8% (used 48608 bytes from 327680 bytes)
Flash: [========= ]  91.5% (used 1679670 bytes from 1835008 bytes)
```
After:
```
RAM:   [=         ]  14.8% (used 48608 bytes from 327680 bytes)
Flash: [========= ]  91.5% (used 1679516 bytes from 1835008 bytes)
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
