### PR TITLE
[lvgl] Post-process size arguments in meter config

### DIFF
--- a/esphome/components/lvgl/widgets/meter.py
+++ b/esphome/components/lvgl/widgets/meter.py
@@ -13,6 +13,7 @@ from esphome.const import (
     CONF_ROTATION,
     CONF_VALUE,
     CONF_WIDTH,
+    literal,
 )
 
 from ..automation import action_to_code
@@ -217,7 +218,7 @@ class MeterType(WidgetType):
                             meter_var,
                             major[CONF_STRIDE],
                             major[CONF_WIDTH],
-                            major[CONF_LENGTH],
+                            literal(major[CONF_LENGTH]),
                             color,
                             major[CONF_LABEL_GAP],
                         )

--- a/esphome/components/lvgl/widgets/meter.py
+++ b/esphome/components/lvgl/widgets/meter.py
@@ -13,7 +13,6 @@ from esphome.const import (
     CONF_ROTATION,
     CONF_VALUE,
     CONF_WIDTH,
-    literal,
 )
 
 from ..automation import action_to_code
@@ -30,9 +29,9 @@ from ..defines import (
 )
 from ..helpers import add_lv_use, lvgl_components_required
 from ..lv_validation import (
-    angle,
     get_end_value,
     get_start_value,
+    lv_angle,
     lv_bool,
     lv_color,
     lv_float,
@@ -163,7 +162,7 @@ SCALE_SCHEMA = cv.Schema(
         cv.Optional(CONF_RANGE_FROM, default=0.0): cv.float_,
         cv.Optional(CONF_RANGE_TO, default=100.0): cv.float_,
         cv.Optional(CONF_ANGLE_RANGE, default=270): cv.int_range(0, 360),
-        cv.Optional(CONF_ROTATION): angle,
+        cv.Optional(CONF_ROTATION): lv_angle,
         cv.Optional(CONF_INDICATORS): cv.ensure_list(INDICATOR_SCHEMA),
     }
 )
@@ -188,7 +187,7 @@ class MeterType(WidgetType):
         for scale_conf in config.get(CONF_SCALES, ()):
             rotation = 90 + (360 - scale_conf[CONF_ANGLE_RANGE]) / 2
             if CONF_ROTATION in scale_conf:
-                rotation = scale_conf[CONF_ROTATION] // 10
+                rotation = await lv_angle.process(scale_conf[CONF_ROTATION])
             with LocalVariable(
                 "meter_var", "lv_meter_scale_t", lv_expr.meter_add_scale(var)
             ) as meter_var:
@@ -206,21 +205,20 @@ class MeterType(WidgetType):
                         var,
                         meter_var,
                         ticks[CONF_COUNT],
-                        ticks[CONF_WIDTH],
-                        ticks[CONF_LENGTH],
+                        await size.process(ticks[CONF_WIDTH]),
+                        await size.process(ticks[CONF_LENGTH]),
                         color,
                     )
                     if CONF_MAJOR in ticks:
                         major = ticks[CONF_MAJOR]
-                        color = await lv_color.process(major[CONF_COLOR])
                         lv.meter_set_scale_major_ticks(
                             var,
                             meter_var,
                             major[CONF_STRIDE],
-                            major[CONF_WIDTH],
-                            literal(major[CONF_LENGTH]),
-                            color,
-                            major[CONF_LABEL_GAP],
+                            await size.process(major[CONF_WIDTH]),
+                            await size.process(major[CONF_LENGTH]),
+                            await lv_color.process(major[CONF_COLOR]),
+                            await size.process(major[CONF_LABEL_GAP]),
                         )
                 for indicator in scale_conf.get(CONF_INDICATORS, ()):
                     (t, v) = next(iter(indicator.items()))
@@ -234,7 +232,11 @@ class MeterType(WidgetType):
                         lv_assign(
                             ivar,
                             lv_expr.meter_add_needle_line(
-                                var, meter_var, v[CONF_WIDTH], color, v[CONF_R_MOD]
+                                var,
+                                meter_var,
+                                await size.process(v[CONF_WIDTH]),
+                                color,
+                                await size.process(v[CONF_R_MOD]),
                             ),
                         )
                     if t == CONF_ARC:
