### PR TITLE
Fix PlatformIO cache in CI by adding platformio.ini hash to cache key

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -349,28 +349,14 @@ jobs:
         uses: actions/cache@v4.2.3
         with:
           path: ~/.platformio
-          key: platformio-${{ matrix.pio_cache_key }}
+          key: platformio-${{ matrix.pio_cache_key }}-${{ hashFiles('platformio.ini') }}
 
       - name: Cache platformio
         if: github.ref != 'refs/heads/dev'
         uses: actions/cache/restore@v4.2.3
         with:
           path: ~/.platformio
-          key: platformio-${{ matrix.pio_cache_key }}
-
-      - name: Cache platformio libdeps
-        if: github.ref == 'refs/heads/dev'
-        uses: actions/cache@v4.2.3
-        with:
-          path: .pio/libdeps
-          key: pio-libdeps-${{ matrix.pio_cache_key }}-${{ hashFiles('platformio.ini') }}
-
-      - name: Cache platformio libdeps
-        if: github.ref != 'refs/heads/dev'
-        uses: actions/cache/restore@v4.2.3
-        with:
-          path: .pio/libdeps
-          key: pio-libdeps-${{ matrix.pio_cache_key }}-${{ hashFiles('platformio.ini') }}
+          key: platformio-${{ matrix.pio_cache_key }}-${{ hashFiles('platformio.ini') }}
 
       - name: Register problem matchers
         run: |


### PR DESCRIPTION
# What does this implement/fix?

This PR fixes the PlatformIO cache in CI and removes the libdeps cache workaround that was added in #9396.

The root issue was that the main PlatformIO cache key `platformio-${{ matrix.pio_cache_key }}` was static, so it would always hit the exact same key and never update. This caused "cache hit occurred on the primary key" messages and prevented the cache from being saved with new content.

In #9396, a separate libdeps cache was added as a workaround for this broken cache. However, this libdeps cache didn't work either because it was trying to cache `.pio/libdeps` (the default location) while the workflow sets `PLATFORMIO_LIBDEPS_DIR=~/.platformio/libdeps` to store libraries in a different location. This caused "Path Validation Error: Path(s) specified in the action for caching do(es) not exist" warnings.

The correct fix is to make the main cache key dynamic by adding the platformio.ini file hash. This allows the cache to properly update whenever dependencies change, and since libdeps are stored within `~/.platformio/libdeps`, they're already included in the main platformio cache.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Fixes the PlatformIO cache issue introduced in #9396

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

This is a CI-only change that affects all platforms.

## Example entry for `config.yaml`:

```yaml
# N/A - This is a CI infrastructure change
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).