### PR TITLE
Implement shared PlatformIO cache for integration tests 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -257,7 +257,7 @@ jobs:
       - name: Run integration tests
         run: |
           . venv/bin/activate
-          pytest -vvvs --no-cov --tb=native -n auto tests/integration/
+          pytest -vv --no-cov --tb=native -n auto tests/integration/
 
   clang-format:
     name: Check clang-format

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -257,7 +257,7 @@ jobs:
       - name: Run integration tests
         run: |
           . venv/bin/activate
-          pytest -vv --no-cov --tb=native -n auto tests/integration/
+          pytest -vvvs --no-cov --tb=native -n auto tests/integration/
 
   clang-format:
     name: Check clang-format

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -64,22 +64,20 @@ def shared_platformio_cache() -> Generator[Path]:
     # The lock file must be in a directory that already exists to avoid race conditions
     lock_file = Path.home() / "esphome_integration_test_init.lock"
 
-    # Check if cache needs initialization
-    if not cache_dir.exists() or not any(cache_dir.iterdir()):
-        # Acquire exclusive lock to prevent multiple processes from initializing
-        with open(lock_file, "w") as lock_fd:
-            fcntl.flock(lock_fd.fileno(), fcntl.LOCK_EX)
+    # Always acquire the lock to ensure cache is ready before proceeding
+    with open(lock_file, "w") as lock_fd:
+        fcntl.flock(lock_fd.fileno(), fcntl.LOCK_EX)
 
-            # Double-check after acquiring lock (another process might have initialized)
-            if not cache_dir.exists() or not any(cache_dir.iterdir()):
-                # Create the test cache directory if it doesn't exist
-                test_cache_dir.mkdir(exist_ok=True)
+        # Check if cache needs initialization while holding the lock
+        if not cache_dir.exists() or not any(cache_dir.iterdir()):
+            # Create the test cache directory if it doesn't exist
+            test_cache_dir.mkdir(exist_ok=True)
 
