### PR TITLE
2025.7.2

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -48,7 +48,7 @@ PROJECT_NAME           = ESPHome
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 2025.7.1
+PROJECT_NUMBER         = 2025.7.2
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/esphome/components/api/homeassistant_service.h
+++ b/esphome/components/api/homeassistant_service.h
@@ -16,6 +16,9 @@ template<typename... X> class TemplatableStringValue : public TemplatableValue<s
   template<typename T> static std::string value_to_string(T &&val) { return to_string(std::forward<T>(val)); }
 
   // Overloads for string types - needed because std::to_string doesn't support them
+  static std::string value_to_string(char *val) {
+    return val ? std::string(val) : std::string();
+  }  // For lambdas returning char* (e.g., itoa)
   static std::string value_to_string(const char *val) { return std::string(val); }  // For lambdas returning .c_str()
   static std::string value_to_string(const std::string &val) { return val; }
   static std::string value_to_string(std::string &&val) { return std::move(val); }

--- a/esphome/components/esp32_camera/__init__.py
+++ b/esphome/components/esp32_camera/__init__.py
@@ -1,3 +1,5 @@
+import logging
+
 from esphome import automation, pins
 import esphome.codegen as cg
 from esphome.components import i2c
@@ -8,6 +10,7 @@ from esphome.const import (
     CONF_CONTRAST,
     CONF_DATA_PINS,
     CONF_FREQUENCY,
+    CONF_I2C,
     CONF_I2C_ID,
     CONF_ID,
     CONF_PIN,
@@ -20,6 +23,9 @@ from esphome.const import (
 )
 from esphome.core import CORE
 from esphome.core.entity_helpers import setup_entity
+import esphome.final_validate as fv
+
+_LOGGER = logging.getLogger(__name__)
 
 DEPENDENCIES = ["esp32"]
 
@@ -249,6 +255,22 @@ CONFIG_SCHEMA = cv.All(
     ).extend(cv.COMPONENT_SCHEMA),
     cv.has_exactly_one_key(CONF_I2C_PINS, CONF_I2C_ID),
 )
