### PR TITLE
Replace deprecated sprintf with snprintf in API protobuf code generation

### DIFF
--- a/esphome/components/api/api_pb2_dump.cpp
+++ b/esphome/components/api/api_pb2_dump.cpp
@@ -600,12 +600,12 @@ void HelloRequest::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  api_version_major: ");
-  sprintf(buffer, "%" PRIu32, this->api_version_major);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->api_version_major);
   out.append(buffer);
   out.append("\n");
 
   out.append("  api_version_minor: ");
-  sprintf(buffer, "%" PRIu32, this->api_version_minor);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->api_version_minor);
   out.append(buffer);
   out.append("\n");
   out.append("}");
@@ -614,12 +614,12 @@ void HelloResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("HelloResponse {\n");
   out.append("  api_version_major: ");
-  sprintf(buffer, "%" PRIu32, this->api_version_major);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->api_version_major);
   out.append(buffer);
   out.append("\n");
 
   out.append("  api_version_minor: ");
-  sprintf(buffer, "%" PRIu32, this->api_version_minor);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->api_version_minor);
   out.append(buffer);
   out.append("\n");
 
@@ -657,7 +657,7 @@ void AreaInfo::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("AreaInfo {\n");
   out.append("  area_id: ");
-  sprintf(buffer, "%" PRIu32, this->area_id);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->area_id);
   out.append(buffer);
   out.append("\n");
 
@@ -670,7 +670,7 @@ void DeviceInfo::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("DeviceInfo {\n");
   out.append("  device_id: ");
-  sprintf(buffer, "%" PRIu32, this->device_id);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
   out.append(buffer);
   out.append("\n");
 
@@ -679,7 +679,7 @@ void DeviceInfo::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  area_id: ");
-  sprintf(buffer, "%" PRIu32, this->area_id);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->area_id);
   out.append(buffer);
   out.append("\n");
   out.append("}");
@@ -724,17 +724,17 @@ void DeviceInfoResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  webserver_port: ");
-  sprintf(buffer, "%" PRIu32, this->webserver_port);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->webserver_port);
   out.append(buffer);
   out.append("\n");
 
   out.append("  legacy_bluetooth_proxy_version: ");
-  sprintf(buffer, "%" PRIu32, this->legacy_bluetooth_proxy_version);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->legacy_bluetooth_proxy_version);
   out.append(buffer);
   out.append("\n");
 
   out.append("  bluetooth_proxy_feature_flags: ");
-  sprintf(buffer, "%" PRIu32, this->bluetooth_proxy_feature_flags);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->bluetooth_proxy_feature_flags);
   out.append(buffer);
   out.append("\n");
 
@@ -747,12 +747,12 @@ void DeviceInfoResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  legacy_voice_assistant_version: ");
-  sprintf(buffer, "%" PRIu32, this->legacy_voice_assistant_version);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->legacy_voice_assistant_version);
   out.append(buffer);
   out.append("\n");
 
   out.append("  voice_assistant_feature_flags: ");
-  sprintf(buffer, "%" PRIu32, this->voice_assistant_feature_flags);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->voice_assistant_feature_flags);
   out.append(buffer);
   out.append("\n");
 
@@ -797,7 +797,7 @@ void ListEntitiesBinarySensorResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  key: ");
-  sprintf(buffer, "%" PRIu32, this->key);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
   out.append(buffer);
   out.append("\n");
 
@@ -830,7 +830,7 @@ void ListEntitiesBinarySensorResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  device_id: ");
-  sprintf(buffer, "%" PRIu32, this->device_id);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
   out.append(buffer);
   out.append("\n");
   out.append("}");
@@ -839,7 +839,7 @@ void BinarySensorStateResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("BinarySensorStateResponse {\n");
   out.append("  key: ");
-  sprintf(buffer, "%" PRIu32, this->key);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
   out.append(buffer);
   out.append("\n");
 
@@ -852,7 +852,7 @@ void BinarySensorStateResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  device_id: ");
-  sprintf(buffer, "%" PRIu32, this->device_id);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
   out.append(buffer);
   out.append("\n");
   out.append("}");
@@ -867,7 +867,7 @@ void ListEntitiesCoverResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  key: ");
-  sprintf(buffer, "%" PRIu32, this->key);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
   out.append(buffer);
   out.append("\n");
 
@@ -912,7 +912,7 @@ void ListEntitiesCoverResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  device_id: ");
-  sprintf(buffer, "%" PRIu32, this->device_id);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
   out.append(buffer);
   out.append("\n");
   out.append("}");
@@ -921,7 +921,7 @@ void CoverStateResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("CoverStateResponse {\n");
   out.append("  key: ");
-  sprintf(buffer, "%" PRIu32, this->key);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
   out.append(buffer);
   out.append("\n");
 
@@ -930,12 +930,12 @@ void CoverStateResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  position: ");
-  sprintf(buffer, "%g", this->position);
+  snprintf(buffer, sizeof(buffer), "%g", this->position);
   out.append(buffer);
   out.append("\n");
 
   out.append("  tilt: ");
-  sprintf(buffer, "%g", this->tilt);
+  snprintf(buffer, sizeof(buffer), "%g", this->tilt);
   out.append(buffer);
   out.append("\n");
 
@@ -944,7 +944,7 @@ void CoverStateResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  device_id: ");
-  sprintf(buffer, "%" PRIu32, this->device_id);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
   out.append(buffer);
   out.append("\n");
   out.append("}");
@@ -953,7 +953,7 @@ void CoverCommandRequest::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("CoverCommandRequest {\n");
   out.append("  key: ");
-  sprintf(buffer, "%" PRIu32, this->key);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
   out.append(buffer);
   out.append("\n");
 
@@ -970,7 +970,7 @@ void CoverCommandRequest::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  position: ");
-  sprintf(buffer, "%g", this->position);
+  snprintf(buffer, sizeof(buffer), "%g", this->position);
   out.append(buffer);
   out.append("\n");
 
@@ -979,7 +979,7 @@ void CoverCommandRequest::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  tilt: ");
-  sprintf(buffer, "%g", this->tilt);
+  snprintf(buffer, sizeof(buffer), "%g", this->tilt);
   out.append(buffer);
   out.append("\n");
 
@@ -998,7 +998,7 @@ void ListEntitiesFanResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  key: ");
-  sprintf(buffer, "%" PRIu32, this->key);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
   out.append(buffer);
   out.append("\n");
 
@@ -1023,7 +1023,7 @@ void ListEntitiesFanResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  supported_speed_count: ");
-  sprintf(buffer, "%" PRId32, this->supported_speed_count);
+  snprintf(buffer, sizeof(buffer), "%" PRId32, this->supported_speed_count);
   out.append(buffer);
   out.append("\n");
 
@@ -1046,7 +1046,7 @@ void ListEntitiesFanResponse::dump_to(std::string &out) const {
   }
 
   out.append("  device_id: ");
-  sprintf(buffer, "%" PRIu32, this->device_id);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
   out.append(buffer);
   out.append("\n");
   out.append("}");
@@ -1055,7 +1055,7 @@ void FanStateResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("FanStateResponse {\n");
   out.append("  key: ");
-  sprintf(buffer, "%" PRIu32, this->key);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
   out.append(buffer);
   out.append("\n");
 
@@ -1076,7 +1076,7 @@ void FanStateResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  speed_level: ");
-  sprintf(buffer, "%" PRId32, this->speed_level);
+  snprintf(buffer, sizeof(buffer), "%" PRId32, this->speed_level);
   out.append(buffer);
   out.append("\n");
 
@@ -1085,7 +1085,7 @@ void FanStateResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  device_id: ");
-  sprintf(buffer, "%" PRIu32, this->device_id);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
   out.append(buffer);
   out.append("\n");
   out.append("}");
@@ -1094,7 +1094,7 @@ void FanCommandRequest::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("FanCommandRequest {\n");
   out.append("  key: ");
-  sprintf(buffer, "%" PRIu32, this->key);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
   out.append(buffer);
   out.append("\n");
 
@@ -1135,7 +1135,7 @@ void FanCommandRequest::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  speed_level: ");
-  sprintf(buffer, "%" PRId32, this->speed_level);
+  snprintf(buffer, sizeof(buffer), "%" PRId32, this->speed_level);
   out.append(buffer);
   out.append("\n");
 
@@ -1158,7 +1158,7 @@ void ListEntitiesLightResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  key: ");
-  sprintf(buffer, "%" PRIu32, this->key);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
   out.append(buffer);
   out.append("\n");
 
@@ -1193,12 +1193,12 @@ void ListEntitiesLightResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  min_mireds: ");
-  sprintf(buffer, "%g", this->min_mireds);
+  snprintf(buffer, sizeof(buffer), "%g", this->min_mireds);
   out.append(buffer);
   out.append("\n");
 
   out.append("  max_mireds: ");
-  sprintf(buffer, "%g", this->max_mireds);
+  snprintf(buffer, sizeof(buffer), "%g", this->max_mireds);
   out.append(buffer);
   out.append("\n");
 
