### PR TITLE
[deep_sleep] enable sleep pull up/down for wakeup pin

### DIFF
--- a/esphome/components/deep_sleep/deep_sleep_esp32.cpp
+++ b/esphome/components/deep_sleep/deep_sleep_esp32.cpp
@@ -1,4 +1,5 @@
 #ifdef USE_ESP32
+#include "driver/gpio.h"
 #include "deep_sleep_component.h"
 #include "esphome/core/log.h"
 
@@ -74,6 +75,14 @@ void DeepSleepComponent::deep_sleep_() {
   if (this->sleep_duration_.has_value())
     esp_sleep_enable_timer_wakeup(*this->sleep_duration_);
   if (this->wakeup_pin_ != nullptr) {
+    if (this->wakeup_pin_->get_flags() & gpio::FLAG_PULLUP) {
+      gpio_sleep_set_pull_mode(gpio_num_t(this->wakeup_pin_->get_pin()), GPIO_PULLUP_ONLY);
+    } else if (this->wakeup_pin_->get_flags() & gpio::FLAG_PULLDOWN) {
+      gpio_sleep_set_pull_mode(gpio_num_t(this->wakeup_pin_->get_pin()), GPIO_PULLDOWN_ONLY);
+    }
+    gpio_sleep_set_direction(gpio_num_t(this->wakeup_pin_->get_pin()), GPIO_MODE_INPUT);
+    gpio_hold_en(gpio_num_t(this->wakeup_pin_->get_pin()));
+    gpio_deep_sleep_hold_en();
     bool level = !this->wakeup_pin_->is_inverted();
     if (this->wakeup_pin_mode_ == WAKEUP_PIN_MODE_INVERT_WAKEUP && this->wakeup_pin_->digital_read()) {
       level = !level;
@@ -102,6 +111,14 @@ void DeepSleepComponent::deep_sleep_() {
   if (this->sleep_duration_.has_value())
     esp_sleep_enable_timer_wakeup(*this->sleep_duration_);
   if (this->wakeup_pin_ != nullptr) {
+    if (this->wakeup_pin_->get_flags() && gpio::FLAG_PULLUP) {
+      gpio_sleep_set_pull_mode(gpio_num_t(this->wakeup_pin_->get_pin()), GPIO_PULLUP_ONLY);
+    } else if (this->wakeup_pin_->get_flags() && gpio::FLAG_PULLDOWN) {
+      gpio_sleep_set_pull_mode(gpio_num_t(this->wakeup_pin_->get_pin()), GPIO_PULLDOWN_ONLY);
+    }
+    gpio_sleep_set_direction(gpio_num_t(this->wakeup_pin_->get_pin()), GPIO_MODE_INPUT);
+    gpio_hold_en(gpio_num_t(this->wakeup_pin_->get_pin()));
+    gpio_deep_sleep_hold_en();
     bool level = !this->wakeup_pin_->is_inverted();
     if (this->wakeup_pin_mode_ == WAKEUP_PIN_MODE_INVERT_WAKEUP && this->wakeup_pin_->digital_read()) {
       level = !level;

--- a/esphome/components/deep_sleep/deep_sleep_esp32.cpp
+++ b/esphome/components/deep_sleep/deep_sleep_esp32.cpp
@@ -75,19 +75,20 @@ void DeepSleepComponent::deep_sleep_() {
   if (this->sleep_duration_.has_value())
     esp_sleep_enable_timer_wakeup(*this->sleep_duration_);
   if (this->wakeup_pin_ != nullptr) {
+    const auto gpio_pin = gpio_num_t(this->wakeup_pin_->get_pin());
     if (this->wakeup_pin_->get_flags() & gpio::FLAG_PULLUP) {
-      gpio_sleep_set_pull_mode(gpio_num_t(this->wakeup_pin_->get_pin()), GPIO_PULLUP_ONLY);
+      gpio_sleep_set_pull_mode(gpio_pin, GPIO_PULLUP_ONLY);
     } else if (this->wakeup_pin_->get_flags() & gpio::FLAG_PULLDOWN) {
-      gpio_sleep_set_pull_mode(gpio_num_t(this->wakeup_pin_->get_pin()), GPIO_PULLDOWN_ONLY);
+      gpio_sleep_set_pull_mode(gpio_pin, GPIO_PULLDOWN_ONLY);
     }
-    gpio_sleep_set_direction(gpio_num_t(this->wakeup_pin_->get_pin()), GPIO_MODE_INPUT);
-    gpio_hold_en(gpio_num_t(this->wakeup_pin_->get_pin()));
+    gpio_sleep_set_direction(gpio_pin, GPIO_MODE_INPUT);
+    gpio_hold_en(gpio_pin);
     gpio_deep_sleep_hold_en();
     bool level = !this->wakeup_pin_->is_inverted();
     if (this->wakeup_pin_mode_ == WAKEUP_PIN_MODE_INVERT_WAKEUP && this->wakeup_pin_->digital_read()) {
       level = !level;
     }
-    esp_sleep_enable_ext0_wakeup(gpio_num_t(this->wakeup_pin_->get_pin()), level);
+    esp_sleep_enable_ext0_wakeup(gpio_pin, level);
   }
   if (this->ext1_wakeup_.has_value()) {
     esp_sleep_enable_ext1_wakeup(this->ext1_wakeup_->mask, this->ext1_wakeup_->wakeup_mode);
@@ -111,13 +112,14 @@ void DeepSleepComponent::deep_sleep_() {
   if (this->sleep_duration_.has_value())
     esp_sleep_enable_timer_wakeup(*this->sleep_duration_);
   if (this->wakeup_pin_ != nullptr) {
+    const auto gpio_pin = gpio_num_t(this->wakeup_pin_->get_pin());
     if (this->wakeup_pin_->get_flags() && gpio::FLAG_PULLUP) {
-      gpio_sleep_set_pull_mode(gpio_num_t(this->wakeup_pin_->get_pin()), GPIO_PULLUP_ONLY);
+      gpio_sleep_set_pull_mode(gpio_pin, GPIO_PULLUP_ONLY);
     } else if (this->wakeup_pin_->get_flags() && gpio::FLAG_PULLDOWN) {
-      gpio_sleep_set_pull_mode(gpio_num_t(this->wakeup_pin_->get_pin()), GPIO_PULLDOWN_ONLY);
+      gpio_sleep_set_pull_mode(gpio_pin, GPIO_PULLDOWN_ONLY);
     }
-    gpio_sleep_set_direction(gpio_num_t(this->wakeup_pin_->get_pin()), GPIO_MODE_INPUT);
-    gpio_hold_en(gpio_num_t(this->wakeup_pin_->get_pin()));
+    gpio_sleep_set_direction(gpio_pin, GPIO_MODE_INPUT);
+    gpio_hold_en(gpio_pin);
     gpio_deep_sleep_hold_en();
     bool level = !this->wakeup_pin_->is_inverted();
     if (this->wakeup_pin_mode_ == WAKEUP_PIN_MODE_INVERT_WAKEUP && this->wakeup_pin_->digital_read()) {


### PR DESCRIPTION
# What does this implement/fix?

Pull up/down configuration is not preserved during deep sleep leading to immediate wakeups.

Per https://github.com/espressif/esp-idf/issues/12183, the solution (imho, workaround - this appears to be a bug in ESP-IDF) is to configure the pull mode, direction, and enable hold for the wakeup pin and finally call  `gpio_deep_sleep_hold_en()` before entering deep sleep.

With that in place, deep sleep with wakeup pin configuration using pull up/down works as expected.

I'm confident that the hold does not need to be released.
Per the documentation at https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-reference/peripherals/gpio.html#_CPPv412gpio_hold_en10gpio_num_t

    This function works in both input and output modes, and only applicable to output-capable GPIOs. If this function is enabled: in output mode: the output level of the GPIO will be locked and can not be changed. in input mode: the input read value can still reflect the changes of the input signal.


We're doing input mode, and the value still changes, so having it held is not a problem.
I also tested it. The binary sensor I have on the same gpio as the wakeup pin continues to work as expected after a deep sleep.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/9850

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
esphome:
  name: esp32-test
  friendly_name: esp32-test
  platformio_options:
    build_flags: -DBOARD_HAS_PSRAM
    board_build.arduino.memory_type: qio_opi
    board_build.f_flash: 80000000L
    board_build.flash_mode: qio 

esp32:
  board: seeed_xiao_esp32s3
  flash_size: 8MB
  framework:
    type: esp-idf

# Enable logging
logger:

api:
  encryption:
    key: "redacted"

ota:
  - platform: esphome
    password: "redacted"

wifi:
  ssid: !secret wifi_ssid
  password: !secret wifi_password
  on_connect: 
    then:
      - delay: 30s
      - lambda: |-
          ESP_LOGD("debugging", "Wakeup cause: %d", esp_sleep_get_wakeup_cause());
      - deep_sleep.enter: deep_sleep_1

binary_sensor:
  - platform: gpio
    pin:
      number: GPIO5
      allow_other_uses: True
      mode: INPUT_PULLUP
      inverted: True
    name: Deep Sleep Disabled
    id: disable_deep_sleep
    on_release:
      then:
        - logger.log: 'Released'

deep_sleep:
  id: deep_sleep_1
  sleep_duration: 1h
  wakeup_pin:
    number: GPIO5
    allow_other_uses: true
    mode: INPUT_PULLUP
    inverted: True
  wakeup_pin_mode: KEEP_AWAKE
```

With that configuration and nothing connected to the ESP32 (no button/switch is required for this test), the device should wake 30 seconds, then sleep for an hour. With this PR, that happens. Without this PR, the device immediately wakes up after going to sleep.

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
