### PR TITLE
[esp32_touch] Fix setup mode in v1 driver

### DIFF
--- a/esphome/components/esp32_touch/esp32_touch_v1.cpp
+++ b/esphome/components/esp32_touch/esp32_touch_v1.cpp
@@ -120,8 +120,8 @@ void ESP32TouchComponent::loop() {
         child->publish_state(new_state);
         // Original ESP32: ISR only fires when touched, release is detected by timeout
         // Note: ESP32 v1 uses inverted logic - touched when value < threshold
-        ESP_LOGV(TAG, "Touch Pad '%s' state: ON (value: %" PRIu32 " < threshold: %" PRIu32 ")",
-                 child->get_name().c_str(), event.value, child->get_threshold());
+        ESP_LOGV(TAG, "Touch Pad '%s' state: %s (value: %" PRIu32 " < threshold: %" PRIu32 ")",
+                 child->get_name().c_str(), ONOFF(new_state), event.value, child->get_threshold());
       }
       break;  // Exit inner loop after processing matching pad
     }

--- a/esphome/components/esp32_touch/esp32_touch_v1.cpp
+++ b/esphome/components/esp32_touch/esp32_touch_v1.cpp
@@ -16,6 +16,8 @@ namespace esp32_touch {
 
 static const char *const TAG = "esp32_touch";
 
+static const uint32_t SETUP_MODE_THRESHOLD = 0xFFFF;
+
 void ESP32TouchComponent::setup() {
   // Create queue for touch events
   // Queue size calculation: children * 4 allows for burst scenarios where ISR
@@ -44,7 +46,11 @@ void ESP32TouchComponent::setup() {
 
   // Configure each touch pad
   for (auto *child : this->children_) {
-    touch_pad_config(child->get_touch_pad(), child->get_threshold());
+    if (this->setup_mode_) {
+      touch_pad_config(child->get_touch_pad(), SETUP_MODE_THRESHOLD);
+    } else {
+      touch_pad_config(child->get_touch_pad(), child->get_threshold());
+    }
   }
 
   // Register ISR handler
@@ -188,11 +194,6 @@ void IRAM_ATTR ESP32TouchComponent::touch_isr_handler(void *arg) {
   // as any pad remains touched. This allows us to detect both new touches and
   // continued touches, but releases must be detected by timeout in the main loop.
 
-  // IMPORTANT: ESP32 v1 touch detection logic - INVERTED compared to v2!
-  // ESP32 v1: Touch is detected when capacitance INCREASES, causing the measured value to DECREASE
-  // Therefore: touched = (value < threshold)
-  // This is opposite to ESP32-S2/S3 v2 where touched = (value > threshold)
-
   // Process all configured pads to check their current state
   // Note: ESP32 v1 doesn't tell us which specific pad triggered the interrupt,
   // so we must scan all configured pads to find which ones were touched
@@ -211,10 +212,15 @@ void IRAM_ATTR ESP32TouchComponent::touch_isr_handler(void *arg) {
     }
 
     // Skip pads that aren’t in the trigger mask
-    bool is_touched = (mask >> pad) & 1;
-    if (!is_touched) {
+    if (((mask >> pad) & 1) == 0) {
       continue;
     }
+
+    // IMPORTANT: ESP32 v1 touch detection logic - INVERTED compared to v2!
+    // ESP32 v1: Touch is detected when capacitance INCREASES, causing the measured value to DECREASE
+    // Therefore: touched = (value < threshold)
+    // This is opposite to ESP32-S2/S3 v2 where touched = (value > threshold)
+    bool is_touched = value < child->get_threshold();
 
     // Always send the current state - the main loop will filter for changes
     // We send both touched and untouched states because the ISR doesn't


### PR DESCRIPTION
# What does this implement/fix?

Fix setup mode in v1 driver. Set the threshold to the max and compare the value it in software. Will get an interrupt every period. Without this setup mode never shows any data unless touched. If setup_mode is false set the real threshold to avoid constant interrupts. 

Fix log message, always said the state was ON. 

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/9690

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
