### PR TITLE
[bluetooth_proxy] Optimize service discovery with in-place construction

### DIFF
--- a/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
@@ -95,8 +95,8 @@ void BluetoothConnection::send_service_for_discovery_() {
 
   api::BluetoothGATTGetServicesResponse resp;
   resp.address = this->address_;
-  resp.services.reserve(1);  // Always one service per response in this implementation
-  api::BluetoothGATTService service_resp;
+  resp.services.emplace_back();
+  auto &service_resp = resp.services.back();
   service_resp.uuid = get_128bit_uuid_vec(service_result.uuid);
   service_resp.handle = service_result.start_handle;
 
@@ -134,7 +134,8 @@ void BluetoothConnection::send_service_for_discovery_() {
       break;
     }
 
-    api::BluetoothGATTCharacteristic characteristic_resp;
+    service_resp.characteristics.emplace_back();
+    auto &characteristic_resp = service_resp.characteristics.back();
     characteristic_resp.uuid = get_128bit_uuid_vec(char_result.uuid);
     characteristic_resp.handle = char_result.char_handle;
     characteristic_resp.properties = char_result.properties;
@@ -173,15 +174,13 @@ void BluetoothConnection::send_service_for_discovery_() {
         break;
       }
 
-      api::BluetoothGATTDescriptor descriptor_resp;
+      characteristic_resp.descriptors.emplace_back();
+      auto &descriptor_resp = characteristic_resp.descriptors.back();
       descriptor_resp.uuid = get_128bit_uuid_vec(desc_result.uuid);
       descriptor_resp.handle = desc_result.handle;
-      characteristic_resp.descriptors.push_back(std::move(descriptor_resp));
       desc_offset++;
     }
-    service_resp.characteristics.push_back(std::move(characteristic_resp));
   }
-  resp.services.push_back(std::move(service_resp));
 
   // Send the message (we already checked api_conn is not null at the beginning)
   api_conn->send_message(resp, api::BluetoothGATTGetServicesResponse::MESSAGE_TYPE);

