### PR TITLE
[CI] Add ``by-code-owner`` labelling

### DIFF
--- a/.github/workflows/auto-label-pr.yml
+++ b/.github/workflows/auto-label-pr.yml
@@ -121,6 +121,7 @@ jobs:
                 'small-pr',
                 'dashboard',
                 'github-actions',
+                'by-code-owner',
                 'has-tests',
                 'needs-tests',
                 'too-big',
@@ -295,6 +296,67 @@ jobs:
 
             if (githubActionsFiles.length > 0) {
               labels.add('github-actions');
+            }
+
+            // Strategy: Code Owner detection
+            try {
+              // Fetch CODEOWNERS file from the repository (in case it was changed in this PR)
+              const { data: codeownersFile } = await github.rest.repos.getContent({
+                owner,
+                repo,
+                path: '.github/CODEOWNERS',
+                ref: context.payload.pull_request.head.sha
+              });
+
+              const codeownersContent = Buffer.from(codeownersFile.content, 'base64').toString('utf8');
+              const prAuthor = context.payload.pull_request.user.login;
+
+              // Parse CODEOWNERS file
+              const codeownersLines = codeownersContent.split('\n')
+                .map(line => line.trim())
+                .filter(line => line && !line.startsWith('#'));
+
+              let isCodeOwner = false;
+
+              for (const file of changedFiles) {
+                for (const line of codeownersLines) {
+                  const parts = line.split(/\s+/);
+                  const pattern = parts[0];
+                  const owners = parts.slice(1);
+
+                  // Convert CODEOWNERS pattern to regex
+                  let regex;
+                  if (pattern.endsWith('*')) {
+                    // Directory pattern like "esphome/components/api/*"
+                    const dir = pattern.slice(0, -1);
+                    regex = new RegExp(`^${dir.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`);
+                  } else if (pattern.includes('*')) {
+                    // Glob pattern
+                    const regexPattern = pattern
+                      .replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+                      .replace(/\\*/g, '.*');
+                    regex = new RegExp(`^${regexPattern}$`);
+                  } else {
+                    // Exact match
+                    regex = new RegExp(`^${pattern.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}$`);
+                  }
+
+                  if (regex.test(file)) {
+                    // Check if PR author is in the owners list
+                    if (owners.some(owner => owner === `@${prAuthor}`) {
+                      isCodeOwner = true;
+                      break;
+                    }
+                  }
+                }
+                if (isCodeOwner) break;
+              }
+
+              if (isCodeOwner) {
+                labels.add('by-code-owner');
+              }
+            } catch (error) {
+              console.log('Failed to read or parse CODEOWNERS file:', error.message);
             }
 
             // Strategy: Test detection

--- a/.github/workflows/auto-label-pr.yml
+++ b/.github/workflows/auto-label-pr.yml
@@ -318,32 +318,36 @@ jobs:
 
               let isCodeOwner = false;
 
+              // Precompile CODEOWNERS patterns into regex objects
+              const codeownersRegexes = codeownersLines.map(line => {
+                const parts = line.split(/\s+/);
+                const pattern = parts[0];
+                const owners = parts.slice(1);
+
+                let regex;
+                if (pattern.endsWith('*')) {
+                  // Directory pattern like "esphome/components/api/*"
+                  const dir = pattern.slice(0, -1);
+                  regex = new RegExp(`^${dir.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`);
+                } else if (pattern.includes('*')) {
+                  // Glob pattern
+                  const regexPattern = pattern
+                    .replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+                    .replace(/\\*/g, '.*');
+                  regex = new RegExp(`^${regexPattern}$`);
+                } else {
+                  // Exact match
+                  regex = new RegExp(`^${pattern.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}$`);
+                }
+
+                return { regex, owners };
+              });
+
               for (const file of changedFiles) {
-                for (const line of codeownersLines) {
-                  const parts = line.split(/\s+/);
-                  const pattern = parts[0];
-                  const owners = parts.slice(1);
-
-                  // Convert CODEOWNERS pattern to regex
-                  let regex;
-                  if (pattern.endsWith('*')) {
-                    // Directory pattern like "esphome/components/api/*"
-                    const dir = pattern.slice(0, -1);
-                    regex = new RegExp(`^${dir.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`);
-                  } else if (pattern.includes('*')) {
-                    // Glob pattern
-                    const regexPattern = pattern
-                      .replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-                      .replace(/\\*/g, '.*');
-                    regex = new RegExp(`^${regexPattern}$`);
-                  } else {
-                    // Exact match
-                    regex = new RegExp(`^${pattern.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}$`);
-                  }
-
+                for (const { regex, owners } of codeownersRegexes) {
                   if (regex.test(file)) {
                     // Check if PR author is in the owners list
-                    if (owners.some(owner => owner === `@${prAuthor}`) {
+                    if (owners.some(owner => owner === `@${prAuthor}`)) {
                       isCodeOwner = true;
                       break;
                     }


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Add the `by-code-owner` PR if one of the files changed in the PR falls under the author as being the codeowner as per `.github/CODEOWNERS`

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
