### PR TITLE
[libretiny] Set lib_compat_mode to soft for libretiny

### DIFF
--- a/esphome/components/libretiny/__init__.py
+++ b/esphome/components/libretiny/__init__.py
@@ -268,7 +268,7 @@ async def component_to_code(config):
 
     # disable library compatibility checks
     cg.add_platformio_option("lib_ldf_mode", "off")
-    cg.add_platformio_option("lib_compat_mode", "strict")
+    cg.add_platformio_option("lib_compat_mode", "soft")
     # include <Arduino.h> in every file
     cg.add_platformio_option("build_src_flags", "-include Arduino.h")
     # dummy version code

--- a/platformio.ini
+++ b/platformio.ini
@@ -212,6 +212,7 @@ build_unflags =
 extends = common:arduino
 platform = libretiny@1.9.1
 framework = arduino
+lib_compat_mode = soft
 lib_deps =
     droscy/esp_wireguard@0.4.2    ; wireguard
 build_flags =


### PR DESCRIPTION
# What does this implement/fix?

Can't set strict on libretiny as its not in the platforms list of heatpumpir: https://github.com/ToniA/arduino-heatpumpir/blob/master/library.json

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [x] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
