### PR TITLE
[fan] Do not save state for fan if configured as NO_RESTORE

### DIFF
--- a/esphome/components/fan/fan.cpp
+++ b/esphome/components/fan/fan.cpp
@@ -177,6 +177,10 @@ optional<FanRestoreState> Fan::restore_state_() {
   return {};
 }
 void Fan::save_state_() {
+  if (this->restore_mode_ == FanRestoreMode::NO_RESTORE) {
+    return;
+  }
+
   FanRestoreState state{};
   state.state = this->state;
   state.oscillating = this->oscillating;


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

When configuring `restore_mode` with a value of `NO_RESTORE` it can reasonably be expected that there should be no reason to save the component's updated state when a change is made.

The change has been made to the Fan component as well as Template Cover and Tuya Cover. It seems like Template Valve should also be affected but I could not easily reproduce the problem there, so I haven't made the same modification in that component.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes esphome/issues#7228

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
fan:
    - name: "No state fan"
      platform: template
      has_direction: true
      restore_mode: NO_RESTORE
    - name: "Stateful fan"
      platform: template
      has_direction: true
      restore_mode: ALWAYS_OFF
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
