### PR TITLE
[substitutions] Fix #7189

### DIFF
--- a/esphome/components/substitutions/__init__.py
+++ b/esphome/components/substitutions/__init__.py
@@ -151,8 +151,11 @@ def _substitute_item(substitutions, item, path, jinja, ignore_missing):
             if sub is not None:
                 item[k] = sub
         for old, new in replace_keys:
-            item[new] = merge_config(item.get(old), item.get(new))
-            del item[old]
+            if str(new) == str(old):
+                item[new] = item[old]
+            else:
+                item[new] = merge_config(item.get(old), item.get(new))
+                del item[old]
     elif isinstance(item, str):
         sub = _expand_substitutions(substitutions, item, path, jinja, ignore_missing)
         if isinstance(sub, JinjaStr) or sub != item:

--- a/tests/unit_tests/fixtures/substitutions/00-simple_var.approved.yaml
+++ b/tests/unit_tests/fixtures/substitutions/00-simple_var.approved.yaml
@@ -17,3 +17,5 @@ test_list:
   - ${undefined_var}
   - $undefined_var
   - ${ undefined_var }
+  - key1: 1
+    key2: 2

--- a/tests/unit_tests/fixtures/substitutions/00-simple_var.input.yaml
+++ b/tests/unit_tests/fixtures/substitutions/00-simple_var.input.yaml
@@ -19,3 +19,5 @@ test_list:
   - ${undefined_var}
   - $undefined_var
   - ${ undefined_var }
+  - key${var1}: 1
+    key${var2}: 2

--- a/tests/unit_tests/fixtures/substitutions/03-closures.approved.yaml
+++ b/tests/unit_tests/fixtures/substitutions/03-closures.approved.yaml
@@ -6,6 +6,7 @@ package_result:
     root file
   - Double substitution also works; the value of var7 is 79, where A is a package
     var
+  - key79: Key should substitute to key79
 local_results:
   - The value of B is 5
   - 'You will see, however, that

--- a/tests/unit_tests/fixtures/substitutions/closures_package.yaml
+++ b/tests/unit_tests/fixtures/substitutions/closures_package.yaml
@@ -1,3 +1,4 @@
 package_result:
   - The value of A*B is ${A * B}, where A is a package var and B is a substitution in the root file
   - Double substitution also works; the value of var7 is ${var$A}, where A is a package var
+  - key${var7}: Key should substitute to key79


### PR DESCRIPTION
# What does this implement/fix?

This PR fixes a small bug whereupon substitutions in keys would not be correctly replaced if those keys where in an included package.

Fixes [#7189](https://github.com/esphome/issues/issues/7189)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Fixes [#7189](https://github.com/esphome/issues/issues/7189)


**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
