### PR TITLE
Reduce API component flash usage by consolidating error logging

### DIFF
--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -86,8 +86,8 @@ void APIConnection::start() {
   APIError err = this->helper_->init();
   if (err != APIError::OK) {
     on_fatal_error();
-    ESP_LOGW(TAG, "%s: Helper init failed: %s errno=%d", this->get_client_combined_info().c_str(),
-             api_error_to_str(err), errno);
+    ESP_LOGW(TAG, "%s: Helper init failed %s errno=%d", this->get_client_combined_info().c_str(), api_error_to_str(err),
+             errno);
     return;
   }
   this->client_info_ = helper_->getpeername();
@@ -119,7 +119,7 @@ void APIConnection::loop() {
   APIError err = this->helper_->loop();
   if (err != APIError::OK) {
     on_fatal_error();
-    ESP_LOGW(TAG, "%s: Socket operation failed: %s errno=%d", this->get_client_combined_info().c_str(),
+    ESP_LOGW(TAG, "%s: Socket operation failed %s errno=%d", this->get_client_combined_info().c_str(),
              api_error_to_str(err), errno);
     return;
   }
@@ -136,14 +136,8 @@ void APIConnection::loop() {
         break;
       } else if (err != APIError::OK) {
         on_fatal_error();
-        if (err == APIError::SOCKET_READ_FAILED && errno == ECONNRESET) {
-          ESP_LOGW(TAG, "%s: Connection reset", this->get_client_combined_info().c_str());
-        } else if (err == APIError::CONNECTION_CLOSED) {
-          ESP_LOGW(TAG, "%s: Connection closed", this->get_client_combined_info().c_str());
-        } else {
-          ESP_LOGW(TAG, "%s: Reading failed: %s errno=%d", this->get_client_combined_info().c_str(),
-                   api_error_to_str(err), errno);
-        }
+        ESP_LOGW(TAG, "%s: Reading failed %s errno=%d", this->get_client_combined_info().c_str(), api_error_to_str(err),
+                 errno);
         return;
       } else {
         this->last_traffic_ = now;
@@ -1596,7 +1590,7 @@ bool APIConnection::try_to_clear_buffer(bool log_out_of_space) {
   APIError err = this->helper_->loop();
   if (err != APIError::OK) {
     on_fatal_error();
-    ESP_LOGW(TAG, "%s: Socket operation failed: %s errno=%d", this->get_client_combined_info().c_str(),
+    ESP_LOGW(TAG, "%s: Socket operation failed %s errno=%d", this->get_client_combined_info().c_str(),
              api_error_to_str(err), errno);
     return false;
   }
@@ -1617,12 +1611,8 @@ bool APIConnection::send_buffer(ProtoWriteBuffer buffer, uint8_t message_type) {
     return false;
   if (err != APIError::OK) {
     on_fatal_error();
-    if (err == APIError::SOCKET_WRITE_FAILED && errno == ECONNRESET) {
-      ESP_LOGW(TAG, "%s: Connection reset", this->get_client_combined_info().c_str());
-    } else {
-      ESP_LOGW(TAG, "%s: Packet write failed %s errno=%d", this->get_client_combined_info().c_str(),
-               api_error_to_str(err), errno);
-    }
+    ESP_LOGW(TAG, "%s: Packet write failed %s errno=%d", this->get_client_combined_info().c_str(),
+             api_error_to_str(err), errno);
     return false;
   }
   // Do not set last_traffic_ on send
@@ -1630,11 +1620,11 @@ bool APIConnection::send_buffer(ProtoWriteBuffer buffer, uint8_t message_type) {
 }
 void APIConnection::on_unauthenticated_access() {
   this->on_fatal_error();
-  ESP_LOGD(TAG, "%s requested access without authentication", this->get_client_combined_info().c_str());
+  ESP_LOGD(TAG, "%s access without authentication", this->get_client_combined_info().c_str());
 }
 void APIConnection::on_no_setup_connection() {
   this->on_fatal_error();
-  ESP_LOGD(TAG, "%s requested access without full connection", this->get_client_combined_info().c_str());
+  ESP_LOGD(TAG, "%s access without full connection", this->get_client_combined_info().c_str());
 }
 void APIConnection::on_fatal_error() {
   this->helper_->close();
@@ -1799,12 +1789,8 @@ void APIConnection::process_batch_() {
       this->helper_->write_protobuf_packets(ProtoWriteBuffer{&this->parent_->get_shared_buffer_ref()}, packet_info);
   if (err != APIError::OK && err != APIError::WOULD_BLOCK) {
     on_fatal_error();
-    if (err == APIError::SOCKET_WRITE_FAILED && errno == ECONNRESET) {
-      ESP_LOGW(TAG, "%s: Connection reset during batch write", this->get_client_combined_info().c_str());
-    } else {
-      ESP_LOGW(TAG, "%s: Batch write failed %s errno=%d", this->get_client_combined_info().c_str(),
-               api_error_to_str(err), errno);
-    }
+    ESP_LOGW(TAG, "%s: Batch write failed %s errno=%d", this->get_client_combined_info().c_str(), api_error_to_str(err),
+             errno);
   }
 
 #ifdef HAS_PROTO_MESSAGE_DUMP

--- a/esphome/components/api/api_server.cpp
+++ b/esphome/components/api/api_server.cpp
@@ -428,7 +428,7 @@ bool APIServer::save_noise_psk(psk_t psk, bool make_active) {
   ESP_LOGD(TAG, "Noise PSK saved");
   if (make_active) {
     this->set_timeout(100, [this, psk]() {
-      ESP_LOGW(TAG, "Disconnecting all clients to reset connections");
+      ESP_LOGW(TAG, "Disconnecting all clients to reset PSK");
       this->set_noise_psk(psk);
       for (auto &c : this->clients_) {
         c->send_message(DisconnectRequest());


### PR DESCRIPTION
# What does this implement/fix?

This PR reduces flash usage in the API component by consolidating redundant error logging. The main optimization removes specific error condition checks (ECONNRESET, CONNECTION_CLOSED) since the generic error logging already includes both the error string via `api_error_to_str()` and errno, providing all necessary debugging information.

## Changes made:
- Removed redundant ECONNRESET checks in 3 locations (api_connection.cpp)
- Consolidated error messages to use the generic format that already includes error details
- Fixed misleading log message "Disconnecting all clients to reset connections" → "Disconnecting all clients to reset PSK"
- Removed unnecessary colons from error messages to follow ESPHome logging guidelines

## Flash savings:
- Saves 280 bytes of flash (0.1% reduction)
- Before: Flash: [=======   ]  65.7% (used 1204884 bytes from 1835008 bytes)
- After:  Flash: [=======   ]  65.6% (used 1204604 bytes from 1835008 bytes)
- Eliminates duplicate string literals for "Connection reset" and "Connection closed"
- Removes conditional logic for checking specific error types

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# No configuration changes required
api:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).