### PR TITLE
Reduce API proto vtable overhead by splitting decode functionality

### DIFF
--- a/esphome/components/api/api_pb2.cpp
+++ b/esphome/components/api/api_pb2.cpp
@@ -56,26 +56,6 @@ void ConnectResponse::encode(ProtoWriteBuffer buffer) const { buffer.encode_bool
 void ConnectResponse::calculate_size(uint32_t &total_size) const {
   ProtoSize::add_bool_field(total_size, 1, this->invalid_password);
 }
-bool AreaInfo::decode_varint(uint32_t field_id, ProtoVarInt value) {
-  switch (field_id) {
-    case 1:
-      this->area_id = value.as_uint32();
-      break;
-    default:
-      return false;
-  }
-  return true;
-}
-bool AreaInfo::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
-  switch (field_id) {
-    case 2:
-      this->name = value.as_string();
-      break;
-    default:
-      return false;
-  }
-  return true;
-}
 void AreaInfo::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint32(1, this->area_id);
   buffer.encode_string(2, this->name);
@@ -83,29 +63,6 @@ void AreaInfo::encode(ProtoWriteBuffer buffer) const {
 void AreaInfo::calculate_size(uint32_t &total_size) const {
   ProtoSize::add_uint32_field(total_size, 1, this->area_id);
   ProtoSize::add_string_field(total_size, 1, this->name);
-}
-bool DeviceInfo::decode_varint(uint32_t field_id, ProtoVarInt value) {
-  switch (field_id) {
-    case 1:
-      this->device_id = value.as_uint32();
-      break;
-    case 3:
-      this->area_id = value.as_uint32();
-      break;
-    default:
-      return false;
-  }
-  return true;
-}
-bool DeviceInfo::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
-  switch (field_id) {
-    case 2:
-      this->name = value.as_string();
-      break;
-    default:
-      return false;
-  }
-  return true;
 }
 void DeviceInfo::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint32(1, this->device_id);
@@ -918,19 +875,6 @@ void NoiseEncryptionSetKeyResponse::calculate_size(uint32_t &total_size) const {
   ProtoSize::add_bool_field(total_size, 1, this->success);
 }
 #endif
-bool HomeassistantServiceMap::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
-  switch (field_id) {
-    case 1:
-      this->key = value.as_string();
-      break;
-    case 2:
-      this->value = value.as_string();
-      break;
-    default:
-      return false;
-  }
-  return true;
-}
 void HomeassistantServiceMap::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_string(1, this->key);
   buffer.encode_string(2, this->value);
@@ -1000,26 +944,6 @@ void GetTimeResponse::calculate_size(uint32_t &total_size) const {
   ProtoSize::add_fixed32_field(total_size, 1, this->epoch_seconds);
 }
 #ifdef USE_API_SERVICES
-bool ListEntitiesServicesArgument::decode_varint(uint32_t field_id, ProtoVarInt value) {
-  switch (field_id) {
-    case 2:
-      this->type = static_cast<enums::ServiceArgType>(value.as_uint32());
-      break;
-    default:
-      return false;
-  }
-  return true;
-}
-bool ListEntitiesServicesArgument::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
-  switch (field_id) {
-    case 1:
-      this->name = value.as_string();
-      break;
-    default:
-      return false;
-  }
-  return true;
-}
 void ListEntitiesServicesArgument::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_string(1, this->name);
   buffer.encode_uint32(2, static_cast<uint32_t>(this->type));
@@ -1087,50 +1011,6 @@ bool ExecuteServiceArgument::decode_32bit(uint32_t field_id, Proto32Bit value) {
       return false;
   }
   return true;
-}
-void ExecuteServiceArgument::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_bool(1, this->bool_);
-  buffer.encode_int32(2, this->legacy_int);
-  buffer.encode_float(3, this->float_);
-  buffer.encode_string(4, this->string_);
-  buffer.encode_sint32(5, this->int_);
-  for (auto it : this->bool_array) {
-    buffer.encode_bool(6, it, true);
-  }
-  for (auto &it : this->int_array) {
-    buffer.encode_sint32(7, it, true);
-  }
-  for (auto &it : this->float_array) {
-    buffer.encode_float(8, it, true);
-  }
-  for (auto &it : this->string_array) {
-    buffer.encode_string(9, it, true);
-  }
-}
-void ExecuteServiceArgument::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_bool_field(total_size, 1, this->bool_);
-  ProtoSize::add_int32_field(total_size, 1, this->legacy_int);
-  ProtoSize::add_float_field(total_size, 1, this->float_);
-  ProtoSize::add_string_field(total_size, 1, this->string_);
-  ProtoSize::add_sint32_field(total_size, 1, this->int_);
-  if (!this->bool_array.empty()) {
-    for (const auto it : this->bool_array) {
-      ProtoSize::add_bool_field_repeated(total_size, 1, it);
-    }
-  }
-  if (!this->int_array.empty()) {
-    for (const auto &it : this->int_array) {
-      ProtoSize::add_sint32_field_repeated(total_size, 1, it);
-    }
-  }
-  if (!this->float_array.empty()) {
-    total_size += this->float_array.size() * 5;
-  }
-  if (!this->string_array.empty()) {
-    for (const auto &it : this->string_array) {
-      ProtoSize::add_string_field_repeated(total_size, 1, it);
-    }
-  }
 }
 bool ExecuteServiceRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
