### PR TITLE
[helpers] Fix ``format_hex_pretty`` resize without separator

### DIFF
--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -263,7 +263,7 @@ std::string format_hex_pretty(const uint8_t *data, size_t length, char separator
     return "";
   std::string ret;
   uint8_t multiple = separator ? 3 : 2;  // 3 if separator is not \0, 2 otherwise
-  ret.resize(multiple * length - 1);
+  ret.resize(multiple * length - (separator ? 1 : 0));
   for (size_t i = 0; i < length; i++) {
     ret[multiple * i] = format_hex_pretty_char((data[i] & 0xF0) >> 4);
     ret[multiple * i + 1] = format_hex_pretty_char(data[i] & 0x0F);
@@ -283,7 +283,7 @@ std::string format_hex_pretty(const uint16_t *data, size_t length, char separato
     return "";
   std::string ret;
   uint8_t multiple = separator ? 5 : 4;  // 5 if separator is not \0, 4 otherwise
-  ret.resize(multiple * length - 1);
+  ret.resize(multiple * length - (separator ? 1 : 0));
   for (size_t i = 0; i < length; i++) {
     ret[multiple * i] = format_hex_pretty_char((data[i] & 0xF000) >> 12);
     ret[multiple * i + 1] = format_hex_pretty_char((data[i] & 0x0F00) >> 8);
@@ -304,7 +304,7 @@ std::string format_hex_pretty(const std::string &data, char separator, bool show
     return "";
   std::string ret;
   uint8_t multiple = separator ? 3 : 2;  // 3 if separator is not \0, 2 otherwise
-  ret.resize(multiple * data.length() - 1);
+  ret.resize(multiple * data.length() - (separator ? 1 : 0));
   for (size_t i = 0; i < data.length(); i++) {
     ret[multiple * i] = format_hex_pretty_char((data[i] & 0xF0) >> 4);
     ret[multiple * i + 1] = format_hex_pretty_char(data[i] & 0x0F);


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Patch pulled from #9375

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