@@ -1221,7 +1221,7 @@ void ListEntitiesLightResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  device_id: ");
-  sprintf(buffer, "%" PRIu32, this->device_id);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
   out.append(buffer);
   out.append("\n");
   out.append("}");
@@ -1230,7 +1230,7 @@ void LightStateResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("LightStateResponse {\n");
   out.append("  key: ");
-  sprintf(buffer, "%" PRIu32, this->key);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
   out.append(buffer);
   out.append("\n");
 
@@ -1239,7 +1239,7 @@ void LightStateResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  brightness: ");
-  sprintf(buffer, "%g", this->brightness);
+  snprintf(buffer, sizeof(buffer), "%g", this->brightness);
   out.append(buffer);
   out.append("\n");
 
@@ -1248,42 +1248,42 @@ void LightStateResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  color_brightness: ");
-  sprintf(buffer, "%g", this->color_brightness);
+  snprintf(buffer, sizeof(buffer), "%g", this->color_brightness);
   out.append(buffer);
   out.append("\n");
 
   out.append("  red: ");
-  sprintf(buffer, "%g", this->red);
+  snprintf(buffer, sizeof(buffer), "%g", this->red);
   out.append(buffer);
   out.append("\n");
 
   out.append("  green: ");
-  sprintf(buffer, "%g", this->green);
+  snprintf(buffer, sizeof(buffer), "%g", this->green);
   out.append(buffer);
   out.append("\n");
 
   out.append("  blue: ");
-  sprintf(buffer, "%g", this->blue);
+  snprintf(buffer, sizeof(buffer), "%g", this->blue);
   out.append(buffer);
   out.append("\n");
 
   out.append("  white: ");
-  sprintf(buffer, "%g", this->white);
+  snprintf(buffer, sizeof(buffer), "%g", this->white);
   out.append(buffer);
   out.append("\n");
 
   out.append("  color_temperature: ");
-  sprintf(buffer, "%g", this->color_temperature);
+  snprintf(buffer, sizeof(buffer), "%g", this->color_temperature);
   out.append(buffer);
   out.append("\n");
 
   out.append("  cold_white: ");
-  sprintf(buffer, "%g", this->cold_white);
+  snprintf(buffer, sizeof(buffer), "%g", this->cold_white);
   out.append(buffer);
   out.append("\n");
 
   out.append("  warm_white: ");
-  sprintf(buffer, "%g", this->warm_white);
+  snprintf(buffer, sizeof(buffer), "%g", this->warm_white);
   out.append(buffer);
   out.append("\n");
 
@@ -1292,7 +1292,7 @@ void LightStateResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  device_id: ");
-  sprintf(buffer, "%" PRIu32, this->device_id);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
   out.append(buffer);
   out.append("\n");
   out.append("}");
@@ -1301,7 +1301,7 @@ void LightCommandRequest::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("LightCommandRequest {\n");
   out.append("  key: ");
-  sprintf(buffer, "%" PRIu32, this->key);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
   out.append(buffer);
   out.append("\n");
 
@@ -1318,7 +1318,7 @@ void LightCommandRequest::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  brightness: ");
-  sprintf(buffer, "%g", this->brightness);
+  snprintf(buffer, sizeof(buffer), "%g", this->brightness);
   out.append(buffer);
   out.append("\n");
 
@@ -1335,7 +1335,7 @@ void LightCommandRequest::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  color_brightness: ");
-  sprintf(buffer, "%g", this->color_brightness);
+  snprintf(buffer, sizeof(buffer), "%g", this->color_brightness);
   out.append(buffer);
   out.append("\n");
 
@@ -1344,17 +1344,17 @@ void LightCommandRequest::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  red: ");
-  sprintf(buffer, "%g", this->red);
+  snprintf(buffer, sizeof(buffer), "%g", this->red);
   out.append(buffer);
   out.append("\n");
 
   out.append("  green: ");
-  sprintf(buffer, "%g", this->green);
+  snprintf(buffer, sizeof(buffer), "%g", this->green);
   out.append(buffer);
   out.append("\n");
 
   out.append("  blue: ");
-  sprintf(buffer, "%g", this->blue);
+  snprintf(buffer, sizeof(buffer), "%g", this->blue);
   out.append(buffer);
   out.append("\n");
 
@@ -1363,7 +1363,7 @@ void LightCommandRequest::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  white: ");
-  sprintf(buffer, "%g", this->white);
+  snprintf(buffer, sizeof(buffer), "%g", this->white);
   out.append(buffer);
   out.append("\n");
 
@@ -1372,7 +1372,7 @@ void LightCommandRequest::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  color_temperature: ");
-  sprintf(buffer, "%g", this->color_temperature);
+  snprintf(buffer, sizeof(buffer), "%g", this->color_temperature);
   out.append(buffer);
   out.append("\n");
 
@@ -1381,7 +1381,7 @@ void LightCommandRequest::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  cold_white: ");
-  sprintf(buffer, "%g", this->cold_white);
+  snprintf(buffer, sizeof(buffer), "%g", this->cold_white);
   out.append(buffer);
   out.append("\n");
 
@@ -1390,7 +1390,7 @@ void LightCommandRequest::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  warm_white: ");
-  sprintf(buffer, "%g", this->warm_white);
+  snprintf(buffer, sizeof(buffer), "%g", this->warm_white);
   out.append(buffer);
   out.append("\n");
 
@@ -1399,7 +1399,7 @@ void LightCommandRequest::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  transition_length: ");
-  sprintf(buffer, "%" PRIu32, this->transition_length);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->transition_length);
   out.append(buffer);
   out.append("\n");
 
@@ -1408,7 +1408,7 @@ void LightCommandRequest::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  flash_length: ");
-  sprintf(buffer, "%" PRIu32, this->flash_length);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->flash_length);
   out.append(buffer);
   out.append("\n");
 
@@ -1431,7 +1431,7 @@ void ListEntitiesSensorResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  key: ");
-  sprintf(buffer, "%" PRIu32, this->key);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
   out.append(buffer);
   out.append("\n");
 
@@ -1452,7 +1452,7 @@ void ListEntitiesSensorResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  accuracy_decimals: ");
-  sprintf(buffer, "%" PRId32, this->accuracy_decimals);
+  snprintf(buffer, sizeof(buffer), "%" PRId32, this->accuracy_decimals);
   out.append(buffer);
   out.append("\n");
 
@@ -1481,7 +1481,7 @@ void ListEntitiesSensorResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  device_id: ");
-  sprintf(buffer, "%" PRIu32, this->device_id);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
   out.append(buffer);
   out.append("\n");
   out.append("}");
@@ -1490,12 +1490,12 @@ void SensorStateResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("SensorStateResponse {\n");
   out.append("  key: ");
-  sprintf(buffer, "%" PRIu32, this->key);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
   out.append(buffer);
   out.append("\n");
 
   out.append("  state: ");
-  sprintf(buffer, "%g", this->state);
+  snprintf(buffer, sizeof(buffer), "%g", this->state);
   out.append(buffer);
   out.append("\n");
 
@@ -1504,7 +1504,7 @@ void SensorStateResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  device_id: ");
-  sprintf(buffer, "%" PRIu32, this->device_id);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
   out.append(buffer);
   out.append("\n");
   out.append("}");
@@ -1519,7 +1519,7 @@ void ListEntitiesSwitchResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  key: ");
-  sprintf(buffer, "%" PRIu32, this->key);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
   out.append(buffer);
   out.append("\n");
 
@@ -1552,7 +1552,7 @@ void ListEntitiesSwitchResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  device_id: ");
-  sprintf(buffer, "%" PRIu32, this->device_id);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
   out.append(buffer);
   out.append("\n");
   out.append("}");
@@ -1561,7 +1561,7 @@ void SwitchStateResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("SwitchStateResponse {\n");
   out.append("  key: ");
-  sprintf(buffer, "%" PRIu32, this->key);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
   out.append(buffer);
   out.append("\n");
 
@@ -1570,7 +1570,7 @@ void SwitchStateResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  device_id: ");
-  sprintf(buffer, "%" PRIu32, this->device_id);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
   out.append(buffer);
   out.append("\n");
   out.append("}");
@@ -1579,7 +1579,7 @@ void SwitchCommandRequest::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("SwitchCommandRequest {\n");
   out.append("  key: ");
-  sprintf(buffer, "%" PRIu32, this->key);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
   out.append(buffer);
   out.append("\n");
 
@@ -1598,7 +1598,7 @@ void ListEntitiesTextSensorResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  key: ");
-  sprintf(buffer, "%" PRIu32, this->key);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
   out.append(buffer);
   out.append("\n");
 
@@ -1627,7 +1627,7 @@ void ListEntitiesTextSensorResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  device_id: ");
-  sprintf(buffer, "%" PRIu32, this->device_id);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
   out.append(buffer);
   out.append("\n");
   out.append("}");
@@ -1636,7 +1636,7 @@ void TextSensorStateResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("TextSensorStateResponse {\n");
   out.append("  key: ");
