### PR TITLE
[api] Use emplace_back for TemplatableKeyValuePair construction in HomeAssistant services

### DIFF
--- a/esphome/components/api/homeassistant_service.h
+++ b/esphome/components/api/homeassistant_service.h
@@ -5,6 +5,7 @@
 #include "api_pb2.h"
 #include "esphome/core/automation.h"
 #include "esphome/core/helpers.h"
+#include <utility>
 #include <vector>
 
 namespace esphome {
@@ -36,10 +37,10 @@ template<typename... X> class TemplatableStringValue : public TemplatableValue<s
 
 template<typename... Ts> class TemplatableKeyValuePair {
  public:
-  // It's safe to use const std::string& for the key parameter because keys are always
-  // string literals from YAML dictionary keys (e.g., "code", "event") and never
-  // templatable values or lambdas. Only the value parameter can be a lambda/template.
-  template<typename T> TemplatableKeyValuePair(const std::string &key, T value) : key(key), value(value) {}
+  // Keys are always string literals from YAML dictionary keys (e.g., "code", "event")
+  // and never templatable values or lambdas. Only the value parameter can be a lambda/template.
+  // Using pass-by-value with std::move allows optimal performance for both lvalues and rvalues.
+  template<typename T> TemplatableKeyValuePair(std::string key, T value) : key(std::move(key)), value(value) {}
   std::string key;
   TemplatableStringValue<Ts...> value;
 };

--- a/esphome/components/api/homeassistant_service.h
+++ b/esphome/components/api/homeassistant_service.h
@@ -47,15 +47,11 @@ template<typename... Ts> class HomeAssistantServiceCallAction : public Action<Ts
 
   template<typename T> void set_service(T service) { this->service_ = service; }
 
-  template<typename T> void add_data(std::string key, T value) {
-    this->data_.push_back(TemplatableKeyValuePair<Ts...>(key, value));
-  }
+  template<typename T> void add_data(std::string key, T value) { this->data_.emplace_back(key, value); }
   template<typename T> void add_data_template(std::string key, T value) {
-    this->data_template_.push_back(TemplatableKeyValuePair<Ts...>(key, value));
+    this->data_template_.emplace_back(key, value);
   }
-  template<typename T> void add_variable(std::string key, T value) {
-    this->variables_.push_back(TemplatableKeyValuePair<Ts...>(key, value));
-  }
+  template<typename T> void add_variable(std::string key, T value) { this->variables_.emplace_back(key, value); }
 
   void play(Ts... x) override {
     HomeassistantServiceResponse resp;

--- a/esphome/components/api/homeassistant_service.h
+++ b/esphome/components/api/homeassistant_service.h
@@ -51,14 +51,16 @@ template<typename... Ts> class HomeAssistantServiceCallAction : public Action<Ts
 
   template<typename T> void set_service(T service) { this->service_ = service; }
 
-  // These methods use const std::string& for keys because keys are always string literals
-  // from the Python code generation (e.g., cg.add(var.add_data("tag_id", templ))).
+  // Keys are always string literals from the Python code generation (e.g., cg.add(var.add_data("tag_id", templ))).
   // The value parameter can be a lambda/template, but keys are never templatable.
-  template<typename T> void add_data(const std::string &key, T value) { this->data_.emplace_back(key, value); }
-  template<typename T> void add_data_template(const std::string &key, T value) {
-    this->data_template_.emplace_back(key, value);
+  // Using pass-by-value allows the compiler to optimize for both lvalues and rvalues.
+  template<typename T> void add_data(std::string key, T value) { this->data_.emplace_back(std::move(key), value); }
+  template<typename T> void add_data_template(std::string key, T value) {
+    this->data_template_.emplace_back(std::move(key), value);
   }
-  template<typename T> void add_variable(const std::string &key, T value) { this->variables_.emplace_back(key, value); }
+  template<typename T> void add_variable(std::string key, T value) {
+    this->variables_.emplace_back(std::move(key), value);
+  }
 
   void play(Ts... x) override {
     HomeassistantServiceResponse resp;

--- a/esphome/components/api/homeassistant_service.h
+++ b/esphome/components/api/homeassistant_service.h
@@ -36,7 +36,7 @@ template<typename... X> class TemplatableStringValue : public TemplatableValue<s
 
 template<typename... Ts> class TemplatableKeyValuePair {
  public:
-  template<typename T> TemplatableKeyValuePair(std::string key, T value) : key(std::move(key)), value(value) {}
+  template<typename T> TemplatableKeyValuePair(const std::string &key, T value) : key(key), value(value) {}
   std::string key;
   TemplatableStringValue<Ts...> value;
 };
@@ -47,11 +47,11 @@ template<typename... Ts> class HomeAssistantServiceCallAction : public Action<Ts
 
   template<typename T> void set_service(T service) { this->service_ = service; }
 
-  template<typename T> void add_data(std::string key, T value) { this->data_.emplace_back(key, value); }
-  template<typename T> void add_data_template(std::string key, T value) {
+  template<typename T> void add_data(const std::string &key, T value) { this->data_.emplace_back(key, value); }
+  template<typename T> void add_data_template(const std::string &key, T value) {
     this->data_template_.emplace_back(key, value);
   }
-  template<typename T> void add_variable(std::string key, T value) { this->variables_.emplace_back(key, value); }
+  template<typename T> void add_variable(const std::string &key, T value) { this->variables_.emplace_back(key, value); }
 
   void play(Ts... x) override {
     HomeassistantServiceResponse resp;

--- a/esphome/components/api/homeassistant_service.h
+++ b/esphome/components/api/homeassistant_service.h
@@ -5,7 +5,6 @@
 #include "api_pb2.h"
 #include "esphome/core/automation.h"
 #include "esphome/core/helpers.h"
-#include <utility>
 #include <vector>
 
 namespace esphome {

--- a/esphome/components/api/homeassistant_service.h
+++ b/esphome/components/api/homeassistant_service.h
@@ -36,6 +36,9 @@ template<typename... X> class TemplatableStringValue : public TemplatableValue<s
 
 template<typename... Ts> class TemplatableKeyValuePair {
  public:
+  // It's safe to use const std::string& for the key parameter because keys are always
+  // string literals from YAML dictionary keys (e.g., "code", "event") and never
+  // templatable values or lambdas. Only the value parameter can be a lambda/template.
   template<typename T> TemplatableKeyValuePair(const std::string &key, T value) : key(key), value(value) {}
   std::string key;
   TemplatableStringValue<Ts...> value;
@@ -47,6 +50,9 @@ template<typename... Ts> class HomeAssistantServiceCallAction : public Action<Ts
 
   template<typename T> void set_service(T service) { this->service_ = service; }
 
+  // These methods use const std::string& for keys because keys are always string literals
+  // from the Python code generation (e.g., cg.add(var.add_data("tag_id", templ))).
+  // The value parameter can be a lambda/template, but keys are never templatable.
   template<typename T> void add_data(const std::string &key, T value) { this->data_.emplace_back(key, value); }
   template<typename T> void add_data_template(const std::string &key, T value) {
     this->data_template_.emplace_back(key, value);


### PR DESCRIPTION
# What does this implement/fix?

This PR optimizes vector operations in the HomeAssistant service API by replacing `push_back` with `emplace_back` when constructing `TemplatableKeyValuePair` objects. This avoids creating temporary objects and instead constructs them directly in the vector's memory.

While modern compilers likely optimize away the temporary objects already (through RVO/NRVO), using `emplace_back` is the more semantically correct approach in modern C++ when constructing objects from arguments rather than inserting already-constructed objects.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A - No documentation changes needed

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - this is an internal optimization
api:
  services:
    - service: test_service
      variables:
        my_var: string
      then:
        - logger.log: "Service called"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).