@@ -242,7 +244,11 @@ class MeterType(WidgetType):
                         lv_assign(
                             ivar,
                             lv_expr.meter_add_arc(
-                                var, meter_var, v[CONF_WIDTH], color, v[CONF_R_MOD]
+                                var,
+                                meter_var,
+                                await size.process(v[CONF_WIDTH]),
+                                color,
+                                await size.process(v[CONF_R_MOD]),
                             ),
                         )
                     if t == CONF_TICK_STYLE:
@@ -258,7 +264,7 @@ class MeterType(WidgetType):
                                 color_start,
                                 color_end,
                                 v[CONF_LOCAL],
-                                v[CONF_WIDTH],
+                                size.process(v[CONF_WIDTH]),
                             ),
                         )
                     if t == CONF_IMAGE:

--- a/tests/components/lvgl/lvgl-package.yaml
+++ b/tests/components/lvgl/lvgl-package.yaml
@@ -919,21 +919,21 @@ lvgl:
                       text_color: 0xFFFFFF
                       scales:
                         - ticks:
-                            width: 1
+                            width: !lambda return 1;
                             count: 61
-                            length: 20
+                            length: 20%
                             color: 0xFFFFFF
                           range_from: 0
                           range_to: 60
                           angle_range: 360
-                          rotation: 270
+                          rotation: !lambda return 2700;
                           indicators:
                             - line:
                                 opa: 50%
                                 id: minute_hand
                                 color: 0xFF0000
-                                r_mod: -1
-                                width: 3
+                                r_mod: !lambda return -1;
+                                width: !lambda return 3;
                         -
                           angle_range: 330
                           rotation: 300


### PR DESCRIPTION
# What does this implement/fix?

Using LVGL with major ticks, for example…

```yaml
lvgl:
  pages:
    - id: meter
      widgets:
        - meter:
            scales:
              - range_from: 0
                range_to: 100
                angle_range: 180
                ticks:
                  color: 0x0000FF
                  major:
                    color: 0xFF0000
```

results in this error

```
test.yaml:66:3: error: no matching function for call to 'lv_meter_set_scale_major_ticks'
   66 |   lv_meter_set_scale_major_ticks(lv_meter_t_id, meter_var_VAR_, 3, 5, "lv_pct(15)", lv_color_make(255, 255, 255), 4);
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
.piolibdeps/test/lvgl/src/extra/widgets/meter/lv_meter.h:158:6: note: candidate function not viable: no known conversion from 'const char[11]' to 'uint16_t' (aka 'unsigned short') for 5th argument
  158 | void lv_meter_set_scale_major_ticks(lv_obj_t * obj, lv_meter_scale_t * scale, uint16_t nth, uint16_t width,
      |      ^
  159 |                                     uint16_t len, lv_color_t color, int16_t label_gap);
      |                                     ~~~~~~~~~~~~
1 error generated.
*** [.pioenvs/test/src/main.o] Error 
```

Looking at the generated `main.cpp`, `lv_pct()` was being inserted as a string into `lv_meter_set_scale_major_ticks()`

```cpp
lv_meter_set_scale_major_ticks(lv_meter_t_id, meter_var_VAR_, 3, 5, "lv_pct(15)", lv_color_make(0, 0, 0), 4);
```

wrapping this in a `literal()` seems to fix it, although I'm not sure if this may cause other uses/configurations to break. Also, should this `literal()` go into `pixels_or_percent_validator()` itself?

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

[Discord thread](https://discord.com/channels/429907082951524364/1393759796729221282)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
lvgl:
  pages:
    - id: meter
      widgets:
        - meter:
            scales:
              - range_from: 0
                range_to: 100
                angle_range: 180
                ticks:
                  color: 0x0000FF
                  major:
                    color: 0xFF0000
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
