### PR TITLE
Optimize API flash usage by storing message size at compile time

### DIFF
--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -201,7 +201,7 @@ void APIConnection::loop() {
 
 #ifdef USE_CAMERA
   if (this->image_reader_ && this->image_reader_->available() && this->helper_->can_write_without_blocking()) {
-    uint32_t to_send = std::min((size_t) MAX_PACKET_SIZE, this->image_reader_->available());
+    uint32_t to_send = std::min((size_t) MAX_BATCH_PACKET_SIZE, this->image_reader_->available());
     bool done = this->image_reader_->available() == to_send;
     uint32_t msg_size = 0;
     ProtoSize::add_fixed_field<4>(msg_size, 1, true);
@@ -1614,6 +1614,11 @@ bool APIConnection::send_buffer(ProtoWriteBuffer buffer, uint8_t message_type) {
   if (err == APIError::WOULD_BLOCK)
     return false;
   if (err != APIError::OK) {
+    if (err == APIError::MESSAGE_TOO_LARGE) {
+      // Log error for oversized messages - safe here since we're not in the middle of encoding
+      ESP_LOGE(TAG, "%s: Message type %u is too large to send (exceeds %u byte limit)",
+               this->get_client_combined_info().c_str(), message_type, PacketInfo::MAX_PAYLOAD_SIZE);
+    }
     on_fatal_error();
     if (err == APIError::SOCKET_WRITE_FAILED && errno == ECONNRESET) {
       ESP_LOGW(TAG, "%s: Connection reset", this->get_client_combined_info().c_str());
@@ -1771,9 +1776,9 @@ void APIConnection::process_batch_() {
 
     // Update tracking variables
     items_processed++;
-    // After first message, set remaining size to MAX_PACKET_SIZE to avoid fragmentation
+    // After first message, set remaining size to MAX_BATCH_PACKET_SIZE to avoid fragmentation
     if (items_processed == 1) {
-      remaining_size = MAX_PACKET_SIZE;
+      remaining_size = MAX_BATCH_PACKET_SIZE;
     }
     remaining_size -= payload_size;
     // Calculate where the next message's header padding will start

--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -1614,11 +1614,6 @@ bool APIConnection::send_buffer(ProtoWriteBuffer buffer, uint8_t message_type) {
   if (err == APIError::WOULD_BLOCK)
     return false;
   if (err != APIError::OK) {
-    if (err == APIError::MESSAGE_TOO_LARGE) {
-      // Log error for oversized messages - safe here since we're not in the middle of encoding
-      ESP_LOGE(TAG, "%s: Message type %u is too large to send (exceeds %u byte limit)",
-               this->get_client_combined_info().c_str(), message_type, PacketInfo::MAX_PAYLOAD_SIZE);
-    }
     on_fatal_error();
     if (err == APIError::SOCKET_WRITE_FAILED && errno == ECONNRESET) {
       ESP_LOGW(TAG, "%s: Connection reset", this->get_client_combined_info().c_str());

--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -193,7 +193,8 @@ void APIConnection::loop() {
       // If we can't send the ping request directly (tx_buffer full),
       // schedule it at the front of the batch so it will be sent with priority
       ESP_LOGW(TAG, "Buffer full, ping queued");
-      this->schedule_message_front_(nullptr, &APIConnection::try_send_ping_request, PingRequest::MESSAGE_TYPE);
+      this->schedule_message_front_(nullptr, &APIConnection::try_send_ping_request, PingRequest::MESSAGE_TYPE,
+                                    PingRequest::ESTIMATED_SIZE);
       this->flags_.sent_ping = true;  // Mark as sent to avoid scheduling multiple pings
     }
   }
@@ -265,7 +266,7 @@ void APIConnection::on_disconnect_response(const DisconnectResponse &value) {
 
 // Encodes a message to the buffer and returns the total number of bytes used,
 // including header and footer overhead. Returns 0 if the message doesn't fit.
-uint16_t APIConnection::encode_message_to_buffer(ProtoMessage &msg, uint16_t message_type, APIConnection *conn,
+uint16_t APIConnection::encode_message_to_buffer(ProtoMessage &msg, uint8_t message_type, APIConnection *conn,
                                                  uint32_t remaining_size, bool is_single) {
 #ifdef HAS_PROTO_MESSAGE_DUMP
   // If in log-only mode, just log and return
@@ -316,7 +317,7 @@ uint16_t APIConnection::encode_message_to_buffer(ProtoMessage &msg, uint16_t mes
 #ifdef USE_BINARY_SENSOR
 bool APIConnection::send_binary_sensor_state(binary_sensor::BinarySensor *binary_sensor) {
   return this->send_message_smart_(binary_sensor, &APIConnection::try_send_binary_sensor_state,
-                                   BinarySensorStateResponse::MESSAGE_TYPE);
+                                   BinarySensorStateResponse::MESSAGE_TYPE, BinarySensorStateResponse::ESTIMATED_SIZE);
 }
 
 uint16_t APIConnection::try_send_binary_sensor_state(EntityBase *entity, APIConnection *conn, uint32_t remaining_size,
@@ -343,7 +344,8 @@ uint16_t APIConnection::try_send_binary_sensor_info(EntityBase *entity, APIConne
 
 #ifdef USE_COVER
 bool APIConnection::send_cover_state(cover::Cover *cover) {
-  return this->send_message_smart_(cover, &APIConnection::try_send_cover_state, CoverStateResponse::MESSAGE_TYPE);
+  return this->send_message_smart_(cover, &APIConnection::try_send_cover_state, CoverStateResponse::MESSAGE_TYPE,
+                                   CoverStateResponse::ESTIMATED_SIZE);
 }
 uint16_t APIConnection::try_send_cover_state(EntityBase *entity, APIConnection *conn, uint32_t remaining_size,
                                              bool is_single) {
@@ -400,7 +402,8 @@ void APIConnection::cover_command(const CoverCommandRequest &msg) {
 
 #ifdef USE_FAN
 bool APIConnection::send_fan_state(fan::Fan *fan) {
-  return this->send_message_smart_(fan, &APIConnection::try_send_fan_state, FanStateResponse::MESSAGE_TYPE);
+  return this->send_message_smart_(fan, &APIConnection::try_send_fan_state, FanStateResponse::MESSAGE_TYPE,
+                                   FanStateResponse::ESTIMATED_SIZE);
 }
 uint16_t APIConnection::try_send_fan_state(EntityBase *entity, APIConnection *conn, uint32_t remaining_size,
                                            bool is_single) {
@@ -455,7 +458,8 @@ void APIConnection::fan_command(const FanCommandRequest &msg) {
 
 #ifdef USE_LIGHT
 bool APIConnection::send_light_state(light::LightState *light) {
-  return this->send_message_smart_(light, &APIConnection::try_send_light_state, LightStateResponse::MESSAGE_TYPE);
+  return this->send_message_smart_(light, &APIConnection::try_send_light_state, LightStateResponse::MESSAGE_TYPE,
+                                   LightStateResponse::ESTIMATED_SIZE);
 }
 uint16_t APIConnection::try_send_light_state(EntityBase *entity, APIConnection *conn, uint32_t remaining_size,
                                              bool is_single) {
@@ -543,7 +547,8 @@ void APIConnection::light_command(const LightCommandRequest &msg) {
 
 #ifdef USE_SENSOR
 bool APIConnection::send_sensor_state(sensor::Sensor *sensor) {
-  return this->send_message_smart_(sensor, &APIConnection::try_send_sensor_state, SensorStateResponse::MESSAGE_TYPE);
+  return this->send_message_smart_(sensor, &APIConnection::try_send_sensor_state, SensorStateResponse::MESSAGE_TYPE,
+                                   SensorStateResponse::ESTIMATED_SIZE);
 }
 
 uint16_t APIConnection::try_send_sensor_state(EntityBase *entity, APIConnection *conn, uint32_t remaining_size,
@@ -575,7 +580,8 @@ uint16_t APIConnection::try_send_sensor_info(EntityBase *entity, APIConnection *
 
 #ifdef USE_SWITCH
 bool APIConnection::send_switch_state(switch_::Switch *a_switch) {
-  return this->send_message_smart_(a_switch, &APIConnection::try_send_switch_state, SwitchStateResponse::MESSAGE_TYPE);
+  return this->send_message_smart_(a_switch, &APIConnection::try_send_switch_state, SwitchStateResponse::MESSAGE_TYPE,
+                                   SwitchStateResponse::ESTIMATED_SIZE);
 }
 
 uint16_t APIConnection::try_send_switch_state(EntityBase *entity, APIConnection *conn, uint32_t remaining_size,
@@ -611,7 +617,7 @@ void APIConnection::switch_command(const SwitchCommandRequest &msg) {
 #ifdef USE_TEXT_SENSOR
 bool APIConnection::send_text_sensor_state(text_sensor::TextSensor *text_sensor) {
   return this->send_message_smart_(text_sensor, &APIConnection::try_send_text_sensor_state,
-                                   TextSensorStateResponse::MESSAGE_TYPE);
+                                   TextSensorStateResponse::MESSAGE_TYPE, TextSensorStateResponse::ESTIMATED_SIZE);
 }
 
 uint16_t APIConnection::try_send_text_sensor_state(EntityBase *entity, APIConnection *conn, uint32_t remaining_size,
@@ -638,7 +644,8 @@ uint16_t APIConnection::try_send_text_sensor_info(EntityBase *entity, APIConnect
 
 #ifdef USE_CLIMATE
 bool APIConnection::send_climate_state(climate::Climate *climate) {
-  return this->send_message_smart_(climate, &APIConnection::try_send_climate_state, ClimateStateResponse::MESSAGE_TYPE);
+  return this->send_message_smart_(climate, &APIConnection::try_send_climate_state, ClimateStateResponse::MESSAGE_TYPE,
+                                   ClimateStateResponse::ESTIMATED_SIZE);
 }
 uint16_t APIConnection::try_send_climate_state(EntityBase *entity, APIConnection *conn, uint32_t remaining_size,
                                                bool is_single) {
@@ -734,7 +741,8 @@ void APIConnection::climate_command(const ClimateCommandRequest &msg) {
 
 #ifdef USE_NUMBER
 bool APIConnection::send_number_state(number::Number *number) {
-  return this->send_message_smart_(number, &APIConnection::try_send_number_state, NumberStateResponse::MESSAGE_TYPE);
+  return this->send_message_smart_(number, &APIConnection::try_send_number_state, NumberStateResponse::MESSAGE_TYPE,
+                                   NumberStateResponse::ESTIMATED_SIZE);
 }
 
 uint16_t APIConnection::try_send_number_state(EntityBase *entity, APIConnection *conn, uint32_t remaining_size,
@@ -770,7 +778,8 @@ void APIConnection::number_command(const NumberCommandRequest &msg) {
 
 #ifdef USE_DATETIME_DATE
 bool APIConnection::send_date_state(datetime::DateEntity *date) {
-  return this->send_message_smart_(date, &APIConnection::try_send_date_state, DateStateResponse::MESSAGE_TYPE);
+  return this->send_message_smart_(date, &APIConnection::try_send_date_state, DateStateResponse::MESSAGE_TYPE,
+                                   DateStateResponse::ESTIMATED_SIZE);
 }
 uint16_t APIConnection::try_send_date_state(EntityBase *entity, APIConnection *conn, uint32_t remaining_size,
                                             bool is_single) {
@@ -800,7 +809,8 @@ void APIConnection::date_command(const DateCommandRequest &msg) {
 
 #ifdef USE_DATETIME_TIME
 bool APIConnection::send_time_state(datetime::TimeEntity *time) {
-  return this->send_message_smart_(time, &APIConnection::try_send_time_state, TimeStateResponse::MESSAGE_TYPE);
+  return this->send_message_smart_(time, &APIConnection::try_send_time_state, TimeStateResponse::MESSAGE_TYPE,
+                                   TimeStateResponse::ESTIMATED_SIZE);
 }
 uint16_t APIConnection::try_send_time_state(EntityBase *entity, APIConnection *conn, uint32_t remaining_size,
                                             bool is_single) {
@@ -831,7 +841,7 @@ void APIConnection::time_command(const TimeCommandRequest &msg) {
 #ifdef USE_DATETIME_DATETIME
 bool APIConnection::send_datetime_state(datetime::DateTimeEntity *datetime) {
   return this->send_message_smart_(datetime, &APIConnection::try_send_datetime_state,
-                                   DateTimeStateResponse::MESSAGE_TYPE);
+                                   DateTimeStateResponse::MESSAGE_TYPE, DateTimeStateResponse::ESTIMATED_SIZE);
 }
 uint16_t APIConnection::try_send_datetime_state(EntityBase *entity, APIConnection *conn, uint32_t remaining_size,
                                                 bool is_single) {
@@ -862,7 +872,8 @@ void APIConnection::datetime_command(const DateTimeCommandRequest &msg) {
 
 #ifdef USE_TEXT
 bool APIConnection::send_text_state(text::Text *text) {
-  return this->send_message_smart_(text, &APIConnection::try_send_text_state, TextStateResponse::MESSAGE_TYPE);
+  return this->send_message_smart_(text, &APIConnection::try_send_text_state, TextStateResponse::MESSAGE_TYPE,
+                                   TextStateResponse::ESTIMATED_SIZE);
 }
 
 uint16_t APIConnection::try_send_text_state(EntityBase *entity, APIConnection *conn, uint32_t remaining_size,
@@ -896,7 +907,8 @@ void APIConnection::text_command(const TextCommandRequest &msg) {
 
 #ifdef USE_SELECT
 bool APIConnection::send_select_state(select::Select *select) {
-  return this->send_message_smart_(select, &APIConnection::try_send_select_state, SelectStateResponse::MESSAGE_TYPE);
+  return this->send_message_smart_(select, &APIConnection::try_send_select_state, SelectStateResponse::MESSAGE_TYPE,
+                                   SelectStateResponse::ESTIMATED_SIZE);
 }
 
 uint16_t APIConnection::try_send_select_state(EntityBase *entity, APIConnection *conn, uint32_t remaining_size,
@@ -944,7 +956,8 @@ void esphome::api::APIConnection::button_command(const ButtonCommandRequest &msg
 
 #ifdef USE_LOCK
 bool APIConnection::send_lock_state(lock::Lock *a_lock) {
-  return this->send_message_smart_(a_lock, &APIConnection::try_send_lock_state, LockStateResponse::MESSAGE_TYPE);
+  return this->send_message_smart_(a_lock, &APIConnection::try_send_lock_state, LockStateResponse::MESSAGE_TYPE,
+                                   LockStateResponse::ESTIMATED_SIZE);
 }
 
 uint16_t APIConnection::try_send_lock_state(EntityBase *entity, APIConnection *conn, uint32_t remaining_size,
@@ -986,7 +999,8 @@ void APIConnection::lock_command(const LockCommandRequest &msg) {
 
 #ifdef USE_VALVE
 bool APIConnection::send_valve_state(valve::Valve *valve) {
-  return this->send_message_smart_(valve, &APIConnection::try_send_valve_state, ValveStateResponse::MESSAGE_TYPE);
+  return this->send_message_smart_(valve, &APIConnection::try_send_valve_state, ValveStateResponse::MESSAGE_TYPE,
+                                   ValveStateResponse::ESTIMATED_SIZE);
 }
 uint16_t APIConnection::try_send_valve_state(EntityBase *entity, APIConnection *conn, uint32_t remaining_size,
                                              bool is_single) {
@@ -1023,7 +1037,7 @@ void APIConnection::valve_command(const ValveCommandRequest &msg) {
 #ifdef USE_MEDIA_PLAYER
 bool APIConnection::send_media_player_state(media_player::MediaPlayer *media_player) {
   return this->send_message_smart_(media_player, &APIConnection::try_send_media_player_state,
-                                   MediaPlayerStateResponse::MESSAGE_TYPE);
+                                   MediaPlayerStateResponse::MESSAGE_TYPE, MediaPlayerStateResponse::ESTIMATED_SIZE);
 }
 uint16_t APIConnection::try_send_media_player_state(EntityBase *entity, APIConnection *conn, uint32_t remaining_size,
                                                     bool is_single) {
@@ -1262,7 +1276,8 @@ void APIConnection::voice_assistant_set_configuration(const VoiceAssistantSetCon
 #ifdef USE_ALARM_CONTROL_PANEL
 bool APIConnection::send_alarm_control_panel_state(alarm_control_panel::AlarmControlPanel *a_alarm_control_panel) {
   return this->send_message_smart_(a_alarm_control_panel, &APIConnection::try_send_alarm_control_panel_state,
-                                   AlarmControlPanelStateResponse::MESSAGE_TYPE);
+                                   AlarmControlPanelStateResponse::MESSAGE_TYPE,
+                                   AlarmControlPanelStateResponse::ESTIMATED_SIZE);
 }
 uint16_t APIConnection::try_send_alarm_control_panel_state(EntityBase *entity, APIConnection *conn,
                                                            uint32_t remaining_size, bool is_single) {
@@ -1316,7 +1331,8 @@ void APIConnection::alarm_control_panel_command(const AlarmControlPanelCommandRe
 
 #ifdef USE_EVENT
 void APIConnection::send_event(event::Event *event, const std::string &event_type) {
-  this->schedule_message_(event, MessageCreator(event_type), EventResponse::MESSAGE_TYPE);
+  this->schedule_message_(event, MessageCreator(event_type), EventResponse::MESSAGE_TYPE,
+                          EventResponse::ESTIMATED_SIZE);
 }
 uint16_t APIConnection::try_send_event_response(event::Event *event, const std::string &event_type, APIConnection *conn,
                                                 uint32_t remaining_size, bool is_single) {
@@ -1341,7 +1357,8 @@ uint16_t APIConnection::try_send_event_info(EntityBase *entity, APIConnection *c
 
 #ifdef USE_UPDATE
 bool APIConnection::send_update_state(update::UpdateEntity *update) {
-  return this->send_message_smart_(update, &APIConnection::try_send_update_state, UpdateStateResponse::MESSAGE_TYPE);
+  return this->send_message_smart_(update, &APIConnection::try_send_update_state, UpdateStateResponse::MESSAGE_TYPE,
+                                   UpdateStateResponse::ESTIMATED_SIZE);
 }
 uint16_t APIConnection::try_send_update_state(EntityBase *entity, APIConnection *conn, uint32_t remaining_size,
                                               bool is_single) {
@@ -1588,7 +1605,7 @@ bool APIConnection::try_to_clear_buffer(bool log_out_of_space) {
   }
   return false;
 }
-bool APIConnection::send_buffer(ProtoWriteBuffer buffer, uint16_t message_type) {
+bool APIConnection::send_buffer(ProtoWriteBuffer buffer, uint8_t message_type) {
   if (!this->try_to_clear_buffer(message_type != SubscribeLogsResponse::MESSAGE_TYPE)) {  // SubscribeLogsResponse
     return false;
   }
@@ -1622,7 +1639,8 @@ void APIConnection::on_fatal_error() {
   this->flags_.remove = true;
 }
 
-void APIConnection::DeferredBatch::add_item(EntityBase *entity, MessageCreator creator, uint16_t message_type) {
+void APIConnection::DeferredBatch::add_item(EntityBase *entity, MessageCreator creator, uint8_t message_type,
+                                            uint8_t estimated_size) {
   // Check if we already have a message of this type for this entity
   // This provides deduplication per entity/message_type combination
   // O(n) but optimized for RAM and not performance.
@@ -1637,12 +1655,13 @@ void APIConnection::DeferredBatch::add_item(EntityBase *entity, MessageCreator c
   }
 
   // No existing item found, add new one
-  items.emplace_back(entity, std::move(creator), message_type);
+  items.emplace_back(entity, std::move(creator), message_type, estimated_size);
 }
 
-void APIConnection::DeferredBatch::add_item_front(EntityBase *entity, MessageCreator creator, uint16_t message_type) {
+void APIConnection::DeferredBatch::add_item_front(EntityBase *entity, MessageCreator creator, uint8_t message_type,
+                                                  uint8_t estimated_size) {
   // Insert at front for high priority messages (no deduplication check)
-  items.insert(items.begin(), BatchItem(entity, std::move(creator), message_type));
+  items.insert(items.begin(), BatchItem(entity, std::move(creator), message_type, estimated_size));
 }
 
 bool APIConnection::schedule_batch_() {
@@ -1714,7 +1733,7 @@ void APIConnection::process_batch_() {
   uint32_t total_estimated_size = 0;
   for (size_t i = 0; i < this->deferred_batch_.size(); i++) {
     const auto &item = this->deferred_batch_[i];
-    total_estimated_size += get_estimated_message_size(item.message_type);
+    total_estimated_size += item.estimated_size;
   }
 
   // Calculate total overhead for all messages
@@ -1808,7 +1827,7 @@ void APIConnection::process_batch_() {
 }
 
 uint16_t APIConnection::MessageCreator::operator()(EntityBase *entity, APIConnection *conn, uint32_t remaining_size,
-                                                   bool is_single, uint16_t message_type) const {
+                                                   bool is_single, uint8_t message_type) const {
 #ifdef USE_EVENT
   // Special case: EventResponse uses string pointer
   if (message_type == EventResponse::MESSAGE_TYPE) {
@@ -1837,149 +1856,6 @@ uint16_t APIConnection::try_send_ping_request(EntityBase *entity, APIConnection 
                                               bool is_single) {
   PingRequest req;
   return encode_message_to_buffer(req, PingRequest::MESSAGE_TYPE, conn, remaining_size, is_single);
-}
-
-uint16_t APIConnection::get_estimated_message_size(uint16_t message_type) {
-  // Use generated ESTIMATED_SIZE constants from each message type
-  switch (message_type) {
-#ifdef USE_BINARY_SENSOR
-    case BinarySensorStateResponse::MESSAGE_TYPE:
-      return BinarySensorStateResponse::ESTIMATED_SIZE;
-    case ListEntitiesBinarySensorResponse::MESSAGE_TYPE:
-      return ListEntitiesBinarySensorResponse::ESTIMATED_SIZE;
-#endif
-#ifdef USE_SENSOR
-    case SensorStateResponse::MESSAGE_TYPE:
-      return SensorStateResponse::ESTIMATED_SIZE;
-    case ListEntitiesSensorResponse::MESSAGE_TYPE:
-      return ListEntitiesSensorResponse::ESTIMATED_SIZE;
-#endif
-#ifdef USE_SWITCH
-    case SwitchStateResponse::MESSAGE_TYPE:
-      return SwitchStateResponse::ESTIMATED_SIZE;
-    case ListEntitiesSwitchResponse::MESSAGE_TYPE:
-      return ListEntitiesSwitchResponse::ESTIMATED_SIZE;
-#endif
-#ifdef USE_TEXT_SENSOR
-    case TextSensorStateResponse::MESSAGE_TYPE:
-      return TextSensorStateResponse::ESTIMATED_SIZE;
-    case ListEntitiesTextSensorResponse::MESSAGE_TYPE:
-      return ListEntitiesTextSensorResponse::ESTIMATED_SIZE;
-#endif
-#ifdef USE_NUMBER
-    case NumberStateResponse::MESSAGE_TYPE:
-      return NumberStateResponse::ESTIMATED_SIZE;
-    case ListEntitiesNumberResponse::MESSAGE_TYPE:
-      return ListEntitiesNumberResponse::ESTIMATED_SIZE;
-#endif
-#ifdef USE_TEXT
-    case TextStateResponse::MESSAGE_TYPE:
-      return TextStateResponse::ESTIMATED_SIZE;
-    case ListEntitiesTextResponse::MESSAGE_TYPE:
-      return ListEntitiesTextResponse::ESTIMATED_SIZE;
-#endif
-#ifdef USE_SELECT
-    case SelectStateResponse::MESSAGE_TYPE:
-      return SelectStateResponse::ESTIMATED_SIZE;
-    case ListEntitiesSelectResponse::MESSAGE_TYPE:
-      return ListEntitiesSelectResponse::ESTIMATED_SIZE;
-#endif
-#ifdef USE_LOCK
-    case LockStateResponse::MESSAGE_TYPE:
-      return LockStateResponse::ESTIMATED_SIZE;
-    case ListEntitiesLockResponse::MESSAGE_TYPE:
-      return ListEntitiesLockResponse::ESTIMATED_SIZE;
-#endif
-#ifdef USE_EVENT
-    case EventResponse::MESSAGE_TYPE:
-      return EventResponse::ESTIMATED_SIZE;
-    case ListEntitiesEventResponse::MESSAGE_TYPE:
-      return ListEntitiesEventResponse::ESTIMATED_SIZE;
-#endif
-#ifdef USE_COVER
-    case CoverStateResponse::MESSAGE_TYPE:
-      return CoverStateResponse::ESTIMATED_SIZE;
-    case ListEntitiesCoverResponse::MESSAGE_TYPE:
-      return ListEntitiesCoverResponse::ESTIMATED_SIZE;
-#endif
-#ifdef USE_FAN
-    case FanStateResponse::MESSAGE_TYPE:
-      return FanStateResponse::ESTIMATED_SIZE;
-    case ListEntitiesFanResponse::MESSAGE_TYPE:
-      return ListEntitiesFanResponse::ESTIMATED_SIZE;
-#endif
-#ifdef USE_LIGHT
-    case LightStateResponse::MESSAGE_TYPE:
-      return LightStateResponse::ESTIMATED_SIZE;
-    case ListEntitiesLightResponse::MESSAGE_TYPE:
-      return ListEntitiesLightResponse::ESTIMATED_SIZE;
-#endif
-#ifdef USE_CLIMATE
-    case ClimateStateResponse::MESSAGE_TYPE:
-      return ClimateStateResponse::ESTIMATED_SIZE;
-    case ListEntitiesClimateResponse::MESSAGE_TYPE:
-      return ListEntitiesClimateResponse::ESTIMATED_SIZE;
-#endif
-#ifdef USE_CAMERA
-    case ListEntitiesCameraResponse::MESSAGE_TYPE:
-      return ListEntitiesCameraResponse::ESTIMATED_SIZE;
-#endif
-#ifdef USE_BUTTON
-    case ListEntitiesButtonResponse::MESSAGE_TYPE:
-      return ListEntitiesButtonResponse::ESTIMATED_SIZE;
-#endif
-#ifdef USE_MEDIA_PLAYER
-    case MediaPlayerStateResponse::MESSAGE_TYPE:
-      return MediaPlayerStateResponse::ESTIMATED_SIZE;
-    case ListEntitiesMediaPlayerResponse::MESSAGE_TYPE:
-      return ListEntitiesMediaPlayerResponse::ESTIMATED_SIZE;
-#endif
-#ifdef USE_ALARM_CONTROL_PANEL
-    case AlarmControlPanelStateResponse::MESSAGE_TYPE:
-      return AlarmControlPanelStateResponse::ESTIMATED_SIZE;
-    case ListEntitiesAlarmControlPanelResponse::MESSAGE_TYPE:
-      return ListEntitiesAlarmControlPanelResponse::ESTIMATED_SIZE;
-#endif
-#ifdef USE_DATETIME_DATE
-    case DateStateResponse::MESSAGE_TYPE:
-      return DateStateResponse::ESTIMATED_SIZE;
-    case ListEntitiesDateResponse::MESSAGE_TYPE:
-      return ListEntitiesDateResponse::ESTIMATED_SIZE;
-#endif
-#ifdef USE_DATETIME_TIME
-    case TimeStateResponse::MESSAGE_TYPE:
-      return TimeStateResponse::ESTIMATED_SIZE;
-    case ListEntitiesTimeResponse::MESSAGE_TYPE:
-      return ListEntitiesTimeResponse::ESTIMATED_SIZE;
-#endif
-#ifdef USE_DATETIME_DATETIME
-    case DateTimeStateResponse::MESSAGE_TYPE:
-      return DateTimeStateResponse::ESTIMATED_SIZE;
-    case ListEntitiesDateTimeResponse::MESSAGE_TYPE:
-      return ListEntitiesDateTimeResponse::ESTIMATED_SIZE;
-#endif
-#ifdef USE_VALVE
-    case ValveStateResponse::MESSAGE_TYPE:
-      return ValveStateResponse::ESTIMATED_SIZE;
-    case ListEntitiesValveResponse::MESSAGE_TYPE:
-      return ListEntitiesValveResponse::ESTIMATED_SIZE;
-#endif
-#ifdef USE_UPDATE
-    case UpdateStateResponse::MESSAGE_TYPE:
-      return UpdateStateResponse::ESTIMATED_SIZE;
-    case ListEntitiesUpdateResponse::MESSAGE_TYPE:
-      return ListEntitiesUpdateResponse::ESTIMATED_SIZE;
-#endif
-    case ListEntitiesServicesResponse::MESSAGE_TYPE:
-      return ListEntitiesServicesResponse::ESTIMATED_SIZE;
-    case ListEntitiesDoneResponse::MESSAGE_TYPE:
-      return ListEntitiesDoneResponse::ESTIMATED_SIZE;
-    case DisconnectRequest::MESSAGE_TYPE:
-      return DisconnectRequest::ESTIMATED_SIZE;
-    default:
-      // Fallback for unknown message types
-      return 24;
-  }
 }
 
 }  // namespace api

--- a/esphome/components/api/api_connection.h
+++ b/esphome/components/api/api_connection.h
@@ -33,7 +33,7 @@ class APIConnection : public APIServerConnection {
 
   bool send_list_info_done() {
     return this->schedule_message_(nullptr, &APIConnection::try_send_list_info_done,
-                                   ListEntitiesDoneResponse::MESSAGE_TYPE);
+                                   ListEntitiesDoneResponse::MESSAGE_TYPE, ListEntitiesDoneResponse::ESTIMATED_SIZE);
   }
 #ifdef USE_BINARY_SENSOR
   bool send_binary_sensor_state(binary_sensor::BinarySensor *binary_sensor);
@@ -256,7 +256,7 @@ class APIConnection : public APIServerConnection {
   }
 
   bool try_to_clear_buffer(bool log_out_of_space);
-  bool send_buffer(ProtoWriteBuffer buffer, uint16_t message_type) override;
+  bool send_buffer(ProtoWriteBuffer buffer, uint8_t message_type) override;
 
   std::string get_client_combined_info() const {
     if (this->client_info_ == this->client_peername_) {
@@ -298,7 +298,7 @@ class APIConnection : public APIServerConnection {
   }
 
   // Non-template helper to encode any ProtoMessage
-  static uint16_t encode_message_to_buffer(ProtoMessage &msg, uint16_t message_type, APIConnection *conn,
+  static uint16_t encode_message_to_buffer(ProtoMessage &msg, uint8_t message_type, APIConnection *conn,
                                            uint32_t remaining_size, bool is_single);
 
 #ifdef USE_VOICE_ASSISTANT
@@ -443,9 +443,6 @@ class APIConnection : public APIServerConnection {
   static uint16_t try_send_disconnect_request(EntityBase *entity, APIConnection *conn, uint32_t remaining_size,
                                               bool is_single);
 
-  // Helper function to get estimated message size for buffer pre-allocation
-  static uint16_t get_estimated_message_size(uint16_t message_type);
-
   // Batch message method for ping requests
   static uint16_t try_send_ping_request(EntityBase *entity, APIConnection *conn, uint32_t remaining_size,
                                         bool is_single);
@@ -505,10 +502,10 @@ class APIConnection : public APIServerConnection {
 
     // Call operator - uses message_type to determine union type
     uint16_t operator()(EntityBase *entity, APIConnection *conn, uint32_t remaining_size, bool is_single,
-                        uint16_t message_type) const;
+                        uint8_t message_type) const;
 
     // Manual cleanup method - must be called before destruction for string types
-    void cleanup(uint16_t message_type) {
+    void cleanup(uint8_t message_type) {
 #ifdef USE_EVENT
       if (message_type == EventResponse::MESSAGE_TYPE && data_.string_ptr != nullptr) {
         delete data_.string_ptr;
@@ -529,11 +526,12 @@ class APIConnection : public APIServerConnection {
     struct BatchItem {
       EntityBase *entity;      // Entity pointer
       MessageCreator creator;  // Function that creates the message when needed
-      uint16_t message_type;   // Message type for overhead calculation
+      uint8_t message_type;    // Message type for overhead calculation (max 255)
+      uint8_t estimated_size;  // Estimated message size (max 255 bytes)
 
       // Constructor for creating BatchItem
-      BatchItem(EntityBase *entity, MessageCreator creator, uint16_t message_type)
-          : entity(entity), creator(std::move(creator)), message_type(message_type) {}
+      BatchItem(EntityBase *entity, MessageCreator creator, uint8_t message_type, uint8_t estimated_size)
+          : entity(entity), creator(std::move(creator)), message_type(message_type), estimated_size(estimated_size) {}
     };
 
     std::vector<BatchItem> items;
@@ -559,9 +557,9 @@ class APIConnection : public APIServerConnection {
     }
 
     // Add item to the batch
-    void add_item(EntityBase *entity, MessageCreator creator, uint16_t message_type);
+    void add_item(EntityBase *entity, MessageCreator creator, uint8_t message_type, uint8_t estimated_size);
     // Add item to the front of the batch (for high priority messages like ping)
-    void add_item_front(EntityBase *entity, MessageCreator creator, uint16_t message_type);
+    void add_item_front(EntityBase *entity, MessageCreator creator, uint8_t message_type, uint8_t estimated_size);
 
     // Clear all items with proper cleanup
     void clear() {
@@ -641,7 +639,7 @@ class APIConnection : public APIServerConnection {
 
 #ifdef HAS_PROTO_MESSAGE_DUMP
   // Helper to log a proto message from a MessageCreator object
-  void log_proto_message_(EntityBase *entity, const MessageCreator &creator, uint16_t message_type) {
+  void log_proto_message_(EntityBase *entity, const MessageCreator &creator, uint8_t message_type) {
     this->flags_.log_only_mode = true;
     creator(entity, this, MAX_PACKET_SIZE, true, message_type);
     this->flags_.log_only_mode = false;
@@ -654,7 +652,8 @@ class APIConnection : public APIServerConnection {
 #endif
 
   // Helper method to send a message either immediately or via batching
-  bool send_message_smart_(EntityBase *entity, MessageCreatorPtr creator, uint16_t message_type) {
+  bool send_message_smart_(EntityBase *entity, MessageCreatorPtr creator, uint8_t message_type,
+                           uint8_t estimated_size) {
     // Try to send immediately if:
     // 1. We should try to send immediately (should_try_send_immediately = true)
     // 2. Batch delay is 0 (user has opted in to immediate sending)
@@ -675,23 +674,25 @@ class APIConnection : public APIServerConnection {
     }
 
     // Fall back to scheduled batching
-    return this->schedule_message_(entity, creator, message_type);
+    return this->schedule_message_(entity, creator, message_type, estimated_size);
   }
 
   // Helper function to schedule a deferred message with known message type
-  bool schedule_message_(EntityBase *entity, MessageCreator creator, uint16_t message_type) {
-    this->deferred_batch_.add_item(entity, std::move(creator), message_type);
+  bool schedule_message_(EntityBase *entity, MessageCreator creator, uint8_t message_type, uint8_t estimated_size) {
+    this->deferred_batch_.add_item(entity, std::move(creator), message_type, estimated_size);
     return this->schedule_batch_();
   }
 
   // Overload for function pointers (for info messages and current state reads)
-  bool schedule_message_(EntityBase *entity, MessageCreatorPtr function_ptr, uint16_t message_type) {
-    return schedule_message_(entity, MessageCreator(function_ptr), message_type);
+  bool schedule_message_(EntityBase *entity, MessageCreatorPtr function_ptr, uint8_t message_type,
+                         uint8_t estimated_size) {
+    return schedule_message_(entity, MessageCreator(function_ptr), message_type, estimated_size);
   }
 
   // Helper function to schedule a high priority message at the front of the batch
-  bool schedule_message_front_(EntityBase *entity, MessageCreatorPtr function_ptr, uint16_t message_type) {
-    this->deferred_batch_.add_item_front(entity, MessageCreator(function_ptr), message_type);
+  bool schedule_message_front_(EntityBase *entity, MessageCreatorPtr function_ptr, uint8_t message_type,
+                               uint8_t estimated_size) {
+    this->deferred_batch_.add_item_front(entity, MessageCreator(function_ptr), message_type, estimated_size);
     return this->schedule_batch_();
   }
 };

--- a/esphome/components/api/api_connection.h
+++ b/esphome/components/api/api_connection.h
@@ -628,7 +628,7 @@ class APIConnection : public APIServerConnection {
   // to send in one go. This is the maximum size of a single packet
   // that can be sent over the network.
   // This is to avoid fragmentation of the packet.
-  static constexpr size_t MAX_PACKET_SIZE = 1390;  // MTU
+  static constexpr size_t MAX_BATCH_PACKET_SIZE = 1390;  // MTU
 
   bool schedule_batch_();
   void process_batch_();
@@ -641,7 +641,7 @@ class APIConnection : public APIServerConnection {
   // Helper to log a proto message from a MessageCreator object
   void log_proto_message_(EntityBase *entity, const MessageCreator &creator, uint8_t message_type) {
     this->flags_.log_only_mode = true;
-    creator(entity, this, MAX_PACKET_SIZE, true, message_type);
+    creator(entity, this, MAX_BATCH_PACKET_SIZE, true, message_type);
     this->flags_.log_only_mode = false;
   }
 
@@ -661,7 +661,7 @@ class APIConnection : public APIServerConnection {
     if (this->flags_.should_try_send_immediately && this->get_batch_delay_ms_() == 0 &&
         this->helper_->can_write_without_blocking()) {
       // Now actually encode and send
-      if (creator(entity, this, MAX_PACKET_SIZE, true) &&
+      if (creator(entity, this, MAX_BATCH_PACKET_SIZE, true) &&
           this->send_buffer(ProtoWriteBuffer{&this->parent_->get_shared_buffer_ref()}, message_type)) {
 #ifdef HAS_PROTO_MESSAGE_DUMP
         // Log the message in verbose mode

--- a/esphome/components/api/api_frame_helper.cpp
+++ b/esphome/components/api/api_frame_helper.cpp
@@ -613,7 +613,7 @@ APIError APINoiseFrameHelper::read_packet(ReadPacketBuffer *buffer) {
   buffer->type = type;
   return APIError::OK;
 }
-APIError APINoiseFrameHelper::write_protobuf_packet(uint16_t type, ProtoWriteBuffer buffer) {
+APIError APINoiseFrameHelper::write_protobuf_packet(uint8_t type, ProtoWriteBuffer buffer) {
   // Resize to include MAC space (required for Noise encryption)
   buffer.get_buffer()->resize(buffer.get_buffer()->size() + frame_footer_size_);
   PacketInfo packet{type, 0,
@@ -1002,7 +1002,7 @@ APIError APIPlaintextFrameHelper::read_packet(ReadPacketBuffer *buffer) {
   buffer->type = rx_header_parsed_type_;
   return APIError::OK;
 }
-APIError APIPlaintextFrameHelper::write_protobuf_packet(uint16_t type, ProtoWriteBuffer buffer) {
+APIError APIPlaintextFrameHelper::write_protobuf_packet(uint8_t type, ProtoWriteBuffer buffer) {
   PacketInfo packet{type, 0, static_cast<uint16_t>(buffer.get_buffer()->size() - frame_header_padding_)};
   return write_protobuf_packets(buffer, std::span<const PacketInfo>(&packet, 1));
 }

--- a/esphome/components/api/api_frame_helper.cpp
+++ b/esphome/components/api/api_frame_helper.cpp
@@ -62,8 +62,6 @@ const char *api_error_to_str(APIError err) {
     return "BAD_HANDSHAKE_ERROR_BYTE";
   } else if (err == APIError::CONNECTION_CLOSED) {
     return "CONNECTION_CLOSED";
-  } else if (err == APIError::MESSAGE_TOO_LARGE) {
-    return "MESSAGE_TOO_LARGE";
   }
   return "UNKNOWN";
 }
@@ -621,11 +619,6 @@ APIError APINoiseFrameHelper::write_protobuf_packet(uint8_t type, ProtoWriteBuff
   uint16_t payload_size =
       static_cast<uint16_t>(buffer.get_buffer()->size() - frame_header_padding_ - frame_footer_size_);
 
-  // Check if message exceeds PacketInfo limits
-  if (payload_size > PacketInfo::MAX_PAYLOAD_SIZE) {
-    return APIError::MESSAGE_TOO_LARGE;
-  }
-
   PacketInfo packet{type, 0, payload_size};
   return write_protobuf_packets(buffer, std::span<const PacketInfo>(&packet, 1));
 }
@@ -1013,11 +1006,6 @@ APIError APIPlaintextFrameHelper::read_packet(ReadPacketBuffer *buffer) {
 }
 APIError APIPlaintextFrameHelper::write_protobuf_packet(uint8_t type, ProtoWriteBuffer buffer) {
   uint16_t payload_size = static_cast<uint16_t>(buffer.get_buffer()->size() - frame_header_padding_);
-
-  // Check if message exceeds PacketInfo limits
-  if (payload_size > PacketInfo::MAX_PAYLOAD_SIZE) {
-    return APIError::MESSAGE_TOO_LARGE;
-  }
 
   PacketInfo packet{type, 0, payload_size};
   return write_protobuf_packets(buffer, std::span<const PacketInfo>(&packet, 1));

--- a/esphome/components/api/api_frame_helper.cpp
+++ b/esphome/components/api/api_frame_helper.cpp
@@ -616,10 +616,8 @@ APIError APINoiseFrameHelper::read_packet(ReadPacketBuffer *buffer) {
 APIError APINoiseFrameHelper::write_protobuf_packet(uint8_t type, ProtoWriteBuffer buffer) {
   // Resize to include MAC space (required for Noise encryption)
   buffer.get_buffer()->resize(buffer.get_buffer()->size() + frame_footer_size_);
-  uint16_t payload_size =
-      static_cast<uint16_t>(buffer.get_buffer()->size() - frame_header_padding_ - frame_footer_size_);
-
-  PacketInfo packet{type, 0, payload_size};
+  PacketInfo packet{type, 0,
+                    static_cast<uint16_t>(buffer.get_buffer()->size() - frame_header_padding_ - frame_footer_size_)};
   return write_protobuf_packets(buffer, std::span<const PacketInfo>(&packet, 1));
 }
 
@@ -1005,9 +1003,7 @@ APIError APIPlaintextFrameHelper::read_packet(ReadPacketBuffer *buffer) {
   return APIError::OK;
 }
 APIError APIPlaintextFrameHelper::write_protobuf_packet(uint8_t type, ProtoWriteBuffer buffer) {
-  uint16_t payload_size = static_cast<uint16_t>(buffer.get_buffer()->size() - frame_header_padding_);
-
-  PacketInfo packet{type, 0, payload_size};
+  PacketInfo packet{type, 0, static_cast<uint16_t>(buffer.get_buffer()->size() - frame_header_padding_)};
   return write_protobuf_packets(buffer, std::span<const PacketInfo>(&packet, 1));
 }
 

--- a/esphome/components/api/api_frame_helper.cpp
+++ b/esphome/components/api/api_frame_helper.cpp
@@ -62,6 +62,8 @@ const char *api_error_to_str(APIError err) {
     return "BAD_HANDSHAKE_ERROR_BYTE";
   } else if (err == APIError::CONNECTION_CLOSED) {
     return "CONNECTION_CLOSED";
+  } else if (err == APIError::MESSAGE_TOO_LARGE) {
+    return "MESSAGE_TOO_LARGE";
   }
   return "UNKNOWN";
 }
@@ -616,8 +618,15 @@ APIError APINoiseFrameHelper::read_packet(ReadPacketBuffer *buffer) {
 APIError APINoiseFrameHelper::write_protobuf_packet(uint8_t type, ProtoWriteBuffer buffer) {
   // Resize to include MAC space (required for Noise encryption)
   buffer.get_buffer()->resize(buffer.get_buffer()->size() + frame_footer_size_);
-  PacketInfo packet{type, 0,
-                    static_cast<uint16_t>(buffer.get_buffer()->size() - frame_header_padding_ - frame_footer_size_)};
+  uint16_t payload_size =
+      static_cast<uint16_t>(buffer.get_buffer()->size() - frame_header_padding_ - frame_footer_size_);
+
+  // Check if message exceeds PacketInfo limits
+  if (payload_size > PacketInfo::MAX_PAYLOAD_SIZE) {
+    return APIError::MESSAGE_TOO_LARGE;
+  }
+
+  PacketInfo packet{type, 0, payload_size};
   return write_protobuf_packets(buffer, std::span<const PacketInfo>(&packet, 1));
 }
 
@@ -1003,7 +1012,14 @@ APIError APIPlaintextFrameHelper::read_packet(ReadPacketBuffer *buffer) {
   return APIError::OK;
 }
 APIError APIPlaintextFrameHelper::write_protobuf_packet(uint8_t type, ProtoWriteBuffer buffer) {
-  PacketInfo packet{type, 0, static_cast<uint16_t>(buffer.get_buffer()->size() - frame_header_padding_)};
+  uint16_t payload_size = static_cast<uint16_t>(buffer.get_buffer()->size() - frame_header_padding_);
+
+  // Check if message exceeds PacketInfo limits
+  if (payload_size > PacketInfo::MAX_PAYLOAD_SIZE) {
+    return APIError::MESSAGE_TOO_LARGE;
+  }
+
+  PacketInfo packet{type, 0, payload_size};
   return write_protobuf_packets(buffer, std::span<const PacketInfo>(&packet, 1));
 }
 

--- a/esphome/components/api/api_frame_helper.h
+++ b/esphome/components/api/api_frame_helper.h
@@ -30,13 +30,14 @@ struct ReadPacketBuffer {
 
 // Packed packet info structure to minimize memory usage
 struct PacketInfo {
-  uint16_t message_type;  // 2 bytes
+  uint8_t message_type;   // 1 byte (max 255 message types)
+  uint8_t padding1;       // 1 byte (for alignment)
   uint16_t offset;        // 2 bytes (sufficient for packet size ~1460 bytes)
   uint16_t payload_size;  // 2 bytes (up to 65535 bytes)
-  uint16_t padding;       // 2 byte (for alignment)
+  uint16_t padding2;      // 2 bytes (for alignment to 8 bytes)
 
-  PacketInfo(uint16_t type, uint16_t off, uint16_t size)
-      : message_type(type), offset(off), payload_size(size), padding(0) {}
+  PacketInfo(uint8_t type, uint16_t off, uint16_t size)
+      : message_type(type), padding1(0), offset(off), payload_size(size), padding2(0) {}
 };
 
 enum class APIError : uint16_t {
@@ -98,7 +99,7 @@ class APIFrameHelper {
   }
   // Give this helper a name for logging
   void set_log_info(std::string info) { info_ = std::move(info); }
-  virtual APIError write_protobuf_packet(uint16_t type, ProtoWriteBuffer buffer) = 0;
+  virtual APIError write_protobuf_packet(uint8_t type, ProtoWriteBuffer buffer) = 0;
   // Write multiple protobuf packets in a single operation
   // packets contains (message_type, offset, length) for each message in the buffer
   // The buffer contains all messages with appropriate padding before each
@@ -197,7 +198,7 @@ class APINoiseFrameHelper : public APIFrameHelper {
   APIError init() override;
   APIError loop() override;
   APIError read_packet(ReadPacketBuffer *buffer) override;
-  APIError write_protobuf_packet(uint16_t type, ProtoWriteBuffer buffer) override;
+  APIError write_protobuf_packet(uint8_t type, ProtoWriteBuffer buffer) override;
   APIError write_protobuf_packets(ProtoWriteBuffer buffer, std::span<const PacketInfo> packets) override;
   // Get the frame header padding required by this protocol
   uint8_t frame_header_padding() override { return frame_header_padding_; }
@@ -251,7 +252,7 @@ class APIPlaintextFrameHelper : public APIFrameHelper {
   APIError init() override;
   APIError loop() override;
   APIError read_packet(ReadPacketBuffer *buffer) override;
-  APIError write_protobuf_packet(uint16_t type, ProtoWriteBuffer buffer) override;
+  APIError write_protobuf_packet(uint8_t type, ProtoWriteBuffer buffer) override;
   APIError write_protobuf_packets(ProtoWriteBuffer buffer, std::span<const PacketInfo> packets) override;
   uint8_t frame_header_padding() override { return frame_header_padding_; }
   // Get the frame footer size required by this protocol

--- a/esphome/components/api/api_frame_helper.h
+++ b/esphome/components/api/api_frame_helper.h
@@ -28,16 +28,14 @@ struct ReadPacketBuffer {
   uint16_t data_len;
 };
 
-// Packed packet info structure to minimize memory usage
+// Packet info structure
 struct PacketInfo {
-  uint8_t message_type;   // 1 byte (max 255 message types)
-  uint8_t padding1;       // 1 byte (for alignment)
   uint16_t offset;        // 2 bytes (sufficient for packet size ~1460 bytes)
   uint16_t payload_size;  // 2 bytes (up to 65535 bytes)
-  uint16_t padding2;      // 2 bytes (for alignment to 8 bytes)
+  uint8_t message_type;   // 1 byte (max 255 message types)
+  // Total: 5 bytes, compiler adds 3 bytes padding for alignment (8 bytes total)
 
-  PacketInfo(uint8_t type, uint16_t off, uint16_t size)
-      : message_type(type), padding1(0), offset(off), payload_size(size), padding2(0) {}
+  PacketInfo(uint8_t type, uint16_t off, uint16_t size) : offset(off), payload_size(size), message_type(type) {}
 };
 
 enum class APIError : uint16_t {

--- a/esphome/components/api/api_frame_helper.h
+++ b/esphome/components/api/api_frame_helper.h
@@ -28,13 +28,13 @@ struct ReadPacketBuffer {
   uint16_t data_len;
 };
 
-// Packet info structure for batching multiple messages
+// Packed packet info structure to minimize memory usage
 struct PacketInfo {
-  uint8_t message_type;   // Message type (0-255)
   uint16_t offset;        // Offset in buffer where message starts
   uint16_t payload_size;  // Size of the message payload
+  uint8_t message_type;   // Message type (0-255)
 
-  PacketInfo(uint8_t type, uint16_t off, uint16_t size) : message_type(type), offset(off), payload_size(size) {}
+  PacketInfo(uint8_t type, uint16_t off, uint16_t size) : offset(off), payload_size(size), message_type(type) {}
 };
 
 enum class APIError : uint16_t {

--- a/esphome/components/api/api_frame_helper.h
+++ b/esphome/components/api/api_frame_helper.h
@@ -30,22 +30,27 @@ struct ReadPacketBuffer {
 
 // Packet info structure - packed into 4 bytes using bit fields
 // Note: While the API protocol supports message sizes up to 65535 (uint16_t),
-// we limit payload_size and offset to 4095 (12 bits) for practical reasons:
-// 1. Messages larger than 4095 bytes cannot be sent immediately
-// 2. They will be buffered, potentially filling up the tx buffer
-// 3. Large messages risk network fragmentation issues
-// 4. The typical MTU-based batch size (MAX_BATCH_PACKET_SIZE) is 1390 bytes
-// This limitation provides a good balance between efficiency and practicality.
+// we limit offset to 2047 (11 bits) and payload_size to 8191 (13 bits) for practical reasons:
+// 1. Messages larger than 8KB are rare but do occur (e.g., select entities with many options)
+// 2. Very large messages may cause memory pressure on constrained devices
+// 3. The typical MTU-based batch size (MAX_BATCH_PACKET_SIZE) is 1390 bytes
+//
+// Why MAX_OFFSET (2047) > MAX_BATCH_PACKET_SIZE (1390):
+// When batching, messages are only included if the total batch size stays under
+// MAX_BATCH_PACKET_SIZE. However, we need extra headroom in MAX_OFFSET for:
+// - Protocol headers and padding for each message in the batch
+// - Future protocol extensions that might need additional offset space
+// Large messages (> MAX_BATCH_PACKET_SIZE) are sent individually with offset=0.
 struct PacketInfo {
-  static constexpr uint16_t MAX_OFFSET = 4095;        // 12 bits max
-  static constexpr uint16_t MAX_PAYLOAD_SIZE = 4095;  // 12 bits max
+  static constexpr uint16_t MAX_OFFSET = 2047;        // 11 bits max
+  static constexpr uint16_t MAX_PAYLOAD_SIZE = 8191;  // 13 bits max
 
-  uint32_t offset : 12;        // 12 bits: 0-4095
-  uint32_t payload_size : 12;  // 12 bits: 0-4095
   uint32_t message_type : 8;   // 8 bits: 0-255
+  uint32_t offset : 11;        // 11 bits: 0-2047
+  uint32_t payload_size : 13;  // 13 bits: 0-8191
   // Total: 32 bits = 4 bytes exactly
 
-  PacketInfo(uint8_t type, uint16_t off, uint16_t size) : offset(off), payload_size(size), message_type(type) {}
+  PacketInfo(uint8_t type, uint16_t off, uint16_t size) : message_type(type), offset(off), payload_size(size) {}
 };
 
 enum class APIError : uint16_t {

--- a/esphome/components/api/api_frame_helper.h
+++ b/esphome/components/api/api_frame_helper.h
@@ -1,5 +1,4 @@
 #pragma once
-#include <cassert>
 #include <cstdint>
 #include <deque>
 #include <limits>
@@ -46,10 +45,7 @@ struct PacketInfo {
   uint32_t message_type : 8;   // 8 bits: 0-255
   // Total: 32 bits = 4 bytes exactly
 
-  PacketInfo(uint8_t type, uint16_t off, uint16_t size) : offset(off), payload_size(size), message_type(type) {
-    assert(off <= MAX_OFFSET);
-    assert(size <= MAX_PAYLOAD_SIZE);
-  }
+  PacketInfo(uint8_t type, uint16_t off, uint16_t size) : offset(off), payload_size(size), message_type(type) {}
 };
 
 enum class APIError : uint16_t {

--- a/esphome/components/api/api_frame_helper.h
+++ b/esphome/components/api/api_frame_helper.h
@@ -28,27 +28,11 @@ struct ReadPacketBuffer {
   uint16_t data_len;
 };
 
-// Packet info structure - packed into 4 bytes using bit fields
-// Note: While the API protocol supports message sizes up to 65535 (uint16_t),
-// we limit offset to 2047 (11 bits) and payload_size to 8191 (13 bits) for practical reasons:
-// 1. Messages larger than 8KB are rare but do occur (e.g., select entities with many options)
-// 2. Very large messages may cause memory pressure on constrained devices
-// 3. The typical MTU-based batch size (MAX_BATCH_PACKET_SIZE) is 1390 bytes
-//
-// Why MAX_OFFSET (2047) > MAX_BATCH_PACKET_SIZE (1390):
-// When batching, messages are only included if the total batch size stays under
-// MAX_BATCH_PACKET_SIZE. However, we need extra headroom in MAX_OFFSET for:
-// - Protocol headers and padding for each message in the batch
-// - Future protocol extensions that might need additional offset space
-// Large messages (> MAX_BATCH_PACKET_SIZE) are sent individually with offset=0.
+// Packet info structure for batching multiple messages
 struct PacketInfo {
-  static constexpr uint16_t MAX_OFFSET = 2047;        // 11 bits max
-  static constexpr uint16_t MAX_PAYLOAD_SIZE = 8191;  // 13 bits max
-
-  uint32_t message_type : 8;   // 8 bits: 0-255
-  uint32_t offset : 11;        // 11 bits: 0-2047
-  uint32_t payload_size : 13;  // 13 bits: 0-8191
-  // Total: 32 bits = 4 bytes exactly
+  uint8_t message_type;   // Message type (0-255)
+  uint16_t offset;        // Offset in buffer where message starts
+  uint16_t payload_size;  // Size of the message payload
 
   PacketInfo(uint8_t type, uint16_t off, uint16_t size) : message_type(type), offset(off), payload_size(size) {}
 };
@@ -77,7 +61,6 @@ enum class APIError : uint16_t {
   HANDSHAKESTATE_SPLIT_FAILED = 1020,
   BAD_HANDSHAKE_ERROR_BYTE = 1021,
   CONNECTION_CLOSED = 1022,
-  MESSAGE_TOO_LARGE = 1023,
 };
 
 const char *api_error_to_str(APIError err);

--- a/esphome/components/api/api_frame_helper.h
+++ b/esphome/components/api/api_frame_helper.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cassert>
 #include <cstdint>
 #include <deque>
 #include <limits>
@@ -28,14 +29,27 @@ struct ReadPacketBuffer {
   uint16_t data_len;
 };
 
-// Packet info structure
+// Packet info structure - packed into 4 bytes using bit fields
+// Note: While the API protocol supports message sizes up to 65535 (uint16_t),
+// we limit payload_size and offset to 4095 (12 bits) for practical reasons:
+// 1. Messages larger than 4095 bytes cannot be sent immediately
+// 2. They will be buffered, potentially filling up the tx buffer
+// 3. Large messages risk network fragmentation issues
+// 4. The typical MTU-based batch size (MAX_BATCH_PACKET_SIZE) is 1390 bytes
+// This limitation provides a good balance between efficiency and practicality.
 struct PacketInfo {
-  uint16_t offset;        // 2 bytes (sufficient for packet size ~1460 bytes)
-  uint16_t payload_size;  // 2 bytes (up to 65535 bytes)
-  uint8_t message_type;   // 1 byte (max 255 message types)
-  // Total: 5 bytes, compiler adds 3 bytes padding for alignment (8 bytes total)
+  static constexpr uint16_t MAX_OFFSET = 4095;        // 12 bits max
+  static constexpr uint16_t MAX_PAYLOAD_SIZE = 4095;  // 12 bits max
 
-  PacketInfo(uint8_t type, uint16_t off, uint16_t size) : offset(off), payload_size(size), message_type(type) {}
+  uint32_t offset : 12;        // 12 bits: 0-4095
+  uint32_t payload_size : 12;  // 12 bits: 0-4095
+  uint32_t message_type : 8;   // 8 bits: 0-255
+  // Total: 32 bits = 4 bytes exactly
+
+  PacketInfo(uint8_t type, uint16_t off, uint16_t size) : offset(off), payload_size(size), message_type(type) {
+    assert(off <= MAX_OFFSET);
+    assert(size <= MAX_PAYLOAD_SIZE);
+  }
 };
 
 enum class APIError : uint16_t {
@@ -62,6 +76,7 @@ enum class APIError : uint16_t {
   HANDSHAKESTATE_SPLIT_FAILED = 1020,
   BAD_HANDSHAKE_ERROR_BYTE = 1021,
   CONNECTION_CLOSED = 1022,
+  MESSAGE_TOO_LARGE = 1023,
 };
 
 const char *api_error_to_str(APIError err);

--- a/esphome/components/api/api_pb2.h
+++ b/esphome/components/api/api_pb2.h
@@ -318,8 +318,8 @@ class CommandProtoMessage : public ProtoMessage {
 };
 class HelloRequest : public ProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 1;
-  static constexpr uint16_t ESTIMATED_SIZE = 17;
+  static constexpr uint8_t MESSAGE_TYPE = 1;
+  static constexpr uint8_t ESTIMATED_SIZE = 17;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "hello_request"; }
 #endif
@@ -338,8 +338,8 @@ class HelloRequest : public ProtoMessage {
 };
 class HelloResponse : public ProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 2;
-  static constexpr uint16_t ESTIMATED_SIZE = 26;
+  static constexpr uint8_t MESSAGE_TYPE = 2;
+  static constexpr uint8_t ESTIMATED_SIZE = 26;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "hello_response"; }
 #endif
@@ -359,8 +359,8 @@ class HelloResponse : public ProtoMessage {
 };
 class ConnectRequest : public ProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 3;
-  static constexpr uint16_t ESTIMATED_SIZE = 9;
+  static constexpr uint8_t MESSAGE_TYPE = 3;
+  static constexpr uint8_t ESTIMATED_SIZE = 9;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "connect_request"; }
 #endif
@@ -376,8 +376,8 @@ class ConnectRequest : public ProtoMessage {
 };
 class ConnectResponse : public ProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 4;
-  static constexpr uint16_t ESTIMATED_SIZE = 2;
+  static constexpr uint8_t MESSAGE_TYPE = 4;
+  static constexpr uint8_t ESTIMATED_SIZE = 2;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "connect_response"; }
 #endif
@@ -393,8 +393,8 @@ class ConnectResponse : public ProtoMessage {
 };
 class DisconnectRequest : public ProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 5;
-  static constexpr uint16_t ESTIMATED_SIZE = 0;
+  static constexpr uint8_t MESSAGE_TYPE = 5;
+  static constexpr uint8_t ESTIMATED_SIZE = 0;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "disconnect_request"; }
 #endif
@@ -406,8 +406,8 @@ class DisconnectRequest : public ProtoMessage {
 };
 class DisconnectResponse : public ProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 6;
-  static constexpr uint16_t ESTIMATED_SIZE = 0;
+  static constexpr uint8_t MESSAGE_TYPE = 6;
+  static constexpr uint8_t ESTIMATED_SIZE = 0;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "disconnect_response"; }
 #endif
@@ -419,8 +419,8 @@ class DisconnectResponse : public ProtoMessage {
 };
 class PingRequest : public ProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 7;
-  static constexpr uint16_t ESTIMATED_SIZE = 0;
+  static constexpr uint8_t MESSAGE_TYPE = 7;
+  static constexpr uint8_t ESTIMATED_SIZE = 0;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "ping_request"; }
 #endif
@@ -432,8 +432,8 @@ class PingRequest : public ProtoMessage {
 };
 class PingResponse : public ProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 8;
-  static constexpr uint16_t ESTIMATED_SIZE = 0;
+  static constexpr uint8_t MESSAGE_TYPE = 8;
+  static constexpr uint8_t ESTIMATED_SIZE = 0;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "ping_response"; }
 #endif
@@ -445,8 +445,8 @@ class PingResponse : public ProtoMessage {
 };
 class DeviceInfoRequest : public ProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 9;
-  static constexpr uint16_t ESTIMATED_SIZE = 0;
+  static constexpr uint8_t MESSAGE_TYPE = 9;
+  static constexpr uint8_t ESTIMATED_SIZE = 0;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "device_info_request"; }
 #endif
@@ -487,8 +487,8 @@ class DeviceInfo : public ProtoMessage {
 };
 class DeviceInfoResponse : public ProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 10;
-  static constexpr uint16_t ESTIMATED_SIZE = 219;
+  static constexpr uint8_t MESSAGE_TYPE = 10;
+  static constexpr uint8_t ESTIMATED_SIZE = 219;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "device_info_response"; }
 #endif
@@ -526,8 +526,8 @@ class DeviceInfoResponse : public ProtoMessage {
 };
 class ListEntitiesRequest : public ProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 11;
-  static constexpr uint16_t ESTIMATED_SIZE = 0;
+  static constexpr uint8_t MESSAGE_TYPE = 11;
+  static constexpr uint8_t ESTIMATED_SIZE = 0;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "list_entities_request"; }
 #endif
@@ -539,8 +539,8 @@ class ListEntitiesRequest : public ProtoMessage {
 };
 class ListEntitiesDoneResponse : public ProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 19;
-  static constexpr uint16_t ESTIMATED_SIZE = 0;
+  static constexpr uint8_t MESSAGE_TYPE = 19;
+  static constexpr uint8_t ESTIMATED_SIZE = 0;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "list_entities_done_response"; }
 #endif
@@ -552,8 +552,8 @@ class ListEntitiesDoneResponse : public ProtoMessage {
 };
 class SubscribeStatesRequest : public ProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 20;
-  static constexpr uint16_t ESTIMATED_SIZE = 0;
+  static constexpr uint8_t MESSAGE_TYPE = 20;
+  static constexpr uint8_t ESTIMATED_SIZE = 0;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "subscribe_states_request"; }
 #endif
@@ -566,8 +566,8 @@ class SubscribeStatesRequest : public ProtoMessage {
 #ifdef USE_BINARY_SENSOR
 class ListEntitiesBinarySensorResponse : public InfoResponseProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 12;
-  static constexpr uint16_t ESTIMATED_SIZE = 60;
+  static constexpr uint8_t MESSAGE_TYPE = 12;
+  static constexpr uint8_t ESTIMATED_SIZE = 60;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "list_entities_binary_sensor_response"; }
 #endif
@@ -586,8 +586,8 @@ class ListEntitiesBinarySensorResponse : public InfoResponseProtoMessage {
 };
 class BinarySensorStateResponse : public StateResponseProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 21;
-  static constexpr uint16_t ESTIMATED_SIZE = 13;
+  static constexpr uint8_t MESSAGE_TYPE = 21;
+  static constexpr uint8_t ESTIMATED_SIZE = 13;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "binary_sensor_state_response"; }
 #endif
@@ -607,8 +607,8 @@ class BinarySensorStateResponse : public StateResponseProtoMessage {
 #ifdef USE_COVER
 class ListEntitiesCoverResponse : public InfoResponseProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 13;
-  static constexpr uint16_t ESTIMATED_SIZE = 66;
+  static constexpr uint8_t MESSAGE_TYPE = 13;
+  static constexpr uint8_t ESTIMATED_SIZE = 66;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "list_entities_cover_response"; }
 #endif
@@ -630,8 +630,8 @@ class ListEntitiesCoverResponse : public InfoResponseProtoMessage {
 };
 class CoverStateResponse : public StateResponseProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 22;
-  static constexpr uint16_t ESTIMATED_SIZE = 23;
+  static constexpr uint8_t MESSAGE_TYPE = 22;
+  static constexpr uint8_t ESTIMATED_SIZE = 23;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "cover_state_response"; }
 #endif
@@ -651,8 +651,8 @@ class CoverStateResponse : public StateResponseProtoMessage {
 };
 class CoverCommandRequest : public CommandProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 30;
-  static constexpr uint16_t ESTIMATED_SIZE = 29;
+  static constexpr uint8_t MESSAGE_TYPE = 30;
+  static constexpr uint8_t ESTIMATED_SIZE = 29;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "cover_command_request"; }
 #endif
@@ -677,8 +677,8 @@ class CoverCommandRequest : public CommandProtoMessage {
 #ifdef USE_FAN
 class ListEntitiesFanResponse : public InfoResponseProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 14;
-  static constexpr uint16_t ESTIMATED_SIZE = 77;
+  static constexpr uint8_t MESSAGE_TYPE = 14;
+  static constexpr uint8_t ESTIMATED_SIZE = 77;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "list_entities_fan_response"; }
 #endif
@@ -700,8 +700,8 @@ class ListEntitiesFanResponse : public InfoResponseProtoMessage {
 };
 class FanStateResponse : public StateResponseProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 23;
-  static constexpr uint16_t ESTIMATED_SIZE = 30;
+  static constexpr uint8_t MESSAGE_TYPE = 23;
+  static constexpr uint8_t ESTIMATED_SIZE = 30;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "fan_state_response"; }
 #endif
@@ -724,8 +724,8 @@ class FanStateResponse : public StateResponseProtoMessage {
 };
 class FanCommandRequest : public CommandProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 31;
-  static constexpr uint16_t ESTIMATED_SIZE = 42;
+  static constexpr uint8_t MESSAGE_TYPE = 31;
+  static constexpr uint8_t ESTIMATED_SIZE = 42;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "fan_command_request"; }
 #endif
@@ -756,8 +756,8 @@ class FanCommandRequest : public CommandProtoMessage {
 #ifdef USE_LIGHT
 class ListEntitiesLightResponse : public InfoResponseProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 15;
-  static constexpr uint16_t ESTIMATED_SIZE = 90;
+  static constexpr uint8_t MESSAGE_TYPE = 15;
+  static constexpr uint8_t ESTIMATED_SIZE = 90;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "list_entities_light_response"; }
 #endif
@@ -782,8 +782,8 @@ class ListEntitiesLightResponse : public InfoResponseProtoMessage {
 };
 class LightStateResponse : public StateResponseProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 24;
-  static constexpr uint16_t ESTIMATED_SIZE = 67;
+  static constexpr uint8_t MESSAGE_TYPE = 24;
+  static constexpr uint8_t ESTIMATED_SIZE = 67;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "light_state_response"; }
 #endif
@@ -812,8 +812,8 @@ class LightStateResponse : public StateResponseProtoMessage {
 };
 class LightCommandRequest : public CommandProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 32;
-  static constexpr uint16_t ESTIMATED_SIZE = 112;
+  static constexpr uint8_t MESSAGE_TYPE = 32;
+  static constexpr uint8_t ESTIMATED_SIZE = 112;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "light_command_request"; }
 #endif
@@ -858,8 +858,8 @@ class LightCommandRequest : public CommandProtoMessage {
 #ifdef USE_SENSOR
 class ListEntitiesSensorResponse : public InfoResponseProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 16;
-  static constexpr uint16_t ESTIMATED_SIZE = 77;
+  static constexpr uint8_t MESSAGE_TYPE = 16;
+  static constexpr uint8_t ESTIMATED_SIZE = 77;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "list_entities_sensor_response"; }
 #endif
@@ -882,8 +882,8 @@ class ListEntitiesSensorResponse : public InfoResponseProtoMessage {
 };
 class SensorStateResponse : public StateResponseProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 25;
-  static constexpr uint16_t ESTIMATED_SIZE = 16;
+  static constexpr uint8_t MESSAGE_TYPE = 25;
+  static constexpr uint8_t ESTIMATED_SIZE = 16;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "sensor_state_response"; }
 #endif
@@ -903,8 +903,8 @@ class SensorStateResponse : public StateResponseProtoMessage {
 #ifdef USE_SWITCH
 class ListEntitiesSwitchResponse : public InfoResponseProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 17;
-  static constexpr uint16_t ESTIMATED_SIZE = 60;
+  static constexpr uint8_t MESSAGE_TYPE = 17;
+  static constexpr uint8_t ESTIMATED_SIZE = 60;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "list_entities_switch_response"; }
 #endif
@@ -923,8 +923,8 @@ class ListEntitiesSwitchResponse : public InfoResponseProtoMessage {
 };
 class SwitchStateResponse : public StateResponseProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 26;
-  static constexpr uint16_t ESTIMATED_SIZE = 11;
+  static constexpr uint8_t MESSAGE_TYPE = 26;
+  static constexpr uint8_t ESTIMATED_SIZE = 11;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "switch_state_response"; }
 #endif
@@ -941,8 +941,8 @@ class SwitchStateResponse : public StateResponseProtoMessage {
 };
 class SwitchCommandRequest : public CommandProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 33;
-  static constexpr uint16_t ESTIMATED_SIZE = 11;
+  static constexpr uint8_t MESSAGE_TYPE = 33;
+  static constexpr uint8_t ESTIMATED_SIZE = 11;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "switch_command_request"; }
 #endif
@@ -961,8 +961,8 @@ class SwitchCommandRequest : public CommandProtoMessage {
 #ifdef USE_TEXT_SENSOR
 class ListEntitiesTextSensorResponse : public InfoResponseProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 18;
-  static constexpr uint16_t ESTIMATED_SIZE = 58;
+  static constexpr uint8_t MESSAGE_TYPE = 18;
+  static constexpr uint8_t ESTIMATED_SIZE = 58;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "list_entities_text_sensor_response"; }
 #endif
@@ -980,8 +980,8 @@ class ListEntitiesTextSensorResponse : public InfoResponseProtoMessage {
 };
 class TextSensorStateResponse : public StateResponseProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 27;
-  static constexpr uint16_t ESTIMATED_SIZE = 20;
+  static constexpr uint8_t MESSAGE_TYPE = 27;
+  static constexpr uint8_t ESTIMATED_SIZE = 20;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "text_sensor_state_response"; }
 #endif
@@ -1001,8 +1001,8 @@ class TextSensorStateResponse : public StateResponseProtoMessage {
 #endif
 class SubscribeLogsRequest : public ProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 28;
-  static constexpr uint16_t ESTIMATED_SIZE = 4;
+  static constexpr uint8_t MESSAGE_TYPE = 28;
+  static constexpr uint8_t ESTIMATED_SIZE = 4;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "subscribe_logs_request"; }
 #endif
@@ -1019,8 +1019,8 @@ class SubscribeLogsRequest : public ProtoMessage {
 };
 class SubscribeLogsResponse : public ProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 29;
-  static constexpr uint16_t ESTIMATED_SIZE = 13;
+  static constexpr uint8_t MESSAGE_TYPE = 29;
+  static constexpr uint8_t ESTIMATED_SIZE = 13;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "subscribe_logs_response"; }
 #endif
@@ -1040,8 +1040,8 @@ class SubscribeLogsResponse : public ProtoMessage {
 #ifdef USE_API_NOISE
 class NoiseEncryptionSetKeyRequest : public ProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 124;
-  static constexpr uint16_t ESTIMATED_SIZE = 9;
+  static constexpr uint8_t MESSAGE_TYPE = 124;
+  static constexpr uint8_t ESTIMATED_SIZE = 9;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "noise_encryption_set_key_request"; }
 #endif
@@ -1057,8 +1057,8 @@ class NoiseEncryptionSetKeyRequest : public ProtoMessage {
 };
 class NoiseEncryptionSetKeyResponse : public ProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 125;
-  static constexpr uint16_t ESTIMATED_SIZE = 2;
+  static constexpr uint8_t MESSAGE_TYPE = 125;
+  static constexpr uint8_t ESTIMATED_SIZE = 2;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "noise_encryption_set_key_response"; }
 #endif
@@ -1075,8 +1075,8 @@ class NoiseEncryptionSetKeyResponse : public ProtoMessage {
 #endif
 class SubscribeHomeassistantServicesRequest : public ProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 34;
-  static constexpr uint16_t ESTIMATED_SIZE = 0;
+  static constexpr uint8_t MESSAGE_TYPE = 34;
+  static constexpr uint8_t ESTIMATED_SIZE = 0;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "subscribe_homeassistant_services_request"; }
 #endif
@@ -1101,8 +1101,8 @@ class HomeassistantServiceMap : public ProtoMessage {
 };
 class HomeassistantServiceResponse : public ProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 35;
-  static constexpr uint16_t ESTIMATED_SIZE = 113;
+  static constexpr uint8_t MESSAGE_TYPE = 35;
+  static constexpr uint8_t ESTIMATED_SIZE = 113;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "homeassistant_service_response"; }
 #endif
@@ -1123,8 +1123,8 @@ class HomeassistantServiceResponse : public ProtoMessage {
 };
 class SubscribeHomeAssistantStatesRequest : public ProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 38;
-  static constexpr uint16_t ESTIMATED_SIZE = 0;
+  static constexpr uint8_t MESSAGE_TYPE = 38;
+  static constexpr uint8_t ESTIMATED_SIZE = 0;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "subscribe_home_assistant_states_request"; }
 #endif
@@ -1136,8 +1136,8 @@ class SubscribeHomeAssistantStatesRequest : public ProtoMessage {
 };
 class SubscribeHomeAssistantStateResponse : public ProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 39;
-  static constexpr uint16_t ESTIMATED_SIZE = 20;
+  static constexpr uint8_t MESSAGE_TYPE = 39;
+  static constexpr uint8_t ESTIMATED_SIZE = 20;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "subscribe_home_assistant_state_response"; }
 #endif
@@ -1156,8 +1156,8 @@ class SubscribeHomeAssistantStateResponse : public ProtoMessage {
 };
 class HomeAssistantStateResponse : public ProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 40;
-  static constexpr uint16_t ESTIMATED_SIZE = 27;
+  static constexpr uint8_t MESSAGE_TYPE = 40;
+  static constexpr uint8_t ESTIMATED_SIZE = 27;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "home_assistant_state_response"; }
 #endif
@@ -1175,8 +1175,8 @@ class HomeAssistantStateResponse : public ProtoMessage {
 };
 class GetTimeRequest : public ProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 36;
-  static constexpr uint16_t ESTIMATED_SIZE = 0;
+  static constexpr uint8_t MESSAGE_TYPE = 36;
+  static constexpr uint8_t ESTIMATED_SIZE = 0;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "get_time_request"; }
 #endif
@@ -1188,8 +1188,8 @@ class GetTimeRequest : public ProtoMessage {
 };
 class GetTimeResponse : public ProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 37;
-  static constexpr uint16_t ESTIMATED_SIZE = 5;
+  static constexpr uint8_t MESSAGE_TYPE = 37;
+  static constexpr uint8_t ESTIMATED_SIZE = 5;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "get_time_response"; }
 #endif
@@ -1219,8 +1219,8 @@ class ListEntitiesServicesArgument : public ProtoMessage {
 };
 class ListEntitiesServicesResponse : public ProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 41;
-  static constexpr uint16_t ESTIMATED_SIZE = 48;
+  static constexpr uint8_t MESSAGE_TYPE = 41;
+  static constexpr uint8_t ESTIMATED_SIZE = 48;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "list_entities_services_response"; }
 #endif
@@ -1261,8 +1261,8 @@ class ExecuteServiceArgument : public ProtoMessage {
 };
 class ExecuteServiceRequest : public ProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 42;
-  static constexpr uint16_t ESTIMATED_SIZE = 39;
+  static constexpr uint8_t MESSAGE_TYPE = 42;
+  static constexpr uint8_t ESTIMATED_SIZE = 39;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "execute_service_request"; }
 #endif
@@ -1281,8 +1281,8 @@ class ExecuteServiceRequest : public ProtoMessage {
 #ifdef USE_CAMERA
 class ListEntitiesCameraResponse : public InfoResponseProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 43;
-  static constexpr uint16_t ESTIMATED_SIZE = 49;
+  static constexpr uint8_t MESSAGE_TYPE = 43;
+  static constexpr uint8_t ESTIMATED_SIZE = 49;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "list_entities_camera_response"; }
 #endif
@@ -1299,8 +1299,8 @@ class ListEntitiesCameraResponse : public InfoResponseProtoMessage {
 };
 class CameraImageResponse : public StateResponseProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 44;
-  static constexpr uint16_t ESTIMATED_SIZE = 20;
+  static constexpr uint8_t MESSAGE_TYPE = 44;
+  static constexpr uint8_t ESTIMATED_SIZE = 20;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "camera_image_response"; }
 #endif
@@ -1319,8 +1319,8 @@ class CameraImageResponse : public StateResponseProtoMessage {
 };
 class CameraImageRequest : public ProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 45;
-  static constexpr uint16_t ESTIMATED_SIZE = 4;
+  static constexpr uint8_t MESSAGE_TYPE = 45;
+  static constexpr uint8_t ESTIMATED_SIZE = 4;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "camera_image_request"; }
 #endif
@@ -1339,8 +1339,8 @@ class CameraImageRequest : public ProtoMessage {
 #ifdef USE_CLIMATE
 class ListEntitiesClimateResponse : public InfoResponseProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 46;
-  static constexpr uint16_t ESTIMATED_SIZE = 156;
+  static constexpr uint8_t MESSAGE_TYPE = 46;
+  static constexpr uint8_t ESTIMATED_SIZE = 156;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "list_entities_climate_response"; }
 #endif
@@ -1375,8 +1375,8 @@ class ListEntitiesClimateResponse : public InfoResponseProtoMessage {
 };
 class ClimateStateResponse : public StateResponseProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 47;
-  static constexpr uint16_t ESTIMATED_SIZE = 70;
+  static constexpr uint8_t MESSAGE_TYPE = 47;
+  static constexpr uint8_t ESTIMATED_SIZE = 70;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "climate_state_response"; }
 #endif
@@ -1407,8 +1407,8 @@ class ClimateStateResponse : public StateResponseProtoMessage {
 };
 class ClimateCommandRequest : public CommandProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 48;
-  static constexpr uint16_t ESTIMATED_SIZE = 88;
+  static constexpr uint8_t MESSAGE_TYPE = 48;
+  static constexpr uint8_t ESTIMATED_SIZE = 88;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "climate_command_request"; }
 #endif
@@ -1449,8 +1449,8 @@ class ClimateCommandRequest : public CommandProtoMessage {
 #ifdef USE_NUMBER
 class ListEntitiesNumberResponse : public InfoResponseProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 49;
-  static constexpr uint16_t ESTIMATED_SIZE = 84;
+  static constexpr uint8_t MESSAGE_TYPE = 49;
+  static constexpr uint8_t ESTIMATED_SIZE = 84;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "list_entities_number_response"; }
 #endif
@@ -1473,8 +1473,8 @@ class ListEntitiesNumberResponse : public InfoResponseProtoMessage {
 };
 class NumberStateResponse : public StateResponseProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 50;
-  static constexpr uint16_t ESTIMATED_SIZE = 16;
+  static constexpr uint8_t MESSAGE_TYPE = 50;
+  static constexpr uint8_t ESTIMATED_SIZE = 16;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "number_state_response"; }
 #endif
@@ -1492,8 +1492,8 @@ class NumberStateResponse : public StateResponseProtoMessage {
 };
 class NumberCommandRequest : public CommandProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 51;
-  static constexpr uint16_t ESTIMATED_SIZE = 14;
+  static constexpr uint8_t MESSAGE_TYPE = 51;
+  static constexpr uint8_t ESTIMATED_SIZE = 14;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "number_command_request"; }
 #endif
@@ -1512,8 +1512,8 @@ class NumberCommandRequest : public CommandProtoMessage {
 #ifdef USE_SELECT
 class ListEntitiesSelectResponse : public InfoResponseProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 52;
-  static constexpr uint16_t ESTIMATED_SIZE = 67;
+  static constexpr uint8_t MESSAGE_TYPE = 52;
+  static constexpr uint8_t ESTIMATED_SIZE = 67;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "list_entities_select_response"; }
 #endif
@@ -1531,8 +1531,8 @@ class ListEntitiesSelectResponse : public InfoResponseProtoMessage {
 };
 class SelectStateResponse : public StateResponseProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 53;
-  static constexpr uint16_t ESTIMATED_SIZE = 20;
+  static constexpr uint8_t MESSAGE_TYPE = 53;
+  static constexpr uint8_t ESTIMATED_SIZE = 20;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "select_state_response"; }
 #endif
@@ -1551,8 +1551,8 @@ class SelectStateResponse : public StateResponseProtoMessage {
 };
 class SelectCommandRequest : public CommandProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 54;
-  static constexpr uint16_t ESTIMATED_SIZE = 18;
+  static constexpr uint8_t MESSAGE_TYPE = 54;
+  static constexpr uint8_t ESTIMATED_SIZE = 18;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "select_command_request"; }
 #endif
@@ -1572,8 +1572,8 @@ class SelectCommandRequest : public CommandProtoMessage {
 #ifdef USE_SIREN
 class ListEntitiesSirenResponse : public InfoResponseProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 55;
-  static constexpr uint16_t ESTIMATED_SIZE = 71;
+  static constexpr uint8_t MESSAGE_TYPE = 55;
+  static constexpr uint8_t ESTIMATED_SIZE = 71;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "list_entities_siren_response"; }
 #endif
@@ -1593,8 +1593,8 @@ class ListEntitiesSirenResponse : public InfoResponseProtoMessage {
 };
 class SirenStateResponse : public StateResponseProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 56;
-  static constexpr uint16_t ESTIMATED_SIZE = 11;
+  static constexpr uint8_t MESSAGE_TYPE = 56;
+  static constexpr uint8_t ESTIMATED_SIZE = 11;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "siren_state_response"; }
 #endif
@@ -1611,8 +1611,8 @@ class SirenStateResponse : public StateResponseProtoMessage {
 };
 class SirenCommandRequest : public CommandProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 57;
-  static constexpr uint16_t ESTIMATED_SIZE = 37;
+  static constexpr uint8_t MESSAGE_TYPE = 57;
+  static constexpr uint8_t ESTIMATED_SIZE = 37;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "siren_command_request"; }
 #endif
@@ -1639,8 +1639,8 @@ class SirenCommandRequest : public CommandProtoMessage {
 #ifdef USE_LOCK
 class ListEntitiesLockResponse : public InfoResponseProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 58;
-  static constexpr uint16_t ESTIMATED_SIZE = 64;
+  static constexpr uint8_t MESSAGE_TYPE = 58;
+  static constexpr uint8_t ESTIMATED_SIZE = 64;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "list_entities_lock_response"; }
 #endif
@@ -1661,8 +1661,8 @@ class ListEntitiesLockResponse : public InfoResponseProtoMessage {
 };
 class LockStateResponse : public StateResponseProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 59;
-  static constexpr uint16_t ESTIMATED_SIZE = 11;
+  static constexpr uint8_t MESSAGE_TYPE = 59;
+  static constexpr uint8_t ESTIMATED_SIZE = 11;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "lock_state_response"; }
 #endif
@@ -1679,8 +1679,8 @@ class LockStateResponse : public StateResponseProtoMessage {
 };
 class LockCommandRequest : public CommandProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 60;
-  static constexpr uint16_t ESTIMATED_SIZE = 22;
+  static constexpr uint8_t MESSAGE_TYPE = 60;
+  static constexpr uint8_t ESTIMATED_SIZE = 22;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "lock_command_request"; }
 #endif
@@ -1702,8 +1702,8 @@ class LockCommandRequest : public CommandProtoMessage {
 #ifdef USE_BUTTON
 class ListEntitiesButtonResponse : public InfoResponseProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 61;
-  static constexpr uint16_t ESTIMATED_SIZE = 58;
+  static constexpr uint8_t MESSAGE_TYPE = 61;
+  static constexpr uint8_t ESTIMATED_SIZE = 58;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "list_entities_button_response"; }
 #endif
@@ -1721,8 +1721,8 @@ class ListEntitiesButtonResponse : public InfoResponseProtoMessage {
 };
 class ButtonCommandRequest : public CommandProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 62;
-  static constexpr uint16_t ESTIMATED_SIZE = 9;
+  static constexpr uint8_t MESSAGE_TYPE = 62;
+  static constexpr uint8_t ESTIMATED_SIZE = 9;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "button_command_request"; }
 #endif
@@ -1757,8 +1757,8 @@ class MediaPlayerSupportedFormat : public ProtoMessage {
 };
 class ListEntitiesMediaPlayerResponse : public InfoResponseProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 63;
-  static constexpr uint16_t ESTIMATED_SIZE = 85;
+  static constexpr uint8_t MESSAGE_TYPE = 63;
+  static constexpr uint8_t ESTIMATED_SIZE = 85;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "list_entities_media_player_response"; }
 #endif
@@ -1777,8 +1777,8 @@ class ListEntitiesMediaPlayerResponse : public InfoResponseProtoMessage {
 };
 class MediaPlayerStateResponse : public StateResponseProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 64;
-  static constexpr uint16_t ESTIMATED_SIZE = 18;
+  static constexpr uint8_t MESSAGE_TYPE = 64;
+  static constexpr uint8_t ESTIMATED_SIZE = 18;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "media_player_state_response"; }
 #endif
@@ -1797,8 +1797,8 @@ class MediaPlayerStateResponse : public StateResponseProtoMessage {
 };
 class MediaPlayerCommandRequest : public CommandProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 65;
-  static constexpr uint16_t ESTIMATED_SIZE = 35;
+  static constexpr uint8_t MESSAGE_TYPE = 65;
+  static constexpr uint8_t ESTIMATED_SIZE = 35;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "media_player_command_request"; }
 #endif
@@ -1825,8 +1825,8 @@ class MediaPlayerCommandRequest : public CommandProtoMessage {
 #ifdef USE_BLUETOOTH_PROXY
 class SubscribeBluetoothLEAdvertisementsRequest : public ProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 66;
-  static constexpr uint16_t ESTIMATED_SIZE = 4;
+  static constexpr uint8_t MESSAGE_TYPE = 66;
+  static constexpr uint8_t ESTIMATED_SIZE = 4;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "subscribe_bluetooth_le_advertisements_request"; }
 #endif
@@ -1857,8 +1857,8 @@ class BluetoothServiceData : public ProtoMessage {
 };
 class BluetoothLEAdvertisementResponse : public ProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 67;
-  static constexpr uint16_t ESTIMATED_SIZE = 107;
+  static constexpr uint8_t MESSAGE_TYPE = 67;
+  static constexpr uint8_t ESTIMATED_SIZE = 107;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "bluetooth_le_advertisement_response"; }
 #endif
@@ -1897,8 +1897,8 @@ class BluetoothLERawAdvertisement : public ProtoMessage {
 };
 class BluetoothLERawAdvertisementsResponse : public ProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 93;
-  static constexpr uint16_t ESTIMATED_SIZE = 34;
+  static constexpr uint8_t MESSAGE_TYPE = 93;
+  static constexpr uint8_t ESTIMATED_SIZE = 34;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "bluetooth_le_raw_advertisements_response"; }
 #endif
@@ -1914,8 +1914,8 @@ class BluetoothLERawAdvertisementsResponse : public ProtoMessage {
 };
 class BluetoothDeviceRequest : public ProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 68;
-  static constexpr uint16_t ESTIMATED_SIZE = 12;
+  static constexpr uint8_t MESSAGE_TYPE = 68;
+  static constexpr uint8_t ESTIMATED_SIZE = 12;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "bluetooth_device_request"; }
 #endif
@@ -1934,8 +1934,8 @@ class BluetoothDeviceRequest : public ProtoMessage {
 };
 class BluetoothDeviceConnectionResponse : public ProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 69;
-  static constexpr uint16_t ESTIMATED_SIZE = 14;
+  static constexpr uint8_t MESSAGE_TYPE = 69;
+  static constexpr uint8_t ESTIMATED_SIZE = 14;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "bluetooth_device_connection_response"; }
 #endif
@@ -1954,8 +1954,8 @@ class BluetoothDeviceConnectionResponse : public ProtoMessage {
 };
 class BluetoothGATTGetServicesRequest : public ProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 70;
-  static constexpr uint16_t ESTIMATED_SIZE = 4;
+  static constexpr uint8_t MESSAGE_TYPE = 70;
+  static constexpr uint8_t ESTIMATED_SIZE = 4;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "bluetooth_gatt_get_services_request"; }
 #endif
@@ -2015,8 +2015,8 @@ class BluetoothGATTService : public ProtoMessage {
 };
 class BluetoothGATTGetServicesResponse : public ProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 71;
-  static constexpr uint16_t ESTIMATED_SIZE = 38;
+  static constexpr uint8_t MESSAGE_TYPE = 71;
+  static constexpr uint8_t ESTIMATED_SIZE = 38;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "bluetooth_gatt_get_services_response"; }
 #endif
@@ -2034,8 +2034,8 @@ class BluetoothGATTGetServicesResponse : public ProtoMessage {
 };
 class BluetoothGATTGetServicesDoneResponse : public ProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 72;
-  static constexpr uint16_t ESTIMATED_SIZE = 4;
+  static constexpr uint8_t MESSAGE_TYPE = 72;
+  static constexpr uint8_t ESTIMATED_SIZE = 4;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "bluetooth_gatt_get_services_done_response"; }
 #endif
@@ -2051,8 +2051,8 @@ class BluetoothGATTGetServicesDoneResponse : public ProtoMessage {
 };
 class BluetoothGATTReadRequest : public ProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 73;
-  static constexpr uint16_t ESTIMATED_SIZE = 8;
+  static constexpr uint8_t MESSAGE_TYPE = 73;
+  static constexpr uint8_t ESTIMATED_SIZE = 8;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "bluetooth_gatt_read_request"; }
 #endif
@@ -2069,8 +2069,8 @@ class BluetoothGATTReadRequest : public ProtoMessage {
 };
 class BluetoothGATTReadResponse : public ProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 74;
-  static constexpr uint16_t ESTIMATED_SIZE = 17;
+  static constexpr uint8_t MESSAGE_TYPE = 74;
+  static constexpr uint8_t ESTIMATED_SIZE = 17;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "bluetooth_gatt_read_response"; }
 #endif
@@ -2089,8 +2089,8 @@ class BluetoothGATTReadResponse : public ProtoMessage {
 };
 class BluetoothGATTWriteRequest : public ProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 75;
-  static constexpr uint16_t ESTIMATED_SIZE = 19;
+  static constexpr uint8_t MESSAGE_TYPE = 75;
+  static constexpr uint8_t ESTIMATED_SIZE = 19;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "bluetooth_gatt_write_request"; }
 #endif
@@ -2110,8 +2110,8 @@ class BluetoothGATTWriteRequest : public ProtoMessage {
 };
 class BluetoothGATTReadDescriptorRequest : public ProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 76;
-  static constexpr uint16_t ESTIMATED_SIZE = 8;
+  static constexpr uint8_t MESSAGE_TYPE = 76;
+  static constexpr uint8_t ESTIMATED_SIZE = 8;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "bluetooth_gatt_read_descriptor_request"; }
 #endif
@@ -2128,8 +2128,8 @@ class BluetoothGATTReadDescriptorRequest : public ProtoMessage {
 };
 class BluetoothGATTWriteDescriptorRequest : public ProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 77;
-  static constexpr uint16_t ESTIMATED_SIZE = 17;
+  static constexpr uint8_t MESSAGE_TYPE = 77;
+  static constexpr uint8_t ESTIMATED_SIZE = 17;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "bluetooth_gatt_write_descriptor_request"; }
 #endif
@@ -2148,8 +2148,8 @@ class BluetoothGATTWriteDescriptorRequest : public ProtoMessage {
 };
 class BluetoothGATTNotifyRequest : public ProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 78;
-  static constexpr uint16_t ESTIMATED_SIZE = 10;
+  static constexpr uint8_t MESSAGE_TYPE = 78;
+  static constexpr uint8_t ESTIMATED_SIZE = 10;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "bluetooth_gatt_notify_request"; }
 #endif
@@ -2167,8 +2167,8 @@ class BluetoothGATTNotifyRequest : public ProtoMessage {
 };
 class BluetoothGATTNotifyDataResponse : public ProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 79;
-  static constexpr uint16_t ESTIMATED_SIZE = 17;
+  static constexpr uint8_t MESSAGE_TYPE = 79;
+  static constexpr uint8_t ESTIMATED_SIZE = 17;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "bluetooth_gatt_notify_data_response"; }
 #endif
@@ -2187,8 +2187,8 @@ class BluetoothGATTNotifyDataResponse : public ProtoMessage {
 };
 class SubscribeBluetoothConnectionsFreeRequest : public ProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 80;
-  static constexpr uint16_t ESTIMATED_SIZE = 0;
+  static constexpr uint8_t MESSAGE_TYPE = 80;
+  static constexpr uint8_t ESTIMATED_SIZE = 0;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "subscribe_bluetooth_connections_free_request"; }
 #endif
@@ -2200,8 +2200,8 @@ class SubscribeBluetoothConnectionsFreeRequest : public ProtoMessage {
 };
 class BluetoothConnectionsFreeResponse : public ProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 81;
-  static constexpr uint16_t ESTIMATED_SIZE = 16;
+  static constexpr uint8_t MESSAGE_TYPE = 81;
+  static constexpr uint8_t ESTIMATED_SIZE = 16;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "bluetooth_connections_free_response"; }
 #endif
@@ -2219,8 +2219,8 @@ class BluetoothConnectionsFreeResponse : public ProtoMessage {
 };
 class BluetoothGATTErrorResponse : public ProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 82;
-  static constexpr uint16_t ESTIMATED_SIZE = 12;
+  static constexpr uint8_t MESSAGE_TYPE = 82;
+  static constexpr uint8_t ESTIMATED_SIZE = 12;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "bluetooth_gatt_error_response"; }
 #endif
@@ -2238,8 +2238,8 @@ class BluetoothGATTErrorResponse : public ProtoMessage {
 };
 class BluetoothGATTWriteResponse : public ProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 83;
-  static constexpr uint16_t ESTIMATED_SIZE = 8;
+  static constexpr uint8_t MESSAGE_TYPE = 83;
+  static constexpr uint8_t ESTIMATED_SIZE = 8;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "bluetooth_gatt_write_response"; }
 #endif
@@ -2256,8 +2256,8 @@ class BluetoothGATTWriteResponse : public ProtoMessage {
 };
 class BluetoothGATTNotifyResponse : public ProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 84;
-  static constexpr uint16_t ESTIMATED_SIZE = 8;
+  static constexpr uint8_t MESSAGE_TYPE = 84;
+  static constexpr uint8_t ESTIMATED_SIZE = 8;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "bluetooth_gatt_notify_response"; }
 #endif
@@ -2274,8 +2274,8 @@ class BluetoothGATTNotifyResponse : public ProtoMessage {
 };
 class BluetoothDevicePairingResponse : public ProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 85;
-  static constexpr uint16_t ESTIMATED_SIZE = 10;
+  static constexpr uint8_t MESSAGE_TYPE = 85;
+  static constexpr uint8_t ESTIMATED_SIZE = 10;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "bluetooth_device_pairing_response"; }
 #endif
@@ -2293,8 +2293,8 @@ class BluetoothDevicePairingResponse : public ProtoMessage {
 };
 class BluetoothDeviceUnpairingResponse : public ProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 86;
-  static constexpr uint16_t ESTIMATED_SIZE = 10;
+  static constexpr uint8_t MESSAGE_TYPE = 86;
+  static constexpr uint8_t ESTIMATED_SIZE = 10;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "bluetooth_device_unpairing_response"; }
 #endif
@@ -2312,8 +2312,8 @@ class BluetoothDeviceUnpairingResponse : public ProtoMessage {
 };
 class UnsubscribeBluetoothLEAdvertisementsRequest : public ProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 87;
-  static constexpr uint16_t ESTIMATED_SIZE = 0;
+  static constexpr uint8_t MESSAGE_TYPE = 87;
+  static constexpr uint8_t ESTIMATED_SIZE = 0;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "unsubscribe_bluetooth_le_advertisements_request"; }
 #endif
@@ -2325,8 +2325,8 @@ class UnsubscribeBluetoothLEAdvertisementsRequest : public ProtoMessage {
 };
 class BluetoothDeviceClearCacheResponse : public ProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 88;
-  static constexpr uint16_t ESTIMATED_SIZE = 10;
+  static constexpr uint8_t MESSAGE_TYPE = 88;
+  static constexpr uint8_t ESTIMATED_SIZE = 10;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "bluetooth_device_clear_cache_response"; }
 #endif
@@ -2344,8 +2344,8 @@ class BluetoothDeviceClearCacheResponse : public ProtoMessage {
 };
 class BluetoothScannerStateResponse : public ProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 126;
-  static constexpr uint16_t ESTIMATED_SIZE = 4;
+  static constexpr uint8_t MESSAGE_TYPE = 126;
+  static constexpr uint8_t ESTIMATED_SIZE = 4;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "bluetooth_scanner_state_response"; }
 #endif
@@ -2362,8 +2362,8 @@ class BluetoothScannerStateResponse : public ProtoMessage {
 };
 class BluetoothScannerSetModeRequest : public ProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 127;
-  static constexpr uint16_t ESTIMATED_SIZE = 2;
+  static constexpr uint8_t MESSAGE_TYPE = 127;
+  static constexpr uint8_t ESTIMATED_SIZE = 2;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "bluetooth_scanner_set_mode_request"; }
 #endif
@@ -2381,8 +2381,8 @@ class BluetoothScannerSetModeRequest : public ProtoMessage {
 #ifdef USE_VOICE_ASSISTANT
 class SubscribeVoiceAssistantRequest : public ProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 89;
-  static constexpr uint16_t ESTIMATED_SIZE = 6;
+  static constexpr uint8_t MESSAGE_TYPE = 89;
+  static constexpr uint8_t ESTIMATED_SIZE = 6;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "subscribe_voice_assistant_request"; }
 #endif
@@ -2414,8 +2414,8 @@ class VoiceAssistantAudioSettings : public ProtoMessage {
 };
 class VoiceAssistantRequest : public ProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 90;
-  static constexpr uint16_t ESTIMATED_SIZE = 41;
+  static constexpr uint8_t MESSAGE_TYPE = 90;
+  static constexpr uint8_t ESTIMATED_SIZE = 41;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "voice_assistant_request"; }
 #endif
@@ -2436,8 +2436,8 @@ class VoiceAssistantRequest : public ProtoMessage {
 };
 class VoiceAssistantResponse : public ProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 91;
-  static constexpr uint16_t ESTIMATED_SIZE = 6;
+  static constexpr uint8_t MESSAGE_TYPE = 91;
+  static constexpr uint8_t ESTIMATED_SIZE = 6;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "voice_assistant_response"; }
 #endif
@@ -2467,8 +2467,8 @@ class VoiceAssistantEventData : public ProtoMessage {
 };
 class VoiceAssistantEventResponse : public ProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 92;
-  static constexpr uint16_t ESTIMATED_SIZE = 36;
+  static constexpr uint8_t MESSAGE_TYPE = 92;
+  static constexpr uint8_t ESTIMATED_SIZE = 36;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "voice_assistant_event_response"; }
 #endif
@@ -2486,8 +2486,8 @@ class VoiceAssistantEventResponse : public ProtoMessage {
 };
 class VoiceAssistantAudio : public ProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 106;
-  static constexpr uint16_t ESTIMATED_SIZE = 11;
+  static constexpr uint8_t MESSAGE_TYPE = 106;
+  static constexpr uint8_t ESTIMATED_SIZE = 11;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "voice_assistant_audio"; }
 #endif
@@ -2505,8 +2505,8 @@ class VoiceAssistantAudio : public ProtoMessage {
 };
 class VoiceAssistantTimerEventResponse : public ProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 115;
-  static constexpr uint16_t ESTIMATED_SIZE = 30;
+  static constexpr uint8_t MESSAGE_TYPE = 115;
+  static constexpr uint8_t ESTIMATED_SIZE = 30;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "voice_assistant_timer_event_response"; }
 #endif
@@ -2528,8 +2528,8 @@ class VoiceAssistantTimerEventResponse : public ProtoMessage {
 };
 class VoiceAssistantAnnounceRequest : public ProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 119;
-  static constexpr uint16_t ESTIMATED_SIZE = 29;
+  static constexpr uint8_t MESSAGE_TYPE = 119;
+  static constexpr uint8_t ESTIMATED_SIZE = 29;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "voice_assistant_announce_request"; }
 #endif
@@ -2549,8 +2549,8 @@ class VoiceAssistantAnnounceRequest : public ProtoMessage {
 };
 class VoiceAssistantAnnounceFinished : public ProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 120;
-  static constexpr uint16_t ESTIMATED_SIZE = 2;
+  static constexpr uint8_t MESSAGE_TYPE = 120;
+  static constexpr uint8_t ESTIMATED_SIZE = 2;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "voice_assistant_announce_finished"; }
 #endif
@@ -2580,8 +2580,8 @@ class VoiceAssistantWakeWord : public ProtoMessage {
 };
 class VoiceAssistantConfigurationRequest : public ProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 121;
-  static constexpr uint16_t ESTIMATED_SIZE = 0;
+  static constexpr uint8_t MESSAGE_TYPE = 121;
+  static constexpr uint8_t ESTIMATED_SIZE = 0;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "voice_assistant_configuration_request"; }
 #endif
@@ -2593,8 +2593,8 @@ class VoiceAssistantConfigurationRequest : public ProtoMessage {
 };
 class VoiceAssistantConfigurationResponse : public ProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 122;
-  static constexpr uint16_t ESTIMATED_SIZE = 56;
+  static constexpr uint8_t MESSAGE_TYPE = 122;
+  static constexpr uint8_t ESTIMATED_SIZE = 56;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "voice_assistant_configuration_response"; }
 #endif
@@ -2613,8 +2613,8 @@ class VoiceAssistantConfigurationResponse : public ProtoMessage {
 };
 class VoiceAssistantSetConfiguration : public ProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 123;
-  static constexpr uint16_t ESTIMATED_SIZE = 18;
+  static constexpr uint8_t MESSAGE_TYPE = 123;
+  static constexpr uint8_t ESTIMATED_SIZE = 18;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "voice_assistant_set_configuration"; }
 #endif
@@ -2632,8 +2632,8 @@ class VoiceAssistantSetConfiguration : public ProtoMessage {
 #ifdef USE_ALARM_CONTROL_PANEL
 class ListEntitiesAlarmControlPanelResponse : public InfoResponseProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 94;
-  static constexpr uint16_t ESTIMATED_SIZE = 57;
+  static constexpr uint8_t MESSAGE_TYPE = 94;
+  static constexpr uint8_t ESTIMATED_SIZE = 57;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "list_entities_alarm_control_panel_response"; }
 #endif
@@ -2653,8 +2653,8 @@ class ListEntitiesAlarmControlPanelResponse : public InfoResponseProtoMessage {
 };
 class AlarmControlPanelStateResponse : public StateResponseProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 95;
-  static constexpr uint16_t ESTIMATED_SIZE = 11;
+  static constexpr uint8_t MESSAGE_TYPE = 95;
+  static constexpr uint8_t ESTIMATED_SIZE = 11;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "alarm_control_panel_state_response"; }
 #endif
@@ -2671,8 +2671,8 @@ class AlarmControlPanelStateResponse : public StateResponseProtoMessage {
 };
 class AlarmControlPanelCommandRequest : public CommandProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 96;
-  static constexpr uint16_t ESTIMATED_SIZE = 20;
+  static constexpr uint8_t MESSAGE_TYPE = 96;
+  static constexpr uint8_t ESTIMATED_SIZE = 20;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "alarm_control_panel_command_request"; }
 #endif
@@ -2693,8 +2693,8 @@ class AlarmControlPanelCommandRequest : public CommandProtoMessage {
 #ifdef USE_TEXT
 class ListEntitiesTextResponse : public InfoResponseProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 97;
-  static constexpr uint16_t ESTIMATED_SIZE = 68;
+  static constexpr uint8_t MESSAGE_TYPE = 97;
+  static constexpr uint8_t ESTIMATED_SIZE = 68;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "list_entities_text_response"; }
 #endif
@@ -2715,8 +2715,8 @@ class ListEntitiesTextResponse : public InfoResponseProtoMessage {
 };
 class TextStateResponse : public StateResponseProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 98;
-  static constexpr uint16_t ESTIMATED_SIZE = 20;
+  static constexpr uint8_t MESSAGE_TYPE = 98;
+  static constexpr uint8_t ESTIMATED_SIZE = 20;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "text_state_response"; }
 #endif
@@ -2735,8 +2735,8 @@ class TextStateResponse : public StateResponseProtoMessage {
 };
 class TextCommandRequest : public CommandProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 99;
-  static constexpr uint16_t ESTIMATED_SIZE = 18;
+  static constexpr uint8_t MESSAGE_TYPE = 99;
+  static constexpr uint8_t ESTIMATED_SIZE = 18;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "text_command_request"; }
 #endif
