### PR TITLE
Only generate protobuf encode/decode methods for the message direction they're used

### DIFF
--- a/esphome/components/api/api_pb2.cpp
+++ b/esphome/components/api/api_pb2.cpp
@@ -31,16 +31,6 @@ bool HelloRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value) 
       return false;
   }
 }
-void HelloRequest::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_string(1, this->client_info);
-  buffer.encode_uint32(2, this->api_version_major);
-  buffer.encode_uint32(3, this->api_version_minor);
-}
-void HelloRequest::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_string_field(total_size, 1, this->client_info);
-  ProtoSize::add_uint32_field(total_size, 1, this->api_version_major);
-  ProtoSize::add_uint32_field(total_size, 1, this->api_version_minor);
-}
 void HelloResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint32(1, this->api_version_major);
   buffer.encode_uint32(2, this->api_version_minor);
@@ -62,10 +52,6 @@ bool ConnectRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value
     default:
       return false;
   }
-}
-void ConnectRequest::encode(ProtoWriteBuffer buffer) const { buffer.encode_string(1, this->password); }
-void ConnectRequest::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_string_field(total_size, 1, this->password);
 }
 void ConnectResponse::encode(ProtoWriteBuffer buffer) const { buffer.encode_bool(1, this->invalid_password); }
 void ConnectResponse::calculate_size(uint32_t &total_size) const {
@@ -318,28 +304,6 @@ bool CoverCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
       return false;
   }
 }
-void CoverCommandRequest::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_fixed32(1, this->key);
-  buffer.encode_bool(2, this->has_legacy_command);
-  buffer.encode_uint32(3, static_cast<uint32_t>(this->legacy_command));
-  buffer.encode_bool(4, this->has_position);
-  buffer.encode_float(5, this->position);
-  buffer.encode_bool(6, this->has_tilt);
-  buffer.encode_float(7, this->tilt);
-  buffer.encode_bool(8, this->stop);
-  buffer.encode_uint32(9, this->device_id);
-}
-void CoverCommandRequest::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0);
-  ProtoSize::add_bool_field(total_size, 1, this->has_legacy_command);
-  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->legacy_command));
-  ProtoSize::add_bool_field(total_size, 1, this->has_position);
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->position != 0.0f);
-  ProtoSize::add_bool_field(total_size, 1, this->has_tilt);
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->tilt != 0.0f);
-  ProtoSize::add_bool_field(total_size, 1, this->stop);
-  ProtoSize::add_uint32_field(total_size, 1, this->device_id);
-}
 #endif
 #ifdef USE_FAN
 void ListEntitiesFanResponse::encode(ProtoWriteBuffer buffer) const {
@@ -471,38 +435,6 @@ bool FanCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
     default:
       return false;
   }
-}
-void FanCommandRequest::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_fixed32(1, this->key);
-  buffer.encode_bool(2, this->has_state);
-  buffer.encode_bool(3, this->state);
-  buffer.encode_bool(4, this->has_speed);
-  buffer.encode_uint32(5, static_cast<uint32_t>(this->speed));
-  buffer.encode_bool(6, this->has_oscillating);
-  buffer.encode_bool(7, this->oscillating);
-  buffer.encode_bool(8, this->has_direction);
-  buffer.encode_uint32(9, static_cast<uint32_t>(this->direction));
-  buffer.encode_bool(10, this->has_speed_level);
-  buffer.encode_int32(11, this->speed_level);
-  buffer.encode_bool(12, this->has_preset_mode);
-  buffer.encode_string(13, this->preset_mode);
-  buffer.encode_uint32(14, this->device_id);
-}
-void FanCommandRequest::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0);
-  ProtoSize::add_bool_field(total_size, 1, this->has_state);
-  ProtoSize::add_bool_field(total_size, 1, this->state);
-  ProtoSize::add_bool_field(total_size, 1, this->has_speed);
-  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->speed));
-  ProtoSize::add_bool_field(total_size, 1, this->has_oscillating);
-  ProtoSize::add_bool_field(total_size, 1, this->oscillating);
-  ProtoSize::add_bool_field(total_size, 1, this->has_direction);
-  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->direction));
-  ProtoSize::add_bool_field(total_size, 1, this->has_speed_level);
-  ProtoSize::add_int32_field(total_size, 1, this->speed_level);
-  ProtoSize::add_bool_field(total_size, 1, this->has_preset_mode);
-  ProtoSize::add_string_field(total_size, 1, this->preset_mode);
-  ProtoSize::add_uint32_field(total_size, 1, this->device_id);
 }
 #endif
 #ifdef USE_LIGHT
@@ -716,66 +648,6 @@ bool LightCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
       return false;
   }
 }
-void LightCommandRequest::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_fixed32(1, this->key);
-  buffer.encode_bool(2, this->has_state);
-  buffer.encode_bool(3, this->state);
-  buffer.encode_bool(4, this->has_brightness);
-  buffer.encode_float(5, this->brightness);
-  buffer.encode_bool(22, this->has_color_mode);
-  buffer.encode_uint32(23, static_cast<uint32_t>(this->color_mode));
-  buffer.encode_bool(20, this->has_color_brightness);
-  buffer.encode_float(21, this->color_brightness);
-  buffer.encode_bool(6, this->has_rgb);
-  buffer.encode_float(7, this->red);
-  buffer.encode_float(8, this->green);
-  buffer.encode_float(9, this->blue);
-  buffer.encode_bool(10, this->has_white);
-  buffer.encode_float(11, this->white);
-  buffer.encode_bool(12, this->has_color_temperature);
-  buffer.encode_float(13, this->color_temperature);
-  buffer.encode_bool(24, this->has_cold_white);
-  buffer.encode_float(25, this->cold_white);
-  buffer.encode_bool(26, this->has_warm_white);
-  buffer.encode_float(27, this->warm_white);
-  buffer.encode_bool(14, this->has_transition_length);
-  buffer.encode_uint32(15, this->transition_length);
-  buffer.encode_bool(16, this->has_flash_length);
-  buffer.encode_uint32(17, this->flash_length);
-  buffer.encode_bool(18, this->has_effect);
-  buffer.encode_string(19, this->effect);
-  buffer.encode_uint32(28, this->device_id);
-}
-void LightCommandRequest::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0);
-  ProtoSize::add_bool_field(total_size, 1, this->has_state);
-  ProtoSize::add_bool_field(total_size, 1, this->state);
-  ProtoSize::add_bool_field(total_size, 1, this->has_brightness);
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->brightness != 0.0f);
-  ProtoSize::add_bool_field(total_size, 2, this->has_color_mode);
-  ProtoSize::add_enum_field(total_size, 2, static_cast<uint32_t>(this->color_mode));
-  ProtoSize::add_bool_field(total_size, 2, this->has_color_brightness);
-  ProtoSize::add_fixed_field<4>(total_size, 2, this->color_brightness != 0.0f);
-  ProtoSize::add_bool_field(total_size, 1, this->has_rgb);
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->red != 0.0f);
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->green != 0.0f);
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->blue != 0.0f);
-  ProtoSize::add_bool_field(total_size, 1, this->has_white);
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->white != 0.0f);
-  ProtoSize::add_bool_field(total_size, 1, this->has_color_temperature);
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->color_temperature != 0.0f);
-  ProtoSize::add_bool_field(total_size, 2, this->has_cold_white);
-  ProtoSize::add_fixed_field<4>(total_size, 2, this->cold_white != 0.0f);
-  ProtoSize::add_bool_field(total_size, 2, this->has_warm_white);
-  ProtoSize::add_fixed_field<4>(total_size, 2, this->warm_white != 0.0f);
-  ProtoSize::add_bool_field(total_size, 1, this->has_transition_length);
-  ProtoSize::add_uint32_field(total_size, 1, this->transition_length);
-  ProtoSize::add_bool_field(total_size, 2, this->has_flash_length);
-  ProtoSize::add_uint32_field(total_size, 2, this->flash_length);
-  ProtoSize::add_bool_field(total_size, 2, this->has_effect);
-  ProtoSize::add_string_field(total_size, 2, this->effect);
-  ProtoSize::add_uint32_field(total_size, 2, this->device_id);
-}
 #endif
 #ifdef USE_SENSOR
 void ListEntitiesSensorResponse::encode(ProtoWriteBuffer buffer) const {
@@ -882,16 +754,6 @@ bool SwitchCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
       return false;
   }
 }
-void SwitchCommandRequest::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_fixed32(1, this->key);
-  buffer.encode_bool(2, this->state);
-  buffer.encode_uint32(3, this->device_id);
-}
-void SwitchCommandRequest::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0);
-  ProtoSize::add_bool_field(total_size, 1, this->state);
-  ProtoSize::add_uint32_field(total_size, 1, this->device_id);
-}
 #endif
 #ifdef USE_TEXT_SENSOR
 void ListEntitiesTextSensorResponse::encode(ProtoWriteBuffer buffer) const {
@@ -943,14 +805,6 @@ bool SubscribeLogsRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
       return false;
   }
 }
-void SubscribeLogsRequest::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_uint32(1, static_cast<uint32_t>(this->level));
-  buffer.encode_bool(2, this->dump_config);
-}
-void SubscribeLogsRequest::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->level));
-  ProtoSize::add_bool_field(total_size, 1, this->dump_config);
-}
 void SubscribeLogsResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint32(1, static_cast<uint32_t>(this->level));
   buffer.encode_bytes(3, reinterpret_cast<const uint8_t *>(this->message.data()), this->message.size());
@@ -971,12 +825,6 @@ bool NoiseEncryptionSetKeyRequest::decode_length(uint32_t field_id, ProtoLengthD
     default:
       return false;
   }
-}
-void NoiseEncryptionSetKeyRequest::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_bytes(1, reinterpret_cast<const uint8_t *>(this->key.data()), this->key.size());
-}
-void NoiseEncryptionSetKeyRequest::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_string_field(total_size, 1, this->key);
 }
 void NoiseEncryptionSetKeyResponse::encode(ProtoWriteBuffer buffer) const { buffer.encode_bool(1, this->success); }
 void NoiseEncryptionSetKeyResponse::calculate_size(uint32_t &total_size) const {
@@ -1052,16 +900,6 @@ bool HomeAssistantStateResponse::decode_length(uint32_t field_id, ProtoLengthDel
     default:
       return false;
   }
-}
-void HomeAssistantStateResponse::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_string(1, this->entity_id);
-  buffer.encode_string(2, this->state);
-  buffer.encode_string(3, this->attribute);
-}
-void HomeAssistantStateResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_string_field(total_size, 1, this->entity_id);
-  ProtoSize::add_string_field(total_size, 1, this->state);
-  ProtoSize::add_string_field(total_size, 1, this->attribute);
 }
 bool GetTimeResponse::decode_32bit(uint32_t field_id, Proto32Bit value) {
   switch (field_id) {
@@ -1237,16 +1075,6 @@ bool ExecuteServiceRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
       return false;
   }
 }
-void ExecuteServiceRequest::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_fixed32(1, this->key);
-  for (auto &it : this->args) {
-    buffer.encode_message(2, it, true);
-  }
-}
-void ExecuteServiceRequest::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0);
-  ProtoSize::add_repeated_message(total_size, 1, this->args);
-}
 #endif
 #ifdef USE_CAMERA
 void ListEntitiesCameraResponse::encode(ProtoWriteBuffer buffer) const {
@@ -1294,14 +1122,6 @@ bool CameraImageRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
     default:
       return false;
   }
-}
-void CameraImageRequest::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_bool(1, this->single);
-  buffer.encode_bool(2, this->stream);
-}
-void CameraImageRequest::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_bool_field(total_size, 1, this->single);
-  ProtoSize::add_bool_field(total_size, 1, this->stream);
 }
 #endif
 #ifdef USE_CLIMATE
@@ -1547,58 +1367,6 @@ bool ClimateCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
       return false;
   }
 }
-void ClimateCommandRequest::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_fixed32(1, this->key);
-  buffer.encode_bool(2, this->has_mode);
-  buffer.encode_uint32(3, static_cast<uint32_t>(this->mode));
-  buffer.encode_bool(4, this->has_target_temperature);
-  buffer.encode_float(5, this->target_temperature);
-  buffer.encode_bool(6, this->has_target_temperature_low);
-  buffer.encode_float(7, this->target_temperature_low);
-  buffer.encode_bool(8, this->has_target_temperature_high);
-  buffer.encode_float(9, this->target_temperature_high);
-  buffer.encode_bool(10, this->unused_has_legacy_away);
-  buffer.encode_bool(11, this->unused_legacy_away);
-  buffer.encode_bool(12, this->has_fan_mode);
-  buffer.encode_uint32(13, static_cast<uint32_t>(this->fan_mode));
-  buffer.encode_bool(14, this->has_swing_mode);
-  buffer.encode_uint32(15, static_cast<uint32_t>(this->swing_mode));
-  buffer.encode_bool(16, this->has_custom_fan_mode);
-  buffer.encode_string(17, this->custom_fan_mode);
-  buffer.encode_bool(18, this->has_preset);
-  buffer.encode_uint32(19, static_cast<uint32_t>(this->preset));
-  buffer.encode_bool(20, this->has_custom_preset);
-  buffer.encode_string(21, this->custom_preset);
-  buffer.encode_bool(22, this->has_target_humidity);
-  buffer.encode_float(23, this->target_humidity);
-  buffer.encode_uint32(24, this->device_id);
-}
-void ClimateCommandRequest::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0);
-  ProtoSize::add_bool_field(total_size, 1, this->has_mode);
-  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->mode));
-  ProtoSize::add_bool_field(total_size, 1, this->has_target_temperature);
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->target_temperature != 0.0f);
-  ProtoSize::add_bool_field(total_size, 1, this->has_target_temperature_low);
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->target_temperature_low != 0.0f);
-  ProtoSize::add_bool_field(total_size, 1, this->has_target_temperature_high);
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->target_temperature_high != 0.0f);
-  ProtoSize::add_bool_field(total_size, 1, this->unused_has_legacy_away);
-  ProtoSize::add_bool_field(total_size, 1, this->unused_legacy_away);
-  ProtoSize::add_bool_field(total_size, 1, this->has_fan_mode);
-  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->fan_mode));
-  ProtoSize::add_bool_field(total_size, 1, this->has_swing_mode);
-  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->swing_mode));
-  ProtoSize::add_bool_field(total_size, 2, this->has_custom_fan_mode);
-  ProtoSize::add_string_field(total_size, 2, this->custom_fan_mode);
-  ProtoSize::add_bool_field(total_size, 2, this->has_preset);
-  ProtoSize::add_enum_field(total_size, 2, static_cast<uint32_t>(this->preset));
-  ProtoSize::add_bool_field(total_size, 2, this->has_custom_preset);
-  ProtoSize::add_string_field(total_size, 2, this->custom_preset);
-  ProtoSize::add_bool_field(total_size, 2, this->has_target_humidity);
-  ProtoSize::add_fixed_field<4>(total_size, 2, this->target_humidity != 0.0f);
-  ProtoSize::add_uint32_field(total_size, 2, this->device_id);
-}
 #endif
 #ifdef USE_NUMBER
 void ListEntitiesNumberResponse::encode(ProtoWriteBuffer buffer) const {
@@ -1668,16 +1436,6 @@ bool NumberCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
     default:
       return false;
   }
-}
-void NumberCommandRequest::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_fixed32(1, this->key);
-  buffer.encode_float(2, this->state);
-  buffer.encode_uint32(3, this->device_id);
-}
-void NumberCommandRequest::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0);
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->state != 0.0f);
-  ProtoSize::add_uint32_field(total_size, 1, this->device_id);
 }
 #endif
 #ifdef USE_SELECT
@@ -1750,16 +1508,6 @@ bool SelectCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
     default:
       return false;
   }
-}
-void SelectCommandRequest::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_fixed32(1, this->key);
-  buffer.encode_string(2, this->state);
-  buffer.encode_uint32(3, this->device_id);
-}
-void SelectCommandRequest::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0);
-  ProtoSize::add_string_field(total_size, 1, this->state);
-  ProtoSize::add_uint32_field(total_size, 1, this->device_id);
 }
 #endif
 #ifdef USE_SIREN
@@ -1863,30 +1611,6 @@ bool SirenCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
       return false;
   }
 }
-void SirenCommandRequest::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_fixed32(1, this->key);
-  buffer.encode_bool(2, this->has_state);
-  buffer.encode_bool(3, this->state);
-  buffer.encode_bool(4, this->has_tone);
-  buffer.encode_string(5, this->tone);
-  buffer.encode_bool(6, this->has_duration);
-  buffer.encode_uint32(7, this->duration);
-  buffer.encode_bool(8, this->has_volume);
-  buffer.encode_float(9, this->volume);
-  buffer.encode_uint32(10, this->device_id);
-}
-void SirenCommandRequest::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0);
-  ProtoSize::add_bool_field(total_size, 1, this->has_state);
-  ProtoSize::add_bool_field(total_size, 1, this->state);
-  ProtoSize::add_bool_field(total_size, 1, this->has_tone);
-  ProtoSize::add_string_field(total_size, 1, this->tone);
-  ProtoSize::add_bool_field(total_size, 1, this->has_duration);
-  ProtoSize::add_uint32_field(total_size, 1, this->duration);
-  ProtoSize::add_bool_field(total_size, 1, this->has_volume);
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->volume != 0.0f);
-  ProtoSize::add_uint32_field(total_size, 1, this->device_id);
-}
 #endif
 #ifdef USE_LOCK
 void ListEntitiesLockResponse::encode(ProtoWriteBuffer buffer) const {
@@ -1965,20 +1689,6 @@ bool LockCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
       return false;
   }
 }
-void LockCommandRequest::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_fixed32(1, this->key);
-  buffer.encode_uint32(2, static_cast<uint32_t>(this->command));
-  buffer.encode_bool(3, this->has_code);
-  buffer.encode_string(4, this->code);
-  buffer.encode_uint32(5, this->device_id);
-}
-void LockCommandRequest::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0);
-  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->command));
-  ProtoSize::add_bool_field(total_size, 1, this->has_code);
-  ProtoSize::add_string_field(total_size, 1, this->code);
-  ProtoSize::add_uint32_field(total_size, 1, this->device_id);
-}
 #endif
 #ifdef USE_BUTTON
 void ListEntitiesButtonResponse::encode(ProtoWriteBuffer buffer) const {
@@ -2022,14 +1732,6 @@ bool ButtonCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
     default:
       return false;
   }
-}
-void ButtonCommandRequest::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_fixed32(1, this->key);
-  buffer.encode_uint32(2, this->device_id);
-}
-void ButtonCommandRequest::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0);
-  ProtoSize::add_uint32_field(total_size, 1, this->device_id);
 }
 #endif
 #ifdef USE_MEDIA_PLAYER
@@ -2177,30 +1879,6 @@ bool MediaPlayerCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value
       return false;
   }
 }
