### PR TITLE
Optional Write enable, hardware echo, custom switches

### DIFF
--- a/esphome/components/micronova/__init__.py
+++ b/esphome/components/micronova/__init__.py
@@ -10,6 +10,7 @@ DEPENDENCIES = ["uart"]
 
 CONF_MICRONOVA_ID = "micronova_id"
 CONF_ENABLE_RX_PIN = "enable_rx_pin"
+CONF_UART_ECHO = "uart_echo"
 CONF_MEMORY_LOCATION = "memory_location"
 CONF_MEMORY_ADDRESS = "memory_address"
 
@@ -18,6 +19,7 @@ micronova_ns = cg.esphome_ns.namespace("micronova")
 MicroNovaFunctions = micronova_ns.enum("MicroNovaFunctions", is_class=True)
 MICRONOVA_FUNCTIONS_ENUM = {
     "STOVE_FUNCTION_SWITCH": MicroNovaFunctions.STOVE_FUNCTION_SWITCH,
+    "STOVE_FUNCTION_SWITCH_CUSTOM": MicroNovaFunctions.STOVE_FUNCTION_SWITCH_CUSTOM,
     "STOVE_FUNCTION_ROOM_TEMPERATURE": MicroNovaFunctions.STOVE_FUNCTION_ROOM_TEMPERATURE,
     "STOVE_FUNCTION_THERMOSTAT_TEMPERATURE": MicroNovaFunctions.STOVE_FUNCTION_THERMOSTAT_TEMPERATURE,
     "STOVE_FUNCTION_FUMES_TEMPERATURE": MicroNovaFunctions.STOVE_FUNCTION_FUMES_TEMPERATURE,
@@ -37,7 +39,8 @@ CONFIG_SCHEMA = (
     cv.Schema(
         {
             cv.GenerateID(): cv.declare_id(MicroNova),
-            cv.Required(CONF_ENABLE_RX_PIN): pins.gpio_output_pin_schema,
+            cv.Optional(CONF_ENABLE_RX_PIN): pins.gpio_output_pin_schema,
+            cv.Optional(CONF_UART_ECHO, default=False): cv.boolean,
         }
     )
     .extend(uart.UART_DEVICE_SCHEMA)
@@ -63,5 +66,7 @@ async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
     await uart.register_uart_device(var, config)
-    enable_rx_pin = await cg.gpio_pin_expression(config[CONF_ENABLE_RX_PIN])
-    cg.add(var.set_enable_rx_pin(enable_rx_pin))
+    if CONF_ENABLE_RX_PIN in config:
+        enable_rx_pin = await cg.gpio_pin_expression(config[CONF_ENABLE_RX_PIN])
+        cg.add(var.set_enable_rx_pin(enable_rx_pin))
+    cg.add(var.set_uart_echo(config[CONF_UART_ECHO]))

--- a/esphome/components/micronova/micronova.cpp
+++ b/esphome/components/micronova/micronova.cpp
@@ -78,11 +78,14 @@ void MicroNova::request_address(uint8_t location, uint8_t address, MicroNovaSens
     write_data[1] = address;
     ESP_LOGV(TAG, "Request from stove [%02X,%02X]", write_data[0], write_data[1]);
 
-    if (this->enable_rx_pin_ != nullptr) this->enable_rx_pin_->digital_write(true);
+    if (this->enable_rx_pin_ != nullptr)
+      this->enable_rx_pin_->digital_write(true);
     this->write_array(write_data, 2);
     this->flush();
-    if (this->enable_rx_pin_ != nullptr) this->enable_rx_pin_->digital_write(false);
-    if (this->uart_echo_) this->read_array(write_data, 2);
+    if (this->enable_rx_pin_ != nullptr)
+      this->enable_rx_pin_->digital_write(false);
+    if (this->uart_echo_)
+      this->read_array(write_data, 2);
 
     this->current_transmission_.request_transmission_time = millis();
     this->current_transmission_.memory_location = location;
@@ -130,14 +133,18 @@ void MicroNova::write_address(uint8_t location, uint8_t address, uint8_t data) {
 
     ESP_LOGV(TAG, "Write 4 bytes [%02X,%02X,%02X,%02X]", write_data[0], write_data[1], write_data[2], write_data[3]);
 
-    if (this->enable_rx_pin_ != nullptr) this->enable_rx_pin_->digital_write(true);
+    if (this->enable_rx_pin_ != nullptr)
+      this->enable_rx_pin_->digital_write(true);
     this->write_array(write_data, 4);
     this->flush();
-    if (this->enable_rx_pin_ != nullptr) this->enable_rx_pin_->digital_write(false);
-    if (this->uart_echo_) this->read_array(write_data, 4);
+    if (this->enable_rx_pin_ != nullptr)
+      this->enable_rx_pin_->digital_write(false);
+    if (this->uart_echo_)
+      this->read_array(write_data, 4);
 
     this->current_transmission_.request_transmission_time = millis();
-    this->current_transmission_.memory_location = location | 0x80;;
+    this->current_transmission_.memory_location = location | 0x80;
+    ;
     this->current_transmission_.memory_address = address;
     this->current_transmission_.reply_pending = true;
     this->current_transmission_.initiating_listener = nullptr;

--- a/esphome/components/micronova/micronova.cpp
+++ b/esphome/components/micronova/micronova.cpp
@@ -78,10 +78,11 @@ void MicroNova::request_address(uint8_t location, uint8_t address, MicroNovaSens
     write_data[1] = address;
     ESP_LOGV(TAG, "Request from stove [%02X,%02X]", write_data[0], write_data[1]);
 
-    this->enable_rx_pin_->digital_write(true);
+    if (this->enable_rx_pin_ != nullptr) this->enable_rx_pin_->digital_write(true);
     this->write_array(write_data, 2);
     this->flush();
-    this->enable_rx_pin_->digital_write(false);
+    if (this->enable_rx_pin_ != nullptr) this->enable_rx_pin_->digital_write(false);
+    if (this->uart_echo_) this->read_array(write_data, 2);
 
     this->current_transmission_.request_transmission_time = millis();
     this->current_transmission_.memory_location = location;
@@ -120,7 +121,7 @@ void MicroNova::write_address(uint8_t location, uint8_t address, uint8_t data) {
   uint16_t checksum = 0;
 
   if (this->reply_pending_mutex_.try_lock()) {
-    write_data[0] = location;
+    write_data[0] = location | 0x80;
     write_data[1] = address;
     write_data[2] = data;
 
@@ -129,13 +130,14 @@ void MicroNova::write_address(uint8_t location, uint8_t address, uint8_t data) {
 
     ESP_LOGV(TAG, "Write 4 bytes [%02X,%02X,%02X,%02X]", write_data[0], write_data[1], write_data[2], write_data[3]);
 
-    this->enable_rx_pin_->digital_write(true);
+    if (this->enable_rx_pin_ != nullptr) this->enable_rx_pin_->digital_write(true);
     this->write_array(write_data, 4);
     this->flush();
-    this->enable_rx_pin_->digital_write(false);
+    if (this->enable_rx_pin_ != nullptr) this->enable_rx_pin_->digital_write(false);
+    if (this->uart_echo_) this->read_array(write_data, 4);
 
     this->current_transmission_.request_transmission_time = millis();
-    this->current_transmission_.memory_location = location;
+    this->current_transmission_.memory_location = location | 0x80;;
     this->current_transmission_.memory_address = address;
     this->current_transmission_.reply_pending = true;
     this->current_transmission_.initiating_listener = nullptr;

--- a/esphome/components/micronova/micronova.h
+++ b/esphome/components/micronova/micronova.h
@@ -134,7 +134,7 @@ class MicroNova : public PollingComponent, public uart::UARTDevice {
   int read_stove_reply();
 
   void set_enable_rx_pin(GPIOPin *enable_rx_pin) { this->enable_rx_pin_ = enable_rx_pin; }
-  void set_uart_echo(bool x) { this->uart_echo_ = x;}
+  void set_uart_echo(bool x) { this->uart_echo_ = x; }
 
   void set_current_stove_state(uint8_t s) { this->current_stove_state_ = s; }
   uint8_t get_current_stove_state() { return this->current_stove_state_; }

--- a/esphome/components/micronova/micronova.h
+++ b/esphome/components/micronova/micronova.h
@@ -39,7 +39,8 @@ enum class MicroNovaFunctions {
   STOVE_FUNCTION_WATER_TEMPERATURE = 9,
   STOVE_FUNCTION_WATER_PRESSURE = 10,
   STOVE_FUNCTION_POWER_LEVEL = 11,
-  STOVE_FUNCTION_CUSTOM = 12
+  STOVE_FUNCTION_CUSTOM = 12,
+  STOVE_FUNCTION_SWITCH_CUSTOM = 13
 };
 
 class MicroNova;
@@ -133,6 +134,7 @@ class MicroNova : public PollingComponent, public uart::UARTDevice {
   int read_stove_reply();
 
   void set_enable_rx_pin(GPIOPin *enable_rx_pin) { this->enable_rx_pin_ = enable_rx_pin; }
+  void set_uart_echo(bool x) { this->uart_echo_ = x;}
 
   void set_current_stove_state(uint8_t s) { this->current_stove_state_ = s; }
   uint8_t get_current_stove_state() { return this->current_stove_state_; }
@@ -144,6 +146,7 @@ class MicroNova : public PollingComponent, public uart::UARTDevice {
   uint8_t current_stove_state_ = 0;
 
   GPIOPin *enable_rx_pin_{nullptr};
+  bool uart_echo_{false};
 
   struct MicroNovaSerialTransmission {
     uint32_t request_transmission_time;

--- a/esphome/components/micronova/switch/__init__.py
+++ b/esphome/components/micronova/switch/__init__.py
@@ -16,8 +16,18 @@ from .. import (
 CONF_STOVE = "stove"
 CONF_MEMORY_DATA_ON = "memory_data_on"
 CONF_MEMORY_DATA_OFF = "memory_data_off"
+CONF_CUSTOM = "custom"
 
 MicroNovaSwitch = micronova_ns.class_("MicroNovaSwitch", switch.Switch, cg.Component)
+
+CUSTOM_SWITCH_SCHEMA = (
+    switch.switch_schema(MicroNovaSwitch)
+    .extend(MICRONOVA_LISTENER_SCHEMA(default_memory_location=0x00, default_memory_address=0x01))
+    .extend({
+        cv.Optional(CONF_MEMORY_DATA_OFF, default=0x01): cv.hex_int_range(),
+        cv.Optional(CONF_MEMORY_DATA_ON, default=0x01): cv.hex_int_range(),
+    })
+)
 
 CONFIG_SCHEMA = cv.Schema(
     {
@@ -37,6 +47,8 @@ CONFIG_SCHEMA = cv.Schema(
                 cv.Optional(CONF_MEMORY_DATA_ON, default=0x01): cv.hex_int_range(),
             }
         ),
+        cv.Optional(CONF_CUSTOM, default=[]): cv.ensure_list(CUSTOM_SWITCH_SCHEMA)
+
     }
 )
 
@@ -52,3 +64,11 @@ async def to_code(config):
         cg.add(sw.set_memory_data_on(stove_config[CONF_MEMORY_DATA_ON]))
         cg.add(sw.set_memory_data_off(stove_config[CONF_MEMORY_DATA_OFF]))
         cg.add(sw.set_function(MicroNovaFunctions.STOVE_FUNCTION_SWITCH))
+
+    for cfg in config[CONF_CUSTOM]:
+        sw = await switch.new_switch(cfg, mv)
+        cg.add(sw.set_memory_location(cfg[CONF_MEMORY_LOCATION]))
+        cg.add(sw.set_memory_address(cfg[CONF_MEMORY_ADDRESS]))
+        cg.add(sw.set_memory_data_on(cfg[CONF_MEMORY_DATA_ON]))
+        cg.add(sw.set_memory_data_off(cfg[CONF_MEMORY_DATA_OFF]))
+        cg.add(sw.set_function(MicroNovaFunctions.STOVE_FUNCTION_SWITCH_CUSTOM))

--- a/esphome/components/micronova/switch/__init__.py
+++ b/esphome/components/micronova/switch/__init__.py
@@ -22,11 +22,17 @@ MicroNovaSwitch = micronova_ns.class_("MicroNovaSwitch", switch.Switch, cg.Compo
 
 CUSTOM_SWITCH_SCHEMA = (
     switch.switch_schema(MicroNovaSwitch)
-    .extend(MICRONOVA_LISTENER_SCHEMA(default_memory_location=0x00, default_memory_address=0x01))
-    .extend({
-        cv.Optional(CONF_MEMORY_DATA_OFF, default=0x01): cv.hex_int_range(),
-        cv.Optional(CONF_MEMORY_DATA_ON, default=0x01): cv.hex_int_range(),
-    })
+    .extend(
+        MICRONOVA_LISTENER_SCHEMA(
+            default_memory_location=0x00, default_memory_address=0x01
+        )
+    )
+    .extend(
+        {
+            cv.Optional(CONF_MEMORY_DATA_OFF, default=0x01): cv.hex_int_range(),
+            cv.Optional(CONF_MEMORY_DATA_ON, default=0x01): cv.hex_int_range(),
+        }
+    )
 )
 
 CONFIG_SCHEMA = cv.Schema(
@@ -47,8 +53,7 @@ CONFIG_SCHEMA = cv.Schema(
                 cv.Optional(CONF_MEMORY_DATA_ON, default=0x01): cv.hex_int_range(),
             }
         ),
-        cv.Optional(CONF_CUSTOM, default=[]): cv.ensure_list(CUSTOM_SWITCH_SCHEMA)
-
+        cv.Optional(CONF_CUSTOM, default=[]): cv.ensure_list(CUSTOM_SWITCH_SCHEMA),
     }
 )
 

--- a/esphome/components/micronova/switch/micronova_switch.cpp
+++ b/esphome/components/micronova/switch/micronova_switch.cpp
@@ -26,6 +26,17 @@ void MicroNovaSwitch::write_state(bool state) {
       this->micronova_->update();
       break;
 
+    case MicroNovaFunctions::STOVE_FUNCTION_SWITCH_CUSTOM:
+      if (state) {
+        this->micronova_->write_address(this->memory_location_, this->memory_address_, this->memory_data_on_);
+        this->publish_state(true);
+      } else {
+        this->micronova_->write_address(this->memory_location_, this->memory_address_, this->memory_data_off_);
+        this->publish_state(false);
+      }
+      this->micronova_->update();
+      break;
+
     default:
       break;
   }

--- a/esphome/components/micronova/switch/micronova_switch.h
+++ b/esphome/components/micronova/switch/micronova_switch.h
@@ -17,6 +17,7 @@ class MicroNovaSwitch : public Component, public switch_::Switch, public MicroNo
 
   void set_memory_data_on(uint8_t f) { this->memory_data_on_ = f; }
   uint8_t get_memory_data_on() { return this->memory_data_on_; }
+  
 
   void set_memory_data_off(uint8_t f) { this->memory_data_off_ = f; }
   uint8_t get_memory_data_off() { return this->memory_data_off_; }

--- a/esphome/components/micronova/switch/micronova_switch.h
+++ b/esphome/components/micronova/switch/micronova_switch.h
@@ -17,7 +17,6 @@ class MicroNovaSwitch : public Component, public switch_::Switch, public MicroNo
 
   void set_memory_data_on(uint8_t f) { this->memory_data_on_ = f; }
   uint8_t get_memory_data_on() { return this->memory_data_on_; }
-  
 
   void set_memory_data_off(uint8_t f) { this->memory_data_off_ = f; }
   uint8_t get_memory_data_off() { return this->memory_data_off_; }


### PR DESCRIPTION
Optional Write enable,
Added option for boards that have an hardware ECHO 
Added custom switch

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**
Write fails without | 80 in the first bytes

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
micronova:
  update_interval: 10s
  uart_echo: true

switch:
  - platform: micronova
    custom:
      - name: Switch 1
        memory_location: 0x00
        memory_address: 0x28
        memory_data_on: 0x01
        memory_data_off: 0x00
      - name: Switch 2
        memory_location: 0x00
        memory_address: 0x29
        memory_data_on: 0x01
        memory_data_off: 0x00
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
