### PR TITLE
[sdl][mipi_spi] Respect clipping when drawing

### DIFF
--- a/esphome/components/mipi_spi/mipi_spi.h
+++ b/esphome/components/mipi_spi/mipi_spi.h
@@ -534,6 +534,8 @@ class MipiSpiBuffer : public MipiSpi<BUFFERTYPE, BUFFERPIXEL, IS_BIG_ENDIAN, DIS
 
   // Draw a pixel at the given coordinates.
   void draw_pixel_at(int x, int y, Color color) override {
+    if (!this->get_clipping().inside(x, y))
+      return;
     rotate_coordinates_(x, y);
     if (x < 0 || x >= WIDTH || y < this->start_line_ || y >= this->end_line_)
       return;

--- a/esphome/components/sdl/sdl_esphome.cpp
+++ b/esphome/components/sdl/sdl_esphome.cpp
@@ -49,7 +49,7 @@ void Sdl::draw_pixels_at(int x_start, int y_start, int w, int h, const uint8_t *
 
 void Sdl::draw_pixel_at(int x, int y, Color color) {
   if (!this->get_clipping().inside(x, y))
-    return;  // NOLINT
+    return;
 
   SDL_Rect rect{x, y, 1, 1};
   auto data = (display::ColorUtil::color_to_565(color, display::COLOR_ORDER_RGB));

--- a/esphome/components/sdl/sdl_esphome.cpp
+++ b/esphome/components/sdl/sdl_esphome.cpp
@@ -48,11 +48,12 @@ void Sdl::draw_pixels_at(int x_start, int y_start, int w, int h, const uint8_t *
 }
 
 void Sdl::draw_pixel_at(int x, int y, Color color) {
-  if (this->get_clipping().inside(x, y)) {
-    SDL_Rect rect{x, y, 1, 1};
-    auto data = (display::ColorUtil::color_to_565(color, display::COLOR_ORDER_RGB));
-    SDL_UpdateTexture(this->texture_, &rect, &data, 2);
-  }
+  if (!this->get_clipping().inside(x, y))
+    return;  // NOLINT
+
+  SDL_Rect rect{x, y, 1, 1};
+  auto data = (display::ColorUtil::color_to_565(color, display::COLOR_ORDER_RGB));
+  SDL_UpdateTexture(this->texture_, &rect, &data, 2);
   if (x < this->x_low_)
     this->x_low_ = x;
   if (y < this->y_low_)

--- a/esphome/components/sdl/sdl_esphome.cpp
+++ b/esphome/components/sdl/sdl_esphome.cpp
@@ -48,9 +48,11 @@ void Sdl::draw_pixels_at(int x_start, int y_start, int w, int h, const uint8_t *
 }
 
 void Sdl::draw_pixel_at(int x, int y, Color color) {
-  SDL_Rect rect{x, y, 1, 1};
-  auto data = (display::ColorUtil::color_to_565(color, display::COLOR_ORDER_RGB));
-  SDL_UpdateTexture(this->texture_, &rect, &data, 2);
+  if (this->get_clipping().inside(x, y)) {
+    SDL_Rect rect{x, y, 1, 1};
+    auto data = (display::ColorUtil::color_to_565(color, display::COLOR_ORDER_RGB));
+    SDL_UpdateTexture(this->texture_, &rect, &data, 2);
+  }
   if (x < this->x_low_)
     this->x_low_ = x;
   if (y < this->y_low_)


### PR DESCRIPTION
# What does this implement/fix?

The sdl display previously ignored the clipping settings of the esphome display. This pr fixes that issue.
No previously opened Issue because I found and fixed the bug while debugging my code.

Similar fix applied to mipi_spi


## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
display:
  - platform: sdl
    id: eink
    update_interval: never
    dimensions:
      width: 800
      height: 480
    lambda: |-
      it.start_clipping(100, 100, 200, 200);

      it.circle(100, 100, 100);
      it.rectangle(100, 100, 100, 100);

      it.end_clipping();

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
