### PR TITLE
Fix blocked CI cancellation caused by always() in clang-tidy workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,30 +246,13 @@ jobs:
           . venv/bin/activate
           pytest -vv --no-cov --tb=native -n auto tests/integration/
 
-  clang-tidy-deps:
-    name: Clang-tidy dependencies
-    runs-on: ubuntu-24.04
-    needs:
-      - common
-      - ci-custom
-      - pytest
-      - determine-jobs
-    if: |
-      always() &&
-      needs.determine-jobs.outputs.clang-tidy == 'true'
-    steps:
-      - run: echo "All clang-tidy dependencies ready"
-
   clang-tidy:
     name: ${{ matrix.name }}
     runs-on: ubuntu-24.04
     needs:
-      - clang-tidy-deps
+      - common
       - determine-jobs
-    if: |
-      always() &&
-      needs.determine-jobs.outputs.clang-tidy == 'true' &&
-      needs.clang-tidy-deps.result == 'success'
+    if: needs.determine-jobs.outputs.clang-tidy == 'true'
     env:
       GH_TOKEN: ${{ github.token }}
     strategy:
@@ -502,7 +485,6 @@ jobs:
       - pylint
       - pytest
       - integration-tests
-      - clang-tidy-deps
       - clang-tidy
       - determine-jobs
       - test-build-components


### PR DESCRIPTION
# What does this implement/fix?

This PR fixes the CI workflow cancellation issue by removing the `always()` condition from the clang-tidy job dependency chain. The `always()` condition was making the `clang-tidy-deps` job uncancellable, which prevented proper workflow cancellation when new commits are pushed, causing CI resource blocking and concurrency issues.

The fix removes the intermediate `clang-tidy-deps` job entirely since clang-tidy no longer needs to wait for Python linters to complete. This simplifies the workflow and ensures all jobs properly respect cancellation signals.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Follows up on #9463 which introduced the `always()` condition to fix a broken dependency chain

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - This is a CI-only change

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# N/A - CI workflow change only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