@@ -2756,8 +2756,8 @@ class TextCommandRequest : public CommandProtoMessage {
 #ifdef USE_DATETIME_DATE
 class ListEntitiesDateResponse : public InfoResponseProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 100;
-  static constexpr uint16_t ESTIMATED_SIZE = 49;
+  static constexpr uint8_t MESSAGE_TYPE = 100;
+  static constexpr uint8_t ESTIMATED_SIZE = 49;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "list_entities_date_response"; }
 #endif
@@ -2774,8 +2774,8 @@ class ListEntitiesDateResponse : public InfoResponseProtoMessage {
 };
 class DateStateResponse : public StateResponseProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 101;
-  static constexpr uint16_t ESTIMATED_SIZE = 23;
+  static constexpr uint8_t MESSAGE_TYPE = 101;
+  static constexpr uint8_t ESTIMATED_SIZE = 23;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "date_state_response"; }
 #endif
@@ -2795,8 +2795,8 @@ class DateStateResponse : public StateResponseProtoMessage {
 };
 class DateCommandRequest : public CommandProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 102;
-  static constexpr uint16_t ESTIMATED_SIZE = 21;
+  static constexpr uint8_t MESSAGE_TYPE = 102;
+  static constexpr uint8_t ESTIMATED_SIZE = 21;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "date_command_request"; }
 #endif
