### PR TITLE
[logger] fix on_message

### DIFF
--- a/esphome/components/logger/__init__.py
+++ b/esphome/components/logger/__init__.py
@@ -193,7 +193,7 @@ def validate_local_no_higher_than_global(value):
 Logger = logger_ns.class_("Logger", cg.Component)
 LoggerMessageTrigger = logger_ns.class_(
     "LoggerMessageTrigger",
-    automation.Trigger.template(cg.int_, cg.const_char_ptr, cg.const_char_ptr),
+    automation.Trigger.template(cg.uint8, cg.const_char_ptr, cg.const_char_ptr),
 )
 
 
@@ -390,7 +390,7 @@ async def to_code(config):
         await automation.build_automation(
             trigger,
             [
-                (cg.int_, "level"),
+                (cg.uint8, "level"),
                 (cg.const_char_ptr, "tag"),
                 (cg.const_char_ptr, "message"),
             ],

--- a/tests/components/logger/test-on_message.host.yaml
+++ b/tests/components/logger/test-on_message.host.yaml
@@ -1,0 +1,18 @@
+logger:
+  id: logger_id
+  level: DEBUG
+  on_message:
+    - level: DEBUG
+      then:
+        - lambda: |-
+            ESP_LOGD("test", "Got message level %d: %s - %s", level, tag, message);
+    - level: WARN
+      then:
+        - lambda: |-
+            ESP_LOGW("test", "Warning level %d from %s", level, tag);
+    - level: ERROR
+      then:
+        - lambda: |-
+            // Test that level is uint8_t by using it in calculations
+            uint8_t adjusted_level = level + 1;
+            ESP_LOGE("test", "Error with adjusted level %d", adjusted_level);


### PR DESCRIPTION
# What does this implement/fix?

The level changed to a `uint8_t` which breaks the `on_message` code generation.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/9592

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
