### PR TITLE
Fix flaky test_api_conditional_memory by disabling API batch delay

### DIFF
--- a/tests/integration/fixtures/api_conditional_memory.yaml
+++ b/tests/integration/fixtures/api_conditional_memory.yaml
@@ -2,6 +2,7 @@ esphome:
   name: api-conditional-memory-test
 host:
 api:
+  batch_delay: 0ms
   actions:
     - action: test_simple_service
       then:


### PR DESCRIPTION
# What does this implement/fix?

This PR fixes a flaky integration test `test_api_conditional_memory` that was failing intermittently due to a race condition caused by the default API batching delay.

The test was checking if a client connection state was `True` immediately after connecting, but the state update was being delayed by the default 100ms batch delay in the API component. This caused the assertion to fail when the test ran faster than the batch delay.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes flaky test in CI

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Not applicable - this is a test fixture fix
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

