### PR TITLE
[api] Remove unused add_fixed_field template function

### DIFF
--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -225,11 +225,10 @@ void APIConnection::loop() {
   if (this->image_reader_ && this->image_reader_->available() && this->helper_->can_write_without_blocking()) {
     uint32_t to_send = std::min((size_t) MAX_BATCH_PACKET_SIZE, this->image_reader_->available());
     bool done = this->image_reader_->available() == to_send;
-    uint32_t msg_size = 0;
-    ProtoSize::add_fixed_field<4>(msg_size, 1, true);
     // partial message size calculated manually since its a special case
-    // 1 for the data field, varint for the data size, and the data itself
-    msg_size += 1 + ProtoSize::varint(to_send) + to_send;
+    // fixed32 key = 1 (1 byte for field header + 4 bytes for fixed32)
+    // bytes data = 2 (1 byte for field header + varint for data size + data itself)
+    uint32_t msg_size = 1 + 4 + 1 + ProtoSize::varint(to_send) + to_send;
     ProtoSize::add_bool_field(msg_size, 1, done);
 
     auto buffer = this->create_buffer(msg_size);

--- a/esphome/components/api/proto.h
+++ b/esphome/components/api/proto.h
@@ -528,25 +528,6 @@ class ProtoSize {
   }
 
   /**
-   * @brief Calculates and adds the size of a fixed field to the total message size
-   *
-   * Fixed fields always take exactly N bytes (4 for fixed32/float, 8 for fixed64/double).
-   *
-   * @tparam NumBytes The number of bytes for this fixed field (4 or 8)
-   * @param is_nonzero Whether the value is non-zero
-   */
-  template<uint32_t NumBytes>
-  static inline void add_fixed_field(uint32_t &total_size, uint32_t field_id_size, bool is_nonzero) {
-    // Skip calculation if value is zero
-    if (!is_nonzero) {
-      return;  // No need to update total_size
-    }
-
-    // Fixed fields always take exactly NumBytes
-    total_size += field_id_size + NumBytes;
-  }
-
-  /**
    * @brief Calculates and adds the size of a float field to the total message size
    */
   static inline void add_float_field(uint32_t &total_size, uint32_t field_id_size, float value) {


### PR DESCRIPTION
# What does this implement/fix?

This PR completes the removal of the `add_fixed_field` template function that was started in #9487 (c691f01c7f7ec29c978d0937b811232170b6239e). It removes the last usage in the camera streaming code and deletes the now-unused template function from `proto.h`.

The camera streaming code now uses direct size calculation since it's a special case where the message size is manually calculated anyway. This simplifies the code and removes an unnecessary abstraction.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - internal code cleanup only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).