@@ -2817,8 +2817,8 @@ class DateCommandRequest : public CommandProtoMessage {
 #ifdef USE_DATETIME_TIME
 class ListEntitiesTimeResponse : public InfoResponseProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 103;
-  static constexpr uint16_t ESTIMATED_SIZE = 49;
+  static constexpr uint8_t MESSAGE_TYPE = 103;
+  static constexpr uint8_t ESTIMATED_SIZE = 49;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "list_entities_time_response"; }
 #endif
@@ -2835,8 +2835,8 @@ class ListEntitiesTimeResponse : public InfoResponseProtoMessage {
 };
 class TimeStateResponse : public StateResponseProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 104;
-  static constexpr uint16_t ESTIMATED_SIZE = 23;
+  static constexpr uint8_t MESSAGE_TYPE = 104;
+  static constexpr uint8_t ESTIMATED_SIZE = 23;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "time_state_response"; }
 #endif
@@ -2856,8 +2856,8 @@ class TimeStateResponse : public StateResponseProtoMessage {
 };
 class TimeCommandRequest : public CommandProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 105;
-  static constexpr uint16_t ESTIMATED_SIZE = 21;
+  static constexpr uint8_t MESSAGE_TYPE = 105;
+  static constexpr uint8_t ESTIMATED_SIZE = 21;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "time_command_request"; }
 #endif
