### PR TITLE
[speaker] Media player's pipeline properly returns playing state near end of file

### DIFF
--- a/esphome/components/speaker/media_player/audio_pipeline.cpp
+++ b/esphome/components/speaker/media_player/audio_pipeline.cpp
@@ -200,7 +200,7 @@ AudioPipelineState AudioPipeline::process_state() {
       if ((this->read_task_handle_ != nullptr) || (this->decode_task_handle_ != nullptr)) {
         this->delete_tasks_();
         if (this->hard_stop_) {
-          // Stop command was sent, so immediately end of the playback
+          // Stop command was sent, so immediately end the playback
           this->speaker_->stop();
           this->hard_stop_ = false;
         } else {
@@ -210,11 +210,23 @@ AudioPipelineState AudioPipeline::process_state() {
       }
     }
     this->is_playing_ = false;
-    return AudioPipelineState::STOPPED;
+    if (!this->speaker_->is_running()) {
+      return AudioPipelineState::STOPPED;
+    } else {
+      this->is_finishing_ = true;
+    }
   }
 
   if (this->pause_state_) {
     return AudioPipelineState::PAUSED;
+  }
+
+  if (this->is_finishing_) {
+    if (!this->speaker_->is_running()) {
+      this->is_finishing_ = false;
+    } else {
+      return AudioPipelineState::PLAYING;
+    }
   }
 
   if ((this->read_task_handle_ == nullptr) && (this->decode_task_handle_ == nullptr)) {

--- a/esphome/components/speaker/media_player/audio_pipeline.h
+++ b/esphome/components/speaker/media_player/audio_pipeline.h
@@ -114,6 +114,7 @@ class AudioPipeline {
 
   bool hard_stop_{false};
   bool is_playing_{false};
+  bool is_finishing_{false};
   bool pause_state_{false};
   bool task_stack_in_psram_;
 


### PR DESCRIPTION
# What does this implement/fix?

Currently, the speaker media player will change its state to stopped as soon as the file is decoded, but some audio will remains in the output speaker's buffer. This causes problems for the voice assistant when duplex audio isn't supported, as the microphone isn't able to start while the speaker is finishing.

This PR fixes that issue by tracking an ``is_finishing`` state, where it waits until the speaker indicates its done before changing the media player's state to stopped.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** not applicable

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** not applicable

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

media_player:
  - platform: speaker
    id: external_media_player
    name: Media Player
    internal: False
    volume_increment: 0.05
    volume_min: 0.4
    volume_max: 0.85
    announcement_pipeline:
      speaker: __OUTPUT_SPEAKER__
      format: FLAC
      num_channels: 1
      sample_rate: 48000

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
