### PR TITLE
(Maybe?) fix I2S speaker internal DAC mode

### DIFF
--- a/esphome/components/i2s_audio/speaker/__init__.py
+++ b/esphome/components/i2s_audio/speaker/__init__.py
@@ -180,7 +180,7 @@ async def to_code(config):
     await speaker.register_speaker(var, config)
 
     if config[CONF_DAC_TYPE] == "internal":
-        cg.add(var.set_internal_dac_mode(config[CONF_CHANNEL]))
+        cg.add(var.set_internal_dac_mode(config[CONF_MODE]))
     else:
         cg.add(var.set_dout_pin(config[CONF_I2S_DOUT_PIN]))
         if use_legacy():


### PR DESCRIPTION
# What does this implement/fix?

Someone in [this discord thread](https://discord.com/channels/429907082951524364/1393003972792422450) was having issues with using the internal DAC for `i2s_audio/speaker`, but said it works with `i2s_audio/media_player`.

Comparing the code, it seems that in `speaker`, `set_internal_dac_mode()` is inadvertently being passed `CONF_CHANNEL` instead of `CONF_MODE`.

```diff
<         cg.add(var.set_internal_dac_mode(config[CONF_MODE]))
---
>         cg.add(var.set_internal_dac_mode(config[CONF_CHANNEL]))
```

I don't have a speaker to actually test this with, so hopefully someone else can, but I'm pretty sure this is the right fix.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
i2s_audio:
  - id: i2sout
    i2s_lrclk_pin: GPIO0

speaker:
  - platform: i2s_audio
    id: internal_speaker
    dac_type: internal
    mode: stereo
    i2s_audio_id: i2sout

output:
  - platform: esp32_dac
    pin: GPIO25
    id: dac_output
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
