### PR TITLE
[audio] fix typo ``gneneral`` and ``divison``

### DIFF
--- a/esphome/components/audio/audio.h
+++ b/esphome/components/audio/audio.h
@@ -15,7 +15,7 @@ class AudioStreamInfo {
    *  - An audio sample represents a unit of audio for one channel.
    *  - A frame represents a unit of audio with a sample for every channel.
    *
-   * In gneneral, converting between bytes, samples, and frames shouldn't result in rounding errors so long as frames
+   * In general, converting between bytes, samples, and frames shouldn't result in rounding errors so long as frames
    * are used as the main unit when transferring audio data. Durations may result in rounding for certain sample rates;
    * e.g., 44.1 KHz. The ``frames_to_milliseconds_with_remainder`` function should be used for accuracy, as it takes
    * into account the remainder rather than just ignoring any rounding.
@@ -76,7 +76,7 @@ class AudioStreamInfo {
 
   /// @brief Computes the duration, in microseconds, the given amount of frames represents.
   /// @param frames Number of audio frames
-  /// @return Duration in microseconds `frames` respresents. May be slightly inaccurate due to integer divison rounding
+  /// @return Duration in microseconds `frames` respresents. May be slightly inaccurate due to integer division rounding
   ///         for certain sample rates.
   uint32_t frames_to_microseconds(uint32_t frames) const;
 

--- a/esphome/components/audio/audio.h
+++ b/esphome/components/audio/audio.h
@@ -76,7 +76,7 @@ class AudioStreamInfo {
 
   /// @brief Computes the duration, in microseconds, the given amount of frames represents.
   /// @param frames Number of audio frames
-  /// @return Duration in microseconds `frames` respresents. May be slightly inaccurate due to integer division rounding
+  /// @return Duration in microseconds `frames` represents. May be slightly inaccurate due to integer division rounding
   ///         for certain sample rates.
   uint32_t frames_to_microseconds(uint32_t frames) const;
 


### PR DESCRIPTION
# What does this implement/fix?

fix typo `gneneral` and `divison`

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
