### PR TITLE
[gpio] Auto-disable interrupts for shared GPIO pins in binary sensors

### DIFF
--- a/esphome/components/gpio/binary_sensor/__init__.py
+++ b/esphome/components/gpio/binary_sensor/__init__.py
@@ -4,7 +4,13 @@ from esphome import pins
 import esphome.codegen as cg
 from esphome.components import binary_sensor
 import esphome.config_validation as cv
-from esphome.const import CONF_ID, CONF_NAME, CONF_NUMBER, CONF_PIN
+from esphome.const import (
+    CONF_ALLOW_OTHER_USES,
+    CONF_ID,
+    CONF_NAME,
+    CONF_NUMBER,
+    CONF_PIN,
+)
 from esphome.core import CORE
 
 from .. import gpio_ns
@@ -73,6 +79,18 @@ async def to_code(config):
             "The sensor will work exactly as before, but other pins have better "
             "performance with interrupts.",
             config.get(CONF_NAME, config[CONF_ID]),
+        )
+        use_interrupt = False
+
+    # Check if pin is shared with other components (allow_other_uses)
+    # When a pin is shared, interrupts can interfere with other components
+    # (e.g., duty_cycle sensor) that need to monitor the pin's state changes
+    if use_interrupt and config[CONF_PIN].get(CONF_ALLOW_OTHER_USES, False):
+        _LOGGER.info(
+            "GPIO binary_sensor '%s': Disabling interrupts because pin %s is shared with other components. "
+            "The sensor will use polling mode for compatibility with other pin uses.",
+            config.get(CONF_NAME, config[CONF_ID]),
+            config[CONF_PIN][CONF_NUMBER],
         )
         use_interrupt = False
 


### PR DESCRIPTION
# What does this implement/fix?

This PR automatically disables interrupts for GPIO binary sensors when the pin is shared with other components (i.e., when `allow_other_uses: true` is set). This fixes an issue where binary sensors stop working correctly when sharing a pin with components like duty_cycle sensors.

Previously, users had to manually set `use_interrupt: false` to resolve conflicts. This change makes it automatic, improving the user experience and preventing hard-to-diagnose issues.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes #9700 fixes https://github.com/esphome/esphome/issues/9640

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#5137

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example showing a GPIO binary sensor sharing a pin with a duty_cycle sensor
# The binary sensor will automatically use polling mode instead of interrupts

binary_sensor:
  - platform: gpio
    pin:
      number: D1
      mode: INPUT_PULLUP
      allow_other_uses: true
    name: "Sewer Pump Status"

sensor:
  - platform: duty_cycle
    pin:
      number: D1
      mode: INPUT_PULLUP
      allow_other_uses: true
    name: "Sewer Pump Duty Cycle"
    update_interval: 10s
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

## Additional Details

When a GPIO pin is configured with `allow_other_uses: true`, it means multiple components are using the same pin. In such cases, having interrupts enabled on the binary sensor can interfere with other components' ability to read the pin state correctly.

This PR adds a check in the GPIO binary sensor's `to_code()` function that automatically disables interrupts when `allow_other_uses` is detected. An informative log message is displayed to let users know why interrupts are being disabled:

```
INFO GPIO binary_sensor 'Test Binary Sensor': Disabling interrupts because pin 5 is shared with other components. The sensor will use polling mode for compatibility with other pin uses.
```

This is a backward-compatible fix that maintains existing functionality while preventing the reported issue.