### PR TITLE
Fix scheduler rollover detection with concurrent task calls

### DIFF
--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -14,6 +14,8 @@ namespace esphome {
 static const char *const TAG = "scheduler";
 
 static const uint32_t MAX_LOGICALLY_DELETED_ITEMS = 10;
+// Half the 32-bit range - used to detect rollovers vs normal time progression
+static const uint32_t HALF_MAX_UINT32 = 0x80000000UL;
 
 // Uncomment to debug scheduler
 // #define ESPHOME_DEBUG_SCHEDULER
@@ -504,13 +506,13 @@ uint64_t Scheduler::millis_64_(uint32_t now) {
 
   // If we might be near a rollover (large backwards jump), take the lock for the entire operation
   // This ensures rollover detection and last_millis_ update are atomic together
-  if (now < last && (last - now) > 0x80000000UL) {
+  if (now < last && (last - now) > HALF_MAX_UINT32) {
     // Potential rollover - need lock for atomic rollover detection + update
     LockGuard guard{this->lock_};
     // Re-read with lock held
     last = this->last_millis_.load(std::memory_order_relaxed);
 
-    if (now < last && (last - now) > 0x80000000UL) {
+    if (now < last && (last - now) > HALF_MAX_UINT32) {
       // True rollover detected (happens every ~49.7 days)
       this->millis_major_++;
 #ifdef ESPHOME_DEBUG_SCHEDULER
@@ -522,7 +524,7 @@ uint64_t Scheduler::millis_64_(uint32_t now) {
   } else {
     // Normal case: Try lock-free update, but only allow forward movement within same epoch
     // This prevents accidentally moving backwards across a rollover boundary
-    while (now > last && (now - last) < 0x80000000UL) {
+    while (now > last && (now - last) < HALF_MAX_UINT32) {
       if (this->last_millis_.compare_exchange_weak(last, now, std::memory_order_relaxed)) {
         break;
       }
@@ -535,7 +537,7 @@ uint64_t Scheduler::millis_64_(uint32_t now) {
   uint32_t last = this->last_millis_;
 
   // Check for rollover
-  if (now < last && (last - now) > 0x80000000UL) {
+  if (now < last && (last - now) > HALF_MAX_UINT32) {
     this->millis_major_++;
 #ifdef ESPHOME_DEBUG_SCHEDULER
     ESP_LOGD(TAG, "Detected true 32-bit rollover at %" PRIu32 "ms (was %" PRIu32 ")", now, last);

--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -484,45 +484,58 @@ bool HOT Scheduler::cancel_item_locked_(Component *component, const char *name_c
 
 uint64_t Scheduler::millis_64_(uint32_t now) {
   // THREAD SAFETY NOTE:
-  // This function can be called from multiple threads simultaneously.
-  // We use a local snapshot and a large threshold to make it thread-safe without locks.
+  // This function can be called from multiple threads simultaneously on ESP32/LibreTiny.
+  // On single-threaded platforms (ESP8266, RP2040), atomics are not needed.
 
-  // Read once to ensure consistent value throughout this function
-  uint32_t last = this->last_millis_;
+#if !defined(USE_ESP8266) && !defined(USE_RP2040)
+  // Multi-threaded platforms: Use atomic operations for thread safety
+  uint32_t last = this->last_millis_.load(std::memory_order_relaxed);
 
   // Check for rollover - only if backwards jump is very large
-  // A true 32-bit rollover means jumping from ~4294967295 to ~0
-  // So we only consider it a rollover if the backwards jump is > 2^31 (half the range)
-  // This prevents false positives from thread timing variations while detecting real rollovers
-  //
-  // THREAD SAFETY: Even with concurrent access, this is safe because:
-  // 1. We use a consistent snapshot (last) for the entire check
-  // 2. The threshold (0x80000000) is so large that timing variations between threads
-  //    (at most a few ms) can never cause a false positive
   if (now < last && (last - now) > 0x80000000UL) {
-    // This is a true rollover (happens every ~49.7 days)
-    // Use a lock here to prevent multiple threads from incrementing for the same rollover
-    // This is worth the overhead since it only happens every 49.7 days
+    // True rollover detected (happens every ~49.7 days)
+    // Must lock here to prevent multiple threads from incrementing for the same rollover
     LockGuard guard{this->lock_};
-    // Re-check with lock held to prevent double increment
-    if (now < this->last_millis_ && (this->last_millis_ - now) > 0x80000000UL) {
+    // Re-check with lock held using atomic loads
+    uint32_t locked_last = this->last_millis_.load(std::memory_order_relaxed);
+    if (now < locked_last && (locked_last - now) > 0x80000000UL) {
+      // Increment while holding the lock
       this->millis_major_++;
 #ifdef ESPHOME_DEBUG_SCHEDULER
-      ESP_LOGD(TAG, "Detected true 32-bit rollover at %" PRIu32 "ms (was %" PRIu32 ")", now, this->last_millis_);
+      ESP_LOGD(TAG, "Detected true 32-bit rollover at %" PRIu32 "ms (was %" PRIu32 ")", now, locked_last);
 #endif
     }
   }
 
-  // Only update last_millis_ if time moved forward
-  // This maintains the latest time seen for rollover detection
-  // THREAD SAFETY: If another thread already updated to a higher value,
-  // we skip our update. This is fine - we just want the highest value seen.
+  // Update last_millis_ using compare_exchange to prevent writing stale values
+  while (last < now) {
+    if (this->last_millis_.compare_exchange_weak(last, now, std::memory_order_relaxed)) {
+      break;
+    }
+    // last is automatically updated by compare_exchange_weak if it fails
+  }
+
+  return now + (static_cast<uint64_t>(this->millis_major_) << 32);
+
+#else
+  // Single-threaded platforms: No atomics needed
+  uint32_t last = this->last_millis_;
+
+  // Check for rollover
+  if (now < last && (last - now) > 0x80000000UL) {
+    this->millis_major_++;
+#ifdef ESPHOME_DEBUG_SCHEDULER
+    ESP_LOGD(TAG, "Detected true 32-bit rollover at %" PRIu32 "ms (was %" PRIu32 ")", now, last);
+#endif
+  }
+
+  // Only update if time moved forward
   if (now > last) {
     this->last_millis_ = now;
   }
 
-  // Combine major (high 32 bits) and now (low 32 bits) into 64-bit time
   return now + (static_cast<uint64_t>(this->millis_major_) << 32);
+#endif
 }
 
 bool HOT Scheduler::SchedulerItem::cmp(const std::unique_ptr<SchedulerItem> &a,

--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -491,6 +491,13 @@ uint64_t Scheduler::millis_64_(uint32_t now) {
   // THREAD SAFETY NOTE:
   // This function can be called from multiple threads simultaneously on ESP32/LibreTiny.
   // On single-threaded platforms (ESP8266, RP2040), atomics are not needed.
+  //
+  // KNOWN LIMITATION: There is a small race condition at the 32-bit rollover boundary
+  // (every 49.7 days). To fix this completely would require either:
+  // 1. 64-bit atomic operations (not available on ESP32)
+  // 2. Locking on every time check (unacceptable performance impact)
+  // We accept this edge case as the race window is tiny (microseconds every 49.7 days)
+  // and the consequence is timeouts firing early, not crashes.
 
 #if !defined(USE_ESP8266) && !defined(USE_RP2040)
   // Multi-threaded platforms: Need to handle rollover carefully

--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -268,8 +268,13 @@ void HOT Scheduler::call(uint32_t now) {
   if (now_64 - last_print > 2000) {
     last_print = now_64;
     std::vector<std::unique_ptr<SchedulerItem>> old_items;
+#if !defined(USE_ESP8266) && !defined(USE_RP2040)
+    ESP_LOGD(TAG, "Items: count=%zu, now=%" PRIu64 " (%u, %" PRIu32 ")", this->items_.size(), now_64,
+             this->millis_major_, this->last_millis_.load(std::memory_order_relaxed));
+#else
     ESP_LOGD(TAG, "Items: count=%zu, now=%" PRIu64 " (%u, %" PRIu32 ")", this->items_.size(), now_64,
              this->millis_major_, this->last_millis_);
+#endif
     while (!this->empty_()) {
       std::unique_ptr<SchedulerItem> item;
       {

--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -483,16 +483,44 @@ bool HOT Scheduler::cancel_item_locked_(Component *component, const char *name_c
 }
 
 uint64_t Scheduler::millis_64_(uint32_t now) {
-  // Check for rollover by comparing with last value
-  if (now < this->last_millis_) {
-    // Detected rollover (happens every ~49.7 days)
-    this->millis_major_++;
+  // THREAD SAFETY NOTE:
+  // This function can be called from multiple threads simultaneously.
+  // We use a local snapshot and a large threshold to make it thread-safe without locks.
+
+  // Read once to ensure consistent value throughout this function
+  uint32_t last = this->last_millis_;
+
+  // Check for rollover - only if backwards jump is very large
+  // A true 32-bit rollover means jumping from ~4294967295 to ~0
+  // So we only consider it a rollover if the backwards jump is > 2^31 (half the range)
+  // This prevents false positives from thread timing variations while detecting real rollovers
+  //
+  // THREAD SAFETY: Even with concurrent access, this is safe because:
+  // 1. We use a consistent snapshot (last) for the entire check
+  // 2. The threshold (0x80000000) is so large that timing variations between threads
+  //    (at most a few ms) can never cause a false positive
+  if (now < last && (last - now) > 0x80000000UL) {
+    // This is a true rollover (happens every ~49.7 days)
+    // Use a lock here to prevent multiple threads from incrementing for the same rollover
+    // This is worth the overhead since it only happens every 49.7 days
+    LockGuard guard{this->lock_};
+    // Re-check with lock held to prevent double increment
+    if (now < this->last_millis_ && (this->last_millis_ - now) > 0x80000000UL) {
+      this->millis_major_++;
 #ifdef ESPHOME_DEBUG_SCHEDULER
-    ESP_LOGD(TAG, "Incrementing scheduler major at %" PRIu64 "ms",
-             now + (static_cast<uint64_t>(this->millis_major_) << 32));
+      ESP_LOGD(TAG, "Detected true 32-bit rollover at %" PRIu32 "ms (was %" PRIu32 ")", now, this->last_millis_);
 #endif
+    }
   }
-  this->last_millis_ = now;
+
+  // Only update last_millis_ if time moved forward
+  // This maintains the latest time seen for rollover detection
+  // THREAD SAFETY: If another thread already updated to a higher value,
+  // we skip our update. This is fine - we just want the highest value seen.
+  if (now > last) {
+    this->last_millis_ = now;
+  }
+
   // Combine major (high 32 bits) and now (low 32 bits) into 64-bit time
   return now + (static_cast<uint64_t>(this->millis_major_) << 32);
 }

--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -515,8 +515,6 @@ uint64_t Scheduler::millis_64_(uint32_t now) {
     // last is automatically updated by compare_exchange_weak if it fails
   }
 
-  return now + (static_cast<uint64_t>(this->millis_major_) << 32);
-
 #else
   // Single-threaded platforms: No atomics needed
   uint32_t last = this->last_millis_;
@@ -533,9 +531,10 @@ uint64_t Scheduler::millis_64_(uint32_t now) {
   if (now > last) {
     this->last_millis_ = now;
   }
-
-  return now + (static_cast<uint64_t>(this->millis_major_) << 32);
 #endif
+
+  // Combine major (high 32 bits) and now (low 32 bits) into 64-bit time
+  return now + (static_cast<uint64_t>(this->millis_major_) << 32);
 }
 
 bool HOT Scheduler::SchedulerItem::cmp(const std::unique_ptr<SchedulerItem> &a,

--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -93,7 +93,8 @@ void HOT Scheduler::set_timer_common_(Component *component, SchedulerItem::Type 
   }
 #endif
 
-  const auto now = this->millis_64_(millis());
+  // Get fresh timestamp for new timer/interval - ensures accurate scheduling
+  const auto now = this->millis_64_(millis());  // Fresh millis() call
 
   // Type-specific setup
   if (type == SchedulerItem::INTERVAL) {
@@ -222,7 +223,8 @@ optional<uint32_t> HOT Scheduler::next_schedule_in(uint32_t now) {
   if (this->empty_())
     return {};
   auto &item = this->items_[0];
-  const auto now_64 = this->millis_64_(now);
+  // Convert the fresh timestamp from caller (usually Application::loop()) to 64-bit
+  const auto now_64 = this->millis_64_(now);  // 'now' from parameter - fresh from caller
   if (item->next_execution_ < now_64)
     return 0;
   return item->next_execution_ - now_64;
@@ -261,7 +263,8 @@ void HOT Scheduler::call(uint32_t now) {
   }
 #endif
 
-  const auto now_64 = this->millis_64_(now);
+  // Convert the fresh timestamp from main loop to 64-bit for scheduler operations
+  const auto now_64 = this->millis_64_(now);  // 'now' from parameter - fresh from Application::loop()
   this->process_to_add();
 
 #ifdef ESPHOME_DEBUG_SCHEDULER
@@ -493,6 +496,10 @@ uint64_t Scheduler::millis_64_(uint32_t now) {
   // THREAD SAFETY NOTE:
   // This function can be called from multiple threads simultaneously on ESP32/LibreTiny.
   // On single-threaded platforms (ESP8266, RP2040), atomics are not needed.
+  //
+  // IMPORTANT: Always pass fresh millis() values to this function. The implementation
+  // handles out-of-order timestamps between threads, but minimizing time differences
+  // helps maintain accuracy.
   //
   // The implementation handles the 32-bit rollover (every 49.7 days) by:
   // 1. Using a lock when detecting rollover to ensure atomic update

--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -492,12 +492,11 @@ uint64_t Scheduler::millis_64_(uint32_t now) {
   // This function can be called from multiple threads simultaneously on ESP32/LibreTiny.
   // On single-threaded platforms (ESP8266, RP2040), atomics are not needed.
   //
-  // KNOWN LIMITATION: There is a small race condition at the 32-bit rollover boundary
-  // (every 49.7 days). To fix this completely would require either:
-  // 1. 64-bit atomic operations (not available on ESP32)
-  // 2. Locking on every time check (unacceptable performance impact)
-  // We accept this edge case as the race window is tiny (microseconds every 49.7 days)
-  // and the consequence is timeouts firing early, not crashes.
+  // The implementation handles the 32-bit rollover (every 49.7 days) by:
+  // 1. Using a lock when detecting rollover to ensure atomic update
+  // 2. Restricting normal updates to forward movement within the same epoch
+  // This prevents race conditions at the rollover boundary without requiring
+  // 64-bit atomics or locking on every call.
 
 #if !defined(USE_ESP8266) && !defined(USE_RP2040)
   // Multi-threaded platforms: Need to handle rollover carefully

--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -493,31 +493,34 @@ uint64_t Scheduler::millis_64_(uint32_t now) {
   // On single-threaded platforms (ESP8266, RP2040), atomics are not needed.
 
 #if !defined(USE_ESP8266) && !defined(USE_RP2040)
-  // Multi-threaded platforms: Use atomic operations for thread safety
+  // Multi-threaded platforms: Need to handle rollover carefully
   uint32_t last = this->last_millis_.load(std::memory_order_relaxed);
 
-  // Check for rollover - only if backwards jump is very large
+  // If we might be near a rollover (large backwards jump), take the lock for the entire operation
+  // This ensures rollover detection and last_millis_ update are atomic together
   if (now < last && (last - now) > 0x80000000UL) {
-    // True rollover detected (happens every ~49.7 days)
-    // Must lock here to prevent multiple threads from incrementing for the same rollover
+    // Potential rollover - need lock for atomic rollover detection + update
     LockGuard guard{this->lock_};
-    // Re-check with lock held using atomic loads
-    uint32_t locked_last = this->last_millis_.load(std::memory_order_relaxed);
-    if (now < locked_last && (locked_last - now) > 0x80000000UL) {
-      // Increment while holding the lock
+    // Re-read with lock held
+    last = this->last_millis_.load(std::memory_order_relaxed);
+
+    if (now < last && (last - now) > 0x80000000UL) {
+      // True rollover detected (happens every ~49.7 days)
       this->millis_major_++;
 #ifdef ESPHOME_DEBUG_SCHEDULER
-      ESP_LOGD(TAG, "Detected true 32-bit rollover at %" PRIu32 "ms (was %" PRIu32 ")", now, locked_last);
+      ESP_LOGD(TAG, "Detected true 32-bit rollover at %" PRIu32 "ms (was %" PRIu32 ")", now, last);
 #endif
     }
-  }
-
-  // Update last_millis_ using compare_exchange to prevent writing stale values
-  while (last < now) {
-    if (this->last_millis_.compare_exchange_weak(last, now, std::memory_order_relaxed)) {
-      break;
+    // Update last_millis_ while holding lock to prevent races
+    this->last_millis_.store(now, std::memory_order_relaxed);
+  } else {
+    // Normal case: Try lock-free update
+    while (now > last) {
+      if (this->last_millis_.compare_exchange_weak(last, now, std::memory_order_relaxed)) {
+        break;
+      }
+      // last is automatically updated by compare_exchange_weak if it fails
     }
-    // last is automatically updated by compare_exchange_weak if it fails
   }
 
 #else

--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -521,8 +521,9 @@ uint64_t Scheduler::millis_64_(uint32_t now) {
     // Update last_millis_ while holding lock to prevent races
     this->last_millis_.store(now, std::memory_order_relaxed);
   } else {
-    // Normal case: Try lock-free update
-    while (now > last) {
+    // Normal case: Try lock-free update, but only allow forward movement within same epoch
+    // This prevents accidentally moving backwards across a rollover boundary
+    while (now > last && (now - last) < 0x80000000UL) {
       if (this->last_millis_.compare_exchange_weak(last, now, std::memory_order_relaxed)) {
         break;
       }

--- a/esphome/core/scheduler.h
+++ b/esphome/core/scheduler.h
@@ -215,7 +215,7 @@ class Scheduler {
 #endif
   // millis_major_ is protected by lock when incrementing, volatile ensures
   // reads outside the lock see fresh values (not cached in registers)
-  volatile uint16_t millis_major_{0};
+  uint16_t millis_major_{0};
   uint32_t to_remove_{0};
 };
 

--- a/esphome/core/scheduler.h
+++ b/esphome/core/scheduler.h
@@ -55,8 +55,12 @@ class Scheduler {
                  std::function<RetryResult(uint8_t)> func, float backoff_increase_factor = 1.0f);
   bool cancel_retry(Component *component, const std::string &name);
 
+  // Calculate when the next scheduled item should run
+  // @param now Fresh timestamp from millis() - must not be stale/cached
   optional<uint32_t> next_schedule_in(uint32_t now);
 
+  // Execute all scheduled items that are ready
+  // @param now Fresh timestamp from millis() - must not be stale/cached
   void call(uint32_t now);
 
   void process_to_add();

--- a/esphome/core/scheduler.h
+++ b/esphome/core/scheduler.h
@@ -4,6 +4,9 @@
 #include <memory>
 #include <cstring>
 #include <deque>
+#if !defined(USE_ESP8266) && !defined(USE_RP2040)
+#include <atomic>
+#endif
 
 #include "esphome/core/component.h"
 #include "esphome/core/helpers.h"
@@ -203,8 +206,16 @@ class Scheduler {
   // Both platforms save 40 bytes of RAM by excluding this
   std::deque<std::unique_ptr<SchedulerItem>> defer_queue_;  // FIFO queue for defer() calls
 #endif
+#if !defined(USE_ESP8266) && !defined(USE_RP2040)
+  // Multi-threaded platforms: last_millis_ needs atomic for lock-free updates
+  std::atomic<uint32_t> last_millis_{0};
+#else
+  // Single-threaded platforms: no atomics needed
   uint32_t last_millis_{0};
-  uint16_t millis_major_{0};
+#endif
+  // millis_major_ is protected by lock when incrementing, volatile ensures
+  // reads outside the lock see fresh values (not cached in registers)
+  volatile uint16_t millis_major_{0};
   uint32_t to_remove_{0};
 };
 


### PR DESCRIPTION
# What does this implement/fix?

This PR fixes a regression introduced in #9524 where the scheduler's rollover detection could trigger incorrectly when scheduler functions are called from background tasks/threads, causing timeouts to execute nearly instantaneously.

## Background - How PR #9524 made the existing issue worse

**Before PR #9524:**
- `set_timeout()` called `millis()` directly
- `millis_64_()` was called immediately with that fresh value
- Race window: microseconds between the `millis()` call and updating `last_millis_`

**After PR #9524:**
- Main loop captures time once and uses it for all `scheduler.call()` operations
- Background tasks still call `millis()` directly in `set_timeout()`
- Race window: potentially milliseconds (the entire duration of the main loop iteration)

The larger race window made it much more likely for background tasks to call `millis_64_()` with a timestamp that appears to go backwards, triggering false rollover detection.

## The issue

When `millis_64_()` sees a timestamp earlier than `last_millis_`, it could incorrectly detect a 32-bit rollover, adding ~49.7 days to all timestamps and making timeouts execute immediately.

Additionally, as pointed out by @RubenKelevra in review, the original atomic implementation had a race condition where threads could repeatedly increment `millis_major_` or overwrite post-rollover values with pre-rollover values. This has been fully addressed in the current implementation.

## The fix

1. **Half-range check**: Only detects rollover when the backwards jump is > 2^31 (half the 32-bit range), preventing false positives from timing variations. The constant `HALF_MAX_UINT32` makes this clear.

2. **Platform-specific implementation**:
   - **Multi-threaded platforms (ESP32, LibreTiny)**: 
     - Lock-free atomic updates for normal forward time progression
     - Lock protection when detecting potential rollover to ensure atomic rollover detection + `last_millis_` update
     - Restricts normal updates to same-epoch forward movement only (prevents backwards jumps across rollover boundary)
   - **Single-threaded platforms (ESP8266, RP2040)**: 
     - Simple non-atomic implementation since there's no concurrency

3. **Complete thread safety without 64-bit atomics**:
   - Rollover case: Lock ensures detection and update happen atomically together
   - Normal case: CAS loop only allows forward updates within same epoch (diff < 2^31)
   - This combination prevents all race conditions at the rollover boundary
   - All `millis_64_()` call sites are documented to require fresh timestamps

This approach provides complete thread safety without requiring 64-bit atomic operations (unavailable on ESP32) or adding locking overhead to every time check. The implementation handles out-of-order timestamps between threads gracefully.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes regression from #9524
- addresses review comment from @RubenKelevra about rollover race conditions

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# No configuration changes needed
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - N/A