-void MediaPlayerCommandRequest::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_fixed32(1, this->key);
-  buffer.encode_bool(2, this->has_command);
-  buffer.encode_uint32(3, static_cast<uint32_t>(this->command));
-  buffer.encode_bool(4, this->has_volume);
-  buffer.encode_float(5, this->volume);
-  buffer.encode_bool(6, this->has_media_url);
-  buffer.encode_string(7, this->media_url);
-  buffer.encode_bool(8, this->has_announcement);
-  buffer.encode_bool(9, this->announcement);
-  buffer.encode_uint32(10, this->device_id);
-}
-void MediaPlayerCommandRequest::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0);
-  ProtoSize::add_bool_field(total_size, 1, this->has_command);
-  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->command));
-  ProtoSize::add_bool_field(total_size, 1, this->has_volume);
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->volume != 0.0f);
-  ProtoSize::add_bool_field(total_size, 1, this->has_media_url);
-  ProtoSize::add_string_field(total_size, 1, this->media_url);
-  ProtoSize::add_bool_field(total_size, 1, this->has_announcement);
-  ProtoSize::add_bool_field(total_size, 1, this->announcement);
-  ProtoSize::add_uint32_field(total_size, 1, this->device_id);
-}
 #endif
 #ifdef USE_BLUETOOTH_PROXY
 bool SubscribeBluetoothLEAdvertisementsRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
@@ -2212,12 +1890,6 @@ bool SubscribeBluetoothLEAdvertisementsRequest::decode_varint(uint32_t field_id,
     default:
       return false;
   }
-}
-void SubscribeBluetoothLEAdvertisementsRequest::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_uint32(1, this->flags);
-}
-void SubscribeBluetoothLEAdvertisementsRequest::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_uint32_field(total_size, 1, this->flags);
 }
 bool BluetoothServiceData::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
@@ -2357,18 +2029,6 @@ bool BluetoothDeviceRequest::decode_varint(uint32_t field_id, ProtoVarInt value)
       return false;
   }
 }
-void BluetoothDeviceRequest::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_uint64(1, this->address);
-  buffer.encode_uint32(2, static_cast<uint32_t>(this->request_type));
-  buffer.encode_bool(3, this->has_address_type);
-  buffer.encode_uint32(4, this->address_type);
-}
-void BluetoothDeviceRequest::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_uint64_field(total_size, 1, this->address);
-  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->request_type));
-  ProtoSize::add_bool_field(total_size, 1, this->has_address_type);
-  ProtoSize::add_uint32_field(total_size, 1, this->address_type);
-}
 void BluetoothDeviceConnectionResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint64(1, this->address);
   buffer.encode_bool(2, this->connected);
@@ -2390,10 +2050,6 @@ bool BluetoothGATTGetServicesRequest::decode_varint(uint32_t field_id, ProtoVarI
     default:
       return false;
   }
-}
-void BluetoothGATTGetServicesRequest::encode(ProtoWriteBuffer buffer) const { buffer.encode_uint64(1, this->address); }
-void BluetoothGATTGetServicesRequest::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_uint64_field(total_size, 1, this->address);
 }
 bool BluetoothGATTDescriptor::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
@@ -2545,14 +2201,6 @@ bool BluetoothGATTReadRequest::decode_varint(uint32_t field_id, ProtoVarInt valu
       return false;
   }
 }
-void BluetoothGATTReadRequest::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_uint64(1, this->address);
-  buffer.encode_uint32(2, this->handle);
-}
-void BluetoothGATTReadRequest::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_uint64_field(total_size, 1, this->address);
-  ProtoSize::add_uint32_field(total_size, 1, this->handle);
-}
 void BluetoothGATTReadResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint64(1, this->address);
   buffer.encode_uint32(2, this->handle);
@@ -2591,18 +2239,6 @@ bool BluetoothGATTWriteRequest::decode_length(uint32_t field_id, ProtoLengthDeli
       return false;
   }
 }
-void BluetoothGATTWriteRequest::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_uint64(1, this->address);
-  buffer.encode_uint32(2, this->handle);
-  buffer.encode_bool(3, this->response);
-  buffer.encode_bytes(4, reinterpret_cast<const uint8_t *>(this->data.data()), this->data.size());
-}
-void BluetoothGATTWriteRequest::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_uint64_field(total_size, 1, this->address);
-  ProtoSize::add_uint32_field(total_size, 1, this->handle);
-  ProtoSize::add_bool_field(total_size, 1, this->response);
-  ProtoSize::add_string_field(total_size, 1, this->data);
-}
 bool BluetoothGATTReadDescriptorRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 1: {
@@ -2616,14 +2252,6 @@ bool BluetoothGATTReadDescriptorRequest::decode_varint(uint32_t field_id, ProtoV
     default:
       return false;
   }
-}
-void BluetoothGATTReadDescriptorRequest::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_uint64(1, this->address);
-  buffer.encode_uint32(2, this->handle);
-}
-void BluetoothGATTReadDescriptorRequest::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_uint64_field(total_size, 1, this->address);
-  ProtoSize::add_uint32_field(total_size, 1, this->handle);
 }
 bool BluetoothGATTWriteDescriptorRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
@@ -2649,16 +2277,6 @@ bool BluetoothGATTWriteDescriptorRequest::decode_length(uint32_t field_id, Proto
       return false;
   }
 }
-void BluetoothGATTWriteDescriptorRequest::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_uint64(1, this->address);
-  buffer.encode_uint32(2, this->handle);
-  buffer.encode_bytes(3, reinterpret_cast<const uint8_t *>(this->data.data()), this->data.size());
-}
-void BluetoothGATTWriteDescriptorRequest::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_uint64_field(total_size, 1, this->address);
-  ProtoSize::add_uint32_field(total_size, 1, this->handle);
-  ProtoSize::add_string_field(total_size, 1, this->data);
-}
 bool BluetoothGATTNotifyRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 1: {
@@ -2676,16 +2294,6 @@ bool BluetoothGATTNotifyRequest::decode_varint(uint32_t field_id, ProtoVarInt va
     default:
       return false;
   }
-}
-void BluetoothGATTNotifyRequest::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_uint64(1, this->address);
-  buffer.encode_uint32(2, this->handle);
-  buffer.encode_bool(3, this->enable);
-}
-void BluetoothGATTNotifyRequest::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_uint64_field(total_size, 1, this->address);
-  ProtoSize::add_uint32_field(total_size, 1, this->handle);
-  ProtoSize::add_bool_field(total_size, 1, this->enable);
 }
 void BluetoothGATTNotifyDataResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint64(1, this->address);
@@ -2787,12 +2395,6 @@ bool BluetoothScannerSetModeRequest::decode_varint(uint32_t field_id, ProtoVarIn
       return false;
   }
 }
-void BluetoothScannerSetModeRequest::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_uint32(1, static_cast<uint32_t>(this->mode));
-}
-void BluetoothScannerSetModeRequest::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->mode));
-}
 #endif
 #ifdef USE_VOICE_ASSISTANT
 bool SubscribeVoiceAssistantRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
@@ -2808,14 +2410,6 @@ bool SubscribeVoiceAssistantRequest::decode_varint(uint32_t field_id, ProtoVarIn
     default:
       return false;
   }
-}
-void SubscribeVoiceAssistantRequest::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_bool(1, this->subscribe);
-  buffer.encode_uint32(2, this->flags);
-}
-void SubscribeVoiceAssistantRequest::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_bool_field(total_size, 1, this->subscribe);
-  ProtoSize::add_uint32_field(total_size, 1, this->flags);
 }
 bool VoiceAssistantAudioSettings::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
@@ -2879,14 +2473,6 @@ bool VoiceAssistantResponse::decode_varint(uint32_t field_id, ProtoVarInt value)
       return false;
   }
 }
-void VoiceAssistantResponse::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_uint32(1, this->port);
-  buffer.encode_bool(2, this->error);
-}
-void VoiceAssistantResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_uint32_field(total_size, 1, this->port);
-  ProtoSize::add_bool_field(total_size, 1, this->error);
-}
 bool VoiceAssistantEventData::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 1: {
@@ -2929,16 +2515,6 @@ bool VoiceAssistantEventResponse::decode_length(uint32_t field_id, ProtoLengthDe
     default:
       return false;
   }
-}
-void VoiceAssistantEventResponse::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_uint32(1, static_cast<uint32_t>(this->event_type));
-  for (auto &it : this->data) {
-    buffer.encode_message(2, it, true);
-  }
-}
-void VoiceAssistantEventResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->event_type));
-  ProtoSize::add_repeated_message(total_size, 1, this->data);
 }
 bool VoiceAssistantAudio::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
@@ -3004,22 +2580,6 @@ bool VoiceAssistantTimerEventResponse::decode_length(uint32_t field_id, ProtoLen
       return false;
   }
 }
-void VoiceAssistantTimerEventResponse::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_uint32(1, static_cast<uint32_t>(this->event_type));
-  buffer.encode_string(2, this->timer_id);
-  buffer.encode_string(3, this->name);
-  buffer.encode_uint32(4, this->total_seconds);
-  buffer.encode_uint32(5, this->seconds_left);
-  buffer.encode_bool(6, this->is_active);
-}
-void VoiceAssistantTimerEventResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->event_type));
-  ProtoSize::add_string_field(total_size, 1, this->timer_id);
-  ProtoSize::add_string_field(total_size, 1, this->name);
-  ProtoSize::add_uint32_field(total_size, 1, this->total_seconds);
-  ProtoSize::add_uint32_field(total_size, 1, this->seconds_left);
-  ProtoSize::add_bool_field(total_size, 1, this->is_active);
-}
 bool VoiceAssistantAnnounceRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
     case 4: {
@@ -3047,18 +2607,6 @@ bool VoiceAssistantAnnounceRequest::decode_length(uint32_t field_id, ProtoLength
     default:
       return false;
   }
-}
-void VoiceAssistantAnnounceRequest::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_string(1, this->media_id);
-  buffer.encode_string(2, this->text);
-  buffer.encode_string(3, this->preannounce_media_id);
-  buffer.encode_bool(4, this->start_conversation);
-}
-void VoiceAssistantAnnounceRequest::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_string_field(total_size, 1, this->media_id);
-  ProtoSize::add_string_field(total_size, 1, this->text);
-  ProtoSize::add_string_field(total_size, 1, this->preannounce_media_id);
-  ProtoSize::add_bool_field(total_size, 1, this->start_conversation);
 }
 void VoiceAssistantAnnounceFinished::encode(ProtoWriteBuffer buffer) const { buffer.encode_bool(1, this->success); }
 void VoiceAssistantAnnounceFinished::calculate_size(uint32_t &total_size) const {
@@ -3124,18 +2672,6 @@ bool VoiceAssistantSetConfiguration::decode_length(uint32_t field_id, ProtoLengt
     }
     default:
       return false;
-  }
-}
-void VoiceAssistantSetConfiguration::encode(ProtoWriteBuffer buffer) const {
-  for (auto &it : this->active_wake_words) {
-    buffer.encode_string(1, it, true);
-  }
-}
-void VoiceAssistantSetConfiguration::calculate_size(uint32_t &total_size) const {
-  if (!this->active_wake_words.empty()) {
-    for (const auto &it : this->active_wake_words) {
-      ProtoSize::add_string_field_repeated(total_size, 1, it);
-    }
   }
 }
 #endif
@@ -3210,18 +2746,6 @@ bool AlarmControlPanelCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit
       return false;
   }
 }
-void AlarmControlPanelCommandRequest::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_fixed32(1, this->key);
-  buffer.encode_uint32(2, static_cast<uint32_t>(this->command));
-  buffer.encode_string(3, this->code);
-  buffer.encode_uint32(4, this->device_id);
-}
-void AlarmControlPanelCommandRequest::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0);
-  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->command));
-  ProtoSize::add_string_field(total_size, 1, this->code);
-  ProtoSize::add_uint32_field(total_size, 1, this->device_id);
-}
 #endif
 #ifdef USE_TEXT
 void ListEntitiesTextResponse::encode(ProtoWriteBuffer buffer) const {
@@ -3294,16 +2818,6 @@ bool TextCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
       return false;
   }
 }
-void TextCommandRequest::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_fixed32(1, this->key);
-  buffer.encode_string(2, this->state);
-  buffer.encode_uint32(3, this->device_id);
-}
-void TextCommandRequest::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0);
-  ProtoSize::add_string_field(total_size, 1, this->state);
-  ProtoSize::add_uint32_field(total_size, 1, this->device_id);
-}
 #endif
 #ifdef USE_DATETIME_DATE
 void ListEntitiesDateResponse::encode(ProtoWriteBuffer buffer) const {
@@ -3374,20 +2888,6 @@ bool DateCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
       return false;
   }
 }
-void DateCommandRequest::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_fixed32(1, this->key);
-  buffer.encode_uint32(2, this->year);
-  buffer.encode_uint32(3, this->month);
-  buffer.encode_uint32(4, this->day);
-  buffer.encode_uint32(5, this->device_id);
-}
-void DateCommandRequest::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0);
-  ProtoSize::add_uint32_field(total_size, 1, this->year);
-  ProtoSize::add_uint32_field(total_size, 1, this->month);
-  ProtoSize::add_uint32_field(total_size, 1, this->day);
-  ProtoSize::add_uint32_field(total_size, 1, this->device_id);
-}
 #endif
 #ifdef USE_DATETIME_TIME
 void ListEntitiesTimeResponse::encode(ProtoWriteBuffer buffer) const {
@@ -3457,20 +2957,6 @@ bool TimeCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
     default:
       return false;
   }
-}
-void TimeCommandRequest::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_fixed32(1, this->key);
-  buffer.encode_uint32(2, this->hour);
-  buffer.encode_uint32(3, this->minute);
-  buffer.encode_uint32(4, this->second);
-  buffer.encode_uint32(5, this->device_id);
-}
-void TimeCommandRequest::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0);
-  ProtoSize::add_uint32_field(total_size, 1, this->hour);
-  ProtoSize::add_uint32_field(total_size, 1, this->minute);
-  ProtoSize::add_uint32_field(total_size, 1, this->second);
-  ProtoSize::add_uint32_field(total_size, 1, this->device_id);
 }
 #endif
 #ifdef USE_EVENT
@@ -3588,20 +3074,6 @@ bool ValveCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
       return false;
   }
 }
-void ValveCommandRequest::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_fixed32(1, this->key);
-  buffer.encode_bool(2, this->has_position);
-  buffer.encode_float(3, this->position);
-  buffer.encode_bool(4, this->stop);
-  buffer.encode_uint32(5, this->device_id);
-}
-void ValveCommandRequest::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0);
-  ProtoSize::add_bool_field(total_size, 1, this->has_position);
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->position != 0.0f);
-  ProtoSize::add_bool_field(total_size, 1, this->stop);
-  ProtoSize::add_uint32_field(total_size, 1, this->device_id);
-}
 #endif
 #ifdef USE_DATETIME_DATETIME
 void ListEntitiesDateTimeResponse::encode(ProtoWriteBuffer buffer) const {
@@ -3659,16 +3131,6 @@ bool DateTimeCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
     default:
       return false;
   }
-}
-void DateTimeCommandRequest::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_fixed32(1, this->key);
-  buffer.encode_fixed32(2, this->epoch_seconds);
-  buffer.encode_uint32(3, this->device_id);
-}
-void DateTimeCommandRequest::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0);
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->epoch_seconds != 0);
-  ProtoSize::add_uint32_field(total_size, 1, this->device_id);
 }
 #endif
 #ifdef USE_UPDATE
@@ -3743,16 +3205,6 @@ bool UpdateCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
     default:
       return false;
   }
-}
-void UpdateCommandRequest::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_fixed32(1, this->key);
-  buffer.encode_uint32(2, static_cast<uint32_t>(this->command));
-  buffer.encode_uint32(3, this->device_id);
-}
-void UpdateCommandRequest::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_fixed_field<4>(total_size, 1, this->key != 0);
-  ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->command));
-  ProtoSize::add_uint32_field(total_size, 1, this->device_id);
 }
 #endif
 

--- a/esphome/components/api/api_pb2.cpp
+++ b/esphome/components/api/api_pb2.cpp
@@ -41,34 +41,6 @@ void HelloRequest::calculate_size(uint32_t &total_size) const {
   ProtoSize::add_uint32_field(total_size, 1, this->api_version_major);
   ProtoSize::add_uint32_field(total_size, 1, this->api_version_minor);
 }
