### PR TITLE
[ms8607] Fix humidity calc

### DIFF
--- a/esphome/components/ms8607/ms8607.cpp
+++ b/esphome/components/ms8607/ms8607.cpp
@@ -356,7 +356,7 @@ void MS8607Component::read_humidity_(float temperature_float) {
 
   // map 16 bit humidity value into range [-6%, 118%]
   float const humidity_partial = double(humidity) / (1 << 16);
-  float const humidity_percentage = lerp(humidity_partial, -6.0, 118.0);
+  float const humidity_percentage = std::lerp(-6.0, 118.0, humidity_partial);
   float const compensated_humidity_percentage =
       humidity_percentage + (20 - temperature_float) * MS8607_H_TEMP_COEFFICIENT;
   ESP_LOGD(TAG, "Compensated for temperature, humidity=%.2f%%", compensated_humidity_percentage);


### PR DESCRIPTION
Fix lerp

# What does this implement/fix?

<!-- Quick description and explanation of changes -->
ms8607: Fix humidity calc

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
