### PR TITLE
Optimize API proto size calculations by removing redundant force parameter

### DIFF
--- a/esphome/components/api/api_pb2.cpp
+++ b/esphome/components/api/api_pb2.cpp
@@ -2200,9 +2200,7 @@ void ExecuteServiceArgument::calculate_size(uint32_t &total_size) const {
     }
   }
   if (!this->float_array.empty()) {
-    for (const auto &it : this->float_array) {
-      ProtoSize::add_fixed_field_repeated<4>(total_size, 1);
-    }
+    total_size += this->float_array.size() * 5;
   }
   if (!this->string_array.empty()) {
     for (const auto &it : this->string_array) {

--- a/esphome/components/api/api_pb2.cpp
+++ b/esphome/components/api/api_pb2.cpp
@@ -38,9 +38,9 @@ void HelloRequest::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint32(3, this->api_version_minor);
 }
 void HelloRequest::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_string_field(total_size, 1, this->client_info, false);
-  ProtoSize::add_uint32_field(total_size, 1, this->api_version_major, false);
-  ProtoSize::add_uint32_field(total_size, 1, this->api_version_minor, false);
+  ProtoSize::add_string_field(total_size, 1, this->client_info);
+  ProtoSize::add_uint32_field(total_size, 1, this->api_version_major);
+  ProtoSize::add_uint32_field(total_size, 1, this->api_version_minor);
 }
 bool HelloResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
@@ -77,10 +77,10 @@ void HelloResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_string(4, this->name);
 }
 void HelloResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_uint32_field(total_size, 1, this->api_version_major, false);
-  ProtoSize::add_uint32_field(total_size, 1, this->api_version_minor, false);
-  ProtoSize::add_string_field(total_size, 1, this->server_info, false);
-  ProtoSize::add_string_field(total_size, 1, this->name, false);
+  ProtoSize::add_uint32_field(total_size, 1, this->api_version_major);
+  ProtoSize::add_uint32_field(total_size, 1, this->api_version_minor);
+  ProtoSize::add_string_field(total_size, 1, this->server_info);
+  ProtoSize::add_string_field(total_size, 1, this->name);
 }
 bool ConnectRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
@@ -94,7 +94,7 @@ bool ConnectRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value
 }
 void ConnectRequest::encode(ProtoWriteBuffer buffer) const { buffer.encode_string(1, this->password); }
 void ConnectRequest::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_string_field(total_size, 1, this->password, false);
+  ProtoSize::add_string_field(total_size, 1, this->password);
 }
 bool ConnectResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
@@ -108,7 +108,7 @@ bool ConnectResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
 }
 void ConnectResponse::encode(ProtoWriteBuffer buffer) const { buffer.encode_bool(1, this->invalid_password); }
 void ConnectResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_bool_field(total_size, 1, this->invalid_password, false);
+  ProtoSize::add_bool_field(total_size, 1, this->invalid_password);
 }
 bool AreaInfo::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
@@ -135,8 +135,8 @@ void AreaInfo::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_string(2, this->name);
 }
 void AreaInfo::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_uint32_field(total_size, 1, this->area_id, false);
-  ProtoSize::add_string_field(total_size, 1, this->name, false);
+  ProtoSize::add_uint32_field(total_size, 1, this->area_id);
+  ProtoSize::add_string_field(total_size, 1, this->name);
 }
 bool DeviceInfo::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
@@ -168,9 +168,9 @@ void DeviceInfo::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint32(3, this->area_id);
 }
 void DeviceInfo::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_uint32_field(total_size, 1, this->device_id, false);
-  ProtoSize::add_string_field(total_size, 1, this->name, false);
-  ProtoSize::add_uint32_field(total_size, 1, this->area_id, false);
+  ProtoSize::add_uint32_field(total_size, 1, this->device_id);
+  ProtoSize::add_string_field(total_size, 1, this->name);
+  ProtoSize::add_uint32_field(total_size, 1, this->area_id);
 }
 bool DeviceInfoResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
@@ -301,28 +301,28 @@ void DeviceInfoResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_message<AreaInfo>(22, this->area);
 }
 void DeviceInfoResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_bool_field(total_size, 1, this->uses_password, false);
-  ProtoSize::add_string_field(total_size, 1, this->name, false);
-  ProtoSize::add_string_field(total_size, 1, this->mac_address, false);
-  ProtoSize::add_string_field(total_size, 1, this->esphome_version, false);
-  ProtoSize::add_string_field(total_size, 1, this->compilation_time, false);
-  ProtoSize::add_string_field(total_size, 1, this->model, false);
-  ProtoSize::add_bool_field(total_size, 1, this->has_deep_sleep, false);
-  ProtoSize::add_string_field(total_size, 1, this->project_name, false);
-  ProtoSize::add_string_field(total_size, 1, this->project_version, false);
-  ProtoSize::add_uint32_field(total_size, 1, this->webserver_port, false);
-  ProtoSize::add_uint32_field(total_size, 1, this->legacy_bluetooth_proxy_version, false);
-  ProtoSize::add_uint32_field(total_size, 1, this->bluetooth_proxy_feature_flags, false);
-  ProtoSize::add_string_field(total_size, 1, this->manufacturer, false);
-  ProtoSize::add_string_field(total_size, 1, this->friendly_name, false);
-  ProtoSize::add_uint32_field(total_size, 1, this->legacy_voice_assistant_version, false);
-  ProtoSize::add_uint32_field(total_size, 2, this->voice_assistant_feature_flags, false);
-  ProtoSize::add_string_field(total_size, 2, this->suggested_area, false);
-  ProtoSize::add_string_field(total_size, 2, this->bluetooth_mac_address, false);
-  ProtoSize::add_bool_field(total_size, 2, this->api_encryption_supported, false);
+  ProtoSize::add_bool_field(total_size, 1, this->uses_password);
+  ProtoSize::add_string_field(total_size, 1, this->name);
+  ProtoSize::add_string_field(total_size, 1, this->mac_address);
+  ProtoSize::add_string_field(total_size, 1, this->esphome_version);
+  ProtoSize::add_string_field(total_size, 1, this->compilation_time);
+  ProtoSize::add_string_field(total_size, 1, this->model);
+  ProtoSize::add_bool_field(total_size, 1, this->has_deep_sleep);
+  ProtoSize::add_string_field(total_size, 1, this->project_name);
+  ProtoSize::add_string_field(total_size, 1, this->project_version);
+  ProtoSize::add_uint32_field(total_size, 1, this->webserver_port);
+  ProtoSize::add_uint32_field(total_size, 1, this->legacy_bluetooth_proxy_version);
+  ProtoSize::add_uint32_field(total_size, 1, this->bluetooth_proxy_feature_flags);
+  ProtoSize::add_string_field(total_size, 1, this->manufacturer);
+  ProtoSize::add_string_field(total_size, 1, this->friendly_name);
+  ProtoSize::add_uint32_field(total_size, 1, this->legacy_voice_assistant_version);
+  ProtoSize::add_uint32_field(total_size, 2, this->voice_assistant_feature_flags);
+  ProtoSize::add_string_field(total_size, 2, this->suggested_area);
+  ProtoSize::add_string_field(total_size, 2, this->bluetooth_mac_address);
+  ProtoSize::add_bool_field(total_size, 2, this->api_encryption_supported);
   ProtoSize::add_repeated_message(total_size, 2, this->devices);
   ProtoSize::add_repeated_message(total_size, 2, this->areas);
-  ProtoSize::add_message_object(total_size, 2, this->area, false);
+  ProtoSize::add_message_object(total_size, 2, this->area);
 }
 #ifdef USE_BINARY_SENSOR
 bool ListEntitiesBinarySensorResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
@@ -396,16 +396,16 @@ void ListEntitiesBinarySensorResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint32(10, this->device_id);
 }
 void ListEntitiesBinarySensorResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_string_field(total_size, 1, this->object_id, false);
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0, false);
-  ProtoSize::add_string_field(total_size, 1, this->name, false);
-  ProtoSize::add_string_field(total_size, 1, this->unique_id, false);
-  ProtoSize::add_string_field(total_size, 1, this->device_class, false);
-  ProtoSize::add_bool_field(total_size, 1, this->is_status_binary_sensor, false);
-  ProtoSize::add_bool_field(total_size, 1, this->disabled_by_default, false);
-  ProtoSize::add_string_field(total_size, 1, this->icon, false);
-  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->entity_category), false);
-  ProtoSize::add_uint32_field(total_size, 1, this->device_id, false);
+  ProtoSize::add_string_field(total_size, 1, this->object_id);
+  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0);
+  ProtoSize::add_string_field(total_size, 1, this->name);
+  ProtoSize::add_string_field(total_size, 1, this->unique_id);
+  ProtoSize::add_string_field(total_size, 1, this->device_class);
+  ProtoSize::add_bool_field(total_size, 1, this->is_status_binary_sensor);
+  ProtoSize::add_bool_field(total_size, 1, this->disabled_by_default);
+  ProtoSize::add_string_field(total_size, 1, this->icon);
+  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->entity_category));
+  ProtoSize::add_uint32_field(total_size, 1, this->device_id);
 }
 bool BinarySensorStateResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
@@ -442,10 +442,10 @@ void BinarySensorStateResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint32(4, this->device_id);
 }
 void BinarySensorStateResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0, false);
-  ProtoSize::add_bool_field(total_size, 1, this->state, false);
-  ProtoSize::add_bool_field(total_size, 1, this->missing_state, false);
-  ProtoSize::add_uint32_field(total_size, 1, this->device_id, false);
+  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0);
+  ProtoSize::add_bool_field(total_size, 1, this->state);
+  ProtoSize::add_bool_field(total_size, 1, this->missing_state);
+  ProtoSize::add_uint32_field(total_size, 1, this->device_id);
 }
 #endif
 #ifdef USE_COVER
@@ -535,19 +535,19 @@ void ListEntitiesCoverResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint32(13, this->device_id);
 }
 void ListEntitiesCoverResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_string_field(total_size, 1, this->object_id, false);
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0, false);
-  ProtoSize::add_string_field(total_size, 1, this->name, false);
-  ProtoSize::add_string_field(total_size, 1, this->unique_id, false);
-  ProtoSize::add_bool_field(total_size, 1, this->assumed_state, false);
-  ProtoSize::add_bool_field(total_size, 1, this->supports_position, false);
-  ProtoSize::add_bool_field(total_size, 1, this->supports_tilt, false);
-  ProtoSize::add_string_field(total_size, 1, this->device_class, false);
-  ProtoSize::add_bool_field(total_size, 1, this->disabled_by_default, false);
-  ProtoSize::add_string_field(total_size, 1, this->icon, false);
-  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->entity_category), false);
-  ProtoSize::add_bool_field(total_size, 1, this->supports_stop, false);
-  ProtoSize::add_uint32_field(total_size, 1, this->device_id, false);
+  ProtoSize::add_string_field(total_size, 1, this->object_id);
+  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0);
+  ProtoSize::add_string_field(total_size, 1, this->name);
+  ProtoSize::add_string_field(total_size, 1, this->unique_id);
+  ProtoSize::add_bool_field(total_size, 1, this->assumed_state);
+  ProtoSize::add_bool_field(total_size, 1, this->supports_position);
+  ProtoSize::add_bool_field(total_size, 1, this->supports_tilt);
+  ProtoSize::add_string_field(total_size, 1, this->device_class);
+  ProtoSize::add_bool_field(total_size, 1, this->disabled_by_default);
+  ProtoSize::add_string_field(total_size, 1, this->icon);
+  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->entity_category));
+  ProtoSize::add_bool_field(total_size, 1, this->supports_stop);
+  ProtoSize::add_uint32_field(total_size, 1, this->device_id);
 }
 bool CoverStateResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
@@ -594,12 +594,12 @@ void CoverStateResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint32(6, this->device_id);
 }
 void CoverStateResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0, false);
-  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->legacy_state), false);
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->position != 0.0f, false);
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->tilt != 0.0f, false);
-  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->current_operation), false);
-  ProtoSize::add_uint32_field(total_size, 1, this->device_id, false);
+  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0);
+  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->legacy_state));
+  ProtoSize::add_fixed_field<4>(total_size, 1, this->position != 0.0f);
+  ProtoSize::add_fixed_field<4>(total_size, 1, this->tilt != 0.0f);
+  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->current_operation));
+  ProtoSize::add_uint32_field(total_size, 1, this->device_id);
 }
 bool CoverCommandRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
@@ -661,15 +661,15 @@ void CoverCommandRequest::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint32(9, this->device_id);
 }
 void CoverCommandRequest::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0, false);
-  ProtoSize::add_bool_field(total_size, 1, this->has_legacy_command, false);
-  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->legacy_command), false);
-  ProtoSize::add_bool_field(total_size, 1, this->has_position, false);
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->position != 0.0f, false);
-  ProtoSize::add_bool_field(total_size, 1, this->has_tilt, false);
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->tilt != 0.0f, false);
-  ProtoSize::add_bool_field(total_size, 1, this->stop, false);
-  ProtoSize::add_uint32_field(total_size, 1, this->device_id, false);
+  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0);
+  ProtoSize::add_bool_field(total_size, 1, this->has_legacy_command);
+  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->legacy_command));
+  ProtoSize::add_bool_field(total_size, 1, this->has_position);
+  ProtoSize::add_fixed_field<4>(total_size, 1, this->position != 0.0f);
+  ProtoSize::add_bool_field(total_size, 1, this->has_tilt);
+  ProtoSize::add_fixed_field<4>(total_size, 1, this->tilt != 0.0f);
+  ProtoSize::add_bool_field(total_size, 1, this->stop);
+  ProtoSize::add_uint32_field(total_size, 1, this->device_id);
 }
 #endif
 #ifdef USE_FAN
@@ -761,23 +761,23 @@ void ListEntitiesFanResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint32(13, this->device_id);
 }
 void ListEntitiesFanResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_string_field(total_size, 1, this->object_id, false);
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0, false);
-  ProtoSize::add_string_field(total_size, 1, this->name, false);
-  ProtoSize::add_string_field(total_size, 1, this->unique_id, false);
-  ProtoSize::add_bool_field(total_size, 1, this->supports_oscillation, false);
-  ProtoSize::add_bool_field(total_size, 1, this->supports_speed, false);
-  ProtoSize::add_bool_field(total_size, 1, this->supports_direction, false);
-  ProtoSize::add_int32_field(total_size, 1, this->supported_speed_count, false);
-  ProtoSize::add_bool_field(total_size, 1, this->disabled_by_default, false);
-  ProtoSize::add_string_field(total_size, 1, this->icon, false);
-  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->entity_category), false);
+  ProtoSize::add_string_field(total_size, 1, this->object_id);
+  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0);
+  ProtoSize::add_string_field(total_size, 1, this->name);
+  ProtoSize::add_string_field(total_size, 1, this->unique_id);
+  ProtoSize::add_bool_field(total_size, 1, this->supports_oscillation);
+  ProtoSize::add_bool_field(total_size, 1, this->supports_speed);
+  ProtoSize::add_bool_field(total_size, 1, this->supports_direction);
+  ProtoSize::add_int32_field(total_size, 1, this->supported_speed_count);
+  ProtoSize::add_bool_field(total_size, 1, this->disabled_by_default);
+  ProtoSize::add_string_field(total_size, 1, this->icon);
+  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->entity_category));
   if (!this->supported_preset_modes.empty()) {
     for (const auto &it : this->supported_preset_modes) {
-      ProtoSize::add_string_field(total_size, 1, it, true);
+      ProtoSize::add_string_field_repeated(total_size, 1, it);
     }
   }
-  ProtoSize::add_uint32_field(total_size, 1, this->device_id, false);
+  ProtoSize::add_uint32_field(total_size, 1, this->device_id);
 }
 bool FanStateResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
@@ -840,14 +840,14 @@ void FanStateResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint32(8, this->device_id);
 }
 void FanStateResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0, false);
-  ProtoSize::add_bool_field(total_size, 1, this->state, false);
-  ProtoSize::add_bool_field(total_size, 1, this->oscillating, false);
-  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->speed), false);
-  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->direction), false);
-  ProtoSize::add_int32_field(total_size, 1, this->speed_level, false);
-  ProtoSize::add_string_field(total_size, 1, this->preset_mode, false);
-  ProtoSize::add_uint32_field(total_size, 1, this->device_id, false);
+  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0);
+  ProtoSize::add_bool_field(total_size, 1, this->state);
+  ProtoSize::add_bool_field(total_size, 1, this->oscillating);
+  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->speed));
+  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->direction));
+  ProtoSize::add_int32_field(total_size, 1, this->speed_level);
+  ProtoSize::add_string_field(total_size, 1, this->preset_mode);
+  ProtoSize::add_uint32_field(total_size, 1, this->device_id);
 }
 bool FanCommandRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
@@ -940,20 +940,20 @@ void FanCommandRequest::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint32(14, this->device_id);
 }
 void FanCommandRequest::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0, false);
-  ProtoSize::add_bool_field(total_size, 1, this->has_state, false);
-  ProtoSize::add_bool_field(total_size, 1, this->state, false);
-  ProtoSize::add_bool_field(total_size, 1, this->has_speed, false);
-  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->speed), false);
-  ProtoSize::add_bool_field(total_size, 1, this->has_oscillating, false);
-  ProtoSize::add_bool_field(total_size, 1, this->oscillating, false);
-  ProtoSize::add_bool_field(total_size, 1, this->has_direction, false);
-  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->direction), false);
-  ProtoSize::add_bool_field(total_size, 1, this->has_speed_level, false);
-  ProtoSize::add_int32_field(total_size, 1, this->speed_level, false);
-  ProtoSize::add_bool_field(total_size, 1, this->has_preset_mode, false);
-  ProtoSize::add_string_field(total_size, 1, this->preset_mode, false);
-  ProtoSize::add_uint32_field(total_size, 1, this->device_id, false);
+  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0);
+  ProtoSize::add_bool_field(total_size, 1, this->has_state);
+  ProtoSize::add_bool_field(total_size, 1, this->state);
+  ProtoSize::add_bool_field(total_size, 1, this->has_speed);
+  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->speed));
+  ProtoSize::add_bool_field(total_size, 1, this->has_oscillating);
+  ProtoSize::add_bool_field(total_size, 1, this->oscillating);
+  ProtoSize::add_bool_field(total_size, 1, this->has_direction);
+  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->direction));
+  ProtoSize::add_bool_field(total_size, 1, this->has_speed_level);
+  ProtoSize::add_int32_field(total_size, 1, this->speed_level);
+  ProtoSize::add_bool_field(total_size, 1, this->has_preset_mode);
+  ProtoSize::add_string_field(total_size, 1, this->preset_mode);
+  ProtoSize::add_uint32_field(total_size, 1, this->device_id);
 }
 #endif
 #ifdef USE_LIGHT
@@ -1062,30 +1062,30 @@ void ListEntitiesLightResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint32(16, this->device_id);
 }
 void ListEntitiesLightResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_string_field(total_size, 1, this->object_id, false);
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0, false);
-  ProtoSize::add_string_field(total_size, 1, this->name, false);
-  ProtoSize::add_string_field(total_size, 1, this->unique_id, false);
+  ProtoSize::add_string_field(total_size, 1, this->object_id);
+  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0);
+  ProtoSize::add_string_field(total_size, 1, this->name);
+  ProtoSize::add_string_field(total_size, 1, this->unique_id);
   if (!this->supported_color_modes.empty()) {
     for (const auto &it : this->supported_color_modes) {
-      ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(it), true);
+      ProtoSize::add_enum_field_repeated(total_size, 1, static_cast<uint32_t>(it));
     }
   }
-  ProtoSize::add_bool_field(total_size, 1, this->legacy_supports_brightness, false);
-  ProtoSize::add_bool_field(total_size, 1, this->legacy_supports_rgb, false);
-  ProtoSize::add_bool_field(total_size, 1, this->legacy_supports_white_value, false);
-  ProtoSize::add_bool_field(total_size, 1, this->legacy_supports_color_temperature, false);
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->min_mireds != 0.0f, false);
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->max_mireds != 0.0f, false);
+  ProtoSize::add_bool_field(total_size, 1, this->legacy_supports_brightness);
+  ProtoSize::add_bool_field(total_size, 1, this->legacy_supports_rgb);
+  ProtoSize::add_bool_field(total_size, 1, this->legacy_supports_white_value);
+  ProtoSize::add_bool_field(total_size, 1, this->legacy_supports_color_temperature);
+  ProtoSize::add_fixed_field<4>(total_size, 1, this->min_mireds != 0.0f);
+  ProtoSize::add_fixed_field<4>(total_size, 1, this->max_mireds != 0.0f);
   if (!this->effects.empty()) {
     for (const auto &it : this->effects) {
-      ProtoSize::add_string_field(total_size, 1, it, true);
+      ProtoSize::add_string_field_repeated(total_size, 1, it);
     }
   }
