### PR TITLE
Revert "Override toolchain-esp32ulp"

### DIFF
--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -732,11 +732,6 @@ async def to_code(config):
 
         cg.add_platformio_option("platform_packages", [conf[CONF_SOURCE]])
 
-        # platformio/toolchain-esp32ulp does not support linux_aarch64 yet and has not been updated for over 2 years
-        # This is espressif's own published version which is more up to date.
-        cg.add_platformio_option(
-            "platform_packages", ["espressif/toolchain-esp32ulp@2.35.0-20220830"]
-        )
         add_idf_sdkconfig_option(
             f"CONFIG_ESPTOOLPY_FLASHSIZE_{config[CONF_FLASH_SIZE]}", True
         )


### PR DESCRIPTION
# What does this implement/fix?

This reverts commit f84392530107bf8716bd8b37b52e586c272e28af.

Since the original commit the situation has reversed, the version that was hardcoded is the only version that was ever published under the "espressif" namespace, and is now substantially out of date and incompatible with the main toolchain:

https://registry.platformio.org/tools/espressif/toolchain-esp32ulp

The version in the "platformio" namespace is currently up-to-date.

https://registry.platformio.org/tools/platformio/toolchain-esp32ulp

This fixes the following error:

```
CMake Error at /home/user/.platformio/packages/framework-espidf@src-c44434145e05010467d5d5a727b42ef9/tools/cmake/tool_version_check.cmake:36 (message):
  

  Tool doesn't match supported version from list ['2.38_20240113']:
  /home/user/.platformio/packages/toolchain-esp32ulp/bin/esp32ulp-elf-as

  Please try to run 'idf.py fullclean' to solve it.

Call Stack (most recent call first):
  CMakeLists.txt:24 (check_expected_tool_version)
```

This error was encountered when trying to merge `dev` into https://github.com/esphome/esphome/pull/7548, as the default esp-idf version and platform_version have changed, causing the toolchain mismatch.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
