### PR TITLE
fix default i2c address

### DIFF
--- a/esphome/components/rc522_i2c/__init__.py
+++ b/esphome/components/rc522_i2c/__init__.py
@@ -16,7 +16,7 @@ CONFIG_SCHEMA = cv.All(
         {
             cv.GenerateID(): cv.declare_id(RC522I2C),
         }
-    ).extend(i2c.i2c_device_schema(0x2C))
+    ).extend(i2c.i2c_device_schema(0x28))
 )
 
 


### PR DESCRIPTION
# What does this implement/fix?

Fixes default RC522 I2C address to match the documentation and device. I guess this is technically a breaking change if a board with 0x2C as the default address exists and anyone was relying on the default.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

seems to have been causing problems for a while: https://community.home-assistant.io/t/m5stack-atom-lite-esp32-and-rc522-rfid/383235/3

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
rc522_i2c:
  address: 0x28      <-- should not be required since the docs call it out as the default
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
