### PR TITLE
[i2s_audio] Bugfix: cast adc_channel_t to adc1_channel_t

### DIFF
--- a/esphome/components/i2s_audio/microphone/i2s_audio_microphone.h
+++ b/esphome/components/i2s_audio/microphone/i2s_audio_microphone.h
@@ -36,8 +36,8 @@ class I2SAudioMicrophone : public I2SAudioIn, public microphone::Microphone, pub
 
 #ifdef USE_I2S_LEGACY
 #if SOC_I2S_SUPPORTS_ADC
-  void set_adc_channel(adc1_channel_t channel) {
-    this->adc_channel_ = channel;
+  void set_adc_channel(adc_channel_t channel) {
+    this->adc_channel_ = (adc1_channel_t) channel;
     this->adc_ = true;
   }
 #endif


### PR DESCRIPTION
# What does this implement/fix?

#9021 modified the type that ``ESP32_VARIANT_ADC1_PIN_TO_CHANNEL`` returns to be ``adc_channel_t``. The legacy I2S driver used to support the internal ADC microphone requires that type to be ``adc1_channel_t``. This PR just adds a simple cast to adjust this.

I am unable to test this on actual hardware, but it does fix the compilation errors.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** not applicable

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** not applicable

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

Pulled from tests/components/microphone/test.esp32-ard.yaml, which previously failed.

```yaml

# Example config.yaml

microphone:
  - platform: i2s_audio
    id: mic_id_adc
    adc_pin: 32
    adc_type: internal

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
