### PR TITLE
core/scheduler: Make ``millis_64_`` rollover monotonic on SMP

### DIFF
--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -31,6 +31,7 @@ from esphome.const import (
     KEY_TARGET_FRAMEWORK,
     KEY_TARGET_PLATFORM,
     PLATFORM_ESP32,
+    CoreModel,
     __version__,
 )
 from esphome.core import CORE, HexInt, TimePeriod
@@ -713,6 +714,7 @@ async def to_code(config):
     cg.add_define("ESPHOME_BOARD", config[CONF_BOARD])
     cg.add_build_flag(f"-DUSE_ESP32_VARIANT_{config[CONF_VARIANT]}")
     cg.add_define("ESPHOME_VARIANT", VARIANT_FRIENDLY[config[CONF_VARIANT]])
+    cg.add_define(CoreModel.MULTI_ATOMICS)
 
     cg.add_platformio_option("lib_ldf_mode", "off")
     cg.add_platformio_option("lib_compat_mode", "strict")

--- a/esphome/components/esp8266/__init__.py
+++ b/esphome/components/esp8266/__init__.py
@@ -15,6 +15,7 @@ from esphome.const import (
     KEY_TARGET_FRAMEWORK,
     KEY_TARGET_PLATFORM,
     PLATFORM_ESP8266,
+    CoreModel,
 )
 from esphome.core import CORE, coroutine_with_priority
 from esphome.helpers import copy_file_if_changed
@@ -187,6 +188,7 @@ async def to_code(config):
     cg.set_cpp_standard("gnu++20")
     cg.add_define("ESPHOME_BOARD", config[CONF_BOARD])
     cg.add_define("ESPHOME_VARIANT", "ESP8266")
+    cg.add_define(CoreModel.SINGLE)
 
     cg.add_platformio_option("extra_scripts", ["post:post_build.py"])
 

--- a/esphome/components/host/__init__.py
+++ b/esphome/components/host/__init__.py
@@ -7,6 +7,7 @@ from esphome.const import (
     KEY_TARGET_FRAMEWORK,
     KEY_TARGET_PLATFORM,
     PLATFORM_HOST,
+    CoreModel,
 )
 from esphome.core import CORE
 
@@ -43,6 +44,7 @@ async def to_code(config):
     cg.add_define("USE_ESPHOME_HOST_MAC_ADDRESS", config[CONF_MAC_ADDRESS].parts)
     cg.add_build_flag("-std=gnu++20")
     cg.add_define("ESPHOME_BOARD", "host")
+    cg.add_define(CoreModel.MULTI_ATOMICS)
     cg.add_platformio_option("platform", "platformio/native")
     cg.add_platformio_option("lib_ldf_mode", "off")
     cg.add_platformio_option("lib_compat_mode", "strict")

--- a/esphome/components/libretiny/__init__.py
+++ b/esphome/components/libretiny/__init__.py
@@ -20,6 +20,7 @@ from esphome.const import (
     KEY_FRAMEWORK_VERSION,
     KEY_TARGET_FRAMEWORK,
     KEY_TARGET_PLATFORM,
+    CoreModel,
     __version__,
 )
 from esphome.core import CORE
@@ -260,6 +261,7 @@ async def component_to_code(config):
     cg.add_build_flag(f"-DUSE_LIBRETINY_VARIANT_{config[CONF_FAMILY]}")
     cg.add_define("ESPHOME_BOARD", config[CONF_BOARD])
     cg.add_define("ESPHOME_VARIANT", FAMILY_FRIENDLY[config[CONF_FAMILY]])
+    cg.add_define(CoreModel.MULTI_NO_ATOMICS)
 
     # force using arduino framework
     cg.add_platformio_option("framework", "arduino")

--- a/esphome/components/rp2040/__init__.py
+++ b/esphome/components/rp2040/__init__.py
@@ -16,6 +16,7 @@ from esphome.const import (
     KEY_TARGET_FRAMEWORK,
     KEY_TARGET_PLATFORM,
     PLATFORM_RP2040,
+    CoreModel,
 )
 from esphome.core import CORE, EsphomeError, coroutine_with_priority
 from esphome.helpers import copy_file_if_changed, mkdir_p, read_file, write_file
@@ -171,6 +172,7 @@ async def to_code(config):
     cg.set_cpp_standard("gnu++20")
     cg.add_define("ESPHOME_BOARD", config[CONF_BOARD])
     cg.add_define("ESPHOME_VARIANT", "RP2040")
+    cg.add_define(CoreModel.SINGLE)
 
     cg.add_platformio_option("extra_scripts", ["post:post_build.py"])
 

--- a/esphome/const.py
+++ b/esphome/const.py
@@ -35,6 +35,14 @@ class Framework(StrEnum):
     ZEPHYR = "zephyr"
 
 
+class CoreModel(StrEnum):
+    """Core model identifiers for ESPHome scheduler."""
+
+    SINGLE = "ESPHOME_CORES_SINGLE"
+    MULTI_NO_ATOMICS = "ESPHOME_CORES_MULTI_NO_ATOMICS"
+    MULTI_ATOMICS = "ESPHOME_CORES_MULTI_ATOMICS"
+
+
 class PlatformFramework(Enum):
     """Combined platform-framework identifiers with tuple values."""
 

--- a/esphome/core/defines.h
+++ b/esphome/core/defines.h
@@ -15,6 +15,9 @@
 #define ESPHOME_VARIANT "ESP32"
 #define ESPHOME_DEBUG_SCHEDULER
 
+// Default threading model for static analysis (ESP32 is multi-core with atomics)
+#define ESPHOME_CORES_MULTI_ATOMICS
+
 // logger
 #define ESPHOME_LOG_LEVEL ESPHOME_LOG_LEVEL_VERY_VERBOSE
 

--- a/esphome/core/defines.h
+++ b/esphome/core/defines.h
@@ -229,21 +229,6 @@
 #define USE_SOCKET_SELECT_SUPPORT
 #endif
 
-// Helper macro for single core platforms that lack atomic scheduler support
-#if defined(USE_ESP8266) || defined(USE_RP2040)
-#define ESPHOME_SINGLE_CORE
-#endif
-
-// Helper macro for multi core platforms that lack atomic scheduler support
-#if !defined(ESPHOME_SINGLE_CORE) && defined(USE_LIBRETINY)
-#define ESPHOME_MULTI_CORE_NO_ATOMICS
-#endif
-
-// Helper macro for multi core platforms with atomic scheduler support
-#if !defined(ESPHOME_SINGLE_CORE) && !defined(USE_LIBRETINY)
-#define ESPHOME_MULTI_CORE_ATOMICS
-#endif
-
 // Disabled feature flags
 // #define USE_BSEC   // Requires a library with proprietary license
 // #define USE_BSEC2  // Requires a library with proprietary license

--- a/esphome/core/defines.h
+++ b/esphome/core/defines.h
@@ -229,6 +229,16 @@
 #define USE_SOCKET_SELECT_SUPPORT
 #endif
 
+// Helper macro for platforms that lack atomic scheduler support
+#if defined(USE_ESP8266) || defined(USE_RP2040)
+#define ESPHOME_SINGLE_CORE
+#endif
+
+// Helper macro for platforms with atomic scheduler support
+#if !defined(ESPHOME_SINGLE_CORE) && !defined(USE_LIBRETINY)
+#define ESPHOME_ATOMIC_SCHEDULER
+#endif
+
 // Disabled feature flags
 // #define USE_BSEC   // Requires a library with proprietary license
 // #define USE_BSEC2  // Requires a library with proprietary license

--- a/esphome/core/defines.h
+++ b/esphome/core/defines.h
@@ -229,14 +229,19 @@
 #define USE_SOCKET_SELECT_SUPPORT
 #endif
 
-// Helper macro for platforms that lack atomic scheduler support
+// Helper macro for single core platforms that lack atomic scheduler support
 #if defined(USE_ESP8266) || defined(USE_RP2040)
 #define ESPHOME_SINGLE_CORE
 #endif
 
-// Helper macro for platforms with atomic scheduler support
+// Helper macro for multi core platforms that lack atomic scheduler support
+#if !defined(ESPHOME_SINGLE_CORE) && defined(USE_LIBRETINY)
+#define ESPHOME_MULTI_CORE_NO_ATOMICS
+#endif
+
+// Helper macro for multi core platforms with atomic scheduler support
 #if !defined(ESPHOME_SINGLE_CORE) && !defined(USE_LIBRETINY)
-#define ESPHOME_ATOMIC_SCHEDULER
+#define ESPHOME_MULTI_CORE_ATOMICS
 #endif
 
 // Disabled feature flags

