### PR TITLE
[lvgl]: fix missing await keyword in meter tick_style width processing

### DIFF
--- a/esphome/components/lvgl/widgets/meter.py
+++ b/esphome/components/lvgl/widgets/meter.py
@@ -264,7 +264,7 @@ class MeterType(WidgetType):
                                 color_start,
                                 color_end,
                                 v[CONF_LOCAL],
-                                size.process(v[CONF_WIDTH]),
+                                await size.process(v[CONF_WIDTH]),
                             ),
                         )
                     if t == CONF_IMAGE:

--- a/tests/components/lvgl/lvgl-package.yaml
+++ b/tests/components/lvgl/lvgl-package.yaml
@@ -928,6 +928,12 @@ lvgl:
                           angle_range: 360
                           rotation: !lambda return 2700;
                           indicators:
+                            - tick_style:
+                                start_value: 0
+                                end_value: 60
+                                color_start: 0x0000bd
+                                color_end: 0xbd0000
+                                width: !lambda return 1;
                             - line:
                                 opa: 50%
                                 id: minute_hand


### PR DESCRIPTION


# What does this implement/fix?
Using LVGL with tick_style results in:
```  
raise ValueError("Object is not an expression", obj)
ValueError: ('Object is not an expression', <coroutine object LValidator.process at 0x1050cebd0>)
sys:1: RuntimeWarning: coroutine 'LValidator.process' was never awaited
```


<!-- Quick description and explanation of changes -->

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
lvgl:
  pages:
    - id: meter
      widgets:
        - meter:
            height: 200px
            width: 200px
            indicator:
              bg_color: 0xFF
              radius: 0
            bg_opa: TRANSP
            text_color: 0xFFFFFF
            scales:
              - ticks:
                  width: !lambda return 1;
                  count: 61
                  length: 20%
                  color: 0xFFFFFF
                range_from: 0
                range_to: 60
                angle_range: 360
                rotation: !lambda return 2700;
                indicators:
                  - tick_style:
                      start_value: 0
                      end_value: 60
                      color_start: 0x0000bd
                      color_end: 0xbd0000
                      width: !lambda return 1;
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).