-  ProtoSize::add_bool_field(total_size, 1, this->disabled_by_default, false);
-  ProtoSize::add_string_field(total_size, 1, this->icon, false);
-  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->entity_category), false);
-  ProtoSize::add_uint32_field(total_size, 2, this->device_id, false);
+  ProtoSize::add_bool_field(total_size, 1, this->disabled_by_default);
+  ProtoSize::add_string_field(total_size, 1, this->icon);
+  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->entity_category));
+  ProtoSize::add_uint32_field(total_size, 2, this->device_id);
 }
 bool LightStateResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
@@ -1178,20 +1178,20 @@ void LightStateResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint32(14, this->device_id);
 }
 void LightStateResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0, false);
-  ProtoSize::add_bool_field(total_size, 1, this->state, false);
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->brightness != 0.0f, false);
-  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->color_mode), false);
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->color_brightness != 0.0f, false);
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->red != 0.0f, false);
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->green != 0.0f, false);
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->blue != 0.0f, false);
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->white != 0.0f, false);
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->color_temperature != 0.0f, false);
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->cold_white != 0.0f, false);
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->warm_white != 0.0f, false);
-  ProtoSize::add_string_field(total_size, 1, this->effect, false);
-  ProtoSize::add_uint32_field(total_size, 1, this->device_id, false);
+  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0);
+  ProtoSize::add_bool_field(total_size, 1, this->state);
+  ProtoSize::add_fixed_field<4>(total_size, 1, this->brightness != 0.0f);
+  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->color_mode));
+  ProtoSize::add_fixed_field<4>(total_size, 1, this->color_brightness != 0.0f);
+  ProtoSize::add_fixed_field<4>(total_size, 1, this->red != 0.0f);
+  ProtoSize::add_fixed_field<4>(total_size, 1, this->green != 0.0f);
+  ProtoSize::add_fixed_field<4>(total_size, 1, this->blue != 0.0f);
+  ProtoSize::add_fixed_field<4>(total_size, 1, this->white != 0.0f);
+  ProtoSize::add_fixed_field<4>(total_size, 1, this->color_temperature != 0.0f);
+  ProtoSize::add_fixed_field<4>(total_size, 1, this->cold_white != 0.0f);
+  ProtoSize::add_fixed_field<4>(total_size, 1, this->warm_white != 0.0f);
+  ProtoSize::add_string_field(total_size, 1, this->effect);
+  ProtoSize::add_uint32_field(total_size, 1, this->device_id);
 }
 bool LightCommandRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
@@ -1354,34 +1354,34 @@ void LightCommandRequest::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint32(28, this->device_id);
 }
 void LightCommandRequest::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0, false);
-  ProtoSize::add_bool_field(total_size, 1, this->has_state, false);
-  ProtoSize::add_bool_field(total_size, 1, this->state, false);
-  ProtoSize::add_bool_field(total_size, 1, this->has_brightness, false);
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->brightness != 0.0f, false);
-  ProtoSize::add_bool_field(total_size, 2, this->has_color_mode, false);
-  ProtoSize::add_enum_field(total_size, 2, static_cast<uint32_t>(this->color_mode), false);
-  ProtoSize::add_bool_field(total_size, 2, this->has_color_brightness, false);
-  ProtoSize::add_fixed_field<4>(total_size, 2, this->color_brightness != 0.0f, false);
-  ProtoSize::add_bool_field(total_size, 1, this->has_rgb, false);
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->red != 0.0f, false);
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->green != 0.0f, false);
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->blue != 0.0f, false);
-  ProtoSize::add_bool_field(total_size, 1, this->has_white, false);
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->white != 0.0f, false);
-  ProtoSize::add_bool_field(total_size, 1, this->has_color_temperature, false);
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->color_temperature != 0.0f, false);
-  ProtoSize::add_bool_field(total_size, 2, this->has_cold_white, false);
-  ProtoSize::add_fixed_field<4>(total_size, 2, this->cold_white != 0.0f, false);
-  ProtoSize::add_bool_field(total_size, 2, this->has_warm_white, false);
-  ProtoSize::add_fixed_field<4>(total_size, 2, this->warm_white != 0.0f, false);
-  ProtoSize::add_bool_field(total_size, 1, this->has_transition_length, false);
-  ProtoSize::add_uint32_field(total_size, 1, this->transition_length, false);
-  ProtoSize::add_bool_field(total_size, 2, this->has_flash_length, false);
-  ProtoSize::add_uint32_field(total_size, 2, this->flash_length, false);
-  ProtoSize::add_bool_field(total_size, 2, this->has_effect, false);
-  ProtoSize::add_string_field(total_size, 2, this->effect, false);
-  ProtoSize::add_uint32_field(total_size, 2, this->device_id, false);
+  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0);
+  ProtoSize::add_bool_field(total_size, 1, this->has_state);
+  ProtoSize::add_bool_field(total_size, 1, this->state);
+  ProtoSize::add_bool_field(total_size, 1, this->has_brightness);
+  ProtoSize::add_fixed_field<4>(total_size, 1, this->brightness != 0.0f);
+  ProtoSize::add_bool_field(total_size, 2, this->has_color_mode);
+  ProtoSize::add_enum_field(total_size, 2, static_cast<uint32_t>(this->color_mode));
+  ProtoSize::add_bool_field(total_size, 2, this->has_color_brightness);
+  ProtoSize::add_fixed_field<4>(total_size, 2, this->color_brightness != 0.0f);
+  ProtoSize::add_bool_field(total_size, 1, this->has_rgb);
+  ProtoSize::add_fixed_field<4>(total_size, 1, this->red != 0.0f);
+  ProtoSize::add_fixed_field<4>(total_size, 1, this->green != 0.0f);
+  ProtoSize::add_fixed_field<4>(total_size, 1, this->blue != 0.0f);
+  ProtoSize::add_bool_field(total_size, 1, this->has_white);
+  ProtoSize::add_fixed_field<4>(total_size, 1, this->white != 0.0f);
+  ProtoSize::add_bool_field(total_size, 1, this->has_color_temperature);
+  ProtoSize::add_fixed_field<4>(total_size, 1, this->color_temperature != 0.0f);
+  ProtoSize::add_bool_field(total_size, 2, this->has_cold_white);
+  ProtoSize::add_fixed_field<4>(total_size, 2, this->cold_white != 0.0f);
+  ProtoSize::add_bool_field(total_size, 2, this->has_warm_white);
+  ProtoSize::add_fixed_field<4>(total_size, 2, this->warm_white != 0.0f);
+  ProtoSize::add_bool_field(total_size, 1, this->has_transition_length);
+  ProtoSize::add_uint32_field(total_size, 1, this->transition_length);
+  ProtoSize::add_bool_field(total_size, 2, this->has_flash_length);
+  ProtoSize::add_uint32_field(total_size, 2, this->flash_length);
+  ProtoSize::add_bool_field(total_size, 2, this->has_effect);
+  ProtoSize::add_string_field(total_size, 2, this->effect);
+  ProtoSize::add_uint32_field(total_size, 2, this->device_id);
 }
 #endif
 #ifdef USE_SENSOR
@@ -1476,20 +1476,20 @@ void ListEntitiesSensorResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint32(14, this->device_id);
 }
 void ListEntitiesSensorResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_string_field(total_size, 1, this->object_id, false);
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0, false);
-  ProtoSize::add_string_field(total_size, 1, this->name, false);
-  ProtoSize::add_string_field(total_size, 1, this->unique_id, false);
-  ProtoSize::add_string_field(total_size, 1, this->icon, false);
-  ProtoSize::add_string_field(total_size, 1, this->unit_of_measurement, false);
-  ProtoSize::add_int32_field(total_size, 1, this->accuracy_decimals, false);
-  ProtoSize::add_bool_field(total_size, 1, this->force_update, false);
-  ProtoSize::add_string_field(total_size, 1, this->device_class, false);
-  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->state_class), false);
-  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->legacy_last_reset_type), false);
-  ProtoSize::add_bool_field(total_size, 1, this->disabled_by_default, false);
-  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->entity_category), false);
-  ProtoSize::add_uint32_field(total_size, 1, this->device_id, false);
+  ProtoSize::add_string_field(total_size, 1, this->object_id);
+  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0);
+  ProtoSize::add_string_field(total_size, 1, this->name);
+  ProtoSize::add_string_field(total_size, 1, this->unique_id);
+  ProtoSize::add_string_field(total_size, 1, this->icon);
+  ProtoSize::add_string_field(total_size, 1, this->unit_of_measurement);
+  ProtoSize::add_int32_field(total_size, 1, this->accuracy_decimals);
+  ProtoSize::add_bool_field(total_size, 1, this->force_update);
+  ProtoSize::add_string_field(total_size, 1, this->device_class);
+  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->state_class));
+  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->legacy_last_reset_type));
+  ProtoSize::add_bool_field(total_size, 1, this->disabled_by_default);
+  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->entity_category));
+  ProtoSize::add_uint32_field(total_size, 1, this->device_id);
 }
 bool SensorStateResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
@@ -1526,10 +1526,10 @@ void SensorStateResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint32(4, this->device_id);
 }
 void SensorStateResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0, false);
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->state != 0.0f, false);
-  ProtoSize::add_bool_field(total_size, 1, this->missing_state, false);
-  ProtoSize::add_uint32_field(total_size, 1, this->device_id, false);
+  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0);
+  ProtoSize::add_fixed_field<4>(total_size, 1, this->state != 0.0f);
+  ProtoSize::add_bool_field(total_size, 1, this->missing_state);
+  ProtoSize::add_uint32_field(total_size, 1, this->device_id);
 }
 #endif
 #ifdef USE_SWITCH
@@ -1604,16 +1604,16 @@ void ListEntitiesSwitchResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint32(10, this->device_id);
 }
 void ListEntitiesSwitchResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_string_field(total_size, 1, this->object_id, false);
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0, false);
-  ProtoSize::add_string_field(total_size, 1, this->name, false);
-  ProtoSize::add_string_field(total_size, 1, this->unique_id, false);
-  ProtoSize::add_string_field(total_size, 1, this->icon, false);
-  ProtoSize::add_bool_field(total_size, 1, this->assumed_state, false);
-  ProtoSize::add_bool_field(total_size, 1, this->disabled_by_default, false);
-  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->entity_category), false);
-  ProtoSize::add_string_field(total_size, 1, this->device_class, false);
-  ProtoSize::add_uint32_field(total_size, 1, this->device_id, false);
+  ProtoSize::add_string_field(total_size, 1, this->object_id);
+  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0);
+  ProtoSize::add_string_field(total_size, 1, this->name);
+  ProtoSize::add_string_field(total_size, 1, this->unique_id);
+  ProtoSize::add_string_field(total_size, 1, this->icon);
+  ProtoSize::add_bool_field(total_size, 1, this->assumed_state);
+  ProtoSize::add_bool_field(total_size, 1, this->disabled_by_default);
+  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->entity_category));
+  ProtoSize::add_string_field(total_size, 1, this->device_class);
+  ProtoSize::add_uint32_field(total_size, 1, this->device_id);
 }
 bool SwitchStateResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
@@ -1645,9 +1645,9 @@ void SwitchStateResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint32(3, this->device_id);
 }
 void SwitchStateResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0, false);
-  ProtoSize::add_bool_field(total_size, 1, this->state, false);
-  ProtoSize::add_uint32_field(total_size, 1, this->device_id, false);
+  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0);
+  ProtoSize::add_bool_field(total_size, 1, this->state);
+  ProtoSize::add_uint32_field(total_size, 1, this->device_id);
 }
 bool SwitchCommandRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
@@ -1679,9 +1679,9 @@ void SwitchCommandRequest::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint32(3, this->device_id);
 }
 void SwitchCommandRequest::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0, false);
-  ProtoSize::add_bool_field(total_size, 1, this->state, false);
-  ProtoSize::add_uint32_field(total_size, 1, this->device_id, false);
+  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0);
+  ProtoSize::add_bool_field(total_size, 1, this->state);
+  ProtoSize::add_uint32_field(total_size, 1, this->device_id);
 }
 #endif
 #ifdef USE_TEXT_SENSOR
@@ -1751,15 +1751,15 @@ void ListEntitiesTextSensorResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint32(9, this->device_id);
 }
 void ListEntitiesTextSensorResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_string_field(total_size, 1, this->object_id, false);
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0, false);
-  ProtoSize::add_string_field(total_size, 1, this->name, false);
-  ProtoSize::add_string_field(total_size, 1, this->unique_id, false);
-  ProtoSize::add_string_field(total_size, 1, this->icon, false);
-  ProtoSize::add_bool_field(total_size, 1, this->disabled_by_default, false);
-  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->entity_category), false);
-  ProtoSize::add_string_field(total_size, 1, this->device_class, false);
-  ProtoSize::add_uint32_field(total_size, 1, this->device_id, false);
+  ProtoSize::add_string_field(total_size, 1, this->object_id);
+  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0);
+  ProtoSize::add_string_field(total_size, 1, this->name);
+  ProtoSize::add_string_field(total_size, 1, this->unique_id);
+  ProtoSize::add_string_field(total_size, 1, this->icon);
+  ProtoSize::add_bool_field(total_size, 1, this->disabled_by_default);
+  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->entity_category));
+  ProtoSize::add_string_field(total_size, 1, this->device_class);
+  ProtoSize::add_uint32_field(total_size, 1, this->device_id);
 }
 bool TextSensorStateResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
@@ -1802,10 +1802,10 @@ void TextSensorStateResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint32(4, this->device_id);
 }
 void TextSensorStateResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0, false);
-  ProtoSize::add_string_field(total_size, 1, this->state, false);
-  ProtoSize::add_bool_field(total_size, 1, this->missing_state, false);
-  ProtoSize::add_uint32_field(total_size, 1, this->device_id, false);
+  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0);
+  ProtoSize::add_string_field(total_size, 1, this->state);
+  ProtoSize::add_bool_field(total_size, 1, this->missing_state);
+  ProtoSize::add_uint32_field(total_size, 1, this->device_id);
 }
 #endif
 bool SubscribeLogsRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
@@ -1827,8 +1827,8 @@ void SubscribeLogsRequest::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_bool(2, this->dump_config);
 }
 void SubscribeLogsRequest::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->level), false);
-  ProtoSize::add_bool_field(total_size, 1, this->dump_config, false);
+  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->level));
+  ProtoSize::add_bool_field(total_size, 1, this->dump_config);
 }
 bool SubscribeLogsResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
@@ -1860,9 +1860,9 @@ void SubscribeLogsResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_bool(4, this->send_failed);
 }
 void SubscribeLogsResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->level), false);
-  ProtoSize::add_string_field(total_size, 1, this->message, false);
-  ProtoSize::add_bool_field(total_size, 1, this->send_failed, false);
+  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->level));
+  ProtoSize::add_string_field(total_size, 1, this->message);
+  ProtoSize::add_bool_field(total_size, 1, this->send_failed);
 }
 #ifdef USE_API_NOISE
 bool NoiseEncryptionSetKeyRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
@@ -1879,7 +1879,7 @@ void NoiseEncryptionSetKeyRequest::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_bytes(1, reinterpret_cast<const uint8_t *>(this->key.data()), this->key.size());
 }
 void NoiseEncryptionSetKeyRequest::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_string_field(total_size, 1, this->key, false);
+  ProtoSize::add_string_field(total_size, 1, this->key);
 }
 bool NoiseEncryptionSetKeyResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
@@ -1893,7 +1893,7 @@ bool NoiseEncryptionSetKeyResponse::decode_varint(uint32_t field_id, ProtoVarInt
 }
 void NoiseEncryptionSetKeyResponse::encode(ProtoWriteBuffer buffer) const { buffer.encode_bool(1, this->success); }
 void NoiseEncryptionSetKeyResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_bool_field(total_size, 1, this->success, false);
+  ProtoSize::add_bool_field(total_size, 1, this->success);
 }
 #endif
 bool HomeassistantServiceMap::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
@@ -1915,8 +1915,8 @@ void HomeassistantServiceMap::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_string(2, this->value);
 }
 void HomeassistantServiceMap::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_string_field(total_size, 1, this->key, false);
-  ProtoSize::add_string_field(total_size, 1, this->value, false);
+  ProtoSize::add_string_field(total_size, 1, this->key);
+  ProtoSize::add_string_field(total_size, 1, this->value);
 }
 bool HomeassistantServiceResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
@@ -1964,11 +1964,11 @@ void HomeassistantServiceResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_bool(5, this->is_event);
 }
 void HomeassistantServiceResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_string_field(total_size, 1, this->service, false);
+  ProtoSize::add_string_field(total_size, 1, this->service);
   ProtoSize::add_repeated_message(total_size, 1, this->data);
   ProtoSize::add_repeated_message(total_size, 1, this->data_template);
   ProtoSize::add_repeated_message(total_size, 1, this->variables);
-  ProtoSize::add_bool_field(total_size, 1, this->is_event, false);
+  ProtoSize::add_bool_field(total_size, 1, this->is_event);
 }
 bool SubscribeHomeAssistantStateResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
@@ -2000,9 +2000,9 @@ void SubscribeHomeAssistantStateResponse::encode(ProtoWriteBuffer buffer) const 
   buffer.encode_bool(3, this->once);
 }
 void SubscribeHomeAssistantStateResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_string_field(total_size, 1, this->entity_id, false);
-  ProtoSize::add_string_field(total_size, 1, this->attribute, false);
-  ProtoSize::add_bool_field(total_size, 1, this->once, false);
+  ProtoSize::add_string_field(total_size, 1, this->entity_id);
+  ProtoSize::add_string_field(total_size, 1, this->attribute);
+  ProtoSize::add_bool_field(total_size, 1, this->once);
 }
 bool HomeAssistantStateResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
@@ -2028,9 +2028,9 @@ void HomeAssistantStateResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_string(3, this->attribute);
 }
 void HomeAssistantStateResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_string_field(total_size, 1, this->entity_id, false);
-  ProtoSize::add_string_field(total_size, 1, this->state, false);
-  ProtoSize::add_string_field(total_size, 1, this->attribute, false);
+  ProtoSize::add_string_field(total_size, 1, this->entity_id);
+  ProtoSize::add_string_field(total_size, 1, this->state);
+  ProtoSize::add_string_field(total_size, 1, this->attribute);
 }
 bool GetTimeResponse::decode_32bit(uint32_t field_id, Proto32Bit value) {
   switch (field_id) {
@@ -2044,7 +2044,7 @@ bool GetTimeResponse::decode_32bit(uint32_t field_id, Proto32Bit value) {
 }
 void GetTimeResponse::encode(ProtoWriteBuffer buffer) const { buffer.encode_fixed32(1, this->epoch_seconds); }
 void GetTimeResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->epoch_seconds != 0, false);
+  ProtoSize::add_fixed_field<4>(total_size, 1, this->epoch_seconds != 0);
 }
 bool ListEntitiesServicesArgument::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
@@ -2071,8 +2071,8 @@ void ListEntitiesServicesArgument::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_enum<enums::ServiceArgType>(2, this->type);
 }
 void ListEntitiesServicesArgument::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_string_field(total_size, 1, this->name, false);
-  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->type), false);
+  ProtoSize::add_string_field(total_size, 1, this->name);
+  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->type));
 }
 bool ListEntitiesServicesResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
@@ -2106,8 +2106,8 @@ void ListEntitiesServicesResponse::encode(ProtoWriteBuffer buffer) const {
   }
 }
 void ListEntitiesServicesResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_string_field(total_size, 1, this->name, false);
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0, false);
+  ProtoSize::add_string_field(total_size, 1, this->name);
+  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0);
   ProtoSize::add_repeated_message(total_size, 1, this->args);
 }
 bool ExecuteServiceArgument::decode_varint(uint32_t field_id, ProtoVarInt value) {
@@ -2184,29 +2184,29 @@ void ExecuteServiceArgument::encode(ProtoWriteBuffer buffer) const {
   }
 }
 void ExecuteServiceArgument::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_bool_field(total_size, 1, this->bool_, false);
-  ProtoSize::add_int32_field(total_size, 1, this->legacy_int, false);
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->float_ != 0.0f, false);
-  ProtoSize::add_string_field(total_size, 1, this->string_, false);
-  ProtoSize::add_sint32_field(total_size, 1, this->int_, false);
+  ProtoSize::add_bool_field(total_size, 1, this->bool_);
+  ProtoSize::add_int32_field(total_size, 1, this->legacy_int);
+  ProtoSize::add_fixed_field<4>(total_size, 1, this->float_ != 0.0f);
+  ProtoSize::add_string_field(total_size, 1, this->string_);
+  ProtoSize::add_sint32_field(total_size, 1, this->int_);
   if (!this->bool_array.empty()) {
     for (const auto it : this->bool_array) {
-      ProtoSize::add_bool_field(total_size, 1, it, true);
+      ProtoSize::add_bool_field_repeated(total_size, 1, it);
     }
   }
   if (!this->int_array.empty()) {
     for (const auto &it : this->int_array) {
-      ProtoSize::add_sint32_field(total_size, 1, it, true);
+      ProtoSize::add_sint32_field_repeated(total_size, 1, it);
     }
   }
   if (!this->float_array.empty()) {
     for (const auto &it : this->float_array) {
-      ProtoSize::add_fixed_field<4>(total_size, 1, it != 0.0f, true);
+      ProtoSize::add_fixed_field_repeated<4>(total_size, 1);
     }
   }
   if (!this->string_array.empty()) {
     for (const auto &it : this->string_array) {
-      ProtoSize::add_string_field(total_size, 1, it, true);
+      ProtoSize::add_string_field_repeated(total_size, 1, it);
     }
   }
 }
