### PR TITLE
Reduce API flash usage by eliminating unnecessary template instantiations

### DIFF
--- a/esphome/components/api/api_pb2.cpp
+++ b/esphome/components/api/api_pb2.cpp
@@ -257,15 +257,17 @@ bool DeviceInfoResponse::decode_length(uint32_t field_id, ProtoLengthDelimited v
       return true;
     }
     case 20: {
-      this->devices.push_back(value.as_message<DeviceInfo>());
+      this->devices.emplace_back();
+      value.decode_to_message(this->devices.back());
       return true;
     }
     case 21: {
-      this->areas.push_back(value.as_message<AreaInfo>());
+      this->areas.emplace_back();
+      value.decode_to_message(this->areas.back());
       return true;
     }
     case 22: {
-      this->area = value.as_message<AreaInfo>();
+      value.decode_to_message(this->area);
       return true;
     }
     default:
@@ -1935,15 +1937,18 @@ bool HomeassistantServiceResponse::decode_length(uint32_t field_id, ProtoLengthD
       return true;
     }
     case 2: {
-      this->data.push_back(value.as_message<HomeassistantServiceMap>());
+      this->data.emplace_back();
+      value.decode_to_message(this->data.back());
       return true;
     }
     case 3: {
-      this->data_template.push_back(value.as_message<HomeassistantServiceMap>());
+      this->data_template.emplace_back();
+      value.decode_to_message(this->data_template.back());
       return true;
     }
     case 4: {
-      this->variables.push_back(value.as_message<HomeassistantServiceMap>());
+      this->variables.emplace_back();
+      value.decode_to_message(this->variables.back());
       return true;
     }
     default:
@@ -2081,7 +2086,8 @@ bool ListEntitiesServicesResponse::decode_length(uint32_t field_id, ProtoLengthD
       return true;
     }
     case 3: {
-      this->args.push_back(value.as_message<ListEntitiesServicesArgument>());
+      this->args.emplace_back();
+      value.decode_to_message(this->args.back());
       return true;
     }
     default:
@@ -2213,7 +2219,8 @@ void ExecuteServiceArgument::calculate_size(uint32_t &total_size) const {
 bool ExecuteServiceRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 2: {
-      this->args.push_back(value.as_message<ExecuteServiceArgument>());
+      this->args.emplace_back();
+      value.decode_to_message(this->args.back());
       return true;
     }
     default:
@@ -3820,7 +3827,8 @@ bool ListEntitiesMediaPlayerResponse::decode_length(uint32_t field_id, ProtoLeng
       return true;
     }
     case 9: {
-      this->supported_formats.push_back(value.as_message<MediaPlayerSupportedFormat>());
+      this->supported_formats.emplace_back();
+      value.decode_to_message(this->supported_formats.back());
       return true;
     }
     default:
@@ -4078,11 +4086,13 @@ bool BluetoothLEAdvertisementResponse::decode_length(uint32_t field_id, ProtoLen
       return true;
     }
     case 5: {
-      this->service_data.push_back(value.as_message<BluetoothServiceData>());
+      this->service_data.emplace_back();
+      value.decode_to_message(this->service_data.back());
       return true;
     }
     case 6: {
-      this->manufacturer_data.push_back(value.as_message<BluetoothServiceData>());
+      this->manufacturer_data.emplace_back();
+      value.decode_to_message(this->manufacturer_data.back());
       return true;
     }
     default:
@@ -4160,7 +4170,8 @@ void BluetoothLERawAdvertisement::calculate_size(uint32_t &total_size) const {
 bool BluetoothLERawAdvertisementsResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 1: {
-      this->advertisements.push_back(value.as_message<BluetoothLERawAdvertisement>());
+      this->advertisements.emplace_back();
+      value.decode_to_message(this->advertisements.back());
       return true;
     }
     default:
@@ -4306,7 +4317,8 @@ bool BluetoothGATTCharacteristic::decode_varint(uint32_t field_id, ProtoVarInt v
 bool BluetoothGATTCharacteristic::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 4: {
-      this->descriptors.push_back(value.as_message<BluetoothGATTDescriptor>());
+      this->descriptors.emplace_back();
+      value.decode_to_message(this->descriptors.back());
       return true;
     }
     default:
@@ -4350,7 +4362,8 @@ bool BluetoothGATTService::decode_varint(uint32_t field_id, ProtoVarInt value) {
 bool BluetoothGATTService::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 3: {
-      this->characteristics.push_back(value.as_message<BluetoothGATTCharacteristic>());
+      this->characteristics.emplace_back();
+      value.decode_to_message(this->characteristics.back());
       return true;
     }
     default:
@@ -4388,7 +4401,8 @@ bool BluetoothGATTGetServicesResponse::decode_varint(uint32_t field_id, ProtoVar
 bool BluetoothGATTGetServicesResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 2: {
-      this->services.push_back(value.as_message<BluetoothGATTService>());
+      this->services.emplace_back();
+      value.decode_to_message(this->services.back());
       return true;
     }
     default:
@@ -4942,7 +4956,7 @@ bool VoiceAssistantRequest::decode_length(uint32_t field_id, ProtoLengthDelimite
       return true;
     }
     case 4: {
-      this->audio_settings = value.as_message<VoiceAssistantAudioSettings>();
+      value.decode_to_message(this->audio_settings);
       return true;
     }
     case 5: {
@@ -5024,7 +5038,8 @@ bool VoiceAssistantEventResponse::decode_varint(uint32_t field_id, ProtoVarInt v
 bool VoiceAssistantEventResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 2: {
-      this->data.push_back(value.as_message<VoiceAssistantEventData>());
+      this->data.emplace_back();
+      value.decode_to_message(this->data.back());
       return true;
     }
     default:
@@ -5222,7 +5237,8 @@ bool VoiceAssistantConfigurationResponse::decode_varint(uint32_t field_id, Proto
 bool VoiceAssistantConfigurationResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 1: {
-      this->available_wake_words.push_back(value.as_message<VoiceAssistantWakeWord>());
+      this->available_wake_words.emplace_back();
+      value.decode_to_message(this->available_wake_words.back());
       return true;
     }
     case 2: {

--- a/esphome/components/api/api_pb2.cpp
+++ b/esphome/components/api/api_pb2.cpp
@@ -394,7 +394,7 @@ void ListEntitiesBinarySensorResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_bool(6, this->is_status_binary_sensor);
   buffer.encode_bool(7, this->disabled_by_default);
   buffer.encode_string(8, this->icon);
-  buffer.encode_enum_uint32(9, static_cast<uint32_t>(this->entity_category));
+  buffer.encode_uint32(9, static_cast<uint32_t>(this->entity_category));
   buffer.encode_uint32(10, this->device_id);
 }
 void ListEntitiesBinarySensorResponse::calculate_size(uint32_t &total_size) const {
@@ -532,7 +532,7 @@ void ListEntitiesCoverResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_string(8, this->device_class);
   buffer.encode_bool(9, this->disabled_by_default);
   buffer.encode_string(10, this->icon);
-  buffer.encode_enum_uint32(11, static_cast<uint32_t>(this->entity_category));
+  buffer.encode_uint32(11, static_cast<uint32_t>(this->entity_category));
   buffer.encode_bool(12, this->supports_stop);
   buffer.encode_uint32(13, this->device_id);
 }
@@ -589,10 +589,10 @@ bool CoverStateResponse::decode_32bit(uint32_t field_id, Proto32Bit value) {
 }
 void CoverStateResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_fixed32(1, this->key);
-  buffer.encode_enum_uint32(2, static_cast<uint32_t>(this->legacy_state));
+  buffer.encode_uint32(2, static_cast<uint32_t>(this->legacy_state));
   buffer.encode_float(3, this->position);
   buffer.encode_float(4, this->tilt);
-  buffer.encode_enum_uint32(5, static_cast<uint32_t>(this->current_operation));
+  buffer.encode_uint32(5, static_cast<uint32_t>(this->current_operation));
   buffer.encode_uint32(6, this->device_id);
 }
 void CoverStateResponse::calculate_size(uint32_t &total_size) const {
@@ -654,7 +654,7 @@ bool CoverCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
 void CoverCommandRequest::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_fixed32(1, this->key);
   buffer.encode_bool(2, this->has_legacy_command);
-  buffer.encode_enum_uint32(3, static_cast<uint32_t>(this->legacy_command));
+  buffer.encode_uint32(3, static_cast<uint32_t>(this->legacy_command));
   buffer.encode_bool(4, this->has_position);
   buffer.encode_float(5, this->position);
   buffer.encode_bool(6, this->has_tilt);
@@ -756,7 +756,7 @@ void ListEntitiesFanResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_int32(8, this->supported_speed_count);
   buffer.encode_bool(9, this->disabled_by_default);
   buffer.encode_string(10, this->icon);
-  buffer.encode_enum_uint32(11, static_cast<uint32_t>(this->entity_category));
+  buffer.encode_uint32(11, static_cast<uint32_t>(this->entity_category));
   for (auto &it : this->supported_preset_modes) {
     buffer.encode_string(12, it, true);
   }
@@ -835,8 +835,8 @@ void FanStateResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_fixed32(1, this->key);
   buffer.encode_bool(2, this->state);
   buffer.encode_bool(3, this->oscillating);
-  buffer.encode_enum_uint32(4, static_cast<uint32_t>(this->speed));
-  buffer.encode_enum_uint32(5, static_cast<uint32_t>(this->direction));
+  buffer.encode_uint32(4, static_cast<uint32_t>(this->speed));
+  buffer.encode_uint32(5, static_cast<uint32_t>(this->direction));
   buffer.encode_int32(6, this->speed_level);
   buffer.encode_string(7, this->preset_mode);
   buffer.encode_uint32(8, this->device_id);
@@ -930,11 +930,11 @@ void FanCommandRequest::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_bool(2, this->has_state);
   buffer.encode_bool(3, this->state);
   buffer.encode_bool(4, this->has_speed);
-  buffer.encode_enum_uint32(5, static_cast<uint32_t>(this->speed));
+  buffer.encode_uint32(5, static_cast<uint32_t>(this->speed));
   buffer.encode_bool(6, this->has_oscillating);
   buffer.encode_bool(7, this->oscillating);
   buffer.encode_bool(8, this->has_direction);
-  buffer.encode_enum_uint32(9, static_cast<uint32_t>(this->direction));
+  buffer.encode_uint32(9, static_cast<uint32_t>(this->direction));
   buffer.encode_bool(10, this->has_speed_level);
   buffer.encode_int32(11, this->speed_level);
   buffer.encode_bool(12, this->has_preset_mode);
@@ -1047,7 +1047,7 @@ void ListEntitiesLightResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_string(3, this->name);
   buffer.encode_string(4, this->unique_id);
   for (auto &it : this->supported_color_modes) {
-    buffer.encode_enum_uint32(12, static_cast<uint32_t>(it), true);
+    buffer.encode_uint32(12, static_cast<uint32_t>(it), true);
   }
   buffer.encode_bool(5, this->legacy_supports_brightness);
   buffer.encode_bool(6, this->legacy_supports_rgb);
@@ -1060,7 +1060,7 @@ void ListEntitiesLightResponse::encode(ProtoWriteBuffer buffer) const {
   }
   buffer.encode_bool(13, this->disabled_by_default);
   buffer.encode_string(14, this->icon);
-  buffer.encode_enum_uint32(15, static_cast<uint32_t>(this->entity_category));
+  buffer.encode_uint32(15, static_cast<uint32_t>(this->entity_category));
   buffer.encode_uint32(16, this->device_id);
 }
 void ListEntitiesLightResponse::calculate_size(uint32_t &total_size) const {
@@ -1167,7 +1167,7 @@ void LightStateResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_fixed32(1, this->key);
   buffer.encode_bool(2, this->state);
   buffer.encode_float(3, this->brightness);
-  buffer.encode_enum_uint32(11, static_cast<uint32_t>(this->color_mode));
+  buffer.encode_uint32(11, static_cast<uint32_t>(this->color_mode));
   buffer.encode_float(10, this->color_brightness);
   buffer.encode_float(4, this->red);
   buffer.encode_float(5, this->green);
@@ -1332,7 +1332,7 @@ void LightCommandRequest::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_bool(4, this->has_brightness);
   buffer.encode_float(5, this->brightness);
   buffer.encode_bool(22, this->has_color_mode);
-  buffer.encode_enum_uint32(23, static_cast<uint32_t>(this->color_mode));
+  buffer.encode_uint32(23, static_cast<uint32_t>(this->color_mode));
   buffer.encode_bool(20, this->has_color_brightness);
   buffer.encode_float(21, this->color_brightness);
   buffer.encode_bool(6, this->has_rgb);
@@ -1471,10 +1471,10 @@ void ListEntitiesSensorResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_int32(7, this->accuracy_decimals);
   buffer.encode_bool(8, this->force_update);
   buffer.encode_string(9, this->device_class);
-  buffer.encode_enum_uint32(10, static_cast<uint32_t>(this->state_class));
-  buffer.encode_enum_uint32(11, static_cast<uint32_t>(this->legacy_last_reset_type));
+  buffer.encode_uint32(10, static_cast<uint32_t>(this->state_class));
+  buffer.encode_uint32(11, static_cast<uint32_t>(this->legacy_last_reset_type));
   buffer.encode_bool(12, this->disabled_by_default);
-  buffer.encode_enum_uint32(13, static_cast<uint32_t>(this->entity_category));
+  buffer.encode_uint32(13, static_cast<uint32_t>(this->entity_category));
   buffer.encode_uint32(14, this->device_id);
 }
 void ListEntitiesSensorResponse::calculate_size(uint32_t &total_size) const {
@@ -1601,7 +1601,7 @@ void ListEntitiesSwitchResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_string(5, this->icon);
   buffer.encode_bool(6, this->assumed_state);
   buffer.encode_bool(7, this->disabled_by_default);
-  buffer.encode_enum_uint32(8, static_cast<uint32_t>(this->entity_category));
+  buffer.encode_uint32(8, static_cast<uint32_t>(this->entity_category));
   buffer.encode_string(9, this->device_class);
   buffer.encode_uint32(10, this->device_id);
 }
@@ -1748,7 +1748,7 @@ void ListEntitiesTextSensorResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_string(4, this->unique_id);
   buffer.encode_string(5, this->icon);
   buffer.encode_bool(6, this->disabled_by_default);
-  buffer.encode_enum_uint32(7, static_cast<uint32_t>(this->entity_category));
+  buffer.encode_uint32(7, static_cast<uint32_t>(this->entity_category));
   buffer.encode_string(8, this->device_class);
   buffer.encode_uint32(9, this->device_id);
 }
@@ -1825,7 +1825,7 @@ bool SubscribeLogsRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
   }
 }
 void SubscribeLogsRequest::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_enum_uint32(1, static_cast<uint32_t>(this->level));
+  buffer.encode_uint32(1, static_cast<uint32_t>(this->level));
   buffer.encode_bool(2, this->dump_config);
 }
 void SubscribeLogsRequest::calculate_size(uint32_t &total_size) const {
@@ -1857,7 +1857,7 @@ bool SubscribeLogsResponse::decode_length(uint32_t field_id, ProtoLengthDelimite
   }
 }
 void SubscribeLogsResponse::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_enum_uint32(1, static_cast<uint32_t>(this->level));
+  buffer.encode_uint32(1, static_cast<uint32_t>(this->level));
   buffer.encode_bytes(3, reinterpret_cast<const uint8_t *>(this->message.data()), this->message.size());
   buffer.encode_bool(4, this->send_failed);
 }
@@ -2073,7 +2073,7 @@ bool ListEntitiesServicesArgument::decode_length(uint32_t field_id, ProtoLengthD
 }
 void ListEntitiesServicesArgument::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_string(1, this->name);
-  buffer.encode_enum_uint32(2, static_cast<uint32_t>(this->type));
+  buffer.encode_uint32(2, static_cast<uint32_t>(this->type));
 }
 void ListEntitiesServicesArgument::calculate_size(uint32_t &total_size) const {
   ProtoSize::add_string_field(total_size, 1, this->name, false);
@@ -2305,7 +2305,7 @@ void ListEntitiesCameraResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_string(4, this->unique_id);
   buffer.encode_bool(5, this->disabled_by_default);
   buffer.encode_string(6, this->icon);
-  buffer.encode_enum_uint32(7, static_cast<uint32_t>(this->entity_category));
+  buffer.encode_uint32(7, static_cast<uint32_t>(this->entity_category));
   buffer.encode_uint32(8, this->device_id);
 }
 void ListEntitiesCameraResponse::calculate_size(uint32_t &total_size) const {
@@ -2518,7 +2518,7 @@ void ListEntitiesClimateResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_bool(5, this->supports_current_temperature);
   buffer.encode_bool(6, this->supports_two_point_target_temperature);
   for (auto &it : this->supported_modes) {
-    buffer.encode_enum_uint32(7, static_cast<uint32_t>(it), true);
+    buffer.encode_uint32(7, static_cast<uint32_t>(it), true);
   }
   buffer.encode_float(8, this->visual_min_temperature);
   buffer.encode_float(9, this->visual_max_temperature);
@@ -2526,23 +2526,23 @@ void ListEntitiesClimateResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_bool(11, this->legacy_supports_away);
   buffer.encode_bool(12, this->supports_action);
   for (auto &it : this->supported_fan_modes) {
-    buffer.encode_enum_uint32(13, static_cast<uint32_t>(it), true);
+    buffer.encode_uint32(13, static_cast<uint32_t>(it), true);
   }
   for (auto &it : this->supported_swing_modes) {
-    buffer.encode_enum_uint32(14, static_cast<uint32_t>(it), true);
+    buffer.encode_uint32(14, static_cast<uint32_t>(it), true);
   }
   for (auto &it : this->supported_custom_fan_modes) {
     buffer.encode_string(15, it, true);
   }
   for (auto &it : this->supported_presets) {
-    buffer.encode_enum_uint32(16, static_cast<uint32_t>(it), true);
+    buffer.encode_uint32(16, static_cast<uint32_t>(it), true);
   }
   for (auto &it : this->supported_custom_presets) {
     buffer.encode_string(17, it, true);
   }
   buffer.encode_bool(18, this->disabled_by_default);
   buffer.encode_string(19, this->icon);
-  buffer.encode_enum_uint32(20, static_cast<uint32_t>(this->entity_category));
+  buffer.encode_uint32(20, static_cast<uint32_t>(this->entity_category));
   buffer.encode_float(21, this->visual_current_temperature_step);
   buffer.encode_bool(22, this->supports_current_humidity);
   buffer.encode_bool(23, this->supports_target_humidity);
@@ -2686,17 +2686,17 @@ bool ClimateStateResponse::decode_32bit(uint32_t field_id, Proto32Bit value) {
 }
 void ClimateStateResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_fixed32(1, this->key);
-  buffer.encode_enum_uint32(2, static_cast<uint32_t>(this->mode));
+  buffer.encode_uint32(2, static_cast<uint32_t>(this->mode));
   buffer.encode_float(3, this->current_temperature);
   buffer.encode_float(4, this->target_temperature);
   buffer.encode_float(5, this->target_temperature_low);
   buffer.encode_float(6, this->target_temperature_high);
   buffer.encode_bool(7, this->unused_legacy_away);
-  buffer.encode_enum_uint32(8, static_cast<uint32_t>(this->action));
-  buffer.encode_enum_uint32(9, static_cast<uint32_t>(this->fan_mode));
-  buffer.encode_enum_uint32(10, static_cast<uint32_t>(this->swing_mode));
+  buffer.encode_uint32(8, static_cast<uint32_t>(this->action));
+  buffer.encode_uint32(9, static_cast<uint32_t>(this->fan_mode));
+  buffer.encode_uint32(10, static_cast<uint32_t>(this->swing_mode));
   buffer.encode_string(11, this->custom_fan_mode);
-  buffer.encode_enum_uint32(12, static_cast<uint32_t>(this->preset));
+  buffer.encode_uint32(12, static_cast<uint32_t>(this->preset));
   buffer.encode_string(13, this->custom_preset);
   buffer.encode_float(14, this->current_humidity);
   buffer.encode_float(15, this->target_humidity);
@@ -2837,7 +2837,7 @@ bool ClimateCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
 void ClimateCommandRequest::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_fixed32(1, this->key);
   buffer.encode_bool(2, this->has_mode);
-  buffer.encode_enum_uint32(3, static_cast<uint32_t>(this->mode));
+  buffer.encode_uint32(3, static_cast<uint32_t>(this->mode));
   buffer.encode_bool(4, this->has_target_temperature);
   buffer.encode_float(5, this->target_temperature);
   buffer.encode_bool(6, this->has_target_temperature_low);
@@ -2847,13 +2847,13 @@ void ClimateCommandRequest::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_bool(10, this->unused_has_legacy_away);
   buffer.encode_bool(11, this->unused_legacy_away);
   buffer.encode_bool(12, this->has_fan_mode);
-  buffer.encode_enum_uint32(13, static_cast<uint32_t>(this->fan_mode));
+  buffer.encode_uint32(13, static_cast<uint32_t>(this->fan_mode));
   buffer.encode_bool(14, this->has_swing_mode);
-  buffer.encode_enum_uint32(15, static_cast<uint32_t>(this->swing_mode));
+  buffer.encode_uint32(15, static_cast<uint32_t>(this->swing_mode));
   buffer.encode_bool(16, this->has_custom_fan_mode);
   buffer.encode_string(17, this->custom_fan_mode);
   buffer.encode_bool(18, this->has_preset);
-  buffer.encode_enum_uint32(19, static_cast<uint32_t>(this->preset));
+  buffer.encode_uint32(19, static_cast<uint32_t>(this->preset));
   buffer.encode_bool(20, this->has_custom_preset);
   buffer.encode_string(21, this->custom_preset);
   buffer.encode_bool(22, this->has_target_humidity);
@@ -2972,9 +2972,9 @@ void ListEntitiesNumberResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_float(7, this->max_value);
   buffer.encode_float(8, this->step);
   buffer.encode_bool(9, this->disabled_by_default);
-  buffer.encode_enum_uint32(10, static_cast<uint32_t>(this->entity_category));
+  buffer.encode_uint32(10, static_cast<uint32_t>(this->entity_category));
   buffer.encode_string(11, this->unit_of_measurement);
-  buffer.encode_enum_uint32(12, static_cast<uint32_t>(this->mode));
+  buffer.encode_uint32(12, static_cast<uint32_t>(this->mode));
   buffer.encode_string(13, this->device_class);
   buffer.encode_uint32(14, this->device_id);
 }
@@ -3134,7 +3134,7 @@ void ListEntitiesSelectResponse::encode(ProtoWriteBuffer buffer) const {
     buffer.encode_string(6, it, true);
   }
   buffer.encode_bool(7, this->disabled_by_default);
-  buffer.encode_enum_uint32(8, static_cast<uint32_t>(this->entity_category));
+  buffer.encode_uint32(8, static_cast<uint32_t>(this->entity_category));
   buffer.encode_uint32(9, this->device_id);
 }
 void ListEntitiesSelectResponse::calculate_size(uint32_t &total_size) const {
@@ -3314,7 +3314,7 @@ void ListEntitiesSirenResponse::encode(ProtoWriteBuffer buffer) const {
   }
   buffer.encode_bool(8, this->supports_duration);
   buffer.encode_bool(9, this->supports_volume);
-  buffer.encode_enum_uint32(10, static_cast<uint32_t>(this->entity_category));
+  buffer.encode_uint32(10, static_cast<uint32_t>(this->entity_category));
   buffer.encode_uint32(11, this->device_id);
 }
 void ListEntitiesSirenResponse::calculate_size(uint32_t &total_size) const {
@@ -3525,7 +3525,7 @@ void ListEntitiesLockResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_string(4, this->unique_id);
   buffer.encode_string(5, this->icon);
   buffer.encode_bool(6, this->disabled_by_default);
-  buffer.encode_enum_uint32(7, static_cast<uint32_t>(this->entity_category));
+  buffer.encode_uint32(7, static_cast<uint32_t>(this->entity_category));
   buffer.encode_bool(8, this->assumed_state);
   buffer.encode_bool(9, this->supports_open);
   buffer.encode_bool(10, this->requires_code);
@@ -3572,7 +3572,7 @@ bool LockStateResponse::decode_32bit(uint32_t field_id, Proto32Bit value) {
 }
 void LockStateResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_fixed32(1, this->key);
-  buffer.encode_enum_uint32(2, static_cast<uint32_t>(this->state));
+  buffer.encode_uint32(2, static_cast<uint32_t>(this->state));
   buffer.encode_uint32(3, this->device_id);
 }
 void LockStateResponse::calculate_size(uint32_t &total_size) const {
@@ -3620,7 +3620,7 @@ bool LockCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
 }
 void LockCommandRequest::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_fixed32(1, this->key);