@@ -1859,35 +1739,6 @@ bool ButtonCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
 }
 #endif
 #ifdef USE_MEDIA_PLAYER
-bool MediaPlayerSupportedFormat::decode_varint(uint32_t field_id, ProtoVarInt value) {
-  switch (field_id) {
-    case 2:
-      this->sample_rate = value.as_uint32();
-      break;
-    case 3:
-      this->num_channels = value.as_uint32();
-      break;
-    case 4:
-      this->purpose = static_cast<enums::MediaPlayerFormatPurpose>(value.as_uint32());
-      break;
-    case 5:
-      this->sample_bytes = value.as_uint32();
-      break;
-    default:
-      return false;
-  }
-  return true;
-}
-bool MediaPlayerSupportedFormat::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
-  switch (field_id) {
-    case 1:
-      this->format = value.as_string();
-      break;
-    default:
-      return false;
-  }
-  return true;
-}
 void MediaPlayerSupportedFormat::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_string(1, this->format);
   buffer.encode_uint32(2, this->sample_rate);
@@ -2017,29 +1868,6 @@ bool SubscribeBluetoothLEAdvertisementsRequest::decode_varint(uint32_t field_id,
   }
   return true;
 }
-bool BluetoothServiceData::decode_varint(uint32_t field_id, ProtoVarInt value) {
-  switch (field_id) {
-    case 2:
-      this->legacy_data.push_back(value.as_uint32());
-      break;
-    default:
-      return false;
-  }
-  return true;
-}
-bool BluetoothServiceData::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
-  switch (field_id) {
-    case 1:
-      this->uuid = value.as_string();
-      break;
-    case 3:
-      this->data = value.as_string();
-      break;
-    default:
-      return false;
-  }
-  return true;
-}
 void BluetoothServiceData::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_string(1, this->uuid);
   for (auto &it : this->legacy_data) {
@@ -2083,32 +1911,6 @@ void BluetoothLEAdvertisementResponse::calculate_size(uint32_t &total_size) cons
   ProtoSize::add_repeated_message(total_size, 1, this->service_data);
   ProtoSize::add_repeated_message(total_size, 1, this->manufacturer_data);
   ProtoSize::add_uint32_field(total_size, 1, this->address_type);
-}
-bool BluetoothLERawAdvertisement::decode_varint(uint32_t field_id, ProtoVarInt value) {
-  switch (field_id) {
-    case 1:
-      this->address = value.as_uint64();
-      break;
-    case 2:
-      this->rssi = value.as_sint32();
-      break;
-    case 3:
-      this->address_type = value.as_uint32();
-      break;
-    default:
-      return false;
-  }
-  return true;
-}
-bool BluetoothLERawAdvertisement::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
-  switch (field_id) {
-    case 4:
-      this->data = value.as_string();
-      break;
-    default:
-      return false;
-  }
-  return true;
 }
 void BluetoothLERawAdvertisement::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint64(1, this->address);
@@ -2171,19 +1973,6 @@ bool BluetoothGATTGetServicesRequest::decode_varint(uint32_t field_id, ProtoVarI
   }
   return true;
 }