@@ -2237,7 +2237,7 @@ void ExecuteServiceRequest::encode(ProtoWriteBuffer buffer) const {
   }
 }
 void ExecuteServiceRequest::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0, false);
+  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0);
   ProtoSize::add_repeated_message(total_size, 1, this->args);
 }
 #ifdef USE_CAMERA
@@ -2302,14 +2302,14 @@ void ListEntitiesCameraResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint32(8, this->device_id);
 }
 void ListEntitiesCameraResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_string_field(total_size, 1, this->object_id, false);
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0, false);
-  ProtoSize::add_string_field(total_size, 1, this->name, false);
-  ProtoSize::add_string_field(total_size, 1, this->unique_id, false);
-  ProtoSize::add_bool_field(total_size, 1, this->disabled_by_default, false);
-  ProtoSize::add_string_field(total_size, 1, this->icon, false);
-  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->entity_category), false);
-  ProtoSize::add_uint32_field(total_size, 1, this->device_id, false);
+  ProtoSize::add_string_field(total_size, 1, this->object_id);
+  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0);
+  ProtoSize::add_string_field(total_size, 1, this->name);
+  ProtoSize::add_string_field(total_size, 1, this->unique_id);
+  ProtoSize::add_bool_field(total_size, 1, this->disabled_by_default);
+  ProtoSize::add_string_field(total_size, 1, this->icon);
+  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->entity_category));
+  ProtoSize::add_uint32_field(total_size, 1, this->device_id);
 }
 bool CameraImageResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
@@ -2352,10 +2352,10 @@ void CameraImageResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint32(4, this->device_id);
 }
 void CameraImageResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0, false);
-  ProtoSize::add_string_field(total_size, 1, this->data, false);
-  ProtoSize::add_bool_field(total_size, 1, this->done, false);
-  ProtoSize::add_uint32_field(total_size, 1, this->device_id, false);
+  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0);
+  ProtoSize::add_string_field(total_size, 1, this->data);
+  ProtoSize::add_bool_field(total_size, 1, this->done);
+  ProtoSize::add_uint32_field(total_size, 1, this->device_id);
 }
 bool CameraImageRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
@@ -2376,8 +2376,8 @@ void CameraImageRequest::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_bool(2, this->stream);
 }
 void CameraImageRequest::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_bool_field(total_size, 1, this->single, false);
-  ProtoSize::add_bool_field(total_size, 1, this->stream, false);
+  ProtoSize::add_bool_field(total_size, 1, this->single);
+  ProtoSize::add_bool_field(total_size, 1, this->stream);
 }
 #endif
 #ifdef USE_CLIMATE
@@ -2544,56 +2544,56 @@ void ListEntitiesClimateResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint32(26, this->device_id);
 }
 void ListEntitiesClimateResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_string_field(total_size, 1, this->object_id, false);
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0, false);
-  ProtoSize::add_string_field(total_size, 1, this->name, false);
-  ProtoSize::add_string_field(total_size, 1, this->unique_id, false);
-  ProtoSize::add_bool_field(total_size, 1, this->supports_current_temperature, false);
-  ProtoSize::add_bool_field(total_size, 1, this->supports_two_point_target_temperature, false);
+  ProtoSize::add_string_field(total_size, 1, this->object_id);
+  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0);
+  ProtoSize::add_string_field(total_size, 1, this->name);
+  ProtoSize::add_string_field(total_size, 1, this->unique_id);
+  ProtoSize::add_bool_field(total_size, 1, this->supports_current_temperature);
+  ProtoSize::add_bool_field(total_size, 1, this->supports_two_point_target_temperature);
   if (!this->supported_modes.empty()) {
     for (const auto &it : this->supported_modes) {
-      ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(it), true);
+      ProtoSize::add_enum_field_repeated(total_size, 1, static_cast<uint32_t>(it));
     }
   }
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->visual_min_temperature != 0.0f, false);
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->visual_max_temperature != 0.0f, false);
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->visual_target_temperature_step != 0.0f, false);
-  ProtoSize::add_bool_field(total_size, 1, this->legacy_supports_away, false);
-  ProtoSize::add_bool_field(total_size, 1, this->supports_action, false);
+  ProtoSize::add_fixed_field<4>(total_size, 1, this->visual_min_temperature != 0.0f);
+  ProtoSize::add_fixed_field<4>(total_size, 1, this->visual_max_temperature != 0.0f);
+  ProtoSize::add_fixed_field<4>(total_size, 1, this->visual_target_temperature_step != 0.0f);
+  ProtoSize::add_bool_field(total_size, 1, this->legacy_supports_away);
+  ProtoSize::add_bool_field(total_size, 1, this->supports_action);
   if (!this->supported_fan_modes.empty()) {
     for (const auto &it : this->supported_fan_modes) {
-      ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(it), true);
+      ProtoSize::add_enum_field_repeated(total_size, 1, static_cast<uint32_t>(it));
     }
   }
   if (!this->supported_swing_modes.empty()) {
     for (const auto &it : this->supported_swing_modes) {
-      ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(it), true);
+      ProtoSize::add_enum_field_repeated(total_size, 1, static_cast<uint32_t>(it));
     }
   }
   if (!this->supported_custom_fan_modes.empty()) {
     for (const auto &it : this->supported_custom_fan_modes) {
-      ProtoSize::add_string_field(total_size, 1, it, true);
+      ProtoSize::add_string_field_repeated(total_size, 1, it);
     }
   }
   if (!this->supported_presets.empty()) {
     for (const auto &it : this->supported_presets) {
-      ProtoSize::add_enum_field(total_size, 2, static_cast<uint32_t>(it), true);
+      ProtoSize::add_enum_field_repeated(total_size, 2, static_cast<uint32_t>(it));
     }
   }
   if (!this->supported_custom_presets.empty()) {
     for (const auto &it : this->supported_custom_presets) {
-      ProtoSize::add_string_field(total_size, 2, it, true);
+      ProtoSize::add_string_field_repeated(total_size, 2, it);
     }
   }
-  ProtoSize::add_bool_field(total_size, 2, this->disabled_by_default, false);
-  ProtoSize::add_string_field(total_size, 2, this->icon, false);
-  ProtoSize::add_enum_field(total_size, 2, static_cast<uint32_t>(this->entity_category), false);
-  ProtoSize::add_fixed_field<4>(total_size, 2, this->visual_current_temperature_step != 0.0f, false);
-  ProtoSize::add_bool_field(total_size, 2, this->supports_current_humidity, false);
-  ProtoSize::add_bool_field(total_size, 2, this->supports_target_humidity, false);
-  ProtoSize::add_fixed_field<4>(total_size, 2, this->visual_min_humidity != 0.0f, false);
-  ProtoSize::add_fixed_field<4>(total_size, 2, this->visual_max_humidity != 0.0f, false);
-  ProtoSize::add_uint32_field(total_size, 2, this->device_id, false);
+  ProtoSize::add_bool_field(total_size, 2, this->disabled_by_default);
+  ProtoSize::add_string_field(total_size, 2, this->icon);
+  ProtoSize::add_enum_field(total_size, 2, static_cast<uint32_t>(this->entity_category));
+  ProtoSize::add_fixed_field<4>(total_size, 2, this->visual_current_temperature_step != 0.0f);
+  ProtoSize::add_bool_field(total_size, 2, this->supports_current_humidity);
+  ProtoSize::add_bool_field(total_size, 2, this->supports_target_humidity);
+  ProtoSize::add_fixed_field<4>(total_size, 2, this->visual_min_humidity != 0.0f);
+  ProtoSize::add_fixed_field<4>(total_size, 2, this->visual_max_humidity != 0.0f);
+  ProtoSize::add_uint32_field(total_size, 2, this->device_id);
 }
 bool ClimateStateResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
@@ -2696,22 +2696,22 @@ void ClimateStateResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint32(16, this->device_id);
 }
 void ClimateStateResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0, false);
-  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->mode), false);
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->current_temperature != 0.0f, false);
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->target_temperature != 0.0f, false);
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->target_temperature_low != 0.0f, false);
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->target_temperature_high != 0.0f, false);
-  ProtoSize::add_bool_field(total_size, 1, this->unused_legacy_away, false);
-  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->action), false);
-  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->fan_mode), false);
-  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->swing_mode), false);
-  ProtoSize::add_string_field(total_size, 1, this->custom_fan_mode, false);
-  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->preset), false);
-  ProtoSize::add_string_field(total_size, 1, this->custom_preset, false);
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->current_humidity != 0.0f, false);
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->target_humidity != 0.0f, false);
-  ProtoSize::add_uint32_field(total_size, 2, this->device_id, false);
+  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0);
+  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->mode));
+  ProtoSize::add_fixed_field<4>(total_size, 1, this->current_temperature != 0.0f);
+  ProtoSize::add_fixed_field<4>(total_size, 1, this->target_temperature != 0.0f);
+  ProtoSize::add_fixed_field<4>(total_size, 1, this->target_temperature_low != 0.0f);
+  ProtoSize::add_fixed_field<4>(total_size, 1, this->target_temperature_high != 0.0f);
+  ProtoSize::add_bool_field(total_size, 1, this->unused_legacy_away);
+  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->action));
+  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->fan_mode));
+  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->swing_mode));
+  ProtoSize::add_string_field(total_size, 1, this->custom_fan_mode);
+  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->preset));
+  ProtoSize::add_string_field(total_size, 1, this->custom_preset);
+  ProtoSize::add_fixed_field<4>(total_size, 1, this->current_humidity != 0.0f);
+  ProtoSize::add_fixed_field<4>(total_size, 1, this->target_humidity != 0.0f);
+  ProtoSize::add_uint32_field(total_size, 2, this->device_id);
 }
 bool ClimateCommandRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
@@ -2854,30 +2854,30 @@ void ClimateCommandRequest::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint32(24, this->device_id);
 }
 void ClimateCommandRequest::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0, false);
-  ProtoSize::add_bool_field(total_size, 1, this->has_mode, false);
-  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->mode), false);
-  ProtoSize::add_bool_field(total_size, 1, this->has_target_temperature, false);
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->target_temperature != 0.0f, false);
-  ProtoSize::add_bool_field(total_size, 1, this->has_target_temperature_low, false);
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->target_temperature_low != 0.0f, false);
-  ProtoSize::add_bool_field(total_size, 1, this->has_target_temperature_high, false);
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->target_temperature_high != 0.0f, false);
-  ProtoSize::add_bool_field(total_size, 1, this->unused_has_legacy_away, false);
-  ProtoSize::add_bool_field(total_size, 1, this->unused_legacy_away, false);
-  ProtoSize::add_bool_field(total_size, 1, this->has_fan_mode, false);
-  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->fan_mode), false);
-  ProtoSize::add_bool_field(total_size, 1, this->has_swing_mode, false);
-  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->swing_mode), false);
-  ProtoSize::add_bool_field(total_size, 2, this->has_custom_fan_mode, false);
-  ProtoSize::add_string_field(total_size, 2, this->custom_fan_mode, false);
-  ProtoSize::add_bool_field(total_size, 2, this->has_preset, false);
-  ProtoSize::add_enum_field(total_size, 2, static_cast<uint32_t>(this->preset), false);
-  ProtoSize::add_bool_field(total_size, 2, this->has_custom_preset, false);
-  ProtoSize::add_string_field(total_size, 2, this->custom_preset, false);
-  ProtoSize::add_bool_field(total_size, 2, this->has_target_humidity, false);
-  ProtoSize::add_fixed_field<4>(total_size, 2, this->target_humidity != 0.0f, false);
-  ProtoSize::add_uint32_field(total_size, 2, this->device_id, false);
+  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0);
+  ProtoSize::add_bool_field(total_size, 1, this->has_mode);
+  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->mode));
+  ProtoSize::add_bool_field(total_size, 1, this->has_target_temperature);
+  ProtoSize::add_fixed_field<4>(total_size, 1, this->target_temperature != 0.0f);
+  ProtoSize::add_bool_field(total_size, 1, this->has_target_temperature_low);
+  ProtoSize::add_fixed_field<4>(total_size, 1, this->target_temperature_low != 0.0f);
+  ProtoSize::add_bool_field(total_size, 1, this->has_target_temperature_high);
+  ProtoSize::add_fixed_field<4>(total_size, 1, this->target_temperature_high != 0.0f);
+  ProtoSize::add_bool_field(total_size, 1, this->unused_has_legacy_away);
+  ProtoSize::add_bool_field(total_size, 1, this->unused_legacy_away);
+  ProtoSize::add_bool_field(total_size, 1, this->has_fan_mode);
+  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->fan_mode));
+  ProtoSize::add_bool_field(total_size, 1, this->has_swing_mode);
+  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->swing_mode));
+  ProtoSize::add_bool_field(total_size, 2, this->has_custom_fan_mode);
+  ProtoSize::add_string_field(total_size, 2, this->custom_fan_mode);
+  ProtoSize::add_bool_field(total_size, 2, this->has_preset);
+  ProtoSize::add_enum_field(total_size, 2, static_cast<uint32_t>(this->preset));
+  ProtoSize::add_bool_field(total_size, 2, this->has_custom_preset);
+  ProtoSize::add_string_field(total_size, 2, this->custom_preset);
+  ProtoSize::add_bool_field(total_size, 2, this->has_target_humidity);
+  ProtoSize::add_fixed_field<4>(total_size, 2, this->target_humidity != 0.0f);
+  ProtoSize::add_uint32_field(total_size, 2, this->device_id);
 }
 #endif
 #ifdef USE_NUMBER
@@ -2972,20 +2972,20 @@ void ListEntitiesNumberResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint32(14, this->device_id);
 }
 void ListEntitiesNumberResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_string_field(total_size, 1, this->object_id, false);
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0, false);
-  ProtoSize::add_string_field(total_size, 1, this->name, false);
-  ProtoSize::add_string_field(total_size, 1, this->unique_id, false);
-  ProtoSize::add_string_field(total_size, 1, this->icon, false);
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->min_value != 0.0f, false);
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->max_value != 0.0f, false);
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->step != 0.0f, false);
-  ProtoSize::add_bool_field(total_size, 1, this->disabled_by_default, false);
-  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->entity_category), false);
-  ProtoSize::add_string_field(total_size, 1, this->unit_of_measurement, false);
-  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->mode), false);
-  ProtoSize::add_string_field(total_size, 1, this->device_class, false);
-  ProtoSize::add_uint32_field(total_size, 1, this->device_id, false);
+  ProtoSize::add_string_field(total_size, 1, this->object_id);
+  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0);
+  ProtoSize::add_string_field(total_size, 1, this->name);
+  ProtoSize::add_string_field(total_size, 1, this->unique_id);
+  ProtoSize::add_string_field(total_size, 1, this->icon);
+  ProtoSize::add_fixed_field<4>(total_size, 1, this->min_value != 0.0f);
+  ProtoSize::add_fixed_field<4>(total_size, 1, this->max_value != 0.0f);
+  ProtoSize::add_fixed_field<4>(total_size, 1, this->step != 0.0f);
+  ProtoSize::add_bool_field(total_size, 1, this->disabled_by_default);
+  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->entity_category));
+  ProtoSize::add_string_field(total_size, 1, this->unit_of_measurement);
+  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->mode));
+  ProtoSize::add_string_field(total_size, 1, this->device_class);
+  ProtoSize::add_uint32_field(total_size, 1, this->device_id);
 }
 bool NumberStateResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
@@ -3022,10 +3022,10 @@ void NumberStateResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint32(4, this->device_id);
 }
 void NumberStateResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0, false);
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->state != 0.0f, false);
-  ProtoSize::add_bool_field(total_size, 1, this->missing_state, false);
-  ProtoSize::add_uint32_field(total_size, 1, this->device_id, false);
+  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0);
+  ProtoSize::add_fixed_field<4>(total_size, 1, this->state != 0.0f);
+  ProtoSize::add_bool_field(total_size, 1, this->missing_state);
+  ProtoSize::add_uint32_field(total_size, 1, this->device_id);
 }
 bool NumberCommandRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
@@ -3057,9 +3057,9 @@ void NumberCommandRequest::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint32(3, this->device_id);
 }
 void NumberCommandRequest::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0, false);
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->state != 0.0f, false);
-  ProtoSize::add_uint32_field(total_size, 1, this->device_id, false);
+  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0);
+  ProtoSize::add_fixed_field<4>(total_size, 1, this->state != 0.0f);
+  ProtoSize::add_uint32_field(total_size, 1, this->device_id);
 }
 #endif
 #ifdef USE_SELECT
@@ -3131,19 +3131,19 @@ void ListEntitiesSelectResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint32(9, this->device_id);
 }
 void ListEntitiesSelectResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_string_field(total_size, 1, this->object_id, false);
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0, false);
-  ProtoSize::add_string_field(total_size, 1, this->name, false);
-  ProtoSize::add_string_field(total_size, 1, this->unique_id, false);
-  ProtoSize::add_string_field(total_size, 1, this->icon, false);
+  ProtoSize::add_string_field(total_size, 1, this->object_id);
+  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0);
+  ProtoSize::add_string_field(total_size, 1, this->name);
+  ProtoSize::add_string_field(total_size, 1, this->unique_id);
+  ProtoSize::add_string_field(total_size, 1, this->icon);
   if (!this->options.empty()) {
     for (const auto &it : this->options) {
-      ProtoSize::add_string_field(total_size, 1, it, true);
+      ProtoSize::add_string_field_repeated(total_size, 1, it);
     }
   }
-  ProtoSize::add_bool_field(total_size, 1, this->disabled_by_default, false);
-  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->entity_category), false);
-  ProtoSize::add_uint32_field(total_size, 1, this->device_id, false);
+  ProtoSize::add_bool_field(total_size, 1, this->disabled_by_default);
+  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->entity_category));
+  ProtoSize::add_uint32_field(total_size, 1, this->device_id);
 }
 bool SelectStateResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
@@ -3186,10 +3186,10 @@ void SelectStateResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint32(4, this->device_id);
 }
 void SelectStateResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0, false);
-  ProtoSize::add_string_field(total_size, 1, this->state, false);
-  ProtoSize::add_bool_field(total_size, 1, this->missing_state, false);
-  ProtoSize::add_uint32_field(total_size, 1, this->device_id, false);
+  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0);
+  ProtoSize::add_string_field(total_size, 1, this->state);
+  ProtoSize::add_bool_field(total_size, 1, this->missing_state);
+  ProtoSize::add_uint32_field(total_size, 1, this->device_id);
 }
 bool SelectCommandRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
@@ -3227,9 +3227,9 @@ void SelectCommandRequest::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint32(3, this->device_id);
 }
 void SelectCommandRequest::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0, false);
-  ProtoSize::add_string_field(total_size, 1, this->state, false);
-  ProtoSize::add_uint32_field(total_size, 1, this->device_id, false);
+  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0);
+  ProtoSize::add_string_field(total_size, 1, this->state);
+  ProtoSize::add_uint32_field(total_size, 1, this->device_id);
 }
 #endif
 #ifdef USE_SIREN
@@ -3311,21 +3311,21 @@ void ListEntitiesSirenResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint32(11, this->device_id);
 }
 void ListEntitiesSirenResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_string_field(total_size, 1, this->object_id, false);
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0, false);
-  ProtoSize::add_string_field(total_size, 1, this->name, false);
-  ProtoSize::add_string_field(total_size, 1, this->unique_id, false);
-  ProtoSize::add_string_field(total_size, 1, this->icon, false);
-  ProtoSize::add_bool_field(total_size, 1, this->disabled_by_default, false);
+  ProtoSize::add_string_field(total_size, 1, this->object_id);
+  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0);
+  ProtoSize::add_string_field(total_size, 1, this->name);
+  ProtoSize::add_string_field(total_size, 1, this->unique_id);
+  ProtoSize::add_string_field(total_size, 1, this->icon);
+  ProtoSize::add_bool_field(total_size, 1, this->disabled_by_default);
   if (!this->tones.empty()) {
     for (const auto &it : this->tones) {
-      ProtoSize::add_string_field(total_size, 1, it, true);
+      ProtoSize::add_string_field_repeated(total_size, 1, it);
     }
   }