@@ -2878,8 +2878,8 @@ class TimeCommandRequest : public CommandProtoMessage {
 #ifdef USE_EVENT
 class ListEntitiesEventResponse : public InfoResponseProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 107;
-  static constexpr uint16_t ESTIMATED_SIZE = 76;
+  static constexpr uint8_t MESSAGE_TYPE = 107;
+  static constexpr uint8_t ESTIMATED_SIZE = 76;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "list_entities_event_response"; }
 #endif
@@ -2898,8 +2898,8 @@ class ListEntitiesEventResponse : public InfoResponseProtoMessage {
 };
 class EventResponse : public StateResponseProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 108;
-  static constexpr uint16_t ESTIMATED_SIZE = 18;
+  static constexpr uint8_t MESSAGE_TYPE = 108;
+  static constexpr uint8_t ESTIMATED_SIZE = 18;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "event_response"; }
 #endif
@@ -2919,8 +2919,8 @@ class EventResponse : public StateResponseProtoMessage {
 #ifdef USE_VALVE
 class ListEntitiesValveResponse : public InfoResponseProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 109;
-  static constexpr uint16_t ESTIMATED_SIZE = 64;
+  static constexpr uint8_t MESSAGE_TYPE = 109;
+  static constexpr uint8_t ESTIMATED_SIZE = 64;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "list_entities_valve_response"; }
 #endif
