### PR TITLE
Optimize logger performance by eliminating redundant strlen calls

### DIFF
--- a/esphome/components/logger/logger.h
+++ b/esphome/components/logger/logger.h
@@ -355,7 +355,7 @@ class Logger : public Component {
   }
 
   inline void HOT write_footer_to_buffer_(char *buffer, uint16_t *buffer_at, uint16_t buffer_size) {
-    static const uint16_t RESET_COLOR_LEN = strlen(ESPHOME_LOG_RESET_COLOR);
+    static constexpr uint16_t RESET_COLOR_LEN = sizeof(ESPHOME_LOG_RESET_COLOR) - 1;
     this->write_body_to_buffer_(ESPHOME_LOG_RESET_COLOR, RESET_COLOR_LEN, buffer, buffer_at, buffer_size);
   }
 

--- a/esphome/components/logger/logger_esp32.cpp
+++ b/esphome/components/logger/logger_esp32.cpp
@@ -184,7 +184,9 @@ void HOT Logger::write_msg_(const char *msg) {
   ) {
     puts(msg);
   } else {
-    uart_write_bytes(this->uart_num_, msg, strlen(msg));
+    // Use tx_buffer_at_ if msg points to tx_buffer_, otherwise fall back to strlen
+    size_t len = (msg == this->tx_buffer_) ? this->tx_buffer_at_ : strlen(msg);
+    uart_write_bytes(this->uart_num_, msg, len);
     uart_write_bytes(this->uart_num_, "\n", 1);
   }
 }


### PR DESCRIPTION
# What does this implement/fix?

This PR optimizes the logger component by eliminating unnecessary `strlen()` calls during log message building and output. These optimizations reduce CPU cycles spent on string operations, particularly beneficial for high-frequency logging scenarios.

## Key optimizations:

1. **Replace runtime `strlen()` with compile-time constant**: Changed `strlen(ESPHOME_LOG_RESET_COLOR)` to `sizeof(ESPHOME_LOG_RESET_COLOR) - 1` in the footer formatting, eliminating a runtime string length calculation for a constant string.

2. **Avoid redundant `strlen()` in ESP32 ESP-IDF uart output**: The logger already knows the message length in `tx_buffer_at_` when writing from `tx_buffer_`, so we now use that instead of calling `strlen()` again.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - this is an internal optimization
logger:
  level: DEBUG
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).