### PR TITLE
Fix timing overflow when components disable themselves during loop

### DIFF
--- a/esphome/core/application.cpp
+++ b/esphome/core/application.cpp
@@ -310,7 +310,10 @@ void Application::disable_component_loop_(Component *component) {
           // Decrement so we'll process the swapped component next
           this->current_loop_index_--;
           // Update the loop start time to current time so the swapped component
-          // gets correct timing instead of inheriting stale timing
+          // gets correct timing instead of inheriting stale timing.
+          // This prevents integer underflow in timing calculations by ensuring
+          // the swapped component starts with a fresh timing reference, avoiding
+          // errors caused by stale or wrapped timing values.
           this->loop_component_start_time_ = millis();
         }
       }

--- a/esphome/core/application.cpp
+++ b/esphome/core/application.cpp
@@ -309,6 +309,9 @@ void Application::disable_component_loop_(Component *component) {
         if (this->in_loop_ && i == this->current_loop_index_) {
           // Decrement so we'll process the swapped component next
           this->current_loop_index_--;
+          // Update the loop start time to current time so the swapped component
+          // gets correct timing instead of inheriting stale timing
+          this->loop_component_start_time_ = millis();
         }
       }
       return;


### PR DESCRIPTION
# What does this implement/fix?

This PR fixes a timing overflow bug that occurs when a component disables itself during its loop execution. The bug causes incorrect timing calculations, resulting in warnings like:

```
[W][component:278]: Component web_server took a long time for an operation (4294417866 ms).
```

The issue occurs because when a component calls `disable_loop()` on itself:
1. Another component is swapped into its position in the looping components list
2. The loop index is decremented to re-process that position
3. The swapped component inherits a stale `last_op_end_time` from before the disabled component ran
4. This causes an integer underflow in the timing calculation, showing values close to UINT32_MAX

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

None

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

Not applicable - internal timing fix

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# No configuration changes required
# This fix applies to all components that may disable themselves during runtime
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