@@ -2941,8 +2941,8 @@ class ListEntitiesValveResponse : public InfoResponseProtoMessage {
 };
 class ValveStateResponse : public StateResponseProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 110;
-  static constexpr uint16_t ESTIMATED_SIZE = 16;
+  static constexpr uint8_t MESSAGE_TYPE = 110;
+  static constexpr uint8_t ESTIMATED_SIZE = 16;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "valve_state_response"; }
 #endif
@@ -2960,8 +2960,8 @@ class ValveStateResponse : public StateResponseProtoMessage {
 };
 class ValveCommandRequest : public CommandProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 111;
-  static constexpr uint16_t ESTIMATED_SIZE = 18;
+  static constexpr uint8_t MESSAGE_TYPE = 111;
+  static constexpr uint8_t ESTIMATED_SIZE = 18;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "valve_command_request"; }
 #endif
@@ -2982,8 +2982,8 @@ class ValveCommandRequest : public CommandProtoMessage {
 #ifdef USE_DATETIME_DATETIME
 class ListEntitiesDateTimeResponse : public InfoResponseProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 112;
-  static constexpr uint16_t ESTIMATED_SIZE = 49;
+  static constexpr uint8_t MESSAGE_TYPE = 112;
+  static constexpr uint8_t ESTIMATED_SIZE = 49;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "list_entities_date_time_response"; }
 #endif
