### PR TITLE
Exclude internal entities from name uniqueness validation

### DIFF
--- a/esphome/core/entity_helpers.py
+++ b/esphome/core/entity_helpers.py
@@ -187,6 +187,12 @@ def entity_duplicate_validator(platform: str) -> Callable[[ConfigType], ConfigTy
             # No name to validate
             return config
 
+        # Skip validation for internal entities
+        # Internal entities are not exposed to Home Assistant and don't use the hash-based
+        # entity state tracking system, so name collisions don't matter for them
+        if config.get(CONF_INTERNAL, False):
+            return config
+
         # Get the entity name
         entity_name = config[CONF_NAME]
 


### PR DESCRIPTION
# What does this implement/fix?

This PR fixes an issue where internal entities were unnecessarily subjected to name uniqueness validation introduced in #9276. Internal entities are never exposed to Home Assistant and don't participate in the hash-based entity state tracking system, so enforcing unique names for them is not needed and can be problematic for components that use common names for their internal state tracking.

The change allows components to use internal entities with duplicate names (e.g., multiple components can have internal "Temperature" sensors) while still maintaining the important name uniqueness requirement for user-facing entities that are exposed to Home Assistant.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Addresses regression from #9276 where internal entities couldn't have duplicate names

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - This is a bug fix that doesn't change user-facing behavior

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

Note: This change only affects Python configuration validation and was tested via unit tests on the host platform.

## Example entry for `config.yaml`:

```yaml
# Example showing internal entities can now have duplicate names
esphome:
  name: my-device

esp32:
  board: esp32dev

# Component 1 with internal temperature sensor
custom_component_1:
  - platform: my_custom
    # This internal sensor is not exposed to HA
    internal_sensors:
      - platform: template
        name: "Temperature"
        internal: true
        lambda: return 20.0;

# Component 2 can also have internal temperature sensor with same name
custom_component_2:
  - platform: another_custom
    # This internal sensor is also not exposed to HA
    internal_sensors:
      - platform: template
        name: "Temperature"  # Same name is OK for internal entities
        internal: true
        lambda: return 25.0;

# But user-facing entities still need unique names
sensor:
  - platform: template
    name: "Living Room Temperature"
    lambda: return 22.0;
    
  # This would still fail validation (duplicate non-internal name)
  # - platform: template
  #   name: "Living Room Temperature"
  #   lambda: return 23.0;
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).