### PR TITLE
Drop Python 3.10 support, require Python 3.11+

### DIFF
--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5.6.0
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3.11.1
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,8 @@ permissions:
   contents: read
 
 env:
-  DEFAULT_PYTHON: "3.10"
-  PYUPGRADE_TARGET: "--py310-plus"
+  DEFAULT_PYTHON: "3.11"
+  PYUPGRADE_TARGET: "--py311-plus"
 
 concurrency:
   # yamllint disable-line rule:line-length
@@ -112,7 +112,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - "3.10"
           - "3.11"
           - "3.12"
           - "3.13"
@@ -128,13 +127,9 @@ jobs:
             os: windows-latest
           - python-version: "3.12"
             os: windows-latest
-          - python-version: "3.10"
-            os: windows-latest
           - python-version: "3.13"
             os: macOS-latest
           - python-version: "3.12"
-            os: macOS-latest
-          - python-version: "3.10"
             os: macOS-latest
     runs-on: ${{ matrix.os }}
     needs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,7 +96,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5.6.0
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3.11.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,7 +40,7 @@ repos:
     rev: v3.20.0
     hooks:
       - id: pyupgrade
-        args: [--py310-plus]
+        args: [--py311-plus]
   - repo: https://github.com/adrienverge/yamllint.git
     rev: v1.37.1
     hooks:

--- a/esphome/components/lvgl/styles.py
+++ b/esphome/components/lvgl/styles.py
@@ -76,6 +76,7 @@ async def theme_to_code(config):
         for w_name, style in theme.items():
             # Work around Python 3.10 bug with nested async comprehensions
             # With Python 3.11 this could be simplified
+            # TODO: Now that we require Python 3.11+, this can be updated to use nested comprehensions
             styles = {}
             for part, states in collect_parts(style).items():
                 styles[part] = {

--- a/esphome/dashboard/dns.py
+++ b/esphome/dashboard/dns.py
@@ -3,14 +3,8 @@ from __future__ import annotations
 import asyncio
 from contextlib import suppress
 from ipaddress import ip_address
-import sys
 
 from icmplib import NameLookupError, async_resolve
-
-if sys.version_info >= (3, 11):
-    from asyncio import timeout as async_timeout
-else:
-    from async_timeout import timeout as async_timeout
 
 RESOLVE_TIMEOUT = 3.0
 
@@ -20,9 +14,9 @@ async def _async_resolve_wrapper(hostname: str) -> list[str] | Exception:
     with suppress(ValueError):
         return [str(ip_address(hostname))]
     try:
-        async with async_timeout(RESOLVE_TIMEOUT):
+        async with asyncio.timeout(RESOLVE_TIMEOUT):
             return await async_resolve(hostname)
-    except (asyncio.TimeoutError, NameLookupError, UnicodeError) as ex:
+    except (TimeoutError, NameLookupError, UnicodeError) as ex:
         return ex
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Topic :: Home Automation",
 ]
-requires-python = ">=3.10.0"
+requires-python = ">=3.11.0"
 
 dynamic = ["dependencies", "optional-dependencies", "version"]
 
@@ -62,7 +62,7 @@ addopts = [
 ]
 
 [tool.pylint.MAIN]
-py-version = "3.10"
+py-version = "3.11"
 ignore = [
   "api_pb2.py",
 ]
@@ -106,7 +106,7 @@ expected-line-ending-format = "LF"
 
 [tool.ruff]
 required-version = ">=0.5.0"
-target-version = "py310"
+target-version = "py311"
 exclude = ['generated']
 
 [tool.ruff.lint]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-async_timeout==5.0.1; python_version <= "3.10"
 cryptography==45.0.1
 voluptuous==0.15.2
 PyYAML==6.0.2

--- a/script/lint-python
+++ b/script/lint-python
@@ -137,7 +137,7 @@ def main():
     print()
     print("Running pyupgrade...")
     print()