@@ -3000,8 +3000,8 @@ class ListEntitiesDateTimeResponse : public InfoResponseProtoMessage {
 };
 class DateTimeStateResponse : public StateResponseProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 113;
-  static constexpr uint16_t ESTIMATED_SIZE = 16;
+  static constexpr uint8_t MESSAGE_TYPE = 113;
+  static constexpr uint8_t ESTIMATED_SIZE = 16;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "date_time_state_response"; }
 #endif
@@ -3019,8 +3019,8 @@ class DateTimeStateResponse : public StateResponseProtoMessage {
 };
 class DateTimeCommandRequest : public CommandProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 114;
-  static constexpr uint16_t ESTIMATED_SIZE = 14;
+  static constexpr uint8_t MESSAGE_TYPE = 114;
+  static constexpr uint8_t ESTIMATED_SIZE = 14;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "date_time_command_request"; }
 #endif
@@ -3039,8 +3039,8 @@ class DateTimeCommandRequest : public CommandProtoMessage {
 #ifdef USE_UPDATE
 class ListEntitiesUpdateResponse : public InfoResponseProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 116;
-  static constexpr uint16_t ESTIMATED_SIZE = 58;
+  static constexpr uint8_t MESSAGE_TYPE = 116;
+  static constexpr uint8_t ESTIMATED_SIZE = 58;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "list_entities_update_response"; }
 #endif
