### PR TITLE
Fix another race in the string lifetime scheduler test

### DIFF
--- a/tests/integration/fixtures/external_components/scheduler_string_lifetime_component/string_lifetime_component.cpp
+++ b/tests/integration/fixtures/external_components/scheduler_string_lifetime_component/string_lifetime_component.cpp
@@ -23,19 +23,6 @@ void SchedulerStringLifetimeComponent::run_string_lifetime_test() {
   test_vector_reallocation();
   test_string_move_semantics();
   test_lambda_capture_lifetime();
-
-  // Schedule final check
-  this->set_timeout("final_check", 200, [this]() {
-    ESP_LOGI(TAG, "Tests passed: %d", this->tests_passed_);
-    ESP_LOGI(TAG, "Tests failed: %d", this->tests_failed_);
-
-    if (this->tests_failed_ == 0) {
-      ESP_LOGI(TAG, "SUCCESS: All string lifetime tests passed!");
-    } else {
-      ESP_LOGE(TAG, "FAILURE: %d string lifetime tests failed!", this->tests_failed_);
-    }
-    ESP_LOGI(TAG, "String lifetime tests complete");
-  });
 }
 
 void SchedulerStringLifetimeComponent::run_test1() {
@@ -69,7 +56,6 @@ void SchedulerStringLifetimeComponent::run_test5() {
 }
 
 void SchedulerStringLifetimeComponent::run_final_check() {
-  ESP_LOGI(TAG, "String lifetime tests complete");
   ESP_LOGI(TAG, "Tests passed: %d", this->tests_passed_);
   ESP_LOGI(TAG, "Tests failed: %d", this->tests_failed_);
 
@@ -78,6 +64,7 @@ void SchedulerStringLifetimeComponent::run_final_check() {
   } else {
     ESP_LOGE(TAG, "FAILURE: %d string lifetime tests failed!", this->tests_failed_);
   }
+  ESP_LOGI(TAG, "String lifetime tests complete");
 }
 
 void SchedulerStringLifetimeComponent::test_temporary_string_lifetime() {


### PR DESCRIPTION


# What does this implement/fix?

I previously fixed the one in set_timeout, but its better to simply wait for the final check instead of doing the timeout as it makes the test a lot simpler and more reliable.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
