### PR TITLE
Deep sleep error checking, reset configuration before applying current configuration

### DIFF
--- a/esphome/components/deep_sleep/deep_sleep_esp32.cpp
+++ b/esphome/components/deep_sleep/deep_sleep_esp32.cpp
@@ -70,44 +70,81 @@ bool DeepSleepComponent::prepare_to_sleep_() {
 }
 
 void DeepSleepComponent::deep_sleep_() {
+  esp_err_t err;
 #if !defined(USE_ESP32_VARIANT_ESP32C3) && !defined(USE_ESP32_VARIANT_ESP32C6) && !defined(USE_ESP32_VARIANT_ESP32H2)
   if (this->sleep_duration_.has_value())
-    esp_sleep_enable_timer_wakeup(*this->sleep_duration_);
+    err = esp_sleep_enable_timer_wakeup(*this->sleep_duration_);
+  if (err != ESP_OK) {
+    ESP_LOGE(TAG, "esp_sleep_enable_timer_wakeup failed: %s", esp_err_to_name(err));
+    return;
+  }
   if (this->wakeup_pin_ != nullptr) {
     bool level = !this->wakeup_pin_->is_inverted();
     if (this->wakeup_pin_mode_ == WAKEUP_PIN_MODE_INVERT_WAKEUP && this->wakeup_pin_->digital_read()) {
       level = !level;
     }
-    esp_sleep_enable_ext0_wakeup(gpio_num_t(this->wakeup_pin_->get_pin()), level);
+    err = esp_sleep_enable_ext0_wakeup(gpio_num_t(this->wakeup_pin_->get_pin()), level);
+    if (err != ESP_OK) {
+      ESP_LOGE(TAG, "esp_sleep_enable_ext0_wakeup failed: %s", esp_err_to_name(err));
+      return;
+    }
   }
   if (this->ext1_wakeup_.has_value()) {
-    esp_sleep_enable_ext1_wakeup(this->ext1_wakeup_->mask, this->ext1_wakeup_->wakeup_mode);
+    err = esp_sleep_enable_ext1_wakeup(this->ext1_wakeup_->mask, this->ext1_wakeup_->wakeup_mode);
+    if (err != ESP_OK) {
+      ESP_LOGE(TAG, "esp_sleep_enable_ext1_wakeup failed: %s", esp_err_to_name(err));
+      return;
+    }
   }
 
   if (this->touch_wakeup_.has_value() && *(this->touch_wakeup_)) {
-    esp_sleep_enable_touchpad_wakeup();
-    esp_sleep_pd_config(ESP_PD_DOMAIN_RTC_PERIPH, ESP_PD_OPTION_ON);
+    err = esp_sleep_enable_touchpad_wakeup();
+    if (err != ESP_OK) {
+      ESP_LOGE(TAG, "esp_sleep_enable_touchpad_wakeup failed: %s", esp_err_to_name(err));
+      return;
+    }
+    err = esp_sleep_pd_config(ESP_PD_DOMAIN_RTC_PERIPH, ESP_PD_OPTION_ON);
+    if (err != ESP_OK) {
+      ESP_LOGE(TAG, "esp_sleep_pd_config failed: %s", esp_err_to_name(err));
+      return;
+    }
   }
 #endif
 
 #if defined(USE_ESP32_VARIANT_ESP32H2)
   if (this->sleep_duration_.has_value())
-    esp_sleep_enable_timer_wakeup(*this->sleep_duration_);
+    err = esp_sleep_enable_timer_wakeup(*this->sleep_duration_);
+  if (err != ESP_OK) {
+    ESP_LOGE(TAG, "esp_sleep_enable_timer_wakeup failed: %s", esp_err_to_name(err));
+    return;
+  }
   if (this->ext1_wakeup_.has_value()) {
-    esp_sleep_enable_ext1_wakeup(this->ext1_wakeup_->mask, this->ext1_wakeup_->wakeup_mode);
+    err = esp_sleep_enable_ext1_wakeup(this->ext1_wakeup_->mask, this->ext1_wakeup_->wakeup_mode);
+    if (err != ESP_OK) {
+      ESP_LOGE(TAG, "esp_sleep_enable_ext1_wakeup failed: %s", esp_err_to_name(err));
+      return;
+    }
   }
 #endif
 
 #if defined(USE_ESP32_VARIANT_ESP32C3) || defined(USE_ESP32_VARIANT_ESP32C6)
   if (this->sleep_duration_.has_value())
-    esp_sleep_enable_timer_wakeup(*this->sleep_duration_);
+    err = esp_sleep_enable_timer_wakeup(*this->sleep_duration_);
+  if (err != ESP_OK) {
+    ESP_LOGE(TAG, "esp_sleep_enable_timer_wakeup failed: %s", esp_err_to_name(err));
+    return;
+  }
   if (this->wakeup_pin_ != nullptr) {
     bool level = !this->wakeup_pin_->is_inverted();
     if (this->wakeup_pin_mode_ == WAKEUP_PIN_MODE_INVERT_WAKEUP && this->wakeup_pin_->digital_read()) {
       level = !level;
     }
-    esp_deep_sleep_enable_gpio_wakeup(1 << this->wakeup_pin_->get_pin(),
-                                      static_cast<esp_deepsleep_gpio_wake_up_mode_t>(level));
+    err = esp_deep_sleep_enable_gpio_wakeup(1 << this->wakeup_pin_->get_pin(),
+                                            static_cast<esp_deepsleep_gpio_wake_up_mode_t>(level));
+    if (err != ESP_OK) {
+      ESP_LOGE(TAG, "esp_deep_sleep_enable_gpio_wakeup failed: %s", esp_err_to_name(err));
+      return;
+    }
   }
 #endif
   esp_deep_sleep_start();

--- a/esphome/components/deep_sleep/deep_sleep_esp32.cpp
+++ b/esphome/components/deep_sleep/deep_sleep_esp32.cpp
@@ -71,6 +71,12 @@ bool DeepSleepComponent::prepare_to_sleep_() {
 
 void DeepSleepComponent::deep_sleep_() {
   esp_err_t err;
+  // Reset all enabled IO wakeup configuration
+  err = esp_sleep_disable_ext1_wakeup_io(0);
+  if (err != ESP_OK) {
+    ESP_LOGE(TAG, "esp_sleep_disable_ext1_wakeup_io failed: %s", esp_err_to_name(err));
+    return;
+  }
 #if !defined(USE_ESP32_VARIANT_ESP32C3) && !defined(USE_ESP32_VARIANT_ESP32C6) && !defined(USE_ESP32_VARIANT_ESP32H2)
   if (this->sleep_duration_.has_value())
     err = esp_sleep_enable_timer_wakeup(*this->sleep_duration_);

--- a/esphome/components/deep_sleep/deep_sleep_esp32.cpp
+++ b/esphome/components/deep_sleep/deep_sleep_esp32.cpp
@@ -108,6 +108,12 @@ void DeepSleepComponent::deep_sleep_() {
       ESP_LOGE(TAG, "esp_sleep_pd_config failed: %s", esp_err_to_name(err));
       return;
     }
+  } else {
+    err = esp_sleep_pd_config(ESP_PD_DOMAIN_RTC_PERIPH, ESP_PD_OPTION_AUTO);
+    if (err != ESP_OK) {
+      ESP_LOGE(TAG, "esp_sleep_pd_config failed: %s", esp_err_to_name(err));
+      return;
+    }
   }
 #endif
 

--- a/esphome/components/deep_sleep/deep_sleep_esp32.cpp
+++ b/esphome/components/deep_sleep/deep_sleep_esp32.cpp
@@ -77,6 +77,12 @@ void DeepSleepComponent::deep_sleep_() {
     ESP_LOGE(TAG, "esp_sleep_disable_ext1_wakeup_io failed: %s", esp_err_to_name(err));
     return;
   }
+  // Reset all wakeup source configuration
+  err = esp_sleep_disable_wakeup_source(ESP_SLEEP_WAKEUP_ALL);
+  if (err != ESP_OK) {
+    ESP_LOGE(TAG, "esp_sleep_disable_wakeup_source failed: %s", esp_err_to_name(err));
+    return;
+  }
 #if !defined(USE_ESP32_VARIANT_ESP32C3) && !defined(USE_ESP32_VARIANT_ESP32C6) && !defined(USE_ESP32_VARIANT_ESP32H2)
   if (this->sleep_duration_.has_value())
     err = esp_sleep_enable_timer_wakeup(*this->sleep_duration_);


### PR DESCRIPTION
# What does this implement/fix?

Ensure expected behavior by disabling all configuration before applying the current configuration. Done for the IO configuration and the wake up sources configuration.

Also do error checking for all sleep functions.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

n/a

## Test Environment

- [X] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
deep_sleep:
  run_duration: 10s
  sleep_duration: 10min
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
