### PR TITLE
[api] Implement zero-copy string optimization for outgoing protobuf messages

### DIFF
--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -1019,13 +1019,13 @@ uint16_t APIConnection::try_send_media_player_info(EntityBase *entity, APIConnec
   auto traits = media_player->get_traits();
   msg.supports_pause = traits.get_supports_pause();
   for (auto &supported_format : traits.get_supported_formats()) {
-    MediaPlayerSupportedFormat media_format;
-    media_format.format = supported_format.format;
+    msg.supported_formats.emplace_back();
+    auto &media_format = msg.supported_formats.back();
+    media_format.set_format(StringRef(supported_format.format));
     media_format.sample_rate = supported_format.sample_rate;
     media_format.num_channels = supported_format.num_channels;
     media_format.purpose = static_cast<enums::MediaPlayerFormatPurpose>(supported_format.purpose);
     media_format.sample_bytes = supported_format.sample_bytes;
-    msg.supported_formats.push_back(media_format);
   }
   return fill_and_encode_entity_info(media_player, msg, ListEntitiesMediaPlayerResponse::MESSAGE_TYPE, conn,
                                      remaining_size, is_single);

--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -260,14 +260,14 @@ void APIConnection::loop() {
   }
 }
 
-DisconnectResponse APIConnection::disconnect(const DisconnectRequest &msg) {
+bool APIConnection::send_disconnect_response(const DisconnectRequest &msg) {
   // remote initiated disconnect_client
   // don't close yet, we still need to send the disconnect response
   // close will happen on next loop
   ESP_LOGD(TAG, "%s disconnected", this->get_client_combined_info().c_str());
   this->flags_.next_close = true;
   DisconnectResponse resp;
-  return resp;
+  return this->send_message(resp, DisconnectResponse::MESSAGE_TYPE);
 }
 void APIConnection::on_disconnect_response(const DisconnectResponse &value) {
   this->helper_->close();
@@ -1086,6 +1086,12 @@ void APIConnection::on_get_time_response(const GetTimeResponse &value) {
 }
 #endif
 
+bool APIConnection::send_get_time_response(const GetTimeRequest &msg) {
+  GetTimeResponse resp;
+  resp.epoch_seconds = ::time(nullptr);
+  return this->send_message(resp, GetTimeResponse::MESSAGE_TYPE);
+}
+
 #ifdef USE_BLUETOOTH_PROXY
 void APIConnection::subscribe_bluetooth_le_advertisements(const SubscribeBluetoothLEAdvertisementsRequest &msg) {
   bluetooth_proxy::global_bluetooth_proxy->subscribe_api_connection(this, msg.flags);
@@ -1116,12 +1122,12 @@ void APIConnection::bluetooth_gatt_notify(const BluetoothGATTNotifyRequest &msg)
   bluetooth_proxy::global_bluetooth_proxy->bluetooth_gatt_notify(msg);
 }
 
-BluetoothConnectionsFreeResponse APIConnection::subscribe_bluetooth_connections_free(
+bool APIConnection::send_subscribe_bluetooth_connections_free_response(
     const SubscribeBluetoothConnectionsFreeRequest &msg) {
   BluetoothConnectionsFreeResponse resp;
   resp.free = bluetooth_proxy::global_bluetooth_proxy->get_bluetooth_connections_free();
   resp.limit = bluetooth_proxy::global_bluetooth_proxy->get_bluetooth_connections_limit();
-  return resp;
+  return this->send_message(resp, BluetoothConnectionsFreeResponse::MESSAGE_TYPE);
 }
 
 void APIConnection::bluetooth_scanner_set_mode(const BluetoothScannerSetModeRequest &msg) {
@@ -1182,11 +1188,10 @@ void APIConnection::on_voice_assistant_announce_request(const VoiceAssistantAnno
   }
 }
 
-VoiceAssistantConfigurationResponse APIConnection::voice_assistant_get_configuration(
-    const VoiceAssistantConfigurationRequest &msg) {
+bool APIConnection::send_voice_assistant_get_configuration_response(const VoiceAssistantConfigurationRequest &msg) {
   VoiceAssistantConfigurationResponse resp;
   if (!this->check_voice_assistant_api_connection_()) {
-    return resp;
+    return this->send_message(resp, VoiceAssistantConfigurationResponse::MESSAGE_TYPE);
   }
 
   auto &config = voice_assistant::global_voice_assistant->get_configuration();
@@ -1203,7 +1208,7 @@ VoiceAssistantConfigurationResponse APIConnection::voice_assistant_get_configura
     resp.active_wake_words.push_back(wake_word_id);
   }
   resp.max_active_wake_words = config.max_active_wake_words;
-  return resp;
+  return this->send_message(resp, VoiceAssistantConfigurationResponse::MESSAGE_TYPE);
 }
 
 void APIConnection::voice_assistant_set_configuration(const VoiceAssistantSetConfiguration &msg) {
@@ -1369,7 +1374,8 @@ void APIConnection::complete_authentication_() {
 #endif
 }
 
-HelloResponse APIConnection::hello(const HelloRequest &msg) {
+bool APIConnection::send_hello_response(const HelloRequest &msg) {
+  // Process the request first
   this->client_info_.name = msg.client_info;
   this->client_info_.peername = this->helper_->getpeername();
   this->client_api_version_major_ = msg.api_version_major;
@@ -1380,7 +1386,7 @@ HelloResponse APIConnection::hello(const HelloRequest &msg) {
   HelloResponse resp;
   resp.api_version_major = 1;
   resp.api_version_minor = 10;
-  // Temporary string needed to concatenate app name with version string
+  // Temporary string for concatenation - will be valid during send_message call
   std::string server_info = App.get_name() + " (esphome v" ESPHOME_VERSION ")";
   resp.set_server_info(StringRef(server_info));
   resp.set_name(StringRef(App.get_name()));
@@ -1393,9 +1399,9 @@ HelloResponse APIConnection::hello(const HelloRequest &msg) {
   this->complete_authentication_();
 #endif
 
-  return resp;
+  return this->send_message(resp, HelloResponse::MESSAGE_TYPE);
 }
-ConnectResponse APIConnection::connect(const ConnectRequest &msg) {
+bool APIConnection::send_connect_response(const ConnectRequest &msg) {
   bool correct = true;
 #ifdef USE_API_PASSWORD
   correct = this->parent_->check_password(msg.password);
@@ -1407,9 +1413,15 @@ ConnectResponse APIConnection::connect(const ConnectRequest &msg) {
   if (correct) {
     this->complete_authentication_();
   }
-  return resp;
+  return this->send_message(resp, ConnectResponse::MESSAGE_TYPE);
 }
-DeviceInfoResponse APIConnection::device_info(const DeviceInfoRequest &msg) {
+
+bool APIConnection::send_ping_response(const PingRequest &msg) {
+  PingResponse resp;
+  return this->send_message(resp, PingResponse::MESSAGE_TYPE);
+}
+
+bool APIConnection::send_device_info_response(const DeviceInfoRequest &msg) {
   DeviceInfoResponse resp{};
 #ifdef USE_API_PASSWORD
   resp.uses_password = true;
@@ -1419,9 +1431,9 @@ DeviceInfoResponse APIConnection::device_info(const DeviceInfoRequest &msg) {
 #ifdef USE_AREAS
   resp.set_suggested_area(StringRef(App.get_area()));
 #endif
-  // Temporary string needed because get_mac_address_pretty() formats the MAC on-the-fly
-  std::string mac = get_mac_address_pretty();
-  resp.set_mac_address(StringRef(mac));
+  // mac_address must store temporary string - will be valid during send_message call
+  std::string mac_address = get_mac_address_pretty();
+  resp.set_mac_address(StringRef(mac_address));
   resp.set_esphome_version(StringRef(ESPHOME_VERSION));
   resp.set_compilation_time(StringRef(App.get_compilation_time()));
 #if defined(USE_ESP8266) || defined(USE_ESP32)
@@ -1450,9 +1462,9 @@ DeviceInfoResponse APIConnection::device_info(const DeviceInfoRequest &msg) {
 #endif
 #ifdef USE_BLUETOOTH_PROXY
   resp.bluetooth_proxy_feature_flags = bluetooth_proxy::global_bluetooth_proxy->get_feature_flags();
-  // Temporary string needed because get_bluetooth_mac_address_pretty() formats the MAC on-the-fly
-  std::string bt_mac = bluetooth_proxy::global_bluetooth_proxy->get_bluetooth_mac_address_pretty();
-  resp.set_bluetooth_mac_address(StringRef(bt_mac));
+  // bt_mac must store temporary string - will be valid during send_message call
+  std::string bluetooth_mac = bluetooth_proxy::global_bluetooth_proxy->get_bluetooth_mac_address_pretty();
+  resp.set_bluetooth_mac_address(StringRef(bluetooth_mac));
 #endif
 #ifdef USE_VOICE_ASSISTANT
   resp.voice_assistant_feature_flags = voice_assistant::global_voice_assistant->get_feature_flags();
@@ -1465,6 +1477,7 @@ DeviceInfoResponse APIConnection::device_info(const DeviceInfoRequest &msg) {
     resp.devices.emplace_back();
     auto &device_info = resp.devices.back();
     device_info.device_id = device->get_device_id();
+    // device->get_name() returns a reference to the device's name string
     device_info.set_name(StringRef(device->get_name()));
     device_info.area_id = device->get_area_id();
   }
@@ -1474,11 +1487,14 @@ DeviceInfoResponse APIConnection::device_info(const DeviceInfoRequest &msg) {
     resp.areas.emplace_back();
     auto &area_info = resp.areas.back();
     area_info.area_id = area->get_area_id();
+    // area->get_name() returns a reference to the area's name string
     area_info.set_name(StringRef(area->get_name()));
   }
 #endif
-  return resp;
+
+  return this->send_message(resp, DeviceInfoResponse::MESSAGE_TYPE);
 }
+
 void APIConnection::on_home_assistant_state_response(const HomeAssistantStateResponse &msg) {
   for (auto &it : this->parent_->get_state_subs()) {
     if (it.entity_id == msg.entity_id && it.attribute.value() == msg.attribute) {
@@ -1500,23 +1516,21 @@ void APIConnection::execute_service(const ExecuteServiceRequest &msg) {
 }
 #endif
 #ifdef USE_API_NOISE
-NoiseEncryptionSetKeyResponse APIConnection::noise_encryption_set_key(const NoiseEncryptionSetKeyRequest &msg) {
+bool APIConnection::send_noise_encryption_set_key_response(const NoiseEncryptionSetKeyRequest &msg) {
   psk_t psk{};
   NoiseEncryptionSetKeyResponse resp;
   if (base64_decode(msg.key, psk.data(), msg.key.size()) != psk.size()) {
     ESP_LOGW(TAG, "Invalid encryption key length");
     resp.success = false;
-    return resp;
+    return this->send_message(resp, NoiseEncryptionSetKeyResponse::MESSAGE_TYPE);
   }
-
   if (!this->parent_->save_noise_psk(psk, true)) {
     ESP_LOGW(TAG, "Failed to save encryption key");
     resp.success = false;
-    return resp;
+    return this->send_message(resp, NoiseEncryptionSetKeyResponse::MESSAGE_TYPE);
   }
-
   resp.success = true;
-  return resp;
+  return this->send_message(resp, NoiseEncryptionSetKeyResponse::MESSAGE_TYPE);
 }
 #endif
 void APIConnection::subscribe_home_assistant_states(const SubscribeHomeAssistantStatesRequest &msg) {

--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -248,8 +248,8 @@ void APIConnection::loop() {
     if (state_subs_at_ < static_cast<int>(subs.size())) {
       auto &it = subs[state_subs_at_];
       SubscribeHomeAssistantStateResponse resp;
-      resp.set_entity_id(it.entity_id.c_str(), it.entity_id.length());
-      resp.set_attribute(it.attribute.value().c_str(), it.attribute.value().length());
+      resp.set_entity_id(StringRef(it.entity_id));
+      resp.set_attribute(StringRef(it.attribute.value()));
       resp.once = it.once;
       if (this->send_message(resp, SubscribeHomeAssistantStateResponse::MESSAGE_TYPE)) {
         state_subs_at_++;
@@ -344,8 +344,7 @@ uint16_t APIConnection::try_send_binary_sensor_info(EntityBase *entity, APIConne
                                                     bool is_single) {
   auto *binary_sensor = static_cast<binary_sensor::BinarySensor *>(entity);
   ListEntitiesBinarySensorResponse msg;
-  const std::string &device_class = binary_sensor->get_device_class();
-  msg.set_device_class(device_class.c_str(), device_class.length());
+  msg.set_device_class(StringRef(binary_sensor->get_device_class()));
   msg.is_status_binary_sensor = binary_sensor->is_status_binary_sensor();
   return fill_and_encode_entity_info(binary_sensor, msg, ListEntitiesBinarySensorResponse::MESSAGE_TYPE, conn,
                                      remaining_size, is_single);
@@ -377,8 +376,7 @@ uint16_t APIConnection::try_send_cover_info(EntityBase *entity, APIConnection *c
   msg.supports_position = traits.get_supports_position();
   msg.supports_tilt = traits.get_supports_tilt();
   msg.supports_stop = traits.get_supports_stop();
-  const std::string &device_class = cover->get_device_class();
-  msg.set_device_class(device_class.c_str(), device_class.length());
+  msg.set_device_class(StringRef(cover->get_device_class()));
   return fill_and_encode_entity_info(cover, msg, ListEntitiesCoverResponse::MESSAGE_TYPE, conn, remaining_size,
                                      is_single);
 }
@@ -413,7 +411,7 @@ uint16_t APIConnection::try_send_fan_state(EntityBase *entity, APIConnection *co
   if (traits.supports_direction())
     msg.direction = static_cast<enums::FanDirection>(fan->direction);
   if (traits.supports_preset_modes())
-    msg.set_preset_mode(fan->preset_mode.c_str(), fan->preset_mode.length());
+    msg.set_preset_mode(StringRef(fan->preset_mode));
   return fill_and_encode_entity_state(fan, msg, FanStateResponse::MESSAGE_TYPE, conn, remaining_size, is_single);
 }
 uint16_t APIConnection::try_send_fan_info(EntityBase *entity, APIConnection *conn, uint32_t remaining_size,
@@ -471,8 +469,7 @@ uint16_t APIConnection::try_send_light_state(EntityBase *entity, APIConnection *
   resp.cold_white = values.get_cold_white();
   resp.warm_white = values.get_warm_white();
   if (light->supports_effects()) {
-    const std::string &effect_name = light->get_effect_name();
-    resp.set_effect(effect_name.c_str(), effect_name.length());
+    resp.set_effect(StringRef(light->get_effect_name()));
   }
   return fill_and_encode_entity_state(light, resp, LightStateResponse::MESSAGE_TYPE, conn, remaining_size, is_single);
 }
@@ -549,12 +546,10 @@ uint16_t APIConnection::try_send_sensor_info(EntityBase *entity, APIConnection *
                                              bool is_single) {
   auto *sensor = static_cast<sensor::Sensor *>(entity);
   ListEntitiesSensorResponse msg;
-  const std::string &unit = sensor->get_unit_of_measurement();
-  msg.set_unit_of_measurement(unit.c_str(), unit.length());
+  msg.set_unit_of_measurement(StringRef(sensor->get_unit_of_measurement()));
   msg.accuracy_decimals = sensor->get_accuracy_decimals();
   msg.force_update = sensor->get_force_update();
-  const std::string &device_class = sensor->get_device_class();
-  msg.set_device_class(device_class.c_str(), device_class.length());
+  msg.set_device_class(StringRef(sensor->get_device_class()));
   msg.state_class = static_cast<enums::SensorStateClass>(sensor->get_state_class());
   return fill_and_encode_entity_info(sensor, msg, ListEntitiesSensorResponse::MESSAGE_TYPE, conn, remaining_size,
                                      is_single);
@@ -581,8 +576,7 @@ uint16_t APIConnection::try_send_switch_info(EntityBase *entity, APIConnection *
   auto *a_switch = static_cast<switch_::Switch *>(entity);
   ListEntitiesSwitchResponse msg;
   msg.assumed_state = a_switch->assumed_state();
-  const std::string &device_class = a_switch->get_device_class();
-  msg.set_device_class(device_class.c_str(), device_class.length());
+  msg.set_device_class(StringRef(a_switch->get_device_class()));
   return fill_and_encode_entity_info(a_switch, msg, ListEntitiesSwitchResponse::MESSAGE_TYPE, conn, remaining_size,
                                      is_single);
 }
@@ -607,7 +601,7 @@ uint16_t APIConnection::try_send_text_sensor_state(EntityBase *entity, APIConnec
                                                    bool is_single) {
   auto *text_sensor = static_cast<text_sensor::TextSensor *>(entity);
   TextSensorStateResponse resp;
-  resp.set_state(text_sensor->state.c_str(), text_sensor->state.length());
+  resp.set_state(StringRef(text_sensor->state));
   resp.missing_state = !text_sensor->has_state();
   return fill_and_encode_entity_state(text_sensor, resp, TextSensorStateResponse::MESSAGE_TYPE, conn, remaining_size,
                                       is_single);
@@ -616,8 +610,7 @@ uint16_t APIConnection::try_send_text_sensor_info(EntityBase *entity, APIConnect
                                                   bool is_single) {
   auto *text_sensor = static_cast<text_sensor::TextSensor *>(entity);
   ListEntitiesTextSensorResponse msg;
-  const std::string &device_class = text_sensor->get_device_class();
-  msg.set_device_class(device_class.c_str(), device_class.length());
+  msg.set_device_class(StringRef(text_sensor->get_device_class()));
   return fill_and_encode_entity_info(text_sensor, msg, ListEntitiesTextSensorResponse::MESSAGE_TYPE, conn,
                                      remaining_size, is_single);
 }
@@ -646,15 +639,13 @@ uint16_t APIConnection::try_send_climate_state(EntityBase *entity, APIConnection
   if (traits.get_supports_fan_modes() && climate->fan_mode.has_value())
     resp.fan_mode = static_cast<enums::ClimateFanMode>(climate->fan_mode.value());
   if (!traits.get_supported_custom_fan_modes().empty() && climate->custom_fan_mode.has_value()) {
-    const std::string &custom_fan = climate->custom_fan_mode.value();
-    resp.set_custom_fan_mode(custom_fan.c_str(), custom_fan.length());
+    resp.set_custom_fan_mode(StringRef(climate->custom_fan_mode.value()));
   }
   if (traits.get_supports_presets() && climate->preset.has_value()) {
     resp.preset = static_cast<enums::ClimatePreset>(climate->preset.value());
   }
   if (!traits.get_supported_custom_presets().empty() && climate->custom_preset.has_value()) {
-    const std::string &custom_preset = climate->custom_preset.value();
-    resp.set_custom_preset(custom_preset.c_str(), custom_preset.length());
+    resp.set_custom_preset(StringRef(climate->custom_preset.value()));
   }
   if (traits.get_supports_swing_modes())
     resp.swing_mode = static_cast<enums::ClimateSwingMode>(climate->swing_mode);
@@ -741,11 +732,9 @@ uint16_t APIConnection::try_send_number_info(EntityBase *entity, APIConnection *
                                              bool is_single) {
   auto *number = static_cast<number::Number *>(entity);
   ListEntitiesNumberResponse msg;
-  const std::string &unit = number->traits.get_unit_of_measurement();
-  msg.set_unit_of_measurement(unit.c_str(), unit.length());
+  msg.set_unit_of_measurement(StringRef(number->traits.get_unit_of_measurement()));
   msg.mode = static_cast<enums::NumberMode>(number->traits.get_mode());
-  const std::string &device_class = number->traits.get_device_class();
-  msg.set_device_class(device_class.c_str(), device_class.length());
+  msg.set_device_class(StringRef(number->traits.get_device_class()));
   msg.min_value = number->traits.get_min_value();
   msg.max_value = number->traits.get_max_value();
   msg.step = number->traits.get_step();
@@ -858,7 +847,7 @@ uint16_t APIConnection::try_send_text_state(EntityBase *entity, APIConnection *c
                                             bool is_single) {
   auto *text = static_cast<text::Text *>(entity);
   TextStateResponse resp;
-  resp.set_state(text->state.c_str(), text->state.length());
+  resp.set_state(StringRef(text->state));
   resp.missing_state = !text->has_state();
   return fill_and_encode_entity_state(text, resp, TextStateResponse::MESSAGE_TYPE, conn, remaining_size, is_single);
 }
@@ -870,8 +859,7 @@ uint16_t APIConnection::try_send_text_info(EntityBase *entity, APIConnection *co
   msg.mode = static_cast<enums::TextMode>(text->traits.get_mode());
   msg.min_length = text->traits.get_min_length();
   msg.max_length = text->traits.get_max_length();
-  const std::string &pattern = text->traits.get_pattern();
-  msg.set_pattern(pattern.c_str(), pattern.length());
+  msg.set_pattern(StringRef(text->traits.get_pattern()));
   return fill_and_encode_entity_info(text, msg, ListEntitiesTextResponse::MESSAGE_TYPE, conn, remaining_size,
                                      is_single);
 }
@@ -892,7 +880,7 @@ uint16_t APIConnection::try_send_select_state(EntityBase *entity, APIConnection 
                                               bool is_single) {
   auto *select = static_cast<select::Select *>(entity);
   SelectStateResponse resp;
-  resp.set_state(select->state.c_str(), select->state.length());
+  resp.set_state(StringRef(select->state));
   resp.missing_state = !select->has_state();
   return fill_and_encode_entity_state(select, resp, SelectStateResponse::MESSAGE_TYPE, conn, remaining_size, is_single);
 }
@@ -918,8 +906,7 @@ uint16_t APIConnection::try_send_button_info(EntityBase *entity, APIConnection *
                                              bool is_single) {
   auto *button = static_cast<button::Button *>(entity);
   ListEntitiesButtonResponse msg;
-  const std::string &device_class = button->get_device_class();
-  msg.set_device_class(device_class.c_str(), device_class.length());
+  msg.set_device_class(StringRef(button->get_device_class()));
   return fill_and_encode_entity_info(button, msg, ListEntitiesButtonResponse::MESSAGE_TYPE, conn, remaining_size,
                                      is_single);
 }
@@ -988,8 +975,7 @@ uint16_t APIConnection::try_send_valve_info(EntityBase *entity, APIConnection *c
   auto *valve = static_cast<valve::Valve *>(entity);
   ListEntitiesValveResponse msg;
   auto traits = valve->get_traits();
-  const std::string &device_class = valve->get_device_class();
-  msg.set_device_class(device_class.c_str(), device_class.length());
+  msg.set_device_class(StringRef(valve->get_device_class()));
   msg.assumed_state = traits.get_is_assumed_state();
   msg.supports_position = traits.get_supports_position();
   msg.supports_stop = traits.get_supports_stop();
@@ -1290,7 +1276,7 @@ void APIConnection::send_event(event::Event *event, const std::string &event_typ
 uint16_t APIConnection::try_send_event_response(event::Event *event, const std::string &event_type, APIConnection *conn,
                                                 uint32_t remaining_size, bool is_single) {
   EventResponse resp;
-  resp.set_event_type(event_type.c_str(), event_type.length());
+  resp.set_event_type(StringRef(event_type));
   return fill_and_encode_entity_state(event, resp, EventResponse::MESSAGE_TYPE, conn, remaining_size, is_single);
 }
 
@@ -1298,8 +1284,7 @@ uint16_t APIConnection::try_send_event_info(EntityBase *entity, APIConnection *c
                                             bool is_single) {
   auto *event = static_cast<event::Event *>(entity);
   ListEntitiesEventResponse msg;
-  const std::string &device_class = event->get_device_class();
-  msg.set_device_class(device_class.c_str(), device_class.length());
+  msg.set_device_class(StringRef(event->get_device_class()));
   for (const auto &event_type : event->get_event_types())
     msg.event_types.push_back(event_type);
   return fill_and_encode_entity_info(event, msg, ListEntitiesEventResponse::MESSAGE_TYPE, conn, remaining_size,
@@ -1323,11 +1308,11 @@ uint16_t APIConnection::try_send_update_state(EntityBase *entity, APIConnection 
       resp.has_progress = true;
       resp.progress = update->update_info.progress;
     }
-    resp.set_current_version(update->update_info.current_version.c_str(), update->update_info.current_version.length());
-    resp.set_latest_version(update->update_info.latest_version.c_str(), update->update_info.latest_version.length());
-    resp.set_title(update->update_info.title.c_str(), update->update_info.title.length());
-    resp.set_release_summary(update->update_info.summary.c_str(), update->update_info.summary.length());
-    resp.set_release_url(update->update_info.release_url.c_str(), update->update_info.release_url.length());
+    resp.set_current_version(StringRef(update->update_info.current_version));
+    resp.set_latest_version(StringRef(update->update_info.latest_version));
+    resp.set_title(StringRef(update->update_info.title));
+    resp.set_release_summary(StringRef(update->update_info.summary));
+    resp.set_release_url(StringRef(update->update_info.release_url));
   }
   return fill_and_encode_entity_state(update, resp, UpdateStateResponse::MESSAGE_TYPE, conn, remaining_size, is_single);
 }
@@ -1335,8 +1320,7 @@ uint16_t APIConnection::try_send_update_info(EntityBase *entity, APIConnection *
                                              bool is_single) {
   auto *update = static_cast<update::UpdateEntity *>(entity);
   ListEntitiesUpdateResponse msg;
-  const std::string &device_class = update->get_device_class();
-  msg.set_device_class(device_class.c_str(), device_class.length());
+  msg.set_device_class(StringRef(update->get_device_class()));
   return fill_and_encode_entity_info(update, msg, ListEntitiesUpdateResponse::MESSAGE_TYPE, conn, remaining_size,
                                      is_single);
 }
@@ -1397,9 +1381,8 @@ HelloResponse APIConnection::hello(const HelloRequest &msg) {
   resp.api_version_major = 1;
   resp.api_version_minor = 10;
   std::string server_info = App.get_name() + " (esphome v" ESPHOME_VERSION ")";
-  resp.set_server_info(server_info.c_str(), server_info.length());
-  const std::string &name = App.get_name();
-  resp.set_name(name.c_str(), name.length());
+  resp.set_server_info(StringRef(server_info));
+  resp.set_name(StringRef(App.get_name()));
 
 #ifdef USE_API_PASSWORD
   // Password required - wait for authentication
@@ -1430,39 +1413,35 @@ DeviceInfoResponse APIConnection::device_info(const DeviceInfoRequest &msg) {
 #ifdef USE_API_PASSWORD
   resp.uses_password = true;
 #endif
-  const std::string &name = App.get_name();
-  resp.set_name(name.c_str(), name.length());
-  const std::string &friendly_name = App.get_friendly_name();
-  resp.set_friendly_name(friendly_name.c_str(), friendly_name.length());
+  resp.set_name(StringRef(App.get_name()));
+  resp.set_friendly_name(StringRef(App.get_friendly_name()));
 #ifdef USE_AREAS
-  const std::string &area = App.get_area();
-  resp.set_suggested_area(area.c_str(), area.length());
+  resp.set_suggested_area(StringRef(App.get_area()));
 #endif
   std::string mac = get_mac_address_pretty();
-  resp.set_mac_address(mac.c_str(), mac.length());
-  resp.set_esphome_version(ESPHOME_VERSION, strlen(ESPHOME_VERSION));
-  const std::string &compilation_time = App.get_compilation_time();
-  resp.set_compilation_time(compilation_time.c_str(), compilation_time.length());
+  resp.set_mac_address(StringRef(mac));
+  resp.set_esphome_version(StringRef(ESPHOME_VERSION));
+  resp.set_compilation_time(StringRef(App.get_compilation_time()));
 #if defined(USE_ESP8266) || defined(USE_ESP32)
-  resp.set_manufacturer("Espressif", 9);
+  resp.set_manufacturer(StringRef("Espressif"));
 #elif defined(USE_RP2040)
-  resp.set_manufacturer("Raspberry Pi", 12);
+  resp.set_manufacturer(StringRef("Raspberry Pi"));
 #elif defined(USE_BK72XX)
-  resp.set_manufacturer("Beken", 5);
+  resp.set_manufacturer(StringRef("Beken"));
 #elif defined(USE_LN882X)
-  resp.set_manufacturer("Lightning", 9);
+  resp.set_manufacturer(StringRef("Lightning"));
 #elif defined(USE_RTL87XX)
-  resp.set_manufacturer("Realtek", 7);
+  resp.set_manufacturer(StringRef("Realtek"));
 #elif defined(USE_HOST)
-  resp.set_manufacturer("Host", 4);
+  resp.set_manufacturer(StringRef("Host"));
 #endif
-  resp.set_model(ESPHOME_BOARD, strlen(ESPHOME_BOARD));
+  resp.set_model(StringRef(ESPHOME_BOARD));
 #ifdef USE_DEEP_SLEEP
   resp.has_deep_sleep = deep_sleep::global_has_deep_sleep;
 #endif
 #ifdef ESPHOME_PROJECT_NAME
-  resp.set_project_name(ESPHOME_PROJECT_NAME, strlen(ESPHOME_PROJECT_NAME));
-  resp.set_project_version(ESPHOME_PROJECT_VERSION, strlen(ESPHOME_PROJECT_VERSION));
+  resp.set_project_name(StringRef(ESPHOME_PROJECT_NAME));
+  resp.set_project_version(StringRef(ESPHOME_PROJECT_VERSION));
 #endif
 #ifdef USE_WEBSERVER
   resp.webserver_port = USE_WEBSERVER_PORT;
@@ -1470,7 +1449,7 @@ DeviceInfoResponse APIConnection::device_info(const DeviceInfoRequest &msg) {
 #ifdef USE_BLUETOOTH_PROXY
   resp.bluetooth_proxy_feature_flags = bluetooth_proxy::global_bluetooth_proxy->get_feature_flags();
   std::string bt_mac = bluetooth_proxy::global_bluetooth_proxy->get_bluetooth_mac_address_pretty();
-  resp.set_bluetooth_mac_address(bt_mac.c_str(), bt_mac.length());
+  resp.set_bluetooth_mac_address(StringRef(bt_mac));
 #endif
 #ifdef USE_VOICE_ASSISTANT
   resp.voice_assistant_feature_flags = voice_assistant::global_voice_assistant->get_feature_flags();
@@ -1483,8 +1462,7 @@ DeviceInfoResponse APIConnection::device_info(const DeviceInfoRequest &msg) {
     resp.devices.emplace_back();
     auto &device_info = resp.devices.back();
     device_info.device_id = device->get_device_id();
-    const std::string &device_name = device->get_name();
-    device_info.set_name(device_name.c_str(), device_name.length());
+    device_info.set_name(StringRef(device->get_name()));
     device_info.area_id = device->get_area_id();
   }
 #endif
@@ -1493,8 +1471,7 @@ DeviceInfoResponse APIConnection::device_info(const DeviceInfoRequest &msg) {
     resp.areas.emplace_back();
     auto &area_info = resp.areas.back();
     area_info.area_id = area->get_area_id();
-    const std::string &area_name = area->get_name();
-    area_info.set_name(area_name.c_str(), area_name.length());
+    area_info.set_name(StringRef(area->get_name()));
   }
 #endif
   return resp;

--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -248,8 +248,8 @@ void APIConnection::loop() {
     if (state_subs_at_ < static_cast<int>(subs.size())) {
       auto &it = subs[state_subs_at_];
       SubscribeHomeAssistantStateResponse resp;
-      resp.entity_id = it.entity_id;
-      resp.attribute = it.attribute.value();
+      resp.set_entity_id(it.entity_id.c_str(), it.entity_id.length());
+      resp.set_attribute(it.attribute.value().c_str(), it.attribute.value().length());
       resp.once = it.once;
       if (this->send_message(resp, SubscribeHomeAssistantStateResponse::MESSAGE_TYPE)) {
         state_subs_at_++;
@@ -344,7 +344,8 @@ uint16_t APIConnection::try_send_binary_sensor_info(EntityBase *entity, APIConne
                                                     bool is_single) {
   auto *binary_sensor = static_cast<binary_sensor::BinarySensor *>(entity);
   ListEntitiesBinarySensorResponse msg;
-  msg.device_class = binary_sensor->get_device_class();
+  const std::string &device_class = binary_sensor->get_device_class();
+  msg.set_device_class(device_class.c_str(), device_class.length());
   msg.is_status_binary_sensor = binary_sensor->is_status_binary_sensor();
   return fill_and_encode_entity_info(binary_sensor, msg, ListEntitiesBinarySensorResponse::MESSAGE_TYPE, conn,
                                      remaining_size, is_single);
@@ -376,7 +377,8 @@ uint16_t APIConnection::try_send_cover_info(EntityBase *entity, APIConnection *c
   msg.supports_position = traits.get_supports_position();
   msg.supports_tilt = traits.get_supports_tilt();
   msg.supports_stop = traits.get_supports_stop();
-  msg.device_class = cover->get_device_class();
+  const std::string &device_class = cover->get_device_class();
+  msg.set_device_class(device_class.c_str(), device_class.length());
   return fill_and_encode_entity_info(cover, msg, ListEntitiesCoverResponse::MESSAGE_TYPE, conn, remaining_size,
                                      is_single);
 }
@@ -411,7 +413,7 @@ uint16_t APIConnection::try_send_fan_state(EntityBase *entity, APIConnection *co
   if (traits.supports_direction())
     msg.direction = static_cast<enums::FanDirection>(fan->direction);
   if (traits.supports_preset_modes())
-    msg.preset_mode = fan->preset_mode;
+    msg.set_preset_mode(fan->preset_mode.c_str(), fan->preset_mode.length());
   return fill_and_encode_entity_state(fan, msg, FanStateResponse::MESSAGE_TYPE, conn, remaining_size, is_single);
 }
 uint16_t APIConnection::try_send_fan_info(EntityBase *entity, APIConnection *conn, uint32_t remaining_size,
@@ -468,8 +470,10 @@ uint16_t APIConnection::try_send_light_state(EntityBase *entity, APIConnection *
   resp.color_temperature = values.get_color_temperature();
   resp.cold_white = values.get_cold_white();
   resp.warm_white = values.get_warm_white();
-  if (light->supports_effects())
-    resp.effect = light->get_effect_name();
+  if (light->supports_effects()) {
+    const std::string &effect_name = light->get_effect_name();
+    resp.set_effect(effect_name.c_str(), effect_name.length());
+  }
   return fill_and_encode_entity_state(light, resp, LightStateResponse::MESSAGE_TYPE, conn, remaining_size, is_single);
 }
 uint16_t APIConnection::try_send_light_info(EntityBase *entity, APIConnection *conn, uint32_t remaining_size,
@@ -545,10 +549,12 @@ uint16_t APIConnection::try_send_sensor_info(EntityBase *entity, APIConnection *
                                              bool is_single) {
   auto *sensor = static_cast<sensor::Sensor *>(entity);
   ListEntitiesSensorResponse msg;
-  msg.unit_of_measurement = sensor->get_unit_of_measurement();
+  const std::string &unit = sensor->get_unit_of_measurement();
+  msg.set_unit_of_measurement(unit.c_str(), unit.length());
   msg.accuracy_decimals = sensor->get_accuracy_decimals();
   msg.force_update = sensor->get_force_update();
-  msg.device_class = sensor->get_device_class();
+  const std::string &device_class = sensor->get_device_class();
+  msg.set_device_class(device_class.c_str(), device_class.length());
   msg.state_class = static_cast<enums::SensorStateClass>(sensor->get_state_class());
   return fill_and_encode_entity_info(sensor, msg, ListEntitiesSensorResponse::MESSAGE_TYPE, conn, remaining_size,
                                      is_single);
@@ -575,7 +581,8 @@ uint16_t APIConnection::try_send_switch_info(EntityBase *entity, APIConnection *
   auto *a_switch = static_cast<switch_::Switch *>(entity);
   ListEntitiesSwitchResponse msg;
   msg.assumed_state = a_switch->assumed_state();
-  msg.device_class = a_switch->get_device_class();
+  const std::string &device_class = a_switch->get_device_class();
+  msg.set_device_class(device_class.c_str(), device_class.length());
   return fill_and_encode_entity_info(a_switch, msg, ListEntitiesSwitchResponse::MESSAGE_TYPE, conn, remaining_size,
                                      is_single);
 }
@@ -600,7 +607,7 @@ uint16_t APIConnection::try_send_text_sensor_state(EntityBase *entity, APIConnec
                                                    bool is_single) {
   auto *text_sensor = static_cast<text_sensor::TextSensor *>(entity);
   TextSensorStateResponse resp;
-  resp.state = text_sensor->state;
+  resp.set_state(text_sensor->state.c_str(), text_sensor->state.length());
   resp.missing_state = !text_sensor->has_state();
   return fill_and_encode_entity_state(text_sensor, resp, TextSensorStateResponse::MESSAGE_TYPE, conn, remaining_size,
                                       is_single);
@@ -609,7 +616,8 @@ uint16_t APIConnection::try_send_text_sensor_info(EntityBase *entity, APIConnect
                                                   bool is_single) {
   auto *text_sensor = static_cast<text_sensor::TextSensor *>(entity);
   ListEntitiesTextSensorResponse msg;
-  msg.device_class = text_sensor->get_device_class();
+  const std::string &device_class = text_sensor->get_device_class();
+  msg.set_device_class(device_class.c_str(), device_class.length());
   return fill_and_encode_entity_info(text_sensor, msg, ListEntitiesTextSensorResponse::MESSAGE_TYPE, conn,
                                      remaining_size, is_single);
 }
@@ -637,13 +645,17 @@ uint16_t APIConnection::try_send_climate_state(EntityBase *entity, APIConnection
   }
   if (traits.get_supports_fan_modes() && climate->fan_mode.has_value())
     resp.fan_mode = static_cast<enums::ClimateFanMode>(climate->fan_mode.value());
-  if (!traits.get_supported_custom_fan_modes().empty() && climate->custom_fan_mode.has_value())
-    resp.custom_fan_mode = climate->custom_fan_mode.value();
+  if (!traits.get_supported_custom_fan_modes().empty() && climate->custom_fan_mode.has_value()) {
+    const std::string &custom_fan = climate->custom_fan_mode.value();
+    resp.set_custom_fan_mode(custom_fan.c_str(), custom_fan.length());
+  }
   if (traits.get_supports_presets() && climate->preset.has_value()) {
     resp.preset = static_cast<enums::ClimatePreset>(climate->preset.value());
   }
-  if (!traits.get_supported_custom_presets().empty() && climate->custom_preset.has_value())
-    resp.custom_preset = climate->custom_preset.value();
+  if (!traits.get_supported_custom_presets().empty() && climate->custom_preset.has_value()) {
+    const std::string &custom_preset = climate->custom_preset.value();
+    resp.set_custom_preset(custom_preset.c_str(), custom_preset.length());
+  }
   if (traits.get_supports_swing_modes())
     resp.swing_mode = static_cast<enums::ClimateSwingMode>(climate->swing_mode);
   if (traits.get_supports_current_humidity())
@@ -729,9 +741,11 @@ uint16_t APIConnection::try_send_number_info(EntityBase *entity, APIConnection *
                                              bool is_single) {
   auto *number = static_cast<number::Number *>(entity);
   ListEntitiesNumberResponse msg;
-  msg.unit_of_measurement = number->traits.get_unit_of_measurement();
+  const std::string &unit = number->traits.get_unit_of_measurement();
+  msg.set_unit_of_measurement(unit.c_str(), unit.length());
   msg.mode = static_cast<enums::NumberMode>(number->traits.get_mode());
-  msg.device_class = number->traits.get_device_class();
+  const std::string &device_class = number->traits.get_device_class();
+  msg.set_device_class(device_class.c_str(), device_class.length());
   msg.min_value = number->traits.get_min_value();
   msg.max_value = number->traits.get_max_value();
   msg.step = number->traits.get_step();
@@ -844,7 +858,7 @@ uint16_t APIConnection::try_send_text_state(EntityBase *entity, APIConnection *c
                                             bool is_single) {
   auto *text = static_cast<text::Text *>(entity);
   TextStateResponse resp;
-  resp.state = text->state;
+  resp.set_state(text->state.c_str(), text->state.length());
   resp.missing_state = !text->has_state();
   return fill_and_encode_entity_state(text, resp, TextStateResponse::MESSAGE_TYPE, conn, remaining_size, is_single);
 }
@@ -856,7 +870,8 @@ uint16_t APIConnection::try_send_text_info(EntityBase *entity, APIConnection *co
   msg.mode = static_cast<enums::TextMode>(text->traits.get_mode());
   msg.min_length = text->traits.get_min_length();
   msg.max_length = text->traits.get_max_length();
-  msg.pattern = text->traits.get_pattern();
+  const std::string &pattern = text->traits.get_pattern();
+  msg.set_pattern(pattern.c_str(), pattern.length());
   return fill_and_encode_entity_info(text, msg, ListEntitiesTextResponse::MESSAGE_TYPE, conn, remaining_size,
                                      is_single);
 }
@@ -877,7 +892,7 @@ uint16_t APIConnection::try_send_select_state(EntityBase *entity, APIConnection 
                                               bool is_single) {
   auto *select = static_cast<select::Select *>(entity);
   SelectStateResponse resp;
-  resp.state = select->state;
+  resp.set_state(select->state.c_str(), select->state.length());
   resp.missing_state = !select->has_state();
   return fill_and_encode_entity_state(select, resp, SelectStateResponse::MESSAGE_TYPE, conn, remaining_size, is_single);
 }
@@ -903,7 +918,8 @@ uint16_t APIConnection::try_send_button_info(EntityBase *entity, APIConnection *
                                              bool is_single) {
   auto *button = static_cast<button::Button *>(entity);
   ListEntitiesButtonResponse msg;
-  msg.device_class = button->get_device_class();
+  const std::string &device_class = button->get_device_class();
+  msg.set_device_class(device_class.c_str(), device_class.length());
   return fill_and_encode_entity_info(button, msg, ListEntitiesButtonResponse::MESSAGE_TYPE, conn, remaining_size,
                                      is_single);
 }
@@ -972,7 +988,8 @@ uint16_t APIConnection::try_send_valve_info(EntityBase *entity, APIConnection *c
   auto *valve = static_cast<valve::Valve *>(entity);
   ListEntitiesValveResponse msg;
   auto traits = valve->get_traits();
-  msg.device_class = valve->get_device_class();
+  const std::string &device_class = valve->get_device_class();
+  msg.set_device_class(device_class.c_str(), device_class.length());
   msg.assumed_state = traits.get_is_assumed_state();
   msg.supports_position = traits.get_supports_position();
   msg.supports_stop = traits.get_supports_stop();
@@ -1273,7 +1290,7 @@ void APIConnection::send_event(event::Event *event, const std::string &event_typ
 uint16_t APIConnection::try_send_event_response(event::Event *event, const std::string &event_type, APIConnection *conn,
                                                 uint32_t remaining_size, bool is_single) {
   EventResponse resp;
-  resp.event_type = event_type;
+  resp.set_event_type(event_type.c_str(), event_type.length());
   return fill_and_encode_entity_state(event, resp, EventResponse::MESSAGE_TYPE, conn, remaining_size, is_single);
 }
 
@@ -1281,7 +1298,8 @@ uint16_t APIConnection::try_send_event_info(EntityBase *entity, APIConnection *c
                                             bool is_single) {
   auto *event = static_cast<event::Event *>(entity);
   ListEntitiesEventResponse msg;
-  msg.device_class = event->get_device_class();
+  const std::string &device_class = event->get_device_class();
+  msg.set_device_class(device_class.c_str(), device_class.length());
   for (const auto &event_type : event->get_event_types())
     msg.event_types.push_back(event_type);
   return fill_and_encode_entity_info(event, msg, ListEntitiesEventResponse::MESSAGE_TYPE, conn, remaining_size,
@@ -1305,11 +1323,11 @@ uint16_t APIConnection::try_send_update_state(EntityBase *entity, APIConnection 
       resp.has_progress = true;
       resp.progress = update->update_info.progress;
     }
-    resp.current_version = update->update_info.current_version;
-    resp.latest_version = update->update_info.latest_version;
-    resp.title = update->update_info.title;
-    resp.release_summary = update->update_info.summary;
-    resp.release_url = update->update_info.release_url;
+    resp.set_current_version(update->update_info.current_version.c_str(), update->update_info.current_version.length());
+    resp.set_latest_version(update->update_info.latest_version.c_str(), update->update_info.latest_version.length());
+    resp.set_title(update->update_info.title.c_str(), update->update_info.title.length());
+    resp.set_release_summary(update->update_info.summary.c_str(), update->update_info.summary.length());
+    resp.set_release_url(update->update_info.release_url.c_str(), update->update_info.release_url.length());
   }
   return fill_and_encode_entity_state(update, resp, UpdateStateResponse::MESSAGE_TYPE, conn, remaining_size, is_single);
 }
@@ -1317,7 +1335,8 @@ uint16_t APIConnection::try_send_update_info(EntityBase *entity, APIConnection *
                                              bool is_single) {
   auto *update = static_cast<update::UpdateEntity *>(entity);
   ListEntitiesUpdateResponse msg;
-  msg.device_class = update->get_device_class();
+  const std::string &device_class = update->get_device_class();
+  msg.set_device_class(device_class.c_str(), device_class.length());
   return fill_and_encode_entity_info(update, msg, ListEntitiesUpdateResponse::MESSAGE_TYPE, conn, remaining_size,
                                      is_single);
 }
@@ -1377,8 +1396,10 @@ HelloResponse APIConnection::hello(const HelloRequest &msg) {
   HelloResponse resp;
   resp.api_version_major = 1;
   resp.api_version_minor = 10;
-  resp.server_info = App.get_name() + " (esphome v" ESPHOME_VERSION ")";
-  resp.name = App.get_name();
+  std::string server_info = App.get_name() + " (esphome v" ESPHOME_VERSION ")";
+  resp.set_server_info(server_info.c_str(), server_info.length());
+  const std::string &name = App.get_name();
+  resp.set_name(name.c_str(), name.length());
 
 #ifdef USE_API_PASSWORD
   // Password required - wait for authentication
@@ -1409,41 +1430,47 @@ DeviceInfoResponse APIConnection::device_info(const DeviceInfoRequest &msg) {
 #ifdef USE_API_PASSWORD
   resp.uses_password = true;
 #endif
-  resp.name = App.get_name();
-  resp.friendly_name = App.get_friendly_name();
+  const std::string &name = App.get_name();
+  resp.set_name(name.c_str(), name.length());
+  const std::string &friendly_name = App.get_friendly_name();
+  resp.set_friendly_name(friendly_name.c_str(), friendly_name.length());
 #ifdef USE_AREAS
-  resp.suggested_area = App.get_area();
+  const std::string &area = App.get_area();
+  resp.set_suggested_area(area.c_str(), area.length());
 #endif
-  resp.mac_address = get_mac_address_pretty();
-  resp.esphome_version = ESPHOME_VERSION;
-  resp.compilation_time = App.get_compilation_time();
+  std::string mac = get_mac_address_pretty();
+  resp.set_mac_address(mac.c_str(), mac.length());
+  resp.set_esphome_version(ESPHOME_VERSION, strlen(ESPHOME_VERSION));
+  const std::string &compilation_time = App.get_compilation_time();
+  resp.set_compilation_time(compilation_time.c_str(), compilation_time.length());
 #if defined(USE_ESP8266) || defined(USE_ESP32)
-  resp.manufacturer = "Espressif";
+  resp.set_manufacturer("Espressif", 9);
 #elif defined(USE_RP2040)
-  resp.manufacturer = "Raspberry Pi";
+  resp.set_manufacturer("Raspberry Pi", 12);
 #elif defined(USE_BK72XX)
-  resp.manufacturer = "Beken";
+  resp.set_manufacturer("Beken", 5);
 #elif defined(USE_LN882X)
-  resp.manufacturer = "Lightning";
+  resp.set_manufacturer("Lightning", 9);
 #elif defined(USE_RTL87XX)
-  resp.manufacturer = "Realtek";
+  resp.set_manufacturer("Realtek", 7);
 #elif defined(USE_HOST)
-  resp.manufacturer = "Host";
+  resp.set_manufacturer("Host", 4);
 #endif
-  resp.model = ESPHOME_BOARD;
+  resp.set_model(ESPHOME_BOARD, strlen(ESPHOME_BOARD));
 #ifdef USE_DEEP_SLEEP
   resp.has_deep_sleep = deep_sleep::global_has_deep_sleep;
 #endif
 #ifdef ESPHOME_PROJECT_NAME
-  resp.project_name = ESPHOME_PROJECT_NAME;
-  resp.project_version = ESPHOME_PROJECT_VERSION;
+  resp.set_project_name(ESPHOME_PROJECT_NAME, strlen(ESPHOME_PROJECT_NAME));
+  resp.set_project_version(ESPHOME_PROJECT_VERSION, strlen(ESPHOME_PROJECT_VERSION));
 #endif
 #ifdef USE_WEBSERVER
   resp.webserver_port = USE_WEBSERVER_PORT;
 #endif
 #ifdef USE_BLUETOOTH_PROXY
   resp.bluetooth_proxy_feature_flags = bluetooth_proxy::global_bluetooth_proxy->get_feature_flags();
-  resp.bluetooth_mac_address = bluetooth_proxy::global_bluetooth_proxy->get_bluetooth_mac_address_pretty();
+  std::string bt_mac = bluetooth_proxy::global_bluetooth_proxy->get_bluetooth_mac_address_pretty();
+  resp.set_bluetooth_mac_address(bt_mac.c_str(), bt_mac.length());
 #endif
 #ifdef USE_VOICE_ASSISTANT
   resp.voice_assistant_feature_flags = voice_assistant::global_voice_assistant->get_feature_flags();
@@ -1453,19 +1480,21 @@ DeviceInfoResponse APIConnection::device_info(const DeviceInfoRequest &msg) {
 #endif
 #ifdef USE_DEVICES
   for (auto const &device : App.get_devices()) {
-    DeviceInfo device_info;
+    resp.devices.emplace_back();
+    auto &device_info = resp.devices.back();
     device_info.device_id = device->get_device_id();
-    device_info.name = device->get_name();
+    const std::string &device_name = device->get_name();
+    device_info.set_name(device_name.c_str(), device_name.length());
     device_info.area_id = device->get_area_id();
-    resp.devices.push_back(device_info);
   }
 #endif
 #ifdef USE_AREAS
   for (auto const &area : App.get_areas()) {
-    AreaInfo area_info;
+    resp.areas.emplace_back();
+    auto &area_info = resp.areas.back();
     area_info.area_id = area->get_area_id();
-    area_info.name = area->get_name();
-    resp.areas.push_back(area_info);
+    const std::string &area_name = area->get_name();
+    area_info.set_name(area_name.c_str(), area_name.length());
   }
 #endif
   return resp;

--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -249,7 +249,9 @@ void APIConnection::loop() {
       auto &it = subs[state_subs_at_];
       SubscribeHomeAssistantStateResponse resp;
       resp.set_entity_id(StringRef(it.entity_id));
-      resp.set_attribute(StringRef(it.attribute.value()));
+      // attribute.value() returns temporary - must store it
+      std::string attribute_value = it.attribute.value();
+      resp.set_attribute(StringRef(attribute_value));
       resp.once = it.once;
       if (this->send_message(resp, SubscribeHomeAssistantStateResponse::MESSAGE_TYPE)) {
         state_subs_at_++;
@@ -641,13 +643,17 @@ uint16_t APIConnection::try_send_climate_state(EntityBase *entity, APIConnection
   if (traits.get_supports_fan_modes() && climate->fan_mode.has_value())
     resp.fan_mode = static_cast<enums::ClimateFanMode>(climate->fan_mode.value());
   if (!traits.get_supported_custom_fan_modes().empty() && climate->custom_fan_mode.has_value()) {
-    resp.set_custom_fan_mode(StringRef(climate->custom_fan_mode.value()));
+    // custom_fan_mode.value() returns temporary - must store it
+    std::string custom_fan_mode = climate->custom_fan_mode.value();
+    resp.set_custom_fan_mode(StringRef(custom_fan_mode));
   }
   if (traits.get_supports_presets() && climate->preset.has_value()) {
     resp.preset = static_cast<enums::ClimatePreset>(climate->preset.value());
   }
   if (!traits.get_supported_custom_presets().empty() && climate->custom_preset.has_value()) {
-    resp.set_custom_preset(StringRef(climate->custom_preset.value()));
+    // custom_preset.value() returns temporary - must store it
+    std::string custom_preset = climate->custom_preset.value();
+    resp.set_custom_preset(StringRef(custom_preset));
   }
   if (traits.get_supports_swing_modes())
     resp.swing_mode = static_cast<enums::ClimateSwingMode>(climate->swing_mode);

--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -1441,30 +1441,41 @@ bool APIConnection::send_device_info_response(const DeviceInfoRequest &msg) {
   // mac_address must store temporary string - will be valid during send_message call
   std::string mac_address = get_mac_address_pretty();
   resp.set_mac_address(StringRef(mac_address));
-  resp.set_esphome_version(StringRef(ESPHOME_VERSION));
+
+  // Compile-time StringRef constants
+  static constexpr auto ESPHOME_VERSION_REF = StringRef::from_lit(ESPHOME_VERSION);
+  resp.set_esphome_version(ESPHOME_VERSION_REF);
+
   // get_compilation_time() returns temporary std::string - must store it
   std::string compilation_time = App.get_compilation_time();
   resp.set_compilation_time(StringRef(compilation_time));
+
+  // Compile-time StringRef constants for manufacturers
 #if defined(USE_ESP8266) || defined(USE_ESP32)
-  resp.set_manufacturer(StringRef("Espressif"));
+  static constexpr auto MANUFACTURER = StringRef::from_lit("Espressif");
 #elif defined(USE_RP2040)
-  resp.set_manufacturer(StringRef("Raspberry Pi"));
+  static constexpr auto MANUFACTURER = StringRef::from_lit("Raspberry Pi");
 #elif defined(USE_BK72XX)
-  resp.set_manufacturer(StringRef("Beken"));
+  static constexpr auto MANUFACTURER = StringRef::from_lit("Beken");
 #elif defined(USE_LN882X)
-  resp.set_manufacturer(StringRef("Lightning"));
+  static constexpr auto MANUFACTURER = StringRef::from_lit("Lightning");
 #elif defined(USE_RTL87XX)
-  resp.set_manufacturer(StringRef("Realtek"));
+  static constexpr auto MANUFACTURER = StringRef::from_lit("Realtek");
 #elif defined(USE_HOST)
-  resp.set_manufacturer(StringRef("Host"));
+  static constexpr auto MANUFACTURER = StringRef::from_lit("Host");
 #endif
-  resp.set_model(StringRef(ESPHOME_BOARD));
+  resp.set_manufacturer(MANUFACTURER);
+
+  static constexpr auto MODEL = StringRef::from_lit(ESPHOME_BOARD);
+  resp.set_model(MODEL);
 #ifdef USE_DEEP_SLEEP
   resp.has_deep_sleep = deep_sleep::global_has_deep_sleep;
 #endif
 #ifdef ESPHOME_PROJECT_NAME
-  resp.set_project_name(StringRef(ESPHOME_PROJECT_NAME));
-  resp.set_project_version(StringRef(ESPHOME_PROJECT_VERSION));
+  static constexpr auto PROJECT_NAME = StringRef::from_lit(ESPHOME_PROJECT_NAME);
+  static constexpr auto PROJECT_VERSION = StringRef::from_lit(ESPHOME_PROJECT_VERSION);
+  resp.set_project_name(PROJECT_NAME);
+  resp.set_project_version(PROJECT_VERSION);
 #endif
 #ifdef USE_WEBSERVER
   resp.webserver_port = USE_WEBSERVER_PORT;

--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -1198,13 +1198,13 @@ bool APIConnection::send_voice_assistant_get_configuration_response(const VoiceA
 
   auto &config = voice_assistant::global_voice_assistant->get_configuration();
   for (auto &wake_word : config.available_wake_words) {
-    VoiceAssistantWakeWord resp_wake_word;
-    resp_wake_word.id = wake_word.id;
-    resp_wake_word.wake_word = wake_word.wake_word;
+    resp.available_wake_words.emplace_back();
+    auto &resp_wake_word = resp.available_wake_words.back();
+    resp_wake_word.set_id(StringRef(wake_word.id));
+    resp_wake_word.set_wake_word(StringRef(wake_word.wake_word));
     for (const auto &lang : wake_word.trained_languages) {
       resp_wake_word.trained_languages.push_back(lang);
     }
-    resp.available_wake_words.push_back(std::move(resp_wake_word));
   }
   for (auto &wake_word_id : config.active_wake_words) {
     resp.active_wake_words.push_back(wake_word_id);

--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -1380,6 +1380,7 @@ HelloResponse APIConnection::hello(const HelloRequest &msg) {
   HelloResponse resp;
   resp.api_version_major = 1;
   resp.api_version_minor = 10;
+  // Temporary string needed to concatenate app name with version string
   std::string server_info = App.get_name() + " (esphome v" ESPHOME_VERSION ")";
   resp.set_server_info(StringRef(server_info));
   resp.set_name(StringRef(App.get_name()));
@@ -1418,6 +1419,7 @@ DeviceInfoResponse APIConnection::device_info(const DeviceInfoRequest &msg) {
 #ifdef USE_AREAS
   resp.set_suggested_area(StringRef(App.get_area()));
 #endif
+  // Temporary string needed because get_mac_address_pretty() formats the MAC on-the-fly
   std::string mac = get_mac_address_pretty();
   resp.set_mac_address(StringRef(mac));
   resp.set_esphome_version(StringRef(ESPHOME_VERSION));
@@ -1448,6 +1450,7 @@ DeviceInfoResponse APIConnection::device_info(const DeviceInfoRequest &msg) {
 #endif
 #ifdef USE_BLUETOOTH_PROXY
   resp.bluetooth_proxy_feature_flags = bluetooth_proxy::global_bluetooth_proxy->get_feature_flags();
+  // Temporary string needed because get_bluetooth_mac_address_pretty() formats the MAC on-the-fly
   std::string bt_mac = bluetooth_proxy::global_bluetooth_proxy->get_bluetooth_mac_address_pretty();
   resp.set_bluetooth_mac_address(StringRef(bt_mac));
 #endif

--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -344,7 +344,7 @@ uint16_t APIConnection::try_send_binary_sensor_info(EntityBase *entity, APIConne
                                                     bool is_single) {
   auto *binary_sensor = static_cast<binary_sensor::BinarySensor *>(entity);
   ListEntitiesBinarySensorResponse msg;
-  msg.set_device_class(StringRef(binary_sensor->get_device_class()));
+  msg.set_device_class(binary_sensor->get_device_class_ref());
   msg.is_status_binary_sensor = binary_sensor->is_status_binary_sensor();
   return fill_and_encode_entity_info(binary_sensor, msg, ListEntitiesBinarySensorResponse::MESSAGE_TYPE, conn,
                                      remaining_size, is_single);
@@ -376,7 +376,7 @@ uint16_t APIConnection::try_send_cover_info(EntityBase *entity, APIConnection *c
   msg.supports_position = traits.get_supports_position();
   msg.supports_tilt = traits.get_supports_tilt();
   msg.supports_stop = traits.get_supports_stop();
-  msg.set_device_class(StringRef(cover->get_device_class()));
+  msg.set_device_class(cover->get_device_class_ref());
   return fill_and_encode_entity_info(cover, msg, ListEntitiesCoverResponse::MESSAGE_TYPE, conn, remaining_size,
                                      is_single);
 }
@@ -469,7 +469,9 @@ uint16_t APIConnection::try_send_light_state(EntityBase *entity, APIConnection *
   resp.cold_white = values.get_cold_white();
   resp.warm_white = values.get_warm_white();
   if (light->supports_effects()) {
-    resp.set_effect(StringRef(light->get_effect_name()));
+    // get_effect_name() returns temporary std::string - must store it
+    std::string effect_name = light->get_effect_name();
+    resp.set_effect(StringRef(effect_name));
   }
   return fill_and_encode_entity_state(light, resp, LightStateResponse::MESSAGE_TYPE, conn, remaining_size, is_single);
 }
@@ -546,10 +548,10 @@ uint16_t APIConnection::try_send_sensor_info(EntityBase *entity, APIConnection *
                                              bool is_single) {
   auto *sensor = static_cast<sensor::Sensor *>(entity);
   ListEntitiesSensorResponse msg;
-  msg.set_unit_of_measurement(StringRef(sensor->get_unit_of_measurement()));
+  msg.set_unit_of_measurement(sensor->get_unit_of_measurement_ref());
   msg.accuracy_decimals = sensor->get_accuracy_decimals();
   msg.force_update = sensor->get_force_update();
-  msg.set_device_class(StringRef(sensor->get_device_class()));
+  msg.set_device_class(sensor->get_device_class_ref());
   msg.state_class = static_cast<enums::SensorStateClass>(sensor->get_state_class());
   return fill_and_encode_entity_info(sensor, msg, ListEntitiesSensorResponse::MESSAGE_TYPE, conn, remaining_size,
                                      is_single);
@@ -576,7 +578,7 @@ uint16_t APIConnection::try_send_switch_info(EntityBase *entity, APIConnection *
   auto *a_switch = static_cast<switch_::Switch *>(entity);
   ListEntitiesSwitchResponse msg;
   msg.assumed_state = a_switch->assumed_state();
-  msg.set_device_class(StringRef(a_switch->get_device_class()));
+  msg.set_device_class(a_switch->get_device_class_ref());
   return fill_and_encode_entity_info(a_switch, msg, ListEntitiesSwitchResponse::MESSAGE_TYPE, conn, remaining_size,
                                      is_single);
 }
@@ -610,7 +612,7 @@ uint16_t APIConnection::try_send_text_sensor_info(EntityBase *entity, APIConnect
                                                   bool is_single) {
   auto *text_sensor = static_cast<text_sensor::TextSensor *>(entity);
   ListEntitiesTextSensorResponse msg;
-  msg.set_device_class(StringRef(text_sensor->get_device_class()));
+  msg.set_device_class(text_sensor->get_device_class_ref());
   return fill_and_encode_entity_info(text_sensor, msg, ListEntitiesTextSensorResponse::MESSAGE_TYPE, conn,
                                      remaining_size, is_single);
 }
@@ -732,9 +734,9 @@ uint16_t APIConnection::try_send_number_info(EntityBase *entity, APIConnection *
                                              bool is_single) {
   auto *number = static_cast<number::Number *>(entity);
   ListEntitiesNumberResponse msg;
-  msg.set_unit_of_measurement(StringRef(number->traits.get_unit_of_measurement()));
+  msg.set_unit_of_measurement(number->traits.get_unit_of_measurement_ref());
   msg.mode = static_cast<enums::NumberMode>(number->traits.get_mode());
-  msg.set_device_class(StringRef(number->traits.get_device_class()));
+  msg.set_device_class(number->traits.get_device_class_ref());
   msg.min_value = number->traits.get_min_value();
   msg.max_value = number->traits.get_max_value();
   msg.step = number->traits.get_step();
@@ -859,7 +861,7 @@ uint16_t APIConnection::try_send_text_info(EntityBase *entity, APIConnection *co
   msg.mode = static_cast<enums::TextMode>(text->traits.get_mode());
   msg.min_length = text->traits.get_min_length();
   msg.max_length = text->traits.get_max_length();
-  msg.set_pattern(StringRef(text->traits.get_pattern()));
+  msg.set_pattern(text->traits.get_pattern_ref());
   return fill_and_encode_entity_info(text, msg, ListEntitiesTextResponse::MESSAGE_TYPE, conn, remaining_size,
                                      is_single);
 }
@@ -906,7 +908,7 @@ uint16_t APIConnection::try_send_button_info(EntityBase *entity, APIConnection *
                                              bool is_single) {
   auto *button = static_cast<button::Button *>(entity);
   ListEntitiesButtonResponse msg;
-  msg.set_device_class(StringRef(button->get_device_class()));
+  msg.set_device_class(button->get_device_class_ref());
   return fill_and_encode_entity_info(button, msg, ListEntitiesButtonResponse::MESSAGE_TYPE, conn, remaining_size,
                                      is_single);
 }
@@ -975,7 +977,7 @@ uint16_t APIConnection::try_send_valve_info(EntityBase *entity, APIConnection *c
   auto *valve = static_cast<valve::Valve *>(entity);
   ListEntitiesValveResponse msg;
   auto traits = valve->get_traits();
-  msg.set_device_class(StringRef(valve->get_device_class()));
+  msg.set_device_class(valve->get_device_class_ref());
   msg.assumed_state = traits.get_is_assumed_state();
   msg.supports_position = traits.get_supports_position();
   msg.supports_stop = traits.get_supports_stop();
@@ -1289,7 +1291,7 @@ uint16_t APIConnection::try_send_event_info(EntityBase *entity, APIConnection *c
                                             bool is_single) {
   auto *event = static_cast<event::Event *>(entity);
   ListEntitiesEventResponse msg;
-  msg.set_device_class(StringRef(event->get_device_class()));
+  msg.set_device_class(event->get_device_class_ref());
   for (const auto &event_type : event->get_event_types())
     msg.event_types.push_back(event_type);
   return fill_and_encode_entity_info(event, msg, ListEntitiesEventResponse::MESSAGE_TYPE, conn, remaining_size,
@@ -1325,7 +1327,7 @@ uint16_t APIConnection::try_send_update_info(EntityBase *entity, APIConnection *
                                              bool is_single) {
   auto *update = static_cast<update::UpdateEntity *>(entity);
   ListEntitiesUpdateResponse msg;
-  msg.set_device_class(StringRef(update->get_device_class()));
+  msg.set_device_class(update->get_device_class_ref());
   return fill_and_encode_entity_info(update, msg, ListEntitiesUpdateResponse::MESSAGE_TYPE, conn, remaining_size,
                                      is_single);
 }
@@ -1435,7 +1437,9 @@ bool APIConnection::send_device_info_response(const DeviceInfoRequest &msg) {
   std::string mac_address = get_mac_address_pretty();
   resp.set_mac_address(StringRef(mac_address));
   resp.set_esphome_version(StringRef(ESPHOME_VERSION));
-  resp.set_compilation_time(StringRef(App.get_compilation_time()));
+  // get_compilation_time() returns temporary std::string - must store it
+  std::string compilation_time = App.get_compilation_time();
+  resp.set_compilation_time(StringRef(compilation_time));
 #if defined(USE_ESP8266) || defined(USE_ESP32)
   resp.set_manufacturer(StringRef("Espressif"));
 #elif defined(USE_RP2040)

--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -1481,7 +1481,6 @@ bool APIConnection::send_device_info_response(const DeviceInfoRequest &msg) {
     resp.devices.emplace_back();
     auto &device_info = resp.devices.back();
     device_info.device_id = device->get_device_id();
-    // device->get_name() returns a reference to the device's name string
     device_info.set_name(StringRef(device->get_name()));
     device_info.area_id = device->get_area_id();
   }
@@ -1491,7 +1490,6 @@ bool APIConnection::send_device_info_response(const DeviceInfoRequest &msg) {
     resp.areas.emplace_back();
     auto &area_info = resp.areas.back();
     area_info.area_id = area->get_area_id();
-    // area->get_name() returns a reference to the area's name string
     area_info.set_name(StringRef(area->get_name()));
   }
 #endif

--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -1377,7 +1377,6 @@ void APIConnection::complete_authentication_() {
 }
 
 bool APIConnection::send_hello_response(const HelloRequest &msg) {
-  // Process the request first
   this->client_info_.name = msg.client_info;
   this->client_info_.peername = this->helper_->getpeername();
   this->client_api_version_major_ = msg.api_version_major;

--- a/esphome/components/api/api_connection.h
+++ b/esphome/components/api/api_connection.h
@@ -313,18 +313,15 @@ class APIConnection : public APIServerConnection {
                                               APIConnection *conn, uint32_t remaining_size, bool is_single) {
     // Set common fields that are shared by all entity types
     msg.key = entity->get_object_id_hash();
-    const std::string &object_id = entity->get_object_id();
-    msg.set_object_id(object_id.c_str(), object_id.length());
+    msg.set_object_id(StringRef(entity->get_object_id()));
 
     if (entity->has_own_name()) {
-      const std::string &name = entity->get_name();
-      msg.set_name(name.c_str(), name.length());
+      msg.set_name(StringRef(entity->get_name()));
     }
 
     // Set common EntityBase properties
 #ifdef USE_ENTITY_ICON
-    const std::string &icon = entity->get_icon();
-    msg.set_icon(icon.c_str(), icon.length());
+    msg.set_icon(StringRef(entity->get_icon()));
 #endif
     msg.disabled_by_default = entity->is_disabled_by_default();
     msg.entity_category = static_cast<enums::EntityCategory>(entity->get_entity_category());

--- a/esphome/components/api/api_connection.h
+++ b/esphome/components/api/api_connection.h
@@ -308,15 +308,17 @@ class APIConnection : public APIServerConnection {
                                               APIConnection *conn, uint32_t remaining_size, bool is_single) {
     // Set common fields that are shared by all entity types
     msg.key = entity->get_object_id_hash();
-    msg.set_object_id(StringRef(entity->get_object_id()));
+    // IMPORTANT: get_object_id() may return a temporary std::string
+    std::string object_id = entity->get_object_id();
+    msg.set_object_id(StringRef(object_id));
 
     if (entity->has_own_name()) {
-      msg.set_name(StringRef(entity->get_name()));
+      msg.set_name(entity->get_name());
     }
 
     // Set common EntityBase properties
 #ifdef USE_ENTITY_ICON
-    msg.set_icon(StringRef(entity->get_icon()));
+    msg.set_icon(entity->get_icon_ref());
 #endif
     msg.disabled_by_default = entity->is_disabled_by_default();
     msg.entity_category = static_cast<enums::EntityCategory>(entity->get_entity_category());

--- a/esphome/components/api/api_connection.h
+++ b/esphome/components/api/api_connection.h
@@ -148,8 +148,7 @@ class APIConnection : public APIServerConnection {
   void bluetooth_gatt_write_descriptor(const BluetoothGATTWriteDescriptorRequest &msg) override;
   void bluetooth_gatt_get_services(const BluetoothGATTGetServicesRequest &msg) override;
   void bluetooth_gatt_notify(const BluetoothGATTNotifyRequest &msg) override;
-  BluetoothConnectionsFreeResponse subscribe_bluetooth_connections_free(
-      const SubscribeBluetoothConnectionsFreeRequest &msg) override;
+  bool send_subscribe_bluetooth_connections_free_response(const SubscribeBluetoothConnectionsFreeRequest &msg) override;
   void bluetooth_scanner_set_mode(const BluetoothScannerSetModeRequest &msg) override;
 
 #endif
@@ -167,8 +166,7 @@ class APIConnection : public APIServerConnection {
   void on_voice_assistant_audio(const VoiceAssistantAudio &msg) override;
   void on_voice_assistant_timer_event_response(const VoiceAssistantTimerEventResponse &msg) override;
   void on_voice_assistant_announce_request(const VoiceAssistantAnnounceRequest &msg) override;
-  VoiceAssistantConfigurationResponse voice_assistant_get_configuration(
-      const VoiceAssistantConfigurationRequest &msg) override;
+  bool send_voice_assistant_get_configuration_response(const VoiceAssistantConfigurationRequest &msg) override;
   void voice_assistant_set_configuration(const VoiceAssistantSetConfiguration &msg) override;
 #endif
 
@@ -195,11 +193,11 @@ class APIConnection : public APIServerConnection {
 #ifdef USE_HOMEASSISTANT_TIME
   void on_get_time_response(const GetTimeResponse &value) override;
 #endif
-  HelloResponse hello(const HelloRequest &msg) override;
-  ConnectResponse connect(const ConnectRequest &msg) override;
-  DisconnectResponse disconnect(const DisconnectRequest &msg) override;
-  PingResponse ping(const PingRequest &msg) override { return {}; }
-  DeviceInfoResponse device_info(const DeviceInfoRequest &msg) override;
+  bool send_hello_response(const HelloRequest &msg) override;
+  bool send_connect_response(const ConnectRequest &msg) override;
+  bool send_disconnect_response(const DisconnectRequest &msg) override;
+  bool send_ping_response(const PingRequest &msg) override;
+  bool send_device_info_response(const DeviceInfoRequest &msg) override;
   void list_entities(const ListEntitiesRequest &msg) override { this->list_entities_iterator_.begin(); }
   void subscribe_states(const SubscribeStatesRequest &msg) override {
     this->flags_.state_subscription = true;
@@ -214,15 +212,12 @@ class APIConnection : public APIServerConnection {
     this->flags_.service_call_subscription = true;
   }
   void subscribe_home_assistant_states(const SubscribeHomeAssistantStatesRequest &msg) override;
-  GetTimeResponse get_time(const GetTimeRequest &msg) override {
-    // TODO
-    return {};
-  }
+  bool send_get_time_response(const GetTimeRequest &msg) override;
 #ifdef USE_API_SERVICES
   void execute_service(const ExecuteServiceRequest &msg) override;
 #endif
 #ifdef USE_API_NOISE
-  NoiseEncryptionSetKeyResponse noise_encryption_set_key(const NoiseEncryptionSetKeyRequest &msg) override;
+  bool send_noise_encryption_set_key_response(const NoiseEncryptionSetKeyRequest &msg) override;
 #endif
 
   bool is_authenticated() override {

--- a/esphome/components/api/api_connection.h
+++ b/esphome/components/api/api_connection.h
@@ -313,14 +313,18 @@ class APIConnection : public APIServerConnection {
                                               APIConnection *conn, uint32_t remaining_size, bool is_single) {
     // Set common fields that are shared by all entity types
     msg.key = entity->get_object_id_hash();
-    msg.object_id = entity->get_object_id();
+    const std::string &object_id = entity->get_object_id();
+    msg.set_object_id(object_id.c_str(), object_id.length());
 
-    if (entity->has_own_name())
-      msg.name = entity->get_name();
+    if (entity->has_own_name()) {
+      const std::string &name = entity->get_name();
+      msg.set_name(name.c_str(), name.length());
+    }
 
-      // Set common EntityBase properties
+    // Set common EntityBase properties
 #ifdef USE_ENTITY_ICON
-    msg.icon = entity->get_icon();
+    const std::string &icon = entity->get_icon();
+    msg.set_icon(icon.c_str(), icon.length());
 #endif
     msg.disabled_by_default = entity->is_disabled_by_default();
     msg.entity_category = static_cast<enums::EntityCategory>(entity->get_entity_category());

--- a/esphome/components/api/api_pb2.cpp
+++ b/esphome/components/api/api_pb2.cpp
@@ -356,7 +356,7 @@ void ListEntitiesFanResponse::calculate_size(uint32_t &total_size) const {
   ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->entity_category));
   if (!this->supported_preset_modes.empty()) {
     for (const auto &it : this->supported_preset_modes) {
-      ProtoSize::add_string_field(total_size, 1, it.length());
+      ProtoSize::add_string_field_repeated(total_size, 1, it);
     }
   }
 #ifdef USE_DEVICES
@@ -480,7 +480,7 @@ void ListEntitiesLightResponse::calculate_size(uint32_t &total_size) const {
   ProtoSize::add_float_field(total_size, 1, this->max_mireds);
   if (!this->effects.empty()) {
     for (const auto &it : this->effects) {
-      ProtoSize::add_string_field(total_size, 1, it.length());
+      ProtoSize::add_string_field_repeated(total_size, 1, it);
     }
   }
   ProtoSize::add_bool_field(total_size, 1, this->disabled_by_default);
@@ -1130,7 +1130,7 @@ void ListEntitiesClimateResponse::calculate_size(uint32_t &total_size) const {
   }
   if (!this->supported_custom_fan_modes.empty()) {
     for (const auto &it : this->supported_custom_fan_modes) {
-      ProtoSize::add_string_field(total_size, 1, it.length());
+      ProtoSize::add_string_field_repeated(total_size, 1, it);
     }
   }
   if (!this->supported_presets.empty()) {
@@ -1140,7 +1140,7 @@ void ListEntitiesClimateResponse::calculate_size(uint32_t &total_size) const {
   }
   if (!this->supported_custom_presets.empty()) {
     for (const auto &it : this->supported_custom_presets) {
-      ProtoSize::add_string_field(total_size, 2, it.length());
+      ProtoSize::add_string_field_repeated(total_size, 2, it);
     }
   }
   ProtoSize::add_bool_field(total_size, 2, this->disabled_by_default);
@@ -1392,7 +1392,7 @@ void ListEntitiesSelectResponse::calculate_size(uint32_t &total_size) const {
 #endif
   if (!this->options.empty()) {
     for (const auto &it : this->options) {
-      ProtoSize::add_string_field(total_size, 1, it.length());
+      ProtoSize::add_string_field_repeated(total_size, 1, it);
     }
   }
   ProtoSize::add_bool_field(total_size, 1, this->disabled_by_default);
@@ -1479,7 +1479,7 @@ void ListEntitiesSirenResponse::calculate_size(uint32_t &total_size) const {
   ProtoSize::add_bool_field(total_size, 1, this->disabled_by_default);
   if (!this->tones.empty()) {
     for (const auto &it : this->tones) {
-      ProtoSize::add_string_field(total_size, 1, it.length());
+      ProtoSize::add_string_field_repeated(total_size, 1, it);
     }
   }
   ProtoSize::add_bool_field(total_size, 1, this->supports_duration);
@@ -2347,7 +2347,7 @@ void VoiceAssistantWakeWord::calculate_size(uint32_t &total_size) const {
   ProtoSize::add_string_field(total_size, 1, this->wake_word_ref_.size());
   if (!this->trained_languages.empty()) {
     for (const auto &it : this->trained_languages) {
-      ProtoSize::add_string_field(total_size, 1, it.length());
+      ProtoSize::add_string_field_repeated(total_size, 1, it);
     }
   }
 }
@@ -2364,7 +2364,7 @@ void VoiceAssistantConfigurationResponse::calculate_size(uint32_t &total_size) c
   ProtoSize::add_repeated_message(total_size, 1, this->available_wake_words);
   if (!this->active_wake_words.empty()) {
     for (const auto &it : this->active_wake_words) {
-      ProtoSize::add_string_field(total_size, 1, it.length());
+      ProtoSize::add_string_field_repeated(total_size, 1, it);
     }
   }
   ProtoSize::add_uint32_field(total_size, 1, this->max_active_wake_words);
@@ -2735,7 +2735,7 @@ void ListEntitiesEventResponse::calculate_size(uint32_t &total_size) const {
   ProtoSize::add_string_field(total_size, 1, this->device_class_ref_.size());
   if (!this->event_types.empty()) {
     for (const auto &it : this->event_types) {
-      ProtoSize::add_string_field(total_size, 1, it.length());
+      ProtoSize::add_string_field_repeated(total_size, 1, it);
     }
   }
 #ifdef USE_DEVICES

--- a/esphome/components/api/api_pb2.cpp
+++ b/esphome/components/api/api_pb2.cpp
@@ -34,14 +34,14 @@ bool HelloRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value) 
 void HelloResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint32(1, this->api_version_major);
   buffer.encode_uint32(2, this->api_version_minor);
-  buffer.encode_string(3, this->server_info_ptr_, this->server_info_len_);
-  buffer.encode_string(4, this->name_ptr_, this->name_len_);
+  buffer.encode_string(3, this->server_info_ref_);
+  buffer.encode_string(4, this->name_ref_);
 }
 void HelloResponse::calculate_size(uint32_t &total_size) const {
   ProtoSize::add_uint32_field(total_size, 1, this->api_version_major);
   ProtoSize::add_uint32_field(total_size, 1, this->api_version_minor);
-  ProtoSize::add_string_field(total_size, 1, this->server_info_len_);
-  ProtoSize::add_string_field(total_size, 1, this->name_len_);
+  ProtoSize::add_string_field(total_size, 1, this->server_info_ref_.size());
+  ProtoSize::add_string_field(total_size, 1, this->name_ref_.size());
 }
 bool ConnectRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
@@ -60,22 +60,22 @@ void ConnectResponse::calculate_size(uint32_t &total_size) const {
 #ifdef USE_AREAS
 void AreaInfo::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint32(1, this->area_id);
-  buffer.encode_string(2, this->name_ptr_, this->name_len_);
+  buffer.encode_string(2, this->name_ref_);
 }
 void AreaInfo::calculate_size(uint32_t &total_size) const {
   ProtoSize::add_uint32_field(total_size, 1, this->area_id);
-  ProtoSize::add_string_field(total_size, 1, this->name_len_);
+  ProtoSize::add_string_field(total_size, 1, this->name_ref_.size());
 }
 #endif
 #ifdef USE_DEVICES
 void DeviceInfo::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint32(1, this->device_id);
-  buffer.encode_string(2, this->name_ptr_, this->name_len_);
+  buffer.encode_string(2, this->name_ref_);
   buffer.encode_uint32(3, this->area_id);
 }
 void DeviceInfo::calculate_size(uint32_t &total_size) const {
   ProtoSize::add_uint32_field(total_size, 1, this->device_id);
-  ProtoSize::add_string_field(total_size, 1, this->name_len_);
+  ProtoSize::add_string_field(total_size, 1, this->name_ref_.size());
   ProtoSize::add_uint32_field(total_size, 1, this->area_id);
 }
 #endif
@@ -83,19 +83,19 @@ void DeviceInfoResponse::encode(ProtoWriteBuffer buffer) const {
 #ifdef USE_API_PASSWORD
   buffer.encode_bool(1, this->uses_password);
 #endif
-  buffer.encode_string(2, this->name_ptr_, this->name_len_);
-  buffer.encode_string(3, this->mac_address_ptr_, this->mac_address_len_);
-  buffer.encode_string(4, this->esphome_version_ptr_, this->esphome_version_len_);
-  buffer.encode_string(5, this->compilation_time_ptr_, this->compilation_time_len_);
-  buffer.encode_string(6, this->model_ptr_, this->model_len_);
+  buffer.encode_string(2, this->name_ref_);
+  buffer.encode_string(3, this->mac_address_ref_);
+  buffer.encode_string(4, this->esphome_version_ref_);
+  buffer.encode_string(5, this->compilation_time_ref_);
+  buffer.encode_string(6, this->model_ref_);
 #ifdef USE_DEEP_SLEEP
   buffer.encode_bool(7, this->has_deep_sleep);
 #endif
 #ifdef ESPHOME_PROJECT_NAME
-  buffer.encode_string(8, this->project_name_ptr_, this->project_name_len_);
+  buffer.encode_string(8, this->project_name_ref_);
 #endif
 #ifdef ESPHOME_PROJECT_NAME
-  buffer.encode_string(9, this->project_version_ptr_, this->project_version_len_);
+  buffer.encode_string(9, this->project_version_ref_);
 #endif
 #ifdef USE_WEBSERVER
   buffer.encode_uint32(10, this->webserver_port);
@@ -103,16 +103,16 @@ void DeviceInfoResponse::encode(ProtoWriteBuffer buffer) const {
 #ifdef USE_BLUETOOTH_PROXY
   buffer.encode_uint32(15, this->bluetooth_proxy_feature_flags);
 #endif
-  buffer.encode_string(12, this->manufacturer_ptr_, this->manufacturer_len_);
-  buffer.encode_string(13, this->friendly_name_ptr_, this->friendly_name_len_);
+  buffer.encode_string(12, this->manufacturer_ref_);
+  buffer.encode_string(13, this->friendly_name_ref_);
 #ifdef USE_VOICE_ASSISTANT
   buffer.encode_uint32(17, this->voice_assistant_feature_flags);
 #endif
 #ifdef USE_AREAS
-  buffer.encode_string(16, this->suggested_area_ptr_, this->suggested_area_len_);
+  buffer.encode_string(16, this->suggested_area_ref_);
 #endif
 #ifdef USE_BLUETOOTH_PROXY
-  buffer.encode_string(18, this->bluetooth_mac_address_ptr_, this->bluetooth_mac_address_len_);
+  buffer.encode_string(18, this->bluetooth_mac_address_ref_);
 #endif
 #ifdef USE_API_NOISE
   buffer.encode_bool(19, this->api_encryption_supported);
@@ -135,19 +135,19 @@ void DeviceInfoResponse::calculate_size(uint32_t &total_size) const {
 #ifdef USE_API_PASSWORD
   ProtoSize::add_bool_field(total_size, 1, this->uses_password);
 #endif
-  ProtoSize::add_string_field(total_size, 1, this->name_len_);
-  ProtoSize::add_string_field(total_size, 1, this->mac_address_len_);
-  ProtoSize::add_string_field(total_size, 1, this->esphome_version_len_);
-  ProtoSize::add_string_field(total_size, 1, this->compilation_time_len_);
-  ProtoSize::add_string_field(total_size, 1, this->model_len_);
+  ProtoSize::add_string_field(total_size, 1, this->name_ref_.size());
+  ProtoSize::add_string_field(total_size, 1, this->mac_address_ref_.size());
+  ProtoSize::add_string_field(total_size, 1, this->esphome_version_ref_.size());
+  ProtoSize::add_string_field(total_size, 1, this->compilation_time_ref_.size());
+  ProtoSize::add_string_field(total_size, 1, this->model_ref_.size());
 #ifdef USE_DEEP_SLEEP
   ProtoSize::add_bool_field(total_size, 1, this->has_deep_sleep);
 #endif
 #ifdef ESPHOME_PROJECT_NAME
-  ProtoSize::add_string_field(total_size, 1, this->project_name_len_);
+  ProtoSize::add_string_field(total_size, 1, this->project_name_ref_.size());
 #endif
 #ifdef ESPHOME_PROJECT_NAME
-  ProtoSize::add_string_field(total_size, 1, this->project_version_len_);
+  ProtoSize::add_string_field(total_size, 1, this->project_version_ref_.size());
 #endif
 #ifdef USE_WEBSERVER
   ProtoSize::add_uint32_field(total_size, 1, this->webserver_port);
@@ -155,16 +155,16 @@ void DeviceInfoResponse::calculate_size(uint32_t &total_size) const {
 #ifdef USE_BLUETOOTH_PROXY
   ProtoSize::add_uint32_field(total_size, 1, this->bluetooth_proxy_feature_flags);
 #endif
-  ProtoSize::add_string_field(total_size, 1, this->manufacturer_len_);
-  ProtoSize::add_string_field(total_size, 1, this->friendly_name_len_);
+  ProtoSize::add_string_field(total_size, 1, this->manufacturer_ref_.size());
+  ProtoSize::add_string_field(total_size, 1, this->friendly_name_ref_.size());
 #ifdef USE_VOICE_ASSISTANT
   ProtoSize::add_uint32_field(total_size, 2, this->voice_assistant_feature_flags);
 #endif
 #ifdef USE_AREAS
-  ProtoSize::add_string_field(total_size, 2, this->suggested_area_len_);
+  ProtoSize::add_string_field(total_size, 2, this->suggested_area_ref_.size());
 #endif
 #ifdef USE_BLUETOOTH_PROXY
-  ProtoSize::add_string_field(total_size, 2, this->bluetooth_mac_address_len_);
+  ProtoSize::add_string_field(total_size, 2, this->bluetooth_mac_address_ref_.size());
 #endif
 #ifdef USE_API_NOISE
   ProtoSize::add_bool_field(total_size, 2, this->api_encryption_supported);
@@ -181,14 +181,14 @@ void DeviceInfoResponse::calculate_size(uint32_t &total_size) const {
 }
 #ifdef USE_BINARY_SENSOR
 void ListEntitiesBinarySensorResponse::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_string(1, this->object_id_ptr_, this->object_id_len_);
+  buffer.encode_string(1, this->object_id_ref_);
   buffer.encode_fixed32(2, this->key);
-  buffer.encode_string(3, this->name_ptr_, this->name_len_);
-  buffer.encode_string(5, this->device_class_ptr_, this->device_class_len_);
+  buffer.encode_string(3, this->name_ref_);
+  buffer.encode_string(5, this->device_class_ref_);
   buffer.encode_bool(6, this->is_status_binary_sensor);
   buffer.encode_bool(7, this->disabled_by_default);
 #ifdef USE_ENTITY_ICON
-  buffer.encode_string(8, this->icon_ptr_, this->icon_len_);
+  buffer.encode_string(8, this->icon_ref_);
 #endif
   buffer.encode_uint32(9, static_cast<uint32_t>(this->entity_category));
 #ifdef USE_DEVICES
@@ -196,14 +196,14 @@ void ListEntitiesBinarySensorResponse::encode(ProtoWriteBuffer buffer) const {
 #endif
 }
 void ListEntitiesBinarySensorResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_string_field(total_size, 1, this->object_id_len_);
+  ProtoSize::add_string_field(total_size, 1, this->object_id_ref_.size());
   ProtoSize::add_fixed32_field(total_size, 1, this->key);
-  ProtoSize::add_string_field(total_size, 1, this->name_len_);
-  ProtoSize::add_string_field(total_size, 1, this->device_class_len_);
+  ProtoSize::add_string_field(total_size, 1, this->name_ref_.size());
+  ProtoSize::add_string_field(total_size, 1, this->device_class_ref_.size());
   ProtoSize::add_bool_field(total_size, 1, this->is_status_binary_sensor);
   ProtoSize::add_bool_field(total_size, 1, this->disabled_by_default);
 #ifdef USE_ENTITY_ICON
-  ProtoSize::add_string_field(total_size, 1, this->icon_len_);
+  ProtoSize::add_string_field(total_size, 1, this->icon_ref_.size());
 #endif
   ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->entity_category));
 #ifdef USE_DEVICES
@@ -229,16 +229,16 @@ void BinarySensorStateResponse::calculate_size(uint32_t &total_size) const {
 #endif
 #ifdef USE_COVER
 void ListEntitiesCoverResponse::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_string(1, this->object_id_ptr_, this->object_id_len_);
+  buffer.encode_string(1, this->object_id_ref_);
   buffer.encode_fixed32(2, this->key);
-  buffer.encode_string(3, this->name_ptr_, this->name_len_);
+  buffer.encode_string(3, this->name_ref_);
   buffer.encode_bool(5, this->assumed_state);
   buffer.encode_bool(6, this->supports_position);
   buffer.encode_bool(7, this->supports_tilt);
-  buffer.encode_string(8, this->device_class_ptr_, this->device_class_len_);
+  buffer.encode_string(8, this->device_class_ref_);
   buffer.encode_bool(9, this->disabled_by_default);
 #ifdef USE_ENTITY_ICON
-  buffer.encode_string(10, this->icon_ptr_, this->icon_len_);
+  buffer.encode_string(10, this->icon_ref_);
 #endif
   buffer.encode_uint32(11, static_cast<uint32_t>(this->entity_category));
   buffer.encode_bool(12, this->supports_stop);
@@ -247,16 +247,16 @@ void ListEntitiesCoverResponse::encode(ProtoWriteBuffer buffer) const {
 #endif
 }
 void ListEntitiesCoverResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_string_field(total_size, 1, this->object_id_len_);
+  ProtoSize::add_string_field(total_size, 1, this->object_id_ref_.size());
   ProtoSize::add_fixed32_field(total_size, 1, this->key);
-  ProtoSize::add_string_field(total_size, 1, this->name_len_);
+  ProtoSize::add_string_field(total_size, 1, this->name_ref_.size());
   ProtoSize::add_bool_field(total_size, 1, this->assumed_state);
   ProtoSize::add_bool_field(total_size, 1, this->supports_position);
   ProtoSize::add_bool_field(total_size, 1, this->supports_tilt);
-  ProtoSize::add_string_field(total_size, 1, this->device_class_len_);
+  ProtoSize::add_string_field(total_size, 1, this->device_class_ref_.size());
   ProtoSize::add_bool_field(total_size, 1, this->disabled_by_default);
 #ifdef USE_ENTITY_ICON
-  ProtoSize::add_string_field(total_size, 1, this->icon_len_);
+  ProtoSize::add_string_field(total_size, 1, this->icon_ref_.size());
 #endif
   ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->entity_category));
   ProtoSize::add_bool_field(total_size, 1, this->supports_stop);
@@ -322,16 +322,16 @@ bool CoverCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
 #endif
 #ifdef USE_FAN
 void ListEntitiesFanResponse::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_string(1, this->object_id_ptr_, this->object_id_len_);
+  buffer.encode_string(1, this->object_id_ref_);
   buffer.encode_fixed32(2, this->key);
-  buffer.encode_string(3, this->name_ptr_, this->name_len_);
+  buffer.encode_string(3, this->name_ref_);
   buffer.encode_bool(5, this->supports_oscillation);
   buffer.encode_bool(6, this->supports_speed);
   buffer.encode_bool(7, this->supports_direction);
   buffer.encode_int32(8, this->supported_speed_count);
   buffer.encode_bool(9, this->disabled_by_default);
 #ifdef USE_ENTITY_ICON
-  buffer.encode_string(10, this->icon_ptr_, this->icon_len_);
+  buffer.encode_string(10, this->icon_ref_);
 #endif
   buffer.encode_uint32(11, static_cast<uint32_t>(this->entity_category));
   for (auto &it : this->supported_preset_modes) {
@@ -342,16 +342,16 @@ void ListEntitiesFanResponse::encode(ProtoWriteBuffer buffer) const {
 #endif
 }
 void ListEntitiesFanResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_string_field(total_size, 1, this->object_id_len_);
+  ProtoSize::add_string_field(total_size, 1, this->object_id_ref_.size());
   ProtoSize::add_fixed32_field(total_size, 1, this->key);
-  ProtoSize::add_string_field(total_size, 1, this->name_len_);
+  ProtoSize::add_string_field(total_size, 1, this->name_ref_.size());
   ProtoSize::add_bool_field(total_size, 1, this->supports_oscillation);
   ProtoSize::add_bool_field(total_size, 1, this->supports_speed);
   ProtoSize::add_bool_field(total_size, 1, this->supports_direction);
   ProtoSize::add_int32_field(total_size, 1, this->supported_speed_count);
   ProtoSize::add_bool_field(total_size, 1, this->disabled_by_default);
 #ifdef USE_ENTITY_ICON
-  ProtoSize::add_string_field(total_size, 1, this->icon_len_);
+  ProtoSize::add_string_field(total_size, 1, this->icon_ref_.size());
 #endif
   ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->entity_category));
   if (!this->supported_preset_modes.empty()) {
@@ -369,7 +369,7 @@ void FanStateResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_bool(3, this->oscillating);
   buffer.encode_uint32(5, static_cast<uint32_t>(this->direction));
   buffer.encode_int32(6, this->speed_level);
-  buffer.encode_string(7, this->preset_mode_ptr_, this->preset_mode_len_);
+  buffer.encode_string(7, this->preset_mode_ref_);
 #ifdef USE_DEVICES
   buffer.encode_uint32(8, this->device_id);
 #endif
@@ -380,7 +380,7 @@ void FanStateResponse::calculate_size(uint32_t &total_size) const {
   ProtoSize::add_bool_field(total_size, 1, this->oscillating);
   ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->direction));
   ProtoSize::add_int32_field(total_size, 1, this->speed_level);
-  ProtoSize::add_string_field(total_size, 1, this->preset_mode_len_);
+  ProtoSize::add_string_field(total_size, 1, this->preset_mode_ref_.size());
 #ifdef USE_DEVICES
   ProtoSize::add_uint32_field(total_size, 1, this->device_id);
 #endif
@@ -447,9 +447,9 @@ bool FanCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
 #endif
 #ifdef USE_LIGHT
 void ListEntitiesLightResponse::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_string(1, this->object_id_ptr_, this->object_id_len_);
+  buffer.encode_string(1, this->object_id_ref_);
   buffer.encode_fixed32(2, this->key);
-  buffer.encode_string(3, this->name_ptr_, this->name_len_);
+  buffer.encode_string(3, this->name_ref_);
   for (auto &it : this->supported_color_modes) {
     buffer.encode_uint32(12, static_cast<uint32_t>(it), true);
   }
@@ -460,7 +460,7 @@ void ListEntitiesLightResponse::encode(ProtoWriteBuffer buffer) const {
   }
   buffer.encode_bool(13, this->disabled_by_default);
 #ifdef USE_ENTITY_ICON
-  buffer.encode_string(14, this->icon_ptr_, this->icon_len_);
+  buffer.encode_string(14, this->icon_ref_);
 #endif
   buffer.encode_uint32(15, static_cast<uint32_t>(this->entity_category));
 #ifdef USE_DEVICES
@@ -468,9 +468,9 @@ void ListEntitiesLightResponse::encode(ProtoWriteBuffer buffer) const {
 #endif
 }
 void ListEntitiesLightResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_string_field(total_size, 1, this->object_id_len_);
+  ProtoSize::add_string_field(total_size, 1, this->object_id_ref_.size());
   ProtoSize::add_fixed32_field(total_size, 1, this->key);
-  ProtoSize::add_string_field(total_size, 1, this->name_len_);
+  ProtoSize::add_string_field(total_size, 1, this->name_ref_.size());
   if (!this->supported_color_modes.empty()) {
     for (const auto &it : this->supported_color_modes) {
       ProtoSize::add_enum_field_repeated(total_size, 1, static_cast<uint32_t>(it));
@@ -485,7 +485,7 @@ void ListEntitiesLightResponse::calculate_size(uint32_t &total_size) const {
   }
   ProtoSize::add_bool_field(total_size, 1, this->disabled_by_default);
 #ifdef USE_ENTITY_ICON
-  ProtoSize::add_string_field(total_size, 1, this->icon_len_);
+  ProtoSize::add_string_field(total_size, 1, this->icon_ref_.size());
 #endif
   ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->entity_category));
 #ifdef USE_DEVICES
@@ -505,7 +505,7 @@ void LightStateResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_float(8, this->color_temperature);
   buffer.encode_float(12, this->cold_white);
   buffer.encode_float(13, this->warm_white);
-  buffer.encode_string(9, this->effect_ptr_, this->effect_len_);
+  buffer.encode_string(9, this->effect_ref_);
 #ifdef USE_DEVICES
   buffer.encode_uint32(14, this->device_id);
 #endif
@@ -523,7 +523,7 @@ void LightStateResponse::calculate_size(uint32_t &total_size) const {
   ProtoSize::add_float_field(total_size, 1, this->color_temperature);
   ProtoSize::add_float_field(total_size, 1, this->cold_white);
   ProtoSize::add_float_field(total_size, 1, this->warm_white);
-  ProtoSize::add_string_field(total_size, 1, this->effect_len_);
+  ProtoSize::add_string_field(total_size, 1, this->effect_ref_.size());
 #ifdef USE_DEVICES
   ProtoSize::add_uint32_field(total_size, 1, this->device_id);
 #endif
@@ -638,16 +638,16 @@ bool LightCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
 #endif
 #ifdef USE_SENSOR
 void ListEntitiesSensorResponse::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_string(1, this->object_id_ptr_, this->object_id_len_);
+  buffer.encode_string(1, this->object_id_ref_);
   buffer.encode_fixed32(2, this->key);
-  buffer.encode_string(3, this->name_ptr_, this->name_len_);
+  buffer.encode_string(3, this->name_ref_);
 #ifdef USE_ENTITY_ICON
-  buffer.encode_string(5, this->icon_ptr_, this->icon_len_);
+  buffer.encode_string(5, this->icon_ref_);
 #endif
-  buffer.encode_string(6, this->unit_of_measurement_ptr_, this->unit_of_measurement_len_);
+  buffer.encode_string(6, this->unit_of_measurement_ref_);
   buffer.encode_int32(7, this->accuracy_decimals);
   buffer.encode_bool(8, this->force_update);
-  buffer.encode_string(9, this->device_class_ptr_, this->device_class_len_);
+  buffer.encode_string(9, this->device_class_ref_);
   buffer.encode_uint32(10, static_cast<uint32_t>(this->state_class));
   buffer.encode_bool(12, this->disabled_by_default);
   buffer.encode_uint32(13, static_cast<uint32_t>(this->entity_category));
@@ -656,16 +656,16 @@ void ListEntitiesSensorResponse::encode(ProtoWriteBuffer buffer) const {
 #endif
 }
 void ListEntitiesSensorResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_string_field(total_size, 1, this->object_id_len_);
+  ProtoSize::add_string_field(total_size, 1, this->object_id_ref_.size());
   ProtoSize::add_fixed32_field(total_size, 1, this->key);
-  ProtoSize::add_string_field(total_size, 1, this->name_len_);
+  ProtoSize::add_string_field(total_size, 1, this->name_ref_.size());
 #ifdef USE_ENTITY_ICON
-  ProtoSize::add_string_field(total_size, 1, this->icon_len_);
+  ProtoSize::add_string_field(total_size, 1, this->icon_ref_.size());
 #endif
-  ProtoSize::add_string_field(total_size, 1, this->unit_of_measurement_len_);
+  ProtoSize::add_string_field(total_size, 1, this->unit_of_measurement_ref_.size());
   ProtoSize::add_int32_field(total_size, 1, this->accuracy_decimals);
   ProtoSize::add_bool_field(total_size, 1, this->force_update);
-  ProtoSize::add_string_field(total_size, 1, this->device_class_len_);
+  ProtoSize::add_string_field(total_size, 1, this->device_class_ref_.size());
   ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->state_class));
   ProtoSize::add_bool_field(total_size, 1, this->disabled_by_default);
   ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->entity_category));
@@ -692,31 +692,31 @@ void SensorStateResponse::calculate_size(uint32_t &total_size) const {
 #endif
 #ifdef USE_SWITCH
 void ListEntitiesSwitchResponse::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_string(1, this->object_id_ptr_, this->object_id_len_);
+  buffer.encode_string(1, this->object_id_ref_);
   buffer.encode_fixed32(2, this->key);
-  buffer.encode_string(3, this->name_ptr_, this->name_len_);
+  buffer.encode_string(3, this->name_ref_);
 #ifdef USE_ENTITY_ICON
-  buffer.encode_string(5, this->icon_ptr_, this->icon_len_);
+  buffer.encode_string(5, this->icon_ref_);
 #endif
   buffer.encode_bool(6, this->assumed_state);
   buffer.encode_bool(7, this->disabled_by_default);
   buffer.encode_uint32(8, static_cast<uint32_t>(this->entity_category));
-  buffer.encode_string(9, this->device_class_ptr_, this->device_class_len_);
+  buffer.encode_string(9, this->device_class_ref_);
 #ifdef USE_DEVICES
   buffer.encode_uint32(10, this->device_id);
 #endif
 }
 void ListEntitiesSwitchResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_string_field(total_size, 1, this->object_id_len_);
+  ProtoSize::add_string_field(total_size, 1, this->object_id_ref_.size());
   ProtoSize::add_fixed32_field(total_size, 1, this->key);
-  ProtoSize::add_string_field(total_size, 1, this->name_len_);
+  ProtoSize::add_string_field(total_size, 1, this->name_ref_.size());
 #ifdef USE_ENTITY_ICON
-  ProtoSize::add_string_field(total_size, 1, this->icon_len_);
+  ProtoSize::add_string_field(total_size, 1, this->icon_ref_.size());
 #endif
   ProtoSize::add_bool_field(total_size, 1, this->assumed_state);
   ProtoSize::add_bool_field(total_size, 1, this->disabled_by_default);
   ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->entity_category));
-  ProtoSize::add_string_field(total_size, 1, this->device_class_len_);
+  ProtoSize::add_string_field(total_size, 1, this->device_class_ref_.size());
 #ifdef USE_DEVICES
   ProtoSize::add_uint32_field(total_size, 1, this->device_id);
 #endif
@@ -763,36 +763,36 @@ bool SwitchCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
 #endif
 #ifdef USE_TEXT_SENSOR
 void ListEntitiesTextSensorResponse::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_string(1, this->object_id_ptr_, this->object_id_len_);
+  buffer.encode_string(1, this->object_id_ref_);
   buffer.encode_fixed32(2, this->key);
-  buffer.encode_string(3, this->name_ptr_, this->name_len_);
+  buffer.encode_string(3, this->name_ref_);
 #ifdef USE_ENTITY_ICON
-  buffer.encode_string(5, this->icon_ptr_, this->icon_len_);
+  buffer.encode_string(5, this->icon_ref_);
 #endif
   buffer.encode_bool(6, this->disabled_by_default);
   buffer.encode_uint32(7, static_cast<uint32_t>(this->entity_category));
-  buffer.encode_string(8, this->device_class_ptr_, this->device_class_len_);
+  buffer.encode_string(8, this->device_class_ref_);
 #ifdef USE_DEVICES
   buffer.encode_uint32(9, this->device_id);
 #endif
 }
 void ListEntitiesTextSensorResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_string_field(total_size, 1, this->object_id_len_);
+  ProtoSize::add_string_field(total_size, 1, this->object_id_ref_.size());
   ProtoSize::add_fixed32_field(total_size, 1, this->key);
-  ProtoSize::add_string_field(total_size, 1, this->name_len_);
+  ProtoSize::add_string_field(total_size, 1, this->name_ref_.size());
 #ifdef USE_ENTITY_ICON
-  ProtoSize::add_string_field(total_size, 1, this->icon_len_);
+  ProtoSize::add_string_field(total_size, 1, this->icon_ref_.size());
 #endif
   ProtoSize::add_bool_field(total_size, 1, this->disabled_by_default);
   ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->entity_category));
-  ProtoSize::add_string_field(total_size, 1, this->device_class_len_);
+  ProtoSize::add_string_field(total_size, 1, this->device_class_ref_.size());
 #ifdef USE_DEVICES
   ProtoSize::add_uint32_field(total_size, 1, this->device_id);
 #endif
 }
 void TextSensorStateResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_fixed32(1, this->key);
-  buffer.encode_string(2, this->state_ptr_, this->state_len_);
+  buffer.encode_string(2, this->state_ref_);
   buffer.encode_bool(3, this->missing_state);
 #ifdef USE_DEVICES
   buffer.encode_uint32(4, this->device_id);
@@ -800,7 +800,7 @@ void TextSensorStateResponse::encode(ProtoWriteBuffer buffer) const {
 }
 void TextSensorStateResponse::calculate_size(uint32_t &total_size) const {
   ProtoSize::add_fixed32_field(total_size, 1, this->key);
-  ProtoSize::add_string_field(total_size, 1, this->state_len_);
+  ProtoSize::add_string_field(total_size, 1, this->state_ref_.size());
   ProtoSize::add_bool_field(total_size, 1, this->missing_state);
 #ifdef USE_DEVICES
   ProtoSize::add_uint32_field(total_size, 1, this->device_id);
@@ -845,15 +845,15 @@ void NoiseEncryptionSetKeyResponse::calculate_size(uint32_t &total_size) const {
 }
 #endif
 void HomeassistantServiceMap::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_string(1, this->key_ptr_, this->key_len_);
-  buffer.encode_string(2, this->value_ptr_, this->value_len_);
+  buffer.encode_string(1, this->key_ref_);
+  buffer.encode_string(2, this->value_ref_);
 }
 void HomeassistantServiceMap::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_string_field(total_size, 1, this->key_len_);
-  ProtoSize::add_string_field(total_size, 1, this->value_len_);
+  ProtoSize::add_string_field(total_size, 1, this->key_ref_.size());
+  ProtoSize::add_string_field(total_size, 1, this->value_ref_.size());
 }
 void HomeassistantServiceResponse::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_string(1, this->service_ptr_, this->service_len_);
+  buffer.encode_string(1, this->service_ref_);
   for (auto &it : this->data) {
     buffer.encode_message(2, it, true);
   }
@@ -866,20 +866,20 @@ void HomeassistantServiceResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_bool(5, this->is_event);
 }
 void HomeassistantServiceResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_string_field(total_size, 1, this->service_len_);
+  ProtoSize::add_string_field(total_size, 1, this->service_ref_.size());
   ProtoSize::add_repeated_message(total_size, 1, this->data);
   ProtoSize::add_repeated_message(total_size, 1, this->data_template);
   ProtoSize::add_repeated_message(total_size, 1, this->variables);
   ProtoSize::add_bool_field(total_size, 1, this->is_event);
 }
 void SubscribeHomeAssistantStateResponse::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_string(1, this->entity_id_ptr_, this->entity_id_len_);
-  buffer.encode_string(2, this->attribute_ptr_, this->attribute_len_);
+  buffer.encode_string(1, this->entity_id_ref_);
+  buffer.encode_string(2, this->attribute_ref_);
   buffer.encode_bool(3, this->once);
 }
 void SubscribeHomeAssistantStateResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_string_field(total_size, 1, this->entity_id_len_);
-  ProtoSize::add_string_field(total_size, 1, this->attribute_len_);
+  ProtoSize::add_string_field(total_size, 1, this->entity_id_ref_.size());
+  ProtoSize::add_string_field(total_size, 1, this->attribute_ref_.size());
   ProtoSize::add_bool_field(total_size, 1, this->once);
 }
 bool HomeAssistantStateResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
@@ -914,22 +914,22 @@ void GetTimeResponse::calculate_size(uint32_t &total_size) const {
 }
 #ifdef USE_API_SERVICES
 void ListEntitiesServicesArgument::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_string(1, this->name_ptr_, this->name_len_);
+  buffer.encode_string(1, this->name_ref_);
   buffer.encode_uint32(2, static_cast<uint32_t>(this->type));
 }
 void ListEntitiesServicesArgument::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_string_field(total_size, 1, this->name_len_);
+  ProtoSize::add_string_field(total_size, 1, this->name_ref_.size());
   ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->type));
 }
 void ListEntitiesServicesResponse::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_string(1, this->name_ptr_, this->name_len_);
+  buffer.encode_string(1, this->name_ref_);
   buffer.encode_fixed32(2, this->key);
   for (auto &it : this->args) {
     buffer.encode_message(3, it, true);
   }
 }
 void ListEntitiesServicesResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_string_field(total_size, 1, this->name_len_);
+  ProtoSize::add_string_field(total_size, 1, this->name_ref_.size());
   ProtoSize::add_fixed32_field(total_size, 1, this->key);
   ProtoSize::add_repeated_message(total_size, 1, this->args);
 }
@@ -1005,12 +1005,12 @@ bool ExecuteServiceRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
 #endif
 #ifdef USE_CAMERA
 void ListEntitiesCameraResponse::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_string(1, this->object_id_ptr_, this->object_id_len_);
+  buffer.encode_string(1, this->object_id_ref_);
   buffer.encode_fixed32(2, this->key);
-  buffer.encode_string(3, this->name_ptr_, this->name_len_);
+  buffer.encode_string(3, this->name_ref_);
   buffer.encode_bool(5, this->disabled_by_default);
 #ifdef USE_ENTITY_ICON
-  buffer.encode_string(6, this->icon_ptr_, this->icon_len_);
+  buffer.encode_string(6, this->icon_ref_);
 #endif
   buffer.encode_uint32(7, static_cast<uint32_t>(this->entity_category));
 #ifdef USE_DEVICES
@@ -1018,12 +1018,12 @@ void ListEntitiesCameraResponse::encode(ProtoWriteBuffer buffer) const {
 #endif
 }
 void ListEntitiesCameraResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_string_field(total_size, 1, this->object_id_len_);
+  ProtoSize::add_string_field(total_size, 1, this->object_id_ref_.size());
   ProtoSize::add_fixed32_field(total_size, 1, this->key);
-  ProtoSize::add_string_field(total_size, 1, this->name_len_);
+  ProtoSize::add_string_field(total_size, 1, this->name_ref_.size());
   ProtoSize::add_bool_field(total_size, 1, this->disabled_by_default);
 #ifdef USE_ENTITY_ICON
-  ProtoSize::add_string_field(total_size, 1, this->icon_len_);
+  ProtoSize::add_string_field(total_size, 1, this->icon_ref_.size());
 #endif
   ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->entity_category));
 #ifdef USE_DEVICES
@@ -1062,9 +1062,9 @@ bool CameraImageRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
 #endif
 #ifdef USE_CLIMATE
 void ListEntitiesClimateResponse::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_string(1, this->object_id_ptr_, this->object_id_len_);
+  buffer.encode_string(1, this->object_id_ref_);
   buffer.encode_fixed32(2, this->key);
-  buffer.encode_string(3, this->name_ptr_, this->name_len_);
+  buffer.encode_string(3, this->name_ref_);
   buffer.encode_bool(5, this->supports_current_temperature);
   buffer.encode_bool(6, this->supports_two_point_target_temperature);
   for (auto &it : this->supported_modes) {
@@ -1091,7 +1091,7 @@ void ListEntitiesClimateResponse::encode(ProtoWriteBuffer buffer) const {
   }
   buffer.encode_bool(18, this->disabled_by_default);
 #ifdef USE_ENTITY_ICON
-  buffer.encode_string(19, this->icon_ptr_, this->icon_len_);
+  buffer.encode_string(19, this->icon_ref_);
 #endif
   buffer.encode_uint32(20, static_cast<uint32_t>(this->entity_category));
   buffer.encode_float(21, this->visual_current_temperature_step);
@@ -1104,9 +1104,9 @@ void ListEntitiesClimateResponse::encode(ProtoWriteBuffer buffer) const {
 #endif
 }
 void ListEntitiesClimateResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_string_field(total_size, 1, this->object_id_len_);
+  ProtoSize::add_string_field(total_size, 1, this->object_id_ref_.size());
   ProtoSize::add_fixed32_field(total_size, 1, this->key);
-  ProtoSize::add_string_field(total_size, 1, this->name_len_);
+  ProtoSize::add_string_field(total_size, 1, this->name_ref_.size());
   ProtoSize::add_bool_field(total_size, 1, this->supports_current_temperature);
   ProtoSize::add_bool_field(total_size, 1, this->supports_two_point_target_temperature);
   if (!this->supported_modes.empty()) {
@@ -1145,7 +1145,7 @@ void ListEntitiesClimateResponse::calculate_size(uint32_t &total_size) const {
   }
   ProtoSize::add_bool_field(total_size, 2, this->disabled_by_default);
 #ifdef USE_ENTITY_ICON
-  ProtoSize::add_string_field(total_size, 2, this->icon_len_);
+  ProtoSize::add_string_field(total_size, 2, this->icon_ref_.size());
 #endif
   ProtoSize::add_enum_field(total_size, 2, static_cast<uint32_t>(this->entity_category));
   ProtoSize::add_float_field(total_size, 2, this->visual_current_temperature_step);
@@ -1167,9 +1167,9 @@ void ClimateStateResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint32(8, static_cast<uint32_t>(this->action));
   buffer.encode_uint32(9, static_cast<uint32_t>(this->fan_mode));
   buffer.encode_uint32(10, static_cast<uint32_t>(this->swing_mode));
-  buffer.encode_string(11, this->custom_fan_mode_ptr_, this->custom_fan_mode_len_);
+  buffer.encode_string(11, this->custom_fan_mode_ref_);
   buffer.encode_uint32(12, static_cast<uint32_t>(this->preset));
-  buffer.encode_string(13, this->custom_preset_ptr_, this->custom_preset_len_);
+  buffer.encode_string(13, this->custom_preset_ref_);
   buffer.encode_float(14, this->current_humidity);
   buffer.encode_float(15, this->target_humidity);
 #ifdef USE_DEVICES
@@ -1186,9 +1186,9 @@ void ClimateStateResponse::calculate_size(uint32_t &total_size) const {
   ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->action));
   ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->fan_mode));
   ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->swing_mode));
-  ProtoSize::add_string_field(total_size, 1, this->custom_fan_mode_len_);
+  ProtoSize::add_string_field(total_size, 1, this->custom_fan_mode_ref_.size());
   ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->preset));
-  ProtoSize::add_string_field(total_size, 1, this->custom_preset_len_);
+  ProtoSize::add_string_field(total_size, 1, this->custom_preset_ref_.size());
   ProtoSize::add_float_field(total_size, 1, this->current_humidity);
   ProtoSize::add_float_field(total_size, 1, this->target_humidity);
 #ifdef USE_DEVICES
@@ -1287,39 +1287,39 @@ bool ClimateCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
 #endif
 #ifdef USE_NUMBER
 void ListEntitiesNumberResponse::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_string(1, this->object_id_ptr_, this->object_id_len_);
+  buffer.encode_string(1, this->object_id_ref_);
   buffer.encode_fixed32(2, this->key);
-  buffer.encode_string(3, this->name_ptr_, this->name_len_);
+  buffer.encode_string(3, this->name_ref_);
 #ifdef USE_ENTITY_ICON
-  buffer.encode_string(5, this->icon_ptr_, this->icon_len_);
+  buffer.encode_string(5, this->icon_ref_);
 #endif
   buffer.encode_float(6, this->min_value);
   buffer.encode_float(7, this->max_value);
   buffer.encode_float(8, this->step);
   buffer.encode_bool(9, this->disabled_by_default);
   buffer.encode_uint32(10, static_cast<uint32_t>(this->entity_category));
-  buffer.encode_string(11, this->unit_of_measurement_ptr_, this->unit_of_measurement_len_);
+  buffer.encode_string(11, this->unit_of_measurement_ref_);
   buffer.encode_uint32(12, static_cast<uint32_t>(this->mode));
-  buffer.encode_string(13, this->device_class_ptr_, this->device_class_len_);
+  buffer.encode_string(13, this->device_class_ref_);
 #ifdef USE_DEVICES
   buffer.encode_uint32(14, this->device_id);
 #endif
 }
 void ListEntitiesNumberResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_string_field(total_size, 1, this->object_id_len_);
+  ProtoSize::add_string_field(total_size, 1, this->object_id_ref_.size());
   ProtoSize::add_fixed32_field(total_size, 1, this->key);
-  ProtoSize::add_string_field(total_size, 1, this->name_len_);
+  ProtoSize::add_string_field(total_size, 1, this->name_ref_.size());
 #ifdef USE_ENTITY_ICON
-  ProtoSize::add_string_field(total_size, 1, this->icon_len_);
+  ProtoSize::add_string_field(total_size, 1, this->icon_ref_.size());
 #endif
   ProtoSize::add_float_field(total_size, 1, this->min_value);
   ProtoSize::add_float_field(total_size, 1, this->max_value);
   ProtoSize::add_float_field(total_size, 1, this->step);
   ProtoSize::add_bool_field(total_size, 1, this->disabled_by_default);
   ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->entity_category));
-  ProtoSize::add_string_field(total_size, 1, this->unit_of_measurement_len_);
+  ProtoSize::add_string_field(total_size, 1, this->unit_of_measurement_ref_.size());
   ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->mode));
-  ProtoSize::add_string_field(total_size, 1, this->device_class_len_);
+  ProtoSize::add_string_field(total_size, 1, this->device_class_ref_.size());
 #ifdef USE_DEVICES
   ProtoSize::add_uint32_field(total_size, 1, this->device_id);
 #endif
@@ -1368,11 +1368,11 @@ bool NumberCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
 #endif
 #ifdef USE_SELECT
 void ListEntitiesSelectResponse::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_string(1, this->object_id_ptr_, this->object_id_len_);
+  buffer.encode_string(1, this->object_id_ref_);
   buffer.encode_fixed32(2, this->key);
-  buffer.encode_string(3, this->name_ptr_, this->name_len_);
+  buffer.encode_string(3, this->name_ref_);
 #ifdef USE_ENTITY_ICON
-  buffer.encode_string(5, this->icon_ptr_, this->icon_len_);
+  buffer.encode_string(5, this->icon_ref_);
 #endif
   for (auto &it : this->options) {
     buffer.encode_string(6, it, true);
@@ -1384,11 +1384,11 @@ void ListEntitiesSelectResponse::encode(ProtoWriteBuffer buffer) const {
 #endif
 }
 void ListEntitiesSelectResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_string_field(total_size, 1, this->object_id_len_);
+  ProtoSize::add_string_field(total_size, 1, this->object_id_ref_.size());
   ProtoSize::add_fixed32_field(total_size, 1, this->key);
-  ProtoSize::add_string_field(total_size, 1, this->name_len_);
+  ProtoSize::add_string_field(total_size, 1, this->name_ref_.size());
 #ifdef USE_ENTITY_ICON
-  ProtoSize::add_string_field(total_size, 1, this->icon_len_);
+  ProtoSize::add_string_field(total_size, 1, this->icon_ref_.size());
 #endif
   if (!this->options.empty()) {
     for (const auto &it : this->options) {
@@ -1403,7 +1403,7 @@ void ListEntitiesSelectResponse::calculate_size(uint32_t &total_size) const {
 }
 void SelectStateResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_fixed32(1, this->key);
-  buffer.encode_string(2, this->state_ptr_, this->state_len_);
+  buffer.encode_string(2, this->state_ref_);
   buffer.encode_bool(3, this->missing_state);
 #ifdef USE_DEVICES
   buffer.encode_uint32(4, this->device_id);
@@ -1411,7 +1411,7 @@ void SelectStateResponse::encode(ProtoWriteBuffer buffer) const {
 }
 void SelectStateResponse::calculate_size(uint32_t &total_size) const {
   ProtoSize::add_fixed32_field(total_size, 1, this->key);
-  ProtoSize::add_string_field(total_size, 1, this->state_len_);
+  ProtoSize::add_string_field(total_size, 1, this->state_ref_.size());
   ProtoSize::add_bool_field(total_size, 1, this->missing_state);
 #ifdef USE_DEVICES
   ProtoSize::add_uint32_field(total_size, 1, this->device_id);
@@ -1452,11 +1452,11 @@ bool SelectCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
 #endif
 #ifdef USE_SIREN
 void ListEntitiesSirenResponse::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_string(1, this->object_id_ptr_, this->object_id_len_);
+  buffer.encode_string(1, this->object_id_ref_);
   buffer.encode_fixed32(2, this->key);
-  buffer.encode_string(3, this->name_ptr_, this->name_len_);
+  buffer.encode_string(3, this->name_ref_);
 #ifdef USE_ENTITY_ICON
-  buffer.encode_string(5, this->icon_ptr_, this->icon_len_);
+  buffer.encode_string(5, this->icon_ref_);
 #endif
   buffer.encode_bool(6, this->disabled_by_default);
   for (auto &it : this->tones) {
@@ -1470,11 +1470,11 @@ void ListEntitiesSirenResponse::encode(ProtoWriteBuffer buffer) const {
 #endif
 }
 void ListEntitiesSirenResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_string_field(total_size, 1, this->object_id_len_);
+  ProtoSize::add_string_field(total_size, 1, this->object_id_ref_.size());
   ProtoSize::add_fixed32_field(total_size, 1, this->key);
-  ProtoSize::add_string_field(total_size, 1, this->name_len_);
+  ProtoSize::add_string_field(total_size, 1, this->name_ref_.size());
 #ifdef USE_ENTITY_ICON
-  ProtoSize::add_string_field(total_size, 1, this->icon_len_);
+  ProtoSize::add_string_field(total_size, 1, this->icon_ref_.size());
 #endif
   ProtoSize::add_bool_field(total_size, 1, this->disabled_by_default);
   if (!this->tones.empty()) {
@@ -1559,35 +1559,35 @@ bool SirenCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
 #endif
 #ifdef USE_LOCK
 void ListEntitiesLockResponse::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_string(1, this->object_id_ptr_, this->object_id_len_);
+  buffer.encode_string(1, this->object_id_ref_);
   buffer.encode_fixed32(2, this->key);
-  buffer.encode_string(3, this->name_ptr_, this->name_len_);
+  buffer.encode_string(3, this->name_ref_);
 #ifdef USE_ENTITY_ICON
-  buffer.encode_string(5, this->icon_ptr_, this->icon_len_);
+  buffer.encode_string(5, this->icon_ref_);
 #endif
   buffer.encode_bool(6, this->disabled_by_default);
   buffer.encode_uint32(7, static_cast<uint32_t>(this->entity_category));
   buffer.encode_bool(8, this->assumed_state);
   buffer.encode_bool(9, this->supports_open);
   buffer.encode_bool(10, this->requires_code);
-  buffer.encode_string(11, this->code_format_ptr_, this->code_format_len_);
+  buffer.encode_string(11, this->code_format_ref_);
 #ifdef USE_DEVICES
   buffer.encode_uint32(12, this->device_id);
 #endif
 }
 void ListEntitiesLockResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_string_field(total_size, 1, this->object_id_len_);
+  ProtoSize::add_string_field(total_size, 1, this->object_id_ref_.size());
   ProtoSize::add_fixed32_field(total_size, 1, this->key);
-  ProtoSize::add_string_field(total_size, 1, this->name_len_);
+  ProtoSize::add_string_field(total_size, 1, this->name_ref_.size());
 #ifdef USE_ENTITY_ICON
-  ProtoSize::add_string_field(total_size, 1, this->icon_len_);
+  ProtoSize::add_string_field(total_size, 1, this->icon_ref_.size());
 #endif
   ProtoSize::add_bool_field(total_size, 1, this->disabled_by_default);
   ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->entity_category));
   ProtoSize::add_bool_field(total_size, 1, this->assumed_state);
   ProtoSize::add_bool_field(total_size, 1, this->supports_open);
   ProtoSize::add_bool_field(total_size, 1, this->requires_code);
-  ProtoSize::add_string_field(total_size, 1, this->code_format_len_);
+  ProtoSize::add_string_field(total_size, 1, this->code_format_ref_.size());
 #ifdef USE_DEVICES
   ProtoSize::add_uint32_field(total_size, 1, this->device_id);
 #endif
@@ -1647,29 +1647,29 @@ bool LockCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
 #endif
 #ifdef USE_BUTTON
 void ListEntitiesButtonResponse::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_string(1, this->object_id_ptr_, this->object_id_len_);
+  buffer.encode_string(1, this->object_id_ref_);
   buffer.encode_fixed32(2, this->key);
-  buffer.encode_string(3, this->name_ptr_, this->name_len_);
+  buffer.encode_string(3, this->name_ref_);
 #ifdef USE_ENTITY_ICON
-  buffer.encode_string(5, this->icon_ptr_, this->icon_len_);
+  buffer.encode_string(5, this->icon_ref_);
 #endif
   buffer.encode_bool(6, this->disabled_by_default);
   buffer.encode_uint32(7, static_cast<uint32_t>(this->entity_category));
-  buffer.encode_string(8, this->device_class_ptr_, this->device_class_len_);
+  buffer.encode_string(8, this->device_class_ref_);
 #ifdef USE_DEVICES
   buffer.encode_uint32(9, this->device_id);
 #endif
 }
 void ListEntitiesButtonResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_string_field(total_size, 1, this->object_id_len_);
+  ProtoSize::add_string_field(total_size, 1, this->object_id_ref_.size());
   ProtoSize::add_fixed32_field(total_size, 1, this->key);
-  ProtoSize::add_string_field(total_size, 1, this->name_len_);
+  ProtoSize::add_string_field(total_size, 1, this->name_ref_.size());
 #ifdef USE_ENTITY_ICON
-  ProtoSize::add_string_field(total_size, 1, this->icon_len_);
+  ProtoSize::add_string_field(total_size, 1, this->icon_ref_.size());
 #endif
   ProtoSize::add_bool_field(total_size, 1, this->disabled_by_default);
   ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->entity_category));
-  ProtoSize::add_string_field(total_size, 1, this->device_class_len_);
+  ProtoSize::add_string_field(total_size, 1, this->device_class_ref_.size());
 #ifdef USE_DEVICES
   ProtoSize::add_uint32_field(total_size, 1, this->device_id);
 #endif
@@ -1699,25 +1699,25 @@ bool ButtonCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
 #endif
 #ifdef USE_MEDIA_PLAYER
 void MediaPlayerSupportedFormat::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_string(1, this->format_ptr_, this->format_len_);
+  buffer.encode_string(1, this->format_ref_);
   buffer.encode_uint32(2, this->sample_rate);
   buffer.encode_uint32(3, this->num_channels);
   buffer.encode_uint32(4, static_cast<uint32_t>(this->purpose));
   buffer.encode_uint32(5, this->sample_bytes);
 }
 void MediaPlayerSupportedFormat::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_string_field(total_size, 1, this->format_len_);
+  ProtoSize::add_string_field(total_size, 1, this->format_ref_.size());
   ProtoSize::add_uint32_field(total_size, 1, this->sample_rate);
   ProtoSize::add_uint32_field(total_size, 1, this->num_channels);
   ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->purpose));
   ProtoSize::add_uint32_field(total_size, 1, this->sample_bytes);
 }
 void ListEntitiesMediaPlayerResponse::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_string(1, this->object_id_ptr_, this->object_id_len_);
+  buffer.encode_string(1, this->object_id_ref_);
   buffer.encode_fixed32(2, this->key);
-  buffer.encode_string(3, this->name_ptr_, this->name_len_);
+  buffer.encode_string(3, this->name_ref_);
 #ifdef USE_ENTITY_ICON
-  buffer.encode_string(5, this->icon_ptr_, this->icon_len_);
+  buffer.encode_string(5, this->icon_ref_);
 #endif
   buffer.encode_bool(6, this->disabled_by_default);
   buffer.encode_uint32(7, static_cast<uint32_t>(this->entity_category));
@@ -1730,11 +1730,11 @@ void ListEntitiesMediaPlayerResponse::encode(ProtoWriteBuffer buffer) const {
 #endif
 }
 void ListEntitiesMediaPlayerResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_string_field(total_size, 1, this->object_id_len_);
+  ProtoSize::add_string_field(total_size, 1, this->object_id_ref_.size());
   ProtoSize::add_fixed32_field(total_size, 1, this->key);
-  ProtoSize::add_string_field(total_size, 1, this->name_len_);
+  ProtoSize::add_string_field(total_size, 1, this->name_ref_.size());
 #ifdef USE_ENTITY_ICON
-  ProtoSize::add_string_field(total_size, 1, this->icon_len_);
+  ProtoSize::add_string_field(total_size, 1, this->icon_ref_.size());
 #endif
   ProtoSize::add_bool_field(total_size, 1, this->disabled_by_default);
   ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->entity_category));
@@ -2186,17 +2186,17 @@ void VoiceAssistantAudioSettings::calculate_size(uint32_t &total_size) const {
 }
 void VoiceAssistantRequest::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_bool(1, this->start);
-  buffer.encode_string(2, this->conversation_id_ptr_, this->conversation_id_len_);
+  buffer.encode_string(2, this->conversation_id_ref_);
   buffer.encode_uint32(3, this->flags);
   buffer.encode_message(4, this->audio_settings);
-  buffer.encode_string(5, this->wake_word_phrase_ptr_, this->wake_word_phrase_len_);
+  buffer.encode_string(5, this->wake_word_phrase_ref_);
 }
 void VoiceAssistantRequest::calculate_size(uint32_t &total_size) const {
   ProtoSize::add_bool_field(total_size, 1, this->start);
-  ProtoSize::add_string_field(total_size, 1, this->conversation_id_len_);
+  ProtoSize::add_string_field(total_size, 1, this->conversation_id_ref_.size());
   ProtoSize::add_uint32_field(total_size, 1, this->flags);
   ProtoSize::add_message_object(total_size, 1, this->audio_settings);
-  ProtoSize::add_string_field(total_size, 1, this->wake_word_phrase_len_);
+  ProtoSize::add_string_field(total_size, 1, this->wake_word_phrase_ref_.size());
 }
 bool VoiceAssistantResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
@@ -2336,15 +2336,15 @@ void VoiceAssistantAnnounceFinished::calculate_size(uint32_t &total_size) const 
   ProtoSize::add_bool_field(total_size, 1, this->success);
 }
 void VoiceAssistantWakeWord::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_string(1, this->id_ptr_, this->id_len_);
-  buffer.encode_string(2, this->wake_word_ptr_, this->wake_word_len_);
+  buffer.encode_string(1, this->id_ref_);
+  buffer.encode_string(2, this->wake_word_ref_);
   for (auto &it : this->trained_languages) {
     buffer.encode_string(3, it, true);
   }
 }
 void VoiceAssistantWakeWord::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_string_field(total_size, 1, this->id_len_);
-  ProtoSize::add_string_field(total_size, 1, this->wake_word_len_);
+  ProtoSize::add_string_field(total_size, 1, this->id_ref_.size());
+  ProtoSize::add_string_field(total_size, 1, this->wake_word_ref_.size());
   if (!this->trained_languages.empty()) {
     for (const auto &it : this->trained_languages) {
       ProtoSize::add_string_field(total_size, 1, it.length());
@@ -2382,11 +2382,11 @@ bool VoiceAssistantSetConfiguration::decode_length(uint32_t field_id, ProtoLengt
 #endif
 #ifdef USE_ALARM_CONTROL_PANEL
 void ListEntitiesAlarmControlPanelResponse::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_string(1, this->object_id_ptr_, this->object_id_len_);
+  buffer.encode_string(1, this->object_id_ref_);
   buffer.encode_fixed32(2, this->key);
-  buffer.encode_string(3, this->name_ptr_, this->name_len_);
+  buffer.encode_string(3, this->name_ref_);
 #ifdef USE_ENTITY_ICON
-  buffer.encode_string(5, this->icon_ptr_, this->icon_len_);
+  buffer.encode_string(5, this->icon_ref_);
 #endif
   buffer.encode_bool(6, this->disabled_by_default);
   buffer.encode_uint32(7, static_cast<uint32_t>(this->entity_category));
@@ -2398,11 +2398,11 @@ void ListEntitiesAlarmControlPanelResponse::encode(ProtoWriteBuffer buffer) cons
 #endif
 }
 void ListEntitiesAlarmControlPanelResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_string_field(total_size, 1, this->object_id_len_);
+  ProtoSize::add_string_field(total_size, 1, this->object_id_ref_.size());
   ProtoSize::add_fixed32_field(total_size, 1, this->key);
-  ProtoSize::add_string_field(total_size, 1, this->name_len_);
+  ProtoSize::add_string_field(total_size, 1, this->name_ref_.size());
 #ifdef USE_ENTITY_ICON
-  ProtoSize::add_string_field(total_size, 1, this->icon_len_);
+  ProtoSize::add_string_field(total_size, 1, this->icon_ref_.size());
 #endif
   ProtoSize::add_bool_field(total_size, 1, this->disabled_by_default);
   ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->entity_category));
@@ -2465,34 +2465,34 @@ bool AlarmControlPanelCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit
 #endif
 #ifdef USE_TEXT
 void ListEntitiesTextResponse::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_string(1, this->object_id_ptr_, this->object_id_len_);
+  buffer.encode_string(1, this->object_id_ref_);
   buffer.encode_fixed32(2, this->key);
-  buffer.encode_string(3, this->name_ptr_, this->name_len_);
+  buffer.encode_string(3, this->name_ref_);
 #ifdef USE_ENTITY_ICON
-  buffer.encode_string(5, this->icon_ptr_, this->icon_len_);
+  buffer.encode_string(5, this->icon_ref_);
 #endif
   buffer.encode_bool(6, this->disabled_by_default);
   buffer.encode_uint32(7, static_cast<uint32_t>(this->entity_category));
   buffer.encode_uint32(8, this->min_length);
   buffer.encode_uint32(9, this->max_length);
-  buffer.encode_string(10, this->pattern_ptr_, this->pattern_len_);
+  buffer.encode_string(10, this->pattern_ref_);
   buffer.encode_uint32(11, static_cast<uint32_t>(this->mode));
 #ifdef USE_DEVICES
   buffer.encode_uint32(12, this->device_id);
 #endif
 }
 void ListEntitiesTextResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_string_field(total_size, 1, this->object_id_len_);
+  ProtoSize::add_string_field(total_size, 1, this->object_id_ref_.size());
   ProtoSize::add_fixed32_field(total_size, 1, this->key);
-  ProtoSize::add_string_field(total_size, 1, this->name_len_);
+  ProtoSize::add_string_field(total_size, 1, this->name_ref_.size());
 #ifdef USE_ENTITY_ICON
-  ProtoSize::add_string_field(total_size, 1, this->icon_len_);
+  ProtoSize::add_string_field(total_size, 1, this->icon_ref_.size());
 #endif
   ProtoSize::add_bool_field(total_size, 1, this->disabled_by_default);
   ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->entity_category));
   ProtoSize::add_uint32_field(total_size, 1, this->min_length);
   ProtoSize::add_uint32_field(total_size, 1, this->max_length);
-  ProtoSize::add_string_field(total_size, 1, this->pattern_len_);
+  ProtoSize::add_string_field(total_size, 1, this->pattern_ref_.size());
   ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->mode));
 #ifdef USE_DEVICES
   ProtoSize::add_uint32_field(total_size, 1, this->device_id);
@@ -2500,7 +2500,7 @@ void ListEntitiesTextResponse::calculate_size(uint32_t &total_size) const {
 }
 void TextStateResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_fixed32(1, this->key);
-  buffer.encode_string(2, this->state_ptr_, this->state_len_);
+  buffer.encode_string(2, this->state_ref_);
   buffer.encode_bool(3, this->missing_state);
 #ifdef USE_DEVICES
   buffer.encode_uint32(4, this->device_id);
@@ -2508,7 +2508,7 @@ void TextStateResponse::encode(ProtoWriteBuffer buffer) const {
 }
 void TextStateResponse::calculate_size(uint32_t &total_size) const {
   ProtoSize::add_fixed32_field(total_size, 1, this->key);
-  ProtoSize::add_string_field(total_size, 1, this->state_len_);
+  ProtoSize::add_string_field(total_size, 1, this->state_ref_.size());
   ProtoSize::add_bool_field(total_size, 1, this->missing_state);
 #ifdef USE_DEVICES
   ProtoSize::add_uint32_field(total_size, 1, this->device_id);
@@ -2549,11 +2549,11 @@ bool TextCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
 #endif
 #ifdef USE_DATETIME_DATE
 void ListEntitiesDateResponse::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_string(1, this->object_id_ptr_, this->object_id_len_);
+  buffer.encode_string(1, this->object_id_ref_);
   buffer.encode_fixed32(2, this->key);
-  buffer.encode_string(3, this->name_ptr_, this->name_len_);
+  buffer.encode_string(3, this->name_ref_);
 #ifdef USE_ENTITY_ICON
-  buffer.encode_string(5, this->icon_ptr_, this->icon_len_);
+  buffer.encode_string(5, this->icon_ref_);
 #endif
   buffer.encode_bool(6, this->disabled_by_default);
   buffer.encode_uint32(7, static_cast<uint32_t>(this->entity_category));
@@ -2562,11 +2562,11 @@ void ListEntitiesDateResponse::encode(ProtoWriteBuffer buffer) const {
 #endif
 }
 void ListEntitiesDateResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_string_field(total_size, 1, this->object_id_len_);
+  ProtoSize::add_string_field(total_size, 1, this->object_id_ref_.size());
   ProtoSize::add_fixed32_field(total_size, 1, this->key);
-  ProtoSize::add_string_field(total_size, 1, this->name_len_);
+  ProtoSize::add_string_field(total_size, 1, this->name_ref_.size());
 #ifdef USE_ENTITY_ICON
-  ProtoSize::add_string_field(total_size, 1, this->icon_len_);
+  ProtoSize::add_string_field(total_size, 1, this->icon_ref_.size());
 #endif
   ProtoSize::add_bool_field(total_size, 1, this->disabled_by_default);
   ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->entity_category));
@@ -2628,11 +2628,11 @@ bool DateCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
 #endif
 #ifdef USE_DATETIME_TIME
 void ListEntitiesTimeResponse::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_string(1, this->object_id_ptr_, this->object_id_len_);
+  buffer.encode_string(1, this->object_id_ref_);
   buffer.encode_fixed32(2, this->key);
-  buffer.encode_string(3, this->name_ptr_, this->name_len_);
+  buffer.encode_string(3, this->name_ref_);
 #ifdef USE_ENTITY_ICON
-  buffer.encode_string(5, this->icon_ptr_, this->icon_len_);
+  buffer.encode_string(5, this->icon_ref_);
 #endif
   buffer.encode_bool(6, this->disabled_by_default);
   buffer.encode_uint32(7, static_cast<uint32_t>(this->entity_category));
@@ -2641,11 +2641,11 @@ void ListEntitiesTimeResponse::encode(ProtoWriteBuffer buffer) const {
 #endif
 }
 void ListEntitiesTimeResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_string_field(total_size, 1, this->object_id_len_);
+  ProtoSize::add_string_field(total_size, 1, this->object_id_ref_.size());
   ProtoSize::add_fixed32_field(total_size, 1, this->key);
-  ProtoSize::add_string_field(total_size, 1, this->name_len_);
+  ProtoSize::add_string_field(total_size, 1, this->name_ref_.size());
 #ifdef USE_ENTITY_ICON
-  ProtoSize::add_string_field(total_size, 1, this->icon_len_);
+  ProtoSize::add_string_field(total_size, 1, this->icon_ref_.size());
 #endif
   ProtoSize::add_bool_field(total_size, 1, this->disabled_by_default);
   ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->entity_category));
@@ -2707,15 +2707,15 @@ bool TimeCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
 #endif
 #ifdef USE_EVENT
 void ListEntitiesEventResponse::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_string(1, this->object_id_ptr_, this->object_id_len_);
+  buffer.encode_string(1, this->object_id_ref_);
   buffer.encode_fixed32(2, this->key);
-  buffer.encode_string(3, this->name_ptr_, this->name_len_);
+  buffer.encode_string(3, this->name_ref_);
 #ifdef USE_ENTITY_ICON
-  buffer.encode_string(5, this->icon_ptr_, this->icon_len_);
+  buffer.encode_string(5, this->icon_ref_);
 #endif
   buffer.encode_bool(6, this->disabled_by_default);
   buffer.encode_uint32(7, static_cast<uint32_t>(this->entity_category));
-  buffer.encode_string(8, this->device_class_ptr_, this->device_class_len_);
+  buffer.encode_string(8, this->device_class_ref_);
   for (auto &it : this->event_types) {
     buffer.encode_string(9, it, true);
   }
@@ -2724,15 +2724,15 @@ void ListEntitiesEventResponse::encode(ProtoWriteBuffer buffer) const {
 #endif
 }
 void ListEntitiesEventResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_string_field(total_size, 1, this->object_id_len_);
+  ProtoSize::add_string_field(total_size, 1, this->object_id_ref_.size());
   ProtoSize::add_fixed32_field(total_size, 1, this->key);
-  ProtoSize::add_string_field(total_size, 1, this->name_len_);
+  ProtoSize::add_string_field(total_size, 1, this->name_ref_.size());
 #ifdef USE_ENTITY_ICON
-  ProtoSize::add_string_field(total_size, 1, this->icon_len_);
+  ProtoSize::add_string_field(total_size, 1, this->icon_ref_.size());
 #endif
   ProtoSize::add_bool_field(total_size, 1, this->disabled_by_default);
   ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->entity_category));
-  ProtoSize::add_string_field(total_size, 1, this->device_class_len_);
+  ProtoSize::add_string_field(total_size, 1, this->device_class_ref_.size());
   if (!this->event_types.empty()) {
     for (const auto &it : this->event_types) {
       ProtoSize::add_string_field(total_size, 1, it.length());
@@ -2744,14 +2744,14 @@ void ListEntitiesEventResponse::calculate_size(uint32_t &total_size) const {
 }
 void EventResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_fixed32(1, this->key);
-  buffer.encode_string(2, this->event_type_ptr_, this->event_type_len_);
+  buffer.encode_string(2, this->event_type_ref_);
 #ifdef USE_DEVICES
   buffer.encode_uint32(3, this->device_id);
 #endif
 }
 void EventResponse::calculate_size(uint32_t &total_size) const {
   ProtoSize::add_fixed32_field(total_size, 1, this->key);
-  ProtoSize::add_string_field(total_size, 1, this->event_type_len_);
+  ProtoSize::add_string_field(total_size, 1, this->event_type_ref_.size());
 #ifdef USE_DEVICES
   ProtoSize::add_uint32_field(total_size, 1, this->device_id);
 #endif
@@ -2759,15 +2759,15 @@ void EventResponse::calculate_size(uint32_t &total_size) const {
 #endif
 #ifdef USE_VALVE
 void ListEntitiesValveResponse::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_string(1, this->object_id_ptr_, this->object_id_len_);
+  buffer.encode_string(1, this->object_id_ref_);
   buffer.encode_fixed32(2, this->key);
-  buffer.encode_string(3, this->name_ptr_, this->name_len_);
+  buffer.encode_string(3, this->name_ref_);
 #ifdef USE_ENTITY_ICON
-  buffer.encode_string(5, this->icon_ptr_, this->icon_len_);
+  buffer.encode_string(5, this->icon_ref_);
 #endif
   buffer.encode_bool(6, this->disabled_by_default);
   buffer.encode_uint32(7, static_cast<uint32_t>(this->entity_category));
-  buffer.encode_string(8, this->device_class_ptr_, this->device_class_len_);
+  buffer.encode_string(8, this->device_class_ref_);
   buffer.encode_bool(9, this->assumed_state);
   buffer.encode_bool(10, this->supports_position);
   buffer.encode_bool(11, this->supports_stop);
@@ -2776,15 +2776,15 @@ void ListEntitiesValveResponse::encode(ProtoWriteBuffer buffer) const {
 #endif
 }
 void ListEntitiesValveResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_string_field(total_size, 1, this->object_id_len_);
+  ProtoSize::add_string_field(total_size, 1, this->object_id_ref_.size());
   ProtoSize::add_fixed32_field(total_size, 1, this->key);
-  ProtoSize::add_string_field(total_size, 1, this->name_len_);
+  ProtoSize::add_string_field(total_size, 1, this->name_ref_.size());
 #ifdef USE_ENTITY_ICON
-  ProtoSize::add_string_field(total_size, 1, this->icon_len_);
+  ProtoSize::add_string_field(total_size, 1, this->icon_ref_.size());
 #endif
   ProtoSize::add_bool_field(total_size, 1, this->disabled_by_default);
   ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->entity_category));
-  ProtoSize::add_string_field(total_size, 1, this->device_class_len_);
+  ProtoSize::add_string_field(total_size, 1, this->device_class_ref_.size());
   ProtoSize::add_bool_field(total_size, 1, this->assumed_state);
   ProtoSize::add_bool_field(total_size, 1, this->supports_position);
   ProtoSize::add_bool_field(total_size, 1, this->supports_stop);
@@ -2842,11 +2842,11 @@ bool ValveCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
 #endif
 #ifdef USE_DATETIME_DATETIME
 void ListEntitiesDateTimeResponse::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_string(1, this->object_id_ptr_, this->object_id_len_);
+  buffer.encode_string(1, this->object_id_ref_);
   buffer.encode_fixed32(2, this->key);
-  buffer.encode_string(3, this->name_ptr_, this->name_len_);
+  buffer.encode_string(3, this->name_ref_);
 #ifdef USE_ENTITY_ICON
-  buffer.encode_string(5, this->icon_ptr_, this->icon_len_);
+  buffer.encode_string(5, this->icon_ref_);
 #endif
   buffer.encode_bool(6, this->disabled_by_default);
   buffer.encode_uint32(7, static_cast<uint32_t>(this->entity_category));
@@ -2855,11 +2855,11 @@ void ListEntitiesDateTimeResponse::encode(ProtoWriteBuffer buffer) const {
 #endif
 }
 void ListEntitiesDateTimeResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_string_field(total_size, 1, this->object_id_len_);
+  ProtoSize::add_string_field(total_size, 1, this->object_id_ref_.size());
   ProtoSize::add_fixed32_field(total_size, 1, this->key);
-  ProtoSize::add_string_field(total_size, 1, this->name_len_);
+  ProtoSize::add_string_field(total_size, 1, this->name_ref_.size());
 #ifdef USE_ENTITY_ICON
-  ProtoSize::add_string_field(total_size, 1, this->icon_len_);
+  ProtoSize::add_string_field(total_size, 1, this->icon_ref_.size());
 #endif
   ProtoSize::add_bool_field(total_size, 1, this->disabled_by_default);
   ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->entity_category));
@@ -2911,29 +2911,29 @@ bool DateTimeCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
 #endif
 #ifdef USE_UPDATE
 void ListEntitiesUpdateResponse::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_string(1, this->object_id_ptr_, this->object_id_len_);
+  buffer.encode_string(1, this->object_id_ref_);
   buffer.encode_fixed32(2, this->key);
-  buffer.encode_string(3, this->name_ptr_, this->name_len_);
+  buffer.encode_string(3, this->name_ref_);
 #ifdef USE_ENTITY_ICON
-  buffer.encode_string(5, this->icon_ptr_, this->icon_len_);
+  buffer.encode_string(5, this->icon_ref_);
 #endif
   buffer.encode_bool(6, this->disabled_by_default);
   buffer.encode_uint32(7, static_cast<uint32_t>(this->entity_category));
-  buffer.encode_string(8, this->device_class_ptr_, this->device_class_len_);
+  buffer.encode_string(8, this->device_class_ref_);
 #ifdef USE_DEVICES
   buffer.encode_uint32(9, this->device_id);
 #endif
 }
 void ListEntitiesUpdateResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_string_field(total_size, 1, this->object_id_len_);
+  ProtoSize::add_string_field(total_size, 1, this->object_id_ref_.size());
   ProtoSize::add_fixed32_field(total_size, 1, this->key);
-  ProtoSize::add_string_field(total_size, 1, this->name_len_);
+  ProtoSize::add_string_field(total_size, 1, this->name_ref_.size());
 #ifdef USE_ENTITY_ICON
-  ProtoSize::add_string_field(total_size, 1, this->icon_len_);
+  ProtoSize::add_string_field(total_size, 1, this->icon_ref_.size());
 #endif
   ProtoSize::add_bool_field(total_size, 1, this->disabled_by_default);
   ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->entity_category));
-  ProtoSize::add_string_field(total_size, 1, this->device_class_len_);
+  ProtoSize::add_string_field(total_size, 1, this->device_class_ref_.size());
 #ifdef USE_DEVICES
   ProtoSize::add_uint32_field(total_size, 1, this->device_id);
 #endif
@@ -2944,11 +2944,11 @@ void UpdateStateResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_bool(3, this->in_progress);
   buffer.encode_bool(4, this->has_progress);
   buffer.encode_float(5, this->progress);
-  buffer.encode_string(6, this->current_version_ptr_, this->current_version_len_);
-  buffer.encode_string(7, this->latest_version_ptr_, this->latest_version_len_);
-  buffer.encode_string(8, this->title_ptr_, this->title_len_);
-  buffer.encode_string(9, this->release_summary_ptr_, this->release_summary_len_);
-  buffer.encode_string(10, this->release_url_ptr_, this->release_url_len_);
+  buffer.encode_string(6, this->current_version_ref_);
+  buffer.encode_string(7, this->latest_version_ref_);
+  buffer.encode_string(8, this->title_ref_);
+  buffer.encode_string(9, this->release_summary_ref_);
+  buffer.encode_string(10, this->release_url_ref_);
 #ifdef USE_DEVICES
   buffer.encode_uint32(11, this->device_id);
 #endif
@@ -2959,11 +2959,11 @@ void UpdateStateResponse::calculate_size(uint32_t &total_size) const {
   ProtoSize::add_bool_field(total_size, 1, this->in_progress);
   ProtoSize::add_bool_field(total_size, 1, this->has_progress);
   ProtoSize::add_float_field(total_size, 1, this->progress);
-  ProtoSize::add_string_field(total_size, 1, this->current_version_len_);
-  ProtoSize::add_string_field(total_size, 1, this->latest_version_len_);
-  ProtoSize::add_string_field(total_size, 1, this->title_len_);
-  ProtoSize::add_string_field(total_size, 1, this->release_summary_len_);
-  ProtoSize::add_string_field(total_size, 1, this->release_url_len_);
+  ProtoSize::add_string_field(total_size, 1, this->current_version_ref_.size());
+  ProtoSize::add_string_field(total_size, 1, this->latest_version_ref_.size());
+  ProtoSize::add_string_field(total_size, 1, this->title_ref_.size());
+  ProtoSize::add_string_field(total_size, 1, this->release_summary_ref_.size());
+  ProtoSize::add_string_field(total_size, 1, this->release_url_ref_.size());
 #ifdef USE_DEVICES
   ProtoSize::add_uint32_field(total_size, 1, this->device_id);
 #endif

--- a/esphome/components/api/api_pb2.cpp
+++ b/esphome/components/api/api_pb2.cpp
@@ -34,14 +34,14 @@ bool HelloRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value) 
 void HelloResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint32(1, this->api_version_major);
   buffer.encode_uint32(2, this->api_version_minor);
-  buffer.encode_string(3, this->server_info);
-  buffer.encode_string(4, this->name);
+  buffer.encode_string(3, this->server_info_ptr_, this->server_info_len_);
+  buffer.encode_string(4, this->name_ptr_, this->name_len_);
 }
 void HelloResponse::calculate_size(uint32_t &total_size) const {
   ProtoSize::add_uint32_field(total_size, 1, this->api_version_major);
   ProtoSize::add_uint32_field(total_size, 1, this->api_version_minor);
-  ProtoSize::add_string_field(total_size, 1, this->server_info);
-  ProtoSize::add_string_field(total_size, 1, this->name);
+  ProtoSize::add_string_field(total_size, 1, this->server_info_len_);
+  ProtoSize::add_string_field(total_size, 1, this->name_len_);
 }
 bool ConnectRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
@@ -60,22 +60,22 @@ void ConnectResponse::calculate_size(uint32_t &total_size) const {
 #ifdef USE_AREAS
 void AreaInfo::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint32(1, this->area_id);
-  buffer.encode_string(2, this->name);
+  buffer.encode_string(2, this->name_ptr_, this->name_len_);
 }
 void AreaInfo::calculate_size(uint32_t &total_size) const {
   ProtoSize::add_uint32_field(total_size, 1, this->area_id);
-  ProtoSize::add_string_field(total_size, 1, this->name);
+  ProtoSize::add_string_field(total_size, 1, this->name_len_);
 }
 #endif
 #ifdef USE_DEVICES
 void DeviceInfo::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint32(1, this->device_id);
-  buffer.encode_string(2, this->name);
+  buffer.encode_string(2, this->name_ptr_, this->name_len_);
   buffer.encode_uint32(3, this->area_id);
 }
 void DeviceInfo::calculate_size(uint32_t &total_size) const {
   ProtoSize::add_uint32_field(total_size, 1, this->device_id);
-  ProtoSize::add_string_field(total_size, 1, this->name);
+  ProtoSize::add_string_field(total_size, 1, this->name_len_);
   ProtoSize::add_uint32_field(total_size, 1, this->area_id);
 }
 #endif
@@ -83,19 +83,19 @@ void DeviceInfoResponse::encode(ProtoWriteBuffer buffer) const {
 #ifdef USE_API_PASSWORD
   buffer.encode_bool(1, this->uses_password);
 #endif
-  buffer.encode_string(2, this->name);
-  buffer.encode_string(3, this->mac_address);
-  buffer.encode_string(4, this->esphome_version);
-  buffer.encode_string(5, this->compilation_time);
-  buffer.encode_string(6, this->model);
+  buffer.encode_string(2, this->name_ptr_, this->name_len_);
+  buffer.encode_string(3, this->mac_address_ptr_, this->mac_address_len_);
+  buffer.encode_string(4, this->esphome_version_ptr_, this->esphome_version_len_);
+  buffer.encode_string(5, this->compilation_time_ptr_, this->compilation_time_len_);
+  buffer.encode_string(6, this->model_ptr_, this->model_len_);
 #ifdef USE_DEEP_SLEEP
   buffer.encode_bool(7, this->has_deep_sleep);
 #endif
 #ifdef ESPHOME_PROJECT_NAME
-  buffer.encode_string(8, this->project_name);
+  buffer.encode_string(8, this->project_name_ptr_, this->project_name_len_);
 #endif
 #ifdef ESPHOME_PROJECT_NAME
-  buffer.encode_string(9, this->project_version);
+  buffer.encode_string(9, this->project_version_ptr_, this->project_version_len_);
 #endif
 #ifdef USE_WEBSERVER
   buffer.encode_uint32(10, this->webserver_port);
@@ -103,16 +103,16 @@ void DeviceInfoResponse::encode(ProtoWriteBuffer buffer) const {
 #ifdef USE_BLUETOOTH_PROXY
   buffer.encode_uint32(15, this->bluetooth_proxy_feature_flags);
 #endif
-  buffer.encode_string(12, this->manufacturer);
-  buffer.encode_string(13, this->friendly_name);
+  buffer.encode_string(12, this->manufacturer_ptr_, this->manufacturer_len_);
+  buffer.encode_string(13, this->friendly_name_ptr_, this->friendly_name_len_);
 #ifdef USE_VOICE_ASSISTANT
   buffer.encode_uint32(17, this->voice_assistant_feature_flags);
 #endif
 #ifdef USE_AREAS
-  buffer.encode_string(16, this->suggested_area);
+  buffer.encode_string(16, this->suggested_area_ptr_, this->suggested_area_len_);
 #endif
 #ifdef USE_BLUETOOTH_PROXY
-  buffer.encode_string(18, this->bluetooth_mac_address);
+  buffer.encode_string(18, this->bluetooth_mac_address_ptr_, this->bluetooth_mac_address_len_);
 #endif
 #ifdef USE_API_NOISE
   buffer.encode_bool(19, this->api_encryption_supported);
@@ -135,19 +135,19 @@ void DeviceInfoResponse::calculate_size(uint32_t &total_size) const {
 #ifdef USE_API_PASSWORD
   ProtoSize::add_bool_field(total_size, 1, this->uses_password);
 #endif
-  ProtoSize::add_string_field(total_size, 1, this->name);
-  ProtoSize::add_string_field(total_size, 1, this->mac_address);
-  ProtoSize::add_string_field(total_size, 1, this->esphome_version);
-  ProtoSize::add_string_field(total_size, 1, this->compilation_time);
-  ProtoSize::add_string_field(total_size, 1, this->model);
+  ProtoSize::add_string_field(total_size, 1, this->name_len_);
+  ProtoSize::add_string_field(total_size, 1, this->mac_address_len_);
+  ProtoSize::add_string_field(total_size, 1, this->esphome_version_len_);
+  ProtoSize::add_string_field(total_size, 1, this->compilation_time_len_);
+  ProtoSize::add_string_field(total_size, 1, this->model_len_);
 #ifdef USE_DEEP_SLEEP
   ProtoSize::add_bool_field(total_size, 1, this->has_deep_sleep);
 #endif
 #ifdef ESPHOME_PROJECT_NAME
-  ProtoSize::add_string_field(total_size, 1, this->project_name);
+  ProtoSize::add_string_field(total_size, 1, this->project_name_len_);
 #endif
 #ifdef ESPHOME_PROJECT_NAME
-  ProtoSize::add_string_field(total_size, 1, this->project_version);
+  ProtoSize::add_string_field(total_size, 1, this->project_version_len_);
 #endif
 #ifdef USE_WEBSERVER
   ProtoSize::add_uint32_field(total_size, 1, this->webserver_port);
@@ -155,16 +155,16 @@ void DeviceInfoResponse::calculate_size(uint32_t &total_size) const {
 #ifdef USE_BLUETOOTH_PROXY
   ProtoSize::add_uint32_field(total_size, 1, this->bluetooth_proxy_feature_flags);
 #endif
-  ProtoSize::add_string_field(total_size, 1, this->manufacturer);
-  ProtoSize::add_string_field(total_size, 1, this->friendly_name);
+  ProtoSize::add_string_field(total_size, 1, this->manufacturer_len_);
+  ProtoSize::add_string_field(total_size, 1, this->friendly_name_len_);
 #ifdef USE_VOICE_ASSISTANT
   ProtoSize::add_uint32_field(total_size, 2, this->voice_assistant_feature_flags);
 #endif
 #ifdef USE_AREAS
-  ProtoSize::add_string_field(total_size, 2, this->suggested_area);
+  ProtoSize::add_string_field(total_size, 2, this->suggested_area_len_);
 #endif
 #ifdef USE_BLUETOOTH_PROXY
-  ProtoSize::add_string_field(total_size, 2, this->bluetooth_mac_address);
+  ProtoSize::add_string_field(total_size, 2, this->bluetooth_mac_address_len_);
 #endif
 #ifdef USE_API_NOISE
   ProtoSize::add_bool_field(total_size, 2, this->api_encryption_supported);
@@ -181,14 +181,14 @@ void DeviceInfoResponse::calculate_size(uint32_t &total_size) const {
 }
 #ifdef USE_BINARY_SENSOR
 void ListEntitiesBinarySensorResponse::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_string(1, this->object_id);
+  buffer.encode_string(1, this->object_id_ptr_, this->object_id_len_);
   buffer.encode_fixed32(2, this->key);
-  buffer.encode_string(3, this->name);
-  buffer.encode_string(5, this->device_class);
+  buffer.encode_string(3, this->name_ptr_, this->name_len_);
+  buffer.encode_string(5, this->device_class_ptr_, this->device_class_len_);
   buffer.encode_bool(6, this->is_status_binary_sensor);
   buffer.encode_bool(7, this->disabled_by_default);
 #ifdef USE_ENTITY_ICON
-  buffer.encode_string(8, this->icon);
+  buffer.encode_string(8, this->icon_ptr_, this->icon_len_);
 #endif
   buffer.encode_uint32(9, static_cast<uint32_t>(this->entity_category));
 #ifdef USE_DEVICES
@@ -196,14 +196,14 @@ void ListEntitiesBinarySensorResponse::encode(ProtoWriteBuffer buffer) const {
 #endif
 }
 void ListEntitiesBinarySensorResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_string_field(total_size, 1, this->object_id);
+  ProtoSize::add_string_field(total_size, 1, this->object_id_len_);
   ProtoSize::add_fixed32_field(total_size, 1, this->key);
-  ProtoSize::add_string_field(total_size, 1, this->name);
-  ProtoSize::add_string_field(total_size, 1, this->device_class);
+  ProtoSize::add_string_field(total_size, 1, this->name_len_);
+  ProtoSize::add_string_field(total_size, 1, this->device_class_len_);
   ProtoSize::add_bool_field(total_size, 1, this->is_status_binary_sensor);
   ProtoSize::add_bool_field(total_size, 1, this->disabled_by_default);
 #ifdef USE_ENTITY_ICON
-  ProtoSize::add_string_field(total_size, 1, this->icon);
+  ProtoSize::add_string_field(total_size, 1, this->icon_len_);
 #endif
   ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->entity_category));
 #ifdef USE_DEVICES
@@ -229,16 +229,16 @@ void BinarySensorStateResponse::calculate_size(uint32_t &total_size) const {
 #endif
 #ifdef USE_COVER
 void ListEntitiesCoverResponse::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_string(1, this->object_id);
+  buffer.encode_string(1, this->object_id_ptr_, this->object_id_len_);
   buffer.encode_fixed32(2, this->key);
-  buffer.encode_string(3, this->name);
+  buffer.encode_string(3, this->name_ptr_, this->name_len_);
   buffer.encode_bool(5, this->assumed_state);
   buffer.encode_bool(6, this->supports_position);
   buffer.encode_bool(7, this->supports_tilt);
-  buffer.encode_string(8, this->device_class);
+  buffer.encode_string(8, this->device_class_ptr_, this->device_class_len_);
   buffer.encode_bool(9, this->disabled_by_default);
 #ifdef USE_ENTITY_ICON
-  buffer.encode_string(10, this->icon);
+  buffer.encode_string(10, this->icon_ptr_, this->icon_len_);
 #endif
   buffer.encode_uint32(11, static_cast<uint32_t>(this->entity_category));
   buffer.encode_bool(12, this->supports_stop);
@@ -247,16 +247,16 @@ void ListEntitiesCoverResponse::encode(ProtoWriteBuffer buffer) const {
 #endif
 }
 void ListEntitiesCoverResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_string_field(total_size, 1, this->object_id);
+  ProtoSize::add_string_field(total_size, 1, this->object_id_len_);
   ProtoSize::add_fixed32_field(total_size, 1, this->key);
-  ProtoSize::add_string_field(total_size, 1, this->name);
+  ProtoSize::add_string_field(total_size, 1, this->name_len_);
   ProtoSize::add_bool_field(total_size, 1, this->assumed_state);
   ProtoSize::add_bool_field(total_size, 1, this->supports_position);
   ProtoSize::add_bool_field(total_size, 1, this->supports_tilt);
-  ProtoSize::add_string_field(total_size, 1, this->device_class);
+  ProtoSize::add_string_field(total_size, 1, this->device_class_len_);
   ProtoSize::add_bool_field(total_size, 1, this->disabled_by_default);
 #ifdef USE_ENTITY_ICON
-  ProtoSize::add_string_field(total_size, 1, this->icon);
+  ProtoSize::add_string_field(total_size, 1, this->icon_len_);
 #endif
   ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->entity_category));
   ProtoSize::add_bool_field(total_size, 1, this->supports_stop);
@@ -322,16 +322,16 @@ bool CoverCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
 #endif
 #ifdef USE_FAN
 void ListEntitiesFanResponse::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_string(1, this->object_id);
+  buffer.encode_string(1, this->object_id_ptr_, this->object_id_len_);
   buffer.encode_fixed32(2, this->key);
-  buffer.encode_string(3, this->name);
+  buffer.encode_string(3, this->name_ptr_, this->name_len_);
   buffer.encode_bool(5, this->supports_oscillation);
   buffer.encode_bool(6, this->supports_speed);
   buffer.encode_bool(7, this->supports_direction);
   buffer.encode_int32(8, this->supported_speed_count);
   buffer.encode_bool(9, this->disabled_by_default);
 #ifdef USE_ENTITY_ICON
-  buffer.encode_string(10, this->icon);
+  buffer.encode_string(10, this->icon_ptr_, this->icon_len_);
 #endif
   buffer.encode_uint32(11, static_cast<uint32_t>(this->entity_category));
   for (auto &it : this->supported_preset_modes) {
@@ -342,21 +342,21 @@ void ListEntitiesFanResponse::encode(ProtoWriteBuffer buffer) const {
 #endif
 }
 void ListEntitiesFanResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_string_field(total_size, 1, this->object_id);
+  ProtoSize::add_string_field(total_size, 1, this->object_id_len_);
   ProtoSize::add_fixed32_field(total_size, 1, this->key);
-  ProtoSize::add_string_field(total_size, 1, this->name);
+  ProtoSize::add_string_field(total_size, 1, this->name_len_);
   ProtoSize::add_bool_field(total_size, 1, this->supports_oscillation);
   ProtoSize::add_bool_field(total_size, 1, this->supports_speed);
   ProtoSize::add_bool_field(total_size, 1, this->supports_direction);
   ProtoSize::add_int32_field(total_size, 1, this->supported_speed_count);
   ProtoSize::add_bool_field(total_size, 1, this->disabled_by_default);
 #ifdef USE_ENTITY_ICON
-  ProtoSize::add_string_field(total_size, 1, this->icon);
+  ProtoSize::add_string_field(total_size, 1, this->icon_len_);
 #endif
   ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->entity_category));
   if (!this->supported_preset_modes.empty()) {
     for (const auto &it : this->supported_preset_modes) {
-      ProtoSize::add_string_field_repeated(total_size, 1, it);
+      ProtoSize::add_string_field(total_size, 1, it.length());
     }
   }
 #ifdef USE_DEVICES
@@ -369,7 +369,7 @@ void FanStateResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_bool(3, this->oscillating);
   buffer.encode_uint32(5, static_cast<uint32_t>(this->direction));
   buffer.encode_int32(6, this->speed_level);
-  buffer.encode_string(7, this->preset_mode);
+  buffer.encode_string(7, this->preset_mode_ptr_, this->preset_mode_len_);
 #ifdef USE_DEVICES
   buffer.encode_uint32(8, this->device_id);
 #endif
@@ -380,7 +380,7 @@ void FanStateResponse::calculate_size(uint32_t &total_size) const {
   ProtoSize::add_bool_field(total_size, 1, this->oscillating);
   ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->direction));
   ProtoSize::add_int32_field(total_size, 1, this->speed_level);
-  ProtoSize::add_string_field(total_size, 1, this->preset_mode);
+  ProtoSize::add_string_field(total_size, 1, this->preset_mode_len_);
 #ifdef USE_DEVICES
   ProtoSize::add_uint32_field(total_size, 1, this->device_id);
 #endif
@@ -447,9 +447,9 @@ bool FanCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
 #endif
 #ifdef USE_LIGHT
 void ListEntitiesLightResponse::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_string(1, this->object_id);
+  buffer.encode_string(1, this->object_id_ptr_, this->object_id_len_);
   buffer.encode_fixed32(2, this->key);
-  buffer.encode_string(3, this->name);
+  buffer.encode_string(3, this->name_ptr_, this->name_len_);
   for (auto &it : this->supported_color_modes) {
     buffer.encode_uint32(12, static_cast<uint32_t>(it), true);
   }
@@ -460,7 +460,7 @@ void ListEntitiesLightResponse::encode(ProtoWriteBuffer buffer) const {
   }
   buffer.encode_bool(13, this->disabled_by_default);
 #ifdef USE_ENTITY_ICON
-  buffer.encode_string(14, this->icon);
+  buffer.encode_string(14, this->icon_ptr_, this->icon_len_);
 #endif
   buffer.encode_uint32(15, static_cast<uint32_t>(this->entity_category));
 #ifdef USE_DEVICES
@@ -468,9 +468,9 @@ void ListEntitiesLightResponse::encode(ProtoWriteBuffer buffer) const {
 #endif
 }
 void ListEntitiesLightResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_string_field(total_size, 1, this->object_id);
+  ProtoSize::add_string_field(total_size, 1, this->object_id_len_);
   ProtoSize::add_fixed32_field(total_size, 1, this->key);
-  ProtoSize::add_string_field(total_size, 1, this->name);
+  ProtoSize::add_string_field(total_size, 1, this->name_len_);
   if (!this->supported_color_modes.empty()) {
     for (const auto &it : this->supported_color_modes) {
       ProtoSize::add_enum_field_repeated(total_size, 1, static_cast<uint32_t>(it));
@@ -480,12 +480,12 @@ void ListEntitiesLightResponse::calculate_size(uint32_t &total_size) const {
   ProtoSize::add_float_field(total_size, 1, this->max_mireds);
   if (!this->effects.empty()) {
     for (const auto &it : this->effects) {
-      ProtoSize::add_string_field_repeated(total_size, 1, it);
+      ProtoSize::add_string_field(total_size, 1, it.length());
     }
   }
   ProtoSize::add_bool_field(total_size, 1, this->disabled_by_default);
 #ifdef USE_ENTITY_ICON
-  ProtoSize::add_string_field(total_size, 1, this->icon);
+  ProtoSize::add_string_field(total_size, 1, this->icon_len_);
 #endif
   ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->entity_category));
 #ifdef USE_DEVICES
@@ -505,7 +505,7 @@ void LightStateResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_float(8, this->color_temperature);
   buffer.encode_float(12, this->cold_white);
   buffer.encode_float(13, this->warm_white);
-  buffer.encode_string(9, this->effect);
+  buffer.encode_string(9, this->effect_ptr_, this->effect_len_);
 #ifdef USE_DEVICES
   buffer.encode_uint32(14, this->device_id);
 #endif
@@ -523,7 +523,7 @@ void LightStateResponse::calculate_size(uint32_t &total_size) const {
   ProtoSize::add_float_field(total_size, 1, this->color_temperature);
   ProtoSize::add_float_field(total_size, 1, this->cold_white);
   ProtoSize::add_float_field(total_size, 1, this->warm_white);
-  ProtoSize::add_string_field(total_size, 1, this->effect);
+  ProtoSize::add_string_field(total_size, 1, this->effect_len_);
 #ifdef USE_DEVICES
   ProtoSize::add_uint32_field(total_size, 1, this->device_id);
 #endif
@@ -638,16 +638,16 @@ bool LightCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
 #endif
 #ifdef USE_SENSOR
 void ListEntitiesSensorResponse::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_string(1, this->object_id);
+  buffer.encode_string(1, this->object_id_ptr_, this->object_id_len_);
   buffer.encode_fixed32(2, this->key);
-  buffer.encode_string(3, this->name);
+  buffer.encode_string(3, this->name_ptr_, this->name_len_);
 #ifdef USE_ENTITY_ICON
-  buffer.encode_string(5, this->icon);
+  buffer.encode_string(5, this->icon_ptr_, this->icon_len_);
 #endif
-  buffer.encode_string(6, this->unit_of_measurement);
+  buffer.encode_string(6, this->unit_of_measurement_ptr_, this->unit_of_measurement_len_);
   buffer.encode_int32(7, this->accuracy_decimals);
   buffer.encode_bool(8, this->force_update);
-  buffer.encode_string(9, this->device_class);
+  buffer.encode_string(9, this->device_class_ptr_, this->device_class_len_);
   buffer.encode_uint32(10, static_cast<uint32_t>(this->state_class));
   buffer.encode_bool(12, this->disabled_by_default);
   buffer.encode_uint32(13, static_cast<uint32_t>(this->entity_category));
@@ -656,16 +656,16 @@ void ListEntitiesSensorResponse::encode(ProtoWriteBuffer buffer) const {
 #endif
 }
 void ListEntitiesSensorResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_string_field(total_size, 1, this->object_id);
+  ProtoSize::add_string_field(total_size, 1, this->object_id_len_);
   ProtoSize::add_fixed32_field(total_size, 1, this->key);
-  ProtoSize::add_string_field(total_size, 1, this->name);
+  ProtoSize::add_string_field(total_size, 1, this->name_len_);
 #ifdef USE_ENTITY_ICON
-  ProtoSize::add_string_field(total_size, 1, this->icon);
+  ProtoSize::add_string_field(total_size, 1, this->icon_len_);
 #endif
-  ProtoSize::add_string_field(total_size, 1, this->unit_of_measurement);
+  ProtoSize::add_string_field(total_size, 1, this->unit_of_measurement_len_);
   ProtoSize::add_int32_field(total_size, 1, this->accuracy_decimals);
   ProtoSize::add_bool_field(total_size, 1, this->force_update);
-  ProtoSize::add_string_field(total_size, 1, this->device_class);
+  ProtoSize::add_string_field(total_size, 1, this->device_class_len_);
   ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->state_class));
   ProtoSize::add_bool_field(total_size, 1, this->disabled_by_default);
   ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->entity_category));
@@ -692,31 +692,31 @@ void SensorStateResponse::calculate_size(uint32_t &total_size) const {
 #endif
 #ifdef USE_SWITCH
 void ListEntitiesSwitchResponse::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_string(1, this->object_id);
+  buffer.encode_string(1, this->object_id_ptr_, this->object_id_len_);
   buffer.encode_fixed32(2, this->key);
-  buffer.encode_string(3, this->name);
+  buffer.encode_string(3, this->name_ptr_, this->name_len_);
 #ifdef USE_ENTITY_ICON
-  buffer.encode_string(5, this->icon);
+  buffer.encode_string(5, this->icon_ptr_, this->icon_len_);
 #endif
   buffer.encode_bool(6, this->assumed_state);
   buffer.encode_bool(7, this->disabled_by_default);
   buffer.encode_uint32(8, static_cast<uint32_t>(this->entity_category));
-  buffer.encode_string(9, this->device_class);
+  buffer.encode_string(9, this->device_class_ptr_, this->device_class_len_);
 #ifdef USE_DEVICES
   buffer.encode_uint32(10, this->device_id);
 #endif
 }
 void ListEntitiesSwitchResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_string_field(total_size, 1, this->object_id);
+  ProtoSize::add_string_field(total_size, 1, this->object_id_len_);
   ProtoSize::add_fixed32_field(total_size, 1, this->key);
-  ProtoSize::add_string_field(total_size, 1, this->name);
+  ProtoSize::add_string_field(total_size, 1, this->name_len_);
 #ifdef USE_ENTITY_ICON
-  ProtoSize::add_string_field(total_size, 1, this->icon);
+  ProtoSize::add_string_field(total_size, 1, this->icon_len_);
 #endif
   ProtoSize::add_bool_field(total_size, 1, this->assumed_state);
   ProtoSize::add_bool_field(total_size, 1, this->disabled_by_default);
   ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->entity_category));
-  ProtoSize::add_string_field(total_size, 1, this->device_class);
+  ProtoSize::add_string_field(total_size, 1, this->device_class_len_);
 #ifdef USE_DEVICES
   ProtoSize::add_uint32_field(total_size, 1, this->device_id);
 #endif
@@ -763,36 +763,36 @@ bool SwitchCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
 #endif
 #ifdef USE_TEXT_SENSOR
 void ListEntitiesTextSensorResponse::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_string(1, this->object_id);
+  buffer.encode_string(1, this->object_id_ptr_, this->object_id_len_);
   buffer.encode_fixed32(2, this->key);
-  buffer.encode_string(3, this->name);
+  buffer.encode_string(3, this->name_ptr_, this->name_len_);
 #ifdef USE_ENTITY_ICON
-  buffer.encode_string(5, this->icon);
+  buffer.encode_string(5, this->icon_ptr_, this->icon_len_);
 #endif
   buffer.encode_bool(6, this->disabled_by_default);
   buffer.encode_uint32(7, static_cast<uint32_t>(this->entity_category));
-  buffer.encode_string(8, this->device_class);
+  buffer.encode_string(8, this->device_class_ptr_, this->device_class_len_);
 #ifdef USE_DEVICES
   buffer.encode_uint32(9, this->device_id);
 #endif
 }
 void ListEntitiesTextSensorResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_string_field(total_size, 1, this->object_id);
+  ProtoSize::add_string_field(total_size, 1, this->object_id_len_);
   ProtoSize::add_fixed32_field(total_size, 1, this->key);
-  ProtoSize::add_string_field(total_size, 1, this->name);
+  ProtoSize::add_string_field(total_size, 1, this->name_len_);
 #ifdef USE_ENTITY_ICON
-  ProtoSize::add_string_field(total_size, 1, this->icon);
+  ProtoSize::add_string_field(total_size, 1, this->icon_len_);
 #endif
   ProtoSize::add_bool_field(total_size, 1, this->disabled_by_default);
   ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->entity_category));
-  ProtoSize::add_string_field(total_size, 1, this->device_class);
+  ProtoSize::add_string_field(total_size, 1, this->device_class_len_);
 #ifdef USE_DEVICES
   ProtoSize::add_uint32_field(total_size, 1, this->device_id);
 #endif
 }
 void TextSensorStateResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_fixed32(1, this->key);
-  buffer.encode_string(2, this->state);
+  buffer.encode_string(2, this->state_ptr_, this->state_len_);
   buffer.encode_bool(3, this->missing_state);
 #ifdef USE_DEVICES
   buffer.encode_uint32(4, this->device_id);
@@ -800,7 +800,7 @@ void TextSensorStateResponse::encode(ProtoWriteBuffer buffer) const {
 }
 void TextSensorStateResponse::calculate_size(uint32_t &total_size) const {
   ProtoSize::add_fixed32_field(total_size, 1, this->key);
-  ProtoSize::add_string_field(total_size, 1, this->state);
+  ProtoSize::add_string_field(total_size, 1, this->state_len_);
   ProtoSize::add_bool_field(total_size, 1, this->missing_state);
 #ifdef USE_DEVICES
   ProtoSize::add_uint32_field(total_size, 1, this->device_id);
@@ -845,15 +845,15 @@ void NoiseEncryptionSetKeyResponse::calculate_size(uint32_t &total_size) const {
 }
 #endif
 void HomeassistantServiceMap::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_string(1, this->key);
-  buffer.encode_string(2, this->value);
+  buffer.encode_string(1, this->key_ptr_, this->key_len_);
+  buffer.encode_string(2, this->value_ptr_, this->value_len_);
 }
 void HomeassistantServiceMap::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_string_field(total_size, 1, this->key);
-  ProtoSize::add_string_field(total_size, 1, this->value);
+  ProtoSize::add_string_field(total_size, 1, this->key_len_);
+  ProtoSize::add_string_field(total_size, 1, this->value_len_);
 }
 void HomeassistantServiceResponse::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_string(1, this->service);
+  buffer.encode_string(1, this->service_ptr_, this->service_len_);
   for (auto &it : this->data) {
     buffer.encode_message(2, it, true);
   }
@@ -866,20 +866,20 @@ void HomeassistantServiceResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_bool(5, this->is_event);
 }
 void HomeassistantServiceResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_string_field(total_size, 1, this->service);
+  ProtoSize::add_string_field(total_size, 1, this->service_len_);
   ProtoSize::add_repeated_message(total_size, 1, this->data);
   ProtoSize::add_repeated_message(total_size, 1, this->data_template);
   ProtoSize::add_repeated_message(total_size, 1, this->variables);
   ProtoSize::add_bool_field(total_size, 1, this->is_event);
 }
 void SubscribeHomeAssistantStateResponse::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_string(1, this->entity_id);
-  buffer.encode_string(2, this->attribute);
+  buffer.encode_string(1, this->entity_id_ptr_, this->entity_id_len_);
+  buffer.encode_string(2, this->attribute_ptr_, this->attribute_len_);
   buffer.encode_bool(3, this->once);
 }
 void SubscribeHomeAssistantStateResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_string_field(total_size, 1, this->entity_id);
-  ProtoSize::add_string_field(total_size, 1, this->attribute);
+  ProtoSize::add_string_field(total_size, 1, this->entity_id_len_);
+  ProtoSize::add_string_field(total_size, 1, this->attribute_len_);
   ProtoSize::add_bool_field(total_size, 1, this->once);
 }
 bool HomeAssistantStateResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
@@ -914,22 +914,22 @@ void GetTimeResponse::calculate_size(uint32_t &total_size) const {
 }
 #ifdef USE_API_SERVICES
 void ListEntitiesServicesArgument::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_string(1, this->name);
+  buffer.encode_string(1, this->name_ptr_, this->name_len_);
   buffer.encode_uint32(2, static_cast<uint32_t>(this->type));
 }
 void ListEntitiesServicesArgument::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_string_field(total_size, 1, this->name);
+  ProtoSize::add_string_field(total_size, 1, this->name_len_);
   ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->type));
 }
 void ListEntitiesServicesResponse::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_string(1, this->name);
+  buffer.encode_string(1, this->name_ptr_, this->name_len_);
   buffer.encode_fixed32(2, this->key);
   for (auto &it : this->args) {
     buffer.encode_message(3, it, true);
   }
 }
 void ListEntitiesServicesResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_string_field(total_size, 1, this->name);
+  ProtoSize::add_string_field(total_size, 1, this->name_len_);
   ProtoSize::add_fixed32_field(total_size, 1, this->key);
   ProtoSize::add_repeated_message(total_size, 1, this->args);
 }
@@ -1005,12 +1005,12 @@ bool ExecuteServiceRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
 #endif
 #ifdef USE_CAMERA
 void ListEntitiesCameraResponse::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_string(1, this->object_id);
+  buffer.encode_string(1, this->object_id_ptr_, this->object_id_len_);
   buffer.encode_fixed32(2, this->key);
-  buffer.encode_string(3, this->name);
+  buffer.encode_string(3, this->name_ptr_, this->name_len_);
   buffer.encode_bool(5, this->disabled_by_default);
 #ifdef USE_ENTITY_ICON
-  buffer.encode_string(6, this->icon);
+  buffer.encode_string(6, this->icon_ptr_, this->icon_len_);
 #endif
   buffer.encode_uint32(7, static_cast<uint32_t>(this->entity_category));
 #ifdef USE_DEVICES
@@ -1018,12 +1018,12 @@ void ListEntitiesCameraResponse::encode(ProtoWriteBuffer buffer) const {
 #endif
 }
 void ListEntitiesCameraResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_string_field(total_size, 1, this->object_id);
+  ProtoSize::add_string_field(total_size, 1, this->object_id_len_);
   ProtoSize::add_fixed32_field(total_size, 1, this->key);
-  ProtoSize::add_string_field(total_size, 1, this->name);
+  ProtoSize::add_string_field(total_size, 1, this->name_len_);
   ProtoSize::add_bool_field(total_size, 1, this->disabled_by_default);
 #ifdef USE_ENTITY_ICON
-  ProtoSize::add_string_field(total_size, 1, this->icon);
+  ProtoSize::add_string_field(total_size, 1, this->icon_len_);
 #endif
   ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->entity_category));
 #ifdef USE_DEVICES
@@ -1062,9 +1062,9 @@ bool CameraImageRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
 #endif
 #ifdef USE_CLIMATE
 void ListEntitiesClimateResponse::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_string(1, this->object_id);
+  buffer.encode_string(1, this->object_id_ptr_, this->object_id_len_);
   buffer.encode_fixed32(2, this->key);
-  buffer.encode_string(3, this->name);
+  buffer.encode_string(3, this->name_ptr_, this->name_len_);
   buffer.encode_bool(5, this->supports_current_temperature);
   buffer.encode_bool(6, this->supports_two_point_target_temperature);
   for (auto &it : this->supported_modes) {
@@ -1091,7 +1091,7 @@ void ListEntitiesClimateResponse::encode(ProtoWriteBuffer buffer) const {
   }
   buffer.encode_bool(18, this->disabled_by_default);
 #ifdef USE_ENTITY_ICON
-  buffer.encode_string(19, this->icon);
+  buffer.encode_string(19, this->icon_ptr_, this->icon_len_);
 #endif
   buffer.encode_uint32(20, static_cast<uint32_t>(this->entity_category));
   buffer.encode_float(21, this->visual_current_temperature_step);
@@ -1104,9 +1104,9 @@ void ListEntitiesClimateResponse::encode(ProtoWriteBuffer buffer) const {
 #endif
 }
 void ListEntitiesClimateResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_string_field(total_size, 1, this->object_id);
+  ProtoSize::add_string_field(total_size, 1, this->object_id_len_);
   ProtoSize::add_fixed32_field(total_size, 1, this->key);
-  ProtoSize::add_string_field(total_size, 1, this->name);
+  ProtoSize::add_string_field(total_size, 1, this->name_len_);
   ProtoSize::add_bool_field(total_size, 1, this->supports_current_temperature);
   ProtoSize::add_bool_field(total_size, 1, this->supports_two_point_target_temperature);
   if (!this->supported_modes.empty()) {
@@ -1130,7 +1130,7 @@ void ListEntitiesClimateResponse::calculate_size(uint32_t &total_size) const {
   }
   if (!this->supported_custom_fan_modes.empty()) {
     for (const auto &it : this->supported_custom_fan_modes) {
-      ProtoSize::add_string_field_repeated(total_size, 1, it);
+      ProtoSize::add_string_field(total_size, 1, it.length());
     }
   }
   if (!this->supported_presets.empty()) {
@@ -1140,12 +1140,12 @@ void ListEntitiesClimateResponse::calculate_size(uint32_t &total_size) const {
   }
   if (!this->supported_custom_presets.empty()) {
     for (const auto &it : this->supported_custom_presets) {
-      ProtoSize::add_string_field_repeated(total_size, 2, it);
+      ProtoSize::add_string_field(total_size, 2, it.length());
     }
   }
   ProtoSize::add_bool_field(total_size, 2, this->disabled_by_default);
 #ifdef USE_ENTITY_ICON
-  ProtoSize::add_string_field(total_size, 2, this->icon);
+  ProtoSize::add_string_field(total_size, 2, this->icon_len_);
 #endif
   ProtoSize::add_enum_field(total_size, 2, static_cast<uint32_t>(this->entity_category));
   ProtoSize::add_float_field(total_size, 2, this->visual_current_temperature_step);
@@ -1167,9 +1167,9 @@ void ClimateStateResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint32(8, static_cast<uint32_t>(this->action));
   buffer.encode_uint32(9, static_cast<uint32_t>(this->fan_mode));
   buffer.encode_uint32(10, static_cast<uint32_t>(this->swing_mode));
-  buffer.encode_string(11, this->custom_fan_mode);
+  buffer.encode_string(11, this->custom_fan_mode_ptr_, this->custom_fan_mode_len_);
   buffer.encode_uint32(12, static_cast<uint32_t>(this->preset));
-  buffer.encode_string(13, this->custom_preset);
+  buffer.encode_string(13, this->custom_preset_ptr_, this->custom_preset_len_);
   buffer.encode_float(14, this->current_humidity);
   buffer.encode_float(15, this->target_humidity);
 #ifdef USE_DEVICES
@@ -1186,9 +1186,9 @@ void ClimateStateResponse::calculate_size(uint32_t &total_size) const {
   ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->action));
   ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->fan_mode));
   ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->swing_mode));
-  ProtoSize::add_string_field(total_size, 1, this->custom_fan_mode);
+  ProtoSize::add_string_field(total_size, 1, this->custom_fan_mode_len_);
   ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->preset));
-  ProtoSize::add_string_field(total_size, 1, this->custom_preset);
+  ProtoSize::add_string_field(total_size, 1, this->custom_preset_len_);
   ProtoSize::add_float_field(total_size, 1, this->current_humidity);
   ProtoSize::add_float_field(total_size, 1, this->target_humidity);
 #ifdef USE_DEVICES
@@ -1287,39 +1287,39 @@ bool ClimateCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
 #endif
 #ifdef USE_NUMBER
 void ListEntitiesNumberResponse::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_string(1, this->object_id);
+  buffer.encode_string(1, this->object_id_ptr_, this->object_id_len_);
   buffer.encode_fixed32(2, this->key);
-  buffer.encode_string(3, this->name);
+  buffer.encode_string(3, this->name_ptr_, this->name_len_);
 #ifdef USE_ENTITY_ICON
-  buffer.encode_string(5, this->icon);
+  buffer.encode_string(5, this->icon_ptr_, this->icon_len_);
 #endif
   buffer.encode_float(6, this->min_value);
   buffer.encode_float(7, this->max_value);
   buffer.encode_float(8, this->step);
   buffer.encode_bool(9, this->disabled_by_default);
   buffer.encode_uint32(10, static_cast<uint32_t>(this->entity_category));
-  buffer.encode_string(11, this->unit_of_measurement);
+  buffer.encode_string(11, this->unit_of_measurement_ptr_, this->unit_of_measurement_len_);
   buffer.encode_uint32(12, static_cast<uint32_t>(this->mode));
-  buffer.encode_string(13, this->device_class);
+  buffer.encode_string(13, this->device_class_ptr_, this->device_class_len_);
 #ifdef USE_DEVICES
   buffer.encode_uint32(14, this->device_id);
 #endif
 }
 void ListEntitiesNumberResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_string_field(total_size, 1, this->object_id);
+  ProtoSize::add_string_field(total_size, 1, this->object_id_len_);
   ProtoSize::add_fixed32_field(total_size, 1, this->key);
-  ProtoSize::add_string_field(total_size, 1, this->name);
+  ProtoSize::add_string_field(total_size, 1, this->name_len_);
 #ifdef USE_ENTITY_ICON
-  ProtoSize::add_string_field(total_size, 1, this->icon);
+  ProtoSize::add_string_field(total_size, 1, this->icon_len_);
 #endif
   ProtoSize::add_float_field(total_size, 1, this->min_value);
   ProtoSize::add_float_field(total_size, 1, this->max_value);
   ProtoSize::add_float_field(total_size, 1, this->step);
   ProtoSize::add_bool_field(total_size, 1, this->disabled_by_default);
   ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->entity_category));
-  ProtoSize::add_string_field(total_size, 1, this->unit_of_measurement);
+  ProtoSize::add_string_field(total_size, 1, this->unit_of_measurement_len_);
   ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->mode));
-  ProtoSize::add_string_field(total_size, 1, this->device_class);
+  ProtoSize::add_string_field(total_size, 1, this->device_class_len_);
 #ifdef USE_DEVICES
   ProtoSize::add_uint32_field(total_size, 1, this->device_id);
 #endif
@@ -1368,11 +1368,11 @@ bool NumberCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
 #endif
 #ifdef USE_SELECT
 void ListEntitiesSelectResponse::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_string(1, this->object_id);
+  buffer.encode_string(1, this->object_id_ptr_, this->object_id_len_);
   buffer.encode_fixed32(2, this->key);
-  buffer.encode_string(3, this->name);
+  buffer.encode_string(3, this->name_ptr_, this->name_len_);
 #ifdef USE_ENTITY_ICON
-  buffer.encode_string(5, this->icon);
+  buffer.encode_string(5, this->icon_ptr_, this->icon_len_);
 #endif
   for (auto &it : this->options) {
     buffer.encode_string(6, it, true);
@@ -1384,15 +1384,15 @@ void ListEntitiesSelectResponse::encode(ProtoWriteBuffer buffer) const {
 #endif
 }
 void ListEntitiesSelectResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_string_field(total_size, 1, this->object_id);
+  ProtoSize::add_string_field(total_size, 1, this->object_id_len_);
   ProtoSize::add_fixed32_field(total_size, 1, this->key);
-  ProtoSize::add_string_field(total_size, 1, this->name);
+  ProtoSize::add_string_field(total_size, 1, this->name_len_);
 #ifdef USE_ENTITY_ICON
-  ProtoSize::add_string_field(total_size, 1, this->icon);
+  ProtoSize::add_string_field(total_size, 1, this->icon_len_);
 #endif
   if (!this->options.empty()) {
     for (const auto &it : this->options) {
-      ProtoSize::add_string_field_repeated(total_size, 1, it);
+      ProtoSize::add_string_field(total_size, 1, it.length());
     }
   }
   ProtoSize::add_bool_field(total_size, 1, this->disabled_by_default);
@@ -1403,7 +1403,7 @@ void ListEntitiesSelectResponse::calculate_size(uint32_t &total_size) const {
 }
 void SelectStateResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_fixed32(1, this->key);
-  buffer.encode_string(2, this->state);
+  buffer.encode_string(2, this->state_ptr_, this->state_len_);
   buffer.encode_bool(3, this->missing_state);
 #ifdef USE_DEVICES
   buffer.encode_uint32(4, this->device_id);
@@ -1411,7 +1411,7 @@ void SelectStateResponse::encode(ProtoWriteBuffer buffer) const {
 }
 void SelectStateResponse::calculate_size(uint32_t &total_size) const {
   ProtoSize::add_fixed32_field(total_size, 1, this->key);
-  ProtoSize::add_string_field(total_size, 1, this->state);
+  ProtoSize::add_string_field(total_size, 1, this->state_len_);
   ProtoSize::add_bool_field(total_size, 1, this->missing_state);
 #ifdef USE_DEVICES
   ProtoSize::add_uint32_field(total_size, 1, this->device_id);
@@ -1452,11 +1452,11 @@ bool SelectCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
 #endif
 #ifdef USE_SIREN
 void ListEntitiesSirenResponse::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_string(1, this->object_id);
+  buffer.encode_string(1, this->object_id_ptr_, this->object_id_len_);
   buffer.encode_fixed32(2, this->key);
-  buffer.encode_string(3, this->name);
+  buffer.encode_string(3, this->name_ptr_, this->name_len_);
 #ifdef USE_ENTITY_ICON
-  buffer.encode_string(5, this->icon);
+  buffer.encode_string(5, this->icon_ptr_, this->icon_len_);
 #endif
   buffer.encode_bool(6, this->disabled_by_default);
   for (auto &it : this->tones) {
@@ -1470,16 +1470,16 @@ void ListEntitiesSirenResponse::encode(ProtoWriteBuffer buffer) const {
 #endif
 }
 void ListEntitiesSirenResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_string_field(total_size, 1, this->object_id);
+  ProtoSize::add_string_field(total_size, 1, this->object_id_len_);
   ProtoSize::add_fixed32_field(total_size, 1, this->key);
-  ProtoSize::add_string_field(total_size, 1, this->name);
+  ProtoSize::add_string_field(total_size, 1, this->name_len_);
 #ifdef USE_ENTITY_ICON
-  ProtoSize::add_string_field(total_size, 1, this->icon);
+  ProtoSize::add_string_field(total_size, 1, this->icon_len_);
 #endif
   ProtoSize::add_bool_field(total_size, 1, this->disabled_by_default);
   if (!this->tones.empty()) {
     for (const auto &it : this->tones) {
-      ProtoSize::add_string_field_repeated(total_size, 1, it);
+      ProtoSize::add_string_field(total_size, 1, it.length());
     }
   }
   ProtoSize::add_bool_field(total_size, 1, this->supports_duration);
@@ -1559,35 +1559,35 @@ bool SirenCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
 #endif
 #ifdef USE_LOCK
 void ListEntitiesLockResponse::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_string(1, this->object_id);
+  buffer.encode_string(1, this->object_id_ptr_, this->object_id_len_);
   buffer.encode_fixed32(2, this->key);
-  buffer.encode_string(3, this->name);
+  buffer.encode_string(3, this->name_ptr_, this->name_len_);
 #ifdef USE_ENTITY_ICON
-  buffer.encode_string(5, this->icon);
+  buffer.encode_string(5, this->icon_ptr_, this->icon_len_);
 #endif
   buffer.encode_bool(6, this->disabled_by_default);
   buffer.encode_uint32(7, static_cast<uint32_t>(this->entity_category));
   buffer.encode_bool(8, this->assumed_state);
   buffer.encode_bool(9, this->supports_open);
   buffer.encode_bool(10, this->requires_code);
-  buffer.encode_string(11, this->code_format);
+  buffer.encode_string(11, this->code_format_ptr_, this->code_format_len_);
 #ifdef USE_DEVICES
   buffer.encode_uint32(12, this->device_id);
 #endif
 }
 void ListEntitiesLockResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_string_field(total_size, 1, this->object_id);
+  ProtoSize::add_string_field(total_size, 1, this->object_id_len_);
   ProtoSize::add_fixed32_field(total_size, 1, this->key);
-  ProtoSize::add_string_field(total_size, 1, this->name);
+  ProtoSize::add_string_field(total_size, 1, this->name_len_);
 #ifdef USE_ENTITY_ICON
-  ProtoSize::add_string_field(total_size, 1, this->icon);
+  ProtoSize::add_string_field(total_size, 1, this->icon_len_);
 #endif
   ProtoSize::add_bool_field(total_size, 1, this->disabled_by_default);
   ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->entity_category));
   ProtoSize::add_bool_field(total_size, 1, this->assumed_state);
   ProtoSize::add_bool_field(total_size, 1, this->supports_open);
   ProtoSize::add_bool_field(total_size, 1, this->requires_code);
-  ProtoSize::add_string_field(total_size, 1, this->code_format);
+  ProtoSize::add_string_field(total_size, 1, this->code_format_len_);
 #ifdef USE_DEVICES
   ProtoSize::add_uint32_field(total_size, 1, this->device_id);
 #endif
@@ -1647,29 +1647,29 @@ bool LockCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
 #endif
 #ifdef USE_BUTTON
 void ListEntitiesButtonResponse::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_string(1, this->object_id);
+  buffer.encode_string(1, this->object_id_ptr_, this->object_id_len_);
   buffer.encode_fixed32(2, this->key);
-  buffer.encode_string(3, this->name);
+  buffer.encode_string(3, this->name_ptr_, this->name_len_);
 #ifdef USE_ENTITY_ICON
-  buffer.encode_string(5, this->icon);
+  buffer.encode_string(5, this->icon_ptr_, this->icon_len_);
 #endif
   buffer.encode_bool(6, this->disabled_by_default);
   buffer.encode_uint32(7, static_cast<uint32_t>(this->entity_category));
-  buffer.encode_string(8, this->device_class);
+  buffer.encode_string(8, this->device_class_ptr_, this->device_class_len_);
 #ifdef USE_DEVICES
   buffer.encode_uint32(9, this->device_id);
 #endif
 }
 void ListEntitiesButtonResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_string_field(total_size, 1, this->object_id);
+  ProtoSize::add_string_field(total_size, 1, this->object_id_len_);
   ProtoSize::add_fixed32_field(total_size, 1, this->key);
-  ProtoSize::add_string_field(total_size, 1, this->name);
+  ProtoSize::add_string_field(total_size, 1, this->name_len_);
 #ifdef USE_ENTITY_ICON
-  ProtoSize::add_string_field(total_size, 1, this->icon);
+  ProtoSize::add_string_field(total_size, 1, this->icon_len_);
 #endif
   ProtoSize::add_bool_field(total_size, 1, this->disabled_by_default);
   ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->entity_category));
-  ProtoSize::add_string_field(total_size, 1, this->device_class);
+  ProtoSize::add_string_field(total_size, 1, this->device_class_len_);
 #ifdef USE_DEVICES
   ProtoSize::add_uint32_field(total_size, 1, this->device_id);
 #endif
@@ -1699,25 +1699,25 @@ bool ButtonCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
 #endif
 #ifdef USE_MEDIA_PLAYER
 void MediaPlayerSupportedFormat::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_string(1, this->format);
+  buffer.encode_string(1, this->format_ptr_, this->format_len_);
   buffer.encode_uint32(2, this->sample_rate);
   buffer.encode_uint32(3, this->num_channels);
   buffer.encode_uint32(4, static_cast<uint32_t>(this->purpose));
   buffer.encode_uint32(5, this->sample_bytes);
 }
 void MediaPlayerSupportedFormat::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_string_field(total_size, 1, this->format);
+  ProtoSize::add_string_field(total_size, 1, this->format_len_);
   ProtoSize::add_uint32_field(total_size, 1, this->sample_rate);
   ProtoSize::add_uint32_field(total_size, 1, this->num_channels);
   ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->purpose));
   ProtoSize::add_uint32_field(total_size, 1, this->sample_bytes);
 }
 void ListEntitiesMediaPlayerResponse::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_string(1, this->object_id);
+  buffer.encode_string(1, this->object_id_ptr_, this->object_id_len_);
   buffer.encode_fixed32(2, this->key);
-  buffer.encode_string(3, this->name);
+  buffer.encode_string(3, this->name_ptr_, this->name_len_);
 #ifdef USE_ENTITY_ICON
-  buffer.encode_string(5, this->icon);
+  buffer.encode_string(5, this->icon_ptr_, this->icon_len_);
 #endif
   buffer.encode_bool(6, this->disabled_by_default);
   buffer.encode_uint32(7, static_cast<uint32_t>(this->entity_category));
@@ -1730,11 +1730,11 @@ void ListEntitiesMediaPlayerResponse::encode(ProtoWriteBuffer buffer) const {
 #endif
 }
 void ListEntitiesMediaPlayerResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_string_field(total_size, 1, this->object_id);
+  ProtoSize::add_string_field(total_size, 1, this->object_id_len_);
   ProtoSize::add_fixed32_field(total_size, 1, this->key);
-  ProtoSize::add_string_field(total_size, 1, this->name);
+  ProtoSize::add_string_field(total_size, 1, this->name_len_);
 #ifdef USE_ENTITY_ICON
-  ProtoSize::add_string_field(total_size, 1, this->icon);
+  ProtoSize::add_string_field(total_size, 1, this->icon_len_);
 #endif
   ProtoSize::add_bool_field(total_size, 1, this->disabled_by_default);
   ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->entity_category));
@@ -2186,17 +2186,17 @@ void VoiceAssistantAudioSettings::calculate_size(uint32_t &total_size) const {
 }
 void VoiceAssistantRequest::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_bool(1, this->start);
-  buffer.encode_string(2, this->conversation_id);
+  buffer.encode_string(2, this->conversation_id_ptr_, this->conversation_id_len_);
   buffer.encode_uint32(3, this->flags);
   buffer.encode_message(4, this->audio_settings);
-  buffer.encode_string(5, this->wake_word_phrase);
+  buffer.encode_string(5, this->wake_word_phrase_ptr_, this->wake_word_phrase_len_);
 }
 void VoiceAssistantRequest::calculate_size(uint32_t &total_size) const {
   ProtoSize::add_bool_field(total_size, 1, this->start);
-  ProtoSize::add_string_field(total_size, 1, this->conversation_id);
+  ProtoSize::add_string_field(total_size, 1, this->conversation_id_len_);
   ProtoSize::add_uint32_field(total_size, 1, this->flags);
   ProtoSize::add_message_object(total_size, 1, this->audio_settings);
-  ProtoSize::add_string_field(total_size, 1, this->wake_word_phrase);
+  ProtoSize::add_string_field(total_size, 1, this->wake_word_phrase_len_);
 }
 bool VoiceAssistantResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {
@@ -2336,18 +2336,18 @@ void VoiceAssistantAnnounceFinished::calculate_size(uint32_t &total_size) const 
   ProtoSize::add_bool_field(total_size, 1, this->success);
 }
 void VoiceAssistantWakeWord::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_string(1, this->id);
-  buffer.encode_string(2, this->wake_word);
+  buffer.encode_string(1, this->id_ptr_, this->id_len_);
+  buffer.encode_string(2, this->wake_word_ptr_, this->wake_word_len_);
   for (auto &it : this->trained_languages) {
     buffer.encode_string(3, it, true);
   }
 }
 void VoiceAssistantWakeWord::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_string_field(total_size, 1, this->id);
-  ProtoSize::add_string_field(total_size, 1, this->wake_word);
+  ProtoSize::add_string_field(total_size, 1, this->id_len_);
+  ProtoSize::add_string_field(total_size, 1, this->wake_word_len_);
   if (!this->trained_languages.empty()) {
     for (const auto &it : this->trained_languages) {
-      ProtoSize::add_string_field_repeated(total_size, 1, it);
+      ProtoSize::add_string_field(total_size, 1, it.length());
     }
   }
 }
@@ -2364,7 +2364,7 @@ void VoiceAssistantConfigurationResponse::calculate_size(uint32_t &total_size) c
   ProtoSize::add_repeated_message(total_size, 1, this->available_wake_words);
   if (!this->active_wake_words.empty()) {
     for (const auto &it : this->active_wake_words) {
-      ProtoSize::add_string_field_repeated(total_size, 1, it);
+      ProtoSize::add_string_field(total_size, 1, it.length());
     }
   }
   ProtoSize::add_uint32_field(total_size, 1, this->max_active_wake_words);
@@ -2382,11 +2382,11 @@ bool VoiceAssistantSetConfiguration::decode_length(uint32_t field_id, ProtoLengt
 #endif
 #ifdef USE_ALARM_CONTROL_PANEL
 void ListEntitiesAlarmControlPanelResponse::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_string(1, this->object_id);
+  buffer.encode_string(1, this->object_id_ptr_, this->object_id_len_);
   buffer.encode_fixed32(2, this->key);
-  buffer.encode_string(3, this->name);
+  buffer.encode_string(3, this->name_ptr_, this->name_len_);
 #ifdef USE_ENTITY_ICON
-  buffer.encode_string(5, this->icon);
+  buffer.encode_string(5, this->icon_ptr_, this->icon_len_);
 #endif
   buffer.encode_bool(6, this->disabled_by_default);
   buffer.encode_uint32(7, static_cast<uint32_t>(this->entity_category));
@@ -2398,11 +2398,11 @@ void ListEntitiesAlarmControlPanelResponse::encode(ProtoWriteBuffer buffer) cons
 #endif
 }
 void ListEntitiesAlarmControlPanelResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_string_field(total_size, 1, this->object_id);
+  ProtoSize::add_string_field(total_size, 1, this->object_id_len_);
   ProtoSize::add_fixed32_field(total_size, 1, this->key);
-  ProtoSize::add_string_field(total_size, 1, this->name);
+  ProtoSize::add_string_field(total_size, 1, this->name_len_);
 #ifdef USE_ENTITY_ICON
-  ProtoSize::add_string_field(total_size, 1, this->icon);
+  ProtoSize::add_string_field(total_size, 1, this->icon_len_);
 #endif
   ProtoSize::add_bool_field(total_size, 1, this->disabled_by_default);
   ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->entity_category));
@@ -2465,34 +2465,34 @@ bool AlarmControlPanelCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit
 #endif
 #ifdef USE_TEXT
 void ListEntitiesTextResponse::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_string(1, this->object_id);
+  buffer.encode_string(1, this->object_id_ptr_, this->object_id_len_);
   buffer.encode_fixed32(2, this->key);
-  buffer.encode_string(3, this->name);
+  buffer.encode_string(3, this->name_ptr_, this->name_len_);
 #ifdef USE_ENTITY_ICON
-  buffer.encode_string(5, this->icon);
+  buffer.encode_string(5, this->icon_ptr_, this->icon_len_);
 #endif
   buffer.encode_bool(6, this->disabled_by_default);
   buffer.encode_uint32(7, static_cast<uint32_t>(this->entity_category));
   buffer.encode_uint32(8, this->min_length);
   buffer.encode_uint32(9, this->max_length);
-  buffer.encode_string(10, this->pattern);
+  buffer.encode_string(10, this->pattern_ptr_, this->pattern_len_);
   buffer.encode_uint32(11, static_cast<uint32_t>(this->mode));
 #ifdef USE_DEVICES
   buffer.encode_uint32(12, this->device_id);
 #endif
 }
 void ListEntitiesTextResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_string_field(total_size, 1, this->object_id);
+  ProtoSize::add_string_field(total_size, 1, this->object_id_len_);
   ProtoSize::add_fixed32_field(total_size, 1, this->key);
-  ProtoSize::add_string_field(total_size, 1, this->name);
+  ProtoSize::add_string_field(total_size, 1, this->name_len_);
 #ifdef USE_ENTITY_ICON
-  ProtoSize::add_string_field(total_size, 1, this->icon);
+  ProtoSize::add_string_field(total_size, 1, this->icon_len_);
 #endif
   ProtoSize::add_bool_field(total_size, 1, this->disabled_by_default);
   ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->entity_category));
   ProtoSize::add_uint32_field(total_size, 1, this->min_length);
   ProtoSize::add_uint32_field(total_size, 1, this->max_length);
-  ProtoSize::add_string_field(total_size, 1, this->pattern);
+  ProtoSize::add_string_field(total_size, 1, this->pattern_len_);
   ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->mode));
 #ifdef USE_DEVICES
   ProtoSize::add_uint32_field(total_size, 1, this->device_id);
@@ -2500,7 +2500,7 @@ void ListEntitiesTextResponse::calculate_size(uint32_t &total_size) const {
 }
 void TextStateResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_fixed32(1, this->key);
-  buffer.encode_string(2, this->state);
+  buffer.encode_string(2, this->state_ptr_, this->state_len_);
   buffer.encode_bool(3, this->missing_state);
 #ifdef USE_DEVICES
   buffer.encode_uint32(4, this->device_id);
@@ -2508,7 +2508,7 @@ void TextStateResponse::encode(ProtoWriteBuffer buffer) const {
 }
 void TextStateResponse::calculate_size(uint32_t &total_size) const {
   ProtoSize::add_fixed32_field(total_size, 1, this->key);
-  ProtoSize::add_string_field(total_size, 1, this->state);
+  ProtoSize::add_string_field(total_size, 1, this->state_len_);
   ProtoSize::add_bool_field(total_size, 1, this->missing_state);
 #ifdef USE_DEVICES
   ProtoSize::add_uint32_field(total_size, 1, this->device_id);
@@ -2549,11 +2549,11 @@ bool TextCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
 #endif
 #ifdef USE_DATETIME_DATE
 void ListEntitiesDateResponse::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_string(1, this->object_id);
+  buffer.encode_string(1, this->object_id_ptr_, this->object_id_len_);
   buffer.encode_fixed32(2, this->key);
-  buffer.encode_string(3, this->name);
+  buffer.encode_string(3, this->name_ptr_, this->name_len_);
 #ifdef USE_ENTITY_ICON
-  buffer.encode_string(5, this->icon);
+  buffer.encode_string(5, this->icon_ptr_, this->icon_len_);
 #endif
   buffer.encode_bool(6, this->disabled_by_default);
   buffer.encode_uint32(7, static_cast<uint32_t>(this->entity_category));
@@ -2562,11 +2562,11 @@ void ListEntitiesDateResponse::encode(ProtoWriteBuffer buffer) const {
 #endif
 }
 void ListEntitiesDateResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_string_field(total_size, 1, this->object_id);
+  ProtoSize::add_string_field(total_size, 1, this->object_id_len_);
   ProtoSize::add_fixed32_field(total_size, 1, this->key);
-  ProtoSize::add_string_field(total_size, 1, this->name);
+  ProtoSize::add_string_field(total_size, 1, this->name_len_);
 #ifdef USE_ENTITY_ICON
-  ProtoSize::add_string_field(total_size, 1, this->icon);
+  ProtoSize::add_string_field(total_size, 1, this->icon_len_);
 #endif
   ProtoSize::add_bool_field(total_size, 1, this->disabled_by_default);
   ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->entity_category));
@@ -2628,11 +2628,11 @@ bool DateCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
 #endif
 #ifdef USE_DATETIME_TIME
 void ListEntitiesTimeResponse::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_string(1, this->object_id);
+  buffer.encode_string(1, this->object_id_ptr_, this->object_id_len_);
   buffer.encode_fixed32(2, this->key);
-  buffer.encode_string(3, this->name);
+  buffer.encode_string(3, this->name_ptr_, this->name_len_);
 #ifdef USE_ENTITY_ICON
-  buffer.encode_string(5, this->icon);
+  buffer.encode_string(5, this->icon_ptr_, this->icon_len_);
 #endif
   buffer.encode_bool(6, this->disabled_by_default);
   buffer.encode_uint32(7, static_cast<uint32_t>(this->entity_category));
@@ -2641,11 +2641,11 @@ void ListEntitiesTimeResponse::encode(ProtoWriteBuffer buffer) const {
 #endif
 }
 void ListEntitiesTimeResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_string_field(total_size, 1, this->object_id);
+  ProtoSize::add_string_field(total_size, 1, this->object_id_len_);
   ProtoSize::add_fixed32_field(total_size, 1, this->key);
-  ProtoSize::add_string_field(total_size, 1, this->name);
+  ProtoSize::add_string_field(total_size, 1, this->name_len_);
 #ifdef USE_ENTITY_ICON
-  ProtoSize::add_string_field(total_size, 1, this->icon);
+  ProtoSize::add_string_field(total_size, 1, this->icon_len_);
 #endif
   ProtoSize::add_bool_field(total_size, 1, this->disabled_by_default);
   ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->entity_category));
@@ -2707,15 +2707,15 @@ bool TimeCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
 #endif
 #ifdef USE_EVENT
 void ListEntitiesEventResponse::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_string(1, this->object_id);
+  buffer.encode_string(1, this->object_id_ptr_, this->object_id_len_);
   buffer.encode_fixed32(2, this->key);
-  buffer.encode_string(3, this->name);
+  buffer.encode_string(3, this->name_ptr_, this->name_len_);
 #ifdef USE_ENTITY_ICON
-  buffer.encode_string(5, this->icon);
+  buffer.encode_string(5, this->icon_ptr_, this->icon_len_);
 #endif
   buffer.encode_bool(6, this->disabled_by_default);
   buffer.encode_uint32(7, static_cast<uint32_t>(this->entity_category));
-  buffer.encode_string(8, this->device_class);
+  buffer.encode_string(8, this->device_class_ptr_, this->device_class_len_);
   for (auto &it : this->event_types) {
     buffer.encode_string(9, it, true);
   }
@@ -2724,18 +2724,18 @@ void ListEntitiesEventResponse::encode(ProtoWriteBuffer buffer) const {
 #endif
 }
 void ListEntitiesEventResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_string_field(total_size, 1, this->object_id);
+  ProtoSize::add_string_field(total_size, 1, this->object_id_len_);
   ProtoSize::add_fixed32_field(total_size, 1, this->key);
-  ProtoSize::add_string_field(total_size, 1, this->name);
+  ProtoSize::add_string_field(total_size, 1, this->name_len_);
 #ifdef USE_ENTITY_ICON
-  ProtoSize::add_string_field(total_size, 1, this->icon);
+  ProtoSize::add_string_field(total_size, 1, this->icon_len_);
 #endif
   ProtoSize::add_bool_field(total_size, 1, this->disabled_by_default);
   ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->entity_category));
-  ProtoSize::add_string_field(total_size, 1, this->device_class);
+  ProtoSize::add_string_field(total_size, 1, this->device_class_len_);
   if (!this->event_types.empty()) {
     for (const auto &it : this->event_types) {
-      ProtoSize::add_string_field_repeated(total_size, 1, it);
+      ProtoSize::add_string_field(total_size, 1, it.length());
     }
   }
 #ifdef USE_DEVICES
@@ -2744,14 +2744,14 @@ void ListEntitiesEventResponse::calculate_size(uint32_t &total_size) const {
 }
 void EventResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_fixed32(1, this->key);
-  buffer.encode_string(2, this->event_type);
+  buffer.encode_string(2, this->event_type_ptr_, this->event_type_len_);
 #ifdef USE_DEVICES
   buffer.encode_uint32(3, this->device_id);
 #endif
 }
 void EventResponse::calculate_size(uint32_t &total_size) const {
   ProtoSize::add_fixed32_field(total_size, 1, this->key);
-  ProtoSize::add_string_field(total_size, 1, this->event_type);
+  ProtoSize::add_string_field(total_size, 1, this->event_type_len_);
 #ifdef USE_DEVICES
   ProtoSize::add_uint32_field(total_size, 1, this->device_id);
 #endif
@@ -2759,15 +2759,15 @@ void EventResponse::calculate_size(uint32_t &total_size) const {
 #endif
 #ifdef USE_VALVE
 void ListEntitiesValveResponse::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_string(1, this->object_id);
+  buffer.encode_string(1, this->object_id_ptr_, this->object_id_len_);
   buffer.encode_fixed32(2, this->key);
-  buffer.encode_string(3, this->name);
+  buffer.encode_string(3, this->name_ptr_, this->name_len_);
 #ifdef USE_ENTITY_ICON
-  buffer.encode_string(5, this->icon);
+  buffer.encode_string(5, this->icon_ptr_, this->icon_len_);
 #endif
   buffer.encode_bool(6, this->disabled_by_default);
   buffer.encode_uint32(7, static_cast<uint32_t>(this->entity_category));
-  buffer.encode_string(8, this->device_class);
+  buffer.encode_string(8, this->device_class_ptr_, this->device_class_len_);
   buffer.encode_bool(9, this->assumed_state);
   buffer.encode_bool(10, this->supports_position);
   buffer.encode_bool(11, this->supports_stop);
@@ -2776,15 +2776,15 @@ void ListEntitiesValveResponse::encode(ProtoWriteBuffer buffer) const {
 #endif
 }
 void ListEntitiesValveResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_string_field(total_size, 1, this->object_id);
+  ProtoSize::add_string_field(total_size, 1, this->object_id_len_);
   ProtoSize::add_fixed32_field(total_size, 1, this->key);
-  ProtoSize::add_string_field(total_size, 1, this->name);
+  ProtoSize::add_string_field(total_size, 1, this->name_len_);
 #ifdef USE_ENTITY_ICON
-  ProtoSize::add_string_field(total_size, 1, this->icon);
+  ProtoSize::add_string_field(total_size, 1, this->icon_len_);
 #endif
   ProtoSize::add_bool_field(total_size, 1, this->disabled_by_default);
   ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->entity_category));
-  ProtoSize::add_string_field(total_size, 1, this->device_class);
+  ProtoSize::add_string_field(total_size, 1, this->device_class_len_);
   ProtoSize::add_bool_field(total_size, 1, this->assumed_state);
   ProtoSize::add_bool_field(total_size, 1, this->supports_position);
   ProtoSize::add_bool_field(total_size, 1, this->supports_stop);
@@ -2842,11 +2842,11 @@ bool ValveCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
 #endif
 #ifdef USE_DATETIME_DATETIME
 void ListEntitiesDateTimeResponse::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_string(1, this->object_id);
+  buffer.encode_string(1, this->object_id_ptr_, this->object_id_len_);
   buffer.encode_fixed32(2, this->key);
-  buffer.encode_string(3, this->name);
+  buffer.encode_string(3, this->name_ptr_, this->name_len_);
 #ifdef USE_ENTITY_ICON
-  buffer.encode_string(5, this->icon);
+  buffer.encode_string(5, this->icon_ptr_, this->icon_len_);
 #endif
   buffer.encode_bool(6, this->disabled_by_default);
   buffer.encode_uint32(7, static_cast<uint32_t>(this->entity_category));
@@ -2855,11 +2855,11 @@ void ListEntitiesDateTimeResponse::encode(ProtoWriteBuffer buffer) const {
 #endif
 }
 void ListEntitiesDateTimeResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_string_field(total_size, 1, this->object_id);
+  ProtoSize::add_string_field(total_size, 1, this->object_id_len_);
   ProtoSize::add_fixed32_field(total_size, 1, this->key);
-  ProtoSize::add_string_field(total_size, 1, this->name);
+  ProtoSize::add_string_field(total_size, 1, this->name_len_);
 #ifdef USE_ENTITY_ICON
-  ProtoSize::add_string_field(total_size, 1, this->icon);
+  ProtoSize::add_string_field(total_size, 1, this->icon_len_);
 #endif
   ProtoSize::add_bool_field(total_size, 1, this->disabled_by_default);
   ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->entity_category));
@@ -2911,29 +2911,29 @@ bool DateTimeCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
 #endif
 #ifdef USE_UPDATE
 void ListEntitiesUpdateResponse::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_string(1, this->object_id);
+  buffer.encode_string(1, this->object_id_ptr_, this->object_id_len_);
   buffer.encode_fixed32(2, this->key);
-  buffer.encode_string(3, this->name);
+  buffer.encode_string(3, this->name_ptr_, this->name_len_);
 #ifdef USE_ENTITY_ICON
-  buffer.encode_string(5, this->icon);
+  buffer.encode_string(5, this->icon_ptr_, this->icon_len_);
 #endif
   buffer.encode_bool(6, this->disabled_by_default);
   buffer.encode_uint32(7, static_cast<uint32_t>(this->entity_category));
-  buffer.encode_string(8, this->device_class);
+  buffer.encode_string(8, this->device_class_ptr_, this->device_class_len_);
 #ifdef USE_DEVICES
   buffer.encode_uint32(9, this->device_id);
 #endif
 }
 void ListEntitiesUpdateResponse::calculate_size(uint32_t &total_size) const {
-  ProtoSize::add_string_field(total_size, 1, this->object_id);
+  ProtoSize::add_string_field(total_size, 1, this->object_id_len_);
   ProtoSize::add_fixed32_field(total_size, 1, this->key);
-  ProtoSize::add_string_field(total_size, 1, this->name);
+  ProtoSize::add_string_field(total_size, 1, this->name_len_);
 #ifdef USE_ENTITY_ICON
-  ProtoSize::add_string_field(total_size, 1, this->icon);
+  ProtoSize::add_string_field(total_size, 1, this->icon_len_);
 #endif
   ProtoSize::add_bool_field(total_size, 1, this->disabled_by_default);
   ProtoSize::add_enum_field(total_size, 1, static_cast<uint32_t>(this->entity_category));
-  ProtoSize::add_string_field(total_size, 1, this->device_class);
+  ProtoSize::add_string_field(total_size, 1, this->device_class_len_);
 #ifdef USE_DEVICES
   ProtoSize::add_uint32_field(total_size, 1, this->device_id);
 #endif
@@ -2944,11 +2944,11 @@ void UpdateStateResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_bool(3, this->in_progress);
   buffer.encode_bool(4, this->has_progress);
   buffer.encode_float(5, this->progress);
-  buffer.encode_string(6, this->current_version);
-  buffer.encode_string(7, this->latest_version);
-  buffer.encode_string(8, this->title);
-  buffer.encode_string(9, this->release_summary);
-  buffer.encode_string(10, this->release_url);
+  buffer.encode_string(6, this->current_version_ptr_, this->current_version_len_);
+  buffer.encode_string(7, this->latest_version_ptr_, this->latest_version_len_);
+  buffer.encode_string(8, this->title_ptr_, this->title_len_);
+  buffer.encode_string(9, this->release_summary_ptr_, this->release_summary_len_);
+  buffer.encode_string(10, this->release_url_ptr_, this->release_url_len_);
 #ifdef USE_DEVICES
   buffer.encode_uint32(11, this->device_id);
 #endif
@@ -2959,11 +2959,11 @@ void UpdateStateResponse::calculate_size(uint32_t &total_size) const {
   ProtoSize::add_bool_field(total_size, 1, this->in_progress);
   ProtoSize::add_bool_field(total_size, 1, this->has_progress);
   ProtoSize::add_float_field(total_size, 1, this->progress);
-  ProtoSize::add_string_field(total_size, 1, this->current_version);
-  ProtoSize::add_string_field(total_size, 1, this->latest_version);
-  ProtoSize::add_string_field(total_size, 1, this->title);
-  ProtoSize::add_string_field(total_size, 1, this->release_summary);
-  ProtoSize::add_string_field(total_size, 1, this->release_url);
+  ProtoSize::add_string_field(total_size, 1, this->current_version_len_);
+  ProtoSize::add_string_field(total_size, 1, this->latest_version_len_);
+  ProtoSize::add_string_field(total_size, 1, this->title_len_);
+  ProtoSize::add_string_field(total_size, 1, this->release_summary_len_);
+  ProtoSize::add_string_field(total_size, 1, this->release_url_len_);
 #ifdef USE_DEVICES
   ProtoSize::add_uint32_field(total_size, 1, this->device_id);
 #endif

--- a/esphome/components/api/api_pb2.h
+++ b/esphome/components/api/api_pb2.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "esphome/core/defines.h"
+#include "esphome/core/string_ref.h"
 
 #include "proto.h"
 
@@ -269,27 +270,15 @@ enum UpdateCommand : uint32_t {
 class InfoResponseProtoMessage : public ProtoMessage {
  public:
   ~InfoResponseProtoMessage() override = default;
-  const char *object_id_ptr_{nullptr};
-  size_t object_id_len_{0};
-  void set_object_id(const char *data, size_t len) {
-    this->object_id_ptr_ = data;
-    this->object_id_len_ = len;
-  }
+  StringRef object_id_ref_{};
+  void set_object_id(const StringRef &ref) { this->object_id_ref_ = ref; }
   uint32_t key{0};
-  const char *name_ptr_{nullptr};
-  size_t name_len_{0};
-  void set_name(const char *data, size_t len) {
-    this->name_ptr_ = data;
-    this->name_len_ = len;
-  }
+  StringRef name_ref_{};
+  void set_name(const StringRef &ref) { this->name_ref_ = ref; }
   bool disabled_by_default{false};
 #ifdef USE_ENTITY_ICON
-  const char *icon_ptr_{nullptr};
-  size_t icon_len_{0};
-  void set_icon(const char *data, size_t len) {
-    this->icon_ptr_ = data;
-    this->icon_len_ = len;
-  }
+  StringRef icon_ref_{};
+  void set_icon(const StringRef &ref) { this->icon_ref_ = ref; }
 #endif
   enums::EntityCategory entity_category{};
 #ifdef USE_DEVICES
@@ -347,18 +336,10 @@ class HelloResponse : public ProtoMessage {
 #endif
   uint32_t api_version_major{0};
   uint32_t api_version_minor{0};
-  const char *server_info_ptr_{nullptr};
-  size_t server_info_len_{0};
-  void set_server_info(const char *data, size_t len) {
-    this->server_info_ptr_ = data;
-    this->server_info_len_ = len;
-  }
-  const char *name_ptr_{nullptr};
-  size_t name_len_{0};
-  void set_name(const char *data, size_t len) {
-    this->name_ptr_ = data;
-    this->name_len_ = len;
-  }
+  StringRef server_info_ref_{};
+  void set_server_info(const StringRef &ref) { this->server_info_ref_ = ref; }
+  StringRef name_ref_{};
+  void set_name(const StringRef &ref) { this->name_ref_ = ref; }
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(uint32_t &total_size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
@@ -467,12 +448,8 @@ class DeviceInfoRequest : public ProtoDecodableMessage {
 class AreaInfo : public ProtoMessage {
  public:
   uint32_t area_id{0};
-  const char *name_ptr_{nullptr};
-  size_t name_len_{0};
-  void set_name(const char *data, size_t len) {
-    this->name_ptr_ = data;
-    this->name_len_ = len;
-  }
+  StringRef name_ref_{};
+  void set_name(const StringRef &ref) { this->name_ref_ = ref; }
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(uint32_t &total_size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
@@ -486,12 +463,8 @@ class AreaInfo : public ProtoMessage {
 class DeviceInfo : public ProtoMessage {
  public:
   uint32_t device_id{0};
-  const char *name_ptr_{nullptr};
-  size_t name_len_{0};
-  void set_name(const char *data, size_t len) {
-    this->name_ptr_ = data;
-    this->name_len_ = len;
-  }
+  StringRef name_ref_{};
+  void set_name(const StringRef &ref) { this->name_ref_ = ref; }
   uint32_t area_id{0};
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(uint32_t &total_size) const override;
@@ -512,54 +485,26 @@ class DeviceInfoResponse : public ProtoMessage {
 #ifdef USE_API_PASSWORD
   bool uses_password{false};
 #endif
-  const char *name_ptr_{nullptr};
-  size_t name_len_{0};
-  void set_name(const char *data, size_t len) {
-    this->name_ptr_ = data;
-    this->name_len_ = len;
-  }
-  const char *mac_address_ptr_{nullptr};
-  size_t mac_address_len_{0};
-  void set_mac_address(const char *data, size_t len) {
-    this->mac_address_ptr_ = data;
-    this->mac_address_len_ = len;
-  }
-  const char *esphome_version_ptr_{nullptr};
-  size_t esphome_version_len_{0};
-  void set_esphome_version(const char *data, size_t len) {
-    this->esphome_version_ptr_ = data;
-    this->esphome_version_len_ = len;
-  }
-  const char *compilation_time_ptr_{nullptr};
-  size_t compilation_time_len_{0};
-  void set_compilation_time(const char *data, size_t len) {
-    this->compilation_time_ptr_ = data;
-    this->compilation_time_len_ = len;
-  }
-  const char *model_ptr_{nullptr};
-  size_t model_len_{0};
-  void set_model(const char *data, size_t len) {
-    this->model_ptr_ = data;
-    this->model_len_ = len;
-  }
+  StringRef name_ref_{};
+  void set_name(const StringRef &ref) { this->name_ref_ = ref; }
+  StringRef mac_address_ref_{};
+  void set_mac_address(const StringRef &ref) { this->mac_address_ref_ = ref; }
+  StringRef esphome_version_ref_{};
+  void set_esphome_version(const StringRef &ref) { this->esphome_version_ref_ = ref; }
+  StringRef compilation_time_ref_{};
+  void set_compilation_time(const StringRef &ref) { this->compilation_time_ref_ = ref; }
+  StringRef model_ref_{};
+  void set_model(const StringRef &ref) { this->model_ref_ = ref; }
 #ifdef USE_DEEP_SLEEP
   bool has_deep_sleep{false};
 #endif
 #ifdef ESPHOME_PROJECT_NAME
-  const char *project_name_ptr_{nullptr};
-  size_t project_name_len_{0};
-  void set_project_name(const char *data, size_t len) {
-    this->project_name_ptr_ = data;
-    this->project_name_len_ = len;
-  }
+  StringRef project_name_ref_{};
+  void set_project_name(const StringRef &ref) { this->project_name_ref_ = ref; }
 #endif
 #ifdef ESPHOME_PROJECT_NAME
-  const char *project_version_ptr_{nullptr};
-  size_t project_version_len_{0};
-  void set_project_version(const char *data, size_t len) {
-    this->project_version_ptr_ = data;
-    this->project_version_len_ = len;
-  }
+  StringRef project_version_ref_{};
+  void set_project_version(const StringRef &ref) { this->project_version_ref_ = ref; }
 #endif
 #ifdef USE_WEBSERVER
   uint32_t webserver_port{0};
@@ -567,36 +512,20 @@ class DeviceInfoResponse : public ProtoMessage {
 #ifdef USE_BLUETOOTH_PROXY
   uint32_t bluetooth_proxy_feature_flags{0};
 #endif
-  const char *manufacturer_ptr_{nullptr};
-  size_t manufacturer_len_{0};
-  void set_manufacturer(const char *data, size_t len) {
-    this->manufacturer_ptr_ = data;
-    this->manufacturer_len_ = len;
-  }
-  const char *friendly_name_ptr_{nullptr};
-  size_t friendly_name_len_{0};
-  void set_friendly_name(const char *data, size_t len) {
-    this->friendly_name_ptr_ = data;
-    this->friendly_name_len_ = len;
-  }
+  StringRef manufacturer_ref_{};
+  void set_manufacturer(const StringRef &ref) { this->manufacturer_ref_ = ref; }
+  StringRef friendly_name_ref_{};
+  void set_friendly_name(const StringRef &ref) { this->friendly_name_ref_ = ref; }
 #ifdef USE_VOICE_ASSISTANT
   uint32_t voice_assistant_feature_flags{0};
 #endif
 #ifdef USE_AREAS
-  const char *suggested_area_ptr_{nullptr};
-  size_t suggested_area_len_{0};
-  void set_suggested_area(const char *data, size_t len) {
-    this->suggested_area_ptr_ = data;
-    this->suggested_area_len_ = len;
-  }
+  StringRef suggested_area_ref_{};
+  void set_suggested_area(const StringRef &ref) { this->suggested_area_ref_ = ref; }
 #endif
 #ifdef USE_BLUETOOTH_PROXY
-  const char *bluetooth_mac_address_ptr_{nullptr};
-  size_t bluetooth_mac_address_len_{0};
-  void set_bluetooth_mac_address(const char *data, size_t len) {
-    this->bluetooth_mac_address_ptr_ = data;
-    this->bluetooth_mac_address_len_ = len;
-  }
+  StringRef bluetooth_mac_address_ref_{};
+  void set_bluetooth_mac_address(const StringRef &ref) { this->bluetooth_mac_address_ref_ = ref; }
 #endif
 #ifdef USE_API_NOISE
   bool api_encryption_supported{false};
@@ -665,12 +594,8 @@ class ListEntitiesBinarySensorResponse : public InfoResponseProtoMessage {
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "list_entities_binary_sensor_response"; }
 #endif
-  const char *device_class_ptr_{nullptr};
-  size_t device_class_len_{0};
-  void set_device_class(const char *data, size_t len) {
-    this->device_class_ptr_ = data;
-    this->device_class_len_ = len;
-  }
+  StringRef device_class_ref_{};
+  void set_device_class(const StringRef &ref) { this->device_class_ref_ = ref; }
   bool is_status_binary_sensor{false};
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(uint32_t &total_size) const override;
@@ -709,12 +634,8 @@ class ListEntitiesCoverResponse : public InfoResponseProtoMessage {
   bool assumed_state{false};
   bool supports_position{false};
   bool supports_tilt{false};
-  const char *device_class_ptr_{nullptr};
-  size_t device_class_len_{0};
-  void set_device_class(const char *data, size_t len) {
-    this->device_class_ptr_ = data;
-    this->device_class_len_ = len;
-  }
+  StringRef device_class_ref_{};
+  void set_device_class(const StringRef &ref) { this->device_class_ref_ = ref; }
   bool supports_stop{false};
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(uint32_t &total_size) const override;
@@ -795,12 +716,8 @@ class FanStateResponse : public StateResponseProtoMessage {
   bool oscillating{false};
   enums::FanDirection direction{};
   int32_t speed_level{0};
-  const char *preset_mode_ptr_{nullptr};
-  size_t preset_mode_len_{0};
-  void set_preset_mode(const char *data, size_t len) {
-    this->preset_mode_ptr_ = data;
-    this->preset_mode_len_ = len;
-  }
+  StringRef preset_mode_ref_{};
+  void set_preset_mode(const StringRef &ref) { this->preset_mode_ref_ = ref; }
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(uint32_t &total_size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
@@ -874,12 +791,8 @@ class LightStateResponse : public StateResponseProtoMessage {
   float color_temperature{0.0f};
   float cold_white{0.0f};
   float warm_white{0.0f};
-  const char *effect_ptr_{nullptr};
-  size_t effect_len_{0};
-  void set_effect(const char *data, size_t len) {
-    this->effect_ptr_ = data;
-    this->effect_len_ = len;
-  }
+  StringRef effect_ref_{};
+  void set_effect(const StringRef &ref) { this->effect_ref_ = ref; }
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(uint32_t &total_size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
@@ -939,20 +852,12 @@ class ListEntitiesSensorResponse : public InfoResponseProtoMessage {
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "list_entities_sensor_response"; }
 #endif
-  const char *unit_of_measurement_ptr_{nullptr};
-  size_t unit_of_measurement_len_{0};
-  void set_unit_of_measurement(const char *data, size_t len) {
-    this->unit_of_measurement_ptr_ = data;
-    this->unit_of_measurement_len_ = len;
-  }
+  StringRef unit_of_measurement_ref_{};
+  void set_unit_of_measurement(const StringRef &ref) { this->unit_of_measurement_ref_ = ref; }
   int32_t accuracy_decimals{0};
   bool force_update{false};
-  const char *device_class_ptr_{nullptr};
-  size_t device_class_len_{0};
-  void set_device_class(const char *data, size_t len) {
-    this->device_class_ptr_ = data;
-    this->device_class_len_ = len;
-  }
+  StringRef device_class_ref_{};
+  void set_device_class(const StringRef &ref) { this->device_class_ref_ = ref; }
   enums::SensorStateClass state_class{};
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(uint32_t &total_size) const override;
@@ -989,12 +894,8 @@ class ListEntitiesSwitchResponse : public InfoResponseProtoMessage {
   const char *message_name() const override { return "list_entities_switch_response"; }
 #endif
   bool assumed_state{false};
-  const char *device_class_ptr_{nullptr};
-  size_t device_class_len_{0};
-  void set_device_class(const char *data, size_t len) {
-    this->device_class_ptr_ = data;
-    this->device_class_len_ = len;
-  }
+  StringRef device_class_ref_{};
+  void set_device_class(const StringRef &ref) { this->device_class_ref_ = ref; }
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(uint32_t &total_size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
@@ -1044,12 +945,8 @@ class ListEntitiesTextSensorResponse : public InfoResponseProtoMessage {
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "list_entities_text_sensor_response"; }
 #endif
-  const char *device_class_ptr_{nullptr};
-  size_t device_class_len_{0};
-  void set_device_class(const char *data, size_t len) {
-    this->device_class_ptr_ = data;
-    this->device_class_len_ = len;
-  }
+  StringRef device_class_ref_{};
+  void set_device_class(const StringRef &ref) { this->device_class_ref_ = ref; }
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(uint32_t &total_size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
@@ -1065,12 +962,8 @@ class TextSensorStateResponse : public StateResponseProtoMessage {
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "text_sensor_state_response"; }
 #endif
-  const char *state_ptr_{nullptr};
-  size_t state_len_{0};
-  void set_state(const char *data, size_t len) {
-    this->state_ptr_ = data;
-    this->state_len_ = len;
-  }
+  StringRef state_ref_{};
+  void set_state(const StringRef &ref) { this->state_ref_ = ref; }
   bool missing_state{false};
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(uint32_t &total_size) const override;
@@ -1167,18 +1060,10 @@ class SubscribeHomeassistantServicesRequest : public ProtoDecodableMessage {
 };
 class HomeassistantServiceMap : public ProtoMessage {
  public:
-  const char *key_ptr_{nullptr};
-  size_t key_len_{0};
-  void set_key(const char *data, size_t len) {
-    this->key_ptr_ = data;
-    this->key_len_ = len;
-  }
-  const char *value_ptr_{nullptr};
-  size_t value_len_{0};
-  void set_value(const char *data, size_t len) {
-    this->value_ptr_ = data;
-    this->value_len_ = len;
-  }
+  StringRef key_ref_{};
+  void set_key(const StringRef &ref) { this->key_ref_ = ref; }
+  StringRef value_ref_{};
+  void set_value(const StringRef &ref) { this->value_ref_ = ref; }
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(uint32_t &total_size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
@@ -1194,12 +1079,8 @@ class HomeassistantServiceResponse : public ProtoMessage {
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "homeassistant_service_response"; }
 #endif
-  const char *service_ptr_{nullptr};
-  size_t service_len_{0};
-  void set_service(const char *data, size_t len) {
-    this->service_ptr_ = data;
-    this->service_len_ = len;
-  }
+  StringRef service_ref_{};
+  void set_service(const StringRef &ref) { this->service_ref_ = ref; }
   std::vector<HomeassistantServiceMap> data{};
   std::vector<HomeassistantServiceMap> data_template{};
   std::vector<HomeassistantServiceMap> variables{};
@@ -1232,18 +1113,10 @@ class SubscribeHomeAssistantStateResponse : public ProtoMessage {
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "subscribe_home_assistant_state_response"; }
 #endif
-  const char *entity_id_ptr_{nullptr};
-  size_t entity_id_len_{0};
-  void set_entity_id(const char *data, size_t len) {
-    this->entity_id_ptr_ = data;
-    this->entity_id_len_ = len;
-  }
-  const char *attribute_ptr_{nullptr};
-  size_t attribute_len_{0};
-  void set_attribute(const char *data, size_t len) {
-    this->attribute_ptr_ = data;
-    this->attribute_len_ = len;
-  }
+  StringRef entity_id_ref_{};
+  void set_entity_id(const StringRef &ref) { this->entity_id_ref_ = ref; }
+  StringRef attribute_ref_{};
+  void set_attribute(const StringRef &ref) { this->attribute_ref_ = ref; }
   bool once{false};
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(uint32_t &total_size) const override;
@@ -1303,12 +1176,8 @@ class GetTimeResponse : public ProtoDecodableMessage {
 #ifdef USE_API_SERVICES
 class ListEntitiesServicesArgument : public ProtoMessage {
  public:
-  const char *name_ptr_{nullptr};
-  size_t name_len_{0};
-  void set_name(const char *data, size_t len) {
-    this->name_ptr_ = data;
-    this->name_len_ = len;
-  }
+  StringRef name_ref_{};
+  void set_name(const StringRef &ref) { this->name_ref_ = ref; }
   enums::ServiceArgType type{};
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(uint32_t &total_size) const override;
@@ -1325,12 +1194,8 @@ class ListEntitiesServicesResponse : public ProtoMessage {
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "list_entities_services_response"; }
 #endif
-  const char *name_ptr_{nullptr};
-  size_t name_len_{0};
-  void set_name(const char *data, size_t len) {
-    this->name_ptr_ = data;
-    this->name_len_ = len;
-  }
+  StringRef name_ref_{};
+  void set_name(const StringRef &ref) { this->name_ref_ = ref; }
   uint32_t key{0};
   std::vector<ListEntitiesServicesArgument> args{};
   void encode(ProtoWriteBuffer buffer) const override;
@@ -1482,19 +1347,11 @@ class ClimateStateResponse : public StateResponseProtoMessage {
   enums::ClimateAction action{};
   enums::ClimateFanMode fan_mode{};
   enums::ClimateSwingMode swing_mode{};
-  const char *custom_fan_mode_ptr_{nullptr};
-  size_t custom_fan_mode_len_{0};
-  void set_custom_fan_mode(const char *data, size_t len) {
-    this->custom_fan_mode_ptr_ = data;
-    this->custom_fan_mode_len_ = len;
-  }
+  StringRef custom_fan_mode_ref_{};
+  void set_custom_fan_mode(const StringRef &ref) { this->custom_fan_mode_ref_ = ref; }
   enums::ClimatePreset preset{};
-  const char *custom_preset_ptr_{nullptr};
-  size_t custom_preset_len_{0};
-  void set_custom_preset(const char *data, size_t len) {
-    this->custom_preset_ptr_ = data;
-    this->custom_preset_len_ = len;
-  }
+  StringRef custom_preset_ref_{};
+  void set_custom_preset(const StringRef &ref) { this->custom_preset_ref_ = ref; }
   float current_humidity{0.0f};
   float target_humidity{0.0f};
   void encode(ProtoWriteBuffer buffer) const override;
@@ -1553,19 +1410,11 @@ class ListEntitiesNumberResponse : public InfoResponseProtoMessage {
   float min_value{0.0f};
   float max_value{0.0f};
   float step{0.0f};
-  const char *unit_of_measurement_ptr_{nullptr};
-  size_t unit_of_measurement_len_{0};
-  void set_unit_of_measurement(const char *data, size_t len) {
-    this->unit_of_measurement_ptr_ = data;
-    this->unit_of_measurement_len_ = len;
-  }
+  StringRef unit_of_measurement_ref_{};
+  void set_unit_of_measurement(const StringRef &ref) { this->unit_of_measurement_ref_ = ref; }
   enums::NumberMode mode{};
-  const char *device_class_ptr_{nullptr};
-  size_t device_class_len_{0};
-  void set_device_class(const char *data, size_t len) {
-    this->device_class_ptr_ = data;
-    this->device_class_len_ = len;
-  }
+  StringRef device_class_ref_{};
+  void set_device_class(const StringRef &ref) { this->device_class_ref_ = ref; }
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(uint32_t &total_size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
@@ -1632,12 +1481,8 @@ class SelectStateResponse : public StateResponseProtoMessage {
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "select_state_response"; }
 #endif
-  const char *state_ptr_{nullptr};
-  size_t state_len_{0};
-  void set_state(const char *data, size_t len) {
-    this->state_ptr_ = data;
-    this->state_len_ = len;
-  }
+  StringRef state_ref_{};
+  void set_state(const StringRef &ref) { this->state_ref_ = ref; }
   bool missing_state{false};
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(uint32_t &total_size) const override;
@@ -1736,12 +1581,8 @@ class ListEntitiesLockResponse : public InfoResponseProtoMessage {
   bool assumed_state{false};
   bool supports_open{false};
   bool requires_code{false};
-  const char *code_format_ptr_{nullptr};
-  size_t code_format_len_{0};
-  void set_code_format(const char *data, size_t len) {
-    this->code_format_ptr_ = data;
-    this->code_format_len_ = len;
-  }
+  StringRef code_format_ref_{};
+  void set_code_format(const StringRef &ref) { this->code_format_ref_ = ref; }
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(uint32_t &total_size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
@@ -1794,12 +1635,8 @@ class ListEntitiesButtonResponse : public InfoResponseProtoMessage {
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "list_entities_button_response"; }
 #endif
-  const char *device_class_ptr_{nullptr};
-  size_t device_class_len_{0};
-  void set_device_class(const char *data, size_t len) {
-    this->device_class_ptr_ = data;
-    this->device_class_len_ = len;
-  }
+  StringRef device_class_ref_{};
+  void set_device_class(const StringRef &ref) { this->device_class_ref_ = ref; }
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(uint32_t &total_size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
@@ -1827,12 +1664,8 @@ class ButtonCommandRequest : public CommandProtoMessage {
 #ifdef USE_MEDIA_PLAYER
 class MediaPlayerSupportedFormat : public ProtoMessage {
  public:
-  const char *format_ptr_{nullptr};
-  size_t format_len_{0};
-  void set_format(const char *data, size_t len) {
-    this->format_ptr_ = data;
-    this->format_len_ = len;
-  }
+  StringRef format_ref_{};
+  void set_format(const StringRef &ref) { this->format_ref_ = ref; }
   uint32_t sample_rate{0};
   uint32_t num_channels{0};
   enums::MediaPlayerFormatPurpose purpose{};
@@ -2429,20 +2262,12 @@ class VoiceAssistantRequest : public ProtoMessage {
   const char *message_name() const override { return "voice_assistant_request"; }
 #endif
   bool start{false};
-  const char *conversation_id_ptr_{nullptr};
-  size_t conversation_id_len_{0};
-  void set_conversation_id(const char *data, size_t len) {
-    this->conversation_id_ptr_ = data;
-    this->conversation_id_len_ = len;
-  }
+  StringRef conversation_id_ref_{};
+  void set_conversation_id(const StringRef &ref) { this->conversation_id_ref_ = ref; }
   uint32_t flags{0};
   VoiceAssistantAudioSettings audio_settings{};
-  const char *wake_word_phrase_ptr_{nullptr};
-  size_t wake_word_phrase_len_{0};
-  void set_wake_word_phrase(const char *data, size_t len) {
-    this->wake_word_phrase_ptr_ = data;
-    this->wake_word_phrase_len_ = len;
-  }
+  StringRef wake_word_phrase_ref_{};
+  void set_wake_word_phrase(const StringRef &ref) { this->wake_word_phrase_ref_ = ref; }
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(uint32_t &total_size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
@@ -2578,18 +2403,10 @@ class VoiceAssistantAnnounceFinished : public ProtoMessage {
 };
 class VoiceAssistantWakeWord : public ProtoMessage {
  public:
-  const char *id_ptr_{nullptr};
-  size_t id_len_{0};
-  void set_id(const char *data, size_t len) {
-    this->id_ptr_ = data;
-    this->id_len_ = len;
-  }
-  const char *wake_word_ptr_{nullptr};
-  size_t wake_word_len_{0};
-  void set_wake_word(const char *data, size_t len) {
-    this->wake_word_ptr_ = data;
-    this->wake_word_len_ = len;
-  }
+  StringRef id_ref_{};
+  void set_id(const StringRef &ref) { this->id_ref_ = ref; }
+  StringRef wake_word_ref_{};
+  void set_wake_word(const StringRef &ref) { this->wake_word_ref_ = ref; }
   std::vector<std::string> trained_languages{};
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(uint32_t &total_size) const override;
@@ -2710,12 +2527,8 @@ class ListEntitiesTextResponse : public InfoResponseProtoMessage {
 #endif
   uint32_t min_length{0};
   uint32_t max_length{0};
-  const char *pattern_ptr_{nullptr};
-  size_t pattern_len_{0};
-  void set_pattern(const char *data, size_t len) {
-    this->pattern_ptr_ = data;
-    this->pattern_len_ = len;
-  }
+  StringRef pattern_ref_{};
+  void set_pattern(const StringRef &ref) { this->pattern_ref_ = ref; }
   enums::TextMode mode{};
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(uint32_t &total_size) const override;
@@ -2732,12 +2545,8 @@ class TextStateResponse : public StateResponseProtoMessage {
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "text_state_response"; }
 #endif
-  const char *state_ptr_{nullptr};
-  size_t state_len_{0};
-  void set_state(const char *data, size_t len) {
-    this->state_ptr_ = data;
-    this->state_len_ = len;
-  }
+  StringRef state_ref_{};
+  void set_state(const StringRef &ref) { this->state_ref_ = ref; }
   bool missing_state{false};
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(uint32_t &total_size) const override;
@@ -2881,12 +2690,8 @@ class ListEntitiesEventResponse : public InfoResponseProtoMessage {
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "list_entities_event_response"; }
 #endif
-  const char *device_class_ptr_{nullptr};
-  size_t device_class_len_{0};
-  void set_device_class(const char *data, size_t len) {
-    this->device_class_ptr_ = data;
-    this->device_class_len_ = len;
-  }
+  StringRef device_class_ref_{};
+  void set_device_class(const StringRef &ref) { this->device_class_ref_ = ref; }
   std::vector<std::string> event_types{};
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(uint32_t &total_size) const override;
@@ -2903,12 +2708,8 @@ class EventResponse : public StateResponseProtoMessage {
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "event_response"; }
 #endif
-  const char *event_type_ptr_{nullptr};
-  size_t event_type_len_{0};
-  void set_event_type(const char *data, size_t len) {
-    this->event_type_ptr_ = data;
-    this->event_type_len_ = len;
-  }
+  StringRef event_type_ref_{};
+  void set_event_type(const StringRef &ref) { this->event_type_ref_ = ref; }
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(uint32_t &total_size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
@@ -2926,12 +2727,8 @@ class ListEntitiesValveResponse : public InfoResponseProtoMessage {
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "list_entities_valve_response"; }
 #endif
-  const char *device_class_ptr_{nullptr};
-  size_t device_class_len_{0};
-  void set_device_class(const char *data, size_t len) {
-    this->device_class_ptr_ = data;
-    this->device_class_len_ = len;
-  }
+  StringRef device_class_ref_{};
+  void set_device_class(const StringRef &ref) { this->device_class_ref_ = ref; }
   bool assumed_state{false};
   bool supports_position{false};
   bool supports_stop{false};
@@ -3037,12 +2834,8 @@ class ListEntitiesUpdateResponse : public InfoResponseProtoMessage {
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "list_entities_update_response"; }
 #endif
-  const char *device_class_ptr_{nullptr};
-  size_t device_class_len_{0};
-  void set_device_class(const char *data, size_t len) {
-    this->device_class_ptr_ = data;
-    this->device_class_len_ = len;
-  }
+  StringRef device_class_ref_{};
+  void set_device_class(const StringRef &ref) { this->device_class_ref_ = ref; }
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(uint32_t &total_size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
@@ -3062,36 +2855,16 @@ class UpdateStateResponse : public StateResponseProtoMessage {
   bool in_progress{false};
   bool has_progress{false};
   float progress{0.0f};
-  const char *current_version_ptr_{nullptr};
-  size_t current_version_len_{0};
-  void set_current_version(const char *data, size_t len) {
-    this->current_version_ptr_ = data;
-    this->current_version_len_ = len;
-  }
-  const char *latest_version_ptr_{nullptr};
-  size_t latest_version_len_{0};
-  void set_latest_version(const char *data, size_t len) {
-    this->latest_version_ptr_ = data;
-    this->latest_version_len_ = len;
-  }
-  const char *title_ptr_{nullptr};
-  size_t title_len_{0};
-  void set_title(const char *data, size_t len) {
-    this->title_ptr_ = data;
-    this->title_len_ = len;
-  }
-  const char *release_summary_ptr_{nullptr};
-  size_t release_summary_len_{0};
-  void set_release_summary(const char *data, size_t len) {
-    this->release_summary_ptr_ = data;
-    this->release_summary_len_ = len;
-  }
-  const char *release_url_ptr_{nullptr};
-  size_t release_url_len_{0};
-  void set_release_url(const char *data, size_t len) {
-    this->release_url_ptr_ = data;
-    this->release_url_len_ = len;
-  }
+  StringRef current_version_ref_{};
+  void set_current_version(const StringRef &ref) { this->current_version_ref_ = ref; }
+  StringRef latest_version_ref_{};
+  void set_latest_version(const StringRef &ref) { this->latest_version_ref_ = ref; }
+  StringRef title_ref_{};
+  void set_title(const StringRef &ref) { this->title_ref_ = ref; }
+  StringRef release_summary_ref_{};
+  void set_release_summary(const StringRef &ref) { this->release_summary_ref_ = ref; }
+  StringRef release_url_ref_{};
+  void set_release_url(const StringRef &ref) { this->release_url_ref_ = ref; }
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(uint32_t &total_size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP

--- a/esphome/components/api/api_pb2.h
+++ b/esphome/components/api/api_pb2.h
@@ -269,12 +269,27 @@ enum UpdateCommand : uint32_t {
 class InfoResponseProtoMessage : public ProtoMessage {
  public:
   ~InfoResponseProtoMessage() override = default;
-  std::string object_id{};
+  const char *object_id_ptr_{nullptr};
+  size_t object_id_len_{0};
+  void set_object_id(const char *data, size_t len) {
+    this->object_id_ptr_ = data;
+    this->object_id_len_ = len;
+  }
   uint32_t key{0};
-  std::string name{};
+  const char *name_ptr_{nullptr};
+  size_t name_len_{0};
+  void set_name(const char *data, size_t len) {
+    this->name_ptr_ = data;
+    this->name_len_ = len;
+  }
   bool disabled_by_default{false};
 #ifdef USE_ENTITY_ICON
-  std::string icon{};
+  const char *icon_ptr_{nullptr};
+  size_t icon_len_{0};
+  void set_icon(const char *data, size_t len) {
+    this->icon_ptr_ = data;
+    this->icon_len_ = len;
+  }
 #endif
   enums::EntityCategory entity_category{};
 #ifdef USE_DEVICES
@@ -332,8 +347,18 @@ class HelloResponse : public ProtoMessage {
 #endif
   uint32_t api_version_major{0};
   uint32_t api_version_minor{0};
-  std::string server_info{};
-  std::string name{};
+  const char *server_info_ptr_{nullptr};
+  size_t server_info_len_{0};
+  void set_server_info(const char *data, size_t len) {
+    this->server_info_ptr_ = data;
+    this->server_info_len_ = len;
+  }
+  const char *name_ptr_{nullptr};
+  size_t name_len_{0};
+  void set_name(const char *data, size_t len) {
+    this->name_ptr_ = data;
+    this->name_len_ = len;
+  }
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(uint32_t &total_size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
@@ -442,7 +467,12 @@ class DeviceInfoRequest : public ProtoDecodableMessage {
 class AreaInfo : public ProtoMessage {
  public:
   uint32_t area_id{0};
-  std::string name{};
+  const char *name_ptr_{nullptr};
+  size_t name_len_{0};
+  void set_name(const char *data, size_t len) {
+    this->name_ptr_ = data;
+    this->name_len_ = len;
+  }
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(uint32_t &total_size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
@@ -456,7 +486,12 @@ class AreaInfo : public ProtoMessage {
 class DeviceInfo : public ProtoMessage {
  public:
   uint32_t device_id{0};
-  std::string name{};
+  const char *name_ptr_{nullptr};
+  size_t name_len_{0};
+  void set_name(const char *data, size_t len) {
+    this->name_ptr_ = data;
+    this->name_len_ = len;
+  }
   uint32_t area_id{0};
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(uint32_t &total_size) const override;
@@ -477,19 +512,54 @@ class DeviceInfoResponse : public ProtoMessage {
 #ifdef USE_API_PASSWORD
   bool uses_password{false};
 #endif
-  std::string name{};
-  std::string mac_address{};
-  std::string esphome_version{};
-  std::string compilation_time{};
-  std::string model{};
+  const char *name_ptr_{nullptr};
+  size_t name_len_{0};
+  void set_name(const char *data, size_t len) {
+    this->name_ptr_ = data;
+    this->name_len_ = len;
+  }
+  const char *mac_address_ptr_{nullptr};
+  size_t mac_address_len_{0};
+  void set_mac_address(const char *data, size_t len) {
+    this->mac_address_ptr_ = data;
+    this->mac_address_len_ = len;
+  }
+  const char *esphome_version_ptr_{nullptr};
+  size_t esphome_version_len_{0};
+  void set_esphome_version(const char *data, size_t len) {
+    this->esphome_version_ptr_ = data;
+    this->esphome_version_len_ = len;
+  }
+  const char *compilation_time_ptr_{nullptr};
+  size_t compilation_time_len_{0};
+  void set_compilation_time(const char *data, size_t len) {
+    this->compilation_time_ptr_ = data;
+    this->compilation_time_len_ = len;
+  }
+  const char *model_ptr_{nullptr};
+  size_t model_len_{0};
+  void set_model(const char *data, size_t len) {
+    this->model_ptr_ = data;
+    this->model_len_ = len;
+  }
 #ifdef USE_DEEP_SLEEP
   bool has_deep_sleep{false};
 #endif
 #ifdef ESPHOME_PROJECT_NAME
-  std::string project_name{};
+  const char *project_name_ptr_{nullptr};
+  size_t project_name_len_{0};
+  void set_project_name(const char *data, size_t len) {
+    this->project_name_ptr_ = data;
+    this->project_name_len_ = len;
+  }
 #endif
 #ifdef ESPHOME_PROJECT_NAME
-  std::string project_version{};
+  const char *project_version_ptr_{nullptr};
+  size_t project_version_len_{0};
+  void set_project_version(const char *data, size_t len) {
+    this->project_version_ptr_ = data;
+    this->project_version_len_ = len;
+  }
 #endif
 #ifdef USE_WEBSERVER
   uint32_t webserver_port{0};
@@ -497,16 +567,36 @@ class DeviceInfoResponse : public ProtoMessage {
 #ifdef USE_BLUETOOTH_PROXY
   uint32_t bluetooth_proxy_feature_flags{0};
 #endif
-  std::string manufacturer{};
-  std::string friendly_name{};
+  const char *manufacturer_ptr_{nullptr};
+  size_t manufacturer_len_{0};
+  void set_manufacturer(const char *data, size_t len) {
+    this->manufacturer_ptr_ = data;
+    this->manufacturer_len_ = len;
+  }
+  const char *friendly_name_ptr_{nullptr};
+  size_t friendly_name_len_{0};
+  void set_friendly_name(const char *data, size_t len) {
+    this->friendly_name_ptr_ = data;
+    this->friendly_name_len_ = len;
+  }
 #ifdef USE_VOICE_ASSISTANT
   uint32_t voice_assistant_feature_flags{0};
 #endif
 #ifdef USE_AREAS
-  std::string suggested_area{};
+  const char *suggested_area_ptr_{nullptr};
+  size_t suggested_area_len_{0};
+  void set_suggested_area(const char *data, size_t len) {
+    this->suggested_area_ptr_ = data;
+    this->suggested_area_len_ = len;
+  }
 #endif
 #ifdef USE_BLUETOOTH_PROXY
-  std::string bluetooth_mac_address{};
+  const char *bluetooth_mac_address_ptr_{nullptr};
+  size_t bluetooth_mac_address_len_{0};
+  void set_bluetooth_mac_address(const char *data, size_t len) {
+    this->bluetooth_mac_address_ptr_ = data;
+    this->bluetooth_mac_address_len_ = len;
+  }
 #endif
 #ifdef USE_API_NOISE
   bool api_encryption_supported{false};
@@ -575,7 +665,12 @@ class ListEntitiesBinarySensorResponse : public InfoResponseProtoMessage {
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "list_entities_binary_sensor_response"; }
 #endif
-  std::string device_class{};
+  const char *device_class_ptr_{nullptr};
+  size_t device_class_len_{0};
+  void set_device_class(const char *data, size_t len) {
+    this->device_class_ptr_ = data;
+    this->device_class_len_ = len;
+  }
   bool is_status_binary_sensor{false};
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(uint32_t &total_size) const override;
@@ -614,7 +709,12 @@ class ListEntitiesCoverResponse : public InfoResponseProtoMessage {
   bool assumed_state{false};
   bool supports_position{false};
   bool supports_tilt{false};
-  std::string device_class{};
+  const char *device_class_ptr_{nullptr};
+  size_t device_class_len_{0};
+  void set_device_class(const char *data, size_t len) {
+    this->device_class_ptr_ = data;
+    this->device_class_len_ = len;
+  }
   bool supports_stop{false};
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(uint32_t &total_size) const override;
@@ -695,7 +795,12 @@ class FanStateResponse : public StateResponseProtoMessage {
   bool oscillating{false};
   enums::FanDirection direction{};
   int32_t speed_level{0};
-  std::string preset_mode{};
+  const char *preset_mode_ptr_{nullptr};
+  size_t preset_mode_len_{0};
+  void set_preset_mode(const char *data, size_t len) {
+    this->preset_mode_ptr_ = data;
+    this->preset_mode_len_ = len;
+  }
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(uint32_t &total_size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
@@ -769,7 +874,12 @@ class LightStateResponse : public StateResponseProtoMessage {
   float color_temperature{0.0f};
   float cold_white{0.0f};
   float warm_white{0.0f};
-  std::string effect{};
+  const char *effect_ptr_{nullptr};
+  size_t effect_len_{0};
+  void set_effect(const char *data, size_t len) {
+    this->effect_ptr_ = data;
+    this->effect_len_ = len;
+  }
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(uint32_t &total_size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
@@ -829,10 +939,20 @@ class ListEntitiesSensorResponse : public InfoResponseProtoMessage {
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "list_entities_sensor_response"; }
 #endif
-  std::string unit_of_measurement{};
+  const char *unit_of_measurement_ptr_{nullptr};
+  size_t unit_of_measurement_len_{0};
+  void set_unit_of_measurement(const char *data, size_t len) {
+    this->unit_of_measurement_ptr_ = data;
+    this->unit_of_measurement_len_ = len;
+  }
   int32_t accuracy_decimals{0};
   bool force_update{false};
-  std::string device_class{};
+  const char *device_class_ptr_{nullptr};
+  size_t device_class_len_{0};
+  void set_device_class(const char *data, size_t len) {
+    this->device_class_ptr_ = data;
+    this->device_class_len_ = len;
+  }
   enums::SensorStateClass state_class{};
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(uint32_t &total_size) const override;
@@ -869,7 +989,12 @@ class ListEntitiesSwitchResponse : public InfoResponseProtoMessage {
   const char *message_name() const override { return "list_entities_switch_response"; }
 #endif
   bool assumed_state{false};
-  std::string device_class{};
+  const char *device_class_ptr_{nullptr};
+  size_t device_class_len_{0};
+  void set_device_class(const char *data, size_t len) {
+    this->device_class_ptr_ = data;
+    this->device_class_len_ = len;
+  }
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(uint32_t &total_size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
@@ -919,7 +1044,12 @@ class ListEntitiesTextSensorResponse : public InfoResponseProtoMessage {
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "list_entities_text_sensor_response"; }
 #endif
-  std::string device_class{};
+  const char *device_class_ptr_{nullptr};
+  size_t device_class_len_{0};
+  void set_device_class(const char *data, size_t len) {
+    this->device_class_ptr_ = data;
+    this->device_class_len_ = len;
+  }
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(uint32_t &total_size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
@@ -935,7 +1065,12 @@ class TextSensorStateResponse : public StateResponseProtoMessage {
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "text_sensor_state_response"; }
 #endif
-  std::string state{};
+  const char *state_ptr_{nullptr};
+  size_t state_len_{0};
+  void set_state(const char *data, size_t len) {
+    this->state_ptr_ = data;
+    this->state_len_ = len;
+  }
   bool missing_state{false};
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(uint32_t &total_size) const override;
@@ -1032,8 +1167,18 @@ class SubscribeHomeassistantServicesRequest : public ProtoDecodableMessage {
 };
 class HomeassistantServiceMap : public ProtoMessage {
  public:
-  std::string key{};
-  std::string value{};
+  const char *key_ptr_{nullptr};
+  size_t key_len_{0};
+  void set_key(const char *data, size_t len) {
+    this->key_ptr_ = data;
+    this->key_len_ = len;
+  }
+  const char *value_ptr_{nullptr};
+  size_t value_len_{0};
+  void set_value(const char *data, size_t len) {
+    this->value_ptr_ = data;
+    this->value_len_ = len;
+  }
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(uint32_t &total_size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
@@ -1049,7 +1194,12 @@ class HomeassistantServiceResponse : public ProtoMessage {
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "homeassistant_service_response"; }
 #endif
-  std::string service{};
+  const char *service_ptr_{nullptr};
+  size_t service_len_{0};
+  void set_service(const char *data, size_t len) {
+    this->service_ptr_ = data;
+    this->service_len_ = len;
+  }
   std::vector<HomeassistantServiceMap> data{};
   std::vector<HomeassistantServiceMap> data_template{};
   std::vector<HomeassistantServiceMap> variables{};
@@ -1082,8 +1232,18 @@ class SubscribeHomeAssistantStateResponse : public ProtoMessage {
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "subscribe_home_assistant_state_response"; }
 #endif
-  std::string entity_id{};
-  std::string attribute{};
+  const char *entity_id_ptr_{nullptr};
+  size_t entity_id_len_{0};
+  void set_entity_id(const char *data, size_t len) {
+    this->entity_id_ptr_ = data;
+    this->entity_id_len_ = len;
+  }
+  const char *attribute_ptr_{nullptr};
+  size_t attribute_len_{0};
+  void set_attribute(const char *data, size_t len) {
+    this->attribute_ptr_ = data;
+    this->attribute_len_ = len;
+  }
   bool once{false};
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(uint32_t &total_size) const override;
@@ -1143,7 +1303,12 @@ class GetTimeResponse : public ProtoDecodableMessage {
 #ifdef USE_API_SERVICES
 class ListEntitiesServicesArgument : public ProtoMessage {
  public:
-  std::string name{};
+  const char *name_ptr_{nullptr};
+  size_t name_len_{0};
+  void set_name(const char *data, size_t len) {
+    this->name_ptr_ = data;
+    this->name_len_ = len;
+  }
   enums::ServiceArgType type{};
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(uint32_t &total_size) const override;
@@ -1160,7 +1325,12 @@ class ListEntitiesServicesResponse : public ProtoMessage {
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "list_entities_services_response"; }
 #endif
-  std::string name{};
+  const char *name_ptr_{nullptr};
+  size_t name_len_{0};
+  void set_name(const char *data, size_t len) {
+    this->name_ptr_ = data;
+    this->name_len_ = len;
+  }
   uint32_t key{0};
   std::vector<ListEntitiesServicesArgument> args{};
   void encode(ProtoWriteBuffer buffer) const override;
@@ -1312,9 +1482,19 @@ class ClimateStateResponse : public StateResponseProtoMessage {
   enums::ClimateAction action{};
   enums::ClimateFanMode fan_mode{};
   enums::ClimateSwingMode swing_mode{};
-  std::string custom_fan_mode{};
+  const char *custom_fan_mode_ptr_{nullptr};
+  size_t custom_fan_mode_len_{0};
+  void set_custom_fan_mode(const char *data, size_t len) {
+    this->custom_fan_mode_ptr_ = data;
+    this->custom_fan_mode_len_ = len;
+  }
   enums::ClimatePreset preset{};
-  std::string custom_preset{};
+  const char *custom_preset_ptr_{nullptr};
+  size_t custom_preset_len_{0};
+  void set_custom_preset(const char *data, size_t len) {
+    this->custom_preset_ptr_ = data;
+    this->custom_preset_len_ = len;
+  }
   float current_humidity{0.0f};
   float target_humidity{0.0f};
   void encode(ProtoWriteBuffer buffer) const override;
@@ -1373,9 +1553,19 @@ class ListEntitiesNumberResponse : public InfoResponseProtoMessage {
   float min_value{0.0f};
   float max_value{0.0f};
   float step{0.0f};
-  std::string unit_of_measurement{};
+  const char *unit_of_measurement_ptr_{nullptr};
+  size_t unit_of_measurement_len_{0};
+  void set_unit_of_measurement(const char *data, size_t len) {
+    this->unit_of_measurement_ptr_ = data;
+    this->unit_of_measurement_len_ = len;
+  }
   enums::NumberMode mode{};
-  std::string device_class{};
+  const char *device_class_ptr_{nullptr};
+  size_t device_class_len_{0};
+  void set_device_class(const char *data, size_t len) {
+    this->device_class_ptr_ = data;
+    this->device_class_len_ = len;
+  }
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(uint32_t &total_size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
@@ -1442,7 +1632,12 @@ class SelectStateResponse : public StateResponseProtoMessage {
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "select_state_response"; }
 #endif
-  std::string state{};
+  const char *state_ptr_{nullptr};
+  size_t state_len_{0};
+  void set_state(const char *data, size_t len) {
+    this->state_ptr_ = data;
+    this->state_len_ = len;
+  }
   bool missing_state{false};
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(uint32_t &total_size) const override;
@@ -1541,7 +1736,12 @@ class ListEntitiesLockResponse : public InfoResponseProtoMessage {
   bool assumed_state{false};
   bool supports_open{false};
   bool requires_code{false};
-  std::string code_format{};
+  const char *code_format_ptr_{nullptr};
+  size_t code_format_len_{0};
+  void set_code_format(const char *data, size_t len) {
+    this->code_format_ptr_ = data;
+    this->code_format_len_ = len;
+  }
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(uint32_t &total_size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
@@ -1594,7 +1794,12 @@ class ListEntitiesButtonResponse : public InfoResponseProtoMessage {
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "list_entities_button_response"; }
 #endif
-  std::string device_class{};
+  const char *device_class_ptr_{nullptr};
+  size_t device_class_len_{0};
+  void set_device_class(const char *data, size_t len) {
+    this->device_class_ptr_ = data;
+    this->device_class_len_ = len;
+  }
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(uint32_t &total_size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
@@ -1622,7 +1827,12 @@ class ButtonCommandRequest : public CommandProtoMessage {
 #ifdef USE_MEDIA_PLAYER
 class MediaPlayerSupportedFormat : public ProtoMessage {
  public:
-  std::string format{};
+  const char *format_ptr_{nullptr};
+  size_t format_len_{0};
+  void set_format(const char *data, size_t len) {
+    this->format_ptr_ = data;
+    this->format_len_ = len;
+  }
   uint32_t sample_rate{0};
   uint32_t num_channels{0};
   enums::MediaPlayerFormatPurpose purpose{};
@@ -2219,10 +2429,20 @@ class VoiceAssistantRequest : public ProtoMessage {
   const char *message_name() const override { return "voice_assistant_request"; }
 #endif
   bool start{false};
-  std::string conversation_id{};
+  const char *conversation_id_ptr_{nullptr};
+  size_t conversation_id_len_{0};
+  void set_conversation_id(const char *data, size_t len) {
+    this->conversation_id_ptr_ = data;
+    this->conversation_id_len_ = len;
+  }
   uint32_t flags{0};
   VoiceAssistantAudioSettings audio_settings{};
-  std::string wake_word_phrase{};
+  const char *wake_word_phrase_ptr_{nullptr};
+  size_t wake_word_phrase_len_{0};
+  void set_wake_word_phrase(const char *data, size_t len) {
+    this->wake_word_phrase_ptr_ = data;
+    this->wake_word_phrase_len_ = len;
+  }
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(uint32_t &total_size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
@@ -2358,8 +2578,18 @@ class VoiceAssistantAnnounceFinished : public ProtoMessage {
 };
 class VoiceAssistantWakeWord : public ProtoMessage {
  public:
-  std::string id{};
-  std::string wake_word{};
+  const char *id_ptr_{nullptr};
+  size_t id_len_{0};
+  void set_id(const char *data, size_t len) {
+    this->id_ptr_ = data;
+    this->id_len_ = len;
+  }
+  const char *wake_word_ptr_{nullptr};
+  size_t wake_word_len_{0};
+  void set_wake_word(const char *data, size_t len) {
+    this->wake_word_ptr_ = data;
+    this->wake_word_len_ = len;
+  }
   std::vector<std::string> trained_languages{};
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(uint32_t &total_size) const override;
@@ -2480,7 +2710,12 @@ class ListEntitiesTextResponse : public InfoResponseProtoMessage {
 #endif
   uint32_t min_length{0};
   uint32_t max_length{0};
-  std::string pattern{};
+  const char *pattern_ptr_{nullptr};
+  size_t pattern_len_{0};
+  void set_pattern(const char *data, size_t len) {
+    this->pattern_ptr_ = data;
+    this->pattern_len_ = len;
+  }
   enums::TextMode mode{};
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(uint32_t &total_size) const override;
@@ -2497,7 +2732,12 @@ class TextStateResponse : public StateResponseProtoMessage {
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "text_state_response"; }
 #endif
-  std::string state{};
+  const char *state_ptr_{nullptr};
+  size_t state_len_{0};
+  void set_state(const char *data, size_t len) {
+    this->state_ptr_ = data;
+    this->state_len_ = len;
+  }
   bool missing_state{false};
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(uint32_t &total_size) const override;
@@ -2641,7 +2881,12 @@ class ListEntitiesEventResponse : public InfoResponseProtoMessage {
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "list_entities_event_response"; }
 #endif
-  std::string device_class{};
+  const char *device_class_ptr_{nullptr};
+  size_t device_class_len_{0};
+  void set_device_class(const char *data, size_t len) {
+    this->device_class_ptr_ = data;
+    this->device_class_len_ = len;
+  }
   std::vector<std::string> event_types{};
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(uint32_t &total_size) const override;
@@ -2658,7 +2903,12 @@ class EventResponse : public StateResponseProtoMessage {
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "event_response"; }
 #endif
-  std::string event_type{};
+  const char *event_type_ptr_{nullptr};
+  size_t event_type_len_{0};
+  void set_event_type(const char *data, size_t len) {
+    this->event_type_ptr_ = data;
+    this->event_type_len_ = len;
+  }
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(uint32_t &total_size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
@@ -2676,7 +2926,12 @@ class ListEntitiesValveResponse : public InfoResponseProtoMessage {
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "list_entities_valve_response"; }
 #endif
-  std::string device_class{};
+  const char *device_class_ptr_{nullptr};
+  size_t device_class_len_{0};
+  void set_device_class(const char *data, size_t len) {
+    this->device_class_ptr_ = data;
+    this->device_class_len_ = len;
+  }
   bool assumed_state{false};
   bool supports_position{false};
   bool supports_stop{false};
@@ -2782,7 +3037,12 @@ class ListEntitiesUpdateResponse : public InfoResponseProtoMessage {
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "list_entities_update_response"; }
 #endif
-  std::string device_class{};
+  const char *device_class_ptr_{nullptr};
+  size_t device_class_len_{0};
+  void set_device_class(const char *data, size_t len) {
+    this->device_class_ptr_ = data;
+    this->device_class_len_ = len;
+  }
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(uint32_t &total_size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
@@ -2802,11 +3062,36 @@ class UpdateStateResponse : public StateResponseProtoMessage {
   bool in_progress{false};
   bool has_progress{false};
   float progress{0.0f};
-  std::string current_version{};
-  std::string latest_version{};
-  std::string title{};
-  std::string release_summary{};
-  std::string release_url{};
+  const char *current_version_ptr_{nullptr};
+  size_t current_version_len_{0};
+  void set_current_version(const char *data, size_t len) {
+    this->current_version_ptr_ = data;
+    this->current_version_len_ = len;
+  }
+  const char *latest_version_ptr_{nullptr};
+  size_t latest_version_len_{0};
+  void set_latest_version(const char *data, size_t len) {
+    this->latest_version_ptr_ = data;
+    this->latest_version_len_ = len;
+  }
+  const char *title_ptr_{nullptr};
+  size_t title_len_{0};
+  void set_title(const char *data, size_t len) {
+    this->title_ptr_ = data;
+    this->title_len_ = len;
+  }
+  const char *release_summary_ptr_{nullptr};
+  size_t release_summary_len_{0};
+  void set_release_summary(const char *data, size_t len) {
+    this->release_summary_ptr_ = data;
+    this->release_summary_len_ = len;
+  }
+  const char *release_url_ptr_{nullptr};
+  size_t release_url_len_{0};
+  void set_release_url(const char *data, size_t len) {
+    this->release_url_ptr_ = data;
+    this->release_url_len_ = len;
+  }
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(uint32_t &total_size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP

--- a/esphome/components/api/api_pb2_dump.cpp
+++ b/esphome/components/api/api_pb2_dump.cpp
@@ -580,11 +580,19 @@ void HelloResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  server_info: ");
-  out.append("'").append(this->server_info).append("'");
+  if (this->server_info_ptr_ != nullptr) {
+    out.append("'").append(this->server_info_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
   out.append("  name: ");
-  out.append("'").append(this->name).append("'");
+  if (this->name_ptr_ != nullptr) {
+    out.append("'").append(this->name_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
   out.append("}");
 }
@@ -619,7 +627,11 @@ void AreaInfo::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  name: ");
-  out.append("'").append(this->name).append("'");
+  if (this->name_ptr_ != nullptr) {
+    out.append("'").append(this->name_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
   out.append("}");
 }
@@ -634,7 +646,11 @@ void DeviceInfo::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  name: ");
-  out.append("'").append(this->name).append("'");
+  if (this->name_ptr_ != nullptr) {
+    out.append("'").append(this->name_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
   out.append("  area_id: ");
@@ -654,23 +670,43 @@ void DeviceInfoResponse::dump_to(std::string &out) const {
 
 #endif
   out.append("  name: ");
-  out.append("'").append(this->name).append("'");
+  if (this->name_ptr_ != nullptr) {
+    out.append("'").append(this->name_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
   out.append("  mac_address: ");
-  out.append("'").append(this->mac_address).append("'");
+  if (this->mac_address_ptr_ != nullptr) {
+    out.append("'").append(this->mac_address_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
   out.append("  esphome_version: ");
-  out.append("'").append(this->esphome_version).append("'");
+  if (this->esphome_version_ptr_ != nullptr) {
+    out.append("'").append(this->esphome_version_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
   out.append("  compilation_time: ");
-  out.append("'").append(this->compilation_time).append("'");
+  if (this->compilation_time_ptr_ != nullptr) {
+    out.append("'").append(this->compilation_time_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
   out.append("  model: ");
-  out.append("'").append(this->model).append("'");
+  if (this->model_ptr_ != nullptr) {
+    out.append("'").append(this->model_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
 #ifdef USE_DEEP_SLEEP
@@ -681,13 +717,21 @@ void DeviceInfoResponse::dump_to(std::string &out) const {
 #endif
 #ifdef ESPHOME_PROJECT_NAME
   out.append("  project_name: ");
-  out.append("'").append(this->project_name).append("'");
+  if (this->project_name_ptr_ != nullptr) {
+    out.append("'").append(this->project_name_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
 #endif
 #ifdef ESPHOME_PROJECT_NAME
   out.append("  project_version: ");
-  out.append("'").append(this->project_version).append("'");
+  if (this->project_version_ptr_ != nullptr) {
+    out.append("'").append(this->project_version_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
 #endif
@@ -706,11 +750,19 @@ void DeviceInfoResponse::dump_to(std::string &out) const {
 
 #endif
   out.append("  manufacturer: ");
-  out.append("'").append(this->manufacturer).append("'");
+  if (this->manufacturer_ptr_ != nullptr) {
+    out.append("'").append(this->manufacturer_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
   out.append("  friendly_name: ");
-  out.append("'").append(this->friendly_name).append("'");
+  if (this->friendly_name_ptr_ != nullptr) {
+    out.append("'").append(this->friendly_name_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
 #ifdef USE_VOICE_ASSISTANT
@@ -722,13 +774,21 @@ void DeviceInfoResponse::dump_to(std::string &out) const {
 #endif
 #ifdef USE_AREAS
   out.append("  suggested_area: ");
-  out.append("'").append(this->suggested_area).append("'");
+  if (this->suggested_area_ptr_ != nullptr) {
+    out.append("'").append(this->suggested_area_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
 #endif
 #ifdef USE_BLUETOOTH_PROXY
   out.append("  bluetooth_mac_address: ");
-  out.append("'").append(this->bluetooth_mac_address).append("'");
+  if (this->bluetooth_mac_address_ptr_ != nullptr) {
+    out.append("'").append(this->bluetooth_mac_address_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
 #endif
@@ -770,7 +830,11 @@ void ListEntitiesBinarySensorResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("ListEntitiesBinarySensorResponse {\n");
   out.append("  object_id: ");
-  out.append("'").append(this->object_id).append("'");
+  if (this->object_id_ptr_ != nullptr) {
+    out.append("'").append(this->object_id_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
   out.append("  key: ");
@@ -779,11 +843,19 @@ void ListEntitiesBinarySensorResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  name: ");
-  out.append("'").append(this->name).append("'");
+  if (this->name_ptr_ != nullptr) {
+    out.append("'").append(this->name_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
   out.append("  device_class: ");
-  out.append("'").append(this->device_class).append("'");
+  if (this->device_class_ptr_ != nullptr) {
+    out.append("'").append(this->device_class_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
   out.append("  is_status_binary_sensor: ");
@@ -796,7 +868,11 @@ void ListEntitiesBinarySensorResponse::dump_to(std::string &out) const {
 
 #ifdef USE_ENTITY_ICON
   out.append("  icon: ");
-  out.append("'").append(this->icon).append("'");
+  if (this->icon_ptr_ != nullptr) {
+    out.append("'").append(this->icon_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
 #endif
@@ -844,7 +920,11 @@ void ListEntitiesCoverResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("ListEntitiesCoverResponse {\n");
   out.append("  object_id: ");
-  out.append("'").append(this->object_id).append("'");
+  if (this->object_id_ptr_ != nullptr) {
+    out.append("'").append(this->object_id_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
   out.append("  key: ");
@@ -853,7 +933,11 @@ void ListEntitiesCoverResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  name: ");
-  out.append("'").append(this->name).append("'");
+  if (this->name_ptr_ != nullptr) {
+    out.append("'").append(this->name_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
   out.append("  assumed_state: ");
@@ -869,7 +953,11 @@ void ListEntitiesCoverResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  device_class: ");
-  out.append("'").append(this->device_class).append("'");
+  if (this->device_class_ptr_ != nullptr) {
+    out.append("'").append(this->device_class_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
   out.append("  disabled_by_default: ");
@@ -878,7 +966,11 @@ void ListEntitiesCoverResponse::dump_to(std::string &out) const {
 
 #ifdef USE_ENTITY_ICON
   out.append("  icon: ");
-  out.append("'").append(this->icon).append("'");
+  if (this->icon_ptr_ != nullptr) {
+    out.append("'").append(this->icon_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
 #endif
@@ -975,7 +1067,11 @@ void ListEntitiesFanResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("ListEntitiesFanResponse {\n");
   out.append("  object_id: ");
-  out.append("'").append(this->object_id).append("'");
+  if (this->object_id_ptr_ != nullptr) {
+    out.append("'").append(this->object_id_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
   out.append("  key: ");
@@ -984,7 +1080,11 @@ void ListEntitiesFanResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  name: ");
-  out.append("'").append(this->name).append("'");
+  if (this->name_ptr_ != nullptr) {
+    out.append("'").append(this->name_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
   out.append("  supports_oscillation: ");
@@ -1010,7 +1110,11 @@ void ListEntitiesFanResponse::dump_to(std::string &out) const {
 
 #ifdef USE_ENTITY_ICON
   out.append("  icon: ");
-  out.append("'").append(this->icon).append("'");
+  if (this->icon_ptr_ != nullptr) {
+    out.append("'").append(this->icon_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
 #endif
@@ -1020,7 +1124,11 @@ void ListEntitiesFanResponse::dump_to(std::string &out) const {
 
   for (const auto &it : this->supported_preset_modes) {
     out.append("  supported_preset_modes: ");
-    out.append("'").append(it).append("'");
+    if (this->supported_preset_modes_ptr_ != nullptr) {
+      out.append("'").append(this->supported_preset_modes_ptr_).append("'");
+    } else {
+      out.append("'").append(this->supported_preset_modes).append("'");
+    }
     out.append("\n");
   }
 
@@ -1059,7 +1167,11 @@ void FanStateResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  preset_mode: ");
-  out.append("'").append(this->preset_mode).append("'");
+  if (this->preset_mode_ptr_ != nullptr) {
+    out.append("'").append(this->preset_mode_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
 #ifdef USE_DEVICES
@@ -1135,7 +1247,11 @@ void ListEntitiesLightResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("ListEntitiesLightResponse {\n");
   out.append("  object_id: ");
-  out.append("'").append(this->object_id).append("'");
+  if (this->object_id_ptr_ != nullptr) {
+    out.append("'").append(this->object_id_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
   out.append("  key: ");
@@ -1144,7 +1260,11 @@ void ListEntitiesLightResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  name: ");
-  out.append("'").append(this->name).append("'");
+  if (this->name_ptr_ != nullptr) {
+    out.append("'").append(this->name_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
   for (const auto &it : this->supported_color_modes) {
@@ -1165,7 +1285,11 @@ void ListEntitiesLightResponse::dump_to(std::string &out) const {
 
   for (const auto &it : this->effects) {
     out.append("  effects: ");
-    out.append("'").append(it).append("'");
+    if (this->effects_ptr_ != nullptr) {
+      out.append("'").append(this->effects_ptr_).append("'");
+    } else {
+      out.append("'").append(this->effects).append("'");
+    }
     out.append("\n");
   }
 
@@ -1175,7 +1299,11 @@ void ListEntitiesLightResponse::dump_to(std::string &out) const {
 
 #ifdef USE_ENTITY_ICON
   out.append("  icon: ");
-  out.append("'").append(this->icon).append("'");
+  if (this->icon_ptr_ != nullptr) {
+    out.append("'").append(this->icon_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
 #endif
@@ -1254,7 +1382,11 @@ void LightStateResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  effect: ");
-  out.append("'").append(this->effect).append("'");
+  if (this->effect_ptr_ != nullptr) {
+    out.append("'").append(this->effect_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
 #ifdef USE_DEVICES
@@ -1404,7 +1536,11 @@ void ListEntitiesSensorResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("ListEntitiesSensorResponse {\n");
   out.append("  object_id: ");
-  out.append("'").append(this->object_id).append("'");
+  if (this->object_id_ptr_ != nullptr) {
+    out.append("'").append(this->object_id_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
   out.append("  key: ");
@@ -1413,17 +1549,29 @@ void ListEntitiesSensorResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  name: ");
-  out.append("'").append(this->name).append("'");
+  if (this->name_ptr_ != nullptr) {
+    out.append("'").append(this->name_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
 #ifdef USE_ENTITY_ICON
   out.append("  icon: ");
-  out.append("'").append(this->icon).append("'");
+  if (this->icon_ptr_ != nullptr) {
+    out.append("'").append(this->icon_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
 #endif
   out.append("  unit_of_measurement: ");
-  out.append("'").append(this->unit_of_measurement).append("'");
+  if (this->unit_of_measurement_ptr_ != nullptr) {
+    out.append("'").append(this->unit_of_measurement_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
   out.append("  accuracy_decimals: ");
@@ -1436,7 +1584,11 @@ void ListEntitiesSensorResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  device_class: ");
-  out.append("'").append(this->device_class).append("'");
+  if (this->device_class_ptr_ != nullptr) {
+    out.append("'").append(this->device_class_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
   out.append("  state_class: ");
@@ -1492,7 +1644,11 @@ void ListEntitiesSwitchResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("ListEntitiesSwitchResponse {\n");
   out.append("  object_id: ");
-  out.append("'").append(this->object_id).append("'");
+  if (this->object_id_ptr_ != nullptr) {
+    out.append("'").append(this->object_id_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
   out.append("  key: ");
@@ -1501,12 +1657,20 @@ void ListEntitiesSwitchResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  name: ");
-  out.append("'").append(this->name).append("'");
+  if (this->name_ptr_ != nullptr) {
+    out.append("'").append(this->name_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
 #ifdef USE_ENTITY_ICON
   out.append("  icon: ");
-  out.append("'").append(this->icon).append("'");
+  if (this->icon_ptr_ != nullptr) {
+    out.append("'").append(this->icon_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
 #endif
@@ -1523,7 +1687,11 @@ void ListEntitiesSwitchResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  device_class: ");
-  out.append("'").append(this->device_class).append("'");
+  if (this->device_class_ptr_ != nullptr) {
+    out.append("'").append(this->device_class_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
 #ifdef USE_DEVICES
@@ -1583,7 +1751,11 @@ void ListEntitiesTextSensorResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("ListEntitiesTextSensorResponse {\n");
   out.append("  object_id: ");
-  out.append("'").append(this->object_id).append("'");
+  if (this->object_id_ptr_ != nullptr) {
+    out.append("'").append(this->object_id_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
   out.append("  key: ");
@@ -1592,12 +1764,20 @@ void ListEntitiesTextSensorResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  name: ");
-  out.append("'").append(this->name).append("'");
+  if (this->name_ptr_ != nullptr) {
+    out.append("'").append(this->name_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
 #ifdef USE_ENTITY_ICON
   out.append("  icon: ");
-  out.append("'").append(this->icon).append("'");
+  if (this->icon_ptr_ != nullptr) {
+    out.append("'").append(this->icon_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
 #endif
@@ -1610,7 +1790,11 @@ void ListEntitiesTextSensorResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  device_class: ");
-  out.append("'").append(this->device_class).append("'");
+  if (this->device_class_ptr_ != nullptr) {
+    out.append("'").append(this->device_class_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
 #ifdef USE_DEVICES
@@ -1631,7 +1815,11 @@ void TextSensorStateResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  state: ");
-  out.append("'").append(this->state).append("'");
+  if (this->state_ptr_ != nullptr) {
+    out.append("'").append(this->state_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
   out.append("  missing_state: ");
@@ -1697,11 +1885,19 @@ void HomeassistantServiceMap::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("HomeassistantServiceMap {\n");
   out.append("  key: ");
-  out.append("'").append(this->key).append("'");
+  if (this->key_ptr_ != nullptr) {
+    out.append("'").append(this->key_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
   out.append("  value: ");
-  out.append("'").append(this->value).append("'");
+  if (this->value_ptr_ != nullptr) {
+    out.append("'").append(this->value_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
   out.append("}");
 }
@@ -1709,7 +1905,11 @@ void HomeassistantServiceResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("HomeassistantServiceResponse {\n");
   out.append("  service: ");
-  out.append("'").append(this->service).append("'");
+  if (this->service_ptr_ != nullptr) {
+    out.append("'").append(this->service_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
   for (const auto &it : this->data) {
@@ -1742,11 +1942,19 @@ void SubscribeHomeAssistantStateResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("SubscribeHomeAssistantStateResponse {\n");
   out.append("  entity_id: ");
-  out.append("'").append(this->entity_id).append("'");
+  if (this->entity_id_ptr_ != nullptr) {
+    out.append("'").append(this->entity_id_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
   out.append("  attribute: ");
-  out.append("'").append(this->attribute).append("'");
+  if (this->attribute_ptr_ != nullptr) {
+    out.append("'").append(this->attribute_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
   out.append("  once: ");
@@ -1785,7 +1993,11 @@ void ListEntitiesServicesArgument::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("ListEntitiesServicesArgument {\n");
   out.append("  name: ");
-  out.append("'").append(this->name).append("'");
+  if (this->name_ptr_ != nullptr) {
+    out.append("'").append(this->name_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
   out.append("  type: ");
@@ -1797,7 +2009,11 @@ void ListEntitiesServicesResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("ListEntitiesServicesResponse {\n");
   out.append("  name: ");
-  out.append("'").append(this->name).append("'");
+  if (this->name_ptr_ != nullptr) {
+    out.append("'").append(this->name_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
   out.append("  key: ");
@@ -1860,7 +2076,11 @@ void ExecuteServiceArgument::dump_to(std::string &out) const {
 
   for (const auto &it : this->string_array) {
     out.append("  string_array: ");
-    out.append("'").append(it).append("'");
+    if (this->string_array_ptr_ != nullptr) {
+      out.append("'").append(this->string_array_ptr_).append("'");
+    } else {
+      out.append("'").append(this->string_array).append("'");
+    }
     out.append("\n");
   }
   out.append("}");
@@ -1886,7 +2106,11 @@ void ListEntitiesCameraResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("ListEntitiesCameraResponse {\n");
   out.append("  object_id: ");
-  out.append("'").append(this->object_id).append("'");
+  if (this->object_id_ptr_ != nullptr) {
+    out.append("'").append(this->object_id_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
   out.append("  key: ");
@@ -1895,7 +2119,11 @@ void ListEntitiesCameraResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  name: ");
-  out.append("'").append(this->name).append("'");
+  if (this->name_ptr_ != nullptr) {
+    out.append("'").append(this->name_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
   out.append("  disabled_by_default: ");
@@ -1904,7 +2132,11 @@ void ListEntitiesCameraResponse::dump_to(std::string &out) const {
 
 #ifdef USE_ENTITY_ICON
   out.append("  icon: ");
-  out.append("'").append(this->icon).append("'");
+  if (this->icon_ptr_ != nullptr) {
+    out.append("'").append(this->icon_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
 #endif
@@ -1964,7 +2196,11 @@ void ListEntitiesClimateResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("ListEntitiesClimateResponse {\n");
   out.append("  object_id: ");
-  out.append("'").append(this->object_id).append("'");
+  if (this->object_id_ptr_ != nullptr) {
+    out.append("'").append(this->object_id_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
   out.append("  key: ");
@@ -1973,7 +2209,11 @@ void ListEntitiesClimateResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  name: ");
-  out.append("'").append(this->name).append("'");
+  if (this->name_ptr_ != nullptr) {
+    out.append("'").append(this->name_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
   out.append("  supports_current_temperature: ");
@@ -2023,7 +2263,11 @@ void ListEntitiesClimateResponse::dump_to(std::string &out) const {
 
   for (const auto &it : this->supported_custom_fan_modes) {
     out.append("  supported_custom_fan_modes: ");
-    out.append("'").append(it).append("'");
+    if (this->supported_custom_fan_modes_ptr_ != nullptr) {
+      out.append("'").append(this->supported_custom_fan_modes_ptr_).append("'");
+    } else {
+      out.append("'").append(this->supported_custom_fan_modes).append("'");
+    }
     out.append("\n");
   }
 
@@ -2035,7 +2279,11 @@ void ListEntitiesClimateResponse::dump_to(std::string &out) const {
 
   for (const auto &it : this->supported_custom_presets) {
     out.append("  supported_custom_presets: ");
-    out.append("'").append(it).append("'");
+    if (this->supported_custom_presets_ptr_ != nullptr) {
+      out.append("'").append(this->supported_custom_presets_ptr_).append("'");
+    } else {
+      out.append("'").append(this->supported_custom_presets).append("'");
+    }
     out.append("\n");
   }
 
@@ -2045,7 +2293,11 @@ void ListEntitiesClimateResponse::dump_to(std::string &out) const {
 
 #ifdef USE_ENTITY_ICON
   out.append("  icon: ");
-  out.append("'").append(this->icon).append("'");
+  if (this->icon_ptr_ != nullptr) {
+    out.append("'").append(this->icon_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
 #endif
@@ -2130,7 +2382,11 @@ void ClimateStateResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  custom_fan_mode: ");
-  out.append("'").append(this->custom_fan_mode).append("'");
+  if (this->custom_fan_mode_ptr_ != nullptr) {
+    out.append("'").append(this->custom_fan_mode_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
   out.append("  preset: ");
@@ -2138,7 +2394,11 @@ void ClimateStateResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  custom_preset: ");
-  out.append("'").append(this->custom_preset).append("'");
+  if (this->custom_preset_ptr_ != nullptr) {
+    out.append("'").append(this->custom_preset_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
   out.append("  current_humidity: ");
@@ -2267,7 +2527,11 @@ void ListEntitiesNumberResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("ListEntitiesNumberResponse {\n");
   out.append("  object_id: ");
-  out.append("'").append(this->object_id).append("'");
+  if (this->object_id_ptr_ != nullptr) {
+    out.append("'").append(this->object_id_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
   out.append("  key: ");
@@ -2276,12 +2540,20 @@ void ListEntitiesNumberResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  name: ");
-  out.append("'").append(this->name).append("'");
+  if (this->name_ptr_ != nullptr) {
+    out.append("'").append(this->name_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
 #ifdef USE_ENTITY_ICON
   out.append("  icon: ");
-  out.append("'").append(this->icon).append("'");
+  if (this->icon_ptr_ != nullptr) {
+    out.append("'").append(this->icon_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
 #endif
@@ -2309,7 +2581,11 @@ void ListEntitiesNumberResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  unit_of_measurement: ");
-  out.append("'").append(this->unit_of_measurement).append("'");
+  if (this->unit_of_measurement_ptr_ != nullptr) {
+    out.append("'").append(this->unit_of_measurement_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
   out.append("  mode: ");
@@ -2317,7 +2593,11 @@ void ListEntitiesNumberResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  device_class: ");
-  out.append("'").append(this->device_class).append("'");
+  if (this->device_class_ptr_ != nullptr) {
+    out.append("'").append(this->device_class_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
 #ifdef USE_DEVICES
@@ -2383,7 +2663,11 @@ void ListEntitiesSelectResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("ListEntitiesSelectResponse {\n");
   out.append("  object_id: ");
-  out.append("'").append(this->object_id).append("'");
+  if (this->object_id_ptr_ != nullptr) {
+    out.append("'").append(this->object_id_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
   out.append("  key: ");
@@ -2392,18 +2676,30 @@ void ListEntitiesSelectResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  name: ");
-  out.append("'").append(this->name).append("'");
+  if (this->name_ptr_ != nullptr) {
+    out.append("'").append(this->name_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
 #ifdef USE_ENTITY_ICON
   out.append("  icon: ");
-  out.append("'").append(this->icon).append("'");
+  if (this->icon_ptr_ != nullptr) {
+    out.append("'").append(this->icon_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
 #endif
   for (const auto &it : this->options) {
     out.append("  options: ");
-    out.append("'").append(it).append("'");
+    if (this->options_ptr_ != nullptr) {
+      out.append("'").append(this->options_ptr_).append("'");
+    } else {
+      out.append("'").append(this->options).append("'");
+    }
     out.append("\n");
   }
 
@@ -2433,7 +2729,11 @@ void SelectStateResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  state: ");
-  out.append("'").append(this->state).append("'");
+  if (this->state_ptr_ != nullptr) {
+    out.append("'").append(this->state_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
   out.append("  missing_state: ");
@@ -2476,7 +2776,11 @@ void ListEntitiesSirenResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("ListEntitiesSirenResponse {\n");
   out.append("  object_id: ");
-  out.append("'").append(this->object_id).append("'");
+  if (this->object_id_ptr_ != nullptr) {
+    out.append("'").append(this->object_id_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
   out.append("  key: ");
@@ -2485,12 +2789,20 @@ void ListEntitiesSirenResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  name: ");
-  out.append("'").append(this->name).append("'");
+  if (this->name_ptr_ != nullptr) {
+    out.append("'").append(this->name_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
 #ifdef USE_ENTITY_ICON
   out.append("  icon: ");
-  out.append("'").append(this->icon).append("'");
+  if (this->icon_ptr_ != nullptr) {
+    out.append("'").append(this->icon_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
 #endif
@@ -2500,7 +2812,11 @@ void ListEntitiesSirenResponse::dump_to(std::string &out) const {
 
   for (const auto &it : this->tones) {
     out.append("  tones: ");
-    out.append("'").append(it).append("'");
+    if (this->tones_ptr_ != nullptr) {
+      out.append("'").append(this->tones_ptr_).append("'");
+    } else {
+      out.append("'").append(this->tones).append("'");
+    }
     out.append("\n");
   }
 
@@ -2603,7 +2919,11 @@ void ListEntitiesLockResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("ListEntitiesLockResponse {\n");
   out.append("  object_id: ");
-  out.append("'").append(this->object_id).append("'");
+  if (this->object_id_ptr_ != nullptr) {
+    out.append("'").append(this->object_id_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
   out.append("  key: ");
@@ -2612,12 +2932,20 @@ void ListEntitiesLockResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  name: ");
-  out.append("'").append(this->name).append("'");
+  if (this->name_ptr_ != nullptr) {
+    out.append("'").append(this->name_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
 #ifdef USE_ENTITY_ICON
   out.append("  icon: ");
-  out.append("'").append(this->icon).append("'");
+  if (this->icon_ptr_ != nullptr) {
+    out.append("'").append(this->icon_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
 #endif
@@ -2642,7 +2970,11 @@ void ListEntitiesLockResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  code_format: ");
-  out.append("'").append(this->code_format).append("'");
+  if (this->code_format_ptr_ != nullptr) {
+    out.append("'").append(this->code_format_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
 #ifdef USE_DEVICES
@@ -2710,7 +3042,11 @@ void ListEntitiesButtonResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("ListEntitiesButtonResponse {\n");
   out.append("  object_id: ");
-  out.append("'").append(this->object_id).append("'");
+  if (this->object_id_ptr_ != nullptr) {
+    out.append("'").append(this->object_id_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
   out.append("  key: ");
@@ -2719,12 +3055,20 @@ void ListEntitiesButtonResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  name: ");
-  out.append("'").append(this->name).append("'");
+  if (this->name_ptr_ != nullptr) {
+    out.append("'").append(this->name_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
 #ifdef USE_ENTITY_ICON
   out.append("  icon: ");
-  out.append("'").append(this->icon).append("'");
+  if (this->icon_ptr_ != nullptr) {
+    out.append("'").append(this->icon_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
 #endif
@@ -2737,7 +3081,11 @@ void ListEntitiesButtonResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  device_class: ");
-  out.append("'").append(this->device_class).append("'");
+  if (this->device_class_ptr_ != nullptr) {
+    out.append("'").append(this->device_class_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
 #ifdef USE_DEVICES
@@ -2772,7 +3120,11 @@ void MediaPlayerSupportedFormat::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("MediaPlayerSupportedFormat {\n");
   out.append("  format: ");
-  out.append("'").append(this->format).append("'");
+  if (this->format_ptr_ != nullptr) {
+    out.append("'").append(this->format_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
   out.append("  sample_rate: ");
@@ -2799,7 +3151,11 @@ void ListEntitiesMediaPlayerResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("ListEntitiesMediaPlayerResponse {\n");
   out.append("  object_id: ");
-  out.append("'").append(this->object_id).append("'");
+  if (this->object_id_ptr_ != nullptr) {
+    out.append("'").append(this->object_id_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
   out.append("  key: ");
@@ -2808,12 +3164,20 @@ void ListEntitiesMediaPlayerResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  name: ");
-  out.append("'").append(this->name).append("'");
+  if (this->name_ptr_ != nullptr) {
+    out.append("'").append(this->name_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
 #ifdef USE_ENTITY_ICON
   out.append("  icon: ");
-  out.append("'").append(this->icon).append("'");
+  if (this->icon_ptr_ != nullptr) {
+    out.append("'").append(this->icon_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
 #endif
@@ -3423,7 +3787,11 @@ void VoiceAssistantRequest::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  conversation_id: ");
-  out.append("'").append(this->conversation_id).append("'");
+  if (this->conversation_id_ptr_ != nullptr) {
+    out.append("'").append(this->conversation_id_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
   out.append("  flags: ");
@@ -3436,7 +3804,11 @@ void VoiceAssistantRequest::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  wake_word_phrase: ");
-  out.append("'").append(this->wake_word_phrase).append("'");
+  if (this->wake_word_phrase_ptr_ != nullptr) {
+    out.append("'").append(this->wake_word_phrase_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
   out.append("}");
 }
@@ -3557,16 +3929,28 @@ void VoiceAssistantWakeWord::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("VoiceAssistantWakeWord {\n");
   out.append("  id: ");
-  out.append("'").append(this->id).append("'");
+  if (this->id_ptr_ != nullptr) {
+    out.append("'").append(this->id_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
   out.append("  wake_word: ");
-  out.append("'").append(this->wake_word).append("'");
+  if (this->wake_word_ptr_ != nullptr) {
+    out.append("'").append(this->wake_word_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
   for (const auto &it : this->trained_languages) {
     out.append("  trained_languages: ");
-    out.append("'").append(it).append("'");
+    if (this->trained_languages_ptr_ != nullptr) {
+      out.append("'").append(this->trained_languages_ptr_).append("'");
+    } else {
+      out.append("'").append(this->trained_languages).append("'");
+    }
     out.append("\n");
   }
   out.append("}");
@@ -3585,7 +3969,11 @@ void VoiceAssistantConfigurationResponse::dump_to(std::string &out) const {
 
   for (const auto &it : this->active_wake_words) {
     out.append("  active_wake_words: ");
-    out.append("'").append(it).append("'");
+    if (this->active_wake_words_ptr_ != nullptr) {
+      out.append("'").append(this->active_wake_words_ptr_).append("'");
+    } else {
+      out.append("'").append(this->active_wake_words).append("'");
+    }
     out.append("\n");
   }
 
@@ -3600,7 +3988,11 @@ void VoiceAssistantSetConfiguration::dump_to(std::string &out) const {
   out.append("VoiceAssistantSetConfiguration {\n");
   for (const auto &it : this->active_wake_words) {
     out.append("  active_wake_words: ");
-    out.append("'").append(it).append("'");
+    if (this->active_wake_words_ptr_ != nullptr) {
+      out.append("'").append(this->active_wake_words_ptr_).append("'");
+    } else {
+      out.append("'").append(this->active_wake_words).append("'");
+    }
     out.append("\n");
   }
   out.append("}");
@@ -3611,7 +4003,11 @@ void ListEntitiesAlarmControlPanelResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("ListEntitiesAlarmControlPanelResponse {\n");
   out.append("  object_id: ");
-  out.append("'").append(this->object_id).append("'");
+  if (this->object_id_ptr_ != nullptr) {
+    out.append("'").append(this->object_id_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
   out.append("  key: ");
@@ -3620,12 +4016,20 @@ void ListEntitiesAlarmControlPanelResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  name: ");
-  out.append("'").append(this->name).append("'");
+  if (this->name_ptr_ != nullptr) {
+    out.append("'").append(this->name_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
 #ifdef USE_ENTITY_ICON
   out.append("  icon: ");
-  out.append("'").append(this->icon).append("'");
+  if (this->icon_ptr_ != nullptr) {
+    out.append("'").append(this->icon_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
 #endif
@@ -3711,7 +4115,11 @@ void ListEntitiesTextResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("ListEntitiesTextResponse {\n");
   out.append("  object_id: ");
-  out.append("'").append(this->object_id).append("'");
+  if (this->object_id_ptr_ != nullptr) {
+    out.append("'").append(this->object_id_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
   out.append("  key: ");
@@ -3720,12 +4128,20 @@ void ListEntitiesTextResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  name: ");
-  out.append("'").append(this->name).append("'");
+  if (this->name_ptr_ != nullptr) {
+    out.append("'").append(this->name_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
 #ifdef USE_ENTITY_ICON
   out.append("  icon: ");
-  out.append("'").append(this->icon).append("'");
+  if (this->icon_ptr_ != nullptr) {
+    out.append("'").append(this->icon_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
 #endif
@@ -3748,7 +4164,11 @@ void ListEntitiesTextResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  pattern: ");
-  out.append("'").append(this->pattern).append("'");
+  if (this->pattern_ptr_ != nullptr) {
+    out.append("'").append(this->pattern_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
   out.append("  mode: ");
@@ -3773,7 +4193,11 @@ void TextStateResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  state: ");
-  out.append("'").append(this->state).append("'");
+  if (this->state_ptr_ != nullptr) {
+    out.append("'").append(this->state_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
   out.append("  missing_state: ");
@@ -3816,7 +4240,11 @@ void ListEntitiesDateResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("ListEntitiesDateResponse {\n");
   out.append("  object_id: ");
-  out.append("'").append(this->object_id).append("'");
+  if (this->object_id_ptr_ != nullptr) {
+    out.append("'").append(this->object_id_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
   out.append("  key: ");
@@ -3825,12 +4253,20 @@ void ListEntitiesDateResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  name: ");
-  out.append("'").append(this->name).append("'");
+  if (this->name_ptr_ != nullptr) {
+    out.append("'").append(this->name_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
 #ifdef USE_ENTITY_ICON
   out.append("  icon: ");
-  out.append("'").append(this->icon).append("'");
+  if (this->icon_ptr_ != nullptr) {
+    out.append("'").append(this->icon_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
 #endif
@@ -3925,7 +4361,11 @@ void ListEntitiesTimeResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("ListEntitiesTimeResponse {\n");
   out.append("  object_id: ");
-  out.append("'").append(this->object_id).append("'");
+  if (this->object_id_ptr_ != nullptr) {
+    out.append("'").append(this->object_id_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
   out.append("  key: ");
@@ -3934,12 +4374,20 @@ void ListEntitiesTimeResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  name: ");
-  out.append("'").append(this->name).append("'");
+  if (this->name_ptr_ != nullptr) {
+    out.append("'").append(this->name_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
 #ifdef USE_ENTITY_ICON
   out.append("  icon: ");
-  out.append("'").append(this->icon).append("'");
+  if (this->icon_ptr_ != nullptr) {
+    out.append("'").append(this->icon_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
 #endif
@@ -4034,7 +4482,11 @@ void ListEntitiesEventResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("ListEntitiesEventResponse {\n");
   out.append("  object_id: ");
-  out.append("'").append(this->object_id).append("'");
+  if (this->object_id_ptr_ != nullptr) {
+    out.append("'").append(this->object_id_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
   out.append("  key: ");
@@ -4043,12 +4495,20 @@ void ListEntitiesEventResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  name: ");
-  out.append("'").append(this->name).append("'");
+  if (this->name_ptr_ != nullptr) {
+    out.append("'").append(this->name_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
 #ifdef USE_ENTITY_ICON
   out.append("  icon: ");
-  out.append("'").append(this->icon).append("'");
+  if (this->icon_ptr_ != nullptr) {
+    out.append("'").append(this->icon_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
 #endif
@@ -4061,12 +4521,20 @@ void ListEntitiesEventResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  device_class: ");
-  out.append("'").append(this->device_class).append("'");
+  if (this->device_class_ptr_ != nullptr) {
+    out.append("'").append(this->device_class_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
   for (const auto &it : this->event_types) {
     out.append("  event_types: ");
-    out.append("'").append(it).append("'");
+    if (this->event_types_ptr_ != nullptr) {
+      out.append("'").append(this->event_types_ptr_).append("'");
+    } else {
+      out.append("'").append(this->event_types).append("'");
+    }
     out.append("\n");
   }
 
@@ -4088,7 +4556,11 @@ void EventResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  event_type: ");
-  out.append("'").append(this->event_type).append("'");
+  if (this->event_type_ptr_ != nullptr) {
+    out.append("'").append(this->event_type_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
 #ifdef USE_DEVICES
@@ -4106,7 +4578,11 @@ void ListEntitiesValveResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("ListEntitiesValveResponse {\n");
   out.append("  object_id: ");
-  out.append("'").append(this->object_id).append("'");
+  if (this->object_id_ptr_ != nullptr) {
+    out.append("'").append(this->object_id_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
   out.append("  key: ");
@@ -4115,12 +4591,20 @@ void ListEntitiesValveResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  name: ");
-  out.append("'").append(this->name).append("'");
+  if (this->name_ptr_ != nullptr) {
+    out.append("'").append(this->name_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
 #ifdef USE_ENTITY_ICON
   out.append("  icon: ");
-  out.append("'").append(this->icon).append("'");
+  if (this->icon_ptr_ != nullptr) {
+    out.append("'").append(this->icon_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
 #endif
@@ -4133,7 +4617,11 @@ void ListEntitiesValveResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  device_class: ");
-  out.append("'").append(this->device_class).append("'");
+  if (this->device_class_ptr_ != nullptr) {
+    out.append("'").append(this->device_class_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
   out.append("  assumed_state: ");
@@ -4219,7 +4707,11 @@ void ListEntitiesDateTimeResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("ListEntitiesDateTimeResponse {\n");
   out.append("  object_id: ");
-  out.append("'").append(this->object_id).append("'");
+  if (this->object_id_ptr_ != nullptr) {
+    out.append("'").append(this->object_id_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
   out.append("  key: ");
@@ -4228,12 +4720,20 @@ void ListEntitiesDateTimeResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  name: ");
-  out.append("'").append(this->name).append("'");
+  if (this->name_ptr_ != nullptr) {
+    out.append("'").append(this->name_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
 #ifdef USE_ENTITY_ICON
   out.append("  icon: ");
-  out.append("'").append(this->icon).append("'");
+  if (this->icon_ptr_ != nullptr) {
+    out.append("'").append(this->icon_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
 #endif
@@ -4308,7 +4808,11 @@ void ListEntitiesUpdateResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("ListEntitiesUpdateResponse {\n");
   out.append("  object_id: ");
-  out.append("'").append(this->object_id).append("'");
+  if (this->object_id_ptr_ != nullptr) {
+    out.append("'").append(this->object_id_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
   out.append("  key: ");
@@ -4317,12 +4821,20 @@ void ListEntitiesUpdateResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  name: ");
-  out.append("'").append(this->name).append("'");
+  if (this->name_ptr_ != nullptr) {
+    out.append("'").append(this->name_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
 #ifdef USE_ENTITY_ICON
   out.append("  icon: ");
-  out.append("'").append(this->icon).append("'");
+  if (this->icon_ptr_ != nullptr) {
+    out.append("'").append(this->icon_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
 #endif
@@ -4335,7 +4847,11 @@ void ListEntitiesUpdateResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  device_class: ");
-  out.append("'").append(this->device_class).append("'");
+  if (this->device_class_ptr_ != nullptr) {
+    out.append("'").append(this->device_class_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
 #ifdef USE_DEVICES
@@ -4373,23 +4889,43 @@ void UpdateStateResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  current_version: ");
-  out.append("'").append(this->current_version).append("'");
+  if (this->current_version_ptr_ != nullptr) {
+    out.append("'").append(this->current_version_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
   out.append("  latest_version: ");
-  out.append("'").append(this->latest_version).append("'");
+  if (this->latest_version_ptr_ != nullptr) {
+    out.append("'").append(this->latest_version_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
   out.append("  title: ");
-  out.append("'").append(this->title).append("'");
+  if (this->title_ptr_ != nullptr) {
+    out.append("'").append(this->title_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
   out.append("  release_summary: ");
-  out.append("'").append(this->release_summary).append("'");
+  if (this->release_summary_ptr_ != nullptr) {
+    out.append("'").append(this->release_summary_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
   out.append("  release_url: ");
-  out.append("'").append(this->release_url).append("'");
+  if (this->release_url_ptr_ != nullptr) {
+    out.append("'").append(this->release_url_ptr_).append("'");
+  } else {
+    out.append("'").append("").append("'");
+  }
   out.append("\n");
 
 #ifdef USE_DEVICES

--- a/esphome/components/api/api_pb2_dump.cpp
+++ b/esphome/components/api/api_pb2_dump.cpp
@@ -1877,11 +1877,7 @@ void ExecuteServiceArgument::dump_to(std::string &out) const {
 
   for (const auto &it : this->string_array) {
     out.append("  string_array: ");
-    if (!this->string_array_ref_.empty()) {
-      out.append("'").append(this->string_array_ref_.c_str()).append("'");
-    } else {
-      out.append("'").append(this->string_array).append("'");
-    }
+    append_quoted_string(out, StringRef(it));
     out.append("\n");
   }
   out.append("}");

--- a/esphome/components/api/api_pb2_dump.cpp
+++ b/esphome/components/api/api_pb2_dump.cpp
@@ -1029,11 +1029,7 @@ void ListEntitiesFanResponse::dump_to(std::string &out) const {
 
   for (const auto &it : this->supported_preset_modes) {
     out.append("  supported_preset_modes: ");
-    if (!this->supported_preset_modes_ref_.empty()) {
-      out.append("'").append(this->supported_preset_modes_ref_.c_str()).append("'");
-    } else {
-      out.append("'").append(this->supported_preset_modes).append("'");
-    }
+    append_quoted_string(out, StringRef(it));
     out.append("\n");
   }
 
@@ -1178,11 +1174,7 @@ void ListEntitiesLightResponse::dump_to(std::string &out) const {
 
   for (const auto &it : this->effects) {
     out.append("  effects: ");
-    if (!this->effects_ref_.empty()) {
-      out.append("'").append(this->effects_ref_.c_str()).append("'");
-    } else {
-      out.append("'").append(this->effects).append("'");
-    }
+    append_quoted_string(out, StringRef(it));
     out.append("\n");
   }
 
@@ -2040,11 +2032,7 @@ void ListEntitiesClimateResponse::dump_to(std::string &out) const {
 
   for (const auto &it : this->supported_custom_fan_modes) {
     out.append("  supported_custom_fan_modes: ");
-    if (!this->supported_custom_fan_modes_ref_.empty()) {
-      out.append("'").append(this->supported_custom_fan_modes_ref_.c_str()).append("'");
-    } else {
-      out.append("'").append(this->supported_custom_fan_modes).append("'");
-    }
+    append_quoted_string(out, StringRef(it));
     out.append("\n");
   }
 
@@ -2056,11 +2044,7 @@ void ListEntitiesClimateResponse::dump_to(std::string &out) const {
 
   for (const auto &it : this->supported_custom_presets) {
     out.append("  supported_custom_presets: ");
-    if (!this->supported_custom_presets_ref_.empty()) {
-      out.append("'").append(this->supported_custom_presets_ref_.c_str()).append("'");
-    } else {
-      out.append("'").append(this->supported_custom_presets).append("'");
-    }
+    append_quoted_string(out, StringRef(it));
     out.append("\n");
   }
 
@@ -2428,11 +2412,7 @@ void ListEntitiesSelectResponse::dump_to(std::string &out) const {
 #endif
   for (const auto &it : this->options) {
     out.append("  options: ");
-    if (!this->options_ref_.empty()) {
-      out.append("'").append(this->options_ref_.c_str()).append("'");
-    } else {
-      out.append("'").append(this->options).append("'");
-    }
+    append_quoted_string(out, StringRef(it));
     out.append("\n");
   }
 
@@ -2529,11 +2509,7 @@ void ListEntitiesSirenResponse::dump_to(std::string &out) const {
 
   for (const auto &it : this->tones) {
     out.append("  tones: ");
-    if (!this->tones_ref_.empty()) {
-      out.append("'").append(this->tones_ref_.c_str()).append("'");
-    } else {
-      out.append("'").append(this->tones).append("'");
-    }
+    append_quoted_string(out, StringRef(it));
     out.append("\n");
   }
 
@@ -3599,11 +3575,7 @@ void VoiceAssistantWakeWord::dump_to(std::string &out) const {
 
   for (const auto &it : this->trained_languages) {
     out.append("  trained_languages: ");
-    if (!this->trained_languages_ref_.empty()) {
-      out.append("'").append(this->trained_languages_ref_.c_str()).append("'");
-    } else {
-      out.append("'").append(this->trained_languages).append("'");
-    }
+    append_quoted_string(out, StringRef(it));
     out.append("\n");
   }
   out.append("}");
@@ -3622,11 +3594,7 @@ void VoiceAssistantConfigurationResponse::dump_to(std::string &out) const {
 
   for (const auto &it : this->active_wake_words) {
     out.append("  active_wake_words: ");
-    if (!this->active_wake_words_ref_.empty()) {
-      out.append("'").append(this->active_wake_words_ref_.c_str()).append("'");
-    } else {
-      out.append("'").append(this->active_wake_words).append("'");
-    }
+    append_quoted_string(out, StringRef(it));
     out.append("\n");
   }
 
@@ -3641,11 +3609,7 @@ void VoiceAssistantSetConfiguration::dump_to(std::string &out) const {
   out.append("VoiceAssistantSetConfiguration {\n");
   for (const auto &it : this->active_wake_words) {
     out.append("  active_wake_words: ");
-    if (!this->active_wake_words_ref_.empty()) {
-      out.append("'").append(this->active_wake_words_ref_.c_str()).append("'");
-    } else {
-      out.append("'").append(this->active_wake_words).append("'");
-    }
+    append_quoted_string(out, StringRef(it));
     out.append("\n");
   }
   out.append("}");
@@ -4111,11 +4075,7 @@ void ListEntitiesEventResponse::dump_to(std::string &out) const {
 
   for (const auto &it : this->event_types) {
     out.append("  event_types: ");
-    if (!this->event_types_ref_.empty()) {
-      out.append("'").append(this->event_types_ref_.c_str()).append("'");
-    } else {
-      out.append("'").append(this->event_types).append("'");
-    }
+    append_quoted_string(out, StringRef(it));
     out.append("\n");
   }
 

--- a/esphome/components/api/api_pb2_dump.cpp
+++ b/esphome/components/api/api_pb2_dump.cpp
@@ -10,6 +10,15 @@
 namespace esphome {
 namespace api {
 
+// Helper function to append a quoted string, handling empty StringRef
+static inline void append_quoted_string(std::string &out, const StringRef &ref) {
+  out.append("'");
+  if (!ref.empty()) {
+    out.append(ref.c_str());
+  }
+  out.append("'");
+}
+
 template<> const char *proto_enum_to_string<enums::EntityCategory>(enums::EntityCategory value) {
   switch (value) {
     case enums::ENTITY_CATEGORY_NONE:
@@ -580,19 +589,11 @@ void HelloResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  server_info: ");
-  if (!this->server_info_ref_.empty()) {
-    out.append("'").append(this->server_info_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->server_info_ref_);
   out.append("\n");
 
   out.append("  name: ");
-  if (!this->name_ref_.empty()) {
-    out.append("'").append(this->name_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->name_ref_);
   out.append("\n");
   out.append("}");
 }
@@ -627,11 +628,7 @@ void AreaInfo::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  name: ");
-  if (!this->name_ref_.empty()) {
-    out.append("'").append(this->name_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->name_ref_);
   out.append("\n");
   out.append("}");
 }
@@ -646,11 +643,7 @@ void DeviceInfo::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  name: ");
-  if (!this->name_ref_.empty()) {
-    out.append("'").append(this->name_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->name_ref_);
   out.append("\n");
 
   out.append("  area_id: ");
@@ -670,43 +663,23 @@ void DeviceInfoResponse::dump_to(std::string &out) const {
 
 #endif
   out.append("  name: ");
-  if (!this->name_ref_.empty()) {
-    out.append("'").append(this->name_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->name_ref_);
   out.append("\n");
 
   out.append("  mac_address: ");
-  if (!this->mac_address_ref_.empty()) {
-    out.append("'").append(this->mac_address_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->mac_address_ref_);
   out.append("\n");
 
   out.append("  esphome_version: ");
-  if (!this->esphome_version_ref_.empty()) {
-    out.append("'").append(this->esphome_version_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->esphome_version_ref_);
   out.append("\n");
 
   out.append("  compilation_time: ");
-  if (!this->compilation_time_ref_.empty()) {
-    out.append("'").append(this->compilation_time_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->compilation_time_ref_);
   out.append("\n");
 
   out.append("  model: ");
-  if (!this->model_ref_.empty()) {
-    out.append("'").append(this->model_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->model_ref_);
   out.append("\n");
 
 #ifdef USE_DEEP_SLEEP
@@ -717,21 +690,13 @@ void DeviceInfoResponse::dump_to(std::string &out) const {
 #endif
 #ifdef ESPHOME_PROJECT_NAME
   out.append("  project_name: ");
-  if (!this->project_name_ref_.empty()) {
-    out.append("'").append(this->project_name_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->project_name_ref_);
   out.append("\n");
 
 #endif
 #ifdef ESPHOME_PROJECT_NAME
   out.append("  project_version: ");
-  if (!this->project_version_ref_.empty()) {
-    out.append("'").append(this->project_version_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->project_version_ref_);
   out.append("\n");
 
 #endif
@@ -750,19 +715,11 @@ void DeviceInfoResponse::dump_to(std::string &out) const {
 
 #endif
   out.append("  manufacturer: ");
-  if (!this->manufacturer_ref_.empty()) {
-    out.append("'").append(this->manufacturer_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->manufacturer_ref_);
   out.append("\n");
 
   out.append("  friendly_name: ");
-  if (!this->friendly_name_ref_.empty()) {
-    out.append("'").append(this->friendly_name_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->friendly_name_ref_);
   out.append("\n");
 
 #ifdef USE_VOICE_ASSISTANT
@@ -774,21 +731,13 @@ void DeviceInfoResponse::dump_to(std::string &out) const {
 #endif
 #ifdef USE_AREAS
   out.append("  suggested_area: ");
-  if (!this->suggested_area_ref_.empty()) {
-    out.append("'").append(this->suggested_area_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->suggested_area_ref_);
   out.append("\n");
 
 #endif
 #ifdef USE_BLUETOOTH_PROXY
   out.append("  bluetooth_mac_address: ");
-  if (!this->bluetooth_mac_address_ref_.empty()) {
-    out.append("'").append(this->bluetooth_mac_address_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->bluetooth_mac_address_ref_);
   out.append("\n");
 
 #endif
@@ -830,11 +779,7 @@ void ListEntitiesBinarySensorResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("ListEntitiesBinarySensorResponse {\n");
   out.append("  object_id: ");
-  if (!this->object_id_ref_.empty()) {
-    out.append("'").append(this->object_id_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->object_id_ref_);
   out.append("\n");
 
   out.append("  key: ");
@@ -843,19 +788,11 @@ void ListEntitiesBinarySensorResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  name: ");
-  if (!this->name_ref_.empty()) {
-    out.append("'").append(this->name_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->name_ref_);
   out.append("\n");
 
   out.append("  device_class: ");
-  if (!this->device_class_ref_.empty()) {
-    out.append("'").append(this->device_class_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->device_class_ref_);
   out.append("\n");
 
   out.append("  is_status_binary_sensor: ");
@@ -868,11 +805,7 @@ void ListEntitiesBinarySensorResponse::dump_to(std::string &out) const {
 
 #ifdef USE_ENTITY_ICON
   out.append("  icon: ");
-  if (!this->icon_ref_.empty()) {
-    out.append("'").append(this->icon_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->icon_ref_);
   out.append("\n");
 
 #endif
@@ -920,11 +853,7 @@ void ListEntitiesCoverResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("ListEntitiesCoverResponse {\n");
   out.append("  object_id: ");
-  if (!this->object_id_ref_.empty()) {
-    out.append("'").append(this->object_id_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->object_id_ref_);
   out.append("\n");
 
   out.append("  key: ");
@@ -933,11 +862,7 @@ void ListEntitiesCoverResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  name: ");
-  if (!this->name_ref_.empty()) {
-    out.append("'").append(this->name_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->name_ref_);
   out.append("\n");
 
   out.append("  assumed_state: ");
@@ -953,11 +878,7 @@ void ListEntitiesCoverResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  device_class: ");
-  if (!this->device_class_ref_.empty()) {
-    out.append("'").append(this->device_class_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->device_class_ref_);
   out.append("\n");
 
   out.append("  disabled_by_default: ");
@@ -966,11 +887,7 @@ void ListEntitiesCoverResponse::dump_to(std::string &out) const {
 
 #ifdef USE_ENTITY_ICON
   out.append("  icon: ");
-  if (!this->icon_ref_.empty()) {
-    out.append("'").append(this->icon_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->icon_ref_);
   out.append("\n");
 
 #endif
@@ -1067,11 +984,7 @@ void ListEntitiesFanResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("ListEntitiesFanResponse {\n");
   out.append("  object_id: ");
-  if (!this->object_id_ref_.empty()) {
-    out.append("'").append(this->object_id_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->object_id_ref_);
   out.append("\n");
 
   out.append("  key: ");
@@ -1080,11 +993,7 @@ void ListEntitiesFanResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  name: ");
-  if (!this->name_ref_.empty()) {
-    out.append("'").append(this->name_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->name_ref_);
   out.append("\n");
 
   out.append("  supports_oscillation: ");
@@ -1110,11 +1019,7 @@ void ListEntitiesFanResponse::dump_to(std::string &out) const {
 
 #ifdef USE_ENTITY_ICON
   out.append("  icon: ");
-  if (!this->icon_ref_.empty()) {
-    out.append("'").append(this->icon_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->icon_ref_);
   out.append("\n");
 
 #endif
@@ -1167,11 +1072,7 @@ void FanStateResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  preset_mode: ");
-  if (!this->preset_mode_ref_.empty()) {
-    out.append("'").append(this->preset_mode_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->preset_mode_ref_);
   out.append("\n");
 
 #ifdef USE_DEVICES
@@ -1247,11 +1148,7 @@ void ListEntitiesLightResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("ListEntitiesLightResponse {\n");
   out.append("  object_id: ");
-  if (!this->object_id_ref_.empty()) {
-    out.append("'").append(this->object_id_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->object_id_ref_);
   out.append("\n");
 
   out.append("  key: ");
@@ -1260,11 +1157,7 @@ void ListEntitiesLightResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  name: ");
-  if (!this->name_ref_.empty()) {
-    out.append("'").append(this->name_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->name_ref_);
   out.append("\n");
 
   for (const auto &it : this->supported_color_modes) {
@@ -1299,11 +1192,7 @@ void ListEntitiesLightResponse::dump_to(std::string &out) const {
 
 #ifdef USE_ENTITY_ICON
   out.append("  icon: ");
-  if (!this->icon_ref_.empty()) {
-    out.append("'").append(this->icon_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->icon_ref_);
   out.append("\n");
 
 #endif
@@ -1382,11 +1271,7 @@ void LightStateResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  effect: ");
-  if (!this->effect_ref_.empty()) {
-    out.append("'").append(this->effect_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->effect_ref_);
   out.append("\n");
 
 #ifdef USE_DEVICES
@@ -1536,11 +1421,7 @@ void ListEntitiesSensorResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("ListEntitiesSensorResponse {\n");
   out.append("  object_id: ");
-  if (!this->object_id_ref_.empty()) {
-    out.append("'").append(this->object_id_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->object_id_ref_);
   out.append("\n");
 
   out.append("  key: ");
@@ -1549,29 +1430,17 @@ void ListEntitiesSensorResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  name: ");
-  if (!this->name_ref_.empty()) {
-    out.append("'").append(this->name_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->name_ref_);
   out.append("\n");
 
 #ifdef USE_ENTITY_ICON
   out.append("  icon: ");
-  if (!this->icon_ref_.empty()) {
-    out.append("'").append(this->icon_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->icon_ref_);
   out.append("\n");
 
 #endif
   out.append("  unit_of_measurement: ");
-  if (!this->unit_of_measurement_ref_.empty()) {
-    out.append("'").append(this->unit_of_measurement_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->unit_of_measurement_ref_);
   out.append("\n");
 
   out.append("  accuracy_decimals: ");
@@ -1584,11 +1453,7 @@ void ListEntitiesSensorResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  device_class: ");
-  if (!this->device_class_ref_.empty()) {
-    out.append("'").append(this->device_class_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->device_class_ref_);
   out.append("\n");
 
   out.append("  state_class: ");
@@ -1644,11 +1509,7 @@ void ListEntitiesSwitchResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("ListEntitiesSwitchResponse {\n");
   out.append("  object_id: ");
-  if (!this->object_id_ref_.empty()) {
-    out.append("'").append(this->object_id_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->object_id_ref_);
   out.append("\n");
 
   out.append("  key: ");
@@ -1657,20 +1518,12 @@ void ListEntitiesSwitchResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  name: ");
-  if (!this->name_ref_.empty()) {
-    out.append("'").append(this->name_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->name_ref_);
   out.append("\n");
 
 #ifdef USE_ENTITY_ICON
   out.append("  icon: ");
-  if (!this->icon_ref_.empty()) {
-    out.append("'").append(this->icon_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->icon_ref_);
   out.append("\n");
 
 #endif
@@ -1687,11 +1540,7 @@ void ListEntitiesSwitchResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  device_class: ");
-  if (!this->device_class_ref_.empty()) {
-    out.append("'").append(this->device_class_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->device_class_ref_);
   out.append("\n");
 
 #ifdef USE_DEVICES
@@ -1751,11 +1600,7 @@ void ListEntitiesTextSensorResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("ListEntitiesTextSensorResponse {\n");
   out.append("  object_id: ");
-  if (!this->object_id_ref_.empty()) {
-    out.append("'").append(this->object_id_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->object_id_ref_);
   out.append("\n");
 
   out.append("  key: ");
@@ -1764,20 +1609,12 @@ void ListEntitiesTextSensorResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  name: ");
-  if (!this->name_ref_.empty()) {
-    out.append("'").append(this->name_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->name_ref_);
   out.append("\n");
 
 #ifdef USE_ENTITY_ICON
   out.append("  icon: ");
-  if (!this->icon_ref_.empty()) {
-    out.append("'").append(this->icon_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->icon_ref_);
   out.append("\n");
 
 #endif
@@ -1790,11 +1627,7 @@ void ListEntitiesTextSensorResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  device_class: ");
-  if (!this->device_class_ref_.empty()) {
-    out.append("'").append(this->device_class_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->device_class_ref_);
   out.append("\n");
 
 #ifdef USE_DEVICES
@@ -1815,11 +1648,7 @@ void TextSensorStateResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  state: ");
-  if (!this->state_ref_.empty()) {
-    out.append("'").append(this->state_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->state_ref_);
   out.append("\n");
 
   out.append("  missing_state: ");
@@ -1885,19 +1714,11 @@ void HomeassistantServiceMap::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("HomeassistantServiceMap {\n");
   out.append("  key: ");
-  if (!this->key_ref_.empty()) {
-    out.append("'").append(this->key_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->key_ref_);
   out.append("\n");
 
   out.append("  value: ");
-  if (!this->value_ref_.empty()) {
-    out.append("'").append(this->value_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->value_ref_);
   out.append("\n");
   out.append("}");
 }
@@ -1905,11 +1726,7 @@ void HomeassistantServiceResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("HomeassistantServiceResponse {\n");
   out.append("  service: ");
-  if (!this->service_ref_.empty()) {
-    out.append("'").append(this->service_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->service_ref_);
   out.append("\n");
 
   for (const auto &it : this->data) {
@@ -1942,19 +1759,11 @@ void SubscribeHomeAssistantStateResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("SubscribeHomeAssistantStateResponse {\n");
   out.append("  entity_id: ");
-  if (!this->entity_id_ref_.empty()) {
-    out.append("'").append(this->entity_id_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->entity_id_ref_);
   out.append("\n");
 
   out.append("  attribute: ");
-  if (!this->attribute_ref_.empty()) {
-    out.append("'").append(this->attribute_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->attribute_ref_);
   out.append("\n");
 
   out.append("  once: ");
@@ -1993,11 +1802,7 @@ void ListEntitiesServicesArgument::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("ListEntitiesServicesArgument {\n");
   out.append("  name: ");
-  if (!this->name_ref_.empty()) {
-    out.append("'").append(this->name_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->name_ref_);
   out.append("\n");
 
   out.append("  type: ");
@@ -2009,11 +1814,7 @@ void ListEntitiesServicesResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("ListEntitiesServicesResponse {\n");
   out.append("  name: ");
-  if (!this->name_ref_.empty()) {
-    out.append("'").append(this->name_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->name_ref_);
   out.append("\n");
 
   out.append("  key: ");
@@ -2106,11 +1907,7 @@ void ListEntitiesCameraResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("ListEntitiesCameraResponse {\n");
   out.append("  object_id: ");
-  if (!this->object_id_ref_.empty()) {
-    out.append("'").append(this->object_id_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->object_id_ref_);
   out.append("\n");
 
   out.append("  key: ");
@@ -2119,11 +1916,7 @@ void ListEntitiesCameraResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  name: ");
-  if (!this->name_ref_.empty()) {
-    out.append("'").append(this->name_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->name_ref_);
   out.append("\n");
 
   out.append("  disabled_by_default: ");
@@ -2132,11 +1925,7 @@ void ListEntitiesCameraResponse::dump_to(std::string &out) const {
 
 #ifdef USE_ENTITY_ICON
   out.append("  icon: ");
-  if (!this->icon_ref_.empty()) {
-    out.append("'").append(this->icon_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->icon_ref_);
   out.append("\n");
 
 #endif
@@ -2196,11 +1985,7 @@ void ListEntitiesClimateResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("ListEntitiesClimateResponse {\n");
   out.append("  object_id: ");
-  if (!this->object_id_ref_.empty()) {
-    out.append("'").append(this->object_id_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->object_id_ref_);
   out.append("\n");
 
   out.append("  key: ");
@@ -2209,11 +1994,7 @@ void ListEntitiesClimateResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  name: ");
-  if (!this->name_ref_.empty()) {
-    out.append("'").append(this->name_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->name_ref_);
   out.append("\n");
 
   out.append("  supports_current_temperature: ");
@@ -2293,11 +2074,7 @@ void ListEntitiesClimateResponse::dump_to(std::string &out) const {
 
 #ifdef USE_ENTITY_ICON
   out.append("  icon: ");
-  if (!this->icon_ref_.empty()) {
-    out.append("'").append(this->icon_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->icon_ref_);
   out.append("\n");
 
 #endif
@@ -2382,11 +2159,7 @@ void ClimateStateResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  custom_fan_mode: ");
-  if (!this->custom_fan_mode_ref_.empty()) {
-    out.append("'").append(this->custom_fan_mode_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->custom_fan_mode_ref_);
   out.append("\n");
 
   out.append("  preset: ");
@@ -2394,11 +2167,7 @@ void ClimateStateResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  custom_preset: ");
-  if (!this->custom_preset_ref_.empty()) {
-    out.append("'").append(this->custom_preset_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->custom_preset_ref_);
   out.append("\n");
 
   out.append("  current_humidity: ");
@@ -2527,11 +2296,7 @@ void ListEntitiesNumberResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("ListEntitiesNumberResponse {\n");
   out.append("  object_id: ");
-  if (!this->object_id_ref_.empty()) {
-    out.append("'").append(this->object_id_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->object_id_ref_);
   out.append("\n");
 
   out.append("  key: ");
@@ -2540,20 +2305,12 @@ void ListEntitiesNumberResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  name: ");
-  if (!this->name_ref_.empty()) {
-    out.append("'").append(this->name_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->name_ref_);
   out.append("\n");
 
 #ifdef USE_ENTITY_ICON
   out.append("  icon: ");
-  if (!this->icon_ref_.empty()) {
-    out.append("'").append(this->icon_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->icon_ref_);
   out.append("\n");
 
 #endif
@@ -2581,11 +2338,7 @@ void ListEntitiesNumberResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  unit_of_measurement: ");
-  if (!this->unit_of_measurement_ref_.empty()) {
-    out.append("'").append(this->unit_of_measurement_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->unit_of_measurement_ref_);
   out.append("\n");
 
   out.append("  mode: ");
@@ -2593,11 +2346,7 @@ void ListEntitiesNumberResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  device_class: ");
-  if (!this->device_class_ref_.empty()) {
-    out.append("'").append(this->device_class_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->device_class_ref_);
   out.append("\n");
 
 #ifdef USE_DEVICES
@@ -2663,11 +2412,7 @@ void ListEntitiesSelectResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("ListEntitiesSelectResponse {\n");
   out.append("  object_id: ");
-  if (!this->object_id_ref_.empty()) {
-    out.append("'").append(this->object_id_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->object_id_ref_);
   out.append("\n");
 
   out.append("  key: ");
@@ -2676,20 +2421,12 @@ void ListEntitiesSelectResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  name: ");
-  if (!this->name_ref_.empty()) {
-    out.append("'").append(this->name_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->name_ref_);
   out.append("\n");
 
 #ifdef USE_ENTITY_ICON
   out.append("  icon: ");
-  if (!this->icon_ref_.empty()) {
-    out.append("'").append(this->icon_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->icon_ref_);
   out.append("\n");
 
 #endif
@@ -2729,11 +2466,7 @@ void SelectStateResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  state: ");
-  if (!this->state_ref_.empty()) {
-    out.append("'").append(this->state_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->state_ref_);
   out.append("\n");
 
   out.append("  missing_state: ");
@@ -2776,11 +2509,7 @@ void ListEntitiesSirenResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("ListEntitiesSirenResponse {\n");
   out.append("  object_id: ");
-  if (!this->object_id_ref_.empty()) {
-    out.append("'").append(this->object_id_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->object_id_ref_);
   out.append("\n");
 
   out.append("  key: ");
@@ -2789,20 +2518,12 @@ void ListEntitiesSirenResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  name: ");
-  if (!this->name_ref_.empty()) {
-    out.append("'").append(this->name_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->name_ref_);
   out.append("\n");
 
 #ifdef USE_ENTITY_ICON
   out.append("  icon: ");
-  if (!this->icon_ref_.empty()) {
-    out.append("'").append(this->icon_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->icon_ref_);
   out.append("\n");
 
 #endif
@@ -2919,11 +2640,7 @@ void ListEntitiesLockResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("ListEntitiesLockResponse {\n");
   out.append("  object_id: ");
-  if (!this->object_id_ref_.empty()) {
-    out.append("'").append(this->object_id_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->object_id_ref_);
   out.append("\n");
 
   out.append("  key: ");
@@ -2932,20 +2649,12 @@ void ListEntitiesLockResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  name: ");
-  if (!this->name_ref_.empty()) {
-    out.append("'").append(this->name_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->name_ref_);
   out.append("\n");
 
 #ifdef USE_ENTITY_ICON
   out.append("  icon: ");
-  if (!this->icon_ref_.empty()) {
-    out.append("'").append(this->icon_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->icon_ref_);
   out.append("\n");
 
 #endif
@@ -2970,11 +2679,7 @@ void ListEntitiesLockResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  code_format: ");
-  if (!this->code_format_ref_.empty()) {
-    out.append("'").append(this->code_format_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->code_format_ref_);
   out.append("\n");
 
 #ifdef USE_DEVICES
@@ -3042,11 +2747,7 @@ void ListEntitiesButtonResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("ListEntitiesButtonResponse {\n");
   out.append("  object_id: ");
-  if (!this->object_id_ref_.empty()) {
-    out.append("'").append(this->object_id_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->object_id_ref_);
   out.append("\n");
 
   out.append("  key: ");
@@ -3055,20 +2756,12 @@ void ListEntitiesButtonResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  name: ");
-  if (!this->name_ref_.empty()) {
-    out.append("'").append(this->name_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->name_ref_);
   out.append("\n");
 
 #ifdef USE_ENTITY_ICON
   out.append("  icon: ");
-  if (!this->icon_ref_.empty()) {
-    out.append("'").append(this->icon_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->icon_ref_);
   out.append("\n");
 
 #endif
@@ -3081,11 +2774,7 @@ void ListEntitiesButtonResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  device_class: ");
-  if (!this->device_class_ref_.empty()) {
-    out.append("'").append(this->device_class_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->device_class_ref_);
   out.append("\n");
 
 #ifdef USE_DEVICES
@@ -3120,11 +2809,7 @@ void MediaPlayerSupportedFormat::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("MediaPlayerSupportedFormat {\n");
   out.append("  format: ");
-  if (!this->format_ref_.empty()) {
-    out.append("'").append(this->format_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->format_ref_);
   out.append("\n");
 
   out.append("  sample_rate: ");
@@ -3151,11 +2836,7 @@ void ListEntitiesMediaPlayerResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("ListEntitiesMediaPlayerResponse {\n");
   out.append("  object_id: ");
-  if (!this->object_id_ref_.empty()) {
-    out.append("'").append(this->object_id_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->object_id_ref_);
   out.append("\n");
 
   out.append("  key: ");
@@ -3164,20 +2845,12 @@ void ListEntitiesMediaPlayerResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  name: ");
-  if (!this->name_ref_.empty()) {
-    out.append("'").append(this->name_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->name_ref_);
   out.append("\n");
 
 #ifdef USE_ENTITY_ICON
   out.append("  icon: ");
-  if (!this->icon_ref_.empty()) {
-    out.append("'").append(this->icon_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->icon_ref_);
   out.append("\n");
 
 #endif
@@ -3787,11 +3460,7 @@ void VoiceAssistantRequest::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  conversation_id: ");
-  if (!this->conversation_id_ref_.empty()) {
-    out.append("'").append(this->conversation_id_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->conversation_id_ref_);
   out.append("\n");
 
   out.append("  flags: ");
@@ -3804,11 +3473,7 @@ void VoiceAssistantRequest::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  wake_word_phrase: ");
-  if (!this->wake_word_phrase_ref_.empty()) {
-    out.append("'").append(this->wake_word_phrase_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->wake_word_phrase_ref_);
   out.append("\n");
   out.append("}");
 }
@@ -3929,19 +3594,11 @@ void VoiceAssistantWakeWord::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("VoiceAssistantWakeWord {\n");
   out.append("  id: ");
-  if (!this->id_ref_.empty()) {
-    out.append("'").append(this->id_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->id_ref_);
   out.append("\n");
 
   out.append("  wake_word: ");
-  if (!this->wake_word_ref_.empty()) {
-    out.append("'").append(this->wake_word_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->wake_word_ref_);
   out.append("\n");
 
   for (const auto &it : this->trained_languages) {
@@ -4003,11 +3660,7 @@ void ListEntitiesAlarmControlPanelResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("ListEntitiesAlarmControlPanelResponse {\n");
   out.append("  object_id: ");
-  if (!this->object_id_ref_.empty()) {
-    out.append("'").append(this->object_id_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->object_id_ref_);
   out.append("\n");
 
   out.append("  key: ");
@@ -4016,20 +3669,12 @@ void ListEntitiesAlarmControlPanelResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  name: ");
-  if (!this->name_ref_.empty()) {
-    out.append("'").append(this->name_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->name_ref_);
   out.append("\n");
 
 #ifdef USE_ENTITY_ICON
   out.append("  icon: ");
-  if (!this->icon_ref_.empty()) {
-    out.append("'").append(this->icon_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->icon_ref_);
   out.append("\n");
 
 #endif
@@ -4115,11 +3760,7 @@ void ListEntitiesTextResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("ListEntitiesTextResponse {\n");
   out.append("  object_id: ");
-  if (!this->object_id_ref_.empty()) {
-    out.append("'").append(this->object_id_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->object_id_ref_);
   out.append("\n");
 
   out.append("  key: ");
@@ -4128,20 +3769,12 @@ void ListEntitiesTextResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  name: ");
-  if (!this->name_ref_.empty()) {
-    out.append("'").append(this->name_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->name_ref_);
   out.append("\n");
 
 #ifdef USE_ENTITY_ICON
   out.append("  icon: ");
-  if (!this->icon_ref_.empty()) {
-    out.append("'").append(this->icon_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->icon_ref_);
   out.append("\n");
 
 #endif
@@ -4164,11 +3797,7 @@ void ListEntitiesTextResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  pattern: ");
-  if (!this->pattern_ref_.empty()) {
-    out.append("'").append(this->pattern_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->pattern_ref_);
   out.append("\n");
 
   out.append("  mode: ");
@@ -4193,11 +3822,7 @@ void TextStateResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  state: ");
-  if (!this->state_ref_.empty()) {
-    out.append("'").append(this->state_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->state_ref_);
   out.append("\n");
 
   out.append("  missing_state: ");
@@ -4240,11 +3865,7 @@ void ListEntitiesDateResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("ListEntitiesDateResponse {\n");
   out.append("  object_id: ");
-  if (!this->object_id_ref_.empty()) {
-    out.append("'").append(this->object_id_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->object_id_ref_);
   out.append("\n");
 
   out.append("  key: ");
@@ -4253,20 +3874,12 @@ void ListEntitiesDateResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  name: ");
-  if (!this->name_ref_.empty()) {
-    out.append("'").append(this->name_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->name_ref_);
   out.append("\n");
 
 #ifdef USE_ENTITY_ICON
   out.append("  icon: ");
-  if (!this->icon_ref_.empty()) {
-    out.append("'").append(this->icon_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->icon_ref_);
   out.append("\n");
 
 #endif
@@ -4361,11 +3974,7 @@ void ListEntitiesTimeResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("ListEntitiesTimeResponse {\n");
   out.append("  object_id: ");
-  if (!this->object_id_ref_.empty()) {
-    out.append("'").append(this->object_id_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->object_id_ref_);
   out.append("\n");
 
   out.append("  key: ");
@@ -4374,20 +3983,12 @@ void ListEntitiesTimeResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  name: ");
-  if (!this->name_ref_.empty()) {
-    out.append("'").append(this->name_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->name_ref_);
   out.append("\n");
 
 #ifdef USE_ENTITY_ICON
   out.append("  icon: ");
-  if (!this->icon_ref_.empty()) {
-    out.append("'").append(this->icon_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->icon_ref_);
   out.append("\n");
 
 #endif
@@ -4482,11 +4083,7 @@ void ListEntitiesEventResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("ListEntitiesEventResponse {\n");
   out.append("  object_id: ");
-  if (!this->object_id_ref_.empty()) {
-    out.append("'").append(this->object_id_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->object_id_ref_);
   out.append("\n");
 
   out.append("  key: ");
@@ -4495,20 +4092,12 @@ void ListEntitiesEventResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  name: ");
-  if (!this->name_ref_.empty()) {
-    out.append("'").append(this->name_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->name_ref_);
   out.append("\n");
 
 #ifdef USE_ENTITY_ICON
   out.append("  icon: ");
-  if (!this->icon_ref_.empty()) {
-    out.append("'").append(this->icon_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->icon_ref_);
   out.append("\n");
 
 #endif
@@ -4521,11 +4110,7 @@ void ListEntitiesEventResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  device_class: ");
-  if (!this->device_class_ref_.empty()) {
-    out.append("'").append(this->device_class_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->device_class_ref_);
   out.append("\n");
 
   for (const auto &it : this->event_types) {
@@ -4556,11 +4141,7 @@ void EventResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  event_type: ");
-  if (!this->event_type_ref_.empty()) {
-    out.append("'").append(this->event_type_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->event_type_ref_);
   out.append("\n");
 
 #ifdef USE_DEVICES
@@ -4578,11 +4159,7 @@ void ListEntitiesValveResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("ListEntitiesValveResponse {\n");
   out.append("  object_id: ");
-  if (!this->object_id_ref_.empty()) {
-    out.append("'").append(this->object_id_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->object_id_ref_);
   out.append("\n");
 
   out.append("  key: ");
@@ -4591,20 +4168,12 @@ void ListEntitiesValveResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  name: ");
-  if (!this->name_ref_.empty()) {
-    out.append("'").append(this->name_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->name_ref_);
   out.append("\n");
 
 #ifdef USE_ENTITY_ICON
   out.append("  icon: ");
-  if (!this->icon_ref_.empty()) {
-    out.append("'").append(this->icon_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->icon_ref_);
   out.append("\n");
 
 #endif
@@ -4617,11 +4186,7 @@ void ListEntitiesValveResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  device_class: ");
-  if (!this->device_class_ref_.empty()) {
-    out.append("'").append(this->device_class_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->device_class_ref_);
   out.append("\n");
 
   out.append("  assumed_state: ");
@@ -4707,11 +4272,7 @@ void ListEntitiesDateTimeResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("ListEntitiesDateTimeResponse {\n");
   out.append("  object_id: ");
-  if (!this->object_id_ref_.empty()) {
-    out.append("'").append(this->object_id_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->object_id_ref_);
   out.append("\n");
 
   out.append("  key: ");
@@ -4720,20 +4281,12 @@ void ListEntitiesDateTimeResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  name: ");
-  if (!this->name_ref_.empty()) {
-    out.append("'").append(this->name_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->name_ref_);
   out.append("\n");
 
 #ifdef USE_ENTITY_ICON
   out.append("  icon: ");
-  if (!this->icon_ref_.empty()) {
-    out.append("'").append(this->icon_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->icon_ref_);
   out.append("\n");
 
 #endif
@@ -4808,11 +4361,7 @@ void ListEntitiesUpdateResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("ListEntitiesUpdateResponse {\n");
   out.append("  object_id: ");
-  if (!this->object_id_ref_.empty()) {
-    out.append("'").append(this->object_id_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->object_id_ref_);
   out.append("\n");
 
   out.append("  key: ");
@@ -4821,20 +4370,12 @@ void ListEntitiesUpdateResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  name: ");
-  if (!this->name_ref_.empty()) {
-    out.append("'").append(this->name_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->name_ref_);
   out.append("\n");
 
 #ifdef USE_ENTITY_ICON
   out.append("  icon: ");
-  if (!this->icon_ref_.empty()) {
-    out.append("'").append(this->icon_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->icon_ref_);
   out.append("\n");
 
 #endif
@@ -4847,11 +4388,7 @@ void ListEntitiesUpdateResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  device_class: ");
-  if (!this->device_class_ref_.empty()) {
-    out.append("'").append(this->device_class_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->device_class_ref_);
   out.append("\n");
 
 #ifdef USE_DEVICES
@@ -4889,43 +4426,23 @@ void UpdateStateResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  current_version: ");
-  if (!this->current_version_ref_.empty()) {
-    out.append("'").append(this->current_version_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->current_version_ref_);
   out.append("\n");
 
   out.append("  latest_version: ");
-  if (!this->latest_version_ref_.empty()) {
-    out.append("'").append(this->latest_version_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->latest_version_ref_);
   out.append("\n");
 
   out.append("  title: ");
-  if (!this->title_ref_.empty()) {
-    out.append("'").append(this->title_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->title_ref_);
   out.append("\n");
 
   out.append("  release_summary: ");
-  if (!this->release_summary_ref_.empty()) {
-    out.append("'").append(this->release_summary_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->release_summary_ref_);
   out.append("\n");
 
   out.append("  release_url: ");
-  if (!this->release_url_ref_.empty()) {
-    out.append("'").append(this->release_url_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append("").append("'");
-  }
+  append_quoted_string(out, this->release_url_ref_);
   out.append("\n");
 
 #ifdef USE_DEVICES

--- a/esphome/components/api/api_pb2_dump.cpp
+++ b/esphome/components/api/api_pb2_dump.cpp
@@ -580,16 +580,16 @@ void HelloResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  server_info: ");
-  if (this->server_info_ptr_ != nullptr) {
-    out.append("'").append(this->server_info_ptr_).append("'");
+  if (!this->server_info_ref_.empty()) {
+    out.append("'").append(this->server_info_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
   out.append("\n");
 
   out.append("  name: ");
-  if (this->name_ptr_ != nullptr) {
-    out.append("'").append(this->name_ptr_).append("'");
+  if (!this->name_ref_.empty()) {
+    out.append("'").append(this->name_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
@@ -627,8 +627,8 @@ void AreaInfo::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  name: ");
-  if (this->name_ptr_ != nullptr) {
-    out.append("'").append(this->name_ptr_).append("'");
+  if (!this->name_ref_.empty()) {
+    out.append("'").append(this->name_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
@@ -646,8 +646,8 @@ void DeviceInfo::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  name: ");
-  if (this->name_ptr_ != nullptr) {
-    out.append("'").append(this->name_ptr_).append("'");
+  if (!this->name_ref_.empty()) {
+    out.append("'").append(this->name_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
@@ -670,40 +670,40 @@ void DeviceInfoResponse::dump_to(std::string &out) const {
 
 #endif
   out.append("  name: ");
-  if (this->name_ptr_ != nullptr) {
-    out.append("'").append(this->name_ptr_).append("'");
+  if (!this->name_ref_.empty()) {
+    out.append("'").append(this->name_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
   out.append("\n");
 
   out.append("  mac_address: ");
-  if (this->mac_address_ptr_ != nullptr) {
-    out.append("'").append(this->mac_address_ptr_).append("'");
+  if (!this->mac_address_ref_.empty()) {
+    out.append("'").append(this->mac_address_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
   out.append("\n");
 
   out.append("  esphome_version: ");
-  if (this->esphome_version_ptr_ != nullptr) {
-    out.append("'").append(this->esphome_version_ptr_).append("'");
+  if (!this->esphome_version_ref_.empty()) {
+    out.append("'").append(this->esphome_version_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
   out.append("\n");
 
   out.append("  compilation_time: ");
-  if (this->compilation_time_ptr_ != nullptr) {
-    out.append("'").append(this->compilation_time_ptr_).append("'");
+  if (!this->compilation_time_ref_.empty()) {
+    out.append("'").append(this->compilation_time_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
   out.append("\n");
 
   out.append("  model: ");
-  if (this->model_ptr_ != nullptr) {
-    out.append("'").append(this->model_ptr_).append("'");
+  if (!this->model_ref_.empty()) {
+    out.append("'").append(this->model_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
@@ -717,8 +717,8 @@ void DeviceInfoResponse::dump_to(std::string &out) const {
 #endif
 #ifdef ESPHOME_PROJECT_NAME
   out.append("  project_name: ");
-  if (this->project_name_ptr_ != nullptr) {
-    out.append("'").append(this->project_name_ptr_).append("'");
+  if (!this->project_name_ref_.empty()) {
+    out.append("'").append(this->project_name_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
@@ -727,8 +727,8 @@ void DeviceInfoResponse::dump_to(std::string &out) const {
 #endif
 #ifdef ESPHOME_PROJECT_NAME
   out.append("  project_version: ");
-  if (this->project_version_ptr_ != nullptr) {
-    out.append("'").append(this->project_version_ptr_).append("'");
+  if (!this->project_version_ref_.empty()) {
+    out.append("'").append(this->project_version_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
@@ -750,16 +750,16 @@ void DeviceInfoResponse::dump_to(std::string &out) const {
 
 #endif
   out.append("  manufacturer: ");
-  if (this->manufacturer_ptr_ != nullptr) {
-    out.append("'").append(this->manufacturer_ptr_).append("'");
+  if (!this->manufacturer_ref_.empty()) {
+    out.append("'").append(this->manufacturer_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
   out.append("\n");
 
   out.append("  friendly_name: ");
-  if (this->friendly_name_ptr_ != nullptr) {
-    out.append("'").append(this->friendly_name_ptr_).append("'");
+  if (!this->friendly_name_ref_.empty()) {
+    out.append("'").append(this->friendly_name_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
@@ -774,8 +774,8 @@ void DeviceInfoResponse::dump_to(std::string &out) const {
 #endif
 #ifdef USE_AREAS
   out.append("  suggested_area: ");
-  if (this->suggested_area_ptr_ != nullptr) {
-    out.append("'").append(this->suggested_area_ptr_).append("'");
+  if (!this->suggested_area_ref_.empty()) {
+    out.append("'").append(this->suggested_area_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
@@ -784,8 +784,8 @@ void DeviceInfoResponse::dump_to(std::string &out) const {
 #endif
 #ifdef USE_BLUETOOTH_PROXY
   out.append("  bluetooth_mac_address: ");
-  if (this->bluetooth_mac_address_ptr_ != nullptr) {
-    out.append("'").append(this->bluetooth_mac_address_ptr_).append("'");
+  if (!this->bluetooth_mac_address_ref_.empty()) {
+    out.append("'").append(this->bluetooth_mac_address_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
@@ -830,8 +830,8 @@ void ListEntitiesBinarySensorResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("ListEntitiesBinarySensorResponse {\n");
   out.append("  object_id: ");
-  if (this->object_id_ptr_ != nullptr) {
-    out.append("'").append(this->object_id_ptr_).append("'");
+  if (!this->object_id_ref_.empty()) {
+    out.append("'").append(this->object_id_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
@@ -843,16 +843,16 @@ void ListEntitiesBinarySensorResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  name: ");
-  if (this->name_ptr_ != nullptr) {
-    out.append("'").append(this->name_ptr_).append("'");
+  if (!this->name_ref_.empty()) {
+    out.append("'").append(this->name_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
   out.append("\n");
 
   out.append("  device_class: ");
-  if (this->device_class_ptr_ != nullptr) {
-    out.append("'").append(this->device_class_ptr_).append("'");
+  if (!this->device_class_ref_.empty()) {
+    out.append("'").append(this->device_class_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
@@ -868,8 +868,8 @@ void ListEntitiesBinarySensorResponse::dump_to(std::string &out) const {
 
 #ifdef USE_ENTITY_ICON
   out.append("  icon: ");
-  if (this->icon_ptr_ != nullptr) {
-    out.append("'").append(this->icon_ptr_).append("'");
+  if (!this->icon_ref_.empty()) {
+    out.append("'").append(this->icon_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
@@ -920,8 +920,8 @@ void ListEntitiesCoverResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("ListEntitiesCoverResponse {\n");
   out.append("  object_id: ");
-  if (this->object_id_ptr_ != nullptr) {
-    out.append("'").append(this->object_id_ptr_).append("'");
+  if (!this->object_id_ref_.empty()) {
+    out.append("'").append(this->object_id_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
@@ -933,8 +933,8 @@ void ListEntitiesCoverResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  name: ");
-  if (this->name_ptr_ != nullptr) {
-    out.append("'").append(this->name_ptr_).append("'");
+  if (!this->name_ref_.empty()) {
+    out.append("'").append(this->name_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
@@ -953,8 +953,8 @@ void ListEntitiesCoverResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  device_class: ");
-  if (this->device_class_ptr_ != nullptr) {
-    out.append("'").append(this->device_class_ptr_).append("'");
+  if (!this->device_class_ref_.empty()) {
+    out.append("'").append(this->device_class_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
@@ -966,8 +966,8 @@ void ListEntitiesCoverResponse::dump_to(std::string &out) const {
 
 #ifdef USE_ENTITY_ICON
   out.append("  icon: ");
-  if (this->icon_ptr_ != nullptr) {
-    out.append("'").append(this->icon_ptr_).append("'");
+  if (!this->icon_ref_.empty()) {
+    out.append("'").append(this->icon_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
@@ -1067,8 +1067,8 @@ void ListEntitiesFanResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("ListEntitiesFanResponse {\n");
   out.append("  object_id: ");
-  if (this->object_id_ptr_ != nullptr) {
-    out.append("'").append(this->object_id_ptr_).append("'");
+  if (!this->object_id_ref_.empty()) {
+    out.append("'").append(this->object_id_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
@@ -1080,8 +1080,8 @@ void ListEntitiesFanResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  name: ");
-  if (this->name_ptr_ != nullptr) {
-    out.append("'").append(this->name_ptr_).append("'");
+  if (!this->name_ref_.empty()) {
+    out.append("'").append(this->name_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
@@ -1110,8 +1110,8 @@ void ListEntitiesFanResponse::dump_to(std::string &out) const {
 
 #ifdef USE_ENTITY_ICON
   out.append("  icon: ");
-  if (this->icon_ptr_ != nullptr) {
-    out.append("'").append(this->icon_ptr_).append("'");
+  if (!this->icon_ref_.empty()) {
+    out.append("'").append(this->icon_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
@@ -1124,8 +1124,8 @@ void ListEntitiesFanResponse::dump_to(std::string &out) const {
 
   for (const auto &it : this->supported_preset_modes) {
     out.append("  supported_preset_modes: ");
-    if (this->supported_preset_modes_ptr_ != nullptr) {
-      out.append("'").append(this->supported_preset_modes_ptr_).append("'");
+    if (!this->supported_preset_modes_ref_.empty()) {
+      out.append("'").append(this->supported_preset_modes_ref_.c_str()).append("'");
     } else {
       out.append("'").append(this->supported_preset_modes).append("'");
     }
@@ -1167,8 +1167,8 @@ void FanStateResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  preset_mode: ");
-  if (this->preset_mode_ptr_ != nullptr) {
-    out.append("'").append(this->preset_mode_ptr_).append("'");
+  if (!this->preset_mode_ref_.empty()) {
+    out.append("'").append(this->preset_mode_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
@@ -1247,8 +1247,8 @@ void ListEntitiesLightResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("ListEntitiesLightResponse {\n");
   out.append("  object_id: ");
-  if (this->object_id_ptr_ != nullptr) {
-    out.append("'").append(this->object_id_ptr_).append("'");
+  if (!this->object_id_ref_.empty()) {
+    out.append("'").append(this->object_id_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
@@ -1260,8 +1260,8 @@ void ListEntitiesLightResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  name: ");
-  if (this->name_ptr_ != nullptr) {
-    out.append("'").append(this->name_ptr_).append("'");
+  if (!this->name_ref_.empty()) {
+    out.append("'").append(this->name_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
@@ -1285,8 +1285,8 @@ void ListEntitiesLightResponse::dump_to(std::string &out) const {
 
   for (const auto &it : this->effects) {
     out.append("  effects: ");
-    if (this->effects_ptr_ != nullptr) {
-      out.append("'").append(this->effects_ptr_).append("'");
+    if (!this->effects_ref_.empty()) {
+      out.append("'").append(this->effects_ref_.c_str()).append("'");
     } else {
       out.append("'").append(this->effects).append("'");
     }
@@ -1299,8 +1299,8 @@ void ListEntitiesLightResponse::dump_to(std::string &out) const {
 
 #ifdef USE_ENTITY_ICON
   out.append("  icon: ");
-  if (this->icon_ptr_ != nullptr) {
-    out.append("'").append(this->icon_ptr_).append("'");
+  if (!this->icon_ref_.empty()) {
+    out.append("'").append(this->icon_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
@@ -1382,8 +1382,8 @@ void LightStateResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  effect: ");
-  if (this->effect_ptr_ != nullptr) {
-    out.append("'").append(this->effect_ptr_).append("'");
+  if (!this->effect_ref_.empty()) {
+    out.append("'").append(this->effect_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
@@ -1536,8 +1536,8 @@ void ListEntitiesSensorResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("ListEntitiesSensorResponse {\n");
   out.append("  object_id: ");
-  if (this->object_id_ptr_ != nullptr) {
-    out.append("'").append(this->object_id_ptr_).append("'");
+  if (!this->object_id_ref_.empty()) {
+    out.append("'").append(this->object_id_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
@@ -1549,8 +1549,8 @@ void ListEntitiesSensorResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  name: ");
-  if (this->name_ptr_ != nullptr) {
-    out.append("'").append(this->name_ptr_).append("'");
+  if (!this->name_ref_.empty()) {
+    out.append("'").append(this->name_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
@@ -1558,8 +1558,8 @@ void ListEntitiesSensorResponse::dump_to(std::string &out) const {
 
 #ifdef USE_ENTITY_ICON
   out.append("  icon: ");
-  if (this->icon_ptr_ != nullptr) {
-    out.append("'").append(this->icon_ptr_).append("'");
+  if (!this->icon_ref_.empty()) {
+    out.append("'").append(this->icon_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
@@ -1567,8 +1567,8 @@ void ListEntitiesSensorResponse::dump_to(std::string &out) const {
 
 #endif
   out.append("  unit_of_measurement: ");
-  if (this->unit_of_measurement_ptr_ != nullptr) {
-    out.append("'").append(this->unit_of_measurement_ptr_).append("'");
+  if (!this->unit_of_measurement_ref_.empty()) {
+    out.append("'").append(this->unit_of_measurement_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
@@ -1584,8 +1584,8 @@ void ListEntitiesSensorResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  device_class: ");
-  if (this->device_class_ptr_ != nullptr) {
-    out.append("'").append(this->device_class_ptr_).append("'");
+  if (!this->device_class_ref_.empty()) {
+    out.append("'").append(this->device_class_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
@@ -1644,8 +1644,8 @@ void ListEntitiesSwitchResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("ListEntitiesSwitchResponse {\n");
   out.append("  object_id: ");
-  if (this->object_id_ptr_ != nullptr) {
-    out.append("'").append(this->object_id_ptr_).append("'");
+  if (!this->object_id_ref_.empty()) {
+    out.append("'").append(this->object_id_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
@@ -1657,8 +1657,8 @@ void ListEntitiesSwitchResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  name: ");
-  if (this->name_ptr_ != nullptr) {
-    out.append("'").append(this->name_ptr_).append("'");
+  if (!this->name_ref_.empty()) {
+    out.append("'").append(this->name_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
@@ -1666,8 +1666,8 @@ void ListEntitiesSwitchResponse::dump_to(std::string &out) const {
 
 #ifdef USE_ENTITY_ICON
   out.append("  icon: ");
-  if (this->icon_ptr_ != nullptr) {
-    out.append("'").append(this->icon_ptr_).append("'");
+  if (!this->icon_ref_.empty()) {
+    out.append("'").append(this->icon_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
@@ -1687,8 +1687,8 @@ void ListEntitiesSwitchResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  device_class: ");
-  if (this->device_class_ptr_ != nullptr) {
-    out.append("'").append(this->device_class_ptr_).append("'");
+  if (!this->device_class_ref_.empty()) {
+    out.append("'").append(this->device_class_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
@@ -1751,8 +1751,8 @@ void ListEntitiesTextSensorResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("ListEntitiesTextSensorResponse {\n");
   out.append("  object_id: ");
-  if (this->object_id_ptr_ != nullptr) {
-    out.append("'").append(this->object_id_ptr_).append("'");
+  if (!this->object_id_ref_.empty()) {
+    out.append("'").append(this->object_id_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
@@ -1764,8 +1764,8 @@ void ListEntitiesTextSensorResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  name: ");
-  if (this->name_ptr_ != nullptr) {
-    out.append("'").append(this->name_ptr_).append("'");
+  if (!this->name_ref_.empty()) {
+    out.append("'").append(this->name_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
@@ -1773,8 +1773,8 @@ void ListEntitiesTextSensorResponse::dump_to(std::string &out) const {
 
 #ifdef USE_ENTITY_ICON
   out.append("  icon: ");
-  if (this->icon_ptr_ != nullptr) {
-    out.append("'").append(this->icon_ptr_).append("'");
+  if (!this->icon_ref_.empty()) {
+    out.append("'").append(this->icon_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
@@ -1790,8 +1790,8 @@ void ListEntitiesTextSensorResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  device_class: ");
-  if (this->device_class_ptr_ != nullptr) {
-    out.append("'").append(this->device_class_ptr_).append("'");
+  if (!this->device_class_ref_.empty()) {
+    out.append("'").append(this->device_class_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
@@ -1815,8 +1815,8 @@ void TextSensorStateResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  state: ");
-  if (this->state_ptr_ != nullptr) {
-    out.append("'").append(this->state_ptr_).append("'");
+  if (!this->state_ref_.empty()) {
+    out.append("'").append(this->state_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
@@ -1885,16 +1885,16 @@ void HomeassistantServiceMap::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("HomeassistantServiceMap {\n");
   out.append("  key: ");
-  if (this->key_ptr_ != nullptr) {
-    out.append("'").append(this->key_ptr_).append("'");
+  if (!this->key_ref_.empty()) {
+    out.append("'").append(this->key_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
   out.append("\n");
 
   out.append("  value: ");
-  if (this->value_ptr_ != nullptr) {
-    out.append("'").append(this->value_ptr_).append("'");
+  if (!this->value_ref_.empty()) {
+    out.append("'").append(this->value_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
@@ -1905,8 +1905,8 @@ void HomeassistantServiceResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("HomeassistantServiceResponse {\n");
   out.append("  service: ");
-  if (this->service_ptr_ != nullptr) {
-    out.append("'").append(this->service_ptr_).append("'");
+  if (!this->service_ref_.empty()) {
+    out.append("'").append(this->service_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
@@ -1942,16 +1942,16 @@ void SubscribeHomeAssistantStateResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("SubscribeHomeAssistantStateResponse {\n");
   out.append("  entity_id: ");
-  if (this->entity_id_ptr_ != nullptr) {
-    out.append("'").append(this->entity_id_ptr_).append("'");
+  if (!this->entity_id_ref_.empty()) {
+    out.append("'").append(this->entity_id_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
   out.append("\n");
 
   out.append("  attribute: ");
-  if (this->attribute_ptr_ != nullptr) {
-    out.append("'").append(this->attribute_ptr_).append("'");
+  if (!this->attribute_ref_.empty()) {
+    out.append("'").append(this->attribute_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
@@ -1993,8 +1993,8 @@ void ListEntitiesServicesArgument::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("ListEntitiesServicesArgument {\n");
   out.append("  name: ");
-  if (this->name_ptr_ != nullptr) {
-    out.append("'").append(this->name_ptr_).append("'");
+  if (!this->name_ref_.empty()) {
+    out.append("'").append(this->name_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
@@ -2009,8 +2009,8 @@ void ListEntitiesServicesResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("ListEntitiesServicesResponse {\n");
   out.append("  name: ");
-  if (this->name_ptr_ != nullptr) {
-    out.append("'").append(this->name_ptr_).append("'");
+  if (!this->name_ref_.empty()) {
+    out.append("'").append(this->name_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
@@ -2076,8 +2076,8 @@ void ExecuteServiceArgument::dump_to(std::string &out) const {
 
   for (const auto &it : this->string_array) {
     out.append("  string_array: ");
-    if (this->string_array_ptr_ != nullptr) {
-      out.append("'").append(this->string_array_ptr_).append("'");
+    if (!this->string_array_ref_.empty()) {
+      out.append("'").append(this->string_array_ref_.c_str()).append("'");
     } else {
       out.append("'").append(this->string_array).append("'");
     }
@@ -2106,8 +2106,8 @@ void ListEntitiesCameraResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("ListEntitiesCameraResponse {\n");
   out.append("  object_id: ");
-  if (this->object_id_ptr_ != nullptr) {
-    out.append("'").append(this->object_id_ptr_).append("'");
+  if (!this->object_id_ref_.empty()) {
+    out.append("'").append(this->object_id_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
@@ -2119,8 +2119,8 @@ void ListEntitiesCameraResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  name: ");
-  if (this->name_ptr_ != nullptr) {
-    out.append("'").append(this->name_ptr_).append("'");
+  if (!this->name_ref_.empty()) {
+    out.append("'").append(this->name_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
@@ -2132,8 +2132,8 @@ void ListEntitiesCameraResponse::dump_to(std::string &out) const {
 
 #ifdef USE_ENTITY_ICON
   out.append("  icon: ");
-  if (this->icon_ptr_ != nullptr) {
-    out.append("'").append(this->icon_ptr_).append("'");
+  if (!this->icon_ref_.empty()) {
+    out.append("'").append(this->icon_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
@@ -2196,8 +2196,8 @@ void ListEntitiesClimateResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("ListEntitiesClimateResponse {\n");
   out.append("  object_id: ");
-  if (this->object_id_ptr_ != nullptr) {
-    out.append("'").append(this->object_id_ptr_).append("'");
+  if (!this->object_id_ref_.empty()) {
+    out.append("'").append(this->object_id_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
@@ -2209,8 +2209,8 @@ void ListEntitiesClimateResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  name: ");
-  if (this->name_ptr_ != nullptr) {
-    out.append("'").append(this->name_ptr_).append("'");
+  if (!this->name_ref_.empty()) {
+    out.append("'").append(this->name_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
@@ -2263,8 +2263,8 @@ void ListEntitiesClimateResponse::dump_to(std::string &out) const {
 
   for (const auto &it : this->supported_custom_fan_modes) {
     out.append("  supported_custom_fan_modes: ");
-    if (this->supported_custom_fan_modes_ptr_ != nullptr) {
-      out.append("'").append(this->supported_custom_fan_modes_ptr_).append("'");
+    if (!this->supported_custom_fan_modes_ref_.empty()) {
+      out.append("'").append(this->supported_custom_fan_modes_ref_.c_str()).append("'");
     } else {
       out.append("'").append(this->supported_custom_fan_modes).append("'");
     }
@@ -2279,8 +2279,8 @@ void ListEntitiesClimateResponse::dump_to(std::string &out) const {
 
   for (const auto &it : this->supported_custom_presets) {
     out.append("  supported_custom_presets: ");
-    if (this->supported_custom_presets_ptr_ != nullptr) {
-      out.append("'").append(this->supported_custom_presets_ptr_).append("'");
+    if (!this->supported_custom_presets_ref_.empty()) {
+      out.append("'").append(this->supported_custom_presets_ref_.c_str()).append("'");
     } else {
       out.append("'").append(this->supported_custom_presets).append("'");
     }
@@ -2293,8 +2293,8 @@ void ListEntitiesClimateResponse::dump_to(std::string &out) const {
 
 #ifdef USE_ENTITY_ICON
   out.append("  icon: ");
-  if (this->icon_ptr_ != nullptr) {
-    out.append("'").append(this->icon_ptr_).append("'");
+  if (!this->icon_ref_.empty()) {
+    out.append("'").append(this->icon_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
@@ -2382,8 +2382,8 @@ void ClimateStateResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  custom_fan_mode: ");
-  if (this->custom_fan_mode_ptr_ != nullptr) {
-    out.append("'").append(this->custom_fan_mode_ptr_).append("'");
+  if (!this->custom_fan_mode_ref_.empty()) {
+    out.append("'").append(this->custom_fan_mode_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
@@ -2394,8 +2394,8 @@ void ClimateStateResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  custom_preset: ");
-  if (this->custom_preset_ptr_ != nullptr) {
-    out.append("'").append(this->custom_preset_ptr_).append("'");
+  if (!this->custom_preset_ref_.empty()) {
+    out.append("'").append(this->custom_preset_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
@@ -2527,8 +2527,8 @@ void ListEntitiesNumberResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("ListEntitiesNumberResponse {\n");
   out.append("  object_id: ");
-  if (this->object_id_ptr_ != nullptr) {
-    out.append("'").append(this->object_id_ptr_).append("'");
+  if (!this->object_id_ref_.empty()) {
+    out.append("'").append(this->object_id_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
@@ -2540,8 +2540,8 @@ void ListEntitiesNumberResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  name: ");
-  if (this->name_ptr_ != nullptr) {
-    out.append("'").append(this->name_ptr_).append("'");
+  if (!this->name_ref_.empty()) {
+    out.append("'").append(this->name_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
@@ -2549,8 +2549,8 @@ void ListEntitiesNumberResponse::dump_to(std::string &out) const {
 
 #ifdef USE_ENTITY_ICON
   out.append("  icon: ");
-  if (this->icon_ptr_ != nullptr) {
-    out.append("'").append(this->icon_ptr_).append("'");
+  if (!this->icon_ref_.empty()) {
+    out.append("'").append(this->icon_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
@@ -2581,8 +2581,8 @@ void ListEntitiesNumberResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  unit_of_measurement: ");
-  if (this->unit_of_measurement_ptr_ != nullptr) {
-    out.append("'").append(this->unit_of_measurement_ptr_).append("'");
+  if (!this->unit_of_measurement_ref_.empty()) {
+    out.append("'").append(this->unit_of_measurement_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
@@ -2593,8 +2593,8 @@ void ListEntitiesNumberResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  device_class: ");
-  if (this->device_class_ptr_ != nullptr) {
-    out.append("'").append(this->device_class_ptr_).append("'");
+  if (!this->device_class_ref_.empty()) {
+    out.append("'").append(this->device_class_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
@@ -2663,8 +2663,8 @@ void ListEntitiesSelectResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("ListEntitiesSelectResponse {\n");
   out.append("  object_id: ");
-  if (this->object_id_ptr_ != nullptr) {
-    out.append("'").append(this->object_id_ptr_).append("'");
+  if (!this->object_id_ref_.empty()) {
+    out.append("'").append(this->object_id_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
@@ -2676,8 +2676,8 @@ void ListEntitiesSelectResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  name: ");
-  if (this->name_ptr_ != nullptr) {
-    out.append("'").append(this->name_ptr_).append("'");
+  if (!this->name_ref_.empty()) {
+    out.append("'").append(this->name_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
@@ -2685,8 +2685,8 @@ void ListEntitiesSelectResponse::dump_to(std::string &out) const {
 
 #ifdef USE_ENTITY_ICON
   out.append("  icon: ");
-  if (this->icon_ptr_ != nullptr) {
-    out.append("'").append(this->icon_ptr_).append("'");
+  if (!this->icon_ref_.empty()) {
+    out.append("'").append(this->icon_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
@@ -2695,8 +2695,8 @@ void ListEntitiesSelectResponse::dump_to(std::string &out) const {
 #endif
   for (const auto &it : this->options) {
     out.append("  options: ");
-    if (this->options_ptr_ != nullptr) {
-      out.append("'").append(this->options_ptr_).append("'");
+    if (!this->options_ref_.empty()) {
+      out.append("'").append(this->options_ref_.c_str()).append("'");
     } else {
       out.append("'").append(this->options).append("'");
     }
@@ -2729,8 +2729,8 @@ void SelectStateResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  state: ");
-  if (this->state_ptr_ != nullptr) {
-    out.append("'").append(this->state_ptr_).append("'");
+  if (!this->state_ref_.empty()) {
+    out.append("'").append(this->state_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
@@ -2776,8 +2776,8 @@ void ListEntitiesSirenResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("ListEntitiesSirenResponse {\n");
   out.append("  object_id: ");
-  if (this->object_id_ptr_ != nullptr) {
-    out.append("'").append(this->object_id_ptr_).append("'");
+  if (!this->object_id_ref_.empty()) {
+    out.append("'").append(this->object_id_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
@@ -2789,8 +2789,8 @@ void ListEntitiesSirenResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  name: ");
-  if (this->name_ptr_ != nullptr) {
-    out.append("'").append(this->name_ptr_).append("'");
+  if (!this->name_ref_.empty()) {
+    out.append("'").append(this->name_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
@@ -2798,8 +2798,8 @@ void ListEntitiesSirenResponse::dump_to(std::string &out) const {
 
 #ifdef USE_ENTITY_ICON
   out.append("  icon: ");
-  if (this->icon_ptr_ != nullptr) {
-    out.append("'").append(this->icon_ptr_).append("'");
+  if (!this->icon_ref_.empty()) {
+    out.append("'").append(this->icon_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
@@ -2812,8 +2812,8 @@ void ListEntitiesSirenResponse::dump_to(std::string &out) const {
 
   for (const auto &it : this->tones) {
     out.append("  tones: ");
-    if (this->tones_ptr_ != nullptr) {
-      out.append("'").append(this->tones_ptr_).append("'");
+    if (!this->tones_ref_.empty()) {
+      out.append("'").append(this->tones_ref_.c_str()).append("'");
     } else {
       out.append("'").append(this->tones).append("'");
     }
@@ -2919,8 +2919,8 @@ void ListEntitiesLockResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("ListEntitiesLockResponse {\n");
   out.append("  object_id: ");
-  if (this->object_id_ptr_ != nullptr) {
-    out.append("'").append(this->object_id_ptr_).append("'");
+  if (!this->object_id_ref_.empty()) {
+    out.append("'").append(this->object_id_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
@@ -2932,8 +2932,8 @@ void ListEntitiesLockResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  name: ");
-  if (this->name_ptr_ != nullptr) {
-    out.append("'").append(this->name_ptr_).append("'");
+  if (!this->name_ref_.empty()) {
+    out.append("'").append(this->name_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
@@ -2941,8 +2941,8 @@ void ListEntitiesLockResponse::dump_to(std::string &out) const {
 
 #ifdef USE_ENTITY_ICON
   out.append("  icon: ");
-  if (this->icon_ptr_ != nullptr) {
-    out.append("'").append(this->icon_ptr_).append("'");
+  if (!this->icon_ref_.empty()) {
+    out.append("'").append(this->icon_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
@@ -2970,8 +2970,8 @@ void ListEntitiesLockResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  code_format: ");
-  if (this->code_format_ptr_ != nullptr) {
-    out.append("'").append(this->code_format_ptr_).append("'");
+  if (!this->code_format_ref_.empty()) {
+    out.append("'").append(this->code_format_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
@@ -3042,8 +3042,8 @@ void ListEntitiesButtonResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("ListEntitiesButtonResponse {\n");
   out.append("  object_id: ");
-  if (this->object_id_ptr_ != nullptr) {
-    out.append("'").append(this->object_id_ptr_).append("'");
+  if (!this->object_id_ref_.empty()) {
+    out.append("'").append(this->object_id_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
@@ -3055,8 +3055,8 @@ void ListEntitiesButtonResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  name: ");
-  if (this->name_ptr_ != nullptr) {
-    out.append("'").append(this->name_ptr_).append("'");
+  if (!this->name_ref_.empty()) {
+    out.append("'").append(this->name_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
@@ -3064,8 +3064,8 @@ void ListEntitiesButtonResponse::dump_to(std::string &out) const {
 
 #ifdef USE_ENTITY_ICON
   out.append("  icon: ");
-  if (this->icon_ptr_ != nullptr) {
-    out.append("'").append(this->icon_ptr_).append("'");
+  if (!this->icon_ref_.empty()) {
+    out.append("'").append(this->icon_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
@@ -3081,8 +3081,8 @@ void ListEntitiesButtonResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  device_class: ");
-  if (this->device_class_ptr_ != nullptr) {
-    out.append("'").append(this->device_class_ptr_).append("'");
+  if (!this->device_class_ref_.empty()) {
+    out.append("'").append(this->device_class_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
@@ -3120,8 +3120,8 @@ void MediaPlayerSupportedFormat::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("MediaPlayerSupportedFormat {\n");
   out.append("  format: ");
-  if (this->format_ptr_ != nullptr) {
-    out.append("'").append(this->format_ptr_).append("'");
+  if (!this->format_ref_.empty()) {
+    out.append("'").append(this->format_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
@@ -3151,8 +3151,8 @@ void ListEntitiesMediaPlayerResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("ListEntitiesMediaPlayerResponse {\n");
   out.append("  object_id: ");
-  if (this->object_id_ptr_ != nullptr) {
-    out.append("'").append(this->object_id_ptr_).append("'");
+  if (!this->object_id_ref_.empty()) {
+    out.append("'").append(this->object_id_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
@@ -3164,8 +3164,8 @@ void ListEntitiesMediaPlayerResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  name: ");
-  if (this->name_ptr_ != nullptr) {
-    out.append("'").append(this->name_ptr_).append("'");
+  if (!this->name_ref_.empty()) {
+    out.append("'").append(this->name_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
@@ -3173,8 +3173,8 @@ void ListEntitiesMediaPlayerResponse::dump_to(std::string &out) const {
 
 #ifdef USE_ENTITY_ICON
   out.append("  icon: ");
-  if (this->icon_ptr_ != nullptr) {
-    out.append("'").append(this->icon_ptr_).append("'");
+  if (!this->icon_ref_.empty()) {
+    out.append("'").append(this->icon_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
@@ -3787,8 +3787,8 @@ void VoiceAssistantRequest::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  conversation_id: ");
-  if (this->conversation_id_ptr_ != nullptr) {
-    out.append("'").append(this->conversation_id_ptr_).append("'");
+  if (!this->conversation_id_ref_.empty()) {
+    out.append("'").append(this->conversation_id_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
@@ -3804,8 +3804,8 @@ void VoiceAssistantRequest::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  wake_word_phrase: ");
-  if (this->wake_word_phrase_ptr_ != nullptr) {
-    out.append("'").append(this->wake_word_phrase_ptr_).append("'");
+  if (!this->wake_word_phrase_ref_.empty()) {
+    out.append("'").append(this->wake_word_phrase_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
@@ -3929,16 +3929,16 @@ void VoiceAssistantWakeWord::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("VoiceAssistantWakeWord {\n");
   out.append("  id: ");
-  if (this->id_ptr_ != nullptr) {
-    out.append("'").append(this->id_ptr_).append("'");
+  if (!this->id_ref_.empty()) {
+    out.append("'").append(this->id_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
   out.append("\n");
 
   out.append("  wake_word: ");
-  if (this->wake_word_ptr_ != nullptr) {
-    out.append("'").append(this->wake_word_ptr_).append("'");
+  if (!this->wake_word_ref_.empty()) {
+    out.append("'").append(this->wake_word_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
@@ -3946,8 +3946,8 @@ void VoiceAssistantWakeWord::dump_to(std::string &out) const {
 
   for (const auto &it : this->trained_languages) {
     out.append("  trained_languages: ");
-    if (this->trained_languages_ptr_ != nullptr) {
-      out.append("'").append(this->trained_languages_ptr_).append("'");
+    if (!this->trained_languages_ref_.empty()) {
+      out.append("'").append(this->trained_languages_ref_.c_str()).append("'");
     } else {
       out.append("'").append(this->trained_languages).append("'");
     }
@@ -3969,8 +3969,8 @@ void VoiceAssistantConfigurationResponse::dump_to(std::string &out) const {
 
   for (const auto &it : this->active_wake_words) {
     out.append("  active_wake_words: ");
-    if (this->active_wake_words_ptr_ != nullptr) {
-      out.append("'").append(this->active_wake_words_ptr_).append("'");
+    if (!this->active_wake_words_ref_.empty()) {
+      out.append("'").append(this->active_wake_words_ref_.c_str()).append("'");
     } else {
       out.append("'").append(this->active_wake_words).append("'");
     }
@@ -3988,8 +3988,8 @@ void VoiceAssistantSetConfiguration::dump_to(std::string &out) const {
   out.append("VoiceAssistantSetConfiguration {\n");
   for (const auto &it : this->active_wake_words) {
     out.append("  active_wake_words: ");
-    if (this->active_wake_words_ptr_ != nullptr) {
-      out.append("'").append(this->active_wake_words_ptr_).append("'");
+    if (!this->active_wake_words_ref_.empty()) {
+      out.append("'").append(this->active_wake_words_ref_.c_str()).append("'");
     } else {
       out.append("'").append(this->active_wake_words).append("'");
     }
@@ -4003,8 +4003,8 @@ void ListEntitiesAlarmControlPanelResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("ListEntitiesAlarmControlPanelResponse {\n");
   out.append("  object_id: ");
-  if (this->object_id_ptr_ != nullptr) {
-    out.append("'").append(this->object_id_ptr_).append("'");
+  if (!this->object_id_ref_.empty()) {
+    out.append("'").append(this->object_id_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
@@ -4016,8 +4016,8 @@ void ListEntitiesAlarmControlPanelResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  name: ");
-  if (this->name_ptr_ != nullptr) {
-    out.append("'").append(this->name_ptr_).append("'");
+  if (!this->name_ref_.empty()) {
+    out.append("'").append(this->name_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
@@ -4025,8 +4025,8 @@ void ListEntitiesAlarmControlPanelResponse::dump_to(std::string &out) const {
 
 #ifdef USE_ENTITY_ICON
   out.append("  icon: ");
-  if (this->icon_ptr_ != nullptr) {
-    out.append("'").append(this->icon_ptr_).append("'");
+  if (!this->icon_ref_.empty()) {
+    out.append("'").append(this->icon_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
@@ -4115,8 +4115,8 @@ void ListEntitiesTextResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("ListEntitiesTextResponse {\n");
   out.append("  object_id: ");
-  if (this->object_id_ptr_ != nullptr) {
-    out.append("'").append(this->object_id_ptr_).append("'");
+  if (!this->object_id_ref_.empty()) {
+    out.append("'").append(this->object_id_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
@@ -4128,8 +4128,8 @@ void ListEntitiesTextResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  name: ");
-  if (this->name_ptr_ != nullptr) {
-    out.append("'").append(this->name_ptr_).append("'");
+  if (!this->name_ref_.empty()) {
+    out.append("'").append(this->name_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
@@ -4137,8 +4137,8 @@ void ListEntitiesTextResponse::dump_to(std::string &out) const {
 
 #ifdef USE_ENTITY_ICON
   out.append("  icon: ");
-  if (this->icon_ptr_ != nullptr) {
-    out.append("'").append(this->icon_ptr_).append("'");
+  if (!this->icon_ref_.empty()) {
+    out.append("'").append(this->icon_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
@@ -4164,8 +4164,8 @@ void ListEntitiesTextResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  pattern: ");
-  if (this->pattern_ptr_ != nullptr) {
-    out.append("'").append(this->pattern_ptr_).append("'");
+  if (!this->pattern_ref_.empty()) {
+    out.append("'").append(this->pattern_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
@@ -4193,8 +4193,8 @@ void TextStateResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  state: ");
-  if (this->state_ptr_ != nullptr) {
-    out.append("'").append(this->state_ptr_).append("'");
+  if (!this->state_ref_.empty()) {
+    out.append("'").append(this->state_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
@@ -4240,8 +4240,8 @@ void ListEntitiesDateResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("ListEntitiesDateResponse {\n");
   out.append("  object_id: ");
-  if (this->object_id_ptr_ != nullptr) {
-    out.append("'").append(this->object_id_ptr_).append("'");
+  if (!this->object_id_ref_.empty()) {
+    out.append("'").append(this->object_id_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
@@ -4253,8 +4253,8 @@ void ListEntitiesDateResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  name: ");
-  if (this->name_ptr_ != nullptr) {
-    out.append("'").append(this->name_ptr_).append("'");
+  if (!this->name_ref_.empty()) {
+    out.append("'").append(this->name_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
@@ -4262,8 +4262,8 @@ void ListEntitiesDateResponse::dump_to(std::string &out) const {
 
 #ifdef USE_ENTITY_ICON
   out.append("  icon: ");
-  if (this->icon_ptr_ != nullptr) {
-    out.append("'").append(this->icon_ptr_).append("'");
+  if (!this->icon_ref_.empty()) {
+    out.append("'").append(this->icon_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
@@ -4361,8 +4361,8 @@ void ListEntitiesTimeResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("ListEntitiesTimeResponse {\n");
   out.append("  object_id: ");
-  if (this->object_id_ptr_ != nullptr) {
-    out.append("'").append(this->object_id_ptr_).append("'");
+  if (!this->object_id_ref_.empty()) {
+    out.append("'").append(this->object_id_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
@@ -4374,8 +4374,8 @@ void ListEntitiesTimeResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  name: ");
-  if (this->name_ptr_ != nullptr) {
-    out.append("'").append(this->name_ptr_).append("'");
+  if (!this->name_ref_.empty()) {
+    out.append("'").append(this->name_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
@@ -4383,8 +4383,8 @@ void ListEntitiesTimeResponse::dump_to(std::string &out) const {
 
 #ifdef USE_ENTITY_ICON
   out.append("  icon: ");
-  if (this->icon_ptr_ != nullptr) {
-    out.append("'").append(this->icon_ptr_).append("'");
+  if (!this->icon_ref_.empty()) {
+    out.append("'").append(this->icon_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
@@ -4482,8 +4482,8 @@ void ListEntitiesEventResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("ListEntitiesEventResponse {\n");
   out.append("  object_id: ");
-  if (this->object_id_ptr_ != nullptr) {
-    out.append("'").append(this->object_id_ptr_).append("'");
+  if (!this->object_id_ref_.empty()) {
+    out.append("'").append(this->object_id_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
@@ -4495,8 +4495,8 @@ void ListEntitiesEventResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  name: ");
-  if (this->name_ptr_ != nullptr) {
-    out.append("'").append(this->name_ptr_).append("'");
+  if (!this->name_ref_.empty()) {
+    out.append("'").append(this->name_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
@@ -4504,8 +4504,8 @@ void ListEntitiesEventResponse::dump_to(std::string &out) const {
 
 #ifdef USE_ENTITY_ICON
   out.append("  icon: ");
-  if (this->icon_ptr_ != nullptr) {
-    out.append("'").append(this->icon_ptr_).append("'");
+  if (!this->icon_ref_.empty()) {
+    out.append("'").append(this->icon_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
@@ -4521,8 +4521,8 @@ void ListEntitiesEventResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  device_class: ");
-  if (this->device_class_ptr_ != nullptr) {
-    out.append("'").append(this->device_class_ptr_).append("'");
+  if (!this->device_class_ref_.empty()) {
+    out.append("'").append(this->device_class_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
@@ -4530,8 +4530,8 @@ void ListEntitiesEventResponse::dump_to(std::string &out) const {
 
   for (const auto &it : this->event_types) {
     out.append("  event_types: ");
-    if (this->event_types_ptr_ != nullptr) {
-      out.append("'").append(this->event_types_ptr_).append("'");
+    if (!this->event_types_ref_.empty()) {
+      out.append("'").append(this->event_types_ref_.c_str()).append("'");
     } else {
       out.append("'").append(this->event_types).append("'");
     }
@@ -4556,8 +4556,8 @@ void EventResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  event_type: ");
-  if (this->event_type_ptr_ != nullptr) {
-    out.append("'").append(this->event_type_ptr_).append("'");
+  if (!this->event_type_ref_.empty()) {
+    out.append("'").append(this->event_type_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
@@ -4578,8 +4578,8 @@ void ListEntitiesValveResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("ListEntitiesValveResponse {\n");
   out.append("  object_id: ");
-  if (this->object_id_ptr_ != nullptr) {
-    out.append("'").append(this->object_id_ptr_).append("'");
+  if (!this->object_id_ref_.empty()) {
+    out.append("'").append(this->object_id_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
@@ -4591,8 +4591,8 @@ void ListEntitiesValveResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  name: ");
-  if (this->name_ptr_ != nullptr) {
-    out.append("'").append(this->name_ptr_).append("'");
+  if (!this->name_ref_.empty()) {
+    out.append("'").append(this->name_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
@@ -4600,8 +4600,8 @@ void ListEntitiesValveResponse::dump_to(std::string &out) const {
 
 #ifdef USE_ENTITY_ICON
   out.append("  icon: ");
-  if (this->icon_ptr_ != nullptr) {
-    out.append("'").append(this->icon_ptr_).append("'");
+  if (!this->icon_ref_.empty()) {
+    out.append("'").append(this->icon_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
@@ -4617,8 +4617,8 @@ void ListEntitiesValveResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  device_class: ");
-  if (this->device_class_ptr_ != nullptr) {
-    out.append("'").append(this->device_class_ptr_).append("'");
+  if (!this->device_class_ref_.empty()) {
+    out.append("'").append(this->device_class_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
@@ -4707,8 +4707,8 @@ void ListEntitiesDateTimeResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("ListEntitiesDateTimeResponse {\n");
   out.append("  object_id: ");
-  if (this->object_id_ptr_ != nullptr) {
-    out.append("'").append(this->object_id_ptr_).append("'");
+  if (!this->object_id_ref_.empty()) {
+    out.append("'").append(this->object_id_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
@@ -4720,8 +4720,8 @@ void ListEntitiesDateTimeResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  name: ");
-  if (this->name_ptr_ != nullptr) {
-    out.append("'").append(this->name_ptr_).append("'");
+  if (!this->name_ref_.empty()) {
+    out.append("'").append(this->name_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
@@ -4729,8 +4729,8 @@ void ListEntitiesDateTimeResponse::dump_to(std::string &out) const {
 
 #ifdef USE_ENTITY_ICON
   out.append("  icon: ");
-  if (this->icon_ptr_ != nullptr) {
-    out.append("'").append(this->icon_ptr_).append("'");
+  if (!this->icon_ref_.empty()) {
+    out.append("'").append(this->icon_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
@@ -4808,8 +4808,8 @@ void ListEntitiesUpdateResponse::dump_to(std::string &out) const {
   __attribute__((unused)) char buffer[64];
   out.append("ListEntitiesUpdateResponse {\n");
   out.append("  object_id: ");
-  if (this->object_id_ptr_ != nullptr) {
-    out.append("'").append(this->object_id_ptr_).append("'");
+  if (!this->object_id_ref_.empty()) {
+    out.append("'").append(this->object_id_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
@@ -4821,8 +4821,8 @@ void ListEntitiesUpdateResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  name: ");
-  if (this->name_ptr_ != nullptr) {
-    out.append("'").append(this->name_ptr_).append("'");
+  if (!this->name_ref_.empty()) {
+    out.append("'").append(this->name_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
@@ -4830,8 +4830,8 @@ void ListEntitiesUpdateResponse::dump_to(std::string &out) const {
 
 #ifdef USE_ENTITY_ICON
   out.append("  icon: ");
-  if (this->icon_ptr_ != nullptr) {
-    out.append("'").append(this->icon_ptr_).append("'");
+  if (!this->icon_ref_.empty()) {
+    out.append("'").append(this->icon_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
@@ -4847,8 +4847,8 @@ void ListEntitiesUpdateResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  device_class: ");
-  if (this->device_class_ptr_ != nullptr) {
-    out.append("'").append(this->device_class_ptr_).append("'");
+  if (!this->device_class_ref_.empty()) {
+    out.append("'").append(this->device_class_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
@@ -4889,40 +4889,40 @@ void UpdateStateResponse::dump_to(std::string &out) const {
   out.append("\n");
 
   out.append("  current_version: ");
-  if (this->current_version_ptr_ != nullptr) {
-    out.append("'").append(this->current_version_ptr_).append("'");
+  if (!this->current_version_ref_.empty()) {
+    out.append("'").append(this->current_version_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
   out.append("\n");
 
   out.append("  latest_version: ");
-  if (this->latest_version_ptr_ != nullptr) {
-    out.append("'").append(this->latest_version_ptr_).append("'");
+  if (!this->latest_version_ref_.empty()) {
+    out.append("'").append(this->latest_version_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
   out.append("\n");
 
   out.append("  title: ");
-  if (this->title_ptr_ != nullptr) {
-    out.append("'").append(this->title_ptr_).append("'");
+  if (!this->title_ref_.empty()) {
+    out.append("'").append(this->title_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
   out.append("\n");
 
   out.append("  release_summary: ");
-  if (this->release_summary_ptr_ != nullptr) {
-    out.append("'").append(this->release_summary_ptr_).append("'");
+  if (!this->release_summary_ref_.empty()) {
+    out.append("'").append(this->release_summary_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }
   out.append("\n");
 
   out.append("  release_url: ");
-  if (this->release_url_ptr_ != nullptr) {
-    out.append("'").append(this->release_url_ptr_).append("'");
+  if (!this->release_url_ref_.empty()) {
+    out.append("'").append(this->release_url_ref_.c_str()).append("'");
   } else {
     out.append("'").append("").append("'");
   }

--- a/esphome/components/api/api_pb2_service.cpp
+++ b/esphome/components/api/api_pb2_service.cpp
@@ -597,33 +597,28 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
 }
 
 void APIServerConnection::on_hello_request(const HelloRequest &msg) {
-  HelloResponse ret = this->hello(msg);
-  if (!this->send_message(ret, HelloResponse::MESSAGE_TYPE)) {
+  if (!this->send_hello_response(msg)) {
     this->on_fatal_error();
   }
 }
 void APIServerConnection::on_connect_request(const ConnectRequest &msg) {
-  ConnectResponse ret = this->connect(msg);
-  if (!this->send_message(ret, ConnectResponse::MESSAGE_TYPE)) {
+  if (!this->send_connect_response(msg)) {
     this->on_fatal_error();
   }
 }
 void APIServerConnection::on_disconnect_request(const DisconnectRequest &msg) {
-  DisconnectResponse ret = this->disconnect(msg);
-  if (!this->send_message(ret, DisconnectResponse::MESSAGE_TYPE)) {
+  if (!this->send_disconnect_response(msg)) {
     this->on_fatal_error();
   }
 }
 void APIServerConnection::on_ping_request(const PingRequest &msg) {
-  PingResponse ret = this->ping(msg);
-  if (!this->send_message(ret, PingResponse::MESSAGE_TYPE)) {
+  if (!this->send_ping_response(msg)) {
     this->on_fatal_error();
   }
 }
 void APIServerConnection::on_device_info_request(const DeviceInfoRequest &msg) {
   if (this->check_connection_setup_()) {
-    DeviceInfoResponse ret = this->device_info(msg);
-    if (!this->send_message(ret, DeviceInfoResponse::MESSAGE_TYPE)) {
+    if (!this->send_device_info_response(msg)) {
       this->on_fatal_error();
     }
   }
@@ -656,8 +651,7 @@ void APIServerConnection::on_subscribe_home_assistant_states_request(const Subsc
 }
 void APIServerConnection::on_get_time_request(const GetTimeRequest &msg) {
   if (this->check_connection_setup_()) {
-    GetTimeResponse ret = this->get_time(msg);
-    if (!this->send_message(ret, GetTimeResponse::MESSAGE_TYPE)) {
+    if (!this->send_get_time_response(msg)) {
       this->on_fatal_error();
     }
   }
@@ -672,8 +666,7 @@ void APIServerConnection::on_execute_service_request(const ExecuteServiceRequest
 #ifdef USE_API_NOISE
 void APIServerConnection::on_noise_encryption_set_key_request(const NoiseEncryptionSetKeyRequest &msg) {
   if (this->check_authenticated_()) {
-    NoiseEncryptionSetKeyResponse ret = this->noise_encryption_set_key(msg);
-    if (!this->send_message(ret, NoiseEncryptionSetKeyResponse::MESSAGE_TYPE)) {
+    if (!this->send_noise_encryption_set_key_response(msg)) {
       this->on_fatal_error();
     }
   }
@@ -866,8 +859,7 @@ void APIServerConnection::on_bluetooth_gatt_notify_request(const BluetoothGATTNo
 void APIServerConnection::on_subscribe_bluetooth_connections_free_request(
     const SubscribeBluetoothConnectionsFreeRequest &msg) {
   if (this->check_authenticated_()) {
-    BluetoothConnectionsFreeResponse ret = this->subscribe_bluetooth_connections_free(msg);
-    if (!this->send_message(ret, BluetoothConnectionsFreeResponse::MESSAGE_TYPE)) {
+    if (!this->send_subscribe_bluetooth_connections_free_response(msg)) {
       this->on_fatal_error();
     }
   }
@@ -898,8 +890,7 @@ void APIServerConnection::on_subscribe_voice_assistant_request(const SubscribeVo
 #ifdef USE_VOICE_ASSISTANT
 void APIServerConnection::on_voice_assistant_configuration_request(const VoiceAssistantConfigurationRequest &msg) {
   if (this->check_authenticated_()) {
-    VoiceAssistantConfigurationResponse ret = this->voice_assistant_get_configuration(msg);
-    if (!this->send_message(ret, VoiceAssistantConfigurationResponse::MESSAGE_TYPE)) {
+    if (!this->send_voice_assistant_get_configuration_response(msg)) {
       this->on_fatal_error();
     }
   }

--- a/esphome/components/api/api_pb2_service.h
+++ b/esphome/components/api/api_pb2_service.h
@@ -207,22 +207,22 @@ class APIServerConnectionBase : public ProtoService {
 
 class APIServerConnection : public APIServerConnectionBase {
  public:
-  virtual HelloResponse hello(const HelloRequest &msg) = 0;
-  virtual ConnectResponse connect(const ConnectRequest &msg) = 0;
-  virtual DisconnectResponse disconnect(const DisconnectRequest &msg) = 0;
-  virtual PingResponse ping(const PingRequest &msg) = 0;
-  virtual DeviceInfoResponse device_info(const DeviceInfoRequest &msg) = 0;
+  virtual bool send_hello_response(const HelloRequest &msg) = 0;
+  virtual bool send_connect_response(const ConnectRequest &msg) = 0;
+  virtual bool send_disconnect_response(const DisconnectRequest &msg) = 0;
+  virtual bool send_ping_response(const PingRequest &msg) = 0;
+  virtual bool send_device_info_response(const DeviceInfoRequest &msg) = 0;
   virtual void list_entities(const ListEntitiesRequest &msg) = 0;
   virtual void subscribe_states(const SubscribeStatesRequest &msg) = 0;
   virtual void subscribe_logs(const SubscribeLogsRequest &msg) = 0;
   virtual void subscribe_homeassistant_services(const SubscribeHomeassistantServicesRequest &msg) = 0;
   virtual void subscribe_home_assistant_states(const SubscribeHomeAssistantStatesRequest &msg) = 0;
-  virtual GetTimeResponse get_time(const GetTimeRequest &msg) = 0;
+  virtual bool send_get_time_response(const GetTimeRequest &msg) = 0;
 #ifdef USE_API_SERVICES
   virtual void execute_service(const ExecuteServiceRequest &msg) = 0;
 #endif
 #ifdef USE_API_NOISE
-  virtual NoiseEncryptionSetKeyResponse noise_encryption_set_key(const NoiseEncryptionSetKeyRequest &msg) = 0;
+  virtual bool send_noise_encryption_set_key_response(const NoiseEncryptionSetKeyRequest &msg) = 0;
 #endif
 #ifdef USE_BUTTON
   virtual void button_command(const ButtonCommandRequest &msg) = 0;
@@ -303,7 +303,7 @@ class APIServerConnection : public APIServerConnectionBase {
   virtual void bluetooth_gatt_notify(const BluetoothGATTNotifyRequest &msg) = 0;
 #endif
 #ifdef USE_BLUETOOTH_PROXY
-  virtual BluetoothConnectionsFreeResponse subscribe_bluetooth_connections_free(
+  virtual bool send_subscribe_bluetooth_connections_free_response(
       const SubscribeBluetoothConnectionsFreeRequest &msg) = 0;
 #endif
 #ifdef USE_BLUETOOTH_PROXY
@@ -316,8 +316,7 @@ class APIServerConnection : public APIServerConnectionBase {
   virtual void subscribe_voice_assistant(const SubscribeVoiceAssistantRequest &msg) = 0;
 #endif
 #ifdef USE_VOICE_ASSISTANT
-  virtual VoiceAssistantConfigurationResponse voice_assistant_get_configuration(
-      const VoiceAssistantConfigurationRequest &msg) = 0;
+  virtual bool send_voice_assistant_get_configuration_response(const VoiceAssistantConfigurationRequest &msg) = 0;
 #endif
 #ifdef USE_VOICE_ASSISTANT
   virtual void voice_assistant_set_configuration(const VoiceAssistantSetConfiguration &msg) = 0;

--- a/esphome/components/api/custom_api_device.h
+++ b/esphome/components/api/custom_api_device.h
@@ -148,7 +148,7 @@ class CustomAPIDevice {
    */
   void call_homeassistant_service(const std::string &service_name) {
     HomeassistantServiceResponse resp;
-    resp.set_service(service_name.c_str(), service_name.length());
+    resp.set_service(StringRef(service_name));
     global_api_server->send_homeassistant_service_call(resp);
   }
 
@@ -168,12 +168,12 @@ class CustomAPIDevice {
    */
   void call_homeassistant_service(const std::string &service_name, const std::map<std::string, std::string> &data) {
     HomeassistantServiceResponse resp;
-    resp.set_service(service_name.c_str(), service_name.length());
+    resp.set_service(StringRef(service_name));
     for (auto &it : data) {
       resp.data.emplace_back();
       auto &kv = resp.data.back();
-      kv.set_key(it.first.c_str(), it.first.length());
-      kv.set_value(it.second.c_str(), it.second.length());
+      kv.set_key(StringRef(it.first));
+      kv.set_value(StringRef(it.second));
     }
     global_api_server->send_homeassistant_service_call(resp);
   }
@@ -190,7 +190,7 @@ class CustomAPIDevice {
    */
   void fire_homeassistant_event(const std::string &event_name) {
     HomeassistantServiceResponse resp;
-    resp.set_service(event_name.c_str(), event_name.length());
+    resp.set_service(StringRef(event_name));
     resp.is_event = true;
     global_api_server->send_homeassistant_service_call(resp);
   }
@@ -210,13 +210,13 @@ class CustomAPIDevice {
    */
   void fire_homeassistant_event(const std::string &service_name, const std::map<std::string, std::string> &data) {
     HomeassistantServiceResponse resp;
-    resp.set_service(service_name.c_str(), service_name.length());
+    resp.set_service(StringRef(service_name));
     resp.is_event = true;
     for (auto &it : data) {
       resp.data.emplace_back();
       auto &kv = resp.data.back();
-      kv.set_key(it.first.c_str(), it.first.length());
-      kv.set_value(it.second.c_str(), it.second.length());
+      kv.set_key(StringRef(it.first));
+      kv.set_value(StringRef(it.second));
     }
     global_api_server->send_homeassistant_service_call(resp);
   }

--- a/esphome/components/api/custom_api_device.h
+++ b/esphome/components/api/custom_api_device.h
@@ -148,7 +148,7 @@ class CustomAPIDevice {
    */
   void call_homeassistant_service(const std::string &service_name) {
     HomeassistantServiceResponse resp;
-    resp.service = service_name;
+    resp.set_service(service_name.c_str(), service_name.length());
     global_api_server->send_homeassistant_service_call(resp);
   }
 
@@ -168,12 +168,12 @@ class CustomAPIDevice {
    */
   void call_homeassistant_service(const std::string &service_name, const std::map<std::string, std::string> &data) {
     HomeassistantServiceResponse resp;
-    resp.service = service_name;
+    resp.set_service(service_name.c_str(), service_name.length());
     for (auto &it : data) {
-      HomeassistantServiceMap kv;
-      kv.key = it.first;
-      kv.value = it.second;
-      resp.data.push_back(kv);
+      resp.data.emplace_back();
+      auto &kv = resp.data.back();
+      kv.set_key(it.first.c_str(), it.first.length());
+      kv.set_value(it.second.c_str(), it.second.length());
     }
     global_api_server->send_homeassistant_service_call(resp);
   }
@@ -190,7 +190,7 @@ class CustomAPIDevice {
    */
   void fire_homeassistant_event(const std::string &event_name) {
     HomeassistantServiceResponse resp;
-    resp.service = event_name;
+    resp.set_service(event_name.c_str(), event_name.length());
     resp.is_event = true;
     global_api_server->send_homeassistant_service_call(resp);
   }
@@ -210,13 +210,13 @@ class CustomAPIDevice {
    */
   void fire_homeassistant_event(const std::string &service_name, const std::map<std::string, std::string> &data) {
     HomeassistantServiceResponse resp;
-    resp.service = service_name;
+    resp.set_service(service_name.c_str(), service_name.length());
     resp.is_event = true;
     for (auto &it : data) {
-      HomeassistantServiceMap kv;
-      kv.key = it.first;
-      kv.value = it.second;
-      resp.data.push_back(kv);
+      resp.data.emplace_back();
+      auto &kv = resp.data.back();
+      kv.set_key(it.first.c_str(), it.first.length());
+      kv.set_value(it.second.c_str(), it.second.length());
     }
     global_api_server->send_homeassistant_service_call(resp);
   }

--- a/esphome/components/api/homeassistant_service.h
+++ b/esphome/components/api/homeassistant_service.h
@@ -59,25 +59,29 @@ template<typename... Ts> class HomeAssistantServiceCallAction : public Action<Ts
 
   void play(Ts... x) override {
     HomeassistantServiceResponse resp;
-    resp.service = this->service_.value(x...);
+    std::string service_value = this->service_.value(x...);
+    resp.set_service(service_value.c_str(), service_value.length());
     resp.is_event = this->is_event_;
     for (auto &it : this->data_) {
-      HomeassistantServiceMap kv;
-      kv.key = it.key;
-      kv.value = it.value.value(x...);
-      resp.data.push_back(kv);
+      resp.data.emplace_back();
+      auto &kv = resp.data.back();
+      kv.set_key(it.key.c_str(), it.key.length());
+      std::string value = it.value.value(x...);
+      kv.set_value(value.c_str(), value.length());
     }
     for (auto &it : this->data_template_) {
-      HomeassistantServiceMap kv;
-      kv.key = it.key;
-      kv.value = it.value.value(x...);
-      resp.data_template.push_back(kv);
+      resp.data_template.emplace_back();
+      auto &kv = resp.data_template.back();
+      kv.set_key(it.key.c_str(), it.key.length());
+      std::string value = it.value.value(x...);
+      kv.set_value(value.c_str(), value.length());
     }
     for (auto &it : this->variables_) {
-      HomeassistantServiceMap kv;
-      kv.key = it.key;
-      kv.value = it.value.value(x...);
-      resp.variables.push_back(kv);
+      resp.variables.emplace_back();
+      auto &kv = resp.variables.back();
+      kv.set_key(it.key.c_str(), it.key.length());
+      std::string value = it.value.value(x...);
+      kv.set_value(value.c_str(), value.length());
     }
     this->parent_->send_homeassistant_service_call(resp);
   }

--- a/esphome/components/api/homeassistant_service.h
+++ b/esphome/components/api/homeassistant_service.h
@@ -60,28 +60,28 @@ template<typename... Ts> class HomeAssistantServiceCallAction : public Action<Ts
   void play(Ts... x) override {
     HomeassistantServiceResponse resp;
     std::string service_value = this->service_.value(x...);
-    resp.set_service(service_value.c_str(), service_value.length());
+    resp.set_service(StringRef(service_value));
     resp.is_event = this->is_event_;
     for (auto &it : this->data_) {
       resp.data.emplace_back();
       auto &kv = resp.data.back();
-      kv.set_key(it.key.c_str(), it.key.length());
+      kv.set_key(StringRef(it.key));
       std::string value = it.value.value(x...);
-      kv.set_value(value.c_str(), value.length());
+      kv.set_value(StringRef(value));
     }
     for (auto &it : this->data_template_) {
       resp.data_template.emplace_back();
       auto &kv = resp.data_template.back();
-      kv.set_key(it.key.c_str(), it.key.length());
+      kv.set_key(StringRef(it.key));
       std::string value = it.value.value(x...);
-      kv.set_value(value.c_str(), value.length());
+      kv.set_value(StringRef(value));
     }
     for (auto &it : this->variables_) {
       resp.variables.emplace_back();
       auto &kv = resp.variables.back();
-      kv.set_key(it.key.c_str(), it.key.length());
+      kv.set_key(StringRef(it.key));
       std::string value = it.value.value(x...);
-      kv.set_value(value.c_str(), value.length());
+      kv.set_value(StringRef(value));
     }
     this->parent_->send_homeassistant_service_call(resp);
   }

--- a/esphome/components/api/proto.h
+++ b/esphome/components/api/proto.h
@@ -683,12 +683,16 @@ class ProtoSize {
   }
 
   /**
-   * @brief Calculates and adds the size of a string/bytes field to the total message size (repeated field version)
+   * @brief Calculates and adds the size of a string field using length
    */
-  static inline void add_string_field_repeated(uint32_t &total_size, uint32_t field_id_size, const std::string &str) {
-    // Always calculate size for repeated fields
-    const uint32_t str_size = static_cast<uint32_t>(str.size());
-    total_size += field_id_size + varint(str_size) + str_size;
+  static inline void add_string_field(uint32_t &total_size, uint32_t field_id_size, size_t len) {
+    // Skip calculation if string is empty
+    if (len == 0) {
+      return;  // No need to update total_size
+    }
+
+    // Field ID + length varint + string bytes
+    total_size += field_id_size + varint(static_cast<uint32_t>(len)) + static_cast<uint32_t>(len);
   }
 
   /**

--- a/esphome/components/api/proto.h
+++ b/esphome/components/api/proto.h
@@ -16,6 +16,37 @@
 namespace esphome {
 namespace api {
 
+/*
+ * StringRef Ownership Model for API Protocol Messages
+ * ===================================================
+ *
+ * StringRef is used for zero-copy string handling in outgoing (SOURCE_SERVER) messages.
+ * It holds a pointer and length to existing string data without copying.
+ *
+ * CRITICAL: The referenced string data MUST remain valid until message encoding completes.
+ *
+ * Safe StringRef Patterns:
+ * 1. String literals: StringRef("literal") - Always safe (static storage duration)
+ * 2. Member variables: StringRef(this->member_string_) - Safe if object outlives encoding
+ * 3. Global/static strings: StringRef(GLOBAL_CONSTANT) - Always safe
+ * 4. Local variables: Safe ONLY if encoding happens before function returns:
+ *    std::string temp = compute_value();
+ *    msg.set_field(StringRef(temp));
+ *    return this->send_message(msg);  // temp is valid during encoding
+ *
+ * Unsafe Patterns (WILL cause crashes/corruption):
+ * 1. Temporaries: msg.set_field(StringRef(obj.get_string())) // get_string() returns by value
+ * 2. Optional values: msg.set_field(StringRef(optional.value())) // value() returns a copy
+ * 3. Concatenation: msg.set_field(StringRef(str1 + str2)) // Result is temporary
+ *
+ * For unsafe patterns, store in a local variable first:
+ *    std::string temp = optional.value();  // or get_string() or str1 + str2
+ *    msg.set_field(StringRef(temp));
+ *
+ * The send_*_response pattern ensures proper lifetime management by encoding
+ * within the same function scope where temporaries are created.
+ */
+
 /// Representation of a VarInt - in ProtoBuf should be 64bit but we only use 32bit
 class ProtoVarInt {
  public:

--- a/esphome/components/api/proto.h
+++ b/esphome/components/api/proto.h
@@ -700,6 +700,15 @@ class ProtoSize {
   }
 
   /**
+   * @brief Calculates and adds the size of a string/bytes field to the total message size (repeated field version)
+   */
+  static inline void add_string_field_repeated(uint32_t &total_size, uint32_t field_id_size, const std::string &str) {
+    // Always calculate size for repeated fields (no empty check)
+    const uint32_t str_size = static_cast<uint32_t>(str.size());
+    total_size += field_id_size + varint(str_size) + str_size;
+  }
+
+  /**
    * @brief Calculates and adds the size of a bytes field to the total message size
    */
   static inline void add_bytes_field(uint32_t &total_size, uint32_t field_id_size, size_t len) {

--- a/esphome/components/api/proto.h
+++ b/esphome/components/api/proto.h
@@ -689,7 +689,7 @@ class ProtoSize {
    * @brief Calculates and adds the size of a string/bytes field to the total message size (repeated field version)
    */
   static inline void add_string_field_repeated(uint32_t &total_size, uint32_t field_id_size, const std::string &str) {
-    // Always calculate size for repeated fields (no empty check)
+    // Always calculate size for repeated fields
     const uint32_t str_size = static_cast<uint32_t>(str.size());
     total_size += field_id_size + varint(str_size) + str_size;
   }

--- a/esphome/components/api/proto.h
+++ b/esphome/components/api/proto.h
@@ -3,6 +3,7 @@
 #include "esphome/core/component.h"
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
+#include "esphome/core/string_ref.h"
 
 #include <cassert>
 #include <cstring>
@@ -217,6 +218,9 @@ class ProtoWriteBuffer {
   }
   void encode_string(uint32_t field_id, const std::string &value, bool force = false) {
     this->encode_string(field_id, value.data(), value.size(), force);
+  }
+  void encode_string(uint32_t field_id, const StringRef &ref, bool force = false) {
+    this->encode_string(field_id, ref.c_str(), ref.size(), force);
   }
   void encode_bytes(uint32_t field_id, const uint8_t *data, size_t len, bool force = false) {
     this->encode_string(field_id, reinterpret_cast<const char *>(data), len, force);

--- a/esphome/components/api/proto.h
+++ b/esphome/components/api/proto.h
@@ -673,20 +673,6 @@ class ProtoSize {
   // sint64 type is not supported by ESPHome API to reduce overhead on embedded systems
 
   /**
-   * @brief Calculates and adds the size of a string/bytes field to the total message size
-   */
-  static inline void add_string_field(uint32_t &total_size, uint32_t field_id_size, const std::string &str) {
-    // Skip calculation if string is empty
-    if (str.empty()) {
-      return;  // No need to update total_size
-    }
-
-    // Calculate and directly add to total_size
-    const uint32_t str_size = static_cast<uint32_t>(str.size());
-    total_size += field_id_size + varint(str_size) + str_size;
-  }
-
-  /**
    * @brief Calculates and adds the size of a string field using length
    */
   static inline void add_string_field(uint32_t &total_size, uint32_t field_id_size, size_t len) {

--- a/esphome/components/api/user_services.h
+++ b/esphome/components/api/user_services.h
@@ -33,14 +33,14 @@ template<typename... Ts> class UserServiceBase : public UserServiceDescriptor {
 
   ListEntitiesServicesResponse encode_list_service_response() override {
     ListEntitiesServicesResponse msg;
-    msg.name = this->name_;
+    msg.set_name(this->name_.c_str(), this->name_.length());
     msg.key = this->key_;
     std::array<enums::ServiceArgType, sizeof...(Ts)> arg_types = {to_service_arg_type<Ts>()...};
     for (int i = 0; i < sizeof...(Ts); i++) {
-      ListEntitiesServicesArgument arg;
+      msg.args.emplace_back();
+      auto &arg = msg.args.back();
       arg.type = arg_types[i];
-      arg.name = this->arg_names_[i];
-      msg.args.push_back(arg);
+      arg.set_name(this->arg_names_[i].c_str(), this->arg_names_[i].length());
     }
     return msg;
   }

--- a/esphome/components/api/user_services.h
+++ b/esphome/components/api/user_services.h
@@ -33,14 +33,14 @@ template<typename... Ts> class UserServiceBase : public UserServiceDescriptor {
 
   ListEntitiesServicesResponse encode_list_service_response() override {
     ListEntitiesServicesResponse msg;
-    msg.set_name(this->name_.c_str(), this->name_.length());
+    msg.set_name(StringRef(this->name_));
     msg.key = this->key_;
     std::array<enums::ServiceArgType, sizeof...(Ts)> arg_types = {to_service_arg_type<Ts>()...};
     for (int i = 0; i < sizeof...(Ts); i++) {
       msg.args.emplace_back();
       auto &arg = msg.args.back();
       arg.type = arg_types[i];
-      arg.set_name(this->arg_names_[i].c_str(), this->arg_names_[i].length());
+      arg.set_name(StringRef(this->arg_names_[i]));
     }
     return msg;
   }

--- a/esphome/components/homeassistant/number/homeassistant_number.cpp
+++ b/esphome/components/homeassistant/number/homeassistant_number.cpp
@@ -84,17 +84,18 @@ void HomeassistantNumber::control(float value) {
   this->publish_state(value);
 
   api::HomeassistantServiceResponse resp;
-  resp.service = "number.set_value";
+  resp.set_service("number.set_value", 17);
 
-  api::HomeassistantServiceMap entity_id;
-  entity_id.key = "entity_id";
-  entity_id.value = this->entity_id_;
-  resp.data.push_back(entity_id);
+  resp.data.emplace_back();
+  auto &entity_id = resp.data.back();
+  entity_id.set_key("entity_id", 9);
+  entity_id.set_value(this->entity_id_.c_str(), this->entity_id_.length());
 
-  api::HomeassistantServiceMap entity_value;
-  entity_value.key = "value";
-  entity_value.value = to_string(value);
-  resp.data.push_back(entity_value);
+  resp.data.emplace_back();
+  auto &entity_value = resp.data.back();
+  entity_value.set_key("value", 5);
+  std::string value_str = to_string(value);
+  entity_value.set_value(value_str.c_str(), value_str.length());
 
   api::global_api_server->send_homeassistant_service_call(resp);
 }

--- a/esphome/components/homeassistant/number/homeassistant_number.cpp
+++ b/esphome/components/homeassistant/number/homeassistant_number.cpp
@@ -84,16 +84,16 @@ void HomeassistantNumber::control(float value) {
   this->publish_state(value);
 
   api::HomeassistantServiceResponse resp;
-  resp.set_service("number.set_value", 17);
+  resp.set_service(StringRef("number.set_value"));
 
   resp.data.emplace_back();
   auto &entity_id = resp.data.back();
-  entity_id.set_key("entity_id", 9);
+  entity_id.set_key(StringRef("entity_id"));
   entity_id.set_value(StringRef(this->entity_id_));
 
   resp.data.emplace_back();
   auto &entity_value = resp.data.back();
-  entity_value.set_key("value", 5);
+  entity_value.set_key(StringRef("value"));
   std::string value_str = to_string(value);
   entity_value.set_value(StringRef(value_str));
 

--- a/esphome/components/homeassistant/number/homeassistant_number.cpp
+++ b/esphome/components/homeassistant/number/homeassistant_number.cpp
@@ -98,6 +98,7 @@ void HomeassistantNumber::control(float value) {
   resp.data.emplace_back();
   auto &entity_value = resp.data.back();
   entity_value.set_key(VALUE_KEY);
+  // to_string() returns a temporary - must store it to avoid dangling reference
   std::string value_str = to_string(value);
   entity_value.set_value(StringRef(value_str));
 

--- a/esphome/components/homeassistant/number/homeassistant_number.cpp
+++ b/esphome/components/homeassistant/number/homeassistant_number.cpp
@@ -83,17 +83,21 @@ void HomeassistantNumber::control(float value) {
 
   this->publish_state(value);
 
+  static constexpr auto SERVICE_NAME = StringRef::from_lit("number.set_value");
+  static constexpr auto ENTITY_ID_KEY = StringRef::from_lit("entity_id");
+  static constexpr auto VALUE_KEY = StringRef::from_lit("value");
+
   api::HomeassistantServiceResponse resp;
-  resp.set_service(StringRef("number.set_value"));
+  resp.set_service(SERVICE_NAME);
 
   resp.data.emplace_back();
   auto &entity_id = resp.data.back();
-  entity_id.set_key(StringRef("entity_id"));
+  entity_id.set_key(ENTITY_ID_KEY);
   entity_id.set_value(StringRef(this->entity_id_));
 
   resp.data.emplace_back();
   auto &entity_value = resp.data.back();
-  entity_value.set_key(StringRef("value"));
+  entity_value.set_key(VALUE_KEY);
   std::string value_str = to_string(value);
   entity_value.set_value(StringRef(value_str));
 

--- a/esphome/components/homeassistant/number/homeassistant_number.cpp
+++ b/esphome/components/homeassistant/number/homeassistant_number.cpp
@@ -89,13 +89,13 @@ void HomeassistantNumber::control(float value) {
   resp.data.emplace_back();
   auto &entity_id = resp.data.back();
   entity_id.set_key("entity_id", 9);
-  entity_id.set_value(this->entity_id_.c_str(), this->entity_id_.length());
+  entity_id.set_value(StringRef(this->entity_id_));
 
   resp.data.emplace_back();
   auto &entity_value = resp.data.back();
   entity_value.set_key("value", 5);
   std::string value_str = to_string(value);
-  entity_value.set_value(value_str.c_str(), value_str.length());
+  entity_value.set_value(StringRef(value_str));
 
   api::global_api_server->send_homeassistant_service_call(resp);
 }

--- a/esphome/components/homeassistant/switch/homeassistant_switch.cpp
+++ b/esphome/components/homeassistant/switch/homeassistant_switch.cpp
@@ -42,14 +42,14 @@ void HomeassistantSwitch::write_state(bool state) {
 
   api::HomeassistantServiceResponse resp;
   if (state) {
-    resp.set_service("homeassistant.turn_on", 22);
+    resp.set_service(StringRef("homeassistant.turn_on"));
   } else {
-    resp.set_service("homeassistant.turn_off", 23);
+    resp.set_service(StringRef("homeassistant.turn_off"));
   }
 
   resp.data.emplace_back();
   auto &entity_id_kv = resp.data.back();
-  entity_id_kv.set_key("entity_id", 9);
+  entity_id_kv.set_key(StringRef("entity_id"));
   entity_id_kv.set_value(StringRef(this->entity_id_));
 
   api::global_api_server->send_homeassistant_service_call(resp);

--- a/esphome/components/homeassistant/switch/homeassistant_switch.cpp
+++ b/esphome/components/homeassistant/switch/homeassistant_switch.cpp
@@ -40,16 +40,20 @@ void HomeassistantSwitch::write_state(bool state) {
     return;
   }
 
+  static constexpr auto SERVICE_ON = StringRef::from_lit("homeassistant.turn_on");
+  static constexpr auto SERVICE_OFF = StringRef::from_lit("homeassistant.turn_off");
+  static constexpr auto ENTITY_ID_KEY = StringRef::from_lit("entity_id");
+
   api::HomeassistantServiceResponse resp;
   if (state) {
-    resp.set_service(StringRef("homeassistant.turn_on"));
+    resp.set_service(SERVICE_ON);
   } else {
-    resp.set_service(StringRef("homeassistant.turn_off"));
+    resp.set_service(SERVICE_OFF);
   }
 
   resp.data.emplace_back();
   auto &entity_id_kv = resp.data.back();
-  entity_id_kv.set_key(StringRef("entity_id"));
+  entity_id_kv.set_key(ENTITY_ID_KEY);
   entity_id_kv.set_value(StringRef(this->entity_id_));
 
   api::global_api_server->send_homeassistant_service_call(resp);

--- a/esphome/components/homeassistant/switch/homeassistant_switch.cpp
+++ b/esphome/components/homeassistant/switch/homeassistant_switch.cpp
@@ -42,15 +42,15 @@ void HomeassistantSwitch::write_state(bool state) {
 
   api::HomeassistantServiceResponse resp;
   if (state) {
-    resp.service = "homeassistant.turn_on";
+    resp.set_service("homeassistant.turn_on", 22);
   } else {
-    resp.service = "homeassistant.turn_off";
+    resp.set_service("homeassistant.turn_off", 23);
   }
 
-  api::HomeassistantServiceMap entity_id_kv;
-  entity_id_kv.key = "entity_id";
-  entity_id_kv.value = this->entity_id_;
-  resp.data.push_back(entity_id_kv);
+  resp.data.emplace_back();
+  auto &entity_id_kv = resp.data.back();
+  entity_id_kv.set_key("entity_id", 9);
+  entity_id_kv.set_value(this->entity_id_.c_str(), this->entity_id_.length());
 
   api::global_api_server->send_homeassistant_service_call(resp);
 }

--- a/esphome/components/homeassistant/switch/homeassistant_switch.cpp
+++ b/esphome/components/homeassistant/switch/homeassistant_switch.cpp
@@ -50,7 +50,7 @@ void HomeassistantSwitch::write_state(bool state) {
   resp.data.emplace_back();
   auto &entity_id_kv = resp.data.back();
   entity_id_kv.set_key("entity_id", 9);
-  entity_id_kv.set_value(this->entity_id_.c_str(), this->entity_id_.length());
+  entity_id_kv.set_value(StringRef(this->entity_id_));
 
   api::global_api_server->send_homeassistant_service_call(resp);
 }

--- a/esphome/components/text/text_traits.h
+++ b/esphome/components/text/text_traits.h
@@ -3,6 +3,7 @@
 #include <utility>
 
 #include "esphome/core/helpers.h"
+#include "esphome/core/string_ref.h"
 
 namespace esphome {
 namespace text {
@@ -23,6 +24,7 @@ class TextTraits {
   // Set/get the pattern.
   void set_pattern(std::string pattern) { this->pattern_ = std::move(pattern); }
   std::string get_pattern() const { return this->pattern_; }
+  StringRef get_pattern_ref() const { return StringRef(this->pattern_); }
 
   // Set/get the frontend mode.
   void set_mode(TextMode mode) { this->mode_ = mode; }

--- a/esphome/components/voice_assistant/voice_assistant.cpp
+++ b/esphome/components/voice_assistant/voice_assistant.cpp
@@ -238,10 +238,10 @@ void VoiceAssistant::loop() {
 
       api::VoiceAssistantRequest msg;
       msg.start = true;
-      msg.conversation_id = this->conversation_id_;
+      msg.set_conversation_id(StringRef(this->conversation_id_));
       msg.flags = flags;
       msg.audio_settings = audio_settings;
-      msg.wake_word_phrase = this->wake_word_;
+      msg.set_wake_word_phrase(StringRef(this->wake_word_));
       this->wake_word_ = "";
 
       // Reset media player state tracking

--- a/esphome/core/entity_base.h
+++ b/esphome/core/entity_base.h
@@ -56,10 +56,7 @@ class EntityBase {
   void set_icon(const char *icon);
   StringRef get_icon_ref() const {
 #ifdef USE_ENTITY_ICON
-    if (this->icon_c_str_ == nullptr) {
-      return StringRef("");
-    }
-    return StringRef(this->icon_c_str_);
+    return this->icon_c_str_ == nullptr ? StringRef("") : StringRef(this->icon_c_str_);
 #else
     return StringRef("");
 #endif
@@ -117,10 +114,7 @@ class EntityBase_DeviceClass {  // NOLINT(readability-identifier-naming)
   void set_device_class(const char *device_class);
   /// Get the device class as StringRef
   StringRef get_device_class_ref() const {
-    if (this->device_class_ == nullptr) {
-      return StringRef("");
-    }
-    return StringRef(this->device_class_);
+    return this->device_class_ == nullptr ? StringRef("") : StringRef(this->device_class_);
   }
 
  protected:
@@ -135,10 +129,7 @@ class EntityBase_UnitOfMeasurement {  // NOLINT(readability-identifier-naming)
   void set_unit_of_measurement(const char *unit_of_measurement);
   /// Get the unit of measurement as StringRef
   StringRef get_unit_of_measurement_ref() const {
-    if (this->unit_of_measurement_ == nullptr) {
-      return StringRef("");
-    }
-    return StringRef(this->unit_of_measurement_);
+    return this->unit_of_measurement_ == nullptr ? StringRef("") : StringRef(this->unit_of_measurement_);
   }
 
  protected:

--- a/esphome/core/entity_base.h
+++ b/esphome/core/entity_base.h
@@ -55,10 +55,11 @@ class EntityBase {
   std::string get_icon() const;
   void set_icon(const char *icon);
   StringRef get_icon_ref() const {
+    static constexpr auto EMPTY_STRING = StringRef::from_lit("");
 #ifdef USE_ENTITY_ICON
-    return this->icon_c_str_ == nullptr ? StringRef("") : StringRef(this->icon_c_str_);
+    return this->icon_c_str_ == nullptr ? EMPTY_STRING : StringRef(this->icon_c_str_);
 #else
-    return StringRef("");
+    return EMPTY_STRING;
 #endif
   }
 
@@ -114,7 +115,8 @@ class EntityBase_DeviceClass {  // NOLINT(readability-identifier-naming)
   void set_device_class(const char *device_class);
   /// Get the device class as StringRef
   StringRef get_device_class_ref() const {
-    return this->device_class_ == nullptr ? StringRef("") : StringRef(this->device_class_);
+    static constexpr auto EMPTY_STRING = StringRef::from_lit("");
+    return this->device_class_ == nullptr ? EMPTY_STRING : StringRef(this->device_class_);
   }
 
  protected:
@@ -129,7 +131,8 @@ class EntityBase_UnitOfMeasurement {  // NOLINT(readability-identifier-naming)
   void set_unit_of_measurement(const char *unit_of_measurement);
   /// Get the unit of measurement as StringRef
   StringRef get_unit_of_measurement_ref() const {
-    return this->unit_of_measurement_ == nullptr ? StringRef("") : StringRef(this->unit_of_measurement_);
+    static constexpr auto EMPTY_STRING = StringRef::from_lit("");
+    return this->unit_of_measurement_ == nullptr ? EMPTY_STRING : StringRef(this->unit_of_measurement_);
   }
 
  protected:

--- a/esphome/core/entity_base.h
+++ b/esphome/core/entity_base.h
@@ -54,6 +54,16 @@ class EntityBase {
   // Get/set this entity's icon
   std::string get_icon() const;
   void set_icon(const char *icon);
+  StringRef get_icon_ref() const {
+#ifdef USE_ENTITY_ICON
+    if (this->icon_c_str_ == nullptr) {
+      return StringRef("");
+    }
+    return StringRef(this->icon_c_str_);
+#else
+    return StringRef("");
+#endif
+  }
 
 #ifdef USE_DEVICES
   // Get/set this entity's device id
@@ -105,6 +115,13 @@ class EntityBase_DeviceClass {  // NOLINT(readability-identifier-naming)
   std::string get_device_class();
   /// Manually set the device class.
   void set_device_class(const char *device_class);
+  /// Get the device class as StringRef
+  StringRef get_device_class_ref() const {
+    if (this->device_class_ == nullptr) {
+      return StringRef("");
+    }
+    return StringRef(this->device_class_);
+  }
 
  protected:
   const char *device_class_{nullptr};  ///< Device class override
@@ -116,6 +133,13 @@ class EntityBase_UnitOfMeasurement {  // NOLINT(readability-identifier-naming)
   std::string get_unit_of_measurement();
   /// Manually set the unit of measurement.
   void set_unit_of_measurement(const char *unit_of_measurement);
+  /// Get the unit of measurement as StringRef
+  StringRef get_unit_of_measurement_ref() const {
+    if (this->unit_of_measurement_ == nullptr) {
+      return StringRef("");
+    }
+    return StringRef(this->unit_of_measurement_);
+  }
 
  protected:
   const char *unit_of_measurement_{nullptr};  ///< Unit of measurement override

--- a/script/api_protobuf/api_protobuf.py
+++ b/script/api_protobuf/api_protobuf.py
@@ -569,6 +569,10 @@ class StringType(TypeInfo):
         return f"buffer.encode_string({self.number}, this->{self.field_name}_ref_);"
 
     def dump(self, name):
+        # If name is 'it', this is a repeated field element - always use string
+        if name == "it":
+            return "append_quoted_string(out, StringRef(it));"
+
         # For SOURCE_CLIENT only, always use std::string
         if not self._needs_encode:
             return f'out.append("\'").append(this->{self.field_name}).append("\'");'

--- a/script/api_protobuf/api_protobuf.py
+++ b/script/api_protobuf/api_protobuf.py
@@ -575,13 +575,7 @@ class StringType(TypeInfo):
 
         # For SOURCE_SERVER, always use StringRef
         if not self._needs_decode:
-            return (
-                f"if (!this->{self.field_name}_ref_.empty()) {{"
-                f'  out.append("\'").append(this->{self.field_name}_ref_.c_str()).append("\'");'
-                f"}} else {{"
-                f'  out.append("\'").append("").append("\'");'
-                f"}}"
-            )
+            return f"append_quoted_string(out, this->{self.field_name}_ref_);"
 
         # For SOURCE_BOTH, check if StringRef is set (sending) or use string (received)
         return (
@@ -1867,6 +1861,15 @@ namespace api {
 
 namespace esphome {
 namespace api {
+
+// Helper function to append a quoted string, handling empty StringRef
+static inline void append_quoted_string(std::string &out, const StringRef &ref) {
+  out.append("'");
+  if (!ref.empty()) {
+    out.append(ref.c_str());
+  }
+  out.append("'");
+}
 
 """
 

--- a/script/api_protobuf/api_protobuf.py
+++ b/script/api_protobuf/api_protobuf.py
@@ -2106,7 +2106,13 @@ static const char *const TAG = "api.service";
             cpp += f"#ifdef {ifdef}\n"
 
         hpp_protected += f"  void {on_func}(const {inp} &msg) override;\n"
-        hpp += f"  virtual {ret} {func}(const {inp} &msg) = 0;\n"
+
+        # For non-void methods, generate a send_ method instead of return-by-value
+        if is_void:
+            hpp += f"  virtual void {func}(const {inp} &msg) = 0;\n"
+        else:
+            hpp += f"  virtual bool send_{func}_response(const {inp} &msg) = 0;\n"
+
         cpp += f"void {class_name}::{on_func}(const {inp} &msg) {{\n"
 
         # Start with authentication/connection check if needed
@@ -2124,10 +2130,7 @@ static const char *const TAG = "api.service";
             if is_void:
                 handler_body = f"this->{func}(msg);\n"
             else:
-                handler_body = f"{ret} ret = this->{func}(msg);\n"
-                handler_body += (
-                    f"if (!this->send_message(ret, {ret}::MESSAGE_TYPE)) {{\n"
-                )
+                handler_body = f"if (!this->send_{func}_response(msg)) {{\n"
                 handler_body += "  this->on_fatal_error();\n"
                 handler_body += "}\n"
 
@@ -2139,8 +2142,7 @@ static const char *const TAG = "api.service";
             if is_void:
                 body += f"this->{func}(msg);\n"
             else:
-                body += f"{ret} ret = this->{func}(msg);\n"
-                body += f"if (!this->send_message(ret, {ret}::MESSAGE_TYPE)) {{\n"
+                body += f"if (!this->send_{func}_response(msg)) {{\n"
                 body += "  this->on_fatal_error();\n"
                 body += "}\n"
 

--- a/script/api_protobuf/api_protobuf.py
+++ b/script/api_protobuf/api_protobuf.py
@@ -554,13 +554,11 @@ class StringType(TypeInfo):
         if self._needs_encode:
             content.extend(
                 [
-                    # Add pointer/length fields if message needs encoding
-                    f"const char* {self.field_name}_ptr_{{nullptr}};",
-                    f"size_t {self.field_name}_len_{{0}};",
+                    # Add StringRef field if message needs encoding
+                    f"StringRef {self.field_name}_ref_{{}};",
                     # Add setter method if message needs encoding
-                    f"void set_{self.field_name}(const char* data, size_t len) {{",
-                    f"  this->{self.field_name}_ptr_ = data;",
-                    f"  this->{self.field_name}_len_ = len;",
+                    f"void set_{self.field_name}(const StringRef &ref) {{",
+                    f"  this->{self.field_name}_ref_ = ref;",
                     "}",
                 ]
             )
@@ -568,27 +566,27 @@ class StringType(TypeInfo):
 
     @property
     def encode_content(self) -> str:
-        return f"buffer.encode_string({self.number}, this->{self.field_name}_ptr_, this->{self.field_name}_len_);"
+        return f"buffer.encode_string({self.number}, this->{self.field_name}_ref_);"
 
     def dump(self, name):
         # For SOURCE_CLIENT only, always use std::string
         if not self._needs_encode:
             return f'out.append("\'").append(this->{self.field_name}).append("\'");'
 
-        # For SOURCE_SERVER, always use pointer/length
+        # For SOURCE_SERVER, always use StringRef
         if not self._needs_decode:
             return (
-                f"if (this->{self.field_name}_ptr_ != nullptr) {{"
-                f'  out.append("\'").append(this->{self.field_name}_ptr_).append("\'");'
+                f"if (!this->{self.field_name}_ref_.empty()) {{"
+                f'  out.append("\'").append(this->{self.field_name}_ref_.c_str()).append("\'");'
                 f"}} else {{"
                 f'  out.append("\'").append("").append("\'");'
                 f"}}"
             )
 
-        # For SOURCE_BOTH, check if pointer is set (sending) or use string (received)
+        # For SOURCE_BOTH, check if StringRef is set (sending) or use string (received)
         return (
-            f"if (this->{self.field_name}_ptr_ != nullptr) {{"
-            f'  out.append("\'").append(this->{self.field_name}_ptr_).append("\'");'
+            f"if (!this->{self.field_name}_ref_.empty()) {{"
+            f'  out.append("\'").append(this->{self.field_name}_ref_.c_str()).append("\'");'
             f"}} else {{"
             f'  out.append("\'").append(this->{self.field_name}).append("\'");'
             f"}}"
@@ -605,9 +603,9 @@ class StringType(TypeInfo):
             field_id_size = self.calculate_field_id_size()
             return f"ProtoSize::add_string_field(total_size, {field_id_size}, it.length());"
 
-        # For messages that need encoding, use the length only
+        # For messages that need encoding, use the StringRef size
         field_id_size = self.calculate_field_id_size()
-        return f"ProtoSize::add_string_field(total_size, {field_id_size}, this->{self.field_name}_len_);"
+        return f"ProtoSize::add_string_field(total_size, {field_id_size}, this->{self.field_name}_ref_.size());"
 
     def get_estimated_size(self) -> int:
         return self.calculate_field_id_size() + 8  # field ID + 8 bytes typical string
@@ -1835,6 +1833,7 @@ def main() -> None:
 #pragma once
 
 #include "esphome/core/defines.h"
+#include "esphome/core/string_ref.h"
 
 #include "proto.h"
 

--- a/script/api_protobuf/api_protobuf.py
+++ b/script/api_protobuf/api_protobuf.py
@@ -340,6 +340,10 @@ def create_field_type_info(
     if field.type == 12:
         return BytesType(field, needs_decode, needs_encode)
 
+    # Special handling for string fields
+    if field.type == 9:
+        return StringType(field, needs_decode, needs_encode)
+
     validate_field_type(field.type, field.name)
     return TYPE_INFO[field.type](field)
 
@@ -540,12 +544,70 @@ class StringType(TypeInfo):
     encode_func = "encode_string"
     wire_type = WireType.LENGTH_DELIMITED  # Uses wire type 2
 
+    @property
+    def public_content(self) -> list[str]:
+        content: list[str] = []
+        # Add std::string storage if message needs decoding
+        if self._needs_decode:
+            content.append(f"std::string {self.field_name}{{}};")
+
+        if self._needs_encode:
+            content.extend(
+                [
+                    # Add pointer/length fields if message needs encoding
+                    f"const char* {self.field_name}_ptr_{{nullptr}};",
+                    f"size_t {self.field_name}_len_{{0}};",
+                    # Add setter method if message needs encoding
+                    f"void set_{self.field_name}(const char* data, size_t len) {{",
+                    f"  this->{self.field_name}_ptr_ = data;",
+                    f"  this->{self.field_name}_len_ = len;",
+                    "}",
+                ]
+            )
+        return content
+
+    @property
+    def encode_content(self) -> str:
+        return f"buffer.encode_string({self.number}, this->{self.field_name}_ptr_, this->{self.field_name}_len_);"
+
     def dump(self, name):
-        o = f'out.append("\'").append({name}).append("\'");'
-        return o
+        # For SOURCE_CLIENT only, always use std::string
+        if not self._needs_encode:
+            return f'out.append("\'").append(this->{self.field_name}).append("\'");'
+
+        # For SOURCE_SERVER, always use pointer/length
+        if not self._needs_decode:
+            return (
+                f"if (this->{self.field_name}_ptr_ != nullptr) {{"
+                f'  out.append("\'").append(this->{self.field_name}_ptr_).append("\'");'
+                f"}} else {{"
+                f'  out.append("\'").append("").append("\'");'
+                f"}}"
+            )
+
+        # For SOURCE_BOTH, check if pointer is set (sending) or use string (received)
+        return (
+            f"if (this->{self.field_name}_ptr_ != nullptr) {{"
+            f'  out.append("\'").append(this->{self.field_name}_ptr_).append("\'");'
+            f"}} else {{"
+            f'  out.append("\'").append(this->{self.field_name}).append("\'");'
+            f"}}"
+        )
 
     def get_size_calculation(self, name: str, force: bool = False) -> str:
-        return self._get_simple_size_calculation(name, force, "add_string_field")
+        # For SOURCE_CLIENT only messages, use the string field directly
+        if not self._needs_encode:
+            return self._get_simple_size_calculation(name, force, "add_string_field")
+
+        # Check if this is being called from a repeated field context
+        # In that case, 'name' will be 'it' and we need to use .length()
+        if name == "it":
+            field_id_size = self.calculate_field_id_size()
+            return f"ProtoSize::add_string_field(total_size, {field_id_size}, it.length());"
+
+        # For messages that need encoding, use the length only
+        field_id_size = self.calculate_field_id_size()
+        return f"ProtoSize::add_string_field(total_size, {field_id_size}, this->{self.field_name}_len_);"
 
     def get_estimated_size(self) -> int:
         return self.calculate_field_id_size() + 8  # field ID + 8 bytes typical string

--- a/script/api_protobuf/api_protobuf.py
+++ b/script/api_protobuf/api_protobuf.py
@@ -598,10 +598,11 @@ class StringType(TypeInfo):
             return self._get_simple_size_calculation(name, force, "add_string_field")
 
         # Check if this is being called from a repeated field context
-        # In that case, 'name' will be 'it' and we need to use .length()
+        # In that case, 'name' will be 'it' and we need to use the repeated version
         if name == "it":
+            # For repeated fields, we need to use add_string_field_repeated which includes field ID
             field_id_size = self.calculate_field_id_size()
-            return f"ProtoSize::add_string_field(total_size, {field_id_size}, it.length());"
+            return f"ProtoSize::add_string_field_repeated(total_size, {field_id_size}, it);"
 
         # For messages that need encoding, use the StringRef size
         field_id_size = self.calculate_field_id_size()


### PR DESCRIPTION
https://github.com/esphome/esphome/pull/9782 should merge first as it will conflict

# What does this implement/fix?

This PR addresses the memory allocation bottleneck that occurs when Home Assistant initially connects to ESPHome devices and retrieves all entity information and initial states. Users with high entity counts have reported connection issues where not all entities are visible (see home-assistant/core#145293), requiring device restarts to see all entities.

By implementing zero-copy string handling for outgoing API protobuf messages (SOURCE_SERVER) using StringRef, this PR significantly reduces memory churn during the critical connection phase when ESPHome sends:
- Device information
- Entity listings for all sensors, switches, lights, etc.
- Initial state values for all entities

Key improvements:
- **Eliminates string copies** for all outgoing API messages using StringRef
- **Reduces heap fragmentation** during the connection burst when sending entity information
- **Flash memory savings**: 732-1,772 bytes depending on device complexity
- **Faster connection establishment** with less memory allocation overhead
- Maintains backward compatibility for incoming messages (SOURCE_CLIENT)

This optimization is particularly beneficial for devices with many entities where the initial connection data transfer can overwhelm the ESP's limited memory resources.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Addresses connection bottleneck reported in home-assistant/core#145293
- Follows pattern established in #9761 for bytes fields
- Related to performance optimization efforts for memory-constrained devices

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal implementation detail, no user-facing changes)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - this is an internal optimization
# All existing configurations continue to work as before
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

## Implementation Details

### Changes Made:

1. **Protobuf Generator Updates (`script/api_protobuf/api_protobuf.py`)**:
   - Modified `StringType` class to generate StringRef fields for SOURCE_SERVER messages
   - Added proper handling for repeated string fields using `add_string_field_repeated`
   - Fixed empty string handling in repeated fields

2. **API Protocol Updates (`esphome/components/api/`)**:
   - Added `encode_string` overload for StringRef in `proto.h`
   - Restored `add_string_field_repeated` helper for correct repeated field size calculation
   - Added `append_quoted_string` helper for cleaner dump output

3. **Entity Base Classes (`esphome/core/entity_base.h`)**:
   - Added `get_icon_ref()`, `get_device_class_ref()`, and `get_unit_of_measurement_ref()` methods
   - These return StringRef to member variables, avoiding temporary string creation

4. **API Connection Updates (`esphome/components/api/api_connection.cpp`)**:
   - Updated all message creation to use StringRef where appropriate
   - Added proper handling for temporary strings from getter methods
   - Ensured all StringRef instances have valid lifetime

5. **Component Updates**:
   - Updated HomeAssistant number and switch components to use StringRef
   - Updated user services to use StringRef for service names and arguments
   - Optimized string literals to use compile-time constexpr StringRef via `StringRef::from_lit()`

6. **Compile-time Optimizations**:
   - String literals are now constructed at compile time using `StringRef::from_lit()`
   - Empty strings, service names, and key names are all constexpr
   - Examples:
     ```cpp
     static constexpr auto SERVICE_NAME = StringRef::from_lit("number.set_value");
     static constexpr auto ENTITY_ID_KEY = StringRef::from_lit("entity_id");
     static constexpr auto EMPTY_STRING = StringRef::from_lit("");
     ```

7. **Documentation** (`proto.h`):
   - Added comprehensive StringRef ownership model documentation
   - Documented safe and unsafe patterns with examples
   - Provides guidance for future contributors on proper StringRef usage

### Safety Considerations:

**Important architectural change**: Service response methods now follow the `send_*_response` pattern instead of returning response objects. This ensures string lifetimes remain valid throughout the encoding process:

```cpp
// OLD (potentially unsafe with StringRef):
DisconnectResponse APIConnection::disconnect(const DisconnectRequest &msg) {
  DisconnectResponse resp;
  // ... build response ...
  return resp;  // StringRef could point to destroyed temporaries
}

// NEW (safe):
bool APIConnection::send_disconnect_response(const DisconnectRequest &msg) {
  DisconnectResponse resp;
  // ... build response ...
  return this->send_message(resp, DisconnectResponse::MESSAGE_TYPE);
  // All strings remain valid until encoding completes
}
```

This pattern ensures that:
- Response objects are created, populated, and encoded within the same function scope
- Any temporary strings remain alive throughout the encoding process
- StringRef instances never outlive the data they reference

All StringRef usages have been verified for lifetime safety:
- String literals: Safe (static storage duration)
- Member variables: Safe (live as long as the entity)
- Temporary strings: Stored in local variables when needed
- All encoding happens synchronously before function returns

### Testing:

- All existing API tests pass
- Manual testing with various device configurations

### Performance Impact:

**Memory allocation reduction during connection:**
- Eliminates temporary string allocations when sending entity listings
- Reduces heap fragmentation during initial connection burst
- Particularly beneficial for devices with 50+ entities

**Flash memory savings measured on ESP32:**
- Simple device (few entities): 720 bytes saved
  - Before: Flash: [===       ]  28.5% (used 522232 bytes from 1835008 bytes)
  - After: Flash: [===       ]  28.4% (used 521512 bytes from 1835008 bytes)
- Complex device (many entities): 1,708 bytes saved
  - Before: Flash: [=======   ]  69.3% (used 1271972 bytes from 1835008 bytes)
  - After: Flash: [=======   ]  69.2% (used 1270264 bytes from 1835008 bytes)

**Runtime benefits:**
- Faster Home Assistant connection establishment
- Reduced risk of connection failures with high entity counts
- Lower memory pressure during entity state updates
