### PR TITLE
[api] Fix compilation error with char* lambdas in HomeAssistant services

### DIFF
--- a/esphome/components/api/homeassistant_service.h
+++ b/esphome/components/api/homeassistant_service.h
@@ -17,7 +17,7 @@ template<typename... X> class TemplatableStringValue : public TemplatableValue<s
 
   // Overloads for string types - needed because std::to_string doesn't support them
   static std::string value_to_string(char *val) {
-    return std::string(val);
+    return val ? std::string(val) : std::string();
   }  // For lambdas returning char* (e.g., itoa)
   static std::string value_to_string(const char *val) { return std::string(val); }  // For lambdas returning .c_str()
   static std::string value_to_string(const std::string &val) { return val; }

--- a/esphome/components/api/homeassistant_service.h
+++ b/esphome/components/api/homeassistant_service.h
@@ -16,6 +16,9 @@ template<typename... X> class TemplatableStringValue : public TemplatableValue<s
   template<typename T> static std::string value_to_string(T &&val) { return to_string(std::forward<T>(val)); }
 
   // Overloads for string types - needed because std::to_string doesn't support them
+  static std::string value_to_string(char *val) {
+    return std::string(val);
+  }  // For lambdas returning char* (e.g., itoa)
   static std::string value_to_string(const char *val) { return std::string(val); }  // For lambdas returning .c_str()
   static std::string value_to_string(const std::string &val) { return val; }
   static std::string value_to_string(std::string &&val) { return std::move(val); }

--- a/tests/integration/fixtures/api_string_lambda.yaml
+++ b/tests/integration/fixtures/api_string_lambda.yaml
@@ -60,5 +60,28 @@ api:
             data:
               value: !lambda 'return input_float;'
 
+    # Service that tests char* lambda functionality (e.g., from itoa or sprintf)
+    - action: test_char_ptr_lambda
+      variables:
+        input_number: int
+        input_string: string
+      then:
+        # Log the input to verify service was called
+        - logger.log:
+            format: "Service called with number for char* test: %d"
+            args: [input_number]
+
+        # Test that char* lambdas work correctly
+        # This would fail in issue #9628 with "invalid conversion from 'char*' to 'long long unsigned int'"
+        - homeassistant.event:
+            event: esphome.test_char_ptr_lambda
+            data:
+              # Test snprintf returning char*
+              decimal_value: !lambda 'static char buffer[20]; snprintf(buffer, sizeof(buffer), "%d", input_number); return buffer;'
+              # Test strdup returning char* (dynamically allocated)
+              string_copy: !lambda 'return strdup(input_string.c_str());'
+              # Test string literal (const char*)
+              literal: !lambda 'return "test literal";'
+
 logger:
   level: DEBUG

--- a/tests/integration/test_api_string_lambda.py
+++ b/tests/integration/test_api_string_lambda.py
@@ -19,15 +19,17 @@ async def test_api_string_lambda(
     """Test TemplatableStringValue works with lambdas that return different types."""
     loop = asyncio.get_running_loop()
 
-    # Track log messages for all three service calls
+    # Track log messages for all four service calls
     string_called_future = loop.create_future()
     int_called_future = loop.create_future()
     float_called_future = loop.create_future()
+    char_ptr_called_future = loop.create_future()
 
     # Patterns to match in logs - confirms the lambdas compiled and executed
     string_pattern = re.compile(r"Service called with string: STRING_FROM_LAMBDA")
     int_pattern = re.compile(r"Service called with int: 42")
     float_pattern = re.compile(r"Service called with float: 3\.14")
+    char_ptr_pattern = re.compile(r"Service called with number for char\* test: 123")
 
     def check_output(line: str) -> None:
         """Check log output for expected messages."""
@@ -37,6 +39,8 @@ async def test_api_string_lambda(
             int_called_future.set_result(True)
         if not float_called_future.done() and float_pattern.search(line):
             float_called_future.set_result(True)
+        if not char_ptr_called_future.done() and char_ptr_pattern.search(line):
+            char_ptr_called_future.set_result(True)
 
     # Run with log monitoring
     async with (
@@ -65,17 +69,28 @@ async def test_api_string_lambda(
         )
         assert float_service is not None, "test_float_lambda service not found"
 
-        # Execute all three services to test different lambda return types
+        char_ptr_service = next(
+            (s for s in services if s.name == "test_char_ptr_lambda"), None
+        )
+        assert char_ptr_service is not None, "test_char_ptr_lambda service not found"
+
+        # Execute all four services to test different lambda return types
         client.execute_service(string_service, {"input_string": "STRING_FROM_LAMBDA"})
         client.execute_service(int_service, {"input_number": 42})
         client.execute_service(float_service, {"input_float": 3.14})
+        client.execute_service(
+            char_ptr_service, {"input_number": 123, "input_string": "test_string"}
+        )
 
         # Wait for all service log messages
         # This confirms the lambdas compiled successfully and executed
         try:
             await asyncio.wait_for(
                 asyncio.gather(
-                    string_called_future, int_called_future, float_called_future
+                    string_called_future,
+                    int_called_future,
+                    float_called_future,
+                    char_ptr_called_future,
                 ),
                 timeout=5.0,
             )


### PR DESCRIPTION
# What does this implement/fix?

This PR fixes a compilation error when using lambdas that return `char*` (non-const) in HomeAssistant service calls. The issue occurs when using functions like `itoa()` which return a non-const `char*`, causing a template instantiation error because the existing overloads only handled `const char*`.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/9628

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no documentation changes needed)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example configuration that previously failed to compile
rf_bridge:
  on_advanced_code_received:
    then:
      - homeassistant.event:
          event: esphome.rf_advanced_code_received
          data:
            # This lambda returns char* from itoa, which now compiles correctly
            length: !lambda 'char buffer[10]; return itoa(data.length, buffer, 16);'
            protocol: !lambda 'char buffer[10]; return itoa(data.protocol, buffer, 16);'
            code: !lambda 'return data.code;'
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

## Additional Notes

This extends the fix from PR #9543 which added support for `const char*` and `std::string` returns. This PR adds support for non-const `char*` returns, completing the coverage of common string return types from lambdas.

The fix is minimal - just one line adding an overload for `char*` to match the existing `const char*` overload. An integration test has been added to `tests/integration/fixtures/api_string_lambda.yaml` to ensure this case is covered.