-  sprintf(buffer, "%" PRIu32, this->key);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
   out.append(buffer);
   out.append("\n");
 
@@ -1649,7 +1649,7 @@ void TextSensorStateResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  device_id: ");
-  sprintf(buffer, "%" PRIu32, this->device_id);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
   out.append(buffer);
   out.append("\n");
   out.append("}");
@@ -1786,7 +1786,7 @@ void GetTimeResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("GetTimeResponse {\n");
   out.append("  epoch_seconds: ");
-  sprintf(buffer, "%" PRIu32, this->epoch_seconds);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->epoch_seconds);
   out.append(buffer);
   out.append("\n");
   out.append("}");
@@ -1811,7 +1811,7 @@ void ListEntitiesServicesResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  key: ");
-  sprintf(buffer, "%" PRIu32, this->key);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
   out.append(buffer);
   out.append("\n");
 
@@ -1830,12 +1830,12 @@ void ExecuteServiceArgument::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  legacy_int: ");
-  sprintf(buffer, "%" PRId32, this->legacy_int);
+  snprintf(buffer, sizeof(buffer), "%" PRId32, this->legacy_int);
   out.append(buffer);
   out.append("\n");
 
   out.append("  float_: ");
-  sprintf(buffer, "%g", this->float_);
+  snprintf(buffer, sizeof(buffer), "%g", this->float_);
   out.append(buffer);
   out.append("\n");
 
@@ -1844,7 +1844,7 @@ void ExecuteServiceArgument::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  int_: ");
-  sprintf(buffer, "%" PRId32, this->int_);
+  snprintf(buffer, sizeof(buffer), "%" PRId32, this->int_);
   out.append(buffer);
   out.append("\n");
 
@@ -1856,14 +1856,14 @@ void ExecuteServiceArgument::dump_to(std::string &out) const {
 
   for (const auto &it : this->int_array) {
     out.append("  int_array: ");
-    sprintf(buffer, "%" PRId32, it);
+    snprintf(buffer, sizeof(buffer), "%" PRId32, it);
     out.append(buffer);
     out.append("\n");
   }
 
   for (const auto &it : this->float_array) {
     out.append("  float_array: ");
-    sprintf(buffer, "%g", it);
+    snprintf(buffer, sizeof(buffer), "%g", it);
     out.append(buffer);
     out.append("\n");
   }
@@ -1879,7 +1879,7 @@ void ExecuteServiceRequest::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("ExecuteServiceRequest {\n");
   out.append("  key: ");
-  sprintf(buffer, "%" PRIu32, this->key);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
   out.append(buffer);
   out.append("\n");
 
@@ -1899,7 +1899,7 @@ void ListEntitiesCameraResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  key: ");
-  sprintf(buffer, "%" PRIu32, this->key);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
   out.append(buffer);
   out.append("\n");
 
@@ -1924,7 +1924,7 @@ void ListEntitiesCameraResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  device_id: ");
-  sprintf(buffer, "%" PRIu32, this->device_id);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
   out.append(buffer);
   out.append("\n");
   out.append("}");
@@ -1933,7 +1933,7 @@ void CameraImageResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("CameraImageResponse {\n");
   out.append("  key: ");
-  sprintf(buffer, "%" PRIu32, this->key);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
   out.append(buffer);
   out.append("\n");
 
@@ -1968,7 +1968,7 @@ void ListEntitiesClimateResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  key: ");
-  sprintf(buffer, "%" PRIu32, this->key);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
   out.append(buffer);
   out.append("\n");
 
@@ -1995,17 +1995,17 @@ void ListEntitiesClimateResponse::dump_to(std::string &out) const {
   }
 
   out.append("  visual_min_temperature: ");
-  sprintf(buffer, "%g", this->visual_min_temperature);
+  snprintf(buffer, sizeof(buffer), "%g", this->visual_min_temperature);
   out.append(buffer);
   out.append("\n");
 
   out.append("  visual_max_temperature: ");
-  sprintf(buffer, "%g", this->visual_max_temperature);
+  snprintf(buffer, sizeof(buffer), "%g", this->visual_max_temperature);
   out.append(buffer);
   out.append("\n");
 
   out.append("  visual_target_temperature_step: ");
-  sprintf(buffer, "%g", this->visual_target_temperature_step);
+  snprintf(buffer, sizeof(buffer), "%g", this->visual_target_temperature_step);
   out.append(buffer);
   out.append("\n");
 
@@ -2060,7 +2060,7 @@ void ListEntitiesClimateResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  visual_current_temperature_step: ");
-  sprintf(buffer, "%g", this->visual_current_temperature_step);
+  snprintf(buffer, sizeof(buffer), "%g", this->visual_current_temperature_step);
   out.append(buffer);
   out.append("\n");
 
@@ -2073,17 +2073,17 @@ void ListEntitiesClimateResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  visual_min_humidity: ");
-  sprintf(buffer, "%g", this->visual_min_humidity);
+  snprintf(buffer, sizeof(buffer), "%g", this->visual_min_humidity);
   out.append(buffer);
   out.append("\n");
 
   out.append("  visual_max_humidity: ");
-  sprintf(buffer, "%g", this->visual_max_humidity);
+  snprintf(buffer, sizeof(buffer), "%g", this->visual_max_humidity);
   out.append(buffer);
   out.append("\n");
 
   out.append("  device_id: ");
-  sprintf(buffer, "%" PRIu32, this->device_id);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
   out.append(buffer);
   out.append("\n");
   out.append("}");
@@ -2092,7 +2092,7 @@ void ClimateStateResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("ClimateStateResponse {\n");
   out.append("  key: ");
-  sprintf(buffer, "%" PRIu32, this->key);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
   out.append(buffer);
   out.append("\n");
 
@@ -2101,22 +2101,22 @@ void ClimateStateResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  current_temperature: ");
-  sprintf(buffer, "%g", this->current_temperature);
+  snprintf(buffer, sizeof(buffer), "%g", this->current_temperature);
   out.append(buffer);
   out.append("\n");
 
   out.append("  target_temperature: ");
-  sprintf(buffer, "%g", this->target_temperature);
+  snprintf(buffer, sizeof(buffer), "%g", this->target_temperature);
   out.append(buffer);
   out.append("\n");
 
   out.append("  target_temperature_low: ");
-  sprintf(buffer, "%g", this->target_temperature_low);
+  snprintf(buffer, sizeof(buffer), "%g", this->target_temperature_low);
   out.append(buffer);
   out.append("\n");
 
   out.append("  target_temperature_high: ");
-  sprintf(buffer, "%g", this->target_temperature_high);
+  snprintf(buffer, sizeof(buffer), "%g", this->target_temperature_high);
   out.append(buffer);
   out.append("\n");
 
@@ -2149,17 +2149,17 @@ void ClimateStateResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  current_humidity: ");
-  sprintf(buffer, "%g", this->current_humidity);
+  snprintf(buffer, sizeof(buffer), "%g", this->current_humidity);
   out.append(buffer);
   out.append("\n");
 
   out.append("  target_humidity: ");
-  sprintf(buffer, "%g", this->target_humidity);
+  snprintf(buffer, sizeof(buffer), "%g", this->target_humidity);
   out.append(buffer);
   out.append("\n");
 
   out.append("  device_id: ");
-  sprintf(buffer, "%" PRIu32, this->device_id);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
   out.append(buffer);
   out.append("\n");
   out.append("}");
@@ -2168,7 +2168,7 @@ void ClimateCommandRequest::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("ClimateCommandRequest {\n");
   out.append("  key: ");
-  sprintf(buffer, "%" PRIu32, this->key);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
   out.append(buffer);
   out.append("\n");
 
@@ -2185,7 +2185,7 @@ void ClimateCommandRequest::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  target_temperature: ");
-  sprintf(buffer, "%g", this->target_temperature);
+  snprintf(buffer, sizeof(buffer), "%g", this->target_temperature);
   out.append(buffer);
   out.append("\n");
 
@@ -2194,7 +2194,7 @@ void ClimateCommandRequest::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  target_temperature_low: ");
-  sprintf(buffer, "%g", this->target_temperature_low);
+  snprintf(buffer, sizeof(buffer), "%g", this->target_temperature_low);
   out.append(buffer);
   out.append("\n");
 
@@ -2203,7 +2203,7 @@ void ClimateCommandRequest::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  target_temperature_high: ");
-  sprintf(buffer, "%g", this->target_temperature_high);
+  snprintf(buffer, sizeof(buffer), "%g", this->target_temperature_high);
   out.append(buffer);
   out.append("\n");
 
@@ -2260,7 +2260,7 @@ void ClimateCommandRequest::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  target_humidity: ");
-  sprintf(buffer, "%g", this->target_humidity);
+  snprintf(buffer, sizeof(buffer), "%g", this->target_humidity);
   out.append(buffer);
   out.append("\n");
   out.append("}");
@@ -2275,7 +2275,7 @@ void ListEntitiesNumberResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  key: ");
-  sprintf(buffer, "%" PRIu32, this->key);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
   out.append(buffer);
   out.append("\n");
 
@@ -2292,17 +2292,17 @@ void ListEntitiesNumberResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  min_value: ");
-  sprintf(buffer, "%g", this->min_value);
+  snprintf(buffer, sizeof(buffer), "%g", this->min_value);
   out.append(buffer);
   out.append("\n");
 
   out.append("  max_value: ");
-  sprintf(buffer, "%g", this->max_value);
+  snprintf(buffer, sizeof(buffer), "%g", this->max_value);
   out.append(buffer);
   out.append("\n");
 
   out.append("  step: ");
-  sprintf(buffer, "%g", this->step);
+  snprintf(buffer, sizeof(buffer), "%g", this->step);
   out.append(buffer);
   out.append("\n");
 
@@ -2327,7 +2327,7 @@ void ListEntitiesNumberResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  device_id: ");
-  sprintf(buffer, "%" PRIu32, this->device_id);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
   out.append(buffer);
   out.append("\n");
   out.append("}");
@@ -2336,12 +2336,12 @@ void NumberStateResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("NumberStateResponse {\n");
   out.append("  key: ");
-  sprintf(buffer, "%" PRIu32, this->key);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
   out.append(buffer);
   out.append("\n");
 
   out.append("  state: ");
-  sprintf(buffer, "%g", this->state);
+  snprintf(buffer, sizeof(buffer), "%g", this->state);
   out.append(buffer);
   out.append("\n");
 
@@ -2350,7 +2350,7 @@ void NumberStateResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  device_id: ");
-  sprintf(buffer, "%" PRIu32, this->device_id);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
   out.append(buffer);
   out.append("\n");
   out.append("}");
@@ -2359,12 +2359,12 @@ void NumberCommandRequest::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("NumberCommandRequest {\n");
   out.append("  key: ");
-  sprintf(buffer, "%" PRIu32, this->key);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
   out.append(buffer);
   out.append("\n");
 
   out.append("  state: ");
-  sprintf(buffer, "%g", this->state);
+  snprintf(buffer, sizeof(buffer), "%g", this->state);
   out.append(buffer);
   out.append("\n");
   out.append("}");
@@ -2379,7 +2379,7 @@ void ListEntitiesSelectResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  key: ");
-  sprintf(buffer, "%" PRIu32, this->key);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
   out.append(buffer);
   out.append("\n");
 
@@ -2410,7 +2410,7 @@ void ListEntitiesSelectResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  device_id: ");
-  sprintf(buffer, "%" PRIu32, this->device_id);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
   out.append(buffer);
   out.append("\n");
   out.append("}");
@@ -2419,7 +2419,7 @@ void SelectStateResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("SelectStateResponse {\n");
   out.append("  key: ");
-  sprintf(buffer, "%" PRIu32, this->key);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
   out.append(buffer);
   out.append("\n");
 
@@ -2432,7 +2432,7 @@ void SelectStateResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  device_id: ");
-  sprintf(buffer, "%" PRIu32, this->device_id);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
   out.append(buffer);
   out.append("\n");
   out.append("}");
@@ -2441,7 +2441,7 @@ void SelectCommandRequest::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("SelectCommandRequest {\n");
   out.append("  key: ");
-  sprintf(buffer, "%" PRIu32, this->key);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
   out.append(buffer);
   out.append("\n");
 
@@ -2460,7 +2460,7 @@ void ListEntitiesSirenResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  key: ");
-  sprintf(buffer, "%" PRIu32, this->key);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
   out.append(buffer);
   out.append("\n");
 
@@ -2499,7 +2499,7 @@ void ListEntitiesSirenResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  device_id: ");
-  sprintf(buffer, "%" PRIu32, this->device_id);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
   out.append(buffer);
   out.append("\n");
   out.append("}");
@@ -2508,7 +2508,7 @@ void SirenStateResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("SirenStateResponse {\n");
   out.append("  key: ");
-  sprintf(buffer, "%" PRIu32, this->key);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
   out.append(buffer);
   out.append("\n");
 
@@ -2517,7 +2517,7 @@ void SirenStateResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  device_id: ");
-  sprintf(buffer, "%" PRIu32, this->device_id);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
   out.append(buffer);
   out.append("\n");
   out.append("}");
@@ -2526,7 +2526,7 @@ void SirenCommandRequest::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("SirenCommandRequest {\n");
   out.append("  key: ");
-  sprintf(buffer, "%" PRIu32, this->key);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
   out.append(buffer);
   out.append("\n");
 
@@ -2551,7 +2551,7 @@ void SirenCommandRequest::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  duration: ");
-  sprintf(buffer, "%" PRIu32, this->duration);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->duration);
   out.append(buffer);
   out.append("\n");
 
