### PR TITLE
Update script/helpers.py to use ESPHome YAML parser for integration fixtures

### DIFF
--- a/script/helpers.py
+++ b/script/helpers.py
@@ -530,27 +530,26 @@ def get_components_from_integration_fixtures() -> set[str]:
     Returns:
         Set of component names used in integration test fixtures
     """
-    import yaml
+    from esphome import yaml_util
 
     components: set[str] = set()
     fixtures_dir = Path(__file__).parent.parent / "tests" / "integration" / "fixtures"
 
     for yaml_file in fixtures_dir.glob("*.yaml"):
-        with open(yaml_file) as f:
-            config: dict[str, any] | None = yaml.safe_load(f)
-            if not config:
+        config: dict[str, any] | None = yaml_util.load_yaml(str(yaml_file))
+        if not config:
+            continue
+
+        # Add all top-level component keys
+        components.update(config.keys())
+
+        # Add platform components (e.g., output.template)
+        for value in config.values():
+            if not isinstance(value, list):
                 continue
 
-            # Add all top-level component keys
-            components.update(config.keys())
-
-            # Add platform components (e.g., output.template)
-            for value in config.values():
-                if not isinstance(value, list):
-                    continue
-
-                for item in value:
-                    if isinstance(item, dict) and "platform" in item:
-                        components.add(item["platform"])
+            for item in value:
+                if isinstance(item, dict) and "platform" in item:
+                    components.add(item["platform"])
 
     return components

--- a/tests/script/test_helpers.py
+++ b/tests/script/test_helpers.py
@@ -986,8 +986,7 @@ def test_get_components_from_integration_fixtures() -> None:
 
     with (
         patch("pathlib.Path.glob") as mock_glob,
-        patch("builtins.open", create=True),
-        patch("yaml.safe_load", return_value=yaml_content),
+        patch("esphome.yaml_util.load_yaml", return_value=yaml_content),
     ):
         mock_glob.return_value = [mock_yaml_file]
 


### PR DESCRIPTION
# What does this implement/fix?

This fixes the CI test failures when parsing integration test fixture YAML files that contain ESPHome-specific tags like `!lambda`. The `script/helpers.py` was using Python's standard `yaml.safe_load()` which doesn't understand ESPHome's custom YAML tags, causing test failures with "could not determine a constructor for the tag '!lambda'".

The fix updates `get_components_from_integration_fixtures()` to use ESPHome's own `yaml_util.load_yaml()` which properly handles all custom tags used in ESPHome configurations.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A (CI infrastructure fix)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no documentation changes needed)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# N/A - This is a CI infrastructure fix
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).