### PR TITLE
Fix scheduler crash when cancelling items with NULL names

### DIFF
--- a/esphome/core/scheduler.h
+++ b/esphome/core/scheduler.h
@@ -150,9 +150,6 @@ class Scheduler {
     return is_static_string ? static_cast<const char *>(name_ptr) : static_cast<const std::string *>(name_ptr)->c_str();
   }
 
-  // Helper to check if a name is valid (not null and not empty)
-  inline bool is_name_valid_(const char *name) { return name != nullptr && name[0] != '\0'; }
-
   // Common implementation for cancel operations
   bool cancel_item_(Component *component, bool is_static_string, const void *name_ptr, SchedulerItem::Type type);
 

--- a/tests/integration/fixtures/scheduler_null_name.yaml
+++ b/tests/integration/fixtures/scheduler_null_name.yaml
@@ -11,23 +11,33 @@ api:
     - service: test_null_name
       then:
         - lambda: |-
-            // Test 1: set_timeout with nullptr (simulating defer() behavior)
-            App.scheduler.set_timeout(nullptr, nullptr, 0, []() {
+            // First, create a scenario that would trigger the crash
+            // The crash happens when defer() is called with a name that would be cancelled
+
+            // Test 1: Create a defer with a valid name
+            App.scheduler.set_timeout(nullptr, "test_defer", 0, []() {
+              ESP_LOGI("TEST", "First defer should be cancelled");
+            });
+
+            // Test 2: Create another defer with the same name - this triggers cancel_item_locked_
+            // In the unfixed code, this would crash if the name was NULL
+            App.scheduler.set_timeout(nullptr, "test_defer", 0, []() {
+              ESP_LOGI("TEST", "Second defer executed");
+            });
+
+            // Test 3: Now test with nullptr - this is the actual crash scenario
+            // Create a defer item without a name (like voice assistant does)
+            const char* null_name = nullptr;
+            App.scheduler.set_timeout(nullptr, null_name, 0, []() {
               ESP_LOGI("TEST", "Defer with null name executed");
             });
 
-            // Test 2: Cancel with nullptr name - should not crash
-            App.scheduler.cancel_timeout(nullptr, nullptr);
-
-            // Test 3: set_interval with nullptr
-            App.scheduler.set_interval(nullptr, nullptr, 100, []() {
-              ESP_LOGI("TEST", "Interval with null name executed");
+            // Test 4: Create another defer with null name - this would trigger the crash
+            App.scheduler.set_timeout(nullptr, null_name, 0, []() {
+              ESP_LOGI("TEST", "Second null defer executed");
             });
 
-            // Test 4: Cancel interval with nullptr - should not crash
-            App.scheduler.cancel_interval(nullptr, nullptr);
-
-            // Test 5: Verify scheduler still works after null operations
+            // Test 5: Verify scheduler still works
             App.scheduler.set_timeout(nullptr, "valid_timeout", 50, []() {
               ESP_LOGI("TEST", "Test completed successfully");
             });

--- a/tests/integration/fixtures/scheduler_null_name.yaml
+++ b/tests/integration/fixtures/scheduler_null_name.yaml
@@ -1,0 +1,33 @@
+esphome:
+  name: scheduler-null-name
+
+host:
+
+logger:
+  level: DEBUG
+
+api:
+  services:
+    - service: test_null_name
+      then:
+        - lambda: |-
+            // Test 1: set_timeout with nullptr (simulating defer() behavior)
+            App.scheduler.set_timeout(nullptr, nullptr, 0, []() {
+              ESP_LOGI("TEST", "Defer with null name executed");
+            });
+
+            // Test 2: Cancel with nullptr name - should not crash
+            App.scheduler.cancel_timeout(nullptr, nullptr);
+
+            // Test 3: set_interval with nullptr
+            App.scheduler.set_interval(nullptr, nullptr, 100, []() {
+              ESP_LOGI("TEST", "Interval with null name executed");
+            });
+
+            // Test 4: Cancel interval with nullptr - should not crash
+            App.scheduler.cancel_interval(nullptr, nullptr);
+
+            // Test 5: Verify scheduler still works after null operations
+            App.scheduler.set_timeout(nullptr, "valid_timeout", 50, []() {
+              ESP_LOGI("TEST", "Test completed successfully");
+            });

--- a/tests/integration/test_scheduler_null_name.py
+++ b/tests/integration/test_scheduler_null_name.py
@@ -1,0 +1,59 @@
+"""Test that scheduler handles NULL names safely without crashing."""
+
+import asyncio
+import re
+
+import pytest
+
+from .types import APIClientConnectedFactory, RunCompiledFunction
+
+
+@pytest.mark.asyncio
+async def test_scheduler_null_name(
+    yaml_config: str,
+    run_compiled: RunCompiledFunction,
+    api_client_connected: APIClientConnectedFactory,
+) -> None:
+    """Test that scheduler handles NULL names safely without crashing."""
+
+    loop = asyncio.get_running_loop()
+    test_complete_future: asyncio.Future[bool] = loop.create_future()
+
+    # Pattern to match test completion
+    test_complete_pattern = re.compile(r"Test completed successfully")
+
+    def check_output(line: str) -> None:
+        """Check log output for test completion."""
+        if not test_complete_future.done() and test_complete_pattern.search(line):
+            test_complete_future.set_result(True)
+
+    async with run_compiled(yaml_config, line_callback=check_output):
+        async with api_client_connected() as client:
+            # Verify we can connect
+            device_info = await client.device_info()
+            assert device_info is not None
+            assert device_info.name == "scheduler-null-name"
+
+            # List services
+            _, services = await asyncio.wait_for(
+                client.list_entities_services(), timeout=5.0
+            )
+
+            # Find our test service
+            test_null_name_service = next(
+                (s for s in services if s.name == "test_null_name"), None
+            )
+            assert test_null_name_service is not None, (
+                "test_null_name service not found"
+            )
+
+            # Execute the test
+            client.execute_service(test_null_name_service, {})
+
+            # Wait for test completion
+            try:
+                await asyncio.wait_for(test_complete_future, timeout=10.0)
+            except asyncio.TimeoutError:
+                pytest.fail(
+                    "Test did not complete within timeout - likely crashed due to NULL name"
+                )


### PR DESCRIPTION
# What does this implement/fix?

This PR fixes a crash in the scheduler when `cancel_item_locked_` is called with a NULL name pointer. The crash was reported in voice assistant but could occur in any component that uses the defer queue with dynamic names.

The fix adds a NULL/empty check directly in `cancel_item_locked_` rather than requiring all callers to validate the name first. This makes the API safer and removes redundant validation code.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- replaces and closes #9441

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal implementation fix, no user-facing changes)

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - this is an internal fix
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - N/A - This is an internal fix with no user-exposed changes

## Additional Details

The crash occurred when:
1. A defer (delay=0) timeout is set with a name
2. The defer queue path calls `cancel_item_locked_` without checking if the name is valid
3. `matches_item_` calls `strcmp` with a NULL pointer, causing a segmentation fault

Stack trace from the original issue:
```
0x40034c9e: esphome::Scheduler::matches_item_(...) at scheduler.h:178
0x40034e40: esphome::Scheduler::cancel_item_locked_(...) at scheduler.cpp:473
0x40035478: esphome::Scheduler::set_timer_common_(...) at scheduler.cpp:91
0x4002c8c4: esphome::voice_assistant::VoiceAssistant::on_event(...) at voice_assistant.cpp:604
```

### Changes made:

1. **Added NULL/empty check in `cancel_item_locked_`** - This function now safely handles NULL or empty names by returning early
2. **Removed redundant `is_name_valid_` checks** - Since `cancel_item_locked_` now handles validation internally, removed all redundant checks before calling it
3. **Inlined and removed `is_name_valid_` function** - It was only used once after the refactoring
4. **Added integration test** - `test_scheduler_null_name` verifies the scheduler handles NULL names without crashing

The test confirms the fix works - without it, the test crashes with "EOF received" as the process segfaults. With the fix, all tests pass.