-                with tempfile.TemporaryDirectory() as tmpdir:
-                    # Create a basic host config
-                    init_dir = Path(tmpdir)
-                    config_path = init_dir / "cache_init.yaml"
-                    config_path.write_text("""esphome:
+            with tempfile.TemporaryDirectory() as tmpdir:
+                # Create a basic host config
+                init_dir = Path(tmpdir)
+                config_path = init_dir / "cache_init.yaml"
+                config_path.write_text("""esphome:
   name: cache-init
 host:
 api:
@@ -88,21 +86,23 @@ api:
 logger:
 """)
 
-                    # Run compilation to populate the cache
-                    # We must succeed here to avoid race conditions where multiple
-                    # tests try to populate the same cache directory simultaneously
-                    env = os.environ.copy()
-                    env["PLATFORMIO_CORE_DIR"] = str(cache_dir)
-                    env["PLATFORMIO_CACHE_DIR"] = str(cache_dir / ".cache")
+                # Run compilation to populate the cache
+                # We must succeed here to avoid race conditions where multiple
+                # tests try to populate the same cache directory simultaneously
+                env = os.environ.copy()
+                env["PLATFORMIO_CORE_DIR"] = str(cache_dir)
+                env["PLATFORMIO_CACHE_DIR"] = str(cache_dir / ".cache")
 
-                    subprocess.run(
-                        ["esphome", "compile", str(config_path)],
-                        check=True,
-                        cwd=init_dir,
-                        env=env,
-                        capture_output=True,
-                        text=True,
-                    )
+                subprocess.run(
+                    ["esphome", "compile", str(config_path)],
+                    check=True,
+                    cwd=init_dir,
+                    env=env,
+                    capture_output=True,
+                    text=True,
+                )
+
+        # Lock is held until here, ensuring cache is fully populated before any test proceeds
 
     yield cache_dir
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 from collections.abc import AsyncGenerator, Callable, Generator
 from contextlib import AbstractAsyncContextManager, asynccontextmanager
+import fcntl
 import logging
 import os
 from pathlib import Path
@@ -54,15 +55,29 @@ import pty  # not available on Windows
 @pytest.fixture(scope="session")
 def shared_platformio_cache() -> Generator[Path]:
     """Initialize a shared PlatformIO cache for all integration tests."""
-    cache_dir = Path.home() / ".platformio"
+    # Use a dedicated directory for integration tests to avoid conflicts
+    test_cache_dir = Path.home() / ".esphome-integration-tests"
+    test_cache_dir.mkdir(exist_ok=True)
+
+    cache_dir = test_cache_dir / "platformio"
+
+    # Use a lock file to ensure only one process initializes the cache
+    # This is needed when running with pytest-xdist
+    lock_file = test_cache_dir / "platformio_init.lock"
 
     # Check if cache needs initialization
     if not cache_dir.exists() or not any(cache_dir.iterdir()):
-        with tempfile.TemporaryDirectory() as tmpdir:
-            # Create a basic host config
-            init_dir = Path(tmpdir)
-            config_path = init_dir / "cache_init.yaml"
-            config_path.write_text("""esphome:
+        # Acquire exclusive lock to prevent multiple processes from initializing
+        with open(lock_file, "w") as lock_fd:
+            fcntl.flock(lock_fd.fileno(), fcntl.LOCK_EX)
+
+            # Double-check after acquiring lock (another process might have initialized)
+            if not cache_dir.exists() or not any(cache_dir.iterdir()):
+                with tempfile.TemporaryDirectory() as tmpdir:
+                    # Create a basic host config
+                    init_dir = Path(tmpdir)
+                    config_path = init_dir / "cache_init.yaml"
+                    config_path.write_text("""esphome:
   name: cache-init
 host:
 api:
@@ -71,16 +86,21 @@ api:
 logger:
 """)
 
-            # Run compilation to populate the cache
-            # We must succeed here to avoid race conditions where multiple
-            # tests try to populate the same cache directory simultaneously
-            subprocess.run(
-                ["esphome", "compile", str(config_path)],
-                check=True,
-                cwd=init_dir,
-                capture_output=True,
-                text=True,
-            )
+                    # Run compilation to populate the cache
+                    # We must succeed here to avoid race conditions where multiple
+                    # tests try to populate the same cache directory simultaneously
+                    env = os.environ.copy()
+                    env["PLATFORMIO_CORE_DIR"] = str(cache_dir)
+                    env["PLATFORMIO_CACHE_DIR"] = str(cache_dir / ".cache")
+
+                    subprocess.run(
+                        ["esphome", "compile", str(config_path)],
+                        check=True,
+                        cwd=init_dir,
+                        env=env,
+                        capture_output=True,
+                        text=True,
+                    )
 
     yield cache_dir
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -50,6 +50,40 @@ if platform.system() == "Windows":
 import pty  # not available on Windows
 
 
+@pytest.fixture(scope="session")
+def shared_platformio_cache() -> Generator[Path]:
+    """Initialize a shared PlatformIO cache for all integration tests."""
+    cache_dir = Path.home() / ".platformio"
+
+    # Check if cache needs initialization
+    if not cache_dir.exists() or not any(cache_dir.iterdir()):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create a basic host config
+            init_dir = Path(tmpdir)
+            config_path = init_dir / "cache_init.yaml"
+            config_path.write_text("""esphome:
+  name: cache-init
+host:
+api:
+  encryption:
+    key: "IIevImVI42I0FGos5nLqFK91jrJehrgidI0ArwMLr8w="
+logger:
+""")
+
+            # Run compilation to populate the cache
+            import subprocess
+
+            subprocess.run(
+                ["esphome", "compile", str(config_path)],
+                check=False,
+                cwd=init_dir,
+                capture_output=True,
+                text=True,
+            )
+
+    yield cache_dir
+
+
 @pytest.fixture(scope="module", autouse=True)
 def enable_aioesphomeapi_debug_logging():
     """Enable debug logging for aioesphomeapi to help diagnose connection issues."""
@@ -161,22 +195,16 @@ async def write_yaml_config(
 @pytest_asyncio.fixture
 async def compile_esphome(
     integration_test_dir: Path,
+    shared_platformio_cache: Path,
 ) -> AsyncGenerator[CompileFunction]:
     """Compile an ESPHome configuration and return the binary path."""
 
     async def _compile(config_path: Path) -> Path:
-        # Create a unique PlatformIO directory for this test to avoid race conditions
-        platformio_dir = integration_test_dir / ".platformio"
-        platformio_dir.mkdir(parents=True, exist_ok=True)
-
-        # Create cache directory as well
-        platformio_cache_dir = platformio_dir / ".cache"
-        platformio_cache_dir.mkdir(parents=True, exist_ok=True)
-
-        # Set up environment with isolated PlatformIO directories
+        # Use the shared PlatformIO cache for faster compilation
+        # This avoids re-downloading dependencies for each test
         env = os.environ.copy()
-        env["PLATFORMIO_CORE_DIR"] = str(platformio_dir)
-        env["PLATFORMIO_CACHE_DIR"] = str(platformio_cache_dir)
+        env["PLATFORMIO_CORE_DIR"] = str(shared_platformio_cache)
+        env["PLATFORMIO_CACHE_DIR"] = str(shared_platformio_cache / ".cache")
 
         # Retry compilation up to 3 times if we get a segfault
         max_retries = 3

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -75,7 +75,7 @@ logger:
 
             subprocess.run(
                 ["esphome", "compile", str(config_path)],
-                check=False,
+                check=True,
                 cwd=init_dir,
                 capture_output=True,
                 text=True,

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -52,6 +52,15 @@ if platform.system() == "Windows":
 import pty  # not available on Windows
 
 
+def _get_platformio_env(cache_dir: Path) -> dict[str, str]:
+    """Get environment variables for PlatformIO with shared cache."""
+    env = os.environ.copy()
+    env["PLATFORMIO_CORE_DIR"] = str(cache_dir)
+    env["PLATFORMIO_CACHE_DIR"] = str(cache_dir / ".cache")
+    env["PLATFORMIO_LIBDEPS_DIR"] = str(cache_dir / "libdeps")
+    return env
+
+
 @pytest.fixture(scope="session")
 def shared_platformio_cache() -> Generator[Path]:
     """Initialize a shared PlatformIO cache for all integration tests."""
@@ -89,10 +98,7 @@ logger:
                 # Run compilation to populate the cache
                 # We must succeed here to avoid race conditions where multiple
                 # tests try to populate the same cache directory simultaneously
-                env = os.environ.copy()
-                env["PLATFORMIO_CORE_DIR"] = str(cache_dir)
-                env["PLATFORMIO_CACHE_DIR"] = str(cache_dir / ".cache")
-                env["PLATFORMIO_LIBDEPS_DIR"] = str(cache_dir / "libdeps")
+                env = _get_platformio_env(cache_dir)
 
                 subprocess.run(
                     ["esphome", "compile", str(config_path)],
@@ -224,11 +230,7 @@ async def compile_esphome(
     async def _compile(config_path: Path) -> Path:
         # Use the shared PlatformIO cache for faster compilation
         # This avoids re-downloading dependencies for each test
-        env = os.environ.copy()
-        env["PLATFORMIO_CORE_DIR"] = str(shared_platformio_cache)
-        env["PLATFORMIO_CACHE_DIR"] = str(shared_platformio_cache / ".cache")
-        # Also share library dependencies to avoid re-downloading noise-c and libsodium
-        env["PLATFORMIO_LIBDEPS_DIR"] = str(shared_platformio_cache / "libdeps")
+        env = _get_platformio_env(shared_platformio_cache)
 
         # Retry compilation up to 3 times if we get a segfault
         max_retries = 3

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -92,14 +92,13 @@ logger:
                 env = os.environ.copy()
                 env["PLATFORMIO_CORE_DIR"] = str(cache_dir)
                 env["PLATFORMIO_CACHE_DIR"] = str(cache_dir / ".cache")
+                env["PLATFORMIO_LIBDEPS_DIR"] = str(cache_dir / "libdeps")
 
                 subprocess.run(
                     ["esphome", "compile", str(config_path)],
                     check=True,
                     cwd=init_dir,
                     env=env,
-                    capture_output=True,
-                    text=True,
                 )
 
         # Lock is held until here, ensuring cache is fully populated before any test proceeds
@@ -228,6 +227,8 @@ async def compile_esphome(
         env = os.environ.copy()
         env["PLATFORMIO_CORE_DIR"] = str(shared_platformio_cache)
         env["PLATFORMIO_CACHE_DIR"] = str(shared_platformio_cache / ".cache")
+        # Also share library dependencies to avoid re-downloading noise-c and libsodium
+        env["PLATFORMIO_LIBDEPS_DIR"] = str(shared_platformio_cache / "libdeps")
 
         # Retry compilation up to 3 times if we get a segfault
         max_retries = 3

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -11,6 +11,7 @@ from pathlib import Path
 import platform
 import signal
 import socket
+import subprocess
 import sys
 import tempfile
 from typing import TextIO
@@ -71,8 +72,8 @@ logger:
 """)
 
             # Run compilation to populate the cache
-            import subprocess
-
+            # We must succeed here to avoid race conditions where multiple
+            # tests try to populate the same cache directory simultaneously
             subprocess.run(
                 ["esphome", "compile", str(config_path)],
                 check=True,

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -57,13 +57,12 @@ def shared_platformio_cache() -> Generator[Path]:
     """Initialize a shared PlatformIO cache for all integration tests."""
     # Use a dedicated directory for integration tests to avoid conflicts
     test_cache_dir = Path.home() / ".esphome-integration-tests"
-    test_cache_dir.mkdir(exist_ok=True)
-
     cache_dir = test_cache_dir / "platformio"
 
-    # Use a lock file to ensure only one process initializes the cache
+    # Use a lock file in the home directory to ensure only one process initializes the cache
     # This is needed when running with pytest-xdist
-    lock_file = test_cache_dir / "platformio_init.lock"
+    # The lock file must be in a directory that already exists to avoid race conditions
+    lock_file = Path.home() / "esphome_integration_test_init.lock"
 
     # Check if cache needs initialization
     if not cache_dir.exists() or not any(cache_dir.iterdir()):
@@ -73,6 +72,9 @@ def shared_platformio_cache() -> Generator[Path]:
 
             # Double-check after acquiring lock (another process might have initialized)
             if not cache_dir.exists() or not any(cache_dir.iterdir()):
+                # Create the test cache directory if it doesn't exist
+                test_cache_dir.mkdir(exist_ok=True)
+
                 with tempfile.TemporaryDirectory() as tmpdir:
                     # Create a basic host config
                     init_dir = Path(tmpdir)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -71,7 +71,7 @@ def shared_platformio_cache() -> Generator[Path]:
     # Use a lock file in the home directory to ensure only one process initializes the cache
     # This is needed when running with pytest-xdist
     # The lock file must be in a directory that already exists to avoid race conditions
-    lock_file = Path.home() / "esphome_integration_test_init.lock"
+    lock_file = Path.home() / ".esphome-integration-tests-init.lock"
 
     # Always acquire the lock to ensure cache is ready before proceeding
     with open(lock_file, "w") as lock_fd:


### PR DESCRIPTION
# What does this implement/fix?

This PR implements a shared PlatformIO cache for integration tests to avoid repeated downloads of packages, platforms, and library dependencies across test runs.

## Background

PR #9383 fixed race conditions in integration tests by giving each test its own isolated PlatformIO directory. While this solved the race condition, it had the unintended consequence of requiring each test to download its own copy of PlatformIO packages, platforms, and libraries like `noise-c` and `libsodium`.

## Implementation

This PR introduces a shared cache that all integration tests can use while maintaining proper isolation:

1. **Session-scoped fixture** (`shared_platformio_cache`) that initializes the cache once per test session
2. **Dedicated directory** (`~/.esphome-integration-tests/platformio`) to avoid conflicts with regular ESPHome usage
3. **File locking** to handle pytest-xdist parallel execution safely
4. **Environment variables** (`PLATFORMIO_CORE_DIR`, `PLATFORMIO_CACHE_DIR`, `PLATFORMIO_LIBDEPS_DIR`) to ensure all downloads are cached

## Benefits

- **Reduced network traffic**: Each package/library is only downloaded once instead of per-test
- **Improved reliability**: Fewer network requests mean fewer potential failure points
- **Better local development experience**: Significant speedup on fast machines (32% faster on M4 MacBook Pro)
- **Cleaner test output**: No repeated "Installing..." messages for every test

Note: On GitHub Actions, the time improvement is minimal as compilation time dominates on slower CPUs. The primary benefit there is reduced network usage and improved reliability.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Addresses performance regression from #9383

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A - This is an internal testing infrastructure improvement

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

Note: This change affects the integration test infrastructure for all platforms but doesn't modify platform-specific code.

## Example entry for `config.yaml`:

```yaml
# N/A - This is a test infrastructure change
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

## Additional Details

### Background:

PR #9383 fixed race conditions in integration tests by giving each test its own isolated PlatformIO directory. While this solved the race condition, it had the unintended consequence of making tests slower because each test had to download its own copy of PlatformIO packages.

### Implementation Details:

1. **Added `shared_platformio_cache` fixture** in `tests/integration/conftest.py`:
   - Session-scoped to run once per test session
   - Uses dedicated `~/.esphome-integration-tests/platformio` directory
   - Implements file locking (`fcntl.flock`) to handle pytest-xdist parallel workers
   - Lock file placed in home directory (`~/esphome_integration_test_init.lock`) to avoid race conditions
   - Every process acquires the lock before proceeding to ensure cache is ready
   - Lock is held during entire initialization process, preventing partial cache usage
   - If cache is empty, compiles a basic host configuration to populate it
   - Includes noise encryption in the initialization to cache noise-c library

2. **Modified `compile_esphome` fixture**:
   - Now accepts the `shared_platformio_cache` as a dependency
   - Sets `PLATFORMIO_CORE_DIR`, `PLATFORMIO_CACHE_DIR`, and `PLATFORMIO_LIBDEPS_DIR` environment variables
   - This ensures all PlatformIO downloads (packages, platforms, and library dependencies) are shared
   - Library dependencies like `noise-c` and `libsodium` are only downloaded once
   - Maintains test isolation for build artifacts while sharing all downloaded resources

### Performance Analysis:

The main performance gains come from:
- Avoiding repeated downloads of PlatformIO packages and platforms
- Avoiding repeated downloads of library dependencies (noise-c, libsodium)
- Sharing compiled libraries between tests
- Leveraging PlatformIO's built-in caching mechanisms

The "Core config, version changed, cleaning build files..." messages still appear but have negligible impact since each test uses a fresh temporary directory with nothing to clean.

### Why This Works:

This approach maintains the race condition fix from #9383 (each test still has its own build directory) while sharing the expensive-to-populate package cache. Key design decisions:

1. **Dedicated test directory**: Using `~/.esphome-integration-tests/platformio` prevents any interference with regular ESPHome usage
2. **Robust file locking**: 
   - Lock file in home directory avoids directory creation races
   - All processes acquire lock, not just the initializer
   - Lock held until cache is fully populated
3. **Read-only packages**: Since PlatformIO packages are read-only after download, sharing them across tests is safe and doesn't reintroduce race conditions
4. **Fail-fast on init errors**: If cache initialization fails, tests fail immediately rather than racing to populate the cach