--- a/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
@@ -13,17 +13,16 @@ namespace bluetooth_proxy {
 
 static const char *const TAG = "bluetooth_proxy.connection";
 
-static void set_128bit_uuid_vec(std::vector<uint64_t> &out, esp_bt_uuid_t uuid_source) {
+static std::vector<uint64_t> get_128bit_uuid_vec(esp_bt_uuid_t uuid_source) {
   esp_bt_uuid_t uuid = espbt::ESPBTUUID::from_uuid(uuid_source).as_128bit().get_uuid();
-  out.reserve(2);
-  out.emplace_back(((uint64_t) uuid.uuid.uuid128[15] << 56) | ((uint64_t) uuid.uuid.uuid128[14] << 48) |
-                   ((uint64_t) uuid.uuid.uuid128[13] << 40) | ((uint64_t) uuid.uuid.uuid128[12] << 32) |
-                   ((uint64_t) uuid.uuid.uuid128[11] << 24) | ((uint64_t) uuid.uuid.uuid128[10] << 16) |
-                   ((uint64_t) uuid.uuid.uuid128[9] << 8) | ((uint64_t) uuid.uuid.uuid128[8]));
-  out.emplace_back(((uint64_t) uuid.uuid.uuid128[7] << 56) | ((uint64_t) uuid.uuid.uuid128[6] << 48) |
-                   ((uint64_t) uuid.uuid.uuid128[5] << 40) | ((uint64_t) uuid.uuid.uuid128[4] << 32) |
-                   ((uint64_t) uuid.uuid.uuid128[3] << 24) | ((uint64_t) uuid.uuid.uuid128[2] << 16) |
-                   ((uint64_t) uuid.uuid.uuid128[1] << 8) | ((uint64_t) uuid.uuid.uuid128[0]));
+  return std::vector<uint64_t>{((uint64_t) uuid.uuid.uuid128[15] << 56) | ((uint64_t) uuid.uuid.uuid128[14] << 48) |
+                                   ((uint64_t) uuid.uuid.uuid128[13] << 40) | ((uint64_t) uuid.uuid.uuid128[12] << 32) |
+                                   ((uint64_t) uuid.uuid.uuid128[11] << 24) | ((uint64_t) uuid.uuid.uuid128[10] << 16) |
+                                   ((uint64_t) uuid.uuid.uuid128[9] << 8) | ((uint64_t) uuid.uuid.uuid128[8]),
+                               ((uint64_t) uuid.uuid.uuid128[7] << 56) | ((uint64_t) uuid.uuid.uuid128[6] << 48) |
+                                   ((uint64_t) uuid.uuid.uuid128[5] << 40) | ((uint64_t) uuid.uuid.uuid128[4] << 32) |
+                                   ((uint64_t) uuid.uuid.uuid128[3] << 24) | ((uint64_t) uuid.uuid.uuid128[2] << 16) |
+                                   ((uint64_t) uuid.uuid.uuid128[1] << 8) | ((uint64_t) uuid.uuid.uuid128[0])};
 }
 
 void BluetoothConnection::dump_config() {
@@ -98,7 +97,7 @@ void BluetoothConnection::send_service_for_discovery_() {
   resp.address = this->address_;
   resp.services.emplace_back();
   auto &service_resp = resp.services.back();
-  set_128bit_uuid_vec(service_resp.uuid, service_result.uuid);
+  service_resp.uuid = get_128bit_uuid_vec(service_result.uuid);
   service_resp.handle = service_result.start_handle;
 
   // Get the number of characteristics directly with one call
@@ -137,7 +136,7 @@ void BluetoothConnection::send_service_for_discovery_() {
 
     service_resp.characteristics.emplace_back();
     auto &characteristic_resp = service_resp.characteristics.back();
-    set_128bit_uuid_vec(characteristic_resp.uuid, char_result.uuid);
+    characteristic_resp.uuid = get_128bit_uuid_vec(char_result.uuid);
     characteristic_resp.handle = char_result.char_handle;
     characteristic_resp.properties = char_result.properties;
     char_offset++;
@@ -177,7 +176,7 @@ void BluetoothConnection::send_service_for_discovery_() {
 
       characteristic_resp.descriptors.emplace_back();
       auto &descriptor_resp = characteristic_resp.descriptors.back();
-      set_128bit_uuid_vec(descriptor_resp.uuid, desc_result.uuid);
+      descriptor_resp.uuid = get_128bit_uuid_vec(desc_result.uuid);
       descriptor_resp.handle = desc_result.handle;
       desc_offset++;
     }

--- a/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
@@ -13,16 +13,17 @@ namespace bluetooth_proxy {
 
 static const char *const TAG = "bluetooth_proxy.connection";
 
-static std::vector<uint64_t> get_128bit_uuid_vec(esp_bt_uuid_t uuid_source) {
+static void set_128bit_uuid_vec(std::vector<uint64_t> &out, esp_bt_uuid_t uuid_source) {
   esp_bt_uuid_t uuid = espbt::ESPBTUUID::from_uuid(uuid_source).as_128bit().get_uuid();
-  return std::vector<uint64_t>{((uint64_t) uuid.uuid.uuid128[15] << 56) | ((uint64_t) uuid.uuid.uuid128[14] << 48) |
-                                   ((uint64_t) uuid.uuid.uuid128[13] << 40) | ((uint64_t) uuid.uuid.uuid128[12] << 32) |
-                                   ((uint64_t) uuid.uuid.uuid128[11] << 24) | ((uint64_t) uuid.uuid.uuid128[10] << 16) |
-                                   ((uint64_t) uuid.uuid.uuid128[9] << 8) | ((uint64_t) uuid.uuid.uuid128[8]),
-                               ((uint64_t) uuid.uuid.uuid128[7] << 56) | ((uint64_t) uuid.uuid.uuid128[6] << 48) |
-                                   ((uint64_t) uuid.uuid.uuid128[5] << 40) | ((uint64_t) uuid.uuid.uuid128[4] << 32) |
-                                   ((uint64_t) uuid.uuid.uuid128[3] << 24) | ((uint64_t) uuid.uuid.uuid128[2] << 16) |
-                                   ((uint64_t) uuid.uuid.uuid128[1] << 8) | ((uint64_t) uuid.uuid.uuid128[0])};
+  out.reserve(2);
+  out.push_back(((uint64_t) uuid.uuid.uuid128[15] << 56) | ((uint64_t) uuid.uuid.uuid128[14] << 48) |
+                ((uint64_t) uuid.uuid.uuid128[13] << 40) | ((uint64_t) uuid.uuid.uuid128[12] << 32) |
+                ((uint64_t) uuid.uuid.uuid128[11] << 24) | ((uint64_t) uuid.uuid.uuid128[10] << 16) |
+                ((uint64_t) uuid.uuid.uuid128[9] << 8) | ((uint64_t) uuid.uuid.uuid128[8]));
+  out.push_back(((uint64_t) uuid.uuid.uuid128[7] << 56) | ((uint64_t) uuid.uuid.uuid128[6] << 48) |
+                ((uint64_t) uuid.uuid.uuid128[5] << 40) | ((uint64_t) uuid.uuid.uuid128[4] << 32) |
+                ((uint64_t) uuid.uuid.uuid128[3] << 24) | ((uint64_t) uuid.uuid.uuid128[2] << 16) |
+                ((uint64_t) uuid.uuid.uuid128[1] << 8) | ((uint64_t) uuid.uuid.uuid128[0]));
 }
 
 void BluetoothConnection::dump_config() {
@@ -97,7 +98,7 @@ void BluetoothConnection::send_service_for_discovery_() {
   resp.address = this->address_;
   resp.services.emplace_back();
   auto &service_resp = resp.services.back();
-  service_resp.uuid = get_128bit_uuid_vec(service_result.uuid);
+  set_128bit_uuid_vec(service_resp.uuid, service_result.uuid);
   service_resp.handle = service_result.start_handle;
 
   // Get the number of characteristics directly with one call
@@ -136,7 +137,7 @@ void BluetoothConnection::send_service_for_discovery_() {
 
     service_resp.characteristics.emplace_back();
     auto &characteristic_resp = service_resp.characteristics.back();
-    characteristic_resp.uuid = get_128bit_uuid_vec(char_result.uuid);
+    set_128bit_uuid_vec(characteristic_resp.uuid, char_result.uuid);
     characteristic_resp.handle = char_result.char_handle;
     characteristic_resp.properties = char_result.properties;
     char_offset++;
@@ -176,7 +177,7 @@ void BluetoothConnection::send_service_for_discovery_() {
 
       characteristic_resp.descriptors.emplace_back();
       auto &descriptor_resp = characteristic_resp.descriptors.back();
-      descriptor_resp.uuid = get_128bit_uuid_vec(desc_result.uuid);
+      set_128bit_uuid_vec(descriptor_resp.uuid, desc_result.uuid);
       descriptor_resp.handle = desc_result.handle;
       desc_offset++;
     }

--- a/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
@@ -16,14 +16,14 @@ static const char *const TAG = "bluetooth_proxy.connection";
 static void set_128bit_uuid_vec(std::vector<uint64_t> &out, esp_bt_uuid_t uuid_source) {
   esp_bt_uuid_t uuid = espbt::ESPBTUUID::from_uuid(uuid_source).as_128bit().get_uuid();
   out.reserve(2);
-  out.push_back(((uint64_t) uuid.uuid.uuid128[15] << 56) | ((uint64_t) uuid.uuid.uuid128[14] << 48) |
-                ((uint64_t) uuid.uuid.uuid128[13] << 40) | ((uint64_t) uuid.uuid.uuid128[12] << 32) |
-                ((uint64_t) uuid.uuid.uuid128[11] << 24) | ((uint64_t) uuid.uuid.uuid128[10] << 16) |
-                ((uint64_t) uuid.uuid.uuid128[9] << 8) | ((uint64_t) uuid.uuid.uuid128[8]));
-  out.push_back(((uint64_t) uuid.uuid.uuid128[7] << 56) | ((uint64_t) uuid.uuid.uuid128[6] << 48) |
-                ((uint64_t) uuid.uuid.uuid128[5] << 40) | ((uint64_t) uuid.uuid.uuid128[4] << 32) |
-                ((uint64_t) uuid.uuid.uuid128[3] << 24) | ((uint64_t) uuid.uuid.uuid128[2] << 16) |
-                ((uint64_t) uuid.uuid.uuid128[1] << 8) | ((uint64_t) uuid.uuid.uuid128[0]));
+  out.emplace_back(((uint64_t) uuid.uuid.uuid128[15] << 56) | ((uint64_t) uuid.uuid.uuid128[14] << 48) |
+                   ((uint64_t) uuid.uuid.uuid128[13] << 40) | ((uint64_t) uuid.uuid.uuid128[12] << 32) |
+                   ((uint64_t) uuid.uuid.uuid128[11] << 24) | ((uint64_t) uuid.uuid.uuid128[10] << 16) |
+                   ((uint64_t) uuid.uuid.uuid128[9] << 8) | ((uint64_t) uuid.uuid.uuid128[8]));
+  out.emplace_back(((uint64_t) uuid.uuid.uuid128[7] << 56) | ((uint64_t) uuid.uuid.uuid128[6] << 48) |
+                   ((uint64_t) uuid.uuid.uuid128[5] << 40) | ((uint64_t) uuid.uuid.uuid128[4] << 32) |
+                   ((uint64_t) uuid.uuid.uuid128[3] << 24) | ((uint64_t) uuid.uuid.uuid128[2] << 16) |
+                   ((uint64_t) uuid.uuid.uuid128[1] << 8) | ((uint64_t) uuid.uuid.uuid128[0]));
 }
 
 void BluetoothConnection::dump_config() {


### PR DESCRIPTION
# What does this implement/fix?

This PR optimizes the `BluetoothConnection::send_service_for_discovery_` method by:
1. Using `emplace_back` for in-place construction instead of `push_back` with `std::move`
2. Removing unnecessary `reserve(1)` call when we always add exactly one service

These changes reduce unnecessary object construction and move operations, improving performance and reducing memory usage during Bluetooth service discovery. This is particularly important as crashes have been observed in this function when memory is constrained.

**Performance Impact**: 176 bytes saved in flash usage.

Note: A follow-up PR will address UUID vector allocations by extending the protobuf `fixed_array_size` option to support repeated fields, which would eliminate heap allocations for UUIDs entirely.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

None

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

None - internal optimization only

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes needed - this is an internal optimization
bluetooth_proxy:
  active: true
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

