### PR TITLE
esp32_camera: deprecate i2c_pins; throw error if combined with i2c: block

### DIFF
--- a/esphome/components/esp32_camera/__init__.py
+++ b/esphome/components/esp32_camera/__init__.py
@@ -1,3 +1,5 @@
+import logging
+
 from esphome import automation, pins
 import esphome.codegen as cg
 from esphome.components import i2c
@@ -8,6 +10,7 @@ from esphome.const import (
     CONF_CONTRAST,
     CONF_DATA_PINS,
     CONF_FREQUENCY,
+    CONF_I2C,
     CONF_I2C_ID,
     CONF_ID,
     CONF_PIN,
@@ -20,6 +23,9 @@ from esphome.const import (
 )
 from esphome.core import CORE
 from esphome.core.entity_helpers import setup_entity
+import esphome.final_validate as fv
+
+_LOGGER = logging.getLogger(__name__)
 
 DEPENDENCIES = ["esp32"]
 
@@ -249,6 +255,22 @@ CONFIG_SCHEMA = cv.All(
     ).extend(cv.COMPONENT_SCHEMA),
     cv.has_exactly_one_key(CONF_I2C_PINS, CONF_I2C_ID),
 )
+
+
+def _final_validate(config):
+    if CONF_I2C_PINS not in config:
+        return
+    fconf = fv.full_config.get()
+    if fconf.get(CONF_I2C):
+        raise cv.Invalid(
+            "The `i2c_pins:` config option is incompatible with an dedicated `i2c:` block, use `i2c_id` instead"
+        )
+    _LOGGER.warning(
+        "The `i2c_pins:` config option is deprecated. Use `i2c_id:` with a dedicated `i2c:` definition instead."
+    )
+
+
+FINAL_VALIDATE_SCHEMA = _final_validate
 
 SETTERS = {
     # pin assignment


### PR DESCRIPTION
# What does this implement/fix?

If `i2c_pins:` is used in combination with an `i2c:` block, the i2c module does not properly iterate to the next hardware. Leading to both components trying to use the same hardware with different GPIO pins.

This change will make it invalid to use `i2c_pins:` in combination with an `i2c:` block and instead guide the user to use the new `i2c_id:` option instead, which uses the i2c component by reference.

In addition a warning will be printed, if `i2c_pins:` is used reminding the existing userbase, that this option is now deprecated (as it's no longer documented in the documentation).


## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other: Deprecation of feature

**Related issue or feature (if applicable):**

- fixes #9601 

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** 

- esphome/esphome-docs#5115


## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
