### PR TITLE
[nfc] Update code to use ``format_hex_pretty``

### DIFF
--- a/esphome/components/nfc/nfc.cpp
+++ b/esphome/components/nfc/nfc.cpp
@@ -1,5 +1,6 @@
 #include "nfc.h"
 #include <cstdio>
+#include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
 namespace esphome {
@@ -7,29 +8,9 @@ namespace nfc {
 
 static const char *const TAG = "nfc";
 
-std::string format_uid(std::vector<uint8_t> &uid) {
-  char buf[(uid.size() * 2) + uid.size() - 1];
-  int offset = 0;
-  for (size_t i = 0; i < uid.size(); i++) {
-    const char *format = "%02X";
-    if (i + 1 < uid.size())
-      format = "%02X-";
-    offset += sprintf(buf + offset, format, uid[i]);
-  }
-  return std::string(buf);
-}
+std::string format_uid(std::vector<uint8_t> &uid) { return format_hex_pretty(uid, '-', false); }
 
-std::string format_bytes(std::vector<uint8_t> &bytes) {
-  char buf[(bytes.size() * 2) + bytes.size() - 1];
-  int offset = 0;
-  for (size_t i = 0; i < bytes.size(); i++) {
-    const char *format = "%02X";
-    if (i + 1 < bytes.size())
-      format = "%02X ";
-    offset += sprintf(buf + offset, format, bytes[i]);
-  }
-  return std::string(buf);
-}
+std::string format_bytes(std::vector<uint8_t> &bytes) { return format_hex_pretty(bytes, ' ', false); }
 
 uint8_t guess_tag_type(uint8_t uid_length) {
   if (uid_length == 4) {

--- a/esphome/components/nfc/nfc.cpp
+++ b/esphome/components/nfc/nfc.cpp
@@ -8,9 +8,9 @@ namespace nfc {
 
 static const char *const TAG = "nfc";
 
-std::string format_uid(std::vector<uint8_t> &uid) { return format_hex_pretty(uid, '-', false); }
+std::string format_uid(const std::vector<uint8_t> &uid) { return format_hex_pretty(uid, '-', false); }
 
-std::string format_bytes(std::vector<uint8_t> &bytes) { return format_hex_pretty(bytes, ' ', false); }
+std::string format_bytes(const std::vector<uint8_t> &bytes) { return format_hex_pretty(bytes, ' ', false); }
 
 uint8_t guess_tag_type(uint8_t uid_length) {
   if (uid_length == 4) {

--- a/esphome/components/nfc/nfc.h
+++ b/esphome/components/nfc/nfc.h
@@ -2,8 +2,8 @@
 
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
-#include "ndef_record.h"
 #include "ndef_message.h"
+#include "ndef_record.h"
 #include "nfc_tag.h"
 
 #include <vector>
@@ -53,8 +53,8 @@ static const uint8_t DEFAULT_KEY[6] = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
 static const uint8_t NDEF_KEY[6] = {0xD3, 0xF7, 0xD3, 0xF7, 0xD3, 0xF7};
 static const uint8_t MAD_KEY[6] = {0xA0, 0xA1, 0xA2, 0xA3, 0xA4, 0xA5};
 
-std::string format_uid(std::vector<uint8_t> &uid);
-std::string format_bytes(std::vector<uint8_t> &bytes);
+std::string format_uid(const std::vector<uint8_t> &uid);
+std::string format_bytes(const std::vector<uint8_t> &bytes);
 
 uint8_t guess_tag_type(uint8_t uid_length);
 uint8_t get_mifare_classic_ndef_start_index(std::vector<uint8_t> &data);


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

New arguments implemented in #9380

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