@@ -2560,7 +2560,7 @@ void SirenCommandRequest::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  volume: ");
-  sprintf(buffer, "%g", this->volume);
+  snprintf(buffer, sizeof(buffer), "%g", this->volume);
   out.append(buffer);
   out.append("\n");
   out.append("}");
@@ -2575,7 +2575,7 @@ void ListEntitiesLockResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  key: ");
-  sprintf(buffer, "%" PRIu32, this->key);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
   out.append(buffer);
   out.append("\n");
 
@@ -2616,7 +2616,7 @@ void ListEntitiesLockResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  device_id: ");
-  sprintf(buffer, "%" PRIu32, this->device_id);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
   out.append(buffer);
   out.append("\n");
   out.append("}");
@@ -2625,7 +2625,7 @@ void LockStateResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("LockStateResponse {\n");
   out.append("  key: ");
-  sprintf(buffer, "%" PRIu32, this->key);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
   out.append(buffer);
   out.append("\n");
 
@@ -2634,7 +2634,7 @@ void LockStateResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  device_id: ");
-  sprintf(buffer, "%" PRIu32, this->device_id);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
   out.append(buffer);
   out.append("\n");
   out.append("}");
@@ -2643,7 +2643,7 @@ void LockCommandRequest::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("LockCommandRequest {\n");
   out.append("  key: ");
-  sprintf(buffer, "%" PRIu32, this->key);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
   out.append(buffer);
   out.append("\n");
 
@@ -2670,7 +2670,7 @@ void ListEntitiesButtonResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  key: ");
-  sprintf(buffer, "%" PRIu32, this->key);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
   out.append(buffer);
   out.append("\n");
 
@@ -2699,7 +2699,7 @@ void ListEntitiesButtonResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  device_id: ");
-  sprintf(buffer, "%" PRIu32, this->device_id);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
   out.append(buffer);
   out.append("\n");
   out.append("}");
@@ -2708,7 +2708,7 @@ void ButtonCommandRequest::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("ButtonCommandRequest {\n");
   out.append("  key: ");
-  sprintf(buffer, "%" PRIu32, this->key);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
   out.append(buffer);
   out.append("\n");
   out.append("}");
@@ -2723,12 +2723,12 @@ void MediaPlayerSupportedFormat::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  sample_rate: ");
-  sprintf(buffer, "%" PRIu32, this->sample_rate);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->sample_rate);
   out.append(buffer);
   out.append("\n");
 
   out.append("  num_channels: ");
-  sprintf(buffer, "%" PRIu32, this->num_channels);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->num_channels);
   out.append(buffer);
   out.append("\n");
 
@@ -2737,7 +2737,7 @@ void MediaPlayerSupportedFormat::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  sample_bytes: ");
-  sprintf(buffer, "%" PRIu32, this->sample_bytes);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->sample_bytes);
   out.append(buffer);
   out.append("\n");
   out.append("}");
@@ -2750,7 +2750,7 @@ void ListEntitiesMediaPlayerResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  key: ");
-  sprintf(buffer, "%" PRIu32, this->key);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
   out.append(buffer);
   out.append("\n");
 
@@ -2785,7 +2785,7 @@ void ListEntitiesMediaPlayerResponse::dump_to(std::string &out) const {
   }
 
   out.append("  device_id: ");
-  sprintf(buffer, "%" PRIu32, this->device_id);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
   out.append(buffer);
   out.append("\n");
   out.append("}");
@@ -2794,7 +2794,7 @@ void MediaPlayerStateResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("MediaPlayerStateResponse {\n");
   out.append("  key: ");
-  sprintf(buffer, "%" PRIu32, this->key);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
   out.append(buffer);
   out.append("\n");
 
@@ -2803,7 +2803,7 @@ void MediaPlayerStateResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  volume: ");
-  sprintf(buffer, "%g", this->volume);
+  snprintf(buffer, sizeof(buffer), "%g", this->volume);
   out.append(buffer);
   out.append("\n");
 
@@ -2812,7 +2812,7 @@ void MediaPlayerStateResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  device_id: ");
-  sprintf(buffer, "%" PRIu32, this->device_id);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
   out.append(buffer);
   out.append("\n");
   out.append("}");
@@ -2821,7 +2821,7 @@ void MediaPlayerCommandRequest::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("MediaPlayerCommandRequest {\n");
   out.append("  key: ");
-  sprintf(buffer, "%" PRIu32, this->key);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
   out.append(buffer);
   out.append("\n");
 