+
+
+def _final_validate(config):
+    if CONF_I2C_PINS not in config:
+        return
+    fconf = fv.full_config.get()
+    if fconf.get(CONF_I2C):
+        raise cv.Invalid(
+            "The `i2c_pins:` config option is incompatible with an dedicated `i2c:` block, use `i2c_id` instead"
+        )
+    _LOGGER.warning(
+        "The `i2c_pins:` config option is deprecated. Use `i2c_id:` with a dedicated `i2c:` definition instead."
+    )
+
+
+FINAL_VALIDATE_SCHEMA = _final_validate
 
 SETTERS = {
     # pin assignment

--- a/esphome/components/gpio/binary_sensor/__init__.py
+++ b/esphome/components/gpio/binary_sensor/__init__.py
@@ -29,7 +29,21 @@ CONFIG_SCHEMA = (
     .extend(
         {
             cv.Required(CONF_PIN): pins.gpio_input_pin_schema,
-            cv.Optional(CONF_USE_INTERRUPT, default=True): cv.boolean,
+            # Interrupts are disabled by default for bk72xx, ln882x, and rtl87xx platforms
+            # due to hardware limitations or lack of reliable interrupt support. This ensures
+            # stable operation on these platforms. Future maintainers should verify platform
+            # capabilities before changing this default behavior.
+            cv.SplitDefault(
+                CONF_USE_INTERRUPT,
+                bk72xx=False,
+                esp32=True,
+                esp8266=True,
+                host=True,
+                ln882x=False,
+                nrf52=True,
+                rp2040=True,
+                rtl87xx=False,
+            ): cv.boolean,
             cv.Optional(CONF_INTERRUPT_TYPE, default="ANY"): cv.enum(
                 INTERRUPT_TYPES, upper=True
             ),

--- a/esphome/components/logger/__init__.py
+++ b/esphome/components/logger/__init__.py
@@ -183,7 +183,7 @@ def validate_local_no_higher_than_global(value):
 Logger = logger_ns.class_("Logger", cg.Component)
 LoggerMessageTrigger = logger_ns.class_(
     "LoggerMessageTrigger",
-    automation.Trigger.template(cg.int_, cg.const_char_ptr, cg.const_char_ptr),
+    automation.Trigger.template(cg.uint8, cg.const_char_ptr, cg.const_char_ptr),
 )
 
 CONF_ESP8266_STORE_LOG_STRINGS_IN_FLASH = "esp8266_store_log_strings_in_flash"
@@ -368,7 +368,7 @@ async def to_code(config):
         await automation.build_automation(
             trigger,
             [
-                (cg.int_, "level"),
+                (cg.uint8, "level"),
                 (cg.const_char_ptr, "tag"),
                 (cg.const_char_ptr, "message"),
             ],

--- a/esphome/components/lvgl/types.py
+++ b/esphome/components/lvgl/types.py
@@ -192,7 +192,7 @@ class WidgetType:
 
 class NumberType(WidgetType):
     def get_max(self, config: dict):
-        return int(config[CONF_MAX_VALUE] or 100)
+        return int(config.get(CONF_MAX_VALUE, 100))
 
     def get_min(self, config: dict):
-        return int(config[CONF_MIN_VALUE] or 0)
+        return int(config.get(CONF_MIN_VALUE, 0))

--- a/esphome/components/lvgl/widgets/meter.py
+++ b/esphome/components/lvgl/widgets/meter.py
@@ -14,6 +14,7 @@ from esphome.const import (
     CONF_VALUE,
     CONF_WIDTH,
 )
+from esphome.cpp_generator import IntLiteral
 
 from ..automation import action_to_code
 from ..defines import (
@@ -188,6 +189,8 @@ class MeterType(WidgetType):
             rotation = 90 + (360 - scale_conf[CONF_ANGLE_RANGE]) / 2
             if CONF_ROTATION in scale_conf:
                 rotation = await lv_angle.process(scale_conf[CONF_ROTATION])
+                if isinstance(rotation, IntLiteral):
+                    rotation = int(str(rotation)) // 10
             with LocalVariable(
                 "meter_var", "lv_meter_scale_t", lv_expr.meter_add_scale(var)
             ) as meter_var:

--- a/esphome/components/speaker/media_player/audio_pipeline.cpp
+++ b/esphome/components/speaker/media_player/audio_pipeline.cpp
@@ -200,7 +200,7 @@ AudioPipelineState AudioPipeline::process_state() {
       if ((this->read_task_handle_ != nullptr) || (this->decode_task_handle_ != nullptr)) {
         this->delete_tasks_();
         if (this->hard_stop_) {
-          // Stop command was sent, so immediately end of the playback
+          // Stop command was sent, so immediately end the playback
           this->speaker_->stop();
           this->hard_stop_ = false;
         } else {
@@ -210,11 +210,23 @@ AudioPipelineState AudioPipeline::process_state() {
       }
     }
     this->is_playing_ = false;
-    return AudioPipelineState::STOPPED;
+    if (!this->speaker_->is_running()) {
+      return AudioPipelineState::STOPPED;
+    } else {
+      this->is_finishing_ = true;
+    }
   }
 
   if (this->pause_state_) {
     return AudioPipelineState::PAUSED;
+  }
+
+  if (this->is_finishing_) {
+    if (!this->speaker_->is_running()) {
+      this->is_finishing_ = false;
+    } else {
+      return AudioPipelineState::PLAYING;
+    }
   }
 
   if ((this->read_task_handle_ == nullptr) && (this->decode_task_handle_ == nullptr)) {

--- a/esphome/components/speaker/media_player/audio_pipeline.h
+++ b/esphome/components/speaker/media_player/audio_pipeline.h
@@ -114,6 +114,7 @@ class AudioPipeline {
 
   bool hard_stop_{false};
   bool is_playing_{false};
+  bool is_finishing_{false};
   bool pause_state_{false};
   bool task_stack_in_psram_;
 

--- a/esphome/components/voice_assistant/voice_assistant.h
+++ b/esphome/components/voice_assistant/voice_assistant.h
@@ -90,6 +90,15 @@ struct Configuration {
   uint32_t max_active_wake_words;
 };
 
+#ifdef USE_MEDIA_PLAYER
+enum class MediaPlayerResponseState {
+  IDLE,
+  URL_SENT,
+  PLAYING,
+  FINISHED,
+};
+#endif
+
 class VoiceAssistant : public Component {
  public:
   VoiceAssistant();
@@ -272,8 +281,8 @@ class VoiceAssistant : public Component {
   media_player::MediaPlayer *media_player_{nullptr};
   std::string tts_response_url_{""};
   bool started_streaming_tts_{false};
-  bool media_player_wait_for_announcement_start_{false};
-  bool media_player_wait_for_announcement_end_{false};
+
+  MediaPlayerResponseState media_player_response_state_{MediaPlayerResponseState::IDLE};
 #endif
 
   bool local_output_{false};

--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -1620,7 +1620,9 @@ void WebServer::handle_event_request(AsyncWebServerRequest *request, const UrlMa
   request->send(404);
 }
 
-static std::string get_event_type(event::Event *event) { return event->last_event_type ? *event->last_event_type : ""; }
+static std::string get_event_type(event::Event *event) {
+  return (event && event->last_event_type) ? *event->last_event_type : "";
+}
 
 std::string WebServer::event_state_json_generator(WebServer *web_server, void *source) {
   auto *event = static_cast<event::Event *>(source);

--- a/esphome/components/wireguard/wireguard.cpp
+++ b/esphome/components/wireguard/wireguard.cpp
@@ -8,6 +8,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/time.h"
 #include "esphome/components/network/util.h"
+#include "esphome/core/helpers.h"
 
 #include <esp_wireguard.h>
 #include <esp_wireguard_err.h>
@@ -42,7 +43,10 @@ void Wireguard::setup() {
 
   this->publish_enabled_state();
 
-  this->wg_initialized_ = esp_wireguard_init(&(this->wg_config_), &(this->wg_ctx_));
+  {
+    LwIPLock lock;
+    this->wg_initialized_ = esp_wireguard_init(&(this->wg_config_), &(this->wg_ctx_));
+  }
 
   if (this->wg_initialized_ == ESP_OK) {
     ESP_LOGI(TAG, "Initialized");
@@ -249,7 +253,10 @@ void Wireguard::start_connection_() {
   }
 
   ESP_LOGD(TAG, "Starting connection");
-  this->wg_connected_ = esp_wireguard_connect(&(this->wg_ctx_));
+  {
+    LwIPLock lock;
+    this->wg_connected_ = esp_wireguard_connect(&(this->wg_ctx_));
+  }
 
   if (this->wg_connected_ == ESP_OK) {
     ESP_LOGI(TAG, "Connection started");
@@ -280,7 +287,10 @@ void Wireguard::start_connection_() {
 void Wireguard::stop_connection_() {
   if (this->wg_initialized_ == ESP_OK && this->wg_connected_ == ESP_OK) {
     ESP_LOGD(TAG, "Stopping connection");
-    esp_wireguard_disconnect(&(this->wg_ctx_));
+    {
+      LwIPLock lock;
+      esp_wireguard_disconnect(&(this->wg_ctx_));
+    }
     this->wg_connected_ = ESP_FAIL;
   }
 }

--- a/esphome/const.py
+++ b/esphome/const.py
@@ -4,7 +4,7 @@ from enum import Enum
 
 from esphome.enum import StrEnum
 
-__version__ = "2025.7.1"
+__version__ = "2025.7.2"
 
 ALLOWED_NAME_CHARS = "abcdefghijklmnopqrstuvwxyz0123456789-_"
 VALID_SUBSTITUTIONS_CHARACTERS = (

--- a/esphome/core/base_automation.h
+++ b/esphome/core/base_automation.h
@@ -158,14 +158,14 @@ template<typename... Ts> class DelayAction : public Action<Ts...>, public Compon
   void play_complex(Ts... x) override {
     auto f = std::bind(&DelayAction<Ts...>::play_next_, this, x...);
     this->num_running_++;
-    this->set_timeout(this->delay_.value(x...), f);
+    this->set_timeout("delay", this->delay_.value(x...), f);
   }
   float get_setup_priority() const override { return setup_priority::HARDWARE; }
 
   void play(Ts... x) override { /* ignore - see play_complex */
   }
 
-  void stop() override { this->cancel_timeout(""); }
+  void stop() override { this->cancel_timeout("delay"); }
 };
 
 template<typename... Ts> class LambdaAction : public Action<Ts...> {

--- a/esphome/core/component.cpp
+++ b/esphome/core/component.cpp
@@ -252,10 +252,10 @@ void Component::defer(const char *name, std::function<void()> &&f) {  // NOLINT
   App.scheduler.set_timeout(this, name, 0, std::move(f));
 }
 void Component::set_timeout(uint32_t timeout, std::function<void()> &&f) {  // NOLINT
-  App.scheduler.set_timeout(this, "", timeout, std::move(f));
+  App.scheduler.set_timeout(this, static_cast<const char *>(nullptr), timeout, std::move(f));
 }
 void Component::set_interval(uint32_t interval, std::function<void()> &&f) {  // NOLINT
-  App.scheduler.set_interval(this, "", interval, std::move(f));
+  App.scheduler.set_interval(this, static_cast<const char *>(nullptr), interval, std::move(f));
 }
 void Component::set_retry(uint32_t initial_wait_time, uint8_t max_attempts, std::function<RetryResult(uint8_t)> &&f,
                           float backoff_increase_factor) {  // NOLINT

--- a/esphome/core/event_pool.h
+++ b/esphome/core/event_pool.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#if defined(USE_ESP32) || defined(USE_LIBRETINY)
+#if defined(USE_ESP32)
 
 #include <atomic>
 #include <cstddef>
@@ -78,4 +78,4 @@ template<class T, uint8_t SIZE> class EventPool {
 
 }  // namespace esphome
 
-#endif  // defined(USE_ESP32) || defined(USE_LIBRETINY)
+#endif  // defined(USE_ESP32)

--- a/esphome/core/lock_free_queue.h
+++ b/esphome/core/lock_free_queue.h
@@ -1,17 +1,12 @@
 #pragma once
 
-#if defined(USE_ESP32) || defined(USE_LIBRETINY)
+#if defined(USE_ESP32)
 
 #include <atomic>
 #include <cstddef>
 
-#if defined(USE_ESP32)
 #include <freertos/FreeRTOS.h>
 #include <freertos/task.h>
-#elif defined(USE_LIBRETINY)
-#include <FreeRTOS.h>
-#include <task.h>
-#endif
 
 /*
  * Lock-free queue for single-producer single-consumer scenarios.
@@ -148,4 +143,4 @@ template<class T, uint8_t SIZE> class NotifyingLockFreeQueue : public LockFreeQu
 
 }  // namespace esphome
 
-#endif  // defined(USE_ESP32) || defined(USE_LIBRETINY)
+#endif  // defined(USE_ESP32)

--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -446,7 +446,7 @@ bool HOT Scheduler::cancel_item_(Component *component, bool is_static_string, co
 // Helper to cancel items by name - must be called with lock held
 bool HOT Scheduler::cancel_item_locked_(Component *component, const char *name_cstr, SchedulerItem::Type type) {
   // Early return if name is invalid - no items to cancel
-  if (name_cstr == nullptr || name_cstr[0] == '\0') {
+  if (name_cstr == nullptr) {
     return false;
   }
 

--- a/esphome/core/scheduler.h
+++ b/esphome/core/scheduler.h
@@ -114,16 +114,17 @@ class Scheduler {
         name_is_dynamic = false;
       }
 
-      if (!name || !name[0]) {
+      if (!name) {
+        // nullptr case - no name provided
         name_.static_name = nullptr;
       } else if (make_copy) {
-        // Make a copy for dynamic strings
+        // Make a copy for dynamic strings (including empty strings)
         size_t len = strlen(name);
         name_.dynamic_name = new char[len + 1];
         memcpy(name_.dynamic_name, name, len + 1);
         name_is_dynamic = true;
       } else {
-        // Use static string directly
+        // Use static string directly (including empty strings)
         name_.static_name = name;
       }
     }

--- a/platformio.ini
+++ b/platformio.ini
@@ -138,7 +138,7 @@ lib_deps =
     WiFi                                 ; wifi,web_server_base,ethernet (Arduino built-in)
     Update                               ; ota,web_server_base (Arduino built-in)
     ${common:arduino.lib_deps}
-    ESP32Async/AsyncTCP@3.4.4            ; async_tcp
+    ESP32Async/AsyncTCP@3.4.5            ; async_tcp
     NetworkClientSecure                  ; http_request,nextion (Arduino built-in)
     HTTPClient                           ; http_request,nextion (Arduino built-in)
     ESPmDNS                              ; mdns (Arduino built-in)

--- a/tests/components/logger/test-on_message.host.yaml
+++ b/tests/components/logger/test-on_message.host.yaml
@@ -1,0 +1,18 @@
+logger:
+  id: logger_id
+  level: DEBUG
+  on_message:
+    - level: DEBUG
+      then:
+        - lambda: |-
+            ESP_LOGD("test", "Got message level %d: %s - %s", level, tag, message);
+    - level: WARN
+      then:
+        - lambda: |-
+            ESP_LOGW("test", "Warning level %d from %s", level, tag);
+    - level: ERROR
+      then:
+        - lambda: |-
+            // Test that level is uint8_t by using it in calculations
+            uint8_t adjusted_level = level + 1;
+            ESP_LOGE("test", "Error with adjusted level %d", adjusted_level);

--- a/tests/integration/fixtures/api_string_lambda.yaml
+++ b/tests/integration/fixtures/api_string_lambda.yaml
@@ -60,5 +60,28 @@ api:
             data:
               value: !lambda 'return input_float;'
 
+    # Service that tests char* lambda functionality (e.g., from itoa or sprintf)
+    - action: test_char_ptr_lambda
+      variables:
+        input_number: int
+        input_string: string
+      then:
+        # Log the input to verify service was called
+        - logger.log:
+            format: "Service called with number for char* test: %d"
+            args: [input_number]
+
+        # Test that char* lambdas work correctly
+        # This would fail in issue #9628 with "invalid conversion from 'char*' to 'long long unsigned int'"
+        - homeassistant.event:
+            event: esphome.test_char_ptr_lambda
+            data:
+              # Test snprintf returning char*
+              decimal_value: !lambda 'static char buffer[20]; snprintf(buffer, sizeof(buffer), "%d", input_number); return buffer;'
+              # Test strdup returning char* (dynamically allocated)
+              string_copy: !lambda 'return strdup(input_string.c_str());'
+              # Test string literal (const char*)
+              literal: !lambda 'return "test literal";'
+
 logger:
   level: DEBUG

--- a/tests/integration/fixtures/delay_action_cancellation.yaml
+++ b/tests/integration/fixtures/delay_action_cancellation.yaml
@@ -1,0 +1,24 @@
+esphome:
+  name: test-delay-action
+
+host:
+api:
+  actions:
+    - action: start_delay_then_restart
+      then:
+        - logger.log: "Starting first script execution"
+        - script.execute: test_delay_script
+        - delay: 250ms  # Give first script time to start delay
+        - logger.log: "Restarting script (should cancel first delay)"
+        - script.execute: test_delay_script
+
+logger:
+  level: DEBUG
+
+script:
+  - id: test_delay_script
+    mode: restart
+    then:
+      - logger.log: "Script started, beginning delay"
+      - delay: 500ms  # Long enough that it won't complete before restart
+      - logger.log: "Delay completed successfully"

--- a/tests/integration/fixtures/scheduler_string_test.yaml
+++ b/tests/integration/fixtures/scheduler_string_test.yaml
@@ -4,9 +4,7 @@ esphome:
     priority: -100
     then:
       - logger.log: "Starting scheduler string tests"
-  platformio_options:
-    build_flags:
-      - "-DESPHOME_DEBUG_SCHEDULER"  # Enable scheduler debug logging
+  debug_scheduler: true  # Enable scheduler debug logging
 
 host:
 api:
@@ -30,6 +28,12 @@ globals:
     type: bool
     initial_value: 'false'
   - id: results_reported
+    type: bool
+    initial_value: 'false'
+  - id: edge_tests_done
+    type: bool
+    initial_value: 'false'
+  - id: empty_cancel_failed
     type: bool
     initial_value: 'false'
 
@@ -147,11 +151,105 @@ script:
           static TestDynamicDeferComponent test_dynamic_defer_component;
           test_dynamic_defer_component.test_dynamic_defer();
 
+  - id: test_cancellation_edge_cases
+    then:
+      - logger.log: "Testing cancellation edge cases"
+      - lambda: |-
+          auto *component1 = id(test_sensor1);
+          // Use a different component for empty string tests to avoid interference
+          auto *component2 = id(test_sensor2);
+
+          // Test 12: Cancel with empty string - regression test for issue #9599
+          // First create a timeout with empty name on component2 to avoid interference
+          App.scheduler.set_timeout(component2, "", 500, []() {
+            ESP_LOGE("test", "ERROR: Empty name timeout fired - it should have been cancelled!");
+            id(empty_cancel_failed) = true;
+          });
+
+          // Now cancel it - this should work after our fix
+          bool cancelled_empty = App.scheduler.cancel_timeout(component2, "");
+          ESP_LOGI("test", "Cancel empty string result: %s (should be true)", cancelled_empty ? "true" : "false");
+          if (!cancelled_empty) {
+            ESP_LOGE("test", "ERROR: Failed to cancel empty string timeout!");
+            id(empty_cancel_failed) = true;
+          }
+
+          // Test 13: Cancel non-existent timeout
+          bool cancelled_nonexistent = App.scheduler.cancel_timeout(component1, "does_not_exist");
+          ESP_LOGI("test", "Cancel non-existent timeout result: %s",
+                   cancelled_nonexistent ? "true (unexpected!)" : "false (expected)");
+
+          // Test 14: Multiple timeouts with same name - only last should execute
+          for (int i = 0; i < 5; i++) {
+            App.scheduler.set_timeout(component1, "duplicate_timeout", 200 + i*10, [i]() {
+              ESP_LOGI("test", "Duplicate timeout %d fired", i);
+              id(timeout_counter) += 1;
+            });
+          }
+          ESP_LOGI("test", "Created 5 timeouts with same name 'duplicate_timeout'");
+
+          // Test 15: Multiple intervals with same name - only last should run
+          for (int i = 0; i < 3; i++) {
+            App.scheduler.set_interval(component1, "duplicate_interval", 300, [i]() {
+              ESP_LOGI("test", "Duplicate interval %d fired", i);
+              id(interval_counter) += 10; // Large increment to detect multiple
+              // Cancel after first execution
+              App.scheduler.cancel_interval(id(test_sensor1), "duplicate_interval");
+            });
+          }
+          ESP_LOGI("test", "Created 3 intervals with same name 'duplicate_interval'");
+
+          // Test 16: Cancel with nullptr protection (via empty const char*)
+          const char* null_name = "";
+          App.scheduler.set_timeout(component2, null_name, 600, []() {
+            ESP_LOGE("test", "ERROR: Const char* empty timeout fired - should have been cancelled!");
+            id(empty_cancel_failed) = true;
+          });
+          bool cancelled_const_empty = App.scheduler.cancel_timeout(component2, null_name);
+          ESP_LOGI("test", "Cancel const char* empty result: %s (should be true)",
+                   cancelled_const_empty ? "true" : "false");
+          if (!cancelled_const_empty) {
+            ESP_LOGE("test", "ERROR: Failed to cancel const char* empty timeout!");
+            id(empty_cancel_failed) = true;
+          }
+
+          // Test 17: Rapid create/cancel/create with same name
+          App.scheduler.set_timeout(component1, "rapid_test", 5000, []() {
+            ESP_LOGI("test", "First rapid timeout - should not fire");
+            id(timeout_counter) += 100;
+          });
+          App.scheduler.cancel_timeout(component1, "rapid_test");
+          App.scheduler.set_timeout(component1, "rapid_test", 250, []() {
+            ESP_LOGI("test", "Second rapid timeout - should fire");
+            id(timeout_counter) += 1;
+          });
+
+          // Test 18: Cancel all with a specific name (multiple instances)
+          // Create multiple with same name
+          App.scheduler.set_timeout(component1, "multi_cancel", 300, []() {
+            ESP_LOGI("test", "Multi-cancel timeout 1");
+          });
+          App.scheduler.set_timeout(component1, "multi_cancel", 350, []() {
+            ESP_LOGI("test", "Multi-cancel timeout 2");
+          });
+          App.scheduler.set_timeout(component1, "multi_cancel", 400, []() {
+            ESP_LOGI("test", "Multi-cancel timeout 3 - only this should fire");
+            id(timeout_counter) += 1;
+          });
+          // Note: Each set_timeout with same name cancels the previous one automatically
+
   - id: report_results
     then:
       - lambda: |-
           ESP_LOGI("test", "Final results - Timeouts: %d, Intervals: %d",
                    id(timeout_counter), id(interval_counter));
+
+          // Check if empty string cancellation test passed
+          if (id(empty_cancel_failed)) {
+            ESP_LOGE("test", "ERROR: Empty string cancellation test FAILED!");
+          } else {
+            ESP_LOGI("test", "Empty string cancellation test PASSED");
+          }
 
 sensor:
   - platform: template
@@ -189,12 +287,23 @@ interval:
             - delay: 0.2s
             - script.execute: test_dynamic_strings
 
+  # Run cancellation edge case tests after dynamic tests
+  - interval: 0.2s
+    then:
+      - if:
+          condition:
+            lambda: 'return id(dynamic_tests_done) && !id(edge_tests_done);'
+          then:
+            - lambda: 'id(edge_tests_done) = true;'
+            - delay: 0.5s
+            - script.execute: test_cancellation_edge_cases
+
   # Report results after all tests
   - interval: 0.2s
     then:
       - if:
           condition:
-            lambda: 'return id(dynamic_tests_done) && !id(results_reported);'
+            lambda: 'return id(edge_tests_done) && !id(results_reported);'
           then:
             - lambda: 'id(results_reported) = true;'
             - delay: 1s

--- a/tests/integration/test_api_string_lambda.py
+++ b/tests/integration/test_api_string_lambda.py
@@ -19,15 +19,17 @@ async def test_api_string_lambda(
     """Test TemplatableStringValue works with lambdas that return different types."""
     loop = asyncio.get_running_loop()
 
-    # Track log messages for all three service calls
+    # Track log messages for all four service calls
     string_called_future = loop.create_future()
     int_called_future = loop.create_future()
     float_called_future = loop.create_future()
+    char_ptr_called_future = loop.create_future()
 
     # Patterns to match in logs - confirms the lambdas compiled and executed
     string_pattern = re.compile(r"Service called with string: STRING_FROM_LAMBDA")
     int_pattern = re.compile(r"Service called with int: 42")
     float_pattern = re.compile(r"Service called with float: 3\.14")
+    char_ptr_pattern = re.compile(r"Service called with number for char\* test: 123")
 
     def check_output(line: str) -> None:
         """Check log output for expected messages."""
@@ -37,6 +39,8 @@ async def test_api_string_lambda(
             int_called_future.set_result(True)
         if not float_called_future.done() and float_pattern.search(line):
             float_called_future.set_result(True)
+        if not char_ptr_called_future.done() and char_ptr_pattern.search(line):
+            char_ptr_called_future.set_result(True)
 
     # Run with log monitoring
     async with (
@@ -65,17 +69,28 @@ async def test_api_string_lambda(
         )
         assert float_service is not None, "test_float_lambda service not found"
 
-        # Execute all three services to test different lambda return types
+        char_ptr_service = next(
+            (s for s in services if s.name == "test_char_ptr_lambda"), None
+        )
+        assert char_ptr_service is not None, "test_char_ptr_lambda service not found"
+
+        # Execute all four services to test different lambda return types
         client.execute_service(string_service, {"input_string": "STRING_FROM_LAMBDA"})
         client.execute_service(int_service, {"input_number": 42})
         client.execute_service(float_service, {"input_float": 3.14})
+        client.execute_service(
+            char_ptr_service, {"input_number": 123, "input_string": "test_string"}
+        )
 
         # Wait for all service log messages
         # This confirms the lambdas compiled successfully and executed
         try:
             await asyncio.wait_for(
                 asyncio.gather(
-                    string_called_future, int_called_future, float_called_future
+                    string_called_future,
+                    int_called_future,
+                    float_called_future,
+                    char_ptr_called_future,
                 ),
                 timeout=5.0,
             )

--- a/tests/integration/test_automations.py
+++ b/tests/integration/test_automations.py
@@ -1,0 +1,91 @@
+"""Test ESPHome automations functionality."""
+
+from __future__ import annotations
+
+import asyncio
+import re
+
+import pytest
+
+from .types import APIClientConnectedFactory, RunCompiledFunction
+
+
+@pytest.mark.asyncio
+async def test_delay_action_cancellation(
+    yaml_config: str,
+    run_compiled: RunCompiledFunction,
+    api_client_connected: APIClientConnectedFactory,
+) -> None:
+    """Test that delay actions can be properly cancelled when script restarts."""
+    loop = asyncio.get_running_loop()
+
+    # Track log messages with timestamps
+    log_entries: list[tuple[float, str]] = []
+    script_starts: list[float] = []
+    delay_completions: list[float] = []
+    script_restart_logged = False
+    test_started_time = None
+
+    # Patterns to match
+    test_start_pattern = re.compile(r"Starting first script execution")
+    script_start_pattern = re.compile(r"Script started, beginning delay")
+    restart_pattern = re.compile(r"Restarting script \(should cancel first delay\)")
+    delay_complete_pattern = re.compile(r"Delay completed successfully")
+
+    # Future to track when we can check results
+    second_script_started = loop.create_future()
+
+    def check_output(line: str) -> None:
+        """Check log output for expected messages."""
+        nonlocal script_restart_logged, test_started_time
+
+        current_time = loop.time()
+        log_entries.append((current_time, line))
+
+        if test_start_pattern.search(line):
+            test_started_time = current_time
+        elif script_start_pattern.search(line) and test_started_time:
+            script_starts.append(current_time)
+            if len(script_starts) == 2 and not second_script_started.done():
+                second_script_started.set_result(True)
+        elif restart_pattern.search(line):
+            script_restart_logged = True
+        elif delay_complete_pattern.search(line):
+            delay_completions.append(current_time)
+
+    async with (
+        run_compiled(yaml_config, line_callback=check_output),
+        api_client_connected() as client,
+    ):
+        # Get services
+        entities, services = await client.list_entities_services()
+
+        # Find our test service
+        test_service = next(
+            (s for s in services if s.name == "start_delay_then_restart"), None
+        )
+        assert test_service is not None, "start_delay_then_restart service not found"
+
+        # Execute the test sequence
+        client.execute_service(test_service, {})
+
+        # Wait for the second script to start
+        await asyncio.wait_for(second_script_started, timeout=5.0)
+
+        # Wait for potential delay completion
+        await asyncio.sleep(0.75)  # Original delay was 500ms
+
+        # Check results
+        assert len(script_starts) == 2, (
+            f"Script should have started twice, but started {len(script_starts)} times"
+        )
+        assert script_restart_logged, "Script restart was not logged"
+
+        # Verify we got exactly one completion and it happened ~500ms after the second start
+        assert len(delay_completions) == 1, (
+            f"Expected 1 delay completion, got {len(delay_completions)}"
+        )
+        time_from_second_start = delay_completions[0] - script_starts[1]
+        assert 0.4 < time_from_second_start < 0.6, (
+            f"Delay completed {time_from_second_start:.3f}s after second start, expected ~0.5s"
+        )

--- a/tests/integration/test_scheduler_heap_stress.py
+++ b/tests/integration/test_scheduler_heap_stress.py
@@ -103,13 +103,14 @@ async def test_scheduler_heap_stress(
 
         # Wait for all callbacks to execute (should be quick, but give more time for scheduling)
         try:
-            await asyncio.wait_for(test_complete_future, timeout=60.0)
+            await asyncio.wait_for(test_complete_future, timeout=10.0)
         except asyncio.TimeoutError:
             # Report how many we got
+            missing_ids = sorted(set(range(1000)) - executed_callbacks)
             pytest.fail(
                 f"Stress test timed out. Only {len(executed_callbacks)} of "
                 f"1000 callbacks executed. Missing IDs: "
-                f"{sorted(set(range(1000)) - executed_callbacks)[:10]}..."
+                f"{missing_ids[:20]}... (total missing: {len(missing_ids)})"
             )
 
         # Verify all callbacks executed


### PR DESCRIPTION
**Do not merge, release script will automatically merge**
<details>
<summary>Show</summary>

- Fix template event web_server crash [esphome#9618](https://github.com/esphome/esphome/pull/9618)
- [api] Fix compilation error with char* lambdas in HomeAssistant services [esphome#9638](https://github.com/esphome/esphome/pull/9638)
- [wireguard] Fix boot loop when CONFIG_LWIP_TCPIP_CORE_LOCKING is enabled [esphome#9637](https://github.com/esphome/esphome/pull/9637)
- [scheduler] Fix cancellation of timers with empty string names [esphome#9641](https://github.com/esphome/esphome/pull/9641)
- [logger] fix on_message [esphome#9642](https://github.com/esphome/esphome/pull/9642)
- esp32_camera: deprecate i2c_pins; throw error if combined with i2c: block [esphome#9615](https://github.com/esphome/esphome/pull/9615)
- [scheduler] Fix DelayAction cancellation in restart mode scripts [esphome#9646](https://github.com/esphome/esphome/pull/9646)
- [lvgl] Fix meter rotation [esphome#9605](https://github.com/esphome/esphome/pull/9605)
- [libretiny] Remove unsupported lock-free queue and event pool implementations [esphome#9653](https://github.com/esphome/esphome/pull/9653)
- [lvgl] Prevent keyerror on min/max value widgets with no default [esphome#9660](https://github.com/esphome/esphome/pull/9660)
- Fix AsyncTCP version mismatch between platformio.ini and async_tcp component [esphome#9676](https://github.com/esphome/esphome/pull/9676)
- [speaker] Media player's pipeline properly returns playing state near end of file [esphome#9668](https://github.com/esphome/esphome/pull/9668)
- [voice_assistant] Use media player callbacks to track TTS response status [esphome#9670](https://github.com/esphome/esphome/pull/9670)
- [gpio] Disable interrupt mode by default for LibreTiny platforms [esphome#9687](https://github.com/esphome/esphome/pull/9687)
</details>

<details>
<summary>Metadata</summary>

@coderabbitai ignore
</details>
