### PR TITLE
Automatically disable interrupts for ESP8266 GPIO16 binary sensors

### DIFF
--- a/esphome/components/gpio/binary_sensor/__init__.py
+++ b/esphome/components/gpio/binary_sensor/__init__.py
@@ -4,7 +4,7 @@ from esphome import pins
 import esphome.codegen as cg
 from esphome.components import binary_sensor
 import esphome.config_validation as cv
-from esphome.const import CONF_ID, CONF_NUMBER, CONF_PIN
+from esphome.const import CONF_ID, CONF_NAME, CONF_NUMBER, CONF_PIN
 from esphome.core import CORE
 
 from .. import gpio_ns
@@ -58,7 +58,7 @@ async def to_code(config):
             "Falling back to polling mode (same as in ESPHome <2025.8). "
             "The sensor will work exactly as before, but other pins have better "
             "performance with interrupts.",
-            config[CONF_ID],
+            config.get(CONF_NAME, config[CONF_ID]),
         )
         use_interrupt = False
 

--- a/esphome/components/gpio/binary_sensor/__init__.py
+++ b/esphome/components/gpio/binary_sensor/__init__.py
@@ -1,10 +1,15 @@
+import logging
+
 from esphome import pins
 import esphome.codegen as cg
 from esphome.components import binary_sensor
 import esphome.config_validation as cv
-from esphome.const import CONF_PIN
+from esphome.const import CONF_NUMBER, CONF_PIN
+from esphome.core import CORE
 
 from .. import gpio_ns
+
+_LOGGER = logging.getLogger(__name__)
 
 GPIOBinarySensor = gpio_ns.class_(
     "GPIOBinarySensor", binary_sensor.BinarySensor, cg.Component
@@ -41,6 +46,19 @@ async def to_code(config):
     pin = await cg.gpio_pin_expression(config[CONF_PIN])
     cg.add(var.set_pin(pin))
 
-    cg.add(var.set_use_interrupt(config[CONF_USE_INTERRUPT]))
-    if config[CONF_USE_INTERRUPT]:
+    # Check for ESP8266 GPIO16 interrupt limitation
+    # GPIO16 on ESP8266 is a special pin that doesn't support interrupts through
+    # the Arduino attachInterrupt() function. This is the only known GPIO pin
+    # across all supported platforms that has this limitation, so we handle it
+    # here instead of in the platform-specific code.
+    use_interrupt = config[CONF_USE_INTERRUPT]
+    if use_interrupt and CORE.is_esp8266 and config[CONF_PIN][CONF_NUMBER] == 16:
+        _LOGGER.warning(
+            "GPIO16 on ESP8266 doesn't support interrupts. "
+            "Automatically disabling interrupt mode for this pin."
+        )
+        use_interrupt = False
+
+    cg.add(var.set_use_interrupt(use_interrupt))
+    if use_interrupt:
         cg.add(var.set_interrupt_type(config[CONF_INTERRUPT_TYPE]))

--- a/esphome/components/gpio/binary_sensor/__init__.py
+++ b/esphome/components/gpio/binary_sensor/__init__.py
@@ -58,7 +58,7 @@ async def to_code(config):
             "Falling back to polling mode (same as in ESPHome <2025.8). "
             "The sensor will work exactly as before, but other pins have better "
             "performance with interrupts.",
-            config.get(CONF_ID) or "unnamed",
+            config[CONF_ID],
         )
         use_interrupt = False
 

--- a/esphome/components/gpio/binary_sensor/__init__.py
+++ b/esphome/components/gpio/binary_sensor/__init__.py
@@ -55,7 +55,7 @@ async def to_code(config):
     if use_interrupt and CORE.is_esp8266 and config[CONF_PIN][CONF_NUMBER] == 16:
         _LOGGER.warning(
             "GPIO16 on ESP8266 doesn't support interrupts. "
-            "Falling back to polling mode (same as in ESPHome <2025.7). "
+            "Falling back to polling mode (same as in ESPHome <2025.8). "
             "The sensor will work exactly as before, but other pins have better "
             "performance with interrupts."
         )