-bool HelloResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
-  switch (field_id) {
-    case 1: {
-      this->api_version_major = value.as_uint32();
-      return true;
-    }
-    case 2: {
-      this->api_version_minor = value.as_uint32();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
-bool HelloResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
-  switch (field_id) {
-    case 3: {
-      this->server_info = value.as_string();
-      return true;
-    }
-    case 4: {
-      this->name = value.as_string();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
 void HelloResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint32(1, this->api_version_major);
   buffer.encode_uint32(2, this->api_version_minor);
@@ -94,16 +66,6 @@ bool ConnectRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value
 void ConnectRequest::encode(ProtoWriteBuffer buffer) const { buffer.encode_string(1, this->password); }
 void ConnectRequest::calculate_size(uint32_t &total_size) const {
   ProtoSize::add_string_field(total_size, 1, this->password);
-}
-bool ConnectResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
-  switch (field_id) {
-    case 1: {
-      this->invalid_password = value.as_bool();
-      return true;
-    }
-    default:
-      return false;
-  }
 }
 void ConnectResponse::encode(ProtoWriteBuffer buffer) const { buffer.encode_bool(1, this->invalid_password); }
 void ConnectResponse::calculate_size(uint32_t &total_size) const {
@@ -171,108 +133,6 @@ void DeviceInfo::calculate_size(uint32_t &total_size) const {
   ProtoSize::add_string_field(total_size, 1, this->name);
   ProtoSize::add_uint32_field(total_size, 1, this->area_id);
 }
-bool DeviceInfoResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
-  switch (field_id) {
-    case 1: {
-      this->uses_password = value.as_bool();
-      return true;
-    }
-    case 7: {
-      this->has_deep_sleep = value.as_bool();
-      return true;
-    }
-    case 10: {
-      this->webserver_port = value.as_uint32();
-      return true;
-    }
-    case 11: {
-      this->legacy_bluetooth_proxy_version = value.as_uint32();
-      return true;
-    }
-    case 15: {
-      this->bluetooth_proxy_feature_flags = value.as_uint32();
-      return true;
-    }
-    case 14: {
-      this->legacy_voice_assistant_version = value.as_uint32();
-      return true;
-    }
-    case 17: {
-      this->voice_assistant_feature_flags = value.as_uint32();
-      return true;
-    }
-    case 19: {
-      this->api_encryption_supported = value.as_bool();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
-bool DeviceInfoResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
-  switch (field_id) {
-    case 2: {
-      this->name = value.as_string();
-      return true;
-    }
-    case 3: {
-      this->mac_address = value.as_string();
-      return true;
-    }
-    case 4: {
-      this->esphome_version = value.as_string();
-      return true;
-    }
-    case 5: {
-      this->compilation_time = value.as_string();
-      return true;
-    }
-    case 6: {
-      this->model = value.as_string();
-      return true;
-    }
-    case 8: {
-      this->project_name = value.as_string();
-      return true;
-    }
-    case 9: {
-      this->project_version = value.as_string();
-      return true;
-    }
-    case 12: {
-      this->manufacturer = value.as_string();
-      return true;
-    }
-    case 13: {
-      this->friendly_name = value.as_string();
-      return true;
-    }
-    case 16: {
-      this->suggested_area = value.as_string();
-      return true;
-    }
-    case 18: {
-      this->bluetooth_mac_address = value.as_string();
-      return true;
-    }
-    case 20: {
-      this->devices.emplace_back();
-      value.decode_to_message(this->devices.back());
-      return true;
-    }
-    case 21: {
-      this->areas.emplace_back();
-      value.decode_to_message(this->areas.back());
-      return true;
-    }
-    case 22: {
-      value.decode_to_message(this->area);
-      return true;
-    }
-    default:
-      return false;
-  }
-}
 void DeviceInfoResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_bool(1, this->uses_password);
   buffer.encode_string(2, this->name);
@@ -326,64 +186,6 @@ void DeviceInfoResponse::calculate_size(uint32_t &total_size) const {
   ProtoSize::add_message_object(total_size, 2, this->area);
 }
 #ifdef USE_BINARY_SENSOR
-bool ListEntitiesBinarySensorResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
-  switch (field_id) {
-    case 6: {
-      this->is_status_binary_sensor = value.as_bool();
-      return true;
-    }
-    case 7: {
-      this->disabled_by_default = value.as_bool();
-      return true;
-    }
-    case 9: {
-      this->entity_category = static_cast<enums::EntityCategory>(value.as_uint32());
-      return true;
-    }
-    case 10: {
-      this->device_id = value.as_uint32();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
-bool ListEntitiesBinarySensorResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
-  switch (field_id) {
-    case 1: {
-      this->object_id = value.as_string();
-      return true;
-    }
-    case 3: {
-      this->name = value.as_string();
-      return true;
-    }
-    case 4: {
-      this->unique_id = value.as_string();
-      return true;
-    }
-    case 5: {
-      this->device_class = value.as_string();
-      return true;
-    }
-    case 8: {
-      this->icon = value.as_string();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
-bool ListEntitiesBinarySensorResponse::decode_32bit(uint32_t field_id, Proto32Bit value) {
-  switch (field_id) {
-    case 2: {
-      this->key = value.as_fixed32();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
 void ListEntitiesBinarySensorResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_string(1, this->object_id);
   buffer.encode_fixed32(2, this->key);
@@ -408,34 +210,6 @@ void ListEntitiesBinarySensorResponse::calculate_size(uint32_t &total_size) cons
   ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->entity_category));
   ProtoSize::add_uint32_field(total_size, 1, this->device_id);
 }
-bool BinarySensorStateResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
-  switch (field_id) {
-    case 2: {
-      this->state = value.as_bool();
-      return true;
-    }
-    case 3: {
-      this->missing_state = value.as_bool();
-      return true;
-    }
-    case 4: {
-      this->device_id = value.as_uint32();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
-bool BinarySensorStateResponse::decode_32bit(uint32_t field_id, Proto32Bit value) {
-  switch (field_id) {
-    case 1: {
-      this->key = value.as_fixed32();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
 void BinarySensorStateResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_fixed32(1, this->key);
   buffer.encode_bool(2, this->state);
@@ -450,76 +224,6 @@ void BinarySensorStateResponse::calculate_size(uint32_t &total_size) const {
 }
 #endif
 #ifdef USE_COVER
-bool ListEntitiesCoverResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
-  switch (field_id) {
-    case 5: {
-      this->assumed_state = value.as_bool();
-      return true;
-    }
-    case 6: {
-      this->supports_position = value.as_bool();
-      return true;
-    }
-    case 7: {
-      this->supports_tilt = value.as_bool();
-      return true;
-    }
-    case 9: {
-      this->disabled_by_default = value.as_bool();
-      return true;
-    }
-    case 11: {
-      this->entity_category = static_cast<enums::EntityCategory>(value.as_uint32());
-      return true;
-    }
-    case 12: {
-      this->supports_stop = value.as_bool();
-      return true;
-    }
-    case 13: {
-      this->device_id = value.as_uint32();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
-bool ListEntitiesCoverResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
-  switch (field_id) {
-    case 1: {
-      this->object_id = value.as_string();
-      return true;
-    }
-    case 3: {
-      this->name = value.as_string();
-      return true;
-    }
-    case 4: {
-      this->unique_id = value.as_string();
-      return true;
-    }
-    case 8: {
-      this->device_class = value.as_string();
-      return true;
-    }
-    case 10: {
-      this->icon = value.as_string();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
-bool ListEntitiesCoverResponse::decode_32bit(uint32_t field_id, Proto32Bit value) {
-  switch (field_id) {
-    case 2: {
-      this->key = value.as_fixed32();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
 void ListEntitiesCoverResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_string(1, this->object_id);
   buffer.encode_fixed32(2, this->key);
@@ -549,42 +253,6 @@ void ListEntitiesCoverResponse::calculate_size(uint32_t &total_size) const {
   ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->entity_category));
   ProtoSize::add_bool_field(total_size, 1, this->supports_stop);
   ProtoSize::add_uint32_field(total_size, 1, this->device_id);
-}
-bool CoverStateResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
-  switch (field_id) {
-    case 2: {
-      this->legacy_state = static_cast<enums::LegacyCoverState>(value.as_uint32());
-      return true;
-    }
-    case 5: {
-      this->current_operation = static_cast<enums::CoverOperation>(value.as_uint32());
-      return true;
-    }
-    case 6: {
-      this->device_id = value.as_uint32();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
-bool CoverStateResponse::decode_32bit(uint32_t field_id, Proto32Bit value) {
-  switch (field_id) {
-    case 1: {
-      this->key = value.as_fixed32();
-      return true;
-    }
-    case 3: {
-      this->position = value.as_float();
-      return true;
-    }
-    case 4: {
-      this->tilt = value.as_float();
-      return true;
-    }
-    default:
-      return false;
-  }
 }
 void CoverStateResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_fixed32(1, this->key);
@@ -674,76 +342,6 @@ void CoverCommandRequest::calculate_size(uint32_t &total_size) const {
 }
 #endif
 #ifdef USE_FAN
-bool ListEntitiesFanResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
-  switch (field_id) {
-    case 5: {
-      this->supports_oscillation = value.as_bool();
-      return true;
-    }
-    case 6: {
-      this->supports_speed = value.as_bool();
-      return true;
-    }
-    case 7: {
-      this->supports_direction = value.as_bool();
-      return true;
-    }
-    case 8: {
-      this->supported_speed_count = value.as_int32();
-      return true;
-    }
-    case 9: {
-      this->disabled_by_default = value.as_bool();
-      return true;
-    }
-    case 11: {
-      this->entity_category = static_cast<enums::EntityCategory>(value.as_uint32());
-      return true;
-    }
-    case 13: {
-      this->device_id = value.as_uint32();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
-bool ListEntitiesFanResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
-  switch (field_id) {
-    case 1: {
-      this->object_id = value.as_string();
-      return true;
-    }
-    case 3: {
-      this->name = value.as_string();
-      return true;
-    }
-    case 4: {
-      this->unique_id = value.as_string();
-      return true;
-    }
-    case 10: {
-      this->icon = value.as_string();
-      return true;
-    }
-    case 12: {
-      this->supported_preset_modes.push_back(value.as_string());
-      return true;
-    }
-    default:
-      return false;
-  }
-}
-bool ListEntitiesFanResponse::decode_32bit(uint32_t field_id, Proto32Bit value) {
-  switch (field_id) {
-    case 2: {
-      this->key = value.as_fixed32();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
 void ListEntitiesFanResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_string(1, this->object_id);
   buffer.encode_fixed32(2, this->key);
@@ -779,56 +377,6 @@ void ListEntitiesFanResponse::calculate_size(uint32_t &total_size) const {
     }
   }
   ProtoSize::add_uint32_field(total_size, 1, this->device_id);
-}
-bool FanStateResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
-  switch (field_id) {
-    case 2: {
-      this->state = value.as_bool();
-      return true;
-    }
-    case 3: {
-      this->oscillating = value.as_bool();
-      return true;
-    }
-    case 4: {
-      this->speed = static_cast<enums::FanSpeed>(value.as_uint32());
-      return true;
-    }
-    case 5: {
-      this->direction = static_cast<enums::FanDirection>(value.as_uint32());
-      return true;
-    }
-    case 6: {
-      this->speed_level = value.as_int32();
-      return true;
-    }
-    case 8: {
-      this->device_id = value.as_uint32();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
-bool FanStateResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
-  switch (field_id) {
-    case 7: {
-      this->preset_mode = value.as_string();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
-bool FanStateResponse::decode_32bit(uint32_t field_id, Proto32Bit value) {
-  switch (field_id) {
-    case 1: {
-      this->key = value.as_fixed32();
-      return true;
-    }
-    default:
-      return false;
-  }
 }
 void FanStateResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_fixed32(1, this->key);
@@ -958,88 +506,6 @@ void FanCommandRequest::calculate_size(uint32_t &total_size) const {
 }
 #endif
 #ifdef USE_LIGHT
-bool ListEntitiesLightResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
-  switch (field_id) {
-    case 12: {
-      this->supported_color_modes.push_back(static_cast<enums::ColorMode>(value.as_uint32()));
-      return true;
-    }
-    case 5: {
-      this->legacy_supports_brightness = value.as_bool();
-      return true;
-    }
-    case 6: {
-      this->legacy_supports_rgb = value.as_bool();
-      return true;
-    }
-    case 7: {
-      this->legacy_supports_white_value = value.as_bool();
-      return true;
-    }
-    case 8: {
-      this->legacy_supports_color_temperature = value.as_bool();
-      return true;
-    }
-    case 13: {
-      this->disabled_by_default = value.as_bool();
-      return true;
-    }
-    case 15: {
-      this->entity_category = static_cast<enums::EntityCategory>(value.as_uint32());
-      return true;
-    }
-    case 16: {
-      this->device_id = value.as_uint32();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
-bool ListEntitiesLightResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
-  switch (field_id) {
-    case 1: {
-      this->object_id = value.as_string();
-      return true;
-    }
-    case 3: {
-      this->name = value.as_string();
-      return true;
-    }
-    case 4: {
-      this->unique_id = value.as_string();
-      return true;
-    }
-    case 11: {
-      this->effects.push_back(value.as_string());
-      return true;
-    }
-    case 14: {
-      this->icon = value.as_string();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
-bool ListEntitiesLightResponse::decode_32bit(uint32_t field_id, Proto32Bit value) {
-  switch (field_id) {
-    case 2: {
-      this->key = value.as_fixed32();
-      return true;
-    }
-    case 9: {
-      this->min_mireds = value.as_float();
-      return true;
-    }
-    case 10: {
-      this->max_mireds = value.as_float();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
 void ListEntitiesLightResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_string(1, this->object_id);
   buffer.encode_fixed32(2, this->key);
@@ -1087,80 +553,6 @@ void ListEntitiesLightResponse::calculate_size(uint32_t &total_size) const {
   ProtoSize::add_string_field(total_size, 1, this->icon);
   ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->entity_category));
   ProtoSize::add_uint32_field(total_size, 2, this->device_id);
-}
-bool LightStateResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
-  switch (field_id) {
-    case 2: {
-      this->state = value.as_bool();
-      return true;
-    }
-    case 11: {
-      this->color_mode = static_cast<enums::ColorMode>(value.as_uint32());
-      return true;
-    }
-    case 14: {
-      this->device_id = value.as_uint32();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
-bool LightStateResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
-  switch (field_id) {
-    case 9: {
-      this->effect = value.as_string();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
-bool LightStateResponse::decode_32bit(uint32_t field_id, Proto32Bit value) {
-  switch (field_id) {
-    case 1: {
-      this->key = value.as_fixed32();
-      return true;
-    }
-    case 3: {
-      this->brightness = value.as_float();
-      return true;
-    }
-    case 10: {
-      this->color_brightness = value.as_float();
-      return true;
-    }
-    case 4: {
-      this->red = value.as_float();
-      return true;
-    }
-    case 5: {
-      this->green = value.as_float();
-      return true;
-    }
-    case 6: {
-      this->blue = value.as_float();
-      return true;
-    }
-    case 7: {
-      this->white = value.as_float();
-      return true;
-    }
-    case 8: {
-      this->color_temperature = value.as_float();
-      return true;
-    }
-    case 12: {
-      this->cold_white = value.as_float();
-      return true;
-    }
-    case 13: {
-      this->warm_white = value.as_float();
-      return true;
-    }
-    default:
-      return false;
-  }
 }
 void LightStateResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_fixed32(1, this->key);
@@ -1386,80 +778,6 @@ void LightCommandRequest::calculate_size(uint32_t &total_size) const {
 }
 #endif
 #ifdef USE_SENSOR
-bool ListEntitiesSensorResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
-  switch (field_id) {
-    case 7: {
-      this->accuracy_decimals = value.as_int32();
-      return true;
-    }
-    case 8: {
-      this->force_update = value.as_bool();
-      return true;
-    }
-    case 10: {
-      this->state_class = static_cast<enums::SensorStateClass>(value.as_uint32());
-      return true;
-    }
-    case 11: {
-      this->legacy_last_reset_type = static_cast<enums::SensorLastResetType>(value.as_uint32());
-      return true;
-    }
-    case 12: {
-      this->disabled_by_default = value.as_bool();
-      return true;
-    }
-    case 13: {
-      this->entity_category = static_cast<enums::EntityCategory>(value.as_uint32());
-      return true;
-    }
-    case 14: {
-      this->device_id = value.as_uint32();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
-bool ListEntitiesSensorResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
-  switch (field_id) {
-    case 1: {
-      this->object_id = value.as_string();
-      return true;
-    }
-    case 3: {
-      this->name = value.as_string();
-      return true;
-    }
-    case 4: {
-      this->unique_id = value.as_string();
-      return true;
-    }
-    case 5: {
-      this->icon = value.as_string();
-      return true;
-    }
-    case 6: {
-      this->unit_of_measurement = value.as_string();
-      return true;
-    }
-    case 9: {
-      this->device_class = value.as_string();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
-bool ListEntitiesSensorResponse::decode_32bit(uint32_t field_id, Proto32Bit value) {
-  switch (field_id) {
-    case 2: {
-      this->key = value.as_fixed32();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
 void ListEntitiesSensorResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_string(1, this->object_id);
   buffer.encode_fixed32(2, this->key);
@@ -1492,34 +810,6 @@ void ListEntitiesSensorResponse::calculate_size(uint32_t &total_size) const {
   ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->entity_category));
   ProtoSize::add_uint32_field(total_size, 1, this->device_id);
 }
-bool SensorStateResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
-  switch (field_id) {
-    case 3: {
-      this->missing_state = value.as_bool();
-      return true;
-    }
-    case 4: {
-      this->device_id = value.as_uint32();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
-bool SensorStateResponse::decode_32bit(uint32_t field_id, Proto32Bit value) {
-  switch (field_id) {
-    case 1: {
-      this->key = value.as_fixed32();
-      return true;
-    }
-    case 2: {
-      this->state = value.as_float();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
 void SensorStateResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_fixed32(1, this->key);
   buffer.encode_float(2, this->state);
@@ -1534,64 +824,6 @@ void SensorStateResponse::calculate_size(uint32_t &total_size) const {
 }
 #endif
 #ifdef USE_SWITCH
-bool ListEntitiesSwitchResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
-  switch (field_id) {
-    case 6: {
-      this->assumed_state = value.as_bool();
-      return true;
-    }
-    case 7: {
-      this->disabled_by_default = value.as_bool();
-      return true;
-    }
-    case 8: {
-      this->entity_category = static_cast<enums::EntityCategory>(value.as_uint32());
-      return true;
-    }
-    case 10: {
-      this->device_id = value.as_uint32();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
-bool ListEntitiesSwitchResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
-  switch (field_id) {
-    case 1: {
-      this->object_id = value.as_string();
-      return true;
-    }
-    case 3: {
-      this->name = value.as_string();
-      return true;
-    }
-    case 4: {
-      this->unique_id = value.as_string();
-      return true;
-    }
-    case 5: {
-      this->icon = value.as_string();
-      return true;
-    }
-    case 9: {
-      this->device_class = value.as_string();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
-bool ListEntitiesSwitchResponse::decode_32bit(uint32_t field_id, Proto32Bit value) {
-  switch (field_id) {
-    case 2: {
-      this->key = value.as_fixed32();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
 void ListEntitiesSwitchResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_string(1, this->object_id);
   buffer.encode_fixed32(2, this->key);
@@ -1615,30 +847,6 @@ void ListEntitiesSwitchResponse::calculate_size(uint32_t &total_size) const {
   ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->entity_category));
   ProtoSize::add_string_field(total_size, 1, this->device_class);
   ProtoSize::add_uint32_field(total_size, 1, this->device_id);
-}
-bool SwitchStateResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
-  switch (field_id) {
-    case 2: {
-      this->state = value.as_bool();
-      return true;
-    }
-    case 3: {
-      this->device_id = value.as_uint32();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
-bool SwitchStateResponse::decode_32bit(uint32_t field_id, Proto32Bit value) {
-  switch (field_id) {
-    case 1: {
-      this->key = value.as_fixed32();
-      return true;
-    }
-    default:
-      return false;
-  }
 }
 void SwitchStateResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_fixed32(1, this->key);
@@ -1686,60 +894,6 @@ void SwitchCommandRequest::calculate_size(uint32_t &total_size) const {
 }
 #endif
 #ifdef USE_TEXT_SENSOR
-bool ListEntitiesTextSensorResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
-  switch (field_id) {
-    case 6: {
-      this->disabled_by_default = value.as_bool();
-      return true;
-    }
-    case 7: {
-      this->entity_category = static_cast<enums::EntityCategory>(value.as_uint32());
-      return true;
-    }
-    case 9: {
-      this->device_id = value.as_uint32();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
-bool ListEntitiesTextSensorResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
-  switch (field_id) {
-    case 1: {
-      this->object_id = value.as_string();
-      return true;
-    }
-    case 3: {
-      this->name = value.as_string();
-      return true;
-    }
-    case 4: {
-      this->unique_id = value.as_string();
-      return true;
-    }
-    case 5: {
-      this->icon = value.as_string();
-      return true;
-    }
-    case 8: {
-      this->device_class = value.as_string();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
-bool ListEntitiesTextSensorResponse::decode_32bit(uint32_t field_id, Proto32Bit value) {
-  switch (field_id) {
-    case 2: {
-      this->key = value.as_fixed32();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
 void ListEntitiesTextSensorResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_string(1, this->object_id);
   buffer.encode_fixed32(2, this->key);
@@ -1761,40 +915,6 @@ void ListEntitiesTextSensorResponse::calculate_size(uint32_t &total_size) const 
   ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->entity_category));
   ProtoSize::add_string_field(total_size, 1, this->device_class);
   ProtoSize::add_uint32_field(total_size, 1, this->device_id);
-}
-bool TextSensorStateResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
-  switch (field_id) {
-    case 3: {
-      this->missing_state = value.as_bool();
-      return true;
-    }
-    case 4: {
-      this->device_id = value.as_uint32();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
-bool TextSensorStateResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
-  switch (field_id) {
-    case 2: {
-      this->state = value.as_string();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
-bool TextSensorStateResponse::decode_32bit(uint32_t field_id, Proto32Bit value) {
-  switch (field_id) {
-    case 1: {
-      this->key = value.as_fixed32();
-      return true;
-    }
-    default:
-      return false;
-  }
 }
 void TextSensorStateResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_fixed32(1, this->key);
@@ -1831,30 +951,6 @@ void SubscribeLogsRequest::calculate_size(uint32_t &total_size) const {
   ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->level));
   ProtoSize::add_bool_field(total_size, 1, this->dump_config);
 }
-bool SubscribeLogsResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
-  switch (field_id) {
-    case 1: {
-      this->level = static_cast<enums::LogLevel>(value.as_uint32());
-      return true;
-    }
-    case 4: {
-      this->send_failed = value.as_bool();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
-bool SubscribeLogsResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
-  switch (field_id) {
-    case 3: {
-      this->message = value.as_string();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
 void SubscribeLogsResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint32(1, static_cast<uint32_t>(this->level));
   buffer.encode_bytes(3, reinterpret_cast<const uint8_t *>(this->message.data()), this->message.size());
@@ -1881,16 +977,6 @@ void NoiseEncryptionSetKeyRequest::encode(ProtoWriteBuffer buffer) const {
 }
 void NoiseEncryptionSetKeyRequest::calculate_size(uint32_t &total_size) const {
   ProtoSize::add_string_field(total_size, 1, this->key);
-}
-bool NoiseEncryptionSetKeyResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
-  switch (field_id) {
-    case 1: {
-      this->success = value.as_bool();
-      return true;
-    }
-    default:
-      return false;
-  }
 }
 void NoiseEncryptionSetKeyResponse::encode(ProtoWriteBuffer buffer) const { buffer.encode_bool(1, this->success); }
 void NoiseEncryptionSetKeyResponse::calculate_size(uint32_t &total_size) const {
@@ -1919,41 +1005,6 @@ void HomeassistantServiceMap::calculate_size(uint32_t &total_size) const {
   ProtoSize::add_string_field(total_size, 1, this->key);
   ProtoSize::add_string_field(total_size, 1, this->value);
 }
-bool HomeassistantServiceResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
-  switch (field_id) {
-    case 5: {
-      this->is_event = value.as_bool();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
-bool HomeassistantServiceResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
-  switch (field_id) {
-    case 1: {
-      this->service = value.as_string();
-      return true;
-    }
-    case 2: {
-      this->data.emplace_back();
-      value.decode_to_message(this->data.back());
-      return true;
-    }
-    case 3: {
-      this->data_template.emplace_back();
-      value.decode_to_message(this->data_template.back());
-      return true;
-    }
-    case 4: {
-      this->variables.emplace_back();
-      value.decode_to_message(this->variables.back());
-      return true;
-    }
-    default:
-      return false;
-  }
-}
 void HomeassistantServiceResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_string(1, this->service);
   for (auto &it : this->data) {
@@ -1973,30 +1024,6 @@ void HomeassistantServiceResponse::calculate_size(uint32_t &total_size) const {
   ProtoSize::add_repeated_message(total_size, 1, this->data_template);
   ProtoSize::add_repeated_message(total_size, 1, this->variables);
   ProtoSize::add_bool_field(total_size, 1, this->is_event);
-}
-bool SubscribeHomeAssistantStateResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
-  switch (field_id) {
-    case 3: {
-      this->once = value.as_bool();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
-bool SubscribeHomeAssistantStateResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
-  switch (field_id) {
-    case 1: {
-      this->entity_id = value.as_string();
-      return true;
-    }
-    case 2: {
-      this->attribute = value.as_string();
-      return true;
-    }
-    default:
-      return false;
-  }
 }
 void SubscribeHomeAssistantStateResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_string(1, this->entity_id);
@@ -2078,31 +1105,6 @@ void ListEntitiesServicesArgument::encode(ProtoWriteBuffer buffer) const {
 void ListEntitiesServicesArgument::calculate_size(uint32_t &total_size) const {
   ProtoSize::add_string_field(total_size, 1, this->name);
   ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->type));
-}
-bool ListEntitiesServicesResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
-  switch (field_id) {
-    case 1: {
-      this->name = value.as_string();
-      return true;
-    }
-    case 3: {
-      this->args.emplace_back();
-      value.decode_to_message(this->args.back());
-      return true;
-    }
-    default:
-      return false;
-  }
-}
-bool ListEntitiesServicesResponse::decode_32bit(uint32_t field_id, Proto32Bit value) {
-  switch (field_id) {
-    case 2: {
-      this->key = value.as_fixed32();
-      return true;
-    }
-    default:
-      return false;
-  }
 }
 void ListEntitiesServicesResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_string(1, this->name);
@@ -2247,56 +1249,6 @@ void ExecuteServiceRequest::calculate_size(uint32_t &total_size) const {
 }
 #endif
 #ifdef USE_CAMERA
-bool ListEntitiesCameraResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
-  switch (field_id) {
-    case 5: {
-      this->disabled_by_default = value.as_bool();
-      return true;
-    }
-    case 7: {
-      this->entity_category = static_cast<enums::EntityCategory>(value.as_uint32());
-      return true;
-    }
-    case 8: {
-      this->device_id = value.as_uint32();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
-bool ListEntitiesCameraResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
-  switch (field_id) {
-    case 1: {
-      this->object_id = value.as_string();
-      return true;
-    }
-    case 3: {
-      this->name = value.as_string();
-      return true;
-    }
-    case 4: {
-      this->unique_id = value.as_string();
-      return true;
-    }
-    case 6: {
-      this->icon = value.as_string();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
-bool ListEntitiesCameraResponse::decode_32bit(uint32_t field_id, Proto32Bit value) {
-  switch (field_id) {
-    case 2: {
-      this->key = value.as_fixed32();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
 void ListEntitiesCameraResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_string(1, this->object_id);
   buffer.encode_fixed32(2, this->key);
@@ -2316,40 +1268,6 @@ void ListEntitiesCameraResponse::calculate_size(uint32_t &total_size) const {
   ProtoSize::add_string_field(total_size, 1, this->icon);
   ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->entity_category));
   ProtoSize::add_uint32_field(total_size, 1, this->device_id);
-}
-bool CameraImageResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
-  switch (field_id) {
-    case 3: {
-      this->done = value.as_bool();
-      return true;
-    }
-    case 4: {
-      this->device_id = value.as_uint32();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
-bool CameraImageResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
-  switch (field_id) {
-    case 2: {
-      this->data = value.as_string();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
-bool CameraImageResponse::decode_32bit(uint32_t field_id, Proto32Bit value) {
-  switch (field_id) {
-    case 1: {
-      this->key = value.as_fixed32();
-      return true;
-    }
-    default:
-      return false;
-  }
 }
 void CameraImageResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_fixed32(1, this->key);
@@ -2387,128 +1305,6 @@ void CameraImageRequest::calculate_size(uint32_t &total_size) const {
 }
 #endif
 #ifdef USE_CLIMATE
-bool ListEntitiesClimateResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
-  switch (field_id) {
-    case 5: {
-      this->supports_current_temperature = value.as_bool();
-      return true;
-    }
-    case 6: {
-      this->supports_two_point_target_temperature = value.as_bool();
-      return true;
-    }
-    case 7: {
-      this->supported_modes.push_back(static_cast<enums::ClimateMode>(value.as_uint32()));
-      return true;
-    }
-    case 11: {
-      this->legacy_supports_away = value.as_bool();
-      return true;
-    }
-    case 12: {
-      this->supports_action = value.as_bool();
-      return true;
-    }
-    case 13: {
-      this->supported_fan_modes.push_back(static_cast<enums::ClimateFanMode>(value.as_uint32()));
-      return true;
-    }
-    case 14: {
-      this->supported_swing_modes.push_back(static_cast<enums::ClimateSwingMode>(value.as_uint32()));
-      return true;
-    }
-    case 16: {
-      this->supported_presets.push_back(static_cast<enums::ClimatePreset>(value.as_uint32()));
-      return true;
-    }
-    case 18: {
-      this->disabled_by_default = value.as_bool();
-      return true;
-    }
-    case 20: {
-      this->entity_category = static_cast<enums::EntityCategory>(value.as_uint32());
-      return true;
-    }
-    case 22: {
-      this->supports_current_humidity = value.as_bool();
-      return true;
-    }
-    case 23: {
-      this->supports_target_humidity = value.as_bool();
-      return true;
-    }
-    case 26: {
-      this->device_id = value.as_uint32();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
-bool ListEntitiesClimateResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
-  switch (field_id) {
-    case 1: {
-      this->object_id = value.as_string();
-      return true;
-    }
-    case 3: {
-      this->name = value.as_string();
-      return true;
-    }
-    case 4: {
-      this->unique_id = value.as_string();
-      return true;
-    }
-    case 15: {
-      this->supported_custom_fan_modes.push_back(value.as_string());
-      return true;
-    }
-    case 17: {
-      this->supported_custom_presets.push_back(value.as_string());
-      return true;
-    }
-    case 19: {
-      this->icon = value.as_string();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
-bool ListEntitiesClimateResponse::decode_32bit(uint32_t field_id, Proto32Bit value) {
-  switch (field_id) {
-    case 2: {
-      this->key = value.as_fixed32();
-      return true;
-    }
-    case 8: {
-      this->visual_min_temperature = value.as_float();
-      return true;
-    }
-    case 9: {
-      this->visual_max_temperature = value.as_float();
-      return true;
-    }
-    case 10: {
-      this->visual_target_temperature_step = value.as_float();
-      return true;
-    }
-    case 21: {
-      this->visual_current_temperature_step = value.as_float();
-      return true;
-    }
-    case 24: {
-      this->visual_min_humidity = value.as_float();
-      return true;
-    }
-    case 25: {
-      this->visual_max_humidity = value.as_float();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
 void ListEntitiesClimateResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_string(1, this->object_id);
   buffer.encode_fixed32(2, this->key);
@@ -2600,88 +1396,6 @@ void ListEntitiesClimateResponse::calculate_size(uint32_t &total_size) const {
   ProtoSize::add_fixed_field<4>(total_size, 2, this->visual_min_humidity != 0.0f);
   ProtoSize::add_fixed_field<4>(total_size, 2, this->visual_max_humidity != 0.0f);
   ProtoSize::add_uint32_field(total_size, 2, this->device_id);
-}
-bool ClimateStateResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
-  switch (field_id) {
-    case 2: {
-      this->mode = static_cast<enums::ClimateMode>(value.as_uint32());
-      return true;
-    }
-    case 7: {
-      this->unused_legacy_away = value.as_bool();
-      return true;
-    }
-    case 8: {
-      this->action = static_cast<enums::ClimateAction>(value.as_uint32());
-      return true;
-    }
-    case 9: {
-      this->fan_mode = static_cast<enums::ClimateFanMode>(value.as_uint32());
-      return true;
-    }
-    case 10: {
-      this->swing_mode = static_cast<enums::ClimateSwingMode>(value.as_uint32());
-      return true;
-    }
-    case 12: {
-      this->preset = static_cast<enums::ClimatePreset>(value.as_uint32());
-      return true;
-    }
-    case 16: {
-      this->device_id = value.as_uint32();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
-bool ClimateStateResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
-  switch (field_id) {
-    case 11: {
-      this->custom_fan_mode = value.as_string();
-      return true;
-    }
-    case 13: {
-      this->custom_preset = value.as_string();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
-bool ClimateStateResponse::decode_32bit(uint32_t field_id, Proto32Bit value) {
-  switch (field_id) {
-    case 1: {
-      this->key = value.as_fixed32();
-      return true;
-    }
-    case 3: {
-      this->current_temperature = value.as_float();
-      return true;
-    }
-    case 4: {
-      this->target_temperature = value.as_float();
-      return true;
-    }
-    case 5: {
-      this->target_temperature_low = value.as_float();
-      return true;
-    }
-    case 6: {
-      this->target_temperature_high = value.as_float();
-      return true;
-    }
-    case 14: {
-      this->current_humidity = value.as_float();
-      return true;
-    }
-    case 15: {
-      this->target_humidity = value.as_float();
-      return true;
-    }
-    default:
-      return false;
-  }
 }
 void ClimateStateResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_fixed32(1, this->key);
@@ -2887,80 +1601,6 @@ void ClimateCommandRequest::calculate_size(uint32_t &total_size) const {
 }
 #endif
 #ifdef USE_NUMBER
-bool ListEntitiesNumberResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
-  switch (field_id) {
-    case 9: {
-      this->disabled_by_default = value.as_bool();
-      return true;
-    }
-    case 10: {
-      this->entity_category = static_cast<enums::EntityCategory>(value.as_uint32());
-      return true;
-    }
-    case 12: {
-      this->mode = static_cast<enums::NumberMode>(value.as_uint32());
-      return true;
-    }
-    case 14: {
-      this->device_id = value.as_uint32();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
-bool ListEntitiesNumberResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
-  switch (field_id) {
-    case 1: {
-      this->object_id = value.as_string();
-      return true;
-    }
-    case 3: {
-      this->name = value.as_string();
-      return true;
-    }
-    case 4: {
-      this->unique_id = value.as_string();
-      return true;
-    }
-    case 5: {
-      this->icon = value.as_string();
-      return true;
-    }
-    case 11: {
-      this->unit_of_measurement = value.as_string();
-      return true;
-    }
-    case 13: {
-      this->device_class = value.as_string();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
-bool ListEntitiesNumberResponse::decode_32bit(uint32_t field_id, Proto32Bit value) {
-  switch (field_id) {
-    case 2: {
-      this->key = value.as_fixed32();
-      return true;
-    }
-    case 6: {
-      this->min_value = value.as_float();
-      return true;
-    }
-    case 7: {
-      this->max_value = value.as_float();
-      return true;
-    }
-    case 8: {
-      this->step = value.as_float();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
 void ListEntitiesNumberResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_string(1, this->object_id);
   buffer.encode_fixed32(2, this->key);
@@ -2992,34 +1632,6 @@ void ListEntitiesNumberResponse::calculate_size(uint32_t &total_size) const {
   ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->mode));
   ProtoSize::add_string_field(total_size, 1, this->device_class);
   ProtoSize::add_uint32_field(total_size, 1, this->device_id);
-}
-bool NumberStateResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
-  switch (field_id) {
-    case 3: {
-      this->missing_state = value.as_bool();
-      return true;
-    }
-    case 4: {
-      this->device_id = value.as_uint32();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
-bool NumberStateResponse::decode_32bit(uint32_t field_id, Proto32Bit value) {
-  switch (field_id) {
-    case 1: {
-      this->key = value.as_fixed32();
-      return true;
-    }
-    case 2: {
-      this->state = value.as_float();
-      return true;
-    }
-    default:
-      return false;
-  }
 }
 void NumberStateResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_fixed32(1, this->key);
@@ -3069,60 +1681,6 @@ void NumberCommandRequest::calculate_size(uint32_t &total_size) const {
 }
 #endif
 #ifdef USE_SELECT
-bool ListEntitiesSelectResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
-  switch (field_id) {
-    case 7: {
-      this->disabled_by_default = value.as_bool();
-      return true;
-    }
-    case 8: {
-      this->entity_category = static_cast<enums::EntityCategory>(value.as_uint32());
-      return true;
-    }
-    case 9: {
-      this->device_id = value.as_uint32();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
-bool ListEntitiesSelectResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
-  switch (field_id) {
-    case 1: {
-      this->object_id = value.as_string();
-      return true;
-    }
-    case 3: {
-      this->name = value.as_string();
-      return true;
-    }
-    case 4: {
-      this->unique_id = value.as_string();
-      return true;
-    }
-    case 5: {
-      this->icon = value.as_string();
-      return true;
-    }
-    case 6: {
-      this->options.push_back(value.as_string());
-      return true;
-    }
-    default:
-      return false;
-  }
-}
-bool ListEntitiesSelectResponse::decode_32bit(uint32_t field_id, Proto32Bit value) {
-  switch (field_id) {
-    case 2: {
-      this->key = value.as_fixed32();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
 void ListEntitiesSelectResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_string(1, this->object_id);
   buffer.encode_fixed32(2, this->key);
@@ -3150,40 +1708,6 @@ void ListEntitiesSelectResponse::calculate_size(uint32_t &total_size) const {
   ProtoSize::add_bool_field(total_size, 1, this->disabled_by_default);
   ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->entity_category));
   ProtoSize::add_uint32_field(total_size, 1, this->device_id);
-}
-bool SelectStateResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
-  switch (field_id) {
-    case 3: {
-      this->missing_state = value.as_bool();
-      return true;
-    }
-    case 4: {
-      this->device_id = value.as_uint32();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
-bool SelectStateResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
-  switch (field_id) {
-    case 2: {
-      this->state = value.as_string();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
-bool SelectStateResponse::decode_32bit(uint32_t field_id, Proto32Bit value) {
-  switch (field_id) {
-    case 1: {
-      this->key = value.as_fixed32();
-      return true;
-    }
-    default:
-      return false;
-  }
 }
 void SelectStateResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_fixed32(1, this->key);
@@ -3239,68 +1763,6 @@ void SelectCommandRequest::calculate_size(uint32_t &total_size) const {
 }
 #endif
 #ifdef USE_SIREN
-bool ListEntitiesSirenResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
-  switch (field_id) {
-    case 6: {
-      this->disabled_by_default = value.as_bool();
-      return true;
-    }
-    case 8: {
-      this->supports_duration = value.as_bool();
-      return true;
-    }
-    case 9: {
-      this->supports_volume = value.as_bool();
-      return true;
-    }
-    case 10: {
-      this->entity_category = static_cast<enums::EntityCategory>(value.as_uint32());
-      return true;
-    }
-    case 11: {
-      this->device_id = value.as_uint32();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
-bool ListEntitiesSirenResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
-  switch (field_id) {
-    case 1: {
-      this->object_id = value.as_string();
-      return true;
-    }
-    case 3: {
-      this->name = value.as_string();
-      return true;
-    }
-    case 4: {
-      this->unique_id = value.as_string();
-      return true;
-    }
-    case 5: {
-      this->icon = value.as_string();
-      return true;
-    }
-    case 7: {
-      this->tones.push_back(value.as_string());
-      return true;
-    }
-    default:
-      return false;
-  }
-}
-bool ListEntitiesSirenResponse::decode_32bit(uint32_t field_id, Proto32Bit value) {
-  switch (field_id) {
-    case 2: {
-      this->key = value.as_fixed32();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
 void ListEntitiesSirenResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_string(1, this->object_id);
   buffer.encode_fixed32(2, this->key);
@@ -3332,30 +1794,6 @@ void ListEntitiesSirenResponse::calculate_size(uint32_t &total_size) const {
   ProtoSize::add_bool_field(total_size, 1, this->supports_volume);
   ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->entity_category));
   ProtoSize::add_uint32_field(total_size, 1, this->device_id);
-}
-bool SirenStateResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
-  switch (field_id) {
-    case 2: {
-      this->state = value.as_bool();
-      return true;
-    }
-    case 3: {
-      this->device_id = value.as_uint32();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
-bool SirenStateResponse::decode_32bit(uint32_t field_id, Proto32Bit value) {
-  switch (field_id) {
-    case 1: {
-      this->key = value.as_fixed32();
-      return true;
-    }
-    default:
-      return false;
-  }
 }
 void SirenStateResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_fixed32(1, this->key);
@@ -3451,72 +1889,6 @@ void SirenCommandRequest::calculate_size(uint32_t &total_size) const {
 }
 #endif
 #ifdef USE_LOCK
-bool ListEntitiesLockResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
-  switch (field_id) {
-    case 6: {
-      this->disabled_by_default = value.as_bool();
-      return true;
-    }
-    case 7: {
-      this->entity_category = static_cast<enums::EntityCategory>(value.as_uint32());
-      return true;
-    }
-    case 8: {
-      this->assumed_state = value.as_bool();
-      return true;
-    }
-    case 9: {
-      this->supports_open = value.as_bool();
-      return true;
-    }
-    case 10: {
-      this->requires_code = value.as_bool();
-      return true;
-    }
-    case 12: {
-      this->device_id = value.as_uint32();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
-bool ListEntitiesLockResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
-  switch (field_id) {
-    case 1: {
-      this->object_id = value.as_string();
-      return true;
-    }
-    case 3: {
-      this->name = value.as_string();
-      return true;
-    }
-    case 4: {
-      this->unique_id = value.as_string();
-      return true;
-    }
-    case 5: {
-      this->icon = value.as_string();
-      return true;
-    }
-    case 11: {
-      this->code_format = value.as_string();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
-bool ListEntitiesLockResponse::decode_32bit(uint32_t field_id, Proto32Bit value) {
-  switch (field_id) {
-    case 2: {
-      this->key = value.as_fixed32();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
 void ListEntitiesLockResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_string(1, this->object_id);
   buffer.encode_fixed32(2, this->key);
@@ -3544,30 +1916,6 @@ void ListEntitiesLockResponse::calculate_size(uint32_t &total_size) const {
   ProtoSize::add_bool_field(total_size, 1, this->requires_code);
   ProtoSize::add_string_field(total_size, 1, this->code_format);
   ProtoSize::add_uint32_field(total_size, 1, this->device_id);
-}
-bool LockStateResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
-  switch (field_id) {
-    case 2: {
-      this->state = static_cast<enums::LockState>(value.as_uint32());
-      return true;
-    }
-    case 3: {
-      this->device_id = value.as_uint32();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
-bool LockStateResponse::decode_32bit(uint32_t field_id, Proto32Bit value) {
-  switch (field_id) {
-    case 1: {
-      this->key = value.as_fixed32();
-      return true;
-    }
-    default:
-      return false;
-  }
 }
 void LockStateResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_fixed32(1, this->key);
@@ -3633,60 +1981,6 @@ void LockCommandRequest::calculate_size(uint32_t &total_size) const {
 }
 #endif
 #ifdef USE_BUTTON
-bool ListEntitiesButtonResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
-  switch (field_id) {
-    case 6: {
-      this->disabled_by_default = value.as_bool();
-      return true;
-    }
-    case 7: {
-      this->entity_category = static_cast<enums::EntityCategory>(value.as_uint32());
-      return true;
-    }
-    case 9: {
-      this->device_id = value.as_uint32();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
-bool ListEntitiesButtonResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
-  switch (field_id) {
-    case 1: {
-      this->object_id = value.as_string();
-      return true;
-    }
-    case 3: {
-      this->name = value.as_string();
-      return true;
-    }
-    case 4: {
-      this->unique_id = value.as_string();
-      return true;
-    }
-    case 5: {
-      this->icon = value.as_string();
-      return true;
-    }
-    case 8: {
-      this->device_class = value.as_string();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
-bool ListEntitiesButtonResponse::decode_32bit(uint32_t field_id, Proto32Bit value) {
-  switch (field_id) {
-    case 2: {
-      this->key = value.as_fixed32();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
 void ListEntitiesButtonResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_string(1, this->object_id);
   buffer.encode_fixed32(2, this->key);
@@ -3785,65 +2079,6 @@ void MediaPlayerSupportedFormat::calculate_size(uint32_t &total_size) const {
   ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->purpose));
   ProtoSize::add_uint32_field(total_size, 1, this->sample_bytes);
 }
-bool ListEntitiesMediaPlayerResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
-  switch (field_id) {
-    case 6: {
-      this->disabled_by_default = value.as_bool();
-      return true;
-    }
-    case 7: {
-      this->entity_category = static_cast<enums::EntityCategory>(value.as_uint32());
-      return true;
-    }
-    case 8: {
-      this->supports_pause = value.as_bool();
-      return true;
-    }
-    case 10: {
-      this->device_id = value.as_uint32();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
-bool ListEntitiesMediaPlayerResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
-  switch (field_id) {
-    case 1: {
-      this->object_id = value.as_string();
-      return true;
-    }
-    case 3: {
-      this->name = value.as_string();
-      return true;
-    }
-    case 4: {
-      this->unique_id = value.as_string();
-      return true;
-    }
-    case 5: {
-      this->icon = value.as_string();
-      return true;
-    }
-    case 9: {
-      this->supported_formats.emplace_back();
-      value.decode_to_message(this->supported_formats.back());
-      return true;
-    }
-    default:
-      return false;
-  }
-}
-bool ListEntitiesMediaPlayerResponse::decode_32bit(uint32_t field_id, Proto32Bit value) {
-  switch (field_id) {
-    case 2: {
-      this->key = value.as_fixed32();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
 void ListEntitiesMediaPlayerResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_string(1, this->object_id);
   buffer.encode_fixed32(2, this->key);
@@ -3869,38 +2104,6 @@ void ListEntitiesMediaPlayerResponse::calculate_size(uint32_t &total_size) const
   ProtoSize::add_bool_field(total_size, 1, this->supports_pause);
   ProtoSize::add_repeated_message(total_size, 1, this->supported_formats);
   ProtoSize::add_uint32_field(total_size, 1, this->device_id);
-}
-bool MediaPlayerStateResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
-  switch (field_id) {
-    case 2: {
-      this->state = static_cast<enums::MediaPlayerState>(value.as_uint32());
-      return true;
-    }
-    case 4: {
-      this->muted = value.as_bool();
-      return true;
-    }
-    case 5: {
-      this->device_id = value.as_uint32();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
-bool MediaPlayerStateResponse::decode_32bit(uint32_t field_id, Proto32Bit value) {
-  switch (field_id) {
-    case 1: {
-      this->key = value.as_fixed32();
-      return true;
-    }
-    case 3: {
-      this->volume = value.as_float();
-      return true;
-    }
-    default:
-      return false;
-  }
 }
 void MediaPlayerStateResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_fixed32(1, this->key);
@@ -4056,48 +2259,6 @@ void BluetoothServiceData::calculate_size(uint32_t &total_size) const {
   }
   ProtoSize::add_string_field(total_size, 1, this->data);
 }
-bool BluetoothLEAdvertisementResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
-  switch (field_id) {
-    case 1: {
-      this->address = value.as_uint64();
-      return true;
-    }
-    case 3: {
-      this->rssi = value.as_sint32();
-      return true;
-    }
-    case 7: {
-      this->address_type = value.as_uint32();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
-bool BluetoothLEAdvertisementResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
-  switch (field_id) {
-    case 2: {
-      this->name = value.as_string();
-      return true;
-    }
-    case 4: {
-      this->service_uuids.push_back(value.as_string());
-      return true;
-    }
-    case 5: {
-      this->service_data.emplace_back();
-      value.decode_to_message(this->service_data.back());
-      return true;
-    }
-    case 6: {
-      this->manufacturer_data.emplace_back();
-      value.decode_to_message(this->manufacturer_data.back());
-      return true;
-    }
-    default:
-      return false;
-  }
-}
 void BluetoothLEAdvertisementResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint64(1, this->address);
   buffer.encode_bytes(2, reinterpret_cast<const uint8_t *>(this->name.data()), this->name.size());
@@ -4166,17 +2327,6 @@ void BluetoothLERawAdvertisement::calculate_size(uint32_t &total_size) const {
   ProtoSize::add_uint32_field(total_size, 1, this->address_type);
   ProtoSize::add_string_field(total_size, 1, this->data);
 }
-bool BluetoothLERawAdvertisementsResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
-  switch (field_id) {
-    case 1: {
-      this->advertisements.emplace_back();
-      value.decode_to_message(this->advertisements.back());
-      return true;
-    }
-    default:
-      return false;
-  }
-}
 void BluetoothLERawAdvertisementsResponse::encode(ProtoWriteBuffer buffer) const {
   for (auto &it : this->advertisements) {
     buffer.encode_message(1, it, true);
@@ -4218,28 +2368,6 @@ void BluetoothDeviceRequest::calculate_size(uint32_t &total_size) const {
   ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->request_type));
   ProtoSize::add_bool_field(total_size, 1, this->has_address_type);
   ProtoSize::add_uint32_field(total_size, 1, this->address_type);
-}
-bool BluetoothDeviceConnectionResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
-  switch (field_id) {
-    case 1: {
-      this->address = value.as_uint64();
-      return true;
-    }
-    case 2: {
-      this->connected = value.as_bool();
-      return true;
-    }
-    case 3: {
-      this->mtu = value.as_uint32();
-      return true;
-    }
-    case 4: {
-      this->error = value.as_int32();
-      return true;
-    }
-    default:
-      return false;
-  }
 }
 void BluetoothDeviceConnectionResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint64(1, this->address);
@@ -4387,27 +2515,6 @@ void BluetoothGATTService::calculate_size(uint32_t &total_size) const {
   ProtoSize::add_uint32_field(total_size, 1, this->handle);
   ProtoSize::add_repeated_message(total_size, 1, this->characteristics);
 }
-bool BluetoothGATTGetServicesResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
-  switch (field_id) {
-    case 1: {
-      this->address = value.as_uint64();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
-bool BluetoothGATTGetServicesResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
-  switch (field_id) {
-    case 2: {
-      this->services.emplace_back();
-      value.decode_to_message(this->services.back());
-      return true;
-    }
-    default:
-      return false;
-  }
-}
 void BluetoothGATTGetServicesResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint64(1, this->address);
   for (auto &it : this->services) {
@@ -4417,16 +2524,6 @@ void BluetoothGATTGetServicesResponse::encode(ProtoWriteBuffer buffer) const {
 void BluetoothGATTGetServicesResponse::calculate_size(uint32_t &total_size) const {
   ProtoSize::add_uint64_field(total_size, 1, this->address);
   ProtoSize::add_repeated_message(total_size, 1, this->services);
-}
-bool BluetoothGATTGetServicesDoneResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
-  switch (field_id) {
-    case 1: {
-      this->address = value.as_uint64();
-      return true;
-    }
-    default:
-      return false;
-  }
 }
 void BluetoothGATTGetServicesDoneResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint64(1, this->address);
@@ -4455,30 +2552,6 @@ void BluetoothGATTReadRequest::encode(ProtoWriteBuffer buffer) const {
 void BluetoothGATTReadRequest::calculate_size(uint32_t &total_size) const {
   ProtoSize::add_uint64_field(total_size, 1, this->address);
   ProtoSize::add_uint32_field(total_size, 1, this->handle);
-}
-bool BluetoothGATTReadResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
-  switch (field_id) {
-    case 1: {
-      this->address = value.as_uint64();
-      return true;
-    }
-    case 2: {
-      this->handle = value.as_uint32();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
-bool BluetoothGATTReadResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
-  switch (field_id) {
-    case 3: {
-      this->data = value.as_string();
-      return true;
-    }
-    default:
-      return false;
-  }
 }
 void BluetoothGATTReadResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint64(1, this->address);
@@ -4614,30 +2687,6 @@ void BluetoothGATTNotifyRequest::calculate_size(uint32_t &total_size) const {
   ProtoSize::add_uint32_field(total_size, 1, this->handle);
   ProtoSize::add_bool_field(total_size, 1, this->enable);
 }
-bool BluetoothGATTNotifyDataResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
-  switch (field_id) {
-    case 1: {
-      this->address = value.as_uint64();
-      return true;
-    }
-    case 2: {
-      this->handle = value.as_uint32();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
-bool BluetoothGATTNotifyDataResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
-  switch (field_id) {
-    case 3: {
-      this->data = value.as_string();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
 void BluetoothGATTNotifyDataResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint64(1, this->address);
   buffer.encode_uint32(2, this->handle);
@@ -4647,24 +2696,6 @@ void BluetoothGATTNotifyDataResponse::calculate_size(uint32_t &total_size) const
   ProtoSize::add_uint64_field(total_size, 1, this->address);
   ProtoSize::add_uint32_field(total_size, 1, this->handle);
   ProtoSize::add_string_field(total_size, 1, this->data);
-}
-bool BluetoothConnectionsFreeResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
-  switch (field_id) {
-    case 1: {
-      this->free = value.as_uint32();
-      return true;
-    }
-    case 2: {
-      this->limit = value.as_uint32();
-      return true;
-    }
-    case 3: {
-      this->allocated.push_back(value.as_uint64());
-      return true;
-    }
-    default:
-      return false;
-  }
 }
 void BluetoothConnectionsFreeResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint32(1, this->free);
@@ -4682,24 +2713,6 @@ void BluetoothConnectionsFreeResponse::calculate_size(uint32_t &total_size) cons
     }
   }
 }
-bool BluetoothGATTErrorResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
-  switch (field_id) {
-    case 1: {
-      this->address = value.as_uint64();
-      return true;
-    }
-    case 2: {
-      this->handle = value.as_uint32();
-      return true;
-    }
-    case 3: {
-      this->error = value.as_int32();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
 void BluetoothGATTErrorResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint64(1, this->address);
   buffer.encode_uint32(2, this->handle);
@@ -4710,20 +2723,6 @@ void BluetoothGATTErrorResponse::calculate_size(uint32_t &total_size) const {
   ProtoSize::add_uint32_field(total_size, 1, this->handle);
   ProtoSize::add_int32_field(total_size, 1, this->error);
 }
-bool BluetoothGATTWriteResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
-  switch (field_id) {
-    case 1: {
-      this->address = value.as_uint64();
-      return true;
-    }
-    case 2: {
-      this->handle = value.as_uint32();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
 void BluetoothGATTWriteResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint64(1, this->address);
   buffer.encode_uint32(2, this->handle);
@@ -4732,20 +2731,6 @@ void BluetoothGATTWriteResponse::calculate_size(uint32_t &total_size) const {
   ProtoSize::add_uint64_field(total_size, 1, this->address);
   ProtoSize::add_uint32_field(total_size, 1, this->handle);
 }
-bool BluetoothGATTNotifyResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
-  switch (field_id) {
-    case 1: {
-      this->address = value.as_uint64();
-      return true;
-    }
-    case 2: {
-      this->handle = value.as_uint32();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
 void BluetoothGATTNotifyResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint64(1, this->address);
   buffer.encode_uint32(2, this->handle);
@@ -4753,24 +2738,6 @@ void BluetoothGATTNotifyResponse::encode(ProtoWriteBuffer buffer) const {
 void BluetoothGATTNotifyResponse::calculate_size(uint32_t &total_size) const {
   ProtoSize::add_uint64_field(total_size, 1, this->address);
   ProtoSize::add_uint32_field(total_size, 1, this->handle);
-}
-bool BluetoothDevicePairingResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
-  switch (field_id) {
-    case 1: {
-      this->address = value.as_uint64();
-      return true;
-    }
-    case 2: {
-      this->paired = value.as_bool();
-      return true;
-    }
-    case 3: {
-      this->error = value.as_int32();
-      return true;
-    }
-    default:
-      return false;
-  }
 }
 void BluetoothDevicePairingResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint64(1, this->address);
@@ -4782,24 +2749,6 @@ void BluetoothDevicePairingResponse::calculate_size(uint32_t &total_size) const 
   ProtoSize::add_bool_field(total_size, 1, this->paired);
   ProtoSize::add_int32_field(total_size, 1, this->error);
 }
-bool BluetoothDeviceUnpairingResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
-  switch (field_id) {
-    case 1: {
-      this->address = value.as_uint64();
-      return true;
-    }
-    case 2: {
-      this->success = value.as_bool();
-      return true;
-    }
-    case 3: {
-      this->error = value.as_int32();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
 void BluetoothDeviceUnpairingResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint64(1, this->address);
   buffer.encode_bool(2, this->success);
@@ -4810,24 +2759,6 @@ void BluetoothDeviceUnpairingResponse::calculate_size(uint32_t &total_size) cons
   ProtoSize::add_bool_field(total_size, 1, this->success);
   ProtoSize::add_int32_field(total_size, 1, this->error);
 }
-bool BluetoothDeviceClearCacheResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
-  switch (field_id) {
-    case 1: {
-      this->address = value.as_uint64();
-      return true;
-    }
-    case 2: {
-      this->success = value.as_bool();
-      return true;
-    }
-    case 3: {
-      this->error = value.as_int32();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
 void BluetoothDeviceClearCacheResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint64(1, this->address);
   buffer.encode_bool(2, this->success);
@@ -4837,20 +2768,6 @@ void BluetoothDeviceClearCacheResponse::calculate_size(uint32_t &total_size) con
   ProtoSize::add_uint64_field(total_size, 1, this->address);
   ProtoSize::add_bool_field(total_size, 1, this->success);
   ProtoSize::add_int32_field(total_size, 1, this->error);
-}
-bool BluetoothScannerStateResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
-  switch (field_id) {
-    case 1: {
-      this->state = static_cast<enums::BluetoothScannerState>(value.as_uint32());
-      return true;
-    }
-    case 2: {
-      this->mode = static_cast<enums::BluetoothScannerMode>(value.as_uint32());
-      return true;
-    }
-    default:
-      return false;
-  }
 }
 void BluetoothScannerStateResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint32(1, static_cast<uint32_t>(this->state));
@@ -4933,38 +2850,6 @@ void VoiceAssistantAudioSettings::calculate_size(uint32_t &total_size) const {
   ProtoSize::add_uint32_field(total_size, 1, this->noise_suppression_level);
   ProtoSize::add_uint32_field(total_size, 1, this->auto_gain);
   ProtoSize::add_fixed_field<4>(total_size, 1, this->volume_multiplier != 0.0f);
-}
-bool VoiceAssistantRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
-  switch (field_id) {
-    case 1: {
-      this->start = value.as_bool();
-      return true;
-    }
-    case 3: {
-      this->flags = value.as_uint32();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
-bool VoiceAssistantRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
-  switch (field_id) {
-    case 2: {
-      this->conversation_id = value.as_string();
-      return true;
-    }
-    case 4: {
-      value.decode_to_message(this->audio_settings);
-      return true;
-    }
-    case 5: {
-      this->wake_word_phrase = value.as_string();
-      return true;
-    }
-    default:
-      return false;
-  }
 }
 void VoiceAssistantRequest::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_bool(1, this->start);
@@ -5175,16 +3060,6 @@ void VoiceAssistantAnnounceRequest::calculate_size(uint32_t &total_size) const {
   ProtoSize::add_string_field(total_size, 1, this->preannounce_media_id);
   ProtoSize::add_bool_field(total_size, 1, this->start_conversation);
 }
-bool VoiceAssistantAnnounceFinished::decode_varint(uint32_t field_id, ProtoVarInt value) {
-  switch (field_id) {
-    case 1: {
-      this->success = value.as_bool();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
 void VoiceAssistantAnnounceFinished::encode(ProtoWriteBuffer buffer) const { buffer.encode_bool(1, this->success); }
 void VoiceAssistantAnnounceFinished::calculate_size(uint32_t &total_size) const {
   ProtoSize::add_bool_field(total_size, 1, this->success);
@@ -5221,31 +3096,6 @@ void VoiceAssistantWakeWord::calculate_size(uint32_t &total_size) const {
     for (const auto &it : this->trained_languages) {
       ProtoSize::add_string_field_repeated(total_size, 1, it);
     }
-  }
-}
-bool VoiceAssistantConfigurationResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
-  switch (field_id) {
-    case 3: {
-      this->max_active_wake_words = value.as_uint32();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
-bool VoiceAssistantConfigurationResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
-  switch (field_id) {
-    case 1: {
-      this->available_wake_words.emplace_back();
-      value.decode_to_message(this->available_wake_words.back());
-      return true;
-    }
-    case 2: {
-      this->active_wake_words.push_back(value.as_string());
-      return true;
-    }
-    default:
-      return false;
   }
 }
 void VoiceAssistantConfigurationResponse::encode(ProtoWriteBuffer buffer) const {
@@ -5290,68 +3140,6 @@ void VoiceAssistantSetConfiguration::calculate_size(uint32_t &total_size) const 
 }
 #endif
 #ifdef USE_ALARM_CONTROL_PANEL
-bool ListEntitiesAlarmControlPanelResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
-  switch (field_id) {
-    case 6: {
-      this->disabled_by_default = value.as_bool();
-      return true;
-    }
-    case 7: {
-      this->entity_category = static_cast<enums::EntityCategory>(value.as_uint32());
-      return true;
-    }
-    case 8: {
-      this->supported_features = value.as_uint32();
-      return true;
-    }
-    case 9: {
-      this->requires_code = value.as_bool();
-      return true;
-    }
-    case 10: {
-      this->requires_code_to_arm = value.as_bool();
-      return true;
-    }
-    case 11: {
-      this->device_id = value.as_uint32();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
-bool ListEntitiesAlarmControlPanelResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
-  switch (field_id) {
-    case 1: {
-      this->object_id = value.as_string();
-      return true;
-    }
-    case 3: {
-      this->name = value.as_string();
-      return true;
-    }
-    case 4: {
-      this->unique_id = value.as_string();
-      return true;
-    }
-    case 5: {
-      this->icon = value.as_string();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
-bool ListEntitiesAlarmControlPanelResponse::decode_32bit(uint32_t field_id, Proto32Bit value) {
-  switch (field_id) {
-    case 2: {
-      this->key = value.as_fixed32();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
 void ListEntitiesAlarmControlPanelResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_string(1, this->object_id);
   buffer.encode_fixed32(2, this->key);
@@ -5377,30 +3165,6 @@ void ListEntitiesAlarmControlPanelResponse::calculate_size(uint32_t &total_size)
   ProtoSize::add_bool_field(total_size, 1, this->requires_code);
   ProtoSize::add_bool_field(total_size, 1, this->requires_code_to_arm);
   ProtoSize::add_uint32_field(total_size, 1, this->device_id);
-}
-bool AlarmControlPanelStateResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
-  switch (field_id) {
-    case 2: {
-      this->state = static_cast<enums::AlarmControlPanelState>(value.as_uint32());
-      return true;
-    }
-    case 3: {
-      this->device_id = value.as_uint32();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
-bool AlarmControlPanelStateResponse::decode_32bit(uint32_t field_id, Proto32Bit value) {
-  switch (field_id) {
-    case 1: {
-      this->key = value.as_fixed32();
-      return true;
-    }
-    default:
-      return false;
-  }
 }
 void AlarmControlPanelStateResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_fixed32(1, this->key);
@@ -5460,72 +3224,6 @@ void AlarmControlPanelCommandRequest::calculate_size(uint32_t &total_size) const
 }
 #endif
 #ifdef USE_TEXT
-bool ListEntitiesTextResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
-  switch (field_id) {
-    case 6: {
-      this->disabled_by_default = value.as_bool();
-      return true;
-    }
-    case 7: {
-      this->entity_category = static_cast<enums::EntityCategory>(value.as_uint32());
-      return true;
-    }
-    case 8: {
-      this->min_length = value.as_uint32();
-      return true;
-    }
-    case 9: {
-      this->max_length = value.as_uint32();
-      return true;
-    }
-    case 11: {
-      this->mode = static_cast<enums::TextMode>(value.as_uint32());
-      return true;
-    }
-    case 12: {
-      this->device_id = value.as_uint32();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
-bool ListEntitiesTextResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
-  switch (field_id) {
-    case 1: {
-      this->object_id = value.as_string();
-      return true;
-    }
-    case 3: {
-      this->name = value.as_string();
-      return true;
-    }
-    case 4: {
-      this->unique_id = value.as_string();
-      return true;
-    }
-    case 5: {
-      this->icon = value.as_string();
-      return true;
-    }
-    case 10: {
-      this->pattern = value.as_string();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
-bool ListEntitiesTextResponse::decode_32bit(uint32_t field_id, Proto32Bit value) {
-  switch (field_id) {
-    case 2: {
-      this->key = value.as_fixed32();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
 void ListEntitiesTextResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_string(1, this->object_id);
   buffer.encode_fixed32(2, this->key);
@@ -5553,40 +3251,6 @@ void ListEntitiesTextResponse::calculate_size(uint32_t &total_size) const {
   ProtoSize::add_string_field(total_size, 1, this->pattern);
   ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->mode));
   ProtoSize::add_uint32_field(total_size, 1, this->device_id);
-}
-bool TextStateResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
-  switch (field_id) {
-    case 3: {
-      this->missing_state = value.as_bool();
-      return true;
-    }
-    case 4: {
-      this->device_id = value.as_uint32();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
-bool TextStateResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
-  switch (field_id) {
-    case 2: {
-      this->state = value.as_string();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
-bool TextStateResponse::decode_32bit(uint32_t field_id, Proto32Bit value) {
-  switch (field_id) {
-    case 1: {
-      this->key = value.as_fixed32();
-      return true;
-    }
-    default:
-      return false;
-  }
 }
 void TextStateResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_fixed32(1, this->key);
@@ -5642,56 +3306,6 @@ void TextCommandRequest::calculate_size(uint32_t &total_size) const {
 }
 #endif
 #ifdef USE_DATETIME_DATE
-bool ListEntitiesDateResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
-  switch (field_id) {
-    case 6: {
-      this->disabled_by_default = value.as_bool();
-      return true;
-    }
-    case 7: {
-      this->entity_category = static_cast<enums::EntityCategory>(value.as_uint32());
-      return true;
-    }
-    case 8: {
-      this->device_id = value.as_uint32();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
-bool ListEntitiesDateResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
-  switch (field_id) {
-    case 1: {
-      this->object_id = value.as_string();
-      return true;
-    }
-    case 3: {
-      this->name = value.as_string();
-      return true;
-    }
-    case 4: {
-      this->unique_id = value.as_string();
-      return true;
-    }
-    case 5: {
-      this->icon = value.as_string();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
-bool ListEntitiesDateResponse::decode_32bit(uint32_t field_id, Proto32Bit value) {
-  switch (field_id) {
-    case 2: {
-      this->key = value.as_fixed32();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
 void ListEntitiesDateResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_string(1, this->object_id);
   buffer.encode_fixed32(2, this->key);
@@ -5711,42 +3325,6 @@ void ListEntitiesDateResponse::calculate_size(uint32_t &total_size) const {
   ProtoSize::add_bool_field(total_size, 1, this->disabled_by_default);
   ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->entity_category));
   ProtoSize::add_uint32_field(total_size, 1, this->device_id);
-}
-bool DateStateResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
-  switch (field_id) {
-    case 2: {
-      this->missing_state = value.as_bool();
-      return true;
-    }
-    case 3: {
-      this->year = value.as_uint32();
-      return true;
-    }
-    case 4: {
-      this->month = value.as_uint32();
-      return true;
-    }
-    case 5: {
-      this->day = value.as_uint32();
-      return true;
-    }
-    case 6: {
-      this->device_id = value.as_uint32();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
-bool DateStateResponse::decode_32bit(uint32_t field_id, Proto32Bit value) {
-  switch (field_id) {
-    case 1: {
-      this->key = value.as_fixed32();
-      return true;
-    }
-    default:
-      return false;
-  }
 }
 void DateStateResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_fixed32(1, this->key);
@@ -5812,56 +3390,6 @@ void DateCommandRequest::calculate_size(uint32_t &total_size) const {
 }
 #endif
 #ifdef USE_DATETIME_TIME
-bool ListEntitiesTimeResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
-  switch (field_id) {
-    case 6: {
-      this->disabled_by_default = value.as_bool();
-      return true;
-    }
-    case 7: {
-      this->entity_category = static_cast<enums::EntityCategory>(value.as_uint32());
-      return true;
-    }
-    case 8: {
-      this->device_id = value.as_uint32();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
-bool ListEntitiesTimeResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
-  switch (field_id) {
-    case 1: {
-      this->object_id = value.as_string();
-      return true;
-    }
-    case 3: {
-      this->name = value.as_string();
-      return true;
-    }
-    case 4: {
-      this->unique_id = value.as_string();
-      return true;
-    }
-    case 5: {
-      this->icon = value.as_string();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
-bool ListEntitiesTimeResponse::decode_32bit(uint32_t field_id, Proto32Bit value) {
-  switch (field_id) {
-    case 2: {
-      this->key = value.as_fixed32();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
 void ListEntitiesTimeResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_string(1, this->object_id);
   buffer.encode_fixed32(2, this->key);
@@ -5881,42 +3409,6 @@ void ListEntitiesTimeResponse::calculate_size(uint32_t &total_size) const {
   ProtoSize::add_bool_field(total_size, 1, this->disabled_by_default);
   ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->entity_category));
   ProtoSize::add_uint32_field(total_size, 1, this->device_id);
-}
-bool TimeStateResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
-  switch (field_id) {
-    case 2: {
-      this->missing_state = value.as_bool();
-      return true;
-    }
-    case 3: {
-      this->hour = value.as_uint32();
-      return true;
-    }
-    case 4: {
-      this->minute = value.as_uint32();
-      return true;
-    }
-    case 5: {
-      this->second = value.as_uint32();
-      return true;
-    }
-    case 6: {
-      this->device_id = value.as_uint32();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
-bool TimeStateResponse::decode_32bit(uint32_t field_id, Proto32Bit value) {
-  switch (field_id) {
-    case 1: {
-      this->key = value.as_fixed32();
-      return true;
-    }
-    default:
-      return false;
-  }
 }
 void TimeStateResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_fixed32(1, this->key);
@@ -5982,64 +3474,6 @@ void TimeCommandRequest::calculate_size(uint32_t &total_size) const {
 }
 #endif
 #ifdef USE_EVENT
-bool ListEntitiesEventResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
-  switch (field_id) {
-    case 6: {
-      this->disabled_by_default = value.as_bool();
-      return true;
-    }
-    case 7: {
-      this->entity_category = static_cast<enums::EntityCategory>(value.as_uint32());
-      return true;
-    }
-    case 10: {
-      this->device_id = value.as_uint32();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
-bool ListEntitiesEventResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
-  switch (field_id) {
-    case 1: {
-      this->object_id = value.as_string();
-      return true;
-    }
-    case 3: {
-      this->name = value.as_string();
-      return true;
-    }
-    case 4: {
-      this->unique_id = value.as_string();
-      return true;
-    }
-    case 5: {
-      this->icon = value.as_string();
-      return true;
-    }
-    case 8: {
-      this->device_class = value.as_string();
-      return true;
-    }
-    case 9: {
-      this->event_types.push_back(value.as_string());
-      return true;
-    }
-    default:
-      return false;
-  }
-}
-bool ListEntitiesEventResponse::decode_32bit(uint32_t field_id, Proto32Bit value) {
-  switch (field_id) {
-    case 2: {
-      this->key = value.as_fixed32();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
 void ListEntitiesEventResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_string(1, this->object_id);
   buffer.encode_fixed32(2, this->key);
@@ -6070,36 +3504,6 @@ void ListEntitiesEventResponse::calculate_size(uint32_t &total_size) const {
   }
   ProtoSize::add_uint32_field(total_size, 1, this->device_id);
 }
-bool EventResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
-  switch (field_id) {
-    case 3: {
-      this->device_id = value.as_uint32();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
-bool EventResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
-  switch (field_id) {
-    case 2: {
-      this->event_type = value.as_string();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
-bool EventResponse::decode_32bit(uint32_t field_id, Proto32Bit value) {
-  switch (field_id) {
-    case 1: {
-      this->key = value.as_fixed32();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
 void EventResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_fixed32(1, this->key);
   buffer.encode_string(2, this->event_type);
@@ -6112,72 +3516,6 @@ void EventResponse::calculate_size(uint32_t &total_size) const {
 }
 #endif
 #ifdef USE_VALVE
-bool ListEntitiesValveResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
-  switch (field_id) {
-    case 6: {
-      this->disabled_by_default = value.as_bool();
-      return true;
-    }
-    case 7: {
-      this->entity_category = static_cast<enums::EntityCategory>(value.as_uint32());
-      return true;
-    }
-    case 9: {
-      this->assumed_state = value.as_bool();
-      return true;
-    }
-    case 10: {
-      this->supports_position = value.as_bool();
-      return true;
-    }
-    case 11: {
-      this->supports_stop = value.as_bool();
-      return true;
-    }
-    case 12: {
-      this->device_id = value.as_uint32();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
-bool ListEntitiesValveResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
-  switch (field_id) {
-    case 1: {
-      this->object_id = value.as_string();
-      return true;
-    }
-    case 3: {
-      this->name = value.as_string();
-      return true;
-    }
-    case 4: {
-      this->unique_id = value.as_string();
-      return true;
-    }
-    case 5: {
-      this->icon = value.as_string();
-      return true;
-    }
-    case 8: {
-      this->device_class = value.as_string();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
-bool ListEntitiesValveResponse::decode_32bit(uint32_t field_id, Proto32Bit value) {
-  switch (field_id) {
-    case 2: {
-      this->key = value.as_fixed32();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
 void ListEntitiesValveResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_string(1, this->object_id);
   buffer.encode_fixed32(2, this->key);
@@ -6205,34 +3543,6 @@ void ListEntitiesValveResponse::calculate_size(uint32_t &total_size) const {
   ProtoSize::add_bool_field(total_size, 1, this->supports_position);
   ProtoSize::add_bool_field(total_size, 1, this->supports_stop);
   ProtoSize::add_uint32_field(total_size, 1, this->device_id);
-}
-bool ValveStateResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
-  switch (field_id) {
-    case 3: {
-      this->current_operation = static_cast<enums::ValveOperation>(value.as_uint32());
-      return true;
-    }
-    case 4: {
-      this->device_id = value.as_uint32();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
-bool ValveStateResponse::decode_32bit(uint32_t field_id, Proto32Bit value) {
-  switch (field_id) {
-    case 1: {
-      this->key = value.as_fixed32();
-      return true;
-    }
-    case 2: {
-      this->position = value.as_float();
-      return true;
-    }
-    default:
-      return false;
-  }
 }
 void ValveStateResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_fixed32(1, this->key);
@@ -6294,56 +3604,6 @@ void ValveCommandRequest::calculate_size(uint32_t &total_size) const {
 }
 #endif
 #ifdef USE_DATETIME_DATETIME
-bool ListEntitiesDateTimeResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
-  switch (field_id) {
-    case 6: {
-      this->disabled_by_default = value.as_bool();
-      return true;
-    }
-    case 7: {
-      this->entity_category = static_cast<enums::EntityCategory>(value.as_uint32());
-      return true;
-    }
-    case 8: {
-      this->device_id = value.as_uint32();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
-bool ListEntitiesDateTimeResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
-  switch (field_id) {
-    case 1: {
-      this->object_id = value.as_string();
-      return true;
-    }
-    case 3: {
-      this->name = value.as_string();
-      return true;
-    }
-    case 4: {
-      this->unique_id = value.as_string();
-      return true;
-    }
-    case 5: {
-      this->icon = value.as_string();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
-bool ListEntitiesDateTimeResponse::decode_32bit(uint32_t field_id, Proto32Bit value) {
-  switch (field_id) {
-    case 2: {
-      this->key = value.as_fixed32();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
 void ListEntitiesDateTimeResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_string(1, this->object_id);
   buffer.encode_fixed32(2, this->key);
@@ -6363,34 +3623,6 @@ void ListEntitiesDateTimeResponse::calculate_size(uint32_t &total_size) const {
   ProtoSize::add_bool_field(total_size, 1, this->disabled_by_default);
   ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->entity_category));
   ProtoSize::add_uint32_field(total_size, 1, this->device_id);
-}
-bool DateTimeStateResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
-  switch (field_id) {
-    case 2: {
-      this->missing_state = value.as_bool();
-      return true;
-    }
-    case 4: {
-      this->device_id = value.as_uint32();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
-bool DateTimeStateResponse::decode_32bit(uint32_t field_id, Proto32Bit value) {
-  switch (field_id) {
-    case 1: {
-      this->key = value.as_fixed32();
-      return true;
-    }
-    case 3: {
-      this->epoch_seconds = value.as_fixed32();
-      return true;
-    }
-    default:
-      return false;
-  }
 }
 void DateTimeStateResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_fixed32(1, this->key);
@@ -6440,60 +3672,6 @@ void DateTimeCommandRequest::calculate_size(uint32_t &total_size) const {
 }
 #endif
 #ifdef USE_UPDATE
-bool ListEntitiesUpdateResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
-  switch (field_id) {
-    case 6: {
-      this->disabled_by_default = value.as_bool();
-      return true;
-    }
-    case 7: {
-      this->entity_category = static_cast<enums::EntityCategory>(value.as_uint32());
-      return true;
-    }
-    case 9: {
-      this->device_id = value.as_uint32();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
-bool ListEntitiesUpdateResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
-  switch (field_id) {
-    case 1: {
-      this->object_id = value.as_string();
-      return true;
-    }
-    case 3: {
-      this->name = value.as_string();
-      return true;
-    }
-    case 4: {
-      this->unique_id = value.as_string();
-      return true;
-    }
-    case 5: {
-      this->icon = value.as_string();
-      return true;
-    }
-    case 8: {
-      this->device_class = value.as_string();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
-bool ListEntitiesUpdateResponse::decode_32bit(uint32_t field_id, Proto32Bit value) {
-  switch (field_id) {
-    case 2: {
-      this->key = value.as_fixed32();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
 void ListEntitiesUpdateResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_string(1, this->object_id);
   buffer.encode_fixed32(2, this->key);
@@ -6515,68 +3693,6 @@ void ListEntitiesUpdateResponse::calculate_size(uint32_t &total_size) const {
   ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->entity_category));
   ProtoSize::add_string_field(total_size, 1, this->device_class);
   ProtoSize::add_uint32_field(total_size, 1, this->device_id);
-}
-bool UpdateStateResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
-  switch (field_id) {
-    case 2: {
-      this->missing_state = value.as_bool();
-      return true;
-    }
-    case 3: {
-      this->in_progress = value.as_bool();
-      return true;
-    }
-    case 4: {
-      this->has_progress = value.as_bool();
-      return true;
-    }
-    case 11: {
-      this->device_id = value.as_uint32();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
-bool UpdateStateResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
-  switch (field_id) {
-    case 6: {
-      this->current_version = value.as_string();
-      return true;
-    }
-    case 7: {
-      this->latest_version = value.as_string();
-      return true;
-    }
-    case 8: {
-      this->title = value.as_string();
-      return true;
-    }
-    case 9: {
-      this->release_summary = value.as_string();
-      return true;
-    }
-    case 10: {
-      this->release_url = value.as_string();
-      return true;
-    }
-    default:
-      return false;
-  }
-}
-bool UpdateStateResponse::decode_32bit(uint32_t field_id, Proto32Bit value) {
-  switch (field_id) {
-    case 1: {
-      this->key = value.as_fixed32();
-      return true;
-    }
-    case 5: {
-      this->progress = value.as_float();
-      return true;
-    }
-    default:
-      return false;
-  }
 }
 void UpdateStateResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_fixed32(1, this->key);

--- a/esphome/components/api/api_pb2.h
+++ b/esphome/components/api/api_pb2.h
@@ -327,8 +327,6 @@ class HelloRequest : public ProtoMessage {
   std::string client_info{};
   uint32_t api_version_major{0};
   uint32_t api_version_minor{0};
-  void encode(ProtoWriteBuffer buffer) const override;
-  void calculate_size(uint32_t &total_size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
 #endif
@@ -364,8 +362,6 @@ class ConnectRequest : public ProtoMessage {
   const char *message_name() const override { return "connect_request"; }
 #endif
   std::string password{};
-  void encode(ProtoWriteBuffer buffer) const override;
-  void calculate_size(uint32_t &total_size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
 #endif
@@ -649,8 +645,6 @@ class CoverCommandRequest : public CommandProtoMessage {
   bool has_tilt{false};
   float tilt{0.0f};
   bool stop{false};
-  void encode(ProtoWriteBuffer buffer) const override;
-  void calculate_size(uint32_t &total_size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
 #endif
@@ -721,8 +715,6 @@ class FanCommandRequest : public CommandProtoMessage {
   int32_t speed_level{0};
   bool has_preset_mode{false};
   std::string preset_mode{};
-  void encode(ProtoWriteBuffer buffer) const override;
-  void calculate_size(uint32_t &total_size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
 #endif
@@ -817,8 +809,6 @@ class LightCommandRequest : public CommandProtoMessage {
   uint32_t flash_length{0};
   bool has_effect{false};
   std::string effect{};
-  void encode(ProtoWriteBuffer buffer) const override;
-  void calculate_size(uint32_t &total_size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
 #endif
@@ -911,8 +901,6 @@ class SwitchCommandRequest : public CommandProtoMessage {
   const char *message_name() const override { return "switch_command_request"; }
 #endif
   bool state{false};
-  void encode(ProtoWriteBuffer buffer) const override;
-  void calculate_size(uint32_t &total_size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
 #endif
@@ -966,8 +954,6 @@ class SubscribeLogsRequest : public ProtoMessage {
 #endif
   enums::LogLevel level{};
   bool dump_config{false};
-  void encode(ProtoWriteBuffer buffer) const override;
-  void calculate_size(uint32_t &total_size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
 #endif
@@ -1002,8 +988,6 @@ class NoiseEncryptionSetKeyRequest : public ProtoMessage {
   const char *message_name() const override { return "noise_encryption_set_key_request"; }
 #endif
   std::string key{};
-  void encode(ProtoWriteBuffer buffer) const override;
-  void calculate_size(uint32_t &total_size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
 #endif
@@ -1115,8 +1099,6 @@ class HomeAssistantStateResponse : public ProtoMessage {
   std::string entity_id{};
   std::string state{};
   std::string attribute{};
-  void encode(ProtoWriteBuffer buffer) const override;
-  void calculate_size(uint32_t &total_size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
 #endif
@@ -1218,8 +1200,6 @@ class ExecuteServiceRequest : public ProtoMessage {
 #endif
   uint32_t key{0};
   std::vector<ExecuteServiceArgument> args{};
-  void encode(ProtoWriteBuffer buffer) const override;
-  void calculate_size(uint32_t &total_size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
 #endif
@@ -1271,8 +1251,6 @@ class CameraImageRequest : public ProtoMessage {
 #endif
   bool single{false};
   bool stream{false};
-  void encode(ProtoWriteBuffer buffer) const override;
-  void calculate_size(uint32_t &total_size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
 #endif
@@ -1373,8 +1351,6 @@ class ClimateCommandRequest : public CommandProtoMessage {
   std::string custom_preset{};
   bool has_target_humidity{false};
   float target_humidity{0.0f};
-  void encode(ProtoWriteBuffer buffer) const override;
-  void calculate_size(uint32_t &total_size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
 #endif
@@ -1432,8 +1408,6 @@ class NumberCommandRequest : public CommandProtoMessage {
   const char *message_name() const override { return "number_command_request"; }
 #endif
   float state{0.0f};
-  void encode(ProtoWriteBuffer buffer) const override;
-  void calculate_size(uint32_t &total_size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
 #endif
@@ -1485,8 +1459,6 @@ class SelectCommandRequest : public CommandProtoMessage {
   const char *message_name() const override { return "select_command_request"; }
 #endif
   std::string state{};
-  void encode(ProtoWriteBuffer buffer) const override;
-  void calculate_size(uint32_t &total_size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
 #endif
@@ -1547,8 +1519,6 @@ class SirenCommandRequest : public CommandProtoMessage {
   uint32_t duration{0};
   bool has_volume{false};
   float volume{0.0f};
-  void encode(ProtoWriteBuffer buffer) const override;
-  void calculate_size(uint32_t &total_size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
 #endif
@@ -1605,8 +1575,6 @@ class LockCommandRequest : public CommandProtoMessage {
   enums::LockCommand command{};
   bool has_code{false};
   std::string code{};
-  void encode(ProtoWriteBuffer buffer) const override;
-  void calculate_size(uint32_t &total_size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
 #endif
@@ -1641,8 +1609,6 @@ class ButtonCommandRequest : public CommandProtoMessage {
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "button_command_request"; }
 #endif
-  void encode(ProtoWriteBuffer buffer) const override;
-  void calculate_size(uint32_t &total_size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
 #endif
@@ -1720,8 +1686,6 @@ class MediaPlayerCommandRequest : public CommandProtoMessage {
   std::string media_url{};
   bool has_announcement{false};
   bool announcement{false};
-  void encode(ProtoWriteBuffer buffer) const override;
-  void calculate_size(uint32_t &total_size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
 #endif
@@ -1741,8 +1705,6 @@ class SubscribeBluetoothLEAdvertisementsRequest : public ProtoMessage {
   const char *message_name() const override { return "subscribe_bluetooth_le_advertisements_request"; }
 #endif
   uint32_t flags{0};
-  void encode(ProtoWriteBuffer buffer) const override;
-  void calculate_size(uint32_t &total_size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
 #endif
@@ -1830,8 +1792,6 @@ class BluetoothDeviceRequest : public ProtoMessage {
   enums::BluetoothDeviceRequestType request_type{};
   bool has_address_type{false};
   uint32_t address_type{0};
-  void encode(ProtoWriteBuffer buffer) const override;
-  void calculate_size(uint32_t &total_size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
 #endif
@@ -1866,8 +1826,6 @@ class BluetoothGATTGetServicesRequest : public ProtoMessage {
   const char *message_name() const override { return "bluetooth_gatt_get_services_request"; }
 #endif
   uint64_t address{0};
-  void encode(ProtoWriteBuffer buffer) const override;
-  void calculate_size(uint32_t &total_size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
 #endif
@@ -1961,8 +1919,6 @@ class BluetoothGATTReadRequest : public ProtoMessage {
 #endif
   uint64_t address{0};
   uint32_t handle{0};
-  void encode(ProtoWriteBuffer buffer) const override;
-  void calculate_size(uint32_t &total_size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
 #endif
@@ -1999,8 +1955,6 @@ class BluetoothGATTWriteRequest : public ProtoMessage {
   uint32_t handle{0};
   bool response{false};
   std::string data{};
-  void encode(ProtoWriteBuffer buffer) const override;
-  void calculate_size(uint32_t &total_size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
 #endif
@@ -2018,8 +1972,6 @@ class BluetoothGATTReadDescriptorRequest : public ProtoMessage {
 #endif
   uint64_t address{0};
   uint32_t handle{0};
-  void encode(ProtoWriteBuffer buffer) const override;
-  void calculate_size(uint32_t &total_size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
 #endif
@@ -2037,8 +1989,6 @@ class BluetoothGATTWriteDescriptorRequest : public ProtoMessage {
   uint64_t address{0};
   uint32_t handle{0};
   std::string data{};
-  void encode(ProtoWriteBuffer buffer) const override;
-  void calculate_size(uint32_t &total_size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
 #endif
@@ -2057,8 +2007,6 @@ class BluetoothGATTNotifyRequest : public ProtoMessage {
   uint64_t address{0};
   uint32_t handle{0};
   bool enable{false};
-  void encode(ProtoWriteBuffer buffer) const override;
-  void calculate_size(uint32_t &total_size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
 #endif
@@ -2259,8 +2207,6 @@ class BluetoothScannerSetModeRequest : public ProtoMessage {
   const char *message_name() const override { return "bluetooth_scanner_set_mode_request"; }
 #endif
   enums::BluetoothScannerMode mode{};
-  void encode(ProtoWriteBuffer buffer) const override;
-  void calculate_size(uint32_t &total_size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
 #endif
@@ -2279,8 +2225,6 @@ class SubscribeVoiceAssistantRequest : public ProtoMessage {
 #endif
   bool subscribe{false};
   uint32_t flags{0};
-  void encode(ProtoWriteBuffer buffer) const override;
-  void calculate_size(uint32_t &total_size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
 #endif
@@ -2332,8 +2276,6 @@ class VoiceAssistantResponse : public ProtoMessage {
 #endif
   uint32_t port{0};
   bool error{false};
-  void encode(ProtoWriteBuffer buffer) const override;
-  void calculate_size(uint32_t &total_size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
 #endif
@@ -2363,8 +2305,6 @@ class VoiceAssistantEventResponse : public ProtoMessage {
 #endif
   enums::VoiceAssistantEvent event_type{};
   std::vector<VoiceAssistantEventData> data{};
-  void encode(ProtoWriteBuffer buffer) const override;
-  void calculate_size(uint32_t &total_size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
 #endif
@@ -2405,8 +2345,6 @@ class VoiceAssistantTimerEventResponse : public ProtoMessage {
   uint32_t total_seconds{0};
   uint32_t seconds_left{0};
   bool is_active{false};
-  void encode(ProtoWriteBuffer buffer) const override;
-  void calculate_size(uint32_t &total_size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
 #endif
@@ -2426,8 +2364,6 @@ class VoiceAssistantAnnounceRequest : public ProtoMessage {
   std::string text{};
   std::string preannounce_media_id{};
   bool start_conversation{false};
-  void encode(ProtoWriteBuffer buffer) const override;
-  void calculate_size(uint32_t &total_size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
 #endif
@@ -2505,8 +2441,6 @@ class VoiceAssistantSetConfiguration : public ProtoMessage {
   const char *message_name() const override { return "voice_assistant_set_configuration"; }
 #endif
   std::vector<std::string> active_wake_words{};
-  void encode(ProtoWriteBuffer buffer) const override;
-  void calculate_size(uint32_t &total_size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
 #endif
@@ -2559,8 +2493,6 @@ class AlarmControlPanelCommandRequest : public CommandProtoMessage {
 #endif
   enums::AlarmControlPanelStateCommand command{};
   std::string code{};
-  void encode(ProtoWriteBuffer buffer) const override;
-  void calculate_size(uint32_t &total_size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
 #endif
@@ -2616,8 +2548,6 @@ class TextCommandRequest : public CommandProtoMessage {
   const char *message_name() const override { return "text_command_request"; }
 #endif
   std::string state{};
-  void encode(ProtoWriteBuffer buffer) const override;
-  void calculate_size(uint32_t &total_size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
 #endif
@@ -2673,8 +2603,6 @@ class DateCommandRequest : public CommandProtoMessage {
   uint32_t year{0};
   uint32_t month{0};
   uint32_t day{0};
-  void encode(ProtoWriteBuffer buffer) const override;
-  void calculate_size(uint32_t &total_size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
 #endif
@@ -2729,8 +2657,6 @@ class TimeCommandRequest : public CommandProtoMessage {
   uint32_t hour{0};
   uint32_t minute{0};
   uint32_t second{0};
-  void encode(ProtoWriteBuffer buffer) const override;
-  void calculate_size(uint32_t &total_size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
 #endif
@@ -2822,8 +2748,6 @@ class ValveCommandRequest : public CommandProtoMessage {
   bool has_position{false};
   float position{0.0f};
   bool stop{false};
-  void encode(ProtoWriteBuffer buffer) const override;
-  void calculate_size(uint32_t &total_size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
 #endif
@@ -2874,8 +2798,6 @@ class DateTimeCommandRequest : public CommandProtoMessage {
   const char *message_name() const override { return "date_time_command_request"; }
 #endif
   uint32_t epoch_seconds{0};
-  void encode(ProtoWriteBuffer buffer) const override;
-  void calculate_size(uint32_t &total_size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
 #endif
@@ -2934,8 +2856,6 @@ class UpdateCommandRequest : public CommandProtoMessage {
   const char *message_name() const override { return "update_command_request"; }
 #endif
   enums::UpdateCommand command{};
-  void encode(ProtoWriteBuffer buffer) const override;
-  void calculate_size(uint32_t &total_size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
 #endif

--- a/esphome/components/api/api_pb2.h
+++ b/esphome/components/api/api_pb2.h
@@ -355,8 +355,6 @@ class HelloResponse : public ProtoMessage {
 #endif
 
  protected:
-  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
 class ConnectRequest : public ProtoMessage {
  public:
@@ -390,7 +388,6 @@ class ConnectResponse : public ProtoMessage {
 #endif
 
  protected:
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
 class DisconnectRequest : public ProtoMessage {
  public:
@@ -522,8 +519,6 @@ class DeviceInfoResponse : public ProtoMessage {
 #endif
 
  protected:
-  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
 class ListEntitiesRequest : public ProtoMessage {
  public:
@@ -581,9 +576,6 @@ class ListEntitiesBinarySensorResponse : public InfoResponseProtoMessage {
 #endif
 
  protected:
-  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
-  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
 class BinarySensorStateResponse : public StateResponseProtoMessage {
  public:
@@ -601,8 +593,6 @@ class BinarySensorStateResponse : public StateResponseProtoMessage {
 #endif
 
  protected:
-  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
 #endif
 #ifdef USE_COVER
@@ -625,9 +615,6 @@ class ListEntitiesCoverResponse : public InfoResponseProtoMessage {
 #endif
 
  protected:
-  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
-  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
 class CoverStateResponse : public StateResponseProtoMessage {
  public:
@@ -647,8 +634,6 @@ class CoverStateResponse : public StateResponseProtoMessage {
 #endif
 
  protected:
-  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
 class CoverCommandRequest : public CommandProtoMessage {
  public:
@@ -695,9 +680,6 @@ class ListEntitiesFanResponse : public InfoResponseProtoMessage {
 #endif
 
  protected:
-  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
-  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
 class FanStateResponse : public StateResponseProtoMessage {
  public:
@@ -719,9 +701,6 @@ class FanStateResponse : public StateResponseProtoMessage {
 #endif
 
  protected:
-  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
-  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
 class FanCommandRequest : public CommandProtoMessage {
  public:
@@ -777,9 +756,6 @@ class ListEntitiesLightResponse : public InfoResponseProtoMessage {
 #endif
 
  protected:
-  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
-  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
 class LightStateResponse : public StateResponseProtoMessage {
  public:
@@ -807,9 +783,6 @@ class LightStateResponse : public StateResponseProtoMessage {
 #endif
 
  protected:
-  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
-  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
 class LightCommandRequest : public CommandProtoMessage {
  public:
@@ -877,9 +850,6 @@ class ListEntitiesSensorResponse : public InfoResponseProtoMessage {
 #endif
 
  protected:
-  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
-  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
 class SensorStateResponse : public StateResponseProtoMessage {
  public:
@@ -897,8 +867,6 @@ class SensorStateResponse : public StateResponseProtoMessage {
 #endif
 
  protected:
-  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
 #endif
 #ifdef USE_SWITCH
@@ -918,9 +886,6 @@ class ListEntitiesSwitchResponse : public InfoResponseProtoMessage {
 #endif
 
  protected:
-  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
-  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
 class SwitchStateResponse : public StateResponseProtoMessage {
  public:
@@ -937,8 +902,6 @@ class SwitchStateResponse : public StateResponseProtoMessage {
 #endif
 
  protected:
-  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
 class SwitchCommandRequest : public CommandProtoMessage {
  public:
@@ -975,9 +938,6 @@ class ListEntitiesTextSensorResponse : public InfoResponseProtoMessage {
 #endif
 
  protected:
-  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
-  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
 class TextSensorStateResponse : public StateResponseProtoMessage {
  public:
@@ -995,9 +955,6 @@ class TextSensorStateResponse : public StateResponseProtoMessage {
 #endif
 
  protected:
-  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
-  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
 #endif
 class SubscribeLogsRequest : public ProtoMessage {
@@ -1035,8 +992,6 @@ class SubscribeLogsResponse : public ProtoMessage {
 #endif
 
  protected:
-  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
 #ifdef USE_API_NOISE
 class NoiseEncryptionSetKeyRequest : public ProtoMessage {
@@ -1071,7 +1026,6 @@ class NoiseEncryptionSetKeyResponse : public ProtoMessage {
 #endif
 
  protected:
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
 #endif
 class SubscribeHomeassistantServicesRequest : public ProtoMessage {
@@ -1119,8 +1073,6 @@ class HomeassistantServiceResponse : public ProtoMessage {
 #endif
 
  protected:
-  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
 class SubscribeHomeAssistantStatesRequest : public ProtoMessage {
  public:
@@ -1152,8 +1104,6 @@ class SubscribeHomeAssistantStateResponse : public ProtoMessage {
 #endif
 
  protected:
-  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
 class HomeAssistantStateResponse : public ProtoMessage {
  public:
@@ -1236,8 +1186,6 @@ class ListEntitiesServicesResponse : public ProtoMessage {
 #endif
 
  protected:
-  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
-  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
 };
 class ExecuteServiceArgument : public ProtoMessage {
  public:
@@ -1296,9 +1244,6 @@ class ListEntitiesCameraResponse : public InfoResponseProtoMessage {
 #endif
 
  protected:
-  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
-  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
 class CameraImageResponse : public StateResponseProtoMessage {
  public:
@@ -1316,9 +1261,6 @@ class CameraImageResponse : public StateResponseProtoMessage {
 #endif
 
  protected:
-  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
-  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
 class CameraImageRequest : public ProtoMessage {
  public:
@@ -1372,9 +1314,6 @@ class ListEntitiesClimateResponse : public InfoResponseProtoMessage {
 #endif
 
  protected:
-  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
-  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
 class ClimateStateResponse : public StateResponseProtoMessage {
  public:
@@ -1404,9 +1343,6 @@ class ClimateStateResponse : public StateResponseProtoMessage {
 #endif
 
  protected:
-  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
-  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
 class ClimateCommandRequest : public CommandProtoMessage {
  public:
@@ -1470,9 +1406,6 @@ class ListEntitiesNumberResponse : public InfoResponseProtoMessage {
 #endif
 
  protected:
-  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
-  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
 class NumberStateResponse : public StateResponseProtoMessage {
  public:
@@ -1490,8 +1423,6 @@ class NumberStateResponse : public StateResponseProtoMessage {
 #endif
 
  protected:
-  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
 class NumberCommandRequest : public CommandProtoMessage {
  public:
@@ -1528,9 +1459,6 @@ class ListEntitiesSelectResponse : public InfoResponseProtoMessage {
 #endif
 
  protected:
-  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
-  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
 class SelectStateResponse : public StateResponseProtoMessage {
  public:
@@ -1548,9 +1476,6 @@ class SelectStateResponse : public StateResponseProtoMessage {
 #endif
 
  protected:
-  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
-  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
 class SelectCommandRequest : public CommandProtoMessage {
  public:
@@ -1590,9 +1515,6 @@ class ListEntitiesSirenResponse : public InfoResponseProtoMessage {
 #endif
 
  protected:
-  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
-  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
 class SirenStateResponse : public StateResponseProtoMessage {
  public:
@@ -1609,8 +1531,6 @@ class SirenStateResponse : public StateResponseProtoMessage {
 #endif
 
  protected:
-  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
 class SirenCommandRequest : public CommandProtoMessage {
  public:
@@ -1658,9 +1578,6 @@ class ListEntitiesLockResponse : public InfoResponseProtoMessage {
 #endif
 
  protected:
-  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
-  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
 class LockStateResponse : public StateResponseProtoMessage {
  public:
@@ -1677,8 +1594,6 @@ class LockStateResponse : public StateResponseProtoMessage {
 #endif
 
  protected:
-  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
 class LockCommandRequest : public CommandProtoMessage {
  public:
@@ -1718,9 +1633,6 @@ class ListEntitiesButtonResponse : public InfoResponseProtoMessage {
 #endif
 
  protected:
-  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
-  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
 class ButtonCommandRequest : public CommandProtoMessage {
  public:
@@ -1774,9 +1686,6 @@ class ListEntitiesMediaPlayerResponse : public InfoResponseProtoMessage {
 #endif
 
  protected:
-  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
-  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
 class MediaPlayerStateResponse : public StateResponseProtoMessage {
  public:
@@ -1795,8 +1704,6 @@ class MediaPlayerStateResponse : public StateResponseProtoMessage {
 #endif
 
  protected:
-  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
 class MediaPlayerCommandRequest : public CommandProtoMessage {
  public:
@@ -1879,8 +1786,6 @@ class BluetoothLEAdvertisementResponse : public ProtoMessage {
 #endif
 
  protected:
-  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
 class BluetoothLERawAdvertisement : public ProtoMessage {
  public:
@@ -1913,7 +1818,6 @@ class BluetoothLERawAdvertisementsResponse : public ProtoMessage {
 #endif
 
  protected:
-  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
 };
 class BluetoothDeviceRequest : public ProtoMessage {
  public:
@@ -1953,7 +1857,6 @@ class BluetoothDeviceConnectionResponse : public ProtoMessage {
 #endif
 
  protected:
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
 class BluetoothGATTGetServicesRequest : public ProtoMessage {
  public:
@@ -2032,8 +1935,6 @@ class BluetoothGATTGetServicesResponse : public ProtoMessage {
 #endif
 
  protected:
-  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
 class BluetoothGATTGetServicesDoneResponse : public ProtoMessage {
  public:
@@ -2050,7 +1951,6 @@ class BluetoothGATTGetServicesDoneResponse : public ProtoMessage {
 #endif
 
  protected:
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
 class BluetoothGATTReadRequest : public ProtoMessage {
  public:
@@ -2087,8 +1987,6 @@ class BluetoothGATTReadResponse : public ProtoMessage {
 #endif
 
  protected:
-  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
 class BluetoothGATTWriteRequest : public ProtoMessage {
  public:
@@ -2185,8 +2083,6 @@ class BluetoothGATTNotifyDataResponse : public ProtoMessage {
 #endif
 
  protected:
-  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
 class SubscribeBluetoothConnectionsFreeRequest : public ProtoMessage {
  public:
@@ -2218,7 +2114,6 @@ class BluetoothConnectionsFreeResponse : public ProtoMessage {
 #endif
 
  protected:
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
 class BluetoothGATTErrorResponse : public ProtoMessage {
  public:
@@ -2237,7 +2132,6 @@ class BluetoothGATTErrorResponse : public ProtoMessage {
 #endif
 
  protected:
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
 class BluetoothGATTWriteResponse : public ProtoMessage {
  public:
@@ -2255,7 +2149,6 @@ class BluetoothGATTWriteResponse : public ProtoMessage {
 #endif
 
  protected:
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
 class BluetoothGATTNotifyResponse : public ProtoMessage {
  public:
@@ -2273,7 +2166,6 @@ class BluetoothGATTNotifyResponse : public ProtoMessage {
 #endif
 
  protected:
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
 class BluetoothDevicePairingResponse : public ProtoMessage {
  public:
@@ -2292,7 +2184,6 @@ class BluetoothDevicePairingResponse : public ProtoMessage {
 #endif
 
  protected:
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
 class BluetoothDeviceUnpairingResponse : public ProtoMessage {
  public:
@@ -2311,7 +2202,6 @@ class BluetoothDeviceUnpairingResponse : public ProtoMessage {
 #endif
 
  protected:
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
 class UnsubscribeBluetoothLEAdvertisementsRequest : public ProtoMessage {
  public:
@@ -2343,7 +2233,6 @@ class BluetoothDeviceClearCacheResponse : public ProtoMessage {
 #endif
 
  protected:
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
 class BluetoothScannerStateResponse : public ProtoMessage {
  public:
@@ -2361,7 +2250,6 @@ class BluetoothScannerStateResponse : public ProtoMessage {
 #endif
 
  protected:
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
 class BluetoothScannerSetModeRequest : public ProtoMessage {
  public:
@@ -2434,8 +2322,6 @@ class VoiceAssistantRequest : public ProtoMessage {
 #endif
 
  protected:
-  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
 class VoiceAssistantResponse : public ProtoMessage {
  public:
@@ -2565,7 +2451,6 @@ class VoiceAssistantAnnounceFinished : public ProtoMessage {
 #endif
 
  protected:
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
 class VoiceAssistantWakeWord : public ProtoMessage {
  public:
@@ -2611,8 +2496,6 @@ class VoiceAssistantConfigurationResponse : public ProtoMessage {
 #endif
 
  protected:
-  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
 class VoiceAssistantSetConfiguration : public ProtoMessage {
  public:
@@ -2650,9 +2533,6 @@ class ListEntitiesAlarmControlPanelResponse : public InfoResponseProtoMessage {
 #endif
 
  protected:
-  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
-  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
 class AlarmControlPanelStateResponse : public StateResponseProtoMessage {
  public:
@@ -2669,8 +2549,6 @@ class AlarmControlPanelStateResponse : public StateResponseProtoMessage {
 #endif
 
  protected:
-  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
 class AlarmControlPanelCommandRequest : public CommandProtoMessage {
  public:
@@ -2712,9 +2590,6 @@ class ListEntitiesTextResponse : public InfoResponseProtoMessage {
 #endif
 
  protected:
-  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
-  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
 class TextStateResponse : public StateResponseProtoMessage {
  public:
@@ -2732,9 +2607,6 @@ class TextStateResponse : public StateResponseProtoMessage {
 #endif
 
  protected:
-  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
-  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
 class TextCommandRequest : public CommandProtoMessage {
  public:
@@ -2771,9 +2643,6 @@ class ListEntitiesDateResponse : public InfoResponseProtoMessage {
 #endif
 
  protected:
-  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
-  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
 class DateStateResponse : public StateResponseProtoMessage {
  public:
@@ -2793,8 +2662,6 @@ class DateStateResponse : public StateResponseProtoMessage {
 #endif
 
  protected:
-  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
 class DateCommandRequest : public CommandProtoMessage {
  public:
@@ -2832,9 +2699,6 @@ class ListEntitiesTimeResponse : public InfoResponseProtoMessage {
 #endif
 
  protected:
-  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
-  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
 class TimeStateResponse : public StateResponseProtoMessage {
  public:
@@ -2854,8 +2718,6 @@ class TimeStateResponse : public StateResponseProtoMessage {
 #endif
 
  protected:
-  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
 class TimeCommandRequest : public CommandProtoMessage {
  public:
@@ -2895,9 +2757,6 @@ class ListEntitiesEventResponse : public InfoResponseProtoMessage {
 #endif
 
  protected:
-  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
-  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
 class EventResponse : public StateResponseProtoMessage {
  public:
@@ -2914,9 +2773,6 @@ class EventResponse : public StateResponseProtoMessage {
 #endif
 
  protected:
-  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
-  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
 #endif
 #ifdef USE_VALVE
@@ -2938,9 +2794,6 @@ class ListEntitiesValveResponse : public InfoResponseProtoMessage {
 #endif
 
  protected:
-  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
-  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
 class ValveStateResponse : public StateResponseProtoMessage {
  public:
@@ -2958,8 +2811,6 @@ class ValveStateResponse : public StateResponseProtoMessage {
 #endif
 
  protected:
-  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
 class ValveCommandRequest : public CommandProtoMessage {
  public:
@@ -2997,9 +2848,6 @@ class ListEntitiesDateTimeResponse : public InfoResponseProtoMessage {
 #endif
 
  protected:
-  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
-  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
 class DateTimeStateResponse : public StateResponseProtoMessage {
  public:
@@ -3017,8 +2865,6 @@ class DateTimeStateResponse : public StateResponseProtoMessage {
 #endif
 
  protected:
-  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
 class DateTimeCommandRequest : public CommandProtoMessage {
  public:
@@ -3055,9 +2901,6 @@ class ListEntitiesUpdateResponse : public InfoResponseProtoMessage {
 #endif
 
  protected:
-  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
-  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
 class UpdateStateResponse : public StateResponseProtoMessage {
  public:
@@ -3082,9 +2925,6 @@ class UpdateStateResponse : public StateResponseProtoMessage {
 #endif
 
  protected:
-  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
-  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
 class UpdateCommandRequest : public CommandProtoMessage {
  public:

--- a/script/api_protobuf/api_protobuf.py
+++ b/script/api_protobuf/api_protobuf.py
@@ -1059,6 +1059,10 @@ def build_message_type(
     # Get message ID if it's a service message
     message_id: int | None = get_opt(desc, pb.id)
 
+    # Get source direction to determine if we need decode methods
+    source: int = get_opt(desc, pb.source, SOURCE_BOTH)
+    needs_decode = source in (SOURCE_BOTH, SOURCE_CLIENT)
+
     # Add MESSAGE_TYPE method if this is a service message
     if message_id is not None:
         # Validate that message_id fits in uint8_t
@@ -1105,14 +1109,16 @@ def build_message_type(
         encode.append(ti.encode_content)
         size_calc.append(ti.get_size_calculation(f"this->{ti.field_name}"))
 
-        if ti.decode_varint_content:
-            decode_varint.append(ti.decode_varint_content)
-        if ti.decode_length_content:
-            decode_length.append(ti.decode_length_content)
-        if ti.decode_32bit_content:
-            decode_32bit.append(ti.decode_32bit_content)
-        if ti.decode_64bit_content:
-            decode_64bit.append(ti.decode_64bit_content)
+        # Only collect decode methods if this message needs them
+        if needs_decode:
+            if ti.decode_varint_content:
+                decode_varint.append(ti.decode_varint_content)
+            if ti.decode_length_content:
+                decode_length.append(ti.decode_length_content)
+            if ti.decode_32bit_content:
+                decode_32bit.append(ti.decode_32bit_content)
+            if ti.decode_64bit_content:
+                decode_64bit.append(ti.decode_64bit_content)
         if ti.dump_content:
             dump.append(ti.dump_content)
 

--- a/script/api_protobuf/api_protobuf.py
+++ b/script/api_protobuf/api_protobuf.py
@@ -1059,9 +1059,10 @@ def build_message_type(
     # Get message ID if it's a service message
     message_id: int | None = get_opt(desc, pb.id)
 
-    # Get source direction to determine if we need decode methods
+    # Get source direction to determine if we need decode/encode methods
     source: int = get_opt(desc, pb.source, SOURCE_BOTH)
     needs_decode = source in (SOURCE_BOTH, SOURCE_CLIENT)
+    needs_encode = source in (SOURCE_BOTH, SOURCE_SERVER)
 
     # Add MESSAGE_TYPE method if this is a service message
     if message_id is not None:
@@ -1105,9 +1106,10 @@ def build_message_type(
             protected_content.extend(ti.protected_content)
             public_content.extend(ti.public_content)
 
-        # Always include encode/decode logic for all fields
-        encode.append(ti.encode_content)
-        size_calc.append(ti.get_size_calculation(f"this->{ti.field_name}"))
+        # Only collect encode logic if this message needs it
+        if needs_encode:
+            encode.append(ti.encode_content)
+            size_calc.append(ti.get_size_calculation(f"this->{ti.field_name}"))
 
         # Only collect decode methods if this message needs them
         if needs_decode:
@@ -1164,8 +1166,8 @@ def build_message_type(
         prot = "bool decode_64bit(uint32_t field_id, Proto64Bit value) override;"
         protected_content.insert(0, prot)
 
-    # Only generate encode method if there are fields to encode
-    if encode:
+    # Only generate encode method if this message needs encoding and has fields
+    if needs_encode and encode:
         o = f"void {desc.name}::encode(ProtoWriteBuffer buffer) const {{"
         if len(encode) == 1 and len(encode[0]) + len(o) + 3 < 120:
             o += f" {encode[0]} "
@@ -1176,10 +1178,10 @@ def build_message_type(
         cpp += o
         prot = "void encode(ProtoWriteBuffer buffer) const override;"
         public_content.append(prot)
-    # If no fields to encode, the default implementation in ProtoMessage will be used
+    # If no fields to encode or message doesn't need encoding, the default implementation in ProtoMessage will be used
 
-    # Add calculate_size method only if there are fields
-    if size_calc:
+    # Add calculate_size method only if this message needs encoding and has fields
+    if needs_encode and size_calc:
         o = f"void {desc.name}::calculate_size(uint32_t &total_size) const {{"
         # For a single field, just inline it for simplicity
         if len(size_calc) == 1 and len(size_calc[0]) + len(o) + 3 < 120:
@@ -1192,7 +1194,7 @@ def build_message_type(
         cpp += o
         prot = "void calculate_size(uint32_t &total_size) const override;"
         public_content.append(prot)
-    # If no fields to calculate size for, the default implementation in ProtoMessage will be used
+    # If no fields to calculate size for or message doesn't need encoding, the default implementation in ProtoMessage will be used
 
     # dump_to method declaration in header
     prot = "#ifdef HAS_PROTO_MESSAGE_DUMP\n"


### PR DESCRIPTION
# What does this implement/fix?

This PR fixes a significant oversight in the protobuf code generator that has existed since its introduction in 2019. The generator was creating unused encode/decode methods for all message types, regardless of their direction.

The protobuf generator now checks the `source` option on messages and only generates the methods that are actually needed:
- **SOURCE_SERVER messages** (ESPHome → Client): Only generate `encode()` and `calculate_size()`, skip decode methods
- **SOURCE_CLIENT messages** (Client → ESPHome): Only generate decode methods, skip `encode()` and `calculate_size()`
- **SOURCE_BOTH messages** (Both directions): Generate all methods

**Impact:**
- Removes ~4,687 lines of dead code (4,447 from `api_pb2.cpp`, 240 from `api_pb2.h`)
- Reduces flash usage on ESP32:
  - Device with many entities: **13.3KB savings**
    - Before: `Flash: [=======   ]  66.4% (used 1218188 bytes from 1835008 bytes)`
    - After: `Flash: [=======   ]  65.7% (used 1204884 bytes from 1835008 bytes)`
  - Minimal device: **3.2KB savings**
    - Before: `Flash: [===       ]  28.7% (used 527080 bytes from 1835008 bytes)`
    - After: `Flash: [===       ]  28.5% (used 523884 bytes from 1835008 bytes)`
- Improves compile times
- No functional changes - this only removes code that was never called

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# No configuration changes needed - this is an internal optimization
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).