### PR TITLE
[hitachi_ac424] Add internal cleaning mode support.

### DIFF
--- a/esphome/components/hitachi_ac424/climate.py
+++ b/esphome/components/hitachi_ac424/climate.py
@@ -1,13 +1,21 @@
 import esphome.codegen as cg
 from esphome.components import climate_ir
+import esphome.config_validation as cv
 
 AUTO_LOAD = ["climate_ir"]
 
 hitachi_ac424_ns = cg.esphome_ns.namespace("hitachi_ac424")
 HitachiClimate = hitachi_ac424_ns.class_("HitachiClimate", climate_ir.ClimateIR)
 
-CONFIG_SCHEMA = climate_ir.climate_ir_with_receiver_schema(HitachiClimate)
+CONF_INTERNAL_CLEANING = "internal_cleaning"
+CONFIG_SCHEMA = climate_ir.climate_ir_with_receiver_schema(HitachiClimate).extend(
+    {
+        cv.Optional(CONF_INTERNAL_CLEANING, default=False): cv.boolean,
+    }
+)
 
 
 async def to_code(config):
-    await climate_ir.new_climate_ir(config)
+    var = await climate_ir.new_climate_ir(config)
+
+    cg.add(var.set_internal_cleaning(config[CONF_INTERNAL_CLEANING]))

