### PR TITLE
[CI] Label PR too-big if it has more than 1000 lines changed

### DIFF
--- a/.github/workflows/auto-label-pr.yml
+++ b/.github/workflows/auto-label-pr.yml
@@ -56,6 +56,7 @@ env:
     valve
   SMALL_PR_THRESHOLD: 30
   MAX_LABELS: 15
+  TOO_BIG_THRESHOLD: 1000
 
 jobs:
   label:
@@ -147,6 +148,7 @@ jobs:
             const platformComponents = `${{ env.PLATFORM_COMPONENTS }}`.split('\n').filter(p => p.trim().length > 0).map(p => p.trim());
             const smallPrThreshold = parseInt('${{ env.SMALL_PR_THRESHOLD }}');
             const maxLabels = parseInt('${{ env.MAX_LABELS }}');
+            const tooBigThreshold = parseInt('${{ env.TOO_BIG_THRESHOLD }}');
 
             // Strategy: Merge to release or beta branch
             const baseRef = context.payload.pull_request.base.ref;
@@ -402,18 +404,34 @@ jobs:
 
             console.log('Computed labels:', finalLabels.join(', '));
 
-            // Don't set more than max labels
-            if (finalLabels.length > maxLabels) {
+            // Check if PR is allowed to be too big
+            const allowedTooBig = currentLabels.includes('mega-pr');
+
+            // Check if PR is too big (either too many labels or too many line changes)
+            const tooManyLabels = finalLabels.length > maxLabels;
+            const tooManyChanges = totalChanges > tooBigThreshold;
+
+            if ((tooManyLabels || tooManyChanges) && !allowedTooBig) {
               const originalLength = finalLabels.length;
-              console.log(`Not setting ${originalLength} labels because out of range`);
+              console.log(`PR is too big - Labels: ${originalLength}, Changes: ${totalChanges}`);
               finalLabels = ['too-big'];
+
+              // Create appropriate review message
+              let reviewBody;
+              if (tooManyLabels && tooManyChanges) {
+                reviewBody = `This PR is too large with ${totalChanges} line changes and affects ${originalLength} different components/areas. Please consider breaking it down into smaller, focused PRs to make review easier and reduce the risk of conflicts.`;
+              } else if (tooManyLabels) {
+                reviewBody = `This PR affects ${originalLength} different components/areas. Please consider breaking it down into smaller, focused PRs to make review easier and reduce the risk of conflicts.`;
+              } else {
+                reviewBody = `This PR is too large with ${totalChanges} line changes. Please consider breaking it down into smaller, focused PRs to make review easier and reduce the risk of conflicts.`;
+              }
 
               // Request changes on the PR
               await github.rest.pulls.createReview({
                 owner,
                 repo,
                 pull_number: pr_number,
-                body: `This PR is too large and affects ${originalLength} different components/areas. Please consider breaking it down into smaller, focused PRs to make review easier and reduce the risk of conflicts.`,
+                body: reviewBody,
                 event: 'REQUEST_CHANGES'
               });
             }


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

This will auto request the author changes the PR to make it smaller and will label with `too-big`

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
