### PR TITLE
Remove redundant pyupgrade CI job (follow-up to #9484)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,29 +84,6 @@ jobs:
         run: script/ci-suggest-changes
         if: always()
 
-  pyupgrade:
-    name: Check pyupgrade
-    runs-on: ubuntu-24.04
-    needs:
-      - common
-      - determine-jobs
-    if: needs.determine-jobs.outputs.python-linters == 'true'
-    steps:
-      - name: Check out code from GitHub
-        uses: actions/checkout@v4.2.2
-      - name: Restore Python
-        uses: ./.github/actions/restore-python
-        with:
-          python-version: ${{ env.DEFAULT_PYTHON }}
-          cache-key: ${{ needs.common.outputs.cache-key }}
-      - name: Run pyupgrade
-        run: |
-          . venv/bin/activate
-          pyupgrade ${{ env.PYUPGRADE_TARGET }} `find esphome -name "*.py" -type f`
-      - name: Suggested changes
-        run: script/ci-suggest-changes
-        if: always()
-
   ci-custom:
     name: Run script/ci-custom
     runs-on: ubuntu-24.04
@@ -525,7 +502,6 @@ jobs:
       - pylint
       - pytest
       - integration-tests
-      - pyupgrade
       - clang-tidy-deps
       - clang-tidy
       - determine-jobs


### PR DESCRIPTION
# What does this implement/fix?

This PR completes the CI cleanup work from #9484 by removing the separate pyupgrade CI job. In the previous PR, we removed the separate ruff and flake8 CI jobs since they're now handled by pre-commit-ci lite mode, but we missed removing the pyupgrade job.

The pyupgrade check is still enforced through the pre-commit hook configuration, so this just removes the redundant CI job.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Follow-up to #9484

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- N/A (CI configuration change only)

## Example entry for `config.yaml`:

```yaml
# N/A - CI configuration change only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - N/A Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - N/A Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

