### PR TITLE
[bme680] Eliminate warnings due to unused functions

### DIFF
--- a/esphome/components/bme680/bme680.cpp
+++ b/esphome/components/bme680/bme680.cpp
@@ -28,8 +28,7 @@ const float BME680_GAS_LOOKUP_TABLE_1[16] PROGMEM = {0.0, 0.0, 0.0,  0.0,  0.0, 
 const float BME680_GAS_LOOKUP_TABLE_2[16] PROGMEM = {0.0,  0.0, 0.0, 0.0, 0.1, 0.7, 0.0, -0.8,
                                                      -0.1, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
 
-[[maybe_unused]]
-static const char *oversampling_to_str(BME680Oversampling oversampling) {
+[[maybe_unused]] static const char *oversampling_to_str(BME680Oversampling oversampling) {
   switch (oversampling) {
     case BME680_OVERSAMPLING_NONE:
       return "None";
@@ -48,8 +47,7 @@ static const char *oversampling_to_str(BME680Oversampling oversampling) {
   }
 }
 
-[[maybe_unused]]
-static const char *iir_filter_to_str(BME680IIRFilter filter) {
+[[maybe_unused]] static const char *iir_filter_to_str(BME680IIRFilter filter) {
   switch (filter) {
     case BME680_IIR_FILTER_OFF:
       return "OFF";

--- a/esphome/components/bme680/bme680.cpp
+++ b/esphome/components/bme680/bme680.cpp
@@ -28,6 +28,7 @@ const float BME680_GAS_LOOKUP_TABLE_1[16] PROGMEM = {0.0, 0.0, 0.0,  0.0,  0.0, 
 const float BME680_GAS_LOOKUP_TABLE_2[16] PROGMEM = {0.0,  0.0, 0.0, 0.0, 0.1, 0.7, 0.0, -0.8,
                                                      -0.1, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
 
+[[maybe_unused]]
 static const char *oversampling_to_str(BME680Oversampling oversampling) {
   switch (oversampling) {
     case BME680_OVERSAMPLING_NONE:
@@ -47,6 +48,7 @@ static const char *oversampling_to_str(BME680Oversampling oversampling) {
   }
 }
 
+[[maybe_unused]]
 static const char *iir_filter_to_str(BME680IIRFilter filter) {
   switch (filter) {
     case BME680_IIR_FILTER_OFF:


### PR DESCRIPTION
There are oversampling and IIR filter string conversion functions which are in the code only when ESP_LOGCONFIG macro is used, while this for regular device compilation is not needed, hence I'm getting warning like: 
`warning: 'const char* esphome::bme680::iir_filter_to_str(...)' defined but not used [-Wunused-function]`

# What does this implement/fix?

This PR adds `[[maybe_unused]]` prior those functions, so no warnings, while all functionality remains.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**
not raised

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**
not needed

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:
not changed, nothing to add

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
