### PR TITLE
[gpio] Disable interrupt mode by default for LibreTiny platforms

### DIFF
--- a/esphome/components/gpio/binary_sensor/__init__.py
+++ b/esphome/components/gpio/binary_sensor/__init__.py
@@ -38,6 +38,7 @@ CONFIG_SCHEMA = (
                 esp8266=True,
                 esp32=True,
                 rp2040=True,
+                nrf52=True,
                 bk72xx=False,
                 ln882x=False,
                 rtl87xx=False,

--- a/esphome/components/gpio/binary_sensor/__init__.py
+++ b/esphome/components/gpio/binary_sensor/__init__.py
@@ -29,7 +29,12 @@ CONFIG_SCHEMA = (
     .extend(
         {
             cv.Required(CONF_PIN): pins.gpio_input_pin_schema,
-            cv.Optional(CONF_USE_INTERRUPT, default=True): cv.boolean,
+            cv.SplitDefault(
+                CONF_USE_INTERRUPT,
+                bk72xx=False,
+                ln882x=False,
+                rtl87xx=False,
+            ): cv.boolean,
             cv.Optional(CONF_INTERRUPT_TYPE, default="ANY"): cv.enum(
                 INTERRUPT_TYPES, upper=True
             ),

--- a/esphome/components/gpio/binary_sensor/__init__.py
+++ b/esphome/components/gpio/binary_sensor/__init__.py
@@ -29,6 +29,10 @@ CONFIG_SCHEMA = (
     .extend(
         {
             cv.Required(CONF_PIN): pins.gpio_input_pin_schema,
+            # Interrupts are disabled by default for bk72xx, ln882x, and rtl87xx platforms
+            # due to hardware limitations or lack of reliable interrupt support. This ensures
+            # stable operation on these platforms. Future maintainers should verify platform
+            # capabilities before changing this default behavior.
             cv.SplitDefault(
                 CONF_USE_INTERRUPT,
                 bk72xx=False,

--- a/esphome/components/gpio/binary_sensor/__init__.py
+++ b/esphome/components/gpio/binary_sensor/__init__.py
@@ -35,14 +35,14 @@ CONFIG_SCHEMA = (
             # capabilities before changing this default behavior.
             cv.SplitDefault(
                 CONF_USE_INTERRUPT,
-                esp8266=True,
-                esp32=True,
-                rp2040=True,
-                nrf52=True,
                 bk72xx=False,
-                ln882x=False,
-                rtl87xx=False,
+                esp32=True,
+                esp8266=True,
                 host=True,
+                ln882x=False,
+                nrf52=True,
+                rp2040=True,
+                rtl87xx=False,
             ): cv.boolean,
             cv.Optional(CONF_INTERRUPT_TYPE, default="ANY"): cv.enum(
                 INTERRUPT_TYPES, upper=True

--- a/esphome/components/gpio/binary_sensor/__init__.py
+++ b/esphome/components/gpio/binary_sensor/__init__.py
@@ -31,9 +31,13 @@ CONFIG_SCHEMA = (
             cv.Required(CONF_PIN): pins.gpio_input_pin_schema,
             cv.SplitDefault(
                 CONF_USE_INTERRUPT,
+                esp8266=True,
+                esp32=True,
+                rp2040=True,
                 bk72xx=False,
                 ln882x=False,
                 rtl87xx=False,
+                host=True,
             ): cv.boolean,
             cv.Optional(CONF_INTERRUPT_TYPE, default="ANY"): cv.enum(
                 INTERRUPT_TYPES, upper=True


### PR DESCRIPTION
~~*IMPORTANT* `nrf52` will need to be removed on cherry-pick~~ It actually just ignores the kwarg so this is fine with the extra one for nrf52

## Description:

Updates the GPIO binary sensor documentation to reflect the new default behavior for LibreTiny platforms (BK72xx, RTL87xx, LN882x), where `use_interrupt` now defaults to `false` due to hardware limitations with edge interrupts.

This documentation update explains:
- The different default values for `use_interrupt` based on platform
- Why LibreTiny platforms default to polling mode
- That users can still explicitly enable interrupt mode if needed (though it may not work reliably)

**Related issue (if applicable):** fixes https://github.com/esphome/esphome/issues/9665

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** 

- esphome/esphome#9687

## Checklist:

  - [x] I am merging into `next` because this is new documentation that has a matching pull-request in [esphome](https://github.com/esphome/esphome) as linked above.  
    or
  - [ ] I am merging into `current` because this is a fix, change and/or adjustment in the current documentation and is not for a new component or feature.

  - [ ] Link added in `/components/index.rst` when creating new documents for new components or cookbook.%                                                                   bdraco@Mac esphome % cat gpio_libretiny_pr.md
# What does this implement/fix?

This PR fixes GPIO binary sensors on LibreTiny platforms (BK72xx, RTL87xx, LN882x) by changing the default value of `use_interrupt` from `true` to `false` for these platforms.

The issue was that GPIO binary sensors would only detect the first button press after boot on LibreTiny devices, particularly on CB3S (BK7231N) boards. This is due to hardware limitations where these chips don't properly support ANY_EDGE (CHANGE) interrupts.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/9665

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#5132

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [x] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml for BK72xx device
esphome:
  name: test-device

bk72xx:
  board: cb3s

logger:

binary_sensor:
  - platform: gpio
    pin: P8
    name: "Test Button"
    # use_interrupt now defaults to false on LibreTiny platforms
    # No need to explicitly set it anymore
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).