### PR TITLE
Suppress spurious volatile and Python syntax warnings during builds

### DIFF
--- a/esphome/platformio_api.py
+++ b/esphome/platformio_api.py
@@ -79,7 +79,7 @@ def run_platformio_cli(*args, **kwargs) -> str | int:
         "PLATFORMIO_LIBDEPS_DIR", os.path.abspath(CORE.relative_piolibdeps_path())
     )
     # Suppress Python syntax warnings from third-party scripts during compilation
-    os.environ["PYTHONWARNINGS"] = "ignore::SyntaxWarning"
+    os.environ.setdefault("PYTHONWARNINGS", "ignore::SyntaxWarning")
     cmd = ["platformio"] + list(args)
 
     if not CORE.verbose:

--- a/esphome/platformio_api.py
+++ b/esphome/platformio_api.py
@@ -78,6 +78,8 @@ def run_platformio_cli(*args, **kwargs) -> str | int:
     os.environ.setdefault(
         "PLATFORMIO_LIBDEPS_DIR", os.path.abspath(CORE.relative_piolibdeps_path())
     )
+    # Suppress Python syntax warnings from third-party scripts during compilation
+    os.environ["PYTHONWARNINGS"] = "ignore::SyntaxWarning"
     cmd = ["platformio"] + list(args)
 
     if not CORE.verbose:

--- a/esphome/writer.py
+++ b/esphome/writer.py
@@ -162,6 +162,9 @@ def get_ini_content():
     # Sort to avoid changing build unflags order
     CORE.add_platformio_option("build_unflags", sorted(CORE.build_unflags))
 
+    # Add extra script for C++ flags
+    CORE.add_platformio_option("extra_scripts", ["pre:cxx_flags.py"])
+
     content = "[platformio]\n"
     content += f"description = ESPHome {__version__}\n"
 
@@ -221,6 +224,9 @@ def write_platformio_project():
     if not get_bool_env(ENV_NOGITIGNORE):
         write_gitignore()
     write_platformio_ini(content)
+
+    # Write extra script for C++ specific flags
+    write_cxx_flags_script()
 
 
 DEFINES_H_FORMAT = ESPHOME_H_FORMAT = """\
@@ -394,3 +400,16 @@ def write_gitignore():
     if not os.path.isfile(path):
         with open(file=path, mode="w", encoding="utf-8") as f:
             f.write(GITIGNORE_CONTENT)
+
+
+CXX_FLAGS_SCRIPT = """# Auto-generated ESPHome script for C++ specific compiler flags
+Import("env")
+
+# Add C++ specific warning flags
+env.Append(CXXFLAGS=["-Wno-volatile"])
+"""
+
+
+def write_cxx_flags_script() -> None:
+    path = CORE.relative_build_path("cxx_flags.py")
+    write_file_if_changed(path, CXX_FLAGS_SCRIPT)


### PR DESCRIPTION
# What does this implement/fix?

1. Disables the `-Wvolatile` compiler warning globally across all ESPHome components and dependencies.
2. Suppresses Python SyntaxWarnings from third-party scripts during compilation.

In C++20, compound assignment operations (|=, &=, +=, -=, etc.) on volatile-qualified variables were deprecated, resulting in warnings when using GCC 10+ with C++20. This deprecation was made without proper consideration for embedded systems where volatile compound operations on hardware registers are essential and common practice.

The issues with this warning in embedded contexts:
- Hardware register access requires volatile semantics to prevent compiler optimizations
- Rewriting `reg |= bit` as `reg = reg | bit` can cause unwanted double-reads of hardware registers
- Many vendor-supplied headers use these patterns extensively
- The suggested workarounds result in less efficient and less clear code

Example of the specific warning being suppressed:
```
src/esphome/components/esp8266/gpio.cpp:152:27: warning: compound assignment with 'volatile'-qualified left operand is deprecated [-Wvolatile]
  152 |         *arg->control_reg &= ~(1 << GPCD);
      |         ~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~
```

The C++ committee has since acknowledged this was a mistake and has undeprecated volatile compound assignments in C++23 through proposal [P2327R1](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/p2327r1.pdf), recognizing their legitimate use in embedded systems. Until projects move to C++23, disabling this warning is the recommended approach used by major embedded projects including [Raspberry Pi Pico SDK](https://github.com/raspberrypi/pico-sdk/issues/1017) and [ARM CMSIS](https://github.com/ARM-software/CMSIS_5/issues/1544).

By adding `-Wno-volatile` to the global build flags, we maintain proper volatile semantics that are critical for embedded systems while eliminating spurious warnings.

## Implementation Details

The `-Wno-volatile` flag is added via a PlatformIO extra script rather than directly in build_flags because:
- The warning only affects C++ files, but adding it to build_flags applies it to both C and C++ files
- When applied to C files, it generates additional warnings: "command-line option '-Wno-volatile' is valid for C++/ObjC++ but not for C"
- PlatformIO's extra_scripts mechanism allows us to use `CXXFLAGS` to target only C++ compilation
- This approach follows PlatformIO's recommended pattern for language-specific compiler flags

Additionally, this PR suppresses Python SyntaxWarnings that appear during compilation from third-party framework scripts. These warnings about invalid escape sequences are harmless but create noise in the build output:

```
.platformio/packages/framework-arduinoespressif8266/tools/elf2bin.py:54: SyntaxWarning: invalid escape sequence '\s'
  words = re.split('\s+', line)
.platformio/packages/framework-arduinoespressif8266/tools/elf2bin.py:73: SyntaxWarning: invalid escape sequence '\s'
  words = re.split('\s+', line)
```

Since these are in third-party code outside ESPHome's control, we suppress them by setting `PYTHONWARNINGS=ignore::SyntaxWarning` during the PlatformIO build process.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - this is a build system change
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).