### PR TITLE
2025.7.3

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -48,7 +48,7 @@ PROJECT_NAME           = ESPHome
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 2025.7.2
+PROJECT_NUMBER         = 2025.7.3
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/esphome/components/bme680_bsec/__init__.py
+++ b/esphome/components/bme680_bsec/__init__.py
@@ -1,7 +1,7 @@
 import esphome.codegen as cg
 from esphome.components import esp32, i2c
 import esphome.config_validation as cv
-from esphome.const import CONF_ID, CONF_SAMPLE_RATE, CONF_TEMPERATURE_OFFSET
+from esphome.const import CONF_ID, CONF_SAMPLE_RATE, CONF_TEMPERATURE_OFFSET, Framework
 
 CODEOWNERS = ["@trvrnrth"]
 DEPENDENCIES = ["i2c"]
@@ -56,7 +56,15 @@ CONFIG_SCHEMA = cv.All(
             ): cv.positive_time_period_minutes,
         }
     ).extend(i2c.i2c_device_schema(0x76)),
-    cv.only_with_arduino,
+    cv.only_with_framework(
+        frameworks=Framework.ARDUINO,
+        suggestions={
+            Framework.ESP_IDF: (
+                "bme68x_bsec2_i2c",
+                "sensor/bme68x_bsec2",
+            )
+        },
+    ),
     cv.Any(
         cv.only_on_esp8266,
         cv.All(

--- a/esphome/components/fastled_clockless/light.py
+++ b/esphome/components/fastled_clockless/light.py
@@ -2,7 +2,13 @@ from esphome import pins
 import esphome.codegen as cg
 from esphome.components import fastled_base
 import esphome.config_validation as cv
-from esphome.const import CONF_CHIPSET, CONF_NUM_LEDS, CONF_PIN, CONF_RGB_ORDER
+from esphome.const import (
+    CONF_CHIPSET,
+    CONF_NUM_LEDS,
+    CONF_PIN,
+    CONF_RGB_ORDER,
+    Framework,
+)
 
 AUTO_LOAD = ["fastled_base"]
 
@@ -48,13 +54,22 @@ CONFIG_SCHEMA = cv.All(
             cv.Required(CONF_PIN): pins.internal_gpio_output_pin_number,
         }
     ),
-    _validate,
+    cv.only_with_framework(
+        frameworks=Framework.ARDUINO,
+        suggestions={
+            Framework.ESP_IDF: (
+                "esp32_rmt_led_strip",
+                "light/esp32_rmt_led_strip",
+            )
+        },
+    ),
     cv.require_framework_version(
         esp8266_arduino=cv.Version(2, 7, 4),
         esp32_arduino=cv.Version(99, 0, 0),
         max_version=True,
         extra_message="Please see note on documentation for FastLED",
     ),
+    _validate,
 )
 
 

--- a/esphome/components/fastled_spi/light.py
+++ b/esphome/components/fastled_spi/light.py
@@ -9,6 +9,7 @@ from esphome.const import (
     CONF_DATA_RATE,
     CONF_NUM_LEDS,
     CONF_RGB_ORDER,
+    Framework,
 )
 
 AUTO_LOAD = ["fastled_base"]
@@ -32,6 +33,15 @@ CONFIG_SCHEMA = cv.All(
             cv.Required(CONF_CLOCK_PIN): pins.internal_gpio_output_pin_number,
             cv.Optional(CONF_DATA_RATE): cv.frequency,
         }