@@ -3058,8 +3058,8 @@ class ListEntitiesUpdateResponse : public InfoResponseProtoMessage {
 };
 class UpdateStateResponse : public StateResponseProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 117;
-  static constexpr uint16_t ESTIMATED_SIZE = 65;
+  static constexpr uint8_t MESSAGE_TYPE = 117;
+  static constexpr uint8_t ESTIMATED_SIZE = 65;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "update_state_response"; }
 #endif
@@ -3085,8 +3085,8 @@ class UpdateStateResponse : public StateResponseProtoMessage {
 };
 class UpdateCommandRequest : public CommandProtoMessage {
  public:
-  static constexpr uint16_t MESSAGE_TYPE = 118;
-  static constexpr uint16_t ESTIMATED_SIZE = 11;
+  static constexpr uint8_t MESSAGE_TYPE = 118;
+  static constexpr uint8_t ESTIMATED_SIZE = 11;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "update_command_request"; }
 #endif

--- a/esphome/components/api/api_server.cpp
+++ b/esphome/components/api/api_server.cpp
@@ -475,7 +475,8 @@ void APIServer::on_shutdown() {
     if (!c->send_message(DisconnectRequest())) {
       // If we can't send the disconnect request directly (tx_buffer full),
       // schedule it at the front of the batch so it will be sent with priority
-      c->schedule_message_front_(nullptr, &APIConnection::try_send_disconnect_request, DisconnectRequest::MESSAGE_TYPE);
+      c->schedule_message_front_(nullptr, &APIConnection::try_send_disconnect_request, DisconnectRequest::MESSAGE_TYPE,
+                                 DisconnectRequest::ESTIMATED_SIZE);
     }
   }
 }