--- a/esphome/components/hitachi_ac424/hitachi_ac424.cpp
+++ b/esphome/components/hitachi_ac424/hitachi_ac424.cpp
@@ -102,12 +102,18 @@ void HitachiClimate::set_fan_(uint8_t speed) {
   // Set the values
 
   set_bits(&remote_state_[HITACHI_AC424_FAN_BYTE], 4, 4, new_speed);
-  remote_state_[9] = 0x92;
 
-  // When fan is at min/max, additional bytes seem to be set
-  if (new_speed == HITACHI_AC424_FAN_MIN)
+  // Set additional bits
+  remote_state_[9] = 0x92;
+  remote_state_[29] = 0x00;
+  if (new_speed == HITACHI_AC424_FAN_MAX) {
+    remote_state_[9] = 0xA9;
+    remote_state_[29] = 0x30;
+  } else if (this->internal_cleaning_enabled_) {
+    remote_state_[9] = 0xA3;
+  } else if (new_speed == HITACHI_AC424_FAN_MIN) {
     remote_state_[9] = 0x98;
-  remote_state_[29] = 0x01;
+  }
 }
 
 void HitachiClimate::set_swing_v_toggle_(bool on) {
@@ -149,6 +155,10 @@ uint8_t HitachiClimate::get_swing_h_() {
 uint8_t HitachiClimate::get_button_() { return remote_state_[HITACHI_AC424_BUTTON_BYTE]; }
 
 void HitachiClimate::set_button_(uint8_t button) { remote_state_[HITACHI_AC424_BUTTON_BYTE] = button; }
+
+void HitachiClimate::set_internal_cleaning_(bool on) {
+  set_bit(&remote_state_[HITACHI_AC424_CLEAN_BYTE], HITACHI_AC424_CLEAN_OFFSET, on);
+}
 
 void HitachiClimate::transmit_state() {
   switch (this->mode) {
@@ -210,6 +220,8 @@ void HitachiClimate::transmit_state() {
       set_swing_h_(HITACHI_AC424_SWINGH_MIDDLE);
       break;
   }
+
+  set_internal_cleaning_(this->internal_cleaning_enabled_);
 
   // TODO: find change value to set button, now always set to power button
   set_button_(HITACHI_AC424_BUTTON_POWER);
@@ -314,6 +326,14 @@ bool HitachiClimate::parse_swing_(const uint8_t remote_state[]) {
   return true;
 }
 
+bool HitachiClimate::parse_internal_cleaning_(const uint8_t remote_state[]) {
+  bool cleaning = HITACHI_AC424_GETBIT8(remote_state[HITACHI_AC424_CLEAN_BYTE], HITACHI_AC424_CLEAN_OFFSET);
+  ESP_LOGV(TAG, "Internal Cleaning: %02X %s", remote_state[HITACHI_AC424_CLEAN_BYTE], (cleaning ? "true" : "false"));
+  this->internal_cleaning_enabled_ = cleaning;
+
+  return true;
+}
+
 bool HitachiClimate::on_receive(remote_base::RemoteReceiveData data) {
   // Validate header
   if (!data.expect_item(HITACHI_AC424_HDR_MARK, HITACHI_AC424_HDR_SPACE)) {
@@ -351,6 +371,8 @@ bool HitachiClimate::on_receive(remote_base::RemoteReceiveData data) {
   this->parse_fan_(recv_state);
   // parse swingv
   this->parse_swing_(recv_state);
+  // parse internal cleaning
+  this->parse_internal_cleaning_(recv_state);
   this->publish_state();
   for (uint8_t i = 0; i < HITACHI_AC424_STATE_LENGTH; i++)
     remote_state_[i] = recv_state[i];
@@ -364,7 +386,7 @@ void HitachiClimate::dump_state_(const char action[], uint8_t state[]) {
              state[i + 2], state[i + 3], state[i + 4], state[i + 5], state[i + 6], state[i + 7], state[i + 8],
              state[i + 9]);
   }
-  ESP_LOGV(TAG, "%s: %02X %02X %02X", action, state[40], state[41], state[42]);
+  ESP_LOGV(TAG, "%s: %02X %02X %02X", action, state[50], state[51], state[52]);
 }
 
 }  // namespace hitachi_ac424

--- a/esphome/components/hitachi_ac424/hitachi_ac424.h
+++ b/esphome/components/hitachi_ac424/hitachi_ac424.h
@@ -55,6 +55,9 @@ const uint8_t HITACHI_AC424_POWER_BYTE = 27;
 const uint8_t HITACHI_AC424_POWER_ON = 0xF1;
 const uint8_t HITACHI_AC424_POWER_OFF = 0xE1;
 
+const uint8_t HITACHI_AC424_CLEAN_BYTE = 33;
+const uint8_t HITACHI_AC424_CLEAN_OFFSET = 3;     // Mask 0b0000x000
+
 const uint8_t HITACHI_AC424_SWINGH_BYTE = 35;
 const uint8_t HITACHI_AC424_SWINGH_OFFSET = 0;     // Mask 0b00000xxx
 const uint8_t HITACHI_AC424_SWINGH_SIZE = 3;       // Mask 0b00000xxx
@@ -86,12 +89,14 @@ class HitachiClimate : public climate_ir::ClimateIR {
                                climate::CLIMATE_FAN_HIGH},
                               {climate::CLIMATE_SWING_OFF, climate::CLIMATE_SWING_HORIZONTAL}) {}
 
+  void set_internal_cleaning(bool on) { this->internal_cleaning_enabled_ = on; }
  protected:
   uint8_t remote_state_[HITACHI_AC424_STATE_LENGTH]{
       0x01, 0x10, 0x00, 0x40, 0xBF, 0xFF, 0x00, 0xCC, 0x33, 0x92, 0x6D, 0x13, 0xEC, 0x5C, 0xA3, 0x00, 0xFF, 0x00,
       0xFF, 0x00, 0xFF, 0x00, 0xFF, 0x00, 0xFF, 0x53, 0xAC, 0xF1, 0x0E, 0x00, 0xFF, 0x00, 0xFF, 0x80, 0x7F, 0x03,
       0xFC, 0x01, 0xFE, 0x88, 0x77, 0x00, 0xFF, 0x00, 0xFF, 0xFF, 0x00, 0xFF, 0x00, 0xFF, 0x00, 0xFF, 0x00};
   uint8_t previous_temp_{27};
+  bool internal_cleaning_enabled_{false};
   // Transmit via IR the state of this climate controller.
   void transmit_state() override;
   bool get_power_();
@@ -109,12 +114,14 @@ class HitachiClimate : public climate_ir::ClimateIR {
   uint8_t get_swing_h_();
   uint8_t get_button_();
   void set_button_(uint8_t button);
+  void set_internal_cleaning_(bool on);
   // Handle received IR Buffer
   bool on_receive(remote_base::RemoteReceiveData data) override;
   bool parse_mode_(const uint8_t remote_state[]);
   bool parse_temperature_(const uint8_t remote_state[]);
   bool parse_fan_(const uint8_t remote_state[]);
   bool parse_swing_(const uint8_t remote_state[]);
+  bool parse_internal_cleaning_(const uint8_t remote_state[]);
   bool parse_state_frame_(const uint8_t frame[]);
   void dump_state_(const char action[], uint8_t remote_state[]);
 };

--- a/esphome/components/hitachi_ac424/hitachi_ac424.h
+++ b/esphome/components/hitachi_ac424/hitachi_ac424.h
@@ -56,7 +56,7 @@ const uint8_t HITACHI_AC424_POWER_ON = 0xF1;
 const uint8_t HITACHI_AC424_POWER_OFF = 0xE1;
 
 const uint8_t HITACHI_AC424_CLEAN_BYTE = 33;
-const uint8_t HITACHI_AC424_CLEAN_OFFSET = 3;     // Mask 0b0000x000
+const uint8_t HITACHI_AC424_CLEAN_OFFSET = 3;  // Mask 0b0000x000
 
 const uint8_t HITACHI_AC424_SWINGH_BYTE = 35;
 const uint8_t HITACHI_AC424_SWINGH_OFFSET = 0;     // Mask 0b00000xxx
@@ -90,6 +90,7 @@ class HitachiClimate : public climate_ir::ClimateIR {
                               {climate::CLIMATE_SWING_OFF, climate::CLIMATE_SWING_HORIZONTAL}) {}
 
   void set_internal_cleaning(bool on) { this->internal_cleaning_enabled_ = on; }
+
  protected:
   uint8_t remote_state_[HITACHI_AC424_STATE_LENGTH]{
       0x01, 0x10, 0x00, 0x40, 0xBF, 0xFF, 0x00, 0xCC, 0x33, 0x92, 0x6D, 0x13, 0xEC, 0x5C, 0xA3, 0x00, 0xFF, 0x00,


### PR DESCRIPTION
# What does this implement/fix?

This pull request adds internal cleaning mode feature in the hitachi_ac424 component of the IR Remote Climate.
(Tested with the RAS-AJ22L model.)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#5150

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
remote_receiver:
  id: rcvr
  pin:
    number: GPIO4
    inverted: true
    mode:
      input: true
      pullup: true
  tolerance: 25%
  filter: 255us
  receive_symbols: 430

climate:
  - platform: hitachi_ac424
    name: "Hitachi AC"
    receiver_id: rcvr
    internal_cleaning: true

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
