### PR TITLE
[neopixelbus] Add suggested alternate when using IDF

### DIFF
--- a/esphome/components/neopixelbus/light.py
+++ b/esphome/components/neopixelbus/light.py
@@ -164,7 +164,7 @@ def _validate_method(value):
 
 CONFIG_SCHEMA = cv.All(
     cv.only_with_framework(
-        frameworks="arduino",
+        frameworks=Framework.ARDUINO,
         suggestions={
             Framework.ESP_IDF: (
                 "esp32_rmt_led_strip",

--- a/esphome/components/neopixelbus/light.py
+++ b/esphome/components/neopixelbus/light.py
@@ -15,6 +15,7 @@ from esphome.const import (
     CONF_PIN,
     CONF_TYPE,
     CONF_VARIANT,
+    Framework,
 )
 from esphome.core import CORE
 
@@ -162,7 +163,15 @@ def _validate_method(value):
 
 
 CONFIG_SCHEMA = cv.All(
-    cv.only_with_arduino,
+    cv.only_with_framework(
+        frameworks="arduino",
+        suggestions={
+            Framework.ESP_IDF: (
+                "esp32_rmt_led_strip",
+                "light/esp32_rmt_led_strip",
+            )
+        },
+    ),
     cv.require_framework_version(
         esp8266_arduino=cv.Version(2, 4, 0),
         esp32_arduino=cv.Version(0, 0, 0),


### PR DESCRIPTION
# What does this implement/fix?

Builds on #9757 to suggest using `esp32_rmt_led_strip` when attempting to build with IDF

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