-  buffer.encode_enum_uint32(2, static_cast<uint32_t>(this->command));
+  buffer.encode_uint32(2, static_cast<uint32_t>(this->command));
   buffer.encode_bool(3, this->has_code);
   buffer.encode_string(4, this->code);
   buffer.encode_uint32(5, this->device_id);
@@ -3695,7 +3695,7 @@ void ListEntitiesButtonResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_string(4, this->unique_id);
   buffer.encode_string(5, this->icon);
   buffer.encode_bool(6, this->disabled_by_default);
-  buffer.encode_enum_uint32(7, static_cast<uint32_t>(this->entity_category));
+  buffer.encode_uint32(7, static_cast<uint32_t>(this->entity_category));
   buffer.encode_string(8, this->device_class);
   buffer.encode_uint32(9, this->device_id);
 }
@@ -3776,7 +3776,7 @@ void MediaPlayerSupportedFormat::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_string(1, this->format);
   buffer.encode_uint32(2, this->sample_rate);
   buffer.encode_uint32(3, this->num_channels);
-  buffer.encode_enum_uint32(4, static_cast<uint32_t>(this->purpose));
+  buffer.encode_uint32(4, static_cast<uint32_t>(this->purpose));
   buffer.encode_uint32(5, this->sample_bytes);
 }
 void MediaPlayerSupportedFormat::calculate_size(uint32_t &total_size) const {
@@ -3852,7 +3852,7 @@ void ListEntitiesMediaPlayerResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_string(4, this->unique_id);
   buffer.encode_string(5, this->icon);
   buffer.encode_bool(6, this->disabled_by_default);
-  buffer.encode_enum_uint32(7, static_cast<uint32_t>(this->entity_category));
+  buffer.encode_uint32(7, static_cast<uint32_t>(this->entity_category));
   buffer.encode_bool(8, this->supports_pause);
   for (auto &it : this->supported_formats) {
     buffer.encode_message(9, it, true);
@@ -3905,7 +3905,7 @@ bool MediaPlayerStateResponse::decode_32bit(uint32_t field_id, Proto32Bit value)
 }
 void MediaPlayerStateResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_fixed32(1, this->key);
-  buffer.encode_enum_uint32(2, static_cast<uint32_t>(this->state));
+  buffer.encode_uint32(2, static_cast<uint32_t>(this->state));
   buffer.encode_float(3, this->volume);
   buffer.encode_bool(4, this->muted);
   buffer.encode_uint32(5, this->device_id);
@@ -3978,7 +3978,7 @@ bool MediaPlayerCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value
 void MediaPlayerCommandRequest::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_fixed32(1, this->key);
   buffer.encode_bool(2, this->has_command);
-  buffer.encode_enum_uint32(3, static_cast<uint32_t>(this->command));
+  buffer.encode_uint32(3, static_cast<uint32_t>(this->command));
   buffer.encode_bool(4, this->has_volume);
   buffer.encode_float(5, this->volume);
   buffer.encode_bool(6, this->has_media_url);
@@ -4210,7 +4210,7 @@ bool BluetoothDeviceRequest::decode_varint(uint32_t field_id, ProtoVarInt value)
 }
 void BluetoothDeviceRequest::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint64(1, this->address);
