### PR TITLE
Optimize MedianFilter memory allocation by adding vector reserve

### DIFF
--- a/esphome/components/sensor/filter.cpp
+++ b/esphome/components/sensor/filter.cpp
@@ -50,6 +50,7 @@ optional<float> MedianFilter::new_value(float value) {
     if (!this->queue_.empty()) {
       // Copy queue without NaN values
       std::vector<float> median_queue;
+      median_queue.reserve(this->queue_.size());
       for (auto v : this->queue_) {
         if (!std::isnan(v)) {
           median_queue.push_back(v);


### PR DESCRIPTION
# What does this implement/fix?

This PR optimizes the MedianFilter by adding a `reserve()` call before populating the vector, preventing multiple memory reallocations during the filtering process.

Currently, when the MedianFilter copies values from the deque to a vector for sorting, it doesn't reserve space upfront. This causes the vector to potentially reallocate memory multiple times as elements are added via `push_back()`, which is inefficient.

The fix adds a single line that reserves the maximum possible size (the queue size) before the loop, ensuring at most one allocation.

This is a performance optimization that reduces memory allocations without changing functionality. The reserve call uses the queue's size as the upper bound, which may slightly over-allocate if NaN values are present, but this is preferable to multiple reallocations. The vector is short-lived (local to the function), so any temporary over-allocation is immediately freed.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A - No documentation changes needed

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

