### PR TITLE
[esp32] Warn if cpu_frequency is not set and defaults to 160MHZ

### DIFF
--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -132,6 +132,12 @@ def set_core_data(config):
             cpu_frequency = "360MHZ"
         else:
             cpu_frequency = choices[-1]
+        if cpu_frequency != choices[-1] and cpu_frequency == "160MHZ":
+            _LOGGER.warning(
+                "[esp32] cpu_frequency was not set, defaulting to 160MHZ, "
+                "maximum is %s, see https://esphome.io/components/esp32",
+                choices[-1],
+            )
         config[CONF_CPU_FREQUENCY] = cpu_frequency
     elif cpu_frequency not in CPU_FREQUENCIES[variant]:
         raise cv.Invalid(


### PR DESCRIPTION
# What does this implement/fix?

The issue:
- On Arduino the default changed from 240 to 160 and most people don't know that happened, see the attached issue. 
- On IDF sdkconfig settings are now overwritten by the esp32 component, happens without people knowing.
- Some people just assume it runs at max speed. 

Add a warning if cpu_frequency is not set to make this visible. Seems the simplest solution:

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes 

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
