### PR TITLE
Fix clang-tidy skipping when Python linters are skipped

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -368,7 +368,10 @@ jobs:
     needs:
       - clang-tidy-deps
       - determine-jobs
-    if: needs.determine-jobs.outputs.clang-tidy == 'true'
+    if: |
+      always() &&
+      needs.determine-jobs.outputs.clang-tidy == 'true' &&
+      needs.clang-tidy-deps.result == 'success'
     env:
       GH_TOKEN: ${{ github.token }}
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -345,18 +345,28 @@ jobs:
         run: script/ci-suggest-changes
         if: always()
 
+  clang-tidy-deps:
+    name: Clang-tidy dependencies
+    runs-on: ubuntu-24.04
+    needs:
+      - common
+      - ci-custom
+      - clang-format
+      - pytest
+      - determine-jobs
+      - ruff
+    if: |
+      always() &&
+      needs.determine-jobs.outputs.clang-tidy == 'true' &&
+      (needs.ruff.result == 'success' || needs.ruff.result == 'skipped')
+    steps:
+      - run: echo "All clang-tidy dependencies ready"
+
   clang-tidy:
     name: ${{ matrix.name }}
     runs-on: ubuntu-24.04
     needs:
-      - common
-      - ruff
-      - ci-custom
-      - clang-format
-      - flake8
-      - pylint
-      - pytest
-      - pyupgrade
+      - clang-tidy-deps
       - determine-jobs
     if: needs.determine-jobs.outputs.clang-tidy == 'true'
     env:
@@ -575,6 +585,7 @@ jobs:
       - pytest
       - integration-tests
       - pyupgrade
+      - clang-tidy-deps
       - clang-tidy
       - determine-jobs
       - test-build-components

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -354,11 +354,9 @@ jobs:
       - clang-format
       - pytest
       - determine-jobs
-      - ruff
     if: |
       always() &&
-      needs.determine-jobs.outputs.clang-tidy == 'true' &&
-      (needs.ruff.result == 'success' || needs.ruff.result == 'skipped')
+      needs.determine-jobs.outputs.clang-tidy == 'true'
     steps:
       - run: echo "All clang-tidy dependencies ready"
 


### PR DESCRIPTION
# What does this implement/fix?

This PR fixes an issue where clang-tidy CI checks were being skipped when only C++ files were changed in a pull request. The root cause was that clang-tidy job had dependencies on Python linter jobs (ruff, flake8, pylint, pyupgrade) which are conditionally skipped when no Python files are modified.

When Python linters are skipped, GitHub Actions treats the clang-tidy job's dependencies as not met, causing it to be skipped as well - even though clang-tidy should run for C++ changes.

**Bonus:** This allows clang-tidy to start immediately without waiting for any Python linters. Since clang-tidy now only takes 1-2 minutes (thanks to the determine-jobs system), developers get C++ feedback much faster!

## Background

Historically, clang-tidy ran on every file in the repository which was time-consuming, so it made sense to delay its execution until after other checks completed. However, with the introduction of the `determine-jobs` system that intelligently decides which jobs to run based on changed files, clang-tidy now only runs on changed files and typically completes in just 1-2 minutes. 

The current setup forces clang-tidy to wait behind Python linters (including pylint which is one of the slowest jobs), even when those linters aren't needed. This unnecessarily delays C++ feedback for developers.

## Solution

Add an intermediate `clang-tidy-deps` job that handles the dependencies:
- The job includes all clang-tidy dependencies except Python linters
- Uses `always()` condition to ensure it runs when needed
- This allows clang-tidy to proceed without waiting for any Python linters

The clang-tidy job now only depends on:
- `clang-tidy-deps` - the intermediate job that handles dependencies
- `determine-jobs` - to check if clang-tidy should run

This ensures clang-tidy:
1. Always runs when C++ files are changed
2. Doesn't wait for any Python linters (ruff, flake8, pylint, pyupgrade)
3. Provides the fastest possible C++ feedback to developers

## Future Improvements

**Note:** In the future, we could consider replacing flake8 and pyupgrade with ruff entirely, as ruff has rules that cover both flake8 and pyupgrade functionality. This would further simplify the CI pipeline and reduce overall CI time since ruff is significantly faster than running multiple separate linters.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Fixes clang-tidy not running on PRs with only C++ changes (e.g., PR #9433)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - This is a CI/CD fix only

## Test Environment

- N/A - This is a CI workflow change

## Example entry for `config.yaml`:

```yaml
# N/A - This is a CI workflow change
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - N/A - This is an internal CI/CD fix