### PR TITLE
[lvgl] Prevent keyerror on min/max value widgets with no default

### DIFF
--- a/esphome/components/lvgl/types.py
+++ b/esphome/components/lvgl/types.py
@@ -192,7 +192,7 @@ class WidgetType:
 
 class NumberType(WidgetType):
     def get_max(self, config: dict):
-        return int(config[CONF_MAX_VALUE] or 100)
+        return int(config.get(CONF_MAX_VALUE, 100))
 
     def get_min(self, config: dict):
-        return int(config[CONF_MIN_VALUE] or 0)
+        return int(config.get(CONF_MIN_VALUE, 0))


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes #9659

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