-  buffer.encode_enum_uint32(2, static_cast<uint32_t>(this->request_type));
+  buffer.encode_uint32(2, static_cast<uint32_t>(this->request_type));
   buffer.encode_bool(3, this->has_address_type);
   buffer.encode_uint32(4, this->address_type);
 }
@@ -4854,8 +4854,8 @@ bool BluetoothScannerStateResponse::decode_varint(uint32_t field_id, ProtoVarInt
   }
 }
 void BluetoothScannerStateResponse::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_enum_uint32(1, static_cast<uint32_t>(this->state));
-  buffer.encode_enum_uint32(2, static_cast<uint32_t>(this->mode));
+  buffer.encode_uint32(1, static_cast<uint32_t>(this->state));
+  buffer.encode_uint32(2, static_cast<uint32_t>(this->mode));
 }
 void BluetoothScannerStateResponse::calculate_size(uint32_t &total_size) const {
   ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->state), false);
@@ -4872,7 +4872,7 @@ bool BluetoothScannerSetModeRequest::decode_varint(uint32_t field_id, ProtoVarIn
   }
 }
 void BluetoothScannerSetModeRequest::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_enum_uint32(1, static_cast<uint32_t>(this->mode));
+  buffer.encode_uint32(1, static_cast<uint32_t>(this->mode));
 }
 void BluetoothScannerSetModeRequest::calculate_size(uint32_t &total_size) const {
   ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->mode), false);
@@ -5047,7 +5047,7 @@ bool VoiceAssistantEventResponse::decode_length(uint32_t field_id, ProtoLengthDe
   }
 }
 void VoiceAssistantEventResponse::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_enum_uint32(1, static_cast<uint32_t>(this->event_type));
+  buffer.encode_uint32(1, static_cast<uint32_t>(this->event_type));
   for (auto &it : this->data) {
     buffer.encode_message(2, it, true);
   }
@@ -5121,7 +5121,7 @@ bool VoiceAssistantTimerEventResponse::decode_length(uint32_t field_id, ProtoLen
   }
 }
 void VoiceAssistantTimerEventResponse::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_enum_uint32(1, static_cast<uint32_t>(this->event_type));
+  buffer.encode_uint32(1, static_cast<uint32_t>(this->event_type));
   buffer.encode_string(2, this->timer_id);
   buffer.encode_string(3, this->name);
   buffer.encode_uint32(4, this->total_seconds);
@@ -5360,7 +5360,7 @@ void ListEntitiesAlarmControlPanelResponse::encode(ProtoWriteBuffer buffer) cons
   buffer.encode_string(4, this->unique_id);
   buffer.encode_string(5, this->icon);
   buffer.encode_bool(6, this->disabled_by_default);
-  buffer.encode_enum_uint32(7, static_cast<uint32_t>(this->entity_category));
+  buffer.encode_uint32(7, static_cast<uint32_t>(this->entity_category));
   buffer.encode_uint32(8, this->supported_features);
   buffer.encode_bool(9, this->requires_code);
   buffer.encode_bool(10, this->requires_code_to_arm);
@@ -5405,7 +5405,7 @@ bool AlarmControlPanelStateResponse::decode_32bit(uint32_t field_id, Proto32Bit 
 }
 void AlarmControlPanelStateResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_fixed32(1, this->key);
-  buffer.encode_enum_uint32(2, static_cast<uint32_t>(this->state));
+  buffer.encode_uint32(2, static_cast<uint32_t>(this->state));
   buffer.encode_uint32(3, this->device_id);
 }
 void AlarmControlPanelStateResponse::calculate_size(uint32_t &total_size) const {
@@ -5449,7 +5449,7 @@ bool AlarmControlPanelCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit
 }
 void AlarmControlPanelCommandRequest::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_fixed32(1, this->key);
-  buffer.encode_enum_uint32(2, static_cast<uint32_t>(this->command));
+  buffer.encode_uint32(2, static_cast<uint32_t>(this->command));
   buffer.encode_string(3, this->code);
   buffer.encode_uint32(4, this->device_id);
 }
@@ -5534,11 +5534,11 @@ void ListEntitiesTextResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_string(4, this->unique_id);
   buffer.encode_string(5, this->icon);
   buffer.encode_bool(6, this->disabled_by_default);
-  buffer.encode_enum_uint32(7, static_cast<uint32_t>(this->entity_category));
+  buffer.encode_uint32(7, static_cast<uint32_t>(this->entity_category));
   buffer.encode_uint32(8, this->min_length);
   buffer.encode_uint32(9, this->max_length);
   buffer.encode_string(10, this->pattern);
-  buffer.encode_enum_uint32(11, static_cast<uint32_t>(this->mode));
+  buffer.encode_uint32(11, static_cast<uint32_t>(this->mode));
   buffer.encode_uint32(12, this->device_id);
 }
 void ListEntitiesTextResponse::calculate_size(uint32_t &total_size) const {
@@ -5700,7 +5700,7 @@ void ListEntitiesDateResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_string(4, this->unique_id);
   buffer.encode_string(5, this->icon);
   buffer.encode_bool(6, this->disabled_by_default);
-  buffer.encode_enum_uint32(7, static_cast<uint32_t>(this->entity_category));
+  buffer.encode_uint32(7, static_cast<uint32_t>(this->entity_category));
   buffer.encode_uint32(8, this->device_id);
 }
 void ListEntitiesDateResponse::calculate_size(uint32_t &total_size) const {
@@ -5870,7 +5870,7 @@ void ListEntitiesTimeResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_string(4, this->unique_id);
   buffer.encode_string(5, this->icon);
   buffer.encode_bool(6, this->disabled_by_default);
-  buffer.encode_enum_uint32(7, static_cast<uint32_t>(this->entity_category));
+  buffer.encode_uint32(7, static_cast<uint32_t>(this->entity_category));
   buffer.encode_uint32(8, this->device_id);
 }
 void ListEntitiesTimeResponse::calculate_size(uint32_t &total_size) const {
@@ -6048,7 +6048,7 @@ void ListEntitiesEventResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_string(4, this->unique_id);
   buffer.encode_string(5, this->icon);
   buffer.encode_bool(6, this->disabled_by_default);
-  buffer.encode_enum_uint32(7, static_cast<uint32_t>(this->entity_category));
+  buffer.encode_uint32(7, static_cast<uint32_t>(this->entity_category));
   buffer.encode_string(8, this->device_class);
   for (auto &it : this->event_types) {
     buffer.encode_string(9, it, true);
@@ -6186,7 +6186,7 @@ void ListEntitiesValveResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_string(4, this->unique_id);
   buffer.encode_string(5, this->icon);
   buffer.encode_bool(6, this->disabled_by_default);
-  buffer.encode_enum_uint32(7, static_cast<uint32_t>(this->entity_category));
+  buffer.encode_uint32(7, static_cast<uint32_t>(this->entity_category));
   buffer.encode_string(8, this->device_class);
   buffer.encode_bool(9, this->assumed_state);
   buffer.encode_bool(10, this->supports_position);
@@ -6238,7 +6238,7 @@ bool ValveStateResponse::decode_32bit(uint32_t field_id, Proto32Bit value) {
 void ValveStateResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_fixed32(1, this->key);
   buffer.encode_float(2, this->position);
-  buffer.encode_enum_uint32(3, static_cast<uint32_t>(this->current_operation));
+  buffer.encode_uint32(3, static_cast<uint32_t>(this->current_operation));
   buffer.encode_uint32(4, this->device_id);
 }
 void ValveStateResponse::calculate_size(uint32_t &total_size) const {
@@ -6352,7 +6352,7 @@ void ListEntitiesDateTimeResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_string(4, this->unique_id);
   buffer.encode_string(5, this->icon);
   buffer.encode_bool(6, this->disabled_by_default);
-  buffer.encode_enum_uint32(7, static_cast<uint32_t>(this->entity_category));
+  buffer.encode_uint32(7, static_cast<uint32_t>(this->entity_category));
   buffer.encode_uint32(8, this->device_id);
 }
 void ListEntitiesDateTimeResponse::calculate_size(uint32_t &total_size) const {
@@ -6502,7 +6502,7 @@ void ListEntitiesUpdateResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_string(4, this->unique_id);
   buffer.encode_string(5, this->icon);
   buffer.encode_bool(6, this->disabled_by_default);
-  buffer.encode_enum_uint32(7, static_cast<uint32_t>(this->entity_category));
+  buffer.encode_uint32(7, static_cast<uint32_t>(this->entity_category));
   buffer.encode_string(8, this->device_class);
   buffer.encode_uint32(9, this->device_id);
 }
@@ -6631,7 +6631,7 @@ bool UpdateCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
 }
 void UpdateCommandRequest::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_fixed32(1, this->key);
-  buffer.encode_enum_uint32(2, static_cast<uint32_t>(this->command));
+  buffer.encode_uint32(2, static_cast<uint32_t>(this->command));
   buffer.encode_uint32(3, this->device_id);
 }
 void UpdateCommandRequest::calculate_size(uint32_t &total_size) const {

--- a/esphome/components/api/api_pb2.cpp
+++ b/esphome/components/api/api_pb2.cpp
@@ -293,12 +293,12 @@ void DeviceInfoResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_string(18, this->bluetooth_mac_address);
   buffer.encode_bool(19, this->api_encryption_supported);
   for (auto &it : this->devices) {
-    buffer.encode_message<DeviceInfo>(20, it, true);
+    buffer.encode_message(20, it, true);
   }
   for (auto &it : this->areas) {
-    buffer.encode_message<AreaInfo>(21, it, true);
+    buffer.encode_message(21, it, true);
   }
-  buffer.encode_message<AreaInfo>(22, this->area);
+  buffer.encode_message(22, this->area);
 }
 void DeviceInfoResponse::calculate_size(uint32_t &total_size) const {
   ProtoSize::add_bool_field(total_size, 1, this->uses_password, false);
@@ -1953,13 +1953,13 @@ bool HomeassistantServiceResponse::decode_length(uint32_t field_id, ProtoLengthD
 void HomeassistantServiceResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_string(1, this->service);
   for (auto &it : this->data) {
-    buffer.encode_message<HomeassistantServiceMap>(2, it, true);
+    buffer.encode_message(2, it, true);
   }
   for (auto &it : this->data_template) {
-    buffer.encode_message<HomeassistantServiceMap>(3, it, true);
+    buffer.encode_message(3, it, true);
   }
   for (auto &it : this->variables) {
-    buffer.encode_message<HomeassistantServiceMap>(4, it, true);
+    buffer.encode_message(4, it, true);
   }
   buffer.encode_bool(5, this->is_event);
 }
@@ -2102,7 +2102,7 @@ void ListEntitiesServicesResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_string(1, this->name);
   buffer.encode_fixed32(2, this->key);
   for (auto &it : this->args) {
-    buffer.encode_message<ListEntitiesServicesArgument>(3, it, true);
+    buffer.encode_message(3, it, true);
   }
 }
 void ListEntitiesServicesResponse::calculate_size(uint32_t &total_size) const {
@@ -2233,7 +2233,7 @@ bool ExecuteServiceRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
 void ExecuteServiceRequest::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_fixed32(1, this->key);
   for (auto &it : this->args) {
-    buffer.encode_message<ExecuteServiceArgument>(2, it, true);
+    buffer.encode_message(2, it, true);
   }
 }
 void ExecuteServiceRequest::calculate_size(uint32_t &total_size) const {
@@ -3847,7 +3847,7 @@ void ListEntitiesMediaPlayerResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_enum_uint32(7, static_cast<uint32_t>(this->entity_category));
   buffer.encode_bool(8, this->supports_pause);
   for (auto &it : this->supported_formats) {
-    buffer.encode_message<MediaPlayerSupportedFormat>(9, it, true);
+    buffer.encode_message(9, it, true);
   }
   buffer.encode_uint32(10, this->device_id);
 }
@@ -4097,10 +4097,10 @@ void BluetoothLEAdvertisementResponse::encode(ProtoWriteBuffer buffer) const {
     buffer.encode_string(4, it, true);
   }
   for (auto &it : this->service_data) {
-    buffer.encode_message<BluetoothServiceData>(5, it, true);
+    buffer.encode_message(5, it, true);
   }
   for (auto &it : this->manufacturer_data) {
-    buffer.encode_message<BluetoothServiceData>(6, it, true);
+    buffer.encode_message(6, it, true);
   }
   buffer.encode_uint32(7, this->address_type);
 }
