### PR TITLE
Replace remaining instances of USE_ESP32_CAMERA with USE_CAMERA

### DIFF
--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -1920,7 +1920,7 @@ uint16_t APIConnection::get_estimated_message_size(uint16_t message_type) {
     case ListEntitiesClimateResponse::MESSAGE_TYPE:
       return ListEntitiesClimateResponse::ESTIMATED_SIZE;
 #endif
-#ifdef USE_ESP32_CAMERA
+#ifdef USE_CAMERA
     case ListEntitiesCameraResponse::MESSAGE_TYPE:
       return ListEntitiesCameraResponse::ESTIMATED_SIZE;
 #endif

--- a/esphome/components/esp32_camera/__init__.py
+++ b/esphome/components/esp32_camera/__init__.py
@@ -308,7 +308,7 @@ async def to_code(config):
     cg.add(var.set_frame_buffer_count(config[CONF_FRAME_BUFFER_COUNT]))
     cg.add(var.set_frame_size(config[CONF_RESOLUTION]))
 
-    cg.add_define("USE_ESP32_CAMERA")
+    cg.add_define("USE_CAMERA")
 
     if CORE.using_esp_idf:
         add_idf_component(name="espressif/esp32-camera", ref="2.0.15")


### PR DESCRIPTION
# What does this implement/fix?

This PR updates remaining instances of the deprecated USE_ESP32_CAMERA macro to USE_CAMERA.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes #9285

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [X] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
