### PR TITLE
Display menu base improvements

### DIFF
--- a/esphome/components/display_menu_base/display_menu_base.cpp
+++ b/esphome/components/display_menu_base/display_menu_base.cpp
@@ -68,7 +68,7 @@ void DisplayMenuComponent::left() {
           case MENU_MODE_JOYSTICK:
             if (this->editing_ || this->get_selected_item_()->get_immediate_edit())
               changed = this->get_selected_item_()->select_prev();
-            if (this->displayed_item_->get_parent() == nullptr) 
+            if (this->displayed_item_->get_parent() == nullptr)
               this->hide();
             break;
           default:

--- a/esphome/components/display_menu_base/display_menu_base.cpp
+++ b/esphome/components/display_menu_base/display_menu_base.cpp
@@ -68,13 +68,14 @@ void DisplayMenuComponent::left() {
           case MENU_MODE_JOYSTICK:
             if (this->editing_ || this->get_selected_item_()->get_immediate_edit())
               changed = this->get_selected_item_()->select_prev();
-            if (this->displayed_item_->get_parent() == nullptr) this->hide();
+            if (this->displayed_item_->get_parent() == nullptr) 
+              this->hide();
             break;
           default:
             break;
         }
         break;
-      case MENU_ITEM_MENU:   
+      case MENU_ITEM_MENU:
       case MENU_ITEM_LABEL:
       case MENU_ITEM_BACK:
         changed = this->leave_menu_();
@@ -303,10 +304,10 @@ bool DisplayMenuComponent::leave_menu_() {
     this->displayed_item_->on_enter();
     changed = true;
   } else {
-    this->hide(); 
+    this->hide();
     changed = true;
-  }   
-  
+  }
+
   return changed;
 }
 

--- a/esphome/components/display_menu_base/display_menu_base.cpp
+++ b/esphome/components/display_menu_base/display_menu_base.cpp
@@ -55,6 +55,7 @@ void DisplayMenuComponent::left() {
       case MENU_ITEM_SWITCH:
       case MENU_ITEM_NUMBER:
       case MENU_ITEM_CUSTOM:
+      case MENU_ITEM_COMMAND:
         switch (this->mode_) {
           case MENU_MODE_ROTARY:
             if (this->editing_) {
@@ -67,11 +68,14 @@ void DisplayMenuComponent::left() {
           case MENU_MODE_JOYSTICK:
             if (this->editing_ || this->get_selected_item_()->get_immediate_edit())
               changed = this->get_selected_item_()->select_prev();
+            if (this->displayed_item_->get_parent() == nullptr) this->hide();
             break;
           default:
             break;
         }
         break;
+      case MENU_ITEM_MENU:   
+      case MENU_ITEM_LABEL:
       case MENU_ITEM_BACK:
         changed = this->leave_menu_();
         break;
@@ -298,8 +302,11 @@ bool DisplayMenuComponent::leave_menu_() {
     this->selection_stack_.pop_front();
     this->displayed_item_->on_enter();
     changed = true;
-  }
-
+  } else {
+    this->hide(); 
+    changed = true;
+  }   
+  
   return changed;
 }
 


### PR DESCRIPTION
# What does this implement/fix?

With this modification, I improved the behavior of the “display_menu.left()” action by supporting more logical navigation through the menu levels, allowing consistent navigation even for “command” type items. As with the display_menu.right() action that allows you to enter menus, the change consistently allows you to exit the current menu with the “left()” action and, in the case of the main menu, closes the menu with the “Hide()” action.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes inconsistent behavior between the “right()” action and the “left()” action of the component.


**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- no changes on documentation are required considering that it does not enter into details of the current/modificed behaviour.

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] No impacts on documentation in [esphome-docs](https://github.com/esphome/esphome-docs).
