### PR TITLE
esp32cam: add fb location config option

### DIFF
--- a/esphome/components/esp32_camera/__init__.py
+++ b/esphome/components/esp32_camera/__init__.py
@@ -113,6 +113,12 @@ ENUM_SPECIAL_EFFECT = {
     "SEPIA": ESP32SpecialEffect.ESP32_SPECIAL_EFFECT_SEPIA,
 }
 
+camera_fb_location_t = cg.global_ns.enum("camera_fb_location_t")
+ENUM_FB_LOCATION = {
+    "PSRAM": cg.global_ns.CAMERA_FB_IN_PSRAM,
+    "DRAM": cg.global_ns.CAMERA_FB_IN_DRAM,
+}
+
 # pin assignment
 CONF_HREF_PIN = "href_pin"
 CONF_PIXEL_CLOCK_PIN = "pixel_clock_pin"
@@ -143,6 +149,7 @@ CONF_MAX_FRAMERATE = "max_framerate"
 CONF_IDLE_FRAMERATE = "idle_framerate"
 # frame buffer
 CONF_FRAME_BUFFER_COUNT = "frame_buffer_count"
+CONF_FRAME_BUFFER_LOCATION = "frame_buffer_location"
 
 # stream trigger
 CONF_ON_STREAM_START = "on_stream_start"
@@ -224,6 +231,9 @@ CONFIG_SCHEMA = cv.All(
                 cv.framerate, cv.Range(min=0, max=1)
             ),
             cv.Optional(CONF_FRAME_BUFFER_COUNT, default=1): cv.int_range(min=1, max=2),
+            cv.Optional(CONF_FRAME_BUFFER_LOCATION, default="PSRAM"): cv.enum(
+                ENUM_FB_LOCATION, upper=True
+            ),
             cv.Optional(CONF_ON_STREAM_START): automation.validate_automation(
                 {
                     cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(
@@ -279,6 +289,7 @@ SETTERS = {
     CONF_WB_MODE: "set_wb_mode",
     # test pattern
     CONF_TEST_PATTERN: "set_test_pattern",
+    CONF_FRAME_BUFFER_LOCATION: "set_frame_buffer_location",
 }
 
 
@@ -306,6 +317,7 @@ async def to_code(config):
     else:
         cg.add(var.set_idle_update_interval(1000 / config[CONF_IDLE_FRAMERATE]))
     cg.add(var.set_frame_buffer_count(config[CONF_FRAME_BUFFER_COUNT]))
+    cg.add(var.set_frame_buffer_location(config[CONF_FRAME_BUFFER_LOCATION]))
     cg.add(var.set_frame_size(config[CONF_RESOLUTION]))
 
     cg.add_define("USE_CAMERA")

--- a/esphome/components/esp32_camera/esp32_camera.cpp
+++ b/esphome/components/esp32_camera/esp32_camera.cpp
@@ -133,6 +133,7 @@ void ESP32Camera::dump_config() {
   ESP_LOGCONFIG(TAG,
                 "  JPEG Quality: %u\n"
                 "  Framebuffer Count: %u\n"
+                "  Framebuffer Location: %s\n"
                 "  Contrast: %d\n"
                 "  Brightness: %d\n"
                 "  Saturation: %d\n"
@@ -140,8 +141,9 @@ void ESP32Camera::dump_config() {
                 "  Horizontal Mirror: %s\n"
                 "  Special Effect: %u\n"
                 "  White Balance Mode: %u",
-                st.quality, conf.fb_count, st.contrast, st.brightness, st.saturation, ONOFF(st.vflip),
-                ONOFF(st.hmirror), st.special_effect, st.wb_mode);
+                st.quality, conf.fb_count, this->config_.fb_location == CAMERA_FB_IN_PSRAM ? "PSRAM" : "DRAM",
+                st.contrast, st.brightness, st.saturation, ONOFF(st.vflip), ONOFF(st.hmirror), st.special_effect,
+                st.wb_mode);
   // ESP_LOGCONFIG(TAG, "  Auto White Balance: %u", st.awb);
   // ESP_LOGCONFIG(TAG, "  Auto White Balance Gain: %u", st.awb_gain);
   ESP_LOGCONFIG(TAG,
@@ -349,6 +351,9 @@ void ESP32Camera::set_frame_buffer_mode(camera_grab_mode_t mode) { this->config_
 void ESP32Camera::set_frame_buffer_count(uint8_t fb_count) {
   this->config_.fb_count = fb_count;
   this->set_frame_buffer_mode(fb_count > 1 ? CAMERA_GRAB_LATEST : CAMERA_GRAB_WHEN_EMPTY);
+}
+void ESP32Camera::set_frame_buffer_location(camera_fb_location_t fb_location) {
+  this->config_.fb_location = fb_location;
 }
 
 /* ---------------- public API (specific) ---------------- */

--- a/esphome/components/esp32_camera/esp32_camera.h
+++ b/esphome/components/esp32_camera/esp32_camera.h
@@ -152,6 +152,7 @@ class ESP32Camera : public camera::Camera {
   /* -- frame buffer */
   void set_frame_buffer_mode(camera_grab_mode_t mode);
   void set_frame_buffer_count(uint8_t fb_count);
+  void set_frame_buffer_location(camera_fb_location_t fb_location);
 
   /* public API (derivated) */
   void setup() override;

--- a/tests/components/esp32_camera/common.yaml
+++ b/tests/components/esp32_camera/common.yaml
@@ -22,6 +22,7 @@ esp32_camera:
   power_down_pin: 1
   resolution: 640x480
   jpeg_quality: 10
+  frame_buffer_location: PSRAM
   on_image:
     then:
       - lambda: |-


### PR DESCRIPTION

# What does this implement/fix?

Introduced a configurable frame buffer location using the new camera_fb_location_t enum and CONF_FRAME_BUFFER_LOCATION setting, defaulting to PSRAM.


_Requested by @jesserockz [here](https://github.com/esphome/esphome-docs/pull/5115#discussion_r2214040620)_

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/MichaKersloot/esphome_custom_components/issues/2

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#5129

## Test Environment

@MichaKersloot please review and test.

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
