### PR TITLE
[api] Simplify generated authentication check code

### DIFF
--- a/esphome/components/api/api_pb2_service.cpp
+++ b/esphome/components/api/api_pb2_service.cpp
@@ -617,10 +617,8 @@ void APIServerConnection::on_ping_request(const PingRequest &msg) {
   }
 }
 void APIServerConnection::on_device_info_request(const DeviceInfoRequest &msg) {
-  if (this->check_connection_setup_()) {
-    if (!this->send_device_info_response(msg)) {
-      this->on_fatal_error();
-    }
+  if (this->check_connection_setup_() && !this->send_device_info_response(msg)) {
+    this->on_fatal_error();
   }
 }
 void APIServerConnection::on_list_entities_request(const ListEntitiesRequest &msg) {
@@ -650,10 +648,8 @@ void APIServerConnection::on_subscribe_home_assistant_states_request(const Subsc
   }
 }
 void APIServerConnection::on_get_time_request(const GetTimeRequest &msg) {
-  if (this->check_connection_setup_()) {
-    if (!this->send_get_time_response(msg)) {
-      this->on_fatal_error();
-    }
+  if (this->check_connection_setup_() && !this->send_get_time_response(msg)) {
+    this->on_fatal_error();
   }
 }
 #ifdef USE_API_SERVICES
@@ -665,10 +661,8 @@ void APIServerConnection::on_execute_service_request(const ExecuteServiceRequest
 #endif
 #ifdef USE_API_NOISE
 void APIServerConnection::on_noise_encryption_set_key_request(const NoiseEncryptionSetKeyRequest &msg) {
-  if (this->check_authenticated_()) {
-    if (!this->send_noise_encryption_set_key_response(msg)) {
-      this->on_fatal_error();
-    }
+  if (this->check_authenticated_() && !this->send_noise_encryption_set_key_response(msg)) {
+    this->on_fatal_error();
   }
 }
 #endif
@@ -858,10 +852,8 @@ void APIServerConnection::on_bluetooth_gatt_notify_request(const BluetoothGATTNo
 #ifdef USE_BLUETOOTH_PROXY
 void APIServerConnection::on_subscribe_bluetooth_connections_free_request(
     const SubscribeBluetoothConnectionsFreeRequest &msg) {
-  if (this->check_authenticated_()) {
-    if (!this->send_subscribe_bluetooth_connections_free_response(msg)) {
-      this->on_fatal_error();
-    }
+  if (this->check_authenticated_() && !this->send_subscribe_bluetooth_connections_free_response(msg)) {
+    this->on_fatal_error();
   }
 }
 #endif
@@ -889,10 +881,8 @@ void APIServerConnection::on_subscribe_voice_assistant_request(const SubscribeVo
 #endif
 #ifdef USE_VOICE_ASSISTANT
 void APIServerConnection::on_voice_assistant_configuration_request(const VoiceAssistantConfigurationRequest &msg) {
-  if (this->check_authenticated_()) {
-    if (!this->send_voice_assistant_get_configuration_response(msg)) {
-      this->on_fatal_error();
-    }
+  if (this->check_authenticated_() && !this->send_voice_assistant_get_configuration_response(msg)) {
+    this->on_fatal_error();
   }
 }
 #endif

--- a/script/api_protobuf/api_protobuf.py
+++ b/script/api_protobuf/api_protobuf.py
@@ -2260,19 +2260,16 @@ static const char *const TAG = "api.service";
             else:
                 check_func = "this->check_connection_setup_()"
 
-            body = f"if ({check_func}) {{\n"
-
-            # Add the actual handler code, indented
-            handler_body = ""
             if is_void:
-                handler_body = f"this->{func}(msg);\n"
+                # For void methods, just wrap with auth check
+                body = f"if ({check_func}) {{\n"
+                body += f"  this->{func}(msg);\n"
+                body += "}\n"
             else:
-                handler_body = f"if (!this->send_{func}_response(msg)) {{\n"
-                handler_body += "  this->on_fatal_error();\n"
-                handler_body += "}\n"
-
-            body += indent(handler_body) + "\n"
-            body += "}\n"
+                # For non-void methods, combine auth check and send response check
+                body = f"if ({check_func} && !this->send_{func}_response(msg)) {{\n"
+                body += "  this->on_fatal_error();\n"
+                body += "}\n"
         else:
             # No auth check needed, just call the handler
             body = ""


### PR DESCRIPTION
# What does this implement/fix?

This PR simplifies the generated C++ code in the API service by combining authentication checks with response sending checks into a single conditional statement. This eliminates unnecessary nesting in the generated code, making it more readable and reducing the source file size.

The change modifies `script/api_protobuf/api_protobuf.py` to generate:
```cpp
if (this->check_authenticated_() && !this->send_response(msg)) {
  this->on_fatal_error();
}
```

Instead of:
```cpp
if (this->check_authenticated_()) {
  if (!this->send_response(msg)) {
    this->on_fatal_error();
  }
}
```

While this doesn't affect the compiled binary size (compilers optimize both patterns identically), it improves code readability and reduces the generated source file size.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - this is a code generation improvement
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome