### PR TITLE
Sync api.proto from aioesphomeapi

### DIFF
--- a/esphome/components/api/api.proto
+++ b/esphome/components/api/api.proto
@@ -374,6 +374,7 @@ message CoverCommandRequest {
   option (source) = SOURCE_CLIENT;
   option (ifdef) = "USE_COVER";
   option (no_delay) = true;
+  option (base_class) = "CommandProtoMessage";
 
   fixed32 key = 1;
 
@@ -387,6 +388,7 @@ message CoverCommandRequest {
   bool has_tilt = 6;
   float tilt = 7;
   bool stop = 8;
+  uint32 device_id = 9;
 }
 
 // ==================== FAN ====================
@@ -441,6 +443,7 @@ message FanCommandRequest {
   option (source) = SOURCE_CLIENT;
   option (ifdef) = "USE_FAN";
   option (no_delay) = true;
+  option (base_class) = "CommandProtoMessage";
 
   fixed32 key = 1;
   bool has_state = 2;
@@ -455,6 +458,7 @@ message FanCommandRequest {
   int32 speed_level = 11;
   bool has_preset_mode = 12;
   string preset_mode = 13;
+  uint32 device_id = 14;
 }
 
 // ==================== LIGHT ====================
@@ -523,6 +527,7 @@ message LightCommandRequest {
   option (source) = SOURCE_CLIENT;
   option (ifdef) = "USE_LIGHT";
   option (no_delay) = true;
+  option (base_class) = "CommandProtoMessage";
 
   fixed32 key = 1;
   bool has_state = 2;
@@ -551,6 +556,7 @@ message LightCommandRequest {
   uint32 flash_length = 17;
   bool has_effect = 18;
   string effect = 19;
+  uint32 device_id = 28;
 }
 
 // ==================== SENSOR ====================
@@ -640,9 +646,11 @@ message SwitchCommandRequest {
   option (source) = SOURCE_CLIENT;
   option (ifdef) = "USE_SWITCH";
   option (no_delay) = true;
+  option (base_class) = "CommandProtoMessage";
 
   fixed32 key = 1;
   bool state = 2;
+  uint32 device_id = 3;
 }
 
 // ==================== TEXT SENSOR ====================
@@ -850,12 +858,14 @@ message ListEntitiesCameraResponse {
 
 message CameraImageResponse {
   option (id) = 44;
+  option (base_class) = "StateResponseProtoMessage";
   option (source) = SOURCE_SERVER;
   option (ifdef) = "USE_CAMERA";
 
   fixed32 key = 1;
   bytes data = 2;
   bool done = 3;
+  uint32 device_id = 4;
 }
 message CameraImageRequest {
   option (id) = 45;
@@ -980,6 +990,7 @@ message ClimateCommandRequest {
   option (source) = SOURCE_CLIENT;
   option (ifdef) = "USE_CLIMATE";
   option (no_delay) = true;
+  option (base_class) = "CommandProtoMessage";
 
   fixed32 key = 1;
   bool has_mode = 2;
@@ -1005,6 +1016,7 @@ message ClimateCommandRequest {
   string custom_preset = 21;
   bool has_target_humidity = 22;
   float target_humidity = 23;
+  uint32 device_id = 24;
 }
 
 // ==================== NUMBER ====================
@@ -1054,9 +1066,11 @@ message NumberCommandRequest {
   option (source) = SOURCE_CLIENT;
   option (ifdef) = "USE_NUMBER";
   option (no_delay) = true;
+  option (base_class) = "CommandProtoMessage";
 
   fixed32 key = 1;
   float state = 2;
+  uint32 device_id = 3;
 }
 
 // ==================== SELECT ====================
@@ -1096,9 +1110,11 @@ message SelectCommandRequest {
   option (source) = SOURCE_CLIENT;
   option (ifdef) = "USE_SELECT";
   option (no_delay) = true;
+  option (base_class) = "CommandProtoMessage";
 
   fixed32 key = 1;
   string state = 2;
+  uint32 device_id = 3;
 }
 
 // ==================== SIREN ====================
@@ -1137,6 +1153,7 @@ message SirenCommandRequest {
   option (source) = SOURCE_CLIENT;
   option (ifdef) = "USE_SIREN";
   option (no_delay) = true;
+  option (base_class) = "CommandProtoMessage";
 
   fixed32 key = 1;
   bool has_state = 2;
@@ -1147,6 +1164,7 @@ message SirenCommandRequest {
   uint32 duration = 7;
   bool has_volume = 8;
   float volume = 9;
+  uint32 device_id = 10;
 }
 
 // ==================== LOCK ====================
@@ -1201,12 +1219,14 @@ message LockCommandRequest {
   option (source) = SOURCE_CLIENT;
   option (ifdef) = "USE_LOCK";
   option (no_delay) = true;
+  option (base_class) = "CommandProtoMessage";
   fixed32 key = 1;
   LockCommand command = 2;
 
   // Not yet implemented:
   bool has_code = 3;
   string code = 4;
+  uint32 device_id = 5;
 }
 
 // ==================== BUTTON ====================
@@ -1232,8 +1252,10 @@ message ButtonCommandRequest {
   option (source) = SOURCE_CLIENT;
   option (ifdef) = "USE_BUTTON";
   option (no_delay) = true;
+  option (base_class) = "CommandProtoMessage";
 
   fixed32 key = 1;
+  uint32 device_id = 2;
 }
 
 // ==================== MEDIA PLAYER ====================
@@ -1301,6 +1323,7 @@ message MediaPlayerCommandRequest {
   option (source) = SOURCE_CLIENT;
   option (ifdef) = "USE_MEDIA_PLAYER";
   option (no_delay) = true;
+  option (base_class) = "CommandProtoMessage";
 
   fixed32 key = 1;
 
@@ -1315,6 +1338,7 @@ message MediaPlayerCommandRequest {
 
   bool has_announcement = 8;
   bool announcement = 9;
+  uint32 device_id = 10;
 }
 
 // ==================== BLUETOOTH ====================
@@ -1843,9 +1867,11 @@ message AlarmControlPanelCommandRequest {
   option (source) = SOURCE_CLIENT;
   option (ifdef) = "USE_ALARM_CONTROL_PANEL";
   option (no_delay) = true;
+  option (base_class) = "CommandProtoMessage";
   fixed32 key = 1;
   AlarmControlPanelStateCommand command = 2;
   string code = 3;
+  uint32 device_id = 4;
 }
 
 // ===================== TEXT =====================
@@ -1892,9 +1918,11 @@ message TextCommandRequest {
   option (source) = SOURCE_CLIENT;
   option (ifdef) = "USE_TEXT";
   option (no_delay) = true;
+  option (base_class) = "CommandProtoMessage";
 
   fixed32 key = 1;
   string state = 2;
+  uint32 device_id = 3;
 }
 
 
@@ -1936,11 +1964,13 @@ message DateCommandRequest {
   option (source) = SOURCE_CLIENT;
   option (ifdef) = "USE_DATETIME_DATE";
   option (no_delay) = true;
+  option (base_class) = "CommandProtoMessage";
 
   fixed32 key = 1;
   uint32 year = 2;
   uint32 month = 3;
   uint32 day = 4;
+  uint32 device_id = 5;
 }
 
 // ==================== DATETIME TIME ====================
@@ -1981,11 +2011,13 @@ message TimeCommandRequest {
   option (source) = SOURCE_CLIENT;
   option (ifdef) = "USE_DATETIME_TIME";
   option (no_delay) = true;
+  option (base_class) = "CommandProtoMessage";
 
   fixed32 key = 1;
   uint32 hour = 2;
   uint32 minute = 3;
   uint32 second = 4;
+  uint32 device_id = 5;
 }
 
 // ==================== EVENT ====================
@@ -2065,11 +2097,13 @@ message ValveCommandRequest {
   option (source) = SOURCE_CLIENT;
   option (ifdef) = "USE_VALVE";
   option (no_delay) = true;
+  option (base_class) = "CommandProtoMessage";
 
   fixed32 key = 1;
   bool has_position = 2;
   float position = 3;
   bool stop = 4;
+  uint32 device_id = 5;
 }
 
 // ==================== DATETIME DATETIME ====================
@@ -2108,9 +2142,11 @@ message DateTimeCommandRequest {
   option (source) = SOURCE_CLIENT;
   option (ifdef) = "USE_DATETIME_DATETIME";
   option (no_delay) = true;
+  option (base_class) = "CommandProtoMessage";
 
   fixed32 key = 1;
   fixed32 epoch_seconds = 2;
+  uint32 device_id = 3;
 }
 
 // ==================== UPDATE ====================
@@ -2160,7 +2196,9 @@ message UpdateCommandRequest {
   option (source) = SOURCE_CLIENT;
   option (ifdef) = "USE_UPDATE";
   option (no_delay) = true;
+  option (base_class) = "CommandProtoMessage";
 
   fixed32 key = 1;
   UpdateCommand command = 2;
+  uint32 device_id = 3;
 }

--- a/esphome/components/api/api_pb2.cpp
+++ b/esphome/components/api/api_pb2.cpp
@@ -623,6 +623,10 @@ bool CoverCommandRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
       this->stop = value.as_bool();
       return true;
     }
+    case 9: {
+      this->device_id = value.as_uint32();
+      return true;
+    }
     default:
       return false;
   }
@@ -654,6 +658,7 @@ void CoverCommandRequest::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_bool(6, this->has_tilt);
   buffer.encode_float(7, this->tilt);
   buffer.encode_bool(8, this->stop);
+  buffer.encode_uint32(9, this->device_id);
 }
 void CoverCommandRequest::calculate_size(uint32_t &total_size) const {
   ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0, false);
@@ -664,6 +669,7 @@ void CoverCommandRequest::calculate_size(uint32_t &total_size) const {
   ProtoSize::add_bool_field(total_size, 1, this->has_tilt, false);
   ProtoSize::add_fixed_field<4>(total_size, 1, this->tilt != 0.0f, false);
   ProtoSize::add_bool_field(total_size, 1, this->stop, false);
+  ProtoSize::add_uint32_field(total_size, 1, this->device_id, false);
 }
 #endif
 #ifdef USE_FAN
@@ -889,6 +895,10 @@ bool FanCommandRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
       this->has_preset_mode = value.as_bool();
       return true;
     }
+    case 14: {
+      this->device_id = value.as_uint32();
+      return true;
+    }
     default:
       return false;
   }
@@ -927,6 +937,7 @@ void FanCommandRequest::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_int32(11, this->speed_level);
   buffer.encode_bool(12, this->has_preset_mode);
   buffer.encode_string(13, this->preset_mode);
+  buffer.encode_uint32(14, this->device_id);
 }
 void FanCommandRequest::calculate_size(uint32_t &total_size) const {
   ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0, false);
@@ -942,6 +953,7 @@ void FanCommandRequest::calculate_size(uint32_t &total_size) const {
   ProtoSize::add_int32_field(total_size, 1, this->speed_level, false);
   ProtoSize::add_bool_field(total_size, 1, this->has_preset_mode, false);
   ProtoSize::add_string_field(total_size, 1, this->preset_mode, false);
+  ProtoSize::add_uint32_field(total_size, 1, this->device_id, false);
 }
 #endif
 #ifdef USE_LIGHT
@@ -1247,6 +1259,10 @@ bool LightCommandRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
       this->has_effect = value.as_bool();
       return true;
     }
+    case 28: {
+      this->device_id = value.as_uint32();
+      return true;
+    }
     default:
       return false;
   }