-  ProtoSize::add_bool_field(total_size, 1, this->supports_duration, false);
-  ProtoSize::add_bool_field(total_size, 1, this->supports_volume, false);
-  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->entity_category), false);
-  ProtoSize::add_uint32_field(total_size, 1, this->device_id, false);
+  ProtoSize::add_bool_field(total_size, 1, this->supports_duration);
+  ProtoSize::add_bool_field(total_size, 1, this->supports_volume);
+  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->entity_category));
+  ProtoSize::add_uint32_field(total_size, 1, this->device_id);
 }
 bool SirenStateResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
@@ -3357,9 +3357,9 @@ void SirenStateResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint32(3, this->device_id);
 }
 void SirenStateResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0, false);
-  ProtoSize::add_bool_field(total_size, 1, this->state, false);
-  ProtoSize::add_uint32_field(total_size, 1, this->device_id, false);
+  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0);
+  ProtoSize::add_bool_field(total_size, 1, this->state);
+  ProtoSize::add_uint32_field(total_size, 1, this->device_id);
 }
 bool SirenCommandRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
@@ -3432,16 +3432,16 @@ void SirenCommandRequest::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint32(10, this->device_id);
 }
 void SirenCommandRequest::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0, false);
-  ProtoSize::add_bool_field(total_size, 1, this->has_state, false);
-  ProtoSize::add_bool_field(total_size, 1, this->state, false);
-  ProtoSize::add_bool_field(total_size, 1, this->has_tone, false);
-  ProtoSize::add_string_field(total_size, 1, this->tone, false);
-  ProtoSize::add_bool_field(total_size, 1, this->has_duration, false);
-  ProtoSize::add_uint32_field(total_size, 1, this->duration, false);
-  ProtoSize::add_bool_field(total_size, 1, this->has_volume, false);
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->volume != 0.0f, false);
-  ProtoSize::add_uint32_field(total_size, 1, this->device_id, false);
+  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0);
+  ProtoSize::add_bool_field(total_size, 1, this->has_state);
+  ProtoSize::add_bool_field(total_size, 1, this->state);
+  ProtoSize::add_bool_field(total_size, 1, this->has_tone);
+  ProtoSize::add_string_field(total_size, 1, this->tone);
+  ProtoSize::add_bool_field(total_size, 1, this->has_duration);
+  ProtoSize::add_uint32_field(total_size, 1, this->duration);
+  ProtoSize::add_bool_field(total_size, 1, this->has_volume);
+  ProtoSize::add_fixed_field<4>(total_size, 1, this->volume != 0.0f);
+  ProtoSize::add_uint32_field(total_size, 1, this->device_id);
 }
 #endif
 #ifdef USE_LOCK
@@ -3526,18 +3526,18 @@ void ListEntitiesLockResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint32(12, this->device_id);
 }
 void ListEntitiesLockResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_string_field(total_size, 1, this->object_id, false);
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0, false);
-  ProtoSize::add_string_field(total_size, 1, this->name, false);
-  ProtoSize::add_string_field(total_size, 1, this->unique_id, false);
-  ProtoSize::add_string_field(total_size, 1, this->icon, false);
-  ProtoSize::add_bool_field(total_size, 1, this->disabled_by_default, false);
-  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->entity_category), false);
-  ProtoSize::add_bool_field(total_size, 1, this->assumed_state, false);
-  ProtoSize::add_bool_field(total_size, 1, this->supports_open, false);
-  ProtoSize::add_bool_field(total_size, 1, this->requires_code, false);
-  ProtoSize::add_string_field(total_size, 1, this->code_format, false);
-  ProtoSize::add_uint32_field(total_size, 1, this->device_id, false);
+  ProtoSize::add_string_field(total_size, 1, this->object_id);
+  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0);
+  ProtoSize::add_string_field(total_size, 1, this->name);
+  ProtoSize::add_string_field(total_size, 1, this->unique_id);
+  ProtoSize::add_string_field(total_size, 1, this->icon);
+  ProtoSize::add_bool_field(total_size, 1, this->disabled_by_default);
+  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->entity_category));
+  ProtoSize::add_bool_field(total_size, 1, this->assumed_state);
+  ProtoSize::add_bool_field(total_size, 1, this->supports_open);
+  ProtoSize::add_bool_field(total_size, 1, this->requires_code);
+  ProtoSize::add_string_field(total_size, 1, this->code_format);
+  ProtoSize::add_uint32_field(total_size, 1, this->device_id);
 }
 bool LockStateResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
@@ -3569,9 +3569,9 @@ void LockStateResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint32(3, this->device_id);
 }
 void LockStateResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0, false);
-  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->state), false);
-  ProtoSize::add_uint32_field(total_size, 1, this->device_id, false);
+  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0);
+  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->state));
+  ProtoSize::add_uint32_field(total_size, 1, this->device_id);
 }
 bool LockCommandRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
@@ -3619,11 +3619,11 @@ void LockCommandRequest::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint32(5, this->device_id);
 }
 void LockCommandRequest::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0, false);
-  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->command), false);
-  ProtoSize::add_bool_field(total_size, 1, this->has_code, false);
-  ProtoSize::add_string_field(total_size, 1, this->code, false);
-  ProtoSize::add_uint32_field(total_size, 1, this->device_id, false);
+  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0);
+  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->command));
+  ProtoSize::add_bool_field(total_size, 1, this->has_code);
+  ProtoSize::add_string_field(total_size, 1, this->code);
+  ProtoSize::add_uint32_field(total_size, 1, this->device_id);
 }
 #endif
 #ifdef USE_BUTTON
@@ -3693,15 +3693,15 @@ void ListEntitiesButtonResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint32(9, this->device_id);
 }
 void ListEntitiesButtonResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_string_field(total_size, 1, this->object_id, false);
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0, false);
-  ProtoSize::add_string_field(total_size, 1, this->name, false);
-  ProtoSize::add_string_field(total_size, 1, this->unique_id, false);
-  ProtoSize::add_string_field(total_size, 1, this->icon, false);
-  ProtoSize::add_bool_field(total_size, 1, this->disabled_by_default, false);
-  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->entity_category), false);
-  ProtoSize::add_string_field(total_size, 1, this->device_class, false);
-  ProtoSize::add_uint32_field(total_size, 1, this->device_id, false);
+  ProtoSize::add_string_field(total_size, 1, this->object_id);
+  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0);
+  ProtoSize::add_string_field(total_size, 1, this->name);
+  ProtoSize::add_string_field(total_size, 1, this->unique_id);
+  ProtoSize::add_string_field(total_size, 1, this->icon);
+  ProtoSize::add_bool_field(total_size, 1, this->disabled_by_default);
+  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->entity_category));
+  ProtoSize::add_string_field(total_size, 1, this->device_class);
+  ProtoSize::add_uint32_field(total_size, 1, this->device_id);
 }
 bool ButtonCommandRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
@@ -3728,8 +3728,8 @@ void ButtonCommandRequest::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint32(2, this->device_id);
 }
 void ButtonCommandRequest::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0, false);
-  ProtoSize::add_uint32_field(total_size, 1, this->device_id, false);
+  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0);
+  ProtoSize::add_uint32_field(total_size, 1, this->device_id);
 }
 #endif
 #ifdef USE_MEDIA_PLAYER
@@ -3773,11 +3773,11 @@ void MediaPlayerSupportedFormat::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint32(5, this->sample_bytes);
 }
 void MediaPlayerSupportedFormat::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_string_field(total_size, 1, this->format, false);
-  ProtoSize::add_uint32_field(total_size, 1, this->sample_rate, false);
-  ProtoSize::add_uint32_field(total_size, 1, this->num_channels, false);
-  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->purpose), false);
-  ProtoSize::add_uint32_field(total_size, 1, this->sample_bytes, false);
+  ProtoSize::add_string_field(total_size, 1, this->format);
+  ProtoSize::add_uint32_field(total_size, 1, this->sample_rate);
+  ProtoSize::add_uint32_field(total_size, 1, this->num_channels);
+  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->purpose));
+  ProtoSize::add_uint32_field(total_size, 1, this->sample_bytes);
 }
 bool ListEntitiesMediaPlayerResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
@@ -3852,16 +3852,16 @@ void ListEntitiesMediaPlayerResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint32(10, this->device_id);
 }
 void ListEntitiesMediaPlayerResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_string_field(total_size, 1, this->object_id, false);
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0, false);
-  ProtoSize::add_string_field(total_size, 1, this->name, false);
-  ProtoSize::add_string_field(total_size, 1, this->unique_id, false);
-  ProtoSize::add_string_field(total_size, 1, this->icon, false);
-  ProtoSize::add_bool_field(total_size, 1, this->disabled_by_default, false);
-  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->entity_category), false);
-  ProtoSize::add_bool_field(total_size, 1, this->supports_pause, false);
+  ProtoSize::add_string_field(total_size, 1, this->object_id);
+  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0);
+  ProtoSize::add_string_field(total_size, 1, this->name);
+  ProtoSize::add_string_field(total_size, 1, this->unique_id);
+  ProtoSize::add_string_field(total_size, 1, this->icon);
+  ProtoSize::add_bool_field(total_size, 1, this->disabled_by_default);
+  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->entity_category));
+  ProtoSize::add_bool_field(total_size, 1, this->supports_pause);
   ProtoSize::add_repeated_message(total_size, 1, this->supported_formats);
-  ProtoSize::add_uint32_field(total_size, 1, this->device_id, false);
+  ProtoSize::add_uint32_field(total_size, 1, this->device_id);
 }
 bool MediaPlayerStateResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
@@ -3903,11 +3903,11 @@ void MediaPlayerStateResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint32(5, this->device_id);
 }
 void MediaPlayerStateResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0, false);
-  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->state), false);
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->volume != 0.0f, false);
-  ProtoSize::add_bool_field(total_size, 1, this->muted, false);
-  ProtoSize::add_uint32_field(total_size, 1, this->device_id, false);
+  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0);
+  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->state));
+  ProtoSize::add_fixed_field<4>(total_size, 1, this->volume != 0.0f);
+  ProtoSize::add_bool_field(total_size, 1, this->muted);
+  ProtoSize::add_uint32_field(total_size, 1, this->device_id);
 }
 bool MediaPlayerCommandRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
@@ -3980,16 +3980,16 @@ void MediaPlayerCommandRequest::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint32(10, this->device_id);
 }
 void MediaPlayerCommandRequest::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0, false);
-  ProtoSize::add_bool_field(total_size, 1, this->has_command, false);
-  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->command), false);
-  ProtoSize::add_bool_field(total_size, 1, this->has_volume, false);
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->volume != 0.0f, false);
-  ProtoSize::add_bool_field(total_size, 1, this->has_media_url, false);
-  ProtoSize::add_string_field(total_size, 1, this->media_url, false);
-  ProtoSize::add_bool_field(total_size, 1, this->has_announcement, false);
-  ProtoSize::add_bool_field(total_size, 1, this->announcement, false);
-  ProtoSize::add_uint32_field(total_size, 1, this->device_id, false);
+  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0);
+  ProtoSize::add_bool_field(total_size, 1, this->has_command);
+  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->command));
+  ProtoSize::add_bool_field(total_size, 1, this->has_volume);
+  ProtoSize::add_fixed_field<4>(total_size, 1, this->volume != 0.0f);
+  ProtoSize::add_bool_field(total_size, 1, this->has_media_url);
+  ProtoSize::add_string_field(total_size, 1, this->media_url);
+  ProtoSize::add_bool_field(total_size, 1, this->has_announcement);
+  ProtoSize::add_bool_field(total_size, 1, this->announcement);
+  ProtoSize::add_uint32_field(total_size, 1, this->device_id);
 }
 #endif
 #ifdef USE_BLUETOOTH_PROXY
@@ -4007,7 +4007,7 @@ void SubscribeBluetoothLEAdvertisementsRequest::encode(ProtoWriteBuffer buffer) 
   buffer.encode_uint32(1, this->flags);
 }
 void SubscribeBluetoothLEAdvertisementsRequest::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_uint32_field(total_size, 1, this->flags, false);
+  ProtoSize::add_uint32_field(total_size, 1, this->flags);
 }
 bool BluetoothServiceData::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
@@ -4041,13 +4041,13 @@ void BluetoothServiceData::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_bytes(3, reinterpret_cast<const uint8_t *>(this->data.data()), this->data.size());
 }
 void BluetoothServiceData::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_string_field(total_size, 1, this->uuid, false);
+  ProtoSize::add_string_field(total_size, 1, this->uuid);
   if (!this->legacy_data.empty()) {
     for (const auto &it : this->legacy_data) {
-      ProtoSize::add_uint32_field(total_size, 1, it, true);
+      ProtoSize::add_uint32_field_repeated(total_size, 1, it);
     }
   }
-  ProtoSize::add_string_field(total_size, 1, this->data, false);
+  ProtoSize::add_string_field(total_size, 1, this->data);
 }
 bool BluetoothLEAdvertisementResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
@@ -4105,17 +4105,17 @@ void BluetoothLEAdvertisementResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint32(7, this->address_type);
 }
 void BluetoothLEAdvertisementResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_uint64_field(total_size, 1, this->address, false);
-  ProtoSize::add_string_field(total_size, 1, this->name, false);
-  ProtoSize::add_sint32_field(total_size, 1, this->rssi, false);
+  ProtoSize::add_uint64_field(total_size, 1, this->address);
+  ProtoSize::add_string_field(total_size, 1, this->name);
+  ProtoSize::add_sint32_field(total_size, 1, this->rssi);
   if (!this->service_uuids.empty()) {
     for (const auto &it : this->service_uuids) {
-      ProtoSize::add_string_field(total_size, 1, it, true);
+      ProtoSize::add_string_field_repeated(total_size, 1, it);
     }
   }
   ProtoSize::add_repeated_message(total_size, 1, this->service_data);
   ProtoSize::add_repeated_message(total_size, 1, this->manufacturer_data);
-  ProtoSize::add_uint32_field(total_size, 1, this->address_type, false);
+  ProtoSize::add_uint32_field(total_size, 1, this->address_type);
 }
 bool BluetoothLERawAdvertisement::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
@@ -4152,10 +4152,10 @@ void BluetoothLERawAdvertisement::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_bytes(4, reinterpret_cast<const uint8_t *>(this->data.data()), this->data.size());
 }
 void BluetoothLERawAdvertisement::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_uint64_field(total_size, 1, this->address, false);
-  ProtoSize::add_sint32_field(total_size, 1, this->rssi, false);
-  ProtoSize::add_uint32_field(total_size, 1, this->address_type, false);
-  ProtoSize::add_string_field(total_size, 1, this->data, false);
+  ProtoSize::add_uint64_field(total_size, 1, this->address);
+  ProtoSize::add_sint32_field(total_size, 1, this->rssi);
+  ProtoSize::add_uint32_field(total_size, 1, this->address_type);
+  ProtoSize::add_string_field(total_size, 1, this->data);
 }
 bool BluetoothLERawAdvertisementsResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
@@ -4204,10 +4204,10 @@ void BluetoothDeviceRequest::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint32(4, this->address_type);
 }
 void BluetoothDeviceRequest::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_uint64_field(total_size, 1, this->address, false);
-  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->request_type), false);
-  ProtoSize::add_bool_field(total_size, 1, this->has_address_type, false);
-  ProtoSize::add_uint32_field(total_size, 1, this->address_type, false);
+  ProtoSize::add_uint64_field(total_size, 1, this->address);
+  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->request_type));
+  ProtoSize::add_bool_field(total_size, 1, this->has_address_type);
+  ProtoSize::add_uint32_field(total_size, 1, this->address_type);
 }
 bool BluetoothDeviceConnectionResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
@@ -4238,10 +4238,10 @@ void BluetoothDeviceConnectionResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_int32(4, this->error);
 }
 void BluetoothDeviceConnectionResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_uint64_field(total_size, 1, this->address, false);
-  ProtoSize::add_bool_field(total_size, 1, this->connected, false);
-  ProtoSize::add_uint32_field(total_size, 1, this->mtu, false);
-  ProtoSize::add_int32_field(total_size, 1, this->error, false);
+  ProtoSize::add_uint64_field(total_size, 1, this->address);
+  ProtoSize::add_bool_field(total_size, 1, this->connected);
+  ProtoSize::add_uint32_field(total_size, 1, this->mtu);
+  ProtoSize::add_int32_field(total_size, 1, this->error);
 }
 bool BluetoothGATTGetServicesRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
@@ -4255,7 +4255,7 @@ bool BluetoothGATTGetServicesRequest::decode_varint(uint32_t field_id, ProtoVarI
 }
 void BluetoothGATTGetServicesRequest::encode(ProtoWriteBuffer buffer) const { buffer.encode_uint64(1, this->address); }
 void BluetoothGATTGetServicesRequest::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_uint64_field(total_size, 1, this->address, false);
+  ProtoSize::add_uint64_field(total_size, 1, this->address);
 }
 bool BluetoothGATTDescriptor::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
@@ -4280,10 +4280,10 @@ void BluetoothGATTDescriptor::encode(ProtoWriteBuffer buffer) const {
 void BluetoothGATTDescriptor::calculate_size(uint32_t &total_size) const {
   if (!this->uuid.empty()) {
     for (const auto &it : this->uuid) {
-      ProtoSize::add_uint64_field(total_size, 1, it, true);
+      ProtoSize::add_uint64_field_repeated(total_size, 1, it);
     }
   }
-  ProtoSize::add_uint32_field(total_size, 1, this->handle, false);
+  ProtoSize::add_uint32_field(total_size, 1, this->handle);
 }
 bool BluetoothGATTCharacteristic::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
@@ -4326,11 +4326,11 @@ void BluetoothGATTCharacteristic::encode(ProtoWriteBuffer buffer) const {
 void BluetoothGATTCharacteristic::calculate_size(uint32_t &total_size) const {
   if (!this->uuid.empty()) {
     for (const auto &it : this->uuid) {
-      ProtoSize::add_uint64_field(total_size, 1, it, true);
+      ProtoSize::add_uint64_field_repeated(total_size, 1, it);
     }
   }
-  ProtoSize::add_uint32_field(total_size, 1, this->handle, false);
-  ProtoSize::add_uint32_field(total_size, 1, this->properties, false);
+  ProtoSize::add_uint32_field(total_size, 1, this->handle);
+  ProtoSize::add_uint32_field(total_size, 1, this->properties);
   ProtoSize::add_repeated_message(total_size, 1, this->descriptors);
 }
 bool BluetoothGATTService::decode_varint(uint32_t field_id, ProtoVarInt value) {
@@ -4369,10 +4369,10 @@ void BluetoothGATTService::encode(ProtoWriteBuffer buffer) const {
 void BluetoothGATTService::calculate_size(uint32_t &total_size) const {
   if (!this->uuid.empty()) {
     for (const auto &it : this->uuid) {
-      ProtoSize::add_uint64_field(total_size, 1, it, true);
+      ProtoSize::add_uint64_field_repeated(total_size, 1, it);
     }
   }
-  ProtoSize::add_uint32_field(total_size, 1, this->handle, false);
+  ProtoSize::add_uint32_field(total_size, 1, this->handle);
   ProtoSize::add_repeated_message(total_size, 1, this->characteristics);
 }
 bool BluetoothGATTGetServicesResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
@@ -4402,7 +4402,7 @@ void BluetoothGATTGetServicesResponse::encode(ProtoWriteBuffer buffer) const {
   }
 }
 void BluetoothGATTGetServicesResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_uint64_field(total_size, 1, this->address, false);
+  ProtoSize::add_uint64_field(total_size, 1, this->address);
   ProtoSize::add_repeated_message(total_size, 1, this->services);
 }
 bool BluetoothGATTGetServicesDoneResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
@@ -4419,7 +4419,7 @@ void BluetoothGATTGetServicesDoneResponse::encode(ProtoWriteBuffer buffer) const
   buffer.encode_uint64(1, this->address);
 }
 void BluetoothGATTGetServicesDoneResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_uint64_field(total_size, 1, this->address, false);
+  ProtoSize::add_uint64_field(total_size, 1, this->address);
 }
 bool BluetoothGATTReadRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
@@ -4440,8 +4440,8 @@ void BluetoothGATTReadRequest::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint32(2, this->handle);
 }
 void BluetoothGATTReadRequest::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_uint64_field(total_size, 1, this->address, false);
-  ProtoSize::add_uint32_field(total_size, 1, this->handle, false);
+  ProtoSize::add_uint64_field(total_size, 1, this->address);
+  ProtoSize::add_uint32_field(total_size, 1, this->handle);
 }
 bool BluetoothGATTReadResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
@@ -4473,9 +4473,9 @@ void BluetoothGATTReadResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_bytes(3, reinterpret_cast<const uint8_t *>(this->data.data()), this->data.size());
 }
 void BluetoothGATTReadResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_uint64_field(total_size, 1, this->address, false);
-  ProtoSize::add_uint32_field(total_size, 1, this->handle, false);
-  ProtoSize::add_string_field(total_size, 1, this->data, false);
+  ProtoSize::add_uint64_field(total_size, 1, this->address);
+  ProtoSize::add_uint32_field(total_size, 1, this->handle);
+  ProtoSize::add_string_field(total_size, 1, this->data);
 }
 bool BluetoothGATTWriteRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
