### PR TITLE
[sx127x, sx126x] Fix preamble_size default and validation

### DIFF
--- a/esphome/components/sx126x/__init__.py
+++ b/esphome/components/sx126x/__init__.py
@@ -167,8 +167,8 @@ def validate_config(config):
     if config[CONF_MODULATION] == "LORA":
         if config[CONF_BANDWIDTH] not in lora_bws:
             raise cv.Invalid(f"{config[CONF_BANDWIDTH]} is not available with LORA")
-        if config[CONF_PREAMBLE_SIZE] > 0 and config[CONF_PREAMBLE_SIZE] < 6:
-            raise cv.Invalid("Minimum preamble size is 6 with LORA")
+        if config[CONF_PREAMBLE_SIZE] < 6:
+            raise cv.Invalid("Minimum 'preamble_size' is 6 with LORA")
         if config[CONF_SPREADING_FACTOR] == 6 and config[CONF_PAYLOAD_LENGTH] == 0:
             raise cv.Invalid("Payload length must be set when spreading factor is 6")
     else:
@@ -200,7 +200,7 @@ CONFIG_SCHEMA = (
             cv.Optional(CONF_PA_RAMP, default="40us"): cv.enum(RAMP),
             cv.Optional(CONF_PAYLOAD_LENGTH, default=0): cv.int_range(min=0, max=256),
             cv.Optional(CONF_PREAMBLE_DETECT, default=2): cv.int_range(min=0, max=4),
-            cv.Required(CONF_PREAMBLE_SIZE): cv.int_range(min=1, max=65535),
+            cv.Optional(CONF_PREAMBLE_SIZE, default=8): cv.int_range(min=1, max=65535),
             cv.Required(CONF_RST_PIN): pins.internal_gpio_output_pin_schema,
             cv.Optional(CONF_RX_START, default=True): cv.boolean,
             cv.Required(CONF_RF_SWITCH): cv.boolean,

--- a/esphome/components/sx127x/__init__.py
+++ b/esphome/components/sx127x/__init__.py
@@ -164,8 +164,8 @@ def validate_config(config):
             raise cv.Invalid(f"{config[CONF_BANDWIDTH]} is not available with LORA")
         if CONF_DIO0_PIN not in config:
             raise cv.Invalid("Cannot use LoRa without dio0_pin")
-        if 0 < config[CONF_PREAMBLE_SIZE] < 6:
-            raise cv.Invalid("Minimum preamble size is 6 with LORA")
+        if config[CONF_PREAMBLE_SIZE] < 6:
+            raise cv.Invalid("Minimum 'preamble_size' is 6 with LORA")
         if config[CONF_SPREADING_FACTOR] == 6 and config[CONF_PAYLOAD_LENGTH] == 0:
             raise cv.Invalid("Payload length must be set when spreading factor is 6")
     else:


### PR DESCRIPTION
# What does this implement/fix?

Fix LoRa `preamble_size` validation on both sx126x and sx127x, zero is not allowed.

On sx126x the docs say `preamble_size` is optional and the default is 8, update the code to match. 

On sx127x it doesn't make sense to set `preamble_size` in continuous mode so a default of 8 doesn't make sense. Mark it required in the docs for LoRa. 

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://discord.com/channels/429907082951524364/1392912614887260251

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#https://github.com/esphome/esphome-docs/pull/5089

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
