### PR TITLE
[tests] Fix flaky scheduler retry test timing

### DIFF
--- a/tests/integration/fixtures/scheduler_retry_test.yaml
+++ b/tests/integration/fixtures/scheduler_retry_test.yaml
@@ -130,15 +130,15 @@ script:
       - logger.log: "=== Test 5: Empty name retry ==="
       - lambda: |-
           auto *component = id(test_sensor);
-          App.scheduler.set_retry(component, "", 50, 5,
+          App.scheduler.set_retry(component, "", 100, 5,
             [](uint8_t retry_countdown) {
               id(empty_name_retry_counter)++;
               ESP_LOGI("test", "Empty name retry attempt %d", id(empty_name_retry_counter));
               return RetryResult::RETRY;
             });
 
-          // Try to cancel after 75ms
-          App.scheduler.set_timeout(component, "empty_cancel_timer", 75, []() {
+          // Try to cancel after 150ms
+          App.scheduler.set_timeout(component, "empty_cancel_timer", 150, []() {
             bool cancelled = App.scheduler.cancel_retry(id(test_sensor), "");
             ESP_LOGI("test", "Empty name retry cancel result: %s",
                      cancelled ? "true" : "false");


### PR DESCRIPTION
# What does this implement/fix?

This PR fixes a flaky test in the scheduler retry integration test. The test was failing intermittently because the empty name retry test was executing more retry attempts than expected due to timing issues.

The issue was that with a 50ms retry interval and 75ms cancel timeout, the test could squeeze in up to 5 retry attempts before cancellation in slower test environments, but the test was only expecting 1-2 attempts.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes flaky test in CI

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - test-only change

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - This is a test-only change
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