@@ -4512,10 +4512,10 @@ void BluetoothGATTWriteRequest::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_bytes(4, reinterpret_cast<const uint8_t *>(this->data.data()), this->data.size());
 }
 void BluetoothGATTWriteRequest::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_uint64_field(total_size, 1, this->address, false);
-  ProtoSize::add_uint32_field(total_size, 1, this->handle, false);
-  ProtoSize::add_bool_field(total_size, 1, this->response, false);
-  ProtoSize::add_string_field(total_size, 1, this->data, false);
+  ProtoSize::add_uint64_field(total_size, 1, this->address);
+  ProtoSize::add_uint32_field(total_size, 1, this->handle);
+  ProtoSize::add_bool_field(total_size, 1, this->response);
+  ProtoSize::add_string_field(total_size, 1, this->data);
 }
 bool BluetoothGATTReadDescriptorRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
@@ -4536,8 +4536,8 @@ void BluetoothGATTReadDescriptorRequest::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint32(2, this->handle);
 }
 void BluetoothGATTReadDescriptorRequest::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_uint64_field(total_size, 1, this->address, false);
-  ProtoSize::add_uint32_field(total_size, 1, this->handle, false);
+  ProtoSize::add_uint64_field(total_size, 1, this->address);
+  ProtoSize::add_uint32_field(total_size, 1, this->handle);
 }
 bool BluetoothGATTWriteDescriptorRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
@@ -4569,9 +4569,9 @@ void BluetoothGATTWriteDescriptorRequest::encode(ProtoWriteBuffer buffer) const 
   buffer.encode_bytes(3, reinterpret_cast<const uint8_t *>(this->data.data()), this->data.size());
 }
 void BluetoothGATTWriteDescriptorRequest::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_uint64_field(total_size, 1, this->address, false);
-  ProtoSize::add_uint32_field(total_size, 1, this->handle, false);
-  ProtoSize::add_string_field(total_size, 1, this->data, false);
+  ProtoSize::add_uint64_field(total_size, 1, this->address);
+  ProtoSize::add_uint32_field(total_size, 1, this->handle);
+  ProtoSize::add_string_field(total_size, 1, this->data);
 }
 bool BluetoothGATTNotifyRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
@@ -4597,9 +4597,9 @@ void BluetoothGATTNotifyRequest::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_bool(3, this->enable);
 }
 void BluetoothGATTNotifyRequest::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_uint64_field(total_size, 1, this->address, false);
-  ProtoSize::add_uint32_field(total_size, 1, this->handle, false);
-  ProtoSize::add_bool_field(total_size, 1, this->enable, false);
+  ProtoSize::add_uint64_field(total_size, 1, this->address);
+  ProtoSize::add_uint32_field(total_size, 1, this->handle);
+  ProtoSize::add_bool_field(total_size, 1, this->enable);
 }
 bool BluetoothGATTNotifyDataResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
@@ -4631,9 +4631,9 @@ void BluetoothGATTNotifyDataResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_bytes(3, reinterpret_cast<const uint8_t *>(this->data.data()), this->data.size());
 }
 void BluetoothGATTNotifyDataResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_uint64_field(total_size, 1, this->address, false);
-  ProtoSize::add_uint32_field(total_size, 1, this->handle, false);
-  ProtoSize::add_string_field(total_size, 1, this->data, false);
+  ProtoSize::add_uint64_field(total_size, 1, this->address);
+  ProtoSize::add_uint32_field(total_size, 1, this->handle);
+  ProtoSize::add_string_field(total_size, 1, this->data);
 }
 bool BluetoothConnectionsFreeResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
@@ -4661,11 +4661,11 @@ void BluetoothConnectionsFreeResponse::encode(ProtoWriteBuffer buffer) const {
   }
 }
 void BluetoothConnectionsFreeResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_uint32_field(total_size, 1, this->free, false);
-  ProtoSize::add_uint32_field(total_size, 1, this->limit, false);
+  ProtoSize::add_uint32_field(total_size, 1, this->free);
+  ProtoSize::add_uint32_field(total_size, 1, this->limit);
   if (!this->allocated.empty()) {
     for (const auto &it : this->allocated) {
-      ProtoSize::add_uint64_field(total_size, 1, it, true);
+      ProtoSize::add_uint64_field_repeated(total_size, 1, it);
     }
   }
 }
@@ -4693,9 +4693,9 @@ void BluetoothGATTErrorResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_int32(3, this->error);
 }
 void BluetoothGATTErrorResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_uint64_field(total_size, 1, this->address, false);
-  ProtoSize::add_uint32_field(total_size, 1, this->handle, false);
-  ProtoSize::add_int32_field(total_size, 1, this->error, false);
+  ProtoSize::add_uint64_field(total_size, 1, this->address);
+  ProtoSize::add_uint32_field(total_size, 1, this->handle);
+  ProtoSize::add_int32_field(total_size, 1, this->error);
 }
 bool BluetoothGATTWriteResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
@@ -4716,8 +4716,8 @@ void BluetoothGATTWriteResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint32(2, this->handle);
 }
 void BluetoothGATTWriteResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_uint64_field(total_size, 1, this->address, false);
-  ProtoSize::add_uint32_field(total_size, 1, this->handle, false);
+  ProtoSize::add_uint64_field(total_size, 1, this->address);
+  ProtoSize::add_uint32_field(total_size, 1, this->handle);
 }
 bool BluetoothGATTNotifyResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
@@ -4738,8 +4738,8 @@ void BluetoothGATTNotifyResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint32(2, this->handle);
 }
 void BluetoothGATTNotifyResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_uint64_field(total_size, 1, this->address, false);
-  ProtoSize::add_uint32_field(total_size, 1, this->handle, false);
+  ProtoSize::add_uint64_field(total_size, 1, this->address);
+  ProtoSize::add_uint32_field(total_size, 1, this->handle);
 }
 bool BluetoothDevicePairingResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
@@ -4765,9 +4765,9 @@ void BluetoothDevicePairingResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_int32(3, this->error);
 }
 void BluetoothDevicePairingResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_uint64_field(total_size, 1, this->address, false);
-  ProtoSize::add_bool_field(total_size, 1, this->paired, false);
-  ProtoSize::add_int32_field(total_size, 1, this->error, false);
+  ProtoSize::add_uint64_field(total_size, 1, this->address);
+  ProtoSize::add_bool_field(total_size, 1, this->paired);
+  ProtoSize::add_int32_field(total_size, 1, this->error);
 }
 bool BluetoothDeviceUnpairingResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
@@ -4793,9 +4793,9 @@ void BluetoothDeviceUnpairingResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_int32(3, this->error);
 }
 void BluetoothDeviceUnpairingResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_uint64_field(total_size, 1, this->address, false);
-  ProtoSize::add_bool_field(total_size, 1, this->success, false);
-  ProtoSize::add_int32_field(total_size, 1, this->error, false);
+  ProtoSize::add_uint64_field(total_size, 1, this->address);
+  ProtoSize::add_bool_field(total_size, 1, this->success);
+  ProtoSize::add_int32_field(total_size, 1, this->error);
 }
 bool BluetoothDeviceClearCacheResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
@@ -4821,9 +4821,9 @@ void BluetoothDeviceClearCacheResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_int32(3, this->error);
 }
 void BluetoothDeviceClearCacheResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_uint64_field(total_size, 1, this->address, false);
-  ProtoSize::add_bool_field(total_size, 1, this->success, false);
-  ProtoSize::add_int32_field(total_size, 1, this->error, false);
+  ProtoSize::add_uint64_field(total_size, 1, this->address);
+  ProtoSize::add_bool_field(total_size, 1, this->success);
+  ProtoSize::add_int32_field(total_size, 1, this->error);
 }
 bool BluetoothScannerStateResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
@@ -4844,8 +4844,8 @@ void BluetoothScannerStateResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_enum<enums::BluetoothScannerMode>(2, this->mode);
 }
 void BluetoothScannerStateResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->state), false);
-  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->mode), false);
+  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->state));
+  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->mode));
 }
 bool BluetoothScannerSetModeRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
@@ -4861,7 +4861,7 @@ void BluetoothScannerSetModeRequest::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_enum<enums::BluetoothScannerMode>(1, this->mode);
 }
 void BluetoothScannerSetModeRequest::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->mode), false);
+  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->mode));
 }
 #endif
 #ifdef USE_VOICE_ASSISTANT
@@ -4884,8 +4884,8 @@ void SubscribeVoiceAssistantRequest::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint32(2, this->flags);
 }
 void SubscribeVoiceAssistantRequest::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_bool_field(total_size, 1, this->subscribe, false);
-  ProtoSize::add_uint32_field(total_size, 1, this->flags, false);
+  ProtoSize::add_bool_field(total_size, 1, this->subscribe);
+  ProtoSize::add_uint32_field(total_size, 1, this->flags);
 }
 bool VoiceAssistantAudioSettings::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
@@ -4917,9 +4917,9 @@ void VoiceAssistantAudioSettings::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_float(3, this->volume_multiplier);
 }
 void VoiceAssistantAudioSettings::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_uint32_field(total_size, 1, this->noise_suppression_level, false);
-  ProtoSize::add_uint32_field(total_size, 1, this->auto_gain, false);
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->volume_multiplier != 0.0f, false);
+  ProtoSize::add_uint32_field(total_size, 1, this->noise_suppression_level);
+  ProtoSize::add_uint32_field(total_size, 1, this->auto_gain);
+  ProtoSize::add_fixed_field<4>(total_size, 1, this->volume_multiplier != 0.0f);
 }
 bool VoiceAssistantRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
@@ -4961,11 +4961,11 @@ void VoiceAssistantRequest::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_string(5, this->wake_word_phrase);
 }
 void VoiceAssistantRequest::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_bool_field(total_size, 1, this->start, false);
-  ProtoSize::add_string_field(total_size, 1, this->conversation_id, false);
-  ProtoSize::add_uint32_field(total_size, 1, this->flags, false);
-  ProtoSize::add_message_object(total_size, 1, this->audio_settings, false);
-  ProtoSize::add_string_field(total_size, 1, this->wake_word_phrase, false);
+  ProtoSize::add_bool_field(total_size, 1, this->start);
+  ProtoSize::add_string_field(total_size, 1, this->conversation_id);
+  ProtoSize::add_uint32_field(total_size, 1, this->flags);
+  ProtoSize::add_message_object(total_size, 1, this->audio_settings);
+  ProtoSize::add_string_field(total_size, 1, this->wake_word_phrase);
 }
 bool VoiceAssistantResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
@@ -4986,8 +4986,8 @@ void VoiceAssistantResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_bool(2, this->error);
 }
 void VoiceAssistantResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_uint32_field(total_size, 1, this->port, false);
-  ProtoSize::add_bool_field(total_size, 1, this->error, false);
+  ProtoSize::add_uint32_field(total_size, 1, this->port);
+  ProtoSize::add_bool_field(total_size, 1, this->error);
 }
 bool VoiceAssistantEventData::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
@@ -5008,8 +5008,8 @@ void VoiceAssistantEventData::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_string(2, this->value);
 }
 void VoiceAssistantEventData::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_string_field(total_size, 1, this->name, false);
-  ProtoSize::add_string_field(total_size, 1, this->value, false);
+  ProtoSize::add_string_field(total_size, 1, this->name);
+  ProtoSize::add_string_field(total_size, 1, this->value);
 }
 bool VoiceAssistantEventResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
@@ -5038,7 +5038,7 @@ void VoiceAssistantEventResponse::encode(ProtoWriteBuffer buffer) const {
   }
 }
 void VoiceAssistantEventResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->event_type), false);
+  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->event_type));
   ProtoSize::add_repeated_message(total_size, 1, this->data);
 }
 bool VoiceAssistantAudio::decode_varint(uint32_t field_id, ProtoVarInt value) {
@@ -5066,8 +5066,8 @@ void VoiceAssistantAudio::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_bool(2, this->end);
 }
 void VoiceAssistantAudio::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_string_field(total_size, 1, this->data, false);
-  ProtoSize::add_bool_field(total_size, 1, this->end, false);
+  ProtoSize::add_string_field(total_size, 1, this->data);
+  ProtoSize::add_bool_field(total_size, 1, this->end);
 }
 bool VoiceAssistantTimerEventResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
@@ -5114,12 +5114,12 @@ void VoiceAssistantTimerEventResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_bool(6, this->is_active);
 }
 void VoiceAssistantTimerEventResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->event_type), false);
-  ProtoSize::add_string_field(total_size, 1, this->timer_id, false);
-  ProtoSize::add_string_field(total_size, 1, this->name, false);
-  ProtoSize::add_uint32_field(total_size, 1, this->total_seconds, false);
-  ProtoSize::add_uint32_field(total_size, 1, this->seconds_left, false);
-  ProtoSize::add_bool_field(total_size, 1, this->is_active, false);
+  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->event_type));
+  ProtoSize::add_string_field(total_size, 1, this->timer_id);
+  ProtoSize::add_string_field(total_size, 1, this->name);
+  ProtoSize::add_uint32_field(total_size, 1, this->total_seconds);
+  ProtoSize::add_uint32_field(total_size, 1, this->seconds_left);
+  ProtoSize::add_bool_field(total_size, 1, this->is_active);
 }
 bool VoiceAssistantAnnounceRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
@@ -5156,10 +5156,10 @@ void VoiceAssistantAnnounceRequest::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_bool(4, this->start_conversation);
 }
 void VoiceAssistantAnnounceRequest::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_string_field(total_size, 1, this->media_id, false);
-  ProtoSize::add_string_field(total_size, 1, this->text, false);
-  ProtoSize::add_string_field(total_size, 1, this->preannounce_media_id, false);
-  ProtoSize::add_bool_field(total_size, 1, this->start_conversation, false);
+  ProtoSize::add_string_field(total_size, 1, this->media_id);
+  ProtoSize::add_string_field(total_size, 1, this->text);
+  ProtoSize::add_string_field(total_size, 1, this->preannounce_media_id);
+  ProtoSize::add_bool_field(total_size, 1, this->start_conversation);
 }
 bool VoiceAssistantAnnounceFinished::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
@@ -5173,7 +5173,7 @@ bool VoiceAssistantAnnounceFinished::decode_varint(uint32_t field_id, ProtoVarIn
 }
 void VoiceAssistantAnnounceFinished::encode(ProtoWriteBuffer buffer) const { buffer.encode_bool(1, this->success); }
 void VoiceAssistantAnnounceFinished::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_bool_field(total_size, 1, this->success, false);
+  ProtoSize::add_bool_field(total_size, 1, this->success);
 }
 bool VoiceAssistantWakeWord::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
@@ -5201,11 +5201,11 @@ void VoiceAssistantWakeWord::encode(ProtoWriteBuffer buffer) const {
   }
 }
 void VoiceAssistantWakeWord::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_string_field(total_size, 1, this->id, false);
-  ProtoSize::add_string_field(total_size, 1, this->wake_word, false);
+  ProtoSize::add_string_field(total_size, 1, this->id);
+  ProtoSize::add_string_field(total_size, 1, this->wake_word);
   if (!this->trained_languages.empty()) {
     for (const auto &it : this->trained_languages) {
-      ProtoSize::add_string_field(total_size, 1, it, true);
+      ProtoSize::add_string_field_repeated(total_size, 1, it);
     }
   }
 }
@@ -5246,10 +5246,10 @@ void VoiceAssistantConfigurationResponse::calculate_size(uint32_t &total_size) c
   ProtoSize::add_repeated_message(total_size, 1, this->available_wake_words);
   if (!this->active_wake_words.empty()) {
     for (const auto &it : this->active_wake_words) {
-      ProtoSize::add_string_field(total_size, 1, it, true);
+      ProtoSize::add_string_field_repeated(total_size, 1, it);
     }
   }
-  ProtoSize::add_uint32_field(total_size, 1, this->max_active_wake_words, false);
+  ProtoSize::add_uint32_field(total_size, 1, this->max_active_wake_words);
 }
 bool VoiceAssistantSetConfiguration::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
@@ -5269,7 +5269,7 @@ void VoiceAssistantSetConfiguration::encode(ProtoWriteBuffer buffer) const {
 void VoiceAssistantSetConfiguration::calculate_size(uint32_t &total_size) const {
   if (!this->active_wake_words.empty()) {
     for (const auto &it : this->active_wake_words) {
-      ProtoSize::add_string_field(total_size, 1, it, true);
+      ProtoSize::add_string_field_repeated(total_size, 1, it);
     }
   }
 }
@@ -5351,17 +5351,17 @@ void ListEntitiesAlarmControlPanelResponse::encode(ProtoWriteBuffer buffer) cons
   buffer.encode_uint32(11, this->device_id);
 }
 void ListEntitiesAlarmControlPanelResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_string_field(total_size, 1, this->object_id, false);
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0, false);
-  ProtoSize::add_string_field(total_size, 1, this->name, false);
-  ProtoSize::add_string_field(total_size, 1, this->unique_id, false);
-  ProtoSize::add_string_field(total_size, 1, this->icon, false);
-  ProtoSize::add_bool_field(total_size, 1, this->disabled_by_default, false);
-  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->entity_category), false);
-  ProtoSize::add_uint32_field(total_size, 1, this->supported_features, false);
-  ProtoSize::add_bool_field(total_size, 1, this->requires_code, false);
-  ProtoSize::add_bool_field(total_size, 1, this->requires_code_to_arm, false);
-  ProtoSize::add_uint32_field(total_size, 1, this->device_id, false);
+  ProtoSize::add_string_field(total_size, 1, this->object_id);
+  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0);
+  ProtoSize::add_string_field(total_size, 1, this->name);
+  ProtoSize::add_string_field(total_size, 1, this->unique_id);
+  ProtoSize::add_string_field(total_size, 1, this->icon);
+  ProtoSize::add_bool_field(total_size, 1, this->disabled_by_default);
+  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->entity_category));
+  ProtoSize::add_uint32_field(total_size, 1, this->supported_features);
+  ProtoSize::add_bool_field(total_size, 1, this->requires_code);
+  ProtoSize::add_bool_field(total_size, 1, this->requires_code_to_arm);
+  ProtoSize::add_uint32_field(total_size, 1, this->device_id);
 }
 bool AlarmControlPanelStateResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
@@ -5393,9 +5393,9 @@ void AlarmControlPanelStateResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint32(3, this->device_id);
 }
 void AlarmControlPanelStateResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0, false);
-  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->state), false);
-  ProtoSize::add_uint32_field(total_size, 1, this->device_id, false);
+  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0);
+  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->state));
+  ProtoSize::add_uint32_field(total_size, 1, this->device_id);
 }
 bool AlarmControlPanelCommandRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
@@ -5438,10 +5438,10 @@ void AlarmControlPanelCommandRequest::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint32(4, this->device_id);
 }
 void AlarmControlPanelCommandRequest::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0, false);
-  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->command), false);
-  ProtoSize::add_string_field(total_size, 1, this->code, false);
-  ProtoSize::add_uint32_field(total_size, 1, this->device_id, false);
+  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0);
+  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->command));
+  ProtoSize::add_string_field(total_size, 1, this->code);
+  ProtoSize::add_uint32_field(total_size, 1, this->device_id);
 }
 #endif
 #ifdef USE_TEXT
@@ -5526,18 +5526,18 @@ void ListEntitiesTextResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint32(12, this->device_id);
 }
 void ListEntitiesTextResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_string_field(total_size, 1, this->object_id, false);
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0, false);
-  ProtoSize::add_string_field(total_size, 1, this->name, false);
-  ProtoSize::add_string_field(total_size, 1, this->unique_id, false);
-  ProtoSize::add_string_field(total_size, 1, this->icon, false);
-  ProtoSize::add_bool_field(total_size, 1, this->disabled_by_default, false);
-  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->entity_category), false);
-  ProtoSize::add_uint32_field(total_size, 1, this->min_length, false);
-  ProtoSize::add_uint32_field(total_size, 1, this->max_length, false);
-  ProtoSize::add_string_field(total_size, 1, this->pattern, false);
-  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->mode), false);
-  ProtoSize::add_uint32_field(total_size, 1, this->device_id, false);
+  ProtoSize::add_string_field(total_size, 1, this->object_id);
+  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0);
+  ProtoSize::add_string_field(total_size, 1, this->name);
+  ProtoSize::add_string_field(total_size, 1, this->unique_id);
+  ProtoSize::add_string_field(total_size, 1, this->icon);
+  ProtoSize::add_bool_field(total_size, 1, this->disabled_by_default);
+  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->entity_category));
+  ProtoSize::add_uint32_field(total_size, 1, this->min_length);
+  ProtoSize::add_uint32_field(total_size, 1, this->max_length);
+  ProtoSize::add_string_field(total_size, 1, this->pattern);
+  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->mode));
+  ProtoSize::add_uint32_field(total_size, 1, this->device_id);
 }
 bool TextStateResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