@@ -4169,7 +4169,7 @@ bool BluetoothLERawAdvertisementsResponse::decode_length(uint32_t field_id, Prot
 }
 void BluetoothLERawAdvertisementsResponse::encode(ProtoWriteBuffer buffer) const {
   for (auto &it : this->advertisements) {
-    buffer.encode_message<BluetoothLERawAdvertisement>(1, it, true);
+    buffer.encode_message(1, it, true);
   }
 }
 void BluetoothLERawAdvertisementsResponse::calculate_size(uint32_t &total_size) const {
@@ -4320,7 +4320,7 @@ void BluetoothGATTCharacteristic::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint32(2, this->handle);
   buffer.encode_uint32(3, this->properties);
   for (auto &it : this->descriptors) {
-    buffer.encode_message<BluetoothGATTDescriptor>(4, it, true);
+    buffer.encode_message(4, it, true);
   }
 }
 void BluetoothGATTCharacteristic::calculate_size(uint32_t &total_size) const {
@@ -4363,7 +4363,7 @@ void BluetoothGATTService::encode(ProtoWriteBuffer buffer) const {
   }
   buffer.encode_uint32(2, this->handle);
   for (auto &it : this->characteristics) {
-    buffer.encode_message<BluetoothGATTCharacteristic>(3, it, true);
+    buffer.encode_message(3, it, true);
   }
 }
 void BluetoothGATTService::calculate_size(uint32_t &total_size) const {
@@ -4398,7 +4398,7 @@ bool BluetoothGATTGetServicesResponse::decode_length(uint32_t field_id, ProtoLen
 void BluetoothGATTGetServicesResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint64(1, this->address);
   for (auto &it : this->services) {
-    buffer.encode_message<BluetoothGATTService>(2, it, true);
+    buffer.encode_message(2, it, true);
   }
 }
 void BluetoothGATTGetServicesResponse::calculate_size(uint32_t &total_size) const {
@@ -4957,7 +4957,7 @@ void VoiceAssistantRequest::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_bool(1, this->start);
   buffer.encode_string(2, this->conversation_id);
   buffer.encode_uint32(3, this->flags);
-  buffer.encode_message<VoiceAssistantAudioSettings>(4, this->audio_settings);
+  buffer.encode_message(4, this->audio_settings);
   buffer.encode_string(5, this->wake_word_phrase);
 }
 void VoiceAssistantRequest::calculate_size(uint32_t &total_size) const {
@@ -5034,7 +5034,7 @@ bool VoiceAssistantEventResponse::decode_length(uint32_t field_id, ProtoLengthDe
 void VoiceAssistantEventResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_enum_uint32(1, static_cast<uint32_t>(this->event_type));
   for (auto &it : this->data) {
-    buffer.encode_message<VoiceAssistantEventData>(2, it, true);
+    buffer.encode_message(2, it, true);
   }
 }
 void VoiceAssistantEventResponse::calculate_size(uint32_t &total_size) const {
@@ -5235,7 +5235,7 @@ bool VoiceAssistantConfigurationResponse::decode_length(uint32_t field_id, Proto
 }
 void VoiceAssistantConfigurationResponse::encode(ProtoWriteBuffer buffer) const {
   for (auto &it : this->available_wake_words) {
-    buffer.encode_message<VoiceAssistantWakeWord>(1, it, true);
+    buffer.encode_message(1, it, true);
   }
   for (auto &it : this->active_wake_words) {
     buffer.encode_string(2, it, true);

--- a/esphome/components/api/api_pb2.cpp
+++ b/esphome/components/api/api_pb2.cpp
@@ -336,7 +336,7 @@ bool ListEntitiesBinarySensorResponse::decode_varint(uint32_t field_id, ProtoVar
       return true;
     }
     case 9: {
-      this->entity_category = value.as_enum<enums::EntityCategory>();
+      this->entity_category = static_cast<enums::EntityCategory>(value.as_uint32());
       return true;
     }
     case 10: {
@@ -392,7 +392,7 @@ void ListEntitiesBinarySensorResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_bool(6, this->is_status_binary_sensor);
   buffer.encode_bool(7, this->disabled_by_default);
   buffer.encode_string(8, this->icon);
-  buffer.encode_enum<enums::EntityCategory>(9, this->entity_category);
+  buffer.encode_enum_uint32(9, static_cast<uint32_t>(this->entity_category));
   buffer.encode_uint32(10, this->device_id);
 }
 void ListEntitiesBinarySensorResponse::calculate_size(uint32_t &total_size) const {
@@ -468,7 +468,7 @@ bool ListEntitiesCoverResponse::decode_varint(uint32_t field_id, ProtoVarInt val
       return true;
     }
     case 11: {
-      this->entity_category = value.as_enum<enums::EntityCategory>();
+      this->entity_category = static_cast<enums::EntityCategory>(value.as_uint32());
       return true;
     }
     case 12: {
@@ -530,7 +530,7 @@ void ListEntitiesCoverResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_string(8, this->device_class);
   buffer.encode_bool(9, this->disabled_by_default);
   buffer.encode_string(10, this->icon);
-  buffer.encode_enum<enums::EntityCategory>(11, this->entity_category);
+  buffer.encode_enum_uint32(11, static_cast<uint32_t>(this->entity_category));
   buffer.encode_bool(12, this->supports_stop);
   buffer.encode_uint32(13, this->device_id);
 }
@@ -552,11 +552,11 @@ void ListEntitiesCoverResponse::calculate_size(uint32_t &total_size) const {
 bool CoverStateResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 2: {
-      this->legacy_state = value.as_enum<enums::LegacyCoverState>();
+      this->legacy_state = static_cast<enums::LegacyCoverState>(value.as_uint32());
       return true;
     }
     case 5: {
-      this->current_operation = value.as_enum<enums::CoverOperation>();
+      this->current_operation = static_cast<enums::CoverOperation>(value.as_uint32());
       return true;
     }
     case 6: {
@@ -587,10 +587,10 @@ bool CoverStateResponse::decode_32bit(uint32_t field_id, Proto32Bit value) {
 }
 void CoverStateResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_fixed32(1, this->key);
-  buffer.encode_enum<enums::LegacyCoverState>(2, this->legacy_state);
+  buffer.encode_enum_uint32(2, static_cast<uint32_t>(this->legacy_state));
   buffer.encode_float(3, this->position);
   buffer.encode_float(4, this->tilt);
-  buffer.encode_enum<enums::CoverOperation>(5, this->current_operation);
+  buffer.encode_enum_uint32(5, static_cast<uint32_t>(this->current_operation));
   buffer.encode_uint32(6, this->device_id);
 }
 void CoverStateResponse::calculate_size(uint32_t &total_size) const {
@@ -608,7 +608,7 @@ bool CoverCommandRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
       return true;
     }
     case 3: {
-      this->legacy_command = value.as_enum<enums::LegacyCoverCommand>();
+      this->legacy_command = static_cast<enums::LegacyCoverCommand>(value.as_uint32());
       return true;
     }
     case 4: {
@@ -652,7 +652,7 @@ bool CoverCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
 void CoverCommandRequest::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_fixed32(1, this->key);
   buffer.encode_bool(2, this->has_legacy_command);
-  buffer.encode_enum<enums::LegacyCoverCommand>(3, this->legacy_command);
+  buffer.encode_enum_uint32(3, static_cast<uint32_t>(this->legacy_command));
   buffer.encode_bool(4, this->has_position);
   buffer.encode_float(5, this->position);
   buffer.encode_bool(6, this->has_tilt);
@@ -696,7 +696,7 @@ bool ListEntitiesFanResponse::decode_varint(uint32_t field_id, ProtoVarInt value
       return true;
     }
     case 11: {
-      this->entity_category = value.as_enum<enums::EntityCategory>();
+      this->entity_category = static_cast<enums::EntityCategory>(value.as_uint32());
       return true;
     }
     case 13: {
@@ -754,7 +754,7 @@ void ListEntitiesFanResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_int32(8, this->supported_speed_count);
   buffer.encode_bool(9, this->disabled_by_default);
   buffer.encode_string(10, this->icon);
-  buffer.encode_enum<enums::EntityCategory>(11, this->entity_category);
+  buffer.encode_enum_uint32(11, static_cast<uint32_t>(this->entity_category));
   for (auto &it : this->supported_preset_modes) {
     buffer.encode_string(12, it, true);
   }
@@ -790,11 +790,11 @@ bool FanStateResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
       return true;
     }
     case 4: {
-      this->speed = value.as_enum<enums::FanSpeed>();
+      this->speed = static_cast<enums::FanSpeed>(value.as_uint32());
       return true;
     }
     case 5: {
-      this->direction = value.as_enum<enums::FanDirection>();
+      this->direction = static_cast<enums::FanDirection>(value.as_uint32());
       return true;
     }
     case 6: {
@@ -833,8 +833,8 @@ void FanStateResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_fixed32(1, this->key);
   buffer.encode_bool(2, this->state);
   buffer.encode_bool(3, this->oscillating);
-  buffer.encode_enum<enums::FanSpeed>(4, this->speed);
-  buffer.encode_enum<enums::FanDirection>(5, this->direction);
+  buffer.encode_enum_uint32(4, static_cast<uint32_t>(this->speed));
+  buffer.encode_enum_uint32(5, static_cast<uint32_t>(this->direction));
   buffer.encode_int32(6, this->speed_level);
   buffer.encode_string(7, this->preset_mode);
   buffer.encode_uint32(8, this->device_id);
@@ -864,7 +864,7 @@ bool FanCommandRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
       return true;
     }
     case 5: {
-      this->speed = value.as_enum<enums::FanSpeed>();
+      this->speed = static_cast<enums::FanSpeed>(value.as_uint32());
       return true;
     }
     case 6: {
@@ -880,7 +880,7 @@ bool FanCommandRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
       return true;
     }
     case 9: {
-      this->direction = value.as_enum<enums::FanDirection>();
+      this->direction = static_cast<enums::FanDirection>(value.as_uint32());
       return true;
     }
     case 10: {
@@ -928,11 +928,11 @@ void FanCommandRequest::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_bool(2, this->has_state);
   buffer.encode_bool(3, this->state);
   buffer.encode_bool(4, this->has_speed);
-  buffer.encode_enum<enums::FanSpeed>(5, this->speed);
+  buffer.encode_enum_uint32(5, static_cast<uint32_t>(this->speed));
   buffer.encode_bool(6, this->has_oscillating);
   buffer.encode_bool(7, this->oscillating);
   buffer.encode_bool(8, this->has_direction);
-  buffer.encode_enum<enums::FanDirection>(9, this->direction);
+  buffer.encode_enum_uint32(9, static_cast<uint32_t>(this->direction));
   buffer.encode_bool(10, this->has_speed_level);
   buffer.encode_int32(11, this->speed_level);
   buffer.encode_bool(12, this->has_preset_mode);
@@ -960,7 +960,7 @@ void FanCommandRequest::calculate_size(uint32_t &total_size) const {
 bool ListEntitiesLightResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 12: {
-      this->supported_color_modes.push_back(value.as_enum<enums::ColorMode>());
+      this->supported_color_modes.push_back(static_cast<enums::ColorMode>(value.as_uint32()));
       return true;
     }
     case 5: {
@@ -984,7 +984,7 @@ bool ListEntitiesLightResponse::decode_varint(uint32_t field_id, ProtoVarInt val
       return true;
     }
     case 15: {
-      this->entity_category = value.as_enum<enums::EntityCategory>();
+      this->entity_category = static_cast<enums::EntityCategory>(value.as_uint32());
       return true;
     }
     case 16: {
@@ -1045,7 +1045,7 @@ void ListEntitiesLightResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_string(3, this->name);
   buffer.encode_string(4, this->unique_id);
   for (auto &it : this->supported_color_modes) {
-    buffer.encode_enum<enums::ColorMode>(12, it, true);
+    buffer.encode_enum_uint32(12, static_cast<uint32_t>(it), true);
   }
   buffer.encode_bool(5, this->legacy_supports_brightness);
   buffer.encode_bool(6, this->legacy_supports_rgb);
@@ -1058,7 +1058,7 @@ void ListEntitiesLightResponse::encode(ProtoWriteBuffer buffer) const {
   }
   buffer.encode_bool(13, this->disabled_by_default);
   buffer.encode_string(14, this->icon);
-  buffer.encode_enum<enums::EntityCategory>(15, this->entity_category);
+  buffer.encode_enum_uint32(15, static_cast<uint32_t>(this->entity_category));
   buffer.encode_uint32(16, this->device_id);
 }
 void ListEntitiesLightResponse::calculate_size(uint32_t &total_size) const {
@@ -1094,7 +1094,7 @@ bool LightStateResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
       return true;
     }
     case 11: {
-      this->color_mode = value.as_enum<enums::ColorMode>();
+      this->color_mode = static_cast<enums::ColorMode>(value.as_uint32());
       return true;
     }
     case 14: {
@@ -1165,7 +1165,7 @@ void LightStateResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_fixed32(1, this->key);
   buffer.encode_bool(2, this->state);
   buffer.encode_float(3, this->brightness);
-  buffer.encode_enum<enums::ColorMode>(11, this->color_mode);
+  buffer.encode_enum_uint32(11, static_cast<uint32_t>(this->color_mode));
   buffer.encode_float(10, this->color_brightness);
   buffer.encode_float(4, this->red);
   buffer.encode_float(5, this->green);
@@ -1212,7 +1212,7 @@ bool LightCommandRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
       return true;
     }
     case 23: {
-      this->color_mode = value.as_enum<enums::ColorMode>();
+      this->color_mode = static_cast<enums::ColorMode>(value.as_uint32());
       return true;
     }
     case 20: {
@@ -1330,7 +1330,7 @@ void LightCommandRequest::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_bool(4, this->has_brightness);
   buffer.encode_float(5, this->brightness);
   buffer.encode_bool(22, this->has_color_mode);
-  buffer.encode_enum<enums::ColorMode>(23, this->color_mode);
+  buffer.encode_enum_uint32(23, static_cast<uint32_t>(this->color_mode));
   buffer.encode_bool(20, this->has_color_brightness);
   buffer.encode_float(21, this->color_brightness);
   buffer.encode_bool(6, this->has_rgb);
@@ -1396,11 +1396,11 @@ bool ListEntitiesSensorResponse::decode_varint(uint32_t field_id, ProtoVarInt va
       return true;
     }
     case 10: {
-      this->state_class = value.as_enum<enums::SensorStateClass>();
+      this->state_class = static_cast<enums::SensorStateClass>(value.as_uint32());
       return true;
     }
     case 11: {
-      this->legacy_last_reset_type = value.as_enum<enums::SensorLastResetType>();
+      this->legacy_last_reset_type = static_cast<enums::SensorLastResetType>(value.as_uint32());
       return true;
     }
     case 12: {
@@ -1408,7 +1408,7 @@ bool ListEntitiesSensorResponse::decode_varint(uint32_t field_id, ProtoVarInt va
       return true;
     }
     case 13: {
-      this->entity_category = value.as_enum<enums::EntityCategory>();
+      this->entity_category = static_cast<enums::EntityCategory>(value.as_uint32());
       return true;
     }
     case 14: {
@@ -1469,10 +1469,10 @@ void ListEntitiesSensorResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_int32(7, this->accuracy_decimals);
   buffer.encode_bool(8, this->force_update);
   buffer.encode_string(9, this->device_class);
-  buffer.encode_enum<enums::SensorStateClass>(10, this->state_class);
-  buffer.encode_enum<enums::SensorLastResetType>(11, this->legacy_last_reset_type);
+  buffer.encode_enum_uint32(10, static_cast<uint32_t>(this->state_class));
+  buffer.encode_enum_uint32(11, static_cast<uint32_t>(this->legacy_last_reset_type));
   buffer.encode_bool(12, this->disabled_by_default);
-  buffer.encode_enum<enums::EntityCategory>(13, this->entity_category);
+  buffer.encode_enum_uint32(13, static_cast<uint32_t>(this->entity_category));
   buffer.encode_uint32(14, this->device_id);
 }
 void ListEntitiesSensorResponse::calculate_size(uint32_t &total_size) const {
@@ -1544,7 +1544,7 @@ bool ListEntitiesSwitchResponse::decode_varint(uint32_t field_id, ProtoVarInt va
       return true;
     }
     case 8: {
-      this->entity_category = value.as_enum<enums::EntityCategory>();
+      this->entity_category = static_cast<enums::EntityCategory>(value.as_uint32());
       return true;
     }
     case 10: {
@@ -1599,7 +1599,7 @@ void ListEntitiesSwitchResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_string(5, this->icon);
   buffer.encode_bool(6, this->assumed_state);
   buffer.encode_bool(7, this->disabled_by_default);
-  buffer.encode_enum<enums::EntityCategory>(8, this->entity_category);
+  buffer.encode_enum_uint32(8, static_cast<uint32_t>(this->entity_category));
   buffer.encode_string(9, this->device_class);
   buffer.encode_uint32(10, this->device_id);
 }
@@ -1692,7 +1692,7 @@ bool ListEntitiesTextSensorResponse::decode_varint(uint32_t field_id, ProtoVarIn
       return true;
     }
     case 7: {
-      this->entity_category = value.as_enum<enums::EntityCategory>();
+      this->entity_category = static_cast<enums::EntityCategory>(value.as_uint32());
       return true;
     }
     case 9: {
@@ -1746,7 +1746,7 @@ void ListEntitiesTextSensorResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_string(4, this->unique_id);
   buffer.encode_string(5, this->icon);
   buffer.encode_bool(6, this->disabled_by_default);
-  buffer.encode_enum<enums::EntityCategory>(7, this->entity_category);
+  buffer.encode_enum_uint32(7, static_cast<uint32_t>(this->entity_category));
   buffer.encode_string(8, this->device_class);
   buffer.encode_uint32(9, this->device_id);
 }
@@ -1811,7 +1811,7 @@ void TextSensorStateResponse::calculate_size(uint32_t &total_size) const {
 bool SubscribeLogsRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 1: {
-      this->level = value.as_enum<enums::LogLevel>();
+      this->level = static_cast<enums::LogLevel>(value.as_uint32());
       return true;
     }
     case 2: {
@@ -1823,7 +1823,7 @@ bool SubscribeLogsRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
   }
 }
 void SubscribeLogsRequest::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_enum<enums::LogLevel>(1, this->level);
+  buffer.encode_enum_uint32(1, static_cast<uint32_t>(this->level));
   buffer.encode_bool(2, this->dump_config);
 }
 void SubscribeLogsRequest::calculate_size(uint32_t &total_size) const {
@@ -1833,7 +1833,7 @@ void SubscribeLogsRequest::calculate_size(uint32_t &total_size) const {
 bool SubscribeLogsResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 1: {
-      this->level = value.as_enum<enums::LogLevel>();
+      this->level = static_cast<enums::LogLevel>(value.as_uint32());
       return true;
     }
     case 4: {
@@ -1855,7 +1855,7 @@ bool SubscribeLogsResponse::decode_length(uint32_t field_id, ProtoLengthDelimite
   }
 }
 void SubscribeLogsResponse::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_enum<enums::LogLevel>(1, this->level);
+  buffer.encode_enum_uint32(1, static_cast<uint32_t>(this->level));
   buffer.encode_bytes(3, reinterpret_cast<const uint8_t *>(this->message.data()), this->message.size());
   buffer.encode_bool(4, this->send_failed);
 }
@@ -2049,7 +2049,7 @@ void GetTimeResponse::calculate_size(uint32_t &total_size) const {
 bool ListEntitiesServicesArgument::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 2: {
-      this->type = value.as_enum<enums::ServiceArgType>();
+      this->type = static_cast<enums::ServiceArgType>(value.as_uint32());
       return true;
     }
     default:
@@ -2068,7 +2068,7 @@ bool ListEntitiesServicesArgument::decode_length(uint32_t field_id, ProtoLengthD
 }
 void ListEntitiesServicesArgument::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_string(1, this->name);
-  buffer.encode_enum<enums::ServiceArgType>(2, this->type);
+  buffer.encode_enum_uint32(2, static_cast<uint32_t>(this->type));
 }
 void ListEntitiesServicesArgument::calculate_size(uint32_t &total_size) const {
   ProtoSize::add_string_field(total_size, 1, this->name, false);
@@ -2248,7 +2248,7 @@ bool ListEntitiesCameraResponse::decode_varint(uint32_t field_id, ProtoVarInt va
       return true;
     }
     case 7: {
-      this->entity_category = value.as_enum<enums::EntityCategory>();
+      this->entity_category = static_cast<enums::EntityCategory>(value.as_uint32());
       return true;
     }
     case 8: {
@@ -2298,7 +2298,7 @@ void ListEntitiesCameraResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_string(4, this->unique_id);
   buffer.encode_bool(5, this->disabled_by_default);
   buffer.encode_string(6, this->icon);
-  buffer.encode_enum<enums::EntityCategory>(7, this->entity_category);
+  buffer.encode_enum_uint32(7, static_cast<uint32_t>(this->entity_category));
   buffer.encode_uint32(8, this->device_id);
 }
 void ListEntitiesCameraResponse::calculate_size(uint32_t &total_size) const {
@@ -2392,7 +2392,7 @@ bool ListEntitiesClimateResponse::decode_varint(uint32_t field_id, ProtoVarInt v
       return true;
     }
     case 7: {
-      this->supported_modes.push_back(value.as_enum<enums::ClimateMode>());
+      this->supported_modes.push_back(static_cast<enums::ClimateMode>(value.as_uint32()));
       return true;
     }
     case 11: {
@@ -2404,15 +2404,15 @@ bool ListEntitiesClimateResponse::decode_varint(uint32_t field_id, ProtoVarInt v
       return true;
     }
     case 13: {
-      this->supported_fan_modes.push_back(value.as_enum<enums::ClimateFanMode>());
+      this->supported_fan_modes.push_back(static_cast<enums::ClimateFanMode>(value.as_uint32()));
       return true;
     }
     case 14: {
-      this->supported_swing_modes.push_back(value.as_enum<enums::ClimateSwingMode>());
+      this->supported_swing_modes.push_back(static_cast<enums::ClimateSwingMode>(value.as_uint32()));
       return true;
     }
     case 16: {
-      this->supported_presets.push_back(value.as_enum<enums::ClimatePreset>());
+      this->supported_presets.push_back(static_cast<enums::ClimatePreset>(value.as_uint32()));
       return true;
     }
     case 18: {
@@ -2420,7 +2420,7 @@ bool ListEntitiesClimateResponse::decode_varint(uint32_t field_id, ProtoVarInt v
       return true;
     }
     case 20: {
-      this->entity_category = value.as_enum<enums::EntityCategory>();
+      this->entity_category = static_cast<enums::EntityCategory>(value.as_uint32());
       return true;
     }
     case 22: {
@@ -2511,7 +2511,7 @@ void ListEntitiesClimateResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_bool(5, this->supports_current_temperature);
   buffer.encode_bool(6, this->supports_two_point_target_temperature);
   for (auto &it : this->supported_modes) {
-    buffer.encode_enum<enums::ClimateMode>(7, it, true);
+    buffer.encode_enum_uint32(7, static_cast<uint32_t>(it), true);
   }
   buffer.encode_float(8, this->visual_min_temperature);
   buffer.encode_float(9, this->visual_max_temperature);
@@ -2519,23 +2519,23 @@ void ListEntitiesClimateResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_bool(11, this->legacy_supports_away);
   buffer.encode_bool(12, this->supports_action);
   for (auto &it : this->supported_fan_modes) {
-    buffer.encode_enum<enums::ClimateFanMode>(13, it, true);
+    buffer.encode_enum_uint32(13, static_cast<uint32_t>(it), true);
   }
   for (auto &it : this->supported_swing_modes) {
-    buffer.encode_enum<enums::ClimateSwingMode>(14, it, true);
+    buffer.encode_enum_uint32(14, static_cast<uint32_t>(it), true);
   }
   for (auto &it : this->supported_custom_fan_modes) {
     buffer.encode_string(15, it, true);
   }
   for (auto &it : this->supported_presets) {
-    buffer.encode_enum<enums::ClimatePreset>(16, it, true);
+    buffer.encode_enum_uint32(16, static_cast<uint32_t>(it), true);
   }
   for (auto &it : this->supported_custom_presets) {
     buffer.encode_string(17, it, true);
   }
   buffer.encode_bool(18, this->disabled_by_default);
   buffer.encode_string(19, this->icon);
-  buffer.encode_enum<enums::EntityCategory>(20, this->entity_category);
+  buffer.encode_enum_uint32(20, static_cast<uint32_t>(this->entity_category));
   buffer.encode_float(21, this->visual_current_temperature_step);
   buffer.encode_bool(22, this->supports_current_humidity);
   buffer.encode_bool(23, this->supports_target_humidity);
@@ -2598,7 +2598,7 @@ void ListEntitiesClimateResponse::calculate_size(uint32_t &total_size) const {
 bool ClimateStateResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 2: {
-      this->mode = value.as_enum<enums::ClimateMode>();
+      this->mode = static_cast<enums::ClimateMode>(value.as_uint32());
       return true;
     }
     case 7: {
@@ -2606,19 +2606,19 @@ bool ClimateStateResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
       return true;
     }
     case 8: {
-      this->action = value.as_enum<enums::ClimateAction>();
+      this->action = static_cast<enums::ClimateAction>(value.as_uint32());
       return true;
     }
     case 9: {
-      this->fan_mode = value.as_enum<enums::ClimateFanMode>();
+      this->fan_mode = static_cast<enums::ClimateFanMode>(value.as_uint32());
       return true;
     }
     case 10: {
-      this->swing_mode = value.as_enum<enums::ClimateSwingMode>();
+      this->swing_mode = static_cast<enums::ClimateSwingMode>(value.as_uint32());
       return true;
     }
     case 12: {
-      this->preset = value.as_enum<enums::ClimatePreset>();
+      this->preset = static_cast<enums::ClimatePreset>(value.as_uint32());
       return true;
     }
     case 16: {
@@ -2679,17 +2679,17 @@ bool ClimateStateResponse::decode_32bit(uint32_t field_id, Proto32Bit value) {
 }
 void ClimateStateResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_fixed32(1, this->key);
-  buffer.encode_enum<enums::ClimateMode>(2, this->mode);
+  buffer.encode_enum_uint32(2, static_cast<uint32_t>(this->mode));
   buffer.encode_float(3, this->current_temperature);
   buffer.encode_float(4, this->target_temperature);
   buffer.encode_float(5, this->target_temperature_low);
   buffer.encode_float(6, this->target_temperature_high);
   buffer.encode_bool(7, this->unused_legacy_away);
-  buffer.encode_enum<enums::ClimateAction>(8, this->action);
-  buffer.encode_enum<enums::ClimateFanMode>(9, this->fan_mode);
-  buffer.encode_enum<enums::ClimateSwingMode>(10, this->swing_mode);
+  buffer.encode_enum_uint32(8, static_cast<uint32_t>(this->action));
+  buffer.encode_enum_uint32(9, static_cast<uint32_t>(this->fan_mode));
+  buffer.encode_enum_uint32(10, static_cast<uint32_t>(this->swing_mode));
   buffer.encode_string(11, this->custom_fan_mode);
-  buffer.encode_enum<enums::ClimatePreset>(12, this->preset);
+  buffer.encode_enum_uint32(12, static_cast<uint32_t>(this->preset));
   buffer.encode_string(13, this->custom_preset);
   buffer.encode_float(14, this->current_humidity);
   buffer.encode_float(15, this->target_humidity);
@@ -2720,7 +2720,7 @@ bool ClimateCommandRequest::decode_varint(uint32_t field_id, ProtoVarInt value) 
       return true;
     }
     case 3: {
-      this->mode = value.as_enum<enums::ClimateMode>();
+      this->mode = static_cast<enums::ClimateMode>(value.as_uint32());
       return true;
     }
     case 4: {
@@ -2748,7 +2748,7 @@ bool ClimateCommandRequest::decode_varint(uint32_t field_id, ProtoVarInt value) 
       return true;
     }
     case 13: {
-      this->fan_mode = value.as_enum<enums::ClimateFanMode>();
+      this->fan_mode = static_cast<enums::ClimateFanMode>(value.as_uint32());
       return true;
     }
     case 14: {
@@ -2756,7 +2756,7 @@ bool ClimateCommandRequest::decode_varint(uint32_t field_id, ProtoVarInt value) 
       return true;
     }
     case 15: {
-      this->swing_mode = value.as_enum<enums::ClimateSwingMode>();
+      this->swing_mode = static_cast<enums::ClimateSwingMode>(value.as_uint32());
       return true;
     }
     case 16: {
@@ -2768,7 +2768,7 @@ bool ClimateCommandRequest::decode_varint(uint32_t field_id, ProtoVarInt value) 
       return true;
     }
     case 19: {
-      this->preset = value.as_enum<enums::ClimatePreset>();
+      this->preset = static_cast<enums::ClimatePreset>(value.as_uint32());
       return true;
     }
     case 20: {
@@ -2830,7 +2830,7 @@ bool ClimateCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
 void ClimateCommandRequest::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_fixed32(1, this->key);
   buffer.encode_bool(2, this->has_mode);
-  buffer.encode_enum<enums::ClimateMode>(3, this->mode);
+  buffer.encode_enum_uint32(3, static_cast<uint32_t>(this->mode));
   buffer.encode_bool(4, this->has_target_temperature);
   buffer.encode_float(5, this->target_temperature);
   buffer.encode_bool(6, this->has_target_temperature_low);
@@ -2840,13 +2840,13 @@ void ClimateCommandRequest::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_bool(10, this->unused_has_legacy_away);
   buffer.encode_bool(11, this->unused_legacy_away);
   buffer.encode_bool(12, this->has_fan_mode);
-  buffer.encode_enum<enums::ClimateFanMode>(13, this->fan_mode);
+  buffer.encode_enum_uint32(13, static_cast<uint32_t>(this->fan_mode));
   buffer.encode_bool(14, this->has_swing_mode);
-  buffer.encode_enum<enums::ClimateSwingMode>(15, this->swing_mode);
+  buffer.encode_enum_uint32(15, static_cast<uint32_t>(this->swing_mode));
   buffer.encode_bool(16, this->has_custom_fan_mode);
   buffer.encode_string(17, this->custom_fan_mode);
   buffer.encode_bool(18, this->has_preset);
-  buffer.encode_enum<enums::ClimatePreset>(19, this->preset);
+  buffer.encode_enum_uint32(19, static_cast<uint32_t>(this->preset));
   buffer.encode_bool(20, this->has_custom_preset);
   buffer.encode_string(21, this->custom_preset);
   buffer.encode_bool(22, this->has_target_humidity);
@@ -2888,11 +2888,11 @@ bool ListEntitiesNumberResponse::decode_varint(uint32_t field_id, ProtoVarInt va
       return true;
     }
     case 10: {
-      this->entity_category = value.as_enum<enums::EntityCategory>();
+      this->entity_category = static_cast<enums::EntityCategory>(value.as_uint32());
       return true;
     }
     case 12: {
-      this->mode = value.as_enum<enums::NumberMode>();
+      this->mode = static_cast<enums::NumberMode>(value.as_uint32());
       return true;
     }
     case 14: {
@@ -2965,9 +2965,9 @@ void ListEntitiesNumberResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_float(7, this->max_value);
   buffer.encode_float(8, this->step);
   buffer.encode_bool(9, this->disabled_by_default);
-  buffer.encode_enum<enums::EntityCategory>(10, this->entity_category);
+  buffer.encode_enum_uint32(10, static_cast<uint32_t>(this->entity_category));
   buffer.encode_string(11, this->unit_of_measurement);
-  buffer.encode_enum<enums::NumberMode>(12, this->mode);
+  buffer.encode_enum_uint32(12, static_cast<uint32_t>(this->mode));
   buffer.encode_string(13, this->device_class);
   buffer.encode_uint32(14, this->device_id);
 }
@@ -3070,7 +3070,7 @@ bool ListEntitiesSelectResponse::decode_varint(uint32_t field_id, ProtoVarInt va
       return true;
     }
     case 8: {
-      this->entity_category = value.as_enum<enums::EntityCategory>();
+      this->entity_category = static_cast<enums::EntityCategory>(value.as_uint32());
       return true;
     }
     case 9: {
@@ -3127,7 +3127,7 @@ void ListEntitiesSelectResponse::encode(ProtoWriteBuffer buffer) const {
     buffer.encode_string(6, it, true);
   }
   buffer.encode_bool(7, this->disabled_by_default);
-  buffer.encode_enum<enums::EntityCategory>(8, this->entity_category);
+  buffer.encode_enum_uint32(8, static_cast<uint32_t>(this->entity_category));
   buffer.encode_uint32(9, this->device_id);
 }
 void ListEntitiesSelectResponse::calculate_size(uint32_t &total_size) const {
@@ -3248,7 +3248,7 @@ bool ListEntitiesSirenResponse::decode_varint(uint32_t field_id, ProtoVarInt val
       return true;
     }
     case 10: {
-      this->entity_category = value.as_enum<enums::EntityCategory>();
+      this->entity_category = static_cast<enums::EntityCategory>(value.as_uint32());
       return true;
     }
     case 11: {
@@ -3307,7 +3307,7 @@ void ListEntitiesSirenResponse::encode(ProtoWriteBuffer buffer) const {
   }
   buffer.encode_bool(8, this->supports_duration);
   buffer.encode_bool(9, this->supports_volume);
-  buffer.encode_enum<enums::EntityCategory>(10, this->entity_category);
+  buffer.encode_enum_uint32(10, static_cast<uint32_t>(this->entity_category));
   buffer.encode_uint32(11, this->device_id);
 }
 void ListEntitiesSirenResponse::calculate_size(uint32_t &total_size) const {
@@ -3452,7 +3452,7 @@ bool ListEntitiesLockResponse::decode_varint(uint32_t field_id, ProtoVarInt valu
       return true;
     }
     case 7: {
-      this->entity_category = value.as_enum<enums::EntityCategory>();
+      this->entity_category = static_cast<enums::EntityCategory>(value.as_uint32());
       return true;
     }
     case 8: {
@@ -3518,7 +3518,7 @@ void ListEntitiesLockResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_string(4, this->unique_id);
   buffer.encode_string(5, this->icon);
   buffer.encode_bool(6, this->disabled_by_default);
-  buffer.encode_enum<enums::EntityCategory>(7, this->entity_category);
+  buffer.encode_enum_uint32(7, static_cast<uint32_t>(this->entity_category));
   buffer.encode_bool(8, this->assumed_state);
   buffer.encode_bool(9, this->supports_open);
   buffer.encode_bool(10, this->requires_code);
@@ -3542,7 +3542,7 @@ void ListEntitiesLockResponse::calculate_size(uint32_t &total_size) const {
 bool LockStateResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 2: {
-      this->state = value.as_enum<enums::LockState>();
+      this->state = static_cast<enums::LockState>(value.as_uint32());
       return true;
     }
     case 3: {
@@ -3565,7 +3565,7 @@ bool LockStateResponse::decode_32bit(uint32_t field_id, Proto32Bit value) {
 }
 void LockStateResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_fixed32(1, this->key);
-  buffer.encode_enum<enums::LockState>(2, this->state);
+  buffer.encode_enum_uint32(2, static_cast<uint32_t>(this->state));
   buffer.encode_uint32(3, this->device_id);
 }
 void LockStateResponse::calculate_size(uint32_t &total_size) const {
@@ -3576,7 +3576,7 @@ void LockStateResponse::calculate_size(uint32_t &total_size) const {
 bool LockCommandRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 2: {
-      this->command = value.as_enum<enums::LockCommand>();
+      this->command = static_cast<enums::LockCommand>(value.as_uint32());
       return true;
     }
     case 3: {
@@ -3613,7 +3613,7 @@ bool LockCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
 }
 void LockCommandRequest::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_fixed32(1, this->key);
-  buffer.encode_enum<enums::LockCommand>(2, this->command);
+  buffer.encode_enum_uint32(2, static_cast<uint32_t>(this->command));
   buffer.encode_bool(3, this->has_code);
   buffer.encode_string(4, this->code);
   buffer.encode_uint32(5, this->device_id);
@@ -3634,7 +3634,7 @@ bool ListEntitiesButtonResponse::decode_varint(uint32_t field_id, ProtoVarInt va
       return true;
     }
     case 7: {
-      this->entity_category = value.as_enum<enums::EntityCategory>();
+      this->entity_category = static_cast<enums::EntityCategory>(value.as_uint32());
       return true;
     }
     case 9: {
@@ -3688,7 +3688,7 @@ void ListEntitiesButtonResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_string(4, this->unique_id);
   buffer.encode_string(5, this->icon);
   buffer.encode_bool(6, this->disabled_by_default);
-  buffer.encode_enum<enums::EntityCategory>(7, this->entity_category);
+  buffer.encode_enum_uint32(7, static_cast<uint32_t>(this->entity_category));
   buffer.encode_string(8, this->device_class);
   buffer.encode_uint32(9, this->device_id);
 }
@@ -3744,7 +3744,7 @@ bool MediaPlayerSupportedFormat::decode_varint(uint32_t field_id, ProtoVarInt va
       return true;
     }
     case 4: {
-      this->purpose = value.as_enum<enums::MediaPlayerFormatPurpose>();
+      this->purpose = static_cast<enums::MediaPlayerFormatPurpose>(value.as_uint32());
       return true;
     }
     case 5: {
@@ -3769,7 +3769,7 @@ void MediaPlayerSupportedFormat::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_string(1, this->format);
   buffer.encode_uint32(2, this->sample_rate);
   buffer.encode_uint32(3, this->num_channels);
-  buffer.encode_enum<enums::MediaPlayerFormatPurpose>(4, this->purpose);
+  buffer.encode_enum_uint32(4, static_cast<uint32_t>(this->purpose));
   buffer.encode_uint32(5, this->sample_bytes);
 }
 void MediaPlayerSupportedFormat::calculate_size(uint32_t &total_size) const {
@@ -3786,7 +3786,7 @@ bool ListEntitiesMediaPlayerResponse::decode_varint(uint32_t field_id, ProtoVarI
       return true;
     }
     case 7: {
-      this->entity_category = value.as_enum<enums::EntityCategory>();
+      this->entity_category = static_cast<enums::EntityCategory>(value.as_uint32());
       return true;
     }
     case 8: {
@@ -3844,7 +3844,7 @@ void ListEntitiesMediaPlayerResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_string(4, this->unique_id);
   buffer.encode_string(5, this->icon);
   buffer.encode_bool(6, this->disabled_by_default);
-  buffer.encode_enum<enums::EntityCategory>(7, this->entity_category);
+  buffer.encode_enum_uint32(7, static_cast<uint32_t>(this->entity_category));
   buffer.encode_bool(8, this->supports_pause);
   for (auto &it : this->supported_formats) {
     buffer.encode_message<MediaPlayerSupportedFormat>(9, it, true);
@@ -3866,7 +3866,7 @@ void ListEntitiesMediaPlayerResponse::calculate_size(uint32_t &total_size) const
 bool MediaPlayerStateResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 2: {
-      this->state = value.as_enum<enums::MediaPlayerState>();
+      this->state = static_cast<enums::MediaPlayerState>(value.as_uint32());
       return true;
     }
     case 4: {
@@ -3897,7 +3897,7 @@ bool MediaPlayerStateResponse::decode_32bit(uint32_t field_id, Proto32Bit value)
 }
 void MediaPlayerStateResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_fixed32(1, this->key);
-  buffer.encode_enum<enums::MediaPlayerState>(2, this->state);
+  buffer.encode_enum_uint32(2, static_cast<uint32_t>(this->state));
   buffer.encode_float(3, this->volume);
   buffer.encode_bool(4, this->muted);
   buffer.encode_uint32(5, this->device_id);
@@ -3916,7 +3916,7 @@ bool MediaPlayerCommandRequest::decode_varint(uint32_t field_id, ProtoVarInt val
       return true;
     }
     case 3: {
-      this->command = value.as_enum<enums::MediaPlayerCommand>();
+      this->command = static_cast<enums::MediaPlayerCommand>(value.as_uint32());
       return true;
     }
     case 4: {
@@ -3970,7 +3970,7 @@ bool MediaPlayerCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value
 void MediaPlayerCommandRequest::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_fixed32(1, this->key);
   buffer.encode_bool(2, this->has_command);
-  buffer.encode_enum<enums::MediaPlayerCommand>(3, this->command);
+  buffer.encode_enum_uint32(3, static_cast<uint32_t>(this->command));
   buffer.encode_bool(4, this->has_volume);
   buffer.encode_float(5, this->volume);
   buffer.encode_bool(6, this->has_media_url);
@@ -4182,7 +4182,7 @@ bool BluetoothDeviceRequest::decode_varint(uint32_t field_id, ProtoVarInt value)
       return true;
     }
     case 2: {
-      this->request_type = value.as_enum<enums::BluetoothDeviceRequestType>();
+      this->request_type = static_cast<enums::BluetoothDeviceRequestType>(value.as_uint32());
       return true;
     }
     case 3: {
@@ -4199,7 +4199,7 @@ bool BluetoothDeviceRequest::decode_varint(uint32_t field_id, ProtoVarInt value)
 }
 void BluetoothDeviceRequest::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint64(1, this->address);
-  buffer.encode_enum<enums::BluetoothDeviceRequestType>(2, this->request_type);
+  buffer.encode_enum_uint32(2, static_cast<uint32_t>(this->request_type));
   buffer.encode_bool(3, this->has_address_type);
   buffer.encode_uint32(4, this->address_type);
 }
@@ -4828,11 +4828,11 @@ void BluetoothDeviceClearCacheResponse::calculate_size(uint32_t &total_size) con
 bool BluetoothScannerStateResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 1: {
-      this->state = value.as_enum<enums::BluetoothScannerState>();
+      this->state = static_cast<enums::BluetoothScannerState>(value.as_uint32());
       return true;
     }
     case 2: {
-      this->mode = value.as_enum<enums::BluetoothScannerMode>();
+      this->mode = static_cast<enums::BluetoothScannerMode>(value.as_uint32());
       return true;
     }
     default:
@@ -4840,8 +4840,8 @@ bool BluetoothScannerStateResponse::decode_varint(uint32_t field_id, ProtoVarInt
   }
 }
 void BluetoothScannerStateResponse::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_enum<enums::BluetoothScannerState>(1, this->state);
-  buffer.encode_enum<enums::BluetoothScannerMode>(2, this->mode);
+  buffer.encode_enum_uint32(1, static_cast<uint32_t>(this->state));
+  buffer.encode_enum_uint32(2, static_cast<uint32_t>(this->mode));
 }
 void BluetoothScannerStateResponse::calculate_size(uint32_t &total_size) const {
   ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->state), false);
@@ -4850,7 +4850,7 @@ void BluetoothScannerStateResponse::calculate_size(uint32_t &total_size) const {
 bool BluetoothScannerSetModeRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 1: {
-      this->mode = value.as_enum<enums::BluetoothScannerMode>();
+      this->mode = static_cast<enums::BluetoothScannerMode>(value.as_uint32());
       return true;
     }
     default:
@@ -4858,7 +4858,7 @@ bool BluetoothScannerSetModeRequest::decode_varint(uint32_t field_id, ProtoVarIn
   }
 }
 void BluetoothScannerSetModeRequest::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_enum<enums::BluetoothScannerMode>(1, this->mode);
+  buffer.encode_enum_uint32(1, static_cast<uint32_t>(this->mode));
 }
 void BluetoothScannerSetModeRequest::calculate_size(uint32_t &total_size) const {
   ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->mode), false);
@@ -5014,7 +5014,7 @@ void VoiceAssistantEventData::calculate_size(uint32_t &total_size) const {
 bool VoiceAssistantEventResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 1: {
-      this->event_type = value.as_enum<enums::VoiceAssistantEvent>();
+      this->event_type = static_cast<enums::VoiceAssistantEvent>(value.as_uint32());
       return true;
     }
     default:
@@ -5032,7 +5032,7 @@ bool VoiceAssistantEventResponse::decode_length(uint32_t field_id, ProtoLengthDe
   }
 }
 void VoiceAssistantEventResponse::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_enum<enums::VoiceAssistantEvent>(1, this->event_type);
+  buffer.encode_enum_uint32(1, static_cast<uint32_t>(this->event_type));
   for (auto &it : this->data) {
     buffer.encode_message<VoiceAssistantEventData>(2, it, true);
   }
@@ -5072,7 +5072,7 @@ void VoiceAssistantAudio::calculate_size(uint32_t &total_size) const {
 bool VoiceAssistantTimerEventResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 1: {
-      this->event_type = value.as_enum<enums::VoiceAssistantTimerEvent>();
+      this->event_type = static_cast<enums::VoiceAssistantTimerEvent>(value.as_uint32());
       return true;
     }
     case 4: {
@@ -5106,7 +5106,7 @@ bool VoiceAssistantTimerEventResponse::decode_length(uint32_t field_id, ProtoLen
   }
 }
 void VoiceAssistantTimerEventResponse::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_enum<enums::VoiceAssistantTimerEvent>(1, this->event_type);
+  buffer.encode_enum_uint32(1, static_cast<uint32_t>(this->event_type));
   buffer.encode_string(2, this->timer_id);
   buffer.encode_string(3, this->name);
   buffer.encode_uint32(4, this->total_seconds);
@@ -5282,7 +5282,7 @@ bool ListEntitiesAlarmControlPanelResponse::decode_varint(uint32_t field_id, Pro
       return true;
     }
     case 7: {
-      this->entity_category = value.as_enum<enums::EntityCategory>();
+      this->entity_category = static_cast<enums::EntityCategory>(value.as_uint32());
       return true;
     }
     case 8: {
@@ -5344,7 +5344,7 @@ void ListEntitiesAlarmControlPanelResponse::encode(ProtoWriteBuffer buffer) cons
   buffer.encode_string(4, this->unique_id);
   buffer.encode_string(5, this->icon);
   buffer.encode_bool(6, this->disabled_by_default);
-  buffer.encode_enum<enums::EntityCategory>(7, this->entity_category);
+  buffer.encode_enum_uint32(7, static_cast<uint32_t>(this->entity_category));
   buffer.encode_uint32(8, this->supported_features);
   buffer.encode_bool(9, this->requires_code);
   buffer.encode_bool(10, this->requires_code_to_arm);
@@ -5366,7 +5366,7 @@ void ListEntitiesAlarmControlPanelResponse::calculate_size(uint32_t &total_size)
 bool AlarmControlPanelStateResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 2: {
-      this->state = value.as_enum<enums::AlarmControlPanelState>();
+      this->state = static_cast<enums::AlarmControlPanelState>(value.as_uint32());
       return true;
     }
     case 3: {
@@ -5389,7 +5389,7 @@ bool AlarmControlPanelStateResponse::decode_32bit(uint32_t field_id, Proto32Bit 
 }
 void AlarmControlPanelStateResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_fixed32(1, this->key);
-  buffer.encode_enum<enums::AlarmControlPanelState>(2, this->state);
+  buffer.encode_enum_uint32(2, static_cast<uint32_t>(this->state));
   buffer.encode_uint32(3, this->device_id);
 }
 void AlarmControlPanelStateResponse::calculate_size(uint32_t &total_size) const {
@@ -5400,7 +5400,7 @@ void AlarmControlPanelStateResponse::calculate_size(uint32_t &total_size) const 
 bool AlarmControlPanelCommandRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 2: {
-      this->command = value.as_enum<enums::AlarmControlPanelStateCommand>();
+      this->command = static_cast<enums::AlarmControlPanelStateCommand>(value.as_uint32());
       return true;
     }
     case 4: {
@@ -5433,7 +5433,7 @@ bool AlarmControlPanelCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit
 }
 void AlarmControlPanelCommandRequest::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_fixed32(1, this->key);
-  buffer.encode_enum<enums::AlarmControlPanelStateCommand>(2, this->command);
+  buffer.encode_enum_uint32(2, static_cast<uint32_t>(this->command));
   buffer.encode_string(3, this->code);
   buffer.encode_uint32(4, this->device_id);
 }
@@ -5452,7 +5452,7 @@ bool ListEntitiesTextResponse::decode_varint(uint32_t field_id, ProtoVarInt valu
       return true;
     }
     case 7: {
-      this->entity_category = value.as_enum<enums::EntityCategory>();
+      this->entity_category = static_cast<enums::EntityCategory>(value.as_uint32());
       return true;
     }
     case 8: {
@@ -5464,7 +5464,7 @@ bool ListEntitiesTextResponse::decode_varint(uint32_t field_id, ProtoVarInt valu
       return true;
     }
     case 11: {
-      this->mode = value.as_enum<enums::TextMode>();
+      this->mode = static_cast<enums::TextMode>(value.as_uint32());
       return true;
     }
     case 12: {
@@ -5518,11 +5518,11 @@ void ListEntitiesTextResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_string(4, this->unique_id);
   buffer.encode_string(5, this->icon);
   buffer.encode_bool(6, this->disabled_by_default);
-  buffer.encode_enum<enums::EntityCategory>(7, this->entity_category);
+  buffer.encode_enum_uint32(7, static_cast<uint32_t>(this->entity_category));
   buffer.encode_uint32(8, this->min_length);
   buffer.encode_uint32(9, this->max_length);
   buffer.encode_string(10, this->pattern);
-  buffer.encode_enum<enums::TextMode>(11, this->mode);
+  buffer.encode_enum_uint32(11, static_cast<uint32_t>(this->mode));
   buffer.encode_uint32(12, this->device_id);
 }
 void ListEntitiesTextResponse::calculate_size(uint32_t &total_size) const {
@@ -5634,7 +5634,7 @@ bool ListEntitiesDateResponse::decode_varint(uint32_t field_id, ProtoVarInt valu
       return true;
     }
     case 7: {
-      this->entity_category = value.as_enum<enums::EntityCategory>();
+      this->entity_category = static_cast<enums::EntityCategory>(value.as_uint32());
       return true;
     }
     case 8: {
@@ -5684,7 +5684,7 @@ void ListEntitiesDateResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_string(4, this->unique_id);
   buffer.encode_string(5, this->icon);
   buffer.encode_bool(6, this->disabled_by_default);
-  buffer.encode_enum<enums::EntityCategory>(7, this->entity_category);
+  buffer.encode_enum_uint32(7, static_cast<uint32_t>(this->entity_category));
   buffer.encode_uint32(8, this->device_id);
 }
 void ListEntitiesDateResponse::calculate_size(uint32_t &total_size) const {
@@ -5804,7 +5804,7 @@ bool ListEntitiesTimeResponse::decode_varint(uint32_t field_id, ProtoVarInt valu
       return true;
     }
     case 7: {
-      this->entity_category = value.as_enum<enums::EntityCategory>();
+      this->entity_category = static_cast<enums::EntityCategory>(value.as_uint32());
       return true;
     }
     case 8: {
@@ -5854,7 +5854,7 @@ void ListEntitiesTimeResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_string(4, this->unique_id);
   buffer.encode_string(5, this->icon);
   buffer.encode_bool(6, this->disabled_by_default);
-  buffer.encode_enum<enums::EntityCategory>(7, this->entity_category);
+  buffer.encode_enum_uint32(7, static_cast<uint32_t>(this->entity_category));
   buffer.encode_uint32(8, this->device_id);
 }
 void ListEntitiesTimeResponse::calculate_size(uint32_t &total_size) const {
@@ -5974,7 +5974,7 @@ bool ListEntitiesEventResponse::decode_varint(uint32_t field_id, ProtoVarInt val
       return true;
     }
     case 7: {
-      this->entity_category = value.as_enum<enums::EntityCategory>();
+      this->entity_category = static_cast<enums::EntityCategory>(value.as_uint32());
       return true;
     }
     case 10: {
@@ -6032,7 +6032,7 @@ void ListEntitiesEventResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_string(4, this->unique_id);
   buffer.encode_string(5, this->icon);
   buffer.encode_bool(6, this->disabled_by_default);
-  buffer.encode_enum<enums::EntityCategory>(7, this->entity_category);
+  buffer.encode_enum_uint32(7, static_cast<uint32_t>(this->entity_category));
   buffer.encode_string(8, this->device_class);
   for (auto &it : this->event_types) {
     buffer.encode_string(9, it, true);
@@ -6104,7 +6104,7 @@ bool ListEntitiesValveResponse::decode_varint(uint32_t field_id, ProtoVarInt val
       return true;
     }
     case 7: {
-      this->entity_category = value.as_enum<enums::EntityCategory>();
+      this->entity_category = static_cast<enums::EntityCategory>(value.as_uint32());
       return true;
     }
     case 9: {
@@ -6170,7 +6170,7 @@ void ListEntitiesValveResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_string(4, this->unique_id);
   buffer.encode_string(5, this->icon);
   buffer.encode_bool(6, this->disabled_by_default);
-  buffer.encode_enum<enums::EntityCategory>(7, this->entity_category);
+  buffer.encode_enum_uint32(7, static_cast<uint32_t>(this->entity_category));
   buffer.encode_string(8, this->device_class);
   buffer.encode_bool(9, this->assumed_state);
   buffer.encode_bool(10, this->supports_position);
@@ -6194,7 +6194,7 @@ void ListEntitiesValveResponse::calculate_size(uint32_t &total_size) const {
 bool ValveStateResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 3: {
-      this->current_operation = value.as_enum<enums::ValveOperation>();
+      this->current_operation = static_cast<enums::ValveOperation>(value.as_uint32());
       return true;
     }
     case 4: {
@@ -6222,7 +6222,7 @@ bool ValveStateResponse::decode_32bit(uint32_t field_id, Proto32Bit value) {
 void ValveStateResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_fixed32(1, this->key);
   buffer.encode_float(2, this->position);
-  buffer.encode_enum<enums::ValveOperation>(3, this->current_operation);
+  buffer.encode_enum_uint32(3, static_cast<uint32_t>(this->current_operation));
   buffer.encode_uint32(4, this->device_id);
 }
 void ValveStateResponse::calculate_size(uint32_t &total_size) const {
@@ -6286,7 +6286,7 @@ bool ListEntitiesDateTimeResponse::decode_varint(uint32_t field_id, ProtoVarInt 
       return true;
     }
     case 7: {
-      this->entity_category = value.as_enum<enums::EntityCategory>();
+      this->entity_category = static_cast<enums::EntityCategory>(value.as_uint32());
       return true;
     }
     case 8: {
@@ -6336,7 +6336,7 @@ void ListEntitiesDateTimeResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_string(4, this->unique_id);
   buffer.encode_string(5, this->icon);
   buffer.encode_bool(6, this->disabled_by_default);
-  buffer.encode_enum<enums::EntityCategory>(7, this->entity_category);
+  buffer.encode_enum_uint32(7, static_cast<uint32_t>(this->entity_category));
   buffer.encode_uint32(8, this->device_id);
 }
 void ListEntitiesDateTimeResponse::calculate_size(uint32_t &total_size) const {
@@ -6432,7 +6432,7 @@ bool ListEntitiesUpdateResponse::decode_varint(uint32_t field_id, ProtoVarInt va
       return true;
     }
     case 7: {
-      this->entity_category = value.as_enum<enums::EntityCategory>();
+      this->entity_category = static_cast<enums::EntityCategory>(value.as_uint32());
       return true;
     }
     case 9: {
@@ -6486,7 +6486,7 @@ void ListEntitiesUpdateResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_string(4, this->unique_id);
   buffer.encode_string(5, this->icon);
   buffer.encode_bool(6, this->disabled_by_default);
-  buffer.encode_enum<enums::EntityCategory>(7, this->entity_category);
+  buffer.encode_enum_uint32(7, static_cast<uint32_t>(this->entity_category));
   buffer.encode_string(8, this->device_class);
   buffer.encode_uint32(9, this->device_id);
 }
@@ -6592,7 +6592,7 @@ void UpdateStateResponse::calculate_size(uint32_t &total_size) const {
 bool UpdateCommandRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 2: {
-      this->command = value.as_enum<enums::UpdateCommand>();
+      this->command = static_cast<enums::UpdateCommand>(value.as_uint32());
       return true;
     }
     case 3: {
@@ -6615,7 +6615,7 @@ bool UpdateCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
 }
 void UpdateCommandRequest::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_fixed32(1, this->key);
-  buffer.encode_enum<enums::UpdateCommand>(2, this->command);
+  buffer.encode_enum_uint32(2, static_cast<uint32_t>(this->command));
   buffer.encode_uint32(3, this->device_id);
 }
 void UpdateCommandRequest::calculate_size(uint32_t &total_size) const {

--- a/esphome/components/api/proto.h
+++ b/esphome/components/api/proto.h
@@ -133,15 +133,16 @@ class ProtoVarInt {
   uint64_t value_;
 };
 
+// Forward declaration for decode_to_message
+class ProtoMessage;
+
 class ProtoLengthDelimited {
  public:
   explicit ProtoLengthDelimited(const uint8_t *value, size_t length) : value_(value), length_(length) {}
   std::string as_string() const { return std::string(reinterpret_cast<const char *>(this->value_), this->length_); }
-  template<class C> C as_message() const {
-    auto msg = C();
-    msg.decode(this->value_, this->length_);
-    return msg;
-  }
+
+  // Non-template method to decode into an existing message instance
+  void decode_to_message(ProtoMessage &msg) const;
 
  protected:
   const uint8_t *const value_;
@@ -350,6 +351,11 @@ inline void ProtoWriteBuffer::encode_message(uint32_t field_id, const ProtoMessa
   std::vector<uint8_t> var;
   ProtoVarInt(nested_length).encode(var);
   this->buffer_->insert(this->buffer_->begin() + begin, var.begin(), var.end());
+}
+
+// Implementation of decode_to_message - must be after ProtoMessage is defined
+inline void ProtoLengthDelimited::decode_to_message(ProtoMessage &msg) const {
+  msg.decode(this->value_, this->length_);
 }
 
 template<typename T> const char *proto_enum_to_string(T value);

--- a/esphome/components/api/proto.h
+++ b/esphome/components/api/proto.h
@@ -266,10 +266,6 @@ class ProtoWriteBuffer {
     this->write((value >> 48) & 0xFF);
     this->write((value >> 56) & 0xFF);
   }
-  // Non-template version for enum encoding to reduce flash usage
-  void encode_enum_uint32(uint32_t field_id, uint32_t value, bool force = false) {
-    this->encode_uint32(field_id, value, force);
-  }
   void encode_float(uint32_t field_id, float value, bool force = false) {
     if (value == 0.0f && !force)
       return;

--- a/esphome/components/api/proto.h
+++ b/esphome/components/api/proto.h
@@ -59,7 +59,6 @@ class ProtoVarInt {
   uint32_t as_uint32() const { return this->value_; }
   uint64_t as_uint64() const { return this->value_; }
   bool as_bool() const { return this->value_; }
-  // Removed template as_enum - now use as_uint32() directly with static_cast in generated code
   int32_t as_int32() const {
     // Not ZigZag encoded
     return static_cast<int32_t>(this->as_int64());

--- a/esphome/components/api/proto.h
+++ b/esphome/components/api/proto.h
@@ -307,18 +307,7 @@ class ProtoWriteBuffer {
     }
     this->encode_uint64(field_id, uvalue, force);
   }
-  void encode_message(uint32_t field_id, const ProtoMessage &value, bool force = false) {
-    this->encode_field_raw(field_id, 2);  // type 2: Length-delimited message
-    size_t begin = this->buffer_->size();
-
-    value.encode(*this);
-
-    const uint32_t nested_length = this->buffer_->size() - begin;
-    // add size varint
-    std::vector<uint8_t> var;
-    ProtoVarInt(nested_length).encode(var);
-    this->buffer_->insert(this->buffer_->begin() + begin, var.begin(), var.end());
-  }
+  void encode_message(uint32_t field_id, const ProtoMessage &value, bool force = false);
   std::vector<uint8_t> *get_buffer() const { return buffer_; }
 
  protected:
@@ -345,6 +334,20 @@ class ProtoMessage {
   virtual bool decode_32bit(uint32_t field_id, Proto32Bit value) { return false; }
   virtual bool decode_64bit(uint32_t field_id, Proto64Bit value) { return false; }
 };
+
+// Implementation of encode_message - must be after ProtoMessage is defined
+inline void ProtoWriteBuffer::encode_message(uint32_t field_id, const ProtoMessage &value, bool force) {
+  this->encode_field_raw(field_id, 2);  // type 2: Length-delimited message
+  size_t begin = this->buffer_->size();
+
+  value.encode(*this);
+
+  const uint32_t nested_length = this->buffer_->size() - begin;
+  // add size varint
+  std::vector<uint8_t> var;
+  ProtoVarInt(nested_length).encode(var);
+  this->buffer_->insert(this->buffer_->begin() + begin, var.begin(), var.end());
+}
 
 template<typename T> const char *proto_enum_to_string(T value);
 

--- a/esphome/components/api/proto.h
+++ b/esphome/components/api/proto.h
@@ -132,15 +132,20 @@ class ProtoVarInt {
   uint64_t value_;
 };
 
-// Forward declaration for decode_to_message
-class ProtoMessage;
-
 class ProtoLengthDelimited {
  public:
   explicit ProtoLengthDelimited(const uint8_t *value, size_t length) : value_(value), length_(length) {}
   std::string as_string() const { return std::string(reinterpret_cast<const char *>(this->value_), this->length_); }
 
-  // Non-template method to decode into an existing message instance
+  /**
+   * Decode the length-delimited data into an existing ProtoMessage instance.
+   *
+   * This method allows decoding without templates, enabling use in contexts
+   * where the message type is not known at compile time. The ProtoMessage's
+   * decode() method will be called with the raw data and length.
+   *
+   * @param msg The ProtoMessage instance to decode into
+   */
   void decode_to_message(ProtoMessage &msg) const;
 
  protected:

--- a/esphome/components/api/proto.h
+++ b/esphome/components/api/proto.h
@@ -307,7 +307,7 @@ class ProtoWriteBuffer {
     }
     this->encode_uint64(field_id, uvalue, force);
   }
-  template<class C> void encode_message(uint32_t field_id, const C &value, bool force = false) {
+  void encode_message(uint32_t field_id, const ProtoMessage &value, bool force = false) {
     this->encode_field_raw(field_id, 2);  // type 2: Length-delimited message
     size_t begin = this->buffer_->size();
 

--- a/esphome/components/api/proto.h
+++ b/esphome/components/api/proto.h
@@ -184,6 +184,9 @@ class Proto64Bit {
   const uint64_t value_;
 };
 
+// Forward declaration needed for method declaration
+class ProtoMessage;
+
 class ProtoWriteBuffer {
  public:
   ProtoWriteBuffer(std::vector<uint8_t> *buffer) : buffer_(buffer) {}

--- a/esphome/components/api/proto.h
+++ b/esphome/components/api/proto.h
@@ -59,7 +59,7 @@ class ProtoVarInt {
   uint32_t as_uint32() const { return this->value_; }
   uint64_t as_uint64() const { return this->value_; }
   bool as_bool() const { return this->value_; }
-  template<typename T> T as_enum() const { return static_cast<T>(this->as_uint32()); }
+  // Removed template as_enum - now use as_uint32() directly with static_cast in generated code
   int32_t as_int32() const {
     // Not ZigZag encoded
     return static_cast<int32_t>(this->as_int64());
@@ -263,8 +263,9 @@ class ProtoWriteBuffer {
     this->write((value >> 48) & 0xFF);
     this->write((value >> 56) & 0xFF);
   }
-  template<typename T> void encode_enum(uint32_t field_id, T value, bool force = false) {
-    this->encode_uint32(field_id, static_cast<uint32_t>(value), force);
+  // Non-template version for enum encoding to reduce flash usage
+  void encode_enum_uint32(uint32_t field_id, uint32_t value, bool force = false) {
+    this->encode_uint32(field_id, value, force);
   }
   void encode_float(uint32_t field_id, float value, bool force = false) {
     if (value == 0.0f && !force)

--- a/esphome/components/api/proto.h
+++ b/esphome/components/api/proto.h
@@ -132,6 +132,9 @@ class ProtoVarInt {
   uint64_t value_;
 };
 
+// Forward declaration for decode_to_message and encode_to_writer
+class ProtoMessage;
+
 class ProtoLengthDelimited {
  public:
   explicit ProtoLengthDelimited(const uint8_t *value, size_t length) : value_(value), length_(length) {}
@@ -188,9 +191,6 @@ class Proto64Bit {
  protected:
   const uint64_t value_;
 };
-
-// Forward declaration needed for method declaration
-class ProtoMessage;
 
 class ProtoWriteBuffer {
  public:

--- a/script/api_protobuf/api_protobuf.py
+++ b/script/api_protobuf/api_protobuf.py
@@ -502,7 +502,19 @@ class MessageType(TypeInfo):
 
     @property
     def decode_length(self) -> str:
-        return f"value.as_message<{self.cpp_type}>()"
+        # For non-template decoding, we need to handle this differently
+        return None
+
+    @property
+    def decode_length_content(self) -> str:
+        # Custom decode that doesn't use templates
+        return dedent(
+            f"""\
+        case {self.number}: {{
+          value.decode_to_message(this->{self.field_name});
+          return true;
+        }}"""
+        )
 
     def dump(self, name: str) -> str:
         o = f"{name}.dump_to(out);"
@@ -731,6 +743,16 @@ class RepeatedTypeInfo(TypeInfo):
     @property
     def decode_length_content(self) -> str:
         content = self._ti.decode_length
+        if content is None and isinstance(self._ti, MessageType):
+            # Special handling for non-template message decoding
+            return dedent(
+                f"""\
+        case {self.number}: {{
+          this->{self.field_name}.emplace_back();
+          value.decode_to_message(this->{self.field_name}.back());
+          return true;
+        }}"""
+            )
         if content is None:
             return None
         return dedent(

--- a/script/api_protobuf/api_protobuf.py
+++ b/script/api_protobuf/api_protobuf.py
@@ -540,7 +540,10 @@ class MessageType(TypeInfo):
 
     @property
     def decode_length(self) -> str:
-        # For non-template decoding, we need to handle this differently
+        # Override to return None for message types because we can't use template-based
+        # decoding when the specific message type isn't known at compile time.
+        # Instead, we use the non-template decode_to_message() method which allows
+        # runtime polymorphism through virtual function calls.
         return None
 
     @property

--- a/script/api_protobuf/api_protobuf.py
+++ b/script/api_protobuf/api_protobuf.py
@@ -595,7 +595,7 @@ class EnumType(TypeInfo):
 
     @property
     def encode_func(self) -> str:
-        return "encode_enum_uint32"
+        return "encode_uint32"
 
     @property
     def encode_content(self) -> str:

--- a/script/api_protobuf/api_protobuf.py
+++ b/script/api_protobuf/api_protobuf.py
@@ -576,14 +576,18 @@ class EnumType(TypeInfo):
 
     @property
     def decode_varint(self) -> str:
-        return f"value.as_enum<{self.cpp_type}>()"
+        return f"static_cast<{self.cpp_type}>(value.as_uint32())"
 
     default_value = ""
     wire_type = WireType.VARINT  # Uses wire type 0
 
     @property
     def encode_func(self) -> str:
-        return f"encode_enum<{self.cpp_type}>"
+        return "encode_enum_uint32"
+
+    @property
+    def encode_content(self) -> str:
+        return f"buffer.{self.encode_func}({self.number}, static_cast<uint32_t>(this->{self.field_name}));"
 
     def dump(self, name: str) -> str:
         o = f"out.append(proto_enum_to_string<{self.cpp_type}>({name}));"
@@ -771,7 +775,10 @@ class RepeatedTypeInfo(TypeInfo):
     @property
     def encode_content(self) -> str:
         o = f"for (auto {'' if self._ti_is_bool else '&'}it : this->{self.field_name}) {{\n"
-        o += f"  buffer.{self._ti.encode_func}({self.number}, it, true);\n"
+        if isinstance(self._ti, EnumType):
+            o += f"  buffer.{self._ti.encode_func}({self.number}, static_cast<uint32_t>(it), true);\n"
+        else:
+            o += f"  buffer.{self._ti.encode_func}({self.number}, it, true);\n"
         o += "}"
         return o
 

--- a/script/api_protobuf/api_protobuf.py
+++ b/script/api_protobuf/api_protobuf.py
@@ -498,7 +498,7 @@ class MessageType(TypeInfo):
 
     @property
     def encode_func(self) -> str:
-        return f"encode_message<{self.cpp_type}>"
+        return "encode_message"
 
     @property
     def decode_length(self) -> str:


### PR DESCRIPTION
## What does this implement/fix?

This PR optimizes the API protocol buffer implementation by eliminating unnecessary C++ template instantiations, reducing flash usage by 620 bytes with no functional changes or performance impact.

## Changes Made

### 1. Eliminated `encode_enum<T>` template
- Generated code now uses `encode_uint32()` with `static_cast<uint32_t>()` for all enum values
- Removed unnecessary wrapper functions

### 2. Removed `as_enum<T>()` template
- Eliminated the template function entirely
- Generated code now uses `static_cast<enums::Type>(value.as_uint32())` directly

### 3. Eliminated `encode_message<T>` template
- Replaced with non-template version accepting `const ProtoMessage&` base class
- Uses virtual function polymorphism instead of templates

### 4. Eliminated `as_message<T>()` template
- Replaced with `decode_to_message(ProtoMessage&)` that decodes into existing instances
- For repeated fields, uses `emplace_back()` then decodes into the last element

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

No configuration changes required - this is a transparent optimization.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (if applicable).
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

## Flash Usage Results

**Before optimization:**
```
Flash: [=======   ]  67.1% (used 1230876 bytes from 1835008 bytes)
```

**After optimization:**
```
Flash: [=======   ]  67.0% (used 1230256 bytes from 1835008 bytes)
```

**Savings: 620 bytes**

## Benefits

1. **No breaking changes** - Purely internal optimization
2. **No user action required** - Works transparently with existing configurations
3. **Scalable savings** - More enum/message types = more savings
4. **No runtime overhead** - Same performance, less flash usage
5. **Cleaner code** - Eliminates unnecessary template complexity

## Technical Details

The protobuf wire format represents all enums as `uint32_t` and all messages inherit from `ProtoMessage`, making the templates unnecessary. By eliminating these template instantiations:

- Each enum type no longer generates separate `encode_enum<T>` and `as_enum<T>` instantiations
- Each message type no longer generates separate `encode_message<T>` and `as_message<T>` instantiations
- The compiler produces less code duplication, reducing flash usage

This optimization is particularly beneficial for memory-constrained devices where every byte counts.