### PR TITLE
hydreon_rgxx: remove precipitation_intensity from RG9

### DIFF
--- a/esphome/components/hydreon_rgxx/sensor.py
+++ b/esphome/components/hydreon_rgxx/sensor.py
@@ -111,8 +111,8 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_MOISTURE): sensor.sensor_schema(
                 unit_of_measurement=UNIT_INTENSITY,
                 accuracy_decimals=0,
-                device_class=DEVICE_CLASS_PRECIPITATION_INTENSITY,
                 state_class=STATE_CLASS_MEASUREMENT,
+                icon="mdi:weather-rainy",
             ),
             cv.Optional(CONF_TEMPERATURE): sensor.sensor_schema(
                 unit_of_measurement=UNIT_CELSIUS,


### PR DESCRIPTION
Remove the device class `PRECIPITATION_INTENSITY` from RG9 primary output.
This is because the otherwise incompatible `intensity` unit of measurement is no longer supported since HA 2025.7 with the `PRECIPITATION_INTENSITY` device class. See https://github.com/home-assistant/core/pull/146722

As the RG9 sensor is not calibrated, we cannot reasonably switch to a supported unit of measurement, like mm/h.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
uart:
  rx_pin: GPIO16
  tx_pin: GPIO17
  baud_rate: 9600
  id: uart_port


sensor:
  - platform: hydreon_rgxx
    model: "RG 9"
    uart_id: uart_port
    update_interval: 5s
    moisture:
      name: "rain"
      id: rain

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