-bool BluetoothGATTDescriptor::decode_varint(uint32_t field_id, ProtoVarInt value) {
-  switch (field_id) {
-    case 1:
-      this->uuid.push_back(value.as_uint64());
-      break;
-    case 2:
-      this->handle = value.as_uint32();
-      break;
-    default:
-      return false;
-  }
-  return true;
-}
 void BluetoothGATTDescriptor::encode(ProtoWriteBuffer buffer) const {
   for (auto &it : this->uuid) {
     buffer.encode_uint64(1, it, true);
@@ -2197,33 +1986,6 @@ void BluetoothGATTDescriptor::calculate_size(uint32_t &total_size) const {
     }
   }
   ProtoSize::add_uint32_field(total_size, 1, this->handle);
-}
-bool BluetoothGATTCharacteristic::decode_varint(uint32_t field_id, ProtoVarInt value) {
-  switch (field_id) {
-    case 1:
-      this->uuid.push_back(value.as_uint64());
-      break;
-    case 2:
-      this->handle = value.as_uint32();
-      break;
-    case 3:
-      this->properties = value.as_uint32();
-      break;
-    default:
-      return false;
-  }
-  return true;
-}
-bool BluetoothGATTCharacteristic::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
-  switch (field_id) {
-    case 4:
-      this->descriptors.emplace_back();
-      value.decode_to_message(this->descriptors.back());
-      break;
-    default:
-      return false;
-  }
-  return true;
 }
 void BluetoothGATTCharacteristic::encode(ProtoWriteBuffer buffer) const {
   for (auto &it : this->uuid) {
@@ -2244,30 +2006,6 @@ void BluetoothGATTCharacteristic::calculate_size(uint32_t &total_size) const {
   ProtoSize::add_uint32_field(total_size, 1, this->handle);
   ProtoSize::add_uint32_field(total_size, 1, this->properties);
   ProtoSize::add_repeated_message(total_size, 1, this->descriptors);
-}
-bool BluetoothGATTService::decode_varint(uint32_t field_id, ProtoVarInt value) {
-  switch (field_id) {
-    case 1:
-      this->uuid.push_back(value.as_uint64());
-      break;
-    case 2:
-      this->handle = value.as_uint32();
-      break;
-    default:
-      return false;
-  }
-  return true;
-}
-bool BluetoothGATTService::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
-  switch (field_id) {
-    case 3:
-      this->characteristics.emplace_back();
-      value.decode_to_message(this->characteristics.back());
-      break;
-    default:
-      return false;
-  }
-  return true;
 }
 void BluetoothGATTService::encode(ProtoWriteBuffer buffer) const {
   for (auto &it : this->uuid) {
@@ -2519,29 +2257,6 @@ bool SubscribeVoiceAssistantRequest::decode_varint(uint32_t field_id, ProtoVarIn
   }
   return true;
 }
-bool VoiceAssistantAudioSettings::decode_varint(uint32_t field_id, ProtoVarInt value) {
-  switch (field_id) {
-    case 1:
-      this->noise_suppression_level = value.as_uint32();
-      break;
-    case 2:
-      this->auto_gain = value.as_uint32();
-      break;
-    default:
-      return false;
-  }
-  return true;
-}
-bool VoiceAssistantAudioSettings::decode_32bit(uint32_t field_id, Proto32Bit value) {
-  switch (field_id) {
-    case 3:
-      this->volume_multiplier = value.as_float();
-      break;
-    default:
-      return false;
-  }
-  return true;
-}
 void VoiceAssistantAudioSettings::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint32(1, this->noise_suppression_level);
   buffer.encode_uint32(2, this->auto_gain);
@@ -2591,14 +2306,6 @@ bool VoiceAssistantEventData::decode_length(uint32_t field_id, ProtoLengthDelimi
       return false;
   }
   return true;
-}
-void VoiceAssistantEventData::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_string(1, this->name);
-  buffer.encode_string(2, this->value);
-}
-void VoiceAssistantEventData::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_string_field(total_size, 1, this->name);
-  ProtoSize::add_string_field(total_size, 1, this->value);
 }
 bool VoiceAssistantEventResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
@@ -2710,22 +2417,6 @@ bool VoiceAssistantAnnounceRequest::decode_length(uint32_t field_id, ProtoLength
 void VoiceAssistantAnnounceFinished::encode(ProtoWriteBuffer buffer) const { buffer.encode_bool(1, this->success); }
 void VoiceAssistantAnnounceFinished::calculate_size(uint32_t &total_size) const {
   ProtoSize::add_bool_field(total_size, 1, this->success);
-}
-bool VoiceAssistantWakeWord::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
-  switch (field_id) {
-    case 1:
-      this->id = value.as_string();
-      break;
-    case 2:
-      this->wake_word = value.as_string();
-      break;
-    case 3:
-      this->trained_languages.push_back(value.as_string());
-      break;
-    default:
-      return false;
-  }
-  return true;
 }
 void VoiceAssistantWakeWord::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_string(1, this->id);

--- a/esphome/components/api/api_pb2.h
+++ b/esphome/components/api/api_pb2.h
@@ -308,7 +308,7 @@ class StateResponseProtoMessage : public ProtoMessage {
  protected:
 };
 