--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -273,15 +273,15 @@ void HOT Scheduler::call(uint32_t now) {
   if (now_64 - last_print > 2000) {
     last_print = now_64;
     std::vector<std::unique_ptr<SchedulerItem>> old_items;
-#ifdef ESPHOME_ATOMIC_SCHEDULER
+#ifdef ESPHOME_MULTI_CORE_ATOMICS
     const auto last_dbg = this->last_millis_.load(std::memory_order_relaxed);
     const auto major_dbg = this->millis_major_.load(std::memory_order_relaxed);
     ESP_LOGD(TAG, "Items: count=%zu, now=%" PRIu64 " (%" PRIu16 ", %" PRIu32 ")", this->items_.size(), now_64,
              major_dbg, last_dbg);
-#else  /* not ESPHOME_ATOMIC_SCHEDULER */
+#else  /* not ESPHOME_MULTI_CORE_ATOMICS */
     ESP_LOGD(TAG, "Items: count=%zu, now=%" PRIu64 " (%" PRIu16 ", %" PRIu32 ")", this->items_.size(), now_64,
              this->millis_major_, this->last_millis_);
-#endif /* else ESPHOME_ATOMIC_SCHEDULER */
+#endif /* else ESPHOME_MULTI_CORE_ATOMICS */
     while (!this->empty_()) {
       std::unique_ptr<SchedulerItem> item;
       {
@@ -494,10 +494,18 @@ bool HOT Scheduler::cancel_item_locked_(Component *component, const char *name_c
   return total_cancelled > 0;
 }
 
+#ifdef ESPHOME_SINGLE_CORE
+
 uint64_t Scheduler::millis_64_(uint32_t now) {
   // THREAD SAFETY NOTE:
-  // This function can be called from multiple threads simultaneously on ESP32/LibreTiny.
-  // On single-core platforms, atomics are not needed.
+  // This function has three implemenations, based on the precompiler flags
+  // - ESPHOME_SINGLE_CORE
+  // - ESPHOME_MULTI_CORE_NO_ATOMICS
+  // - ESPHOME_MULTI_CORE_ATOMICS
+  //
+  // Make sure all changes are synchronous if you edit this function.
+  //
+  // This is the single core implementation.
   //
   // IMPORTANT: Always pass fresh millis() values to this function. The implementation
   // handles out-of-order timestamps between threads, but minimizing time differences
@@ -509,101 +517,8 @@ uint64_t Scheduler::millis_64_(uint32_t now) {
   // This prevents race conditions at the rollover boundary without requiring
   // 64-bit atomics or locking on every call.
 
-#ifdef ESPHOME_ATOMIC_SCHEDULER
-  for (;;) {
-    uint16_t major = this->millis_major_.load(std::memory_order_acquire);
-#else  /* not ESPHOME_ATOMIC_SCHEDULER */
   uint16_t major = this->millis_major_;
-#endif /* else ESPHOME_ATOMIC_SCHEDULER */
 
-#ifdef USE_LIBRETINY
-    // LibreTiny: Multi-threaded but lacks atomic operation support
-    // TODO: If LibreTiny ever adds atomic support, remove this entire block and
-    // let it fall through to the atomic-based implementation below
-    // We need to use a lock when near the rollover boundary to prevent races
-    uint32_t last = this->last_millis_;
-
-    // Define a safe window around the rollover point (10 seconds)
-    // This covers any reasonable scheduler delays or thread preemption
-    static const uint32_t ROLLOVER_WINDOW = 10000;  // 10 seconds in milliseconds
-
-    // Check if we're near the rollover boundary (close to std::numeric_limits<uint32_t>::max() or just past 0)
-    bool near_rollover = (last > (std::numeric_limits<uint32_t>::max() - ROLLOVER_WINDOW)) || (now < ROLLOVER_WINDOW);
-
-    if (near_rollover || (now < last && (last - now) > HALF_MAX_UINT32)) {
-      // Near rollover or detected a rollover - need lock for safety
-      LockGuard guard{this->lock_};
-      // Re-read with lock held
-      last = this->last_millis_;
-
-      if (now < last && (last - now) > HALF_MAX_UINT32) {
-        // True rollover detected (happens every ~49.7 days)
-        this->millis_major_++;
-        major++;
-#ifdef ESPHOME_DEBUG_SCHEDULER
-        ESP_LOGD(TAG, "Detected true 32-bit rollover at %" PRIu32 "ms (was %" PRIu32 ")", now, last);
-#endif /* ESPHOME_DEBUG_SCHEDULER */
-      }
-      // Update last_millis_ while holding lock
-      this->last_millis_ = now;
-    } else if (now > last) {
-      // Normal case: Not near rollover and time moved forward
-      // Update without lock. While this may cause minor races (microseconds of
-      // backwards time movement), they're acceptable because:
-      // 1. The scheduler operates at millisecond resolution, not microsecond
-      // 2. We've already prevented the critical rollover race condition
-      // 3. Any backwards movement is orders of magnitude smaller than scheduler delays
-      this->last_millis_ = now;
-    }
-    // If now <= last and we're not near rollover, don't update
-    // This minimizes backwards time movement
-
-#elif defined(ESPHOME_ATOMIC_SCHEDULER)
-  /*
-   * Multi-threaded platforms with atomic support (ESP32)
-   * Acquire so that if we later decide **not** to take the lock we still
-   * observe a `millis_major_` value coherent with the loaded `last_millis_`.
-   * The acquire load ensures any later read of `millis_major_` sees its
-   * corresponding increment.
-   */
-  uint32_t last = this->last_millis_.load(std::memory_order_acquire);
-
-  // If we might be near a rollover (large backwards jump), take the lock for the entire operation
-  // This ensures rollover detection and last_millis_ update are atomic together
-  if (now < last && (last - now) > HALF_MAX_UINT32) {
-    // Potential rollover - need lock for atomic rollover detection + update
-    LockGuard guard{this->lock_};
-    // Re-read with lock held; mutex already provides ordering
-    last = this->last_millis_.load(std::memory_order_relaxed);
-
-    if (now < last && (last - now) > HALF_MAX_UINT32) {
-      // True rollover detected (happens every ~49.7 days)
-      this->millis_major_.fetch_add(1, std::memory_order_relaxed);
-      major++;
-#ifdef ESPHOME_DEBUG_SCHEDULER
-      ESP_LOGD(TAG, "Detected true 32-bit rollover at %" PRIu32 "ms (was %" PRIu32 ")", now, last);
-#endif /* ESPHOME_DEBUG_SCHEDULER */
-    }
-    /*
-     * Update last_millis_ while holding the lock to prevent races
-     * Publish the new low-word *after* bumping `millis_major_` (done above)
-     * so readers never see a mismatched pair.
-     */
-    this->last_millis_.store(now, std::memory_order_release);
-  } else {
-    // Normal case: Try lock-free update, but only allow forward movement within same epoch
-    // This prevents accidentally moving backwards across a rollover boundary
-    while (now > last && (now - last) < HALF_MAX_UINT32) {
-      if (this->last_millis_.compare_exchange_weak(last, now,
-                                                   std::memory_order_release,     // success
-                                                   std::memory_order_relaxed)) {  // failure
-        break;
-      }
-      // CAS failure means no data was published; relaxed is fine
-      // last is automatically updated by compare_exchange_weak if it fails
-    }
-  }
-#else  /* not USE_LIBRETINY; not ESPHOME_ATOMIC_SCHEDULER */
   // Single-core platforms: No atomics needed
   uint32_t last = this->last_millis_;
 
@@ -620,18 +535,162 @@ uint64_t Scheduler::millis_64_(uint32_t now) {
   if (now > last) {
     this->last_millis_ = now;
   }
-#endif /* else (USE_LIBRETINY / ESPHOME_ATOMIC_SCHEDULER) */
 
-#ifdef ESPHOME_ATOMIC_SCHEDULER
+  // Combine major (high 32 bits) and now (low 32 bits) into 64-bit time
+  return now + (static_cast<uint64_t>(major) << 32);
+}
+
+#endif
+
+#ifdef ESPHOME_MULTI_CORE_NO_ATOMICS
+
+uint64_t Scheduler::millis_64_(uint32_t now) {
+  // THREAD SAFETY NOTE:
+  // This function has three implemenations, based on the precompiler flags
+  // - ESPHOME_SINGLE_CORE
+  // - ESPHOME_MULTI_CORE_NO_ATOMICS
+  // - ESPHOME_MULTI_CORE_ATOMICS
+  //
+  // Make sure all changes are synchronous if you edit this function.
+  //
+  // This is the multi core no atomics implementation.
+  //
+  // IMPORTANT: Always pass fresh millis() values to this function. The implementation
+  // handles out-of-order timestamps between threads, but minimizing time differences
+  // helps maintain accuracy.
+  //
+  // The implementation handles the 32-bit rollover (every 49.7 days) by:
+  // 1. Using a lock when detecting rollover to ensure atomic update
+  // 2. Restricting normal updates to forward movement within the same epoch
+  // This prevents race conditions at the rollover boundary without requiring
+  // 64-bit atomics or locking on every call.
+
+  uint16_t major = this->millis_major_;
+
+  // LibreTiny: Multi-threaded but lacks atomic operation support
+  // TODO: If LibreTiny ever adds atomic support, remove this entire block and
+  // let it fall through to the atomic-based implementation below
+  // We need to use a lock when near the rollover boundary to prevent races
+  uint32_t last = this->last_millis_;
+
+  // Define a safe window around the rollover point (10 seconds)
+  // This covers any reasonable scheduler delays or thread preemption
+  static const uint32_t ROLLOVER_WINDOW = 10000;  // 10 seconds in milliseconds
+
+  // Check if we're near the rollover boundary (close to std::numeric_limits<uint32_t>::max() or just past 0)
+  bool near_rollover = (last > (std::numeric_limits<uint32_t>::max() - ROLLOVER_WINDOW)) || (now < ROLLOVER_WINDOW);
+
+  if (near_rollover || (now < last && (last - now) > HALF_MAX_UINT32)) {
+    // Near rollover or detected a rollover - need lock for safety
+    LockGuard guard{this->lock_};
+    // Re-read with lock held
+    last = this->last_millis_;
+
+    if (now < last && (last - now) > HALF_MAX_UINT32) {
+      // True rollover detected (happens every ~49.7 days)
+      this->millis_major_++;
+      major++;
+#ifdef ESPHOME_DEBUG_SCHEDULER
+      ESP_LOGD(TAG, "Detected true 32-bit rollover at %" PRIu32 "ms (was %" PRIu32 ")", now, last);
+#endif /* ESPHOME_DEBUG_SCHEDULER */
+    }
+    // Update last_millis_ while holding lock
+    this->last_millis_ = now;
+  } else if (now > last) {
+    // Normal case: Not near rollover and time moved forward
+    // Update without lock. While this may cause minor races (microseconds of
+    // backwards time movement), they're acceptable because:
+    // 1. The scheduler operates at millisecond resolution, not microsecond
+    // 2. We've already prevented the critical rollover race condition
+    // 3. Any backwards movement is orders of magnitude smaller than scheduler delays
+    this->last_millis_ = now;
+  }
+  // If now <= last and we're not near rollover, don't update
+  // This minimizes backwards time movement
+
+  // Combine major (high 32 bits) and now (low 32 bits) into 64-bit time
+  return now + (static_cast<uint64_t>(major) << 32);
+}
+
+#endif
+
+#ifdef ESPHOME_MULTI_CORE_ATOMICS
+
+uint64_t Scheduler::millis_64_(uint32_t now) {
+  // THREAD SAFETY NOTE:
+  // This function has three implemenations, based on the precompiler flags
+  // - ESPHOME_SINGLE_CORE
+  // - ESPHOME_MULTI_CORE_NO_ATOMICS
+  // - ESPHOME_MULTI_CORE_ATOMICS
+  //
+  // Make sure all changes are synchronous if you edit this function.
+  //
+  // This is the multi core with atomics implementation.
+  //
+  // IMPORTANT: Always pass fresh millis() values to this function. The implementation
+  // handles out-of-order timestamps between threads, but minimizing time differences
+  // helps maintain accuracy.
+  //
+  // The implementation handles the 32-bit rollover (every 49.7 days) by:
+  // 1. Using a lock when detecting rollover to ensure atomic update
+  // 2. Restricting normal updates to forward movement within the same epoch
+  // This prevents race conditions at the rollover boundary without requiring
+  // 64-bit atomics or locking on every call.
+
+  for (;;) {
+    uint16_t major = this->millis_major_.load(std::memory_order_acquire);
+
+    /*
+     * Multi-threaded platforms with atomic support (ESP32)
+     * Acquire so that if we later decide **not** to take the lock we still
+     * observe a `millis_major_` value coherent with the loaded `last_millis_`.
+     * The acquire load ensures any later read of `millis_major_` sees its
+     * corresponding increment.
+     */
+    uint32_t last = this->last_millis_.load(std::memory_order_acquire);
+
+    // If we might be near a rollover (large backwards jump), take the lock for the entire operation
+    // This ensures rollover detection and last_millis_ update are atomic together
+    if (now < last && (last - now) > HALF_MAX_UINT32) {
+      // Potential rollover - need lock for atomic rollover detection + update
+      LockGuard guard{this->lock_};
+      // Re-read with lock held; mutex already provides ordering
+      last = this->last_millis_.load(std::memory_order_relaxed);
+
+      if (now < last && (last - now) > HALF_MAX_UINT32) {
+        // True rollover detected (happens every ~49.7 days)
+        this->millis_major_.fetch_add(1, std::memory_order_relaxed);
+        major++;
+#ifdef ESPHOME_DEBUG_SCHEDULER
+        ESP_LOGD(TAG, "Detected true 32-bit rollover at %" PRIu32 "ms (was %" PRIu32 ")", now, last);
+#endif /* ESPHOME_DEBUG_SCHEDULER */
+      }
+      /*
+       * Update last_millis_ while holding the lock to prevent races
+       * Publish the new low-word *after* bumping `millis_major_` (done above)
+       * so readers never see a mismatched pair.
+       */
+      this->last_millis_.store(now, std::memory_order_release);
+    } else {
+      // Normal case: Try lock-free update, but only allow forward movement within same epoch
+      // This prevents accidentally moving backwards across a rollover boundary
+      while (now > last && (now - last) < HALF_MAX_UINT32) {
+        if (this->last_millis_.compare_exchange_weak(last, now,
+                                                     std::memory_order_release,     // success
+                                                     std::memory_order_relaxed)) {  // failure
+          break;
+        }
+        // CAS failure means no data was published; relaxed is fine
+        // last is automatically updated by compare_exchange_weak if it fails
+      }
+    }
     uint16_t major_end = this->millis_major_.load(std::memory_order_relaxed);
     if (major_end == major)
       return now + (static_cast<uint64_t>(major) << 32);
   }
-#else  /* not ESPHOME_ATOMIC_SCHEDULER */
-  // Combine major (high 32 bits) and now (low 32 bits) into 64-bit time
-  return now + (static_cast<uint64_t>(major) << 32);
-#endif /* ESPHOME_ATOMIC_SCHEDULER */
 }
+
+#endif
 
 bool HOT Scheduler::SchedulerItem::cmp(const std::unique_ptr<SchedulerItem> &a,
                                        const std::unique_ptr<SchedulerItem> &b) {

--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -533,9 +533,8 @@ uint64_t Scheduler::millis_64_(uint32_t now) {
 
   // Combine major (high 32 bits) and now (low 32 bits) into 64-bit time
   return now + (static_cast<uint64_t>(major) << 32);
-#endif  // ESPHOME_CORES_SINGLE
 
-#ifdef ESPHOME_CORES_MULTI_NO_ATOMICS
+#elif defined(ESPHOME_CORES_MULTI_NO_ATOMICS)
   // This is the multi core no atomics implementation.
   //
   // Without atomics, this implementation uses locks more aggressively:
@@ -583,9 +582,8 @@ uint64_t Scheduler::millis_64_(uint32_t now) {
 
   // Combine major (high 32 bits) and now (low 32 bits) into 64-bit time
   return now + (static_cast<uint64_t>(major) << 32);
-#endif  // ESPHOME_CORES_MULTI_NO_ATOMICS
 
-#ifdef ESPHOME_CORES_MULTI_ATOMICS
+#elif defined(ESPHOME_CORES_MULTI_ATOMICS)
   // This is the multi core with atomics implementation.
   //
   // Uses atomic operations with acquire/release semantics to ensure coherent
@@ -647,7 +645,11 @@ uint64_t Scheduler::millis_64_(uint32_t now) {
   }
   // Unreachable - the loop always returns when major_end == major
   __builtin_unreachable();
-#endif  // ESPHOME_CORES_MULTI_ATOMICS
+
+#else
+#error \
+    "No platform threading model defined. One of ESPHOME_CORES_SINGLE, ESPHOME_CORES_MULTI_NO_ATOMICS, or ESPHOME_CORES_MULTI_ATOMICS must be defined."
+#endif
 }
 
 bool HOT Scheduler::SchedulerItem::cmp(const std::unique_ptr<SchedulerItem> &a,

--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -511,15 +511,10 @@ uint64_t Scheduler::millis_64_(uint32_t now) {
 #ifdef ESPHOME_SINGLE_CORE
   // This is the single core implementation.
   //
-  // The implementation handles the 32-bit rollover (every 49.7 days) by:
-  // 1. Using a lock when detecting rollover to ensure atomic update
-  // 2. Restricting normal updates to forward movement within the same epoch
-  // This prevents race conditions at the rollover boundary without requiring
-  // 64-bit atomics or locking on every call.
+  // Single-core platforms have no concurrency, so this is a simple implementation
+  // that just tracks 32-bit rollover (every 49.7 days) without any locking or atomics.
 
   uint16_t major = this->millis_major_;
-
-  // Single-core platforms: No atomics needed
   uint32_t last = this->last_millis_;
 
   // Check for rollover
@@ -538,121 +533,119 @@ uint64_t Scheduler::millis_64_(uint32_t now) {
 
   // Combine major (high 32 bits) and now (low 32 bits) into 64-bit time
   return now + (static_cast<uint64_t>(major) << 32);
-}
 #endif  // ESPHOME_SINGLE_CORE
 
 #ifdef ESPHOME_MULTI_CORE_NO_ATOMICS
-// This is the multi core no atomics implementation.
-//
-// The implementation handles the 32-bit rollover (every 49.7 days) by:
-// 1. Using a lock when detecting rollover to ensure atomic update
-// 2. Restricting normal updates to forward movement within the same epoch
-// This prevents race conditions at the rollover boundary without requiring
-// 64-bit atomics or locking on every call.
+  // This is the multi core no atomics implementation.
+  //
+  // The implementation handles the 32-bit rollover (every 49.7 days) by:
+  // 1. Using a lock when detecting rollover to ensure atomic update
+  // 2. Restricting normal updates to forward movement within the same epoch
+  // This prevents race conditions at the rollover boundary without requiring
+  // 64-bit atomics or locking on every call.
 
-uint16_t major = this->millis_major_;
-uint32_t last = this->last_millis_;
+  uint16_t major = this->millis_major_;
+  uint32_t last = this->last_millis_;
 
-// Define a safe window around the rollover point (10 seconds)
-// This covers any reasonable scheduler delays or thread preemption
-static const uint32_t ROLLOVER_WINDOW = 10000;  // 10 seconds in milliseconds
+  // Define a safe window around the rollover point (10 seconds)
+  // This covers any reasonable scheduler delays or thread preemption
+  static const uint32_t ROLLOVER_WINDOW = 10000;  // 10 seconds in milliseconds
 
-// Check if we're near the rollover boundary (close to std::numeric_limits<uint32_t>::max() or just past 0)
-bool near_rollover = (last > (std::numeric_limits<uint32_t>::max() - ROLLOVER_WINDOW)) || (now < ROLLOVER_WINDOW);
+  // Check if we're near the rollover boundary (close to std::numeric_limits<uint32_t>::max() or just past 0)
+  bool near_rollover = (last > (std::numeric_limits<uint32_t>::max() - ROLLOVER_WINDOW)) || (now < ROLLOVER_WINDOW);
 
-if (near_rollover || (now < last && (last - now) > HALF_MAX_UINT32)) {
-  // Near rollover or detected a rollover - need lock for safety
-  LockGuard guard{this->lock_};
-  // Re-read with lock held
-  last = this->last_millis_;
-
-  if (now < last && (last - now) > HALF_MAX_UINT32) {
-    // True rollover detected (happens every ~49.7 days)
-    this->millis_major_++;
-    major++;
-#ifdef ESPHOME_DEBUG_SCHEDULER
-    ESP_LOGD(TAG, "Detected true 32-bit rollover at %" PRIu32 "ms (was %" PRIu32 ")", now, last);
-#endif /* ESPHOME_DEBUG_SCHEDULER */
-  }
-  // Update last_millis_ while holding lock
-  this->last_millis_ = now;
-} else if (now > last) {
-  // Normal case: Not near rollover and time moved forward
-  // Update without lock. While this may cause minor races (microseconds of
-  // backwards time movement), they're acceptable because:
-  // 1. The scheduler operates at millisecond resolution, not microsecond
-  // 2. We've already prevented the critical rollover race condition
-  // 3. Any backwards movement is orders of magnitude smaller than scheduler delays
-  this->last_millis_ = now;
-}
-// If now <= last and we're not near rollover, don't update
-// This minimizes backwards time movement
-
-// Combine major (high 32 bits) and now (low 32 bits) into 64-bit time
-return now + (static_cast<uint64_t>(major) << 32);
-#endif  // ESPHOME_MULTI_CORE_NO_ATOMICS
-
-#ifdef ESPHOME_MULTI_CORE_ATOMICS
-// This is the multi core with atomics implementation.
-//
-// The implementation handles the 32-bit rollover (every 49.7 days) by:
-// 1. Using a lock when detecting rollover to ensure atomic update
-// 2. Restricting normal updates to forward movement within the same epoch
-// This prevents race conditions at the rollover boundary without requiring
-// 64-bit atomics or locking on every call.
-
-for (;;) {
-  uint16_t major = this->millis_major_.load(std::memory_order_acquire);
-
-  /*
-   * Acquire so that if we later decide **not** to take the lock we still
-   * observe a `millis_major_` value coherent with the loaded `last_millis_`.
-   * The acquire load ensures any later read of `millis_major_` sees its
-   * corresponding increment.
-   */
-  uint32_t last = this->last_millis_.load(std::memory_order_acquire);
-
-  // If we might be near a rollover (large backwards jump), take the lock for the entire operation
-  // This ensures rollover detection and last_millis_ update are atomic together
-  if (now < last && (last - now) > HALF_MAX_UINT32) {
-    // Potential rollover - need lock for atomic rollover detection + update
+  if (near_rollover || (now < last && (last - now) > HALF_MAX_UINT32)) {
+    // Near rollover or detected a rollover - need lock for safety
     LockGuard guard{this->lock_};
-    // Re-read with lock held; mutex already provides ordering
-    last = this->last_millis_.load(std::memory_order_relaxed);
+    // Re-read with lock held
+    last = this->last_millis_;
 
     if (now < last && (last - now) > HALF_MAX_UINT32) {
       // True rollover detected (happens every ~49.7 days)
-      this->millis_major_.fetch_add(1, std::memory_order_relaxed);
+      this->millis_major_++;
       major++;
 #ifdef ESPHOME_DEBUG_SCHEDULER
       ESP_LOGD(TAG, "Detected true 32-bit rollover at %" PRIu32 "ms (was %" PRIu32 ")", now, last);
 #endif /* ESPHOME_DEBUG_SCHEDULER */
     }
-    /*
-     * Update last_millis_ while holding the lock to prevent races
-     * Publish the new low-word *after* bumping `millis_major_` (done above)
-     * so readers never see a mismatched pair.
-     */
-    this->last_millis_.store(now, std::memory_order_release);
-  } else {
-    // Normal case: Try lock-free update, but only allow forward movement within same epoch
-    // This prevents accidentally moving backwards across a rollover boundary
-    while (now > last && (now - last) < HALF_MAX_UINT32) {
-      if (this->last_millis_.compare_exchange_weak(last, now,
-                                                   std::memory_order_release,     // success
-                                                   std::memory_order_relaxed)) {  // failure
-        break;
-      }
-      // CAS failure means no data was published; relaxed is fine
-      // last is automatically updated by compare_exchange_weak if it fails
-    }
+    // Update last_millis_ while holding lock
+    this->last_millis_ = now;
+  } else if (now > last) {
+    // Normal case: Not near rollover and time moved forward
+    // Update without lock. While this may cause minor races (microseconds of
+    // backwards time movement), they're acceptable because:
+    // 1. The scheduler operates at millisecond resolution, not microsecond
+    // 2. We've already prevented the critical rollover race condition
+    // 3. Any backwards movement is orders of magnitude smaller than scheduler delays
+    this->last_millis_ = now;
   }
-  uint16_t major_end = this->millis_major_.load(std::memory_order_relaxed);
-  if (major_end == major)
-    return now + (static_cast<uint64_t>(major) << 32);
-}
-#endif  // ESPHOME_MULTI_CORE_ATOMICS
+  // If now <= last and we're not near rollover, don't update
+  // This minimizes backwards time movement
 
+  // Combine major (high 32 bits) and now (low 32 bits) into 64-bit time
+  return now + (static_cast<uint64_t>(major) << 32);
+#endif  // ESPHOME_MULTI_CORE_NO_ATOMICS
+
+#ifdef ESPHOME_MULTI_CORE_ATOMICS
+  // This is the multi core with atomics implementation.
+  //
+  // The implementation handles the 32-bit rollover (every 49.7 days) by:
+  // 1. Using a lock when detecting rollover to ensure atomic update
+  // 2. Restricting normal updates to forward movement within the same epoch
+  // This prevents race conditions at the rollover boundary without requiring
+  // 64-bit atomics or locking on every call.
+
+  for (;;) {
+    uint16_t major = this->millis_major_.load(std::memory_order_acquire);
+
+    /*
+     * Acquire so that if we later decide **not** to take the lock we still
+     * observe a `millis_major_` value coherent with the loaded `last_millis_`.
+     * The acquire load ensures any later read of `millis_major_` sees its
+     * corresponding increment.
+     */
+    uint32_t last = this->last_millis_.load(std::memory_order_acquire);
+
+    // If we might be near a rollover (large backwards jump), take the lock for the entire operation
+    // This ensures rollover detection and last_millis_ update are atomic together
+    if (now < last && (last - now) > HALF_MAX_UINT32) {
+      // Potential rollover - need lock for atomic rollover detection + update
+      LockGuard guard{this->lock_};
+      // Re-read with lock held; mutex already provides ordering
+      last = this->last_millis_.load(std::memory_order_relaxed);
+
+      if (now < last && (last - now) > HALF_MAX_UINT32) {
+        // True rollover detected (happens every ~49.7 days)
+        this->millis_major_.fetch_add(1, std::memory_order_relaxed);
+        major++;
+#ifdef ESPHOME_DEBUG_SCHEDULER
+        ESP_LOGD(TAG, "Detected true 32-bit rollover at %" PRIu32 "ms (was %" PRIu32 ")", now, last);
+#endif /* ESPHOME_DEBUG_SCHEDULER */
+      }
+      /*
+       * Update last_millis_ while holding the lock to prevent races
+       * Publish the new low-word *after* bumping `millis_major_` (done above)
+       * so readers never see a mismatched pair.
+       */
+      this->last_millis_.store(now, std::memory_order_release);
+    } else {
+      // Normal case: Try lock-free update, but only allow forward movement within same epoch
+      // This prevents accidentally moving backwards across a rollover boundary
+      while (now > last && (now - last) < HALF_MAX_UINT32) {
+        if (this->last_millis_.compare_exchange_weak(last, now,
+                                                     std::memory_order_release,     // success
+                                                     std::memory_order_relaxed)) {  // failure
+          break;
+        }
+        // CAS failure means no data was published; relaxed is fine
+        // last is automatically updated by compare_exchange_weak if it fails
+      }
+    }
+    uint16_t major_end = this->millis_major_.load(std::memory_order_relaxed);
+    if (major_end == major)
+      return now + (static_cast<uint64_t>(major) << 32);
+  }
+#endif  // ESPHOME_MULTI_CORE_ATOMICS
 }
 
 bool HOT Scheduler::SchedulerItem::cmp(const std::unique_ptr<SchedulerItem> &a,

--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -589,11 +589,12 @@ uint64_t Scheduler::millis_64_(uint32_t now) {
 #ifdef ESPHOME_MULTI_CORE_ATOMICS
   // This is the multi core with atomics implementation.
   //
-  // The implementation handles the 32-bit rollover (every 49.7 days) by:
-  // 1. Using a lock when detecting rollover to ensure atomic update
-  // 2. Restricting normal updates to forward movement within the same epoch
-  // This prevents race conditions at the rollover boundary without requiring
-  // 64-bit atomics or locking on every call.
+  // Uses atomic operations with acquire/release semantics to ensure coherent
+  // reads of millis_major_ and last_millis_ across cores. Features:
+  // 1. Epoch-coherency retry loop to handle concurrent updates
+  // 2. Lock only taken for actual rollover detection and update
+  // 3. Lock-free CAS updates for normal forward time progression
+  // 4. Memory ordering ensures cores see consistent time values
 
   for (;;) {
     uint16_t major = this->millis_major_.load(std::memory_order_acquire);

--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -538,11 +538,11 @@ uint64_t Scheduler::millis_64_(uint32_t now) {
 #ifdef ESPHOME_MULTI_CORE_NO_ATOMICS
   // This is the multi core no atomics implementation.
   //
-  // The implementation handles the 32-bit rollover (every 49.7 days) by:
-  // 1. Using a lock when detecting rollover to ensure atomic update
-  // 2. Restricting normal updates to forward movement within the same epoch
-  // This prevents race conditions at the rollover boundary without requiring
-  // 64-bit atomics or locking on every call.
+  // Without atomics, this implementation uses locks more aggressively:
+  // 1. Always locks when near the rollover boundary (within 10 seconds)
+  // 2. Always locks when detecting a large backwards jump
+  // 3. Updates without lock in normal forward progression (accepting minor races)
+  // This is less efficient but necessary without atomic operations.
   uint16_t major = this->millis_major_;
   uint32_t last = this->last_millis_;
 
@@ -588,11 +588,12 @@ uint64_t Scheduler::millis_64_(uint32_t now) {
 #ifdef ESPHOME_MULTI_CORE_ATOMICS
   // This is the multi core with atomics implementation.
   //
-  // The implementation handles the 32-bit rollover (every 49.7 days) by:
-  // 1. Using a lock when detecting rollover to ensure atomic update
-  // 2. Restricting normal updates to forward movement within the same epoch
-  // This prevents race conditions at the rollover boundary without requiring
-  // 64-bit atomics or locking on every call.
+  // Uses atomic operations with acquire/release semantics to ensure coherent
+  // reads of millis_major_ and last_millis_ across cores. Features:
+  // 1. Epoch-coherency retry loop to handle concurrent updates
+  // 2. Lock only taken for actual rollover detection and update
+  // 3. Lock-free CAS updates for normal forward time progression
+  // 4. Memory ordering ensures cores see consistent time values
 
   for (;;) {
     uint16_t major = this->millis_major_.load(std::memory_order_acquire);

--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -82,7 +82,7 @@ void HOT Scheduler::set_timer_common_(Component *component, SchedulerItem::Type 
   item->callback = std::move(func);
   item->remove = false;
 
-#ifndef ESPHOME_SINGLE_CORE
+#ifndef ESPHOME_CORES_SINGLE
   // Special handling for defer() (delay = 0, type = TIMEOUT)
   // Single-core platforms don't need thread-safe defer handling
   if (delay == 0 && type == SchedulerItem::TIMEOUT) {
@@ -92,7 +92,7 @@ void HOT Scheduler::set_timer_common_(Component *component, SchedulerItem::Type 
     this->defer_queue_.push_back(std::move(item));
     return;
   }
-#endif /* not ESPHOME_SINGLE_CORE */
+#endif /* not ESPHOME_CORES_SINGLE */
 
   // Get fresh timestamp for new timer/interval - ensures accurate scheduling
   const auto now = this->millis_64_(millis());  // Fresh millis() call
@@ -231,7 +231,7 @@ optional<uint32_t> HOT Scheduler::next_schedule_in(uint32_t now) {
   return item->next_execution_ - now_64;
 }
 void HOT Scheduler::call(uint32_t now) {
-#ifndef ESPHOME_SINGLE_CORE
+#ifndef ESPHOME_CORES_SINGLE
   // Process defer queue first to guarantee FIFO execution order for deferred items.
   // Previously, defer() used the heap which gave undefined order for equal timestamps,
   // causing race conditions on multi-core systems (ESP32, BK7200).
@@ -261,7 +261,7 @@ void HOT Scheduler::call(uint32_t now) {
       this->execute_item_(item.get(), now);
     }
   }
-#endif /* not ESPHOME_SINGLE_CORE */
+#endif /* not ESPHOME_CORES_SINGLE */
 
   // Convert the fresh timestamp from main loop to 64-bit for scheduler operations
   const auto now_64 = this->millis_64_(now);  // 'now' from parameter - fresh from Application::loop()
@@ -273,15 +273,15 @@ void HOT Scheduler::call(uint32_t now) {
   if (now_64 - last_print > 2000) {
     last_print = now_64;
     std::vector<std::unique_ptr<SchedulerItem>> old_items;
-#ifdef ESPHOME_MULTI_CORE_ATOMICS
+#ifdef ESPHOME_CORES_MULTI_ATOMICS
     const auto last_dbg = this->last_millis_.load(std::memory_order_relaxed);
     const auto major_dbg = this->millis_major_.load(std::memory_order_relaxed);
     ESP_LOGD(TAG, "Items: count=%zu, now=%" PRIu64 " (%" PRIu16 ", %" PRIu32 ")", this->items_.size(), now_64,
              major_dbg, last_dbg);
-#else  /* not ESPHOME_MULTI_CORE_ATOMICS */
+#else  /* not ESPHOME_CORES_MULTI_ATOMICS */
     ESP_LOGD(TAG, "Items: count=%zu, now=%" PRIu64 " (%" PRIu16 ", %" PRIu32 ")", this->items_.size(), now_64,
              this->millis_major_, this->last_millis_);
-#endif /* else ESPHOME_MULTI_CORE_ATOMICS */
+#endif /* else ESPHOME_CORES_MULTI_ATOMICS */
     while (!this->empty_()) {
       std::unique_ptr<SchedulerItem> item;
       {
@@ -461,7 +461,7 @@ bool HOT Scheduler::cancel_item_locked_(Component *component, const char *name_c
   size_t total_cancelled = 0;
 
   // Check all containers for matching items
-#ifndef ESPHOME_SINGLE_CORE
+#ifndef ESPHOME_CORES_SINGLE
   // Only check defer queue for timeouts (intervals never go there)
   if (type == SchedulerItem::TIMEOUT) {
     for (auto &item : this->defer_queue_) {
@@ -471,7 +471,7 @@ bool HOT Scheduler::cancel_item_locked_(Component *component, const char *name_c
       }
     }
   }
-#endif /* not ESPHOME_SINGLE_CORE */
+#endif /* not ESPHOME_CORES_SINGLE */
 
   // Cancel items in the main heap
   for (auto &item : this->items_) {
@@ -497,9 +497,9 @@ bool HOT Scheduler::cancel_item_locked_(Component *component, const char *name_c
 uint64_t Scheduler::millis_64_(uint32_t now) {
   // THREAD SAFETY NOTE:
   // This function has three implementations, based on the precompiler flags
-  // - ESPHOME_SINGLE_CORE - Runs on single-core platforms (ESP8266, RP2040, etc.)
-  // - ESPHOME_MULTI_CORE_NO_ATOMICS - Runs on multi-core platforms without atomics (LibreTiny)
-  // - ESPHOME_MULTI_CORE_ATOMICS - Runs on multi-core platforms with atomics (ESP32, HOST, etc.)
+  // - ESPHOME_CORES_SINGLE - Runs on single-core platforms (ESP8266, RP2040, etc.)
+  // - ESPHOME_CORES_MULTI_NO_ATOMICS - Runs on multi-core platforms without atomics (LibreTiny)
+  // - ESPHOME_CORES_MULTI_ATOMICS - Runs on multi-core platforms with atomics (ESP32, HOST, etc.)
   //
   // Make sure all changes are synchronized if you edit this function.
   //
@@ -508,7 +508,7 @@ uint64_t Scheduler::millis_64_(uint32_t now) {
   // helps maintain accuracy.
   //
 
-#ifdef ESPHOME_SINGLE_CORE
+#ifdef ESPHOME_CORES_SINGLE
   // This is the single core implementation.
   //
   // Single-core platforms have no concurrency, so this is a simple implementation
@@ -533,9 +533,9 @@ uint64_t Scheduler::millis_64_(uint32_t now) {
 
   // Combine major (high 32 bits) and now (low 32 bits) into 64-bit time
   return now + (static_cast<uint64_t>(major) << 32);
-#endif  // ESPHOME_SINGLE_CORE
+#endif  // ESPHOME_CORES_SINGLE
 
-#ifdef ESPHOME_MULTI_CORE_NO_ATOMICS
+#ifdef ESPHOME_CORES_MULTI_NO_ATOMICS
   // This is the multi core no atomics implementation.
   //
   // Without atomics, this implementation uses locks more aggressively:
@@ -583,9 +583,9 @@ uint64_t Scheduler::millis_64_(uint32_t now) {
 
   // Combine major (high 32 bits) and now (low 32 bits) into 64-bit time
   return now + (static_cast<uint64_t>(major) << 32);
-#endif  // ESPHOME_MULTI_CORE_NO_ATOMICS
+#endif  // ESPHOME_CORES_MULTI_NO_ATOMICS
 
-#ifdef ESPHOME_MULTI_CORE_ATOMICS
+#ifdef ESPHOME_CORES_MULTI_ATOMICS
   // This is the multi core with atomics implementation.
   //
   // Uses atomic operations with acquire/release semantics to ensure coherent
@@ -645,7 +645,9 @@ uint64_t Scheduler::millis_64_(uint32_t now) {
     if (major_end == major)
       return now + (static_cast<uint64_t>(major) << 32);
   }
-#endif  // ESPHOME_MULTI_CORE_ATOMICS
+  // Unreachable - the loop always returns when major_end == major
+  __builtin_unreachable();
+#endif  // ESPHOME_CORES_MULTI_ATOMICS
 }
 
 bool HOT Scheduler::SchedulerItem::cmp(const std::unique_ptr<SchedulerItem> &a,

--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -494,22 +494,22 @@ bool HOT Scheduler::cancel_item_locked_(Component *component, const char *name_c
   return total_cancelled > 0;
 }
 
-#ifdef ESPHOME_SINGLE_CORE
-
 uint64_t Scheduler::millis_64_(uint32_t now) {
   // THREAD SAFETY NOTE:
-  // This function has three implemenations, based on the precompiler flags
-  // - ESPHOME_SINGLE_CORE
-  // - ESPHOME_MULTI_CORE_NO_ATOMICS
-  // - ESPHOME_MULTI_CORE_ATOMICS
+  // This function has three implementations, based on the precompiler flags
+  // - ESPHOME_SINGLE_CORE - Runs on single-core platforms (ESP8266, RP2040, etc.)
+  // - ESPHOME_MULTI_CORE_NO_ATOMICS - Runs on multi-core platforms without atomics (LibreTiny)
+  // - ESPHOME_MULTI_CORE_ATOMICS - Runs on multi-core platforms with atomics (ESP32, HOST, etc.)
   //
-  // Make sure all changes are synchronous if you edit this function.
-  //
-  // This is the single core implementation.
+  // Make sure all changes are synchronized if you edit this function.
   //
   // IMPORTANT: Always pass fresh millis() values to this function. The implementation
   // handles out-of-order timestamps between threads, but minimizing time differences
   // helps maintain accuracy.
+  //
+
+#ifdef ESPHOME_SINGLE_CORE
+  // This is the single core implementation.
   //
   // The implementation handles the 32-bit rollover (every 49.7 days) by:
   // 1. Using a lock when detecting rollover to ensure atomic update
@@ -539,158 +539,121 @@ uint64_t Scheduler::millis_64_(uint32_t now) {
   // Combine major (high 32 bits) and now (low 32 bits) into 64-bit time
   return now + (static_cast<uint64_t>(major) << 32);
 }
-
-#endif
+#endif  // ESPHOME_SINGLE_CORE
 
 #ifdef ESPHOME_MULTI_CORE_NO_ATOMICS
+// This is the multi core no atomics implementation.
+//
+// The implementation handles the 32-bit rollover (every 49.7 days) by:
+// 1. Using a lock when detecting rollover to ensure atomic update
+// 2. Restricting normal updates to forward movement within the same epoch
+// This prevents race conditions at the rollover boundary without requiring
+// 64-bit atomics or locking on every call.
 
-uint64_t Scheduler::millis_64_(uint32_t now) {
-  // THREAD SAFETY NOTE:
-  // This function has three implemenations, based on the precompiler flags
-  // - ESPHOME_SINGLE_CORE
-  // - ESPHOME_MULTI_CORE_NO_ATOMICS
-  // - ESPHOME_MULTI_CORE_ATOMICS
-  //
-  // Make sure all changes are synchronous if you edit this function.
-  //
-  // This is the multi core no atomics implementation.
-  //
-  // IMPORTANT: Always pass fresh millis() values to this function. The implementation
-  // handles out-of-order timestamps between threads, but minimizing time differences
-  // helps maintain accuracy.
-  //
-  // The implementation handles the 32-bit rollover (every 49.7 days) by:
-  // 1. Using a lock when detecting rollover to ensure atomic update
-  // 2. Restricting normal updates to forward movement within the same epoch
-  // This prevents race conditions at the rollover boundary without requiring
-  // 64-bit atomics or locking on every call.
+uint16_t major = this->millis_major_;
+uint32_t last = this->last_millis_;
 
-  uint16_t major = this->millis_major_;
+// Define a safe window around the rollover point (10 seconds)
+// This covers any reasonable scheduler delays or thread preemption
+static const uint32_t ROLLOVER_WINDOW = 10000;  // 10 seconds in milliseconds
 
-  // LibreTiny: Multi-threaded but lacks atomic operation support
-  // TODO: If LibreTiny ever adds atomic support, remove this entire block and
-  // let it fall through to the atomic-based implementation below
-  // We need to use a lock when near the rollover boundary to prevent races
-  uint32_t last = this->last_millis_;
+// Check if we're near the rollover boundary (close to std::numeric_limits<uint32_t>::max() or just past 0)
+bool near_rollover = (last > (std::numeric_limits<uint32_t>::max() - ROLLOVER_WINDOW)) || (now < ROLLOVER_WINDOW);
 
-  // Define a safe window around the rollover point (10 seconds)
-  // This covers any reasonable scheduler delays or thread preemption
-  static const uint32_t ROLLOVER_WINDOW = 10000;  // 10 seconds in milliseconds
+if (near_rollover || (now < last && (last - now) > HALF_MAX_UINT32)) {
+  // Near rollover or detected a rollover - need lock for safety
+  LockGuard guard{this->lock_};
+  // Re-read with lock held
+  last = this->last_millis_;
 
-  // Check if we're near the rollover boundary (close to std::numeric_limits<uint32_t>::max() or just past 0)
-  bool near_rollover = (last > (std::numeric_limits<uint32_t>::max() - ROLLOVER_WINDOW)) || (now < ROLLOVER_WINDOW);
+  if (now < last && (last - now) > HALF_MAX_UINT32) {
+    // True rollover detected (happens every ~49.7 days)
+    this->millis_major_++;
+    major++;
+#ifdef ESPHOME_DEBUG_SCHEDULER
+    ESP_LOGD(TAG, "Detected true 32-bit rollover at %" PRIu32 "ms (was %" PRIu32 ")", now, last);
+#endif /* ESPHOME_DEBUG_SCHEDULER */
+  }
+  // Update last_millis_ while holding lock
+  this->last_millis_ = now;
+} else if (now > last) {
+  // Normal case: Not near rollover and time moved forward
+  // Update without lock. While this may cause minor races (microseconds of
+  // backwards time movement), they're acceptable because:
+  // 1. The scheduler operates at millisecond resolution, not microsecond
+  // 2. We've already prevented the critical rollover race condition
+  // 3. Any backwards movement is orders of magnitude smaller than scheduler delays
+  this->last_millis_ = now;
+}
+// If now <= last and we're not near rollover, don't update
+// This minimizes backwards time movement
 
-  if (near_rollover || (now < last && (last - now) > HALF_MAX_UINT32)) {
-    // Near rollover or detected a rollover - need lock for safety
+// Combine major (high 32 bits) and now (low 32 bits) into 64-bit time
+return now + (static_cast<uint64_t>(major) << 32);
+#endif  // ESPHOME_MULTI_CORE_NO_ATOMICS
+
+#ifdef ESPHOME_MULTI_CORE_ATOMICS
+// This is the multi core with atomics implementation.
+//
+// The implementation handles the 32-bit rollover (every 49.7 days) by:
+// 1. Using a lock when detecting rollover to ensure atomic update
+// 2. Restricting normal updates to forward movement within the same epoch
+// This prevents race conditions at the rollover boundary without requiring
+// 64-bit atomics or locking on every call.
+
+for (;;) {
+  uint16_t major = this->millis_major_.load(std::memory_order_acquire);
+
+  /*
+   * Acquire so that if we later decide **not** to take the lock we still
+   * observe a `millis_major_` value coherent with the loaded `last_millis_`.
+   * The acquire load ensures any later read of `millis_major_` sees its
+   * corresponding increment.
+   */
+  uint32_t last = this->last_millis_.load(std::memory_order_acquire);
+
+  // If we might be near a rollover (large backwards jump), take the lock for the entire operation
+  // This ensures rollover detection and last_millis_ update are atomic together
+  if (now < last && (last - now) > HALF_MAX_UINT32) {
+    // Potential rollover - need lock for atomic rollover detection + update
     LockGuard guard{this->lock_};
-    // Re-read with lock held
-    last = this->last_millis_;
+    // Re-read with lock held; mutex already provides ordering
+    last = this->last_millis_.load(std::memory_order_relaxed);
 
     if (now < last && (last - now) > HALF_MAX_UINT32) {
       // True rollover detected (happens every ~49.7 days)
-      this->millis_major_++;
+      this->millis_major_.fetch_add(1, std::memory_order_relaxed);
       major++;
 #ifdef ESPHOME_DEBUG_SCHEDULER
       ESP_LOGD(TAG, "Detected true 32-bit rollover at %" PRIu32 "ms (was %" PRIu32 ")", now, last);
 #endif /* ESPHOME_DEBUG_SCHEDULER */
     }
-    // Update last_millis_ while holding lock
-    this->last_millis_ = now;
-  } else if (now > last) {
-    // Normal case: Not near rollover and time moved forward
-    // Update without lock. While this may cause minor races (microseconds of
-    // backwards time movement), they're acceptable because:
-    // 1. The scheduler operates at millisecond resolution, not microsecond
-    // 2. We've already prevented the critical rollover race condition
-    // 3. Any backwards movement is orders of magnitude smaller than scheduler delays
-    this->last_millis_ = now;
-  }
-  // If now <= last and we're not near rollover, don't update
-  // This minimizes backwards time movement
-
-  // Combine major (high 32 bits) and now (low 32 bits) into 64-bit time
-  return now + (static_cast<uint64_t>(major) << 32);
-}
-
-#endif
-
-#ifdef ESPHOME_MULTI_CORE_ATOMICS
-
-uint64_t Scheduler::millis_64_(uint32_t now) {
-  // THREAD SAFETY NOTE:
-  // This function has three implemenations, based on the precompiler flags
-  // - ESPHOME_SINGLE_CORE
-  // - ESPHOME_MULTI_CORE_NO_ATOMICS
-  // - ESPHOME_MULTI_CORE_ATOMICS
-  //
-  // Make sure all changes are synchronous if you edit this function.
-  //
-  // This is the multi core with atomics implementation.
-  //
-  // IMPORTANT: Always pass fresh millis() values to this function. The implementation
-  // handles out-of-order timestamps between threads, but minimizing time differences
-  // helps maintain accuracy.
-  //
-  // The implementation handles the 32-bit rollover (every 49.7 days) by:
-  // 1. Using a lock when detecting rollover to ensure atomic update
-  // 2. Restricting normal updates to forward movement within the same epoch
-  // This prevents race conditions at the rollover boundary without requiring
-  // 64-bit atomics or locking on every call.
-
-  for (;;) {
-    uint16_t major = this->millis_major_.load(std::memory_order_acquire);
-
     /*
-     * Multi-threaded platforms with atomic support (ESP32)
-     * Acquire so that if we later decide **not** to take the lock we still
-     * observe a `millis_major_` value coherent with the loaded `last_millis_`.
-     * The acquire load ensures any later read of `millis_major_` sees its
-     * corresponding increment.
+     * Update last_millis_ while holding the lock to prevent races
+     * Publish the new low-word *after* bumping `millis_major_` (done above)
+     * so readers never see a mismatched pair.
      */
-    uint32_t last = this->last_millis_.load(std::memory_order_acquire);
-
-    // If we might be near a rollover (large backwards jump), take the lock for the entire operation
-    // This ensures rollover detection and last_millis_ update are atomic together
-    if (now < last && (last - now) > HALF_MAX_UINT32) {
-      // Potential rollover - need lock for atomic rollover detection + update
-      LockGuard guard{this->lock_};
-      // Re-read with lock held; mutex already provides ordering
-      last = this->last_millis_.load(std::memory_order_relaxed);
-
-      if (now < last && (last - now) > HALF_MAX_UINT32) {
-        // True rollover detected (happens every ~49.7 days)
-        this->millis_major_.fetch_add(1, std::memory_order_relaxed);
-        major++;
-#ifdef ESPHOME_DEBUG_SCHEDULER
-        ESP_LOGD(TAG, "Detected true 32-bit rollover at %" PRIu32 "ms (was %" PRIu32 ")", now, last);
-#endif /* ESPHOME_DEBUG_SCHEDULER */
+    this->last_millis_.store(now, std::memory_order_release);
+  } else {
+    // Normal case: Try lock-free update, but only allow forward movement within same epoch
+    // This prevents accidentally moving backwards across a rollover boundary
+    while (now > last && (now - last) < HALF_MAX_UINT32) {
+      if (this->last_millis_.compare_exchange_weak(last, now,
+                                                   std::memory_order_release,     // success
+                                                   std::memory_order_relaxed)) {  // failure
+        break;
       }
-      /*
-       * Update last_millis_ while holding the lock to prevent races
-       * Publish the new low-word *after* bumping `millis_major_` (done above)
-       * so readers never see a mismatched pair.
-       */
-      this->last_millis_.store(now, std::memory_order_release);
-    } else {
-      // Normal case: Try lock-free update, but only allow forward movement within same epoch
-      // This prevents accidentally moving backwards across a rollover boundary
-      while (now > last && (now - last) < HALF_MAX_UINT32) {
-        if (this->last_millis_.compare_exchange_weak(last, now,
-                                                     std::memory_order_release,     // success
-                                                     std::memory_order_relaxed)) {  // failure
-          break;
-        }
-        // CAS failure means no data was published; relaxed is fine
-        // last is automatically updated by compare_exchange_weak if it fails
-      }
+      // CAS failure means no data was published; relaxed is fine
+      // last is automatically updated by compare_exchange_weak if it fails
     }
-    uint16_t major_end = this->millis_major_.load(std::memory_order_relaxed);
-    if (major_end == major)
-      return now + (static_cast<uint64_t>(major) << 32);
   }
+  uint16_t major_end = this->millis_major_.load(std::memory_order_relaxed);
+  if (major_end == major)
+    return now + (static_cast<uint64_t>(major) << 32);
 }
+#endif  // ESPHOME_MULTI_CORE_ATOMICS
 
-#endif
+}
 
 bool HOT Scheduler::SchedulerItem::cmp(const std::unique_ptr<SchedulerItem> &a,
                                        const std::unique_ptr<SchedulerItem> &b) {

--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -54,7 +54,7 @@ static void validate_static_string(const char *name) {
     ESP_LOGW(TAG, "WARNING: Scheduler name '%s' at %p might be on heap (static ref at %p)", name, name, static_str);
   }
 }
-#endif
+#endif /* ESPHOME_DEBUG_SCHEDULER */
 
 // A note on locking: the `lock_` lock protects the `items_` and `to_add_` containers. It must be taken when writing to
 // them (i.e. when adding/removing items, but not when changing items). As items are only deleted from the loop task,
@@ -82,9 +82,9 @@ void HOT Scheduler::set_timer_common_(Component *component, SchedulerItem::Type 
   item->callback = std::move(func);
   item->remove = false;
 
-#if !defined(USE_ESP8266) && !defined(USE_RP2040)
+#ifndef ESPHOME_SINGLE_CORE
   // Special handling for defer() (delay = 0, type = TIMEOUT)
-  // ESP8266 and RP2040 are excluded because they don't need thread-safe defer handling
+  // Single-core platforms don't need thread-safe defer handling
   if (delay == 0 && type == SchedulerItem::TIMEOUT) {
     // Put in defer queue for guaranteed FIFO execution
     LockGuard guard{this->lock_};
@@ -92,7 +92,7 @@ void HOT Scheduler::set_timer_common_(Component *component, SchedulerItem::Type 
     this->defer_queue_.push_back(std::move(item));
     return;
   }
-#endif
+#endif /* not ESPHOME_SINGLE_CORE */
 
   // Get fresh timestamp for new timer/interval - ensures accurate scheduling
   const auto now = this->millis_64_(millis());  // Fresh millis() call
@@ -123,7 +123,7 @@ void HOT Scheduler::set_timer_common_(Component *component, SchedulerItem::Type 
     ESP_LOGD(TAG, "set_%s(name='%s/%s', %s=%" PRIu32 ", offset=%" PRIu32 ")", type_str, item->get_source(),
              name_cstr ? name_cstr : "(null)", type_str, delay, static_cast<uint32_t>(item->next_execution_ - now));
   }
-#endif
+#endif /* ESPHOME_DEBUG_SCHEDULER */
 
   LockGuard guard{this->lock_};
   // If name is provided, do atomic cancel-and-add
@@ -231,7 +231,7 @@ optional<uint32_t> HOT Scheduler::next_schedule_in(uint32_t now) {
   return item->next_execution_ - now_64;
 }
 void HOT Scheduler::call(uint32_t now) {
-#if !defined(USE_ESP8266) && !defined(USE_RP2040)
+#ifndef ESPHOME_SINGLE_CORE
   // Process defer queue first to guarantee FIFO execution order for deferred items.
   // Previously, defer() used the heap which gave undefined order for equal timestamps,
   // causing race conditions on multi-core systems (ESP32, BK7200).
@@ -239,8 +239,7 @@ void HOT Scheduler::call(uint32_t now) {
   // - Deferred items (delay=0) go directly to defer_queue_ in set_timer_common_
   // - Items execute in exact order they were deferred (FIFO guarantee)
   // - No deferred items exist in to_add_, so processing order doesn't affect correctness
-  // ESP8266 and RP2040 don't use this queue - they fall back to the heap-based approach
-  // (ESP8266: single-core, RP2040: empty mutex implementation).
+  // Single-core platforms don't use this queue and fall back to the heap-based approach.
   //
   // Note: Items cancelled via cancel_item_locked_() are marked with remove=true but still
   // processed here. They are removed from the queue normally via pop_front() but skipped
@@ -262,7 +261,7 @@ void HOT Scheduler::call(uint32_t now) {
       this->execute_item_(item.get(), now);
     }
   }
-#endif
+#endif /* not ESPHOME_SINGLE_CORE */
 
   // Convert the fresh timestamp from main loop to 64-bit for scheduler operations
   const auto now_64 = this->millis_64_(now);  // 'now' from parameter - fresh from Application::loop()
@@ -274,13 +273,15 @@ void HOT Scheduler::call(uint32_t now) {
   if (now_64 - last_print > 2000) {
     last_print = now_64;
     std::vector<std::unique_ptr<SchedulerItem>> old_items;
-#if !defined(USE_ESP8266) && !defined(USE_RP2040) && !defined(USE_LIBRETINY)
-    ESP_LOGD(TAG, "Items: count=%zu, now=%" PRIu64 " (%u, %" PRIu32 ")", this->items_.size(), now_64,
-             this->millis_major_, this->last_millis_.load(std::memory_order_relaxed));
-#else
-    ESP_LOGD(TAG, "Items: count=%zu, now=%" PRIu64 " (%u, %" PRIu32 ")", this->items_.size(), now_64,
+#ifdef ESPHOME_ATOMIC_SCHEDULER
+    const auto last_dbg = this->last_millis_.load(std::memory_order_relaxed);
+    const auto major_dbg = this->millis_major_.load(std::memory_order_relaxed);
+    ESP_LOGD(TAG, "Items: count=%zu, now=%" PRIu64 " (%" PRIu16 ", %" PRIu32 ")", this->items_.size(), now_64,
+             major_dbg, last_dbg);
+#else  /* not ESPHOME_ATOMIC_SCHEDULER */
+    ESP_LOGD(TAG, "Items: count=%zu, now=%" PRIu64 " (%" PRIu16 ", %" PRIu32 ")", this->items_.size(), now_64,
              this->millis_major_, this->last_millis_);
-#endif
+#endif /* else ESPHOME_ATOMIC_SCHEDULER */
     while (!this->empty_()) {
       std::unique_ptr<SchedulerItem> item;
       {
@@ -305,7 +306,7 @@ void HOT Scheduler::call(uint32_t now) {
       std::make_heap(this->items_.begin(), this->items_.end(), SchedulerItem::cmp);
     }
   }
-#endif  // ESPHOME_DEBUG_SCHEDULER
+#endif /* ESPHOME_DEBUG_SCHEDULER */
 
   // If we have too many items to remove
   if (this->to_remove_ > MAX_LOGICALLY_DELETED_ITEMS) {
@@ -352,7 +353,7 @@ void HOT Scheduler::call(uint32_t now) {
       ESP_LOGV(TAG, "Running %s '%s/%s' with interval=%" PRIu32 " next_execution=%" PRIu64 " (now=%" PRIu64 ")",
                item->get_type_str(), item->get_source(), item_name ? item_name : "(null)", item->interval,
                item->next_execution_, now_64);
-#endif
+#endif /* ESPHOME_DEBUG_SCHEDULER */
 
       // Warning: During callback(), a lot of stuff can happen, including:
       //  - timeouts/intervals get added, potentially invalidating vector pointers
@@ -460,7 +461,7 @@ bool HOT Scheduler::cancel_item_locked_(Component *component, const char *name_c
   size_t total_cancelled = 0;
 
   // Check all containers for matching items
-#if !defined(USE_ESP8266) && !defined(USE_RP2040)
+#ifndef ESPHOME_SINGLE_CORE
   // Only check defer queue for timeouts (intervals never go there)
   if (type == SchedulerItem::TIMEOUT) {
     for (auto &item : this->defer_queue_) {
@@ -470,7 +471,7 @@ bool HOT Scheduler::cancel_item_locked_(Component *component, const char *name_c
       }
     }
   }
-#endif
+#endif /* not ESPHOME_SINGLE_CORE */
 
   // Cancel items in the main heap
   for (auto &item : this->items_) {
@@ -496,7 +497,7 @@ bool HOT Scheduler::cancel_item_locked_(Component *component, const char *name_c
 uint64_t Scheduler::millis_64_(uint32_t now) {
   // THREAD SAFETY NOTE:
   // This function can be called from multiple threads simultaneously on ESP32/LibreTiny.
-  // On single-threaded platforms (ESP8266, RP2040), atomics are not needed.
+  // On single-core platforms, atomics are not needed.
   //
   // IMPORTANT: Always pass fresh millis() values to this function. The implementation
   // handles out-of-order timestamps between threads, but minimizing time differences
@@ -508,99 +509,128 @@ uint64_t Scheduler::millis_64_(uint32_t now) {
   // This prevents race conditions at the rollover boundary without requiring
   // 64-bit atomics or locking on every call.
 
+#ifdef ESPHOME_ATOMIC_SCHEDULER
+  for (;;) {
+    uint16_t major = this->millis_major_.load(std::memory_order_acquire);
+#else  /* not ESPHOME_ATOMIC_SCHEDULER */
+  uint16_t major = this->millis_major_;
+#endif /* else ESPHOME_ATOMIC_SCHEDULER */
+
 #ifdef USE_LIBRETINY
-  // LibreTiny: Multi-threaded but lacks atomic operation support
-  // TODO: If LibreTiny ever adds atomic support, remove this entire block and
-  // let it fall through to the atomic-based implementation below
-  // We need to use a lock when near the rollover boundary to prevent races
-  uint32_t last = this->last_millis_;
+    // LibreTiny: Multi-threaded but lacks atomic operation support
+    // TODO: If LibreTiny ever adds atomic support, remove this entire block and
+    // let it fall through to the atomic-based implementation below
+    // We need to use a lock when near the rollover boundary to prevent races
+    uint32_t last = this->last_millis_;
 
-  // Define a safe window around the rollover point (10 seconds)
-  // This covers any reasonable scheduler delays or thread preemption
-  static const uint32_t ROLLOVER_WINDOW = 10000;  // 10 seconds in milliseconds
+    // Define a safe window around the rollover point (10 seconds)
+    // This covers any reasonable scheduler delays or thread preemption
+    static const uint32_t ROLLOVER_WINDOW = 10000;  // 10 seconds in milliseconds
 
-  // Check if we're near the rollover boundary (close to std::numeric_limits<uint32_t>::max() or just past 0)
-  bool near_rollover = (last > (std::numeric_limits<uint32_t>::max() - ROLLOVER_WINDOW)) || (now < ROLLOVER_WINDOW);
+    // Check if we're near the rollover boundary (close to std::numeric_limits<uint32_t>::max() or just past 0)
+    bool near_rollover = (last > (std::numeric_limits<uint32_t>::max() - ROLLOVER_WINDOW)) || (now < ROLLOVER_WINDOW);
 
-  if (near_rollover || (now < last && (last - now) > HALF_MAX_UINT32)) {
-    // Near rollover or detected a rollover - need lock for safety
-    LockGuard guard{this->lock_};
-    // Re-read with lock held
-    last = this->last_millis_;
+    if (near_rollover || (now < last && (last - now) > HALF_MAX_UINT32)) {
+      // Near rollover or detected a rollover - need lock for safety
+      LockGuard guard{this->lock_};
+      // Re-read with lock held
+      last = this->last_millis_;
 
-    if (now < last && (last - now) > HALF_MAX_UINT32) {
-      // True rollover detected (happens every ~49.7 days)
-      this->millis_major_++;
+      if (now < last && (last - now) > HALF_MAX_UINT32) {
+        // True rollover detected (happens every ~49.7 days)
+        this->millis_major_++;
+        major++;
 #ifdef ESPHOME_DEBUG_SCHEDULER
-      ESP_LOGD(TAG, "Detected true 32-bit rollover at %" PRIu32 "ms (was %" PRIu32 ")", now, last);
-#endif
+        ESP_LOGD(TAG, "Detected true 32-bit rollover at %" PRIu32 "ms (was %" PRIu32 ")", now, last);
+#endif /* ESPHOME_DEBUG_SCHEDULER */
+      }
+      // Update last_millis_ while holding lock
+      this->last_millis_ = now;
+    } else if (now > last) {
+      // Normal case: Not near rollover and time moved forward
+      // Update without lock. While this may cause minor races (microseconds of
+      // backwards time movement), they're acceptable because:
+      // 1. The scheduler operates at millisecond resolution, not microsecond
+      // 2. We've already prevented the critical rollover race condition
+      // 3. Any backwards movement is orders of magnitude smaller than scheduler delays
+      this->last_millis_ = now;
     }
-    // Update last_millis_ while holding lock
-    this->last_millis_ = now;
-  } else if (now > last) {
-    // Normal case: Not near rollover and time moved forward
-    // Update without lock. While this may cause minor races (microseconds of
-    // backwards time movement), they're acceptable because:
-    // 1. The scheduler operates at millisecond resolution, not microsecond
-    // 2. We've already prevented the critical rollover race condition
-    // 3. Any backwards movement is orders of magnitude smaller than scheduler delays
-    this->last_millis_ = now;
-  }
-  // If now <= last and we're not near rollover, don't update
-  // This minimizes backwards time movement
+    // If now <= last and we're not near rollover, don't update
+    // This minimizes backwards time movement
 
-#elif !defined(USE_ESP8266) && !defined(USE_RP2040)
-  // Multi-threaded platforms with atomic support (ESP32)
-  uint32_t last = this->last_millis_.load(std::memory_order_relaxed);
+#elif defined(ESPHOME_ATOMIC_SCHEDULER)
+  /*
+   * Multi-threaded platforms with atomic support (ESP32)
+   * Acquire so that if we later decide **not** to take the lock we still
+   * observe a `millis_major_` value coherent with the loaded `last_millis_`.
+   * The acquire load ensures any later read of `millis_major_` sees its
+   * corresponding increment.
+   */
+  uint32_t last = this->last_millis_.load(std::memory_order_acquire);
 
   // If we might be near a rollover (large backwards jump), take the lock for the entire operation
   // This ensures rollover detection and last_millis_ update are atomic together
   if (now < last && (last - now) > HALF_MAX_UINT32) {
     // Potential rollover - need lock for atomic rollover detection + update
     LockGuard guard{this->lock_};
-    // Re-read with lock held
+    // Re-read with lock held; mutex already provides ordering
     last = this->last_millis_.load(std::memory_order_relaxed);
 
     if (now < last && (last - now) > HALF_MAX_UINT32) {
       // True rollover detected (happens every ~49.7 days)
-      this->millis_major_++;
+      this->millis_major_.fetch_add(1, std::memory_order_relaxed);
+      major++;
 #ifdef ESPHOME_DEBUG_SCHEDULER
       ESP_LOGD(TAG, "Detected true 32-bit rollover at %" PRIu32 "ms (was %" PRIu32 ")", now, last);
-#endif
+#endif /* ESPHOME_DEBUG_SCHEDULER */
     }
-    // Update last_millis_ while holding lock to prevent races
-    this->last_millis_.store(now, std::memory_order_relaxed);
+    /*
+     * Update last_millis_ while holding the lock to prevent races
+     * Publish the new low-word *after* bumping `millis_major_` (done above)
+     * so readers never see a mismatched pair.
+     */
+    this->last_millis_.store(now, std::memory_order_release);
   } else {
     // Normal case: Try lock-free update, but only allow forward movement within same epoch
     // This prevents accidentally moving backwards across a rollover boundary
     while (now > last && (now - last) < HALF_MAX_UINT32) {
-      if (this->last_millis_.compare_exchange_weak(last, now, std::memory_order_relaxed)) {
+      if (this->last_millis_.compare_exchange_weak(last, now,
+                                                   std::memory_order_release,     // success
+                                                   std::memory_order_relaxed)) {  // failure
         break;
       }
+      // CAS failure means no data was published; relaxed is fine
       // last is automatically updated by compare_exchange_weak if it fails
     }
   }
-
-#else
-  // Single-threaded platforms (ESP8266, RP2040): No atomics needed
+#else  /* not USE_LIBRETINY; not ESPHOME_ATOMIC_SCHEDULER */
+  // Single-core platforms: No atomics needed
   uint32_t last = this->last_millis_;
 
   // Check for rollover
   if (now < last && (last - now) > HALF_MAX_UINT32) {
     this->millis_major_++;
+    major++;
 #ifdef ESPHOME_DEBUG_SCHEDULER
     ESP_LOGD(TAG, "Detected true 32-bit rollover at %" PRIu32 "ms (was %" PRIu32 ")", now, last);
-#endif
+#endif /* ESPHOME_DEBUG_SCHEDULER */
   }
 
   // Only update if time moved forward
   if (now > last) {
     this->last_millis_ = now;
   }
-#endif
+#endif /* else (USE_LIBRETINY / ESPHOME_ATOMIC_SCHEDULER) */
 
+#ifdef ESPHOME_ATOMIC_SCHEDULER
+    uint16_t major_end = this->millis_major_.load(std::memory_order_relaxed);
+    if (major_end == major)
+      return now + (static_cast<uint64_t>(major) << 32);
+  }
+#else  /* not ESPHOME_ATOMIC_SCHEDULER */
   // Combine major (high 32 bits) and now (low 32 bits) into 64-bit time
-  return now + (static_cast<uint64_t>(this->millis_major_) << 32);
+  return now + (static_cast<uint64_t>(major) << 32);
+#endif /* ESPHOME_ATOMIC_SCHEDULER */
 }
 
 bool HOT Scheduler::SchedulerItem::cmp(const std::unique_ptr<SchedulerItem> &a,

--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -538,12 +538,11 @@ uint64_t Scheduler::millis_64_(uint32_t now) {
 #ifdef ESPHOME_MULTI_CORE_NO_ATOMICS
   // This is the multi core no atomics implementation.
   //
-  // Without atomics, this implementation uses locks more aggressively:
-  // 1. Always locks when near the rollover boundary (within 10 seconds)
-  // 2. Always locks when detecting a large backwards jump
-  // 3. Updates without lock in normal forward progression (accepting minor races)
-  // This is less efficient but necessary without atomic operations.
-
+  // The implementation handles the 32-bit rollover (every 49.7 days) by:
+  // 1. Using a lock when detecting rollover to ensure atomic update
+  // 2. Restricting normal updates to forward movement within the same epoch
+  // This prevents race conditions at the rollover boundary without requiring
+  // 64-bit atomics or locking on every call.
   uint16_t major = this->millis_major_;
   uint32_t last = this->last_millis_;
 
@@ -589,12 +588,11 @@ uint64_t Scheduler::millis_64_(uint32_t now) {
 #ifdef ESPHOME_MULTI_CORE_ATOMICS
   // This is the multi core with atomics implementation.
   //
-  // Uses atomic operations with acquire/release semantics to ensure coherent
-  // reads of millis_major_ and last_millis_ across cores. Features:
-  // 1. Epoch-coherency retry loop to handle concurrent updates
-  // 2. Lock only taken for actual rollover detection and update
-  // 3. Lock-free CAS updates for normal forward time progression
-  // 4. Memory ordering ensures cores see consistent time values
+  // The implementation handles the 32-bit rollover (every 49.7 days) by:
+  // 1. Using a lock when detecting rollover to ensure atomic update
+  // 2. Restricting normal updates to forward movement within the same epoch
+  // This prevents race conditions at the rollover boundary without requiring
+  // 64-bit atomics or locking on every call.
 
   for (;;) {
     uint16_t major = this->millis_major_.load(std::memory_order_acquire);

--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -538,11 +538,11 @@ uint64_t Scheduler::millis_64_(uint32_t now) {
 #ifdef ESPHOME_MULTI_CORE_NO_ATOMICS
   // This is the multi core no atomics implementation.
   //
-  // The implementation handles the 32-bit rollover (every 49.7 days) by:
-  // 1. Using a lock when detecting rollover to ensure atomic update
-  // 2. Restricting normal updates to forward movement within the same epoch
-  // This prevents race conditions at the rollover boundary without requiring
-  // 64-bit atomics or locking on every call.
+  // Without atomics, this implementation uses locks more aggressively:
+  // 1. Always locks when near the rollover boundary (within 10 seconds)
+  // 2. Always locks when detecting a large backwards jump
+  // 3. Updates without lock in normal forward progression (accepting minor races)
+  // This is less efficient but necessary without atomic operations.
 
   uint16_t major = this->millis_major_;
   uint32_t last = this->last_millis_;

--- a/esphome/core/scheduler.h
+++ b/esphome/core/scheduler.h
@@ -1,10 +1,11 @@
 #pragma once
 
+#include "esphome/core/defines.h"
 #include <vector>
 #include <memory>
 #include <cstring>
 #include <deque>
-#if !defined(USE_ESP8266) && !defined(USE_RP2040) && !defined(USE_LIBRETINY)
+#ifdef ESPHOME_ATOMIC_SCHEDULER
 #include <atomic>
 #endif
 
@@ -204,22 +205,37 @@ class Scheduler {
   Mutex lock_;
   std::vector<std::unique_ptr<SchedulerItem>> items_;
   std::vector<std::unique_ptr<SchedulerItem>> to_add_;
-#if !defined(USE_ESP8266) && !defined(USE_RP2040)
-  // ESP8266 and RP2040 don't need the defer queue because:
-  // ESP8266: Single-core with no preemptive multitasking
-  // RP2040: Currently has empty mutex implementation in ESPHome
-  // Both platforms save 40 bytes of RAM by excluding this
+#ifndef ESPHOME_SINGLE_CORE
+  // Single-core platforms don't need the defer queue and save 40 bytes of RAM
   std::deque<std::unique_ptr<SchedulerItem>> defer_queue_;  // FIFO queue for defer() calls
-#endif
-#if !defined(USE_ESP8266) && !defined(USE_RP2040) && !defined(USE_LIBRETINY)
-  // Multi-threaded platforms with atomic support: last_millis_ needs atomic for lock-free updates
+#endif                                                      /* ESPHOME_SINGLE_CORE */
+#ifdef ESPHOME_ATOMIC_SCHEDULER
+  /*
+   * Multi-threaded platforms with atomic support: last_millis_ needs atomic for lock-free updates
+   *
+   * MEMORY-ORDERING NOTE
+   * --------------------
+   * `last_millis_` and `millis_major_` form a single 64-bit timestamp split in half.
+   * Writers publish `last_millis_` with memory_order_release and readers use
+   * memory_order_acquire. This ensures that once a reader sees the new low word,
+   * it also observes the corresponding increment of `millis_major_`.
+   */
   std::atomic<uint32_t> last_millis_{0};
-#else
+#else  /* not ESPHOME_ATOMIC_SCHEDULER */
   // Platforms without atomic support or single-threaded platforms
   uint32_t last_millis_{0};
-#endif
-  // millis_major_ is protected by lock when incrementing
+#endif /* else ESPHOME_ATOMIC_SCHEDULER */
+  /*
+   * Upper 16 bits of the 64-bit millis counter. Incremented only while holding
+   * `lock_`; read concurrently. Atomic (relaxed) avoids a formal data race.
+   * Ordering relative to `last_millis_` is provided by its release store and the
+   * corresponding acquire loads.
+   */
+#ifdef ESPHOME_ATOMIC_SCHEDULER
+  std::atomic<uint16_t> millis_major_{0};
+#else  /* not ESPHOME_ATOMIC_SCHEDULER */
   uint16_t millis_major_{0};
+#endif /* else ESPHOME_ATOMIC_SCHEDULER */
   uint32_t to_remove_{0};
 };
 

--- a/esphome/core/scheduler.h
+++ b/esphome/core/scheduler.h
@@ -5,7 +5,7 @@
 #include <memory>
 #include <cstring>
 #include <deque>
-#ifdef ESPHOME_MULTI_CORE_ATOMICS
+#ifdef ESPHOME_CORES_MULTI_ATOMICS
 #include <atomic>
 #endif
 
@@ -205,13 +205,13 @@ class Scheduler {
   Mutex lock_;
   std::vector<std::unique_ptr<SchedulerItem>> items_;
   std::vector<std::unique_ptr<SchedulerItem>> to_add_;
-#ifndef ESPHOME_SINGLE_CORE
+#ifndef ESPHOME_CORES_SINGLE
   // Single-core platforms don't need the defer queue and save 40 bytes of RAM
   std::deque<std::unique_ptr<SchedulerItem>> defer_queue_;  // FIFO queue for defer() calls
-#endif                                                      /* ESPHOME_SINGLE_CORE */
+#endif                                                      /* ESPHOME_CORES_SINGLE */
   uint32_t to_remove_{0};
 
-#ifdef ESPHOME_MULTI_CORE_ATOMICS
+#ifdef ESPHOME_CORES_MULTI_ATOMICS
   /*
    * Multi-threaded platforms with atomic support: last_millis_ needs atomic for lock-free updates
    *
@@ -223,10 +223,10 @@ class Scheduler {
    * it also observes the corresponding increment of `millis_major_`.
    */
   std::atomic<uint32_t> last_millis_{0};
-#else  /* not ESPHOME_MULTI_CORE_ATOMICS */
+#else  /* not ESPHOME_CORES_MULTI_ATOMICS */
   // Platforms without atomic support or single-threaded platforms
   uint32_t last_millis_{0};
-#endif /* else ESPHOME_MULTI_CORE_ATOMICS */
+#endif /* else ESPHOME_CORES_MULTI_ATOMICS */
 
   /*
    * Upper 16 bits of the 64-bit millis counter. Incremented only while holding
@@ -234,11 +234,11 @@ class Scheduler {
    * Ordering relative to `last_millis_` is provided by its release store and the
    * corresponding acquire loads.
    */
-#ifdef ESPHOME_MULTI_CORE_ATOMICS
+#ifdef ESPHOME_CORES_MULTI_ATOMICS
   std::atomic<uint16_t> millis_major_{0};
-#else  /* not ESPHOME_MULTI_CORE_ATOMICS */
+#else  /* not ESPHOME_CORES_MULTI_ATOMICS */
   uint16_t millis_major_{0};
-#endif /* else ESPHOME_MULTI_CORE_ATOMICS */
+#endif /* else ESPHOME_CORES_MULTI_ATOMICS */
 };
 
 }  // namespace esphome

--- a/esphome/core/scheduler.h
+++ b/esphome/core/scheduler.h
@@ -209,6 +209,8 @@ class Scheduler {
   // Single-core platforms don't need the defer queue and save 40 bytes of RAM
   std::deque<std::unique_ptr<SchedulerItem>> defer_queue_;  // FIFO queue for defer() calls
 #endif                                                      /* ESPHOME_SINGLE_CORE */
+  uint32_t to_remove_{0};
+
 #ifdef ESPHOME_MULTI_CORE_ATOMICS
   /*
    * Multi-threaded platforms with atomic support: last_millis_ needs atomic for lock-free updates
@@ -225,6 +227,7 @@ class Scheduler {
   // Platforms without atomic support or single-threaded platforms
   uint32_t last_millis_{0};
 #endif /* else ESPHOME_MULTI_CORE_ATOMICS */
+
   /*
    * Upper 16 bits of the 64-bit millis counter. Incremented only while holding
    * `lock_`; read concurrently. Atomic (relaxed) avoids a formal data race.
@@ -236,7 +239,6 @@ class Scheduler {
 #else  /* not ESPHOME_MULTI_CORE_ATOMICS */
   uint16_t millis_major_{0};
 #endif /* else ESPHOME_MULTI_CORE_ATOMICS */
-  uint32_t to_remove_{0};
 };
 
 }  // namespace esphome

--- a/esphome/core/scheduler.h
+++ b/esphome/core/scheduler.h
@@ -5,7 +5,7 @@
 #include <memory>
 #include <cstring>
 #include <deque>
-#ifdef ESPHOME_ATOMIC_SCHEDULER
+#ifdef ESPHOME_MULTI_CORE_ATOMICS
 #include <atomic>
 #endif
 
@@ -209,7 +209,7 @@ class Scheduler {
   // Single-core platforms don't need the defer queue and save 40 bytes of RAM
   std::deque<std::unique_ptr<SchedulerItem>> defer_queue_;  // FIFO queue for defer() calls
 #endif                                                      /* ESPHOME_SINGLE_CORE */
-#ifdef ESPHOME_ATOMIC_SCHEDULER
+#ifdef ESPHOME_MULTI_CORE_ATOMICS
   /*
    * Multi-threaded platforms with atomic support: last_millis_ needs atomic for lock-free updates
    *
@@ -221,21 +221,21 @@ class Scheduler {
    * it also observes the corresponding increment of `millis_major_`.
    */
   std::atomic<uint32_t> last_millis_{0};
-#else  /* not ESPHOME_ATOMIC_SCHEDULER */
+#else  /* not ESPHOME_MULTI_CORE_ATOMICS */
   // Platforms without atomic support or single-threaded platforms
   uint32_t last_millis_{0};
-#endif /* else ESPHOME_ATOMIC_SCHEDULER */
+#endif /* else ESPHOME_MULTI_CORE_ATOMICS */
   /*
    * Upper 16 bits of the 64-bit millis counter. Incremented only while holding
    * `lock_`; read concurrently. Atomic (relaxed) avoids a formal data race.
    * Ordering relative to `last_millis_` is provided by its release store and the
    * corresponding acquire loads.
    */
-#ifdef ESPHOME_ATOMIC_SCHEDULER
+#ifdef ESPHOME_MULTI_CORE_ATOMICS
   std::atomic<uint16_t> millis_major_{0};
-#else  /* not ESPHOME_ATOMIC_SCHEDULER */
+#else  /* not ESPHOME_MULTI_CORE_ATOMICS */
   uint16_t millis_major_{0};
-#endif /* else ESPHOME_ATOMIC_SCHEDULER */
+#endif /* else ESPHOME_MULTI_CORE_ATOMICS */
   uint32_t to_remove_{0};
 };
 


### PR DESCRIPTION
# What does this implement/fix?

The current implementation uses only `memory_order_relaxed` on all atomic accesses. That protects each variable individually, but not the semantic link between the low word (`last_millis_`) and the high-word epoch counter (`millis_major_`). On a multi-core target a reader could observe a freshly stored low word before seeing the matching increment of the epoch, causing a ~49-day negative jump.

Key fixes
- Release/acquire pairing
  - writer: compare_exchange_weak(..., memory_order_release, …)
  - reader: first load of `last_millis_` now uses memory_order_acquire
  - ensures any core that sees the new low word also sees the updated high word
- Epoch-coherency retry loop
  - re-loads millis_major_ after the update and retries if it changed, guaranteeing monotonicity even when another core rolls over concurrently
- millis_major_ promoted to `std::atomic<uint16_t>` on SMP platforms
  - removes the formal data race at negligible cost
- new macros for better readability
  - ESPHOME_SINGLE_CORE – currently ESP8266/RP2040 only
  - ESPHOME_ATOMIC_SCHEDULER – all others except LibreTiny
- Logging and comments
  - loads atomics safely in debug output
  - updated inline docs to match the memory ordering

Behavior on single-core or non-atomic platforms is unchanged; multi-core targets now get a provably monotonic 64-bit millisecond clock with minimal overhead.


## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

Related PR: https://github.com/esphome/esphome/pull/9624

@bdraco please review. :)