### PR TITLE
[fastled_clockless, fastled_spi] Add suggested alternate when using IDF

### DIFF
--- a/esphome/components/fastled_clockless/light.py
+++ b/esphome/components/fastled_clockless/light.py
@@ -2,7 +2,13 @@ from esphome import pins
 import esphome.codegen as cg
 from esphome.components import fastled_base
 import esphome.config_validation as cv
-from esphome.const import CONF_CHIPSET, CONF_NUM_LEDS, CONF_PIN, CONF_RGB_ORDER
+from esphome.const import (
+    CONF_CHIPSET,
+    CONF_NUM_LEDS,
+    CONF_PIN,
+    CONF_RGB_ORDER,
+    Framework,
+)
 
 AUTO_LOAD = ["fastled_base"]
 
@@ -48,13 +54,22 @@ CONFIG_SCHEMA = cv.All(
             cv.Required(CONF_PIN): pins.internal_gpio_output_pin_number,
         }
     ),
-    _validate,
+    cv.only_with_framework(
+        frameworks=Framework.ARDUINO,
+        suggestions={
+            Framework.ESP_IDF: (
+                "esp32_rmt_led_strip",
+                "light/esp32_rmt_led_strip",
+            )
+        },
+    ),
     cv.require_framework_version(
         esp8266_arduino=cv.Version(2, 7, 4),
         esp32_arduino=cv.Version(99, 0, 0),
         max_version=True,
         extra_message="Please see note on documentation for FastLED",
     ),
+    _validate,
 )
 
 

--- a/esphome/components/fastled_spi/light.py
+++ b/esphome/components/fastled_spi/light.py
@@ -9,6 +9,7 @@ from esphome.const import (
     CONF_DATA_RATE,
     CONF_NUM_LEDS,
     CONF_RGB_ORDER,
+    Framework,
 )
 
 AUTO_LOAD = ["fastled_base"]
@@ -32,6 +33,15 @@ CONFIG_SCHEMA = cv.All(
             cv.Required(CONF_CLOCK_PIN): pins.internal_gpio_output_pin_number,
             cv.Optional(CONF_DATA_RATE): cv.frequency,
         }
+    ),
+    cv.only_with_framework(
+        frameworks=Framework.ARDUINO,
+        suggestions={
+            Framework.ESP_IDF: (
+                "spi_led_strip",
+                "light/spi_led_strip",
+            )
+        },
     ),
     cv.require_framework_version(
         esp8266_arduino=cv.Version(2, 7, 4),


### PR DESCRIPTION
# What does this implement/fix?

Builds on #9757 to suggest using `esp32_rmt_led_strip` or `spi_led_strip` when attempting to build with IDF

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
