### PR TITLE
Fix Python cache key mismatch for all pytest jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,6 +204,7 @@ jobs:
       - name: Check out code from GitHub
         uses: actions/checkout@v4.2.2
       - name: Restore Python
+        id: restore-python
         uses: ./.github/actions/restore-python
         with:
           python-version: ${{ matrix.python-version }}
@@ -229,7 +230,7 @@ jobs:
         uses: actions/cache/save@v4.2.3
         with:
           path: venv
-          key: ${{ runner.os }}-${{ matrix.python-version }}-venv-${{ needs.common.outputs.cache-key }}
+          key: ${{ runner.os }}-${{ steps.restore-python.outputs.python-version }}-venv-${{ needs.common.outputs.cache-key }}
 
   integration-tests:
     name: Run integration tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,7 +225,7 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
       - name: Save Python virtual environment cache
-        if: github.ref == 'refs/heads/dev' && (matrix.os == 'windows-latest' || matrix.os == 'macOS-latest')
+        if: github.ref == 'refs/heads/dev'
         uses: actions/cache/save@v4.2.3
         with:
           path: venv


### PR DESCRIPTION
# What does this implement/fix?

Fixes Python virtual environment caching for all pytest CI jobs. Currently these jobs are reinstalling all Python packages on every run due to cache key mismatches and missing caches.

The CI shows errors like:
```
Cache not found for input keys: Linux-3.12.11-venv-f105076841cf7250e065bdc62c888a76e717e8c43c357a9a4b351bc64e1b2fdf
Cache not found for input keys: Windows-3.11.9-venv-f105076841cf7250e065bdc62c888a76e717e8c43c357a9a4b351bc64e1b2fdf
```

There are two issues:
1. Only the `common` job (Python 3.10 on Ubuntu) was saving caches - other Python versions had no caches
2. Cache key mismatch: The cache was saved with `Windows-3.11-venv-...` but restore was looking for `Windows-3.11.9-venv-...`

This PR:
- Extends the fix from #9415 to also save caches for all Python versions on Linux
- Fixes the cache key mismatch by using the actual Python version from `setup-python` output when saving caches

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Extends #9415 (which fixed Windows/macOS cache saving)
- Related to #9411 (similar fix for PlatformIO cache)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

N/A - This is a CI infrastructure change

## Example entry for `config.yaml`:

N/A - This is a CI infrastructure change

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
