### PR TITLE
Skip API log message calls for unsubscribed log levels

### DIFF
--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -1410,9 +1410,6 @@ void APIConnection::update_command(const UpdateCommandRequest &msg) {
 #endif
 
 bool APIConnection::try_send_log_message(int level, const char *tag, const char *line, size_t message_len) {
-  if (this->flags_.log_subscription < level)
-    return false;
-
   // Pre-calculate message size to avoid reallocations
   uint32_t msg_size = 0;
 

--- a/esphome/components/api/api_connection.h
+++ b/esphome/components/api/api_connection.h
@@ -209,6 +209,7 @@ class APIConnection : public APIServerConnection {
     return static_cast<ConnectionState>(this->flags_.connection_state) == ConnectionState::CONNECTED ||
            this->is_authenticated();
   }
+  uint8_t get_log_subscription_level() const { return this->flags_.log_subscription; }
   void on_fatal_error() override;
   void on_unauthenticated_access() override;
   void on_no_setup_connection() override;

--- a/esphome/components/api/api_server.cpp
+++ b/esphome/components/api/api_server.cpp
@@ -105,7 +105,7 @@ void APIServer::setup() {
             return;
           }
           for (auto &c : this->clients_) {
-            if (!c->flags_.remove)
+            if (!c->flags_.remove && c->get_log_subscription_level() >= level)
               c->try_send_log_message(level, tag, message, message_len);
           }
         });


### PR DESCRIPTION
# What does this implement/fix?

This PR optimizes API log message sending by checking the log subscription level before calling `try_send_log_message()`, avoiding unnecessary function calls when log messages won't be sent.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [x] Tested on host platform

## Example entry for `config.yaml`:

```yaml
# No configuration changes required
api:
  password: !secret api_password

logger:
  level: DEBUG
```

## Details

This optimization:
- Adds an inline getter `get_log_subscription_level()` to expose the client's log subscription level
- Moves the log level check from inside `try_send_log_message()` to the caller in `api_server.cpp`
- Avoids function call overhead, parameter passing, and stack operations when logs won't be sent
- Reduces flash usage by 4 bytes (from 1200500 to 1200496 bytes)

The performance benefit is particularly noticeable when:
- Many API clients are connected but only some are subscribed to logs
- Clients are subscribed to higher log levels (e.g., warnings/errors only) while the system generates many debug/info messages
- The system logs frequently (which ESPHome often does)

While this is a tiny optimization, it's essentially free and reduces both CPU cycles and flash usage. Given that logging can be very frequent in ESPHome, the cumulative effect of avoiding unnecessary function calls can be meaningful.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).