### PR TITLE
[esp_ldo] Component schema; default priority

### DIFF
--- a/esphome/components/esp_ldo/__init__.py
+++ b/esphome/components/esp_ldo/__init__.py
@@ -20,14 +20,16 @@ adjusted_ids = set()
 
 CONFIG_SCHEMA = cv.All(
     cv.ensure_list(
-        {
-            cv.GenerateID(): cv.declare_id(EspLdo),
-            cv.Required(CONF_VOLTAGE): cv.All(
-                cv.voltage, cv.float_range(min=0.5, max=2.7)
-            ),
-            cv.Required(CONF_CHANNEL): cv.one_of(*CHANNELS, int=True),
-            cv.Optional(CONF_ADJUSTABLE, default=False): cv.boolean,
-        }
+        cv.COMPONENT_SCHEMA.extend(
+            {
+                cv.GenerateID(): cv.declare_id(EspLdo),
+                cv.Required(CONF_VOLTAGE): cv.All(
+                    cv.voltage, cv.float_range(min=0.5, max=2.7)
+                ),
+                cv.Required(CONF_CHANNEL): cv.one_of(*CHANNELS, int=True),
+                cv.Optional(CONF_ADJUSTABLE, default=False): cv.boolean,
+            }
+        )
     ),
     cv.only_with_esp_idf,
     only_on_variant(supported=[VARIANT_ESP32P4]),

--- a/esphome/components/esp_ldo/esp_ldo.h
+++ b/esphome/components/esp_ldo/esp_ldo.h
@@ -17,6 +17,9 @@ class EspLdo : public Component {
   void set_adjustable(bool adjustable) { this->adjustable_ = adjustable; }
   void set_voltage(float voltage) { this->voltage_ = voltage; }
   void adjust_voltage(float voltage);
+  float get_setup_priority() const override {
+    return setup_priority::BUS;  // LDO setup should be done early
+  }
 
  protected:
   int channel_;

--- a/tests/components/esp_ldo/test.esp32-p4-idf.yaml
+++ b/tests/components/esp_ldo/test.esp32-p4-idf.yaml
@@ -6,6 +6,7 @@ esp_ldo:
   - id: ldo_4
     channel: 4
     voltage: 2.0V
+    setup_priority: 900
 
 esphome:
   on_boot:


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

* Extend `COMPONENT_SCHEMA` to allow priority config;
* Default priority should be higher

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
