### PR TITLE
[dependabot] Use specific labels for github-actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,9 @@ updates:
       # Hypotehsis is only used for testing and is updated quite often
       - dependency-name: hypothesis
   - package-ecosystem: github-actions
+    labels:
+      - "dependencies"
+      - "github-actions"
     directory: "/"
     schedule:
       interval: daily
@@ -20,11 +23,17 @@ updates:
           - "docker/login-action"
           - "docker/setup-buildx-action"
   - package-ecosystem: github-actions
+    labels:
+      - "dependencies"
+      - "github-actions"
     directory: "/.github/actions/build-image"
     schedule:
       interval: daily
     open-pull-requests-limit: 10
   - package-ecosystem: github-actions
+    labels:
+      - "dependencies"
+      - "github-actions"
     directory: "/.github/actions/restore-python"
     schedule:
       interval: daily


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

A simple change from the default `github_actions` to `github-actions` with a hyphen to make it more consistent with the rest of our labels

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