@@ -5580,10 +5580,10 @@ void TextStateResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint32(4, this->device_id);
 }
 void TextStateResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0, false);
-  ProtoSize::add_string_field(total_size, 1, this->state, false);
-  ProtoSize::add_bool_field(total_size, 1, this->missing_state, false);
-  ProtoSize::add_uint32_field(total_size, 1, this->device_id, false);
+  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0);
+  ProtoSize::add_string_field(total_size, 1, this->state);
+  ProtoSize::add_bool_field(total_size, 1, this->missing_state);
+  ProtoSize::add_uint32_field(total_size, 1, this->device_id);
 }
 bool TextCommandRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
@@ -5621,9 +5621,9 @@ void TextCommandRequest::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint32(3, this->device_id);
 }
 void TextCommandRequest::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0, false);
-  ProtoSize::add_string_field(total_size, 1, this->state, false);
-  ProtoSize::add_uint32_field(total_size, 1, this->device_id, false);
+  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0);
+  ProtoSize::add_string_field(total_size, 1, this->state);
+  ProtoSize::add_uint32_field(total_size, 1, this->device_id);
 }
 #endif
 #ifdef USE_DATETIME_DATE
@@ -5688,14 +5688,14 @@ void ListEntitiesDateResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint32(8, this->device_id);
 }
 void ListEntitiesDateResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_string_field(total_size, 1, this->object_id, false);
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0, false);
-  ProtoSize::add_string_field(total_size, 1, this->name, false);
-  ProtoSize::add_string_field(total_size, 1, this->unique_id, false);
-  ProtoSize::add_string_field(total_size, 1, this->icon, false);
-  ProtoSize::add_bool_field(total_size, 1, this->disabled_by_default, false);
-  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->entity_category), false);
-  ProtoSize::add_uint32_field(total_size, 1, this->device_id, false);
+  ProtoSize::add_string_field(total_size, 1, this->object_id);
+  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0);
+  ProtoSize::add_string_field(total_size, 1, this->name);
+  ProtoSize::add_string_field(total_size, 1, this->unique_id);
+  ProtoSize::add_string_field(total_size, 1, this->icon);
+  ProtoSize::add_bool_field(total_size, 1, this->disabled_by_default);
+  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->entity_category));
+  ProtoSize::add_uint32_field(total_size, 1, this->device_id);
 }
 bool DateStateResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
@@ -5742,12 +5742,12 @@ void DateStateResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint32(6, this->device_id);
 }
 void DateStateResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0, false);
-  ProtoSize::add_bool_field(total_size, 1, this->missing_state, false);
-  ProtoSize::add_uint32_field(total_size, 1, this->year, false);
-  ProtoSize::add_uint32_field(total_size, 1, this->month, false);
-  ProtoSize::add_uint32_field(total_size, 1, this->day, false);
-  ProtoSize::add_uint32_field(total_size, 1, this->device_id, false);
+  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0);
+  ProtoSize::add_bool_field(total_size, 1, this->missing_state);
+  ProtoSize::add_uint32_field(total_size, 1, this->year);
+  ProtoSize::add_uint32_field(total_size, 1, this->month);
+  ProtoSize::add_uint32_field(total_size, 1, this->day);
+  ProtoSize::add_uint32_field(total_size, 1, this->device_id);
 }
 bool DateCommandRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
@@ -5789,11 +5789,11 @@ void DateCommandRequest::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint32(5, this->device_id);
 }
 void DateCommandRequest::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0, false);
-  ProtoSize::add_uint32_field(total_size, 1, this->year, false);
-  ProtoSize::add_uint32_field(total_size, 1, this->month, false);
-  ProtoSize::add_uint32_field(total_size, 1, this->day, false);
-  ProtoSize::add_uint32_field(total_size, 1, this->device_id, false);
+  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0);
+  ProtoSize::add_uint32_field(total_size, 1, this->year);
+  ProtoSize::add_uint32_field(total_size, 1, this->month);
+  ProtoSize::add_uint32_field(total_size, 1, this->day);
+  ProtoSize::add_uint32_field(total_size, 1, this->device_id);
 }
 #endif
 #ifdef USE_DATETIME_TIME
@@ -5858,14 +5858,14 @@ void ListEntitiesTimeResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint32(8, this->device_id);
 }
 void ListEntitiesTimeResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_string_field(total_size, 1, this->object_id, false);
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0, false);
-  ProtoSize::add_string_field(total_size, 1, this->name, false);
-  ProtoSize::add_string_field(total_size, 1, this->unique_id, false);
-  ProtoSize::add_string_field(total_size, 1, this->icon, false);
-  ProtoSize::add_bool_field(total_size, 1, this->disabled_by_default, false);
-  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->entity_category), false);
-  ProtoSize::add_uint32_field(total_size, 1, this->device_id, false);
+  ProtoSize::add_string_field(total_size, 1, this->object_id);
+  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0);
+  ProtoSize::add_string_field(total_size, 1, this->name);
+  ProtoSize::add_string_field(total_size, 1, this->unique_id);
+  ProtoSize::add_string_field(total_size, 1, this->icon);
+  ProtoSize::add_bool_field(total_size, 1, this->disabled_by_default);
+  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->entity_category));
+  ProtoSize::add_uint32_field(total_size, 1, this->device_id);
 }
 bool TimeStateResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
@@ -5912,12 +5912,12 @@ void TimeStateResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint32(6, this->device_id);
 }
 void TimeStateResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0, false);
-  ProtoSize::add_bool_field(total_size, 1, this->missing_state, false);
-  ProtoSize::add_uint32_field(total_size, 1, this->hour, false);
-  ProtoSize::add_uint32_field(total_size, 1, this->minute, false);
-  ProtoSize::add_uint32_field(total_size, 1, this->second, false);
-  ProtoSize::add_uint32_field(total_size, 1, this->device_id, false);
+  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0);
+  ProtoSize::add_bool_field(total_size, 1, this->missing_state);
+  ProtoSize::add_uint32_field(total_size, 1, this->hour);
+  ProtoSize::add_uint32_field(total_size, 1, this->minute);
+  ProtoSize::add_uint32_field(total_size, 1, this->second);
+  ProtoSize::add_uint32_field(total_size, 1, this->device_id);
 }
 bool TimeCommandRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
@@ -5959,11 +5959,11 @@ void TimeCommandRequest::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint32(5, this->device_id);
 }
 void TimeCommandRequest::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0, false);
-  ProtoSize::add_uint32_field(total_size, 1, this->hour, false);
-  ProtoSize::add_uint32_field(total_size, 1, this->minute, false);
-  ProtoSize::add_uint32_field(total_size, 1, this->second, false);
-  ProtoSize::add_uint32_field(total_size, 1, this->device_id, false);
+  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0);
+  ProtoSize::add_uint32_field(total_size, 1, this->hour);
+  ProtoSize::add_uint32_field(total_size, 1, this->minute);
+  ProtoSize::add_uint32_field(total_size, 1, this->second);
+  ProtoSize::add_uint32_field(total_size, 1, this->device_id);
 }
 #endif
 #ifdef USE_EVENT
@@ -6040,20 +6040,20 @@ void ListEntitiesEventResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint32(10, this->device_id);
 }
 void ListEntitiesEventResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_string_field(total_size, 1, this->object_id, false);
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0, false);
-  ProtoSize::add_string_field(total_size, 1, this->name, false);
-  ProtoSize::add_string_field(total_size, 1, this->unique_id, false);
-  ProtoSize::add_string_field(total_size, 1, this->icon, false);
-  ProtoSize::add_bool_field(total_size, 1, this->disabled_by_default, false);
-  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->entity_category), false);
-  ProtoSize::add_string_field(total_size, 1, this->device_class, false);
+  ProtoSize::add_string_field(total_size, 1, this->object_id);
+  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0);
+  ProtoSize::add_string_field(total_size, 1, this->name);
+  ProtoSize::add_string_field(total_size, 1, this->unique_id);
+  ProtoSize::add_string_field(total_size, 1, this->icon);
+  ProtoSize::add_bool_field(total_size, 1, this->disabled_by_default);
+  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->entity_category));
+  ProtoSize::add_string_field(total_size, 1, this->device_class);
   if (!this->event_types.empty()) {
     for (const auto &it : this->event_types) {
-      ProtoSize::add_string_field(total_size, 1, it, true);
+      ProtoSize::add_string_field_repeated(total_size, 1, it);
     }
   }
-  ProtoSize::add_uint32_field(total_size, 1, this->device_id, false);
+  ProtoSize::add_uint32_field(total_size, 1, this->device_id);
 }
 bool EventResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
@@ -6091,9 +6091,9 @@ void EventResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint32(3, this->device_id);
 }
 void EventResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0, false);
-  ProtoSize::add_string_field(total_size, 1, this->event_type, false);
-  ProtoSize::add_uint32_field(total_size, 1, this->device_id, false);
+  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0);
+  ProtoSize::add_string_field(total_size, 1, this->event_type);
+  ProtoSize::add_uint32_field(total_size, 1, this->device_id);
 }
 #endif
 #ifdef USE_VALVE
@@ -6178,18 +6178,18 @@ void ListEntitiesValveResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint32(12, this->device_id);
 }
 void ListEntitiesValveResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_string_field(total_size, 1, this->object_id, false);
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0, false);
-  ProtoSize::add_string_field(total_size, 1, this->name, false);
-  ProtoSize::add_string_field(total_size, 1, this->unique_id, false);
-  ProtoSize::add_string_field(total_size, 1, this->icon, false);
-  ProtoSize::add_bool_field(total_size, 1, this->disabled_by_default, false);
-  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->entity_category), false);
-  ProtoSize::add_string_field(total_size, 1, this->device_class, false);
-  ProtoSize::add_bool_field(total_size, 1, this->assumed_state, false);
-  ProtoSize::add_bool_field(total_size, 1, this->supports_position, false);
-  ProtoSize::add_bool_field(total_size, 1, this->supports_stop, false);
-  ProtoSize::add_uint32_field(total_size, 1, this->device_id, false);
+  ProtoSize::add_string_field(total_size, 1, this->object_id);
+  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0);
+  ProtoSize::add_string_field(total_size, 1, this->name);
+  ProtoSize::add_string_field(total_size, 1, this->unique_id);
+  ProtoSize::add_string_field(total_size, 1, this->icon);
+  ProtoSize::add_bool_field(total_size, 1, this->disabled_by_default);
+  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->entity_category));
+  ProtoSize::add_string_field(total_size, 1, this->device_class);
+  ProtoSize::add_bool_field(total_size, 1, this->assumed_state);
+  ProtoSize::add_bool_field(total_size, 1, this->supports_position);
+  ProtoSize::add_bool_field(total_size, 1, this->supports_stop);
+  ProtoSize::add_uint32_field(total_size, 1, this->device_id);
 }
 bool ValveStateResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
@@ -6226,10 +6226,10 @@ void ValveStateResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint32(4, this->device_id);
 }
 void ValveStateResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0, false);
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->position != 0.0f, false);
-  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->current_operation), false);
-  ProtoSize::add_uint32_field(total_size, 1, this->device_id, false);
+  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0);
+  ProtoSize::add_fixed_field<4>(total_size, 1, this->position != 0.0f);
+  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->current_operation));
+  ProtoSize::add_uint32_field(total_size, 1, this->device_id);
 }
 bool ValveCommandRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
@@ -6271,11 +6271,11 @@ void ValveCommandRequest::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint32(5, this->device_id);
 }
 void ValveCommandRequest::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0, false);
-  ProtoSize::add_bool_field(total_size, 1, this->has_position, false);
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->position != 0.0f, false);
-  ProtoSize::add_bool_field(total_size, 1, this->stop, false);
-  ProtoSize::add_uint32_field(total_size, 1, this->device_id, false);
+  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0);
+  ProtoSize::add_bool_field(total_size, 1, this->has_position);
+  ProtoSize::add_fixed_field<4>(total_size, 1, this->position != 0.0f);
+  ProtoSize::add_bool_field(total_size, 1, this->stop);
+  ProtoSize::add_uint32_field(total_size, 1, this->device_id);
 }
 #endif
 #ifdef USE_DATETIME_DATETIME
@@ -6340,14 +6340,14 @@ void ListEntitiesDateTimeResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint32(8, this->device_id);
 }
 void ListEntitiesDateTimeResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_string_field(total_size, 1, this->object_id, false);
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0, false);
-  ProtoSize::add_string_field(total_size, 1, this->name, false);
-  ProtoSize::add_string_field(total_size, 1, this->unique_id, false);
-  ProtoSize::add_string_field(total_size, 1, this->icon, false);
-  ProtoSize::add_bool_field(total_size, 1, this->disabled_by_default, false);
-  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->entity_category), false);
-  ProtoSize::add_uint32_field(total_size, 1, this->device_id, false);
+  ProtoSize::add_string_field(total_size, 1, this->object_id);
+  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0);
+  ProtoSize::add_string_field(total_size, 1, this->name);
+  ProtoSize::add_string_field(total_size, 1, this->unique_id);
+  ProtoSize::add_string_field(total_size, 1, this->icon);
+  ProtoSize::add_bool_field(total_size, 1, this->disabled_by_default);
+  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->entity_category));
+  ProtoSize::add_uint32_field(total_size, 1, this->device_id);
 }
 bool DateTimeStateResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
@@ -6384,10 +6384,10 @@ void DateTimeStateResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint32(4, this->device_id);
 }
 void DateTimeStateResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0, false);
-  ProtoSize::add_bool_field(total_size, 1, this->missing_state, false);
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->epoch_seconds != 0, false);
-  ProtoSize::add_uint32_field(total_size, 1, this->device_id, false);
+  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0);
+  ProtoSize::add_bool_field(total_size, 1, this->missing_state);
+  ProtoSize::add_fixed_field<4>(total_size, 1, this->epoch_seconds != 0);
+  ProtoSize::add_uint32_field(total_size, 1, this->device_id);
 }
 bool DateTimeCommandRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
@@ -6419,9 +6419,9 @@ void DateTimeCommandRequest::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint32(3, this->device_id);
 }
 void DateTimeCommandRequest::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0, false);
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->epoch_seconds != 0, false);
-  ProtoSize::add_uint32_field(total_size, 1, this->device_id, false);
+  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0);
+  ProtoSize::add_fixed_field<4>(total_size, 1, this->epoch_seconds != 0);
+  ProtoSize::add_uint32_field(total_size, 1, this->device_id);
 }
 #endif
 #ifdef USE_UPDATE
@@ -6491,15 +6491,15 @@ void ListEntitiesUpdateResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint32(9, this->device_id);
 }
 void ListEntitiesUpdateResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_string_field(total_size, 1, this->object_id, false);
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0, false);
-  ProtoSize::add_string_field(total_size, 1, this->name, false);
-  ProtoSize::add_string_field(total_size, 1, this->unique_id, false);
-  ProtoSize::add_string_field(total_size, 1, this->icon, false);
-  ProtoSize::add_bool_field(total_size, 1, this->disabled_by_default, false);
-  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->entity_category), false);
-  ProtoSize::add_string_field(total_size, 1, this->device_class, false);
-  ProtoSize::add_uint32_field(total_size, 1, this->device_id, false);
+  ProtoSize::add_string_field(total_size, 1, this->object_id);
+  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0);
+  ProtoSize::add_string_field(total_size, 1, this->name);
+  ProtoSize::add_string_field(total_size, 1, this->unique_id);
+  ProtoSize::add_string_field(total_size, 1, this->icon);
+  ProtoSize::add_bool_field(total_size, 1, this->disabled_by_default);
+  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->entity_category));
+  ProtoSize::add_string_field(total_size, 1, this->device_class);
+  ProtoSize::add_uint32_field(total_size, 1, this->device_id);
 }
 bool UpdateStateResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
@@ -6577,17 +6577,17 @@ void UpdateStateResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint32(11, this->device_id);
 }
 void UpdateStateResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0, false);
-  ProtoSize::add_bool_field(total_size, 1, this->missing_state, false);
-  ProtoSize::add_bool_field(total_size, 1, this->in_progress, false);
-  ProtoSize::add_bool_field(total_size, 1, this->has_progress, false);
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->progress != 0.0f, false);
-  ProtoSize::add_string_field(total_size, 1, this->current_version, false);
-  ProtoSize::add_string_field(total_size, 1, this->latest_version, false);
-  ProtoSize::add_string_field(total_size, 1, this->title, false);
-  ProtoSize::add_string_field(total_size, 1, this->release_summary, false);
-  ProtoSize::add_string_field(total_size, 1, this->release_url, false);
-  ProtoSize::add_uint32_field(total_size, 1, this->device_id, false);
+  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0);
+  ProtoSize::add_bool_field(total_size, 1, this->missing_state);
+  ProtoSize::add_bool_field(total_size, 1, this->in_progress);
+  ProtoSize::add_bool_field(total_size, 1, this->has_progress);
+  ProtoSize::add_fixed_field<4>(total_size, 1, this->progress != 0.0f);
+  ProtoSize::add_string_field(total_size, 1, this->current_version);
+  ProtoSize::add_string_field(total_size, 1, this->latest_version);
+  ProtoSize::add_string_field(total_size, 1, this->title);
+  ProtoSize::add_string_field(total_size, 1, this->release_summary);
+  ProtoSize::add_string_field(total_size, 1, this->release_url);
+  ProtoSize::add_uint32_field(total_size, 1, this->device_id);
 }
 bool UpdateCommandRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
@@ -6619,9 +6619,9 @@ void UpdateCommandRequest::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint32(3, this->device_id);
 }
 void UpdateCommandRequest::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0, false);
-  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->command), false);
-  ProtoSize::add_uint32_field(total_size, 1, this->device_id, false);
+  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0);
+  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->command));
+  ProtoSize::add_uint32_field(total_size, 1, this->device_id);
 }
 #endif
 

--- a/esphome/components/api/api_pb2_size.h
+++ b/esphome/components/api/api_pb2_size.h
@@ -379,7 +379,8 @@ class ProtoSize {
     }
 
     // Calculate and directly add to total_size
-    total_size += field_id_size + varint(static_cast<uint32_t>(str.size())) + str.size();
+    const uint32_t str_size = static_cast<uint32_t>(str.size());
+    total_size += field_id_size + varint(str_size) + str_size;
   }
 
   /**
@@ -387,8 +388,8 @@ class ProtoSize {
    */
   static inline void add_string_field_repeated(uint32_t &total_size, uint32_t field_id_size, const std::string &str) {
     // Always calculate size for repeated fields
-    // No local variable needed for simple case
-    total_size += field_id_size + varint(static_cast<uint32_t>(str.size())) + str.size();
+    const uint32_t str_size = static_cast<uint32_t>(str.size());
+    total_size += field_id_size + varint(str_size) + str_size;
   }
 
   /**

--- a/esphome/components/api/api_pb2_size.h
+++ b/esphome/components/api/api_pb2_size.h
@@ -234,18 +234,6 @@ class ProtoSize {
   }
 
   /**
-   * @brief Calculates and adds the size of a fixed field to the total message size (repeated field version)
-   *
-   * @tparam NumBytes The number of bytes for this fixed field (4 or 8)
-   */
-  template<uint32_t NumBytes>
-  static inline void add_fixed_field_repeated(uint32_t &total_size, uint32_t field_id_size) {
-    // Always calculate size for repeated fields
-    // Fixed fields always take exactly NumBytes
-    total_size += field_id_size + NumBytes;
-  }
-
-  /**
    * @brief Calculates and adds the size of an enum field to the total message size
    *
    * Enum fields are encoded as uint32 varints.

--- a/esphome/components/api/api_pb2_size.h
+++ b/esphome/components/api/api_pb2_size.h
@@ -141,9 +141,9 @@ class ProtoSize {
   /**
    * @brief Calculates and adds the size of an int32 field to the total message size
    */
