### PR TITLE
[libretiny] Remove unsupported lock-free queue and event pool implementations

### DIFF
--- a/esphome/core/event_pool.h
+++ b/esphome/core/event_pool.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#if defined(USE_ESP32) || defined(USE_LIBRETINY)
+#if defined(USE_ESP32)
 
 #include <atomic>
 #include <cstddef>
@@ -78,4 +78,4 @@ template<class T, uint8_t SIZE> class EventPool {
 
 }  // namespace esphome
 
-#endif  // defined(USE_ESP32) || defined(USE_LIBRETINY)
+#endif  // defined(USE_ESP32)

--- a/esphome/core/lock_free_queue.h
+++ b/esphome/core/lock_free_queue.h
@@ -1,17 +1,12 @@
 #pragma once
 
-#if defined(USE_ESP32) || defined(USE_LIBRETINY)
+#if defined(USE_ESP32)
 
 #include <atomic>
 #include <cstddef>
 
-#if defined(USE_ESP32)
 #include <freertos/FreeRTOS.h>
 #include <freertos/task.h>
-#elif defined(USE_LIBRETINY)
-#include <FreeRTOS.h>
-#include <task.h>
-#endif
 
 /*
  * Lock-free queue for single-producer single-consumer scenarios.
@@ -148,4 +143,4 @@ template<class T, uint8_t SIZE> class NotifyingLockFreeQueue : public LockFreeQu
 
 }  // namespace esphome
 
-#endif  // defined(USE_ESP32) || defined(USE_LIBRETINY)
+#endif  // defined(USE_ESP32)


### PR DESCRIPTION
# What does this implement/fix?

Remove LibreTiny support from lock-free queue and event pool implementations to fix compilation errors on RTL87XX platforms.

LibreTiny platforms don't have working atomics and these implementations aren't used on LibreTiny anyway. This change prevents compilation failures due to missing FreeRTOS headers (might actually be incorrect headers but moot anyways) on LibreTiny/RTL87XX platforms.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/9545

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal implementation change)

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx (Fix based on issue report - no RTL87xx hardware available for testing)
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

Note: This is a safe change that removes unused code paths. The lock-free implementations were not being used on LibreTiny platforms, and LibreTiny lacks working atomics required for these implementations.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).