-class CommandProtoMessage : public ProtoMessage {
+class CommandProtoMessage : public ProtoDecodableMessage {
  public:
   ~CommandProtoMessage() override = default;
   uint32_t key{0};
@@ -316,7 +316,7 @@ class CommandProtoMessage : public ProtoMessage {
 
  protected:
 };
-class HelloRequest : public ProtoMessage {
+class HelloRequest : public ProtoDecodableMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 1;
   static constexpr uint8_t ESTIMATED_SIZE = 17;
@@ -353,7 +353,7 @@ class HelloResponse : public ProtoMessage {
 
  protected:
 };
-class ConnectRequest : public ProtoMessage {
+class ConnectRequest : public ProtoDecodableMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 3;
   static constexpr uint8_t ESTIMATED_SIZE = 9;
@@ -384,7 +384,7 @@ class ConnectResponse : public ProtoMessage {
 
  protected:
 };
-class DisconnectRequest : public ProtoMessage {
+class DisconnectRequest : public ProtoDecodableMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 5;
   static constexpr uint8_t ESTIMATED_SIZE = 0;
@@ -397,7 +397,7 @@ class DisconnectRequest : public ProtoMessage {
 
  protected:
 };
-class DisconnectResponse : public ProtoMessage {
+class DisconnectResponse : public ProtoDecodableMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 6;
   static constexpr uint8_t ESTIMATED_SIZE = 0;
@@ -410,7 +410,7 @@ class DisconnectResponse : public ProtoMessage {
 
  protected:
 };
-class PingRequest : public ProtoMessage {
+class PingRequest : public ProtoDecodableMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 7;
   static constexpr uint8_t ESTIMATED_SIZE = 0;
@@ -423,7 +423,7 @@ class PingRequest : public ProtoMessage {
 
  protected:
 };
-class PingResponse : public ProtoMessage {
+class PingResponse : public ProtoDecodableMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 8;
   static constexpr uint8_t ESTIMATED_SIZE = 0;
@@ -436,7 +436,7 @@ class PingResponse : public ProtoMessage {
 
  protected:
 };
-class DeviceInfoRequest : public ProtoMessage {
+class DeviceInfoRequest : public ProtoDecodableMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 9;
   static constexpr uint8_t ESTIMATED_SIZE = 0;
@@ -460,8 +460,6 @@ class AreaInfo : public ProtoMessage {
 #endif
 
  protected:
-  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
 class DeviceInfo : public ProtoMessage {
  public:
@@ -475,8 +473,6 @@ class DeviceInfo : public ProtoMessage {
 #endif
 
  protected:
-  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
 class DeviceInfoResponse : public ProtoMessage {
  public:
@@ -543,7 +539,7 @@ class DeviceInfoResponse : public ProtoMessage {
 
  protected:
 };
-class ListEntitiesRequest : public ProtoMessage {
+class ListEntitiesRequest : public ProtoDecodableMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 11;
   static constexpr uint8_t ESTIMATED_SIZE = 0;
@@ -569,7 +565,7 @@ class ListEntitiesDoneResponse : public ProtoMessage {
 
  protected:
 };
-class SubscribeStatesRequest : public ProtoMessage {
+class SubscribeStatesRequest : public ProtoDecodableMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 20;
   static constexpr uint8_t ESTIMATED_SIZE = 0;
@@ -972,7 +968,7 @@ class TextSensorStateResponse : public StateResponseProtoMessage {
  protected:
 };
 #endif
-class SubscribeLogsRequest : public ProtoMessage {
+class SubscribeLogsRequest : public ProtoDecodableMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 28;
   static constexpr uint8_t ESTIMATED_SIZE = 4;
@@ -1007,7 +1003,7 @@ class SubscribeLogsResponse : public ProtoMessage {
  protected:
 };
 #ifdef USE_API_NOISE
-class NoiseEncryptionSetKeyRequest : public ProtoMessage {
+class NoiseEncryptionSetKeyRequest : public ProtoDecodableMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 124;
   static constexpr uint8_t ESTIMATED_SIZE = 9;
@@ -1039,7 +1035,7 @@ class NoiseEncryptionSetKeyResponse : public ProtoMessage {
  protected:
 };
 #endif
-class SubscribeHomeassistantServicesRequest : public ProtoMessage {
+class SubscribeHomeassistantServicesRequest : public ProtoDecodableMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 34;
   static constexpr uint8_t ESTIMATED_SIZE = 0;
@@ -1063,7 +1059,6 @@ class HomeassistantServiceMap : public ProtoMessage {
 #endif
 
  protected:
-  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
 };
 class HomeassistantServiceResponse : public ProtoMessage {
  public:
@@ -1085,7 +1080,7 @@ class HomeassistantServiceResponse : public ProtoMessage {
 
  protected:
 };
-class SubscribeHomeAssistantStatesRequest : public ProtoMessage {
+class SubscribeHomeAssistantStatesRequest : public ProtoDecodableMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 38;
   static constexpr uint8_t ESTIMATED_SIZE = 0;
@@ -1116,7 +1111,7 @@ class SubscribeHomeAssistantStateResponse : public ProtoMessage {
 
  protected:
 };
-class HomeAssistantStateResponse : public ProtoMessage {
+class HomeAssistantStateResponse : public ProtoDecodableMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 40;
   static constexpr uint8_t ESTIMATED_SIZE = 27;
@@ -1133,7 +1128,7 @@ class HomeAssistantStateResponse : public ProtoMessage {
  protected:
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
 };
-class GetTimeRequest : public ProtoMessage {
+class GetTimeRequest : public ProtoDecodableMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 36;
   static constexpr uint8_t ESTIMATED_SIZE = 0;
@@ -1146,7 +1141,7 @@ class GetTimeRequest : public ProtoMessage {
 
  protected:
 };
-class GetTimeResponse : public ProtoMessage {
+class GetTimeResponse : public ProtoDecodableMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 37;
   static constexpr uint8_t ESTIMATED_SIZE = 5;
@@ -1175,8 +1170,6 @@ class ListEntitiesServicesArgument : public ProtoMessage {
 #endif
 
  protected:
-  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
 class ListEntitiesServicesResponse : public ProtoMessage {
  public:
@@ -1196,7 +1189,7 @@ class ListEntitiesServicesResponse : public ProtoMessage {
 
  protected:
 };
-class ExecuteServiceArgument : public ProtoMessage {
+class ExecuteServiceArgument : public ProtoDecodableMessage {
  public:
   bool bool_{false};
   int32_t legacy_int{0};
@@ -1207,8 +1200,6 @@ class ExecuteServiceArgument : public ProtoMessage {
   std::vector<int32_t> int_array{};
   std::vector<float> float_array{};
   std::vector<std::string> string_array{};
-  void encode(ProtoWriteBuffer buffer) const override;
-  void calculate_size(uint32_t &total_size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
 #endif
@@ -1218,7 +1209,7 @@ class ExecuteServiceArgument : public ProtoMessage {
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
-class ExecuteServiceRequest : public ProtoMessage {
+class ExecuteServiceRequest : public ProtoDecodableMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 42;
   static constexpr uint8_t ESTIMATED_SIZE = 39;
@@ -1269,7 +1260,7 @@ class CameraImageResponse : public StateResponseProtoMessage {
 
  protected:
 };
-class CameraImageRequest : public ProtoMessage {
+class CameraImageRequest : public ProtoDecodableMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 45;
   static constexpr uint8_t ESTIMATED_SIZE = 4;
@@ -1660,8 +1651,6 @@ class MediaPlayerSupportedFormat : public ProtoMessage {
 #endif
 
  protected:
-  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
 class ListEntitiesMediaPlayerResponse : public InfoResponseProtoMessage {
  public:
@@ -1724,7 +1713,7 @@ class MediaPlayerCommandRequest : public CommandProtoMessage {
 };
 #endif
 #ifdef USE_BLUETOOTH_PROXY
-class SubscribeBluetoothLEAdvertisementsRequest : public ProtoMessage {
+class SubscribeBluetoothLEAdvertisementsRequest : public ProtoDecodableMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 66;
   static constexpr uint8_t ESTIMATED_SIZE = 4;
@@ -1751,8 +1740,6 @@ class BluetoothServiceData : public ProtoMessage {
 #endif
 
  protected:
-  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
 class BluetoothLEAdvertisementResponse : public ProtoMessage {
  public:
@@ -1789,8 +1776,6 @@ class BluetoothLERawAdvertisement : public ProtoMessage {
 #endif
 
  protected:
-  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
 class BluetoothLERawAdvertisementsResponse : public ProtoMessage {
  public:
@@ -1808,7 +1793,7 @@ class BluetoothLERawAdvertisementsResponse : public ProtoMessage {
 
  protected:
 };
-class BluetoothDeviceRequest : public ProtoMessage {
+class BluetoothDeviceRequest : public ProtoDecodableMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 68;
   static constexpr uint8_t ESTIMATED_SIZE = 12;
@@ -1845,7 +1830,7 @@ class BluetoothDeviceConnectionResponse : public ProtoMessage {
 
  protected:
 };
-class BluetoothGATTGetServicesRequest : public ProtoMessage {
+class BluetoothGATTGetServicesRequest : public ProtoDecodableMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 70;
   static constexpr uint8_t ESTIMATED_SIZE = 4;
@@ -1871,7 +1856,6 @@ class BluetoothGATTDescriptor : public ProtoMessage {
 #endif
 
  protected:
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
 class BluetoothGATTCharacteristic : public ProtoMessage {
  public:
@@ -1886,8 +1870,6 @@ class BluetoothGATTCharacteristic : public ProtoMessage {
 #endif
 
  protected:
-  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
 class BluetoothGATTService : public ProtoMessage {
  public:
@@ -1901,8 +1883,6 @@ class BluetoothGATTService : public ProtoMessage {
 #endif
 
  protected:
-  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
 class BluetoothGATTGetServicesResponse : public ProtoMessage {
  public:
@@ -1937,7 +1917,7 @@ class BluetoothGATTGetServicesDoneResponse : public ProtoMessage {
 
  protected:
 };
-class BluetoothGATTReadRequest : public ProtoMessage {
+class BluetoothGATTReadRequest : public ProtoDecodableMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 73;
   static constexpr uint8_t ESTIMATED_SIZE = 8;
@@ -1971,7 +1951,7 @@ class BluetoothGATTReadResponse : public ProtoMessage {
 
  protected:
 };
-class BluetoothGATTWriteRequest : public ProtoMessage {
+class BluetoothGATTWriteRequest : public ProtoDecodableMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 75;
   static constexpr uint8_t ESTIMATED_SIZE = 19;
@@ -1990,7 +1970,7 @@ class BluetoothGATTWriteRequest : public ProtoMessage {
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
-class BluetoothGATTReadDescriptorRequest : public ProtoMessage {
+class BluetoothGATTReadDescriptorRequest : public ProtoDecodableMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 76;
   static constexpr uint8_t ESTIMATED_SIZE = 8;
@@ -2006,7 +1986,7 @@ class BluetoothGATTReadDescriptorRequest : public ProtoMessage {
  protected:
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
-class BluetoothGATTWriteDescriptorRequest : public ProtoMessage {
+class BluetoothGATTWriteDescriptorRequest : public ProtoDecodableMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 77;
   static constexpr uint8_t ESTIMATED_SIZE = 17;
@@ -2024,7 +2004,7 @@ class BluetoothGATTWriteDescriptorRequest : public ProtoMessage {
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
-class BluetoothGATTNotifyRequest : public ProtoMessage {
+class BluetoothGATTNotifyRequest : public ProtoDecodableMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 78;
   static constexpr uint8_t ESTIMATED_SIZE = 10;
@@ -2059,7 +2039,7 @@ class BluetoothGATTNotifyDataResponse : public ProtoMessage {
 
  protected:
 };
-class SubscribeBluetoothConnectionsFreeRequest : public ProtoMessage {
+class SubscribeBluetoothConnectionsFreeRequest : public ProtoDecodableMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 80;
   static constexpr uint8_t ESTIMATED_SIZE = 0;
@@ -2178,7 +2158,7 @@ class BluetoothDeviceUnpairingResponse : public ProtoMessage {
 
  protected:
 };
-class UnsubscribeBluetoothLEAdvertisementsRequest : public ProtoMessage {
+class UnsubscribeBluetoothLEAdvertisementsRequest : public ProtoDecodableMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 87;
   static constexpr uint8_t ESTIMATED_SIZE = 0;
@@ -2226,7 +2206,7 @@ class BluetoothScannerStateResponse : public ProtoMessage {
 
  protected:
 };
-class BluetoothScannerSetModeRequest : public ProtoMessage {
+class BluetoothScannerSetModeRequest : public ProtoDecodableMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 127;
   static constexpr uint8_t ESTIMATED_SIZE = 2;
@@ -2243,7 +2223,7 @@ class BluetoothScannerSetModeRequest : public ProtoMessage {
 };
 #endif
 #ifdef USE_VOICE_ASSISTANT
-class SubscribeVoiceAssistantRequest : public ProtoMessage {
+class SubscribeVoiceAssistantRequest : public ProtoDecodableMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 89;
   static constexpr uint8_t ESTIMATED_SIZE = 6;
@@ -2271,8 +2251,6 @@ class VoiceAssistantAudioSettings : public ProtoMessage {
 #endif
 
  protected:
-  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
 class VoiceAssistantRequest : public ProtoMessage {
  public:
@@ -2294,7 +2272,7 @@ class VoiceAssistantRequest : public ProtoMessage {
 
  protected:
 };
-class VoiceAssistantResponse : public ProtoMessage {
+class VoiceAssistantResponse : public ProtoDecodableMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 91;
   static constexpr uint8_t ESTIMATED_SIZE = 6;
@@ -2310,12 +2288,10 @@ class VoiceAssistantResponse : public ProtoMessage {
  protected:
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
-class VoiceAssistantEventData : public ProtoMessage {
+class VoiceAssistantEventData : public ProtoDecodableMessage {
  public:
   std::string name{};
   std::string value{};
-  void encode(ProtoWriteBuffer buffer) const override;
-  void calculate_size(uint32_t &total_size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
 #endif
@@ -2323,7 +2299,7 @@ class VoiceAssistantEventData : public ProtoMessage {
  protected:
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
 };
-class VoiceAssistantEventResponse : public ProtoMessage {
+class VoiceAssistantEventResponse : public ProtoDecodableMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 92;
   static constexpr uint8_t ESTIMATED_SIZE = 36;
@@ -2340,7 +2316,7 @@ class VoiceAssistantEventResponse : public ProtoMessage {
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
-class VoiceAssistantAudio : public ProtoMessage {
+class VoiceAssistantAudio : public ProtoDecodableMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 106;
   static constexpr uint8_t ESTIMATED_SIZE = 11;
@@ -2359,7 +2335,7 @@ class VoiceAssistantAudio : public ProtoMessage {
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
-class VoiceAssistantTimerEventResponse : public ProtoMessage {
+class VoiceAssistantTimerEventResponse : public ProtoDecodableMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 115;
   static constexpr uint8_t ESTIMATED_SIZE = 30;
@@ -2380,7 +2356,7 @@ class VoiceAssistantTimerEventResponse : public ProtoMessage {
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
-class VoiceAssistantAnnounceRequest : public ProtoMessage {
+class VoiceAssistantAnnounceRequest : public ProtoDecodableMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 119;
   static constexpr uint8_t ESTIMATED_SIZE = 29;
@@ -2427,9 +2403,8 @@ class VoiceAssistantWakeWord : public ProtoMessage {
 #endif
 
  protected:
-  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
 };
-class VoiceAssistantConfigurationRequest : public ProtoMessage {
+class VoiceAssistantConfigurationRequest : public ProtoDecodableMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 121;
   static constexpr uint8_t ESTIMATED_SIZE = 0;
@@ -2460,7 +2435,7 @@ class VoiceAssistantConfigurationResponse : public ProtoMessage {
 
  protected:
 };
-class VoiceAssistantSetConfiguration : public ProtoMessage {
+class VoiceAssistantSetConfiguration : public ProtoDecodableMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 123;
   static constexpr uint8_t ESTIMATED_SIZE = 18;

--- a/esphome/components/api/proto.cpp
+++ b/esphome/components/api/proto.cpp
@@ -8,7 +8,7 @@ namespace api {
 
 static const char *const TAG = "api.proto";
 
-void ProtoMessage::decode(const uint8_t *buffer, size_t length) {
+void ProtoDecodableMessage::decode(const uint8_t *buffer, size_t length) {
   uint32_t i = 0;
   bool error = false;
   while (i < length) {

--- a/esphome/components/api/proto.h
+++ b/esphome/components/api/proto.h
@@ -135,6 +135,7 @@ class ProtoVarInt {
 
 // Forward declaration for decode_to_message and encode_to_writer
 class ProtoMessage;
+class ProtoDecodableMessage;
 
 class ProtoLengthDelimited {
  public:
@@ -142,15 +143,15 @@ class ProtoLengthDelimited {
   std::string as_string() const { return std::string(reinterpret_cast<const char *>(this->value_), this->length_); }
 
   /**
-   * Decode the length-delimited data into an existing ProtoMessage instance.
+   * Decode the length-delimited data into an existing ProtoDecodableMessage instance.
    *
    * This method allows decoding without templates, enabling use in contexts
-   * where the message type is not known at compile time. The ProtoMessage's
+   * where the message type is not known at compile time. The ProtoDecodableMessage's
    * decode() method will be called with the raw data and length.
    *
-   * @param msg The ProtoMessage instance to decode into
+   * @param msg The ProtoDecodableMessage instance to decode into
    */
-  void decode_to_message(ProtoMessage &msg) const;
+  void decode_to_message(ProtoDecodableMessage &msg) const;
 
  protected:
   const uint8_t *const value_;
@@ -298,7 +299,6 @@ class ProtoMessage {
   virtual ~ProtoMessage() = default;
   // Default implementation for messages with no fields
   virtual void encode(ProtoWriteBuffer buffer) const {}
-  void decode(const uint8_t *buffer, size_t length);
   // Default implementation for messages with no fields
   virtual void calculate_size(uint32_t &total_size) const {}
 #ifdef HAS_PROTO_MESSAGE_DUMP
@@ -306,6 +306,12 @@ class ProtoMessage {
   virtual void dump_to(std::string &out) const = 0;
   virtual const char *message_name() const { return "unknown"; }
 #endif
+};
+
+// Base class for messages that support decoding
+class ProtoDecodableMessage : public virtual ProtoMessage {
+ public:
+  void decode(const uint8_t *buffer, size_t length);
 
  protected:
   virtual bool decode_varint(uint32_t field_id, ProtoVarInt value) { return false; }
@@ -808,8 +814,8 @@ inline void ProtoWriteBuffer::encode_message(uint32_t field_id, const ProtoMessa
   assert(this->buffer_->size() == begin + varint_length_bytes + msg_length_bytes);
 }
 
-// Implementation of decode_to_message - must be after ProtoMessage is defined
-inline void ProtoLengthDelimited::decode_to_message(ProtoMessage &msg) const {
+// Implementation of decode_to_message - must be after ProtoDecodableMessage is defined
+inline void ProtoLengthDelimited::decode_to_message(ProtoDecodableMessage &msg) const {
   msg.decode(this->value_, this->length_);
 }
 

--- a/esphome/components/api/proto.h
+++ b/esphome/components/api/proto.h
@@ -309,7 +309,7 @@ class ProtoMessage {
 };
 
 // Base class for messages that support decoding
-class ProtoDecodableMessage : public virtual ProtoMessage {
+class ProtoDecodableMessage : public ProtoMessage {
  public:
   void decode(const uint8_t *buffer, size_t length);
 


### PR DESCRIPTION
# What does this implement/fix?

This PR optimizes the API proto message vtable overhead by splitting decode functionality into a separate base class `ProtoDecodableMessage`. This eliminates unused virtual decode methods from encode-only messages, saving 176 bytes on typical devices and up to 8.7KB on devices with many components.

## Summary of Changes

1. **Split decode functionality into a separate class:**
   - `ProtoMessage` - Base class with only encode functionality (4 virtual methods: destructor, encode, calculate_size, dump_to)
   - `ProtoDecodableMessage : public ProtoMessage` - Adds decode functionality (+4 virtual methods: decode_varint, decode_length, decode_32bit, + non-virtual decode)

2. **Smart inheritance for proto messages:**
   - Messages with `source = SOURCE_SERVER` inherit from `ProtoMessage` (encode-only)
   - Messages with `source = SOURCE_CLIENT` or `SOURCE_BOTH` inherit from `ProtoDecodableMessage`
   - Embedded messages inherit their source from parent messages that use them

3. **Fixed incorrect decode generation:**
   - Previously, embedded messages like `BluetoothLERawAdvertisement` were getting decode methods even though they're only used in server->client messages
   - Now these embedded messages correctly inherit encode-only behavior from their parent messages

## Results

**Flash savings scale with device complexity:**

### Typical device:
```
Before: RAM:   [          ]   4.7% (used 15492 bytes from 327680 bytes)
        Flash: [===       ]  28.5% (used 522088 bytes from 1835008 bytes)

After:  RAM:   [          ]   4.7% (used 15492 bytes from 327680 bytes)
        Flash: [===       ]  28.4% (used 521912 bytes from 1835008 bytes)
```
**Saved: 176 bytes**

### Large device with many components:
```
Before: RAM:   [=         ]  13.0% (used 42496 bytes from 327680 bytes)
        Flash: [=======   ]  65.8% (used 1206896 bytes from 1835008 bytes)

After:  RAM:   [=         ]  13.0% (used 42496 bytes from 327680 bytes)
        Flash: [=======   ]  65.3% (used 1198176 bytes from 1835008 bytes)
```
**Saved: 8,720 bytes**

The optimization exceeded expectations! The savings come from:
1. Removing unused decode methods from ~70 encode-only messages
2. Removing unused decode methods from embedded messages that inherit source from their parents
3. Smaller vtables (4 entries instead of 8) for all encode-only messages (~32 bytes saved per message class)

## Implementation Details

The clean inheritance hierarchy:
- `ProtoMessage` - Base class with encode functionality only (4 virtual methods)
- `ProtoDecodableMessage : public ProtoMessage` - Adds decode functionality (+3 virtual methods)
- No virtual inheritance needed - simple linear inheritance chain

## Technical Details

The optimization works by:
1. Analyzing message embedding relationships during proto generation
2. Propagating source types from parent messages to embedded messages
3. Generating appropriate inheritance based on actual usage

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)  
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A - Internal optimization, no user-facing changes

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - this is an internal optimization
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - N/A - Internal optimization only