@@ -2838,7 +2838,7 @@ void MediaPlayerCommandRequest::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  volume: ");
-  sprintf(buffer, "%g", this->volume);
+  snprintf(buffer, sizeof(buffer), "%g", this->volume);
   out.append(buffer);
   out.append("\n");
 
@@ -2865,7 +2865,7 @@ void SubscribeBluetoothLEAdvertisementsRequest::dump_to(std::string &out) const 
   __attribute__((unused)) char buffer[64];
   out.append("SubscribeBluetoothLEAdvertisementsRequest {\n");
   out.append("  flags: ");
-  sprintf(buffer, "%" PRIu32, this->flags);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->flags);
   out.append(buffer);
   out.append("\n");
   out.append("}");
@@ -2879,7 +2879,7 @@ void BluetoothServiceData::dump_to(std::string &out) const {
 
   for (const auto &it : this->legacy_data) {
     out.append("  legacy_data: ");
-    sprintf(buffer, "%" PRIu32, it);
+    snprintf(buffer, sizeof(buffer), "%" PRIu32, it);
     out.append(buffer);
     out.append("\n");
   }
@@ -2893,7 +2893,7 @@ void BluetoothLEAdvertisementResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("BluetoothLEAdvertisementResponse {\n");
   out.append("  address: ");
-  sprintf(buffer, "%llu", this->address);
+  snprintf(buffer, sizeof(buffer), "%llu", this->address);
   out.append(buffer);
   out.append("\n");
 
@@ -2902,7 +2902,7 @@ void BluetoothLEAdvertisementResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  rssi: ");
-  sprintf(buffer, "%" PRId32, this->rssi);
+  snprintf(buffer, sizeof(buffer), "%" PRId32, this->rssi);
   out.append(buffer);
   out.append("\n");
 
@@ -2925,7 +2925,7 @@ void BluetoothLEAdvertisementResponse::dump_to(std::string &out) const {
   }
 
   out.append("  address_type: ");
-  sprintf(buffer, "%" PRIu32, this->address_type);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->address_type);
   out.append(buffer);
   out.append("\n");
   out.append("}");
@@ -2934,17 +2934,17 @@ void BluetoothLERawAdvertisement::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("BluetoothLERawAdvertisement {\n");
   out.append("  address: ");
-  sprintf(buffer, "%llu", this->address);
+  snprintf(buffer, sizeof(buffer), "%llu", this->address);
   out.append(buffer);
   out.append("\n");
 
   out.append("  rssi: ");
-  sprintf(buffer, "%" PRId32, this->rssi);
+  snprintf(buffer, sizeof(buffer), "%" PRId32, this->rssi);
   out.append(buffer);
   out.append("\n");
 
   out.append("  address_type: ");
-  sprintf(buffer, "%" PRIu32, this->address_type);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->address_type);
   out.append(buffer);
   out.append("\n");
 
@@ -2967,7 +2967,7 @@ void BluetoothDeviceRequest::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("BluetoothDeviceRequest {\n");
   out.append("  address: ");
-  sprintf(buffer, "%llu", this->address);
+  snprintf(buffer, sizeof(buffer), "%llu", this->address);
   out.append(buffer);
   out.append("\n");
 
@@ -2980,7 +2980,7 @@ void BluetoothDeviceRequest::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  address_type: ");
-  sprintf(buffer, "%" PRIu32, this->address_type);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->address_type);
   out.append(buffer);
   out.append("\n");
   out.append("}");
@@ -2989,7 +2989,7 @@ void BluetoothDeviceConnectionResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("BluetoothDeviceConnectionResponse {\n");
   out.append("  address: ");
-  sprintf(buffer, "%llu", this->address);
+  snprintf(buffer, sizeof(buffer), "%llu", this->address);
   out.append(buffer);
   out.append("\n");
 
@@ -2998,12 +2998,12 @@ void BluetoothDeviceConnectionResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  mtu: ");
-  sprintf(buffer, "%" PRIu32, this->mtu);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->mtu);
   out.append(buffer);
   out.append("\n");
 
   out.append("  error: ");
-  sprintf(buffer, "%" PRId32, this->error);
+  snprintf(buffer, sizeof(buffer), "%" PRId32, this->error);
   out.append(buffer);
   out.append("\n");
   out.append("}");
@@ -3012,7 +3012,7 @@ void BluetoothGATTGetServicesRequest::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("BluetoothGATTGetServicesRequest {\n");
   out.append("  address: ");
-  sprintf(buffer, "%llu", this->address);
+  snprintf(buffer, sizeof(buffer), "%llu", this->address);
   out.append(buffer);
   out.append("\n");
   out.append("}");
@@ -3022,13 +3022,13 @@ void BluetoothGATTDescriptor::dump_to(std::string &out) const {
   out.append("BluetoothGATTDescriptor {\n");
   for (const auto &it : this->uuid) {
     out.append("  uuid: ");
-    sprintf(buffer, "%llu", it);
+    snprintf(buffer, sizeof(buffer), "%llu", it);
     out.append(buffer);
     out.append("\n");
   }
 
   out.append("  handle: ");
-  sprintf(buffer, "%" PRIu32, this->handle);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->handle);
   out.append(buffer);
   out.append("\n");
   out.append("}");
@@ -3038,18 +3038,18 @@ void BluetoothGATTCharacteristic::dump_to(std::string &out) const {
   out.append("BluetoothGATTCharacteristic {\n");
   for (const auto &it : this->uuid) {
     out.append("  uuid: ");
-    sprintf(buffer, "%llu", it);
+    snprintf(buffer, sizeof(buffer), "%llu", it);
     out.append(buffer);
     out.append("\n");
   }
 
   out.append("  handle: ");
-  sprintf(buffer, "%" PRIu32, this->handle);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->handle);
   out.append(buffer);
   out.append("\n");
 
   out.append("  properties: ");
-  sprintf(buffer, "%" PRIu32, this->properties);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->properties);
   out.append(buffer);
   out.append("\n");
 
@@ -3065,13 +3065,13 @@ void BluetoothGATTService::dump_to(std::string &out) const {
   out.append("BluetoothGATTService {\n");
   for (const auto &it : this->uuid) {
     out.append("  uuid: ");
-    sprintf(buffer, "%llu", it);
+    snprintf(buffer, sizeof(buffer), "%llu", it);
     out.append(buffer);
     out.append("\n");
   }
 
   out.append("  handle: ");
-  sprintf(buffer, "%" PRIu32, this->handle);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->handle);
   out.append(buffer);
   out.append("\n");
 
@@ -3086,7 +3086,7 @@ void BluetoothGATTGetServicesResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("BluetoothGATTGetServicesResponse {\n");
   out.append("  address: ");
-  sprintf(buffer, "%llu", this->address);
+  snprintf(buffer, sizeof(buffer), "%llu", this->address);
   out.append(buffer);
   out.append("\n");
 
@@ -3101,7 +3101,7 @@ void BluetoothGATTGetServicesDoneResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("BluetoothGATTGetServicesDoneResponse {\n");
   out.append("  address: ");
-  sprintf(buffer, "%llu", this->address);
+  snprintf(buffer, sizeof(buffer), "%llu", this->address);
   out.append(buffer);
   out.append("\n");
   out.append("}");
@@ -3110,12 +3110,12 @@ void BluetoothGATTReadRequest::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("BluetoothGATTReadRequest {\n");
   out.append("  address: ");
-  sprintf(buffer, "%llu", this->address);
+  snprintf(buffer, sizeof(buffer), "%llu", this->address);
   out.append(buffer);
   out.append("\n");
 
   out.append("  handle: ");
-  sprintf(buffer, "%" PRIu32, this->handle);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->handle);
   out.append(buffer);
   out.append("\n");
   out.append("}");
@@ -3124,12 +3124,12 @@ void BluetoothGATTReadResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("BluetoothGATTReadResponse {\n");
   out.append("  address: ");
-  sprintf(buffer, "%llu", this->address);
+  snprintf(buffer, sizeof(buffer), "%llu", this->address);
   out.append(buffer);
   out.append("\n");
 
   out.append("  handle: ");
-  sprintf(buffer, "%" PRIu32, this->handle);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->handle);
   out.append(buffer);
   out.append("\n");
 
@@ -3142,12 +3142,12 @@ void BluetoothGATTWriteRequest::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("BluetoothGATTWriteRequest {\n");
   out.append("  address: ");
-  sprintf(buffer, "%llu", this->address);
+  snprintf(buffer, sizeof(buffer), "%llu", this->address);
   out.append(buffer);
   out.append("\n");
 
   out.append("  handle: ");
-  sprintf(buffer, "%" PRIu32, this->handle);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->handle);
   out.append(buffer);
   out.append("\n");
 
@@ -3164,12 +3164,12 @@ void BluetoothGATTReadDescriptorRequest::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("BluetoothGATTReadDescriptorRequest {\n");
   out.append("  address: ");
-  sprintf(buffer, "%llu", this->address);
+  snprintf(buffer, sizeof(buffer), "%llu", this->address);
   out.append(buffer);
   out.append("\n");
 
   out.append("  handle: ");
