### PR TITLE
[api] Eliminate heap allocation in ``process_batch_`` using stack-allocated PacketInfo array

### DIFF
--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -1766,6 +1766,8 @@ void APIConnection::process_batch_() {
     uint16_t proto_payload_size = payload_size - header_padding - footer_size;
     // Use placement new to construct PacketInfo in pre-allocated stack array
     // This avoids default-constructing all MAX_PACKETS_PER_BATCH elements
+    // Explicit destruction is not needed because PacketInfo is trivially destructible,
+    // as ensured by the static_assert in its definition.
     new (&packet_info[packet_count++]) PacketInfo(item.message_type, current_offset, proto_payload_size);
 
     // Update tracking variables

--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -1671,6 +1671,10 @@ ProtoWriteBuffer APIConnection::allocate_batch_message_buffer(uint16_t size) {
 }
 
 void APIConnection::process_batch_() {
+  // Ensure PacketInfo remains trivially destructible for our placement new approach
+  static_assert(std::is_trivially_destructible<PacketInfo>::value,
+                "PacketInfo must remain trivially destructible with this placement-new approach");
+
   if (this->deferred_batch_.empty()) {
     this->flags_.batch_scheduled = false;
     return;

--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -1708,9 +1708,12 @@ void APIConnection::process_batch_() {
     return;
   }
 
-  // Pre-allocate storage for packet info
-  std::vector<PacketInfo> packet_info;
-  packet_info.reserve(num_items);
+  size_t packets_to_process = std::min(num_items, MAX_PACKETS_PER_BATCH);
+
+  // Stack-allocated array for packet info
+  alignas(PacketInfo) char packet_info_storage[MAX_PACKETS_PER_BATCH * sizeof(PacketInfo)];
+  PacketInfo *packet_info = reinterpret_cast<PacketInfo *>(packet_info_storage);
+  size_t packet_count = 0;
 
   // Cache these values to avoid repeated virtual calls
   const uint8_t header_padding = this->helper_->frame_header_padding();
@@ -1742,8 +1745,8 @@ void APIConnection::process_batch_() {
   // The actual message data follows after the header padding
   uint32_t current_offset = 0;
 
-  // Process items and encode directly to buffer
-  for (size_t i = 0; i < this->deferred_batch_.size(); i++) {
+  // Process items and encode directly to buffer (up to our limit)
+  for (size_t i = 0; i < packets_to_process; i++) {
     const auto &item = this->deferred_batch_[i];
     // Try to encode message
     // The creator will calculate overhead to determine if the message fits
@@ -1757,7 +1760,9 @@ void APIConnection::process_batch_() {
     // Message was encoded successfully
     // payload_size is header_padding + actual payload size + footer_size
     uint16_t proto_payload_size = payload_size - header_padding - footer_size;
-    packet_info.emplace_back(item.message_type, current_offset, proto_payload_size);
+    // Use placement new to construct PacketInfo in pre-allocated stack array
+    // This avoids default-constructing all MAX_PACKETS_PER_BATCH elements
+    new (&packet_info[packet_count++]) PacketInfo(item.message_type, current_offset, proto_payload_size);
 
     // Update tracking variables
     items_processed++;
@@ -1783,8 +1788,8 @@ void APIConnection::process_batch_() {
   }
 
   // Send all collected packets
-  APIError err =
-      this->helper_->write_protobuf_packets(ProtoWriteBuffer{&this->parent_->get_shared_buffer_ref()}, packet_info);
+  APIError err = this->helper_->write_protobuf_packets(ProtoWriteBuffer{&this->parent_->get_shared_buffer_ref()},
+                                                       std::span<const PacketInfo>(packet_info, packet_count));
   if (err != APIError::OK && err != APIError::WOULD_BLOCK) {
     on_fatal_error();
     ESP_LOGW(TAG, "%s: Batch write failed %s errno=%d", this->get_client_combined_info().c_str(), api_error_to_str(err),

--- a/esphome/components/api/api_connection.h
+++ b/esphome/components/api/api_connection.h
@@ -19,6 +19,8 @@ namespace api {
 // Keepalive timeout in milliseconds
 static constexpr uint32_t KEEPALIVE_TIMEOUT_MS = 60000;
 // Maximum number of entities to process in a single batch during initial state/info sending
+// This was increased from 20 to 24 after removing the unique_id field from entity info messages,
+// which reduced message sizes allowing more entities per batch without exceeding packet limits
 static constexpr size_t MAX_INITIAL_PER_BATCH = 24;
 // Maximum number of packets to process in a single batch (platform-dependent)
 // This limit exists to prevent stack overflow from the PacketInfo array in process_batch_

--- a/esphome/components/api/api_connection.h
+++ b/esphome/components/api/api_connection.h
@@ -19,7 +19,15 @@ namespace api {
 // Keepalive timeout in milliseconds
 static constexpr uint32_t KEEPALIVE_TIMEOUT_MS = 60000;
 // Maximum number of entities to process in a single batch during initial state/info sending
-static constexpr size_t MAX_INITIAL_PER_BATCH = 20;
+static constexpr size_t MAX_INITIAL_PER_BATCH = 24;
+// Maximum number of packets to process in a single batch (platform-dependent)
+// This limit exists to prevent stack overflow from the PacketInfo array in process_batch_
+// Each PacketInfo is 8 bytes, so 64 * 8 = 512 bytes, 32 * 8 = 256 bytes
+#if defined(USE_ESP32) || defined(USE_HOST)
+static constexpr size_t MAX_PACKETS_PER_BATCH = 64;  // ESP32 has 8KB+ stack, HOST has plenty
+#else
+static constexpr size_t MAX_PACKETS_PER_BATCH = 32;  // ESP8266/RP2040/etc have smaller stacks
+#endif
 
 class APIConnection : public APIServerConnection {
  public:


### PR DESCRIPTION
# What does this implement/fix?

This PR optimizes the API connection's `process_batch_` method by eliminating heap allocations for the `PacketInfo` vector. Instead of dynamically allocating memory for each batch, it now uses a stack-allocated array with platform-specific size limits.

**Performance improvements:**
- Eliminates heap allocation overhead for PacketInfo array
- Saves ~200-1000 CPU cycles per batch from malloc/free operations
- Reduces memory fragmentation
- Provides deterministic memory usage
- No allocation failures possible

**Resource usage:**
- **Flash**: Reduced by 380 bytes (removing vector operations)
- **RAM**: No change (stack allocation is temporary)
- ESP32/HOST: 512 bytes stack (64 packets max)
- ESP8266/RP2040/LibreTiny: 256 bytes stack (32 packets max)

Based on real-world analysis, typical batches contain 2-26 items, well within both limits.

**Additional changes:**
- Increased `MAX_INITIAL_PER_BATCH` from 20 to 24 to take advantage of smaller entity info messages after the removal of the unique_id field
- Added `static_assert` to ensure `PacketInfo` remains trivially destructible

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

fixes https://github.com/home-assistant/core/issues/145293

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes needed - this is an internal optimization
api:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

