### PR TITLE
Disable WiFi when using Ethernet to save memory

### DIFF
--- a/esphome/components/ethernet/__init__.py
+++ b/esphome/components/ethernet/__init__.py
@@ -342,5 +342,11 @@ async def to_code(config):
 
     cg.add_define("USE_ETHERNET")
 
+    # Disable WiFi when using Ethernet to save memory
+    if CORE.using_esp_idf:
+        add_idf_sdkconfig_option("CONFIG_ESP_WIFI_ENABLED", False)
+        # Also disable WiFi/BT coexistence since WiFi is disabled
+        add_idf_sdkconfig_option("CONFIG_SW_COEXIST_ENABLE", False)
+
     if CORE.using_arduino:
         cg.add_library("WiFi", None)


### PR DESCRIPTION
# What does this implement/fix?

This PR explicitly disables WiFi in ESP-IDF when using the Ethernet component, resulting in significant memory savings. Since WiFi and Ethernet are mutually exclusive (enforced by `CONFLICTS_WITH = ["wifi"]`), there's no need to compile in the WiFi stack for Ethernet-only configurations.

**Memory savings observed:**
- RAM: 1,856 bytes saved (4.3% reduction)
- Flash: 10,420 bytes saved (1.0% reduction)

The change also disables `CONFIG_SW_COEXIST_ENABLE` (WiFi/Bluetooth coexistence) since it's not needed without WiFi, providing additional memory savings for Ethernet+Bluetooth configurations.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# No configuration changes needed - this optimization is automatic
# when using Ethernet with ESP-IDF
esp32:
  board: esp32doit-devkit-v1
  framework:
    type: esp-idf

ethernet:
  type: IP101
  mdc_pin: GPIO23
  mdio_pin: GPIO18
  clk_mode: GPIO0_IN
  phy_addr: 1
  power_pin: GPIO5
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
