### PR TITLE
Use message_source_map consistently in proto generation

### DIFF
--- a/script/api_protobuf/api_protobuf.py
+++ b/script/api_protobuf/api_protobuf.py
@@ -1393,6 +1393,7 @@ def build_base_class(
     base_class_name: str,
     common_fields: list[descriptor.FieldDescriptorProto],
     messages: list[descriptor.DescriptorProto],
+    message_source_map: dict[str, int],
 ) -> tuple[str, str, str]:
     """Build the base class definition and implementation."""
     public_content = []
@@ -1409,7 +1410,7 @@ def build_base_class(
 
     # Determine if any message using this base class needs decoding
     needs_decode = any(
-        get_opt(msg, pb.source, SOURCE_BOTH) in (SOURCE_BOTH, SOURCE_CLIENT)
+        message_source_map.get(msg.name, SOURCE_BOTH) in (SOURCE_BOTH, SOURCE_CLIENT)
         for msg in messages
     )
 
@@ -1441,6 +1442,7 @@ def build_base_class(
 
 def generate_base_classes(
     base_class_groups: dict[str, list[descriptor.DescriptorProto]],
+    message_source_map: dict[str, int],
 ) -> tuple[str, str, str]:
     """Generate all base classes."""
     all_headers = []
@@ -1454,7 +1456,7 @@ def generate_base_classes(
         if common_fields:
             # Generate base class
             header, cpp, dump_cpp = build_base_class(
-                base_class_name, common_fields, messages
+                base_class_name, common_fields, messages, message_source_map
             )
             all_headers.append(header)
             all_cpp.append(cpp)
@@ -1465,6 +1467,7 @@ def generate_base_classes(
 
 def build_service_message_type(
     mt: descriptor.DescriptorProto,
+    message_source_map: dict[str, int],
 ) -> tuple[str, str] | None:
     """Builds the service message type."""
     snake = camel_to_snake(mt.name)
@@ -1472,7 +1475,7 @@ def build_service_message_type(
     if id_ is None:
         return None
 
-    source: int = get_opt(mt, pb.source, 0)
+    source: int = message_source_map.get(mt.name, SOURCE_BOTH)
 
     ifdef: str | None = get_opt(mt, pb.ifdef)
     log: bool = get_opt(mt, pb.log, True)
@@ -1611,7 +1614,9 @@ namespace api {
 
     # Generate base classes
     if base_class_fields:
-        base_headers, base_cpp, base_dump_cpp = generate_base_classes(base_class_groups)
+        base_headers, base_cpp, base_dump_cpp = generate_base_classes(
+            base_class_groups, message_source_map
+        )
         content += base_headers
         cpp += base_cpp
         dump_cpp += base_dump_cpp
@@ -1730,7 +1735,7 @@ static const char *const TAG = "api.service";
     cpp += "#endif\n\n"
 
     for mt in file.message_type:
-        obj = build_service_message_type(mt)
+        obj = build_service_message_type(mt, message_source_map)
         if obj is None:
             continue
         hout, cout = obj


### PR DESCRIPTION
# What does this implement/fix?

This PR addresses review feedback from #9541 by ensuring all proto generation code uses the computed `message_source_map` instead of accessing `pb.source` directly. This improves consistency and future-proofs the code for cases where base classes might have mixed source types.

## Summary of Changes

1. **Updated `build_base_class` function**:
   - Now uses `message_source_map` to determine if base classes need decoding
   - Ensures base classes correctly inherit decode functionality based on all derived messages

2. **Updated `build_service_message_type` function**:
   - Now uses `message_source_map` for consistency
   - Ensures service messages use the same source determination logic

3. **Added `message_source_map` parameter propagation**:
   - `generate_base_classes` now receives and passes the source map
   - All functions now use the centralized source computation

## Why this matters: Future-Proofing for Mixed Source Types

Currently, all base classes have uniform source types:
- `InfoResponseProtoMessage`: All derived messages are SOURCE_SERVER (server→client only)
- `CommandProtoMessage`: All derived messages are SOURCE_CLIENT (client→server only)

**No mixed source scenarios exist today**, but future API changes could introduce them:

### Example 1: Hypothetical Bidirectional Base Class (Does Not Exist Today)
```protobuf
// Hypothetical future scenario: A base class for settings that can be read AND written
message SettingProtoMessage {
  option (base_class) = true;
  string key = 1;
  string value = 2;
}

// Can be sent by server (SOURCE_SERVER)
message SettingStateResponse {
  option (extends) = "SettingProtoMessage";
  option (source) = SOURCE_SERVER;
}

// Can be sent by client (SOURCE_CLIENT)
message UpdateSettingRequest {
  option (extends) = "SettingProtoMessage";
  option (source) = SOURCE_CLIENT;
}
```

In this case, the base class needs BOTH encode and decode methods (ProtoDecodableMessage).

### Example 2: Hypothetical Mixed Usage of Embedded Messages (Does Not Exist Today)
```protobuf
// Currently BluetoothLERawAdvertisement only appears in SOURCE_SERVER messages
// But hypothetically, what if it's used in a bidirectional context in the future?
message BluetoothLERawAdvertisement {
  uint64 address = 1;
  sint32 rssi = 2;
}

// Future: Client might send advertisements for testing/simulation
message SimulateAdvertisementRequest {
  option (source) = SOURCE_CLIENT;
  BluetoothLERawAdvertisement advertisement = 1;  // Now needs decode!
}
```

Using `message_source_map` ensures these hypothetical future cases would be handled correctly by analyzing actual usage patterns rather than assuming uniform behavior.

**To be clear: The current codebase works correctly because no mixed source types exist today.** This change is purely for code consistency and future-proofing.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** Follow-up to #9541, specifically addressing [this review feedback](https://github.com/esphome/esphome/pull/9541#discussion_r2209661435)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A - Internal code improvement

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

Note: This change only affects code generation on the host platform, not the generated code itself.

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - this is an internal code improvement
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - N/A - Internal code improvement only

