### PR TITLE
Optimize API connection batch priority message handling to reduce flash usage

### DIFF
--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -186,7 +186,8 @@ void APIConnection::loop() {
       on_fatal_error();
       ESP_LOGW(TAG, "%s is unresponsive; disconnecting", this->get_client_combined_info().c_str());
     }
-  } else if (now - this->last_traffic_ > KEEPALIVE_TIMEOUT_MS) {
+  } else if (now - this->last_traffic_ > KEEPALIVE_TIMEOUT_MS && !this->flags_.remove) {
+    // Only send ping if we're not disconnecting
     ESP_LOGVV(TAG, "Sending keepalive PING");
     this->flags_.sent_ping = this->send_message(PingRequest());
     if (!this->flags_.sent_ping) {
@@ -1662,8 +1663,15 @@ void APIConnection::DeferredBatch::add_item(EntityBase *entity, MessageCreator c
 
 void APIConnection::DeferredBatch::add_item_front(EntityBase *entity, MessageCreator creator, uint8_t message_type,
                                                   uint8_t estimated_size) {
-  // Insert at front for high priority messages (no deduplication check)
-  items.insert(items.begin(), BatchItem(entity, std::move(creator), message_type, estimated_size));
+  // Add high priority message and swap to front
+  // This avoids expensive vector::insert which shifts all elements
+  // Note: We only ever have one high-priority message at a time (ping OR disconnect)
+  // If we're disconnecting, pings are blocked, so this simple swap is sufficient
+  items.emplace_back(entity, std::move(creator), message_type, estimated_size);
+  if (items.size() > 1) {
+    // Swap the new high-priority item to the front
+    std::swap(items.front(), items.back());
+  }
 }
 
 bool APIConnection::schedule_batch_() {


### PR DESCRIPTION
# What does this implement/fix?

This PR optimizes the flash memory usage of the API connection's `add_item_front` method by replacing the expensive `vector::insert()` operation with a more efficient `emplace_back()` + `swap()` approach.

The change reduces flash usage by approximately 300 bytes by avoiding the need to shift all vector elements when inserting at the front (add_item_front stl vector ops generated a lot of hidden code). This is safe because:
- Only one high-priority message (ping or disconnect) exists at a time
- We already prevent pings when disconnecting
- The exact order within a batch doesn't affect delivery since we send the entire batch together

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# No configuration changes needed - this is an internal optimization
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

## Additional Information

### Flash usage measurements:
- Before: 16,147 bytes
- After: 15,844 bytes
- **Savings: 303 bytes**

### Technical details:
The `add_item_front` method is only used for high-priority messages (ping and disconnect) when the transmit buffer is full. Since we only have one high-priority message at a time and pings are blocked during disconnect, the simple swap approach is sufficient and much more efficient than shifting all vector elements.

