### PR TITLE
[bme680_bsec] Add suggested alternate when using IDF

### DIFF
--- a/esphome/components/bme680_bsec/__init__.py
+++ b/esphome/components/bme680_bsec/__init__.py
@@ -1,7 +1,7 @@
 import esphome.codegen as cg
 from esphome.components import esp32, i2c
 import esphome.config_validation as cv
-from esphome.const import CONF_ID, CONF_SAMPLE_RATE, CONF_TEMPERATURE_OFFSET
+from esphome.const import CONF_ID, CONF_SAMPLE_RATE, CONF_TEMPERATURE_OFFSET, Framework
 
 CODEOWNERS = ["@trvrnrth"]
 DEPENDENCIES = ["i2c"]
@@ -56,7 +56,15 @@ CONFIG_SCHEMA = cv.All(
             ): cv.positive_time_period_minutes,
         }
     ).extend(i2c.i2c_device_schema(0x76)),
-    cv.only_with_arduino,
+    cv.only_with_framework(
+        frameworks=Framework.ARDUINO,
+        suggestions={
+            Framework.ESP_IDF: (
+                "bme68x_bsec2_i2c",
+                "sensor/bme68x_bsec2",
+            )
+        },
+    ),
     cv.Any(
         cv.only_on_esp8266,
         cv.All(


### PR DESCRIPTION
# What does this implement/fix?

Builds on #9757 to suggest using `bme68x_bsec2_i2c` when attempting to build with IDF

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
