### PR TITLE
[scheduler] Fix cancellation of timers with empty string names

### DIFF
--- a/esphome/core/component.cpp
+++ b/esphome/core/component.cpp
@@ -255,10 +255,10 @@ void Component::defer(const char *name, std::function<void()> &&f) {  // NOLINT
   App.scheduler.set_timeout(this, name, 0, std::move(f));
 }
 void Component::set_timeout(uint32_t timeout, std::function<void()> &&f) {  // NOLINT
-  App.scheduler.set_timeout(this, "", timeout, std::move(f));
+  App.scheduler.set_timeout(this, static_cast<const char *>(nullptr), timeout, std::move(f));
 }
 void Component::set_interval(uint32_t interval, std::function<void()> &&f) {  // NOLINT
-  App.scheduler.set_interval(this, "", interval, std::move(f));
+  App.scheduler.set_interval(this, static_cast<const char *>(nullptr), interval, std::move(f));
 }
 void Component::set_retry(uint32_t initial_wait_time, uint8_t max_attempts, std::function<RetryResult(uint8_t)> &&f,
                           float backoff_increase_factor) {  // NOLINT

--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -452,7 +452,7 @@ bool HOT Scheduler::cancel_item_(Component *component, bool is_static_string, co
 // Helper to cancel items by name - must be called with lock held
 bool HOT Scheduler::cancel_item_locked_(Component *component, const char *name_cstr, SchedulerItem::Type type) {
   // Early return if name is invalid - no items to cancel
-  if (name_cstr == nullptr || name_cstr[0] == '\0') {
+  if (name_cstr == nullptr) {
     return false;
   }
 

--- a/esphome/core/scheduler.h
+++ b/esphome/core/scheduler.h
@@ -121,16 +121,17 @@ class Scheduler {
         name_is_dynamic = false;
       }
 
-      if (!name || !name[0]) {
+      if (!name) {
+        // nullptr case - no name provided
         name_.static_name = nullptr;
       } else if (make_copy) {
-        // Make a copy for dynamic strings
+        // Make a copy for dynamic strings (including empty strings)
         size_t len = strlen(name);
         name_.dynamic_name = new char[len + 1];
         memcpy(name_.dynamic_name, name, len + 1);
         name_is_dynamic = true;
       } else {
-        // Use static string directly
+        // Use static string directly (including empty strings)
         name_.static_name = name;
       }
     }

--- a/tests/integration/fixtures/scheduler_string_test.yaml
+++ b/tests/integration/fixtures/scheduler_string_test.yaml
@@ -4,9 +4,7 @@ esphome:
     priority: -100
     then:
       - logger.log: "Starting scheduler string tests"
-  platformio_options:
-    build_flags:
-      - "-DESPHOME_DEBUG_SCHEDULER"  # Enable scheduler debug logging
+  debug_scheduler: true  # Enable scheduler debug logging
 
 host:
 api:
@@ -30,6 +28,12 @@ globals:
     type: bool
     initial_value: 'false'
   - id: results_reported
+    type: bool
+    initial_value: 'false'
+  - id: edge_tests_done
+    type: bool
+    initial_value: 'false'
+  - id: empty_cancel_failed
     type: bool
     initial_value: 'false'
 
@@ -147,11 +151,105 @@ script:
           static TestDynamicDeferComponent test_dynamic_defer_component;
           test_dynamic_defer_component.test_dynamic_defer();
 
+  - id: test_cancellation_edge_cases
+    then:
+      - logger.log: "Testing cancellation edge cases"
+      - lambda: |-
+          auto *component1 = id(test_sensor1);
+          // Use a different component for empty string tests to avoid interference
+          auto *component2 = id(test_sensor2);
+
+          // Test 12: Cancel with empty string - regression test for issue #9599
+          // First create a timeout with empty name on component2 to avoid interference
+          App.scheduler.set_timeout(component2, "", 500, []() {
+            ESP_LOGE("test", "ERROR: Empty name timeout fired - it should have been cancelled!");
+            id(empty_cancel_failed) = true;
+          });
+
+          // Now cancel it - this should work after our fix
+          bool cancelled_empty = App.scheduler.cancel_timeout(component2, "");
+          ESP_LOGI("test", "Cancel empty string result: %s (should be true)", cancelled_empty ? "true" : "false");
+          if (!cancelled_empty) {
+            ESP_LOGE("test", "ERROR: Failed to cancel empty string timeout!");
+            id(empty_cancel_failed) = true;
+          }
+
+          // Test 13: Cancel non-existent timeout
+          bool cancelled_nonexistent = App.scheduler.cancel_timeout(component1, "does_not_exist");
+          ESP_LOGI("test", "Cancel non-existent timeout result: %s",
+                   cancelled_nonexistent ? "true (unexpected!)" : "false (expected)");
+
+          // Test 14: Multiple timeouts with same name - only last should execute
+          for (int i = 0; i < 5; i++) {
+            App.scheduler.set_timeout(component1, "duplicate_timeout", 200 + i*10, [i]() {
+              ESP_LOGI("test", "Duplicate timeout %d fired", i);
+              id(timeout_counter) += 1;
+            });
+          }
+          ESP_LOGI("test", "Created 5 timeouts with same name 'duplicate_timeout'");
+
+          // Test 15: Multiple intervals with same name - only last should run
+          for (int i = 0; i < 3; i++) {
+            App.scheduler.set_interval(component1, "duplicate_interval", 300, [i]() {
+              ESP_LOGI("test", "Duplicate interval %d fired", i);
+              id(interval_counter) += 10; // Large increment to detect multiple
+              // Cancel after first execution
+              App.scheduler.cancel_interval(id(test_sensor1), "duplicate_interval");
+            });
+          }
+          ESP_LOGI("test", "Created 3 intervals with same name 'duplicate_interval'");
+
+          // Test 16: Cancel with nullptr protection (via empty const char*)
+          const char* null_name = "";
+          App.scheduler.set_timeout(component2, null_name, 600, []() {
+            ESP_LOGE("test", "ERROR: Const char* empty timeout fired - should have been cancelled!");
+            id(empty_cancel_failed) = true;
+          });
+          bool cancelled_const_empty = App.scheduler.cancel_timeout(component2, null_name);
+          ESP_LOGI("test", "Cancel const char* empty result: %s (should be true)",
+                   cancelled_const_empty ? "true" : "false");
+          if (!cancelled_const_empty) {
+            ESP_LOGE("test", "ERROR: Failed to cancel const char* empty timeout!");
+            id(empty_cancel_failed) = true;
+          }
+
+          // Test 17: Rapid create/cancel/create with same name
+          App.scheduler.set_timeout(component1, "rapid_test", 5000, []() {
+            ESP_LOGI("test", "First rapid timeout - should not fire");
+            id(timeout_counter) += 100;
+          });
+          App.scheduler.cancel_timeout(component1, "rapid_test");
+          App.scheduler.set_timeout(component1, "rapid_test", 250, []() {
+            ESP_LOGI("test", "Second rapid timeout - should fire");
+            id(timeout_counter) += 1;
+          });
+
+          // Test 18: Cancel all with a specific name (multiple instances)
+          // Create multiple with same name
+          App.scheduler.set_timeout(component1, "multi_cancel", 300, []() {
+            ESP_LOGI("test", "Multi-cancel timeout 1");
+          });
+          App.scheduler.set_timeout(component1, "multi_cancel", 350, []() {
+            ESP_LOGI("test", "Multi-cancel timeout 2");
+          });
+          App.scheduler.set_timeout(component1, "multi_cancel", 400, []() {
+            ESP_LOGI("test", "Multi-cancel timeout 3 - only this should fire");
+            id(timeout_counter) += 1;
+          });
+          // Note: Each set_timeout with same name cancels the previous one automatically
+
   - id: report_results
     then:
       - lambda: |-
           ESP_LOGI("test", "Final results - Timeouts: %d, Intervals: %d",
                    id(timeout_counter), id(interval_counter));
+
+          // Check if empty string cancellation test passed
+          if (id(empty_cancel_failed)) {
+            ESP_LOGE("test", "ERROR: Empty string cancellation test FAILED!");
+          } else {
+            ESP_LOGI("test", "Empty string cancellation test PASSED");
+          }
 
 sensor:
   - platform: template
@@ -189,12 +287,23 @@ interval:
             - delay: 0.2s
             - script.execute: test_dynamic_strings
 
+  # Run cancellation edge case tests after dynamic tests
+  - interval: 0.2s
+    then:
+      - if:
+          condition:
+            lambda: 'return id(dynamic_tests_done) && !id(edge_tests_done);'
+          then:
+            - lambda: 'id(edge_tests_done) = true;'
+            - delay: 0.5s
+            - script.execute: test_cancellation_edge_cases
+
   # Report results after all tests
   - interval: 0.2s
     then:
       - if:
           condition:
-            lambda: 'return id(dynamic_tests_done) && !id(results_reported);'
+            lambda: 'return id(edge_tests_done) && !id(results_reported);'
           then:
             - lambda: 'id(results_reported) = true;'
             - delay: 1s

--- a/tests/integration/test_scheduler_heap_stress.py
+++ b/tests/integration/test_scheduler_heap_stress.py
@@ -103,13 +103,14 @@ async def test_scheduler_heap_stress(
 
         # Wait for all callbacks to execute (should be quick, but give more time for scheduling)
         try:
-            await asyncio.wait_for(test_complete_future, timeout=60.0)
+            await asyncio.wait_for(test_complete_future, timeout=10.0)
         except TimeoutError:
             # Report how many we got
+            missing_ids = sorted(set(range(1000)) - executed_callbacks)
             pytest.fail(
                 f"Stress test timed out. Only {len(executed_callbacks)} of "
                 f"1000 callbacks executed. Missing IDs: "
-                f"{sorted(set(range(1000)) - executed_callbacks)[:10]}..."
+                f"{missing_ids[:20]}... (total missing: {len(missing_ids)})"
             )
 
         # Verify all callbacks executed


### PR DESCRIPTION
# What does this implement/fix?

This PR fixes a regression introduced in #9251 where timers/timeouts with empty string names could not be cancelled. This broke the `script` component's restart mode functionality, which relies on cancelling timers with empty names.

The issue had three parts:
1. The `cancel_item_locked_` function was rejecting empty string names (`""`) due to an overly restrictive check
2. The `set_name()` function was incorrectly converting empty strings to `nullptr`, conflating "no name" with "empty name"
3. The Component methods `set_timeout()` and `set_interval()` without name parameters were incorrectly passing `""` instead of `nullptr`

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes partially #9599

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no documentation changes needed)

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

Tested on ESP32 and host platform (integration tests).

## Example entry for `config.yaml`:

```yaml
# Example demonstrating the issue - script restart mode
script:
  - id: test_restart
    mode: restart  # This mode was broken
    then:
      - delay: 5s
      - logger.log: "Script completed"

button:
  - platform: template
    name: "Trigger Script"
    on_press:
      - script.execute: test_restart  # Pressing again should restart
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

## Additional Details

### Root Cause
There were two separate issues:

1. **Empty string handling**: The `set_name()` function was treating empty strings (`""`) and `nullptr` as the same thing, converting both to `nullptr`. This prevented proper cancellation because:
   - Creating a timer with `""` would store `nullptr` as the name
   - Cancelling with `""` would look for a timer with name `""`, not `nullptr`
   - The match would fail, leaving the timer active

2. **Component API inconsistency**: The no-name overloads were passing `""` instead of `nullptr`, which is semantically incorrect:
   - `nullptr` means "no name" (timer cannot be cancelled)
   - `""` means "empty name" (timer can be cancelled with empty string)

### Fix
1. Removed the `name_cstr[0] == '\0'` check from `cancel_item_locked_` that was preventing empty string cancellations
2. Modified `set_name()` to preserve the distinction between `nullptr` (no name) and `""` (empty name)
3. Fixed Component methods to pass `nullptr` instead of `""` when no name is provided:
   - `set_timeout(timeout, func)` now correctly passes `nullptr`
   - `set_interval(interval, func)` now correctly passes `nullptr`
   - `set_retry()` continues to use `""` as intended for unnamed retries

### Testing
Added comprehensive tests in `scheduler_string_test.yaml` covering:
- Cancelling timers with empty string names
- Cancelling non-existent timers
- Cancelling multiple timers with the same name
- Edge cases around cancellation

The tests verify that empty string timers can be properly cancelled, fixing the script restart mode regression.