-  sprintf(buffer, "%" PRIu32, this->handle);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->handle);
   out.append(buffer);
   out.append("\n");
   out.append("}");
@@ -3178,12 +3178,12 @@ void BluetoothGATTWriteDescriptorRequest::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("BluetoothGATTWriteDescriptorRequest {\n");
   out.append("  address: ");
-  sprintf(buffer, "%llu", this->address);
+  snprintf(buffer, sizeof(buffer), "%llu", this->address);
   out.append(buffer);
   out.append("\n");
 
   out.append("  handle: ");
-  sprintf(buffer, "%" PRIu32, this->handle);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->handle);
   out.append(buffer);
   out.append("\n");
 
@@ -3196,12 +3196,12 @@ void BluetoothGATTNotifyRequest::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("BluetoothGATTNotifyRequest {\n");
   out.append("  address: ");
-  sprintf(buffer, "%llu", this->address);
+  snprintf(buffer, sizeof(buffer), "%llu", this->address);
   out.append(buffer);
   out.append("\n");
 
   out.append("  handle: ");
-  sprintf(buffer, "%" PRIu32, this->handle);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->handle);
   out.append(buffer);
   out.append("\n");
 
@@ -3214,12 +3214,12 @@ void BluetoothGATTNotifyDataResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("BluetoothGATTNotifyDataResponse {\n");
   out.append("  address: ");
-  sprintf(buffer, "%llu", this->address);
+  snprintf(buffer, sizeof(buffer), "%llu", this->address);
   out.append(buffer);
   out.append("\n");
 
   out.append("  handle: ");
-  sprintf(buffer, "%" PRIu32, this->handle);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->handle);
   out.append(buffer);
   out.append("\n");
 
@@ -3235,18 +3235,18 @@ void BluetoothConnectionsFreeResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("BluetoothConnectionsFreeResponse {\n");
   out.append("  free: ");
-  sprintf(buffer, "%" PRIu32, this->free);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->free);
   out.append(buffer);
   out.append("\n");
 
   out.append("  limit: ");
-  sprintf(buffer, "%" PRIu32, this->limit);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->limit);
   out.append(buffer);
   out.append("\n");
 
   for (const auto &it : this->allocated) {
     out.append("  allocated: ");
-    sprintf(buffer, "%llu", it);
+    snprintf(buffer, sizeof(buffer), "%llu", it);
     out.append(buffer);
     out.append("\n");
   }
@@ -3256,17 +3256,17 @@ void BluetoothGATTErrorResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("BluetoothGATTErrorResponse {\n");
   out.append("  address: ");
-  sprintf(buffer, "%llu", this->address);
+  snprintf(buffer, sizeof(buffer), "%llu", this->address);
   out.append(buffer);
   out.append("\n");
 
   out.append("  handle: ");
-  sprintf(buffer, "%" PRIu32, this->handle);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->handle);
   out.append(buffer);
   out.append("\n");
 
   out.append("  error: ");
-  sprintf(buffer, "%" PRId32, this->error);
+  snprintf(buffer, sizeof(buffer), "%" PRId32, this->error);
   out.append(buffer);
   out.append("\n");
   out.append("}");
@@ -3275,12 +3275,12 @@ void BluetoothGATTWriteResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("BluetoothGATTWriteResponse {\n");
   out.append("  address: ");
-  sprintf(buffer, "%llu", this->address);
+  snprintf(buffer, sizeof(buffer), "%llu", this->address);
   out.append(buffer);
   out.append("\n");
 
   out.append("  handle: ");
-  sprintf(buffer, "%" PRIu32, this->handle);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->handle);
   out.append(buffer);
   out.append("\n");
   out.append("}");
@@ -3289,12 +3289,12 @@ void BluetoothGATTNotifyResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("BluetoothGATTNotifyResponse {\n");
   out.append("  address: ");
-  sprintf(buffer, "%llu", this->address);
+  snprintf(buffer, sizeof(buffer), "%llu", this->address);
   out.append(buffer);
   out.append("\n");
 
   out.append("  handle: ");
-  sprintf(buffer, "%" PRIu32, this->handle);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->handle);
   out.append(buffer);
   out.append("\n");
   out.append("}");
@@ -3303,7 +3303,7 @@ void BluetoothDevicePairingResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("BluetoothDevicePairingResponse {\n");
   out.append("  address: ");
-  sprintf(buffer, "%llu", this->address);
+  snprintf(buffer, sizeof(buffer), "%llu", this->address);
   out.append(buffer);
   out.append("\n");
 
@@ -3312,7 +3312,7 @@ void BluetoothDevicePairingResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  error: ");
-  sprintf(buffer, "%" PRId32, this->error);
+  snprintf(buffer, sizeof(buffer), "%" PRId32, this->error);
   out.append(buffer);
   out.append("\n");
   out.append("}");
@@ -3321,7 +3321,7 @@ void BluetoothDeviceUnpairingResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("BluetoothDeviceUnpairingResponse {\n");
   out.append("  address: ");
-  sprintf(buffer, "%llu", this->address);
+  snprintf(buffer, sizeof(buffer), "%llu", this->address);
   out.append(buffer);
   out.append("\n");
 
@@ -3330,7 +3330,7 @@ void BluetoothDeviceUnpairingResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  error: ");
-  sprintf(buffer, "%" PRId32, this->error);
+  snprintf(buffer, sizeof(buffer), "%" PRId32, this->error);
   out.append(buffer);
   out.append("\n");
   out.append("}");
@@ -3342,7 +3342,7 @@ void BluetoothDeviceClearCacheResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("BluetoothDeviceClearCacheResponse {\n");
   out.append("  address: ");
-  sprintf(buffer, "%llu", this->address);
+  snprintf(buffer, sizeof(buffer), "%llu", this->address);
   out.append(buffer);
   out.append("\n");
 
@@ -3351,7 +3351,7 @@ void BluetoothDeviceClearCacheResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  error: ");
-  sprintf(buffer, "%" PRId32, this->error);
+  snprintf(buffer, sizeof(buffer), "%" PRId32, this->error);
   out.append(buffer);
   out.append("\n");
   out.append("}");
@@ -3386,7 +3386,7 @@ void SubscribeVoiceAssistantRequest::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  flags: ");
-  sprintf(buffer, "%" PRIu32, this->flags);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->flags);
   out.append(buffer);
   out.append("\n");
   out.append("}");
@@ -3395,17 +3395,17 @@ void VoiceAssistantAudioSettings::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("VoiceAssistantAudioSettings {\n");
   out.append("  noise_suppression_level: ");
-  sprintf(buffer, "%" PRIu32, this->noise_suppression_level);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->noise_suppression_level);
   out.append(buffer);
   out.append("\n");
 
   out.append("  auto_gain: ");
-  sprintf(buffer, "%" PRIu32, this->auto_gain);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->auto_gain);
   out.append(buffer);
   out.append("\n");
 
   out.append("  volume_multiplier: ");
-  sprintf(buffer, "%g", this->volume_multiplier);
+  snprintf(buffer, sizeof(buffer), "%g", this->volume_multiplier);
   out.append(buffer);
   out.append("\n");
   out.append("}");
@@ -3422,7 +3422,7 @@ void VoiceAssistantRequest::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  flags: ");
-  sprintf(buffer, "%" PRIu32, this->flags);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->flags);
   out.append(buffer);
   out.append("\n");
 
@@ -3439,7 +3439,7 @@ void VoiceAssistantResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("VoiceAssistantResponse {\n");
   out.append("  port: ");
-  sprintf(buffer, "%" PRIu32, this->port);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->port);
   out.append(buffer);
   out.append("\n");
 
@@ -3502,12 +3502,12 @@ void VoiceAssistantTimerEventResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  total_seconds: ");
-  sprintf(buffer, "%" PRIu32, this->total_seconds);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->total_seconds);
   out.append(buffer);
   out.append("\n");
 
   out.append("  seconds_left: ");
-  sprintf(buffer, "%" PRIu32, this->seconds_left);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->seconds_left);
   out.append(buffer);
   out.append("\n");
 
@@ -3581,7 +3581,7 @@ void VoiceAssistantConfigurationResponse::dump_to(std::string &out) const {
   }
 
   out.append("  max_active_wake_words: ");
-  sprintf(buffer, "%" PRIu32, this->max_active_wake_words);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->max_active_wake_words);
   out.append(buffer);
   out.append("\n");
   out.append("}");
@@ -3606,7 +3606,7 @@ void ListEntitiesAlarmControlPanelResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  key: ");
-  sprintf(buffer, "%" PRIu32, this->key);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
   out.append(buffer);
   out.append("\n");
 
@@ -3631,7 +3631,7 @@ void ListEntitiesAlarmControlPanelResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  supported_features: ");
-  sprintf(buffer, "%" PRIu32, this->supported_features);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->supported_features);
   out.append(buffer);
   out.append("\n");
 
@@ -3644,7 +3644,7 @@ void ListEntitiesAlarmControlPanelResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  device_id: ");
-  sprintf(buffer, "%" PRIu32, this->device_id);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
   out.append(buffer);
   out.append("\n");
   out.append("}");
