### PR TITLE
[bluetooth_proxy] Fix service discovery on disconnect and refactor connection handling

### DIFF
--- a/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
@@ -360,13 +360,13 @@ esp_err_t BluetoothConnection::read_descriptor(uint16_t handle) {
              this->address_str().c_str());
     return ESP_GATT_NOT_CONNECTED;
   }
-  ESP_LOGV(TAG, "[%d] [%s] Reading GATT descriptor handle %d", this->get_connection_index(), this->address_str_.c_str(),
-           handle);
+  ESP_LOGV(TAG, "[%d] [%s] Reading GATT descriptor handle %d", this->get_connection_index(),
+           this->address_str().c_str(), handle);
 
   esp_err_t err = esp_ble_gattc_read_char_descr(this->gattc_if_, this->conn_id_, handle, ESP_GATT_AUTH_REQ_NONE);
   if (err != ERR_OK) {
     ESP_LOGW(TAG, "[%d] [%s] esp_ble_gattc_read_char_descr error, err=%d", this->get_connection_index(),
-             this->address_str_.c_str(), err);
+             this->address_str().c_str(), err);
     return err;
   }
   return ESP_OK;
@@ -378,15 +378,15 @@ esp_err_t BluetoothConnection::write_descriptor(uint16_t handle, const std::stri
              this->address_str().c_str());
     return ESP_GATT_NOT_CONNECTED;
   }
-  ESP_LOGV(TAG, "[%d] [%s] Writing GATT descriptor handle %d", this->get_connection_index(), this->address_str_.c_str(),
-           handle);
+  ESP_LOGV(TAG, "[%d] [%s] Writing GATT descriptor handle %d", this->get_connection_index(),
+           this->address_str().c_str(), handle);
 
   esp_err_t err = esp_ble_gattc_write_char_descr(
       this->gattc_if_, this->conn_id_, handle, data.size(), (uint8_t *) data.data(),
       response ? ESP_GATT_WRITE_TYPE_RSP : ESP_GATT_WRITE_TYPE_NO_RSP, ESP_GATT_AUTH_REQ_NONE);
   if (err != ERR_OK) {
     ESP_LOGW(TAG, "[%d] [%s] esp_ble_gattc_write_char_descr error, err=%d", this->get_connection_index(),
-             this->address_str_.c_str(), err);
+             this->address_str().c_str(), err);
     return err;
   }
   return ESP_OK;
@@ -405,7 +405,7 @@ esp_err_t BluetoothConnection::notify_characteristic(uint16_t handle, bool enabl
     esp_err_t err = esp_ble_gattc_register_for_notify(this->gattc_if_, this->remote_bda_, handle);
     if (err != ESP_OK) {
       ESP_LOGW(TAG, "[%d] [%s] esp_ble_gattc_register_for_notify failed, err=%d", this->get_connection_index(),
-               this->address_str_.c_str(), err);
+               this->address_str().c_str(), err);
       return err;
     }
   } else {
@@ -414,7 +414,7 @@ esp_err_t BluetoothConnection::notify_characteristic(uint16_t handle, bool enabl
     esp_err_t err = esp_ble_gattc_unregister_for_notify(this->gattc_if_, this->remote_bda_, handle);
     if (err != ESP_OK) {
       ESP_LOGW(TAG, "[%d] [%s] esp_ble_gattc_unregister_for_notify failed, err=%d", this->get_connection_index(),
-               this->address_str_.c_str(), err);
+               this->address_str().c_str(), err);
       return err;
     }
   }

--- a/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
@@ -323,12 +323,12 @@ esp_err_t BluetoothConnection::read_characteristic(uint16_t handle) {
   }
 
   ESP_LOGV(TAG, "[%d] [%s] Reading GATT characteristic handle %d", this->get_connection_index(),
-           this->address_str_.c_str(), handle);
+           this->address_str().c_str(), handle);
 
   esp_err_t err = esp_ble_gattc_read_char(this->gattc_if_, this->conn_id_, handle, ESP_GATT_AUTH_REQ_NONE);
   if (err != ERR_OK) {
     ESP_LOGW(TAG, "[%d] [%s] esp_ble_gattc_read_char error, err=%d", this->get_connection_index(),
-             this->address_str_.c_str(), err);
+             this->address_str().c_str(), err);
     return err;
   }
   return ESP_OK;

--- a/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
@@ -65,6 +65,12 @@ void BluetoothConnection::send_service_for_discovery_() {
     return;
   }
 
+  // Early return if no API connection
+  auto *api_conn = this->proxy_->get_api_connection();
+  if (api_conn == nullptr) {
+    return;
+  }
+
   // Send next service
   esp_gattc_service_elem_t service_result;
   uint16_t service_count = 1;
@@ -174,10 +180,8 @@ void BluetoothConnection::send_service_for_discovery_() {
   }
   resp.services.push_back(std::move(service_resp));
 
-  auto *api_conn = this->proxy_->get_api_connection();
-  if (api_conn != nullptr) {
-    api_conn->send_message(resp, api::BluetoothGATTGetServicesResponse::MESSAGE_TYPE);
-  }
+  // Send the message (we already checked api_conn is not null at the beginning)
+  api_conn->send_message(resp, api::BluetoothGATTGetServicesResponse::MESSAGE_TYPE);
 }
 
 bool BluetoothConnection::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if,

