### PR TITLE
Fix clang-tidy not finding changed files on squash-merge commits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -344,6 +344,9 @@ jobs:
     steps:
       - name: Check out code from GitHub
         uses: actions/checkout@v4.2.2
+        with:
+          # Need history for HEAD~1 to work for checking changed files
+          fetch-depth: 2
 
       - name: Restore Python
         uses: ./.github/actions/restore-python


### PR DESCRIPTION
# What does this implement/fix?

Fix clang-tidy not detecting changed files on squash-merge commits to dev branch. The CI was running with a shallow clone (depth 1), which meant `HEAD~1` was not available when trying to determine what files changed in the commit.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

This fixes the issue where clang-tidy runs on push events (including squash-merge commits) were failing to detect any changed files, resulting in no files being checked. Example: https://github.com/esphome/esphome/actions/runs/16184225830/job/45686802954

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A - CI configuration change only

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

N/A - This is a CI configuration change that affects all platforms

## Example entry for `config.yaml`:

```yaml
# N/A - CI configuration change
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