--- a/esphome/components/gpio/binary_sensor/__init__.py
+++ b/esphome/components/gpio/binary_sensor/__init__.py
@@ -55,7 +55,8 @@ async def to_code(config):
     if use_interrupt and CORE.is_esp8266 and config[CONF_PIN][CONF_NUMBER] == 16:
         _LOGGER.warning(
             "GPIO16 on ESP8266 doesn't support interrupts. "
-            "Automatically disabling interrupt mode for this pin."
+            "Falling back to polling mode (same as in ESPHome <2025.7). "
+            "The sensor will work exactly as before, but other pins have better performance with interrupts."
         )
         use_interrupt = False
 

--- a/esphome/components/gpio/binary_sensor/__init__.py
+++ b/esphome/components/gpio/binary_sensor/__init__.py
@@ -4,7 +4,7 @@ from esphome import pins
 import esphome.codegen as cg
 from esphome.components import binary_sensor
 import esphome.config_validation as cv
-from esphome.const import CONF_NUMBER, CONF_PIN
+from esphome.const import CONF_ID, CONF_NUMBER, CONF_PIN
 from esphome.core import CORE
 
 from .. import gpio_ns
@@ -54,10 +54,11 @@ async def to_code(config):
     use_interrupt = config[CONF_USE_INTERRUPT]
     if use_interrupt and CORE.is_esp8266 and config[CONF_PIN][CONF_NUMBER] == 16:
         _LOGGER.warning(
-            "GPIO16 on ESP8266 doesn't support interrupts. "
+            "GPIO binary_sensor '%s': GPIO16 on ESP8266 doesn't support interrupts. "
             "Falling back to polling mode (same as in ESPHome <2025.8). "
             "The sensor will work exactly as before, but other pins have better "
-            "performance with interrupts."
+            "performance with interrupts.",
+            config.get(CONF_ID) or "unnamed",
         )
         use_interrupt = False
 

--- a/esphome/components/gpio/binary_sensor/__init__.py
+++ b/esphome/components/gpio/binary_sensor/__init__.py
@@ -56,7 +56,8 @@ async def to_code(config):
         _LOGGER.warning(
             "GPIO16 on ESP8266 doesn't support interrupts. "
             "Falling back to polling mode (same as in ESPHome <2025.7). "
-            "The sensor will work exactly as before, but other pins have better performance with interrupts."
+            "The sensor will work exactly as before, but other pins have better "
+            "performance with interrupts."
         )
         use_interrupt = False
 