-  static inline void add_int32_field(uint32_t &total_size, uint32_t field_id_size, int32_t value, bool force = false) {
-    // Skip calculation if value is zero and not forced
-    if (value == 0 && !force) {
+  static inline void add_int32_field(uint32_t &total_size, uint32_t field_id_size, int32_t value) {
+    // Skip calculation if value is zero
+    if (value == 0) {
       return;  // No need to update total_size
     }
 
@@ -158,12 +158,25 @@ class ProtoSize {
   }
 
   /**
+   * @brief Calculates and adds the size of an int32 field to the total message size (repeated field version)
+   */
+  static inline void add_int32_field_repeated(uint32_t &total_size, uint32_t field_id_size, int32_t value) {
+    // Always calculate size for repeated fields
+    if (value < 0) {
+      // Negative values are encoded as 10-byte varints in protobuf
+      total_size += field_id_size + 10;
+    } else {
+      // For non-negative values, use the standard varint size
+      total_size += field_id_size + varint(static_cast<uint32_t>(value));
+    }
+  }
+
+  /**
    * @brief Calculates and adds the size of a uint32 field to the total message size
    */
-  static inline void add_uint32_field(uint32_t &total_size, uint32_t field_id_size, uint32_t value,
-                                      bool force = false) {
-    // Skip calculation if value is zero and not forced
-    if (value == 0 && !force) {
+  static inline void add_uint32_field(uint32_t &total_size, uint32_t field_id_size, uint32_t value) {
+    // Skip calculation if value is zero
+    if (value == 0) {
       return;  // No need to update total_size
     }
 
@@ -172,15 +185,32 @@ class ProtoSize {
   }
 
   /**
+   * @brief Calculates and adds the size of a uint32 field to the total message size (repeated field version)
+   */
+  static inline void add_uint32_field_repeated(uint32_t &total_size, uint32_t field_id_size, uint32_t value) {
+    // Always calculate size for repeated fields
+    total_size += field_id_size + varint(value);
+  }
+
+  /**
    * @brief Calculates and adds the size of a boolean field to the total message size
    */
-  static inline void add_bool_field(uint32_t &total_size, uint32_t field_id_size, bool value, bool force = false) {
-    // Skip calculation if value is false and not forced
-    if (!value && !force) {
+  static inline void add_bool_field(uint32_t &total_size, uint32_t field_id_size, bool value) {
+    // Skip calculation if value is false
+    if (!value) {
       return;  // No need to update total_size
     }
 
     // Boolean fields always use 1 byte when true
+    total_size += field_id_size + 1;
+  }
+
+  /**
+   * @brief Calculates and adds the size of a boolean field to the total message size (repeated field version)
+   */
+  static inline void add_bool_field_repeated(uint32_t &total_size, uint32_t field_id_size, bool value) {
+    // Always calculate size for repeated fields
+    // Boolean fields always use 1 byte
     total_size += field_id_size + 1;
   }
 
@@ -193,13 +223,24 @@ class ProtoSize {
    * @param is_nonzero Whether the value is non-zero
    */
   template<uint32_t NumBytes>
-  static inline void add_fixed_field(uint32_t &total_size, uint32_t field_id_size, bool is_nonzero,
-                                     bool force = false) {
-    // Skip calculation if value is zero and not forced
-    if (!is_nonzero && !force) {
+  static inline void add_fixed_field(uint32_t &total_size, uint32_t field_id_size, bool is_nonzero) {
+    // Skip calculation if value is zero
+    if (!is_nonzero) {
       return;  // No need to update total_size
     }
 
+    // Fixed fields always take exactly NumBytes
+    total_size += field_id_size + NumBytes;
+  }
+
+  /**
+   * @brief Calculates and adds the size of a fixed field to the total message size (repeated field version)
+   *
+   * @tparam NumBytes The number of bytes for this fixed field (4 or 8)
+   */
+  template<uint32_t NumBytes>
+  static inline void add_fixed_field_repeated(uint32_t &total_size, uint32_t field_id_size) {
+    // Always calculate size for repeated fields
     // Fixed fields always take exactly NumBytes
     total_size += field_id_size + NumBytes;
   }
@@ -209,12 +250,23 @@ class ProtoSize {
    *
    * Enum fields are encoded as uint32 varints.
    */
-  static inline void add_enum_field(uint32_t &total_size, uint32_t field_id_size, uint32_t value, bool force = false) {
-    // Skip calculation if value is zero and not forced
-    if (value == 0 && !force) {
+  static inline void add_enum_field(uint32_t &total_size, uint32_t field_id_size, uint32_t value) {
+    // Skip calculation if value is zero
+    if (value == 0) {
       return;  // No need to update total_size
     }
 
+    // Enums are encoded as uint32
+    total_size += field_id_size + varint(value);
+  }
+
+  /**
+   * @brief Calculates and adds the size of an enum field to the total message size (repeated field version)
+   *
+   * Enum fields are encoded as uint32 varints.
+   */
+  static inline void add_enum_field_repeated(uint32_t &total_size, uint32_t field_id_size, uint32_t value) {
+    // Always calculate size for repeated fields
     // Enums are encoded as uint32
     total_size += field_id_size + varint(value);
   }
@@ -224,9 +276,9 @@ class ProtoSize {
    *
    * Sint32 fields use ZigZag encoding, which is more efficient for negative values.
    */
-  static inline void add_sint32_field(uint32_t &total_size, uint32_t field_id_size, int32_t value, bool force = false) {
-    // Skip calculation if value is zero and not forced
-    if (value == 0 && !force) {
+  static inline void add_sint32_field(uint32_t &total_size, uint32_t field_id_size, int32_t value) {
+    // Skip calculation if value is zero
+    if (value == 0) {
       return;  // No need to update total_size
     }
 
@@ -236,11 +288,23 @@ class ProtoSize {
   }
 
   /**
+   * @brief Calculates and adds the size of a sint32 field to the total message size (repeated field version)
+   *
+   * Sint32 fields use ZigZag encoding, which is more efficient for negative values.
+   */
+  static inline void add_sint32_field_repeated(uint32_t &total_size, uint32_t field_id_size, int32_t value) {
+    // Always calculate size for repeated fields
+    // ZigZag encoding for sint32: (n << 1) ^ (n >> 31)
+    uint32_t zigzag = (static_cast<uint32_t>(value) << 1) ^ (static_cast<uint32_t>(value >> 31));
+    total_size += field_id_size + varint(zigzag);
+  }
+
+  /**
    * @brief Calculates and adds the size of an int64 field to the total message size
    */
-  static inline void add_int64_field(uint32_t &total_size, uint32_t field_id_size, int64_t value, bool force = false) {
-    // Skip calculation if value is zero and not forced
-    if (value == 0 && !force) {
+  static inline void add_int64_field(uint32_t &total_size, uint32_t field_id_size, int64_t value) {
+    // Skip calculation if value is zero
+    if (value == 0) {
       return;  // No need to update total_size
     }
 
@@ -249,16 +313,31 @@ class ProtoSize {
   }
 
   /**
+   * @brief Calculates and adds the size of an int64 field to the total message size (repeated field version)
+   */
+  static inline void add_int64_field_repeated(uint32_t &total_size, uint32_t field_id_size, int64_t value) {
+    // Always calculate size for repeated fields
+    total_size += field_id_size + varint(value);
+  }
+
+  /**
    * @brief Calculates and adds the size of a uint64 field to the total message size
    */
-  static inline void add_uint64_field(uint32_t &total_size, uint32_t field_id_size, uint64_t value,
-                                      bool force = false) {
-    // Skip calculation if value is zero and not forced
-    if (value == 0 && !force) {
+  static inline void add_uint64_field(uint32_t &total_size, uint32_t field_id_size, uint64_t value) {
+    // Skip calculation if value is zero
+    if (value == 0) {
       return;  // No need to update total_size
     }
 
     // Calculate and directly add to total_size
+    total_size += field_id_size + varint(value);
+  }
+
+  /**
+   * @brief Calculates and adds the size of a uint64 field to the total message size (repeated field version)
+   */
+  static inline void add_uint64_field_repeated(uint32_t &total_size, uint32_t field_id_size, uint64_t value) {
+    // Always calculate size for repeated fields
     total_size += field_id_size + varint(value);
   }
 
@@ -267,9 +346,9 @@ class ProtoSize {
    *
    * Sint64 fields use ZigZag encoding, which is more efficient for negative values.
    */
-  static inline void add_sint64_field(uint32_t &total_size, uint32_t field_id_size, int64_t value, bool force = false) {
-    // Skip calculation if value is zero and not forced
-    if (value == 0 && !force) {
+  static inline void add_sint64_field(uint32_t &total_size, uint32_t field_id_size, int64_t value) {
+    // Skip calculation if value is zero
+    if (value == 0) {
       return;  // No need to update total_size
     }
 
@@ -279,36 +358,65 @@ class ProtoSize {
   }
 
   /**
+   * @brief Calculates and adds the size of a sint64 field to the total message size (repeated field version)
+   *
+   * Sint64 fields use ZigZag encoding, which is more efficient for negative values.
+   */
+  static inline void add_sint64_field_repeated(uint32_t &total_size, uint32_t field_id_size, int64_t value) {
+    // Always calculate size for repeated fields
+    // ZigZag encoding for sint64: (n << 1) ^ (n >> 63)
+    uint64_t zigzag = (static_cast<uint64_t>(value) << 1) ^ (static_cast<uint64_t>(value >> 63));
+    total_size += field_id_size + varint(zigzag);
+  }
+
+  /**
    * @brief Calculates and adds the size of a string/bytes field to the total message size
    */
-  static inline void add_string_field(uint32_t &total_size, uint32_t field_id_size, const std::string &str,
-                                      bool force = false) {
-    // Skip calculation if string is empty and not forced
-    if (str.empty() && !force) {
+  static inline void add_string_field(uint32_t &total_size, uint32_t field_id_size, const std::string &str) {
+    // Skip calculation if string is empty
+    if (str.empty()) {
       return;  // No need to update total_size
     }
 
     // Calculate and directly add to total_size
-    const uint32_t str_size = static_cast<uint32_t>(str.size());
-    total_size += field_id_size + varint(str_size) + str_size;
+    total_size += field_id_size + varint(static_cast<uint32_t>(str.size())) + str.size();
+  }
+
+  /**
+   * @brief Calculates and adds the size of a string/bytes field to the total message size (repeated field version)
+   */
+  static inline void add_string_field_repeated(uint32_t &total_size, uint32_t field_id_size, const std::string &str) {
+    // Always calculate size for repeated fields
+    // No local variable needed for simple case
+    total_size += field_id_size + varint(static_cast<uint32_t>(str.size())) + str.size();
   }
 
   /**
    * @brief Calculates and adds the size of a nested message field to the total message size
    *
    * This helper function directly updates the total_size reference if the nested size
-   * is greater than zero or force is true.
+   * is greater than zero.
    *
    * @param nested_size The pre-calculated size of the nested message
    */
-  static inline void add_message_field(uint32_t &total_size, uint32_t field_id_size, uint32_t nested_size,
-                                       bool force = false) {
-    // Skip calculation if nested message is empty and not forced
-    if (nested_size == 0 && !force) {
+  static inline void add_message_field(uint32_t &total_size, uint32_t field_id_size, uint32_t nested_size) {
+    // Skip calculation if nested message is empty
+    if (nested_size == 0) {
       return;  // No need to update total_size
     }
 
     // Calculate and directly add to total_size
+    // Field ID + length varint + nested message content
+    total_size += field_id_size + varint(nested_size) + nested_size;
+  }
+
+  /**
+   * @brief Calculates and adds the size of a nested message field to the total message size (repeated field version)
+   *
+   * @param nested_size The pre-calculated size of the nested message
+   */
+  static inline void add_message_field_repeated(uint32_t &total_size, uint32_t field_id_size, uint32_t nested_size) {
+    // Always calculate size for repeated fields
     // Field ID + length varint + nested message content
     total_size += field_id_size + varint(nested_size) + nested_size;
   }
@@ -322,13 +430,26 @@ class ProtoSize {
    *
    * @param message The nested message object
    */
-  static inline void add_message_object(uint32_t &total_size, uint32_t field_id_size, const ProtoMessage &message,
-                                        bool force = false) {
+  static inline void add_message_object(uint32_t &total_size, uint32_t field_id_size, const ProtoMessage &message) {
     uint32_t nested_size = 0;
     message.calculate_size(nested_size);
 
     // Use the base implementation with the calculated nested_size
-    add_message_field(total_size, field_id_size, nested_size, force);
+    add_message_field(total_size, field_id_size, nested_size);
+  }
+
+  /**
+   * @brief Calculates and adds the size of a nested message field to the total message size (repeated field version)
+   *
+   * @param message The nested message object
+   */
+  static inline void add_message_object_repeated(uint32_t &total_size, uint32_t field_id_size,
+                                                 const ProtoMessage &message) {
+    uint32_t nested_size = 0;
+    message.calculate_size(nested_size);
+
+    // Use the base implementation with the calculated nested_size
+    add_message_field_repeated(total_size, field_id_size, nested_size);
   }
 
   /**
@@ -348,9 +469,9 @@ class ProtoSize {
       return;
     }
 
-    // For repeated fields, always use force=true
+    // Use the repeated field version for all messages
     for (const auto &message : messages) {
-      add_message_object(total_size, field_id_size, message, true);
+      add_message_object_repeated(total_size, field_id_size, message);
     }
   }
 };

--- a/script/api_protobuf/api_protobuf.py
+++ b/script/api_protobuf/api_protobuf.py
@@ -277,15 +277,13 @@ class TypeInfo(ABC):
             zero_check: Expression to check for zero value (e.g., "!= 0.0f")
         """
         field_id_size = self.calculate_field_id_size()
-        method = (
-            f"add_fixed_field_repeated<{num_bytes}>"
-            if force
-            else f"add_fixed_field<{num_bytes}>"
+        # Fixed-size repeated fields are handled differently in RepeatedTypeInfo
+        # so we should never get force=True here
+        assert not force, (
+            "Fixed-size repeated fields should be handled by RepeatedTypeInfo"
         )
-        if force:
-            return f"ProtoSize::{method}(total_size, {field_id_size});"
-        else:
-            return f"ProtoSize::{method}(total_size, {field_id_size}, {name} {zero_check});"
+        method = f"add_fixed_field<{num_bytes}>"
+        return f"ProtoSize::{method}(total_size, {field_id_size}, {name} {zero_check});"
 
     @abstractmethod
     def get_size_calculation(self, name: str, force: bool = False) -> str:
@@ -295,6 +293,14 @@ class TypeInfo(ABC):
             name: The name of the field
             force: Whether to force encoding the field even if it has a default value
         """
+
+    def get_fixed_size_bytes(self) -> int | None:
+        """Get the number of bytes for fixed-size fields (float, double, fixed32, etc).
+
+        Returns:
+            The number of bytes (4 or 8) for fixed-size fields, None for variable-size fields.
+        """
+        return None
 
     @abstractmethod
     def get_estimated_size(self) -> int:
@@ -335,6 +341,9 @@ class DoubleType(TypeInfo):
     def get_size_calculation(self, name: str, force: bool = False) -> str:
         return self._get_fixed_size_calculation(name, force, 8, "!= 0.0")
 
+    def get_fixed_size_bytes(self) -> int:
+        return 8
+
     def get_estimated_size(self) -> int:
         return self.calculate_field_id_size() + 8  # field ID + 8 bytes for double
 
@@ -354,6 +363,9 @@ class FloatType(TypeInfo):
 
     def get_size_calculation(self, name: str, force: bool = False) -> str:
         return self._get_fixed_size_calculation(name, force, 4, "!= 0.0f")
+
+    def get_fixed_size_bytes(self) -> int:
+        return 4
 
     def get_estimated_size(self) -> int:
         return self.calculate_field_id_size() + 4  # field ID + 4 bytes for float
@@ -435,6 +447,9 @@ class Fixed64Type(TypeInfo):
     def get_size_calculation(self, name: str, force: bool = False) -> str:
         return self._get_fixed_size_calculation(name, force, 8, "!= 0")
 
+    def get_fixed_size_bytes(self) -> int:
+        return 8
+
     def get_estimated_size(self) -> int:
         return self.calculate_field_id_size() + 8  # field ID + 8 bytes fixed
 
@@ -454,6 +469,9 @@ class Fixed32Type(TypeInfo):
 
     def get_size_calculation(self, name: str, force: bool = False) -> str:
         return self._get_fixed_size_calculation(name, force, 4, "!= 0")
+
+    def get_fixed_size_bytes(self) -> int:
+        return 4
 
     def get_estimated_size(self) -> int:
         return self.calculate_field_id_size() + 4  # field ID + 4 bytes fixed
@@ -628,6 +646,9 @@ class SFixed32Type(TypeInfo):
     def get_size_calculation(self, name: str, force: bool = False) -> str:
         return self._get_fixed_size_calculation(name, force, 4, "!= 0")
 
+    def get_fixed_size_bytes(self) -> int:
+        return 4
+
     def get_estimated_size(self) -> int:
         return self.calculate_field_id_size() + 4  # field ID + 4 bytes fixed
 
@@ -647,6 +668,9 @@ class SFixed64Type(TypeInfo):
 
     def get_size_calculation(self, name: str, force: bool = False) -> str:
         return self._get_fixed_size_calculation(name, force, 8, "!= 0")
+
+    def get_fixed_size_bytes(self) -> int:
+        return 8
 
     def get_estimated_size(self) -> int:
         return self.calculate_field_id_size() + 8  # field ID + 8 bytes fixed
@@ -801,11 +825,23 @@ class RepeatedTypeInfo(TypeInfo):
             field_id_size = self._ti.calculate_field_id_size()
             o = f"ProtoSize::add_repeated_message(total_size, {field_id_size}, {name});"
             return o
+
         # For other repeated types, use the underlying type's size calculation with force=True
         o = f"if (!{name}.empty()) {{\n"
-        o += f"  for (const auto {'' if self._ti_is_bool else '&'}it : {name}) {{\n"
-        o += f"    {self._ti.get_size_calculation('it', True)}\n"
-        o += "  }\n"
+
+        # Check if this is a fixed-size type by seeing if it has a fixed byte count
+        num_bytes = self._ti.get_fixed_size_bytes()
+        if num_bytes is not None:
+            # Fixed types have constant size per element, so we can multiply
+            field_id_size = self._ti.calculate_field_id_size()
+            # Pre-calculate the total bytes per element
+            bytes_per_element = field_id_size + num_bytes
+            o += f"  total_size += {name}.size() * {bytes_per_element};\n"
+        else:
+            # Other types need the actual value
+            o += f"  for (const auto {'' if self._ti_is_bool else '&'}it : {name}) {{\n"
+            o += f"    {self._ti.get_size_calculation('it', True)}\n"
+            o += "  }\n"
         o += "}"
         return o
 

--- a/script/api_protobuf/api_protobuf.py
+++ b/script/api_protobuf/api_protobuf.py
@@ -249,6 +249,44 @@ class TypeInfo(ABC):
             return 4  # 28 bits
         return 5  # 32 bits (maximum for uint32_t)
 
+    def _get_simple_size_calculation(
+        self, name: str, force: bool, base_method: str, value_expr: str = None
+    ) -> str:
+        """Helper for simple size calculations.
+
+        Args:
+            name: Field name
+            force: Whether this is for a repeated field
+            base_method: Base method name (e.g., "add_int32_field")
+            value_expr: Optional value expression (defaults to name)
+        """
+        field_id_size = self.calculate_field_id_size()
+        method = f"{base_method}_repeated" if force else base_method
+        value = value_expr if value_expr else name
+        return f"ProtoSize::{method}(total_size, {field_id_size}, {value});"
+
+    def _get_fixed_size_calculation(
+        self, name: str, force: bool, num_bytes: int, zero_check: str
+    ) -> str:
+        """Helper for fixed-size field calculations.
+
+        Args:
+            name: Field name
+            force: Whether this is for a repeated field
+            num_bytes: Number of bytes (4 or 8)
+            zero_check: Expression to check for zero value (e.g., "!= 0.0f")
+        """
+        field_id_size = self.calculate_field_id_size()
+        method = (
+            f"add_fixed_field_repeated<{num_bytes}>"
+            if force
+            else f"add_fixed_field<{num_bytes}>"
+        )
+        if force:
+            return f"ProtoSize::{method}(total_size, {field_id_size});"
+        else:
+            return f"ProtoSize::{method}(total_size, {field_id_size}, {name} {zero_check});"
+
     @abstractmethod
     def get_size_calculation(self, name: str, force: bool = False) -> str:
         """Calculate the size needed for encoding this field.
@@ -295,13 +333,7 @@ class DoubleType(TypeInfo):
         return o
 
     def get_size_calculation(self, name: str, force: bool = False) -> str:
-        field_id_size = self.calculate_field_id_size()
-        method = "add_fixed_field_repeated<8>" if force else "add_fixed_field<8>"
-        if force:
-            o = f"ProtoSize::{method}(total_size, {field_id_size});"
-        else:
-            o = f"ProtoSize::{method}(total_size, {field_id_size}, {name} != 0.0);"
-        return o
+        return self._get_fixed_size_calculation(name, force, 8, "!= 0.0")
 
     def get_estimated_size(self) -> int:
         return self.calculate_field_id_size() + 8  # field ID + 8 bytes for double
@@ -321,13 +353,7 @@ class FloatType(TypeInfo):
         return o
 
     def get_size_calculation(self, name: str, force: bool = False) -> str:
-        field_id_size = self.calculate_field_id_size()
-        method = "add_fixed_field_repeated<4>" if force else "add_fixed_field<4>"
-        if force:
-            o = f"ProtoSize::{method}(total_size, {field_id_size});"
-        else:
-            o = f"ProtoSize::{method}(total_size, {field_id_size}, {name} != 0.0f);"
-        return o
+        return self._get_fixed_size_calculation(name, force, 4, "!= 0.0f")
 
     def get_estimated_size(self) -> int:
         return self.calculate_field_id_size() + 4  # field ID + 4 bytes for float
@@ -347,10 +373,7 @@ class Int64Type(TypeInfo):
         return o
 
     def get_size_calculation(self, name: str, force: bool = False) -> str:
-        field_id_size = self.calculate_field_id_size()
-        method = "add_int64_field_repeated" if force else "add_int64_field"
-        o = f"ProtoSize::{method}(total_size, {field_id_size}, {name});"
-        return o
+        return self._get_simple_size_calculation(name, force, "add_int64_field")
 
     def get_estimated_size(self) -> int:
         return self.calculate_field_id_size() + 3  # field ID + 3 bytes typical varint
@@ -370,10 +393,7 @@ class UInt64Type(TypeInfo):
         return o
 
     def get_size_calculation(self, name: str, force: bool = False) -> str:
-        field_id_size = self.calculate_field_id_size()
-        method = "add_uint64_field_repeated" if force else "add_uint64_field"
-        o = f"ProtoSize::{method}(total_size, {field_id_size}, {name});"
-        return o
+        return self._get_simple_size_calculation(name, force, "add_uint64_field")
 
     def get_estimated_size(self) -> int:
         return self.calculate_field_id_size() + 3  # field ID + 3 bytes typical varint
@@ -393,10 +413,7 @@ class Int32Type(TypeInfo):
         return o
 
     def get_size_calculation(self, name: str, force: bool = False) -> str:
-        field_id_size = self.calculate_field_id_size()
-        method = "add_int32_field_repeated" if force else "add_int32_field"
-        o = f"ProtoSize::{method}(total_size, {field_id_size}, {name});"
-        return o
+        return self._get_simple_size_calculation(name, force, "add_int32_field")
 
     def get_estimated_size(self) -> int:
         return self.calculate_field_id_size() + 3  # field ID + 3 bytes typical varint
@@ -416,13 +433,7 @@ class Fixed64Type(TypeInfo):
         return o
 
     def get_size_calculation(self, name: str, force: bool = False) -> str:
-        field_id_size = self.calculate_field_id_size()
-        method = "add_fixed_field_repeated<8>" if force else "add_fixed_field<8>"
-        if force:
-            o = f"ProtoSize::{method}(total_size, {field_id_size});"
-        else:
-            o = f"ProtoSize::{method}(total_size, {field_id_size}, {name} != 0);"
-        return o
+        return self._get_fixed_size_calculation(name, force, 8, "!= 0")
 
     def get_estimated_size(self) -> int:
         return self.calculate_field_id_size() + 8  # field ID + 8 bytes fixed
@@ -442,13 +453,7 @@ class Fixed32Type(TypeInfo):
         return o
 
     def get_size_calculation(self, name: str, force: bool = False) -> str:
-        field_id_size = self.calculate_field_id_size()
-        method = "add_fixed_field_repeated<4>" if force else "add_fixed_field<4>"
-        if force:
-            o = f"ProtoSize::{method}(total_size, {field_id_size});"
-        else:
-            o = f"ProtoSize::{method}(total_size, {field_id_size}, {name} != 0);"
-        return o
+        return self._get_fixed_size_calculation(name, force, 4, "!= 0")
 
     def get_estimated_size(self) -> int:
         return self.calculate_field_id_size() + 4  # field ID + 4 bytes fixed
@@ -467,10 +472,7 @@ class BoolType(TypeInfo):
         return o
 
     def get_size_calculation(self, name: str, force: bool = False) -> str:
-        field_id_size = self.calculate_field_id_size()
-        method = "add_bool_field_repeated" if force else "add_bool_field"
-        o = f"ProtoSize::{method}(total_size, {field_id_size}, {name});"
-        return o
+        return self._get_simple_size_calculation(name, force, "add_bool_field")
 
     def get_estimated_size(self) -> int:
         return self.calculate_field_id_size() + 1  # field ID + 1 byte
@@ -491,10 +493,7 @@ class StringType(TypeInfo):
         return o
 
     def get_size_calculation(self, name: str, force: bool = False) -> str:
-        field_id_size = self.calculate_field_id_size()
-        method = "add_string_field_repeated" if force else "add_string_field"
-        o = f"ProtoSize::{method}(total_size, {field_id_size}, {name});"
-        return o
+        return self._get_simple_size_calculation(name, force, "add_string_field")
 
     def get_estimated_size(self) -> int:
         return self.calculate_field_id_size() + 8  # field ID + 8 bytes typical string
@@ -530,10 +529,7 @@ class MessageType(TypeInfo):
         return o
 
     def get_size_calculation(self, name: str, force: bool = False) -> str:
-        field_id_size = self.calculate_field_id_size()
-        method = "add_message_object_repeated" if force else "add_message_object"
-        o = f"ProtoSize::{method}(total_size, {field_id_size}, {name});"
-        return o
+        return self._get_simple_size_calculation(name, force, "add_message_object")
 
     def get_estimated_size(self) -> int:
         return (
@@ -560,10 +556,7 @@ class BytesType(TypeInfo):
         return o
 
     def get_size_calculation(self, name: str, force: bool = False) -> str:
-        field_id_size = self.calculate_field_id_size()
-        method = "add_string_field_repeated" if force else "add_string_field"
-        o = f"ProtoSize::{method}(total_size, {field_id_size}, {name});"
-        return o
+        return self._get_simple_size_calculation(name, force, "add_string_field")
 
     def get_estimated_size(self) -> int:
         return self.calculate_field_id_size() + 8  # field ID + 8 bytes typical bytes
@@ -583,10 +576,7 @@ class UInt32Type(TypeInfo):
         return o
 
     def get_size_calculation(self, name: str, force: bool = False) -> str:
-        field_id_size = self.calculate_field_id_size()
-        method = "add_uint32_field_repeated" if force else "add_uint32_field"
-        o = f"ProtoSize::{method}(total_size, {field_id_size}, {name});"
-        return o
+        return self._get_simple_size_calculation(name, force, "add_uint32_field")
 
     def get_estimated_size(self) -> int:
         return self.calculate_field_id_size() + 3  # field ID + 3 bytes typical varint
@@ -614,10 +604,9 @@ class EnumType(TypeInfo):
         return o
 
     def get_size_calculation(self, name: str, force: bool = False) -> str:
-        field_id_size = self.calculate_field_id_size()
-        method = "add_enum_field_repeated" if force else "add_enum_field"
-        o = f"ProtoSize::{method}(total_size, {field_id_size}, static_cast<uint32_t>({name}));"
-        return o
+        return self._get_simple_size_calculation(
+            name, force, "add_enum_field", f"static_cast<uint32_t>({name})"
+        )
 
     def get_estimated_size(self) -> int:
         return self.calculate_field_id_size() + 1  # field ID + 1 byte typical enum
@@ -637,13 +626,7 @@ class SFixed32Type(TypeInfo):
         return o
 
     def get_size_calculation(self, name: str, force: bool = False) -> str:
-        field_id_size = self.calculate_field_id_size()
-        method = "add_fixed_field_repeated<4>" if force else "add_fixed_field<4>"
-        if force:
-            o = f"ProtoSize::{method}(total_size, {field_id_size});"
-        else:
-            o = f"ProtoSize::{method}(total_size, {field_id_size}, {name} != 0);"
-        return o
+        return self._get_fixed_size_calculation(name, force, 4, "!= 0")
 
     def get_estimated_size(self) -> int:
         return self.calculate_field_id_size() + 4  # field ID + 4 bytes fixed
@@ -663,13 +646,7 @@ class SFixed64Type(TypeInfo):
         return o
 
     def get_size_calculation(self, name: str, force: bool = False) -> str:
-        field_id_size = self.calculate_field_id_size()
-        method = "add_fixed_field_repeated<8>" if force else "add_fixed_field<8>"
-        if force:
-            o = f"ProtoSize::{method}(total_size, {field_id_size});"
-        else:
-            o = f"ProtoSize::{method}(total_size, {field_id_size}, {name} != 0);"
-        return o
+        return self._get_fixed_size_calculation(name, force, 8, "!= 0")
 
     def get_estimated_size(self) -> int:
         return self.calculate_field_id_size() + 8  # field ID + 8 bytes fixed
@@ -689,10 +666,7 @@ class SInt32Type(TypeInfo):
         return o
 
     def get_size_calculation(self, name: str, force: bool = False) -> str:
-        field_id_size = self.calculate_field_id_size()
-        method = "add_sint32_field_repeated" if force else "add_sint32_field"
-        o = f"ProtoSize::{method}(total_size, {field_id_size}, {name});"
-        return o
+        return self._get_simple_size_calculation(name, force, "add_sint32_field")
 
     def get_estimated_size(self) -> int:
         return self.calculate_field_id_size() + 3  # field ID + 3 bytes typical varint
@@ -712,10 +686,7 @@ class SInt64Type(TypeInfo):
         return o
 
     def get_size_calculation(self, name: str, force: bool = False) -> str:
-        field_id_size = self.calculate_field_id_size()
-        method = "add_sint64_field_repeated" if force else "add_sint64_field"
-        o = f"ProtoSize::{method}(total_size, {field_id_size}, {name});"
-        return o
+        return self._get_simple_size_calculation(name, force, "add_sint64_field")
 
     def get_estimated_size(self) -> int:
         return self.calculate_field_id_size() + 3  # field ID + 3 bytes typical varint

--- a/script/api_protobuf/api_protobuf.py
+++ b/script/api_protobuf/api_protobuf.py
@@ -296,7 +296,11 @@ class DoubleType(TypeInfo):
 
     def get_size_calculation(self, name: str, force: bool = False) -> str:
         field_id_size = self.calculate_field_id_size()
-        o = f"ProtoSize::add_fixed_field<8>(total_size, {field_id_size}, {name} != 0.0, {force_str(force)});"
+        method = "add_fixed_field_repeated<8>" if force else "add_fixed_field<8>"
+        if force:
+            o = f"ProtoSize::{method}(total_size, {field_id_size});"
+        else:
+            o = f"ProtoSize::{method}(total_size, {field_id_size}, {name} != 0.0);"
         return o
 
     def get_estimated_size(self) -> int:
@@ -318,7 +322,11 @@ class FloatType(TypeInfo):
 
     def get_size_calculation(self, name: str, force: bool = False) -> str:
         field_id_size = self.calculate_field_id_size()
-        o = f"ProtoSize::add_fixed_field<4>(total_size, {field_id_size}, {name} != 0.0f, {force_str(force)});"
+        method = "add_fixed_field_repeated<4>" if force else "add_fixed_field<4>"
+        if force:
+            o = f"ProtoSize::{method}(total_size, {field_id_size});"
+        else:
+            o = f"ProtoSize::{method}(total_size, {field_id_size}, {name} != 0.0f);"
         return o
 
     def get_estimated_size(self) -> int:
@@ -340,7 +348,8 @@ class Int64Type(TypeInfo):
 
     def get_size_calculation(self, name: str, force: bool = False) -> str:
         field_id_size = self.calculate_field_id_size()
-        o = f"ProtoSize::add_int64_field(total_size, {field_id_size}, {name}, {force_str(force)});"
+        method = "add_int64_field_repeated" if force else "add_int64_field"
+        o = f"ProtoSize::{method}(total_size, {field_id_size}, {name});"
         return o
 
     def get_estimated_size(self) -> int:
@@ -362,7 +371,8 @@ class UInt64Type(TypeInfo):
 
     def get_size_calculation(self, name: str, force: bool = False) -> str:
         field_id_size = self.calculate_field_id_size()
-        o = f"ProtoSize::add_uint64_field(total_size, {field_id_size}, {name}, {force_str(force)});"
+        method = "add_uint64_field_repeated" if force else "add_uint64_field"
+        o = f"ProtoSize::{method}(total_size, {field_id_size}, {name});"
         return o
 
     def get_estimated_size(self) -> int:
@@ -384,7 +394,8 @@ class Int32Type(TypeInfo):
 
     def get_size_calculation(self, name: str, force: bool = False) -> str:
         field_id_size = self.calculate_field_id_size()
-        o = f"ProtoSize::add_int32_field(total_size, {field_id_size}, {name}, {force_str(force)});"
+        method = "add_int32_field_repeated" if force else "add_int32_field"
+        o = f"ProtoSize::{method}(total_size, {field_id_size}, {name});"
         return o
 
     def get_estimated_size(self) -> int:
@@ -406,7 +417,11 @@ class Fixed64Type(TypeInfo):
 
     def get_size_calculation(self, name: str, force: bool = False) -> str:
         field_id_size = self.calculate_field_id_size()
-        o = f"ProtoSize::add_fixed_field<8>(total_size, {field_id_size}, {name} != 0, {force_str(force)});"
+        method = "add_fixed_field_repeated<8>" if force else "add_fixed_field<8>"
+        if force:
+            o = f"ProtoSize::{method}(total_size, {field_id_size});"
+        else:
+            o = f"ProtoSize::{method}(total_size, {field_id_size}, {name} != 0);"
         return o
 
     def get_estimated_size(self) -> int:
@@ -428,7 +443,11 @@ class Fixed32Type(TypeInfo):
 
     def get_size_calculation(self, name: str, force: bool = False) -> str:
         field_id_size = self.calculate_field_id_size()
-        o = f"ProtoSize::add_fixed_field<4>(total_size, {field_id_size}, {name} != 0, {force_str(force)});"
+        method = "add_fixed_field_repeated<4>" if force else "add_fixed_field<4>"
+        if force:
+            o = f"ProtoSize::{method}(total_size, {field_id_size});"
+        else:
+            o = f"ProtoSize::{method}(total_size, {field_id_size}, {name} != 0);"
         return o
 
     def get_estimated_size(self) -> int:
@@ -449,7 +468,8 @@ class BoolType(TypeInfo):
 
     def get_size_calculation(self, name: str, force: bool = False) -> str:
         field_id_size = self.calculate_field_id_size()
-        o = f"ProtoSize::add_bool_field(total_size, {field_id_size}, {name}, {force_str(force)});"
+        method = "add_bool_field_repeated" if force else "add_bool_field"
+        o = f"ProtoSize::{method}(total_size, {field_id_size}, {name});"
         return o
 
     def get_estimated_size(self) -> int:
@@ -472,7 +492,8 @@ class StringType(TypeInfo):
 
     def get_size_calculation(self, name: str, force: bool = False) -> str:
         field_id_size = self.calculate_field_id_size()
-        o = f"ProtoSize::add_string_field(total_size, {field_id_size}, {name}, {force_str(force)});"
+        method = "add_string_field_repeated" if force else "add_string_field"
+        o = f"ProtoSize::{method}(total_size, {field_id_size}, {name});"
         return o
 
     def get_estimated_size(self) -> int:
@@ -510,7 +531,8 @@ class MessageType(TypeInfo):
 
     def get_size_calculation(self, name: str, force: bool = False) -> str:
         field_id_size = self.calculate_field_id_size()
-        o = f"ProtoSize::add_message_object(total_size, {field_id_size}, {name}, {force_str(force)});"
+        method = "add_message_object_repeated" if force else "add_message_object"
+        o = f"ProtoSize::{method}(total_size, {field_id_size}, {name});"
         return o
 
     def get_estimated_size(self) -> int:
@@ -539,7 +561,8 @@ class BytesType(TypeInfo):
 
     def get_size_calculation(self, name: str, force: bool = False) -> str:
         field_id_size = self.calculate_field_id_size()
-        o = f"ProtoSize::add_string_field(total_size, {field_id_size}, {name}, {force_str(force)});"
+        method = "add_string_field_repeated" if force else "add_string_field"
+        o = f"ProtoSize::{method}(total_size, {field_id_size}, {name});"
         return o
 
     def get_estimated_size(self) -> int:
@@ -561,7 +584,8 @@ class UInt32Type(TypeInfo):
 
     def get_size_calculation(self, name: str, force: bool = False) -> str:
         field_id_size = self.calculate_field_id_size()
-        o = f"ProtoSize::add_uint32_field(total_size, {field_id_size}, {name}, {force_str(force)});"
+        method = "add_uint32_field_repeated" if force else "add_uint32_field"
+        o = f"ProtoSize::{method}(total_size, {field_id_size}, {name});"
         return o
 
     def get_estimated_size(self) -> int:
@@ -591,7 +615,8 @@ class EnumType(TypeInfo):
 
     def get_size_calculation(self, name: str, force: bool = False) -> str:
         field_id_size = self.calculate_field_id_size()
-        o = f"ProtoSize::add_enum_field(total_size, {field_id_size}, static_cast<uint32_t>({name}), {force_str(force)});"
+        method = "add_enum_field_repeated" if force else "add_enum_field"
+        o = f"ProtoSize::{method}(total_size, {field_id_size}, static_cast<uint32_t>({name}));"
         return o
 
     def get_estimated_size(self) -> int:
@@ -613,7 +638,11 @@ class SFixed32Type(TypeInfo):
 
     def get_size_calculation(self, name: str, force: bool = False) -> str:
         field_id_size = self.calculate_field_id_size()
-        o = f"ProtoSize::add_fixed_field<4>(total_size, {field_id_size}, {name} != 0, {force_str(force)});"
+        method = "add_fixed_field_repeated<4>" if force else "add_fixed_field<4>"
+        if force:
+            o = f"ProtoSize::{method}(total_size, {field_id_size});"
+        else:
+            o = f"ProtoSize::{method}(total_size, {field_id_size}, {name} != 0);"
         return o
 
     def get_estimated_size(self) -> int:
@@ -635,7 +664,11 @@ class SFixed64Type(TypeInfo):
 
     def get_size_calculation(self, name: str, force: bool = False) -> str:
         field_id_size = self.calculate_field_id_size()
-        o = f"ProtoSize::add_fixed_field<8>(total_size, {field_id_size}, {name} != 0, {force_str(force)});"
+        method = "add_fixed_field_repeated<8>" if force else "add_fixed_field<8>"
+        if force:
+            o = f"ProtoSize::{method}(total_size, {field_id_size});"
+        else:
+            o = f"ProtoSize::{method}(total_size, {field_id_size}, {name} != 0);"
         return o
 
     def get_estimated_size(self) -> int:
@@ -657,7 +690,8 @@ class SInt32Type(TypeInfo):
 
     def get_size_calculation(self, name: str, force: bool = False) -> str:
         field_id_size = self.calculate_field_id_size()
-        o = f"ProtoSize::add_sint32_field(total_size, {field_id_size}, {name}, {force_str(force)});"
+        method = "add_sint32_field_repeated" if force else "add_sint32_field"
+        o = f"ProtoSize::{method}(total_size, {field_id_size}, {name});"
         return o
 
     def get_estimated_size(self) -> int:
@@ -679,7 +713,8 @@ class SInt64Type(TypeInfo):
 
     def get_size_calculation(self, name: str, force: bool = False) -> str:
         field_id_size = self.calculate_field_id_size()
-        o = f"ProtoSize::add_sint64_field(total_size, {field_id_size}, {name}, {force_str(force)});"
+        method = "add_sint64_field_repeated" if force else "add_sint64_field"
+        o = f"ProtoSize::{method}(total_size, {field_id_size}, {name});"
         return o
 
     def get_estimated_size(self) -> int:
@@ -1701,7 +1736,6 @@ static const char *const TAG = "api.service";
         exec_clang_format(root / "api_pb2_service.cpp")
         exec_clang_format(root / "api_pb2.h")
         exec_clang_format(root / "api_pb2.cpp")
-        exec_clang_format(root / "api_pb2_dump.h")
         exec_clang_format(root / "api_pb2_dump.cpp")
     except ImportError:
         pass


### PR DESCRIPTION
# What does this implement/fix?

This PR optimizes the ESPHome API protocol buffer implementation by removing the redundant `force` parameter from ProtoSize methods. The optimization creates separate methods for regular fields (which check for default values) and repeated fields (which always encode), eliminating the need to pass a boolean parameter at every call site.

This change reduces flash usage by approximately 1,200 bytes on ESP32 with no impact on RAM usage or performance.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - this is an internal optimization
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

## Additional Information

### Implementation Details
1. Created two versions of each ProtoSize method:
   - Regular field version (e.g., `add_int32_field`) - checks for default values
   - Repeated field version (e.g., `add_int32_field_repeated`) - no default checks
2. Updated `api_protobuf.py` to generate calls to the appropriate method based on field type
3. For fixed-size fields, the repeated version omits the `is_nonzero` parameter

### Memory Usage Results
**Before optimization:**
- Flash: 67.1% (1,231,140 bytes)
- RAM: 13.5% (44,336 bytes)

**After optimization:**
- Flash: 67.0% (1,229,940 bytes) - **Saved 1,200 bytes**
- RAM: 13.5% (44,336 bytes) - No change

### Performance Results
Benchmarked using BLE advertisement encoding (5 advertisements, 231 bytes each):

**Calculate Size performance:**
- Before: 8.010 µs
- After: 7.605 µs - **5.1% faster** (consistent across multiple runs)

The optimization consistently improves `calculate_size` performance while having no impact on overall API performance.

### Code Changes
- Modified `esphome/components/api/api_pb2_size.h` to add separate methods for repeated fields
- Updated `script/api_protobuf/api_protobuf.py` to generate appropriate method calls
- All generated proto files automatically updated with the new calling convention