### PR TITLE
Make API ConnectRequest optional for passwordless connections

### DIFF
--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -1433,9 +1433,13 @@ HelloResponse APIConnection::hello(const HelloRequest &msg) {
   resp.server_info = App.get_name() + " (esphome v" ESPHOME_VERSION ")";
   resp.name = App.get_name();
 
-  // Auto-authenticate if no password is required
+  bool needs_auth = false;
 #ifdef USE_API_PASSWORD
-  if (!this->parent_->uses_password()) {
+  needs_auth = this->parent_->uses_password();
+#endif
+
+  if (!needs_auth) {
+    // Auto-authenticate if no password is required
     this->flags_.connection_state = static_cast<uint8_t>(ConnectionState::AUTHENTICATED);
     ESP_LOGD(TAG, "%s connected (no password)", this->get_client_combined_info().c_str());
 #ifdef USE_API_CLIENT_CONNECTED_TRIGGER
@@ -1449,19 +1453,6 @@ HelloResponse APIConnection::hello(const HelloRequest &msg) {
   } else {
     this->flags_.connection_state = static_cast<uint8_t>(ConnectionState::CONNECTED);
   }
-#else
-  // No password support compiled in, always authenticate
-  this->flags_.connection_state = static_cast<uint8_t>(ConnectionState::AUTHENTICATED);
-  ESP_LOGD(TAG, "%s connected (no password)", this->get_client_combined_info().c_str());
-#ifdef USE_API_CLIENT_CONNECTED_TRIGGER
-  this->parent_->get_client_connected_trigger()->trigger(this->client_info_, this->client_peername_);
-#endif
-#ifdef USE_HOMEASSISTANT_TIME
-  if (homeassistant::global_homeassistant_time != nullptr) {
-    this->send_time_request();
-  }
-#endif
-#endif
 
   return resp;
 }

--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -1425,7 +1425,7 @@ void APIConnection::complete_authentication_() {
   }
 
   this->flags_.connection_state = static_cast<uint8_t>(ConnectionState::AUTHENTICATED);
-  ESP_LOGD(TAG, "%s connected (no password)", this->get_client_combined_info().c_str());
+  ESP_LOGD(TAG, "%s connected", this->get_client_combined_info().c_str());
 #ifdef USE_API_CLIENT_CONNECTED_TRIGGER
   this->parent_->get_client_connected_trigger()->trigger(this->client_info_, this->client_peername_);
 #endif
@@ -1471,7 +1471,6 @@ ConnectResponse APIConnection::connect(const ConnectRequest &msg) {
   // bool invalid_password = 1;
   resp.invalid_password = !correct;
   if (correct) {
-    ESP_LOGD(TAG, "%s connected", this->get_client_combined_info().c_str());
     this->complete_authentication_();
   }
   return resp;

--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -1452,14 +1452,10 @@ HelloResponse APIConnection::hello(const HelloRequest &msg) {
   resp.name = App.get_name();
 
 #ifdef USE_API_PASSWORD
-  if (!this->parent_->uses_password()) {
-    // Auto-authenticate if no password is required
-    this->complete_authentication_();
-  } else {
-    this->flags_.connection_state = static_cast<uint8_t>(ConnectionState::CONNECTED);
-  }
+  // Password required - wait for authentication
+  this->flags_.connection_state = static_cast<uint8_t>(ConnectionState::CONNECTED);
 #else
-  // No password support - always auto-authenticate
+  // No password configured - auto-authenticate
   this->complete_authentication_();
 #endif
 
@@ -1483,7 +1479,7 @@ ConnectResponse APIConnection::connect(const ConnectRequest &msg) {
 DeviceInfoResponse APIConnection::device_info(const DeviceInfoRequest &msg) {
   DeviceInfoResponse resp{};
 #ifdef USE_API_PASSWORD
-  resp.uses_password = this->parent_->uses_password();
+  resp.uses_password = true;
 #else
   resp.uses_password = false;
 #endif

--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -1433,7 +1433,36 @@ HelloResponse APIConnection::hello(const HelloRequest &msg) {
   resp.server_info = App.get_name() + " (esphome v" ESPHOME_VERSION ")";
   resp.name = App.get_name();
 
-  this->flags_.connection_state = static_cast<uint8_t>(ConnectionState::CONNECTED);
+  // Auto-authenticate if no password is required
+#ifdef USE_API_PASSWORD
+  if (!this->parent_->uses_password()) {
+    this->flags_.connection_state = static_cast<uint8_t>(ConnectionState::AUTHENTICATED);
+    ESP_LOGD(TAG, "%s connected (no password)", this->get_client_combined_info().c_str());
+#ifdef USE_API_CLIENT_CONNECTED_TRIGGER
+    this->parent_->get_client_connected_trigger()->trigger(this->client_info_, this->client_peername_);
+#endif
+#ifdef USE_HOMEASSISTANT_TIME
+    if (homeassistant::global_homeassistant_time != nullptr) {
+      this->send_time_request();
+    }
+#endif
+  } else {
+    this->flags_.connection_state = static_cast<uint8_t>(ConnectionState::CONNECTED);
+  }
+#else
+  // No password support compiled in, always authenticate
+  this->flags_.connection_state = static_cast<uint8_t>(ConnectionState::AUTHENTICATED);
+  ESP_LOGD(TAG, "%s connected (no password)", this->get_client_combined_info().c_str());
+#ifdef USE_API_CLIENT_CONNECTED_TRIGGER
+  this->parent_->get_client_connected_trigger()->trigger(this->client_info_, this->client_peername_);
+#endif
+#ifdef USE_HOMEASSISTANT_TIME
+  if (homeassistant::global_homeassistant_time != nullptr) {
+    this->send_time_request();
+  }
+#endif
+#endif
+
   return resp;
 }
 ConnectResponse APIConnection::connect(const ConnectRequest &msg) {

--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -1418,6 +1418,24 @@ bool APIConnection::try_send_log_message(int level, const char *tag, const char 
   return this->send_buffer(buffer, SubscribeLogsResponse::MESSAGE_TYPE);
 }
 
+void APIConnection::complete_authentication_() {
+  // Early return if already authenticated
+  if (this->flags_.connection_state == static_cast<uint8_t>(ConnectionState::AUTHENTICATED)) {
+    return;
+  }
+
+  this->flags_.connection_state = static_cast<uint8_t>(ConnectionState::AUTHENTICATED);
+  ESP_LOGD(TAG, "%s connected (no password)", this->get_client_combined_info().c_str());
+#ifdef USE_API_CLIENT_CONNECTED_TRIGGER
+  this->parent_->get_client_connected_trigger()->trigger(this->client_info_, this->client_peername_);
+#endif
+#ifdef USE_HOMEASSISTANT_TIME
+  if (homeassistant::global_homeassistant_time != nullptr) {
+    this->send_time_request();
+  }
+#endif
+}
+
 HelloResponse APIConnection::hello(const HelloRequest &msg) {
   this->client_info_ = msg.client_info;
   this->client_peername_ = this->helper_->getpeername();
@@ -1433,26 +1451,17 @@ HelloResponse APIConnection::hello(const HelloRequest &msg) {
   resp.server_info = App.get_name() + " (esphome v" ESPHOME_VERSION ")";
   resp.name = App.get_name();
 
-  bool needs_auth = false;
 #ifdef USE_API_PASSWORD
-  needs_auth = this->parent_->uses_password();
-#endif
-
-  if (!needs_auth) {
+  if (!this->parent_->uses_password()) {
     // Auto-authenticate if no password is required
-    this->flags_.connection_state = static_cast<uint8_t>(ConnectionState::AUTHENTICATED);
-    ESP_LOGD(TAG, "%s connected (no password)", this->get_client_combined_info().c_str());
-#ifdef USE_API_CLIENT_CONNECTED_TRIGGER
-    this->parent_->get_client_connected_trigger()->trigger(this->client_info_, this->client_peername_);
-#endif
-#ifdef USE_HOMEASSISTANT_TIME
-    if (homeassistant::global_homeassistant_time != nullptr) {
-      this->send_time_request();
-    }
-#endif
+    this->complete_authentication_();
   } else {
     this->flags_.connection_state = static_cast<uint8_t>(ConnectionState::CONNECTED);
   }
+#else
+  // No password support - always auto-authenticate
+  this->complete_authentication_();
+#endif
 
   return resp;
 }
@@ -1467,22 +1476,7 @@ ConnectResponse APIConnection::connect(const ConnectRequest &msg) {
   resp.invalid_password = !correct;
   if (correct) {
     ESP_LOGD(TAG, "%s connected", this->get_client_combined_info().c_str());
-
-    // Check if we're already authenticated (e.g., from auto-auth during hello)
-    bool was_authenticated = this->flags_.connection_state == static_cast<uint8_t>(ConnectionState::AUTHENTICATED);
-    this->flags_.connection_state = static_cast<uint8_t>(ConnectionState::AUTHENTICATED);
-
-    // Only trigger events if we weren't already authenticated
-    if (!was_authenticated) {
-#ifdef USE_API_CLIENT_CONNECTED_TRIGGER
-      this->parent_->get_client_connected_trigger()->trigger(this->client_info_, this->client_peername_);
-#endif
-#ifdef USE_HOMEASSISTANT_TIME
-      if (homeassistant::global_homeassistant_time != nullptr) {
-        this->send_time_request();
-      }
-#endif
-    }
+    this->complete_authentication_();
   }
   return resp;
 }

--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -1467,15 +1467,22 @@ ConnectResponse APIConnection::connect(const ConnectRequest &msg) {
   resp.invalid_password = !correct;
   if (correct) {
     ESP_LOGD(TAG, "%s connected", this->get_client_combined_info().c_str());
+
+    // Check if we're already authenticated (e.g., from auto-auth during hello)
+    bool was_authenticated = this->flags_.connection_state == static_cast<uint8_t>(ConnectionState::AUTHENTICATED);
     this->flags_.connection_state = static_cast<uint8_t>(ConnectionState::AUTHENTICATED);
+
+    // Only trigger events if we weren't already authenticated
+    if (!was_authenticated) {
 #ifdef USE_API_CLIENT_CONNECTED_TRIGGER
-    this->parent_->get_client_connected_trigger()->trigger(this->client_info_, this->client_peername_);
+      this->parent_->get_client_connected_trigger()->trigger(this->client_info_, this->client_peername_);
 #endif
 #ifdef USE_HOMEASSISTANT_TIME
-    if (homeassistant::global_homeassistant_time != nullptr) {
-      this->send_time_request();
-    }
+      if (homeassistant::global_homeassistant_time != nullptr) {
+        this->send_time_request();
+      }
 #endif
+    }
   }
   return resp;
 }

--- a/esphome/components/api/api_connection.h
+++ b/esphome/components/api/api_connection.h
@@ -271,6 +271,9 @@ class APIConnection : public APIServerConnection {
   ProtoWriteBuffer allocate_batch_message_buffer(uint16_t size);
 
  protected:
+  // Helper function to handle authentication completion
+  void complete_authentication_();
+
   // Helper function to fill common entity info fields
   static void fill_entity_info_base(esphome::EntityBase *entity, InfoResponseProtoMessage &response) {
     // Set common fields that are shared by all entity types

--- a/esphome/components/api/api_server.cpp
+++ b/esphome/components/api/api_server.cpp
@@ -227,8 +227,6 @@ void APIServer::dump_config() {
 }
 
 #ifdef USE_API_PASSWORD
-bool APIServer::uses_password() const { return !this->password_.empty(); }
-
 bool APIServer::check_password(const std::string &password) const {
   // depend only on input password length
   const char *a = this->password_.c_str();

--- a/esphome/components/api/api_server.h
+++ b/esphome/components/api/api_server.h
@@ -42,7 +42,6 @@ class APIServer : public Component, public Controller {
   bool teardown() override;
 #ifdef USE_API_PASSWORD
   bool check_password(const std::string &password) const;
-  bool uses_password() const;
   void set_password(const std::string &password);
 #endif
   void set_port(uint16_t port);

--- a/tests/integration/fixtures/host_mode_api_password.yaml
+++ b/tests/integration/fixtures/host_mode_api_password.yaml
@@ -1,27 +1,14 @@
 esphome:
-  name: ${name}
-  build_path: ${build_path}
-  friendly_name: ESPHome Host Mode API Password Test
-  name_add_mac_suffix: no
-  area: Entryway
-  platformio_options:
-    build_flags:
-      - -std=gnu++17
-      - -Wall
-    build_unflags:
-      - -std=gnu++11
-
+  name: host-mode-api-password
+host:
 api:
   password: "test_password_123"
-
 logger:
   level: DEBUG
-
 # Test sensor to verify connection works
 sensor:
   - platform: template
     name: Test Sensor
     id: test_sensor
-    lambda: |-
-      return 42.0;
-    update_interval: 1s
+    lambda: return 42.0;
+    update_interval: 0.1s

--- a/tests/integration/fixtures/host_mode_api_password.yaml
+++ b/tests/integration/fixtures/host_mode_api_password.yaml
@@ -1,0 +1,27 @@
+esphome:
+  name: ${name}
+  build_path: ${build_path}
+  friendly_name: ESPHome Host Mode API Password Test
+  name_add_mac_suffix: no
+  area: Entryway
+  platformio_options:
+    build_flags:
+      - -std=gnu++17
+      - -Wall
+    build_unflags:
+      - -std=gnu++11
+
+api:
+  password: "test_password_123"
+
+logger:
+  level: DEBUG
+
+# Test sensor to verify connection works
+sensor:
+  - platform: template
+    name: Test Sensor
+    id: test_sensor
+    lambda: |-
+      return 42.0;
+    update_interval: 1s

--- a/tests/integration/test_host_mode_api_password.py
+++ b/tests/integration/test_host_mode_api_password.py
@@ -18,12 +18,7 @@ async def test_host_mode_api_password(
 ) -> None:
     """Test API authentication with password."""
     async with run_compiled(yaml_config):
-        # First, try to connect without password - should fail
-        with pytest.raises(APIConnectionError, match="Authentication"):
-            async with api_client_connected(password=""):
-                pass  # Should not reach here
-
-        # Now connect with correct password
+        # Connect with correct password
         async with api_client_connected(password="test_password_123") as client:
             # Verify we can get device info
             device_info = await client.device_info()
@@ -32,20 +27,27 @@ async def test_host_mode_api_password(
             assert device_info.name == "host-mode-api-password"
 
             # Subscribe to states to ensure authenticated connection works
+            loop = asyncio.get_running_loop()
+            state_future: asyncio.Future[bool] = loop.create_future()
             states = {}
 
             def on_state(state):
                 states[state.key] = state
+                if not state_future.done():
+                    state_future.set_result(True)
 
-            await client.subscribe_states(on_state)
+            client.subscribe_states(on_state)
 
-            # Wait a bit to receive the test sensor state
-            await asyncio.sleep(0.5)
+            # Wait for at least one state with timeout
+            try:
+                await asyncio.wait_for(state_future, timeout=5.0)
+            except asyncio.TimeoutError:
+                pytest.fail("No states received within timeout")
 
             # Should have received at least one state (the test sensor)
             assert len(states) > 0
 
         # Test with wrong password - should fail
-        with pytest.raises(APIConnectionError, match="Authentication"):
+        with pytest.raises(APIConnectionError, match="Invalid password"):
             async with api_client_connected(password="wrong_password"):
                 pass  # Should not reach here

--- a/tests/integration/test_host_mode_api_password.py
+++ b/tests/integration/test_host_mode_api_password.py
@@ -1,0 +1,51 @@
+"""Integration test for API password authentication."""
+
+from __future__ import annotations
+
+import asyncio
+
+from aioesphomeapi import APIConnectionError
+import pytest
+
+from .types import APIClientConnectedFactory, RunCompiledFunction
+
+
+@pytest.mark.asyncio
+async def test_host_mode_api_password(
+    yaml_config: str,
+    run_compiled: RunCompiledFunction,
+    api_client_connected: APIClientConnectedFactory,
+) -> None:
+    """Test API authentication with password."""
+    async with run_compiled(yaml_config):
+        # First, try to connect without password - should fail
+        with pytest.raises(APIConnectionError, match="Authentication"):
+            async with api_client_connected(password=""):
+                pass  # Should not reach here
+
+        # Now connect with correct password
+        async with api_client_connected(password="test_password_123") as client:
+            # Verify we can get device info
+            device_info = await client.device_info()
+            assert device_info is not None
+            assert device_info.uses_password is True
+            assert device_info.name == "host-mode-api-password"
+
+            # Subscribe to states to ensure authenticated connection works
+            states = {}
+
+            def on_state(state):
+                states[state.key] = state
+
+            await client.subscribe_states(on_state)
+
+            # Wait a bit to receive the test sensor state
+            await asyncio.sleep(0.5)
+
+            # Should have received at least one state (the test sensor)
+            assert len(states) > 0
+
+        # Test with wrong password - should fail
+        with pytest.raises(APIConnectionError, match="Authentication"):
+            async with api_client_connected(password="wrong_password"):
+                pass  # Should not reach here


### PR DESCRIPTION
## What does this implement/fix?

This PR implements **Phase 1** of a three-phase plan to optimize API connections and reduce flash usage for devices without password authentication.

### Background

ESPHome has been transitioning away from password authentication since 2023, replacing it with the more secure Noise encryption protocol. Password authentication has been deprecated since 2023, and many devices run without any password configured. PR #9297 further optimized this by not compiling password-related code when no password is configured. The `ConnectRequest`/`ConnectResponse` messages are remnants of the old password authentication system and are unnecessary overhead for passwordless devices.

This optimization is the next logical step in modernizing the API connection flow as we continue phasing out the legacy password authentication system.

### Three-Phase Migration Plan:

**Phase 1 (This PR)**: Make ConnectRequest optional on the ESPHome side
- Auto-authenticate connections during the hello handshake when no password is configured
- Maintain full backward compatibility - clients can still send ConnectRequest
- Prevent duplicate event triggers if ConnectRequest is sent after auto-authentication

**Phase 2**: Update aioesphomeapi client behavior
- Modify the client to skip sending ConnectRequest when connecting to passwordless devices
- The CLI already knows if a password is configured, making this a simple logic change
- Tracked in esphome/aioesphomeapi#1246

**Phase 3**: Remove ConnectRequest/Response code entirely (revisit #9443)
- After sufficient time for clients to update, conditionally exclude ConnectRequest/Response messages when `USE_API_PASSWORD` is not defined
- This will save approximately 492 bytes of flash space on passwordless devices

## How does it work?

The implementation modifies the `hello()` method in `api_connection.cpp` to:

1. Check if `USE_API_PASSWORD` is defined (password authentication is compiled in)
2. If no password support is compiled in, immediately transition to `AUTHENTICATED` state  
3. Trigger the same events (client connected, time sync) that would normally happen during connect

A new helper method `complete_authentication_()` was added to:
- Handle the authentication completion logic in one place
- Prevent duplicate event triggers with an early return check
- Ensure client_connected trigger and time sync only happen once

The implementation also includes several code improvements:
- Removed redundant `uses_password()` method since `USE_API_PASSWORD` being defined means a password is always configured
- Eliminated unnecessary `needs_auth` variable
- Fixed duplicate "connected" log messages
- Properly guarded code paths to avoid dead code when `USE_API_PASSWORD` is not defined

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Related issue or feature (if applicable)

- Builds upon #9297 which made API password code conditional
- Prepares for future implementation of #9443

## Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable): 

N/A - No user-facing changes, this is transparent to end users

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# No password - connections will be auto-authenticated
api:

# With password - still requires ConnectRequest as before
api:
  password: "mypassword"

# Recommended: Use encryption instead of password
api:
  encryption:
    key: "..."
```

## Checklist

- [x] The code change is tested and works locally.
- [x] Tests have been added to verify that the new code works (under `tests/` folder).
  - Added `test_host_mode_api_password` integration test to verify password authentication still works correctly
  - Test verifies authentication with correct password, state subscription, and rejection of wrong password
  - Existing integration tests implicitly verify auto-authentication for passwordless connections
- [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).