### PR TITLE
[nrf52, gpio] check different port notation

### DIFF
--- a/tests/components/gpio/test.nrf52-adafruit.yaml
+++ b/tests/components/gpio/test.nrf52-adafruit.yaml
@@ -5,10 +5,10 @@ binary_sensor:
 
 output:
   - platform: gpio
-    pin: 3
+    pin: P0.3
     id: gpio_output
 
 switch:
   - platform: gpio
-    pin: 4
+    pin: P1.2
     id: gpio_switch

--- a/tests/components/gpio/test.nrf52-mcumgr.yaml
+++ b/tests/components/gpio/test.nrf52-mcumgr.yaml
@@ -5,10 +5,10 @@ binary_sensor:
 
 output:
   - platform: gpio
-    pin: 3
+    pin: P0.3
     id: gpio_output
 
 switch:
   - platform: gpio
-    pin: 4
+    pin: P1.2
     id: gpio_switch


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->
[nrf52, gpio] check diffrent port notation

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
