### PR TITLE
Fix Python cache for all pytest CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,6 +224,12 @@ jobs:
         uses: codecov/codecov-action@v5.4.3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+      - name: Save Python virtual environment cache
+        if: github.ref == 'refs/heads/dev' && (matrix.os == 'windows-latest' || matrix.os == 'macOS-latest')
+        uses: actions/cache/save@v4.2.3
+        with:
+          path: venv
+          key: ${{ runner.os }}-${{ matrix.python-version }}-venv-${{ needs.common.outputs.cache-key }}
 
   integration-tests:
     name: Run integration tests


### PR DESCRIPTION
# What does this implement/fix?

Fixes Python virtual environment caching for all pytest CI jobs. Currently most Python version/OS combinations are reinstalling all packages on every run because their specific caches don't exist.

**This is especially problematic because Windows and macOS runners are much slower than Linux runners and have very limited availability. We often spend more time waiting for these runners to become available than actually running the tests. When they finally start, they waste precious minutes reinstalling packages that should have been cached.**

The CI shows these errors:
```
Cache not found for input keys: Linux-3.12.11-venv-f105076841cf7250e065bdc62c888a76e717e8c43c357a9a4b351bc64e1b2fdf
```
```
Cache not found for input keys: macOS-3.11.9-venv-f105076841cf7250e065bdc62c888a76e717e8c43c357a9a4b351bc64e1b2fdf
```
```
Cache not found for input keys: Windows-3.11.9-venv-f105076841cf7250e065bdc62c888a76e717e8c43c357a9a4b351bc64e1b2fdf
```

The root cause is that only the `common` job (which runs Python 3.10 on Ubuntu) was saving caches. All other Python version/OS combinations had no saved caches to restore.

This PR adds cache saving for all pytest jobs on the `dev` branch, following the same pattern as the PlatformIO cache fix in #9411.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Related to #9411 (similar fix for PlatformIO cache)
- Helps with CI performance issues mentioned in #9412

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

N/A - This is a CI infrastructure change

## Example entry for `config.yaml`:

N/A - This is a CI infrastructure change

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).