-    PYUPGRADE_TARGET = "--py310-plus"
+    PYUPGRADE_TARGET = "--py311-plus"
     for files in filesets:
         cmd = ["pyupgrade", PYUPGRADE_TARGET] + files
         log = get_err(*cmd)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -395,7 +395,7 @@ async def wait_and_connect_api_client(
         # Wait for connection with timeout
         try:
             await asyncio.wait_for(connected_future, timeout=timeout)
-        except asyncio.TimeoutError:
+        except TimeoutError:
             raise TimeoutError(f"Failed to connect to API after {timeout} seconds")
 
         yield client
@@ -575,12 +575,12 @@ async def run_binary_and_wait_for_port(
             process.send_signal(signal.SIGINT)
             try:
                 await asyncio.wait_for(process.wait(), timeout=SIGINT_TIMEOUT)
-            except asyncio.TimeoutError:
+            except TimeoutError:
                 # If SIGINT didn't work, try SIGTERM
                 process.terminate()
                 try:
                     await asyncio.wait_for(process.wait(), timeout=SIGTERM_TIMEOUT)
-                except asyncio.TimeoutError:
+                except TimeoutError:
                     # Last resort: SIGKILL
                     process.kill()
                     await process.wait()

--- a/tests/integration/test_api_message_size_batching.py
+++ b/tests/integration/test_api_message_size_batching.py
@@ -177,7 +177,7 @@ async def test_api_message_size_batching(
         # Wait for states with timeout
         try:
             await asyncio.wait_for(states_future, timeout=5.0)
-        except asyncio.TimeoutError:
+        except TimeoutError:
             missing_keys = expected_keys - received_keys
             pytest.fail(
                 f"Did not receive states from all entities within 5 seconds. "

--- a/tests/integration/test_api_reboot_timeout.py
+++ b/tests/integration/test_api_reboot_timeout.py
@@ -29,7 +29,7 @@ async def test_api_reboot_timeout(
         # (0.5s reboot timeout + some margin for processing)
         try:
             await asyncio.wait_for(reboot_future, timeout=2.0)
-        except asyncio.TimeoutError:
+        except TimeoutError:
             pytest.fail("Device did not reboot within expected timeout")
 
     # Test passes if we get here - reboot was detected

--- a/tests/integration/test_areas_and_devices.py
+++ b/tests/integration/test_areas_and_devices.py
@@ -98,7 +98,7 @@ async def test_areas_and_devices(
         # Wait for sensor states
         try:
             await asyncio.wait_for(states_future, timeout=10.0)
-        except asyncio.TimeoutError:
+        except TimeoutError:
             pytest.fail(
                 f"Did not receive all sensor states within 10 seconds. "
                 f"Received {len(states)} states"

--- a/tests/integration/test_device_id_in_state.py
+++ b/tests/integration/test_device_id_in_state.py
@@ -77,7 +77,7 @@ async def test_device_id_in_state(
         # Wait for states
         try:
             await asyncio.wait_for(states_future, timeout=10.0)
-        except asyncio.TimeoutError:
+        except TimeoutError:
             pytest.fail(
                 f"Did not receive all entity states within 10 seconds. "
                 f"Received {len(states)} states, expected {len(entity_device_mapping)}"

--- a/tests/integration/test_duplicate_entities.py
+++ b/tests/integration/test_duplicate_entities.py
@@ -206,7 +206,7 @@ async def test_duplicate_entities_not_allowed_on_different_devices(
         # Wait for all entity states
         try:
             await asyncio.wait_for(states_future, timeout=10.0)
-        except asyncio.TimeoutError:
+        except TimeoutError:
             pytest.fail(
                 f"Did not receive all entity states within 10 seconds. "
                 f"Expected {expected_count}, received {state_count}"

--- a/tests/integration/test_entity_icon.py
+++ b/tests/integration/test_entity_icon.py
@@ -82,7 +82,7 @@ async def test_entity_icon(
         # Wait for states
         try:
             await asyncio.wait_for(state_received.wait(), timeout=5.0)
-        except asyncio.TimeoutError:
+        except TimeoutError:
             pytest.fail("No states received within 5 seconds")
 
         # Verify we received states

--- a/tests/integration/test_host_mode_batch_delay.py
+++ b/tests/integration/test_host_mode_batch_delay.py
@@ -44,7 +44,7 @@ async def test_host_mode_batch_delay(
         # Wait for states from all entities with timeout
         try:
             entity_count = await asyncio.wait_for(entity_count_future, timeout=5.0)
-        except asyncio.TimeoutError:
+        except TimeoutError:
             pytest.fail(
                 f"Did not receive states from at least 7 entities within 5 seconds. "
                 f"Received {len(states)} states"

--- a/tests/integration/test_host_mode_empty_string_options.py
+++ b/tests/integration/test_host_mode_empty_string_options.py
@@ -99,7 +99,7 @@ async def test_host_mode_empty_string_options(
         # Wait for initial states with timeout
         try:
             await asyncio.wait_for(states_received_future, timeout=5.0)
-        except asyncio.TimeoutError:
+        except TimeoutError:
             pytest.fail(
                 f"Did not receive states for all select entities. "
                 f"Expected keys: {expected_select_keys}, Received: {received_select_keys}"

--- a/tests/integration/test_host_mode_entity_fields.py
+++ b/tests/integration/test_host_mode_entity_fields.py
@@ -86,7 +86,7 @@ async def test_host_mode_entity_fields(
         # Wait for at least one state
         try:
             await asyncio.wait_for(state_received.wait(), timeout=5.0)
-        except asyncio.TimeoutError:
+        except TimeoutError:
             pytest.fail("No states received within 5 seconds")
 
         # Verify we received states (which means has_state flag is working)

--- a/tests/integration/test_host_mode_many_entities.py
+++ b/tests/integration/test_host_mode_many_entities.py
@@ -41,7 +41,7 @@ async def test_host_mode_many_entities(
         # Wait for states from at least 50 sensors with timeout
         try:
             sensor_count = await asyncio.wait_for(sensor_count_future, timeout=10.0)
-        except asyncio.TimeoutError:
+        except TimeoutError:
             sensor_states = [
                 s
                 for s in states.values()

--- a/tests/integration/test_host_mode_many_entities_multiple_connections.py
+++ b/tests/integration/test_host_mode_many_entities_multiple_connections.py
@@ -50,7 +50,7 @@ async def test_host_mode_many_entities_multiple_connections(
                 asyncio.wait_for(client1_ready, timeout=10.0),
                 asyncio.wait_for(client2_ready, timeout=10.0),
             )
-        except asyncio.TimeoutError:
+        except TimeoutError:
             pytest.fail(
                 f"One or both clients did not receive enough states within 10 seconds. "
                 f"Client1: {len(states1)}, Client2: {len(states2)}"

--- a/tests/integration/test_host_mode_sensor.py
+++ b/tests/integration/test_host_mode_sensor.py
@@ -40,7 +40,7 @@ async def test_host_mode_with_sensor(
         # Wait for sensor with specific value (42.0) with timeout
         try:
             test_sensor_state = await asyncio.wait_for(sensor_future, timeout=5.0)
-        except asyncio.TimeoutError:
+        except TimeoutError:
             pytest.fail(
                 f"Sensor with value 42.0 not received within 5 seconds. "
                 f"Received states: {list(states.values())}"

--- a/tests/integration/test_loop_disable_enable.py
+++ b/tests/integration/test_loop_disable_enable.py
@@ -150,7 +150,7 @@ async def test_loop_disable_enable(
         # Wait for self_disable_10 to disable itself
         try:
             await asyncio.wait_for(self_disable_10_disabled.wait(), timeout=10.0)
-        except asyncio.TimeoutError:
+        except TimeoutError:
             pytest.fail("self_disable_10 did not disable itself within 10 seconds")
 
         # Verify it ran at least 10 times before disabling
@@ -164,7 +164,7 @@ async def test_loop_disable_enable(
         # Wait for normal_component to run at least 10 times
         try:
             await asyncio.wait_for(normal_component_10_loops.wait(), timeout=10.0)
-        except asyncio.TimeoutError:
+        except TimeoutError:
             pytest.fail(
                 f"normal_component did not reach 10 loops within timeout, got {len(normal_component_counts)}"
             )
@@ -172,12 +172,12 @@ async def test_loop_disable_enable(
         # Wait for redundant operation tests
         try:
             await asyncio.wait_for(redundant_enable_tested.wait(), timeout=10.0)
-        except asyncio.TimeoutError:
+        except TimeoutError:
             pytest.fail("redundant_enable did not test enabling when already enabled")
 
         try:
             await asyncio.wait_for(redundant_disable_tested.wait(), timeout=10.0)
-        except asyncio.TimeoutError:
+        except TimeoutError:
             pytest.fail(
                 "redundant_disable did not test disabling when will be disabled"
             )
@@ -185,7 +185,7 @@ async def test_loop_disable_enable(
         # Wait to see if self_disable_10 gets re-enabled
         try:
             await asyncio.wait_for(self_disable_10_re_enabled.wait(), timeout=5.0)
-        except asyncio.TimeoutError:
+        except TimeoutError:
             pytest.fail("self_disable_10 was not re-enabled within 5 seconds")
 
         # Component was re-enabled - verify it ran more times
@@ -198,7 +198,7 @@ async def test_loop_disable_enable(
         # Wait for ISR component to disable itself after 5 loops
         try:
             await asyncio.wait_for(isr_component_disabled.wait(), timeout=3.0)
-        except asyncio.TimeoutError:
+        except TimeoutError:
             pytest.fail("ISR component did not disable itself within 3 seconds")
 
         # Verify it ran exactly 5 times before disabling
@@ -210,7 +210,7 @@ async def test_loop_disable_enable(
         # Wait for component to be re-enabled by periodic ISR simulation and run again
         try:
             await asyncio.wait_for(isr_component_re_enabled.wait(), timeout=2.0)
-        except asyncio.TimeoutError:
+        except TimeoutError:
             pytest.fail("ISR component was not re-enabled after ISR call")
 
         # Verify it's running again after ISR enable
@@ -222,7 +222,7 @@ async def test_loop_disable_enable(
         # Wait for pure ISR enable (no main loop enable) to work
         try:
             await asyncio.wait_for(isr_component_pure_re_enabled.wait(), timeout=2.0)
-        except asyncio.TimeoutError:
+        except TimeoutError:
             pytest.fail("ISR component was not re-enabled by pure ISR call")
 
         # Verify it ran after pure ISR enable
@@ -235,7 +235,7 @@ async def test_loop_disable_enable(
         # Wait for update component to disable its loop
         try:
             await asyncio.wait_for(update_component_loop_disabled.wait(), timeout=3.0)
-        except asyncio.TimeoutError:
+        except TimeoutError:
             pytest.fail("Update component did not disable its loop within 3 seconds")
 
         # Verify it ran exactly 3 loops before disabling
@@ -248,7 +248,7 @@ async def test_loop_disable_enable(
             await asyncio.wait_for(
                 update_component_manual_update_called.wait(), timeout=5.0
             )
-        except asyncio.TimeoutError:
+        except TimeoutError:
             pytest.fail("Manual component.update was not called within 5 seconds")
 
         # The key test: verify that manual component.update worked after loop was disabled

--- a/tests/integration/test_scheduler_bulk_cleanup.py
+++ b/tests/integration/test_scheduler_bulk_cleanup.py
@@ -103,7 +103,7 @@ async def test_scheduler_bulk_cleanup(
         # Wait for test completion
         try:
             await asyncio.wait_for(test_complete_future, timeout=10.0)
-        except asyncio.TimeoutError:
+        except TimeoutError:
             pytest.fail("Bulk cleanup test timed out")
 
         # Verify bulk cleanup was triggered

--- a/tests/integration/test_scheduler_defer_cancel.py
+++ b/tests/integration/test_scheduler_defer_cancel.py
@@ -85,7 +85,7 @@ async def test_scheduler_defer_cancel(
         try:
             await asyncio.wait_for(test_complete_future, timeout=10.0)
             executed_defer = await asyncio.wait_for(test_result_future, timeout=1.0)
-        except asyncio.TimeoutError:
+        except TimeoutError:
             pytest.fail("Test did not complete within timeout")
 
         # Verify that only defer 10 was executed

--- a/tests/integration/test_scheduler_defer_cancel_regular.py
+++ b/tests/integration/test_scheduler_defer_cancel_regular.py
@@ -64,7 +64,7 @@ async def test_scheduler_defer_cancels_regular(
         # Wait for test completion
         try:
             await asyncio.wait_for(test_complete_future, timeout=5.0)
-        except asyncio.TimeoutError:
+        except TimeoutError:
             pytest.fail(f"Test timed out. Log messages: {log_messages}")
 
         # Verify results

--- a/tests/integration/test_scheduler_defer_fifo_simple.py
+++ b/tests/integration/test_scheduler_defer_fifo_simple.py
@@ -90,7 +90,7 @@ async def test_scheduler_defer_fifo_simple(
         try:
             await asyncio.wait_for(test_complete_future, timeout=5.0)
             test1_passed = await asyncio.wait_for(test_result_future, timeout=1.0)
-        except asyncio.TimeoutError:
+        except TimeoutError:
             pytest.fail("Test set_timeout(0) did not complete within 5 seconds")
 
         assert test1_passed is True, (
@@ -108,7 +108,7 @@ async def test_scheduler_defer_fifo_simple(
         try:
             await asyncio.wait_for(test_complete_future, timeout=5.0)
             test2_passed = await asyncio.wait_for(test_result_future, timeout=1.0)
-        except asyncio.TimeoutError:
+        except TimeoutError:
             pytest.fail("Test defer() did not complete within 5 seconds")
 
         # Verify the test passed

--- a/tests/integration/test_scheduler_defer_stress.py
+++ b/tests/integration/test_scheduler_defer_stress.py
@@ -97,7 +97,7 @@ async def test_scheduler_defer_stress(
         # Wait for all defers to execute (should be quick)
         try:
             await asyncio.wait_for(test_complete_future, timeout=5.0)
-        except asyncio.TimeoutError:
+        except TimeoutError:
             # Report how many we got
             pytest.fail(
                 f"Stress test timed out. Only {len(executed_defers)} of "

--- a/tests/integration/test_scheduler_heap_stress.py
+++ b/tests/integration/test_scheduler_heap_stress.py
@@ -104,7 +104,7 @@ async def test_scheduler_heap_stress(
         # Wait for all callbacks to execute (should be quick, but give more time for scheduling)
         try:
             await asyncio.wait_for(test_complete_future, timeout=60.0)
-        except asyncio.TimeoutError:
+        except TimeoutError:
             # Report how many we got
             pytest.fail(
                 f"Stress test timed out. Only {len(executed_callbacks)} of "

--- a/tests/integration/test_scheduler_null_name.py
+++ b/tests/integration/test_scheduler_null_name.py
@@ -53,7 +53,7 @@ async def test_scheduler_null_name(
             # Wait for test completion
             try:
                 await asyncio.wait_for(test_complete_future, timeout=10.0)
-            except asyncio.TimeoutError:
+            except TimeoutError:
                 pytest.fail(
                     "Test did not complete within timeout - likely crashed due to NULL name"
                 )

--- a/tests/integration/test_scheduler_rapid_cancellation.py
+++ b/tests/integration/test_scheduler_rapid_cancellation.py
@@ -112,7 +112,7 @@ async def test_scheduler_rapid_cancellation(
         # Wait for test to complete with timeout
         try:
             await asyncio.wait_for(test_complete_future, timeout=10.0)
-        except asyncio.TimeoutError:
+        except TimeoutError:
             pytest.fail(f"Test timed out. Stats: {test_stats}")
 
         # Check for any errors

--- a/tests/integration/test_scheduler_recursive_timeout.py
+++ b/tests/integration/test_scheduler_recursive_timeout.py
@@ -84,7 +84,7 @@ async def test_scheduler_recursive_timeout(
         # Wait for test to complete
         try:
             await asyncio.wait_for(test_complete_future, timeout=10.0)
-        except asyncio.TimeoutError:
+        except TimeoutError:
             pytest.fail(
                 f"Recursive timeout test timed out. Got sequence: {execution_sequence}"
             )

--- a/tests/integration/test_scheduler_simultaneous_callbacks.py
+++ b/tests/integration/test_scheduler_simultaneous_callbacks.py
@@ -103,7 +103,7 @@ async def test_scheduler_simultaneous_callbacks(
         # Wait for test to complete
         try:
             await asyncio.wait_for(test_complete_future, timeout=30.0)
-        except asyncio.TimeoutError:
+        except TimeoutError:
             pytest.fail(f"Simultaneous callbacks test timed out. Stats: {test_stats}")
 
         # Check for any errors

--- a/tests/integration/test_scheduler_string_lifetime.py
+++ b/tests/integration/test_scheduler_string_lifetime.py
@@ -157,7 +157,7 @@ async def test_scheduler_string_lifetime(
             client.execute_service(test_services["final"], {})
             await asyncio.wait_for(all_tests_complete.wait(), timeout=5.0)
 
-        except asyncio.TimeoutError:
+        except TimeoutError:
             pytest.fail(f"String lifetime test timed out. Stats: {test_stats}")
 
         # Check for any errors

--- a/tests/integration/test_scheduler_string_name_stress.py
+++ b/tests/integration/test_scheduler_string_name_stress.py
@@ -97,7 +97,7 @@ async def test_scheduler_string_name_stress(
         # Wait for test to complete or crash
         try:
             await asyncio.wait_for(test_complete_future, timeout=30.0)
-        except asyncio.TimeoutError:
+        except TimeoutError:
             pytest.fail(
                 f"String name stress test timed out. Executed {len(executed_callbacks)} callbacks. "
                 f"This might indicate a deadlock."

--- a/tests/integration/test_scheduler_string_test.py
+++ b/tests/integration/test_scheduler_string_test.py
@@ -122,22 +122,22 @@ async def test_scheduler_string_test(
         # Wait for static string tests
         try:
             await asyncio.wait_for(static_timeout_1_fired.wait(), timeout=0.5)
-        except asyncio.TimeoutError:
+        except TimeoutError:
             pytest.fail("Static timeout 1 did not fire within 0.5 seconds")
 
         try:
             await asyncio.wait_for(static_timeout_2_fired.wait(), timeout=0.5)
-        except asyncio.TimeoutError:
+        except TimeoutError:
             pytest.fail("Static timeout 2 did not fire within 0.5 seconds")
 
         try:
             await asyncio.wait_for(static_interval_fired.wait(), timeout=1.0)
-        except asyncio.TimeoutError:
+        except TimeoutError:
             pytest.fail("Static interval did not fire within 1 second")
 
         try:
             await asyncio.wait_for(static_interval_cancelled.wait(), timeout=2.0)
-        except asyncio.TimeoutError:
+        except TimeoutError:
             pytest.fail("Static interval was not cancelled within 2 seconds")
 
         # Verify static interval ran at least 3 times
@@ -153,41 +153,41 @@ async def test_scheduler_string_test(
         # Wait for static defer tests
         try:
             await asyncio.wait_for(static_defer_1_fired.wait(), timeout=0.5)
-        except asyncio.TimeoutError:
+        except TimeoutError:
             pytest.fail("Static defer 1 did not fire within 0.5 seconds")
 
         try:
             await asyncio.wait_for(static_defer_2_fired.wait(), timeout=0.5)
-        except asyncio.TimeoutError:
+        except TimeoutError:
             pytest.fail("Static defer 2 did not fire within 0.5 seconds")
 
         # Wait for dynamic string tests
         try:
             await asyncio.wait_for(dynamic_timeout_fired.wait(), timeout=1.0)
-        except asyncio.TimeoutError:
+        except TimeoutError:
             pytest.fail("Dynamic timeout did not fire within 1 second")
 
         try:
             await asyncio.wait_for(dynamic_interval_fired.wait(), timeout=1.5)
-        except asyncio.TimeoutError:
+        except TimeoutError:
             pytest.fail("Dynamic interval did not fire within 1.5 seconds")
 
         # Wait for dynamic defer test
         try:
             await asyncio.wait_for(dynamic_defer_fired.wait(), timeout=1.0)
-        except asyncio.TimeoutError:
+        except TimeoutError:
             pytest.fail("Dynamic defer did not fire within 1 second")
 
         # Wait for cancel test
         try:
             await asyncio.wait_for(cancel_test_done.wait(), timeout=1.0)
-        except asyncio.TimeoutError:
+        except TimeoutError:
             pytest.fail("Cancel test did not complete within 1 second")
 
         # Wait for final results
         try:
             await asyncio.wait_for(final_results_logged.wait(), timeout=4.0)
-        except asyncio.TimeoutError:
+        except TimeoutError:
             pytest.fail("Final results were not logged within 4 seconds")
 
         # Verify results


### PR DESCRIPTION
# What does this implement/fix?

This PR drops support for Python 3.10 and makes Python 3.11 the minimum required version for ESPHome.

As outlined in esphome/backlog#44, each Python version we support adds development overhead and prevents us from using newer language features. With Debian Bookworm now using Python 3.11, we can safely drop Python 3.10 support to simplify our development and CI infrastructure.

## Changes made:
- Updated minimum Python version to 3.11 in `pyproject.toml`
- Updated all CI workflows to use Python 3.11 as the default
- Removed Python 3.10 from test matrices
- Updated linting tools (pylint, ruff, pyupgrade) to target Python 3.11+
- Removed Python 3.10-specific code:
  - Removed conditional `async_timeout` import (now using `asyncio.timeout`)
  - Removed `async_timeout` dependency from requirements.txt
- Updated pre-commit configuration to use `--py311-plus`

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- closes esphome/backlog#44

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- Not applicable - documentation already mentions Python 3.11 requirement

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# No configuration changes required
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).