### PR TITLE
[pca9685] Allow to disable the phase balancer for PCA9685

### DIFF
--- a/esphome/components/pca9685/__init__.py
+++ b/esphome/components/pca9685/__init__.py
@@ -1,13 +1,24 @@
 import esphome.codegen as cg
 from esphome.components import i2c
 import esphome.config_validation as cv
-from esphome.const import CONF_EXTERNAL_CLOCK_INPUT, CONF_FREQUENCY, CONF_ID
+from esphome.const import (
+    CONF_EXTERNAL_CLOCK_INPUT,
+    CONF_FREQUENCY,
+    CONF_ID,
+    CONF_PHASE_BALANCER,
+)
 
 DEPENDENCIES = ["i2c"]
 MULTI_CONF = True
 
 pca9685_ns = cg.esphome_ns.namespace("pca9685")
 PCA9685Output = pca9685_ns.class_("PCA9685Output", cg.Component, i2c.I2CDevice)
+
+phase_balancer = pca9685_ns.enum("PhaseBalancer", is_class=True)
+PHASE_BALANCERS = {
+    "none": phase_balancer.NONE,
+    "linear": phase_balancer.LINEAR,
+}
 
 
 def validate_frequency(config):
@@ -30,6 +41,9 @@ CONFIG_SCHEMA = cv.All(
                 cv.frequency, cv.Range(min=23.84, max=1525.88)
             ),
             cv.Optional(CONF_EXTERNAL_CLOCK_INPUT, default=False): cv.boolean,
+            cv.Optional(CONF_PHASE_BALANCER, default="linear"): cv.enum(
+                PHASE_BALANCERS
+            ),
         }
     )
     .extend(cv.COMPONENT_SCHEMA)
@@ -43,5 +57,6 @@ async def to_code(config):
     if CONF_FREQUENCY in config:
         cg.add(var.set_frequency(config[CONF_FREQUENCY]))
     cg.add(var.set_extclk(config[CONF_EXTERNAL_CLOCK_INPUT]))
+    cg.add(var.set_phase_balancer(config[CONF_PHASE_BALANCER]))
     await cg.register_component(var, config)
     await i2c.register_i2c_device(var, config)

--- a/esphome/components/pca9685/pca9685_output.cpp
+++ b/esphome/components/pca9685/pca9685_output.cpp
@@ -107,7 +107,18 @@ void PCA9685Output::loop() {
   const uint16_t num_channels = this->max_channel_ - this->min_channel_ + 1;
   const uint16_t phase_delta_begin = 4096 / num_channels;
   for (uint8_t channel = this->min_channel_; channel <= this->max_channel_; channel++) {
-    uint16_t phase_begin = (channel - this->min_channel_) * phase_delta_begin;
+    uint16_t phase_begin;
+    switch (this->balancer_) {
+      case PhaseBalancer::NONE:
+        phase_begin = 0;
+        break;
+      case PhaseBalancer::LINEAR:
+        phase_begin = (channel - this->min_channel_) * phase_delta_begin;
+        break;
+      default:
+        ESP_LOGE(TAG, "Unknown phase balancer %d", static_cast<int>(this->balancer_));
+        return;
+    }
     uint16_t phase_end;
     uint16_t amount = this->pwm_amounts_[channel];
     if (amount == 0) {

--- a/esphome/components/pca9685/pca9685_output.h
+++ b/esphome/components/pca9685/pca9685_output.h
@@ -7,6 +7,11 @@
 namespace esphome {
 namespace pca9685 {
 
+enum class PhaseBalancer {
+  NONE = 0x00,
+  LINEAR = 0x01,
+};
+
 /// Inverts polarity of channel output signal
 extern const uint8_t PCA9685_MODE_INVERTED;
 /// Channel update happens upon ACK (post-set) rather than on STOP (endTransmission)
@@ -47,6 +52,7 @@ class PCA9685Output : public Component, public i2c::I2CDevice {
   void loop() override;
   void set_extclk(bool extclk) { this->extclk_ = extclk; }
   void set_frequency(float frequency) { this->frequency_ = frequency; }
+  void set_phase_balancer(PhaseBalancer balancer) { this->balancer_ = balancer; }
 
  protected:
   friend PCA9685Channel;
@@ -60,6 +66,7 @@ class PCA9685Output : public Component, public i2c::I2CDevice {
   float frequency_;
   uint8_t mode_;
   bool extclk_ = false;
+  PhaseBalancer balancer_ = PhaseBalancer::LINEAR;
 
   uint8_t min_channel_{0xFF};
   uint8_t max_channel_{0x00};

--- a/tests/components/pca9685/common.yaml
+++ b/tests/components/pca9685/common.yaml
@@ -6,6 +6,7 @@ i2c:
 pca9685:
   frequency: 500
   address: 0x0
+  phase_balancer: linear
 
 output:
   - platform: pca9685


### PR DESCRIPTION
# What does this implement/fix?

The PCA9685 chip allows for flexible phase angles. Currently the component uses this ability to set the phase angles equidistantly for all output channels. So 3 output channels would have a phase angle of 0°, 120° and 240°. This however can cause flickering of the LEDs when animating / fading, because when the output changes and the start angle is higher than the end angle of the output the chip will need an additional frame where no signal is outputted (as indicated by the [datasheet](https://cdn-shop.adafruit.com/datasheets/PCA9685.pdf#page=20)

This pull requests adds an new configuration option `phase_balancer` with the options of `linear`, which keeps the current behavior and is the default. And `none` which sets all phase angles to 0°, so that the problem described above does not happen.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#5748

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
pca9685:
  frequency: 1525.88
  address: 0x40
  phase_balancer: none
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).
          (Just added the additional option to the component test yaml)

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
