### PR TITLE
ESP_EXT1_WAKEUP_ANY_LOW is for s2/s3/c6/h2; ESP_EXT1_WAKEUP_ALL_LOW otherwise

### DIFF
--- a/esphome/components/deep_sleep/__init__.py
+++ b/esphome/components/deep_sleep/__init__.py
@@ -121,6 +121,24 @@ def validate_config(config):
         raise cv.Invalid("ESP32-C3 does not support wakeup from touch.")
     if get_esp32_variant() == VARIANT_ESP32C3 and CONF_TOUCH_WAKEUP in config:
         raise cv.Invalid("ESP32-C3 does not support wakeup from ext1")
+    if (
+        CONF_ESP32_EXT1_WAKEUP in config
+        and config[CONF_ESP32_EXT1_WAKEUP] == "ALL_LOW"
+        and get_esp32_variant()
+        in [VARIANT_ESP32S2, VARIANT_ESP32S3, VARIANT_ESP32C6, VARIANT_ESP32H2]
+    ):
+        raise cv.Invalid(
+            "ESP32-S2, ESP32-S3, ESP32-C6, and ESP32-H2 do not support ALL_LOW"
+        )
+    if (
+        CONF_ESP32_EXT1_WAKEUP in config
+        and config[CONF_ESP32_EXT1_WAKEUP] == "ANY_LOW"
+        and get_esp32_variant()
+        not in [VARIANT_ESP32S2, VARIANT_ESP32S3, VARIANT_ESP32C6, VARIANT_ESP32H2]
+    ):
+        raise cv.Invalid(
+            "Only ESP32-S2, ESP32-S3, ESP32-C6, and ESP32-H2 support ANY_LOW"
+        )
     return config
 
 
