### PR TITLE
Update esp32-camera library version to 2.1.0

### DIFF
--- a/esphome/components/esp32_camera/__init__.py
+++ b/esphome/components/esp32_camera/__init__.py
@@ -345,7 +345,7 @@ async def to_code(config):
     cg.add_define("USE_CAMERA")
 
     if CORE.using_esp_idf:
-        add_idf_component(name="espressif/esp32-camera", ref="2.0.15")
+        add_idf_component(name="espressif/esp32-camera", ref="2.1.0")
 
     for conf in config.get(CONF_ON_STREAM_START, []):
         trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)

--- a/esphome/idf_component.yml
+++ b/esphome/idf_component.yml
@@ -2,7 +2,7 @@ dependencies:
   espressif/esp-tflite-micro:
     version: 1.3.3~1
   espressif/esp32-camera:
-    version: 2.0.15
+    version: 2.1.0
   espressif/mdns:
     version: 1.8.2
   espressif/esp_wifi_remote:


### PR DESCRIPTION
# What does this implement/fix?

- Add camera drivers for hm0360 and hm1055 [esp32-camera#707](https://github.com/espressif/esp32-camera/pull/707)
- Some critical fixes for memory safety

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx


## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
