### PR TITLE
[api] Sync uses_password field_ifdef optimization from aioesphomeapi

### DIFF
--- a/esphome/components/api/api.proto
+++ b/esphome/components/api/api.proto
@@ -203,7 +203,7 @@ message DeviceInfoResponse {
   option (id) = 10;
   option (source) = SOURCE_SERVER;
 
-  bool uses_password = 1;
+  bool uses_password = 1 [(field_ifdef) = "USE_API_PASSWORD"];
 
   // The name of the node, given by "App.set_name()"
   string name = 2;

--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -1432,8 +1432,6 @@ DeviceInfoResponse APIConnection::device_info(const DeviceInfoRequest &msg) {
   DeviceInfoResponse resp{};
 #ifdef USE_API_PASSWORD
   resp.uses_password = true;
-#else
-  resp.uses_password = false;
 #endif
   resp.name = App.get_name();
   resp.friendly_name = App.get_friendly_name();

--- a/esphome/components/api/api_pb2.cpp
+++ b/esphome/components/api/api_pb2.cpp
@@ -80,7 +80,9 @@ void DeviceInfo::calculate_size(uint32_t &total_size) const {
 }
 #endif
 void DeviceInfoResponse::encode(ProtoWriteBuffer buffer) const {
+#ifdef USE_API_PASSWORD
   buffer.encode_bool(1, this->uses_password);
+#endif
   buffer.encode_string(2, this->name);
   buffer.encode_string(3, this->mac_address);
   buffer.encode_string(4, this->esphome_version);
@@ -130,7 +132,9 @@ void DeviceInfoResponse::encode(ProtoWriteBuffer buffer) const {
 #endif
 }
 void DeviceInfoResponse::calculate_size(uint32_t &total_size) const {
+#ifdef USE_API_PASSWORD
   ProtoSize::add_bool_field(total_size, 1, this->uses_password);
+#endif
   ProtoSize::add_string_field(total_size, 1, this->name);
   ProtoSize::add_string_field(total_size, 1, this->mac_address);
   ProtoSize::add_string_field(total_size, 1, this->esphome_version);

--- a/esphome/components/api/api_pb2.h
+++ b/esphome/components/api/api_pb2.h
@@ -474,7 +474,9 @@ class DeviceInfoResponse : public ProtoMessage {
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "device_info_response"; }
 #endif
+#ifdef USE_API_PASSWORD
   bool uses_password{false};
+#endif
   std::string name{};
   std::string mac_address{};
   std::string esphome_version{};

--- a/esphome/components/api/api_pb2_dump.cpp
+++ b/esphome/components/api/api_pb2_dump.cpp
@@ -647,10 +647,12 @@ void DeviceInfo::dump_to(std::string &out) const {
 void DeviceInfoResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("DeviceInfoResponse {\n");
+#ifdef USE_API_PASSWORD
   out.append("  uses_password: ");
   out.append(YESNO(this->uses_password));
   out.append("\n");
 
+#endif
   out.append("  name: ");
   out.append("'").append(this->name).append("'");
   out.append("\n");


### PR DESCRIPTION
# What does this implement/fix?

This PR syncs the `uses_password` field optimization from aioesphomeapi PR esphome/aioesphomeapi#1266 to the ESPHome codebase. It adds the missing `field_ifdef` annotation to conditionally compile the `uses_password` field in `DeviceInfoResponse` based on whether password authentication is enabled in the firmware.

When ESPHome is compiled without password support (`USE_API_PASSWORD` not defined), the `uses_password` field is now completely excluded from the protocol messages, reducing unnecessary data transmission and improving efficiency for devices that don't use password authentication.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Syncs with https://github.com/esphome/aioesphomeapi/pull/1266

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- Not applicable (internal optimization, no user-facing changes)

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - this is an internal optimization
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).
    - Note: Existing test `test_host_mode_api_password.py` already provides full coverage for this change

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
    - Not applicable - no user-exposed functionality changes