@@ -148,6 +166,7 @@ WAKEUP_PIN_MODES = {
 esp_sleep_ext1_wakeup_mode_t = cg.global_ns.enum("esp_sleep_ext1_wakeup_mode_t")
 Ext1Wakeup = deep_sleep_ns.struct("Ext1Wakeup")
 EXT1_WAKEUP_MODES = {
+    "ANY_LOW": esp_sleep_ext1_wakeup_mode_t.ESP_EXT1_WAKEUP_ANY_LOW,
     "ALL_LOW": esp_sleep_ext1_wakeup_mode_t.ESP_EXT1_WAKEUP_ALL_LOW,
     "ANY_HIGH": esp_sleep_ext1_wakeup_mode_t.ESP_EXT1_WAKEUP_ANY_HIGH,
 }

--- a/esphome/components/deep_sleep/__init__.py
+++ b/esphome/components/deep_sleep/__init__.py
@@ -117,7 +117,6 @@ def validate_pin_number(value):
 
 
 def _validate_ex1_wakeup_mode(value):
-    print(value)
     if value == "ALL_LOW":
         esp32.only_on_variant(supported=[VARIANT_ESP32], msg_prefix="ALL_LOW")(value)
     if value == "ANY_LOW":

--- a/esphome/components/deep_sleep/__init__.py
+++ b/esphome/components/deep_sleep/__init__.py
@@ -1,6 +1,6 @@
 from esphome import automation, pins
 import esphome.codegen as cg
-from esphome.components import time
+from esphome.components import esp32, time
 from esphome.components.esp32 import get_esp32_variant
 from esphome.components.esp32.const import (
     VARIANT_ESP32,
@@ -116,30 +116,21 @@ def validate_pin_number(value):
     return value
 
 
-def validate_config(config):
-    if get_esp32_variant() == VARIANT_ESP32C3 and CONF_ESP32_EXT1_WAKEUP in config:
-        raise cv.Invalid("ESP32-C3 does not support wakeup from touch.")
-    if get_esp32_variant() == VARIANT_ESP32C3 and CONF_TOUCH_WAKEUP in config:
-        raise cv.Invalid("ESP32-C3 does not support wakeup from ext1")
-    if (
-        CONF_ESP32_EXT1_WAKEUP in config
-        and config[CONF_ESP32_EXT1_WAKEUP] == "ALL_LOW"
-        and get_esp32_variant()
-        in [VARIANT_ESP32S2, VARIANT_ESP32S3, VARIANT_ESP32C6, VARIANT_ESP32H2]
-    ):
-        raise cv.Invalid(
-            "ESP32-S2, ESP32-S3, ESP32-C6, and ESP32-H2 do not support ALL_LOW"
-        )
-    if (
-        CONF_ESP32_EXT1_WAKEUP in config
-        and config[CONF_ESP32_EXT1_WAKEUP] == "ANY_LOW"
-        and get_esp32_variant()
-        not in [VARIANT_ESP32S2, VARIANT_ESP32S3, VARIANT_ESP32C6, VARIANT_ESP32H2]
-    ):
-        raise cv.Invalid(
-            "Only ESP32-S2, ESP32-S3, ESP32-C6, and ESP32-H2 support ANY_LOW"
-        )
-    return config
+def _validate_ex1_wakeup_mode(value):
+    print(value)
+    if value == "ALL_LOW":
+        esp32.only_on_variant(supported=[VARIANT_ESP32], msg_prefix="ALL_LOW")(value)
+    if value == "ANY_LOW":
+        esp32.only_on_variant(
+            supported=[
+                VARIANT_ESP32S2,
+                VARIANT_ESP32S3,
+                VARIANT_ESP32C6,
+                VARIANT_ESP32H2,
+            ],
+            msg_prefix="ANY_LOW",
+        )(value)
+    return value
 
 
 deep_sleep_ns = cg.esphome_ns.namespace("deep_sleep")
@@ -206,16 +197,28 @@ CONFIG_SCHEMA = cv.All(
             ),
             cv.Optional(CONF_ESP32_EXT1_WAKEUP): cv.All(
                 cv.only_on_esp32,
+                esp32.only_on_variant(
+                    unsupported=[VARIANT_ESP32C3], msg_prefix="Wakeup from ext1"
+                ),
                 cv.Schema(
                     {
                         cv.Required(CONF_PINS): cv.ensure_list(
                             pins.internal_gpio_input_pin_schema, validate_pin_number
                         ),
-                        cv.Required(CONF_MODE): cv.enum(EXT1_WAKEUP_MODES, upper=True),
+                        cv.Required(CONF_MODE): cv.All(
+                            cv.enum(EXT1_WAKEUP_MODES, upper=True),
+                            _validate_ex1_wakeup_mode,
+                        ),
                     }
                 ),
             ),
-            cv.Optional(CONF_TOUCH_WAKEUP): cv.All(cv.only_on_esp32, cv.boolean),
+            cv.Optional(CONF_TOUCH_WAKEUP): cv.All(
+                cv.only_on_esp32,
+                esp32.only_on_variant(
+                    unsupported=[VARIANT_ESP32C3], msg_prefix="Wakeup from touch"
+                ),
+                cv.boolean,
+            ),
         }
     ).extend(cv.COMPONENT_SCHEMA),
     cv.only_on([PLATFORM_ESP32, PLATFORM_ESP8266]),


### PR DESCRIPTION
# What does this implement/fix?

Define ESP_EXT1_WAKEUP_ANY_LOW for ESP32-S2, ESP32-S3, ESP32-C6 or ESP32-H2; otherwise, define ESP_EXT1_WAKEUP_ALL_LOW for all others.

From the documentation at https://docs.espressif.com/projects/esp-idf/en/v5.1.5/esp32/api-reference/system/sleep_modes.html

    level_mode -- Select logic function used to determine wakeup condition:

    When target chip is ESP32:

        ESP_EXT1_WAKEUP_ALL_LOW: wake up when all selected GPIOs are low
        ESP_EXT1_WAKEUP_ANY_HIGH: wake up when any of the selected GPIOs is high

    When target chip is ESP32-S2, ESP32-S3, ESP32-C6 or ESP32-H2:

        ESP_EXT1_WAKEUP_ANY_LOW: wake up when any of the selected GPIOs is low
        ESP_EXT1_WAKEUP_ANY_HIGH: wake up when any of the selected GPIOs is high`

Also stated by expressif at https://github.com/espressif/esp-idf/issues/11870#issuecomment-1643359217

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/issues/issues/6651

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

https://github.com/esphome/esphome-docs/pull/5080

## Test Environment

- [ ] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
deep_sleep:
  id: dp
  sleep_duration: 7d
  wakeup_pin_mode: KEEP_AWAKE
  esp32_ext1_wakeup: 
    mode: ANY_LOW
    pins:
      - 13
      - 14
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
