### PR TITLE
[core] Refactor scheduler to eliminate hidden side effects in ``empty_``

### DIFF
--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -222,11 +222,8 @@ optional<uint32_t> HOT Scheduler::next_schedule_in(uint32_t now) {
   // It performs cleanup and accesses items_[0] without holding a lock, which is only
   // safe when called from the main thread. Other threads must not call this method.
 
-  // Cleanup removed items first
-  size_t item_count = this->cleanup_();
-
   // If no items, return empty optional
-  if (item_count == 0)
+  if (this->cleanup_() == 0)
     return {};
 
   auto &item = this->items_[0];

--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -219,10 +219,16 @@ bool HOT Scheduler::cancel_retry(Component *component, const std::string &name) 
 
 optional<uint32_t> HOT Scheduler::next_schedule_in(uint32_t now) {
   // IMPORTANT: This method should only be called from the main thread (loop task).
-  // It calls empty_() and accesses items_[0] without holding a lock, which is only
+  // It performs cleanup and accesses items_[0] without holding a lock, which is only
   // safe when called from the main thread. Other threads must not call this method.
-  if (this->empty_())
+
+  // Cleanup removed items first
+  size_t item_count = this->cleanup_();
+
+  // If no items, return empty optional
+  if (item_count == 0)
     return {};
+
   auto &item = this->items_[0];
   // Convert the fresh timestamp from caller (usually Application::loop()) to 64-bit
   const auto now_64 = this->millis_64_(now);  // 'now' from parameter - fresh from caller
@@ -281,7 +287,9 @@ void HOT Scheduler::call(uint32_t now) {
     ESP_LOGD(TAG, "Items: count=%zu, now=%" PRIu64 " (%u, %" PRIu32 ")", this->items_.size(), now_64,
              this->millis_major_, this->last_millis_);
 #endif
-    while (!this->empty_()) {
+    // Cleanup before debug output
+    this->cleanup_();
+    while (!this->items_.empty()) {
       std::unique_ptr<SchedulerItem> item;
       {
         LockGuard guard{this->lock_};
@@ -332,7 +340,9 @@ void HOT Scheduler::call(uint32_t now) {
     this->to_remove_ = 0;
   }
 
-  while (!this->empty_()) {
+  // Cleanup removed items before processing
+  this->cleanup_();
+  while (!this->items_.empty()) {
     // use scoping to indicate visibility of `item` variable
     {
       // Don't copy-by value yet
@@ -398,8 +408,8 @@ void HOT Scheduler::process_to_add() {
   }
   this->to_add_.clear();
 }
-void HOT Scheduler::cleanup_() {
-  // Fast path: if nothing to remove, just return
+size_t HOT Scheduler::cleanup_() {
+  // Fast path: if nothing to remove, just return the current size
   // Reading to_remove_ without lock is safe because:
   // 1. We only call this from the main thread during call()
   // 2. If it's 0, there's definitely nothing to cleanup
@@ -407,7 +417,7 @@ void HOT Scheduler::cleanup_() {
   // 4. Not all platforms support atomics, so we accept this race in favor of performance
   // 5. The worst case is a one-loop-iteration delay in cleanup, which is harmless
   if (this->to_remove_ == 0)
-    return;
+    return this->items_.size();
 
   // We must hold the lock for the entire cleanup operation because:
   // 1. We're modifying items_ (via pop_raw_) which requires exclusive access
@@ -421,10 +431,11 @@ void HOT Scheduler::cleanup_() {
   while (!this->items_.empty()) {
     auto &item = this->items_[0];
     if (!item->remove)
-      return;
+      break;
     this->to_remove_--;
     this->pop_raw_();
   }
+  return this->items_.size();
 }
 void HOT Scheduler::pop_raw_() {
   std::pop_heap(this->items_.begin(), this->items_.end(), SchedulerItem::cmp);

--- a/esphome/core/scheduler.h
+++ b/esphome/core/scheduler.h
@@ -57,6 +57,9 @@ class Scheduler {
 
   // Calculate when the next scheduled item should run
   // @param now Fresh timestamp from millis() - must not be stale/cached
+  // Returns the time in milliseconds until the next scheduled item, or nullopt if no items
+  // This method performs cleanup of removed items before checking the schedule
+  // IMPORTANT: This method should only be called from the main thread (loop task).
   optional<uint32_t> next_schedule_in(uint32_t now);
 
   // Execute all scheduled items that are ready
@@ -146,7 +149,10 @@ class Scheduler {
                          uint32_t delay, std::function<void()> func);
 
   uint64_t millis_64_(uint32_t now);
-  void cleanup_();
+  // Cleanup logically deleted items from the scheduler
+  // Returns the number of items remaining after cleanup
+  // IMPORTANT: This method should only be called from the main thread (loop task).
+  size_t cleanup_();
   void pop_raw_();
 
  private:
@@ -188,17 +194,6 @@ class Scheduler {
   // Helper to check if item should be skipped
   bool should_skip_item_(const SchedulerItem *item) const {
     return item->remove || (item->component != nullptr && item->component->is_failed());
-  }
-
-  // Check if the scheduler has no items.
-  // IMPORTANT: This method should only be called from the main thread (loop task).
-  // It performs cleanup of removed items and checks if the queue is empty.
-  // The items_.empty() check at the end is done without a lock for performance,
-  // which is safe because this is only called from the main thread while other
-  // threads only add items (never remove them).
-  bool empty_() {
-    this->cleanup_();
-    return this->items_.empty();
   }
 
   Mutex lock_;


### PR DESCRIPTION
# What does this implement/fix?

This PR refactors the Scheduler's `empty_()` method to eliminate hidden side effects and improve code clarity. The `empty_()` method previously performed cleanup operations as a side effect, which was not obvious from its name and could lead to thread safety issues if called from the wrong context.

The refactoring:
- Removes the `empty_()` method entirely
- Makes `cleanup_()` return the number of items remaining after cleanup
- Moves cleanup into `next_schedule_in()` so callers don't need to worry about it
- Keeps explicit cleanup calls in the scheduler's `call()` method where needed for processing

This makes the code more maintainable and reduces the risk of subtle bugs from misunderstanding what `empty_()` actually does.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal implementation change)

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - this is an internal refactoring
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).