### PR TITLE
Fix WebServer routes constant naming convention

### DIFF
--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -1887,7 +1887,7 @@ void WebServer::handleRequest(AsyncWebServerRequest *request) {
     void (WebServer::*handler)(AsyncWebServerRequest *, const UrlMatch &);
   };
 
-  static const ComponentRoute routes[] = {
+  static const ComponentRoute ROUTES[] = {
 #ifdef USE_SENSOR
       {"sensor", &WebServer::handle_sensor_request},
 #endif
@@ -1948,7 +1948,7 @@ void WebServer::handleRequest(AsyncWebServerRequest *request) {
   };
 
   // Check each route
-  for (const auto &route : routes) {
+  for (const auto &route : ROUTES) {
     if (match.domain_equals(route.domain)) {
       (this->*route.handler)(request, match);
       return;


### PR DESCRIPTION
# What does this implement/fix?

This PR fixes a naming convention issue in the WebServer component where the constant array `routes` was not following the uppercase naming convention for constants. It should be `ROUTES`.

This issue was missed in PR #9470 because it was originally run on the CI before the clang-tidy CI fix in #9463 was applied. The clang-tidy check would have caught this naming convention violation, but it wasn't running at the time.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Follow-up fix for #9470 (Refactor WebServer request handling for improved maintainability)
- Related to clang-tidy CI fix in #9463

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - Internal code quality fix only

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# No configuration changes - internal code quality fix only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).