--- a/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
@@ -68,18 +68,18 @@ void BluetoothConnection::send_service_for_discovery_() {
   // Send next service
   esp_gattc_service_elem_t service_result;
   uint16_t service_count = 1;
-  esp_gatt_status_t service_status = esp_ble_gattc_get_service(this->get_gattc_if(), this->get_conn_id(), nullptr,
+  esp_gatt_status_t service_status = esp_ble_gattc_get_service(this->get_gattc_if(), this->conn_id_, nullptr,
                                                                &service_result, &service_count, this->send_service_);
   this->send_service_++;
 
   if (service_status != ESP_GATT_OK) {
-    ESP_LOGE(TAG, "[%d] [%s] esp_ble_gattc_get_service error at offset=%d, status=%d", this->get_connection_index(),
+    ESP_LOGE(TAG, "[%d] [%s] esp_ble_gattc_get_service error at offset=%d, status=%d", this->connection_index_,
              this->address_str().c_str(), this->send_service_ - 1, service_status);
     return;
   }
 
   if (service_count == 0) {
-    ESP_LOGE(TAG, "[%d] [%s] esp_ble_gattc_get_service missing, service_count=%d", this->get_connection_index(),
+    ESP_LOGE(TAG, "[%d] [%s] esp_ble_gattc_get_service missing, service_count=%d", this->connection_index_,
              this->address_str().c_str(), service_count);
     return;
   }
@@ -94,14 +94,14 @@ void BluetoothConnection::send_service_for_discovery_() {
   // Get the number of characteristics directly with one call
   uint16_t total_char_count = 0;
   esp_gatt_status_t char_count_status =
-      esp_ble_gattc_get_attr_count(this->get_gattc_if(), this->get_conn_id(), ESP_GATT_DB_CHARACTERISTIC,
+      esp_ble_gattc_get_attr_count(this->get_gattc_if(), this->conn_id_, ESP_GATT_DB_CHARACTERISTIC,
                                    service_result.start_handle, service_result.end_handle, 0, &total_char_count);
 
   if (char_count_status == ESP_GATT_OK && total_char_count > 0) {
     // Only reserve if we successfully got a count
     service_resp.characteristics.reserve(total_char_count);
   } else if (char_count_status != ESP_GATT_OK) {
-    ESP_LOGW(TAG, "[%d] [%s] Error getting characteristic count, status=%d", this->get_connection_index(),
+    ESP_LOGW(TAG, "[%d] [%s] Error getting characteristic count, status=%d", this->connection_index_,
              this->address_str().c_str(), char_count_status);
   }
 
@@ -111,13 +111,13 @@ void BluetoothConnection::send_service_for_discovery_() {
   while (true) {  // characteristics
     uint16_t char_count = 1;
     esp_gatt_status_t char_status =
-        esp_ble_gattc_get_all_char(this->get_gattc_if(), this->get_conn_id(), service_result.start_handle,
+        esp_ble_gattc_get_all_char(this->get_gattc_if(), this->conn_id_, service_result.start_handle,
                                    service_result.end_handle, &char_result, &char_count, char_offset);
     if (char_status == ESP_GATT_INVALID_OFFSET || char_status == ESP_GATT_NOT_FOUND) {
       break;
     }
     if (char_status != ESP_GATT_OK) {
-      ESP_LOGE(TAG, "[%d] [%s] esp_ble_gattc_get_all_char error, status=%d", this->get_connection_index(),
+      ESP_LOGE(TAG, "[%d] [%s] esp_ble_gattc_get_all_char error, status=%d", this->connection_index_,
                this->address_str().c_str(), char_status);
       break;
     }
@@ -134,15 +134,15 @@ void BluetoothConnection::send_service_for_discovery_() {
     // Get the number of descriptors directly with one call
     uint16_t total_desc_count = 0;
     esp_gatt_status_t desc_count_status =
-        esp_ble_gattc_get_attr_count(this->get_gattc_if(), this->get_conn_id(), ESP_GATT_DB_DESCRIPTOR,
+        esp_ble_gattc_get_attr_count(this->get_gattc_if(), this->conn_id_, ESP_GATT_DB_DESCRIPTOR,
                                      char_result.char_handle, service_result.end_handle, 0, &total_desc_count);
 
     if (desc_count_status == ESP_GATT_OK && total_desc_count > 0) {
       // Only reserve if we successfully got a count
       characteristic_resp.descriptors.reserve(total_desc_count);
     } else if (desc_count_status != ESP_GATT_OK) {
-      ESP_LOGW(TAG, "[%d] [%s] Error getting descriptor count for char handle %d, status=%d",
-               this->get_connection_index(), this->address_str().c_str(), char_result.char_handle, desc_count_status);
+      ESP_LOGW(TAG, "[%d] [%s] Error getting descriptor count for char handle %d, status=%d", this->connection_index_,
+               this->address_str().c_str(), char_result.char_handle, desc_count_status);
     }
 
     // Now process descriptors
@@ -151,12 +151,12 @@ void BluetoothConnection::send_service_for_discovery_() {
     while (true) {  // descriptors
       uint16_t desc_count = 1;
       esp_gatt_status_t desc_status = esp_ble_gattc_get_all_descr(
-          this->get_gattc_if(), this->get_conn_id(), char_result.char_handle, &desc_result, &desc_count, desc_offset);
+          this->get_gattc_if(), this->conn_id_, char_result.char_handle, &desc_result, &desc_count, desc_offset);
       if (desc_status == ESP_GATT_INVALID_OFFSET || desc_status == ESP_GATT_NOT_FOUND) {
         break;
       }
       if (desc_status != ESP_GATT_OK) {
-        ESP_LOGE(TAG, "[%d] [%s] esp_ble_gattc_get_all_descr error, status=%d", this->get_connection_index(),
+        ESP_LOGE(TAG, "[%d] [%s] esp_ble_gattc_get_all_descr error, status=%d", this->connection_index_,
                  this->address_str().c_str(), desc_status);
         break;
       }

--- a/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
@@ -13,9 +13,172 @@ namespace bluetooth_proxy {
 
 static const char *const TAG = "bluetooth_proxy.connection";
 
+// Helper function from bluetooth_proxy.cpp
+static std::vector<uint64_t> get_128bit_uuid_vec(esp_bt_uuid_t uuid_source) {
+  esp_bt_uuid_t uuid = espbt::ESPBTUUID::from_uuid(uuid_source).as_128bit().get_uuid();
+  return std::vector<uint64_t>{((uint64_t) uuid.uuid.uuid128[15] << 56) | ((uint64_t) uuid.uuid.uuid128[14] << 48) |
+                                   ((uint64_t) uuid.uuid.uuid128[13] << 40) | ((uint64_t) uuid.uuid.uuid128[12] << 32) |
+                                   ((uint64_t) uuid.uuid.uuid128[11] << 24) | ((uint64_t) uuid.uuid.uuid128[10] << 16) |
+                                   ((uint64_t) uuid.uuid.uuid128[9] << 8) | ((uint64_t) uuid.uuid.uuid128[8]),
+                               ((uint64_t) uuid.uuid.uuid128[7] << 56) | ((uint64_t) uuid.uuid.uuid128[6] << 48) |
+                                   ((uint64_t) uuid.uuid.uuid128[5] << 40) | ((uint64_t) uuid.uuid.uuid128[4] << 32) |
+                                   ((uint64_t) uuid.uuid.uuid128[3] << 24) | ((uint64_t) uuid.uuid.uuid128[2] << 16) |
+                                   ((uint64_t) uuid.uuid.uuid128[1] << 8) | ((uint64_t) uuid.uuid.uuid128[0])};
+}
+
 void BluetoothConnection::dump_config() {
   ESP_LOGCONFIG(TAG, "BLE Connection:");
   BLEClientBase::dump_config();
+}
+
+void BluetoothConnection::loop() {
+  BLEClientBase::loop();
+
+  // Early return if no active connection or not in service discovery phase
+  if (this->address_ == 0 || this->send_service_ < 0 || this->send_service_ > this->service_count_) {
+    return;
+  }
+
+  // Handle service discovery
+  this->send_service_for_discovery_();
+}
+
+void BluetoothConnection::reset_connection_() {
+  // Important: If we were in the middle of sending services, we do NOT send
+  // send_gatt_services_done() here. This ensures the client knows that
+  // the service discovery was interrupted and can retry. The client
+  // (aioesphomeapi) implements a 30-second timeout (DEFAULT_BLE_TIMEOUT)
+  // to detect incomplete service discovery rather than relying on us to
+  // tell them about a partial list.
+  this->set_address(0);
+  this->send_service_ = DONE_SENDING_SERVICES;
+  this->proxy_->send_connections_free();
+}
+
+void BluetoothConnection::send_service_for_discovery_() {
+  if (this->send_service_ == this->service_count_) {
+    this->send_service_ = DONE_SENDING_SERVICES;
+    this->proxy_->send_gatt_services_done(this->get_address());
+    if (this->connection_type_ == espbt::ConnectionType::V3_WITH_CACHE ||
+        this->connection_type_ == espbt::ConnectionType::V3_WITHOUT_CACHE) {
+      this->release_services();
+    }
+    return;
+  }
+
+  // Send next service
+  esp_gattc_service_elem_t service_result;
+  uint16_t service_count = 1;
+  esp_gatt_status_t service_status = esp_ble_gattc_get_service(this->get_gattc_if(), this->get_conn_id(), nullptr,
+                                                               &service_result, &service_count, this->send_service_);
+  this->send_service_++;
+
+  if (service_status != ESP_GATT_OK) {
+    ESP_LOGE(TAG, "[%d] [%s] esp_ble_gattc_get_service error at offset=%d, status=%d", this->get_connection_index(),
+             this->address_str().c_str(), this->send_service_ - 1, service_status);
+    return;
+  }
+
+  if (service_count == 0) {
+    ESP_LOGE(TAG, "[%d] [%s] esp_ble_gattc_get_service missing, service_count=%d", this->get_connection_index(),
+             this->address_str().c_str(), service_count);
+    return;
+  }
+
+  api::BluetoothGATTGetServicesResponse resp;
+  resp.address = this->get_address();
+  resp.services.reserve(1);  // Always one service per response in this implementation
+  api::BluetoothGATTService service_resp;
+  service_resp.uuid = get_128bit_uuid_vec(service_result.uuid);
+  service_resp.handle = service_result.start_handle;
+
+  // Get the number of characteristics directly with one call
+  uint16_t total_char_count = 0;
+  esp_gatt_status_t char_count_status =
+      esp_ble_gattc_get_attr_count(this->get_gattc_if(), this->get_conn_id(), ESP_GATT_DB_CHARACTERISTIC,
+                                   service_result.start_handle, service_result.end_handle, 0, &total_char_count);
+
+  if (char_count_status == ESP_GATT_OK && total_char_count > 0) {
+    // Only reserve if we successfully got a count
+    service_resp.characteristics.reserve(total_char_count);
+  } else if (char_count_status != ESP_GATT_OK) {
+    ESP_LOGW(TAG, "[%d] [%s] Error getting characteristic count, status=%d", this->get_connection_index(),
+             this->address_str().c_str(), char_count_status);
+  }
+
+  // Now process characteristics
+  uint16_t char_offset = 0;
+  esp_gattc_char_elem_t char_result;
+  while (true) {  // characteristics
+    uint16_t char_count = 1;
+    esp_gatt_status_t char_status =
+        esp_ble_gattc_get_all_char(this->get_gattc_if(), this->get_conn_id(), service_result.start_handle,
+                                   service_result.end_handle, &char_result, &char_count, char_offset);
+    if (char_status == ESP_GATT_INVALID_OFFSET || char_status == ESP_GATT_NOT_FOUND) {
+      break;
+    }
+    if (char_status != ESP_GATT_OK) {
+      ESP_LOGE(TAG, "[%d] [%s] esp_ble_gattc_get_all_char error, status=%d", this->get_connection_index(),
+               this->address_str().c_str(), char_status);
+      break;
+    }
+    if (char_count == 0) {
+      break;
+    }
+
+    api::BluetoothGATTCharacteristic characteristic_resp;
+    characteristic_resp.uuid = get_128bit_uuid_vec(char_result.uuid);
+    characteristic_resp.handle = char_result.char_handle;
+    characteristic_resp.properties = char_result.properties;
+    char_offset++;
+
+    // Get the number of descriptors directly with one call
+    uint16_t total_desc_count = 0;
+    esp_gatt_status_t desc_count_status =
+        esp_ble_gattc_get_attr_count(this->get_gattc_if(), this->get_conn_id(), ESP_GATT_DB_DESCRIPTOR,
+                                     char_result.char_handle, service_result.end_handle, 0, &total_desc_count);
+
+    if (desc_count_status == ESP_GATT_OK && total_desc_count > 0) {
+      // Only reserve if we successfully got a count
+      characteristic_resp.descriptors.reserve(total_desc_count);
+    } else if (desc_count_status != ESP_GATT_OK) {
+      ESP_LOGW(TAG, "[%d] [%s] Error getting descriptor count for char handle %d, status=%d",
+               this->get_connection_index(), this->address_str().c_str(), char_result.char_handle, desc_count_status);
+    }
+
+    // Now process descriptors
+    uint16_t desc_offset = 0;
+    esp_gattc_descr_elem_t desc_result;
+    while (true) {  // descriptors
+      uint16_t desc_count = 1;
+      esp_gatt_status_t desc_status = esp_ble_gattc_get_all_descr(
+          this->get_gattc_if(), this->get_conn_id(), char_result.char_handle, &desc_result, &desc_count, desc_offset);
+      if (desc_status == ESP_GATT_INVALID_OFFSET || desc_status == ESP_GATT_NOT_FOUND) {
+        break;
+      }
+      if (desc_status != ESP_GATT_OK) {
+        ESP_LOGE(TAG, "[%d] [%s] esp_ble_gattc_get_all_descr error, status=%d", this->get_connection_index(),
+                 this->address_str().c_str(), desc_status);
+        break;
+      }
+      if (desc_count == 0) {
+        break;
+      }
+
+      api::BluetoothGATTDescriptor descriptor_resp;
+      descriptor_resp.uuid = get_128bit_uuid_vec(desc_result.uuid);
+      descriptor_resp.handle = desc_result.handle;
+      characteristic_resp.descriptors.push_back(std::move(descriptor_resp));
+      desc_offset++;
+    }
+    service_resp.characteristics.push_back(std::move(characteristic_resp));
+  }
+  resp.services.push_back(std::move(service_resp));
+
+  auto *api_conn = this->proxy_->get_api_connection();
+  if (api_conn != nullptr) {
+    api_conn->send_message(resp, api::BluetoothGATTGetServicesResponse::MESSAGE_TYPE);
+  }
 }
 
 bool BluetoothConnection::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if,
@@ -26,21 +189,18 @@ bool BluetoothConnection::gattc_event_handler(esp_gattc_cb_event_t event, esp_ga
   switch (event) {
     case ESP_GATTC_DISCONNECT_EVT: {
       this->proxy_->send_device_connection(this->address_, false, 0, param->disconnect.reason);
-      this->set_address(0);
-      this->proxy_->send_connections_free();
+      this->reset_connection_();
       break;
     }
     case ESP_GATTC_CLOSE_EVT: {
       this->proxy_->send_device_connection(this->address_, false, 0, param->close.reason);
-      this->set_address(0);
-      this->proxy_->send_connections_free();
+      this->reset_connection_();
       break;
     }
     case ESP_GATTC_OPEN_EVT: {
       if (param->open.status != ESP_GATT_OK && param->open.status != ESP_GATT_ALREADY_OPEN) {
         this->proxy_->send_device_connection(this->address_, false, 0, param->open.status);
-        this->set_address(0);
-        this->proxy_->send_connections_free();
+        this->reset_connection_();
       } else if (this->connection_type_ == espbt::ConnectionType::V3_WITH_CACHE) {
         this->proxy_->send_device_connection(this->address_, true, this->mtu_);
         this->proxy_->send_connections_free();

--- a/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
@@ -341,14 +341,14 @@ esp_err_t BluetoothConnection::write_characteristic(uint16_t handle, const std::
     return ESP_GATT_NOT_CONNECTED;
   }
   ESP_LOGV(TAG, "[%d] [%s] Writing GATT characteristic handle %d", this->get_connection_index(),
-           this->address_str().c_str(), handle);
+           this->address_str_.c_str(), handle);
 
   esp_err_t err =
       esp_ble_gattc_write_char(this->gattc_if_, this->conn_id_, handle, data.size(), (uint8_t *) data.data(),
                                response ? ESP_GATT_WRITE_TYPE_RSP : ESP_GATT_WRITE_TYPE_NO_RSP, ESP_GATT_AUTH_REQ_NONE);
   if (err != ERR_OK) {
     ESP_LOGW(TAG, "[%d] [%s] esp_ble_gattc_write_char error, err=%d", this->get_connection_index(),
-             this->address_str().c_str(), err);
+             this->address_str_.c_str(), err);
     return err;
   }
   return ESP_OK;

--- a/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
@@ -60,7 +60,7 @@ void BluetoothConnection::reset_connection_(esp_err_t reason) {
 void BluetoothConnection::send_service_for_discovery_() {
   if (this->send_service_ == this->service_count_) {
     this->send_service_ = DONE_SENDING_SERVICES;
-    this->proxy_->send_gatt_services_done(this->get_address());
+    this->proxy_->send_gatt_services_done(this->address_);
     if (this->connection_type_ == espbt::ConnectionType::V3_WITH_CACHE ||
         this->connection_type_ == espbt::ConnectionType::V3_WITHOUT_CACHE) {
       this->release_services();
@@ -94,7 +94,7 @@ void BluetoothConnection::send_service_for_discovery_() {
   }
 
   api::BluetoothGATTGetServicesResponse resp;
-  resp.address = this->get_address();
+  resp.address = this->address_;
   resp.services.reserve(1);  // Always one service per response in this implementation
   api::BluetoothGATTService service_resp;
   service_resp.uuid = get_128bit_uuid_vec(service_result.uuid);

--- a/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
@@ -323,12 +323,12 @@ esp_err_t BluetoothConnection::read_characteristic(uint16_t handle) {
   }
 
   ESP_LOGV(TAG, "[%d] [%s] Reading GATT characteristic handle %d", this->get_connection_index(),
-           this->address_str().c_str(), handle);
+           this->address_str_.c_str(), handle);
 
   esp_err_t err = esp_ble_gattc_read_char(this->gattc_if_, this->conn_id_, handle, ESP_GATT_AUTH_REQ_NONE);
   if (err != ERR_OK) {
     ESP_LOGW(TAG, "[%d] [%s] esp_ble_gattc_read_char error, err=%d", this->get_connection_index(),
-             this->address_str().c_str(), err);
+             this->address_str_.c_str(), err);
     return err;
   }
   return ESP_OK;

--- a/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
@@ -68,7 +68,7 @@ void BluetoothConnection::send_service_for_discovery_() {
   // Send next service
   esp_gattc_service_elem_t service_result;
   uint16_t service_count = 1;
-  esp_gatt_status_t service_status = esp_ble_gattc_get_service(this->get_gattc_if(), this->conn_id_, nullptr,
+  esp_gatt_status_t service_status = esp_ble_gattc_get_service(this->gattc_if_, this->conn_id_, nullptr,
                                                                &service_result, &service_count, this->send_service_);
   this->send_service_++;
 
@@ -94,7 +94,7 @@ void BluetoothConnection::send_service_for_discovery_() {
   // Get the number of characteristics directly with one call
   uint16_t total_char_count = 0;
   esp_gatt_status_t char_count_status =
-      esp_ble_gattc_get_attr_count(this->get_gattc_if(), this->conn_id_, ESP_GATT_DB_CHARACTERISTIC,
+      esp_ble_gattc_get_attr_count(this->gattc_if_, this->conn_id_, ESP_GATT_DB_CHARACTERISTIC,
                                    service_result.start_handle, service_result.end_handle, 0, &total_char_count);
 
   if (char_count_status == ESP_GATT_OK && total_char_count > 0) {
@@ -111,7 +111,7 @@ void BluetoothConnection::send_service_for_discovery_() {
   while (true) {  // characteristics
     uint16_t char_count = 1;
     esp_gatt_status_t char_status =
-        esp_ble_gattc_get_all_char(this->get_gattc_if(), this->conn_id_, service_result.start_handle,
+        esp_ble_gattc_get_all_char(this->gattc_if_, this->conn_id_, service_result.start_handle,
                                    service_result.end_handle, &char_result, &char_count, char_offset);
     if (char_status == ESP_GATT_INVALID_OFFSET || char_status == ESP_GATT_NOT_FOUND) {
       break;
@@ -134,8 +134,8 @@ void BluetoothConnection::send_service_for_discovery_() {
     // Get the number of descriptors directly with one call
     uint16_t total_desc_count = 0;
     esp_gatt_status_t desc_count_status =
-        esp_ble_gattc_get_attr_count(this->get_gattc_if(), this->conn_id_, ESP_GATT_DB_DESCRIPTOR,
-                                     char_result.char_handle, service_result.end_handle, 0, &total_desc_count);
+        esp_ble_gattc_get_attr_count(this->gattc_if_, this->conn_id_, ESP_GATT_DB_DESCRIPTOR, char_result.char_handle,
+                                     service_result.end_handle, 0, &total_desc_count);
 
     if (desc_count_status == ESP_GATT_OK && total_desc_count > 0) {
       // Only reserve if we successfully got a count
@@ -151,7 +151,7 @@ void BluetoothConnection::send_service_for_discovery_() {
     while (true) {  // descriptors
       uint16_t desc_count = 1;
       esp_gatt_status_t desc_status = esp_ble_gattc_get_all_descr(
-          this->get_gattc_if(), this->conn_id_, char_result.char_handle, &desc_result, &desc_count, desc_offset);
+          this->gattc_if_, this->conn_id_, char_result.char_handle, &desc_result, &desc_count, desc_offset);
       if (desc_status == ESP_GATT_INVALID_OFFSET || desc_status == ESP_GATT_NOT_FOUND) {
         break;
       }

--- a/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
@@ -223,8 +223,8 @@ bool BluetoothConnection::gattc_event_handler(esp_gattc_cb_event_t event, esp_ga
     case ESP_GATTC_READ_DESCR_EVT:
     case ESP_GATTC_READ_CHAR_EVT: {
       if (param->read.status != ESP_GATT_OK) {
-        ESP_LOGW(TAG, "[%d] [%s] Error reading char/descriptor at handle 0x%2X, status=%d", this->connection_index_,
-                 this->address_str().c_str(), param->read.handle, param->read.status);
+        ESP_LOGW(TAG, "[%d] [%s] Error reading char/descriptor at handle 0x%2X, status=%d",
+                 this->get_connection_index(), this->address_str().c_str(), param->read.handle, param->read.status);
         this->proxy_->send_gatt_error(this->address_, param->read.handle, param->read.status);
         break;
       }
@@ -240,8 +240,8 @@ bool BluetoothConnection::gattc_event_handler(esp_gattc_cb_event_t event, esp_ga
     case ESP_GATTC_WRITE_CHAR_EVT:
     case ESP_GATTC_WRITE_DESCR_EVT: {
       if (param->write.status != ESP_GATT_OK) {
-        ESP_LOGW(TAG, "[%d] [%s] Error writing char/descriptor at handle 0x%2X, status=%d", this->connection_index_,
-                 this->address_str().c_str(), param->write.handle, param->write.status);
+        ESP_LOGW(TAG, "[%d] [%s] Error writing char/descriptor at handle 0x%2X, status=%d",
+                 this->get_connection_index(), this->address_str().c_str(), param->write.handle, param->write.status);
         this->proxy_->send_gatt_error(this->address_, param->write.handle, param->write.status);
         break;
       }
@@ -254,7 +254,7 @@ bool BluetoothConnection::gattc_event_handler(esp_gattc_cb_event_t event, esp_ga
     case ESP_GATTC_UNREG_FOR_NOTIFY_EVT: {
       if (param->unreg_for_notify.status != ESP_GATT_OK) {
         ESP_LOGW(TAG, "[%d] [%s] Error unregistering notifications for handle 0x%2X, status=%d",
-                 this->connection_index_, this->address_str().c_str(), param->unreg_for_notify.handle,
+                 this->get_connection_index(), this->address_str().c_str(), param->unreg_for_notify.handle,
                  param->unreg_for_notify.status);
         this->proxy_->send_gatt_error(this->address_, param->unreg_for_notify.handle, param->unreg_for_notify.status);
         break;
@@ -267,8 +267,9 @@ bool BluetoothConnection::gattc_event_handler(esp_gattc_cb_event_t event, esp_ga
     }
     case ESP_GATTC_REG_FOR_NOTIFY_EVT: {
       if (param->reg_for_notify.status != ESP_GATT_OK) {
-        ESP_LOGW(TAG, "[%d] [%s] Error registering notifications for handle 0x%2X, status=%d", this->connection_index_,
-                 this->address_str().c_str(), param->reg_for_notify.handle, param->reg_for_notify.status);
+        ESP_LOGW(TAG, "[%d] [%s] Error registering notifications for handle 0x%2X, status=%d",
+                 this->get_connection_index(), this->address_str().c_str(), param->reg_for_notify.handle,
+                 param->reg_for_notify.status);
         this->proxy_->send_gatt_error(this->address_, param->reg_for_notify.handle, param->reg_for_notify.status);
         break;
       }
@@ -279,7 +280,7 @@ bool BluetoothConnection::gattc_event_handler(esp_gattc_cb_event_t event, esp_ga
       break;
     }
     case ESP_GATTC_NOTIFY_EVT: {
-      ESP_LOGV(TAG, "[%d] [%s] ESP_GATTC_NOTIFY_EVT: handle=0x%2X", this->connection_index_,
+      ESP_LOGV(TAG, "[%d] [%s] ESP_GATTC_NOTIFY_EVT: handle=0x%2X", this->get_connection_index(),
                this->address_str().c_str(), param->notify.handle);
       api::BluetoothGATTNotifyDataResponse resp;
       resp.address = this->address_;
@@ -316,17 +317,17 @@ void BluetoothConnection::gap_event_handler(esp_gap_ble_cb_event_t event, esp_bl
 
 esp_err_t BluetoothConnection::read_characteristic(uint16_t handle) {
   if (!this->connected()) {
-    ESP_LOGW(TAG, "[%d] [%s] Cannot read GATT characteristic, not connected.", this->connection_index_,
+    ESP_LOGW(TAG, "[%d] [%s] Cannot read GATT characteristic, not connected.", this->get_connection_index(),
              this->address_str().c_str());
     return ESP_GATT_NOT_CONNECTED;
   }
 
-  ESP_LOGV(TAG, "[%d] [%s] Reading GATT characteristic handle %d", this->connection_index_, this->address_str_.c_str(),
-           handle);
+  ESP_LOGV(TAG, "[%d] [%s] Reading GATT characteristic handle %d", this->get_connection_index(),
+           this->address_str_.c_str(), handle);
 
   esp_err_t err = esp_ble_gattc_read_char(this->gattc_if_, this->conn_id_, handle, ESP_GATT_AUTH_REQ_NONE);
   if (err != ERR_OK) {
-    ESP_LOGW(TAG, "[%d] [%s] esp_ble_gattc_read_char error, err=%d", this->connection_index_,
+    ESP_LOGW(TAG, "[%d] [%s] esp_ble_gattc_read_char error, err=%d", this->get_connection_index(),
              this->address_str_.c_str(), err);
     return err;
   }
@@ -335,18 +336,18 @@ esp_err_t BluetoothConnection::read_characteristic(uint16_t handle) {
 
 esp_err_t BluetoothConnection::write_characteristic(uint16_t handle, const std::string &data, bool response) {
   if (!this->connected()) {
-    ESP_LOGW(TAG, "[%d] [%s] Cannot write GATT characteristic, not connected.", this->connection_index_,
+    ESP_LOGW(TAG, "[%d] [%s] Cannot write GATT characteristic, not connected.", this->get_connection_index(),
              this->address_str().c_str());
     return ESP_GATT_NOT_CONNECTED;
   }
-  ESP_LOGV(TAG, "[%d] [%s] Writing GATT characteristic handle %d", this->connection_index_, this->address_str_.c_str(),
-           handle);
+  ESP_LOGV(TAG, "[%d] [%s] Writing GATT characteristic handle %d", this->get_connection_index(),
+           this->address_str_.c_str(), handle);
 
   esp_err_t err =
       esp_ble_gattc_write_char(this->gattc_if_, this->conn_id_, handle, data.size(), (uint8_t *) data.data(),
                                response ? ESP_GATT_WRITE_TYPE_RSP : ESP_GATT_WRITE_TYPE_NO_RSP, ESP_GATT_AUTH_REQ_NONE);
   if (err != ERR_OK) {
-    ESP_LOGW(TAG, "[%d] [%s] esp_ble_gattc_write_char error, err=%d", this->connection_index_,
+    ESP_LOGW(TAG, "[%d] [%s] esp_ble_gattc_write_char error, err=%d", this->get_connection_index(),
              this->address_str_.c_str(), err);
     return err;
   }
@@ -355,16 +356,16 @@ esp_err_t BluetoothConnection::write_characteristic(uint16_t handle, const std::
 
 esp_err_t BluetoothConnection::read_descriptor(uint16_t handle) {
   if (!this->connected()) {
-    ESP_LOGW(TAG, "[%d] [%s] Cannot read GATT descriptor, not connected.", this->connection_index_,
+    ESP_LOGW(TAG, "[%d] [%s] Cannot read GATT descriptor, not connected.", this->get_connection_index(),
              this->address_str().c_str());
     return ESP_GATT_NOT_CONNECTED;
   }
-  ESP_LOGV(TAG, "[%d] [%s] Reading GATT descriptor handle %d", this->connection_index_, this->address_str_.c_str(),
+  ESP_LOGV(TAG, "[%d] [%s] Reading GATT descriptor handle %d", this->get_connection_index(), this->address_str_.c_str(),
            handle);
 
   esp_err_t err = esp_ble_gattc_read_char_descr(this->gattc_if_, this->conn_id_, handle, ESP_GATT_AUTH_REQ_NONE);
   if (err != ERR_OK) {
-    ESP_LOGW(TAG, "[%d] [%s] esp_ble_gattc_read_char_descr error, err=%d", this->connection_index_,
+    ESP_LOGW(TAG, "[%d] [%s] esp_ble_gattc_read_char_descr error, err=%d", this->get_connection_index(),
              this->address_str_.c_str(), err);
     return err;
   }
@@ -373,18 +374,18 @@ esp_err_t BluetoothConnection::read_descriptor(uint16_t handle) {
 
 esp_err_t BluetoothConnection::write_descriptor(uint16_t handle, const std::string &data, bool response) {
   if (!this->connected()) {
-    ESP_LOGW(TAG, "[%d] [%s] Cannot write GATT descriptor, not connected.", this->connection_index_,
+    ESP_LOGW(TAG, "[%d] [%s] Cannot write GATT descriptor, not connected.", this->get_connection_index(),
              this->address_str().c_str());
     return ESP_GATT_NOT_CONNECTED;
   }
-  ESP_LOGV(TAG, "[%d] [%s] Writing GATT descriptor handle %d", this->connection_index_, this->address_str_.c_str(),
+  ESP_LOGV(TAG, "[%d] [%s] Writing GATT descriptor handle %d", this->get_connection_index(), this->address_str_.c_str(),
            handle);
 
   esp_err_t err = esp_ble_gattc_write_char_descr(
       this->gattc_if_, this->conn_id_, handle, data.size(), (uint8_t *) data.data(),
       response ? ESP_GATT_WRITE_TYPE_RSP : ESP_GATT_WRITE_TYPE_NO_RSP, ESP_GATT_AUTH_REQ_NONE);
   if (err != ERR_OK) {
-    ESP_LOGW(TAG, "[%d] [%s] esp_ble_gattc_write_char_descr error, err=%d", this->connection_index_,
+    ESP_LOGW(TAG, "[%d] [%s] esp_ble_gattc_write_char_descr error, err=%d", this->get_connection_index(),
              this->address_str_.c_str(), err);
     return err;
   }
@@ -393,26 +394,26 @@ esp_err_t BluetoothConnection::write_descriptor(uint16_t handle, const std::stri
 
 esp_err_t BluetoothConnection::notify_characteristic(uint16_t handle, bool enable) {
   if (!this->connected()) {
-    ESP_LOGW(TAG, "[%d] [%s] Cannot notify GATT characteristic, not connected.", this->connection_index_,
+    ESP_LOGW(TAG, "[%d] [%s] Cannot notify GATT characteristic, not connected.", this->get_connection_index(),
              this->address_str().c_str());
     return ESP_GATT_NOT_CONNECTED;
   }
 
   if (enable) {
-    ESP_LOGV(TAG, "[%d] [%s] Registering for GATT characteristic notifications handle %d", this->connection_index_,
+    ESP_LOGV(TAG, "[%d] [%s] Registering for GATT characteristic notifications handle %d", this->get_connection_index(),
              this->address_str_.c_str(), handle);
     esp_err_t err = esp_ble_gattc_register_for_notify(this->gattc_if_, this->remote_bda_, handle);
     if (err != ESP_OK) {
-      ESP_LOGW(TAG, "[%d] [%s] esp_ble_gattc_register_for_notify failed, err=%d", this->connection_index_,
+      ESP_LOGW(TAG, "[%d] [%s] esp_ble_gattc_register_for_notify failed, err=%d", this->get_connection_index(),
                this->address_str_.c_str(), err);
       return err;
     }
   } else {
-    ESP_LOGV(TAG, "[%d] [%s] Unregistering for GATT characteristic notifications handle %d", this->connection_index_,
-             this->address_str_.c_str(), handle);
+    ESP_LOGV(TAG, "[%d] [%s] Unregistering for GATT characteristic notifications handle %d",
+             this->get_connection_index(), this->address_str_.c_str(), handle);
     esp_err_t err = esp_ble_gattc_unregister_for_notify(this->gattc_if_, this->remote_bda_, handle);
     if (err != ESP_OK) {
-      ESP_LOGW(TAG, "[%d] [%s] esp_ble_gattc_unregister_for_notify failed, err=%d", this->connection_index_,
+      ESP_LOGW(TAG, "[%d] [%s] esp_ble_gattc_unregister_for_notify failed, err=%d", this->get_connection_index(),
                this->address_str_.c_str(), err);
       return err;
     }

--- a/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
@@ -223,8 +223,8 @@ bool BluetoothConnection::gattc_event_handler(esp_gattc_cb_event_t event, esp_ga
     case ESP_GATTC_READ_DESCR_EVT:
     case ESP_GATTC_READ_CHAR_EVT: {
       if (param->read.status != ESP_GATT_OK) {
-        ESP_LOGW(TAG, "[%d] [%s] Error reading char/descriptor at handle 0x%2X, status=%d",
-                 this->get_connection_index(), this->address_str().c_str(), param->read.handle, param->read.status);
+        ESP_LOGW(TAG, "[%d] [%s] Error reading char/descriptor at handle 0x%2X, status=%d", this->connection_index_,
+                 this->address_str().c_str(), param->read.handle, param->read.status);
         this->proxy_->send_gatt_error(this->address_, param->read.handle, param->read.status);
         break;
       }
@@ -240,8 +240,8 @@ bool BluetoothConnection::gattc_event_handler(esp_gattc_cb_event_t event, esp_ga
     case ESP_GATTC_WRITE_CHAR_EVT:
     case ESP_GATTC_WRITE_DESCR_EVT: {
       if (param->write.status != ESP_GATT_OK) {
-        ESP_LOGW(TAG, "[%d] [%s] Error writing char/descriptor at handle 0x%2X, status=%d",
-                 this->get_connection_index(), this->address_str().c_str(), param->write.handle, param->write.status);
+        ESP_LOGW(TAG, "[%d] [%s] Error writing char/descriptor at handle 0x%2X, status=%d", this->connection_index_,
+                 this->address_str().c_str(), param->write.handle, param->write.status);
         this->proxy_->send_gatt_error(this->address_, param->write.handle, param->write.status);
         break;
       }
@@ -254,7 +254,7 @@ bool BluetoothConnection::gattc_event_handler(esp_gattc_cb_event_t event, esp_ga
     case ESP_GATTC_UNREG_FOR_NOTIFY_EVT: {
       if (param->unreg_for_notify.status != ESP_GATT_OK) {
         ESP_LOGW(TAG, "[%d] [%s] Error unregistering notifications for handle 0x%2X, status=%d",
-                 this->get_connection_index(), this->address_str().c_str(), param->unreg_for_notify.handle,
+                 this->connection_index_, this->address_str().c_str(), param->unreg_for_notify.handle,
                  param->unreg_for_notify.status);
         this->proxy_->send_gatt_error(this->address_, param->unreg_for_notify.handle, param->unreg_for_notify.status);
         break;
@@ -267,9 +267,8 @@ bool BluetoothConnection::gattc_event_handler(esp_gattc_cb_event_t event, esp_ga
     }
     case ESP_GATTC_REG_FOR_NOTIFY_EVT: {
       if (param->reg_for_notify.status != ESP_GATT_OK) {
-        ESP_LOGW(TAG, "[%d] [%s] Error registering notifications for handle 0x%2X, status=%d",
-                 this->get_connection_index(), this->address_str().c_str(), param->reg_for_notify.handle,
-                 param->reg_for_notify.status);
+        ESP_LOGW(TAG, "[%d] [%s] Error registering notifications for handle 0x%2X, status=%d", this->connection_index_,
+                 this->address_str().c_str(), param->reg_for_notify.handle, param->reg_for_notify.status);
         this->proxy_->send_gatt_error(this->address_, param->reg_for_notify.handle, param->reg_for_notify.status);
         break;
       }
@@ -280,7 +279,7 @@ bool BluetoothConnection::gattc_event_handler(esp_gattc_cb_event_t event, esp_ga
       break;
     }
     case ESP_GATTC_NOTIFY_EVT: {
-      ESP_LOGV(TAG, "[%d] [%s] ESP_GATTC_NOTIFY_EVT: handle=0x%2X", this->get_connection_index(),
+      ESP_LOGV(TAG, "[%d] [%s] ESP_GATTC_NOTIFY_EVT: handle=0x%2X", this->connection_index_,
                this->address_str().c_str(), param->notify.handle);
       api::BluetoothGATTNotifyDataResponse resp;
       resp.address = this->address_;
@@ -317,17 +316,17 @@ void BluetoothConnection::gap_event_handler(esp_gap_ble_cb_event_t event, esp_bl
 
 esp_err_t BluetoothConnection::read_characteristic(uint16_t handle) {
   if (!this->connected()) {
-    ESP_LOGW(TAG, "[%d] [%s] Cannot read GATT characteristic, not connected.", this->get_connection_index(),
+    ESP_LOGW(TAG, "[%d] [%s] Cannot read GATT characteristic, not connected.", this->connection_index_,
              this->address_str().c_str());
     return ESP_GATT_NOT_CONNECTED;
   }
 
-  ESP_LOGV(TAG, "[%d] [%s] Reading GATT characteristic handle %d", this->get_connection_index(),
-           this->address_str_.c_str(), handle);
+  ESP_LOGV(TAG, "[%d] [%s] Reading GATT characteristic handle %d", this->connection_index_, this->address_str_.c_str(),
+           handle);
 
   esp_err_t err = esp_ble_gattc_read_char(this->gattc_if_, this->conn_id_, handle, ESP_GATT_AUTH_REQ_NONE);
   if (err != ERR_OK) {
-    ESP_LOGW(TAG, "[%d] [%s] esp_ble_gattc_read_char error, err=%d", this->get_connection_index(),
+    ESP_LOGW(TAG, "[%d] [%s] esp_ble_gattc_read_char error, err=%d", this->connection_index_,
              this->address_str_.c_str(), err);
     return err;
   }
@@ -336,18 +335,18 @@ esp_err_t BluetoothConnection::read_characteristic(uint16_t handle) {
 
 esp_err_t BluetoothConnection::write_characteristic(uint16_t handle, const std::string &data, bool response) {
   if (!this->connected()) {
-    ESP_LOGW(TAG, "[%d] [%s] Cannot write GATT characteristic, not connected.", this->get_connection_index(),
+    ESP_LOGW(TAG, "[%d] [%s] Cannot write GATT characteristic, not connected.", this->connection_index_,
              this->address_str().c_str());
     return ESP_GATT_NOT_CONNECTED;
   }
-  ESP_LOGV(TAG, "[%d] [%s] Writing GATT characteristic handle %d", this->get_connection_index(),
-           this->address_str_.c_str(), handle);
+  ESP_LOGV(TAG, "[%d] [%s] Writing GATT characteristic handle %d", this->connection_index_, this->address_str_.c_str(),
+           handle);
 
   esp_err_t err =
       esp_ble_gattc_write_char(this->gattc_if_, this->conn_id_, handle, data.size(), (uint8_t *) data.data(),
                                response ? ESP_GATT_WRITE_TYPE_RSP : ESP_GATT_WRITE_TYPE_NO_RSP, ESP_GATT_AUTH_REQ_NONE);
   if (err != ERR_OK) {
-    ESP_LOGW(TAG, "[%d] [%s] esp_ble_gattc_write_char error, err=%d", this->get_connection_index(),
+    ESP_LOGW(TAG, "[%d] [%s] esp_ble_gattc_write_char error, err=%d", this->connection_index_,
              this->address_str_.c_str(), err);
     return err;
   }
@@ -356,16 +355,16 @@ esp_err_t BluetoothConnection::write_characteristic(uint16_t handle, const std::
 
 esp_err_t BluetoothConnection::read_descriptor(uint16_t handle) {
   if (!this->connected()) {
-    ESP_LOGW(TAG, "[%d] [%s] Cannot read GATT descriptor, not connected.", this->get_connection_index(),
+    ESP_LOGW(TAG, "[%d] [%s] Cannot read GATT descriptor, not connected.", this->connection_index_,
              this->address_str().c_str());
     return ESP_GATT_NOT_CONNECTED;
   }
-  ESP_LOGV(TAG, "[%d] [%s] Reading GATT descriptor handle %d", this->get_connection_index(), this->address_str_.c_str(),
+  ESP_LOGV(TAG, "[%d] [%s] Reading GATT descriptor handle %d", this->connection_index_, this->address_str_.c_str(),
            handle);
 
   esp_err_t err = esp_ble_gattc_read_char_descr(this->gattc_if_, this->conn_id_, handle, ESP_GATT_AUTH_REQ_NONE);
   if (err != ERR_OK) {
-    ESP_LOGW(TAG, "[%d] [%s] esp_ble_gattc_read_char_descr error, err=%d", this->get_connection_index(),
+    ESP_LOGW(TAG, "[%d] [%s] esp_ble_gattc_read_char_descr error, err=%d", this->connection_index_,
              this->address_str_.c_str(), err);
     return err;
   }
@@ -374,18 +373,18 @@ esp_err_t BluetoothConnection::read_descriptor(uint16_t handle) {
 
 esp_err_t BluetoothConnection::write_descriptor(uint16_t handle, const std::string &data, bool response) {
   if (!this->connected()) {
-    ESP_LOGW(TAG, "[%d] [%s] Cannot write GATT descriptor, not connected.", this->get_connection_index(),
+    ESP_LOGW(TAG, "[%d] [%s] Cannot write GATT descriptor, not connected.", this->connection_index_,
              this->address_str().c_str());
     return ESP_GATT_NOT_CONNECTED;
   }
-  ESP_LOGV(TAG, "[%d] [%s] Writing GATT descriptor handle %d", this->get_connection_index(), this->address_str_.c_str(),
+  ESP_LOGV(TAG, "[%d] [%s] Writing GATT descriptor handle %d", this->connection_index_, this->address_str_.c_str(),
            handle);
 
   esp_err_t err = esp_ble_gattc_write_char_descr(
       this->gattc_if_, this->conn_id_, handle, data.size(), (uint8_t *) data.data(),
       response ? ESP_GATT_WRITE_TYPE_RSP : ESP_GATT_WRITE_TYPE_NO_RSP, ESP_GATT_AUTH_REQ_NONE);
   if (err != ERR_OK) {
-    ESP_LOGW(TAG, "[%d] [%s] esp_ble_gattc_write_char_descr error, err=%d", this->get_connection_index(),
+    ESP_LOGW(TAG, "[%d] [%s] esp_ble_gattc_write_char_descr error, err=%d", this->connection_index_,
              this->address_str_.c_str(), err);
     return err;
   }
@@ -394,26 +393,26 @@ esp_err_t BluetoothConnection::write_descriptor(uint16_t handle, const std::stri
 
 esp_err_t BluetoothConnection::notify_characteristic(uint16_t handle, bool enable) {
   if (!this->connected()) {
-    ESP_LOGW(TAG, "[%d] [%s] Cannot notify GATT characteristic, not connected.", this->get_connection_index(),
+    ESP_LOGW(TAG, "[%d] [%s] Cannot notify GATT characteristic, not connected.", this->connection_index_,
              this->address_str().c_str());
     return ESP_GATT_NOT_CONNECTED;
   }
 
   if (enable) {
-    ESP_LOGV(TAG, "[%d] [%s] Registering for GATT characteristic notifications handle %d", this->get_connection_index(),
+    ESP_LOGV(TAG, "[%d] [%s] Registering for GATT characteristic notifications handle %d", this->connection_index_,
              this->address_str_.c_str(), handle);
     esp_err_t err = esp_ble_gattc_register_for_notify(this->gattc_if_, this->remote_bda_, handle);
     if (err != ESP_OK) {
-      ESP_LOGW(TAG, "[%d] [%s] esp_ble_gattc_register_for_notify failed, err=%d", this->get_connection_index(),
+      ESP_LOGW(TAG, "[%d] [%s] esp_ble_gattc_register_for_notify failed, err=%d", this->connection_index_,
                this->address_str_.c_str(), err);
       return err;
     }
   } else {
-    ESP_LOGV(TAG, "[%d] [%s] Unregistering for GATT characteristic notifications handle %d",
-             this->get_connection_index(), this->address_str_.c_str(), handle);
+    ESP_LOGV(TAG, "[%d] [%s] Unregistering for GATT characteristic notifications handle %d", this->connection_index_,
+             this->address_str_.c_str(), handle);
     esp_err_t err = esp_ble_gattc_unregister_for_notify(this->gattc_if_, this->remote_bda_, handle);
     if (err != ESP_OK) {
-      ESP_LOGW(TAG, "[%d] [%s] esp_ble_gattc_unregister_for_notify failed, err=%d", this->get_connection_index(),
+      ESP_LOGW(TAG, "[%d] [%s] esp_ble_gattc_unregister_for_notify failed, err=%d", this->connection_index_,
                this->address_str_.c_str(), err);
       return err;
     }

--- a/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
@@ -42,7 +42,10 @@ void BluetoothConnection::loop() {
   this->send_service_for_discovery_();
 }
 
-void BluetoothConnection::reset_connection_() {
+void BluetoothConnection::reset_connection_(esp_err_t reason) {
+  // Send disconnection notification
+  this->proxy_->send_device_connection(this->address_, false, 0, reason);
+
   // Important: If we were in the middle of sending services, we do NOT send
   // send_gatt_services_done() here. This ensures the client knows that
   // the service discovery was interrupted and can retry. The client
@@ -191,19 +194,16 @@ bool BluetoothConnection::gattc_event_handler(esp_gattc_cb_event_t event, esp_ga
 
   switch (event) {
     case ESP_GATTC_DISCONNECT_EVT: {
-      this->proxy_->send_device_connection(this->address_, false, 0, param->disconnect.reason);
-      this->reset_connection_();
+      this->reset_connection_(param->disconnect.reason);
       break;
     }
     case ESP_GATTC_CLOSE_EVT: {
-      this->proxy_->send_device_connection(this->address_, false, 0, param->close.reason);
-      this->reset_connection_();
+      this->reset_connection_(param->close.reason);
       break;
     }
     case ESP_GATTC_OPEN_EVT: {
       if (param->open.status != ESP_GATT_OK && param->open.status != ESP_GATT_ALREADY_OPEN) {
-        this->proxy_->send_device_connection(this->address_, false, 0, param->open.status);
-        this->reset_connection_();
+        this->reset_connection_(param->open.status);
       } else if (this->connection_type_ == espbt::ConnectionType::V3_WITH_CACHE) {
         this->proxy_->send_device_connection(this->address_, true, this->mtu_);
         this->proxy_->send_connections_free();

--- a/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
@@ -224,7 +224,7 @@ bool BluetoothConnection::gattc_event_handler(esp_gattc_cb_event_t event, esp_ga
     case ESP_GATTC_READ_CHAR_EVT: {
       if (param->read.status != ESP_GATT_OK) {
         ESP_LOGW(TAG, "[%d] [%s] Error reading char/descriptor at handle 0x%2X, status=%d", this->connection_index_,
-                 this->address_str_.c_str(), param->read.handle, param->read.status);
+                 this->address_str().c_str(), param->read.handle, param->read.status);
         this->proxy_->send_gatt_error(this->address_, param->read.handle, param->read.status);
         break;
       }
@@ -241,7 +241,7 @@ bool BluetoothConnection::gattc_event_handler(esp_gattc_cb_event_t event, esp_ga
     case ESP_GATTC_WRITE_DESCR_EVT: {
       if (param->write.status != ESP_GATT_OK) {
         ESP_LOGW(TAG, "[%d] [%s] Error writing char/descriptor at handle 0x%2X, status=%d", this->connection_index_,
-                 this->address_str_.c_str(), param->write.handle, param->write.status);
+                 this->address_str().c_str(), param->write.handle, param->write.status);
         this->proxy_->send_gatt_error(this->address_, param->write.handle, param->write.status);
         break;
       }
@@ -254,7 +254,7 @@ bool BluetoothConnection::gattc_event_handler(esp_gattc_cb_event_t event, esp_ga
     case ESP_GATTC_UNREG_FOR_NOTIFY_EVT: {
       if (param->unreg_for_notify.status != ESP_GATT_OK) {
         ESP_LOGW(TAG, "[%d] [%s] Error unregistering notifications for handle 0x%2X, status=%d",
-                 this->connection_index_, this->address_str_.c_str(), param->unreg_for_notify.handle,
+                 this->connection_index_, this->address_str().c_str(), param->unreg_for_notify.handle,
                  param->unreg_for_notify.status);
         this->proxy_->send_gatt_error(this->address_, param->unreg_for_notify.handle, param->unreg_for_notify.status);
         break;
@@ -268,7 +268,7 @@ bool BluetoothConnection::gattc_event_handler(esp_gattc_cb_event_t event, esp_ga
     case ESP_GATTC_REG_FOR_NOTIFY_EVT: {
       if (param->reg_for_notify.status != ESP_GATT_OK) {
         ESP_LOGW(TAG, "[%d] [%s] Error registering notifications for handle 0x%2X, status=%d", this->connection_index_,
-                 this->address_str_.c_str(), param->reg_for_notify.handle, param->reg_for_notify.status);
+                 this->address_str().c_str(), param->reg_for_notify.handle, param->reg_for_notify.status);
         this->proxy_->send_gatt_error(this->address_, param->reg_for_notify.handle, param->reg_for_notify.status);
         break;
       }
@@ -279,8 +279,8 @@ bool BluetoothConnection::gattc_event_handler(esp_gattc_cb_event_t event, esp_ga
       break;
     }
     case ESP_GATTC_NOTIFY_EVT: {
-      ESP_LOGV(TAG, "[%d] [%s] ESP_GATTC_NOTIFY_EVT: handle=0x%2X", this->connection_index_, this->address_str_.c_str(),
-               param->notify.handle);
+      ESP_LOGV(TAG, "[%d] [%s] ESP_GATTC_NOTIFY_EVT: handle=0x%2X", this->connection_index_,
+               this->address_str().c_str(), param->notify.handle);
       api::BluetoothGATTNotifyDataResponse resp;
       resp.address = this->address_;
       resp.handle = param->notify.handle;
@@ -317,7 +317,7 @@ void BluetoothConnection::gap_event_handler(esp_gap_ble_cb_event_t event, esp_bl
 esp_err_t BluetoothConnection::read_characteristic(uint16_t handle) {
   if (!this->connected()) {
     ESP_LOGW(TAG, "[%d] [%s] Cannot read GATT characteristic, not connected.", this->connection_index_,
-             this->address_str_.c_str());
+             this->address_str().c_str());
     return ESP_GATT_NOT_CONNECTED;
   }
 
@@ -336,7 +336,7 @@ esp_err_t BluetoothConnection::read_characteristic(uint16_t handle) {
 esp_err_t BluetoothConnection::write_characteristic(uint16_t handle, const std::string &data, bool response) {
   if (!this->connected()) {
     ESP_LOGW(TAG, "[%d] [%s] Cannot write GATT characteristic, not connected.", this->connection_index_,
-             this->address_str_.c_str());
+             this->address_str().c_str());
     return ESP_GATT_NOT_CONNECTED;
   }
   ESP_LOGV(TAG, "[%d] [%s] Writing GATT characteristic handle %d", this->connection_index_, this->address_str_.c_str(),
@@ -356,7 +356,7 @@ esp_err_t BluetoothConnection::write_characteristic(uint16_t handle, const std::
 esp_err_t BluetoothConnection::read_descriptor(uint16_t handle) {
   if (!this->connected()) {
     ESP_LOGW(TAG, "[%d] [%s] Cannot read GATT descriptor, not connected.", this->connection_index_,
-             this->address_str_.c_str());
+             this->address_str().c_str());
     return ESP_GATT_NOT_CONNECTED;
   }
   ESP_LOGV(TAG, "[%d] [%s] Reading GATT descriptor handle %d", this->connection_index_, this->address_str_.c_str(),
@@ -374,7 +374,7 @@ esp_err_t BluetoothConnection::read_descriptor(uint16_t handle) {
 esp_err_t BluetoothConnection::write_descriptor(uint16_t handle, const std::string &data, bool response) {
   if (!this->connected()) {
     ESP_LOGW(TAG, "[%d] [%s] Cannot write GATT descriptor, not connected.", this->connection_index_,
-             this->address_str_.c_str());
+             this->address_str().c_str());
     return ESP_GATT_NOT_CONNECTED;
   }
   ESP_LOGV(TAG, "[%d] [%s] Writing GATT descriptor handle %d", this->connection_index_, this->address_str_.c_str(),
@@ -394,7 +394,7 @@ esp_err_t BluetoothConnection::write_descriptor(uint16_t handle, const std::stri
 esp_err_t BluetoothConnection::notify_characteristic(uint16_t handle, bool enable) {
   if (!this->connected()) {
     ESP_LOGW(TAG, "[%d] [%s] Cannot notify GATT characteristic, not connected.", this->connection_index_,
-             this->address_str_.c_str());
+             this->address_str().c_str());
     return ESP_GATT_NOT_CONNECTED;
   }
 

--- a/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
@@ -224,7 +224,7 @@ bool BluetoothConnection::gattc_event_handler(esp_gattc_cb_event_t event, esp_ga
     case ESP_GATTC_READ_CHAR_EVT: {
       if (param->read.status != ESP_GATT_OK) {
         ESP_LOGW(TAG, "[%d] [%s] Error reading char/descriptor at handle 0x%2X, status=%d", this->connection_index_,
-                 this->address_str().c_str(), param->read.handle, param->read.status);
+                 this->address_str_.c_str(), param->read.handle, param->read.status);
         this->proxy_->send_gatt_error(this->address_, param->read.handle, param->read.status);
         break;
       }
@@ -241,7 +241,7 @@ bool BluetoothConnection::gattc_event_handler(esp_gattc_cb_event_t event, esp_ga
     case ESP_GATTC_WRITE_DESCR_EVT: {
       if (param->write.status != ESP_GATT_OK) {
         ESP_LOGW(TAG, "[%d] [%s] Error writing char/descriptor at handle 0x%2X, status=%d", this->connection_index_,
-                 this->address_str().c_str(), param->write.handle, param->write.status);
+                 this->address_str_.c_str(), param->write.handle, param->write.status);
         this->proxy_->send_gatt_error(this->address_, param->write.handle, param->write.status);
         break;
       }
@@ -254,7 +254,7 @@ bool BluetoothConnection::gattc_event_handler(esp_gattc_cb_event_t event, esp_ga
     case ESP_GATTC_UNREG_FOR_NOTIFY_EVT: {
       if (param->unreg_for_notify.status != ESP_GATT_OK) {
         ESP_LOGW(TAG, "[%d] [%s] Error unregistering notifications for handle 0x%2X, status=%d",
-                 this->connection_index_, this->address_str().c_str(), param->unreg_for_notify.handle,
+                 this->connection_index_, this->address_str_.c_str(), param->unreg_for_notify.handle,
                  param->unreg_for_notify.status);
         this->proxy_->send_gatt_error(this->address_, param->unreg_for_notify.handle, param->unreg_for_notify.status);
         break;
@@ -268,7 +268,7 @@ bool BluetoothConnection::gattc_event_handler(esp_gattc_cb_event_t event, esp_ga
     case ESP_GATTC_REG_FOR_NOTIFY_EVT: {
       if (param->reg_for_notify.status != ESP_GATT_OK) {
         ESP_LOGW(TAG, "[%d] [%s] Error registering notifications for handle 0x%2X, status=%d", this->connection_index_,
-                 this->address_str().c_str(), param->reg_for_notify.handle, param->reg_for_notify.status);
+                 this->address_str_.c_str(), param->reg_for_notify.handle, param->reg_for_notify.status);
         this->proxy_->send_gatt_error(this->address_, param->reg_for_notify.handle, param->reg_for_notify.status);
         break;
       }
@@ -279,8 +279,8 @@ bool BluetoothConnection::gattc_event_handler(esp_gattc_cb_event_t event, esp_ga
       break;
     }
     case ESP_GATTC_NOTIFY_EVT: {
-      ESP_LOGV(TAG, "[%d] [%s] ESP_GATTC_NOTIFY_EVT: handle=0x%2X", this->connection_index_,
-               this->address_str().c_str(), param->notify.handle);
+      ESP_LOGV(TAG, "[%d] [%s] ESP_GATTC_NOTIFY_EVT: handle=0x%2X", this->connection_index_, this->address_str_.c_str(),
+               param->notify.handle);
       api::BluetoothGATTNotifyDataResponse resp;
       resp.address = this->address_;
       resp.handle = param->notify.handle;
@@ -317,7 +317,7 @@ void BluetoothConnection::gap_event_handler(esp_gap_ble_cb_event_t event, esp_bl
 esp_err_t BluetoothConnection::read_characteristic(uint16_t handle) {
   if (!this->connected()) {
     ESP_LOGW(TAG, "[%d] [%s] Cannot read GATT characteristic, not connected.", this->connection_index_,
-             this->address_str().c_str());
+             this->address_str_.c_str());
     return ESP_GATT_NOT_CONNECTED;
   }
 
@@ -336,7 +336,7 @@ esp_err_t BluetoothConnection::read_characteristic(uint16_t handle) {
 esp_err_t BluetoothConnection::write_characteristic(uint16_t handle, const std::string &data, bool response) {
   if (!this->connected()) {
     ESP_LOGW(TAG, "[%d] [%s] Cannot write GATT characteristic, not connected.", this->connection_index_,
-             this->address_str().c_str());
+             this->address_str_.c_str());
     return ESP_GATT_NOT_CONNECTED;
   }
   ESP_LOGV(TAG, "[%d] [%s] Writing GATT characteristic handle %d", this->connection_index_, this->address_str_.c_str(),
@@ -356,7 +356,7 @@ esp_err_t BluetoothConnection::write_characteristic(uint16_t handle, const std::
 esp_err_t BluetoothConnection::read_descriptor(uint16_t handle) {
   if (!this->connected()) {
     ESP_LOGW(TAG, "[%d] [%s] Cannot read GATT descriptor, not connected.", this->connection_index_,
-             this->address_str().c_str());
+             this->address_str_.c_str());
     return ESP_GATT_NOT_CONNECTED;
   }
   ESP_LOGV(TAG, "[%d] [%s] Reading GATT descriptor handle %d", this->connection_index_, this->address_str_.c_str(),
@@ -374,7 +374,7 @@ esp_err_t BluetoothConnection::read_descriptor(uint16_t handle) {
 esp_err_t BluetoothConnection::write_descriptor(uint16_t handle, const std::string &data, bool response) {
   if (!this->connected()) {
     ESP_LOGW(TAG, "[%d] [%s] Cannot write GATT descriptor, not connected.", this->connection_index_,
-             this->address_str().c_str());
+             this->address_str_.c_str());
     return ESP_GATT_NOT_CONNECTED;
   }
   ESP_LOGV(TAG, "[%d] [%s] Writing GATT descriptor handle %d", this->connection_index_, this->address_str_.c_str(),
@@ -394,7 +394,7 @@ esp_err_t BluetoothConnection::write_descriptor(uint16_t handle, const std::stri
 esp_err_t BluetoothConnection::notify_characteristic(uint16_t handle, bool enable) {
   if (!this->connected()) {
     ESP_LOGW(TAG, "[%d] [%s] Cannot notify GATT characteristic, not connected.", this->connection_index_,
-             this->address_str().c_str());
+             this->address_str_.c_str());
     return ESP_GATT_NOT_CONNECTED;
   }
 

--- a/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
@@ -360,13 +360,13 @@ esp_err_t BluetoothConnection::read_descriptor(uint16_t handle) {
              this->address_str().c_str());
     return ESP_GATT_NOT_CONNECTED;
   }
-  ESP_LOGV(TAG, "[%d] [%s] Reading GATT descriptor handle %d", this->get_connection_index(),
-           this->address_str().c_str(), handle);
+  ESP_LOGV(TAG, "[%d] [%s] Reading GATT descriptor handle %d", this->get_connection_index(), this->address_str_.c_str(),
+           handle);
 
   esp_err_t err = esp_ble_gattc_read_char_descr(this->gattc_if_, this->conn_id_, handle, ESP_GATT_AUTH_REQ_NONE);
   if (err != ERR_OK) {
     ESP_LOGW(TAG, "[%d] [%s] esp_ble_gattc_read_char_descr error, err=%d", this->get_connection_index(),
-             this->address_str().c_str(), err);
+             this->address_str_.c_str(), err);
     return err;
   }
   return ESP_OK;
@@ -378,15 +378,15 @@ esp_err_t BluetoothConnection::write_descriptor(uint16_t handle, const std::stri
              this->address_str().c_str());
     return ESP_GATT_NOT_CONNECTED;
   }
-  ESP_LOGV(TAG, "[%d] [%s] Writing GATT descriptor handle %d", this->get_connection_index(),
-           this->address_str().c_str(), handle);
+  ESP_LOGV(TAG, "[%d] [%s] Writing GATT descriptor handle %d", this->get_connection_index(), this->address_str_.c_str(),
+           handle);
 
   esp_err_t err = esp_ble_gattc_write_char_descr(
       this->gattc_if_, this->conn_id_, handle, data.size(), (uint8_t *) data.data(),
       response ? ESP_GATT_WRITE_TYPE_RSP : ESP_GATT_WRITE_TYPE_NO_RSP, ESP_GATT_AUTH_REQ_NONE);
   if (err != ERR_OK) {
     ESP_LOGW(TAG, "[%d] [%s] esp_ble_gattc_write_char_descr error, err=%d", this->get_connection_index(),
-             this->address_str().c_str(), err);
+             this->address_str_.c_str(), err);
     return err;
   }
   return ESP_OK;
@@ -405,7 +405,7 @@ esp_err_t BluetoothConnection::notify_characteristic(uint16_t handle, bool enabl
     esp_err_t err = esp_ble_gattc_register_for_notify(this->gattc_if_, this->remote_bda_, handle);
     if (err != ESP_OK) {
       ESP_LOGW(TAG, "[%d] [%s] esp_ble_gattc_register_for_notify failed, err=%d", this->get_connection_index(),
-               this->address_str().c_str(), err);
+               this->address_str_.c_str(), err);
       return err;
     }
   } else {
@@ -414,7 +414,7 @@ esp_err_t BluetoothConnection::notify_characteristic(uint16_t handle, bool enabl
     esp_err_t err = esp_ble_gattc_unregister_for_notify(this->gattc_if_, this->remote_bda_, handle);
     if (err != ESP_OK) {
       ESP_LOGW(TAG, "[%d] [%s] esp_ble_gattc_unregister_for_notify failed, err=%d", this->get_connection_index(),
-               this->address_str().c_str(), err);
+               this->address_str_.c_str(), err);
       return err;
     }
   }

--- a/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
@@ -401,7 +401,7 @@ esp_err_t BluetoothConnection::notify_characteristic(uint16_t handle, bool enabl
 
   if (enable) {
     ESP_LOGV(TAG, "[%d] [%s] Registering for GATT characteristic notifications handle %d", this->get_connection_index(),
-             this->address_str_.c_str(), handle);
+             this->address_str().c_str(), handle);
     esp_err_t err = esp_ble_gattc_register_for_notify(this->gattc_if_, this->remote_bda_, handle);
     if (err != ESP_OK) {
       ESP_LOGW(TAG, "[%d] [%s] esp_ble_gattc_register_for_notify failed, err=%d", this->get_connection_index(),

--- a/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
@@ -13,7 +13,6 @@ namespace bluetooth_proxy {
 
 static const char *const TAG = "bluetooth_proxy.connection";
 
-// Helper function from bluetooth_proxy.cpp
 static std::vector<uint64_t> get_128bit_uuid_vec(esp_bt_uuid_t uuid_source) {
   esp_bt_uuid_t uuid = espbt::ESPBTUUID::from_uuid(uuid_source).as_128bit().get_uuid();
   return std::vector<uint64_t>{((uint64_t) uuid.uuid.uuid128[15] << 56) | ((uint64_t) uuid.uuid.uuid128[14] << 48) |

--- a/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
@@ -401,7 +401,7 @@ esp_err_t BluetoothConnection::notify_characteristic(uint16_t handle, bool enabl
 
   if (enable) {
     ESP_LOGV(TAG, "[%d] [%s] Registering for GATT characteristic notifications handle %d", this->get_connection_index(),
-             this->address_str().c_str(), handle);
+             this->address_str_.c_str(), handle);
     esp_err_t err = esp_ble_gattc_register_for_notify(this->gattc_if_, this->remote_bda_, handle);
     if (err != ESP_OK) {
       ESP_LOGW(TAG, "[%d] [%s] esp_ble_gattc_register_for_notify failed, err=%d", this->get_connection_index(),

--- a/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
@@ -341,14 +341,14 @@ esp_err_t BluetoothConnection::write_characteristic(uint16_t handle, const std::
     return ESP_GATT_NOT_CONNECTED;
   }
   ESP_LOGV(TAG, "[%d] [%s] Writing GATT characteristic handle %d", this->get_connection_index(),
-           this->address_str_.c_str(), handle);
+           this->address_str().c_str(), handle);
 
   esp_err_t err =
       esp_ble_gattc_write_char(this->gattc_if_, this->conn_id_, handle, data.size(), (uint8_t *) data.data(),
                                response ? ESP_GATT_WRITE_TYPE_RSP : ESP_GATT_WRITE_TYPE_NO_RSP, ESP_GATT_AUTH_REQ_NONE);
   if (err != ERR_OK) {
     ESP_LOGW(TAG, "[%d] [%s] esp_ble_gattc_write_char error, err=%d", this->get_connection_index(),
-             this->address_str_.c_str(), err);
+             this->address_str().c_str(), err);
     return err;
   }
   return ESP_OK;

--- a/esphome/components/bluetooth_proxy/bluetooth_connection.h
+++ b/esphome/components/bluetooth_proxy/bluetooth_connection.h
@@ -29,7 +29,7 @@ class BluetoothConnection : public esp32_ble_client::BLEClientBase {
   friend class BluetoothProxy;
 
   void send_service_for_discovery_();
-  void reset_connection_();
+  void reset_connection_(esp_err_t reason);
 
   // Memory optimized layout for 32-bit systems
   // Group 1: Pointers (4 bytes each, naturally aligned)

--- a/esphome/components/bluetooth_proxy/bluetooth_connection.h
+++ b/esphome/components/bluetooth_proxy/bluetooth_connection.h
@@ -29,7 +29,17 @@ class BluetoothConnection : public esp32_ble_client::BLEClientBase {
   friend class BluetoothProxy;
 
   void send_service_for_discovery_();
-  void reset_connection_();
+  void reset_connection_() {
+    // Important: If we were in the middle of sending services, we do NOT send
+    // send_gatt_services_done() here. This ensures the client knows that
+    // the service discovery was interrupted and can retry. The client
+    // (aioesphomeapi) implements a 30-second timeout (DEFAULT_BLE_TIMEOUT)
+    // to detect incomplete service discovery rather than relying on us to
+    // tell them about a partial list.
+    this->set_address(0);
+    this->send_service_ = DONE_SENDING_SERVICES;
+    this->proxy_->send_connections_free();
+  }
 
   // Memory optimized layout for 32-bit systems
   // Group 1: Pointers (4 bytes each, naturally aligned)

--- a/esphome/components/bluetooth_proxy/bluetooth_connection.h
+++ b/esphome/components/bluetooth_proxy/bluetooth_connection.h
@@ -12,6 +12,7 @@ class BluetoothProxy;
 class BluetoothConnection : public esp32_ble_client::BLEClientBase {
  public:
   void dump_config() override;
+  void loop() override;
   bool gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if,
                            esp_ble_gattc_cb_param_t *param) override;
   void gap_event_handler(esp_gap_ble_cb_event_t event, esp_ble_gap_cb_param_t *param) override;
@@ -26,6 +27,9 @@ class BluetoothConnection : public esp32_ble_client::BLEClientBase {
 
  protected:
   friend class BluetoothProxy;
+
+  void send_service_for_discovery_();
+  void reset_connection_();
 
   // Memory optimized layout for 32-bit systems
   // Group 1: Pointers (4 bytes each, naturally aligned)

--- a/esphome/components/bluetooth_proxy/bluetooth_connection.h
+++ b/esphome/components/bluetooth_proxy/bluetooth_connection.h
@@ -29,17 +29,7 @@ class BluetoothConnection : public esp32_ble_client::BLEClientBase {
   friend class BluetoothProxy;
 
   void send_service_for_discovery_();
-  void reset_connection_() {
-    // Important: If we were in the middle of sending services, we do NOT send
-    // send_gatt_services_done() here. This ensures the client knows that
-    // the service discovery was interrupted and can retry. The client
-    // (aioesphomeapi) implements a 30-second timeout (DEFAULT_BLE_TIMEOUT)
-    // to detect incomplete service discovery rather than relying on us to
-    // tell them about a partial list.
-    this->set_address(0);
-    this->send_service_ = DONE_SENDING_SERVICES;
-    this->proxy_->send_connections_free();
-  }
+  void reset_connection_();
 
   // Memory optimized layout for 32-bit systems
   // Group 1: Pointers (4 bytes each, naturally aligned)

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
@@ -199,11 +199,6 @@ void BluetoothProxy::loop() {
     return;
   }
 
-  // Early return if no advertisements pending
-  if (this->advertisement_count_ == 0) {
-    return;
-  }
-
   // Flush any pending BLE advertisements that have been accumulated but not yet sent
   uint32_t now = App.get_loop_component_start_time();
 

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
@@ -426,8 +426,7 @@ void BluetoothProxy::bluetooth_gatt_send_services(const api::BluetoothGATTGetSer
     return;
   }
   if (!connection->service_count_) {
-    ESP_LOGW(TAG, "[%d] [%s] No GATT services found", connection->get_connection_index(),
-             connection->address_str().c_str());
+    ESP_LOGW(TAG, "[%d] [%s] No GATT services found", connection->connection_index_, connection->address_str().c_str());
     this->send_gatt_services_done(msg.address);
     return;
   }

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
@@ -426,7 +426,8 @@ void BluetoothProxy::bluetooth_gatt_send_services(const api::BluetoothGATTGetSer
     return;
   }
   if (!connection->service_count_) {
-    ESP_LOGW(TAG, "[%d] [%s] No GATT services found", connection->connection_index_, connection->address_str().c_str());
+    ESP_LOGW(TAG, "[%d] [%s] No GATT services found", connection->get_connection_index(),
+             connection->address_str().c_str());
     this->send_gatt_services_done(msg.address);
     return;
   }

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
@@ -199,6 +199,11 @@ void BluetoothProxy::loop() {
     return;
   }
 
+  // Early return if no advertisements pending
+  if (this->advertisement_count_ == 0) {
+    return;
+  }
+
   // Flush any pending BLE advertisements that have been accumulated but not yet sent
   uint32_t now = App.get_loop_component_start_time();
 

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.h
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.h
@@ -22,6 +22,7 @@ namespace esphome {
 namespace bluetooth_proxy {
 
 static const esp_err_t ESP_GATT_NOT_CONNECTED = -1;
+static const int DONE_SENDING_SERVICES = -2;
 
 using namespace esp32_ble_client;
 
@@ -149,7 +150,10 @@ class BluetoothProxy : public esp32_ble_tracker::ESPBTDeviceListener, public Com
   std::vector<api::BluetoothLERawAdvertisement> advertisement_pool_;
   std::unique_ptr<api::BluetoothLERawAdvertisementsResponse> response_;
 
-  // Group 3: 1-byte types grouped together
+  // Group 3: 4-byte types
+  uint32_t last_advertisement_flush_time_{0};
+
+  // Group 4: 1-byte types grouped together
   bool active_;
   uint8_t advertisement_count_{0};
   // 2 bytes used, 2 bytes padding


### PR DESCRIPTION
Not intended for backport. bleak-esphome already has mitigates for incomplete service lists (which I could never figure out where they came from) so its not urgent to fix and its a significant enough refactor that I'd like to run it on my production for a month anyways.

# What does this implement/fix?

This PR fixes a bug in the bluetooth_proxy component where service discovery could continue attempting to enumerate services on disconnected connections.

**The Bug:**
When a BLE connection disconnected during service discovery, the old code would:
1. Set `address_ = 0` but NOT reset `send_service_` 
2. Continue attempting to call `esp_ble_gattc_get_service()` on the disconnected connection
3. Log errors for each failed attempt but keep incrementing `send_service_`
4. Eventually send `send_gatt_services_done()` for address 0

This could potentially contribute to incomplete service lists and represents improper handling of connection state during disconnects.

**The Fix:**
1. Moved service discovery from the proxy's main loop into each connection's `loop()` method
2. Added `reset_connection_()` helper that properly cleans up state on disconnect
3. Reset `send_service_ = DONE_SENDING_SERVICES` when connections drop
4. Do NOT send `send_gatt_services_done()` on disconnect - let the client timeout to detect incomplete discovery

This leverages the existing `BLEClientBase` infrastructure that automatically disables the loop when connections are idle.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes (none - discovered through runtime analysis)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- Not required (internal implementation change)

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - this is an internal optimization
bluetooth_proxy:
  active: true

api:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

## Additional Details

### Key Changes:
1. **Added `loop()` override to `BluetoothConnection`** - Handles service discovery per connection
2. **Moved service discovery logic** - From `bluetooth_proxy.cpp` main loop to `bluetooth_connection.cpp`
3. **Added `reset_connection_()` helper** - Ensures proper cleanup on disconnect with clear documentation about not sending completion signals
4. **Enhanced state management** - `send_service_` is properly reset to `DONE_SENDING_SERVICES` on disconnect
5. **Added early API connection check** - Avoids building service responses when there's no connection to send them through
6. **Code cleanup** - Converted static timer to member variable, moved constants to shared header

### Bug Impact:
- **Fixes improper handling of disconnects during service discovery**: No more attempting GATT operations on disconnected connections
- **Prevents sending completion signals for address 0**: The old code would eventually send `send_gatt_services_done(0)` after failing through all services
- **Proper state cleanup**: Connection objects can be safely reused from the pool with `send_service_` properly reset to `DONE_SENDING_SERVICES`
- **May help with incomplete service lists**: While not definitively proven as the root cause, this improper state handling could contribute to the issue

### Architecture Improvements:
- Service discovery is now properly encapsulated in the connection object
- Leverages existing `BLEClientBase::loop()` disable mechanism when idle
- Cleaner separation of concerns between proxy and connection