@@ -1335,6 +1351,7 @@ void LightCommandRequest::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint32(17, this->flash_length);
   buffer.encode_bool(18, this->has_effect);
   buffer.encode_string(19, this->effect);
+  buffer.encode_uint32(28, this->device_id);
 }
 void LightCommandRequest::calculate_size(uint32_t &total_size) const {
   ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0, false);
@@ -1364,6 +1381,7 @@ void LightCommandRequest::calculate_size(uint32_t &total_size) const {
   ProtoSize::add_uint32_field(total_size, 2, this->flash_length, false);
   ProtoSize::add_bool_field(total_size, 2, this->has_effect, false);
   ProtoSize::add_string_field(total_size, 2, this->effect, false);
+  ProtoSize::add_uint32_field(total_size, 2, this->device_id, false);
 }
 #endif
 #ifdef USE_SENSOR
@@ -1637,6 +1655,10 @@ bool SwitchCommandRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
       this->state = value.as_bool();
       return true;
     }
+    case 3: {
+      this->device_id = value.as_uint32();
+      return true;
+    }
     default:
       return false;
   }
@@ -1654,10 +1676,12 @@ bool SwitchCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
 void SwitchCommandRequest::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_fixed32(1, this->key);
   buffer.encode_bool(2, this->state);
+  buffer.encode_uint32(3, this->device_id);
 }
 void SwitchCommandRequest::calculate_size(uint32_t &total_size) const {
   ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0, false);
   ProtoSize::add_bool_field(total_size, 1, this->state, false);
