### PR TITLE
[packet_transport] Don't run update if ping_pong not enabled.

### DIFF
--- a/esphome/components/packet_transport/packet_transport.cpp
+++ b/esphome/components/packet_transport/packet_transport.cpp
@@ -314,6 +314,10 @@ void PacketTransport::send_data_(bool all) {
 }
 
 void PacketTransport::update() {
+  if (!this->ping_pong_enable_) {
+    this->stop_poller();
+    return;
+  }
   auto now = millis() / 1000;
   if (this->last_key_time_ + this->ping_pong_recyle_time_ < now) {
     this->resend_ping_key_ = this->ping_pong_enable_;

--- a/esphome/components/packet_transport/packet_transport.cpp
+++ b/esphome/components/packet_transport/packet_transport.cpp
@@ -315,7 +315,6 @@ void PacketTransport::send_data_(bool all) {
 
 void PacketTransport::update() {
   if (!this->ping_pong_enable_) {
-    this->stop_poller();
     return;
   }
   auto now = millis() / 1000;


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

If ping_pong is not enabled, the `packet_transport` component doesn't need to run update, so stop it.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://discord.com/channels/429907082951524364/1392912614887260251

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
