### PR TITLE
Skip compilation of web_server_v1.cpp when not using version 1

### DIFF
--- a/esphome/components/web_server/__init__.py
+++ b/esphome/components/web_server/__init__.py
@@ -321,7 +321,7 @@ async def to_code(config):
 
 def FILTER_SOURCE_FILES() -> list[str]:
     """Filter out web_server_v1.cpp when version is not 1."""
-    files_to_filter = []
+    files_to_filter: list[str] = []
 
     # web_server_v1.cpp is only needed when version is 1
     config = CORE.config.get("web_server", {})

--- a/esphome/components/web_server/__init__.py
+++ b/esphome/components/web_server/__init__.py
@@ -325,7 +325,7 @@ def FILTER_SOURCE_FILES() -> list[str]:
 
     # web_server_v1.cpp is only needed when version is 1
     config = CORE.config.get("web_server", {})
-    if config and config.get(CONF_VERSION, 2) != 1:
+    if config.get(CONF_VERSION, 2) != 1:
         files_to_filter.append("web_server_v1.cpp")
 
     return files_to_filter

--- a/esphome/components/web_server/__init__.py
+++ b/esphome/components/web_server/__init__.py
@@ -317,3 +317,15 @@ async def to_code(config):
     if (sorting_group_config := config.get(CONF_SORTING_GROUPS)) is not None:
         cg.add_define("USE_WEBSERVER_SORTING")
         add_sorting_groups(var, sorting_group_config)
+
+
+def FILTER_SOURCE_FILES() -> list[str]:
+    """Filter out web_server_v1.cpp when version is not 1."""
+    files_to_filter = []
+
+    # web_server_v1.cpp is only needed when version is 1
+    config = CORE.config.get("web_server", {})
+    if config and config.get(CONF_VERSION, 2) != 1:
+        files_to_filter.append("web_server_v1.cpp")
+
+    return files_to_filter


### PR DESCRIPTION
# What does this implement/fix?

This PR adds a `FILTER_SOURCE_FILES` function to the web_server component to exclude `web_server_v1.cpp` from compilation when the web server version is not 1. This follows the same pattern used by the API component to reduce compilation time and binary size by not compiling unused source files.

Currently, `web_server_v1.cpp` is always compiled even when using version 2 or 3 (which is the default), resulting in unnecessary compilation time.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Reduces compilation time by not compiling unused web server v1 code

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - No documentation changes needed

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# No configuration changes needed
# This optimization is automatic based on web_server version

# Version 1 (will compile web_server_v1.cpp)
web_server:
  version: 1

# Version 2 or 3 (will NOT compile web_server_v1.cpp)
web_server:
  version: 2  # or omit version for default v2
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).