+  ProtoSize::add_uint32_field(total_size, 1, this->device_id, false);
 }
 #endif
 #ifdef USE_TEXT_SENSOR
@@ -2293,6 +2317,10 @@ bool CameraImageResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
       this->done = value.as_bool();
       return true;
     }
+    case 4: {
+      this->device_id = value.as_uint32();
+      return true;
+    }
     default:
       return false;
   }
@@ -2321,11 +2349,13 @@ void CameraImageResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_fixed32(1, this->key);
   buffer.encode_bytes(2, reinterpret_cast<const uint8_t *>(this->data.data()), this->data.size());
   buffer.encode_bool(3, this->done);
+  buffer.encode_uint32(4, this->device_id);
 }
 void CameraImageResponse::calculate_size(uint32_t &total_size) const {
   ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0, false);
   ProtoSize::add_string_field(total_size, 1, this->data, false);
   ProtoSize::add_bool_field(total_size, 1, this->done, false);
+  ProtoSize::add_uint32_field(total_size, 1, this->device_id, false);
 }
 bool CameraImageRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
@@ -2749,6 +2779,10 @@ bool ClimateCommandRequest::decode_varint(uint32_t field_id, ProtoVarInt value) 
       this->has_target_humidity = value.as_bool();
       return true;
     }
+    case 24: {
+      this->device_id = value.as_uint32();
+      return true;
+    }
     default:
       return false;
   }
@@ -2817,6 +2851,7 @@ void ClimateCommandRequest::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_string(21, this->custom_preset);
   buffer.encode_bool(22, this->has_target_humidity);
   buffer.encode_float(23, this->target_humidity);
+  buffer.encode_uint32(24, this->device_id);
 }
 void ClimateCommandRequest::calculate_size(uint32_t &total_size) const {
   ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0, false);
@@ -2842,6 +2877,7 @@ void ClimateCommandRequest::calculate_size(uint32_t &total_size) const {
   ProtoSize::add_string_field(total_size, 2, this->custom_preset, false);
   ProtoSize::add_bool_field(total_size, 2, this->has_target_humidity, false);
   ProtoSize::add_fixed_field<4>(total_size, 2, this->target_humidity != 0.0f, false);
+  ProtoSize::add_uint32_field(total_size, 2, this->device_id, false);
 }
 #endif
 #ifdef USE_NUMBER
@@ -2991,6 +3027,16 @@ void NumberStateResponse::calculate_size(uint32_t &total_size) const {
   ProtoSize::add_bool_field(total_size, 1, this->missing_state, false);
   ProtoSize::add_uint32_field(total_size, 1, this->device_id, false);
 }
+bool NumberCommandRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 3: {
+      this->device_id = value.as_uint32();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
 bool NumberCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
   switch (field_id) {
     case 1: {
@@ -3008,10 +3054,12 @@ bool NumberCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
 void NumberCommandRequest::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_fixed32(1, this->key);
   buffer.encode_float(2, this->state);
+  buffer.encode_uint32(3, this->device_id);
 }
 void NumberCommandRequest::calculate_size(uint32_t &total_size) const {
   ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0, false);
   ProtoSize::add_fixed_field<4>(total_size, 1, this->state != 0.0f, false);
+  ProtoSize::add_uint32_field(total_size, 1, this->device_id, false);
 }
 #endif
 #ifdef USE_SELECT
@@ -3143,6 +3191,16 @@ void SelectStateResponse::calculate_size(uint32_t &total_size) const {
   ProtoSize::add_bool_field(total_size, 1, this->missing_state, false);
   ProtoSize::add_uint32_field(total_size, 1, this->device_id, false);
 }
+bool SelectCommandRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 3: {
+      this->device_id = value.as_uint32();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
 bool SelectCommandRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 2: {
@@ -3166,10 +3224,12 @@ bool SelectCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
 void SelectCommandRequest::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_fixed32(1, this->key);
   buffer.encode_string(2, this->state);
+  buffer.encode_uint32(3, this->device_id);
 }
 void SelectCommandRequest::calculate_size(uint32_t &total_size) const {
   ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0, false);
   ProtoSize::add_string_field(total_size, 1, this->state, false);
+  ProtoSize::add_uint32_field(total_size, 1, this->device_id, false);
 }
 #endif
 #ifdef USE_SIREN
@@ -3327,6 +3387,10 @@ bool SirenCommandRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
       this->has_volume = value.as_bool();
       return true;
     }
+    case 10: {
+      this->device_id = value.as_uint32();
+      return true;
+    }
     default:
       return false;
   }
@@ -3365,6 +3429,7 @@ void SirenCommandRequest::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint32(7, this->duration);
   buffer.encode_bool(8, this->has_volume);
   buffer.encode_float(9, this->volume);
+  buffer.encode_uint32(10, this->device_id);
 }
 void SirenCommandRequest::calculate_size(uint32_t &total_size) const {
   ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0, false);