@@ -3653,7 +3653,7 @@ void AlarmControlPanelStateResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("AlarmControlPanelStateResponse {\n");
   out.append("  key: ");
-  sprintf(buffer, "%" PRIu32, this->key);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
   out.append(buffer);
   out.append("\n");
 
@@ -3662,7 +3662,7 @@ void AlarmControlPanelStateResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  device_id: ");
-  sprintf(buffer, "%" PRIu32, this->device_id);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
   out.append(buffer);
   out.append("\n");
   out.append("}");
@@ -3671,7 +3671,7 @@ void AlarmControlPanelCommandRequest::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("AlarmControlPanelCommandRequest {\n");
   out.append("  key: ");
-  sprintf(buffer, "%" PRIu32, this->key);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
   out.append(buffer);
   out.append("\n");
 
@@ -3694,7 +3694,7 @@ void ListEntitiesTextResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  key: ");
-  sprintf(buffer, "%" PRIu32, this->key);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
   out.append(buffer);
   out.append("\n");
 
@@ -3719,12 +3719,12 @@ void ListEntitiesTextResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  min_length: ");
-  sprintf(buffer, "%" PRIu32, this->min_length);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->min_length);
   out.append(buffer);
   out.append("\n");
 
   out.append("  max_length: ");
-  sprintf(buffer, "%" PRIu32, this->max_length);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->max_length);
   out.append(buffer);
   out.append("\n");
 
@@ -3737,7 +3737,7 @@ void ListEntitiesTextResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  device_id: ");
-  sprintf(buffer, "%" PRIu32, this->device_id);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
   out.append(buffer);
   out.append("\n");
   out.append("}");
@@ -3746,7 +3746,7 @@ void TextStateResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("TextStateResponse {\n");
   out.append("  key: ");
-  sprintf(buffer, "%" PRIu32, this->key);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
   out.append(buffer);
   out.append("\n");
 
@@ -3759,7 +3759,7 @@ void TextStateResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  device_id: ");
-  sprintf(buffer, "%" PRIu32, this->device_id);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
   out.append(buffer);
   out.append("\n");
   out.append("}");
@@ -3768,7 +3768,7 @@ void TextCommandRequest::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("TextCommandRequest {\n");
   out.append("  key: ");
-  sprintf(buffer, "%" PRIu32, this->key);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
   out.append(buffer);
   out.append("\n");
 
@@ -3787,7 +3787,7 @@ void ListEntitiesDateResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  key: ");
-  sprintf(buffer, "%" PRIu32, this->key);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
   out.append(buffer);
   out.append("\n");
 
@@ -3812,7 +3812,7 @@ void ListEntitiesDateResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  device_id: ");
-  sprintf(buffer, "%" PRIu32, this->device_id);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
   out.append(buffer);
   out.append("\n");
   out.append("}");
@@ -3821,7 +3821,7 @@ void DateStateResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("DateStateResponse {\n");
   out.append("  key: ");
-  sprintf(buffer, "%" PRIu32, this->key);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
   out.append(buffer);
   out.append("\n");
 
@@ -3830,22 +3830,22 @@ void DateStateResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  year: ");
-  sprintf(buffer, "%" PRIu32, this->year);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->year);
   out.append(buffer);
   out.append("\n");
 
   out.append("  month: ");
-  sprintf(buffer, "%" PRIu32, this->month);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->month);
   out.append(buffer);
   out.append("\n");
 
   out.append("  day: ");
-  sprintf(buffer, "%" PRIu32, this->day);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->day);
   out.append(buffer);
   out.append("\n");
 
   out.append("  device_id: ");
-  sprintf(buffer, "%" PRIu32, this->device_id);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
   out.append(buffer);
   out.append("\n");
   out.append("}");
@@ -3854,22 +3854,22 @@ void DateCommandRequest::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("DateCommandRequest {\n");
   out.append("  key: ");
-  sprintf(buffer, "%" PRIu32, this->key);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
   out.append(buffer);
   out.append("\n");
 
   out.append("  year: ");
-  sprintf(buffer, "%" PRIu32, this->year);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->year);
   out.append(buffer);
   out.append("\n");
 
   out.append("  month: ");
-  sprintf(buffer, "%" PRIu32, this->month);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->month);
   out.append(buffer);
   out.append("\n");
 
   out.append("  day: ");
-  sprintf(buffer, "%" PRIu32, this->day);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->day);
   out.append(buffer);
   out.append("\n");
   out.append("}");
@@ -3884,7 +3884,7 @@ void ListEntitiesTimeResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  key: ");
-  sprintf(buffer, "%" PRIu32, this->key);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
   out.append(buffer);
   out.append("\n");
 
@@ -3909,7 +3909,7 @@ void ListEntitiesTimeResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  device_id: ");
-  sprintf(buffer, "%" PRIu32, this->device_id);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
   out.append(buffer);
   out.append("\n");
   out.append("}");
@@ -3918,7 +3918,7 @@ void TimeStateResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("TimeStateResponse {\n");
   out.append("  key: ");
-  sprintf(buffer, "%" PRIu32, this->key);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
   out.append(buffer);
   out.append("\n");
 
@@ -3927,22 +3927,22 @@ void TimeStateResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  hour: ");
-  sprintf(buffer, "%" PRIu32, this->hour);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->hour);
   out.append(buffer);
   out.append("\n");
 
   out.append("  minute: ");
-  sprintf(buffer, "%" PRIu32, this->minute);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->minute);
   out.append(buffer);
   out.append("\n");
 
   out.append("  second: ");
-  sprintf(buffer, "%" PRIu32, this->second);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->second);
   out.append(buffer);
   out.append("\n");
 
   out.append("  device_id: ");
-  sprintf(buffer, "%" PRIu32, this->device_id);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
   out.append(buffer);
   out.append("\n");
   out.append("}");
@@ -3951,22 +3951,22 @@ void TimeCommandRequest::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("TimeCommandRequest {\n");
   out.append("  key: ");
-  sprintf(buffer, "%" PRIu32, this->key);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
   out.append(buffer);
   out.append("\n");
 
   out.append("  hour: ");
-  sprintf(buffer, "%" PRIu32, this->hour);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->hour);
   out.append(buffer);
   out.append("\n");
 
   out.append("  minute: ");
-  sprintf(buffer, "%" PRIu32, this->minute);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->minute);
   out.append(buffer);
   out.append("\n");
 
   out.append("  second: ");
-  sprintf(buffer, "%" PRIu32, this->second);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->second);
   out.append(buffer);
   out.append("\n");
   out.append("}");
@@ -3981,7 +3981,7 @@ void ListEntitiesEventResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  key: ");
-  sprintf(buffer, "%" PRIu32, this->key);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
   out.append(buffer);
   out.append("\n");
 
@@ -4016,7 +4016,7 @@ void ListEntitiesEventResponse::dump_to(std::string &out) const {
   }
 
   out.append("  device_id: ");
-  sprintf(buffer, "%" PRIu32, this->device_id);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
   out.append(buffer);
   out.append("\n");
   out.append("}");
@@ -4025,7 +4025,7 @@ void EventResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("EventResponse {\n");
   out.append("  key: ");
-  sprintf(buffer, "%" PRIu32, this->key);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
   out.append(buffer);
   out.append("\n");
 
@@ -4034,7 +4034,7 @@ void EventResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  device_id: ");
-  sprintf(buffer, "%" PRIu32, this->device_id);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
   out.append(buffer);
   out.append("\n");
   out.append("}");
@@ -4049,7 +4049,7 @@ void ListEntitiesValveResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  key: ");
-  sprintf(buffer, "%" PRIu32, this->key);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
   out.append(buffer);
   out.append("\n");
 
@@ -4090,7 +4090,7 @@ void ListEntitiesValveResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  device_id: ");
-  sprintf(buffer, "%" PRIu32, this->device_id);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
   out.append(buffer);
   out.append("\n");
   out.append("}");
@@ -4099,12 +4099,12 @@ void ValveStateResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("ValveStateResponse {\n");
   out.append("  key: ");
-  sprintf(buffer, "%" PRIu32, this->key);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
   out.append(buffer);
   out.append("\n");
 
   out.append("  position: ");
-  sprintf(buffer, "%g", this->position);
+  snprintf(buffer, sizeof(buffer), "%g", this->position);
   out.append(buffer);
   out.append("\n");
 
@@ -4113,7 +4113,7 @@ void ValveStateResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  device_id: ");
-  sprintf(buffer, "%" PRIu32, this->device_id);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
   out.append(buffer);
   out.append("\n");
   out.append("}");
@@ -4122,7 +4122,7 @@ void ValveCommandRequest::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("ValveCommandRequest {\n");
   out.append("  key: ");
-  sprintf(buffer, "%" PRIu32, this->key);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
   out.append(buffer);
   out.append("\n");
 