--- a/esphome/components/api/list_entities.h
+++ b/esphome/components/api/list_entities.h
@@ -14,7 +14,7 @@ class APIConnection;
 #define LIST_ENTITIES_HANDLER(entity_type, EntityClass, ResponseType) \
   bool ListEntitiesIterator::on_##entity_type(EntityClass *entity) { /* NOLINT(bugprone-macro-parentheses) */ \
     return this->client_->schedule_message_(entity, &APIConnection::try_send_##entity_type##_info, \
-                                            ResponseType::MESSAGE_TYPE); \
+                                            ResponseType::MESSAGE_TYPE, ResponseType::ESTIMATED_SIZE); \
   }
 
 class ListEntitiesIterator : public ComponentIterator {

--- a/esphome/components/api/proto.h
+++ b/esphome/components/api/proto.h
@@ -363,11 +363,11 @@ class ProtoService {
    * @return A ProtoWriteBuffer object with the reserved size.
    */
   virtual ProtoWriteBuffer create_buffer(uint32_t reserve_size) = 0;
-  virtual bool send_buffer(ProtoWriteBuffer buffer, uint16_t message_type) = 0;
+  virtual bool send_buffer(ProtoWriteBuffer buffer, uint8_t message_type) = 0;
   virtual void read_message(uint32_t msg_size, uint32_t msg_type, uint8_t *msg_data) = 0;
 
   // Optimized method that pre-allocates buffer based on message size
-  bool send_message_(const ProtoMessage &msg, uint16_t message_type) {
+  bool send_message_(const ProtoMessage &msg, uint8_t message_type) {
     uint32_t msg_size = 0;
     msg.calculate_size(msg_size);
 

--- a/script/api_protobuf/api_protobuf.py
+++ b/script/api_protobuf/api_protobuf.py
@@ -987,13 +987,24 @@ def build_message_type(
 
     # Add MESSAGE_TYPE method if this is a service message
     if message_id is not None:
+        # Validate that message_id fits in uint8_t
+        if message_id > 255:
+            raise ValueError(
+                f"Message ID {message_id} for {desc.name} exceeds uint8_t maximum (255)"
+            )
+
         # Add static constexpr for message type
-        public_content.append(f"static constexpr uint16_t MESSAGE_TYPE = {message_id};")
+        public_content.append(f"static constexpr uint8_t MESSAGE_TYPE = {message_id};")
 
         # Add estimated size constant
         estimated_size = calculate_message_estimated_size(desc)
+        # Validate that estimated_size fits in uint8_t
+        if estimated_size > 255:
+            raise ValueError(
+                f"Estimated size {estimated_size} for {desc.name} exceeds uint8_t maximum (255)"
+            )
         public_content.append(
-            f"static constexpr uint16_t ESTIMATED_SIZE = {estimated_size};"
+            f"static constexpr uint8_t ESTIMATED_SIZE = {estimated_size};"
         )
 
         # Add message_name method inline in header


### PR DESCRIPTION
# What does this implement/fix?

This PR optimizes the ESPHome API's performance and flash usage by:

1. **Eliminating the runtime message size lookup** - Removes the `get_estimated_message_size()` function with its large 140+ case switch statement
2. **Storing message size at compile time** - Each BatchItem now directly stores the estimated size from the compile-time constant
3. **Reducing flash usage** - Removes a large switch statement function from the binary
4. **Improving batch processing performance** - Direct access to message size eliminates runtime lookups

The memory usage remains the same but is better utilized by storing useful data (estimated_size) instead of requiring runtime computation.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A (internal implementation change)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - this is an internal optimization
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

## Technical Details

### Performance Optimization:

- **Before**: Every batch allocation required calling `get_estimated_message_size()` which performed a 140+ case switch lookup
- **After**: Message size is stored directly in BatchItem, providing O(1) access during batch processing

### Flash Usage Optimization:

- Removes the entire `get_estimated_message_size()` function and its large switch statement  
- While we add MESSAGE_TYPE and ESTIMATED_SIZE constants to each message class, these are typically inlined by the compiler when used as immediate values

### Rationale for using uint8_t for message_type:

- **Current usage**: Maximum message ID is currently 127
- **Growth rate**: It took nearly 7 years to reach this many messages, and all base message types are already defined
- **Future headroom**: This leaves 128 additional message slots (50% headroom), which should last many years at the current growth rate
- **Scale considerations**: Having 255+ message types would create a massive protocol complexity problem anyway
- **Future flexibility**: We can always change back to uint16_t later without a breaking change if needed
- **Hardware evolution**: By the time we might need more messages, devices will likely have more RAM/Flash available

### Changes Made:

1. **API Protocol Generator (`script/api_protobuf/api_protobuf.py`)**:
   - Changed MESSAGE_TYPE and ESTIMATED_SIZE from `uint16_t` to `uint8_t` (sufficient for max values of 127 and 219)
   - Added validation to ensure values don't exceed uint8_t range

2. **API Connection (`api_connection.h/cpp`)**:
   - Updated `BatchItem` struct to include `estimated_size` field (uint8_t)
   - Removed the entire `get_estimated_message_size()` function
   - Updated all message sending calls to pass the compile-time ESTIMATED_SIZE constant
   - Changed message_type parameters to uint8_t throughout
   - Renamed MAX_PACKET_SIZE to MAX_BATCH_PACKET_SIZE for clarity

3. **Protocol Layer (`proto.h`)**:
   - Updated function signatures to use uint8_t for message_type parameters
   - Wire protocol remains unchanged (still supports 16-bit message types for compatibility)

### Impact:

- **Flash**: Varies by device complexity (-148 bytes for complex devices, +48 bytes for basic devices)
- **RAM**: Unchanged (but more efficiently used during batch processing)
- **Performance**: Faster batch processing without runtime lookups (O(1) instead of O(n))
- **Memory**: Better utilized with useful data instead of runtime computation
- **Compatibility**: Wire protocol unchanged, fully backward compatible

### Measured Results (ESP32):

**Complex device with many components:**
- Before: Flash 1230652 bytes
- After: Flash 1230388 bytes  
- **Savings: 264 bytes**

**Basic device with minimal components:**
- Before: Flash 537880 bytes
- After: Flash 537724 bytes
- **Savings: 156 bytes**

Both complex and basic devices see flash savings from this optimization. The removal of the large switch statement more than compensates for the added compile-time constants.