@@ -3376,6 +3441,7 @@ void SirenCommandRequest::calculate_size(uint32_t &total_size) const {
   ProtoSize::add_uint32_field(total_size, 1, this->duration, false);
   ProtoSize::add_bool_field(total_size, 1, this->has_volume, false);
   ProtoSize::add_fixed_field<4>(total_size, 1, this->volume != 0.0f, false);
+  ProtoSize::add_uint32_field(total_size, 1, this->device_id, false);
 }
 #endif
 #ifdef USE_LOCK
@@ -3517,6 +3583,10 @@ bool LockCommandRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
       this->has_code = value.as_bool();
       return true;
     }
+    case 5: {
+      this->device_id = value.as_uint32();
+      return true;
+    }
     default:
       return false;
   }
@@ -3546,12 +3616,14 @@ void LockCommandRequest::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_enum<enums::LockCommand>(2, this->command);
   buffer.encode_bool(3, this->has_code);
   buffer.encode_string(4, this->code);
+  buffer.encode_uint32(5, this->device_id);
 }
 void LockCommandRequest::calculate_size(uint32_t &total_size) const {
   ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0, false);
   ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->command), false);
   ProtoSize::add_bool_field(total_size, 1, this->has_code, false);
   ProtoSize::add_string_field(total_size, 1, this->code, false);
+  ProtoSize::add_uint32_field(total_size, 1, this->device_id, false);
 }
 #endif
 #ifdef USE_BUTTON
@@ -3631,6 +3703,16 @@ void ListEntitiesButtonResponse::calculate_size(uint32_t &total_size) const {
   ProtoSize::add_string_field(total_size, 1, this->device_class, false);
   ProtoSize::add_uint32_field(total_size, 1, this->device_id, false);
 }
+bool ButtonCommandRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 2: {
+      this->device_id = value.as_uint32();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
 bool ButtonCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
   switch (field_id) {
     case 1: {
@@ -3641,9 +3723,13 @@ bool ButtonCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
       return false;
   }
 }
-void ButtonCommandRequest::encode(ProtoWriteBuffer buffer) const { buffer.encode_fixed32(1, this->key); }
+void ButtonCommandRequest::encode(ProtoWriteBuffer buffer) const {
+  buffer.encode_fixed32(1, this->key);
+  buffer.encode_uint32(2, this->device_id);
+}
 void ButtonCommandRequest::calculate_size(uint32_t &total_size) const {
   ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0, false);
+  ProtoSize::add_uint32_field(total_size, 1, this->device_id, false);
 }
 #endif
 #ifdef USE_MEDIA_PLAYER
@@ -3849,6 +3935,10 @@ bool MediaPlayerCommandRequest::decode_varint(uint32_t field_id, ProtoVarInt val
       this->announcement = value.as_bool();
       return true;
     }
+    case 10: {
+      this->device_id = value.as_uint32();
+      return true;
+    }
     default:
       return false;
   }
@@ -3887,6 +3977,7 @@ void MediaPlayerCommandRequest::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_string(7, this->media_url);
   buffer.encode_bool(8, this->has_announcement);
   buffer.encode_bool(9, this->announcement);
+  buffer.encode_uint32(10, this->device_id);
 }
 void MediaPlayerCommandRequest::calculate_size(uint32_t &total_size) const {
   ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0, false);
@@ -3898,6 +3989,7 @@ void MediaPlayerCommandRequest::calculate_size(uint32_t &total_size) const {
   ProtoSize::add_string_field(total_size, 1, this->media_url, false);
   ProtoSize::add_bool_field(total_size, 1, this->has_announcement, false);
   ProtoSize::add_bool_field(total_size, 1, this->announcement, false);
+  ProtoSize::add_uint32_field(total_size, 1, this->device_id, false);
 }
 #endif
 #ifdef USE_BLUETOOTH_PROXY
@@ -5311,6 +5403,10 @@ bool AlarmControlPanelCommandRequest::decode_varint(uint32_t field_id, ProtoVarI
       this->command = value.as_enum<enums::AlarmControlPanelStateCommand>();
       return true;
     }
+    case 4: {
+      this->device_id = value.as_uint32();
+      return true;
+    }
     default:
       return false;
   }
@@ -5339,11 +5435,13 @@ void AlarmControlPanelCommandRequest::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_fixed32(1, this->key);
   buffer.encode_enum<enums::AlarmControlPanelStateCommand>(2, this->command);
   buffer.encode_string(3, this->code);
+  buffer.encode_uint32(4, this->device_id);
 }
 void AlarmControlPanelCommandRequest::calculate_size(uint32_t &total_size) const {
   ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0, false);
   ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->command), false);
   ProtoSize::add_string_field(total_size, 1, this->code, false);
+  ProtoSize::add_uint32_field(total_size, 1, this->device_id, false);
 }
 #endif
 #ifdef USE_TEXT
@@ -5487,6 +5585,16 @@ void TextStateResponse::calculate_size(uint32_t &total_size) const {
   ProtoSize::add_bool_field(total_size, 1, this->missing_state, false);
   ProtoSize::add_uint32_field(total_size, 1, this->device_id, false);
 }
+bool TextCommandRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 3: {
+      this->device_id = value.as_uint32();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
 bool TextCommandRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 2: {
@@ -5510,10 +5618,12 @@ bool TextCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
 void TextCommandRequest::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_fixed32(1, this->key);
   buffer.encode_string(2, this->state);
+  buffer.encode_uint32(3, this->device_id);
 }
 void TextCommandRequest::calculate_size(uint32_t &total_size) const {
   ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0, false);
   ProtoSize::add_string_field(total_size, 1, this->state, false);
+  ProtoSize::add_uint32_field(total_size, 1, this->device_id, false);
 }
 #endif
 #ifdef USE_DATETIME_DATE
@@ -5653,6 +5763,10 @@ bool DateCommandRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
       this->day = value.as_uint32();
       return true;
     }
+    case 5: {
+      this->device_id = value.as_uint32();
+      return true;
+    }
     default:
       return false;
   }
@@ -5672,12 +5786,14 @@ void DateCommandRequest::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint32(2, this->year);
   buffer.encode_uint32(3, this->month);
   buffer.encode_uint32(4, this->day);
