### PR TITLE
[config_validation] Add support for suggesting alternate component/platform

### DIFF
--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -689,8 +689,8 @@ def only_with_framework(
 only_on_esp32 = only_on(PLATFORM_ESP32)
 only_on_esp8266 = only_on(PLATFORM_ESP8266)
 only_on_rp2040 = only_on(PLATFORM_RP2040)
-only_with_arduino = only_with_framework("arduino")
-only_with_esp_idf = only_with_framework("esp-idf")
+only_with_arduino = only_with_framework(Framework.ARDUINO)
+only_with_esp_idf = only_with_framework(Framework.ESP_IDF)
 
 
 # Adapted from:

--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -73,6 +73,7 @@ from esphome.const import (
     TYPE_GIT,
     TYPE_LOCAL,
     VALID_SUBSTITUTIONS_CHARACTERS,
+    Framework,
     __version__ as ESPHOME_VERSION,
 )
 from esphome.core import (
@@ -280,6 +281,37 @@ class Required(vol.Required):
 
 class FinalExternalInvalid(Invalid):
     """Represents an invalid value in the final validation phase where the path should not be prepended."""
+
+
+@dataclass(frozen=True, order=True)
+class Version:
+    major: int
+    minor: int
+    patch: int
+    extra: str = ""
+
+    def __str__(self):
+        return f"{self.major}.{self.minor}.{self.patch}"
+
+    @classmethod
+    def parse(cls, value: str) -> Version:
+        match = re.match(r"^(\d+).(\d+).(\d+)-?(\w*)$", value)
+        if match is None:
+            raise ValueError(f"Not a valid version number {value}")
+        major = int(match[1])
+        minor = int(match[2])
+        patch = int(match[3])
+        extra = match[4] or ""
+        return Version(major=major, minor=minor, patch=patch, extra=extra)
+
+    @property
+    def is_beta(self) -> bool:
+        """Check if this version is a beta version."""
+        return self.extra.startswith("b")
+
+    def is_dev(self) -> bool:
+        """Check if this version is a development version."""
+        return self.extra.startswith("dev")
 
 
 def check_not_templatable(value):
@@ -620,19 +652,33 @@ def only_on(platforms):
 
 
 def only_with_framework(
-    frameworks, suggested_alternate=None, suggested_alternate_doc=None
+    frameworks: Framework | str | list[Framework | str], suggestions=None
 ):
     """Validate that this option can only be specified on the given frameworks."""
     if not isinstance(frameworks, list):
         frameworks = [frameworks]
 
+    frameworks = [Framework(framework) for framework in frameworks]
+
+    if suggestions is None:
+        suggestions = {}
+
+    version = Version.parse(ESPHOME_VERSION)
+    if version.is_beta:
+        docs_format = "https://beta.esphome.io/components/{path}"
+    elif version.is_dev:
+        docs_format = "https://next.esphome.io/components/{path}"
+    else:
+        docs_format = "https://esphome.io/components/{path}"
+
     def validator_(obj):
         if CORE.target_framework not in frameworks:
-            err_str = f"This feature is only available with frameworks {frameworks}"
-            if suggested_alternate is not None:
-                err_str += f"\nPlease use '{suggested_alternate}'"
-                if suggested_alternate_doc is not None:
-                    err_str += f": {suggested_alternate_doc}"
+            err_str = f"This feature is only available with frameworks {', '.join([framework.value for framework in frameworks])}"
+            if suggestion := suggestions.get(CORE.target_framework, None):
+                (component, docs_path) = suggestion
+                err_str += f"\nPlease use '{component}'"
+                if docs_path:
+                    err_str += f": {docs_format.format(path=docs_path)}"
             raise Invalid(err_str)
         return obj
 
@@ -1969,26 +2015,6 @@ def source_refresh(value: str):
     if value.lower() == "never":
         return source_refresh("365250d")
     return positive_time_period_seconds(value)
-
-
-@dataclass(frozen=True, order=True)
-class Version:
-    major: int
-    minor: int
-    patch: int
-
-    def __str__(self):
-        return f"{self.major}.{self.minor}.{self.patch}"
-
-    @classmethod
-    def parse(cls, value: str) -> Version:
-        match = re.match(r"^(\d+).(\d+).(\d+)-?\w*$", value)
-        if match is None:
-            raise ValueError(f"Not a valid version number {value}")
-        major = int(match[1])
-        minor = int(match[2])
-        patch = int(match[3])
-        return Version(major=major, minor=minor, patch=patch)
 
 
 def version_number(value):

--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -619,16 +619,21 @@ def only_on(platforms):
     return validator_
 
 
-def only_with_framework(frameworks):
+def only_with_framework(
+    frameworks, suggested_alternate=None, suggested_alternate_doc=None
+):
     """Validate that this option can only be specified on the given frameworks."""
     if not isinstance(frameworks, list):
         frameworks = [frameworks]
 
     def validator_(obj):
         if CORE.target_framework not in frameworks:
-            raise Invalid(
-                f"This feature is only available with frameworks {frameworks}"
-            )
+            err_str = f"This feature is only available with frameworks {frameworks}"
+            if suggested_alternate is not None:
+                err_str += f"\nPlease use '{suggested_alternate}'"
+                if suggested_alternate_doc is not None:
+                    err_str += f": {suggested_alternate_doc}"
+            raise Invalid(err_str)
         return obj
 
     return validator_

--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -309,6 +309,7 @@ class Version:
         """Check if this version is a beta version."""
         return self.extra.startswith("b")
 
+    @property
     def is_dev(self) -> bool:
         """Check if this version is a development version."""
         return self.extra.startswith("dev")

--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -674,7 +674,7 @@ def only_with_framework(
 
     def validator_(obj):
         if CORE.target_framework not in frameworks:
-            err_str = f"This feature is only available with frameworks {', '.join([framework.value for framework in frameworks])}"
+            err_str = f"This feature is only available with framework(s) {', '.join([framework.value for framework in frameworks])}"
             if suggestion := suggestions.get(CORE.target_framework, None):
                 (component, docs_path) = suggestion
                 err_str += f"\nPlease use '{component}'"

--- a/tests/component_tests/mipi_spi/test_init.py
+++ b/tests/component_tests/mipi_spi/test_init.py
@@ -266,7 +266,7 @@ def test_framework_specific_errors(
 
     with pytest.raises(
         cv.Invalid,
-        match=r"This feature is only available with frameworks \['esp-idf'\]",
+        match=r"This feature is only available with frameworks esp-idf",
     ):
         run_schema_validation({"model": "wt32-sc01-plus"})
 

--- a/tests/component_tests/mipi_spi/test_init.py
+++ b/tests/component_tests/mipi_spi/test_init.py
@@ -266,7 +266,7 @@ def test_framework_specific_errors(
 
     with pytest.raises(
         cv.Invalid,
-        match=r"This feature is only available with framework(s) esp-idf",
+        match=r"This feature is only available with framework\(s\) esp-idf",
     ):
         run_schema_validation({"model": "wt32-sc01-plus"})
 

--- a/tests/component_tests/mipi_spi/test_init.py
+++ b/tests/component_tests/mipi_spi/test_init.py
@@ -266,7 +266,7 @@ def test_framework_specific_errors(
 
     with pytest.raises(
         cv.Invalid,
-        match=r"This feature is only available with frameworks esp-idf",
+        match=r"This feature is only available with framework(s) esp-idf",
     ):
         run_schema_validation({"model": "wt32-sc01-plus"})
 


### PR DESCRIPTION
# What does this implement/fix?

Extends the `only_with_framework` validator to permit suggesting an alternate component/platform & related documentation.

I'll do follow-up PRs to sprinkle this in to some components/platforms where appropriate.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
