### PR TITLE
Allow disabling OTA for web_server while keeping it enabled for captive_portal

### DIFF
--- a/esphome/components/web_server/__init__.py
+++ b/esphome/components/web_server/__init__.py
@@ -74,13 +74,14 @@ def validate_local(config: ConfigType) -> ConfigType:
     return config
 
 
-def validate_ota_removed(config: ConfigType) -> ConfigType:
-    # Only raise error if OTA is explicitly enabled (True)
-    # If it's False or not specified, we can safely ignore it
-    if config.get(CONF_OTA):
+def validate_ota(config: ConfigType) -> ConfigType:
+    # The OTA option only accepts False to explicitly disable OTA for web_server
+    # IMPORTANT: Setting ota: false ONLY affects the web_server component
+    # The captive_portal component will still be able to perform OTA updates
+    if CONF_OTA in config and config[CONF_OTA] is not False:
         raise cv.Invalid(
-            f"The '{CONF_OTA}' option has been removed from 'web_server'. "
-            f"Please use the new OTA platform structure instead:\n\n"
+            f"The '{CONF_OTA}' option in 'web_server' only accepts 'false' to disable OTA. "
+            f"To enable OTA, please use the new OTA platform structure instead:\n\n"
             f"ota:\n"
             f"  - platform: web_server\n\n"
             f"See https://esphome.io/components/ota for more information."
@@ -185,7 +186,7 @@ CONFIG_SCHEMA = cv.All(
                 web_server_base.WebServerBase
             ),
             cv.Optional(CONF_INCLUDE_INTERNAL, default=False): cv.boolean,
-            cv.Optional(CONF_OTA, default=False): cv.boolean,
+            cv.Optional(CONF_OTA): cv.boolean,
             cv.Optional(CONF_LOG, default=True): cv.boolean,
             cv.Optional(CONF_LOCAL): cv.boolean,
             cv.Optional(CONF_SORTING_GROUPS): cv.ensure_list(sorting_group),
@@ -203,7 +204,7 @@ CONFIG_SCHEMA = cv.All(
     default_url,
     validate_local,
     validate_sorting_groups,
-    validate_ota_removed,
+    validate_ota,
 )
 
 
@@ -288,7 +289,11 @@ async def to_code(config):
         cg.add(var.set_css_url(config[CONF_CSS_URL]))
         cg.add(var.set_js_url(config[CONF_JS_URL]))
     # OTA is now handled by the web_server OTA platform
-    # The CONF_OTA option is kept only for backwards compatibility validation
+    # The CONF_OTA option is kept to allow explicitly disabling OTA for web_server
+    # IMPORTANT: This ONLY affects the web_server component, NOT captive_portal
+    # Captive portal will still be able to perform OTA updates even when this is set
+    if config.get(CONF_OTA) is False:
+        cg.add_define("USE_WEBSERVER_OTA_DISABLED")
     cg.add(var.set_expose_log(config[CONF_LOG]))
     if config[CONF_ENABLE_PRIVATE_NETWORK_ACCESS]:
         cg.add_define("USE_WEBSERVER_PRIVATE_NETWORK_ACCESS")

--- a/esphome/components/web_server/ota/ota_web_server.cpp
+++ b/esphome/components/web_server/ota/ota_web_server.cpp
@@ -35,6 +35,7 @@ class OTARequestHandler : public AsyncWebHandler {
 #if defined(USE_WEBSERVER_OTA_DISABLED) && defined(USE_CAPTIVE_PORTAL)
     // IMPORTANT: USE_WEBSERVER_OTA_DISABLED only disables OTA for the web_server component
     // Captive portal can still perform OTA updates - check if request is from active captive portal
+    // Note: global_captive_portal is the standard way components communicate in ESPHome
     return is_ota_request && captive_portal::global_captive_portal != nullptr &&
            captive_portal::global_captive_portal->is_active();
 #elif defined(USE_WEBSERVER_OTA_DISABLED)

--- a/esphome/components/web_server/ota/ota_web_server.cpp
+++ b/esphome/components/web_server/ota/ota_web_server.cpp
@@ -5,6 +5,10 @@
 #include "esphome/core/application.h"
 #include "esphome/core/log.h"
 
+#ifdef USE_CAPTIVE_PORTAL
+#include "esphome/components/captive_portal/captive_portal.h"
+#endif
+
 #ifdef USE_ARDUINO
 #ifdef USE_ESP8266
 #include <Updater.h>
@@ -25,7 +29,21 @@ class OTARequestHandler : public AsyncWebHandler {
   void handleUpload(AsyncWebServerRequest *request, const String &filename, size_t index, uint8_t *data, size_t len,
                     bool final) override;
   bool canHandle(AsyncWebServerRequest *request) const override {
-    return request->url() == "/update" && request->method() == HTTP_POST;
+    if (request->url() != "/update" || request->method() != HTTP_POST) {
+      return false;
+    }
+
+#if defined(USE_WEBSERVER_OTA_DISABLED) && defined(USE_CAPTIVE_PORTAL)
+    // IMPORTANT: USE_WEBSERVER_OTA_DISABLED only disables OTA for the web_server component
+    // Captive portal can still perform OTA updates - check if request is from active captive portal
+    return captive_portal::global_captive_portal != nullptr && captive_portal::global_captive_portal->is_active();
+#elif defined(USE_WEBSERVER_OTA_DISABLED)
+    // OTA disabled for web_server and no captive portal compiled in
+    return false;
+#else
+    // OTA enabled for web_server
+    return true;
+#endif
   }
 
   // NOLINTNEXTLINE(readability-identifier-naming)

--- a/esphome/components/web_server/ota/ota_web_server.cpp
+++ b/esphome/components/web_server/ota/ota_web_server.cpp
@@ -29,20 +29,20 @@ class OTARequestHandler : public AsyncWebHandler {
   void handleUpload(AsyncWebServerRequest *request, const String &filename, size_t index, uint8_t *data, size_t len,
                     bool final) override;
   bool canHandle(AsyncWebServerRequest *request) const override {
-    if (request->url() != "/update" || request->method() != HTTP_POST) {
-      return false;
-    }
+    // Check if this is an OTA update request
+    bool is_ota_request = request->url() == "/update" && request->method() == HTTP_POST;
 
 #if defined(USE_WEBSERVER_OTA_DISABLED) && defined(USE_CAPTIVE_PORTAL)
     // IMPORTANT: USE_WEBSERVER_OTA_DISABLED only disables OTA for the web_server component
     // Captive portal can still perform OTA updates - check if request is from active captive portal
-    return captive_portal::global_captive_portal != nullptr && captive_portal::global_captive_portal->is_active();
+    return is_ota_request && captive_portal::global_captive_portal != nullptr &&
+           captive_portal::global_captive_portal->is_active();
 #elif defined(USE_WEBSERVER_OTA_DISABLED)
     // OTA disabled for web_server and no captive portal compiled in
     return false;
 #else
     // OTA enabled for web_server
-    return true;
+    return is_ota_request;
 #endif
   }
 

--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -268,10 +268,10 @@ std::string WebServer::get_config_json() {
   return json::build_json([this](JsonObject root) {
     root["title"] = App.get_friendly_name().empty() ? App.get_name() : App.get_friendly_name();
     root["comment"] = App.get_comment();
-#ifdef USE_WEBSERVER_OTA
-    root["ota"] = true;  // web_server OTA platform is configured
+#if defined(USE_WEBSERVER_OTA_DISABLED) || !defined(USE_WEBSERVER_OTA)
+    root["ota"] = false;  // Note: USE_WEBSERVER_OTA_DISABLED only affects web_server, not captive_portal
 #else
-    root["ota"] = false;
+    root["ota"] = true;
 #endif
     root["log"] = this->expose_log_;
     root["lang"] = "en";

--- a/esphome/components/web_server/web_server_v1.cpp
+++ b/esphome/components/web_server/web_server_v1.cpp
@@ -192,7 +192,9 @@ void WebServer::handle_index_request(AsyncWebServerRequest *request) {
 
   stream->print(F("</tbody></table><p>See <a href=\"https://esphome.io/web-api/index.html\">ESPHome Web API</a> for "
                   "REST API documentation.</p>"));
-#ifdef USE_WEBSERVER_OTA
+#if defined(USE_WEBSERVER_OTA) && !defined(USE_WEBSERVER_OTA_DISABLED)
+  // Show OTA form only if web_server OTA is not explicitly disabled
+  // Note: USE_WEBSERVER_OTA_DISABLED only affects web_server, not captive_portal
   stream->print(F("<h2>OTA Update</h2><form method=\"POST\" action=\"/update\" enctype=\"multipart/form-data\"><input "
                   "type=\"file\" name=\"update\"><input type=\"submit\" value=\"Update\"></form>"));
 #endif

--- a/tests/component_tests/web_server/test_ota_migration.py
+++ b/tests/component_tests/web_server/test_ota_migration.py
@@ -8,31 +8,31 @@ from esphome.types import ConfigType
 
 def test_web_server_ota_true_fails_validation() -> None:
     """Test that web_server with ota: true fails validation with helpful message."""
-    from esphome.components.web_server import validate_ota_removed
+    from esphome.components.web_server import validate_ota
 
     # Config with ota: true should fail
     config: ConfigType = {"ota": True}
 
     with pytest.raises(cv.Invalid) as exc_info:
-        validate_ota_removed(config)
+        validate_ota(config)
 
     # Check error message contains migration instructions
     error_msg = str(exc_info.value)
-    assert "has been removed from 'web_server'" in error_msg
+    assert "only accepts 'false' to disable OTA" in error_msg
     assert "platform: web_server" in error_msg
     assert "ota:" in error_msg
 
 
 def test_web_server_ota_false_passes_validation() -> None:
     """Test that web_server with ota: false passes validation."""
-    from esphome.components.web_server import validate_ota_removed
+    from esphome.components.web_server import validate_ota
 
     # Config with ota: false should pass
     config: ConfigType = {"ota": False}
-    result = validate_ota_removed(config)
+    result = validate_ota(config)
     assert result == config
 
     # Config without ota should also pass
     config: ConfigType = {}
-    result = validate_ota_removed(config)
+    result = validate_ota(config)
     assert result == config


### PR DESCRIPTION
# What does this implement/fix?

This PR fixes #9565 by allowing users to explicitly disable OTA updates for the `web_server` component while keeping them enabled for `captive_portal`. 

Previously, when `captive_portal` was configured alongside `web_server`, the captive portal would automatically load the web server OTA platform, making OTA functional on the regular web interface even without explicitly configuring it. This was unexpected behavior for users who wanted OTA to be available only through the captive portal for security reasons.

Now users can explicitly set `web_server: ota: false` to disable OTA for the regular web interface while maintaining OTA functionality through the captive portal when it's active.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes #9565

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#5109

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Disable OTA for web_server while keeping it enabled for captive_portal
web_server:
  port: 80
  ota: false  # Disables OTA through regular web interface

# Captive portal automatically enables web server OTA platform
# OTA will only be accessible when captive portal is active
captive_portal:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

## Additional Context

The implementation:
- Validates that `ota:` only accepts `false` (not `true`) to avoid confusion with the deprecated behavior
- Defines `USE_WEBSERVER_OTA_DISABLED` when `ota: false` is set
- Updates the OTA request handler to check if the request is coming through an active captive portal
- Ensures the web UI correctly reflects the OTA status
- Includes clear comments throughout the code emphasizing that this setting ONLY affects `web_server` and NOT `captive_portal`

This is particularly useful for IoT devices in production environments where administrators want to restrict firmware updates to physical access scenarios (when captive portal is activated) rather than allowing updates through the regular web interface.