+  buffer.encode_uint32(5, this->device_id);
 }
 void DateCommandRequest::calculate_size(uint32_t &total_size) const {
   ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0, false);
   ProtoSize::add_uint32_field(total_size, 1, this->year, false);
   ProtoSize::add_uint32_field(total_size, 1, this->month, false);
   ProtoSize::add_uint32_field(total_size, 1, this->day, false);
+  ProtoSize::add_uint32_field(total_size, 1, this->device_id, false);
 }
 #endif
 #ifdef USE_DATETIME_TIME
@@ -5817,6 +5933,10 @@ bool TimeCommandRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
       this->second = value.as_uint32();
       return true;
     }
+    case 5: {
+      this->device_id = value.as_uint32();
+      return true;
+    }
     default:
       return false;
   }
@@ -5836,12 +5956,14 @@ void TimeCommandRequest::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint32(2, this->hour);
   buffer.encode_uint32(3, this->minute);
   buffer.encode_uint32(4, this->second);
+  buffer.encode_uint32(5, this->device_id);
 }
 void TimeCommandRequest::calculate_size(uint32_t &total_size) const {
   ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0, false);
   ProtoSize::add_uint32_field(total_size, 1, this->hour, false);
   ProtoSize::add_uint32_field(total_size, 1, this->minute, false);
   ProtoSize::add_uint32_field(total_size, 1, this->second, false);
+  ProtoSize::add_uint32_field(total_size, 1, this->device_id, false);
 }
 #endif
 #ifdef USE_EVENT
@@ -6119,6 +6241,10 @@ bool ValveCommandRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
       this->stop = value.as_bool();
       return true;
     }
+    case 5: {
+      this->device_id = value.as_uint32();
+      return true;
+    }
     default:
       return false;
   }
@@ -6142,12 +6268,14 @@ void ValveCommandRequest::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_bool(2, this->has_position);
   buffer.encode_float(3, this->position);
   buffer.encode_bool(4, this->stop);
+  buffer.encode_uint32(5, this->device_id);
 }
 void ValveCommandRequest::calculate_size(uint32_t &total_size) const {
   ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0, false);
   ProtoSize::add_bool_field(total_size, 1, this->has_position, false);
   ProtoSize::add_fixed_field<4>(total_size, 1, this->position != 0.0f, false);
   ProtoSize::add_bool_field(total_size, 1, this->stop, false);
+  ProtoSize::add_uint32_field(total_size, 1, this->device_id, false);
 }
 #endif
 #ifdef USE_DATETIME_DATETIME
@@ -6261,6 +6389,16 @@ void DateTimeStateResponse::calculate_size(uint32_t &total_size) const {
   ProtoSize::add_fixed_field<4>(total_size, 1, this->epoch_seconds != 0, false);
   ProtoSize::add_uint32_field(total_size, 1, this->device_id, false);
 }
+bool DateTimeCommandRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 3: {
+      this->device_id = value.as_uint32();
+      return true;
+    }
+    default:
+      return false;
+  }
+}
 bool DateTimeCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
   switch (field_id) {
     case 1: {
@@ -6278,10 +6416,12 @@ bool DateTimeCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
 void DateTimeCommandRequest::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_fixed32(1, this->key);
   buffer.encode_fixed32(2, this->epoch_seconds);
+  buffer.encode_uint32(3, this->device_id);
 }
 void DateTimeCommandRequest::calculate_size(uint32_t &total_size) const {
   ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0, false);
   ProtoSize::add_fixed_field<4>(total_size, 1, this->epoch_seconds != 0, false);
+  ProtoSize::add_uint32_field(total_size, 1, this->device_id, false);
 }
 #endif
 #ifdef USE_UPDATE
@@ -6455,6 +6595,10 @@ bool UpdateCommandRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
       this->command = value.as_enum<enums::UpdateCommand>();
       return true;
     }
+    case 3: {
+      this->device_id = value.as_uint32();
+      return true;
+    }
     default:
       return false;
   }
@@ -6472,10 +6616,12 @@ bool UpdateCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
 void UpdateCommandRequest::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_fixed32(1, this->key);
   buffer.encode_enum<enums::UpdateCommand>(2, this->command);
+  buffer.encode_uint32(3, this->device_id);
 }
 void UpdateCommandRequest::calculate_size(uint32_t &total_size) const {
   ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0, false);
   ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->command), false);
+  ProtoSize::add_uint32_field(total_size, 1, this->device_id, false);
 }
 #endif
 

--- a/esphome/components/api/api_pb2.h
+++ b/esphome/components/api/api_pb2.h
@@ -307,6 +307,15 @@ class StateResponseProtoMessage : public ProtoMessage {
 
  protected:
 };
