### PR TITLE
[nrf52] Add missing CoreModel define for scheduler

### DIFF
--- a/esphome/components/nrf52/__init__.py
+++ b/esphome/components/nrf52/__init__.py
@@ -23,6 +23,7 @@ from esphome.const import (
     KEY_TARGET_FRAMEWORK,
     KEY_TARGET_PLATFORM,
     PLATFORM_NRF52,
+    CoreModel,
 )
 from esphome.core import CORE, EsphomeError, coroutine_with_priority
 from esphome.storage_json import StorageJSON
@@ -108,6 +109,8 @@ async def to_code(config: ConfigType) -> None:
     cg.add_build_flag("-DUSE_NRF52")
     cg.add_define("ESPHOME_BOARD", config[CONF_BOARD])
     cg.add_define("ESPHOME_VARIANT", "NRF52")
+    # nRF52 processors are single-core
+    cg.add_define(CoreModel.SINGLE)
     cg.add_platformio_option(CONF_FRAMEWORK, CORE.data[KEY_CORE][KEY_TARGET_FRAMEWORK])
     cg.add_platformio_option(
         "platform",

--- a/esphome/components/zephyr/__init__.py
+++ b/esphome/components/zephyr/__init__.py
@@ -2,7 +2,7 @@ import os
 from typing import Final, TypedDict
 
 import esphome.codegen as cg
-from esphome.const import CONF_BOARD, CoreModel
+from esphome.const import CONF_BOARD
 from esphome.core import CORE
 from esphome.helpers import copy_file_if_changed, write_file_if_changed
 
@@ -110,9 +110,6 @@ def zephyr_to_code(config):
     cg.add(zephyr_ns.setup_preferences())
     cg.add_build_flag("-DUSE_ZEPHYR")
     cg.set_cpp_standard("gnu++20")
-    # While Zephyr supports multi-core systems, ESPHome currently only supports
-    # nRF52 which is single-core
-    cg.add_define(CoreModel.SINGLE)
     # build is done by west so bypass board checking in platformio
     cg.add_platformio_option("boards_dir", CORE.relative_build_path("boards"))
 

--- a/esphome/components/zephyr/__init__.py
+++ b/esphome/components/zephyr/__init__.py
@@ -2,7 +2,7 @@ import os
 from typing import Final, TypedDict
 
 import esphome.codegen as cg
-from esphome.const import CONF_BOARD
+from esphome.const import CONF_BOARD, CoreModel
 from esphome.core import CORE
 from esphome.helpers import copy_file_if_changed, write_file_if_changed
 
@@ -110,6 +110,9 @@ def zephyr_to_code(config):
     cg.add(zephyr_ns.setup_preferences())
     cg.add_build_flag("-DUSE_ZEPHYR")
     cg.set_cpp_standard("gnu++20")
+    # While Zephyr supports multi-core systems, ESPHome currently only supports
+    # nRF52 which is single-core
+    cg.add_define(CoreModel.SINGLE)
     # build is done by west so bypass board checking in platformio
     cg.add_platformio_option("boards_dir", CORE.relative_build_path("boards"))
 


### PR DESCRIPTION
# What does this implement/fix?

This PR adds the missing `CoreModel` define for the nRF52 platform component. In commit 6e31fb181ee6bbe4c285332c1d31714547eb644c, CoreModel defines were added to all platform components (ESP32, ESP8266, RP2040, LibreTiny, and Host) to properly configure the scheduler's threading model, but the nRF52 platform (which uses Zephyr internally) was missed.

This change adds `CoreModel.SINGLE` to the nRF52 platform since nRF52 processors are single-core.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Related to commit 6e31fb181ee6bbe4c285332c1d31714547eb644c which added CoreModel defines to other platforms

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - No documentation changes needed

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [x] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - this is an internal fix
esphome:
  name: nrf52-device

nrf52:
  board: adafruit_itsybitsy_nrf52840
  bootloader: adafruit_nrf52_sd140_v6
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

Note: Unable to test locally as nRF52/Zephyr builds don't work on macOS.

If user exposed functionality or configuration variables are added/changed:
  - N/A - This is an internal fix with no user-exposed changes