### PR TITLE
[api] Fix missing ifdef guards for AreaInfo and DeviceInfo messages

### DIFF
--- a/esphome/components/api/api_pb2.cpp
+++ b/esphome/components/api/api_pb2.cpp
@@ -57,6 +57,7 @@ void ConnectResponse::encode(ProtoWriteBuffer buffer) const { buffer.encode_bool
 void ConnectResponse::calculate_size(uint32_t &total_size) const {
   ProtoSize::add_bool_field(total_size, 1, this->invalid_password);
 }
+#ifdef USE_AREAS
 void AreaInfo::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint32(1, this->area_id);
   buffer.encode_string(2, this->name);
@@ -65,6 +66,8 @@ void AreaInfo::calculate_size(uint32_t &total_size) const {
   ProtoSize::add_uint32_field(total_size, 1, this->area_id);
   ProtoSize::add_string_field(total_size, 1, this->name);
 }
+#endif
+#ifdef USE_DEVICES
 void DeviceInfo::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint32(1, this->device_id);
   buffer.encode_string(2, this->name);
@@ -75,6 +78,7 @@ void DeviceInfo::calculate_size(uint32_t &total_size) const {
   ProtoSize::add_string_field(total_size, 1, this->name);
   ProtoSize::add_uint32_field(total_size, 1, this->area_id);
 }
+#endif
 void DeviceInfoResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_bool(1, this->uses_password);
   buffer.encode_string(2, this->name);

--- a/esphome/components/api/api_pb2.h
+++ b/esphome/components/api/api_pb2.h
@@ -457,6 +457,7 @@ class DeviceInfoRequest : public ProtoDecodableMessage {
 
  protected:
 };
+#ifdef USE_AREAS
 class AreaInfo : public ProtoMessage {
  public:
   uint32_t area_id{0};
@@ -469,6 +470,8 @@ class AreaInfo : public ProtoMessage {
 
  protected:
 };
+#endif
+#ifdef USE_DEVICES
 class DeviceInfo : public ProtoMessage {
  public:
   uint32_t device_id{0};
@@ -482,6 +485,7 @@ class DeviceInfo : public ProtoMessage {
 
  protected:
 };
+#endif
 class DeviceInfoResponse : public ProtoMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 10;

--- a/esphome/components/api/api_pb2_dump.cpp
+++ b/esphome/components/api/api_pb2_dump.cpp
@@ -655,6 +655,7 @@ void DisconnectResponse::dump_to(std::string &out) const { out.append("Disconnec
 void PingRequest::dump_to(std::string &out) const { out.append("PingRequest {}"); }
 void PingResponse::dump_to(std::string &out) const { out.append("PingResponse {}"); }
 void DeviceInfoRequest::dump_to(std::string &out) const { out.append("DeviceInfoRequest {}"); }
+#ifdef USE_AREAS
 void AreaInfo::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("AreaInfo {\n");
@@ -668,6 +669,8 @@ void AreaInfo::dump_to(std::string &out) const {
   out.append("\n");
   out.append("}");
 }
+#endif
+#ifdef USE_DEVICES
 void DeviceInfo::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("DeviceInfo {\n");
@@ -686,6 +689,7 @@ void DeviceInfo::dump_to(std::string &out) const {
   out.append("\n");
   out.append("}");
 }
+#endif
 void DeviceInfoResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("DeviceInfoResponse {\n");

--- a/script/api_protobuf/api_protobuf.py
+++ b/script/api_protobuf/api_protobuf.py
@@ -995,6 +995,11 @@ def build_type_usage_map(
     }
 
     # Analyze field usage
+    # Also track field_ifdef for message types
+    message_field_ifdefs: dict[
+        str, set[str | None]
+    ] = {}  # message_name -> set of field_ifdefs that use it
+
     for message in file_desc.message_type:
         for field in message.field:
             type_name = field.type_name.split(".")[-1] if field.type_name else None
@@ -1007,6 +1012,9 @@ def build_type_usage_map(
             # Track message usage
             elif field.type == 11:  # TYPE_MESSAGE
                 message_usage.setdefault(type_name, set()).add(message.name)
+                # Also track the field_ifdef if present
+                field_ifdef = get_field_opt(field, pb.field_ifdef)
+                message_field_ifdefs.setdefault(type_name, set()).add(field_ifdef)
 
     # Helper to get unique ifdef from a set of messages
     def get_unique_ifdef(message_names: set[str]) -> str | None:
@@ -1032,9 +1040,16 @@ def build_type_usage_map(
             message_ifdef_map[message.name] = explicit_ifdef
         elif message.name in message_usage:
             # Inherit ifdef if all parent messages have the same one
-            message_ifdef_map[message.name] = get_unique_ifdef(
-                message_usage[message.name]
-            )
+            if parent_ifdef := get_unique_ifdef(message_usage[message.name]):
+                message_ifdef_map[message.name] = parent_ifdef
+            elif message.name in message_field_ifdefs:
+                # If no parent message ifdef, check if all fields using this message have the same field_ifdef
+                field_ifdefs = message_field_ifdefs[message.name] - {None}
+                message_ifdef_map[message.name] = (
+                    field_ifdefs.pop() if len(field_ifdefs) == 1 else None
+                )
+            else:
+                message_ifdef_map[message.name] = None
         else:
             message_ifdef_map[message.name] = None
 


### PR DESCRIPTION
# What does this implement/fix?

This PR fixes missing `#ifdef` guards for message classes that are only used in fields with `field_ifdef` options. This is a follow-up to #9693 which fixed field-level ifdefs in base classes.

Previously, messages like `AreaInfo` and `DeviceInfo` were always compiled even though they were only used in fields guarded by `USE_AREAS` or `USE_DEVICES`. This fix ensures these message classes are properly wrapped with the appropriate ifdef guards, reducing memory usage on devices where these features are disabled.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Follow-up to #9693

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal implementation detail)

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - this is an internal optimization
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
