### PR TITLE
Fix integration test race condition by isolating PlatformIO directories

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -167,16 +167,16 @@ async def compile_esphome(
     async def _compile(config_path: Path) -> Path:
         # Create a unique PlatformIO directory for this test to avoid race conditions
         platformio_dir = integration_test_dir / ".platformio"
-        platformio_dir.mkdir(exist_ok=True)
+        platformio_dir.mkdir(parents=True, exist_ok=True)
 
         # Create cache directory as well
-        cache_dir = platformio_dir / ".cache"
-        cache_dir.mkdir(exist_ok=True)
+        platformio_cache_dir = platformio_dir / ".cache"
+        platformio_cache_dir.mkdir(parents=True, exist_ok=True)
 
         # Set up environment with isolated PlatformIO directories
         env = os.environ.copy()
         env["PLATFORMIO_CORE_DIR"] = str(platformio_dir)
-        env["PLATFORMIO_CACHE_DIR"] = str(cache_dir)
+        env["PLATFORMIO_CACHE_DIR"] = str(platformio_cache_dir)
 
         # Retry compilation up to 3 times if we get a segfault
         max_retries = 3

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -165,6 +165,19 @@ async def compile_esphome(
     """Compile an ESPHome configuration and return the binary path."""
 
     async def _compile(config_path: Path) -> Path:
+        # Create a unique PlatformIO directory for this test to avoid race conditions
+        platformio_dir = integration_test_dir / ".platformio"
+        platformio_dir.mkdir(exist_ok=True)
+
+        # Create cache directory as well
+        cache_dir = platformio_dir / ".cache"
+        cache_dir.mkdir(exist_ok=True)
+
+        # Set up environment with isolated PlatformIO directories
+        env = os.environ.copy()
+        env["PLATFORMIO_CORE_DIR"] = str(platformio_dir)
+        env["PLATFORMIO_CACHE_DIR"] = str(cache_dir)
+
         # Retry compilation up to 3 times if we get a segfault
         max_retries = 3
         for attempt in range(max_retries):
@@ -179,6 +192,7 @@ async def compile_esphome(
                 stdin=asyncio.subprocess.DEVNULL,
                 # Start in a new process group to isolate signal handling
                 start_new_session=True,
+                env=env,
             )
             await proc.wait()
 


### PR DESCRIPTION
# What does this implement/fix?

This PR fixes a race condition in the integration tests that started occurring when we began running integration tests in isolation from other test suites. Previously, when all tests ran together, the `~/.platformio` directory would already be created by earlier tests. Now that integration tests run separately, multiple parallel tests race to create this directory, causing `FileExistsError: [Errno 17] File exists: '/home/runner/.platformio'`.

The solution creates a unique PlatformIO directory for each test within its temporary test directory by setting `PLATFORMIO_CORE_DIR` and `PLATFORMIO_CACHE_DIR` environment variables, ensuring complete isolation between parallel test runs.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A - This fixes intermittent CI test failures

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A - Internal testing infrastructure change

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

Note: This is a test infrastructure change that affects all platforms during integration testing.

## Example entry for `config.yaml`:

```yaml
# Not applicable - this is a test infrastructure change
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

## Additional Details

### Changes Made:

1. **Modified `tests/integration/conftest.py`**:
   - Updated the `_compile` function to create a unique `.platformio` directory within each test's temporary directory
   - Set `PLATFORMIO_CORE_DIR` and `PLATFORMIO_CACHE_DIR` environment variables to isolate each test
   - Both directories are created with `exist_ok=True` to handle any edge cases

2. **Added verification tests** in `tests/integration/test_platformio_isolation.py`:
   - Test to verify each test gets its own PlatformIO directory
   - Parameterized test that runs 3 tests in parallel to verify isolation works correctly
   - Tests create marker files to prove isolation between parallel runs

### Root Cause:
The race condition occurs because:
1. Integration tests were recently isolated to run separately from other test suites
2. When all tests ran together, the first test would create `~/.platformio` and subsequent tests would reuse it
3. Now with isolated integration tests running in parallel, multiple tests try to create `~/.platformio` simultaneously
4. PlatformIO's `os.makedirs()` call fails with `FileExistsError` when another process creates the directory between the existence check and creation attempt

### Before this change:
- Integration tests would randomly fail on CI with: `FileExistsError: [Errno 17] File exists: '/home/runner/.platformio'`
- Race condition made CI builds flaky and unreliable
- The error would occur in PlatformIO's initialization code when trying to create its state directory

### After this change:
- Each test uses its own isolated PlatformIO directory: `<test_temp_dir>/.platformio`
- Tests can run in parallel without conflicts
- CI builds are more reliable
- No shared state between test runs

### Testing:
Successfully ran parallel integration tests to verify the fix:
```bash
pytest -xvs -n 3 tests/integration/test_platformio_isolation.py::test_parallel_compilation_no_conflicts
```

All 3 parallel test instances passed, confirming proper isolation.