### PR TITLE
[esp32_touch] Fix touch pad values sticking at last touched value in setup mode

### DIFF
--- a/esphome/components/esp32_touch/esp32_touch_v1.cpp
+++ b/esphome/components/esp32_touch/esp32_touch_v1.cpp
@@ -210,9 +210,12 @@ void IRAM_ATTR ESP32TouchComponent::touch_isr_handler(void *arg) {
       value = touch_ll_read_raw_data(pad);
     }
 
-    // Skip pads that aren’t in the trigger mask
+    // Check if pad is in the trigger mask
     bool is_touched = (mask >> pad) & 1;
-    if (!is_touched) {
+
+    // In setup mode, we need to send all pad values for logging
+    // In normal mode, only send touched pads to reduce queue traffic
+    if (!component->setup_mode_ && !is_touched) {
       continue;
     }
 


### PR DESCRIPTION
# What does this implement/fix?

**⚠️ IMPORTANT: This fix is speculative - I don't currently have physical access to an ESP32 board to test this change. Testing by someone with hardware is required to confirm it resolves the issue.**

This PR fixes an issue where ESP32 touch pad values get stuck at the last touched value when in setup mode. The problem was introduced in #9414 (commit 92d03dd19) which optimized the ISR to only send events for pads in the trigger mask - a good optimization that reduces queue pressure during normal operation. However, this means when a pad is released (and no longer in the trigger mask), no event is sent and the value remains stuck at the last touched value, which affects the debug logging in setup mode.

The fix ensures that in setup mode, the ISR sends value updates for all configured pads, not just the touched ones. This allows the debug logging to show current values correctly.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes #9690

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no documentation changes needed)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example configuration that demonstrates the issue
esp32_touch:
  setup_mode: true  # Enable debug logging to see touch values

binary_sensor:
  - platform: esp32_touch
    name: "Touch Button"
    pin: GPIO4
    threshold: 1000
```

## Checklist:
  - [ ] The code change is tested and works locally. (**Cannot test - no hardware available**)
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).