### PR TITLE
[inkplate6] Require 240mhz cpu frequency

### DIFF
--- a/esphome/components/inkplate6/display.py
+++ b/esphome/components/inkplate6/display.py
@@ -1,6 +1,7 @@
 from esphome import pins
 import esphome.codegen as cg
 from esphome.components import display, i2c
+from esphome.components.esp32 import CONF_CPU_FREQUENCY
 import esphome.config_validation as cv
 from esphome.const import (
     CONF_FULL_UPDATE_EVERY,
@@ -13,7 +14,9 @@ from esphome.const import (
     CONF_PAGES,
     CONF_TRANSFORM,
     CONF_WAKEUP_PIN,
+    PLATFORM_ESP32,
 )
+import esphome.final_validate as fv
 
 DEPENDENCIES = ["i2c", "esp32"]
 AUTO_LOAD = ["psram"]
@@ -118,6 +121,17 @@ CONFIG_SCHEMA = cv.All(
     .extend(i2c.i2c_device_schema(0x48)),
     cv.has_at_most_one_key(CONF_PAGES, CONF_LAMBDA),
 )
+
+
+def _validate_cpu_frequency(config):
+    esp32_config = fv.full_config.get()[PLATFORM_ESP32]
+    if esp32_config[CONF_CPU_FREQUENCY] != "240MHZ":
+        raise cv.Invalid(
+            "Inkplate requires 240MHz CPU frequency (set in esp32 component)"
+        )
+
+
+FINAL_VALIDATE_SCHEMA = _validate_cpu_frequency
 
 
 async def to_code(config):

--- a/esphome/components/inkplate6/display.py
+++ b/esphome/components/inkplate6/display.py
@@ -129,6 +129,7 @@ def _validate_cpu_frequency(config):
         raise cv.Invalid(
             "Inkplate requires 240MHz CPU frequency (set in esp32 component)"
         )
+    return config
 
 
 FINAL_VALIDATE_SCHEMA = _validate_cpu_frequency

--- a/tests/components/inkplate6/common.yaml
+++ b/tests/components/inkplate6/common.yaml
@@ -3,6 +3,9 @@ i2c:
     scl: 16
     sda: 17
 
+esp32:
+  cpu_frequency: 240MHz
+
 display:
   - platform: inkplate6
     id: inkplate_display


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->
The inkplate6 requires 240MHz CPU frequency due to the GPIO bitbanging.

Previosuly in ESPHome, `inkplate6` was Arduino Only, and the frequency was already set to 240MHz by default, but with the upgrade to Arduino 3, ESPHome sets the default to 160MHz.


## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/issues/issues/7076

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
