### PR TITLE
[esp32_ble_tracker] Write require feature defines after all clients are registered

### DIFF
--- a/esphome/components/esp32_ble_tracker/__init__.py
+++ b/esphome/components/esp32_ble_tracker/__init__.py
@@ -30,7 +30,7 @@ from esphome.const import (
     CONF_SERVICE_UUID,
     CONF_TRIGGER_ID,
 )
-from esphome.core import CORE
+from esphome.core import CORE, coroutine_with_priority
 from esphome.enum import StrEnum
 from esphome.types import ConfigType
 
@@ -365,12 +365,20 @@ async def to_code(config):
     cg.add_define("USE_OTA_STATE_CALLBACK")  # To be notified when an OTA update starts
     cg.add_define("USE_ESP32_BLE_CLIENT")
 
-    # Add feature-specific defines based on what's needed
-    if BLEFeatures.ESP_BT_DEVICE in _required_features:
-        cg.add_define("USE_ESP32_BLE_DEVICE")
+    CORE.add_job(_add_ble_features)
 
     if config.get(CONF_SOFTWARE_COEXISTENCE):
         cg.add_define("USE_ESP32_BLE_SOFTWARE_COEXISTENCE")
+
+
+# This needs to be run as a job with very low priority so that all components have
+# chance to call register_ble_tracker and register_client before the list is checked
+# and added to the global defines list.
+@coroutine_with_priority(-1000)
+async def _add_ble_features():
+    # Add feature-specific defines based on what's needed
+    if BLEFeatures.ESP_BT_DEVICE in _required_features:
+        cg.add_define("USE_ESP32_BLE_DEVICE")
 
 
 ESP32_BLE_START_SCAN_ACTION_SCHEMA = cv.Schema(


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

`to_code` for the ble tracker waits only for `esp32_ble` to be registered, ble_client, waits for `esp32_ble_tracker` to be registered, meaning given the right conditions, the require_features set might not have been updated before the to_code function of ble_tracker was finished. 

Running the define additions in another job with priority -1000 solves this as all `to_code` jobs run at positive priorities.


## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
