### PR TITLE
[api] Fix missing ifdef guards for field_ifdef fields in protobuf base classes

### DIFF
--- a/esphome/components/api/api_connection.h
+++ b/esphome/components/api/api_connection.h
@@ -301,8 +301,10 @@ class APIConnection : public APIServerConnection {
     if (entity->has_own_name())
       msg.name = entity->get_name();
 
-    // Set common EntityBase properties
+      // Set common EntityBase properties
+#ifdef USE_ENTITY_ICON
     msg.icon = entity->get_icon();
+#endif
     msg.disabled_by_default = entity->is_disabled_by_default();
     msg.entity_category = static_cast<enums::EntityCategory>(entity->get_entity_category());
 #ifdef USE_DEVICES

--- a/esphome/components/api/api_pb2.h
+++ b/esphome/components/api/api_pb2.h
@@ -292,9 +292,13 @@ class InfoResponseProtoMessage : public ProtoMessage {
   uint32_t key{0};
   std::string name{};
   bool disabled_by_default{false};
+#ifdef USE_ENTITY_ICON
   std::string icon{};
+#endif
   enums::EntityCategory entity_category{};
+#ifdef USE_DEVICES
   uint32_t device_id{0};
+#endif
 
  protected:
 };
@@ -303,7 +307,9 @@ class StateResponseProtoMessage : public ProtoMessage {
  public:
   ~StateResponseProtoMessage() override = default;
   uint32_t key{0};
+#ifdef USE_DEVICES
   uint32_t device_id{0};
+#endif
 
  protected:
 };
@@ -312,7 +318,9 @@ class CommandProtoMessage : public ProtoDecodableMessage {
  public:
   ~CommandProtoMessage() override = default;
   uint32_t key{0};
+#ifdef USE_DEVICES
   uint32_t device_id{0};
+#endif
 
  protected:
 };


### PR DESCRIPTION
Not for backport. can wait for 2025.8.x as it just uses more memory than needed but not a lot.

# What does this implement/fix?

This PR fixes the protobuf code generation script to properly wrap fields with their corresponding ifdef guards in base classes. Previously, fields marked with `field_ifdef` options in the proto file (such as `[(field_ifdef) = "USE_DEVICES"]` for device_id and `[(field_ifdef) = "USE_ENTITY_ICON"]` for icon) were not getting ifdef guards when they appeared in generated base classes like `InfoResponseProtoMessage`, `StateResponseProtoMessage`, and `CommandProtoMessage`.

The fix ensures that when common fields are extracted into base classes, their field_ifdef options are preserved if all derived classes have the same ifdef value.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Reduces memory usage by properly excluding optional fields when their corresponding features are not defined

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal code generation change)

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes needed - this is an internal code generation fix
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

## Additional details

The change includes two fixes:

1. **Protobuf generation fix**: Adds a `get_common_field_ifdef()` helper function that checks if all messages sharing a common field have the same `field_ifdef` option. If they do, the base class field declaration is wrapped with the appropriate ifdef guard.

2. **API connection fix**: Wraps the `icon` field access in `api_connection.h` with `#ifdef USE_ENTITY_ICON` to match the generated protobuf headers.

This reduces memory usage by excluding fields when their features are disabled:
- `device_id` field (4 bytes + padding) when `USE_DEVICES` is not defined
- `icon` field (string object overhead) when `USE_ENTITY_ICON` is not defined

This is particularly important for memory-constrained devices where every byte counts.