### PR TITLE
Refactor duplicate socket read error handling in API frame helper

### DIFF
--- a/esphome/components/api/api_frame_helper.h
+++ b/esphome/components/api/api_frame_helper.h
@@ -176,6 +176,9 @@ class APIFrameHelper {
 
   // Common initialization for both plaintext and noise protocols
   APIError init_common_();
+
+  // Helper method to handle socket read results
+  APIError handle_socket_read_result_(ssize_t received);
 };
 
 #ifdef USE_API_NOISE


### PR DESCRIPTION
# What does this implement/fix?

This PR refactors duplicate socket read error handling code in `api_frame_helper.cpp` by extracting it into a common helper method. The same error handling pattern was repeated 4 times across the file.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal refactoring, no user-facing changes)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - this is an internal refactoring
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

## Additional Details

### Changes Made:
1. Added `handle_socket_read_result_()` protected method to `APIFrameHelper` class
2. Replaced 4 instances of duplicate socket read error handling with calls to the new helper method
3. Maintained exact same behavior while reducing code duplication by ~36 lines

### Locations refactored:
- `APINoiseFrameHelper::try_read_frame_` - header read
- `APINoiseFrameHelper::try_read_frame_` - body read  
- `APIPlaintextFrameHelper::try_read_frame_` - header read
- `APIPlaintextFrameHelper::try_read_frame_` - body read
