### PR TITLE
[core] Process pending loop enables during setup blocking phase

### DIFF
--- a/esphome/core/application.cpp
+++ b/esphome/core/application.cpp
@@ -71,8 +71,11 @@ void Application::setup() {
 
     do {
       uint8_t new_app_state = STATUS_LED_WARNING;
-      this->scheduler.call(millis());
-      this->feed_wdt();
+      uint32_t now = millis();
+
+      // Process pending loop enables to handle GPIO interrupts during setup
+      this->before_loop_tasks_(now);
+
       for (uint32_t j = 0; j <= i; j++) {
         // Update loop_component_start_time_ right before calling each component
         this->loop_component_start_time_ = millis();
@@ -81,6 +84,8 @@ void Application::setup() {
         this->app_state_ |= new_app_state;
         this->feed_wdt();
       }
+
+      this->after_loop_tasks_();
       this->app_state_ = new_app_state;
       yield();
     } while (!component->can_proceed());
@@ -100,27 +105,7 @@ void Application::loop() {
   // Get the initial loop time at the start
   uint32_t last_op_end_time = millis();
 
-  this->scheduler.call(last_op_end_time);
-
-  // Feed WDT with time
-  this->feed_wdt(last_op_end_time);
-
-  // Process any pending enable_loop requests from ISRs
-  // This must be done before marking in_loop_ = true to avoid race conditions
-  if (this->has_pending_enable_loop_requests_) {
-    // Clear flag BEFORE processing to avoid race condition
-    // If ISR sets it during processing, we'll catch it next loop iteration
-    // This is safe because:
-    // 1. Each component has its own pending_enable_loop_ flag that we check
-    // 2. If we can't process a component (wrong state), enable_pending_loops_()
-    //    will set this flag back to true
-    // 3. Any new ISR requests during processing will set the flag again
-    this->has_pending_enable_loop_requests_ = false;
-    this->enable_pending_loops_();
-  }
-
-  // Mark that we're in the loop for safe reentrant modifications
-  this->in_loop_ = true;
+  this->before_loop_tasks_(last_op_end_time);
 
   for (this->current_loop_index_ = 0; this->current_loop_index_ < this->looping_components_active_end_;
        this->current_loop_index_++) {
@@ -141,7 +126,7 @@ void Application::loop() {
     this->feed_wdt(last_op_end_time);
   }
 
-  this->in_loop_ = false;
+  this->after_loop_tasks_();
   this->app_state_ = new_app_state;
 
 #ifdef USE_RUNTIME_STATS
@@ -409,6 +394,36 @@ void Application::enable_pending_loops_() {
   if (has_pending) {
     this->has_pending_enable_loop_requests_ = true;
   }
+}
+
+void Application::before_loop_tasks_(uint32_t loop_start_time) {
+  // Process scheduled tasks
+  this->scheduler.call(loop_start_time);
+
+  // Feed the watchdog timer
+  this->feed_wdt(loop_start_time);
+
+  // Process any pending enable_loop requests from ISRs
+  // This must be done before marking in_loop_ = true to avoid race conditions
+  if (this->has_pending_enable_loop_requests_) {
+    // Clear flag BEFORE processing to avoid race condition
+    // If ISR sets it during processing, we'll catch it next loop iteration
+    // This is safe because:
+    // 1. Each component has its own pending_enable_loop_ flag that we check
+    // 2. If we can't process a component (wrong state), enable_pending_loops_()
+    //    will set this flag back to true
+    // 3. Any new ISR requests during processing will set the flag again
+    this->has_pending_enable_loop_requests_ = false;
+    this->enable_pending_loops_();
+  }
+
+  // Mark that we're in the loop for safe reentrant modifications
+  this->in_loop_ = true;
+}
+
+void Application::after_loop_tasks_() {
+  // Clear the in_loop_ flag to indicate we're done processing components
+  this->in_loop_ = false;
 }
 
 #ifdef USE_SOCKET_SELECT_SUPPORT

--- a/esphome/core/application.h
+++ b/esphome/core/application.h
@@ -512,6 +512,8 @@ class Application {
   void enable_component_loop_(Component *component);
   void enable_pending_loops_();
   void activate_looping_component_(uint16_t index);
+  void before_loop_tasks_(uint32_t loop_start_time);
+  void after_loop_tasks_();
 
   void feed_wdt_arch_();
 


### PR DESCRIPTION
Note: there will be a conflict with the scheduler changes in cherry-pick but it should just be taking out the arg to .call() 

# What does this implement/fix?

This PR fixes a core issue where pending loop enable requests (from ISRs or threads) are not processed during the setup phase blocking loop. The symptom reported in #9786 was that GPIO binary sensor events (button presses) were not firing during WiFi connection.

When a component's `can_proceed()` returns false during setup (e.g., WiFi waiting for connection), the application enters a blocking loop. During this time, if any component requests to re-enable its loop from an ISR or thread context, these pending requests are not processed until the blocking component allows setup to proceed. This affected GPIO binary sensors because they use interrupts that request loop re-enabling when triggered.

This fix ensures that `enable_pending_loops_()` is called during the setup blocking loop, allowing components that have been re-enabled from ISR/thread contexts to resume operation immediately, rather than waiting for the blocking component.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/9786

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal implementation detail, no user-facing changes)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# This example shows the reported symptom: GPIO binary sensor events not firing during WiFi setup
# The core fix ensures any component re-enabled from ISR/thread works during setup blocking

esphome:
  name: test-device

wifi:
  ssid: "MyNetwork"
  password: "MyPassword"

binary_sensor:
  - platform: gpio
    pin: GPIO0
    name: "Button"
    on_press:
      - logger.log: "Button pressed - now works even during WiFi connection!"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

## Technical Details

The fix refactors loop task handling into helper methods that are called in both the main loop and setup blocking loop:
- `before_loop_tasks_()`: Handles scheduler, watchdog, and **processes pending loop enable requests**
- `after_loop_tasks_()`: Manages the in_loop_ flag

This ensures consistent behavior whether the application is in normal operation or waiting for a component during setup. Any component that uses `enable_loop_soon_any_context()` from ISR or thread context will now have its loop re-enabled promptly, even during the setup phase.