### PR TITLE
debug: bufferoverflow mitigation in DebugComponent::on_shutdown()

### DIFF
--- a/esphome/components/debug/debug_esp32.cpp
+++ b/esphome/components/debug/debug_esp32.cpp
@@ -53,6 +53,7 @@ void DebugComponent::on_shutdown() {
   auto pref = global_preferences->make_preference(REBOOT_MAX_LEN, fnv1_hash(REBOOT_KEY + App.get_name()));
   if (component != nullptr) {
     strncpy(buffer, component->get_component_source(), REBOOT_MAX_LEN - 1);
+    buffer[REBOOT_MAX_LEN - 1] = '\0';
   }
   ESP_LOGD(TAG, "Storing reboot source: %s", buffer);
   pref.save(&buffer);
@@ -68,6 +69,7 @@ std::string DebugComponent::get_reset_reason_() {
       auto pref = global_preferences->make_preference(REBOOT_MAX_LEN, fnv1_hash(REBOOT_KEY + App.get_name()));
       char buffer[REBOOT_MAX_LEN]{};
       if (pref.load(&buffer)) {
+        buffer[REBOOT_MAX_LEN - 1] = '\0';
         reset_reason = "Reboot request from " + std::string(buffer);
       }
     }


### PR DESCRIPTION
# What does this implement/fix?

`debug_esp32.cpp` copies a component’s source string into a fixed buffer of length 24 using `strncpy`, but never guarantees a `\0` terminator when the source length exceeds 23. Later it prints the buffer with `%s`, which can read past the allocated space.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other
