### PR TITLE
Fix Windows virtual environment activation in CI workflows

### DIFF
--- a/.github/actions/restore-python/action.yml
+++ b/.github/actions/restore-python/action.yml
@@ -41,7 +41,7 @@ runs:
       shell: bash
       run: |
         python -m venv venv
-        ./venv/Scripts/activate
+        source ./venv/Scripts/activate
         python --version
         pip install -r requirements.txt -r requirements_test.txt
         pip install -e .

--- a/.github/actions/restore-python/action.yml
+++ b/.github/actions/restore-python/action.yml
@@ -43,5 +43,5 @@ runs:
         python -m venv venv
         source ./venv/Scripts/activate
         python --version
-        pip install -r requirements.txt -r requirements_test.txt
-        pip install -e .
+        pip install -vv -r requirements.txt -r requirements_test.txt
+        pip install -vv -e .

--- a/.github/actions/restore-python/action.yml
+++ b/.github/actions/restore-python/action.yml
@@ -43,5 +43,5 @@ runs:
         python -m venv venv
         source ./venv/Scripts/activate
         python --version
-        pip install -vv -r requirements.txt -r requirements_test.txt
-        pip install -vv -e .
+        pip install -r requirements.txt -r requirements_test.txt
+        pip install -e .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,7 +214,7 @@ jobs:
       - name: Run pytest
         if: matrix.os == 'windows-latest'
         run: |
-          ./venv/Scripts/activate
+          . ./venv/Scripts/activate.ps1
           pytest -vv --cov-report=xml --tb=native -n auto tests --ignore=tests/integration/
       - name: Run pytest
         if: matrix.os == 'ubuntu-latest' || matrix.os == 'macOS-latest'


### PR DESCRIPTION
# What does this implement/fix?

This PR fixes the Windows virtual environment activation commands in CI workflows that were previously masked by the absence of cached environments. The issue only surfaced after PR #9417 fixed the Python cache key mismatch for pytest jobs, which allowed the cache to be restored but revealed that we weren't properly activating the venv, preventing the cache from saving correctly in the first place.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Fixes pytest failures on Windows after cache restoration started working

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# N/A - CI configuration change only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

---

## Why did this only break once we fixed the cache?

The Windows venv activation issue was previously hidden because:

1. **Before PR #9417**: The Python venv cache wasn't being saved or restored properly on Windows due to the cache key mismatch. The cache would attempt to restore but find nothing, so it would always create a fresh venv.

2. **The circular problem**: 
   - The `restore-python` action would create a venv but fail to activate it properly with `./venv/Scripts/activate` in bash
   - Because the venv wasn't activated, the `pip install` commands would install to the system Python
   - The cache post-job save would then save an empty or incomplete venv directory
   - On the next run, even if the cache was "restored", it was missing the actual packages

3. **After PR #9417**: The cache keys were fixed, which meant:
   - The cache could now properly restore (even though it contained an incomplete venv)
   - The pytest job would then fail immediately when trying to run `./venv/Scripts/activate` in PowerShell
   - This exposed both issues: wrong activation command AND the fact that we'd been caching incomplete venvs

4. **The two bugs revealed**:
   - In PowerShell (pytest job): Should use `. ./venv/Scripts/activate.ps1`
   - In Git Bash (restore-python action): Should use `source ./venv/Scripts/activate`

Without proper activation, the venv was never truly being used or cached correctly, creating a cascade of hidden failures that only became visible once the cache keys were fixed.