### PR TITLE
[http_request] set correct duration_ms for failed requests

### DIFF
--- a/esphome/components/http_request/http_request_idf.cpp
+++ b/esphome/components/http_request/http_request_idf.cpp
@@ -157,8 +157,8 @@ std::shared_ptr<HttpContainer> HttpRequestIDF::perform(std::string url, std::str
   container->status_code = esp_http_client_get_status_code(client);
   container->feed_wdt();
   container->set_response_headers(user_data.response_headers);
+  container->duration_ms = millis() - start;
   if (is_success(container->status_code)) {
-    container->duration_ms = millis() - start;
     return container;
   }
 
@@ -191,8 +191,8 @@ std::shared_ptr<HttpContainer> HttpRequestIDF::perform(std::string url, std::str
       container->feed_wdt();
       container->status_code = esp_http_client_get_status_code(client);
       container->feed_wdt();
+      container->duration_ms = millis() - start;
       if (is_success(container->status_code)) {
-        container->duration_ms = millis() - start;
         return container;
       }
 


### PR DESCRIPTION
The `duration_ms` field is currently set only for successful requests, leaving it with uninitialized garbage values for failed requests. This change ensures that `duration_ms` is properly set for failed requests.

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