+
+class CommandProtoMessage : public ProtoMessage {
+ public:
+  ~CommandProtoMessage() override = default;
+  uint32_t key{0};
+  uint32_t device_id{0};
+
+ protected:
+};
 class HelloRequest : public ProtoMessage {
  public:
   static constexpr uint16_t MESSAGE_TYPE = 1;
@@ -640,14 +649,13 @@ class CoverStateResponse : public StateResponseProtoMessage {
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
-class CoverCommandRequest : public ProtoMessage {
+class CoverCommandRequest : public CommandProtoMessage {
  public:
   static constexpr uint16_t MESSAGE_TYPE = 30;
-  static constexpr uint16_t ESTIMATED_SIZE = 25;
+  static constexpr uint16_t ESTIMATED_SIZE = 29;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "cover_command_request"; }
 #endif
-  uint32_t key{0};
   bool has_legacy_command{false};
   enums::LegacyCoverCommand legacy_command{};
   bool has_position{false};
@@ -714,14 +722,13 @@ class FanStateResponse : public StateResponseProtoMessage {
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
-class FanCommandRequest : public ProtoMessage {
+class FanCommandRequest : public CommandProtoMessage {
  public:
   static constexpr uint16_t MESSAGE_TYPE = 31;
-  static constexpr uint16_t ESTIMATED_SIZE = 38;
+  static constexpr uint16_t ESTIMATED_SIZE = 42;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "fan_command_request"; }
 #endif
-  uint32_t key{0};
   bool has_state{false};
   bool state{false};
   bool has_speed{false};
@@ -803,14 +810,13 @@ class LightStateResponse : public StateResponseProtoMessage {
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
-class LightCommandRequest : public ProtoMessage {
+class LightCommandRequest : public CommandProtoMessage {
  public:
   static constexpr uint16_t MESSAGE_TYPE = 32;
-  static constexpr uint16_t ESTIMATED_SIZE = 107;
+  static constexpr uint16_t ESTIMATED_SIZE = 112;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "light_command_request"; }
 #endif
-  uint32_t key{0};
   bool has_state{false};
   bool state{false};
   bool has_brightness{false};
@@ -933,14 +939,13 @@ class SwitchStateResponse : public StateResponseProtoMessage {
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
-class SwitchCommandRequest : public ProtoMessage {
+class SwitchCommandRequest : public CommandProtoMessage {
  public:
   static constexpr uint16_t MESSAGE_TYPE = 33;
-  static constexpr uint16_t ESTIMATED_SIZE = 7;
+  static constexpr uint16_t ESTIMATED_SIZE = 11;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "switch_command_request"; }
 #endif
-  uint32_t key{0};
   bool state{false};
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(uint32_t &total_size) const override;
@@ -1292,14 +1297,13 @@ class ListEntitiesCameraResponse : public InfoResponseProtoMessage {
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
-class CameraImageResponse : public ProtoMessage {
+class CameraImageResponse : public StateResponseProtoMessage {
  public:
   static constexpr uint16_t MESSAGE_TYPE = 44;
-  static constexpr uint16_t ESTIMATED_SIZE = 16;
+  static constexpr uint16_t ESTIMATED_SIZE = 20;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "camera_image_response"; }
 #endif
-  uint32_t key{0};
   std::string data{};
   bool done{false};
   void encode(ProtoWriteBuffer buffer) const override;
@@ -1401,14 +1405,13 @@ class ClimateStateResponse : public StateResponseProtoMessage {
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
-class ClimateCommandRequest : public ProtoMessage {
+class ClimateCommandRequest : public CommandProtoMessage {
  public:
   static constexpr uint16_t MESSAGE_TYPE = 48;
-  static constexpr uint16_t ESTIMATED_SIZE = 83;
+  static constexpr uint16_t ESTIMATED_SIZE = 88;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "climate_command_request"; }
 #endif
-  uint32_t key{0};
   bool has_mode{false};
   enums::ClimateMode mode{};
   bool has_target_temperature{false};
@@ -1487,14 +1490,13 @@ class NumberStateResponse : public StateResponseProtoMessage {
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
-class NumberCommandRequest : public ProtoMessage {
+class NumberCommandRequest : public CommandProtoMessage {
  public:
   static constexpr uint16_t MESSAGE_TYPE = 51;
-  static constexpr uint16_t ESTIMATED_SIZE = 10;
+  static constexpr uint16_t ESTIMATED_SIZE = 14;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "number_command_request"; }
 #endif
-  uint32_t key{0};
   float state{0.0f};
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(uint32_t &total_size) const override;
@@ -1504,6 +1506,7 @@ class NumberCommandRequest : public ProtoMessage {
 
  protected:
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
 #endif
 #ifdef USE_SELECT
@@ -1546,14 +1549,13 @@ class SelectStateResponse : public StateResponseProtoMessage {
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
-class SelectCommandRequest : public ProtoMessage {
+class SelectCommandRequest : public CommandProtoMessage {
  public:
   static constexpr uint16_t MESSAGE_TYPE = 54;
-  static constexpr uint16_t ESTIMATED_SIZE = 14;
+  static constexpr uint16_t ESTIMATED_SIZE = 18;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "select_command_request"; }
 #endif
-  uint32_t key{0};
   std::string state{};
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(uint32_t &total_size) const override;
@@ -1564,6 +1566,7 @@ class SelectCommandRequest : public ProtoMessage {
  protected:
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
 #endif
 #ifdef USE_SIREN
@@ -1606,14 +1609,13 @@ class SirenStateResponse : public StateResponseProtoMessage {
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
-class SirenCommandRequest : public ProtoMessage {
+class SirenCommandRequest : public CommandProtoMessage {
  public:
   static constexpr uint16_t MESSAGE_TYPE = 57;
-  static constexpr uint16_t ESTIMATED_SIZE = 33;
+  static constexpr uint16_t ESTIMATED_SIZE = 37;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "siren_command_request"; }
 #endif
-  uint32_t key{0};
   bool has_state{false};
   bool state{false};
   bool has_tone{false};
@@ -1675,14 +1677,13 @@ class LockStateResponse : public StateResponseProtoMessage {
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
-class LockCommandRequest : public ProtoMessage {
+class LockCommandRequest : public CommandProtoMessage {
  public:
   static constexpr uint16_t MESSAGE_TYPE = 60;
-  static constexpr uint16_t ESTIMATED_SIZE = 18;
+  static constexpr uint16_t ESTIMATED_SIZE = 22;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "lock_command_request"; }
 #endif
-  uint32_t key{0};
   enums::LockCommand command{};
   bool has_code{false};
   std::string code{};
@@ -1718,14 +1719,13 @@ class ListEntitiesButtonResponse : public InfoResponseProtoMessage {
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
-class ButtonCommandRequest : public ProtoMessage {
+class ButtonCommandRequest : public CommandProtoMessage {
  public:
   static constexpr uint16_t MESSAGE_TYPE = 62;
-  static constexpr uint16_t ESTIMATED_SIZE = 5;
+  static constexpr uint16_t ESTIMATED_SIZE = 9;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "button_command_request"; }
 #endif
-  uint32_t key{0};
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(uint32_t &total_size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
@@ -1734,6 +1734,7 @@ class ButtonCommandRequest : public ProtoMessage {
 
  protected:
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
 #endif
 #ifdef USE_MEDIA_PLAYER
@@ -1794,14 +1795,13 @@ class MediaPlayerStateResponse : public StateResponseProtoMessage {
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
-class MediaPlayerCommandRequest : public ProtoMessage {
+class MediaPlayerCommandRequest : public CommandProtoMessage {
  public:
   static constexpr uint16_t MESSAGE_TYPE = 65;
-  static constexpr uint16_t ESTIMATED_SIZE = 31;
+  static constexpr uint16_t ESTIMATED_SIZE = 35;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "media_player_command_request"; }
 #endif
-  uint32_t key{0};
   bool has_command{false};
   enums::MediaPlayerCommand command{};
   bool has_volume{false};
@@ -2669,14 +2669,13 @@ class AlarmControlPanelStateResponse : public StateResponseProtoMessage {
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
-class AlarmControlPanelCommandRequest : public ProtoMessage {
+class AlarmControlPanelCommandRequest : public CommandProtoMessage {
  public:
   static constexpr uint16_t MESSAGE_TYPE = 96;
-  static constexpr uint16_t ESTIMATED_SIZE = 16;
+  static constexpr uint16_t ESTIMATED_SIZE = 20;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "alarm_control_panel_command_request"; }
 #endif
-  uint32_t key{0};
   enums::AlarmControlPanelStateCommand command{};
   std::string code{};
   void encode(ProtoWriteBuffer buffer) const override;
@@ -2734,14 +2733,13 @@ class TextStateResponse : public StateResponseProtoMessage {
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
-class TextCommandRequest : public ProtoMessage {
+class TextCommandRequest : public CommandProtoMessage {
  public:
   static constexpr uint16_t MESSAGE_TYPE = 99;
-  static constexpr uint16_t ESTIMATED_SIZE = 14;
+  static constexpr uint16_t ESTIMATED_SIZE = 18;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "text_command_request"; }
 #endif
-  uint32_t key{0};
   std::string state{};
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(uint32_t &total_size) const override;
@@ -2752,6 +2750,7 @@ class TextCommandRequest : public ProtoMessage {
  protected:
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
 #endif
 #ifdef USE_DATETIME_DATE
@@ -2794,14 +2793,13 @@ class DateStateResponse : public StateResponseProtoMessage {
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
-class DateCommandRequest : public ProtoMessage {
+class DateCommandRequest : public CommandProtoMessage {
  public:
   static constexpr uint16_t MESSAGE_TYPE = 102;
-  static constexpr uint16_t ESTIMATED_SIZE = 17;
+  static constexpr uint16_t ESTIMATED_SIZE = 21;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "date_command_request"; }
 #endif
-  uint32_t key{0};
   uint32_t year{0};
   uint32_t month{0};
   uint32_t day{0};
@@ -2856,14 +2854,13 @@ class TimeStateResponse : public StateResponseProtoMessage {
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
-class TimeCommandRequest : public ProtoMessage {
+class TimeCommandRequest : public CommandProtoMessage {
  public:
   static constexpr uint16_t MESSAGE_TYPE = 105;
-  static constexpr uint16_t ESTIMATED_SIZE = 17;
+  static constexpr uint16_t ESTIMATED_SIZE = 21;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "time_command_request"; }
 #endif
-  uint32_t key{0};
   uint32_t hour{0};
   uint32_t minute{0};
   uint32_t second{0};
@@ -2961,14 +2958,13 @@ class ValveStateResponse : public StateResponseProtoMessage {
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
-class ValveCommandRequest : public ProtoMessage {
+class ValveCommandRequest : public CommandProtoMessage {
  public:
   static constexpr uint16_t MESSAGE_TYPE = 111;
-  static constexpr uint16_t ESTIMATED_SIZE = 14;
+  static constexpr uint16_t ESTIMATED_SIZE = 18;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "valve_command_request"; }
 #endif
-  uint32_t key{0};
   bool has_position{false};
   float position{0.0f};
   bool stop{false};
@@ -3021,14 +3017,13 @@ class DateTimeStateResponse : public StateResponseProtoMessage {
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
-class DateTimeCommandRequest : public ProtoMessage {
+class DateTimeCommandRequest : public CommandProtoMessage {
  public:
   static constexpr uint16_t MESSAGE_TYPE = 114;
-  static constexpr uint16_t ESTIMATED_SIZE = 10;
+  static constexpr uint16_t ESTIMATED_SIZE = 14;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "date_time_command_request"; }
 #endif
-  uint32_t key{0};
   uint32_t epoch_seconds{0};
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(uint32_t &total_size) const override;
@@ -3038,6 +3033,7 @@ class DateTimeCommandRequest : public ProtoMessage {
 
  protected:
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
 #endif
 #ifdef USE_UPDATE
@@ -3087,14 +3083,13 @@ class UpdateStateResponse : public StateResponseProtoMessage {
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
-class UpdateCommandRequest : public ProtoMessage {
+class UpdateCommandRequest : public CommandProtoMessage {
  public:
   static constexpr uint16_t MESSAGE_TYPE = 118;
-  static constexpr uint16_t ESTIMATED_SIZE = 7;
+  static constexpr uint16_t ESTIMATED_SIZE = 11;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "update_command_request"; }
 #endif
-  uint32_t key{0};
   enums::UpdateCommand command{};
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(uint32_t &total_size) const override;

--- a/esphome/components/api/api_pb2_dump.cpp
+++ b/esphome/components/api/api_pb2_dump.cpp
@@ -986,6 +986,11 @@ void CoverCommandRequest::dump_to(std::string &out) const {
   out.append("  stop: ");
   out.append(YESNO(this->stop));
   out.append("\n");
+
+  out.append("  device_id: ");
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
+  out.append(buffer);
+  out.append("\n");
   out.append("}");
 }
 #endif
@@ -1145,6 +1150,11 @@ void FanCommandRequest::dump_to(std::string &out) const {
 
   out.append("  preset_mode: ");
   out.append("'").append(this->preset_mode).append("'");
+  out.append("\n");
+
+  out.append("  device_id: ");
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
+  out.append(buffer);
   out.append("\n");
   out.append("}");
 }
@@ -1419,6 +1429,11 @@ void LightCommandRequest::dump_to(std::string &out) const {
   out.append("  effect: ");
   out.append("'").append(this->effect).append("'");
   out.append("\n");
+
+  out.append("  device_id: ");
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
+  out.append(buffer);
+  out.append("\n");
   out.append("}");
 }
 #endif
@@ -1585,6 +1600,11 @@ void SwitchCommandRequest::dump_to(std::string &out) const {
 
   out.append("  state: ");
   out.append(YESNO(this->state));
+  out.append("\n");
+
+  out.append("  device_id: ");
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
+  out.append(buffer);
   out.append("\n");
   out.append("}");
 }
@@ -1944,6 +1964,11 @@ void CameraImageResponse::dump_to(std::string &out) const {
   out.append("  done: ");
   out.append(YESNO(this->done));
   out.append("\n");
+
+  out.append("  device_id: ");
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
+  out.append(buffer);
+  out.append("\n");
   out.append("}");
 }
 void CameraImageRequest::dump_to(std::string &out) const {
@@ -2263,6 +2288,11 @@ void ClimateCommandRequest::dump_to(std::string &out) const {
   snprintf(buffer, sizeof(buffer), "%g", this->target_humidity);
   out.append(buffer);
   out.append("\n");
+
+  out.append("  device_id: ");
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
+  out.append(buffer);
+  out.append("\n");
   out.append("}");
 }
 #endif
@@ -2367,6 +2397,11 @@ void NumberCommandRequest::dump_to(std::string &out) const {
   snprintf(buffer, sizeof(buffer), "%g", this->state);
   out.append(buffer);
   out.append("\n");
+
+  out.append("  device_id: ");
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
+  out.append(buffer);
+  out.append("\n");
   out.append("}");
 }
 #endif
@@ -2447,6 +2482,11 @@ void SelectCommandRequest::dump_to(std::string &out) const {
 
   out.append("  state: ");
   out.append("'").append(this->state).append("'");
+  out.append("\n");
+
+  out.append("  device_id: ");
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
+  out.append(buffer);
   out.append("\n");
   out.append("}");
 }
@@ -2563,6 +2603,11 @@ void SirenCommandRequest::dump_to(std::string &out) const {
   snprintf(buffer, sizeof(buffer), "%g", this->volume);
   out.append(buffer);
   out.append("\n");
+
+  out.append("  device_id: ");
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
+  out.append(buffer);
+  out.append("\n");
   out.append("}");
 }
 #endif
@@ -2658,6 +2703,11 @@ void LockCommandRequest::dump_to(std::string &out) const {
   out.append("  code: ");
   out.append("'").append(this->code).append("'");
   out.append("\n");
+
+  out.append("  device_id: ");
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
+  out.append(buffer);
+  out.append("\n");
   out.append("}");
 }
 #endif
@@ -2709,6 +2759,11 @@ void ButtonCommandRequest::dump_to(std::string &out) const {
   out.append("ButtonCommandRequest {\n");
   out.append("  key: ");
   snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  device_id: ");
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
   out.append(buffer);
   out.append("\n");
   out.append("}");
@@ -2856,6 +2911,11 @@ void MediaPlayerCommandRequest::dump_to(std::string &out) const {
 
   out.append("  announcement: ");
   out.append(YESNO(this->announcement));
+  out.append("\n");
+
+  out.append("  device_id: ");
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
+  out.append(buffer);
   out.append("\n");
   out.append("}");
 }
@@ -3682,6 +3742,11 @@ void AlarmControlPanelCommandRequest::dump_to(std::string &out) const {
   out.append("  code: ");
   out.append("'").append(this->code).append("'");
   out.append("\n");
+
+  out.append("  device_id: ");
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
+  out.append(buffer);
+  out.append("\n");
   out.append("}");
 }
 #endif
@@ -3774,6 +3839,11 @@ void TextCommandRequest::dump_to(std::string &out) const {
 
   out.append("  state: ");
   out.append("'").append(this->state).append("'");
+  out.append("\n");
+
+  out.append("  device_id: ");
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
+  out.append(buffer);
   out.append("\n");
   out.append("}");
 }
@@ -3872,6 +3942,11 @@ void DateCommandRequest::dump_to(std::string &out) const {
   snprintf(buffer, sizeof(buffer), "%" PRIu32, this->day);
   out.append(buffer);
   out.append("\n");
+
+  out.append("  device_id: ");
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
+  out.append(buffer);
+  out.append("\n");
   out.append("}");
 }
 #endif
@@ -3967,6 +4042,11 @@ void TimeCommandRequest::dump_to(std::string &out) const {
 
   out.append("  second: ");
   snprintf(buffer, sizeof(buffer), "%" PRIu32, this->second);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  device_id: ");
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
   out.append(buffer);
   out.append("\n");
   out.append("}");
@@ -4138,6 +4218,11 @@ void ValveCommandRequest::dump_to(std::string &out) const {
   out.append("  stop: ");
   out.append(YESNO(this->stop));
   out.append("\n");
+
+  out.append("  device_id: ");
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
+  out.append(buffer);
+  out.append("\n");
   out.append("}");
 }
 #endif
@@ -4213,6 +4298,11 @@ void DateTimeCommandRequest::dump_to(std::string &out) const {
 
   out.append("  epoch_seconds: ");
   snprintf(buffer, sizeof(buffer), "%" PRIu32, this->epoch_seconds);
+  out.append(buffer);
+  out.append("\n");
+
+  out.append("  device_id: ");
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
   out.append(buffer);
   out.append("\n");
   out.append("}");
@@ -4322,6 +4412,11 @@ void UpdateCommandRequest::dump_to(std::string &out) const {
 
   out.append("  command: ");
   out.append(proto_enum_to_string<enums::UpdateCommand>(this->command));
+  out.append("\n");
+
+  out.append("  device_id: ");
+  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
+  out.append(buffer);
   out.append("\n");
   out.append("}");
 }


### PR DESCRIPTION


# What does this implement/fix?

Updates the api.proto to match 34.2.0

The new fields are not used yet for command responses

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