--- a/esphome/components/gpio/binary_sensor/__init__.py
+++ b/esphome/components/gpio/binary_sensor/__init__.py
@@ -55,7 +55,7 @@ async def to_code(config):
     if use_interrupt and CORE.is_esp8266 and config[CONF_PIN][CONF_NUMBER] == 16:
         _LOGGER.warning(
             "GPIO binary_sensor '%s': GPIO16 on ESP8266 doesn't support interrupts. "
-            "Falling back to polling mode (same as in ESPHome <2025.8). "
+            "Falling back to polling mode (same as in ESPHome <2025.7). "
             "The sensor will work exactly as before, but other pins have better "
             "performance with interrupts.",
             config.get(CONF_NAME, config[CONF_ID]),

--- a/tests/component_tests/gpio/test_gpio_binary_sensor.py
+++ b/tests/component_tests/gpio/test_gpio_binary_sensor.py
@@ -38,7 +38,7 @@ def test_gpio_binary_sensor_esp8266_gpio16_disables_interrupt(
 
     # Check that the warning was logged
     assert "GPIO16 on ESP8266 doesn't support interrupts" in caplog.text
-    assert "Automatically disabling interrupt mode for this pin" in caplog.text
+    assert "Falling back to polling mode" in caplog.text
 
 
 def test_gpio_binary_sensor_esp8266_other_pins_use_interrupt(

--- a/tests/component_tests/gpio/test_gpio_binary_sensor.py
+++ b/tests/component_tests/gpio/test_gpio_binary_sensor.py
@@ -14,12 +14,8 @@ def test_gpio_binary_sensor_basic_setup(
     """
     When the GPIO binary sensor is set in the yaml file, it should be registered in main
     """
-    # Given
-
-    # When
     main_cpp = generate_main("tests/component_tests/gpio/test_gpio_binary_sensor.yaml")
 
-    # Then
     assert "new gpio::GPIOBinarySensor();" in main_cpp
     assert "App.register_binary_sensor" in main_cpp
     assert "bs_gpio->set_use_interrupt(true);" in main_cpp
@@ -33,14 +29,10 @@ def test_gpio_binary_sensor_esp8266_gpio16_disables_interrupt(
     """
     Test that ESP8266 GPIO16 automatically disables interrupt mode with a warning
     """
-    # Given
-
-    # When
     main_cpp = generate_main(
         "tests/component_tests/gpio/test_gpio_binary_sensor_esp8266.yaml"
     )
 
-    # Then
     # Check that interrupt is disabled for GPIO16
     assert "bs_gpio16->set_use_interrupt(false);" in main_cpp
 
@@ -55,14 +47,10 @@ def test_gpio_binary_sensor_esp8266_other_pins_use_interrupt(
     """
     Test that ESP8266 pins other than GPIO16 still use interrupt mode
     """
-    # Given
-
-    # When
     main_cpp = generate_main(
         "tests/component_tests/gpio/test_gpio_binary_sensor_esp8266.yaml"
     )
 
-    # Then
     # GPIO5 should still use interrupts
     assert "bs_gpio5->set_use_interrupt(true);" in main_cpp
     assert "bs_gpio5->set_interrupt_type(gpio::INTERRUPT_ANY_EDGE);" in main_cpp
@@ -74,12 +62,8 @@ def test_gpio_binary_sensor_explicit_polling_mode(
     """
     Test that explicitly setting use_interrupt: false works
     """
-    # Given
-
-    # When
     main_cpp = generate_main(
         "tests/component_tests/gpio/test_gpio_binary_sensor_polling.yaml"
     )
 
-    # Then
     assert "bs_polling->set_use_interrupt(false);" in main_cpp

--- a/tests/component_tests/gpio/test_gpio_binary_sensor.py
+++ b/tests/component_tests/gpio/test_gpio_binary_sensor.py
@@ -1,0 +1,85 @@
+"""Tests for the GPIO binary sensor component."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+
+
+def test_gpio_binary_sensor_basic_setup(
+    generate_main: Callable[[str | Path], str],
+) -> None:
+    """
+    When the GPIO binary sensor is set in the yaml file, it should be registered in main
+    """
+    # Given
+
+    # When
+    main_cpp = generate_main("tests/component_tests/gpio/test_gpio_binary_sensor.yaml")
+
+    # Then
+    assert "new gpio::GPIOBinarySensor();" in main_cpp
+    assert "App.register_binary_sensor" in main_cpp
+    assert "bs_gpio->set_use_interrupt(true);" in main_cpp
+    assert "bs_gpio->set_interrupt_type(gpio::INTERRUPT_ANY_EDGE);" in main_cpp
+
+
+def test_gpio_binary_sensor_esp8266_gpio16_disables_interrupt(
+    generate_main: Callable[[str | Path], str],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """
+    Test that ESP8266 GPIO16 automatically disables interrupt mode with a warning
+    """
+    # Given
+
+    # When
+    main_cpp = generate_main(
+        "tests/component_tests/gpio/test_gpio_binary_sensor_esp8266.yaml"
+    )
+
+    # Then
+    # Check that interrupt is disabled for GPIO16
+    assert "bs_gpio16->set_use_interrupt(false);" in main_cpp
+
+    # Check that the warning was logged
+    assert "GPIO16 on ESP8266 doesn't support interrupts" in caplog.text
+    assert "Automatically disabling interrupt mode for this pin" in caplog.text
+
+
+def test_gpio_binary_sensor_esp8266_other_pins_use_interrupt(
+    generate_main: Callable[[str | Path], str],
+) -> None:
+    """
+    Test that ESP8266 pins other than GPIO16 still use interrupt mode
+    """
+    # Given
+
+    # When
+    main_cpp = generate_main(
+        "tests/component_tests/gpio/test_gpio_binary_sensor_esp8266.yaml"
+    )
+
+    # Then
+    # GPIO5 should still use interrupts
+    assert "bs_gpio5->set_use_interrupt(true);" in main_cpp
+    assert "bs_gpio5->set_interrupt_type(gpio::INTERRUPT_ANY_EDGE);" in main_cpp
+
+
+def test_gpio_binary_sensor_explicit_polling_mode(
+    generate_main: Callable[[str | Path], str],
+) -> None:
+    """
+    Test that explicitly setting use_interrupt: false works
+    """
+    # Given
+
+    # When
+    main_cpp = generate_main(
+        "tests/component_tests/gpio/test_gpio_binary_sensor_polling.yaml"
+    )
+
+    # Then
+    assert "bs_polling->set_use_interrupt(false);" in main_cpp

--- a/tests/component_tests/gpio/test_gpio_binary_sensor.yaml
+++ b/tests/component_tests/gpio/test_gpio_binary_sensor.yaml
@@ -1,0 +1,11 @@
+esphome:
+  name: test
+
+esp32:
+  board: esp32dev
+
+binary_sensor:
+  - platform: gpio
+    pin: 5
+    name: "Test GPIO Binary Sensor"
+    id: bs_gpio

--- a/tests/component_tests/gpio/test_gpio_binary_sensor_esp8266.yaml
+++ b/tests/component_tests/gpio/test_gpio_binary_sensor_esp8266.yaml
@@ -1,0 +1,20 @@
+esphome:
+  name: test
+
+esp8266:
+  board: d1_mini
+
+binary_sensor:
+  - platform: gpio
+    pin:
+      number: 16
+      mode: INPUT_PULLDOWN_16
+    name: "GPIO16 Touch Sensor"
+    id: bs_gpio16
+
+  - platform: gpio
+    pin:
+      number: 5
+      mode: INPUT_PULLUP
+    name: "GPIO5 Button"
+    id: bs_gpio5

--- a/tests/component_tests/gpio/test_gpio_binary_sensor_polling.yaml
+++ b/tests/component_tests/gpio/test_gpio_binary_sensor_polling.yaml
@@ -1,0 +1,12 @@
+esphome:
+  name: test
+
+esp32:
+  board: esp32dev
+
+binary_sensor:
+  - platform: gpio
+    pin: 5
+    name: "Polling Mode Sensor"
+    id: bs_polling
+    use_interrupt: false


### PR DESCRIPTION
# What does this implement/fix?

This PR fixes an issue where GPIO16 on ESP8266 devices stopped working as a binary sensor after PR #9115 introduced interrupt support for GPIO binary sensors in ESPHome 2025.7.0b1.

The root cause is clearly documented in the [ESP8266 Arduino Core documentation](https://arduino-esp8266.readthedocs.io/en/latest/reference.html#digital-io): "Pin interrupts are supported through attachInterrupt, detachInterrupt functions. Interrupts may be attached to any GPIO pin, except GPIO16." 

When interrupt mode is enabled (which became the default in #9115), the binary sensor on GPIO16 silently fails to detect state changes because the hardware doesn't support interrupts on this pin.

This fix automatically detects when GPIO16 is used on ESP8266 and falls back to polling mode with a warning message during compilation.

**Manual workaround (if not using this fix):**
Users can manually disable interrupt mode for GPIO16 by adding `use_interrupt: false` to their configuration:
```yaml
binary_sensor:
  - platform: gpio
    pin:
      number: 16
      mode: INPUT_PULLDOWN_16
    name: "Touch Sensor"
    use_interrupt: false  # Silences warning
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Regression introduced by #9115
- Reported by user with ESP8266 + GPIO16 touch sensors that stopped working in 2025.7.0b1

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- Not required - this is an automatic fallback

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# ESP8266 with GPIO16 binary sensor (automatically uses polling mode)
esphome:
  name: esp8266-gpio16-test

esp8266:
  board: d1_mini

binary_sensor:
  - platform: gpio
    pin:
      number: 16
      mode: INPUT_PULLDOWN_16
    name: "Touch Sensor"
    # Note: use_interrupt defaults to true but will be automatically
    # disabled for GPIO16 with a warning during compilation
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

