### PR TITLE
[schema-gen] fix referenced schemas when schema in component platform

### DIFF
--- a/script/build_language_schema.py
+++ b/script/build_language_schema.py
@@ -411,11 +411,16 @@ def add_referenced_recursive(referenced_schemas, config_var, path, eat_schema=Fa
 
             s1 = get_str_path_schema(k)
             p = k.split(".")
-            if len(p) == 3 and path[0] == f"{p[0]}.{p[1]}":
-                # special case for schema inside platforms
-                add_referenced_recursive(
-                    referenced_schemas, s1, [path[0], "schemas", p[2]]
-                )
+            if len(p) == 3:
+                if path[0] == f"{p[0]}.{p[1]}":
+                    # special case for schema inside platforms
+                    add_referenced_recursive(
+                        referenced_schemas, s1, [path[0], "schemas", p[2]]
+                    )
+                else:
+                    add_referenced_recursive(
+                        referenced_schemas, s1, [f"{p[0]}.{p[1]}", "schemas", p[2]]
+                    )
             else:
                 add_referenced_recursive(
                     referenced_schemas, s1, [p[0], "schemas", p[1]]


### PR DESCRIPTION
# What does this implement/fix?

An issue in the schema generator when a schema is referenced from an action defined in the main and the schema is inside a sensor

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes #9694

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
