### PR TITLE
[wireguard] Fix boot loop when CONFIG_LWIP_TCPIP_CORE_LOCKING is enabled

### DIFF
--- a/esphome/components/wireguard/wireguard.cpp
+++ b/esphome/components/wireguard/wireguard.cpp
@@ -8,6 +8,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/time.h"
 #include "esphome/components/network/util.h"
+#include "esphome/core/helpers.h"
 
 #include <esp_wireguard.h>
 #include <esp_wireguard_err.h>
@@ -42,7 +43,10 @@ void Wireguard::setup() {
 
   this->publish_enabled_state();
 
-  this->wg_initialized_ = esp_wireguard_init(&(this->wg_config_), &(this->wg_ctx_));
+  {
+    LwIPLock lock;
+    this->wg_initialized_ = esp_wireguard_init(&(this->wg_config_), &(this->wg_ctx_));
+  }
 
   if (this->wg_initialized_ == ESP_OK) {
     ESP_LOGI(TAG, "Initialized");
@@ -249,7 +253,10 @@ void Wireguard::start_connection_() {
   }
 
   ESP_LOGD(TAG, "Starting connection");
-  this->wg_connected_ = esp_wireguard_connect(&(this->wg_ctx_));
+  {
+    LwIPLock lock;
+    this->wg_connected_ = esp_wireguard_connect(&(this->wg_ctx_));
+  }
 
   if (this->wg_connected_ == ESP_OK) {
     ESP_LOGI(TAG, "Connection started");
@@ -280,7 +287,10 @@ void Wireguard::start_connection_() {
 void Wireguard::stop_connection_() {
   if (this->wg_initialized_ == ESP_OK && this->wg_connected_ == ESP_OK) {
     ESP_LOGD(TAG, "Stopping connection");
-    esp_wireguard_disconnect(&(this->wg_ctx_));
+    {
+      LwIPLock lock;
+      esp_wireguard_disconnect(&(this->wg_ctx_));
+    }
     this->wg_connected_ = ESP_FAIL;
   }
 }


### PR DESCRIPTION
~~**Note:** I don't have an ESP that is able to access any of my current WireGuard setups to test this fix. The change follows the same pattern used in other ESPHome components (WiFi, Ethernet, MQTT, E131) that require TCPIP core locking. Testing by someone with a WireGuard configuration would be appreciated.~~ Was tested in https://github.com/esphome/esphome/issues/9619#issuecomment-3085673764

# What does this implement/fix?

This PR fixes a boot loop issue with the WireGuard component on ESP32 when `CONFIG_LWIP_TCPIP_CORE_LOCKING` is enabled. The device would crash during WireGuard initialization with the following assertion failure:

```
assert failed: udp_new_ip_type /IDF/components/lwip/lwip/src/core/udp.c:1277 (Required to lock TCPIP core functionality!)
```

The issue occurs because the WireGuard component calls esp_wireguard library functions that create and manage UDP sockets without proper TCPIP core locking. When `CONFIG_LWIP_TCPIP_CORE_LOCKING` is enabled (which happens with certain ESP-IDF configurations), lwIP enforces that UDP operations must be called from the TCPIP thread or with proper locking.

This PR adds `LwIPLock` RAII guards around the critical esp_wireguard calls that perform UDP socket operations:
- `esp_wireguard_init()` - Creates the UDP socket
- `esp_wireguard_connect()` - Connects the UDP socket
- `esp_wireguard_disconnect()` - Closes the UDP socket

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/9619

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no documentation changes needed)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).