+    ),
+    cv.only_with_framework(
+        frameworks=Framework.ARDUINO,
+        suggestions={
+            Framework.ESP_IDF: (
+                "spi_led_strip",
+                "light/spi_led_strip",
+            )
+        },
     ),
     cv.require_framework_version(
         esp8266_arduino=cv.Version(2, 7, 4),

--- a/esphome/components/gpio/binary_sensor/__init__.py
+++ b/esphome/components/gpio/binary_sensor/__init__.py
@@ -4,7 +4,13 @@ from esphome import pins
 import esphome.codegen as cg
 from esphome.components import binary_sensor
 import esphome.config_validation as cv
-from esphome.const import CONF_ID, CONF_NAME, CONF_NUMBER, CONF_PIN
+from esphome.const import (
+    CONF_ALLOW_OTHER_USES,
+    CONF_ID,
+    CONF_NAME,
+    CONF_NUMBER,
+    CONF_PIN,
+)
 from esphome.core import CORE
 
 from .. import gpio_ns
@@ -73,6 +79,18 @@ async def to_code(config):
             "The sensor will work exactly as before, but other pins have better "
             "performance with interrupts.",
             config.get(CONF_NAME, config[CONF_ID]),
+        )
+        use_interrupt = False
+
+    # Check if pin is shared with other components (allow_other_uses)
+    # When a pin is shared, interrupts can interfere with other components
+    # (e.g., duty_cycle sensor) that need to monitor the pin's state changes
+    if use_interrupt and config[CONF_PIN].get(CONF_ALLOW_OTHER_USES, False):
+        _LOGGER.info(
+            "GPIO binary_sensor '%s': Disabling interrupts because pin %s is shared with other components. "
+            "The sensor will use polling mode for compatibility with other pin uses.",
+            config.get(CONF_NAME, config[CONF_ID]),
+            config[CONF_PIN][CONF_NUMBER],
         )
         use_interrupt = False
 

--- a/esphome/components/neopixelbus/light.py
+++ b/esphome/components/neopixelbus/light.py
@@ -15,6 +15,7 @@ from esphome.const import (
     CONF_PIN,
     CONF_TYPE,
     CONF_VARIANT,
+    Framework,
 )
 from esphome.core import CORE
 
