### PR TITLE
Refactor API send_message from template to non-template implementation

### DIFF
--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -202,7 +202,8 @@ void APIConnection::loop() {
   } else if (now - this->last_traffic_ > KEEPALIVE_TIMEOUT_MS && !this->flags_.remove) {
     // Only send ping if we're not disconnecting
     ESP_LOGVV(TAG, "Sending keepalive PING");
-    this->flags_.sent_ping = this->send_message(PingRequest());
+    PingRequest req;
+    this->flags_.sent_ping = this->send_message(req, PingRequest::MESSAGE_TYPE);
     if (!this->flags_.sent_ping) {
       // If we can't send the ping request directly (tx_buffer full),
       // schedule it at the front of the batch so it will be sent with priority
@@ -251,7 +252,7 @@ void APIConnection::loop() {
       resp.entity_id = it.entity_id;
       resp.attribute = it.attribute.value();
       resp.once = it.once;
-      if (this->send_message(resp)) {
+      if (this->send_message(resp, SubscribeHomeAssistantStateResponse::MESSAGE_TYPE)) {
         state_subs_at_++;
       }
     } else {
@@ -1123,9 +1124,9 @@ bool APIConnection::send_bluetooth_le_advertisement(const BluetoothLEAdvertiseme
       manufacturer_data.legacy_data.assign(manufacturer_data.data.begin(), manufacturer_data.data.end());
       manufacturer_data.data.clear();
     }
-    return this->send_message(resp);
+    return this->send_message(resp, BluetoothLEAdvertisementResponse::MESSAGE_TYPE);
   }
-  return this->send_message(msg);
+  return this->send_message(msg, BluetoothLEAdvertisementResponse::MESSAGE_TYPE);
 }
 void APIConnection::bluetooth_device_request(const BluetoothDeviceRequest &msg) {
   bluetooth_proxy::global_bluetooth_proxy->bluetooth_device_request(msg);

--- a/esphome/components/api/api_connection.h
+++ b/esphome/components/api/api_connection.h
@@ -111,7 +111,7 @@ class APIConnection : public APIServerConnection {
   void send_homeassistant_service_call(const HomeassistantServiceResponse &call) {
     if (!this->flags_.service_call_subscription)
       return;
-    this->send_message(call);
+    this->send_message(call, HomeassistantServiceResponse::MESSAGE_TYPE);
   }
 #ifdef USE_BLUETOOTH_PROXY
   void subscribe_bluetooth_le_advertisements(const SubscribeBluetoothLEAdvertisementsRequest &msg) override;
@@ -133,7 +133,7 @@ class APIConnection : public APIServerConnection {
 #ifdef USE_HOMEASSISTANT_TIME
   void send_time_request() {
     GetTimeRequest req;
-    this->send_message(req);
+    this->send_message(req, GetTimeRequest::MESSAGE_TYPE);
   }
 #endif
 

--- a/esphome/components/api/api_pb2_service.cpp
+++ b/esphome/components/api/api_pb2_service.cpp
@@ -598,32 +598,32 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
 
 void APIServerConnection::on_hello_request(const HelloRequest &msg) {
   HelloResponse ret = this->hello(msg);
-  if (!this->send_message(ret)) {
+  if (!this->send_message(ret, HelloResponse::MESSAGE_TYPE)) {
     this->on_fatal_error();
   }
 }
 void APIServerConnection::on_connect_request(const ConnectRequest &msg) {
   ConnectResponse ret = this->connect(msg);
-  if (!this->send_message(ret)) {
+  if (!this->send_message(ret, ConnectResponse::MESSAGE_TYPE)) {
     this->on_fatal_error();
   }
 }
 void APIServerConnection::on_disconnect_request(const DisconnectRequest &msg) {
   DisconnectResponse ret = this->disconnect(msg);
-  if (!this->send_message(ret)) {
+  if (!this->send_message(ret, DisconnectResponse::MESSAGE_TYPE)) {
     this->on_fatal_error();
   }
 }
 void APIServerConnection::on_ping_request(const PingRequest &msg) {
   PingResponse ret = this->ping(msg);
-  if (!this->send_message(ret)) {
+  if (!this->send_message(ret, PingResponse::MESSAGE_TYPE)) {
     this->on_fatal_error();
   }
 }
 void APIServerConnection::on_device_info_request(const DeviceInfoRequest &msg) {
   if (this->check_connection_setup_()) {
     DeviceInfoResponse ret = this->device_info(msg);
-    if (!this->send_message(ret)) {
+    if (!this->send_message(ret, DeviceInfoResponse::MESSAGE_TYPE)) {
       this->on_fatal_error();
     }
   }
@@ -657,7 +657,7 @@ void APIServerConnection::on_subscribe_home_assistant_states_request(const Subsc
 void APIServerConnection::on_get_time_request(const GetTimeRequest &msg) {
   if (this->check_connection_setup_()) {
     GetTimeResponse ret = this->get_time(msg);
-    if (!this->send_message(ret)) {
+    if (!this->send_message(ret, GetTimeResponse::MESSAGE_TYPE)) {
       this->on_fatal_error();
     }
   }
@@ -673,7 +673,7 @@ void APIServerConnection::on_execute_service_request(const ExecuteServiceRequest
 void APIServerConnection::on_noise_encryption_set_key_request(const NoiseEncryptionSetKeyRequest &msg) {
   if (this->check_authenticated_()) {
     NoiseEncryptionSetKeyResponse ret = this->noise_encryption_set_key(msg);
-    if (!this->send_message(ret)) {
+    if (!this->send_message(ret, NoiseEncryptionSetKeyResponse::MESSAGE_TYPE)) {
       this->on_fatal_error();
     }
   }
@@ -867,7 +867,7 @@ void APIServerConnection::on_subscribe_bluetooth_connections_free_request(
     const SubscribeBluetoothConnectionsFreeRequest &msg) {
   if (this->check_authenticated_()) {
     BluetoothConnectionsFreeResponse ret = this->subscribe_bluetooth_connections_free(msg);
-    if (!this->send_message(ret)) {
+    if (!this->send_message(ret, BluetoothConnectionsFreeResponse::MESSAGE_TYPE)) {
       this->on_fatal_error();
     }
   }
@@ -899,7 +899,7 @@ void APIServerConnection::on_subscribe_voice_assistant_request(const SubscribeVo
 void APIServerConnection::on_voice_assistant_configuration_request(const VoiceAssistantConfigurationRequest &msg) {
   if (this->check_authenticated_()) {
     VoiceAssistantConfigurationResponse ret = this->voice_assistant_get_configuration(msg);
-    if (!this->send_message(ret)) {
+    if (!this->send_message(ret, VoiceAssistantConfigurationResponse::MESSAGE_TYPE)) {
       this->on_fatal_error();
     }
   }

--- a/esphome/components/api/api_pb2_service.h
+++ b/esphome/components/api/api_pb2_service.h
@@ -18,11 +18,11 @@ class APIServerConnectionBase : public ProtoService {
  public:
 #endif
 
-  template<typename T> bool send_message(const T &msg) {
+  bool send_message(const ProtoMessage &msg, uint8_t message_type) {
 #ifdef HAS_PROTO_MESSAGE_DUMP
     this->log_send_message_(msg.message_name(), msg.dump());
 #endif
-    return this->send_message_(msg, T::MESSAGE_TYPE);
+    return this->send_message_(msg, message_type);
   }
 
   virtual void on_hello_request(const HelloRequest &value){};

--- a/esphome/components/api/api_server.cpp
+++ b/esphome/components/api/api_server.cpp
@@ -428,7 +428,8 @@ bool APIServer::save_noise_psk(psk_t psk, bool make_active) {
       ESP_LOGW(TAG, "Disconnecting all clients to reset PSK");
       this->set_noise_psk(psk);
       for (auto &c : this->clients_) {
-        c->send_message(DisconnectRequest());
+        DisconnectRequest req;
+        c->send_message(req, DisconnectRequest::MESSAGE_TYPE);
       }
     });
   }

--- a/esphome/components/api/api_server.cpp
+++ b/esphome/components/api/api_server.cpp
@@ -461,7 +461,8 @@ void APIServer::on_shutdown() {
 
   // Send disconnect requests to all connected clients
   for (auto &c : this->clients_) {
-    if (!c->send_message(DisconnectRequest())) {
+    DisconnectRequest req;
+    if (!c->send_message(req, DisconnectRequest::MESSAGE_TYPE)) {
       // If we can't send the disconnect request directly (tx_buffer full),
       // schedule it at the front of the batch so it will be sent with priority
       c->schedule_message_front_(nullptr, &APIConnection::try_send_disconnect_request, DisconnectRequest::MESSAGE_TYPE,

--- a/esphome/components/api/list_entities.cpp
+++ b/esphome/components/api/list_entities.cpp
@@ -86,7 +86,7 @@ ListEntitiesIterator::ListEntitiesIterator(APIConnection *client) : client_(clie
 #ifdef USE_API_SERVICES
 bool ListEntitiesIterator::on_service(UserServiceDescriptor *service) {
   auto resp = service->encode_list_service_response();
-  return this->client_->send_message(resp);
+  return this->client_->send_message(resp, ListEntitiesServicesResponse::MESSAGE_TYPE);
 }
 #endif
 

--- a/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
@@ -75,7 +75,7 @@ bool BluetoothConnection::gattc_event_handler(esp_gattc_cb_event_t event, esp_ga
       resp.data.reserve(param->read.value_len);
       // Use bulk insert instead of individual push_backs
       resp.data.insert(resp.data.end(), param->read.value, param->read.value + param->read.value_len);
-      this->proxy_->get_api_connection()->send_message(resp);
+      this->proxy_->get_api_connection()->send_message(resp, api::BluetoothGATTReadResponse::MESSAGE_TYPE);
       break;
     }
     case ESP_GATTC_WRITE_CHAR_EVT:
@@ -89,7 +89,7 @@ bool BluetoothConnection::gattc_event_handler(esp_gattc_cb_event_t event, esp_ga
       api::BluetoothGATTWriteResponse resp;
       resp.address = this->address_;
       resp.handle = param->write.handle;
-      this->proxy_->get_api_connection()->send_message(resp);
+      this->proxy_->get_api_connection()->send_message(resp, api::BluetoothGATTWriteResponse::MESSAGE_TYPE);
       break;
     }
     case ESP_GATTC_UNREG_FOR_NOTIFY_EVT: {
@@ -103,7 +103,7 @@ bool BluetoothConnection::gattc_event_handler(esp_gattc_cb_event_t event, esp_ga
       api::BluetoothGATTNotifyResponse resp;
       resp.address = this->address_;
       resp.handle = param->unreg_for_notify.handle;
-      this->proxy_->get_api_connection()->send_message(resp);
+      this->proxy_->get_api_connection()->send_message(resp, api::BluetoothGATTNotifyResponse::MESSAGE_TYPE);
       break;
     }
     case ESP_GATTC_REG_FOR_NOTIFY_EVT: {
@@ -116,7 +116,7 @@ bool BluetoothConnection::gattc_event_handler(esp_gattc_cb_event_t event, esp_ga
       api::BluetoothGATTNotifyResponse resp;
       resp.address = this->address_;
       resp.handle = param->reg_for_notify.handle;
-      this->proxy_->get_api_connection()->send_message(resp);
+      this->proxy_->get_api_connection()->send_message(resp, api::BluetoothGATTNotifyResponse::MESSAGE_TYPE);
       break;
     }
     case ESP_GATTC_NOTIFY_EVT: {
@@ -128,7 +128,7 @@ bool BluetoothConnection::gattc_event_handler(esp_gattc_cb_event_t event, esp_ga
       resp.data.reserve(param->notify.value_len);
       // Use bulk insert instead of individual push_backs
       resp.data.insert(resp.data.end(), param->notify.value, param->notify.value + param->notify.value_len);
-      this->proxy_->get_api_connection()->send_message(resp);
+      this->proxy_->get_api_connection()->send_message(resp, api::BluetoothGATTNotifyDataResponse::MESSAGE_TYPE);
       break;
     }
     default:

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
@@ -39,7 +39,7 @@ void BluetoothProxy::send_bluetooth_scanner_state_(esp32_ble_tracker::ScannerSta
   resp.state = static_cast<api::enums::BluetoothScannerState>(state);
   resp.mode = this->parent_->get_scan_active() ? api::enums::BluetoothScannerMode::BLUETOOTH_SCANNER_MODE_ACTIVE
                                                : api::enums::BluetoothScannerMode::BLUETOOTH_SCANNER_MODE_PASSIVE;
-  this->api_connection_->send_message(resp);
+  this->api_connection_->send_message(resp, api::BluetoothScannerStateResponse::MESSAGE_TYPE);
 }
 
 #ifdef USE_ESP32_BLE_DEVICE
@@ -111,7 +111,7 @@ void BluetoothProxy::flush_pending_advertisements() {
 
   api::BluetoothLERawAdvertisementsResponse resp;
   resp.advertisements.swap(batch_buffer);
-  this->api_connection_->send_message(resp);
+  this->api_connection_->send_message(resp, api::BluetoothLERawAdvertisementsResponse::MESSAGE_TYPE);
 }
 
 #ifdef USE_ESP32_BLE_DEVICE
@@ -150,7 +150,7 @@ void BluetoothProxy::send_api_packet_(const esp32_ble_tracker::ESPBTDevice &devi
     manufacturer_data.data.assign(data.data.begin(), data.data.end());
   }
 
-  this->api_connection_->send_message(resp);
+  this->api_connection_->send_message(resp, api::BluetoothLEAdvertisementResponse::MESSAGE_TYPE);
 }
 #endif  // USE_ESP32_BLE_DEVICE
 
@@ -309,7 +309,7 @@ void BluetoothProxy::loop() {
         service_resp.characteristics.push_back(std::move(characteristic_resp));
       }
       resp.services.push_back(std::move(service_resp));
-      this->api_connection_->send_message(resp);
+      this->api_connection_->send_message(resp, api::BluetoothGATTGetServicesResponse::MESSAGE_TYPE);
     }
   }
 }
@@ -460,7 +460,7 @@ void BluetoothProxy::bluetooth_device_request(const api::BluetoothDeviceRequest 
       call.success = ret == ESP_OK;
       call.error = ret;
 
-      this->api_connection_->send_message(call);
+      this->api_connection_->send_message(call, api::BluetoothDeviceClearCacheResponse::MESSAGE_TYPE);
 
       break;
     }
@@ -582,7 +582,7 @@ void BluetoothProxy::send_device_connection(uint64_t address, bool connected, ui
   call.connected = connected;
   call.mtu = mtu;
   call.error = error;
-  this->api_connection_->send_message(call);
+  this->api_connection_->send_message(call, api::BluetoothDeviceConnectionResponse::MESSAGE_TYPE);
 }
 void BluetoothProxy::send_connections_free() {
   if (this->api_connection_ == nullptr)
@@ -595,7 +595,7 @@ void BluetoothProxy::send_connections_free() {
       call.allocated.push_back(connection->address_);
     }
   }
-  this->api_connection_->send_message(call);
+  this->api_connection_->send_message(call, api::BluetoothConnectionsFreeResponse::MESSAGE_TYPE);
 }
 
 void BluetoothProxy::send_gatt_services_done(uint64_t address) {
@@ -603,7 +603,7 @@ void BluetoothProxy::send_gatt_services_done(uint64_t address) {
     return;
   api::BluetoothGATTGetServicesDoneResponse call;
   call.address = address;
-  this->api_connection_->send_message(call);
+  this->api_connection_->send_message(call, api::BluetoothGATTGetServicesDoneResponse::MESSAGE_TYPE);
 }
 
 void BluetoothProxy::send_gatt_error(uint64_t address, uint16_t handle, esp_err_t error) {
@@ -613,7 +613,7 @@ void BluetoothProxy::send_gatt_error(uint64_t address, uint16_t handle, esp_err_
   call.address = address;
   call.handle = handle;
   call.error = error;
-  this->api_connection_->send_message(call);
+  this->api_connection_->send_message(call, api::BluetoothGATTWriteResponse::MESSAGE_TYPE);
 }
 
 void BluetoothProxy::send_device_pairing(uint64_t address, bool paired, esp_err_t error) {
@@ -622,7 +622,7 @@ void BluetoothProxy::send_device_pairing(uint64_t address, bool paired, esp_err_
   call.paired = paired;
   call.error = error;
 
-  this->api_connection_->send_message(call);
+  this->api_connection_->send_message(call, api::BluetoothDevicePairingResponse::MESSAGE_TYPE);
 }
 
 void BluetoothProxy::send_device_unpairing(uint64_t address, bool success, esp_err_t error) {
@@ -631,7 +631,7 @@ void BluetoothProxy::send_device_unpairing(uint64_t address, bool success, esp_e
   call.success = success;
   call.error = error;
 
-  this->api_connection_->send_message(call);
+  this->api_connection_->send_message(call, api::BluetoothDeviceUnpairingResponse::MESSAGE_TYPE);
 }
 
 void BluetoothProxy::bluetooth_scanner_set_mode(bool active) {

--- a/esphome/components/voice_assistant/voice_assistant.cpp
+++ b/esphome/components/voice_assistant/voice_assistant.cpp
@@ -223,7 +223,8 @@ void VoiceAssistant::loop() {
       msg.wake_word_phrase = this->wake_word_;
       this->wake_word_ = "";
 
-      if (this->api_client_ == nullptr || !this->api_client_->send_message(msg)) {
+      if (this->api_client_ == nullptr ||
+          !this->api_client_->send_message(msg, api::VoiceAssistantRequest::MESSAGE_TYPE)) {
         ESP_LOGW(TAG, "Could not request start");
         this->error_trigger_->trigger("not-connected", "Could not request start");
         this->continuous_ = false;
@@ -245,7 +246,7 @@ void VoiceAssistant::loop() {
         if (this->audio_mode_ == AUDIO_MODE_API) {
           api::VoiceAssistantAudio msg;
           msg.data.assign((char *) this->send_buffer_, read_bytes);
-          this->api_client_->send_message(msg);
+          this->api_client_->send_message(msg, api::VoiceAssistantAudio::MESSAGE_TYPE);
         } else {
           if (!this->udp_socket_running_) {
             if (!this->start_udp_socket_()) {
@@ -331,7 +332,7 @@ void VoiceAssistant::loop() {
 
           api::VoiceAssistantAnnounceFinished msg;
           msg.success = true;
-          this->api_client_->send_message(msg);
+          this->api_client_->send_message(msg, api::VoiceAssistantAnnounceFinished::MESSAGE_TYPE);
           break;
         }
       }
@@ -580,7 +581,7 @@ void VoiceAssistant::signal_stop_() {
   ESP_LOGD(TAG, "Signaling stop");
   api::VoiceAssistantRequest msg;
   msg.start = false;
-  this->api_client_->send_message(msg);
+  this->api_client_->send_message(msg, api::VoiceAssistantRequest::MESSAGE_TYPE);
 }
 
 void VoiceAssistant::start_playback_timeout_() {
@@ -590,7 +591,7 @@ void VoiceAssistant::start_playback_timeout_() {
 
     api::VoiceAssistantAnnounceFinished msg;
     msg.success = true;
-    this->api_client_->send_message(msg);
+    this->api_client_->send_message(msg, api::VoiceAssistantAnnounceFinished::MESSAGE_TYPE);
   });
 }
 

--- a/script/api_protobuf/api_protobuf.py
+++ b/script/api_protobuf/api_protobuf.py
@@ -1713,13 +1713,12 @@ static const char *const TAG = "api.service";
     hpp += " public:\n"
     hpp += "#endif\n\n"
 
-    # Add generic send_message method
-    hpp += "  template<typename T>\n"
-    hpp += "  bool send_message(const T &msg) {\n"
+    # Add non-template send_message method
+    hpp += "  bool send_message(const ProtoMessage &msg, uint8_t message_type) {\n"
     hpp += "#ifdef HAS_PROTO_MESSAGE_DUMP\n"
     hpp += "    this->log_send_message_(msg.message_name(), msg.dump());\n"
     hpp += "#endif\n"
-    hpp += "    return this->send_message_(msg, T::MESSAGE_TYPE);\n"
+    hpp += "    return this->send_message_(msg, message_type);\n"
     hpp += "  }\n\n"
 
     # Add logging helper method implementation to cpp
@@ -1805,7 +1804,9 @@ static const char *const TAG = "api.service";
                 handler_body = f"this->{func}(msg);\n"
             else:
                 handler_body = f"{ret} ret = this->{func}(msg);\n"
-                handler_body += "if (!this->send_message(ret)) {\n"
+                handler_body += (
+                    f"if (!this->send_message(ret, {ret}::MESSAGE_TYPE)) {{\n"
+                )
                 handler_body += "  this->on_fatal_error();\n"
                 handler_body += "}\n"
 
@@ -1818,7 +1819,7 @@ static const char *const TAG = "api.service";
                 body += f"this->{func}(msg);\n"
             else:
                 body += f"{ret} ret = this->{func}(msg);\n"
-                body += "if (!this->send_message(ret)) {\n"
+                body += f"if (!this->send_message(ret, {ret}::MESSAGE_TYPE)) {{\n"
                 body += "  this->on_fatal_error();\n"
                 body += "}\n"
 


### PR DESCRIPTION
# What does this implement/fix?

This PR refactors the API's `send_message` method from a template function to a non-template implementation. All callers now explicitly pass the message type instead of relying on template instantiation.

**Why now?** While this change shows zero impact on binary size today (the compiler currently optimizes it perfectly), it's critical to make this change **before** we add any complexity to `send_message`. Once additional logic is added to a template function, we risk significant code bloat from duplicate instantiations across 50+ message types. It's much easier to refactor this now while the code is simple than to untangle it later when we're already suffering from template bloat.

## Changes made:

1. Removed template `send_message<T>` from `APIServerConnectionBase`
2. Updated all callers to use `send_message(msg, MessageType::MESSAGE_TYPE)`
3. Modified code generator to produce non-template calls
4. Updated affected components: bluetooth_proxy, voice_assistant, list_entities, api_server

## Impact:

- **Current**: Zero change in RAM/Flash usage (compiler already optimized it well)
- **Future**: Prevents potential code bloat when features are added to send_message
- **Maintenance**: Cleaner, more explicit API that's easier to debug
- **Build time**: Reduced template instantiation overhead

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Part of ongoing API memory optimization efforts

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal implementation detail)

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - this is an internal refactor
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

## Memory comparison

Before:
```
RAM:   [=         ]  13.0% (used 42496 bytes from 327680 bytes)
Flash: [=======   ]  65.3% (used 1197988 bytes from 1835008 bytes)
```

After:
```
RAM:   [=         ]  13.0% (used 42496 bytes from 327680 bytes)
Flash: [=======   ]  65.3% (used 1197988 bytes from 1835008 bytes)
```

The identical sizes demonstrate that the compiler was already optimizing the simple template perfectly. This refactor ensures we maintain that efficiency as the codebase evolves.