### PR TITLE
2025.7.0b3

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ ci:
   autoupdate_commit_msg: 'pre-commit: autoupdate'
   autoupdate_schedule: weekly
   # Skip hooks that have issues in pre-commit CI environment
-  skip: [pylint, clang-tidy-hash, yamllint]
+  skip: [pylint, yamllint]
 
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,13 @@
 ---
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
+
+ci:
+  autoupdate_commit_msg: 'pre-commit: autoupdate'
+  autoupdate_schedule: weekly
+  # Skip hooks that have issues in pre-commit CI environment
+  skip: [pylint, clang-tidy-hash, yamllint]
+
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,7 @@
 ci:
   autoupdate_commit_msg: 'pre-commit: autoupdate'
   autoupdate_schedule: weekly
+  autofix_prs: false
   # Skip hooks that have issues in pre-commit CI environment
   skip: [pylint, yamllint]
 

--- a/Doxyfile
+++ b/Doxyfile
@@ -48,7 +48,7 @@ PROJECT_NAME           = ESPHome
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 2025.7.0b2
+PROJECT_NUMBER         = 2025.7.0b3
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/esphome/components/esp_ldo/__init__.py
+++ b/esphome/components/esp_ldo/__init__.py
@@ -20,14 +20,16 @@ adjusted_ids = set()
 
 CONFIG_SCHEMA = cv.All(
     cv.ensure_list(
-        {
-            cv.GenerateID(): cv.declare_id(EspLdo),
-            cv.Required(CONF_VOLTAGE): cv.All(
-                cv.voltage, cv.float_range(min=0.5, max=2.7)
-            ),
-            cv.Required(CONF_CHANNEL): cv.one_of(*CHANNELS, int=True),
-            cv.Optional(CONF_ADJUSTABLE, default=False): cv.boolean,
-        }
+        cv.COMPONENT_SCHEMA.extend(
+            {
+                cv.GenerateID(): cv.declare_id(EspLdo),
+                cv.Required(CONF_VOLTAGE): cv.All(
+                    cv.voltage, cv.float_range(min=0.5, max=2.7)
+                ),
+                cv.Required(CONF_CHANNEL): cv.one_of(*CHANNELS, int=True),
+                cv.Optional(CONF_ADJUSTABLE, default=False): cv.boolean,
+            }
+        )
     ),
     cv.only_with_esp_idf,
     only_on_variant(supported=[VARIANT_ESP32P4]),

--- a/esphome/components/esp_ldo/esp_ldo.h
+++ b/esphome/components/esp_ldo/esp_ldo.h
@@ -17,6 +17,9 @@ class EspLdo : public Component {
   void set_adjustable(bool adjustable) { this->adjustable_ = adjustable; }
   void set_voltage(float voltage) { this->voltage_ = voltage; }
   void adjust_voltage(float voltage);
+  float get_setup_priority() const override {
+    return setup_priority::BUS;  // LDO setup should be done early
+  }
 
  protected:
   int channel_;

--- a/esphome/components/i2s_audio/speaker/__init__.py
+++ b/esphome/components/i2s_audio/speaker/__init__.py
@@ -180,7 +180,7 @@ async def to_code(config):
     await speaker.register_speaker(var, config)
 
     if config[CONF_DAC_TYPE] == "internal":
-        cg.add(var.set_internal_dac_mode(config[CONF_CHANNEL]))
+        cg.add(var.set_internal_dac_mode(config[CONF_MODE]))
     else:
         cg.add(var.set_dout_pin(config[CONF_I2S_DOUT_PIN]))
         if use_legacy():

--- a/esphome/components/ld2420/binary_sensor/ld2420_binary_sensor.cpp
+++ b/esphome/components/ld2420/binary_sensor/ld2420_binary_sensor.cpp
@@ -5,10 +5,10 @@
 namespace esphome {
 namespace ld2420 {
 
-static const char *const TAG = "LD2420.binary_sensor";
+static const char *const TAG = "ld2420.binary_sensor";
 
 void LD2420BinarySensor::dump_config() {
-  ESP_LOGCONFIG(TAG, "LD2420 BinarySensor:");
+  ESP_LOGCONFIG(TAG, "Binary Sensor:");
   LOG_BINARY_SENSOR("  ", "Presence", this->presence_bsensor_);
 }
 

--- a/esphome/components/ld2420/button/reconfig_buttons.cpp
+++ b/esphome/components/ld2420/button/reconfig_buttons.cpp
@@ -2,7 +2,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-static const char *const TAG = "LD2420.button";
+static const char *const TAG = "ld2420.button";
 
 namespace esphome {
 namespace ld2420 {

--- a/esphome/components/ld2420/number/gate_config_number.cpp
+++ b/esphome/components/ld2420/number/gate_config_number.cpp
@@ -2,7 +2,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-static const char *const TAG = "LD2420.number";
+static const char *const TAG = "ld2420.number";
 
 namespace esphome {
 namespace ld2420 {

--- a/esphome/components/ld2420/select/operating_mode_select.cpp
+++ b/esphome/components/ld2420/select/operating_mode_select.cpp
@@ -5,7 +5,7 @@
 namespace esphome {
 namespace ld2420 {
 
-static const char *const TAG = "LD2420.select";
+static const char *const TAG = "ld2420.select";
 
 void LD2420Select::control(const std::string &value) {
   this->publish_state(value);

--- a/esphome/components/ld2420/sensor/ld2420_sensor.cpp
+++ b/esphome/components/ld2420/sensor/ld2420_sensor.cpp
@@ -5,10 +5,10 @@
 namespace esphome {
 namespace ld2420 {
 
-static const char *const TAG = "LD2420.sensor";
+static const char *const TAG = "ld2420.sensor";
 
 void LD2420Sensor::dump_config() {
-  ESP_LOGCONFIG(TAG, "LD2420 Sensor:");
+  ESP_LOGCONFIG(TAG, "Sensor:");
   LOG_SENSOR("  ", "Distance", this->distance_sensor_);
 }
 

--- a/esphome/components/ld2420/text_sensor/text_sensor.cpp
+++ b/esphome/components/ld2420/text_sensor/text_sensor.cpp
@@ -5,10 +5,10 @@
 namespace esphome {
 namespace ld2420 {
 
-static const char *const TAG = "LD2420.text_sensor";
+static const char *const TAG = "ld2420.text_sensor";
 
 void LD2420TextSensor::dump_config() {
-  ESP_LOGCONFIG(TAG, "LD2420 TextSensor:");
+  ESP_LOGCONFIG(TAG, "Text Sensor:");
   LOG_TEXT_SENSOR("  ", "Firmware", this->fw_version_text_sensor_);
 }
 

--- a/esphome/components/lvgl/widgets/meter.py
+++ b/esphome/components/lvgl/widgets/meter.py
@@ -29,9 +29,9 @@ from ..defines import (
 )
 from ..helpers import add_lv_use, lvgl_components_required
 from ..lv_validation import (
-    angle,
     get_end_value,
     get_start_value,
+    lv_angle,
     lv_bool,
     lv_color,
     lv_float,
@@ -162,7 +162,7 @@ SCALE_SCHEMA = cv.Schema(
         cv.Optional(CONF_RANGE_FROM, default=0.0): cv.float_,
         cv.Optional(CONF_RANGE_TO, default=100.0): cv.float_,
         cv.Optional(CONF_ANGLE_RANGE, default=270): cv.int_range(0, 360),
-        cv.Optional(CONF_ROTATION): angle,
+        cv.Optional(CONF_ROTATION): lv_angle,
         cv.Optional(CONF_INDICATORS): cv.ensure_list(INDICATOR_SCHEMA),
     }
 )
@@ -187,7 +187,7 @@ class MeterType(WidgetType):
         for scale_conf in config.get(CONF_SCALES, ()):
             rotation = 90 + (360 - scale_conf[CONF_ANGLE_RANGE]) / 2
             if CONF_ROTATION in scale_conf:
-                rotation = scale_conf[CONF_ROTATION] // 10
+                rotation = await lv_angle.process(scale_conf[CONF_ROTATION])
             with LocalVariable(
                 "meter_var", "lv_meter_scale_t", lv_expr.meter_add_scale(var)
             ) as meter_var:
@@ -205,21 +205,20 @@ class MeterType(WidgetType):
                         var,
                         meter_var,
                         ticks[CONF_COUNT],
-                        ticks[CONF_WIDTH],
-                        ticks[CONF_LENGTH],
+                        await size.process(ticks[CONF_WIDTH]),
+                        await size.process(ticks[CONF_LENGTH]),
                         color,
                     )
                     if CONF_MAJOR in ticks:
                         major = ticks[CONF_MAJOR]
-                        color = await lv_color.process(major[CONF_COLOR])
                         lv.meter_set_scale_major_ticks(
                             var,
                             meter_var,
                             major[CONF_STRIDE],
-                            major[CONF_WIDTH],
-                            major[CONF_LENGTH],
-                            color,
-                            major[CONF_LABEL_GAP],
+                            await size.process(major[CONF_WIDTH]),
+                            await size.process(major[CONF_LENGTH]),
+                            await lv_color.process(major[CONF_COLOR]),
+                            await size.process(major[CONF_LABEL_GAP]),
                         )
                 for indicator in scale_conf.get(CONF_INDICATORS, ()):
                     (t, v) = next(iter(indicator.items()))
@@ -233,7 +232,11 @@ class MeterType(WidgetType):
                         lv_assign(
                             ivar,
                             lv_expr.meter_add_needle_line(
-                                var, meter_var, v[CONF_WIDTH], color, v[CONF_R_MOD]
+                                var,
+                                meter_var,
+                                await size.process(v[CONF_WIDTH]),
+                                color,
+                                await size.process(v[CONF_R_MOD]),
                             ),
                         )
                     if t == CONF_ARC:
@@ -241,7 +244,11 @@ class MeterType(WidgetType):
                         lv_assign(
                             ivar,
                             lv_expr.meter_add_arc(
-                                var, meter_var, v[CONF_WIDTH], color, v[CONF_R_MOD]
+                                var,
+                                meter_var,
+                                await size.process(v[CONF_WIDTH]),
+                                color,
+                                await size.process(v[CONF_R_MOD]),
                             ),
                         )
                     if t == CONF_TICK_STYLE:
@@ -257,7 +264,7 @@ class MeterType(WidgetType):
                                 color_start,
                                 color_end,
                                 v[CONF_LOCAL],
-                                v[CONF_WIDTH],
+                                size.process(v[CONF_WIDTH]),
                             ),
                         )
                     if t == CONF_IMAGE:

--- a/esphome/components/substitutions/__init__.py
+++ b/esphome/components/substitutions/__init__.py
@@ -151,8 +151,11 @@ def _substitute_item(substitutions, item, path, jinja, ignore_missing):
             if sub is not None:
                 item[k] = sub
         for old, new in replace_keys:
-            item[new] = merge_config(item.get(old), item.get(new))
-            del item[old]
+            if str(new) == str(old):
+                item[new] = item[old]
+            else:
+                item[new] = merge_config(item.get(old), item.get(new))
+                del item[old]
     elif isinstance(item, str):
         sub = _expand_substitutions(substitutions, item, path, jinja, ignore_missing)
         if isinstance(sub, JinjaStr) or sub != item:

--- a/esphome/const.py
+++ b/esphome/const.py
@@ -4,7 +4,7 @@ from enum import Enum
 
 from esphome.enum import StrEnum
 
-__version__ = "2025.7.0b2"
+__version__ = "2025.7.0b3"
 
 ALLOWED_NAME_CHARS = "abcdefghijklmnopqrstuvwxyz0123456789-_"
 VALID_SUBSTITUTIONS_CHARACTERS = (

--- a/esphome/core/component.cpp
+++ b/esphome/core/component.cpp
@@ -138,7 +138,7 @@ void Component::call_dump_config() {
         }
       }
     }
-    ESP_LOGE(TAG, "  Component %s is marked FAILED: %s", this->get_component_source(), error_msg);
+    ESP_LOGE(TAG, "  %s is marked FAILED: %s", this->get_component_source(), error_msg);
   }
 }
 
@@ -191,7 +191,7 @@ bool Component::should_warn_of_blocking(uint32_t blocking_time) {
   return false;
 }
 void Component::mark_failed() {
-  ESP_LOGE(TAG, "Component %s was marked as failed", this->get_component_source());
+  ESP_LOGE(TAG, "%s was marked as failed", this->get_component_source());
   this->component_state_ &= ~COMPONENT_STATE_MASK;
   this->component_state_ |= COMPONENT_STATE_FAILED;
   this->status_set_error();
@@ -229,7 +229,7 @@ void IRAM_ATTR HOT Component::enable_loop_soon_any_context() {
 }
 void Component::reset_to_construction_state() {
   if ((this->component_state_ & COMPONENT_STATE_MASK) == COMPONENT_STATE_FAILED) {
-    ESP_LOGI(TAG, "Component %s is being reset to construction state", this->get_component_source());
+    ESP_LOGI(TAG, "%s is being reset to construction state", this->get_component_source());
     this->component_state_ &= ~COMPONENT_STATE_MASK;
     this->component_state_ |= COMPONENT_STATE_CONSTRUCTION;
     // Clear error status when resetting
@@ -275,14 +275,14 @@ void Component::status_set_warning(const char *message) {
     return;
   this->component_state_ |= STATUS_LED_WARNING;
   App.app_state_ |= STATUS_LED_WARNING;
-  ESP_LOGW(TAG, "Component %s set Warning flag: %s", this->get_component_source(), message);
+  ESP_LOGW(TAG, "%s set Warning flag: %s", this->get_component_source(), message);
 }
 void Component::status_set_error(const char *message) {
   if ((this->component_state_ & STATUS_LED_ERROR) != 0)
     return;
   this->component_state_ |= STATUS_LED_ERROR;
   App.app_state_ |= STATUS_LED_ERROR;
-  ESP_LOGE(TAG, "Component %s set Error flag: %s", this->get_component_source(), message);
+  ESP_LOGE(TAG, "%s set Error flag: %s", this->get_component_source(), message);
   if (strcmp(message, "unspecified") != 0) {
     // Lazy allocate the error messages vector if needed
     if (!component_error_messages) {
@@ -303,13 +303,13 @@ void Component::status_clear_warning() {
   if ((this->component_state_ & STATUS_LED_WARNING) == 0)
     return;
   this->component_state_ &= ~STATUS_LED_WARNING;
-  ESP_LOGW(TAG, "Component %s cleared Warning flag", this->get_component_source());
+  ESP_LOGW(TAG, "%s cleared Warning flag", this->get_component_source());
 }
 void Component::status_clear_error() {
   if ((this->component_state_ & STATUS_LED_ERROR) == 0)
     return;
   this->component_state_ &= ~STATUS_LED_ERROR;
-  ESP_LOGE(TAG, "Component %s cleared Error flag", this->get_component_source());
+  ESP_LOGE(TAG, "%s cleared Error flag", this->get_component_source());
 }
 void Component::status_momentary_warning(const std::string &name, uint32_t length) {
   this->status_set_warning();
@@ -403,7 +403,7 @@ uint32_t WarnIfComponentBlockingGuard::finish() {
   }
   if (should_warn) {
     const char *src = component_ == nullptr ? "<null>" : component_->get_component_source();
-    ESP_LOGW(TAG, "Component %s took a long time for an operation (%" PRIu32 " ms)", src, blocking_time);
+    ESP_LOGW(TAG, "%s took a long time for an operation (%" PRIu32 " ms)", src, blocking_time);
     ESP_LOGW(TAG, "Components should block for at most 30 ms");
   }
 

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -783,7 +783,7 @@ template<class T> class RAMAllocator {
   T *reallocate(T *p, size_t n) { return this->reallocate(p, n, sizeof(T)); }
 
   T *reallocate(T *p, size_t n, size_t manual_size) {
-    size_t size = n * sizeof(T);
+    size_t size = n * manual_size;
     T *ptr = nullptr;
 #ifdef USE_ESP32
     if (this->flags_ & Flags::ALLOC_EXTERNAL) {

--- a/tests/component_tests/gpio/test_gpio_binary_sensor.py
+++ b/tests/component_tests/gpio/test_gpio_binary_sensor.py
@@ -1,0 +1,69 @@
+"""Tests for the GPIO binary sensor component."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+
+
+def test_gpio_binary_sensor_basic_setup(
+    generate_main: Callable[[str | Path], str],
+) -> None:
+    """
+    When the GPIO binary sensor is set in the yaml file, it should be registered in main
+    """
+    main_cpp = generate_main("tests/component_tests/gpio/test_gpio_binary_sensor.yaml")
+
+    assert "new gpio::GPIOBinarySensor();" in main_cpp
+    assert "App.register_binary_sensor" in main_cpp
+    assert "bs_gpio->set_use_interrupt(true);" in main_cpp
+    assert "bs_gpio->set_interrupt_type(gpio::INTERRUPT_ANY_EDGE);" in main_cpp
+
+
+def test_gpio_binary_sensor_esp8266_gpio16_disables_interrupt(
+    generate_main: Callable[[str | Path], str],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """
+    Test that ESP8266 GPIO16 automatically disables interrupt mode with a warning
+    """
+    main_cpp = generate_main(
+        "tests/component_tests/gpio/test_gpio_binary_sensor_esp8266.yaml"
+    )
+
+    # Check that interrupt is disabled for GPIO16
+    assert "bs_gpio16->set_use_interrupt(false);" in main_cpp
+
+    # Check that the warning was logged
+    assert "GPIO16 on ESP8266 doesn't support interrupts" in caplog.text
+    assert "Falling back to polling mode" in caplog.text
+
+
+def test_gpio_binary_sensor_esp8266_other_pins_use_interrupt(
+    generate_main: Callable[[str | Path], str],
+) -> None:
+    """
+    Test that ESP8266 pins other than GPIO16 still use interrupt mode
+    """
+    main_cpp = generate_main(
+        "tests/component_tests/gpio/test_gpio_binary_sensor_esp8266.yaml"
+    )
+
+    # GPIO5 should still use interrupts
+    assert "bs_gpio5->set_use_interrupt(true);" in main_cpp
+    assert "bs_gpio5->set_interrupt_type(gpio::INTERRUPT_ANY_EDGE);" in main_cpp
+
+
+def test_gpio_binary_sensor_explicit_polling_mode(
+    generate_main: Callable[[str | Path], str],
+) -> None:
+    """
+    Test that explicitly setting use_interrupt: false works
+    """
+    main_cpp = generate_main(
+        "tests/component_tests/gpio/test_gpio_binary_sensor_polling.yaml"
+    )
+
+    assert "bs_polling->set_use_interrupt(false);" in main_cpp

--- a/tests/component_tests/gpio/test_gpio_binary_sensor.yaml
+++ b/tests/component_tests/gpio/test_gpio_binary_sensor.yaml
@@ -1,0 +1,11 @@
+esphome:
+  name: test
+
+esp32:
+  board: esp32dev
+
+binary_sensor:
+  - platform: gpio
+    pin: 5
+    name: "Test GPIO Binary Sensor"
+    id: bs_gpio

--- a/tests/component_tests/gpio/test_gpio_binary_sensor_esp8266.yaml
+++ b/tests/component_tests/gpio/test_gpio_binary_sensor_esp8266.yaml
@@ -1,0 +1,20 @@
+esphome:
+  name: test
+
+esp8266:
+  board: d1_mini
+
+binary_sensor:
+  - platform: gpio
+    pin:
+      number: 16
+      mode: INPUT_PULLDOWN_16
+    name: "GPIO16 Touch Sensor"
+    id: bs_gpio16
+
+  - platform: gpio
+    pin:
+      number: 5
+      mode: INPUT_PULLUP
+    name: "GPIO5 Button"
+    id: bs_gpio5

--- a/tests/component_tests/gpio/test_gpio_binary_sensor_polling.yaml
+++ b/tests/component_tests/gpio/test_gpio_binary_sensor_polling.yaml
@@ -1,0 +1,12 @@
+esphome:
+  name: test
+
+esp32:
+  board: esp32dev
+
+binary_sensor:
+  - platform: gpio
+    pin: 5
+    name: "Polling Mode Sensor"
+    id: bs_polling
+    use_interrupt: false

--- a/tests/components/esp_ldo/test.esp32-p4-idf.yaml
+++ b/tests/components/esp_ldo/test.esp32-p4-idf.yaml
@@ -6,6 +6,7 @@ esp_ldo:
   - id: ldo_4
     channel: 4
     voltage: 2.0V
+    setup_priority: 900
 
 esphome:
   on_boot:

--- a/tests/components/lvgl/lvgl-package.yaml
+++ b/tests/components/lvgl/lvgl-package.yaml
@@ -919,21 +919,21 @@ lvgl:
                       text_color: 0xFFFFFF
                       scales:
                         - ticks:
-                            width: 1
+                            width: !lambda return 1;
                             count: 61
-                            length: 20
+                            length: 20%
                             color: 0xFFFFFF
                           range_from: 0
                           range_to: 60
                           angle_range: 360
-                          rotation: 270
+                          rotation: !lambda return 2700;
                           indicators:
                             - line:
                                 opa: 50%
                                 id: minute_hand
                                 color: 0xFF0000
-                                r_mod: -1
-                                width: 3
+                                r_mod: !lambda return -1;
+                                width: !lambda return 3;
                         -
                           angle_range: 330
                           rotation: 300

--- a/tests/unit_tests/fixtures/substitutions/00-simple_var.approved.yaml
+++ b/tests/unit_tests/fixtures/substitutions/00-simple_var.approved.yaml
@@ -17,3 +17,5 @@ test_list:
   - ${undefined_var}
   - $undefined_var
   - ${ undefined_var }
+  - key1: 1
+    key2: 2

--- a/tests/unit_tests/fixtures/substitutions/00-simple_var.input.yaml
+++ b/tests/unit_tests/fixtures/substitutions/00-simple_var.input.yaml
@@ -19,3 +19,5 @@ test_list:
   - ${undefined_var}
   - $undefined_var
   - ${ undefined_var }
+  - key${var1}: 1
+    key${var2}: 2

--- a/tests/unit_tests/fixtures/substitutions/03-closures.approved.yaml
+++ b/tests/unit_tests/fixtures/substitutions/03-closures.approved.yaml
@@ -6,6 +6,7 @@ package_result:
     root file
   - Double substitution also works; the value of var7 is 79, where A is a package
     var
+  - key79: Key should substitute to key79
 local_results:
   - The value of B is 5
   - 'You will see, however, that

--- a/tests/unit_tests/fixtures/substitutions/closures_package.yaml
+++ b/tests/unit_tests/fixtures/substitutions/closures_package.yaml
@@ -1,3 +1,4 @@
 package_result:
   - The value of A*B is ${A * B}, where A is a package var and B is a substitution in the root file
   - Double substitution also works; the value of var7 is ${var$A}, where A is a package var
+  - key${var7}: Key should substitute to key79


### PR DESCRIPTION
**Do not merge, release script will automatically merge**
## Full list of changes

### All changes

<details>
<summary>Show</summary>

- [ld2420] Memory optimization, code clean-up [esphome#9426](https://github.com/esphome/esphome/pull/9426)
- (Maybe?) fix I2S speaker internal DAC mode [esphome#9435](https://github.com/esphome/esphome/pull/9435)
- [lvgl] Post-process size arguments in meter config [esphome#9466](https://github.com/esphome/esphome/pull/9466)
- Automatically disable interrupts for ESP8266 GPIO16 binary sensors [esphome#9467](https://github.com/esphome/esphome/pull/9467)
- [substitutions] Fix #7189 [esphome#9469](https://github.com/esphome/esphome/pull/9469)
- [esp_ldo] Component schema; default priority [esphome#9479](https://github.com/esphome/esphome/pull/9479)
- Follow logging best practices by removing redundant component prefix [esphome#9481](https://github.com/esphome/esphome/pull/9481)
- Fix dormant bug in RAMAllocator::reallocate() manual_size calculation [esphome#9482](https://github.com/esphome/esphome/pull/9482)
</details>

<details>
<summary>Metadata</summary>

@coderabbitai ignore
</details>