@@ -4131,7 +4131,7 @@ void ValveCommandRequest::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  position: ");
-  sprintf(buffer, "%g", this->position);
+  snprintf(buffer, sizeof(buffer), "%g", this->position);
   out.append(buffer);
   out.append("\n");
 
@@ -4150,7 +4150,7 @@ void ListEntitiesDateTimeResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  key: ");
-  sprintf(buffer, "%" PRIu32, this->key);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
   out.append(buffer);
   out.append("\n");
 
@@ -4175,7 +4175,7 @@ void ListEntitiesDateTimeResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  device_id: ");
-  sprintf(buffer, "%" PRIu32, this->device_id);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
   out.append(buffer);
   out.append("\n");
   out.append("}");
@@ -4184,7 +4184,7 @@ void DateTimeStateResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("DateTimeStateResponse {\n");
   out.append("  key: ");
-  sprintf(buffer, "%" PRIu32, this->key);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
   out.append(buffer);
   out.append("\n");
 
@@ -4193,12 +4193,12 @@ void DateTimeStateResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  epoch_seconds: ");
-  sprintf(buffer, "%" PRIu32, this->epoch_seconds);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->epoch_seconds);
   out.append(buffer);
   out.append("\n");
 
   out.append("  device_id: ");
-  sprintf(buffer, "%" PRIu32, this->device_id);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
   out.append(buffer);
   out.append("\n");
   out.append("}");
@@ -4207,12 +4207,12 @@ void DateTimeCommandRequest::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("DateTimeCommandRequest {\n");
   out.append("  key: ");
-  sprintf(buffer, "%" PRIu32, this->key);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
   out.append(buffer);
   out.append("\n");
 
   out.append("  epoch_seconds: ");
-  sprintf(buffer, "%" PRIu32, this->epoch_seconds);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->epoch_seconds);
   out.append(buffer);
   out.append("\n");
   out.append("}");
@@ -4227,7 +4227,7 @@ void ListEntitiesUpdateResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  key: ");
-  sprintf(buffer, "%" PRIu32, this->key);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
   out.append(buffer);
   out.append("\n");
 
@@ -4256,7 +4256,7 @@ void ListEntitiesUpdateResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  device_id: ");
-  sprintf(buffer, "%" PRIu32, this->device_id);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
   out.append(buffer);
   out.append("\n");
   out.append("}");
@@ -4265,7 +4265,7 @@ void UpdateStateResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("UpdateStateResponse {\n");
   out.append("  key: ");
-  sprintf(buffer, "%" PRIu32, this->key);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
   out.append(buffer);
   out.append("\n");
 
@@ -4282,7 +4282,7 @@ void UpdateStateResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  progress: ");
-  sprintf(buffer, "%g", this->progress);
+  snprintf(buffer, sizeof(buffer), "%g", this->progress);
   out.append(buffer);
   out.append("\n");
 
@@ -4307,7 +4307,7 @@ void UpdateStateResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  device_id: ");
-  sprintf(buffer, "%" PRIu32, this->device_id);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
   out.append(buffer);
   out.append("\n");
   out.append("}");
@@ -4316,7 +4316,7 @@ void UpdateCommandRequest::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("UpdateCommandRequest {\n");
   out.append("  key: ");
-  sprintf(buffer, "%" PRIu32, this->key);
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
   out.append(buffer);
   out.append("\n");
 

--- a/script/api_protobuf/api_protobuf.py
+++ b/script/api_protobuf/api_protobuf.py
@@ -290,7 +290,7 @@ class DoubleType(TypeInfo):
     wire_type = WireType.FIXED64  # Uses wire type 1 according to protobuf spec
 
     def dump(self, name: str) -> str:
-        o = f'sprintf(buffer, "%g", {name});\n'
+        o = f'snprintf(buffer, sizeof(buffer), "%g", {name});\n'
         o += "out.append(buffer);"
         return o
 
@@ -312,7 +312,7 @@ class FloatType(TypeInfo):
     wire_type = WireType.FIXED32  # Uses wire type 5
 
     def dump(self, name: str) -> str:
-        o = f'sprintf(buffer, "%g", {name});\n'
+        o = f'snprintf(buffer, sizeof(buffer), "%g", {name});\n'
         o += "out.append(buffer);"
         return o
 
@@ -334,7 +334,7 @@ class Int64Type(TypeInfo):
     wire_type = WireType.VARINT  # Uses wire type 0
 
     def dump(self, name: str) -> str:
-        o = f'sprintf(buffer, "%lld", {name});\n'
+        o = f'snprintf(buffer, sizeof(buffer), "%lld", {name});\n'
         o += "out.append(buffer);"
         return o
 
@@ -356,7 +356,7 @@ class UInt64Type(TypeInfo):
     wire_type = WireType.VARINT  # Uses wire type 0
 
     def dump(self, name: str) -> str:
-        o = f'sprintf(buffer, "%llu", {name});\n'
+        o = f'snprintf(buffer, sizeof(buffer), "%llu", {name});\n'
         o += "out.append(buffer);"
         return o
 
@@ -378,7 +378,7 @@ class Int32Type(TypeInfo):
     wire_type = WireType.VARINT  # Uses wire type 0
 
     def dump(self, name: str) -> str:
-        o = f'sprintf(buffer, "%" PRId32, {name});\n'
+        o = f'snprintf(buffer, sizeof(buffer), "%" PRId32, {name});\n'
         o += "out.append(buffer);"
         return o
 
@@ -400,7 +400,7 @@ class Fixed64Type(TypeInfo):
     wire_type = WireType.FIXED64  # Uses wire type 1
 
     def dump(self, name: str) -> str:
-        o = f'sprintf(buffer, "%llu", {name});\n'
+        o = f'snprintf(buffer, sizeof(buffer), "%llu", {name});\n'
         o += "out.append(buffer);"
         return o
 
@@ -422,7 +422,7 @@ class Fixed32Type(TypeInfo):
     wire_type = WireType.FIXED32  # Uses wire type 5
 
     def dump(self, name: str) -> str:
-        o = f'sprintf(buffer, "%" PRIu32, {name});\n'
+        o = f'snprintf(buffer, sizeof(buffer), "%" PRIu32, {name});\n'
         o += "out.append(buffer);"
         return o
 
@@ -555,7 +555,7 @@ class UInt32Type(TypeInfo):
     wire_type = WireType.VARINT  # Uses wire type 0
 
     def dump(self, name: str) -> str:
-        o = f'sprintf(buffer, "%" PRIu32, {name});\n'
+        o = f'snprintf(buffer, sizeof(buffer), "%" PRIu32, {name});\n'
         o += "out.append(buffer);"
         return o
 
@@ -607,7 +607,7 @@ class SFixed32Type(TypeInfo):
     wire_type = WireType.FIXED32  # Uses wire type 5
 
     def dump(self, name: str) -> str:
-        o = f'sprintf(buffer, "%" PRId32, {name});\n'
+        o = f'snprintf(buffer, sizeof(buffer), "%" PRId32, {name});\n'
         o += "out.append(buffer);"
         return o
 
@@ -629,7 +629,7 @@ class SFixed64Type(TypeInfo):
     wire_type = WireType.FIXED64  # Uses wire type 1
 
     def dump(self, name: str) -> str:
-        o = f'sprintf(buffer, "%lld", {name});\n'
+        o = f'snprintf(buffer, sizeof(buffer), "%lld", {name});\n'
         o += "out.append(buffer);"
         return o
 
@@ -651,7 +651,7 @@ class SInt32Type(TypeInfo):
     wire_type = WireType.VARINT  # Uses wire type 0
 
     def dump(self, name: str) -> str:
-        o = f'sprintf(buffer, "%" PRId32, {name});\n'
+        o = f'snprintf(buffer, sizeof(buffer), "%" PRId32, {name});\n'
         o += "out.append(buffer);"
         return o
 
@@ -673,7 +673,7 @@ class SInt64Type(TypeInfo):
     wire_type = WireType.VARINT  # Uses wire type 0
 
     def dump(self, name: str) -> str:
-        o = f'sprintf(buffer, "%lld", {name});\n'
+        o = f'snprintf(buffer, sizeof(buffer), "%lld", {name});\n'
         o += "out.append(buffer);"
         return o
 


### PR DESCRIPTION
# What does this implement/fix?

This PR fixes compiler warnings about the use of deprecated `sprintf` function in the generated API protobuf dump code. The warnings were caused by the code generation script using `sprintf` instead of the safer `snprintf` function.

**Compiler warnings fixed:**
```
src/esphome/components/api/api_pb2_dump.cpp:603:3: warning: 'sprintf' is deprecated: This function is provided for compatibility reasons only. Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead. [-Wdeprecated-declarations]
  sprintf(buffer, "%" PRIu32, this->api_version_major);
  ^
```

The fix modifies the `script/api_protobuf/api_protobuf.py` code generator to use `snprintf(buffer, sizeof(buffer), ...)` instead of `sprintf(buffer, ...)` for all numeric type dump methods.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes deprecated function warnings on macOS and other platforms with strict security policies

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no documentation changes needed - internal code generation only)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# No configuration changes - this is an internal code generation fix
api:
  # All API configurations work without changes
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).