### PR TITLE
[scheduler] Fix crash with defer

### DIFF
--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -1,13 +1,13 @@
 #include "scheduler.h"
 
+#include <algorithm>
+#include <cinttypes>
+#include <cstring>
 #include "application.h"
 #include "esphome/core/defines.h"
 #include "esphome/core/hal.h"
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
-#include <algorithm>
-#include <cinttypes>
-#include <cstring>
 
 namespace esphome {
 
@@ -86,8 +86,10 @@ void HOT Scheduler::set_timer_common_(Component *component, SchedulerItem::Type 
   // ESP8266 and RP2040 are excluded because they don't need thread-safe defer handling
   if (delay == 0 && type == SchedulerItem::TIMEOUT) {
     // Put in defer queue for guaranteed FIFO execution
-    LockGuard guard{this->lock_};
-    this->cancel_item_locked_(component, name_cstr, type);
+    if (is_name_valid_(name_cstr)) {
+      LockGuard guard{this->lock_};
+      this->cancel_item_locked_(component, name_cstr, type);
+    }
     this->defer_queue_.push_back(std::move(item));
     return;
   }


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

```
0x40034c9e: esphome::Scheduler::matches_item_(std::unique_ptr > const&, esphome::Component*, char const*, esphome::Scheduler::SchedulerItem::Type) at /home/jesse/workspace/esphome/esphome/config/.esphome/build/tab5/src/esphome/core/scheduler.h:178
...
0x40034e40: esphome::Scheduler::cancel_item_locked_(esphome::Component*, char const*, esphome::Scheduler::SchedulerItem::Type) at /home/jesse/workspace/esphome/esphome/config/.esphome/build/tab5/src/esphome/core/scheduler.cpp:473
...
0x40035478: esphome::Scheduler::set_timer_common_(esphome::Component*, esphome::Scheduler::SchedulerItem::Type, bool, void const*, unsigned long, std::function) at /home/jesse/workspace/esphome/esphome/config/.esphome/build/tab5/src/esphome/core/scheduler.cpp:91
...
0x4002c8c4: esphome::voice_assistant::VoiceAssistant::on_event(esphome::api::VoiceAssistantEventResponse const&) at /home/jesse/workspace/esphome/esphome/config/.esphome/build/tab5/src/esphome/components/voice_assistant/voice_assistant.cpp:604
...
0x40035682: esphome::Scheduler::set_timeout(esphome::Component*, char const*, unsigned long, std::function) at /home/jesse/workspace/esphome/esphome/config/.esphome/build/tab5/src/esphome/core/scheduler.cpp:138
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