@@ -162,7 +163,15 @@ def _validate_method(value):
 
 
 CONFIG_SCHEMA = cv.All(
-    cv.only_with_arduino,
+    cv.only_with_framework(
+        frameworks=Framework.ARDUINO,
+        suggestions={
+            Framework.ESP_IDF: (
+                "esp32_rmt_led_strip",
+                "light/esp32_rmt_led_strip",
+            )
+        },
+    ),
     cv.require_framework_version(
         esp8266_arduino=cv.Version(2, 4, 0),
         esp32_arduino=cv.Version(0, 0, 0),

--- a/esphome/components/sdl/sdl_esphome.cpp
+++ b/esphome/components/sdl/sdl_esphome.cpp
@@ -48,6 +48,9 @@ void Sdl::draw_pixels_at(int x_start, int y_start, int w, int h, const uint8_t *
 }
 
 void Sdl::draw_pixel_at(int x, int y, Color color) {
+  if (!this->get_clipping().inside(x, y))
+    return;
+
   SDL_Rect rect{x, y, 1, 1};
   auto data = (display::ColorUtil::color_to_565(color, display::COLOR_ORDER_RGB));
   SDL_UpdateTexture(this->texture_, &rect, &data, 2);

--- a/esphome/components/tuya/fan/__init__.py
+++ b/esphome/components/tuya/fan/__init__.py
@@ -1,7 +1,7 @@
 import esphome.codegen as cg
 from esphome.components import fan
 import esphome.config_validation as cv
-from esphome.const import CONF_OUTPUT_ID, CONF_SPEED_COUNT, CONF_SWITCH_DATAPOINT
+from esphome.const import CONF_ID, CONF_SPEED_COUNT, CONF_SWITCH_DATAPOINT
 
 from .. import CONF_TUYA_ID, Tuya, tuya_ns
 
@@ -14,9 +14,9 @@ CONF_DIRECTION_DATAPOINT = "direction_datapoint"
 TuyaFan = tuya_ns.class_("TuyaFan", cg.Component, fan.Fan)
 
 CONFIG_SCHEMA = cv.All(
-    fan.FAN_SCHEMA.extend(
+    fan.fan_schema(TuyaFan)
+    .extend(
         {
-            cv.GenerateID(CONF_OUTPUT_ID): cv.declare_id(TuyaFan),
             cv.GenerateID(CONF_TUYA_ID): cv.use_id(Tuya),
             cv.Optional(CONF_OSCILLATION_DATAPOINT): cv.uint8_t,
             cv.Optional(CONF_SPEED_DATAPOINT): cv.uint8_t,
@@ -24,7 +24,8 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_DIRECTION_DATAPOINT): cv.uint8_t,
             cv.Optional(CONF_SPEED_COUNT, default=3): cv.int_range(min=1, max=256),
         }
-    ).extend(cv.COMPONENT_SCHEMA),
+    )
+    .extend(cv.COMPONENT_SCHEMA),
     cv.has_at_least_one_key(CONF_SPEED_DATAPOINT, CONF_SWITCH_DATAPOINT),
 )
 
@@ -32,7 +33,7 @@ CONFIG_SCHEMA = cv.All(
 async def to_code(config):
     parent = await cg.get_variable(config[CONF_TUYA_ID])
 
-    var = cg.new_Pvariable(config[CONF_OUTPUT_ID], parent, config[CONF_SPEED_COUNT])
+    var = cg.new_Pvariable(config[CONF_ID], parent, config[CONF_SPEED_COUNT])
     await cg.register_component(var, config)
     await fan.register_fan(var, config)
 

--- a/esphome/components/web_server/ota/ota_web_server.cpp
+++ b/esphome/components/web_server/ota/ota_web_server.cpp
@@ -76,7 +76,7 @@ void OTARequestHandler::report_ota_progress_(AsyncWebServerRequest *request) {
       percentage = (this->ota_read_length_ * 100.0f) / request->contentLength();
       ESP_LOGD(TAG, "OTA in progress: %0.1f%%", percentage);
     } else {
-      ESP_LOGD(TAG, "OTA in progress: %u bytes read", this->ota_read_length_);
+      ESP_LOGD(TAG, "OTA in progress: %" PRIu32 " bytes read", this->ota_read_length_);
     }
 #ifdef USE_OTA_STATE_CALLBACK
     // Report progress - use call_deferred since we're in web server task
@@ -171,7 +171,7 @@ void OTARequestHandler::handleUpload(AsyncWebServerRequest *request, const Strin
 
   // Finalize
   if (final) {
-    ESP_LOGD(TAG, "OTA final chunk: index=%zu, len=%zu, total_read=%u, contentLength=%zu", index, len,
+    ESP_LOGD(TAG, "OTA final chunk: index=%zu, len=%zu, total_read=%" PRIu32 ", contentLength=%zu", index, len,
              this->ota_read_length_, request->contentLength());
 
     // For Arduino framework, the Update library tracks expected size from firmware header

--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -73,6 +73,7 @@ from esphome.const import (
     TYPE_GIT,
     TYPE_LOCAL,
     VALID_SUBSTITUTIONS_CHARACTERS,
+    Framework,
     __version__ as ESPHOME_VERSION,
 )
 from esphome.core import (
@@ -280,6 +281,38 @@ class Required(vol.Required):
 
 class FinalExternalInvalid(Invalid):
     """Represents an invalid value in the final validation phase where the path should not be prepended."""
+
+
+@dataclass(frozen=True, order=True)
+class Version:
+    major: int
+    minor: int
+    patch: int
+    extra: str = ""
+
+    def __str__(self):
+        return f"{self.major}.{self.minor}.{self.patch}"
+
+    @classmethod
+    def parse(cls, value: str) -> Version:
+        match = re.match(r"^(\d+).(\d+).(\d+)-?(\w*)$", value)
+        if match is None:
+            raise ValueError(f"Not a valid version number {value}")
+        major = int(match[1])
+        minor = int(match[2])
+        patch = int(match[3])
+        extra = match[4] or ""
+        return Version(major=major, minor=minor, patch=patch, extra=extra)
+
+    @property
+    def is_beta(self) -> bool:
+        """Check if this version is a beta version."""
+        return self.extra.startswith("b")
+
+    @property
+    def is_dev(self) -> bool:
+        """Check if this version is a development version."""
+        return self.extra.startswith("dev")
 
 
 def check_not_templatable(value):
@@ -619,16 +652,35 @@ def only_on(platforms):
     return validator_
 
 
-def only_with_framework(frameworks):
+def only_with_framework(
+    frameworks: Framework | str | list[Framework | str], suggestions=None
+):
     """Validate that this option can only be specified on the given frameworks."""
     if not isinstance(frameworks, list):
         frameworks = [frameworks]
 
+    frameworks = [Framework(framework) for framework in frameworks]
+
+    if suggestions is None:
+        suggestions = {}
+
+    version = Version.parse(ESPHOME_VERSION)
+    if version.is_beta:
+        docs_format = "https://beta.esphome.io/components/{path}"
+    elif version.is_dev:
+        docs_format = "https://next.esphome.io/components/{path}"
+    else:
+        docs_format = "https://esphome.io/components/{path}"
+
     def validator_(obj):
         if CORE.target_framework not in frameworks:
-            raise Invalid(
-                f"This feature is only available with frameworks {frameworks}"
-            )
+            err_str = f"This feature is only available with framework(s) {', '.join([framework.value for framework in frameworks])}"
+            if suggestion := suggestions.get(CORE.target_framework, None):
+                (component, docs_path) = suggestion
+                err_str += f"\nPlease use '{component}'"
+                if docs_path:
+                    err_str += f": {docs_format.format(path=docs_path)}"
+            raise Invalid(err_str)
         return obj
 
     return validator_
@@ -637,8 +689,8 @@ def only_with_framework(frameworks):
 only_on_esp32 = only_on(PLATFORM_ESP32)
 only_on_esp8266 = only_on(PLATFORM_ESP8266)
 only_on_rp2040 = only_on(PLATFORM_RP2040)
-only_with_arduino = only_with_framework("arduino")
-only_with_esp_idf = only_with_framework("esp-idf")
+only_with_arduino = only_with_framework(Framework.ARDUINO)
+only_with_esp_idf = only_with_framework(Framework.ESP_IDF)
 
 
 # Adapted from:
@@ -1963,26 +2015,6 @@ def source_refresh(value: str):
     if value.lower() == "never":
         return source_refresh("365250d")
     return positive_time_period_seconds(value)
-
-
-@dataclass(frozen=True, order=True)
-class Version:
-    major: int
-    minor: int
-    patch: int
-
-    def __str__(self):
-        return f"{self.major}.{self.minor}.{self.patch}"
-
-    @classmethod
-    def parse(cls, value: str) -> Version:
-        match = re.match(r"^(\d+).(\d+).(\d+)-?\w*$", value)
-        if match is None:
-            raise ValueError(f"Not a valid version number {value}")
-        major = int(match[1])
-        minor = int(match[2])
-        patch = int(match[3])
-        return Version(major=major, minor=minor, patch=patch)
 
 
 def version_number(value):

--- a/esphome/const.py
+++ b/esphome/const.py
@@ -4,7 +4,7 @@ from enum import Enum
 
 from esphome.enum import StrEnum
 
-__version__ = "2025.7.2"
+__version__ = "2025.7.3"
 
 ALLOWED_NAME_CHARS = "abcdefghijklmnopqrstuvwxyz0123456789-_"
 VALID_SUBSTITUTIONS_CHARACTERS = (

--- a/esphome/core/application.h
+++ b/esphome/core/application.h
@@ -504,6 +504,8 @@ class Application {
   void enable_component_loop_(Component *component);
   void enable_pending_loops_();
   void activate_looping_component_(uint16_t index);
+  void before_loop_tasks_(uint32_t loop_start_time);
+  void after_loop_tasks_();
 
   void feed_wdt_arch_();
 


### PR DESCRIPTION
**Do not merge, release script will automatically merge**
<details>
<summary>Show</summary>

- [gpio] Auto-disable interrupts for shared GPIO pins in binary sensors [esphome#9701](https://github.com/esphome/esphome/pull/9701)
- Fix format string error in ota_web_server.cpp [esphome#9711](https://github.com/esphome/esphome/pull/9711)
- [sdl][mipi_spi] Respect clipping when drawing [esphome#9722](https://github.com/esphome/esphome/pull/9722)
- [esp32_touch] Fix setup mode in v1 driver [esphome#9725](https://github.com/esphome/esphome/pull/9725)
- [tuya] Update use of fan_schema [esphome#9762](https://github.com/esphome/esphome/pull/9762)
- [config_validation] Add support for suggesting alternate component/platform [esphome#9757](https://github.com/esphome/esphome/pull/9757)
- [core] Process pending loop enables during setup blocking phase [esphome#9787](https://github.com/esphome/esphome/pull/9787)
- [fastled_clockless, fastled_spi] Add suggested alternate when using IDF [esphome#9784](https://github.com/esphome/esphome/pull/9784)
- [neopixelbus] Add suggested alternate when using IDF [esphome#9783](https://github.com/esphome/esphome/pull/9783)
- [bme680_bsec] Add suggested alternate when using IDF [esphome#9785](https://github.com/esphome/esphome/pull/9785)
</details>

<details>
<summary>Metadata</summary>

@coderabbitai ignore
</details>
